### PR TITLE
Support paged kv cache for benchmarks

### DIFF
--- a/benchmarks/python/benchmark.py
+++ b/benchmarks/python/benchmark.py
@@ -182,6 +182,22 @@ def parse_arguments():
         help=
         'By default, we use dtype for KV cache. fp8_kv_cache chooses fp8 quantization for KV'
     )
+    parser.add_argument(
+        '--use_inflight_batching',
+        action="store_true",
+        default=False,
+        help="Activates inflight batching mode of gptAttentionPlugin.")
+    parser.add_argument(
+        '--paged_kv_cache',
+        action="store_true",
+        default=False,
+        help=
+        'By default we use contiguous KV cache. By setting this flag you enable paged KV cache'
+    )
+    parser.add_argument('--tokens_per_block',
+                        type=int,
+                        default=16,
+                        help='Number of tokens per block in paged KV cache')
     parser.add_argument('--csv',
                         default=False,
                         action="store_true",
@@ -236,7 +252,10 @@ def main(args):
             enable_fp8=args.enable_fp8,
             fp8_kv_cache=args.fp8_kv_cache,
             enable_cuda_graph=args.enable_cuda_graph,
-            enable_custom_all_reduce=args.enable_custom_all_reduce)
+            enable_custom_all_reduce=args.enable_custom_all_reduce,
+            paged_kv_cached=args.paged_kv_cache,
+            tokens_per_block=args.tokens_per_block,
+            use_inflight_batching=args.use_inflight_batching)
     elif args.model in get_allowed_models(benchmark_type="bert"):
         benchmarker = BERTBenchmark(args.engine_dir,
                                     args.model,


### PR DESCRIPTION
This supports building a new engine with paged kv cache or loading existing engine built with KV cache. Otherwise there would be tensor name errors.

Listing this as draft since I think there's some issue with memory management in either benchmarks or generation that causing KV cache to be not freed and I'm getting steadily increasing memory usage and eventually OOM.

Edit: converting to ready to review since I think OOM is a separate issue from this pR https://github.com/NVIDIA/TensorRT-LLM/issues/283