### PR TITLE
Support the gather_all_token_logits flag for Llama

### DIFF
--- a/examples/llama/build.py
+++ b/examples/llama/build.py
@@ -211,6 +211,9 @@ def parse_arguments():
         'For FP8 PTQ, the downside is slight reduction of accuracy because one of the quantization scaling factors are discarded '
         '(0.45734 vs 0.45755 for LLaMA-v2 7B using ammo/examples/hf/instruct_eval/mmlu.py).'
     )
+    parser.add_argument('--gather_all_token_logits',
+                        action='store_true',
+                        default=False)
 
     # Arguments related to the quantization of the model.
     parser.add_argument(
@@ -629,7 +632,8 @@ def build_rank_engine(builder: Builder,
                                                    args.max_input_len,
                                                    args.max_output_len, True,
                                                    args.max_beam_width,
-                                                   args.max_num_tokens)
+                                                   args.max_num_tokens,
+                                                   gather_all_token_logits=args.gather_all_token_logits)
         tensorrt_llm_llama(*inputs)
         if args.enable_debug_output:
             # mark intermediate nodes' outputs
@@ -693,7 +697,8 @@ def build(rank, args):
             fp8=args.quant_mode.has_fp8_qdq(),
             quant_mode=args.quant_mode,
             strongly_typed=args.strongly_typed,
-            opt_level=args.builder_opt)
+            opt_level=args.builder_opt,
+            gather_all_token_logits=args.gather_all_token_logits)
         engine_name = get_engine_name(MODEL_NAME, args.dtype, args.tp_size,
                                       args.pp_size, cur_rank)
         engine = build_rank_engine(builder, builder_config, engine_name,

--- a/tensorrt_llm/models/llama/model.py
+++ b/tensorrt_llm/models/llama/model.py
@@ -372,7 +372,8 @@ class LLaMAForCausalLM(LLaMAModel, GenerationMixin):
                        max_new_tokens,
                        use_cache,
                        max_beam_width,
-                       max_num_tokens: int = None):
+                       max_num_tokens: int = None,
+                       gather_all_token_logits: bool = False):
         '''@brief: Prepare inputs Tensors for the model, the given sizes are used to determine the
             ranges of the dimensions of when using TRT dynamic shapes.
 
@@ -408,7 +409,8 @@ class LLaMAForCausalLM(LLaMAModel, GenerationMixin):
             dtype=self.dtype,
             num_heads=self.num_heads,
             mapping=self.mapping,
-            max_num_tokens=max_num_tokens)
+            max_num_tokens=max_num_tokens,
+            gather_all_token_logits=gather_all_token_logits)
 
         return (model_inputs['input_ids'], model_inputs['position_ids'], True,
                 model_inputs['last_token_ids'], model_inputs['attention_mask'],


### PR DESCRIPTION
Support the `gather_all_token_logits` flag for building Llama models. This is needed to support returning `context_logits`

Relevant issue: https://github.com/NVIDIA/TensorRT-LLM/issues/122