### PR TITLE
Add support for loading from pretrained model to BertModel example build script

### DIFF
--- a/examples/bert/README.md
+++ b/examples/bert/README.md
@@ -30,6 +30,14 @@ The following command can be used to run the BERT model on a single GPU:
 python3 run.py
 ```
 
+#### Building from a pretrained model
+
+Building from a pretrained model can be enabled with the `--pretrained_model_name_or_path` option along with the name of the model.
+
+```bash
+python3 build.py --dtype=float16 --log_level=verbose --pretrained_model_name_or_path <hf-bert-model-name-or-path>
+```
+
 #### Fused MultiHead Attention (FMHA)
 
 You can enable the FMHA kernels for BERT by adding `--enable_context_fmha` to the invocation of `build.py`. Note that it is disabled by default because of possible accuracy issues due to the use of Flash Attention.

--- a/examples/bert/build.py
+++ b/examples/bert/build.py
@@ -84,6 +84,9 @@ def parse_arguments():
     parser.add_argument('--enable_context_fmha_fp32_acc',
                         default=False,
                         action='store_true')
+    parser.add_argument('--pretrained_model_name_or_path',
+                        type=str,
+                        default=None)
     parser.add_argument(
         '--model',
         default=tensorrt_llm.models.BertModel.__name__,
@@ -129,7 +132,11 @@ if __name__ == '__main__':
 
     output_name = 'hidden_states'
     if args.model == tensorrt_llm.models.BertModel.__name__:
-        hf_bert = BertModel(bert_config, add_pooling_layer=False)
+        if args.pretrained_model_name_or_path:
+            hf_bert = BertModel.from_pretrained(args.pretrained_model_name_or_path)
+            bert_config = hf_bert.config
+        else:
+            hf_bert = BertModel(bert_config, add_pooling_layer=False)
         tensorrt_llm_bert = tensorrt_llm.models.BertModel(
             num_layers=bert_config.num_hidden_layers,
             num_heads=bert_config.num_attention_heads,
@@ -152,7 +159,11 @@ if __name__ == '__main__':
         )
 
     elif args.model == tensorrt_llm.models.BertForQuestionAnswering.__name__:
-        hf_bert = BertForQuestionAnswering(bert_config)
+        if args.pretrained_model_name_or_path:
+            hf_bert = BertForQuestionAnswering.from_pretrained(args.pretrained_model_name_or_path)
+            bert_config = hf_bert.config
+        else:
+            hf_bert = BertForQuestionAnswering(bert_config)
         tensorrt_llm_bert = tensorrt_llm.models.BertForQuestionAnswering(
             num_layers=bert_config.num_hidden_layers,
             num_heads=bert_config.num_attention_heads,


### PR DESCRIPTION
Add support for loading from pretrained model to BertModel example build script.

New argument `--pretrained_model_name_or_path` that accepts a name of a hugging face model or local path to load the model from.

_Note_: I'm unsure which base branch Pull Requests should be targeted to.
