### PR TITLE
fix: GPTBenchmark object has no attribute num_kv_heads

### DIFF
--- a/benchmarks/python/gpt_benchmark.py
+++ b/benchmarks/python/gpt_benchmark.py
@@ -69,6 +69,8 @@ class GPTBenchmark(BaseBenchmark):
             self.serialize_path = os.path.join(engine_dir, self.engine_name)
             with open(self.serialize_path, 'rb') as f:
                 engine_buffer = f.read()
+            if not hasattr(self, "num_kv_heads") or self.num_kv_heads is None:
+                self.num_kv_heads = self.num_heads
         else:
             # Build engine
             self.world_size = tensorrt_llm.mpi_world_size()


### PR DESCRIPTION
run command:
```python
python benchmark.py -m bloom_560m  --batch_size "1" --input_output_len "1024,20" --engine_dir /some/dir
```

Errors:
```python
Traceback (most recent call last):
  File "/workspace/volume/wangchao2/TensorRT-LLM/benchmarks/python/benchmark.py", line 322, in <module>
    main(args)
  File "/workspace/volume/wangchao2/TensorRT-LLM/benchmarks/python/benchmark.py", line 219, in main
    benchmarker = GPTBenchmark(
  File "/workspace/volume/wangchao2/TensorRT-LLM/benchmarks/python/gpt_benchmark.py", line 72, in __init__
    if self.num_kv_heads is None:
AttributeError: 'GPTBenchmark' object has no attribute 'num_kv_heads'. Did you mean: 'num_heads'?
```

This PR tries to fix this.