### PR TITLE
add cudnn_root arguments for build_wheel.py for not build TensorRT-LL…

### DIFF
--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -47,6 +47,7 @@ def main(build_type: str = "Release",
          extra_make_targets: str = "",
          trt_root: str = None,
          nccl_root: str = None,
+         cudnn_root: str = None,
          clean: bool = False,
          use_ccache: bool = False,
          cpp_only: bool = False,
@@ -121,6 +122,9 @@ def main(build_type: str = "Release",
     if nccl_root is not None:
         cmake_def_args.append(f"-DNCCL_LIB_DIR={nccl_root}/lib")
         cmake_def_args.append(f"-DNCCL_INCLUDE_DIR={nccl_root}/include")
+    
+    if cudnn_root is not None:
+        cmake_def_args.append(f"-DCUDNN_ROOT_DIR={cudnn_root}")
 
     source_dir = project_dir / "cpp"
 
@@ -232,6 +236,8 @@ if __name__ == "__main__":
                         help="Directory to find TensorRT headers/libs")
     parser.add_argument("--nccl_root",
                         help="Directory to find NCCL headers/libs")
+    parser.add_argument("--cudnn_root",
+                        help="Directory to find cuDNN headers/libs")
     parser.add_argument("--build_dir",
                         type=Path,
                         help="Directory where cpp sources are built")


### PR DESCRIPTION
add cudnn_root arguments for build_wheel.py  for not build TensorRT-LLM in docker image.
when someone has a local environment in their docker, they don't want to create a new docker image. they can use  `python3 ./scripts/build_wheel.py` to build TensorRT-LLM. but current code not pass any cuDNN relative environment to cmake, cause to this error:
```
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
CUDNN_LIB
    linked by target "tensorrt_llm_static" in directory /nfs_home/nagato/work/src/TensorRT-LLM/cpp/tensorrt_llm
    linked by target "tensorrt_llm" in directory /nfs_home/nagato/work/src/TensorRT-LLM/cpp/tensorrt_llm
    linked by target "nvinfer_plugin_tensorrt_llm" in directory /nfs_home/nagato/work/src/TensorRT-LLM/cpp/tensorrt_llm/plugins

CMake Warning at tensorrt_llm/thop/CMakeLists.txt:21 (add_library):
  Cannot generate a safe runtime search path for target th_common because
  files in some directories may conflict with libraries in implicit
  directories:
```
this commit add a arugments cudnn_root to add cmake variable