### PR TITLE
Include an option when no quantization mode is needed

### DIFF
--- a/tensorrt_llm/quantization/mode.py
+++ b/tensorrt_llm/quantization/mode.py
@@ -18,6 +18,8 @@ from enum import IntFlag, auto
 class QuantMode(IntFlag):
     # [WARNING] KEEP BELOW DEFINITION IN SYNC WITH cpp/tensorrt_llm/common/quantization.h
 
+    # No quantization.
+    NONE = 0
     # The weights are quantized to 4 bits.
     INT4_WEIGHTS = auto()
     # The weights are quantized to 8 bits.


### PR DESCRIPTION
Hi,

I have added a NONE value to the QuantMode class because of the following two reasons:

- 'none' is present in cpp/tensorrt_llm/common/quantization.h but not here.

- by adding it, it will avoid a 'magic' 0 number in some default values, like in the following code: https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/models/llama/model.py#L49

If this PR is accepted, I would change all the occurrences of QuantMode(0) to QuantMode(QuantMode.NONE)