### PR TITLE
add `--allow-change-held-packages` 

### DIFF
--- a/docker/common/install_tensorrt.sh
+++ b/docker/common/install_tensorrt.sh
@@ -36,7 +36,7 @@ install_ubuntu_requirements() {
 
     apt-get update
     if [[ $(apt list --installed | grep libcudnn8) ]]; then
-      apt-get remove --purge -y libcudnn8*
+      apt-get remove --purge -y --allow-change-held-packages libcudnn8*
     fi
     if [[ $(apt list --installed | grep libnccl) ]]; then
       apt-get remove --purge -y --allow-change-held-packages libnccl*


### PR DESCRIPTION
I have faced following issue when I build docker image by using my custom cuda image.

```
#14 58.89 + [[ -n libcudnn8-dev/unknown,now 8.9.6.50-1+cuda12.2 amd64 [installed,upgradable to: 8.9.7.29-1+cuda12.2]
#14 58.89 libcudnn8/unknown,now 8.9.6.50-1+cuda12.2 amd64 [installed,upgradable to: 8.9.7.29-1+cuda12.2] ]]
#14 58.89 + apt-get remove --purge -y 'libcudnn8*'
#14 59.25 Reading package lists...
#14 63.95 Building dependency tree...
#14 64.68 Reading state information...
#14 65.65 Package 'libcudnn8-samples' is not installed, so not removed
#14 65.65 The following packages will be REMOVED:
#14 65.65   libcudnn8* libcudnn8-dev*
#14 65.66 The following held packages will be changed:
#14 65.66   libcudnn8
#14 65.69 0 upgraded, 0 newly installed, 2 to remove and 10 not upgraded.
#14 65.69 E: Held packages were changed and -y was used without --allow-change-held-packages.
```

It looks like I need to add `--allow-change-held-packages` to remove the existing libcudnn8 libraries.