### PR TITLE
fix banRepeatNgram

### DIFF
--- a/cpp/tensorrt_llm/kernels/banRepeatNgram.h
+++ b/cpp/tensorrt_llm/kernels/banRepeatNgram.h
@@ -28,7 +28,7 @@ namespace kernels
 template <typename T>
 void invokeBanRepeatNgram(T* logits, const int** output_ids_buf, const FinishedState* finished_buf,
     const int* parent_ids_buf, int batch_size, int local_batch_size, int beam_width,
-    const int* no_repeat_ngram_size_buf, int id_offset, int vocab_size_padded, size_t step, cudaStream_t stream);
+    const int* no_repeat_ngram_size_buf, int id_offset, int vocab_size_padded, size_t step, int max_seq_len, cudaStream_t stream);
 
 } // namespace kernels
 } // namespace tensorrt_llm

--- a/cpp/tensorrt_llm/layers/dynamicDecodeLayer.cpp
+++ b/cpp/tensorrt_llm/layers/dynamicDecodeLayer.cpp
@@ -229,7 +229,7 @@ void DynamicDecodeLayer<T>::forward(OutputParams& outputs, ForwardParams const& 
             reinterpret_cast<FinishedState*>(
                 params.finished.value_or(Tensor{}).template getPtr<FinishedState::UnderlyingType>()),
             outputs.parent_ids.value_or(Tensor{}).template getPtr<const int>(), batch_size, local_batch_size,
-            beam_width, no_repeat_ngram_size_buf, id_offset, vocab_size_padded_, step, stream_);
+            beam_width, no_repeat_ngram_size_buf, id_offset, vocab_size_padded_, step, max_seq_len, stream_);
     }
 
     if (params.bad_words_list)


### PR DESCRIPTION
Find error when run engine with beam size >1 and no_repeat_ngram_size is not None.
Try to fix it (output_ids_buf and parent_ids_buf here are not {batchsize*beamsize, max_seq_len} but {batchsize, beamsize*max_seq_len}?, like in banBadWords?)

