### PR TITLE
refactor: use torch to get device capability considering older NVIDIA driver

### DIFF
--- a/benchmarks/python/base_benchmark.py
+++ b/benchmarks/python/base_benchmark.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 import json
 import os
-import subprocess
 import time
 from collections import OrderedDict
 

--- a/benchmarks/python/base_benchmark.py
+++ b/benchmarks/python/base_benchmark.py
@@ -26,10 +26,8 @@ from tensorrt_llm.quantization import QuantMode
 
 
 def get_compute_cap():
-    output = subprocess.check_output(
-        ['nvidia-smi', "--query-gpu=compute_cap", "--format=csv"])
-    _, csv_value, *_ = output.splitlines()
-    return str(int(float(csv_value) * 10))
+    cap = torch.cuda.get_device_capability()
+    return str(cap[0] * 10 + cap[1])
 
 
 def get_csv_filename(model, dtype, tp_size, mode, **kwargs):


### PR DESCRIPTION
In older NVIDIA driver(e.g. 470.82.01), the field "compute_cap" is not a valid field to query in "nvidia-smi" command.

So this PR use torch instead of "nvidia-smi" to get device capability.