### PR TITLE
[Bug]Fixed SQ bug

### DIFF
--- a/tensorrt_llm/quantization/layers.py
+++ b/tensorrt_llm/quantization/layers.py
@@ -860,6 +860,8 @@ class SmoothQuantGatedMLP(SmoothQuantMLP):
         else:
             self.register_parameter('quantization_scaling_factor', None)
 
+        self.dtype = dtype
+
     def forward(self, hidden_states, workspace=None, lora_layer_params=None):
         assert lora_layer_params is None, "lora is not supported on SmoothQuantGatedMLP now"
         inter = self.fc(hidden_states)


### PR DESCRIPTION
The build smooth quant model will report an error, mainly because [self.dtype](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/quantization/layers.py#L869C51-L869C55) is not defined

