### PR TITLE
chore : add memory required in build from source guide

### DIFF
--- a/docs/source/build_from_source.md
+++ b/docs/source/build_from_source.md
@@ -20,7 +20,7 @@ We first recommend that you [`install TensorRT-LLM`](../../README.md#installatio
 Building from source code is necessary for users who require the best performance or debugging
 capabilities, or if the [GNU C++11 ABI](https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html) is required.
 
-We recommend the use of [Docker](https://www.docker.com) to build and run TensorRT-LLM. Instructions
+We recommend the use of [Docker](https://www.docker.com) to build and run TensorRT-LLM. 64GB or more of cpu memory is required. Instructions
 to install an environment to run Docker containers for the NVIDIA platform can be found
 [here](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html).
 


### PR DESCRIPTION
I think it would be better if the memory required information for "whl build" is existed.

https://github.com/NVIDIA/TensorRT-LLM/issues/914#issuecomment-1899511336