### PR TITLE
fix: fix qwen-vl deploy bug in A10.

### DIFF
--- a/examples/qwenvl/run_chat.py
+++ b/examples/qwenvl/run_chat.py
@@ -80,8 +80,7 @@ def exist_cooridinate(input):
 if __name__ == '__main__':
     args = parse_arguments()
     stream = torch.cuda.current_stream().cuda_stream
-    image_embeds = vit_process(args.input_dir, args.vit_engine_dir,
-                               args.log_level, stream)
+    image_embeds = vit_process(args.input_dir, args.vit_engine_dir, stream)
     qinfer = QWenInfer(args.tokenizer_dir, args.qwen_engine_dir, args.log_level,
                        args.output_csv, args.output_npy, args.num_beams)
     qinfer.qwen_model_init()


### PR DESCRIPTION
There are some problem when run qwen-vl in Tesla A10.

1. weight.py: Support load multi .safetensors quant file from model dir, such as original qwen-gptq model.
2. run_chat.py: Remove invalid func parameter.
3. vit_onnx_trt.py: Export vit onnx cause OOM in tesla A10 device. Load qwen-vl in cpu and extract visual model to gpu can solve this problem.