### PR TITLE
Add weight-only quantization for T5 models

### DIFF
--- a/examples/enc_dec/README.md
+++ b/examples/enc_dec/README.md
@@ -123,6 +123,19 @@ python build.py --model_type bart \
                 --use_gemm_plugin \
                 --dtype float32 \
                 --max_beam_width 1
+
+# Example 5: build t5-small using weight-only int8 quantization
+python build.py --model_type t5 \
+                --weight_dir tmp/trt_models/t5-small/tp1 \
+                -o tmp/trt_engines/t5-small/int8/1-gpu \
+                --engine_name t5-small \
+                --remove_input_padding \
+                --use_bert_attention_plugin \
+                --use_gpt_attention_plugin \
+                --use_gemm_plugin \
+                --dtype float16 \
+                --use_weight_only \
+                --weight_only_precision int8
 ```
 
 ### Run

--- a/examples/enc_dec/build.py
+++ b/examples/enc_dec/build.py
@@ -302,8 +302,7 @@ def parse_arguments(component):
     args = parser.parse_args()
     logger.set_level(args.log_level)
 
-    # TODO: Add quantization for encoder as well.
-    if args.use_weight_only and component == 'decoder':
+    if args.use_weight_only:
         args.quant_mode = QuantMode.from_description(
             quantize_weights=True,
             quantize_activations=False,

--- a/tensorrt_llm/models/enc_dec/model.py
+++ b/tensorrt_llm/models/enc_dec/model.py
@@ -1078,7 +1078,7 @@ class DecoderModel(Module, GenerationMixin):
         # No enable_two_optimization_profiles support yet
 
         encoder_input_len_range = [
-            0, (max_encoder_input_len + 1) // 2, max_encoder_input_len
+            1, (max_encoder_input_len + 1) // 2, max_encoder_input_len
         ]
         past_key_value = []
         sequence_length = None


### PR DESCRIPTION
## Summary 
Add weight-only quantization for T5.

I've added this to the path loading from binary weights. I do not think the HF weight loading currently works, so I have not added this functionality to this path yet. But please let me know if I've misunderstood.

## Test Plan
Built the engine with `t5-small` using the following commands

```
python t5/convert.py -i t5-small -o $FT_WEIGHT_DIR --weight_data_type float32 --inference_tensor_para_size 1
```
and then
```
python build.py --model_type t5 \
                --weight_dir ${FT_WEIGHT_DIR}/tp1 \
                -o $TRT_ENGINE_DIR \
                --engine_name t5 \
                --use_bert_attention_plugin  \
                --use_gpt_attention_plugin  \
                --use_gemm_plugin  \
                --dtype float16 \
                --max_beam_width 4 \
                --max_batch_size 32 \
                --max_output_len 512 \
                --use_weight_only \
                --weight_only_precision int8
```
Then we measured the performance using
```
python run.py --engine_dir $TRT_ENGINE_DIR --engine_name t5-small --model_name t5-small --max_new_token=64 --num_beams=1 --compare_hf_fp32
```
## Model Sizes
### fp16
*Encoder*:  69Mb
*Decoder*: 112Mb

### int8 quant
*Encoder*: 51Mb
*Decoder*: 88Mb

### int4 quant
*Encoder*: 42Mb
*Decoder*: 76Mb

## Benchmark Results

### No quantization (fp16)
TRT-LLM E2E time 233.34026336669922ms
TRT-LLM results match HF FP32 results with literal match rate 0.9255813953488372

### Weight-only int8 (fp16)
TRT-LLM E2E time 215.11101722717285ms
Match rate 0.784037558685446

### Weight-only int4 (fp16)
TRT-LLM E2E time 203.82308959960938ms
Match rate 0.38095238095238093

## Follow-ups
1. Fix issue with FP16 inference with T5 models. (https://github.com/huggingface/transformers/issues/20287). I believe we need fp16 for woq to work, so this will be needed to be useful in production.
2. May consider adding flag to quantize decoder only. This greatly improves on the match quality, so can give more granular control over quality vs. latency trade-off.
3. Support remaining quantization schemes (SmoothQuant, AWQ, GPTQ).
4. Add this for other enc_dec models outside of T5.
