### PR TITLE
fix: wrong request processing order

### DIFF
--- a/tensorrt_llm/engine.py
+++ b/tensorrt_llm/engine.py
@@ -157,7 +157,7 @@ class AsyncLLMEngine:
         for _ in range(max_num_sequences):
             if len(self.requests) == 0:
                 break
-            fetched.append(self.requests.pop())
+            fetched.append(self.requests.pop(0))
         return fetched
 
     def _handle_response_callback(self, req_id: int,

--- a/tensorrt_llm/executor.py
+++ b/tensorrt_llm/executor.py
@@ -492,7 +492,7 @@ class ParallelGenerationExecutor(GenerationExecutor):
             # the MPIPoolExecutor will always submit the same input to every worker, sometimes they arrive at slightly different time
             while len(self._requests) == 0:
                 time.sleep(0.05)
-            fetched.append(self._requests.pop())
+            fetched.append(self._requests.pop(0))
 
         return fetched
 


### PR DESCRIPTION
The processing of `self.requests` should be order-preserving, so it needs to be FIFO, the original implementation is LIFO, which will lead to different ordering of requests from different mpi sessions when a large batch of requests are flooding in, resulting in an error of the result when using `ParallelGenerationExecutor`.