### PR TITLE
Relax python dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,5 +13,5 @@ pytest-forked
 pytest-xdist
 rouge_score
 cloudpickle
-typing-extensions==4.8.0
-bandit==1.7.7
+typing-extensions>=4.8.0
+bandit>=1.7.7

--- a/requirements-windows.txt
+++ b/requirements-windows.txt
@@ -1,10 +1,10 @@
 --extra-index-url https://download.pytorch.org/whl/cu121
 --extra-index-url https://pypi.nvidia.com
-accelerate==0.25.0
+accelerate>=0.25.0
 build
 colored
-cuda-python==12.2.0
-diffusers==0.15.0
+cuda-python>=12.2.0
+diffusers>=0.15.0
 mpi4py
 numpy
 onnx>=1.12.0
@@ -16,14 +16,14 @@ pandas
 h5py
 pywin32
 sentencepiece>=0.1.99
-tensorrt==9.2.0.post12.dev5
+tensorrt>=9.2.0.post12.dev5
 tokenizers>=0.14
 # Default torch is CPU-only on Windows, so need to specify a torch version with GPU support
-torch==2.1.0+cu121
-torchdata==0.7.0
-torchtext==0.16.0+cpu
-torchvision==0.16.0+cu121
-transformers==4.38.2
+torch>=2.1.0+cu121
+torchdata>=0.7.0
+torchtext>=0.16.0+cpu
+torchvision>=0.16.0+cu121
+transformers>=4.38.2
 wheel
 optimum
 evaluate

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 --extra-index-url https://pypi.nvidia.com
-accelerate==0.25.0
+accelerate>=0.25.0
 build
 colored
 cuda-python # Do not override the custom version of cuda-python installed in the NGC PyTorch image.
-diffusers==0.15.0
+diffusers>=0.15.0
 lark
 mpi4py
 numpy
@@ -15,12 +15,12 @@ pulp
 pandas
 h5py
 sentencepiece>=0.1.99
-tensorrt==9.3.0.post12.dev1
+tensorrt>=9.3.0.post12.dev1
 # https://github.com/pytorch/pytorch/blob/v2.2.1/version.txt still uses 2.2.0a0.
 # https://docs.nvidia.com/deeplearning/frameworks/pytorch-release-notes/rel-24-02.html#rel-24-02 uses 2.3.0a0.
 torch>=2.2.0a,<=2.3.0a
 nvidia-ammo~=0.7.0
-transformers==4.38.2
+transformers>=4.38.2
 wheel
 optimum
 evaluate


### PR DESCRIPTION
Avoid strict pinning of python dependencies to make TensorRT-LLM easier to integrate.