### PR TITLE
Add SmoothQuant for T5 (decoder only right now)

### DIFF
--- a/examples/enc_dec/t5/convert.py
+++ b/examples/enc_dec/t5/convert.py
@@ -17,16 +17,24 @@ import configparser
 import logging
 import multiprocessing
 import os
+from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
+from typing import Literal, Optional
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
+from datasets import load_dataset
 import numpy as np
 import torch  # pytype: disable=import-error
 from transformers import T5ForConditionalGeneration
+from transformers import T5ForConditionalGeneration, T5Tokenizer
+from transformers.models.t5.modeling_t5 import (
+    T5Block, T5LayerCrossAttention, T5LayerSelfAttention, T5LayerFF
+)
 
 from tensorrt_llm._utils import str_dtype_to_torch, torch_to_numpy
+from smoothquant import capture_activation_range, smooth_gemm, smooth_gemm_fc1_gate
 
 LOGGER = logging.getLogger(__name__)
 
@@ -39,14 +47,23 @@ extra_configs = {
     }
 }
 
+def save_val(val, dir, key, tp_num=None):
+    suffix = "bin" if tp_num is None else f"{tp_num}.bin"
+    val.tofile(dir / f"{key}.{suffix}")
 
-def fuse_qkv(model, factor, saved_dir):
+def save_split(split_vals, dir, key, i, factor):
+    for j, val in enumerate(split_vals):
+        save_val(val, dir, key, i * factor + j)
+
+def fuse_qkv(model, factor, saved_dir, act_range: dict, int8_outputs: Optional[str]):
 
     def get_attn_module(component, block, layer, attn_type):
         m = getattr(model, component)
         m = m.block[int(block)].layer[int(layer)]
         m = getattr(m, attn_type)
         return m
+    
+    save_int8 = int8_outputs == "all"
 
     for name, param in model.named_parameters():
         if 'Attention.q' in name:
@@ -64,12 +81,263 @@ def fuse_qkv(model, factor, saved_dir):
             # ColumnLinear projection weights W=[3*d_out/TP, d_in], split dim=0 or dim=1 in [3, d_out/TP, d_in]
             split_dim = 1
             split_vals = np.split(qkv, factor, axis=split_dim)
-            for j in range(factor):
-                saved_path = saved_dir / f"{component}.block.{block_idx}.layer.{layer_idx}.{attn_type}.qkv.weight.{j}.bin"
-                split_vals[j].tofile(saved_path.as_posix())
+            key = f"{component}.block.{block_idx}.layer.{layer_idx}.{attn_type}.qkv.weight"
+            component = "encoder" if name.startswith("encoder") else "decoder"
+            save_split(split_vals, saved_dir, key, 0, factor)
 
+            scales = act_range.get(name.replace(".weight", "").replace("Attention.q", "Attention.qkv"))
+            if save_int8 and scales:
+                vals_i8 = generate_int8(qkv,
+                                        scales,
+                                        key,
+                                        is_qkv=True)
+                write_int8(vals_i8,
+                        saved_dir,
+                        key,
+                        split_dim,
+                        0,
+                        factor,
+                        is_qkv=True)
 
-def split_and_convert_process(key, val, factor, saved_dir):
+def generate_int8(weights, act_range, key: str, is_qkv=False):
+    """
+     This function has two purposes:
+      - compute quantized weights, scaled either per-tensor or per-column
+      - compute scaling factors
+
+      Depending on the GEMM API (CUTLASS/CUBLAS) the required scaling factors differ.
+      CUTLASS uses two sets of scaling factors. One for the activation X, one for the weight W.
+      CUBLAS only has one (we can't do per-row scaling). So we must provide pre-multiplied scaling factor.
+
+      Here is the list of what we need (T means per-tensor, C per-column):
+        - scale_x_orig_quant puts fp activation into the quantized range (i.e. [-128, 127], for int8). Used before the GEMM. (T)
+        - scale_y_quant_orig puts quantized activation into the fp range. Used if the GEMM outputs int8. (T)
+        - scale_w_quant_orig puts weights from quant range to fp range (used with CUTLASS) (T, C)
+        - scale_y_accum_quant puts the GEMM result (XW) from accumulation range (int32)
+          to quant range (int8) (used for CUBLAS) (T, C)
+
+      Note that we don't do anything special about row-parallel GEMM. Theoretically, we could have per-GPU scaling factors too,
+      but then the model would change depending on the number of GPUs used.
+
+      For QKV projection, the behavior is special. Even if we have a single matrix to perform QKV projection, we consider it
+      as three different matrices: Q, K, and V. So per-tensor actually means one scaling factor for each Q, K and V.
+      For our GEMM implementation to respect this behavior, we use per-column mode and replicate values along columns.
+    """
+
+    # compute weight scaling factors for fp->int8 and int8->fp
+    if is_qkv:
+        scale_w_orig_quant_t = 127. / act_range["w"].reshape(3, -1).max(
+            dim=-1, keepdims=True)[0].cpu().numpy()
+        scale_w_orig_quant_c = 127. / act_range["w"].reshape(3,
+                                                             -1).cpu().numpy()
+    else:
+        scale_w_orig_quant_t = 127. / act_range["w"].max().cpu().numpy()
+        scale_w_orig_quant_c = 127. / act_range["w"].cpu().numpy()
+    
+    scale_w_orig_quant_t = np.expand_dims(scale_w_orig_quant_t, -1)
+    scale_w_orig_quant_c = np.expand_dims(scale_w_orig_quant_c, -1)
+    scale_w_quant_orig_t = 1.0 / scale_w_orig_quant_t
+    scale_w_quant_orig_c = 1.0 / scale_w_orig_quant_c
+
+    # compute the rest of needed scaling factors
+    scale_x_orig_quant_t = np.array(127. / act_range["x"].max().item())
+    scale_y_orig_quant_t = np.array(127. / act_range["y"].max().item())
+    scale_y_quant_orig_t = np.array(act_range["y"].max().item() / 127.)
+    try:
+        scale_y_accum_quant_t = scale_y_orig_quant_t / (scale_x_orig_quant_t *
+                                                        scale_w_orig_quant_t)
+        scale_y_accum_quant_c = scale_y_orig_quant_t / (scale_x_orig_quant_t *
+                                                        scale_w_orig_quant_c)
+        if is_qkv:
+            scale_y_accum_quant_t = np.broadcast_to(scale_y_accum_quant_t,
+                                                    scale_w_orig_quant_c.shape)
+            scale_w_quant_orig_t = np.broadcast_to(scale_w_quant_orig_t,
+                                               scale_w_orig_quant_c.shape)
+    except:
+        print(f"---------------{key}-----------------------")
+        print(f"scale_w_orig_quant_t = {scale_w_orig_quant_t}")
+        print(f"scale_w_orig_quant_c = {scale_w_orig_quant_c}")
+        print(f"scale_x_orig_quant_t = {scale_x_orig_quant_t}")
+        print(f"scale_y_orig_quant_t = {scale_y_orig_quant_t}")
+
+    to_i8 = lambda x: x.round().clip(-127, 127).astype(np.int8)
+
+    weight_int8 = to_i8(weights * scale_w_orig_quant_t)
+    return {
+        "weight.int8": weight_int8,
+        "weight.int8.col": to_i8(weights * scale_w_orig_quant_c),
+        "scale_x_orig_quant": scale_x_orig_quant_t.astype(np.float32),
+        "scale_w_quant_orig": scale_w_quant_orig_t.astype(np.float32),
+        "scale_w_quant_orig.col": scale_w_quant_orig_c.astype(np.float32),
+        "scale_y_accum_quant": scale_y_accum_quant_t.astype(np.float32),
+        "scale_y_accum_quant.col": scale_y_accum_quant_c.astype(np.float32),
+        "scale_y_quant_orig": scale_y_quant_orig_t.astype(np.float32),
+    }
+
+def write_int8(vals,
+               dir,
+               key,
+               split_dim,
+               i,
+               factor,
+               is_qkv=False):
+
+    base_key = key.replace(".weight", "")
+    saved_keys_once = [
+        "scale_x_orig_quant", "scale_w_quant_orig", "scale_y_accum_quant",
+        "scale_y_quant_orig"
+    ]
+
+    save_split(np.split(vals["weight.int8"], factor, axis=split_dim), dir,
+                f"{base_key}.weight.int8", i, factor)
+    save_split(np.split(vals["weight.int8.col"], factor, axis=split_dim),
+                dir, f"{base_key}.weight.int8.col", i, factor)
+
+    if split_dim != -1:
+        save_split(
+            np.split(vals["scale_w_quant_orig.col"], factor,
+                        axis=split_dim), dir,
+            f"{base_key}.scale_w_quant_orig.col", i, factor)
+        save_split(
+            np.split(vals["scale_y_accum_quant.col"],
+                        factor,
+                        axis=split_dim), dir,
+            f"{base_key}.scale_y_accum_quant.col", i, factor)
+        if is_qkv:
+            save_split(
+                np.split(vals["scale_y_accum_quant"],
+                            factor,
+                            axis=split_dim), dir,
+                f"{base_key}.scale_y_accum_quant", i, factor)
+            save_split(
+                np.split(vals["scale_w_quant_orig"], factor,
+                            axis=split_dim), dir,
+                f"{base_key}.scale_w_quant_orig", i, factor)
+            saved_keys_once = ["scale_x_orig_quant", "scale_y_quant_orig"]
+    else:
+        saved_keys_once += [
+            "scale_w_quant_orig.col", "scale_y_accum_quant.col"
+        ]
+
+    if i == 0:
+        for save_key in saved_keys_once:
+            save_val(vals[save_key], dir, f"{base_key}.{save_key}")
+
+@torch.no_grad()
+def smooth_t5_model(
+    model: T5ForConditionalGeneration,
+    scales: defaultdict,
+    alpha: float,
+    t5_smoother: dict,
+) -> None:
+    # Smooth the activation and weights with smoother = $\diag{s}$
+
+    def set_attention_scales_and_smoother(name, submodules, attention_type: Literal["self_attn", "cross_attn"]):
+        layer_idx, submodule = submodules[attention_type]
+        attn_field_name = "SelfAttention" if attention_type == "self_attn" else "EncDecAttention"
+        attention_layer = getattr(submodule, attn_field_name)
+        attn_qkv_weight = torch.cat([
+            attention_layer.q.weight,
+            attention_layer.k.weight,
+            attention_layer.v.weight, 
+        ], dim=0)
+        
+        # QKV
+        layer_name_q = name + f".layer.{layer_idx}.{attn_field_name}.q"
+        layer_name_k = name + f".layer.{layer_idx}.{attn_field_name}.k"
+        layer_name_v = name + f".layer.{layer_idx}.{attn_field_name}.v"
+        layer_name_qkv = name + f".layer.{layer_idx}.{attn_field_name}.qkv"
+
+        smoother = smooth_gemm(attn_qkv_weight, scales[layer_name_q]["x"],
+                               submodule.layer_norm.weight, None, alpha)
+
+        scales[layer_name_qkv]["x"] = scales[layer_name_q]["x"] / smoother
+        scales[layer_name_qkv]["w"] = attn_qkv_weight.abs().max(dim=1)[0]
+        scales[layer_name_qkv]["y"] = torch.cat([
+            scales[layer_name_q]["y"], scales[layer_name_k]["y"],
+            scales[layer_name_v]["y"]
+        ], dim=0)
+
+        # Attention O
+        layer_name = name + f".layer.{layer_idx}.{attn_field_name}.o"
+        smoother = smooth_gemm(attention_layer.o.weight,
+                               scales[layer_name]["x"], None, None, alpha)
+        t5_smoother[layer_name] = smoother.float()
+
+        scales[layer_name]["x"] = scales[layer_name]["x"] / smoother
+        scales[layer_name]["w"] = attention_layer.o.weight.abs().max(
+            dim=1)[0]
+
+    
+    for name, module in model.named_modules():
+        # TODO: remove this logic when we add SmoothQuantBertAttention
+        # For now, only quantize the weights for the decoder.
+        if name.startswith("encoder"):
+            continue
+        if not isinstance(module, T5Block):
+            continue
+        
+        submodules = {}
+        for i, submodule in enumerate(module.layer):
+            # Each T5 Block has SelfAttention, LayerFF, and maybe CrossAttention (decoder only).
+            if isinstance(submodule, T5LayerSelfAttention):
+                submodules["self_attn"] = (i, submodule)
+            elif isinstance(submodule, T5LayerCrossAttention):
+                submodules["cross_attn"] = (i, submodule)
+            elif isinstance(submodule, T5LayerFF):
+                submodules["dense_act"] = (i, submodule)
+
+        # ======================= Scale and Smooth Attention =============================
+        set_attention_scales_and_smoother(name, submodules, "self_attn")
+        if "cross_attn" in submodules:
+            set_attention_scales_and_smoother(name, submodules, "cross_attn")
+
+        # ======================= Scale and Smooth MLP =============================
+        layer_idx, submodule = submodules["dense_act"]
+        fc1_layer_name = name + f".layer.{layer_idx}.DenseReluDense.wi"
+        
+        if model.config.is_gated_act:
+            fc1_layer_name = name + f".layer.{layer_idx}.DenseReluDense.wi_0"
+            gate_layer_name = name + f".layer.{layer_idx}.DenseReluDense.wi_1"
+            smoother = smooth_gemm_fc1_gate(
+                submodule.DenseReluDense.wi_0.weight,
+                submodule.DenseReluDense.wi_1.weight,
+                scales[fc1_layer_name]["x"],
+                submodule.layer_norm.weight,
+                None, alpha)
+            scales[gate_layer_name]["x"] = scales[gate_layer_name]["x"] / smoother
+            scales[gate_layer_name]["w"] = submodule.DenseReluDense.wi_1.weight.abs().max(
+                dim=1)[0]
+            scales[fc1_layer_name]["w"] = submodule.DenseReluDense.wi_0.weight.abs().max(
+            dim=1)[0]
+        else:
+            smoother = smooth_gemm(
+                submodule.DenseReluDense.wi.weight,
+                scales[fc1_layer_name]["x"],
+                submodule.layer_norm.weight,
+                None, alpha)
+            scales[fc1_layer_name]["w"] = submodule.DenseReluDense.wi.weight.abs().max(
+            dim=1)[0]
+
+        scales[fc1_layer_name]["x"] = scales[fc1_layer_name]["x"] / smoother
+        
+        
+        mlp_proj_layer_name = name + f".layer.{layer_idx}.DenseReluDense.wo"
+        smoother = smooth_gemm(submodule.DenseReluDense.wo.weight,
+                               scales[mlp_proj_layer_name]["x"], None, None, alpha)
+        t5_smoother[mlp_proj_layer_name] = smoother.float()
+        scales[mlp_proj_layer_name]["x"] = scales[mlp_proj_layer_name]["x"] / smoother
+        scales[mlp_proj_layer_name]["w"] = submodule.DenseReluDense.wo.weight.abs().max(
+            dim=1)[0]
+
+def split_and_convert_process(
+    key,
+    val,
+    factor,
+    saved_dir,
+    act_range: Optional[dict] = None,
+    int8_outputs: Optional[str] = None
+) -> None:
     # The split_factor indicates the number of ranks to implement
     # distributed GEMMs. For Tensor Parallelism, each rank/GPU works
     # on split_hidden_dim // split_factor channels.
@@ -104,6 +372,10 @@ def split_and_convert_process(key, val, factor, saved_dir):
         for j in range(factor):
             saved_path = saved_dir / f"{saved_key}.{j:d}.bin"
             split_vals[j].tofile(saved_path.as_posix())
+        
+        if act_range is not None and int8_outputs == "all":
+            vals_i8 = generate_int8(val, act_range, key)
+            write_int8(vals_i8, saved_dir, key, split_dim, 0, factor)
 
     elif ("lm_head.weight" in key or "DenseReluDense.wi.weight" in key
           or "DenseReluDense.wi_0.weight" in key
@@ -118,6 +390,10 @@ def split_and_convert_process(key, val, factor, saved_dir):
         for j in range(factor):
             saved_path = saved_dir / f"{saved_key}.{j:d}.bin"
             split_vals[j].tofile(saved_path.as_posix())
+        
+        if act_range is not None and int8_outputs == "all":
+            vals_i8 = generate_int8(val, act_range, key)
+            write_int8(vals_i8, saved_dir, saved_key, split_dim, 0, factor)
 
     elif (("encoder" in key and
            ("SelfAttention.q.weight" in key or "SelfAttention.k.weight" in key
@@ -132,6 +408,9 @@ def split_and_convert_process(key, val, factor, saved_dir):
 
     elif "encoder.embed_tokens.weight" in key or "decoder.embed_tokens.weight" in key:
         LOGGER.warning(f"Not save {key}, using shared.weight directly.")
+    elif ".smoother" in key:
+        split_vals = np.split(val, factor, axis=0)
+        save_split(split_vals, saved_dir, key, 0, factor)
 
     else:
         LOGGER.warning(f"cannot find key '{key}' with shape {val.shape}")
@@ -141,8 +420,11 @@ def convert_checkpoint(args):
     saved_dir = Path(args.output_dir) / f"tp{args.inference_tensor_para_size}"
     saved_dir.mkdir(parents=True, exist_ok=True)
 
-    t5_model = T5ForConditionalGeneration.from_pretrained(args.input_dir)
-    t5_model = t5_model.to(str_dtype_to_torch(args.weight_data_type))
+    t5_model = T5ForConditionalGeneration.from_pretrained(
+        args.input_dir,
+        device_map="auto" if not args.load_model_on_cpu else "cpu",
+        torch_dtype=str_dtype_to_torch(args.weight_data_type),
+    )
 
     config = configparser.ConfigParser()
     extra_configs["structure"]["use_gated_activation"] = str(
@@ -152,6 +434,25 @@ def convert_checkpoint(args):
     for key, val in t5_model.encoder.config.to_dict().items():
         config["encoder"][key] = f"{val}"
     config["encoder"]["weight_data_type"] = args.weight_data_type
+
+    act_range = {}
+    t5_smoother = {}  # smoother for inputs of SelfAttention.o and DenseReluDense.wo
+
+    if args.smoothquant is not None:
+        os.environ["TOKENIZERS_PARALLELISM"] = os.environ.get(
+            "TOKENIZERS_PARALLELISM", "false")
+        # TODO: Provide ability to pass in custom dataset
+        dataset = load_dataset("ccdv/cnn_dailymail",
+                               '3.0.0',
+                               cache_dir=args.dataset_cache_dir)
+        act_range = capture_activation_range(
+            t5_model,
+            T5Tokenizer.from_pretrained(args.input_dir),
+            dataset,
+            num_samples=args.calibration_set_num_samples)
+        if args.smoothquant is not None:
+            smooth_t5_model(t5_model, act_range, args.smoothquant,
+                               t5_smoother)
 
     # manually set q_scaling to offset attention scaling's effect.
     # TODO: modify kernels to control whether to disable attention scaling
@@ -182,15 +483,44 @@ def convert_checkpoint(args):
 
     i_gpu_num = args.inference_tensor_para_size
 
+    int8_outputs = None
+    if args.smoothquant is not None:
+        int8_outputs = "all"
+
     pool = multiprocessing.Pool(args.processes)
-    pool.starmap_async(split_and_convert_process,
-                       [(name, torch_to_numpy(param), i_gpu_num, saved_dir)
-                        for name, param in t5_model.state_dict().items()])
+    starmap_args = []
+    for name, param in t5_model.state_dict().items():
+        if name.replace(".weight", "") in t5_smoother.keys():
+            smoother = t5_smoother[name.replace(".weight", "")]
+            smoother = smoother.detach().cpu().numpy()
+            starmap_args.append(
+                (
+                    f"{name}.smoother".replace(".weight", ""),
+                    smoother,
+                    i_gpu_num,
+                    saved_dir,
+                    None,
+                    int8_outputs
+                )
+            )
+        starmap_args.append(
+            (
+                name,
+                torch_to_numpy(param),
+                i_gpu_num,
+                saved_dir,
+                act_range.get(name.replace(".weight", "")),
+                int8_outputs
+            )
+        )
+    pool.starmap_async(
+        split_and_convert_process, starmap_args
+    )
 
     pool.close()
     pool.join()
 
-    fuse_qkv(t5_model, i_gpu_num, saved_dir)
+    fuse_qkv(t5_model, i_gpu_num, saved_dir, act_range, int8_outputs)
 
 
 if __name__ == "__main__":
@@ -224,6 +554,46 @@ if __name__ == "__main__":
     parser.add_argument("--verbose",
                         action="store_true",
                         help="Provide verbose messages")
+    parser.add_argument(
+        "--smoothquant",
+        "-sq",
+        type=float,
+        default=None,
+        help="Set the α parameter (see https://arxiv.org/pdf/2211.10438.pdf)"
+        " to Smoothquant the model, and output int8 weights."
+        " A good first try is 0.5. Must be in [0, 1]")
+    parser.add_argument(
+        '--per_channel',
+        action="store_true",
+        default=False,
+        help=
+        'By default, we use a single static scaling factor for the GEMM\'s result. '
+        'per_channel instead uses a different static scaling factor for each channel. '
+        'The latter is usually more accurate, but a little slower.')
+    parser.add_argument(
+        '--per_token',
+        action="store_true",
+        default=False,
+        help=
+        'By default, we use a single static scaling factor to scale activations in the int8 range. '
+        'per_token chooses at run time, and for each token, a custom scaling factor. '
+        'The latter is usually more accurate, but a little slower.')
+    parser.add_argument("--dataset-cache-dir",
+                        type=str,
+                        default=None,
+                        help="cache dir to load the hugging face dataset")
+    parser.add_argument(
+        "--calibration_set_num_samples",
+        type=int,
+        default=512,
+        help="Number of samples used for capture_activation_range. Only used for SmoothQuant."
+    )
+    parser.add_argument(
+        "--load_model_on_cpu",
+        action="store_true",
+        default=False,
+        help="Whether to load the model on CPU."
+    )
     args = parser.parse_args()
     log_format = "%(asctime)s %(name)s [%(levelname)s] %(message)s"
     logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO,

--- a/examples/enc_dec/t5/smoothquant.py
+++ b/examples/enc_dec/t5/smoothquant.py
@@ -1,0 +1,215 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Utilities for SmoothQuant models
+"""
+
+import copy
+import functools
+from collections import defaultdict
+
+import torch
+import torch.nn as nn
+from tqdm import tqdm
+from transformers.pytorch_utils import Conv1D
+
+
+@torch.no_grad()
+def apply_smoothing(
+    scales,
+    gemm_weights,
+    layernorm_weights=None,
+    layernorm_bias=None,
+    dtype=torch.float32,
+    layernorm_1p=False,
+):
+    if not isinstance(gemm_weights, list):
+        gemm_weights = [gemm_weights]
+
+    if layernorm_weights is not None:
+        assert layernorm_weights.numel() == scales.numel()
+        layernorm_weights.div_(scales).to(dtype)
+    if layernorm_bias is not None:
+        assert layernorm_bias.numel() == scales.numel()
+        layernorm_bias.div_(scales).to(dtype)
+    if layernorm_1p:
+        layernorm_weights += (1 / scales) - 1
+
+    for gemm in gemm_weights:
+        gemm.mul_(scales.view(1, -1)).to(dtype)
+
+
+@torch.no_grad()
+def smooth_gemm(
+    gemm_weights,
+    act_scales,
+    layernorm_weights=None,
+    layernorm_bias=None,
+    alpha=0.5,
+    weight_scales=None,
+):
+    if not isinstance(gemm_weights, list):
+        gemm_weights = [gemm_weights]
+    orig_dtype = gemm_weights[0].dtype
+
+    for gemm in gemm_weights:
+        # gemm_weights are expected to be transposed
+        assert gemm.shape[1] == act_scales.numel()
+
+    if weight_scales is None:
+        weight_scales = torch.cat(
+            [gemm.abs().max(dim=0, keepdim=True)[0] for gemm in gemm_weights], dim=0
+        )
+        weight_scales = weight_scales.max(dim=0)[0]
+    weight_scales.to(float).clamp(min=1e-5)
+    scales = (
+        act_scales.to(gemm_weights[0].device).to(float).pow(alpha)
+        / weight_scales.pow(1 - alpha)
+    ).clamp(min=1e-5)
+
+    apply_smoothing(scales, gemm_weights, layernorm_weights, layernorm_bias, orig_dtype)
+
+    return scales
+
+
+@torch.no_grad()
+def smooth_gemm_fc1_gate(
+    fc1_weights,
+    gate_weights,
+    act_scales,
+    layernorm_weights=None,
+    layernorm_bias=None,
+    alpha=0.5,
+    weight_scales=None,
+):
+    gemm_weights = []
+    if not isinstance(fc1_weights, list):
+        fc1_weights = [fc1_weights]
+    if not isinstance(gate_weights, list):
+        gate_weights = [gate_weights]
+
+    for i in range(len(fc1_weights)):
+        gemm_weight = torch.cat([fc1_weights[i], gate_weights[i]], dim=0)
+        gemm_weights.append(gemm_weight)
+
+    orig_dtype = gemm_weights[0].dtype
+
+    for gemm in gemm_weights:
+        # gemm_weights are expected to be transposed
+        assert gemm.shape[1] == act_scales.numel()
+
+    if weight_scales is None:
+        weight_scales = torch.cat(
+            [gemm.abs().max(dim=0, keepdim=True)[0] for gemm in gemm_weights], dim=0
+        )
+        weight_scales = weight_scales.max(dim=0)[0]
+    weight_scales.to(float).clamp(min=1e-5)
+    scales = (
+        act_scales.to(gemm_weights[0].device).to(float).pow(alpha)
+        / weight_scales.pow(1 - alpha)
+    ).clamp(min=1e-5)
+
+    apply_smoothing(
+        scales,
+        fc1_weights + gate_weights,
+        layernorm_weights,
+        layernorm_bias,
+        orig_dtype,
+    )
+
+    return scales
+
+
+@torch.no_grad()
+def smooth_ln_fcs(ln, fcs, act_scales, alpha=0.5):
+    if not isinstance(fcs, list):
+        fcs = [fcs]
+    for fc in fcs:
+        assert isinstance(fc, nn.Linear)
+        assert ln.weight.numel() == fc.in_features == act_scales.numel()
+
+    device, dtype = fcs[0].weight.device, fcs[0].weight.dtype
+    act_scales = act_scales.to(device=device, dtype=dtype)
+    weight_scales = torch.cat(
+        [fc.weight.abs().max(dim=0, keepdim=True)[0] for fc in fcs], dim=0
+    )
+    weight_scales = weight_scales.max(dim=0)[0].clamp(min=1e-5)
+
+    scales = (
+        (act_scales.pow(alpha) / weight_scales.pow(1 - alpha))
+        .clamp(min=1e-5)
+        .to(device)
+        .to(dtype)
+    )
+
+    if ln is not None:
+        ln.weight.div_(scales)
+        ln.bias.div_(scales)
+
+    for fc in fcs:
+        fc.weight.mul_(scales.view(1, -1))
+    return scales
+
+
+@torch.no_grad()
+def capture_activation_range(model, tokenizer, dataset, num_samples=512, seq_len=512):
+    model.eval()
+    device = next(model.parameters()).device
+    act_scales = defaultdict(lambda: {"x": None, "y": None, "w": None})
+
+    tokenizer.pad_token = tokenizer.eos_token
+
+    def stat_tensor(name, tensor, act_scales, key):
+        hidden_dim = tensor.shape[-1]
+        tensor = tensor.view(-1, hidden_dim).abs().detach()
+        comming_max = torch.max(tensor, dim=0)[0].float()
+
+        if act_scales[name][key] is None:
+            act_scales[name][key] = comming_max
+        else:
+            act_scales[name][key] = torch.max(act_scales[name][key], comming_max)
+
+    def stat_input_hook(m, x, y, name):
+        if isinstance(x, tuple):
+            x = x[0]
+        stat_tensor(name, x, act_scales, "x")
+        stat_tensor(name, y, act_scales, "y")
+
+        if act_scales[name]["w"] is None:
+            act_scales[name]["w"] = m.weight.abs().clip(1e-8, None).max(dim=1)[0]
+
+    hooks = []
+    for name, m in model.named_modules():
+        if isinstance(m, nn.Linear) or isinstance(m, Conv1D):
+            hooks.append(
+                m.register_forward_hook(functools.partial(stat_input_hook, name=name))
+            )
+
+    # TODO(Eddie): Make this task more flexible
+    for i in tqdm(range(num_samples), desc="calibrating model"):
+        datapoint = dataset["train"][i : i + 1]
+        line = copy.copy(datapoint["article"])
+        line[0] = line[0] + " TL;DR: "
+        line[0] = line[0].strip()
+        line[0] = line[0].replace(" n't", "n't")
+        input_ids = tokenizer(
+            line, return_tensors="pt", max_length=seq_len, padding=True, truncation=True
+        ).input_ids.to(device)
+        model.generate(input_ids)
+
+    for h in hooks:
+        h.remove()
+
+    return act_scales

--- a/tensorrt_llm/models/enc_dec/model.py
+++ b/tensorrt_llm/models/enc_dec/model.py
@@ -321,6 +321,23 @@ class DecoderLayer(Module):
         # e.g. BART post, T5 pre
         self.layernorm_position = layernorm_position
 
+        self.hidden_size = hidden_size
+        self.ffn_hidden_size = ffn_hidden_size
+        self.num_attention_heads = num_attention_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_size = head_size
+        self.max_position_embeddings = max_position_embeddings
+        self.q_scaling = q_scaling
+        self.has_attention_qkvo_bias = has_attention_qkvo_bias
+        self.layernorm_eps = layernorm_eps
+        self.hidden_act = hidden_act
+        self.mapping = mapping
+        self.dtype = dtype
+        self.max_distance = max_distance
+        self.num_buckets = num_buckets
+        self.relative_attention = relative_attention
+        self.has_mlp_bias = has_mlp_bias
+
         # e.g. BART q_scaling = 1.f, T5 q_scaling = 1.f/sqrt(head_size)
         self.self_attention = Attention(
             local_layer_idx=local_layer_idx,

--- a/tensorrt_llm/models/quantized/quant.py
+++ b/tensorrt_llm/models/quantized/quant.py
@@ -449,7 +449,6 @@ def _smooth_quantize_encoder_decoder(model, quant_mode):
                     else PositionEmbeddingType.learned_absolute
                 ),
                 quant_mode=quant_mode,
-                clip_qkv=None,
             )
             layer.cross_attention = SmoothQuantAttention(
                 layer.hidden_size,
@@ -470,7 +469,6 @@ def _smooth_quantize_encoder_decoder(model, quant_mode):
                 num_buckets=layer.num_buckets,
                 position_embedding_type=PositionEmbeddingType.learned_absolute,
                 quant_mode=quant_mode,
-                clip_qkv=None,
             )
         else: # Encoder
             # TODO: Need to support BertAttention for SQ


### PR DESCRIPTION
### Summary
Add SmoothQuant quantization for T5

### Test Plan
Built the engine with t5-small using the following commands

```
python t5/convert.py -i t5-large -o $CONVERTED_WEIGHT_DIR --weight_data_type float32 --inference_tensor_para_size 1
and then

python build.py --model_type t5 \
                --weight_dir ${CONVERTED_WEIGHT_DIR}/tp1 \
                -o $TRT_ENGINE_DIR \
                --engine_name t5 \
                --use_bert_attention_plugin  \
                --use_gpt_attention_plugin  \
                --use_gemm_plugin  \
                --dtype float16 \
                --max_beam_width 4 \
                --max_batch_size 32 \
                --max_output_len 512 \
                --use_weight_only \
                --world_size 1 \
                --tp_size 1 \
                --use_smooth_quant \
                --per_token \
                --per_channel
```
Tried this with TP=4 as well, and each combination of `--per_token` and `--per_channel` (i.e. only per_token, only --per_channel, and both).

Then measured the performance using:
```
python run.py --engine_dir $TRT_ENGINE_DIR --engine_name t5 --model_name t5-large --max_new_token=64 --num_beams=1 --compare_hf_fp32
```

### Results
**Hugging Face FP32**
```
HF E2E time 2135.8585357666016m
['Das Haus ist wunderbar.', 'i am a high-performance inference optimizer and runtime.', ", the Eiffel Tower was the world's tallest man-made structure.... During its construction, the Eiffel Tower surpassed the Washington Monument to become the world's tallest man-made structure......."]
```
**TRT-LLM SmoothQuant (vanilla, no per_token or per_channel)**
```
TRT-LLM E2E time 447.0314979553222
['Das Haus ist wunderbar.', 'a high-performance inference optimizer and runtime.', '.: i.g. : i.t.: i.t.: : : : : : : : : : : : : : : :
 : : : : ']
```

**TRT-LLM SmoothQuant with --per_token and --per_channel**
NOTE: to get --per_token to work, I had to disable the quantize_per_token plugin since this gave incorrect results. But this greatly slows down the inference time.
```
TRT-LLM E2E time 1073.2574462890625ms
Precision: float16
['Das Haus ist wunderbar.', 'i am a high-performance inference optimizer and runtime.', 'the Eiffel Tower was built. The Eiffel Tower is the symbol of Paris and its people. The Eiffel Tower is the symbol of its people. The symbol of its people. The symbol of its people. The symbol of its people. The symbol of its people. The symbol of its people. The symbol']
```

### Remaining Issues

1. I did not add the `SmoothQuantBertAttention` module yet, so this quantizes the decoder only. I can add that once we confirm the decoder logic is correct. The existing output seems quite poor compared to HF, so I wanted to double check my implementation before adding more unknowns.
2. Flan-T5 models look very bad, so I am not sure I quantized the gate part correctly.
3. When the `quantize_per_token` plugin is enabled, the output is nonsensical. So this needs to be disabled to get `--per_token` to run, but this makes the model much slower.
4. The existing speed is slower than weight-only int8 quantization, even at larger batches (batch_size = 32). From profiling, this seems like it's compute bound at this point, so I feel like my implementation must be suboptimal in places.
