### PR TITLE
llama convert add rotary_scaling param in cli_args

### DIFF
--- a/examples/llama/convert_checkpoint.py
+++ b/examples/llama/convert_checkpoint.py
@@ -120,6 +120,12 @@ def parse_arguments():
 
     parser.add_argument('--rotary_base', type=float, default=10000.0)
 
+    parser.add_argument('--rotary_scaling',
+                        nargs=2,
+                        type=str,
+                        default=None,
+                        help='There are two arguments, the config can be --rotary_scaling linear 4.0')
+
     parser.add_argument('--group_size',
                         type=int,
                         default=128,
@@ -268,6 +274,15 @@ def args_to_build_options(args):
 
 def from_cli_args(args):
     n_kv_head = args.n_kv_head if args.n_kv_head is not None else args.n_head
+    if args.rotary_scaling is not None:
+        # assert args.use_gpt_attention_plugin, "RoPE scaling is only supported through GPT attention plugin."
+        rotary_scaling = {
+            "type": args.rotary_scaling[0],
+            "factor": float(args.rotary_scaling[1])
+        }
+        assert rotary_scaling["type"] in ["linear", "dynamic"]
+        assert rotary_scaling["factor"] > 1.0
+        args.rotary_scaling = rotary_scaling
     config = {
         'architecture': "LlamaForCausalLM",
         'dtype': args.dtype,
@@ -282,6 +297,7 @@ def from_cli_args(args):
         'max_position_embeddings': args.n_positions,
         'hidden_act': args.hidden_act,
         'rotary_base': args.rotary_base,
+        'rotary_scaling': args.rotary_scaling,
         'norm_epsilon': args.rms_norm_eps,
         'moe_num_experts': args.moe_num_experts,
         'moe_top_k': args.moe_top_k,


### PR DESCRIPTION
In the convert_checkpoint.py of llama, if we define the args with command, the rotary_scaling param can not be missed in some situations, so rotary_scaling param should be added to avoid the special situations.

For example, [deepseek-coder-6.7b-base](https://huggingface.co/deepseek-ai/deepseek-coder-6.7b-base), it needs the rotary_scaling param. 
```
  "rope_scaling": {
    "factor": 4.0,
    "type": "linear"
  }
```
Otherwise, there will be a lot of duplicate tokens during inference.
```
curl -X POST localhost:8620/v2/models/ensemble/generate -d '{"text_input": "def quick_sort", "max_tokens": 10, "bad_words": "", "stop_words": "", "stream": true, "temperature": 0.2, "return_log_probs": true, "top_p": 0.75, "end_id": [32022]}'
```

```
"text_output":"sortsortsortsortsortsortsortsortsortsort"
```
