### PR TITLE
fix: correct cudaSetDevice error when GPUs per node are fewer than their ranks in inter-node inference

### DIFF
--- a/cpp/tensorrt_llm/pybind/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/bindings.cpp
@@ -222,7 +222,7 @@ PYBIND11_MODULE(TRTLLM_PYBIND_MODULE, m)
     py::class_<tr::WorldConfig>(m, "WorldConfig")
         .def(py::init<SizeType, SizeType, SizeType, SizeType, std::optional<std::vector<SizeType>> const&>(),
             py::arg("tensor_parallelism") = 1, py::arg("pipeline_parallelism") = 1, py::arg("rank") = 0,
-            py::arg("gpus_per_node") = tr::WorldConfig::kDefaultGpusPerNode, py::arg("device_ids") = py::none())
+            py::arg("gpus_per_node") = tc::getDeviceCount(), py::arg("device_ids") = py::none())
         .def_property_readonly("size", &tr::WorldConfig::getSize)
         .def_property_readonly("tensor_parallelism", &tr::WorldConfig::getTensorParallelism)
         .def_property_readonly("pipeline_parallelism", &tr::WorldConfig::getPipelineParallelism)
@@ -237,7 +237,7 @@ PYBIND11_MODULE(TRTLLM_PYBIND_MODULE, m)
         .def_static("mpi",
             py::overload_cast<SizeType, std::optional<SizeType>, std::optional<SizeType>,
                 std::optional<std::vector<SizeType>> const&>(&tr::WorldConfig::mpi),
-            py::arg("gpus_per_node") = tr::WorldConfig::kDefaultGpusPerNode, py::arg("tensor_parallelism") = py::none(),
+            py::arg("gpus_per_node") = tc::getDeviceCount(), py::arg("tensor_parallelism") = py::none(),
             py::arg("pipeline_parallelism") = py::none(), py::arg("device_ids") = py::none());
 
     auto SamplingConfigGetState = [](tr::SamplingConfig const& config) -> py::tuple

--- a/tensorrt_llm/mapping.py
+++ b/tensorrt_llm/mapping.py
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import List
-
+from cuda import cudart
+status, gpus_per_node = cudart.cudaGetDeviceCount()
+assert status == 0, f"cudaGetDeviceCount failed with error: {status}"
 
 class Mapping(object):
     '''
@@ -35,7 +37,7 @@ class Mapping(object):
     def __init__(self,
                  world_size=1,
                  rank=0,
-                 gpus_per_node=8,
+                 gpus_per_node=gpus_per_node,
                  tp_size=1,
                  pp_size=1):
         self.tp_size = tp_size


### PR DESCRIPTION
#1494 