### PR TITLE
Remove the <s> token from post_prompt of multimodal

### DIFF
--- a/examples/multimodal/run.py
+++ b/examples/multimodal/run.py
@@ -158,6 +158,7 @@ class MultimodalModelRunner:
         if post_prompt[0] is not None:
             post_input_ids = self.tokenizer(post_prompt,
                                             return_tensors="pt",
+                                            add_special_tokens=False,
                                             padding=True).input_ids
             length = pre_input_ids.shape[1] + post_input_ids.shape[
                 1] + visual_atts.shape[1]
@@ -269,7 +270,7 @@ class MultimodalModelRunner:
         if post_input_ids is not None:
             input_ids = [pre_input_ids, fake_prompt_id, post_input_ids]
         else:
-            input_ids = [fake_prompt_id, pre_input_ids]
+            input_ids = [pre_input_ids, fake_prompt_id]
         input_ids = torch.cat(input_ids, dim=1).contiguous().to(torch.int32)
 
         if self.decoder_llm or self.runtime_mapping.is_first_pp_rank():


### PR DESCRIPTION
In the multimodal example, both `pre_input_ids, post_input_ids` are generated using `self.tokenizer` and being concat to form the final input_id. 
tokenizer by default will prefix a `<s>` special start of line token in the start.  remove the `<s>` token from `post_input_ids` to make sure the final prompt don't have surprise tokens, also reorder the `pre_input_ids, fake_prompt_id`, since `pre_input_ids` also have a `<s>` token added in the front. 