### PR TITLE
INT8 kv cache dequant SCALE_QP_INSTEAD_OF_KV

### DIFF
--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttentionUtils.h
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttentionUtils.h
@@ -2431,6 +2431,15 @@ inline __device__ float4 mul(float4 a, int32_t b)
     return fc;
 }
 
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+template <>
+inline __device__ Float4_ mul(float4 a, int32_t b)
+{
+    float4 fc = mul<float4, float4, int32_t>(a, b);
+    return reinterpret_cast<Float4_&>(fc);
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 inline __device__ float sum(float v)


### PR DESCRIPTION
Following the logic of MMHA_FP8_SCALE_Q_INSTEAD_OF_K and MMHA_FP8_SCALE_P_INSTEAD_OF_V, I implemented the INT8 version. 

It is theoretically equivalent to the original compute logic without any numeric accuracy degradation. 

I tested the speed on H20, A100, and 4090 GPUs. The results show that the average latency of the MMHA kernel decreased by about 5% to 8%, thanks to fewer FMUL instructions.

Nsight Compute Kernel Summary
![image](https://github.com/user-attachments/assets/95334dc8-cb28-420b-8237-be83fec0b411)

Nsight Compute Instruction Statistics
![image](https://github.com/user-attachments/assets/3cf51896-07e5-4913-ade6-9385e3c16dfa)
