### PR TITLE
[examples/bert/build.py]: Load weights for BertModel and RobertaModel if `--model_dir` is provided

### DIFF
--- a/examples/bert/build.py
+++ b/examples/bert/build.py
@@ -221,8 +221,12 @@ if __name__ == '__main__':
 
     output_name = 'hidden_states'
     if args.model == 'BertModel' or args.model == 'RobertaModel':
-        hf_bert = globals()[f'{model_type}Model'](bert_config,
-                                                  add_pooling_layer=False)
+        if args.model_dir:
+            # Shall the same be done for other models?
+            hf_bert = globals()[f'{model_type}Model'].from_pretrained(args.model_dir, config=bert_config, add_pooling_layer=False)
+        else:
+            hf_bert = globals()[f'{model_type}Model'](bert_config,
+                                                    add_pooling_layer=False)
         tensorrt_llm_bert = tensorrt_llm.models.BertModel(
             num_layers=bert_config.num_hidden_layers,
             num_heads=bert_config.num_attention_heads,

--- a/examples/bert/build.py
+++ b/examples/bert/build.py
@@ -226,7 +226,7 @@ if __name__ == '__main__':
             hf_bert = globals()[f'{model_type}Model'].from_pretrained(args.model_dir, config=bert_config, add_pooling_layer=False)
         else:
             hf_bert = globals()[f'{model_type}Model'](bert_config,
-                                                    add_pooling_layer=False)
+                                                      add_pooling_layer=False)
         tensorrt_llm_bert = tensorrt_llm.models.BertModel(
             num_layers=bert_config.num_hidden_layers,
             num_heads=bert_config.num_attention_heads,


### PR DESCRIPTION
Currently the example TensorRT LLM engine builder for Bert models simply ignores model weights if those are present in the model directory, it only reads the `config.json` file, making it essentially impossible to generate a working engine from a pretrained model. This change fixes that.
