### PR TITLE
Create INT8 KV Cache on Qserve

### DIFF
--- a/examples/llama/convert_checkpoint.py
+++ b/examples/llama/convert_checkpoint.py
@@ -439,7 +439,7 @@ def convert_and_save_hf(args):
         # llava_llama needs its own defined config.
         logger.warning("AutoConfig cannot load the huggingface config.")
 
-    if args.smoothquant is not None or args.int8_kv_cache:
+    if (args.smoothquant is not None or args.int8_kv_cache) and not args.use_qserve:
         assert not args.load_by_shard, "When using quantization, TRT-LLM needs to load the whole HF model, thus load by shard not supported"
         mapping = Mapping(world_size=world_size,
                           tp_size=args.tp_size,
@@ -474,6 +474,10 @@ def convert_and_save_hf(args):
                 args.dtype,
                 mapping=mapping,
                 quant_config=quant_config,
+                device='cpu' if args.load_model_on_cpu else 'cuda',
+                calib_dataset=args.calib_dataset,
+                calib_batches=args.calib_size,
+                calib_max_seq_length=args.calib_max_seq_length,
                 load_by_shard=load_by_shard,
                 **override_fields,
             )

--- a/tensorrt_llm/models/llama/model.py
+++ b/tensorrt_llm/models/llama/model.py
@@ -36,7 +36,6 @@ from .convert import (load_hf_llama, load_weights_from_gptq,
                       load_weights_from_hf_safetensors,
                       load_weights_from_lmquant, load_weights_from_meta_ckpt)
 
-from tensorrt_llm.quantization import QuantAlgo
 
 class LLaMADecoderLayer(Module):
 

--- a/tensorrt_llm/models/llama/model.py
+++ b/tensorrt_llm/models/llama/model.py
@@ -36,6 +36,7 @@ from .convert import (load_hf_llama, load_weights_from_gptq,
                       load_weights_from_hf_safetensors,
                       load_weights_from_lmquant, load_weights_from_meta_ckpt)
 
+from tensorrt_llm.quantization import QuantAlgo
 
 class LLaMADecoderLayer(Module):
 
@@ -331,6 +332,10 @@ class LLaMAForCausalLM(DecoderModelForCausalLM):
             dtype: str = 'auto',
             mapping: Optional[Mapping] = None,
             quant_config: Optional[QuantConfig] = None,
+            device: str = 'cuda',
+            calib_dataset: str = 'cnn_dailymail',
+            calib_batches: int = 512,
+            calib_max_seq_length: int = 512,
             **kwargs):
         ''' Create a LLaMAForCausalLM object from give parameters
         '''
@@ -413,7 +418,9 @@ class LLaMAForCausalLM(DecoderModelForCausalLM):
                 if quant_config.quant_mode.is_int4_weight_only():
                     weights = load_weights_from_gptq(quant_ckpt_path, config)
                 elif quant_config.quant_mode.is_qserve_w4a8():
-                    weights = load_weights_from_lmquant(quant_ckpt_path, config)
+                    weights = load_weights_from_lmquant(quant_ckpt_path, 
+                        config, quant_config, hf_model_dir,
+                        device, calib_dataset, calib_batches, calib_max_seq_length)
                 else:
                     raise ValueError(
                         "quant_ckpt_path should be specified only for GPTQ or QServe"

--- a/tensorrt_llm/quantization/quantize.py
+++ b/tensorrt_llm/quantization/quantize.py
@@ -521,7 +521,7 @@ def qserve_quantize(model, quant_config: QuantConfig):
 def kv_cache_quantize(model):
     for name, module in model.named_modules():
         if isinstance(module,
-                      (Attention, SmoothQuantAttention, Fp8RowwiseAttention)):
+                      (Attention, SmoothQuantAttention, Fp8RowwiseAttention, QServeAttention)):
             module.kv_cache_scaling_factor = Parameter(shape=(1, ),
                                                        dtype='float32')
     return model


### PR DESCRIPTION
Hi, 

Thanks for your contributions and updates of Qserve.

I added an INT8KV feature as well.

Previously, the scale factor was calculated using the maximum value among the outputs of `q_proj`, `k_proj`, and `v_proj`. ([code](https://github.com/NVIDIA/TensorRT-LLM/blob/c629546ce429623c8a163633095230154a6f0574/tensorrt_llm/models/llama/convert.py#L640))

However, I found that it is not working in Qserve.

It only works well in Qserve when the scale factor is calculated based solely on the outputs of `k_proj` and `v_proj`.
This is different from the INT8 KV Cache in Qserve paper, which uses a dynamic cache. However, this int8 kv cache is a sufficient alternative for Qserve with high accuracy.

[Reference]
Qserve retrieves the scale of the kv cache separately for k and v, treating each with its own scale. ([code](https://github.com/mit-han-lab/qserve/blob/5106921a6cc683f8e501b3ef3c887a63294c3e9b/kernels/csrc/fused_attention/decoderMaskedMultiheadAttentionTemplate.hpp#L923C1-L928C115))
However, TensorRT-LLM merges the k and v scales into a single `kv_cache_scaling_factor` derived from the outputs of `qkv_proj`. This setup made it difficult to use the kv cache scaling style of Qserve in TensorRT-LLM. However, I modified the approach to obtain the kv cache scale without considering `q_proj`, making it more similar to Qserve.
And I got much higher quality of outputs.