### PR TITLE
Fix prompt_table_data empty tensor shape error

### DIFF
--- a/tensorrt_llm/runtime/model_runner.py
+++ b/tensorrt_llm/runtime/model_runner.py
@@ -464,7 +464,7 @@ class ModelRunnerMixin:
             task_vocab_size = torch.tensor([task_vocab_size], dtype=torch.int32)
             prompt_table_data = prompt_table_data.view(-1, hidden_size)
         else:
-            prompt_table_data = torch.empty([1, self.hidden_size],
+            prompt_table_data = torch.empty([1, self.hidden_size * self.mapping.tp_size],
                                             dtype=self.dtype)
             task_vocab_size = torch.zeros([1], dtype=torch.int32)
 


### PR DESCRIPTION
When executing LLM in a VLM model alone, the correct prompt_table_data's hidden_size = self.hidden_size * tp_size, because self.hidden_size = pretrained_config.hidden_size // tp_size