### PR TITLE
bugfix/incorrect lora out dims

### DIFF
--- a/cpp/tensorrt_llm/runtime/loraModule.cpp
+++ b/cpp/tensorrt_llm/runtime/loraModule.cpp
@@ -45,9 +45,9 @@ std::vector<LoraModule> LoraModule::createLoraModules(std::vector<std::string> c
         case ModuleType::kATTN_Q: modules.emplace_back(t, hidden, numHeads * attnHeadSize, false, true, -1, 0); break;
         case ModuleType::kATTN_K: modules.emplace_back(t, hidden, numKvHeads * attnHeadSize, false, true, -1, 0); break;
         case ModuleType::kATTN_V: modules.emplace_back(t, hidden, numKvHeads * attnHeadSize, false, true, -1, 0); break;
-        case ModuleType::kCROSS_ATTN_Q: modules.emplace_back(t, hidden, numHeads * attnHeadSize, false, true, -1, 0); break;
-        case ModuleType::kCROSS_ATTN_K: modules.emplace_back(t, hidden, numKvHeads * attnHeadSize, false, true, -1, 0); break;
-        case ModuleType::kCROSS_ATTN_V: modules.emplace_back(t, hidden, numKvHeads * attnHeadSize, false, true, -1, 0); break;
+        case ModuleType::kCROSS_ATTN_Q:
+        case ModuleType::kCROSS_ATTN_K:
+        case ModuleType::kCROSS_ATTN_V: modules.emplace_back(t, hidden, hidden, false, true, -1, 0); break;
         case ModuleType::kATTN_DENSE:
         case ModuleType::kCROSS_ATTN_DENSE: modules.emplace_back(t, hidden, hidden, false, true, 1, -1); break;
         case ModuleType::kMLP_H_TO_4H: modules.emplace_back(t, hidden, mlpHidden, false, true, -1, 0); break;

--- a/cpp/tensorrt_llm/runtime/loraModule.cpp
+++ b/cpp/tensorrt_llm/runtime/loraModule.cpp
@@ -42,12 +42,12 @@ std::vector<LoraModule> LoraModule::createLoraModules(std::vector<std::string> c
             modules.emplace_back(
                 t, hidden, (numHeads * attnHeadSize + 2 * numKvHeads * attnHeadSize), false, true, -1, 0);
             break;
-        case ModuleType::kATTN_Q:
-        case ModuleType::kATTN_K:
-        case ModuleType::kATTN_V:
-        case ModuleType::kCROSS_ATTN_Q:
-        case ModuleType::kCROSS_ATTN_K:
-        case ModuleType::kCROSS_ATTN_V: modules.emplace_back(t, hidden, hidden, false, true, -1, 0); break;
+        case ModuleType::kATTN_Q: modules.emplace_back(t, hidden, numHeads * attnHeadSize, false, true, -1, 0); break;
+        case ModuleType::kATTN_K: modules.emplace_back(t, hidden, numKvHeads * attnHeadSize, false, true, -1, 0); break;
+        case ModuleType::kATTN_V: modules.emplace_back(t, hidden, numKvHeads * attnHeadSize, false, true, -1, 0); break;
+        case ModuleType::kCROSS_ATTN_Q: modules.emplace_back(t, hidden, numHeads * attnHeadSize, false, true, -1, 0); break;
+        case ModuleType::kCROSS_ATTN_K: modules.emplace_back(t, hidden, numKvHeads * attnHeadSize, false, true, -1, 0); break;
+        case ModuleType::kCROSS_ATTN_V: modules.emplace_back(t, hidden, numKvHeads * attnHeadSize, false, true, -1, 0); break;
         case ModuleType::kATTN_DENSE:
         case ModuleType::kCROSS_ATTN_DENSE: modules.emplace_back(t, hidden, hidden, false, true, 1, -1); break;
         case ModuleType::kMLP_H_TO_4H: modules.emplace_back(t, hidden, mlpHidden, false, true, -1, 0); break;


### PR DESCRIPTION
I have in-house model for which `hidden_size != num_heads * head_size` (attention dimension is higher then hidden_size) and lora doesn't work properly. But after this fix, everything works exactly the same as in Python (same generations).

My target modules:
```
  "target_modules": [
    "v_proj",
    "q_proj",
    "k_proj",
    "down_proj"
  ],
```

It probably makes sense to make similar changes for `kCROSS_ATTN_Q,kCROSS_ATTN_V,kCROSS_ATTN_K`



