### PR TITLE
Add issue triage workflows

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,43 @@
+name: auto-assign
+on:
+  issues:
+    types:
+      - labeled
+
+jobs:
+  assign_issue:
+    # Only run on module label colors.
+    if: ${{ github.event.label.color == '00611d' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Get Assignee
+        uses: actions/github-script@v6
+        id: get-assignee
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const fs = require('fs');
+            
+            // Read configuration file
+            const config = JSON.parse(fs.readFileSync('.github/workflows/module-owners.json', 'utf8'));
+
+            // Find matching label in config
+            for (const [configLabel, users] of Object.entries(config)) {
+              if (configLabel == "${{ github.event.label.name}}") {
+                // Select Randomly
+                const index = Math.floor(Math.random() * users.length)
+                const assignee = users[index % users.length];
+                return assignee
+              }
+            }
+            // Returning empty string in case a valid assignee is not found.
+            return ""
+          result-encoding: string
+
+      - name: Assign
+        run: gh issue edit ${{ github.event.issue.number }} --add-label "triaged" --add-label "investigating" --add-assignee ${{ steps.get-assignee.outputs.result }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto_close_inactive_issues.yml
+++ b/.github/workflows/auto_close_inactive_issues.yml
@@ -1,8 +1,9 @@
 # Ref: https://docs.github.com/en/actions/managing-issues-and-pull-requests/closing-inactive-issues
 name: Close inactive issues
 on:
+  workflow_dispatch:
   schedule:
-    - cron: "30 1 * * *"
+    - cron: "0 * * * *"
 
 jobs:
   stale:
@@ -10,16 +11,19 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+
     steps:
       - uses: actions/stale@v9
         with:
-          days-before-issue-stale: 30
-          days-before-issue-close: 15
-          stale-issue-label: "stale"
-          exempt-issue-labels: ""
-          stale-issue-message: This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 15 days."
-          close-issue-message: "This issue was closed because it has been stalled for 15 days with no activity."
-          days-before-pr-stale: -1
-          days-before-pr-close: -1
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          debug-only: false
+          stale-issue-message: 'Issue has not received an update in over 14 days. Adding stale label.'
+          stale-pr-message: 'PR has not received an update in over 14 days. Adding stale label.'
+          close-issue-message: 'This issue was closed because it has been 14 days without activity since it has been marked as stale.'
+          close-pr-message: 'This PR was closed because it has been 14 days without activity since it has been marked as stale.'
+          days-before-issue-stale: 14
+          days-before-close: 14
+          only-labels: 'waiting for feedback'
+          labels-to-add-when-unstale: 'investigating'
+          labels-to-remove-when-unstale: 'stale,waiting for feedback'
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'

--- a/.github/workflows/module-owners.json
+++ b/.github/workflows/module-owners.json
@@ -1,0 +1,13 @@
+{
+    "Generic Runtime": ["funatiq", "pcastonguay", "Shixiaowei02", "MartinMarciniszyn", "schetlur-nv", "dcampora"],
+    "Triton Backend": ["Tabrizian", "pcastonguay", "schetlur-nv"],
+    "LLM API/Workflow": ["Superjomn", "syuoni", "nv-guomingz", "litaotju", "QiJune"],
+    "KV-Cache Management":["thorjohnsen", "schetlur-nv"],
+    "Low Precision":["Tracin", "nv-guomingz", "Naveassaf"],
+    "Speculative Decoding":["yweng0828", "nekorobov", "lfr-0531"],
+    "Customized Kernels":["lowsfer", "PerkzZheng", "jdemouth-nvidia"],
+    "Performance": ["kaiyux", "jiahanc", "hypdeb"],
+    "Lora/P-tuning":["byshiue", "Naveassaf"],
+    "Disaggregated Serving":["Shixiaowei02", "joyang-nv", "chuangz0", "schetlur-nv"],
+    "Documentation":["nv-guomingz", "mikemckiernan"]
+}


### PR DESCRIPTION
Add module owners, and Github actions for the following cases:

- Assign to random module owner when a corresponding `module` tag is added to an issue
- Add stale checker action to automatically mark issues with `waiting for feedback` tag as stale when 14 days have passed without inactivity.