### PR TITLE
fix NV bench output len was garbage value

### DIFF
--- a/benchmarks/cpp/utils/utils.cpp
+++ b/benchmarks/cpp/utils/utils.cpp
@@ -92,7 +92,7 @@ Samples parseWorkloadJson(
         {
             input_ids.resize(maxPromptLen.value());
         }
-        samples.emplace_back(Sample{std::move(input_ids), sample["output_len"], taskId});
+        samples.emplace_back(Sample{std::move(input_ids), sample["output_len"].template get<int32_t>(), taskId});
     }
     return samples;
 }


### PR DESCRIPTION
output len was incorrect dtype so garbage value was being used.
I added the following log:
```
printf("sample['output_len']: %d, correct: %d\n", sample["output_len"], sample["output_len"].template get<int32_t>());
```

which gave the following output:
```
sample['output_len']: -275253488, correct: 1024
sample['output_len']: 1773460384, correct: 1024
```

