### PR TITLE
Fix kwarg name

### DIFF
--- a/tensorrt_llm/llmapi/llm_utils.py
+++ b/tensorrt_llm/llmapi/llm_utils.py
@@ -485,7 +485,7 @@ class LlmArgs:
         else:
             self.tokenizer = tokenizer_factory(
                 self.tokenizer,
-                rust_remote_code=self.trust_remote_code,
+                trust_remote_code=self.trust_remote_code,
                 use_fast=self.tokenizer_mode != 'slow')
 
         if torch.cuda.get_device_properties(0).major < 8:


### PR DESCRIPTION
A small fix for updating [kwargs](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/llmapi/tokenizer.py#L189) when init a tokenizer