### PR TITLE
feat: deepseek_v1 gqa and correct normalization mode

### DIFF
--- a/tensorrt_llm/models/deepseek_v1/config.py
+++ b/tensorrt_llm/models/deepseek_v1/config.py
@@ -80,7 +80,7 @@ class DeepSeekV1Config(PretrainedConfig):
             top_k=getattr(hf_config, 'num_experts_per_tok', 0),
             normalization_mode=getattr(
                 hf_config, 'moe_normalization_mode',
-                MoeConfig.ExpertScaleNormalizationMode.RENORMALIZE),
+                MoeConfig.ExpertScaleNormalizationMode.NONE),
         )
         moe_config.validate()
         return cls(architecture=hf_config.architectures[0],


### PR DESCRIPTION
For deepssek_v1 `norm_topk_prob` should be `false`.

https://huggingface.co/deepseek-ai/deepseek-moe-16b-base/blob/main/config.json