### PR TITLE
fix: Add missing parameter for WeightOnlyQuantRowLinear module

### DIFF
--- a/tensorrt_llm/quantization/layers.py
+++ b/tensorrt_llm/quantization/layers.py
@@ -800,16 +800,17 @@ WeightOnlyQuantColumnLinear = WeightOnlyQuantLinear
 class WeightOnlyQuantRowLinear(RowLinear):
 
     def __init__(
-            self,
-            in_features,
-            out_features,
-            bias=True,
-            dtype=None,
-            tp_group=None,
-            tp_size=1,
-            tp_rank=0,
-            quant_mode=QuantMode.use_weight_only(),
-            prefer_managed_weight=True,
+        self,
+        in_features,
+        out_features,
+        bias=True,
+        dtype=None,
+        tp_group=None,
+        tp_size=1,
+        tp_rank=0,
+        quant_mode=QuantMode.use_weight_only(),
+        prefer_managed_weight=True,
+        is_expert=False,
     ):
         multiple = 64 * tp_size
         self.is_padded = False
@@ -826,7 +827,8 @@ class WeightOnlyQuantRowLinear(RowLinear):
                          dtype=dtype,
                          tp_group=tp_group,
                          tp_size=tp_size,
-                         prefer_managed_weight=prefer_managed_weight)
+                         prefer_managed_weight=prefer_managed_weight,
+                         is_expert=is_expert)
         if quant_mode.is_int8_weight_only():
             self.weight_only_quant_mode = 1
         elif quant_mode.is_int4_weight_only():
@@ -863,9 +865,17 @@ class WeightOnlyQuantRowLinear(RowLinear):
                                   == AllReduceFusionOp.RESIDUAL_RMS_NORM)
             if fuse_bias_into_all_reduce:
                 all_reduce_params.bias = self.bias.value
-            x = allreduce(x, self.tp_group, all_reduce_params=all_reduce_params)
-            if need_bias and not fuse_bias_into_all_reduce:
-                x = x + self.bias.value
+            if not self.is_expert:
+                x = allreduce(x,
+                              self.tp_group,
+                              all_reduce_params=all_reduce_params)
+                if need_bias and not fuse_bias_into_all_reduce:
+                    bias = cast(self.bias.value, x.dtype)
+                    x = x + bias
+            else:
+                if need_bias and not fuse_bias_into_all_reduce:
+                    bias = cast(self.bias.value, x.dtype)
+                    x = x + bias / self.tp_size
             return x
 
         if self.bias is not None:


### PR DESCRIPTION
The `WeightOnlyQuantRowLinear` module was missing the `is_expert` parameter, which caused MoE models like Deepseek 2/3 and Mixtral to perform unnecessary `allreduce` operations during INT8 weight-only quantization. This issue resulted in incorrect outputs when running `run.py` on Deepseek V2.5 quantized by INT8 weight-only, as shown below:

```
Input [Text 0]: "<｜begin▁of▁sentence｜>Born in north-east France, Soyer trained as a"
Output [Text 0 Beam 0]: ",我们，的 ，3


，�
 、 00精度100,在
00
"
```

This has been fixed, and the correct output is now generated as follows:

```
Input [Text 0]: "<｜begin▁of▁sentence｜>Born in north-east France, Soyer trained as a"
Output [Text 0 Beam 0]: " chef in Paris before moving to London in 1840. He became the first celebrity chef, writing several cookbooks and inventing the double"
```

Additionally, the summary results are now accurate:

```
' James Best, best known for his portrayal of Sheriff Rosco P. Coltrane on TV\'s "The Dukes of Hazzard," died at 88 after a brief illness. He was a busy actor for decades in theater and Hollywood, but didn\'t become famous until 1979 when "The Dukes of Hazzard" began airing. Best gave his character a childlike enthusiasm that made him endearing. The show ran until 1985'
INFO:TRT-LLM:[TRT-LLM] [I]   rouge1 : 28.546239873545996
INFO:TRT-LLM:[TRT-LLM] [I]   rouge2 : 9.14361660942447
INFO:TRT-LLM:[TRT-LLM] [I]   rougeL : 20.7284256053234
INFO:TRT-LLM:[TRT-LLM] [I]   rougeLsum : 23.15367596318552
```