### PR TITLE
chore: fix default path for compile commands in clangd

### DIFF
--- a/.devcontainer/clangd/devcontainer.json
+++ b/.devcontainer/clangd/devcontainer.json
@@ -48,7 +48,7 @@
             // "clang-format.executable": "/usr/local/bin/clang-format",
             "clangd.arguments": [
               // "--compile-commands-dir=${workspaceFolder}/cpp/build_RelWithDebInfo"
-              "--compile-commands-dir=${workspaceFolder}"
+              "--compile-commands-dir=${workspaceFolder}/cpp/build"
             ]
           }
         }


### PR DESCRIPTION
This changes the default directory for the compile commands used by the clangd server to be consistent with `build_wheel.py`.