### PR TITLE
fix: The constructor checks useDynamicTree but doesn’t validate dynamicTreeMaxTopK if set

### DIFF
--- a/cpp/tensorrt_llm/executor/decodingConfig.cpp
+++ b/cpp/tensorrt_llm/executor/decodingConfig.cpp
@@ -164,6 +164,10 @@ EagleConfig::EagleConfig(std::optional<EagleChoices> eagleChoices, bool greedySa
         TLLM_CHECK_WITH_INFO(eagleChoices.has_value() == false,
             "When dynamic tree is enabled (for Eagle-2), eagle choices should not be set.");
     }
+    if (mDynamicTreeMaxTopK.has_value())
+    {
+        TLLM_CHECK_WITH_INFO(mDynamicTreeMaxTopK.value() > 0, "dynamicTreeMaxTopK must be positive");
+    }
 }
 
 bool EagleConfig::operator==(EagleConfig const& other) const


### PR DESCRIPTION
The check is tied to mDynamicTreeMaxTopK, which is only meaningful in the context of useDynamicTree. While the check could theoretically apply even when useDynamicTree is false, enforcing it here ensures it’s validated at construction time alongside related conditions.