### PR TITLE
chore: disable kv cache reuse when minimum window size is reached, instead of maximum window size

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -396,10 +396,12 @@ public:
         return mKvCacheRetentionConfig.getDecodeDurationMs();
     }
 
-    // Have we begun overwriting the beginning of the sequence's kvcache
-    [[nodiscard]] bool isPreCyclic() const
+    // @brief Check whether the sequence uses cyclic KV cache.
+    // @return `true` if we have begun overwriting the beginning of the sequence's KV cache.
+    // @details If `true`, we cannot store the sequence's KV cache for reuse.
+    [[nodiscard]] bool isCyclic() const
     {
-        return mNumTokens < mCyclicThreshold;
+        return mNumTokens >= mCyclicThreshold;
     }
 
 private:

--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -300,7 +300,7 @@ public:
     using SizeType32 = tensorrt_llm::runtime::SizeType32;
 
     explicit GenerationRequest(LlmRequest::RequestIdType requestId, SizeType32 numTokens, SizeType32 beamWidth,
-        SizeType32 maxBlocks, SizeType32 numPools = 1,
+        SizeType32 maxBlocks, SizeType32 cyclicThreshold, SizeType32 numPools = 1,
         executor::KvCacheRetentionConfig kvCacheRetentionConfig = executor::KvCacheRetentionConfig())
         : mRequestId(requestId)
         , mNumTokens(numTokens)
@@ -310,6 +310,7 @@ public:
               runtime::ITensor::makeShape({numPools, beamWidth, 2, maxBlocks}),
               runtime::TRTDataType<tensorrt_llm::kernels::KVCacheIndex>::value)}
         , mKvCacheRetentionConfig(std::move(kvCacheRetentionConfig))
+        , mCyclicThreshold(cyclicThreshold)
     {
         auto cacheBlockIdsRange = runtime::BufferRange<tensorrt_llm::kernels::KVCacheIndex>(*mCacheBlockIndices);
         std::fill(cacheBlockIdsRange.begin(), cacheBlockIdsRange.end(),
@@ -395,14 +396,10 @@ public:
         return mKvCacheRetentionConfig.getDecodeDurationMs();
     }
 
-    [[nodiscard]] bool getContextRequiresCyclicKvCache() const
+    // Have we begun overwriting the beginning of the sequence's kvcache
+    [[nodiscard]] bool isPreCyclic() const
     {
-        return mContextRequiresCyclicKvCache;
-    }
-
-    void setContextRequiresCyclicKvCache(bool contextRequiresCyclicKvCache)
-    {
-        mContextRequiresCyclicKvCache = contextRequiresCyclicKvCache;
+        return mNumTokens < mCyclicThreshold;
     }
 
 private:
@@ -419,8 +416,8 @@ private:
     // The retention priority to assign to decode blocks
     executor::KvCacheRetentionConfig mKvCacheRetentionConfig;
 
-    // A value indicating whether or not the context is long enough to warrant the use of cyclic kv-cache.
-    bool mContextRequiresCyclicKvCache{false};
+    // Number of tokens at which the KV Cache begins sliding
+    SizeType32 mCyclicThreshold;
 };
 
 // attach metadata to a pool pointer
@@ -972,37 +969,40 @@ public:
 
     KVCacheManager(std::vector<SizeType32> const& numKvHeadsPerLayer, SizeType32 sizePerHead, SizeType32 tokensPerBlock,
         SizeType32 blocksInPrimaryPool, SizeType32 blocksInSecondaryPool, SizeType32 maxNumSequences,
-        SizeType32 maxBeamWidth, SizeType32 maxAttentionWindow, SizeType32 temporaryAttentionWindow,
-        SizeType32 sinkTokenLength, CudaStreamPtr stream, std::optional<SizeType32> maxSequenceLength,
-        bool enableBlockReuse = false, bool onboardBlocks = true, CacheType cacheType = CacheType::kSELF,
+        SizeType32 maxBeamWidth, std::vector<SizeType32> const& maxAttentionWindowVec,
+        SizeType32 temporaryAttentionWindow, SizeType32 sinkTokenLength, CudaStreamPtr stream,
+        std::optional<SizeType32> maxSequenceLength, bool enableBlockReuse = false, bool onboardBlocks = true,
+        CacheType cacheType = CacheType::kSELF,
         std::optional<executor::RetentionPriority> secondaryOffloadMinPriority = std::nullopt,
         std::shared_ptr<KVCacheEventManager> eventManager = nullptr, bool enableHashKey = false,
         bool enablePartialReuse = true, bool copyOnpartialReuse = true);
 
     KVCacheManager(std::vector<SizeType32> const& numKvHeadsPerLayer, SizeType32 sizePerHead, SizeType32 tokensPerBlock,
         SizeType32 blocksInPrimaryPool, SizeType32 blocksInSecondaryPool, SizeType32 maxNumSequences,
-        SizeType32 maxBeamWidth, SizeType32 maxAttentionWindow, SizeType32 temporaryAttentionWindow,
-        SizeType32 sinkTokenLength, int64_t stream, std::optional<SizeType32> maxSequenceLength,
-        bool enableBlockReuse = false, bool onboardBlocks = true, CacheType cacheType = CacheType::kSELF,
+        SizeType32 maxBeamWidth, std::vector<SizeType32> const& maxAttentionWindowVec,
+        SizeType32 temporaryAttentionWindow, SizeType32 sinkTokenLength, int64_t stream,
+        std::optional<SizeType32> maxSequenceLength, bool enableBlockReuse = false, bool onboardBlocks = true,
+        CacheType cacheType = CacheType::kSELF,
         std::optional<executor::RetentionPriority> secondaryOffloadMinPriority = std::nullopt,
         std::shared_ptr<KVCacheEventManager> eventManager = nullptr, bool enablePartialReuse = true,
         bool copyOnpartialReuse = true);
 
     KVCacheManager(SizeType32 numLayers, SizeType32 numKvHeads, SizeType32 sizePerHead, SizeType32 tokensPerBlock,
         SizeType32 blocksInPrimaryPool, SizeType32 blocksInSecondaryPool, SizeType32 maxNumSequences,
-        SizeType32 maxBeamWidth, SizeType32 maxAttentionWindow, SizeType32 temporaryAttentionWindow,
-        SizeType32 sinkTokenLength, CudaStreamPtr stream, std::optional<SizeType32> maxSequenceLength,
-        bool enableBlockReuse = true, bool onboardBlocks = true, CacheType cacheType = CacheType::kSELF,
+        SizeType32 maxBeamWidth, std::vector<SizeType32> const& maxAttentionWindowVec,
+        SizeType32 temporaryAttentionWindow, SizeType32 sinkTokenLength, CudaStreamPtr stream,
+        std::optional<SizeType32> maxSequenceLength, bool enableBlockReuse = true, bool onboardBlocks = true,
+        CacheType cacheType = CacheType::kSELF,
         std::optional<executor::RetentionPriority> secondaryOffloadMinPriority = std::nullopt,
         std::shared_ptr<KVCacheEventManager> eventManager = nullptr, bool enableHashKey = false,
         bool enablePartialReuse = true, bool copyOnpartialReuse = true);
 
     KVCacheManager(SizeType32 numLayers, SizeType32 numKvHeads, SizeType32 sizePerHead, SizeType32 tokensPerBlock,
         SizeType32 blocksInPrimaryPool, SizeType32 blocksInSecondaryPool, SizeType32 maxNumSequences,
-        SizeType32 maxBeamWidth, SizeType32 maxAttentionWindow, SizeType32 temporaryAttentionWindow,
-        SizeType32 sinkTokenLength, int64_t stream, std::optional<SizeType32> maxSequenceLength,
-        bool enableBlockReuse = false, bool onboardBlocks = true, CacheType cacheType = CacheType::kSELF,
-        bool enablePartialReuse = true, bool copyOnpartialReuse = true);
+        SizeType32 maxBeamWidth, std::vector<SizeType32> const& maxAttentionWindowVec,
+        SizeType32 temporaryAttentionWindow, SizeType32 sinkTokenLength, int64_t stream,
+        std::optional<SizeType32> maxSequenceLength, bool enableBlockReuse = false, bool onboardBlocks = true,
+        CacheType cacheType = CacheType::kSELF, bool enablePartialReuse = true, bool copyOnpartialReuse = true);
 
     ~KVCacheManager() override = default;
 
@@ -1264,8 +1264,9 @@ private:
     // Maximum number of blocks per sequence
     SizeType32 mMaxBlocksPerSeq;
     // Maximum kv cache length per sequence
-    // Enable cyclic kv cache when it exceeds
     SizeType32 mMaxAttentionWindow;
+    // Minimum kv cache length per sequence
+    SizeType32 mMinAttentionWindow;
     // Temporary kv cache length per sequence.
     // Only needed when chunked context + sliding window attention are used together.
     // And it should only be considered when allocating blocks.

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -430,17 +430,14 @@ bool BlockManager::verifyQueueIntegrity()
 
 void BlockManager::storeContextBlocks(GenerationRequest& sequence, LlmRequest const& llmRequest)
 {
-    if (!sequence.getContextRequiresCyclicKvCache())
-    {
-        constexpr int beamIdx = 0; // no need to consider more than one beam for input tokens
-        auto const& cacheBlockIds = sequence.getCacheBlockIds();
-        auto const& uniqueTokens = llmRequest.getUniqueTokens(beamIdx);
+    constexpr int beamIdx = 0; // no need to consider more than one beam for input tokens
+    auto const& cacheBlockIds = sequence.getCacheBlockIds();
+    auto const& uniqueTokens = llmRequest.getUniqueTokens(beamIdx);
 
-        auto blockedUniqueTokens
-            = chopVectorIntoBlocks<UniqueToken>(uniqueTokens, uniqueTokens.size() - 1, getTokensPerBlock(), false);
-        auto blockKeys = buildBlockKeys(blockedUniqueTokens, llmRequest);
-        storeBlocks(std::move(blockKeys), cacheBlockIds[beamIdx]);
-    }
+    auto blockedUniqueTokens
+        = chopVectorIntoBlocks<UniqueToken>(uniqueTokens, uniqueTokens.size() - 1, getTokensPerBlock(), false);
+    auto blockKeys = buildBlockKeys(blockedUniqueTokens, llmRequest);
+    storeBlocks(std::move(blockKeys), cacheBlockIds[beamIdx]);
 }
 
 void BlockManager::createBlockScalePools(SizeType32 quantBlockSize)
@@ -1149,8 +1146,7 @@ void BlockManager::releaseBlocks(GenerationRequest& sequence, OptionalRef<LlmReq
     // - The sequence was not marked for use with cyclic kv-cache when it was added (when its context is too long to fit
     // the max attention window).
     // - The sequence did not switch to cyclic kv-cache during generation phase.
-    bool const storeBlocksForReuse
-        = sequence.getBeamWidth() == 1 && llmRequest.has_value() && !sequence.getContextRequiresCyclicKvCache();
+    bool const storeBlocksForReuse = sequence.getBeamWidth() == 1 && llmRequest.has_value() && sequence.isPreCyclic();
     if (storeBlocksForReuse)
     {
         auto constexpr beamIdx = 0;
@@ -1163,16 +1159,7 @@ void BlockManager::releaseBlocks(GenerationRequest& sequence, OptionalRef<LlmReq
         auto const usableSize = static_cast<runtime::SizeType32>(uniqueTokens.size()) - 1;
         auto blockedUniqueTokens = chopVectorIntoBlocks<UniqueToken>(uniqueTokens, usableSize, mTokensPerBlock, true);
         auto blockKeys = buildBlockKeys(blockedUniqueTokens, *llmRequest);
-
-        // TODO (jdebache): implicit check depending on implementation detail of other parts of this component. Fix.
-        // Here we implicitly check whether we used cyclic kv-cache by comparing how many blocks of kv-cache the
-        // sequence is occupying (i.e. constrained by the max attention window), versus how many it would need if the
-        // whole sequence had been stored (no maximum attention window required). If the whole sequence doesn't fit the
-        // stored blocks, then we had to use cyclic kv-cache.
-        if (!(blockKeys.size() > cacheBlockIds[beamIdx].size())) // No cyclic kv-cache -> store blocks.
-        {
-            storeBlocks(std::move(blockKeys), cacheBlockIds[beamIdx]);
-        }
+        storeBlocks(std::move(blockKeys), cacheBlockIds[beamIdx]);
     }
 
     auto node = mAllocatedBlocksPerSeq.extract(requestId);
@@ -1209,12 +1196,12 @@ void BlockManager::schedulingReleaseBlocks(RequestIdType requestId)
 
 KVCacheManager::KVCacheManager(SizeType32 numLayers, SizeType32 numKvHeads, SizeType32 sizePerHead,
     SizeType32 tokensPerBlock, SizeType32 blocksInPrimaryPool, SizeType32 blocksInSecondaryPool,
-    SizeType32 maxNumSequences, SizeType32 maxBeamWidth, SizeType32 maxAttentionWindow,
+    SizeType32 maxNumSequences, SizeType32 maxBeamWidth, std::vector<SizeType32> const& maxAttentionWindowVec,
     SizeType32 temporaryAttentionWindow, SizeType32 sinkTokenLength, int64_t stream,
     std::optional<runtime::SizeType32> maxSequenceLength, bool enableBlockReuse, bool onboardBlocks,
     CacheType cacheType, bool enablePartialReuse, bool copyOnPartialReuse)
     : KVCacheManager(std::vector<SizeType32>(numLayers, numKvHeads), sizePerHead, tokensPerBlock, blocksInPrimaryPool,
-        blocksInSecondaryPool, maxNumSequences, maxBeamWidth, maxAttentionWindow, temporaryAttentionWindow,
+        blocksInSecondaryPool, maxNumSequences, maxBeamWidth, maxAttentionWindowVec, temporaryAttentionWindow,
         sinkTokenLength, std::make_shared<runtime::CudaStream>(reinterpret_cast<cudaStream_t>(stream)),
         maxSequenceLength, enableBlockReuse, onboardBlocks, cacheType, std::nullopt, nullptr, false, enablePartialReuse,
         copyOnPartialReuse)
@@ -1223,13 +1210,13 @@ KVCacheManager::KVCacheManager(SizeType32 numLayers, SizeType32 numKvHeads, Size
 
 KVCacheManager::KVCacheManager(std::vector<SizeType32> const& numKvHeadsPerLayer, SizeType32 sizePerHead,
     SizeType32 tokensPerBlock, SizeType32 blocksInPrimaryPool, SizeType32 blocksInSecondaryPool,
-    SizeType32 maxNumSequences, SizeType32 maxBeamWidth, SizeType32 maxAttentionWindow,
+    SizeType32 maxNumSequences, SizeType32 maxBeamWidth, std::vector<SizeType32> const& maxAttentionWindowVec,
     SizeType32 temporaryAttentionWindow, SizeType32 sinkTokenLength, int64_t stream,
     std::optional<runtime::SizeType32> maxSequenceLength, bool enableBlockReuse, bool onboardBlocks,
     CacheType cacheType, std::optional<executor::RetentionPriority> secondaryOffloadMinPriority,
     std::shared_ptr<KVCacheEventManager> eventManager, bool enablePartialReuse, bool copyOnPartialReuse)
     : KVCacheManager(numKvHeadsPerLayer, sizePerHead, tokensPerBlock, blocksInPrimaryPool, blocksInSecondaryPool,
-        maxNumSequences, maxBeamWidth, maxAttentionWindow, temporaryAttentionWindow, sinkTokenLength,
+        maxNumSequences, maxBeamWidth, maxAttentionWindowVec, temporaryAttentionWindow, sinkTokenLength,
         std::make_shared<runtime::CudaStream>(reinterpret_cast<cudaStream_t>(stream)), maxSequenceLength,
         enableBlockReuse, onboardBlocks, cacheType, secondaryOffloadMinPriority, std::move(eventManager), false,
         enablePartialReuse, copyOnPartialReuse)
@@ -1238,14 +1225,15 @@ KVCacheManager::KVCacheManager(std::vector<SizeType32> const& numKvHeadsPerLayer
 
 KVCacheManager::KVCacheManager(std::vector<SizeType32> const& numKvHeadsPerLayer, SizeType32 sizePerHead,
     SizeType32 tokensPerBlock, SizeType32 blocksInPrimaryPool, SizeType32 blocksInSecondaryPool,
-    SizeType32 maxNumSequences, SizeType32 maxBeamWidth, SizeType32 maxAttentionWindow,
+    SizeType32 maxNumSequences, SizeType32 maxBeamWidth, std::vector<SizeType32> const& maxAttentionWindowVec,
     SizeType32 temporaryAttentionWindow, SizeType32 sinkTokenLength, CudaStreamPtr stream,
     std::optional<runtime::SizeType32> maxSequenceLength, bool enableBlockReuse, bool onboardBlocks,
     CacheType cacheType, std::optional<executor::RetentionPriority> secondaryOffloadMinPriority,
     std::shared_ptr<KVCacheEventManager> eventManager, bool enableHashKey, bool enablePartialReuse,
     bool copyOnPartialReuse)
     : mMaxBeamWidth(maxBeamWidth)
-    , mMaxAttentionWindow(maxAttentionWindow)
+    , mMaxAttentionWindow(*std::max_element(maxAttentionWindowVec.begin(), maxAttentionWindowVec.end()))
+    , mMinAttentionWindow(*std::min_element(maxAttentionWindowVec.begin(), maxAttentionWindowVec.end()))
     , mTemporaryAttentionWindow(temporaryAttentionWindow)
     , mTokensPerBlock(tokensPerBlock)
     , mSinkBubbleLength(BaseKVCacheManager::getSinkBubbleLength(sinkTokenLength, tokensPerBlock))
@@ -1267,7 +1255,7 @@ KVCacheManager::KVCacheManager(std::vector<SizeType32> const& numKvHeadsPerLayer
     // If maxBeamWidth > 1, use one more block for each sequence in the paged kv cache to avoid dropping the needed
     // tokens, when enabling cyclic kv cache.
     mUseOneMoreBlock
-        = maxSequenceLength.has_value() && maxSequenceLength.value() > maxAttentionWindow && maxBeamWidth > 1;
+        = maxSequenceLength.has_value() && maxSequenceLength.value() > mMaxAttentionWindow && maxBeamWidth > 1;
     TLLM_CHECK_WITH_INFO(!mUseOneMoreBlock || mTemporaryAttentionWindow == 0,
         "Can't support sliding window attention, paged context fmha, and beam search are used together.");
     if (mUseOneMoreBlock)
@@ -1285,14 +1273,14 @@ KVCacheManager::KVCacheManager(std::vector<SizeType32> const& numKvHeadsPerLayer
 
 KVCacheManager::KVCacheManager(SizeType32 numLayers, SizeType32 numKvHeads, SizeType32 sizePerHead,
     SizeType32 tokensPerBlock, SizeType32 blocksInPrimaryPool, SizeType32 blocksInSecondaryPool,
-    SizeType32 maxNumSequences, SizeType32 maxBeamWidth, SizeType32 maxAttentionWindow,
+    SizeType32 maxNumSequences, SizeType32 maxBeamWidth, std::vector<SizeType32> const& maxAttentionWindowVec,
     SizeType32 temporaryAttentionWindow, SizeType32 sinkTokenLength, CudaStreamPtr stream,
     std::optional<runtime::SizeType32> maxSequenceLength, bool enableBlockReuse, bool onboardBlocks,
     CacheType cacheType, std::optional<executor::RetentionPriority> secondaryOffloadMinPriority,
     std::shared_ptr<KVCacheEventManager> eventManager, bool enableHashKey, bool enablePartialReuse,
     bool copyOnPartialReuse)
     : KVCacheManager(std::vector<SizeType32>(numLayers, numKvHeads), sizePerHead, tokensPerBlock, blocksInPrimaryPool,
-        blocksInSecondaryPool, maxNumSequences, maxBeamWidth, maxAttentionWindow, temporaryAttentionWindow,
+        blocksInSecondaryPool, maxNumSequences, maxBeamWidth, maxAttentionWindowVec, temporaryAttentionWindow,
         sinkTokenLength, std::move(stream), maxSequenceLength, enableBlockReuse, onboardBlocks, cacheType,
         secondaryOffloadMinPriority, std::move(eventManager), enableHashKey, enablePartialReuse, copyOnPartialReuse)
 {
@@ -1603,16 +1591,12 @@ void KVCacheManager::addSequence(
     {
         auto lck = std::scoped_lock(mSequencesMtx);
         return mSequences.emplace(requestId,
-            GenerationRequest(requestId, inputLength, beamWidth, mMaxBlocksPerSeq, mBlockManager.getNumPools(),
-                kvCacheRetentionConfig));
+            GenerationRequest(requestId, inputLength, beamWidth, mMaxBlocksPerSeq,
+                mMinAttentionWindow + mSinkBubbleLength, // When the request has started cycling, disable reuse.
+                mBlockManager.getNumPools(), kvCacheRetentionConfig));
     }();
     TLLM_CHECK(emplaceDone);
     auto& sequence = seqIt->second;
-
-    // Enable cyclic kv cache when inputLength exceeds maxAttentionWindow.
-    // Note that currently cyclic kv cache doesn't work with shared kv cache of different beams.
-    sequence.setContextRequiresCyclicKvCache(
-        inputLength >= mMaxTokenNum); // We decide at the outset whether a request uses cyclic kv-cache or not.
 
     // Get the final token index in kv cache
     SizeType32 const finalTokenKVIdx
@@ -1621,8 +1605,7 @@ void KVCacheManager::addSequence(
     // Get block index that with shareAmongBeams=False.
     // For cross kv cache in encoder-decoder models, always shareAmongBeams=True.
     SizeType32 unsharedBlockIdx = -1;
-    if ((!sequence.getContextRequiresCyclicKvCache() || beamWidth > 1 || finalTokenKVIdx % getTokensPerBlock() > 0)
-        && !isCrossKv())
+    if ((sequence.isPreCyclic() || beamWidth > 1 || finalTokenKVIdx % getTokensPerBlock() > 0) && !isCrossKv())
     {
         unsharedBlockIdx = ((finalTokenKVIdx + 1) % getTokensPerBlock() == 0)
             ? finalTokenKVIdx / getTokensPerBlock() + 1
@@ -1639,7 +1622,7 @@ void KVCacheManager::addSequence(
     SizeType32 const numReusedBlocksPreRequest = mBlockManager.getNumReusedBlocks();
     SizeType32 const numMissedBlocksPreRequest = mBlockManager.getNumMissedBlocks();
 
-    if (!sequence.getContextRequiresCyclicKvCache() && mEnableBlockReuse)
+    if (sequence.isPreCyclic() && mEnableBlockReuse)
     {
         mBlockManager.addSequence(sequence, inputLength, numContextBlocks, *llmRequest);
     }
@@ -1695,7 +1678,7 @@ void KVCacheManager::storeContextBlocks(LlmRequest const& llmRequest)
 {
     auto const requestId = llmRequest.mRequestId;
     auto& sequence = getSequence(requestId);
-    if (mEnableBlockReuse && !sequence.getContextRequiresCyclicKvCache())
+    if (mEnableBlockReuse && sequence.isPreCyclic())
     {
         mBlockManager.storeContextBlocks(sequence, llmRequest);
     }

--- a/cpp/tensorrt_llm/batch_manager/trtGptModel.h
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModel.h
@@ -292,9 +292,16 @@ protected:
         return mCudaGraphMode;
     }
 
-    void setMaxAttentionWindow(SizeType32 maxAttentionWindow)
+    void setMaxAttentionWindow(SizeType32 newMaxAttentionWindow)
     {
-        mMaxAttentionWindow = maxAttentionWindow;
+        auto const oldMax = mMaxAttentionWindow;
+        mMaxAttentionWindow = newMaxAttentionWindow;
+        std::for_each(std::begin(mMaxAttentionWindowVec), std::end(mMaxAttentionWindowVec),
+            [oldMax, newMaxAttentionWindow](SizeType32 w)
+            {
+                TLLM_CHECK_DEBUG_WITH_INFO(w <= oldMax, "A window can't be larger than oldMax");
+                return std::min(w, newMaxAttentionWindow); // clamp vec to newMaxAttentionWindow
+            });
     }
 
     void setMaxSequenceLen(SizeType32 maxSequenceLen)

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -1340,15 +1340,15 @@ void TrtGptModelInflightBatching::createDecoder(std::optional<executor::Decoding
 
         if (decodingMode.isExplicitDraftTokens())
         {
-            mDecoder->setupExplicitDraftTokens(mDecoderBuffers->explicitDraftTokensBuffers);
+            mDecoder->getDecoderState().setupExplicitDraftTokens(mDecoderBuffers->explicitDraftTokensBuffers);
         }
         if (decodingMode.isLookahead())
         {
-            mDecoder->setupLookahead(mDecoderBuffers->lookaheadBuffers.value());
+            mDecoder->getDecoderState().setupLookahead(mDecoderBuffers->lookaheadBuffers.value());
         }
         if (decodingMode.isEagle())
         {
-            mDecoder->setupEagle(mDecoderBuffers->eagleBuffers);
+            mDecoder->getDecoderState().setupEagle(mDecoderBuffers->eagleBuffers);
         }
     }
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
@@ -1674,8 +1674,8 @@ void TrtGptModelInflightBatching::setupDecoderStep(
             // Setup underlying decoder.
             auto const localBatchSize = batchSlots->getSize();
             auto samplingConfig = SamplingConfig(samplingConfigs);
-            mDecoder->getUnderlyingDecoder().setup(
-                samplingConfig, localBatchSize, batchSlots, {mDecoder->getJointDecodingOutput()}, {decoderRequests});
+            mDecoder->getUnderlyingDecoder().setup(samplingConfig, localBatchSize, batchSlots,
+                {mDecoder->getDecoderState().getJointDecodingOutput()}, {decoderRequests});
 
             auto const& stream = mDecoder->getDecoderStream();
             CudaEvent event{};
@@ -1804,9 +1804,9 @@ void TrtGptModelInflightBatching::getDecoderSlotHostOutputs(
         // Make sure that postprocessing is done before copying outputIds
         mCopyBufferManager.getStream().wait(event.get());
 
-        auto outputIds = mDecoder->getGatheredIds(seqSlot);
-        auto cumLogProbs = mDecoder->getCumLogProbs(seqSlot);
-        auto logProbs = mDecoder->getLogProbs(seqSlot);
+        auto outputIds = mDecoder->getDecoderState().getGatheredIds(seqSlot);
+        auto cumLogProbs = mDecoder->getDecoderState().getCumLogProbs(seqSlot);
+        auto logProbs = mDecoder->getDecoderState().getLogProbs(seqSlot);
 
         runtime::CudaEvent beforeEvent{};
         mRuntime->getStreamPtr()->record(beforeEvent);
@@ -1989,20 +1989,20 @@ TrtGptModelInflightBatching::DecoderFinishedEventPtr TrtGptModelInflightBatching
     // Chain copy after decoder event, using a different stream
     mCopyBufferManager.getStream().wait(decoderFinishEvent->event);
 
-    mDecoderBuffers->newOutputTokens = mDecoder->getAllNewTokens();
+    mDecoderBuffers->newOutputTokens = mDecoder->getDecoderState().getAllNewTokens();
 
     mCopyBufferManager.copy(*mDecoderBuffers->newOutputTokens, *mDecoderBuffers->newOutputTokensHost);
     mCopyBufferManager.copy(*mDecoderBuffers->sequenceLengths, *mDecoderBuffers->sequenceLengthsHost);
 
-    auto const finishedSumDevice = mDecoder->getFinishedSum();
+    auto const finishedSumDevice = mDecoder->getDecoderState().getFinishedSum();
     mCopyBufferManager.copy(*finishedSumDevice, *mDecoderBuffers->finishedSumHost);
-    auto const finishReasonsDevice = mDecoder->getFinishReasons();
+    auto const finishReasonsDevice = mDecoder->getDecoderState().getFinishReasons();
     mCopyBufferManager.copy(*finishReasonsDevice, *mDecoderBuffers->finishReasonsHost);
 
     if (returnLogProbs)
     {
-        mDecoderBuffers->cumLogProbs = mDecoder->getCumLogProbs();
-        mDecoderBuffers->logProbs = mDecoder->getLogProbs();
+        mDecoderBuffers->cumLogProbs = mDecoder->getDecoderState().getCumLogProbs();
+        mDecoderBuffers->logProbs = mDecoder->getDecoderState().getLogProbs();
         mCopyBufferManager.copy(*mDecoderBuffers->cumLogProbs, *mDecoderBuffers->cumLogProbsHost);
         mCopyBufferManager.copy(*mDecoderBuffers->logProbs, *mDecoderBuffers->logProbsHost);
     }
@@ -2010,14 +2010,16 @@ TrtGptModelInflightBatching::DecoderFinishedEventPtr TrtGptModelInflightBatching
     if (mModelConfig.getSpeculativeDecodingMode().predictsDraftTokens())
     {
         // TODO(rkobus): keep data on device for next iteration
-        mDecoderBuffers->draftBuffers.nextDraftTokensDevice = mDecoder->getNextDraftTokens();
+        mDecoderBuffers->draftBuffers.nextDraftTokensDevice = mDecoder->getDecoderState().getNextDraftTokens();
         mCopyBufferManager.copy(
             *mDecoderBuffers->draftBuffers.nextDraftTokensDevice, *mDecoderBuffers->draftBuffers.nextDraftTokensHost);
 
         if (mModelConfig.getSpeculativeDecodingMode().variableDraftLength())
         {
-            mDecoderBuffers->draftBuffers.nextDraftTokensLengthsDevice = mDecoder->getNextDraftTokensLengths();
-            mDecoderBuffers->draftBuffers.prevDraftTokensLengthsDevice = mDecoder->getPrevDraftTokensLengths();
+            mDecoderBuffers->draftBuffers.nextDraftTokensLengthsDevice
+                = mDecoder->getDecoderState().getNextDraftTokensLengths();
+            mDecoderBuffers->draftBuffers.prevDraftTokensLengthsDevice
+                = mDecoder->getDecoderState().getPrevDraftTokensLengths();
             mCopyBufferManager.copy(*mDecoderBuffers->draftBuffers.nextDraftTokensLengthsDevice,
                 *mDecoderBuffers->draftBuffers.nextDraftTokensLengthsHost);
             mCopyBufferManager.copy(*mDecoderBuffers->draftBuffers.prevDraftTokensLengthsDevice,
@@ -2027,8 +2029,9 @@ TrtGptModelInflightBatching::DecoderFinishedEventPtr TrtGptModelInflightBatching
 
     if (mModelConfig.getSpeculativeDecodingMode().needsKVCacheRewind())
     {
-        mDecoderBuffers->draftBuffers.acceptedLengthsCumSumDevice = mDecoder->getAcceptedLengthsCumSum();
-        mDecoderBuffers->draftBuffers.acceptedPackedPathsDevice = mDecoder->getAcceptedPackedPaths();
+        mDecoderBuffers->draftBuffers.acceptedLengthsCumSumDevice
+            = mDecoder->getDecoderState().getAcceptedLengthsCumSum();
+        mDecoderBuffers->draftBuffers.acceptedPackedPathsDevice = mDecoder->getDecoderState().getAcceptedPackedPaths();
     }
 
     runtime::CudaEvent copyEvent{};

--- a/cpp/tensorrt_llm/pybind/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/kvCacheManager.cpp
@@ -431,12 +431,12 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(py::module_& m)
 
     py::classh<tbk::KVCacheManager, tbk::BaseKVCacheManager>(m, "KVCacheManager")
         .def(py::init<std::vector<SizeType32> const&, SizeType32, SizeType32, SizeType32, SizeType32, SizeType32,
-                 SizeType32, SizeType32, SizeType32, SizeType32, bool, int64_t, bool, bool, tbk::CacheType,
-                 std::optional<tensorrt_llm::executor::RetentionPriority>, std::shared_ptr<tbk::KVCacheEventManager>,
-                 bool, bool>(),
+                 SizeType32, std::vector<SizeType32> const&, SizeType32, SizeType32, bool, int64_t, bool, bool,
+                 tbk::CacheType, std::optional<tensorrt_llm::executor::RetentionPriority>,
+                 std::shared_ptr<tbk::KVCacheEventManager>, bool, bool>(),
             py::arg("num_kv_heads_per_layer"), py::arg("size_per_head"), py::arg("tokens_per_block"),
             py::arg("blocks_in_primary_pool"), py::arg("blocks_in_secondary_pool"), py::arg("max_num_sequences"),
-            py::arg("max_beam_width"), py::arg("max_attention_window"), py::arg("temporary_attention_window"),
+            py::arg("max_beam_width"), py::arg("max_attention_window_vec"), py::arg("temporary_attention_window"),
             py::arg("sink_token_length"), py::arg("stream"), py::arg("max_sequence_length"),
             py::arg("enable_block_reuse") = false, py::arg("onboard_blocks") = true,
             py::arg_v("cache_type", tbk::CacheType::kSELF, "bindings.internal.batch_manager.CacheType.SELF"),

--- a/cpp/tensorrt_llm/runtime/gptSession.cpp
+++ b/cpp/tensorrt_llm/runtime/gptSession.cpp
@@ -242,7 +242,7 @@ void GptSession::createKvCacheManager(SizeType32 maxBatchSize, SizeType32 maxBea
         kvCacheConfig, kvDtype, mModelConfig, mWorldConfig, getBufferManager());
     mKvCacheManager = std::make_shared<bmkv::KVCacheManager>(
         std::vector<SizeType32>(numKvHeadsPerLayerBegin, numKvHeadsPerLayerEnd), sizePerHead, tokensPerBlock,
-        blocksInPrimaryPool, blocksInSecondaryPool, maxBatchSize, maxBeamWidth, maxAttentionWindow,
+        blocksInPrimaryPool, blocksInSecondaryPool, maxBatchSize, maxBeamWidth, mDecoderMaxAttentionWindowVec,
         /*temporaryAttentionWindow*/ 0, sinkTokenLength, mRuntime->getStreamPtr(), maxSequenceLength, enableBlockReuse,
         kvCacheConfig.onboardBlocks);
 

--- a/cpp/tests/batch_manager/cacheTransceiverTest.cpp
+++ b/cpp/tests/batch_manager/cacheTransceiverTest.cpp
@@ -293,9 +293,9 @@ protected:
         auto constexpr dataType = nvinfer1::DataType::kFLOAT;
 
         mManager = std::make_unique<KVCacheManager>(numLayers, numHeads, sizePerHead, tokensPerBlock, totalNumBlocks,
-            blocksInSecondaryPool, mMaxNumSequences, maxBeamWidth, maxAttentionWindow, temporaryAttentionWindow,
-            sinkTokenLength, stream, std::nullopt, enableBlockReuse, onboardBlocks, CacheType::kSELF, std::nullopt,
-            nullptr, true);
+            blocksInSecondaryPool, mMaxNumSequences, maxBeamWidth, std::vector<SizeType32>{maxAttentionWindow},
+            temporaryAttentionWindow, sinkTokenLength, stream, std::nullopt, enableBlockReuse, onboardBlocks,
+            CacheType::kSELF, std::nullopt, nullptr, true);
         mCacheState = std::make_unique<texec::kv_cache::CacheState>(
             numLayers, numHeads, sizePerHead, tokensPerBlock, 1, 1, dataType);
         mConnectionManager = std::make_unique<texec::kv_cache::MpiConnectionManager>(mComm);
@@ -580,9 +580,9 @@ protected:
             numHeadsPerRankForContext = numHeads;
         }
         mManager = std::make_unique<KVCacheManager>(numLayers / mPpSize, numHeadsPerRank, sizePerHead, tokensPerBlock,
-            totalNumBlocks, blocksInSecondaryPool, mMaxNumSequences, maxBeamWidth, maxAttentionWindow,
-            temporaryAttentionWindow, sinkTokenLength, stream, std::nullopt, enableBlockReuse, onboardBlocks, cacheType,
-            std::nullopt, nullptr, true);
+            totalNumBlocks, blocksInSecondaryPool, mMaxNumSequences, maxBeamWidth,
+            std::vector<SizeType32>{maxAttentionWindow}, temporaryAttentionWindow, sinkTokenLength, stream,
+            std::nullopt, enableBlockReuse, onboardBlocks, cacheType, std::nullopt, nullptr, true);
         texec::kv_cache::CacheState::AttentionType attentionType = isMLA
             ? texec::kv_cache::CacheState::AttentionType::kMLA
             : texec::kv_cache::CacheState::AttentionType::kDEFAULT;

--- a/cpp/tests/unit_tests/batch_manager/capacitySchedulerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/capacitySchedulerTest.cpp
@@ -131,8 +131,8 @@ protected:
 
         // init KV cache block manager
         return std::make_shared<kv_cache_manager::KVCacheManager>(numLayers, nbKvHeads, sizePerHead, tokensPerBlock,
-            maxNumBlocks, 0, maxNumRequests, 1, maxNumTokensPerSeq, 0, sinkTokenLength, streamPtr, std::nullopt,
-            enableReuse, onboardBlocks, cacheType);
+            maxNumBlocks, 0, maxNumRequests, 1, std::vector<SizeType32>{maxNumTokensPerSeq}, 0, sinkTokenLength,
+            streamPtr, std::nullopt, enableReuse, onboardBlocks, cacheType);
     }
 
     static std::shared_ptr<BasePeftCacheManager> getPeftCacheManager()

--- a/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
@@ -124,7 +124,9 @@ TEST_F(KVCacheManagerTest, BlockManagerTest)
     auto constexpr beamWidth = 8;
     auto constexpr numBlocksPerBeam = blocksInPrimaryPool / beamWidth;
     auto constexpr numTokens = tokensPerBlock * numBlocksPerBeam;
-    GenerationRequest seq0{requestId, numTokens, beamWidth, numBlocksPerBeam};
+    auto constexpr maxAttentionWindow = numTokens;
+    auto const maxAttentionWindowVec = std::vector<BlockManager::SizeType32>{maxAttentionWindow};
+    GenerationRequest seq0{requestId, numTokens, beamWidth, numBlocksPerBeam, maxAttentionWindow};
     blockManager.addSequence(seq0, numBlocksPerBeam, numBlocksPerBeam - 1);
     auto constexpr occupiedBlocks = (numBlocksPerBeam - 1) + beamWidth;
     EXPECT_EQ(blockManager.getNumFreeBlocks(), blocksInPrimaryPool - occupiedBlocks);
@@ -155,13 +157,13 @@ TEST_F(KVCacheManagerTest, BlockManagerTest)
 
     // occupy 22/24 blocks
     EXPECT_NO_THROW(blockManager.addSequence(seq0, numBlocksPerBeam, numBlocksPerBeam - 1));
-    GenerationRequest seq1{requestId + 1, numTokens, beamWidth, numBlocksPerBeam};
+    GenerationRequest seq1{requestId + 1, numTokens, beamWidth, numBlocksPerBeam, maxAttentionWindow};
     EXPECT_NO_THROW(blockManager.addSequence(seq1, numBlocksPerBeam, numBlocksPerBeam - 1));
     // same requestId not allowed
-    GenerationRequest seq2{requestId, numTokens, beamWidth, numBlocksPerBeam};
+    GenerationRequest seq2{requestId, numTokens, beamWidth, numBlocksPerBeam, maxAttentionWindow};
     EXPECT_THROW(blockManager.addSequence(seq2, numBlocksPerBeam, numBlocksPerBeam - 1), std::runtime_error);
     // no more blocks
-    GenerationRequest seq3{requestId + 2, numTokens, beamWidth, numBlocksPerBeam};
+    GenerationRequest seq3{requestId + 2, numTokens, beamWidth, numBlocksPerBeam, maxAttentionWindow};
     EXPECT_THROW(blockManager.addSequence(seq3, numBlocksPerBeam, numBlocksPerBeam - 1), std::runtime_error);
 }
 
@@ -222,7 +224,7 @@ void runPartialCopyTest()
     auto const inputLength = static_cast<SizeType32>(inputTokens->size());
     LlmRequest::RequestIdType requestId{0};
     auto llmRequest0 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens, samplingConfig, isStreaming);
-    GenerationRequest seq0{requestId, inputLength, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq0{requestId, inputLength, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
     auto promptLen0 = llmRequest0->getNumTokens(beamIdx);
     auto numContextBlocks0 = tc::ceilDiv(promptLen0, blockManager.getTokensPerBlock());
     blockManager.addSequence(seq0, promptLen0, numContextBlocks0, *llmRequest0);
@@ -261,7 +263,7 @@ void runPartialCopyTest()
     auto const inputLength1 = static_cast<SizeType32>(inputTokens1->size());
     requestId = 1;
     auto llmRequest1 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens1, samplingConfig, isStreaming);
-    GenerationRequest seq1{requestId, inputLength1, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq1{requestId, inputLength1, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
     auto promptLen1 = llmRequest1->getNumTokens(beamIdx);
     auto numContextBlocks1 = tc::ceilDiv(promptLen1, blockManager.getTokensPerBlock());
     blockManager.addSequence(seq1, promptLen1, numContextBlocks1, *llmRequest1);
@@ -285,7 +287,7 @@ void runPartialCopyTest()
     auto const inputLength2 = static_cast<SizeType32>(inputTokens2->size());
     requestId = 2;
     auto llmRequest2 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens2, samplingConfig, isStreaming);
-    GenerationRequest seq2{requestId, inputLength2, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq2{requestId, inputLength2, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
     auto promptLen2 = llmRequest2->getNumTokens(beamIdx);
     auto numContextBlocks2 = tc::ceilDiv(promptLen2, blockManager.getTokensPerBlock());
     blockManager.addSequence(seq2, promptLen2, numContextBlocks2, *llmRequest2);
@@ -397,7 +399,7 @@ TEST_F(KVCacheManagerTest, FP4BlockScaleManagementTest)
     auto constexpr beamWidth = 1;
 
     KVCacheManager kvCacheManager(numLayers, numHeads, sizePerHead, tokensPerBlock, blocksInPrimaryPool,
-        blocksInSecondaryPool, maxNumSequences, beamWidth, tokensPerBlock * maxBlocksPerSeq, 0, false, stream, true,
+        blocksInSecondaryPool, maxNumSequences, beamWidth, {tokensPerBlock * maxBlocksPerSeq}, 0, false, stream, true,
         onboardBlocks);
 
     kvCacheManager.allocatePools(nvinfer1::DataType::kFP4, /*useUvm=*/false);
@@ -425,6 +427,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseTest)
     auto constexpr maxNumSequences = 8;
     auto const stream = std::make_shared<tr::CudaStream>();
     auto constexpr onboardBlocks = true;
+    auto constexpr maxAttentionWindow = tokensPerBlock * maxBlocksPerSeq;
 
     BlockManager blockManager(std::vector<BlockManager::SizeType32>(numLayers, numKvHeads), sizePerHead, tokensPerBlock,
         blocksInPrimaryPool, blocksInSecondaryPool, maxNumSequences, stream, onboardBlocks);
@@ -444,7 +447,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseTest)
     LlmRequest::RequestIdType requestId{0};
     auto llmRequest0 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens, samplingConfig, isStreaming);
 
-    GenerationRequest seq0{requestId, inputLength, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq0{requestId, inputLength, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
 
     ///////////////////////////////////////////////////////////////////////////
     // add request and then remove it
@@ -472,7 +475,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseTest)
     // new request with same tokens [0, 1, 2, 3, 4, 5, 6, 7, 8] and then remove it
     requestId = 1;
     auto llmRequest1 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens, samplingConfig, isStreaming);
-    GenerationRequest seq1{requestId, inputLength, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq1{requestId, inputLength, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
 
     // reuse blocks 0, 1 ([0, 1, 2, 3], [4, 5, 6, 7]) and get new block 3
     auto promptLen1 = llmRequest1->getNumTokens(beamIdx);
@@ -538,7 +541,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseTest)
     auto llmRequest2 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens2, samplingConfig, isStreaming);
 
     numTokens = llmRequest2->getNumTokens(beamIdx);
-    GenerationRequest seq2{requestId, numTokens, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq2{requestId, numTokens, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
     // reuse block 0 ([0, 1, 2, 3]), get new block 5
     auto promptLen2 = llmRequest2->getNumTokens(beamIdx);
     auto numContextBlocks2 = tc::ceilDiv(promptLen2, blockManager.getTokensPerBlock());
@@ -559,7 +562,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseTest)
     auto llmRequest3 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens3, samplingConfig, isStreaming);
 
     numTokens = llmRequest3->getNumTokens(beamIdx);
-    GenerationRequest seq3{requestId, numTokens, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq3{requestId, numTokens, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
     // reuse blocks 0, 1, 4(p) ([0, 1, 2, 3], [4, 5, 6, 7], [8, 9])
     auto promptLen3 = llmRequest3->getNumTokens(beamIdx);
     auto numContextBlocks3 = tc::ceilDiv(promptLen3, blockManager.getTokensPerBlock());
@@ -588,7 +591,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseTest)
     auto llmRequest4 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens4, samplingConfig, isStreaming);
 
     numTokens = llmRequest4->getNumTokens(beamIdx);
-    GenerationRequest seq4{requestId, numTokens, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq4{requestId, numTokens, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
 
     // reuse blocks 0, 1, 4(p) ([0, 1, 2, 3], [4, 5, 6, 7], [8,9])
     auto promptLen4 = llmRequest4->getNumTokens(beamIdx);
@@ -642,7 +645,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseTest)
     auto llmRequest5 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens5, samplingConfig, isStreaming);
 
     numTokens = llmRequest5->getNumTokens(beamIdx);
-    GenerationRequest seq5{requestId, numTokens, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq5{requestId, numTokens, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
     // no reuse, all blocks need to be freed
     auto promptLen5 = llmRequest5->getNumTokens(beamIdx);
     auto numContextBlocks5 = tc::ceilDiv(promptLen5, blockManager.getTokensPerBlock());
@@ -665,7 +668,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseTest)
     auto llmRequest6 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens6, samplingConfig, isStreaming);
 
     numTokens = llmRequest6->getNumTokens(beamIdx);
-    GenerationRequest seq6{requestId, numTokens, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq6{requestId, numTokens, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
     // no reuse, all blocks need to be freed
     auto promptLen6 = llmRequest6->getNumTokens(beamIdx);
     auto numContextBlocks6 = tc::ceilDiv(promptLen6, blockManager.getTokensPerBlock());
@@ -698,6 +701,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithExtraIdTest)
     auto const stream = std::make_shared<tr::CudaStream>();
     auto constexpr onboardBlocks = true;
     auto constexpr numReturnSequences = 1;
+    auto constexpr maxAttentionWindow = tokensPerBlock * maxBlocksPerSeq;
 
     BlockManager blockManager(std::vector(numLayers, numKvHeads), sizePerHead, tokensPerBlock, blocksInPrimaryPool,
         blocksInSecondaryPool, maxNumSequences, stream, onboardBlocks);
@@ -724,7 +728,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithExtraIdTest)
         std::nullopt, std::nullopt, std::nullopt, LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION,
         inputTokenExtraIds, numReturnSequences);
 
-    GenerationRequest seq0{requestId, inputLength, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq0{requestId, inputLength, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
 
     ///////////////////////////////////////////////////////////////////////////
     // add request and then remove it
@@ -756,7 +760,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithExtraIdTest)
         false, std::nullopt, std::nullopt, false, std::nullopt, false, std::nullopt, false, std::nullopt, 0.5,
         std::nullopt, std::nullopt, std::nullopt, LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION,
         inputTokenExtraIds, numReturnSequences);
-    GenerationRequest seq1{requestId, inputLength, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq1{requestId, inputLength, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
 
     // reuse blocks 0, 1 and get new block 3
     auto promptLen1 = llmRequest1->getNumTokens(beamIdx);
@@ -832,7 +836,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithExtraIdTest)
         inputTokenExtraIds2, numReturnSequences);
 
     numTokens = llmRequest2->getNumTokens(beamIdx);
-    GenerationRequest seq2{requestId, numTokens, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq2{requestId, numTokens, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
     // no reuse, get new block 5, 6, 7
     auto promptLen2 = llmRequest2->getNumTokens(beamIdx);
     auto numContextBlocks2 = tc::ceilDiv(promptLen2, blockManager.getTokensPerBlock());
@@ -857,7 +861,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithExtraIdTest)
         inputTokenExtraIds3, numReturnSequences);
 
     numTokens = llmRequest3->getNumTokens(beamIdx);
-    GenerationRequest seq3{requestId, numTokens, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq3{requestId, numTokens, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
     // reuse block 0, get new block 8, 9
     auto promptLen3 = llmRequest3->getNumTokens(beamIdx);
     auto numContextBlocks3 = tc::ceilDiv(promptLen3, blockManager.getTokensPerBlock());
@@ -891,6 +895,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithLoraTaskIdTest)
     auto constexpr maxNumSequences = 8;
     auto const stream = std::make_shared<tr::CudaStream>();
     auto constexpr onboardBlocks = true;
+    auto constexpr maxAttentionWindow = tokensPerBlock * maxBlocksPerSeq;
 
     BlockManager blockManager(std::vector(numLayers, numKvHeads), sizePerHead, tokensPerBlock, blocksInPrimaryPool,
         blocksInSecondaryPool, maxNumSequences, stream, onboardBlocks);
@@ -913,7 +918,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithLoraTaskIdTest)
     auto llmRequest0 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens, samplingConfig, isStreaming,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
         std::nullopt, std::nullopt, loraTaskId);
-    GenerationRequest seq0{requestId, inputLength, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq0{requestId, inputLength, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
 
     ///////////////////////////////////////////////////////////////////////////
     // add request and then remove it
@@ -944,7 +949,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithLoraTaskIdTest)
     auto llmRequest1 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens, samplingConfig, isStreaming,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
         std::nullopt, std::nullopt, loraTaskId);
-    GenerationRequest seq1{requestId, inputLength, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq1{requestId, inputLength, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
 
     // reuse blocks 0, 1 and get new block 3
     auto promptLen1 = llmRequest1->getNumTokens(beamIdx);
@@ -1016,7 +1021,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithLoraTaskIdTest)
         std::nullopt, std::nullopt, loraTaskId);
 
     numTokens = llmRequest2->getNumTokens(beamIdx);
-    GenerationRequest seq2{requestId, numTokens, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq2{requestId, numTokens, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
     // no reuse, get new block 5, 6, 7
     auto promptLen2 = llmRequest2->getNumTokens(beamIdx);
     auto numContextBlocks2 = tc::ceilDiv(promptLen2, blockManager.getTokensPerBlock());
@@ -1043,7 +1048,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithLoraTaskIdTest)
         std::nullopt, std::nullopt, loraTaskId);
 
     numTokens = llmRequest3->getNumTokens(beamIdx);
-    GenerationRequest seq3{requestId, numTokens, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq3{requestId, numTokens, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
     // reuse blocks 5, 6, 7(p) ([0,1,2,3], [4,5,6,7], [8])
     auto promptLen3 = llmRequest3->getNumTokens(beamIdx);
     auto numContextBlocks3 = tc::ceilDiv(promptLen3, blockManager.getTokensPerBlock());
@@ -1071,7 +1076,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithLoraTaskIdTest)
         std::nullopt, std::nullopt, loraTaskId);
 
     numTokens = llmRequest4->getNumTokens(beamIdx);
-    GenerationRequest seq4{requestId, numTokens, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq4{requestId, numTokens, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
     // reuse blocks 0, get new block 8
     auto promptLen4 = llmRequest4->getNumTokens(beamIdx);
     auto numContextBlocks4 = tc::ceilDiv(promptLen4, blockManager.getTokensPerBlock());
@@ -1094,7 +1099,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithLoraTaskIdTest)
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt);
 
     numTokens = llmRequest5->getNumTokens(beamIdx);
-    GenerationRequest seq5{requestId, numTokens, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq5{requestId, numTokens, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
     // no reuse, get new block 9, 10, 11
     auto promptLen5 = llmRequest5->getNumTokens(beamIdx);
     auto numContextBlocks5 = tc::ceilDiv(promptLen5, blockManager.getTokensPerBlock());
@@ -1127,6 +1132,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithExtraIdAndLoraTaskIdTest)
     auto constexpr maxNumSequences = 8;
     auto const stream = std::make_shared<tr::CudaStream>();
     auto constexpr onboardBlocks = true;
+    auto constexpr maxAttentionWindow = tokensPerBlock * maxBlocksPerSeq;
 
     BlockManager blockManager(std::vector(numLayers, numKvHeads), sizePerHead, tokensPerBlock, blocksInPrimaryPool,
         blocksInSecondaryPool, maxNumSequences, stream, onboardBlocks);
@@ -1154,7 +1160,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithExtraIdAndLoraTaskIdTest)
         std::nullopt, std::nullopt, std::nullopt, LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION,
         inputTokenExtraIds);
 
-    GenerationRequest seq0{requestId, inputLength, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq0{requestId, inputLength, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
 
     ///////////////////////////////////////////////////////////////////////////
     // add request with loraTaskId 1 and then remove it
@@ -1187,7 +1193,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithExtraIdAndLoraTaskIdTest)
         false, std::nullopt, std::nullopt, false, std::nullopt, false, std::nullopt, false, std::nullopt, 0.5,
         std::nullopt, std::nullopt, std::nullopt, LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION,
         inputTokenExtraIds);
-    GenerationRequest seq1{requestId, inputLength, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq1{requestId, inputLength, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
 
     // no reuse, get new block 3, 4, 5
     auto promptLen1 = llmRequest1->getNumTokens(beamIdx);
@@ -1262,7 +1268,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithExtraIdAndLoraTaskIdTest)
         inputTokenExtraIds2);
 
     numTokens = llmRequest2->getNumTokens(beamIdx);
-    GenerationRequest seq2{requestId, numTokens, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq2{requestId, numTokens, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
     // no reuse, get new block 7, 8, 9
     auto promptLen2 = llmRequest2->getNumTokens(beamIdx);
     auto numContextBlocks2 = tc::ceilDiv(promptLen2, blockManager.getTokensPerBlock());
@@ -1287,7 +1293,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithExtraIdAndLoraTaskIdTest)
         inputTokenExtraIds3);
 
     numTokens = llmRequest3->getNumTokens(beamIdx);
-    GenerationRequest seq3{requestId, numTokens, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq3{requestId, numTokens, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
     // reuse block 0, get new block 10, 11
     auto promptLen3 = llmRequest3->getNumTokens(beamIdx);
     auto numContextBlocks3 = tc::ceilDiv(promptLen3, blockManager.getTokensPerBlock());
@@ -1311,7 +1317,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithExtraIdAndLoraTaskIdTest)
         inputTokenExtraIds3);
 
     numTokens = llmRequest4->getNumTokens(beamIdx);
-    GenerationRequest seq4{requestId, numTokens, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq4{requestId, numTokens, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
     // reuse block 3, get new block 12, 13
     auto promptLen4 = llmRequest4->getNumTokens(beamIdx);
     auto numContextBlocks4 = tc::ceilDiv(promptLen4, blockManager.getTokensPerBlock());
@@ -1350,8 +1356,8 @@ TEST_F(KVCacheManagerTest, KVCacheManagerPerRequestStatsTest)
     bool constexpr isStreaming{false};
 
     KVCacheManager kvCacheManager(numLayers, numHeads, sizePerHead, tokensPerBlock, blocksInPrimaryPool,
-        blocksInSecondaryPool, maxNumSequences, beamWidth, tokensPerBlock * maxBlocksPerSeq, 0, 0, stream, std::nullopt,
-        true, onboardBlocks);
+        blocksInSecondaryPool, maxNumSequences, beamWidth, {tokensPerBlock * maxBlocksPerSeq}, 0, 0, stream,
+        std::nullopt, true, onboardBlocks);
     kvCacheManager.allocatePools(nvinfer1::DataType::kHALF, false);
 
     auto inputTokens = std::make_shared<VecTokens>(VecTokens{0, 1, 2, 3, 4, 5, 6, 7, 8});
@@ -1398,6 +1404,7 @@ TEST_F(KVCacheManagerTest, BlockManagerBlockPriorityTest)
     auto constexpr maxNumSequences = 4;
     auto const stream = std::make_shared<tr::CudaStream>();
     auto constexpr onboardBlocks = true;
+    auto constexpr maxAttentionWindow = tokensPerBlock * maxBlocksPerSeq;
 
     BlockManager blockManager(std::vector<BlockManager::SizeType32>(numLayers, numKvHeads), sizePerHead, tokensPerBlock,
         blocksInPrimaryPool, blocksInSecondaryPool, maxNumSequences, stream, onboardBlocks);
@@ -1420,7 +1427,7 @@ TEST_F(KVCacheManagerTest, BlockManagerBlockPriorityTest)
         KvCacheRetentionConfig({KvCacheRetentionConfig::TokenRangeRetentionConfig(0, 4, 90),
                                    KvCacheRetentionConfig::TokenRangeRetentionConfig(4, 8, 10)},
             20));
-    GenerationRequest seq0{0, inputLength0, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq0{0, inputLength0, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
     auto numContextBlocks0 = tc::ceilDiv(inputLength0, blockManager.getTokensPerBlock());
     blockManager.addSequence(seq0, llmRequest0->getNumTokens(0), numContextBlocks0, *llmRequest0);
 
@@ -1428,7 +1435,7 @@ TEST_F(KVCacheManagerTest, BlockManagerBlockPriorityTest)
     auto inputTokens1 = std::make_shared<VecTokens>(VecTokens{8, 9, 10, 11, 12, 13, 14, 15});
     auto const inputLength1 = static_cast<SizeType32>(inputTokens1->size());
     auto llmRequest1 = std::make_shared<LlmRequest>(1, maxNewTokens, inputTokens1, samplingConfig, isStreaming);
-    GenerationRequest seq1{1, inputLength1, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq1{1, inputLength1, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
     auto numContextBlocks1 = tc::ceilDiv(inputLength1, blockManager.getTokensPerBlock());
     blockManager.addSequence(seq1, llmRequest1->getNumTokens(0), numContextBlocks1, *llmRequest1);
 
@@ -1442,7 +1449,7 @@ TEST_F(KVCacheManagerTest, BlockManagerBlockPriorityTest)
     auto llmRequest2 = std::make_shared<LlmRequest>(2, maxNewTokens, inputTokens2, samplingConfig, isStreaming);
     llmRequest2->setKvCacheRetentionConfig(
         KvCacheRetentionConfig({KvCacheRetentionConfig::TokenRangeRetentionConfig(0, std::nullopt, 20)}, 20));
-    GenerationRequest seq2{2, inputLength2, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq2{2, inputLength2, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
     auto numContextBlocks2 = tc::ceilDiv(inputLength2, blockManager.getTokensPerBlock());
     blockManager.addSequence(seq2, llmRequest2->getNumTokens(0), numContextBlocks2, *llmRequest2);
     blockManager.releaseBlocks(seq2, llmRequest2);
@@ -1451,7 +1458,7 @@ TEST_F(KVCacheManagerTest, BlockManagerBlockPriorityTest)
     auto inputTokens3 = std::make_shared<VecTokens>(VecTokens{8, 9, 10, 11, 12, 13, 14, 15});
     auto const inputLength3 = static_cast<SizeType32>(inputTokens3->size());
     auto llmRequest3 = std::make_shared<LlmRequest>(3, maxNewTokens, inputTokens3, samplingConfig, isStreaming);
-    GenerationRequest seq3{3, inputLength3, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq3{3, inputLength3, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
     auto numContextBlocks3 = tc::ceilDiv(inputLength3, blockManager.getTokensPerBlock());
     blockManager.addSequence(seq3, llmRequest3->getNumTokens(0), numContextBlocks3, *llmRequest3);
 
@@ -1464,7 +1471,7 @@ TEST_F(KVCacheManagerTest, BlockManagerBlockPriorityTest)
     auto inputTokens4 = std::make_shared<VecTokens>(VecTokens{0, 1, 2, 3, 4, 5, 6, 7});
     auto const inputLength4 = static_cast<SizeType32>(inputTokens4->size());
     auto llmRequest4 = std::make_shared<LlmRequest>(4, maxNewTokens, inputTokens4, samplingConfig, isStreaming);
-    GenerationRequest seq4{4, inputLength3, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq4{4, inputLength3, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
     auto numContextBlocks4 = tc::ceilDiv(inputLength4, blockManager.getTokensPerBlock());
     blockManager.addSequence(seq4, llmRequest4->getNumTokens(0), numContextBlocks4, *llmRequest4);
 
@@ -1474,7 +1481,7 @@ TEST_F(KVCacheManagerTest, BlockManagerBlockPriorityTest)
     auto inputTokens5 = std::make_shared<VecTokens>(VecTokens{16, 17, 18, 19, 20, 21, 22, 23});
     auto const inputLength5 = static_cast<SizeType32>(inputTokens5->size());
     auto llmRequest5 = std::make_shared<LlmRequest>(5, maxNewTokens, inputTokens5, samplingConfig, isStreaming);
-    GenerationRequest seq5{5, inputLength5, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq5{5, inputLength5, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
     auto numContextBlocks5 = tc::ceilDiv(inputLength5, blockManager.getTokensPerBlock());
     blockManager.addSequence(seq5, llmRequest5->getNumTokens(0), numContextBlocks5, *llmRequest5);
 
@@ -1500,8 +1507,8 @@ TEST_F(KVCacheManagerTest, KVCacheManagerDecodeBlockPriorityTest)
     bool constexpr isStreaming{false};
 
     KVCacheManager kvCacheManager(numLayers, numHeads, sizePerHead, tokensPerBlock, blocksInPrimaryPool,
-        blocksInSecondaryPool, maxNumSequences, beamWidth, tokensPerBlock * maxBlocksPerSeq, 0, 0, stream, std::nullopt,
-        true, onboardBlocks);
+        blocksInSecondaryPool, maxNumSequences, beamWidth, {tokensPerBlock * maxBlocksPerSeq}, 0, 0, stream,
+        std::nullopt, true, onboardBlocks);
     kvCacheManager.allocatePools(nvinfer1::DataType::kHALF, false);
 
     auto const& blockManager = kvCacheManager.getBlockManager();
@@ -1602,8 +1609,8 @@ TEST_F(KVCacheManagerTest, KVCacheManagerTimedEvictionTest)
     bool constexpr isStreaming{false};
 
     KVCacheManager kvCacheManager(numLayers, numHeads, sizePerHead, tokensPerBlock, blocksInPrimaryPool,
-        blocksInSecondaryPool, maxNumSequences, beamWidth, tokensPerBlock * maxBlocksPerSeq, 0, 0, stream, std::nullopt,
-        true, onboardBlocks);
+        blocksInSecondaryPool, maxNumSequences, beamWidth, {tokensPerBlock * maxBlocksPerSeq}, 0, 0, stream,
+        std::nullopt, true, onboardBlocks);
     kvCacheManager.allocatePools(nvinfer1::DataType::kHALF, false);
 
     auto inputTokens0 = std::make_shared<VecTokens>(VecTokens{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11});
@@ -1666,8 +1673,8 @@ TEST_F(KVCacheManagerTest, KVCacheManagerDecodeTimedEvictionTest)
     bool constexpr isStreaming{false};
 
     KVCacheManager kvCacheManager(numLayers, numHeads, sizePerHead, tokensPerBlock, blocksInPrimaryPool,
-        blocksInSecondaryPool, maxNumSequences, beamWidth, tokensPerBlock * maxBlocksPerSeq, 0, 0, stream, std::nullopt,
-        true, onboardBlocks);
+        blocksInSecondaryPool, maxNumSequences, beamWidth, {tokensPerBlock * maxBlocksPerSeq}, 0, 0, stream,
+        std::nullopt, true, onboardBlocks);
     kvCacheManager.allocatePools(nvinfer1::DataType::kHALF, false);
     {
         auto inputTokens0 = std::make_shared<VecTokens>(VecTokens{1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11});
@@ -1739,7 +1746,7 @@ TEST_F(KVCacheManagerTest, KVCacheManagerSecondaryBlockPrimaryChildTest)
     bool constexpr isStreaming{false};
 
     KVCacheManager kvCacheManager(numLayers, numHeads, sizePerHead, tokensPerBlock, blocksInPrimaryPool,
-        blocksInSecondaryPool, maxNumSequences, beamWidth, tokensPerBlock * maxBlocksPerSeq, 0, false, stream, true,
+        blocksInSecondaryPool, maxNumSequences, beamWidth, {tokensPerBlock * maxBlocksPerSeq}, 0, false, stream, true,
         onboardBlocks);
     kvCacheManager.allocatePools(nvinfer1::DataType::kHALF, false);
 
@@ -1811,7 +1818,7 @@ TEST_F(KVCacheManagerTest, KVCacheManagerLeafBlockTest)
     bool constexpr isStreaming{false};
 
     KVCacheManager kvCacheManager(numLayers, numHeads, sizePerHead, tokensPerBlock, blocksInPrimaryPool,
-        blocksInSecondaryPool, maxNumSequences, beamWidth, tokensPerBlock * maxBlocksPerSeq, 0, false, stream, true,
+        blocksInSecondaryPool, maxNumSequences, beamWidth, {tokensPerBlock * maxBlocksPerSeq}, 0, false, stream, true,
         onboardBlocks);
     kvCacheManager.allocatePools(nvinfer1::DataType::kHALF, false);
 
@@ -1899,10 +1906,10 @@ TEST_P(KVCacheManagerTest, KVCacheManagerAllocationTest)
     auto const granularity = tensorrt_llm::common::getAllocationGranularity();
     KVCacheManager kvCacheManager = homogeneousLayers
         ? KVCacheManager(numLayers, numHeads, sizePerHead, tokensPerBlock, totalNumBlocks, blocksInSecondaryPool,
-            maxNumSequences, maxBeamWidth, maxAttentionWindow, temporaryAttentionWindow, sinkTokenLength, stream,
+            maxNumSequences, maxBeamWidth, {maxAttentionWindow}, temporaryAttentionWindow, sinkTokenLength, stream,
             std::nullopt, enableBlockReuse, onboardBlocks)
         : KVCacheManager(std::vector<KVCacheManager::SizeType32>(numLayers, numHeads), sizePerHead, tokensPerBlock,
-            totalNumBlocks, blocksInSecondaryPool, maxNumSequences, maxBeamWidth, maxAttentionWindow,
+            totalNumBlocks, blocksInSecondaryPool, maxNumSequences, maxBeamWidth, {maxAttentionWindow},
             temporaryAttentionWindow, sinkTokenLength, stream, std::nullopt, enableBlockReuse, onboardBlocks);
 
     auto const& bufferManager = kvCacheManager.getBlockManager().getBufferManager();
@@ -1956,10 +1963,10 @@ TEST_P(KVCacheManagerTest, KVCacheManagerTest)
 
     KVCacheManager kvCacheManager = homogeneousLayers
         ? KVCacheManager(numLayers, numHeads, sizePerHead, tokensPerBlock, totalNumBlocks, blocksInSecondaryPool,
-            maxNumSequences, maxBeamWidth, maxAttentionWindow, temporaryAttentionWindow, sinkTokenLength, stream,
+            maxNumSequences, maxBeamWidth, {maxAttentionWindow}, temporaryAttentionWindow, sinkTokenLength, stream,
             std::nullopt, enableBlockReuse, onboardBlocks)
         : KVCacheManager(numHeadsPerLayer, sizePerHead, tokensPerBlock, totalNumBlocks, blocksInSecondaryPool,
-            maxNumSequences, maxBeamWidth, maxAttentionWindow, temporaryAttentionWindow, sinkTokenLength, stream,
+            maxNumSequences, maxBeamWidth, {maxAttentionWindow}, temporaryAttentionWindow, sinkTokenLength, stream,
             std::nullopt, enableBlockReuse, onboardBlocks);
     kvCacheManager.allocatePools(nvinfer1::DataType::kHALF, false);
 
@@ -2103,10 +2110,10 @@ TEST_P(KVCacheManagerTest, KVCacheManagerRewindTokensTest)
 
     KVCacheManager kvCacheManager = homogeneousLayers
         ? KVCacheManager(numLayers, numHeads, sizePerHead, tokensPerBlock, totalNumBlocks, blocksInSecondaryPool,
-            maxNumSequences, maxBeamWidth, maxAttentionWindow, temporaryAttentionWindow, sinkTokenLength, stream,
+            maxNumSequences, maxBeamWidth, {maxAttentionWindow}, temporaryAttentionWindow, sinkTokenLength, stream,
             std::nullopt, enableBlockReuse, onboardBlocks)
         : KVCacheManager(std::vector<KVCacheManager::SizeType32>(numLayers, numHeads), sizePerHead, tokensPerBlock,
-            totalNumBlocks, blocksInSecondaryPool, maxNumSequences, maxBeamWidth, maxAttentionWindow,
+            totalNumBlocks, blocksInSecondaryPool, maxNumSequences, maxBeamWidth, {maxAttentionWindow},
             temporaryAttentionWindow, sinkTokenLength, stream, std::nullopt, enableBlockReuse, onboardBlocks);
     kvCacheManager.allocatePools(nvinfer1::DataType::kHALF, false);
 
@@ -2189,10 +2196,10 @@ TEST_P(KVCacheManagerTest, KVCacheManagerMaxAttentionWindowTest)
 
     KVCacheManager kvCacheManager = homogeneousLayers
         ? KVCacheManager(numLayers, numHeads, sizePerHead, tokensPerBlock, totalNumBlocks, blocksInSecondaryPool,
-            maxNumSequences, maxBeamWidth, maxAttentionWindow, temporaryAttentionWindow, sinkTokenLength, stream,
+            maxNumSequences, maxBeamWidth, {maxAttentionWindow}, temporaryAttentionWindow, sinkTokenLength, stream,
             std::nullopt, enableBlockReuse, onboardBlocks)
         : KVCacheManager(numHeadsPerLayer, sizePerHead, tokensPerBlock, totalNumBlocks, blocksInSecondaryPool,
-            maxNumSequences, maxBeamWidth, maxAttentionWindow, temporaryAttentionWindow, sinkTokenLength, stream,
+            maxNumSequences, maxBeamWidth, {maxAttentionWindow}, temporaryAttentionWindow, sinkTokenLength, stream,
             std::nullopt, enableBlockReuse, onboardBlocks);
     kvCacheManager.allocatePools(nvinfer1::DataType::kHALF, false);
 
@@ -2306,7 +2313,7 @@ TEST_F(KVCacheManagerTest, KVCacheManagerMaxAttentionWindowWithReuseTest)
     auto constexpr onboardBlocks = true;
 
     KVCacheManager kvCacheManager(numLayers, numHeads, sizePerHead, tokensPerBlock, blocksInPrimaryPool,
-        blocksInSecondaryPool, maxNumSequences, maxBeamWidth, maxAttentionWindow, temporaryAttentionWindow,
+        blocksInSecondaryPool, maxNumSequences, maxBeamWidth, {maxAttentionWindow}, temporaryAttentionWindow,
         sinkTokenLength, stream, std::nullopt, enableBlockReuse, onboardBlocks);
     kvCacheManager.allocatePools(nvinfer1::DataType::kHALF, false);
 
@@ -2424,6 +2431,125 @@ TEST_F(KVCacheManagerTest, KVCacheManagerMaxAttentionWindowWithReuseTest)
     EXPECT_THAT(seq4.getCacheBlockIds().at(beamIdx), ::testing::ElementsAreArray({10, 11, 12, 13}));
 }
 
+TEST_F(KVCacheManagerTest, KVCacheManagerVariableWindowAttentionWithReuseTest)
+{
+    auto constexpr numLayers = 2;
+    auto constexpr numHeads = 2;
+    auto constexpr sizePerHead = 64;
+    auto constexpr tokensPerBlock = 4;
+    auto constexpr maxNumSequences = 8;
+    auto constexpr maxBeamWidth = 1;
+    auto constexpr sinkTokenLength = 0;
+    auto const stream = std::make_shared<tr::CudaStream>();
+
+    // Enable cyclic kv cache for long input tokens.
+    auto constexpr minAttentionWindow = 8;
+    auto constexpr maxAttentionWindow = 16;
+    auto const maxAttentionWindowVec = std::vector<SizeType32>{maxAttentionWindow, minAttentionWindow};
+    auto constexpr temporaryAttentionWindow = 0;
+    auto constexpr maxBlocksPerSeq = tc::ceilDiv(maxAttentionWindow, tokensPerBlock);
+
+    auto constexpr blocksInPrimaryPool = 16;
+    auto constexpr blocksInSecondaryPool = 0;
+
+    auto constexpr enableBlockReuse = true;
+    auto constexpr onboardBlocks = true;
+
+    KVCacheManager kvCacheManager(numLayers, numHeads, sizePerHead, tokensPerBlock, blocksInPrimaryPool,
+        blocksInSecondaryPool, maxNumSequences, maxBeamWidth, maxAttentionWindowVec, temporaryAttentionWindow,
+        sinkTokenLength, stream, std::nullopt, enableBlockReuse, onboardBlocks);
+    kvCacheManager.allocatePools(nvinfer1::DataType::kHALF, false);
+
+    auto const& blockManager = kvCacheManager.getBlockManager();
+
+    SizeType32 constexpr maxNewTokens = 4;
+
+    // prepare tokens with token[i] = 1000 + i
+    TokenIdType constexpr firstToken = 1000;
+
+    auto constexpr beamWidth = maxBeamWidth;
+    tr::SamplingConfig const samplingConfig{beamWidth};
+    bool constexpr isStreaming{false};
+
+    SizeType32 requestId = 0;
+    int inputLength = 7;
+    auto inputTokens = std::make_shared<VecTokens>(inputLength);
+    std::iota(inputTokens->begin(), inputTokens->end(), firstToken);
+    auto llmRequest = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens, samplingConfig, isStreaming);
+    auto constexpr beamIdx = 0;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // add a request that will exceed the min attention window *after context*, and then remove it.
+    kvCacheManager.addSequence(requestId, inputLength, beamWidth, llmRequest);
+    GenerationRequest const& seq0 = kvCacheManager.getSequence(requestId);
+    EXPECT_EQ(llmRequest->getContextCurrentPosition(), 0);
+    EXPECT_THAT(seq0.getCacheBlockIds().at(beamIdx), ::testing::ElementsAreArray({0, 1}));
+
+    // add tokens to enable cyclic kv cache
+    llmRequest->addNewToken(1016, beamIdx);
+    kvCacheManager.addToken(requestId);
+    llmRequest->addNewToken(1017, beamIdx);
+    kvCacheManager.addToken(requestId);
+    auto numTokens = llmRequest->getNumTokens(beamIdx);
+    auto numBlocks = seq0.getCacheBlockIds()[beamIdx].size();
+    EXPECT_EQ(blockManager.getNumAllocatedBlocks(), numBlocks);
+    EXPECT_EQ(blockManager.getNumFreeBlocks(), blocksInPrimaryPool - numBlocks);
+    EXPECT_NO_THROW(kvCacheManager.removeSequence(requestId, llmRequest));
+    // no blocks stored because cyclic KV cache was enabled
+    EXPECT_EQ(blockManager.getNumAllocatedBlocks(), 0);
+    EXPECT_EQ(blockManager.getNumFreeBlocks(), blocksInPrimaryPool);
+
+    ///////////////////////////////////////////////////////////////////////////
+    // add a short request that is between the min and max attention window
+    requestId = 1;
+    inputLength = 9;
+    inputTokens->resize(inputLength);
+    llmRequest = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens, samplingConfig, isStreaming);
+    kvCacheManager.addSequence(requestId, inputLength, beamWidth, llmRequest);
+    GenerationRequest const& seq1 = kvCacheManager.getSequence(requestId);
+    EXPECT_EQ(llmRequest->getContextCurrentPosition(), 0);
+    EXPECT_THAT(seq1.getCacheBlockIds().at(beamIdx), ::testing::ElementsAreArray({3, 4, 5}));
+
+    llmRequest->addNewToken(1007, beamIdx);
+    kvCacheManager.addToken(requestId);
+    llmRequest->addNewToken(1008, beamIdx);
+    kvCacheManager.addToken(requestId);
+    numTokens = llmRequest->getNumTokens(beamIdx);
+    numBlocks = seq1.getCacheBlockIds()[beamIdx].size();
+    EXPECT_EQ(numBlocks, 3);
+    EXPECT_NO_THROW(kvCacheManager.removeSequence(requestId, llmRequest));
+
+    ///////////////////////////////////////////////////////////////////////////
+    // add a request that won't reach the min attention window, so a block can be reused.
+    requestId = 2;
+    inputLength = 4;
+    inputTokens->resize(inputLength);
+    std::iota(inputTokens->begin(), inputTokens->end(), firstToken);
+    llmRequest = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens, samplingConfig, isStreaming);
+    kvCacheManager.addSequence(requestId, inputLength, beamWidth, llmRequest);
+    GenerationRequest const& seq2 = kvCacheManager.getSequence(requestId);
+    EXPECT_EQ(llmRequest->getContextCurrentPosition(), 0);
+    EXPECT_THAT(seq2.getCacheBlockIds().at(beamIdx), ::testing::ElementsAreArray({6}));
+
+    numTokens = llmRequest->getNumTokens(beamIdx);
+    numBlocks = tc::ceilDiv(numTokens, tokensPerBlock);
+    EXPECT_EQ(numBlocks, 1);
+    EXPECT_NO_THROW(kvCacheManager.removeSequence(requestId, llmRequest));
+    // store block 6 for reuse
+
+    ///////////////////////////////////////////////////////////////////////////
+    // add a request that won't reach the min attention window, so a block 6 from previous request will be reused.
+    requestId = 3;
+    inputLength = 4;
+    inputTokens->resize(inputLength);
+    std::iota(inputTokens->begin(), inputTokens->end(), firstToken);
+    llmRequest = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens, samplingConfig, isStreaming);
+    kvCacheManager.addSequence(requestId, inputLength, beamWidth, llmRequest);
+    GenerationRequest const& seq3 = kvCacheManager.getSequence(requestId);
+    EXPECT_EQ(llmRequest->getContextCurrentPosition(), 3);
+    EXPECT_THAT(seq3.getCacheBlockIds().at(beamIdx), ::testing::ElementsAreArray({6}));
+}
+
 namespace
 {
 KVCacheManager setupKvCacheManagerForHashTest(bool enableBlockReuse)
@@ -2448,7 +2574,7 @@ KVCacheManager setupKvCacheManagerForHashTest(bool enableBlockReuse)
     auto constexpr onboardBlocks = true;
 
     return {std::vector<SizeType32>(numLayers, numHeads), sizePerHead, tokensPerBlock, blocksInPrimaryPool,
-        blocksInSecondaryPool, maxNumSequences, maxBeamWidth, maxAttentionWindow, temporaryAttentionWindow,
+        blocksInSecondaryPool, maxNumSequences, maxBeamWidth, {maxAttentionWindow}, temporaryAttentionWindow,
         sinkTokenLength, stream, std::nullopt, enableBlockReuse, onboardBlocks, CacheType::kSELF, std::nullopt, nullptr,
         /*enableHashKey*/ true};
 }
@@ -2619,8 +2745,9 @@ TEST_F(KVCacheManagerTest, KVCacheManagerEventStream)
     bool constexpr isStreaming{false};
 
     KVCacheManager kvCacheManager(numLayers, numHeads, sizePerHead, tokensPerBlock, blocksInPrimaryPool,
-        blocksInSecondaryPool, maxNumSequences, beamWidth, tokensPerBlock * maxBlocksPerSeq, 0, 0, stream, std::nullopt,
-        true, onboardBlocks, CacheType::kSELF, std::nullopt, std::make_unique<tlk::KVCacheEventManager>(1024));
+        blocksInSecondaryPool, maxNumSequences, beamWidth, {tokensPerBlock * maxBlocksPerSeq}, 0, 0, stream,
+        std::nullopt, true, onboardBlocks, CacheType::kSELF, std::nullopt,
+        std::make_unique<tlk::KVCacheEventManager>(1024));
     kvCacheManager.allocatePools(dtype, false);
 
     auto events = getEvents(kvCacheManager);
@@ -2770,8 +2897,9 @@ TEST_F(KVCacheManagerTest, KVCacheManagerEventStreamOverflow)
     bool constexpr isStreaming{false};
 
     KVCacheManager kvCacheManager(numLayers, numHeads, sizePerHead, tokensPerBlock, blocksInPrimaryPool,
-        blocksInSecondaryPool, maxNumSequences, beamWidth, tokensPerBlock * maxBlocksPerSeq, 0, 0, stream, std::nullopt,
-        true, onboardBlocks, CacheType::kSELF, std::nullopt, std::make_unique<tlk::KVCacheEventManager>(1));
+        blocksInSecondaryPool, maxNumSequences, beamWidth, {tokensPerBlock * maxBlocksPerSeq}, 0, 0, stream,
+        std::nullopt, true, onboardBlocks, CacheType::kSELF, std::nullopt,
+        std::make_unique<tlk::KVCacheEventManager>(1));
     kvCacheManager.allocatePools(dtype, false);
 
     auto inputTokens0 = std::make_shared<VecTokens>(VecTokens{0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
@@ -2823,8 +2951,9 @@ TEST_F(KVCacheManagerTest, KVCacheManagerEventStreamPriority)
     bool constexpr isStreaming{false};
 
     KVCacheManager kvCacheManager(numLayers, numHeads, sizePerHead, tokensPerBlock, blocksInPrimaryPool,
-        blocksInSecondaryPool, maxNumSequences, beamWidth, tokensPerBlock * maxBlocksPerSeq, 0, 0, stream, std::nullopt,
-        true, onboardBlocks, CacheType::kSELF, std::nullopt, std::make_unique<tlk::KVCacheEventManager>(1024));
+        blocksInSecondaryPool, maxNumSequences, beamWidth, {tokensPerBlock * maxBlocksPerSeq}, 0, 0, stream,
+        std::nullopt, true, onboardBlocks, CacheType::kSELF, std::nullopt,
+        std::make_unique<tlk::KVCacheEventManager>(1024));
     kvCacheManager.allocatePools(dtype, false);
 
     auto inputTokens0 = std::make_shared<VecTokens>(VecTokens{0, 1, 2, 3, 4, 5, 6, 7});
@@ -2893,14 +3022,15 @@ TEST_F(KVCacheManagerTest, KVCacheManagerEventStreamBlocking)
     bool constexpr isStreaming{false};
 
     KVCacheManager kvCacheManagerTest(numLayers, numHeads, sizePerHead, tokensPerBlock, blocksInPrimaryPool,
-        blocksInSecondaryPool, maxNumSequences, beamWidth, tokensPerBlock * maxBlocksPerSeq, 0, 0, stream, std::nullopt,
-        true, onboardBlocks, CacheType::kSELF, std::nullopt);
+        blocksInSecondaryPool, maxNumSequences, beamWidth, {tokensPerBlock * maxBlocksPerSeq}, 0, 0, stream,
+        std::nullopt, true, onboardBlocks, CacheType::kSELF, std::nullopt);
 
     EXPECT_EQ(getEvents(kvCacheManagerTest).size(), 0);
 
     KVCacheManager kvCacheManager(numLayers, numHeads, sizePerHead, tokensPerBlock, blocksInPrimaryPool,
-        blocksInSecondaryPool, maxNumSequences, beamWidth, tokensPerBlock * maxBlocksPerSeq, 0, 0, stream, std::nullopt,
-        true, onboardBlocks, CacheType::kSELF, std::nullopt, std::make_unique<tlk::KVCacheEventManager>(1024));
+        blocksInSecondaryPool, maxNumSequences, beamWidth, {tokensPerBlock * maxBlocksPerSeq}, 0, 0, stream,
+        std::nullopt, true, onboardBlocks, CacheType::kSELF, std::nullopt,
+        std::make_unique<tlk::KVCacheEventManager>(1024));
 
     kvCacheManager.allocatePools(dtype, false);
     kvCacheManager.flushIterationEvents();
@@ -3000,10 +3130,10 @@ TEST_P(KVCacheManagerTest, KVCacheManagerSinkTokenLengthTest)
     auto const maxSequenceLength = tokensPerBlock * maxBlocksPerSeq;
     KVCacheManager kvCacheManager = homogeneousLayers
         ? KVCacheManager(numLayers, numHeads, sizePerHead, tokensPerBlock, totalNumBlocks, blocksInSecondaryPool,
-            maxNumSequences, maxBeamWidth, maxAttentionWindow, temporaryAttentionWindow, sinkTokenLength, stream,
+            maxNumSequences, maxBeamWidth, {maxAttentionWindow}, temporaryAttentionWindow, sinkTokenLength, stream,
             maxSequenceLength, enableBlockReuse, onboardBlocks)
         : KVCacheManager(numHeadsPerLayer, sizePerHead, tokensPerBlock, totalNumBlocks, blocksInSecondaryPool,
-            maxNumSequences, maxBeamWidth, maxAttentionWindow, temporaryAttentionWindow, sinkTokenLength, stream,
+            maxNumSequences, maxBeamWidth, {maxAttentionWindow}, temporaryAttentionWindow, sinkTokenLength, stream,
             maxSequenceLength, enableBlockReuse, onboardBlocks);
     kvCacheManager.allocatePools(nvinfer1::DataType::kHALF, false);
 
@@ -3136,10 +3266,10 @@ TEST_P(KVCacheManagerTest, KVCacheManagerBatchTest)
 
     KVCacheManager kvCacheManager = homogeneousLayers
         ? KVCacheManager(numLayers, numHeads, sizePerHead, tokensPerBlock, totalNumBlocks, blocksInSecondaryPool,
-            maxNumSequences, maxBeamWidth, maxAttentionWindow, temporaryAttentionWindow, sinkTokenLength, stream,
+            maxNumSequences, maxBeamWidth, {maxAttentionWindow}, temporaryAttentionWindow, sinkTokenLength, stream,
             std::nullopt, enableBlockReuse, onboardBlocks)
         : KVCacheManager(numHeadsPerLayer, sizePerHead, tokensPerBlock, totalNumBlocks, blocksInSecondaryPool,
-            maxNumSequences, maxBeamWidth, maxAttentionWindow, temporaryAttentionWindow, sinkTokenLength, stream,
+            maxNumSequences, maxBeamWidth, {maxAttentionWindow}, temporaryAttentionWindow, sinkTokenLength, stream,
             std::nullopt, enableBlockReuse, onboardBlocks);
     kvCacheManager.allocatePools(nvinfer1::DataType::kHALF, false);
 
@@ -3272,10 +3402,11 @@ void testNeededBlocksOneStep(bool kv_cache_block_reuse, int beamWidth, int draft
 
             KVCacheManager kvCacheManager = homogeneousLayers
                 ? KVCacheManager(numLayers, numHeads, sizePerHead, tokensPerBlock, totalNumBlocks,
-                    blocksInSecondaryPool, maxNumSequences, maxBeamWidth, maxAttentionWindow, temporaryAttentionWindow,
-                    sinkTokenLength, stream, std::nullopt, kv_cache_block_reuse, onboardBlocks)
+                    blocksInSecondaryPool, maxNumSequences, maxBeamWidth, {maxAttentionWindow},
+                    temporaryAttentionWindow, sinkTokenLength, stream, std::nullopt, kv_cache_block_reuse,
+                    onboardBlocks)
                 : KVCacheManager(numHeadsPerLayer, sizePerHead, tokensPerBlock, totalNumBlocks, blocksInSecondaryPool,
-                    maxNumSequences, maxBeamWidth, maxAttentionWindow, temporaryAttentionWindow, sinkTokenLength,
+                    maxNumSequences, maxBeamWidth, {maxAttentionWindow}, temporaryAttentionWindow, sinkTokenLength,
                     stream, std::nullopt, kv_cache_block_reuse, onboardBlocks);
             kvCacheManager.allocatePools(nvinfer1::DataType::kHALF, false);
 
@@ -3488,7 +3619,7 @@ std::shared_ptr<KVCacheManager> createKvCacheManager(
         return std::make_shared<KVCacheManager>(numHeadsPerLayerVec, kvCacheInstantiationParameters.sizePerHead,
             kvCacheInstantiationParameters.tokensPerBlock, kvCacheInstantiationParameters.numBlocksInPrimaryPool, 0,
             kvCacheInstantiationParameters.numBlocksInPrimaryPool, kvCacheInstantiationParameters.maxBeamWidth,
-            kvCacheInstantiationParameters.maxAttentionWindow, temporaryKvCacheLength,
+            std::vector<SizeType32>{kvCacheInstantiationParameters.maxAttentionWindow}, temporaryKvCacheLength,
             kvCacheInstantiationParameters.sinkTokenLength, stream, std::nullopt,
             kvCacheInstantiationParameters.kvCacheBlockReuse, true);
     }
@@ -3499,7 +3630,7 @@ std::shared_ptr<KVCacheManager> createKvCacheManager(
         return std::make_shared<KVCacheManager>(numHeadsPerLayer, kvCacheInstantiationParameters.sizePerHead,
             kvCacheInstantiationParameters.tokensPerBlock, kvCacheInstantiationParameters.numBlocksInPrimaryPool, 0,
             kvCacheInstantiationParameters.numBlocksInPrimaryPool, kvCacheInstantiationParameters.maxBeamWidth,
-            kvCacheInstantiationParameters.maxAttentionWindow, temporaryKvCacheLength,
+            std::vector<SizeType32>{kvCacheInstantiationParameters.maxAttentionWindow}, temporaryKvCacheLength,
             kvCacheInstantiationParameters.sinkTokenLength, stream, std::nullopt,
             kvCacheInstantiationParameters.kvCacheBlockReuse, true);
     }

--- a/cpp/tests/unit_tests/batch_manager/kvCacheUtilsTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/kvCacheUtilsTest.cpp
@@ -79,6 +79,8 @@ TEST_F(BlockIteratorTest, CacheManagerTest)
     auto constexpr blocksInPrimaryPool = 8;
     auto constexpr blocksInSecondaryPool = 0;
     auto constexpr maxNumSequences = 8;
+    auto constexpr maxAttentionWindow = tokensPerBlock * maxBlocksPerSeq;
+
     auto const stream = std::make_shared<tr::CudaStream>();
     auto constexpr onboardBlocks = true;
 
@@ -100,7 +102,7 @@ TEST_F(BlockIteratorTest, CacheManagerTest)
     LlmRequest::RequestIdType requestId{0};
     auto llmRequest0 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens, samplingConfig, isStreaming);
 
-    GenerationRequest seq0{requestId, inputLength, beamWidth, maxBlocksPerSeq};
+    GenerationRequest seq0{requestId, inputLength, beamWidth, maxBlocksPerSeq, maxAttentionWindow};
 
     auto constexpr beamIdx = 0;
     auto promptLen0 = llmRequest0->getNumTokens(beamIdx);

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -188,7 +188,7 @@ class KVCacheManager(BaseResourceManager):
             'blocks_in_secondary_pool': self.blocks_in_secondary_pool,
             'max_num_sequences': max_batch_size,
             'max_beam_width': 1,  # TODO: more than 1 beam?
-            'max_attention_window': max_kv_cache_len,
+            'max_attention_window_vec': [max_kv_cache_len],
             'temporary_attention_window': 0,
             'sink_token_length': sink_token_length,
             'stream': self._stream.cuda_stream,

--- a/tests/unittest/bindings/test_bindings_ut.py
+++ b/tests/unittest/bindings/test_bindings_ut.py
@@ -546,8 +546,7 @@ def test_KvCache_events_binding():
         1,
         'max_beam_width':
         1,
-        'max_attention_window':
-        10,
+        'max_attention_window_vec': [10],
         'temporary_attention_window':
         0,
         'sink_token_length':


### PR DESCRIPTION
TRTLLM supports running models with Sliding Window Attention (SWA). Currently, SWA is implemented via a *cyclic* kv cache, i.e., when the window size is reached, the kvcache starts writing to the *beginning* of the window's cache, thus the SWA's cache size never exceeds the window size.
This cyclic implementation clashes with kvcache reuse ("prefix caching") - once the kv cache starts overwriting the beginning of the cache, the prefix becomes corrupted and can no longer be reused.

So, TRTLLM disables the reuse feature for sequences that exceed the cyclic threshold.

Currently, the check whether sequences have become cyclic, and therefore need to have reuse disabled, has a bug in the case of *VSWA*, or Variable Sliding Window Attention (where layers may have different window sizes), which TRTLLM supports - the check currently checks whether the sequence length has exceeded the *maximum* window size value. In the case of VSWA, once the *minimum* window size value has been reached, the layers with the minimum value have corrupted their cache, and therefore should have reuse disabled.

This PR amends the check to make it so kvcache reuse is disabled when the *minimum* window size is exceeded [in the case of a non-variable SWA, maximum=minimum=the only window size, so the behavior shouldn't change.]