### PR TITLE
feat: AddKVCacheTransfer

### DIFF
--- a/benchmarks/cpp/disaggServerBenchmark.cpp
+++ b/benchmarks/cpp/disaggServerBenchmark.cpp
@@ -22,6 +22,7 @@
 #include "tensorrt_llm/executor/types.h"
 #include "tensorrt_llm/plugins/api/tllmPlugin.h"
 #include "tensorrt_llm/runtime/common.h"
+#include "tensorrt_llm/runtime/generationConfig.h"
 #include "tensorrt_llm/runtime/gptJsonConfig.h"
 #include "tensorrt_llm/runtime/tllmLogger.h"
 #include "tensorrt_llm/runtime/utils/mpiUtils.h"
@@ -859,7 +860,6 @@ public:
 
             if (mEnableCollectKvCacheTransferTime)
             {
-
                 for (std::size_t i = 0; i < generationRequestStatsPerIteration.size(); i++)
                 {
                     auto const& stats = generationRequestStatsPerIteration.at(i);

--- a/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
+++ b/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
@@ -1649,6 +1649,16 @@ public:
         mPerfMetrics.timingMetrics.kvCacheTransferEnd = time;
     }
 
+    std::chrono::time_point<std::chrono::steady_clock> getKvCacheTransferStart()
+    {
+        return mPerfMetrics.timingMetrics.kvCacheTransferStart;
+    }
+
+    std::chrono::time_point<std::chrono::steady_clock> getKvCacheTransferEnd()
+    {
+        return mPerfMetrics.timingMetrics.kvCacheTransferEnd;
+    }
+
     [[nodiscard]] double getKvCacheTransferTimeMS() const
     {
         // get max with 0 in case this function is called while end time is not recorded

--- a/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
@@ -215,6 +215,7 @@ void CacheFormatter::formatOutput(LlmRequest const& llmRequest,
             TLLM_CUDA_CHECK(cudaSetDevice(deviceId));
             TLLM_CHECK(connections.size() > processIdx);
             TLLM_CHECK(outputSplitCaches.size() > processIdx);
+            auto startTime = std::chrono::steady_clock::now();
             if (processIdx < bufferCoverTargetNum)
             {
                 TransferHelper::sendBuffer(
@@ -246,6 +247,11 @@ void CacheFormatter::formatOutput(LlmRequest const& llmRequest,
                     remainSendSize -= sendSize;
                 }
             }
+
+            auto endTime = std::chrono::steady_clock::now();
+            double cacheTransferTime
+                = std::max(0.0, std::chrono::duration<double, std::milli>(endTime - startTime).count());
+            kvCacheTimeHelper.appendKVCacheTransferTime(llmRequest.mRequestId, cacheTransferTime);
         };
 
         if (connections.size() > 1)

--- a/cpp/tensorrt_llm/batch_manager/cacheFormatter.h
+++ b/cpp/tensorrt_llm/batch_manager/cacheFormatter.h
@@ -103,6 +103,8 @@ private:
 
     std::unordered_map<std::string, runtime::ITensor::SharedPtr> mProcessToRecvBuffer;
     std::mutex mProcessToRecvBufferMutex;
+
+    KvCacheTimeHelper kvCacheTimeHelper{common::getEnvKVCacheTransferOutputPath()};
 };
 
 } // namespace tensorrt_llm::batch_manager::kv_cache_manager

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -15,6 +15,10 @@
  * limitations under the License.
  */
 
+#include "tensorrt_llm/executor/types.h"
+#include <cstdint>
+#include <limits>
+#include <sstream>
 #define UCX_WRAPPER_LIB_NAME "tensorrt_llm_ucx_wrapper"
 
 #if defined(_WIN32)
@@ -260,6 +264,43 @@ std::vector<LlmRequest::RequestIdType> gatherRequestIds(
     return retData;
 }
 
+void updateKVCacheTransferTime(mpi::MpiComm const& mpiComm, LlmRequest* request)
+{
+    namespace su = executor::serialize_utils;
+    int worldSize = mpiComm.getSize();
+
+    std::ostringstream oStream;
+    su::serialize(request->getKvCacheTransferStart(), oStream);
+    su::serialize(request->getKvCacheTransferEnd(), oStream);
+
+    auto str = oStream.str();
+    std::vector<char> sendBuffer(str.begin(), str.end());
+    auto sendBufferSize = sendBuffer.size();
+    auto recvBufferSize = sendBufferSize * worldSize;
+    std::vector<char> recvBuffer(recvBufferSize);
+
+    mpiComm.allgather(sendBuffer.data(), recvBuffer.data(), sendBufferSize, mpi::MpiType::kCHAR);
+
+    su::VectorWrapBuf<char> strbuf(recvBuffer);
+    std::istream is(&strbuf);
+
+    auto minStartTime = executor::RequestPerfMetrics::TimePoint::max();
+    auto maxEndTime = executor::RequestPerfMetrics::TimePoint::min();
+
+    for (int rank = 0; rank < worldSize; rank++)
+    {
+        minStartTime = std::min(su::deserialize<executor::RequestPerfMetrics::TimePoint>(is), minStartTime);
+        maxEndTime = std::max(su::deserialize<executor::RequestPerfMetrics::TimePoint>(is), maxEndTime);
+    }
+
+    // Update the latest KV cache transfer time for leader rank
+    if (mpiComm.getRank() == 0)
+    {
+        request->setKvCacheTransferStart(minStartTime);
+        request->setKvCacheTransferEnd(maxEndTime);
+    }
+}
+
 void CacheTransceiver::checkContextTransferStatus(bool blocking)
 {
     auto syncComm = mCacheState->getParallelConfig().mEnableAttenionDP ? mMpiGroupTPInDPComm : mMpiGroupTensorParaComm;
@@ -403,6 +444,11 @@ void CacheTransceiver::checkGenTransferStatus(int atLeastRequestNum)
         {
             it->second.get();
 
+            // Gather the kv cache transfer time from all workers and update to leader rank
+            if (!common::getEnvKVCacheTransferOutputPath().empty())
+            {
+                updateKVCacheTransferTime(*mMpiGroupComm, it->first);
+            }
             TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(),
                 "**** it->first->mRequestId: %ld, context request ID: %ld ******** get feature ***",
                 it->first->mRequestId, it->first->getContextPhaseParams().value().getReqId());

--- a/cpp/tensorrt_llm/common/envUtils.cpp
+++ b/cpp/tensorrt_llm/common/envUtils.cpp
@@ -21,6 +21,8 @@
 #include <cstddef>
 #include <cstdlib>
 #include <mutex>
+#include <optional>
+#include <string>
 
 namespace tensorrt_llm::common
 {
@@ -46,6 +48,16 @@ std::optional<size_t> getUInt64Env(char const* name)
     size_t const val = std::stoull(env);
     return {val};
 };
+
+std::optional<std::string> getStrEnv(char const* name)
+{
+    char const* const env = std::getenv(name);
+    if (env == nullptr)
+    {
+        return std::nullopt;
+    }
+    return std::string(env);
+}
 
 // Returns true if the env variable exists and is set to "1"
 static bool getBoolEnv(char const* name)
@@ -335,6 +347,12 @@ size_t getEnvAllReduceWorkspaceSize()
     static size_t const workspaceSize
         = getUInt64Env("FORCE_ALLREDUCE_KERNEL_WORKSPACE_SIZE").value_or(1000 * 1000 * 1000);
     return workspaceSize;
+}
+
+std::string getEnvKVCacheTransferOutputPath()
+{
+    static std::string outputPath = getStrEnv("TRTLLM_KVCACHE_TIME_OUTPUT_PATH").value_or("");
+    return outputPath;
 }
 
 bool getEnvKVCacheTransferUseAsyncBuffer()

--- a/cpp/tensorrt_llm/common/envUtils.h
+++ b/cpp/tensorrt_llm/common/envUtils.h
@@ -67,6 +67,8 @@ bool getEnvDisableKVCacheTransferOverlap();
 
 bool getEnvDisableReceiveKVCacheParallel();
 
+std::string getEnvKVCacheTransferOutputPath();
+
 bool getEnvTryZCopyForKVCacheTransfer();
 
 // Force deterministic behavior for all kernels.


### PR DESCRIPTION
Add fine-grained kv cache transfer measurement in disaggregated serving case. The use can set the env `TRTLLM_KVCACHE_TIME_OUTPUT_PATH` to dump the metrics. 