### PR TITLE
chore: Refactor return of first gen token in PD

### DIFF
--- a/tensorrt_llm/executor/result.py
+++ b/tensorrt_llm/executor/result.py
@@ -173,6 +173,15 @@ class GenerationResultBase:
             output.token_ids = response_tensors.output_token_ids[src_idx]
         else:
             output.token_ids.extend(response_tensors.output_token_ids[src_idx])
+
+        # In PD, the first generation response will return 2 tokens
+        # Skip output the first generated token in generation response
+        # TODO: We should have a better way to handle this when enable
+        # beam search with PD.
+        if not self.sampling_params.use_beam_search and \
+            len(response_tensors.output_token_ids[src_idx]) == 2:
+            output._last_token_ids_len = 1
+
         if response_tensors.cum_log_probs is not None:
             output.cumulative_logprob = response_tensors.cum_log_probs[src_idx]
         if response_tensors.log_probs is not None:

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -356,11 +356,9 @@ class LLM:
             disaggregated_params=disaggregated_params,
             postproc_params=_postproc_params,
         )
-        #For dis serving context only requests, skip post-processing
-        tokenizer = None if (disaggregated_params
-                             and disaggregated_params.request_type
-                             == "context_only") else self.tokenizer
-        return RequestOutput._from_generation_result(result, prompt, tokenizer)
+
+        return RequestOutput._from_generation_result(result, prompt,
+                                                     self.tokenizer)
 
     def get_stats(self, timeout: Optional[float] = 2) -> List[dict]:
         '''Get iteration statistics from the runtime.


### PR DESCRIPTION
In the current implementation, we will return the first and second generated token together from generation worker. I refactor this logic and return the first generated token from context worker as soon as it finishes computation. 