### PR TITLE
fix: Fix path to constraints.txt in bloom/requirements.txt

### DIFF
--- a/examples/models/contrib/bloom/requirements.txt
+++ b/examples/models/contrib/bloom/requirements.txt
@@ -1,4 +1,5 @@
--c ../constraints.txt
+-c ../../../constraints.txt
+
 tensorrt_llm>=0.0.0.dev0
 datasets~=2.14.5
 evaluate


### PR DESCRIPTION
This PR fixes a broken path in:
```ruby 
examples/models/contrib/bloom/requirements.txt
```
which was referencing
```ruby
 -c ../constraints.txt.
```
Since the file was moved deeper, the correct relative path is now
```ruby
 -c ../../../constraints.txt
```

This change ensures proper installation of the example dependencies without file-not-found errors

