### PR TITLE
feat : reduce trt engine build time in testing

### DIFF
--- a/tests/unittest/attention/test_gpt_attention.py
+++ b/tests/unittest/attention/test_gpt_attention.py
@@ -754,7 +754,9 @@ class TestFunctional(unittest.TestCase):
                 precision=dtype,
                 int8=int8_trt_flag,
                 quant_mode=quant_mode)
-
+            # Reuce the TRT engine build time by setting the max allowed number of tactics in builder tactic profiling.
+            if builder_config.trt_builder_config.max_num_tactics == -1:
+                builder_config.trt_builder_config.max_num_tactics = 30
             if session is None:
                 engine = builder.build_engine(net, builder_config)
                 session = tensorrt_llm.runtime.Session.from_serialized_engine(


### PR DESCRIPTION
The default max tactic number to autotune is (when builder_config.trt_builder_config.max_num_tactics == -1 and trt will choose heuristic path):
100 for SM90
60 for other architectures
This number may have slight impact on the e2e perf, but no impact on the functional tests and would save nearly 50% test time on related tests. 