### PR TITLE
feat: Support cos_sin_cache in all cases.

### DIFF
--- a/benchmarks/python/mem_monitor.py
+++ b/benchmarks/python/mem_monitor.py
@@ -67,6 +67,9 @@ class MemoryMonitor:
         self.mem_monitor_process.join(timeout=20)
         self.mem_monitor_process = None
         logger.debug("Memory monitor subprocess joined.")
+        self.peak_mem_queue.close()
+        self.peak_mem_queue.join_thread()
+        logger.debug("Peak memory queue closed and joined.")
 
     def _upd_peak_memory_usage(self, signal_event, peak_mem_queue):
         peak_host_used, peak_device_used = self.get_memory_usage()

--- a/cpp/tensorrt_llm/common/attentionOp.h
+++ b/cpp/tensorrt_llm/common/attentionOp.h
@@ -263,6 +263,7 @@ public:
         return mPositionEmbeddingType == tensorrt_llm::kernels::PositionEmbeddingType::kROPE_GPTJ
             || mPositionEmbeddingType == tensorrt_llm::kernels::PositionEmbeddingType::kROPE_GPT_NEOX
             || mPositionEmbeddingType == tensorrt_llm::kernels::PositionEmbeddingType::kLONG_ROPE
+            || mPositionEmbeddingType == tensorrt_llm::kernels::PositionEmbeddingType::kYARN
             || mPositionEmbeddingType == tensorrt_llm::kernels::PositionEmbeddingType::kROPE_M;
     }
 

--- a/cpp/tensorrt_llm/thop/attentionOp.cpp
+++ b/cpp/tensorrt_llm/thop/attentionOp.cpp
@@ -133,11 +133,10 @@ public:
 
         if (op.isRoPE())
         {
-            rotary_inv_freq_ptr = rotary_inv_freq.value().data_ptr<float>();
-        }
-
-        if (op.isRoPE() || op.isMLAEnabled())
-        {
+            if (rotary_inv_freq.has_value())
+            {
+                rotary_inv_freq_ptr = rotary_inv_freq.value().data_ptr<float>();
+            }
             rotary_cos_sin_ptr = static_cast<float2 const*>(rotary_cos_sin.value().data_ptr());
         }
 

--- a/examples/auto_deploy/build_and_run_ad.py
+++ b/examples/auto_deploy/build_and_run_ad.py
@@ -105,6 +105,7 @@ def main(config: Optional[SimpleConfig] = None):
             "Benchmark with " + ", ".join(f"{k}={getattr(config, k)}" for k in keys),
             results_path=config.benchmark_results_path,
         )
+    llm.shutdown()
 
 
 if __name__ == "__main__":

--- a/examples/quantization/quantize.py
+++ b/examples/quantization/quantize.py
@@ -5,9 +5,8 @@ import torch.multiprocessing as mp
 from tensorrt_llm.quantization import (quantize_and_export,
                                        quantize_nemo_and_export)
 
-mp.set_start_method("spawn", force=True)
-
 if __name__ == "__main__":
+    mp.set_start_method("spawn", force=True)
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--model_dir",
                         help="Specify where the HuggingFace model is",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,6 +19,7 @@ pytest-xdist
 pytest-timeout
 pytest-split
 pytest-mock
+pytest-threadleak
 rouge_score
 cloudpickle
 typing-extensions==4.12.2

--- a/tensorrt_llm/_torch/attention_backend/flashinfer.py
+++ b/tensorrt_llm/_torch/attention_backend/flashinfer.py
@@ -412,9 +412,10 @@ class FlashInferAttention(AttentionBackend[FlashInferAttentionMetadata]):
         head_dim: int,
         num_kv_heads: Optional[int] = None,
         quant_config: Optional[QuantConfig] = None,
+        **kwargs,
     ):
         super().__init__(layer_idx, num_heads, head_dim, num_kv_heads,
-                         quant_config)
+                         quant_config, **kwargs)
 
         self.has_fp8_kv_cache = False
         if quant_config and quant_config.layer_quant_mode.has_any_quant():

--- a/tensorrt_llm/_torch/attention_backend/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/interface.py
@@ -1,6 +1,6 @@
 import copy
-import enum
 from dataclasses import dataclass, field
+from enum import Enum, IntEnum
 from functools import lru_cache
 from typing import (Generic, List, Optional, Protocol, Tuple, Type, TypeVar,
                     Union)
@@ -22,6 +22,14 @@ class AttentionRuntimeFeatures:
     chunked_prefill: bool = False
     cache_reuse: bool = False
     has_speculative_draft_tokens: bool = False
+
+
+# The type of requests in qkv passed to attention
+# Please keep sync with AttentionInputType in cpp/tensorrt_llm/thop/attentionOp.cpp
+class AttentionInputType(IntEnum):
+    mixed = 0  # contains both context and generation
+    context_only = 1
+    generation_only = 2
 
 
 @dataclass(kw_only=True)
@@ -420,7 +428,7 @@ class PositionalEmbeddingParams:
 TMetadata = TypeVar("TMetadata", bound=AttentionMetadata)
 
 
-class PredefinedAttentionMask(str, enum.Enum):
+class PredefinedAttentionMask(str, Enum):
     """
     Predefined attention mask types
 
@@ -449,6 +457,7 @@ class AttentionBackend(Generic[TMetadata]):
         head_dim: int,
         num_kv_heads: Optional[int] = None,
         quant_config: Optional[QuantConfig] = None,
+        **kwargs,
     ):
         """
         Initialize the backend.

--- a/tensorrt_llm/_torch/attention_backend/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/interface.py
@@ -362,7 +362,7 @@ class RopeParams:
 
         return rope_params
 
-    def create_rope_const_params(self):
+    def create_rope_const_params(self, interleave: bool = True):
         if self.dim == 0:
             return None, None
 
@@ -370,7 +370,7 @@ class RopeParams:
         extra_attrs = get_model_extra_attrs()
         if extra_attrs is not None:
             cache = extra_attrs.setdefault("rope_const_params", {})
-            rope_const_params = cache.get(self, None)
+            rope_const_params = cache.get((self, interleave), None)
             if rope_const_params is not None and rope_const_params.cos_sin(
             ) is not None:
                 return (
@@ -413,13 +413,17 @@ class RopeParams:
                 dtype=torch.float32,
                 device='cuda',
             )
+        if not interleave:
+            rope_cos_sin = rope_cos_sin.reshape(
+                self.max_positions, -1,
+                2)[:, :self.dim // 2, :].transpose(0, 2, 1).reshape(1, -1)
         rope_cos_sin = torch.torch.tensor(
             rope_cos_sin,
             dtype=torch.float32,
             device='cuda',
         )
         if extra_attrs is not None:
-            cache[self] = RopeConstParams(
+            cache[(self, interleave)] = RopeConstParams(
                 weakref.ref(rope_inv_freq)
                 if rope_inv_freq is not None else None,
                 weakref.ref(rope_cos_sin),
@@ -434,6 +438,7 @@ class PositionalEmbeddingParams:
 
     # RoPE params
     rope: Optional[RopeParams] = None
+    is_neox: bool = True
 
     def __post_init__(self) -> None:
         if self.type.is_deferred():

--- a/tensorrt_llm/_torch/attention_backend/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/interface.py
@@ -1,7 +1,8 @@
 import copy
+import weakref
+from collections import namedtuple
 from dataclasses import dataclass, field
 from enum import Enum, IntEnum
-from functools import lru_cache
 from typing import (Generic, List, Optional, Protocol, Tuple, Type, TypeVar,
                     Union)
 
@@ -15,6 +16,7 @@ from tensorrt_llm.models.modeling_utils import QuantConfig
 
 from ..metadata import KVCacheParams
 from ..pyexecutor.resource_manager import KVCacheManager
+from ..utils import get_model_extra_attrs
 
 
 @dataclass
@@ -333,6 +335,7 @@ class RopeParams:
         # rotary embedding dim.
         rope_params.dim = (getattr(config, 'rotary_dim', None)
                            or getattr(config, 'rotary_emb_base', None)
+                           or getattr(config, 'qk_rope_head_dim', None)
                            or int(head_dim * rope_percentage))
         # rotary scaling.
         rope_params.scale_type = RotaryScalingType.none
@@ -353,57 +356,74 @@ class RopeParams:
             rope_params.beta_slow = rope_scaling.get("beta_slow", 1)
             rope_params.mscale = rope_scaling.get("mscale", 1.0)
             rope_params.mscale_all_dim = rope_scaling.get("mscale_all_dim", 0.0)
+        # Workaround for DeepSeek V3 Lite since its rope_scaling is null in config.json.
+        if config.model_type == "deepseek_v3":
+            rope_params.scale_type = RotaryScalingType.yarn
 
         return rope_params
 
-    @lru_cache(maxsize=1)
     def create_rope_const_params(self):
         if self.dim == 0:
             return None, None
-        assert self.scale_type != RotaryScalingType.longrope, "Long RoPE is not yet supported."
-        rope_inv_freq, rope_cos_sin = RopeEmbeddingUtils.create_sinusoidal_positions_for_attention_plugin(
-            self.max_positions,
-            self.dim,
-            self.theta,
-            self.scale,
-            self.scale_type,
-            rope_scaling_config={
-                "factor": self.scale,
-                "low_freq_factor": self.low_freq_factor,
-                "high_freq_factor": self.high_freq_factor,
-                "original_max_position_embeddings": self.original_max_positions,
-            })
-        rope_inv_freq = torch.torch.tensor(
-            rope_inv_freq,
-            dtype=torch.float32,
-            device='cuda',
-        )
-        rope_cos_sin = torch.torch.tensor(
-            rope_cos_sin,
-            dtype=torch.float32,
-            device='cuda',
-        )
-        return rope_inv_freq, rope_cos_sin
 
-    @lru_cache(maxsize=1)
-    def create_deepseek_rope_const_params(self, qk_rope_head_dim: int):
-        rope_cos_sin = RopeEmbeddingUtils.create_sinusoidal_positions_for_deepseek_attention_plugin(
-            self.max_positions,
-            qk_rope_head_dim,
-            self.theta,
-            self.scale,
-            self.original_max_positions,
-            self.beta_fast,
-            self.beta_slow,
-            self.mscale,
-            self.mscale_all_dim,
-        )
+        RopeConstParams = namedtuple("RopeConstParams", ["inv_freq", "cos_sin"])
+        extra_attrs = get_model_extra_attrs()
+        if extra_attrs is not None:
+            cache = extra_attrs.setdefault("rope_const_params", {})
+            rope_const_params = cache.get(self, None)
+            if rope_const_params is not None and rope_const_params.cos_sin(
+            ) is not None:
+                return (
+                    rope_const_params.inv_freq()
+                    if rope_const_params.inv_freq is not None else None,
+                    rope_const_params.cos_sin(),
+                )
+
+        assert self.scale_type != RotaryScalingType.longrope, "Long RoPE is not yet supported."
+        if self.scale_type == RotaryScalingType.yarn:
+            rope_inv_freq = None
+            rope_cos_sin = RopeEmbeddingUtils.create_sinusoidal_positions_yarn(
+                self.max_positions,
+                self.dim,
+                self.theta,
+                self.scale,
+                self.original_max_positions,
+                self.beta_fast,
+                self.beta_slow,
+                self.mscale,
+                self.mscale_all_dim,
+            )
+        else:
+            rope_inv_freq, rope_cos_sin = RopeEmbeddingUtils.create_sinusoidal_positions_for_attention_plugin(
+                self.max_positions,
+                self.dim,
+                self.theta,
+                self.scale,
+                self.scale_type,
+                rope_scaling_config={
+                    "factor": self.scale,
+                    "low_freq_factor": self.low_freq_factor,
+                    "high_freq_factor": self.high_freq_factor,
+                    "original_max_position_embeddings":
+                    self.original_max_positions,
+                })
+        if rope_inv_freq is not None:
+            rope_inv_freq = torch.torch.tensor(
+                rope_inv_freq,
+                dtype=torch.float32,
+                device='cuda',
+            )
         rope_cos_sin = torch.torch.tensor(
             rope_cos_sin,
             dtype=torch.float32,
             device='cuda',
         )
-        rope_inv_freq = None
+        if extra_attrs is not None:
+            cache[self] = RopeConstParams(
+                weakref.ref(rope_inv_freq)
+                if rope_inv_freq is not None else None,
+                weakref.ref(rope_cos_sin),
+            )
         return rope_inv_freq, rope_cos_sin
 
 

--- a/tensorrt_llm/_torch/attention_backend/star_flashinfer.py
+++ b/tensorrt_llm/_torch/attention_backend/star_flashinfer.py
@@ -304,9 +304,10 @@ class StarAttention(AttentionBackend[StarAttentionMetadata]):
         head_dim: int,
         num_kv_heads: Optional[int] = None,
         quant_config: Optional[QuantConfig] = None,
+        **kwargs,
     ):
         super().__init__(layer_idx, num_heads, head_dim, num_kv_heads,
-                         quant_config)
+                         quant_config, **kwargs)
 
     def forward(self,
                 q: torch.Tensor,

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -3,8 +3,7 @@ from typing import Optional
 
 import torch
 
-from tensorrt_llm.functional import (AttentionMaskType, RopeEmbeddingUtils,
-                                     RotaryScalingType)
+from tensorrt_llm.functional import AttentionMaskType
 from tensorrt_llm.logger import logger
 from tensorrt_llm.models.modeling_utils import QuantConfig
 
@@ -84,16 +83,14 @@ class TrtllmAttentionWrapper:
             pos_embd_params (PositionalEmbeddingParams): Optional parameters defining how positional embedding should be applied.
             quant_config (QuantConfig): Optional quantization configuration. If None, no quantization is applied.
         """
+        rope_params = None
         if pos_embd_params is not None:
             rope_params = pos_embd_params.rope
-        else:
-            self.rotary_inv_freq = None
-            self.rotary_cos_sin = None
-            rope_params = RopeParams()
+        rope_params = rope_params or RopeParams()
+        self.rope_params = rope_params
 
         self.is_mla_enable = mla_params is not None
         self.q_scaling = q_scaling or 1.0
-        self.mla_rope_params = None
         self.predicted_tokens_per_seq = 1
 
         if self.is_mla_enable:
@@ -103,13 +100,6 @@ class TrtllmAttentionWrapper:
             self.qk_rope_head_dim = mla_params.qk_rope_head_dim
             self.v_head_dim = mla_params.v_head_dim
             self.predicted_tokens_per_seq = mla_params.predicted_tokens_per_seq
-
-            self.rotary_embedding_dim = 0
-            self.rotary_inv_freq, self.rotary_cos_sin = rope_params.create_deepseek_rope_const_params(
-                self.qk_rope_head_dim)
-            self.rotary_embedding_scale_type = RotaryScalingType.none
-            self.rotary_embedding_scale = 1.0
-            self.mla_rope_params = rope_params
         else:
             self.q_lora_rank = None
             self.kv_lora_rank = None
@@ -117,11 +107,8 @@ class TrtllmAttentionWrapper:
             self.qk_rope_head_dim = None
             self.v_head_dim = None
 
-            self.rotary_inv_freq, self.rotary_cos_sin = rope_params.create_rope_const_params(
-            )
-            self.rotary_embedding_dim = rope_params.dim
-            self.rotary_embedding_scale_type = int(rope_params.scale_type)
-            self.rotary_embedding_scale = rope_params.scale
+        self.rotary_inv_freq, self.rotary_cos_sin = rope_params.create_rope_const_params(
+        )
 
         self.layer_idx = layer_idx
         self.num_heads = num_heads
@@ -131,7 +118,10 @@ class TrtllmAttentionWrapper:
         self.quant_mode = int(quant_config.layer_quant_mode)
         self.position_embedding_type = int(
             pos_embd_params.type) if pos_embd_params is not None else 0
+        self.rotary_embedding_dim = rope_params.dim
         self.rotary_embedding_base = rope_params.theta
+        self.rotary_embedding_scale_type = int(rope_params.scale_type)
+        self.rotary_embedding_scale = rope_params.scale
         self.rotary_embedding_short_m_scale = rope_params.short_m_scale
         self.rotary_embedding_long_m_scale = rope_params.long_m_scale
         self.rotary_embedding_max_positions = rope_params.max_positions
@@ -229,24 +219,10 @@ class TrtllmAttentionWrapper:
         self.kwargs.update(kwargs)
         self.block_ids_per_seq = block_ids_per_seq
 
-        if self.is_mla_enable:
-            # max_context_length will increment 1 when overlap scheduler enabled
-            if self.max_context_length > (self.rotary_cos_sin.shape[1] /
-                                          (2 * self.qk_rope_head_dim) + 1):
-                rope_cos_sin = RopeEmbeddingUtils.create_sinusoidal_positions_for_deepseek_attention_plugin(
-                    self.max_context_length,
-                    self.qk_rope_head_dim,
-                    self.mla_rope_params.theta,
-                    self.mla_rope_params.scale,
-                    self.mla_rope_params.original_max_positions,
-                    self.mla_rope_params.beta_fast,
-                    self.mla_rope_params.beta_slow,
-                    self.mla_rope_params.mscale,
-                    self.mla_rope_params.mscale_all_dim,
-                )
-                self.rotary_cos_sin = torch.tensor(rope_cos_sin,
-                                                   dtype=torch.float32,
-                                                   device="cuda")
+        if max_sequence_length > self.rope_params.max_positions:
+            self.rope_params.max_positions = max_sequence_length
+            self.rotary_inv_freq, self.rotary_cos_sin = self.rope_params.create_rope_const_params(
+            )
 
     def run(
         self,

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -1,6 +1,4 @@
-import math
 from dataclasses import dataclass
-from enum import IntEnum
 from typing import Optional
 
 import torch
@@ -10,18 +8,10 @@ from tensorrt_llm.functional import (AttentionMaskType, RopeEmbeddingUtils,
 from tensorrt_llm.logger import logger
 from tensorrt_llm.models.modeling_utils import QuantConfig
 
-from .interface import (AttentionBackend, AttentionMask, AttentionMetadata,
-                        MLAParams, PositionalEmbeddingParams,
+from .interface import (AttentionBackend, AttentionInputType, AttentionMask,
+                        AttentionMetadata, MLAParams, PositionalEmbeddingParams,
                         PredefinedAttentionMask, RopeParams)
 from .vanilla import VanillaAttention
-
-
-# The type of requests in qkv passed to attention
-# Please keep sync with AttentionInputType in cpp/tensorrt_llm/thop/attentionOp.cpp
-class AttentionInputType(IntEnum):
-    mixed = 0  # contains both context and generation
-    context_only = 1
-    generation_only = 2
 
 
 @dataclass(kw_only=True, init=False)
@@ -65,11 +55,11 @@ class TrtllmAttentionWrapper:
     rotary_embedding_original_max_positions: int
     use_paged_context_fmha: bool
     is_mla_enable: bool
-    q_lora_rank: int
-    kv_lora_rank: int
-    qk_rope_head_dim: int
-    qk_nope_head_dim: int
-    v_head_dim: int
+    q_lora_rank: Optional[int]
+    kv_lora_rank: Optional[int]
+    qk_rope_head_dim: Optional[int]
+    qk_nope_head_dim: Optional[int]
+    v_head_dim: Optional[int]
     kwargs: dict
 
     def __init__(
@@ -80,6 +70,7 @@ class TrtllmAttentionWrapper:
         num_kv_heads: Optional[int] = None,
         pos_embd_params: Optional[PositionalEmbeddingParams] = None,
         quant_config: Optional[QuantConfig] = None,
+        q_scaling: Optional[float] = None,
         mla_params: Optional[MLAParams] = None,
         **kwargs,
     ):
@@ -101,7 +92,7 @@ class TrtllmAttentionWrapper:
             rope_params = RopeParams()
 
         self.is_mla_enable = mla_params is not None
-        self.q_scaling = 1.0
+        self.q_scaling = q_scaling or 1.0
         self.mla_rope_params = None
         self.predicted_tokens_per_seq = 1
 
@@ -114,18 +105,6 @@ class TrtllmAttentionWrapper:
             self.predicted_tokens_per_seq = mla_params.predicted_tokens_per_seq
 
             self.rotary_embedding_dim = 0
-
-            def yarn_get_mscale(scale=1, mscale=1):
-                if scale <= 1:
-                    return 1.0
-                return 0.1 * mscale * math.log(scale) + 1.0
-
-            mscale_all_dim = rope_params.mscale_all_dim
-            scaling_factor = rope_params.scale
-            if mscale_all_dim:
-                mscale = yarn_get_mscale(scaling_factor, mscale_all_dim)
-                self.q_scaling = 1.0 / (mscale * mscale)
-
             self.rotary_inv_freq, self.rotary_cos_sin = rope_params.create_deepseek_rope_const_params(
                 self.qk_rope_head_dim)
             self.rotary_embedding_scale_type = RotaryScalingType.none
@@ -165,6 +144,7 @@ class TrtllmAttentionWrapper:
         *,
         tokens_per_block: int,
         max_num_requests: int,
+        max_sequence_length: int,
         max_context_length: int,
         attention_window_size: Optional[int] = None,
         sink_token_length: int = 0,
@@ -196,6 +176,7 @@ class TrtllmAttentionWrapper:
         Args:
             tokens_per_block (int): Token number per KV cache block.
             max_num_requests (int): Max request number per batch.
+            max_sequence_length (int): Max sequence length.
             max_context_length (int): Max context length per context-phase sequence.
             attention_window_size (int): Max token number attended in windowed attention.
             sink_token_length (int): Sink token number in StreamingLLM.
@@ -220,7 +201,7 @@ class TrtllmAttentionWrapper:
         self.tokens_per_block = tokens_per_block
         self.max_num_requests = max_num_requests
         self.max_context_length = max_context_length
-        self.attention_window_size = attention_window_size or max_context_length
+        self.attention_window_size = attention_window_size or max_sequence_length
         self.sink_token_length = sink_token_length
         self.beam_width = beam_width
         self.sequence_length = sequence_length
@@ -538,9 +519,11 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
         num_heads: int,
         head_dim: int,
         num_kv_heads: Optional[int] = None,
-        pos_embd_params: Optional[PositionalEmbeddingParams] = None,
         quant_config: Optional[QuantConfig] = None,
+        q_scaling: Optional[float] = None,
+        pos_embd_params: Optional[PositionalEmbeddingParams] = None,
         mla_params: Optional[MLAParams] = None,
+        **kwargs,
     ):
         """
         Initialize the backend.
@@ -549,13 +532,21 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
             num_heads (int): The number of query heads.
             head_dim (int): The size of each attention head (hidden_size // num_heads).
             num_kv_heads (int): The number of kv heads. Defaults to num_heads if None.
+            quant_config (QuantConfig): Optional quantization configuration. If None, no quantization is applied.
             pos_embd_params (PositionalEmbeddingParams): Optional parameters defining how positional embedding should be applied.
                                                          If None, positional embedding should be applied by the model before calling the backend.
                                                          Otherwise, the backend is in-charge of applying positional embedding and may cache K without embedding it first.
-            quant_config (QuantConfig): Optional quantization configuration. If None, no quantization is applied.
+            mla_params (MLAParams): Optional parameters for MLA. If None, MLA is not enabled.
         """
-        super().__init__(layer_idx, num_heads, head_dim, num_kv_heads,
-                         quant_config)
+        super().__init__(layer_idx,
+                         num_heads,
+                         head_dim,
+                         num_kv_heads,
+                         quant_config,
+                         q_scaling=q_scaling,
+                         pos_embd_params=pos_embd_params,
+                         mla_params=mla_params,
+                         **kwargs)
         self.wrapper = TrtllmAttentionWrapper(
             layer_idx,
             num_heads,
@@ -563,6 +554,7 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
             num_kv_heads,
             pos_embd_params=pos_embd_params,
             quant_config=quant_config,
+            q_scaling=q_scaling,
             mla_params=mla_params,
         )
 
@@ -651,7 +643,9 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
         self.wrapper.plan(
             tokens_per_block=metadata.kv_cache_manager.tokens_per_block,
             max_num_requests=metadata.kv_cache_manager.max_batch_size,
-            max_context_length=metadata.kv_cache_manager.max_seq_len,
+            max_sequence_length=metadata.kv_cache_manager.max_seq_len,
+            max_context_length=min(metadata.kv_cache_manager.max_seq_len - 1,
+                                   metadata.max_num_tokens),
             attention_window_size=None,
             sink_token_length=0,
             beam_width=1,

--- a/tensorrt_llm/_torch/attention_backend/utils.py
+++ b/tensorrt_llm/_torch/attention_backend/utils.py
@@ -32,42 +32,40 @@ def create_attention(
     num_kv_heads: Optional[int] = None,
     pos_embd_params: Optional[PositionalEmbeddingParams] = None,
     quant_config: Optional[QuantConfig] = None,
-    is_mla_enable: Optional[bool] = False,
-    q_lora_rank: Optional[int] = 0,
-    kv_lora_rank: Optional[int] = 0,
-    qk_rope_head_dim: Optional[int] = 0,
-    qk_nope_head_dim: Optional[int] = 0,
-    v_head_dim: Optional[int] = 0,
+    q_scaling: Optional[float] = None,
+    is_mla_enable: bool = False,
+    q_lora_rank: Optional[int] = None,
+    kv_lora_rank: Optional[int] = None,
+    qk_rope_head_dim: Optional[int] = None,
+    qk_nope_head_dim: Optional[int] = None,
+    v_head_dim: Optional[int] = None,
     predicted_tokens_per_seq: Optional[int] = 1,
 ):
 
     attn_cls = get_attention_backend(backend_name)
+
     if is_mla_enable:
         assert attn_cls == TrtllmAttention
         assert (q_lora_rank > 0 and kv_lora_rank > 0 and qk_rope_head_dim > 0
                 and qk_nope_head_dim > 0 and v_head_dim > 0)
-
-    if attn_cls == TrtllmAttention:
-        if is_mla_enable:
-            mla_params = MLAParams(
-                q_lora_rank=q_lora_rank,
-                kv_lora_rank=kv_lora_rank,
-                qk_rope_head_dim=qk_rope_head_dim,
-                qk_nope_head_dim=qk_nope_head_dim,
-                v_head_dim=v_head_dim,
-                predicted_tokens_per_seq=predicted_tokens_per_seq,
-            )
-        else:
-            mla_params = None
-
-        return TrtllmAttention(
-            layer_idx,
-            num_heads,
-            head_dim,
-            num_kv_heads,
-            pos_embd_params,
-            quant_config,
-            mla_params=mla_params,
+        mla_params = MLAParams(
+            q_lora_rank=q_lora_rank,
+            kv_lora_rank=kv_lora_rank,
+            qk_rope_head_dim=qk_rope_head_dim,
+            qk_nope_head_dim=qk_nope_head_dim,
+            v_head_dim=v_head_dim,
+            predicted_tokens_per_seq=predicted_tokens_per_seq,
         )
+    else:
+        mla_params = None
 
-    return attn_cls(layer_idx, num_heads, head_dim, num_kv_heads, quant_config)
+    return attn_cls(
+        layer_idx,
+        num_heads,
+        head_dim,
+        num_kv_heads,
+        quant_config=quant_config,
+        q_scaling=q_scaling,
+        pos_embd_params=pos_embd_params,
+        mla_params=mla_params,
+    )

--- a/tensorrt_llm/_torch/attention_backend/vanilla.py
+++ b/tensorrt_llm/_torch/attention_backend/vanilla.py
@@ -67,9 +67,10 @@ class VanillaAttention(AttentionBackend[VanillaAttentionMetadata]):
         head_dim: int,
         num_kv_heads: Optional[int] = None,
         quant_config: Optional[QuantConfig] = None,
+        **kwargs,
     ):
         super().__init__(layer_idx, num_heads, head_dim, num_kv_heads,
-                         quant_config)
+                         quant_config, **kwargs)
         self.num_key_value_groups = self.num_heads // self.num_kv_heads
 
     def _single_request_update_kv_cache(self, k, v, kv_cache_tensor, seq_len,

--- a/tensorrt_llm/_torch/auto_deploy/distributed/common.py
+++ b/tensorrt_llm/_torch/auto_deploy/distributed/common.py
@@ -263,5 +263,8 @@ class MultiProcessExecutor:
             self.input_queues[i].put(None)
         _join_multiprocess_job(self.processes)
         self.processes = None
-        del self.input_queues
-        del self.output_queue
+        for q in self.input_queues:
+            q.close()
+            q.join_thread()
+        self.output_queue.close()
+        self.output_queue.join_thread()

--- a/tensorrt_llm/_torch/custom_ops/__init__.py
+++ b/tensorrt_llm/_torch/custom_ops/__init__.py
@@ -11,13 +11,13 @@ __all__ = [
 ]
 
 if IS_FLASHINFER_AVAIABLE:
-    from .flashinfer_custom_ops import (flashinfer_apply_rope_inplace,
-                                        flashinfer_fused_add_rmsnorm,
-                                        flashinfer_rmsnorm,
-                                        flashinfer_silu_and_mul)
+    from .flashinfer_custom_ops import (
+        flashinfer_apply_rope_with_cos_sin_cache_inplace,
+        flashinfer_fused_add_rmsnorm, flashinfer_rmsnorm,
+        flashinfer_silu_and_mul)
     __all__ += [
         'flashinfer_silu_and_mul',
         'flashinfer_rmsnorm',
         'flashinfer_fused_add_rmsnorm',
-        'flashinfer_apply_rope_inplace',
+        'flashinfer_apply_rope_with_cos_sin_cache_inplace',
     ]

--- a/tensorrt_llm/_torch/custom_ops/flashinfer_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/flashinfer_custom_ops.py
@@ -1,7 +1,6 @@
 import os
 import platform
 import traceback
-from typing import Optional
 
 import torch
 
@@ -48,8 +47,8 @@ if IS_FLASHINFER_AVAIABLE:
         return rmsnorm(input, weight, eps, enable_pdl=ENABLE_PDL)
 
     @flashinfer_rmsnorm.register_fake
-    def rmsnorm_fake(input: torch.Tensor, weight: torch.Tensor,
-                     eps: float) -> torch.Tensor:
+    def _(input: torch.Tensor, weight: torch.Tensor,
+          eps: float) -> torch.Tensor:
         return torch.empty_like(input)
 
     @torch.library.custom_op("trtllm::flashinfer_fused_add_rmsnorm",
@@ -59,30 +58,33 @@ if IS_FLASHINFER_AVAIABLE:
                                      weight: torch.Tensor, eps: float) -> None:
         fused_add_rmsnorm(input, residual, weight, eps, enable_pdl=ENABLE_PDL)
 
-    @torch.library.custom_op("trtllm::flashinfer_apply_rope_inplace",
-                             mutates_args=("q", "k"))
-    def flashinfer_apply_rope_inplace(
-        q: torch.Tensor,
-        k: torch.Tensor,
-        indptr: torch.Tensor,
-        offsets: torch.Tensor,
-        rotary_dim: Optional[int] = None,
-        interleave: bool = False,
-        rope_scale: float = 1,
-        rope_theta: float = 1e4,
+    @torch.library.custom_op(
+        "trtllm::flashinfer_apply_rope_with_cos_sin_cache_inplace",
+        mutates_args=("query", "key"))
+    def flashinfer_apply_rope_with_cos_sin_cache_inplace(
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        head_size: int,
+        cos_sin_cache: torch.Tensor,
+        is_neox: bool = True,
     ) -> None:
-        flashinfer.apply_rope_inplace(q, k, indptr, offsets, rotary_dim,
-                                      interleave, rope_scale, rope_theta)
+        flashinfer.apply_rope_with_cos_sin_cache_inplace(
+            positions,
+            query,
+            key,
+            head_size,
+            cos_sin_cache,
+            is_neox,
+        )
 
-    @flashinfer_apply_rope_inplace.register_fake
-    def apply_rope_inplace_fake(
-        q: torch.Tensor,
-        k: torch.Tensor,
-        indptr: torch.Tensor,
-        offsets: torch.Tensor,
-        rotary_dim: Optional[int] = None,
-        interleave: bool = False,
-        rope_scale: float = 1,
-        rope_theta: float = 1e4,
+    @flashinfer_apply_rope_with_cos_sin_cache_inplace.register_fake
+    def _(
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        head_size: int,
+        cos_sin_cache: torch.Tensor,
+        is_neox: bool = True,
     ):
         return

--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -35,14 +35,6 @@ class ModelConfig(Generic[TConfig]):
                 self.pretrained_config.architectures)
 
     @property
-    def fuse_pos_embd(self):
-        if self.attn_backend == 'TRTLLM':
-            return True
-        elif self.attn_backend == 'FLASHINFER':
-            return False
-        return False
-
-    @property
     def enable_flash_mla(self):
         if self.attn_backend == 'TRTLLM':
             if hasattr(self.pretrained_config, "kv_lora_rank") and hasattr(

--- a/tensorrt_llm/_torch/models/modeling_auto.py
+++ b/tensorrt_llm/_torch/models/modeling_auto.py
@@ -1,6 +1,7 @@
 from typing import Generic
 
 from ..model_config import ModelConfig
+from ..utils import model_extra_attrs
 from .modeling_utils import (MODEL_CLASS_MAPPING, DecoderModelForCausalLM,
                              TConfig, TModel)
 
@@ -25,4 +26,8 @@ class AutoModelForCausalLM(Generic[TModel, TConfig]):
             )
         if issubclass(cls, DecoderModelForCausalLM):
             config.skip_create_weights = True
-        return cls(config)
+        extra_attrs = {}
+        with model_extra_attrs(extra_attrs):
+            model = cls(config)
+        model.extra_attrs = extra_attrs
+        return model

--- a/tensorrt_llm/_torch/models/modeling_bert.py
+++ b/tensorrt_llm/_torch/models/modeling_bert.py
@@ -81,7 +81,6 @@ class BertAttention(Attention):
                  layer_idx: Optional[int] = None):
         config = model_config.pretrained_config
         pos_embd_params = None
-        rotary_emb = None
         bias = True
         super().__init__(
             hidden_size=config.hidden_size,
@@ -89,7 +88,6 @@ class BertAttention(Attention):
             num_key_value_heads=config.num_attention_heads,
             max_position_embeddings=config.max_position_embeddings,
             bias=bias,
-            rotary_emb=rotary_emb,
             pos_embd_params=pos_embd_params,
             layer_idx=layer_idx,
             dtype=config.torch_dtype,

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -24,7 +24,6 @@ from ..modules.fused_moe import BaseMoeRoutingMethod, FusedMoE
 from ..modules.gated_mlp import GatedMLP
 from ..modules.linear import Linear
 from ..modules.rms_norm import RMSNorm
-from ..modules.rotary_embedding import RotaryEmbedding
 from ..pipeline_interface import PipelineInterface
 from ..pyexecutor.cuda_graph_runner import is_graph_capturing
 from ..speculative import MTPEagleWorker, MTPSpecMetadata, MTPWorker
@@ -60,20 +59,6 @@ class DeepseekV3MTPHead(nn.Module):
         return logits
 
 
-class DeepseekV3RotaryEmbedding(RotaryEmbedding):
-
-    def __init__(self,
-                 config: PretrainedConfig,
-                 device: Optional[torch.device] = None):
-        head_dim = config.hidden_size // config.num_attention_heads
-        super().__init__(config,
-                         head_dim=head_dim,
-                         num_attention_heads=config.num_attention_heads,
-                         max_position_embeddings=config.max_position_embeddings,
-                         device=device,
-                         rope_type="default")
-
-
 class DeepseekV3Attention(MLA):
 
     def __init__(
@@ -83,14 +68,6 @@ class DeepseekV3Attention(MLA):
         aux_stream: Optional[torch.cuda.Stream] = None,
     ):
         config = model_config.pretrained_config
-        if model_config.fuse_pos_embd:
-            pos_embd_params = PositionalEmbeddingParams(
-                type=PositionEmbeddingType.yarn,
-                rope=RopeParams.from_config(config),
-            )
-        else:
-            pos_embd_params = None
-
         predicted_tokens_per_seq = model_config.spec_config.num_nextn_predict_layers + 1 if model_config.spec_config is not None else 1
         super().__init__(hidden_size=config.hidden_size,
                          num_attention_heads=config.num_attention_heads,
@@ -103,8 +80,11 @@ class DeepseekV3Attention(MLA):
                          predicted_tokens_per_seq=predicted_tokens_per_seq,
                          max_position_embeddings=config.max_position_embeddings,
                          bias=False,
-                         rotary_emb=DeepseekV3RotaryEmbedding(config),
-                         pos_embd_params=pos_embd_params,
+                         pos_embd_params=PositionalEmbeddingParams(
+                             type=PositionEmbeddingType.yarn,
+                             rope=RopeParams.from_config(config),
+                             is_neox=False,
+                         ),
                          layer_idx=layer_idx,
                          dtype=config.torch_dtype,
                          config=model_config,

--- a/tensorrt_llm/_torch/models/modeling_mamba_hybrid.py
+++ b/tensorrt_llm/_torch/models/modeling_mamba_hybrid.py
@@ -76,7 +76,6 @@ class TransformerLayer(Attention):
             num_key_value_heads=config.num_key_value_heads,
             max_position_embeddings=config.max_position_embeddings,
             bias=config.attention_bias,
-            rotary_emb=None,
             pos_embd_params=None,
             layer_idx=layer_idx,
             dtype=config.torch_dtype,

--- a/tensorrt_llm/_torch/models/modeling_mixtral.py
+++ b/tensorrt_llm/_torch/models/modeling_mixtral.py
@@ -16,7 +16,6 @@ from ..modules.decoder_layer import DecoderLayer
 from ..modules.fused_moe import FusedMoE, RenormalizeMoeRoutingMethod
 from ..modules.linear import Linear
 from ..modules.rms_norm import RMSNorm
-from ..modules.rotary_embedding import RotaryEmbedding
 from .modeling_utils import (DecoderModel, DecoderModelForCausalLM,
                              register_auto_model)
 
@@ -72,20 +71,6 @@ class MixtralMoE(nn.Module):
         return final_hidden_states
 
 
-class MixtralRotaryEmbedding(RotaryEmbedding):
-
-    def __init__(self,
-                 config: PretrainedConfig,
-                 device: Optional[torch.device] = None):
-        head_dim = config.hidden_size // config.num_attention_heads
-        super().__init__(config,
-                         head_dim=head_dim,
-                         num_attention_heads=config.num_attention_heads,
-                         max_position_embeddings=config.max_position_embeddings,
-                         device=device,
-                         rope_type="default")
-
-
 class MixtralAttention(Attention):
 
     def __init__(
@@ -94,21 +79,15 @@ class MixtralAttention(Attention):
         layer_idx: Optional[int] = None,
     ):
         config = model_config.pretrained_config
-        if model_config.fuse_pos_embd:
-            pos_embd_params = PositionalEmbeddingParams(
-                type=PositionEmbeddingType.rope_gpt_neox,
-                rope=RopeParams.from_config(config),
-            )
-        else:
-            pos_embd_params = None
-
         super().__init__(hidden_size=config.hidden_size,
                          num_attention_heads=config.num_attention_heads,
                          num_key_value_heads=config.num_key_value_heads,
                          max_position_embeddings=config.max_position_embeddings,
                          bias=False,
-                         rotary_emb=MixtralRotaryEmbedding(config),
-                         pos_embd_params=pos_embd_params,
+                         pos_embd_params=PositionalEmbeddingParams(
+                             type=PositionEmbeddingType.rope_gpt_neox,
+                             rope=RopeParams.from_config(config),
+                         ),
                          layer_idx=layer_idx,
                          dtype=config.torch_dtype,
                          config=model_config)

--- a/tensorrt_llm/_torch/models/modeling_qwen.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen.py
@@ -16,26 +16,9 @@ from ..modules.embedding import Embedding
 from ..modules.gated_mlp import GatedMLP
 from ..modules.linear import Linear
 from ..modules.rms_norm import RMSNorm
-from ..modules.rotary_embedding import RotaryEmbedding
 from ..pipeline_interface import PipelineInterface
 from .modeling_utils import (DecoderModel, DecoderModelForCausalLM,
                              register_auto_model)
-
-
-class QwenRotaryEmbedding(RotaryEmbedding):
-
-    def __init__(
-        self,
-        config: Qwen2Config,
-        device: Optional[torch.device] = None,
-    ):
-        super().__init__(config,
-                         head_dim=config.hidden_size //
-                         config.num_attention_heads,
-                         num_attention_heads=config.num_attention_heads,
-                         max_position_embeddings=config.max_position_embeddings,
-                         device=device,
-                         rope_type="default")
 
 
 class QwenAttention(Attention):
@@ -46,27 +29,23 @@ class QwenAttention(Attention):
         layer_idx: Optional[int] = None,
     ):
         config = model_config.pretrained_config
-        if model_config.fuse_pos_embd:
-            if getattr(config, "rope_scaling", None) is not None:
-                pos_embd_params = PositionalEmbeddingParams(
-                    type=PositionEmbeddingType.from_string(
-                        config.rope_scaling["type"]),
-                    rope=RopeParams.from_config(config),
-                )
-            else:
-                pos_embd_params = PositionalEmbeddingParams(
-                    type=PositionEmbeddingType.rope_gpt_neox,
-                    rope=RopeParams.from_config(config),
-                )
+        if getattr(config, "rope_scaling", None) is not None:
+            pos_embd_params = PositionalEmbeddingParams(
+                type=PositionEmbeddingType.from_string(
+                    config.rope_scaling["type"]),
+                rope=RopeParams.from_config(config),
+            )
         else:
-            pos_embd_params = None
+            pos_embd_params = PositionalEmbeddingParams(
+                type=PositionEmbeddingType.rope_gpt_neox,
+                rope=RopeParams.from_config(config),
+            )
         super().__init__(
             hidden_size=config.hidden_size,
             num_attention_heads=config.num_attention_heads,
             num_key_value_heads=config.num_key_value_heads,
             max_position_embeddings=config.max_position_embeddings,
             bias=True,
-            rotary_emb=QwenRotaryEmbedding(config),
             pos_embd_params=pos_embd_params,
             layer_idx=layer_idx,
             dtype=config.torch_dtype,

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -4,7 +4,8 @@ from typing import Optional
 import torch
 from torch import nn
 
-from ..attention_backend import AttentionInputType, AttentionMetadata
+from ..attention_backend import (AttentionInputType, AttentionMetadata,
+                                 TrtllmAttention)
 from ..attention_backend.interface import (PositionalEmbeddingParams,
                                            PredefinedAttentionMask)
 from ..attention_backend.utils import create_attention
@@ -278,8 +279,7 @@ class MLA(nn.Module):
 
             self.q_b_proj = Linear(
                 self.q_lora_rank,
-                tp_size * self.num_heads *
-                (self.qk_nope_head_dim + self.qk_rope_head_dim),
+                tp_size * self.num_heads * self.qk_head_dim,
                 bias=bias,
                 dtype=dtype,
                 parallel_config=col_parallel_config,
@@ -295,15 +295,13 @@ class MLA(nn.Module):
                 skip_create_weights=config.skip_create_weights,
                 use_custom_cublas_mm=True)
 
-            self.q_proj = Linear(
-                self.q_lora_rank,
-                tp_size * self.num_heads *
-                (self.qk_nope_head_dim + self.qk_rope_head_dim),
-                bias=bias,
-                dtype=dtype,
-                parallel_config=col_parallel_config,
-                quant_config=quant_config,
-                skip_create_weights=config.skip_create_weights)
+            self.q_proj = Linear(self.q_lora_rank,
+                                 tp_size * self.num_heads * self.qk_head_dim,
+                                 bias=bias,
+                                 dtype=dtype,
+                                 parallel_config=col_parallel_config,
+                                 quant_config=quant_config,
+                                 skip_create_weights=config.skip_create_weights)
             self.q_b_proj = self.q_proj
 
         self.kv_a_layernorm = RMSNorm(hidden_size=kv_lora_rank,
@@ -429,6 +427,25 @@ class MLA(nn.Module):
         self.aux_stream = aux_stream
         self.ln_events = [torch.cuda.Event(), torch.cuda.Event()]
 
+        self.enable_rope_fusion = isinstance(self.mha, TrtllmAttention)
+        self.support_fused_qkv = isinstance(self.mha, TrtllmAttention)
+        self.support_unfused_qkv = not isinstance(self.mha, TrtllmAttention)
+        self.rotary_emb = None
+        if not self.enable_rope_fusion:
+            self.rotary_emb = RotaryEmbedding(
+                pos_embd_params.rope,
+                head_dim=self.qk_rope_head_dim,
+                is_neox=pos_embd_params.is_neox,
+            )
+
+    def apply_rope(self, q, k_pe, position_ids):
+        q_pe = q[..., self.qk_nope_head_dim:].reshape(
+            -1, self.num_heads * self.qk_rope_head_dim)
+        q_pe, k_pe = self.rotary_emb(position_ids, [q_pe, k_pe])
+        q[..., self.qk_nope_head_dim:] = q_pe.view(-1, self.num_heads,
+                                                   self.qk_rope_head_dim)
+        return k_pe
+
     def forward(
         self,
         position_ids: Optional[torch.LongTensor],
@@ -475,6 +492,10 @@ class MLA(nn.Module):
             q_ctx = q[:num_ctx_tokens, ...]
             compressed_kv_ctx = compressed_kv[:num_ctx_tokens, ...]
             k_pe_ctx = k_pe[:num_ctx_tokens, ...]
+            if self.rotary_emb is not None and position_ids is not None:
+                k_pe_ctx = self.apply_rope(
+                    q_ctx.view(-1, self.num_heads, self.qk_head_dim), k_pe_ctx,
+                    position_ids)
 
             attn_output_context = self.forward_context(q_ctx, compressed_kv_ctx,
                                                        k_pe_ctx, attn_metadata)
@@ -485,6 +506,10 @@ class MLA(nn.Module):
             q_gen = q[num_ctx_tokens:, ...]
             compressed_kv_gen = compressed_kv[num_ctx_tokens:, ...]
             k_pe_gen = k_pe[num_ctx_tokens:, ...]
+            if self.rotary_emb is not None and position_ids is not None:
+                k_pe_gen = self.apply_rope(
+                    q_gen.view(-1, self.num_heads, self.qk_head_dim), k_pe_gen,
+                    position_ids)
 
             attn_output_gen = self.forward_generation(q_gen, compressed_kv_gen,
                                                       k_pe_gen, attn_metadata)
@@ -510,6 +535,12 @@ class MLA(nn.Module):
                                   all_reduce_params=all_reduce_params)
         return attn_output
 
+    def convert_qkv(self, q, k, v):
+        if k is not None and v is not None and not self.support_unfused_qkv:
+            qkv = torch.concat([q, k, v], dim=-1)
+            q, k, v = qkv, None, None
+        return q, k, v
+
     def forward_context(
         self,
         q: torch.Tensor,
@@ -528,22 +559,22 @@ class MLA(nn.Module):
             -1,
         )
 
-        k = torch.empty_like(q).view(
-            -1, self.num_heads, (self.qk_nope_head_dim + self.qk_rope_head_dim))
+        k = torch.empty_like(q).view(-1, self.num_heads, self.qk_head_dim)
         k[..., :self.qk_nope_head_dim] = k_nope.view(-1, self.num_heads,
                                                      self.qk_nope_head_dim)
-        k = k.view(
-            -1,
-            self.num_heads * (self.qk_nope_head_dim + self.qk_rope_head_dim))
+        if not self.enable_rope_fusion:
+            k[..., self.qk_nope_head_dim:] = k_pe.view(-1, 1,
+                                                       self.qk_rope_head_dim)
+        k = k.view(-1, self.num_heads * self.qk_head_dim)
 
-        # Concat q(including q_pe), k + k_pe, v together as input_qkv
-        input_qkv = torch.cat([q, k, v], dim=-1)
+        # May concat q(including q_pe), k + k_pe, v together
+        q, k, v = self.convert_qkv(q, k, v)
 
         out_scale = getattr(self.o_proj, "inv_input_scale", None)
         attn_output = self.mha.forward(
-            input_qkv,
-            None,
-            None,
+            q,
+            k,
+            v,
             attn_metadata,
             attention_input_type=AttentionInputType.context_only,
             latent_cache=latent_cache,
@@ -562,9 +593,8 @@ class MLA(nn.Module):
         num_tokens = q.shape[0]
         latent_cache = torch.concat([compressed_kv, k_pe], dim=-1)
 
-        q_nope, q_pe = q.view([
-            -1, self.num_heads, self.qk_nope_head_dim + self.qk_rope_head_dim
-        ]).split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
+        q_nope, q_pe = q.view([-1, self.num_heads, self.qk_head_dim]).split(
+            [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
 
         # fused_q contains 1) the result of the following bmm with shape [num_tokens, num_heads, kv_lora_rank]
         # 2) rope(q_pe) with shape [num_tokens, num_heads, qk_rope_head_dim]. rope is applied inside AttentionOp
@@ -602,6 +632,8 @@ class MLA(nn.Module):
             raise NotImplementedError(
                 f"Missing bmm impl for dtype: {self.k_b_proj_trans.dtype}.")
 
+        if not self.enable_rope_fusion:
+            fused_q[..., self.kv_lora_rank:] = q_pe
         fused_q = fused_q.view([
             num_tokens,
             self.num_heads * (self.kv_lora_rank + self.qk_rope_head_dim)

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -4,8 +4,7 @@ from typing import Optional
 import torch
 from torch import nn
 
-from ..attention_backend import (AttentionInputType, AttentionMetadata,
-                                 TrtllmAttention)
+from ..attention_backend import AttentionInputType, AttentionMetadata
 from ..attention_backend.interface import (PositionalEmbeddingParams,
                                            PredefinedAttentionMask)
 from ..attention_backend.utils import create_attention
@@ -27,7 +26,6 @@ class Attention(nn.Module):
         max_position_embeddings: int,
         bias: bool,
         pos_embd_params: Optional[PositionalEmbeddingParams] = None,
-        rotary_emb: Optional[RotaryEmbedding] = None,
         layer_idx: Optional[int] = None,
         dtype: torch.dtype = None,
         dense_bias: Optional[bool] = None,
@@ -103,7 +101,17 @@ class Attention(nn.Module):
         self.quant_config = config.get_quant_config()
         self.attn_backend = config.attn_backend
         self.pos_embd_params = pos_embd_params
-        self.rotary_emb = rotary_emb
+
+        self.enable_rope_fusion = self.attn_backend == "TRTLLM"
+        self.support_fused_qkv = self.attn_backend == "TRTLLM"
+        self.support_unfused_qkv = self.attn_backend != "TRTLLM"
+        self.rotary_emb = None
+        if not self.enable_rope_fusion and pos_embd_params is not None:
+            self.rotary_emb = RotaryEmbedding(
+                pos_embd_params.rope,
+                head_dim=self.head_dim,
+                is_neox=pos_embd_params.is_neox,
+            )
 
         if not config.skip_create_weights:
             self.create_weights()
@@ -119,6 +127,14 @@ class Attention(nn.Module):
             quant_config=self.quant_config,
         )
 
+    def convert_qkv(self, q, k, v):
+        if k is None and v is None and not self.support_fused_qkv:
+            q, k, v = q.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        elif k is not None and v is not None and not self.support_unfused_qkv:
+            qkv = torch.concat([q, k, v], dim=-1)
+            q, k, v = qkv, None, None
+        return q, k, v
+
     def forward(
         self,
         position_ids: Optional[torch.LongTensor],
@@ -130,47 +146,25 @@ class Attention(nn.Module):
         **kwargs,
     ) -> torch.Tensor:
         qkv = self.qkv_proj(hidden_states)
-        is_fused_qkv = False
-        if isinstance(self.attn, TrtllmAttention):
-            is_fused_qkv = True
+        q, k, v = qkv, None, None
 
-        if is_fused_qkv:
-            if self.pos_embd_params is None and position_ids is not None:
-                q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size],
-                                    dim=-1)
-                q, k = self.rotary_emb(
-                    position_ids,
-                    [q.contiguous(), k.contiguous()], attn_metadata)
-                qkv = torch.concat(
-                    [q.contiguous(),
-                     k.contiguous(),
-                     v.contiguous()], dim=-1)
-
-            out_scale = None
-            if self.o_proj.has_fp8_qdq or self.o_proj.has_nv_fp4 or self.o_proj.has_fp8_block_scales:
-                out_scale = self.o_proj.inv_input_scale
-            attn_output = self.attn.forward(qkv,
-                                            None,
-                                            None,
-                                            attn_metadata,
-                                            out_scale=out_scale,
-                                            attention_mask=attention_mask,
-                                            mrope_config=mrope_config)
-        else:
+        if self.rotary_emb is not None and position_ids is not None:
             q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size],
                                 dim=-1)
+            q, k = self.rotary_emb(position_ids, [q, k])
 
-            if self.pos_embd_params is None and position_ids is not None:
-                q, k = self.rotary_emb(
-                    position_ids,
-                    [q.contiguous(), k.contiguous()], attn_metadata)
+        out_scale = None
+        if self.o_proj.has_fp8_qdq or self.o_proj.has_nv_fp4 or self.o_proj.has_fp8_block_scales:
+            out_scale = self.o_proj.inv_input_scale
 
-            attn_output = self.attn.forward(q.contiguous(),
-                                            k.contiguous(),
-                                            v.contiguous(),
-                                            attn_metadata,
-                                            attention_mask=attention_mask,
-                                            mrope_config=mrope_config)
+        q, k, v = self.convert_qkv(q, k, v)
+        attn_output = self.attn.forward(q,
+                                        k,
+                                        v,
+                                        attn_metadata,
+                                        out_scale=out_scale,
+                                        attention_mask=attention_mask,
+                                        mrope_config=mrope_config)
 
         attn_output = self.o_proj(attn_output)
 
@@ -195,7 +189,6 @@ class MLA(nn.Module):
         bias: bool,
         aux_stream: Optional[torch.cuda.Stream] = None,
         pos_embd_params: Optional[PositionalEmbeddingParams] = None,
-        rotary_emb: Optional[RotaryEmbedding] = None,
         layer_idx: Optional[int] = None,
         dtype: torch.dtype = None,
         dense_bias: Optional[bool] = None,
@@ -232,6 +225,7 @@ class MLA(nn.Module):
             raise ValueError(
                 f"hidden_size must be divisible by num_heads (got `hidden_size`: {self.hidden_size}"
                 f" and `num_heads`: {self.num_heads}).")
+        assert pos_embd_params is not None, "pos_embd_params must be provided in MLA"
 
         # tensor parallel
         config = config or ModelConfig()
@@ -431,7 +425,7 @@ class MLA(nn.Module):
             v_head_dim=self.kv_lora_rank,
             predicted_tokens_per_seq=self.predicted_tokens_per_seq,
         )
-        self.rotary_emb = rotary_emb
+
         self.aux_stream = aux_stream
         self.ln_events = [torch.cuda.Event(), torch.cuda.Event()]
 

--- a/tensorrt_llm/_torch/modules/rotary_embedding.py
+++ b/tensorrt_llm/_torch/modules/rotary_embedding.py
@@ -1,207 +1,62 @@
-import math
-from typing import List, Literal, Optional, Tuple
+from typing import List
 
 import torch
 from torch import nn
-from transformers import LlamaConfig, PretrainedConfig
 
-from ..attention_backend import IS_FLASHINFER_AVAIABLE, AttentionMetadata
-
-
-def compute_default_rope_parameters(
-    config: PretrainedConfig,
-    device: Optional[torch.device] = None,
-) -> "Tuple[torch.Tensor, float]":
-    """
-    Computes the inverse frequencies according to the original RoPE implementation
-    Args:
-        config ([`~transformers.PretrainedConfig`]):
-            The model configuration.
-        device (`torch.device`):
-            The device to use for initialization of the inverse frequencies.
-        seq_len (`int`, *optional*):
-            The current sequence length. Unused for this type of RoPE.
-    Returns:
-        Tuple of (`torch.Tensor`, `float`), containing the inverse frequencies for the RoPE embeddings and the
-        post-processing scaling factor applied to the computed cos/sin (unused in this type of RoPE).
-    """
-    base = config.rope_theta
-    partial_rotary_factor = config.partial_rotary_factor if hasattr(
-        config, "partial_rotary_factor") else 1.0
-    dim = int((config.hidden_size // config.num_attention_heads) *
-              partial_rotary_factor)
-
-    attention_factor = 1.0  # Unused in this type of RoPE
-
-    # Compute the inverse frequencies
-    inv_freq = 1.0 / (base**(
-        torch.arange(0, dim, 2, dtype=torch.int64).float().to(device) / dim))
-    return inv_freq, attention_factor
-
-
-def compute_llama3_parameters(
-        config: LlamaConfig,
-        device: "torch.device") -> "Tuple[torch.Tensor, float]":
-    """
-    Computes the inverse frequencies for llama 3.1.
-
-    Args:
-        config ([`~transformers.PretrainedConfig`]):
-            The model configuration.
-        device (`torch.device`):
-            The device to use for initialization of the inverse frequencies.
-    Returns:
-        Tuple of (`torch.Tensor`, `float`), containing the inverse frequencies for the RoPE embeddings and the
-        post-processing scaling factor applied to the computed cos/sin.
-    """
-    # Gets the default RoPE parameters
-    inv_freq, attention_factor = compute_default_rope_parameters(config, device)
-
-    factor: int = config.rope_scaling[
-        "factor"]  # `8` in the original implementation
-    low_freq_factor: int = config.rope_scaling[
-        "low_freq_factor"]  # `1` in the original implementation
-    high_freq_factor: int = config.rope_scaling[
-        "high_freq_factor"]  # `4` in the original implementation
-    old_context_len: int = config.rope_scaling[
-        "original_max_position_embeddings"]  # `8192` in the original implementation
-
-    low_freq_wavelen = old_context_len / low_freq_factor
-    high_freq_wavelen = old_context_len / high_freq_factor
-
-    wavelen = 2 * math.pi / inv_freq
-    # wavelen < high_freq_wavelen: do nothing
-    # wavelen > low_freq_wavelen: divide by factor
-    inv_freq_llama = torch.where(wavelen > low_freq_wavelen, inv_freq / factor,
-                                 inv_freq)
-    # otherwise: interpolate between the two, using a smooth factor
-    smooth_factor = (old_context_len / wavelen -
-                     low_freq_factor) / (high_freq_factor - low_freq_factor)
-    smoothed_inv_freq = (
-        1 - smooth_factor
-    ) * inv_freq_llama / factor + smooth_factor * inv_freq_llama
-    is_medium_freq = ~(wavelen < high_freq_wavelen) * ~(wavelen
-                                                        > low_freq_wavelen)
-    inv_freq_llama = torch.where(is_medium_freq, smoothed_inv_freq,
-                                 inv_freq_llama)
-
-    return inv_freq_llama, attention_factor
+from ..attention_backend import IS_FLASHINFER_AVAIABLE
+from ..attention_backend.interface import RopeParams
 
 
 class RotaryEmbedding(nn.Module):
 
     def __init__(
         self,
-        config: PretrainedConfig,
+        rope_params: RopeParams,
         *,
         head_dim: int,
-        num_attention_heads: int,
-        max_position_embeddings: int,
-        device: Optional[torch.device] = None,
-        rope_type: Literal['default', 'llama3'] = "default",
+        is_neox: bool = True,
     ):
         super().__init__()
-        self.config = config
+        self.rope_params = rope_params
         self.head_dim = head_dim
-        self.num_attention_heads = num_attention_heads
-        self.rope_type = rope_type
-        self.max_seq_len_cached = max_position_embeddings
-        self.original_max_seq_len = max_position_embeddings
-
-        rope_init_fn = compute_llama3_parameters if rope_type == "llama3" else compute_default_rope_parameters
-
-        inv_freq, self.attention_scaling = rope_init_fn(config, device)
-        self.register_buffer("inv_freq", inv_freq, persistent=False)
-        self.original_inv_freq = self.inv_freq
-
-        rope_percentage = (getattr(config, 'rotary_pct', None)
-                           or getattr(config, 'partial_rotary_factor', None)
-                           or 1.0)
-        self.rotary_dim = (getattr(config, 'rotary_dim', None)
-                           or getattr(config, 'rotary_emb_base', None)
-                           or int(head_dim * rope_percentage))
+        self.is_neox = is_neox
+        self.max_positions = rope_params.max_positions
+        self.rotary_cos_sin = rope_params.create_rope_const_params(
+            interleave=False)[1].reshape(rope_params.max_positions, 2, -1)
 
     def forward(
         self,
         position_ids: torch.Tensor,
         targets: List[torch.Tensor],
-        attn_metadata: Optional[AttentionMetadata] = None
     ) -> List[torch.Tensor]:
         """
         Apply RoPE to any number of target tensors with the same position_ids.
         This is useful if q_len = k_len, in which case we may RoPE q and k with the same cos and sin values.
         However, if k is cached without positional embedding, we need to apply rope to q and k with different values, so we need a separate call for each.
         """
-        if IS_FLASHINFER_AVAIABLE:
-            from ..attention_backend import FlashInferAttentionMetadata
-            if attn_metadata is not None:
-                from ..attention_backend import (FlashInferAttentionMetadata,
-                                                 StarAttentionMetadata)
-                if isinstance(attn_metadata, StarAttentionMetadata):
-                    pass
-                elif isinstance(attn_metadata, FlashInferAttentionMetadata):
-                    from ..custom_ops import flashinfer_apply_rope_inplace
-                    assert len(targets) == 2
-                    q = targets[0]
-                    seq_len = q.size()[0]
-                    q = targets[0].view(seq_len, -1, self.head_dim)
-                    k = targets[1].view(seq_len, -1, self.head_dim)
-                    rope_theta = self.config.rope_theta
-                    if self.rope_type in ['default', 'llama3']:
-                        flashinfer_apply_rope_inplace(
-                            q,
-                            k,
-                            attn_metadata.qo_indptr,
-                            attn_metadata.cached_token_lens,
-                            rope_theta=rope_theta,
-                            rotary_dim=self.rotary_dim)
-                    else:
-                        # TODO(qijun): support apply_llama31_rope_inplace
-                        raise ValueError(
-                            f'unsupported rope type {self.rope_type}')
-                        # rope_scale = self.config.rope_scaling
-                        # flashinfer.apply_llama31_rope_inplace(
-                        #     q,
-                        #     k,
-                        #     attn_metadata.qo_indptr,
-                        #     attn_metadata.cached_token_lens,
-                        #     rope_theta=rope_theta,
-                        #     rope_scale=rope_scale["factor"],
-                        #     low_freq_factor=rope_scale["low_freq_factor"],
-                        #     high_freq_factor=rope_scale["high_freq_factor"],
-                        #     old_context_len=rope_scale[
-                        #         "original_max_position_embeddings"],
-                        # )
-
-                    q = q.view(seq_len, -1)
-                    k = k.view(seq_len, -1)
-                    return [q, k]
+        if IS_FLASHINFER_AVAIABLE and len(targets) == 2:
+            from ..custom_ops import \
+                flashinfer_apply_rope_with_cos_sin_cache_inplace
+            q = targets[0]
+            k = targets[1]
+            flashinfer_apply_rope_with_cos_sin_cache_inplace(
+                position_ids.view(-1),
+                q,
+                k,
+                self.head_dim,
+                self.rotary_cos_sin.view(self.max_positions, -1),
+                self.is_neox,
+            )
+            return [q, k]
 
         # it is assumed all targets are of the same rank
         q_or_k = targets[0]
         remove_input_padding = (len(q_or_k.size()) == 2)
 
-        # Core RoPE block
-        inv_freq_expanded = self.inv_freq[None, :, None].float().expand(
-            position_ids.shape[0], -1, 1)
-        position_ids_expanded = position_ids[:, None, :].float()
-        # Force float32 (see https://github.com/huggingface/transformers/pull/29285)
-        device_type = q_or_k.device.type
-        device_type = device_type if isinstance(
-            device_type, str) and device_type != "mps" else "cpu"
-        with torch.autocast(device_type=device_type, enabled=False):
-            freqs = (inv_freq_expanded.float()
-                     @ position_ids_expanded.float()).transpose(1, 2)
-            emb = torch.cat((freqs, freqs), dim=-1)
-            cos = emb.cos()
-            sin = emb.sin()
-
-        # Advanced RoPE types (e.g. yarn) apply a post-processing scaling factor, equivalent to scaling attention
-        cos = cos * self.attention_scaling
-        sin = sin * self.attention_scaling
-
-        cos = cos.to(dtype=q_or_k.dtype)
-        sin = sin.to(dtype=q_or_k.dtype)
+        cos_sin = self.rotary_cos_sin[position_ids.view(-1)]
+        cos, sin = cos_sin[:, 0, :], cos_sin[:, 1, :]
+        cos = cos.to(dtype=q_or_k.dtype).unsqueeze(0)
+        sin = sin.to(dtype=q_or_k.dtype).unsqueeze(0)
 
         if remove_input_padding:
             bsz = 1
@@ -212,7 +67,10 @@ class RotaryEmbedding(nn.Module):
         def rope_target(target):
             target = target.view(bsz, seq_len, -1,
                                  self.head_dim).transpose(1, 2)
-            target = RotaryEmbedding.apply_rotary_pos_emb(target, cos, sin)
+            target = RotaryEmbedding.apply_rotary_pos_emb(target,
+                                                          cos,
+                                                          sin,
+                                                          is_neox=self.is_neox)
             target = target.transpose(1, 2).contiguous()
             if remove_input_padding:
                 target = target.view(seq_len, -1)
@@ -226,7 +84,8 @@ class RotaryEmbedding(nn.Module):
     def apply_rotary_pos_emb(q_or_k: torch.Tensor,
                              cos: torch.Tensor,
                              sin: torch.Tensor,
-                             unsqueeze_dim: int = 1) -> torch.Tensor:
+                             unsqueeze_dim: int = 1,
+                             is_neox: bool = True) -> torch.Tensor:
         """Applies Rotary Position Embedding to the query and key tensors.
 
         Args:
@@ -240,22 +99,29 @@ class RotaryEmbedding(nn.Module):
                 k have the shape [batch_size, heads, seq_len, head_dim], then setting unsqueeze_dim=1 makes
                 cos[position_ids] and sin[position_ids] broadcastable to the shapes of q and k. Similarly, if q and k have
                 the shape [batch_size, seq_len, heads, head_dim], then set unsqueeze_dim=2.
+            is_neox (bool): Whether to use Neox style RoPE, True by default.
         Returns:
             `tuple(torch.Tensor)` comprising of the query and key tensors rotated using the Rotary Position Embedding.
         """
         cos = cos.unsqueeze(unsqueeze_dim)
         sin = sin.unsqueeze(unsqueeze_dim)
 
-        rot_dim = cos.shape[-1]
+        rot_dim = cos.shape[-1] * 2
         # If q_or_k_pass is empty, rotary pos embedding is applied to all tensor
         q_or_k, q_or_k_pass = q_or_k[..., :rot_dim], q_or_k[..., rot_dim:]
 
-        embed = (q_or_k * cos) + (RotaryEmbedding.rotate_half(q_or_k) * sin)
-        return torch.cat((embed, q_or_k_pass), dim=-1)
+        if is_neox:
+            x1 = q_or_k[..., :q_or_k.shape[-1] // 2]
+            x2 = q_or_k[..., q_or_k.shape[-1] // 2:]
+        else:
+            x1 = q_or_k[..., ::2]
+            x2 = q_or_k[..., 1::2]
 
-    @staticmethod
-    def rotate_half(x: torch.Tensor) -> torch.Tensor:
-        """Rotates half the hidden dims of the input."""
-        x1 = x[..., :x.shape[-1] // 2]
-        x2 = x[..., x.shape[-1] // 2:]
-        return torch.cat((-x2, x1), dim=-1)
+        o1 = x1 * cos - x2 * sin
+        o2 = x2 * cos + x1 * sin
+
+        if is_neox:
+            return torch.cat((o1, o2, q_or_k_pass), dim=-1)
+        else:
+            embed = torch.stack((o1, o2), dim=-1).flatten(-2)
+            return torch.cat((embed, q_or_k_pass), dim=-1)

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -11,7 +11,7 @@ import safetensors
 import torch
 
 import tensorrt_llm.bindings.internal.userbuffers as ub
-from tensorrt_llm._utils import nvtx_range
+from tensorrt_llm._utils import nvtx_range, release_gc
 from tensorrt_llm.bindings.executor import GuidedDecodingConfig
 from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
@@ -731,7 +731,8 @@ class PyTorchModelEngine(ModelEngine):
         if self.ub_buffers:
             for u in self.ub_buffers:
                 ub.ub_deallocate(u)
-        torch.cuda.empty_cache()
+        # Release model weights.
+        release_gc()
 
     def _load_model(self, checkpoint_dir: str, load_format: LoadFormat,
                     max_num_tokens: int, moe_max_num_tokens: int, **kwargs):

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -29,7 +29,7 @@ from ..models import AutoModelForCausalLM
 from ..models.modeling_utils import MetaInitMode, timing
 from ..pipeline_interface import PipelineInterface
 from ..speculative import SpecConfig, SpecMetadata, get_spec_metadata
-from ..utils import set_torch_compiling
+from ..utils import set_torch_compiling, with_model_extra_attrs
 from .config import LoadFormat, PyTorchConfig
 from .cuda_graph_runner import DecodingCUDAGraphRunner
 from .distributed import MPIDist
@@ -260,6 +260,9 @@ class PyTorchModelEngine(ModelEngine):
             max_num_tokens=max_num_tokens,
             moe_max_num_tokens=pytorch_backend_config.moe_max_num_tokens,
         )
+        # In case that some tests use stub models and override `_load_model`.
+        if not hasattr(self.model, 'extra_attrs'):
+            self.model.extra_attrs = {}
         if self.pytorch_backend_config.enable_layerwise_nvtx_marker:
             layerwise_nvtx_marker = LayerwiseNvtxMarker()
             module_prefix = 'Model'
@@ -1534,6 +1537,7 @@ class PyTorchModelEngine(ModelEngine):
                                            new_tensors_device)
 
     @torch.inference_mode()
+    @with_model_extra_attrs(lambda self: self.model.extra_attrs)
     def forward(self,
                 scheduled_requests: ScheduledRequests,
                 resource_manager: ResourceManager,
@@ -1647,9 +1651,10 @@ class PyTorchModelEngine(ModelEngine):
 
         # For simplicity, just return all the the logits if we have special gather_ids
         # from speculative decoding.
-        logits = self.model.forward(**inputs,
-                                    return_context_logits=gather_ids
-                                    is not None)
+        logits = self.model.forward(
+            **inputs,
+            return_context_logits=gather_ids is not None,
+        )
         if gather_ids is not None:
             return {'logits': logits[gather_ids]}
         else:

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -308,6 +308,7 @@ class PyExecutor:
         for manager in self.resource_manager.resource_managers.values():
             if manager:
                 manager.shutdown()
+        del self.model_engine
 
     def can_enqueue_requests(self) -> bool:
         """

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -293,6 +293,7 @@ class ExecutorBindingsProxy(GenerationExecutor):
 
         ready_signal = self.request_error_queue.get()
         if ready_signal != ExecutorBindingsProxy.READY_SIGNAL:
+            self.mpi_session.shutdown()
             raise ready_signal
 
     def _abort_all_requests(self):

--- a/tensorrt_llm/executor/utils.py
+++ b/tensorrt_llm/executor/utils.py
@@ -86,7 +86,7 @@ class ProcessPoolExecutorSession(MpiSession):
         return [future.result() for future in futures]
 
     def shutdown(self):
-        self.mpi_pool.shutdown(wait=False)
+        self.mpi_pool.shutdown(wait=True)
 
 
 class ExecutorResponseTensors(NamedTuple):

--- a/tensorrt_llm/functional.py
+++ b/tensorrt_llm/functional.py
@@ -4783,7 +4783,7 @@ class RopeEmbeddingUtils:
         return np.random.rand(dim).astype(dtype)
 
     @staticmethod
-    def create_sinusoidal_positions_for_deepseek_attention_plugin(
+    def create_sinusoidal_positions_yarn(
             num_pos: int,
             dim: int,
             base: int = 10000,

--- a/tensorrt_llm/layers/attention.py
+++ b/tensorrt_llm/layers/attention.py
@@ -1996,7 +1996,7 @@ class DeepseekV2Attention(Attention):
                 mscale = yarn_get_mscale(scaling_factor, mscale_all_dim)
                 self.q_scaling = 1.0 / (mscale * mscale)
 
-        embed_positions_for_gpt_attention = RopeEmbeddingUtils.create_sinusoidal_positions_for_deepseek_attention_plugin(
+        embed_positions_for_gpt_attention = RopeEmbeddingUtils.create_sinusoidal_positions_yarn(
             self.max_position_embeddings, self.qk_rope_head_dim,
             self.rotary_embedding_base, self.rotary_scaling["factor"],
             rotary_embedding_origin_max_position, rotary_embedding_beta_fast,

--- a/tensorrt_llm/llmapi/_perf_evaluator.py
+++ b/tensorrt_llm/llmapi/_perf_evaluator.py
@@ -208,6 +208,7 @@ class MemoryContinuousMonitorThread(threading.Thread):
 
     def stop(self):
         self._stop_event.set()
+        self.join()
 
 
 def get_host_memory_usage() -> float:

--- a/tensorrt_llm/llmapi/mpi_session.py
+++ b/tensorrt_llm/llmapi/mpi_session.py
@@ -122,7 +122,7 @@ class MpiPoolSession(MpiSession):
 
     def shutdown(self):
         if self.mpi_pool is not None:
-            self.mpi_pool.shutdown(wait=False)
+            self.mpi_pool.shutdown(wait=True)
             self.mpi_pool = None
 
     def _start_mpi_pool(self):
@@ -200,8 +200,11 @@ class MpiCommSession(MpiSession):
 
     def shutdown(self):
         if self.mpi_pool is not None:
-            self.mpi_pool.shutdown(wait=False)
+            self.mpi_pool.shutdown(wait=True)
             self.mpi_pool = None
+        if self.thread_pool is not None:
+            self.thread_pool.shutdown(wait=True)
+            self.thread_pool = None
 
     def _start_mpi_pool(self):
         assert not self.mpi_pool, 'MPI session already started'

--- a/tests/integration/defs/conftest.py
+++ b/tests/integration/defs/conftest.py
@@ -29,6 +29,7 @@ from pathlib import Path
 import defs.ci_profiler
 import psutil
 import pytest
+import tqdm
 import yaml
 
 from tensorrt_llm.bindings import ipc_nvls_supported
@@ -2091,6 +2092,11 @@ def pytest_collection_modifyitems(session, config, items):
     for item in items:
         if test_prefix:
             item._nodeid = f"{test_prefix}/{item._nodeid}"
+
+
+def pytest_configure(config):
+    # avoid thread leak of tqdm's TMonitor
+    tqdm.tqdm.monitor_interval = 0
 
 
 def deselect_by_regex(regexp, items, test_prefix, config):

--- a/tests/integration/defs/examples/test_mistral.py
+++ b/tests/integration/defs/examples/test_mistral.py
@@ -797,8 +797,6 @@ def test_llm_mistral_quantization_4gpus_llmapi(llama_example_root,
             "AI agent" in generated_text
         ), "Generated text should start with either 'Assistant' or 'AI agent'"
 
-    del llm
-
     threshold = 55 if 'int4' in quant else 60
 
     mmlu_cmd = [

--- a/tests/integration/defs/pytest.ini
+++ b/tests/integration/defs/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+threadleak = True
 junit_family=legacy
 addopts = --ignore-glob="*perf/test_perf.py"  --ignore-glob="*test_list_validation.py"  --ignore-glob="*llm-test-workspace*"  --durations=0 -W ignore::DeprecationWarning
 markers =

--- a/tests/integration/defs/test_e2e.py
+++ b/tests/integration/defs/test_e2e.py
@@ -1087,7 +1087,6 @@ def test_llmapi_load_engine_from_build_command_with_lora(
 ])
 def test_llmapi_build_command_parameters_align(llm_root, llm_venv, engine_dir,
                                                model_name, model_path):
-    from tensorrt_llm._utils import release_gc
     from tensorrt_llm.llmapi import LLM
     from tensorrt_llm.llmapi.llm_utils import BuildConfig
     llama_example_root = os.path.join(llm_root, "examples", model_name)
@@ -1146,8 +1145,6 @@ def test_llmapi_build_command_parameters_align(llm_root, llm_venv, engine_dir,
             llm_api_engine_cfg["build_config"]).to_dict()
 
     assert build_cmd_cfg == build_llmapi_cfg
-    del LLM
-    release_gc()
 
 
 def test_llmapi_load_ckpt_from_convert_command(llm_root, llm_venv, engine_dir):

--- a/tests/unittest/_torch/modeling/test_modeling_out_of_tree.py
+++ b/tests/unittest/_torch/modeling/test_modeling_out_of_tree.py
@@ -57,7 +57,8 @@ class TestOutOfTree(unittest.TestCase):
         ]
 
         sampling_params = SamplingParams(max_tokens=10)
-        outputs = llm.generate(prompts, sampling_params=sampling_params)
+        with llm:
+            outputs = llm.generate(prompts, sampling_params=sampling_params)
 
         for output, ref in zip(outputs, references):
             assert similar(output.outputs[0].text, ref)

--- a/tests/unittest/_torch/modeling/test_modeling_vila.py
+++ b/tests/unittest/_torch/modeling/test_modeling_vila.py
@@ -1,7 +1,6 @@
 import unittest
 from copy import deepcopy
 from typing import Any
-from unittest.mock import patch
 
 import torch
 from parameterized import parameterized
@@ -279,11 +278,6 @@ def reduce_vila_config(mem_for_full_model: int, config_dict: dict[str, Any]):
 class TestVila(unittest.TestCase):
 
     @parameterized.expand([None])
-    # rms_norm in flashinfer needs the following fix to work
-    # https://github.com/flashinfer-ai/flashinfer/pull/646
-    # temporarily disable it for testing
-    @patch('tensorrt_llm._torch.modules.rms_norm.IS_FLASHINFER_AVAIABLE',
-           new=False)
     def test_vila_sanity(self, quant_algo):
         config_dict = deepcopy(VILA_1_5_3B_CONFIG)
         mem_for_full_model = (2 + 1) * 3 * 2**(30)

--- a/tests/unittest/_torch/multi_gpu_modeling/test_deepseek.py
+++ b/tests/unittest/_torch/multi_gpu_modeling/test_deepseek.py
@@ -332,3 +332,4 @@ def test_deepseek_streaming(model_name, backend, quant, tp_size):
                            1.0), f"Expected '{expected}' but get '{result}'"
 
     asyncio.run(test())
+    llm.shutdown()

--- a/tests/unittest/_torch/speculative/test_eagle3.py
+++ b/tests/unittest/_torch/speculative/test_eagle3.py
@@ -66,14 +66,15 @@ def test_llama_eagle3():
     ]
     results_spec = llm_spec.generate(prompts, sampling_params)
     generated_text_spec = [result.outputs[0].text for result in results_spec]
+    llm_spec.shutdown()
 
-    del llm_spec
     llm_ref = LLM(model=target_model_dir,
                   pytorch_backend_config=pytorch_config,
                   kv_cache_config=kv_cache_config)
 
     results_ref = llm_ref.generate(prompts, sampling_params)
     generated_text_ref = [result.outputs[0].text for result in results_ref]
+    llm_ref.shutdown()
 
     for text_spec, text_ref in zip(generated_text_spec, generated_text_ref):
         # The spec decode algorithm currently guarantees identical results

--- a/tests/unittest/_torch/test_attention.py
+++ b/tests/unittest/_torch/test_attention.py
@@ -516,6 +516,10 @@ def test_attention_backend(s: Scenario):
         },
     )
 
+    del flashinfer_kv_cache
+    del ref_kv_cache
+    torch.cuda.empty_cache()
+
 
 def generate_causal_mask(seq_lens, qo_lens, batch_size, dtype):
     causal_masks = []
@@ -696,6 +700,11 @@ def test_attention_backend_ifb(s: PagedScenario):
                               vanilla_outputs[i],
                               atol=fp8_atol if is_fp8 else atol,
                               rtol=rtol)
+
+    del flashinfer_kv_cache
+    del ref_kv_cache
+    del vanilla_kv_cache
+    torch.cuda.empty_cache()
 
 
 if __name__ == "__main__":

--- a/tests/unittest/_torch/test_flashinfer_attention.py
+++ b/tests/unittest/_torch/test_flashinfer_attention.py
@@ -132,6 +132,7 @@ class TestFlashInferAttention(unittest.TestCase):
             buf = kv_cache_manager.get_buffers(i)
             if buf is not None:
                 torch.nn.init.normal_(buf)
+                del buf
 
         if isinstance(num_kv_heads, int):
             num_kv_heads = [num_kv_heads] * num_layers
@@ -268,6 +269,7 @@ class TestFlashInferAttention(unittest.TestCase):
                     gen_vs[gen_seq_id].view(-1, num_kv_heads, head_dim))
 
             results_1.append(result_1)
+            del cache_buf
 
         for plan_params in attn_metadata._plan_params_to_wrappers.keys():
             self.assertEqual(attn_metadata.get_num_plans(plan_params), 1)

--- a/tests/unittest/_torch/test_flashinfer_star_attn.py
+++ b/tests/unittest/_torch/test_flashinfer_star_attn.py
@@ -181,6 +181,7 @@ class TestStarAttention(unittest.TestCase):
             buf = kv_cache_manager.get_buffers(i)
             if buf is not None:
                 torch.nn.init.normal_(buf)
+            del buf
 
         if isinstance(num_kv_heads, int):
             num_kv_heads = [num_kv_heads] * num_layers
@@ -375,6 +376,7 @@ class TestStarAttention(unittest.TestCase):
                     gen_vs[gen_seq_id].view(-1, num_kv_heads, head_dim))
 
             results_1.append(result_1)
+            del cache_buf
 
         for plan_params in attn_metadata._plan_params_to_wrappers.keys():
             self.assertEqual(attn_metadata.get_num_plans(plan_params), 1)

--- a/tests/unittest/_torch/test_overlap_scheduler.py
+++ b/tests/unittest/_torch/test_overlap_scheduler.py
@@ -64,7 +64,7 @@ def test_overlap_scheduler_consistency(model_path, test_case):
     texts_with_overlap = [[
         completion.text for completion in request_output.outputs
     ] for request_output in outputs_with_overlap]
-    del llm
+    llm.shutdown()
 
     # Test with overlap scheduler disabled
     llm = create_llm(model_path, enable_overlap_scheduler=False)
@@ -74,7 +74,7 @@ def test_overlap_scheduler_consistency(model_path, test_case):
     texts_without_overlap = [[
         completion.text for completion in request_output.outputs
     ] for request_output in outputs_without_overlap]
-    del llm
+    llm.shutdown()
 
     # Verify outputs are consistent
     for with_overlap, without_overlap in zip(texts_with_overlap,

--- a/tests/unittest/_torch/test_pytorch_model_engine.py
+++ b/tests/unittest/_torch/test_pytorch_model_engine.py
@@ -256,6 +256,8 @@ class PyTorchModelEngineTestCase(unittest.TestCase):
                                    atol=0,
                                    rtol=0)
 
+        kv_cache_manager.shutdown()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unittest/_torch/test_vanilla_attention.py
+++ b/tests/unittest/_torch/test_vanilla_attention.py
@@ -113,6 +113,7 @@ class TestVanillaAttention(unittest.TestCase):
             buf = kv_cache_manager.get_buffers(i)
             if buf is not None:
                 torch.nn.init.normal_(buf)
+                del buf
 
         vanilla_attn = VanillaAttention(layer_idx=0,
                                         num_heads=num_heads,

--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -14,6 +14,12 @@
 # limitations under the License.
 # # Force resource release after test
 import pytest
+import tqdm
+
+
+def pytest_configure(config):
+    # avoid thread leak of tqdm's TMonitor
+    tqdm.tqdm.monitor_interval = 0
 
 
 @pytest.hookimpl(wrapper=True)

--- a/tests/unittest/llmapi/apps/_test_llm_chat.py
+++ b/tests/unittest/llmapi/apps/_test_llm_chat.py
@@ -27,3 +27,4 @@ def test_interactive_console(interactive_console):
     assert console.history[0]['role'] == 'user'
     assert console.history[1]['role'] == 'assistant'
     assert console.history[1]['content']  # reply not empty
+    console.llm.shutdown()

--- a/tests/unittest/llmapi/apps/_test_llm_server.py
+++ b/tests/unittest/llmapi/apps/_test_llm_server.py
@@ -9,6 +9,8 @@ import tensorrt_llm.profiler as profiler
 
 from ..test_llm import llama_model_path
 
+pytestmark = pytest.mark.threadleak(enabled=False)
+
 
 @pytest.fixture(scope="module")
 def client():
@@ -22,8 +24,7 @@ def client():
     client = TestClient(app_instance.app)
     yield client
 
-    del llm
-    del app_instance.llm
+    llm.shutdown()
 
 
 def test_health(client):

--- a/tests/unittest/llmapi/apps/_test_openai_chat.py
+++ b/tests/unittest/llmapi/apps/_test_openai_chat.py
@@ -12,6 +12,8 @@ import yaml
 from ..test_llm import get_model_path
 from .openai_server import RemoteOpenAIServer
 
+pytestmark = pytest.mark.threadleak(enabled=False)
+
 
 @pytest.fixture(scope="module", ids=["TinyLlama-1.1B-Chat"])
 def model_name():

--- a/tests/unittest/llmapi/apps/_test_openai_consistent_chat.py
+++ b/tests/unittest/llmapi/apps/_test_openai_consistent_chat.py
@@ -57,8 +57,8 @@ def build_engine(model_name, request):
               build_config=build_config)
 
     engine_dir = TemporaryDirectory(suffix="-engine_dir")
-    llm.save(engine_dir.name)
-    del llm
+    with llm:
+        llm.save(engine_dir.name)
 
     yield engine_dir.name
 

--- a/tests/unittest/llmapi/apps/_test_openai_metrics.py
+++ b/tests/unittest/llmapi/apps/_test_openai_metrics.py
@@ -33,8 +33,7 @@ def client():
     client = TestClient(app_instance.app)
     yield client
 
-    del llm
-    del app_instance.llm
+    llm.shutdown()
 
 
 def test_health(client):

--- a/tests/unittest/llmapi/apps/_test_openai_multi_chat.py
+++ b/tests/unittest/llmapi/apps/_test_openai_multi_chat.py
@@ -54,8 +54,8 @@ def engine_from_fp8_quantization(model_name):
               build_config=build_config)
 
     engine_dir = TemporaryDirectory(suffix="-engine_dir")
-    llm.save(engine_dir.name)
-    del llm
+    with llm:
+        llm.save(engine_dir.name)
 
     yield engine_dir.name
 

--- a/tests/unittest/llmapi/test_executor.py
+++ b/tests/unittest/llmapi/test_executor.py
@@ -41,7 +41,8 @@ def llama_7b_path(engine_path: Path) -> Path:
     if not path.exists():
         model_dir = str(llm_models_root() / "llama-models/llama-7b-hf")
         llm = LLM(model_dir)
-        llm.save(str(path))
+        with llm:
+            llm.save(str(path))
 
     return path
 
@@ -56,7 +57,8 @@ def llama_7b_bs2_path(engine_path: Path) -> Path:
         build_config.max_beam_width = 2
         # TODO[chunweiy]: switch to executor backend
         llm = LLM(model_dir, build_config=build_config)
-        llm.save(str(path))
+        with llm:
+            llm.save(str(path))
 
     return path
 
@@ -68,7 +70,8 @@ def llama_7b_tp2_path(engine_path: Path) -> Path:
     if not path.exists():
         model_dir = str(llm_models_root() / "llama-models/llama-7b-hf")
         llm = LLM(model_dir, tensor_parallel_size=2)
-        llm.save(str(path))
+        with llm:
+            llm.save(str(path))
 
     return path
 
@@ -347,6 +350,8 @@ def test_ZeroMqQueue_sync_async():
         push_pipe.put(i)
 
     assert res.result() == 45
+    pool.shutdown()
+    push_pipe.close()
 
 
 Input = PostprocWorker.Input
@@ -413,6 +418,10 @@ def test_ResponsePostprocessWorker():
 
     input_pipe.put(None)  # tell worker to shutdown
     fut.result()
+
+    pool.shutdown()
+    input_pipe.close()
+    out_pipe.close()
 
 
 if __name__ == '__main__':

--- a/tests/unittest/llmapi/test_llm.py
+++ b/tests/unittest/llmapi/test_llm.py
@@ -44,6 +44,8 @@ from utils.util import force_ampere, similar, skip_gpu_memory_less_than_40gb, sk
 # There are other tests based on llama-7B model, such as the end-to-end tests in test_e2e.py, and parallel tests in
 # test_llm_multi_gpu.py.
 
+pytestmark = pytest.mark.threadleak(enabled=False)
+
 
 def get_model_path(model_name):
     engine_dir = os.environ.get('LLM_ENGINE_DIR', None)
@@ -511,7 +513,7 @@ def _test_llm_generate_async(model_name=default_model_name,
 
 
 @pytest.fixture(scope="module")
-def llm_for_sampling_params() -> LLM:
+def llm_for_sampling_params():
     build_config = BuildConfig(max_beam_width=3)
     llm = LLM(
         model=llama_model_path,
@@ -519,7 +521,8 @@ def llm_for_sampling_params() -> LLM:
         kv_cache_config=global_kvcache_config,
         fast_build=True,
     )
-    return llm
+    yield llm
+    llm.shutdown()
 
 
 @pytest.mark.part0

--- a/tests/unittest/llmapi/test_llm_download.py
+++ b/tests/unittest/llmapi/test_llm_download.py
@@ -15,12 +15,14 @@ def test_llm_with_model_downloaded():
     llm = LLM(model=model_name, enable_build_cache=True)
     for output in llm.generate(prompts):
         print(output)
+    llm.shutdown()
 
 
 def test_llm_with_tokenizer_downloaded():
     llm = LLM(model=llama_model_path, tokenizer=model_name)
     for output in llm.generate(prompts):
         print(output)
+    llm.shutdown()
 
 
 def test_download_config():

--- a/tests/unittest/llmapi/test_llm_kv_cache_events.py
+++ b/tests/unittest/llmapi/test_llm_kv_cache_events.py
@@ -119,6 +119,7 @@ def test_expected_kv_cache_events():
                 assert event[0]["data"]["type"] == "created"
             elif event[0]["event_id"] == 1:
                 assert event[0]["data"]["type"] == "stored"
+    llm.shutdown()
 
 
 @pytest.mark.skip("https://nvbugs/5150466: flaky fail")
@@ -147,6 +148,7 @@ def test_kv_cache_event_async_api():
             await asyncio.gather(task0(), task1())
 
     asyncio.run(main())
+    llm.shutdown()
 
 
 def test_llm_kv_events_api():
@@ -207,3 +209,5 @@ def test_llm_kv_events_api():
 
     # no more events after request is finished
     assert not llm.get_kv_cache_events(5)
+
+    llm.shutdown()

--- a/tests/unittest/llmapi/test_llm_quant.py
+++ b/tests/unittest/llmapi/test_llm_quant.py
@@ -23,6 +23,7 @@ def test_llm_int4_awq_quantization():
     for output in llm.generate(["A B C"], sampling_params=sampling_params):
         print(output)
         assert output.outputs[0].text == "D E F G H I"
+    llm.shutdown()
 
 
 @skip_pre_hopper
@@ -39,6 +40,7 @@ def test_llm_fp8_quantization():
     for output in llm.generate(["A B C"], sampling_params=sampling_params):
         print(output)
         assert output.outputs[0].text == "D E F G H I"
+    llm.shutdown()
 
 
 @skip_pre_blackwell
@@ -55,6 +57,7 @@ def test_llm_nvfp4_quantization():
     for output in llm.generate(["A B C"], sampling_params=sampling_params):
         print(output)
         assert output.outputs[0].text == "D E F G H I"
+    llm.shutdown()
 
 
 @skip_pre_hopper
@@ -68,6 +71,7 @@ def test_llm_fp8_quantization_modelOpt_ckpt():
     for output in llm.generate(["A B C"], sampling_params=sampling_params):
         print(output)
         assert output.outputs[0].text == " D E F G H I"
+    llm.shutdown()
 
 
 if __name__ == "__main__":

--- a/tests/unittest/pytest.ini
+++ b/tests/unittest/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+threadleak = True
 addopts = --durations=0 -W ignore::DeprecationWarning
 pythonpath =
     _torch/auto_deploy/_utils_test


### PR DESCRIPTION
This MR contains the following updates:

1. Handle `fuse_pos_embd=True/False` and create `RotaryEmbedding` inside attention module, so that the users don't need to handle it in the modeling files.
2. Cache `cos_sin` for unfused rope implementation. If flashinfer is available, use `apply_rope_with_cos_sin_cache_inplace` instead of `apply_rope_inplace`. Otherwise, we fallback to pure pytorch implementation, which can support any rope now.
3. We use `create_rope_const_params` to create and cache `cos_sin_cache` for all rope types, including Deepseek yarn rope.