### PR TITLE
chore: add git lfs to build_wheel.py to avoid confusing error

### DIFF
--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -108,6 +108,11 @@ def main(*,
     if any(not (project_dir / submodule / ".git").exists()
            for submodule in submodules):
         build_run('git submodule update --init --recursive')
+
+    # Invoke git lfs automatically for downloading kernels
+    build_run('git lfs install')
+    build_run('git lfs pull')
+
     on_windows = platform.system() == "Windows"
     requirements_filename = "requirements-dev-windows.txt" if on_windows else "requirements-dev.txt"
     build_run(f"\"{sys.executable}\" -m pip install -r {requirements_filename}")


### PR DESCRIPTION
The current build_wheel.py assumes that the `git lfs pull` is invoked before, and with the existing command, it will report errors:
```
CMake Error at tensorrt_llm/CMakeLists.txt:224 (file):
  file SIZE requested of path that is not readable:

    /workspace/project/trtllm.main/cpp/tensorrt_llm/kernels/internal_cutlass_kernels/x86_64-linux-gnu/libtensorrt_llm_internal_cutlass_kernels_static.a


CMake Error: File /workspace/project/trtllm.main/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/nvrtcWrapper/x86_64-linux-gnu/libtensorrt_llm_nvrtc_wrapper.so does not exist.
CMake Error at tensorrt_llm/CMakeLists.txt:338 (configure_file):
  configure_file Problem configuring file


CMake Error at tensorrt_llm/CMakeLists.txt:351 (file):
  file SIZE requested of path that is not readable:

    /workspace/project/trtllm.main/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/nvrtcWrapper/x86_64-linux-gnu/libtensorrt_llm_nvrtc_wrapper.so
```

Ideally, the build_wheel.py should invoke git lfs operations automatically, just as it does with `git submodule`.

This MR adds the git lfs operations to avoid confusing errors with the existing usage.