### PR TITLE
feat: Add initial EAGLE-3 implementation

### DIFF
--- a/examples/pytorch/out_of_tree_example/modeling_opt.py
+++ b/examples/pytorch/out_of_tree_example/modeling_opt.py
@@ -197,6 +197,7 @@ class OPTModel(DecoderModel):
         input_ids: Optional[torch.LongTensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
+        **kwargs,
     ) -> torch.Tensor:
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError(

--- a/examples/pytorch/quickstart_advanced.py
+++ b/examples/pytorch/quickstart_advanced.py
@@ -4,7 +4,7 @@ from tensorrt_llm import SamplingParams
 from tensorrt_llm._torch import LLM
 from tensorrt_llm._torch.pyexecutor.config import PyTorchConfig
 from tensorrt_llm.bindings.executor import KvCacheConfig
-from tensorrt_llm.llmapi import MTPDecodingConfig
+from tensorrt_llm.llmapi import EagleDecodingConfig, MTPDecodingConfig
 
 example_prompts = [
     "Hello, my name is",
@@ -84,7 +84,10 @@ def add_llm_args(parser):
     parser.add_argument('--load_format', type=str, default='auto')
 
     # Speculative decoding
-    parser.add_argument('--mtp_nextn', type=int, default=0)
+    parser.add_argument('--spec_decode_algo', type=str, default=None)
+    parser.add_argument('--spec_decode_nextn', type=int, default=1)
+    parser.add_argument('--eagle_model_dir', type=str, default=None)
+
     return parser
 
 
@@ -111,8 +114,18 @@ def setup_llm(args):
         free_gpu_memory_fraction=args.kv_cache_fraction,
     )
 
-    mtp_config = MTPDecodingConfig(
-        num_nextn_predict_layers=args.mtp_nextn) if args.mtp_nextn > 0 else None
+    spec_decode_algo = args.spec_decode_algo.upper(
+    ) if args.spec_decode_algo is not None else None
+
+    if spec_decode_algo == 'MTP':
+        spec_config = MTPDecodingConfig(
+            num_nextn_predict_layers=args.spec_decode_nextn)
+    elif spec_decode_algo == "EAGLE3":
+        spec_config = EagleDecodingConfig(
+            max_draft_len=args.spec_decode_nextn,
+            pytorch_eagle_weights_path=args.eagle_model_dir)
+    else:
+        spec_config = None
 
     llm = LLM(model=args.model_dir,
               max_seq_len=args.max_seq_len,
@@ -126,7 +139,7 @@ def setup_llm(args):
               moe_expert_parallel_size=args.moe_ep_size,
               moe_tensor_parallel_size=args.moe_tp_size,
               enable_chunked_prefill=args.enable_chunked_prefill,
-              speculative_config=mtp_config)
+              speculative_config=spec_config)
 
     sampling_params = SamplingParams(
         max_tokens=args.max_tokens,

--- a/tensorrt_llm/_torch/attention_backend/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/interface.py
@@ -21,6 +21,7 @@ from ..pyexecutor.resource_manager import KVCacheManager
 class AttentionRuntimeFeatures:
     chunked_prefill: bool = False
     cache_reuse: bool = False
+    has_speculative_draft_tokens: bool = False
 
 
 @dataclass(kw_only=True)

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -630,8 +630,10 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
         )
         assert not metadata.is_cross, "TRT-LLM Attention does not support cross attention yet."
 
-        use_paged_context_fmha = (metadata.runtime_features.chunked_prefill
-                                  or metadata.runtime_features.cache_reuse)
+        use_paged_context_fmha = (
+            metadata.runtime_features.chunked_prefill
+            or metadata.runtime_features.cache_reuse
+            or metadata.runtime_features.has_speculative_draft_tokens)
 
         if use_paged_context_fmha and self.has_fp8_kv_cache:
             # NOTE: W4A8_AWQ can be included too, exclude for now since

--- a/tensorrt_llm/_torch/models/modeling_auto.py
+++ b/tensorrt_llm/_torch/models/modeling_auto.py
@@ -11,7 +11,14 @@ class AutoModelForCausalLM(Generic[TModel, TConfig]):
     def from_config(
         config: ModelConfig[TConfig],
     ) -> DecoderModelForCausalLM[TModel, TConfig]:
-        cls = MODEL_CLASS_MAPPING.get(config.pretrained_config.architectures[0])
+        model_arch = config.pretrained_config.architectures[0]
+        # Hack to detect eagle3 checkpoints. TODO: should we provide
+        # our own checkpoints with the correct arch? It would let us
+        # avoid nasty stuff like this.
+        if hasattr(config.pretrained_config, "draft_vocab_size"):
+            model_arch = "EAGLE3" + model_arch
+
+        cls = MODEL_CLASS_MAPPING.get(model_arch)
         if cls is None:
             raise ValueError(
                 f"Unknown architecture for AutoModelForCausalLM: {config.pretrained_config.architectures[0]}"

--- a/tensorrt_llm/_torch/models/modeling_llama.py
+++ b/tensorrt_llm/_torch/models/modeling_llama.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 import torch
 from torch import nn
@@ -14,8 +14,10 @@ from ..modules.attention import Attention
 from ..modules.decoder_layer import DecoderLayer
 from ..modules.embedding import Embedding
 from ..modules.gated_mlp import GatedMLP
+from ..modules.linear import Linear, WeightMode, WeightsLoadingConfig
 from ..modules.rms_norm import RMSNorm
 from ..modules.rotary_embedding import RotaryEmbedding
+from ..speculative import Eagle3SpecMetadata, SpecMetadata
 from .modeling_utils import (DecoderModel, DecoderModelForCausalLM,
                              register_auto_model, support_pp)
 
@@ -74,6 +76,8 @@ class LlamaDecoderLayer(DecoderLayer):
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         super().__init__()
         config = model_config.pretrained_config
+        self.layer_idx = layer_idx
+
         self.self_attn = LlamaAttention(
             model_config,
             layer_idx=layer_idx,
@@ -89,6 +93,7 @@ class LlamaDecoderLayer(DecoderLayer):
         self.input_layernorm = RMSNorm(hidden_size=config.hidden_size,
                                        eps=config.rms_norm_eps,
                                        dtype=config.torch_dtype)
+
         self.post_attention_layernorm = RMSNorm(hidden_size=config.hidden_size,
                                                 eps=config.rms_norm_eps,
                                                 dtype=config.torch_dtype)
@@ -99,6 +104,7 @@ class LlamaDecoderLayer(DecoderLayer):
         hidden_states: torch.Tensor,
         attn_metadata: AttentionMetadata,
         residual: Optional[torch.Tensor] = None,
+        spec_metadata: Optional[SpecMetadata] = None,
         **kwargs,
     ) -> torch.Tensor:
         if residual is None:
@@ -117,6 +123,107 @@ class LlamaDecoderLayer(DecoderLayer):
         )
 
         # Fully Connected
+        hidden_states, residual = self.post_attention_layernorm(
+            hidden_states, residual)
+        hidden_states = self.mlp(hidden_states)
+        if spec_metadata is not None:
+            spec_metadata.maybe_capture_hidden_states(self.layer_idx,
+                                                      hidden_states, residual)
+        return hidden_states, residual
+
+
+class Eagle3LlamaAttention(LlamaAttention):
+
+    def __init__(
+        self,
+        model_config: ModelConfig[LlamaConfig],
+        layer_idx: Optional[int] = None,
+    ):
+        super().__init__(model_config, layer_idx)
+
+        model_config = model_config or ModelConfig()
+        config = model_config.pretrained_config
+
+        tp_size = model_config.mapping.tp_size
+        tp_rank = model_config.mapping.tp_rank
+        gpus_per_node = model_config.mapping.gpus_per_node
+
+        # Override the QKV projection. The number of input features
+        # is twice as big for EAGLE3 draft models.
+        self.qkv_proj = Linear(
+            2 * self.hidden_size,
+            tp_size * self.q_size + 2 * tp_size * self.kv_size,
+            bias=config.attention_bias,
+            dtype=config.torch_dtype,
+            parallel_config=ParallelConfig(
+                tensor_parallel_size=tp_size,
+                tensor_parallel_rank=tp_rank,
+                tensor_parallel_mode=TensorParallelMode.COLUMN,
+                gpus_per_node=gpus_per_node,
+                pipeline_parallel_size=model_config.mapping.pp_size,
+                parallel_rank=model_config.mapping.rank),
+            weights_loading_config=WeightsLoadingConfig(
+                weight_mode=WeightMode.FUSED_QKV_LINEAR),
+            quant_config=model_config.get_quant_config(),
+            skip_create_weights=model_config.skip_create_weights,
+        )
+
+
+class Eagle3LlamaDecoderLayer(DecoderLayer):
+
+    def __init__(
+        self,
+        model_config: ModelConfig[LlamaConfig],
+        layer_idx: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        super().__init__()
+        config = model_config.pretrained_config
+        self.layer_idx = layer_idx
+
+        self.self_attn = Eagle3LlamaAttention(
+            model_config,
+            layer_idx=layer_idx,
+        )
+
+        self.mlp = GatedMLP(
+            hidden_size=config.hidden_size,
+            intermediate_size=config.intermediate_size,
+            bias=config.mlp_bias,
+            dtype=config.torch_dtype,
+            config=model_config,
+        )
+        self.input_layernorm = RMSNorm(hidden_size=config.hidden_size,
+                                       eps=config.rms_norm_eps,
+                                       dtype=config.torch_dtype)
+
+        self.hidden_norm = RMSNorm(hidden_size=config.hidden_size,
+                                   eps=config.rms_norm_eps,
+                                   dtype=config.torch_dtype)
+
+        self.post_attention_layernorm = RMSNorm(hidden_size=config.hidden_size,
+                                                eps=config.rms_norm_eps,
+                                                dtype=config.torch_dtype)
+
+    def forward(
+        self,
+        position_ids: torch.LongTensor,
+        embeds: torch.Tensor,
+        hidden_states: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+    ) -> torch.Tensor:
+        residual = hidden_states
+
+        embeds = self.input_layernorm(embeds)
+        hidden_states = self.hidden_norm(hidden_states)
+
+        hidden_states = torch.cat([embeds, hidden_states], dim=-1)
+
+        hidden_states = self.self_attn(
+            position_ids=position_ids,
+            hidden_states=hidden_states,
+            attn_metadata=attn_metadata,
+        )
+
         hidden_states, residual = self.post_attention_layernorm(
             hidden_states, residual)
         hidden_states = self.mlp(hidden_states)
@@ -161,6 +268,7 @@ class LlamaModel(DecoderModel):
         input_ids: Optional[torch.LongTensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
+        spec_metadata: Optional[SpecMetadata] = None,
     ) -> torch.Tensor:
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError(
@@ -177,7 +285,8 @@ class LlamaModel(DecoderModel):
             hidden_states, residual = decoder_layer(position_ids=position_ids,
                                                     hidden_states=hidden_states,
                                                     attn_metadata=attn_metadata,
-                                                    residual=residual)
+                                                    residual=residual,
+                                                    spec_metadata=spec_metadata)
 
         hidden_states, _ = self.norm(hidden_states, residual)
         return hidden_states
@@ -207,3 +316,123 @@ class MistralForCausalLM(DecoderModelForCausalLM[LlamaModel, LlamaConfig]):
                          config=model_config,
                          hidden_size=model_config.pretrained_config.hidden_size,
                          vocab_size=model_config.pretrained_config.vocab_size)
+
+
+class Eagle3LlamaDraftModel(DecoderModel):
+
+    def __init__(self, model_config: ModelConfig[LlamaConfig]) -> None:
+        super().__init__(model_config)
+
+        config = model_config.pretrained_config
+        self.dtype = config.torch_dtype
+
+        self.fc = Linear(config.hidden_size * 3,
+                         config.hidden_size,
+                         bias=False,
+                         dtype=config.torch_dtype)
+
+        self.midlayer = Eagle3LlamaDecoderLayer(model_config, 0)
+
+        self.norm = RMSNorm(hidden_size=config.hidden_size,
+                            eps=config.rms_norm_eps,
+                            dtype=config.torch_dtype)
+
+        self.d2t = nn.Parameter(torch.empty((config.draft_vocab_size, ),
+                                            dtype=torch.int64),
+                                requires_grad=False)
+
+    def forward(
+        self,
+        attn_metadata: AttentionMetadata,
+        embed_tokens: torch.nn.Module,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        spec_metadata: Optional[SpecMetadata] = None,
+        hidden_states: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError(
+                "You cannot specify both input_ids and inputs_embeds at the same time, and must specify either one"
+            )
+
+        if inputs_embeds is None:
+            inputs_embeds = embed_tokens(input_ids).to(self.dtype)
+
+        assert hidden_states is not None and len(hidden_states) > 0
+
+        if len(hidden_states) > 1:
+            hidden_states = torch.cat(hidden_states, dim=-1)
+            hidden_states = self.fc(hidden_states.to(self.dtype))
+        else:
+            hidden_states = hidden_states[0].to(self.dtype)
+
+        hidden_states, residual = self.midlayer(position_ids=position_ids,
+                                                embeds=inputs_embeds,
+                                                hidden_states=hidden_states,
+                                                attn_metadata=attn_metadata)
+
+        hidden_states, hidden_states_to_save = self.norm(
+            hidden_states, residual)
+        assert isinstance(spec_metadata, Eagle3SpecMetadata)
+        spec_metadata.hidden_states.append(hidden_states_to_save)
+        return hidden_states
+
+
+@register_auto_model("EAGLE3LlamaForCausalLM")
+class Eagle3LlamaForCausalLM(DecoderModelForCausalLM[Eagle3LlamaDraftModel,
+                                                     LlamaConfig]):
+
+    def __init__(
+        self,
+        model_config: ModelConfig[LlamaConfig],
+    ):
+        super().__init__(
+            Eagle3LlamaDraftModel(model_config),
+            config=model_config,
+            hidden_size=model_config.pretrained_config.hidden_size,
+            vocab_size=model_config.pretrained_config.draft_vocab_size)
+
+    def forward(
+        self,
+        attn_metadata: AttentionMetadata,
+        input_ids: torch.LongTensor = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        return_context_logits: bool = False,
+        spec_metadata: Optional[SpecMetadata] = None,
+        hidden_states: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        if "embed_tokens" not in kwargs:
+            raise ValueError(
+                "EAGLE3 checkpoints do not include embed_tokens. "
+                "The embed_tokens module from the target model therefore needs to "
+                "be passed explicitly via extra_model_inputs. NOTE: we can "
+                "get rid of this hack by providing our own custom checkpoint "
+                "format that includes embed_tokens.")
+
+        output = self.model(
+            input_ids=input_ids,
+            embed_tokens=kwargs['embed_tokens'],
+            attn_metadata=attn_metadata,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+            spec_metadata=spec_metadata,
+            hidden_states=hidden_states,
+        )
+
+        return self.logits_processor.forward(
+            output,
+            self.lm_head,
+            attn_metadata,
+            return_context_logits,
+        )
+
+    def load_weights(self, weights: Dict):
+        new_weights = {}
+        for k, v in weights.items():
+            new_k = "model." + k if 'lm_head' not in k and "embed_tokens" not in k else k
+            new_weights[new_k] = v
+
+        super().load_weights(new_weights)

--- a/tensorrt_llm/_torch/models/modeling_mamba_hybrid.py
+++ b/tensorrt_llm/_torch/models/modeling_mamba_hybrid.py
@@ -206,6 +206,7 @@ class MambaHybridModel(DecoderModel):
         input_ids: Optional[torch.LongTensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
+        **kwargs,
     ) -> torch.Tensor:
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError(

--- a/tensorrt_llm/_torch/models/modeling_mixtral.py
+++ b/tensorrt_llm/_torch/models/modeling_mixtral.py
@@ -211,6 +211,7 @@ class MixtralModel(DecoderModel):
         input_ids: Optional[torch.LongTensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
+        **kwargs,
     ) -> torch.Tensor:
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError(

--- a/tensorrt_llm/_torch/models/modeling_nemotron.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron.py
@@ -177,6 +177,7 @@ class NemotronModel(DecoderModel):
         input_ids: Optional[torch.LongTensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
+        **kwargs,
     ) -> torch.Tensor:
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError(

--- a/tensorrt_llm/_torch/models/modeling_qwen.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen.py
@@ -172,6 +172,7 @@ class QwenModel(DecoderModel):
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         mrope_config: Optional[Tuple[torch.Tensor, int]] = None,
+        **kwargs,
     ) -> torch.Tensor:
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError(

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -41,6 +41,7 @@ def check_flash_mla_config(config):
 
 def cal_max_tokens(peak_memory, total_gpu_memory, fraction, model_config,
                    mapping: Mapping):
+    # TODO: take space occupied by draft KV cache manager into account.
     mem_per_token = 2
     quant_config = model_config.quant_config
     if quant_config is not None and quant_config.quant_mode.has_fp8_kv_cache():

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -47,6 +47,7 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
         self.py_batch_idx = None
         self.py_rewind_len = 0
         self.py_draft_tokens = self.draft_tokens
+        self.py_last_draft_tokens = None
 
 
 def convert_wordlist(word_list) -> List[List[int]]:

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -210,6 +210,7 @@ class KVCacheManager(BaseResourceManager):
         self.kv_cache_pool_mapping = self.impl.get_layer_to_pool_mapping()
         self.num_pools = self.impl.num_pools
         self.max_blocks_per_seq = self.impl.max_blocks_per_seq
+        self.enable_block_reuse = kv_cache_config.enable_block_reuse
 
     def shutdown(self):
         self.impl.release_pools()

--- a/tensorrt_llm/_torch/speculative/__init__.py
+++ b/tensorrt_llm/_torch/speculative/__init__.py
@@ -1,3 +1,4 @@
+from .eagle3 import Eagle3Config, Eagle3SpecMetadata
 from .interface import SpecConfig, SpecMetadata
 from .mtp import MTPConfig, MTPEagleWorker, MTPSpecMetadata, MTPWorker
 from .utils import (get_num_spec_layers, get_spec_decoder, get_spec_metadata,
@@ -5,6 +6,7 @@ from .utils import (get_num_spec_layers, get_spec_decoder, get_spec_metadata,
 
 __all__ = [
     "SpecConfig", "SpecMetadata", "MTPConfig", "MTPWorker", "MTPEagleWorker",
-    "MTPSpecMetadata", "get_spec_metadata", "get_spec_resource_manager",
-    "get_spec_decoder", "get_num_spec_layers"
+    "Eagle3Config", "Eagle3SpecMetadata", "MTPSpecMetadata",
+    "get_spec_metadata", "get_spec_resource_manager", "get_spec_decoder",
+    "get_num_spec_layers"
 ]

--- a/tensorrt_llm/_torch/speculative/eagle3.py
+++ b/tensorrt_llm/_torch/speculative/eagle3.py
@@ -1,0 +1,105 @@
+from dataclasses import dataclass, field
+from itertools import chain
+from typing import Dict, List, Optional, Tuple
+
+import torch
+
+from ..pyexecutor.decoder import TorchDecoder
+from .interface import SpecConfig, SpecMetadata, SpeculativeDecodingMode
+
+
+@dataclass
+class Eagle3Config(SpecConfig):
+    spec_dec_name: str = "EAGLE3"
+    eagle_weights_path: Optional[str] = None
+    num_layers: int = 0
+
+    def __post_init__(self):
+        if self.eagle_weights_path is None:
+            raise ValueError("Path to EAGLE3 weights must be specified.")
+
+        self.spec_dec_mode = SpeculativeDecodingMode.from_string(
+            self.spec_dec_name)
+        self.num_extra_kv_tokens = 0
+
+    def update_from_model_config(self, model_config):
+        self.num_layers = model_config.num_hidden_layers
+
+    def get_draft_model_prompt(self,
+                               input_tokens: torch.Tensor) -> torch.Tensor:
+        """
+        Eagle3 always throws away the first token when processing draft inputs
+        """
+        return input_tokens[1:]
+
+
+@dataclass
+class Eagle3SpecMetadata(SpecMetadata):
+    hidden_states: List[torch.Tensor] = field(default_factory=list)
+    num_layers: int = 0
+    layers_to_capture: Tuple[int, ...] = field(init=False)
+    target_model_embed_tokens: Optional[torch.nn.Module] = None
+
+    def __post_init__(self):
+        if self.num_layers == 1:
+            # For the draft model, we have to capture hiddens states
+            # manually outside of the decoder layer.
+            self.layers_to_capture = ()
+        else:
+            if self.num_layers <= 5:
+                raise ValueError("Not enough hidden layers for EAGLE")
+
+            self.layers_to_capture = (1, self.num_layers // 2 - 1,
+                                      self.num_layers - 3)
+
+    def prepare(self):
+        self.hidden_states = []
+
+    def maybe_capture_hidden_states(self, layer_id: int,
+                                    hidden_states: torch.Tensor,
+                                    residual: torch.Tensor) -> None:
+        if layer_id in self.layers_to_capture:
+            # TODO(miovine): write directly into a pre-allocated buffer for
+            # CUDA graph support.
+            self.hidden_states.append(hidden_states + residual)
+
+    def get_hidden_states(
+            self,
+            scheduled_requests,
+            num_rejected_tokens: Optional[Dict] = None) -> List[torch.Tensor]:
+        req_id_to_gather_ids = {}
+        seq_start = 0
+        for req_id, seqlen in zip(self.request_ids, self.seq_lens):
+            if num_rejected_tokens is not None:
+                if req_id in num_rejected_tokens:
+                    req_id_to_gather_ids[req_id] = list(
+                        range(seq_start,
+                              seq_start + seqlen - num_rejected_tokens[req_id]))
+            else:
+                req_id_to_gather_ids[req_id] = [seq_start + seqlen - 1]
+
+            seq_start += seqlen
+
+        hidden_states_gather_ids = []
+        for req in chain(scheduled_requests.context_requests,
+                         scheduled_requests.generation_requests):
+            hidden_states_gather_ids.extend(
+                req_id_to_gather_ids[req.py_request_id])
+
+        return [h[hidden_states_gather_ids] for h in self.hidden_states]
+
+
+class Eagle3Decoder(TorchDecoder):
+
+    def _batch_decode(self, scheduled_requests, model_outputs):
+        logits = model_outputs["logits"]
+        new_tokens_device = torch.argmax(logits, dim=-1)
+        if "d2t" in model_outputs:
+            d2t = model_outputs["d2t"]
+            new_tokens_device = d2t[new_tokens_device] + new_tokens_device
+        new_tokens_host = new_tokens_device.to('cpu', non_blocking=True)
+        new_tensors_device = {"new_tokens_device": new_tokens_device}
+        new_tensors_host = {"new_tokens_host": new_tokens_host}
+        decoder_event = torch.cuda.Event()
+        decoder_event.record()
+        return new_tensors_device, new_tensors_host, decoder_event

--- a/tensorrt_llm/_torch/speculative/utils.py
+++ b/tensorrt_llm/_torch/speculative/utils.py
@@ -1,3 +1,4 @@
+from .eagle3 import Eagle3Decoder, Eagle3SpecMetadata
 from .mtp import MTPDecoder, MTPHiddenStatesManager, MTPSpecMetadata
 
 
@@ -11,6 +12,11 @@ def get_spec_metadata(spec_config,
             mtp_num_modules=spec_config.num_nextn_predict_layers,
             max_num_requests=max_num_requests,
             mtp_hidden_states_manager=spec_resource_manager)
+    elif spec_config.spec_dec_mode.is_eagle3():
+        return Eagle3SpecMetadata(max_draft_tokens=spec_config.max_draft_tokens,
+                                  spec_dec_mode=spec_config.spec_dec_mode,
+                                  max_num_requests=max_num_requests,
+                                  num_layers=spec_config.num_layers)
     else:
         return None
 
@@ -29,6 +35,8 @@ def get_spec_resource_manager(spec_config, model_config, max_num_requests):
 def get_spec_decoder(max_seq_len, spec_config):
     if spec_config.spec_dec_mode.is_mtp():
         return MTPDecoder(max_seq_len, spec_config)
+    if spec_config.spec_dec_mode.is_eagle3():
+        return Eagle3Decoder(max_seq_len)
     else:
         return None
 

--- a/tensorrt_llm/models/opt/model.py
+++ b/tensorrt_llm/models/opt/model.py
@@ -134,7 +134,8 @@ class OPTModel(Module):
                 attention_params=None,
                 prompt_embedding_table=None,
                 prompt_tasks=None,
-                prompt_vocab_size=None):
+                prompt_vocab_size=None,
+                **kwargs):
 
         args = [prompt_embedding_table, prompt_tasks, prompt_vocab_size
                 ] if prompt_embedding_table is not None else []

--- a/tests/integration/defs/test_e2e.py
+++ b/tests/integration/defs/test_e2e.py
@@ -1440,10 +1440,34 @@ def test_ptq_quickstart_advanced_mtp(llm_root, llm_venv, model_name,
         str(example_root / "quickstart_advanced.py"),
         "--enable_overlap_scheduler",
         "--use_cuda_graph",
-        "--mtp_nextn",
+        "--spec_decode_nextn",
         "1",  # test 1 MTP module
+        "--spec_decode_algo",
+        "MTP",
         "--model_dir",
         f"{llm_models_root()}/{model_path}",
+    ])
+
+
+@pytest.mark.parametrize("model_name,model_path,eagle_model_path", [
+    ("Llama-3.1-8b-Instruct", "llama-3.1-model/Llama-3.1-8B-Instruct",
+     "EAGLE3-LLaMA3.1-Instruct-8B"),
+])
+def test_ptp_quickstart_advanced_eagle3(llm_root, llm_venv, model_name,
+                                        model_path, eagle_model_path):
+    print(f"Testing {model_name}.")
+    example_root = Path(os.path.join(llm_root, "examples", "pytorch"))
+    llm_venv.run_cmd([
+        str(example_root / "quickstart_advanced.py"),
+        "--spec_decode_nextn",
+        "4",
+        "--spec_decode_algo",
+        "eagle3",
+        "--model_dir",
+        f"{llm_models_root()}/{model_path}",
+        "--eagle_model_dir",
+        f"{llm_models_root()}/{eagle_model_path}",
+        "--kv_cache_enable_block_reuse",
     ])
 
 

--- a/tests/integration/test_lists/test-db/l0_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_b200.yml
@@ -14,7 +14,7 @@ l0_b200:
   - test_e2e.py::test_ptp_quickstart_advanced[Llama3.1-8B-NVFP4-nvfp4-quantized/Meta-Llama-3.1-8B]
   - test_e2e.py::test_ptp_quickstart_advanced[Llama3.1-8B-FP8-llama-3.1-model/Llama-3.1-8B-Instruct-FP8]
   - test_e2e.py::test_ptq_quickstart_advanced_mtp[DeepSeek-V3-Lite-BF16-DeepSeek-V3-Lite/bf16]
-  - test_e2e.py::test_ptp_quickstart_advanced_mixed_precision
+  - test_e2e.py::test_ptp_quickstart_advanced_eagle3[Llama-3.1-8b-Instruct-llama-3.1-model/Llama-3.1-8B-Instruct-EAGLE3-LLaMA3.1-Instruct-8B]
   - examples/test_pytorch.py::test_llm_llama_1gpu[llama-3.1-8b-enable_fp4]
   - test_e2e.py::test_trtllm_bench_pytorch_backend_sanity[meta-llama/Llama-3.1-8B-llama-3.1-8b-False-False]
   - unittest/_torch -k "not (modeling or multi_gpu or auto_deploy)"
@@ -23,6 +23,7 @@ l0_b200:
   - unittest/_torch/multi_gpu_modeling -k "deepseek and tp1 and nextn0"
   - unittest/_torch/multi_gpu_modeling -k "deepseek and tp1 and not nextn0"
   - unittest/_torch/auto_deploy/unit/singlegpu
+  - unittest/_torch/speculative/test_eagle3.py
   - examples/test_pytorch.py::test_llm_deepseek_1gpu[deepseek-v3-lite-disable_fp8-enable_fp4]
   - examples/test_pytorch.py::test_llm_deepseek_1gpu[deepseek-v3-lite-disable_fp8-disable_fp4]
   # ------------- TRT tests ---------------

--- a/tests/unittest/_torch/speculative/test_eagle3.py
+++ b/tests/unittest/_torch/speculative/test_eagle3.py
@@ -1,0 +1,84 @@
+import os
+import sys
+import unittest
+
+from tensorrt_llm import SamplingParams
+from tensorrt_llm._torch import LLM
+from tensorrt_llm._torch.pyexecutor.config import PyTorchConfig
+from tensorrt_llm.bindings.executor import KvCacheConfig
+from tensorrt_llm.llmapi import EagleDecodingConfig
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+from utils.llm_data import llm_models_root
+
+
+def test_llama_eagle3():
+    models_path = llm_models_root()
+
+    pytorch_config = PyTorchConfig(
+        enable_overlap_scheduler=False,
+        use_cuda_graph=False,
+    )
+
+    kv_cache_config = KvCacheConfig(enable_block_reuse=False, )
+
+    eagle_model_dir = f"{models_path}/EAGLE3-LLaMA3.1-Instruct-8B"
+    target_model_dir = f"{models_path}/llama-3.1-model/Llama-3.1-8B-Instruct"
+
+    draft_len = 4
+    spec_config = EagleDecodingConfig(
+        max_draft_len=draft_len, pytorch_eagle_weights_path=eagle_model_dir)
+
+    llm_spec = LLM(model=target_model_dir,
+                   pytorch_backend_config=pytorch_config,
+                   kv_cache_config=kv_cache_config,
+                   speculative_config=spec_config)
+
+    sampling_params = SamplingParams(
+        max_tokens=32,
+        temperature=0,
+    )
+
+    # First make sure the acceptance rate is reasonable.
+    tok_ids = llm_spec.tokenizer.encode("The future of AI is")
+    num_tokens = 0
+
+    num_drafted = 0
+    num_accepted = 0
+
+    for output in llm_spec.generate_async(tok_ids,
+                                          SamplingParams(max_tokens=128,
+                                                         temperature=0),
+                                          streaming=True):
+        beam = output.outputs[0]
+        new_tokens = beam.token_ids
+
+        num_drafted += draft_len
+        num_accepted += len(new_tokens) - num_tokens - 1
+
+        num_tokens = len(new_tokens)
+
+    accept_rate = num_accepted / num_drafted
+    assert accept_rate > 0.25
+
+    prompts = [
+        "The capital of France is", "The president of the United States is"
+    ]
+    results_spec = llm_spec.generate(prompts, sampling_params)
+    generated_text_spec = [result.outputs[0].text for result in results_spec]
+
+    del llm_spec
+    llm_ref = LLM(model=target_model_dir,
+                  pytorch_backend_config=pytorch_config,
+                  kv_cache_config=kv_cache_config)
+
+    results_ref = llm_ref.generate(prompts, sampling_params)
+    generated_text_ref = [result.outputs[0].text for result in results_ref]
+
+    for text_spec, text_ref in zip(generated_text_spec, generated_text_ref):
+        # The spec decode algorithm currently guarantees identical results
+        assert text_spec == text_ref
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add an initial implementation of EAGLE3. The algorithm is not fully implemented yet. Specifically: we are
predicting **single extension sequences only** with this MR, not the fully token trees introduced by EAGLE2 and extended
by EAGLE3.

## Performance

The performance is nevertheless improved. The following data is from the MT bench dataset.

```
Without spec decode
E2E Request Time {'min': '0.1272', 'max': '10.0149', 'mean': '3.9125', 'std': '2.5989', 'quantiles': {
'0.25': '1.5769', '0.5': '3.7717', '0.75': '6.0113'}}
TTFT Time {'min': '0.0112', 'max': '1.2804', 'mean': '0.0255', 'std': '0.0996', 'quantiles': {'0.25': 
'0.0141', '0.5': '0.0166', '0.75': '0.0207'}}
Generation Step Time {'min': '0.0076', 'max': '1.2804', 'mean': '0.0093', 'std': '0.0050', 'quantiles'
: {'0.25': '0.0090', '0.5': '0.0093', '0.75': '0.0096'}}

With EAGLE3 (4 draft tokens)
E2E Request Time {'min': '0.1232', 'max': '7.0007', 'mean': '2.5146', 'std': '1.6071', 'quantiles': {'
0.25': '1.1102', '0.5': '2.5067', '0.75': '3.7379'}}
TTFT Time {'min': '0.0114', 'max': '1.2818', 'mean': '0.0256', 'std': '0.0997', 'quantiles': {'0.25': 
'0.0137', '0.5': '0.0171', '0.75': '0.0208'}}
Generation Step Time {'min': '0.0111', 'max': '1.2818', 'mean': '0.0140', 'std': '0.0075', 'quantiles'
: {'0.25': '0.0136', '0.5': '0.0139', '0.75': '0.0142'}}
```

Note the reduction in mean E2E request time. I am seeing between 2-3 tokens generated per iteration on average, with some variance depending on the prompts.

This was measured with LLama 3.1 8b instruct on a single H200. Other important parts of the setup: no KV cache reuse, no CUDA graphs.

CUDA graphs are disabled because they won't work yet with EAGLE3. We need to re-enable them in a followup. The trend I see across most prompts is that (EAGLE3 + no overlap scheduler) is faster than (vanilla + overlap scheduler), but slower than (vanilla + overlap scheduler + CUDA graphs). The CUDA graphs matter a lot, so I wanted an apples to apples comparison for these benchmarks.

## Design Overview

I tried to keep it as simple as possible and reuse our existing abstractions. 
* No overlap scheduler for now. This is possible to add in theory, but it will make the code pretty messy once token trees get involved. I think the best way to proceed is to finish implementing token trees + CUDA graphs, then add overlap scheduler support if the ROI is high enough. The other 2 items are much easier to do and will boost our performance by a lot more than the overlap scheduler.

* The EAGLE3 draft model is loaded in a separate `ModelEngine`. Utilizing this abstraction is crucial for keeping the code simple. Prepping `AttentionMetadata` by hand is very error prone. The added bonus here is that we can easily enable CUDA graphs for when we invoke the draft model autoregressively because all of the logic already exists inside `ModelEngine`. 

* Before invoking the target model `forward`, I call a separate `prepare_draft_tokens` function. This will append draft tokens to generation requests. 

* I think this `prepare_draft_tokens` function can be easily reused for e.g. Medusa, draft/target spec decode, or future versions of EAGLE. **My secondary goal is to avoid extensive runtime changes for adding future spec decode algorithms.**