### PR TITLE
chore: [TRTLLM-3694] Move functional args to llmargs

### DIFF
--- a/examples/pytorch/quickstart_advanced.py
+++ b/examples/pytorch/quickstart_advanced.py
@@ -4,7 +4,7 @@ from tensorrt_llm import SamplingParams
 from tensorrt_llm._torch import LLM
 from tensorrt_llm._torch.pyexecutor.config import PyTorchConfig
 from tensorrt_llm.bindings.executor import KvCacheConfig
-from tensorrt_llm.llmapi import BuildConfig, MTPDecodingConfig
+from tensorrt_llm.llmapi import MTPDecodingConfig
 
 example_prompts = [
     "Hello, my name is",
@@ -114,11 +114,10 @@ def setup_llm(args):
     mtp_config = MTPDecodingConfig(
         num_nextn_predict_layers=args.mtp_nextn) if args.mtp_nextn > 0 else None
 
-    build_config = BuildConfig(max_seq_len=args.max_seq_len,
-                               max_batch_size=args.max_batch_size,
-                               max_num_tokens=args.max_num_tokens)
-
     llm = LLM(model=args.model_dir,
+              max_seq_len=args.max_seq_len,
+              max_batch_size=args.max_batch_size,
+              max_num_tokens=args.max_num_tokens,
               pytorch_backend_config=pytorch_config,
               kv_cache_config=kv_cache_config,
               tensor_parallel_size=args.tp_size,
@@ -127,8 +126,7 @@ def setup_llm(args):
               moe_expert_parallel_size=args.moe_ep_size,
               moe_tensor_parallel_size=args.moe_tp_size,
               enable_chunked_prefill=args.enable_chunked_prefill,
-              speculative_config=mtp_config,
-              build_config=build_config)
+              speculative_config=mtp_config)
 
     sampling_params = SamplingParams(
         max_tokens=args.max_tokens,

--- a/examples/pytorch/star_attention.py
+++ b/examples/pytorch/star_attention.py
@@ -6,7 +6,7 @@ from difflib import SequenceMatcher
 
 import torch
 
-from tensorrt_llm import BuildConfig, SamplingParams
+from tensorrt_llm import SamplingParams
 from tensorrt_llm._torch import LLM
 from tensorrt_llm._torch.pyexecutor.config import PyTorchConfig
 from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
@@ -70,14 +70,13 @@ def generate_llm_outputs(args,
         "block_size": args.sa_block_size
     }
 
-    build_config = BuildConfig(max_batch_size=args.max_batch_size,
-                               max_input_len=args.max_input_len,
-                               max_seq_len=args.max_seq_len,
-                               max_num_tokens=args.max_num_tokens)
     pytorch_backend_config = PyTorchConfig(
         attn_backend='FLASHINFER_STAR_ATTENTION')
     llm = LLM(model=args.model_path,
-              build_config=build_config,
+              max_batch_size=args.max_batch_size,
+              max_input_len=args.max_input_len,
+              max_seq_len=args.max_seq_len,
+              max_num_tokens=args.max_num_tokens,
               quant_config=quant_config,
               tensor_parallel_size=1,
               context_parallel_size=args.num_procs,

--- a/tensorrt_llm/_torch/pyexecutor/config.py
+++ b/tensorrt_llm/_torch/pyexecutor/config.py
@@ -132,8 +132,10 @@ def update_executor_config(
         mapping: Optional[Mapping] = None,
         build_config: Optional[BuildConfig] = None,
         speculative_config: Optional[SpecConfig] = None,
-        hf_model_dir: str = None,
-        trt_engine_dir: str = None):
+        hf_model_dir: Optional[str] = None,
+        trt_engine_dir: Optional[str] = None,
+        max_input_len: Optional[int] = None,
+        max_seq_len: Optional[int] = None):
     if backend is None:
         return
 
@@ -151,8 +153,14 @@ def update_executor_config(
     logger.info(f"{executor_config.pytorch_backend_config}")
 
     if build_config is not None:
-        executor_config.max_seq_len = build_config.max_seq_len
+        # TODO: move to pure-Python KvCacheConfig, and remove dependency on build_config.
         executor_config.tokens_per_block = executor_config.tokens_per_block or build_config.plugin_config.tokens_per_block
 
     executor_config.hf_model_dir = hf_model_dir
     executor_config.trt_engine_dir = trt_engine_dir
+
+    if max_input_len is not None:
+        executor_config.max_input_len = max_input_len
+
+    if max_seq_len is not None:
+        executor_config.max_seq_len = max_seq_len

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -178,7 +178,6 @@ class PyExecutor:
             "kv_cache_manager")
         self.enable_kv_cache_events = self.kv_cache_manager is not None and self.kv_cache_manager.event_buffer_max_size > 0
 
-        # todo: we need pass this by builder config from LLM and LLMargs
         self.max_input_len = max_input_len
         # _executor_loop private data
         self.max_num_active_requests = model_engine.get_max_num_sequences()

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -275,5 +275,6 @@ def create_py_executor(executor_config: ExecutorConfig,
                              enable_overlap_scheduler=pytorch_backend_config.
                              enable_overlap_scheduler,
                              max_batch_size=executor_config.max_batch_size,
+                             max_input_len=executor_config.max_input_len,
                              kv_cache_transceiver=kv_cache_transceiver)
     return py_executor

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -540,7 +540,7 @@ class LLM:
 
         executor_config.normalize_log_probs = self.args.normalize_log_probs
         executor_config.enable_chunked_context = self.args.enable_chunked_prefill
-        executor_config.max_beam_width = self.args.build_config.max_beam_width
+        executor_config.max_beam_width = self.args.max_beam_width or self.args.build_config.max_beam_width
         if self.args.extended_runtime_perf_knob_config is not None:
             executor_config.extended_runtime_perf_knob_config = self.args.extended_runtime_perf_knob_config
 
@@ -553,7 +553,9 @@ class LLM:
             build_config=self.args.build_config,
             speculative_config=self.args.speculative_config,
             hf_model_dir=self._hf_model_dir,
-            trt_engine_dir=self._engine_dir)
+            trt_engine_dir=self._engine_dir,
+            max_input_len=self.args.max_input_len,
+            max_seq_len=self.args.max_seq_len)
         executor_config.llm_parallel_config = self.args.parallel_config
         return_logits = self.args.gather_generation_logits or (
             self.args.build_config

--- a/tensorrt_llm/scaffolding/worker.py
+++ b/tensorrt_llm/scaffolding/worker.py
@@ -65,13 +65,13 @@ class ProposerWorker(Worker):
             max_num_tokens=max_num_tokens)
         executor_config.kv_cache_config = kv_cache_config
         build_config = BuildConfig()
-        build_config.max_seq_len = max_seq_len
 
         update_executor_config(
             executor_config,
             backend='pytorch',
             pytorch_backend_config=self.pytorch_backend_config,
             build_config=build_config,
+            max_seq_len=max_seq_len,
             hf_model_dir=model_dir,
             trt_engine_dir=None,
         )

--- a/tests/unittest/_torch/multi_gpu_modeling/test_llama.py
+++ b/tests/unittest/_torch/multi_gpu_modeling/test_llama.py
@@ -8,7 +8,7 @@ from utils.util import getSMVersion
 from tensorrt_llm import SamplingParams
 from tensorrt_llm._torch import LLM
 from tensorrt_llm._torch.pyexecutor.config import PyTorchConfig
-from tensorrt_llm.llmapi.llm_utils import BuildConfig, CalibConfig
+from tensorrt_llm.llmapi.llm_utils import CalibConfig
 from tensorrt_llm.llmapi.utils import get_total_gpu_memory
 from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
 
@@ -94,9 +94,8 @@ def test_llama(model_name, backend, quant, tp_size, pp_size, torch_compile):
         pytorch_backend_config=pytorch_config,
         calib_config=CalibConfig(calib_dataset=str(llm_models_root() /
                                                    "datasets/cnn_dailymail")),
-        build_config=BuildConfig(
-            max_seq_len=2048,
-        ),  # This verifies a bug in compile warmUp that does not generate valid warmup requests
+        max_seq_len=
+        2048,  # This verifies a bug in compile warmUp that does not generate valid warmup requests
     )
     with llm:
         outputs = llm.generate(

--- a/tests/unittest/api_stability/references/llm_args.yaml
+++ b/tests/unittest/api_stability/references/llm_args.yaml
@@ -47,6 +47,15 @@ methods:
       backend:
         annotation: Optional[str]
         default: null
+      max_input_len:
+        annotation: int
+        default: 1024
+      max_seq_len:
+        annotation: int
+        default: null
+      max_beam_width:
+        annotation: int
+        default: 1
       max_batch_size:
         annotation: Optional[int]
         default: null


### PR DESCRIPTION
Moving args shared across TRT & Torch backend out from BuildConfig to first-level LLMArgs as discussed w/ Chunwei. 