### PR TITLE
chore: Fix logits dtype in assert

### DIFF
--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
@@ -183,7 +183,6 @@ public:
     void prepareDisaggGenInitRequests(RequestList const& activeRequests, RequestVector& newGenReques);
     void checkDisaggGenTransferStatus(RequestList const& activeRequests);
     void prepareDistGenBufferAndDecoder(RequestVector const& generationRequests);
-    RequestVector scheduleDistGenInitRequests(RequestList const& activeRequests);
 
     void resetIterationStats() override;
 
@@ -306,8 +305,6 @@ private:
     /// @param[in] genBufferId The id of the generation buffers for those requests.
     void copyCacheIndirectionFromOutputsToInputs(ScheduledRequests const& scheduledRequests, SizeType32 genBufferId);
 
-    void invokeLogitsPostProcessors(ScheduledRequests const& scheduledRequests);
-
     [[nodiscard]] bool getGatherGenerationLogits() const override
     {
         return getModelConfig().computeGenerationLogits() || mGatherGenerationLogits;
@@ -335,13 +332,6 @@ private:
     [[nodiscard]] nvinfer1::Dims getTensorShape(std::string const& name) const override;
 
     void reshapeKvTensors(SizeType32 maxBlocksPerSeq, kv_cache_manager::CacheType kvCacheType, SizeType32 numPools);
-
-    // This function waits for MPI async sends on a separate thread
-    void asyncSendWaitThread();
-
-    void draftModelSendLogitsThread();
-    std::optional<TensorPtr> targetModelReceiveLogits(
-        executor::SpeculativeDecodingFastLogitsInfo const& fastLogitsInfo);
 
     [[nodiscard]] bool hasSpeculativeDecodingFastLogits() const noexcept override
     {

--- a/cpp/tensorrt_llm/batch_manager/utils/logitsThread.cpp
+++ b/cpp/tensorrt_llm/batch_manager/utils/logitsThread.cpp
@@ -17,6 +17,8 @@
 
 #include "logitsThread.h"
 
+namespace tc = tensorrt_llm::common;
+
 namespace tensorrt_llm::batch_manager::utils
 {
 
@@ -152,7 +154,8 @@ std::optional<GenerateRequestOptions::TensorPtr> targetModelReceiveLogits(
 
     MPICHECK(MPI_Get_count(&status, MPI_UINT8_T, &count));
 
-    TLLM_CHECK((uint64_t) count == dims[0] * dims[1] * sizeof(nvinfer1::DataType::kFLOAT));
+    uint64_t const expectedSize = static_cast<uint64_t>(dims[0]) * dims[1] * tc::getDTypeSize(logitsDtype);
+    TLLM_CHECK((uint64_t) count == expectedSize);
 
     MPICHECK(MPI_Mrecv(tensor->data(), count, MPI_UINT8_T, &msg, &status));
 


### PR DESCRIPTION
Remove extra methods in trtGptModelInflightBatching.h. The methods were moved out of that class during a previous refactoring, but the definitions have been left behind.