### PR TITLE
chore: Only gather responses on rank 0

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/distributed.py
+++ b/tensorrt_llm/_torch/pyexecutor/distributed.py
@@ -128,6 +128,9 @@ class MPIDist(Distributed):
     def tp_allgather(self, obj):
         return self.tp_comm.allgather(obj)
 
+    def tp_gather(self, obj):
+        return self.tp_comm.gather(obj)
+
     def tp_broadcast(self, obj, root=0):
         return self.tp_comm.bcast(obj, root)
 


### PR DESCRIPTION
Only rank 0 sends responses, so we can use `gather` rather than  `allgather`. In addition, we only need to gather the responses within the TP group.