### PR TITLE
feat: Support prequantized fp8 ckpt for nemotron-mini-4b-instruct

### DIFF
--- a/tests/integration/defs/accuracy/accuracy_core.py
+++ b/tests/integration/defs/accuracy/accuracy_core.py
@@ -349,7 +349,8 @@ class AccuracyTestHarness:
             if self.quant_algo == QuantAlgo.NVFP4:
                 convert_cmd.append("--use_nvfp4")
             elif self.quant_algo == QuantAlgo.FP8:
-                convert_cmd.append("--use_fp8")
+                if self.EXAMPLE_FOLDER != "gpt":  # --use_fp8 flag is not needed for gpt.
+                    convert_cmd.append("--use_fp8")
             elif self.quant_algo == QuantAlgo.FP8_PER_CHANNEL_PER_TOKEN:
                 convert_cmd.append("--use_fp8_rowwise")
             elif quant_config._use_plugin_sq:
@@ -378,7 +379,8 @@ class AccuracyTestHarness:
             if self.kv_cache_quant_algo == QuantAlgo.INT8:
                 convert_cmd.append("--int8_kv_cache")
             elif self.kv_cache_quant_algo == QuantAlgo.FP8:
-                convert_cmd.append("--fp8_kv_cache")
+                if self.EXAMPLE_FOLDER != "gpt":  # --fp8_kv_cache flag is not needed for gpt.
+                    convert_cmd.append("--fp8_kv_cache")
 
         if quant_config._requires_calibration:
             convert_cmd.append(

--- a/tests/integration/defs/accuracy/references/cnn_dailymail.yaml
+++ b/tests/integration/defs/accuracy/references/cnn_dailymail.yaml
@@ -202,3 +202,7 @@ Qwen/Qwen2.5-1.5B-Instruct:
     accuracy: 31.515
   - quant_algo: FP8
     accuracy: 31.560
+nvidia/Nemotron-Mini-4B-Instruct:
+  - quant_algo: FP8
+    kv_cache_quant_algo: FP8
+    accuracy: 25.72

--- a/tests/integration/defs/accuracy/test_accuracy.py
+++ b/tests/integration/defs/accuracy/test_accuracy.py
@@ -174,6 +174,20 @@ class TestMinitron4BBase(AccuracyTestHarness):
                  kv_cache_quant_algo=QuantAlgo.FP8)
 
 
+class TestNemotronMini4BInstruct(AccuracyTestHarness):
+    MODEL_NAME = "nvidia/Nemotron-Mini-4B-Instruct"
+    MODEL_PATH = f"{llm_models_root()}/nemotron/Nemotron-Mini-4B-Instruct"
+    EXAMPLE_FOLDER = "gpt"
+
+    @skip_pre_ada
+    def test_fp8_pre_quantized(self, mocker):
+        mocker.patch.object(
+            self.__class__, "MODEL_PATH",
+            f"{llm_models_root()}/nemotron/nemotron-mini-4b-instruct_vfp8-fp8-bf16-export"
+        )
+        self.run(quant_algo=QuantAlgo.FP8, kv_cache_quant_algo=QuantAlgo.FP8)
+
+
 class TestPhi2(AccuracyTestHarness):
     MODEL_NAME = "microsoft/phi-2"
     MODEL_PATH = f"{llm_models_root()}/phi-2"

--- a/tests/integration/test_lists/qa/examples_test_list.txt
+++ b/tests/integration/test_lists/qa/examples_test_list.txt
@@ -326,6 +326,7 @@ accuracy/test_accuracy.py::TestStarcoder2_15B::test_smooth_quant_ootb
 accuracy/test_accuracy.py::TestGptNext::test_auto_dtype
 accuracy/test_accuracy.py::TestMinitron4BBase::test_auto_dtype
 accuracy/test_accuracy.py::TestMinitron4BBase::test_fp8
+accuracy/test_accuracy.py::TestNemotronMini4BInstruct::test_fp8_pre_quantized
 accuracy/test_accuracy.py::TestPhi2::test_auto_dtype
 accuracy/test_accuracy.py::TestPhi2::test_tp2
 accuracy/test_accuracy.py::TestPhi3Mini4kInstruct::test_auto_dtype

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -137,6 +137,7 @@ l0_h100:
   - accuracy/test_accuracy.py::TestGpt2::test_attention_ootb
   - accuracy/test_accuracy.py::TestStarcoder2_3B::test_auto_dtype
   - accuracy/test_accuracy.py::TestMinitron4BBase::test_fp8
+  - accuracy/test_accuracy.py::TestNemotronMini4BInstruct::test_fp8_pre_quantized
   - accuracy/test_accuracy.py::TestTinyLlama1_1BChat::test_float32
   - accuracy/test_accuracy.py::TestLlama3_8BInstructGradient1048k::test_long_context
   - accuracy/test_accuracy.py::TestLlama3_8BInstructGradient1048k::test_long_context_ppl


### PR DESCRIPTION
This MR adds changes to support consumption of pre-quantized FP8 ckpt from ModelOpt for nemotron-mini-4b-instruct.
```
$ rm -rf nemotron_mini_4b_tllm_fp8_ckpt/ && python examples/gpt/convert_checkpoint.py --model_dir nemotron-mini-4b-instruct_vfp8-fp8-bf16-export/ --output_dir nemotron_mini_4b_tllm_fp8_ckpt/ --dtype bfloat16
$ rm -rf nemotron_mini_4b_tllm_fp8_eng/ && trtllm-build --checkpoint_dir nemotron_mini_4b_tllm_fp8_ckpt/ --output_dir nemotron_mini_4b_tllm_fp8_eng/
$ python examples/run.py --engine_dir nemotron_mini_4b_tllm_fp8_eng/ --max_output_len 20 --tokenizer_dir nemotron-mini-4b-instruct_vfp8-fp8-bf16-export/ --input_text "Hello, how are you?"
```