### PR TITLE
feat: Adding UCX support for cacheTransceiver

### DIFF
--- a/cpp/tensorrt_llm/CMakeLists.txt
+++ b/cpp/tensorrt_llm/CMakeLists.txt
@@ -149,51 +149,55 @@ else()
     )
   endif()
 
-  add_library(${UCX_WRAPPER_TARGET} SHARED IMPORTED)
-  if(NOT WIN32) # Linux
-    set(UCX_WRAPPER_LIB_SOURCE_REL_LOC
-        "executor/cache_transmission/ucx_utils/${EXECUTOR_TARGET_ARCH}/libtensorrt_llm_ucx_wrapper.so"
-    )
-    set(UCX_WRAPPER_LIB_BINARY_REL_LOC
-        "executor/cache_transmission/ucx_utils/libtensorrt_llm_ucx_wrapper.so")
-  else()
-    set(UCX_WRAPPER_LIB_BINARY_REL_DIR "executor/cache_transmission/ucx_utils/")
-    set(UCX_WRAPPER_DLL_NAME "tensorrt_llm_ucx_wrapper.dll")
-    set(UCX_WRAPPER_LIB_NAME "tensorrt_llm_ucx_wrapper.lib")
+  if(ENABLE_UCX)
+    add_library(${UCX_WRAPPER_TARGET} SHARED IMPORTED)
+    if(NOT WIN32) # Linux
+      set(UCX_WRAPPER_LIB_SOURCE_REL_LOC
+          "executor/cache_transmission/ucx_utils/${EXECUTOR_TARGET_ARCH}/libtensorrt_llm_ucx_wrapper.so"
+      )
+      set(UCX_WRAPPER_LIB_BINARY_REL_LOC
+          "executor/cache_transmission/ucx_utils/libtensorrt_llm_ucx_wrapper.so"
+      )
+    else()
+      set(UCX_WRAPPER_LIB_BINARY_REL_DIR
+          "executor/cache_transmission/ucx_utils/")
+      set(UCX_WRAPPER_DLL_NAME "tensorrt_llm_ucx_wrapper.dll")
+      set(UCX_WRAPPER_LIB_NAME "tensorrt_llm_ucx_wrapper.lib")
 
-    set(UCX_WRAPPER_LIB_SOURCE_REL_LOC
-        "${UCX_WRAPPER_LIB_BINARY_REL_DIR}/${EXECUTOR_TARGET_ARCH}/${UCX_WRAPPER_DLL_NAME}"
-    )
-    set(UCX_WRAPPER_LIB_BINARY_REL_LOC
-        "${UCX_WRAPPER_LIB_BINARY_REL_DIR}/${UCX_WRAPPER_DLL_NAME}")
-    set(UCX_WRAPPER_IMPLIB_SOURCE_REL_LOC
-        "${UCX_WRAPPER_LIB_BINARY_REL_DIR}/${EXECUTOR_TARGET_ARCH}/${UCX_WRAPPER_LIB_NAME}"
-    )
-    set(UCX_WRAPPER_IMPLIB_BINARY_REL_LOC
-        "${UCX_WRAPPER_LIB_BINARY_REL_DIR}/${UCX_WRAPPER_LIB_NAME}")
-  endif()
-  set(UCX_WRAPPER_LIB_LOC
-      "${CMAKE_CURRENT_SOURCE_DIR}/${UCX_WRAPPER_LIB_SOURCE_REL_LOC}")
-  # Copy the .so to build directory, which is needed in build_wheel.py.
-  configure_file(${UCX_WRAPPER_LIB_SOURCE_REL_LOC}
-                 ${UCX_WRAPPER_LIB_BINARY_REL_LOC} COPYONLY)
-  set_property(TARGET ${UCX_WRAPPER_TARGET} PROPERTY IMPORTED_LOCATION
-                                                     ${UCX_WRAPPER_LIB_LOC})
-  if(WIN32)
-    set(UCX_WRAPPER_IMPLIB_LOC
-        "${CMAKE_CURRENT_SOURCE_DIR}/${UCX_WRAPPER_IMPLIB_SOURCE_REL_LOC}")
-    configure_file(${UCX_WRAPPER_IMPLIB_SOURCE_REL_LOC}
-                   ${UCX_WRAPPER_IMPLIB_BINARY_REL_LOC} COPYONLY)
-    set_property(TARGET ${UCX_WRAPPER_TARGET}
-                 PROPERTY IMPORTED_IMPLIB ${UCX_WRAPPER_IMPLIB_LOC})
-  endif()
+      set(UCX_WRAPPER_LIB_SOURCE_REL_LOC
+          "${UCX_WRAPPER_LIB_BINARY_REL_DIR}/${EXECUTOR_TARGET_ARCH}/${UCX_WRAPPER_DLL_NAME}"
+      )
+      set(UCX_WRAPPER_LIB_BINARY_REL_LOC
+          "${UCX_WRAPPER_LIB_BINARY_REL_DIR}/${UCX_WRAPPER_DLL_NAME}")
+      set(UCX_WRAPPER_IMPLIB_SOURCE_REL_LOC
+          "${UCX_WRAPPER_LIB_BINARY_REL_DIR}/${EXECUTOR_TARGET_ARCH}/${UCX_WRAPPER_LIB_NAME}"
+      )
+      set(UCX_WRAPPER_IMPLIB_BINARY_REL_LOC
+          "${UCX_WRAPPER_LIB_BINARY_REL_DIR}/${UCX_WRAPPER_LIB_NAME}")
+    endif()
+    set(UCX_WRAPPER_LIB_LOC
+        "${CMAKE_CURRENT_SOURCE_DIR}/${UCX_WRAPPER_LIB_SOURCE_REL_LOC}")
+    # Copy the .so to build directory, which is needed in build_wheel.py.
+    configure_file(${UCX_WRAPPER_LIB_SOURCE_REL_LOC}
+                   ${UCX_WRAPPER_LIB_BINARY_REL_LOC} COPYONLY)
+    set_property(TARGET ${UCX_WRAPPER_TARGET} PROPERTY IMPORTED_LOCATION
+                                                       ${UCX_WRAPPER_LIB_LOC})
+    if(WIN32)
+      set(UCX_WRAPPER_IMPLIB_LOC
+          "${CMAKE_CURRENT_SOURCE_DIR}/${UCX_WRAPPER_IMPLIB_SOURCE_REL_LOC}")
+      configure_file(${UCX_WRAPPER_IMPLIB_SOURCE_REL_LOC}
+                     ${UCX_WRAPPER_IMPLIB_BINARY_REL_LOC} COPYONLY)
+      set_property(TARGET ${UCX_WRAPPER_TARGET}
+                   PROPERTY IMPORTED_IMPLIB ${UCX_WRAPPER_IMPLIB_LOC})
+    endif()
 
-  file(SIZE ${UCX_WRAPPER_LIB_LOC} UCX_WRAPPER_LIB_SIZE)
-  if(UCX_WRAPPER_LIB_SIZE LESS 1024)
-    message(
-      FATAL_ERROR
-        "The ucx wrapper library is truncated or incomplete. This is usually caused by using Git LFS (Large File Storage) incorrectly. Please try running command `git lfs install && git lfs pull`."
-    )
+    file(SIZE ${UCX_WRAPPER_LIB_LOC} UCX_WRAPPER_LIB_SIZE)
+    if(UCX_WRAPPER_LIB_SIZE LESS 1024)
+      message(
+        FATAL_ERROR
+          "The ucx wrapper library is truncated or incomplete. This is usually caused by using Git LFS (Large File Storage) incorrectly. Please try running command `git lfs install && git lfs pull`."
+      )
+    endif()
   endif()
 endif()
 

--- a/cpp/tensorrt_llm/batch_manager/CMakeLists.txt
+++ b/cpp/tensorrt_llm/batch_manager/CMakeLists.txt
@@ -94,3 +94,12 @@ set_property(TARGET ${BATCH_MANAGER_STATIC_TARGET}
 set(TOP_LEVEL_DIR "${PROJECT_SOURCE_DIR}/..")
 target_compile_definitions(${BATCH_MANAGER_STATIC_TARGET}
                            PUBLIC TOP_LEVEL_DIR="${TOP_LEVEL_DIR}")
+
+if(ENABLE_UCX)
+  find_package(ucx REQUIRED)
+  find_package(ucxx REQUIRED)
+  target_include_directories(
+    ${BATCH_MANAGER_STATIC_TARGET}
+    PRIVATE $<TARGET_PROPERTY:ucxx::ucxx,INTERFACE_INCLUDE_DIRECTORIES>)
+  target_link_libraries(${BATCH_MANAGER_STATIC_TARGET} PUBLIC)
+endif()

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -43,9 +43,6 @@
 #include "tensorrt_llm/common/envUtils.h"
 #include "tensorrt_llm/common/logger.h"
 #include "tensorrt_llm/executor/cache_transmission/mpi_utils/connection.h"
-#include "tensorrt_llm/executor/cache_transmission/ucx_utils/connection.h"
-#include "tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.h"
-
 #include "tensorrt_llm/executor/dataTransceiverState.h"
 #include "tensorrt_llm/executor/serializeUtils.h"
 #include "tensorrt_llm/runtime/utils/mpiUtils.h"

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -43,6 +43,9 @@
 #include "tensorrt_llm/common/envUtils.h"
 #include "tensorrt_llm/common/logger.h"
 #include "tensorrt_llm/executor/cache_transmission/mpi_utils/connection.h"
+#include "tensorrt_llm/executor/cache_transmission/ucx_utils/connection.h"
+#include "tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.h"
+
 #include "tensorrt_llm/executor/dataTransceiverState.h"
 #include "tensorrt_llm/executor/serializeUtils.h"
 #include "tensorrt_llm/runtime/utils/mpiUtils.h"
@@ -143,6 +146,78 @@ CacheTransceiver::CacheTransceiver(kv_cache_manager::BaseKVCacheManager* cacheMa
                 mManager.get(), *mCacheState, worldConfig.getRank(), std::make_unique<MLACacheFormatter>(cacheManager)))
             : std::make_unique<DataRequester>(std::make_unique<DataReceiverImpl>(
                 mManager.get(), *mCacheState, worldConfig.getRank(), std::make_unique<CacheFormatter>(cacheManager)));
+    }
+    else if (mCommType == CommType::UCX)
+    {
+        mMpiWorldComm = std::addressof(tensorrt_llm::mpi::MpiComm::world());
+        mManager = std::make_unique<executor::kv_cache::UcxConnectionManager>(mMpiWorldComm);
+        mDataResponder = std::make_unique<DataResponder>(std::make_unique<DataSenderImpl>(
+            mManager.get(), *mCacheState, worldConfig.getRank(), std::make_unique<CacheFormatter>(cacheManager)));
+        mDataRequester = std::make_unique<DataRequester>(std::make_unique<DataReceiverImpl>(
+            mManager.get(), *mCacheState, worldConfig.getRank(), std::make_unique<CacheFormatter>(cacheManager)));
+        /*
+                {
+                    std::lock_guard<std::mutex> lock(mDllMutex);
+                    mWrapperLibHandle = dllOpen(UCX_WRAPPER_LIB_NAME);
+                    TLLM_CHECK_WITH_INFO(mWrapperLibHandle != nullptr, "UCX wrapper library is not open correctly.");
+                    auto load_sym = [](void* handle, char const* name)
+                    {
+                        void* ret = dllGetSym(handle, name);
+                        TLLM_CHECK_WITH_INFO(ret != nullptr,
+                            "Unable to load UCX wrapper library symbol, possible cause is that TensorRT-LLM library is
+           not " "built with UCX support, please rebuild in UCX-enabled environment."); return ret;
+                    };
+                    std::unique_ptr<DataResponder> (*makeUcxCacheResponder)(
+                        executor::kv_cache::CacheState, SizeType32, kv_cache_manager::BaseKVCacheManager*);
+                    std::unique_ptr<DataRequester> (*makeUcxCacheRequester)(
+                        executor::kv_cache::CacheState, SizeType32, kv_cache_manager::BaseKVCacheManager*);
+                    *(void**) (&makeUcxCacheResponder) = load_sym(mWrapperLibHandle, "makeUcxCacheResponder");
+                    *(void**) (&makeUcxCacheRequester) = load_sym(mWrapperLibHandle, "makeUcxCacheRequester");
+                    mDataResponder = makeUcxCacheResponder(*mCacheState, worldConfig.getRank(), cacheManager);
+                    mDataRequester = makeUcxCacheRequester(*mCacheState, worldConfig.getRank(), cacheManager);
+                }
+                namespace su = tensorrt_llm::executor::serialize_utils;
+
+                if (mMpiGroupComm->getSize() > 1)
+                {
+                    mMpiGroupComm->barrier();
+                    executor::kv_cache::CommState commState = mDataResponder->getCommState();
+                    std::ostringstream oStream;
+                    su::serialize(commState, oStream);
+                    auto str = oStream.str();
+                    std::vector<char> buffer(str.begin(), str.end());
+                    std::vector<SizeType32> sizeofBuffer(mMpiGroupComm->getSize());
+                    SizeType32 bufferSize = buffer.size();
+                    mMpiGroupComm->allgather(&bufferSize, sizeofBuffer.data(), 1, mpi::MpiType::kINT32);
+                    SizeType32 recvBufferSize = std::accumulate(sizeofBuffer.begin(), sizeofBuffer.end(), 0);
+                    std::vector<char> recvBuffer(recvBufferSize);
+                    std::vector<int> displs(mMpiGroupComm->getSize());
+                    for (int r = 0; r < mMpiGroupComm->getSize(); r++)
+                    {
+                        displs[r] = (r == 0) ? 0 : (displs[r - 1] + sizeofBuffer[r - 1]);
+                    }
+                    mMpiGroupComm->allgatherv(buffer.data(), bufferSize, mpi::MpiType::kCHAR, recvBuffer.data(),
+           sizeofBuffer, displs, mpi::MpiType::kCHAR);
+
+                    // deserialize
+                    std::vector<executor::kv_cache::CommState> commSessionCommState(mMpiGroupComm->getSize());
+                    std::vector<executor::kv_cache::SocketState> socketStates;
+                    for (int i = 0; i < mMpiGroupComm->getSize(); i++)
+                    {
+                        std::vector<char> serBuffer(
+                            recvBuffer.begin() + displs[i], recvBuffer.begin() + (displs[i] + sizeofBuffer[i]));
+                        su::VectorWrapBuf<char> strbuf(serBuffer);
+                        std::istream is(&strbuf);
+                        commSessionCommState[i] = su::deserialize<executor::kv_cache::CommState>(is);
+                        TLLM_CHECK_WITH_INFO(
+                            commSessionCommState[i].getSocketState().size() == 1, "getSocketState size should be 1");
+                        socketStates.push_back(commSessionCommState[i].getSocketState()[0]);
+                    }
+                    executor::kv_cache::CommState allCommState{socketStates, worldConfig.getRank()};
+                    mDataResponder->setCommState(std::move(allCommState));
+                }
+        */
+        // TLLM_CHECK(false);
     }
     else
     {

--- a/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/CMakeLists.txt
+++ b/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/CMakeLists.txt
@@ -1,21 +1,21 @@
 # Build UCX data transceiver as shared library for runtime symbol loading, to
 # make UCX on-demand runtime dependency.
-add_library(${UCX_WRAPPER_TARGET} SHARED connection.cpp
-                                         ucxCacheCommunicator.cpp)
-set_target_properties(
-  ${UCX_WRAPPER_TARGET}
-  PROPERTIES CXX_STANDARD "17" CXX_STANDARD_REQUIRED "YES" CXX_EXTENSIONS "NO"
-             POSITION_INDEPENDENT_CODE ON)
-
-set_property(TARGET ${UCX_WRAPPER_TARGET} PROPERTY CUDA_RESOLVE_DEVICE_SYMBOLS
-                                                   ON)
-set(TOP_LEVEL_DIR "${PROJECT_SOURCE_DIR}/..")
-target_compile_definitions(${UCX_WRAPPER_TARGET}
-                           PUBLIC TOP_LEVEL_DIR="${TOP_LEVEL_DIR}")
-
 if(ENABLE_UCX)
   find_package(ucx REQUIRED)
   find_package(ucxx REQUIRED)
+
+  add_library(${UCX_WRAPPER_TARGET} SHARED connection.cpp
+                                           ucxCacheCommunicator.cpp)
+  set_target_properties(
+    ${UCX_WRAPPER_TARGET}
+    PROPERTIES CXX_STANDARD "17" CXX_STANDARD_REQUIRED "YES"
+               CXX_EXTENSIONS "NO" POSITION_INDEPENDENT_CODE ON)
+
+  set_property(TARGET ${UCX_WRAPPER_TARGET} PROPERTY CUDA_RESOLVE_DEVICE_SYMBOLS
+                                                     ON)
+  set(TOP_LEVEL_DIR "${PROJECT_SOURCE_DIR}/..")
+  target_compile_definitions(${UCX_WRAPPER_TARGET}
+                             PUBLIC TOP_LEVEL_DIR="${TOP_LEVEL_DIR}")
 
   target_include_directories(
     ${UCX_WRAPPER_TARGET}

--- a/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/CMakeLists.txt
+++ b/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Build UCX data transceiver as shared library for runtime symbol loading, to
 # make UCX on-demand runtime dependency.
-add_library(${UCX_WRAPPER_TARGET} SHARED connection.cpp)
+add_library(${UCX_WRAPPER_TARGET} SHARED connection.cpp
+                                         ucxCacheCommunicator.cpp)
 set_target_properties(
   ${UCX_WRAPPER_TARGET}
   PROPERTIES CXX_STANDARD "17" CXX_STANDARD_REQUIRED "YES" CXX_EXTENSIONS "NO"

--- a/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/connection.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/connection.cpp
@@ -29,7 +29,7 @@ UcxConnection::UcxConnection(
     : mConnectionId(connectionId)
     , mLocalGID(manager->getLocalGID())
     , mRemoteGID(std::numeric_limits<uint64_t>::max())
-    , mEndpoint(endpoint)
+    , mEndpoint(std::move(endpoint))
     , mManager(manager)
 {
     if (mEndpoint)

--- a/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/connection.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/connection.cpp
@@ -22,11 +22,9 @@
 namespace tensorrt_llm::executor::kv_cache
 {
 
-UcxConnection::UcxConnection(
-    uint64_t connectionId, std::shared_ptr<ucxx::Endpoint> endpoint, std::shared_ptr<UcxConnectionManager> manager)
+UcxConnection::UcxConnection(uint64_t connectionId, std::shared_ptr<ucxx::Endpoint> endpoint)
     : mConnectionId(connectionId)
     , mEndpoint(endpoint)
-    , mManager(std::move(manager))
 {
     if (mEndpoint)
     {
@@ -34,9 +32,11 @@ UcxConnection::UcxConnection(
     }
 }
 
-// UcxConnection::UcxConnection(UcxConnection&& other): mConnectionId(std::move(other.mConnectionId)),
-// mEndpoint(std::move(other.mEndpoint),mManager(other.mManager){
-// }
+void UcxConnection::initialize(std::shared_ptr<UcxConnectionManager> manager)
+{
+    std::cout << "UcxConnection::initialize" << std::endl;
+    mManager = std::move(manager);
+}
 
 void UcxConnection::initializeEndpointTag(int maxTryTimes)
 {
@@ -58,6 +58,7 @@ void UcxConnection::initializeEndpointTag(int maxTryTimes)
     if (status == UCS_OK)
     {
 
+        std::cout << " initializeEndpointTag" << std::endl;
         ucxx::utils::sockaddr_get_ip_port_str(&ep_attr.remote_sockaddr, rIpStr, portStr, INET6_ADDRSTRLEN);
         remotePort = static_cast<ucxx::Tag>(std::stoull(portStr));
 
@@ -112,174 +113,7 @@ void UcxConnection::recv(DataContext const& ctx, void* data, size_t size) const
     req->checkError();
 }
 
-// UcxServer::UcxServer(uint16_t listenerPort)
-// {
-//     mContext = ucxx::createContext({}, ucxx::Context::defaultFeatureFlags);
-//     mWorker = mContext->createWorker();
-//     // Ensure the progress thread has CUDA context initialized
-//     int device;
-//     TLLM_CUDA_CHECK(cudaGetDevice(&device));
-//     mWorker->setProgressThreadStartCallback([device](void* arg) { TLLM_CUDA_CHECK(cudaSetDevice(device)); },
-//     nullptr); mWorker->startProgressThread(); startListener(listenerPort);
-// }
 
-// void UcxServer::listenerCallback(ucp_conn_request_h conn_request, void* arg)
-// {
-//     auto* self = reinterpret_cast<UcxServer*>(arg);
-//     auto endpoint = self->mListener->createEndpointFromConnRequest(conn_request);
-//     // TLLM_CHECK(self->mManager.insert("default", std::make_unique<UcxConnection>(std::move(endpoint))));
-// }
-
-// void UcxServer::startListener(uint16_t listenerPort)
-// {
-//     mListener = mWorker->createListener(listenerPort, listenerCallback, this);
-// #if __linux__
-//     // query network interface
-
-//     struct ifaddrs *ifa, *ifaddr;
-//     void* tmpAddrPtr;
-
-//     TLLM_CHECK_WITH_INFO(getifaddrs(&ifaddr) == 0, " UCX startListener getifaddrs call failed\n");
-//     TLLM_CHECK_WITH_INFO((ifaddr != NULL), "UCX startListener getifaddrs call failed\n");
-//     int idx = 0;
-//     for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next)
-//     {
-//         // exclude docker interface and loopback
-//         if (strcmp(ifa->ifa_name, "docker0") == 0 || strcmp(ifa->ifa_name, "lo") == 0)
-//         {
-//             continue;
-//         }
-//         if (ifa->ifa_addr && ifa->ifa_addr->sa_family == AF_INET)
-//         {
-//             tmpAddrPtr = &((struct sockaddr_in*) ifa->ifa_addr)->sin_addr;
-//             char buffer[INET_ADDRSTRLEN];
-//             inet_ntop(AF_INET, tmpAddrPtr, buffer, INET_ADDRSTRLEN);
-//             mNetInfoMap[std::string(ifa->ifa_name)].interface = std::string(ifa->ifa_name);
-//             mNetInfoMap[std::string(ifa->ifa_name)].ipv4 = std::string(buffer);
-//             if (mNetInfoMap[std::string(ifa->ifa_name)].idx == -1)
-//             {
-//                 mNetInfoMap[std::string(ifa->ifa_name)].idx = idx;
-//                 idx++;
-//             }
-//         }
-//         else if (ifa->ifa_addr && ifa->ifa_addr->sa_family == AF_INET6)
-//         {
-//             tmpAddrPtr = &((struct sockaddr_in6*) ifa->ifa_addr)->sin6_addr;
-//             char buffer[INET6_ADDRSTRLEN];
-//             inet_ntop(AF_INET6, tmpAddrPtr, buffer, INET6_ADDRSTRLEN);
-//             mNetInfoMap[std::string(ifa->ifa_name)].interface = ifa->ifa_name;
-//             mNetInfoMap[std::string(ifa->ifa_name)].ipv6 = std::string(buffer);
-//             if (mNetInfoMap[std::string(ifa->ifa_name)].idx == -1)
-//             {
-//                 mNetInfoMap[std::string(ifa->ifa_name)].idx = idx;
-//                 idx++;
-//             }
-//         }
-//     }
-//     std::string selectedIp;
-//     std::string userUCXInterface = common::getEnvUCXInterface();
-//     if (!userUCXInterface.empty())
-//     {
-//         if (mNetInfoMap.find(userUCXInterface) != mNetInfoMap.end())
-//         {
-//             selectedIp = mNetInfoMap[userUCXInterface].ipv4;
-//             if (selectedIp.empty())
-//             {
-//                 selectedIp = mNetInfoMap[userUCXInterface].ipv6;
-//             }
-//             TLLM_LOG_INFO("UCX listener started on interface:%s address: %s:%u",
-//                 mNetInfoMap[userUCXInterface].interface.c_str(), selectedIp.c_str(), mListener->getPort());
-//             freeifaddrs(ifaddr);
-//             return;
-//         }
-
-//         TLLM_LOG_WARNING("Invalid UCX interface specified: %s will use default interface", userUCXInterface.c_str());
-//     }
-//     std::map<int, NetINfoT> netInfoSortedMap;
-//     for (auto&& [key, netInfo] : mNetInfoMap)
-//     {
-//         netInfoSortedMap[netInfo.idx] = netInfo;
-//     }
-
-//     selectedIp = netInfoSortedMap[0].ipv4;
-//     if (selectedIp.empty())
-//     {
-//         selectedIp = netInfoSortedMap[0].ipv6;
-//     }
-//     TLLM_LOG_INFO("UCX listener started on interface:%s address: %s:%u", netInfoSortedMap[0].interface.c_str(),
-//         selectedIp.c_str(), mListener->getPort());
-//     freeifaddrs(ifaddr);
-// #endif
-// }
-
-// UcxClient::UcxClient()
-// {
-//     mContext = ucxx::createContext({}, ucxx::Context::defaultFeatureFlags);
-//     mWorker = mContext->createWorker();
-//     int device;
-//     TLLM_CUDA_CHECK(cudaGetDevice(&device));
-//     mWorker->setProgressThreadStartCallback([device](void* arg) { TLLM_CUDA_CHECK(cudaSetDevice(device)); },
-//     nullptr); mWorker->startProgressThread(); initSelfIps();
-// }
-
-// void UcxClient::connect(std::string const& ip, std::uint16_t port)
-// {
-/*
-if (mSelfIps.find(ip) != mSelfIps.end())
-{
-    static const std::string localHost{"127.0.0.1"};
-    TLLM_CHECK(mManager.insert(
-        "default", std::make_unique<UcxConnection>(mWorker->createEndpointFromHostname(localHost, port))));
-}
-TLLM_CHECK(
-    mManager.insert("default", std::make_unique<UcxConnection>(mWorker->createEndpointFromHostname(ip, port))));
-*/
-// }
-
-// void UcxClient::initSelfIps()
-// {
-// #if __linux__
-//     struct ifaddrs *ifa, *ifaddr;
-//     void* tmpAddrPtr;
-
-//     TLLM_CHECK_WITH_INFO(getifaddrs(&ifaddr) == 0, " UCX initSelfIps getifaddrs call failed\n");
-//     TLLM_CHECK_WITH_INFO((ifaddr != NULL), "UCX initSelfIps getifaddrs call failed\n");
-
-//     for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next)
-//     {
-//         if (ifa->ifa_addr && ifa->ifa_addr->sa_family == AF_INET)
-//         {
-//             tmpAddrPtr = &((struct sockaddr_in*) ifa->ifa_addr)->sin_addr;
-//             char buffer[INET_ADDRSTRLEN];
-//             inet_ntop(AF_INET, tmpAddrPtr, buffer, INET_ADDRSTRLEN);
-
-//             mSelfIps.insert(std::string(buffer));
-//         }
-//         else if (ifa->ifa_addr && ifa->ifa_addr->sa_family == AF_INET6)
-//         {
-//             tmpAddrPtr = &((struct sockaddr_in6*) ifa->ifa_addr)->sin6_addr;
-//             char buffer[INET6_ADDRSTRLEN];
-//             inet_ntop(AF_INET6, tmpAddrPtr, buffer, INET6_ADDRSTRLEN);
-//             mSelfIps.insert(std::string(buffer));
-//         }
-//     }
-//     freeifaddrs(ifaddr);
-// #endif
-// }
-
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
-#endif
-
-std::unique_ptr<ConnectionManager> makeUcxConnectionManager(mpi::MpiComm const* comm)
-{
-    return nullptr;
-}
-
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
 } // namespace tensorrt_llm::executor::kv_cache
 
 #endif

--- a/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/connection.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/connection.cpp
@@ -22,6 +22,251 @@
 namespace tensorrt_llm::executor::kv_cache
 {
 
+UcxConnection::UcxConnection(
+    uint64_t connectionId, std::shared_ptr<ucxx::Endpoint> endpoint, std::shared_ptr<UcxConnectionManager> manager)
+    : mConnectionId(connectionId)
+    , mEndpoint(endpoint)
+    , mManager(std::move(manager))
+{
+    if (mEndpoint)
+    {
+        initializeEndpointTag();
+    }
+}
+
+// UcxConnection::UcxConnection(UcxConnection&& other): mConnectionId(std::move(other.mConnectionId)),
+// mEndpoint(std::move(other.mEndpoint),mManager(other.mManager){
+// }
+
+void UcxConnection::initializeEndpointTag(int maxTryTimes)
+{
+    // [FIXME] IP exchange seems to be more robust to ensure tag establishment,
+    // i.e. different peers can use the same port number to connect with self worker
+    // which results in identical tag if only self / peer port is used.
+
+    // knowing that ucxx::Tag is uint64_t
+    ucxx::Tag localPort{0};
+    ucxx::Tag remotePort{0};
+    char lIpStr[INET6_ADDRSTRLEN];
+    char rIpStr[INET6_ADDRSTRLEN];
+    char portStr[INET6_ADDRSTRLEN];
+
+    ucp_ep_attr_t ep_attr;
+    ep_attr.field_mask = UCP_EP_ATTR_FIELD_LOCAL_SOCKADDR | UCP_EP_ATTR_FIELD_REMOTE_SOCKADDR;
+
+    ucs_status_t status = ucp_ep_query(mEndpoint->getHandle(), &ep_attr);
+    if (status == UCS_OK)
+    {
+
+        ucxx::utils::sockaddr_get_ip_port_str(&ep_attr.remote_sockaddr, rIpStr, portStr, INET6_ADDRSTRLEN);
+        remotePort = static_cast<ucxx::Tag>(std::stoull(portStr));
+
+        ucxx::utils::sockaddr_get_ip_port_str(&ep_attr.local_sockaddr, lIpStr, portStr, INET6_ADDRSTRLEN);
+        localPort = static_cast<ucxx::Tag>(std::stoull(portStr));
+
+        // Network port value is defined to fit in 16 bit.
+        // sendTag format : [remotePort localPort remotIP]
+        mSendTag = static_cast<ucxx::Tag>((localPort << (16 + 32)) | (remotePort << 32) | std::stoull(lIpStr));
+        mRecvTag = static_cast<ucxx::Tag>((remotePort << (16 + 32)) | (localPort << 32) | std::stoull(rIpStr));
+    }
+    else
+    {
+        // [FIXME] better message
+        if (status == UCS_ERR_NOT_CONNECTED && maxTryTimes > 0)
+        {
+            TLLM_LOG_WARNING("UCX connection has not been established yet. wait 100 ms before retrying. maxTryTimes:%d",
+                maxTryTimes);
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+            initializeEndpointTag(maxTryTimes - 1);
+        }
+        else
+        {
+            TLLM_LOG_WARNING("UCX data transceiver is not created by connecting to a socket address.");
+        }
+    }
+}
+
+void UcxConnection::send(DataContext const& ctx, void const* data, size_t size) const
+{
+    // Guard to ensure CUDA context is initialized for UCX ops
+    TLLM_CUDA_CHECK(cudaFree(0));
+    TLLM_CHECK_WITH_INFO((mEndpoint), "sendBuffer called without established communicator channel.");
+    auto completionCallback = [this](ucs_status_t, ucxx::RequestCallbackUserData) -> void { mCv.notify_all(); };
+    auto req = mEndpoint->tagSend(const_cast<void*>(data), size, mSendTag, false, completionCallback);
+    std::unique_lock<std::mutex> lk(mMtx);
+    mCv.wait(lk, [&req]() { return req->isCompleted(); });
+    // throw if there is error
+    req->checkError();
+}
+
+void UcxConnection::recv(DataContext const& ctx, void* data, size_t size) const
+{
+    // Guard to ensure CUDA context is initialized for UCX ops
+    TLLM_CUDA_CHECK(cudaFree(0));
+    TLLM_CHECK_WITH_INFO((mEndpoint), "recvBuffer called without established communicator channel.");
+    auto completionCallback = [this](ucs_status_t, ucxx::RequestCallbackUserData) -> void { mCv.notify_all(); };
+    auto req = mEndpoint->tagRecv(data, size, mRecvTag, ucxx::TagMaskFull, false, completionCallback);
+    std::unique_lock<std::mutex> lk(mMtx);
+    mCv.wait(lk, [&req]() { return req->isCompleted(); });
+    // throw if there is error
+    req->checkError();
+}
+
+// UcxServer::UcxServer(uint16_t listenerPort)
+// {
+//     mContext = ucxx::createContext({}, ucxx::Context::defaultFeatureFlags);
+//     mWorker = mContext->createWorker();
+//     // Ensure the progress thread has CUDA context initialized
+//     int device;
+//     TLLM_CUDA_CHECK(cudaGetDevice(&device));
+//     mWorker->setProgressThreadStartCallback([device](void* arg) { TLLM_CUDA_CHECK(cudaSetDevice(device)); },
+//     nullptr); mWorker->startProgressThread(); startListener(listenerPort);
+// }
+
+// void UcxServer::listenerCallback(ucp_conn_request_h conn_request, void* arg)
+// {
+//     auto* self = reinterpret_cast<UcxServer*>(arg);
+//     auto endpoint = self->mListener->createEndpointFromConnRequest(conn_request);
+//     // TLLM_CHECK(self->mManager.insert("default", std::make_unique<UcxConnection>(std::move(endpoint))));
+// }
+
+// void UcxServer::startListener(uint16_t listenerPort)
+// {
+//     mListener = mWorker->createListener(listenerPort, listenerCallback, this);
+// #if __linux__
+//     // query network interface
+
+//     struct ifaddrs *ifa, *ifaddr;
+//     void* tmpAddrPtr;
+
+//     TLLM_CHECK_WITH_INFO(getifaddrs(&ifaddr) == 0, " UCX startListener getifaddrs call failed\n");
+//     TLLM_CHECK_WITH_INFO((ifaddr != NULL), "UCX startListener getifaddrs call failed\n");
+//     int idx = 0;
+//     for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next)
+//     {
+//         // exclude docker interface and loopback
+//         if (strcmp(ifa->ifa_name, "docker0") == 0 || strcmp(ifa->ifa_name, "lo") == 0)
+//         {
+//             continue;
+//         }
+//         if (ifa->ifa_addr && ifa->ifa_addr->sa_family == AF_INET)
+//         {
+//             tmpAddrPtr = &((struct sockaddr_in*) ifa->ifa_addr)->sin_addr;
+//             char buffer[INET_ADDRSTRLEN];
+//             inet_ntop(AF_INET, tmpAddrPtr, buffer, INET_ADDRSTRLEN);
+//             mNetInfoMap[std::string(ifa->ifa_name)].interface = std::string(ifa->ifa_name);
+//             mNetInfoMap[std::string(ifa->ifa_name)].ipv4 = std::string(buffer);
+//             if (mNetInfoMap[std::string(ifa->ifa_name)].idx == -1)
+//             {
+//                 mNetInfoMap[std::string(ifa->ifa_name)].idx = idx;
+//                 idx++;
+//             }
+//         }
+//         else if (ifa->ifa_addr && ifa->ifa_addr->sa_family == AF_INET6)
+//         {
+//             tmpAddrPtr = &((struct sockaddr_in6*) ifa->ifa_addr)->sin6_addr;
+//             char buffer[INET6_ADDRSTRLEN];
+//             inet_ntop(AF_INET6, tmpAddrPtr, buffer, INET6_ADDRSTRLEN);
+//             mNetInfoMap[std::string(ifa->ifa_name)].interface = ifa->ifa_name;
+//             mNetInfoMap[std::string(ifa->ifa_name)].ipv6 = std::string(buffer);
+//             if (mNetInfoMap[std::string(ifa->ifa_name)].idx == -1)
+//             {
+//                 mNetInfoMap[std::string(ifa->ifa_name)].idx = idx;
+//                 idx++;
+//             }
+//         }
+//     }
+//     std::string selectedIp;
+//     std::string userUCXInterface = common::getEnvUCXInterface();
+//     if (!userUCXInterface.empty())
+//     {
+//         if (mNetInfoMap.find(userUCXInterface) != mNetInfoMap.end())
+//         {
+//             selectedIp = mNetInfoMap[userUCXInterface].ipv4;
+//             if (selectedIp.empty())
+//             {
+//                 selectedIp = mNetInfoMap[userUCXInterface].ipv6;
+//             }
+//             TLLM_LOG_INFO("UCX listener started on interface:%s address: %s:%u",
+//                 mNetInfoMap[userUCXInterface].interface.c_str(), selectedIp.c_str(), mListener->getPort());
+//             freeifaddrs(ifaddr);
+//             return;
+//         }
+
+//         TLLM_LOG_WARNING("Invalid UCX interface specified: %s will use default interface", userUCXInterface.c_str());
+//     }
+//     std::map<int, NetINfoT> netInfoSortedMap;
+//     for (auto&& [key, netInfo] : mNetInfoMap)
+//     {
+//         netInfoSortedMap[netInfo.idx] = netInfo;
+//     }
+
+//     selectedIp = netInfoSortedMap[0].ipv4;
+//     if (selectedIp.empty())
+//     {
+//         selectedIp = netInfoSortedMap[0].ipv6;
+//     }
+//     TLLM_LOG_INFO("UCX listener started on interface:%s address: %s:%u", netInfoSortedMap[0].interface.c_str(),
+//         selectedIp.c_str(), mListener->getPort());
+//     freeifaddrs(ifaddr);
+// #endif
+// }
+
+// UcxClient::UcxClient()
+// {
+//     mContext = ucxx::createContext({}, ucxx::Context::defaultFeatureFlags);
+//     mWorker = mContext->createWorker();
+//     int device;
+//     TLLM_CUDA_CHECK(cudaGetDevice(&device));
+//     mWorker->setProgressThreadStartCallback([device](void* arg) { TLLM_CUDA_CHECK(cudaSetDevice(device)); },
+//     nullptr); mWorker->startProgressThread(); initSelfIps();
+// }
+
+// void UcxClient::connect(std::string const& ip, std::uint16_t port)
+// {
+/*
+if (mSelfIps.find(ip) != mSelfIps.end())
+{
+    static const std::string localHost{"127.0.0.1"};
+    TLLM_CHECK(mManager.insert(
+        "default", std::make_unique<UcxConnection>(mWorker->createEndpointFromHostname(localHost, port))));
+}
+TLLM_CHECK(
+    mManager.insert("default", std::make_unique<UcxConnection>(mWorker->createEndpointFromHostname(ip, port))));
+*/
+// }
+
+// void UcxClient::initSelfIps()
+// {
+// #if __linux__
+//     struct ifaddrs *ifa, *ifaddr;
+//     void* tmpAddrPtr;
+
+//     TLLM_CHECK_WITH_INFO(getifaddrs(&ifaddr) == 0, " UCX initSelfIps getifaddrs call failed\n");
+//     TLLM_CHECK_WITH_INFO((ifaddr != NULL), "UCX initSelfIps getifaddrs call failed\n");
+
+//     for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next)
+//     {
+//         if (ifa->ifa_addr && ifa->ifa_addr->sa_family == AF_INET)
+//         {
+//             tmpAddrPtr = &((struct sockaddr_in*) ifa->ifa_addr)->sin_addr;
+//             char buffer[INET_ADDRSTRLEN];
+//             inet_ntop(AF_INET, tmpAddrPtr, buffer, INET_ADDRSTRLEN);
+
+//             mSelfIps.insert(std::string(buffer));
+//         }
+//         else if (ifa->ifa_addr && ifa->ifa_addr->sa_family == AF_INET6)
+//         {
+//             tmpAddrPtr = &((struct sockaddr_in6*) ifa->ifa_addr)->sin6_addr;
+//             char buffer[INET6_ADDRSTRLEN];
+//             inet_ntop(AF_INET6, tmpAddrPtr, buffer, INET6_ADDRSTRLEN);
+//             mSelfIps.insert(std::string(buffer));
+//         }
+//     }
+//     freeifaddrs(ifaddr);
+// #endif
+// }
+
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
@@ -35,7 +280,6 @@ std::unique_ptr<ConnectionManager> makeUcxConnectionManager(mpi::MpiComm const* 
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif
-
 } // namespace tensorrt_llm::executor::kv_cache
 
 #endif

--- a/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/connection.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/connection.cpp
@@ -38,22 +38,11 @@ UcxConnection::UcxConnection(
     }
 }
 
-// void UcxConnection::initialize(UcxConnectionManager* manager)
-// {
-//     std::cout << "UcxConnection::initialize" << std::endl;
-//     mManager = manager;
-//     if (mManager)
-//     {
-//         mLocalGID = mManager->getLocalGID();
-//         TLLM_LOG_DEBUG("UcxConnection::initialize | rank %d | local gid: %lu", mManager->getRank(), mLocalGID);
-//     }
-// }
-
 void UcxConnection::sendGID()
 {
     if (mLocalGID == std::numeric_limits<uint64_t>::max())
     {
-        throw std::runtime_error("UcxConnection::sendGID | mLocalGID is not set");
+        TLLM_THROW("UcxConnection::sendGID | mLocalGID is not set");
     }
     std::shared_ptr<ucxx::Request> request
         = mEndpoint->streamSend(reinterpret_cast<void*>(&mLocalGID), sizeof(mLocalGID), false);
@@ -81,8 +70,6 @@ void UcxConnection::initializeEndpointTag(int maxTryTimes)
     ucs_status_t status = ucp_ep_query(mEndpoint->getHandle(), &ep_attr);
     if (status == UCS_OK)
     {
-
-        std::cout << " initializeEndpointTag" << std::endl;
         ucxx::utils::sockaddr_get_ip_port_str(&ep_attr.remote_sockaddr, rIpStr, portStr, INET6_ADDRSTRLEN);
         remotePort = static_cast<ucxx::Tag>(std::stoull(portStr));
 

--- a/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/connection.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/connection.cpp
@@ -102,8 +102,7 @@ void UcxConnection::initializeEndpointTag(int maxTryTimes)
 
 void UcxConnection::send(DataContext const& ctx, void const* data, size_t size) const
 {
-    // Guard to ensure CUDA context is initialized for UCX ops
-    TLLM_CUDA_CHECK(cudaFree(0));
+
     TLLM_CHECK_WITH_INFO((mEndpoint), "sendBuffer called without established communicator channel.");
     TLLM_LOG_DEBUG("UcxConnection::send | rank %d | sendTag: %lu | remote gid: %lu", mLocalGID, mSendTag, mRemoteGID);
     auto completionCallback = [this](ucs_status_t, ucxx::RequestCallbackUserData) -> void { mCv.notify_all(); };

--- a/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/connection.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/connection.cpp
@@ -130,7 +130,6 @@ void UcxConnection::recv(DataContext const& ctx, void* data, size_t size) const
     req->checkError();
 }
 
-
 } // namespace tensorrt_llm::executor::kv_cache
 
 #endif

--- a/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/connection.h
+++ b/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/connection.h
@@ -41,26 +41,13 @@ public:
     UcxConnection() = default;
     explicit UcxConnection(
         uint64_t connectionId, std::shared_ptr<ucxx::Endpoint> endpoint, UcxConnectionManager* manager);
-    // UcxConnection(UcxConnection&& other);
     void sendGID();
     void send(DataContext const& ctx, void const* data, size_t size) const override;
     void recv(DataContext const& ctx, void* data, size_t size) const override;
-    // void initialize(UcxConnectionManager* manager);
     friend class UcxConnectionManager;
 
 private:
     void initializeEndpointTag(int maxTryTimes = 10);
-    /*
-        static constexpr ucxx::Tag kID_TAG{1};
-        static constexpr ucxx::Tag kDATA_TAG{2};
-
-        // Set of bit map used to represent UCXComm flags
-        ucxx::Tag mInfoTag{1};
-
-        static constexpr ucxx::TagMask mEndpointMask{(((uint64_t) 1 << (32 + 1)) - 1) << 32};
-        static constexpr ucxx::TagMask mRequestIdMask{(((uint64_t) 1 << (16 + 1)) - 1) << 16};
-        static constexpr ucxx::TagMask mFlagMask{(((uint64_t) 1 << (16 + 1)) - 1)};
-    */
 
     // a send tag is defined as:
     // | local port (16 bits) | remote port (16 bits) | truncated request id (16 bits) | UCXComm flags (16 bits) |
@@ -77,50 +64,5 @@ private:
     std::shared_ptr<ucxx::Endpoint> mEndpoint;
     UcxConnectionManager* mManager;
 };
-
-// class UcxServer
-// {
-// public:
-//     UcxServer(uint16_t listenerPort = 0);
-//     [[nodiscard]] ConnectionManager const& getConnectionManager() const;
-
-// private:
-//     struct NetINfoT
-//     {
-//         std::string interface;
-//         std::string ipv4;
-//         std::string ipv6;
-//         int idx = -1;
-//     };
-
-//     static void listenerCallback(ucp_conn_request_h conn_request, void* arg);
-//     void startListener(uint16_t listenerPort);
-
-//     UcxConnectionManager& mManager;
-//     std::unordered_map<std::string, NetINfoT> mNetInfoMap;
-//     std::shared_ptr<ucxx::Context> mContext;
-//     std::shared_ptr<ucxx::Worker> mWorker;
-//     std::shared_ptr<ucxx::Listener> mListener;
-// };
-
-// class UcxClient
-// {
-// public:
-//     UcxClient();
-//     void connect(std::string const& ip, std::uint16_t port);
-
-//     [[nodiscard]] ConnectionManager const& getConnectionManager() const
-//     {
-//         return mManager;
-//     }
-
-// private:
-//     void initSelfIps();
-
-//     UcxConnectionManager mManager;
-//     std::shared_ptr<ucxx::Context> mContext;
-//     std::shared_ptr<ucxx::Worker> mWorker;
-//     std::unordered_set<std::string> mSelfIps;
-// };
 
 } // namespace tensorrt_llm::executor::kv_cache

--- a/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/connection.h
+++ b/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/connection.h
@@ -123,18 +123,4 @@ private:
 //     std::unordered_set<std::string> mSelfIps;
 // };
 
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
-#endif
-
-extern "C"
-{
-    [[nodiscard]] std::unique_ptr<ConnectionManager> makeUcxConnectionManager(mpi::MpiComm const* comm);
-}
-
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
-
 } // namespace tensorrt_llm::executor::kv_cache

--- a/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/connection.h
+++ b/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/connection.h
@@ -23,6 +23,91 @@
 namespace tensorrt_llm::executor::kv_cache
 {
 
+class UcxConnectionManager;
+
+class UcxConnection : public Connection
+{
+public:
+    UcxConnection() = default;
+    explicit UcxConnection(
+        uint64_t connectionId, std::shared_ptr<ucxx::Endpoint> endpoint, std::shared_ptr<UcxConnectionManager> manager);
+    // UcxConnection(UcxConnection&& other);
+    void send(DataContext const& ctx, void const* data, size_t size) const override;
+    void recv(DataContext const& ctx, void* data, size_t size) const override;
+
+private:
+    void initializeEndpointTag(int maxTryTimes = 10);
+    /*
+        static constexpr ucxx::Tag kID_TAG{1};
+        static constexpr ucxx::Tag kDATA_TAG{2};
+
+        // Set of bit map used to represent UCXComm flags
+        ucxx::Tag mInfoTag{1};
+
+        static constexpr ucxx::TagMask mEndpointMask{(((uint64_t) 1 << (32 + 1)) - 1) << 32};
+        static constexpr ucxx::TagMask mRequestIdMask{(((uint64_t) 1 << (16 + 1)) - 1) << 16};
+        static constexpr ucxx::TagMask mFlagMask{(((uint64_t) 1 << (16 + 1)) - 1)};
+    */
+
+    // a send tag is defined as:
+    // | local port (16 bits) | remote port (16 bits) | truncated request id (16 bits) | UCXComm flags (16 bits) |
+    // a recv tag is defined as:
+    // | remote port (16 bits) | local port (16 bits) | truncated request id (16 bits) | UCXComm flags (16 bits) |
+    ucxx::Tag mSendTag{0};
+    ucxx::Tag mRecvTag{0};
+
+    mutable std::mutex mMtx;
+    mutable std::condition_variable mCv;
+    uint64_t mConnectionId;
+    std::shared_ptr<ucxx::Endpoint> mEndpoint;
+    std::shared_ptr<UcxConnectionManager> mManager;
+};
+
+// class UcxServer
+// {
+// public:
+//     UcxServer(uint16_t listenerPort = 0);
+//     [[nodiscard]] ConnectionManager const& getConnectionManager() const;
+
+// private:
+//     struct NetINfoT
+//     {
+//         std::string interface;
+//         std::string ipv4;
+//         std::string ipv6;
+//         int idx = -1;
+//     };
+
+//     static void listenerCallback(ucp_conn_request_h conn_request, void* arg);
+//     void startListener(uint16_t listenerPort);
+
+//     UcxConnectionManager& mManager;
+//     std::unordered_map<std::string, NetINfoT> mNetInfoMap;
+//     std::shared_ptr<ucxx::Context> mContext;
+//     std::shared_ptr<ucxx::Worker> mWorker;
+//     std::shared_ptr<ucxx::Listener> mListener;
+// };
+
+// class UcxClient
+// {
+// public:
+//     UcxClient();
+//     void connect(std::string const& ip, std::uint16_t port);
+
+//     [[nodiscard]] ConnectionManager const& getConnectionManager() const
+//     {
+//         return mManager;
+//     }
+
+// private:
+//     void initSelfIps();
+
+//     UcxConnectionManager mManager;
+//     std::shared_ptr<ucxx::Context> mContext;
+//     std::shared_ptr<ucxx::Worker> mWorker;
+//     std::unordered_set<std::string> mSelfIps;
+// };
+
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wreturn-type-c-linkage"

--- a/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/connection.h
+++ b/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/connection.h
@@ -29,11 +29,11 @@ class UcxConnection : public Connection
 {
 public:
     UcxConnection() = default;
-    explicit UcxConnection(
-        uint64_t connectionId, std::shared_ptr<ucxx::Endpoint> endpoint, std::shared_ptr<UcxConnectionManager> manager);
+    explicit UcxConnection(uint64_t connectionId, std::shared_ptr<ucxx::Endpoint> endpoint);
     // UcxConnection(UcxConnection&& other);
     void send(DataContext const& ctx, void const* data, size_t size) const override;
     void recv(DataContext const& ctx, void* data, size_t size) const override;
+    void initialize(std::shared_ptr<UcxConnectionManager> manager);
 
 private:
     void initializeEndpointTag(int maxTryTimes = 10);

--- a/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.cpp
@@ -195,6 +195,14 @@ UcxConnectionManager::UcxConnectionManager(tensorrt_llm::mpi::MpiComm const* com
     }
 }
 
+UcxConnectionManager::~UcxConnectionManager()
+{
+    for (auto& worker : mWorkersPool)
+    {
+        worker->stopProgressThread();
+    }
+}
+
 void UcxConnectionManager::updateGIDToConnectionIdMap(
     std::shared_ptr<ucxx::Request> request, uint64_t* gid, uint64_t connectionId)
 {

--- a/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.cpp
@@ -1,3 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.h"
 #include "tensorrt_llm/common/logger.h"
 #include <exception>
@@ -128,23 +145,6 @@ UcxConnectionManager::UcxConnectionManager(tensorrt_llm::mpi::MpiComm const* com
         tensorrt_llm::mpi::MpiComm kvCacheComm(comm->split(300, mComm->getRank()));
         TLLM_LOG_DEBUG("rank %d | comm split done | kvCacheComm size %d, kvCacheComm rank %d", comm->getRank(),
             kvCacheComm.getSize(), kvCacheComm.getRank());
-        // if (excludeRank0)
-        // {
-        //     MPI_Comm newComm;
-        //     MPI_Group worldGroup, newGroup;
-        //     MPI_Comm_group(MPI_COMM_WORLD, &worldGroup);
-        //     std::vector<int> ranks(comm->getSize() - 1);
-        //     for (int i = 0; i < comm->getSize() - 1; i++) {ranks[i]=i+1;}
-        //     MPI_Group_incl(worldGroup, comm->getSize() - 1, ranks, &newGroup);
-
-        //     // Create the new communicator
-        //     MPI_Comm_create_group(MPI_COMM_WORLD, newGroup, 0, &newComm);
-        //     MPI_Group_free(&newGroup);
-        //     MPI_Group_free(&world_group);
-        //     kvCacheComm = tensorrt_llm::mpi::MpiComm(newComm,true);
-        // }else{
-        //     kvCacheComm = *comm;
-        // }
 
         int excludeRank0 = comm->getSize() != kvCacheComm.getSize();
 
@@ -290,15 +290,6 @@ uint64_t UcxConnectionManager::getNewConnectionId(std::shared_ptr<ucxx::Endpoint
         localPort);
     return ((remotePort << (32 + 16)) | (localPort << 32) | remoteIp);
 }
-
-// void UcxConnectionManager::initializeConnections()
-// {
-//     for (auto& connection : mConnections)
-//     {
-//         TLLM_LOG_DEBUG("UcxConnectionManager::initializeConnections");
-//         connection.second->initialize(this);
-//     }
-// }
 
 Connection const* UcxConnectionManager::recvConnect(DataContext const& ctx, void* data, size_t size)
 {

--- a/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.cpp
@@ -99,7 +99,7 @@ UcxConnectionManager::UcxConnectionManager(tensorrt_llm::mpi::MpiComm const* com
         {
             std::string error = "Error creating worker and starting progress thread for rank "
                 + std::to_string(mComm->getRank()) + ": " + std::string(e.what());
-            throw std::runtime_error(error);
+            TLLM_THROW(error);
         }
 
         try
@@ -110,7 +110,7 @@ UcxConnectionManager::UcxConnectionManager(tensorrt_llm::mpi::MpiComm const* com
         catch (std::exception const& e)
         {
             std::string error = "Error creating listener for rank " + std::to_string(comm->getRank()) + ": " + e.what();
-            throw std::runtime_error(error);
+            TLLM_THROW(error);
         }
 
         // Get local IP address
@@ -191,7 +191,7 @@ UcxConnectionManager::UcxConnectionManager(tensorrt_llm::mpi::MpiComm const* com
     {
         std::string error = "Error in UcxConnectionManager initialization for rank " + std::to_string(comm->getRank())
             + ": " + e.what();
-        throw std::runtime_error(error);
+        TLLM_THROW(error);
     }
 }
 
@@ -227,7 +227,7 @@ uint64_t UcxConnectionManager::addConnection(ucp_conn_request_h connRequest)
     {
         std::string error
             = "Error in addConnection(connRequest) for rank " + std::to_string(mComm->getRank()) + ": " + e.what();
-        throw std::runtime_error(error);
+        TLLM_THROW(error);
     }
 }
 
@@ -247,7 +247,7 @@ uint64_t UcxConnectionManager::addConnection(std::string ip, uint16_t port)
     catch (std::exception const& e)
     {
         std::string error = "Error in addConnection(ip) for rank " + std::to_string(mComm->getRank()) + ": " + e.what();
-        throw std::runtime_error(error);
+        TLLM_THROW(error);
     }
 }
 
@@ -318,7 +318,7 @@ Connection const* UcxConnectionManager::recvConnect(DataContext const& ctx, void
     }
     if (status != UCS_OK)
     {
-        throw std::runtime_error("Error in recvConnect" + std::to_string(status));
+        TLLM_THROW("Error in recvConnect" + std::to_string(status));
     }
     TLLM_LOG_DEBUG("recvConnect2 | rank %d | senderTag: %lu", getLocalGID(), senderTag);
 
@@ -350,7 +350,7 @@ return UcxConnectionManager::create(comm);
     {
         std::string error
             = "Error in makeUcxConnectionManager for rank " + std::to_string(comm->getRank()) + ": " + e.what();
-        throw std::runtime_error(error);
+        TLLM_THROW(error);
     }
 }
 

--- a/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.cpp
@@ -1,36 +1,41 @@
 #include "tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.h"
+#include "tensorrt_llm/common/logger.h"
+#include <exception>
+#include <iostream>
+#include <sys/socket.h>
 #include <unistd.h>
 
 namespace tensorrt_llm::executor::kv_cache
 {
 
-const uint16_t listener_port = 12345;
+const uint16_t listenerPort = 12345;
 int const MAX_IP_LENGTH = 16;
-static void listener_cb(ucp_conn_request_h conn_request, void* arg);
-static std::string getLocalIP();
+static void listenerCallback(ucp_conn_request_h connRequest, void* arg);
+static std::string getLocalIp();
 
-static void listener_cb(ucp_conn_request_h conn_request, void* arg)
+static void listenerCallback(ucp_conn_request_h connRequest, void* arg)
 {
-    char ip_str[INET6_ADDRSTRLEN];
-    char port_str[INET6_ADDRSTRLEN];
+    char ipStr[INET6_ADDRSTRLEN];
+    char portStr[INET6_ADDRSTRLEN];
     ucp_conn_request_attr_t attr{};
     UcxConnectionManager* connectionManager = reinterpret_cast<UcxConnectionManager*>(arg);
 
     attr.field_mask = UCP_CONN_REQUEST_ATTR_FIELD_CLIENT_ADDR;
-    ucxx::utils::ucsErrorThrow(ucp_conn_request_query(conn_request, &attr));
-    ucxx::utils::sockaddr_get_ip_port_str(&attr.client_address, ip_str, port_str, INET6_ADDRSTRLEN);
-    TLLM_LOG_DEBUG("Server received a connection request from client at address %s:%d ", ip_str, port_str);
-    connectionManager->addConnection(conn_request);
+    ucxx::utils::ucsErrorThrow(ucp_conn_request_query(connRequest, &attr));
+    ucxx::utils::sockaddr_get_ip_port_str(&attr.client_address, ipStr, portStr, INET6_ADDRSTRLEN);
+    TLLM_LOG_DEBUG("Server received a connection request from client at address %s:%d ", ipStr, portStr);
+    std::cout << "Server received a connection request from client at address " << ipStr << ":" << portStr << std::endl;
+    connectionManager->addConnection(connRequest);
 }
 
-static std::string getLocalIP()
+static std::string getLocalIp()
 {
     char hostname[256];
     gethostname(hostname, sizeof(hostname));
-    struct hostent* host_entry = gethostbyname(hostname);
-    if (host_entry != nullptr)
+    struct hostent* hostEntry = gethostbyname(hostname);
+    if (hostEntry != nullptr)
     {
-        return inet_ntoa(*((struct in_addr*) host_entry->h_addr_list[0]));
+        return inet_ntoa(*((struct in_addr*) hostEntry->h_addr_list[0]));
     }
     return "Unknown";
 }
@@ -38,45 +43,150 @@ static std::string getLocalIP()
 UcxConnectionManager::UcxConnectionManager(mpi::MpiComm const* comm)
     : mComm(comm)
 {
-    TLLM_CHECK(mComm);
-    int device;
-    TLLM_CUDA_CHECK(cudaGetDevice(&device));
-    mUcxCtx = ucxx::createContext({}, ucxx::Context::defaultFeatureFlags);
-    mWorkersPool.push_back(mUcxCtx->createWorker()); // TODO: support configurable workers pool size
-    mWorkersPool.back().get()->startProgressThread(true);
-    mListener = mWorkersPool.front()->createListener(listener_port, listener_cb, this);
-    // Get local IP address
-    std::string localIP = getLocalIP();
-    std::vector<char> localIPBuffer(MAX_IP_LENGTH, 0);
-    std::strncpy(localIPBuffer.data(), localIP.c_str(), MAX_IP_LENGTH - 1);
-
-    // Allocate buffer for all IP addresses
-    std::vector<char> allIPs(comm->getSize() * MAX_IP_LENGTH);
-
-    // Perform Allgather operation
-    mComm->allgather(
-        localIPBuffer.data(), allIPs.data(), comm->getSize() * MAX_IP_LENGTH, tensorrt_llm::mpi::MpiType::kCHAR);
-    for (int i = comm->getRank() + 1; i < comm->getSize(); i++)
+    try
     {
-        std::string Ip(allIPs.data() + i * MAX_IP_LENGTH);
-        TLLM_LOG_DEBUG("rank %d | got IP %s from rank %d", comm->getRank(), Ip.c_str(), i);
-        addConnection(Ip);
+        TLLM_CHECK(mComm);
+        int device;
+        TLLM_CUDA_CHECK(cudaGetDevice(&device));
+        mUcxCtx = ucxx::createContext({}, ucxx::Context::defaultFeatureFlags);
+
+        mWorkersPool.push_back(mUcxCtx->createWorker());
+        mWorkersPool.back().get()->startProgressThread(true);
+
+        try
+        {
+            mListener = mWorkersPool.front()->createListener(listenerPort + comm->getRank(), listenerCallback, this);
+        }
+        catch (std::exception const& e)
+        {
+            std::string error = "Error creating listener for rank " + std::to_string(comm->getRank()) + ": " + e.what();
+            throw std::runtime_error(error);
+        }
+
+        // Get local IP address
+        std::string localIp = getLocalIp();
+        std::vector<char> localIpBuffer(MAX_IP_LENGTH, 0);
+        std::strncpy(localIpBuffer.data(), localIp.c_str(), MAX_IP_LENGTH - 1);
+
+        // Allocate buffer for all IP addresses
+        std::vector<char> allIps(comm->getSize() * MAX_IP_LENGTH);
+
+        // Perform Allgather operation
+        mComm->allgather(
+            localIpBuffer.data(), allIps.data(), comm->getSize() * MAX_IP_LENGTH, tensorrt_llm::mpi::MpiType::kCHAR);
+
+        for (int i = 0; i < comm->getSize(); i++)
+        {
+            std::string ip(allIps.data() + i * MAX_IP_LENGTH);
+            TLLM_LOG_DEBUG("rank %d | got IP %s from rank %d", comm->getRank(), ip.c_str(), i);
+            mIpToMpiRank[ip] = i;
+        }
+        comm->barrier();
+
+        for (int i = comm->getRank() + 1; i < comm->getSize(); i++)
+        {
+            std::string ip(allIps.data() + i * MAX_IP_LENGTH);
+            addConnection(ip, listenerPort + i);
+        }
+    }
+    catch (std::exception const& e)
+    {
+        std::string error = "Error in UcxConnectionManager initialization for rank " + std::to_string(comm->getRank())
+            + ": " + e.what();
+        throw std::runtime_error(error);
     }
 }
 
-void UcxConnectionManager::addConnection(ucp_conn_request_h conn_request)
+void UcxConnectionManager::addConnection(ucp_conn_request_h connRequest)
 {
-    std::shared_ptr<ucxx::Endpoint> newEp = mListener->createEndpointFromConnRequest(conn_request, true);
-    uint64_t id = getNewConnectionId(newEp);
-    mConnections.emplace(id, std::make_shared<UcxConnection>(id, newEp, shared_from_this()));
+    try
+    {
+        std::shared_ptr<ucxx::Endpoint> newEp = mListener->createEndpointFromConnRequest(connRequest, true);
+        uint64_t id = getNewConnectionId(newEp);
+        mConnections.emplace(id, std::make_shared<UcxConnection>(id, newEp, shared_from_this()));
+    }
+    catch (std::exception const& e)
+    {
+        std::string error
+            = "Error in addConnection(connRequest) for rank " + std::to_string(mComm->getRank()) + ": " + e.what();
+        throw std::runtime_error(error);
+    }
 }
 
-void UcxConnectionManager::addConnection(std::string Ip)
+void UcxConnectionManager::addConnection(std::string ip, uint16_t port)
 {
-    std::shared_ptr<ucxx::Endpoint> newEp
-        = mWorkersPool.front()->createEndpointFromHostname(Ip, listener_port, true); // TODO: workers round robin
-    uint64_t id = getNewConnectionId(newEp);
-    mConnections.emplace(id, std::make_shared<UcxConnection>(id, newEp, shared_from_this()));
+    try
+    {
+        std::shared_ptr<ucxx::Endpoint> newEp = mWorkersPool.front()->createEndpointFromHostname(ip, port, true);
+        uint64_t id = getNewConnectionId(newEp);
+        mConnections.emplace(id, std::make_shared<UcxConnection>(id, newEp, shared_from_this()));
+    }
+    catch (std::exception const& e)
+    {
+        std::string error = "Error in addConnection(ip) for rank " + std::to_string(mComm->getRank()) + ": " + e.what();
+        throw std::runtime_error(error);
+    }
+}
+
+uint64_t UcxConnectionManager::getNewConnectionId(std::shared_ptr<ucxx::Endpoint> newEp)
+{
+    ucp_ep_attr_t ep_attr;
+    ep_attr.field_mask = UCP_EP_ATTR_FIELD_LOCAL_SOCKADDR | UCP_EP_ATTR_FIELD_REMOTE_SOCKADDR;
+    uint64_t remotePort, localPort;
+    uint32_t remoteIp;
+    char lIpStr[INET6_ADDRSTRLEN];
+    char rIpStr[INET6_ADDRSTRLEN];
+    char portStr[INET6_ADDRSTRLEN];
+    ucs_status_t status = ucp_ep_query(newEp->getHandle(), &ep_attr);
+    if (status == UCS_OK)
+    {
+        ucxx::utils::sockaddr_get_ip_port_str(&ep_attr.remote_sockaddr, rIpStr, portStr, INET6_ADDRSTRLEN);
+        remotePort = static_cast<ucxx::Tag>(std::stoull(portStr));
+        remoteIp = std::stoull(lIpStr);
+        ucxx::utils::sockaddr_get_ip_port_str(&ep_attr.local_sockaddr, lIpStr, portStr, INET6_ADDRSTRLEN);
+        localPort = static_cast<ucxx::Tag>(std::stoull(portStr));
+        mMpiRankToConnectionId[mIpToMpiRank[std::string(rIpStr)]]
+            = ((remotePort << (32 + 16)) | (localPort << 32) | remoteIp);
+        return ((remotePort << (32 + 16)) | (localPort << 32) | remoteIp);
+    }
+    else
+    {
+        if (status == UCS_ERR_NOT_CONNECTED)
+        {
+            TLLM_LOG_ERROR("UCX connection has not been established yet");
+        }
+    }
+    return 0;
+}
+
+Connection const* UcxConnectionManager::recvConnect(DataContext const& ctx, void* data, size_t size)
+{
+    // Guard to ensure CUDA context is initialized for UCX ops
+    TLLM_CUDA_CHECK(cudaFree(0));
+    uint64_t senderTag;
+    ucp_request_param_t tagRecvParams;
+    tagRecvParams.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK | UCP_OP_ATTR_FIELD_USER_DATA;
+    tagRecvParams.cb.recv = [](void* request, ucs_status_t status, ucp_tag_recv_info_t const* info,
+                                void* userData) -> void { *(uint64_t*) userData = info->sender_tag; };
+    tagRecvParams.user_data = &senderTag;
+
+    auto request = ucp_tag_recv_nbx(mWorkersPool.front().get()->getHandle(), data, size, 1, 0, &tagRecvParams);
+
+    while (ucp_request_check_status(request) != UCS_INPROGRESS)
+        ;
+
+    return mConnections[senderTag].get();
+}
+
+std::vector<Connection const*> UcxConnectionManager::getConnections(CommState const& state)
+{
+    std::vector<Connection const*> ret;
+    TLLM_CHECK(state.isMpiState());
+    for (auto rank : state.getMpiState().mRanks)
+    {
+        ret.emplace_back(mConnections[mMpiRankToConnectionId[rank]].get());
+    }
+    return ret;
 }
 
 #if defined(__clang__)
@@ -86,7 +196,16 @@ void UcxConnectionManager::addConnection(std::string Ip)
 
 std::unique_ptr<ConnectionManager> makeMpiConnectionManager(mpi::MpiComm const* comm)
 {
-    return std::make_unique<UcxConnectionManager>(comm);
+    try
+    {
+        return std::make_unique<UcxConnectionManager>(comm);
+    }
+    catch (std::exception const& e)
+    {
+        std::string error
+            = "Error in makeUcxConnectionManager for rank " + std::to_string(comm->getRank()) + ": " + e.what();
+        throw std::runtime_error(error);
+    }
 }
 
 #if defined(__clang__)

--- a/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.cpp
@@ -1,0 +1,95 @@
+#include "tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.h"
+#include <unistd.h>
+
+namespace tensorrt_llm::executor::kv_cache
+{
+
+const uint16_t listener_port = 12345;
+int const MAX_IP_LENGTH = 16;
+static void listener_cb(ucp_conn_request_h conn_request, void* arg);
+static std::string getLocalIP();
+
+static void listener_cb(ucp_conn_request_h conn_request, void* arg)
+{
+    char ip_str[INET6_ADDRSTRLEN];
+    char port_str[INET6_ADDRSTRLEN];
+    ucp_conn_request_attr_t attr{};
+    UcxConnectionManager* connectionManager = reinterpret_cast<UcxConnectionManager*>(arg);
+
+    attr.field_mask = UCP_CONN_REQUEST_ATTR_FIELD_CLIENT_ADDR;
+    ucxx::utils::ucsErrorThrow(ucp_conn_request_query(conn_request, &attr));
+    ucxx::utils::sockaddr_get_ip_port_str(&attr.client_address, ip_str, port_str, INET6_ADDRSTRLEN);
+    TLLM_LOG_DEBUG("Server received a connection request from client at address %s:%d ", ip_str, port_str);
+    connectionManager->addConnection(conn_request);
+}
+
+static std::string getLocalIP()
+{
+    char hostname[256];
+    gethostname(hostname, sizeof(hostname));
+    struct hostent* host_entry = gethostbyname(hostname);
+    if (host_entry != nullptr)
+    {
+        return inet_ntoa(*((struct in_addr*) host_entry->h_addr_list[0]));
+    }
+    return "Unknown";
+}
+
+UcxConnectionManager::UcxConnectionManager(mpi::MpiComm const* comm)
+    : mComm(comm)
+{
+    TLLM_CHECK(mComm);
+    int device;
+    TLLM_CUDA_CHECK(cudaGetDevice(&device));
+    mUcxCtx = ucxx::createContext({}, ucxx::Context::defaultFeatureFlags);
+    mWorkersPool.push_back(mUcxCtx->createWorker()); // TODO: support configurable workers pool size
+    mWorkersPool.back().get()->startProgressThread(true);
+    mListener = mWorkersPool.front()->createListener(listener_port, listener_cb, this);
+    // Get local IP address
+    std::string localIP = getLocalIP();
+    std::vector<char> localIPBuffer(MAX_IP_LENGTH, 0);
+    std::strncpy(localIPBuffer.data(), localIP.c_str(), MAX_IP_LENGTH - 1);
+
+    // Allocate buffer for all IP addresses
+    std::vector<char> allIPs(comm->getSize() * MAX_IP_LENGTH);
+
+    // Perform Allgather operation
+    mComm->allgather(
+        localIPBuffer.data(), allIPs.data(), comm->getSize() * MAX_IP_LENGTH, tensorrt_llm::mpi::MpiType::kCHAR);
+    for (int i = comm->getRank() + 1; i < comm->getSize(); i++)
+    {
+        std::string Ip(allIPs.data() + i * MAX_IP_LENGTH);
+        TLLM_LOG_DEBUG("rank %d | got IP %s from rank %d", comm->getRank(), Ip.c_str(), i);
+        addConnection(Ip);
+    }
+}
+
+void UcxConnectionManager::addConnection(ucp_conn_request_h conn_request)
+{
+    std::shared_ptr<ucxx::Endpoint> newEp = mListener->createEndpointFromConnRequest(conn_request, true);
+    uint64_t id = getNewConnectionId(newEp);
+    mConnections.emplace(id, std::make_shared<UcxConnection>(id, newEp, shared_from_this()));
+}
+
+void UcxConnectionManager::addConnection(std::string Ip)
+{
+    std::shared_ptr<ucxx::Endpoint> newEp
+        = mWorkersPool.front()->createEndpointFromHostname(Ip, listener_port, true); // TODO: workers round robin
+    uint64_t id = getNewConnectionId(newEp);
+    mConnections.emplace(id, std::make_shared<UcxConnection>(id, newEp, shared_from_this()));
+}
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
+#endif
+
+std::unique_ptr<ConnectionManager> makeMpiConnectionManager(mpi::MpiComm const* comm)
+{
+    return std::make_unique<UcxConnectionManager>(comm);
+}
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+} // namespace tensorrt_llm::executor::kv_cache

--- a/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.h
+++ b/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.h
@@ -63,7 +63,8 @@ public:
     ~UcxConnectionManager();
 
     // Factory function
-    [[nodiscard]] static std::unique_ptr<UcxConnectionManager> create(tensorrt_llm::mpi::MpiComm const* comm)
+    [[nodiscard]] static std::unique_ptr<tensorrt_llm::executor::kv_cache::UcxConnectionManager> create(
+        tensorrt_llm::mpi::MpiComm const* comm)
     {
         return std::make_unique<UcxConnectionManager>(comm);
     }

--- a/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.h
+++ b/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.h
@@ -55,6 +55,7 @@ private:
 
 public:
     explicit UcxConnectionManager(tensorrt_llm::mpi::MpiComm const* comm);
+    ~UcxConnectionManager();
 
     // Factory function
     static std::unique_ptr<UcxConnectionManager> create(tensorrt_llm::mpi::MpiComm const* comm)

--- a/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.h
+++ b/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.h
@@ -1,0 +1,116 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: NVIDIA TensorRT Source Code License Agreement
+ *
+ * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+ * property and proprietary rights in and to this material, related
+ * documentation and any modifications thereto. Any use, reproduction,
+ * disclosure or distribution of this material and related documentation
+ * without an express license agreement from NVIDIA CORPORATION or
+ * its affiliates is strictly prohibited.
+ */
+
+#pragma once
+
+#include "tensorrt_llm/common/envUtils.h"
+#include "tensorrt_llm/runtime/utils/mpiUtils.h" //TODO: remove when progressing to standalone UCX stack
+
+#include "ucxx/api.h"
+#include "ucxx/utils/sockaddr.h"
+#include "ucxx/utils/ucx.h"
+#if __linux__
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+#endif
+#include "tensorrt_llm/common/cudaUtils.h"
+#include "tensorrt_llm/common/envUtils.h"
+#include "tensorrt_llm/common/logger.h"
+#include "tensorrt_llm/executor/cache_transmission/ucx_utils/connection.h"
+#include "tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.h"
+
+namespace tensorrt_llm::executor::kv_cache
+{
+
+class UcxConnectionManager : public ConnectionManager, public std::enable_shared_from_this<UcxConnectionManager>
+{
+public:
+    UcxConnectionManager(mpi::MpiComm const* comm);
+    void addConnection(ucp_conn_request_h conn_request);
+
+    Connection const* recvConnect(DataContext const& ctx, void* data, size_t size) override
+    {
+        // Guard to ensure CUDA context is initialized for UCX ops
+        TLLM_CUDA_CHECK(cudaFree(0));
+        // TLLM_CHECK_WITH_INFO((mEndpoint), "recvBuffer called without established communicator channel.");
+        uint64_t sender_tag;
+        ucp_request_param_t tag_recv_params;
+        tag_recv_params.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK | UCP_OP_ATTR_FIELD_USER_DATA;
+        tag_recv_params.cb.recv = [](void* request, ucs_status_t status, ucp_tag_recv_info_t const* info,
+                                      void* user_data) -> void { *(uint64_t*) user_data = info->sender_tag; };
+        tag_recv_params.user_data = &sender_tag;
+        // auto completionCallback = [this](ucs_status_t, ucxx::RequestCallbackUserData) -> void { mCv.notify_all(); };
+        auto request = ucp_tag_recv_nbx(mWorkersPool.front().get()->getHandle(), data, size, 1, 0, &tag_recv_params);
+        // auto req = mWorkersPool->tagRecv(data, size, ucxx::Tag(ctx.getTag()), 0, false, completionCallback);
+        // std::unique_lock<std::mutex> lk(mMtx);
+        // mCv.wait(lk, [&req]() { return req->isCompleted(); });
+        // throw if there is error
+        // req->checkError();
+        while (ucp_request_check_status(request) != UCS_INPROGRESS)
+            ;
+
+        return mConnections[sender_tag].get();
+    }
+
+    std::vector<Connection const*> getConnections(CommState const& state) override
+    {
+        std::vector<Connection const*> ret;
+        for (auto const& [id, ucxConnection] : mConnections)
+        {
+            ret.emplace_back(ucxConnection.get());
+        }
+        return ret;
+    }
+
+private:
+    mpi::MpiComm const* mComm;
+    std::shared_ptr<ucxx::Context> mUcxCtx;
+    std::vector<std::shared_ptr<ucxx::Worker>> mWorkersPool;
+    std::map<uint64_t, std::shared_ptr<UcxConnection>> mConnections;
+    std::shared_ptr<ucxx::Listener> mListener;
+
+    uint64_t getNewConnectionId(std::shared_ptr<ucxx::Endpoint> newEp)
+    {
+        ucp_ep_attr_t ep_attr;
+        ep_attr.field_mask = UCP_EP_ATTR_FIELD_LOCAL_SOCKADDR | UCP_EP_ATTR_FIELD_REMOTE_SOCKADDR;
+        uint64_t remotePort, localPort;
+        uint32_t remoteIp;
+        char lIpStr[INET6_ADDRSTRLEN];
+        char rIpStr[INET6_ADDRSTRLEN];
+        char portStr[INET6_ADDRSTRLEN];
+        ucs_status_t status = ucp_ep_query(newEp->getHandle(), &ep_attr);
+        if (status == UCS_OK)
+        {
+
+            ucxx::utils::sockaddr_get_ip_port_str(&ep_attr.remote_sockaddr, rIpStr, portStr, INET6_ADDRSTRLEN);
+            remotePort = static_cast<ucxx::Tag>(std::stoull(portStr));
+            remoteIp = std::stoull(lIpStr);
+            ucxx::utils::sockaddr_get_ip_port_str(&ep_attr.local_sockaddr, lIpStr, portStr, INET6_ADDRSTRLEN);
+            localPort = static_cast<ucxx::Tag>(std::stoull(portStr));
+
+            return ((remotePort << (32 + 16)) | (localPort << 32) | remoteIp);
+        }
+        else
+        {
+            // [FIXME] better message
+            if (status == UCS_ERR_NOT_CONNECTED)
+            {
+                TLLM_LOG_ERROR("UCX connection has not been established yet");
+            }
+        }
+        return 0;
+        // return reinterpret_cast<uint64_t>(newEp.get()->getHandle());
+    }
+
+    void addConnection(std::string Ip);
+};
+} // namespace tensorrt_llm::executor::kv_cache

--- a/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.h
+++ b/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.h
@@ -53,8 +53,8 @@ private:
     std::mutex mPendingGIDFuturesMutex;
     std::queue<std::shared_ptr<std::future<void>>> mPendingGIDFutures;
 
-    uint64_t getNewConnectionId(std::shared_ptr<ucxx::Endpoint> newEp);
-    uint64_t addConnection(std::string ip, uint16_t port);
+    uint64_t getNewConnectionId(std::shared_ptr<ucxx::Endpoint> const& newEp);
+    uint64_t addConnection(std::string const& ip, uint16_t port);
     // void initializeConnections();
     void updateGIDToConnectionIdMap(std::shared_ptr<ucxx::Request> request, uint64_t* gid, uint64_t connectionId);
 
@@ -63,14 +63,14 @@ public:
     ~UcxConnectionManager();
 
     // Factory function
-    static std::unique_ptr<UcxConnectionManager> create(tensorrt_llm::mpi::MpiComm const* comm)
+    [[nodiscard]] static std::unique_ptr<UcxConnectionManager> create(tensorrt_llm::mpi::MpiComm const* comm)
     {
         return std::make_unique<UcxConnectionManager>(comm);
     }
 
     [[nodiscard]] uint64_t getLocalGID() const;
 
-    uint64_t addConnection(ucp_conn_request_h connRequest);
+    void addConnection(ucp_conn_request_h connRequest);
     Connection const* recvConnect(DataContext const& ctx, void* data, size_t size) override;
     std::vector<Connection const*> getConnections(CommState const& state) override;
 };

--- a/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.h
+++ b/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.h
@@ -56,7 +56,7 @@ private:
     uint64_t getNewConnectionId(std::shared_ptr<ucxx::Endpoint> const& newEp);
     uint64_t addConnection(std::string const& ip, uint16_t port);
     // void initializeConnections();
-    void updateGIDToConnectionIdMap(std::shared_ptr<ucxx::Request> request, uint64_t* gid, uint64_t connectionId);
+    void updateGIDToConnectionIdMap(std::shared_ptr<ucxx::Endpoint> const& newEp);
 
 public:
     explicit UcxConnectionManager(tensorrt_llm::mpi::MpiComm const* comm);

--- a/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.h
+++ b/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.h
@@ -1,13 +1,18 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * SPDX-License-Identifier: NVIDIA TensorRT Source Code License Agreement
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
  *
- * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
- * property and proprietary rights in and to this material, related
- * documentation and any modifications thereto. Any use, reproduction,
- * disclosure or distribution of this material and related documentation
- * without an express license agreement from NVIDIA CORPORATION or
- * its affiliates is strictly prohibited.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once
@@ -61,8 +66,6 @@ public:
     static std::unique_ptr<UcxConnectionManager> create(tensorrt_llm::mpi::MpiComm const* comm)
     {
         return std::make_unique<UcxConnectionManager>(comm);
-        // instance->initializeConnections();
-        // return instance;
     }
 
     [[nodiscard]] uint64_t getLocalGID() const;

--- a/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.h
+++ b/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.h
@@ -13,6 +13,8 @@
 #pragma once
 
 #include "tensorrt_llm/common/envUtils.h"
+#include "tensorrt_llm/executor/cacheCommunicator.h"
+#include "tensorrt_llm/executor/cache_transmission/ucx_utils/connection.h"
 #include "tensorrt_llm/runtime/utils/mpiUtils.h" //TODO: remove when progressing to standalone UCX stack
 
 #include "ucxx/api.h"

--- a/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.h
+++ b/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.h
@@ -78,7 +78,7 @@ public:
 
 extern "C"
 {
-    std::unique_ptr<ConnectionManager> makeUcxConnectionManager(tensorrt_llm::mpi::MpiComm const* comm);
+    [[nodiscard]] std::unique_ptr<ConnectionManager> makeUcxConnectionManager(tensorrt_llm::mpi::MpiComm const* comm);
 }
 
 #if defined(__clang__)

--- a/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.h
+++ b/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.h
@@ -18,6 +18,7 @@
 #include "ucxx/api.h"
 #include "ucxx/utils/sockaddr.h"
 #include "ucxx/utils/ucx.h"
+#include <cstdint>
 #if __linux__
 #include <arpa/inet.h>
 #include <ifaddrs.h>
@@ -25,92 +26,47 @@
 #include "tensorrt_llm/common/cudaUtils.h"
 #include "tensorrt_llm/common/envUtils.h"
 #include "tensorrt_llm/common/logger.h"
-#include "tensorrt_llm/executor/cache_transmission/ucx_utils/connection.h"
-#include "tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.h"
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace tensorrt_llm::executor::kv_cache
 {
 
 class UcxConnectionManager : public ConnectionManager, public std::enable_shared_from_this<UcxConnectionManager>
 {
-public:
-    UcxConnectionManager(mpi::MpiComm const* comm);
-    void addConnection(ucp_conn_request_h conn_request);
-
-    Connection const* recvConnect(DataContext const& ctx, void* data, size_t size) override
-    {
-        // Guard to ensure CUDA context is initialized for UCX ops
-        TLLM_CUDA_CHECK(cudaFree(0));
-        // TLLM_CHECK_WITH_INFO((mEndpoint), "recvBuffer called without established communicator channel.");
-        uint64_t sender_tag;
-        ucp_request_param_t tag_recv_params;
-        tag_recv_params.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK | UCP_OP_ATTR_FIELD_USER_DATA;
-        tag_recv_params.cb.recv = [](void* request, ucs_status_t status, ucp_tag_recv_info_t const* info,
-                                      void* user_data) -> void { *(uint64_t*) user_data = info->sender_tag; };
-        tag_recv_params.user_data = &sender_tag;
-        // auto completionCallback = [this](ucs_status_t, ucxx::RequestCallbackUserData) -> void { mCv.notify_all(); };
-        auto request = ucp_tag_recv_nbx(mWorkersPool.front().get()->getHandle(), data, size, 1, 0, &tag_recv_params);
-        // auto req = mWorkersPool->tagRecv(data, size, ucxx::Tag(ctx.getTag()), 0, false, completionCallback);
-        // std::unique_lock<std::mutex> lk(mMtx);
-        // mCv.wait(lk, [&req]() { return req->isCompleted(); });
-        // throw if there is error
-        // req->checkError();
-        while (ucp_request_check_status(request) != UCS_INPROGRESS)
-            ;
-
-        return mConnections[sender_tag].get();
-    }
-
-    std::vector<Connection const*> getConnections(CommState const& state) override
-    {
-        std::vector<Connection const*> ret;
-        for (auto const& [id, ucxConnection] : mConnections)
-        {
-            ret.emplace_back(ucxConnection.get());
-        }
-        return ret;
-    }
-
 private:
     mpi::MpiComm const* mComm;
     std::shared_ptr<ucxx::Context> mUcxCtx;
     std::vector<std::shared_ptr<ucxx::Worker>> mWorkersPool;
     std::map<uint64_t, std::shared_ptr<UcxConnection>> mConnections;
     std::shared_ptr<ucxx::Listener> mListener;
+    std::map<std::string, uint64_t> mIpToMpiRank;
+    std::map<uint64_t, uint64_t> mMpiRankToConnectionId;
 
-    uint64_t getNewConnectionId(std::shared_ptr<ucxx::Endpoint> newEp)
-    {
-        ucp_ep_attr_t ep_attr;
-        ep_attr.field_mask = UCP_EP_ATTR_FIELD_LOCAL_SOCKADDR | UCP_EP_ATTR_FIELD_REMOTE_SOCKADDR;
-        uint64_t remotePort, localPort;
-        uint32_t remoteIp;
-        char lIpStr[INET6_ADDRSTRLEN];
-        char rIpStr[INET6_ADDRSTRLEN];
-        char portStr[INET6_ADDRSTRLEN];
-        ucs_status_t status = ucp_ep_query(newEp->getHandle(), &ep_attr);
-        if (status == UCS_OK)
-        {
+    uint64_t getNewConnectionId(std::shared_ptr<ucxx::Endpoint> newEp);
+    void addConnection(std::string ip, uint16_t port);
 
-            ucxx::utils::sockaddr_get_ip_port_str(&ep_attr.remote_sockaddr, rIpStr, portStr, INET6_ADDRSTRLEN);
-            remotePort = static_cast<ucxx::Tag>(std::stoull(portStr));
-            remoteIp = std::stoull(lIpStr);
-            ucxx::utils::sockaddr_get_ip_port_str(&ep_attr.local_sockaddr, lIpStr, portStr, INET6_ADDRSTRLEN);
-            localPort = static_cast<ucxx::Tag>(std::stoull(portStr));
-
-            return ((remotePort << (32 + 16)) | (localPort << 32) | remoteIp);
-        }
-        else
-        {
-            // [FIXME] better message
-            if (status == UCS_ERR_NOT_CONNECTED)
-            {
-                TLLM_LOG_ERROR("UCX connection has not been established yet");
-            }
-        }
-        return 0;
-        // return reinterpret_cast<uint64_t>(newEp.get()->getHandle());
-    }
-
-    void addConnection(std::string Ip);
+public:
+    explicit UcxConnectionManager(mpi::MpiComm const* comm);
+    void addConnection(ucp_conn_request_h connRequest);
+    Connection const* recvConnect(DataContext const& ctx, void* data, size_t size) override;
+    std::vector<Connection const*> getConnections(CommState const& state) override;
 };
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
+#endif
+
+extern "C"
+{
+    std::unique_ptr<ConnectionManager> makeUcxConnectionManager(mpi::MpiComm const* comm);
+}
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
 } // namespace tensorrt_llm::executor::kv_cache

--- a/cpp/tests/executor/disaggExecutorTest.cpp
+++ b/cpp/tests/executor/disaggExecutorTest.cpp
@@ -421,6 +421,11 @@ TEST_P(DisaggParamsTest, DisaggTokenComparison)
     {
         setenv("UCX_TLS", "^cuda_ipc", 1); // disable cuda_ipc for testing for mpi
     }
+    else
+    {
+        setenv("UCX_TCP_CM_REUSEADDR", "y",
+            1); // tests creates and destroies ucxCacheCommunicatoers frequently, so listener ports must be reused
+    }
     auto const processNum = std::get<0>(GetParam());
     auto const modelNames = std::get<1>(GetParam());
     auto const participantIdsEachInstance = std::get<2>(GetParam());       // std::vector<std::vector<int>>
@@ -632,6 +637,11 @@ TEST_P(DisaggOrchestratorParamsTest, DisaggTokenComparison)
     if (!(tensorrt_llm::common::getEnvUseUCXKvCache()))
     {
         setenv("UCX_TLS", "^cuda_ipc", 1); // disable cuda_ipc for testing for mpi
+    }
+    else
+    {
+        setenv("UCX_TCP_CM_REUSEADDR", "y",
+            1); // tests creates and destroies ucxCacheCommunicatoers frequently, so listener ports must be reused
     }
     auto const processNum = std::get<0>(GetParam());
     auto const modelNames = std::get<1>(GetParam());

--- a/tests/integration/defs/cpp_common.py
+++ b/tests/integration/defs/cpp_common.py
@@ -280,7 +280,6 @@ def run_multi_gpu_tests(build_dir: _pl.Path, timeout=1500):
 
     # Cache transceiver tests with UCX
     new_env = copy.copy(cpp_env)
-    new_env["TRTLLM_USE_MPI_KVCACHE"] = "1"
     new_env["TRTLLM_USE_UCX_KVCACHE"] = "1"
     cache_trans_test = [
         "mpirun",
@@ -292,7 +291,6 @@ def run_multi_gpu_tests(build_dir: _pl.Path, timeout=1500):
     run_command(cache_trans_test, cwd=tests_dir, env=new_env, timeout=300)
 
     new_env = copy.copy(cpp_env)
-    new_env["TRTLLM_USE_MPI_KVCACHE"] = "1"
     new_env["TRTLLM_USE_UCX_KVCACHE"] = "1"
     # Cache transceiver tests
     cache_trans_test_8_proc = [
@@ -486,7 +484,6 @@ def run_disagg_tests(build_dir: _pl.Path):
 
     # UCX transceiver tests, the test may not be built if ENABLE_UCX is 0
     new_env = copy.copy(cpp_env)
-    new_env["TRTLLM_USE_MPI_KVCACHE"] = "1"
     new_env["TRTLLM_USE_UCX_KVCACHE"] = "1"
     xml_output_file = build_dir / "results-multi-gpu-disagg-executor-2-process.xml"
     trt_model_test = produce_mpirun_command(
@@ -501,7 +498,6 @@ def run_disagg_tests(build_dir: _pl.Path):
 
     mgpu_env = copy.copy(cpp_env)
     mgpu_env["RUN_LLAMA_MULTI_GPU"] = "true"
-    mgpu_env["TRTLLM_USE_MPI_KVCACHE"] = "1"
     mgpu_env["TRTLLM_USE_UCX_KVCACHE"] = "1"
     xml_output_file = build_dir / "results-multi-gpu-disagg-executor-4-process.xml"
     trt_model_test = produce_mpirun_command(

--- a/tests/integration/defs/cpp_common.py
+++ b/tests/integration/defs/cpp_common.py
@@ -278,6 +278,35 @@ def run_multi_gpu_tests(build_dir: _pl.Path, timeout=1500):
                 env=new_env,
                 timeout=600)
 
+    # Cache transceiver tests with UCX
+    new_env = copy.copy(cpp_env)
+    new_env["TRTLLM_USE_MPI_KVCACHE"] = "1"
+    new_env["TRTLLM_USE_UCX_KVCACHE"] = "1"
+    cache_trans_test = [
+        "mpirun",
+        "-n",
+        "2",
+        "--allow-run-as-root",
+        "batch_manager/cacheTransceiverTest",
+    ]
+    run_command(cache_trans_test, cwd=tests_dir, env=new_env, timeout=300)
+
+    new_env = copy.copy(cpp_env)
+    new_env["TRTLLM_USE_MPI_KVCACHE"] = "1"
+    new_env["TRTLLM_USE_UCX_KVCACHE"] = "1"
+    # Cache transceiver tests
+    cache_trans_test_8_proc = [
+        "mpirun",
+        "-n",
+        "8",
+        "--allow-run-as-root",
+        "batch_manager/cacheTransceiverTest",
+    ]
+    run_command(cache_trans_test_8_proc,
+                cwd=tests_dir,
+                env=new_env,
+                timeout=600)
+
     xml_output_file = build_dir / "results-multi-gpu-real-decoder.xml"
     trt_model_test = produce_mpirun_command(
         global_commands=["mpirun", "--allow-run-as-root"],
@@ -388,6 +417,92 @@ def run_disagg_tests(build_dir: _pl.Path):
     mgpu_env = copy.copy(cpp_env)
     mgpu_env["RUN_LLAMA_MULTI_GPU"] = "true"
     mgpu_env["TRTLLM_USE_MPI_KVCACHE"] = "1"
+    xml_output_file = build_dir / "results-multi-gpu-disagg-executor-4-process.xml"
+    trt_model_test = produce_mpirun_command(
+        global_commands=["mpirun", "--allow-run-as-root"],
+        nranks=4,
+        local_commands=[
+            "executor/disaggExecutorTest",
+            "--gtest_filter=*DisaggSymmetricExecutorTest*"
+        ],
+        leader_commands=[f"--gtest_output=xml:{xml_output_file}"])
+    # https://nvbugspro.nvidia.com/bug/5026255 disable below tests for now.
+    run_command(trt_model_test, cwd=tests_dir, env=mgpu_env, timeout=1500)
+
+    xml_output_file = build_dir / "results-multi-gpu-disagg-executor-8-process.xml"
+    trt_model_test = produce_mpirun_command(
+        global_commands=["mpirun", "--allow-run-as-root"],
+        nranks=8,
+        local_commands=[
+            "executor/disaggExecutorTest",
+            "--gtest_filter=*LlamaTP2PP2DisaggSymmetricExecutorTest*"
+        ],
+        leader_commands=[f"--gtest_output=xml:{xml_output_file}"])
+    run_command(trt_model_test, cwd=tests_dir, env=mgpu_env, timeout=1500)
+
+    xml_output_file = build_dir / "results-multi-gpu-disagg-asymmetric-executor-4-process.xml"
+    trt_model_test = produce_mpirun_command(
+        global_commands=["mpirun", "--allow-run-as-root"],
+        nranks=4,
+        local_commands=[
+            "executor/disaggExecutorTest",
+            "--gtest_filter=*DisaggAsymmetricExecutorTest*"
+        ],
+        leader_commands=[f"--gtest_output=xml:{xml_output_file}"])
+    run_command(trt_model_test, cwd=tests_dir, env=mgpu_env, timeout=1500)
+
+    xml_output_file = build_dir / "results-multi-gpu-disagg-asymmetric-executor-6-process.xml"
+    trt_model_test = produce_mpirun_command(
+        global_commands=["mpirun", "--allow-run-as-root"],
+        nranks=6,
+        local_commands=[
+            "executor/disaggExecutorTest",
+            "--gtest_filter=*DisaggAsymmetricExecutorTest*"
+        ],
+        leader_commands=[f"--gtest_output=xml:{xml_output_file}"])
+    run_command(trt_model_test, cwd=tests_dir, env=mgpu_env, timeout=1500)
+
+    xml_output_file = build_dir / "results-multi-gpu-disagg-asymmetric-executor-8-process.xml"
+    trt_model_test = produce_mpirun_command(
+        global_commands=["mpirun", "--allow-run-as-root"],
+        nranks=8,
+        local_commands=[
+            "executor/disaggExecutorTest",
+            "--gtest_filter=*DisaggAsymmetricExecutorTest*"
+        ],
+        leader_commands=[f"--gtest_output=xml:{xml_output_file}"])
+    run_command(trt_model_test, cwd=tests_dir, env=mgpu_env, timeout=1500)
+
+    xml_output_file = build_dir / "results-multi-gpu-disagg-asymmetric-orchestrator-executor-7-process.xml"
+    trt_model_test = produce_mpirun_command(
+        global_commands=["mpirun", "--allow-run-as-root"],
+        nranks=7,
+        local_commands=[
+            "executor/disaggExecutorTest",
+            "--gtest_filter=*DisaggOrchestratorParamsTest*"
+        ],
+        leader_commands=[f"--gtest_output=xml:{xml_output_file}"])
+    run_command(trt_model_test, cwd=tests_dir, env=mgpu_env, timeout=1500)
+
+    # UCX transceiver tests, the test may not be built if ENABLE_UCX is 0
+    new_env = copy.copy(cpp_env)
+    new_env["TRTLLM_USE_MPI_KVCACHE"] = "1"
+    new_env["TRTLLM_USE_UCX_KVCACHE"] = "1"
+    xml_output_file = build_dir / "results-multi-gpu-disagg-executor-2-process.xml"
+    trt_model_test = produce_mpirun_command(
+        global_commands=["mpirun", "--allow-run-as-root"],
+        nranks=2,
+        local_commands=[
+            "executor/disaggExecutorTest",
+            "--gtest_filter=*DisaggSymmetricExecutorTest*"
+        ],
+        leader_commands=[f"--gtest_output=xml:{xml_output_file}"])
+    run_command(trt_model_test, cwd=tests_dir, env=new_env, timeout=1500)
+
+    mgpu_env = copy.copy(cpp_env)
+    mgpu_env["RUN_LLAMA_MULTI_GPU"] = "true"
+    mgpu_env["TRTLLM_USE_MPI_KVCACHE"] = "1"
+    mgpu_env["TRTLLM_USE_UCX_KVCACHE"] = "1"
     xml_output_file = build_dir / "results-multi-gpu-disagg-executor-4-process.xml"
     trt_model_test = produce_mpirun_command(
         global_commands=["mpirun", "--allow-run-as-root"],


### PR DESCRIPTION
Support for KvCache transfer over UCXX backend instead of MPI.
To enable the UCX backend  the following environment variable need to be set: 
TRTLLM_USE_UCX_KVCACHE=1 

