### PR TITLE
infra: Devcontainer productivity improvements

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,14 +10,18 @@
       "containerEnv": {
         // "CCACHE_DIR" : "/home/coder/${localWorkspaceFolderBasename}/cpp/.ccache",
         // "CCACHE_BASEDIR" : "/home/coder/${localWorkspaceFolderBasename}",
+        "HF_TOKEN": "${localEnv:HF_TOKEN}",
+        "HF_HOME": "/huggingface",
         "HISTFILE": "${containerWorkspaceFolder}/.cache/._bash_history"
       },
       "workspaceFolder": "/workspaces/tensorrt_llm",
       // "workspaceFolder": "/home/coder/${localWorkspaceFolderBasename}",
       // "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/${localWorkspaceFolderBasename},type=bind,consistency=consistent",
       "mounts": [
+        "source=${localEnv:HOME}/.cache/huggingface,target=/huggingface,type=bind", // HF cache
         "source=/home/scratch.trt_llm_data/,target=/home/scratch.trt_llm_data/,type=bind,consistency=consistent"
       ],
+      "postCreateCommand": "pip install -r requirements-dev.txt && pre-commit install --install-hooks",
       "customizations": {
         "vscode": {
           "extensions": [
@@ -28,6 +32,8 @@
             // Python
             "ms-python.python",
             "eeyore.yapf",
+            // AutoDeploy Linting and Formatting
+            "charliermarsh.ruff",
             // Build Tools
             // "ms-azuretools.vscode-docker",
             // "ms-vscode.makefile-tools",
@@ -49,7 +55,8 @@
             "clangd.arguments": [
               // "--compile-commands-dir=${workspaceFolder}/cpp/build_RelWithDebInfo"
               "--compile-commands-dir=${workspaceFolder}"
-            ]
+            ],
+            "python.defaultInterpreterPath": "/usr/bin/python"
           }
         }
       },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
     // https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/docker-existing-dockerfile
     {
-      "name": "TRT-LLM clangd Devcontainer",
+      "name": "TRT-LLM Devcontainer",
       "dockerComposeFile": [
         "docker-compose.yml"
       ],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
     {
       "name": "TRT-LLM clangd Devcontainer",
       "dockerComposeFile": [
-        "../docker-compose.yml"
+        "docker-compose.yml"
       ],
       "service": "tensorrt_llm-dev",
       "remoteUser": "ubuntu",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,10 @@
         "source=${localEnv:HOME}/.cache/huggingface,target=/huggingface,type=bind", // HF cache
         "source=/home/scratch.trt_llm_data/,target=/home/scratch.trt_llm_data/,type=bind,consistency=consistent"
       ],
-      "postCreateCommand": "pip install -r requirements-dev.txt && pre-commit install --install-hooks",
+      // Note: sourcing .profile is required since we use a local user and the python interpreter is
+      // global (/usr/bin/python). In this case, pip will default to a local user path which is not
+      // by default in the PATH. In interactive devcontainer shells, .profile is sourced by default.
+      "postCreateCommand": "mkdir -p $HOME/.local/bin && source $HOME/.profile && pip install -r requirements-dev.txt && pre-commit install --install-hooks",
       "customizations": {
         "vscode": {
           "extensions": [
@@ -54,7 +57,7 @@
             // "clang-format.executable": "/usr/local/bin/clang-format",
             "clangd.arguments": [
               // "--compile-commands-dir=${workspaceFolder}/cpp/build_RelWithDebInfo"
-              "--compile-commands-dir=${workspaceFolder}"
+              "--compile-commands-dir=${workspaceFolder}/cpp/build"
             ],
             "python.defaultInterpreterPath": "/usr/bin/python"
           }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -19,7 +19,7 @@ services:
         reservations:
           devices:
             - driver: nvidia
-              count: 1
+              count: "all"
               capabilities: [gpu]
 
     volumes:


### PR DESCRIPTION
Adding a few productivity improvements to our devcontainer setup

- [x] Expose all GPUs in docker-compose
- [x] Auto-mount HuggingFace Hub cache if available
- [x] Pre-install requirements and pre-commit hooks
- [x] Move `.devcontainer/clangd/devcontainer.json --> .devcontainer/devcontainer.json`. background: some VSCode commands like `>Dev Container: Clone Repository in Container Volume...` only work with `.devcontainer/devcontainer.json`. If we ever split our devcontainer setup between `clangd` and `python` or others we can move it back but for now it can add additional convenience
- [x] Ensure `python` path is correctly specified for VSCode
- [x] Double-check pre-commit install in post create command (got some issue in one my tests)