### PR TITLE
refactor: Replace DecoderFinishedEvent with CudaEvent in decoder classes

### DIFF
--- a/cpp/include/tensorrt_llm/runtime/gptDecoderBatched.h
+++ b/cpp/include/tensorrt_llm/runtime/gptDecoderBatched.h
@@ -57,7 +57,7 @@ public:
     void disableLookahead(
         SizeType32 maxBatchSize, RequestVector const& genRequests, TensorPtr const& batchSlots) override;
 
-    DecoderFinishedEventPtr forwardAsync(decoder_batch::Output& output, decoder_batch::Input const& input) override;
+    CudaEvent forwardAsync(decoder_batch::Output& output, decoder_batch::Input const& input) override;
     void forward(decoder_batch::Output& output, decoder_batch::Input const& input) override;
 
     //! @brief Gather final beam search results for request `batchSlot`.

--- a/cpp/include/tensorrt_llm/runtime/iGptDecoderBatched.h
+++ b/cpp/include/tensorrt_llm/runtime/iGptDecoderBatched.h
@@ -89,19 +89,6 @@ public:
 
 using Output = decoder::Output;
 
-// used just as a container for easy returning / passing to function
-class DecoderFinishedEvent
-{
-public:
-    explicit DecoderFinishedEvent(CudaEvent&& event, std::vector<bool> const& active)
-        : event(std::move(event))
-        , active(active)
-    {
-    }
-
-    CudaEvent event;
-    std::vector<bool> active;
-};
 } // namespace decoder_batch
 
 //! GPT decoder class with support for in-flight batching
@@ -112,7 +99,6 @@ public:
     using LlmRequestPtr = std::shared_ptr<tensorrt_llm::batch_manager::LlmRequest>;
     using RequestVector = std::vector<LlmRequestPtr>;
     using TensorPtr = std::shared_ptr<ITensor>;
-    using DecoderFinishedEventPtr = std::unique_ptr<decoder_batch::DecoderFinishedEvent const>;
 
     //! @brief Setup the decoder before calling `forward()`
     virtual void setup(executor::DecodingMode const& mode, SizeType32 maxBatchSize, SizeType32 maxBeamWidth,
@@ -127,7 +113,7 @@ public:
         = 0;
 
     //! @brief Run one step for all requests without blocking the host process and return the token for synchronization.
-    virtual DecoderFinishedEventPtr forwardAsync(decoder_batch::Output& output, decoder_batch::Input const& input) = 0;
+    virtual CudaEvent forwardAsync(decoder_batch::Output& output, decoder_batch::Input const& input) = 0;
 
     //! @brief Run one step for all requests and wait for completion on the host.
     virtual void forward(decoder_batch::Output& output, decoder_batch::Input const& input) = 0;

--- a/cpp/include/tensorrt_llm/runtime/statefulGptDecoderBatched.h
+++ b/cpp/include/tensorrt_llm/runtime/statefulGptDecoderBatched.h
@@ -30,7 +30,6 @@ class StatefulGptDecoderBatched : public IStatefulGptDecoder
 public:
     using CudaStreamPtr = std::shared_ptr<CudaStream>;
     using TensorPtr = ITensor::SharedPtr;
-    using DecoderFinishedEventPtr = std::unique_ptr<decoder_batch::DecoderFinishedEvent const>;
 
     StatefulGptDecoderBatched(CudaStreamPtr stream, nvinfer1::DataType dtype);
 
@@ -59,7 +58,7 @@ private:
     std::unique_ptr<GptDecoderBatched> mDecoder;
 
     // only used for IStatefulGptDecoder
-    DecoderFinishedEventPtr mDecoderFinishEvent;
+    CudaEvent mDecoderFinishEvent;
     CudaEvent mForwardEvent;
     TensorPtr mFinishedSum;
     TensorPtr mBatchSlotsSetup;   // [maxBatchSize], int32_t, address map, pinned

--- a/cpp/tensorrt_llm/batch_manager/trtEncoderModel.h
+++ b/cpp/tensorrt_llm/batch_manager/trtEncoderModel.h
@@ -44,7 +44,6 @@ public:
     using BufferManager = tensorrt_llm::runtime::BufferManager;
     using TensorMap = runtime::StringPtrMap<runtime::ITensor>;
     using TensorPtr = runtime::ITensor::SharedPtr;
-    using DecoderFinishedEventPtr = std::unique_ptr<runtime::decoder_batch::DecoderFinishedEvent const>;
 
     TrtEncoderModel(runtime::ModelConfig const& modelConfig, runtime::WorldConfig const& worldConfig,
         runtime::RawEngine const& rawEngine, std::shared_ptr<nvinfer1::ILogger> logger,
@@ -195,7 +194,6 @@ private:
     SizeType32 mNumBuffers;
 
     std::vector<ScheduledRequests> mMicroBatchScheduledRequests;
-    std::vector<DecoderFinishedEventPtr> mEncoderWaitEvents;
     ReqIdsSet mInflightReqIds;
     ReqIdsSet mReqIdsToPause;
 

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -769,7 +769,7 @@ void TrtGptModelInflightBatching::forwardSync()
             }
             // Wait for decoding for requests in flight for the current micro batch
             auto& decoderWaitEvent = mDecoderFinishedEvents.at(mMicroBatchId);
-            mDecStepAsyncSndHdls = decoderSync(currRequests, std::move(decoderWaitEvent));
+            mDecStepAsyncSndHdls = decoderSync(currRequests, std::move(decoderWaitEvent.value()));
             decoderWaitEvent.reset();
 
             if (!mWorldConfig.isLastPipelineParallelRank())
@@ -980,14 +980,15 @@ void TrtGptModelInflightBatching::forwardAsync(RequestList const& activeRequests
                 auto& prevDecoderFinishedEvent = mDecoderFinishedEvents.at(prevMicroBatchId);
                 if (prevDecoderFinishedEvent)
                 {
-                    prevDecoderFinishedEvent->event.synchronize();
+                    prevDecoderFinishedEvent->synchronize();
                 }
             }
 
             auto& decoderFinishedEvent = mDecoderFinishedEvents.at(mMicroBatchId);
-            TLLM_CHECK_WITH_INFO(decoderFinishedEvent.get() == nullptr, "decoderFinishedEvent handle must be nullptr.");
-            decoderFinishedEvent = mWorldConfig.isLastPipelineParallelRank() ? decoderStepAsync(currRequests)
-                                                                             : DecoderFinishedEventPtr();
+            TLLM_CHECK_WITH_INFO(!decoderFinishedEvent.has_value(), "decoderFinishedEvent must be nullopt.");
+            decoderFinishedEvent = mWorldConfig.isLastPipelineParallelRank()
+                ? std::make_optional(decoderStepAsync(currRequests))
+                : std::nullopt;
 
             mLastIterationStatsIFB = fillIterationStats(currRequests, requestsToPause);
             for (auto const& requests : {currRequests.contextRequests, currRequests.generationRequests})
@@ -1036,7 +1037,7 @@ void TrtGptModelInflightBatching::forwardAsync(RequestList const& activeRequests
                 }
                 // Wait for decoding for requests in flight for the current micro batch
                 auto& decoderFinishedEvent = mDecoderFinishedEvents.at(mMicroBatchId);
-                mDecStepAsyncSndHdls = decoderSync(currRequests, std::move(decoderFinishedEvent));
+                mDecStepAsyncSndHdls = decoderSync(currRequests, std::move(decoderFinishedEvent.value()));
                 decoderFinishedEvent.reset();
 
                 mAsyncSendWaitThread->notifyStart();
@@ -1874,8 +1875,7 @@ bool batchReturnLogProbs(ScheduledRequests const& scheduledRequests)
 }
 } // namespace
 
-TrtGptModelInflightBatching::DecoderFinishedEventPtr TrtGptModelInflightBatching::decoderStepAsync(
-    ScheduledRequests const& scheduledRequests)
+runtime::CudaEvent TrtGptModelInflightBatching::decoderStepAsync(ScheduledRequests const& scheduledRequests)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
     NVTX3_SCOPED_RANGE(decoderStepAsync);
@@ -1914,7 +1914,7 @@ TrtGptModelInflightBatching::DecoderFinishedEventPtr TrtGptModelInflightBatching
             *mDecoderBuffers, mDecoderInputBuffers.at(fusedBufferId), mModelConfig, getMaxNumSequences(),
             mOperatingBeamWidth, mRuntime->getBufferManager(), mRuntime->getStream(), *fusedRuntimeBuffers);
 
-    DecoderFinishedEventPtr decoderFinishEvent = mDecoder->forwardAsync(*mDecodingOutput, *decodingInput);
+    runtime::CudaEvent decoderFinishEvent = mDecoder->forwardAsync(*mDecodingOutput, *decodingInput);
 
     auto const returnLogProbs = batchReturnLogProbs(scheduledRequests);
     decoderFinishEvent = updateDecoderBuffers(returnLogProbs, std::move(decoderFinishEvent));
@@ -1980,14 +1980,14 @@ void TrtGptModelInflightBatching::copyCacheIndirectionFromOutputsToInputs(
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
 }
 
-TrtGptModelInflightBatching::DecoderFinishedEventPtr TrtGptModelInflightBatching::updateDecoderBuffers(
-    bool returnLogProbs, DecoderFinishedEventPtr decoderFinishEvent)
+runtime::CudaEvent TrtGptModelInflightBatching::updateDecoderBuffers(
+    bool returnLogProbs, runtime::CudaEvent decoderFinishEvent)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
     NVTX3_SCOPED_RANGE(updateDecoderBuffers);
 
     // Chain copy after decoder event, using a different stream
-    mCopyBufferManager.getStream().wait(decoderFinishEvent->event);
+    mCopyBufferManager.getStream().wait(decoderFinishEvent);
 
     mDecoderBuffers->newOutputTokens = mDecoder->getDecoderState().getAllNewTokens();
 
@@ -2038,7 +2038,7 @@ TrtGptModelInflightBatching::DecoderFinishedEventPtr TrtGptModelInflightBatching
     mCopyBufferManager.getStream().record(copyEvent);
     // Store the event for later sync. Sync stream before calling next decoder. Sync host before updating requests.
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
-    return std::make_unique<decoder_batch::DecoderFinishedEvent>(std::move(copyEvent), decoderFinishEvent->active);
+    return copyEvent;
 }
 
 std::vector<std::unique_ptr<DecoderStepAsyncSend>> TrtGptModelInflightBatching::communicateDecoderBuffers(
@@ -2296,14 +2296,14 @@ void TrtGptModelInflightBatching::updateRequests(ScheduledRequests const& schedu
 }
 
 std::vector<std::unique_ptr<DecoderStepAsyncSend>> TrtGptModelInflightBatching::decoderSync(
-    ScheduledRequests const& scheduledRequests, DecoderFinishedEventPtr decoderFinishEvent)
+    ScheduledRequests const& scheduledRequests, runtime::CudaEvent decoderFinishEvent)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
     NVTX3_SCOPED_RANGE(decoderSync);
 
     if (mWorldConfig.isLastPipelineParallelRank())
     {
-        decoderFinishEvent->event.synchronize();
+        decoderFinishEvent.synchronize();
     }
 
     auto const returnLogProbs = batchReturnLogProbs(scheduledRequests);

--- a/cpp/tensorrt_llm/pybind/runtime/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/runtime/bindings.cpp
@@ -323,15 +323,15 @@ void initBindings(pybind11::module_& m)
     py::class_<tr::DecodingInput>(m, "DecodingInput");
     py::class_<tr::DecodingOutput>(m, "DecodingOutput");
 
-    py::class_<tr::decoder_batch::DecoderFinishedEvent>(m, "Token")
+    py::class_<tr::CudaEvent>(m, "CudaEvent")
         .def(py::init(
-            [](CudaStreamPtr stream, std::vector<bool> const& active)
+            [](CudaStreamPtr stream)
             {
                 tr::CudaEvent eventStop{};
                 stream->record(eventStop);
-                return std::make_unique<tr::decoder_batch::DecoderFinishedEvent>(std::move(eventStop), active);
+                return eventStop;
             }))
-        .def("synchronize", [](tr::decoder_batch::DecoderFinishedEvent& self) { self.event.synchronize(); });
+        .def("synchronize", [](tr::CudaEvent& self) { self.synchronize(); });
 
     py::class_<tr::IGptDecoder, PyIGptDecoder>(m, "IGptDecoder")
         .def(

--- a/cpp/tensorrt_llm/runtime/gptDecoderBatched.cpp
+++ b/cpp/tensorrt_llm/runtime/gptDecoderBatched.cpp
@@ -200,8 +200,7 @@ void GptDecoderBatched::forwardDispatch(decoder_batch::Output& output, decoder_b
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
 }
 
-GptDecoderBatched::DecoderFinishedEventPtr GptDecoderBatched::forwardAsync(
-    decoder_batch::Output& output, decoder_batch::Input const& input)
+CudaEvent GptDecoderBatched::forwardAsync(decoder_batch::Output& output, decoder_batch::Input const& input)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
 
@@ -218,7 +217,7 @@ GptDecoderBatched::DecoderFinishedEventPtr GptDecoderBatched::forwardAsync(
     CudaEvent eventStop{};
     mRuntimeStream->record(eventStop);
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
-    return std::make_unique<decoder_batch::DecoderFinishedEvent>(std::move(eventStop), input.active);
+    return eventStop;
 }
 
 // TODO(rkobus): produce new input and output
@@ -334,7 +333,7 @@ void GptDecoderBatched::forward(decoder_batch::Output& output, decoder_batch::In
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
     auto decoderFinishEvent = forwardAsync(output, input);
-    decoderFinishEvent->event.synchronize();
+    decoderFinishEvent.synchronize();
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
 }
 

--- a/cpp/tensorrt_llm/runtime/statefulGptDecoderBatched.cpp
+++ b/cpp/tensorrt_llm/runtime/statefulGptDecoderBatched.cpp
@@ -237,7 +237,7 @@ void StatefulGptDecoderBatched::forwardSync()
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
 
-    mDecoderFinishEvent->event.synchronize();
+    mDecoderFinishEvent.synchronize();
 
     // wait for mFinishedSum to be updated
     mForwardEvent.synchronize();


### PR DESCRIPTION
- Updated the `forwardAsync` method in `GptDecoderBatched` and `iGptDecoderBatched` to return `CudaEvent` instead of `DecoderFinishedEventPtr`, simplifying event handling.
- Removed the `DecoderFinishedEvent` class and its associated usage across various files, streamlining the codebase.
- Adjusted related methods and Python bindings to accommodate the new event structure, ensuring compatibility and maintaining functionality.

These changes enhance the clarity and efficiency of the decoding process in the batch manager.