### PR TITLE
feat: Variable-Beam-Width-Search (VBWS) part1

### DIFF
--- a/cpp/include/tensorrt_llm/executor/executor.h
+++ b/cpp/include/tensorrt_llm/executor/executor.h
@@ -75,7 +75,8 @@ public:
         std::optional<SizeType32> const& earlyStopping = std::nullopt,
         std::optional<SizeType32> const& noRepeatNgramSize = std::nullopt,
         std::optional<SizeType32> const& numReturnSequences = std::nullopt,
-        std::optional<FloatType> const& minP = std::nullopt);
+        std::optional<FloatType> const& minP = std::nullopt,
+        std::optional<std::vector<SizeType32>> const& beamWidthArray = std::nullopt);
 
     bool operator==(SamplingConfig const& other) const;
 
@@ -100,6 +101,7 @@ public:
     [[nodiscard]] std::optional<SizeType32> getNoRepeatNgramSize() const;
     [[nodiscard]] std::optional<SizeType32> getNumReturnSequences() const;
     [[nodiscard]] std::optional<FloatType> getMinP() const;
+    [[nodiscard]] std::optional<std::vector<SizeType32>> getBeamWidthArray() const;
 
     void setBeamWidth(SizeType32 beamWidth);
     void setTopK(std::optional<SizeType32> const& topK);
@@ -121,6 +123,7 @@ public:
     void setNoRepeatNgramSize(std::optional<SizeType32> const& noRepeatNgramSize);
     void setNumReturnSequences(std::optional<SizeType32> const& numReturnSequences);
     void setMinP(std::optional<FloatType> const& minP);
+    void setBeamWidthArray(std::optional<std::vector<SizeType32>> const& beamWidthArray);
 
 private:
     static SizeType32 checkBeamWidth(SizeType32 beamWidth);
@@ -130,15 +133,18 @@ private:
     static std::optional<TokenIdType> const& checkTopPResetIds(std::optional<TokenIdType> const& topPResetIds);
     static std::optional<FloatType> const& checkTopPDecay(std::optional<FloatType> const& topPDecay);
     static std::optional<FloatType> const& checkTemperature(std::optional<FloatType> const& temperature);
-    static std::optional<FloatType> const& checkRepetitionPenalty(std::optional<FloatType> const& penalty);
     static std::optional<SizeType32> const& checkMinTokens(std::optional<SizeType32> const& minTokens);
-    static std::optional<SizeType32> const& checkNoRepeatNgramSize(std::optional<SizeType32> const& noRepeatNgramSize);
     static std::optional<FloatType> const& checkBeamSearchDiversityRate(
         std::optional<FloatType> const& beamSearchDiversityRate);
+    static std::optional<FloatType> const& checkRepetitionPenalty(std::optional<FloatType> const& repetitionpenalty);
+    static std::optional<FloatType> const& checkLengthPenalty(std::optional<FloatType> const& lengthPenalty);
+    static std::optional<SizeType32> const& checkEarlyStopping(std::optional<SizeType32> const& earlyStopping);
+    static std::optional<SizeType32> const& checkNoRepeatNgramSize(std::optional<SizeType32> const& noRepeatNgramSize);
     static std::optional<SizeType32> const& checkNumReturnSequences(
         std::optional<SizeType32> const& numReturnSequences, SizeType32 beamWidth);
     static std::optional<FloatType> const& checkMinP(std::optional<FloatType> const& minP);
-
+    static std::optional<std::vector<SizeType32>> const& checkBeamWidthArray(
+        std::optional<std::vector<SizeType32>> const& beamWidthArray, std::optional<SizeType32> const beamWidth);
     void updateNumReturnBeams();
 
     friend class Serialization;
@@ -188,6 +194,8 @@ private:
     /// @brief Controls the min_p scaling for sampling.
     /// It masks x which P_x < min_p * P_max, where P_x is probability of candidate x. Default is 0.f
     std::optional<FloatType> mMinP;
+    /// @brief Controls the beam width for each step for Variable-Beam-Width-Search.
+    std::optional<std::vector<SizeType32>> mBeamWidthArray;
 };
 
 /// @brief Configuration that controls the outputs of a Result

--- a/cpp/include/tensorrt_llm/layers/defaultDecodingParams.h
+++ b/cpp/include/tensorrt_llm/layers/defaultDecodingParams.h
@@ -128,6 +128,11 @@ public:
     {
         return 0.0f;
     }
+
+    [[nodiscard]] static std::vector<runtime::SizeType32> getBeamWidthArray()
+    {
+        return std::vector<runtime::SizeType32>{1};
+    }
 };
 } // namespace layers
 } // namespace tensorrt_llm

--- a/cpp/include/tensorrt_llm/runtime/samplingConfig.h
+++ b/cpp/include/tensorrt_llm/runtime/samplingConfig.h
@@ -75,9 +75,6 @@ private:
     }
 
     template <typename T>
-    using Vec = std::vector<T>;
-
-    template <typename T>
     bool validateVec(std::string name, OptVec<T> const& vec, T min, std::optional<T> max = std::nullopt)
     {
         bool valid{true};
@@ -185,6 +182,9 @@ public:
             configs, [&configs](size_t ci) { return configs[ci].outputLogProbs; }, false);
         cumLogProbs = fuseValues<bool>(
             configs, [&configs](size_t ci) { return configs[ci].cumLogProbs; }, false);
+        beamWidthArray = fuseValues<std::vector<SizeType32>>(
+            configs, [&configs](size_t ci) { return configs[ci].beamWidthArray; },
+            layers::DefaultDecodingParams::getBeamWidthArray());
         // Only used for tests.
         draftAcceptanceThreshold = fuseValues<FloatType>(
             configs, [&configs](size_t ci) { return configs[ci].draftAcceptanceThreshold; }, 0);
@@ -193,7 +193,7 @@ public:
     }
 
     explicit SamplingConfig(executor::SamplingConfig const& samplingConfig,
-        std::optional<executor::ExternalDraftTokensConfig> const& externalDraftTokensConfig)
+        std::optional<executor::ExternalDraftTokensConfig> const& externalDraftTokensConfig = std::nullopt)
         : beamWidth{samplingConfig.getBeamWidth()}
         , numReturnSequences(samplingConfig.getNumReturnSequences())
     {
@@ -201,14 +201,14 @@ public:
         if (externalDraftTokensConfig && externalDraftTokensConfig.value().getAcceptanceThreshold())
         {
             draftAcceptanceThreshold
-                = Vec<FloatType>{externalDraftTokensConfig.value().getAcceptanceThreshold().value()};
+                = std::vector<FloatType>{externalDraftTokensConfig.value().getAcceptanceThreshold().value()};
         }
 
 #define SET_FROM_OPTIONAL(varName, VarName, VarType)                                                                   \
                                                                                                                        \
     if (samplingConfig.get##VarName())                                                                                 \
     {                                                                                                                  \
-        varName = Vec<VarType>{samplingConfig.get##VarName().value()};                                                 \
+        varName = std::vector<VarType>{samplingConfig.get##VarName().value()};                                         \
     }
 
         SET_FROM_OPTIONAL(topK, TopK, SizeType32)
@@ -228,6 +228,7 @@ public:
         SET_FROM_OPTIONAL(earlyStopping, EarlyStopping, SizeType32)
         SET_FROM_OPTIONAL(noRepeatNgramSize, NoRepeatNgramSize, SizeType32)
         SET_FROM_OPTIONAL(minP, MinP, FloatType)
+        SET_FROM_OPTIONAL(beamWidthArray, BeamWidthArray, std::vector<SizeType32>)
 #undef SET_FROM_OPTIONAL
     }
 
@@ -266,16 +267,18 @@ public:
         valid &= validateVec("topK", topK, -1);
         valid &= validateVec("topP", topP, -fltEpsilon, {1.f});
         valid &= validateVec("topPMin", topPMin, 0.f, {1.f});
-        valid &= validateVec("topPDecay", topPDecay, 0.f, {1.f});
         valid &= validateVec("topPResetIds", topPResetIds, -1);
-
+        valid &= validateVec("topPDecay", topPDecay, 0.f, {1.f});
         valid &= validateVec("temperature", temperature, -fltEpsilon);
-        valid &= validateVec("repetitionPenalty", repetitionPenalty, 0.f);
         valid &= validateVec("minLength", minLength, -1);
+        valid &= validateVec("beamSearchDiversityRate", beamSearchDiversityRate, -fltEpsilon);
+        valid &= validateVec("repetitionPenalty", repetitionPenalty, 0.f);
+        // TODO: checking `lengthPenalty`leads to a failure in
+        // `test_openai_chat_example`, debug and re-enable it later.
+        // valid &= validateVec("lengthPenalty", lengthPenalty, 0.f);
         valid &= validateVec("noRepeatNgramSize", noRepeatNgramSize, 0);
         valid &= validateVec("minP", minP, -fltEpsilon, {1.f});
-
-        valid &= validateVec("beamSearchDiversityRate", beamSearchDiversityRate, -fltEpsilon);
+        // TODO: check `beamWidthArray`
 
         // Detect greedy sampling and overwrite params.
         if (temperature)
@@ -332,38 +335,39 @@ public:
     SizeType32 beamWidth;
     std::optional<SizeType32> numReturnSequences;
 
-    // penalties
-    OptVec<FloatType> temperature;         // [1] or [batch_size] on cpu
-    OptVec<FloatType> originalTemperature; // [1] or [batch_size] on cpu
-    OptVec<SizeType32> minLength;          // [1] or [batch_size] on cpu
-    OptVec<FloatType> repetitionPenalty;   // [1] or [batch_size] on cpu
-    OptVec<FloatType> presencePenalty;     // [1] or [batch_size] on cpu
-    OptVec<FloatType> frequencyPenalty;    // [1] or [batch_size] on cpu
-    OptVec<SizeType32> noRepeatNgramSize;  // [1] or [batch_size] on cpu
+    // penalties, [1] for one request, [batchSize] for one batch, the same for other parameters below
+    OptVec<FloatType> temperature;         // [1] or [batchSize]
+    OptVec<FloatType> originalTemperature; // [1] or [batchSize]
+    OptVec<SizeType32> minLength;          // [1] or [batchSize]
+    OptVec<FloatType> repetitionPenalty;   // [1] or [batchSize]
+    OptVec<FloatType> presencePenalty;     // [1] or [batchSize]
+    OptVec<FloatType> frequencyPenalty;    // [1] or [batchSize]
+    OptVec<SizeType32> noRepeatNgramSize;  // [1] or [batchSize]
 
     // probs
     OptVec<bool> outputLogProbs;
     OptVec<bool> cumLogProbs;
 
     // sampling layers
-    OptVec<SizeType32> topK;          // [1] or [batch_size] on cpu
-    OptVec<FloatType> topP;           // [1] or [batch_size] on cpu
-    OptVec<uint64_t> randomSeed;      // [1] or [batch_size] on cpu
-    OptVec<FloatType> topPDecay;      // [batch_size], must between [0, 1]
-    OptVec<FloatType> topPMin;        // [batch_size], must between [0, 1]
-    OptVec<TokenIdType> topPResetIds; // [batch_size]
-    OptVec<FloatType> minP;           // [1] or [batch_size] on cpu
+    OptVec<SizeType32> topK;          // [1] or [batchSize]
+    OptVec<FloatType> topP;           // [1] or [batchSize]
+    OptVec<uint64_t> randomSeed;      // [1] or [batchSize]
+    OptVec<FloatType> topPDecay;      // [1] or [batchSize], between [0, 1]
+    OptVec<FloatType> topPMin;        // [1] or [batchSize], between [0, 1]
+    OptVec<TokenIdType> topPResetIds; // [1] or [batchSize]
+    OptVec<FloatType> minP;           // [1] or [batchSize]
 
     // beam search layer
-    OptVec<FloatType> beamSearchDiversityRate; // [1] or [batch_size]
-    OptVec<FloatType> lengthPenalty;           // [1] or [batch_size]
-    OptVec<SizeType32> earlyStopping;          // [1] or [batch_size]
+    OptVec<FloatType> beamSearchDiversityRate;      // [1] or [batchSize]
+    OptVec<FloatType> lengthPenalty;                // [1] or [batchSize]
+    OptVec<SizeType32> earlyStopping;               // [1] or [batchSize]
+    OptVec<std::vector<SizeType32>> beamWidthArray; // [maxBeamWidthArrayLength] or [batchSize, maxBeamWidthArrayLength]
 
     // speculative decoding, only the first value is used (in gptDecoderBatched.cpp)
-    OptVec<FloatType> draftAcceptanceThreshold; // [1] or [batch_size]
+    OptVec<FloatType> draftAcceptanceThreshold; // [1] or [batchSize]
 
     // medusa params
-    OptVec<std::vector<runtime::SizeType32>> topKMedusaHeads; // [batchSize, maxMedusaHeads]
+    OptVec<std::vector<SizeType32>> topKMedusaHeads; // [batchSize, maxMedusaHeads]
 
     std::optional<bool> normalizeLogProbs;
 
@@ -379,7 +383,7 @@ public:
             && lengthPenalty == other.lengthPenalty && earlyStopping == other.earlyStopping
             && draftAcceptanceThreshold == other.draftAcceptanceThreshold && topKMedusaHeads == other.topKMedusaHeads
             && normalizeLogProbs == other.normalizeLogProbs && outputLogProbs == other.outputLogProbs
-            && cumLogProbs == other.cumLogProbs && minP == other.minP;
+            && cumLogProbs == other.cumLogProbs && minP == other.minP && beamWidthArray == other.beamWidthArray;
     }
 
     SizeType32 getNumReturnBeams() const

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelV1.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelV1.cpp
@@ -120,6 +120,7 @@ void addToSamplingConfig(SamplingConfig& batchSamplingConfig, SamplingConfig con
     TLLM_CHECK(batchSamplingConfig.beamSearchDiversityRate == addSamplingConfig.beamSearchDiversityRate);
     TLLM_CHECK(batchSamplingConfig.lengthPenalty == addSamplingConfig.lengthPenalty);
     TLLM_CHECK(batchSamplingConfig.earlyStopping == addSamplingConfig.earlyStopping);
+    TLLM_CHECK(batchSamplingConfig.beamWidthArray == addSamplingConfig.beamWidthArray);
 
     auto addOptional = [](auto& batch, auto const& add, char const* name)
     {

--- a/cpp/tensorrt_llm/executor/serialization.cpp
+++ b/cpp/tensorrt_llm/executor/serialization.cpp
@@ -156,10 +156,11 @@ SamplingConfig Serialization::deserializeSamplingConfig(std::istream& is)
     auto noRepeatNgramSize = su::deserialize<std::optional<SizeType32>>(is);
     auto numReturnSequences = su::deserialize<std::optional<SizeType32>>(is);
     auto minP = su::deserialize<std::optional<FloatType>>(is);
+    auto beamWidthArray = su::deserialize<std::optional<std::vector<SizeType32>>>(is);
 
     return SamplingConfig{beamWidth, topK, topP, topPMin, topPResetIds, topPDecay, randomSeed, temperature, minLength,
         beamSearchDiversityRate, repetitionPenalty, presencePenalty, frequencyPenalty, lengthPenalty, earlyStopping,
-        noRepeatNgramSize, numReturnSequences, minP};
+        noRepeatNgramSize, numReturnSequences, minP, beamWidthArray};
 }
 
 void Serialization::serialize(SamplingConfig const& config, std::ostream& os)
@@ -182,6 +183,7 @@ void Serialization::serialize(SamplingConfig const& config, std::ostream& os)
     su::serialize(config.mNoRepeatNgramSize, os);
     su::serialize(config.mNumReturnSequences, os);
     su::serialize(config.mMinP, os);
+    su::serialize(config.mBeamWidthArray, os);
 }
 
 size_t Serialization::serializedSize(SamplingConfig const& config)
@@ -205,6 +207,7 @@ size_t Serialization::serializedSize(SamplingConfig const& config)
     totalSize += su::serializedSize(config.mNoRepeatNgramSize);
     totalSize += su::serializedSize(config.mNumReturnSequences);
     totalSize += su::serializedSize(config.mMinP);
+    totalSize += su::serializedSize(config.mBeamWidthArray);
     return totalSize;
 }
 

--- a/cpp/tensorrt_llm/kernels/beamSearchKernels.cu
+++ b/cpp/tensorrt_llm/kernels/beamSearchKernels.cu
@@ -59,7 +59,7 @@ void invokeTopkBeamSearch(T const* logProbs, T const* bias, void* workspace, Bea
 #endif // FAST_BUILD
         }
     }
-    else // V1, only use kernels of `beam_width <= nMaxBeamWidthForV1`
+    else // V1, only use kernels of `beam_width <= kMaxBeamWidthForV1`
     {
         switch (nPadBeamWidth)
         {

--- a/cpp/tensorrt_llm/kernels/beamSearchKernels.h
+++ b/cpp/tensorrt_llm/kernels/beamSearchKernels.h
@@ -24,10 +24,11 @@ namespace tensorrt_llm
 {
 namespace kernels
 {
-static constexpr size_t nMaxBeamWidth = 1024;           // Max beam width supported in TRT-LLM now
-static constexpr size_t nMaxBeamWidthForV1 = 8;         // Max beam width for V1 kernels
-static constexpr size_t nThreadForSmallBeamWidth = 256; // Max count of thread for V1 stage 1
-static constexpr size_t nMaxVPartStage1 = 128;          // Max vocab part count for V1 stage 1
+static size_t constexpr kMaxBeamWidth = 1024;           // Max beam width supported in TRT-LLM now
+static size_t constexpr kMaxBeamWidthForV1 = 8;         // Max beam width for V1 workflow (V2 for larger)
+static size_t constexpr kMaxBeamWidthArrayLength = 8;   // Max length of beam width array of a request
+static size_t constexpr kThreadForSmallBeamWidth = 256; // Max count of thread for stage 1 in V1 workflow
+static size_t constexpr kMaxVPartStage1 = 128;          // Max vocab part count for stage 1 in V1 workflow
 
 struct BeamHypotheses
 {

--- a/cpp/tensorrt_llm/kernels/beamSearchKernels/beamSearchKernels1024.cu
+++ b/cpp/tensorrt_llm/kernels/beamSearchKernels/beamSearchKernels1024.cu
@@ -22,7 +22,7 @@ namespace kernels
 {
 
 #ifndef FAST_BUILD // Skip beam_width larger than 16
-// Skip V1 kernels if beam_width > nMaxBeamWidthForV1
+// Skip V1 kernels if beam_width > kMaxBeamWidthForV1
 INSTANTIATE_BEAM_SEARCH(float, 1024, true);
 INSTANTIATE_BEAM_SEARCH(half, 1024, true);
 #endif // FAST_BUILD

--- a/cpp/tensorrt_llm/kernels/beamSearchKernels/beamSearchKernels128.cu
+++ b/cpp/tensorrt_llm/kernels/beamSearchKernels/beamSearchKernels128.cu
@@ -22,7 +22,7 @@ namespace kernels
 {
 
 #ifndef FAST_BUILD // Skip beam_width larger than 16
-// Skip V1 kernels if beam_width > nMaxBeamWidthForV1
+// Skip V1 kernels if beam_width > kMaxBeamWidthForV1
 INSTANTIATE_BEAM_SEARCH(float, 128, true);
 INSTANTIATE_BEAM_SEARCH(half, 128, true);
 #endif // FAST_BUILD

--- a/cpp/tensorrt_llm/kernels/beamSearchKernels/beamSearchKernels16.cu
+++ b/cpp/tensorrt_llm/kernels/beamSearchKernels/beamSearchKernels16.cu
@@ -20,7 +20,7 @@ namespace tensorrt_llm
 {
 namespace kernels
 {
-// Skip V1 kernels if beam_width > nMaxBeamWidthForV1
+// Skip V1 kernels if beam_width > kMaxBeamWidthForV1
 INSTANTIATE_BEAM_SEARCH(float, 16, true);
 INSTANTIATE_BEAM_SEARCH(half, 16, true);
 } // namespace kernels

--- a/cpp/tensorrt_llm/kernels/beamSearchKernels/beamSearchKernels256.cu
+++ b/cpp/tensorrt_llm/kernels/beamSearchKernels/beamSearchKernels256.cu
@@ -22,7 +22,7 @@ namespace kernels
 {
 
 #ifndef FAST_BUILD // Skip beam_width larger than 16
-// Skip V1 kernels if beam_width > nMaxBeamWidthForV1
+// Skip V1 kernels if beam_width > kMaxBeamWidthForV1
 INSTANTIATE_BEAM_SEARCH(float, 256, true);
 INSTANTIATE_BEAM_SEARCH(half, 256, true);
 #endif // FAST_BUILD

--- a/cpp/tensorrt_llm/kernels/beamSearchKernels/beamSearchKernels32.cu
+++ b/cpp/tensorrt_llm/kernels/beamSearchKernels/beamSearchKernels32.cu
@@ -22,7 +22,7 @@ namespace kernels
 {
 
 #ifndef FAST_BUILD // Skip beam_width larger than 16
-// Skip V1 kernels if beam_width > nMaxBeamWidthForV1
+// Skip V1 kernels if beam_width > kMaxBeamWidthForV1
 INSTANTIATE_BEAM_SEARCH(float, 32, true);
 INSTANTIATE_BEAM_SEARCH(half, 32, true);
 #endif // FAST_BUILD

--- a/cpp/tensorrt_llm/kernels/beamSearchKernels/beamSearchKernels512.cu
+++ b/cpp/tensorrt_llm/kernels/beamSearchKernels/beamSearchKernels512.cu
@@ -22,7 +22,7 @@ namespace kernels
 {
 
 #ifndef FAST_BUILD // Skip beam_width larger than 16
-// Skip V1 kernels if beam_width > nMaxBeamWidthForV1
+// Skip V1 kernels if beam_width > kMaxBeamWidthForV1
 INSTANTIATE_BEAM_SEARCH(float, 512, true);
 INSTANTIATE_BEAM_SEARCH(half, 512, true);
 #endif // FAST_BUILD

--- a/cpp/tensorrt_llm/kernels/beamSearchKernels/beamSearchKernels64.cu
+++ b/cpp/tensorrt_llm/kernels/beamSearchKernels/beamSearchKernels64.cu
@@ -22,7 +22,7 @@ namespace kernels
 {
 
 #ifndef FAST_BUILD // Skip beam_width larger than 16
-// Skip V1 kernels if beam_width > nMaxBeamWidthForV1
+// Skip V1 kernels if beam_width > kMaxBeamWidthForV1
 INSTANTIATE_BEAM_SEARCH(float, 64, true);
 INSTANTIATE_BEAM_SEARCH(half, 64, true);
 #endif // FAST_BUILD

--- a/cpp/tensorrt_llm/kernels/beamSearchKernels/beamSearchKernelsTemplate.h
+++ b/cpp/tensorrt_llm/kernels/beamSearchKernels/beamSearchKernelsTemplate.h
@@ -635,7 +635,7 @@ void beamSearchKernelLauncher(
         pStage3 = reinterpret_cast<float*>(pStage2LogProbs + offset);
 
         // Stage 1
-        size_t constexpr nThreadStage1 = (PBM < 16) ? ((PBM < 8) ? nThreadForSmallBeamWidth : 128) : 64;
+        size_t constexpr nThreadStage1 = (PBM < 16) ? ((PBM < 8) ? kThreadForSmallBeamWidth : 128) : 64;
         dim3 grid(nBS, nBM, bh.nVPart);
         beamStage1Kernel<T, PBM, nThreadStage1><<<grid, nThreadStage1, bh.nByteSharedMemoryStage1, stream>>>(
             logProbs, bias, pStage3, bh.endIds, bh.finished, nV, bh.batchSlots);
@@ -656,7 +656,7 @@ void beamSearchKernelLauncher(
         else if (nByteRuntimeSharedMemory <= nByteMaxSharedMemoryPerBlock)
         {
             BEAM_STAGE2_KERNEL(128, true)
-            // No branch with larger `N_VOCAB_PART` since nVPart <= nMaxVPartStage1 == 128
+            // No branch with larger `N_VOCAB_PART` since nVPart <= kMaxVPartStage1 == 128
         }
         else
         {

--- a/cpp/tensorrt_llm/kernels/decodingKernels.cu
+++ b/cpp/tensorrt_llm/kernels/decodingKernels.cu
@@ -458,7 +458,6 @@ __global__ void finalizeKernel(BeamHypotheses bh)
     }
     else
     {
-        // TODO, wili: use CUB to sort for large nCBA
         for (int i = 0; i < nBM; ++i)
         {
             float maxScore = -FLT_MAX;

--- a/cpp/tensorrt_llm/pybind/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/bindings.cpp
@@ -348,11 +348,12 @@ PYBIND11_MODULE(TRTLLM_PYBIND_MODULE, m)
         return py::make_tuple(config.beamWidth, config.temperature, config.minLength, config.repetitionPenalty,
             config.presencePenalty, config.frequencyPenalty, config.topK, config.topP, config.randomSeed,
             config.topPDecay, config.topPMin, config.topPResetIds, config.beamSearchDiversityRate, config.lengthPenalty,
-            config.earlyStopping, config.noRepeatNgramSize, config.minP);
+            config.earlyStopping, config.noRepeatNgramSize, config.numReturnSequences, config.minP,
+            config.beamWidthArray);
     };
     auto SamplingConfigSetState = [](py::tuple t) -> tr::SamplingConfig
     {
-        assert(t.size() == 17);
+        assert(t.size() == 19);
 
         tr::SamplingConfig config;
         config.beamWidth = t[0].cast<SizeType32>();
@@ -371,7 +372,9 @@ PYBIND11_MODULE(TRTLLM_PYBIND_MODULE, m)
         config.lengthPenalty = t[13].cast<OptVec<float>>();
         config.earlyStopping = t[14].cast<OptVec<SizeType32>>();
         config.noRepeatNgramSize = t[15].cast<OptVec<SizeType32>>();
-        config.minP = t[16].cast<OptVec<float>>();
+        config.numReturnSequences = t[16].cast<SizeType32>();
+        config.minP = t[17].cast<OptVec<float>>();
+        config.beamWidthArray = t[18].cast<OptVec<std::vector<SizeType32>>>();
 
         return config;
     };
@@ -396,7 +399,9 @@ PYBIND11_MODULE(TRTLLM_PYBIND_MODULE, m)
         .def_readwrite("length_penalty", &tr::SamplingConfig::lengthPenalty)
         .def_readwrite("early_stopping", &tr::SamplingConfig::earlyStopping)
         .def_readwrite("no_repeat_ngram_size", &tr::SamplingConfig::noRepeatNgramSize)
+        .def_readwrite("num_return_sequences", &tr::SamplingConfig::numReturnSequences)
         .def_readwrite("min_p", &tr::SamplingConfig::minP)
+        .def_readwrite("beam_width_array", &tr::SamplingConfig::beamWidthArray)
         .def(py::pickle(SamplingConfigGetState, SamplingConfigSetState))
         .def("__eq__", &tr::SamplingConfig::operator==);
 

--- a/cpp/tensorrt_llm/pybind/executor/request.cpp
+++ b/cpp/tensorrt_llm/pybind/executor/request.cpp
@@ -68,23 +68,34 @@ void initRequestBindings(pybind11::module_& m)
             self.getTopPResetIds(), self.getTopPDecay(), self.getSeed(), self.getTemperature(), self.getMinTokens(),
             self.getBeamSearchDiversityRate(), self.getRepetitionPenalty(), self.getPresencePenalty(),
             self.getFrequencyPenalty(), self.getLengthPenalty(), self.getEarlyStopping(), self.getNoRepeatNgramSize(),
-            self.getNumReturnSequences(), self.getMinP());
+            self.getNumReturnSequences(), self.getMinP(), self.getBeamWidthArray());
     };
     auto samplingConfigSetstate = [](py::tuple const& state)
     {
-        if (state.size() != 18)
+        if (state.size() != 19)
         {
             throw std::runtime_error("Invalid SamplingConfig state!");
         }
-        return tle::SamplingConfig(state[0].cast<SizeType32>(), state[1].cast<std::optional<SizeType32>>(),
-            state[2].cast<std::optional<FloatType>>(), state[3].cast<std::optional<FloatType>>(),
-            state[4].cast<std::optional<tle::TokenIdType>>(), state[5].cast<std::optional<FloatType>>(),
-            state[6].cast<std::optional<tle::RandomSeedType>>(), state[7].cast<std::optional<FloatType>>(),
-            state[8].cast<std::optional<SizeType32>>(), state[9].cast<std::optional<FloatType>>(),
-            state[10].cast<std::optional<FloatType>>(), state[11].cast<std::optional<FloatType>>(),
-            state[12].cast<std::optional<FloatType>>(), state[13].cast<std::optional<FloatType>>(),
-            state[14].cast<std::optional<SizeType32>>(), state[15].cast<std::optional<SizeType32>>(),
-            state[16].cast<std::optional<SizeType32>>(), state[17].cast<std::optional<FloatType>>());
+        return tle::SamplingConfig(state[0].cast<SizeType32>(),      // BeamWidth
+            state[1].cast<std::optional<SizeType32>>(),              // TopK
+            state[2].cast<std::optional<FloatType>>(),               // TopP
+            state[3].cast<std::optional<FloatType>>(),               // TopPMin
+            state[4].cast<std::optional<tle::TokenIdType>>(),        // TopPResetIds
+            state[5].cast<std::optional<FloatType>>(),               // TopPDecay
+            state[6].cast<std::optional<tle::RandomSeedType>>(),     // Seed
+            state[7].cast<std::optional<FloatType>>(),               // Temperature
+            state[8].cast<std::optional<SizeType32>>(),              // MinTokens
+            state[9].cast<std::optional<FloatType>>(),               // BeamSearchDiversityRate
+            state[10].cast<std::optional<FloatType>>(),              // RepetitionPenalty
+            state[11].cast<std::optional<FloatType>>(),              // PresencePenalty
+            state[12].cast<std::optional<FloatType>>(),              // FrequencyPenalty
+            state[13].cast<std::optional<FloatType>>(),              // LengthPenalty
+            state[14].cast<std::optional<SizeType32>>(),             // EarlyStopping
+            state[15].cast<std::optional<SizeType32>>(),             // NoRepeatNgramSize
+            state[16].cast<std::optional<SizeType32>>(),             // NumReturnSequences
+            state[17].cast<std::optional<FloatType>>(),              // MinP
+            state[18].cast<std::optional<std::vector<SizeType32>>>() // BeamWidthArray
+        );
     };
     py::class_<tle::SamplingConfig>(m, "SamplingConfig")
         // A modified version of constructor to accpect deprecated args randomSeed and minLength
@@ -104,7 +115,8 @@ void initRequestBindings(pybind11::module_& m)
                     std::optional<tle::FloatType> const& lengthPenalty,
                     std::optional<tle::SizeType32> const& earlyStopping,
                     std::optional<tle::SizeType32> const& noRepeatNgramSize,
-                    std::optional<tle::SizeType32> const& numReturnSequences, std::optional<tle::FloatType> const& minP)
+                    std::optional<tle::SizeType32> const& numReturnSequences, std::optional<tle::FloatType> const& minP,
+                    std::optional<std::vector<tle::SizeType32>> const& beamWidthArray)
                 {
                     if (randomSeed.has_value())
                     {
@@ -125,7 +137,7 @@ void initRequestBindings(pybind11::module_& m)
                     return std::make_unique<tle::SamplingConfig>(beamWidth, topK, topP, topPMin, topPResetIds,
                         topPDecay, seed, temperature, minTokens, beamSearchDiversityRate, repetitionPenalty,
                         presencePenalty, frequencyPenalty, lengthPenalty, earlyStopping, noRepeatNgramSize,
-                        numReturnSequences, minP);
+                        numReturnSequences, minP, beamWidthArray);
                 }),
             py::arg("beam_width") = 1, py::kw_only(), py::arg("top_k") = py::none(), py::arg("top_p") = py::none(),
             py::arg("top_p_min") = py::none(), py::arg("top_p_reset_ids") = py::none(),
@@ -135,7 +147,7 @@ void initRequestBindings(pybind11::module_& m)
             py::arg("presence_penalty") = py::none(), py::arg("frequency_penalty") = py::none(),
             py::arg("length_penalty") = py::none(), py::arg("early_stopping") = py::none(),
             py::arg("no_repeat_ngram_size") = py::none(), py::arg("num_return_sequences") = py::none(),
-            py::arg("min_p") = py::none())
+            py::arg("min_p") = py::none(), py::arg("beam_width_array") = py::none())
         .def_property("beam_width", &tle::SamplingConfig::getBeamWidth, &tle::SamplingConfig::setBeamWidth)
         .def_property("top_k", &tle::SamplingConfig::getTopK, &tle::SamplingConfig::setTopK)
         .def_property("top_p", &tle::SamplingConfig::getTopP, &tle::SamplingConfig::setTopP)
@@ -162,6 +174,8 @@ void initRequestBindings(pybind11::module_& m)
         .def_property("num_return_sequences", &tle::SamplingConfig::getNumReturnSequences,
             &tle::SamplingConfig::setNumReturnSequences)
         .def_property("min_p", &tle::SamplingConfig::getMinP, &tle::SamplingConfig::setMinP)
+        .def_property(
+            "beam_width_array", &tle::SamplingConfig::getBeamWidthArray, &tle::SamplingConfig::setBeamWidthArray)
         .def(py::pickle(samplingConfigGetstate, samplingConfigSetstate));
 
     auto additionalModelOutputGetstate = [](tle::OutputConfig::AdditionalModelOutput const& self)

--- a/cpp/tensorrt_llm/thop/dynamicDecodeOp.cpp
+++ b/cpp/tensorrt_llm/thop/dynamicDecodeOp.cpp
@@ -66,13 +66,12 @@ namespace
 template <typename T>
 void safeInsert(th::optional<th::Tensor>& tensor, std::optional<std::vector<T>>& arg)
 {
-    using valueType = T;
     if (tensor.has_value())
     {
-        auto ptr = get_ptr<valueType>(tensor.value());
         auto shape = convert_shape(tensor.value());
         size_t const size = tensorrt_llm::runtime::ITensor::volume(shape);
-        arg = std::vector<valueType>(ptr, ptr + size);
+        auto ptr = get_ptr<T>(tensor.value());
+        arg = std::vector<T>(ptr, ptr + size);
     }
 }
 

--- a/cpp/tests/unit_tests/runtime/samplingConfigTest.cpp
+++ b/cpp/tests/unit_tests/runtime/samplingConfigTest.cpp
@@ -21,88 +21,160 @@ using ::testing::_;
 using ::testing::Invoke;
 
 namespace tr = tensorrt_llm::runtime;
-namespace tc = tensorrt_llm::common;
-namespace texec = tensorrt_llm::executor;
+namespace te = tensorrt_llm::executor;
+using namespace tensorrt_llm::common;
+
+using te::SizeType32;
+using te::FloatType;
+using te::TokenIdType;
+using te::RandomSeedType;
+
+static std::nullopt_t constexpr no = std::nullopt;
+
+void test(bool const useExternalDraftTokensConfig, SizeType32 beamWidth = 1, std::optional<SizeType32> topK = no,
+    std::optional<FloatType> topP = no, std::optional<FloatType> topPMin = no,
+    std::optional<TokenIdType> topPResetIds = no, std::optional<FloatType> topPDecay = no,
+    std::optional<RandomSeedType> randomSeed = no, std::optional<FloatType> temperature = no,
+    std::optional<SizeType32> minLength = no, std::optional<FloatType> beamSearchDiversityRate = no,
+    std::optional<FloatType> repetitionPenalty = no, std::optional<FloatType> presencePenalty = no,
+    std::optional<FloatType> frequencyPenalty = no, std::optional<FloatType> lengthPenalty = no,
+    std::optional<SizeType32> earlyStopping = no, std::optional<SizeType32> noRepeatNgramSize = no,
+    std::optional<SizeType32> numReturnSequences = no, std::optional<FloatType> minP = no,
+    std::optional<std::vector<SizeType32>> beamWidthArray = no)
+{
+    // 19 parameters for SamplingConfig, from `beamWidth` to `beamWidthArray`
+    try
+    {
+        te::SamplingConfig execSamplingCfg(beamWidth, topK, topP, topPMin, topPResetIds, topPDecay, randomSeed,
+            temperature, minLength, beamSearchDiversityRate, repetitionPenalty, presencePenalty, frequencyPenalty,
+            lengthPenalty, earlyStopping, noRepeatNgramSize, numReturnSequences, minP, beamWidthArray);
+        std::optional<te::ExternalDraftTokensConfig> specCfg = std::nullopt;
+        if (useExternalDraftTokensConfig)
+        {
+            specCfg = te::ExternalDraftTokensConfig({1}, no, 0.5f);
+        }
+        tr::SamplingConfig samplingCfg(execSamplingCfg, specCfg);
+
+        EXPECT_EQ(samplingCfg.beamWidth, execSamplingCfg.getBeamWidth());
+        EXPECT_EQ(samplingCfg.numReturnSequences, execSamplingCfg.getNumReturnSequences());
+
+        if (useExternalDraftTokensConfig)
+        {
+            EXPECT_TRUE(samplingCfg.draftAcceptanceThreshold.has_value());
+            EXPECT_THAT(samplingCfg.draftAcceptanceThreshold.value(), testing::ElementsAre(0.5f));
+        }
+        else
+        {
+            EXPECT_EQ(samplingCfg.draftAcceptanceThreshold, no);
+        }
+    }
+    catch (TllmException& e)
+    {
+        // Come here if `sc` is invalid and the exception is caught
+        FAIL() << "Expected TllmException";
+    }
+    catch (std::exception const& e)
+    {
+        // Come here if `sc` is invalid but the exception is not caught
+        FAIL() << "Expected TllmException";
+    }
+}
 
 TEST(samplingConfigTest, validInputs)
 {
-    {
-        texec::SamplingConfig execSamplingCfg(1);
-        tr::SamplingConfig samplingCfg(execSamplingCfg, std::nullopt);
-        EXPECT_EQ(samplingCfg.beamWidth, execSamplingCfg.getBeamWidth());
-        EXPECT_EQ(samplingCfg.draftAcceptanceThreshold, std::nullopt);
-    }
-    {
-        texec::SamplingConfig execSamplingCfg(1);
-        texec::ExternalDraftTokensConfig specCfg({1}, std::nullopt, 0.5);
-        tr::SamplingConfig samplingCfg(execSamplingCfg, specCfg);
-        EXPECT_EQ(samplingCfg.beamWidth, execSamplingCfg.getBeamWidth());
-        EXPECT_TRUE(samplingCfg.draftAcceptanceThreshold.has_value());
-        EXPECT_THAT(samplingCfg.draftAcceptanceThreshold.value(), testing::ElementsAre(0.5f));
-    }
-    {
-        texec::SamplingConfig execSamplingCfg(1);
-        execSamplingCfg.setNumReturnSequences(3);
-        tr::SamplingConfig samplingCfg(execSamplingCfg, std::nullopt);
-        EXPECT_EQ(samplingCfg.beamWidth, execSamplingCfg.getBeamWidth());
-        EXPECT_EQ(samplingCfg.beamWidth, execSamplingCfg.getNumReturnBeams());
-        EXPECT_EQ(samplingCfg.numReturnSequences, execSamplingCfg.getNumReturnSequences());
-    }
-    {
-        texec::SamplingConfig execSamplingCfg(4);
-        execSamplingCfg.setNumReturnSequences(3);
-        tr::SamplingConfig samplingCfg(execSamplingCfg, std::nullopt);
-        EXPECT_EQ(samplingCfg.beamWidth, execSamplingCfg.getBeamWidth());
-        EXPECT_EQ(samplingCfg.numReturnSequences, execSamplingCfg.getNumReturnBeams());
-        EXPECT_EQ(samplingCfg.numReturnSequences, execSamplingCfg.getNumReturnSequences());
-    }
-    {
-        texec::SamplingConfig execSamplingCfg(4);
-        tr::SamplingConfig samplingCfg(execSamplingCfg, std::nullopt);
-        EXPECT_EQ(samplingCfg.beamWidth, execSamplingCfg.getBeamWidth());
-        EXPECT_EQ(samplingCfg.beamWidth, execSamplingCfg.getNumReturnBeams());
-    }
-    {
-        texec::SizeType32 topK = 1;
-        texec::FloatType topP = 0.5;
-        texec::FloatType topPMin = 0.1;
-        texec::SizeType32 topPResetIds = 1;
-        texec::FloatType topPDecay = 0.6;
-        uint64_t randomSeed = 7777;
-        texec::FloatType temperature = 0.245;
-        texec::SizeType32 minLength = 1234;
-        texec::FloatType beamSearchDiversityRate = 0.9999;
-        texec::FloatType repetitionPenalty = 0.11;
-        texec::FloatType presencePenalty = 0.22;
-        texec::FloatType frequencyPenalty = 0.33;
-        texec::FloatType lengthPenalty = 0.44;
-        texec::SizeType32 earlyStopping = 1;
-        texec::SizeType32 noRepeatNgramSize = 1000000;
-        texec::SizeType32 numReturnSequences = 1;
-        texec::FloatType minP = 0.5;
+    // Auto
+    test(false, 1);
+    // Use ExternalDraftTokensConfig
+    test(true, 1);
+    // TopK
+    test(false, 1, 2);
+    // TopP
+    test(false, 1, no, 0.5f);
+    // TopPMin
+    test(false, 1, no, no, 0.5f);
+    // TopP reset ids
+    test(false, 1, no, no, no, 0);
+    // TopP decay
+    test(false, 1, no, no, no, no, 0.5f);
+    // Seed
+    test(false, 1, no, no, no, no, no, 65536);
+    // Temperature
+    test(false, 1, no, no, no, no, no, no, 0.5f);
+    // Min token
+    test(false, 1, no, no, no, no, no, no, no, 64);
+    // Beam divirsity rate
+    test(false, 2, no, no, no, no, no, no, no, no, 0.5f);
+    // Repetition penalty
+    test(false, 1, no, no, no, no, no, no, no, no, no, 1.f);
+    // Presence penalty
+    test(false, 1, no, no, no, no, no, no, no, no, no, no, 1.f);
+    // Frequency penalty
+    test(false, 1, no, no, no, no, no, no, no, no, no, no, no, 1.f);
+    // Length penalty
+    test(false, 1, no, no, no, no, no, no, no, no, no, no, no, no, 1.f);
+    // Early stopping
+    test(false, 1, no, no, no, no, no, no, no, no, no, no, no, no, no, 1.f);
+    // No repeat ngram size
+    test(false, 1, no, no, no, no, no, no, no, no, no, no, no, no, no, no, 2);
+    // NumReturnSequences
+    test(false, 4, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no, 2);
+    // MinP, 18 arguments
+    test(false, 1, no, 0.9, no, no, no, no, no, no, no, no, no, no, no, no, no, no, 0.5f);
+    // BeamWidthArray
+    test(false, 5, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no,
+        std::vector<SizeType32>{2, 3, 4, 5});
 
-        texec::SamplingConfig execSamplingCfg(1, topK, topP, topPMin, topPResetIds, topPDecay, randomSeed, temperature,
-            minLength, beamSearchDiversityRate, repetitionPenalty, presencePenalty, frequencyPenalty, lengthPenalty,
-            earlyStopping, noRepeatNgramSize, numReturnSequences, minP);
-        texec::ExternalDraftTokensConfig specCfg({1}, std::nullopt, 0.5);
+    // All parameters
+    {
+        te::SizeType32 beamWidth{5};
+        te::SizeType32 topK{1};
+        te::FloatType topP{0.5f};
+        te::FloatType topPMin{0.5f};
+        te::SizeType32 topPResetIds{1};
+        te::FloatType topPDecay{0.5f};
+        te::RandomSeedType randomSeed{65536};
+        te::FloatType temperature{0.5f};
+        te::SizeType32 minLength{64};
+        te::FloatType beamSearchDiversityRate{0.5f};
+        te::FloatType repetitionPenalty{0.5f};
+        te::FloatType presencePenalty{0.5f};
+        te::FloatType frequencyPenalty{0.5f};
+        te::FloatType lengthPenalty{0.5f};
+        te::SizeType32 earlyStopping{1};
+        te::SizeType32 noRepeatNgramSize{5};
+        te::SizeType32 numReturnSequences{1};
+        te::FloatType minP{0.5f};
+        std::vector<te::SizeType32> beamWidthArray{2, 3, 4, 5};
+
+        te::SamplingConfig execSamplingCfg(beamWidth, topK, topP, topPMin, topPResetIds, topPDecay, randomSeed,
+            temperature, minLength, beamSearchDiversityRate, repetitionPenalty, presencePenalty, frequencyPenalty,
+            lengthPenalty, earlyStopping, noRepeatNgramSize, numReturnSequences, minP, beamWidthArray);
+        te::ExternalDraftTokensConfig specCfg({1}, no, 0.5f);
         tr::SamplingConfig samplingCfg(execSamplingCfg, specCfg);
         EXPECT_EQ(samplingCfg.beamWidth, execSamplingCfg.getBeamWidth());
+        EXPECT_EQ(samplingCfg.numReturnSequences, execSamplingCfg.getNumReturnSequences());
         EXPECT_THAT(samplingCfg.draftAcceptanceThreshold.value(), testing::ElementsAre(0.5f));
+        EXPECT_THAT(samplingCfg.topK.value(), testing::ElementsAre(topK));
+        EXPECT_THAT(samplingCfg.topP.value(), testing::ElementsAre(topP));
+        EXPECT_THAT(samplingCfg.topPMin.value(), testing::ElementsAre(topPMin));
+        EXPECT_THAT(samplingCfg.topPResetIds.value(), testing::ElementsAre(topPResetIds));
+        EXPECT_THAT(samplingCfg.topPDecay.value(), testing::ElementsAre(topPDecay));
+        EXPECT_THAT(samplingCfg.randomSeed.value(), testing::ElementsAre(randomSeed));
         EXPECT_THAT(samplingCfg.temperature.value(), testing::ElementsAre(temperature));
         EXPECT_THAT(samplingCfg.minLength.value(), testing::ElementsAre(minLength));
+        EXPECT_THAT(samplingCfg.beamSearchDiversityRate.value(), testing::ElementsAre(beamSearchDiversityRate));
         EXPECT_THAT(samplingCfg.repetitionPenalty.value(), testing::ElementsAre(repetitionPenalty));
         EXPECT_THAT(samplingCfg.presencePenalty.value(), testing::ElementsAre(presencePenalty));
         EXPECT_THAT(samplingCfg.frequencyPenalty.value(), testing::ElementsAre(frequencyPenalty));
-        EXPECT_THAT(samplingCfg.topK.value(), testing::ElementsAre(topK));
-        EXPECT_THAT(samplingCfg.topP.value(), testing::ElementsAre(topP));
-        EXPECT_THAT(samplingCfg.randomSeed.value(), testing::ElementsAre(randomSeed));
-        EXPECT_THAT(samplingCfg.topPMin.value(), testing::ElementsAre(topPMin));
-        EXPECT_THAT(samplingCfg.topPResetIds.value(), testing::ElementsAre(topPResetIds));
-        EXPECT_THAT(samplingCfg.beamSearchDiversityRate.value(), testing::ElementsAre(beamSearchDiversityRate));
         EXPECT_THAT(samplingCfg.lengthPenalty.value(), testing::ElementsAre(lengthPenalty));
         EXPECT_THAT(samplingCfg.earlyStopping.value(), testing::ElementsAre(earlyStopping));
         EXPECT_THAT(samplingCfg.noRepeatNgramSize.value(), testing::ElementsAre(noRepeatNgramSize));
-        EXPECT_EQ(samplingCfg.numReturnSequences, execSamplingCfg.getNumReturnSequences());
         EXPECT_THAT(samplingCfg.minP.value(), testing::ElementsAre(minP));
+        auto const beamWidthArrayReturn = samplingCfg.beamWidthArray.value()[0];
+        EXPECT_EQ(beamWidthArrayReturn.size(), beamWidthArray.size());
+        for (int i = 0; i < (int) beamWidthArrayReturn.size(); ++i)
+        {
+            EXPECT_EQ(beamWidthArrayReturn[i], beamWidthArray[i]);
+        }
     }
 }

--- a/examples/chatglm/chatglm-6b/tokenization_chatglm.py
+++ b/examples/chatglm/chatglm-6b/tokenization_chatglm.py
@@ -201,7 +201,7 @@ class ChatGLMTokenizer(PreTrainedTokenizer):
                  pad_token="<pad>",
                  unk_token="<unk>",
                  num_image_tokens=20000,
-                 **kwargs) -> None:  # wili, fix for new transformers
+                 **kwargs) -> None:  # Fix for new transformers
 
         self.do_lower_case = do_lower_case
         self.remove_space = remove_space
@@ -217,7 +217,7 @@ class ChatGLMTokenizer(PreTrainedTokenizer):
                                         num_image_tokens=num_image_tokens)
 
         super().__init__(
-            do_lower_case=do_lower_case,  # wili, fix for new transformers
+            do_lower_case=do_lower_case,  # Fix for new transformers
             remove_space=remove_space,
             padding_side=padding_side,
             bos_token=bos_token,
@@ -363,7 +363,7 @@ class ChatGLMTokenizer(PreTrainedTokenizer):
             padding_strategy: PaddingStrategy = PaddingStrategy.DO_NOT_PAD,
             pad_to_multiple_of: Optional[int] = None,
             return_attention_mask: Optional[bool] = None,
-            padding_side: str = "left",  # wili, fix for new transformers
+            padding_side: str = "left",  # Fix for new transformers
     ) -> dict:
         """
         Pad encoded inputs (on left/right and up to predefined length or max length in the batch)

--- a/examples/chatglm/chatglm2-6b/tokenization_chatglm.py
+++ b/examples/chatglm/chatglm2-6b/tokenization_chatglm.py
@@ -216,7 +216,7 @@ class ChatGLMTokenizer(PreTrainedTokenizer):
             padding_strategy: PaddingStrategy = PaddingStrategy.DO_NOT_PAD,
             pad_to_multiple_of: Optional[int] = None,
             return_attention_mask: Optional[bool] = None,
-            padding_side: str = "left",  # wili, fix for new transformers
+            padding_side: str = "left",  # Fix for new transformers
     ) -> dict:
         """
         Pad encoded inputs (on left/right and up to predefined length or max length in the batch)

--- a/examples/chatglm/chatglm3-6b-32k/tokenization_chatglm.py
+++ b/examples/chatglm/chatglm3-6b-32k/tokenization_chatglm.py
@@ -247,7 +247,7 @@ class ChatGLMTokenizer(PreTrainedTokenizer):
             padding_strategy: PaddingStrategy = PaddingStrategy.DO_NOT_PAD,
             pad_to_multiple_of: Optional[int] = None,
             return_attention_mask: Optional[bool] = None,
-            padding_side: str = "left",  # wili, fix for new transformers
+            padding_side: str = "left",  # Fix for new transformers
     ) -> dict:
         """
         Pad encoded inputs (on left/right and up to predefined length or max length in the batch)

--- a/examples/chatglm/glm-4-9b/tokenization_chatglm.py
+++ b/examples/chatglm/glm-4-9b/tokenization_chatglm.py
@@ -277,7 +277,7 @@ class ChatGLM4Tokenizer(PreTrainedTokenizer):
             padding_strategy: PaddingStrategy = PaddingStrategy.DO_NOT_PAD,
             pad_to_multiple_of: Optional[int] = None,
             return_attention_mask: Optional[bool] = None,
-            padding_side: str = "left",  # wili, fix for new transformers
+            padding_side: str = "left",  # Fix for new transformers
     ) -> dict:
         """
         Pad encoded inputs (on left/right and up to predefined length or max length in the batch)

--- a/tensorrt_llm/sampling_params.py
+++ b/tensorrt_llm/sampling_params.py
@@ -146,6 +146,7 @@ class SamplingParams:
         early_stopping (int, optional): Controls whether the generation process finishes once beamWidth sentences are generated (ends with end_token).  None means using C++ runtime default 1. Defaults to None.
         no_repeat_ngram_size (int, optional): Controls how many repeat ngram size are acceptable. None means using C++ runtime default 1 << 30. Defaults to None.
         min_p (float, optional): scale the most likely token to determine the minimum token probability. None means using C++ runtime default 0.0. Defaults to None.
+        beam_width_array (List[int], optional): The array of beam width using in Variable-Beam-Width-Search. Defaults to None.
 
         return_log_probs (bool): Controls if Result should contain log probabilities. Defaults to False.
         return_context_logits (bool): Controls if Result should contain the context logits. Defaults to False.
@@ -220,6 +221,7 @@ class SamplingParams:
     early_stopping: Optional[int] = None
     no_repeat_ngram_size: Optional[int] = None
     min_p: Optional[float] = None
+    beam_width_array: Optional[List[int]] = None
 
     # Keep the below fields in sync with tllme.OutputConfig
     return_log_probs: bool = False

--- a/tests/unittest/api_stability/references_committed/sampling_params.yaml
+++ b/tests/unittest/api_stability/references_committed/sampling_params.yaml
@@ -54,6 +54,9 @@ methods:
       min_p:
         annotation: Optional[float]
         default: null
+      beam_width_array:
+        annotation: Optional[List[int]]
+        default: null
       # Panelities
       repetition_penalty:
         annotation: Optional[float]

--- a/tests/unittest/api_stability/test_llm_api.py
+++ b/tests/unittest/api_stability/test_llm_api.py
@@ -20,12 +20,27 @@ class TestSamplingParams(ApiStabilityTestHarness):
 
     def test_get_sampling_config(self):
         expected_fields = {
-            "beam_width", "top_k", "top_p", "top_p_min", "top_p_reset_ids",
-            "top_p_decay", "seed", "random_seed", "temperature", "min_tokens",
-            "min_length", "beam_search_diversity_rate", "repetition_penalty",
-            "presence_penalty", "frequency_penalty", "length_penalty",
-            "early_stopping", "no_repeat_ngram_size", "num_return_sequences",
-            "min_p"
+            "beam_width",
+            "top_k",
+            "top_p",
+            "top_p_min",
+            "top_p_reset_ids",
+            "top_p_decay",
+            "seed",
+            "random_seed",
+            "temperature",
+            "min_tokens",
+            "min_length",
+            "beam_search_diversity_rate",
+            "repetition_penalty",
+            "presence_penalty",
+            "frequency_penalty",
+            "length_penalty",
+            "early_stopping",
+            "no_repeat_ngram_size",
+            "num_return_sequences",
+            "min_p",
+            "beam_width_array",
         }
         found_fields = {
             f

--- a/tests/unittest/bindings/test_bindings_ut.py
+++ b/tests/unittest/bindings/test_bindings_ut.py
@@ -510,20 +510,26 @@ def test_Mpicomm():
 
 def test_SamplingConfig_pickle():
     config = _tb.SamplingConfig()
-    config.beam_width = 2
-    config.temperature = [1.0, 2.0]
+    config.beam_width = 5
+    config.num_return_sequences = 1
     config.top_k = [1, 2]
     config.top_p = [0.1, 0.2]
+    config.top_p_min = [1.0, 2.0]
+    config.top_p_reset_ids = [1, 2]
+    config.top_p_decay = [1.0, 2.0]
     config.random_seed = [1, 2]
+    config.temperature = [1.0, 2.0]
+    config.min_length = [32, 64]
+    config.beam_search_diversity_rate = [1.0, 2.0]
     config.repetition_penalty = [1.0, 2.0]
     config.presence_penalty = [1.0, 2.0]
     config.frequency_penalty = [1.0, 2.0]
     config.length_penalty = [1.0, 2.0]
     config.early_stopping = [1, 2]
-    config.top_p_decay = [1.0, 2.0]
-    config.top_p_min = [1.0, 2.0]
-    config.top_p_reset_ids = [1, 2]
-    config.beam_search_diversity_rate = [1.0, 2.0]
+    config.no_repeat_ngram_size = [4, 6]
+    config.num_return_sequences = 1
+    config.min_p = [0.5, 0.5]
+    config.beam_width_array = [[2, 3, 4, 5]]
 
     config1 = pickle.loads(pickle.dumps(config))
 


### PR DESCRIPTION
## Background

In current TRT-LLM, we regard the `beam_width` of the runtime as a scalar, which means:
1. The `same beam_width` must be used for a request along all generation steps (time axis).
2. The `same beam_width` must be used for requests batched together (space axis).

## Final target

+ Loosening the constrains above as:
1. Each request owns a `beam_width_array` for beam search. For example, `--beam_width_array=[20,40,60]` means using `beam_width=20` for the first step, 40 for the second step, 60 for all following steps (we call it Variable-Beam-Width-Search, VBWS).
2. Requests with different beam width can be batched together for generation (we call it Diverse-Beam-Width-Search, DBWS).

## Target of this PR

We plan to implement the final target in 4 PRs, and this PR is the first part, where we achieve:
1. Add member `beamWidthArray` and related methods for class `SamplingConfig`.
2. Rewrite C++/Python unit tests for class `SamplingConfig`.
    + CPP unit test: `cpp/tests/executor/SamplingConfigTest.cpp`, `cpp/tests/runtime/SamplingConfigTest.cpp`.
    + Python unit test: `tests/unittest/api_stability/test_llm_api.py`, `tests/bindings/test_bind‎ings_ut.py‎`.
