### PR TITLE
test: fix QA TRT integration testlist mismatch issue

### DIFF
--- a/tests/integration/test_lists/qa/trt_llm_integration_perf_sanity_test.yml
+++ b/tests/integration/test_lists/qa/trt_llm_integration_perf_sanity_test.yml
@@ -1,5 +1,5 @@
 version: 0.0.1
-llm_trt_integration_perf_sanity_test:
+trt_llm_integration_perf_sanity_test:
 - condition:
     ranges:
       system_gpu_count:

--- a/tests/integration/test_lists/qa/trt_llm_integration_perf_test.yml
+++ b/tests/integration/test_lists/qa/trt_llm_integration_perf_test.yml
@@ -1,5 +1,5 @@
 version: 0.0.1
-llm_trt_integration_perf_test:
+trt_llm_integration_perf_test:
 - condition:
     ranges:
       system_gpu_count:


### PR DESCRIPTION
Incorrect test-db context caused empty test list output.
Fix by typo correction: `llm_trt_*` -> `trt_llm_*`.