### PR TITLE
bug: Fix hang bug when context server doesn't have enough capacity for KV Cache

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/cacheTransceiver.h
+++ b/cpp/include/tensorrt_llm/batch_manager/cacheTransceiver.h
@@ -116,7 +116,7 @@ private:
     CommType mCommType;
     std::unique_ptr<DataResponder> mDataResponder;
     std::unique_ptr<DataRequester> mDataRequester;
-    std::map<LlmRequest*, std::future<void>> mResponderFutures;
+    std::vector<std::pair<LlmRequest*, std::future<void>>> mResponderFutures;
     std::vector<std::pair<LlmRequest*, std::future<void>>> mRequesterFutures;
     mpi::MpiComm const *mMpiGroupComm{nullptr}, *mMpiWorldComm{nullptr};
     std::shared_ptr<mpi::MpiComm> mMpiGroupTensorParaComm, mMpiGroupPipeParaComm, mMpiGroupDataComm,

--- a/cpp/include/tensorrt_llm/batch_manager/cacheTransceiver.h
+++ b/cpp/include/tensorrt_llm/batch_manager/cacheTransceiver.h
@@ -58,9 +58,9 @@ public:
     virtual void requestAndReceiveSync(LlmRequest* llmRequest) = 0;
     virtual void requestAndReceiveAsync(LlmRequest* llmRequest) = 0;
 
-    virtual void checkContextTransferStatus(bool blocking = false) = 0;
+    virtual void checkContextTransferStatus(std::optional<int> const& atLeastRequestNum = std::nullopt) = 0;
 
-    virtual void checkGenTransferStatus(int atLeastRequestNum = 0) = 0;
+    virtual void checkGenTransferStatus(std::optional<int> const& atLeastRequestNum = std::nullopt) = 0;
 
     [[nodiscard]] virtual bool checkGenTransferComplete() const = 0;
 };
@@ -102,9 +102,9 @@ public:
     void requestAndReceiveSync(LlmRequest* llmRequest) override;
     void requestAndReceiveAsync(LlmRequest* llmRequest) override;
 
-    void checkContextTransferStatus(bool blocking = false) override;
+    void checkContextTransferStatus(std::optional<int> const& atLeastRequestNum = std::nullopt) override;
 
-    void checkGenTransferStatus(int atLeastRequestNum = 0) override;
+    void checkGenTransferStatus(std::optional<int> const& atLeastRequestNum = std::nullopt) override;
 
     [[nodiscard]] bool checkGenTransferComplete() const override;
 

--- a/cpp/include/tensorrt_llm/executor/dataTransceiverState.h
+++ b/cpp/include/tensorrt_llm/executor/dataTransceiverState.h
@@ -103,14 +103,15 @@ public:
     {
         SizeType32 mTensorParallelism;
         SizeType32 mPipelineParallelism;
-        bool mEnableAttenionDP;
+        bool mEnableAttentionDP;
         SizeType32 mDPrank;
         SizeType32 mDPsize;
 
         [[nodiscard]] bool operator==(ParallelConfig const& other) const noexcept
         {
             return mTensorParallelism == other.mTensorParallelism && mPipelineParallelism == other.mPipelineParallelism
-                && mEnableAttenionDP == other.mEnableAttenionDP && mDPrank == other.mDPrank && mDPsize == other.mDPsize;
+                && mEnableAttentionDP == other.mEnableAttentionDP && mDPrank == other.mDPrank
+                && mDPsize == other.mDPsize;
         }
     };
 
@@ -161,7 +162,7 @@ public:
         sstring << "mTokensPerBlock:" << mModelConfig.mTokensPerBlock << "\n";
         sstring << "tp:" << mParallelConfig.mTensorParallelism << "\n";
         sstring << "pp:" << mParallelConfig.mPipelineParallelism << "\n";
-        sstring << "enableAttentionDP:" << mParallelConfig.mEnableAttenionDP << "\n";
+        sstring << "enableAttentionDP:" << mParallelConfig.mEnableAttentionDP << "\n";
         sstring << "datatype:" << static_cast<int32_t>(mDataType) << "\n";
         sstring << "attentionType:" << static_cast<int32_t>(mAttentionConfig.mAttentionType) << "\n";
         sstring << "kvFactor:" << mAttentionConfig.mKvFactor << "\n";

--- a/cpp/include/tensorrt_llm/runtime/worldConfig.h
+++ b/cpp/include/tensorrt_llm/runtime/worldConfig.h
@@ -155,7 +155,7 @@ public:
 
     [[nodiscard]] bool constexpr enableAttentionDP() const noexcept
     {
-        return mEnableAttenionDP;
+        return mEnableAttentionDP;
     }
 
     [[nodiscard]] std::vector<SizeType32> getPipelineParallelGroup() const;
@@ -176,7 +176,7 @@ private:
     SizeType32 mContextParallelism;
     SizeType32 mRank;
     SizeType32 mGpusPerNode;
-    bool mEnableAttenionDP;
+    bool mEnableAttentionDP;
     std::vector<SizeType32> mDeviceIds;
 };
 

--- a/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
@@ -697,10 +697,10 @@ void CacheFormatter::formatInput(LlmRequest const& llmRequest,
     {
         return false;
     }
-    int selfTPInDP = selfConfig.getParallelConfig().mEnableAttenionDP
+    int selfTPInDP = selfConfig.getParallelConfig().mEnableAttentionDP
         ? selfConfig.getParallelConfig().mTensorParallelism / selfConfig.getParallelConfig().mDPsize
         : selfConfig.getParallelConfig().mTensorParallelism;
-    int destTPInDP = destConfig.getParallelConfig().mEnableAttenionDP
+    int destTPInDP = destConfig.getParallelConfig().mEnableAttentionDP
         ? destConfig.getParallelConfig().mTensorParallelism / destConfig.getParallelConfig().mDPsize
         : destConfig.getParallelConfig().mTensorParallelism;
     int selfNumHeads = selfConfig.getModelConfig().mNbKvHeadsPerLayer[0] * selfTPInDP;

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -108,7 +108,7 @@ CacheTransceiver::CacheTransceiver(kv_cache_manager::BaseKVCacheManager* cacheMa
     mCacheState = std::make_unique<executor::kv_cache::CacheState>(
         cacheStateModelCfg, worldConfig, dataType, attentionType, kvFactor);
 
-    if (mCacheState->getParallelConfig().mEnableAttenionDP)
+    if (mCacheState->getParallelConfig().mEnableAttentionDP)
     {
         int TPSizeInDPGroup
             = mCacheState->getParallelConfig().mTensorParallelism / mCacheState->getParallelConfig().mDPsize;
@@ -340,7 +340,7 @@ void updateKVCacheTransferBW(mpi::MpiComm const& mpiComm, LlmRequest* request)
 void CacheTransceiver::checkContextTransferStatus(std::optional<int> const& atLeastRequestNum)
 {
     bool blockAll = !atLeastRequestNum.has_value();
-    auto syncComm = mCacheState->getParallelConfig().mEnableAttenionDP ? mMpiGroupTPInDPComm : mMpiGroupTensorParaComm;
+    auto syncComm = mCacheState->getParallelConfig().mEnableAttentionDP ? mMpiGroupTPInDPComm : mMpiGroupTensorParaComm;
     std::vector<LlmRequest::RequestIdType> contextCompleteRequestIds;
     for (auto&& [request, future] : mResponderFutures)
     {
@@ -419,7 +419,7 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
     std::unordered_map<LlmRequest::RequestIdType, int> frequencyMap;
 
     std::vector<LlmRequest::RequestIdType> toBlockRequestIds;
-    auto syncComm = mCacheState->getParallelConfig().mEnableAttenionDP ? mMpiGroupDataComm.get() : mMpiGroupComm;
+    auto syncComm = mCacheState->getParallelConfig().mEnableAttentionDP ? mMpiGroupDataComm.get() : mMpiGroupComm;
     if ((syncComm) && syncComm->getSize() > 1)
     {
         auto gatherRequestIdVec = gatherRequestIds(*syncComm, genTransferReadyRequestIds);

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -380,10 +380,11 @@ void CacheTransceiver::checkContextTransferStatus(std::optional<int> const& atLe
         }
     }
 
-    size_t idx = 0;
+    // Make sure there are at least atLeastRequestNum requests in toCompleteIdSet.
+    // This will preserve the order of insertion for KVCache transfer requests.
     for (auto it = mResponderFutures.begin();
          atLeastRequestNum.value_or(0) > static_cast<int>(toCompleteIdSet.size()) && it != mResponderFutures.end();
-         ++it, ++idx)
+         ++it)
     {
         toCompleteIdSet.insert(it->first->mRequestId);
     }

--- a/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp
@@ -61,11 +61,11 @@ bool MLACacheFormatter::needSendCache(
 {
     int selfTpRank = selfIdx % selfConfig.getParallelConfig().mTensorParallelism;
 
-    if (selfConfig.getParallelConfig().mEnableAttenionDP)
+    if (selfConfig.getParallelConfig().mEnableAttentionDP)
     {
         int selfTPNumInDPGroup
             = selfConfig.getParallelConfig().mTensorParallelism / selfConfig.getParallelConfig().mDPsize;
-        int destTPNumInDPGroup = destConfig.getParallelConfig().mEnableAttenionDP
+        int destTPNumInDPGroup = destConfig.getParallelConfig().mEnableAttentionDP
             ? destConfig.getParallelConfig().mTensorParallelism / destConfig.getParallelConfig().mDPsize
             : destConfig.getParallelConfig().mTensorParallelism;
         int selfTPrankINDPGroup = selfTpRank % selfTPNumInDPGroup;
@@ -76,7 +76,7 @@ bool MLACacheFormatter::needSendCache(
         return selfTPrankINDPGroup % (selfTPNumInDPGroup / destTPNumInDPGroup) == 0;
     }
 
-    int destTPNum = destConfig.getParallelConfig().mEnableAttenionDP
+    int destTPNum = destConfig.getParallelConfig().mEnableAttentionDP
         ? destConfig.getParallelConfig().mTensorParallelism / destConfig.getParallelConfig().mDPsize
         : destConfig.getParallelConfig().mTensorParallelism;
     int selfTPNum = selfConfig.getParallelConfig().mTensorParallelism;
@@ -589,18 +589,18 @@ void MLACacheFormatter::formatInput(LlmRequest const& llmRequest,
     {
         return false;
     }
-    if (selfConfig.getParallelConfig().mEnableAttenionDP
+    if (selfConfig.getParallelConfig().mEnableAttentionDP
         && (selfConfig.getParallelConfig().mTensorParallelism % selfConfig.getParallelConfig().mDPsize != 0))
     {
 
         return false;
     }
-    if (destConfig.getParallelConfig().mEnableAttenionDP
+    if (destConfig.getParallelConfig().mEnableAttentionDP
         && (destConfig.getParallelConfig().mTensorParallelism % destConfig.getParallelConfig().mDPsize != 0))
     {
         return false;
     }
-    if ((destConfig.getParallelConfig().mEnableAttenionDP)
+    if ((destConfig.getParallelConfig().mEnableAttentionDP)
         && (destConfig.getParallelConfig().mTensorParallelism != destConfig.getParallelConfig().mDPsize))
     {
         return false;

--- a/cpp/tensorrt_llm/executor/cache_transmission/cacheConcatenate.cu
+++ b/cpp/tensorrt_llm/executor/cache_transmission/cacheConcatenate.cu
@@ -76,12 +76,12 @@ TargetRanksInfo TargetRanksInfoForDP(
     int mDomainTPSize = 1;
     int peerTpRankEnd = 0;
     int peerDpRank
-        = peerCacheState.getParallelConfig().mEnableAttenionDP ? peerCacheState.getParallelConfig().mDPrank : 0;
-    int selfTPSizeOneDPGroup = selfCacheState.getParallelConfig().mEnableAttenionDP
+        = peerCacheState.getParallelConfig().mEnableAttentionDP ? peerCacheState.getParallelConfig().mDPrank : 0;
+    int selfTPSizeOneDPGroup = selfCacheState.getParallelConfig().mEnableAttentionDP
         ? selfCacheState.getParallelConfig().mTensorParallelism / selfCacheState.getParallelConfig().mDPsize
         : selfTPNum;
 
-    int peerTPSizeOneDPGroup = peerCacheState.getParallelConfig().mEnableAttenionDP
+    int peerTPSizeOneDPGroup = peerCacheState.getParallelConfig().mEnableAttentionDP
         ? peerCacheState.getParallelConfig().mTensorParallelism / peerCacheState.getParallelConfig().mDPsize
         : peerTPNum;
 
@@ -119,7 +119,8 @@ TargetRanksInfo targetIRanks(
     kv_cache::CacheState const& peerCacheState, kv_cache::CacheState const& selfCacheState, int selfRank)
 {
     if (selfCacheState.getAttentionConfig().mAttentionType == CacheState::AttentionType::kMLA
-        || selfCacheState.getParallelConfig().mEnableAttenionDP || peerCacheState.getParallelConfig().mEnableAttenionDP)
+        || selfCacheState.getParallelConfig().mEnableAttentionDP
+        || peerCacheState.getParallelConfig().mEnableAttentionDP)
     {
         return TargetRanksInfoForDP(peerCacheState, selfCacheState, selfRank);
     }

--- a/cpp/tensorrt_llm/executor/serialization.cpp
+++ b/cpp/tensorrt_llm/executor/serialization.cpp
@@ -469,7 +469,7 @@ kv_cache::CacheState Serialization::deserializeCacheState(std::istream& is)
     auto tokensPerBlock = su::deserialize<decltype(CacheState::ModelConfig::mTokensPerBlock)>(is);
     auto tensorParallelism = su::deserialize<decltype(CacheState::ParallelConfig::mTensorParallelism)>(is);
     auto pipelineParallelism = su::deserialize<decltype(CacheState::ParallelConfig::mPipelineParallelism)>(is);
-    auto enableAttentionDP = su::deserialize<decltype(CacheState::ParallelConfig::mEnableAttenionDP)>(is);
+    auto enableAttentionDP = su::deserialize<decltype(CacheState::ParallelConfig::mEnableAttentionDP)>(is);
     auto DPrank = su::deserialize<decltype(CacheState::ParallelConfig::mDPrank)>(is);
     auto DPsize = su::deserialize<decltype(CacheState::ParallelConfig::mDPsize)>(is);
     auto dataType = su::deserialize<decltype(CacheState::mDataType)>(is);
@@ -486,7 +486,7 @@ void Serialization::serialize(kv_cache::CacheState const& state, std::ostream& o
     su::serialize(state.mModelConfig.mTokensPerBlock, os);
     su::serialize(state.mParallelConfig.mTensorParallelism, os);
     su::serialize(state.mParallelConfig.mPipelineParallelism, os);
-    su::serialize(state.mParallelConfig.mEnableAttenionDP, os);
+    su::serialize(state.mParallelConfig.mEnableAttentionDP, os);
     su::serialize(state.mParallelConfig.mDPrank, os);
     su::serialize(state.mParallelConfig.mDPsize, os);
     su::serialize(state.mDataType, os);
@@ -502,7 +502,7 @@ size_t Serialization::serializedSize(kv_cache::CacheState const& state)
     totalSize += su::serializedSize(state.mModelConfig.mTokensPerBlock);
     totalSize += su::serializedSize(state.mParallelConfig.mTensorParallelism);
     totalSize += su::serializedSize(state.mParallelConfig.mPipelineParallelism);
-    totalSize += su::serializedSize(state.mParallelConfig.mEnableAttenionDP);
+    totalSize += su::serializedSize(state.mParallelConfig.mEnableAttentionDP);
     totalSize += su::serializedSize(state.mParallelConfig.mDPrank);
     totalSize += su::serializedSize(state.mParallelConfig.mDPsize);
     totalSize += su::serializedSize(state.mDataType);

--- a/cpp/tensorrt_llm/pybind/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/cacheTransceiver.cpp
@@ -53,12 +53,12 @@ public:
         PYBIND11_OVERLOAD_PURE(void, tb::BaseCacheTransceiver, requestAndReceiveAsync, llmRequest);
     }
 
-    void checkContextTransferStatus(bool blocking = false) override
+    void checkContextTransferStatus(std::optional<int> const& atLeastRequestNum = std::nullopt) override
     {
-        PYBIND11_OVERLOAD_PURE(void, tb::BaseCacheTransceiver, checkContextTransferStatus, blocking);
+        PYBIND11_OVERLOAD_PURE(void, tb::BaseCacheTransceiver, checkContextTransferStatus, atLeastRequestNum);
     }
 
-    void checkGenTransferStatus(int atLeastRequestNum = 0) override
+    void checkGenTransferStatus(std::optional<int> const& atLeastRequestNum = std::nullopt) override
     {
         PYBIND11_OVERLOAD_PURE(void, tb::BaseCacheTransceiver, checkGenTransferStatus, atLeastRequestNum);
     }

--- a/cpp/tensorrt_llm/runtime/worldConfig.cpp
+++ b/cpp/tensorrt_llm/runtime/worldConfig.cpp
@@ -37,7 +37,7 @@ WorldConfig::WorldConfig(SizeType32 tensorParallelism, SizeType32 pipelineParall
     , mContextParallelism{contextParallelism}
     , mRank{rank}
     , mGpusPerNode{gpusPerNode}
-    , mEnableAttenionDP{enableAttentionDP}
+    , mEnableAttentionDP{enableAttentionDP}
     , mDeviceIds{deviceIds.value_or(std::vector<SizeType32>(mGpusPerNode))}
 {
 #if ENABLE_MULTI_DEVICE

--- a/cpp/tests/batch_manager/cacheTransceiverTest.cpp
+++ b/cpp/tests/batch_manager/cacheTransceiverTest.cpp
@@ -815,7 +815,7 @@ protected:
             mContextCacheState->getParallelConfig().mTensorParallelism,
             mContextCacheState->getParallelConfig().mPipelineParallelism, mContextCacheState->getDataType(),
             mContextCacheState->getAttentionConfig().mAttentionType, mContextCacheState->getAttentionConfig().mKvFactor,
-            mContextCacheState->getParallelConfig().mEnableAttenionDP, contextDpRank,
+            mContextCacheState->getParallelConfig().mEnableAttentionDP, contextDpRank,
             mContextCacheState->getParallelConfig().mTensorParallelism};
         state->setCacheState(cacheState);
         auto stats = texec::ContextPhaseParams({}, requestId, state.release(), std::nullopt);
@@ -884,7 +884,7 @@ protected:
         int startLayerId = layerSizePerRank * mPpRank;
         int headSizePerRank = mCacheState->getModelConfig().mNbKvHeadsPerLayer.at(0);
         int startHeadId = headSizePerRank * mTpRank;
-        bool enableDP = mCacheState->getParallelConfig().mEnableAttenionDP;
+        bool enableDP = mCacheState->getParallelConfig().mEnableAttentionDP;
         if (mIsMLA || enableDP)
         {
             startHeadId = 0;
@@ -948,7 +948,7 @@ protected:
         int startLayerId = layerSizePerRank * mPpRank;
         int headSizePerRank = mCacheState->getModelConfig().mNbKvHeadsPerLayer.at(0);
         int startHeadId = headSizePerRank * mTpRank;
-        bool enableDP = mCacheState->getParallelConfig().mEnableAttenionDP;
+        bool enableDP = mCacheState->getParallelConfig().mEnableAttentionDP;
         if (mIsMLA || enableDP)
         {
             startHeadId = 0;

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
@@ -57,7 +57,7 @@ class KvCacheTransceiver(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def check_context_transfer_status(self, blocking: bool):
+    def check_context_transfer_status(self, at_least_request_num: int):
         raise NotImplementedError
 
     @abstractmethod
@@ -94,8 +94,8 @@ class BindKvCacheTransceiver(KvCacheTransceiver):
     def request_and_receive_async(self, req: LlmRequest):
         return self.impl.request_and_receive_async(req)
 
-    def check_context_transfer_status(self, blocking: bool):
-        return self.impl.check_context_transfer_status(blocking)
+    def check_context_transfer_status(self, at_least_request_num: int):
+        return self.impl.check_context_transfer_status(at_least_request_num)
 
     def check_gen_transfer_status(self, at_least_request_num: int):
         return self.impl.check_gen_transfer_status(at_least_request_num)

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -833,7 +833,7 @@ class PyExecutor:
                             "num_fitting_reqs=0 and fitting_disagg_gen_init_requests is empty, may not have enough kvCache"
                         )
                         self.kv_cache_transceiver.check_context_transfer_status(
-                            True)
+                            1)
                 else:
                     assert scheduled_batch.batch_size > 0, (
                         "fail to schedule any pending request, "
@@ -959,7 +959,7 @@ class PyExecutor:
                             "num_fitting_reqs =0 and fitting_disagg_gen_init_requests is empty , may not have enough kvCache"
                         )
                         self.kv_cache_transceiver.check_context_transfer_status(
-                            True)
+                            1)
                 else:
                     assert scheduled_batch.batch_size > 0, (
                         "fail to schedule any pending request, "
@@ -1543,7 +1543,7 @@ class PyExecutor:
             if req.is_context_only_request and req.is_context_finished:
                 self.kv_cache_transceiver.respond_and_send_async(req)
 
-        self.kv_cache_transceiver.check_context_transfer_status(False)
+        self.kv_cache_transceiver.check_context_transfer_status(0)
 
         # Keep track of ctx requests that are in transmission
         ctx_transmission_reqs = [

--- a/tests/integration/defs/disaggregated/test_disaggregated_single_gpu.py
+++ b/tests/integration/defs/disaggregated/test_disaggregated_single_gpu.py
@@ -215,5 +215,95 @@ def test_disaggregated_simple_deepseek(model, generation_overlap,
         ])
 
 
+@pytest.mark.parametrize("model", ["DeepSeek-V3-Lite-fp8/fp8"])
+@pytest.mark.parametrize("enable_cuda_graph", [False])
+@pytest.mark.parametrize("generation_overlap", [False])
+def test_disaggregated_llama_context_capacity(model, enable_cuda_graph,
+                                              generation_overlap):
+    # Test the case where the context worker capacity is exceeded and
+    # needs to wait for the generation worker to complete.
+    worker_pytorch_configs = []
+
+    # Context worker
+    worker_pytorch_configs.append(
+        PyTorchConfig(enable_overlap_scheduler=False,
+                      kv_cache_dtype="auto",
+                      use_cuda_graph=enable_cuda_graph))
+
+    # Generation worker
+    worker_pytorch_configs.append(
+        PyTorchConfig(enable_overlap_scheduler=generation_overlap,
+                      kv_cache_dtype="auto",
+                      use_cuda_graph=enable_cuda_graph))
+
+    kv_cache_configs = [KvCacheConfig(max_tokens=128) for _ in range(2)]
+    model_names = [model_path(model) for _ in range(2)]
+    ranks = [0, 1]
+    worker_args = list(
+        zip(kv_cache_configs, worker_pytorch_configs, model_names, ranks))
+
+    port_name = MPI.Open_port()
+    MPI.Publish_name('my_port', port_name)
+
+    prompt = "European Union is a political and economic union of 27 countries. The European Union is headquartered in Brussels, Belgium. The first president of the European Union was Jean-Claude Juncker. The current president is Ursula von der Leyen. The European Union is a major economic and political entity."
+
+    with MPIPoolExecutor(max_workers=2, env={"TRTLLM_USE_MPI_KVCACHE":
+                                             "1"}) as executor:
+        futures = []
+        try:
+            for worker_arg in worker_args:
+                future = executor.submit(worker_entry_point, *worker_arg)
+                futures.append(future)
+        except Exception as e:
+            print(f"Error in worker {worker_arg}: {e}")
+            raise e
+
+        try:
+            print("Launched all the workers.")
+            intercomm = MPI.COMM_SELF.Accept(port_name)
+
+            for _ in range(2):
+                intercomm.recv(tag=MPI_READY)
+                print("Received ready signal.")
+            max_tokens = 25
+
+            requests = []
+            # Send 256 requests to make sure the context worker is saturated
+            for _ in range(256):
+                requests.append(
+                    (prompt, SamplingParams(max_tokens=1),
+                     DisaggregatedParams(request_type="context_only")))
+
+            intercomm.send(requests, dest=0, tag=MPI_REQUEST)
+
+            for _ in range(len(requests)):
+                output = intercomm.recv(source=0, tag=MPI_RESULT)
+                assert output[0].disaggregated_params is not None
+                assert output[
+                    0].disaggregated_params.request_type == "context_only"
+                assert len(output[0].token_ids) == 1
+
+                generation_request_disagg_params = output[
+                    0].disaggregated_params
+                generation_request_disagg_params.request_type = "generation_only"
+                requests = []
+                requests.append((prompt, SamplingParams(max_tokens=max_tokens),
+                                 generation_request_disagg_params))
+
+                intercomm.send(requests, dest=1, tag=MPI_REQUEST)
+                output = intercomm.recv(source=1, tag=MPI_RESULT)
+
+        finally:
+            # Send termination requests
+            intercomm.send(None, dest=0, tag=MPI_REQUEST)
+            intercomm.send(None, dest=1, tag=MPI_REQUEST)
+            print("Sent termination requests to the workers.")
+
+            # Wait for all futures to complete
+            for future in futures:
+                future.result()
+            print("All workers terminated.")
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -56,6 +56,7 @@ l0_h100:
   - disaggregated/test_disaggregated_single_gpu.py::test_disaggregated_simple_deepseek[True-False-DeepSeek-V3-Lite-fp8/fp8]
   - disaggregated/test_disaggregated_single_gpu.py::test_disaggregated_simple_deepseek[True-True-DeepSeek-V3-Lite-fp8/fp8]
   - disaggregated/test_disaggregated.py::test_disaggregated_load_balance[TinyLlama-1.1B-Chat-v1.0]
+  - disaggregated/test_disaggregated_single_gpu.py::test_disaggregated_llama_context_capacity[False-False-DeepSeek-V3-Lite-fp8/fp8]
 
 - condition:
     ranges:


### PR DESCRIPTION
Fix an issue when the context would hang if it was waiting for all the inflight context transmission to complete and generation worker was not pulling KV cache from the context worker.