### PR TITLE
CI: Waive for https://nvbugspro.nvidia.com/bug/5189673

### DIFF
--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -516,3 +516,4 @@ disaggregated/test_disaggregated.py::test_disaggregated_overlap[TinyLlama-1.1B-C
 examples/test_recurrentgemma.py::test_llm_recurrentgemma_1gpu[use_cpp_session-recurrentgemma-2b-use_paged_cache-disable_quant-float16-enable_attn_plugin-enable_gemm_plugin] SKIP (https://nvbugs/5174573)
 examples/test_mistral.py::test_llm_mistral_nemo_fp8_quantization_1gpu[Mistral-Nemo-12b-Base-summarization] SKIP (https://nvbugspro.nvidia.com/bug/5181262)
 examples/test_qwen.py::test_llm_qwen_moe_single_gpu_summary[qwen1.5_moe_a2.7b_chat-enable_paged_kv_cache-enable_remove_input_padding-enable_weight_only-enable_fmha] SKIP (https://nvbugs/5180961)
+unittest/_torch/multi_gpu_modeling/test_deepseek.py::test_deepseek[disable_overlap_scheduler-enable_cuda_graph-disable_dp-nextn0-ep1-pp4-tp1-fp8-trtllm-deepseekv3_lite] SKIP (https://nvbugspro.nvidia.com/bug/5189673)

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -516,4 +516,3 @@ disaggregated/test_disaggregated.py::test_disaggregated_overlap[TinyLlama-1.1B-C
 examples/test_recurrentgemma.py::test_llm_recurrentgemma_1gpu[use_cpp_session-recurrentgemma-2b-use_paged_cache-disable_quant-float16-enable_attn_plugin-enable_gemm_plugin] SKIP (https://nvbugs/5174573)
 examples/test_mistral.py::test_llm_mistral_nemo_fp8_quantization_1gpu[Mistral-Nemo-12b-Base-summarization] SKIP (https://nvbugspro.nvidia.com/bug/5181262)
 examples/test_qwen.py::test_llm_qwen_moe_single_gpu_summary[qwen1.5_moe_a2.7b_chat-enable_paged_kv_cache-enable_remove_input_padding-enable_weight_only-enable_fmha] SKIP (https://nvbugs/5180961)
-unittest/_torch/multi_gpu_modeling/test_deepseek.py::test_deepseek[disable_overlap_scheduler-enable_cuda_graph-disable_dp-nextn0-ep1-pp4-tp1-fp8-trtllm-deepseekv3_lite] SKIP (https://nvbugspro.nvidia.com/bug/5189673)

--- a/tests/unittest/_torch/multi_gpu_modeling/test_deepseek.py
+++ b/tests/unittest/_torch/multi_gpu_modeling/test_deepseek.py
@@ -56,6 +56,12 @@ def test_deepseek(model_name, backend, quant, tp_size, pp_size, ep_size,
     is_fp8 = quant == "fp8"
     is_fp4 = quant == "fp4"
 
+    if (not enable_overlap_scheduler and enable_cuda_graph and not enable_dp
+            and mtp_nextn == 0 and ep_size == 1 and pp_size == 4
+            and tp_size == 1 and is_fp8):
+
+        pytest.skip("https://nvbugspro.nvidia.com/bug/5189673")
+
     if ep_size > tp_size:
         pytest.skip(
             f"Expert parallel size {ep_size} must be less than or equal to tensor parallel size {tp_size}"


### PR DESCRIPTION
Waive unittest/_torch/multi_gpu_modeling/test_deepseek.py::test_deepseek[disable_overlap_scheduler-enable_cuda_graph-disable_dp-nextn0-ep1-pp4-tp1-fp8-trtllm-deepseekv3_lite]