### PR TITLE
refactor: Simplify disableLookahead and improve numDecodingEngineTokens handling

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/decoderBuffers.h
+++ b/cpp/include/tensorrt_llm/batch_manager/decoderBuffers.h
@@ -111,8 +111,8 @@ public:
     TensorPtr slotOutputIdsHost; // [beamWidth, maxSeqLen], outputIds of single batch slot
     TensorPtr cacheIndirectionInput;
     TensorPtr cacheIndirectionOutput;
-    TensorPtr sequenceLengths;     // [mMaxNumRequests]
-    TensorPtr sequenceLengthsHost; // [mMaxNumRequests], pinned host tensor
+    TensorPtr sequenceLengths;     // [mMaxNumRequests, beamWidth]
+    TensorPtr sequenceLengthsHost; // [mMaxNumRequests, beamWidth], pinned host tensor
     TensorPtr newOutputTokens;     // [maxTokensPerStep, mMaxNumRequests, beamWidth]
     TensorPtr newOutputTokensHost; // [maxTokensPerStep, mMaxNumRequests, beamWidth]
     TensorPtr cumLogProbs;         // [mMaxNumRequests, beamWidth]

--- a/cpp/include/tensorrt_llm/runtime/decoderState.h
+++ b/cpp/include/tensorrt_llm/runtime/decoderState.h
@@ -149,6 +149,20 @@ public:
 
     [[nodiscard]] SizeType32 getMaxDecodingEngineTokens() const;
 
+    //! @brief Get the number of tokens for all requests in the batch.
+    //! @returns The number of tokens for all requests in the batch.
+    [[nodiscard]] std::vector<SizeType32> const& getNumDecodingEngineTokens() const;
+
+    //! @brief Get the number of tokens for a specific request in the batch.
+    //! @param batchIdx The index of the request in the batch.
+    //! @returns The number of tokens for the specified request.
+    [[nodiscard]] SizeType32 getNumDecodingEngineTokens(SizeType32 batchIdx) const;
+
+    //! @brief Set the number of tokens for a specific request in the batch.
+    //! @param batchIdx The index of the request in the batch.
+    //! @param numTokens The number of tokens for the specified request.
+    void setNumDecodingEngineTokens(SizeType32 batchIdx, SizeType32 numTokens);
+
     [[nodiscard]] SpeculativeDecodingMode getSpeculativeDecodingMode() const;
 
     //! @brief Workspace for beam search in streaming mode.
@@ -185,6 +199,9 @@ private:
     // How many tokens predicted by the engine for one request.
     // It is maxDecodingTokens. >= 1 for speculative decoding and == 1 for non speculative decoding.
     SizeType32 mMaxDecodingEngineTokens{1};
+
+    //! @brief [batchSize], the num tokens of each request.
+    std::vector<SizeType32> mNumDecodingEngineTokens;
 
     SpeculativeDecodingMode mSpeculativeDecodingMode{SpeculativeDecodingMode::None()};
 };

--- a/cpp/include/tensorrt_llm/runtime/decoderState.h
+++ b/cpp/include/tensorrt_llm/runtime/decoderState.h
@@ -73,7 +73,7 @@ public:
     void setupEagle(EagleBuffers::Inputs eagleBuffers) const;
 
     //! @brief Disable lookahead decoding.
-    void disableLookahead(SizeType32 maxBatchSize, RequestVector const& genRequests);
+    void disableLookahead(RequestVector const& genRequests);
 
     //! @returns [batchSize], number of finished sequences per request, on gpu
     [[nodiscard]] TensorPtr getFinishedSum() const;

--- a/cpp/include/tensorrt_llm/runtime/decodingInput.h
+++ b/cpp/include/tensorrt_llm/runtime/decodingInput.h
@@ -66,11 +66,9 @@ public:
 
     std::vector<SizeType32> beamWidths; //!<  [batchSize], the beam widths of each request.
 
-    std::vector<SizeType32> numDecodingEngineTokens; //!<  [batchSize], the num tokens of each request.
+    SizeType32 maxStopWordsLen;         //!<  The maximum value in the `stopWordsLens` tensor.
 
-    SizeType32 maxStopWordsLen;                      //!<  The maximum value in the `stopWordsLens` tensor.
-
-    SizeType32 maxBadWordsLen;                       //!<  The maximum value in the `badWordsLens` tensor.
+    SizeType32 maxBadWordsLen;          //!<  The maximum value in the `badWordsLens` tensor.
 
     TensorConstPtr logits; //!<  [batchSize, beamWidth, vocabSizePadded], on gpu. Logits are are a probability
                            //!<  distribution over the vocabulary, the output of the model.

--- a/cpp/include/tensorrt_llm/runtime/gptDecoderBatched.h
+++ b/cpp/include/tensorrt_llm/runtime/gptDecoderBatched.h
@@ -64,7 +64,12 @@ public:
     [[nodiscard]] CudaEvent finalize(decoder::DecoderState const& decoderState, SizeType32 batchSlot,
         SamplingConfig const& samplingConfig, bool streaming) const override;
 
-    decoder::DecoderState& getDecoderState() const
+    decoder::DecoderState& getDecoderState()
+    {
+        return *mDecoderState;
+    }
+
+    decoder::DecoderState const& getDecoderState() const
     {
         return *mDecoderState;
     }

--- a/cpp/include/tensorrt_llm/runtime/gptDecoderBatched.h
+++ b/cpp/include/tensorrt_llm/runtime/gptDecoderBatched.h
@@ -54,8 +54,7 @@ public:
         SizeType32 maxTokensPerStep, nvinfer1::DataType dtype, ModelConfig const& modelConfig,
         WorldConfig const& worldConfig) override;
 
-    void disableLookahead(
-        SizeType32 maxBatchSize, RequestVector const& genRequests, TensorPtr const& batchSlots) override;
+    void disableLookahead(RequestVector const& genRequests, TensorPtr const& batchSlots) override;
 
     DecoderFinishedEventPtr forwardAsync(decoder_batch::Output& output, decoder_batch::Input const& input) override;
     void forward(decoder_batch::Output& output, decoder_batch::Input const& input) override;

--- a/cpp/include/tensorrt_llm/runtime/iGptDecoderBatched.h
+++ b/cpp/include/tensorrt_llm/runtime/iGptDecoderBatched.h
@@ -122,9 +122,7 @@ public:
         = 0;
 
     //! @brief Disable Lookahead decoding.
-    virtual void disableLookahead(
-        SizeType32 maxBatchSize, RequestVector const& genRequests, TensorPtr const& batchSlots)
-        = 0;
+    virtual void disableLookahead(RequestVector const& genRequests, TensorPtr const& batchSlots) = 0;
 
     //! @brief Run one step for all requests without blocking the host process and return the token for synchronization.
     virtual DecoderFinishedEventPtr forwardAsync(decoder_batch::Output& output, decoder_batch::Input const& input) = 0;

--- a/cpp/tensorrt_llm/batch_manager/createNewDecoderRequests.cpp
+++ b/cpp/tensorrt_llm/batch_manager/createNewDecoderRequests.cpp
@@ -59,7 +59,7 @@ void CreateNewDecoderRequests::newRequest(SizeType32 batchSlot, runtime::decoder
     auto const& decoderStream = decoder.getDecoderStream();
     BufferManager manager{decoderStream};
 
-    auto const& decoderState = decoder.getDecoderState();
+    auto& decoderState = decoder.getDecoderState();
 
     auto const& jointOutputIdsShape = decoderState.getJointDecodingOutput().ids->getShape();
     auto const batchSize = jointOutputIdsShape.d[0];
@@ -87,7 +87,7 @@ void CreateNewDecoderRequests::newRequest(SizeType32 batchSlot, runtime::decoder
     auto& dJointInput = decoderState.getJointDecodingInput();
 
     dJointInput.beamWidths.at(batchSlot) = beamWidth;
-    dJointInput.numDecodingEngineTokens.at(batchSlot) = numDecodingEngineTokens;
+    decoderState.setNumDecodingEngineTokens(batchSlot, numDecodingEngineTokens);
 
     TensorPtr endIdTensorPtr{ITensor::slice(constPointerCast(dJointInput.endIds), batchSlot, 1)};
     runtime::kernels::invokeFill(*endIdTensorPtr, endId, *decoderStream);

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -2484,8 +2484,8 @@ void TrtGptModelInflightBatching::changeSpecDecMode(ScheduledRequests const& sch
         mDecodingConfig.setDecodingMode(executor::DecodingMode::Auto());
         mBuffers.at(bufferId)->lookaheadBuffers->disableLookaheadDecoding();
         mDecoderBuffers->disableLookaheadDecoding(getMaxNumSequences());
-        mDecoder->disableLookahead(getMaxNumSequences(), scheduledRequests.generationRequests,
-            mDecoderInputBuffers.at(getFusedBufferId()).setupBatchSlots);
+        mDecoder->disableLookahead(
+            scheduledRequests.generationRequests, mDecoderInputBuffers.at(getFusedBufferId()).setupBatchSlots);
         for (auto const& llmReq : scheduledRequests.generationRequests)
         {
             if (llmReq->getNumDraftTokens() > 0)

--- a/cpp/tensorrt_llm/runtime/decoderState.cpp
+++ b/cpp/tensorrt_llm/runtime/decoderState.cpp
@@ -197,7 +197,7 @@ void DecoderState::setup(SizeType32 maxBatchSize, SizeType32 maxBeamWidth, SizeT
     dInput.badWordsLists.resize(mMaxBatchSize);
 
     auto const maxBatchSizeShape = ITensor::makeShape({mMaxBatchSize});
-    auto const maxBatchSizeXmaxBeamWidth = ITensor::makeShape({mMaxBatchSize, mMaxBeamWidth});
+    auto const maxBatchSizeXmaxBeamWidthShape = ITensor::makeShape({mMaxBatchSize, mMaxBeamWidth});
 
     const_cast<ITensor&>(*dInput.endIds).reshape(maxBatchSizeShape);
     const_cast<ITensor&>(*dInput.batchSlots).reshape(maxBatchSizeShape);
@@ -205,38 +205,37 @@ void DecoderState::setup(SizeType32 maxBatchSize, SizeType32 maxBeamWidth, SizeT
     sequenceLimitLength.reshape(maxBatchSizeShape);
     kernels::invokeFill(sequenceLimitLength, mMaxSequenceLength, stream);
     auto& inputLengths = const_cast<ITensor&>(*dInput.lengths);
-    inputLengths.reshape(maxBatchSizeXmaxBeamWidth);
+    inputLengths.reshape(maxBatchSizeXmaxBeamWidthShape);
     bufferManager.setZero(inputLengths);
 
     dInput.beamWidths.clear();
     dInput.beamWidths.resize(mMaxBatchSize, 0);
 
-    auto const jointOutputIdsShape = ITensor::makeShape({mActualBatchSize, mMaxBeamWidth, mMaxSequenceLength});
+    auto const maxTotalTokensShape = ITensor::makeShape({mMaxBatchSize, mMaxBeamWidth, mMaxSequenceLength});
 
     // setup output
     auto& dOutput = *mJointDecodingOutput;
-    dOutput.ids->reshape(jointOutputIdsShape);
+    dOutput.ids->reshape(maxTotalTokensShape);
 
-    auto const maxTokensPerStepXmaxBatchSizeXmaxBeamWidth
-        = ITensor::makeShape({mMaxDecodingEngineTokens, mMaxBatchSize, mMaxBeamWidth});
-    mFinishedSteps->reshape(maxTokensPerStepXmaxBatchSizeXmaxBeamWidth);
+    auto const maxNewTokensShape = ITensor::makeShape({mMaxDecodingEngineTokens, mMaxBatchSize, mMaxBeamWidth});
+    mFinishedSteps->reshape(maxNewTokensShape);
     bufferManager.setZero(*mFinishedSteps);
 
-    dOutput.finishReasons->reshape(maxBatchSizeXmaxBeamWidth);
+    dOutput.finishReasons->reshape(maxBatchSizeXmaxBeamWidthShape);
     bufferManager.setZero(*dOutput.finishReasons);
 
-    dOutput.parentIds->reshape(jointOutputIdsShape);
+    dOutput.parentIds->reshape(maxTotalTokensShape);
 
     dOutput.finishedSum->reshape(maxBatchSizeShape);
     bufferManager.setZero(*dOutput.finishedSum);
 
-    dOutput.newTokensSteps->reshape(maxTokensPerStepXmaxBatchSizeXmaxBeamWidth);
+    dOutput.newTokensSteps->reshape(maxNewTokensShape);
     bufferManager.setZero(*dOutput.newTokensSteps);
 
-    dOutput.cumLogProbs->reshape(maxBatchSizeXmaxBeamWidth);
+    dOutput.cumLogProbs->reshape(maxBatchSizeXmaxBeamWidthShape);
     bufferManager.setZero(*dOutput.cumLogProbs);
 
-    dOutput.logProbs->reshape(jointOutputIdsShape);
+    dOutput.logProbs->reshape(maxTotalTokensShape);
     bufferManager.setZero(*dOutput.logProbs);
 
     dOutput.logProbsTiled->reshape(ITensor::makeShape({mMaxSequenceLength, mMaxBatchSize, mMaxBeamWidth}));
@@ -247,7 +246,7 @@ void DecoderState::setup(SizeType32 maxBatchSize, SizeType32 maxBeamWidth, SizeT
         dOutput.beamHypotheses.reshape(mMaxBatchSize, mMaxBeamWidth, mMaxSequenceLength);
         mBeamSearchBuffers->reshape(mMaxBeamWidth, mMaxSequenceLength);
 
-        dOutput.gatheredIds->reshape(jointOutputIdsShape);
+        dOutput.gatheredIds->reshape(maxTotalTokensShape);
     }
     else
     {
@@ -283,11 +282,10 @@ void DecoderState::setupSpeculativeDecoding(SpeculativeDecodingMode const& specu
         "Max tokens per engine step must be equal to 1 when no speculative decoding is configured, "
         "or > 1 for any speculative decoding mode");
 
-    auto const maxTokensPerStepXmaxBatchSizeXmaxBeamWidth
-        = ITensor::makeShape({mMaxDecodingEngineTokens, mMaxBatchSize, mMaxBeamWidth});
-    mFinishedSteps->reshape(maxTokensPerStepXmaxBatchSizeXmaxBeamWidth);
+    auto const maxNewTokensShape = ITensor::makeShape({mMaxDecodingEngineTokens, mMaxBatchSize, mMaxBeamWidth});
+    mFinishedSteps->reshape(maxNewTokensShape);
     bufferManager.setZero(*mFinishedSteps);
-    dOutput.newTokensSteps->reshape(maxTokensPerStepXmaxBatchSizeXmaxBeamWidth);
+    dOutput.newTokensSteps->reshape(maxNewTokensShape);
     bufferManager.setZero(*dOutput.newTokensSteps);
 
     if (speculativeDecodingMode.predictsDraftTokens())
@@ -306,7 +304,6 @@ void DecoderState::setupSpeculativeDecoding(SpeculativeDecodingMode const& specu
     }
 
     auto const maxBatchSizeShape = ITensor::makeShape({mMaxBatchSize});
-    auto const maxBatchSizeXmaxTokensPerStep = ITensor::makeShape({mMaxBatchSize, mMaxDecodingEngineTokens});
 
     if (speculativeDecodingMode.isDraftTokensExternal())
     {
@@ -318,7 +315,8 @@ void DecoderState::setupSpeculativeDecoding(SpeculativeDecodingMode const& specu
         dInput.externalDraftTokensInputs->targetProbs->reshape(probsShape);
         dInput.externalDraftTokensInputs->draftLogits->reshape(
             ITensor::makeShape({mMaxBatchSize, mMaxDecodingEngineTokens, static_cast<SizeType32>(vocabSizePadded)}));
-        dInput.externalDraftTokensInputs->draftTokenIds->reshape(maxBatchSizeXmaxTokensPerStep);
+        dInput.externalDraftTokensInputs->draftTokenIds->reshape(
+            ITensor::makeShape({mMaxBatchSize, mMaxDecodingEngineTokens}));
         dInput.externalDraftTokensInputs->numDraftTokens->reshape(maxBatchSizeShape);
         dInput.externalDraftTokensInputs->numDraftTokensHost->reshape(maxBatchSizeShape);
         dInput.externalDraftTokensInputs->useDraftLogits->reshape(maxBatchSizeShape);
@@ -399,10 +397,9 @@ void DecoderState::disableLookahead(RequestVector const& genRequests)
     mMaxDecodingDecoderTokens = 1;
     mJointDecodingInput->lookaheadInputs.reset();
 
-    auto const maxTokensPerStepXmaxBatchSizeXmaxBeamWidth
-        = ITensor::makeShape({mMaxDecodingEngineTokens, mMaxBatchSize, mMaxBeamWidth});
-    mJointDecodingOutput->newTokensSteps->reshape(maxTokensPerStepXmaxBatchSizeXmaxBeamWidth);
-    mFinishedSteps->reshape(maxTokensPerStepXmaxBatchSizeXmaxBeamWidth);
+    auto const maxNewTokensShape = ITensor::makeShape({mMaxDecodingEngineTokens, mMaxBatchSize, mMaxBeamWidth});
+    mJointDecodingOutput->newTokensSteps->reshape(maxNewTokensShape);
+    mFinishedSteps->reshape(maxNewTokensShape);
 
     for (auto const& llmReq : genRequests)
     {

--- a/cpp/tensorrt_llm/runtime/gptDecoderBatched.cpp
+++ b/cpp/tensorrt_llm/runtime/gptDecoderBatched.cpp
@@ -183,8 +183,7 @@ void GptDecoderBatched::forwardDispatch(decoder_batch::Output& output, decoder_b
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
 
-    auto const maxDecodingEngineTokens
-        = maxOfActiveSlots(mDecoderState->getJointDecodingInput().numDecodingEngineTokens, input.active);
+    auto const maxDecodingEngineTokens = maxOfActiveSlots(mDecoderState->getNumDecodingEngineTokens(), input.active);
 
     for (SizeType32 si = 0; si < maxDecodingEngineTokens; si += mDecoderState->getMaxDecodingDecoderTokens())
     {
@@ -264,7 +263,7 @@ void GptDecoderBatched::prepareForward(
     std::vector<SharedConstPtr> logitsVec;
     for (SizeType32 bi = 0; bi < mDecoderState->getActualBatchSize(); ++bi)
     {
-        if (!input.active.at(bi) || step >= mDecoderState->getJointDecodingInput().numDecodingEngineTokens.at(bi))
+        if (!input.active.at(bi) || step >= mDecoderState->getNumDecodingEngineTokens(bi))
         {
             continue;
         }
@@ -280,8 +279,7 @@ void GptDecoderBatched::prepareForward(
     dInput.batchSize = localBatchDecoderIdx;
     dInput.logitsVec = logitsVec;
 
-    auto const maxDecodingEngineTokens
-        = maxOfActiveSlots(mDecoderState->getJointDecodingInput().numDecodingEngineTokens, input.active);
+    auto const maxDecodingEngineTokens = maxOfActiveSlots(mDecoderState->getNumDecodingEngineTokens(), input.active);
 
     TensorPtr finishedStepsInput = ITensor::slice(mDecoderState->getFinishedSteps(), step, 1);
     TensorPtr finishedStepsOutput

--- a/cpp/tensorrt_llm/runtime/gptDecoderBatched.cpp
+++ b/cpp/tensorrt_llm/runtime/gptDecoderBatched.cpp
@@ -53,12 +53,11 @@ GptDecoderBatched::GptDecoderBatched(GptDecoderBatched::CudaStreamPtr stream,
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
 }
 
-void GptDecoderBatched::disableLookahead(
-    SizeType32 maxBatchSize, RequestVector const& genRequests, TensorPtr const& batchSlots)
+void GptDecoderBatched::disableLookahead(RequestVector const& genRequests, TensorPtr const& batchSlots)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
 
-    mDecoderState->disableLookahead(maxBatchSize, genRequests);
+    mDecoderState->disableLookahead(genRequests);
 
     std::vector<SamplingConfig> samplingConfigs;
     samplingConfigs.reserve(genRequests.size());

--- a/cpp/tensorrt_llm/runtime/statefulGptDecoderBatched.cpp
+++ b/cpp/tensorrt_llm/runtime/statefulGptDecoderBatched.cpp
@@ -104,9 +104,10 @@ void StatefulGptDecoderBatched::newBatch(GenerationInput const& inputs, Generati
     // split batch into single requests
     auto const& inputLengths = inputs.lengths;
     mDecoder->getDecoderState().setActualBatchSize(inputLengths->getShape().d[0]);
-    mDecoder->getDecoderState().getJointDecodingInput().numDecodingEngineTokens.clear();
-    mDecoder->getDecoderState().getJointDecodingInput().numDecodingEngineTokens.resize(
-        mDecoder->getDecoderState().getActualBatchSize(), 1);
+    for (auto i = 0; i < mDecoder->getDecoderState().getActualBatchSize(); ++i)
+    {
+        mDecoder->getDecoderState().setNumDecodingEngineTokens(i, 1);
+    }
 
     auto const& jointOutputIdsShape = mDecoder->getDecoderState().getJointDecodingOutput().ids->getShape();
     auto const maxBatchSize = jointOutputIdsShape.d[0];


### PR DESCRIPTION
- Move `numDecodingEngineTokens` from `DecoderState->mJointDecodingInput` to `DecoderState` itself.
  - It's not needed in the inputs, but in the outer decoding loop.
- Simplify disableLookahead
  - Don't take the batch size as a parameter, but use the current `mMaxBatchSize` of the `DecoderState`.


