### PR TITLE
feat: Optionally split MoE inputs into chunks to reduce GPU memory usage

### DIFF
--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -23,6 +23,8 @@ class ModelConfig(Generic[TConfig]):
     quant_config_dict: Optional[Dict[str, QuantConfig]] = None
     skip_create_weights: bool = False
     is_generation: bool = True
+    max_num_tokens: int = 8192
+    moe_max_num_tokens: Optional[int] = None
 
     attn_backend: str = 'TRTLLM'
 

--- a/tensorrt_llm/_torch/pyexecutor/config.py
+++ b/tensorrt_llm/_torch/pyexecutor/config.py
@@ -46,6 +46,10 @@ class PyTorchConfig:
     # This is usually a net win for performance.
     cuda_graph_padding_enabled: bool = False
     enable_overlap_scheduler: bool = False
+    max_num_tokens: int = 8192
+    # If set, at most moe_max_num_tokens tokens will be sent to torch.ops.trtllm.fused_moe at the same time.
+    # If the number of tokens exceeds moe_max_num_tokens, the input tensors will be split into chunks and a for loop will be used.
+    moe_max_num_tokens: Optional[int] = None
 
     attn_backend: str = 'TRTLLM'
     # If true, will iterate over sampling_params of each request and use the

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -257,6 +257,8 @@ class PyTorchModelEngine(ModelEngine):
             mapping=self.mapping,
             attn_backend=attn_backend,
             load_format=pytorch_backend_config.load_format,
+            max_num_tokens=max_num_tokens,
+            moe_max_num_tokens=pytorch_backend_config.moe_max_num_tokens,
         )
         if self.pytorch_backend_config.enable_layerwise_nvtx_marker:
             layerwise_nvtx_marker = LayerwiseNvtxMarker()
@@ -732,11 +734,13 @@ class PyTorchModelEngine(ModelEngine):
         torch.cuda.empty_cache()
 
     def _load_model(self, checkpoint_dir: str, load_format: LoadFormat,
-                    **kwargs):
+                    max_num_tokens: int, moe_max_num_tokens: int, **kwargs):
         config = ModelConfig.from_pretrained(checkpoint_dir,
                                              trust_remote_code=True,
                                              **kwargs)
         config.spec_config = self.spec_config
+        config.max_num_tokens = max_num_tokens
+        config.moe_max_num_tokens = moe_max_num_tokens
 
         validate_and_set_kv_cache_quant(
             config, self.pytorch_backend_config.kv_cache_dtype)

--- a/tensorrt_llm/_torch/utils.py
+++ b/tensorrt_llm/_torch/utils.py
@@ -1,5 +1,6 @@
 import os
 from dataclasses import dataclass
+from enum import Enum
 from typing import List
 
 import torch
@@ -9,6 +10,17 @@ from tensorrt_llm._utils import TensorWrapper, convert_to_torch_tensor
 from .pipeline_interface import PipelineInterface
 
 is_torch_compiling_flag = False
+
+aux_stream_name_list = ['Attention', 'MoeShared', 'MoeChunkingOverlap']
+AuxStreamType = Enum(
+    'AuxStreamType',
+    aux_stream_name_list,
+)
+EventType = Enum(
+    'EventType',
+    ['Main', *aux_stream_name_list],
+    start=0,
+)
 
 
 def set_torch_compiling(enable: bool):


### PR DESCRIPTION
If `max_num_tokens` is large and attention DP is enabled on a relatively large number of GPUs, the MoE workspace size will be very large and thus OOM occurs.

This MR allows to optionally split MoE inputs into chunks to reduce GPU memory usage. To enable this feature, `moe_max_num_tokens` needs to be set in `pytorch_backend_config`. By doing this, at most `moe_max_num_tokens` tokens will be sent to `torch.ops.trtllm.fused_moe` at the same time. If the number of tokens exceeds `moe_max_num_tokens`, the input tensors will be split into chunks and a for loop will be used.

To achieve better performance, an extra CUDA stream is used to allow the overlapping of computation and communication between adjacent chunks.