### PR TITLE
fix: Early exit cmake if find_library() does not find any lib

### DIFF
--- a/cpp/cmake/modules/find_library_create_target.cmake
+++ b/cpp/cmake/modules/find_library_create_target.cmake
@@ -30,6 +30,9 @@ macro(find_library_create_target target_name lib libtype hints)
   find_library(${lib}_LIB_PATH ${lib} HINTS ${hints} NO_DEFAULT_PATH)
   find_library(${lib}_LIB_PATH ${lib})
   message(STATUS "Library that was found ${${lib}_LIB_PATH}")
+  if(${${lib}_LIB_PATH} STREQUAL "${lib}_LIB_PATH-NOTFOUND")
+    message(FATAL_ERROR "${lib} not found. (hints: ${hints})")
+  endif()
   add_library(${target_name} ${libtype} IMPORTED)
   set_target_properties(
     ${target_name} PROPERTIES IMPORTED_LOCATION ${${lib}_LIB_PATH}


### PR DESCRIPTION
Early exit if find_library() does not find any lib. 
As today, the find_library_create_target() cmake macro blindly continues even if the lib is not found,
adding LIB_PATH-NOTFOUND to the target and making the build failing anyway later with non obvious reasons.
This change just early exits if the lib is simply not found with a proper error message.
Fix github issue #3109