### PR TITLE
fix: Reverse CUDA graph size order

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -322,6 +322,10 @@ class PyTorchModelEngine(ModelEngine):
         ]
         self._max_cuda_graph_batch_size = self._cuda_graph_batch_sizes[-1]
 
+        # Reverse the order of the cuda graph batch sizes to make smaller batch sizes could use larger batch size info
+        self._cuda_graph_batch_sizes = sorted(self._cuda_graph_batch_sizes,
+                                              reverse=True)
+
         self.previous_batch_indices_cuda = torch.empty((self.max_num_tokens, ),
                                                        dtype=torch.int,
                                                        device='cuda')

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -322,7 +322,7 @@ class PyTorchModelEngine(ModelEngine):
         ]
         self._max_cuda_graph_batch_size = self._cuda_graph_batch_sizes[-1]
 
-        # Reverse the order of the cuda graph batch sizes to make smaller batch sizes could use larger batch size info
+        # Reverse the order of the cuda graph batch sizes to make smaller batch sizes could reuse larger batch size memory
         self._cuda_graph_batch_sizes = sorted(self._cuda_graph_batch_sizes,
                                               reverse=True)
 

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -322,7 +322,7 @@ class PyTorchModelEngine(ModelEngine):
         ]
         self._max_cuda_graph_batch_size = self._cuda_graph_batch_sizes[-1]
 
-        # Reverse the order of the cuda graph batch sizes to make smaller batch sizes could reuse larger batch size memory
+        # Reverse the order of the cuda graph batch sizes to make smaller batch size graph could reuse larger batch size graph memory
         self._cuda_graph_batch_sizes = sorted(self._cuda_graph_batch_sizes,
                                               reverse=True)
 

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -322,10 +322,6 @@ class PyTorchModelEngine(ModelEngine):
         ]
         self._max_cuda_graph_batch_size = self._cuda_graph_batch_sizes[-1]
 
-        # Reverse the order of the cuda graph batch sizes to make smaller batch size graph could reuse larger batch size graph memory
-        self._cuda_graph_batch_sizes = sorted(self._cuda_graph_batch_sizes,
-                                              reverse=True)
-
         self.previous_batch_indices_cuda = torch.empty((self.max_num_tokens, ),
                                                        dtype=torch.int,
                                                        device='cuda')
@@ -539,7 +535,10 @@ class PyTorchModelEngine(ModelEngine):
         logger.info(
             f"Creating CUDA graph instances for {len(self._cuda_graph_batch_sizes)} batch sizes."
         )
-        for bs in self._cuda_graph_batch_sizes:
+        # Reverse the order of the cuda graph batch sizes to make smaller batch size graph could reuse larger batch size graph memory
+        cuda_graph_batch_sizes = sorted(self._cuda_graph_batch_sizes,
+                                        reverse=True)
+        for bs in cuda_graph_batch_sizes:
             if bs > self.batch_size:
                 # skip batch size larger than self.batch_size
                 continue


### PR DESCRIPTION
During experiment, during cuda graph capture, the graph size oscillates frequently, making total size of graph larger than expected. 
Reverse the order of graph batch size when capturing and this will make the smaller batch size graph reuse memory used in larger batch size.