### PR TITLE
feat: FP8 Rowwise quantization support for Cohere models

### DIFF
--- a/cpp/tensorrt_llm/kernels/layernormKernels.cu
+++ b/cpp/tensorrt_llm/kernels/layernormKernels.cu
@@ -15,6 +15,7 @@
  */
 
 #include "tensorrt_llm/common/cudaTypeUtils.cuh"
+#include "tensorrt_llm/common/quantTypeUtils.cuh"
 #include "tensorrt_llm/common/reduceKernelUtils.cuh"
 #include "tensorrt_llm/kernels/layernormKernels.h"
 
@@ -57,15 +58,27 @@ __inline__ __device__ Tf compute_layernorm(Tf val, float s_mean, float s_varianc
  *           amax per row. A final pass scales to int8 accordingly, and writes output to
  *           normed_output_quant.
  */
-template <typename T, bool USE_DIFF_OF_SQUARES = false>
+template <typename T, typename QuantT, bool USE_SHMEM, bool USE_DIFF_OF_SQUARES = false>
 __global__ void generalLayerNorm(T const* input, T const* gamma, T const* beta, T* normed_output, float const eps,
-    int tokens, int hidden_dim, float const* scale_orig_quant_per_tensor, float* scale_orig_quant_per_token,
-    int8_t* normed_output_quant, bool use_shmem)
+    int tokens, int hidden_dim, float const* clampPtr, float const* scale_orig_quant_per_tensor,
+    float* scale_orig_quant_per_token, float* sum_per_token, QuantT* normed_output_quant, bool hasFp8MinScaling)
 {
     constexpr auto num_elems_T = num_elems<T>::value;
-    using int8_packed_t = typename packed_as<int8_t, num_elems_T>::type;
+    // using int8_packed_t = typename packed_as<int8_t, num_elems_T>::type;
+    // using fp8_packed_t = typename packed_as<__nv_fp8_e4m3, num_elems_T>::type;
+    using QuantT_packed_t = typename packed_as<QuantT, num_elems_T>::type;
     using float_packed_t = typename packed_as<float, num_elems_T>::type;
     using T_scalar = typename packed_as<T, 1>::type;
+
+    // The clamping minimum / maximum values.
+    T const clampMin = cuda_cast<T>(clampPtr ? clampPtr[0] : -FLT_MAX);
+    T const clampMax = cuda_cast<T>(clampPtr ? clampPtr[1] : FLT_MAX);
+
+    // The quantized data type's maximum value (upper-bound).
+    static constexpr float MAX_QUANT_VAL = QuantTypeStaticVals<QuantT>::MAX_VAL;
+    // The minimum scaling factor (lower-bound).
+    static constexpr float MIN_SCALING_FACTOR = QuantTypeStaticVals<QuantT>::MIN_SCALING_FACTOR;
+    static constexpr float MIN_SCALING_FACTOR_RCP = QuantTypeStaticVals<QuantT>::MIN_SCALING_FACTOR_RCP;
 
     extern __shared__ __align__(sizeof(float)) char _shmem[];
     T* shmem = reinterpret_cast<T*>(_shmem);
@@ -84,7 +97,7 @@ __global__ void generalLayerNorm(T const* input, T const* gamma, T const* beta, 
     for (int i = tidx; i < n_elems; i += blockDim.x)
     {
         const T val = input[bidx * n_elems + i];
-        if (use_shmem)
+        if (USE_SHMEM)
         {
             shmem[i] = val;
         }
@@ -125,7 +138,7 @@ __global__ void generalLayerNorm(T const* input, T const* gamma, T const* beta, 
     {
         for (int i = tidx; i < n_elems; i += blockDim.x)
         {
-            const T val = use_shmem ? shmem[i] : input[bidx * n_elems + i];
+            const T val = USE_SHMEM ? shmem[i] : input[bidx * n_elems + i];
             float_packed_t diff = cuda_cast<float_packed_t>(val) - s_mean;
             local_var_sum += cuda_sum<float>(diff * diff);
         }
@@ -140,97 +153,135 @@ __global__ void generalLayerNorm(T const* input, T const* gamma, T const* beta, 
 
     bool const with_per_token_scaling = scale_orig_quant_per_token != nullptr;
     bool const with_per_tensor_scaling = scale_orig_quant_per_tensor != nullptr;
+    bool const with_per_token_sum = sum_per_token != nullptr;
+
     const float_packed_t scale_orig_quant
         = cuda_cast<float_packed_t>(with_per_tensor_scaling ? *scale_orig_quant_per_tensor : 0.0f);
     T_scalar amax = 1e-6f;
+    local_sum = 0.f;
 
     for (int i = tidx; i < n_elems; i += blockDim.x)
     {
         int const index = bidx * n_elems + i;
-        const float_packed_t val_f = cuda_cast<float_packed_t>(use_shmem ? shmem[i] : input[index]);
-        const T val = cuda_cast<T>(compute_layernorm(val_f, s_mean, s_variance, gamma, beta, i));
+        const float_packed_t val_f = cuda_cast<float_packed_t>(USE_SHMEM ? shmem[i] : input[index]);
+        T val = cuda_cast<T>(compute_layernorm(val_f, s_mean, s_variance, gamma, beta, i));
 
         if (with_per_token_scaling)
         {
+            val = cuda_clamp(val, clampMin, clampMax);
             amax = cuda_max(cuda_max<T_scalar, T>(cuda_abs(val)), amax);
-            if (use_shmem)
+            if (USE_SHMEM)
             {
                 shmem[i] = val;
             }
         }
         else if (with_per_tensor_scaling)
         {
-            reinterpret_cast<int8_packed_t*>(normed_output_quant)[index]
-                = cuda_cast<int8_packed_t>(cuda_cast<float_packed_t>(val) * scale_orig_quant);
+            val = cuda_clamp(val, clampMin, clampMax);
+            reinterpret_cast<QuantT_packed_t*>(normed_output_quant)[index]
+                = cuda_cast<QuantT_packed_t>(cuda_cast<float_packed_t>(val) * scale_orig_quant);
         }
         else
         {
             normed_output[index] = val;
+        }
+
+        if (with_per_token_sum)
+        {
+            local_sum += cuda_sum<float>(cuda_cast<float_packed_t>(val));
         }
     }
 
     if (with_per_token_scaling)
     {
         float abs_max_f = blockAllReduceMax(cuda_cast<float>(amax));
-        float const dynamic_per_token_scale = 127.f / abs_max_f;
+        float const dynamic_per_token_scale
+            = hasFp8MinScaling ? fminf(MAX_QUANT_VAL / abs_max_f, MIN_SCALING_FACTOR_RCP) : (MAX_QUANT_VAL / abs_max_f);
         for (int i = tidx; i < n_elems; i += blockDim.x)
         {
             int const index = bidx * n_elems + i;
-            float_packed_t val_f = cuda_cast<float_packed_t>(use_shmem ? shmem[i] : input[index]);
-            if (!use_shmem)
+            float_packed_t val_f = cuda_cast<float_packed_t>(USE_SHMEM ? shmem[i] : input[index]);
+            if (!USE_SHMEM)
             {
                 val_f = compute_layernorm(val_f, s_mean, s_variance, gamma, beta, i);
             }
 
-            reinterpret_cast<int8_packed_t*>(normed_output_quant)[index]
-                = cuda_cast<int8_packed_t>(val_f * cuda_cast<float_packed_t>(dynamic_per_token_scale));
+            reinterpret_cast<QuantT_packed_t*>(normed_output_quant)[index]
+                = cuda_cast<QuantT_packed_t>(val_f * cuda_cast<float_packed_t>(dynamic_per_token_scale));
         }
         if (tidx == 0)
         {
-            scale_orig_quant_per_token[bidx] = abs_max_f / 127.f;
+            scale_orig_quant_per_token[bidx] = hasFp8MinScaling
+                ? cuda_max(abs_max_f / MAX_QUANT_VAL, MIN_SCALING_FACTOR)
+                : abs_max_f / MAX_QUANT_VAL;
+        }
+    }
+
+    if (with_per_token_sum)
+    {
+        float packed_sum[1] = {local_sum};
+        blockReduceSumV2<float, 1>(packed_sum);
+        if (tidx == 0)
+        {
+            sum_per_token[bidx] = packed_sum[0];
         }
     }
 }
 
-template <bool USE_DIFF_OF_SQUARES, typename T>
+template <bool USE_DIFF_OF_SQUARES, typename T, typename QuantT>
 void dispatch_layernorm_type_square_method(T const* input, T const* gamma, T const* beta, T* normed_output,
-    float const eps, int tokens, int hidden_dim, float const* scale_orig_quant_per_tensor,
-    float* scale_orig_quant_per_token, int8_t* normed_output_quant, const dim3 grid, const dim3 block,
-    const size_t shmem_size, cudaStream_t stream)
+    float const eps, int tokens, int hidden_dim, float const* clampPtr, float const* scale_orig_quant_per_tensor,
+    float* scale_orig_quant_per_token, float* sum_per_token, QuantT* normed_output_quant, bool const hasFp8MinScaling,
+    dim3 const grid, dim3 const block, size_t const shmem_size, cudaStream_t stream)
 {
+    // Do we use shared memory to cache intermediate results.
+    bool use_shmem = true;
     if (shmem_size >= (48 << 10))
     {
         cudaError_t ret = cudaFuncSetAttribute(
-            generalLayerNorm<T, USE_DIFF_OF_SQUARES>, cudaFuncAttributeMaxDynamicSharedMemorySize, shmem_size);
+            generalLayerNorm<T, QuantT, true, USE_DIFF_OF_SQUARES>, cudaFuncAttributeMaxDynamicSharedMemorySize, shmem_size);
+        // Use shared memory when the capactity is enough.
+        use_shmem = (ret == cudaSuccess);
     }
-    generalLayerNorm<T, USE_DIFF_OF_SQUARES><<<grid, block, shmem_size, stream>>>(input, gamma, beta, normed_output,
-        eps, tokens, hidden_dim, scale_orig_quant_per_tensor, scale_orig_quant_per_token, normed_output_quant, true);
-}
 
-template <typename T>
-void dispatch_layernorm_type(T const* input, T const* gamma, T const* beta, T* normed_output, float const eps,
-    int tokens, int hidden_dim, float const* scale_orig_quant_per_tensor, float* scale_orig_quant_per_token,
-    int8_t* normed_output_quant, const dim3 grid, const dim3 block, const size_t shmem_size, cudaStream_t stream,
-    bool use_diff_of_squares)
-{
-    if (use_diff_of_squares)
+    if (use_shmem)
     {
-        dispatch_layernorm_type_square_method<true>(input, gamma, beta, normed_output, eps, tokens, hidden_dim,
-            scale_orig_quant_per_tensor, scale_orig_quant_per_token, normed_output_quant, grid, block, shmem_size,
-            stream);
+        generalLayerNorm<T, QuantT, true, USE_DIFF_OF_SQUARES><<<grid, block, shmem_size, stream>>>(input, gamma, beta,
+            normed_output, eps, tokens, hidden_dim, clampPtr, scale_orig_quant_per_tensor, scale_orig_quant_per_token,
+            sum_per_token, normed_output_quant, hasFp8MinScaling);
     }
     else
     {
-        dispatch_layernorm_type_square_method<false>(input, gamma, beta, normed_output, eps, tokens, hidden_dim,
-            scale_orig_quant_per_tensor, scale_orig_quant_per_token, normed_output_quant, grid, block, shmem_size,
-            stream);
+        generalLayerNorm<T, QuantT, false, USE_DIFF_OF_SQUARES><<<grid, block, shmem_size, stream>>>(input, gamma, beta,
+            normed_output, eps, tokens, hidden_dim, clampPtr, scale_orig_quant_per_tensor, scale_orig_quant_per_token,
+            sum_per_token, normed_output_quant, hasFp8MinScaling);
     }
 }
 
-template <typename T>
+template <typename T, typename QuantT>
+void dispatch_layernorm_type(T const* input, T const* gamma, T const* beta, T* normed_output, float const eps, int tokens,
+    int hidden_dim, float const* clampPtr, float const* scale_orig_quant_per_tensor, float* scale_orig_quant_per_token,
+    float* sum_per_token, QuantT* normed_output_quant, bool const hasFp8MinScaling, const dim3 grid, const dim3 block,
+    const size_t shmem_size, cudaStream_t stream, bool use_diff_of_squares)
+{
+    if (use_diff_of_squares)
+    {
+        dispatch_layernorm_type_square_method<true>(input, gamma, beta, normed_output, eps, tokens, hidden_dim, clampPtr,
+            scale_orig_quant_per_tensor, scale_orig_quant_per_token, sum_per_token, normed_output_quant, hasFp8MinScaling,
+            grid, block, shmem_size, stream);
+    }
+    else
+    {
+        dispatch_layernorm_type_square_method<false>(input, gamma, beta, normed_output, eps, tokens, hidden_dim, clampPtr,
+            scale_orig_quant_per_tensor, scale_orig_quant_per_token, sum_per_token, normed_output_quant, hasFp8MinScaling,
+            grid, block, shmem_size, stream);
+    }
+}
+
+template <typename T, typename QuantT>
 void invokeGeneralLayerNorm(T* out, T const* input, T const* gamma, T const* beta, float const eps, int const tokens,
-    int const hidden_dim, cudaStream_t stream, bool use_diff_of_squares, float const* scale, float* dynamic_scale,
-    int8_t* normed_output_quant)
+    int const hidden_dim, QuantMode quantMode, cudaStream_t stream, bool use_diff_of_squares, float const* clampPtr,
+    float const* scale, float* dynamic_scale, float* sum_per_token, QuantT* normed_output_quant)
 {
     dim3 grid(tokens);
     dim3 block(min(hidden_dim, 1024));
@@ -246,30 +297,41 @@ void invokeGeneralLayerNorm(T* out, T const* input, T const* gamma, T const* bet
 #endif
         );
 
+    // Enable min_scaling_factor if it is fp8 rowwise per-token quantization.
+    bool hasFp8MinScaling = quantMode.hasFp8RowWise();
+
     if (use_vec_type)
     {
         using Tp = typename packed_as<T, vec_size>::type;
         dispatch_layernorm_type(reinterpret_cast<Tp const*>(input), reinterpret_cast<Tp const*>(gamma),
-            reinterpret_cast<Tp const*>(beta), reinterpret_cast<Tp*>(out), eps, tokens, hidden_dim, scale,
-            dynamic_scale, normed_output_quant, grid, block, shmem_size, stream, use_diff_of_squares);
+            reinterpret_cast<Tp const*>(beta), reinterpret_cast<Tp*>(out), eps, tokens, hidden_dim, clampPtr, scale,
+            dynamic_scale, sum_per_token, normed_output_quant, hasFp8MinScaling, grid, block, shmem_size, stream, use_diff_of_squares);
     }
     else
     {
-        dispatch_layernorm_type(input, gamma, beta, out, eps, tokens, hidden_dim, scale, dynamic_scale,
-            normed_output_quant, grid, block, shmem_size, stream, use_diff_of_squares);
+        dispatch_layernorm_type(input, gamma, beta, out, eps, tokens, hidden_dim, clampPtr, scale, dynamic_scale,
+            sum_per_token, normed_output_quant, hasFp8MinScaling, grid, block, shmem_size, stream, use_diff_of_squares);
     }
 }
 
-#define INSTANTIATE_GENERAL_LAYERNORM(T)                                                                               \
+#define INSTANTIATE_GENERAL_LAYERNORM(T, QuantT)                                                                       \
     template void invokeGeneralLayerNorm(T* out, const T* input, const T* gamma, const T* beta, const float eps,       \
-        const int tokens, const int hidden_dim, cudaStream_t stream, bool use_diff_of_squares, const float* scale,     \
-        float* dynamic_scale, int8_t* normed_output_quant);
+        const int tokens, const int hidden_dim, QuantMode quantMode, cudaStream_t stream, bool use_diff_of_squares,    \
+        float const* clampPtr, const float* scale, float* dynamic_scale, float* sum_per_token, QuantT* normed_output_quant);
 
-INSTANTIATE_GENERAL_LAYERNORM(float);
-INSTANTIATE_GENERAL_LAYERNORM(half);
+INSTANTIATE_GENERAL_LAYERNORM(float, int8_t);
+INSTANTIATE_GENERAL_LAYERNORM(half, int8_t);
 
 #ifdef ENABLE_BF16
-INSTANTIATE_GENERAL_LAYERNORM(__nv_bfloat16);
+INSTANTIATE_GENERAL_LAYERNORM(__nv_bfloat16, int8_t);
+#endif
+
+#ifdef ENABLE_FP8
+INSTANTIATE_GENERAL_LAYERNORM(float, __nv_fp8_e4m3);
+INSTANTIATE_GENERAL_LAYERNORM(half, __nv_fp8_e4m3);
+#ifdef ENABLE_BF16
+INSTANTIATE_GENERAL_LAYERNORM(__nv_bfloat16, __nv_fp8_e4m3);
+#endif
 #endif
 
 } // namespace kernels

--- a/cpp/tensorrt_llm/kernels/layernormKernels.h
+++ b/cpp/tensorrt_llm/kernels/layernormKernels.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "tensorrt_llm/common/cudaUtils.h"
+#include "tensorrt_llm/common/quantization.h"
 #include <assert.h>
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
@@ -26,10 +27,11 @@ namespace tensorrt_llm
 namespace kernels
 {
 
-template <typename T>
+template <typename T, typename QuantT>
 void invokeGeneralLayerNorm(T* out, T const* input, T const* gamma, T const* beta, float const eps, int const tokens,
-    int const hidden_dim, cudaStream_t stream = 0, bool use_diff_of_squares = true, float const* scale = nullptr,
-    float* dynamic_scale = nullptr, int8_t* out_quant = nullptr);
+    int const hidden_dim, tensorrt_llm::common::QuantMode quantMode, cudaStream_t stream = 0, bool use_diff_of_squares = true,
+    float const* clampPtr = nullptr, float const* scale = nullptr, float* dynamic_scale = nullptr,
+    float* sum_per_token = nullptr, QuantT* out_quant = nullptr);
 
 } // namespace kernels
 } // namespace tensorrt_llm

--- a/cpp/tensorrt_llm/plugins/layernormQuantizationPlugin/layernormQuantizationPlugin.cpp
+++ b/cpp/tensorrt_llm/plugins/layernormQuantizationPlugin/layernormQuantizationPlugin.cpp
@@ -30,12 +30,21 @@ PluginFieldCollection LayernormQuantizationPluginCreator::mFC{};
 std::vector<nvinfer1::PluginField> LayernormQuantizationPluginCreator::mPluginAttributes;
 
 LayernormQuantizationPlugin::LayernormQuantizationPlugin(
-    float eps, bool useDiffOfSquares, bool dynamicActivationScaling, nvinfer1::DataType type)
+    float eps, bool useDiffOfSquares, bool dynamicActivationScaling, bool sumPerToken, bool clampValEnabled,
+    tensorrt_llm::common::QuantMode quantMode, nvinfer1::DataType type, nvinfer1::DataType outputType)
     : mEps(eps)
     , mUseDiffOfSquares(useDiffOfSquares)
     , mDynActScaling(dynamicActivationScaling)
     , mType(type)
+    , mOutputType{outputType}
+    , mClampValEnabled{clampValEnabled}
+    , mQuantMode{quantMode}
+    , mSumPerToken(sumPerToken)
 {
+    TLLM_CHECK_WITH_INFO(mOutputType == nvinfer1::DataType::kINT8 || mOutputType == nvinfer1::DataType::kFP8,
+        "Only int8 or fp8 output type is allowed.");
+    // Check if the quant mode is valid.
+    TLLM_CHECK_WITH_INFO(mQuantMode.hasPerTokenScaling(), "The quant mode is not valid.");
 }
 
 // Parameterized constructor
@@ -45,7 +54,11 @@ LayernormQuantizationPlugin::LayernormQuantizationPlugin(void const* data, size_
     read(d, mEps);
     read(d, mUseDiffOfSquares);
     read(d, mDynActScaling);
+    read(d, mSumPerToken);
+    read(d, mClampValEnabled);
+    read(d, mQuantMode);
     read(d, mType);
+    read(d, mOutputType);
     TLLM_CHECK_WITH_INFO(d == a + length,
         "Expected length (%d) != real length (%d). This is often "
         "caused by using different TensorRT-LLM version to build "
@@ -56,7 +69,8 @@ LayernormQuantizationPlugin::LayernormQuantizationPlugin(void const* data, size_
 // IPluginV2DynamicExt Methods
 nvinfer1::IPluginV2DynamicExt* LayernormQuantizationPlugin::clone() const noexcept
 {
-    auto* plugin = new LayernormQuantizationPlugin(mEps, mUseDiffOfSquares, mDynActScaling, mType);
+    auto* plugin = new LayernormQuantizationPlugin(
+        mEps, mUseDiffOfSquares, mDynActScaling, mSumPerToken, mClampValEnabled, mQuantMode, mType, mOutputType);
     plugin->setPluginNamespace(mNamespace.c_str());
     return plugin;
 }
@@ -70,10 +84,22 @@ nvinfer1::DimsExprs LayernormQuantizationPlugin::getOutputDimensions(
         return inputs[outputIndex];
     }
 
-    // Dynamic scaling output if enabled
+    // Dynamic scaling or per-token sum if enabled.
     try
     {
-        TLLM_CHECK(outputIndex == 1);
+        if (outputIndex == 1)
+        {
+            TLLM_CHECK(mDynActScaling);
+        }
+        else if (outputIndex == 2)
+        {
+            TLLM_CHECK(mSumPerToken);
+        }
+        else
+        {
+            TLLM_CHECK(false);
+        }
+
         DimsExprs ret;
         ret.nbDims = inputs[0].nbDims;
         for (int di = 0; di < ret.nbDims - 1; ++di)
@@ -93,26 +119,47 @@ nvinfer1::DimsExprs LayernormQuantizationPlugin::getOutputDimensions(
 bool LayernormQuantizationPlugin::supportsFormatCombination(
     int pos, nvinfer1::PluginTensorDesc const* inOut, int nbInputs, int nbOutputs) noexcept
 {
-    int const totalPoses = 6 + static_cast<int>(mDynActScaling);
+    int const totalPoses
+        = 6 + static_cast<int>(mClampValEnabled) + static_cast<int>(mDynActScaling) + static_cast<int>(mSumPerToken);
     TLLM_CHECK(0 <= pos && pos < totalPoses);
-    TLLM_CHECK(nbInputs == 4);
+    TLLM_CHECK(nbInputs == 4 + static_cast<int>(mClampValEnabled));
     if (pos < nbInputs)
     {
-        switch (pos)
+        if (pos < 3)
         {
-        case 0:
-        case 1:
-        case 2: return (inOut[pos].type == mType) && (inOut[pos].format == TensorFormat::kLINEAR);
-        case 3: return (inOut[pos].type == nvinfer1::DataType::kFLOAT) && (inOut[pos].format == TensorFormat::kLINEAR);
+            // activation, weight, bias
+            return (inOut[pos].type == mType) && (inOut[pos].format == TensorFormat::kLINEAR);
+        }
+        else if (pos == 3)
+        {
+            // scale
+            return (inOut[pos].type == nvinfer1::DataType::kFLOAT) && (inOut[pos].format == TensorFormat::kLINEAR);
+        }
+        else if (pos == 4 && mClampValEnabled)
+        {
+            // clamp_max_v
+            return inOut[pos].type == nvinfer1::DataType::kFLOAT && inOut[pos].format == TensorFormat::kLINEAR;
         }
     }
-    if (pos == 4)
+    else if (pos == 4 + int(mClampValEnabled))
     {
         // Quantized output
-        return (inOut[pos].type == nvinfer1::DataType::kINT8) && (inOut[pos].format == TensorFormat::kLINEAR);
+        return (inOut[pos].type == mOutputType) && (inOut[pos].format == TensorFormat::kLINEAR);
     }
-    // Dynamic scaling if enabled
-    return (inOut[pos].type == nvinfer1::DataType::kFLOAT) && (inOut[pos].format == TensorFormat::kLINEAR);
+    else if (pos == 5 + int(mClampValEnabled))
+    {
+        // Dynamic scaling if enabled
+        return (inOut[pos].type == nvinfer1::DataType::kFLOAT) && (inOut[pos].format == TensorFormat::kLINEAR);
+    }
+    else if (pos == 6 + int(mClampValEnabled))
+    {
+        // Per-token activation sum if enabled
+        return (inOut[pos].type == nvinfer1::DataType::kFLOAT) && (inOut[pos].format == TensorFormat::kLINEAR);
+    }
+
+    // Never should be here
+    TLLM_CHECK_WITH_INFO(false, "The input/output is not supported.");
+    return false;
 }
 
 void LayernormQuantizationPlugin::configurePlugin(nvinfer1::DynamicPluginTensorDesc const* in, int nbInputs,
@@ -126,6 +173,25 @@ size_t LayernormQuantizationPlugin::getWorkspaceSize(nvinfer1::PluginTensorDesc 
     return 0;
 }
 
+template <typename T, typename QuantT>
+void LayernormQuantizationPlugin::dispatchDataType(void* out, void const* input, void const* gamma, void const* beta, float const eps,
+    int const tokens, int const hidden_dim, cudaStream_t stream, bool use_diff_of_squares, void const* clampValPtr,
+    void const* scale, void* dynamic_scale, void* sum_per_token, void* normed_output_quant) noexcept
+{
+    // inputs
+    //     activation     [dim0(*), dim1]
+    //     clamp_value    [2], contains min val, and max val (optional)
+    // outputs
+    //     quant          [dim0(*), dim1]
+    //     scale_tokens   [dim0(*), 1]
+
+    invokeGeneralLayerNorm(reinterpret_cast<T*>(out), reinterpret_cast<T const*>(input),
+        reinterpret_cast<T const*>(gamma), reinterpret_cast<T const*>(beta), eps, tokens, hidden_dim, mQuantMode,
+        stream, use_diff_of_squares, reinterpret_cast<float const*>(clampValPtr), reinterpret_cast<float const*>(scale),
+        reinterpret_cast<float*>(dynamic_scale), reinterpret_cast<float*>(sum_per_token),
+        reinterpret_cast<QuantT*>(normed_output_quant));
+}
+
 int LayernormQuantizationPlugin::enqueue(nvinfer1::PluginTensorDesc const* inputDesc,
     nvinfer1::PluginTensorDesc const* outputDesc, void const* const* inputs, void* const* outputs, void* workspace,
     cudaStream_t stream) noexcept
@@ -135,9 +201,11 @@ int LayernormQuantizationPlugin::enqueue(nvinfer1::PluginTensorDesc const* input
     //     weight [N, ]
     //     bias [N, ]
     //     scale_to_int [1]
+    //     clamp_value [2], contains min val, and max val (optional)
     // outputs
-    //     output [M(*), N]
-    //     dynamic_scaling [M(*), 1] (optional output)
+    //     output           [M(*), N]   Normalized activations, potentially with quantization applied.
+    //     dynamic_scaling  [M(*), 1]   (Optional) Per-token scales if quantization is enabled.
+    //     token_sums       [M(*), 1]   (Optional) Per-token sums of all the channels (before quantization).
 
     int64_t m64 = 1;
     for (int i = 0; i < inputDesc[0].dims.nbDims - 1; ++i)
@@ -147,36 +215,53 @@ int LayernormQuantizationPlugin::enqueue(nvinfer1::PluginTensorDesc const* input
     int const m = TLLM_INT32_CAST(m64);
     int const n = TLLM_INT32_CAST(inputDesc[1].dims.d[0]);
 
-    float const* scale = reinterpret_cast<float const*>(inputs[3]);
-    int8_t* output = reinterpret_cast<int8_t*>(outputs[0]);
-    float* dynamic_scale = mDynActScaling ? reinterpret_cast<float*>(outputs[1]) : nullptr;
+    void const* input = inputs[0];
+    void const* weight = inputs[1];
+    void const* bias = inputs[2];
+    void const* scale = inputs[3];
+    void const* clampValPtr = mClampValEnabled ? inputs[4] : nullptr;
+    void* output = outputs[0];
+    void* dynamic_scale = mDynActScaling ? outputs[1] : nullptr;
+    void* sum_per_token = mSumPerToken ? outputs[2] : nullptr;
 
-    if (mType == DataType::kHALF)
+    if (inputDesc[0].type == DataType::kFLOAT && mOutputType == DataType::kINT8)
     {
-        half const* input = reinterpret_cast<half const*>(inputs[0]);
-        half const* weight = reinterpret_cast<half const*>(inputs[1]);
-        half const* bias = reinterpret_cast<half const*>(inputs[2]);
-        invokeGeneralLayerNorm(
-            (half*) nullptr, input, weight, bias, mEps, m, n, stream, mUseDiffOfSquares, scale, dynamic_scale, output);
+        dispatchDataType<float, int8_t>(
+            nullptr, input, weight, bias, mEps, m, n, stream, mUseDiffOfSquares, clampValPtr, scale, dynamic_scale, sum_per_token, output);
     }
-    else if (mType == DataType::kFLOAT)
+#ifdef ENABLE_FP8
+    else if (inputDesc[0].type == DataType::kFLOAT && mOutputType == DataType::kFP8)
     {
-        float const* input = reinterpret_cast<float const*>(inputs[0]);
-        float const* weight = reinterpret_cast<float const*>(inputs[1]);
-        float const* bias = reinterpret_cast<float const*>(inputs[2]);
-        invokeGeneralLayerNorm(
-            (float*) nullptr, input, weight, bias, mEps, m, n, stream, mUseDiffOfSquares, scale, dynamic_scale, output);
+        dispatchDataType<float, __nv_fp8_e4m3>(
+            nullptr, input, weight, bias, mEps, m, n, stream, mUseDiffOfSquares, clampValPtr, scale, dynamic_scale, sum_per_token, output);
     }
+#endif // ENABLE_FP8
+    else if (inputDesc[0].type == DataType::kHALF && mOutputType == DataType::kINT8)
+    {
+        dispatchDataType<half, int8_t>(
+            nullptr, input, weight, bias, mEps, m, n, stream, mUseDiffOfSquares, clampValPtr, scale, dynamic_scale, sum_per_token, output);
+    }
+#ifdef ENABLE_FP8
+    else if (inputDesc[0].type == DataType::kHALF && mOutputType == DataType::kFP8)
+    {
+        dispatchDataType<half, __nv_fp8_e4m3>(
+            nullptr, input, weight, bias, mEps, m, n, stream, mUseDiffOfSquares, clampValPtr, scale, dynamic_scale, sum_per_token, output);
+    }
+#endif // ENABLE_FP8
 #ifdef ENABLE_BF16
-    else if (mType == DataType::kBF16)
+    else if (inputDesc[0].type == DataType::kBF16 && mOutputType == DataType::kINT8)
     {
-        __nv_bfloat16 const* input = reinterpret_cast<__nv_bfloat16 const*>(inputs[0]);
-        __nv_bfloat16 const* weight = reinterpret_cast<__nv_bfloat16 const*>(inputs[1]);
-        __nv_bfloat16 const* bias = reinterpret_cast<__nv_bfloat16 const*>(inputs[2]);
-        invokeGeneralLayerNorm((__nv_bfloat16*) nullptr, input, weight, bias, mEps, m, n, stream, mUseDiffOfSquares,
-            scale, dynamic_scale, output);
+        dispatchDataType<__nv_bfloat16, int8_t>(
+            nullptr, input, weight, bias, mEps, m, n, stream, mUseDiffOfSquares, clampValPtr, scale, dynamic_scale, sum_per_token, output);
     }
-#endif
+#ifdef ENABLE_FP8
+    else if (inputDesc[0].type == DataType::kBF16 && mOutputType == DataType::kFP8)
+    {
+        dispatchDataType<__nv_bfloat16, __nv_fp8_e4m3>(
+            nullptr, input, weight, bias, mEps, m, n, stream, mUseDiffOfSquares, clampValPtr, scale, dynamic_scale, sum_per_token, output);
+    }
+#endif // ENABLE_FP8
+#endif // ENABLE_BF16
     sync_check_cuda_error(stream);
     return 0;
 }
@@ -185,14 +270,25 @@ int LayernormQuantizationPlugin::enqueue(nvinfer1::PluginTensorDesc const* input
 nvinfer1::DataType LayernormQuantizationPlugin::getOutputDataType(
     int index, nvinfer1::DataType const* inputTypes, int nbInputs) const noexcept
 {
-    assert((mDynActScaling && index < 2) || (!mDynActScaling && index == 0));
+    assert(index <= 2);
+
     if (index == 0)
     {
         // Output 0 quantized output of layer norm
-        return nvinfer1::DataType::kINT8;
+        return mOutputType;
     }
-    // Output 1 dynamic act scaling
-    return nvinfer1::DataType::kFLOAT;
+    if (index == 1)
+    {
+        assert(mDynActScaling);
+        // Output 1 dynamic act scaling
+        return nvinfer1::DataType::kFLOAT;
+    }
+    // index == 2
+    {
+        assert(mDynActScaling && mSumPerToken);
+        // Output 2 per token sum
+        return nvinfer1::DataType::kFLOAT;
+    }
 }
 
 // IPluginV2 Methods
@@ -209,7 +305,7 @@ char const* LayernormQuantizationPlugin::getPluginVersion() const noexcept
 
 int LayernormQuantizationPlugin::getNbOutputs() const noexcept
 {
-    return 1 + static_cast<int>(mDynActScaling);
+    return 1 + static_cast<int>(mDynActScaling) + static_cast<int>(mSumPerToken);
 }
 
 int LayernormQuantizationPlugin::initialize() noexcept
@@ -221,7 +317,8 @@ void LayernormQuantizationPlugin::terminate() noexcept {}
 
 size_t LayernormQuantizationPlugin::getSerializationSize() const noexcept
 {
-    return sizeof(mEps) + sizeof(mUseDiffOfSquares) + sizeof(mDynActScaling) + sizeof(mType);
+    return sizeof(mOutputType) + sizeof(mClampValEnabled) + sizeof(mEps) + sizeof(mUseDiffOfSquares)
+        + sizeof(mDynActScaling) + sizeof(mSumPerToken) + sizeof(mType) + sizeof(mQuantMode);
 }
 
 void LayernormQuantizationPlugin::serialize(void* buffer) const noexcept
@@ -230,7 +327,11 @@ void LayernormQuantizationPlugin::serialize(void* buffer) const noexcept
     write(d, mEps);
     write(d, mUseDiffOfSquares);
     write(d, mDynActScaling);
+    write(d, mSumPerToken);
+    write(d, mClampValEnabled);
+    write(d, mQuantMode);
     write(d, mType);
+    write(d, mOutputType);
     TLLM_CHECK(d == a + getSerializationSize());
 }
 
@@ -249,7 +350,11 @@ LayernormQuantizationPluginCreator::LayernormQuantizationPluginCreator()
     mPluginAttributes.emplace_back(PluginField("eps", nullptr, PluginFieldType::kFLOAT32));
     mPluginAttributes.emplace_back(PluginField("use_diff_of_squares", nullptr, PluginFieldType::kINT32));
     mPluginAttributes.emplace_back(PluginField("dyn_act_scaling", nullptr, PluginFieldType::kINT32));
+    mPluginAttributes.emplace_back(PluginField("sum_per_token", nullptr, PluginFieldType::kINT32));
+    mPluginAttributes.emplace_back(PluginField("clamp_enabled", nullptr, PluginFieldType::kINT32));
+    mPluginAttributes.emplace_back(PluginField("quant_mode", nullptr, PluginFieldType::kINT32));
     mPluginAttributes.emplace_back(PluginField("type_id", nullptr, PluginFieldType::kINT32));
+    mPluginAttributes.emplace_back(PluginField("out_type_id", nullptr, PluginFieldType::kINT32));
     mFC.nbFields = mPluginAttributes.size();
     mFC.fields = mPluginAttributes.data();
 }
@@ -272,14 +377,33 @@ PluginFieldCollection const* LayernormQuantizationPluginCreator::getFieldNames()
 IPluginV2* LayernormQuantizationPluginCreator::createPlugin(char const* name, PluginFieldCollection const* fc) noexcept
 {
     PluginField const* fields = fc->fields;
+    nvinfer1::DataType outputType{};
+    QuantMode quantMode;
+    bool clampValEnabled = false;
     float eps{};
     nvinfer1::DataType type{};
     bool useDiffOfSquares{};
     bool dynamicActivationScaling{};
+    bool sumPerToken{};
     // Read configurations from each fields
     for (int i = 0; i < fc->nbFields; ++i)
     {
         char const* attrName = fields[i].name;
+        if (!strcmp(attrName, "quant_mode"))
+        {
+            TLLM_CHECK(fields[i].type == PluginFieldType::kINT32);
+            quantMode = QuantMode(*(static_cast<int32_t const*>(fields[i].data)));
+        }
+        else if (!strcmp(attrName, "out_type_id"))
+        {
+            TLLM_CHECK(fields[i].type == PluginFieldType::kINT32);
+            outputType = static_cast<nvinfer1::DataType>(*(static_cast<nvinfer1::DataType const*>(fields[i].data)));
+        }
+        else if (!strcmp(attrName, "clamp_enabled"))
+        {
+            TLLM_CHECK(fields[i].type == PluginFieldType::kINT32);
+            clampValEnabled = static_cast<bool>(*(static_cast<bool const*>(fields[i].data)));
+        }
         if (!strcmp(attrName, "eps"))
         {
             TLLM_CHECK(fields[i].type == PluginFieldType::kFLOAT32);
@@ -300,10 +424,16 @@ IPluginV2* LayernormQuantizationPluginCreator::createPlugin(char const* name, Pl
             TLLM_CHECK(fields[i].type == PluginFieldType::kINT32);
             useDiffOfSquares = static_cast<bool>(*(static_cast<bool const*>(fields[i].data)));
         }
+        else if (!strcmp(attrName, "sum_per_token"))
+        {
+            TLLM_CHECK(fields[i].type == PluginFieldType::kINT32);
+            sumPerToken = static_cast<bool>(*(static_cast<bool const*>(fields[i].data)));
+        }
     }
     try
     {
-        auto* obj = new LayernormQuantizationPlugin(eps, useDiffOfSquares, dynamicActivationScaling, type);
+        auto* obj = new LayernormQuantizationPlugin(
+            eps, useDiffOfSquares, dynamicActivationScaling, sumPerToken, clampValEnabled, quantMode, type, outputType);
         obj->setPluginNamespace(mNamespace.c_str());
         return obj;
     }

--- a/cpp/tensorrt_llm/plugins/layernormQuantizationPlugin/layernormQuantizationPlugin.h
+++ b/cpp/tensorrt_llm/plugins/layernormQuantizationPlugin/layernormQuantizationPlugin.h
@@ -16,6 +16,7 @@
  */
 #pragma once
 
+#include "tensorrt_llm/common/quantization.h"
 #include "tensorrt_llm/plugins/common/plugin.h"
 #include <cassert>
 #include <set>
@@ -29,7 +30,8 @@ class LayernormQuantizationPlugin : public BasePlugin
 {
 public:
     LayernormQuantizationPlugin(
-        float eps, bool useDiffOfSquares, bool dynamicActivationScaling, nvinfer1::DataType type);
+        float eps, bool useDiffOfSquares, bool dynamicActivationScaling, bool sumPerToken, bool clampValEnabled,
+        tensorrt_llm::common::QuantMode quantMode, nvinfer1::DataType type, nvinfer1::DataType outputType);
 
     LayernormQuantizationPlugin(void const* data, size_t length);
 
@@ -47,6 +49,11 @@ public:
         nvinfer1::PluginTensorDesc const* outputs, int nbOutputs) const noexcept override;
     int enqueue(nvinfer1::PluginTensorDesc const* inputDesc, nvinfer1::PluginTensorDesc const* outputDesc,
         void const* const* inputs, void* const* outputs, void* workspace, cudaStream_t stream) noexcept override;
+
+    template <typename T, typename QuantT>
+    void dispatchDataType(void* out, void const* input, void const* gamma, void const* beta, float const eps,
+        int const tokens, int const hidden_dim, cudaStream_t stream, bool use_diff_of_squares, void const* clampValPtr,
+        void const* scale, void* dynamic_scale, void* normed_output_quant, void* act_sum) noexcept;
 
     // IPluginV2Ext Methods
     nvinfer1::DataType getOutputDataType(
@@ -69,6 +76,14 @@ private:
     nvinfer1::DataType mType;
 
     const std::string mLayerName;
+    // The quantized output data type.
+    nvinfer1::DataType mOutputType;
+    // Do we clamp the input tensor ?
+    bool mClampValEnabled;
+    // The quantization mode.
+    tensorrt_llm::common::QuantMode mQuantMode;
+    // Should we output the sum of channels per-token? (Used by QServe GEMM)
+    bool mSumPerToken;
 };
 
 class LayernormQuantizationPluginCreator : public BaseCreator

--- a/tensorrt_llm/plugin/plugin.py
+++ b/tensorrt_llm/plugin/plugin.py
@@ -553,7 +553,7 @@ class PluginConfig(metaclass=PluginConfigMeta):
     def set_fp8_rowwise_quant_plugins(self, dtype: str = "auto"):
         self.fp8_rowwise_gemm_plugin = dtype
         self.rmsnorm_quantization_plugin = dtype
-        # self.layernorm_quantization_plugin = dtype
+        self.layernorm_quantization_plugin = dtype
         self.quantize_per_token_plugin = True
         self.quantize_tensor_plugin = True
         return self

--- a/tensorrt_llm/quantization/functional.py
+++ b/tensorrt_llm/quantization/functional.py
@@ -528,6 +528,83 @@ def smooth_quant_rms_norm(
         return output_quantized, output_scales, output_sums
 
 
+def fp8_rowwise_layer_norm(input: Tensor,
+                         normalized_shape: Union[int, Tuple[int]],
+                         weight: Optional[Tensor] = None,
+                         bias: Optional[Tensor] = None,
+                         scale: Optional[Tensor] = None,
+                         clamp_val: Optional[Tensor] = None,
+                         eps: float = 1e-05,
+                         dynamic_act_scaling: bool = True) -> Tensor:
+    if not default_net().plugin_config.layernorm_quantization_plugin:
+        raise TypeError("Fp8 Rowwise Layer Norm is only supported with plugin")
+    else:
+        plg_creator = trt.get_plugin_registry().get_plugin_creator(
+            'LayernormQuantization', '1', TRT_LLM_PLUGIN_NAMESPACE)
+        assert plg_creator is not None
+
+        output_type = trt.PluginField("out_type_id",
+                                      np.array([int(trt.fp8)], np.int32),
+                                      trt.PluginFieldType.INT32)
+        quant_mode = trt.PluginField(
+            "quant_mode",
+            np.array([int(QuantMode.from_description(use_fp8_rowwise=True))],
+                     np.int32), trt.PluginFieldType.INT32)
+        clamp_enabled = trt.PluginField(
+            "clamp_enabled", np.array([clamp_val is not None], np.int32),
+            trt.PluginFieldType.INT32)
+
+        eps = trt.PluginField("eps", np.array(eps, dtype=np.float32),
+                              trt.PluginFieldType.FLOAT32)
+
+        dyn_act_scaling = trt.PluginField(
+            "dyn_act_scaling", np.array([int(dynamic_act_scaling)], np.int32),
+            trt.PluginFieldType.INT32)
+        sum_per_token_pf = trt.PluginField("sum_per_token",
+                                           np.array([int(False)], np.int32),
+                                           trt.PluginFieldType.INT32)
+
+        p_dtype = default_net().plugin_config.layernorm_quantization_plugin
+        pf_type = trt.PluginField(
+            "type_id", np.array([int(str_dtype_to_trt(p_dtype))], np.int32),
+            trt.PluginFieldType.INT32)
+
+        pfc = trt.PluginFieldCollection([
+            eps, dyn_act_scaling, sum_per_token_pf, clamp_enabled, quant_mode,
+            pf_type, output_type
+        ])
+
+        layernorm_plug = plg_creator.create_plugin("layernorm_quantized", pfc)
+        normalized_shape = [normalized_shape] if isinstance(
+            normalized_shape, int) else normalized_shape
+        if weight is None:
+            weight = constant(
+                np.ones(normalized_shape, dtype=str_dtype_to_np(p_dtype)))
+        if bias is None:
+            bias = constant(
+                np.zeros(normalized_shape, dtype=str_dtype_to_np(p_dtype)))
+        if scale is None:
+            scale = constant(np.ones((1, ), dtype=str_dtype_to_np(p_dtype)))
+
+        # Layer Norm Plugin only supports float32 scale
+        scale = cast(scale, "float32")
+        plug_inputs = [
+            input.trt_tensor, weight.trt_tensor, bias.trt_tensor,
+            scale.trt_tensor
+        ]
+        if clamp_val:
+            plug_inputs += [clamp_val.trt_tensor]
+        layer = default_trtnet().add_plugin_v2(plug_inputs, layernorm_plug)
+        if not default_net().strongly_typed:
+            layer.get_output(0).set_dynamic_range(-448, 448)
+        _add_plugin_info(layer, plg_creator, "layernorm_quantized", pfc)
+        if not dynamic_act_scaling:
+            return _create_tensor(layer.get_output(0), layer)
+
+        return _create_tensor(layer.get_output(0),
+                              layer), _create_tensor(layer.get_output(1), layer)
+
+
 def fp8_rowwise_rms_norm(input: Tensor,
                          normalized_shape: Union[int, Tuple[int]],
                          weight: Optional[Tensor] = None,

--- a/tensorrt_llm/quantization/quantize.py
+++ b/tensorrt_llm/quantization/quantize.py
@@ -11,7 +11,7 @@ from ..models.modeling_utils import LayerQuantConfig, QuantConfig
 from ..parameter import Parameter
 from .layers import (FP4Linear, FP4RowLinear, FP8Linear, FP8RowLinear,
                      Fp8RowwiseAttention, Fp8RowwiseGatedMLP, Fp8RowwiseMLP,
-                     Fp8RowwiseRmsNorm, Int8SmoothQuantLinear,
+                     Fp8RowwiseLayerNorm, Fp8RowwiseRmsNorm, Int8SmoothQuantLinear,
                      Int8SmoothQuantRowLinear, QServeAttention, QServeGatedMLP,
                      QServeMLP, QServeRmsNorm, SmoothQuantAttention,
                      SmoothQuantGatedMLP, SmoothQuantLayerNorm, SmoothQuantMLP,
@@ -239,6 +239,7 @@ def fp8_rowwise_quantize(model, quant_config: QuantConfig):
 
     quant_cls_map = {
         RmsNorm: Fp8RowwiseRmsNorm,
+        LayerNorm: Fp8RowwiseLayerNorm,
         GatedMLP: Fp8RowwiseGatedMLP,
         MLP: Fp8RowwiseMLP,
         Attention: Fp8RowwiseAttention,


### PR DESCRIPTION
This adds FP8 support for the LayerNorm kernel in the same way as was done for the RmsNorm kernel, which then allows us to use FP8 Rowwise quantization with the Cohere models.

For previous discussion, see https://github.com/NVIDIA/TensorRT-LLM/issues/2912 