### PR TITLE
feat: Cohere2ForCausalLM support (Command-A, Command-R7B)

### DIFF
--- a/cpp/tensorrt_llm/pybind/executor/executorConfig.cpp
+++ b/cpp/tensorrt_llm/pybind/executor/executorConfig.cpp
@@ -94,11 +94,25 @@ void initConfigBindings(pybind11::module_& m)
         .def_property_readonly("dynamic_batch_config", &tle::SchedulerConfig::getDynamicBatchConfig)
         .def(py::pickle(schedulerConfigGetstate, schedulerConfigSetstate));
 
+    auto runtimeDefaultsGetstate = [](RuntimeDefaults const& self)
+    {
+        return py::make_tuple(self.maxAttentionWindowVec, self.sinkTokenLength);
+    };
+    auto runtimeDefaultsSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 2)
+        {
+            throw std::runtime_error("Invalid state!");
+        }
+        return RuntimeDefaults(state[0].cast<std::optional<std::vector<SizeType32>>>(),
+            state[1].cast<std::optional<SizeType32>>());
+    };
     py::class_<RuntimeDefaults>(m, "RuntimeDefaults")
         .def(py::init<std::optional<std::vector<SizeType32>>, std::optional<SizeType32>>(),
             py::arg("max_attention_window") = py::none(), py::arg("sink_token_length") = py::none())
         .def_readonly("max_attention_window", &RuntimeDefaults::maxAttentionWindowVec)
-        .def_readonly("sink_token_length", &RuntimeDefaults::sinkTokenLength);
+        .def_readonly("sink_token_length", &RuntimeDefaults::sinkTokenLength)
+        .def(py::pickle(runtimeDefaultsGetstate, runtimeDefaultsSetstate));
 
     auto kvCacheConfigGetstate = [](tle::KvCacheConfig const& self)
     {

--- a/tensorrt_llm/layers/attention.py
+++ b/tensorrt_llm/layers/attention.py
@@ -999,7 +999,9 @@ class Attention(Module):
             if self.cross_attention and (past_key_value is not None):
                 past_key_value = kv_cache_params.past_key_value[1]
             assert self.attention_mask_type in [
-                AttentionMaskType.causal, AttentionMaskType.bidirectional,
+                AttentionMaskType.causal,
+                AttentionMaskType.sliding_window_causal,
+                AttentionMaskType.bidirectional,
                 AttentionMaskType.bidirectionalglm,
                 AttentionMaskType.blocksparse
             ], 'Plugin only support masked MHA.'
@@ -1842,7 +1844,9 @@ class CogVLMAttention(Attention):
             if self.cross_attention and (past_key_value is not None):
                 past_key_value = kv_cache_params.past_key_value[1]
             assert self.attention_mask_type in [
-                AttentionMaskType.causal, AttentionMaskType.bidirectional,
+                AttentionMaskType.causal, 
+                AttentionMaskType.sliding_window_causal,
+                AttentionMaskType.bidirectional,
                 AttentionMaskType.bidirectionalglm
             ], 'Plugin only support masked MHA.'
 
@@ -2189,6 +2193,7 @@ class DeepseekV2Attention(Attention):
                 past_key_value = kv_cache_params.past_key_value[1]
             assert self.attention_mask_type in [
                 AttentionMaskType.causal,
+                AttentionMaskType.sliding_window_causal,
                 AttentionMaskType.bidirectional,
                 AttentionMaskType.bidirectionalglm,
             ], 'Plugin only support masked MHA.'

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -510,6 +510,9 @@ class LLM:
         if self.args.kv_cache_config is not None:
             executor_config.kv_cache_config = PybindMirror.maybe_to_pybind(
                 self.args.kv_cache_config)
+            if self.args._pretrained_config.runtime_defaults is not None:
+                executor_config.kv_cache_config.fill_empty_fields_from_runtime_defaults(
+                    self.args._pretrained_config.runtime_defaults)
         if self.args.peft_cache_config is not None:
             executor_config.peft_cache_config = PybindMirror.maybe_to_pybind(
                 self.args.peft_cache_config)

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1021,10 +1021,6 @@ class LlmArgs:
                         "The build_config is ignored for model format of TLLM_ENGINE."
                     )
                 self._load_config_from_engine(model_obj.model_dir)
-                runtime_defaults = self._pretrained_config.runtime_defaults
-                if self._use_runtime_defaults and runtime_defaults:
-                    self.kv_cache_config.fill_empty_fields_from_runtime_defaults(
-                        runtime_defaults)
 
             # Load parallel_config from the checkpoint.
             elif self.model_format is _ModelFormatKind.TLLM_CKPT:

--- a/tensorrt_llm/models/__init__.py
+++ b/tensorrt_llm/models/__init__.py
@@ -24,6 +24,7 @@ from .clip.model import CLIPVisionTransformer
 from .cogvlm.config import CogVLMConfig
 from .cogvlm.model import CogVLMForCausalLM
 from .commandr.model import CohereForCausalLM
+from .commanda.model import Cohere2ForCausalLM
 from .dbrx.config import DbrxConfig
 from .dbrx.model import DbrxForCausalLM
 from .deepseek_v1.model import DeepseekForCausalLM
@@ -131,6 +132,7 @@ __all__ = [
     'EagleForCausalLM',
     'SpeculativeDecodingMode',
     'CohereForCausalLM',
+    'Cohere2ForCausalLM',
     'MLLaMAForCausalLM',
 ]
 
@@ -204,6 +206,7 @@ MODEL_MAP = {
     'DeepseekV2ForCausalLM': DeepseekV2ForCausalLM,
     'EagleForCausalLM': EagleForCausalLM,
     'CohereForCausalLM': CohereForCausalLM,
+    'Cohere2ForCausalLM': Cohere2ForCausalLM,
     'MLLaMAModel': MLLaMAForCausalLM,  # For modelopt
     'MllamaForConditionalGeneration':
     MLLaMAForCausalLM,  # For mllama load by Auto

--- a/tensorrt_llm/models/commanda/__init__.py
+++ b/tensorrt_llm/models/commanda/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tensorrt_llm/models/commanda/config.py
+++ b/tensorrt_llm/models/commanda/config.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Optional, Union
+
+import transformers
+
+from ...mapping import Mapping
+from ..convert_utils import infer_dtype
+from ..modeling_utils import PretrainedConfig, QuantConfig
+
+
+class Cohere2Config(PretrainedConfig):
+
+    def __init__(
+            self,
+            *,
+            output_multiplier_scale: float = 0.0625,
+            rotary_base: float = 10000.0,
+            attn_bias: bool = False,
+            **kwargs):
+
+        self.output_multiplier_scale = output_multiplier_scale
+        self.rotary_base = rotary_base
+        self.attn_bias = attn_bias
+        super().__init__(**kwargs)
+
+    def to_dict(self):
+        output = super().to_dict()
+        # Serialize the fields added in Cohere2Config
+        output['output_multiplier_scale'] = self.output_multiplier_scale
+        output['rotary_base'] = self.rotary_base
+        output['attn_bias'] = self.attn_bias
+        return output
+
+    @classmethod
+    def from_hugging_face(
+            cls,
+            hf_config_or_dir: Union[str, 'transformers.PretrainedConfig'],
+            dtype: str = 'auto',
+            mapping: Optional[Mapping] = None,
+            quant_config: Optional[QuantConfig] = None,
+            **kwargs):
+
+        if isinstance(hf_config_or_dir, transformers.PretrainedConfig):
+            hf_config = hf_config_or_dir
+        else:
+            hf_config = transformers.AutoConfig.from_pretrained(
+                hf_config_or_dir, trust_remote_code=True)
+
+        head_size = hf_config.hidden_size // hf_config.num_attention_heads
+
+        dtype = infer_dtype(dtype, getattr(hf_config, 'torch_dtype', None))
+
+        return Cohere2Config(
+            runtime_defaults=dict(max_attention_window=[4096, 4096, 4096, 131072]),
+            architecture=hf_config.architectures[0],
+            dtype=dtype,
+            num_hidden_layers=hf_config.num_hidden_layers,
+            num_attention_heads=hf_config.num_attention_heads,
+            hidden_size=hf_config.hidden_size,
+            intermediate_size=hf_config.intermediate_size,
+            num_key_value_heads=hf_config.num_key_value_heads,
+            head_size=head_size,
+            vocab_size=hf_config.vocab_size,
+            position_embedding_type='rope_gptj',  # different rope type
+            max_position_embeddings=hf_config.max_position_embeddings,
+            hidden_act=hf_config.hidden_act,
+            norm_epsilon=hf_config.layer_norm_eps,
+            output_multiplier_scale=hf_config.logit_scale,
+            rotary_base=hf_config.rope_theta,
+            attn_bias=hf_config.attention_bias,
+            mapping=mapping,
+            quantization=quant_config,
+            **kwargs)

--- a/tensorrt_llm/models/commanda/model.py
+++ b/tensorrt_llm/models/commanda/model.py
@@ -1,0 +1,204 @@
+from typing import Optional
+
+from ..._common import default_net
+from ..._utils import pad_vocab_size
+from ...functional import recv, send
+from ...layers import (Attention, AttentionMaskType, ColumnLinear, Embedding,
+                       GatedMLP, LayerNorm, PositionEmbeddingType)
+from ...mapping import Mapping
+from ...module import Module
+from ..model_weights_loader import ModelWeightsLoader
+from ..modeling_utils import (DecoderLayerList, DecoderModelForCausalLM,
+                              QuantConfig)
+from .config import Cohere2Config
+
+
+class Cohere2DecoderLayer(Module):
+
+    def __init__(self, config: Cohere2Config, layer_idx: int):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.config = config
+
+        # Every n-th layer uses global attention with no position embeddings.
+        # The other layers use sliding window attention with rotary embeddings.
+        self.sliding_window = (self.layer_idx + 1) % 4 != 0;
+
+        self.input_layernorm = LayerNorm(
+            normalized_shape=config.hidden_size,
+            eps=config.norm_epsilon,
+            bias=False,
+            dtype=config.dtype)
+
+        layers_range = config.mapping.pp_layers(config.num_hidden_layers)
+        self.local_layer_idx = layer_idx - layers_range[0]
+        self.attention = Attention(
+            local_layer_idx=self.local_layer_idx,
+            hidden_size=config.hidden_size,
+            attention_head_size=config.head_size,
+            num_attention_heads=config.num_attention_heads,
+            num_kv_heads=config.num_key_value_heads,
+            max_position_embeddings=config.max_position_embeddings,
+            dtype=config.dtype,
+            attention_mask_type=AttentionMaskType.sliding_window_causal if self.sliding_window else AttentionMaskType.causal,
+            bias=config.attn_bias,
+            # There isn't a "none" option for the position embedding type.
+            # So this is theoretically incorrect, there are no learned absolute position embeddings.
+            # But because we only set it on the layer, rather than the entire model, it ends up applying no position embeddings.
+            position_embedding_type=PositionEmbeddingType.rope_gptj if self.sliding_window else PositionEmbeddingType.learned_absolute,
+            rotary_embedding_base=config.rotary_base,
+            tp_group=config.mapping.tp_group,
+            tp_size=config.mapping.tp_size,
+            tp_rank=config.mapping.tp_rank,
+            layernorm_share=False,
+            eps=config.norm_epsilon,
+            quant_mode=config.quant_mode)
+
+        self.mlp = GatedMLP(hidden_size=config.hidden_size,
+            ffn_hidden_size=config.intermediate_size,
+            hidden_act=config.hidden_act,
+            dtype=config.dtype,
+            bias=False,
+            tp_group=config.mapping.tp_group,
+            tp_size=config.mapping.tp_size,
+            quant_mode=config.quant_mode)
+
+    def forward(self,
+            hidden_states,
+            attention_mask=None,
+            use_cache=False,
+            spec_decoding_params=None,
+            kv_cache_params=None,
+            attention_params=None):
+
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+
+        attention_output = self.attention(
+            hidden_states,
+            attention_mask=attention_mask,
+            use_cache=use_cache,
+            spec_decoding_params=spec_decoding_params,
+            kv_cache_params=kv_cache_params,
+            attention_params=attention_params)
+
+        if use_cache:
+            attention_output, presents = attention_output
+
+        mlp_output = self.mlp(hidden_states)
+        hidden_states = residual + attention_output + mlp_output
+
+        if use_cache:
+            return (hidden_states, presents)
+        return hidden_states
+
+
+class Cohere2Model(Module):
+
+    def __init__(self, config: Cohere2Config) -> None:
+        super().__init__()
+
+        self.mapping = config.mapping
+        if self.mapping.is_first_pp_rank():
+            self.vocab_embedding = Embedding(
+                config.vocab_size,
+                config.hidden_size,
+                dtype=config.dtype,
+                tp_group=config.mapping.tp_group,
+                tp_size=config.mapping.tp_size,
+                tp_rank=config.mapping.tp_rank)
+
+        self.layers = DecoderLayerList(Cohere2DecoderLayer, config)
+
+        if self.mapping.is_last_pp_rank():
+            self.ln_f = LayerNorm(
+                normalized_shape=config.hidden_size,
+                eps=config.norm_epsilon,
+                bias=False,
+                dtype=config.dtype)
+
+    def forward(
+            self,
+            input_ids=None,
+            position_ids=None,
+            use_cache=False,
+            attention_mask=None,
+            spec_decoding_params=None,
+            kv_cache_params=None,
+            attention_params=None,
+            hidden_states=None):
+
+        if self.mapping.is_first_pp_rank():
+            hidden_states = self.vocab_embedding(input_ids)
+        else:
+            hidden_states = recv(hidden_states, self.mapping.prev_pp_rank())
+
+        hidden_states = self.layers.forward(
+            hidden_states,
+            use_cache=use_cache,
+            attention_mask=attention_mask,
+            kv_cache_params=kv_cache_params,
+            attention_params=attention_params,
+            spec_decoding_params=spec_decoding_params)
+
+        if use_cache:
+            hidden_states, presents = hidden_states
+
+        if self.mapping.is_last_pp_rank():
+            hidden_states = self.ln_f(hidden_states)
+        else:
+            hidden_states = send(hidden_states, self.mapping.next_pp_rank())
+
+        if use_cache:
+            return (hidden_states, presents)
+
+        return hidden_states
+
+
+class Cohere2ForCausalLM(DecoderModelForCausalLM):
+
+    config_class = Cohere2Config
+
+    def __init__(self, config: Cohere2Config):
+        transformer = Cohere2Model(config)
+        vocab_size_padded = pad_vocab_size(
+            config.vocab_size,
+            config.mapping.tp_size)
+
+        if config.mapping.is_last_pp_rank():
+            lm_head = ColumnLinear(
+                config.hidden_size,
+                vocab_size_padded,
+                bias=False,
+                dtype=config.dtype,
+                tp_group=config.mapping.tp_group,
+                tp_size=config.mapping.tp_size,
+                gather_output=True)
+        else:
+            lm_head = None
+
+        self.quant_mode = config.quant_mode
+        self.mapping = config.mapping
+        super().__init__(config, transformer, lm_head)
+
+    @classmethod
+    def from_hugging_face(
+            cls,
+            hf_model_or_dir: str,
+            dtype: str = 'auto',
+            mapping: Optional[Mapping] = None,
+            quant_config: Optional[QuantConfig] = None,
+            **kwargs):
+
+        config = Cohere2Config.from_hugging_face(
+            hf_model_or_dir,
+            dtype=dtype,
+            mapping=mapping,
+            quant_config=quant_config,
+            **kwargs)
+
+        model = cls(config)
+        loader = ModelWeightsLoader(hf_model_or_dir)
+        loader.generate_tllm_weights(model)
+
+        return model

--- a/tensorrt_llm/models/modeling_utils.py
+++ b/tensorrt_llm/models/modeling_utils.py
@@ -424,6 +424,21 @@ class PretrainedConfig:
             return RuntimeDefaults(**defaults)
         return defaults
 
+    @staticmethod
+    def export_runtime_defaults(defaults: Optional[RuntimeDefaults]) -> dict:
+        if defaults is None:
+            return None
+
+        result = {}
+    
+        if defaults.max_attention_window is not None:
+            result['max_attention_window'] = defaults.max_attention_window
+            
+        if defaults.sink_token_length is not None:
+            result['sink_token_length'] = defaults.sink_token_length
+
+        return result if result else None
+
     @property
     def kv_dtype(self):
         # TODO: need to align the kv dtype
@@ -456,6 +471,9 @@ class PretrainedConfig:
         output['mapping'] = self.mapping.to_dict()
         output['mapping'].pop('rank')
         output['quantization'] = self.quantization.to_dict()
+
+        if self.runtime_defaults is not None:
+            output['runtime_defaults'] = self.export_runtime_defaults(self.runtime_defaults)
 
         return output
 

--- a/tensorrt_llm/quantization/layers.py
+++ b/tensorrt_llm/quantization/layers.py
@@ -1982,8 +1982,10 @@ class Fp8RowwiseAttention(Module):
         if use_cache:
             assert kv_cache_params.is_valid(
                 default_net().plugin_config.gpt_attention_plugin)
-        assert self.attention_mask_type == AttentionMaskType.causal, \
-            'Plugin only support masked MHA.'
+        assert self.attention_mask_type in [
+            AttentionMaskType.causal,
+            AttentionMaskType.sliding_window_causal
+        ], 'Plugin only support masked MHA.'
         if self.kv_cache_scaling_factor is not None:
             kv_orig_quant_scale = self.kv_cache_rcp_scaling_factor.value
             kv_quant_orig_scale = self.kv_cache_scaling_factor.value
@@ -2608,8 +2610,10 @@ class SmoothQuantAttention(Module):
             if use_cache:
                 assert kv_cache_params.is_valid(
                     default_net().plugin_config.gpt_attention_plugin)
-            assert self.attention_mask_type == AttentionMaskType.causal, \
-                'Plugin only support masked MHA.'
+            assert self.attention_mask_type in [
+                AttentionMaskType.causal,
+                AttentionMaskType.sliding_window_causal
+            ], 'Plugin only support masked MHA.'
             if self.kv_cache_scaling_factor is not None:
                 kv_orig_quant_scale = self.kv_cache_rcp_scaling_factor.value
                 kv_quant_orig_scale = self.kv_cache_scaling_factor.value
@@ -3130,8 +3134,10 @@ class QServeAttention(Module):
             if use_cache:
                 assert kv_cache_params.is_valid(
                     default_net().plugin_config.gpt_attention_plugin)
-            assert self.attention_mask_type == AttentionMaskType.causal, \
-                'Plugin only support masked MHA.'
+            assert self.attention_mask_type in [
+                AttentionMaskType.causal,
+                AttentionMaskType.sliding_window_causal
+            ], 'Plugin only support masked MHA.'
             if self.kv_cache_scaling_factor is not None:
                 kv_orig_quant_scale = self.kv_cache_rcp_scaling_factor.value
                 kv_quant_orig_scale = self.kv_cache_scaling_factor.value


### PR DESCRIPTION
This adds support for Cohere2ForCausalLM architecture which interleaves global layers without position embedding with sliding window layers with rope positions. I also fixed the RuntimeDefaults thing not actually working in the python API (this is the first model that ever used it).

For previous discussion, see https://github.com/NVIDIA/TensorRT-LLM/issues/2912 

(This PR is not 100% finished, it should load the correct sliding window config from the model config rather than hard coding it. I will add that soon)