### PR TITLE
feat: Variable-Beam-Width-Search (VBWS) Part2

### DIFF
--- a/cpp/include/tensorrt_llm/common/cudaUtils.h
+++ b/cpp/include/tensorrt_llm/common/cudaUtils.h
@@ -677,6 +677,7 @@ __host__ __device__ inline void print_elements(T const* ptr, int nRow, int nCol,
         }
         printf("\n");
     }
+    printf("\n");
 }
 
 template <typename T>
@@ -742,6 +743,19 @@ __device__ inline void printMatrixDevice(T const* ptr, int nRow, int nCol, int n
     printf("addr=%p, sizeof(T)=%lu, nRow=%d, nStride=%d, sizeInByte=%lu\n", ptr, sizeof(T), nRow, nStride, sizeInByte);
     print_elements(ptr, nRow, nCol, nStride);
 }
+
+template __device__ void printMatrixDevice(float const* ptr, int nRow, int nCol, int nStride);
+template __device__ void printMatrixDevice(half const* ptr, int nRow, int nCol, int nStride);
+#ifdef ENABLE_BF16
+template __device__ void printMatrixDevice(__nv_bfloat16 const* ptr, int nRow, int nCol, int nStride);
+#endif
+#ifdef ENABLE_FP8
+template __device__ void printMatrixDevice(__nv_fp8_e4m3 const* ptr, int nRow, int nCol, int nStride);
+#endif
+template __device__ void printMatrixDevice(uint32_t const* ptr, int nRow, int nCol, int nStride);
+template __device__ void printMatrixDevice(uint64_t const* ptr, int nRow, int nCol, int nStride);
+template __device__ void printMatrixDevice(int const* ptr, int nRow, int nCol, int nStride);
+template __device__ void printMatrixDevice(uint8_t const* ptr, int nRow, int nCol, int nStride);
 
 #ifndef CUDA_CALL
 #define CUDA_CALL(answer)                                                                                              \
@@ -1360,19 +1374,6 @@ DEFINE_MEMBER_CHECKER(bias)
 DEFINE_MEMBER_CHECKER(deq)
 DEFINE_MEMBER_CHECKER(qua)
 DEFINE_MEMBER_CHECKER(high_preciecion_normed_output)
-
-template __device__ void printMatrixDevice(float const* ptr, int nRow, int nCol, int nStride);
-template __device__ void printMatrixDevice(half const* ptr, int nRow, int nCol, int nStride);
-#ifdef ENABLE_BF16
-template __device__ void printMatrixDevice(__nv_bfloat16 const* ptr, int nRow, int nCol, int nStride);
-#endif
-#ifdef ENABLE_FP8
-template __device__ void printMatrixDevice(__nv_fp8_e4m3 const* ptr, int nRow, int nCol, int nStride);
-#endif
-template __device__ void printMatrixDevice(uint32_t const* ptr, int nRow, int nCol, int nStride);
-template __device__ void printMatrixDevice(uint64_t const* ptr, int nRow, int nCol, int nStride);
-template __device__ void printMatrixDevice(int const* ptr, int nRow, int nCol, int nStride);
-template __device__ void printMatrixDevice(uint8_t const* ptr, int nRow, int nCol, int nStride);
 
 } // namespace tensorrt_llm::common
 

--- a/cpp/tensorrt_llm/executor/samplingConfig.cpp
+++ b/cpp/tensorrt_llm/executor/samplingConfig.cpp
@@ -298,7 +298,7 @@ void SamplingConfig::setBeamWidthArray(OptVec<SizeType32> const& beamWidthArray)
 // Checkers
 SizeType32 SamplingConfig::checkBeamWidth(SizeType32 beamWidth)
 {
-    TLLM_CHECK(beamWidth > 0 && beamWidth < static_cast<SizeType32 const>(tensorrt_llm::kernels::kMaxBeamWidth));
+    TLLM_CHECK(beamWidth > 0 && beamWidth <= static_cast<SizeType32 const>(tensorrt_llm::kernels::kMaxBeamWidth));
     return beamWidth;
 }
 

--- a/cpp/tensorrt_llm/kernels/beamSearchKernels.cu
+++ b/cpp/tensorrt_llm/kernels/beamSearchKernels.cu
@@ -37,7 +37,7 @@ void beamSearchKernelLauncher(
 template <typename T, bool IS_V2>
 void invokeTopkBeamSearch(T const* logProbs, T const* bias, void* workspace, BeamHypotheses& bh, cudaStream_t stream)
 {
-    int const nPadBeamWidth = padToNextPowerOfTwo(bh.nBeamWidth);
+    int const nPadBeamWidth{padToNextPowerOfTwo(bh.nBeamWidth)};
 
     // case X means X/2 < beam_width <= X
     if constexpr (IS_V2)
@@ -85,43 +85,96 @@ template void invokeTopkBeamSearch<half, false>(
 template void invokeTopkBeamSearch<half, true>(
     half const* logProbs, half const* bias, void* workspace, BeamHypotheses& bh, cudaStream_t stream);
 
-template <typename T>
-__global__ void addCumLogProbs(T* __restrict pStage1Probs, float const* __restrict cumLogProbs,
-    FinishedState const* finished, int const* endIds, float const* diversityRates,
-    runtime::SizeType32 const* batchSlots, size_t const nBS, size_t const nBM)
+__global__ void updateCacheIndirectionKernel(
+    int* tgtCI, int const* srcCI, BeamHypotheses bh, int const nMaxAttentionWindow, int const nSinkTokenLength)
 {
-    int const bid = blockIdx.x;
-    runtime::SizeType32 const slot = batchSlots[bid];
-    float const diversityRate{diversityRates[slot]};
-    T* pLocalProbs = pStage1Probs + bid * nBM * nBM * 2;
+    // Update cache indirections which steps are between `bh.inputLength[x]` to `sequenceLengths[x]`
+    int const step = blockIdx.x * blockDim.x + threadIdx.x;
+    size_t const nBM{bh.nBeamWidth};
+    size_t const nBMIn{bh.nBeamWidthIn};
+    size_t const nBMOut{bh.nBeamWidthOut};
+    size_t const nMSL{bh.nMaxSeqLen};
+    int const indexBatch = blockIdx.y;
+    int const batchSlot = bh.batchSlots[indexBatch];
+    int const tgtIndexBeam = blockIdx.z;
+    int const tgtIndexBatchBeam = batchSlot * nBM + tgtIndexBeam;
+    int const lastStep{bh.sequenceLengths[tgtIndexBatchBeam] - 1}; // minus 1 since it is updated in stage 3 kernel
 
-    for (int index = threadIdx.x; index < nBM * nBM * 2; index += blockDim.x)
+    // Return early when at least one of the conditions is true:
+    // 1. `step` is out of the bound
+    // 2. `step` is inside of input part (since context KV Cache is shared)
+    // 3. `step` is outside of attention widow
+    if (step >= nMSL || step < bh.inputLengths[tgtIndexBatchBeam] || step < (nMSL - nMaxAttentionWindow))
     {
-        int const indexBM = index / (nBM * 2);
-        if (finished[slot * nBM + indexBM].isFinished())
+        return;
+    }
+
+    // Keep all past tokens by parentIdsPtr
+    int const srcIndexBeam = bh.parentIdsPtr[batchSlot][tgtIndexBeam * nMSL + lastStep];
+    // Return early when the source beam isfinished
+    if (bh.finished[tgtIndexBatchBeam].isFinished())
+    {
+        return;
+    }
+
+    int const stepCirc = (step >= nSinkTokenLength)
+        ? nSinkTokenLength + (step - nSinkTokenLength) % (nMaxAttentionWindow - nSinkTokenLength)
+        : step;
+    // Consider cyclic kv cache for the indir tables
+    uint32_t const tgtOffset = batchSlot * nBMOut * nMaxAttentionWindow + tgtIndexBeam * nMaxAttentionWindow + stepCirc;
+    uint32_t const srcOffset = batchSlot * nBMIn * nMaxAttentionWindow + srcIndexBeam * nMaxAttentionWindow + stepCirc;
+    tgtCI[tgtOffset] = (step == lastStep) ? tgtIndexBeam : srcCI[srcOffset];
+}
+
+void invokeUpdateCacheIndirection(int* tgtCI, int const* srcCI, BeamHypotheses& bh,
+    runtime::SizeType32 const maxAttentionWindow, runtime::SizeType32 sinkTokenLength, cudaStream_t stream)
+{
+    dim3 const grid(common::roundUp(bh.nMaxSeqLen, 32), bh.nBatchSize, bh.nBeamWidthOut);
+    updateCacheIndirectionKernel<<<grid, 32, 0, stream>>>(tgtCI, srcCI, bh, maxAttentionWindow, sinkTokenLength);
+    sync_check_cuda_error(stream);
+}
+
+template <typename T>
+__global__ void addCumLogProbs(T* __restrict pStage1LogProbs, float const* __restrict cumLogProbs,
+    FinishedState const* finished, int const* endIds, float const* diversityRates,
+    runtime::SizeType32 const* batchSlots, size_t const nBS, size_t const nBMIn, size_t const nBMOut, size_t const nBM)
+{
+    int const bid = blockIdx.x; // Index of request in batch
+    float const diversityRate{diversityRates[batchSlots[bid]]};
+    T* pLocalLogProbs = pStage1LogProbs + bid * nBMIn * nBMOut * 2;
+
+    for (int i = threadIdx.x; i < nBMIn * nBMOut * 2; i += blockDim.x)
+    {
+        int const iBMIn = i / (nBMOut * 2);
+        if (finished[bid * nBMIn + iBMIn].isFinished())
         {
-            pLocalProbs[index] += (index == endIds[slot]) ? 1.0f : 0.0f;
+            pLocalLogProbs[i] += (i == endIds[bid]) ? 1.0f : 0.0f;
         }
         else
         {
-            pLocalProbs[index] += cumLogProbs[slot * nBM + indexBM] + diversityRate * indexBM;
+            // nBM is used in VBWS since `cumLogProbs` is initialized with kMaxBeamWidth earlier than BeamSearchLayer
+            pLocalLogProbs[i] += cumLogProbs[bid * nBM + iBMIn] + diversityRate * iBMIn;
         }
     }
     return;
 }
 
-template __global__ void addCumLogProbs<float>(float* __restrict pStage1Probs, float const* __restrict cumLogProbs,
+template __global__ void addCumLogProbs<float>(float* __restrict pStage1LogProbs, float const* __restrict cumLogProbs,
     FinishedState const* finished, int const* endIds, float const* diversityRates,
-    runtime::SizeType32 const* batchSlots, size_t const nBS, size_t const nBM);
+    runtime::SizeType32 const* batchSlots, size_t const nBS, size_t const nBMIn, size_t const nBMOut, size_t const nBM);
 
-template __global__ void addCumLogProbs<half>(half* __restrict pStage1Probs, float const* __restrict cumLogProbs,
+template __global__ void addCumLogProbs<half>(half* __restrict pStage1LogProbs, float const* __restrict cumLogProbs,
     FinishedState const* finished, int const* endIds, float const* diversityRates,
-    runtime::SizeType32 const* batchSlots, size_t const nBS, size_t const nBM);
+    runtime::SizeType32 const* batchSlots, size_t const nBS, size_t const nBMIn, size_t const nBMOut, size_t const nBM);
 
-__global__ void gatherId(
-    int const* __restrict pStage1Id, int* __restrict pStage2Id, size_t const nBS, size_t const nBM, size_t const nV)
+__global__ void gatherId(int const* __restrict pStage1Id, int* __restrict pStage2Id, size_t const nBS,
+    size_t const nBMIn, size_t const nBMOut, size_t const nV)
 {
-    // Example (definition of the processes and variables and are in `beamSearchKernelsTemplate.h`).
+    // Use topK output `pStage1Id` and `pStage1Id` to get the index of a new token in `logProbs` for each beam.
+    //
+    // clang-format off
+    //
+    // Example for normal beam search:
     // nBS = 3, nBM = 2, nV = 5, use logProbs with integer values here for simplicity.
     // ┏┏ 46 35 47 18 67 ┓┓      ┏┏ 67 47 46 35 ┓┓ ┏┏ 4 2 0 1 ┓┓
     // ┃┗ 76 23 74 73 17 ┛┃      ┃┗ 76 74 73 23 ┛┃ ┃┗ 0 2 3 1 ┛┃
@@ -129,27 +182,160 @@ __global__ void gatherId(
     // ┃┗ 12 70 77 22 88 ┛┃ ---> ┃┗ 88 77 70 22 ┛┃ ┃┗ 4 2 1 3 ┛┃ ---> ┃ 98 88 88 77 ┃ ┃ 0 1 4 5 ┃ ---> ┃ 2 3 9 7 ┃
     // ┃┏ 55 15 72  3 84 ┓┃      ┃┏ 74 72 55 15 ┓┃ ┃┏ 4 2 0 1 ┓┃      ┗ 98 93 84 77 ┛ ┗ 4 5 0 6 ┛      ┗ 9 6 4 5 ┛
     // ┗┗ 77 93 14 60 98 ┛┛      ┗┗ 98 93 77 60 ┛┛ ┗┗ 4 1 0 3 ┛┛
-    //       logProbs               stage1Probs      stage1Id           stage2Probs    stage2Id      output-stage2Id
+    //       logProbs              stage1LogProbs     stage1Id         stage2LogProbs   stage2Id     output-stage2Id
     //
-    // For `stage2Probs[2][3] == 77`,
-    //     original batch index in logProbs:    bid                         -> 2    (a)
+    // For `stage2LogProbs[2][3] == 77`,
+    //     original batch index in logProbs:    blockIdx.x                  -> 2    (a)
     //     original beam index in logProbs:     stage2Id[2][3] / (nBM * 2)  -> 1    (b)
     //     row index in stage1Probs:            a * nBM + b                 -> 5    (c)
     //     column index in stage1*:             stage2Id[2][3] % (nBM * 2)  -> 2    (d)
     //     column index in logProbs:            stage1Id[c][d]              -> 0    (e)
     //     pad for previous tokens:             b * nV                      -> 5    (f)
     //     final output:                        e + f                       -> 5
-
-    int const bid = blockIdx.x;
-    for (int j = threadIdx.x; j < nBM * 2; j += blockDim.x)
+    //
+    // ========================================================================================================
+    // Example for VBWS:
+    // nBS = 2, nBMIn = 3, nBMOut = 5, nBM = 7, nV = 11, use logProbs with integer values here for simplicity.
+    // ┏┏ 46 35 47 18 67 76 23 74 73 17 67 ┓┓      ┏┏ 76 74 73 67 67 47 46 35 23 18 ┓┓ ┏┏  5  7  8  4 10  2  0  1  6  3 ┓┓
+    // ┃┃ 49 98 88 74 12 70 77 22 88 55 15 ┃┃      ┃┃ 98 88 88 77 74 70 55 49 22 15 ┃┃ ┃┃  1  2  8  6  3  5  9  0  7 10 ┃┃
+    // ┃┗ 72  3 84 77 93 14 60 98 65  4 20 ┛┃  A   ┃┗ 98 93 84 77 72 65 60 20 14  4 ┛┃ ┃┗  7  4  2  3  0  8  6 10  5  9 ┛┃  C
+    // ┃┏ 16 34 71 38 19 91  5 81 97 43 79 ┓┃ ---> ┃┏ 97 91 81 79 71 43 38 34 19 16 ┓┃ ┃┏  8  5  7 10  2  9  3  1  4  0 ┓┃ --->
+    // ┃┃  2 22 77 37 57 33 57 41 27 73 88 ┃┃      ┃┃ 88 77 73 57 57 41 37 33 27 22 ┃┃ ┃┃ 10  2  9  4  6  7  3  5  8  1 ┃┃
+    // ┗┗ 77 16 23 22 82 89  6 77 67 15 31 ┛┛      ┗┗ 89 82 77 77 67 31 23 22 16 15 ┛┛ ┗┗  5  4  0  7  8 10  2  3  1  9 ┛┛
+    //                logProbs                                stage1LogProbs                         stage1Id
+    //
+    //  C    ┏ 98 98 93 88 88 84 77 77 76 74 ┓ ┏ 10 20 21 11 12 22 13 23  0  1 ┓  D   ┏ 12 29 26 13 19 24 17 25  5  7 ┓
+    // --->  ┗ 97 91 89 88 82 81 79 77 77 77 ┛ ┗  0  1 20 10 21  2  3 11 22 23 ┛ ---> ┗  8  5 27 21 26  7 10 13 22 29 ┛
+    //                 stage2LogProbs                        stage2Id                          output-stage2Id
+    //
+    // For `stage2LogProbs[1][4] == 82`,
+    //     original batch index in logProbs:    blockIdx.x                      ->  1   (a)
+    //     original beam index in logProbs:     stage2Id[1][4] / (nBMOut * 2)   ->  2   (b)
+    //     row index in stage1LogProbs:         a * nBMIn + b                   ->  5   (c)
+    //     column index in stage1*:             stage2Id[1][4] % (nBMOut * 2)   ->  1   (d)
+    //     column index in logProbs:            stage1Id[c][d]                  ->  4   (e)
+    //     pad for previous tokens:             b * nV                          -> 22   (f)
+    //     final output:                        e + f                           -> 26   output-stage2Id[1][4]
+    //
+    // clang-format on
+    int const a = blockIdx.x; // Index of request in batch
+    for (int j = threadIdx.x; j < nBMOut * 2; j += blockDim.x)
     {
-        int const index = pStage2Id[bid * nBM * 2 + j];
-        int const iBM = index / (nBM * 2);
-        int const jBM = index % (nBM * 2);
-        pStage2Id[bid * nBM * 2 + j] = pStage1Id[(bid * nBM + iBM) * (nBM * 2) + jBM] + iBM * nV;
+        int const index = a * (nBMOut * 2) + j;
+        int const stage2Id = pStage2Id[index];
+        int const b = stage2Id / (nBMOut * 2);
+        int const c = a * nBMIn + b;
+        int const d = stage2Id % (nBMOut * 2);
+        int const e = pStage1Id[c * (nBMOut * 2) + d];
+        int const f = b * nV;
+        pStage2Id[index] = e + f;
     }
     return;
 }
+
+void printBH(BeamHypotheses const& bh)
+{
+#if BEAM_SEARCH_DEBUG
+    cudaDeviceSynchronize();
+
+    printf("printBH ================================================================\n");
+    PRINT(bh.bReturnNormedScore);
+    PRINT(bh.bVBWS);
+    PRINT(bh.nMaxBatchSize);
+    PRINT(bh.nBatchSize);
+    PRINT(bh.nBeamWidth);
+    PRINT(bh.nBeamWidthIn);
+    PRINT(bh.nBeamWidthOut);
+    PRINT(bh.nMaxSeqLen);
+    PRINT(bh.nVocabSize);
+    PRINT(bh.nVPart);
+    PRINT(bh.nByteMaxSharedMemoryPerBlock);
+    PRINT(bh.nByteSharedMemoryStage1);
+    PRINT(bh.nByteSharedMemoryStage3);
+    size_t const mbs = bh.nMaxBatchSize;
+    size_t const nbs = bh.nBatchSize;
+    size_t const nbm = bh.nBeamWidth;
+    size_t const nbmo = bh.nBeamWidthOut;
+    size_t const msl = bh.nMaxSeqLen;
+
+    QH1(bh.diversityRates, nbs);
+    QH1(bh.lengthPenalties, nbs);
+    QH1(bh.earlyStoppings, nbs);
+    QH2(bh.beamWidthArraysHost, nbs * kMaxBeamWidthArrayLength, kMaxBeamWidthArrayLength);
+    QH2(bh.beamWidthArraysDevice, nbs * kMaxBeamWidthArrayLength, kMaxBeamWidthArrayLength);
+    QH1(bh.nBeamWidthInHost, nbs);
+    QH1(bh.nBeamWidthOutHost, nbs);
+    QH1(bh.nBeamWidthInDevice, nbs);
+    QH1(bh.nBeamWidthOutDevice, nbs);
+
+    QH1(bh.inputLengths, nbs * nbm);
+    QH1(bh.endIds, nbs);
+    QH1(bh.batchSlots, nbs);
+
+    QH2(bh.outputIds, nbs * nbm * msl, msl);
+    QH2(bh.logProbs, nbs * nbm * msl, msl);
+    QH2(bh.sequenceLengths, nbs * nbm, nbm);
+    QH2(bh.cumLogProbs, nbs * nbm, nbm);
+
+    QH2(bh.outputIdsCBA, mbs * nbmo * 2 * msl, msl);
+    QH2(bh.logProbsCBA, mbs * nbmo * 2 * msl, msl);
+    QH2(bh.sequenceLengthsCBA, mbs * nbmo * 2, nbmo * 2);
+    QH2(bh.cumLogProbsCBA, mbs * nbmo * 2, nbmo * 2);
+    QH2(bh.normedScoresCBA, mbs * nbmo * 2, nbmo * 2);
+    QH1(bh.numBeamsCBA, mbs);
+    QH1(bh.minNormedScoresCBA, mbs);
+
+    QH1(bh.batchDones, nbs);
+    uint8_t* finished = reinterpret_cast<uint8_t*>(bh.finished);
+    QH1(finished, nbs * nbm);
+
+    std::vector<runtime::SizeType32> batchSlots(nbs, 0);
+    cudaMemcpy(batchSlots.data(), bh.batchSlots, sizeof(runtime::SizeType32) * nbs, cudaMemcpyDeviceToHost);
+
+    std::vector<int*> outputIdsPtr(nbs, 0);
+    cudaMemcpy(outputIdsPtr.data(), bh.outputIdsPtr, sizeof(int*) * nbs, cudaMemcpyDeviceToHost);
+
+    std::vector<int*> parentIdsPtr(nbs, 0);
+    cudaMemcpy(parentIdsPtr.data(), bh.parentIdsPtr, sizeof(int*) * nbs, cudaMemcpyDeviceToHost);
+    cudaDeviceSynchronize();
+
+    for (int i = 0; i < nbs; ++i)
+    {
+        int slot = batchSlots[i];
+        printf("slot=%d\n", slot);
+        printf("outputIdsPtr[slot]=%p\n", outputIdsPtr[slot]);
+        QH2(outputIdsPtr[slot], nbm * msl, msl);
+    }
+    for (int i = 0; i < nbs; ++i)
+    {
+        int slot = batchSlots[i];
+        printf("slot=%d\n", slot);
+        printf("parentIdsPtr[slot]=%p\n", parentIdsPtr[slot]);
+        QH2(parentIdsPtr[slot], nbm * msl, msl);
+    }
+
+    // QH2(bh.outputIdsUnfinish, nbs * nbm * msl, msl);
+    // QH2(bh.parentIdsUnfinish, nbs * nbm * msl, msl);
+#endif
+}
+
+template <typename T>
+void printLogProbs(T const* x, int const nBS, int const nBMIn, int const nBM, int const nV)
+{
+    for (int bs = 0; bs < nBS; ++bs)
+    {
+        T const* ptrBatch = x + bs * nBM * nV;
+        printArrayInfo(ptrBatch, nBMIn * nV, std::string("Request ") + std::to_string(bs));
+        for (int bm = 0; bm < nBMIn; ++bm)
+        {
+            T const* ptrBeam = ptrBatch + bm * nV;
+            printArrayInfo(ptrBeam, nV, std::string("Beam ") + std::to_string(bm), true);
+        }
+    }
+}
+
+template void printLogProbs<float>(float const* x, int const nBS, int const nBMIn, int const nBM, int const nV);
+template void printLogProbs<half>(half const* x, int const nBS, int const nBMIn, int const nBM, int const nV);
 
 } // namespace kernels
 } // namespace tensorrt_llm

--- a/cpp/tensorrt_llm/kernels/beamSearchKernels.cu
+++ b/cpp/tensorrt_llm/kernels/beamSearchKernels.cu
@@ -258,36 +258,36 @@ void printBH(BeamHypotheses const& bh)
     size_t const nbmo = bh.nBeamWidthOut;
     size_t const msl = bh.nMaxSeqLen;
 
-    QH1(bh.diversityRates, nbs);
-    QH1(bh.lengthPenalties, nbs);
-    QH1(bh.earlyStoppings, nbs);
-    QH2(bh.beamWidthArraysHost, nbs * kMaxBeamWidthArrayLength, kMaxBeamWidthArrayLength);
-    QH2(bh.beamWidthArraysDevice, nbs * kMaxBeamWidthArrayLength, kMaxBeamWidthArrayLength);
-    QH1(bh.nBeamWidthInHost, nbs);
-    QH1(bh.nBeamWidthOutHost, nbs);
-    QH1(bh.nBeamWidthInDevice, nbs);
-    QH1(bh.nBeamWidthOutDevice, nbs);
+    PH2(bh.diversityRates, nbs);
+    PH2(bh.lengthPenalties, nbs);
+    PH2(bh.earlyStoppings, nbs);
+    PH3(bh.beamWidthArraysHost, nbs * kMaxBeamWidthArrayLength, kMaxBeamWidthArrayLength);
+    PH3(bh.beamWidthArraysDevice, nbs * kMaxBeamWidthArrayLength, kMaxBeamWidthArrayLength);
+    PH2(bh.nBeamWidthInHost, nbs);
+    PH2(bh.nBeamWidthOutHost, nbs);
+    PH2(bh.nBeamWidthInDevice, nbs);
+    PH2(bh.nBeamWidthOutDevice, nbs);
 
-    QH1(bh.inputLengths, nbs * nbm);
-    QH1(bh.endIds, nbs);
-    QH1(bh.batchSlots, nbs);
+    PH2(bh.inputLengths, nbs * nbm);
+    PH2(bh.endIds, nbs);
+    PH2(bh.batchSlots, nbs);
 
-    QH2(bh.outputIds, nbs * nbm * msl, msl);
-    QH2(bh.logProbs, nbs * nbm * msl, msl);
-    QH2(bh.sequenceLengths, nbs * nbm, nbm);
-    QH2(bh.cumLogProbs, nbs * nbm, nbm);
+    PH3(bh.outputIds, nbs * nbm * msl, msl);
+    PH3(bh.logProbs, nbs * nbm * msl, msl);
+    PH3(bh.sequenceLengths, nbs * nbm, nbm);
+    PH3(bh.cumLogProbs, nbs * nbm, nbm);
 
-    QH2(bh.outputIdsCBA, mbs * nbmo * 2 * msl, msl);
-    QH2(bh.logProbsCBA, mbs * nbmo * 2 * msl, msl);
-    QH2(bh.sequenceLengthsCBA, mbs * nbmo * 2, nbmo * 2);
-    QH2(bh.cumLogProbsCBA, mbs * nbmo * 2, nbmo * 2);
-    QH2(bh.normedScoresCBA, mbs * nbmo * 2, nbmo * 2);
-    QH1(bh.numBeamsCBA, mbs);
-    QH1(bh.minNormedScoresCBA, mbs);
+    PH3(bh.outputIdsCBA, mbs * nbmo * 2 * msl, msl);
+    PH3(bh.logProbsCBA, mbs * nbmo * 2 * msl, msl);
+    PH3(bh.sequenceLengthsCBA, mbs * nbmo * 2, nbmo * 2);
+    PH3(bh.cumLogProbsCBA, mbs * nbmo * 2, nbmo * 2);
+    PH3(bh.normedScoresCBA, mbs * nbmo * 2, nbmo * 2);
+    PH2(bh.numBeamsCBA, mbs);
+    PH2(bh.minNormedScoresCBA, mbs);
 
-    QH1(bh.batchDones, nbs);
+    PH2(bh.batchDones, nbs);
     uint8_t* finished = reinterpret_cast<uint8_t*>(bh.finished);
-    QH1(finished, nbs * nbm);
+    PH2(finished, nbs * nbm);
 
     std::vector<runtime::SizeType32> batchSlots(nbs, 0);
     cudaMemcpy(batchSlots.data(), bh.batchSlots, sizeof(runtime::SizeType32) * nbs, cudaMemcpyDeviceToHost);
@@ -304,18 +304,19 @@ void printBH(BeamHypotheses const& bh)
         int slot = batchSlots[i];
         printf("slot=%d\n", slot);
         printf("outputIdsPtr[slot]=%p\n", outputIdsPtr[slot]);
-        QH2(outputIdsPtr[slot], nbm * msl, msl);
+        PH3(outputIdsPtr[slot], nbm * msl, msl);
     }
     for (int i = 0; i < nbs; ++i)
     {
         int slot = batchSlots[i];
         printf("slot=%d\n", slot);
         printf("parentIdsPtr[slot]=%p\n", parentIdsPtr[slot]);
-        QH2(parentIdsPtr[slot], nbm * msl, msl);
+        PH3(parentIdsPtr[slot], nbm * msl, msl);
     }
 
-    // QH2(bh.outputIdsUnfinish, nbs * nbm * msl, msl);
-    // QH2(bh.parentIdsUnfinish, nbs * nbm * msl, msl);
+    // May not available in some context
+    // PH3(bh.outputIdsUnfinish, nbs * nbm * msl, msl);
+    // PH3(bh.parentIdsUnfinish, nbs * nbm * msl, msl);
 #endif
 }
 

--- a/cpp/tensorrt_llm/kernels/beamSearchKernels.h
+++ b/cpp/tensorrt_llm/kernels/beamSearchKernels.h
@@ -46,7 +46,7 @@ struct BeamHypotheses
     bool bVBWS{false};                      // whether to use VBWS for Beam-Search
     size_t nMaxBatchSize{0};                // Buildtime max batch size
     size_t nBatchSize{0};                   // Runtime batch size
-    size_t nBeamWidth{0};                   //
+    size_t nBeamWidth{0};                   // Runtime beam width
     size_t nBeamWidthIn{0};                 // Scalar value of current input beam width, for VBWS
     size_t nBeamWidthOut{0};                // Scalar value of current output beam width, for VBWS
     size_t nMaxSeqLen{0};                   //
@@ -153,11 +153,10 @@ void printLogProbs(float const* x, int const nBS, int const nBMIn, int const nBM
     {                                                                                                                  \
         printf(#x "=");                                                                                                \
         print_element_(x);                                                                                             \
-        printf("\n");                                                                                                  \
     }
 
-// Use only in host function
-#define QH(x, nRow, nCol, nColPadded)                                                                                  \
+// Host function
+#define PRINT_HOST(x, nRow, nCol, nColPadded)                                                                          \
     {                                                                                                                  \
         if (x == nullptr)                                                                                              \
         {                                                                                                              \
@@ -169,11 +168,11 @@ void printLogProbs(float const* x, int const nBS, int const nBMIn, int const nBM
             printMatrix(x, nRow, nCol, nColPadded);                                                                    \
         }                                                                                                              \
     }
-#define QH1(x, nCol) QH(x, 1, nCol, nCol)
-#define QH2(x, nElement, nCol) QH(x, ((nElement) / (nCol)), nCol, nCol)
+#define PH2(x, nCol) PRINT_HOST(x, 1, nCol, nCol)
+#define PH3(x, nElement, nCol) PRINT_HOST(x, ((nElement) / (nCol)), nCol, nCol)
 
-// Use only in device function
-#define QD(x, nRow, nCol, nColPadded)                                                                                  \
+// Device function
+#define PRINT_DEVICE(x, nRow, nCol, nColPadded)                                                                        \
     {                                                                                                                  \
         if (x == nullptr)                                                                                              \
         {                                                                                                              \
@@ -185,11 +184,11 @@ void printLogProbs(float const* x, int const nBS, int const nBMIn, int const nBM
             printMatrixDevice(x, nRow, nCol, nColPadded);                                                              \
         }                                                                                                              \
     }
-#define QD1(x, nCol) QD(x, 1, nCol, nCol)
-#define QD2(x, nElement, nCol) QD(x, ((nElement) / (nCol)), nCol, nCol)
+#define PD2(x, nCol) PRINT_DEVICE(x, 1, nCol, nCol)
+#define PD3(x, nElement, nCol) PRINT_DEVICE(x, ((nElement) / (nCol)), nCol, nCol)
 
-// Use only in device function
-#define GUARD(blockIdxx, bSync, code)                                                                                  \
+// Device function
+#define WITH(blockIdxx, bSync, code)                                                                                   \
     {                                                                                                                  \
         if (bSync)                                                                                                     \
         {                                                                                                              \
@@ -210,12 +209,12 @@ void printLogProbs(float const* x, int const nBS, int const nBMIn, int const nBM
 #define LINE(x)
 #define PRINT(x)
 #define QH(x, y, z, w)
-#define QH1(x, nCol)
-#define QH2(x, nElement, nCol)
-#define QD(x, y, z, w)
-#define QD1(x, nCol)
-#define QD2(x, nElement, nCol)
-#define GUARD(x, y, z)
+#define PH2(x, nCol)
+#define PH3(x, nElement, nCol)
+#define PRINT_DEVICE(x, y, z, w)
+#define PD2(x, nCol)
+#define PD3(x, nElement, nCol)
+#define WITH(x, y, z)
 #endif
 
 } // namespace kernels

--- a/cpp/tensorrt_llm/kernels/beamSearchKernels.h
+++ b/cpp/tensorrt_llm/kernels/beamSearchKernels.h
@@ -195,8 +195,8 @@ void printLogProbs(float const* x, int const nBS, int const nBMIn, int const nBM
         {                                                                                                              \
             __syncthreads();                                                                                           \
         }                                                                                                              \
-        if (true && blockIdx.x == (blockIdxx) && blockIdx.y == 0 && blockIdx.z == 0 && threadIdx.x == 0                \
-            && threadIdx.y == 0 && threadIdx.z == 0)                                                                   \
+        if (blockIdx.x == (blockIdxx) && blockIdx.y == 0 && blockIdx.z == 0 && threadIdx.x == 0 && threadIdx.y == 0    \
+            && threadIdx.z == 0)                                                                                       \
         {                                                                                                              \
             code                                                                                                       \
         }                                                                                                              \

--- a/cpp/tensorrt_llm/kernels/beamSearchKernels.h
+++ b/cpp/tensorrt_llm/kernels/beamSearchKernels.h
@@ -15,10 +15,12 @@
  */
 #pragma once
 
+#include "tensorrt_llm/common/cudaUtils.h"
 #include "tensorrt_llm/kernels/decodingCommon.h"
+#include "tensorrt_llm/kernels/topkLastDim.h" // Air TopK
 #include "tensorrt_llm/runtime/common.h"
 
-#include "tensorrt_llm/kernels/topkLastDim.h" // Air TopK
+#define BEAM_SEARCH_DEBUG 0
 
 namespace tensorrt_llm
 {
@@ -37,23 +39,33 @@ struct BeamHypotheses
     // %%: parameter name in file generation.py (python workflow)
     // Candidate beams: a beam which generates end_id or its sequence length reaches MSL
     // Candidate-Beam-Array (CBA): The arrays to place the candidate beams and related information
+    // Variable-Beam-Width-Search (VBWS): A search mode that allows using different beam width for each step
 
     // Scalar values
-    bool bReturnNormedScore{false};         // return `normedScore` or `cumLogProbs`, always be `false` now
-    size_t nMaxBatchSize{0};                // buildtime max batch size
-    size_t nBatchSize{0};                   // runtime batch size
+    bool bReturnNormedScore{false};         // Return `normedScore` or `cumLogProbs`, always be `false` now
+    bool bVBWS{false};                      // whether to use VBWS for Beam-Search
+    size_t nMaxBatchSize{0};                // Buildtime max batch size
+    size_t nBatchSize{0};                   // Runtime batch size
     size_t nBeamWidth{0};                   //
+    size_t nBeamWidthIn{0};                 // Scalar value of current input beam width, for VBWS
+    size_t nBeamWidthOut{0};                // Scalar value of current output beam width, for VBWS
     size_t nMaxSeqLen{0};                   //
-    size_t nVocabSize{0};                   // vocab_size_padded
+    size_t nVocabSize{0};                   // Vocab Size Padded
     size_t nVPart{0};                       // Count of vocab_size_padded divided
-    size_t nByteMaxSharedMemoryPerBlock{0};  // Device information
-    size_t nByteSharedMemoryStage1{0};       // Dynamic shared memory size of stage 1
-    size_t nByteSharedMemoryStage3{0};       // Static shared memory size of stage 3
+    size_t nByteMaxSharedMemoryPerBlock{0}; // Device information
+    size_t nByteSharedMemoryStage1{0};      // Dynamic shared memory size of stage 1
+    size_t nByteSharedMemoryStage3{0};      // Static shared memory size of stage 3
 
     // Pointers from SamplingConfig
     float const* diversityRates{nullptr};           // [BS]
     float const* lengthPenalties{nullptr};          // [BS]
     int const* earlyStoppings{nullptr};             // [BS]
+    int const* beamWidthArraysHost{nullptr};        // [BS, kMaxBeamWidthArrayLength]                           for VBWS
+    int const* beamWidthArraysDevice{nullptr};      // [BS, kMaxBeamWidthArrayLength]                           for VBWS
+    int* nBeamWidthInHost{nullptr};                 // [BS], cpu                                                for VBWS, beam width of last forward computation
+    int* nBeamWidthOutHost{nullptr};                // [BS], cpu                                                for VBWS, beam width of next forward computation
+    int* nBeamWidthInDevice{nullptr};               // [BS]                                                     for VBWS, beam width of last forward computation
+    int* nBeamWidthOutDevice{nullptr};              // [BS]                                                     for VBWS, beam width of next forward computation
 
     // Pointers from input
     int const* inputLengths{nullptr};               // [BS, BM]         %% context_length
@@ -79,7 +91,7 @@ struct BeamHypotheses
     // Pointers related to beam search process, they are initialized in those two functions:
     // [gptDecoder.cpp] GptDecoder<T>::forward or [dynamicDecodeOp.cpp] FtDynamicDecode<T>::forward
     bool* batchDones{nullptr};                      // [BS]             %% self.beam_hyps_is_done               whether a whole batch is finished
-    FinishedState* finished{nullptr};               // [BS*BM]          %% self.finished                        whether and how a beam is finished
+    FinishedState* finished{nullptr};               // [BS*BM], uint8   %% self.finished                        whether and how a beam is finished
 
     // Pointers for backtrack of the beams, they are relocated in [dynamicDecodeLayer.cpp] DynamicDecodeLayer<T>::prepareIdsPtrs
     int** outputIdsPtr{nullptr};                    // [BS][BM, MSL]    %% self.output_ids
@@ -116,13 +128,95 @@ __device__ __forceinline__ T applyLengthPenalty(T const log_prob, int const leng
 template <typename T, bool IS_V2>
 void invokeTopkBeamSearch(T const* logProbs, T const* bias, void* workspace, BeamHypotheses& bh, cudaStream_t stream);
 
+void invokeUpdateCacheIndirection(int* tgtCI, int const* srcCI, BeamHypotheses& bh,
+    runtime::SizeType32 const maxAttentionWindow, runtime::SizeType32 sinkTokenLength, cudaStream_t stream);
+
 template <typename T>
 __global__ void addCumLogProbs(T* __restrict pStage1Probs, float const* __restrict cumLogProbs,
     FinishedState const* finished, int const* endIds, float const* diversityRates,
-    runtime::SizeType32 const* batchSlots, size_t const nBS, size_t const nBM);
+    runtime::SizeType32 const* batchSlots, size_t const nBS, size_t const nBMIn, size_t const nBMOut, size_t const nBM);
 
-__global__ void gatherId(
-    int const* __restrict pStage1Id, int* __restrict pStage2Id, size_t const nBS, size_t const nBM, size_t const nV);
+__global__ void gatherId(int const* __restrict pStage1Id, int* __restrict pStage2Id, size_t const nBS,
+    size_t const nBMIn, size_t const nBMOut, size_t const nV);
+
+void printBH(BeamHypotheses const& bh);
+
+void printLogProbs(float const* x, int const nBS, int const nBMIn, int const nBM, int const nV);
+
+// for Beam Search debug
+#if BEAM_SEARCH_DEBUG
+#define BID 0
+
+#define LINE(x) printf(x "@L%d\n", __LINE__);
+
+#define PRINT(x)                                                                                                       \
+    {                                                                                                                  \
+        printf(#x "=");                                                                                                \
+        print_element_(x);                                                                                             \
+        printf("\n");                                                                                                  \
+    }
+
+// Use only in host function
+#define QH(x, nRow, nCol, nColPadded)                                                                                  \
+    {                                                                                                                  \
+        if (x == nullptr)                                                                                              \
+        {                                                                                                              \
+            printf(#x "=nullptr\n");                                                                                   \
+        }                                                                                                              \
+        else                                                                                                           \
+        {                                                                                                              \
+            printf(#x "=\n");                                                                                          \
+            printMatrix(x, nRow, nCol, nColPadded);                                                                    \
+        }                                                                                                              \
+    }
+#define QH1(x, nCol) QH(x, 1, nCol, nCol)
+#define QH2(x, nElement, nCol) QH(x, ((nElement) / (nCol)), nCol, nCol)
+
+// Use only in device function
+#define QD(x, nRow, nCol, nColPadded)                                                                                  \
+    {                                                                                                                  \
+        if (x == nullptr)                                                                                              \
+        {                                                                                                              \
+            printf(#x "=nullptr\n");                                                                                   \
+        }                                                                                                              \
+        else                                                                                                           \
+        {                                                                                                              \
+            printf(#x "=\n");                                                                                          \
+            printMatrixDevice(x, nRow, nCol, nColPadded);                                                              \
+        }                                                                                                              \
+    }
+#define QD1(x, nCol) QD(x, 1, nCol, nCol)
+#define QD2(x, nElement, nCol) QD(x, ((nElement) / (nCol)), nCol, nCol)
+
+// Use only in device function
+#define GUARD(blockIdxx, bSync, code)                                                                                  \
+    {                                                                                                                  \
+        if (bSync)                                                                                                     \
+        {                                                                                                              \
+            __syncthreads();                                                                                           \
+        }                                                                                                              \
+        if (true && blockIdx.x == (blockIdxx) && blockIdx.y == 0 && blockIdx.z == 0 && threadIdx.x == 0                \
+            && threadIdx.y == 0 && threadIdx.z == 0)                                                                   \
+        {                                                                                                              \
+            code                                                                                                       \
+        }                                                                                                              \
+        if (bSync)                                                                                                     \
+        {                                                                                                              \
+            __syncthreads();                                                                                           \
+        }                                                                                                              \
+    }
+
+#else
+#define LINE(x)
+#define PRINT(x)
+#define QH(x, y, z, w)
+#define QH1(x, nCol)
+#define QH2(x, nElement, nCol)
+#define QD(x, y, z, w)
+#define QD1(x, nCol)
+#define QD2(x, nElement, nCol)
+#define GUARD(x, y, z)
+#endif
 
 } // namespace kernels
 } // namespace tensorrt_llm

--- a/cpp/tensorrt_llm/kernels/beamSearchKernels/beamSearchKernelsTemplate.h
+++ b/cpp/tensorrt_llm/kernels/beamSearchKernels/beamSearchKernelsTemplate.h
@@ -600,7 +600,7 @@ void beamSearchKernelLauncher(
     //     + `nBM` is the max value of the beam width array, which is used for memory allocatation
     // Normal Beam Search:
     //     + `nBMIn` / `nBMOut` / `nBM` share the same value
-    // TODO (wili): now `nBMIn` and `nBMOut` of request 0 is used for the whole batch,
+    // TODO: now `nBMIn` and `nBMOut` of request 0 is used for the whole batch,
     //     change to corresponding BMs if Diverse-Beam-Width-Search is supported
     size_t const nBMIn = bh.bVBWS ? bh.nBeamWidthInHost[0] : nBM;
     size_t const nBMOut = bh.bVBWS ? bh.nBeamWidthOutHost[0] : nBM;

--- a/cpp/tensorrt_llm/kernels/beamSearchKernels/beamSearchKernelsTemplate.h
+++ b/cpp/tensorrt_llm/kernels/beamSearchKernels/beamSearchKernelsTemplate.h
@@ -194,6 +194,9 @@ __launch_bounds__(BLOCK_SIZE) __global__ void beamStage3Kernel(
     int const slot = bh.batchSlots[bid];
     size_t const nMBS{bh.nMaxBatchSize}; // Only for bh.logProbsTiled
     size_t const nBM{bh.nBeamWidth};
+    size_t const nBMIn{bh.bVBWS ? bh.nBeamWidthIn : bh.nBeamWidth};
+    size_t const nBMOut{bh.bVBWS ? bh.nBeamWidthOut : bh.nBeamWidth};
+    size_t const nMSL{bh.nMaxSeqLen};
     size_t const nV{bh.nVocabSize};
     float const diversityRate{bh.diversityRates[slot]};
     float const lengthPenalty{bh.lengthPenalties[slot]};
@@ -210,7 +213,7 @@ __launch_bounds__(BLOCK_SIZE) __global__ void beamStage3Kernel(
         if (bh.numBeamsCBA[slot] == 0 && tid == 0)
         {
             // Initialize worst score in the first call
-            bh.minNormedScoresCBA[slot] = FLT_MAX;
+            bh.minNormedScoresCBA[slot] = 0.0f; // logProbs is in range (-inf, 0]
         }
         else if (earlyStopping == 1 && bh.numBeamsCBA[slot] == nBM
             || earlyStopping != 1 && bh.finished[slot * nBM].isFinished())
@@ -224,11 +227,11 @@ __launch_bounds__(BLOCK_SIZE) __global__ void beamStage3Kernel(
         }
     }
 
-    // Skip this TopK in V2 workflow.
+    // This TopK is needless in V2 workflow
     if constexpr (IS_V2)
     {
-        pStage2Ids += bid * nBM * 2;
-        pStage2LogProbs += bid * nBM * 2;
+        pStage2Ids += bid * nBMOut * 2;
+        pStage2LogProbs += bid * nBMOut * 2;
     }
     else
     {
@@ -297,7 +300,7 @@ __launch_bounds__(BLOCK_SIZE) __global__ void beamStage3Kernel(
         // Select finished beams into CBA or select tokens for next step sequentially
         // Reference (might be changed along HF in the future):
         // https://github.com/huggingface/transformers/blob/main/src/transformers/generation/beam_search.py#L272
-        for (int i = 0; i < 2 * nBM; ++i)
+        for (int i = 0; i < 2 * nBMOut; ++i)
         {
             int topId;
             T topLogProb;
@@ -317,7 +320,7 @@ __launch_bounds__(BLOCK_SIZE) __global__ void beamStage3Kernel(
             bool const isEndToken = (topId % nV == bh.endIds[slot]);
             if (i < nBM && bh.numBeamsCBA != nullptr && isEndToken)
             {
-                // Condition of this branch
+                // Condition of this branch:
                 // This token is end-token and belongs to top nBM range in Beam search mode
                 int const nSeqLen = bh.sequenceLengths[slot * nBM + i] + 1 - bh.inputLengths[slot * nBM + i];
                 float const score = applyLengthPenalty(topLogProb, nSeqLen, lengthPenalty);
@@ -365,7 +368,7 @@ __launch_bounds__(BLOCK_SIZE) __global__ void beamStage3Kernel(
                 // The last token
                 int indexPrev = (topId / nV) % nBM;
                 int const step = bh.sequenceLengths[slot * nBM + indexPrev];
-                int const offsetCBA = (slot * nBM * 2 + nCBA) * bh.nMaxSeqLen;
+                int const offsetCBA = (slot * nBM * 2 + nCBA) * nMSL;
                 bh.outputIdsCBA[offsetCBA + step] = bh.endIds[slot];
                 if (bh.logProbsCBA != nullptr)
                 {
@@ -374,8 +377,8 @@ __launch_bounds__(BLOCK_SIZE) __global__ void beamStage3Kernel(
                 // Previous tokens
                 for (int j = step - 1; j >= 0; j--)
                 {
-                    bh.outputIdsCBA[offsetCBA + j] = bh.outputIdsPtr[slot][indexPrev * bh.nMaxSeqLen + j];
-                    indexPrev = bh.parentIdsPtr[slot][indexPrev * bh.nMaxSeqLen + j];
+                    bh.outputIdsCBA[offsetCBA + j] = bh.outputIdsPtr[slot][indexPrev * nMSL + j];
+                    indexPrev = bh.parentIdsPtr[slot][indexPrev * nMSL + j];
                 }
                 if (bh.logProbsCBA != nullptr && bh.logProbsTiled != nullptr)
                 {
@@ -384,7 +387,7 @@ __launch_bounds__(BLOCK_SIZE) __global__ void beamStage3Kernel(
                     {
                         int const index = (j * nMBS + slot) * nBM + indexPrev;
                         bh.logProbsCBA[offsetCBA + j] = bh.logProbsTiled[index];
-                        indexPrev = bh.parentIdsPtr[slot][indexPrev * bh.nMaxSeqLen + j];
+                        indexPrev = bh.parentIdsPtr[slot][indexPrev * nMSL + j];
                     }
                 }
                 // Other parameters
@@ -403,7 +406,7 @@ __launch_bounds__(BLOCK_SIZE) __global__ void beamStage3Kernel(
                 // 3. bh.numBeamsCBA != nullptr && i >= nBM && isEndToken == false, i.e., add token at the end
                 int const step = bh.sequenceLengths[slot * nBM + nBeamForNextStep];
                 // Copy the selected token to work tree
-                bh.outputIdsPtr[slot][nBeamForNextStep * bh.nMaxSeqLen + step] = topId;
+                bh.outputIdsPtr[slot][nBeamForNextStep * nMSL + step] = topId;
                 if (bh.logProbsTiled != nullptr)
                 {
                     int const index = step * nMBS * nBM + slot * nBM + nBeamForNextStep;
@@ -420,7 +423,7 @@ __launch_bounds__(BLOCK_SIZE) __global__ void beamStage3Kernel(
                 // 2. bh.numBeamsCBA != nullptr && i >= nBM && isEndToken == true, i.e., ignore the worse beams
             }
 
-            if (nBeamForNextStep >= nBM)
+            if (nBeamForNextStep >= nBMOut)
             {
                 // Condition of this branch
                 // 1. In EarlyStopping mode, and get enough candidate beams
@@ -457,7 +460,7 @@ __launch_bounds__(BLOCK_SIZE) __global__ void beamStage3Kernel(
             if (earlyStopping != 0 && lengthPenalty > 0.0f)
             {
                 // Specialization for earlyStopping == "never" and lengthPenalty > 0 in HF
-                nSeqLen = bh.nMaxSeqLen - bh.inputLengths[slot * nBM];
+                nSeqLen = nMSL - bh.inputLengths[slot * nBM];
             }
             float const bestAttainableScore = applyLengthPenalty(bestCumLogProbs, nSeqLen, lengthPenalty);
             bh.batchDones[slot] = bh.minNormedScoresCBA[slot] >= bestAttainableScore;
@@ -472,7 +475,7 @@ __launch_bounds__(BLOCK_SIZE) __global__ void beamStage3Kernel(
     }
     __syncthreads();
 
-    if (tid < nBM)
+    if (tid < nBMIn)
     {
         int const indexBatchBeam = slot * nBM + tid;
         int const step = smemSeqLen[tid];
@@ -480,7 +483,7 @@ __launch_bounds__(BLOCK_SIZE) __global__ void beamStage3Kernel(
         {
             smemSeqLen[tid]++;
         }
-        int const newId = bh.outputIdsPtr[slot][tid * bh.nMaxSeqLen + step];
+        int const newId = bh.outputIdsPtr[slot][tid * nMSL + step];
         int const newBeamId = (newId / nV) % nBM;
         int const newTokenId = newId % nV;
         bh.sequenceLengths[indexBatchBeam] = smemSeqLen[newBeamId];
@@ -488,8 +491,8 @@ __launch_bounds__(BLOCK_SIZE) __global__ void beamStage3Kernel(
         {
             bh.finished[indexBatchBeam].setFinishedEOS();
         }
-        bh.parentIdsPtr[slot][tid * bh.nMaxSeqLen + step] = newBeamId;
-        bh.outputIdsPtr[slot][tid * bh.nMaxSeqLen + step] = newTokenId;
+        bh.parentIdsPtr[slot][tid * nMSL + step] = newBeamId;
+        bh.outputIdsPtr[slot][tid * nMSL + step] = newTokenId;
 
         if ((earlyStopping == 1) && (bh.numBeamsCBA != nullptr && bh.numBeamsCBA[slot] == nBM)
             || (earlyStopping != 1) && bh.batchDones[slot])
@@ -500,31 +503,19 @@ __launch_bounds__(BLOCK_SIZE) __global__ void beamStage3Kernel(
     }
 }
 
-#define BEAM_STAGE2_KERNEL(N_VOCAB_PART, IS_FAST)                                                                      \
-    {                                                                                                                  \
-        if (IS_FAST && nByteRuntimeSharedMemory > (48 << 10))                                                          \
-        {                                                                                                              \
-            TLLM_CUDA_CHECK(cudaFuncSetAttribute(beamStage2Kernel<T, PBM, N_VOCAB_PART, IS_FAST>,                      \
-                cudaFuncAttributeMaxDynamicSharedMemorySize, nByteRuntimeSharedMemory));                               \
-        }                                                                                                              \
-        beamStage2Kernel<T, PBM, N_VOCAB_PART, IS_FAST>                                                                \
-            <<<dim3(nBS, nBM), N_VOCAB_PART, IS_FAST * nByteRuntimeSharedMemory, stream>>>(                            \
-                pStage2Ids, pStage2LogProbs, pStage3, bh.cumLogProbs, bh.batchSlots, nV, nVPart);                      \
-    }
-
 template <typename T, int PBM, bool IS_V2>
 void beamSearchKernelLauncher(
     T const* logProbs, T const* bias, void* workspace, BeamHypotheses& bh, cudaStream_t stream)
 {
     // clang-format off
-
-    /* V1 Workflow (reference: https://github.com/NVIDIA/online-softmax):
+    /*
+    V1 Workflow (reference: https://github.com/NVIDIA/online-softmax):
     logProbs.shape = [nBS, nBM, nV]
-             nV               |<- nVChunk ->|<- nVChunk ->| <- ... ->|          |<- nBM*4 ->|<- nBM*4 ->|<- ... ->|*
+             nV               |<- nVChunk ->|<- nVChunk ->| <- ... ->|          |<- nBM*4 ->|<- nBM*4 ->|<- ... ->| ■
         ┏━━━━━━━━━━┓          ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓          ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
         ┃nBM       ┃          ┃nBM                                   ┃          ┃nBM                              ┃
-        ┣━━━━━━━━━━┫          ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫  A       ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
-    nBS ┃nBM       ┃ ---> nBS ┃nBM                                   ┃ ---> nBS ┃nBM                              ┃
+        ┣━━━━━━━━━━┫          ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫  A       ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫  B
+    nBS ┃nBM       ┃ ---> nBS ┃nBM                                   ┃ ---> nBS ┃nBM                              ┃ --->
         ┣━━━━━━━━━━┫          ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫          ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
         ┃nBM       ┃          ┃nBM                                   ┃          ┃nBM                              ┃
         ┗━━━━━━━━━━┛          ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛          ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
@@ -540,7 +531,7 @@ void beamSearchKernelLauncher(
              ┗━━━━━━━━━━━┛  ┗━━━━━━━━━━━┛
                pStage2Ids  pStage2LogProbs
 
-    *: Each "tile" in pStage3 with shape [`nBM*4`] contains `nBM*2` top ids and corresponding `nBM*2` log probs.
+    ■: Each "tile" in pStage3 with shape [`nBM*4`] contains `nBM*2` top ids and corresponding `nBM*2` log probs.
         |<- nBm*2 ->|<- nBm*2 ->|
         ┏━━━━━━━━━━━━━━━━━━━━━━━┓
       1 ┃  top ids  | log probs ┃
@@ -568,7 +559,7 @@ void beamSearchKernelLauncher(
         ┣━━━━━━━━┫          ┣━━━━━━━━━━━┫  ┣━━━━━━━━━━━┫          ┣━━━━━━━━━━━┫          ┏━━━━━━━━━━━┓                           |
         ┃nBM     ┃          ┃nBM        ┃  ┃nBM        ┃          ┃nBM        ┃      nBS ┃           ┃ --------------------------/
         ┗━━━━━━━━┛          ┗━━━━━━━━━━━┛  ┗━━━━━━━━━━━┛          ┗━━━━━━━━━━━┛          ┗━━━━━━━━━━━┛
-         logProbs             pStage1Id     pStage1Probs           pStage1Probs           pStage2Probs
+         logProbs             pStage1Id   pStage1LogProbs        pStage1LogProbs        pStage2LogProbs
 
     A: TopK            : Get top `nBM*2` elements in `nBS*nBM` groups (`nV` elements per group)
     B: addCumLogProbs  : Add `cumLogProbs` to the elements in each beam
@@ -578,8 +569,21 @@ void beamSearchKernelLauncher(
                              + moves one beam into candidate-beam-array if it is finished (gemerated end_id in this step).
                              + selects BM elements for the next generation step if not.
                              + maintains related score array, min_normed_score / batchDones / finished, etc..
-    */
 
+    ===================================================================================================================================
+
+    V2 Workflow for VBWS, similar to V2 workflow above, but `nBMIn` and `nBMOut` might be different from `nBM`
+    logProbs.shape = [nBS, nBMIn, nV]
+        |<- nV ->|          |<- nBMOut*2 ->|  |<- nBMOut*2 ->|          |<- nBMOut*2 ->|          |<- nBMOut*2 ->|          |<- nBMOut*2 ->|
+        ┏━━━━━━━━┓          ┏━━━━━━━━━━━━━━┓  ┏━━━━━━━━━━━━━━┓          ┏━━━━━━━━━━━━━━┓          ┏━━━━━━━━━━━━━━┓  D       ┏━━━━━━━━━━━━━━┓
+        ┃nBMIn   ┃          ┃nBMIn         ┃  ┃nBMIn         ┃          ┃nBMIn         ┃      nBS ┃              ┃ ---> nBS ┃              ┃ ---\
+        ┣━━━━━━━━┫  A       ┣━━━━━━━━━━━━━━┫  ┣━━━━━━━━━━━━━━┫  B       ┣━━━━━━━━━━━━━━┫  C       ┗━━━━━━━━━━━━━━┛          ┗━━━━━━━━━━━━━━┛    | E
+    nBS ┃nBMIn   ┃ ---> nBS ┃nBMIn         ┃  ┃nBMIn         ┃ ---> nBS ┃nBMIn         ┃ --->         pStage2Id                 pStage2Id       |--->
+        ┣━━━━━━━━┫          ┣━━━━━━━━━━━━━━┫  ┣━━━━━━━━━━━━━━┫          ┣━━━━━━━━━━━━━━┫          ┏━━━━━━━━━━━━━━┓                              |
+        ┃nBMIn   ┃          ┃nBMIn         ┃  ┃nBMIn         ┃          ┃nBMIn         ┃      nBS ┃              ┃ -----------------------------/
+        ┗━━━━━━━━┛          ┗━━━━━━━━━━━━━━┛  ┗━━━━━━━━━━━━━━┛          ┗━━━━━━━━━━━━━━┛          ┗━━━━━━━━━━━━━━┛
+         logProbs               pStage1Id      pStage1LogProbs           pStage1LogProbs           pStage2LogProbs
+    */
     // clang-format on
 
     size_t const nBS{bh.nBatchSize};
@@ -591,12 +595,23 @@ void beamSearchKernelLauncher(
     T* pStage2LogProbs{nullptr};
     float* pStage3{nullptr};
 
+    // VBWS:
+    //     + `nBMIn` / `nBMOut` is the beam width in the last / next network forward computation respectively
+    //     + `nBM` is the max value of the beam width array, which is used for memory allocatation
+    // Normal Beam Search:
+    //     + `nBMIn` / `nBMOut` / `nBM` share the same value
+    // TODO (wili): now `nBMIn` and `nBMOut` of request 0 is used for the whole batch,
+    //     change to corresponding BMs if Diverse-Beam-Width-Search is supported
+    size_t const nBMIn = bh.bVBWS ? bh.nBeamWidthInHost[0] : nBM;
+    size_t const nBMOut = bh.bVBWS ? bh.nBeamWidthOutHost[0] : nBM;
+    bh.nBeamWidthIn = nBMIn;   // Save nBMIn back to bh
+    bh.nBeamWidthOut = nBMOut; // Save nBMOut back to bh
+
     if constexpr (IS_V2)
     {
         // see `BeamSearchLayer<T>::configureBeamSearchLayer()` for the workspace structure
         size_t const offsetStage1 = roundUp(nBS * nBM * nBM * 2, 4);
         size_t const offsetStage2 = roundUp(nBS * nBM * 2, 4);
-
         pStage2Ids = reinterpret_cast<int*>(workspace);
         int offset = sizeof(int) * offsetStage2;
         pStage2LogProbs = reinterpret_cast<T*>(reinterpret_cast<char*>(workspace) + offset);
@@ -609,21 +624,21 @@ void beamSearchKernelLauncher(
         void* pTopK = reinterpret_cast<void*>(reinterpret_cast<char*>(workspace) + offset);
 
         // Stage 1
-        invokeTopkLastDim<T>(nBS * nBM, nV, nBM * 2, true, logProbs, pStage1LogProbs, pStage1Ids, pTopK, stream);
+        invokeTopkLastDim<T>(nBS * nBMIn, nV, nBMOut * 2, true, logProbs, pStage1LogProbs, pStage1Ids, pTopK, stream);
         sync_check_cuda_error(stream);
 
-        int nThread = min(roundUp(nBM * nBM * 2, 32), 1024);
-        addCumLogProbs<<<nBS, nThread, 0, stream>>>(
-            pStage1LogProbs, bh.cumLogProbs, bh.finished, bh.endIds, bh.diversityRates, bh.batchSlots, nBS, nBM);
+        int nThread = min(roundUp(nBMIn * nBMOut * 2, 32), 1024);
+        addCumLogProbs<<<nBS, nThread, 0, stream>>>(pStage1LogProbs, bh.cumLogProbs, bh.finished, bh.endIds,
+            bh.diversityRates, bh.batchSlots, nBS, nBMIn, nBMOut, nBM);
         sync_check_cuda_error(stream);
 
         // Stage 2
         invokeTopkLastDim<T>(
-            nBS, nBM * nBM * 2, nBM * 2, true, pStage1LogProbs, pStage2LogProbs, pStage2Ids, pTopK, stream);
+            nBS, nBMIn * nBMOut * 2, nBMOut * 2, true, pStage1LogProbs, pStage2LogProbs, pStage2Ids, pTopK, stream);
         sync_check_cuda_error(stream);
 
-        nThread = min(roundUp(nBM * 2, 32), 1024);
-        gatherId<<<nBS, nThread, 0, stream>>>(pStage1Ids, pStage2Ids, nBS, nBM, nV);
+        nThread = min(roundUp(nBMOut * 2, 32), 1024);
+        gatherId<<<nBS, nThread, 0, stream>>>(pStage1Ids, pStage2Ids, nBS, nBMIn, nBMOut, nV);
         sync_check_cuda_error(stream);
     }
     else // V1
@@ -636,12 +651,23 @@ void beamSearchKernelLauncher(
 
         // Stage 1
         size_t constexpr nThreadStage1 = (PBM < 16) ? ((PBM < 8) ? kThreadForSmallBeamWidth : 128) : 64;
-        dim3 grid(nBS, nBM, bh.nVPart);
-        beamStage1Kernel<T, PBM, nThreadStage1><<<grid, nThreadStage1, bh.nByteSharedMemoryStage1, stream>>>(
+        dim3 grid(nBS, nBM, bh.nVPart), block(nThreadStage1);
+        beamStage1Kernel<T, PBM, nThreadStage1><<<grid, block, bh.nByteSharedMemoryStage1, stream>>>(
             logProbs, bias, pStage3, bh.endIds, bh.finished, nV, bh.batchSlots);
         sync_check_cuda_error(stream);
 
-        // Stage 2
+// Stage 2
+#define BEAM_STAGE2_KERNEL(N_VOCAB_PART, IS_FAST)                                                                      \
+    {                                                                                                                  \
+        if (IS_FAST && nByteRuntimeSharedMemory > (48 << 10))                                                          \
+        {                                                                                                              \
+            TLLM_CUDA_CHECK(cudaFuncSetAttribute(beamStage2Kernel<T, PBM, N_VOCAB_PART, IS_FAST>,                      \
+                cudaFuncAttributeMaxDynamicSharedMemorySize, nByteRuntimeSharedMemory));                               \
+        }                                                                                                              \
+        beamStage2Kernel<T, PBM, N_VOCAB_PART, IS_FAST>                                                                \
+            <<<dim3(nBS, nBM), N_VOCAB_PART, IS_FAST * nByteRuntimeSharedMemory, stream>>>(                            \
+                pStage2Ids, pStage2LogProbs, pStage3, bh.cumLogProbs, bh.batchSlots, nV, nVPart);                      \
+    }
         // TODO: rewrite kernel to remove dependence of constant block size to reduce compilation time
         size_t nByteRuntimeSharedMemory
             = sizeof(float) * nVPart * (PBM * 4) + sizeof(cub::KeyValuePair<int, T>) * PBM * 2;
@@ -664,6 +690,7 @@ void beamSearchKernelLauncher(
             BEAM_STAGE2_KERNEL(128, false)
         }
         sync_check_cuda_error(stream);
+#undef BEAM_STAGE2_KERNEL
     }
 
     // Stage 3 in common
@@ -671,6 +698,7 @@ void beamSearchKernelLauncher(
     size_t const nByteStaticSharedMemory = bh.nByteSharedMemoryStage3;
     size_t const nByteDynamicSharedMemory = (IS_V2) ? 0 : sizeof(T) * nBM * nBM * 2;
     size_t const nByteRuntimeSharedMemory = nByteStaticSharedMemory + nByteDynamicSharedMemory;
+
     if (nByteRuntimeSharedMemory <= nByteMaxSharedMemoryPerBlock)
     {
         if (nByteRuntimeSharedMemory > (48 << 10))
@@ -692,6 +720,8 @@ void beamSearchKernelLauncher(
             <<<nBS, nThreadStage3, 0, stream>>>(pStage2Ids, pStage2LogProbs, pStage3, bh);
     }
     sync_check_cuda_error(stream);
+
+    return;
 }
 
 #undef BEAM_STAGE2_KERNEL

--- a/cpp/tensorrt_llm/layers/beamSearchLayer.cu
+++ b/cpp/tensorrt_llm/layers/beamSearchLayer.cu
@@ -93,7 +93,8 @@ void BeamSearchLayer<T>::allocateBuffer()
 
     SizeType32 const nBS{mDecoderDomain.getBatchSize()};
     auto const batchSizeShape = ITensor::makeShape({nBS});
-    auto const batchSizeXBeamWidthArraySizeShape = ITensor::makeShape({nBS * (runtime::SizeType32) kMaxBeamWidthArrayLength});
+    auto const batchSizeXBeamWidthArraySizeShape
+        = ITensor::makeShape({nBS * (runtime::SizeType32) kMaxBeamWidthArrayLength});
 
     mBeamSearchDiversityRateHost = mBufferManager->pinnedPool(batchSizeShape, TRTDataType<float>::value);
     mBeamSearchDiversityRateDevice = mBufferManager->gpu(batchSizeShape, TRTDataType<float>::value);

--- a/cpp/tensorrt_llm/layers/beamSearchLayer.cu
+++ b/cpp/tensorrt_llm/layers/beamSearchLayer.cu
@@ -32,10 +32,10 @@ namespace tensorrt_llm::layers
 
 #define GET_INFO_STAGE1(nPBM)                                                                                          \
     {                                                                                                                  \
-        int constexpr nBlock = (nPBM < 16) ? ((nPBM < 8) ? kThreadForSmallBeamWidth : 128) : 64;                       \
+        int constexpr nBlock = ((nPBM) < 16) ? (((nPBM) < 8) ? kThreadForSmallBeamWidth : 128) : 64;                   \
         TLLM_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(                                                 \
-            &nMaxActiveBlock, beamStage1Kernel<T, 2 * nPBM, nBlock>, nBlock, 0));                                      \
-        TLLM_CUDA_CHECK(cudaFuncGetAttributes(&attr, beamStage1Kernel<T, 2 * nPBM, nBlock>));                          \
+            &nMaxActiveBlock, beamStage1Kernel<T, 2 * (nPBM), nBlock>, nBlock, 0));                                    \
+        TLLM_CUDA_CHECK(cudaFuncGetAttributes(&attr, beamStage1Kernel<T, 2 * (nPBM), nBlock>));                        \
         break;                                                                                                         \
     }
 
@@ -43,27 +43,27 @@ namespace tensorrt_llm::layers
     {                                                                                                                  \
         if (nByteDynamicSharedMemoryStage2 > nByteMaxSharedMemoryPerBlock)                                             \
         {                                                                                                              \
-            TLLM_CUDA_CHECK(cudaFuncGetAttributes(&attr, beamStage2Kernel<T, nPBM, 128, false>));                      \
+            TLLM_CUDA_CHECK(cudaFuncGetAttributes(&attr, beamStage2Kernel<T, (nPBM), 128, false>));                    \
         }                                                                                                              \
         else if (nVPart <= 32)                                                                                         \
         {                                                                                                              \
-            TLLM_CUDA_CHECK(cudaFuncGetAttributes(&attr, beamStage2Kernel<T, nPBM, 32, true>));                        \
+            TLLM_CUDA_CHECK(cudaFuncGetAttributes(&attr, beamStage2Kernel<T, (nPBM), 32, true>));                      \
         }                                                                                                              \
         else if (nVPart <= 64)                                                                                         \
         {                                                                                                              \
-            TLLM_CUDA_CHECK(cudaFuncGetAttributes(&attr, beamStage2Kernel<T, nPBM, 64, true>));                        \
+            TLLM_CUDA_CHECK(cudaFuncGetAttributes(&attr, beamStage2Kernel<T, (nPBM), 64, true>));                      \
         }                                                                                                              \
         else                                                                                                           \
         {                                                                                                              \
-            TLLM_CUDA_CHECK(cudaFuncGetAttributes(&attr, beamStage2Kernel<T, nPBM, 128, true>));                       \
+            TLLM_CUDA_CHECK(cudaFuncGetAttributes(&attr, beamStage2Kernel<T, (nPBM), 128, true>));                     \
         }                                                                                                              \
         break;                                                                                                         \
     }
 
 #define GET_INFO_STAGE3(nPBM, bV2)                                                                                     \
     {                                                                                                                  \
-        int constexpr nThreadStage3 = (nPBM + 31) / 32 * 32;                                                           \
-        TLLM_CUDA_CHECK(cudaFuncGetAttributes(&attr, beamStage3Kernel<T, nPBM, nThreadStage3, true, bV2>));            \
+        int constexpr nThreadStage3 = ((nPBM) + 31) / 32 * 32;                                                         \
+        TLLM_CUDA_CHECK(cudaFuncGetAttributes(&attr, beamStage3Kernel<T, (nPBM), nThreadStage3, true, bV2>));          \
         break;                                                                                                         \
     }
 
@@ -78,6 +78,7 @@ BeamSearchLayer<T>::BeamSearchLayer(DecoderDomain const& decoderDomain, std::sha
     SizeType32 const nV{mDecoderDomain.getVocabSize()};
     TLLM_CHECK_WITH_INFO(nBM <= kMaxBeamWidth, "Beam width is larger than the maximum supported (%d > %d)", int(nBM),
         int(kMaxBeamWidth));
+    this->mVBWS = decoderDomain.getUseVariableBeamWidthSearch();
 
     allocateBuffer();
     configureBeamSearchLayer();
@@ -90,13 +91,24 @@ void BeamSearchLayer<T>::allocateBuffer()
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
 
-    auto const batchSizeShape = ITensor::makeShape({mDecoderDomain.getBatchSize()});
+    SizeType32 const nBS{mDecoderDomain.getBatchSize()};
+    auto const batchSizeShape = ITensor::makeShape({nBS});
+    auto const batchSizeXBeamWidthArraySizeShape = ITensor::makeShape({nBS * (runtime::SizeType32) kMaxBeamWidthArrayLength});
+
     mBeamSearchDiversityRateHost = mBufferManager->pinnedPool(batchSizeShape, TRTDataType<float>::value);
-    mLengthPenaltyHost = mBufferManager->pinnedPool(batchSizeShape, TRTDataType<float>::value);
-    mEarlyStoppingHost = mBufferManager->pinnedPool(batchSizeShape, TRTDataType<int>::value);
     mBeamSearchDiversityRateDevice = mBufferManager->gpu(batchSizeShape, TRTDataType<float>::value);
+
+    mLengthPenaltyHost = mBufferManager->pinnedPool(batchSizeShape, TRTDataType<float>::value);
     mLengthPenaltyDevice = mBufferManager->gpu(batchSizeShape, TRTDataType<float>::value);
+
+    mEarlyStoppingHost = mBufferManager->pinnedPool(batchSizeShape, TRTDataType<int>::value);
     mEarlyStoppingDevice = mBufferManager->gpu(batchSizeShape, TRTDataType<int>::value);
+
+    mBeamWidthArrayHost = mBufferManager->pinnedPool(batchSizeXBeamWidthArraySizeShape, TRTDataType<int>::value);
+    mBeamWidthArrayDevice = mBufferManager->gpu(batchSizeXBeamWidthArraySizeShape, TRTDataType<int>::value);
+
+    mBeamWidthIn = mBufferManager->pinnedPool(batchSizeShape, TRTDataType<int>::value);
+    mBeamWidthOut = mBufferManager->pinnedPool(batchSizeShape, TRTDataType<int>::value);
 
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
 }
@@ -112,18 +124,15 @@ void BeamSearchLayer<T>::configureBeamSearchLayer()
     SizeType32 const nPBM{padToNextPowerOfTwo(nBM)}; // Padded Beam Width
     cudaFuncAttributes attr;
 
-    // Find the max smem on the device and use that to determine the vocab parts in the best case.
-    int nByteMaxSharedMemoryPerSM = -1, nByteMaxSharedMemoryPerBlock = -1;
-    int const device = tensorrt_llm::common::getDevice();
-    TLLM_CUDA_CHECK(
-        cudaDeviceGetAttribute(&nByteMaxSharedMemoryPerSM, cudaDevAttrMaxSharedMemoryPerMultiprocessor, device));
-    TLLM_CUDA_CHECK(
-        cudaDeviceGetAttribute(&nByteMaxSharedMemoryPerBlock, cudaDevAttrMaxSharedMemoryPerBlockOptin, device));
-    this->mByteMaxSharedMemoryPerBlock = nByteMaxSharedMemoryPerBlock;
+    // Find device information to determine `nVPart`.
+    int const nByteMaxSharedMemoryPerSM = getMaxSharedMemoryPerSM();
+    int const nByteMaxSharedMemoryPerBlock = getMaxSharedMemoryPerBlockOptin();
     int const nByteReservedSharedMemoryPerBlock = nByteMaxSharedMemoryPerSM - nByteMaxSharedMemoryPerBlock;
+    this->mByteMaxSharedMemoryPerBlock = nByteMaxSharedMemoryPerBlock;
 
-    if (nBM <= kMaxBeamWidthForV1) // Use V1 kernels for small beam width
+    if (nBM <= kMaxBeamWidthForV1 && !(this->mVBWS))
     {
+        // V1 workflow for small beam width and non-VBWS
         // Stage 1
         int nMaxActiveBlock = -1;
         switch (nPBM)
@@ -204,8 +213,9 @@ void BeamSearchLayer<T>::configureBeamSearchLayer()
         size_t const nByteD = (bUseGlobalMemoryStage3) ? nByteDynamicSharedMemoryStage3 : 0;
         this->mWorkspaceSize = nByteA + std::max(nByteB + nByteC, nByteD);
     }
-    else // Use V2 kernels for large beam width
+    else
     {
+        // V2 workflow for large beam width or VBWS
         this->mV2 = true;
         switch (nPBM)
         {
@@ -232,7 +242,7 @@ void BeamSearchLayer<T>::configureBeamSearchLayer()
         SizeType32 const nBS{mDecoderDomain.getBatchSize()};
         SizeType32 const nBM{mDecoderDomain.getBeamWidth()};
         SizeType32 const nV{mDecoderDomain.getVocabSize()};
-        SizeType32 const nPBM = padToNextPowerOfTwo(nBM);
+        SizeType32 const nPBM{padToNextPowerOfTwo(nBM)};
         size_t const nByteStage1LogProbs = roundUp(sizeof(T) * nBS * nPBM * nPBM * 2, 4);
         size_t const nByteStage1Ids = roundUp(sizeof(int) * nBS * nPBM * nPBM * 2, 4);
         size_t const nByteStage2LogProbs = roundUp(sizeof(T) * nBS * nPBM * 2, 4);
@@ -265,10 +275,10 @@ void BeamSearchLayer<T>::setup(SizeType32 const batchSize, SizeType32 const beam
         beamWidth <= nBM, "Beam width is larger than the constructed for (%d > %d).", int(beamWidth), int(nBM));
 
     auto setupParams = std::dynamic_pointer_cast<BeamSearchSetupParams>(baseSetupParams);
-
     auto constexpr fltMax = std::numeric_limits<float>::max();
     auto constexpr fltMin = std::numeric_limits<float>::lowest();
     auto constexpr fltEpsilon = std::numeric_limits<float>::epsilon();
+    auto constexpr int32Max = std::numeric_limits<int32_t>::max();
     FillBuffers const fillBuffers{batchSize, mDecoderDomain.getBatchSize(), mBufferManager};
     fillBuffers(setupParams->beamSearchDiversityRate, DefaultDecodingParams::getBeamSearchDiversity(),
         mBeamSearchDiversityRateHost, mBeamSearchDiversityRateDevice, batchSlots, std::make_pair(-fltEpsilon, fltMax),
@@ -276,42 +286,11 @@ void BeamSearchLayer<T>::setup(SizeType32 const batchSize, SizeType32 const beam
     fillBuffers(setupParams->lengthPenalty, DefaultDecodingParams::getLengthPenalty(), mLengthPenaltyHost,
         mLengthPenaltyDevice, batchSlots, std::make_pair(fltMin, fltMax), "length penalty");
     fillBuffers(setupParams->earlyStopping, DefaultDecodingParams::getEarlyStopping(), mEarlyStoppingHost,
-        mEarlyStoppingDevice, batchSlots, std::make_pair(-fltEpsilon, std::numeric_limits<int>::max()),
-        "early stopping");
+        mEarlyStoppingDevice, batchSlots, std::make_pair(-fltEpsilon, int32Max), "early stopping");
+    fillBuffers(setupParams->beamWidthArray, DefaultDecodingParams::getBeamWidthArray(), mBeamWidthArrayHost,
+        mBeamWidthArrayDevice, batchSlots, std::make_pair(-fltEpsilon, int32Max), "beam width array");
 
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
-}
-
-__global__ void updateCacheIndirectionKernel(
-    int* tgtCI, int const* srcCI, BeamHypotheses bh, int const nMaxAttentionWindow, int const nSinkTokenLength)
-{
-    // Update indirections from steps `bh.inputLength[indexBatchBeam]` to step `sequenceLengths[indexBatchBeam]`
-    int const step = threadIdx.x + blockIdx.x * blockDim.x;
-    size_t const nBM{bh.nBeamWidth};
-    size_t const nMSL{bh.nMaxSeqLen};
-    int const indexBatch = blockIdx.y;
-    int const batchSlot = bh.batchSlots[indexBatch];
-    int const indexBeam = blockIdx.z;
-    int const indexBatchBeam = batchSlot * nBM + indexBeam;
-    int const lastStep{bh.sequenceLengths[indexBatchBeam] - 1}; // the sequenceLengths is updated, need to minus 1
-
-    // Return early when the indexBatchBeam or step is out of the bound
-    // No update for the indices of context part since KV Cache is shared
-    if (step >= nMSL || step < bh.inputLengths[indexBatchBeam] || step < (nMSL - nMaxAttentionWindow)
-        || bh.finished[indexBatchBeam].isFinished())
-    {
-        return;
-    }
-
-    // Keep all past tokens by parentIdsPtr
-    int const indexBeamSrc = bh.parentIdsPtr[batchSlot][indexBeam * nMSL + lastStep];
-    int const stepCirc = (step >= nSinkTokenLength)
-        ? nSinkTokenLength + (step - nSinkTokenLength) % (nMaxAttentionWindow - nSinkTokenLength)
-        : step;
-    // Consider cyclic kv cache for the indir tables
-    uint32_t const tgtOffset = batchSlot * nBM * nMaxAttentionWindow + indexBeam * nMaxAttentionWindow + stepCirc;
-    uint32_t const srcOffset = batchSlot * nBM * nMaxAttentionWindow + indexBeamSrc * nMaxAttentionWindow + stepCirc;
-    tgtCI[tgtOffset] = (step == lastStep) ? indexBeam : srcCI[srcOffset];
 }
 
 template <typename T>
@@ -338,6 +317,7 @@ void BeamSearchLayer<T>::forwardAsync(std::shared_ptr<BaseDecodingOutputs> const
 
     BeamHypotheses bh;
     // bh's members not used in this function: outputIds, logProbs, outputIdsUnfinish, parentIdsUnfinish
+    bh.bVBWS = this->mVBWS;
     bh.nMaxBatchSize = static_cast<std::int32_t>(op->outputIdsPtr->getDimension<0>());
     bh.nBatchSize = ip->localBatchSize;
     bh.nBeamWidth = op->outputIds->getDimension<1>();
@@ -351,10 +331,29 @@ void BeamSearchLayer<T>::forwardAsync(std::shared_ptr<BaseDecodingOutputs> const
     bh.diversityRates = bufferCast<float>(*mBeamSearchDiversityRateDevice);
     bh.lengthPenalties = bufferCast<float>(*mLengthPenaltyDevice);
     bh.earlyStoppings = bufferCast<int>(*mEarlyStoppingDevice);
+    bh.beamWidthArraysHost = bufferCast<int>(*mBeamWidthArrayHost);
+    bh.beamWidthArraysDevice = bufferCast<int>(*mBeamWidthArrayDevice);
+
+    bh.nBeamWidthInHost = bufferCast<int>(*mBeamWidthIn);
+    bh.nBeamWidthOutHost = bufferCast<int>(*mBeamWidthOut);
+    if (this->mVBWS)
+    {
+        int const* batchSlotsHost = bufferCast<int>(*ip->batchSlots);
+        for (int i = 0; i < ip->localBatchSize; ++i)
+        {
+            int const slot = batchSlotsHost[i];
+            int const step = ip->beamSearchSteps.value()[slot];
+            // Clamp `step` to [0, kMaxBeamWidthArrayLength - 1], and set `indexInput=0` when step = 0 or 1
+            int const indexInput = std::min(std::max((int) step - 1, 0), (int) kMaxBeamWidthArrayLength - 1);
+            int const indexOutput = std::min((int) step, (int) kMaxBeamWidthArrayLength - 1);
+            bh.nBeamWidthInHost[i] = bh.beamWidthArraysHost[slot * kMaxBeamWidthArrayLength + indexInput];
+            bh.nBeamWidthOutHost[i] = bh.beamWidthArraysHost[slot * kMaxBeamWidthArrayLength + indexOutput];
+        }
+    }
 
     bh.inputLengths = bufferCast<SizeType32>(*ip->inputLengths.value());
     bh.endIds = bufferCast<TokenIdType>(*ip->endIds);
-    bh.batchSlots = workspace->getDeviceBatchSlotsPtr();
+    bh.batchSlots = workspace->getDeviceBatchSlotsPtr(); // Device copy of `ip->batchSlots`
 
     bh.logProbsTiled = bufferCastOrNull<float>(op->outputLogProbsTiled);
     bh.sequenceLengths = bufferCast<SizeType32>(*op->sequenceLength.value());
@@ -380,7 +379,7 @@ void BeamSearchLayer<T>::forwardAsync(std::shared_ptr<BaseDecodingOutputs> const
         "Workspace size (%lu) is not enough for topk softmax required (%lu).", (uint64_t) getWorkspaceSize(),
         (uint64_t) (2 * bh.nMaxBatchSize * bh.nBeamWidth * bh.nBeamWidth * 2));
 
-    if (this->mV2)
+    if (this->mV2 || this->mVBWS)
     {
         invokeTopkBeamSearch<T, true>(logProbs, bias, workspace->getRawWorkspaceDevicePtr(), bh, getStream());
     }
@@ -389,12 +388,9 @@ void BeamSearchLayer<T>::forwardAsync(std::shared_ptr<BaseDecodingOutputs> const
         invokeTopkBeamSearch<T, false>(logProbs, bias, workspace->getRawWorkspaceDevicePtr(), bh, getStream());
     }
 
-    auto tgtCI = bufferCast<int>(*op->tgtCacheIndirection);
-    auto srcCI = bufferCast<int>(*ip->srcCacheIndirection.value());
-    dim3 const grid(common::roundUp(bh.nMaxSeqLen, 32), bh.nBatchSize, bh.nBeamWidth);
-    updateCacheIndirectionKernel<<<grid, 32, 0, getStream()>>>(
-        tgtCI, srcCI, bh, ip->maxAttentionWindow, ip->sinkTokenLength);
-    sync_check_cuda_error(getStream());
+    int* tgtCI = bufferCast<int>(*op->tgtCacheIndirection);
+    int* srcCI = bufferCast<int>(*ip->srcCacheIndirection.value());
+    invokeUpdateCacheIndirection(tgtCI, srcCI, bh, ip->maxAttentionWindow, ip->sinkTokenLength, getStream());
 
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
 }

--- a/cpp/tensorrt_llm/layers/beamSearchLayer.cu
+++ b/cpp/tensorrt_llm/layers/beamSearchLayer.cu
@@ -94,7 +94,7 @@ void BeamSearchLayer<T>::allocateBuffer()
     SizeType32 const nBS{mDecoderDomain.getBatchSize()};
     auto const batchSizeShape = ITensor::makeShape({nBS});
     auto const batchSizeXBeamWidthArraySizeShape
-        = ITensor::makeShape({nBS * static_cast<runtime::SizeType32 const> (kMaxBeamWidthArrayLength)});
+        = ITensor::makeShape({nBS * static_cast<runtime::SizeType32 const>(kMaxBeamWidthArrayLength)});
 
     mBeamSearchDiversityRateHost = mBufferManager->pinnedPool(batchSizeShape, TRTDataType<float>::value);
     mBeamSearchDiversityRateDevice = mBufferManager->gpu(batchSizeShape, TRTDataType<float>::value);

--- a/cpp/tensorrt_llm/layers/beamSearchLayer.cu
+++ b/cpp/tensorrt_llm/layers/beamSearchLayer.cu
@@ -94,7 +94,7 @@ void BeamSearchLayer<T>::allocateBuffer()
     SizeType32 const nBS{mDecoderDomain.getBatchSize()};
     auto const batchSizeShape = ITensor::makeShape({nBS});
     auto const batchSizeXBeamWidthArraySizeShape
-        = ITensor::makeShape({nBS * (runtime::SizeType32) kMaxBeamWidthArrayLength});
+        = ITensor::makeShape({nBS * static_cast<runtime::SizeType32 const> (kMaxBeamWidthArrayLength)});
 
     mBeamSearchDiversityRateHost = mBufferManager->pinnedPool(batchSizeShape, TRTDataType<float>::value);
     mBeamSearchDiversityRateDevice = mBufferManager->gpu(batchSizeShape, TRTDataType<float>::value);

--- a/cpp/tensorrt_llm/layers/beamSearchLayer.cu
+++ b/cpp/tensorrt_llm/layers/beamSearchLayer.cu
@@ -289,7 +289,7 @@ void BeamSearchLayer<T>::setup(SizeType32 const batchSize, SizeType32 const beam
     fillBuffers(setupParams->earlyStopping, DefaultDecodingParams::getEarlyStopping(), mEarlyStoppingHost,
         mEarlyStoppingDevice, batchSlots, std::make_pair(-fltEpsilon, int32Max), "early stopping");
     fillBuffers(setupParams->beamWidthArray, DefaultDecodingParams::getBeamWidthArray(), mBeamWidthArrayHost,
-        mBeamWidthArrayDevice, batchSlots, std::make_pair(-fltEpsilon, int32Max), "beam width array");
+        mBeamWidthArrayDevice, batchSlots, std::make_pair(-fltEpsilon, kMaxBeamWidth), "beam width array");
 
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
 }

--- a/cpp/tensorrt_llm/layers/beamSearchLayer.h
+++ b/cpp/tensorrt_llm/layers/beamSearchLayer.h
@@ -64,8 +64,8 @@ private:
     TensorPtr mLengthPenaltyDevice;           // [batchSize] gpu
     TensorPtr mEarlyStoppingHost;             // [batchSize] cpu
     TensorPtr mEarlyStoppingDevice;           // [batchSize] gpu
-    TensorPtr mBeamWidthArrayHost;            // [batchSize] cpu
-    TensorPtr mBeamWidthArrayDevice;          // [batchSize] gpu
+    TensorPtr mBeamWidthArrayHost;            // [batchSize, kMaxBeamWidthArrayLength] cpu
+    TensorPtr mBeamWidthArrayDevice;          // [batchSize, kMaxBeamWidthArrayLength] gpu
     TensorPtr mBeamWidthIn;                   // [batchSize] cpu
     TensorPtr mBeamWidthOut;                  // [batchSize] cpu
 };

--- a/cpp/tensorrt_llm/layers/beamSearchLayer.h
+++ b/cpp/tensorrt_llm/layers/beamSearchLayer.h
@@ -66,8 +66,8 @@ private:
     TensorPtr mEarlyStoppingDevice;           // [batchSize] gpu
     TensorPtr mBeamWidthArrayHost;            // [batchSize, kMaxBeamWidthArrayLength] cpu
     TensorPtr mBeamWidthArrayDevice;          // [batchSize, kMaxBeamWidthArrayLength] gpu
-    TensorPtr mBeamWidthIn;                   // [batchSize] cpu
-    TensorPtr mBeamWidthOut;                  // [batchSize] cpu
+    TensorPtr mBeamWidthIn;                   // [batchSize] cpu, the input beamWidth of this step
+    TensorPtr mBeamWidthOut;                  // [batchSize] cpu, the output beamWidth of this step
 };
 
 } // namespace tensorrt_llm::layers

--- a/cpp/tensorrt_llm/layers/beamSearchLayer.h
+++ b/cpp/tensorrt_llm/layers/beamSearchLayer.h
@@ -31,10 +31,10 @@ class BeamSearchLayer : public BaseLayer
 public:
     BeamSearchLayer(DecoderDomain const& decoderDomain, std::shared_ptr<runtime::BufferManager> bufferManager);
 
-    // Functions called after runtime data atrrives
+    // Functions called before input data arrives
     [[nodiscard]] size_t getWorkspaceSize() const noexcept override;
 
-    // Functions called after runtime data atrrives
+    // Functions called after input data arrives
     void setup(runtime::SizeType32 const batchSize, runtime::SizeType32 const beamWidth, TensorConstPtr batchSlots,
         std::shared_ptr<BaseSetupParams> const& setupParams,
         std::shared_ptr<runtime::DecodingLayerWorkspace> const& workspace) override;
@@ -43,7 +43,7 @@ public:
         std::shared_ptr<runtime::DecodingLayerWorkspace> const& workspace) override;
 
 private:
-    // Functions called before runtime data atrrives
+    // Functions called before input data arrives
     void allocateBuffer();
     void configureBeamSearchLayer();
 
@@ -56,13 +56,18 @@ private:
     size_t mVPart{0};                         // Count of parts the beamed-logProbs will be divided into, useless in V2
     size_t mWorkspaceSize{0};                 // Total workspace size for Beam Search kernels
     bool mV2{false};                          // Whether to use V2 Beam Search kernels
+    bool mVBWS{false};                        // Whether to use Variable-Beam-Width-Search
 
-    TensorPtr mBeamSearchDiversityRateDevice; // [batchSize], in device memory.
-    TensorPtr mLengthPenaltyDevice;           // [batchSize], in device memory.
-    TensorPtr mEarlyStoppingDevice;           // [batchSize], in device memory.
-    TensorPtr mBeamSearchDiversityRateHost;   // [batchSize], in pinned host memory.
-    TensorPtr mLengthPenaltyHost;             // [batchSize], in pinned host memory.
-    TensorPtr mEarlyStoppingHost;             // [batchSize], in pinned host memory.
+    TensorPtr mBeamSearchDiversityRateHost;   // [batchSize] cpu
+    TensorPtr mBeamSearchDiversityRateDevice; // [batchSize] gpu
+    TensorPtr mLengthPenaltyHost;             // [batchSize] cpu
+    TensorPtr mLengthPenaltyDevice;           // [batchSize] gpu
+    TensorPtr mEarlyStoppingHost;             // [batchSize] cpu
+    TensorPtr mEarlyStoppingDevice;           // [batchSize] gpu
+    TensorPtr mBeamWidthArrayHost;            // [batchSize] cpu
+    TensorPtr mBeamWidthArrayDevice;          // [batchSize] gpu
+    TensorPtr mBeamWidthIn;                   // [batchSize] cpu
+    TensorPtr mBeamWidthOut;                  // [batchSize] cpu
 };
 
 } // namespace tensorrt_llm::layers

--- a/cpp/tensorrt_llm/layers/decodingParams.h
+++ b/cpp/tensorrt_llm/layers/decodingParams.h
@@ -58,12 +58,14 @@ class DecoderDomain
 public:
     DecoderDomain(runtime::SizeType32 batchSize, runtime::SizeType32 beamWidth, runtime::SizeType32 vocabSize,
         std::optional<runtime::SizeType32> vocabSizePadded = std::nullopt,
-        std::shared_ptr<runtime::SpeculativeDecodingModule const> speculativeDecodingModule = nullptr)
+        std::shared_ptr<runtime::SpeculativeDecodingModule const> speculativeDecodingModule = nullptr,
+        bool const useVariableBeamWidthSearch = false)
         : mBatchSize(batchSize)
         , mBeamWidth(beamWidth)
         , mVocabSize(vocabSize)
         , mVocabSizePadded(vocabSizePadded.value_or(vocabSize))
         , mSpeculativeDecodingModule(std::move(speculativeDecodingModule))
+        , mUseVariableBeamWidthSearch(useVariableBeamWidthSearch)
     {
     }
 
@@ -103,12 +105,18 @@ public:
         return mSpeculativeDecodingModule;
     }
 
+    [[nodiscard]] bool getUseVariableBeamWidthSearch() const
+    {
+        return mUseVariableBeamWidthSearch;
+    }
+
 private:
     runtime::SizeType32 mBatchSize;
     runtime::SizeType32 mBeamWidth;
     runtime::SizeType32 mVocabSize;
     runtime::SizeType32 mVocabSizePadded;
     std::shared_ptr<runtime::SpeculativeDecodingModule const> mSpeculativeDecodingModule;
+    bool mUseVariableBeamWidthSearch;
 };
 
 class BaseSetupParams
@@ -167,6 +175,8 @@ public:
     std::optional<std::vector<float>> beamSearchDiversityRate; // [setupBatchSize] on cpu
     std::optional<std::vector<float>> lengthPenalty;           // [setupBatchSize] on cpu
     std::optional<std::vector<int>> earlyStopping;             // [setupBatchSize] on cpu
+    std::optional<std::vector<std::vector<runtime::SizeType32>>>
+        beamWidthArray; // [setupBatchSize, nMaxBeamWidthArray] on cpu
     bool hasDiffRuntimeArgs{false};
 };
 
@@ -330,6 +340,9 @@ public:
     std::shared_ptr<BanWordsDecodingInputs> banWordsInputs;
 
     std::shared_ptr<StopCriteriaDecodingInputs> stopCriteriaInputs;
+
+    //! Step of each request, for Variable-Beam-Width-Search
+    std::optional<std::vector<runtime::SizeType32>> beamSearchSteps; // [batchSize]
 };
 
 class SamplingInputs : public DecodingInputs
@@ -502,7 +515,7 @@ public:
     //! Indicator whether the context request last chunk or not.
     TensorConstPtr chunkedContextNextTokens; // [forwardBatchSize]
 
-    TensorConstPtr seqSlots;                 // [forwardBatchSize], on gpu
+    TensorConstPtr seqSlots; // [forwardBatchSize], on gpu
 };
 
 class BaseDecodingOutputs

--- a/cpp/tensorrt_llm/layers/decodingParams.h
+++ b/cpp/tensorrt_llm/layers/decodingParams.h
@@ -176,7 +176,7 @@ public:
     std::optional<std::vector<float>> lengthPenalty;           // [setupBatchSize] on cpu
     std::optional<std::vector<int>> earlyStopping;             // [setupBatchSize] on cpu
     std::optional<std::vector<std::vector<runtime::SizeType32>>>
-        beamWidthArray; // [setupBatchSize, nMaxBeamWidthArray] on cpu
+        beamWidthArray;                                        // [setupBatchSize, nMaxBeamWidthArray] on cpu
     bool hasDiffRuntimeArgs{false};
 };
 
@@ -515,7 +515,7 @@ public:
     //! Indicator whether the context request last chunk or not.
     TensorConstPtr chunkedContextNextTokens; // [forwardBatchSize]
 
-    TensorConstPtr seqSlots; // [forwardBatchSize], on gpu
+    TensorConstPtr seqSlots;                 // [forwardBatchSize], on gpu
 };
 
 class BaseDecodingOutputs

--- a/cpp/tests/unit_tests/layers/CMakeLists.txt
+++ b/cpp/tests/unit_tests/layers/CMakeLists.txt
@@ -14,6 +14,10 @@ set(SAMPLING_LAYER_TEST_SRC
     topPSamplingLayerTest.cpp externalDraftTokensLayerTest.cpp)
 add_gtest(samplingLayerTest "${SAMPLING_LAYER_TEST_SRC}")
 
+set(BEAM_SEARCH_LAYER_TEST_SRC baseSamplingLayerTest.cpp
+                               beamSearchLayerTest.cpp)
+add_gtest(beamSearchLayerTest "${BEAM_SEARCH_LAYER_TEST_SRC}")
+
 set(LOOKAHEAD_POOLMANAGER_TEST_SRC randomLlm.cpp lookaheadPoolManagerTest.cpp)
 add_gtest(lookaheadPoolManagerTest "${LOOKAHEAD_POOLMANAGER_TEST_SRC}")
 

--- a/cpp/tests/unit_tests/layers/baseSamplingLayerTest.cpp
+++ b/cpp/tests/unit_tests/layers/baseSamplingLayerTest.cpp
@@ -34,7 +34,7 @@ void BaseSamplingLayerTest<T>::setup(uint64_t seed, TestSamplingParams const& pa
 
     // clang-format off
 
-    // prob = (0.4, 0.3, 0.2, 0.1)
+    // logits = (-0.9163, -1.2040, -1.6094, -2.3026) -> prob = (0.4, 0.3, 0.2, 0.1)
     std::vector<T> testLogits = {
                 -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX, -0.9163, -1.2040, -1.6094, -2.3026, // step 0
                 -0.9163, -1.2040, -1.6094, -2.3026, -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX, // step 1
@@ -63,7 +63,8 @@ void BaseSamplingLayerTest<T>::setup(uint64_t seed, TestSamplingParams const& pa
 
     if (mComputeProbs)
     {
-        computeProb(mTestLogitsInit.data(), mTestLogitsInit.data(), 4 * params.beamWidth, mVocabSize);
+        computeProb(mTestLogitsInit.data(), mTestLogitsInit.data(),
+            BaseSamplingLayerTest::mMaxOutputLen * params.beamWidth, mVocabSize);
     }
 
     mSeqLengthsDevice = mBufferManager->gpu(ITensor::makeShape({maxBatchSize()}), nvinfer1::DataType::kINT32);
@@ -154,7 +155,6 @@ void BaseSamplingLayerTest<T>::setup(uint64_t seed, TestSamplingParams const& pa
     {
         idsPtrHostPtr[bi] = outputIdsDevicePtr + bi * mMaxSeqLen;
     }
-
     if (mBeamWidth > 1)
     {
         auto outputIdsPtr = bufferCast<int*>(*mOutputIdsPtr);

--- a/cpp/tests/unit_tests/layers/baseSamplingLayerTest.cpp
+++ b/cpp/tests/unit_tests/layers/baseSamplingLayerTest.cpp
@@ -332,6 +332,7 @@ void BaseSamplingLayerTest<T>::runTest(
     if (params.beamWidth > 1)
     {
         mBeamWidth = params.beamWidth;
+        mMaxSeed = 1;
         mComputeProbs = true;
     }
     initLayer(params);

--- a/cpp/tests/unit_tests/layers/baseSamplingLayerTest.cpp
+++ b/cpp/tests/unit_tests/layers/baseSamplingLayerTest.cpp
@@ -34,18 +34,36 @@ void BaseSamplingLayerTest<T>::setup(uint64_t seed, TestSamplingParams const& pa
 
     // clang-format off
 
-    // prob = (0.0, 0.0, 0.0, 0.0, 0.4, 0.3, 0.2, 0.1)
-    mTestLogitsInit = {
-            -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX, -0.9163, -1.2040, -1.6094, -2.3026, // step 0
-            -0.9163, -1.2040, -1.6094, -2.3026, -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX, // step 1
-            -FLT_MAX, -FLT_MAX, -0.9163, -1.2040, -1.6094, -2.3026, -FLT_MAX, -FLT_MAX, // step 2
-            -0.9163, -1.2040, -1.6094, -2.3026, -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX  // step 3
+    // prob = (0.4, 0.3, 0.2, 0.1)
+    std::vector<T> testLogits = {
+                -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX, -0.9163, -1.2040, -1.6094, -2.3026, // step 0
+                -0.9163, -1.2040, -1.6094, -2.3026, -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX, // step 1
+                -FLT_MAX, -FLT_MAX, -0.9163, -1.2040, -1.6094, -2.3026, -FLT_MAX, -FLT_MAX, // step 2
+                -0.9163, -1.2040, -1.6094, -2.3026, -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX  // step 3
     };
 
     // clang-format on
+
+    if (params.beamWidth == 1)
+    {
+        mTestLogitsInit = testLogits;
+    }
+    else
+    {
+        for (int step = 0; step < mMaxSeqLen; ++step)
+        {
+            auto const& logitsBegin = testLogits.begin() + mVocabSize * step;
+            auto const& logitsEnd = testLogits.begin() + mVocabSize * (step + 1);
+            for (int bm = 0; bm < params.beamWidth; ++bm)
+            {
+                mTestLogitsInit.insert(mTestLogitsInit.end(), logitsBegin, logitsEnd);
+            }
+        }
+    }
+
     if (mComputeProbs)
     {
-        computeProb(mTestLogitsInit.data(), mTestLogitsInit.data(), 4, mVocabSize);
+        computeProb(mTestLogitsInit.data(), mTestLogitsInit.data(), 4 * params.beamWidth, mVocabSize);
     }
 
     mSeqLengthsDevice = mBufferManager->gpu(ITensor::makeShape({maxBatchSize()}), nvinfer1::DataType::kINT32);
@@ -56,7 +74,7 @@ void BaseSamplingLayerTest<T>::setup(uint64_t seed, TestSamplingParams const& pa
         : mBufferManager->gpu(
             ITensor::makeShape({maxBatchSize()}), TRTDataType<tk::FinishedState::UnderlyingType>::value);
     mOutputIdsDevice
-        = mBufferManager->gpu(ITensor::makeShape({maxBatchSize(), mMaxSeqLen}), nvinfer1::DataType::kINT32);
+        = mBufferManager->gpu(ITensor::makeShape({maxBatchSize(), mBeamWidth, mMaxSeqLen}), nvinfer1::DataType::kINT32);
     mEndIdsDevice = mBufferManager->gpu(ITensor::makeShape({maxBatchSize()}), nvinfer1::DataType::kINT32);
     mIdsPtrHost = mBufferManager->pinned(ITensor::makeShape({maxBatchSize()}), ptrType);
 
@@ -81,6 +99,45 @@ void BaseSamplingLayerTest<T>::setup(uint64_t seed, TestSamplingParams const& pa
     tk::invokeCurandInitialize(reinterpret_cast<curandState_t*>(bufferCast<int8_t>(*mCurandStatesDevice)), nullptr,
         maxBatchSize(), seed, mStream->get());
 
+    if (mBeamWidth > 1)
+    {
+        mSrcCacheIndirection = mBufferManager->gpu(
+            ITensor::makeShape({maxBatchSize(), mBeamWidth, mMaxSeqLen}), nvinfer1::DataType::kINT32);
+        mTgtCacheIndirection = mBufferManager->gpu(
+            ITensor::makeShape({maxBatchSize(), mBeamWidth, mMaxSeqLen}), nvinfer1::DataType::kINT32);
+        mParentIds = mBufferManager->gpu(
+            ITensor::makeShape({maxBatchSize(), mBeamWidth, mMaxSeqLen}), nvinfer1::DataType::kINT32);
+
+        auto constexpr nvTokenIdType = TRTDataType<TokenIdType>::value;
+        auto constexpr nvSizeType = TRTDataType<SizeType32>::value;
+        auto constexpr nvFloatType = TRTDataType<float>::value;
+        auto constexpr nvBoolType = TRTDataType<bool>::value;
+        mOutputIdsCBA
+            = mBufferManager->gpu(ITensor::makeShape({maxBatchSize(), 2 * mBeamWidth, mMaxSeqLen}), nvTokenIdType);
+        mLogProbsCBA
+            = mBufferManager->gpu(ITensor::makeShape({maxBatchSize(), 2 * mBeamWidth, mMaxSeqLen}), nvFloatType);
+        mSequenceLengthsCBA = mBufferManager->gpu(ITensor::makeShape({maxBatchSize(), 2 * mBeamWidth}), nvSizeType);
+        mCumLogProbsCBA = mBufferManager->gpu(ITensor::makeShape({maxBatchSize(), 2 * mBeamWidth}), nvFloatType);
+        mNormedScoresCBA = mBufferManager->gpu(ITensor::makeShape({maxBatchSize(), 2 * mBeamWidth}), nvFloatType);
+        mNumBeamsCBA = mBufferManager->gpu(ITensor::makeShape({maxBatchSize()}), nvSizeType);
+        mMinNormedScoresCBA = mBufferManager->gpu(ITensor::makeShape({maxBatchSize()}), nvFloatType);
+        mBatchDones = mBufferManager->gpu(ITensor::makeShape({maxBatchSize()}), nvBoolType);
+        mOutputIdsPtr = mBufferManager->pinned(ITensor::makeShape({maxBatchSize()}), ptrType);
+        mParentIdsPtr = mBufferManager->pinned(ITensor::makeShape({maxBatchSize()}), ptrType);
+
+        trk::invokeFill(*mSrcCacheIndirection, int32_t{0}, *mStream);
+        trk::invokeFill(*mTgtCacheIndirection, int32_t{0}, *mStream);
+        trk::invokeFill(*mParentIds, int32_t{0}, *mStream);
+        trk::invokeFill(*mOutputIdsCBA, int32_t{0}, *mStream);
+        trk::invokeFill(*mLogProbsCBA, float{0}, *mStream);
+        trk::invokeFill(*mSequenceLengthsCBA, int32_t{0}, *mStream);
+        trk::invokeFill(*mCumLogProbsCBA, float{0}, *mStream);
+        trk::invokeFill(*mNormedScoresCBA, float{0}, *mStream);
+        trk::invokeFill(*mNumBeamsCBA, int32_t{0}, *mStream);
+        trk::invokeFill(*mMinNormedScoresCBA, float{0}, *mStream);
+        trk::invokeFill(*mBatchDones, bool{0}, *mStream);
+    }
+
     auto batchSlotsPtr = bufferCast<int32_t>(*mBatchSlots);
     for (SizeType32 bi = 0; bi < mBatchSize; ++bi)
     {
@@ -98,8 +155,25 @@ void BaseSamplingLayerTest<T>::setup(uint64_t seed, TestSamplingParams const& pa
         idsPtrHostPtr[bi] = outputIdsDevicePtr + bi * mMaxSeqLen;
     }
 
+    if (mBeamWidth > 1)
+    {
+        auto outputIdsPtr = bufferCast<int*>(*mOutputIdsPtr);
+        auto parentIdsPtr = bufferCast<int*>(*mParentIdsPtr);
+        for (SizeType32 bi = 0; bi < maxBatchSize(); bi++)
+        {
+            outputIdsPtr[bi] = outputIdsDevicePtr + bi * mMaxSeqLen;
+            parentIdsPtr[bi] = outputIdsDevicePtr + bi * mMaxSeqLen;
+        }
+    }
+
     std::shared_ptr<DecodingSetupParams> setupParams;
-    if (!params.isExternalDraftTokensLayerTest)
+    if (mBeamWidth > 1)
+    {
+        auto samplingSetupParams = std::make_shared<BeamSearchSetupParams>();
+
+        setupParams = samplingSetupParams;
+    }
+    else if (!params.isExternalDraftTokensLayerTest)
     {
         auto samplingSetupParams = std::make_shared<SamplingSetupParams>();
         samplingSetupParams->randomSeed = std::make_optional<std::vector<uint64_t>>({seed});
@@ -131,7 +205,6 @@ void BaseSamplingLayerTest<T>::setup(uint64_t seed, TestSamplingParams const& pa
     mDecodingWorkspace->setDeviceBatchSlots(mBatchSlots);
     mDecodingWorkspace->getDeviceRuntimeLogits()->reshape(ITensor::makeShape({mBatchSize, mBeamWidth, mVocabSize}));
     mSamplingLayer->setup(mBatchSize, mBeamWidth, mBatchSlots, setupParams, mDecodingWorkspace);
-
     mStream->synchronize();
 }
 
@@ -139,45 +212,76 @@ template <typename T>
 std::shared_ptr<DecodingInputs> BaseSamplingLayerTest<T>::createInputTensors(int32_t step)
 {
     constexpr int32_t ite = 0;
-    auto decodeInputTensors = std::make_shared<SamplingInputs>(mEndIdsDevice, mBatchSlots, step, ite, mBatchSize);
-
-    decodeInputTensors->logits = mDecodingWorkspace->getDeviceRuntimeLogits();
-
-    decodeInputTensors->inputLengths = mContextLengthDevice;
-
-    decodeInputTensors->finished = mFinishedDevice;
-
-    decodeInputTensors->probsComputed = mComputeProbs;
-
-    decodeInputTensors->curandStates = reinterpret_cast<curandState_t*>(bufferCast<int8_t>(*mCurandStatesDevice));
-
-    return decodeInputTensors;
+    if (mBeamWidth > 1)
+    {
+        auto decodeInputTensors = std::make_shared<DecodingInputs>(mEndIdsDevice, mBatchSlots, step, ite, mBatchSize);
+        decodeInputTensors->logits = mDecodingWorkspace->getDeviceRuntimeLogits();
+        decodeInputTensors->inputLengths = mContextLengthDevice;
+        decodeInputTensors->finished = mFinishedDevice;
+        decodeInputTensors->srcCacheIndirection = mSrcCacheIndirection;
+        return decodeInputTensors;
+    }
+    else
+    {
+        auto decodeInputTensors = std::make_shared<SamplingInputs>(mEndIdsDevice, mBatchSlots, step, ite, mBatchSize);
+        decodeInputTensors->logits = mDecodingWorkspace->getDeviceRuntimeLogits();
+        decodeInputTensors->inputLengths = mContextLengthDevice;
+        decodeInputTensors->finished = mFinishedDevice;
+        decodeInputTensors->probsComputed = mComputeProbs;
+        decodeInputTensors->curandStates = reinterpret_cast<curandState_t*>(bufferCast<int8_t>(*mCurandStatesDevice));
+        return decodeInputTensors;
+    }
 }
 
 template <typename T>
 std::shared_ptr<BaseDecodingOutputs> BaseSamplingLayerTest<T>::createOutputTensors()
 {
-    auto decodeOutputs = std::make_shared<BaseDecodingOutputs>(mOutputIdsDevice);
-    decodeOutputs->outputIdsPtr = mIdsPtrHost;
-    decodeOutputs->outputIdsPtrHost = mIdsPtrHost;
+    // TODO: check log probs and cum_log_probs
 
-    decodeOutputs->sequenceLength = mSeqLengthsDevice;
+    if (mBeamWidth > 1)
+    {
+        auto decodeOutputs = std::make_shared<BeamSearchOutputs>(mOutputIdsDevice);
+        decodeOutputs->outputIdsPtr = mOutputIdsPtr;
+        decodeOutputs->outputIdsPtrHost = mIdsPtrHost;
+        decodeOutputs->sequenceLength = mSeqLengthsDevice;
+        decodeOutputs->finished = mFinishedDevice;
+        decodeOutputs->outputLogProbs = mOutputLogProbsDevice;
+        decodeOutputs->cumLogProbs = mCumLogProbsDevice;
+        decodeOutputs->tgtCacheIndirection = mTgtCacheIndirection;
+        decodeOutputs->parentIds = mParentIds;
+        decodeOutputs->parentIdsPtr = mIdsPtrHost;
 
-    decodeOutputs->finished = mFinishedDevice;
+        decodeOutputs->beamHypotheses = std::make_unique<tensorrt_llm::kernels::BeamHypotheses>();
+        decodeOutputs->beamHypotheses->outputIdsCBA = bufferCast<int>(*mOutputIdsCBA);
+        decodeOutputs->beamHypotheses->logProbsCBA = bufferCast<float>(*mLogProbsCBA);
+        decodeOutputs->beamHypotheses->sequenceLengthsCBA = bufferCast<int>(*mSequenceLengthsCBA);
+        decodeOutputs->beamHypotheses->cumLogProbsCBA = bufferCast<float>(*mCumLogProbsCBA);
+        decodeOutputs->beamHypotheses->normedScoresCBA = bufferCast<float>(*mNormedScoresCBA);
+        decodeOutputs->beamHypotheses->numBeamsCBA = bufferCast<int>(*mNumBeamsCBA);
+        decodeOutputs->beamHypotheses->minNormedScoresCBA = bufferCast<float>(*mMinNormedScoresCBA);
+        decodeOutputs->beamHypotheses->batchDones = bufferCast<bool>(*mBatchDones);
 
-    decodeOutputs->outputLogProbs = mOutputLogProbsDevice;
-
-    decodeOutputs->cumLogProbs = mCumLogProbsDevice;
-
-    // TODO(nkorobov): check log probs and cum_log_probs
-    return decodeOutputs;
+        return decodeOutputs;
+    }
+    else
+    {
+        auto decodeOutputs = std::make_shared<BaseDecodingOutputs>(mOutputIdsDevice);
+        decodeOutputs->outputIdsPtr = mIdsPtrHost;
+        decodeOutputs->outputIdsPtrHost = mIdsPtrHost;
+        decodeOutputs->sequenceLength = mSeqLengthsDevice;
+        decodeOutputs->finished = mFinishedDevice;
+        decodeOutputs->outputLogProbs = mOutputLogProbsDevice;
+        decodeOutputs->cumLogProbs = mCumLogProbsDevice;
+        return decodeOutputs;
+    }
 }
 
 template <typename T>
 void BaseSamplingLayerTest<T>::batchCopy(int32_t step)
 {
-    auto const logitsHost = ITensor::wrap(
-        mTestLogitsInit.data() + step * mVocabSize, TRTDataType<T>::value, ITensor::makeShape({1, mVocabSize}));
+    auto const logitsHost = ITensor::wrap(mTestLogitsInit.data() + step * mBeamWidth * mVocabSize,
+        TRTDataType<T>::value, ITensor::makeShape({mBeamWidth, mVocabSize}));
+
     for (int32_t bi = 0; bi < mBatchSize; ++bi)
     {
         auto logitsDeviceView = ITensor::slice(mDecodingWorkspace->getDeviceRuntimeLogits(), bi, 1);
@@ -191,10 +295,10 @@ bool BaseSamplingLayerTest<T>::checkResult(int32_t const* outputIds, std::vector
     assert(expectedIds.size() == mMaxSeqLen * batchBeam());
     int failures = 0;
     auto* const batchSlotsPtr = bufferCast<int32_t>(*mBatchSlots);
-    for (int32_t i = 0; i < mMaxSeqLen * batchBeam(); ++i)
+    for (int32_t i = 0; i < mMaxSeqLen * mBatchSize; ++i)
     {
-        int32_t s = i / batchBeam();
-        int32_t b = i % batchBeam();
+        int32_t s = i / mBatchSize;
+        int32_t b = i % mBatchSize;
         auto const batchSlot = batchSlotsPtr[b];
         std::set<int32_t> expts = expectedIds.at(i);
         auto const outputId = outputIds[batchSlot * mMaxSeqLen + s];
@@ -225,6 +329,11 @@ void BaseSamplingLayerTest<T>::runTest(
     std::vector<std::set<int32_t>> const& expectedOutputIds, TestSamplingParams const& params, int32_t endId)
 {
     mBatchSize = params.batchSize;
+    if (params.beamWidth > 1)
+    {
+        mBeamWidth = params.beamWidth;
+        mComputeProbs = true;
+    }
     initLayer(params);
 
     auto const decoderDomain

--- a/cpp/tests/unit_tests/layers/baseSamplingLayerTest.h
+++ b/cpp/tests/unit_tests/layers/baseSamplingLayerTest.h
@@ -19,6 +19,7 @@
 
 #include <memory>
 
+#include "tensorrt_llm/layers/beamSearchLayer.h"
 #include "tensorrt_llm/layers/externalDraftTokensLayer.h"
 #include "tensorrt_llm/layers/samplingLayer.h"
 #include "tensorrt_llm/layers/topKSamplingLayer.h"
@@ -26,6 +27,7 @@
 #include "tensorrt_llm/runtime/bufferManager.h"
 #include "tensorrt_llm/runtime/cudaStream.h"
 
+#include "tensorrt_llm/kernels/beamSearchKernels.h"
 #include "tensorrt_llm/kernels/penaltyKernels.h"
 #include "tensorrt_llm/kernels/samplingTopKKernels.h"
 #include "tensorrt_llm/kernels/samplingTopPKernels.h"

--- a/cpp/tests/unit_tests/layers/baseSamplingLayerTest.h
+++ b/cpp/tests/unit_tests/layers/baseSamplingLayerTest.h
@@ -89,6 +89,7 @@ struct TestSamplingParams
     std::vector<float> minTopP;
     std::vector<int32_t> topPResetIds;
     int32_t batchSize = 6;
+    int32_t beamWidth = 1;
     bool useBias = false;
     bool isExternalDraftTokensLayerTest = false;
     bool useDraftLogits = false;
@@ -106,9 +107,9 @@ protected:
 
     int32_t seed = 0;
     int32_t mBatchSize = -1; // setup by runTest
+    int32_t mBeamWidth = 1;
     static int32_t constexpr mBatchSizeBadPad = 512;
-    static uint64_t constexpr mMaxSeed = 32;
-    int32_t const mBeamWidth = 1;
+    uint64_t mMaxSeed = 32;
     int32_t const mVocabSize = 8;
     int32_t const mVocabSizePadded = mVocabSize;
 
@@ -137,6 +138,21 @@ protected:
 
     TensorPtr mCurandStatesDevice;
     TensorPtr mPenaltyWorkspaceDevice;
+
+    // For Beam Search
+    TensorPtr mSrcCacheIndirection;
+    TensorPtr mTgtCacheIndirection;
+    TensorPtr mParentIds;
+    TensorPtr mOutputIdsCBA;
+    TensorPtr mLogProbsCBA;
+    TensorPtr mSequenceLengthsCBA;
+    TensorPtr mCumLogProbsCBA;
+    TensorPtr mNormedScoresCBA;
+    TensorPtr mNumBeamsCBA;
+    TensorPtr mMinNormedScoresCBA;
+    TensorPtr mBatchDones;
+    TensorPtr mOutputIdsPtr;
+    TensorPtr mParentIdsPtr;
 
     std::shared_ptr<tensorrt_llm::runtime::CudaStream> mStream;
     std::shared_ptr<tensorrt_llm::runtime::BufferManager> mBufferManager;

--- a/cpp/tests/unit_tests/layers/baseSamplingLayerTest.h
+++ b/cpp/tests/unit_tests/layers/baseSamplingLayerTest.h
@@ -114,7 +114,7 @@ protected:
     int32_t const mVocabSizePadded = mVocabSize;
 
     int32_t const mMaxInputLen = 0; // has no effect.
-    int32_t const mMaxOutputLen = 4;
+    static int32_t constexpr mMaxOutputLen = 4;
     int32_t const mMaxSeqLen = mMaxInputLen + mMaxOutputLen;
     int32_t const mMaxTokensPerEngineStep = mMaxOutputLen;
 

--- a/cpp/tests/unit_tests/layers/beamSearchLayerTest.cpp
+++ b/cpp/tests/unit_tests/layers/beamSearchLayerTest.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tensorrt_llm/executor/types.h"
+#include "tests/unit_tests/layers/baseSamplingLayerTest.h"
+
+namespace
+{
+
+namespace tle = tensorrt_llm::executor;
+
+using namespace tensorrt_llm::tests::layers::sampling;
+using namespace tensorrt_llm::runtime;
+
+template <typename T>
+class BeamSearchLayerTest : public BaseSamplingLayerTest<T>
+{
+    void SetUp() override
+    {
+        this->mStream = std::make_shared<tensorrt_llm::runtime::CudaStream>();
+        this->mBufferManager = std::make_shared<tensorrt_llm::runtime::BufferManager>(this->mStream);
+    }
+
+    void initLayer(TestSamplingParams const& params) override
+    {
+        auto decodingMode = (params.beamWidth > 1) ? tle::DecodingMode::BeamSearch() : tle::DecodingMode::Auto();
+
+        auto const decodingDomain = tensorrt_llm::layers::DecoderDomain(
+            this->maxBatchSize(), params.beamWidth, this->mVocabSize, this->mVocabSizePadded);
+        this->mSamplingLayer
+            = std::make_shared<tensorrt_llm::layers::BeamSearchLayer<T>>(decodingDomain, this->mBufferManager);
+    }
+};
+
+TYPED_TEST_SUITE(BeamSearchLayerTest, FloatAndHalfTypes);
+
+TYPED_TEST(BeamSearchLayerTest, BeamWidth2)
+{
+    TestSamplingParams params;
+
+    params.batchSize = 3;
+    params.beamWidth = 2;
+
+    std::vector<std::set<int32_t>> expectedOutputIds{
+        // batch
+        {4}, {4}, {4}, // step 0
+        {0}, {0}, {0}, // step 1
+        {2}, {2}, {2}, // step 2
+        {0}, {0}, {0}, // step 3
+        {4}, {4}, {4}, // step 0
+        {0}, {0}, {0}, // step 1
+        {2}, {2}, {2}, // step 2
+        {0}, {0}, {0}, // step 3
+    };
+    this->runTest(expectedOutputIds, params);
+}
+
+} // namespace

--- a/tests/unittest/api_stability/references/sampling_params.yaml
+++ b/tests/unittest/api_stability/references/sampling_params.yaml
@@ -24,5 +24,8 @@ methods:
       random_seed:
         annotation: Optional[int]
         default: null
+      beam_width_array:
+        annotation: Optional[List[int]]
+        default: null
     return_annotation: None
 properties: {}

--- a/tests/unittest/api_stability/references_committed/sampling_params.yaml
+++ b/tests/unittest/api_stability/references_committed/sampling_params.yaml
@@ -54,9 +54,6 @@ methods:
       min_p:
         annotation: Optional[float]
         default: null
-      beam_width_array:
-        annotation: Optional[List[int]]
-        default: null
       # Panelities
       repetition_penalty:
         annotation: Optional[float]


### PR DESCRIPTION
## Part 2 of VBWS support.
+ Part 1 is here: [PR3082](https://github.com/NVIDIA/TensorRT-LLM/pull/3082).

## Target of this PR

+ Add infrastructure for Beam Search layer and kernels for VBWS.
+ Add corresponding unit tests for Beam Search layer and kernels, such as `cpp/tests/unit_tests/layers/beamSearchLayerTest.cpp`.
+ Adjust some classes (such as `class DecoderDomain`) to support VBWS (but they are not enabled in normal Beam Search workflow now).
