### PR TITLE
perf: Optimisations for PP + attention DP

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -67,7 +67,8 @@ def cal_max_tokens(peak_memory, total_gpu_memory, fraction, model_config,
         head_dim = (config.hidden_size * num_key_value_heads /
                     config.num_attention_heads / tp_size)
 
-    mem_per_token *= config.num_hidden_layers * head_dim
+    num_hidden_layers = len(mapping.pp_layers_torch(config.num_hidden_layers))
+    mem_per_token *= num_hidden_layers * head_dim
     # K and V
     mem_per_token *= kv_factor
 

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1246,17 +1246,6 @@ class PyExecutor:
                 self._terminate_request(req)
                 self.active_requests.remove(req)
 
-    def _remove_dummy_request(self, scheduled_requests):
-        for request in scheduled_requests.context_requests[:]:
-            if request.is_dummy:
-                scheduled_requests.context_requests.remove(request)
-        for request in scheduled_requests.generation_requests[:]:
-            if request.is_dummy:
-                scheduled_requests.generation_requests.remove(request)
-        for request in self.active_requests[:]:
-            if request.is_dummy:
-                self.active_requests.remove(request)
-
     def _partition_context(self, ctx_ids_list):
         ctx_ids = torch.tensor(ctx_ids_list).unsqueeze(0)
         ctx_len = ctx_ids.shape[-1]

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1124,7 +1124,11 @@ class PyExecutor:
                 self.request_queue, timeout,
                 total_max_num_active_requests - total_num_active_requests)
 
-        new_requests = self.dist.broadcast(new_requests, root=0)
+        if self.dist.has_pp:
+            new_requests = self._broadcast_new_requests_pp(new_requests)
+        else:
+            new_requests = self.dist.broadcast(new_requests, root=0)
+
         num_new_requests_all_ranks = len(new_requests)
         self.expected_num_active_requests = max(
             (total_num_active_requests + num_new_requests_all_ranks +


### PR DESCRIPTION
1. Remove MPI world broadcast in `fetch_adp_new_requests`
2. Sync request finish point for last and intermediate pp ranks to avoid deadlock in TP>=4