### PR TITLE
fix: Update FP8 sf layout for Blackwell and relax blockwise GEMM assertions

### DIFF
--- a/cpp/tensorrt_llm/thop/fp8BlockScalingGemm.cpp
+++ b/cpp/tensorrt_llm/thop/fp8BlockScalingGemm.cpp
@@ -131,15 +131,8 @@ torch::Tensor fp8_block_scale_gemm_blackwell(torch::Tensor const& mat1, torch::T
     TORCH_CHECK(n <= std::numeric_limits<int32_t>::max(), "N must be within int32");
     TORCH_CHECK(k <= std::numeric_limits<int32_t>::max(), "K must be within int32");
 
-    TORCH_CHECK(k % 128 == 0, "K must be a multiple of 128, (K=", k, ")");
-    TORCH_CHECK(n % 128 == 0, "N must be a multiple of 128, (N=", n, ")");
-
-    TORCH_CHECK(mat1Scale.dim() == 2, "mat1Scale must be a matrix");
-    TORCH_CHECK(mat1Scale.sizes()[0] == k / 128, "mat1Scale must have size K/128 x M");
-    TORCH_CHECK(mat1Scale.sizes()[1] == m, "mat1Scale must have size K/128 x M");
-    TORCH_CHECK(mat2Scale.dim() == 2, "mat2Scale must be a matrix");
-    TORCH_CHECK(mat2Scale.sizes()[0] == n / 128, "mat2Scale must have size N/128 x K/128");
-    TORCH_CHECK(mat2Scale.sizes()[1] == k / 128, "mat2Scale must have size N/128 x K/128");
+    TORCH_CHECK(k % 16 == 0, "K must be a multiple of 16, (K=", k, ")");
+    TORCH_CHECK(n % 16 == 0, "N must be a multiple of 16, (N=", n, ")");
 
     auto stream = at::cuda::getCurrentCUDAStream(mat1.get_device());
 

--- a/cpp/tensorrt_llm/thop/fp8Quantize.cpp
+++ b/cpp/tensorrt_llm/thop/fp8Quantize.cpp
@@ -75,6 +75,7 @@ std::tuple<at::Tensor, at::Tensor> fp8_quantize_1x128(at::Tensor const& self)
             act_scal_elesize, " elements, got ", scaleFP8SF.numel());
 
         // scaleFP8SF = scaleFP8SF[0:num_n_blocks, 0:m] // no 4-element alignment in blackwell
+        // TODO: This is a hack to use sm90 quantize kernel for sm100; ideally we should have a separate quantize kernel for sm100.
         scaleFP8SF
             = scaleFP8SF.slice(0, 0, act_scal_elesize).view({num_n_blocks, m_padded}).slice(1, 0, m).contiguous();
     }

--- a/cpp/tensorrt_llm/thop/fp8Quantize.cpp
+++ b/cpp/tensorrt_llm/thop/fp8Quantize.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "tensorrt_llm/common/cudaUtils.h"
 #include "tensorrt_llm/kernels/internal_cutlass_kernels/include/fp8_blockscale_gemm.h"
 #include "tensorrt_llm/thop/thUtils.h"
 
@@ -65,6 +66,18 @@ std::tuple<at::Tensor, at::Tensor> fp8_quantize_1x128(at::Tensor const& self)
     mGemmRunner.fp8CS1x128(
         act_buffer, act_scale_buffer, reinterpret_cast<__nv_bfloat16 const*>(self.data_ptr()), n, m, stream);
 
+    // Post-process the scale tensor for sm100 gemm/moe kernel
+    if (tensorrt_llm::common::getSMVersion() == 100)
+    {
+        auto const num_n_blocks = (n + 127) / 128;
+        auto const act_scal_elesize = num_n_blocks * m_padded;
+        TORCH_CHECK(act_scal_elesize <= scaleFP8SF.numel(), "Scale tensor size mismatch. Expected at least ",
+            act_scal_elesize, " elements, got ", scaleFP8SF.numel());
+
+        // Process scale tensor in a single chain of operations
+        scaleFP8SF
+            = scaleFP8SF.slice(0, 0, act_scal_elesize).view({num_n_blocks, m_padded}).slice(1, 0, m).contiguous();
+    }
     return {valueE4M3.slice(0, 0, m), scaleFP8SF};
 }
 

--- a/cpp/tensorrt_llm/thop/fp8Quantize.cpp
+++ b/cpp/tensorrt_llm/thop/fp8Quantize.cpp
@@ -74,7 +74,7 @@ std::tuple<at::Tensor, at::Tensor> fp8_quantize_1x128(at::Tensor const& self)
         TORCH_CHECK(act_scal_elesize <= scaleFP8SF.numel(), "Scale tensor size mismatch. Expected at least ",
             act_scal_elesize, " elements, got ", scaleFP8SF.numel());
 
-        // Process scale tensor in a single chain of operations
+        // scaleFP8SF = scaleFP8SF[0:num_n_blocks, 0:m] // no 4-element alignment in blackwell
         scaleFP8SF
             = scaleFP8SF.slice(0, 0, act_scal_elesize).view({num_n_blocks, m_padded}).slice(1, 0, m).contiguous();
     }

--- a/cpp/tensorrt_llm/thop/fp8Quantize.cpp
+++ b/cpp/tensorrt_llm/thop/fp8Quantize.cpp
@@ -75,7 +75,8 @@ std::tuple<at::Tensor, at::Tensor> fp8_quantize_1x128(at::Tensor const& self)
             act_scal_elesize, " elements, got ", scaleFP8SF.numel());
 
         // scaleFP8SF = scaleFP8SF[0:num_n_blocks, 0:m] // no 4-element alignment in blackwell
-        // TODO: This is a hack to use sm90 quantize kernel for sm100; ideally we should have a separate quantize kernel for sm100.
+        // TODO: This is a hack to use sm90 quantize kernel for sm100; ideally we should have a separate quantize kernel
+        // for sm100.
         scaleFP8SF
             = scaleFP8SF.slice(0, 0, act_scal_elesize).view({num_n_blocks, m_padded}).slice(1, 0, m).contiguous();
     }

--- a/tests/unittest/_torch/test_fp8_block_scale_gemm.py
+++ b/tests/unittest/_torch/test_fp8_block_scale_gemm.py
@@ -32,7 +32,7 @@ from utils.util import getSMVersion
 )
 @pytest.mark.parametrize(
     "m",
-    [64, 128, 4096],
+    [7, 64, 128, 4096],
 )
 @pytest.mark.parametrize(
     "dtype",

--- a/tests/unittest/_torch/test_fp8_block_scale_gemm.py
+++ b/tests/unittest/_torch/test_fp8_block_scale_gemm.py
@@ -22,7 +22,7 @@ from utils.util import getSMVersion
 
 
 @pytest.mark.skipif(
-    getSMVersion() != 90,
+    getSMVersion() not in [90, 100],
     reason="Op only supported on Hopper",
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
This is to fix: https://github.com/NVIDIA/TensorRT-LLM/issues/3118

Some assertions in Blackwell FP8 blockwise gemm kernel may be misplaced.  Also, this PR handles the scaling factor layout mismatch for Blackwell kernels, compared to Hopper.