### PR TITLE
perf: Use pinned H2D to reduce bubbles

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -502,8 +502,8 @@ class TrtllmAttentionMetadata(AttentionMetadata):
         # the sequence length including the cached tokens and the input tokens.
         self.kv_lens[:self.num_seqs].copy_(
             kv_lens + self.kv_cache_params.num_extra_kv_tokens)
-        self.kv_lens_cuda[:self.num_seqs].copy_(kv_lens[:self.num_seqs],
-                                                non_blocking=True)
+        self.kv_lens_cuda[:self.num_seqs].copy_(
+            kv_lens[:self.num_seqs].pin_memory(), non_blocking=True)
         self.host_request_types[:self.num_contexts].fill_(0)
         self.host_request_types[self.num_contexts:self.num_seqs].fill_(1)
 
@@ -520,7 +520,7 @@ class TrtllmAttentionMetadata(AttentionMetadata):
 
     def prepare_flash_mla(self) -> None:
         block_ids_per_seq = self.kv_cache_manager.get_block_ids_per_seq(
-            self.request_ids)
+            self.request_ids).pin_memory()
         num_blocks = block_ids_per_seq.shape[1]
         self.kv_block_ids_per_seq[:self.num_seqs, :num_blocks].copy_(
             block_ids_per_seq, non_blocking=True)

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1012,7 +1012,9 @@ class PyTorchModelEngine(ModelEngine):
         num_tokens = len(input_ids)
         previous_batchs = len(previous_batch_indices)
         if num_tokens > 0:
-            input_ids = torch.tensor(input_ids, dtype=torch.int)
+            input_ids = torch.tensor(input_ids,
+                                     dtype=torch.int,
+                                     pin_memory=True)
             if len(scheduled_requests.context_requests) == 0:
                 self.input_ids_cuda[previous_batchs:num_tokens +
                                     previous_batchs].copy_(input_ids,
@@ -1023,7 +1025,8 @@ class PyTorchModelEngine(ModelEngine):
         if next_draft_tokens_device is not None:
             if len(previous_batch_indices) > 0:
                 previous_batch_indices = torch.tensor(previous_batch_indices,
-                                                      dtype=torch.int)
+                                                      dtype=torch.int,
+                                                      pin_memory=True)
                 self.previous_batch_indices_cuda[:previous_batchs].copy_(
                     previous_batch_indices, non_blocking=True)
                 # previous input ids
@@ -1045,7 +1048,8 @@ class PyTorchModelEngine(ModelEngine):
                 # prepare data for the preprocess inputs
                 kv_len_offsets_device = new_tokens_lens_device - self.max_draft_len - 1
                 previous_pos_indices = torch.tensor(previous_pos_indices,
-                                                    dtype=torch.int)
+                                                    dtype=torch.int,
+                                                    pin_memory=True)
                 self.previous_pos_indices_cuda[:previous_batch_tokens].copy_(
                     previous_pos_indices, non_blocking=True)
                 self.previous_pos_id_offsets_cuda[:previous_batch_tokens].copy_(
@@ -1063,7 +1067,8 @@ class PyTorchModelEngine(ModelEngine):
         elif new_tokens_device is not None:
             previous_batch_tokens = len(previous_batch_indices)
             previous_batch_indices = torch.tensor(previous_batch_indices,
-                                                  dtype=torch.int)
+                                                  dtype=torch.int,
+                                                  pin_memory=True)
             self.previous_batch_indices_cuda[:previous_batch_tokens].copy_(
                 previous_batch_indices, non_blocking=True)
             if len(scheduled_requests.context_requests) == 0:
@@ -1078,12 +1083,14 @@ class PyTorchModelEngine(ModelEngine):
                         non_blocking=True)
 
         total_num_tokens = len(position_ids)
-        position_ids = torch.tensor(position_ids, dtype=torch.int)
+        position_ids = torch.tensor(position_ids,
+                                    dtype=torch.int,
+                                    pin_memory=True)
         self.position_ids_cuda[:total_num_tokens].copy_(position_ids,
                                                         non_blocking=True)
         if self.spec_config is not None:
             self.gather_ids_cuda[:len(gather_ids)].copy_(torch.tensor(
-                gather_ids, dtype=torch.int),
+                gather_ids, dtype=torch.int, pin_memory=True),
                                                          non_blocking=True)
 
         if not attn_metadata.is_cuda_graph:
@@ -1096,6 +1103,7 @@ class PyTorchModelEngine(ModelEngine):
             attn_metadata.seq_lens = torch.tensor(
                 sequence_lengths,
                 dtype=torch.int,
+                pin_memory=True,
             )
 
         attn_metadata.request_ids = request_ids
@@ -1127,7 +1135,9 @@ class PyTorchModelEngine(ModelEngine):
         if spec_metadata is not None:
             total_draft_lens = sum(draft_lens)
             if len(draft_tokens) > 0:
-                draft_tokens = torch.tensor(draft_tokens, dtype=torch.int)
+                draft_tokens = torch.tensor(draft_tokens,
+                                            dtype=torch.int,
+                                            pin_memory=True)
                 self.draft_tokens_cuda[:len(draft_tokens)].copy_(
                     draft_tokens, non_blocking=True)
             spec_metadata.draft_tokens = self.draft_tokens_cuda[:
@@ -1211,15 +1221,17 @@ class PyTorchModelEngine(ModelEngine):
                 multi_modal_data.append(prompt_embedding_table)
 
         num_tokens = len(input_ids)
-        input_ids = torch.tensor(input_ids, dtype=torch.int)
+        input_ids = torch.tensor(input_ids, dtype=torch.int, pin_memory=True)
         self.input_ids_cuda[:num_tokens].copy_(input_ids, non_blocking=True)
 
-        position_ids = torch.tensor(position_ids, dtype=torch.int)
+        position_ids = torch.tensor(position_ids,
+                                    dtype=torch.int,
+                                    pin_memory=True)
         self.position_ids_cuda[:num_tokens].copy_(position_ids,
                                                   non_blocking=True)
         if self.spec_config is not None:
             self.gather_ids_cuda[:len(gather_ids)].copy_(torch.tensor(
-                gather_ids, dtype=torch.int),
+                gather_ids, dtype=torch.int, pin_memory=True),
                                                          non_blocking=True)
 
         if not attn_metadata.is_cuda_graph:
@@ -1232,6 +1244,7 @@ class PyTorchModelEngine(ModelEngine):
             attn_metadata.seq_lens = torch.tensor(
                 sequence_lengths,
                 dtype=torch.int,
+                pin_memory=True,
             )
 
         attn_metadata.num_contexts = len(scheduled_requests.context_requests)
@@ -1466,10 +1479,12 @@ class PyTorchModelEngine(ModelEngine):
             output_token_idx += 1
 
         num_tokens = len(input_ids)
-        input_ids = torch.tensor(input_ids, dtype=torch.int)
+        input_ids = torch.tensor(input_ids, dtype=torch.int, pin_memory=True)
         self.input_ids_cuda[:num_tokens].copy_(input_ids, non_blocking=True)
 
-        position_ids = torch.tensor(position_ids, dtype=torch.int)
+        position_ids = torch.tensor(position_ids,
+                                    dtype=torch.int,
+                                    pin_memory=True)
         self.position_ids_cuda[:num_tokens].copy_(position_ids,
                                                   non_blocking=True)
 
@@ -1483,6 +1498,7 @@ class PyTorchModelEngine(ModelEngine):
             attn_metadata.seq_lens = torch.tensor(
                 sequence_lengths,
                 dtype=torch.int,
+                pin_memory=True,
             )
 
         attn_metadata.request_ids = request_ids

--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -129,7 +129,10 @@ class MTPSpecMetadata(SpecMetadata):
         assert self.request_ids is not None
         num_seqs = len(self.request_ids)
         # update batch indeices
-        batch_indices = torch.arange(num_seqs, dtype=torch.int, device='cpu')
+        batch_indices = torch.arange(num_seqs,
+                                     dtype=torch.int,
+                                     device='cpu',
+                                     pin_memory=True)
         self.batch_indices_cuda[:num_seqs].copy_(batch_indices,
                                                  non_blocking=True)
         # MTP module need different number of input tokens in generation phase
@@ -153,10 +156,14 @@ class MTPSpecMetadata(SpecMetadata):
                     mtp_past_tokens_pool[slot_id].data_ptr())
                 mtp_slot_ids.append(slot_id)
             mtp_hidden_states_ptrs = torch.tensor(mtp_hidden_states_ptrs,
-                                                  dtype=torch.int64)
+                                                  dtype=torch.int64,
+                                                  pin_memory=True)
             mtp_past_tokens_ptrs = torch.tensor(mtp_past_tokens_ptrs,
-                                                dtype=torch.int64)
-            mtp_slot_ids = torch.tensor(mtp_slot_ids, dtype=torch.int)
+                                                dtype=torch.int64,
+                                                pin_memory=True)
+            mtp_slot_ids = torch.tensor(mtp_slot_ids,
+                                        dtype=torch.int,
+                                        pin_memory=True)
 
             self.mtp_hidden_states_ptrs[:num_seqs].copy_(mtp_hidden_states_ptrs,
                                                          non_blocking=True)


### PR DESCRIPTION
In some cases, some pageable H2D operations are followed by `cudaStreamSynchronize` operations, which block kernel launches on CPU. This problem can be solved by changing pageable H2D to pinned H2D.