### PR TITLE
fix: conditional disagg test name

### DIFF
--- a/cpp/tests/executor/disaggExecutorTest.cpp
+++ b/cpp/tests/executor/disaggExecutorTest.cpp
@@ -1102,7 +1102,7 @@ INSTANTIATE_TEST_SUITE_P(GptSingleDeviceDisaggSymmetricExecutorMixedTest, Disagg
         testing::Values(1)),
     generateTestNameDisaggParams);
 
-INSTANTIATE_TEST_SUITE_P(ConditionalDisaggExecutorTest, ConditionalDisaggParamsTest,
+INSTANTIATE_TEST_SUITE_P(ConditionalDisaggSymmetricExecutorTest, ConditionalDisaggParamsTest,
     testing::Combine(testing::Values("gpt", "llama_tp1_pp1_cp1")), generateTestNameCondDisaggParams);
 
 INSTANTIATE_TEST_SUITE_P(LlamaTP2DisaggSymmetricExecutorTest, DisaggParamsTest,


### PR DESCRIPTION
The test name of conditional disaggregation test is not cover by `run_disagg_multi_gpu_tests` in `cpp_common.py` previously. This PR updated the name to be covered by filter `*DisaggSymmetricExecutorTest*`