### PR TITLE
feat: refactor scaffolding worker and support openai api worker

### DIFF
--- a/tensorrt_llm/scaffolding/task.py
+++ b/tensorrt_llm/scaffolding/task.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import List, Optional, Union
 
 
@@ -20,10 +21,10 @@ class Task:
     custom_output_params: Optional[dict] = None
 
 
-@dataclass
-class TaskStatus:
-    # TODO: add fields or maybe update it to enum
-    pass
+class TaskStatus(Enum):
+    SUCCESS = "success"
+    WORKER_NOT_SUPPORTED = "worker_not_supported"
+    WORKER_EXECEPTION = "worker_exception"
 
 
 @dataclass
@@ -33,11 +34,13 @@ class GenerationTask(Task):
     input_str: Optional[str] = field(default=None)
     skip_tokenizer: bool = False
     skip_detokenizer: bool = False
-    # custom sampling params to override worker's sampling params in each generation.
-    custom_sampling_params: Optional[dict] = None
+    # sampling params
+    #custom_sampling_params: Optional[dict] = None
+    max_tokens: Optional[int] = field(default=None)
+    temperature: Optional[float] = field(default=None)
+    top_p: Optional[float] = field(default=None)
+    top_k: Optional[int] = field(default=None)
 
-    # overwrite base class default value
-    type: str = field(default="generate")
     # suggest to use Controller.WorkerTag
     # anyway, users need to ensure that the value of the worker_tag can be found in the scaffoldingLlm's workers map
     worker_tag: Union[str, "Controller.WorkerTag"] = None

--- a/tests/unittest/scaffolding/test_scaffolding.py
+++ b/tests/unittest/scaffolding/test_scaffolding.py
@@ -1,71 +1,30 @@
-from pathlib import Path
-
 # isort: off
-from utils.llm_data import llm_models_root
 # isort: on
 
-import pytest
+from scaffolding.test_worker import create_trtllm_worker
 
-from tensorrt_llm._torch.pyexecutor.config import PyTorchConfig
 from tensorrt_llm.scaffolding.controller import (MajorityVoteController,
                                                  NativeGenerationController)
 from tensorrt_llm.scaffolding.scaffolding_llm import ScaffoldingLlm
-from tensorrt_llm.scaffolding.worker import ProposerWorker, SamplingParams
-
-
-@pytest.fixture(scope="module")
-def deepseek_distill_7b_path() -> Path:
-    model_dir = llm_models_root() / "DeepSeek-R1/DeepSeek-R1-Distill-Qwen-7B"
-    return model_dir
-
-
-@pytest.fixture(scope="module")
-def sampling_params():
-    return SamplingParams(max_tokens=2048)
-
-
-@pytest.fixture(scope="module")
-def pytorch_config():
-    return PyTorchConfig(
-        mixed_decoder=True,
-        enable_overlap_scheduler=True,
-    )
-
-
-@pytest.fixture(scope="module")
-def default_prompt():
-    prompt = "Natalia sold clips to 48 of her friends in April, and then she sold half as many clips in May. How many clips did Natalia sell altogether in April and May?\r\n\r\n"
-    return prompt
-
-
-def create_proposer_worker(deepseek_distill_7b_path, sampling_params,
-                           pytorch_config):
-    return ProposerWorker(
-        deepseek_distill_7b_path,
-        pytorch_backend_config=pytorch_config,
-        sampling_params=sampling_params,
-    )
 
 
 def create_scaffolding_llm_with_native_generation_controller(
-        deepseek_distill_7b_path, sampling_params, pytorch_config):
-    proposer_worker = create_proposer_worker(deepseek_distill_7b_path,
-                                             sampling_params, pytorch_config)
+        deepseek_distill_7b_path):
+    trtllm_worker = create_trtllm_worker(deepseek_distill_7b_path)
     prototype_generation_controller = NativeGenerationController()
     return ScaffoldingLlm(
         prototype_generation_controller,
-        {NativeGenerationController.WorkerTag.GENERATION: proposer_worker},
+        {NativeGenerationController.WorkerTag.GENERATION: trtllm_worker},
     )
 
 
 def create_scaffolding_llm_with_majority_vote_controller(
-        deepseek_distill_7b_path, sampling_params, pytorch_config, samples_num):
-    proposer_worker = create_proposer_worker(deepseek_distill_7b_path,
-                                             sampling_params, pytorch_config)
+        deepseek_distill_7b_path, samples_num):
+    trtllm_worker = create_trtllm_worker(deepseek_distill_7b_path)
 
     workers = {}
     prototype_generation_controller = NativeGenerationController()
-    workers[NativeGenerationController.WorkerTag.GENERATION] = proposer_worker
+    workers[NativeGenerationController.WorkerTag.GENERATION] = trtllm_worker
 
     prototype_majority_vote_controller = MajorityVoteController(
         prototype_generation_controller,
@@ -80,20 +39,18 @@ def create_scaffolding_llm_with_majority_vote_controller(
     return llm
 
 
-def test_unbatched_scaffolding_sync(default_prompt, deepseek_distill_7b_path,
-                                    sampling_params, pytorch_config):
+def test_unbatched_scaffolding_sync(default_prompt, deepseek_distill_7b_path):
     scaffolding_llm = create_scaffolding_llm_with_native_generation_controller(
-        deepseek_distill_7b_path, sampling_params, pytorch_config)
+        deepseek_distill_7b_path)
     result = scaffolding_llm.generate(default_prompt)
     assert isinstance(result.output.output_str, str) and len(
         result.output.output_str) > 0, "Output should be a non-empty string"
     scaffolding_llm.shutdown(shutdown_wokers=True)
 
 
-def test_batched_scaffolding_sync(default_prompt, deepseek_distill_7b_path,
-                                  sampling_params, pytorch_config):
+def test_batched_scaffolding_sync(default_prompt, deepseek_distill_7b_path):
     scaffolding_llm = create_scaffolding_llm_with_native_generation_controller(
-        deepseek_distill_7b_path, sampling_params, pytorch_config)
+        deepseek_distill_7b_path)
     batch_size = 3
     prompts = [default_prompt] * batch_size
     results = scaffolding_llm.generate(prompts)
@@ -104,12 +61,11 @@ def test_batched_scaffolding_sync(default_prompt, deepseek_distill_7b_path,
     scaffolding_llm.shutdown(shutdown_wokers=True)
 
 
-def test_async_scaffolding_generation(default_prompt, deepseek_distill_7b_path,
-                                      sampling_params, pytorch_config):
+def test_async_scaffolding_generation(default_prompt, deepseek_distill_7b_path):
 
     async def run_async_test():
         scaffolding_llm = create_scaffolding_llm_with_native_generation_controller(
-            deepseek_distill_7b_path, sampling_params, pytorch_config)
+            deepseek_distill_7b_path)
         future = scaffolding_llm.generate_async(default_prompt)
         result = await future.aresult()
         assert isinstance(result.output.output_str, str) and len(
@@ -120,13 +76,9 @@ def test_async_scaffolding_generation(default_prompt, deepseek_distill_7b_path,
     asyncio.run(run_async_test())
 
 
-def test_majority_vote(default_prompt, deepseek_distill_7b_path,
-                       sampling_params, pytorch_config):
+def test_majority_vote(default_prompt, deepseek_distill_7b_path):
     scaffolding_llm = create_scaffolding_llm_with_majority_vote_controller(
-        deepseek_distill_7b_path,
-        sampling_params,
-        pytorch_config,
-        samples_num=3)
+        deepseek_distill_7b_path, samples_num=3)
     result = scaffolding_llm.generate(default_prompt)
     assert isinstance(result.output.output_str, str) and len(
         result.output.output_str) > 0, "Output should be a non-empty string"

--- a/tests/unittest/scaffolding/test_worker.py
+++ b/tests/unittest/scaffolding/test_worker.py
@@ -1,0 +1,123 @@
+from pathlib import Path
+
+# isort: off
+from utils.llm_data import llm_models_root
+# isort: on
+
+import asyncio
+import os
+import sys
+
+import openai
+import pytest
+from llmapi.apps.openai_server import RemoteOpenAIServer
+
+from tensorrt_llm.scaffolding.task import GenerationTask, TaskStatus
+from tensorrt_llm.scaffolding.worker import TRTLLMWorker, TRTOpenaiWorker
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+from llmapi.test_llm import get_model_path
+
+
+@pytest.fixture(scope="module")
+def deepseek_distill_7b_path() -> Path:
+    model_dir = llm_models_root() / "DeepSeek-R1/DeepSeek-R1-Distill-Qwen-7B"
+    return model_dir
+
+
+@pytest.fixture(scope="module")
+def default_prompt():
+    prompt = "Natalia sold clips to 48 of her friends in April, and then she sold half as many clips in May. How many clips did Natalia sell altogether in April and May?\r\n\r\n"
+    return prompt
+
+
+@pytest.fixture(scope="module")
+def model_name():
+    return "DeepSeek-R1/DeepSeek-R1-Distill-Qwen-7B"
+
+
+@pytest.fixture(scope="module", params=['pytorch'])
+def backend(request):
+    return request.param
+
+
+@pytest.fixture(scope="module", params=[2], ids=["enable_processpool"])
+def num_postprocess_workers(request):
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def server(model_name: str, backend: str, num_postprocess_workers: int):
+    model_path = get_model_path(model_name)
+
+    args = ["--backend", f"{backend}"]
+    args.extend(["--num_postprocess_workers", f"{num_postprocess_workers}"])
+    with RemoteOpenAIServer(model_path, args) as remote_server:
+        yield remote_server
+
+
+@pytest.fixture(scope="module")
+def async_client(server: RemoteOpenAIServer):
+    return server.get_async_client()
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_single_completion(async_client: openai.OpenAI, model_name):
+    completion = await async_client.completions.create(
+        model=model_name,
+        prompt="Hello, my name is",
+        max_tokens=5,
+        temperature=0.0,
+    )
+
+    choice = completion.choices[0]
+    assert len(choice.text) >= 5
+    assert choice.finish_reason == "length"
+    assert completion.id is not None
+    assert completion.choices is not None and len(completion.choices) == 1
+    completion_tokens = 5
+    prompt_tokens = 6
+    assert completion.usage == openai.types.CompletionUsage(
+        completion_tokens=completion_tokens,
+        prompt_tokens=prompt_tokens,
+        total_tokens=prompt_tokens + completion_tokens)
+
+    # test using token IDs
+    completion = await async_client.completions.create(
+        model=model_name,
+        prompt=[0, 0, 0, 0, 0],
+        max_tokens=5,
+        temperature=0.0,
+    )
+    assert len(completion.choices[0].text) >= 1
+
+
+def create_trtoai_worker(model_name, async_client):
+    return TRTOpenaiWorker(
+        async_client=async_client,
+        model=model_name,
+    )
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_trtoai_worker_generation(default_prompt, model_name,
+                                        async_client):
+    worker = create_trtoai_worker(model_name, async_client)
+    task = GenerationTask.create_from_prompt(default_prompt)
+    status = await worker.run_task(task)
+    assert status == TaskStatus.SUCCESS, "Generation Task is not successful with TRTOpenaiWorker"
+
+
+def create_trtllm_worker(model_path):
+    return TRTLLMWorker.init_with_new_llm(str(model_path),
+                                          backend="pytorch",
+                                          max_batch_size=32,
+                                          max_num_tokens=4096,
+                                          temperature=0.9)
+
+
+def test_trtllm_worker_generation(default_prompt, deepseek_distill_7b_path):
+    worker = create_trtllm_worker(deepseek_distill_7b_path)
+    task = GenerationTask.create_from_prompt(default_prompt)
+    status = asyncio.run(worker.run_task(task))
+    assert status == TaskStatus.SUCCESS, "Generation Task is not successful with TRTLLMWorker"


### PR DESCRIPTION
refacot scaffolding worker and support openai api worker.

- Add "register_task_handler" api to worker so that user can use this api to register/add/override task handle function.
- Implement openai api workers including standard openai api worker and trtllm special openai api worker.
- Change ProposerWorker to TRTLLMWorker and TRTLLMWorker uses LLM api.