### PR TITLE
feat: Support CUDA graphs for EAGLE3

### DIFF
--- a/tensorrt_llm/_torch/speculative/utils.py
+++ b/tensorrt_llm/_torch/speculative/utils.py
@@ -16,7 +16,8 @@ def get_spec_metadata(spec_config,
         return Eagle3SpecMetadata(max_draft_tokens=spec_config.max_draft_tokens,
                                   spec_dec_mode=spec_config.spec_dec_mode,
                                   max_num_requests=max_num_requests,
-                                  num_layers=spec_config.num_layers)
+                                  num_layers=spec_config.num_layers,
+                                  hidden_size=spec_config.hidden_size)
     else:
         return None
 


### PR DESCRIPTION
Support CUDA graphs for the EAGLE-3 spec decode. Also contains fixes for loading eagle 3 weights for llama3 70B models (previously only tested for 8b).

The graphs significantly improve the performance. However, we still have a lot of work to do to eliminate the host overheads.