### PR TITLE
Revert "refactor: Replace DecoderFinishedEvent with CudaEvent in decoder classes"

### DIFF
--- a/cpp/include/tensorrt_llm/runtime/gptDecoderBatched.h
+++ b/cpp/include/tensorrt_llm/runtime/gptDecoderBatched.h
@@ -57,7 +57,7 @@ public:
     void disableLookahead(
         SizeType32 maxBatchSize, RequestVector const& genRequests, TensorPtr const& batchSlots) override;
 
-    CudaEvent forwardAsync(decoder_batch::Output& output, decoder_batch::Input const& input) override;
+    DecoderFinishedEventPtr forwardAsync(decoder_batch::Output& output, decoder_batch::Input const& input) override;
     void forward(decoder_batch::Output& output, decoder_batch::Input const& input) override;
 
     //! @brief Gather final beam search results for request `batchSlot`.

--- a/cpp/include/tensorrt_llm/runtime/statefulGptDecoderBatched.h
+++ b/cpp/include/tensorrt_llm/runtime/statefulGptDecoderBatched.h
@@ -30,6 +30,7 @@ class StatefulGptDecoderBatched : public IStatefulGptDecoder
 public:
     using CudaStreamPtr = std::shared_ptr<CudaStream>;
     using TensorPtr = ITensor::SharedPtr;
+    using DecoderFinishedEventPtr = std::unique_ptr<decoder_batch::DecoderFinishedEvent const>;
 
     StatefulGptDecoderBatched(CudaStreamPtr stream, nvinfer1::DataType dtype);
 
@@ -58,7 +59,7 @@ private:
     std::unique_ptr<GptDecoderBatched> mDecoder;
 
     // only used for IStatefulGptDecoder
-    CudaEvent mDecoderFinishEvent;
+    DecoderFinishedEventPtr mDecoderFinishEvent;
     CudaEvent mForwardEvent;
     TensorPtr mFinishedSum;
     TensorPtr mBatchSlotsSetup;   // [maxBatchSize], int32_t, address map, pinned

--- a/cpp/tensorrt_llm/batch_manager/trtEncoderModel.h
+++ b/cpp/tensorrt_llm/batch_manager/trtEncoderModel.h
@@ -44,6 +44,7 @@ public:
     using BufferManager = tensorrt_llm::runtime::BufferManager;
     using TensorMap = runtime::StringPtrMap<runtime::ITensor>;
     using TensorPtr = runtime::ITensor::SharedPtr;
+    using DecoderFinishedEventPtr = std::unique_ptr<runtime::decoder_batch::DecoderFinishedEvent const>;
 
     TrtEncoderModel(runtime::ModelConfig const& modelConfig, runtime::WorldConfig const& worldConfig,
         runtime::RawEngine const& rawEngine, std::shared_ptr<nvinfer1::ILogger> logger,
@@ -194,6 +195,7 @@ private:
     SizeType32 mNumBuffers;
 
     std::vector<ScheduledRequests> mMicroBatchScheduledRequests;
+    std::vector<DecoderFinishedEventPtr> mEncoderWaitEvents;
     ReqIdsSet mInflightReqIds;
     ReqIdsSet mReqIdsToPause;
 

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -769,7 +769,7 @@ void TrtGptModelInflightBatching::forwardSync()
             }
             // Wait for decoding for requests in flight for the current micro batch
             auto& decoderWaitEvent = mDecoderFinishedEvents.at(mMicroBatchId);
-            mDecStepAsyncSndHdls = decoderSync(currRequests, std::move(decoderWaitEvent.value()));
+            mDecStepAsyncSndHdls = decoderSync(currRequests, std::move(decoderWaitEvent));
             decoderWaitEvent.reset();
 
             if (!mWorldConfig.isLastPipelineParallelRank())
@@ -980,15 +980,14 @@ void TrtGptModelInflightBatching::forwardAsync(RequestList const& activeRequests
                 auto& prevDecoderFinishedEvent = mDecoderFinishedEvents.at(prevMicroBatchId);
                 if (prevDecoderFinishedEvent)
                 {
-                    prevDecoderFinishedEvent->synchronize();
+                    prevDecoderFinishedEvent->event.synchronize();
                 }
             }
 
             auto& decoderFinishedEvent = mDecoderFinishedEvents.at(mMicroBatchId);
-            TLLM_CHECK_WITH_INFO(!decoderFinishedEvent.has_value(), "decoderFinishedEvent must be nullopt.");
-            decoderFinishedEvent = mWorldConfig.isLastPipelineParallelRank()
-                ? std::make_optional(decoderStepAsync(currRequests))
-                : std::nullopt;
+            TLLM_CHECK_WITH_INFO(decoderFinishedEvent.get() == nullptr, "decoderFinishedEvent handle must be nullptr.");
+            decoderFinishedEvent = mWorldConfig.isLastPipelineParallelRank() ? decoderStepAsync(currRequests)
+                                                                             : DecoderFinishedEventPtr();
 
             mLastIterationStatsIFB = fillIterationStats(currRequests, requestsToPause);
             for (auto const& requests : {currRequests.contextRequests, currRequests.generationRequests})
@@ -1037,7 +1036,7 @@ void TrtGptModelInflightBatching::forwardAsync(RequestList const& activeRequests
                 }
                 // Wait for decoding for requests in flight for the current micro batch
                 auto& decoderFinishedEvent = mDecoderFinishedEvents.at(mMicroBatchId);
-                mDecStepAsyncSndHdls = decoderSync(currRequests, std::move(decoderFinishedEvent.value()));
+                mDecStepAsyncSndHdls = decoderSync(currRequests, std::move(decoderFinishedEvent));
                 decoderFinishedEvent.reset();
 
                 mAsyncSendWaitThread->notifyStart();
@@ -1875,7 +1874,8 @@ bool batchReturnLogProbs(ScheduledRequests const& scheduledRequests)
 }
 } // namespace
 
-runtime::CudaEvent TrtGptModelInflightBatching::decoderStepAsync(ScheduledRequests const& scheduledRequests)
+TrtGptModelInflightBatching::DecoderFinishedEventPtr TrtGptModelInflightBatching::decoderStepAsync(
+    ScheduledRequests const& scheduledRequests)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
     NVTX3_SCOPED_RANGE(decoderStepAsync);
@@ -1914,7 +1914,7 @@ runtime::CudaEvent TrtGptModelInflightBatching::decoderStepAsync(ScheduledReques
             *mDecoderBuffers, mDecoderInputBuffers.at(fusedBufferId), mModelConfig, getMaxNumSequences(),
             mOperatingBeamWidth, mRuntime->getBufferManager(), mRuntime->getStream(), *fusedRuntimeBuffers);
 
-    runtime::CudaEvent decoderFinishEvent = mDecoder->forwardAsync(*mDecodingOutput, *decodingInput);
+    DecoderFinishedEventPtr decoderFinishEvent = mDecoder->forwardAsync(*mDecodingOutput, *decodingInput);
 
     auto const returnLogProbs = batchReturnLogProbs(scheduledRequests);
     decoderFinishEvent = updateDecoderBuffers(returnLogProbs, std::move(decoderFinishEvent));
@@ -1980,14 +1980,14 @@ void TrtGptModelInflightBatching::copyCacheIndirectionFromOutputsToInputs(
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
 }
 
-runtime::CudaEvent TrtGptModelInflightBatching::updateDecoderBuffers(
-    bool returnLogProbs, runtime::CudaEvent decoderFinishEvent)
+TrtGptModelInflightBatching::DecoderFinishedEventPtr TrtGptModelInflightBatching::updateDecoderBuffers(
+    bool returnLogProbs, DecoderFinishedEventPtr decoderFinishEvent)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
     NVTX3_SCOPED_RANGE(updateDecoderBuffers);
 
     // Chain copy after decoder event, using a different stream
-    mCopyBufferManager.getStream().wait(decoderFinishEvent);
+    mCopyBufferManager.getStream().wait(decoderFinishEvent->event);
 
     mDecoderBuffers->newOutputTokens = mDecoder->getDecoderState().getAllNewTokens();
 
@@ -2038,7 +2038,7 @@ runtime::CudaEvent TrtGptModelInflightBatching::updateDecoderBuffers(
     mCopyBufferManager.getStream().record(copyEvent);
     // Store the event for later sync. Sync stream before calling next decoder. Sync host before updating requests.
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
-    return copyEvent;
+    return std::make_unique<decoder_batch::DecoderFinishedEvent>(std::move(copyEvent), decoderFinishEvent->active);
 }
 
 std::vector<std::unique_ptr<DecoderStepAsyncSend>> TrtGptModelInflightBatching::communicateDecoderBuffers(
@@ -2296,14 +2296,14 @@ void TrtGptModelInflightBatching::updateRequests(ScheduledRequests const& schedu
 }
 
 std::vector<std::unique_ptr<DecoderStepAsyncSend>> TrtGptModelInflightBatching::decoderSync(
-    ScheduledRequests const& scheduledRequests, runtime::CudaEvent decoderFinishEvent)
+    ScheduledRequests const& scheduledRequests, DecoderFinishedEventPtr decoderFinishEvent)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
     NVTX3_SCOPED_RANGE(decoderSync);
 
     if (mWorldConfig.isLastPipelineParallelRank())
     {
-        decoderFinishEvent.synchronize();
+        decoderFinishEvent->event.synchronize();
     }
 
     auto const returnLogProbs = batchReturnLogProbs(scheduledRequests);

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
@@ -119,6 +119,7 @@ public:
     using PeftTable = PeftCacheManager::PeftTable;
     using TensorMap = runtime::StringPtrMap<runtime::ITensor>;
     using TensorPtr = runtime::ITensor::SharedPtr;
+    using DecoderFinishedEventPtr = std::unique_ptr<runtime::decoder_batch::DecoderFinishedEvent const>;
 
     TrtGptModelInflightBatching(std::shared_ptr<nvinfer1::ILogger> logger, runtime::ModelConfig const& modelConfig,
         runtime::WorldConfig const& worldConfig, runtime::RawEngine const& rawEngine, bool ctxGenFusion,
@@ -281,11 +282,11 @@ private:
 
     void setupDecoderStep(
         RequestVector const& contextRequests, RuntimeBuffers const& buffers, DecoderInputBuffers const& inputBuffers);
-    runtime::CudaEvent decoderStepAsync(ScheduledRequests const& scheduledRequests);
+    DecoderFinishedEventPtr decoderStepAsync(ScheduledRequests const& scheduledRequests);
     std::vector<std::unique_ptr<DecoderStepAsyncSend>> decoderSync(
-        ScheduledRequests const& scheduledRequests, runtime::CudaEvent decoderFinishEvent);
+        ScheduledRequests const& scheduledRequests, DecoderFinishedEventPtr decoderFinishEvent);
 
-    runtime::CudaEvent updateDecoderBuffers(bool returnLogProbs, runtime::CudaEvent decoderFinishEvent);
+    DecoderFinishedEventPtr updateDecoderBuffers(bool returnLogProbs, DecoderFinishedEventPtr decoderFinishEvent);
     std::vector<std::unique_ptr<DecoderStepAsyncSend>> communicateDecoderBuffers(bool returnLogProbs);
     void updateRequests(ScheduledRequests const& scheduledRequests);
 
@@ -425,7 +426,7 @@ private:
     // Decoder that generates new tokens from the logits.
     std::shared_ptr<runtime::GptDecoderBatched> mDecoder;
     // Synchronization handles for decoder
-    std::vector<std::optional<runtime::CudaEvent>> mDecoderFinishedEvents;
+    std::vector<DecoderFinishedEventPtr> mDecoderFinishedEvents;
 
     // Manager that maps requests to slots
     std::shared_ptr<SequenceSlotManager> mSeqSlotManager;

--- a/cpp/tensorrt_llm/pybind/runtime/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/runtime/bindings.cpp
@@ -323,15 +323,15 @@ void initBindings(pybind11::module_& m)
     py::class_<tr::DecodingInput>(m, "DecodingInput");
     py::class_<tr::DecodingOutput>(m, "DecodingOutput");
 
-    py::class_<tr::CudaEvent>(m, "CudaEvent")
+    py::class_<tr::decoder_batch::DecoderFinishedEvent>(m, "Token")
         .def(py::init(
-            [](CudaStreamPtr stream)
+            [](CudaStreamPtr stream, std::vector<bool> const& active)
             {
                 tr::CudaEvent eventStop{};
                 stream->record(eventStop);
-                return eventStop;
+                return std::make_unique<tr::decoder_batch::DecoderFinishedEvent>(std::move(eventStop), active);
             }))
-        .def("synchronize", [](tr::CudaEvent& self) { self.synchronize(); });
+        .def("synchronize", [](tr::decoder_batch::DecoderFinishedEvent& self) { self.event.synchronize(); });
 
     py::class_<tr::IGptDecoder, PyIGptDecoder>(m, "IGptDecoder")
         .def(

--- a/cpp/tensorrt_llm/runtime/statefulGptDecoderBatched.cpp
+++ b/cpp/tensorrt_llm/runtime/statefulGptDecoderBatched.cpp
@@ -237,7 +237,7 @@ void StatefulGptDecoderBatched::forwardSync()
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
 
-    mDecoderFinishEvent.synchronize();
+    mDecoderFinishEvent->event.synchronize();
 
     // wait for mFinishedSum to be updated
     mForwardEvent.synchronize();


### PR DESCRIPTION
Reverts NVIDIA/TensorRT-LLM#3078.

The previous PR caused `bad optional access` in many multi GPU test cases:

1. unittest/llmapi/test_llm_multi_gpu.py::test_llm_pp2
2. unittest/llmapi/test_llm_multi_gpu.py::test_tinyllama_logits_processor_tp2pp2
3. ccuracy/test_accuracy.py::TestMixtral8x7B::test_fp8_tp2pp2_manage_weights