### PR TITLE
chore: Cursor ignore cubin in headers

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,5 +1,6 @@
 # Add directories or file patterns to ignore during indexing (e.g. foo/ or *.csv)
 
 *cubin.cpp
+*cubin.h
 3rdparty/
 data/


### PR DESCRIPTION
Add `*cubin.h` to ignore-file.