### PR TITLE
[BREAKING CHANGE][TRTLLM-4354] chore: Add output of first token to additional generation outputs

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
+++ b/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
@@ -1407,7 +1407,7 @@ public:
             auto shape = getTensorShape(outputTensorName);
             TLLM_CHECK_WITH_INFO(shape.d[0] == -1, "First dimension of additional output tensor '%s' must be dynamic",
                 outputTensorName.c_str());
-            shape.d[0] = mMaxNewTokens - 1;
+            shape.d[0] = mMaxNewTokens;
             shape = runtime::ITensor::unsqueeze(shape, 0);
             shape.d[0] = mSamplingConfig.beamWidth;
             auto tensor = runtime::BufferManager::pinnedPool(shape, dataType);

--- a/cpp/tests/unit_tests/executor/CMakeLists.txt
+++ b/cpp/tests/unit_tests/executor/CMakeLists.txt
@@ -9,7 +9,7 @@
 # license agreement from NVIDIA CORPORATION or its affiliates is strictly
 # prohibited.
 
-add_gtest(execSamplingConfigTest samplingConfigTest.cpp)
+add_gtest(executorSamplingConfigTest samplingConfigTest.cpp)
 add_gtest(kvCacheConfigTest kvCacheConfigTest.cpp)
 add_gtest(decodingConfigTest decodingConfigTest.cpp)
 add_gtest(requestTest requestTest.cpp)

--- a/cpp/tests/unit_tests/executor/executorTestSmallArbitraryOutputTensors.cpp
+++ b/cpp/tests/unit_tests/executor/executorTestSmallArbitraryOutputTensors.cpp
@@ -172,7 +172,7 @@ protected:
                 auto const& additionalOutputs = response.getResult().additionalOutputs;
                 ASSERT_EQ(additionalOutputs.size(), 1);
                 auto const& topKLogits = additionalOutputs.front();
-                auto const expectedOutputSize = (parameters.maxOutputLength - 1) * parameters.numTopKLogits;
+                auto const expectedOutputSize = parameters.maxOutputLength * parameters.numTopKLogits;
                 ASSERT_EQ(topKLogits.output.getSize(), expectedOutputSize);
                 auto const* topKLogitsData = reinterpret_cast<TLogits const*>(topKLogits.output.getData());
                 for (auto i = 0; i < parameters.numTopKLogits; i++)
@@ -234,7 +234,7 @@ protected:
                 auto const& additionalOutputs = response.getResult().additionalOutputs;
                 ASSERT_EQ(additionalOutputs.size(), 1);
                 auto const& topKLogits = additionalOutputs.front();
-                auto const expectedOutputSize = (parameters.maxOutputLength - 1) * parameters.numTopKLogits;
+                auto const expectedOutputSize = parameters.maxOutputLength * parameters.numTopKLogits;
                 ASSERT_EQ(topKLogits.output.getSize(), expectedOutputSize);
                 auto const* topKLogitsData = reinterpret_cast<TLogits const*>(topKLogits.output.getData());
                 for (auto i = 0; i < parameters.numTopKLogits; i++)
@@ -302,7 +302,7 @@ protected:
                 auto const contextTopKLogitsPtr = std::find_if(additionalOutputs.cbegin(), additionalOutputs.cend(),
                     [&expectedAdditionalOutputName](auto const& ao)
                     { return ao.name == expectedAdditionalOutputName; });
-                auto const expectedOutputSize = (parameters.promptLength) * parameters.numTopKLogits;
+                auto const expectedOutputSize = parameters.promptLength * parameters.numTopKLogits;
                 ASSERT_EQ(contextTopKLogitsPtr->output.getSize(), expectedOutputSize);
                 auto const* topKLogitsData = reinterpret_cast<TLogits const*>(contextTopKLogitsPtr->output.getData());
                 for (auto i = 0; i < parameters.numTopKLogits; i++)
@@ -369,7 +369,7 @@ protected:
                 auto const contextTopKLogitsPtr = std::find_if(additionalOutputs.cbegin(), additionalOutputs.cend(),
                     [&expectedAdditionalOutputName](auto const& ao)
                     { return ao.name == expectedAdditionalOutputName; });
-                auto const expectedOutputSize = (parameters.promptLength) * parameters.numTopKLogits;
+                auto const expectedOutputSize = parameters.promptLength * parameters.numTopKLogits;
                 ASSERT_EQ(contextTopKLogitsPtr->output.getSize(), expectedOutputSize);
                 auto const* topKLogitsData = reinterpret_cast<TLogits const*>(contextTopKLogitsPtr->output.getData());
                 for (auto i = 0; i < parameters.numTopKLogits; i++)


### PR DESCRIPTION
- Updated the first dimension of additional generation output tensors to match number of generated tokens.
- Copy output of last context token to generation outputs.
- Adjusted the expected output size calculations in unit tests to reflect the correct maximum output length.