### PR TITLE
perf: Add total token throughput metric.

### DIFF
--- a/tensorrt_llm/bench/dataclasses/reporting.py
+++ b/tensorrt_llm/bench/dataclasses/reporting.py
@@ -195,6 +195,12 @@ class ReportUtility:
         return self.convert_rate_to_s(self.statistics.output_throughput_tok_ns)
 
     @property
+    def total_token_throughput_tok_s(self) -> float:
+        """Total token throughput in tokens per second."""
+        return self.convert_rate_to_s(
+            self.statistics.total_token_throughput_tok_ns)
+
+    @property
     def per_user_generation_token_throughput_s(self) -> float:
         """Output throughput per user in tokens per second."""
         return self.convert_rate_to_s(
@@ -314,6 +320,8 @@ class ReportUtility:
             "system_output_throughput_tok_s":
             self.output_throughput_tok_s,
             # Output throughput per user (average per request output throughput)
+            "system_total_throughput_tok_s":
+            self.total_token_throughput_tok_s,
             "output_throughput_per_user_tok_s":
             self.per_user_output_throughput_tok_s,
             # Output throughput per GPU (total throughput / world size)
@@ -477,6 +485,7 @@ class ReportUtility:
             f"Total Output Throughput (tokens/sec):             {perf['system_output_throughput_tok_s']:.4f}\n"
             f"Per User Output Throughput (tokens/sec/user):     {perf['output_throughput_per_user_tok_s']:.4f}\n"
             f"Per GPU Output Throughput (tokens/sec/gpu):       {perf['output_throughput_per_gpu_tok_s']:.4f}\n"
+            f"Total Token Throughput (tokens/sec):              {perf['system_total_throughput_tok_s']:.4f}\n"
             f"Total Latency (ms):                               {perf['total_latency_ms']:.4f}\n"
             f"Average request latency (ms):                     {perf['avg_request_latency_ms']:.4f}\n"
         )

--- a/tensorrt_llm/bench/dataclasses/statistics.py
+++ b/tensorrt_llm/bench/dataclasses/statistics.py
@@ -184,5 +184,10 @@ class BenchmarkStatistics(BaseModel):
         return float(self.total_output_tokens) / self.total_latency_ns
 
     @computed_field
+    def total_token_throughput_tok_ns(self) -> float:
+        return float(self.total_input_tokens +
+                     self.total_output_tokens) / self.total_latency_ns
+
+    @computed_field
     def output_throughput_tok_ns_per_user(self) -> float:
         return self.output_throughput_percentiles.average


### PR DESCRIPTION
This MR adds total token throughput to the output for `trtllm-bench`. The computation for this metric is as follows: `(sum(input tokens per request) + sum(output tokens per request))/total time`. We've encountered cases where this metric was reported, so having `trtllm-bench` allows us to have the metric available without needing to compute it.