### PR TITLE
feat: support abort disconnected requests

### DIFF
--- a/tests/unittest/bindings/test_bindings_ut.py
+++ b/tests/unittest/bindings/test_bindings_ut.py
@@ -579,3 +579,21 @@ def test_KvCache_events_binding():
 
     del stream
     torch.cuda.empty_cache()
+
+
+def test_ReqIdsSet_pickle():
+    ids = _tb.internal.batch_manager.ReqIdsSet()
+    ids1 = pickle.loads(pickle.dumps(ids))
+    assert ids1 == ids
+
+    ids.insert(0)
+    ids.insert(1)
+    ids.insert(2)
+    ids1 = pickle.loads(pickle.dumps(ids))
+    assert ids1 == ids
+
+    ids1.erase(0)
+    ids2 = _tb.internal.batch_manager.ReqIdsSet()
+    ids2.insert(1)
+    ids2.insert(2)
+    assert ids1 == ids2

--- a/tests/unittest/llmapi/apps/_test_openai_misc.py
+++ b/tests/unittest/llmapi/apps/_test_openai_misc.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import openai
 import pytest
 import requests
@@ -18,13 +20,30 @@ def backend(request):
     return request.param
 
 
+@pytest.fixture(scope="module", params=['8'])
+def max_batch_size(request):
+    return request.param
+
+
+@pytest.fixture(scope="module", params=['80000'])
+def max_seq_len(request):
+    return request.param
+
+
 @pytest.fixture(scope="module")
-def server(model_name: str, backend: str):
+def server(model_name: str, backend: str, max_batch_size: str,
+           max_seq_len: str):
     model_path = get_model_path(model_name)
     args = ["--max_beam_width", "4"]
     if backend is not None:
         args.append("--backend")
         args.append(backend)
+    if max_batch_size is not None:
+        args.append("--max_batch_size")
+        args.append(max_batch_size)
+    if max_seq_len is not None:
+        args.append("--max_seq_len")
+        args.append(max_seq_len)
     with RemoteOpenAIServer(model_path, args) as remote_server:
         yield remote_server
 
@@ -50,3 +69,42 @@ def test_health(server: RemoteOpenAIServer):
 def test_model(client: openai.OpenAI, model_name: str):
     model = client.models.list().data[0]
     assert model.id == model_name.split('/')[-1]
+
+
+# reference: https://github.com/vllm-project/vllm/blob/44f990515b124272f87954fc763d90697d8aa1db/tests/entrypoints/openai/test_basic.py#L123
+@pytest.mark.asyncio
+async def test_request_cancellation(server: RemoteOpenAIServer,
+                                    model_name: str):
+    # clunky test: send an ungodly amount of load in with short timeouts
+    # then ensure that it still responds quickly afterwards
+
+    chat_input = [{"role": "user", "content": "Write a long story"}]
+    client = server.get_async_client(timeout=0.5, max_retries=3)
+    tasks = []
+    # Request about 2 million tokens
+    for _ in range(200):
+        task = asyncio.create_task(
+            client.chat.completions.create(messages=chat_input,
+                                           model=model_name,
+                                           max_tokens=10000,
+                                           extra_body={"min_tokens": 10000}))
+        tasks.append(task)
+
+    done, pending = await asyncio.wait(tasks, return_when=asyncio.ALL_COMPLETED)
+
+    # Make sure all requests were sent to the server and timed out
+    # (We don't want to hide other errors like 400s that would invalidate this
+    # test)
+    assert len(pending) == 0
+    for d in done:
+        with pytest.raises(openai.APITimeoutError):
+            d.result()
+
+    # If the server had not cancelled all the other requests, then it would not
+    # be able to respond to this one within the timeout
+    client = server.get_async_client(timeout=5)
+    response = await client.chat.completions.create(messages=chat_input,
+                                                    model=model_name,
+                                                    max_tokens=10)
+
+    assert len(response.choices) == 1

--- a/tests/unittest/llmapi/apps/openai_server.py
+++ b/tests/unittest/llmapi/apps/openai_server.py
@@ -83,8 +83,7 @@ class RemoteOpenAIServer:
             api_key=self.DUMMY_API_KEY,
         )
 
-    def get_async_client(self):
-        return openai.AsyncOpenAI(
-            base_url=self.url_for("v1"),
-            api_key=self.DUMMY_API_KEY,
-        )
+    def get_async_client(self, **kwargs):
+        return openai.AsyncOpenAI(base_url=self.url_for("v1"),
+                                  api_key=self.DUMMY_API_KEY,
+                                  **kwargs)


### PR DESCRIPTION
Currently, disconnected requests (e.g., those canceled by the client) continue processing in the executor. This PR attempts to abort such requests immediately upon detection.