### PR TITLE
bump the base docker image from 25.01 to 25.03

### DIFF
--- a/docker/Dockerfile.multi
+++ b/docker/Dockerfile.multi
@@ -1,6 +1,6 @@
 # Multi-stage Dockerfile
 ARG BASE_IMAGE=nvcr.io/nvidia/pytorch
-ARG BASE_TAG=25.01-py3
+ARG BASE_TAG=25.03-py3
 ARG DEVEL_IMAGE=devel
 
 FROM ${BASE_IMAGE}:${BASE_TAG} AS base

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -33,7 +33,7 @@ LLM_ROCKYLINUX8_PY310_DOCKER_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt
 LLM_ROCKYLINUX8_PY312_DOCKER_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:cuda-12.8.0-devel-rocky8-x86_64-rocky8-py312-trt10.8.0.43-skip-devel-202503131720-8877"
 
 // DLFW torch image
-DLFW_IMAGE = "nvcr.io/nvidia/pytorch:25.01-py3"
+DLFW_IMAGE = "nvcr.io/nvidia/pytorch:25.03-py3"
 
 //Ubuntu base image
 UBUNTU_22_04_IMAGE = "urm.nvidia.com/docker/ubuntu:22.04"


### PR DESCRIPTION
dependency changes:
- CUDA: 12.8.0 -> 12.8.1
- cublas: 12.8.3 -> 12.8.4
- TensorRT: 10.8 -> 10.9
- PyTorch: 2.6 -> 2.7