### PR TITLE
fix: remove test relies on timing

### DIFF
--- a/cpp/tests/unit_tests/batch_manager/contextProgressTest.cu
+++ b/cpp/tests/unit_tests/batch_manager/contextProgressTest.cu
@@ -128,19 +128,3 @@ TEST_F(ContextProgressTest, SlowTransmission)
     mTransmissionTime = milliseconds(10);
     runFakeModel(10);
 }
-
-TEST_F(ContextProgressTest, OverlapTiming)
-{
-    int const numLayers = 10;
-    auto start = steady_clock::now();
-    milliseconds timePerLayer{10};
-
-    mPluginTime = timePerLayer;
-    mComputeTime = timePerLayer;
-    mTransmissionTime = timePerLayer;
-    runFakeModel(numLayers);
-
-    auto end = steady_clock::now();
-    auto totalTime = duration_cast<milliseconds>(end - start);
-    EXPECT_LE(totalTime.count(), 2 * numLayers * timePerLayer.count());
-}


### PR DESCRIPTION
The test `ContextProgressTest.OverlapTiming` removed in this PR is flaky because it relies on the total execution time which is vulnerable to thread scheduling and occasional lags. The `ContextProgress`'s functional tests are already covered by other tests in that file.