### PR TITLE
Fix torch nvsmall through pyexecutor and fix its TP support

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_nvsmall.py
+++ b/tensorrt_llm/_torch/models/modeling_nvsmall.py
@@ -168,9 +168,8 @@ class NVSmallModel(DecoderModel):
         super().__init__(model_config)
         config = self.model_config.pretrained_config
         config.num_key_value_heads = [
-            config.num_attention_heads //
-            block.attention.n_heads_in_group if block.attention.n_heads_in_group
-            else block.attention.n_heads_in_group
+            config.num_attention_heads // block.attention.n_heads_in_group
+            if block.attention.n_heads_in_group else 0
             for block in config.block_configs
         ]
 

--- a/tensorrt_llm/_torch/models/modeling_nvsmall.py
+++ b/tensorrt_llm/_torch/models/modeling_nvsmall.py
@@ -168,8 +168,9 @@ class NVSmallModel(DecoderModel):
         super().__init__(model_config)
         config = self.model_config.pretrained_config
         config.num_key_value_heads = [
-            config.num_attention_heads // block.attention.n_heads_in_group
-            if block.attention.n_heads_in_group else 0
+            config.num_attention_heads //
+            block.attention.n_heads_in_group if block.attention.n_heads_in_group
+            else 0  # Set to 0 when block is configured to be a NO-OP
             for block in config.block_configs
         ]
 

--- a/tensorrt_llm/_torch/models/modeling_nvsmall.py
+++ b/tensorrt_llm/_torch/models/modeling_nvsmall.py
@@ -80,6 +80,7 @@ class NVSmallAttention(Attention):
             pos_embd_params=pos_embd_params,
             rotary_emb=NVSmallRotaryEmbedding(config, layer_idx=layer_idx),
             layer_idx=layer_idx,
+            dtype=config.torch_dtype,
             config=model_config)
 
 


### PR DESCRIPTION
Fix torch NVSmallModel load and generate with `pyexecutor` and to better support TP, by:
1. Passing the expected `dtype` to `NVSmallAttention`.
2. Setting `NVSmallModel` `config.num_key_value_heads` to be `0` instead of `None` when no attention in a block.
3. Using TRTLLM's `Linear` instead of `nn.Linear`, for TP support.
4. Passing the model config to `GatedMLP`, so it would be TP-ed as well.