### PR TITLE
feat: Add option to run disaggregated serving without ctx servers,…

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1410,6 +1410,12 @@ class PyExecutor:
     @nvtx_range("_recv_disagg_gen_cache")
     def _recv_disagg_gen_cache(self, new_gen_reqs):
 
+        # For gen-only benchmarking, mark new gen request as transmission complete right away
+        if os.getenv("TRTLLM_DISAGG_BENCHMARK_GEN_ONLY") == "1":
+            for req in new_gen_reqs:
+                req.state = LlmRequestState.DISAGG_GENERATION_TRANS_COMPLETE
+            return
+
         if os.getenv("TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP") == "1":
             for req in new_gen_reqs:
                 self.kv_cache_transceiver.request_and_receive_sync(req)

--- a/tests/integration/defs/disaggregated/sanity_check.sh
+++ b/tests/integration/defs/disaggregated/sanity_check.sh
@@ -19,6 +19,9 @@ CONFIG_FILE=""
 if [[ "${TEST_DESC}" == "2_ranks" ]]; then
   NUM_RANKS=2
   CONFIG_FILE=${EXAMPLE_DIR}/disagg_config.yaml
+elif [[ "${TEST_DESC}" == "gen_only" ]]; then
+  NUM_RANKS=2
+  CONFIG_FILE=${SCRIPT_DIR}/test_configs/disagg_config_gen_only.yaml
 elif [[ "${TEST_DESC}" == "cuda_graph" ]]; then
   NUM_RANKS=2
   CONFIG_FILE=${SCRIPT_DIR}/test_configs/disagg_config_cuda_graph_padding.yaml
@@ -51,8 +54,12 @@ else
   exit 1
 fi
 
+if [[ "${TEST_DESC}" == "gen_only" ]]; then
+    export TRTLLM_DISAGG_BENCHMARK_GEN_ONLY=1
+fi
+
 mpirun --allow-run-as-root -n ${NUM_RANKS} trtllm-serve disaggregated_mpi_worker -c ${CONFIG_FILE} &> output_workers &
-trtllm-serve disaggregated --server_start_timeout 900 -c ${CONFIG_FILE}  &> output_disagg &
+trtllm-serve disaggregated --server_start_timeout 900 -c ${CONFIG_FILE} &> output_disagg &
 
 for i in $(seq 1 ${NUM_ITERS}); do
     python3 ${CLIENT_DIR}/disagg_client.py -c ${EXAMPLE_DIR}/disagg_config.yaml -p ${CLIENT_DIR}/prompts.json --server-start-timeout 950
@@ -75,11 +82,29 @@ if [[ "${SKIP_KILL}" != "yes" ]]; then
   pkill -9 -f trtllm-serve || true
 fi
 
-expected_strings=("The capital of Germany is Berlin" "Asyncio is a Python library")
-if [[ "${TEST_DESC}" =~ "deepseek_v3_lite" ]]; then
-  expected_strings=("Berlin" "Asyncio is a powerful tool")
+# Check that size of output is size of prompts.json + 2
+num_outputs=$(jq '. | length' output.json)
+num_outputs_streaming=$(jq '. | length' output_streaming.json)
+expected_num_outputs=$(jq '. | length' ${CLIENT_DIR}/prompts.json)
+
+if [[ "${num_outputs}" -ne "${expected_num_outputs}" ]]; then
+  echo "Expected ${expected_num_outputs} outputs, got ${num_outputs} outputs"
+  exit 1
 fi
-for expected_string in "${expected_strings[@]}"; do
-    grep "${expected_string}" output.json
-    grep "${expected_string}" output_streaming.json
-done
+
+if [[ "${num_outputs_streaming}" -ne "${expected_num_outputs}" ]]; then
+  echo "Expected ${expected_num_outputs} outputs, got ${num_outputs_streaming} streaming outputs"
+  exit 1
+fi
+
+if [[ "${TEST_DESC}" != "gen_only" ]]; then
+  expected_strings=("The capital of Germany is Berlin" "Asyncio is a Python library")
+  if [[ "${TEST_DESC}" =~ "deepseek_v3_lite" ]]; then
+    expected_strings=("Berlin" "Asyncio is a powerful tool")
+  fi
+
+  for expected_string in "${expected_strings[@]}"; do
+      grep "${expected_string}" output.json
+      grep "${expected_string}" output_streaming.json
+  done
+fi

--- a/tests/integration/defs/disaggregated/sanity_check.sh
+++ b/tests/integration/defs/disaggregated/sanity_check.sh
@@ -82,7 +82,7 @@ if [[ "${SKIP_KILL}" != "yes" ]]; then
   pkill -9 -f trtllm-serve || true
 fi
 
-# Check that size of output is size of prompts.json + 2
+# Check that size of output is size of prompts.json
 num_outputs=$(jq '. | length' output.json)
 num_outputs_streaming=$(jq '. | length' output_streaming.json)
 expected_num_outputs=$(jq '. | length' ${CLIENT_DIR}/prompts.json)

--- a/tests/integration/defs/disaggregated/test_configs/disagg_config_gen_only.yaml
+++ b/tests/integration/defs/disaggregated/test_configs/disagg_config_gen_only.yaml
@@ -1,0 +1,19 @@
+hostname: localhost
+port: 8000
+model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
+backend: "pytorch"
+context_servers:
+  num_instances: 0
+generation_servers:
+  num_instances: 2
+  tensor_parallel_size: 1
+  pipeline_parallel_size: 1
+  kv_cache_config:
+    free_gpu_memory_fraction: 0.2
+    enable_block_reuse: False
+    enable_partial_reuse: False
+  pytorch_backend_config:
+    print_iter_log: True
+  urls:
+      - "localhost:8002"
+      - "localhost:8003"

--- a/tests/integration/defs/disaggregated/test_disaggregated.py
+++ b/tests/integration/defs/disaggregated/test_disaggregated.py
@@ -40,6 +40,27 @@ def test_disaggregated_single_gpu_with_mpirun(disaggregated_test_root,
                cwd=llm_venv.get_working_directory())
 
 
+@pytest.mark.parametrize("llama_model_root", ['TinyLlama-1.1B-Chat-v1.0'],
+                         indirect=True)
+def test_disaggregated_benchmark_gen_only(disaggregated_test_root,
+                                          disaggregated_example_root, llm_venv,
+                                          llama_model_root):
+    src_dst_dict = {
+        llama_model_root:
+        f"{llm_venv.get_working_directory()}/TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+    }
+    for src, dst in src_dst_dict.items():
+        if not os.path.islink(dst):
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            os.symlink(src, dst, target_is_directory=True)
+
+    cmd = f"bash {disaggregated_test_root}/sanity_check.sh {disaggregated_example_root} gen_only"
+    check_call(cmd,
+               shell=True,
+               env=llm_venv._new_env,
+               cwd=llm_venv.get_working_directory())
+
+
 @pytest.mark.skip_less_device(2)
 @pytest.mark.parametrize("llama_model_root", ['TinyLlama-1.1B-Chat-v1.0'],
                          indirect=True)


### PR DESCRIPTION
Adds an option to run disaggregated serving without ctx servers. This can be done by setting environment variable `TRTLLM_DISAGG_BENCHMARK_GEN_ONLY` to 1. In that case, the KV cache for the prefill tokens is left uninitialized for the generation phase. This can be used to benchmark generation only latency/throughput.