### PR TITLE
feat: Support gemma-3-1b-it

### DIFF
--- a/tensorrt_llm/models/__init__.py
+++ b/tensorrt_llm/models/__init__.py
@@ -33,7 +33,8 @@ from .eagle.model import EagleForCausalLM
 from .enc_dec.model import DecoderModel, EncoderModel, WhisperEncoder
 from .falcon.config import FalconConfig
 from .falcon.model import FalconForCausalLM, FalconModel
-from .gemma.config import GEMMA2_ARCHITECTURE, GEMMA_ARCHITECTURE, GemmaConfig
+from .gemma.config import (GEMMA2_ARCHITECTURE, GEMMA3_ARCHITECTURE,
+                           GEMMA_ARCHITECTURE, GemmaConfig)
 from .gemma.model import GemmaForCausalLM
 from .gpt.config import GPTConfig
 from .gpt.model import GPTForCausalLM, GPTModel
@@ -183,6 +184,7 @@ MODEL_MAP = {
     'SkyworkForCausalLM': LLaMAForCausalLM,
     GEMMA_ARCHITECTURE: GemmaForCausalLM,
     GEMMA2_ARCHITECTURE: GemmaForCausalLM,
+    GEMMA3_ARCHITECTURE: GemmaForCausalLM,
     'QWenLMHeadModel': QWenForCausalLM,
     'QWenForCausalLM': QWenForCausalLM,
     'Qwen2ForCausalLM': QWenForCausalLM,

--- a/tensorrt_llm/models/gemma/convert.py
+++ b/tensorrt_llm/models/gemma/convert.py
@@ -317,6 +317,10 @@ class HfParser:
              None),  # merged with above
             (r"model.layers.(\d+).self_attn.o_proj.weight",
              r"layers.\1.attention.dense.weight"),
+            (r"model.layers.(\d+).self_attn.q_norm.weight",
+             r"layers.\1.attention.q_layernorm.weight"),
+            (r"model.layers.(\d+).self_attn.k_norm.weight",
+             r"layers.\1.attention.k_layernorm.weight"),
             (r"model.layers.(\d+).mlp.gate_proj.weight",
              r"layers.\1.mlp.fc.weight"),
             (r"model.layers.(\d+).mlp.up_proj.weight",
@@ -795,6 +799,8 @@ def load_gemma_weights(
                 "pre_feedforward_layernorm",
                 "post_feedforward_layernorm",
                 "model.norm.weight",
+                "q_norm.weight",
+                "k_norm.weight",
         )):
             param = param + 1.0  # upcasted to float32 in case of bfloat16
             add_trt_llm_weight(weights, trt_llm_name, param,

--- a/tensorrt_llm/models/gemma/model.py
+++ b/tensorrt_llm/models/gemma/model.py
@@ -23,8 +23,8 @@ from tensorrt_llm.quantization.mode import (MODELOPT_FLOW_QUANTIZATIONS,
 
 from ..._common import default_net
 from ..._utils import pad_vocab_size
-from ...functional import (AllReduceFusionOp, AllReduceParams, Tensor, cast,
-                           recv, send)
+from ...functional import (AllReduceFusionOp, AllReduceParams, LayerNormType,
+                           Tensor, cast, recv, send)
 from ...layers import (Attention, AttentionMaskType, AttentionParams,
                        ColumnLinear, Embedding, GatedMLP, KeyValueCacheParams,
                        LoraParams, PositionEmbeddingType, RmsNorm)
@@ -56,13 +56,26 @@ class GemmaDecoderLayer(Module):
 
         q_scaling = 1.0
         max_attn_value = 0.0
+        qk_layernorm = False
+        is_sliding = False
+        rotary_base = config.rotary_base
+        rotary_base_local = None
 
         gemma2_config = config.gemma2_config()
+        gemma3_config = config.gemma3_config()
         if gemma2_config:
             q_scaling = math.sqrt(
                 gemma2_config.query_pre_attn_scalar) / math.sqrt(
                     config.head_size)
             max_attn_value = config.attn_logit_softcapping or 0.0
+        elif gemma3_config:
+            qk_layernorm = True
+            q_scaling = math.sqrt(
+                gemma3_config.query_pre_attn_scalar) / math.sqrt(
+                    config.head_size)
+            is_sliding = bool(
+                (layer_idx + 1) % gemma3_config.sliding_window_pattern)
+            rotary_base_local = config.rope_local_base_freq
 
         self.attention = Attention(
             local_layer_idx=self.local_layer_idx,
@@ -70,18 +83,22 @@ class GemmaDecoderLayer(Module):
             num_attention_heads=config.num_attention_heads,
             num_kv_heads=config.num_key_value_heads,
             attention_head_size=config.head_size,
+            qk_layernorm=qk_layernorm,
+            layernorm_type=LayerNormType.RmsNorm,
             max_position_embeddings=config.max_position_embeddings,
             dtype=config.dtype,
             attention_mask_type=AttentionMaskType.causal,
             bias=config.attn_bias,
             position_embedding_type=PositionEmbeddingType.rope_gpt_neox,
-            rotary_embedding_base=config.rotary_base,
+            rotary_embedding_base=rotary_base,
+            rotary_embedding_base_local=rotary_base_local,
             rotary_embedding_scaling=config.rotary_scaling,
             tp_group=config.mapping.tp_group,
             tp_size=config.mapping.tp_size,
             quant_mode=config.quant_mode,
             q_scaling=q_scaling,
             max_attn_value=max_attn_value,
+            is_local=is_sliding,
         )
 
         mlp_hidden_size = config.hidden_size * 4 if config.intermediate_size is None else config.intermediate_size

--- a/tensorrt_llm/quantization/quantize_by_modelopt.py
+++ b/tensorrt_llm/quantization/quantize_by_modelopt.py
@@ -142,6 +142,7 @@ MODEL_NAME_PATTERN_MAP = {
     "QWen": "qwen",
     "Qwen2VLForConditionalGeneration": "qwen2_vl",
     "RecurrentGemma": "recurrentgemma",
+    "Gemma3": "gemma3",
     "Gemma2": "gemma2",
     "Gemma": "gemma",
     "MixtralForCausalLM": "llama",

--- a/tests/integration/defs/examples/test_gemma.py
+++ b/tests/integration/defs/examples/test_gemma.py
@@ -150,7 +150,7 @@ def test_llm_hf_gemma_quantization_1gpu(batch_size, data_type, gemma_model_root,
 @pytest.mark.parametrize("gemma_model_root", [
     "gemma-2b", "gemma-7b", "gemma-2b-torch", "gemma-7b-torch",
     "gemma-2b-keras", "gemma-7b-keras", "gemma-2b-it-flax", "gemma-7b-it-flax",
-    "gemma-2-9b-it", "gemma-2-27b-it"
+    "gemma-2-9b-it", "gemma-2-27b-it", "gemma-3-1b-it"
 ],
                          indirect=True)
 def test_llm_gemma_1gpu_summary(batch_size, data_type, gemma_model_root,
@@ -231,6 +231,13 @@ def test_llm_gemma_1gpu_summary(batch_size, data_type, gemma_model_root,
         ])
     else:
         summary_cmd.append(f"--vocab_file={vocab_file}")
+
+    os.path.basename(gemma_model_root)
+    if 'gemma-3-1b-it' in gemma_model_root:
+        max_attention_window_size = [512, 512, 512, 512, 512, 3100]
+        summary_cmd.append(f"--max_attention_window_size")
+        for window_size in max_attention_window_size:
+            summary_cmd.append(str(window_size))
 
     venv_check_call(llm_venv, summary_cmd)
 

--- a/tests/integration/test_lists/qa/examples_test_list.txt
+++ b/tests/integration/test_lists/qa/examples_test_list.txt
@@ -35,6 +35,7 @@ examples/test_exaone.py::test_llm_exaone_1gpu[disable_weight_only-exaone_3.0_7.8
 examples/test_exaone.py::test_llm_exaone_1gpu[enable_weight_only-exaone_deep_2.4b-float16-nb:1]
 examples/test_exaone.py::test_llm_exaone_2gpu[exaone_3.0_7.8b_instruct-float16-nb:1]
 examples/test_gemma.py::test_llm_gemma_1gpu_summary[gemma-2-27b-it-other-bfloat16-8]
+examples/test_gemma.py::test_llm_gemma_1gpu_summary[gemma-3-1b-it-other-bfloat16-8]
 examples/test_gemma.py::test_llm_hf_gemma_quantization_1gpu[gemma-2-27b-it-fp8-bfloat16-8]
 examples/test_gemma.py::test_hf_gemma_fp8_base_bf16_multi_lora[gemma-2-9b-it]
 examples/test_gemma.py::test_hf_gemma_fp8_base_bf16_multi_lora[gemma-2-27b-it]

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -125,6 +125,7 @@ l0_h100:
   - examples/test_llama.py::test_llama_3_x_fp8_with_bf16_lora[llama-3.2-1b]
   - examples/test_qwen.py::test_llm_hf_qwen_multi_lora_1gpu[qwen2.5_1.5b_instruct]
   - examples/test_gemma.py::test_hf_gemma_fp8_base_bf16_multi_lora[gemma-2-9b-it]
+  - examples/test_gemma.py::test_llm_gemma_1gpu_summary[gemma-3-1b-it-other-bfloat16-8]
   - examples/test_phi.py::test_llm_phi_quantization_1gpu[Phi-4-mini-instruct-fp8-bfloat16]
   - unittest/trt/model_api/test_model_level_api.py # 9 mins on H100
   - unittest/trt/model_api/test_model_api_multi_gpu.py # 0.5 mins on H100


### PR DESCRIPTION
This MR adds model support for `gemma-3-1b-it`.

Details:
* This model has attn layers of two types - one with sliding-window attn with 10k rope base and another with regular attn with 1 million rope base.
* Most models in TRTLLM seem to be working with attention layers with attn layers of same type. Hence, there's only one set of RoPE params under `AttentionParams` that is passed to model's forward pass.
* However, in this case, we need two sets of RoPE params (one for each layer type mentioned above).
* Changes in this MR are adding one more set of RoPE fields under `AttentionParams` with a `_local` suffix to handle the additional layer type.
* Alternative is to copy quite some functionality from `modeling_utils.py` (`DecoderLayerList` and `DecoderModelForCausalLM`) and carefully orchestrate forward pass by passing a different set of `AttentionParams` to each layer type. I felt that's quite some code duplication and maintenance overhead.
* Sliding window requirement is mentioned to the model at runtime using `max_attention_window_size` with `run.py` or whatever API is being used.
[512, 512, 512, 512, 512, 2048, 512, 512, 512, 512, 512, 2048, 512, 512, 512, 512, 512, 2048, 512, 512, 512, 512, 512, 2048, 512, 512]
```
$ rm -rf gemma3_1b_ckpt/ && python3 ./examples/gemma/convert_checkpoint.py --ckpt-type hf --model-dir ../random/hf_models/gemma-3-1b-it/ --dtype float16 --output-model-dir gemma3_1b_ckpt/
$ rm -rf gemma3_1b_eng/ && trtllm-build --checkpoint_dir gemma3_1b_ckpt/ --output_dir gemma3_1b_eng/trtllm_engine --max_batch_size 256 --max_seq_len 32768 --max_num_tokens 32768 --workers 1 --use_paged_context_fmha disable --gpus_per_node 1 --nccl_plugin auto
$ rm -rf tllm_debug/ && python3 examples/run.py --max_output_len 512 --max_input_length 2048 --input_text 'The main cities in Italy are (Write a blog post)' --engine_dir gemma3_1b_eng/trtllm_engine --tokenizer_dir ../random/hf_models/gemma-3-1b-it/ --end_id 106
```