### PR TITLE
feat: Introduce UB allocator for pytorch flow

### DIFF
--- a/cpp/tensorrt_llm/kernels/userbuffers/CMakeLists.txt
+++ b/cpp/tensorrt_llm/kernels/userbuffers/CMakeLists.txt
@@ -15,7 +15,7 @@
 # the License.
 #
 if(ENABLE_MULTI_DEVICE EQUAL 0)
-  add_library(userbuffers_src OBJECT ub_interface.cpp)
+  add_library(userbuffers_src OBJECT ub_interface.cpp userbuffersManager.cpp)
 else()
   file(GLOB_RECURSE SRC_CPP *.cpp)
   file(GLOB_RECURSE SRC_CU *.cu)

--- a/cpp/tensorrt_llm/kernels/userbuffers/ub_allocator.cpp
+++ b/cpp/tensorrt_llm/kernels/userbuffers/ub_allocator.cpp
@@ -49,13 +49,13 @@ UBBuffer UserBufferAllocator::register_ub_buffer(size_t bytes)
     return {addr, handle, bytes};
 }
 
-void* UserBufferAllocator::allocate(int idx, size_t bytes)
+UBBuffer UserBufferAllocator::allocate(size_t bytes)
 {
-    TLLM_CHECK(is_initialized() && idx < buffers_.size() && buffers_[idx].invalid());
+    TLLM_CHECK(is_initialized());
     auto ub_buffer = register_ub_buffer(bytes);
     TLLM_CHECK(!ub_buffer.invalid());
-    buffers_[idx] = ub_buffer;
-    return ub_buffer.addr;
+    buffers_.push_back(ub_buffer);
+    return ub_buffer;
 }
 
 void UserBufferAllocator::deallocate(void* addr) {}

--- a/cpp/tensorrt_llm/kernels/userbuffers/ub_allocator.h
+++ b/cpp/tensorrt_llm/kernels/userbuffers/ub_allocator.h
@@ -51,15 +51,16 @@ public:
 
     void initialize(tensorrt_llm::runtime::WorldConfig const& world_config);
     bool is_initialized();
-    UBBuffer register_ub_buffer(size_t bytes);
-    void* allocate(int idx, size_t bytes);
+    UBBuffer allocate(size_t bytes);
     void deallocate(void* addr);
     UBBuffer get(int idx);
     communicator* comm();
 
 private:
+    UBBuffer register_ub_buffer(size_t bytes);
+
     communicator* ub_comm_;
-    std::array<UBBuffer, 3> buffers_;
+    std::vector<UBBuffer> buffers_;
     bool is_initialized_;
     tensorrt_llm::runtime::WorldConfig world_config_;
 };

--- a/cpp/tensorrt_llm/kernels/userbuffers/ub_interface.cpp
+++ b/cpp/tensorrt_llm/kernels/userbuffers/ub_interface.cpp
@@ -39,9 +39,9 @@ bool ub_is_initialized()
     return UserBufferAllocator::Instance().is_initialized();
 }
 
-void* ub_allocate(int idx, size_t bytes)
+UBBuffer ub_allocate(size_t bytes)
 {
-    return UserBufferAllocator::Instance().allocate(idx, bytes);
+    return UserBufferAllocator::Instance().allocate(bytes);
 }
 
 void ub_deallocate(void* addr)
@@ -128,9 +128,9 @@ bool ub_is_initialized()
     return false;
 }
 
-void* ub_allocate(int idx, size_t bytes)
+UBBuffer ub_allocate(size_t bytes)
 {
-    return nullptr;
+    return UBBuffer();
 }
 
 void ub_deallocate(void* addr) {}

--- a/cpp/tensorrt_llm/kernels/userbuffers/ub_interface.h
+++ b/cpp/tensorrt_llm/kernels/userbuffers/ub_interface.h
@@ -24,7 +24,7 @@ namespace tensorrt_llm::runtime::ub
 void ub_initialize(tensorrt_llm::runtime::WorldConfig const& world_config);
 void ub_initialize(int tp_size);
 bool ub_is_initialized();
-void* ub_allocate(int idx, size_t bytes);
+UBBuffer ub_allocate(size_t bytes);
 void ub_deallocate(void* addr);
 UBBuffer ub_get(int idx);
 communicator* ub_comm();

--- a/cpp/tensorrt_llm/kernels/userbuffers/userbuffersManager.cpp
+++ b/cpp/tensorrt_llm/kernels/userbuffers/userbuffersManager.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "userbuffersManager.h"
+
+namespace tensorrt_llm::runtime::ub
+{
+
+void UserBufferDeleter::operator()(void* ptr)
+{
+    UserBuffersManager::get_instance().release_buffer(ptr);
+}
+
+UserBuffersManager& UserBuffersManager::get_instance()
+{
+    static UserBuffersManager allocator;
+    return allocator;
+}
+
+void UserBuffersManager::initialize(
+    int64_t tp_size, int64_t pp_size, int64_t cp_size, int64_t rank, int64_t gpus_per_node, int64_t buffer_size)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    tensorrt_llm::runtime::WorldConfig world_config(tp_size, pp_size, cp_size, rank, gpus_per_node);
+    tensorrt_llm::runtime::ub::ub_initialize(world_config);
+    TLLM_CHECK(tensorrt_llm::runtime::ub::ub_is_initialized());
+    buffer_size_ = buffer_size;
+}
+
+std::pair<UBBufferPtr, UBBuffer> UserBuffersManager::allocate_userbuffers(int64_t buffer_size)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    TLLM_CHECK(buffer_size <= buffer_size_);
+
+    // Check for all unused buffers
+    int i = 0;
+    for (auto& buffer : buffers_)
+    {
+        if (buffer.second)
+        {
+            i++;
+            continue;
+        }
+        buffer.second = true;
+        TLLM_LOG_DEBUG("Reusing buffer %d", i);
+        return std::make_pair(std::unique_ptr<void, UserBufferDeleter>(buffer.first.addr), buffer.first);
+    }
+
+    auto new_ub = tensorrt_llm::runtime::ub::ub_allocate(buffer_size_);
+    TLLM_CHECK(!new_ub.invalid());
+    buffers_.push_back({new_ub, true});
+    TLLM_LOG_DEBUG("Creating new buffer %d", static_cast<int>(buffers_.size() - 1));
+    return std::make_pair(std::unique_ptr<void, UserBufferDeleter>(new_ub.addr), new_ub);
+}
+
+void UserBuffersManager::release_buffer(void* addr)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto buffer_iter = std::find_if(
+        buffers_.begin(), buffers_.end(), [addr](auto const& buffer) { return buffer.first.addr == addr; });
+    // The UB should be assigned to a tensor
+    TLLM_CHECK(buffer_iter != buffers_.end());
+    TLLM_CHECK(buffer_iter->second);
+    TLLM_CHECK(!buffer_iter->first.invalid());
+    TLLM_LOG_DEBUG("Releasing buffer %d", static_cast<int>(std::distance(buffers_.begin(), buffer_iter)));
+    buffer_iter->second = false;
+}
+
+tensorrt_llm::runtime::ub::UBBuffer UserBuffersManager::search_buffer(void* addr)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto buffer_iter = std::find_if(
+        buffers_.begin(), buffers_.end(), [addr](auto const& buffer) { return buffer.first.addr == addr; });
+    if (buffer_iter == buffers_.end())
+    {
+        return tensorrt_llm::runtime::ub::UBBuffer();
+    }
+    return buffer_iter->first;
+}
+
+tensorrt_llm::runtime::ub::communicator* UserBuffersManager::comm()
+{
+    return tensorrt_llm::runtime::ub::ub_comm();
+}
+
+void initialize_userbuffers_manager(
+    int64_t tp_size, int64_t pp_size, int64_t cp_size, int64_t rank, int64_t gpus_per_node, int64_t buffer_size)
+{
+    UserBuffersManager::get_instance().initialize(tp_size, pp_size, cp_size, rank, gpus_per_node, buffer_size);
+}
+
+} // namespace tensorrt_llm::runtime::ub

--- a/cpp/tensorrt_llm/kernels/userbuffers/userbuffersManager.h
+++ b/cpp/tensorrt_llm/kernels/userbuffers/userbuffersManager.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include "tensorrt_llm/kernels/userbuffers/ub_interface.h"
+#include "tensorrt_llm/runtime/worldConfig.h"
+#include <memory>
+#include <mutex>
+#include <vector>
+
+namespace tensorrt_llm::runtime::ub
+{
+
+class UserBufferDeleter
+{
+public:
+    void operator()(void* ptr);
+};
+
+using UBBufferPtr = std::unique_ptr<void, UserBufferDeleter>;
+using UBBufferInfo = std::pair<tensorrt_llm::runtime::ub::UBBuffer, bool>;
+
+class UserBuffersManager
+{
+public:
+    static UserBuffersManager& get_instance();
+    UserBuffersManager() = default;
+
+    //! @brief Initialize the userbuffers manager.
+    //! @param tp_size Tensor parallel size.
+    //! @param pp_size Pipeline parallel size.
+    //! @param cp_size Compute parallel size.
+    //! @param rank The rank of the current GPU.
+    //! @param gpus_per_node The number of GPUs per node.
+    //! @param buffer_size The size of the buffer to allocate. All buffers allocated by this manager will have this
+    //! size.
+    void initialize(
+        int64_t tp_size, int64_t pp_size, int64_t cp_size, int64_t rank, int64_t gpus_per_node, int64_t buffer_size);
+
+    //! @brief Create a UB tensor from the given shape, strides and data type. The function will choose available UB
+    //! buffer or create a new one if no available buffer is found.
+    //! @param buffer_size The size of the buffer to allocate.
+    //! @return A unique_ptr to the buffer and the UBBuffer object.
+    //! @note Do not manually call release_buffer with the buffer address in tensorrt_llm::runtime::ub::UBBuffer
+    std::pair<UBBufferPtr, tensorrt_llm::runtime::ub::UBBuffer> allocate_userbuffers(int64_t buffer_size);
+
+    //! @brief Search the buffer from the list of buffers.
+    //! @param addr The address of the buffer to search for.
+    //! @return The buffer and whether it is assigned to a tensor. If not found, the UBBuffer is invalid.
+    tensorrt_llm::runtime::ub::UBBuffer search_buffer(void* addr);
+
+    //! @brief Get the communicator.
+    //! @return The communicator.
+    tensorrt_llm::runtime::ub::communicator* comm();
+
+    //! @brief Release the buffer. It does not deallocate the buffer, but just release it to the pool.
+    //! @param addr The address of the buffer to release.
+    void release_buffer(void* addr);
+
+private:
+    std::mutex mutex_;
+    std::vector<UBBufferInfo> buffers_;
+    int64_t buffer_size_;
+};
+
+void initialize_userbuffers_manager(
+    int64_t tp_size, int64_t pp_size, int64_t cp_size, int64_t rank, int64_t gpus_per_node, int64_t buffer_size);
+
+} // namespace tensorrt_llm::runtime::ub

--- a/cpp/tensorrt_llm/pybind/userbuffers/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/userbuffers/bindings.cpp
@@ -17,6 +17,7 @@
 
 #include "bindings.h"
 #include "tensorrt_llm/kernels/userbuffers/ub_interface.h"
+#include "tensorrt_llm/kernels/userbuffers/userbuffersManager.h"
 
 namespace py = pybind11;
 namespace tub = tensorrt_llm::runtime::ub;
@@ -34,10 +35,11 @@ void UserBufferBindings::initBindings(pybind11::module_& m)
 
     m.def("ub_initialize", [](int tp_size) { tub::ub_initialize(tp_size); });
     m.def("ub_is_initialized", &tub::ub_is_initialized);
-    m.def(
-        "ub_allocate", [](int idx, size_t bytes) { return reinterpret_cast<intptr_t>(tub::ub_allocate(idx, bytes)); });
+    m.def("ub_allocate", [](size_t bytes) { return tub::ub_allocate(bytes); });
     m.def("ub_deallocate", [](intptr_t addr) { return tub::ub_deallocate(reinterpret_cast<void*>(addr)); });
     m.def("ub_get", &tub::ub_get);
     m.def("ub_supported", &tub::ub_supported);
+
+    m.def("initialize_userbuffers_manager", &tub::initialize_userbuffers_manager);
 }
 } // namespace tensorrt_llm::kernels::userbuffers

--- a/cpp/tensorrt_llm/runtime/tllmRuntime.cpp
+++ b/cpp/tensorrt_llm/runtime/tllmRuntime.cpp
@@ -749,11 +749,11 @@ void TllmRuntime::initializeUserBuffer(tensorrt_llm::runtime::WorldConfig const&
     TLLM_LOG_INFO("[UserBuffer] MaxBatchSize %d, maxBeamWidth %d, maxSequenceLength %d, maxNumTokens %d, select %lu",
         maxBatchSize, maxBeamWidth, maxSequenceLength, maxNumTokens.has_value() ? maxNumTokens.value() : 0, tokensNum);
     tensorrt_llm::runtime::ub::ub_initialize(world_config);
-    tensorrt_llm::runtime::ub::ub_allocate(0, elemNum * sizeof(half));
-    tensorrt_llm::runtime::ub::ub_allocate(1, elemNum * sizeof(half));
+    tensorrt_llm::runtime::ub::ub_allocate(elemNum * sizeof(half));
+    tensorrt_llm::runtime::ub::ub_allocate(elemNum * sizeof(half));
     if (useNVFP4Model)
     {
-        tensorrt_llm::runtime::ub::ub_allocate(2, elemNum * sizeof(uint8_t) / 16);
+        tensorrt_llm::runtime::ub::ub_allocate(elemNum * sizeof(uint8_t) / 16);
     }
 }
 

--- a/cpp/tensorrt_llm/thop/CMakeLists.txt
+++ b/cpp/tensorrt_llm/thop/CMakeLists.txt
@@ -65,6 +65,7 @@ add_library(
   relativeAttentionBiasOp.cpp
   selectiveScanOp.cpp
   userbuffersFinalizeOp.cpp
+  userbuffersTensor.cpp
   weightOnlyQuantOp.cpp
   mtpOp.cpp)
 set_property(TARGET th_common PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/cpp/tensorrt_llm/thop/userbuffersFinalizeOp.cpp
+++ b/cpp/tensorrt_llm/thop/userbuffersFinalizeOp.cpp
@@ -18,6 +18,7 @@
 #include "tensorrt_llm/kernels/userbuffers/ub_interface.h"
 #include "tensorrt_llm/runtime/torchUtils.h"
 #include "tensorrt_llm/thop/thUtils.h"
+#include "userbuffersTensor.h"
 
 #include <torch/extension.h>
 
@@ -29,21 +30,16 @@ torch::Tensor userbuffers_allreduce_finalize(torch::Tensor input, bool force_app
 #if ENABLE_MULTI_DEVICE
     auto stream = at::cuda::getCurrentCUDAStream(input.get_device());
 
-    auto output = torch::empty_like(input);
     size_t size = input.numel();
     int hidden_size = input.size(-1);
 
-    TLLM_CHECK_WITH_INFO(tensorrt_llm::runtime::ub::ub_is_initialized(), "UserBuffer has not been initialized!");
-    auto ub_buffer1 = tensorrt_llm::runtime::ub::ub_get(1);
-    auto ub_comm = tensorrt_llm::runtime::ub::ub_comm();
+    auto& ub_manager = tensorrt_llm::runtime::ub::UserBuffersManager::get_instance();
+    auto [output, ub_buffer] = torch_ext::create_userbuffers_tensor(input.sizes(), input.scalar_type());
+
     auto const dtype = tensorrt_llm::runtime::TorchUtils::dataType(input.scalar_type());
 
-    tensorrt_llm::kernels::ub::allgather2_userbuff_residual_launcher(
-        ub_buffer1.handle, 0, size, hidden_size, input.data_ptr(), dtype, ub_comm, stream, force_applying_finalize);
-    auto const elem_size = tensorrt_llm::common::getDTypeSize(dtype);
-    // Force memcpy to avoid ub tensor exposed to torch graph.
-    TLLM_CUDA_CHECK(
-        cudaMemcpyAsync(output.data_ptr(), ub_buffer1.addr, size * elem_size, cudaMemcpyDeviceToDevice, stream));
+    tensorrt_llm::kernels::ub::allgather2_userbuff_residual_launcher(ub_buffer.handle, 0, size, hidden_size,
+        input.data_ptr(), dtype, ub_manager.comm(), stream, force_applying_finalize);
     return output;
 #else
     return input;

--- a/cpp/tensorrt_llm/thop/userbuffersTensor.cpp
+++ b/cpp/tensorrt_llm/thop/userbuffersTensor.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "userbuffersTensor.h"
+
+namespace torch_ext
+{
+
+std::pair<torch::Tensor, tensorrt_llm::runtime::ub::UBBuffer> create_userbuffers_tensor(
+    at::IntArrayRef shape, torch::ScalarType dtype)
+{
+    int64_t buffer_size
+        = std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<int64_t>()) * torch::elementSize(dtype);
+
+    std::vector<int64_t> strides_vec(shape.size());
+    strides_vec[shape.size() - 1] = 1;
+    for (int64_t i = static_cast<int64_t>(shape.size()) - 1; i >= 1; --i)
+    {
+        strides_vec[i - 1] = strides_vec[i] * shape[i];
+    }
+
+    auto [ptr, ub] = tensorrt_llm::runtime::ub::UserBuffersManager::get_instance().allocate_userbuffers(buffer_size);
+    auto& deleter = ptr.get_deleter();
+    return std::make_pair(
+        torch::from_blob(ptr.release(), shape, strides_vec, deleter, torch::dtype(dtype).device(torch::kCUDA)), ub);
+}
+
+// Custom op interface for create_userbuffers_tensor.
+// Python side does not need the UBBuffer object.
+torch::Tensor create_userbuffers_tensor_op(at::IntArrayRef shape, torch::ScalarType dtype)
+{
+    return create_userbuffers_tensor(shape, dtype).first;
+}
+
+} // namespace torch_ext
+
+TORCH_LIBRARY_FRAGMENT(trtllm, m)
+{
+    m.def("create_userbuffers_tensor", &torch_ext::create_userbuffers_tensor_op);
+}

--- a/cpp/tensorrt_llm/thop/userbuffersTensor.h
+++ b/cpp/tensorrt_llm/thop/userbuffersTensor.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "tensorrt_llm/kernels/userbuffers/userbuffersManager.h"
+#include <torch/extension.h>
+
+namespace torch_ext
+{
+
+std::pair<torch::Tensor, tensorrt_llm::runtime::ub::UBBuffer> create_userbuffers_tensor(
+    at::IntArrayRef shape, torch::ScalarType dtype);
+
+} // namespace torch_ext

--- a/cpp/tests/unit_tests/runtime/userBufferTest.cpp
+++ b/cpp/tests/unit_tests/runtime/userBufferTest.cpp
@@ -38,8 +38,8 @@ TEST(UserBuffer, basic)
     tr::ub::ub_initialize(world_size);
     EXPECT_EQ(tr::ub::ub_is_initialized(), true);
     EXPECT_NE(tr::ub::ub_comm(), nullptr);
-    void* p0 = tr::ub::ub_allocate(0, 1024);
-    void* p1 = tr::ub::ub_allocate(1, 1024);
+    void* p0 = tr::ub::ub_allocate(1024).addr;
+    void* p1 = tr::ub::ub_allocate(1024).addr;
     EXPECT_NE(p0, nullptr);
     EXPECT_NE(p1, nullptr);
     EXPECT_EQ(tr::ub::ub_get(0).invalid(), false);

--- a/tensorrt_llm/_torch/compilation/patterns/ub_allreduce.py
+++ b/tensorrt_llm/_torch/compilation/patterns/ub_allreduce.py
@@ -1,5 +1,5 @@
 from operator import getitem
-from typing import Optional
+from typing import List, Optional
 
 import torch
 from torch._inductor.pattern_matcher import (CallFunction, Ignored, KeywordArg,
@@ -15,195 +15,390 @@ aten = torch.ops.aten
 from tensorrt_llm.mapping import Mapping
 
 
-def register_ub_allreduce(custom_pass: PatternMatcherPass):
+def register_ub_patterns(custom_passes: List[PatternMatcherPass]):
     mapping = Mapping(
         world_size=tensorrt_llm.mpi_world_size(),
         tp_size=tensorrt_llm.mpi_world_size(),
         rank=tensorrt_llm.mpi_rank(),
     )
 
-    # Only match AUTO strategy all-reduce
-    strategy = int(AllReduceStrategy.AUTO)
-    fusion = int(AllReduceFusionOp.RESIDUAL_RMS_NORM)
+    def register_ub_allreduce_quantize_fusion(custom_pass: PatternMatcherPass):
+        strategy = int(AllReduceStrategy.AUTO)
+        fusion = int(AllReduceFusionOp.RESIDUAL_RMS_NORM)
 
-    mm_dtype = KeywordArg('mm_dtype')
-    trtllm_cublas_scaled_mm_default = CallFunction(
-        torch.ops.trtllm.cublas_scaled_mm.default, KeywordArg('mm0_a'),
-        KeywordArg('mm0_b'), KeywordArg('mm0_a_scale'),
-        KeywordArg('mm0_b_scale'), KeywordArg('mm0_bias'), mm_dtype, -1)
-    trtllm_allreduce_default = CallFunction(
-        torch.ops.trtllm.allreduce.default,
-        trtllm_cublas_scaled_mm_default,
-        Ignored(), [KeywordArg('residual_in'),
-                    KeywordArg('gamma')],
-        mapping.tp_group,
-        strategy,
-        Ignored(),
-        fusion,
-        KeywordArg('eps'),
-        True,
-        False,
-        False,
-        _users=2)
-    getitem_0 = CallFunction(getitem, trtllm_allreduce_default, 0)
-    tensorrt_llm_static_quantize_e4m3_per_tensor_default = CallFunction(
-        torch.ops.tensorrt_llm.static_quantize_e4m3_per_tensor.default,
-        getitem_0,
-        KeywordArg('scale'),
-        _users=2)
-    getitem_1 = CallFunction(
-        getitem, tensorrt_llm_static_quantize_e4m3_per_tensor_default, 0)
-    getitem_2 = CallFunction(
-        getitem, tensorrt_llm_static_quantize_e4m3_per_tensor_default, 1)
-    aten_t_default = CallFunction(torch.ops.aten.t.default, KeywordArg('mm1_b'))
-    trtllm_cublas_scaled_mm_default_1 = CallFunction(
-        torch.ops.trtllm.cublas_scaled_mm.default, getitem_1,
-        aten_t_default, getitem_2, KeywordArg('mm1_b_scale'),
-        KeywordArg('mm1_bias'), mm_dtype, -1)
-    getitem_3 = CallFunction(getitem, trtllm_allreduce_default, 1)
-    ub_ar_pattern = MultiOutputPattern(
-        [trtllm_cublas_scaled_mm_default_1, getitem_3])
+        def register_fp8_quant_pattern(custom_pass: PatternMatcherPass):
+            input_node = KeywordArg('input')
+            trtllm_allreduce_default = CallFunction(
+                torch.ops.trtllm.allreduce.default,
+                input_node,
+                Ignored(), [KeywordArg('residual_in'),
+                            KeywordArg('gamma')],
+                mapping.tp_group,
+                strategy,
+                Ignored(),
+                fusion,
+                KeywordArg('eps'),
+                True,
+                False,
+                False,
+                _users=2)
+            allreduce_output = CallFunction(getitem, trtllm_allreduce_default,
+                                            0)
+            residual_out = CallFunction(getitem, trtllm_allreduce_default, 1)
+            tensorrt_llm_static_quantize_e4m3_per_tensor_default = CallFunction(
+                torch.ops.tensorrt_llm.static_quantize_e4m3_per_tensor.default,
+                allreduce_output,
+                KeywordArg('scale'),
+                _users=2)
+            quant_output = CallFunction(
+                getitem, tensorrt_llm_static_quantize_e4m3_per_tensor_default,
+                0)
+            scale_out = CallFunction(
+                getitem, tensorrt_llm_static_quantize_e4m3_per_tensor_default,
+                1)
+            fp8_quant_pattern = MultiOutputPattern(
+                [quant_output, scale_out, residual_out])
 
-    def empty_pattern(
-        mm0_a: torch.Tensor,
-        mm0_b: torch.Tensor,
-        mm0_a_scale: torch.Tensor,
-        mm0_b_scale: torch.Tensor,
-        mm0_bias: Optional[torch.Tensor],
-        mm_dtype: torch.dtype,
-        residual_in: torch.Tensor,
-        gamma: torch.Tensor,
-        eps: float,
-        scale: torch.Tensor,
-        mm1_b: torch.Tensor,
-        mm1_b_scale: torch.Tensor,
-        mm1_bias: Optional[torch.Tensor],
-    ):
-        return
+            def empty_fp8_quant_pattern(
+                input: torch.Tensor,
+                residual_in: torch.Tensor,
+                gamma: torch.Tensor,
+                eps: float,
+                scale: torch.Tensor,
+            ):
+                return
 
-    def target_pattern(
-        mm0_a: torch.Tensor,
-        mm0_b: torch.Tensor,
-        mm0_a_scale: torch.Tensor,
-        mm0_b_scale: torch.Tensor,
-        mm0_bias: Optional[torch.Tensor],
-        mm_dtype: torch.dtype,
-        residual_in: torch.Tensor,
-        gamma: torch.Tensor,
-        eps: float,
-        scale: torch.Tensor,
-        mm1_b: torch.Tensor,
-        mm1_b_scale: torch.Tensor,
-        mm1_bias: Optional[torch.Tensor],
-    ):
-        all_reduce_output = torch.ops.trtllm.ub_scaled_mm_allreduce_quant_scaled_mm_op(
-            mm0_a, mm0_b, mm0_a_scale, mm0_b_scale, mm0_bias, mm_dtype,
-            residual_in, gamma, mapping.tp_group, eps, scale, mm1_b,
-            mm1_b_scale, mm1_bias)
-        full_residual = torch.ops.trtllm.userbuffers_allreduce_finalize(
-            all_reduce_output[1], False)
-        return all_reduce_output[0], full_residual
+            def target_fp8_quant_pattern(
+                input: torch.Tensor,
+                residual_in: torch.Tensor,
+                gamma: torch.Tensor,
+                eps: float,
+                scale: torch.Tensor,
+            ):
+                input = torch.ops.trtllm.copy_to_userbuffers(input)
+                all_reduce_output = torch.ops.trtllm.allreduce(
+                    input, None, [residual_in, gamma, scale], mapping.tp_group,
+                    int(AllReduceStrategy.UB), 0,
+                    int(AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_FP8), eps,
+                    True, False, True)
+                finalize_output = torch.ops.trtllm.userbuffers_allreduce_finalize(
+                    all_reduce_output[1], False)
+                return all_reduce_output[0], scale, finalize_output
 
-    def extra_check(match: Match) -> bool:
-        # Userbuffers allreduce only supports BF16/FP16
-        if not isinstance(match.ctx.pattern_to_node[mm_dtype], torch.dtype):
-            return False
-        dt = match.ctx.pattern_to_node[mm_dtype]
-        if dt != torch.float16 and dt != torch.bfloat16:
-            return False
-        return True
+            def extra_check_fp8_quant_pattern(match: Match) -> bool:
+                input = match.ctx.pattern_to_node[input_node]
+                if not isinstance(input, torch.fx.graph.Node):
+                    return False
+                dtype = input.meta["tensor_meta"].dtype
+                # UB only supports FP16/BF16 input
+                if dtype != torch.float16 and dtype != torch.bfloat16:
+                    return False
+                return True
 
-    register_replacement(
-        empty_pattern,
-        target_pattern,
-        [],
-        fwd_only,
-        custom_pass,
-        search_fn_pattern=ub_ar_pattern,
-        extra_check=extra_check,
-    )
+            register_replacement(
+                empty_fp8_quant_pattern,
+                target_fp8_quant_pattern,
+                [],
+                fwd_only,
+                custom_pass,
+                search_fn_pattern=fp8_quant_pattern,
+                extra_check=extra_check_fp8_quant_pattern,
+            )
 
+        register_fp8_quant_pattern(custom_pass)
 
-def register_ub_allreduce_finalize(custom_pass: PatternMatcherPass):
-    mapping = Mapping(
-        world_size=tensorrt_llm.mpi_world_size(),
-        tp_size=tensorrt_llm.mpi_world_size(),
-        rank=tensorrt_llm.mpi_rank(),
-    )
-    trtllm_userbuffers_allreduce_finalize_default = CallFunction(
-        torch.ops.trtllm.userbuffers_allreduce_finalize.default,
-        KeywordArg("sharded_residual"), False)
-    trtllm_ub_scaled_mm_allreduce_quant_scaled_mm_op_default = CallFunction(
-        torch.ops.trtllm.ub_scaled_mm_allreduce_quant_scaled_mm_op.default,
-        KeywordArg("mm0_a"),
-        KeywordArg("mm0_b"),
-        KeywordArg("mm0_a_scale"),
-        KeywordArg("mm0_b_scale"),
-        KeywordArg("mm0_bias"),
-        KeywordArg("mm_dtype"),
-        trtllm_userbuffers_allreduce_finalize_default,
-        KeywordArg("gamma"),
-        mapping.tp_group,
-        KeywordArg("eps"),
-        KeywordArg("scale"),
-        KeywordArg("mm1_b"),
-        KeywordArg("mm1_b_scale"),
-        KeywordArg("mm1_bias"),
-        _users=2,
-    )
-    getitem_0 = CallFunction(
-        getitem, trtllm_ub_scaled_mm_allreduce_quant_scaled_mm_op_default, 0)
-    getitem_1 = CallFunction(
-        getitem, trtllm_ub_scaled_mm_allreduce_quant_scaled_mm_op_default, 1)
-    ub_ar_finalize_pattern = MultiOutputPattern([getitem_0, getitem_1])
+    def register_convert_supported_ar_to_ub(custom_pass: PatternMatcherPass):
+        strategy = int(AllReduceStrategy.AUTO)
+        # TODO: Also handle scale once the allreduce interface does not contain
+        # dynamic number of tensors.
+        input_node = KeywordArg('input')
+        fusion = KeywordArg('fusion_op')
+        trtllm_allreduce_default = CallFunction(
+            torch.ops.trtllm.allreduce.default, input_node,
+            Ignored(), [KeywordArg('residual_in'),
+                        KeywordArg('gamma')], mapping.tp_group, strategy,
+            Ignored(), fusion, KeywordArg('eps'), True, False, False)
+        convert_pattern = MultiOutputPattern([trtllm_allreduce_default])
 
-    def empty_pattern(
-        mm0_a: torch.Tensor,
-        mm0_b: torch.Tensor,
-        mm0_a_scale: torch.Tensor,
-        mm0_b_scale: torch.Tensor,
-        mm0_bias: Optional[torch.Tensor],
-        mm_dtype: torch.dtype,
-        sharded_residual: torch.Tensor,
-        gamma: torch.Tensor,
-        eps: float,
-        scale: torch.Tensor,
-        mm1_b: torch.Tensor,
-        mm1_b_scale: torch.Tensor,
-        mm1_bias: Optional[torch.Tensor],
-    ):
-        return
+        def empty_convert_supported_ar_to_ub(
+            input: torch.Tensor,
+            residual_in: torch.Tensor,
+            gamma: torch.Tensor,
+            fusion_op: int,
+            eps: float,
+        ):
+            return
 
-    def target_pattern(
-        mm0_a: torch.Tensor,
-        mm0_b: torch.Tensor,
-        mm0_a_scale: torch.Tensor,
-        mm0_b_scale: torch.Tensor,
-        mm0_bias: Optional[torch.Tensor],
-        mm_dtype: torch.dtype,
-        sharded_residual: torch.Tensor,
-        gamma: torch.Tensor,
-        eps: float,
-        scale: torch.Tensor,
-        mm1_b: torch.Tensor,
-        mm1_b_scale: torch.Tensor,
-        mm1_bias: Optional[torch.Tensor],
-    ):
-        all_reduce_output = torch.ops.trtllm.ub_scaled_mm_allreduce_quant_scaled_mm_op(
-            mm0_a, mm0_b, mm0_a_scale, mm0_b_scale, mm0_bias, mm_dtype,
-            sharded_residual, gamma, mapping.tp_group, eps, scale, mm1_b,
-            mm1_b_scale, mm1_bias)
-        return all_reduce_output[0], all_reduce_output[1]
+        def target_convert_supported_ar_to_ub(
+            input: torch.Tensor,
+            residual_in: torch.Tensor,
+            gamma: torch.Tensor,
+            fusion_op: int,
+            eps: float,
+        ):
+            input = torch.ops.trtllm.copy_to_userbuffers(input)
+            all_reduce_output = torch.ops.trtllm.allreduce(
+                input, None, [residual_in, gamma], mapping.tp_group,
+                int(AllReduceStrategy.UB), 0, fusion_op, eps, True, False,
+                False)
+            finalize_output = torch.ops.trtllm.userbuffers_allreduce_finalize(
+                all_reduce_output[-1], False)
+            all_reduce_output[-1] = finalize_output
+            return all_reduce_output
 
-    def extra_check(match: Match) -> bool:
-        return True
+        def extra_check_convert_supported_ar_to_ub(match: Match) -> bool:
+            input = match.ctx.pattern_to_node[input_node]
+            if not isinstance(input, torch.fx.graph.Node):
+                return False
+            dtype = input.meta["tensor_meta"].dtype
+            # UB only supports FP16/BF16 input
+            if dtype != torch.float16 and dtype != torch.bfloat16:
+                return False
 
-    register_replacement(
-        empty_pattern,
-        target_pattern,
-        [],
-        fwd_only,
-        custom_pass,
-        search_fn_pattern=ub_ar_finalize_pattern,
-        extra_check=extra_check,
-    )
+            fusion_value = match.ctx.pattern_to_node[fusion]
+            if not isinstance(fusion_value, int):
+                return False
+            if fusion_value != int(
+                    AllReduceFusionOp.RESIDUAL_RMS_NORM
+            ) and fusion_value != int(
+                    AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_FP8
+            ) and fusion_value != int(
+                    AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_NVFP4):
+                return False
+
+            return True
+
+        register_replacement(
+            empty_convert_supported_ar_to_ub,
+            target_convert_supported_ar_to_ub,
+            [],
+            fwd_only,
+            custom_pass,
+            search_fn_pattern=convert_pattern,
+            extra_check=extra_check_convert_supported_ar_to_ub,
+        )
+
+    def register_ub_prologue_patterns(custom_pass: PatternMatcherPass):
+
+        def register_scaled_mm_prologue(custom_pass: PatternMatcherPass):
+            mm_dtype = KeywordArg('mm_dtype')
+            trtllm_cublas_scaled_mm_default = CallFunction(
+                torch.ops.trtllm.cublas_scaled_mm.default, KeywordArg('mm0_a'),
+                KeywordArg('mm0_b'), KeywordArg('mm0_a_scale'),
+                KeywordArg('mm0_b_scale'), KeywordArg('mm0_bias'), mm_dtype)
+            ub_copy = CallFunction(torch.ops.trtllm.copy_to_userbuffers,
+                                   trtllm_cublas_scaled_mm_default)
+            scaled_mm_prologue_pattern = MultiOutputPattern([ub_copy])
+
+            def empty_scaled_mm_prologue_pattern(
+                mm0_a: torch.Tensor,
+                mm0_b: torch.Tensor,
+                mm0_a_scale: torch.Tensor,
+                mm0_b_scale: torch.Tensor,
+                mm0_bias: Optional[torch.Tensor],
+                mm_dtype: torch.dtype,
+            ):
+                return
+
+            def target_scaled_mm_prologue_pattern(
+                mm0_a: torch.Tensor,
+                mm0_b: torch.Tensor,
+                mm0_a_scale: torch.Tensor,
+                mm0_b_scale: torch.Tensor,
+                mm0_bias: Optional[torch.Tensor],
+                mm_dtype: torch.dtype,
+            ):
+                scaled_mm_output = torch.ops.trtllm.cublas_scaled_mm(
+                    mm0_a, mm0_b, mm0_a_scale, mm0_b_scale, mm0_bias, mm_dtype,
+                    True)
+                return scaled_mm_output
+
+            # No extra check needed as the output dtype of scaled_mm has been verified when
+            # ub_copy is inserted.
+            register_replacement(
+                empty_scaled_mm_prologue_pattern,
+                target_scaled_mm_prologue_pattern,
+                [],
+                fwd_only,
+                custom_pass,
+                search_fn_pattern=scaled_mm_prologue_pattern,
+            )
+
+        def register_mm_prologue(custom_pass: PatternMatcherPass):
+            aten_mm_default = CallFunction(torch.ops.aten.mm.default,
+                                           KeywordArg('mm0_a'),
+                                           KeywordArg('mm0_b'))
+            ub_copy = CallFunction(torch.ops.trtllm.copy_to_userbuffers,
+                                   aten_mm_default)
+            mm_prologue_pattern = MultiOutputPattern([ub_copy])
+
+            def empty_mm_prologue_pattern(
+                mm0_a: torch.Tensor,
+                mm0_b: torch.Tensor,
+            ):
+                return
+
+            def target_mm_prologue_pattern(
+                mm0_a: torch.Tensor,
+                mm0_b: torch.Tensor,
+            ):
+                mm_output = torch.ops.trtllm.matmul_to_ub(mm0_a, mm0_b)
+                return mm_output
+
+            # No extra check needed as the output dtype of mm has been verified when
+            # ub_copy is inserted.
+            register_replacement(
+                empty_mm_prologue_pattern,
+                target_mm_prologue_pattern,
+                [],
+                fwd_only,
+                custom_pass,
+                search_fn_pattern=mm_prologue_pattern,
+            )
+
+        def register_add_prologue(custom_pass: PatternMatcherPass):
+            aten_add_default = CallFunction(torch.ops.aten.add.Tensor,
+                                            KeywordArg('add_a'),
+                                            KeywordArg('add_b'))
+            ub_copy = CallFunction(torch.ops.trtllm.copy_to_userbuffers,
+                                   aten_add_default)
+            add_prologue_pattern = MultiOutputPattern([ub_copy])
+
+            def empty_add_prologue_pattern(
+                add_a: torch.Tensor,
+                add_b: torch.Tensor,
+            ):
+                return
+
+            def target_add_prologue_pattern(
+                add_a: torch.Tensor,
+                add_b: torch.Tensor,
+            ):
+                add_output = torch.ops.trtllm.add_to_ub(add_a, add_b)
+                return add_output
+
+            # No extra check needed as the output dtype of add has been verified when
+            # ub_copy is inserted.
+            register_replacement(
+                empty_add_prologue_pattern,
+                target_add_prologue_pattern,
+                [],
+                fwd_only,
+                custom_pass,
+                search_fn_pattern=add_prologue_pattern,
+            )
+
+        register_scaled_mm_prologue(custom_pass)
+        register_mm_prologue(custom_pass)
+        register_add_prologue(custom_pass)
+
+    def register_ub_finalize_patterns(custom_pass: PatternMatcherPass):
+        # TODO: Unify the finalize patterns once the allreduce interface does not contain
+        # dynamic number of tensors.
+        def allreduce_fp8_finalize_pattern(custom_pass: PatternMatcherPass):
+            trtllm_userbuffers_allreduce_finalize_default = CallFunction(
+                torch.ops.trtllm.userbuffers_allreduce_finalize.default,
+                KeywordArg("sharded_residual"), False)
+            trtllm_allreduce_default = CallFunction(
+                torch.ops.trtllm.allreduce.default, KeywordArg("input"),
+                Ignored(), [
+                    trtllm_userbuffers_allreduce_finalize_default,
+                    KeywordArg("gamma"),
+                    KeywordArg("scale")
+                ], mapping.tp_group, int(AllReduceStrategy.UB), 0,
+                int(AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_FP8),
+                KeywordArg("eps"), True, False, True)
+            ub_ar_finalize_pattern = MultiOutputPattern(
+                [trtllm_allreduce_default])
+
+            def empty_fp8_finalize_pattern(
+                input: torch.Tensor,
+                sharded_residual: torch.Tensor,
+                gamma: torch.Tensor,
+                scale: torch.Tensor,
+                eps: float,
+            ):
+                return
+
+            def target_fp8_finalize_pattern(
+                input: torch.Tensor,
+                sharded_residual: torch.Tensor,
+                gamma: torch.Tensor,
+                scale: torch.Tensor,
+                eps: float,
+            ):
+                all_reduce_output = torch.ops.trtllm.allreduce(
+                    input, None, [sharded_residual, gamma, scale],
+                    mapping.tp_group, int(AllReduceStrategy.UB), 0,
+                    int(AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_FP8), eps,
+                    True, False, True)
+                return all_reduce_output
+
+            register_replacement(
+                empty_fp8_finalize_pattern,
+                target_fp8_finalize_pattern,
+                [],
+                fwd_only,
+                custom_pass,
+                search_fn_pattern=ub_ar_finalize_pattern,
+            )
+
+        def allreduce_half_finalize_pattern(custom_pass: PatternMatcherPass):
+            trtllm_userbuffers_allreduce_finalize_default = CallFunction(
+                torch.ops.trtllm.userbuffers_allreduce_finalize.default,
+                KeywordArg("sharded_residual"), False)
+            trtllm_allreduce_default = CallFunction(
+                torch.ops.trtllm.allreduce.default, KeywordArg("input"),
+                Ignored(), [
+                    trtllm_userbuffers_allreduce_finalize_default,
+                    KeywordArg("gamma")
+                ], mapping.tp_group, int(AllReduceStrategy.UB), 0,
+                int(AllReduceFusionOp.RESIDUAL_RMS_NORM), KeywordArg("eps"),
+                True, False, False)
+            ub_ar_finalize_pattern = MultiOutputPattern(
+                [trtllm_allreduce_default])
+
+            def empty_half_finalize_pattern(
+                input: torch.Tensor,
+                sharded_residual: torch.Tensor,
+                gamma: torch.Tensor,
+                eps: float,
+            ):
+                return
+
+            def target_half_finalize_pattern(
+                input: torch.Tensor,
+                sharded_residual: torch.Tensor,
+                gamma: torch.Tensor,
+                eps: float,
+            ):
+                all_reduce_output = torch.ops.trtllm.allreduce(
+                    input, None, [sharded_residual, gamma], mapping.tp_group,
+                    int(AllReduceStrategy.UB), 0,
+                    int(AllReduceFusionOp.RESIDUAL_RMS_NORM), eps, True, False,
+                    False)
+                return all_reduce_output
+
+            register_replacement(
+                empty_half_finalize_pattern,
+                target_half_finalize_pattern,
+                [],
+                fwd_only,
+                custom_pass,
+                search_fn_pattern=ub_ar_finalize_pattern,
+            )
+
+        allreduce_fp8_finalize_pattern(custom_pass)
+        allreduce_half_finalize_pattern(custom_pass)
+
+    custom_passes.append(PatternMatcherPass())
+    register_ub_allreduce_quantize_fusion(custom_passes[-1])
+
+    custom_passes.append(PatternMatcherPass())
+    register_convert_supported_ar_to_ub(custom_passes[-1])
+
+    custom_passes.append(PatternMatcherPass())
+    register_ub_prologue_patterns(custom_passes[-1])
+
+    custom_passes.append(PatternMatcherPass())
+    register_ub_finalize_patterns(custom_passes[-1])

--- a/tensorrt_llm/_torch/custom_ops/__init__.py
+++ b/tensorrt_llm/_torch/custom_ops/__init__.py
@@ -1,13 +1,15 @@
 from .cpp_custom_ops import _register_fake
 from .flashinfer_custom_ops import IS_FLASHINFER_AVAIABLE
 from .torch_custom_ops import bmm_out
-from .userbuffers_custom_ops import ub_scaled_mm_allreduce_quant_scaled_mm_op
+from .userbuffers_custom_ops import add_to_ub, copy_to_userbuffers, matmul_to_ub
 
 __all__ = [
     'IS_FLASHINFER_AVAIABLE',
     '_register_fake',
     'bmm_out',
-    'ub_scaled_mm_allreduce_quant_scaled_mm_op',
+    'add_to_ub',
+    'copy_to_userbuffers',
+    'matmul_to_ub',
 ]
 
 if IS_FLASHINFER_AVAIABLE:

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -29,7 +29,7 @@ def _register_fake():
             scale_output = input.new_empty(scale_shape, dtype=torch.uint8)
             return [final_output, scale_output, inter_output]
         elif op == int(AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_FP8):
-            final_output = input.new_empty(fp4_shape, dtype=torch.float8_e4m3fn)
+            final_output = torch.empty_like(input, dtype=torch.float8_e4m3fn)
             inter_output = torch.empty_like(input)
             return [final_output, inter_output]
         elif op == int(AllReduceFusionOp.RESIDUAL_RMS_NORM):
@@ -52,7 +52,7 @@ def _register_fake():
         scale_b: torch.Tensor,
         bias,
         out_dtype,
-        userbuffers_id,
+        userbuffers_id=False,
     ):
         shape = [i for i in mat_a.shape]
         shape[-1] = mat_b.shape[-1]

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -310,7 +310,6 @@ class Linear(nn.Module):
                     scale_b=self.weight_scale,
                     bias=None,
                     out_dtype=self.dtype or input.dtype,
-                    userbuffers_id=-1,
                 )
                 if bias is not None:
                     output = output + bias

--- a/tests/unittest/_torch/thop/test_scaled_mm.py
+++ b/tests/unittest/_torch/thop/test_scaled_mm.py
@@ -53,7 +53,6 @@ def test_fp8_scaled_mm(output_dtype, m, k_n):
         scale_w,
         bias=None,
         out_dtype=output_dtype,
-        userbuffers_id=-1,
     )
     # set pytorch's cublas workspace size to 32MB to be aligned with trtllm
     old_env = os.environ.get("CUBLASLT_WORKSPACE_SIZE", "")


### PR DESCRIPTION
* Instead of allocating UserBuffers at beginning of runtime, UB buffers are now managed with global allocator. The allocator will dynamically assign free UB buffer or allocate new buffer for torch tensor. It makes userbuffers easier to use.

* In common usecase, the Userbuffers will be allocated correctly during warm up stage. There is no dynamic allocation during inference.

* UB fusion pattern is rewroten using the new UB Allocator. It contains following passes:

1. Fuse Quant with allreduce, replace with UB impl, and insert a copy_to_userbuffers. Currently the normal allreduce still does not support FP8 quant. So this need to be done in UB pass
2. Convert all supported allreduce with UB and insert copy_to_userbuffers.
3. Fuse op before ar with the copy_to_userbuffers. So the op directly writes to the userbuffer
4. Remove userbuffers finalize if the output is connect to another UB allreduce.