### PR TITLE
fix: #3137 speculative decoding and multimodal input support

### DIFF
--- a/tensorrt_llm/layers/embedding.py
+++ b/tensorrt_llm/layers/embedding.py
@@ -20,8 +20,8 @@ import torch
 
 from .._utils import set_obj_attrs, str_dtype_to_torch, trt_dtype_to_np
 from ..functional import (ACT2FN, Tensor, arange, concat, constant, cos, div,
-                          embedding, exp, identity, meshgrid2d, outer, pad,
-                          shape, sin, slice, unsqueeze, where)
+                          embedding, exp, expand, identity, meshgrid2d, outer,
+                          pad, shape, sin, slice, unsqueeze, where)
 from ..mapping import Mapping
 from ..module import Module
 from ..parameter import Parameter
@@ -177,6 +177,9 @@ class PromptTuningEmbedding(Embedding):
 
         # tasks: [batch_size, seq_len]
         # prompt_tokens: [batch_size, seq_len]
+        # if speculative decoding is enabled tasks is [batch_size, seq_len + max_draft_len],
+        # so we need to expand tasks to [batch_size, seq_len + max_draft_len]
+        tasks = expand(tasks, (tasks.shape[0], prompt_tokens.shape[1]))
         prompt_tokens = prompt_tokens + tasks
         prompt_embeddings = embedding(prompt_tokens, prompt_embedding_table)
 

--- a/tensorrt_llm/layers/embedding.py
+++ b/tensorrt_llm/layers/embedding.py
@@ -179,7 +179,7 @@ class PromptTuningEmbedding(Embedding):
         # prompt_tokens: [batch_size, seq_len]
         # if speculative decoding is enabled tasks is [batch_size, seq_len + max_draft_len],
         # so we need to expand tasks to [batch_size, seq_len + max_draft_len]
-        tasks = expand(tasks, (tasks.shape[0], prompt_tokens.shape[1]))
+        tasks = expand(tasks, shape(prompt_tokens))
         prompt_tokens = prompt_tokens + tasks
         prompt_embeddings = embedding(prompt_tokens, prompt_embedding_table)
 

--- a/tensorrt_llm/layers/embedding.py
+++ b/tensorrt_llm/layers/embedding.py
@@ -177,7 +177,7 @@ class PromptTuningEmbedding(Embedding):
 
         # tasks: [batch_size, seq_len]
         # prompt_tokens: [batch_size, seq_len]
-        # if speculative decoding is enabled tasks is [batch_size, seq_len + max_draft_len],
+        # if speculative decoding is enabled the shape of prompt_tokens is [batch_size, seq_len + max_draft_len],
         # so we need to expand tasks to [batch_size, seq_len + max_draft_len]
         tasks = expand(tasks, shape(prompt_tokens))
         prompt_tokens = prompt_tokens + tasks


### PR DESCRIPTION
Currently lookahead decoding does not work for batch_size > 1 when multimodal input is enabled.

This is due to the PromptTuningEmbedding layer assuming prompt_tokens are always `[batch_size, seq_len]` but when speculative decoding is enabled shape will be `[batch_size, 1]` thus causing an incompatible shape error as discussed [here](https://github.com/NVIDIA/TensorRT-LLM/issues/3137)

This PR fixes the issue by broadcasting the tasks tensor to the correct shape