### PR TITLE
feat: [TRTLLM-3510] DeepseekV3 support in AutoDeploy

### DIFF
--- a/examples/auto_deploy/README.md
+++ b/examples/auto_deploy/README.md
@@ -72,15 +72,16 @@ Additionally, we have officially verified and fully optimized support for the fo
 <details>
 <summary>Click to expand supported models list</summary>
 
-| Model Series | HF Model Card | Precision | World Size | Runtime | Compile Backend || Attention Backend ||
-|--------------|----------------------|-----------|------------|---------|-----------------|--------------------|--------|--------------------|
-|              |               |           |            |         | torch-simple    | torch-opt          | TritonWithFlattenedInputs | FlashInfer |
-| LLaMA        | meta-llama/Llama-2-7b-chat-hf<br>meta-llama/Meta-Llama-3.1-8B-Instruct<br>meta-llama/Llama-3.1-70B-Instruct<br>codellama/CodeLlama-13b-Instruct-hf | BF16 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ |
-| Nvidia Minitron | nvidia/Llama-3_1-Nemotron-51B-Instruct<br>nvidia/Llama-3.1-Minitron-4B-Width-Base<br>nvidia/Llama-3.1-Minitron-4B-Depth-Base | BF16 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ |
-| Nvidia Model Optimizer | nvidia/Llama-3.1-8B-Instruct-FP8<br>nvidia/Llama-3.1-405B-Instruct-FP8 | FP8 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ |
-| DeepSeek     | deepseek-ai/DeepSeek-R1-Distill-Llama-70B | BF16 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ |
-| Mistral      | mistralai/Mixtral-8x7B-Instruct-v0.1<br>mistralai/Mistral-7B-Instruct-v0.3 | BF16 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ |
-| BigCode      | bigcode/starcoder2-15b | FP32 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ |
+| Model Series | HF Model Card | Precision | World Size | Runtime | Compile Backend || Attention Backend |||
+|--------------|----------------------|-----------|------------|---------|-----------------|--------------------|--------|----------|----------|
+|              |               |           |            |         | torch-simple    | torch-opt          | TritonWithFlattenedInputs | FlashInfer | MultiHeadLatentAttention |
+| LLaMA        | meta-llama/Llama-2-7b-chat-hf<br>meta-llama/Meta-Llama-3.1-8B-Instruct<br>meta-llama/Llama-3.1-70B-Instruct<br>codellama/CodeLlama-13b-Instruct-hf | BF16 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ | n/a |
+| Nvidia Minitron | nvidia/Llama-3_1-Nemotron-51B-Instruct<br>nvidia/Llama-3.1-Minitron-4B-Width-Base<br>nvidia/Llama-3.1-Minitron-4B-Depth-Base | BF16 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ | n/a |
+| Nvidia Model Optimizer | nvidia/Llama-3.1-8B-Instruct-FP8<br>nvidia/Llama-3.1-405B-Instruct-FP8 | FP8 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ | n/a |
+| DeepSeek     | deepseek-ai/DeepSeek-R1-Distill-Llama-70B | BF16 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ | n/a |
+| Mistral      | mistralai/Mixtral-8x7B-Instruct-v0.1<br>mistralai/Mistral-7B-Instruct-v0.3 | BF16 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ | n/a |
+| BigCode      | bigcode/starcoder2-15b | FP32 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ | n/a |
+| Deepseek-V3      | deepseek-ai/DeepSeek-V3 | BF16 | 1,2,4 | demollm | ✅ | ❌ | n/a | n/a | ✅ |
 
 </details>
 
@@ -129,6 +130,7 @@ In the below example:
 - `runtime` specify which type of Engine to use during runtime, default is `demollm` .
 - `compile_backend` specify how to compile the graph from `torch.export`, default is `torch-opt` .
 - `attn_backend` specify kernel implementation for attention, default is `TritonWithFlattenedInputs`.
+- `mla_backend` specify implementation for multi-head latent attention, default is `MultiHeadLatentAttention`.
 - `benchmark` indicates whether to run the built-in benchmark for token generation, default is `False`.
 
 ```bash

--- a/examples/auto_deploy/build_and_run_ad.py
+++ b/examples/auto_deploy/build_and_run_ad.py
@@ -43,6 +43,7 @@ def build_llm_from_config(config: SimpleConfig) -> LLM:
         torch_compile_enabled=config.compile_backend == "torch-opt",
         model_kwargs=config.model_kwargs,
         attn_backend=config.attn_backend,
+        mla_backend=config.mla_backend,
         skip_loading_weights=config.skip_loading_weights,
         cuda_graph_max_batch_size=config.max_batch_size,
     )
@@ -98,7 +99,7 @@ def main(config: Optional[SimpleConfig] = None):
     if config.benchmark:
         token_ids = torch.randint(0, 100, (config.benchmark_bs, config.benchmark_isl)).tolist()
         sampling_params = SamplingParams(max_tokens=config.benchmark_osl, top_k=None)
-        keys = ["compile_backend", "attn_backend"]
+        keys = ["compile_backend", "attn_backend", "mla_backend"]
         benchmark(
             lambda: llm.generate(token_ids, sampling_params=sampling_params, use_tqdm=False),
             config.benchmark_num,

--- a/examples/auto_deploy/simple_config.py
+++ b/examples/auto_deploy/simple_config.py
@@ -44,6 +44,7 @@ class SimpleConfig:
     runtime: str = "demollm"  # chose from "demollm" or "trtllm" (production-grade runtime)
     compile_backend: str = "torch-opt"  # choose from "torch-simple", "torch-opt"
     attn_backend: str = "TritonWithFlattenedInputs"  # "TritonWithFlattenedInputs" or "FlashInfer"
+    mla_backend: str = "MultiHeadLatentAttention"  # only option for now
     max_seq_len: int = 512  # max sequence length for inference/cache
     max_batch_size: int = 8  # max dimension for statically allocated kv cache
     page_size: int = 64  # page size for attention
@@ -106,7 +107,7 @@ class SimpleConfig:
             self.max_seq_len = max(self.max_seq_len, self.benchmark_isl + self.benchmark_osl)
 
         # No paging allowed in TritonWithFlattenedInputs
-        if self.attn_backend == "TritonWithFlattenedInputs":
+        if self.attn_backend in ["TritonWithFlattenedInputs"]:
             self.page_size = self.max_seq_len
 
         # use min instead of max to avoid OOM for large batch size

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/__init__.py
@@ -4,6 +4,7 @@ from .dist import *
 from .flashinfer_attention import *
 from .fused_moe import *
 from .linear import *
+from .mla import *
 from .quant import *
 from .rope import *
 from .torch_attention import *

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/flashinfer_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/flashinfer_attention.py
@@ -331,7 +331,7 @@ class FlashInferAttention(AttentionDescriptor):
 
     @classmethod
     def get_attention_op(cls):
-        return torch.ops.attention.flashinfer_mha_with_cache
+        return torch.ops.attention.flashinfer_mha_with_cache, 3
 
     @classmethod
     def get_prepare_metadata_op(cls):

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe.py
@@ -59,7 +59,9 @@ def torch_moe(
         expert_out = F.linear(prod, w2_weight[expert_idx])
 
         current_hidden_states = expert_out * routing_weights[top_x, idx, None]
-        final_hidden_states.index_add_(0, top_x, current_hidden_states)
+        final_hidden_states.index_add_(
+            0, top_x, current_hidden_states.to(final_hidden_states.dtype)
+        )
 
     return final_hidden_states.view_as(x)
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mla.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mla.py
@@ -1,0 +1,260 @@
+"""Custom ops for MultiHead Latent attention."""
+
+from typing import List, Optional, Tuple, Union
+
+import torch
+
+from .attention_interface import (
+    AttentionDescriptor,
+    AttentionRegistry,
+    BufferInitializerDict,
+    CacheInitializerDict,
+    MHACallable,
+    PrepareMetadataCallable,
+    SequenceInfo,
+)
+from .torch_attention import apply_rotary_pos_emb_ds
+from .triton_attention import _flattened_context_mha, _generate_mha
+
+Constant = Union[int, float, str, None]
+
+
+@torch.library.custom_op("attention::fused_flattened_mla_with_cache", mutates_args=())
+def fused_flattened_mla_with_cache(
+    # Q, K, V
+    q_nope: torch.Tensor,
+    q_pe: torch.Tensor,
+    kv: torch.Tensor,
+    k_pe: torch.Tensor,
+    # METADATA
+    seq_len: torch.Tensor,
+    input_pos: torch.Tensor,
+    cache_loc: torch.Tensor,
+    seq_start: torch.Tensor,
+    # CACHES
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    # BUFFERS
+    cos_sin_stacked: torch.Tensor,
+    # CONSTANTS
+    softmax_scale: Optional[float] = None,
+) -> torch.Tensor:
+    """Flattened & fused MLA with cache with triton kernels."""
+    # b, s info
+    # NOTE: b, s are just the shapes of the input tensor q; not necessarily the number of sequences.
+    # Generally speaking, we expect one of two cases here:
+    # 1. b > 0, s==1: this indicates a generate-only batch of tokens.
+    # 2. b==1, s > 0: this indicates a mixed context+generate phase. The actual number of sequences
+    #    and number of tokens per sequence are encoded in seq_len and seq_start.
+
+    # Get parameters
+    b, num_heads, s, qk_nope_head_dim = q_nope.shape
+    qk_rope_head_dim = q_pe.shape[-1]
+    v_head_dim = kv.shape[-1] - qk_nope_head_dim
+
+    # Get k_nope and value_states
+    k_nope, value_states = torch.split(kv, [qk_nope_head_dim, v_head_dim], dim=-1)
+
+    # Flatten inputs
+    if s == 1:
+        bs_view = (b, s)
+    else:
+        bs_view = (b * s,)
+
+    # TODO(suyogg): do something about all these clones, transposes, and contiguous-es
+    q_nope = q_nope.clone().transpose(1, 2).view(*bs_view, num_heads, qk_nope_head_dim).contiguous()
+    q_pe = q_pe.clone().transpose(1, 2).view(*bs_view, num_heads, qk_rope_head_dim).contiguous()
+    k_nope = k_nope.clone().transpose(1, 2).view(*bs_view, num_heads, qk_nope_head_dim).contiguous()
+    k_pe = k_pe.clone().transpose(1, 2).view(*bs_view, -1, qk_rope_head_dim).contiguous()
+    value_states = value_states.transpose(1, 2).view(*bs_view, -1, v_head_dim).contiguous()
+    # Apply RoPE
+    if cos_sin_stacked.numel() > 0:
+        # Extract cos and sin from freqs_cis
+        cos = cos_sin_stacked[0, ...]
+        sin = cos_sin_stacked[1, ...]
+
+        # TODO: Use triton kernels for RoPE
+        # TODO: Add yarn support
+        for idx in range(seq_len.shape[0]):
+            (
+                q_pe[seq_start[idx] : seq_start[idx] + seq_len[idx], ...],
+                k_pe[seq_start[idx] : seq_start[idx] + seq_len[idx], ...],
+            ) = apply_rotary_pos_emb_ds(
+                q_pe[seq_start[idx] : seq_start[idx] + seq_len[idx], ...],
+                k_pe[seq_start[idx] : seq_start[idx] + seq_len[idx], ...],
+                cos,
+                sin,
+                torch.arange(input_pos[idx] + seq_len[idx])[-1]
+                if s == 1
+                else torch.arange(input_pos[idx] + seq_len[idx]),
+                -2,
+            )
+
+    # Create query_states, key_states
+    query_states = torch.cat((q_nope, q_pe), dim=-1)  # [b*s,n,d]
+    key_states = torch.cat((k_nope, k_pe.expand(*bs_view, num_heads, -1)), dim=-1)  # [b*s,n,d]
+
+    # Compute attention
+    y = torch.empty_like(value_states)
+    if s == 1:
+        # generate-only phase
+        _generate_mha(
+            query_states.contiguous(),
+            key_states.contiguous(),
+            value_states.contiguous(),
+            k_cache,
+            v_cache,
+            cache_loc,
+            input_pos,
+            y,
+        )
+
+    else:
+        # mixed context + generate phase
+        _flattened_context_mha(
+            query_states.contiguous(),
+            key_states.contiguous(),
+            value_states.contiguous(),
+            input_pos,
+            cache_loc,
+            k_cache,
+            v_cache,
+            seq_len,
+            seq_start,
+            y,
+        )
+
+    y = (
+        y.view(b, s, -1, v_head_dim).transpose(1, 2).contiguous()
+    )  # BNSD format as expected by the callsite.
+    return y
+
+
+@fused_flattened_mla_with_cache.register_fake
+def fused_flattened_mla_with_cache_fake(
+    # Q, K, V
+    q_nope: torch.Tensor,
+    q_pe: torch.Tensor,
+    kv: torch.Tensor,
+    k_pe: torch.Tensor,
+    # METADATA
+    seq_len: torch.Tensor,
+    input_pos: torch.Tensor,
+    cache_loc: torch.Tensor,
+    seq_start: torch.Tensor,
+    # CACHES
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    # BUFFERS
+    cos_sin_stacked: torch.Tensor,
+    # CONSTANTS
+    softmax_scale: Optional[float] = None,
+):
+    v_head_dim = kv.shape[-1] - q_nope.shape[-1]
+    return torch.empty_like(kv[..., -v_head_dim:])
+
+
+@torch.library.custom_op("attention::prepare_fused_mla_metadata", mutates_args=())
+def prepare_fused_mla_metadata(
+    input_ids: torch.Tensor,
+    seq_len: torch.Tensor,
+    input_pos: torch.Tensor,
+    cache_loc: torch.Tensor,
+    pages_per_seq: torch.Tensor,
+    page_size: int,
+) -> List[torch.Tensor]:
+    num_seq = SequenceInfo._get_sanitized_num_sequences(input_ids, seq_len)
+    seq_start = torch.zeros_like(seq_len[:num_seq])
+    seq_start[1:] = torch.cumsum(seq_len[: num_seq - 1], 0)
+    return (
+        seq_len[:num_seq].clone(),
+        input_pos[:num_seq].clone(),
+        cache_loc[:num_seq].clone(),
+        seq_start,
+    )
+
+
+@prepare_fused_mla_metadata.register_fake
+def prepare_fused_mla_metadata_fake(
+    input_ids, seq_len, input_pos, cache_loc, pages_per_seq, page_size
+):
+    return (
+        torch.empty_like(seq_len),
+        torch.empty_like(input_pos),
+        torch.empty_like(cache_loc),
+        torch.empty_like(seq_len),
+    )
+
+
+@AttentionRegistry.register("MultiHeadLatentAttention")
+class MultiHeadLatentAttention(AttentionDescriptor):
+    @classmethod
+    def is_paged(cls) -> bool:
+        """Return if the attention op is paged or not."""
+        return False
+
+    @classmethod
+    def get_attention_op(cls) -> Tuple[MHACallable, int]:
+        return torch.ops.attention.fused_flattened_mla_with_cache, 4
+
+    @classmethod
+    def get_prepare_metadata_op(cls) -> Tuple[PrepareMetadataCallable, int]:
+        return torch.ops.attention.prepare_fused_mla_metadata, 4
+
+    @classmethod
+    def get_cache_initializers(cls, get_mla_info) -> CacheInitializerDict:
+        attention_info = get_mla_info()
+
+        def _get_k_cache(si: SequenceInfo):
+            assert not si.is_paged, "Paged cache not supported for MultiHeadLatentAttention"
+            return torch.empty(
+                si.num_pages,
+                si.page_size,
+                attention_info.num_kv_heads,
+                attention_info.head_dim + attention_info.rope_dim,
+                device=si.device,
+                dtype=attention_info.cache_config.dtype or attention_info.dtype,
+            )
+
+        def _get_v_cache(si: SequenceInfo):
+            assert not si.is_paged, "Paged cache not supported for MultiHeadLatentAttention"
+            return torch.empty(
+                si.num_pages,
+                si.page_size,
+                attention_info.num_kv_heads,
+                attention_info.head_dim,
+                device=si.device,
+                dtype=attention_info.cache_config.dtype or attention_info.dtype,
+            )
+
+        return {"k_cache": _get_k_cache, "v_cache": _get_v_cache}
+
+    @classmethod
+    def get_global_buffer_initializers(cls, get_mla_info) -> BufferInitializerDict:
+        attention_info = get_mla_info()
+        rope_head_dim = attention_info.rope_dim
+        rope_theta = attention_info.pos_embd_config.rope_theta
+
+        def _get_cos_sin_stacked(si: SequenceInfo):
+            if rope_theta is None:
+                return torch.empty(0, device=si.device)
+            return cls._precompute_inv_freq(si.max_seq_len, rope_head_dim, rope_theta).to(si.device)
+
+        return {
+            f"cos_sin_stacked_{rope_head_dim}_{rope_theta}".replace(".", "_"): _get_cos_sin_stacked
+        }
+
+    @classmethod
+    def get_constants(cls, get_mla_info) -> List[Constant]:
+        return [None]
+
+    @staticmethod
+    def _precompute_inv_freq(seq_len: int, head_dim: int, rope_theta: float = 1e4) -> torch.Tensor:
+        inv_freq = 1.0 / (rope_theta ** (torch.arange(0, head_dim, 2).float() / head_dim))
+        t = torch.arange(seq_len, device=inv_freq.device, dtype=inv_freq.dtype)
+
+        freqs = torch.outer(t, inv_freq.to(t.device))
+        # Different from paper, but it uses a different permutation in order to obtain the same calculation
+        emb = torch.cat((freqs, freqs), dim=-1)
+        cos_sin_stacked = torch.stack([emb.cos().to(torch.bfloat16), emb.sin().to(torch.bfloat16)])
+        return cos_sin_stacked

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_attention.py
@@ -1,8 +1,10 @@
 """Torch reference implementations for attention."""
 
+import math
 from typing import Optional
 
 import torch
+import torch.nn as nn
 
 from ...attention_backend.vanilla import repeat_kv
 
@@ -163,3 +165,292 @@ def fused_mha_fake(
 ) -> torch.Tensor:
     """Fake Fused MHA+Rope that takes raw input from q, k, v GEMMs."""
     return torch.empty_like(q)
+
+
+def update_kv_cache(
+    key_states: torch.Tensor,
+    value_states: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    seq_len: torch.Tensor,  # metadata
+    input_pos: torch.Tensor,  # metadata
+    cache_loc: torch.Tensor,
+    seq_start: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Reference implementation for update kv cache function. Assumes KV cache layout to be [B,S,N,D].
+    This function can be used to build reference attention implementations that use KV cache.
+    """
+
+    for idx in range(seq_len.shape[0]):
+        k_cache[cache_loc[idx], input_pos[idx] : input_pos[idx] + seq_len[idx], :, :] = key_states[
+            seq_start[idx] : seq_start[idx] + seq_len[idx], ...
+        ]
+        v_cache[cache_loc[idx], input_pos[idx] : input_pos[idx] + seq_len[idx], :, :] = (
+            value_states[seq_start[idx] : seq_start[idx] + seq_len[idx], ...]
+        )
+
+
+# Copied from transformers.models.llama.modeling_llama.rotate_half
+def rotate_half(x):
+    """Rotates half the hidden dims of the input."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+# Copied from transformers.models.llama.modeling_llama.apply_rotary_pos_emb
+@torch.inference_mode()
+def apply_rotary_pos_emb_ds(q, k, cos, sin, position_ids, unsqueeze_dim=1):
+    """Applies Rotary Position Embedding to the query and key tensors.
+    Args:
+        q (`torch.Tensor`): The query tensor.
+        k (`torch.Tensor`): The key tensor.
+        cos (`torch.Tensor`): The cosine part of the rotary embedding.
+        sin (`torch.Tensor`): The sine part of the rotary embedding.
+        position_ids (`torch.Tensor`):
+            The position indices of the tokens corresponding to the query and key tensors. For example, this can be
+            used to pass offsetted position ids when working with a KV-cache.
+        unsqueeze_dim (`int`, *optional*, defaults to 1):
+            The 'unsqueeze_dim' argument specifies the dimension along which to unsqueeze cos[position_ids] and
+            sin[position_ids] so that they can be properly broadcasted to the dimensions of q and k. For example, note
+            that cos[position_ids] and sin[position_ids] have the shape [batch_size, seq_len, head_dim]. Then, if q and
+            k have the shape [batch_size, heads, seq_len, head_dim], then setting unsqueeze_dim=1 makes
+            cos[position_ids] and sin[position_ids] broadcastable to the shapes of q and k. Similarly, if q and k have
+            the shape [batch_size, seq_len, heads, head_dim], then set unsqueeze_dim=2.
+    Returns:
+        `tuple(torch.Tensor)` comprising of the query and key tensors rotated using the Rotary Position Embedding.
+    """
+    cos = cos[position_ids].unsqueeze(unsqueeze_dim)
+    sin = sin[position_ids].unsqueeze(unsqueeze_dim)
+
+    q = q.unflatten(-1, (-1, 2)).transpose(-1, -2).reshape_as(q)
+    k = k.unflatten(-1, (-1, 2)).transpose(-1, -2).reshape_as(k)
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+@torch.library.custom_op("attention::fused_mla_ref", mutates_args=())
+def fused_mla_ref(
+    q_nope: torch.Tensor,
+    q_pe: torch.Tensor,
+    kv: torch.Tensor,
+    k_pe: torch.Tensor,
+    seq_len: torch.Tensor,  # metadata
+    input_pos: torch.Tensor,  # metadata
+    cache_loc: torch.Tensor,
+    seq_start: torch.Tensor,
+    k_cache: torch.Tensor,  # caches
+    v_cache: torch.Tensor,  # caches
+    freqs_cis: torch.Tensor,
+    softmax_scale: Optional[float] = None,
+) -> torch.Tensor:
+    """
+    Reference implementation for Fused MLA with KV cache support.
+    This implementation flattens the inputs and can be used as a reference to debug the triton kernels.
+    """
+    # Compute parameters
+    bs, num_heads, q_len, qk_nope_head_dim = q_nope.shape
+    qk_rope_head_dim = q_pe.shape[-1]
+    v_head_dim = kv.shape[-1] - qk_nope_head_dim
+    q_head_dim = qk_nope_head_dim + qk_rope_head_dim
+
+    # Flatten inputs
+    bs_view = (bs * q_len,)
+
+    k_nope, value_states = torch.split(kv, [qk_nope_head_dim, v_head_dim], dim=-1)
+
+    q_nope = q_nope.transpose(1, 2).view(*bs_view, num_heads, qk_nope_head_dim).contiguous()
+    q_pe = q_pe.transpose(1, 2).clone().view(*bs_view, num_heads, qk_rope_head_dim).contiguous()
+    k_nope = k_nope.clone().transpose(1, 2).view(*bs_view, num_heads, qk_nope_head_dim).contiguous()
+    k_pe = k_pe.clone().transpose(1, 2).view(*bs_view, -1, qk_rope_head_dim).contiguous()
+    value_states = value_states.transpose(1, 2).view(*bs_view, -1, v_head_dim).contiguous()
+
+    if freqs_cis is not None:
+        cos = freqs_cis[0, ...]
+        sin = freqs_cis[1, ...]
+        for idx in range(seq_len.shape[0]):
+            (
+                q_pe[seq_start[idx] : seq_start[idx] + seq_len[idx], ...],
+                k_pe[seq_start[idx] : seq_start[idx] + seq_len[idx], ...],
+            ) = apply_rotary_pos_emb_ds(
+                q_pe[seq_start[idx] : seq_start[idx] + seq_len[idx], ...],
+                k_pe[seq_start[idx] : seq_start[idx] + seq_len[idx], ...],
+                cos,
+                sin,
+                torch.arange(input_pos[idx] + seq_len[idx])[-1]
+                if q_len == 1
+                else torch.arange(input_pos[idx] + seq_len[idx]),
+                -2,
+            )
+
+    query_states = k_pe.new_empty(*bs_view, num_heads, q_head_dim)  # [b*s,n,d]
+    query_states[..., :qk_nope_head_dim] = q_nope
+    query_states[..., qk_nope_head_dim:] = q_pe
+
+    key_states = k_pe.new_empty(*bs_view, num_heads, q_head_dim)
+    key_states[..., :qk_nope_head_dim] = k_nope
+    key_states[..., qk_nope_head_dim:] = k_pe
+
+    # Update KV cache
+    update_kv_cache(
+        key_states, value_states, k_cache, v_cache, seq_len, input_pos, cache_loc, seq_start
+    )
+
+    # Compute attention
+    attn_outputs = []
+    for idx in range(seq_len.shape[0]):
+        # Get inputs from KV cache
+        k = k_cache[cache_loc[idx], : input_pos[idx] + seq_len[idx], :, :]  # [kv_seq_len, n, d]
+        v = v_cache[cache_loc[idx], : input_pos[idx] + seq_len[idx], :, :]  # [kv_seq_len, n, d]
+        # Generate attention mask
+        if q_len == 1:
+            # Generate phase - single token attention mask
+            attn_mask = torch.zeros(
+                1, input_pos[idx] + 1, device=query_states.device, dtype=query_states.dtype
+            )
+        else:
+            # Context phase - causal attention mask
+            temp_mask = torch.ones(
+                seq_len[idx],
+                input_pos[idx] + seq_len[idx],
+                dtype=torch.bool,
+                device=query_states.device,
+            ).tril(diagonal=0)
+            attn_bias = torch.zeros(
+                seq_len[idx],
+                input_pos[idx] + seq_len[idx],
+                device=query_states.device,
+                dtype=query_states.dtype,
+            )
+            attn_mask = attn_bias.masked_fill_(temp_mask.logical_not(), float("-inf")).to(
+                query_states.device
+            )
+
+        # Compute attention weights
+        attn_weights = (
+            torch.matmul(
+                query_states[seq_start[idx] : seq_start[idx] + seq_len[idx], :, :].transpose(0, 1),
+                k.transpose(0, 1).transpose(1, 2),
+            )
+            * 1
+            / math.sqrt(query_states.size(-1))
+        )
+        attn_weights = attn_weights + attn_mask
+        # upcast attention to fp32
+        attn_weights = torch.nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(
+            query_states.dtype
+        )
+        attn_weights = torch.nn.functional.dropout(attn_weights, p=0.0, training=False)
+        attn_output = torch.matmul(attn_weights, v.transpose(0, 1))
+        attn_outputs.append(attn_output)
+
+    if q_len == 1:
+        attn_output = torch.stack(attn_outputs)
+    else:
+        attn_output = torch.cat(attn_outputs, dim=-2).unsqueeze(0)
+
+    return attn_output
+
+
+@fused_mla_ref.register_fake
+def fused_mla_ref_fake(
+    q_nope: torch.Tensor,
+    q_pe: torch.Tensor,
+    kv: torch.Tensor,
+    k_pe: torch.Tensor,
+    seq_len: torch.Tensor,  # metadata
+    input_pos: torch.Tensor,  # metadata
+    cache_loc: torch.Tensor,
+    seq_start: torch.Tensor,
+    k_cache: torch.Tensor,  # caches
+    v_cache: torch.Tensor,  # caches
+    freqs_cis: torch.Tensor,
+    softmax_scale: Optional[float] = None,
+):
+    """Fake Fused MLA+Rope with KV cache support."""
+    v_head_dim = kv.shape[-1] - q_nope.shape[-1]
+    return torch.empty_like(kv[..., -v_head_dim:])
+
+
+@torch.library.custom_op("deepseek::fused_mla", mutates_args=())
+def fused_mla(
+    q_nope: torch.Tensor,
+    q_pe: torch.Tensor,
+    kv: torch.Tensor,
+    k_pe: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    position_ids: torch.Tensor,
+    attention_mask: torch.Tensor,
+    softmax_scale: float,
+) -> torch.Tensor:
+    """MultiHeadLatentAttention as implemented in DeepSeekV3Attention. This does not capture KV cache use/update."""
+    # Did not implement KV cache logic, since we would be writing our own custom op and inserting KV caches later
+    # Compute parameters
+    bs, num_heads, q_len, qk_nope_head_dim = q_nope.shape
+    qk_rope_head_dim = q_pe.shape[-1]
+    v_head_dim = kv.shape[-1] - qk_nope_head_dim
+    q_head_dim = qk_nope_head_dim + qk_rope_head_dim
+
+    k_nope, value_states = torch.split(kv, [qk_nope_head_dim, v_head_dim], dim=-1)
+    kv_seq_len = value_states.shape[-2]
+
+    q_pe, k_pe = apply_rotary_pos_emb_ds(q_pe, k_pe, cos, sin, position_ids)
+
+    query_states = k_pe.new_empty(bs, num_heads, q_len, q_head_dim)
+    query_states[:, :, :, :qk_nope_head_dim] = q_nope
+    query_states[:, :, :, qk_nope_head_dim:] = q_pe
+
+    key_states = k_pe.new_empty(bs, num_heads, q_len, q_head_dim)
+    key_states[:, :, :, :qk_nope_head_dim] = k_nope
+    key_states[:, :, :, qk_nope_head_dim:] = k_pe
+
+    # Use old logic
+    attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) * softmax_scale
+
+    if attn_weights.size() != (bs, num_heads, q_len, kv_seq_len):
+        raise ValueError(
+            f"Attention weights should be of size {(bs, num_heads, q_len, kv_seq_len)}, but is"
+            f" {attn_weights.size()}"
+        )
+    assert attention_mask is not None
+    if attention_mask is not None:
+        if attention_mask.size() != (bs, 1, q_len, kv_seq_len):
+            raise ValueError(
+                f"Attention mask should be of size {(bs, 1, q_len, kv_seq_len)}, but is {attention_mask.size()}"
+            )
+        attn_weights = attn_weights + attention_mask
+
+    # upcast attention to fp32
+    attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(
+        query_states.dtype
+    )
+    attn_weights = nn.functional.dropout(attn_weights, p=0.0, training=False)
+    attn_output = torch.matmul(attn_weights, value_states)
+
+    if attn_output.size() != (bs, num_heads, q_len, v_head_dim):
+        raise ValueError(
+            f"`attn_output` should be of size {(bs, num_heads, q_len, v_head_dim)}, but is"
+            f" {attn_output.size()}"
+        )
+
+    # We do not return attn_weights along with attn_output
+    return attn_output
+
+
+@fused_mla.register_fake
+def fused_mla(
+    q_nope: torch.Tensor,
+    q_pe: torch.Tensor,
+    kv: torch.Tensor,
+    k_pe: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    position_ids: torch.Tensor,
+    attention_mask: torch.Tensor,
+    softmax_scale: float,
+) -> torch.Tensor:
+    v_head_dim = kv.shape[-1] - q_nope.shape[-1]
+    return torch.empty_like(kv[..., -v_head_dim:])

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_attention.py
@@ -897,7 +897,7 @@ class TritonWithFlattenedInputs(AttentionDescriptor):
 
     @classmethod
     def get_attention_op(cls):
-        return torch.ops.attention.fused_flattened_mha_with_cache
+        return torch.ops.attention.fused_flattened_mha_with_cache, 3
 
     @classmethod
     def get_prepare_metadata_op(cls):

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_kernels/rope.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_kernels/rope.py
@@ -101,7 +101,7 @@ def rope_fwd_flattened_kernel(
     input_pos_ptr,  # [B]
     f_ptr,
     output_ptr,
-    H,  # number of heads
+    H: tl.constexpr,  # number of heads
     D: tl.constexpr,
     BLOCK_SIZE_H: tl.constexpr,
     BLOCK_SIZE_L: tl.constexpr,
@@ -147,7 +147,7 @@ def rope_fwd_flattened_kernel(
     nohead_mask2 = row_mask[None, :, None] * col_mask2[None, None, :]
 
     mask1 = head_mask[:, None, None] * nohead_mask1
-    mask2 = head_mask[:, None, None] * nohead_mask1
+    mask2 = head_mask[:, None, None] * nohead_mask2
 
     a = tl.load(x_ptr + offsets1, mask=mask1).to(tl.float32)
     b = tl.load(x_ptr + offsets2, mask=mask2).to(tl.float32)

--- a/tensorrt_llm/_torch/auto_deploy/models/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/__init__.py
@@ -1,2 +1,3 @@
 from . import hf
+from .deepseek import *
 from .factory import *

--- a/tensorrt_llm/_torch/auto_deploy/models/deepseek.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/deepseek.py
@@ -1,0 +1,175 @@
+import types
+import warnings
+from typing import Dict, Optional
+
+import torch
+import torch.utils.checkpoint
+from transformers import AutoModelForCausalLM
+from transformers.cache_utils import Cache
+
+
+def deepseek_v3_attention(
+    self,
+    hidden_states: torch.Tensor,
+    attention_mask: Optional[torch.Tensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    past_key_value: Optional[Cache] = None,
+    output_attentions: bool = False,
+    use_cache: bool = False,
+    **kwargs,
+):
+    """DeepSeekV3Attention forward function rewritten to wrap MultiheadLatentAttention as a custom op."""
+    if "padding_mask" in kwargs:
+        warnings.warn(
+            "Passing `padding_mask` is deprecated and will be removed in v4.37. "
+            "Please make sure use `attention_mask` instead.`"
+        )
+    bsz, q_len, _ = hidden_states.size()
+
+    # If else paths are determined by config.json
+    if self.q_lora_rank is None:
+        q = self.q_proj(hidden_states)
+    else:
+        q = self.q_b_proj(self.q_a_layernorm(self.q_a_proj(hidden_states)))
+    q = q.view(bsz, q_len, self.num_heads, self.q_head_dim).transpose(1, 2)
+    q_nope, q_pe = torch.split(q, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
+
+    compressed_kv = self.kv_a_proj_with_mqa(hidden_states)
+    compressed_kv, k_pe = torch.split(
+        compressed_kv, [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
+    )
+    k_pe = k_pe.view(bsz, q_len, 1, self.qk_rope_head_dim).transpose(1, 2)
+    kv = (
+        self.kv_b_proj(self.kv_a_layernorm(compressed_kv))
+        .view(bsz, q_len, self.num_heads, self.qk_nope_head_dim + self.v_head_dim)
+        .transpose(1, 2)
+    )
+    _, value_states = torch.split(kv, [self.qk_nope_head_dim, self.v_head_dim], dim=-1)
+    kv_seq_len = value_states.shape[-2]
+    if past_key_value is not None:
+        raise ValueError("past_key_value is not supported")
+    cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
+
+    # Use custom op to capture mla. This does not handle KV cache
+    # as passing transformers Cache into a custom op is throwing an error.
+    # Would not be an issue, cause we intend to replace mla op with our implementation further along the pipeline
+    attn_output = torch.ops.deepseek.fused_mla(
+        q_nope,
+        q_pe,
+        kv,
+        k_pe,
+        cos,
+        sin,
+        position_ids,
+        attention_mask,
+        self.softmax_scale,
+    )
+
+    attn_output = attn_output.transpose(1, 2).contiguous()
+    attn_output = attn_output.reshape(bsz, q_len, self.num_heads * self.v_head_dim)
+    attn_output = self.o_proj(attn_output)
+
+    return attn_output, None, past_key_value
+
+
+# This patched module matches exactly with HF generate
+@torch.inference_mode()
+def deepseek_v3_moe_exact(self, hidden_states):
+    """DeepSeekV3MoE forward function rewritten to enable torch export.
+
+    This custom implementation matches exactly with the deepseek implementation. There are
+    some errors in the output tensors when the index_add based implementation is used, leading
+    to some mismatch in the outputs for some prompts. This ensures exact match between HF output
+    without custom patch and with custom patch.
+    """
+    identity = hidden_states
+    batch_size, sequence_length, hidden_dim = hidden_states.shape
+
+    selected_experts, routing_weights, *_ = self.gate(hidden_states)
+
+    hidden_states = hidden_states.view(-1, hidden_dim)
+    idxs = torch.argsort(selected_experts.view(-1), stable=True)
+
+    expert_mask = torch.nn.functional.one_hot(
+        selected_experts, num_classes=self.experts_per_rank
+    ).permute(2, 1, 0)
+    outputs = []
+    for expert_idx in range(len(self.experts)):
+        expert_layer = self.experts[expert_idx]
+        _, top_x = torch.where(expert_mask[expert_idx])
+        # Sort the top_xs and idx
+        sorted, _ = torch.sort(top_x)
+        tokens_for_this_expert = hidden_states[None, sorted].reshape(-1, hidden_dim)
+        expert_out = expert_layer(tokens_for_this_expert)
+        outputs.append(expert_out)
+
+    outs = torch.cat(outputs, dim=0)
+    # Wrap torch.zeros() in a custom op to fix meta device issue during inference.
+    new_x = torch.zeros(
+        (*selected_experts.view(-1).shape, hidden_dim),
+        device=selected_experts.device,
+        dtype=outs.dtype,
+    )
+    new_x[idxs] = outs
+    final_hidden_states = (
+        new_x.view(*selected_experts.shape, -1)
+        .type(routing_weights.dtype)
+        .mul_(routing_weights.unsqueeze(-1))
+        .sum(dim=1)
+        .type(new_x.dtype)
+    )
+    final_hidden_states = final_hidden_states.reshape(batch_size, sequence_length, hidden_dim)
+
+    if self.config.n_shared_experts is not None:
+        final_hidden_states = final_hidden_states + self.shared_experts(identity)
+
+    return final_hidden_states.to(hidden_states.dtype)
+
+
+@torch.inference_mode()
+def deepseek_v3_moe(self, hidden_states):
+    """DeepSeekV3MoE forward function rewritten in Mixtral style to enable torch export."""
+    identity = hidden_states
+    batch_size, sequence_length, hidden_dim = hidden_states.shape
+
+    selected_experts, routing_weights, *_ = self.gate(hidden_states)
+    hidden_states = hidden_states.view(-1, hidden_dim)
+
+    final_hidden_states = torch.ops.moe.torch_moe(
+        hidden_states,
+        selected_experts,
+        routing_weights,
+        w1_weight=[expert.gate_proj.weight for expert in self.experts],
+        w2_weight=[expert.down_proj.weight for expert in self.experts],
+        w3_weight=[expert.up_proj.weight for expert in self.experts],
+    )
+
+    final_hidden_states = final_hidden_states.reshape(batch_size, sequence_length, hidden_dim)
+
+    if self.config.n_shared_experts is not None:
+        final_hidden_states = final_hidden_states + self.shared_experts(identity)
+
+    return final_hidden_states.to(hidden_states.dtype)
+
+
+_from_config_original = AutoModelForCausalLM.from_config
+
+CUSTOM_MODULE_PATCHES: Dict[str, callable] = {
+    "DeepseekV3MoE": deepseek_v3_moe,
+    "DeepseekV2MoE": deepseek_v3_moe,
+    "DeepseekV3Attention": deepseek_v3_attention,
+    "DeepseekV2Attention": deepseek_v3_attention,
+}
+
+
+def get_model_from_config_patched(model_config, trust_remote_code):
+    model = _from_config_original(model_config, trust_remote_code=trust_remote_code)
+    # Patch modules
+    for _, module in model.named_modules():
+        if type(module).__name__ in CUSTOM_MODULE_PATCHES.keys():
+            module.forward = types.MethodType(CUSTOM_MODULE_PATCHES[type(module).__name__], module)
+
+    return model
+
+
+AutoModelForCausalLM.from_config = get_model_from_config_patched

--- a/tensorrt_llm/_torch/auto_deploy/shim/interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/interface.py
@@ -88,6 +88,7 @@ class AutoDeployConfig(PyTorchConfig):
 
     # attention backend to choose from
     attn_backend: str = "TritonWithFlattenedInputs"
+    mla_backend: str = "MultiHeadLatentAttention"
 
     # check if we should skip loading weights
     skip_loading_weights: bool = False

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/fused_moe.py
@@ -252,6 +252,11 @@ def _extract_expert_weights_from_topk(
             if len(node.args) < 2:
                 continue
             arg0, arg1 = node.args[0], node.args[1]
+            if not all(
+                isinstance(arg, torch.fx.Node) and arg.op == "call_function" for arg in (arg0, arg1)
+            ):
+                node = node.next
+                continue
             if _is_routing_weight(arg0) != _is_routing_weight(arg1):
                 candidate_expert_branches.append(arg1 if _is_routing_weight(arg0) else arg0)
 

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_update_kv_cache.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_update_kv_cache.py
@@ -1,0 +1,44 @@
+import torch
+
+from tensorrt_llm._torch.auto_deploy.custom_ops.torch_attention import update_kv_cache
+
+
+def test_update_kv_cache():
+    K_D_HEAD = 4
+    V_D_HEAD = 2
+    MAX_BATCH_SIZE = 2
+    MAX_SEQ_LEN = 4
+    seq_length = 4
+    n_heads = 3
+    batch_size = 1
+
+    # Initialize KV cache
+    k_cache = torch.zeros(MAX_BATCH_SIZE, MAX_SEQ_LEN, n_heads, K_D_HEAD)
+    v_cache = torch.zeros(MAX_BATCH_SIZE, MAX_SEQ_LEN, n_heads, V_D_HEAD)
+
+    # Generate q,k,v test vectors
+    k = torch.ones(batch_size, seq_length, n_heads, K_D_HEAD)
+    v = torch.ones(batch_size, seq_length, n_heads, V_D_HEAD)
+
+    print("k_cache: " + str(k_cache))
+    print("v_cache: " + str(v_cache))
+    print("input_pos: " + str(torch.tensor([0, 0])))
+    print("cache_loc: " + str(torch.tensor([0, 1])))
+    print("seq_start: " + str(torch.tensor([0, 3])))
+
+    update_kv_cache(
+        k.view(batch_size * seq_length, n_heads, K_D_HEAD),
+        v.view(batch_size * seq_length, n_heads, V_D_HEAD),
+        k_cache,
+        v_cache,
+        torch.tensor([3, 1]).long(),
+        torch.tensor([0, 0]),
+        cache_loc=torch.tensor([0, 1]),
+        seq_start=torch.tensor([0, 3]).long(),
+    )
+
+    print("k_cache: " + str(k_cache))
+    print("v_cache: " + str(v_cache))
+
+
+test_update_kv_cache()

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_patches.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_patches.py
@@ -1,0 +1,98 @@
+"""Testing module patches that enable export of deepseek model."""
+
+import types
+
+import pytest
+import torch
+from transformers import AutoConfig, AutoModel
+
+from tensorrt_llm._torch.auto_deploy.models.deepseek import (
+    deepseek_v3_attention,
+    deepseek_v3_moe_exact,
+)
+
+
+def _load_layer_from_model(model_name_or_path, layer_name, num_layers_to_load=1, yarn=False):
+    """
+    Loads a specific layer/module from a model without loading the entire model.
+
+    Parameters:
+        model_name_or_path (str): Path or name of the pretrained model.
+        layer_name (str): Name of the layer to extract.
+
+    Returns:
+        module: The specified layer/module if available, otherwise None.
+    """
+    try:
+        # Load only the model configuration
+        config = AutoConfig.from_pretrained(model_name_or_path, trust_remote_code=True)
+
+        # Load a subset of layers of the model and configure yarn
+        config.num_hidden_layers = num_layers_to_load
+        config.use_cache = False
+        config.first_k_dense_replace = 0
+        if not yarn:
+            config.rope_scaling = None
+
+        # Build the model architecture (no weights loaded yet)
+        model = AutoModel.from_config(config, trust_remote_code=True)
+        model.eval()
+
+        # Access the specific layer by its name
+        module = dict(model.named_modules()).get(layer_name)
+        if module is None:
+            print(f"Layer '{layer_name}' not found in the model.")
+        else:
+            print(f"Successfully extracted layer '{layer_name}'.")
+        return module
+    except Exception as e:
+        print(f"Error extracting layer: {e}")
+        return None
+
+
+def _generate_ds_attention_mask(b, s):
+    return torch.where(
+        torch.tril(torch.full((s, s), float("-inf"))).unsqueeze(0).unsqueeze(0).expand(b, 1, s, s)
+        == float("-inf"),
+        torch.tensor(0.0),
+        torch.tensor(float(-3.4028e38)),
+    )
+
+
+@pytest.mark.parametrize(
+    "model_name, module_name, patch, yarn, inputs",
+    [
+        (
+            "deepseek-ai/DeepSeek-V3",
+            "layers.0.self_attn",
+            deepseek_v3_attention,
+            False,
+            [
+                torch.randn(2, 6, 7168),
+                _generate_ds_attention_mask(2, 6),
+                torch.tensor([[0, 1, 2, 3, 4, 5]]),
+            ],
+        ),  # attention requires  inputs [hidden_states, attention_mask, position_ids]
+        (
+            "deepseek-ai/DeepSeek-V3",
+            "layers.0.mlp",
+            deepseek_v3_moe_exact,
+            False,
+            [torch.randn(2, 6, 7168)],
+        ),  # moe requires  inputs [hidden_states]
+    ],
+)
+def test_module_patches(model_name, module_name, patch, yarn, inputs):
+    # Get module
+    module = _load_layer_from_model(model_name, module_name, 1, yarn)
+
+    # Pass test inputs to generate reference
+    ref, *_ = module(*inputs)
+
+    # Patch layer
+    module.forward = types.MethodType(patch, module)
+
+    # Generate test output
+    test, *_ = module(*inputs)
+
+    torch.allclose(ref, test, atol=0, rtol=0)


### PR DESCRIPTION
Support Deepseek-V3 with auto deploy
1. Model patches for DeepseekV3Attention and DeepseekMOE to enable export
2. EP sharding
3. MLA reference implementation + triton kernels implementation (without rope kernels)
4. Unit tests for model patches

Testing:
1. e2e example with deepseek-v3-lite
`python build_and_run_ad.py --config '{"model":"../../../models/dsv3_lite_fp16", "mla_backend":"MultiHeadLatentAttention", "compile_backend":"torch-simple", "max_tokens":100, "top_k":1, "temperature":1.0, "batch_size":4, "prompt":["In simple words and in a single sentence, explain the concept of gravity: ", "How big is the universe? ", "The future of AI is", "The president of the United States is" ]}' --model-kwargs '{}'`
