### PR TITLE
feat: Add support for Phi-4-MM

### DIFF
--- a/examples/multimodal/eval.py
+++ b/examples/multimodal/eval.py
@@ -274,7 +274,10 @@ if args.test_trtllm or args.test_hf:
         if args.test_trtllm:
             profiler.start('tensorrt_llm')
             _, output_text = trtllm_model.run(
-                prompts, image, max_new_tokens=args.max_new_tokens)
+                input_text=prompts,
+                input_image=image,
+                input_audio=None,
+                max_new_tokens=args.max_new_tokens)
             if runtime_rank == 0:
                 trtllm_result = output_text[0][0]
                 trtllm_correct += eval(trtllm_result, args.eval_task, data)

--- a/examples/multimodal/run.py
+++ b/examples/multimodal/run.py
@@ -40,7 +40,8 @@ def print_result(model, input_text, output_text, args):
                 assert "characteristic | cat food, day | cat food, wet | cat treats" in output_text[
                     0][0].lower()
             elif model.model_type in [
-                    'blip2', 'neva', 'phi-3-vision', 'llava_next'
+                    'blip2', 'neva', 'phi-3-vision', 'llava_next',
+                    'phi-4-multimodal'
             ]:
                 assert 'singapore' in output_text[0][0].lower()
             elif model.model_type == 'video-neva':
@@ -104,23 +105,21 @@ if __name__ == '__main__':
     logger.set_level(args.log_level)
 
     model = MultimodalModelRunner(args)
-    input_multimodal_data = model.load_test_data(args.image_path,
-                                                 args.video_path)
+    visual_data = model.load_test_data(args.image_path, args.video_path)
+    audio_data = model.load_test_audio(args.audio_path)
 
     if args.run_profiling:
         num_warmup_iters = 3  # Multiple iterations to load both vision and LLM engines into memory
         for _ in range(num_warmup_iters):
-            input_text, output_text = model.run(args.input_text,
-                                                input_multimodal_data,
-                                                args.max_new_tokens)
+            input_text, output_text = model.run(args.input_text, visual_data,
+                                                audio_data, args.max_new_tokens)
         profiler.reset()
 
     num_iters = args.profiling_iterations if args.run_profiling else 1
 
     for _ in range(num_iters):
-        input_text, output_text = model.run(args.input_text,
-                                            input_multimodal_data,
-                                            args.max_new_tokens)
+        input_text, output_text = model.run(args.input_text, visual_data,
+                                            audio_data, args.max_new_tokens)
 
     runtime_rank = tensorrt_llm.mpi_rank()
     if runtime_rank == 0:

--- a/examples/multimodal/utils.py
+++ b/examples/multimodal/utils.py
@@ -10,6 +10,10 @@ def add_common_args(parser):
                         type=str,
                         default='model.engine',
                         help='Name of visual TRT engine')
+    parser.add_argument('--audio_engine_name',
+                        type=str,
+                        default='model.engine',
+                        help='Name of audio TRT engine')
     parser.add_argument('--hf_model_dir',
                         type=str,
                         default=None,
@@ -55,6 +59,10 @@ def add_common_args(parser):
                         nargs='+',
                         default=None,
                         help='List of input image paths, separated by symbol')
+    parser.add_argument("--audio_path",
+                        type=str,
+                        default=None,
+                        help='input audio path')
     parser.add_argument("--path_sep",
                         type=str,
                         default=",",

--- a/examples/phi/convert_checkpoint.py
+++ b/examples/phi/convert_checkpoint.py
@@ -154,13 +154,13 @@ if __name__ == '__main__':
     model_type = model_config.architectures[0]
     supported_models = [
         'PhiForCausalLM', 'Phi3ForCausalLM', 'Phi3VForCausalLM',
-        'Phi3SmallForCausalLM', 'PhiMoEForCausalLM'
+        'Phi3SmallForCausalLM', 'PhiMoEForCausalLM', 'Phi4MMForCausalLM'
     ]
 
     if model_type not in supported_models:
         assert False, "Invalid model type"
 
-    is_phi3 = 'Phi3' in model_type or 'PhiMoE' in model_type
+    is_phi3 = 'Phi3' in model_type or 'PhiMoE' in model_type or 'Phi4MM' in model_type
     phi_model_cls = Phi3ForCausalLM if is_phi3 else PhiForCausalLM
 
     quant_config = args_to_quant_config(args)

--- a/tensorrt_llm/models/__init__.py
+++ b/tensorrt_llm/models/__init__.py
@@ -154,6 +154,7 @@ MODEL_MAP = {
     'Phi3VForCausalLM': Phi3ForCausalLM,
     'Phi3SmallForCausalLM': Phi3ForCausalLM,
     'PhiMoEForCausalLM': Phi3ForCausalLM,
+    'Phi4MMForCausalLM': Phi3ForCausalLM,
     'MambaForCausalLM': MambaForCausalLM,
     'GPTNeoXForCausalLM': GPTNeoXForCausalLM,
     'GPTJForCausalLM': GPTJForCausalLM,

--- a/tests/integration/defs/examples/test_multimodal.py
+++ b/tests/integration/defs/examples/test_multimodal.py
@@ -109,7 +109,8 @@ def _test_llm_multimodal_general(llm_venv,
     vila_model = "VILA" in model_name
     cogvlm_model = "cogvlm" in model_name
     nemotron_model = "video-neva" in model_name
-    phi_model = "phi" in model_name.lower()
+    phi3_model = "phi-3" in model_name.lower()
+    phi4_model = "phi-4" in model_name.lower()
     mllama_model = 'Llama-3.2' in model_name
     qwen2_vl_model = 'Qwen2-VL' in model_name
     internlm_model = 'internlm-xcomposer2' in model_name
@@ -136,9 +137,11 @@ def _test_llm_multimodal_general(llm_venv,
         builder_root, model_type = cogvlm_example_root, "cogvlm"
     elif nemotron_model:
         builder_root, model_type = nemotron_example_root, "nemotron"
-    elif phi_model:
+    elif phi3_model:
         model_name = model_name.split('/')[-1]  # Remove HF directory name
         builder_root, model_type = phi_example_root, "phi-3-vision"
+    elif phi4_model:
+        builder_root, model_type = phi_example_root, "phi-4-multimodal"
     elif opt_model:
         builder_root, model_type = opt_example_root, "blip2"
     elif mllama_model:
@@ -210,7 +213,7 @@ def _test_llm_multimodal_general(llm_venv,
     print("Build LLM engines...")
     model_name = model_name.split('/')[-1]  # Remove HF directory name
     llm_engine_dir = f"{engine_dir}/{model_name}/{world_size}-gpu"
-    if "opt" in model_name or llava_model or vila_model or gpt_model or nemotron_model or phi_model or qwen2_vl_model:
+    if "opt" in model_name or llava_model or vila_model or gpt_model or nemotron_model or phi3_model or phi4_model or qwen2_vl_model:
         max_input_len_text = 1024
         max_output_len = 200
         if llava_next_model:
@@ -221,7 +224,9 @@ def _test_llm_multimodal_general(llm_venv,
             multimodal_len = 576
         elif vila_model:
             multimodal_len = 196
-        elif phi_model:
+        elif phi3_model:
+            multimodal_len = 5120
+        elif phi4_model:  # @B: Confirm this.
             multimodal_len = 5120
         elif "fuyu" in model_name:
             multimodal_len = 2640
@@ -374,7 +379,8 @@ def _test_llm_multimodal_general(llm_venv,
     elif 'fuyu' in model_name: vision_model_type = 'fuyu'
     elif 'neva-22b' in model_name: vision_model_type = 'neva'
     elif 'video-neva' in model_name: vision_model_type = 'video-neva'
-    elif phi_model: vision_model_type = "phi-3-vision"
+    elif phi3_model: vision_model_type = "phi-3-vision"
+    elif phi4_model: vision_model_type = "phi-4-multimodal"
     elif 'blip2' in model_name: vision_model_type = 'blip2'
     elif 'Llama-3.2' in model_name: vision_model_type = 'mllama'
     elif "Qwen2-VL" in model_name: vision_model_type = 'qwen2_vl'
@@ -387,9 +393,11 @@ def _test_llm_multimodal_general(llm_venv,
         vit_batch_size = vit_batch_size * 32
 
     llm_engine_subdir = f"{data_type}" if enc_dec_model else ""
+    # Phi4MM has both vision and audio. Engine build dumps to vision and audio dirs automatically by builder.
+    component_dir = "vision" if vision_model_type != "phi-4-multimodal" else ""
     build_cmd = [
         f"{multimodal_example_root}/build_multimodal_engine.py",
-        f"--output_dir={os.path.join(llm_engine_dir, llm_engine_subdir, 'vision')}",
+        f"--output_dir={os.path.join(llm_engine_dir, llm_engine_subdir, component_dir)}",
         f"--model_type={vision_model_type}",
         f"--model_path={model_ckpt_path}",
         f"--max_batch_size={vit_batch_size}",
@@ -402,7 +410,7 @@ def _test_llm_multimodal_general(llm_venv,
         convert_cmd = [
             f"{script_root}/convert_checkpoint.py",
             f"--model_dir={model_ckpt_path}",
-            f"--output_dir={os.path.join(cmodel_dir, model_name, data_type, 'vision')}",
+            f"--output_dir={os.path.join(cmodel_dir, model_name, data_type, component_dir)}",
             f"--dtype={data_type}",
             f"--vision_tp_size={tp_size}",
         ]
@@ -410,8 +418,8 @@ def _test_llm_multimodal_general(llm_venv,
 
         build_cmd = [
             "trtllm-build",
-            f"--checkpoint_dir={os.path.join(cmodel_dir, model_name, data_type, 'vision')}",
-            f"--output_dir={os.path.join(llm_engine_dir, llm_engine_subdir, 'vision')}",
+            f"--checkpoint_dir={os.path.join(cmodel_dir, model_name, data_type, component_dir)}",
+            f"--output_dir={os.path.join(llm_engine_dir, llm_engine_subdir, component_dir)}",
             f"--max_batch_size={vit_batch_size}",
             f"--remove_input_padding disable",
             f"--bert_attention_plugin disable",
@@ -441,6 +449,9 @@ def _test_llm_multimodal_general(llm_venv,
         f"--batch_size={batch_size}", "--check_accuracy",
         "--enable_context_fmha_fp32_acc"
     ]
+    if vision_model_type == 'phi-4-multimodal':
+        audio_path = f"{model_ckpt_path}/examples/what_is_shown_in_this_image.wav"
+        run_cmd.extend(["--audio_path", f"{audio_path}"])
     if vision_model_type in ['llava', 'vila'] and batch_size > 1:
         # batch inference test
         if vision_model_type == 'vila':
@@ -460,7 +471,7 @@ def _test_llm_multimodal_general(llm_venv,
         run_cmd.extend(["--video_path", video_path])
     if llava_onevision_video_model:
         run_cmd.extend(["--video_path", 'llava-onevision-accuracy'])
-    if phi_model:
+    if phi3_model or phi4_model:
         run_cmd.extend(["--kv_cache_free_gpu_memory_fraction", "0.4"])
     if cpp_e2e:
         run_cmd.extend(["--session", "cpp"])
@@ -544,7 +555,7 @@ def _test_llm_multimodal_general(llm_venv,
         # For Phi-3 - correctness lower than HF
         # For qwen_vl - runtime issue with eval.py -- need to unify prompt generation logics
         # For internvl - not added to the test
-        if llava_model or llava_next_model or phi_model or qwen2_vl_model:
+        if llava_model or llava_next_model or phi3_model or qwen2_vl_model:
             return
 
         eval_task = "lmms-lab/ai2d" if mllama_model else "lmms-lab/VQAv2"
@@ -569,7 +580,7 @@ def _test_llm_multimodal_general(llm_venv,
                 f"--dataset_dir={llm_datasets_root}/lmms-lab__VQAv2_valid_2000samples/"
             ])
 
-        if phi_model:
+        if phi3_model:
             eval_cmd.extend(["--kv_cache_free_gpu_memory_fraction", "0.4"])
         elif enc_dec_model:
             eval_cmd.extend(["--cross_kv_cache_fraction", "0.5"])
@@ -607,6 +618,7 @@ def _test_llm_multimodal_general(llm_venv,
     'video-neva',
     'Phi-3-vision-128k-instruct',
     'Phi-3.5-vision-instruct',
+    'Phi-4-multimodal-instruct',
     'Llama-3.2-11B-Vision',
     'Qwen2-VL-7B-Instruct',
     'internlm-xcomposer2-vl-7b',
@@ -658,6 +670,7 @@ def test_llm_multimodal_general(llm_venv, llm_root, llm_datasets_root,
     'video-neva',
     'Phi-3-vision-128k-instruct',
     'Phi-3.5-vision-instruct',
+    'Phi-4-multimodal-instruct',
     'Llama-3.2-11B-Vision-Instruct',
     'Llama-3.2-11B-Vision',
     'Qwen2-VL-7B-Instruct',

--- a/tests/integration/test_lists/qa/examples_test_list.txt
+++ b/tests/integration/test_lists/qa/examples_test_list.txt
@@ -187,6 +187,7 @@ examples/test_mixtral.py::test_llm_mixtral_int4_awq_1gpu_summary[Mixtral-8x7B-In
 examples/test_multimodal.py::test_llm_multimodal_general[Phi-3-vision-128k-instruct-pp:1-tp:1-float16-bs:1-cpp_e2e:False-nb:1]
 examples/test_multimodal.py::test_llm_multimodal_general[Phi-3-vision-128k-instruct-pp:1-tp:1-float16-bs:8-cpp_e2e:False-nb:1]
 examples/test_multimodal.py::test_llm_multimodal_general[Phi-3.5-vision-instruct-pp:1-tp:1-float16-bs:1-cpp_e2e:False-nb:1]
+examples/test_multimodal.py::test_llm_multimodal_general[Phi-4-multimodal-instruct-pp:1-tp:1-float16-bs:1-cpp_e2e:False-nb:1]
 examples/test_multimodal.py::test_llm_multimodal_general[Qwen2-VL-7B-Instruct-pp:1-tp:1-float16-bs:1-cpp_e2e:False-nb:4]
 examples/test_multimodal.py::test_llm_multimodal_general[VILA1.5-3b-pp:1-tp:1-float16-bs:1-cpp_e2e:False-nb:1]
 examples/test_multimodal.py::test_llm_multimodal_general[VILA1.5-3b-pp:1-tp:1-float16-bs:8-cpp_e2e:False-nb:1]

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -208,6 +208,7 @@ l0_h100:
   - examples/test_multimodal.py::test_llm_multimodal_general[kosmos-2-pp:1-tp:1-float16-bs:1-cpp_e2e:True-nb:1]
   - examples/test_multimodal.py::test_llm_multimodal_general[Phi-3-vision-128k-instruct-pp:1-tp:1-float16-bs:1-cpp_e2e:False-nb:1]
   - examples/test_multimodal.py::test_llm_multimodal_general[Phi-3.5-vision-instruct-pp:1-tp:1-float16-bs:1-cpp_e2e:False-nb:1]
+  - examples/test_multimodal.py::test_llm_multimodal_general[Phi-4-multimodal-instruct-pp:1-tp:1-float16-bs:1-cpp_e2e:False-nb:1]
   - examples/test_multimodal.py::test_llm_multimodal_general[VILA1.5-3b-pp:1-tp:1-float16-bs:1-cpp_e2e:False-nb:1] # 10 mins
   - examples/test_enc_dec.py::test_llm_enc_dec_mmlu[flan-t5-small-float32-tp:1-pp:1-nb:1-enable_fp8] # 7 mins
   - examples/test_enc_dec.py::test_llm_enc_dec_general[compare_hf-bart-large-cnn-float16-enable_gemm_plugin-enable_attention_plugin-enable_paged_kv_cache-tp:1-pp:1-nb:1-enable_fp8] # 13 mins


### PR DESCRIPTION
This MR adds support for Phi-4-MM.

Note:
* Following suit with Phi-3 vision models, we're using pytorch vision and audio encoders for testing because of known issues with obtaining their TRT engines. Specifically, Flash/SDPA attention in encoders is not compatible with `torch.onnx.export` and `eager` attention is unstable in PyTorch.
* We still provide code to be able to build TRT engines but that will be inactive.