### PR TITLE
refactor: batch slot management in decoder classes

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/decoderBuffers.h
+++ b/cpp/include/tensorrt_llm/batch_manager/decoderBuffers.h
@@ -37,7 +37,7 @@ public:
     using TensorPtr = runtime::ITensor::SharedPtr;
 
     explicit DecoderInputBuffers(
-        SizeType32 maxBatchSize, SizeType32 maxTokensPerEngineStep, runtime::BufferManager const& manager);
+        SizeType32 maxBatchSize, SizeType32 maxDecoderSteps, runtime::BufferManager const& manager);
 
     // buffers for setup
     TensorPtr setupBatchSlots;

--- a/cpp/include/tensorrt_llm/batch_manager/decoderBuffers.h
+++ b/cpp/include/tensorrt_llm/batch_manager/decoderBuffers.h
@@ -48,7 +48,7 @@ public:
     TensorPtr forwardBatchSlotsRequestOrderDevice;
     TensorPtr fillValues;
     TensorPtr fillValuesDevice;
-    TensorPtr forwardBatchSlots;
+    std::vector<TensorPtr> forwardBatchSlots;
 };
 
 class DecoderStepAsyncSend

--- a/cpp/include/tensorrt_llm/batch_manager/makeDecodingBatchInputOutput.h
+++ b/cpp/include/tensorrt_llm/batch_manager/makeDecodingBatchInputOutput.h
@@ -57,6 +57,11 @@ public:
         runtime::decoder::DecoderState& decoderState, runtime::ModelConfig const& modelConfig,
         SizeType32 maxNumSequences, SizeType32 beamWidth, runtime::BufferManager const& manager,
         runtime::CudaStream const& stream, OptionalRef<RuntimeBuffers> fusedRuntimeBuffers) const;
+
+    [[nodiscard]] static std::unique_ptr<runtime::decoder_batch::Input> createDecoderBatchInputs(
+        std::vector<SizeType32> const& activeSlots, runtime::decoder::DecoderState const& decoderState,
+        std::vector<TensorPtr> const& logits, SizeType32 maxNumSequences, std::vector<TensorPtr> const& batchSlots,
+        TensorPtr const& cacheIndirectionInput);
 };
 
 } // namespace tensorrt_llm::batch_manager

--- a/cpp/include/tensorrt_llm/runtime/iGptDecoderBatched.h
+++ b/cpp/include/tensorrt_llm/runtime/iGptDecoderBatched.h
@@ -49,24 +49,25 @@ public:
     using TensorConstPtr = ITensor::SharedConstPtr;
     using TensorPtr = ITensor::SharedPtr;
 
-    explicit Input(
-        std::vector<TensorPtr> const& logits, std::vector<bool> const& active, SizeType32 maxDecodingEngineTokens)
+    explicit Input(std::vector<std::vector<TensorConstPtr>> const& logits, std::vector<bool> const& active,
+        SizeType32 maxDecodingEngineTokens)
         : logits{logits}
         , maxDecodingEngineTokens{maxDecodingEngineTokens}
         , active{active}
     {
-        TLLM_CHECK_WITH_INFO(
-            this->active.size() == logits.size(), "'active' vector size does not match logits vector size");
+        TLLM_CHECK_WITH_INFO(logits.size() == static_cast<size_t>(maxDecodingEngineTokens),
+            "logits vector size does not match maxDecodingEngineTokens");
     }
 
-    explicit Input(std::vector<TensorPtr> const& logits)
-        : Input{logits, std::vector<bool>(logits.size(), true), 1}
+    explicit Input(std::vector<TensorConstPtr> const& logits)
+        : Input{{logits}, std::vector<bool>(logits.size(), true), 1}
     {
     }
 
     //! Mandatory parameters
-    //! [batchSize][1, beamWidth, vocabSizePadded] or [generatedTokensPerStep, 1, vocabSizePadded], on gpu
-    std::vector<TensorPtr> logits;
+    // FIXME: remove first dimension of tensors
+    //! [generatedTokensPerStep][batchSize][1, beamWidth, vocabSizePadded], on gpu
+    std::vector<std::vector<TensorConstPtr>> logits;
 
     //! Maximum number of decoding tokens of active slots
     SizeType32 maxDecodingEngineTokens;

--- a/cpp/include/tensorrt_llm/runtime/iGptDecoderBatched.h
+++ b/cpp/include/tensorrt_llm/runtime/iGptDecoderBatched.h
@@ -67,8 +67,8 @@ public:
     std::vector<TensorPtr> logits;
     //! Control activity of decoder slots in batch
     std::vector<bool> active; // [batchSize]
-    //! Empty buffer filled in GptDecoderBatched, sorted by slots, [maxTokensPerEngineStep, batchSize]
-    TensorPtr batchSlots;
+    //! Empty buffer filled in GptDecoderBatched, sorted by slots, [maxTokensPerEngineStep][batchSize]
+    std::vector<TensorPtr> batchSlots;
     //! Filled with slots in request order, [batchSize]
     TensorPtr batchSlotsRequestOrder;
 

--- a/cpp/include/tensorrt_llm/runtime/iGptDecoderBatched.h
+++ b/cpp/include/tensorrt_llm/runtime/iGptDecoderBatched.h
@@ -67,7 +67,7 @@ public:
     std::vector<TensorPtr> logits;
     //! Control activity of decoder slots in batch
     std::vector<bool> active; // [batchSize]
-    //! Empty buffer filled in GptDecoderBatched, sorted by slots, [maxTokensPerEngineStep][batchSize]
+    //! Batch of active decoder slots, sorted by slots, [maxTokensPerEngineStep][batchSize]
     std::vector<TensorPtr> batchSlots;
     //! Filled with slots in request order, [batchSize]
     TensorPtr batchSlotsRequestOrder;

--- a/cpp/include/tensorrt_llm/runtime/iGptDecoderBatched.h
+++ b/cpp/include/tensorrt_llm/runtime/iGptDecoderBatched.h
@@ -50,13 +50,13 @@ public:
     using TensorPtr = ITensor::SharedPtr;
 
     explicit Input(std::vector<std::vector<TensorConstPtr>> const& logits, std::vector<bool> const& active,
-        SizeType32 maxDecodingEngineTokens)
+        SizeType32 maxDecoderSteps)
         : logits{logits}
-        , maxDecodingEngineTokens{maxDecodingEngineTokens}
+        , maxDecoderSteps{maxDecoderSteps}
         , active{active}
     {
-        TLLM_CHECK_WITH_INFO(logits.size() == static_cast<size_t>(maxDecodingEngineTokens),
-            "logits vector size does not match maxDecodingEngineTokens");
+        TLLM_CHECK_WITH_INFO(
+            logits.size() == static_cast<size_t>(maxDecoderSteps), "logits vector size does not match maxDecoderSteps");
     }
 
     explicit Input(std::vector<TensorConstPtr> const& logits)
@@ -66,11 +66,11 @@ public:
 
     //! Mandatory parameters
     // FIXME: remove first dimension of tensors
-    //! [generatedTokensPerStep][batchSize][1, beamWidth, vocabSizePadded], on gpu
+    //! [maxDecoderSteps][batchSize][1, beamWidth, vocabSizePadded], on gpu
     std::vector<std::vector<TensorConstPtr>> logits;
 
     //! Maximum number of decoding tokens of active slots
-    SizeType32 maxDecodingEngineTokens;
+    SizeType32 maxDecoderSteps;
 
     //! Control activity of decoder slots in batch
     std::vector<bool> active; // [batchSize]

--- a/cpp/include/tensorrt_llm/runtime/iGptDecoderBatched.h
+++ b/cpp/include/tensorrt_llm/runtime/iGptDecoderBatched.h
@@ -49,18 +49,16 @@ public:
     using TensorConstPtr = ITensor::SharedConstPtr;
     using TensorPtr = ITensor::SharedPtr;
 
-    explicit Input(std::vector<std::vector<TensorConstPtr>> const& logits, std::vector<bool> const& active,
-        SizeType32 maxDecoderSteps)
+    explicit Input(std::vector<std::vector<TensorConstPtr>> const& logits, SizeType32 maxDecoderSteps)
         : logits{logits}
         , maxDecoderSteps{maxDecoderSteps}
-        , active{active}
     {
         TLLM_CHECK_WITH_INFO(
             logits.size() == static_cast<size_t>(maxDecoderSteps), "logits vector size does not match maxDecoderSteps");
     }
 
     explicit Input(std::vector<TensorConstPtr> const& logits)
-        : Input{{logits}, std::vector<bool>(logits.size(), true), 1}
+        : Input{{logits}, 1}
     {
     }
 
@@ -72,16 +70,14 @@ public:
     //! Maximum number of decoding tokens of active slots
     SizeType32 maxDecoderSteps;
 
-    //! Control activity of decoder slots in batch
-    std::vector<bool> active; // [batchSize]
-    //! Batch of active decoder slots, sorted by slots, [maxTokensPerEngineStep][batchSize]
+    //! Batch of active decoder slots, sorted by slots, [maxDecoderSteps][batchSize]
     std::vector<TensorPtr> batchSlots;
     //! Filled with slots in request order, [batchSize]
     TensorPtr batchSlotsRequestOrder;
 
     //! For beam search
     //! Indices into KV cache of different rays within one beam
-    TensorPtr cacheIndirection; // [batchSize, maxBeamWidth, maxSeqLen], on gpu
+    TensorPtr cacheIndirection; // [maxBatchSize, maxBeamWidth, maxSeqLen], on gpu
     //! [maxBatchSize][maxAcceptedDraftTokensPerStep][maxDraftTokens + 1, vocabSizePadded]
     std::vector<std::vector<TensorPtr>> predictedDraftLogits;
 

--- a/cpp/include/tensorrt_llm/runtime/iGptDecoderBatched.h
+++ b/cpp/include/tensorrt_llm/runtime/iGptDecoderBatched.h
@@ -49,8 +49,10 @@ public:
     using TensorConstPtr = ITensor::SharedConstPtr;
     using TensorPtr = ITensor::SharedPtr;
 
-    explicit Input(std::vector<TensorPtr> const& logits, std::vector<bool> const& active)
+    explicit Input(
+        std::vector<TensorPtr> const& logits, std::vector<bool> const& active, SizeType32 maxDecodingEngineTokens)
         : logits{logits}
+        , maxDecodingEngineTokens{maxDecodingEngineTokens}
         , active{active}
     {
         TLLM_CHECK_WITH_INFO(
@@ -58,13 +60,17 @@ public:
     }
 
     explicit Input(std::vector<TensorPtr> const& logits)
-        : Input{logits, std::vector<bool>(logits.size(), true)}
+        : Input{logits, std::vector<bool>(logits.size(), true), 1}
     {
     }
 
     //! Mandatory parameters
     //! [batchSize][1, beamWidth, vocabSizePadded] or [generatedTokensPerStep, 1, vocabSizePadded], on gpu
     std::vector<TensorPtr> logits;
+
+    //! Maximum number of decoding tokens of active slots
+    SizeType32 maxDecodingEngineTokens;
+
     //! Control activity of decoder slots in batch
     std::vector<bool> active; // [batchSize]
     //! Batch of active decoder slots, sorted by slots, [maxTokensPerEngineStep][batchSize]

--- a/cpp/include/tensorrt_llm/runtime/statefulGptDecoderBatched.h
+++ b/cpp/include/tensorrt_llm/runtime/statefulGptDecoderBatched.h
@@ -61,8 +61,8 @@ private:
     CudaEvent mDecoderFinishEvent;
     CudaEvent mForwardEvent;
     TensorPtr mFinishedSum;
-    TensorPtr mBatchSlotsSetup;   // [maxBatchSize], int32_t, address map, pinned
-    TensorPtr mBatchSlotsDecoder; // [maxTokensPerEngineStep, maxBatchSize], int32_t, address map, pinned
+    TensorPtr mBatchSlotsSetup;                // [maxBatchSize], int32_t, address map, pinned
+    std::vector<TensorPtr> mBatchSlotsDecoder; // 1 *[maxBatchSize], int32_t, address map, pinned
 };
 
 } // namespace tensorrt_llm::runtime

--- a/cpp/include/tensorrt_llm/runtime/statefulGptDecoderBatched.h
+++ b/cpp/include/tensorrt_llm/runtime/statefulGptDecoderBatched.h
@@ -61,8 +61,8 @@ private:
     CudaEvent mDecoderFinishEvent;
     CudaEvent mForwardEvent;
     TensorPtr mFinishedSum;
-    TensorPtr mBatchSlotsSetup;                // [maxBatchSize], int32_t, address map, pinned
-    std::vector<TensorPtr> mBatchSlotsDecoder; // 1 *[maxBatchSize], int32_t, address map, pinned
+    TensorPtr mBatchSlotsSetup;   // [maxBatchSize], int32_t, address map, pinned
+    TensorPtr mBatchSlotsDecoder; // [maxBatchSize], int32_t, address map, pinned
 };
 
 } // namespace tensorrt_llm::runtime

--- a/cpp/tensorrt_llm/batch_manager/decoderBuffers.cpp
+++ b/cpp/tensorrt_llm/batch_manager/decoderBuffers.cpp
@@ -29,7 +29,7 @@ namespace tensorrt_llm::batch_manager
 {
 
 DecoderInputBuffers::DecoderInputBuffers(
-    SizeType32 maxBatchSize, SizeType32 maxTokensPerEngineStep, BufferManager const& manager)
+    SizeType32 maxBatchSize, SizeType32 maxDecoderSteps, BufferManager const& manager)
 {
     auto const maxBatchSizeShape = ITensor::makeShape({maxBatchSize});
     auto const nvSizeType = TRTDataType<SizeType32>::value;
@@ -44,8 +44,8 @@ DecoderInputBuffers::DecoderInputBuffers(
     fillValues = tensorrt_llm::runtime::BufferManager::pinnedPool(maxBatchSizeShape, nvSizeType);
     fillValuesDevice = manager.gpu(maxBatchSizeShape, nvSizeType);
 
-    forwardBatchSlots.reserve(maxTokensPerEngineStep);
-    for (SizeType32 i = 0; i < maxTokensPerEngineStep; ++i)
+    forwardBatchSlots.reserve(maxDecoderSteps);
+    for (SizeType32 i = 0; i < maxDecoderSteps; ++i)
     {
         forwardBatchSlots.emplace_back(BufferManager::pinnedPool(ITensor::makeShape({maxBatchSize}), nvSizeType));
     }

--- a/cpp/tensorrt_llm/batch_manager/decoderBuffers.cpp
+++ b/cpp/tensorrt_llm/batch_manager/decoderBuffers.cpp
@@ -44,8 +44,11 @@ DecoderInputBuffers::DecoderInputBuffers(
     fillValues = tensorrt_llm::runtime::BufferManager::pinnedPool(maxBatchSizeShape, nvSizeType);
     fillValuesDevice = manager.gpu(maxBatchSizeShape, nvSizeType);
 
-    forwardBatchSlots
-        = BufferManager::pinnedPool(ITensor::makeShape({maxTokensPerEngineStep, maxBatchSize}), nvSizeType);
+    forwardBatchSlots.reserve(maxTokensPerEngineStep);
+    for (SizeType32 i = 0; i < maxTokensPerEngineStep; ++i)
+    {
+        forwardBatchSlots.emplace_back(BufferManager::pinnedPool(ITensor::makeShape({maxBatchSize}), nvSizeType));
+    }
 }
 
 DecoderBuffers::DecoderBuffers(SizeType32 maxNumSequences, SizeType32 maxBeamWidth, SizeType32 maxAttentionWindow,

--- a/cpp/tensorrt_llm/batch_manager/makeDecodingBatchInputOutput.cpp
+++ b/cpp/tensorrt_llm/batch_manager/makeDecodingBatchInputOutput.cpp
@@ -104,7 +104,7 @@ std::unique_ptr<tr::decoder_batch::Input> createDecoderInputs(RequestVector cons
             "batchSlots size mismatch: %ld != %d", batchSlots.at(step)->getSize(), localBatchDecoderIdx);
     }
 
-    auto decodingInput = std::make_unique<tr::decoder_batch::Input>(logitsVec, active, maxActiveDecoderSteps);
+    auto decodingInput = std::make_unique<tr::decoder_batch::Input>(logitsVec, maxActiveDecoderSteps);
     decodingInput->batchSlots = batchSlots;
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
     return decodingInput;

--- a/cpp/tensorrt_llm/batch_manager/makeDecodingBatchInputOutput.cpp
+++ b/cpp/tensorrt_llm/batch_manager/makeDecodingBatchInputOutput.cpp
@@ -19,6 +19,7 @@
 #include "tensorrt_llm/batch_manager/decoderBuffers.h"
 #include "tensorrt_llm/batch_manager/llmRequest.h"
 #include "tensorrt_llm/batch_manager/runtimeBuffers.h"
+#include "tensorrt_llm/common/cudaUtils.h"
 #include "tensorrt_llm/common/logger.h"
 #include "tensorrt_llm/runtime/bufferManager.h"
 #include "tensorrt_llm/runtime/cudaStream.h"
@@ -43,7 +44,7 @@ std::unique_ptr<tr::decoder_batch::Input> MakeDecodingBatchInputOutput::createDe
     auto const& numDecodingEngineTokens = decoderState.getNumDecodingEngineTokens();
     auto const& maxDecodingEngineTokens = decoderState.getMaxDecodingEngineTokens();
     auto const& maxDecodingDecoderTokens = decoderState.getMaxDecodingDecoderTokens();
-    auto const maxDecoderSteps = maxDecodingEngineTokens / maxDecodingDecoderTokens;
+    auto const maxDecoderSteps = common::ceilDiv(maxDecodingEngineTokens, maxDecodingDecoderTokens);
 
     for (SizeType32 step = 0; step < maxDecoderSteps; ++step)
     {
@@ -54,7 +55,7 @@ std::unique_ptr<tr::decoder_batch::Input> MakeDecodingBatchInputOutput::createDe
     auto maxActiveDecoderSteps = 1;
     for (auto const slot : activeSlots)
     {
-        auto const numDecoderSteps = numDecodingEngineTokens.at(slot) / maxDecodingDecoderTokens;
+        auto const numDecoderSteps = common::ceilDiv(numDecodingEngineTokens.at(slot), maxDecodingDecoderTokens);
         maxActiveDecoderSteps = std::max(maxActiveDecoderSteps, numDecoderSteps);
         for (SizeType32 step = 0; step < numDecoderSteps; ++step)
         {

--- a/cpp/tensorrt_llm/pybind/batch_manager/algorithms.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/algorithms.cpp
@@ -32,6 +32,7 @@
 #include "tensorrt_llm/batch_manager/pauseRequests.h"
 #include "tensorrt_llm/batch_manager/peftCacheManager.h"
 #include "tensorrt_llm/batch_manager/runtimeBuffers.h"
+#include "tensorrt_llm/runtime/decoderState.h"
 #include "tensorrt_llm/runtime/decodingInput.h"
 #include "tensorrt_llm/runtime/decodingOutput.h"
 #include "tensorrt_llm/runtime/torch.h"

--- a/cpp/tensorrt_llm/pybind/runtime/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/runtime/bindings.cpp
@@ -291,10 +291,12 @@ void initBindings(pybind11::module_& m)
     py::bind_vector<std::vector<tr::decoder_batch::Request>>(m, "VectorRequest");
 
     py::class_<tr::decoder_batch::Input>(m, "DecoderBatchInput")
-        .def(py::init<std::vector<tr::ITensor::SharedPtr>, std::vector<bool>>(), py::arg("logits"), py::arg("active"))
+        .def(py::init<std::vector<tr::ITensor::SharedPtr>, std::vector<bool>, tr::SizeType32>(), py::arg("logits"),
+            py::arg("active"), py::arg("max_decoding_engine_tokens"))
         .def(py::init<std::vector<tr::ITensor::SharedPtr>>(), py::arg("logits"))
         .def_readwrite("logits", &tr::decoder_batch::Input::logits)
         .def_readwrite("active", &tr::decoder_batch::Input::active)
+        .def_readwrite("max_decoding_engine_tokens", &tr::decoder_batch::Input::maxDecodingEngineTokens)
         .def_readwrite("cache_indirection", &tr::decoder_batch::Input::cacheIndirection)
         .def_readwrite("predicted_draft_logits", &tr::decoder_batch::Input::predictedDraftLogits)
         .def_readwrite("batch_slots", &tr::decoder_batch::Input::batchSlots);

--- a/cpp/tensorrt_llm/pybind/runtime/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/runtime/bindings.cpp
@@ -296,7 +296,7 @@ void initBindings(pybind11::module_& m)
         .def(py::init<std::vector<tr::ITensor::SharedConstPtr>>(), py::arg("logits"))
         .def_readwrite("logits", &tr::decoder_batch::Input::logits)
         .def_readwrite("active", &tr::decoder_batch::Input::active)
-        .def_readwrite("max_decoding_engine_tokens", &tr::decoder_batch::Input::maxDecodingEngineTokens)
+        .def_readwrite("max_decoder_steps", &tr::decoder_batch::Input::maxDecoderSteps)
         .def_readwrite("cache_indirection", &tr::decoder_batch::Input::cacheIndirection)
         .def_readwrite("predicted_draft_logits", &tr::decoder_batch::Input::predictedDraftLogits)
         .def_readwrite("batch_slots", &tr::decoder_batch::Input::batchSlots);

--- a/cpp/tensorrt_llm/pybind/runtime/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/runtime/bindings.cpp
@@ -291,9 +291,9 @@ void initBindings(pybind11::module_& m)
     py::bind_vector<std::vector<tr::decoder_batch::Request>>(m, "VectorRequest");
 
     py::class_<tr::decoder_batch::Input>(m, "DecoderBatchInput")
-        .def(py::init<std::vector<tr::ITensor::SharedPtr>, std::vector<bool>, tr::SizeType32>(), py::arg("logits"),
-            py::arg("active"), py::arg("max_decoding_engine_tokens"))
-        .def(py::init<std::vector<tr::ITensor::SharedPtr>>(), py::arg("logits"))
+        .def(py::init<std::vector<std::vector<tr::ITensor::SharedConstPtr>>, std::vector<bool>, tr::SizeType32>(),
+            py::arg("logits"), py::arg("active"), py::arg("max_decoding_engine_tokens"))
+        .def(py::init<std::vector<tr::ITensor::SharedConstPtr>>(), py::arg("logits"))
         .def_readwrite("logits", &tr::decoder_batch::Input::logits)
         .def_readwrite("active", &tr::decoder_batch::Input::active)
         .def_readwrite("max_decoding_engine_tokens", &tr::decoder_batch::Input::maxDecodingEngineTokens)

--- a/cpp/tensorrt_llm/pybind/runtime/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/runtime/bindings.cpp
@@ -291,11 +291,10 @@ void initBindings(pybind11::module_& m)
     py::bind_vector<std::vector<tr::decoder_batch::Request>>(m, "VectorRequest");
 
     py::class_<tr::decoder_batch::Input>(m, "DecoderBatchInput")
-        .def(py::init<std::vector<std::vector<tr::ITensor::SharedConstPtr>>, std::vector<bool>, tr::SizeType32>(),
-            py::arg("logits"), py::arg("active"), py::arg("max_decoding_engine_tokens"))
+        .def(py::init<std::vector<std::vector<tr::ITensor::SharedConstPtr>>, tr::SizeType32>(), py::arg("logits"),
+            py::arg("max_decoding_engine_tokens"))
         .def(py::init<std::vector<tr::ITensor::SharedConstPtr>>(), py::arg("logits"))
         .def_readwrite("logits", &tr::decoder_batch::Input::logits)
-        .def_readwrite("active", &tr::decoder_batch::Input::active)
         .def_readwrite("max_decoder_steps", &tr::decoder_batch::Input::maxDecoderSteps)
         .def_readwrite("cache_indirection", &tr::decoder_batch::Input::cacheIndirection)
         .def_readwrite("predicted_draft_logits", &tr::decoder_batch::Input::predictedDraftLogits)

--- a/cpp/tensorrt_llm/runtime/decoderState.cpp
+++ b/cpp/tensorrt_llm/runtime/decoderState.cpp
@@ -202,7 +202,6 @@ void DecoderState::setup(SizeType32 maxBatchSize, SizeType32 maxBeamWidth, SizeT
     auto const maxBatchSizeXmaxBeamWidthShape = ITensor::makeShape({mMaxBatchSize, mMaxBeamWidth});
 
     const_cast<ITensor&>(*dInput.endIds).reshape(maxBatchSizeShape);
-    const_cast<ITensor&>(*dInput.batchSlots).reshape(maxBatchSizeShape);
     auto& sequenceLimitLength = const_cast<ITensor&>(*dInput.sequenceLimitLength);
     sequenceLimitLength.reshape(maxBatchSizeShape);
     kernels::invokeFill(sequenceLimitLength, mMaxSequenceLength, stream);

--- a/cpp/tensorrt_llm/runtime/gptDecoderBatched.cpp
+++ b/cpp/tensorrt_llm/runtime/gptDecoderBatched.cpp
@@ -172,9 +172,9 @@ void GptDecoderBatched::forwardDispatch(decoder_batch::Output& output, decoder_b
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
 
-    for (SizeType32 si = 0; si < input.maxDecodingEngineTokens; si += mDecoderState->getMaxDecodingDecoderTokens())
+    for (SizeType32 step = 0; step < input.maxDecoderSteps; ++step)
     {
-        prepareForward(si, output, input);
+        prepareForward(step, output, input);
 
         if (mDecoderState->getJointDecodingInput().batchSize > 0)
         {
@@ -239,7 +239,7 @@ void GptDecoderBatched::prepareForward(
 
     TensorPtr finishedStepsInput = ITensor::slice(mDecoderState->getFinishedSteps(), step, 1);
     TensorPtr finishedStepsOutput
-        = ITensor::slice(mDecoderState->getFinishedSteps(), std::min(input.maxDecodingEngineTokens - 1, step + 1), 1);
+        = ITensor::slice(mDecoderState->getFinishedSteps(), std::min(input.maxDecoderSteps - 1, step + 1), 1);
     finishedStepsInput->squeeze(0);
     finishedStepsOutput->squeeze(0);
     TensorPtr newTokensStepView

--- a/cpp/tensorrt_llm/runtime/gptDecoderBatched.cpp
+++ b/cpp/tensorrt_llm/runtime/gptDecoderBatched.cpp
@@ -249,7 +249,7 @@ void GptDecoderBatched::prepareForward(
         setEagleInputs(input);
     }
 
-    TensorPtr batchSlotsSlice = ITensor::at(input.batchSlots, {step});
+    auto const& batchSlotsSlice = input.batchSlots.at(step);
     auto batchSlotsRange = BufferRange<SizeType32>(*batchSlotsSlice);
     SizeType32 localBatchDecoderIdx = 0;
     std::vector<SharedConstPtr> logitsVec;

--- a/cpp/tensorrt_llm/runtime/gptDecoderBatched.cpp
+++ b/cpp/tensorrt_llm/runtime/gptDecoderBatched.cpp
@@ -261,15 +261,11 @@ void GptDecoderBatched::prepareForward(
         {
             BufferManager manager{mDecoderStream};
 
-            for (SizeType32 bi = 0; bi < mDecoderState->getActualBatchSize(); ++bi)
+            auto batchSlotsRange = BufferRange<SizeType32 const>(*dInput.batchSlots);
+            for (auto batchSlot : batchSlotsRange)
             {
-                if (!input.active.at(bi))
-                {
-                    continue;
-                }
                 TensorPtr finishedStepsView = ITensor::slice(mDecoderState->getFinishedSteps(), 0, 1);
                 finishedStepsView->squeeze(0);
-                auto batchSlot = bi;
                 TensorPtr finishedSteps = ITensor::slice(finishedStepsView, batchSlot, 1);
                 manager.setZero(*finishedStepsView);
             }

--- a/cpp/tensorrt_llm/runtime/statefulGptDecoderBatched.cpp
+++ b/cpp/tensorrt_llm/runtime/statefulGptDecoderBatched.cpp
@@ -203,7 +203,7 @@ void StatefulGptDecoderBatched::forwardAsync(decoder::Output& output, decoder::I
     auto const& logitsShape = input.logits->getShape();
     auto const batchSize = logitsShape.d[0];
     auto constexpr singleRequest = 1;
-    std::vector<ITensor::SharedPtr> logits;
+    std::vector<ITensor::SharedConstPtr> logits;
     logits.reserve(batchSize);
     for (auto batchIdx = 0; batchIdx < batchSize; ++batchIdx)
     {

--- a/cpp/tests/runtime/gptDecoderBatchedTest.cpp
+++ b/cpp/tests/runtime/gptDecoderBatchedTest.cpp
@@ -152,7 +152,7 @@ decoder_batch::Input prepareDecoderInputs(std::vector<SizeType32> const& activeS
             "batchSlots size mismatch: %ld != %d", batchSlots.at(step)->getSize(), localBatchDecoderIdx);
     }
 
-    auto decodingInput = decoder_batch::Input(logitsVec, active, maxActiveDecodingEngineTokens);
+    auto decodingInput = decoder_batch::Input(logitsVec, maxActiveDecodingEngineTokens);
     decodingInput.batchSlots = batchSlots;
     // FIXME: ignore cacheIndirection for now since they are all the same
     decodingInput.cacheIndirection = std::move(srcCacheIndirection);
@@ -563,8 +563,7 @@ void testDecoderWavefront(nvinfer1::DataType const dtype, std::vector<SamplingCo
         activeSlots.clear();
         for (auto batchIdx = 0; batchIdx < batchSize; ++batchIdx)
         {
-            inputs.active.at(batchIdx) = !finishedVec.at(batchIdx);
-            if (inputs.active.at(batchIdx))
+            if (!finishedVec.at(batchIdx))
             {
                 activeSlots.push_back(batchIdx);
             }

--- a/cpp/tests/runtime/gptDecoderBatchedTest.cpp
+++ b/cpp/tests/runtime/gptDecoderBatchedTest.cpp
@@ -86,6 +86,7 @@ decoder_batch::Input prepareDecoderInputs(SizeType32 batchSize, SizeType32 maxBe
     }
 
     decoder_batch::Input inputs{logits};
+    inputs.maxDecodingEngineTokens = maxGeneratedTokensPerSteps;
 
     if (maxBeamWidth > 1)
     {


### PR DESCRIPTION
Highlights:
* Set up batch slots in `MakeDecodingBatchInputOutput` (outside of the decoder).
* Set up logits vector in `MakeDecodingBatchInputOutput` (outside of the decoder).
* Remove `active` vector from `decoder_batch::Input`.
* Unify the creation of decoder batch inputs in algorithm and tests.

See commit messages for details.