### PR TITLE
refactor: decoder buffers

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/decoderBuffers.h
+++ b/cpp/include/tensorrt_llm/batch_manager/decoderBuffers.h
@@ -182,7 +182,7 @@ public:
         TensorPtr const& logProbsView, bool returnLogProbs, int peer);
 
     std::unique_ptr<DecoderSlotAsyncSend> asyncSend(
-        std::shared_ptr<mpi::MpiComm> const& commSession, bool returnLogProbs, int peer);
+        std::shared_ptr<mpi::MpiComm> const& commSession, bool returnLogProbs, int peer) const;
 
     void recv(std::shared_ptr<mpi::MpiComm> const& commSession, bool returnLogProbs, int peer);
 };

--- a/cpp/include/tensorrt_llm/batch_manager/decoderBuffers.h
+++ b/cpp/include/tensorrt_llm/batch_manager/decoderBuffers.h
@@ -111,7 +111,6 @@ public:
     TensorPtr slotOutputIdsHost; // [beamWidth, maxSeqLen], outputIds of single batch slot
     TensorPtr cacheIndirectionInput;
     TensorPtr cacheIndirectionOutput;
-    TensorPtr sequenceLengths;     // [mMaxNumRequests, beamWidth]
     TensorPtr sequenceLengthsHost; // [mMaxNumRequests, beamWidth], pinned host tensor
     TensorPtr newOutputTokens;     // [maxTokensPerStep, mMaxNumRequests, beamWidth]
     TensorPtr newOutputTokensHost; // [maxTokensPerStep, mMaxNumRequests, beamWidth]
@@ -168,6 +167,7 @@ public:
 
     TensorPtr outputIds;           // [beamWidth, maxSeqLen], outputIds of single batch slot
     TensorPtr outputIdsHost;       // [beamWidth, maxSeqLen], outputIds of single batch slot
+    TensorPtr sequenceLengths;     // [beamWidth]
     TensorPtr sequenceLengthsHost; // [beamWidth]
     TensorPtr cumLogProbs;         // [beamWidth]
     TensorPtr cumLogProbsHost;     // [beamWidth]
@@ -181,11 +181,10 @@ public:
         TensorPtr const& outputIdsView, TensorPtr const& sequenceLengthView, TensorPtr const& cumLogProbsView,
         TensorPtr const& logProbsView, bool returnLogProbs, int peer);
 
-    std::unique_ptr<DecoderSlotAsyncSend> asyncSend(std::shared_ptr<mpi::MpiComm> const& commSession,
-        TensorPtr const& sequenceLengthView, bool returnLogProbs, int peer);
+    std::unique_ptr<DecoderSlotAsyncSend> asyncSend(
+        std::shared_ptr<mpi::MpiComm> const& commSession, bool returnLogProbs, int peer);
 
-    void recv(std::shared_ptr<mpi::MpiComm> const& commSession, TensorPtr const& sequenceLengthView,
-        bool returnLogProbs, int peer);
+    void recv(std::shared_ptr<mpi::MpiComm> const& commSession, bool returnLogProbs, int peer);
 };
 
 } // namespace tensorrt_llm::batch_manager

--- a/cpp/include/tensorrt_llm/batch_manager/decoderBuffers.h
+++ b/cpp/include/tensorrt_llm/batch_manager/decoderBuffers.h
@@ -115,9 +115,7 @@ public:
     TensorPtr sequenceLengthsHost; // [mMaxNumRequests, beamWidth], pinned host tensor
     TensorPtr newOutputTokens;     // [maxTokensPerStep, mMaxNumRequests, beamWidth]
     TensorPtr newOutputTokensHost; // [maxTokensPerStep, mMaxNumRequests, beamWidth]
-    TensorPtr cumLogProbs;         // [mMaxNumRequests, beamWidth]
     TensorPtr cumLogProbsHost;     // [mMaxNumRequests, beamWidth]
-    TensorPtr logProbs;            // [mMaxNumRequests, beamWidth, maxSeqLen]
     TensorPtr logProbsHost;        // [mMaxNumRequests, beamWidth, maxSeqLen]
     TensorPtr finishedSumHost;     // [mMaxNumRequests], pinned host tensor
     TensorPtr finishReasonsHost;   // [mMaxNumRequests, beamWidth], pinned host tensor

--- a/cpp/include/tensorrt_llm/batch_manager/makeDecodingBatchInputOutput.h
+++ b/cpp/include/tensorrt_llm/batch_manager/makeDecodingBatchInputOutput.h
@@ -31,6 +31,11 @@ class DecoderBuffers;
 class RuntimeBuffers;
 } // namespace tensorrt_llm::batch_manager
 
+namespace tensorrt_llm::runtime::decoder
+{
+class DecoderState;
+} // namespace tensorrt_llm::runtime::decoder
+
 namespace tensorrt_llm::batch_manager
 {
 class MakeDecodingBatchInputOutput : Algorithm
@@ -49,9 +54,9 @@ public:
     std::tuple<std::unique_ptr<runtime::decoder_batch::Input>, std::unique_ptr<runtime::decoder_batch::Output>>
     operator()(RequestVector const& contextRequests, RequestVector const& generationRequests,
         DecoderBuffers& decoderBuffers, DecoderInputBuffers const& inputBuffers,
-        runtime::ModelConfig const& modelConfig, SizeType32 maxNumSequences, SizeType32 beamWidth,
-        runtime::BufferManager const& manager, runtime::CudaStream const& stream,
-        OptionalRef<RuntimeBuffers> fusedRuntimeBuffers) const;
+        runtime::decoder::DecoderState& decoderState, runtime::ModelConfig const& modelConfig,
+        SizeType32 maxNumSequences, SizeType32 beamWidth, runtime::BufferManager const& manager,
+        runtime::CudaStream const& stream, OptionalRef<RuntimeBuffers> fusedRuntimeBuffers) const;
 };
 
 } // namespace tensorrt_llm::batch_manager

--- a/cpp/include/tensorrt_llm/runtime/decoderState.h
+++ b/cpp/include/tensorrt_llm/runtime/decoderState.h
@@ -115,6 +115,9 @@ public:
     //! @returns [maxBeamWidth, maxSequenceLength], log probabilities (per beam), on gpu
     [[nodiscard]] TensorPtr getLogProbs(SizeType32 batchIdx) const;
 
+    //! @returns [batchSize, maxBeamWidth], sequence lengths, on gpu
+    [[nodiscard]] TensorPtr getSequenceLengths() const;
+
     //! @brief Get maxTokensPerStep tokens generated in the last forward pass
     //! @returns [maxTokensPerStep, batchSize, maxBeamWidth], tokens generated in last forward pass, on gpu
     [[nodiscard]] TensorPtr getAllNewTokens() const;

--- a/cpp/include/tensorrt_llm/runtime/iGptDecoderBatched.h
+++ b/cpp/include/tensorrt_llm/runtime/iGptDecoderBatched.h
@@ -87,7 +87,16 @@ public:
     std::optional<EagleBuffers::Inputs> eagleLastInputs;
 };
 
-using Output = decoder::Output;
+class Output
+{
+public:
+    using TensorPtr = std::shared_ptr<ITensor>;
+
+    Output() = default;
+
+    // parameters for beam search
+    TensorPtr cacheIndirection; // [batchSize, maxBeamWidth, maxSeqLen], mandatory in beam search, on gpu
+};
 
 } // namespace decoder_batch
 

--- a/cpp/tensorrt_llm/batch_manager/decoderBuffers.cpp
+++ b/cpp/tensorrt_llm/batch_manager/decoderBuffers.cpp
@@ -76,12 +76,8 @@ DecoderBuffers::DecoderBuffers(SizeType32 maxNumSequences, SizeType32 maxBeamWid
     newOutputTokensHost
         = BufferManager::pinned(ITensor::makeShape({maxTokensPerStep, maxNumSequences, maxBeamWidth}), TRTTokenIdType);
 
-    cumLogProbs = manager.gpu(ITensor::makeShape({maxNumSequences, maxBeamWidth}), nvinfer1::DataType::kFLOAT);
-
     cumLogProbsHost
         = BufferManager::pinned(ITensor::makeShape({maxNumSequences, maxBeamWidth}), nvinfer1::DataType::kFLOAT);
-
-    logProbs = manager.gpu(ITensor::makeShape({maxNumSequences, maxBeamWidth, maxSeqLen}), nvinfer1::DataType::kFLOAT);
 
     logProbsHost = BufferManager::pinned(
         ITensor::makeShape({maxNumSequences, maxBeamWidth, maxSeqLen}), nvinfer1::DataType::kFLOAT);

--- a/cpp/tensorrt_llm/batch_manager/decoderBuffers.cpp
+++ b/cpp/tensorrt_llm/batch_manager/decoderBuffers.cpp
@@ -325,11 +325,9 @@ std::unique_ptr<DecoderSlotAsyncSend> SlotDecoderBuffers::asyncSend(std::shared_
 }
 
 std::unique_ptr<DecoderSlotAsyncSend> SlotDecoderBuffers::asyncSend(
-    std::shared_ptr<mpi::MpiComm> const& commSession, bool const returnLogProbs, int const peer)
+    std::shared_ptr<mpi::MpiComm> const& commSession, bool const returnLogProbs, int const peer) const
 {
-    auto decSlotAsyncSndHdl = std::make_unique<DecoderSlotAsyncSend>(
-        commSession, outputIds, sequenceLengths, cumLogProbs, logProbs, returnLogProbs, peer);
-    return decSlotAsyncSndHdl;
+    return asyncSend(commSession, outputIds, sequenceLengths, cumLogProbs, logProbs, returnLogProbs, peer);
 }
 
 void SlotDecoderBuffers::recv(

--- a/cpp/tensorrt_llm/batch_manager/decoderBuffers.cpp
+++ b/cpp/tensorrt_llm/batch_manager/decoderBuffers.cpp
@@ -64,7 +64,6 @@ DecoderBuffers::DecoderBuffers(SizeType32 maxNumSequences, SizeType32 maxBeamWid
     cacheIndirectionOutput = manager.gpu(
         ITensor::makeShape({maxNumSequences, maxBeamWidth, maxAttentionWindow}), nvinfer1::DataType::kINT32);
 
-    sequenceLengths = manager.gpu(ITensor::makeShape({maxNumSequences, maxBeamWidth}), nvinfer1::DataType::kINT32);
     sequenceLengthsHost
         = BufferManager::pinned(ITensor::makeShape({maxNumSequences, maxBeamWidth}), nvinfer1::DataType::kINT32);
 
@@ -325,22 +324,22 @@ std::unique_ptr<DecoderSlotAsyncSend> SlotDecoderBuffers::asyncSend(std::shared_
     return decSlotAsyncSndHdl;
 }
 
-std::unique_ptr<DecoderSlotAsyncSend> SlotDecoderBuffers::asyncSend(std::shared_ptr<mpi::MpiComm> const& commSession,
-    TensorPtr const& sequenceLengthView, bool const returnLogProbs, int const peer)
+std::unique_ptr<DecoderSlotAsyncSend> SlotDecoderBuffers::asyncSend(
+    std::shared_ptr<mpi::MpiComm> const& commSession, bool const returnLogProbs, int const peer)
 {
     auto decSlotAsyncSndHdl = std::make_unique<DecoderSlotAsyncSend>(
-        commSession, outputIds, sequenceLengthView, cumLogProbs, logProbs, returnLogProbs, peer);
+        commSession, outputIds, sequenceLengths, cumLogProbs, logProbs, returnLogProbs, peer);
     return decSlotAsyncSndHdl;
 }
 
-void SlotDecoderBuffers::recv(std::shared_ptr<mpi::MpiComm> const& commSession, TensorPtr const& sequenceLengthView,
-    bool const returnLogProbs, int const peer)
+void SlotDecoderBuffers::recv(
+    std::shared_ptr<mpi::MpiComm> const& commSession, bool const returnLogProbs, int const peer)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
     TLLM_LOG_DEBUG("start recv outputs of SlotDecoderBuffers from rank %d", peer);
 
     commSession->recv(*outputIds, peer, DecoderSlotAsyncSend::kMpiTagOffset);
-    commSession->recv(*sequenceLengthView, peer, DecoderSlotAsyncSend::kMpiTagOffset + 1);
+    commSession->recv(*sequenceLengths, peer, DecoderSlotAsyncSend::kMpiTagOffset + 1);
     if (returnLogProbs)
     {
         commSession->recv(*cumLogProbs, peer, DecoderSlotAsyncSend::kMpiTagOffset + 2);
@@ -354,9 +353,9 @@ void SlotDecoderBuffers::recv(std::shared_ptr<mpi::MpiComm> const& commSession, 
 SlotDecoderBuffers::SlotDecoderBuffers(SizeType32 maxBeamWidth, SizeType32 maxSeqLen, BufferManager const& manager)
 {
     outputIds = manager.gpu(ITensor::makeShape({maxBeamWidth, maxSeqLen}), nvinfer1::DataType::kINT32);
-
     outputIdsHost = BufferManager::pinned(ITensor::makeShape({maxBeamWidth, maxSeqLen}), nvinfer1::DataType::kINT32);
 
+    sequenceLengths = manager.gpu(ITensor::makeShape({maxBeamWidth}), nvinfer1::DataType::kINT32);
     sequenceLengthsHost = BufferManager::pinned(ITensor::makeShape({maxBeamWidth}), nvinfer1::DataType::kINT32);
 
     cumLogProbs = manager.gpu(ITensor::makeShape({maxBeamWidth}), nvinfer1::DataType::kFLOAT);

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -2004,10 +2004,8 @@ runtime::CudaEvent TrtGptModelInflightBatching::updateDecoderBuffers(
 
     if (returnLogProbs)
     {
-        mDecoderBuffers->cumLogProbs = mDecoder->getDecoderState().getCumLogProbs();
-        mDecoderBuffers->logProbs = mDecoder->getDecoderState().getLogProbs();
-        mCopyBufferManager.copy(*mDecoderBuffers->cumLogProbs, *mDecoderBuffers->cumLogProbsHost);
-        mCopyBufferManager.copy(*mDecoderBuffers->logProbs, *mDecoderBuffers->logProbsHost);
+        mCopyBufferManager.copy(*mDecoder->getDecoderState().getCumLogProbs(), *mDecoderBuffers->cumLogProbsHost);
+        mCopyBufferManager.copy(*mDecoder->getDecoderState().getLogProbs(), *mDecoderBuffers->logProbsHost);
     }
 
     if (mModelConfig.getSpeculativeDecodingMode().predictsDraftTokens())

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -1792,16 +1792,6 @@ void TrtGptModelInflightBatching::getDecoderSlotHostOutputs(
     SizeType32 seqSlot, bool returnLogProbs, SamplingConfig const& samplingConfig, bool streaming)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
-    TensorPtr outputIdsView = mSlotDecoderBuffers[seqSlot]->outputIds;
-    // Sequence Length is already computed on device
-    TensorPtr sequenceLengthView = ITensor::slice(mDecoderBuffers->sequenceLengths, seqSlot, 1);
-    TensorPtr cumLogProbsView = nullptr;
-    TensorPtr logProbsView = nullptr;
-    if (returnLogProbs)
-    {
-        cumLogProbsView = mSlotDecoderBuffers[seqSlot]->cumLogProbs;
-        logProbsView = mSlotDecoderBuffers[seqSlot]->logProbs;
-    }
 
     if (mWorldConfig.isLastPipelineParallelRank())
     {
@@ -1809,6 +1799,8 @@ void TrtGptModelInflightBatching::getDecoderSlotHostOutputs(
         // Make sure that postprocessing is done before copying outputIds
         mCopyBufferManager.getStream().wait(event.get());
 
+        TensorPtr sequenceLengthView
+            = ITensor::slice(mDecoder->getDecoderState().getJointDecodingOutput().lengths, seqSlot, 1);
         auto outputIds = mDecoder->getDecoderState().getGatheredIds(seqSlot);
         auto cumLogProbs = mDecoder->getDecoderState().getCumLogProbs(seqSlot);
         auto logProbs = mDecoder->getDecoderState().getLogProbs(seqSlot);
@@ -1816,11 +1808,12 @@ void TrtGptModelInflightBatching::getDecoderSlotHostOutputs(
         runtime::CudaEvent beforeEvent{};
         mRuntime->getStreamPtr()->record(beforeEvent);
         mCopyBufferManager.getStream().wait(beforeEvent);
-        mCopyBufferManager.copy(*outputIds, *outputIdsView);
+        mCopyBufferManager.copy(*sequenceLengthView, *mSlotDecoderBuffers[seqSlot]->sequenceLengths);
+        mCopyBufferManager.copy(*outputIds, *mSlotDecoderBuffers[seqSlot]->outputIds);
         if (returnLogProbs)
         {
-            mCopyBufferManager.copy(*cumLogProbs, *cumLogProbsView);
-            mCopyBufferManager.copy(*logProbs, *logProbsView);
+            mCopyBufferManager.copy(*cumLogProbs, *mSlotDecoderBuffers[seqSlot]->cumLogProbs);
+            mCopyBufferManager.copy(*logProbs, *mSlotDecoderBuffers[seqSlot]->logProbs);
         }
 
         if (mWorldConfig.isPipelineParallel())
@@ -1829,7 +1822,7 @@ void TrtGptModelInflightBatching::getDecoderSlotHostOutputs(
             event.synchronize();
 
             auto const peerSend = 0;
-            mDecSlotAsyncSndHdls.emplace_back(mSlotDecoderBuffers[seqSlot]->asyncSend(
+            mDecSlotAsyncSndHdls.emplace_back(SlotDecoderBuffers::asyncSend(
                 mMpiCommPipelinePara, outputIds, sequenceLengthView, cumLogProbs, logProbs, returnLogProbs, peerSend));
         }
     }
@@ -1837,13 +1830,13 @@ void TrtGptModelInflightBatching::getDecoderSlotHostOutputs(
     {
         auto const peerRecv = mWorldConfig.getPipelineParallelRank() == 0 ? mWorldConfig.getPipelineParallelism() - 1
                                                                           : mWorldConfig.getPipelineParallelRank() - 1;
-        mSlotDecoderBuffers[seqSlot]->recv(mMpiCommPipelinePara, sequenceLengthView, returnLogProbs, peerRecv);
+        mSlotDecoderBuffers[seqSlot]->recv(mMpiCommPipelinePara, returnLogProbs, peerRecv);
 
         auto const peerSend = mWorldConfig.getPipelineParallelRank() + 1;
         if (peerSend != mWorldConfig.getPipelineParallelism() - 1)
         {
-            mDecSlotAsyncSndHdls.emplace_back(mSlotDecoderBuffers[seqSlot]->asyncSend(
-                mMpiCommPipelinePara, sequenceLengthView, returnLogProbs, peerSend));
+            mDecSlotAsyncSndHdls.emplace_back(
+                mSlotDecoderBuffers[seqSlot]->asyncSend(mMpiCommPipelinePara, returnLogProbs, peerSend));
         }
     }
     sync_check_cuda_error(mRuntime->getStream().get());
@@ -1853,13 +1846,15 @@ void TrtGptModelInflightBatching::getDecoderSlotHostOutputs(
     runtime::CudaEvent beforeEvent{};
     mRuntime->getStreamPtr()->record(beforeEvent);
     mCopyBufferManager.getStream().wait(beforeEvent);
-    mCopyBufferManager.copy(*outputIdsView, *mSlotDecoderBuffers[seqSlot]->outputIdsHost);
-    mCopyBufferManager.copy(*sequenceLengthView, *mSlotDecoderBuffers[seqSlot]->sequenceLengthsHost);
+    mCopyBufferManager.copy(*mSlotDecoderBuffers[seqSlot]->outputIds, *mSlotDecoderBuffers[seqSlot]->outputIdsHost);
+    mCopyBufferManager.copy(
+        *mSlotDecoderBuffers[seqSlot]->sequenceLengths, *mSlotDecoderBuffers[seqSlot]->sequenceLengthsHost);
 
     if (returnLogProbs)
     {
-        mCopyBufferManager.copy(*cumLogProbsView, *mSlotDecoderBuffers[seqSlot]->cumLogProbsHost);
-        mCopyBufferManager.copy(*logProbsView, *mSlotDecoderBuffers[seqSlot]->logProbsHost);
+        mCopyBufferManager.copy(
+            *mSlotDecoderBuffers[seqSlot]->cumLogProbs, *mSlotDecoderBuffers[seqSlot]->cumLogProbsHost);
+        mCopyBufferManager.copy(*mSlotDecoderBuffers[seqSlot]->logProbs, *mSlotDecoderBuffers[seqSlot]->logProbsHost);
     }
 
     // Make sure copy is done before continuing on host
@@ -1913,10 +1908,10 @@ runtime::CudaEvent TrtGptModelInflightBatching::decoderStepAsync(ScheduledReques
     auto& fusedRuntimeBuffers = mBuffers.at(fusedBufferId);
 
     auto& decodingInput = mDecodingInputs.at(mMicroBatchId);
-    std::tie(decodingInput, mDecodingOutput)
-        = (*mMakeDecodingBatchInputOutput)(scheduledRequests.contextRequests, scheduledRequests.generationRequests,
-            *mDecoderBuffers, mDecoderInputBuffers.at(fusedBufferId), mModelConfig, getMaxNumSequences(),
-            mOperatingBeamWidth, mRuntime->getBufferManager(), mRuntime->getStream(), *fusedRuntimeBuffers);
+    std::tie(decodingInput, mDecodingOutput) = (*mMakeDecodingBatchInputOutput)(scheduledRequests.contextRequests,
+        scheduledRequests.generationRequests, *mDecoderBuffers, mDecoderInputBuffers.at(fusedBufferId),
+        mDecoder->getDecoderState(), mModelConfig, getMaxNumSequences(), mOperatingBeamWidth,
+        mRuntime->getBufferManager(), mRuntime->getStream(), *fusedRuntimeBuffers);
 
     runtime::CudaEvent decoderFinishEvent = mDecoder->forwardAsync(*mDecodingOutput, *decodingInput);
 
@@ -1995,7 +1990,8 @@ runtime::CudaEvent TrtGptModelInflightBatching::updateDecoderBuffers(
     mDecoderBuffers->newOutputTokens = mDecoder->getDecoderState().getAllNewTokens();
 
     mCopyBufferManager.copy(*mDecoderBuffers->newOutputTokens, *mDecoderBuffers->newOutputTokensHost);
-    mCopyBufferManager.copy(*mDecoderBuffers->sequenceLengths, *mDecoderBuffers->sequenceLengthsHost);
+    mCopyBufferManager.copy(
+        *mDecoder->getDecoderState().getJointDecodingOutput().lengths, *mDecoderBuffers->sequenceLengthsHost);
 
     auto const finishedSumDevice = mDecoder->getDecoderState().getFinishedSum();
     mCopyBufferManager.copy(*finishedSumDevice, *mDecoderBuffers->finishedSumHost);

--- a/cpp/tensorrt_llm/pybind/batch_manager/algorithms.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/algorithms.cpp
@@ -156,8 +156,8 @@ void tensorrt_llm::pybind::batch_manager::algorithms::initBindings(pybind11::mod
         .def(py::init())
         .def("__call__", &MakeDecodingBatchInputOutput::operator(), py::arg("context_requests"),
             py::arg("generation_requests"), py::arg("decoder_buffers"), py::arg("decoder_input_buffers"),
-            py::arg("model_config"), py::arg("max_num_sequences"), py::arg("beam_width"), py::arg("buffer_manager"),
-            py::arg("stream"), py::arg("fused_runtime_buffers") = std::nullopt)
+            py::arg("decoder_state"), py::arg("model_config"), py::arg("max_num_sequences"), py::arg("beam_width"),
+            py::arg("buffer_manager"), py::arg("stream"), py::arg("fused_runtime_buffers") = std::nullopt)
         .def("name", [](MakeDecodingBatchInputOutput const&) { return MakeDecodingBatchInputOutput::name; });
 
     py::class_<LogitsPostProcessor>(m, LogitsPostProcessor::name)

--- a/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
@@ -467,8 +467,6 @@ void initBindings(pybind11::module_& m)
         .def_readwrite("slot_output_ids_host", &tb::DecoderBuffers::slotOutputIdsHost)
         .def_readwrite("cache_indirection_input", &tb::DecoderBuffers::cacheIndirectionInput)
         .def_readwrite("cache_indirection_output", &tb::DecoderBuffers::cacheIndirectionOutput)
-        .def_property_readonly(
-            "sequence_lengths", [](tb::DecoderBuffers& self) { return tr::Torch::tensor(self.sequenceLengths); })
         .def_readwrite("sequence_lengths_host", &tb::DecoderBuffers::sequenceLengthsHost)
         .def_readwrite("finished_sum_host", &tb::DecoderBuffers::finishedSumHost)
         .def_property_readonly(

--- a/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
@@ -475,9 +475,7 @@ void initBindings(pybind11::module_& m)
             "new_output_tokens", [](tb::DecoderBuffers& self) { return tr::Torch::tensor(self.newOutputTokens); })
         .def_property_readonly("new_output_tokens_host",
             [](tb::DecoderBuffers& self) { return tr::Torch::tensor(self.newOutputTokensHost); })
-        .def_readwrite("cum_log_probs", &tb::DecoderBuffers::cumLogProbs)
         .def_readwrite("cum_log_probs_host", &tb::DecoderBuffers::cumLogProbsHost)
-        .def_readwrite("log_probs", &tb::DecoderBuffers::logProbs)
         .def_readwrite("log_probs_host", &tb::DecoderBuffers::logProbsHost)
         .def_readwrite("finish_reasons_host", &tb::DecoderBuffers::finishReasonsHost)
         .def_readwrite("draft_buffers", &tb::DecoderBuffers::draftBuffers);

--- a/cpp/tensorrt_llm/pybind/runtime/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/runtime/bindings.cpp
@@ -301,8 +301,7 @@ void initBindings(pybind11::module_& m)
 
     py::class_<tr::decoder_batch::Output>(m, "DecoderBatchOutput")
         .def(py::init())
-        .def_readwrite("cache_indirection", &tr::decoder::Output::cacheIndirection)
-        .def_readwrite("sequence_lengths", &tr::decoder::Output::sequenceLengths);
+        .def_readwrite("cache_indirection", &tr::decoder_batch::Output::cacheIndirection);
 
     py::class_<tr::decoder::Input>(m, "Input")
         .def(py::init<tr::ITensor::SharedPtr>(), py::arg("logits"))
@@ -368,6 +367,8 @@ void initBindings(pybind11::module_& m)
             "joint_decoding_input", [](tr::decoder::DecoderState& self) { return self.getJointDecodingInput(); })
         .def_property_readonly(
             "joint_decoding_output", [](tr::decoder::DecoderState& self) { return self.getJointDecodingOutput(); })
+        .def_property_readonly("sequence_lengths",
+            [](tr::decoder::DecoderState& self) { return tr::Torch::tensor(self.getSequenceLengths()); })
         .def_property_readonly(
             "all_new_tokens", [](tr::decoder::DecoderState& self) { return tr::Torch::tensor(self.getAllNewTokens()); })
         .def_property_readonly(

--- a/cpp/tensorrt_llm/runtime/gptDecoderBatched.cpp
+++ b/cpp/tensorrt_llm/runtime/gptDecoderBatched.cpp
@@ -233,10 +233,8 @@ void GptDecoderBatched::prepareForward(
 
     TLLM_CHECK(static_cast<SizeType32>(output.sequenceLengths->getSize())
         == mDecoderState->getActualBatchSize() * maxBeamWidth);
-    // TODO should remove this reshape and set shape to [batch_size, beam_width] outside
-    TensorPtr sequenceLengths = ITensor::view(
-        output.sequenceLengths, ITensor::makeShape({mDecoderState->getActualBatchSize(), maxBeamWidth}));
-    TLLM_CHECK(sequenceLengths);
+    TLLM_CHECK(output.sequenceLengths->getDimension<0>() == mDecoderState->getActualBatchSize());
+    TLLM_CHECK(output.sequenceLengths->getDimension<1>() == maxBeamWidth);
 
     auto& dInput = mDecoderState->getJointDecodingInput();
     auto& dOutput = mDecoderState->getJointDecodingOutput();
@@ -321,7 +319,7 @@ void GptDecoderBatched::prepareForward(
 
     dOutput.newTokens = newTokensStepView;
     dOutput.finishReasons = finishedStepsOutput;
-    dOutput.lengths = sequenceLengths;
+    dOutput.lengths = output.sequenceLengths;
 
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
 }

--- a/cpp/tensorrt_llm/runtime/gptDecoderBatched.cpp
+++ b/cpp/tensorrt_llm/runtime/gptDecoderBatched.cpp
@@ -231,11 +231,6 @@ void GptDecoderBatched::prepareForward(
 
     auto constexpr singleRequest = 1;
 
-    TLLM_CHECK(static_cast<SizeType32>(output.sequenceLengths->getSize())
-        == mDecoderState->getActualBatchSize() * maxBeamWidth);
-    TLLM_CHECK(output.sequenceLengths->getDimension<0>() == mDecoderState->getActualBatchSize());
-    TLLM_CHECK(output.sequenceLengths->getDimension<1>() == maxBeamWidth);
-
     auto& dInput = mDecoderState->getJointDecodingInput();
     auto& dOutput = mDecoderState->getJointDecodingOutput();
 
@@ -319,7 +314,6 @@ void GptDecoderBatched::prepareForward(
 
     dOutput.newTokens = newTokensStepView;
     dOutput.finishReasons = finishedStepsOutput;
-    dOutput.lengths = output.sequenceLengths;
 
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
 }

--- a/cpp/tensorrt_llm/runtime/statefulGptDecoderBatched.cpp
+++ b/cpp/tensorrt_llm/runtime/statefulGptDecoderBatched.cpp
@@ -218,7 +218,9 @@ void StatefulGptDecoderBatched::forwardAsync(decoder::Output& output, decoder::I
 
     decoder_batch::Output batchOutput;
     batchOutput.cacheIndirection = output.cacheIndirection;
-    batchOutput.sequenceLengths = output.sequenceLengths;
+    batchOutput.sequenceLengths = ITensor::view(output.sequenceLengths,
+        ITensor::makeShape(
+            {mDecoder->getDecoderState().getActualBatchSize(), mDecoder->getDecoderState().getMaxBeamWidth()}));
 
     mDecoderFinishEvent = mDecoder->forwardAsync(batchOutput, batchInput);
 

--- a/cpp/tensorrt_llm/runtime/statefulGptDecoderBatched.cpp
+++ b/cpp/tensorrt_llm/runtime/statefulGptDecoderBatched.cpp
@@ -218,7 +218,8 @@ void StatefulGptDecoderBatched::forwardAsync(decoder::Output& output, decoder::I
 
     decoder_batch::Output batchOutput;
     batchOutput.cacheIndirection = output.cacheIndirection;
-    batchOutput.sequenceLengths = ITensor::view(output.sequenceLengths,
+    // WAR: use sequenceLengths of output instead of DecoderState
+    mDecoder->getDecoderState().getJointDecodingOutput().lengths = ITensor::view(output.sequenceLengths,
         ITensor::makeShape(
             {mDecoder->getDecoderState().getActualBatchSize(), mDecoder->getDecoderState().getMaxBeamWidth()}));
 

--- a/tensorrt_llm/_torch/pyexecutor/decoder.py
+++ b/tensorrt_llm/_torch/pyexecutor/decoder.py
@@ -538,7 +538,8 @@ class TRTLLMDecoder(Decoder):
                 scheduled_requests.context_requests,
                 scheduled_requests.generation_requests,
                 self.store["decoder_buffers"],
-                self.store["decoder_input_buffers"], self.model_config,
+                self.store["decoder_input_buffers"],
+                self.algs.decoder.decoder_state, self.model_config,
                 self.max_num_sequences, self.beam_width,
                 self.store["buffer_manager"], self.store["cuda_stream"])
             self.algs.decoder.forward_async(self.decoding_output,
@@ -557,8 +558,8 @@ class TRTLLMDecoder(Decoder):
             'cpu', non_blocking=True)
         finish_reasons_host = self.algs.decoder.decoder_state.finish_reasons.to(
             'cpu', non_blocking=True)
-        sequence_lengths_host_data = self.store[
-            "decoder_buffers"].sequence_lengths.to('cpu', non_blocking=True)
+        sequence_lengths_host_data = self.algs.decoder.decoder_state.sequence_lengths.to(
+            'cpu', non_blocking=True)
 
         self.decoder_event.record()
         self.decoder_event.synchronize()


### PR DESCRIPTION
Summary:
* Remove `cumLogProbs` and `logProbs` from `DecoderBuffers` (unnecessary indirection).
* Remove `sequenceLengths` from `DecoderBuffers`. Instead directly use `output->lengths` from `DecoderState`.

For details please see the commit messages.