### PR TITLE
fix: add tp=2 ci test for vision encoder

### DIFF
--- a/tests/integration/test_lists/test-db/l0_dgx_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_h100.yml
@@ -116,6 +116,7 @@ l0_dgx_h100:
   - test_e2e.py::test_llmapi_example_distributed_tp2
   - unittest/trt/functional/test_allreduce_norm.py
   - examples/test_multimodal.py::test_llm_multimodal_general[Llama-3.2-11B-Vision-pp:1-tp:2-bfloat16-bs:1-cpp_e2e:False-nb:1]
+  - examples/test_multimodal.py::test_llm_multimodal_general[llava-v1.6-mistral-7b-hf-vision-trtllm-pp:1-tp:2-float16-bs:1-cpp_e2e:False-nb:1]
   - deterministic/test_mixtral_deterministic.py::test_llm_mixtral_4gpus_deterministic[Mixtral-8x7B-Instruct-v0.1-float16]
 - condition:
     ranges:


### PR DESCRIPTION
Vision encoders w/ tensor parallelism are supported. Add a ci test for tp=2 in L0 ci tests to ensure the correctness.