### PR TITLE
chore: Unwaive DS + overlap disagg test

### DIFF
--- a/tests/integration/defs/disaggregated/sanity_check.sh
+++ b/tests/integration/defs/disaggregated/sanity_check.sh
@@ -31,9 +31,6 @@ elif [[ "${TEST_DESC}" == "mixed" ]]; then
 elif [[ "${TEST_DESC}" == "overlap" ]]; then
   NUM_RANKS=2
   CONFIG_FILE=${SCRIPT_DIR}/test_configs/disagg_config_overlap.yaml
-elif [[ "${TEST_DESC}" == "deepseek_v3_lite_fp_8_overlap_dp" ]]; then
-  NUM_RANKS=4
-  CONFIG_FILE=${SCRIPT_DIR}/test_configs/disagg_config_overlap_dp.yaml
 elif [[ "${TEST_DESC}" == "4_ranks" ]]; then
   NUM_RANKS=4
   CONFIG_FILE=${SCRIPT_DIR}/test_configs/disagg_config_ctxtp2_gentp1.yaml
@@ -49,6 +46,9 @@ elif [[ "${TEST_DESC}" == "deepseek_v3_lite_fp8_attention_dp_overlap_cuda_graph"
 elif [[ "${TEST_DESC}" == "deepseek_v3_lite_fp8_attention_dp" ]]; then
   NUM_RANKS=4
   CONFIG_FILE=${SCRIPT_DIR}/test_configs/disagg_config_ctxtp2_gentp2_deepseek_v3_lite_attention_dp.yaml
+elif [[ "${TEST_DESC}" == "deepseek_v3_lite_fp_8_attention_dp_overlap" ]]; then
+  NUM_RANKS=4
+  CONFIG_FILE=${SCRIPT_DIR}/test_configs/disagg_config_ctxtp2_gentp2_deepseek_v3_lite_attention_dp_overlap.yaml
 elif [[ "${TEST_DESC}" == "deepseek_v3_lite_fp8_attention_dp_one" ]]; then
   NUM_RANKS=4
   CONFIG_FILE=${SCRIPT_DIR}/test_configs/disagg_config_ctxtp2_gentp2_deepseek_v3_lite_attention_dp_one.yaml

--- a/tests/integration/defs/disaggregated/test_configs/disagg_config_ctxtp2_gentp2_deepseek_v3_lite_attention_dp.yaml
+++ b/tests/integration/defs/disaggregated/test_configs/disagg_config_ctxtp2_gentp2_deepseek_v3_lite_attention_dp.yaml
@@ -10,13 +10,13 @@ context_servers:
   num_instances: 1
   tensor_parallel_size: 2
   pipeline_parallel_size: 1
-  enable_attention_dp: true
+  enable_attention_dp: True
   urls:
       - "localhost:8001"
 generation_servers:
   num_instances: 1
   tensor_parallel_size: 2
   pipeline_parallel_size: 1
-  enable_attention_dp: true
+  enable_attention_dp: True
   urls:
       - "localhost:8002"

--- a/tests/integration/defs/disaggregated/test_configs/disagg_config_ctxtp2_gentp2_deepseek_v3_lite_attention_dp_overlap.yaml
+++ b/tests/integration/defs/disaggregated/test_configs/disagg_config_ctxtp2_gentp2_deepseek_v3_lite_attention_dp_overlap.yaml
@@ -1,19 +1,13 @@
-model: DeepSeek-V3-Lite/fp8
 hostname: localhost
 port: 8000
+model: DeepSeek-V3-Lite/fp8
+free_gpu_memory_fraction: 0.25
 backend: "pytorch"
-free_gpu_memory_fraction: 0.2
-speculative_config:
-  decoding_type: MTP
-  num_nextn_predict_layers: 1
 context_servers:
   num_instances: 1
-  max_batch_size: 1
-  max_num_tokens: 3000
-  max_seq_len: 4096
-  enable_attention_dp: True
   tensor_parallel_size: 2
   pipeline_parallel_size: 1
+  enable_attention_dp: True
   pytorch_backend_config:
     use_cuda_graph: False
     enable_overlap_scheduler: False
@@ -23,10 +17,7 @@ generation_servers:
   num_instances: 1
   tensor_parallel_size: 2
   pipeline_parallel_size: 1
-  max_batch_size: 256
-  max_num_tokens: 4096
   enable_attention_dp: True
-  max_seq_len: 4096
   pytorch_backend_config:
     use_cuda_graph: False
     enable_overlap_scheduler: True

--- a/tests/integration/defs/disaggregated/test_disaggregated.py
+++ b/tests/integration/defs/disaggregated/test_disaggregated.py
@@ -223,7 +223,6 @@ def test_disaggregated_deepseek_v3_lite_fp8_ucx(disaggregated_test_root,
     cmd = f"bash {disaggregated_test_root}/sanity_check.sh {disaggregated_example_root} deepseek_v3_lite_fp8"
     check_call(cmd, shell=True, env=env, cwd=llm_venv.get_working_directory())
 
-
 @pytest.mark.parametrize("deepseek_v3_model_root", ['DeepSeek-V3-Lite-fp8'],
                          indirect=True)
 def test_disaggregated_deepseek_v3_lite_fp8_ucx_tp1_single_gpu(
@@ -243,28 +242,6 @@ def test_disaggregated_deepseek_v3_lite_fp8_ucx_tp1_single_gpu(
     cmd = f"bash {disaggregated_test_root}/sanity_check.sh {disaggregated_example_root} deepseek_v3_lite_fp8_tp1"
     check_call(cmd, shell=True, env=env, cwd=llm_venv.get_working_directory())
 
-
-@pytest.mark.parametrize("deepseek_v3_model_root", ['DeepSeek-V3-Lite-fp8'],
-                         indirect=True)
-def test_disaggregated_overlap_dp(disaggregated_test_root, llm_venv,
-                                  disaggregated_example_root,
-                                  deepseek_v3_model_root):
-    src_dst_dict = {
-        deepseek_v3_model_root:
-        f"{llm_venv.get_working_directory()}/DeepSeek-V3-Lite/fp8",
-    }
-    for src, dst in src_dst_dict.items():
-        if not os.path.islink(dst):
-            os.makedirs(os.path.dirname(dst), exist_ok=True)
-            os.symlink(src, dst, target_is_directory=True)
-
-    cmd = f"bash {disaggregated_test_root}/sanity_check.sh {disaggregated_example_root} deepseek_v3_lite_fp_8_overlap_dp"
-    check_call(cmd,
-               shell=True,
-               env=llm_venv._new_env,
-               cwd=llm_venv.get_working_directory())
-
-
 @pytest.mark.parametrize("deepseek_v3_model_root", ['DeepSeek-V3-Lite-fp8'],
                          indirect=True)
 def test_disaggregated_deepseek_v3_lite_fp8_attention_dp(
@@ -281,6 +258,26 @@ def test_disaggregated_deepseek_v3_lite_fp8_attention_dp(
             os.symlink(src, dst, target_is_directory=True)
 
     cmd = f"bash {disaggregated_test_root}/sanity_check.sh {disaggregated_example_root} deepseek_v3_lite_fp8_attention_dp"
+    check_call(cmd,
+               shell=True,
+               env=llm_venv._new_env,
+               cwd=llm_venv.get_working_directory())
+
+@pytest.mark.parametrize("deepseek_v3_model_root", ['DeepSeek-V3-Lite-fp8'],
+                         indirect=True)
+def test_disaggregated_deepseek_v3_lite_fp8_attention_dp_overlap(disaggregated_test_root, llm_venv,
+                                  disaggregated_example_root,
+                                  deepseek_v3_model_root):
+    src_dst_dict = {
+        deepseek_v3_model_root:
+        f"{llm_venv.get_working_directory()}/DeepSeek-V3-Lite/fp8",
+    }
+    for src, dst in src_dst_dict.items():
+        if not os.path.islink(dst):
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            os.symlink(src, dst, target_is_directory=True)
+
+    cmd = f"bash {disaggregated_test_root}/sanity_check.sh {disaggregated_example_root} deepseek_v3_lite_fp_8_attention_dp_overlap"
     check_call(cmd,
                shell=True,
                env=llm_venv._new_env,

--- a/tests/integration/defs/disaggregated/test_disaggregated.py
+++ b/tests/integration/defs/disaggregated/test_disaggregated.py
@@ -243,6 +243,7 @@ def test_disaggregated_deepseek_v3_lite_fp8_ucx_tp1_single_gpu(
     cmd = f"bash {disaggregated_test_root}/sanity_check.sh {disaggregated_example_root} deepseek_v3_lite_fp8_tp1"
     check_call(cmd, shell=True, env=env, cwd=llm_venv.get_working_directory())
 
+
 @pytest.mark.parametrize("deepseek_v3_model_root", ['DeepSeek-V3-Lite-fp8'],
                          indirect=True)
 def test_disaggregated_deepseek_v3_lite_fp8_attention_dp(

--- a/tests/integration/defs/disaggregated/test_disaggregated.py
+++ b/tests/integration/defs/disaggregated/test_disaggregated.py
@@ -223,6 +223,7 @@ def test_disaggregated_deepseek_v3_lite_fp8_ucx(disaggregated_test_root,
     cmd = f"bash {disaggregated_test_root}/sanity_check.sh {disaggregated_example_root} deepseek_v3_lite_fp8"
     check_call(cmd, shell=True, env=env, cwd=llm_venv.get_working_directory())
 
+
 @pytest.mark.parametrize("deepseek_v3_model_root", ['DeepSeek-V3-Lite-fp8'],
                          indirect=True)
 def test_disaggregated_deepseek_v3_lite_fp8_ucx_tp1_single_gpu(
@@ -263,11 +264,12 @@ def test_disaggregated_deepseek_v3_lite_fp8_attention_dp(
                env=llm_venv._new_env,
                cwd=llm_venv.get_working_directory())
 
+
 @pytest.mark.parametrize("deepseek_v3_model_root", ['DeepSeek-V3-Lite-fp8'],
                          indirect=True)
-def test_disaggregated_deepseek_v3_lite_fp8_attention_dp_overlap(disaggregated_test_root, llm_venv,
-                                  disaggregated_example_root,
-                                  deepseek_v3_model_root):
+def test_disaggregated_deepseek_v3_lite_fp8_attention_dp_overlap(
+        disaggregated_test_root, llm_venv, disaggregated_example_root,
+        deepseek_v3_model_root):
     src_dst_dict = {
         deepseek_v3_model_root:
         f"{llm_venv.get_working_directory()}/DeepSeek-V3-Lite/fp8",

--- a/tests/integration/test_lists/test-db/l0_dgx_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_h100.yml
@@ -67,11 +67,11 @@ l0_dgx_h100:
   - disaggregated/test_disaggregated.py::test_disaggregated_deepseek_v3_lite_fp8[DeepSeek-V3-Lite-fp8]
   - disaggregated/test_disaggregated.py::test_disaggregated_deepseek_v3_lite_fp8_ucx[DeepSeek-V3-Lite-fp8]
   - disaggregated/test_disaggregated.py::test_disaggregated_deepseek_v3_lite_fp8_attention_dp[DeepSeek-V3-Lite-fp8]
+  - disaggregated/test_disaggregated.py::test_disaggregated_deepseek_v3_lite_fp8_attention_dp_overlap[DeepSeek-V3-Lite-fp8]
   - disaggregated/test_disaggregated.py::test_disaggregated_deepseek_v3_lite_fp8_attention_dp_one[DeepSeek-V3-Lite-fp8]
   - disaggregated/test_disaggregated.py::test_disaggregated_deepseek_v3_lite_fp8_attention_dp_one_mtp[DeepSeek-V3-Lite-fp8]
   - disaggregated/test_disaggregated.py::test_disaggregated_deepseek_v3_lite_fp8_attention_dp_overlap_cuda_graph[DeepSeek-V3-Lite-fp8]
   - disaggregated/test_disaggregated.py::test_disaggregated_deepseek_v3_lite_fp8_overlap_cuda_graph[DeepSeek-V3-Lite-fp8]
-  - disaggregated/test_disaggregated.py::test_disaggregated_overlap_dp[DeepSeek-V3-Lite-fp8]
 - condition:
     ranges:
       system_gpu_count:


### PR DESCRIPTION
The disaggregated serving test with DS + overlap was waived because it was failing. I re-enabled it but disabled MTP because it looks like the combination DS+overlap+MTP is not giving the correct transcripts. Filed a bug to fix that but at least adding coverage for DS with overlap.