### PR TITLE
feat: Enable DeepGEMM by default

### DIFF
--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_gemm_kernel.cuh
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_gemm_kernel.cuh
@@ -1415,8 +1415,7 @@ static int kNumDeviceSMs = -1;
 static bool kDeepGemmEnabled = []() -> bool
 {
     char const* env_var = std::getenv("TRTLLM_DG_ENABLED");
-    return deep_gemm::jit::getGlobalCompiler().isValid() && env_var
-        && (std::string(env_var) == "1" || std::string(env_var) == "true");
+    return deep_gemm::jit::getGlobalCompiler().isValid() && (!env_var || std::string(env_var) != "0");
 }();
 
 void fp8_1x128_cs(

--- a/examples/deepseek_v3/README.md
+++ b/examples/deepseek_v3/README.md
@@ -333,13 +333,13 @@ trtllm-llmapi-launch trtllm-bench --model deepseek-ai/DeepSeek-V3 --model_path /
 TensorRT-LLM has already integrated FlashMLA in the PyTorch backend. It is enabled automatically when running DeepSeek-V3/R1.
 
 ### DeepGEMM
-TensorRT-LLM also supports DeepGEMM for DeepSeek-V3/R1, which provides significant e2e performance boost on Hopper GPUs. DeepGEMM is enabled by an environment variable `TRTLLM_DG_ENABLED`:
+TensorRT-LLM uses DeepGEMM for DeepSeek-V3/R1, which provides significant e2e performance boost on Hopper GPUs. DeepGEMM can be disabled by setting the environment variable `TRTLLM_DG_ENABLED` to `0`:
 
 DeepGEMM-related behavior can be controlled by the following environment variables:
 
 | Environment Variable | Description |
 | ----------------------------- | ----------- |
-| `TRTLLM_DG_ENABLED` | When set to `1`, enable DeepGEMM. |
+| `TRTLLM_DG_ENABLED` | When set to `0`, disable DeepGEMM. |
 | `TRTLLM_DG_JIT_DEBUG` | When set to `1`, enable JIT debugging. |
 | `TRTLLM_DG_JIT_USE_NVCC` | When set to `1`, use NVCC instead of NVRTC to compile the kernel, which has slightly better performance but requires CUDA Toolkit (>=12.3) and longer compilation time.|
 | `TRTLLM_DG_JIT_DUMP_CUBIN` | When set to `1`, dump the cubin file. This is only effective with NVRTC since NVCC will always dump the cubin file. NVRTC-based JIT will store the generated kernels in memory by default. If you want to persist the kernels across multiple runs, you can either use this variable or use NVCC. |

--- a/tests/unittest/_torch/test_fp8_block_scale_gemm.py
+++ b/tests/unittest/_torch/test_fp8_block_scale_gemm.py
@@ -209,15 +209,12 @@ def run_test_in_subprocess(env, test_file):
     reason="The test is for Hopper only. Current SM is %d." % getSMVersion(),
 )
 @pytest.mark.parametrize("env", [
+    {},
+    {
+        'TRTLLM_DG_JIT_USE_NVCC': '1'
+    },
     {
         'TRTLLM_DG_ENABLED': '0'
-    },
-    {
-        'TRTLLM_DG_ENABLED': '1',
-    },
-    {
-        'TRTLLM_DG_ENABLED': '1',
-        'TRTLLM_DG_JIT_USE_NVCC': '1'
     },
 ])
 def test_deep_gemm_in_subprocess(env):


### PR DESCRIPTION
The current behavior is to enable DeepGEMM only when `TRTLLM_DG_ENABLED` is set to `1`. This PR changes it to disable DeepGEMM only when `TRTLLM_DG_ENABLED` is set to `0`.