### PR TITLE
fix: revert extra cmake var

### DIFF
--- a/tests/integration/defs/test_cpp.py
+++ b/tests/integration/defs/test_cpp.py
@@ -160,7 +160,6 @@ def build_google_tests(request, build_dir):
         use_ccache=True,
         clean=True,
         trt_root="/usr/local/tensorrt",
-        extra_cmake_vars=["ENABLE_UCX=0"],
     )
 
     make_google_tests = [


### PR DESCRIPTION
I added a local cmake var in test_cpp.py but incorrectly committed it in #3239 . This PR reverts the extra cmake var.