### PR TITLE
feat: Allow individual gatherContext for each additional output

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
+++ b/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
@@ -2212,8 +2212,7 @@ public:
     std::optional<executor::Response> createResponse(bool useFastLogits = false, int32_t mpiWorldRank = 0);
 
     void validate(SizeType32 maxInputLen, SizeType32 maxSequenceLen, SizeType32 maxDraftLen, SizeType32 vocabSizePadded,
-        std::optional<SizeType32> maxEncoderInputLen = std::nullopt, bool enableKVCacheReuse = false,
-        bool gatherContextOutputs = false);
+        std::optional<SizeType32> maxEncoderInputLen = std::nullopt, bool enableKVCacheReuse = false);
 
     std::shared_ptr<LlmRequest> createChildRequest(RequestIdType requestId);
 

--- a/cpp/include/tensorrt_llm/batch_manager/runtimeBuffers.h
+++ b/cpp/include/tensorrt_llm/batch_manager/runtimeBuffers.h
@@ -260,7 +260,7 @@ public:
         runtime::TllmRuntime const& runtime, runtime::ModelConfig const& modelConfig,
         runtime::WorldConfig const& worldConfig, executor::DecodingConfig const& decodingConfig,
         bool gatherGenerationLogits, std::optional<SizeType32> maxNumTokens = std::nullopt,
-        std::optional<std::vector<std::string>> const& additionalOutputNames = std::nullopt);
+        std::optional<std::vector<executor::AdditionalModelOutput>> const& additionalModelOutputs = std::nullopt);
 
     RuntimeBuffers(RuntimeBuffers const& other) = delete;
     RuntimeBuffers& operator=(RuntimeBuffers const& other) = delete;
@@ -290,7 +290,7 @@ private:
         SizeType32 maxAttentionWindow, SizeType32 sinkTokenLen, runtime::TllmRuntime const& runtime,
         runtime::ModelConfig const& modelConfig, runtime::WorldConfig const& worldConfig,
         executor::DecodingConfig const& decodingConfig, bool gatherGenerationLogits,
-        std::optional<std::vector<std::string>> const& additionalOutputNames = std::nullopt);
+        std::optional<std::vector<executor::AdditionalModelOutput>> const& additionalModelOutputs = std::nullopt);
 
     void reshape(runtime::TllmRuntime const& runtime, runtime::ModelConfig const& modelConfig,
         runtime::WorldConfig const& worldConfig, bool gatherGenerationLogits);

--- a/cpp/include/tensorrt_llm/batch_manager/trtGptModelOptionalParams.h
+++ b/cpp/include/tensorrt_llm/batch_manager/trtGptModelOptionalParams.h
@@ -96,30 +96,6 @@ public:
     {
     }
 
-    bool operator==(TrtGptModelOptionalParams const& other) const
-    {
-        return kvCacheConfig == other.kvCacheConfig                                 //
-            && enableTrtOverlap == other.enableTrtOverlap                           //
-            && deviceIds == other.deviceIds                                         //
-            && normalizeLogProbs == other.normalizeLogProbs                         //
-            && enableChunkedContext == other.enableChunkedContext                   //
-            && decodingConfig == other.decodingConfig                               //
-            && gpuWeightsPercent == other.gpuWeightsPercent                         //
-            && maxBeamWidth == other.maxBeamWidth                                   //
-            && maxBatchSize == other.maxBatchSize                                   //
-            && maxNumTokens == other.maxNumTokens                                   //
-            && schedulerConfig == other.schedulerConfig                             //
-            && extendedRuntimePerfKnobConfig == other.extendedRuntimePerfKnobConfig //
-            && debugConfig == other.debugConfig                                     //
-            && maxSeqIdleMicroseconds == other.maxSeqIdleMicroseconds               //
-            && speculativeDecodingConfig == other.speculativeDecodingConfig         //
-            && guidedDecodingConfig == other.guidedDecodingConfig                   //
-            && isLeaderInOrchMode == other.isLeaderInOrchMode                       //
-            && additionalOutputNames == other.additionalOutputNames                 //
-            && gatherGenerationLogits == other.gatherGenerationLogits               //
-            ;
-    }
-
     friend std::ostream& operator<<(std::ostream& os, TrtGptModelOptionalParams const& self);
 
     KvCacheConfig kvCacheConfig;

--- a/cpp/include/tensorrt_llm/batch_manager/trtGptModelOptionalParams.h
+++ b/cpp/include/tensorrt_llm/batch_manager/trtGptModelOptionalParams.h
@@ -51,7 +51,8 @@ public:
         uint64_t maxSeqIdleMicroseconds = executor::ExecutorConfig::kDefaultMaxSeqIdleMicroseconds,
         std::optional<executor::SpeculativeDecodingConfig> specDecConfig = std::nullopt,
         std::optional<executor::GuidedDecodingConfig> guidedDecodingConfig = std::nullopt,
-        bool isLeaderInOrchMode = false, std::optional<std::vector<std::string>> additionalOutputNames = std::nullopt,
+        bool isLeaderInOrchMode = false,
+        std::optional<std::vector<executor::AdditionalModelOutput>> additionalModelOutputs = std::nullopt,
         bool gatherGenerationLogits = false)
         : kvCacheConfig{std::move(kvCacheConfig)}
         , enableTrtOverlap{enableTrtOverlap}
@@ -71,7 +72,7 @@ public:
         , speculativeDecodingConfig{specDecConfig}
         , guidedDecodingConfig{std::move(guidedDecodingConfig)}
         , isLeaderInOrchMode{isLeaderInOrchMode}
-        , additionalOutputNames{std::move(additionalOutputNames)}
+        , additionalModelOutputs{std::move(additionalModelOutputs)}
         , gatherGenerationLogits{gatherGenerationLogits}
     {
         if (guidedDecodingConfig)
@@ -90,7 +91,7 @@ public:
             executorConfig.getMaxNumTokens(), executorConfig.getSchedulerConfig(),
             executorConfig.getExtendedRuntimePerfKnobConfig(), executorConfig.getDebugConfig(),
             executorConfig.getMaxSeqIdleMicroseconds(), executorConfig.getSpecDecConfig(),
-            executorConfig.getGuidedDecodingConfig(), isLeaderInOrchMode, executorConfig.getAdditionalOutputNames(),
+            executorConfig.getGuidedDecodingConfig(), isLeaderInOrchMode, executorConfig.getAdditionalModelOutputs(),
             executorConfig.getGatherGenerationLogits())
     {
     }
@@ -143,7 +144,7 @@ public:
     std::optional<executor::GuidedDecodingConfig> guidedDecodingConfig;
     // This rank is the leader worker in orchestrator mode
     bool isLeaderInOrchMode;
-    std::optional<std::vector<std::string>> additionalOutputNames;
+    std::optional<std::vector<executor::AdditionalModelOutput>> additionalModelOutputs;
     bool gatherGenerationLogits;
 };
 

--- a/cpp/include/tensorrt_llm/executor/executor.h
+++ b/cpp/include/tensorrt_llm/executor/executor.h
@@ -198,22 +198,22 @@ private:
     std::optional<std::vector<SizeType32>> mBeamWidthArray;
 };
 
+/// @brief Additional output that should be gathered.
+/// @details By default gather output of shape [beamWidth, x] from each generation phase.
+///          If gatherContext is true, also gather output of shape [promptLen, x] from context phase.
+class AdditionalModelOutput
+{
+public:
+    explicit AdditionalModelOutput(std::string name, bool gatherContext = false);
+
+    std::string name;
+    bool gatherContext{false};
+};
+
 /// @brief Configuration that controls the outputs of a Result
 class OutputConfig
 {
 public:
-    /// @brief Additional output that should be gathered.
-    /// @details By default gather output of shape [beamWidth, x] from each generation phase.
-    ///          If gatherContext is true, also gather output of shape [promptLen, x] from context phase.
-    class AdditionalModelOutput
-    {
-    public:
-        explicit AdditionalModelOutput(std::string name, bool gatherContext = false);
-
-        std::string name;
-        bool gatherContext{false};
-    };
-
     explicit OutputConfig(bool returnLogProbs = false, bool returnContextLogits = false,
         bool returnGenerationLogits = false, bool excludeInputFromOutput = false, bool returnEncoderOutput = false,
         bool returnPerfMetrics = false,
@@ -1413,7 +1413,7 @@ public:
         uint64_t maxSeqIdleMicroseconds = kDefaultMaxSeqIdleMicroseconds,
         std::optional<SpeculativeDecodingConfig> specDecConfig = std::nullopt,
         std::optional<GuidedDecodingConfig> guidedDecodingConfig = std::nullopt,
-        std::optional<std::vector<std::string>> additionalOutputNames = std::nullopt,
+        std::optional<std::vector<AdditionalModelOutput>> additionalModelOutputs = std::nullopt,
         bool gatherGenerationLogits = false, bool useVariableBeamWidthSearch = false);
 
     [[nodiscard]] SizeType32 getMaxBeamWidth() const;
@@ -1443,7 +1443,7 @@ public:
     [[nodiscard]] uint64_t getMaxSeqIdleMicroseconds() const;
     [[nodiscard]] std::optional<SpeculativeDecodingConfig> getSpecDecConfig() const;
     [[nodiscard]] std::optional<GuidedDecodingConfig> getGuidedDecodingConfig() const;
-    [[nodiscard]] std::optional<std::vector<std::string>> getAdditionalOutputNames() const;
+    [[nodiscard]] std::optional<std::vector<AdditionalModelOutput>> getAdditionalModelOutputs() const;
     [[nodiscard]] bool getGatherGenerationLogits() const;
     [[nodiscard]] bool getUseVariableBeamWidthSearch() const;
 
@@ -1469,7 +1469,7 @@ public:
     void setMaxSeqIdleMicroseconds(uint64_t maxSeqIdleMicroseconds);
     void setSpecDecConfig(SpeculativeDecodingConfig const& specDecConfig);
     void setGuidedDecodingConfig(GuidedDecodingConfig const& guidedDecodingConfig);
-    void setAdditionalOutputNames(std::vector<std::string> const& additionalOutputNames);
+    void setAdditionalModelOutputs(std::vector<AdditionalModelOutput> const& additionalModelOutputs);
     void setGatherGenerationLogits(bool gatherGenerationLogits);
     void setUseVariableBeamWidthSearch(bool useVariableBeamWidthSearch);
 
@@ -1541,8 +1541,8 @@ private:
     /// @brief The guided decoding configuration
     std::optional<GuidedDecodingConfig> mGuidedDecodingConfig;
 
-    /// @brief The additional output tensor names
-    std::optional<std::vector<std::string>> mAdditionalOutputNames;
+    /// @brief The additional outputs to gather from the model.
+    std::optional<std::vector<AdditionalModelOutput>> mAdditionalModelOutputs;
 
     /// @brief Controls if generation logits should be gathered, so that returnGenerationLogits can be requested.
     bool mGatherGenerationLogits{false};

--- a/cpp/include/tensorrt_llm/executor/serialization.h
+++ b/cpp/include/tensorrt_llm/executor/serialization.h
@@ -56,9 +56,9 @@ public:
     [[nodiscard]] static size_t serializedSize(OutputConfig const& config);
 
     // OutputConfig::AdditionalModelOutput
-    [[nodiscard]] static OutputConfig::AdditionalModelOutput deserializeAdditionalModelOutput(std::istream& is);
-    static void serialize(OutputConfig::AdditionalModelOutput const& additionalModelOutput, std::ostream& os);
-    [[nodiscard]] static size_t serializedSize(OutputConfig::AdditionalModelOutput const& additionalModelOutput);
+    [[nodiscard]] static AdditionalModelOutput deserializeAdditionalModelOutput(std::istream& is);
+    static void serialize(AdditionalModelOutput const& additionalModelOutput, std::ostream& os);
+    [[nodiscard]] static size_t serializedSize(AdditionalModelOutput const& additionalModelOutput);
 
     // ExternalDraftTokensConfig
     [[nodiscard]] static ExternalDraftTokensConfig deserializeExternalDraftTokensConfig(std::istream& is);

--- a/cpp/tensorrt_llm/batch_manager/llmRequest.cpp
+++ b/cpp/tensorrt_llm/batch_manager/llmRequest.cpp
@@ -182,8 +182,7 @@ std::optional<executor::Response> LlmRequest::createResponse(bool useFastLogits,
 }
 
 void LlmRequest::validate(SizeType32 maxInputLen, SizeType32 maxSequenceLen, SizeType32 maxDraftLen,
-    SizeType32 vocabSizePadded, std::optional<SizeType32> maxEncoderInputLen, bool enableKVCacheReuse,
-    bool gatherContextOutputs)
+    SizeType32 vocabSizePadded, std::optional<SizeType32> maxEncoderInputLen, bool enableKVCacheReuse)
 {
     if (mEndId.has_value())
     {
@@ -253,14 +252,6 @@ void LlmRequest::validate(SizeType32 maxInputLen, SizeType32 maxSequenceLen, Siz
         TLLM_CHECK_WITH_INFO(mInputTokenExtraIds.value()->size() == static_cast<size_t>(mOrigPromptLen),
             "inputTokenExtraIds vector size (%lu) must be the same as input token vector size (%lu).",
             mInputTokenExtraIds.value()->size(), static_cast<size_t>(mOrigPromptLen));
-    }
-
-    if (!gatherContextOutputs && !mAdditionalContextOutputTensors.empty())
-    {
-        TLLM_LOG_WARNING(
-            "Requested additional outputs for context tokens, but engine does not gather context outputs. "
-            "To enable context outputs build the engine with gather_context_logits.");
-        mAdditionalContextOutputTensors.clear();
     }
 }
 

--- a/cpp/tensorrt_llm/batch_manager/runtimeBuffers.cpp
+++ b/cpp/tensorrt_llm/batch_manager/runtimeBuffers.cpp
@@ -53,12 +53,12 @@ RuntimeBuffers::RuntimeBuffers(SizeType32 maxBatchSize, SizeType32 maxBeamWidth,
     std::vector<SizeType32> const& maxAttentionWindowVec, SizeType32 maxAttentionWindow, SizeType32 sinkTokenLen,
     TllmRuntime const& runtime, ModelConfig const& modelConfig, WorldConfig const& worldConfig,
     executor::DecodingConfig const& decodingConfig, bool gatherGenerationLogits, std::optional<SizeType32> maxNumTokens,
-    std::optional<std::vector<std::string>> const& additionalOutputNames)
+    std::optional<std::vector<executor::AdditionalModelOutput>> const& additionalModelOutputs)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
 
     create(maxBatchSize, maxBeamWidth, maxAttentionWindowVec, maxAttentionWindow, sinkTokenLen, runtime, modelConfig,
-        worldConfig, decodingConfig, gatherGenerationLogits, additionalOutputNames);
+        worldConfig, decodingConfig, gatherGenerationLogits, additionalModelOutputs);
 
     // pre-allocate
     setMaxBufferSizes(maxBatchSize, maxBeamWidth, modelConfig, maxNumTokens);
@@ -211,7 +211,7 @@ void RuntimeBuffers::create(SizeType32 maxBatchSize, SizeType32 maxBeamWidth,
     std::vector<SizeType32> const& maxAttentionWindowVec, SizeType32 maxAttentionWindow, SizeType32 sinkTokenLen,
     TllmRuntime const& runtime, ModelConfig const& modelConfig, WorldConfig const& worldConfig,
     executor::DecodingConfig const& decodingConfig, bool gatherGenerationLogits,
-    std::optional<std::vector<std::string>> const& additionalOutputNames)
+    std::optional<std::vector<executor::AdditionalModelOutput>> const& additionalModelOutputs)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
 
@@ -339,11 +339,11 @@ void RuntimeBuffers::create(SizeType32 maxBatchSize, SizeType32 maxBeamWidth,
         languageAdapterRoutings = manager.emptyTensor(MemoryType::kGPU, TRTDataType<SizeType32>::value);
     }
 
-    for (auto const& outputTensorName : additionalOutputNames.value_or(std::vector<std::string>{}))
+    for (auto const& output : additionalModelOutputs.value_or(std::vector<executor::AdditionalModelOutput>{}))
     {
         auto const& engine = runtime.getEngine();
-        auto const dataType = engine.getTensorDataType(outputTensorName.c_str());
-        mAdditionalOutputTensors.emplace(outputTensorName, manager.emptyTensor(runtime::MemoryType::kGPU, dataType));
+        auto const dataType = engine.getTensorDataType(output.name.c_str());
+        mAdditionalOutputTensors.emplace(output.name, manager.emptyTensor(runtime::MemoryType::kGPU, dataType));
     }
 
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);

--- a/cpp/tensorrt_llm/batch_manager/runtimeBuffers.cpp
+++ b/cpp/tensorrt_llm/batch_manager/runtimeBuffers.cpp
@@ -33,7 +33,6 @@
 #include "tensorrt_llm/runtime/common.h"
 #include "tensorrt_llm/runtime/iBuffer.h"
 #include "tensorrt_llm/runtime/iTensor.h"
-#include "tensorrt_llm/runtime/runtimeKernels.h"
 #include "tensorrt_llm/runtime/tllmRuntime.h"
 #include "tensorrt_llm/runtime/utils/sessionUtils.h"
 
@@ -41,7 +40,6 @@
 #include <iterator>
 #include <memory>
 #include <numeric>
-#include <valarray>
 #include <vector>
 
 using namespace tensorrt_llm::runtime;

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -139,7 +139,7 @@ TrtGptModelInflightBatching::TrtGptModelInflightBatching(std::shared_ptr<nvinfer
     , mDecodingConfig{optionalParams.decodingConfig}
     , mExtendedRuntimePerfKnobConfig{optionalParams.extendedRuntimePerfKnobConfig}
     , mDebugConfig{optionalParams.debugConfig}
-    , mAdditionalOutputNames{optionalParams.additionalOutputNames}
+    , mAdditionalModelOutputs{optionalParams.additionalModelOutputs}
     , mLogger{logger ? std::move(logger) : std::make_shared<TllmLogger>()}
     , mRuntime{std::make_shared<TllmRuntime>(
           rawEngine, mLogger.get(), optionalParams.gpuWeightsPercent, modelConfig.useShapeInference())}
@@ -230,7 +230,7 @@ TrtGptModelInflightBatching::TrtGptModelInflightBatching(std::shared_ptr<nvinfer
 
     auto& memCounter = MemoryCounters::getInstance();
     auto const gpuUsage1 = memCounter.getGpu();
-    createBuffers(mDecodingConfig, mAdditionalOutputNames);
+    createBuffers(mDecodingConfig, mAdditionalModelOutputs);
     auto const gpuUsage2 = memCounter.getGpu();
     TLLM_LOG_INFO("[MemUsageChange] Allocated %s GPU memory for runtime buffers.",
         memCounter.bytesToString(gpuUsage2 - gpuUsage1).c_str());
@@ -536,7 +536,7 @@ void TrtGptModelInflightBatching::adjustMaxAttentionWindow(SizeType32 numPrimary
         // maxAttentionWindow; maxAttentionWindowVec; maxSequenceLen;
         // TODO(nhaber): This is problematic, as createBuffers edits the state of trtGptModelInflightBatching, but what
         // if there are different window values for cross+self etc. in encoder+decoder scenario...
-        createBuffers(mDecodingConfig, mAdditionalOutputNames);
+        createBuffers(mDecodingConfig, mAdditionalModelOutputs);
     }
 }
 
@@ -1359,7 +1359,7 @@ void TrtGptModelInflightBatching::createDecoder(std::optional<executor::Decoding
 }
 
 void TrtGptModelInflightBatching::createBuffers(executor::DecodingConfig const& decodingConfig,
-    std::optional<std::vector<std::string>> const& additionalOutputNames)
+    std::optional<std::vector<executor::AdditionalModelOutput>> const& additionalModelOutputs)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
 
@@ -1368,7 +1368,7 @@ void TrtGptModelInflightBatching::createBuffers(executor::DecodingConfig const& 
     {
         mBuffers.emplace_back(std::make_shared<RuntimeBuffers>(getMaxBatchSize(), mOperatingBeamWidth,
             getMaxAttentionWindowVec(), getMaxAttentionWindow(), getSinkTokenLen(), *mRuntime, mModelConfig,
-            mWorldConfig, decodingConfig, getGatherGenerationLogits(), getMaxNumTokens(), additionalOutputNames));
+            mWorldConfig, decodingConfig, getGatherGenerationLogits(), getMaxNumTokens(), additionalModelOutputs));
     }
 
     for (SizeType32 i = 0; i < mNumMicroBatches; ++i)
@@ -1647,7 +1647,7 @@ void TrtGptModelInflightBatching::executeStep(
         debugIOTensors(contextRequests, generationRequests, inputMap, outputMap);
     }
 
-    if (mAdditionalOutputNames.has_value() && !mAdditionalOutputNames.value().empty())
+    if (mAdditionalModelOutputs.has_value() && !mAdditionalModelOutputs.value().empty())
     {
         utils::copyAdditionalOutputs(contextRequests, generationRequests, outputMap, getBufferManager());
     }
@@ -2385,7 +2385,7 @@ void TrtGptModelInflightBatching::changeBeamWidth(SizeType32 beamWidth)
     TLLM_LOG_DEBUG("Changing operating beam width from %d to %d", mOperatingBeamWidth, beamWidth);
     mOperatingBeamWidth = beamWidth;
 
-    createBuffers(mDecodingConfig, mAdditionalOutputNames);
+    createBuffers(mDecodingConfig, mAdditionalModelOutputs);
     createDecoder(mDecodingConfig.getDecodingMode());
 
     if (static_cast<bool>(mKvCacheManager))

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -1649,7 +1649,8 @@ void TrtGptModelInflightBatching::executeStep(
 
     if (mAdditionalModelOutputs.has_value() && !mAdditionalModelOutputs.value().empty())
     {
-        utils::copyAdditionalOutputs(contextRequests, generationRequests, outputMap, getBufferManager());
+        utils::copyAdditionalOutputs(
+            mAdditionalModelOutputs.value(), contextRequests, generationRequests, outputMap, getBufferManager());
     }
 
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
@@ -246,7 +246,7 @@ private:
     void createRuntimeContexts();
     void createDecoder(std::optional<executor::DecodingMode> const& decodingModeOpt);
     void createBuffers(executor::DecodingConfig const& decodingConfig,
-        std::optional<std::vector<std::string>> const& additionalOutputNames);
+        std::optional<std::vector<executor::AdditionalModelOutput>> const& additionalModelOutputs);
     std::shared_ptr<KVCacheManager> createKvCacheManager(KvCacheConfig const& kvCacheConfig,
         SizeType32 blocksInPrimaryPool, SizeType32 blocksInSecondaryPool, KvCacheType kvCacheType = KvCacheType::kSELF);
     void createRnnStateManager();
@@ -416,7 +416,7 @@ private:
     // Config for debugging output
     std::optional<executor::DebugConfig> mDebugConfig;
     // List of additional outputs for each request
-    std::optional<std::vector<std::string>> mAdditionalOutputNames;
+    std::optional<std::vector<executor::AdditionalModelOutput>> mAdditionalModelOutputs;
 
     /******************** Components ********************/
     std::shared_ptr<nvinfer1::ILogger> mLogger;

--- a/cpp/tensorrt_llm/batch_manager/utils/inflightBatchingUtils.cpp
+++ b/cpp/tensorrt_llm/batch_manager/utils/inflightBatchingUtils.cpp
@@ -96,26 +96,44 @@ void copyGenerationLogits(RuntimeBuffers::GenerationLogitsCache& generationLogit
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
 }
 
-void copyAdditionalOutputs(RequestVector const& contextRequests, RequestVector const& generationRequests,
+void copyAdditionalOutputs(std::vector<executor::AdditionalModelOutput> const& additionalModelOutputs,
+    RequestVector const& contextRequests, RequestVector const& generationRequests,
     RuntimeBuffers::TensorMap const& outputMap, runtime::BufferManager const& manager)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
-    SizeType32 srcTensorIndex{0}; // One index shared across all output tensors
+
+    // One index shared across all output tensors that have gatherContext
+    SizeType32 srcTensorIndexWithContext{0};
+    // One index shared across all output tensors that do not have gatherContext
+    SizeType32 srcTensorIndexWithoutContext{0};
+
     for (auto const& llmReq : contextRequests)
     {
         auto numContextTokens = llmReq->getContextChunkSize();
         for (auto const& outputTensor : llmReq->getAdditionalContextOutputs())
         {
             auto const& outputTensorName = outputTensor.first;
-            auto tensorIt = outputMap.find(outputTensorName);
-            TLLM_CHECK_WITH_INFO(
-                tensorIt != outputMap.end(), "Additional context output tensor not found %s", outputTensorName.c_str());
 
+            auto const aoIter = std::find_if(additionalModelOutputs.cbegin(), additionalModelOutputs.cend(),
+                [&outputTensorName](auto const& ao) { return ao.name == outputTensorName; });
+            TLLM_CHECK_WITH_INFO(aoIter != additionalModelOutputs.cend(),
+                "Additional context output tensor not found: %s", outputTensorName.c_str());
+
+            auto const gatherContext = aoIter->gatherContext;
+            TLLM_CHECK_WITH_INFO(
+                gatherContext, "Additional context output tensor not gathered: %s", outputTensorName.c_str());
+
+            auto const tensorIt = outputMap.find(outputTensorName);
+            TLLM_CHECK_WITH_INFO(tensorIt != outputMap.end(), "Additional context output tensor not found: %s",
+                outputTensorName.c_str());
+
+            auto const srcTensorIndex = srcTensorIndexWithContext;
             auto srcView = ITensor::slice(tensorIt->second, srcTensorIndex, numContextTokens);
             auto dstView = ITensor::slice(outputTensor.second, llmReq->getContextCurrentPosition(), numContextTokens);
             manager.copy(*srcView, *dstView);
         }
-        srcTensorIndex += numContextTokens;
+        srcTensorIndexWithContext += numContextTokens;
+        srcTensorIndexWithoutContext += 1;
 
         // Copy output of last token to generation outputs
         if (llmReq->isLastContextChunk())
@@ -123,10 +141,19 @@ void copyAdditionalOutputs(RequestVector const& contextRequests, RequestVector c
             for (auto const& outputTensor : llmReq->getAdditionalGenerationOutputs())
             {
                 auto const& outputTensorName = outputTensor.first;
-                auto tensorIt = outputMap.find(outputTensorName);
-                TLLM_CHECK_WITH_INFO(tensorIt != outputMap.end(), "Additional generation output tensor not found %s",
+
+                auto const aoIter = std::find_if(additionalModelOutputs.cbegin(), additionalModelOutputs.cend(),
+                    [&outputTensorName](auto const& ao) { return ao.name == outputTensorName; });
+                TLLM_CHECK_WITH_INFO(aoIter != additionalModelOutputs.cend(),
+                    "Additional generation output tensor not found: %s", outputTensorName.c_str());
+
+                auto const gatherContext = aoIter->gatherContext;
+
+                auto const tensorIt = outputMap.find(outputTensorName);
+                TLLM_CHECK_WITH_INFO(tensorIt != outputMap.end(), "Additional generation output tensor not found: %s",
                     outputTensorName.c_str());
 
+                auto const srcTensorIndex = gatherContext ? srcTensorIndexWithContext : srcTensorIndexWithoutContext;
                 auto srcView = ITensor::slice(tensorIt->second, srcTensorIndex - 1, 1);
                 for (SizeType32 beam = 0; beam < llmReq->mSamplingConfig.beamWidth; beam++)
                 {
@@ -143,20 +170,30 @@ void copyAdditionalOutputs(RequestVector const& contextRequests, RequestVector c
         for (auto const& outputTensor : llmReq->getAdditionalGenerationOutputs())
         {
             auto const& outputTensorName = outputTensor.first;
-            auto tensorIt = outputMap.find(outputTensorName);
-            TLLM_CHECK_WITH_INFO(tensorIt != outputMap.end(), "Additional generation output tensor not found %s",
+
+            auto const aoIter = std::find_if(additionalModelOutputs.cbegin(), additionalModelOutputs.cend(),
+                [&outputTensorName](auto const& ao) { return ao.name == outputTensorName; });
+            TLLM_CHECK_WITH_INFO(aoIter != additionalModelOutputs.cend(),
+                "Additional generation output tensor not found: %s", outputTensorName.c_str());
+
+            auto const gatherContext = aoIter->gatherContext;
+
+            auto const tensorIt = outputMap.find(outputTensorName);
+            TLLM_CHECK_WITH_INFO(tensorIt != outputMap.end(), "Additional generation output tensor not found: %s",
                 outputTensorName.c_str());
 
+            auto const srcTensorIndex = gatherContext ? srcTensorIndexWithContext : srcTensorIndexWithoutContext;
             for (SizeType32 beam = 0; beam < reqBeamWidth; beam++)
             {
-                auto generatedLength = llmReq->getNumTokens(beam) - llmReq->getPromptLen();
+                auto const generatedLength = llmReq->getNumTokens(beam) - llmReq->getPromptLen();
                 TLLM_CHECK(generatedLength >= 1);
                 auto srcView = ITensor::slice(tensorIt->second, srcTensorIndex + beam, 1);
                 auto dstView = ITensor::slice(outputTensor.second, {beam, generatedLength}, 1);
                 manager.copy(*srcView, *dstView);
             }
         }
-        srcTensorIndex += reqBeamWidth;
+        srcTensorIndexWithContext += reqBeamWidth;
+        srcTensorIndexWithoutContext += reqBeamWidth;
     }
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
 }

--- a/cpp/tensorrt_llm/batch_manager/utils/inflightBatchingUtils.h
+++ b/cpp/tensorrt_llm/batch_manager/utils/inflightBatchingUtils.h
@@ -44,7 +44,8 @@ void copyGenerationLogits(RuntimeBuffers::GenerationLogitsCache& generationLogit
     runtime::BufferManager const& bufferManager, LlmRequest& llmReq, bool beforeDecoder,
     std::vector<SizeType32> const& numDroppedTokens = {});
 
-void copyAdditionalOutputs(RequestVector const& contextRequests, RequestVector const& generationRequests,
+void copyAdditionalOutputs(std::vector<executor::AdditionalModelOutput> const& additionalModelOutputs,
+    RequestVector const& contextRequests, RequestVector const& generationRequests,
     RuntimeBuffers::TensorMap const& outputMap, runtime::BufferManager const& manager);
 
 void terminateRequest(SequenceSlotManager& seqSlotManager, LlmRequest& llmRequest, SizeType32 maxInputLen,

--- a/cpp/tensorrt_llm/executor/executorConfig.cpp
+++ b/cpp/tensorrt_llm/executor/executorConfig.cpp
@@ -32,7 +32,7 @@ ExecutorConfig::ExecutorConfig(SizeType32 maxBeamWidth, SchedulerConfig schedule
     ExtendedRuntimePerfKnobConfig const& extendedRuntimePerfKnobConfig, std::optional<DebugConfig> debugConfig,
     SizeType32 recvPollPeriodMs, uint64_t maxSeqIdleMicroseconds,
     std::optional<SpeculativeDecodingConfig> specDecConfig, std::optional<GuidedDecodingConfig> guidedDecodingConfig,
-    std::optional<std::vector<std::string>> additionalOutputNames, bool gatherGenerationLogits,
+    std::optional<std::vector<AdditionalModelOutput>> additionalModelOutputs, bool gatherGenerationLogits,
     bool useVariableBeamWidthSearch)
     : mMaxBeamWidth(maxBeamWidth)
     , mSchedulerConfig(std::move(schedulerConfig))
@@ -56,7 +56,7 @@ ExecutorConfig::ExecutorConfig(SizeType32 maxBeamWidth, SchedulerConfig schedule
     , mMaxSeqIdleMicroseconds(maxSeqIdleMicroseconds)
     , mSpeculativeDecodingConfig(specDecConfig)
     , mGuidedDecodingConfig(std::move(guidedDecodingConfig))
-    , mAdditionalOutputNames(std::move(additionalOutputNames))
+    , mAdditionalModelOutputs(std::move(additionalModelOutputs))
     , mGatherGenerationLogits(gatherGenerationLogits)
     , mUseVariableBeamWidthSearch(useVariableBeamWidthSearch)
 {
@@ -186,9 +186,9 @@ std::optional<GuidedDecodingConfig> ExecutorConfig::getGuidedDecodingConfig() co
     return mGuidedDecodingConfig;
 }
 
-std::optional<std::vector<std::string>> ExecutorConfig::getAdditionalOutputNames() const
+std::optional<std::vector<AdditionalModelOutput>> ExecutorConfig::getAdditionalModelOutputs() const
 {
-    return mAdditionalOutputNames;
+    return mAdditionalModelOutputs;
 }
 
 bool ExecutorConfig::getGatherGenerationLogits() const
@@ -318,9 +318,9 @@ void ExecutorConfig::setGuidedDecodingConfig(GuidedDecodingConfig const& guidedD
     mGuidedDecodingConfig = guidedDecodingConfig;
 }
 
-void ExecutorConfig::setAdditionalOutputNames(std::vector<std::string> const& additionalOutputNames)
+void ExecutorConfig::setAdditionalModelOutputs(std::vector<AdditionalModelOutput> const& additionalModelOutputs)
 {
-    mAdditionalOutputNames = additionalOutputNames;
+    mAdditionalModelOutputs = additionalModelOutputs;
 }
 
 void ExecutorConfig::setGatherGenerationLogits(bool gatherGenerationLogits)

--- a/cpp/tensorrt_llm/executor/executorImpl.cpp
+++ b/cpp/tensorrt_llm/executor/executorImpl.cpp
@@ -1509,7 +1509,7 @@ std::tuple<Executor::Impl::RequestList, double> Executor::Impl::fetchNewRequests
                 newReq->validate(mModel->getMaxInputLen(), mModel->getMaxSequenceLen(), mModel->getMaxDraftLen(),
                     mModel->getVocabSizePadded(),
                     mEncoderModel ? std::optional<SizeType32>(mEncoderModel->getMaxInputLen()) : std::nullopt,
-                    mEnableBlockReuse, mModel->getModelConfig().computeContextLogits());
+                    mEnableBlockReuse);
 
                 TLLM_CHECK_WITH_INFO(!mEncoderModel || !mIsSchedulerMaxUtilization,
                     "Encoder or Encoder-Decoder model don't support max utilization scheduler yet. Only max requests "

--- a/cpp/tensorrt_llm/executor/outputConfig.cpp
+++ b/cpp/tensorrt_llm/executor/outputConfig.cpp
@@ -33,7 +33,7 @@ OutputConfig::OutputConfig(bool inReturnLogProbs, bool inReturnContextLogits, bo
 {
 }
 
-OutputConfig::AdditionalModelOutput::AdditionalModelOutput(std::string name, bool gatherContext)
+AdditionalModelOutput::AdditionalModelOutput(std::string name, bool gatherContext)
     : name(std::move(name))
     , gatherContext(gatherContext)
 {

--- a/cpp/tensorrt_llm/executor/serialization.cpp
+++ b/cpp/tensorrt_llm/executor/serialization.cpp
@@ -226,7 +226,7 @@ OutputConfig Serialization::deserializeOutputConfig(std::istream& is)
     auto excludeInputFromOutput = su::deserialize<bool>(is);
     auto returnEncoderOutput = su::deserialize<bool>(is);
     auto returnPerfMetrics = su::deserialize<bool>(is);
-    auto additionalOutputs = su::deserialize<std::optional<std::vector<OutputConfig::AdditionalModelOutput>>>(is);
+    auto additionalOutputs = su::deserialize<std::optional<std::vector<AdditionalModelOutput>>>(is);
     return OutputConfig{returnLogProbs, returnContextLogits, returnGenerationLogits, excludeInputFromOutput,
         returnEncoderOutput, returnPerfMetrics, additionalOutputs};
 }
@@ -255,21 +255,21 @@ size_t Serialization::serializedSize(OutputConfig const& config)
     return totalSize;
 }
 
-// OutputConfig::AdditionalModelOutput
-OutputConfig::AdditionalModelOutput Serialization::deserializeAdditionalModelOutput(std::istream& is)
+// AdditionalModelOutput
+AdditionalModelOutput Serialization::deserializeAdditionalModelOutput(std::istream& is)
 {
     auto name = su::deserialize<std::string>(is);
     auto gatherContext = su::deserialize<bool>(is);
-    return OutputConfig::AdditionalModelOutput{name, gatherContext};
+    return AdditionalModelOutput{name, gatherContext};
 }
 
-void Serialization::serialize(OutputConfig::AdditionalModelOutput const& additionalModelOutput, std::ostream& os)
+void Serialization::serialize(AdditionalModelOutput const& additionalModelOutput, std::ostream& os)
 {
     su::serialize(additionalModelOutput.name, os);
     su::serialize(additionalModelOutput.gatherContext, os);
 }
 
-size_t Serialization::serializedSize(OutputConfig::AdditionalModelOutput const& additionalModelOutput)
+size_t Serialization::serializedSize(AdditionalModelOutput const& additionalModelOutput)
 {
     size_t totalSize = 0;
     totalSize += su::serializedSize(additionalModelOutput.name);
@@ -988,7 +988,8 @@ ExecutorConfig Serialization::deserializeExecutorConfig(std::istream& is)
         = su::deserializeWithGetterType<decltype(&ExecutorConfig::getMaxSeqIdleMicroseconds)>(is);
     auto specDecConfig = su::deserializeWithGetterType<decltype(&ExecutorConfig::getSpecDecConfig)>(is);
     auto guidedDecodingConfig = su::deserializeWithGetterType<decltype(&ExecutorConfig::getGuidedDecodingConfig)>(is);
-    auto additionalOutputNames = su::deserializeWithGetterType<decltype(&ExecutorConfig::getAdditionalOutputNames)>(is);
+    auto additionalModelOutputs
+        = su::deserializeWithGetterType<decltype(&ExecutorConfig::getAdditionalModelOutputs)>(is);
     auto gatherGenerationLogits
         = su::deserializeWithGetterType<decltype(&ExecutorConfig::getGatherGenerationLogits)>(is);
 
@@ -996,7 +997,7 @@ ExecutorConfig Serialization::deserializeExecutorConfig(std::istream& is)
         iterStatsMaxIterations, requestStatsMaxIterations, batchingType, maxBatchSize, maxNumTokens, parallelConfig,
         peftCacheConfig, std::nullopt, decodingConfig, gpuWeightsPercent, maxQueueSize, extendedRuntimePerfKnobConfig,
         debugConfig, recvPollPeriodMs, maxSeqIdleMicroseconds, specDecConfig, guidedDecodingConfig,
-        additionalOutputNames, gatherGenerationLogits};
+        additionalModelOutputs, gatherGenerationLogits};
 }
 
 size_t Serialization::serializedSize(ExecutorConfig const& executorConfig)
@@ -1027,7 +1028,7 @@ size_t Serialization::serializedSize(ExecutorConfig const& executorConfig)
     totalSize += su::serializedSize(executorConfig.getMaxSeqIdleMicroseconds());
     totalSize += su::serializedSize(executorConfig.getSpecDecConfig());
     totalSize += su::serializedSize(executorConfig.getGuidedDecodingConfig());
-    totalSize += su::serializedSize(executorConfig.getAdditionalOutputNames());
+    totalSize += su::serializedSize(executorConfig.getAdditionalModelOutputs());
     totalSize += su::serializedSize(executorConfig.getGatherGenerationLogits());
 
     return totalSize;
@@ -1059,7 +1060,7 @@ void Serialization::serialize(ExecutorConfig const& executorConfig, std::ostream
     su::serialize(executorConfig.getMaxSeqIdleMicroseconds(), os);
     su::serialize(executorConfig.getSpecDecConfig(), os);
     su::serialize(executorConfig.getGuidedDecodingConfig(), os);
-    su::serialize(executorConfig.getAdditionalOutputNames(), os);
+    su::serialize(executorConfig.getAdditionalModelOutputs(), os);
     su::serialize(executorConfig.getGatherGenerationLogits(), os);
 }
 

--- a/cpp/tensorrt_llm/executor/serializeUtils.h
+++ b/cpp/tensorrt_llm/executor/serializeUtils.h
@@ -91,7 +91,7 @@ static_assert(hasSerializedSize<RequestPerfMetrics>(size_t()));
 static_assert(hasSerializedSize<Request>(size_t()));
 static_assert(hasSerializedSize<SamplingConfig>(size_t()));
 static_assert(hasSerializedSize<OutputConfig>(size_t()));
-static_assert(hasSerializedSize<OutputConfig::AdditionalModelOutput>(size_t()));
+static_assert(hasSerializedSize<AdditionalModelOutput>(size_t()));
 static_assert(hasSerializedSize<PromptTuningConfig>(size_t()));
 static_assert(hasSerializedSize<MropeConfig>(size_t()));
 static_assert(hasSerializedSize<LoraConfig>(size_t()));
@@ -187,7 +187,7 @@ static_assert(hasSerialize<RequestPerfMetrics>(nullptr));
 static_assert(hasSerialize<Request>(nullptr));
 static_assert(hasSerialize<SamplingConfig>(nullptr));
 static_assert(hasSerialize<OutputConfig>(nullptr));
-static_assert(hasSerialize<OutputConfig::AdditionalModelOutput>(nullptr));
+static_assert(hasSerialize<AdditionalModelOutput>(nullptr));
 static_assert(hasSerialize<PromptTuningConfig>(nullptr));
 static_assert(hasSerialize<MropeConfig>(nullptr));
 static_assert(hasSerialize<LoraConfig>(nullptr));
@@ -323,7 +323,7 @@ T deserialize(std::istream& is)
     {
         return Serialization::deserializeOutputConfig(is);
     }
-    else if constexpr (std::is_same_v<T, tensorrt_llm::executor::OutputConfig::AdditionalModelOutput>)
+    else if constexpr (std::is_same_v<T, tensorrt_llm::executor::AdditionalModelOutput>)
     {
         return Serialization::deserializeAdditionalModelOutput(is);
     }

--- a/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
@@ -403,7 +403,7 @@ void initBindings(pybind11::module_& m)
             py::arg("context_phase_params") = std::nullopt)
         .def("validate", &tb::LlmRequest::validate, py::arg("max_input_len"), py::arg("max_seq_len"),
             py::arg("max_draft_len"), py::arg("vocab_size_padded"), py::arg("max_endocer_input_len") = std::nullopt,
-            py::arg("enable_kv_cache_reuse") = false, py::arg("gather_context_outputs") = false)
+            py::arg("enable_kv_cache_reuse") = false)
         .def("create_response", &tb::LlmRequest::createResponse, py::arg("use_fast_logits") = false,
             py::arg("mpi_world_rank") = 0)
         .def("move_prompt_embedding_table_to_gpu", &tb::LlmRequest::movePromptEmbeddingTableToGpu, py::arg("manager"))

--- a/cpp/tensorrt_llm/pybind/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/bindings.cpp
@@ -523,8 +523,7 @@ PYBIND11_MODULE(TRTLLM_PYBIND_MODULE, m)
         .def_readwrite("gpu_weights_percent", &tb::TrtGptModelOptionalParams::gpuWeightsPercent)
         .def_readwrite("max_beam_width", &tb::TrtGptModelOptionalParams::maxBeamWidth)
         .def_readwrite("scheduler_config", &tb::TrtGptModelOptionalParams::schedulerConfig)
-        .def(py::pickle(gptModelParamsGetState, gptModelParamsSetState))
-        .def("__eq__", &tb::TrtGptModelOptionalParams::operator==);
+        .def(py::pickle(gptModelParamsGetState, gptModelParamsSetState));
 
     py::class_<tr::MemoryCounters>(m, "MemoryCounters")
         .def_static("instance", &tr::MemoryCounters::getInstance, py::return_value_policy::reference)

--- a/cpp/tensorrt_llm/pybind/executor/executorConfig.cpp
+++ b/cpp/tensorrt_llm/pybind/executor/executorConfig.cpp
@@ -455,7 +455,7 @@ void initConfigBindings(pybind11::module_& m)
             cpp_states[19].cast<uint64_t>(),                                      // MaxSeqIdleMicroseconds
             cpp_states[20].cast<std::optional<tle::SpeculativeDecodingConfig>>(), // SpecDecConfig
             cpp_states[21].cast<std::optional<tle::GuidedDecodingConfig>>(),      // GuidedDecodingConfig
-            cpp_states[22].cast<std::optional<std::vector<tle::AdditionalModelOutput>>>(), // AdditionalOutputNames
+            cpp_states[22].cast<std::optional<std::vector<tle::AdditionalModelOutput>>>(), // AdditionalModelOutputs
             cpp_states[23].cast<bool>(),                                                   // GatherGenerationLogits
             cpp_states[24].cast<bool>()                                                    // UseVariableBeamWidthSearch
         );
@@ -489,7 +489,7 @@ void initConfigBindings(pybind11::module_& m)
                  uint64_t,                                               // MaxSeqIdleMicroseconds
                  std::optional<tle::SpeculativeDecodingConfig>,          // SpecDecConfig
                  std::optional<tle::GuidedDecodingConfig>,               // GuidedDecodingConfig
-                 std::optional<std::vector<tle::AdditionalModelOutput>>, // AdditionalOutputNames
+                 std::optional<std::vector<tle::AdditionalModelOutput>>, // AdditionalModelOutputs
                  bool,                                                   // GatherGenerationLogits
                  bool                                                    // UseVariableBeamWidthSearch
                  >(),
@@ -509,7 +509,7 @@ void initConfigBindings(pybind11::module_& m)
             py::arg("debug_config") = py::none(), py::arg("recv_poll_period_ms") = 0,
             py::arg("max_seq_idle_microseconds") = tle::ExecutorConfig::kDefaultMaxSeqIdleMicroseconds,
             py::arg("spec_dec_config") = py::none(), py::arg("guided_decoding_config") = py::none(),
-            py::arg("additional_output_names") = py::none(), py::arg("gather_generation_logits") = false,
+            py::arg("additional_model_outputs") = py::none(), py::arg("gather_generation_logits") = false,
             py::arg("use_variable_beam_width_search") = false)
         .def_property("max_beam_width", &tle::ExecutorConfig::getMaxBeamWidth, &tle::ExecutorConfig::setMaxBeamWidth)
         .def_property("max_batch_size", &tle::ExecutorConfig::getMaxBatchSize, &tle::ExecutorConfig::setMaxBatchSize)
@@ -552,7 +552,7 @@ void initConfigBindings(pybind11::module_& m)
             &tle::ExecutorConfig::setAdditionalModelOutputs)
         .def_property("gather_generation_logits", &tle::ExecutorConfig::getGatherGenerationLogits,
             &tle::ExecutorConfig::setGatherGenerationLogits)
-        .def_property("gather_generation_logits", &tle::ExecutorConfig::getUseVariableBeamWidthSearch,
+        .def_property("use_variable_beam_width_search", &tle::ExecutorConfig::getUseVariableBeamWidthSearch,
             &tle::ExecutorConfig::setUseVariableBeamWidthSearch)
         .def(py::pickle(executorConfigGetState, executorConfigSetState));
 }

--- a/cpp/tensorrt_llm/pybind/executor/executorConfig.cpp
+++ b/cpp/tensorrt_llm/pybind/executor/executorConfig.cpp
@@ -414,7 +414,7 @@ void initConfigBindings(pybind11::module_& m)
             c.getParallelConfig(), c.getPeftCacheConfig(), c.getLogitsPostProcessorConfig(), c.getDecodingConfig(),
             c.getGpuWeightsPercent(), c.getMaxQueueSize(), c.getExtendedRuntimePerfKnobConfig(), c.getDebugConfig(),
             c.getRecvPollPeriodMs(), c.getMaxSeqIdleMicroseconds(), c.getSpecDecConfig(), c.getGuidedDecodingConfig(),
-            c.getAdditionalOutputNames(), c.getGatherGenerationLogits(), c.getUseVariableBeamWidthSearch());
+            c.getAdditionalModelOutputs(), c.getGatherGenerationLogits(), c.getUseVariableBeamWidthSearch());
         auto pickle_tuple = py::make_tuple(cpp_states, py::getattr(self, "__dict__"));
         return pickle_tuple;
     };
@@ -455,9 +455,9 @@ void initConfigBindings(pybind11::module_& m)
             cpp_states[19].cast<uint64_t>(),                                      // MaxSeqIdleMicroseconds
             cpp_states[20].cast<std::optional<tle::SpeculativeDecodingConfig>>(), // SpecDecConfig
             cpp_states[21].cast<std::optional<tle::GuidedDecodingConfig>>(),      // GuidedDecodingConfig
-            cpp_states[22].cast<std::optional<std::vector<std::string>>>(),       // AdditionalOutputNames
-            cpp_states[23].cast<bool>(),                                          // GatherGenerationLogits
-            cpp_states[24].cast<bool>()                                           // UseVariableBeamWidthSearch
+            cpp_states[22].cast<std::optional<std::vector<tle::AdditionalModelOutput>>>(), // AdditionalOutputNames
+            cpp_states[23].cast<bool>(),                                                   // GatherGenerationLogits
+            cpp_states[24].cast<bool>()                                                    // UseVariableBeamWidthSearch
         );
 
         auto py_state = state[1].cast<py::dict>();
@@ -466,32 +466,32 @@ void initConfigBindings(pybind11::module_& m)
     };
 
     py::class_<tle::ExecutorConfig>(m, "ExecutorConfig", pybind11::dynamic_attr())
-        .def(py::init<                                          //
-                 SizeType32,                                    // MaxBeamWidth
-                 tle::SchedulerConfig const&,                   // SchedulerConfig
-                 tle::KvCacheConfig const&,                     // KvCacheConfig
-                 bool,                                          // EnableChunkedContext
-                 bool,                                          // NormalizeLogProbs
-                 SizeType32,                                    // IterStatsMaxIterations
-                 SizeType32,                                    // RequestStatsMaxIterations
-                 tle::BatchingType,                             // BatchingType
-                 std::optional<SizeType32>,                     // MaxBatchSize
-                 std::optional<SizeType32>,                     // MaxNumTokens
-                 std::optional<tle::ParallelConfig>,            // ParallelConfig
-                 tle::PeftCacheConfig const&,                   // PeftCacheConfig
-                 std::optional<tle::LogitsPostProcessorConfig>, // LogitsPostProcessorConfig
-                 std::optional<tle::DecodingConfig>,            // DecodingConfig
-                 float,                                         // GpuWeightsPercent
-                 std::optional<SizeType32>,                     // MaxQueueSize
-                 tle::ExtendedRuntimePerfKnobConfig const&,     // ExtendedRuntimePerfKnobConfig
-                 std::optional<tle::DebugConfig>,               // DebugConfig
-                 SizeType32,                                    // RecvPollPeriodMs
-                 uint64_t,                                      // MaxSeqIdleMicroseconds
-                 std::optional<tle::SpeculativeDecodingConfig>, // SpecDecConfig
-                 std::optional<tle::GuidedDecodingConfig>,      // GuidedDecodingConfig
-                 std::optional<std::vector<std::string>>,       // AdditionalOutputNames
-                 bool,                                          // GatherGenerationLogits
-                 bool                                           // UseVariableBeamWidthSearch
+        .def(py::init<                                                   //
+                 SizeType32,                                             // MaxBeamWidth
+                 tle::SchedulerConfig const&,                            // SchedulerConfig
+                 tle::KvCacheConfig const&,                              // KvCacheConfig
+                 bool,                                                   // EnableChunkedContext
+                 bool,                                                   // NormalizeLogProbs
+                 SizeType32,                                             // IterStatsMaxIterations
+                 SizeType32,                                             // RequestStatsMaxIterations
+                 tle::BatchingType,                                      // BatchingType
+                 std::optional<SizeType32>,                              // MaxBatchSize
+                 std::optional<SizeType32>,                              // MaxNumTokens
+                 std::optional<tle::ParallelConfig>,                     // ParallelConfig
+                 tle::PeftCacheConfig const&,                            // PeftCacheConfig
+                 std::optional<tle::LogitsPostProcessorConfig>,          // LogitsPostProcessorConfig
+                 std::optional<tle::DecodingConfig>,                     // DecodingConfig
+                 float,                                                  // GpuWeightsPercent
+                 std::optional<SizeType32>,                              // MaxQueueSize
+                 tle::ExtendedRuntimePerfKnobConfig const&,              // ExtendedRuntimePerfKnobConfig
+                 std::optional<tle::DebugConfig>,                        // DebugConfig
+                 SizeType32,                                             // RecvPollPeriodMs
+                 uint64_t,                                               // MaxSeqIdleMicroseconds
+                 std::optional<tle::SpeculativeDecodingConfig>,          // SpecDecConfig
+                 std::optional<tle::GuidedDecodingConfig>,               // GuidedDecodingConfig
+                 std::optional<std::vector<tle::AdditionalModelOutput>>, // AdditionalOutputNames
+                 bool,                                                   // GatherGenerationLogits
+                 bool                                                    // UseVariableBeamWidthSearch
                  >(),
             py::arg("max_beam_width") = 1, py::arg_v("scheduler_config", tle::SchedulerConfig(), "SchedulerConfig()"),
             py::arg_v("kv_cache_config", tle::KvCacheConfig(), "KvCacheConfig()"),
@@ -548,8 +548,8 @@ void initConfigBindings(pybind11::module_& m)
         .def_property("spec_dec_config", &tle::ExecutorConfig::getSpecDecConfig, &tle::ExecutorConfig::setSpecDecConfig)
         .def_property("guided_decoding_config", &tle::ExecutorConfig::getGuidedDecodingConfig,
             &tle::ExecutorConfig::setGuidedDecodingConfig)
-        .def_property("additional_output_names", &tle::ExecutorConfig::getAdditionalOutputNames,
-            &tle::ExecutorConfig::setAdditionalOutputNames)
+        .def_property("additional_model_outputs", &tle::ExecutorConfig::getAdditionalModelOutputs,
+            &tle::ExecutorConfig::setAdditionalModelOutputs)
         .def_property("gather_generation_logits", &tle::ExecutorConfig::getGatherGenerationLogits,
             &tle::ExecutorConfig::setGatherGenerationLogits)
         .def_property("gather_generation_logits", &tle::ExecutorConfig::getUseVariableBeamWidthSearch,

--- a/cpp/tensorrt_llm/pybind/executor/request.cpp
+++ b/cpp/tensorrt_llm/pybind/executor/request.cpp
@@ -178,20 +178,20 @@ void initRequestBindings(pybind11::module_& m)
             "beam_width_array", &tle::SamplingConfig::getBeamWidthArray, &tle::SamplingConfig::setBeamWidthArray)
         .def(py::pickle(samplingConfigGetstate, samplingConfigSetstate));
 
-    auto additionalModelOutputGetstate = [](tle::OutputConfig::AdditionalModelOutput const& self)
-    { return py::make_tuple(self.name, self.gatherContext); };
+    auto additionalModelOutputGetstate
+        = [](tle::AdditionalModelOutput const& self) { return py::make_tuple(self.name, self.gatherContext); };
     auto additionalModelOutputSetstate = [](py::tuple const& state)
     {
         if (state.size() != 2)
         {
             throw std::runtime_error("Invalid AdditionalModelOutput state!");
         }
-        return tle::OutputConfig::AdditionalModelOutput(state[0].cast<std::string>(), state[1].cast<bool>());
+        return tle::AdditionalModelOutput(state[0].cast<std::string>(), state[1].cast<bool>());
     };
-    py::class_<tle::OutputConfig::AdditionalModelOutput>(m, "AdditionalModelOutput")
+    py::class_<tle::AdditionalModelOutput>(m, "AdditionalModelOutput")
         .def(py::init<std::string, bool>(), py::arg("name"), py::arg("gather_context") = false)
-        .def_readwrite("name", &tle::OutputConfig::AdditionalModelOutput::name)
-        .def_readwrite("gather_context", &tle::OutputConfig::AdditionalModelOutput::gatherContext)
+        .def_readwrite("name", &tle::AdditionalModelOutput::name)
+        .def_readwrite("gather_context", &tle::AdditionalModelOutput::gatherContext)
         .def(py::pickle(additionalModelOutputGetstate, additionalModelOutputSetstate));
 
     auto outputConfigGetstate = [](tle::OutputConfig const& self)
@@ -207,11 +207,10 @@ void initRequestBindings(pybind11::module_& m)
         }
         return tle::OutputConfig(state[0].cast<bool>(), state[1].cast<bool>(), state[2].cast<bool>(),
             state[3].cast<bool>(), state[4].cast<bool>(), state[5].cast<bool>(),
-            state[6].cast<std::optional<std::vector<tle::OutputConfig::AdditionalModelOutput>>>());
+            state[6].cast<std::optional<std::vector<tle::AdditionalModelOutput>>>());
     };
     py::class_<tle::OutputConfig>(m, "OutputConfig")
-        .def(py::init<bool, bool, bool, bool, bool, bool,
-                 std::optional<std::vector<tle::OutputConfig::AdditionalModelOutput>>>(),
+        .def(py::init<bool, bool, bool, bool, bool, bool, std::optional<std::vector<tle::AdditionalModelOutput>>>(),
             py::arg("return_log_probs") = false, py::arg("return_context_logits") = false,
             py::arg("return_generation_logits") = false, py::arg("exclude_input_from_output") = false,
             py::arg("return_encoder_output") = false, py::arg("return_perf_metrics") = false,

--- a/cpp/tests/batch_manager/trtGptModelRealDecoderTest.cpp
+++ b/cpp/tests/batch_manager/trtGptModelRealDecoderTest.cpp
@@ -556,8 +556,7 @@ RequestList runGptModelInference(std::shared_ptr<TrtGptModel>& trtGptModel, std:
                     = trtGptModel->getModelConfig().getSpeculativeDecodingModulePtr()->getMaxDecodingDraftTokens();
             }
             r->validate(trtGptModel->getMaxInputLen(), trtGptModel->getMaxSequenceLen(), maxDraftTokens,
-                trtGptModel->getVocabSizePadded(), std::nullopt, enableBlockReuse,
-                trtGptModel->getModelConfig().computeContextLogits());
+                trtGptModel->getVocabSizePadded(), std::nullopt, enableBlockReuse);
 
             if (enableStreamingMode)
             {

--- a/cpp/tests/unit_tests/batch_manager/llmRequestTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/llmRequestTest.cpp
@@ -300,7 +300,7 @@ TEST_F(LlmRequestTest, invalidExecRequest)
         llmReq.validate(500, 1000, 1, 32000, std::nullopt, true);
     }
     {
-        using AdditionalModelOutput = texec::OutputConfig::AdditionalModelOutput;
+        using AdditionalModelOutput = texec::AdditionalModelOutput;
         // Validate additional context and gen outputs
         texec::Request execReq(inputTokens, maxNewTokens);
         std::vector<AdditionalModelOutput> additionalModelOutputs{
@@ -318,7 +318,7 @@ TEST_F(LlmRequestTest, invalidExecRequest)
         EXPECT_EQ(additionalGenerationOutputs.count("gen_output"), 1);
     }
     {
-        using AdditionalModelOutput = texec::OutputConfig::AdditionalModelOutput;
+        using AdditionalModelOutput = texec::AdditionalModelOutput;
         // Validate additional context and gen outputs when context outputs not available
         texec::Request execReq(inputTokens, maxNewTokens);
         std::vector<AdditionalModelOutput> additionalModelOutputs{

--- a/cpp/tests/unit_tests/batch_manager/llmRequestTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/llmRequestTest.cpp
@@ -309,7 +309,7 @@ TEST_F(LlmRequestTest, invalidExecRequest)
         outputConfig.additionalModelOutputs = additionalModelOutputs;
         execReq.setOutputConfig(outputConfig);
         tb::LlmRequest llmReq(requestId, execReq);
-        llmReq.validate(10, 60, 2, 32000, std::nullopt, false, true);
+        llmReq.validate(10, 60, 2, 32000, std::nullopt, false);
         auto const& additionalContextOutputs = llmReq.getAdditionalContextOutputs();
         EXPECT_EQ(additionalContextOutputs.count("context_gen_output"), 1);
         EXPECT_EQ(additionalContextOutputs.count("gen_output"), 0);
@@ -327,7 +327,7 @@ TEST_F(LlmRequestTest, invalidExecRequest)
         outputConfig.additionalModelOutputs = additionalModelOutputs;
         execReq.setOutputConfig(outputConfig);
         tb::LlmRequest llmReq(requestId, execReq);
-        llmReq.validate(10, 60, 2, 32000, std::nullopt, false, false);
+        llmReq.validate(10, 60, 2, 32000, std::nullopt, false);
         auto const& additionalContextOutputs = llmReq.getAdditionalContextOutputs();
         EXPECT_EQ(additionalContextOutputs.count("context_gen_output"), 0);
         EXPECT_EQ(additionalContextOutputs.count("gen_output"), 0);

--- a/cpp/tests/unit_tests/batch_manager/llmRequestTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/llmRequestTest.cpp
@@ -317,24 +317,6 @@ TEST_F(LlmRequestTest, invalidExecRequest)
         EXPECT_EQ(additionalGenerationOutputs.count("context_gen_output"), 1);
         EXPECT_EQ(additionalGenerationOutputs.count("gen_output"), 1);
     }
-    {
-        using AdditionalModelOutput = texec::AdditionalModelOutput;
-        // Validate additional context and gen outputs when context outputs not available
-        texec::Request execReq(inputTokens, maxNewTokens);
-        std::vector<AdditionalModelOutput> additionalModelOutputs{
-            AdditionalModelOutput{"context_gen_output", true}, AdditionalModelOutput{"gen_output", false}};
-        texec::OutputConfig outputConfig;
-        outputConfig.additionalModelOutputs = additionalModelOutputs;
-        execReq.setOutputConfig(outputConfig);
-        tb::LlmRequest llmReq(requestId, execReq);
-        llmReq.validate(10, 60, 2, 32000, std::nullopt, false);
-        auto const& additionalContextOutputs = llmReq.getAdditionalContextOutputs();
-        EXPECT_EQ(additionalContextOutputs.count("context_gen_output"), 0);
-        EXPECT_EQ(additionalContextOutputs.count("gen_output"), 0);
-        auto const& additionalGenerationOutputs = llmReq.getAdditionalGenerationOutputs();
-        EXPECT_EQ(additionalGenerationOutputs.count("context_gen_output"), 1);
-        EXPECT_EQ(additionalGenerationOutputs.count("gen_output"), 1);
-    }
 }
 
 TEST_F(LlmRequestTest, pause)

--- a/cpp/tests/unit_tests/executor/executorTestSmall.cpp
+++ b/cpp/tests/unit_tests/executor/executorTestSmall.cpp
@@ -71,7 +71,7 @@ std::unique_ptr<DecoderTestShared<TLogits>> SetupDecoderTest(TrivialConstantDeco
     auto randomLogits = tensorrt_llm::testing::randomLogits<std::mt19937, TLogits>(params.vocabSize, &rng);
     auto const decoderParameters = tensorrt_llm::testing::utils::engines::ConstantTrivialDecoderParameters<TLogits>{
         tensorrt_llm::testing::utils::engines::TrivialDecoderParameters{params.vocabSize, params.maxBatchSize,
-            params.maxNumTokens, DecoderTestShared<TLogits>::kNumTokensPerBlock, params.maxBeamWidth},
+            params.maxNumTokens, DecoderTestShared<TLogits>::kNumTokensPerBlock, params.maxBeamWidth, false},
         randomLogits};
     auto engineHostMemory
         = tensorrt_llm::testing::utils::engines::createConstantTrivialDecoder<TLogits>(decoderParameters, logger);

--- a/cpp/tests/unit_tests/executor/executorTestSmallArbitraryOutputTensors.cpp
+++ b/cpp/tests/unit_tests/executor/executorTestSmallArbitraryOutputTensors.cpp
@@ -121,7 +121,8 @@ std::unique_ptr<DecoderTestShared<TLogits>> SetupDecoderTest(
             executor::BatchingType::kINFLIGHT, params.maxBatchSize, params.maxNumTokens, std::nullopt, std::nullopt,
             std::nullopt, std::nullopt, 1, std::nullopt, executor::ExtendedRuntimePerfKnobConfig(), std::nullopt, 0,
             executor::ExecutorConfig::kDefaultMaxSeqIdleMicroseconds, std::nullopt, std::nullopt,
-            std::vector<std::string>{DecoderTestShared<TLogits>::kTopKTensorName});
+            std::vector<executor::AdditionalModelOutput>{
+                executor::AdditionalModelOutput{DecoderTestShared<TLogits>::kTopKTensorName}});
 
     auto optionalParams = batch_manager::TrtGptModelOptionalParams{executorConfig, false};
     auto model = std::make_shared<batch_manager::TrtGptModelInflightBatching>(
@@ -152,8 +153,8 @@ protected:
         requests.reserve(static_cast<std::size_t>(parameters.numRequests));
         for (auto i = 0; i < parameters.numRequests; i++)
         {
-            std::vector<executor::OutputConfig::AdditionalModelOutput> additionalOutputs{
-                executor::OutputConfig::AdditionalModelOutput{DecoderTestShared<TLogits>::kTopKTensorName}};
+            std::vector<executor::AdditionalModelOutput> additionalOutputs{
+                executor::AdditionalModelOutput{DecoderTestShared<TLogits>::kTopKTensorName}};
             requests.emplace_back(requestTokens, parameters.maxOutputLength, false, executor::SamplingConfig{},
                 executor::OutputConfig{false, false, false, true, false, false, additionalOutputs});
         }
@@ -212,8 +213,8 @@ protected:
         requests.reserve(static_cast<std::size_t>(parameters.numRequests));
         for (auto i = 0; i < parameters.numRequests; i++)
         {
-            std::vector<executor::OutputConfig::AdditionalModelOutput> additionalOutputs{
-                executor::OutputConfig::AdditionalModelOutput{DecoderTestShared<TLogits>::kTopKTensorName}};
+            std::vector<executor::AdditionalModelOutput> additionalOutputs{
+                executor::AdditionalModelOutput{DecoderTestShared<TLogits>::kTopKTensorName}};
             requests.emplace_back(requestTokens, parameters.maxOutputLength, true, executor::SamplingConfig{},
                 executor::OutputConfig{false, false, false, true, false, false, additionalOutputs});
         }
@@ -276,8 +277,8 @@ protected:
         {
             // create different sequence for each request to avoid KV cache reuse
             auto const requestTokens = createConsecutiveTokenSequence(parameters.promptLength, parameters.vocabSize, i);
-            std::vector<executor::OutputConfig::AdditionalModelOutput> additionalOutputs{
-                executor::OutputConfig::AdditionalModelOutput{DecoderTestShared<TLogits>::kTopKTensorName, true}};
+            std::vector<executor::AdditionalModelOutput> additionalOutputs{
+                executor::AdditionalModelOutput{DecoderTestShared<TLogits>::kTopKTensorName, true}};
             requests.emplace_back(requestTokens, parameters.maxOutputLength, true, executor::SamplingConfig{},
                 executor::OutputConfig{false, false, false, true, false, false, additionalOutputs});
         }
@@ -344,8 +345,8 @@ protected:
         {
             // create different sequence for each request to avoid KV cache reuse
             auto const requestTokens = createConsecutiveTokenSequence(parameters.promptLength, parameters.vocabSize, i);
-            std::vector<executor::OutputConfig::AdditionalModelOutput> additionalOutputs{
-                executor::OutputConfig::AdditionalModelOutput{DecoderTestShared<TLogits>::kTopKTensorName, true}};
+            std::vector<executor::AdditionalModelOutput> additionalOutputs{
+                executor::AdditionalModelOutput{DecoderTestShared<TLogits>::kTopKTensorName, true}};
             requests.emplace_back(requestTokens, parameters.maxOutputLength, false, executor::SamplingConfig{},
                 executor::OutputConfig{false, false, false, true, false, false, additionalOutputs});
         }

--- a/cpp/tests/utils/engines.cpp
+++ b/cpp/tests/utils/engines.cpp
@@ -25,6 +25,22 @@ nvinfer1::ITensor& tensorrt_llm::testing::utils::engines::details::addInputIds(
     return *input_ids;
 }
 
+nvinfer1::ITensor* tensorrt_llm::testing::utils::engines::details::addLastTokenIds(
+    EngineBuildState& buildState, runtime::SizeType32 maxBatchSize, runtime::SizeType32 maxBeamWidth)
+{
+    auto* last_token_ids
+        = buildState.networkDefinition->addInput(batch_manager::RuntimeBuffers::kLastTokenIdsTensorName,
+            nvinfer1::DataType::kINT32, runtime::ITensor::makeShape({-1}));
+    buildState.tensors.push_back(last_token_ids);
+    buildState.profile->setDimensions(batch_manager::RuntimeBuffers::kLastTokenIdsTensorName,
+        nvinfer1::OptProfileSelector::kMAX, runtime::ITensor::makeShape({maxBatchSize * maxBeamWidth}));
+    buildState.profile->setDimensions(batch_manager::RuntimeBuffers::kLastTokenIdsTensorName,
+        nvinfer1::OptProfileSelector::kOPT, runtime::ITensor::makeShape({maxBatchSize * maxBeamWidth / 2}));
+    buildState.profile->setDimensions(batch_manager::RuntimeBuffers::kLastTokenIdsTensorName,
+        nvinfer1::OptProfileSelector::kMIN, runtime::ITensor::makeShape({1}));
+    return last_token_ids;
+}
+
 nvinfer1::ITensor& tensorrt_llm::testing::utils::engines::details::addKvCacheOffsets(EngineBuildState& buildState,
     runtime::SizeType32 numPools, runtime::SizeType32 tokensPerBlock, runtime::SizeType32 maxBatchSize,
     runtime::SizeType32 maxNumTokens, runtime::SizeType32 maxBeamWidth)

--- a/docs/source/advanced/executor.md
+++ b/docs/source/advanced/executor.md
@@ -113,18 +113,17 @@ Assuming the TensorRT engine you are planning to use has a tensor named `TopKLog
 ```cpp
 auto const executorConfig = ExecutorConfig{};
 
+std::vector<executor::AdditionalModelOutput> additionalOutputs{
+    executor::AdditionalModelOutput{"TopKLogits", /*whether or not to get the output for the context too */ true}};
+executorConfig.setAdditionalModelOutputs(additionalOutputs);
+
 // ... set more configuration options if needed
-
-executorConfig.setAdditionalOutputNames(std::vector<std::string>{"TopKLogits"});
-
 // ... create the `Executor` instance
 ```
 
 ### Request Additional Output
 Construct a request to enqueue in the executor to query this tensor output:
 ```cpp
-std::vector<executor::OutputConfig::AdditionalModelOutput> additionalOutputs{
-    executor::OutputConfig::AdditionalModelOutput{"TopKLogits", /*whether or not to get the output for the context too */ true}};
 executor::Request request{requestTokens, parameters.maxOutputLength, true, executor::SamplingConfig{},
     executor::OutputConfig{false, false, false, true, false, false, additionalOutputs}};
 executor.enqueueRequest(request);
@@ -134,7 +133,7 @@ The output can be found at the `additionalOutputs` property of each response.
 
 #### Note on context outputs
 
-Note that context outputs require to build the engine with `--gather_context_logits`. If KV cache reuse is enabled, context outputs will not contain outputs for the part of the context that has been reused. This part of the outputs can only be obtained from the prior request with the same prefix that generated this part of the KV cache.
+If KV cache reuse is enabled, context outputs will not contain outputs for the part of the context that has been reused. This part of the outputs can only be obtained from the prior request with the same prefix that generated this part of the KV cache.
 
 ## C++ Executor API Example
 

--- a/tests/unittest/bindings/test_bindings_ut.py
+++ b/tests/unittest/bindings/test_bindings_ut.py
@@ -472,20 +472,26 @@ def test_KvCacheConfig_pickle():
 
 
 def test_TrtGptModelOptionalParams_pickle():
-    cache = _tb.KvCacheConfig(free_gpu_memory_fraction=0.4)
-    params1 = _tb.TrtGptModelOptionalParams(
-        kv_cache_config=cache,
-        enable_trt_overlap=True,
-    )
-    params1.enable_chunked_context = True
+    kv_cache_config = _tb.KvCacheConfig(10, [10], 0, 0.5, False)
+    enable_trt_overlap = True
+    device_ids = [0, 1]
+    normalize_log_probs = False
+    enable_chunked_context = True
+    peft_cache_manager_config = _tb.PeftCacheManagerConfig()
+
+    params1 = _tb.TrtGptModelOptionalParams(kv_cache_config, enable_trt_overlap,
+                                            device_ids, normalize_log_probs,
+                                            enable_chunked_context,
+                                            peft_cache_manager_config)
+
     params2 = pickle.loads(pickle.dumps(params1))
 
-    assert params2 == params1
-
-    params1 = _tb.TrtGptModelOptionalParams()
-    params2 = pickle.loads(pickle.dumps(params1))
-
-    assert params2 == params1
+    assert params2.kv_cache_config.free_gpu_memory_fraction == kv_cache_config.free_gpu_memory_fraction
+    assert params2.enable_trt_overlap
+    assert params2.device_ids == device_ids
+    assert params2.normalize_log_probs == normalize_log_probs
+    assert params2.enable_chunked_context == enable_chunked_context
+    assert params2.gpu_weights_percent == 1
 
 
 def test_Mpicomm():

--- a/tests/unittest/bindings/test_executor_bindings.py
+++ b/tests/unittest/bindings/test_executor_bindings.py
@@ -1523,6 +1523,9 @@ def test_executor_config():
     assert config.max_seq_idle_microseconds == 180000000
     assert config.spec_dec_config is None
     assert config.guided_decoding_config is None
+    assert config.additional_model_outputs is None
+    assert config.gather_generation_logits is False
+    assert config.use_variable_beam_width_search is False
 
     kwargs = {
         "max_beam_width":
@@ -1567,27 +1570,35 @@ def test_executor_config():
         trtllm.GuidedDecodingConfig(
             trtllm.GuidedDecodingConfig.GuidedDecodingBackend.XGRAMMAR,
             encoded_vocab=["eos", "a", "b", "c", "d"]),
-        "additional_output_names": ["topKLogits"]
+        "additional_model_outputs":
+        [trtllm.AdditionalModelOutput("topKLogits")],
+        "gather_generation_logits":
+        True,
+        "use_variable_beam_width_search":
+        True
     }
     config = trtllm.ExecutorConfig(**kwargs)
     for k, v in kwargs.items():
-        if "config" not in k:
+        if "config" not in k and k != "additional_model_outputs":
             assert getattr(config, k) == v
     assert isinstance(config.scheduler_config, trtllm.SchedulerConfig)
     assert config.scheduler_config.capacity_scheduler_policy == trtllm.CapacitySchedulerPolicy.MAX_UTILIZATION
     assert isinstance(config.kv_cache_config, trtllm.KvCacheConfig)
     assert isinstance(config.parallel_config, trtllm.ParallelConfig)
     assert isinstance(config.peft_cache_config, trtllm.PeftCacheConfig)
-    assert config.extended_runtime_perf_knob_config.multi_block_mode == True
+    assert config.extended_runtime_perf_knob_config.multi_block_mode is True
     assert isinstance(config.debug_config, trtllm.DebugConfig)
     assert isinstance(config.logits_post_processor_config,
                       trtllm.LogitsPostProcessorConfig)
     assert isinstance(config.spec_dec_config, trtllm.SpeculativeDecodingConfig)
     assert isinstance(config.guided_decoding_config,
                       trtllm.GuidedDecodingConfig)
-    assert isinstance(config.additional_output_names, list)
-    assert len(config.additional_output_names) == 1
-    assert config.additional_output_names[0] == "topKLogits"
+    assert isinstance(config.additional_model_outputs, list)
+    assert len(config.additional_model_outputs) == 1
+    assert config.additional_model_outputs[0].name == "topKLogits"
+    assert config.additional_model_outputs[0].gather_context is False
+    assert config.gather_generation_logits is True
+    assert config.use_variable_beam_width_search is True
 
 
 def test_parallel_config():


### PR DESCRIPTION
Summary: 
* Add support for a gatherContext flag for each additional output in ExecutorConfig.
* Enhance copyAdditionalOutputs function to work with AdditionalModelOutput.
* Add validation for final indices of additional output tensors.
* Update unit tests to verify the changes.
  * Cover the new gatherContext parameter.
  * Add lastTokenIds input tensor to test engines.
  * Make logits output dependent on gatherContextLogits parameter.