### PR TITLE
Fix failing DSV3 unit tests

### DIFF
--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_patches.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_patches.py
@@ -72,9 +72,7 @@ def _generate_ds_attention_mask(b, s):
                 _generate_ds_attention_mask(2, 6),
                 torch.tensor([[0, 1, 2, 3, 4, 5]]),
             ],
-            marks_extra=[
-                pytest.mark.skip(reason="TODO: Debug CI pipeline failing"),
-            ],
+            marks=pytest.mark.skip(reason="TODO: Debug CI pipeline failing"),
         ),  # attention requires  inputs [hidden_states, attention_mask, position_ids]
         pytest.param(
             "deepseek-ai/DeepSeek-V3",
@@ -82,9 +80,7 @@ def _generate_ds_attention_mask(b, s):
             deepseek_v3_moe_exact,
             False,
             [torch.randn(2, 6, 7168)],
-            marks_extra=[
-                pytest.mark.skip(reason="TODO: Debug CI pipeline failing"),
-            ],
+            marks=pytest.mark.skip(reason="TODO: Debug CI pipeline failing"),
         ),  # moe requires  inputs [hidden_states]
     ],
 )

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_patches.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_patches.py
@@ -62,7 +62,7 @@ def _generate_ds_attention_mask(b, s):
 @pytest.mark.parametrize(
     "model_name, module_name, patch, yarn, inputs",
     [
-        (
+        pytest.param(
             "deepseek-ai/DeepSeek-V3",
             "layers.0.self_attn",
             deepseek_v3_attention,
@@ -72,13 +72,19 @@ def _generate_ds_attention_mask(b, s):
                 _generate_ds_attention_mask(2, 6),
                 torch.tensor([[0, 1, 2, 3, 4, 5]]),
             ],
+            marks_extra=[
+                pytest.mark.skip(reason="TODO: Debug CI pipeline failing"),
+            ],
         ),  # attention requires  inputs [hidden_states, attention_mask, position_ids]
-        (
+        pytest.param(
             "deepseek-ai/DeepSeek-V3",
             "layers.0.mlp",
             deepseek_v3_moe_exact,
             False,
             [torch.randn(2, 6, 7168)],
+            marks_extra=[
+                pytest.mark.skip(reason="TODO: Debug CI pipeline failing"),
+            ],
         ),  # moe requires  inputs [hidden_states]
     ],
 )

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_patches.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_patches.py
@@ -68,19 +68,17 @@ def _generate_ds_attention_mask(b, s):
             deepseek_v3_attention,
             False,
             [
-                torch.randn(2, 6, 7168),
+                torch.randn(2, 6, 7168, dtype=torch.bfloat16),
                 _generate_ds_attention_mask(2, 6),
                 torch.tensor([[0, 1, 2, 3, 4, 5]]),
             ],
-            marks=pytest.mark.skip(reason="TODO: Debug CI pipeline failing"),
         ),  # attention requires  inputs [hidden_states, attention_mask, position_ids]
         pytest.param(
             "deepseek-ai/DeepSeek-V3",
             "layers.0.mlp",
             deepseek_v3_moe_exact,
             False,
-            [torch.randn(2, 6, 7168)],
-            marks=pytest.mark.skip(reason="TODO: Debug CI pipeline failing"),
+            [torch.randn(2, 6, 7168, dtype=torch.bfloat16)],
         ),  # moe requires  inputs [hidden_states]
     ],
 )


### PR DESCRIPTION
Skipping DSV3 unit tests that are causing CI pipeline to fail