### PR TITLE
feat: Support Top-K logprobs and prompt_logprobs in LLMAPI

### DIFF
--- a/cpp/tensorrt_llm/pybind/executor/request.cpp
+++ b/cpp/tensorrt_llm/pybind/executor/request.cpp
@@ -770,6 +770,24 @@ void initRequestBindings(pybind11::module_& m)
         .def("has_error", &tle::Response::hasError)
         .def_property_readonly("error_msg", &tle::Response::getErrorMsg)
         .def_property_readonly("result", &tle::Response::getResult)
+        .def("clear_context_logits",
+            [](tle::Response& self)
+            {
+                if (!self.hasError())
+                {
+                    auto& result = const_cast<tle::Result&>(self.getResult());
+                    result.contextLogits.reset();
+                }
+            })
+        .def("clear_generation_logits",
+            [](tle::Response& self)
+            {
+                if (!self.hasError())
+                {
+                    auto& result = const_cast<tle::Result&>(self.getResult());
+                    result.generationLogits.reset();
+                }
+            })
         .def(py::pickle(responseGetstate, responseSetstate));
 }
 

--- a/tensorrt_llm/executor/executor.py
+++ b/tensorrt_llm/executor/executor.py
@@ -26,7 +26,8 @@ from ..llmapi.mpi_session import (MpiSession, external_mpi_comm_available,
 from ..llmapi.utils import (AsyncQueue, enable_llm_debug,
                             enable_worker_single_process_for_tp1, print_colored,
                             print_colored_debug)
-from ..sampling_params import BatchedLogitsProcessor, SamplingParams
+from ..sampling_params import (BatchedLogitsProcessor, LogprobParams,
+                               SamplingParams)
 from .ipc import FusedIpcQueue
 from .postproc_worker import PostprocParams, PostprocWorkerConfig
 from .request import GenerationRequest, LoRARequest, PromptAdapterRequest
@@ -203,6 +204,24 @@ class GenerationExecutor(ABC):
         # (self._last_client_id + 1) % UINT64_MAX
         self._last_client_id = (self._last_client_id + 1) & ((1 << 64) - 1)
         return self._last_client_id
+
+    def _get_logprob_params(
+            self, request: GenerationRequest) -> Optional[LogprobParams]:
+        """Store logprobs-related fields from request for the later logprob calculation."""
+        logprob_params = None
+        if request.sampling_params.logprobs or request.sampling_params.prompt_logprobs:
+            logprob_params = LogprobParams(
+                logprobs=request.sampling_params.logprobs,
+                prompt_logprobs=request.sampling_params.prompt_logprobs,
+                # drop logits if users didn't explicitly ask for it, or if it's using PostProcess flow
+                drop_context_logits=(
+                    not request.sampling_params._need_return_context_logits)
+                or self.postproc_config.num_postprocess_workers > 0,
+                drop_generation_logits=(
+                    not request.sampling_params._need_return_generation_logits)
+                or self.postproc_config.num_postprocess_workers > 0)
+
+        return logprob_params
 
     def _maybe_initialize_iteration_results(self):
         if self._is_llm_executor:

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -394,12 +394,14 @@ class ExecutorBindingsProxy(GenerationExecutor):
         self._start_dispatch_threads()
 
         request.set_id(self._get_next_client_id())
+        logprob_params = self._get_logprob_params(request)
 
         result = GenerationResult(
             request,
             background_error_handler=self._handle_background_error,
             executor=self,
-            disaggregated_params=request.disaggregated_params)
+            disaggregated_params=request.disaggregated_params,
+            logprob_params=logprob_params)
         self._results[request.id] = result
 
         self.request_queue.put(request)

--- a/tensorrt_llm/executor/result.py
+++ b/tensorrt_llm/executor/result.py
@@ -3,17 +3,19 @@ import json
 import weakref
 from dataclasses import dataclass, field
 from queue import Empty, Queue
-from typing import TYPE_CHECKING, Any, Callable, List, Literal, Optional, Union
+from typing import (TYPE_CHECKING, Any, Callable, List, Literal, NamedTuple,
+                    Optional, TypeAlias, Union)
 from weakref import WeakMethod
 
 import torch
+import torch.nn.functional as F
 
 from .._utils import nvtx_range_debug
 from ..bindings import executor as tllm
 from ..disaggregated_params import DisaggregatedParams
 from ..llmapi.tracer import global_tracer
 from ..llmapi.utils import AsyncQueue
-from ..sampling_params import SamplingParams
+from ..sampling_params import LogprobParams, SamplingParams
 from .utils import ErrorResponse, has_event_loop, is_llm_response
 
 if TYPE_CHECKING:
@@ -31,15 +33,48 @@ __all__ = [
 
 
 @dataclass(slots=True)
+class Logprob:
+    """Holds logprob and vocab rank for a token."""
+    logprob: float
+    rank: Optional[int] = None
+
+
+# List of token_id_to_Logprob dict for prompt or generation texts
+TokenLogprobs: TypeAlias = list[dict[int, Logprob]]
+
+
+class LogProbsResult(NamedTuple):
+    """Optional log probability outputs computed post runtime."""
+    prompt: Optional[TokenLogprobs] = None
+    generation: Optional[TokenLogprobs] = None
+
+
+class ResponseWrapper:
+    """Wrapper of runtime response with optional outputs computed post runtime.
+    """
+
+    def __init__(self,
+                 response: Union["PostprocWorker.Output", tllm.Response],
+                 logprobs: Optional[LogProbsResult] = None):
+        self._response = response
+        self.logprobs = logprobs
+
+    def __getattr__(self, name):
+        response = object.__getattribute__(self, '_response')
+        return getattr(response, name)
+
+
+@dataclass(slots=True)
 class CompletionOutput:
     """The output data of one completion output of a request.
 
     Args:
         index (int): The index of the output in the request.
         text (str): The generated output text. Defaults to "".
-        token_ids (List[int], optional): The token ids of the generated output text. Defaults to None.
+        token_ids (List[int], optional): The token ids of the generated output text. Defaults to [].
         cumulative_logprob (float, optional): The cumulative log probability of the generated output text. Defaults to None.
-        logprobs (List[float], optional): The log probabilities of the top probability words at each position if the logprobs are requested. Defaults to None.
+        logprobs (TokenLogprobs, optional): The log probabilities of the top probability words at each position if the logprobs are requested. Defaults to None.
+        prompt_logprobs (TokenLogprobs, optional): The log probabilities per prompt token. Defaults to None.
         finish_reason (Literal['stop', 'length', 'timeout', 'cancelled'], optional): The reason why the sequence is finished. Defaults to None.
         stop_reason (int, str, optional): The stop string or token id that caused the completion to stop, None if the completion finished for some other reason. Defaults to None.
         generation_logits (torch.Tensor, optional): The logits on the generated output token ids. Defaults to None.
@@ -53,9 +88,10 @@ class CompletionOutput:
     """
     index: int
     text: str = ""
-    token_ids: Optional[List[int]] = None
+    token_ids: Optional[List[int]] = field(default_factory=list)
     cumulative_logprob: Optional[float] = None
-    logprobs: Optional[List[float]] = None
+    logprobs: Optional[TokenLogprobs] = field(default_factory=list)
+    prompt_logprobs: Optional[TokenLogprobs] = field(default_factory=list)
     finish_reason: Optional[Literal['stop', 'length', 'timeout',
                                     'cancelled']] = None
     stop_reason: Optional[Union[int, str]] = None
@@ -71,12 +107,6 @@ class CompletionOutput:
                                                 repr=False)
     # the result of result_handler passed to postprocess workers
     _postprocess_result: Any = None
-
-    def __post_init__(self):
-        if self.token_ids is None:
-            self.token_ids = []
-        if self.logprobs is None:
-            self.logprobs = []
 
     @property
     def length(self) -> int:
@@ -160,8 +190,11 @@ class GenerationResultBase:
     def context_logits(self) -> Optional[torch.Tensor]:
         return self._context_logits
 
-    def _handle_sequence(self, finish_reasons, response_tensors,
-                         sequence_index):
+    def _handle_sequence(self,
+                         finish_reasons,
+                         response_tensors,
+                         sequence_index,
+                         logprobs_result=None):
         """ Handle a single sequence in the response. """
 
         seq_idx = sequence_index
@@ -182,6 +215,11 @@ class GenerationResultBase:
 
         if response_tensors.cum_log_probs is not None:
             output.cumulative_logprob = response_tensors.cum_log_probs[src_idx]
+
+        if logprobs_result:
+            output.prompt_logprobs = logprobs_result.prompt
+            output.logprobs = logprobs_result.generation
+
         if response_tensors.log_probs is not None:
             output._last_logprobs_len = len(output.logprobs)
             output.logprobs = response_tensors.log_probs[src_idx]
@@ -223,8 +261,14 @@ class GenerationResultBase:
     @nvtx_range_debug("handle_response",
                       color="red",
                       category="GenerationResultBase")
-    def _handle_response(self, response: Union["PostprocWorker.Output",
-                                               tllm.Response, ErrorResponse]):
+    def _handle_response(self,
+                         response: Union["PostprocWorker.Output", tllm.Response,
+                                         ResponseWrapper, ErrorResponse]):
+        if isinstance(response, ResponseWrapper):
+            logprobs_result = response.logprobs
+            response = response._response
+        else:
+            logprobs_result = None
 
         if isinstance(response, PostprocWorker.Output):
             self._done = response.is_final
@@ -261,10 +305,11 @@ class GenerationResultBase:
             if self.sampling_params.use_beam_search:
                 for beam_idx, _ in enumerate(response_result.output_token_ids):
                     self._handle_sequence(finish_reasons, response_result,
-                                          beam_idx)
+                                          beam_idx, logprobs_result)
             else:
                 self._handle_sequence(finish_reasons, response_result,
-                                      response_result.sequence_index)
+                                      response_result.sequence_index,
+                                      logprobs_result)
 
             if response_result.context_logits is not None:
                 self._context_logits = response_result.context_logits
@@ -352,11 +397,13 @@ class GenerationResult(GenerationResultBase):
     '''
 
     def __init__(
-            self,
-            generation_request: "GenerationRequest",
-            background_error_handler: Optional[Callable] = None,
-            executor: Optional["GenerationExecutor"] = None,
-            disaggregated_params: Optional[DisaggregatedParams] = None) -> None:
+        self,
+        generation_request: "GenerationRequest",
+        background_error_handler: Optional[Callable] = None,
+        executor: Optional["GenerationExecutor"] = None,
+        disaggregated_params: Optional[DisaggregatedParams] = None,
+        logprob_params: Optional[LogprobParams] = None,
+    ) -> None:
         super().__init__(
             generation_request.id,
             generation_request.sampling_params,
@@ -366,6 +413,8 @@ class GenerationResult(GenerationResultBase):
         self._generation_request = generation_request
         self._streaming = generation_request.streaming
         self.disaggregated_params = disaggregated_params
+        # minimal sampling params needed for logprob calculation
+        self._logprob_params = logprob_params
 
         # for aborting the request
         self._executor: Optional[weakref.ReferenceType[
@@ -398,6 +447,12 @@ class GenerationResult(GenerationResultBase):
     @property
     def finished(self) -> bool:
         return self._done
+
+    def clear_logprob_params(self) -> None:
+        # Remove temporary attribute used in executor
+        # for a cleaner external-facing output.
+        if hasattr(self, "_logprob_params"):
+            del self._logprob_params
 
     def _result_step(self, timeout: Optional[float] = None):
         response = self.queue.get(timeout=timeout)
@@ -534,3 +589,60 @@ class IterationResult:
         except asyncio.TimeoutError:
             self._done = True
             raise StopAsyncIteration
+
+
+def compute_logprobs(
+    k_prompt_logprobs: int,
+    k_logprobs: int,
+    context_logits: Optional[torch.Tensor],
+    generation_logits: Optional[torch.Tensor],
+    output_token_ids: Optional[list[int]],
+) -> LogProbsResult:
+    """
+    Compute top-K logprobs and ranks for each token position.
+
+    Returns:
+        LogProbsResult, a NamedTuple containing:
+            - prompt: Optional[List[Dict[token_id, Logprob]]] logprobs for prompt tokens.
+            - generation: Optional[List[Dict[token_id, Logprob]]] logprobs for generated tokens.
+    """
+
+    def _topk_logprobs(logits: torch.Tensor, top_k: int,
+                       tokens: Optional[list[int]]) -> TokenLogprobs:
+        if logits.dim() == 3:
+            # reshape from [1, T, V] to [T, V]
+            logits = logits.squeeze(0)
+
+        logprobs = F.log_softmax(logits.to("cuda", dtype=torch.float32), dim=-1)
+        topk_vals, topk_indices = torch.topk(logprobs, k=top_k, dim=-1)
+
+        results: TokenLogprobs = []
+        # for each token position
+        for t in range(logprobs.size(0)):
+            token_dict = {
+                idx.item(): Logprob(logprob=val.item(), rank=r + 1)
+                for r, (val,
+                        idx) in enumerate(zip(topk_vals[t], topk_indices[t]))
+            }
+
+            # If we have the sampled token list and it's not in top-k, add it
+            if tokens is not None:
+                token_id = tokens[t]
+                if token_id not in token_dict:
+                    token_logprob = logprobs[t, token_id].item()
+                    rank = (logprobs[t] > token_logprob).sum().item() + 1
+                    token_dict[token_id] = Logprob(logprob=token_logprob,
+                                                   rank=rank)
+
+            results.append(token_dict)
+        return results
+
+    prompt_logprobs = _topk_logprobs(
+        context_logits, k_prompt_logprobs,
+        None) if k_prompt_logprobs and context_logits is not None else None
+    generation_logprobs = _topk_logprobs(
+        generation_logits, k_logprobs, output_token_ids
+    ) if k_logprobs and generation_logits is not None else None
+
+    return LogProbsResult(prompt=prompt_logprobs,
+                          generation=generation_logprobs)

--- a/tensorrt_llm/executor/utils.py
+++ b/tensorrt_llm/executor/utils.py
@@ -139,4 +139,5 @@ class WorkerCommIpcAddrs(NamedTuple):
 def is_llm_response(instance):
     from tensorrt_llm._torch.pyexecutor.llm_request import \
         LlmResponse as PyLlmResponse
-    return isinstance(instance, (Response, PyLlmResponse))
+    from .result import ResponseWrapper
+    return isinstance(instance, (Response, PyLlmResponse, ResponseWrapper))

--- a/tensorrt_llm/executor/utils.py
+++ b/tensorrt_llm/executor/utils.py
@@ -139,5 +139,6 @@ class WorkerCommIpcAddrs(NamedTuple):
 def is_llm_response(instance):
     from tensorrt_llm._torch.pyexecutor.llm_request import \
         LlmResponse as PyLlmResponse
+
     from .result import ResponseWrapper
     return isinstance(instance, (Response, PyLlmResponse, ResponseWrapper))

--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -35,7 +35,8 @@ from .postproc_worker import (PostprocParams, PostprocWorker,
                               PostprocWorkerConfig, postproc_worker_main)
 from .request import (CancellingRequest, GenerationRequest, LoRARequest,
                       PromptAdapterRequest)
-from .result import GenerationResult, IterationResult
+from .result import (GenerationResult, IterationResult, LogProbsResult,
+                     ResponseWrapper, compute_logprobs)
 from .utils import (PERIODICAL_RESP_IN_AWAIT, ErrorResponse, IntraProcessQueue,
                     RequestError, WorkerCommIpcAddrs, has_event_loop,
                     is_llm_response)
@@ -215,6 +216,7 @@ class ExecutorBindingsWorker(GenerationExecutor):
                 logger.warning(
                     f"Request of client_id {client_id} is finished, cannot abort it."
                 )
+                return
             self.engine.cancel_request(request_id)
 
     def _engine_response_callback(self, response: tllm.Response):
@@ -428,11 +430,14 @@ class ExecutorBindingsWorker(GenerationExecutor):
         if request.id is None:
             request.set_id(client_id)
 
+        logprob_params = self._get_logprob_params(request)
+
         result = GenerationResult(
             request,
             background_error_handler=self._handle_background_error,
             executor=self,
-            disaggregated_params=request.disaggregated_params)
+            disaggregated_params=request.disaggregated_params,
+            logprob_params=logprob_params)
 
         self._results[client_id] = result
 
@@ -763,6 +768,10 @@ class AwaitResponseHelper:
             assert response is not None
             queue = self.worker.return_queue(response.client_id)
 
+            logprobs_result = _get_logprobs(self.worker, response)
+            if logprobs_result:
+                response = ResponseWrapper(response, logprobs_result)
+
             # For AsyncQueue.sync_q, we will batch the events to avoid too many
             # event notifications, thus put without wait here.
             if isinstance(queue, _SyncQueue):
@@ -799,6 +808,10 @@ class AwaitResponseHelper:
                     response = ErrorResponse(response.client_id,
                                              response.error_msg,
                                              response.request_id)
+                else:
+                    logprobs_result = _get_logprobs(self.worker, response)
+                    if logprobs_result:
+                        response = ResponseWrapper(response, logprobs_result)
 
                 # TODO: To verify the performance of using ZMQ instead of SharedMemory
                 # to send the logits tensor back to the Proxy process.
@@ -821,6 +834,10 @@ class AwaitResponseHelper:
                 # serialized when it has error.
                 response = ErrorResponse(response.client_id, response.error_msg,
                                          response.request_id)
+            else:
+                logprobs_result = _get_logprobs(self.worker, response)
+                if logprobs_result:
+                    response = ResponseWrapper(response, logprobs_result)
 
             _send_rsp(self.worker,
                       response,
@@ -847,9 +864,38 @@ def _get_params_for_first_rsp(
     return None, None
 
 
+def _get_logprobs(worker, response: tllm.Response) -> Optional[LogProbsResult]:
+    """Compute logprob and prompt logprob and clear out logits if applicable.
+    """
+    logprobs_result = None
+    generation_result = worker._results.get(response.client_id, None)
+
+    if not generation_result:
+        return
+
+    logprob_params = getattr(generation_result, "_logprob_params", None)
+    if logprob_params:
+        logprobs_result = compute_logprobs(logprob_params.prompt_logprobs,
+                                           logprob_params.logprobs,
+                                           response.result.context_logits,
+                                           response.result.generation_logits,
+                                           response.result.output_token_ids[0])
+
+        if logprob_params.drop_context_logits:
+            response.clear_context_logits()
+
+        if logprob_params.drop_generation_logits:
+            response.clear_generation_logits()
+
+    if response.result.is_final:
+        generation_result.clear_logprob_params()
+
+    return logprobs_result
+
+
 def _send_rsp(
         worker,
-        response: Union[tllm.Response, ErrorResponse],
+        response: Union[tllm.Response, ResponseWrapper, ErrorResponse],
         postproc_batches: Optional[List[List["PostprocWorker.Input"]]] = None,
         rsp_batch: Optional[List[tllm.Response]] = None):
     # if postproc_batches is set, append to batch instead of putting to IpcQueue

--- a/tensorrt_llm/sampling_params.py
+++ b/tensorrt_llm/sampling_params.py
@@ -2,7 +2,7 @@ import json
 import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field, fields
-from typing import List, Optional, Tuple, Union
+from typing import List, NamedTuple, Optional, Tuple, Union
 
 import torch
 from pydantic import BaseModel
@@ -35,6 +35,15 @@ class GuidedDecodingParams:
             raise ValueError(
                 f"Only one guide can be used for a request, but got {num_guides}."
             )
+
+
+class LogprobParams(NamedTuple):
+    prompt_logprobs: Optional[int] = None
+    logprobs: Optional[int] = None
+    # Drop the logits once the logprobs are computed
+    drop_context_logits: bool = False
+    # Drop the geneation_logits once the logprobs are computed
+    drop_generation_logits: bool = False
 
 
 class LogitsProcessor(ABC):
@@ -148,7 +157,8 @@ class SamplingParams:
         min_p (float, optional): scale the most likely token to determine the minimum token probability. None means using C++ runtime default 0.0. Defaults to None.
         beam_width_array (List[int], optional): The array of beam width using in Variable-Beam-Width-Search. Defaults to None.
 
-        return_log_probs (bool): Controls if Result should contain log probabilities. Defaults to False.
+        logprobs (int, optional): Number of log probabilities to return per output token. Defaults to None.
+        prompt_logprobs (int, optional): Number of log probabilities to return per prompt token. Defaults to None.
         return_context_logits (bool): Controls if Result should contain the context logits. Defaults to False.
         return_generation_logits (bool): Controls if Result should contain the generation logits. Defaults to False.
         exclude_input_from_output (bool): Controls if output tokens in Result should include the input tokens. Defaults to True.
@@ -224,13 +234,19 @@ class SamplingParams:
     beam_width_array: Optional[List[int]] = None
 
     # Keep the below fields in sync with tllme.OutputConfig
-    return_log_probs: bool = False
+    logprobs: Optional[int] = None
+    prompt_logprobs: Optional[int] = None
     return_context_logits: bool = False
     return_generation_logits: bool = False
     exclude_input_from_output: bool = True
     return_encoder_output: bool = False
     return_perf_metrics: bool = False
     additional_model_outputs: Optional[List[AdditionalModelOutput]] = None
+
+    # Used in logprobs calculation in TRT flow to drop logits early if user did not explicitly request them.
+    # Can be deprecated after migration to PyTorch backend.
+    _context_logits_auto_enabled: bool = False
+    _generation_logits_auto_enabled: bool = False
 
     # Lookahead decoding config
     lookahead_config: Optional[tllme.LookaheadDecodingConfig] = None
@@ -280,13 +296,6 @@ class SamplingParams:
 
         self.best_of = self.best_of or self.n
 
-        if (not self.use_beam_search and self.n < self.best_of
-                and not self.return_log_probs):
-            logger.info(
-                f"Enable 'return_log_probs' to trim the {self.n}-best among "
-                f"{self.best_of} outputs under sampling decoding.")
-            self.return_log_probs = True
-
         self._validate()
 
     def _validate(self):
@@ -326,6 +335,14 @@ class SamplingParams:
         return (not self.use_beam_search
                 and (self.top_k is None or self.top_k == 1)
                 and (self.top_p is None or self.top_p == 0.0))
+
+    @property
+    def _need_return_context_logits(self) -> bool:
+        return self.return_context_logits and not self._context_logits_auto_enabled
+
+    @property
+    def _need_return_generation_logits(self) -> bool:
+        return self.return_generation_logits and not self._generation_logits_auto_enabled
 
     def _setup(self,
                tokenizer,
@@ -429,7 +446,11 @@ class SamplingParams:
         return tllme.SamplingConfig(**llmapi_to_rt_param_map)
 
     def _get_output_config(self) -> tllme.OutputConfig:
-        fields = [f for f in dir(tllme.OutputConfig) if not f.startswith('__')]
+        sampling_param_fields = set(dir(SamplingParams))
+        fields = [
+            f for f in dir(tllme.OutputConfig)
+            if not f.startswith('__') and f in sampling_param_fields
+        ]
         return tllme.OutputConfig(**{f: getattr(self, f) for f in fields})
 
     def _get_guided_decoding_params(self) -> tllme.GuidedDecodingParams:

--- a/tensorrt_llm/sampling_params.py
+++ b/tensorrt_llm/sampling_params.py
@@ -157,6 +157,7 @@ class SamplingParams:
         min_p (float, optional): scale the most likely token to determine the minimum token probability. None means using C++ runtime default 0.0. Defaults to None.
         beam_width_array (List[int], optional): The array of beam width using in Variable-Beam-Width-Search. Defaults to None.
 
+        return_log_probs (bool): Controls if Result should contain log probabilities. Defaults to False.
         logprobs (int, optional): Number of log probabilities to return per output token. Defaults to None.
         prompt_logprobs (int, optional): Number of log probabilities to return per prompt token. Defaults to None.
         return_context_logits (bool): Controls if Result should contain the context logits. Defaults to False.
@@ -234,6 +235,7 @@ class SamplingParams:
     beam_width_array: Optional[List[int]] = None
 
     # Keep the below fields in sync with tllme.OutputConfig
+    return_log_probs: bool = False  # TODO: to be removed after PyTorch flow migrate to use `logprobs`
     logprobs: Optional[int] = None
     prompt_logprobs: Optional[int] = None
     return_context_logits: bool = False

--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -187,7 +187,6 @@ class CompletionRequest(OpenAIBaseModel):
         sampling_params = SamplingParams(
             best_of=self.best_of,
             frequency_penalty=self.frequency_penalty,
-            return_log_probs=self.logprobs,
             max_tokens=self.max_tokens,
             n=self.n,
             presence_penalty=self.presence_penalty,
@@ -502,7 +501,6 @@ class ChatCompletionRequest(OpenAIBaseModel):
 
         sampling_params = SamplingParams(
             frequency_penalty=self.frequency_penalty,
-            return_log_probs=self.logprobs,
             max_tokens=self.max_completion_tokens,
             n=self.n,
             presence_penalty=self.presence_penalty,

--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -187,6 +187,7 @@ class CompletionRequest(OpenAIBaseModel):
         sampling_params = SamplingParams(
             best_of=self.best_of,
             frequency_penalty=self.frequency_penalty,
+            return_log_probs=self.logprobs,  # TODO: to be changed to `logprob`
             max_tokens=self.max_tokens,
             n=self.n,
             presence_penalty=self.presence_penalty,
@@ -501,6 +502,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
 
         sampling_params = SamplingParams(
             frequency_penalty=self.frequency_penalty,
+            return_log_probs=self.logprobs,  # TODO: to be changed to `logprob`
             max_tokens=self.max_completion_tokens,
             n=self.n,
             presence_penalty=self.presence_penalty,

--- a/tests/unittest/api_stability/api_stability_core.py
+++ b/tests/unittest/api_stability/api_stability_core.py
@@ -3,7 +3,7 @@ import copy
 import inspect
 import os
 import pathlib
-from dataclasses import dataclass, fields
+from dataclasses import _HAS_DEFAULT_FACTORY_CLASS, dataclass, fields
 from types import MethodType, NoneType
 from typing import (Any, Callable, ClassVar, Dict, List, Literal, Optional,
                     Sequence, Tuple, Union, _type_repr)
@@ -18,6 +18,7 @@ from pydantic import BaseModel
 
 import tensorrt_llm
 from tensorrt_llm.executor import GenerationResult
+from tensorrt_llm.executor.result import TokenLogprobs
 from tensorrt_llm.llmapi import (LLM, CalibConfig, CompletionOutput,
                                  GuidedDecodingParams, QuantConfig,
                                  RequestOutput, SamplingParams)
@@ -118,7 +119,8 @@ class ParamSnapshot:
     def assert_equal(self, other: 'ParamSnapshot'):
         qual_name = StackTrace().get_qual_name()
         assert self.annotation == other.annotation, f"{qual_name} annotation: {self.annotation} != {other.annotation}"
-        assert self.default == other.default, f"{qual_name} default: {self.default} != {other.default}"
+        if not isinstance(self.default, _HAS_DEFAULT_FACTORY_CLASS):
+            assert self.default == other.default, f"{qual_name} default: {self.default} != {other.default}"
 
 
 @dataclass(slots=True)

--- a/tests/unittest/api_stability/references/completion_output.yaml
+++ b/tests/unittest/api_stability/references/completion_output.yaml
@@ -4,9 +4,6 @@ methods:
       cumulative_logprob:
         annotation: Optional[float]
         default: null
-      logprobs:
-        annotation: Optional[List[float]]
-        default: null
       disaggregated_params:
         annotation: Optional[tensorrt_llm.disaggregated_params.DisaggregatedParams]
         default: null

--- a/tests/unittest/api_stability/references/request_output.yaml
+++ b/tests/unittest/api_stability/references/request_output.yaml
@@ -8,4 +8,7 @@ methods:
   aborted:
     parameters: {}
     return_annotation: bool
+  clear_logprob_params:
+    parameters: {}
+    return_annotation: None
 properties: {}

--- a/tests/unittest/api_stability/references_committed/completion_output.yaml
+++ b/tests/unittest/api_stability/references_committed/completion_output.yaml
@@ -9,7 +9,7 @@ methods:
         default: ''
       token_ids:
         annotation: Optional[List[int]]
-        default: null
+        default: []
       finish_reason:
         annotation: Optional[Literal['stop', 'length', 'timeout', 'cancelled']]
         default: null
@@ -19,9 +19,11 @@ methods:
       generation_logits:
         annotation: Optional[torch.Tensor]
         default: null
-      # TODO [TRTLLM-1049]
-      # logprobs:
-      #   annotation: Optional[SampleLogprobs]
-      #   default: null
+      logprobs:
+        annotation: Optional[list[dict[int, tensorrt_llm.executor.result.Logprob]]]
+        default: null
+      prompt_logprobs:
+        annotation: Optional[list[dict[int, tensorrt_llm.executor.result.Logprob]]]
+        default: null
     return_annotation: None
 properties: {}

--- a/tests/unittest/api_stability/references_committed/request_output.yaml
+++ b/tests/unittest/api_stability/references_committed/request_output.yaml
@@ -27,7 +27,3 @@ properties:
   finished:
     annotation: bool
     default: inspect._empty
-  # TODO [TRTLLM-876]
-  # prompt_logprobs:
-  #   annotation: Optional[PromptLogprobs]
-  #   default: inspect._empty

--- a/tests/unittest/api_stability/references_committed/sampling_params.yaml
+++ b/tests/unittest/api_stability/references_committed/sampling_params.yaml
@@ -123,9 +123,12 @@ methods:
         annotation: bool
         default: true
       # Returning controls
-      return_log_probs:
-        annotation: bool
-        default: false
+      logprobs:
+        annotation: Optional[int]
+        default: None
+      prompt_logprobs:
+        annotation: Optional[int]
+        default: None
       return_context_logits:
         annotation: bool
         default: false

--- a/tests/unittest/api_stability/references_committed/sampling_params.yaml
+++ b/tests/unittest/api_stability/references_committed/sampling_params.yaml
@@ -123,6 +123,9 @@ methods:
         annotation: bool
         default: true
       # Returning controls
+      return_log_probs: # to be removed after PyTorch flow migrate to use `logprobs`
+        annotation: bool
+        default: false
       logprobs:
         annotation: Optional[int]
         default: None

--- a/tests/unittest/llmapi/test_llm_multi_gpu.py
+++ b/tests/unittest/llmapi/test_llm_multi_gpu.py
@@ -3,6 +3,7 @@ import json
 import os
 import subprocess  # nosec B404
 import tempfile
+from typing import Optional
 
 import pytest
 from parameterized import parameterized
@@ -18,11 +19,12 @@ from tensorrt_llm.models.llama.model import LLaMAForCausalLM
 from .test_llm import (
     DummyError, DummyExecutorWorker3, _test_llm_capture_request_error,
     _test_llm_generate_async, check_llm_return_context_logits,
-    check_llm_return_generation_logits, default_model_name, get_model_path,
-    llama_7b_multi_lora_test_harness, llama_model_path,
-    llama_v2_7b_prompt_adapter_test_harness, llama_v2_13b_lora_test_harness,
-    llm_check_output, llm_get_stats_async_test_harness,
-    llm_get_stats_test_harness, llm_test_harness, mixtral_model_name, prompts,
+    check_llm_return_generation_logits, llm_return_logprobs_test_harness,
+    default_model_name, get_model_path, llama_7b_multi_lora_test_harness,
+    llama_model_path, llama_v2_7b_prompt_adapter_test_harness,
+    llama_v2_13b_lora_test_harness, llm_check_output,
+    llm_get_stats_async_test_harness, llm_get_stats_test_harness,
+    llm_test_harness, mixtral_model_name, prompts,
     tinyllama_guided_decoding_test_harness,
     tinyllama_logits_processor_test_harness, run_llm_with_postprocess_parallel,
     run_llm_with_postprocess_parallel_and_result_handler, run_llm_abort_request,
@@ -112,6 +114,23 @@ def test_llm_return_context_logits_tp2():
 @skip_single_gpu
 def test_llm_return_generation_logits_tp2():
     check_llm_return_generation_logits(tp_size=2)
+
+
+@skip_single_gpu
+@pytest.mark.parametrize(
+    "prompt_logprobs, logprobs, return_context_logits, return_generation_logits",
+    [
+        (2, 2, False, True),
+    ])
+def test_llm_return_logprobs_tp2(prompt_logprobs: Optional[int],
+                                 logprobs: Optional[int],
+                                 return_context_logits: bool,
+                                 return_generation_logits: bool):
+    llm_return_logprobs_test_harness(prompt_logprobs,
+                                     logprobs,
+                                     return_context_logits,
+                                     return_generation_logits,
+                                     tp_size=2)
 
 
 @pytest.mark.parametrize("use_auto_parallel", [True, False],


### PR DESCRIPTION
This MR only handles TRT path. PyT flow will be handling in [this MR](https://github.com/NVIDIA/TensorRT-LLM/pull/3221/).

## Usage
```python

llm = LLM(
    model="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
    build_config=BuildConfig(gather_context_logits=True),
    gather_generation_logits=True)
        
sampling_params = SamplingParams(
        temperature=0.8,
        top_p=0.95,
        logprobs=5,   # new
        prompt_logprobs=2 # new
        ) 
        
# output.outputs[0].logprobs (list of dict, where the dict is token_id to Logprob): 
# [{11785: Logprob(logprob=-2.128943920135498, rank=1), 1244: Logprob(logprob=-2.878943920135498, rank=2), 297: Logprob(logprob=-3.003943920135498, rank=3), 451: Logprob(logprob=-3.316443920135498, rank=4), 263: Logprob(logprob=-3.503943920135498, rank=5), 2086: Logprob(logprob=-6.722693920135498, rank=113)}, {17999: Logprob(logprob=-1.5640053749084473, rank=1), 11785: Logprob(logprob=-1.7515053749084473, rank=2), 4280: Logprob(logprob=-2.5015053749084473, rank=3), 4100: Logprob(logprob=-3.0640053749084473, rank=4), 5566: Logprob(logprob=-3.1890053749084473, rank=5)}, {304: Logprob(logprob=-0.16267399489879608, rank=1), 363: Logprob(logprob=-2.6626739501953125, rank=2), 29892: Logprob(logprob=-4.2876739501953125, rank=3), 29889: Logprob(logprob=-4.3501739501953125, rank=4), 322: Logprob(logprob=-4.6001739501953125, rank=5)}...]       


# output.outputs[0].prompt_logprobs
#     same shape as above


 
```      