### PR TITLE
chore: make LLM-API slurm examples executable (#3358)

### DIFF
--- a/examples/llm-api/llm_mgmn_trtllm_bench.sh
+++ b/examples/llm-api/llm_mgmn_trtllm_bench.sh
@@ -8,7 +8,7 @@
 #SBATCH -e logs/trtllm-bench.err
 #SBATCH -J trtllm-bench
 
-### Run trtllm-bench on Slurm
+### Run trtllm-bench with pytorch backend on Slurm
 
 # NOTE, this feature is experimental and may not work on all systems.
 # The trtllm-llmapi-launch is a script that launches the LLM-API code on
@@ -20,24 +20,77 @@
 
 # This docker image should have tensorrt_llm installed, or you need to install
 # it in the task.
-container_image=<docker_image>
-mount_dir=<mount_dir>
-mount_dest=<mount_dest>
-workdir=<workdir>
 
-# Just launch trtllm-bench job with trtllm-llmapi-launch command.
+# The following variables are expected to be set in the environment:
+# You can set them via --export in the srun/sbatch command.
+#   CONTAINER_IMAGE: the docker image to use, you'd better install tensorrt_llm in it, or install it in the task.
+#   MOUNT_DIR: the directory to mount in the container
+#   MOUNT_DEST: the destination directory in the container
+#   WORKDIR: the working directory in the container
+#   SOURCE_ROOT: the path to the TensorRT-LLM source
+#   PROLOGUE: the prologue to run before the script
+#   LOCAL_MODEL: the local model directory to use, NOTE: downloading from HF is
+#      not supported in Slurm mode, you need to download the model and put it in
+#      the LOCAL_MODEL directory.
+
+export prepare_dataset="$SOURCE_ROOT/benchmarks/cpp/prepare_dataset.py"
+export data_path="$WORKDIR/token-norm-dist.txt"
+
+echo "Preparing dataset..."
 srun -l \
-    --container-image=${container_image} \
-    --container-mounts=${mount_dir}:${mount_dest} \
-    --container-workdir=${workdir} \
-    --export=ALL,PYTHONPATH=${TEKIT_ROOT} \
+    -N 1 \
+    -n 1 \
+    --container-image=${CONTAINER_IMAGE} \
+    --container-name="prepare-name" \
+    --container-mounts=${MOUNT_DIR}:${MOUNT_DEST} \
+    --container-workdir=${WORKDIR} \
+    --export=ALL \
     --mpi=pmix \
     bash -c "
+        $PROLOGUE
+        python3 $prepare_dataset \
+            --tokenizer=$LOCAL_MODEL \
+            --stdout token-norm-dist \
+            --num-requests=100 \
+            --input-mean=128 \
+            --output-mean=128 \
+            --input-stdev=0 \
+            --output-stdev=0 > $data_path
+    "
+
+echo "Running benchmark..."
+# Just launch trtllm-bench job with trtllm-llmapi-launch command.
+
+srun -l \
+    --container-image=${CONTAINER_IMAGE} \
+    --container-mounts=${MOUNT_DIR}:${MOUNT_DEST} \
+    --container-workdir=${WORKDIR} \
+    --export=ALL,PYTHONPATH=${SOURCE_ROOT} \
+    --mpi=pmix \
+    bash -c "
+        set -ex
+        $PROLOGUE
+        export PATH=$PATH:~/.local/bin
+
+        # This is optional
+        cat > /tmp/pytorch_extra_args.txt << EOF
+pytorch_backend_config:
+    use_cuda_graph: false
+    enable_overlap_scheduler: true
+    cuda_graph_padding_enabled: false
+    print_iter_log: true
+enable_attention_dp: false
+EOF
+
+        # launch the benchmark
         trtllm-llmapi-launch \
          trtllm-bench \
-            --model <model_name> \
-            --model_path <model_path> \
+            --model $MODEL_NAME \
+            --model_path $LOCAL_MODEL \
             throughput \
-            --dataset <dataset_path> \
-            <remaining_options>
+            --dataset $data_path \
+            --backend pytorch \
+            --tp 16 \
+            --extra_llm_api_options /tmp/pytorch_extra_args.txt \
+            $EXTRA_ARGS
     "

--- a/examples/llm-api/llm_mgmn_trtllm_serve.sh
+++ b/examples/llm-api/llm_mgmn_trtllm_serve.sh
@@ -8,7 +8,7 @@
 #SBATCH -e logs/trtllm-serve.err
 #SBATCH -J trtllm-serve
 
-### Run trtllm-serve on Slurm
+### Run trtllm-serve with pytorch backend on Slurm
 
 # NOTE, this feature is experimental and may not work on all systems.
 # The trtllm-llmapi-launch is a script that launches the LLM-API code on
@@ -20,22 +20,60 @@
 
 # This docker image should have tensorrt_llm installed, or you need to install
 # it in the task.
-container_image=<docker_image>
-mount_dir=<mount_dir>
-mount_dest=<mount_dest>
-workdir=<workdir>
 
-# Just launch trtllm-serve job with trtllm-llmapi-launch command.
+# The following variables are expected to be set in the environment:
+# You can set them via --export in the srun/sbatch command.
+#   CONTAINER_IMAGE: the docker image to use, you'd better install tensorrt_llm in it, or install it in the task.
+#   MOUNT_DIR: the directory to mount in the container
+#   MOUNT_DEST: the destination directory in the container
+#   WORKDIR: the working directory in the container
+#   SOURCE_ROOT: the path to the TensorRT-LLM source
+#   PROLOGUE: the prologue to run before the script
+#   LOCAL_MODEL: the local model directory to use, NOTE: downloading from HF is
+#      not supported in Slurm mode, you need to download the model and put it in
+#      the LOCAL_MODEL directory.
+
+export prepare_dataset="$SOURCE_ROOT/benchmarks/cpp/prepare_dataset.py"
+export data_path="$WORKDIR/token-norm-dist.txt"
+
+echo "Preparing dataset..."
 srun -l \
-    --container-image=${container_image} \
-    --container-mounts=${mount_dir}:${mount_dest} \
-    --container-workdir=${workdir} \
-    --export=ALL,PYTHONPATH=${TEKIT_ROOT} \
+    -N 1 \
+    -n 1 \
+    --container-image=${CONTAINER_IMAGE} \
+    --container-name="prepare-name" \
+    --container-mounts=${MOUNT_DIR}:${MOUNT_DEST} \
+    --container-workdir=${WORKDIR} \
+    --export=ALL \
     --mpi=pmix \
     bash -c "
+        $PROLOGUE
+        python3 $prepare_dataset \
+            --tokenizer=$LOCAL_MODEL \
+            --stdout token-norm-dist \
+            --num-requests=100 \
+            --input-mean=128 \
+            --output-mean=128 \
+            --input-stdev=0 \
+            --output-stdev=0 > $data_path
+    "
+
+echo "Starting trtllm-serve..."
+# Just launch trtllm-serve job with trtllm-llmapi-launch command.
+srun -l \
+    --container-image=${CONTAINER_IMAGE} \
+    --container-mounts=${MOUNT_DIR}:${MOUNT_DEST} \
+    --container-workdir=${WORKDIR} \
+    --export=ALL,PYTHONPATH=${SOURCE_ROOT} \
+    --mpi=pmix \
+    bash -c "
+        set -ex
+        $PROLOGUE
+        export PATH=$PATH:~/.local/bin
+
         trtllm-llmapi-launch \
-         trtllm-serve \
-            --model <model_name> \
-            --model_path <model_path> \
-            <remaining_options>
+         trtllm-serve $LOCAL_MODEL \
+            --tp_size 16 \
+            --backend pytorch \
+            ${ADDITIONAL_OPTIONS}
     "

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -8,6 +8,7 @@ import zmq.asyncio
 
 from tensorrt_llm.logger import logger
 
+from .._utils import mpi_rank
 from ..bindings import executor as tllm
 from ..llmapi.mpi_session import (MpiCommSession, MpiPoolSession, MpiSession,
                                   RemoteMpiCommSessionClient)
@@ -70,11 +71,12 @@ class ExecutorBindingsProxy(GenerationExecutor):
         if isinstance(self.mpi_session,
                       (MpiCommSession, RemoteMpiCommSessionClient)):
             print_colored(
-                "Using MpiCommSession to bind to external MPI processes\n",
+                f"rank {mpi_rank()} using MpiCommSession to bind to external MPI processes\n",
                 "yellow")
         else:
-            print_colored("Using MpiPoolSession to spawn MPI processes\n",
-                          "yellow")
+            print_colored(
+                f"rank {mpi_rank()} using MpiPoolSession to spawn MPI processes\n",
+                "yellow")
 
         self._results: Dict[int, GenerationResult] = {}
 

--- a/tensorrt_llm/executor/utils.py
+++ b/tensorrt_llm/executor/utils.py
@@ -5,6 +5,7 @@ from concurrent.futures import ProcessPoolExecutor
 from queue import Empty, Queue
 from typing import Any, Callable, List, NamedTuple
 
+from tensorrt_llm._utils import mpi_rank
 from tensorrt_llm.llmapi.utils import print_colored_debug
 from tensorrt_llm.logger import logger
 
@@ -32,6 +33,8 @@ if PERIODICAL_RESP_IN_AWAIT:
 
 def create_mpi_comm_session(
         n_workers: int) -> RemoteMpiCommSessionClient | MpiPoolSession:
+    assert mpi_rank(
+    ) == 0, f"create_mpi_comm_session must be called by rank 0, but it was called by rank {mpi_rank()}"
     if get_spawn_proxy_process_env():
         assert get_spawn_proxy_process_ipc_addr_env(
         ), "TLLM_SPAWN_PROXY_PROCESS_IPC_ADDR is not set."

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -95,7 +95,7 @@ def create_input_processor(model_path_or_dir: str, tokenizer):
         config = ModelConfig.from_pretrained(model_path_or_dir,
                                              trust_remote_code=True)
         model_config = config.pretrained_config
-    except ValueError:
+    except (ValueError, EnvironmentError):
         config = None
 
     if model_config is not None:

--- a/tensorrt_llm/llmapi/mpi_session.py
+++ b/tensorrt_llm/llmapi/mpi_session.py
@@ -3,7 +3,6 @@ import itertools
 import os
 import socket
 import sys
-import time
 from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple, TypeVar
@@ -187,10 +186,6 @@ class MpiCommSession(MpiSession):
             for i in range(self.n_workers - 1)
         ]
 
-        # A trick to wait for rank0 to be ready, or the collective tasks will hang
-        # TODO[chunweiy]: Remove this trick
-        time.sleep(10)
-
         rank0_future = self.thread_pool.submit(task, *args, **kwargs)
         return [rank0_future] + worker_futures
 
@@ -250,6 +245,9 @@ class RemoteMpiCommSessionClient():
             "yellow")
         self.queue.put(RemoteTask(task, args, kwargs))
         return []
+
+    def submit_sync(self, task, *args, **kwargs):
+        return self.submit(task, *args, **kwargs)
 
     def shutdown(self):
         if self._is_shutdown:

--- a/tensorrt_llm/llmapi/trtllm-llmapi-launch
+++ b/tensorrt_llm/llmapi/trtllm-llmapi-launch
@@ -13,9 +13,9 @@ pid=$(ps -o pid= -p $$ | tr -d ' ')
 # Tell TRTLLM to spawn a additional process for the Proxy
 export TLLM_SPAWN_PROXY_PROCESS=1
 
-function mpi_size {
-    if [ -n "$SLURM_JOB_NUM_NODES" ]; then
-        echo "$SLURM_JOB_NUM_NODES"
+function mpi_world_size {
+    if [ -n "$SLURM_NTASKS" ]; then
+        echo "$SLURM_NTASKS"
     elif [ -n "$OMPI_COMM_WORLD_SIZE" ]; then
         echo "$OMPI_COMM_WORLD_SIZE"
     else
@@ -63,9 +63,10 @@ if [ -z "$mpi_rank" ] || [ "$mpi_rank" -eq 0 ]; then
         $task_with_command
     ) &
 
-    log_stderr "rank${mpi_rank} run mgmn leader node with mpi_world_size: $(mpi_size) ..."
+    log_stderr "rank${mpi_rank} run mgmn leader node with mpi_world_size: $(mpi_world_size) ..."
+    log_stderr "rank0 host: $HOSTNAME"
     python3 -m tensorrt_llm.llmapi.mgmn_leader_node
 else
-    log_stderr "rank${mpi_rank} run mgmn worker node with mpi_world_size: $(mpi_size) ..."
+    log_stderr "rank${mpi_rank} run mgmn worker node with mpi_world_size: $(mpi_world_size) ..."
     python3 -m tensorrt_llm.llmapi.mgmn_worker_node
 fi


### PR DESCRIPTION
Convert all the three slurm examples to executable scripts, and QA will continue to add them to CI.