### PR TITLE
feat: Make scaffolding Controller more generic #3408

### DIFF
--- a/tensorrt_llm/scaffolding/__init__.py
+++ b/tensorrt_llm/scaffolding/__init__.py
@@ -1,6 +1,6 @@
 from .controller import (BestOfNController, Controller, MajorityVoteController,
                          NativeGenerationController, NativeRewardController,
-                         ScaffoldingOutput)
+                         ParallelProcess, ScaffoldingOutput)
 from .math_utils import (extract_answer_from_boxed, extract_answer_with_regex,
                          get_digit_majority_vote_result)
 from .scaffolding_llm import ScaffoldingLlm
@@ -8,7 +8,7 @@ from .task import GenerationTask, RewardTask, Task, TaskStatus
 from .worker import OpenaiWorker, TRTLLMWorker, TRTOpenaiWorker, Worker
 
 __all__ = [
-    "ScaffoldingLlm", "ScaffoldingOutput", "Controller",
+    "ScaffoldingLlm", "ScaffoldingOutput", "ParallelProcess", "Controller",
     "NativeGenerationController", "NativeRewardController",
     "MajorityVoteController", "BestOfNController", "Task", "GenerationTask",
     "RewardTask", "Worker", "OpenaiWorker", "TRTOpenaiWorker", "TRTLLMWorker",

--- a/tensorrt_llm/scaffolding/worker.py
+++ b/tensorrt_llm/scaffolding/worker.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import ABC
 from copy import deepcopy
 from typing import Callable, List, Optional, Union
 
@@ -30,9 +30,8 @@ class Worker(ABC):
 
     task_handlers = {}
 
-    @abstractmethod
     def shutdown(self):
-        raise NotImplementedError
+        pass
 
     def __enter__(self):
         return self

--- a/tests/unittest/scaffolding/test_parallel_process.py
+++ b/tests/unittest/scaffolding/test_parallel_process.py
@@ -1,0 +1,150 @@
+import asyncio
+import copy
+import time
+from enum import Enum
+from typing import List
+
+from tensorrt_llm.scaffolding import (Controller, ParallelProcess,
+                                      ScaffoldingLlm, ScaffoldingOutput, Task,
+                                      TaskStatus, Worker)
+
+
+class DummyTask(Task):
+
+    def __init__(self, turn: int):
+        self.turn = turn
+        self.numbers = []
+
+    @staticmethod
+    def create_from_prompt(prompt: str) -> "DummyTask":
+        task = DummyTask(2)
+        return task
+
+    def create_scaffolding_output(self) -> "ScaffoldingOutput":
+        self.verify()
+        return ScaffoldingOutput()
+
+    def verify(self):
+        for i in range(len(self.numbers)):
+            assert self.numbers[i] == i, "task.numbers[i] should be i"
+
+
+class DummyControllerBase(Controller):
+
+    def generate(self, prompt: str, **kwargs) -> ScaffoldingOutput:
+        task = DummyTask.create_from_prompt(prompt)
+        yield from self.process([task], **kwargs)
+        return task.create_scaffolding_output()
+
+
+# Controller that yields task.turn times for each task
+class DummyController(DummyControllerBase):
+
+    class WorkerTag(Enum):
+        DUMMY = "dummy"
+
+    def process(self, tasks: List[Task], **kwargs):
+        yield_tasks = tasks
+        while len(yield_tasks) > 0:
+            new_tasks = []
+            for task in yield_tasks:
+                if len(task.numbers) < task.turn:
+                    task.worker_tag = self.WorkerTag.DUMMY
+                    new_tasks.append(task)
+            yield_tasks = new_tasks
+
+            if len(yield_tasks) > 0:
+                yield yield_tasks
+
+
+# The flag to enable parallel process
+# We can use this flag to compare the performance of parallel process and sequence process
+ENABLE_PARALLEL_PROCESS = True
+
+
+class DummyParallelController(DummyControllerBase):
+
+    def __init__(self, controllers):
+        self.controllers = controllers
+
+    def process(self, tasks: List[Task], **kwargs):
+        global ENABLE_PARALLEL_PROCESS
+        if ENABLE_PARALLEL_PROCESS:
+            tasks_list = [
+                copy.deepcopy(tasks) for _ in range(len(self.controllers))
+            ]
+
+            kwargs_list = [kwargs for _ in range(len(self.controllers))]
+            #yield from parallel_process_helper(self.controllers, tasks_list, kwargs_list)
+            yield ParallelProcess(self.controllers, tasks_list, kwargs_list)
+
+            tasks = tasks_list[0]
+        else:
+            original_tasks = copy.deepcopy(tasks)
+            for controller in self.controllers:
+                tasks = copy.deepcopy(original_tasks)
+                yield from controller.process(tasks, **kwargs)
+
+
+class DummyWorker(Worker):
+
+    async def dummy_handler(self, task: DummyTask):
+        await asyncio.sleep(1)
+        task.numbers.append(len(task.numbers))
+        return TaskStatus.SUCCESS
+
+    task_handlers = {DummyTask: dummy_handler}
+
+
+def parallel_process_helper_run_and_verify(controllers):
+    # Obtain the generator from parallel_process_helper.
+    parallel_controller = DummyParallelController(controllers)
+    worker = DummyWorker()
+    llm = ScaffoldingLlm(parallel_controller,
+                         {DummyController.WorkerTag.DUMMY: worker})
+
+    global ENABLE_PARALLEL_PROCESS
+    ENABLE_PARALLEL_PROCESS = True
+    start_time = time.time()
+    llm.generate("")
+    end_time = time.time()
+    print('Parallel process time:', end_time - start_time)
+
+    ENABLE_PARALLEL_PROCESS = False
+    start_time = time.time()
+    llm.generate("")
+    end_time = time.time()
+    print('Sequence process time:', end_time - start_time)
+
+    llm.shutdown()
+
+
+def test_parallel_process_helper():
+    NUM_CONTROLLERS = 3
+    controllers = []
+
+    for _ in range(NUM_CONTROLLERS):
+        controller = DummyController()
+        controllers.append(controller)
+
+    parallel_process_helper_run_and_verify(controllers)
+
+
+def test_parallel_process_helper_with_two_level():
+    NUM_CONTROLLERS_LEVEL_1 = 2
+    NUM_CONTROLLERS_LEVEL_2 = 2
+
+    controllers_level_1 = []
+
+    for _ in range(NUM_CONTROLLERS_LEVEL_1):
+        controller = DummyController()
+        controllers_level_1.append(controller)
+
+    parallel_controller = DummyParallelController(controllers_level_1)
+    controllers_level_2 = [parallel_controller]
+
+    for _ in range(NUM_CONTROLLERS_LEVEL_2):
+        controller = DummyController()
+        controllers_level_2.append(controller)
+
+    parallel_process_helper_run_and_verify(controllers_level_2)

--- a/tests/unittest/scaffolding/test_scaffolding.py
+++ b/tests/unittest/scaffolding/test_scaffolding.py
@@ -1,7 +1,7 @@
-# isort: off
-# isort: on
+# autoflake: skip_file
 
-from scaffolding.test_worker import create_trtllm_worker
+from scaffolding.test_worker import (create_trtllm_worker,
+                                     deepseek_distill_7b_path, default_prompt)
 
 from tensorrt_llm.scaffolding import (MajorityVoteController,
                                       NativeGenerationController,


### PR DESCRIPTION
We need to do some optimizations to make the Controller more generic, which will help with better modularity.
These changes will not affect the existing API.

- We hope the Controller such as MajorityVoteController can be constructed by any Generation Controller. For a example, the Generation Controller may be a dynasor cot Controller which will yield for different and uncertainly turns between different sample. To resolve that, we support yield "ParallelProcess" to "ScaffoldingLlm". The code of majority vote controller looks like:

`

    controllers = [self.generation_controller.clone() for _ in range(sample_num)]

    tasks_list = [[copy.deepcopy(tasks[0])] for _ in range(sample_num)]

    kwargs_list = [kwargs for _ in range(sample_num)]

    yield ParallelProcess(generation_controllers, tasks_list,
                              generation_kwargs_list)`

Then the "ScaffoldingLlm" will run the "process" of each controller with tasks and kwargs parallel. And the generation controller here can be someone which customized by user. In other words, users can pass any class of generation controller into majority vote controller without changing the code of majority vote controller.

- We make the reward method in BestOfNController more generic as we observe that reward methods become various in recently paper and works.

- We remove most of type check for Task as users may override them.