### PR TITLE
Feat: Variable-Beam-Width-Search (VBWS) part4

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/trtGptModelOptionalParams.h
+++ b/cpp/include/tensorrt_llm/batch_manager/trtGptModelOptionalParams.h
@@ -52,7 +52,7 @@ public:
         std::optional<executor::SpeculativeDecodingConfig> specDecConfig = std::nullopt,
         std::optional<executor::GuidedDecodingConfig> guidedDecodingConfig = std::nullopt,
         bool isLeaderInOrchMode = false, std::optional<std::vector<std::string>> additionalOutputNames = std::nullopt,
-        bool gatherGenerationLogits = false)
+        bool gatherGenerationLogits = false, bool useVariableBeamWidthSearch = false)
         : kvCacheConfig{std::move(kvCacheConfig)}
         , enableTrtOverlap{enableTrtOverlap}
         , deviceIds(std::move(deviceIds))
@@ -73,6 +73,7 @@ public:
         , isLeaderInOrchMode{isLeaderInOrchMode}
         , additionalOutputNames{std::move(additionalOutputNames)}
         , gatherGenerationLogits{gatherGenerationLogits}
+        , useVariableBeamWidthSearch{useVariableBeamWidthSearch}
     {
         if (guidedDecodingConfig)
         {
@@ -91,7 +92,7 @@ public:
             executorConfig.getExtendedRuntimePerfKnobConfig(), executorConfig.getDebugConfig(),
             executorConfig.getMaxSeqIdleMicroseconds(), executorConfig.getSpecDecConfig(),
             executorConfig.getGuidedDecodingConfig(), isLeaderInOrchMode, executorConfig.getAdditionalOutputNames(),
-            executorConfig.getGatherGenerationLogits())
+            executorConfig.getGatherGenerationLogits(), executorConfig.getUseVariableBeamWidthSearch())
     {
     }
 
@@ -116,6 +117,7 @@ public:
             && isLeaderInOrchMode == other.isLeaderInOrchMode                       //
             && additionalOutputNames == other.additionalOutputNames                 //
             && gatherGenerationLogits == other.gatherGenerationLogits               //
+            && useVariableBeamWidthSearch == other.useVariableBeamWidthSearch       //
             ;
     }
 
@@ -145,6 +147,7 @@ public:
     bool isLeaderInOrchMode;
     std::optional<std::vector<std::string>> additionalOutputNames;
     bool gatherGenerationLogits;
+    bool useVariableBeamWidthSearch;
 };
 
 } // namespace tensorrt_llm::batch_manager

--- a/cpp/include/tensorrt_llm/executor/executor.h
+++ b/cpp/include/tensorrt_llm/executor/executor.h
@@ -1485,7 +1485,7 @@ private:
     /// @brief The KV cache configuration.
     KvCacheConfig mKvCacheConfig;
 
-    /// @brief The KV cache configuration.
+    /// @brief Controls if chunk context is used or not.
     bool mEnableChunkedContext;
 
     /// @brief Controls if log probabilities should be normalized or not.

--- a/cpp/include/tensorrt_llm/runtime/decodingInput.h
+++ b/cpp/include/tensorrt_llm/runtime/decodingInput.h
@@ -97,6 +97,8 @@ public:
     //! Parameters for beam search
     //! KV cache index for beam search, [batchSize, beamWidth, maxSeqLen] on gpu
     TensorPtr cacheIndirection;
+    //! Step of each request, for Variable-Beam-Width-Search
+    std::optional<std::vector<SizeType32>> steps; // [batchSize]
 
     // Medusa
     class MedusaInputs

--- a/cpp/include/tensorrt_llm/runtime/iGptDecoderBatched.h
+++ b/cpp/include/tensorrt_llm/runtime/iGptDecoderBatched.h
@@ -63,18 +63,25 @@ public:
     }
 
     //! Mandatory parameters
+    //! Logits
     //! [batchSize][1, beamWidth, vocabSizePadded] or [generatedTokensPerStep, 1, vocabSizePadded], on gpu
     std::vector<TensorPtr> logits;
     //! Control activity of decoder slots in batch
     std::vector<bool> active; // [batchSize]
-    //! Empty buffer filled in GptDecoderBatched, sorted by slots, [maxTokensPerEngineStep, batchSize]
-    TensorPtr batchSlots;
-    //! Filled with slots in request order, [batchSize]
-    TensorPtr batchSlotsRequestOrder;
+
+    //! Empty buffer filled in GptDecoderBatched, sorted by slots
+    TensorPtr batchSlots; // [maxTokensPerEngineStep, batchSize]
+    //! Filled with slots in request order
+    TensorPtr batchSlotsRequestOrder; // [batchSize]
 
     //! For beam search
     //! Indices into KV cache of different rays within one beam
     TensorPtr cacheIndirection; // [batchSize, maxBeamWidth, maxSeqLen], on gpu
+    //! The generation step of each request (for Variable-Beam-Width-Search)
+    std::vector<tensorrt_llm::runtime::SizeType32> steps; // [batchSize]
+
+    //! For speculative decoding
+    //! Logits of draft
     //! [maxBatchSize][maxAcceptedDraftTokensPerStep][maxDraftTokens + 1, vocabSizePadded]
     std::vector<std::vector<TensorPtr>> predictedDraftLogits;
 

--- a/cpp/include/tensorrt_llm/runtime/samplingConfig.h
+++ b/cpp/include/tensorrt_llm/runtime/samplingConfig.h
@@ -417,10 +417,9 @@ public:
         auto const& beamWidthArray = this->beamWidthArray;
         if (beamWidthArray.has_value())
         {
-            TLLM_CHECK_WITH_INFO(decodingIter > 0, "getBeamWidthByIter should only be called in generation phase.");
             // Clamped `decodingIter` into [0,kMaxBeamWidthArrayLength-1] as index
-            int const index
-                = std::min(decodingIter, static_cast<int>(tensorrt_llm::kernels::kMaxBeamWidthArrayLength)) - 1;
+            int const index = std::max(
+                std::min(decodingIter, static_cast<int>(tensorrt_llm::kernels::kMaxBeamWidthArrayLength)) - 1, 0);
             reqBeamWidth = beamWidthArray.value()[indexSC][index];
         }
         return reqBeamWidth;

--- a/cpp/tensorrt_llm/batch_manager/handleContextLogits.cpp
+++ b/cpp/tensorrt_llm/batch_manager/handleContextLogits.cpp
@@ -45,7 +45,7 @@ void copyLastContextLogits(TensorPtr const& contextLogits, LlmRequest& llmReq, B
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
     auto const numLogits = contextLogits->getShape().d[0];
-    for (int beam = 0; beam < llmReq.mSamplingConfig.beamWidth; beam++)
+    for (int beam = 0; beam < llmReq.mSamplingConfig.getBeamWidthByIter(0); beam++)
     {
         // [beamWidth, mMaxNewTokens, vocabSizePadded] -> [numLogits, vocabSizePadded]
         auto beamHostTensorPtr = ITensor::slice(llmReq.getGenerationLogitsHost(), {beam, 0}, numLogits);
@@ -80,7 +80,6 @@ SizeType32 HandleContextLogits::operator()(RequestVector const& contextRequests,
     // Copy logits into decoderBuffers.logits
     for (auto const& llmReq : contextRequests)
     {
-        auto const reqBeamWidth = llmReq->mSamplingConfig.beamWidth;
         auto const numContextLogits = numContextLogitsVec.at(batchIndex);
         auto const draftLength = llmReq->isLastContextChunk() ? llmReq->getNumDraftTokens() : 0;
 
@@ -137,6 +136,7 @@ SizeType32 HandleContextLogits::operator()(RequestVector const& contextRequests,
         TLLM_CHECK_DEBUG_WITH_INFO(tru::tensorHasInvalid<float>(*logitsView, manager, "logits") == false,
             "Found invalid number (NaN or Inf) in logits");
         // Scatter the output logits to the decoderLogits
+        auto const reqBeamWidth = llmReq->mSamplingConfig.getBeamWidthByIter(llmReq->getDecodingIter());
         if (reqBeamWidth > 1)
         {
             // Tile logits of context requests

--- a/cpp/tensorrt_llm/batch_manager/handleGenerationLogits.cpp
+++ b/cpp/tensorrt_llm/batch_manager/handleGenerationLogits.cpp
@@ -82,7 +82,7 @@ void HandleGenerationLogits::operator()(SizeType32 logitsIndex, RequestVector co
 
     for (auto const& llmReq : generationRequests)
     {
-        auto const reqBeamWidth = llmReq->mSamplingConfig.beamWidth;
+        auto const reqBeamWidth = llmReq->mSamplingConfig.getBeamWidthByIter(llmReq->getDecodingIter());
         auto const seqSlot = llmReq->mSeqSlot.value();
 
         auto const draftLength = llmReq->getNumDraftTokens();

--- a/cpp/tensorrt_llm/batch_manager/runtimeBuffers.cpp
+++ b/cpp/tensorrt_llm/batch_manager/runtimeBuffers.cpp
@@ -407,7 +407,7 @@ void RuntimeBuffers::setBufferSizes(RequestVector const& contextRequests, Reques
     numGenTokens = 0;
     for (auto const& llmReq : genRequests)
     {
-        auto const reqBeamWidth = llmReq->mSamplingConfig.beamWidth;
+        auto const reqBeamWidth = llmReq->mSamplingConfig.getBeamWidthByIter(llmReq->getDecodingIter());
         numGenSequences += reqBeamWidth;
         auto const draftLen = llmReq->getNumDraftTokens();
         numGenTokens += draftLen + reqBeamWidth;
@@ -633,8 +633,7 @@ void RuntimeBuffers::setFromInputs(RequestVector const& contextRequests, Request
         auto numSequences = numContextRequests;
         for (auto const& llmReq : genRequests)
         {
-            auto const reqBeamWidth = llmReq->mSamplingConfig.beamWidth;
-
+            auto const reqBeamWidth = llmReq->mSamplingConfig.getBeamWidthByIter(llmReq->getDecodingIter());
             auto const draftLength = llmReq->getNumDraftTokens();
             auto const& draftTokens = llmReq->getDraftTokens();
             auto const numLogits = draftLength + reqBeamWidth;
@@ -728,8 +727,7 @@ void RuntimeBuffers::setFromInputs(RequestVector const& contextRequests, Request
         numSequences = numContextRequests;
         for (auto const& llmReq : genRequests)
         {
-            auto const reqBeamWidth = llmReq->mSamplingConfig.beamWidth;
-
+            auto const reqBeamWidth = llmReq->mSamplingConfig.getBeamWidthByIter(llmReq->getDecodingIter());
             auto const draftLength = llmReq->getNumDraftTokens();
 
             auto const contextQLength = llmReq->mPromptLen + draftLength;

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
@@ -309,6 +309,11 @@ private:
         return getModelConfig().computeGenerationLogits() || mGatherGenerationLogits;
     }
 
+    [[nodiscard]] bool getUseVariableBeamWidthSearch() const
+    {
+        return mUseVariableBeamWidthSearch;
+    }
+
     [[nodiscard]] runtime::ModelConfig const& getModelConfig() const override
     {
         return mModelConfig;
@@ -489,6 +494,8 @@ private:
     std::optional<SizeType32> mMaxNumTokensRuntime;
     // Controls if generation logits should be gathered, so that returnGenerationLogits can be requested.
     bool mGatherGenerationLogits{false};
+    // Controls if Variable-Beam-Width-Search is enabled
+    bool mUseVariableBeamWidthSearch{false};
 
     /******************** Buffers ********************/
     // Buffers for each micro batch. Unfused path (mCtxGenFusion==false) uses two times the buffers.

--- a/cpp/tensorrt_llm/kernels/beamSearchKernels.cu
+++ b/cpp/tensorrt_llm/kernels/beamSearchKernels.cu
@@ -262,11 +262,8 @@ void printBH(BeamHypotheses const& bh)
     PH2(bh.lengthPenalties, nbs);
     PH2(bh.earlyStoppings, nbs);
     PH3(bh.beamWidthArraysHost, nbs * kMaxBeamWidthArrayLength, kMaxBeamWidthArrayLength);
-    PH3(bh.beamWidthArraysDevice, nbs * kMaxBeamWidthArrayLength, kMaxBeamWidthArrayLength);
     PH2(bh.nBeamWidthInHost, nbs);
     PH2(bh.nBeamWidthOutHost, nbs);
-    PH2(bh.nBeamWidthInDevice, nbs);
-    PH2(bh.nBeamWidthOutDevice, nbs);
 
     PH2(bh.inputLengths, nbs * nbm);
     PH2(bh.endIds, nbs);

--- a/cpp/tensorrt_llm/kernels/beamSearchKernels.h
+++ b/cpp/tensorrt_llm/kernels/beamSearchKernels.h
@@ -61,11 +61,8 @@ struct BeamHypotheses
     float const* lengthPenalties{nullptr};          // [BS]
     int const* earlyStoppings{nullptr};             // [BS]
     int const* beamWidthArraysHost{nullptr};        // [BS, kMaxBeamWidthArrayLength]                           for VBWS
-    int const* beamWidthArraysDevice{nullptr};      // [BS, kMaxBeamWidthArrayLength]                           for VBWS
     int* nBeamWidthInHost{nullptr};                 // [BS], cpu                                                for VBWS, beam width of last forward computation
     int* nBeamWidthOutHost{nullptr};                // [BS], cpu                                                for VBWS, beam width of next forward computation
-    int* nBeamWidthInDevice{nullptr};               // [BS]                                                     for VBWS, beam width of last forward computation
-    int* nBeamWidthOutDevice{nullptr};              // [BS]                                                     for VBWS, beam width of next forward computation
 
     // Pointers from input
     int const* inputLengths{nullptr};               // [BS, BM]         %% context_length

--- a/cpp/tensorrt_llm/layers/beamSearchLayer.cu
+++ b/cpp/tensorrt_llm/layers/beamSearchLayer.cu
@@ -80,6 +80,7 @@ BeamSearchLayer<T>::BeamSearchLayer(DecoderDomain const& decoderDomain, std::sha
     TLLM_CHECK_WITH_INFO(beamWidth <= kMaxBeamWidth, "Beam width is larger than the maximum supported (%d > %d)",
         int(beamWidth), int(kMaxBeamWidth));
     this->mVBWS = decoderDomain.getUseVariableBeamWidthSearch();
+    TLLM_LOG_INFO("Variable-Beam-Width-Search is %s", this->mVBWS ? "enabled" : "disabled");
 
     allocateBuffer();
     configureBeamSearchLayer();
@@ -106,11 +107,14 @@ void BeamSearchLayer<T>::allocateBuffer()
     mEarlyStoppingHost = mBufferManager->pinnedPool(batchSizeShape, TRTDataType<int>::value);
     mEarlyStoppingDevice = mBufferManager->gpu(batchSizeShape, TRTDataType<int>::value);
 
-    mBeamWidthArrayHost = mBufferManager->pinnedPool(batchSizeXBeamWidthArraySizeShape, TRTDataType<int>::value);
-    mBeamWidthArrayDevice = mBufferManager->gpu(batchSizeXBeamWidthArraySizeShape, TRTDataType<int>::value);
+    if (this->mVBWS)
+    {
+        mBeamWidthArrayHost = mBufferManager->pinnedPool(batchSizeXBeamWidthArraySizeShape, TRTDataType<int>::value);
+        mBeamWidthArrayDevice = mBufferManager->gpu(batchSizeXBeamWidthArraySizeShape, TRTDataType<int>::value);
 
-    mBeamWidthIn = mBufferManager->pinnedPool(batchSizeShape, TRTDataType<int>::value);
-    mBeamWidthOut = mBufferManager->pinnedPool(batchSizeShape, TRTDataType<int>::value);
+        mBeamWidthIn = mBufferManager->pinnedPool(batchSizeShape, TRTDataType<int>::value);
+        mBeamWidthOut = mBufferManager->pinnedPool(batchSizeShape, TRTDataType<int>::value);
+    }
 
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
 }
@@ -293,8 +297,12 @@ void BeamSearchLayer<T>::setup(SizeType32 const batchSize, SizeType32 const beam
         mLengthPenaltyDevice, batchSlots, std::make_pair(fltMin, fltMax), "length penalty");
     fillBuffers(setupParams->earlyStopping, DefaultDecodingParams::getEarlyStopping(), mEarlyStoppingHost,
         mEarlyStoppingDevice, batchSlots, std::make_pair(-fltEpsilon, int32Max), "early stopping");
-    fillBuffers(setupParams->beamWidthArray, DefaultDecodingParams::getBeamWidthArray(), mBeamWidthArrayHost,
-        mBeamWidthArrayDevice, batchSlots, std::make_pair(-fltEpsilon, kMaxBeamWidth), "beam width array");
+
+    if (this->mVBWS)
+    {
+        fillBuffers(setupParams->beamWidthArray, DefaultDecodingParams::getBeamWidthArray(), mBeamWidthArrayHost,
+            mBeamWidthArrayDevice, batchSlots, std::make_pair(-fltEpsilon, kMaxBeamWidth), "beam width array");
+    }
 
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
 }
@@ -333,25 +341,23 @@ void BeamSearchLayer<T>::forwardAsync(std::shared_ptr<BaseDecodingOutputs> const
     bh.nByteMaxSharedMemoryPerBlock = this->mByteMaxSharedMemoryPerBlock;
     bh.nByteSharedMemoryStage1 = this->mByteSharedMemoryStage1;
     bh.nByteSharedMemoryStage3 = this->mByteSharedMemoryStage3;
-
     bh.diversityRates = bufferCast<float>(*mBeamSearchDiversityRateDevice);
     bh.lengthPenalties = bufferCast<float>(*mLengthPenaltyDevice);
     bh.earlyStoppings = bufferCast<int>(*mEarlyStoppingDevice);
-    bh.beamWidthArraysHost = bufferCast<int>(*mBeamWidthArrayHost);
-    bh.beamWidthArraysDevice = bufferCast<int>(*mBeamWidthArrayDevice);
 
-    bh.nBeamWidthInHost = bufferCast<int>(*mBeamWidthIn);
-    bh.nBeamWidthOutHost = bufferCast<int>(*mBeamWidthOut);
     if (this->mVBWS)
     {
+        bh.beamWidthArraysHost = bufferCast<int>(*mBeamWidthArrayHost);
+        bh.nBeamWidthInHost = bufferCast<int>(*mBeamWidthIn);
+        bh.nBeamWidthOutHost = bufferCast<int>(*mBeamWidthOut);
         int const* batchSlotsHost = bufferCast<int>(*ip->batchSlots);
         for (int i = 0; i < ip->localBatchSize; ++i)
         {
-            int const slot = batchSlotsHost[i];
-            int const step = ip->beamSearchSteps.value()[slot];
+            auto const slot = batchSlotsHost[i];
+            auto const step = ip->beamSearchSteps.value()[slot];
             // Clamp `step` to [0, kMaxBeamWidthArrayLength - 1], and set `indexInput=0` when step = 0 or 1
-            int const indexInput = std::min(std::max((int) step - 1, 0), (int) kMaxBeamWidthArrayLength - 1);
-            int const indexOutput = std::min((int) step, (int) kMaxBeamWidthArrayLength - 1);
+            auto const indexOutput = std::min(step, static_cast<SizeType32>(kMaxBeamWidthArrayLength) - 1);
+            auto const indexInput = std::max(indexOutput - 1, 0);
             bh.nBeamWidthInHost[i] = bh.beamWidthArraysHost[slot * kMaxBeamWidthArrayLength + indexInput];
             bh.nBeamWidthOutHost[i] = bh.beamWidthArraysHost[slot * kMaxBeamWidthArrayLength + indexOutput];
         }
@@ -360,11 +366,9 @@ void BeamSearchLayer<T>::forwardAsync(std::shared_ptr<BaseDecodingOutputs> const
     bh.inputLengths = bufferCast<SizeType32>(*ip->inputLengths.value());
     bh.endIds = bufferCast<TokenIdType>(*ip->endIds);
     bh.batchSlots = workspace->getDeviceBatchSlotsPtr(); // Device copy of `ip->batchSlots`
-
     bh.logProbsTiled = bufferCastOrNull<float>(op->outputLogProbsTiled);
     bh.sequenceLengths = bufferCast<SizeType32>(*op->sequenceLength.value());
     bh.cumLogProbs = bufferCast<float>(*op->cumLogProbs.value());
-
     bh.outputIdsCBA = op->beamHypotheses->outputIdsCBA;
     bh.logProbsCBA = op->beamHypotheses->logProbsCBA;
     bh.sequenceLengthsCBA = op->beamHypotheses->sequenceLengthsCBA;
@@ -372,10 +376,8 @@ void BeamSearchLayer<T>::forwardAsync(std::shared_ptr<BaseDecodingOutputs> const
     bh.normedScoresCBA = op->beamHypotheses->normedScoresCBA;
     bh.numBeamsCBA = op->beamHypotheses->numBeamsCBA;
     bh.minNormedScoresCBA = op->beamHypotheses->minNormedScoresCBA;
-
     bh.batchDones = op->beamHypotheses->batchDones;
     bh.finished = reinterpret_cast<FinishedState*>(bufferCast<FinishedState::UnderlyingType>(*op->finished.value()));
-
     bh.outputIdsPtr = bufferCast<TokenIdType*>(*op->outputIdsPtr);
     bh.parentIdsPtr = bufferCast<TokenIdType*>(*op->parentIdsPtr);
 

--- a/cpp/tensorrt_llm/layers/beamSearchLayer.h
+++ b/cpp/tensorrt_llm/layers/beamSearchLayer.h
@@ -66,8 +66,8 @@ private:
     TensorPtr mEarlyStoppingDevice;           // [batchSize] gpu
     TensorPtr mBeamWidthArrayHost;            // [batchSize, kMaxBeamWidthArrayLength] cpu
     TensorPtr mBeamWidthArrayDevice;          // [batchSize, kMaxBeamWidthArrayLength] gpu
-    TensorPtr mBeamWidthIn;                   // [batchSize] cpu, the input beamWidth of this step
-    TensorPtr mBeamWidthOut;                  // [batchSize] cpu, the output beamWidth of this step
+    TensorPtr mBeamWidthIn;                   // [batchSize] cpu, the beamWidth of last forward computation
+    TensorPtr mBeamWidthOut;                  // [batchSize] cpu, the beamWidth of next forward computation
 };
 
 } // namespace tensorrt_llm::layers

--- a/cpp/tensorrt_llm/runtime/gptDecoder.cpp
+++ b/cpp/tensorrt_llm/runtime/gptDecoder.cpp
@@ -49,8 +49,8 @@ GptDecoder<T>::GptDecoder(executor::DecodingMode const& mode, size_t maxBatchSiz
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
 
-    auto const decodingDomain = tensorrt_llm::layers::DecoderDomain(
-        maxBatchSize, maxBeamWidth, vocabSize, vocabSizePadded, speculativeDecodingModule);
+    auto const decodingDomain = tensorrt_llm::layers::DecoderDomain(maxBatchSize, maxBeamWidth, vocabSize,
+        vocabSizePadded, speculativeDecodingModule, mode.isUseVariableBeamWidthSearch());
     mDynamicDecodeLayer = std::make_shared<tensorrt_llm::layers::DynamicDecodeLayer<T>>(mode, decodingDomain, mManager);
 
     mDecodingLayerWorkspace = std::make_unique<tensorrt_llm::runtime::DecodingLayerWorkspace>(
@@ -439,6 +439,12 @@ std::shared_ptr<tl::BaseDecodingInputs> prepareInputs(
     {
         forwardParams = std::make_shared<tl::DecodingInputs>(input.endIds, input.batchSlots, input.step, ite,
             input.batchSize, input.maxAttentionWindow, input.sinkTokenLength);
+
+        if (input.cacheIndirection)
+        {
+            forwardParams->srcCacheIndirection = input.cacheIndirection;
+        }
+        forwardParams->beamSearchSteps = input.steps;
     }
     else if (decodingMode.isMedusa())
     {
@@ -491,11 +497,6 @@ std::shared_ptr<tl::BaseDecodingInputs> prepareInputs(
         }
     }
 
-    if (input.cacheIndirection)
-    {
-        forwardParams->srcCacheIndirection = input.cacheIndirection;
-    }
-
     if (input.embeddingBias)
     {
         forwardParams->embeddingBias = input.embeddingBias;
@@ -515,30 +516,25 @@ std::shared_ptr<tl::BaseDecodingInputs> prepareInputs(
         forwardParams->finished = input.finishReasons;
     }
 
-    // Medusa
+    // Speculative decoding
     if (decodingMode.isMedusa())
     {
         prepareMedusaInputs(input, maxBatchSize, forwardParams);
     }
-
-    // Explicit draft tokens
-    if (decodingMode.isExplicitDraftTokens())
+    else if (decodingMode.isExplicitDraftTokens())
     {
         prepareExplicitDraftTokensInput(input, forwardParams);
     }
-
-    if (decodingMode.isLookahead() && input.lookaheadInputs)
+    else if (decodingMode.isLookahead() && input.lookaheadInputs)
     {
         prepareLookaheadInputs(input, maxBatchSize, forwardParams);
         forwardParams->localBatchSize = input.batchSize;
     }
-
-    if (decodingMode.isExternalDraftTokens())
+    else if (decodingMode.isExternalDraftTokens())
     {
         prepareExternalDraftTokensInputs(input, forwardParams);
     }
-
-    if (decodingMode.isEagle())
+    else if (decodingMode.isEagle())
     {
         prepareEagleInput(input, forwardParams);
     }

--- a/cpp/tensorrt_llm/runtime/gptDecoderBatched.cpp
+++ b/cpp/tensorrt_llm/runtime/gptDecoderBatched.cpp
@@ -245,6 +245,7 @@ void GptDecoderBatched::prepareForward(
     {
         dInput.cacheIndirection = input.cacheIndirection;
         dOutput.cacheIndirection = output.cacheIndirection;
+        dInput.steps = input.steps; // For Variable-Beam-Width-Search
     }
 
     if (speculativeDecodingMode.isExplicitDraftTokens())

--- a/cpp/tensorrt_llm/runtime/tllmRuntime.cpp
+++ b/cpp/tensorrt_llm/runtime/tllmRuntime.cpp
@@ -539,7 +539,20 @@ void TllmRuntime::setInputTensorsImpl(SizeType32 contextIndex, TensorMap const& 
             "%s: expected type %d, provided type %d", name.c_str(), static_cast<std::int32_t>(engineDtype),
             static_cast<std::int32_t>(tensorDtype));
 
-        auto const tensorShape = tensor->getShape();
+        auto tensorShape = tensor->getShape();
+
+        // Change shape of `cache_indirection` for Variable-Beam-Width-Search
+        // TODO: remove this hack if beamWidth of each request are passed into GptAttentionPlugin by input tensor
+        if (name == "cache_indirection")
+        {
+            SizeType32 const beamWidth = getCurrentBeamWidth();
+            if (tensorShape.d[1] != beamWidth)
+            {
+                tensorShape.d[1] = beamWidth;
+                TLLM_LOG_TRACE("Change shape of cache_indirection to %s", ITensor::toString(tensorShape).c_str());
+            }
+        }
+
         auto const setInputShapeSuccess = context.setInputShape(name.c_str(), tensorShape);
         if (!setInputShapeSuccess)
         {

--- a/docs/source/advanced/gpt-runtime.md
+++ b/docs/source/advanced/gpt-runtime.md
@@ -173,18 +173,21 @@ value for a given parameter, the vector can be limited to a single element
 
 ***Beam-search***
 
-|      Name in TRT-LLM      |           Description           |   Data type   |      Range of value      |       Default value       |     Name in HF      |
-| :-----------------------: | :-----------------------------: | :-----------: | :----------------------: | :-----------------------: | :-----------------: |
-|        `beamWidth`        | width for beam-search algorithm |      Int      |        \[0, 1024\]       | `0` (disable beam search) |    `beam_width`     |
-| `beamSearchDiversityRate` |  diversity of generated tokens  | List\[Float\] |     \[0, $+\infty$\)     |          `0.0f`           | `diversity_penalty` |
-|      `lengthPenalty`      |    penalize longer sequences    | List\[Float\] |     \[0, $+\infty$\)     |          `0.0f`           |  `length_penalty`   |
-|      `earlyStopping`      |      see description below      |  List\[Int\]  | \($-\infty$, $+\infty$\) |            `0`            |  `early_stopping`   |
+|      Name in TRT-LLM      |           Description           |      Data type      |      Range of value      |       Default value       |     Name in HF      |
+| :-----------------------: | :-----------------------------: | :-----------------: | :----------------------: | :-----------------------: | :-----------------: |
+|        `beamWidth`        | width for beam-search algorithm |         Int         |       \[0, 1024\]        | `0` (disable beam search) |    `beam_width`     |
+| `beamSearchDiversityRate` |  diversity of generated tokens  |    List\[Float\]    |     \[0, $+\infty$\)     |          `0.0f`           | `diversity_penalty` |
+|      `lengthPenalty`      |    penalize longer sequences    |    List\[Float\]    |     \[0, $+\infty$\)     |          `0.0f`           |  `length_penalty`   |
+|      `earlyStopping`      |      see description below      |     List\[Int\]     | \($-\infty$, $+\infty$\) |            `0`            |  `early_stopping`   |
+|     `beamWidthArray`      |      see description below      | List\[List\[Int\]\] |       \[0, 1024\]        |            ``             |         no          |
 
  * Beam-search algorithm: [beam search](https://en.wikipedia.org/wiki/Beam_search).
  * Parameter `diversity_penalty` in HF is only used for `diverse beam-search decoding` (or named `Group-Beam-Search`), which is not supported by TRT-LLM yet.
  * If setting `earlyStopping = 1`, decoding will stop once `beamWidth` finished sentences are generated.
  * If setting `earlyStopping = 0`, decoding will keep going until no better sentences (with better score) can be generated.
  * If setting `earlyStopping` to other values, decoding will stop only depending on `lengthlengthPenalty`.
+ * `beamWidthArray` is a list of beam width for each step. Using `beamWidthArray = [20,40,80]` as an example,
+beam width will be 20 for the first step, 40 for second step, 80 for the later all steps.
  * The `beamWidth` parameter is a scalar value. It means that in this release of
 TensorRT-LLM, it is not possible to specify a different width for each input
 sequence. This limitation is likely to be removed in a future release.

--- a/tests/integration/defs/accuracy/test_cli_flow.py
+++ b/tests/integration/defs/accuracy/test_cli_flow.py
@@ -78,10 +78,17 @@ class TestGpt2(CliFlowAccuracyTestHarness):
                  extra_summarize_args=["--num_beams=4", "--length_penalty=2.0"])
 
     def test_beam_search_large(self, mocker):
-        mocker.patch.object(CnnDailymail, "MAX_BATCH_SIZE", 8)
-        self.run(extra_acc_spec="beam_width=256",
-                 extra_build_args=["--max_beam_width=256"],
-                 extra_summarize_args=["--num_beams=256"])
+        mocker.patch.object(CnnDailymail, "MAX_BATCH_SIZE", 4)
+        self.run(extra_acc_spec="beam_width=1024",
+                 extra_build_args=["--max_beam_width=1024"],
+                 extra_summarize_args=["--num_beams=1024"])
+
+    def test_variable_beam_width_search(self, mocker):
+        mocker.patch.object(self.__class__, "MAX_BATCH_SIZE", 4)
+        self.run(
+            extra_acc_spec="beam_width=8",
+            extra_build_args=["--max_beam_width=8"],
+            extra_eval_args=["--num_beams=8", "--beam_width_array=[2,3,4,5]"])
 
     def test_weight_streaming_ootb(self):
         self.run(extra_build_args=[

--- a/tests/integration/test_lists/qa/examples_test_list.txt
+++ b/tests/integration/test_lists/qa/examples_test_list.txt
@@ -313,6 +313,7 @@ accuracy/test_cli_flow.py::TestGpt2::test_smooth_quant[]
 accuracy/test_cli_flow.py::TestGpt2::test_smooth_quant[per_token-per_channel]
 accuracy/test_cli_flow.py::TestGpt2::test_beam_search
 accuracy/test_cli_flow.py::TestGpt2::test_beam_search_large
+accuracy/test_cli_flow.py::TestGpt2::test_variable_beam_width_search
 accuracy/test_cli_flow.py::TestGpt2::test_weight_streaming_ootb
 accuracy/test_cli_flow.py::TestGpt2::test_weight_streaming_plugin
 accuracy/test_cli_flow.py::TestGpt2::test_cuda_graph

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -88,6 +88,7 @@ l0_a10:
   - accuracy/test_cli_flow.py::TestGpt2::test_auto_dtype # 1 min
   - accuracy/test_cli_flow.py::TestGpt2::test_beam_search # 1 min
   - accuracy/test_cli_flow.py::TestGpt2::test_beam_search_large # 6 mins
+  - accuracy/test_cli_flow.py::TestGpt2::test_variable_beam_width_search # 1 mins
   - accuracy/test_cli_flow.py::TestGpt2::test_weight_streaming_ootb # 1.5 mins
   - accuracy/test_cli_flow.py::TestGpt2::test_cuda_graph # 1 min
   - accuracy/test_cli_flow.py::TestSantacoder::test_auto_dtype # 1.5 mins

--- a/tests/unittest/api_stability/test_llm_api.py
+++ b/tests/unittest/api_stability/test_llm_api.py
@@ -20,7 +20,6 @@ class TestSamplingParams(ApiStabilityTestHarness):
     def test_get_sampling_config(self):
         expected_fields = {
             "beam_width",
-            "beam_width_array",
             "top_k",
             "top_p",
             "top_p_min",
@@ -40,6 +39,7 @@ class TestSamplingParams(ApiStabilityTestHarness):
             "no_repeat_ngram_size",
             "num_return_sequences",
             "min_p",
+            "beam_width_array",
         }
         found_fields = {
             f


### PR DESCRIPTION
## Part 4 of VBWS support.
+ Part 1: [link](https://github.com/NVIDIA/TensorRT-LLM/pull/3082)
+ Part 2: [link](https://github.com/NVIDIA/TensorRT-LLM/pull/3133)
+ Part 3: [link](https://github.com/NVIDIA/TensorRT-LLM/pull/3338)

## Target of this PR
+ Final PR for VBWS support, so we can use such argument as `--beam_width_array=[2,3,4,5]` for generation.
+ Update related document.
+ Add related unit tests.
+ Small refactor on the code and comment in several places.