### PR TITLE
chore: Rename nvsmall to nemotron nas

### DIFF
--- a/examples/pytorch/README.md
+++ b/examples/pytorch/README.md
@@ -52,6 +52,7 @@ python3 quickstart_multimodal.py --model_dir Efficient-Large-Model/NVILA-8B --mo
 | `MixtralForCausalLM` | Mixtral | `mistralai/Mixtral-8x7B-v0.1` | L |
 | `MllamaForConditionalGeneration` | Llama 3.2 | `meta-llama/Llama-3.2-11B-Vision` | L |
 | `NemotronForCausalLM` | Nemotron-3, Nemotron-4, Minitron | `nvidia/Minitron-8B-Base` | L |
+| `NemotronNASForCausalLM` | NemotronNAS | `nvidia/Llama-3_3-Nemotron-Super-49B-v1` | L |
 | `Qwen2ForCausalLM` | QwQ, Qwen2 | `Qwen/Qwen2-7B-Instruct` | L |
 | `Qwen2ForProcessRewardModel` | Qwen2-based | `Qwen/Qwen2.5-Math-PRM-7B` | L |
 | `Qwen2ForRewardModel` | Qwen2-based | `Qwen/Qwen2.5-Math-RM-72B` | L |

--- a/tensorrt_llm/_torch/models/__init__.py
+++ b/tensorrt_llm/_torch/models/__init__.py
@@ -8,7 +8,7 @@ from .modeling_llava_next import LlavaNextModel
 from .modeling_mamba_hybrid import MambaHybridForCausalLM
 from .modeling_mixtral import MixtralForCausalLM
 from .modeling_nemotron import NemotronForCausalLM
-from .modeling_nvsmall import NVSmallForCausalLM
+from .modeling_nemotron_nas import NemotronNASForCausalLM
 from .modeling_qwen import (Qwen2ForCausalLM, Qwen2ForProcessRewardModel,
                             Qwen2ForRewardModel)
 from .modeling_qwen2vl import Qwen2_5_VLModel, Qwen2VLModel
@@ -26,7 +26,7 @@ __all__ = [
     "MambaHybridForCausalLM",
     "MixtralForCausalLM",
     "NemotronForCausalLM",
-    "NVSmallForCausalLM",
+    "NemotronNASForCausalLM",
     "Qwen2ForCausalLM",
     "Qwen2ForProcessRewardModel",
     "Qwen2ForRewardModel",

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nas.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nas.py
@@ -21,7 +21,7 @@ from .modeling_utils import (DecoderModel, DecoderModelForCausalLM,
                              register_auto_model)
 
 
-class NVSmallRotaryEmbedding(RotaryEmbedding):
+class NemotronNASRotaryEmbedding(RotaryEmbedding):
 
     def __init__(self, config: PretrainedConfig, layer_idx: int):
         if config.rope_scaling is not None:
@@ -69,7 +69,7 @@ def _create_linear_from_configs(model_config: ModelConfig[PretrainedConfig],
     )
 
 
-class NVSmallAttention(Attention):
+class NemotronNASAttention(Attention):
 
     def __init__(self, model_config: ModelConfig[PretrainedConfig],
                  layer_idx: int):
@@ -88,7 +88,7 @@ class NVSmallAttention(Attention):
             max_position_embeddings=config.max_position_embeddings,
             bias=False,
             pos_embd_params=pos_embd_params,
-            rotary_emb=NVSmallRotaryEmbedding(config, layer_idx=layer_idx),
+            rotary_emb=NemotronNASRotaryEmbedding(config, layer_idx=layer_idx),
             layer_idx=layer_idx,
             dtype=config.torch_dtype,
             config=model_config)
@@ -120,7 +120,7 @@ class LinearMLP(nn.Module):
         return self.linear_mlp(hidden_states)
 
 
-class NVSmallDecoderLayer(DecoderLayer):
+class NemotronNASDecoderLayer(DecoderLayer):
 
     def __init__(self, model_config: ModelConfig[PretrainedConfig],
                  block_config: Dict[str, Any], layer_idx: int):
@@ -134,8 +134,8 @@ class NVSmallDecoderLayer(DecoderLayer):
             if self.block_config.attention.replace_with_linear:
                 self.self_attn = LinearAttention(model_config, config)
             else:
-                self.self_attn = NVSmallAttention(model_config=model_config,
-                                                  layer_idx=layer_idx)
+                self.self_attn = NemotronNASAttention(model_config=model_config,
+                                                      layer_idx=layer_idx)
         if not self.block_config.ffn.no_op:
             self.post_attention_layernorm = RMSNorm(
                 hidden_size=config.hidden_size,
@@ -182,7 +182,7 @@ class NVSmallDecoderLayer(DecoderLayer):
         return hidden_states
 
 
-class NVSmallModel(DecoderModel):
+class NemotronNASModel(DecoderModel):
 
     def __init__(self, model_config):
         super().__init__(model_config)
@@ -200,7 +200,7 @@ class NVSmallModel(DecoderModel):
             dtype=config.torch_dtype,
         )
         self.layers = nn.ModuleList([
-            NVSmallDecoderLayer(model_config, block_config, layer_idx)
+            NemotronNASDecoderLayer(model_config, block_config, layer_idx)
             for layer_idx, block_config in enumerate(config.block_configs)
         ])
         self.norm = RMSNorm(hidden_size=config.hidden_size,
@@ -209,11 +209,11 @@ class NVSmallModel(DecoderModel):
 
 
 @register_auto_model("DeciLMForCausalLM")
-class NVSmallForCausalLM(DecoderModelForCausalLM[NVSmallModel,
-                                                 PretrainedConfig]):
+class NemotronNASForCausalLM(DecoderModelForCausalLM[NemotronNASModel,
+                                                     PretrainedConfig]):
 
     def __init__(self, model_config: ModelConfig[PretrainedConfig]):
-        super().__init__(NVSmallModel(model_config),
+        super().__init__(NemotronNASModel(model_config),
                          config=model_config,
                          hidden_size=model_config.pretrained_config.hidden_size,
                          vocab_size=model_config.pretrained_config.vocab_size)

--- a/tests/integration/defs/.test_durations
+++ b/tests/integration/defs/.test_durations
@@ -202,7 +202,7 @@
    "examples/test_multimodal.py::test_llm_multimodal_general[Qwen2-VL-7B-Instruct-pp:1-tp:1-float16-bs:1-cpp_e2e:False-nb:4]": 355.9665117710829,
    "examples/test_qwen.py::test_llm_qwen_single_gpu_summary[qwen2_7b_instruct-enable_paged_kv_cache-enable_remove_input_padding-enable_weight_only-enable_fmha]": 334.18761303275824,
    "examples/test_qwen2audio.py::test_llm_qwen2audio_single_gpu[qwen2_audio_7b_instruct]": 373.8418433815241,
-   "test_unittests.py::test_unittests_v2[unittest/_torch/modeling -k \"modeling_nvsmall\"]": 587.2612264081836,
+   "test_unittests.py::test_unittests_v2[unittest/_torch/modeling -k \"modeling_nemotron_nas\"]": 587.2612264081836,
    "test_unittests.py::test_unittests_v2[unittest/trt/model/test_gpt.py -k \"partition2\"]": 1086.5458996072412,
    "examples/test_draft_target_model.py::test_llm_draft_target_model_1gpu[streaming-gpt2-use_cpp_session-use_tokens-draft_len_4-float16-bs1]": 216.4487509690225,
    "examples/test_enc_dec.py::test_llm_enc_dec_general[compare_hf-byt5-small-float32-enable_gemm_plugin-enable_attention_plugin-enable_paged_kv_cache-tp:1-pp:1-nb:1-disable_fp8]": 213.7413339074701,

--- a/tests/integration/test_lists/test-db/l0_a30.yml
+++ b/tests/integration/test_lists/test-db/l0_a30.yml
@@ -18,7 +18,7 @@ l0_a30:
   - unittest/_torch -k "modeling_llama"
   - unittest/_torch/modeling -k "modeling_mixtral"
   - unittest/_torch/modeling -k "modeling_mllama"
-  - unittest/_torch/modeling -k "modeling_nvsmall"
+  - unittest/_torch/modeling -k "modeling_nemotron_nas"
   - unittest/_torch/modeling -k "modeling_out_of_tree"
   - unittest/_torch/modeling -k "modeling_qwen"
   - unittest/_torch/modeling -k "modeling_qwen_moe"

--- a/tests/integration/test_lists/test-db/l0_l40s.yml
+++ b/tests/integration/test_lists/test-db/l0_l40s.yml
@@ -16,7 +16,7 @@ l0_l40s:
   # ------------- PyTorch tests ---------------
   - unittest/_torch -k "not (modeling or multi_gpu or auto_deploy)"
   - unittest/_torch/modeling -k "modeling_mllama"
-  - unittest/_torch/modeling -k "modeling_nvsmall"
+  - unittest/_torch/modeling -k "modeling_nemotron_nas"
   - unittest/_torch/modeling -k "modeling_out_of_tree"
   - unittest/_torch/modeling -k "modeling_qwen"
   - unittest/_torch/modeling -k "modeling_vila"

--- a/tests/unittest/_torch/auto_deploy/integration/test_ad_build.py
+++ b/tests/unittest/_torch/auto_deploy/integration/test_ad_build.py
@@ -96,7 +96,7 @@ from utils.llm_data import llm_models_root
                 pytest.mark.skip(reason="https://nvbugspro.nvidia.com/bug/5178508"),
             ],
         ),
-        # full NVSmall (Llama-3.1-Nemotron-51B) with torch-opt backend + simple runtime
+        # full NemotronNAS (Llama-3.1-Nemotron-51B) with torch-opt backend + simple runtime
         param_with_device_count(
             4,
             {

--- a/tests/unittest/trt/model/test_nemotron_nas.py
+++ b/tests/unittest/trt/model/test_nemotron_nas.py
@@ -359,7 +359,7 @@ class TestNemotronNas(unittest.TestCase):
 
     def get_loader_test_cases():
         model_root = llm_models_root(check=True)
-        test_models_base_path = Path(model_root, "nvsmall/tests")
+        test_models_base_path = Path(model_root, "nemotron_nas/tests")
         models_path = [
             os.path.join(test_models_base_path, x)
             for x in os.listdir(test_models_base_path)
@@ -822,12 +822,13 @@ class TestNemotronNas(unittest.TestCase):
     @parameterized.expand(
         itertools.product(
             os.listdir(
-                Path(llm_models_root(check=True), "nvsmall/tests").as_posix()),
-            (True, False), (1, 2), (1, 2), ("auto", "float16", "bfloat16")))
+                Path(llm_models_root(check=True),
+                     "nemotron_nas/tests").as_posix()), (True, False), (1, 2),
+            (1, 2), ("auto", "float16", "bfloat16")))
     def test_convert_model_from_hf(self, model_dir: Optional[str],
                                    preloaded: bool, tp_size: int, pp_size: int,
                                    dtype: str) -> None:
-        ckpt_path = Path(llm_models_root(check=True), "nvsmall/tests",
+        ckpt_path = Path(llm_models_root(check=True), "nemotron_nas/tests",
                          model_dir)
 
         if preloaded:
@@ -850,11 +851,11 @@ class TestNemotronNas(unittest.TestCase):
     @parameterized.expand(
         itertools.product(
             os.listdir(
-                Path(llm_models_root(check=True), "nvsmall/tests").as_posix()),
-            (1, 2, 4)))
+                Path(llm_models_root(check=True),
+                     "nemotron_nas/tests").as_posix()), (1, 2, 4)))
     def test_weights_loader(self, model_dir: str, tp_size: int) -> None:
 
-        ckpt_path = Path(llm_models_root(check=True), "nvsmall/tests",
+        ckpt_path = Path(llm_models_root(check=True), "nemotron_nas/tests",
                          model_dir)
         config = DeciConfig.from_hugging_face(ckpt_path, trust_remote_code=True)
         weights = load_weights_from_hf_safetensors(ckpt_path, config)

--- a/tests/unittest/trt/model/test_nemotron_nas.py
+++ b/tests/unittest/trt/model/test_nemotron_nas.py
@@ -359,7 +359,7 @@ class TestNemotronNas(unittest.TestCase):
 
     def get_loader_test_cases():
         model_root = llm_models_root(check=True)
-        test_models_base_path = Path(model_root, "nemotron_nas/tests")
+        test_models_base_path = Path(model_root, "nvsmall/tests")
         models_path = [
             os.path.join(test_models_base_path, x)
             for x in os.listdir(test_models_base_path)
@@ -822,13 +822,12 @@ class TestNemotronNas(unittest.TestCase):
     @parameterized.expand(
         itertools.product(
             os.listdir(
-                Path(llm_models_root(check=True),
-                     "nemotron_nas/tests").as_posix()), (True, False), (1, 2),
-            (1, 2), ("auto", "float16", "bfloat16")))
+                Path(llm_models_root(check=True), "nvsmall/tests").as_posix()),
+            (True, False), (1, 2), (1, 2), ("auto", "float16", "bfloat16")))
     def test_convert_model_from_hf(self, model_dir: Optional[str],
                                    preloaded: bool, tp_size: int, pp_size: int,
                                    dtype: str) -> None:
-        ckpt_path = Path(llm_models_root(check=True), "nemotron_nas/tests",
+        ckpt_path = Path(llm_models_root(check=True), "nvsmall/tests",
                          model_dir)
 
         if preloaded:
@@ -851,11 +850,11 @@ class TestNemotronNas(unittest.TestCase):
     @parameterized.expand(
         itertools.product(
             os.listdir(
-                Path(llm_models_root(check=True),
-                     "nemotron_nas/tests").as_posix()), (1, 2, 4)))
+                Path(llm_models_root(check=True), "nvsmall/tests").as_posix()),
+            (1, 2, 4)))
     def test_weights_loader(self, model_dir: str, tp_size: int) -> None:
 
-        ckpt_path = Path(llm_models_root(check=True), "nemotron_nas/tests",
+        ckpt_path = Path(llm_models_root(check=True), "nvsmall/tests",
                          model_dir)
         config = DeciConfig.from_hugging_face(ckpt_path, trust_remote_code=True)
         weights = load_weights_from_hf_safetensors(ckpt_path, config)


### PR DESCRIPTION
Note that `tests/unittest/trt/model/test_nemotron_nas.py` accesses `llm_models_root / "nvsmall/tests"`, so those paths are not updated in this PR, as a new hardlink with `nemotron_nas` should be created first.