### PR TITLE
chore: Unify Python NVTX call

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -49,4 +49,4 @@ opencv-python-headless
 xgrammar==0.1.16
 backoff
 nvtx
-matplotlib
+matplotlib # FIXME: this is added to make nvtx happy

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,3 +49,4 @@ opencv-python-headless
 xgrammar==0.1.16
 backoff
 nvtx
+matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,3 +48,4 @@ flashinfer-python~=0.2.3
 opencv-python-headless
 xgrammar==0.1.16
 backoff
+nvtx

--- a/tensorrt_llm/_utils.py
+++ b/tensorrt_llm/_utils.py
@@ -740,11 +740,48 @@ def _null_context_manager():
     yield
 
 
-def nvtx_range(msg, color="grey", domain="TensorRT-LLM", category=None):
+def nvtx_range(msg: str,
+               color: str = "grey",
+               domain: str = "TensorRT-LLM",
+               category: Optional[str] = None):
+    """
+    Creates an NVTX range annotation for profiling.
+
+    This function returns a context manager that marks the beginning and end of a
+    range in NVIDIA Tools Extension (NVTX) profiling tools like Nsight Systems.
+
+    Args:
+        msg (str): The message/name for the NVTX range.
+        color (str, optional): The color to use for the range in the profiler. Defaults to "grey".
+        domain (str, optional): The domain name for the range. Defaults to "TensorRT-LLM".
+        category (str, optional): The category for the range. Defaults to None.
+
+    Returns:
+        contextmanager: A context manager that marks the NVTX range.
+    """
     return nvtx.annotate(msg, color=color, domain=domain, category=category)
 
 
-def nvtx_range_debug(msg, color="grey", domain="TensorRT-LLM", category=None):
+def nvtx_range_debug(msg: str,
+                     color: str = "grey",
+                     domain: str = "TensorRT-LLM",
+                     category: Optional[str] = None):
+    """
+    Creates an NVTX range annotation for debugging purposes.
+
+    Similar to nvtx_range, but only creates the range if specific environment
+    variables are set, making it suitable for debug profiling.
+
+    Args:
+        msg (str): The message/name for the NVTX range.
+        color (str, optional): The color to use for the range in the profiler. Defaults to "grey".
+        domain (str, optional): The domain name for the range. Defaults to "TensorRT-LLM".
+        category (str, optional): The category for the range. Defaults to None.
+
+    Returns:
+        contextmanager: A context manager that either marks the NVTX range if enabled,
+                        or a null context manager that does nothing if disabled.
+    """
     if os.getenv("TLLM_LLMAPI_ENABLE_NVTX", "0") == "1" or \
             os.getenv("TLLM_NVTX_DEBUG", "0") == "1":
         return nvtx_range(msg, color=color, domain=domain, category=category)
@@ -752,7 +789,22 @@ def nvtx_range_debug(msg, color="grey", domain="TensorRT-LLM", category=None):
         return _null_context_manager()
 
 
-def nvtx_mark(msg, color="grey", domain="TensorRT-LLM", category=None):
+def nvtx_mark(msg: str,
+              color: str = "grey",
+              domain: str = "TensorRT-LLM",
+              category: Optional[str] = None):
+    """
+    Creates an NVTX marker for profiling.
+
+    This function places a single marker point in NVIDIA Tools Extension (NVTX)
+    profiling tools like Nsight Systems, useful for marking specific events.
+
+    Args:
+        msg (str): The message/name for the NVTX marker.
+        color (str, optional): The color to use for the marker in the profiler. Defaults to "grey".
+        domain (str, optional): The domain name for the marker. Defaults to "TensorRT-LLM".
+        category (str, optional): The category for the marker. Defaults to None.
+    """
     nvtx.mark(msg, color=color, category=category, domain=domain)
 
 

--- a/tensorrt_llm/_utils.py
+++ b/tensorrt_llm/_utils.py
@@ -21,6 +21,7 @@ import os
 import struct
 import trace
 import weakref
+from contextlib import contextmanager
 from dataclasses import asdict
 from enum import EnumMeta
 from functools import partial, wraps
@@ -734,6 +735,11 @@ class QuantModeWrapper:
         return self.objs[index]
 
 
+@contextmanager
+def _null_context_manager():
+    yield
+
+
 def nvtx_range(msg, color="grey", domain="TensorRT-LLM", category=None):
     return nvtx.annotate(msg, color=color, domain=domain, category=category)
 
@@ -742,6 +748,8 @@ def nvtx_range_debug(msg, color="grey", domain="TensorRT-LLM", category=None):
     if os.getenv("TLLM_LLMAPI_ENABLE_NVTX", "0") == "1" or \
             os.getenv("TLLM_NVTX_DEBUG", "0") == "1":
         return nvtx_range(msg, color=color, domain=domain, category=category)
+    else:
+        return _null_context_manager()
 
 
 def nvtx_mark(msg, color="grey", domain="TensorRT-LLM", category=None):

--- a/tensorrt_llm/executor/ipc.py
+++ b/tensorrt_llm/executor/ipc.py
@@ -8,8 +8,9 @@ import zmq.asyncio
 
 from tensorrt_llm.logger import logger
 
-from ..llmapi.utils import (ManagedThread, enable_llm_debug, nvtx_mark,
-                            nvtx_range, print_colored, print_colored_debug)
+from .._utils import nvtx_mark, nvtx_range_debug
+from ..llmapi.utils import (ManagedThread, enable_llm_debug, print_colored,
+                            print_colored_debug)
 
 
 class ZeroMqQueue:
@@ -86,7 +87,7 @@ class ZeroMqQueue:
 
     def put(self, obj: Any):
         self.setup_lazily()
-        with nvtx_range("send", color="blue", category="IPC"):
+        with nvtx_range_debug("send", color="blue", category="IPC"):
             self.socket.send_pyobj(obj)
 
     async def put_async(self, obj: Any):

--- a/tensorrt_llm/executor/postproc_worker.py
+++ b/tensorrt_llm/executor/postproc_worker.py
@@ -8,9 +8,10 @@ from typing import (TYPE_CHECKING, Any, Callable, Dict, List, NamedTuple,
 import zmq
 import zmq.asyncio
 
+from .._utils import nvtx_range_debug
 from ..bindings import executor as tllm
 from ..llmapi.tokenizer import TransformersTokenizer, load_hf_tokenizer
-from ..llmapi.utils import nvtx_range, print_traceback_on_error
+from ..llmapi.utils import print_traceback_on_error
 from ..sampling_params import SamplingParams
 from .ipc import ZeroMqQueue
 
@@ -125,7 +126,9 @@ class PostprocWorker:
                 "Context logits or generation logits are not supposed to be "
                 "sent to postprocessing workers.")
 
-        with nvtx_range("handle_input", color="yellow", category="Postproc"):
+        with nvtx_range_debug("handle_input",
+                              color="yellow",
+                              category="Postproc"):
             req_id = input.rsp.client_id
             if req_id not in self._records:
                 # TODO: support variant creation later

--- a/tensorrt_llm/executor/result.py
+++ b/tensorrt_llm/executor/result.py
@@ -8,10 +8,11 @@ from weakref import WeakMethod
 
 import torch
 
+from .._utils import nvtx_range_debug
 from ..bindings import executor as tllm
 from ..disaggregated_params import DisaggregatedParams
 from ..llmapi.tracer import global_tracer
-from ..llmapi.utils import AsyncQueue, nvtx_range
+from ..llmapi.utils import AsyncQueue
 from ..sampling_params import SamplingParams
 from .utils import ErrorResponse, has_event_loop
 
@@ -219,7 +220,9 @@ class GenerationResultBase:
                 raise ValueError(
                     f"Unknown finish reason: {finish_reasons[src_idx]}")
 
-    @nvtx_range("handle_response", color="red", category="GenerationResultBase")
+    @nvtx_range_debug("handle_response",
+                      color="red",
+                      category="GenerationResultBase")
     def _handle_response(self, response: Union["PostprocWorker.Output",
                                                tllm.Response, ErrorResponse]):
 
@@ -299,9 +302,9 @@ class DetokenizedGenerationResultBase(GenerationResultBase):
         self.tokenizer = tokenizer
         self._streaming = streaming
 
-    @nvtx_range("handle_response",
-                color="red",
-                category="DetokenizedGenerationResultBase")
+    @nvtx_range_debug("handle_response",
+                      color="red",
+                      category="DetokenizedGenerationResultBase")
     def _handle_response(self, response: "GenerationExecutor.Response"):
         GenerationResultBase._handle_response(self, response)
 

--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -14,15 +14,16 @@ import torch
 
 from tensorrt_llm.logger import logger
 
-from .._utils import KVCacheEventSerializer, global_mpi_rank, mpi_comm, mpi_rank
+from .._utils import (KVCacheEventSerializer, global_mpi_rank, mpi_comm,
+                      mpi_rank, nvtx_range_debug)
 from ..bindings import executor as tllm
 from ..builder import ConfigEncoder, Engine, EngineConfig
 from ..llmapi.llm_args import PybindMirror
 from ..llmapi.mpi_session import set_mpi_session_cpp
 from ..llmapi.tracer import VizTracer, global_tracer, set_global_tracer
 from ..llmapi.utils import (AsyncQueue, ManagedThread, _SyncQueue,
-                            clear_sched_affinity, nvtx_range,
-                            print_colored_debug, print_traceback_on_error)
+                            clear_sched_affinity, print_colored_debug,
+                            print_traceback_on_error)
 from ..lora_manager import LoraManager
 from ..prompt_adapter_manager import PromptAdapterManager
 from ..runtime import ModelConfig
@@ -732,9 +733,9 @@ class AwaitResponseHelper:
                 lambda _: _,
                 [self.worker._engine_response_callback(r) for r in responses]))
 
-        with nvtx_range(f"await_response-{len(responses)}",
-                        color="red",
-                        category="Worker"):
+        with nvtx_range_debug(f"await_response-{len(responses)}",
+                              color="red",
+                              category="Worker"):
             self.responses_handler(responses)
         return True
 
@@ -770,9 +771,9 @@ class AwaitResponseHelper:
         in a FusedIpcQueue, and a background thread will batch them and invoke
         IPC periodically. '''
 
-        with nvtx_range(f"handle_for_ipc_periodically-{len(responses)}",
-                        color="red",
-                        category="Worker"):
+        with nvtx_range_debug(f"handle_for_ipc_periodically-{len(responses)}",
+                              color="red",
+                              category="Worker"):
 
             for response in responses:
 

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -11,7 +11,7 @@ from tqdm import tqdm
 from transformers import PreTrainedTokenizerBase
 
 from .. import bindings as tllm
-from .._utils import global_mpi_rank
+from .._utils import global_mpi_rank, nvtx_range_debug
 from ..bindings import executor as tllm
 from ..builder import EngineConfig
 from ..disaggregated_params import DisaggregatedParams
@@ -31,7 +31,7 @@ from .mpi_session import MpiPoolSession, external_mpi_comm_available
 from .tokenizer import TokenizerBase, _xgrammar_tokenizer_info
 # TODO[chunweiy]: move the following symbols back to utils scope, and remove the following import
 from .utils import (append_docstring, exception_handler, get_device_count,
-                    nvtx_range, print_colored_debug)
+                    print_colored_debug)
 
 
 class RequestOutput(DetokenizedGenerationResultBase, GenerationResult):
@@ -264,7 +264,7 @@ class LLM:
 
         return futures
 
-    @nvtx_range("LLM.generate_async", color="green", category="LLM")
+    @nvtx_range_debug("LLM.generate_async", color="green", category="LLM")
     def generate_async(
         self,
         inputs: PromptInputs,

--- a/tensorrt_llm/llmapi/utils.py
+++ b/tensorrt_llm/llmapi/utils.py
@@ -10,7 +10,6 @@ import time
 import traceback
 import warnings
 import weakref
-from contextlib import contextmanager
 from functools import cache, wraps
 from pathlib import Path
 from queue import Queue
@@ -26,37 +25,6 @@ from pydantic import BaseModel
 from tqdm.auto import tqdm
 
 from tensorrt_llm.logger import Singleton, logger
-
-_nvtx_available = False
-
-try:
-    import nvtx
-
-    _nvtx_available = True
-
-except ImportError:
-    _nvtx_available = False
-
-_nvtx_available = _nvtx_available and os.getenv("TLLM_LLMAPI_ENABLE_NVTX",
-                                                "0") == "1"
-
-
-@contextmanager
-def _nvtx_range_faked(*args, **kwargs):
-    yield
-
-
-def nvtx_range(msg, color="grey", domain="TensorRT-LLM", category=None):
-    if _nvtx_available:
-        return nvtx.annotate(msg, color=color, category=category, domain=domain)
-    else:
-
-        return _nvtx_range_faked()
-
-
-def nvtx_mark(msg, color="grey", domain="TensorRT-LLM", category=None):
-    if _nvtx_available:
-        nvtx.mark(msg, color=color, category=category, domain=domain)
 
 
 def print_traceback_on_error(func):

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -19,7 +19,6 @@ from tensorrt_llm.executor import CppExecutorError
 from tensorrt_llm.executor.postproc_worker import PostprocParams
 from tensorrt_llm.llmapi import LLM
 from tensorrt_llm.llmapi.llm import RequestOutput
-from tensorrt_llm.llmapi.utils import nvtx_mark
 from tensorrt_llm.logger import logger
 from tensorrt_llm.serve.openai_protocol import (ChatCompletionRequest,
                                                 ChatCompletionResponse,
@@ -34,6 +33,8 @@ from tensorrt_llm.serve.postprocess_handlers import (
     chat_stream_post_processor, completion_response_post_processor,
     completion_stream_post_processor)
 from tensorrt_llm.version import __version__ as VERSION
+
+from .._utils import nvtx_mark
 
 # yapf: enale
 TIMEOUT_KEEP_ALIVE = 5  # seconds.

--- a/tensorrt_llm/serve/postprocess_handlers.py
+++ b/tensorrt_llm/serve/postprocess_handlers.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass
 from typing import List, Literal, Optional, Union
 
+from .._utils import nvtx_range_debug
 from ..executor import (DetokenizedGenerationResultBase, GenerationResult,
                         GenerationResultBase)
 from ..executor.postproc_worker import PostprocArgs
 from ..llmapi.tokenizer import TransformersTokenizer
-from ..llmapi.utils import nvtx_range
 # yapf: disable
 from .openai_protocol import (ChatCompletionLogProbs,
                               ChatCompletionLogProbsContent,
@@ -70,7 +70,7 @@ def create_logprobs(token_ids: List[int],
     return chat_logprobs
 
 
-@nvtx_range("chat_stream_post_processor")
+@nvtx_range_debug("chat_stream_post_processor")
 def chat_stream_post_processor(rsp: GenerationResultBase, args: ChatPostprocArgs) -> List[str]:
 
     def yield_first_chat(num_tokens: int,
@@ -158,7 +158,7 @@ def chat_stream_post_processor(rsp: GenerationResultBase, args: ChatPostprocArgs
     return res
 
 
-@nvtx_range("chat_response_post_processor")
+@nvtx_range_debug("chat_response_post_processor")
 def chat_response_post_processor(rsp: GenerationResultBase, args: ChatPostprocArgs) -> ChatCompletionResponse:
     choices: List[ChatCompletionResponseChoice] = []
     role = args.role
@@ -229,7 +229,7 @@ class CompletionPostprocArgs(PostprocArgs):
         )
 
 
-@nvtx_range("completion_stream_post_processor")
+@nvtx_range_debug("completion_stream_post_processor")
 def completion_stream_post_processor(rsp: DetokenizedGenerationResultBase, args: CompletionPostprocArgs) -> List[str]:
     res: List[str] = []
     prompt_tokens = args.num_prompt_tokens
@@ -275,7 +275,7 @@ def completion_stream_post_processor(rsp: DetokenizedGenerationResultBase, args:
     return res
 
 
-@nvtx_range("completion_response_post_processor")
+@nvtx_range_debug("completion_response_post_processor")
 def completion_response_post_processor(rsp: GenerationResult, args: CompletionPostprocArgs) -> CompletionResponse:
     prompt_tokens = args.num_prompt_tokens
     completion_tokens = 0


### PR DESCRIPTION
* Move and unify NVTX implementation to `tensorrt_llm/_utils.py`
* Replace the original LLM API NVTX with `nvtx_range_debug` call