### PR TITLE
fix: Eagle decoding

### DIFF
--- a/cpp/tensorrt_llm/kernels/speculativeDecoding/common.h
+++ b/cpp/tensorrt_llm/kernels/speculativeDecoding/common.h
@@ -35,22 +35,26 @@ namespace tensorrt_llm::kernels::speculative_decoding
 //! \param bestPathIds input buffer [maxBatchSize], indices of the selected paths
 //! \param paths input buffer [engineBatchSize, numPaths, maxPathLen] if isPathsLinearBatchIdx else [maxBatchSize,
 //! numPaths, maxPathLen], paths to restore sequences from outputIds and targetIds. Should be filled with -1 for
-//! everything that is not path. \param batchSlots input buffer [engineBatchSize], address map from local index to
-//! global index [0, batchSize]
-//! -> [0, maxBatchSize]
+//! everything that is not path.
+//! \param batchSlots input buffer [engineBatchSize], address map from local index to
+//! global index [0, batchSize] -> [0, maxBatchSize].
+//! This is in the order of increasing order of the requests in the decoder.
+//! \param seqSlots input buffer [engineBatchSize], address map from local index to
+//! global index [0, batchSize] -> [0, maxBatchSize]
+//! These are the slots of the sequences in the runtime buffers.
 //! \param batchSize the number of sequences to be decoded
 //! \param engineBatchSize number of sequences processed in the engine.
 //! Includes chunked context reqs that are not in the last chunk.
 //! \param numPaths maximum number of tokens per step
 //! configured in the system
 //! \param maxPathLen maximum sequence length of the sequence containing draft tokens
-//! \param isPathsLinearBatchIdx access paths using batch slot or linear batch idx
+//! \param isPathsSeqSlotIdx access paths using batch slot or seq slot
 //! \param stream stream
 void invokePackAcceptedPaths(runtime::SizeType32* acceptedLengthsCumSum, runtime::SizeType32* pathsOffsets,
     runtime::SizeType32 const* acceptedLengths, runtime::SizeType32 const* bestPathIds,
-    runtime::SizeType32 const* paths, runtime::SizeType32 const* batchSlots, runtime::SizeType32 batchSize,
-    runtime::SizeType32 engineBatchSize, runtime::SizeType32 numPaths, runtime::SizeType32 maxPathLen,
-    bool isPathsLinearBatchIdx, cudaStream_t stream);
+    runtime::SizeType32 const* paths, runtime::SizeType32 const* batchSlots, runtime::SizeType32 const* seqSlots,
+    runtime::SizeType32 batchSize, runtime::SizeType32 engineBatchSize, runtime::SizeType32 numPaths,
+    runtime::SizeType32 maxPathLen, bool isPathsSeqSlotIdx, cudaStream_t stream);
 
 template <typename T>
 struct AcceptDraftTokensByIdsWithPathsParams

--- a/cpp/tensorrt_llm/layers/eagleDecodingLayer.cpp
+++ b/cpp/tensorrt_llm/layers/eagleDecodingLayer.cpp
@@ -280,8 +280,8 @@ void EagleDecodingLayer<T>::packAcceptedPaths(EagleOutputs const& outputs, Eagle
 
     int8_t* workspaceBytePtr = reinterpret_cast<int8_t*>(workspace->getRawWorkspaceDevicePtr());
     size_t offset{0};
-    nextWorkspacePtr(workspaceBytePtr, offset, engineBatchSize * sizeof(SizeType32));
-
+    SizeType32* augmentedSeqSlots = reinterpret_cast<SizeType32*>(
+        nextWorkspacePtr(workspaceBytePtr, offset, engineBatchSize * sizeof(SizeType32)));
     SizeType32* augmentedBatchSlots = reinterpret_cast<SizeType32*>(
         nextWorkspacePtr(workspaceBytePtr, offset, engineBatchSize * sizeof(SizeType32)));
 
@@ -289,6 +289,7 @@ void EagleDecodingLayer<T>::packAcceptedPaths(EagleOutputs const& outputs, Eagle
     auto numNewTokensCumSum = bufferCast<SizeType32>(*outputs.numNewTokensCumSum);
     auto pathsOffsets = bufferCast<SizeType32>(*outputs.pathsOffsets);
     auto batchSlots = augmentedBatchSlots;
+    auto seqSlots = augmentedSeqSlots;
     auto bestPathIndicesSlotsPtr = bufferCast<SizeType32>(*inputs.acceptedPathIds);
     auto lastDraftPathsSlotsPtr = bufferCast<SizeType32>(*inputs.lastDraftPaths);
 
@@ -297,7 +298,7 @@ void EagleDecodingLayer<T>::packAcceptedPaths(EagleOutputs const& outputs, Eagle
     TLLM_CHECK_WITH_INFO(numNewTokensCumSum != nullptr, "numNewTokensCumSum must be provided for EagleDecodingLayer");
     TLLM_CHECK_WITH_INFO(pathsOffsets != nullptr, "pathsOffsets must be provided for EagleDecodingLayer");
     invokePackAcceptedPaths(numNewTokensCumSum, pathsOffsets, numNewTokens, bestPathIndicesSlotsPtr,
-        lastDraftPathsSlotsPtr, batchSlots, batchSize, engineBatchSize,
+        lastDraftPathsSlotsPtr, batchSlots, seqSlots, batchSize, engineBatchSize,
         mDecoderDomain.getSpeculativeDecodingModule()->getMaxNumPaths(),
         mDecoderDomain.getSpeculativeDecodingModule()->getMaxPathLen(), true, getStream());
 

--- a/cpp/tensorrt_llm/layers/explicitDraftTokensLayer.cpp
+++ b/cpp/tensorrt_llm/layers/explicitDraftTokensLayer.cpp
@@ -288,7 +288,7 @@ void ExplicitDraftTokensLayer<T>::packAcceptedPaths(ExplicitDraftTokensOutputs c
         numNewTokensCumSum != nullptr, "numNewTokensCumSum must be provided for ExplicitDraftTokensLayer");
     TLLM_CHECK_WITH_INFO(pathsOffsets != nullptr, "pathsOffsets must be provided for ExplicitDraftTokensLayer");
     invokePackAcceptedPaths(numNewTokensCumSum, pathsOffsets, numNewTokens, bestPathIndicesSlotsPtr,
-        lastDraftIndicesSlotsPtr, batchSlots, batchSize, batchSize,
+        lastDraftIndicesSlotsPtr, batchSlots, nullptr, batchSize, batchSize,
         mDecoderDomain.getSpeculativeDecodingModule()->getMaxNumPaths(),
         mDecoderDomain.getSpeculativeDecodingModule()->getMaxPathLen(), false, getStream());
 

--- a/cpp/tensorrt_llm/layers/medusaDecodingLayer.cpp
+++ b/cpp/tensorrt_llm/layers/medusaDecodingLayer.cpp
@@ -469,7 +469,7 @@ void MedusaDecodingLayer<T>::packAcceptedPaths(SpeculativeDecodingOutputs const&
     TLLM_CHECK_WITH_INFO(numNewTokensCumSum != nullptr, "numNewTokensCumSum must be provided for MedusaDecoding");
     TLLM_CHECK_WITH_INFO(pathsOffsets != nullptr, "pathsOffsets must be provided for MedusaDecoding");
     invokePackAcceptedPaths(numNewTokensCumSum, pathsOffsets, numNewTokens, bestPathIdsDevicePtr, paths, batchSlots,
-        batchSize, batchSize, mDecoderDomain.getMaxDecodingTokens(),
+        nullptr, batchSize, batchSize, mDecoderDomain.getMaxDecodingTokens(),
         mDecoderDomain.getSpeculativeDecodingModule()->getMaxPathLen(), false, getStream());
 
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);

--- a/cpp/tests/batch_manager/trtGptModelRealDecoderTest.cpp
+++ b/cpp/tests/batch_manager/trtGptModelRealDecoderTest.cpp
@@ -1667,7 +1667,8 @@ INSTANTIATE_TEST_SUITE_P(EagleTests, ParamTest,
                 .setKVCacheType(KVCacheType::kPAGED)
                 .useEagle()
                 .setBatchSizes({8})),
-        testing::Values(TrtGptModelType::InflightFusedBatching), testing::Values(TrtGptModelIfbTestType::BULK),
+        testing::Values(TrtGptModelType::InflightFusedBatching),
+        testing::Values(TrtGptModelIfbTestType::BULK, TrtGptModelIfbTestType::WAVEFRONT),
         testing::Values(BeamConfig{1, {1}}),
         testing::Values(std::nullopt), // maxTokensInPagedKvCache
         testing::Values(std::nullopt), // freeGpuMemoryFraction


### PR DESCRIPTION
Fix issue that Eagle decoding would produce bad output when decoding slots were not in order in a batch.

Add wavefront test to cover the case. W/o the fix the test would fail.