### PR TITLE
fix: switch ZMQ from file socket to tcp socket in RemoteMpiCommSession

### DIFF
--- a/tensorrt_llm/llmapi/mpi_session.py
+++ b/tensorrt_llm/llmapi/mpi_session.py
@@ -232,12 +232,11 @@ class RemoteMpiCommSessionClient():
     '''
 
     def __init__(self, addr: str):
+        from tensorrt_llm.executor.ipc import ZeroMqQueue
+        self.addr = addr
         print_colored_debug(
             f"RemoteMpiCommSessionClient connecting to {addr}\n", "yellow")
-        self.addr = addr
-        self.context = zmq.Context()
-        self.socket = self.context.socket(zmq.PAIR)
-        self.socket.connect(addr)
+        self.queue = ZeroMqQueue(addr, is_server=False)
         self._is_shutdown = False
 
     def submit(self, task: Callable[..., T], *args, **kwargs) -> list:
@@ -246,9 +245,9 @@ class RemoteMpiCommSessionClient():
                 "RemoteMpiCommSessionClient is already shut down\n", "yellow")
             return []
         print_colored_debug(
-            f"RemoteMpiCommSessionClient [rank{global_mpi_rank()}] Sending task {task} to {self.addr}\n",
+            f"RemoteMpiCommSessionClient [rank{global_mpi_rank()}] sending task {task} to {self.addr}\n",
             "yellow")
-        self.socket.send_pyobj(RemoteTask(task, args, kwargs))
+        self.queue.put(RemoteTask(task, args, kwargs))
         return []
 
     def shutdown(self):
@@ -259,10 +258,7 @@ class RemoteMpiCommSessionClient():
             print_colored_debug(
                 f"RemoteMpiCommSessionClient [rank{global_mpi_rank()}] send shutdown signal to server\n",
                 "green")
-            self.socket.send_pyobj(
-                None)  # ask RemoteMpiCommSessionServer to shutdown
-            self.socket.close()
-            self.context.term()
+            self.queue.put(None)  # ask RemoteMpiCommSessionServer to shutdown
         except zmq.error.ZMQError as e:
             print_colored_debug(
                 f"Error during RemoteMpiCommSessionClient shutdown: {e}\n",
@@ -281,10 +277,9 @@ class RemoteMpiCommSessionServer():
                  addr: str = f'tcp://127.0.0.1:*',
                  comm=None,
                  is_comm: bool = False):
-        self.context = zmq.Context()
-        self.socket = self.context.socket(zmq.PAIR)
-        self.socket.bind(addr)
-        self.addr = self.socket.getsockopt(zmq.LAST_ENDPOINT).decode()
+        from tensorrt_llm.executor.ipc import ZeroMqQueue
+        self.addr = addr
+        self.queue = ZeroMqQueue(addr, is_server=True)
         self.comm = comm
 
         if self.comm is not None:
@@ -299,7 +294,7 @@ class RemoteMpiCommSessionServer():
         print_colored_debug(
             f"RemoteMpiCommSessionServer listening on {self.addr}\n", "yellow")
         while True:
-            message: Optional[RemoteTask] = self.socket.recv_pyobj()
+            message: Optional[RemoteTask] = self.queue.get()
             if message is None:
                 print_colored_debug(
                     f"RemoteMpiCommSessionServer [rank{global_mpi_rank()}] received shutdown signal\n",

--- a/tensorrt_llm/llmapi/mpi_session.py
+++ b/tensorrt_llm/llmapi/mpi_session.py
@@ -232,6 +232,7 @@ class RemoteMpiCommSessionClient():
     '''
 
     def __init__(self, addr: str):
+        # FIXME: this is a hack to avoid circular import, resolve later
         from tensorrt_llm.executor.ipc import ZeroMqQueue
         self.addr = addr
         print_colored_debug(
@@ -277,6 +278,7 @@ class RemoteMpiCommSessionServer():
                  addr: str = f'tcp://127.0.0.1:*',
                  comm=None,
                  is_comm: bool = False):
+        # FIXME: this is a hack to avoid circular import, resolve later
         from tensorrt_llm.executor.ipc import ZeroMqQueue
         self.addr = addr
         self.queue = ZeroMqQueue(addr, is_server=True)

--- a/tensorrt_llm/llmapi/trtllm-llmapi-launch
+++ b/tensorrt_llm/llmapi/trtllm-llmapi-launch
@@ -5,14 +5,13 @@ task_with_command="${@:1}"
 native_mpi_rank=$OMPI_COMM_WORLD_RANK
 mpi_rank=${SLURM_PROCID:-${OMPI_COMM_WORLD_RANK:-${PMI_RANK:-${PMI_ID:-0}}}}
 
-log_stderr() { echo "$@" >&2; }
+log_stderr() { echo -e "\033[33m$@\033[0m" >&2; }
 log_stderr "mpi_rank: $mpi_rank"
 
 pid=$(ps -o pid= -p $$ | tr -d ' ')
 
 # Tell TRTLLM to spawn a additional process for the Proxy
 export TLLM_SPAWN_PROXY_PROCESS=1
-export TLLM_SPAWN_PROXY_PROCESS_IPC_ADDR="ipc:///tmp/trtllm-ipc-${pid}"
 
 function mpi_size {
     if [ -n "$SLURM_JOB_NUM_NODES" ]; then
@@ -24,8 +23,17 @@ function mpi_size {
     fi
 }
 
+function export_free_tcp_addr {
+    # find free port with python -c, the port should start from 10000
+    local free_port=$(python -c 'import socket; s=socket.socket(); s.bind(("", 10000)); print(s.getsockname()[1]); s.close()')
+    export TLLM_SPAWN_PROXY_PROCESS_IPC_ADDR="tcp://127.0.0.1:${free_port}"
+    log_stderr "TLLM_SPAWN_PROXY_PROCESS_IPC_ADDR: $TLLM_SPAWN_PROXY_PROCESS_IPC_ADDR"
+}
+
 export tllm_mpi_size=$(mpi_size)
 log_stderr "tllm_mpi_size: $tllm_mpi_size"
+
+export_free_tcp_addr
 
 if [ -z "$mpi_rank" ] || [ "$mpi_rank" -eq 0 ]; then
     log_stderr "rank${mpi_rank} run ${task_with_command} in background"


### PR DESCRIPTION
For zmq.PAIR based on file socket requires the `bind` side to set up first and then the `connect` side, or there may be unknown issues. This PR switched the file socket to TCP socket to eliminate such requirement and enhance stability.