### PR TITLE
perf: Optimize quantization kernels used in DeepSeek on Hopper

### DIFF
--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_gemm_kernel.cuh
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_gemm_kernel.cuh
@@ -991,10 +991,6 @@ __global__ void scale_1x128_kernel(
         // Each thread reads 2 elements from input_line
         int lane_id = threadIdx.x % 32 * 2;
 
-        // if constexpr (std::is_same<InputType, half>::value)
-        // {
-        //     using Input2Type = __half2;
-        // }
         Input2Type input_frag2[2] = {Input2Type(0, 0), Input2Type(0, 0)};
 
         for (int i = 0; i < 2; i++)
@@ -1287,7 +1283,6 @@ __global__ void scale_1x128_reshape_kernel(
             }
             else
             {
-                // input_frag2[i] = make_bfloat162(input_line[lane_id], input_line[lane_id+1]);
                 input_frag2[i] = *((Input2Type*) (input_line) + lane_id / 2);
             }
             input_line += 64;

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_gemm_kernel.cuh
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_gemm_kernel.cuh
@@ -992,7 +992,7 @@ __global__ void scale_1x128_kernel(
         int lane_id = threadIdx.x % 32 * 2;
 
         Input2Type input_frag2[2] = {Input2Type(0, 0), Input2Type(0, 0)};
-
+#pragma unroll
         for (int i = 0; i < 2; i++)
         {
             if (scales_idx_x * 128 + i * 64 + lane_id >= dim_x)
@@ -1005,6 +1005,7 @@ __global__ void scale_1x128_kernel(
             }
             input_line += 64;
         }
+#pragma unroll
         for (int i = 0; i < 2; i++)
         {
             if (scales_idx_x * 128 + i * 64 + lane_id >= dim_x)
@@ -1026,6 +1027,7 @@ __global__ void scale_1x128_kernel(
         }
 
         OutputType* output_line = output + (size_t) scales_idx_y * dim_x + scales_idx_x * 128;
+#pragma unroll
         for (int i = 0; i < 2; i++)
         {
             if (scales_idx_x * 128 + i * 64 + lane_id >= dim_x)

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_gemm_kernel.cuh
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_gemm_kernel.cuh
@@ -979,7 +979,7 @@ __global__ void scale_1x128_kernel(
     size_t scales_along_dim_x = div_up(dim_x, 128);
     size_t scales_along_dim_y = div_up(dim_y, 1);
     size_t stride_scale_dim_y = div_up(dim_y, 4) * 4;
-
+    using Input2Type = typename std::conditional<std::is_same<InputType, half>::value, half2, __nv_bfloat162>::type;
     for (size_t warp_idx = (blockIdx.x * blockDim.x + threadIdx.x) / 32;
          warp_idx < scales_along_dim_x * scales_along_dim_y; warp_idx += gridDim.x * blockDim.x / 32)
     {
@@ -988,21 +988,37 @@ __global__ void scale_1x128_kernel(
 
         InputType const* input_line = input + (size_t) scales_idx_y * dim_x + scales_idx_x * 128;
         InputType input_amax = InputType(0);
-        int lane_id = threadIdx.x % 32;
-        InputType input_frag[4] = {0};
+        // Each thread reads 2 elements from input_line
+        int lane_id = threadIdx.x % 32 * 2;
 
-        for (int i = 0; i < 4; i++)
+        // if constexpr (std::is_same<InputType, half>::value)
+        // {
+        //     using Input2Type = __half2;
+        // }
+        Input2Type input_frag2[2] = {Input2Type(0, 0), Input2Type(0, 0)};
+
+        for (int i = 0; i < 2; i++)
         {
-            if (scales_idx_x * 128 + i * 32 + lane_id >= dim_x)
+            if (scales_idx_x * 128 + i * 64 + lane_id >= dim_x)
             {
                 break;
             }
             else
             {
-                input_frag[i] = input_line[lane_id];
-                input_amax = InputType(std::max(float(input_amax), std::fabs(float(input_frag[i]))));
+                input_frag2[i] = *((Input2Type*) (input_line) + lane_id / 2);
             }
-            input_line += 32;
+            input_line += 64;
+        }
+        for (int i = 0; i < 2; i++)
+        {
+            if (scales_idx_x * 128 + i * 64 + lane_id >= dim_x)
+            {
+                break;
+            }
+            else
+            {
+                input_amax = InputType(__hmax(input_amax, __hmax(__habs(input_frag2[i].x), __habs(input_frag2[i].y))));
+            }
         }
 
         InputType amax = find_max_elem_in_warp(input_amax);
@@ -1014,18 +1030,20 @@ __global__ void scale_1x128_kernel(
         }
 
         OutputType* output_line = output + (size_t) scales_idx_y * dim_x + scales_idx_x * 128;
-        for (int i = 0; i < 4; i++)
+        for (int i = 0; i < 2; i++)
         {
-            if (scales_idx_x * 128 + i * 32 + lane_id >= dim_x)
+            if (scales_idx_x * 128 + i * 64 + lane_id >= dim_x)
             {
                 break;
             }
             else
             {
-                ScaleType value = ScaleType(input_frag[i]) * scale;
-                output_line[lane_id] = OutputType(value);
+                ScaleType value_1 = ScaleType(input_frag2[i].x) * scale;
+                ScaleType value_2 = ScaleType(input_frag2[i].y) * scale;
+                output_line[lane_id] = OutputType(value_1);
+                output_line[lane_id + 1] = OutputType(value_2);
             }
-            output_line += 32;
+            output_line += 64;
         }
     }
 #endif
@@ -1245,7 +1263,7 @@ __global__ void scale_1x128_reshape_kernel(
     size_t scales_along_dim_y = div_up(dim_y, 1);
     size_t scales_along_dim_h = div_up(dim_h, 1);
     size_t stride_scale_dim_y = div_up(dim_y, 4) * 4;
-
+    using Input2Type = typename std::conditional<std::is_same<InputType, half>::value, half2, __nv_bfloat162>::type;
     for (size_t warp_idx = (blockIdx.x * blockDim.x + threadIdx.x) / 32;
          warp_idx < scales_along_dim_x * scales_along_dim_y * scales_along_dim_h;
          warp_idx += gridDim.x * blockDim.x / 32)
@@ -1257,21 +1275,34 @@ __global__ void scale_1x128_reshape_kernel(
         InputType const* input_line
             = input + (size_t) scales_idx_y * stride_x * dim_h + (size_t) scales_idx_h * stride_x + scales_idx_x * 128;
         InputType input_amax = InputType(0);
-        int lane_id = threadIdx.x % 32;
-        InputType input_frag[4] = {0};
+        int lane_id = threadIdx.x % 32 * 2;
 
-        for (int i = 0; i < 4; i++)
+        Input2Type input_frag2[2] = {Input2Type(0, 0), Input2Type(0, 0)};
+#pragma unroll
+        for (int i = 0; i < 2; i++)
         {
-            if (scales_idx_x * 128 + i * 32 + lane_id >= dim_x)
+            if (scales_idx_x * 128 + i * 64 + lane_id >= dim_x)
             {
                 break;
             }
             else
             {
-                input_frag[i] = input_line[lane_id];
-                input_amax = InputType(std::max(float(input_amax), std::fabs(float(input_frag[i]))));
+                // input_frag2[i] = make_bfloat162(input_line[lane_id], input_line[lane_id+1]);
+                input_frag2[i] = *((Input2Type*) (input_line) + lane_id / 2);
             }
-            input_line += 32;
+            input_line += 64;
+        }
+#pragma unroll
+        for (int i = 0; i < 2; i++)
+        {
+            if (scales_idx_x * 128 + i * 64 + lane_id >= dim_x)
+            {
+                break;
+            }
+            else
+            {
+                input_amax = InputType(__hmax(input_amax, __hmax(__habs(input_frag2[i].x), __habs(input_frag2[i].y))));
+            }
         }
 
         InputType amax = find_max_elem_in_warp(input_amax);
@@ -1286,18 +1317,21 @@ __global__ void scale_1x128_reshape_kernel(
 
         OutputType* output_line
             = output + (size_t) scales_idx_h * dim_y * dim_x + (size_t) scales_idx_y * dim_x + scales_idx_x * 128;
-        for (int i = 0; i < 4; i++)
+#pragma unroll
+        for (int i = 0; i < 2; i++)
         {
-            if (scales_idx_x * 128 + i * 32 + lane_id >= dim_x)
+            if (scales_idx_x * 128 + i * 64 + lane_id >= dim_x)
             {
                 break;
             }
             else
             {
-                ScaleType value = ScaleType(input_frag[i]) * scale;
-                output_line[lane_id] = OutputType(value);
+                ScaleType value_1 = ScaleType(input_frag2[i].x) * scale;
+                ScaleType value_2 = ScaleType(input_frag2[i].y) * scale;
+                output_line[lane_id] = OutputType(value_1);
+                output_line[lane_id + 1] = OutputType(value_2);
             }
-            output_line += 32;
+            output_line += 64;
         }
     }
 #endif
@@ -1425,7 +1459,7 @@ void fp8_1x128_cs(
     {
         kNumDeviceSMs = tensorrt_llm::common::getMultiProcessorCount();
     }
-    scale_1x128_kernel<<<kNumDeviceSMs, 256, 0, stream>>>(mat_quant, scales, mat, shape_x, shape_y);
+    scale_1x128_kernel<<<kNumDeviceSMs * 8, 256, 0, stream>>>(mat_quant, scales, mat, shape_x, shape_y);
 }
 
 void fp8_1x128_cs_reshape(__nv_fp8_e4m3* mat_quant, float* scales, __nv_bfloat16 const* mat, int shape_x, int shape_h,
@@ -1435,7 +1469,7 @@ void fp8_1x128_cs_reshape(__nv_fp8_e4m3* mat_quant, float* scales, __nv_bfloat16
     {
         kNumDeviceSMs = tensorrt_llm::common::getMultiProcessorCount();
     }
-    scale_1x128_reshape_kernel<<<kNumDeviceSMs, 256, 0, stream>>>(
+    scale_1x128_reshape_kernel<<<kNumDeviceSMs * 8, 256, 0, stream>>>(
         mat_quant, scales, mat, shape_x, shape_h, shape_y, stride_x);
 }
 
@@ -1642,7 +1676,7 @@ void fp8_gemm_run(__nv_bfloat16 const* mat_a, __nv_fp8_e4m3* fp8_mat_a, int ld_a
 
     if (internal_quantize_a)
     {
-        scale_1x128_kernel<<<kNumDeviceSMs, 256, 0, stream>>>(fp8_mat_a, scales_a, mat_a, shape_k, shape_m);
+        scale_1x128_kernel<<<kNumDeviceSMs * 8, 256, 0, stream>>>(fp8_mat_a, scales_a, mat_a, shape_k, shape_m);
     }
     if (internal_quantize_b)
     {
@@ -1792,7 +1826,7 @@ void fp8_stride_batch_gemm_run(__nv_bfloat16 const* mat_a, __nv_fp8_e4m3* fp8_ma
     }
     if (internal_quantize_a)
     {
-        scale_1x128_kernel<<<kNumDeviceSMs, 256, 0, stream>>>(
+        scale_1x128_kernel<<<kNumDeviceSMs * 8, 256, 0, stream>>>(
             fp8_mat_a, scales_a, mat_a, shape_k, shape_m * num_problems);
     }
     if (internal_quantize_b)


### PR DESCRIPTION
Noticed the 2 quantization kernels `scale_1x128_reshape_kernel` and `scale_1x128_kernel` very slow. 
Optimized the kernel through 3 ways:
1. Assign more CTAs, after profiling seeing CTA/SM bound for these 2 kernels are 8, so set 8 CTA/SM
2. Instead of read-calculate in 1 loop, split them to read first and calculate later, making more overlap in read and calculation
3. Use `__half2` or `__bhalf162` to store read data to utilize memory operator

### perf gain:
1. seeing 3-5x speed up on kernels depending on problem size
2. seeing 9% perf gain on e2e benchmark on 1024/2048 high concurrency max-throughput case on DeepSeek-R1.

``` 
Baseline
"total_latency_ms": 810594.176351,
"avg_request_latency_ms": 201443.84777781763,
"request_throughput_req_s": 5.053083428798738,
"system_output_throughput_tok_s": 10348.714862179815,
"system_total_throughput_tok_s": 15401.798290978555,
"output_throughput_per_user_tok_s": 10.254651298435567,
"output_throughput_per_gpu_tok_s": 1293.589357772477,
```

```
Optimized
"total_latency_ms": 744795.414376,
"avg_request_latency_ms": 185005.46972024365,
"request_throughput_req_s": 5.499496802664509,
"system_output_throughput_tok_s": 11262.969451856914,
"system_total_throughput_tok_s": 16762.46625452142,
"output_throughput_per_user_tok_s": 11.170453560906088,
"output_throughput_per_gpu_tok_s": 1407.8711814821143,
```