### PR TITLE
chore: add llama mlp_bias reading from hf_config

### DIFF
--- a/cpp/include/tensorrt_llm/deep_gemm/compiler.cuh
+++ b/cpp/include/tensorrt_llm/deep_gemm/compiler.cuh
@@ -329,7 +329,7 @@ public:
         // Compiler flags
         std::vector<std::string> flags
             = {"-std=c++17", "--gpu-architecture=sm_90a", "--ptxas-options=-allow-expensive-optimizations=true",
-                "-lineinfo", "--ptxas-options=--register-usage-level=10", "--diag-suppress=161,174,177,940",
+                "--ptxas-options=--register-usage-level=10", "--diag-suppress=161,174,177,940",
                 "-D__FORCE_INCLUDE_CUDA_FP16_HPP_FROM_FP16_H__=1", "-D__FORCE_INCLUDE_CUDA_BF16_HPP_FROM_BF16_H__=1"};
 
         if (kJitUseNvcc)

--- a/tensorrt_llm/models/llama/config.py
+++ b/tensorrt_llm/models/llama/config.py
@@ -154,6 +154,7 @@ class LLaMAConfig(PretrainedConfig):
         head_size = getattr(hf_config, "kv_channels", head_dim)
         attn_bias = getattr(hf_config, 'bias', False) or getattr(
             hf_config, 'attention_bias', False)
+        mlp_bias = getattr(hf_config, 'mlp_bias', False)
         rotary_scaling = getattr(hf_config, "rope_scaling", None)
         rotary_base = getattr(hf_config, "rope_theta", 10000.0)
         residual_mlp = getattr(hf_config, "parallel_attn_mlp_res", False)
@@ -200,6 +201,7 @@ class LLaMAConfig(PretrainedConfig):
             hidden_act=hidden_act,
             norm_epsilon=norm_epsilon,
             attn_bias=attn_bias,
+            mlp_bias=mlp_bias,
             rotary_base=rotary_base,
             rotary_scaling=rotary_scaling,
             residual_mlp=residual_mlp,


### PR DESCRIPTION
When i want to convert and build a llama model with attn_bias and mlp_bias. I noticed that in the config of trtllm's ckpt, the mlp bias is always false even i add mlp_bias in hf_model's config.

So i check the code of trtllm, I find the llama's config.py doesn't read mlp_bias param like the attn_bias.
So i add it.And the model can be converted and built correctly. 