### PR TITLE
fix: Correct reporting of text dtype for Llama 4.

### DIFF
--- a/tensorrt_llm/bench/dataclasses/reporting.py
+++ b/tensorrt_llm/bench/dataclasses/reporting.py
@@ -264,7 +264,9 @@ class ReportUtility:
                 "backend":
                 "Pytorch",
                 "dtype":
-                torch_dtype_to_str(model_config.pretrained_config.torch_dtype),
+                torch_dtype_to_str(
+                    model_config.pretrained_config.torch_dtype
+                    or model_config.pretrained_config.text_config.torch_dtype),
                 "kv_cache_dtype":
                 model_config.quant_config.kv_cache_quant_algo,
                 "quantization":


### PR DESCRIPTION
This is a quick fix that corrects a configuration file format change for Llama 4.

*NOTE:* This fix is only meant to be an unblocking fix. I will submit a PR in the future to correct this reporting.