### PR TITLE
refactor: Remove enforced sorted order of batch slots

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/runtimeBuffers.h
+++ b/cpp/include/tensorrt_llm/batch_manager/runtimeBuffers.h
@@ -235,7 +235,6 @@ public:
     //! Helper for KV cache rewind
     TensorPtr seqSlots;
     TensorPtr seqSlotsDevice;
-    TensorPtr sortedSeqSlots;
     //! For KV cache rewind
     TensorPtr seqSlotRemappingHost;   // [numSequences]
     TensorPtr seqSlotRemappingDevice; // [numSequences]

--- a/cpp/include/tensorrt_llm/batch_manager/runtimeBuffers.h
+++ b/cpp/include/tensorrt_llm/batch_manager/runtimeBuffers.h
@@ -232,12 +232,9 @@ public:
 
     GenerationLogitsCache generationLogitsCache;
 
-    //! Helper for KV cache rewind
+    //! Mapping from batch idx to slot id
     TensorPtr seqSlots;
     TensorPtr seqSlotsDevice;
-    //! For KV cache rewind
-    TensorPtr seqSlotRemappingHost;   // [numSequences]
-    TensorPtr seqSlotRemappingDevice; // [numSequences]
 
     //! Explicitly device-copy src offsets to reduce warp stalls in copy batch kernel invocation
     //! [mMaxNumRequests], on gpu

--- a/cpp/tensorrt_llm/batch_manager/assignReqSeqSlots.cpp
+++ b/cpp/tensorrt_llm/batch_manager/assignReqSeqSlots.cpp
@@ -37,7 +37,7 @@ void tensorrt_llm::batch_manager::AssignReqSeqSlots::operator()(SequenceSlotMana
                 llmReq->setFirstScheduledTime();
             }
             auto const reqSeqSlot = seqSlotManager.getSequenceSlot(isReqNew, llmReq->mRequestId);
-            TLLM_CHECK_WITH_INFO(reqSeqSlot, "Unable to get batch slot for reqId");
+            TLLM_CHECK_WITH_INFO(reqSeqSlot, "Unable to get batch slot for request ID %lu", llmReq->mRequestId);
             llmReq->mSeqSlot = reqSeqSlot;
         }
     }

--- a/cpp/tensorrt_llm/batch_manager/makeDecodingBatchInputOutput.cpp
+++ b/cpp/tensorrt_llm/batch_manager/makeDecodingBatchInputOutput.cpp
@@ -92,27 +92,18 @@ namespace
 std::pair<std::vector<SizeType32>, std::vector<SizeType32>> getActiveSlots(
     RequestVector const& contextRequests, RequestVector const& generationRequests)
 {
-    std::vector<std::pair<SizeType32, SizeType32>> slots;
+    std::vector<SizeType32> activeSlots;
+    std::vector<SizeType32> generationSteps;
     for (auto const& requests : {contextRequests, generationRequests})
     {
         for (auto const& llmReq : requests)
         {
             if (llmReq->isGenerationInProgressState() || llmReq->isLastContextChunk())
             {
-                slots.push_back({llmReq->mSeqSlot.value(), llmReq->getDecodingIter()});
+                activeSlots.push_back(llmReq->mSeqSlot.value());
+                generationSteps.push_back(llmReq->getDecodingIter());
             }
         }
-    }
-
-    std::sort(slots.begin(), slots.end(),
-        [](std::pair<SizeType32, SizeType32> const& a, std::pair<SizeType32, SizeType32> const& b)
-        { return a.first < b.first; });
-
-    std::vector<SizeType32> activeSlots, generationSteps;
-    for (auto const& slot : slots)
-    {
-        activeSlots.push_back(slot.first);
-        generationSteps.push_back(slot.second);
     }
 
     return {activeSlots, generationSteps};

--- a/cpp/tensorrt_llm/batch_manager/runtimeBuffers.cpp
+++ b/cpp/tensorrt_llm/batch_manager/runtimeBuffers.cpp
@@ -104,9 +104,6 @@ void RuntimeBuffers::create(SizeType32 maxBatchSize, SizeType32 maxBeamWidth,
         logits = manager.emptyTensor(MemoryType::kGPU, logitsType);
     }
 
-    seqSlotRemappingHost = manager.emptyTensor(MemoryType::kPINNEDPOOL, nvinfer1::DataType::kINT32);
-    seqSlotRemappingDevice = manager.emptyTensor(MemoryType::kGPU, nvinfer1::DataType::kINT32);
-
     // TODO: check which tensors can be allocated as pinned for max size
     requestTypes = manager.emptyTensor(MemoryType::kCPU, TRTDataType<runtime::RequestType>::value);
 
@@ -382,8 +379,6 @@ void RuntimeBuffers::reshape(TllmRuntime const& runtime, ModelConfig const& mode
     auto const numRequestsShape = ITensor::makeShape({numRequests});
     seqSlots->reshape(numRequestsShape);
     seqSlotsDevice->reshape(numRequestsShape);
-    seqSlotRemappingHost->reshape(numRequestsShape);
-    seqSlotRemappingDevice->reshape(numRequestsShape);
 
     auto const numTokens = getNumTokens();
     inputsIds->reshape(ITensor::makeShape({numTokens}));
@@ -737,13 +732,6 @@ void RuntimeBuffers::setFromInputs(RequestVector const& contextRequests, Request
             std::fill_n(contextLengthsHostPtr + numSequences, reqBeamWidth, contextQLength);
             std::fill_n(sequenceLengthsHostPtr + numSequences, reqBeamWidth, sequenceLen);
             numSequences += reqBeamWidth;
-        }
-        if (modelConfig.getSpeculativeDecodingMode().needsKVCacheRewind())
-        {
-            auto remappingSeqSlotIndices = BufferRange<SizeType32>(*seqSlotRemappingHost);
-
-            std::iota(remappingSeqSlotIndices.begin(), remappingSeqSlotIndices.end(), 0);
-            manager.copy(*seqSlotRemappingHost, *seqSlotRemappingDevice);
         }
         if (modelConfig.getSpeculativeDecodingMode().isLookaheadDecoding())
         {

--- a/cpp/tensorrt_llm/batch_manager/sequenceSlotManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/sequenceSlotManager.cpp
@@ -61,7 +61,7 @@ std::optional<SequenceSlotManager::SlotIdType> SequenceSlotManager::getSequenceS
         auto const it = mSequenceIdToSlot.find(sequenceId);
         if (it == mSequenceIdToSlot.end())
         {
-            TLLM_LOG_ERROR("Could not find sequence id in allocated sequence slots");
+            TLLM_LOG_ERROR("Could not find sequence id %lu in allocated sequence slots", sequenceId);
         }
         else
         {

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -983,8 +983,10 @@ void TrtGptModelInflightBatching::forwardAsync(RequestList const& activeRequests
         if (fittingRequests.empty() && fittingDisaggGenInitRequests.empty())
         {
             TLLM_LOG_WARNING(
-                "CapacityScheduler didn't schedule any requests, probably because of insufficient resources such as KV "
-                "cache, will try wait for KV cache transfer to complete");
+                "CapacityScheduler didn't schedule any requests in iteration %lu, "
+                "probably because of insufficient resources such as KV cache, "
+                "will try wait for KV cache transfer to complete",
+                mIterCounter);
             if (mCacheTransceiver)
             {
                 mCacheTransceiver->checkContextTransferStatus(1);

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -2433,7 +2433,7 @@ void TrtGptModelInflightBatching::rewindKVCacheBlocks(SizeType32 numSequences)
         *mDecoderState->getAcceptedLengthsCumSum(), *mDecoderState->getAcceptedPackedPaths(),
         *runtimeBuffers.sequenceLengthsDevice, pointerArrayPtr, offsetArrayPtr, localNbLayers, numSequences,
         mRewindInputs.numKvHeads, sizeInBytesPerKVHead, commonRewindLen, rewindLens,
-        *runtimeBuffers.seqSlotRemappingDevice, *runtimeBuffers.sortedSeqSlots, getMaxAttentionWindow(),
+        *runtimeBuffers.seqSlotRemappingDevice, *runtimeBuffers.seqSlots, getMaxAttentionWindow(),
         mRewindInputs.maxBlocksPerSeq, tokensPerBlock, mRewindInputs.isUseOneMoreBlock,
         mRuntime->getStreamPtr()->get());
 

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -2432,9 +2432,8 @@ void TrtGptModelInflightBatching::rewindKVCacheBlocks(SizeType32 numSequences)
     tensorrt_llm::runtime::kernels::invokeUpdateKVBlockArrayDraftTokenLocation(
         *mDecoderState->getAcceptedLengthsCumSum(), *mDecoderState->getAcceptedPackedPaths(),
         *runtimeBuffers.sequenceLengthsDevice, pointerArrayPtr, offsetArrayPtr, localNbLayers, numSequences,
-        mRewindInputs.numKvHeads, sizeInBytesPerKVHead, commonRewindLen, rewindLens,
-        *runtimeBuffers.seqSlotRemappingDevice, *runtimeBuffers.seqSlots, getMaxAttentionWindow(),
-        mRewindInputs.maxBlocksPerSeq, tokensPerBlock, mRewindInputs.isUseOneMoreBlock,
+        mRewindInputs.numKvHeads, sizeInBytesPerKVHead, commonRewindLen, rewindLens, *runtimeBuffers.seqSlots,
+        getMaxAttentionWindow(), mRewindInputs.maxBlocksPerSeq, tokensPerBlock, mRewindInputs.isUseOneMoreBlock,
         mRuntime->getStreamPtr()->get());
 
     sync_check_cuda_error(mRuntime->getStream().get());

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -1040,6 +1040,10 @@ void TrtGptModelInflightBatching::forwardAsync(RequestList const& activeRequests
                 auto const contextBufferId = mCtxGenFusion ? getFusedBufferId() : getContextBufferId();
                 setupDecoderStep(currRequests.contextRequests, *mBuffers.at(contextBufferId),
                     mDecoderInputBuffers.at(getFusedBufferId()));
+                // WAR: Sync to ensure that the decoder setup is complete before the context phase starts.
+                // Without this, there may be a race condition between the decoder setup and the context phase
+                // which also leads to spurious test failure in trtGptModelRealDecoderTest.
+                mRuntime->getStream().synchronize();
             }
             else
             {

--- a/cpp/tensorrt_llm/kernels/speculativeDecoding/common.cu
+++ b/cpp/tensorrt_llm/kernels/speculativeDecoding/common.cu
@@ -40,8 +40,8 @@ namespace tensorrt_llm::kernels::speculative_decoding
 template <int32_t BLOCK_SIZE>
 __global__ void packAcceptedPaths(SizeType32* acceptedLengthsCumSum, SizeType32* pathsOffsets,
     SizeType32 const* acceptedLengths, SizeType32 const* bestPathIds, SizeType32 const* paths,
-    SizeType32 const* batchSlots, runtime::SizeType32 const* seqSlots, SizeType32 batchSize, SizeType32 engineBatchSize,
-    SizeType32 numPaths, SizeType32 maxPathLen, bool isPathsSeqSlotIdx)
+    SizeType32 const* batchSlots, SizeType32 batchSize, SizeType32 engineBatchSize, SizeType32 numPaths,
+    SizeType32 maxPathLen, bool isPathsSeqSlotIdx)
 {
     // Specialize BlockScan for a 1D block of 128 threads of type int
     typedef cub::BlockScan<SizeType32, BLOCK_SIZE> BlockScan;
@@ -81,22 +81,7 @@ __global__ void packAcceptedPaths(SizeType32* acceptedLengthsCumSum, SizeType32*
         }
         __syncthreads();
 
-        int32_t pathBatchIdx{batchSlot};
-        if (isPathsSeqSlotIdx)
-        {
-            // If paths tensor is the tensor arranged according to seq slot,
-            // we must find the position of the batchSlots index in the seq slot array.
-            // TODO optimize it.
-            for (int bi = 0; bi < batchSize; ++bi)
-            {
-                auto const seqSlot = seqSlots[bi];
-                if (batchSlot == seqSlot)
-                {
-                    pathBatchIdx = bi;
-                    break;
-                }
-            }
-        }
+        auto const pathBatchIdx = isPathsSeqSlotIdx ? bi : batchSlot;
 
         if (valid)
         {
@@ -117,13 +102,12 @@ __global__ void packAcceptedPaths(SizeType32* acceptedLengthsCumSum, SizeType32*
 
 void invokePackAcceptedPaths(SizeType32* acceptedLengthsCumSum, SizeType32* pathsOffsets,
     SizeType32 const* acceptedLengths, SizeType32 const* bestPathIds, SizeType32 const* paths,
-    SizeType32 const* batchSlots, runtime::SizeType32 const* seqSlots, SizeType32 batchSize, SizeType32 engineBatchSize,
-    SizeType32 numPaths, SizeType32 maxPathLen, bool isPathsLinearBatchIdx, cudaStream_t stream)
+    SizeType32 const* batchSlots, SizeType32 batchSize, SizeType32 engineBatchSize, SizeType32 numPaths,
+    SizeType32 maxPathLen, bool isPathsSeqSlotIdx, cudaStream_t stream)
 {
     constexpr SizeType32 BLOCK_SIZE = 1024;
     packAcceptedPaths<BLOCK_SIZE><<<1, BLOCK_SIZE, 0, stream>>>(acceptedLengthsCumSum, pathsOffsets, acceptedLengths,
-        bestPathIds, paths, batchSlots, seqSlots, batchSize, engineBatchSize, numPaths, maxPathLen,
-        isPathsLinearBatchIdx);
+        bestPathIds, paths, batchSlots, batchSize, engineBatchSize, numPaths, maxPathLen, isPathsSeqSlotIdx);
 }
 
 namespace

--- a/cpp/tensorrt_llm/kernels/speculativeDecoding/common.h
+++ b/cpp/tensorrt_llm/kernels/speculativeDecoding/common.h
@@ -38,10 +38,6 @@ namespace tensorrt_llm::kernels::speculative_decoding
 //! everything that is not path.
 //! \param batchSlots input buffer [engineBatchSize], address map from local index to
 //! global index [0, batchSize] -> [0, maxBatchSize].
-//! This is in the order of increasing order of the requests in the decoder.
-//! \param seqSlots input buffer [engineBatchSize], address map from local index to
-//! global index [0, batchSize] -> [0, maxBatchSize]
-//! These are the slots of the sequences in the runtime buffers.
 //! \param batchSize the number of sequences to be decoded
 //! \param engineBatchSize number of sequences processed in the engine.
 //! Includes chunked context reqs that are not in the last chunk.
@@ -52,9 +48,9 @@ namespace tensorrt_llm::kernels::speculative_decoding
 //! \param stream stream
 void invokePackAcceptedPaths(runtime::SizeType32* acceptedLengthsCumSum, runtime::SizeType32* pathsOffsets,
     runtime::SizeType32 const* acceptedLengths, runtime::SizeType32 const* bestPathIds,
-    runtime::SizeType32 const* paths, runtime::SizeType32 const* batchSlots, runtime::SizeType32 const* seqSlots,
-    runtime::SizeType32 batchSize, runtime::SizeType32 engineBatchSize, runtime::SizeType32 numPaths,
-    runtime::SizeType32 maxPathLen, bool isPathsSeqSlotIdx, cudaStream_t stream);
+    runtime::SizeType32 const* paths, runtime::SizeType32 const* batchSlots, runtime::SizeType32 batchSize,
+    runtime::SizeType32 engineBatchSize, runtime::SizeType32 numPaths, runtime::SizeType32 maxPathLen,
+    bool isPathsSeqSlotIdx, cudaStream_t stream);
 
 template <typename T>
 struct AcceptDraftTokensByIdsWithPathsParams

--- a/cpp/tensorrt_llm/kernels/speculativeDecoding/eagleDecodingKernels.h
+++ b/cpp/tensorrt_llm/kernels/speculativeDecoding/eagleDecodingKernels.h
@@ -552,29 +552,23 @@ void invokeCopyOutputTokensIds(runtime::TokenIdType const* const* tmpOutputIdsPt
     runtime::SizeType32 const* inputPaths, runtime::SizeType32* outputPaths, runtime::SizeType32 maxPathLen,
     cudaStream_t stream);
 
-//! \brief Augment seq slots and batch slots from batchSize size to engineBatchSize size.
-//! For seqSlot sets -1 for non-last chunks (chunkedContextNextTokens != -1).
-//! For batchSlots sets -1 for non-last chunks. Copies actual batch slots to the last chunk or gen requests
-//! positions.
+//! \brief Augment seq slots so that non-last chunks are set to -1 (if chunkedContextNextTokens != -1).
 //!
 //! \param augmentedSeqSlots output buffer [engineBatchSize]
-//! \param augmentedBatchSlots output buffer [engineBatchSize]
 //! \param chunkedContextNextTokens input buffer [engineBatchSize], indicator of the not last chunk of the ctx
 //! requests. -1 for gen requests and last chunk, != -1 otherwise.
 //! \param lastDraftLens input buffer [engineBatchSize], number of draft tokens input to the current iteration.
 //! 0 for ctx requests and > 0 for gen requests.
 //! \param seqSlots input buffer [engineBatchSize], address map from local index to global index [0, batchSize]
 //! -> [0, maxBatchSize]
-//! \param batchSlots input buffer [engineBatchSize], address map from local index to global index [0, batchSize]
-//! -> [0, maxBatchSize]
 //! \param engineBatchSize number of sequences processed in the engine.
 //! Includes chunked context reqs that are not in the last chunk.
 //! \param batchSize the number of sequences to be decoded
 //! \param stream cuda stream.
-void invokeAugmentBatchSlots(runtime::SizeType32* augmentedSeqSlots, runtime::SizeType32* augmentedBatchSlots,
+void invokeAugmentBatchSlots(runtime::SizeType32* augmentedSeqSlots,
     runtime::SizeType32 const* chunkedContextNextTokens, runtime::SizeType32 const* lastDraftLens,
-    runtime::SizeType32 const* seqSlots, runtime::SizeType32 const* batchSlots, runtime::SizeType32 engineBatchSize,
-    runtime::SizeType32 batchSize, cudaStream_t stream);
+    runtime::SizeType32 const* seqSlots, runtime::SizeType32 engineBatchSize, runtime::SizeType32 batchSize,
+    cudaStream_t stream);
 
 //! \brief For Eagle-2, set topK tensor according to the max topK value for each request.
 //! And fill the batchSlots for the softMax kernel.

--- a/cpp/tensorrt_llm/layers/banWordsLayer.cpp
+++ b/cpp/tensorrt_llm/layers/banWordsLayer.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "banWordsLayer.h"
+#include "tensorrt_llm/common/nvtxUtils.h"
 #include "tensorrt_llm/kernels/banBadWords.h"
 #include "tensorrt_llm/kernels/banRepeatNgram.h"
 #include "tensorrt_llm/layers/defaultDecodingParams.h"
@@ -138,6 +139,7 @@ void BanWordsLayer<T>::forwardAsync(std::shared_ptr<BaseDecodingOutputs> const& 
     std::shared_ptr<runtime::DecodingLayerWorkspace> const& workspace)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
+    NVTX3_SCOPED_RANGE(BanWordsLayer_forwardAsync);
 
     auto inputs = std::dynamic_pointer_cast<DecodingInputs>(baseInputs);
     auto outputs = std::dynamic_pointer_cast<BaseDecodingOutputs>(baseOutputs);

--- a/cpp/tensorrt_llm/layers/banWordsLayer.cpp
+++ b/cpp/tensorrt_llm/layers/banWordsLayer.cpp
@@ -62,6 +62,8 @@ void BanWordsLayer<T>::setup(SizeType32 batchSize, SizeType32 beamWidth, TensorC
     std::shared_ptr<runtime::DecodingLayerWorkspace> const& workspace)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
+    NVTX3_SCOPED_RANGE(BanWordsLayer_setup);
+
     auto setupParams = std::dynamic_pointer_cast<DynamicDecodeSetupParams>(baseSetupParams);
     auto const& banWordsParams = setupParams->banWordsParams;
     TLLM_CHECK_WITH_INFO(banWordsParams, "banWordsParams for setup is not set");

--- a/cpp/tensorrt_llm/layers/beamSearchLayer.cu
+++ b/cpp/tensorrt_llm/layers/beamSearchLayer.cu
@@ -18,10 +18,11 @@
 #include "tensorrt_llm/kernels/beamSearchKernels/beamSearchKernelsTemplate.h"
 
 #include "tensorrt_llm/common/cudaUtils.h"
-#include "tensorrt_llm/common/stringUtils.h"
+#include "tensorrt_llm/common/nvtxUtils.h"
 #include "tensorrt_llm/kernels/beamSearchKernels.h"
 #include "tensorrt_llm/layers/defaultDecodingParams.h"
 #include "tensorrt_llm/layers/layerUtils.h"
+
 #include <limits>
 
 using namespace tensorrt_llm::runtime;
@@ -313,6 +314,7 @@ void BeamSearchLayer<T>::forwardAsync(std::shared_ptr<BaseDecodingOutputs> const
     std::shared_ptr<runtime::DecodingLayerWorkspace> const& workspace)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
+    NVTX3_SCOPED_RANGE(BeamSearchLayer_forwardAsync);
 
     auto ip = std::dynamic_pointer_cast<DecodingInputs>(baseInputs);
     auto op = std::dynamic_pointer_cast<BeamSearchOutputs>(baseOutputs);

--- a/cpp/tensorrt_llm/layers/beamSearchLayer.cu
+++ b/cpp/tensorrt_llm/layers/beamSearchLayer.cu
@@ -280,6 +280,7 @@ void BeamSearchLayer<T>::setup(SizeType32 const batchSize, SizeType32 const beam
     std::shared_ptr<runtime::DecodingLayerWorkspace> const& workspace)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
+    NVTX3_SCOPED_RANGE(BeamSearchLayer_setup);
 
     SizeType32 const maxBamWidth{mDecoderDomain.getBeamWidth()};
     TLLM_CHECK_WITH_INFO(beamWidth <= maxBamWidth, "Beam width is larger than the constructed for (%d > %d).",

--- a/cpp/tensorrt_llm/layers/eagleDecodingLayer.cpp
+++ b/cpp/tensorrt_llm/layers/eagleDecodingLayer.cpp
@@ -76,6 +76,7 @@ void EagleDecodingLayer<T>::setup(SizeType32 batchSize, SizeType32 beamWidth, Te
     std::shared_ptr<runtime::DecodingLayerWorkspace> const& workspace)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
+    NVTX3_SCOPED_RANGE(EagleDecodingLayer_setup);
 
     auto setupParams = std::dynamic_pointer_cast<EagleSetupParams>(baseSetupParams);
     workspace->initializeDeviceCurandStates(

--- a/cpp/tensorrt_llm/layers/explicitDraftTokensLayer.cpp
+++ b/cpp/tensorrt_llm/layers/explicitDraftTokensLayer.cpp
@@ -288,7 +288,7 @@ void ExplicitDraftTokensLayer<T>::packAcceptedPaths(ExplicitDraftTokensOutputs c
         numNewTokensCumSum != nullptr, "numNewTokensCumSum must be provided for ExplicitDraftTokensLayer");
     TLLM_CHECK_WITH_INFO(pathsOffsets != nullptr, "pathsOffsets must be provided for ExplicitDraftTokensLayer");
     invokePackAcceptedPaths(numNewTokensCumSum, pathsOffsets, numNewTokens, bestPathIndicesSlotsPtr,
-        lastDraftIndicesSlotsPtr, batchSlots, nullptr, batchSize, batchSize,
+        lastDraftIndicesSlotsPtr, batchSlots, batchSize, batchSize,
         mDecoderDomain.getSpeculativeDecodingModule()->getMaxNumPaths(),
         mDecoderDomain.getSpeculativeDecodingModule()->getMaxPathLen(), false, getStream());
 

--- a/cpp/tensorrt_llm/layers/explicitDraftTokensLayer.cpp
+++ b/cpp/tensorrt_llm/layers/explicitDraftTokensLayer.cpp
@@ -15,13 +15,12 @@
  */
 
 #include "explicitDraftTokensLayer.h"
+#include "tensorrt_llm/common/nvtxUtils.h"
 #include "tensorrt_llm/kernels/penaltyTypes.h"
 #include "tensorrt_llm/kernels/speculativeDecoding/common.h"
 #include "tensorrt_llm/kernels/speculativeDecoding/explicitDraftTokensKernels.h"
 #include "tensorrt_llm/layers/defaultDecodingParams.h"
 #include "tensorrt_llm/layers/layerUtils.h"
-
-#include <algorithm>
 
 using namespace tensorrt_llm::common;
 using namespace tensorrt_llm::kernels;
@@ -115,6 +114,7 @@ void ExplicitDraftTokensLayer<T>::forwardAsync(std::shared_ptr<BaseDecodingOutpu
     std::shared_ptr<runtime::DecodingLayerWorkspace> const& workspace)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
+    NVTX3_SCOPED_RANGE(ExplicitDraftTokensLayer_forwardAsync);
 
     auto inputs = std::dynamic_pointer_cast<ExplicitDraftTokensInputs>(baseInputs);
     auto outputs = std::dynamic_pointer_cast<ExplicitDraftTokensOutputs>(baseOutputs);

--- a/cpp/tensorrt_llm/layers/explicitDraftTokensLayer.cpp
+++ b/cpp/tensorrt_llm/layers/explicitDraftTokensLayer.cpp
@@ -74,6 +74,7 @@ void ExplicitDraftTokensLayer<T>::setup(SizeType32 batchSize, SizeType32 beamWid
     std::shared_ptr<runtime::DecodingLayerWorkspace> const& workspace)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
+    NVTX3_SCOPED_RANGE(ExplicitDraftTokensLayer_setup);
 
     auto setupParams = std::dynamic_pointer_cast<ExplicitDraftTokensSetupParams>(baseSetupParams);
     workspace->initializeDeviceCurandStates(

--- a/cpp/tensorrt_llm/layers/externalDraftTokensLayer.cpp
+++ b/cpp/tensorrt_llm/layers/externalDraftTokensLayer.cpp
@@ -121,6 +121,7 @@ void ExternalDraftTokensLayer<T>::setup(SizeType32 batchSize, SizeType32 beamWid
     std::shared_ptr<runtime::DecodingLayerWorkspace> const& workspace)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
+    NVTX3_SCOPED_RANGE(ExternalDraftTokensLayer_setup);
 
     auto setupParams = std::dynamic_pointer_cast<ExternalDraftTokensSetupParams>(baseSetupParams);
 

--- a/cpp/tensorrt_llm/layers/lookaheadDecodingLayer.cpp
+++ b/cpp/tensorrt_llm/layers/lookaheadDecodingLayer.cpp
@@ -133,6 +133,7 @@ void LookaheadDecodingLayer<T>::setup(SizeType32 batchSize, SizeType32 beamWidth
     std::shared_ptr<runtime::DecodingLayerWorkspace> const& workspace)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
+    NVTX3_SCOPED_RANGE(LookaheadDecodingLayer_setup);
 
     auto setupParams = std::dynamic_pointer_cast<LookaheadSetupParams>(baseSetupParams);
 

--- a/cpp/tensorrt_llm/layers/medusaDecodingLayer.cpp
+++ b/cpp/tensorrt_llm/layers/medusaDecodingLayer.cpp
@@ -469,7 +469,7 @@ void MedusaDecodingLayer<T>::packAcceptedPaths(SpeculativeDecodingOutputs const&
     TLLM_CHECK_WITH_INFO(numNewTokensCumSum != nullptr, "numNewTokensCumSum must be provided for MedusaDecoding");
     TLLM_CHECK_WITH_INFO(pathsOffsets != nullptr, "pathsOffsets must be provided for MedusaDecoding");
     invokePackAcceptedPaths(numNewTokensCumSum, pathsOffsets, numNewTokens, bestPathIdsDevicePtr, paths, batchSlots,
-        nullptr, batchSize, batchSize, mDecoderDomain.getMaxDecodingTokens(),
+        batchSize, batchSize, mDecoderDomain.getMaxDecodingTokens(),
         mDecoderDomain.getSpeculativeDecodingModule()->getMaxPathLen(), false, getStream());
 
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);

--- a/cpp/tensorrt_llm/layers/medusaDecodingLayer.cpp
+++ b/cpp/tensorrt_llm/layers/medusaDecodingLayer.cpp
@@ -105,6 +105,7 @@ void MedusaDecodingLayer<T>::setup(SizeType32 batchSize, SizeType32 beamWidth, T
     std::shared_ptr<runtime::DecodingLayerWorkspace> const& workspace)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
+    NVTX3_SCOPED_RANGE(MedusaDecodingLayer_setup);
 
     auto setupParams = std::dynamic_pointer_cast<MedusaSetupParams>(baseSetupParams);
 

--- a/cpp/tensorrt_llm/layers/penaltyLayer.cpp
+++ b/cpp/tensorrt_llm/layers/penaltyLayer.cpp
@@ -141,6 +141,7 @@ void PenaltyLayer<T>::setup(SizeType32 batchSize, SizeType32 beamWidth, TensorCo
     std::shared_ptr<runtime::DecodingLayerWorkspace> const& workspace)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
+    NVTX3_SCOPED_RANGE(PenaltyLayer_setup);
 
     auto setupParams = std::dynamic_pointer_cast<DynamicDecodeSetupParams>(baseSetupParams);
 

--- a/cpp/tensorrt_llm/layers/samplingLayer.cpp
+++ b/cpp/tensorrt_llm/layers/samplingLayer.cpp
@@ -94,6 +94,7 @@ void SamplingLayer<T>::setup(SizeType32 batchSize, SizeType32 beamWidth, TensorC
     std::shared_ptr<runtime::DecodingLayerWorkspace> const& workspace)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
+    NVTX3_SCOPED_RANGE(SamplingLayer_setup);
 
     auto setupParams = std::dynamic_pointer_cast<SamplingSetupParams>(baseSetupParams);
 

--- a/cpp/tensorrt_llm/layers/topKSamplingLayer.cpp
+++ b/cpp/tensorrt_llm/layers/topKSamplingLayer.cpp
@@ -68,6 +68,7 @@ void TopKSamplingLayer<T>::setup(SizeType32 batchSize, SizeType32 beamWidth, Ten
     std::shared_ptr<runtime::DecodingLayerWorkspace> const& workspace)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
+    NVTX3_SCOPED_RANGE(TopKSamplingLayer_setup);
 
     auto setupParams = std::dynamic_pointer_cast<SamplingSetupParams>(baseSetupParams);
     mNormalizeLogProbs = setupParams->normalizeLogProbs.value_or(false);

--- a/cpp/tensorrt_llm/layers/topPSamplingLayer.cpp
+++ b/cpp/tensorrt_llm/layers/topPSamplingLayer.cpp
@@ -91,6 +91,7 @@ void TopPSamplingLayer<T>::setup(SizeType32 batchSize, SizeType32 beamWidth, Ten
     std::shared_ptr<runtime::DecodingLayerWorkspace> const& workspace)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
+    NVTX3_SCOPED_RANGE(TopPSamplingLayer_setup);
 
     auto setupParams = std::dynamic_pointer_cast<SamplingSetupParams>(baseSetupParams);
 

--- a/cpp/tensorrt_llm/pybind/batch_manager/buffers.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/buffers.cpp
@@ -95,7 +95,6 @@ void Buffers::initBindings(pybind11::module_& m)
         .def_readwrite("logits", &tb::RuntimeBuffers::logits)
         .def_readwrite("seq_slots", &tb::RuntimeBuffers::seqSlots)
         .def_readwrite("seq_slots_device", &tb::RuntimeBuffers::seqSlotsDevice)
-        .def_readwrite("sorted_seq_slots", &tb::RuntimeBuffers::sortedSeqSlots)
         .def_readwrite("seq_slot_remapping_host", &tb::RuntimeBuffers::seqSlotRemappingHost)
         .def_readwrite("seq_slot_remapping_device", &tb::RuntimeBuffers::seqSlotRemappingDevice)
         .def_readwrite("cache_indir_decoder_io_batched_copy_src_offsets_slice_device",

--- a/cpp/tensorrt_llm/pybind/batch_manager/buffers.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/buffers.cpp
@@ -95,8 +95,6 @@ void Buffers::initBindings(pybind11::module_& m)
         .def_readwrite("logits", &tb::RuntimeBuffers::logits)
         .def_readwrite("seq_slots", &tb::RuntimeBuffers::seqSlots)
         .def_readwrite("seq_slots_device", &tb::RuntimeBuffers::seqSlotsDevice)
-        .def_readwrite("seq_slot_remapping_host", &tb::RuntimeBuffers::seqSlotRemappingHost)
-        .def_readwrite("seq_slot_remapping_device", &tb::RuntimeBuffers::seqSlotRemappingDevice)
         .def_readwrite("cache_indir_decoder_io_batched_copy_src_offsets_slice_device",
             &tb::RuntimeBuffers::mCacheIndirDecoderIOBatchedCopySrcOffsetsSliceDevice)
         .def_readwrite("cache_indir_decoder_io_batched_copy_dst_offsets_slice_device",

--- a/cpp/tensorrt_llm/runtime/runtimeKernels.cu
+++ b/cpp/tensorrt_llm/runtime/runtimeKernels.cu
@@ -472,16 +472,14 @@ void invokeUpdateKVBlockArrayDraftTokenLocation(ITensor const& seqAcceptedDraftT
     ITensor const& packedAcceptedDraftTokensIndices, ITensor const& pastKeyValueLengths, void* const* pointerArray,
     ::tensorrt_llm::kernels::KVCacheIndex const* offsetArray, SizeType32 layerCount, SizeType32 seqCount,
     SizeType32 numKVHeads, SizeType32 sizeInBytesPerKVHead, SizeType32 rewindDraftTokenCommonCount,
-    SizeType32 const* rewindDraftTokenSeparateAdjustments, ITensor const& seqSlotRemapping, ITensor const& batchSlots,
-    SizeType32 maxKVCacheLen, SizeType32 maxBlocksPerSeq, SizeType32 tokensPerBlock, bool canUseOneMoreBlock,
-    cudaStream_t stream)
+    SizeType32 const* rewindDraftTokenSeparateAdjustments, ITensor const& batchSlots, SizeType32 maxKVCacheLen,
+    SizeType32 maxBlocksPerSeq, SizeType32 tokensPerBlock, bool canUseOneMoreBlock, cudaStream_t stream)
 {
     tensorrt_llm::kernels::speculative_decoding::updateKVBlockArrayDraftTokenLocation(
         bufferCast<SizeType32>(seqAcceptedDraftTokenOffsets), bufferCast<SizeType32>(packedAcceptedDraftTokensIndices),
         bufferCast<SizeType32>(pastKeyValueLengths), pointerArray, offsetArray, layerCount, seqCount, numKVHeads,
-        sizeInBytesPerKVHead, rewindDraftTokenCommonCount, rewindDraftTokenSeparateAdjustments,
-        bufferCast<SizeType32>(seqSlotRemapping), bufferCast<SizeType32>(batchSlots), maxKVCacheLen, maxBlocksPerSeq,
-        tokensPerBlock, canUseOneMoreBlock, stream);
+        sizeInBytesPerKVHead, rewindDraftTokenCommonCount, rewindDraftTokenSeparateAdjustments, nullptr,
+        bufferCast<SizeType32>(batchSlots), maxKVCacheLen, maxBlocksPerSeq, tokensPerBlock, canUseOneMoreBlock, stream);
 }
 
 } // namespace tensorrt_llm::runtime::kernels

--- a/cpp/tensorrt_llm/runtime/runtimeKernels.h
+++ b/cpp/tensorrt_llm/runtime/runtimeKernels.h
@@ -56,8 +56,7 @@ void invokeUpdateKVBlockArrayDraftTokenLocation(ITensor const& seqAcceptedDraftT
     ITensor const& packedAcceptedDraftTokensIndices, ITensor const& pastKeyValueLengths, void* const* pointerArray,
     ::tensorrt_llm::kernels::KVCacheIndex const* offsetArray, SizeType32 layerCount, SizeType32 seqCount,
     SizeType32 numKVHeads, SizeType32 sizeInBytesPerKVHead, SizeType32 rewindDraftTokenCommonCount,
-    SizeType32 const* rewindDraftTokenSeparateAdjustments, ITensor const& seqSlotRemapping, ITensor const& batchSlots,
-    SizeType32 maxKVCacheLen, SizeType32 maxBlocksPerSeq, SizeType32 tokensPerBlock, bool canUseOneMoreBlock,
-    cudaStream_t stream);
+    SizeType32 const* rewindDraftTokenSeparateAdjustments, ITensor const& batchSlots, SizeType32 maxKVCacheLen,
+    SizeType32 maxBlocksPerSeq, SizeType32 tokensPerBlock, bool canUseOneMoreBlock, cudaStream_t stream);
 
 } // namespace tensorrt_llm::runtime::kernels

--- a/cpp/tests/batch_manager/trtGptModelRealDecoderTest.cpp
+++ b/cpp/tests/batch_manager/trtGptModelRealDecoderTest.cpp
@@ -1605,7 +1605,9 @@ INSTANTIATE_TEST_SUITE_P(MedusaTests, ParamTest,
                 .usePackedInput()
                 .setKVCacheType(KVCacheType::kPAGED)
                 .useMedusa()),
-        testing::Values(TrtGptModelType::InflightFusedBatching), testing::Values(TrtGptModelIfbTestType::BULK),
+        testing::Values(TrtGptModelType::InflightFusedBatching),
+        testing::Values(
+            TrtGptModelIfbTestType::BULK, TrtGptModelIfbTestType::WAVEFRONT, TrtGptModelIfbTestType::RANDOM),
         testing::Values(BeamConfig{1, {1}}),
         testing::Values(std::nullopt),               // maxTokensInPagedKvCache
         testing::Values(0.4),                        // freeGpuMemoryFraction
@@ -1630,7 +1632,8 @@ INSTANTIATE_TEST_SUITE_P(EagleTests, ParamTest,
                 .setKVCacheType(KVCacheType::kPAGED)
                 .useEagle()),
         testing::Values(TrtGptModelType::InflightFusedBatching),
-        testing::Values(TrtGptModelIfbTestType::BULK, TrtGptModelIfbTestType::WAVEFRONT),
+        testing::Values(
+            TrtGptModelIfbTestType::BULK, TrtGptModelIfbTestType::WAVEFRONT, TrtGptModelIfbTestType::RANDOM),
         testing::Values(BeamConfig{1, {1}}),
         testing::Values(std::nullopt),               // maxTokensInPagedKvCache
         testing::Values(0.4),                        // freeGpuMemoryFraction
@@ -1682,7 +1685,9 @@ INSTANTIATE_TEST_SUITE_P(ExplicitDraftTokensDecodingTests, ParamTest,
                 .setKVCacheType(KVCacheType::kPAGED)
                 .useExplicitDraftTokensDecoding()
                 .setMaxOutputLength(128)),
-        testing::Values(TrtGptModelType::InflightFusedBatching), testing::Values(TrtGptModelIfbTestType::BULK),
+        testing::Values(TrtGptModelType::InflightFusedBatching),
+        testing::Values(
+            TrtGptModelIfbTestType::BULK, TrtGptModelIfbTestType::WAVEFRONT, TrtGptModelIfbTestType::RANDOM),
         testing::Values(BeamConfig{1, {1}}),         // beamConfig
         testing::Values(std::nullopt),               // maxTokensInPagedKvCache
         testing::Values(0.4),                        // freeGpuMemoryFraction

--- a/cpp/tests/executor/executorTest.cpp
+++ b/cpp/tests/executor/executorTest.cpp
@@ -2556,7 +2556,7 @@ TEST_F(GptExecutorTest, MaxSeqIdleMicrosecondsError)
             {
                 auto err = response.getErrorMsg();
                 std::cout << "err:" << err << std::endl;
-                EXPECT_THAT(err, testing::HasSubstr("Unable to get batch slot for reqId"));
+                EXPECT_THAT(err, testing::HasSubstr("Unable to get batch slot for request ID"));
                 done = true;
             }
             else


### PR DESCRIPTION
Change the order of decoder `batchSlots` by removing the sort [here](https://github.com/NVIDIA/TensorRT-LLM/pull/3502/files#r2041689369). 
This means that the order passed to the decoder is exactly the same as `seqSlots`. The only difference is that `seqSlots` contain all requests and `batchSlots` contain only finished context and generation requests.

This change simplifies the code and removes some extra steps and buffers. However, it introduces a sync after the decoder setup in the Eagle/ReDrafter/Lookahead case for correctness [here](https://github.com/NVIDIA/TensorRT-LLM/pull/3502#discussion_r2192403292). Without this the Eagle and ReDrafter tests might fail spuriously (so there is likely a race condition).