### PR TITLE
infra: add more codespell ignore words, prevent ans->and

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,7 +64,8 @@ repos:
     -   id: codespell
         additional_dependencies:
         - tomli
-        args: ["-L", "Mor"]
+        # add ignore words list
+        args: ["-L", "Mor,ans"]
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.9.4
     hooks:


### PR DESCRIPTION
The code here https://github.com/NVIDIA/TensorRT-LLM/pull/3501/files will cause codespell fail:
![image](https://github.com/user-attachments/assets/071e36dc-cdc6-4897-8687-246d2d19472b)

We want to add `ans` to ignore list.