### PR TITLE
chore : Split more tests out of gpt tests

### DIFF
--- a/tests/integration/defs/cpp_common.py
+++ b/tests/integration/defs/cpp_common.py
@@ -75,11 +75,11 @@ def generate_result_file_name(test_list: List[str],
 def generate_excluded_test_list(test_list):
     if "gpt" in test_list:
         if "gpt_session" not in test_list:
-            yield "gpt_session"
+            yield "GptSession"
         if "gpt_executor" not in test_list:
-            yield "gpt_executor"
+            yield "GptExecutor"
         if "gpt_tests" not in test_list:
-            yield "gpt_tests"
+            yield "GptTests"
 
 
 def find_dir_containing(files: Sequence[str],

--- a/tests/integration/defs/cpp_common.py
+++ b/tests/integration/defs/cpp_common.py
@@ -743,6 +743,8 @@ def run_single_gpu_tests(build_dir: _pl.Path,
         # exist in multiple running tests
         if gpt_tests.intersection(test_list):
             parallel = 1
+        else:
+            parallel = default_test_parallel
 
         if parallel_override := _os.environ.get("LLM_TEST_PARALLEL_OVERRIDE",
                                                 None):

--- a/tests/integration/defs/test_cpp.py
+++ b/tests/integration/defs/test_cpp.py
@@ -335,8 +335,8 @@ def test_unit_tests(build_google_tests, build_dir, lora_setup):
                          indirect=True)
 @pytest.mark.parametrize("model", [
     "bart", "chatglm", "eagle", "encoder", "enc_dec_language_adapter", "gpt",
-    "gpt_executor", "llama", "mamba", "medusa", "recurrentgemma", "redrafter",
-    "t5"
+    "gpt_executor", "gpt_session", "gpt_tests", "llama", "mamba", "medusa",
+    "recurrentgemma", "redrafter", "t5"
 ])
 @pytest.mark.parametrize("run_fp8", [False, True], ids=["", "fp8"])
 def test_model(build_google_tests, model, prepare_model, run_model_tests,

--- a/tests/integration/test_lists/test-db/l0_a30.yml
+++ b/tests/integration/test_lists/test-db/l0_a30.yml
@@ -42,6 +42,8 @@ l0_a30:
   - test_cpp.py::test_unit_tests[80]
   - test_cpp.py::test_model[gpt-80]
   - test_cpp.py::test_model[gpt_executor-80]
+  - test_cpp.py::test_model[gpt_session-80]
+  - test_cpp.py::test_model[gpt_tests-80]
   - test_cpp.py::test_benchmarks[gpt-80]
 - condition:
     ranges:


### PR DESCRIPTION
Before this change on A30:
test_cpp.py::test_model[gpt-80] : 6951.72s
After this change on A30:
test_cpp.py::test_model[gpt-80] : 2343.66s
test_cpp.py::test_model[gpt_tests-80] : 1622.67s
test_cpp.py::test_model[gpt_session-80] : 1136.56s
Reduce test time on each single test but will add 30min in total test time on A30 test. 

And do not parallelize gpt* test to avoid OOM issues. 