### PR TITLE
Clean up linear.py, mlp.py, gated_mlp.py

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -289,7 +289,7 @@ class Deepseekv3MoE(nn.Module):
             dtype=dtype,
             config=model_config,
             overridden_tp_size=shared_tp_size,
-            is_expert=True)
+            reduce_output=False)
 
         self.mapping = model_config.mapping
         self.all_reduce = AllReduce(self.mapping)
@@ -444,7 +444,7 @@ class DeepseekV3DecoderLayer(DecoderLayer):
                                 dtype=config.torch_dtype,
                                 config=model_config,
                                 overridden_tp_size=self.mlp_tp_size,
-                                is_expert=False)
+                                reduce_output=True)
 
         self.input_layernorm = RMSNorm(hidden_size=config.hidden_size,
                                        eps=config.rms_norm_eps,

--- a/tensorrt_llm/_torch/models/modeling_llama.py
+++ b/tensorrt_llm/_torch/models/modeling_llama.py
@@ -129,7 +129,7 @@ class Llama4MoE(nn.Module):
             bias=False,
             dtype=dtype,
             config=model_config,
-            is_expert=True)
+            reduce_output=False)
 
         self.router = Linear(hidden_size,
                              num_experts,

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -229,7 +229,7 @@ class Attention(nn.Module):
             q, k = self.rotary_emb(position_ids, [q, k])
 
         out_scale = None
-        if self.o_proj.has_fp8_qdq or self.o_proj.has_nv_fp4 or self.o_proj.has_fp8_block_scales:
+        if self.o_proj.has_fp8_qdq or self.o_proj.has_nvfp4 or self.o_proj.has_fp8_block_scales:
             out_scale = self.o_proj.inv_input_scale
 
         q, k, v = self.convert_qkv(q, k, v)

--- a/tensorrt_llm/_torch/modules/fused_moe.py
+++ b/tensorrt_llm/_torch/modules/fused_moe.py
@@ -322,7 +322,7 @@ class FusedMoE(nn.Module):
                 fc_weight_scales=self.w3_w1_weight_scaling_factor,
                 proj_weight_scales=self.w2_weight_scaling_factor,
             )
-        elif self.has_nv_fp4:
+        elif self.has_nvfp4:
             self.quant_scales = FusedMoEQuantScalesNVFP4(
                 fc1_act_global=self.fc31_input_scale,
                 fc1_weight_block=self.w3_w1_weight_scale,
@@ -350,7 +350,7 @@ class FusedMoE(nn.Module):
         self.has_any_quant = False
         self.has_fp8_qdq = False
         self.has_fp8_block_scales = False
-        self.has_nv_fp4 = False
+        self.has_nvfp4 = False
         if self.quant_config and self.quant_config.quant_mode.has_any_quant():
             self.has_any_quant = True
             qc = self.quant_config
@@ -407,7 +407,7 @@ class FusedMoE(nn.Module):
                 self.register_parameter("w2_weight_scaling_factor",
                                         w2_weight_scaling_factor)
             elif qc.quant_mode.has_nvfp4():
-                self.has_nv_fp4 = True
+                self.has_nvfp4 = True
                 weight_dtype = FUSED_MOE_NVFP4_WEIGHT_DTYPE
                 self.scaling_vector_size = 16
                 # Divide by 16 because we use int64 to pack 16 fp4 values
@@ -573,7 +573,7 @@ class FusedMoE(nn.Module):
             if self.has_fp8_qdq:
                 x, _ = torch.ops.tensorrt_llm.static_quantize_e4m3_per_tensor(
                     x, self.fc31_input_dequant)
-            elif self.has_nv_fp4:
+            elif self.has_nvfp4:
                 if not disable_fp4_allgather():
                     if isinstance(x, Fp4QuantizedTensor):
                         x, x_sf = x.fp4_tensor, x.scaling_factor


### PR DESCRIPTION
- Rename `is_expert` to `reduce_output` and the relationship between the two is `reduce_output = not is_expert`.
- Rename `has_nv_fp4` to `has_nvfp4`.
- Change local func `copy` to `_copy`
- Refactor out `_maybe_fuse_bias_into_allreduce` to make the code cleaner.
- Add `forward_lora` to mlp/gated_mlp so the normal forward is not crowded with lora code.