### PR TITLE
infra: [TRTLLM-4051] Support only run some backend type test

### DIFF
--- a/jenkins/L0_MergeRequest.groovy
+++ b/jenkins/L0_MergeRequest.groovy
@@ -79,7 +79,7 @@ def TEST_STAGE_LIST = "stage_list"
 @Field
 def GPU_TYPE_LIST = "gpu_type"
 @Field
-def BACKEND_MODE = "backend_mode"
+def TEST_BACKEND = "test_backend"
 @Field
 def IS_POST_MERGE = "post_merge"
 @Field
@@ -106,7 +106,7 @@ def testFilter = [
     (ENABLE_SKIP_TEST): gitlabParamsFromBot.get((ENABLE_SKIP_TEST), false),
     (TEST_STAGE_LIST): trimForStageList(gitlabParamsFromBot.get((TEST_STAGE_LIST), null)?.tokenize(',')),
     (GPU_TYPE_LIST): trimForStageList(gitlabParamsFromBot.get((GPU_TYPE_LIST), null)?.tokenize(',')),
-    (BACKEND_MODE): trimForStageList(gitlabParamsFromBot.get((BACKEND_MODE), null)?.tokenize(',')),
+    (TEST_BACKEND): trimForStageList(gitlabParamsFromBot.get((TEST_BACKEND), null)?.tokenize(',')),
     (IS_POST_MERGE): (env.JOB_NAME ==~ /.*PostMerge.*/) || gitlabParamsFromBot.get((IS_POST_MERGE), false),
     (ADD_MULTI_GPU_TEST): gitlabParamsFromBot.get((ADD_MULTI_GPU_TEST), false),
     (ONLY_MULTI_GPU_TEST): gitlabParamsFromBot.get((ONLY_MULTI_GPU_TEST), false) || gitlabParamsFromBot.get((ENABLE_MULTI_GPU_TEST), false),
@@ -138,7 +138,7 @@ boolean enableUpdateGitlabStatus =
     !testFilter[ONLY_MULTI_GPU_TEST] &&
     testFilter[GPU_TYPE_LIST] == null &&
     testFilter[TEST_STAGE_LIST] == null &&
-    testFilter[BACKEND_MODE] == null
+    testFilter[TEST_BACKEND] == null
 
 String getShortenedJobName(String path)
 {

--- a/jenkins/L0_MergeRequest.groovy
+++ b/jenkins/L0_MergeRequest.groovy
@@ -79,6 +79,8 @@ def TEST_STAGE_LIST = "stage_list"
 @Field
 def GPU_TYPE_LIST = "gpu_type"
 @Field
+def BACKEND_MODE = "backend_mode"
+@Field
 def IS_POST_MERGE = "post_merge"
 @Field
 def ADD_MULTI_GPU_TEST = "add_multi_gpu_test"
@@ -104,6 +106,7 @@ def testFilter = [
     (ENABLE_SKIP_TEST): gitlabParamsFromBot.get((ENABLE_SKIP_TEST), false),
     (TEST_STAGE_LIST): trimForStageList(gitlabParamsFromBot.get((TEST_STAGE_LIST), null)?.tokenize(',')),
     (GPU_TYPE_LIST): trimForStageList(gitlabParamsFromBot.get((GPU_TYPE_LIST), null)?.tokenize(',')),
+    (BACKEND_MODE): trimForStageList(gitlabParamsFromBot.get((BACKEND_MODE), null)?.tokenize(',')),
     (IS_POST_MERGE): (env.JOB_NAME ==~ /.*PostMerge.*/) || gitlabParamsFromBot.get((IS_POST_MERGE), false),
     (ADD_MULTI_GPU_TEST): gitlabParamsFromBot.get((ADD_MULTI_GPU_TEST), false),
     (ONLY_MULTI_GPU_TEST): gitlabParamsFromBot.get((ONLY_MULTI_GPU_TEST), false) || gitlabParamsFromBot.get((ENABLE_MULTI_GPU_TEST), false),
@@ -134,7 +137,8 @@ boolean enableUpdateGitlabStatus =
     !testFilter[ENABLE_SKIP_TEST] &&
     !testFilter[ONLY_MULTI_GPU_TEST] &&
     testFilter[GPU_TYPE_LIST] == null &&
-    testFilter[TEST_STAGE_LIST] == null
+    testFilter[TEST_STAGE_LIST] == null &&
+    testFilter[BACKEND_MODE] == null
 
 String getShortenedJobName(String path)
 {

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -1551,8 +1551,12 @@ def launchTestJobs(pipeline, testFilter, dockerNode=null)
             "cpp": "-CPP-",
         ]
         def backendModeList = backendMode.collect { changeMap[it] }.flatten()
-        def parallelJobsNoBackend = parallelJobsFiltered.findAll {key -> !changeMap.values().any{backend -> key.contains(backend)}}
-        def parallelJobsBackendMode = parallelJobsFiltered.findAll {key -> backendModeList.any{backend -> key.contains(backend)}}
+        def parallelJobsNoBackend = parallelJobsFiltered.findAll { key, _ -> 
+            !changeMap.values().any { backend -> key.contains(backend) }
+        }
+        def parallelJobsBackendMode = parallelJobsFiltered.findAll { key, _ -> 
+            backendModeList.any { backend -> key.contains(backend) }
+        }
         parallelJobsFiltered = parallelJobsNoBackend + parallelJobsBackendMode
         echo "parallelJobsBackendMode: ${parallelJobsBackendMode.keySet()}"
         println parallelJobsFiltered.keySet()

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -1551,10 +1551,10 @@ def launchTestJobs(pipeline, testFilter, dockerNode=null)
             "cpp": "-CPP-",
         ]
         def backendModeList = backendMode.collect { changeMap[it] }.flatten()
-        def parallelJobsNoBackend = parallelJobsFiltered.findAll { key, _ -> 
+        def parallelJobsNoBackend = parallelJobsFiltered.findAll { key, _ ->
             !changeMap.values().any { backend -> key.contains(backend) }
         }
-        def parallelJobsBackendMode = parallelJobsFiltered.findAll { key, _ -> 
+        def parallelJobsBackendMode = parallelJobsFiltered.findAll { key, _ ->
             backendModeList.any { backend -> key.contains(backend) }
         }
         parallelJobsFiltered = parallelJobsNoBackend + parallelJobsBackendMode

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -101,7 +101,7 @@ def TEST_STAGE_LIST = "stage_list"
 @Field
 def GPU_TYPE_LIST = "gpu_type"
 @Field
-def BACKEND_MODE = "backend_mode"
+def TEST_BACKEND = "test_backend"
 @Field
 def IS_POST_MERGE = "post_merge"
 @Field
@@ -126,7 +126,7 @@ def testFilter = [
     (ENABLE_SKIP_TEST): false,
     (TEST_STAGE_LIST): null,
     (GPU_TYPE_LIST): null,
-    (BACKEND_MODE): null,
+    (TEST_BACKEND): null,
     (IS_POST_MERGE): false,
     (ADD_MULTI_GPU_TEST): false,
     (ONLY_MULTI_GPU_TEST): false,
@@ -1542,9 +1542,9 @@ def launchTestJobs(pipeline, testFilter, dockerNode=null)
     }
 
     // Check --backend-mode, filter test stages.
-    if (testFilter[(BACKEND_MODE)] != null) {
-        echo "Use BACKEND_MODE for filtering. Backend mode: ${testFilter[(BACKEND_MODE)]}."
-        def backendMode = testFilter[(BACKEND_MODE)].collect { it.toLowerCase() }
+    if (testFilter[(TEST_BACKEND)] != null) {
+        echo "Use TEST_BACKEND for filtering. Backend mode: ${testFilter[(TEST_BACKEND)]}."
+        def backendMode = testFilter[(TEST_BACKEND)].collect { it.toLowerCase() }
         def changeMap = [
             "pytorch": "-PyTorch-",
             "tensorrt": "-TensorRT-",
@@ -1563,8 +1563,8 @@ def launchTestJobs(pipeline, testFilter, dockerNode=null)
     }
 
     if (testFilter[(ONLY_PYTORCH_FILE_CHANGED)]) {
-        if (testFilter[(BACKEND_MODE)] != null) {
-            echo "Force disable ONLY_PYTORCH_FILE_CHANGED mode. Backend mode set by flag: ${testFilter[(BACKEND_MODE)]}."
+        if (testFilter[(TEST_BACKEND)] != null) {
+            echo "Force disable ONLY_PYTORCH_FILE_CHANGED mode. Backend mode set by flag: ${testFilter[(TEST_BACKEND)]}."
         } else {
             echo "ONLY_PYTORCH_FILE_CHANGED mode is true."
             parallelJobsFiltered = parallelJobsFiltered.findAll { !it.key.contains("-CPP-") && !it.key.contains("-TensorRT-") }

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -120,7 +120,7 @@ def ONLY_PYTORCH_FILE_CHANGED = "only_pytorch_file_changed"
 def AUTO_TRIGGER_TAG_LIST = "auto_trigger_tag_list"
 @Field
 def DEBUG_MODE = "debug"
-
+@Field
 def testFilter = [
     (REUSE_STAGE_LIST): null,
     (ENABLE_SKIP_TEST): false,

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -1550,7 +1550,7 @@ def launchTestJobs(pipeline, testFilter, dockerNode=null)
             "tensorrt": "-TensorRT-",
             "cpp": "-CPP-",
         ]
-        def backendModeList = backendMode.collect { changeMap[it] }.flatten()
+        def backendModeList = backendMode.collect { changeMap.get(it) }.flatten()
         def parallelJobsNoBackend = parallelJobsFiltered.findAll { key, _ ->
             !changeMap.values().any { backend -> key.contains(backend) }
         }


### PR DESCRIPTION
This pull request support a new flag to only run part of tests by backend type.
Such as `/bot run --test-backend "cpp"` to only run all build/ package stage and cpp stages.
`/bot run --test-backend "pytorch"` to only run all build/ package stage and PyTorch stages.
This flag will not update the github action status to green.