### PR TITLE
fix : release torch-managed memory as soon as it's not needed

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -4,6 +4,7 @@ import glob
 import math
 import os
 import traceback
+import weakref
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from typing import Any, Dict, Optional, Tuple
@@ -765,7 +766,7 @@ class PyTorchModelEngine(ModelEngine):
                 with MetaInitMode():
                     model = AutoModelForCausalLM.from_config(config)
 
-                memo = dict()
+                memo = weakref.WeakValueDictionary()
 
                 def init_meta_tensor(t: torch.Tensor):
                     if t.device != torch.device('meta'):


### PR DESCRIPTION
When running continuous tests using LLM API, torch allocated memory can not be released until the end of the test. Using weakref to release the memory as soon as it's not needed. 