### PR TITLE
[TRTLLM-3429] feat: Overlap scheduling in C++ runtime

### DIFF
--- a/benchmarks/cpp/gptManagerBenchmark.cpp
+++ b/benchmarks/cpp/gptManagerBenchmark.cpp
@@ -639,6 +639,7 @@ public:
             benchmarkParams.cudaGraphCacheSize);
         texec::ExecutorConfig executorConfig(
             maxBeamWidth, schedulerConfig, kvCacheConfig, benchmarkParams.enableChunkedContext, true);
+        executorConfig.setEnableTrtOverlap(benchmarkParams.enableTrtOverlap);
         executorConfig.setGpuWeightsPercent(benchmarkParams.gpuWeightsPercent);
         executorConfig.setPeftCacheConfig(peftCacheConfig);
         executorConfig.setBatchingType(batchingType);
@@ -1161,6 +1162,7 @@ int main(int argc, char* argv[])
         "Specify how many cuda graphs are cached in the runtime. Larger cache gives better perf, but consumes more GPU "
         "memory.",
         cxxopts::value<SizeType32>()->default_value("0"));
+    options.add_options()("enable_trt_overlap", "Enable TRT Overlap", cxxopts::value<bool>()->default_value("false"));
 
     options.add_options()("enable_context_fmha_fp32_acc", "Enable FMHA runner FP32 accumulation",
         cxxopts::value<bool>()->default_value("false"));
@@ -1413,6 +1415,9 @@ int main(int argc, char* argv[])
 
     // Argument: cuda_graph_cache_size
     benchmarkParams.cudaGraphCacheSize = result["cuda_graph_cache_size"].as<SizeType32>();
+
+    // Argument: enable_trt_overlap
+    benchmarkParams.enableTrtOverlap = result["enable_trt_overlap"].as<bool>();
 
     std::optional<TokenIdType> padId;
     // Argument: Padding token id

--- a/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
+++ b/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
@@ -32,7 +32,6 @@
 #include <memory>
 #include <optional>
 #include <utility>
-#include <valarray>
 #include <vector>
 
 namespace tensorrt_llm::batch_manager
@@ -665,6 +664,12 @@ public:
     [[nodiscard]] SizeType32 getMaxNumGeneratedTokens() const
     {
         return getMaxBeamNumTokens() - mPromptLen;
+    }
+
+    /// @brief Returns true if request reaches max number of tokens in the current iteration.
+    [[nodiscard]] bool willCompleteNextIteration() const
+    {
+        return getMaxNumGeneratedTokens() + mNumTokensPerIteration >= mMaxNewTokens;
     }
 
     [[nodiscard]] LlmRequestType getLlmRequestType() const

--- a/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
+++ b/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
@@ -666,7 +666,7 @@ public:
         return getMaxBeamNumTokens() - mPromptLen;
     }
 
-    /// @brief Returns true if request reaches max number of tokens in the current iteration.
+    /// @brief Returns true if request reaches max number of tokens in the next iteration.
     [[nodiscard]] bool willCompleteNextIteration() const
     {
         return getMaxNumGeneratedTokens() + mNumTokensPerIteration >= mMaxNewTokens;

--- a/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
+++ b/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
@@ -1540,7 +1540,7 @@ public:
     }
 
     /// Determines whether the current position is only one chunk away from the end of the context.
-    [[nodiscard]] bool isLastContextChunk() const noexcept
+    [[nodiscard]] bool isLastContextChunk() const
     {
         return isDisaggGenerationInitState() || isDisaggGenerationTransmissionComplete()
             || getContextCurrentPosition() + getContextChunkSize() == mPromptLen;

--- a/cpp/include/tensorrt_llm/batch_manager/makeDecodingBatchInputOutput.h
+++ b/cpp/include/tensorrt_llm/batch_manager/makeDecodingBatchInputOutput.h
@@ -55,7 +55,7 @@ public:
     operator()(RequestVector const& contextRequests, RequestVector const& generationRequests,
         DecoderBuffers& decoderBuffers, DecoderInputBuffers const& inputBuffers,
         runtime::decoder::DecoderState& decoderState, runtime::ModelConfig const& modelConfig,
-        SizeType32 maxNumSequences, SizeType32 beamWidth, runtime::BufferManager const& manager,
+        SizeType32 maxNumSequences, SizeType32 beamWidth, bool isTrtOverlap, runtime::BufferManager const& manager,
         runtime::CudaStream const& stream, OptionalRef<RuntimeBuffers> fusedRuntimeBuffers) const;
 
     [[nodiscard]] static std::unique_ptr<runtime::decoder_batch::Input> createDecoderBatchInputs(

--- a/cpp/include/tensorrt_llm/batch_manager/microBatchScheduler.h
+++ b/cpp/include/tensorrt_llm/batch_manager/microBatchScheduler.h
@@ -53,7 +53,7 @@ public:
     explicit MicroBatchScheduler(std::optional<batch_scheduler::ContextChunkingConfig> ctxChunkConfig = std::nullopt,
         std::optional<SizeType32> maxContextLength = std::nullopt,
         LlmRequestState noScheduleUntilState = LlmRequestState::kCONTEXT_INIT,
-        LlmRequestState noScheduleAfterState = LlmRequestState::kGENERATION_COMPLETE);
+        LlmRequestState noScheduleAfterState = LlmRequestState::kGENERATION_TO_COMPLETE);
 
     std::tuple<RequestVector, RequestVector> operator()(RequestVector& activeRequests, ReqIdsSet const& inflightReqIds,
         SizeType32 maxBatchSizeRuntime, std::optional<SizeType32> maxNumTokensRuntime) const;

--- a/cpp/include/tensorrt_llm/batch_manager/runtimeBuffers.h
+++ b/cpp/include/tensorrt_llm/batch_manager/runtimeBuffers.h
@@ -19,6 +19,7 @@
 #include "tensorrt_llm/batch_manager/common.h"
 #include "tensorrt_llm/batch_manager/decoderBuffers.h"
 #include "tensorrt_llm/batch_manager/rnnStateManager.h"
+#include "tensorrt_llm/common/optionalRef.h"
 #include "tensorrt_llm/runtime/eagleBuffers.h"
 #include "tensorrt_llm/runtime/explicitDraftTokensBuffers.h"
 #include "tensorrt_llm/runtime/iTensor.h"
@@ -76,6 +77,8 @@ public:
     using TensorPtr = runtime::ITensor::SharedPtr;
     using TensorMap = runtime::ITensor::TensorMap;
     using PeftTable = runtime::LoraManager::PeftTable;
+    template <typename T>
+    using OptionalRef = tensorrt_llm::common::OptionalRef<T>;
 
     [[nodiscard]] SizeType32 constexpr getContextIndex() const noexcept
     {
@@ -276,7 +279,7 @@ public:
         kv_cache_manager::BaseKVCacheManager* crossKvCacheManager, rnn_state_manager::RnnStateManager* rnnStateManager,
         PeftTable const& peftTable, runtime::TllmRuntime const& runtime, runtime::ModelConfig const& modelConfig,
         runtime::WorldConfig const& worldConfig, bool gatherGenerationLogits, bool trtOverlap,
-        TensorPtr const& newOutputTokens);
+        OptionalRef<runtime::ITensor const> newOutputTokens = std::nullopt);
 
     void prepareBuffersForCudaGraph(SizeType32 maxSequenceLength);
 
@@ -310,7 +313,7 @@ private:
         kv_cache_manager::BaseKVCacheManager* crossKvCacheManagerPtr,
         rnn_state_manager::RnnStateManager* rnnStateManagerPtr, PeftTable const& peftTable,
         runtime::TllmRuntime const& runtime, runtime::ModelConfig const& modelConfig,
-        runtime::WorldConfig const& worldConfig, bool trtOverlap, TensorPtr const& newOutputTokens);
+        runtime::WorldConfig const& worldConfig, bool trtOverlap, OptionalRef<runtime::ITensor const> newOutputTokens);
 
     void fillIOMaps(runtime::ModelConfig const& modelConfig, runtime::WorldConfig const& worldConfig);
 };

--- a/cpp/include/tensorrt_llm/batch_manager/runtimeBuffers.h
+++ b/cpp/include/tensorrt_llm/batch_manager/runtimeBuffers.h
@@ -275,7 +275,8 @@ public:
         DecoderBuffers& decoderBuffers, kv_cache_manager::BaseKVCacheManager* kvCacheManager,
         kv_cache_manager::BaseKVCacheManager* crossKvCacheManager, rnn_state_manager::RnnStateManager* rnnStateManager,
         PeftTable const& peftTable, runtime::TllmRuntime const& runtime, runtime::ModelConfig const& modelConfig,
-        runtime::WorldConfig const& worldConfig, bool gatherGenerationLogits);
+        runtime::WorldConfig const& worldConfig, bool gatherGenerationLogits, bool trtOverlap,
+        TensorPtr const& newOutputTokens);
 
     void prepareBuffersForCudaGraph(SizeType32 maxSequenceLength);
 
@@ -309,7 +310,7 @@ private:
         kv_cache_manager::BaseKVCacheManager* crossKvCacheManagerPtr,
         rnn_state_manager::RnnStateManager* rnnStateManagerPtr, PeftTable const& peftTable,
         runtime::TllmRuntime const& runtime, runtime::ModelConfig const& modelConfig,
-        runtime::WorldConfig const& worldConfig);
+        runtime::WorldConfig const& worldConfig, bool trtOverlap, TensorPtr const& newOutputTokens);
 
     void fillIOMaps(runtime::ModelConfig const& modelConfig, runtime::WorldConfig const& worldConfig);
 };

--- a/cpp/include/tensorrt_llm/batch_manager/trtGptModelOptionalParams.h
+++ b/cpp/include/tensorrt_llm/batch_manager/trtGptModelOptionalParams.h
@@ -86,7 +86,8 @@ public:
     }
 
     explicit TrtGptModelOptionalParams(executor::ExecutorConfig const& executorConfig, bool isLeaderInOrchMode)
-        : TrtGptModelOptionalParams(KvCacheConfig(executorConfig.getKvCacheConfig()), false,
+        : TrtGptModelOptionalParams(KvCacheConfig(executorConfig.getKvCacheConfig()),
+            executorConfig.getEnableTrtOverlap(),
             executorConfig.getParallelConfig().value_or(executor::ParallelConfig()).getDeviceIds(),
             executorConfig.getNormalizeLogProbs(), executorConfig.getEnableChunkedContext(),
             PeftCacheManagerConfig(executorConfig.getPeftCacheConfig().value_or(executor::PeftCacheConfig())),

--- a/cpp/include/tensorrt_llm/executor/executor.h
+++ b/cpp/include/tensorrt_llm/executor/executor.h
@@ -206,6 +206,8 @@ class AdditionalModelOutput
 public:
     explicit AdditionalModelOutput(std::string name, bool gatherContext = false);
 
+    bool operator==(AdditionalModelOutput const& other) const;
+
     std::string name;
     bool gatherContext{false};
 };
@@ -1390,6 +1392,8 @@ class CacheTransceiverConfig
 public:
     explicit CacheTransceiverConfig(std::optional<size_t> maxNumTokens = std::nullopt);
 
+    bool operator==(CacheTransceiverConfig const& other) const;
+
     [[nodiscard]] std::optional<size_t> getMaxNumTokens() const;
     void setMaxNumTokens(size_t maxNumTokens);
 
@@ -1430,7 +1434,7 @@ public:
         std::optional<std::vector<AdditionalModelOutput>> additionalModelOutputs = std::nullopt,
         std::optional<CacheTransceiverConfig> cacheTransceiverConfig = std::nullopt,
         bool gatherGenerationLogits = false, bool useVariableBeamWidthSearch = false,
-        bool promptTableOffloading = false);
+        bool promptTableOffloading = false, bool enableTrtOverlap = false);
 
     [[nodiscard]] SizeType32 getMaxBeamWidth() const;
     [[nodiscard]] SchedulerConfig getSchedulerConfig() const;
@@ -1465,6 +1469,7 @@ public:
     [[nodiscard]] bool getUseVariableBeamWidthSearch() const;
     [[nodiscard]] bool getPromptTableOffloading() const;
     [[nodiscard]] std::optional<CacheTransceiverConfig> getCacheTransceiverConfig() const;
+    [[nodiscard]] bool getEnableTrtOverlap() const;
 
     void setMaxBeamWidth(SizeType32 maxBeamWidth);
     void setMaxBatchSize(SizeType32 maxBatchSize);
@@ -1494,6 +1499,7 @@ public:
     void setUseVariableBeamWidthSearch(bool useVariableBeamWidthSearch);
     void setPromptTableOffloading(bool promptTableOffloading);
     void setCacheTransceiverConfig(CacheTransceiverConfig const& cacheTransceiverConfig);
+    void setEnableTrtOverlap(bool enableTrtOverlap);
 
 private:
     friend class Serialization;
@@ -1507,7 +1513,7 @@ private:
     /// @brief The KV cache configuration.
     KvCacheConfig mKvCacheConfig;
 
-    /// @brief The KV cache configuration.
+    /// @brief Controls whether context is allowed to be chunked.
     bool mEnableChunkedContext;
 
     /// @brief Controls if log probabilities should be normalized or not.
@@ -1580,6 +1586,9 @@ private:
 
     /// @brief Controls if prompt table offloading is enabled.
     bool mPromptTableOffloading{false};
+
+    /// @brief Controls whether preparation and TRT engine execution should be overlapped.
+    bool mEnableTrtOverlap{false};
 };
 
 struct KVCacheCreatedData

--- a/cpp/tensorrt_llm/batch_manager/runtimeBuffers.cpp
+++ b/cpp/tensorrt_llm/batch_manager/runtimeBuffers.cpp
@@ -455,7 +455,7 @@ void RuntimeBuffers::setFromInputs(RequestVector const& contextRequests, Request
     kv_cache_manager::BaseKVCacheManager* crossKvCacheManagerPtr,
     rnn_state_manager::RnnStateManager* rnnStateManagerPtr, PeftTable const& peftTable,
     runtime::TllmRuntime const& runtime, runtime::ModelConfig const& modelConfig,
-    runtime::WorldConfig const& worldConfig, bool trtOverlap, TensorPtr const& newOutputTokens)
+    runtime::WorldConfig const& worldConfig, bool trtOverlap, OptionalRef<runtime::ITensor const> newOutputTokens)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
     NVTX3_SCOPED_RANGE(runtimeBuffersSetFromInputs);
@@ -926,7 +926,8 @@ std::tuple<SizeType32, RuntimeBuffers::TensorMap const&, RuntimeBuffers::TensorM
     SizeType32 maxAttentionWindow, DecoderBuffers& decoderBuffers, kv_cache_manager::BaseKVCacheManager* kvCacheManager,
     kv_cache_manager::BaseKVCacheManager* crossKvCacheManager, rnn_state_manager::RnnStateManager* rnnStateManager,
     PeftTable const& peftTable, TllmRuntime const& runtime, ModelConfig const& modelConfig,
-    WorldConfig const& worldConfig, bool gatherGenerationLogits, bool trtOverlap, TensorPtr const& newOutputTokens)
+    WorldConfig const& worldConfig, bool gatherGenerationLogits, bool trtOverlap,
+    OptionalRef<runtime::ITensor const> newOutputTokens)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
     NVTX3_SCOPED_RANGE(runtimeBuffersPrepareStep);

--- a/cpp/tensorrt_llm/batch_manager/runtimeBuffers.cpp
+++ b/cpp/tensorrt_llm/batch_manager/runtimeBuffers.cpp
@@ -31,8 +31,10 @@
 #include "tensorrt_llm/common/stlUtils.h"
 #include "tensorrt_llm/runtime/bufferManager.h"
 #include "tensorrt_llm/runtime/common.h"
+#include "tensorrt_llm/runtime/decoderState.h"
 #include "tensorrt_llm/runtime/iBuffer.h"
 #include "tensorrt_llm/runtime/iTensor.h"
+#include "tensorrt_llm/runtime/runtimeKernels.h"
 #include "tensorrt_llm/runtime/tllmRuntime.h"
 #include "tensorrt_llm/runtime/utils/sessionUtils.h"
 
@@ -453,7 +455,7 @@ void RuntimeBuffers::setFromInputs(RequestVector const& contextRequests, Request
     kv_cache_manager::BaseKVCacheManager* crossKvCacheManagerPtr,
     rnn_state_manager::RnnStateManager* rnnStateManagerPtr, PeftTable const& peftTable,
     runtime::TllmRuntime const& runtime, runtime::ModelConfig const& modelConfig,
-    runtime::WorldConfig const& worldConfig)
+    runtime::WorldConfig const& worldConfig, bool trtOverlap, TensorPtr const& newOutputTokens)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
     NVTX3_SCOPED_RANGE(runtimeBuffersSetFromInputs);
@@ -641,13 +643,23 @@ void RuntimeBuffers::setFromInputs(RequestVector const& contextRequests, Request
             TLLM_CHECK(draftLength == 0 || reqBeamWidth == 1);
 
             auto const promptLen = llmReq->mPromptLen;
-            auto const sequenceLen = promptLen + llmReq->getMaxNumGeneratedTokens();
+            auto const sequenceLen
+                = promptLen + llmReq->getMaxNumGeneratedTokens() + static_cast<SizeType32>(trtOverlap);
             auto const& positionIds = llmReq->getPositionIds();
             for (int beam = 0; beam < reqBeamWidth; ++beam)
             {
-                auto const lastToken = llmReq->getLastTokens(beam);
-                auto const numTokens = llmReq->getNumTokens(beam);
-                inputHost.push_back(lastToken);
+                auto const numTokens = llmReq->getNumTokens(beam) + static_cast<SizeType32>(trtOverlap);
+                // TODO: can this be removed completely?
+                if (!trtOverlap)
+                {
+                    auto const lastToken = llmReq->getLastTokens(beam);
+                    inputHost.push_back(lastToken);
+                    if (draftLength > 0)
+                    {
+                        inputHost.insert(inputHost.end(), draftTokens->begin(), draftTokens->end());
+                    }
+                }
+
                 // If model updates generation position ids do not append them here.
                 if (!modelConfig.getSpeculativeDecodingMode().updatesPositionIds())
                 {
@@ -677,11 +689,6 @@ void RuntimeBuffers::setFromInputs(RequestVector const& contextRequests, Request
                             positionIdsHost.push_back(numTokens - 1);
                         }
                     }
-                }
-
-                if (draftLength > 0)
-                {
-                    inputHost.insert(inputHost.end(), draftTokens->begin(), draftTokens->end());
                 }
 
                 if (modelConfig.useMrope())
@@ -733,7 +740,8 @@ void RuntimeBuffers::setFromInputs(RequestVector const& contextRequests, Request
             auto const draftLength = llmReq->getNumDraftTokens();
 
             auto const contextQLength = llmReq->mPromptLen + draftLength;
-            auto const sequenceLen = contextQLength + llmReq->getMaxNumGeneratedTokens();
+            auto const sequenceLen
+                = contextQLength + llmReq->getMaxNumGeneratedTokens() + static_cast<SizeType32>(trtOverlap);
 
             std::fill_n(contextLengthsHostPtr + numSequences, reqBeamWidth, contextQLength);
             std::fill_n(sequenceLengthsHostPtr + numSequences, reqBeamWidth, sequenceLen);
@@ -809,7 +817,20 @@ void RuntimeBuffers::setFromInputs(RequestVector const& contextRequests, Request
 
     {
         NVTX3_SCOPED_RANGE(bufferCopies);
-        manager.copy(inputHost.data(), *inputsIds);
+        if (trtOverlap)
+        {
+            auto contextInputsIds = ITensor::slice(inputsIds, 0, numContextTokens);
+            manager.copy(inputHost.data(), *contextInputsIds);
+
+            auto generationInputsIds = ITensor::slice(inputsIds, numContextTokens);
+            auto seqSlotsDeviceSlice = ITensor::slice(seqSlotsDevice, numContextRequests);
+            runtime::kernels::invokeGatherBatch(
+                *generationInputsIds, *newOutputTokens, *seqSlotsDeviceSlice, maxBeamWidth, stream);
+        }
+        else
+        {
+            manager.copy(inputHost.data(), *inputsIds);
+        }
         // In generation phase, device ptr of context lengths need to be tiled.
         manager.copy(*contextLengthsHost, *contextLengthsDevice);
         manager.copy(*sequenceLengthsHost, *sequenceLengthsDevice);
@@ -905,7 +926,7 @@ std::tuple<SizeType32, RuntimeBuffers::TensorMap const&, RuntimeBuffers::TensorM
     SizeType32 maxAttentionWindow, DecoderBuffers& decoderBuffers, kv_cache_manager::BaseKVCacheManager* kvCacheManager,
     kv_cache_manager::BaseKVCacheManager* crossKvCacheManager, rnn_state_manager::RnnStateManager* rnnStateManager,
     PeftTable const& peftTable, TllmRuntime const& runtime, ModelConfig const& modelConfig,
-    WorldConfig const& worldConfig, bool gatherGenerationLogits)
+    WorldConfig const& worldConfig, bool gatherGenerationLogits, bool trtOverlap, TensorPtr const& newOutputTokens)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
     NVTX3_SCOPED_RANGE(runtimeBuffersPrepareStep);
@@ -914,7 +935,8 @@ std::tuple<SizeType32, RuntimeBuffers::TensorMap const&, RuntimeBuffers::TensorM
     reshape(runtime, modelConfig, worldConfig, gatherGenerationLogits);
 
     setFromInputs(contextRequests, genRequests, maxBeamWidth, maxAttentionWindow, decoderBuffers, kvCacheManager,
-        crossKvCacheManager, rnnStateManager, peftTable, runtime, modelConfig, worldConfig);
+        crossKvCacheManager, rnnStateManager, peftTable, runtime, modelConfig, worldConfig, trtOverlap,
+        newOutputTokens);
 
     fillIOMaps(modelConfig, worldConfig);
 

--- a/cpp/tensorrt_llm/batch_manager/trtEncoderModel.h
+++ b/cpp/tensorrt_llm/batch_manager/trtEncoderModel.h
@@ -179,7 +179,7 @@ private:
     std::shared_ptr<nvinfer1::ILogger> mLogger;
     std::shared_ptr<runtime::TllmRuntime> mRuntime;
 
-    SizeType32 mMicroBatchId;
+    SizeType32 mMicroBatchId{0};
 
     // TODO: Add runtime buffers for async PP
     std::vector<std::shared_ptr<EncoderBuffers>> mBuffers;

--- a/cpp/tensorrt_llm/batch_manager/trtGptModel.h
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModel.h
@@ -69,6 +69,22 @@ public:
         TLLM_CHECK_WITH_INFO(mMaxBatchSize <= modelConfig.getMaxBatchSize(),
             "Runtime configured max batch size (%d) must not exceed engine max batch size (%d)", mMaxBatchSize,
             modelConfig.getMaxBatchSize());
+        if (optionalParams.enableTrtOverlap)
+        {
+            if (mMaxBeamWidth > 1)
+            {
+                mEnableTrtOverlap = false;
+                TLLM_LOG_WARNING(
+                    "TRT overlap is not supported with beam search (maxBeamWidth is set to %d) and will be disabled.",
+                    mMaxBeamWidth);
+            }
+            if (!modelConfig.getSpeculativeDecodingMode().isNone())
+            {
+                mEnableTrtOverlap = false;
+                TLLM_LOG_WARNING("TRT overlap is not supported with speculative decoding and will be disabled.");
+            }
+        }
+
         mMaxAttentionWindow = 0;
         if (optionalParams.kvCacheConfig.maxAttentionWindowVec.has_value())
         {

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -848,7 +848,8 @@ void TrtGptModelInflightBatching::forwardSync()
             }
         }
 
-        for (auto const& llmReq : currRequests.contextRequests)
+        // Finished context requests have been moved to generationRequests by moveFinishedContextRequestsToGeneration
+        for (auto const& llmReq : currRequests.generationRequests)
         {
             // If a context-only request is finished, send its KV cache and mark it.
             if (llmReq->isContextOnlyRequest() && llmReq->isContextFinished())
@@ -951,6 +952,11 @@ void TrtGptModelInflightBatching::forwardAsync(RequestList const& activeRequests
         std::tie(currRequests.contextRequests, currRequests.generationRequests)
             = (*mMicroBatchScheduler)(fittingRequests, mInflightReqIds, mMaxBatchSizeRuntime, mMaxNumTokensRuntime);
         TLLM_CHECK(currRequests.size() <= static_cast<size_t>(getMaxBatchSize()));
+
+        // Move context requests that reached the last context chunk to the end of the vector.
+        // This order is required for moveFinishedContextRequestsToGeneration.
+        std::partition(currRequests.contextRequests.begin(), currRequests.contextRequests.end(),
+            [](auto const& llmReq) { return !llmReq->isLastContextChunk(); });
 
         (*mPauseRequests)(requestsToPause, mInflightReqIds, mReqIdsToPause, false, *mSeqSlotManager, mKvCacheManager,
             mCrossKvCacheManager, mPeftCacheManager);
@@ -1076,6 +1082,8 @@ void TrtGptModelInflightBatching::forwardAsync(RequestList const& activeRequests
                     }
                 }
             }
+
+            utils::moveFinishedContextRequestsToGeneration(currRequests);
         }
         else
         {
@@ -2129,177 +2137,172 @@ void TrtGptModelInflightBatching::updateRequests(ScheduledRequests const& schedu
     auto const* const finishReasonsHostData
         = bufferCast<kernels::FinishedState>(*decoderOutputBuffers.finishReasonsHost);
 
-    // Update the request table tokens
-    // instead of copy-pasting the loop for context and generation requests,
-    // just run the inner loop for both containers
-    for (auto const& requests : {scheduledRequests.contextRequests, scheduledRequests.generationRequests})
+    // Update only requests that ran through the decoder
+    for (auto const& llmReq : scheduledRequests.generationRequests)
     {
-        for (auto const& llmReq : requests)
+        if (llmReq->isGenerationCompleteState())
         {
-            auto const reqBeamWidth = llmReq->mSamplingConfig.beamWidth;
-            if (llmReq->isContextInitState() || llmReq->isGenerationCompleteState())
+            continue;
+        }
+        auto const reqBeamWidth = llmReq->mSamplingConfig.beamWidth;
+        auto const seqSlot = llmReq->mSeqSlot.value();
+        auto const numGeneratedTokens = llmReq->getNumDraftTokens() + 1;
+        auto const currentNumOfTokens = llmReq->getMaxBeamNumTokens();
+
+        // Save the accepted token logits from target model
+        if (llmReq->getReturnGenerationLogits() && mModelConfig.getSpeculativeDecodingMode().isDraftTokensExternal()
+            && llmReq->hasDraftTokens())
+        {
+            TLLM_CHECK_WITH_INFO(reqBeamWidth == 1, "Speculative decoding only works for beam width == 1");
+
+            SizeType32 numAcceptedTokens
+                = sequenceLengthsHostData[seqSlot * mOperatingBeamWidth + 0] - llmReq->getMaxBeamNumTokens();
+
+            auto const& generationLogitsHost = llmReq->getGenerationLogitsHost();
+            auto shape = generationLogitsHost->getShape();
+            shape.d[1] = numAcceptedTokens;
+            generationLogitsHost->reshape(shape);
+        }
+
+        std::vector<SizeType32> numNewTokens(reqBeamWidth);
+        std::vector<SizeType32> numDroppedTokens(reqBeamWidth);
+
+        for (SizeType32 beam = 0; beam < reqBeamWidth; ++beam)
+        {
+            auto const seqLen = sequenceLengthsHostData[seqSlot * mOperatingBeamWidth + beam];
+            // The content of newOutputTokens might not be accurate in the case where
+            // the sequence has finished early due to end token, so only add new tokens
+            // to llmReq if decoder seq length is greater than current number of tokens
+            numNewTokens[beam] = std::min(numGeneratedTokens, seqLen - llmReq->getNumTokens(beam));
+            numDroppedTokens[beam] = numGeneratedTokens - numNewTokens[beam];
+            for (SizeType32 step = 0; step < numNewTokens[beam]; ++step)
             {
-                continue;
-            }
-            auto const seqSlot = llmReq->mSeqSlot.value();
-            auto const numGeneratedTokens = llmReq->getNumDraftTokens() + 1;
-            auto const currentNumOfTokens = llmReq->getMaxBeamNumTokens();
+                auto const newTokenIdx = tc::flat_index(hostNewOutputTokensShape.d, step, seqSlot, beam);
+                auto const newToken = hostNewOutputTokensData[newTokenIdx];
+                llmReq->addNewToken(newToken, beam);
+                TLLM_LOG_DEBUG("request ID %ld beam %d newToken %d", llmReq->mRequestId, beam, newToken);
 
-            // Save the accepted token logits from target model
-            if (llmReq->getReturnGenerationLogits() && mModelConfig.getSpeculativeDecodingMode().isDraftTokensExternal()
-                && llmReq->hasDraftTokens())
-            {
-                TLLM_CHECK_WITH_INFO(reqBeamWidth == 1, "Speculative decoding only works for beam width == 1");
-
-                SizeType32 numAcceptedTokens
-                    = sequenceLengthsHostData[seqSlot * mOperatingBeamWidth + 0] - llmReq->getMaxBeamNumTokens();
-
-                auto const& generationLogitsHost = llmReq->getGenerationLogitsHost();
-                auto shape = generationLogitsHost->getShape();
-                shape.d[1] = numAcceptedTokens;
-                generationLogitsHost->reshape(shape);
-            }
-
-            std::vector<SizeType32> numNewTokens(reqBeamWidth);
-            std::vector<SizeType32> numDroppedTokens(reqBeamWidth);
-
-            for (SizeType32 beam = 0; beam < reqBeamWidth; ++beam)
-            {
-                auto const seqLen = sequenceLengthsHostData[seqSlot * mOperatingBeamWidth + beam];
-                // The content of newOutputTokens might not be accurate in the case where
-                // the sequence has finished early due to end token, so only add new tokens
-                // to llmReq if decoder seq length is greater than current number of tokens
-                numNewTokens[beam] = std::min(numGeneratedTokens, seqLen - llmReq->getNumTokens(beam));
-                numDroppedTokens[beam] = numGeneratedTokens - numNewTokens[beam];
-                for (SizeType32 step = 0; step < numNewTokens[beam]; ++step)
+                if (llmReq->returnLogProbs())
                 {
-                    auto const newTokenIdx = tc::flat_index(hostNewOutputTokensShape.d, step, seqSlot, beam);
-                    auto const newToken = hostNewOutputTokensData[newTokenIdx];
-                    llmReq->addNewToken(newToken, beam);
-                    TLLM_LOG_DEBUG("request ID %ld beam %d newToken %d", llmReq->mRequestId, beam, newToken);
+                    auto const cumLogProb = cumLogProbsPtr[seqSlot * mOperatingBeamWidth + beam];
+                    llmReq->setCumLogProb(cumLogProb, beam);
 
-                    if (llmReq->returnLogProbs())
-                    {
-                        auto const cumLogProb = cumLogProbsPtr[seqSlot * mOperatingBeamWidth + beam];
-                        llmReq->setCumLogProb(cumLogProb, beam);
-
-                        auto const beginLogProbsOffset = reqBeamWidth == 1 ? llmReq->mPromptLen : 0;
-                        SizeType32 offset
-                            = (seqSlot * mOperatingBeamWidth + beam) * getMaxSequenceLen() + beginLogProbsOffset;
-                        auto const generatedLength = seqLen - llmReq->mPromptLen;
-                        std::vector<float> logProbs(logProbsPtr + offset, logProbsPtr + offset + generatedLength);
-                        llmReq->setLogProbs(logProbs, beam);
-                    }
-                }
-
-                auto const finishReason = finishReasonsHostData[seqSlot * mOperatingBeamWidth + beam];
-                llmReq->setFinishedReason(finishReason.toFinishReason(), beam);
-
-                TLLM_LOG_DEBUG("[RANK %d] decoderSync: request ID %lu beam %d tokens %s finished %d",
-                    COMM_SESSION.getRank(), llmReq->mRequestId, beam, common::vec2str(llmReq->getTokens(beam)).c_str(),
-                    static_cast<int>(finishReason.toFinishReason()));
-            }
-
-            // Set number of tokens predicted per runtime iteration. Will be > 1 for speculative decoding.
-            llmReq->updateNumTokensPerIteration(llmReq->getMaxBeamNumTokens() - currentNumOfTokens, mModelConfig);
-
-            // Fill new draft tokens for the next step
-            if (decoderFinishedSumPtr[seqSlot] != reqBeamWidth
-                && (mModelConfig.getSpeculativeDecodingMode().predictsDraftTokens()
-                    || mModelConfig.getSpeculativeDecodingMode().needsKVCacheRewind()))
-            {
-                auto const maxDraftTokensLen = mModelConfig.getMaxDecodingDraftTokens();
-                auto prevDraftTokensLen = llmReq->getNumDraftTokens();
-
-                // We overallocate KV cache for EAGLE to the maxDecodingTokens + maxPathLen in order to fit both
-                // Base model verification (needs up to maxDecodingTokens) and
-                // Drafter (needs up to maxPathLen of accepted tokens and maxDecodingDraftTokens for new draft tokens).
-                if (mModelConfig.getSpeculativeDecodingMode().isEagle())
-                {
-                    prevDraftTokensLen = mModelConfig.getSpeculativeDecodingModule().getMaxDecodingTokens()
-                        + mModelConfig.getSpeculativeDecodingModule().getMaxPathLen() - 1;
-                }
-
-                auto nextDraftTokensLen = mModelConfig.getSpeculativeDecodingModule().getMaxDecodingDraftTokens();
-                if (mModelConfig.getSpeculativeDecodingMode().variableDraftLength())
-                {
-                    nextDraftTokensLen = nextDraftTokensLengthsHostData[seqSlot];
-                }
-                TLLM_CHECK(nextDraftTokensLen <= maxDraftTokensLen);
-
-                auto draftTokensShared
-                    = std::make_shared<std::vector<TokenIdType>>(nextDraftTokensHostData + seqSlot * maxDraftTokensLen,
-                        nextDraftTokensHostData + seqSlot * maxDraftTokensLen + nextDraftTokensLen);
-
-                llmReq->setDraftTokens(draftTokensShared);
-
-                // For all phases except context that does not have draft tokens
-                if (!llmReq->isGenerationCompleteState() && prevDraftTokensLen != 0
-                    && mModelConfig.getSpeculativeDecodingMode().needsKVCacheRewind())
-                {
-                    // -1 here is for current 'main' token
-                    auto const acceptedTokensLen = llmReq->getMaxBeamNumTokens() - currentNumOfTokens - 1;
-                    auto const rewindLength = prevDraftTokensLen - acceptedTokensLen;
-
-                    TLLM_LOG_DEBUG("request ID %lu (seqSlot %d): accepted %d of %d draft tokens, rewind %d tokens",
-                        llmReq->mRequestId, seqSlot, acceptedTokensLen, prevDraftTokensLen, rewindLength);
-                    TLLM_CHECK(0 <= acceptedTokensLen && acceptedTokensLen <= prevDraftTokensLen);
-
-                    // At this point, KV cache rows are already gathered and moved to the right location.
-                    // We can safely rewind (draft - accepted) tokens
-                    mKvCacheManager->rewindKVCache(llmReq->mRequestId, rewindLength);
+                    auto const beginLogProbsOffset = reqBeamWidth == 1 ? llmReq->mPromptLen : 0;
+                    SizeType32 offset
+                        = (seqSlot * mOperatingBeamWidth + beam) * getMaxSequenceLen() + beginLogProbsOffset;
+                    auto const generatedLength = seqLen - llmReq->mPromptLen;
+                    std::vector<float> logProbs(logProbsPtr + offset, logProbsPtr + offset + generatedLength);
+                    llmReq->setLogProbs(logProbs, beam);
                 }
             }
 
-            // Terminate if request has finished or if it is speculative decoding target model
-            if (decoderFinishedSumPtr[seqSlot] == reqBeamWidth
-                || (mModelConfig.getSpeculativeDecodingMode().isDraftTokensExternal() && llmReq->hasDraftTokens()))
-            {
-                postProcessRequest(*llmReq, numDroppedTokens);
+            auto const finishReason = finishReasonsHostData[seqSlot * mOperatingBeamWidth + beam];
+            llmReq->setFinishedReason(finishReason.toFinishReason(), beam);
 
-                if (!mWorldConfig.isPipelineParallel() || !mWorldConfig.isLastPipelineParallelRank())
+            TLLM_LOG_DEBUG("[RANK %d] decoderSync: request ID %lu beam %d tokens %s finished %d",
+                COMM_SESSION.getRank(), llmReq->mRequestId, beam, common::vec2str(llmReq->getTokens(beam)).c_str(),
+                static_cast<int>(finishReason.toFinishReason()));
+        }
+
+        // Set number of tokens predicted per runtime iteration. Will be > 1 for speculative decoding.
+        llmReq->updateNumTokensPerIteration(llmReq->getMaxBeamNumTokens() - currentNumOfTokens, mModelConfig);
+
+        // Fill new draft tokens for the next step
+        if (decoderFinishedSumPtr[seqSlot] != reqBeamWidth
+            && (mModelConfig.getSpeculativeDecodingMode().predictsDraftTokens()
+                || mModelConfig.getSpeculativeDecodingMode().needsKVCacheRewind()))
+        {
+            auto const maxDraftTokensLen = mModelConfig.getMaxDecodingDraftTokens();
+            auto prevDraftTokensLen = llmReq->getNumDraftTokens();
+
+            // We overallocate KV cache for EAGLE to the maxDecodingTokens + maxPathLen in order to fit both
+            // Base model verification (needs up to maxDecodingTokens) and
+            // Drafter (needs up to maxPathLen of accepted tokens and maxDecodingDraftTokens for new draft tokens).
+            if (mModelConfig.getSpeculativeDecodingMode().isEagle())
+            {
+                prevDraftTokensLen = mModelConfig.getSpeculativeDecodingModule().getMaxDecodingTokens()
+                    + mModelConfig.getSpeculativeDecodingModule().getMaxPathLen() - 1;
+            }
+
+            auto nextDraftTokensLen = mModelConfig.getSpeculativeDecodingModule().getMaxDecodingDraftTokens();
+            if (mModelConfig.getSpeculativeDecodingMode().variableDraftLength())
+            {
+                nextDraftTokensLen = nextDraftTokensLengthsHostData[seqSlot];
+            }
+            TLLM_CHECK(nextDraftTokensLen <= maxDraftTokensLen);
+
+            auto draftTokensShared
+                = std::make_shared<std::vector<TokenIdType>>(nextDraftTokensHostData + seqSlot * maxDraftTokensLen,
+                    nextDraftTokensHostData + seqSlot * maxDraftTokensLen + nextDraftTokensLen);
+
+            llmReq->setDraftTokens(draftTokensShared);
+
+            // For all phases except context that does not have draft tokens
+            if (!llmReq->isGenerationCompleteState() && prevDraftTokensLen != 0
+                && mModelConfig.getSpeculativeDecodingMode().needsKVCacheRewind())
+            {
+                // -1 here is for current 'main' token
+                auto const acceptedTokensLen = llmReq->getMaxBeamNumTokens() - currentNumOfTokens - 1;
+                auto const rewindLength = prevDraftTokensLen - acceptedTokensLen;
+
+                TLLM_LOG_DEBUG("request ID %lu (seqSlot %d): accepted %d of %d draft tokens, rewind %d tokens",
+                    llmReq->mRequestId, seqSlot, acceptedTokensLen, prevDraftTokensLen, rewindLength);
+                TLLM_CHECK(0 <= acceptedTokensLen && acceptedTokensLen <= prevDraftTokensLen);
+
+                // At this point, KV cache rows are already gathered and moved to the right location.
+                // We can safely rewind (draft - accepted) tokens
+                mKvCacheManager->rewindKVCache(llmReq->mRequestId, rewindLength);
+            }
+        }
+
+        // Terminate if request has finished or if it is speculative decoding target model
+        if (decoderFinishedSumPtr[seqSlot] == reqBeamWidth
+            || (mModelConfig.getSpeculativeDecodingMode().isDraftTokensExternal() && llmReq->hasDraftTokens()))
+        {
+            postProcessRequest(*llmReq, numDroppedTokens);
+
+            if (!mWorldConfig.isPipelineParallel() || !mWorldConfig.isLastPipelineParallelRank())
+            {
+                if (llmReq->getReturnGenerationLogits() && mSpeculativeDecodingFastLogits && mIsLeaderInOrchMode)
                 {
-                    if (llmReq->getReturnGenerationLogits() && mSpeculativeDecodingFastLogits && mIsLeaderInOrchMode)
-                    {
-                        mDraftRequestsWaitingToSendLogits.push_back(llmReq);
-                    }
-                    else
-                    {
-                        terminateRequest(llmReq);
-                    }
-                    llmReq->setState(LlmRequestState::kGENERATION_COMPLETE);
+                    mDraftRequestsWaitingToSendLogits.push_back(llmReq);
                 }
                 else
                 {
-                    llmReq->setState(LlmRequestState::kGENERATION_TO_COMPLETE);
+                    terminateRequest(llmReq);
                 }
+                llmReq->setState(LlmRequestState::kGENERATION_COMPLETE);
             }
             else
             {
-                // gather tokens in the case of streaming and beam search
-                if (llmReq->isStreaming() && llmReq->mSamplingConfig.beamWidth > 1)
-                {
-                    postProcessRequest(*llmReq, numDroppedTokens);
-                }
-                if (llmReq->isContextInitState())
-                {
-                    llmReq->setState(LlmRequestState::kGENERATION_IN_PROGRESS);
-                }
+                llmReq->setState(LlmRequestState::kGENERATION_TO_COMPLETE);
             }
-
-            if (llmReq->getReturnPerfMetrics())
+        }
+        else
+        {
+            // gather tokens in the case of streaming and beam search
+            if (llmReq->isStreaming() && llmReq->mSamplingConfig.beamWidth > 1)
             {
-                llmReq->updatePerfMetrics(mIterCounter);
+                postProcessRequest(*llmReq, numDroppedTokens);
             }
-
-            llmReq->advanceDecodingIter();
-
-            if (mWorldConfig.isPipelineParallel() && mWorldConfig.isLastPipelineParallelRank())
+            if (llmReq->isContextInitState())
             {
-                for (SizeType32 beam = 0; beam < reqBeamWidth; ++beam)
-                {
-                    llmReq->setNumPreDecodedTokens(numNewTokens[beam], beam);
-                }
+                llmReq->setState(LlmRequestState::kGENERATION_IN_PROGRESS);
+            }
+        }
+
+        if (llmReq->getReturnPerfMetrics())
+        {
+            llmReq->updatePerfMetrics(mIterCounter);
+        }
+
+        llmReq->advanceDecodingIter();
+
+        if (mWorldConfig.isPipelineParallel() && mWorldConfig.isLastPipelineParallelRank())
+        {
+            for (SizeType32 beam = 0; beam < reqBeamWidth; ++beam)
+            {
+                llmReq->setNumPreDecodedTokens(numNewTokens[beam], beam);
             }
         }
     }

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -1576,7 +1576,7 @@ void TrtGptModelInflightBatching::prepareDistGenBufferAndDecoder(RequestVector c
         runtimeBuffers.prepareStep(cacheTransCompleteRequests, {}, getMaxBeamWidth(), getMaxAttentionWindow(),
             *mDecoderBuffers, mKvCacheManager.get(), mCrossKvCacheManager.get(), mRnnStateManager.get(),
             mPeftTables[mMicroBatchId], *mRuntime, mModelConfig, mWorldConfig, getGatherGenerationLogits(),
-            isTrtOverlap(), nullptr);
+            isTrtOverlap());
         auto const contextBufferId = mCtxGenFusion ? getFusedBufferId() : getContextBufferId();
         setupDecoderStep(
             cacheTransCompleteRequests, *mBuffers.at(contextBufferId), mDecoderInputBuffers.at(getFusedBufferId()));

--- a/cpp/tensorrt_llm/batch_manager/utils/inflightBatchingUtils.h
+++ b/cpp/tensorrt_llm/batch_manager/utils/inflightBatchingUtils.h
@@ -37,6 +37,13 @@ TensorPtr collectRequestIds(RequestVector const& contextRequests, RequestVector 
 
 void sortByLoraId(ScheduledRequests& scheduledRequests);
 
+//! @brief Move finished context requests to generation requests.
+//! @details This function assumes that the context requests are sorted so that requests with isLastContextChunk() are
+//!          at the end of the context requests vector. These requests are moved to the beginning of the generation
+//!          requests vector. This means that the order of the requests in context+generation requests is not changed.
+//! @param scheduledRequests The scheduled context and generation requests.
+void moveFinishedContextRequestsToGeneration(ScheduledRequests& scheduledRequests);
+
 //! @param beforeDecoder    Whether the function is called before the decoder. If it is true, correct the output offset.
 //! @param numDroppedTokens The number of dropped tokens for each beam (e.g. when the requests finished early).
 //!                         Generation logits for dropped tokens are ignored.

--- a/cpp/tensorrt_llm/executor/cacheTransceiverConfig.cpp
+++ b/cpp/tensorrt_llm/executor/cacheTransceiverConfig.cpp
@@ -26,6 +26,11 @@ CacheTransceiverConfig::CacheTransceiverConfig(std::optional<size_t> maxNumToken
 {
 }
 
+bool CacheTransceiverConfig::operator==(CacheTransceiverConfig const& other) const
+{
+    return mMaxNumTokens == other.mMaxNumTokens;
+}
+
 std::optional<size_t> CacheTransceiverConfig::getMaxNumTokens() const
 {
     return mMaxNumTokens;

--- a/cpp/tensorrt_llm/executor/executorConfig.cpp
+++ b/cpp/tensorrt_llm/executor/executorConfig.cpp
@@ -34,7 +34,7 @@ ExecutorConfig::ExecutorConfig(SizeType32 maxBeamWidth, SchedulerConfig schedule
     std::optional<SpeculativeDecodingConfig> specDecConfig, std::optional<GuidedDecodingConfig> guidedDecodingConfig,
     std::optional<std::vector<AdditionalModelOutput>> additionalModelOutputs,
     std::optional<CacheTransceiverConfig> cacheTransceiverConfig, bool gatherGenerationLogits,
-    bool useVariableBeamWidthSearch, bool promptTableOffloading)
+    bool useVariableBeamWidthSearch, bool promptTableOffloading, bool enableTrtOverlap)
     : mMaxBeamWidth(maxBeamWidth)
     , mSchedulerConfig(std::move(schedulerConfig))
     , mKvCacheConfig(std::move(kvCacheConfig))
@@ -63,12 +63,15 @@ ExecutorConfig::ExecutorConfig(SizeType32 maxBeamWidth, SchedulerConfig schedule
     , mGatherGenerationLogits(gatherGenerationLogits)
     , mUseVariableBeamWidthSearch(useVariableBeamWidthSearch)
     , mPromptTableOffloading(promptTableOffloading)
+    , mEnableTrtOverlap(enableTrtOverlap)
 {
     TLLM_CHECK(iterStatsMaxIterations >= 0);
     TLLM_CHECK(requestStatsMaxIterations >= 0);
     TLLM_CHECK(mMaxBeamWidth > 0);
     TLLM_CHECK(maxSeqIdleMicroseconds > 0);
 }
+
+// getters
 
 SizeType32 ExecutorConfig::getMaxBeamWidth() const
 {
@@ -220,6 +223,13 @@ bool ExecutorConfig::getPromptTableOffloading() const
     return mPromptTableOffloading;
 }
 
+bool ExecutorConfig::getEnableTrtOverlap() const
+{
+    return mEnableTrtOverlap;
+}
+
+// setters
+
 void ExecutorConfig::setMaxBeamWidth(SizeType32 maxBeamWidth)
 {
     mMaxBeamWidth = maxBeamWidth;
@@ -365,6 +375,11 @@ void ExecutorConfig::setUseVariableBeamWidthSearch(bool useVariableBeamWidthSear
 void ExecutorConfig::setPromptTableOffloading(bool promptTableOffloading)
 {
     mPromptTableOffloading = promptTableOffloading;
+}
+
+void ExecutorConfig::setEnableTrtOverlap(bool enableTrtOverlap)
+{
+    mEnableTrtOverlap = enableTrtOverlap;
 }
 
 } // namespace tensorrt_llm::executor

--- a/cpp/tensorrt_llm/executor/outputConfig.cpp
+++ b/cpp/tensorrt_llm/executor/outputConfig.cpp
@@ -39,4 +39,9 @@ AdditionalModelOutput::AdditionalModelOutput(std::string name, bool gatherContex
 {
 }
 
+bool AdditionalModelOutput::operator==(AdditionalModelOutput const& other) const
+{
+    return name == other.name && gatherContext == other.gatherContext;
+}
+
 } // namespace tensorrt_llm::executor

--- a/cpp/tensorrt_llm/executor/serialization.cpp
+++ b/cpp/tensorrt_llm/executor/serialization.cpp
@@ -996,12 +996,17 @@ ExecutorConfig Serialization::deserializeExecutorConfig(std::istream& is)
         = su::deserializeWithGetterType<decltype(&ExecutorConfig::getCacheTransceiverConfig)>(is);
     auto gatherGenerationLogits
         = su::deserializeWithGetterType<decltype(&ExecutorConfig::getGatherGenerationLogits)>(is);
+    auto useVariableBeamWidthSearch
+        = su::deserializeWithGetterType<decltype(&ExecutorConfig::getUseVariableBeamWidthSearch)>(is);
+    auto promptTableOffloading = su::deserializeWithGetterType<decltype(&ExecutorConfig::getPromptTableOffloading)>(is);
+    auto enableTrtOverlap = su::deserializeWithGetterType<decltype(&ExecutorConfig::getEnableTrtOverlap)>(is);
 
     return ExecutorConfig{maxBeamWidth, schedulerConfig, kvCacheConfig, enableChunkedContext, normalizeLogProbs,
         iterStatsMaxIterations, requestStatsMaxIterations, batchingType, maxBatchSize, maxNumTokens, parallelConfig,
         peftCacheConfig, std::nullopt, decodingConfig, useGpuDirectStorage, gpuWeightsPercent, maxQueueSize,
         extendedRuntimePerfKnobConfig, debugConfig, recvPollPeriodMs, maxSeqIdleMicroseconds, specDecConfig,
-        guidedDecodingConfig, additionalModelOutputs, cacheTransceiverConfig, gatherGenerationLogits};
+        guidedDecodingConfig, additionalModelOutputs, cacheTransceiverConfig, gatherGenerationLogits,
+        useVariableBeamWidthSearch, promptTableOffloading, enableTrtOverlap};
 }
 
 size_t Serialization::serializedSize(ExecutorConfig const& executorConfig)
@@ -1036,6 +1041,9 @@ size_t Serialization::serializedSize(ExecutorConfig const& executorConfig)
     totalSize += su::serializedSize(executorConfig.getAdditionalModelOutputs());
     totalSize += su::serializedSize(executorConfig.getCacheTransceiverConfig());
     totalSize += su::serializedSize(executorConfig.getGatherGenerationLogits());
+    totalSize += su::serializedSize(executorConfig.getUseVariableBeamWidthSearch());
+    totalSize += su::serializedSize(executorConfig.getPromptTableOffloading());
+    totalSize += su::serializedSize(executorConfig.getEnableTrtOverlap());
 
     return totalSize;
 }
@@ -1070,6 +1078,9 @@ void Serialization::serialize(ExecutorConfig const& executorConfig, std::ostream
     su::serialize(executorConfig.getAdditionalModelOutputs(), os);
     su::serialize(executorConfig.getCacheTransceiverConfig(), os);
     su::serialize(executorConfig.getGatherGenerationLogits(), os);
+    su::serialize(executorConfig.getUseVariableBeamWidthSearch(), os);
+    su::serialize(executorConfig.getPromptTableOffloading(), os);
+    su::serialize(executorConfig.getEnableTrtOverlap(), os);
 }
 
 // KvCacheConfig

--- a/cpp/tensorrt_llm/pybind/batch_manager/algorithms.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/algorithms.cpp
@@ -159,7 +159,8 @@ void tensorrt_llm::pybind::batch_manager::algorithms::initBindings(pybind11::mod
         .def("__call__", &MakeDecodingBatchInputOutput::operator(), py::arg("context_requests"),
             py::arg("generation_requests"), py::arg("decoder_buffers"), py::arg("decoder_input_buffers"),
             py::arg("decoder_state"), py::arg("model_config"), py::arg("max_num_sequences"), py::arg("beam_width"),
-            py::arg("buffer_manager"), py::arg("stream"), py::arg("fused_runtime_buffers") = std::nullopt)
+            py::arg("is_trt_overlap"), py::arg("buffer_manager"), py::arg("stream"),
+            py::arg("fused_runtime_buffers") = std::nullopt)
         .def("name", [](MakeDecodingBatchInputOutput const&) { return MakeDecodingBatchInputOutput::name; });
 
     py::class_<LogitsPostProcessor>(m, LogitsPostProcessor::name)

--- a/cpp/tensorrt_llm/pybind/executor/executorConfig.cpp
+++ b/cpp/tensorrt_llm/pybind/executor/executorConfig.cpp
@@ -434,7 +434,7 @@ void initConfigBindings(pybind11::module_& m)
             c.getExtendedRuntimePerfKnobConfig(), c.getDebugConfig(), c.getRecvPollPeriodMs(),
             c.getMaxSeqIdleMicroseconds(), c.getSpecDecConfig(), c.getGuidedDecodingConfig(),
             c.getAdditionalModelOutputs(), c.getCacheTransceiverConfig(), c.getGatherGenerationLogits(),
-            c.getUseVariableBeamWidthSearch(), c.getPromptTableOffloading());
+            c.getUseVariableBeamWidthSearch(), c.getPromptTableOffloading(), c.getEnableTrtOverlap());
         auto pickle_tuple = py::make_tuple(cpp_states, py::getattr(self, "__dict__"));
         return pickle_tuple;
     };
@@ -447,7 +447,7 @@ void initConfigBindings(pybind11::module_& m)
 
         // Restore C++ data
         auto cpp_states = state[0].cast<py::tuple>();
-        if (cpp_states.size() != 28)
+        if (cpp_states.size() != 29)
         {
             throw std::runtime_error("Invalid cpp_states!");
         }
@@ -480,7 +480,8 @@ void initConfigBindings(pybind11::module_& m)
             cpp_states[24].cast<std::optional<tle::CacheTransceiverConfig>>(),             // CacheTransceiverConfig
             cpp_states[25].cast<bool>(),                                                   // GatherGenerationLogits
             cpp_states[26].cast<bool>(),                                                   // UseVariableBeamWidthSearch
-            cpp_states[27].cast<bool>()                                                    // PromptTableOffloading
+            cpp_states[27].cast<bool>(),                                                   // PromptTableOffloading
+            cpp_states[28].cast<bool>()                                                    // EnableTrtOverlap
         );
 
         auto py_state = state[1].cast<py::dict>();
@@ -517,7 +518,8 @@ void initConfigBindings(pybind11::module_& m)
                  std::optional<tle::CacheTransceiverConfig>,             // CacheTransceiverConfig
                  bool,                                                   // GatherGenerationLogits
                  bool,                                                   // UseVariableBeamWidthSearch
-                 bool                                                    // PromptTableOffloading
+                 bool,                                                   // PromptTableOffloading
+                 bool                                                    // EnableTrtOverlap
                  >(),
             py::arg("max_beam_width") = 1, py::arg_v("scheduler_config", tle::SchedulerConfig(), "SchedulerConfig()"),
             py::arg_v("kv_cache_config", tle::KvCacheConfig(), "KvCacheConfig()"),
@@ -538,7 +540,7 @@ void initConfigBindings(pybind11::module_& m)
             py::arg("spec_dec_config") = py::none(), py::arg("guided_decoding_config") = py::none(),
             py::arg("additional_model_outputs") = py::none(), py::arg("cache_transceiver_config") = py::none(),
             py::arg("gather_generation_logits") = false, py::arg("use_variable_beam_width_search") = false,
-            py::arg("mm_embedding_offloading") = false)
+            py::arg("mm_embedding_offloading") = false, py::arg("enable_trt_overlap") = false)
         .def_property("max_beam_width", &tle::ExecutorConfig::getMaxBeamWidth, &tle::ExecutorConfig::setMaxBeamWidth)
         .def_property("max_batch_size", &tle::ExecutorConfig::getMaxBatchSize, &tle::ExecutorConfig::setMaxBatchSize)
         .def_property("max_num_tokens", &tle::ExecutorConfig::getMaxNumTokens, &tle::ExecutorConfig::setMaxNumTokens)
@@ -588,6 +590,8 @@ void initConfigBindings(pybind11::module_& m)
             &tle::ExecutorConfig::setUseVariableBeamWidthSearch)
         .def_property("mm_embedding_offloading", &tle::ExecutorConfig::getPromptTableOffloading,
             &tle::ExecutorConfig::setPromptTableOffloading)
+        .def_property(
+            "enable_trt_overlap", &tle::ExecutorConfig::getEnableTrtOverlap, &tle::ExecutorConfig::setEnableTrtOverlap)
         .def(py::pickle(executorConfigGetState, executorConfigSetState));
 }
 

--- a/cpp/tensorrt_llm/runtime/runtimeKernels.h
+++ b/cpp/tensorrt_llm/runtime/runtimeKernels.h
@@ -33,6 +33,9 @@ void invokeFill(IBuffer& buffer, T value, CudaStream const& stream);
 void invokeFillBatch(
     IBuffer& buffer, IBuffer const& indices, std::size_t stride, IBuffer const& values, CudaStream const& stream);
 
+void invokeGatherBatch(IBuffer& buffer, IBuffer const& values, IBuffer const& slotIndices, std::size_t slotStride,
+    CudaStream const& stream);
+
 void invokeCopyBatch(IBuffer const& srcBuffer, IBuffer& dstBuffer, IBuffer const& srcOffsets, IBuffer const& dstOffsets,
     IBuffer const& sizes, std::size_t maxStride, CudaStream const& stream);
 

--- a/cpp/tests/batch_manager/trtGptModelRealDecoderTest.cpp
+++ b/cpp/tests/batch_manager/trtGptModelRealDecoderTest.cpp
@@ -1382,7 +1382,7 @@ INSTANTIATE_TEST_SUITE_P(GptChunkedLongContextTests, ParamTest,
         testing::Values(BeamConfig{1, {1}}), // beam config
         testing::Values(std::nullopt, 1024), // maxTokensInPagedKvCache
         testing::Values(0.4),                // freeGpuMemoryFraction
-        testing::Values(false),              // enableTrtOverlap
+        testing::Values(true),               // enableTrtOverlap
         testing::Values(true),               // enableChunkedContext
         testing::Values(false),              // enableStreamingMode
         testing::Values(false),              // enableCudaGraphMode

--- a/cpp/tests/unit_tests/executor/serializeUtilsTest.cpp
+++ b/cpp/tests/unit_tests/executor/serializeUtilsTest.cpp
@@ -770,7 +770,9 @@ TEST(SerializeUtilsTest, ExecutorConfig)
         8, texec::ExtendedRuntimePerfKnobConfig(true), texec::DebugConfig(true), 60000000, 180000000,
         texec::SpeculativeDecodingConfig(true),
         texec::GuidedDecodingConfig(
-            texec::GuidedDecodingConfig::GuidedDecodingBackend::kXGRAMMAR, std::initializer_list<std::string>{"eos"}));
+            texec::GuidedDecodingConfig::GuidedDecodingBackend::kXGRAMMAR, std::initializer_list<std::string>{"eos"}),
+        std::vector{tensorrt_llm::executor::AdditionalModelOutput{"output_name"}}, texec::CacheTransceiverConfig(1024),
+        true, true, true, true);
     auto executorConfig2 = serializeDeserialize(executorConfig);
 
     EXPECT_EQ(executorConfig.getMaxBeamWidth(), executorConfig2.getMaxBeamWidth());
@@ -797,6 +799,11 @@ TEST(SerializeUtilsTest, ExecutorConfig)
     EXPECT_EQ(executorConfig.getMaxSeqIdleMicroseconds(), executorConfig2.getMaxSeqIdleMicroseconds());
     EXPECT_EQ(executorConfig.getSpecDecConfig(), executorConfig2.getSpecDecConfig());
     EXPECT_EQ(executorConfig.getGuidedDecodingConfig(), executorConfig2.getGuidedDecodingConfig());
+    EXPECT_EQ(executorConfig.getAdditionalModelOutputs(), executorConfig2.getAdditionalModelOutputs());
+    EXPECT_EQ(executorConfig.getCacheTransceiverConfig(), executorConfig2.getCacheTransceiverConfig());
+    EXPECT_EQ(executorConfig.getGatherGenerationLogits(), executorConfig2.getGatherGenerationLogits());
+    EXPECT_EQ(executorConfig.getPromptTableOffloading(), executorConfig2.getPromptTableOffloading());
+    EXPECT_EQ(executorConfig.getEnableTrtOverlap(), executorConfig2.getEnableTrtOverlap());
 }
 
 TEST(SerializeUtilsTest, RequestStats)

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -474,7 +474,8 @@ def instantiate_decoder(model_engine, executor_config, pytorch_backend_config,
         decoding_mode = executor_config.decoding_config.decoding_mode if executor_config.decoding_config and executor_config.decoding_config.decoding_mode else DecodingMode.TopK(
         )
         decoder = TRTLLMDecoder(executor_config, model_engine.model,
-                                model_engine.dtype, mapping, decoding_mode)
+                                model_engine.dtype, mapping, decoding_mode,
+                                pytorch_backend_config.enable_overlap_scheduler)
     elif not model_engine.model.model_config.is_generation:
         # NOTE: choose decoder based on model type
         decoder = EarlyStopDecoder()

--- a/tests/unittest/_torch/test_overlap_scheduler.py
+++ b/tests/unittest/_torch/test_overlap_scheduler.py
@@ -43,7 +43,7 @@ def create_llm(model_dir, enable_overlap_scheduler, enable_trtllm_decoder):
     )
 
 
-@pytest.mark.parametrize("enable_trtllm_decoder", [False])
+@pytest.mark.parametrize("enable_trtllm_decoder", [False, True])
 def test_overlap_scheduler_consistency(model_path, test_case,
                                        enable_trtllm_decoder):
     # Test configuration


### PR DESCRIPTION
Overlap execution of one iteration and preparation of next iteration.
* Add `enableTrtOverlap` switch  to `ExecutorConfig`.
* Add `enable_trt_overlap` switch to `gptManagerBenchmark`.
* Disable overlap for beam search (because of synchronous `finalize` function).
* Disable overlap for speculative decoding.

Implementation details:
* Separate in-progress and finished context requests. Only finished context requests and generation requests are processed by decoder.
* Early exit based on requests' `maxNewTokens` to avoid surplus iterations.