### PR TITLE
fix: read and set head_size and head_dim when convert Eagle checkpoint

### DIFF
--- a/examples/eagle/convert_checkpoint.py
+++ b/examples/eagle/convert_checkpoint.py
@@ -295,6 +295,8 @@ if __name__ == '__main__':
         args.n_positions = hf_config.max_position_embeddings
         args.dtype = str(
             hf_config.torch_dtype)[6:] if args.dtype == 'auto' else args.dtype
+        args.head_dim = hf_config.head_dim
+        args.head_size = args.head_dim
 
         if args.eagle_model_dir is None:
             hf_config_eagle = hf_config.eagle
@@ -305,6 +307,12 @@ if __name__ == '__main__':
             args.n_kv_head_eagle = hf_config_eagle['num_key_value_heads']
             args.rms_norm_eps_eagle = hf_config_eagle['rms_norm_eps']
             args.n_positions_eagle = hf_config_eagle['max_position_embeddings']
+            if 'head_dim' in hf_config_eagle:
+                args.head_dim_eagle = hf_config_eagle['head_dim']
+            else:
+                args.head_dim_eagle = args.n_embd_eagle // args.n_head_eagle
+
+            args.head_size_eagle = args.head_dim_eagle
         else:
             hf_config_eagle = LlamaConfig.from_pretrained(args.eagle_model_dir)
             args.n_head_eagle = hf_config_eagle.num_attention_heads
@@ -370,6 +378,8 @@ if __name__ == '__main__':
         },
         'use_parallel_embedding': args.use_parallel_embedding,
         'embedding_sharding_dim': args.embedding_sharding_dim,
+        'head_dim': args.head_dim_eagle,
+        'head_size': args.head_size_eagle
     }
 
     config = {
@@ -402,7 +412,9 @@ if __name__ == '__main__':
         'max_draft_len': args.max_draft_len,
         'num_eagle_layers': args.num_eagle_layers,
         'max_non_leaves_per_layer': args.max_non_leaves_per_layer,
-        'eagle_net_config': eagle_net_config
+        'eagle_net_config': eagle_net_config,
+        'head_dim': args.head_dim,
+        'head_size': args.head_size
     }
 
     assert args.max_draft_len <= 256, "args.max_draft_len > 256 is not supported"

--- a/tensorrt_llm/models/eagle/config.py
+++ b/tensorrt_llm/models/eagle/config.py
@@ -88,6 +88,8 @@ class EagleConfig(LLaMAConfig):
             n_positions = hf_config.max_position_embeddings
             hidden_act = hf_config.hidden_act
             dtype = str(hf_config.torch_dtype)[6:] if dtype == 'auto' else dtype
+            head_dim = hf_config.head_dim
+            head_size = hf_config.head_size
 
             if speculative_config_or_dir is None:
                 hf_config_eagle = hf_config.eagle
@@ -143,6 +145,8 @@ class EagleConfig(LLaMAConfig):
             },
             'use_parallel_embedding': kwargs['use_parallel_embedding'],
             'embedding_sharding_dim': kwargs['embedding_sharding_dim'],
+            'head_dim': head_dim,
+            'head_size': head_size
         }
 
         config = {


### PR DESCRIPTION
Add set `head_size` and `head_dim` when converting the Eagle checkpoint. 

This can make the `head_size` and `head_dim` of the main model and eagle model decoupled and their value are unnecessarily equal to `hidden_size / num_attention_heads` (such as mistral-nemo).