### PR TITLE
Clean up modeling_deepseek.py

### DIFF
--- a/tensorrt_llm/_torch/pipeline_interface.py
+++ b/tensorrt_llm/_torch/pipeline_interface.py
@@ -16,7 +16,7 @@ class PipelineInterface:
     - Slicing: pp[start:end]
 
     Note: When using this interface in pp, the packing/unpacking and send/recv
-    operations must be used symmetrically within stage and between succsive ranks.
+    operations must be used symmetrically within stage and between successive ranks.
     """
     _pp_comm = None
 


### PR DESCRIPTION
- Rename some variables to make the code more readable
- Remove unnecessary if/else branches
- Simplify some of the logics in allreduce fusion

The `modeling_deepseek.py` files looks mostly clean after this round of cleaning. I kept the allreduce part the same because we need the allreduce op unification PR to land first.

For accuracy test, I ran the `examples/pytorch/quickstart_advanced.py` script with the R1 model with different configs.