### PR TITLE
fix: Fix fused_moe cache fallback issue.

### DIFF
--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -126,7 +126,9 @@ def fused_moe(
         (2, 0, ((0, ), lambda x: x)),
     ))
 
-    min_latency_tensor = torch.empty(1) if min_latency_mode else torch.empty(0)
+    # TODO: set min_latency_mode always to False due to the error in the moe_kernels
+    min_latency_tensor = torch.empty(0)
+
     # allocate workspace for profiling
     moe_runner = MoERunner(
         x_dtype=input.dtype,


### PR DESCRIPTION
min_latency_mode is only set to False during the warmup phase. Thus, when it becomes true during inference, all tactics fall back to the default one and cause perf regression.
We should first fix the kernel issue when setting min_latency_mode=True in profiling. Then, remove the bypass and enable real tuning for min_latency mode.