### PR TITLE
fix: FP8 kv accuracy

### DIFF
--- a/examples/deepseek_v3/README.md
+++ b/examples/deepseek_v3/README.md
@@ -417,9 +417,9 @@ FP8 KV Cache and MLA quantization could be enabled, which delivers two key perfo
 - Compression of the latent KV cache enables larger batch sizes, resulting in higher throughput;
 - MLA kernel of the generation phase is accelerated by FP8 arithmetic and reduced KV cache memory access.
 
-FP8 KV Cache and MLA is supported on Hopper and Blackwell.
-- On Hopper we use the [FP8 FlashMLA kernel](https://github.com/deepseek-ai/FlashMLA/pull/54) from community. The accuracy loss is small, with GSM8k accuracy drop less than 1%.
-- On Blackwell we use the kernel generated from an internal code-gen based solution called `trtllm-gen`. Note that FP8 MLA on Blackwell currently suffers from accuracy issues and there are ongoing efforts to solve it.
+FP8 KV Cache and MLA is supported on Hopper and Blackwell. The accuracy loss is small, with GSM8k accuracy drop less than 1%.
+- On Hopper we use the [FP8 FlashMLA kernel](https://github.com/deepseek-ai/FlashMLA/pull/54) from community.
+- On Blackwell we use the kernel generated from an internal code-gen based solution called `trtllm-gen`.
 
 You can enable FP8 MLA through either of these methods:
 


### PR DESCRIPTION
Multiply rope scaling to scaleSoftmaxLog2
GSM8K score of R1 (FP8 kv, Blackwell) 70%->96.06% (same as BF16 kv)