### PR TITLE
Fix/executor bugs

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -1,3 +1,4 @@
+import math
 import random
 from collections.abc import Iterable
 
@@ -25,8 +26,7 @@ from .py_executor import PyExecutor
 from .resource_manager import (KVCacheManager, MambaHybridCacheManager,
                                PeftCacheManager, ResourceManager)
 from .scheduler import (BindCapacityScheduler, BindMicroBatchScheduler,
-                        SimpleScheduler, ScheduledRequests)
-import math
+                        SimpleScheduler)
 
 
 def is_nemotron_hybrid(config):
@@ -138,8 +138,12 @@ def get_token_num_for_estimation(executor_config, model_config):
         # block (tokens_per_block tokens) if the sequence length is not perfectly divisible by tokens_per_block.
         # So we add math.ceil(max_num_tokens/max_seq_len) * tokens_per_block extra tokens.
         return min(
-            max(executor_config.max_batch_size, executor_config.max_num_tokens + math.ceil(executor_config.max_num_tokens / executor_config.max_seq_len) * executor_config.tokens_per_block,
-                executor_config.max_seq_len), max_tokens_limit)
+            max(
+                executor_config.max_batch_size, executor_config.max_num_tokens +
+                math.ceil(executor_config.max_num_tokens /
+                          executor_config.max_seq_len) *
+                executor_config.tokens_per_block, executor_config.max_seq_len),
+            max_tokens_limit)
     else:
         return None
 

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -6,7 +6,7 @@ import torch
 import tensorrt_llm
 import tensorrt_llm.bindings as tllm
 import tensorrt_llm.bindings.executor as trtllm
-from tensorrt_llm._utils import (mpi_allgather, mpi_broadcast,
+from tensorrt_llm._utils import (mpi_barrier, mpi_broadcast,
                                  str_dtype_to_binding, torch_dtype_to_str)
 from tensorrt_llm.bindings.executor import ExecutorConfig
 from tensorrt_llm.logger import logger
@@ -25,7 +25,8 @@ from .py_executor import PyExecutor
 from .resource_manager import (KVCacheManager, MambaHybridCacheManager,
                                PeftCacheManager, ResourceManager)
 from .scheduler import (BindCapacityScheduler, BindMicroBatchScheduler,
-                        SimpleScheduler)
+                        SimpleScheduler, ScheduledRequests)
+import math
 
 
 def is_nemotron_hybrid(config):
@@ -132,8 +133,12 @@ def get_token_num_for_estimation(executor_config, model_config):
         fraction = get_fraction_from_executor_config(executor_config)
         kv_size_per_token = get_cache_size_per_token(model_config, mapping)
         max_tokens_limit = int(end * fraction // kv_size_per_token)
+        # When reusing KV cache blocks, we need to add extra tokens to account for partially filled blocks
+        # that cannot be reused. For each sequence of max_num_tokens length, we may need up to one extra
+        # block (tokens_per_block tokens) if the sequence length is not perfectly divisible by tokens_per_block.
+        # So we add math.ceil(max_num_tokens/max_seq_len) * tokens_per_block extra tokens.
         return min(
-            max(executor_config.max_batch_size, executor_config.max_num_tokens,
+            max(executor_config.max_batch_size, executor_config.max_num_tokens + math.ceil(executor_config.max_num_tokens / executor_config.max_seq_len) * executor_config.tokens_per_block,
                 executor_config.max_seq_len), max_tokens_limit)
     else:
         return None
@@ -172,8 +177,9 @@ def estimate_max_kv_cache_tokens(py_executor: PyExecutor,
     req_ids = mpi_broadcast(req_ids, root=0)
     py_executor.start_worker()
     py_executor.await_responses(req_ids)
+
     # sync all ranks after processing dummy requests
-    mpi_allgather(0)
+    mpi_barrier()
 
     torch_peak_memory = torch.cuda.memory_stats()["allocated_bytes.all.peak"]
 
@@ -212,7 +218,7 @@ def estimate_max_kv_cache_tokens(py_executor: PyExecutor,
 
     py_executor.shutdown()
     # sync all ranks after creating new pyExecutor
-    mpi_allgather(0)
+    mpi_barrier()
 
     return kv_cache_max_tokens
 

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -7,7 +7,7 @@ import torch
 import tensorrt_llm
 import tensorrt_llm.bindings as tllm
 import tensorrt_llm.bindings.executor as trtllm
-from tensorrt_llm._utils import (mpi_barrier, mpi_broadcast,
+from tensorrt_llm._utils import (mpi_allgather, mpi_broadcast,
                                  str_dtype_to_binding, torch_dtype_to_str)
 from tensorrt_llm.bindings.executor import ExecutorConfig
 from tensorrt_llm.logger import logger
@@ -183,7 +183,7 @@ def estimate_max_kv_cache_tokens(py_executor: PyExecutor,
     py_executor.await_responses(req_ids)
 
     # sync all ranks after processing dummy requests
-    mpi_barrier()
+    mpi_allgather(0)
 
     torch_peak_memory = torch.cuda.memory_stats()["allocated_bytes.all.peak"]
 
@@ -222,7 +222,7 @@ def estimate_max_kv_cache_tokens(py_executor: PyExecutor,
 
     py_executor.shutdown()
     # sync all ranks after creating new pyExecutor
-    mpi_barrier()
+    mpi_allgather(0)
 
     return kv_cache_max_tokens
 

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -839,6 +839,13 @@ class PyExecutor:
                         "fail to schedule any pending request, "
                         "probably run out of resource.")
 
+
+                logger.debug(
+                    f'has {len(self.active_requests)} active_request, '
+                    f'scheduled {len(scheduled_batch.context_requests)} context requests and '
+                    f'{len(scheduled_batch.generation_requests)} generation requests'
+                )
+
                 self._pause_requests(scheduled_batch.paused_requests)
 
                 finished_requests = []

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -839,7 +839,6 @@ class PyExecutor:
                         "fail to schedule any pending request, "
                         "probably run out of resource.")
 
-
                 logger.debug(
                     f'has {len(self.active_requests)} active_request, '
                     f'scheduled {len(scheduled_batch.context_requests)} context requests and '

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -194,7 +194,7 @@ def create_py_executor(executor_config: ExecutorConfig,
             py_executor = create_py_executor_instance(
                 dist, kv_cache_manager, draft_kv_cache_manager, mapping,
                 pytorch_backend_config, executor_config, ctx_chunk_config,
-                model_engine, draft_model_engine, True, lora_config)
+                model_engine, draft_model_engine, False, lora_config)
 
     py_executor.start_worker()
     return py_executor


### PR DESCRIPTION
1. When we estimate the kv cache memory, we need to consider that we need to add extra token when we enable the kv cache reuse. So, For each sequence of max_num_tokens length, we may need up to one extra block.

2. After getting the max_kv_cache_token by warmup, we recreate a cache manager. But we enable the start_worker there, and start it again. So, disable the first start_worker.