### PR TITLE
Draft: NGRAM drafter for speculative decoding

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -285,6 +285,7 @@ def create_py_executor_instance(dist,
                                 ctx_chunk_config,
                                 model_engine,
                                 draft_model_engine,
+                                pld_pool,
                                 start_worker,
                                 lora_config: LoraConfig = None):
     spec_config = model_engine.spec_config
@@ -417,4 +418,5 @@ def create_py_executor_instance(dist,
                       if spec_config is not None else 0,
                       kv_cache_transceiver=kv_cache_transceiver,
                       draft_model_engine=draft_model_engine,
+                      pld_pool=pld_pool,
                       start_worker=start_worker)

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -42,6 +42,8 @@ from .resource_manager import (BaseResourceManager, KVCacheManager,
                                ResourceManager)
 from .scheduler import ScheduledRequests
 
+from pld_pool import PLDPool
+
 MAX_UINT64 = (1 << 64) - 1
 
 
@@ -213,6 +215,58 @@ def initialize_dummy_weights(
 
 KV_CACHE_MANAGER_KEY = 'kv_cache_manager'
 DRAFT_KV_CACHE_MANAGER_KEY = 'draft_kv_cache_manager'
+
+
+class NGRAMDrafterEngine(ModelEngine):
+    def __init__(
+        self,
+        batch_size: int = 8,
+        max_num_tokens: int = 8192,
+        max_seq_len: Optional[int] = None,
+        mapping: Optional[Mapping] = None,
+        spec_config: Optional[SpecConfig] = None,
+    ):
+        self.batch_size = batch_size
+        self.max_num_tokens = max_num_tokens
+        self.max_seq_len = max_seq_len
+        self.mapping = mapping
+        self.spec_config = spec_config
+
+        self.pld_pool = PLDPool(
+            input_batch_size = self.batch_size,
+            prompt_lookup_num_tokens = spec_config.prompt_lookup_num_tokens,
+            max_matching_ngram_size = spec_config.max_matching_ngram_size,
+            end_id = spec_config.end_id,
+            max_seq_len = spec_config.max_seq_len,
+            is_keep_all = spec_config.is_keep_all,
+            is_use_oldest = spec_config.is_use_oldest
+        )
+
+    def get_max_num_sequences(self) -> int:
+        """
+        Return the maximum number of sequences that the model supports. PyExecutor need this to compute max_num_active_requests
+        """
+        num_batches = self.mapping.pp_size if self.mapping.has_pp() else 1
+        return num_batches * self.batch_size
+
+    @torch.inference_mode()
+    @with_model_extra_attrs(lambda self: self.model.extra_attrs)
+    def forward(self,
+        scheduled_requests: ScheduledRequests,
+        resource_manager: ResourceManager,
+        new_tensors_device: Optional[Dict[str, torch.Tensor]] = None,
+        extra_model_inputs: Optional[Dict[str, Any]] = None,
+        is_dummy_forward: bool = False
+    ):
+        # loop over requests
+        #     find matching ngram using PLDPool
+        #     return matching ngram
+        prefix = []
+        batch_slot = []
+        for scheduled_request in scheduled_requests:
+            prefix.append(scheduled_request.prompt) # don't know if prompt is correct field
+            batch_slot.append(scheduled_request.batch_slot_id)
+        return get_draft_tokens(prefix, batch_slot)
 
 
 class PyTorchModelEngine(ModelEngine):

--- a/tensorrt_llm/_torch/pyexecutor/pld_pool.py
+++ b/tensorrt_llm/_torch/pyexecutor/pld_pool.py
@@ -1,0 +1,73 @@
+class PLDPool:  # Ngrams pool for Prompt-Lookup-Decoding
+
+    def __init__(
+        self,
+        input_batch_size: int,
+        prompt_lookup_num_tokens: int,
+        max_matching_ngram_size: int,
+        end_id: int,
+        max_seq_len: list[int],
+        is_keep_all: bool = True,
+        is_use_oldest: bool = True,
+    ):
+        self.input_batch_size = input_batch_size
+        self.plnt = prompt_lookup_num_tokens  # Shorter name
+        self.mmns = max_matching_ngram_size  # Shorter name
+        self.end_id = end_id
+        self.max_seq_len = max_seq_len
+        self.is_keep_all = is_keep_all
+        self.is_use_oldest = is_use_oldest
+        self.pool = [{} for _ in range(input_batch_size)]
+        self.start_index = [0 for _ in range(input_batch_size)]
+
+    # modified from `transformers/generation/candidate_generator.py`
+    def get_draft_tokens(self, prefix: list[torch.Tensor],
+                         batch_slot: list[int]):
+        batch_size = len(prefix)
+        prefix_len = [len(prefix[bi]) for bi in range(batch_size)]
+        draft_tokens = []  # `logits` is useless yet
+        for bi in range(batch_size):
+            gbi = batch_slot[bi]  # Global index in the input batch
+            chosen_ids = [self.end_id]
+            # Skip search if prefix is length of `max_length - 1`
+            if prefix_len[bi] >= self.max_seq_len[gbi] - 1:
+                draft_tokens.append(chosen_ids)
+                continue
+
+            # Update pool
+            sequence = prefix[bi][self.start_index[gbi]:] #.tolist()
+            for size in range(min(self.mmns, prefix_len[bi] - 1), 0, -1):
+                # Find each possible key-value combination, and use tuple for hash
+                for l in range(len(sequence) - size):
+                    r = min(l + size + self.plnt, len(sequence))
+                    key = tuple(sequence[l:l + size])
+                    value = tuple(sequence[l + size:r])
+                    if key not in self.pool[gbi] or not self.is_keep_all or \
+                        len(self.pool[gbi][key][0]) < self.plnt:
+                        # Update the value if
+                        # 1. the key does not exist
+                        # 2. we only keep one value for each key
+                        # 3. the length of the value saved before is less than `prompt_lookup_num_tokens`
+                        self.pool[gbi][key] = OrderedSet((value, ))
+                    elif value not in self.pool[gbi][key]:
+                        # Extend the value if the key is already existed and we want to keep all of them
+                        self.pool[gbi][key].add(value)
+
+            # Find match
+            for size in range(min(self.mmns, prefix_len[bi] - 1), 0, -1):
+                pattern = tuple(prefix[bi][-size:])
+                if pattern not in self.pool[gbi]:
+                    continue
+                if self.is_use_oldest:
+                    # Always choose the oldest match, aligned with HF
+                    chosen_ids = self.pool[gbi][pattern][0]
+                else:
+                    # Always choose the newest match
+                    chosen_ids = self.pool[gbi][pattern][-1]
+                break
+            draft_tokens.append(chosen_ids)
+            self.start_index[gbi] = max(
+                0, prefix_len[bi] - (self.plnt + self.mmns - 1))
+
+        return draft_tokens, None
+

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -58,7 +58,7 @@ def create_py_executor(executor_config: ExecutorConfig,
     dist = MPIDist(mapping=mapping)
 
     spec_config = executor_config.speculative_config
-    has_draft_model_engine = isinstance(spec_config, Eagle3Config) or isinstance(spec_config, NGRAMConfig)
+    has_draft_model_engine = isinstance(spec_config, Eagle3Config)
     attn_runtime_features = AttentionRuntimeFeatures(
         chunked_prefill=executor_config.enable_chunked_context,
         cache_reuse=executor_config.kv_cache_config.enable_block_reuse,
@@ -80,27 +80,18 @@ def create_py_executor(executor_config: ExecutorConfig,
 
     draft_model_engine = None
     if has_draft_model_engine:
-        if isinstance(spec_config, NGRAMConfig):
-            draft_model_engine = NGRAMDrafterEngine(
-                batch_size=executor_config.max_batch_size,
-                max_num_tokens=executor_config.max_num_tokens,
-                max_seq_len=executor_config.max_seq_len,
-                mapping=mapping,
-                spec_config=copy.copy(spec_config),
-            )
-        else:
-            draft_model_engine = PyTorchModelEngine(
-                spec_config.eagle_weights_path,
-                pytorch_backend_config,
-                batch_size=executor_config.max_batch_size,
-                max_num_tokens=executor_config.max_num_tokens,
-                max_seq_len=executor_config.max_seq_len,
-                mapping=mapping,
-                attn_runtime_features=attn_runtime_features,
-                dist=dist,
-                spec_config=copy.copy(spec_config),
-            )
-            draft_model_engine.kv_cache_manager_key = DRAFT_KV_CACHE_MANAGER_KEY
+        draft_model_engine = PyTorchModelEngine(
+            spec_config.eagle_weights_path,
+            pytorch_backend_config,
+            batch_size=executor_config.max_batch_size,
+            max_num_tokens=executor_config.max_num_tokens,
+            max_seq_len=executor_config.max_seq_len,
+            mapping=mapping,
+            attn_runtime_features=attn_runtime_features,
+            dist=dist,
+            spec_config=copy.copy(spec_config),
+        )
+        draft_model_engine.kv_cache_manager_key = DRAFT_KV_CACHE_MANAGER_KEY
 
     # PyTorchModelEngine modifies these fields, update them to executor_config
     max_seq_len = model_engine.max_seq_len
@@ -113,6 +104,18 @@ def create_py_executor(executor_config: ExecutorConfig,
     if spec_config is not None:
         max_seq_len += spec_config.num_extra_kv_tokens
         max_seq_len += spec_config.max_draft_tokens
+
+    pld_pool = None
+    if isinstance(spec_config, NGRAMConfig):
+        pld_pool = PLDPool(
+            input_batch_size=executor_config.max_batch_size,
+            prompt_lookup_num_tokens=spec_config.prompt_lookup_num_tokens,
+            max_matching_ngram_size=spec_config.max_matching_ngram_size,
+            end_id=???,
+            max_seq_len=max_seq_len,
+            is_keep_all=spec_config.is_keep_all,
+            is_use_oldest=spec_config.is_use_oldest,
+        )
 
     executor_config.max_seq_len = max_seq_len
     executor_config.max_num_tokens = model_engine.max_num_tokens
@@ -164,7 +167,7 @@ def create_py_executor(executor_config: ExecutorConfig,
                                               pytorch_backend_config,
                                               executor_config, ctx_chunk_config,
                                               model_engine, draft_model_engine,
-                                              False, lora_config)
+                                              pld_pool, False, lora_config)
 
     if executor_config.pytorch_backend_config.use_kv_cache and 'cp_type' not in mapping.cp_config:
         kv_cache_max_tokens = estimate_max_kv_cache_tokens(
@@ -195,7 +198,7 @@ def create_py_executor(executor_config: ExecutorConfig,
             py_executor = create_py_executor_instance(
                 dist, kv_cache_manager, draft_kv_cache_manager, mapping,
                 pytorch_backend_config, executor_config, ctx_chunk_config,
-                model_engine, draft_model_engine, True, lora_config)
+                model_engine, draft_model_engine, pld_pool, True, lora_config)
 
     py_executor.start_worker()
     return py_executor

--- a/tensorrt_llm/_torch/speculative/__init__.py
+++ b/tensorrt_llm/_torch/speculative/__init__.py
@@ -1,6 +1,7 @@
 from .eagle3 import Eagle3Config, Eagle3SpecMetadata
 from .interface import SpecConfig, SpecMetadata
 from .mtp import MTPConfig, MTPEagleWorker, MTPSpecMetadata, MTPWorker
+from .ngram import NGRAMConfig, NGRAMSpecMetadata
 from .utils import (get_num_spec_layers, get_spec_decoder, get_spec_metadata,
                     get_spec_resource_manager)
 
@@ -8,5 +9,5 @@ __all__ = [
     "SpecConfig", "SpecMetadata", "MTPConfig", "MTPWorker", "MTPEagleWorker",
     "Eagle3Config", "Eagle3SpecMetadata", "MTPSpecMetadata",
     "get_spec_metadata", "get_spec_resource_manager", "get_spec_decoder",
-    "get_num_spec_layers"
+    "get_num_spec_layers", "NGRAMConfig", "NGRAMSpecMetadata"
 ]

--- a/tensorrt_llm/_torch/speculative/interface.py
+++ b/tensorrt_llm/_torch/speculative/interface.py
@@ -13,6 +13,7 @@ class SpeculativeDecodingMode(IntEnum):
     MTP = auto()
     MTP_EAGLE = auto()
     EAGLE3 = auto()
+    NGRAM = auto()
     NONE = auto()
 
     def is_mtp(self):
@@ -23,6 +24,9 @@ class SpeculativeDecodingMode(IntEnum):
 
     def is_eagle3(self):
         return self == SpeculativeDecodingMode.EAGLE3
+
+    def is_ngram(self):
+        return self == SpeculativeDecodingMode.NGRAM
 
     def is_none(self):
         return self == SpeculativeDecodingMode.NONE

--- a/tensorrt_llm/_torch/speculative/ngram.py
+++ b/tensorrt_llm/_torch/speculative/ngram.py
@@ -1,0 +1,61 @@
+from dataclasses import dataclass, field
+from itertools import chain
+from typing import Dict, List, Optional, Tuple
+
+import torch
+
+from ..pyexecutor.decoder import DecoderState, TorchDecoder
+from .interface import SpecConfig, SpecMetadata, SpeculativeDecodingMode
+
+
+@dataclass
+class NGRAMConfig(SpecConfig):
+    spec_dec_name: str = "NGRAM"
+
+    def __post_init__(self):
+        self.spec_dec_mode = SpeculativeDecodingMode.from_string(
+            self.spec_dec_name)
+
+    def update_from_model_config(self, model_config):
+        pass
+
+
+@dataclass
+class NGRAMSpecMetadata(SpecMetadata):
+    max_draft_tokens: int = 1024
+    prompt_lookup_num_tokens: int = 10
+    end_id: int = -1
+    is_keep_all: bool = True
+    is_use_oldest: bool = True
+
+    def __post_init__(self):
+        pass
+
+    def prepare(self):
+        pass
+
+    def maybe_capture_hidden_states(self, layer_id: int,
+                                    hidden_states: torch.Tensor,
+                                    residual: torch.Tensor) -> None:
+        pass
+
+
+class NGRAMDecoder(TorchDecoder):
+
+    def _batch_decode(self, scheduled_requests, model_outputs):
+        # Is it needed?
+        logits = model_outputs["logits"]
+        new_tokens_device = torch.argmax(logits, dim=-1)
+        if "d2t" in model_outputs:
+            d2t = model_outputs["d2t"]
+            new_tokens_device = d2t[new_tokens_device] + new_tokens_device
+        new_tokens_host = new_tokens_device.to('cpu', non_blocking=True)
+        new_tensors_device = {"new_tokens_device": new_tokens_device}
+        new_tensors_host = {"new_tokens_host": new_tokens_host}
+        decoder_event = torch.cuda.Event()
+        decoder_event.record()
+        return DecoderState(scheduled_requests=scheduled_requests,
+                            logits=logits,
+                            new_tensors_device=new_tensors_device,
+                            new_tensors_host=new_tensors_host,
+                            decoder_event=decoder_event)

--- a/tensorrt_llm/_torch/speculative/ngram.py
+++ b/tensorrt_llm/_torch/speculative/ngram.py
@@ -11,6 +11,13 @@ from .interface import SpecConfig, SpecMetadata, SpeculativeDecodingMode
 @dataclass
 class NGRAMConfig(SpecConfig):
     spec_dec_name: str = "NGRAM"
+    prompt_lookup_num_tokens: int = 5
+    max_matching_ngram_size: int = 5
+    max_draft_len: int = 1024
+    prompt_lookup_num_tokens: int = 10
+    end_id: int = -1
+    is_keep_all: bool = True
+    is_use_oldest: bool = True
 
     def __post_init__(self):
         self.spec_dec_mode = SpeculativeDecodingMode.from_string(
@@ -24,6 +31,7 @@ class NGRAMConfig(SpecConfig):
 class NGRAMSpecMetadata(SpecMetadata):
     max_draft_tokens: int = 1024
     prompt_lookup_num_tokens: int = 10
+    max_matching_ngram_size: int = 5
     end_id: int = -1
     is_keep_all: bool = True
     is_use_oldest: bool = True

--- a/tensorrt_llm/_torch/speculative/utils.py
+++ b/tensorrt_llm/_torch/speculative/utils.py
@@ -20,8 +20,8 @@ def get_spec_metadata(spec_config,
                                   num_layers=spec_config.num_layers)
     elif spec_config.spec_dec_mode.is_ngram():
         return NGRAMSpecMetaData(max_draft_tokens=spec_config.max_draft_tokens,
+                                 spec_dec_mode=spec_config.spec_dec_mode,
                                  prompt_lookup_num_tokens=spec_config.prompt_lookup_num_tokens,
-                                 end_id=spec_config.end_id,
                                  is_keep_all=spec_config.is_keep_all,
                                  is_use_oldest=spec_config.is_use_oldest)
     else:

--- a/tensorrt_llm/_torch/speculative/utils.py
+++ b/tensorrt_llm/_torch/speculative/utils.py
@@ -1,5 +1,6 @@
 from .eagle3 import Eagle3Decoder, Eagle3SpecMetadata
 from .mtp import MTPDecoder, MTPHiddenStatesManager, MTPSpecMetadata
+from .ngram import NGRAMDrafter, NGRAMSpecMetaData
 
 
 def get_spec_metadata(spec_config,
@@ -17,6 +18,12 @@ def get_spec_metadata(spec_config,
                                   spec_dec_mode=spec_config.spec_dec_mode,
                                   max_num_requests=max_num_requests,
                                   num_layers=spec_config.num_layers)
+    elif spec_config.spec_dec_mode.is_ngram():
+        return NGRAMSpecMetaData(max_draft_tokens=spec_config.max_draft_tokens,
+                                 prompt_lookup_num_tokens=spec_config.prompt_lookup_num_tokens,
+                                 end_id=spec_config.end_id,
+                                 is_keep_all=spec_config.is_keep_all,
+                                 is_use_oldest=spec_config.is_use_oldest)
     else:
         return None
 
@@ -28,6 +35,8 @@ def get_spec_resource_manager(spec_config, model_config, max_num_requests):
         return MTPHiddenStatesManager(spec_config, model_config.torch_dtype,
                                       model_config.hidden_size,
                                       max_num_requests)
+    elif spec_config.spec_dec_mode.is_ngram():
+        return None
     else:
         return None
 
@@ -37,6 +46,8 @@ def get_spec_decoder(max_seq_len, spec_config):
         return MTPDecoder(max_seq_len, spec_config)
     if spec_config.spec_dec_mode.is_eagle3():
         return Eagle3Decoder(max_seq_len)
+    if spec_config.spec_dec_mode.is_ngram():
+        return NGRAMDrafter(max_seq_len, spec_config)
     else:
         return None
 


### PR DESCRIPTION
This MR adds an ngram drafter for use with speculative decoding pytorch API. The feature is enabled by adding a NGRAMDrafterConfig object as spec_config argument when creating LLM object.