### PR TITLE
[fix] Fix a few issues with EAGLE3 in PyTorch backend

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/flashinfer.py
+++ b/tensorrt_llm/_torch/attention_backend/flashinfer.py
@@ -122,7 +122,10 @@ class FlashInferAttentionMetadata(AttentionMetadata):
         super().__post_init__()
 
         if self.workspace_buffer is None:
-            self.workspace_buffer = torch.empty(256 * 1024 * 1024,
+            # Note: even though flashinfer only recommends 128 MB, we have to push it
+            # a bit higher to cover all possible CUDA graph cases. If it's too small,
+            # warmup will crash.
+            self.workspace_buffer = torch.empty(320 * 1024 * 1024,
                                                 dtype=torch.uint8,
                                                 device="cuda")
 
@@ -246,12 +249,11 @@ class FlashInferAttentionMetadata(AttentionMetadata):
                                                                paged_kv_indptr_decode
                                                                .size(0)]
         elif self.num_generations == 0:
-            assert not self.is_cuda_graph
             self.paged_kv_indptr = self.paged_kv_indptr_prefill[:
                                                                 paged_kv_indptr_prefill
                                                                 .size(0)]
         else:
-            assert not self.is_cuda_graph
+            assert not self.is_cuda_graph, "Cannot mix decode/prefill with CUDA graphs"
             self.paged_kv_indptr = torch.cumsum(
                 torch.tensor([0] + self.num_blocks, dtype=torch.int32),
                 dtype=torch.int32,
@@ -313,21 +315,24 @@ class FlashInferAttentionMetadata(AttentionMetadata):
                 "Make sure you run a few warmup runs before capturing the graph!"
             )
 
-        if not self.is_cuda_graph:
-            if plan_params in self._plan_params_to_wrappers:
-                prefill_wrapper = self._plan_params_to_wrappers[
-                    plan_params].prefill_wrapper
-            else:
-                # flashinfer fa3 backend has accuracy issue in H100 PCIe
-                prefill_wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
-                    self.workspace_buffer, self.kv_layout, backend='fa2')
+        if plan_params in self._plan_params_to_wrappers:
+            prefill_wrapper = self._plan_params_to_wrappers[
+                plan_params].prefill_wrapper
         else:
-            prefill_wrapper = None
+            # flashinfer fa3 backend has accuracy issue in H100 PCIe
+            prefill_wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+                self.workspace_buffer,
+                self.kv_layout,
+                backend='fa2',
+                qo_indptr_buf=self.qo_indptr,
+                paged_kv_indptr_buf=self.paged_kv_indptr_prefill,
+                paged_kv_indices_buf=self._paged_kv_indices,
+                paged_kv_last_page_len_buf=self._paged_kv_last_page_len,
+                use_cuda_graph=self.is_cuda_graph)
 
         is_causal = plan_params.attention_mask_type == AttentionMaskType.causal
 
         def prefill_plan():
-            assert prefill_wrapper is not None, "Prefill not supported w/ CUDA graphs"
             prefill_wrapper.plan(
                 self.qo_indptr[:self.num_contexts + 1],
                 self.paged_kv_indptr_prefill[:self.num_contexts + 1],

--- a/tensorrt_llm/_torch/models/modeling_llama.py
+++ b/tensorrt_llm/_torch/models/modeling_llama.py
@@ -469,6 +469,10 @@ class Llama4DecoderLayer(DecoderLayer):
             min_latency_mode=min_latency_mode,
         )
         if spec_metadata is not None:
+            # We save the hidden states in the spec metadata here. In _prepare_draft_tokens,
+            # PyExecutor will extract these from the model engine's spec metadata.
+            # They will be passed to the draft model engine on the first draft iteration.
+            # TODO: can we support multiple model outputs instead?
             spec_metadata.maybe_capture_hidden_states(self.layer_idx,
                                                       hidden_states, residual)
 
@@ -567,6 +571,10 @@ class LlamaDecoderLayer(DecoderLayer):
             hidden_states, residual)
         hidden_states = self.mlp(hidden_states, **kwargs)
         if spec_metadata is not None:
+            # We save the hidden states in the spec metadata here. In _prepare_draft_tokens,
+            # PyExecutor will extract these from the model engine's spec metadata.
+            # They will be passed to the draft model engine on the first draft iteration.
+            # TODO: can we support multiple model outputs instead?
             spec_metadata.maybe_capture_hidden_states(self.layer_idx,
                                                       hidden_states, residual)
         return hidden_states, residual
@@ -644,6 +652,7 @@ class Eagle3LlamaDecoderLayer(DecoderLayer):
         embeds: torch.Tensor,
         hidden_states: torch.Tensor,
         attn_metadata: AttentionMetadata,
+        spec_metadata: SpecMetadata,
     ) -> torch.Tensor:
         residual = hidden_states
 
@@ -661,6 +670,15 @@ class Eagle3LlamaDecoderLayer(DecoderLayer):
         hidden_states, residual = self.post_attention_layernorm(
             hidden_states, residual)
         hidden_states = self.mlp(hidden_states)
+
+        assert isinstance(spec_metadata, Eagle3SpecMetadata)
+        # We save the hidden states in the spec metadata here. In _prepare_draft_tokens,
+        # PyExecutor will extract these from the draft model engine's spec metadata.
+        # They will be passed to the draft model engine on the next iteration.
+        # TODO: can we support multiple model outputs instead?
+        spec_metadata.maybe_capture_hidden_states(self.layer_idx, hidden_states,
+                                                  residual)
+
         return hidden_states, residual
 
 
@@ -1049,12 +1067,10 @@ class Eagle3LlamaDraftModel(DecoderModel):
         hidden_states, residual = self.midlayer(position_ids=position_ids,
                                                 embeds=inputs_embeds,
                                                 hidden_states=hidden_states,
-                                                attn_metadata=attn_metadata)
+                                                attn_metadata=attn_metadata,
+                                                spec_metadata=spec_metadata)
 
-        hidden_states, hidden_states_to_save = self.norm(
-            hidden_states, residual)
-        assert isinstance(spec_metadata, Eagle3SpecMetadata)
-        spec_metadata.maybe_capture_hidden_states(1, hidden_states_to_save)
+        hidden_states, _ = self.norm(hidden_states, residual)
         return hidden_states
 
 

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -415,10 +415,11 @@ class PyTorchModelEngine(ModelEngine):
                 token_num = max(
                     1,
                     min(
-                        available_tokens, kv_cache_manager.max_seq_len -
+                        available_tokens, self.max_seq_len -
                         kv_cache_manager.num_extra_kv_tokens - 1 -
                         max_num_draft_tokens),
                 )
+
                 # Add one dummy request with the maximum possible sequence length.
                 # The sequence length is limited by both the max_seq_len and the number of available blocks.
                 max_seq_len_request = kv_cache_manager.add_dummy_requests(
@@ -545,8 +546,8 @@ class PyTorchModelEngine(ModelEngine):
 
         if self.pytorch_backend_config.autotuner_enabled:
             with no_cuda_graph(), autotune():
-                num_tokens_per_request = min(self.max_num_tokens,
-                                             kv_cache_manager.max_seq_len - 1)
+                num_tokens_per_request = min(self.max_seq_len - 1,
+                                             self.max_num_tokens)
                 with release_batch(
                         get_torch_compile_warmup_request(
                             1, num_tokens_per_request)) as batch:

--- a/tests/unittest/_torch/speculative/test_eagle3.py
+++ b/tests/unittest/_torch/speculative/test_eagle3.py
@@ -14,9 +14,10 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from utils.llm_data import llm_models_root
 
 
-@pytest.mark.parametrize("use_cuda_graph", [True, False],
-                         ids=["enable_graphs", "disable_graphs"])
-def test_llama_eagle3(use_cuda_graph: bool):
+@pytest.mark.parametrize("use_cuda_graph,attn_backend",
+                         [[True, "TRTLLM"], [False, "TRTLLM"],
+                          [True, "FLASHINFER"], [False, "FLASHINFER"]])
+def test_llama_eagle3(use_cuda_graph: bool, attn_backend: str):
     total_mem_gb = torch.cuda.get_device_properties(0).total_memory / 1e9
     if total_mem_gb < 35:
         pytest.skip("Not enough memory to load target + draft model")
@@ -27,6 +28,7 @@ def test_llama_eagle3(use_cuda_graph: bool):
         enable_overlap_scheduler=False,
         use_cuda_graph=use_cuda_graph,
         # Only create a single CUDA graph to prevent OOM in CI
+        attn_backend=attn_backend,
         cuda_graph_batch_sizes=[1],
     )
 


### PR DESCRIPTION
* Add a few more explanatory comments
* Clean up draft model hidden state saving logic. 
* Add eagle3 support to flashinfer (includes CUDA graph support). Flashinfer is still useful for debugging; it helped me identify some issues in the warmup phase.
* Fix an illegal memory access related to maximum sequence length in warmup phase. This currently does not cause crashes on the TRTLLM attention path (but it's still UB!)