### PR TITLE
Fix create_weights in attention

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/flashinfer.py
+++ b/tensorrt_llm/_torch/attention_backend/flashinfer.py
@@ -406,14 +406,20 @@ class FlashInferAttention(AttentionBackend[FlashInferAttentionMetadata]):
         head_dim: int,
         num_kv_heads: Optional[int] = None,
         quant_config: Optional[QuantConfig] = None,
+        skip_create_weights_in_init: bool = False,
         **kwargs,
     ):
         super().__init__(layer_idx, num_heads, head_dim, num_kv_heads,
                          quant_config, **kwargs)
+        if not skip_create_weights_in_init:
+            self.update_quant_config(self.quant_config)
 
+    def update_quant_config(self, new_quant_config: Optional[QuantConfig]):
+        self.quant_config = new_quant_config
         self.has_fp8_kv_cache = False
-        if quant_config and quant_config.layer_quant_mode.has_any_quant():
-            quant_mode = quant_config.layer_quant_mode
+        if self.quant_config and self.quant_config.layer_quant_mode.has_any_quant(
+        ):
+            quant_mode = self.quant_config.layer_quant_mode
             if quant_mode.has_fp8_kv_cache():
                 self.has_fp8_kv_cache = True
 

--- a/tensorrt_llm/_torch/attention_backend/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/interface.py
@@ -495,6 +495,7 @@ class AttentionBackend(Generic[TMetadata]):
         head_dim: int,
         num_kv_heads: Optional[int] = None,
         quant_config: Optional[QuantConfig] = None,
+        skip_create_weights_in_init: bool = False,
         **kwargs,
     ):
         """
@@ -511,6 +512,14 @@ class AttentionBackend(Generic[TMetadata]):
         self.head_dim = head_dim
         self.num_kv_heads = num_kv_heads or self.num_heads
         self.quant_config = quant_config
+
+    def update_quant_config(self, new_quant_config: Optional[QuantConfig]):
+        """
+        To support mixed quantization mode, self.quant_config can be modified after __init__ is called.
+        Any states or set up related to self.quant_config must be moved to this function, which is called
+        after self.quant_config is reset.
+        """
+        self.quant_config = new_quant_config
 
     def forward(self,
                 q: torch.Tensor,

--- a/tensorrt_llm/_torch/attention_backend/utils.py
+++ b/tensorrt_llm/_torch/attention_backend/utils.py
@@ -40,6 +40,7 @@ def create_attention(
     qk_nope_head_dim: Optional[int] = None,
     v_head_dim: Optional[int] = None,
     predicted_tokens_per_seq: Optional[int] = 1,
+    skip_create_weights_in_init: bool = False,
 ):
 
     attn_cls = get_attention_backend(backend_name)
@@ -69,4 +70,5 @@ def create_attention(
         q_scaling=q_scaling,
         pos_embd_params=pos_embd_params,
         mla_params=mla_params,
+        skip_create_weights_in_init=skip_create_weights_in_init,
     )

--- a/tensorrt_llm/_torch/models/modeling_auto.py
+++ b/tensorrt_llm/_torch/models/modeling_auto.py
@@ -25,7 +25,7 @@ class AutoModelForCausalLM(Generic[TModel, TConfig]):
                 f"Unknown architecture for AutoModelForCausalLM: {config.pretrained_config.architectures[0]}"
             )
         if issubclass(cls, DecoderModelForCausalLM):
-            config.skip_create_weights = True
+            config.skip_create_weights_in_init = True
         extra_attrs = {}
         with model_extra_attrs(extra_attrs):
             model = cls(config)

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -831,7 +831,8 @@ class DeepseekV3MTP(DeepseekV3DecoderLayer):
             config.hidden_size,
             bias=False,
             dtype=config.torch_dtype,
-            skip_create_weights=model_config.skip_create_weights,
+            skip_create_weights_in_init=model_config.
+            skip_create_weights_in_init,
         )
 
         self.shared_head = DeepseekV3MTPHead(model_config)

--- a/tensorrt_llm/_torch/models/modeling_llama.py
+++ b/tensorrt_llm/_torch/models/modeling_llama.py
@@ -590,7 +590,8 @@ class Eagle3LlamaAttention(LlamaAttention):
             weights_loading_config=WeightsLoadingConfig(
                 weight_mode=WeightMode.FUSED_QKV_LINEAR),
             quant_config=model_config.get_quant_config(),
-            skip_create_weights=model_config.skip_create_weights,
+            skip_create_weights_in_init=model_config.
+            skip_create_weights_in_init,
         )
 
 

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nas.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nas.py
@@ -41,7 +41,7 @@ def _create_linear_from_configs(model_config: ModelConfig[PretrainedConfig],
         tensor_parallel_mode=TensorParallelMode.COLUMN,
         gather_output=True,
         quant_config=model_config.get_quant_config(),
-        skip_create_weights=model_config.skip_create_weights,
+        skip_create_weights_in_init=model_config.skip_create_weights_in_init,
     )
 
 

--- a/tensorrt_llm/_torch/modules/fused_moe.py
+++ b/tensorrt_llm/_torch/modules/fused_moe.py
@@ -307,7 +307,7 @@ class FusedMoE(nn.Module):
         self.has_been_profiled_min_latency = False
 
         self._weights_created = False
-        if not model_config.skip_create_weights:
+        if not model_config.skip_create_weights_in_init:
             self.create_weights()
 
         # If True, the router weight will be multiplied on the input rather than at the end of FC2

--- a/tensorrt_llm/_torch/modules/gated_mlp.py
+++ b/tensorrt_llm/_torch/modules/gated_mlp.py
@@ -74,7 +74,7 @@ class GatedMLP(nn.Module):
                 weight_mode=WeightMode.FUSED_GATE_UP_LINEAR),
             quant_config=config.get_quant_config(),
             reduce_output=False,
-            skip_create_weights=config.skip_create_weights,
+            skip_create_weights_in_init=config.skip_create_weights_in_init,
         )
         self.down_proj = Linear(
             self.intermediate_size,
@@ -85,7 +85,7 @@ class GatedMLP(nn.Module):
             tensor_parallel_mode=TensorParallelMode.ROW,
             quant_config=config.get_quant_config(),
             reduce_output=reduce_output,
-            skip_create_weights=config.skip_create_weights,
+            skip_create_weights_in_init=config.skip_create_weights_in_init,
         )
 
         # These two modules are mutually exclusive - either splitted_gate_up_lora or fused_gate_up_lora will be used,

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -155,7 +155,7 @@ class Linear(nn.Module):
         quant_config: Optional[QuantConfig] = None,
         weights_loading_config: Optional[WeightsLoadingConfig] = None,
         reduce_output: bool = True,  # ROW parallel only
-        skip_create_weights: bool = False,
+        skip_create_weights_in_init: bool = False,
         use_custom_cublas_mm: bool = False,
     ):
         from ..distributed import AllReduce
@@ -198,7 +198,7 @@ class Linear(nn.Module):
         self.reduce_output = reduce_output
         self.use_custom_cublas_mm = use_custom_cublas_mm
 
-        if not skip_create_weights:
+        if not skip_create_weights_in_init:
             self.create_weights()
 
     def create_weights(self):

--- a/tensorrt_llm/_torch/modules/mamba/mixer.py
+++ b/tensorrt_llm/_torch/modules/mamba/mixer.py
@@ -93,7 +93,7 @@ class MambaMixer(nn.Module):
             mapping=self.mapping,
             tensor_parallel_mode=TensorParallelMode.COLUMN,
             quant_config=config.get_quant_config(),
-            skip_create_weights=config.skip_create_weights,
+            skip_create_weights_in_init=config.skip_create_weights_in_init,
         )
 
         # A

--- a/tensorrt_llm/_torch/modules/mlp.py
+++ b/tensorrt_llm/_torch/modules/mlp.py
@@ -28,25 +28,27 @@ class MLP(nn.Module):
         self.activation = activation
 
         config = config or ModelConfig()
-        self.up_proj = Linear(self.hidden_size,
-                              self.intermediate_size,
-                              bias=bias,
-                              dtype=dtype,
-                              mapping=config.mapping,
-                              tensor_parallel_mode=TensorParallelMode.COLUMN,
-                              weights_loading_config=WeightsLoadingConfig(
-                                  weight_mode=WeightMode.VANILLA),
-                              quant_config=config.get_quant_config(),
-                              skip_create_weights=config.skip_create_weights)
+        self.up_proj = Linear(
+            self.hidden_size,
+            self.intermediate_size,
+            bias=bias,
+            dtype=dtype,
+            mapping=config.mapping,
+            tensor_parallel_mode=TensorParallelMode.COLUMN,
+            weights_loading_config=WeightsLoadingConfig(
+                weight_mode=WeightMode.VANILLA),
+            quant_config=config.get_quant_config(),
+            skip_create_weights_in_init=config.skip_create_weights_in_init)
 
-        self.down_proj = Linear(self.intermediate_size,
-                                self.hidden_size,
-                                bias=bias,
-                                dtype=dtype,
-                                mapping=config.mapping,
-                                tensor_parallel_mode=TensorParallelMode.ROW,
-                                quant_config=config.get_quant_config(),
-                                skip_create_weights=config.skip_create_weights)
+        self.down_proj = Linear(
+            self.intermediate_size,
+            self.hidden_size,
+            bias=bias,
+            dtype=dtype,
+            mapping=config.mapping,
+            tensor_parallel_mode=TensorParallelMode.ROW,
+            quant_config=config.get_quant_config(),
+            skip_create_weights_in_init=config.skip_create_weights_in_init)
 
         self.up_lora = LoraLayer([LoraModuleType.MLP_H_TO_4H],
                                  [self.intermediate_size])


### PR DESCRIPTION
Previously, `Attention.create_weights` had to recreate the Attention op when quant_config changes. This is due to some quant states that the attention op sets up in `TrtllmAttention.__init__`. The solution is to move to the quant related changes to another function that can be called in `Attention.create_weights`. 

Separately, config `skip_create_weights` is renamed to `skip_create_weights_in_init` to make it more explicit. 
Also fixed a bug in `MLA` that's related to `MLA.create_weights`. The fp8 related tensors creation code needs to be moved to inside `MLA.create_weights`.