### PR TITLE
Fix TLLM_CHECK(isLeaf()); assertion

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/evictionPolicy.h
+++ b/cpp/include/tensorrt_llm/batch_manager/evictionPolicy.h
@@ -37,6 +37,9 @@ public:
         std::optional<executor::RetentionPriority> secondaryOffloadMinPriority)
         = 0;
 
+    /// @brief After changing the reuse tree we have to update the internal state because the block may no longer be a leaf.
+    virtual void processAddChild(BlockPtr block) = 0;
+
     /// @brief Get a free block from the specified cache level
     /// @returns The pointer to the free block, along with whether it can be offloaded
     virtual std::tuple<BlockPtr, bool> getFreeBlock(SizeType32 cacheLevel) = 0;
@@ -91,10 +94,8 @@ public:
 
     bool verifyQueueIntegrity() override;
 
+    void processAddChild(BlockPtr block) override;
 private:
-    // Check if the block should be added to mFreeQueues.
-    bool isReleasedLeafBlock(BlockPtr const& block);
-
     // Queues of available leaf blocks, split by cache level and priority level
     std::vector<std::vector<FreeBlocksQueue>> mFreeQueues;
     // All blocks that have been released, along with the amount of released children

--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -290,9 +290,6 @@ private:
     // Next block(s) in sequence(s)
     NextBlockMap mNextBlocks;
 
-    // Iterator pointing to this block in mFreeBlocks.
-    std::optional<FreeBlocksQueue::iterator> mFreeBlockIterator;
-
     // Flag indicating if block is full
     bool mIsFull;
 


### PR DESCRIPTION
When stress testing I get the error [TLLM_CHECK(isLeaf());](https://github.com/NVIDIA/TensorRT-LLM/blob/c2ffce7dbd283000255948ae04792f13f13e05dc/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp#L301)

Version is https://github.com/NVIDIA/TensorRT-LLM/tree/c2ffce7dbd283000255948ae04792f13f13e05dc

After studying, I realized that sometimes the LRUEvictionPolicy tree violates invariants about leaf nodes in mFreeQueues.

Solution works fine for me.

NOTE: I have not tested offloading to a secondary pool as I don't use such a feature in prod.


