### PR TITLE
datasets API change : datasets.load_metric => evaluate.load

### DIFF
--- a/examples/models/core/llama/summarize_long.py
+++ b/examples/models/core/llama/summarize_long.py
@@ -17,7 +17,8 @@ import json
 import os
 
 import torch
-from datasets import load_dataset, load_metric
+from datasets import load_dataset
+from evaluate import load
 from transformers import AutoModelForCausalLM, LlamaTokenizer
 
 import tensorrt_llm
@@ -378,9 +379,7 @@ def main(args):
 
         rouge_dir = args.rouge_dir if args.rouge_dir and os.path.exists(
             args.rouge_dir) else "rouge"
-        metric_tensorrt_llm = [
-            load_metric(rouge_dir) for _ in range(args.num_beams)
-        ]
+        metric_tensorrt_llm = [load(rouge_dir) for _ in range(args.num_beams)]
 
         for i in range(args.num_beams):
             metric_tensorrt_llm[i].seed = 0


### PR DESCRIPTION
In datasets>=3.0.0 , `load_metric()` was removed.
Only found once instance of `load_metric()` usage.