### PR TITLE
fix: Fix CUDA graphs when tp_size > 1

### DIFF
--- a/tensorrt_llm/_utils.py
+++ b/tensorrt_llm/_utils.py
@@ -538,6 +538,12 @@ def mpi_recv(buf, source, tag):
     return None
 
 
+def mpi_allreduce(obj, op: MPI.Op):
+    if ENABLE_MULTI_DEVICE:
+        return mpi_comm().allreduce(obj, op)
+    return None
+
+
 def pad_vocab_size(vocab_size, tp_size):
     return int(math.ceil(vocab_size / tp_size) * tp_size)
 

--- a/tests/unittest/_torch/multi_gpu_modeling/test_llama4.py
+++ b/tests/unittest/_torch/multi_gpu_modeling/test_llama4.py
@@ -16,7 +16,9 @@ from tensorrt_llm._torch.pyexecutor.config import PyTorchConfig
 @pytest.mark.parametrize("backend", ["TRTLLM", "FLASHINFER"],
                          ids=["trtllm", "flashinfer"])
 @pytest.mark.parametrize("tp_size", [8], ids=["tp8"])
-def test_llama4(model_name, backend, tp_size):
+@pytest.mark.parametrize("use_cuda_graph", [True, False],
+                         ids=["enable_graph", "disable_graph"])
+def test_llama4(model_name, backend, tp_size, use_cuda_graph):
     prompts = [
         "The president of the United States is",
     ]
@@ -25,7 +27,8 @@ def test_llama4(model_name, backend, tp_size):
         " the head of state and head of government of the",
     ]
 
-    pytorch_config = PyTorchConfig(attn_backend=backend, )
+    pytorch_config = PyTorchConfig(attn_backend=backend,
+                                   use_cuda_graph=use_cuda_graph)
     model_dir = str(llm_models_root() / "llama4-models" / model_name)
 
     llm = LLM(


### PR DESCRIPTION
If the different ranks come up with different KV cache token estimates, you can get illegal memory accesses during the warm up stage. Fix by doing an MPI allreduce.

Also add CUDA graph to llama4 test case to cover this. This seems to only happen to llama4 for some reason.