### PR TITLE
chore: Move opencv-python import inside load_video() function

### DIFF
--- a/tensorrt_llm/inputs/utils.py
+++ b/tensorrt_llm/inputs/utils.py
@@ -1,6 +1,5 @@
 from typing import List, Union
 
-import cv2
 import numpy as np
 import requests
 import torch
@@ -30,6 +29,8 @@ def load_video(
         num_frames: int = 10,
         format: str = "pt",
         device: str = "cuda") -> Union[List[Image.Image], List[torch.Tensor]]:
+    import cv2
+
     assert format in ["pt", "pil"], "format must be either Pytorch or PIL"
 
     # Load video frames from a video file


### PR DESCRIPTION
This pull request implements a small change to render the `opencv-python` package effectively optional. 

This is, in fact, used only in `inputs/utils.py`, and moving the `cv2` import inside of the `load_video()` function is enough to hide the dependency, if video handling is not needed. As we employ TRT-LLM exclusively for text-based use cases, this allows us to save a little bit of storage for our images.