### PR TITLE
Fixing the metric fmeasure access

### DIFF
--- a/examples/models/core/llama/summarize_long.py
+++ b/examples/models/core/llama/summarize_long.py
@@ -397,12 +397,11 @@ def main(args):
                 beam_idx].compute()
             for key in computed_metrics_tensorrt_llm.keys():
                 logger.info(
-                    f'  {key} : {computed_metrics_tensorrt_llm[key].mid[2]*100}'
-                )
+                    f'  {key} : {computed_metrics_tensorrt_llm[key]*100}')
 
             if args.check_accuracy and beam_idx == 0:
-                assert computed_metrics_tensorrt_llm['rouge1'].mid[
-                    2] * 100 > args.tensorrt_llm_rouge1_threshold
+                assert computed_metrics_tensorrt_llm[
+                    'rouge1'] * 100 > args.tensorrt_llm_rouge1_threshold
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
evaluate's metric doesn't return low/mid/high scores like datasets's metric did.
It only returns `mid`'s `fmeasure` i.e. `mid[2]`. 