### PR TITLE
fix: Update num_of_ctx_tokens in iteration stats

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -5,9 +5,9 @@ from collections.abc import Iterable
 import torch
 
 import tensorrt_llm
-import tensorrt_llm.bindings.executor as trtllm
 from tensorrt_llm._utils import (mpi_broadcast, str_dtype_to_binding,
                                  torch_dtype_to_str)
+from tensorrt_llm.bindings import executor as trtllm
 from tensorrt_llm.bindings.executor import DecodingMode, ExecutorConfig
 from tensorrt_llm.logger import logger
 from tensorrt_llm.lora_manager import LoraConfig, load_torch_hf_lora

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -5,9 +5,9 @@ from collections.abc import Iterable
 import torch
 
 import tensorrt_llm
+import tensorrt_llm.bindings.executor as trtllm
 from tensorrt_llm._utils import (mpi_broadcast, str_dtype_to_binding,
                                  torch_dtype_to_str)
-from tensorrt_llm.bindings import executor as trtllm
 from tensorrt_llm.bindings.executor import DecodingMode, ExecutorConfig
 from tensorrt_llm.logger import logger
 from tensorrt_llm.lora_manager import LoraConfig, load_torch_hf_lora


### PR DESCRIPTION
[TRTLLM-4728]Update num_of_ctx_tokens in iteration stats

update number of context tokens directly into iteration stats after engine forward to avoid iteration mismatch in overlap scheduling scenario/

## Test Coverage

test stage A100X-TensorRT-1 shall pass.
