### PR TITLE
feat: add Pytorch support of Vision Encoder for multimodal models

### DIFF
--- a/tensorrt_llm/_torch/models/__init__.py
+++ b/tensorrt_llm/_torch/models/__init__.py
@@ -2,6 +2,7 @@ import transformers
 
 from .modeling_auto import AutoModelForCausalLM
 from .modeling_bert import BertForSequenceClassification
+from .modeling_clip import CLIPVisionModel
 from .modeling_deepseekv3 import DeepseekV3ForCausalLM
 from .modeling_llama import LlamaForCausalLM
 from .modeling_llava_next import LlavaNextModel
@@ -24,6 +25,7 @@ from .modeling_vila import VilaModel
 __all__ = [
     "AutoModelForCausalLM",
     "BertForSequenceClassification",
+    "CLIPVisionModel",
     "DeepseekV3ForCausalLM",
     "LlamaForCausalLM",
     "LlavaNextModel",
@@ -36,13 +38,13 @@ __all__ = [
     "Qwen2ForProcessRewardModel",
     "Qwen2ForRewardModel",
     "Qwen2MoeForCausalLM",
+    "SiglipVisionModel",
     "get_model_architecture",
     "VilaModel",
     "Qwen2VLModel",
     "Qwen2_5_VLModel",
     "Qwen3ForCausalLM",
     "Qwen3MoeForCausalLM",
-    "SiglipVisionModel",
 ]
 
 if transformers.__version__ >= "4.45.1":

--- a/tensorrt_llm/_torch/models/__init__.py
+++ b/tensorrt_llm/_torch/models/__init__.py
@@ -16,6 +16,7 @@ from .modeling_qwen2vl import Qwen2_5_VLModel, Qwen2VLModel
 from .modeling_qwen3 import Qwen3ForCausalLM
 from .modeling_qwen3_moe import Qwen3MoeForCausalLM
 from .modeling_qwen_moe import Qwen2MoeForCausalLM
+from .modeling_siglip import SiglipVisionModel
 from .modeling_utils import get_model_architecture
 from .modeling_vila import VilaModel
 
@@ -41,6 +42,7 @@ __all__ = [
     "Qwen2_5_VLModel",
     "Qwen3ForCausalLM",
     "Qwen3MoeForCausalLM",
+    "SiglipVisionModel",
 ]
 
 if transformers.__version__ >= "4.45.1":

--- a/tensorrt_llm/_torch/models/modeling_clip.py
+++ b/tensorrt_llm/_torch/models/modeling_clip.py
@@ -1,0 +1,351 @@
+from typing import Dict, Optional, Tuple, Union
+
+import torch
+import torch.nn as nn
+from tqdm import tqdm
+from transformers.activations import ACT2FN
+from transformers.modeling_outputs import (BaseModelOutput,
+                                           BaseModelOutputWithPooling)
+from transformers.models.clip.configuration_clip import CLIPVisionConfig
+from transformers.models.clip.modeling_clip import CLIPVisionEmbeddings
+
+from ..attention_backend.interface import (AttentionMetadata,
+                                           PredefinedAttentionMask)
+from ..model_config import ModelConfig
+from ..modules.attention import Attention
+from ..modules.mlp import MLP
+from .modeling_utils import register_auto_model
+"""
+NOTE:
+Configuration Class from HF to TRT-LLM ModelConfig naming convention:
+In this file, all `config`s or `self.config`s are HF Configs
+all `model_config`s or `self.model_config`s are TRT-LLM ModelConfig
+At the same time, the `model_config.pretrained_config` is also HF Config as this is defined by the ModelConfig class
+"""
+
+
+# --- Attention Implementation ---
+class CLIPAttention(Attention):
+
+    # Updated to only take CLIPVisionConfig
+    def __init__(self, model_config: ModelConfig[CLIPVisionConfig],
+                 layer_idx: int):
+        config = model_config.pretrained_config
+        pos_embd_params = None
+        rotary_emb = None
+
+        # Vision model has class token
+        num_patches = (config.image_size // config.patch_size)**2
+        max_position_embeddings = num_patches + 1
+
+        # CLIP uses bias in attention QKV projections
+        bias = True
+        super().__init__(
+            hidden_size=config.hidden_size,
+            num_attention_heads=config.num_attention_heads,
+            num_key_value_heads=config.num_attention_heads,  # CLIP uses MHA
+            max_position_embeddings=max_position_embeddings,
+            bias=bias,
+            rotary_emb=rotary_emb,
+            pos_embd_params=pos_embd_params,
+            layer_idx=layer_idx,
+            dtype=config.torch_dtype
+            if hasattr(config, 'torch_dtype') else torch.float32,
+            config=model_config,
+        )
+
+
+class CLIPEncoderLayer(nn.Module):
+
+    def __init__(self, model_config: ModelConfig[CLIPVisionConfig],
+                 layer_idx: int):
+        super().__init__()
+        config = model_config.pretrained_config
+        self.embed_dim = config.hidden_size
+        self.self_attn = CLIPAttention(model_config=model_config,
+                                       layer_idx=layer_idx)
+        self.layer_norm1 = nn.LayerNorm(self.embed_dim,
+                                        eps=config.layer_norm_eps)
+        self.mlp = MLP(
+            hidden_size=config.hidden_size,
+            intermediate_size=config.intermediate_size,
+            activation=ACT2FN[config.hidden_act],
+            bias=True,  # CLIP MLP bias=True
+            config=model_config)
+        self.layer_norm2 = nn.LayerNorm(self.embed_dim,
+                                        eps=config.layer_norm_eps)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+    ) -> Tuple[torch.FloatTensor]:
+        residual = hidden_states
+        hidden_states = self.layer_norm1(hidden_states)
+
+        hidden_states = self.self_attn(
+            position_ids=None,  # CLIP doesn't use explicit position_ids here
+            hidden_states=hidden_states,
+            attn_metadata=attn_metadata,
+            attention_mask=PredefinedAttentionMask.
+            FULL  # Always FULL for Vision
+        )
+
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.layer_norm2(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+
+        outputs = (hidden_states, )
+
+        return outputs
+
+
+class CLIPEncoder(nn.Module):
+
+    def __init__(self, model_config: ModelConfig[CLIPVisionConfig]):
+        super().__init__()
+        config = model_config.pretrained_config
+        self.config = config  # Keep HF config accessible
+        self.model_config = model_config  # Keep TRT-LLM config accessible
+        self.layers = nn.ModuleList([
+            CLIPEncoderLayer(model_config, layer_idx)
+            for layer_idx in range(config.num_hidden_layers)
+        ])
+
+    def forward(
+        self,
+        inputs_embeds,
+        attn_metadata: AttentionMetadata,
+        output_hidden_states: Optional[bool] = None,
+    ) -> Union[Tuple, BaseModelOutput]:
+
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None
+            else self.config.output_hidden_states if hasattr(
+                self.config, 'output_hidden_states') else False)
+
+        encoder_states = () if output_hidden_states else None
+        hidden_states = inputs_embeds
+
+        for encoder_layer in self.layers:
+            if output_hidden_states:
+                # hidden_states is (batch_size * seq_len, embed_dim) because TRT-LLM Attention is applied to flattened tokens
+                seq_len = (
+                    self.config.image_size // self.config.patch_size
+                )**2 + 1  # the "seq_len" is fixed, it is the number of patches +1 (cls token).
+                batch_size = hidden_states.shape[0] // seq_len
+                # we want the output shape align with HF output shape (batch_size, seq_len, embed_dim)
+                encoder_states = encoder_states + (hidden_states.view(
+                    batch_size, seq_len, -1), )
+                # print(
+                #     f"hidden_states is added with shape: {hidden_states.view(batch_size, seq_len, -1).shape}, batch_size: {batch_size}, seq_len: {seq_len}"
+                # )
+
+            layer_outputs = encoder_layer(
+                hidden_states,
+                attn_metadata=attn_metadata,
+            )
+            hidden_states = layer_outputs[0]
+
+        if output_hidden_states:
+            # hidden_states is (batch_size * seq_len, embed_dim) because TRT-LLM Attention is applied to flattened tokens
+            seq_len = (
+                self.config.image_size // self.config.patch_size
+            )**2 + 1  # the "seq_len" is fixed, it is the number of patches. Note that we have a cls token for clip, so we need to add 1
+            batch_size = hidden_states.shape[0] // seq_len
+            # we want the output shape align with HF output shape (batch_size, seq_len, embed_dim)
+            encoder_states = encoder_states + (hidden_states.view(
+                batch_size, seq_len, -1), )
+            # print(
+            #     f"hidden_states is added with shape: {hidden_states.view(batch_size, seq_len, -1).shape}, batch_size: {batch_size}, seq_len: {seq_len}"
+            # )
+
+        return BaseModelOutput(
+            last_hidden_state=
+            hidden_states,  # Keep it flattened for subsequent layers/pooling
+            hidden_states=encoder_states)
+
+
+# --- Vision Transformer ---
+# Uses HF CLIPVisionEmbeddings
+
+
+class CLIPVisionTransformer(nn.Module):
+
+    def __init__(self, model_config: ModelConfig[CLIPVisionConfig]):
+        super().__init__()
+        config = model_config.pretrained_config
+        self.config = config
+        embed_dim = config.hidden_size
+
+        # Use HF Embeddings
+        self.embeddings = CLIPVisionEmbeddings(config)
+        self.pre_layrnorm = nn.LayerNorm(embed_dim, eps=config.layer_norm_eps)
+        self.encoder = CLIPEncoder(model_config)
+        self.post_layernorm = nn.LayerNorm(embed_dim, eps=config.layer_norm_eps)
+
+    def forward(
+        self,
+        pixel_values,
+        attn_metadata: AttentionMetadata,
+        output_hidden_states: Optional[bool] = None,
+        interpolate_pos_encoding: Optional[bool] = False,
+    ) -> BaseModelOutputWithPooling:
+
+        output_hidden_states = (output_hidden_states
+                                if output_hidden_states is not None else
+                                self.config.output_hidden_states)
+
+        hidden_states = self.embeddings(
+            pixel_values, interpolate_pos_encoding=interpolate_pos_encoding)
+
+        hidden_states = self.pre_layrnorm(hidden_states)
+
+        # Reshape for TRT-LLM Attention: (batch * seq_len, hidden)
+        original_shape = hidden_states.shape  # (batch, seq_len, hidden)
+        hidden_states = hidden_states.reshape(
+            hidden_states.shape[0] * hidden_states.shape[1],
+            hidden_states.shape[2])
+        encoder_outputs: BaseModelOutput = self.encoder(
+            inputs_embeds=hidden_states,
+            attn_metadata=attn_metadata,
+            output_hidden_states=output_hidden_states,
+        )
+
+        last_hidden_state_flat = encoder_outputs.last_hidden_state
+
+        # Reshape last_hidden_state back to (batch, seq, hidden) for pooling
+        last_hidden_state = last_hidden_state_flat.view(original_shape)
+
+        # Pooling: Use the CLS token (first token) output
+        pooled_output = last_hidden_state[:, 0, :]
+        pooled_output = self.post_layernorm(pooled_output)  # Apply final LN
+
+        # Pass the reshaped hidden_states if requested
+        returned_hidden_states = encoder_outputs.hidden_states
+
+        return BaseModelOutputWithPooling(
+            # Return the unflattened last_hidden_state
+            last_hidden_state=last_hidden_state,
+            pooler_output=pooled_output,
+            hidden_states=returned_hidden_states,
+            # Attentions are not returned by TRT-LLM Attention module by default
+            attentions=None,
+        )
+
+
+# --- Vision Model ---
+@register_auto_model("CLIPVisionModel")
+class CLIPVisionModel(nn.Module):
+
+    def __init__(self, model_config: ModelConfig[CLIPVisionConfig]):
+        super().__init__()
+        # No need to check for CLIPConfig anymore
+        if not isinstance(model_config.pretrained_config, CLIPVisionConfig):
+            raise ValueError(
+                "Invalid config type for CLIPVisionModel, expected CLIPVisionConfig"
+            )
+
+        self.model_config = model_config
+        self.config = self.model_config.pretrained_config  # HF Vision Config
+        self.vision_model = CLIPVisionTransformer(self.model_config)
+
+    @property
+    def dtype(self):
+        # Infer dtype from a parameter
+        return next(self.parameters()).dtype
+
+    @property
+    def device(self):
+        return next(self.parameters()).device
+
+    @torch.inference_mode()
+    def forward(self,
+                pixel_values,
+                attn_metadata: AttentionMetadata,
+                output_hidden_states: Optional[bool] = None,
+                interpolate_pos_encoding: Optional[bool] = False):
+
+        return self.vision_model(
+            pixel_values=pixel_values,
+            attn_metadata=attn_metadata,
+            output_hidden_states=output_hidden_states,
+            interpolate_pos_encoding=interpolate_pos_encoding)
+
+    def load_weights(self, weights: Dict):
+        # FIXME: Temporary import
+        from .modeling_utils import (duplicate_kv_weight,
+                                     missing_layer_parameter,
+                                     rename_weights_with_regex)
+
+        # FIXME: Temporary import
+        # Pattern mapping for CLIP based on Siglip's example and CLIP HF names
+        pattern_mapping = {
+            r'(.*?)self_attn\.out_proj(.*)': r'\1self_attn.o_proj\2',
+            r'(.*?)mlp\.fc1(.*)': r'\1mlp.up_proj\2',
+            r'(.*?)mlp\.fc2(.*)': r'\1mlp.down_proj\2',
+        }
+        weights = rename_weights_with_regex(pattern_mapping, weights)
+
+        tp_size = self.model_config.mapping.tp_size
+        head_dim = self.config.hidden_size // self.config.num_attention_heads
+
+        def filter_weights(prefix, weights: Dict):
+            result = {}
+            for k, v in weights.items():
+                if k.startswith(prefix):
+                    new_k = k[len(prefix) + 1:]
+                    result[new_k] = v
+            return result
+
+        params_map = {
+            'qkv_proj': ['q_proj', 'k_proj', 'v_proj'],
+            'gate_up_proj': ['gate_proj', 'up_proj']
+        }
+        for name, module in tqdm(list(self.named_modules()),
+                                 desc="Loading weights"):
+            if len(module._parameters) > 0:
+                # skip load weights if tie word embeddings is enabled and layer is lm_head
+                if self.config.tie_word_embeddings and name.startswith(
+                        "lm_head"):
+                    continue
+
+                # Skip if parameter belongs to a missing layer
+                if missing_layer_parameter(name, self):
+                    continue
+                # print(f"loading {name}")
+
+                names = name.split('.')
+                if names[-1] in params_map:
+                    module_weights = []
+                    for new_name in params_map[names[-1]]:
+                        fw = filter_weights('.'.join(names[:-1] + [new_name]),
+                                            weights)
+                        if new_name in ['k_proj', 'v_proj']:
+                            fw = {
+                                k:
+                                duplicate_kv_weight(
+                                    weight=v[:],
+                                    head_dim=head_dim,
+                                    tensor_parallel_size=tp_size)
+                                if k in ["weight", "bias"] else v
+                                for k, v in fw.items()
+                            }
+                        module_weights.append(fw)
+                    module.load_weights(weights=module_weights)
+                    # print(
+                    #     f"loaded {name}: {[w_dic.keys() for w_dic in module_weights]}"
+                    # )
+                else:
+                    module_weights = filter_weights(name, weights)
+                    # print(f"module_weights: {module_weights.keys()}")
+                    if hasattr(module, 'load_weights'):
+                        module.load_weights(weights=[module_weights])
+                    else:
+                        for n, p in module._parameters.items():
+                            if p is not None:
+                                p.data.copy_(module_weights[n][:])
+                    # print(f"loaded {name}: {module_weights.keys()}")

--- a/tensorrt_llm/_torch/models/modeling_clip.py
+++ b/tensorrt_llm/_torch/models/modeling_clip.py
@@ -29,8 +29,10 @@ class CLIPAttention(Attention):
         pos_embd_params = None
 
         # Vision model has class token
-        num_patches = (config.image_size // config.patch_size)**2
-        max_position_embeddings = num_patches + 1
+        #num_patches = (config.image_size // config.patch_size)**2
+
+        #FIXME: max_position_embeddings seems to be unused
+        max_position_embeddings = None
 
         # CLIP uses bias in attention QKV projections
         bias = True

--- a/tensorrt_llm/_torch/models/modeling_clip.py
+++ b/tensorrt_llm/_torch/models/modeling_clip.py
@@ -3,8 +3,7 @@ from typing import Dict, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 from transformers.activations import ACT2FN
-from transformers.modeling_outputs import (BaseModelOutput,
-                                           BaseModelOutputWithPooling)
+from transformers.modeling_outputs import BaseModelOutput
 from transformers.modeling_utils import (get_parameter_device,
                                          get_parameter_dtype)
 from transformers.models.clip.configuration_clip import CLIPVisionConfig
@@ -112,24 +111,17 @@ class CLIPEncoder(nn.Module):
         self,
         inputs_embeds,
         attn_metadata: AttentionMetadata,
-        output_hidden_states: Optional[bool] = None,
     ) -> Union[Tuple, BaseModelOutput]:
 
-        output_hidden_states = (
-            output_hidden_states if output_hidden_states is not None
-            else self.config.output_hidden_states if hasattr(
-                self.config, 'output_hidden_states') else False)
-
-        encoder_states = () if output_hidden_states else None
+        encoder_states = ()
         hidden_states = inputs_embeds
 
         for encoder_layer in self.layers:
-            if output_hidden_states:
-                # hidden_states is (batch_size * seq_len, embed_dim) because TRT-LLM Attention is applied to flattened tokens
-                # we want the output shape align with HF output shape (batch_size, seq_len, embed_dim)
-                encoder_states = encoder_states + (hidden_states.view(
-                    attn_metadata.seq_lens.shape[0], attn_metadata.seq_lens[0],
-                    -1), )
+            # hidden_states is (batch_size * seq_len, embed_dim) because TRT-LLM Attention is applied to flattened tokens
+            # we want the output shape align with HF output shape (batch_size, seq_len, embed_dim)
+            encoder_states = encoder_states + (hidden_states.view(
+                attn_metadata.seq_lens.shape[0], attn_metadata.seq_lens[0],
+                -1), )
 
             layer_outputs = encoder_layer(
                 hidden_states,
@@ -137,20 +129,19 @@ class CLIPEncoder(nn.Module):
             )
             hidden_states = layer_outputs[0]
 
-        if output_hidden_states:
-            # hidden_states is (batch_size * seq_len, embed_dim) because TRT-LLM Attention is applied to flattened tokens
-            # we want the output shape align with HF output shape (batch_size, seq_len, embed_dim)
-            encoder_states = encoder_states + (hidden_states.view(
-                attn_metadata.seq_lens.shape[0], attn_metadata.seq_lens[0],
-                -1), )
+        # hidden_states is (batch_size * seq_len, embed_dim) because TRT-LLM Attention is applied to flattened tokens
+        # we want the output shape align with HF output shape (batch_size, seq_len, embed_dim)
+        encoder_states = encoder_states + (hidden_states.view(
+            attn_metadata.seq_lens.shape[0], attn_metadata.seq_lens[0], -1), )
 
-        return BaseModelOutput(
-            last_hidden_state=
-            hidden_states,  # Keep it flattened for subsequent layers/pooling
-            hidden_states=encoder_states)
+        return encoder_states
 
 
 class CLIPVisionTransformer(nn.Module):
+    """
+    This CLIPVisionTransformer is tailored for multimodal models that use CLIP as the vision encoder.
+    For example, it is different from the regular CLIPVisionTransformer in the sense that it does not return a pooled output.
+    """
 
     def __init__(self, model_config: ModelConfig[CLIPVisionConfig]):
         super().__init__()
@@ -162,19 +153,13 @@ class CLIPVisionTransformer(nn.Module):
         self.embeddings = CLIPVisionEmbeddings(config)
         self.pre_layrnorm = nn.LayerNorm(embed_dim, eps=config.layer_norm_eps)
         self.encoder = CLIPEncoder(model_config)
-        self.post_layernorm = nn.LayerNorm(embed_dim, eps=config.layer_norm_eps)
 
     def forward(
         self,
         pixel_values,
         attn_metadata: AttentionMetadata,
-        output_hidden_states: Optional[bool] = None,
         interpolate_pos_encoding: Optional[bool] = False,
-    ) -> BaseModelOutputWithPooling:
-
-        output_hidden_states = (output_hidden_states
-                                if output_hidden_states is not None else
-                                self.config.output_hidden_states)
+    ) -> Tuple[torch.Tensor]:
 
         hidden_states = self.embeddings(
             pixel_values, interpolate_pos_encoding=interpolate_pos_encoding)
@@ -182,34 +167,15 @@ class CLIPVisionTransformer(nn.Module):
         hidden_states = self.pre_layrnorm(hidden_states)
 
         # Reshape for TRT-LLM Attention: (batch * seq_len, hidden)
-        original_shape = hidden_states.shape  # (batch, seq_len, hidden)
         hidden_states = hidden_states.reshape(
             hidden_states.shape[0] * hidden_states.shape[1],
             hidden_states.shape[2])
-        encoder_outputs: BaseModelOutput = self.encoder(
+        encoder_outputs: Tuple[torch.Tensor] = self.encoder(
             inputs_embeds=hidden_states,
             attn_metadata=attn_metadata,
-            output_hidden_states=output_hidden_states,
         )
 
-        last_hidden_state_flat = encoder_outputs.last_hidden_state
-
-        # Reshape last_hidden_state back to (batch, seq, hidden) for pooling
-        last_hidden_state = last_hidden_state_flat.view(original_shape)
-
-        # Pooling: Use the CLS token (first token) output
-        pooled_output = last_hidden_state[:, 0, :]
-        pooled_output = self.post_layernorm(pooled_output)
-
-        returned_hidden_states = encoder_outputs.hidden_states
-
-        return BaseModelOutputWithPooling(
-            # Return the unflattened last_hidden_state
-            last_hidden_state=last_hidden_state,
-            pooler_output=pooled_output,
-            hidden_states=returned_hidden_states,
-            attentions=None,
-        )
+        return encoder_outputs
 
 
 @register_auto_model("CLIPVisionModel")
@@ -256,13 +222,11 @@ class CLIPVisionModel(nn.Module):
     def forward(self,
                 pixel_values,
                 attn_metadata: AttentionMetadata,
-                output_hidden_states: Optional[bool] = None,
                 interpolate_pos_encoding: Optional[bool] = False):
 
         return self.vision_model(
             pixel_values=pixel_values,
             attn_metadata=attn_metadata,
-            output_hidden_states=output_hidden_states,
             interpolate_pos_encoding=interpolate_pos_encoding)
 
     def load_weights(self, weights: Dict):

--- a/tensorrt_llm/_torch/models/modeling_clip.py
+++ b/tensorrt_llm/_torch/models/modeling_clip.py
@@ -24,11 +24,6 @@ class CLIPAttention(Attention):
                  layer_idx: int):
         config = model_config.pretrained_config
         pos_embd_params = None
-
-        # Vision model has class token
-        #num_patches = (config.image_size // config.patch_size)**2
-
-        #FIXME: max_position_embeddings seems to be unused
         max_position_embeddings = None
 
         # CLIP uses bias in attention QKV projections
@@ -37,7 +32,8 @@ class CLIPAttention(Attention):
             hidden_size=config.hidden_size,
             num_attention_heads=config.num_attention_heads,
             num_key_value_heads=config.num_attention_heads,  # CLIP uses MHA
-            max_position_embeddings=max_position_embeddings,
+            max_position_embeddings=
+            max_position_embeddings,  # does not matter for CLIP
             bias=bias,
             pos_embd_params=pos_embd_params,
             layer_idx=layer_idx,

--- a/tensorrt_llm/_torch/models/modeling_clip.py
+++ b/tensorrt_llm/_torch/models/modeling_clip.py
@@ -27,7 +27,6 @@ class CLIPAttention(Attention):
                  layer_idx: int):
         config = model_config.pretrained_config
         pos_embd_params = None
-        rotary_emb = None
 
         # Vision model has class token
         num_patches = (config.image_size // config.patch_size)**2
@@ -41,7 +40,6 @@ class CLIPAttention(Attention):
             num_key_value_heads=config.num_attention_heads,  # CLIP uses MHA
             max_position_embeddings=max_position_embeddings,
             bias=bias,
-            rotary_emb=rotary_emb,
             pos_embd_params=pos_embd_params,
             layer_idx=layer_idx,
             dtype=config.torch_dtype

--- a/tensorrt_llm/_torch/models/modeling_llava_next.py
+++ b/tensorrt_llm/_torch/models/modeling_llava_next.py
@@ -54,10 +54,11 @@ class LlavaNextInputProcessor(InputProcessor):
     def _process(self, pixel_values):
         attn_metadata = self.vision_tower.prepare_attn_metadata(
             pixel_values.shape[0])
-        image_features = self.vision_tower(pixel_values,
-                                           attn_metadata=attn_metadata,
-                                           output_hidden_states=True)
-        selected_image_feature = image_features.hidden_states[-2][:, 1:]
+        image_features: Tuple[torch.Tensor] = self.vision_tower(
+            pixel_values,
+            attn_metadata=attn_metadata,
+        )
+        selected_image_feature = image_features[-2][:, 1:]
         image_features = self.mm_projector(selected_image_feature)
         return image_features.reshape(-1, image_features.shape[-1])
 

--- a/tensorrt_llm/_torch/models/modeling_siglip.py
+++ b/tensorrt_llm/_torch/models/modeling_siglip.py
@@ -1,0 +1,347 @@
+from typing import Dict, Optional, Tuple, Union
+
+import torch
+import torch.nn as nn
+from tqdm import tqdm
+from transformers.activations import ACT2FN
+from transformers.modeling_outputs import (BaseModelOutput,
+                                           BaseModelOutputWithPooling)
+from transformers.models.siglip.configuration_siglip import SiglipVisionConfig
+from transformers.models.siglip.modeling_siglip import (
+    SiglipMultiheadAttentionPoolingHead, SiglipVisionConfig,
+    SiglipVisionEmbeddings)
+
+from ..attention_backend.interface import (AttentionMetadata,
+                                           PredefinedAttentionMask)
+from ..model_config import ModelConfig
+from ..modules.attention import Attention
+from ..modules.mlp import MLP
+from .modeling_utils import register_auto_model
+"""
+NOTE:
+Configuration Class from HF to TRT-LLM ModelConfig naming convention:
+In this file, all `config`s or `self.config`s are HF Configs
+all `model_config`s or `self.model_config`s are TRT-LLM ModelConfig
+At the same time, the `model_config.pretrained_config` is also HF Config as this is defined by the ModelConfig class
+"""
+
+
+class SiglipAttention(Attention):
+
+    def __init__(self, model_config: ModelConfig[SiglipVisionConfig],
+                 layer_idx: int):
+        config = model_config.pretrained_config
+        pos_embd_params = None
+        rotary_emb = None
+        num_patches = (config.image_size // config.patch_size)**2
+        # the max_position_embeddings is the number of patches for Vision Transformer
+        max_position_embeddings = num_patches
+        # Siglip uses bias in attention, ref:https://github.com/huggingface/transformers/blob/main/src/transformers/models/siglip/modeling_siglip.py#L399
+        bias = True
+        super().__init__(
+            hidden_size=config.hidden_size,
+            num_attention_heads=config.num_attention_heads,
+            num_key_value_heads=config.num_attention_heads,
+            max_position_embeddings=max_position_embeddings,
+            bias=bias,
+            rotary_emb=rotary_emb,
+            pos_embd_params=pos_embd_params,
+            layer_idx=layer_idx,
+            dtype=config.torch_dtype,
+            config=model_config,
+        )
+
+
+class SiglipEncoderLayer(nn.Module):
+
+    def __init__(self, model_config: ModelConfig[SiglipVisionConfig],
+                 layer_idx: int):
+        super().__init__()
+        config = model_config.pretrained_config
+        self.embed_dim = config.hidden_size
+        self.self_attn = SiglipAttention(model_config=model_config,
+                                         layer_idx=layer_idx)
+        self.layer_norm1 = nn.LayerNorm(self.embed_dim,
+                                        eps=config.layer_norm_eps)
+        # Siglip uses bias in MLP, ref:https://github.com/huggingface/transformers/blob/main/src/transformers/models/siglip/modeling_siglip.py#L458
+        self.mlp = MLP(hidden_size=config.hidden_size,
+                       intermediate_size=config.intermediate_size,
+                       activation=ACT2FN[config.hidden_act],
+                       bias=True)
+        self.layer_norm2 = nn.LayerNorm(self.embed_dim,
+                                        eps=config.layer_norm_eps)
+
+    # Ignore copy
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+    ) -> Tuple[torch.FloatTensor]:
+        """
+        Args:
+            hidden_states (`torch.FloatTensor`):
+                Input to the layer of shape `(batch, seq_len, embed_dim)`.
+        """
+        residual = hidden_states
+
+        hidden_states = self.layer_norm1(hidden_states)
+
+        # FIXME: temporary config for AttentionMetadata and Mask
+        attention_mask = PredefinedAttentionMask.FULL
+        hidden_states = self.self_attn(position_ids=None,
+                                       hidden_states=hidden_states,
+                                       attn_metadata=attn_metadata,
+                                       attention_mask=attention_mask)
+
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.layer_norm2(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+
+        outputs = (hidden_states, )
+
+        return outputs
+
+
+class SiglipEncoder(nn.Module):
+    """
+    Transformer encoder consisting of `config.num_hidden_layers` self attention layers. Each layer is a
+    [`SiglipEncoderLayer`].
+
+    Args:
+        config: SiglipConfig
+    """
+
+    def __init__(self, model_config: ModelConfig[SiglipVisionConfig]):
+        super().__init__()
+        config = model_config.pretrained_config
+        self.config = config
+        self.layers = nn.ModuleList([
+            SiglipEncoderLayer(model_config, layer_idx)
+            for layer_idx in range(config.num_hidden_layers)
+        ])
+
+    # Ignore copy
+    def forward(
+        self,
+        inputs_embeds,
+        attn_metadata: AttentionMetadata,
+        output_hidden_states: Optional[bool] = None,
+    ) -> Union[Tuple, BaseModelOutput]:
+        r"""
+        Args:
+            inputs_embeds (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`):
+                Optionally, instead of passing `input_ids` you can choose to directly pass an embedded representation.
+                This is useful if you want more control over how to convert `input_ids` indices into associated vectors
+                than the model's internal embedding lookup matrix.
+            attention_mask (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
+                Mask to avoid performing attention on padding token indices. Mask values selected in `[0, 1]`:
+
+                - 1 for tokens that are **not masked**,
+                - 0 for tokens that are **masked**.
+
+                [What are attention masks?](../glossary#attention-mask)
+            output_attentions (`bool`, *optional*):
+                Whether or not to return the attentions tensors of all attention layers. See `attentions` under
+                returned tensors for more detail.
+            output_hidden_states (`bool`, *optional*):
+                Whether or not to return the hidden states of all layers. See `hidden_states` under returned tensors
+                for more detail.
+        """
+        output_hidden_states = (output_hidden_states
+                                if output_hidden_states is not None else
+                                self.config.output_hidden_states)
+
+        encoder_states = () if output_hidden_states else None
+
+        hidden_states = inputs_embeds
+        for encoder_layer in self.layers:
+            if output_hidden_states:
+                # hidden_states is (batch_size * seq_len, embed_dim) because TRT-LLM Attention is applied to flattened tokens
+                seq_len = (
+                    self.config.image_size // self.config.patch_size
+                )**2  # the "seq_len" is fixed, it is the number of patches
+                batch_size = hidden_states.shape[0] // seq_len
+                # we want the output shape align with HF output shape (batch_size, seq_len, embed_dim)
+                encoder_states = encoder_states + (hidden_states.view(
+                    batch_size, seq_len, -1), )
+                print(
+                    f"hidden_states is added with shape: {hidden_states.view(batch_size, seq_len, -1).shape}, batch_size: {batch_size}, seq_len: {seq_len}"
+                )
+            layer_outputs = encoder_layer(
+                hidden_states,
+                attn_metadata=attn_metadata,
+            )
+
+            hidden_states = layer_outputs[0]
+
+        if output_hidden_states:
+            # same as above
+            seq_len = (self.config.image_size // self.config.patch_size)**2
+            batch_size = hidden_states.shape[0] // seq_len
+            encoder_states = encoder_states + (hidden_states.view(
+                batch_size, seq_len, -1), )
+
+        return BaseModelOutput(last_hidden_state=hidden_states,
+                               hidden_states=encoder_states)
+
+
+class SiglipVisionTransformer(nn.Module):
+
+    def __init__(self, model_config: ModelConfig[SiglipVisionConfig]):
+        super().__init__()
+        config = model_config.pretrained_config
+        self.config = config
+        embed_dim = config.hidden_size
+
+        self.embeddings = SiglipVisionEmbeddings(config)
+        self.encoder = SiglipEncoder(model_config)
+        self.post_layernorm = nn.LayerNorm(embed_dim, eps=config.layer_norm_eps)
+        self.use_head = True if not hasattr(
+            config, "vision_use_head") else config.vision_use_head
+        if self.use_head:
+            self.head = SiglipMultiheadAttentionPoolingHead(config)
+
+    def forward(
+        self,
+        pixel_values,
+        attn_metadata: AttentionMetadata,
+        output_hidden_states: Optional[bool] = None,
+        interpolate_pos_encoding: Optional[bool] = False,
+    ) -> BaseModelOutputWithPooling:
+        r"""
+        Args:
+            pixel_values (`torch.FloatTensor` of shape `(batch_size, num_channels, height, width)`):
+                Pixel values.
+            attn_metadata (`AttentionMetadata`):
+                Attention metadata.
+        """
+        output_hidden_states = (output_hidden_states
+                                if output_hidden_states is not None else
+                                self.config.output_hidden_states)
+
+        hidden_states = self.embeddings(
+            pixel_values, interpolate_pos_encoding=interpolate_pos_encoding)
+        print(f"hidden_states: {hidden_states.shape}")
+        # reshape hidden_states to (batch_size * seq_len, embed_dim)
+        # TODO: check the overhead here because of the reshape
+        hidden_states = hidden_states.reshape(
+            hidden_states.shape[0] * hidden_states.shape[1],
+            hidden_states.shape[2])
+        print(f"after reshape hidden_states: {hidden_states.shape}")
+        print(f"attn_metadata: {attn_metadata}")
+
+        encoder_outputs: BaseModelOutput = self.encoder(
+            inputs_embeds=hidden_states,
+            attn_metadata=attn_metadata,
+            output_hidden_states=output_hidden_states,
+        )
+        print(f"encoder_outputs: {encoder_outputs}")
+        last_hidden_state = encoder_outputs.last_hidden_state
+        last_hidden_state = self.post_layernorm(last_hidden_state)
+
+        pooler_output = self.head(last_hidden_state) if self.use_head else None
+
+        return BaseModelOutputWithPooling(
+            last_hidden_state=last_hidden_state,
+            pooler_output=pooler_output,
+            hidden_states=encoder_outputs.hidden_states,
+        )
+
+
+@register_auto_model("SiglipVisionModel")
+class SiglipVisionModel(nn.Module):
+
+    def __init__(self, model_config: ModelConfig[SiglipVisionConfig]):
+        super().__init__()
+        self.config = model_config.pretrained_config
+        self.vision_model = SiglipVisionTransformer(model_config)
+        self.model_config = model_config
+
+    @property
+    def dtype(self):
+        return self.config.torch_dtype
+
+    def forward(self,
+                pixel_values,
+                attn_metadata: AttentionMetadata,
+                output_hidden_states: Optional[bool] = None):
+        return self.vision_model(pixel_values, attn_metadata,
+                                 output_hidden_states)
+
+    def load_weights(self, weights: Dict):
+        # FIXME: Temporary import
+        from .modeling_utils import (duplicate_kv_weight,
+                                     missing_layer_parameter,
+                                     rename_weights_with_regex)
+
+        # FIXME: Temporary import
+
+        pattern_mapping = {
+            r'(.*?)out_proj(.*)': r'\1o_proj\2',
+            r'(.*?)fc1(.*)': r'\1up_proj\2',
+            r'(.*?)fc2(.*)': r'\1down_proj\2',
+        }
+        weights = rename_weights_with_regex(pattern_mapping, weights)
+
+        tp_size = self.model_config.mapping.tp_size
+        head_dim = self.config.hidden_size // self.config.num_attention_heads
+
+        def filter_weights(prefix, weights: Dict):
+            result = {}
+            for k, v in weights.items():
+                if k.startswith(prefix):
+                    new_k = k[len(prefix) + 1:]
+                    result[new_k] = v
+            return result
+
+        params_map = {
+            'qkv_proj': ['q_proj', 'k_proj', 'v_proj'],
+            'gate_up_proj': ['gate_proj', 'up_proj']
+        }
+        for name, module in tqdm(list(self.named_modules()),
+                                 desc="Loading weights"):
+            if len(module._parameters) > 0:
+                # skip load weights if tie word embeddings is enabled and layer is lm_head
+                if self.config.tie_word_embeddings and name.startswith(
+                        "lm_head"):
+                    continue
+
+                # Skip if parameter belongs to a missing layer
+                if missing_layer_parameter(name, self):
+                    continue
+                print(f"loading {name}")
+
+                names = name.split('.')
+                if names[-1] in params_map:
+                    module_weights = []
+                    for new_name in params_map[names[-1]]:
+                        fw = filter_weights('.'.join(names[:-1] + [new_name]),
+                                            weights)
+                        if new_name in ['k_proj', 'v_proj']:
+                            fw = {
+                                k:
+                                duplicate_kv_weight(
+                                    weight=v[:],
+                                    head_dim=head_dim,
+                                    tensor_parallel_size=tp_size)
+                                if k in ["weight", "bias"] else v
+                                for k, v in fw.items()
+                            }
+                        module_weights.append(fw)
+                    module.load_weights(weights=module_weights)
+                    print(
+                        f"loaded {name}: {[w_dic.keys() for w_dic in module_weights]}"
+                    )
+                else:
+                    module_weights = filter_weights(name, weights)
+                    print(f"module_weights: {module_weights.keys()}")
+                    if hasattr(module, 'load_weights'):
+                        module.load_weights(weights=[module_weights])
+                    else:
+                        for n, p in module._parameters.items():
+                            if p is not None:
+                                p.data.copy_(module_weights[n][:])
+                    print(f"loaded {name}: {module_weights.keys()}")

--- a/tensorrt_llm/_torch/models/modeling_siglip.py
+++ b/tensorrt_llm/_torch/models/modeling_siglip.py
@@ -29,7 +29,6 @@ class SiglipAttention(Attention):
                  layer_idx: int):
         config = model_config.pretrained_config
         pos_embd_params = None
-        rotary_emb = None
         num_patches = (config.image_size // config.patch_size)**2
         # the max_position_embeddings is the number of patches for Vision Transformer
         max_position_embeddings = num_patches
@@ -41,7 +40,6 @@ class SiglipAttention(Attention):
             num_key_value_heads=config.num_attention_heads,
             max_position_embeddings=max_position_embeddings,
             bias=bias,
-            rotary_emb=rotary_emb,
             pos_embd_params=pos_embd_params,
             layer_idx=layer_idx,
             dtype=config.torch_dtype,

--- a/tensorrt_llm/_torch/models/modeling_siglip.py
+++ b/tensorrt_llm/_torch/models/modeling_siglip.py
@@ -2,7 +2,6 @@ from typing import Dict, Optional
 
 import torch
 import torch.nn as nn
-from tqdm import tqdm
 from transformers.modeling_outputs import (BaseModelOutput,
                                            BaseModelOutputWithPooling)
 from transformers.modeling_utils import (get_parameter_device,
@@ -16,8 +15,7 @@ from ..attention_backend.interface import AttentionMetadata
 from ..attention_backend.utils import get_attention_backend
 from ..model_config import ModelConfig
 from .modeling_clip import CLIPEncoder
-from .modeling_utils import (duplicate_kv_weight, missing_layer_parameter,
-                             register_auto_model, rename_weights_with_regex)
+from .modeling_utils import _load_weights_impl, register_auto_model
 
 SiglipEncoder = CLIPEncoder
 
@@ -127,58 +125,4 @@ class SiglipVisionModel(nn.Module):
             r'(.*?)fc1(.*)': r'\1up_proj\2',
             r'(.*?)fc2(.*)': r'\1down_proj\2',
         }
-        weights = rename_weights_with_regex(pattern_mapping, weights)
-
-        tp_size = self.model_config.mapping.tp_size
-        head_dim = self.config.hidden_size // self.config.num_attention_heads
-
-        def filter_weights(prefix, weights: Dict):
-            result = {}
-            for k, v in weights.items():
-                if k.startswith(prefix):
-                    new_k = k[len(prefix) + 1:]
-                    result[new_k] = v
-            return result
-
-        params_map = {
-            'qkv_proj': ['q_proj', 'k_proj', 'v_proj'],
-            'gate_up_proj': ['gate_proj', 'up_proj']
-        }
-        for name, module in tqdm(list(self.named_modules()),
-                                 desc="Loading weights"):
-            if len(module._parameters) > 0:
-                # skip load weights if tie word embeddings is enabled and layer is lm_head
-                if self.config.tie_word_embeddings and name.startswith(
-                        "lm_head"):
-                    continue
-
-                # Skip if parameter belongs to a missing layer
-                if missing_layer_parameter(name, self):
-                    continue
-
-                names = name.split('.')
-                if names[-1] in params_map:
-                    module_weights = []
-                    for new_name in params_map[names[-1]]:
-                        fw = filter_weights('.'.join(names[:-1] + [new_name]),
-                                            weights)
-                        if new_name in ['k_proj', 'v_proj']:
-                            fw = {
-                                k:
-                                duplicate_kv_weight(
-                                    weight=v[:],
-                                    head_dim=head_dim,
-                                    tensor_parallel_size=tp_size)
-                                if k in ["weight", "bias"] else v
-                                for k, v in fw.items()
-                            }
-                        module_weights.append(fw)
-                    module.load_weights(weights=module_weights)
-                else:
-                    module_weights = filter_weights(name, weights)
-                    if hasattr(module, 'load_weights'):
-                        module.load_weights(weights=[module_weights])
-                    else:
-                        for n, p in module._parameters.items():
-                            if p is not None:
-                                p.data.copy_(module_weights[n][:])
+        _load_weights_impl(self, weights, pattern_mapping)

--- a/tensorrt_llm/_torch/models/modeling_siglip.py
+++ b/tensorrt_llm/_torch/models/modeling_siglip.py
@@ -1,9 +1,8 @@
-from typing import Dict, Optional, Tuple, Union
+from typing import Dict, Optional
 
 import torch
 import torch.nn as nn
 from tqdm import tqdm
-from transformers.activations import ACT2FN
 from transformers.modeling_outputs import (BaseModelOutput,
                                            BaseModelOutputWithPooling)
 from transformers.modeling_utils import (get_parameter_device,
@@ -13,132 +12,14 @@ from transformers.models.siglip.modeling_siglip import (
     SiglipMultiheadAttentionPoolingHead, SiglipVisionConfig,
     SiglipVisionEmbeddings)
 
-from ..attention_backend.interface import (AttentionMetadata,
-                                           PredefinedAttentionMask)
+from ..attention_backend.interface import AttentionMetadata
 from ..attention_backend.utils import get_attention_backend
 from ..model_config import ModelConfig
-from ..modules.attention import Attention
-from ..modules.mlp import MLP
+from .modeling_clip import CLIPEncoder
 from .modeling_utils import (duplicate_kv_weight, missing_layer_parameter,
                              register_auto_model, rename_weights_with_regex)
 
-
-class SiglipAttention(Attention):
-
-    def __init__(self, model_config: ModelConfig[SiglipVisionConfig],
-                 layer_idx: int):
-        config = model_config.pretrained_config
-        pos_embd_params = None
-        num_patches = (config.image_size // config.patch_size)**2
-        # the max_position_embeddings is the number of patches for Vision Transformer
-        max_position_embeddings = num_patches
-        # Siglip uses bias in attention, ref:https://github.com/huggingface/transformers/blob/main/src/transformers/models/siglip/modeling_siglip.py#L399
-        bias = True
-        super().__init__(
-            hidden_size=config.hidden_size,
-            num_attention_heads=config.num_attention_heads,
-            num_key_value_heads=config.num_attention_heads,
-            max_position_embeddings=max_position_embeddings,
-            bias=bias,
-            pos_embd_params=pos_embd_params,
-            layer_idx=layer_idx,
-            dtype=config.torch_dtype,
-            config=model_config,
-        )
-
-
-class SiglipEncoderLayer(nn.Module):
-
-    def __init__(self, model_config: ModelConfig[SiglipVisionConfig],
-                 layer_idx: int):
-        super().__init__()
-        config = model_config.pretrained_config
-        self.embed_dim = config.hidden_size
-        self.self_attn = SiglipAttention(model_config=model_config,
-                                         layer_idx=layer_idx)
-        self.layer_norm1 = nn.LayerNorm(self.embed_dim,
-                                        eps=config.layer_norm_eps)
-        # Siglip uses bias in MLP, ref:https://github.com/huggingface/transformers/blob/main/src/transformers/models/siglip/modeling_siglip.py#L458
-        self.mlp = MLP(hidden_size=config.hidden_size,
-                       intermediate_size=config.intermediate_size,
-                       activation=ACT2FN[config.hidden_act],
-                       bias=True)
-        self.layer_norm2 = nn.LayerNorm(self.embed_dim,
-                                        eps=config.layer_norm_eps)
-
-    def forward(
-        self,
-        hidden_states: torch.Tensor,
-        attn_metadata: AttentionMetadata,
-    ) -> Tuple[torch.FloatTensor]:
-        residual = hidden_states
-
-        hidden_states = self.layer_norm1(hidden_states)
-
-        attention_mask = PredefinedAttentionMask.FULL
-        hidden_states = self.self_attn(position_ids=None,
-                                       hidden_states=hidden_states,
-                                       attn_metadata=attn_metadata,
-                                       attention_mask=attention_mask)
-
-        hidden_states = residual + hidden_states
-
-        residual = hidden_states
-        hidden_states = self.layer_norm2(hidden_states)
-        hidden_states = self.mlp(hidden_states)
-        hidden_states = residual + hidden_states
-
-        outputs = (hidden_states, )
-
-        return outputs
-
-
-class SiglipEncoder(nn.Module):
-
-    def __init__(self, model_config: ModelConfig[SiglipVisionConfig]):
-        super().__init__()
-        config = model_config.pretrained_config
-        self.config = config
-        self.layers = nn.ModuleList([
-            SiglipEncoderLayer(model_config, layer_idx)
-            for layer_idx in range(config.num_hidden_layers)
-        ])
-
-    def forward(
-        self,
-        inputs_embeds,
-        attn_metadata: AttentionMetadata,
-        output_hidden_states: Optional[bool] = None,
-    ) -> Union[Tuple, BaseModelOutput]:
-        output_hidden_states = (output_hidden_states
-                                if output_hidden_states is not None else
-                                self.config.output_hidden_states)
-
-        encoder_states = () if output_hidden_states else None
-
-        hidden_states = inputs_embeds
-        for encoder_layer in self.layers:
-            if output_hidden_states:
-                # hidden_states is (batch_size * seq_len, embed_dim) because TRT-LLM Attention is applied to flattened tokens
-                # we want the output shape align with HF output shape (batch_size, seq_len, embed_dim)
-                encoder_states = encoder_states + (hidden_states.view(
-                    attn_metadata.seq_lens.shape[0], attn_metadata.seq_lens[0],
-                    -1), )
-            layer_outputs = encoder_layer(
-                hidden_states,
-                attn_metadata=attn_metadata,
-            )
-
-            hidden_states = layer_outputs[0]
-
-        if output_hidden_states:
-            # same as above
-            encoder_states = encoder_states + (hidden_states.view(
-                attn_metadata.seq_lens.shape[0], attn_metadata.seq_lens[0],
-                -1), )
-
-        return BaseModelOutput(last_hidden_state=hidden_states,
-                               hidden_states=encoder_states)
+SiglipEncoder = CLIPEncoder
 
 
 class SiglipVisionTransformer(nn.Module):

--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -669,9 +669,6 @@ def rename_weights_with_regex(pattern_mapping: Dict[str, str], weights: Dict):
         # Check each pattern for a match
         for pattern, replacement in pattern_mapping.items():
             if re.match(pattern, key):
-                print(
-                    f"matched {key} with {pattern}, replacing with {replacement}"
-                )
                 # Create the new key by applying the regex replacement
                 new_key = re.sub(pattern, replacement, key)
                 # Store the weight with the new key

--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -510,73 +510,7 @@ class DecoderModelForCausalLM(nn.Module,
         )
 
     def load_weights(self, weights: Dict):
-        tp_size = self.model_config.mapping.tp_size
-        head_dim = getattr(
-            self.config, "head_dim",
-            self.config.hidden_size // self.config.num_attention_heads)
-
-        def filter_weights(prefix, weights: Dict):
-            result = {}
-            for k, v in weights.items():
-                if k.startswith(prefix):
-                    new_k = k[len(prefix) + 1:]
-                    result[new_k] = v
-            return result
-
-        params_map = {
-            'qkv_proj': ['q_proj', 'k_proj', 'v_proj'],
-            'gate_up_proj': ['gate_proj', 'up_proj']
-        }
-
-        for name, module in tqdm(list(self.named_modules()),
-                                 desc="Loading weights"):
-            if len(module._parameters) > 0:
-                # skip load weights if tie word embeddings is enabled and layer is lm_head
-                if self.config.tie_word_embeddings and name.startswith(
-                        "lm_head"):
-                    continue
-
-                # Skip loading weights for embedding and lm_head if LoRA is enabled
-                if hasattr(self.model_config, 'lora_config'
-                           ) and self.model_config.lora_config is not None and (
-                               name == "model.embed_tokens"
-                               or name == "lm_head"):
-                    continue
-
-                # Skip if parameter belongs to a missing layer
-                if missing_layer_parameter(name, self):
-                    continue
-
-                names = name.split('.')
-                # WAR: better solution is that llama has its own load_weights function.
-                if names[-1] == 'next_layer_layernorm':
-                    continue
-                if names[-1] in params_map:
-                    module_weights = []
-                    for new_name in params_map[names[-1]]:
-                        fw = filter_weights('.'.join(names[:-1] + [new_name]),
-                                            weights)
-                        if new_name in ['k_proj', 'v_proj']:
-                            fw = {
-                                k:
-                                duplicate_kv_weight(
-                                    weight=v[:],
-                                    head_dim=head_dim,
-                                    tensor_parallel_size=tp_size)
-                                if k in ["weight", "bias"] else v
-                                for k, v in fw.items()
-                            }
-
-                        module_weights.append(fw)
-                    module.load_weights(weights=module_weights)
-                else:
-                    module_weights = filter_weights(name, weights)
-                    if hasattr(module, 'load_weights'):
-                        module.load_weights(weights=[module_weights])
-                    else:
-                        for n, p in module._parameters.items():
-                            if p is not None:
-                                p.data.copy_(module_weights[n][:])
+        _load_weights_impl(self, weights)
 
     def infer_max_seq_len(self) -> int:
         # Modified from tensorrt_llm/builder.py _init_max_seq_len
@@ -681,3 +615,82 @@ def rename_weights_with_regex(pattern_mapping: Dict[str, str], weights: Dict):
             renamed_weights[key] = weights[key]
 
     return renamed_weights
+
+
+def _load_weights_impl(model: Union[nn.Module, DecoderModelForCausalLM],
+                       weights: Dict,
+                       params_map: Optional[Dict[str, str]] = None):
+    if not hasattr(model, 'model_config') or not isinstance(
+            model.model_config, ModelConfig):
+        raise ValueError("model must have a model_config attribute")
+    if not hasattr(model, 'config'):
+        raise ValueError("model must have a config attribute")
+
+    if params_map is not None:
+        weights = rename_weights_with_regex(params_map, weights)
+        logger.info(f"Renamed weights with params_map: {params_map}")
+
+    tp_size = model.model_config.mapping.tp_size
+    head_dim = getattr(
+        model.config, "head_dim",
+        model.config.hidden_size // model.config.num_attention_heads)
+
+    def filter_weights(prefix, weights: Dict):
+        result = {}
+        for k, v in weights.items():
+            if k.startswith(prefix):
+                new_k = k[len(prefix) + 1:]
+                result[new_k] = v
+        return result
+
+    params_map = {
+        'qkv_proj': ['q_proj', 'k_proj', 'v_proj'],
+        'gate_up_proj': ['gate_proj', 'up_proj']
+    }
+
+    for name, module in tqdm(list(model.named_modules()),
+                             desc="Loading weights"):
+        if len(module._parameters) > 0:
+            # skip load weights if tie word embeddings is enabled and layer is lm_head
+            if model.config.tie_word_embeddings and name.startswith("lm_head"):
+                continue
+
+            # Skip loading weights for embedding and lm_head if LoRA is enabled
+            if hasattr(model.model_config, 'lora_config'
+                       ) and model.model_config.lora_config is not None and (
+                           name == "model.embed_tokens" or name == "lm_head"):
+                continue
+
+            # Skip if parameter belongs to a missing layer
+            if missing_layer_parameter(name, model):
+                continue
+
+            names = name.split('.')
+            # WAR: better solution is that llama has its own load_weights function.
+            if names[-1] == 'next_layer_layernorm':
+                continue
+            if names[-1] in params_map:
+                module_weights = []
+                for new_name in params_map[names[-1]]:
+                    fw = filter_weights('.'.join(names[:-1] + [new_name]),
+                                        weights)
+                    if new_name in ['k_proj', 'v_proj']:
+                        fw = {
+                            k:
+                            duplicate_kv_weight(weight=v[:],
+                                                head_dim=head_dim,
+                                                tensor_parallel_size=tp_size)
+                            if k in ["weight", "bias"] else v
+                            for k, v in fw.items()
+                        }
+
+                    module_weights.append(fw)
+                module.load_weights(weights=module_weights)
+            else:
+                module_weights = filter_weights(name, weights)
+                if hasattr(module, 'load_weights'):
+                    module.load_weights(weights=[module_weights])
+                else:
+                    for n, p in module._parameters.items():
+                        if p is not None:
+                            p.data.copy_(module_weights[n][:])

--- a/tests/unittest/_torch/modeling/test_modeling_clip.py
+++ b/tests/unittest/_torch/modeling/test_modeling_clip.py
@@ -12,7 +12,7 @@ from tensorrt_llm._torch.model_config import ModelConfig
 # Import TRT-LLM CLIP model
 from tensorrt_llm._torch.models.modeling_clip import CLIPVisionModel
 
-# Default CLIP config from HF
+# Default CLIP config from HF (https://github.com/huggingface/transformers/blob/v4.51.3/src/transformers/models/clip/configuration_clip.py#L144-L172)
 CLIP_CONFIG = {
     "hidden_size": 768,
     "intermediate_size": 3072,

--- a/tests/unittest/_torch/modeling/test_modeling_clip.py
+++ b/tests/unittest/_torch/modeling/test_modeling_clip.py
@@ -1,0 +1,161 @@
+import unittest
+from copy import deepcopy
+from dataclasses import dataclass
+
+import torch
+from parameterized import parameterized
+# Import CLIP specific classes from HF
+from transformers import CLIPVisionConfig
+from transformers import CLIPVisionModel as HFCLIPVisionModel
+
+from tensorrt_llm._torch.model_config import ModelConfig
+# Import TRT-LLM CLIP model
+from tensorrt_llm._torch.models.modeling_clip import CLIPVisionModel
+
+# Default CLIP config from HF
+CLIP_CONFIG = {
+    "hidden_size": 768,
+    "intermediate_size": 3072,
+    "num_hidden_layers": 12,
+    "num_attention_heads": 12,
+    "num_channels": 3,
+    "image_size": 224,
+    "patch_size": 32,
+    "hidden_act": "quick_gelu",
+    "layer_norm_eps": 1e-5,
+    "attention_dropout": 0.0,
+    "initializer_range": 0.02,
+    "initializer_factor": 1.0,
+}
+
+ACCURACY_CONFIG = {
+    torch.float16: (1e-2, 1e-3),
+}
+
+
+@dataclass(repr=False)
+class Scenario:
+    backend: str
+    num_images: int
+    dtype: torch.dtype  # Add dtype to scenario
+
+    def __repr__(self) -> str:
+        return f"backend:{self.backend.lower()}_num_images:{self.num_images}_dtype:{self.dtype}"
+
+
+class TestCLIPVisionModel(unittest.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        torch.random.manual_seed(720)
+
+    @parameterized.expand([
+        Scenario(backend="VANILLA", num_images=2, dtype=torch.float16),
+        Scenario(backend="TRTLLM", num_images=2, dtype=torch.float16),
+        Scenario(backend="TRTLLM", num_images=21, dtype=torch.float16),
+    ], lambda testcase_func, param_num, param:
+                          f"{testcase_func.__name__}[{param.args[0]}]")
+    def test_clip_vision_allclose_to_hf(self, scenario: Scenario):
+        """Compare output to HF"""
+        backend = scenario.backend
+        num_images = scenario.num_images
+        dtype = scenario.dtype
+        device = torch.device('cuda')
+
+        # Create configs
+        config_dict = deepcopy(CLIP_CONFIG)
+        hf_config = CLIPVisionConfig.from_dict(config_dict)
+
+        # Prepare HF model
+        hf_model = HFCLIPVisionModel(hf_config).to(dtype).to(device).eval()
+
+        # Prepare tllm pytorch model
+        model_config = ModelConfig(
+            pretrained_config=hf_config,
+            attn_backend=backend,
+        )
+
+        tllm_model = CLIPVisionModel(model_config).to(dtype).to(device)
+        # Use the load_weights method we are testing
+        tllm_model.load_weights(hf_model.state_dict())
+
+        # Prepare inputs - create random pixel values for images
+        batch_size = num_images
+        pixel_values = torch.rand(batch_size,
+                                  hf_config.num_channels,
+                                  hf_config.image_size,
+                                  hf_config.image_size,
+                                  device=device,
+                                  dtype=dtype)
+
+        # Run HF inference
+        with torch.inference_mode():
+            hf_outputs = hf_model(
+                pixel_values=pixel_values,
+                output_attentions=False,
+                output_hidden_states=True)  # Get hidden states for comparison
+
+        # Run TRT-LLM inference
+        attn_metadata = tllm_model.prepare_attn_metadata(batch_size)
+        tllm_outputs = tllm_model(
+            pixel_values=pixel_values,
+            attn_metadata=attn_metadata,
+            output_hidden_states=True,
+        )
+
+        # Compare outputs
+        # 1. Pooled Output (CLS token output after post_layernorm)
+        hf_pooled = hf_outputs.pooler_output
+        tllm_pooled = tllm_outputs.pooler_output
+        rtol, atol = (1e-2, 1e-2) if dtype == torch.float16 else (1e-4, 1e-4)
+        torch.testing.assert_close(
+            hf_pooled.float(),
+            tllm_pooled.float(),
+            rtol=rtol,
+            atol=atol,
+            msg=
+            f"FAILED: TRT-LLM and HF pooled_output mismatch for {dtype} with {num_images} images"
+        )
+        print(
+            f"PASSED: TRT-LLM and HF pooled_output match for {dtype} with {num_images} images"
+        )
+
+        # 2. Last Hidden State (Before pooling/final LN in HF, shaped (batch, seq, hidden))
+        hf_last_hidden = hf_outputs.last_hidden_state
+        tllm_last_hidden = tllm_outputs.last_hidden_state
+        torch.testing.assert_close(
+            hf_last_hidden.float(),
+            tllm_last_hidden.float(),
+            rtol=rtol,
+            atol=atol,
+            msg=
+            f"FAILED: TRT-LLM and HF last_hidden_state mismatch for {dtype} with {num_images} images"
+        )
+        print(
+            f"PASSED: TRT-LLM and HF last_hidden_state match for {dtype} with {num_images} images"
+        )
+
+        # 3. Compare all hidden states if available
+        if tllm_outputs.hidden_states is not None and hf_outputs.hidden_states is not None:
+            self.assertEqual(len(hf_outputs.hidden_states),
+                             len(tllm_outputs.hidden_states),
+                             "Number of hidden states mismatch")
+            for i, (hf_hs, tllm_hs) in enumerate(
+                    zip(hf_outputs.hidden_states, tllm_outputs.hidden_states)):
+                self.assertEqual(hf_hs.shape, tllm_hs.shape,
+                                 f"Shape mismatch for hidden state {i}")
+                torch.testing.assert_close(
+                    hf_hs.float(),
+                    tllm_hs.float(),
+                    rtol=rtol,
+                    atol=atol,
+                    msg=
+                    f"FAILED: TRT-LLM and HF hidden_states mismatch for {dtype} with {num_images} images at layer {i}"
+                )
+                print(
+                    f"PASSED: TRT-LLM and HF hidden_states match for {dtype} with {num_images} images at layer {i}"
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittest/_torch/modeling/test_modeling_siglip.py
+++ b/tests/unittest/_torch/modeling/test_modeling_siglip.py
@@ -10,6 +10,7 @@ from transformers import SiglipVisionModel as HFSiglipVisionModel
 from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.models.modeling_siglip import SiglipVisionModel
 
+# use the default config from HF (https://github.com/huggingface/transformers/blob/main/src/transformers/models/siglip/configuration_siglip.py#L126-L147)
 SIGLIP_CONFIG = {
     "hidden_size": 768,
     "intermediate_size": 3072,
@@ -17,12 +18,16 @@ SIGLIP_CONFIG = {
     "num_attention_heads": 12,
     "image_size": 224,
     "patch_size": 16,
-    "hidden_act": "gelu",
+    "hidden_act": "gelu_pytorch_tanh",
     "layer_norm_eps": 1e-6,
     "hidden_dropout_prob": 0.0,
     "attention_probs_dropout_prob": 0.0,
     "num_channels": 3,
     "vision_use_head": False,
+}
+
+ACCURACY_CONFIG = {
+    torch.float16: (2e-2, 2e-2),
 }
 
 
@@ -105,8 +110,8 @@ class TestSiglipVisionModel(unittest.TestCase):
             torch.testing.assert_close(
                 hf_ref.float(),
                 tllm_res.float(),
-                rtol=2e-2,
-                atol=2e-2,
+                rtol=ACCURACY_CONFIG[dtype][0],
+                atol=ACCURACY_CONFIG[dtype][1],
                 msg=
                 f"FAILED: TRT-LLM and HF hidden_states mismatch for {dtype} with {num_images} images at layer {select_layer}"
             )

--- a/tests/unittest/_torch/modeling/test_modeling_siglip.py
+++ b/tests/unittest/_torch/modeling/test_modeling_siglip.py
@@ -7,7 +7,6 @@ from parameterized import parameterized
 from transformers import SiglipVisionConfig
 from transformers import SiglipVisionModel as HFSiglipVisionModel
 
-from tensorrt_llm._torch.attention_backend.utils import get_attention_backend
 from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.models.modeling_siglip import SiglipVisionModel
 
@@ -19,12 +18,10 @@ SIGLIP_CONFIG = {
     "image_size": 224,
     "patch_size": 16,
     "hidden_act": "gelu",
-    "layer_norm_eps": 1e-5,
+    "layer_norm_eps": 1e-6,
     "hidden_dropout_prob": 0.0,
     "attention_probs_dropout_prob": 0.0,
-    "initializer_range": 0.02,
     "num_channels": 3,
-    # "max_position_embeddings": 197,
     "vision_use_head": False,
 }
 
@@ -33,9 +30,10 @@ SIGLIP_CONFIG = {
 class Scenario:
     backend: str
     num_images: int
+    dtype: torch.dtype
 
     def __repr__(self) -> str:
-        return f"backend:{self.backend.lower()}_num_images:{self.num_images}"
+        return f"backend:{self.backend.lower()}_num_images:{self.num_images}_dtype:{self.dtype}"
 
 
 class TestSiglipVisionModel(unittest.TestCase):
@@ -44,28 +42,22 @@ class TestSiglipVisionModel(unittest.TestCase):
         super().setUp()
         torch.random.manual_seed(1234)
 
-    @parameterized.expand(
-        [
-            # Scenario(backend="VANILLA", num_images=1),
-            # Scenario(backend="TRTLLM", num_images=1),
-            Scenario(backend="TRTLLM", num_images=2),
-            # Scenario(backend="VANILLA", num_images=2),
-            # Scenario(backend="VANILLA", num_images=4),
-        ],
-        lambda testcase_func, param_num, param:
-        f"{testcase_func.__name__}[{param.args[0]}]")
+    @parameterized.expand([
+        Scenario(backend="VANILLA", num_images=2, dtype=torch.float16),
+        Scenario(backend="TRTLLM", num_images=2, dtype=torch.float16),
+        Scenario(backend="TRTLLM", num_images=21, dtype=torch.float16),
+    ], lambda testcase_func, param_num, param:
+                          f"{testcase_func.__name__}[{param.args[0]}]")
     def test_siglip_vision_allclose_to_hf(self, scenario: Scenario):
         """Compare output to HF"""
         backend = scenario.backend
         num_images = scenario.num_images
-        metadata_cls = get_attention_backend(backend).Metadata
+        dtype = scenario.dtype
+        device = torch.device('cuda')
 
         # Create configs
-        torch.random.manual_seed(0)
         config_dict = deepcopy(SIGLIP_CONFIG)
         hf_config = SiglipVisionConfig.from_dict(config_dict)
-        dtype = torch.float16
-        device = torch.device('cuda')
 
         # Prepare HF model
         hf_model = HFSiglipVisionModel(hf_config).to(dtype).to(device).eval()
@@ -86,7 +78,7 @@ class TestSiglipVisionModel(unittest.TestCase):
                                   hf_config.image_size,
                                   hf_config.image_size,
                                   device=device,
-                                  dtype=dtype) * 2.0
+                                  dtype=dtype)
 
         # Run HF inference
         with torch.inference_mode():
@@ -96,31 +88,14 @@ class TestSiglipVisionModel(unittest.TestCase):
                                   output_hidden_states=True)
 
         # Fill the metadata for tllm attn
-        seq_len = (hf_config.image_size // hf_config.patch_size)**2
-        request_ids = list(range(1, batch_size + 1))
-        prompt_lens = [seq_len] * batch_size
+        attn_metadata = tllm_model.prepare_attn_metadata(batch_size)
 
-        attn_metadata = metadata_cls(
-            seq_lens=torch.tensor([seq_len] * batch_size, dtype=torch.int),
-            num_contexts=batch_size,
-            max_num_requests=batch_size,
-            max_num_tokens=seq_len * batch_size,
-            kv_cache_manager=None,
-            request_ids=request_ids,
-            prompt_lens=prompt_lens,
+        # TRT-LLM model forward
+        tllm_outputs = tllm_model(
+            pixel_values=pixel_values,
+            attn_metadata=attn_metadata,
+            output_hidden_states=True,
         )
-        attn_metadata.max_seq_len = seq_len * batch_size
-        attn_metadata.prepare()
-
-        # Run inference
-        with torch.inference_mode():
-            print(f"pixel_values: {pixel_values.shape}")
-            # TRT-LLM model forward
-            tllm_outputs = tllm_model(
-                pixel_values=pixel_values,
-                attn_metadata=attn_metadata,
-                output_hidden_states=True,
-            )
 
         # compare all hidden states
         for select_layer in range(len(hf_outputs.hidden_states)):
@@ -130,7 +105,7 @@ class TestSiglipVisionModel(unittest.TestCase):
             torch.testing.assert_close(
                 hf_ref.float(),
                 tllm_res.float(),
-                rtol=1.5e-2,
+                rtol=2e-2,
                 atol=2e-2,
                 msg=
                 f"FAILED: TRT-LLM and HF hidden_states mismatch for {dtype} with {num_images} images at layer {select_layer}"
@@ -138,27 +113,6 @@ class TestSiglipVisionModel(unittest.TestCase):
             print(
                 f"PASSED: TRT-LLM and HF hidden_states match for {dtype} with {num_images} images at layer {select_layer}"
             )
-
-            # ----------DEBUG----------
-            # is_close = torch.allclose(hf_ref.float(),
-            #                           tllm_res.float(),
-            #                           rtol=1.5e-2,
-            #                           atol=1.5e-2)
-            # if not is_close:
-            #     print(
-            #         f"FAILED: TRT-LLM and HF hidden_states mismatch for {dtype} with {num_images} images at layer {select_layer}"
-            #     )
-            #     print(f"hf_ref: {hf_ref}")
-            #     print(f"tllm_res: {tllm_res}")
-            #     # relative error
-            #     rel_error = torch.norm(hf_ref.float() - tllm_res.float()) / torch.norm(hf_ref.float())
-            #     print(f"relative error: {rel_error}")
-            #     print("-" * 20)
-            # else:
-            #     print(
-            #         f"PASSED: TRT-LLM and HF match for {dtype} with {num_images} images at layer {select_layer}"
-            #     )
-            # ----------DEBUG----------
 
 
 if __name__ == "__main__":

--- a/tests/unittest/_torch/modeling/test_modeling_siglip.py
+++ b/tests/unittest/_torch/modeling/test_modeling_siglip.py
@@ -1,0 +1,165 @@
+import unittest
+from copy import deepcopy
+from dataclasses import dataclass
+
+import torch
+from parameterized import parameterized
+from transformers import SiglipVisionConfig
+from transformers import SiglipVisionModel as HFSiglipVisionModel
+
+from tensorrt_llm._torch.attention_backend.utils import get_attention_backend
+from tensorrt_llm._torch.model_config import ModelConfig
+from tensorrt_llm._torch.models.modeling_siglip import SiglipVisionModel
+
+SIGLIP_CONFIG = {
+    "hidden_size": 768,
+    "intermediate_size": 3072,
+    "num_hidden_layers": 12,
+    "num_attention_heads": 12,
+    "image_size": 224,
+    "patch_size": 16,
+    "hidden_act": "gelu",
+    "layer_norm_eps": 1e-5,
+    "hidden_dropout_prob": 0.0,
+    "attention_probs_dropout_prob": 0.0,
+    "initializer_range": 0.02,
+    "num_channels": 3,
+    # "max_position_embeddings": 197,
+    "vision_use_head": False,
+}
+
+
+@dataclass(repr=False)
+class Scenario:
+    backend: str
+    num_images: int
+
+    def __repr__(self) -> str:
+        return f"backend:{self.backend.lower()}_num_images:{self.num_images}"
+
+
+class TestSiglipVisionModel(unittest.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        torch.random.manual_seed(1234)
+
+    @parameterized.expand(
+        [
+            # Scenario(backend="VANILLA", num_images=1),
+            # Scenario(backend="TRTLLM", num_images=1),
+            Scenario(backend="TRTLLM", num_images=2),
+            # Scenario(backend="VANILLA", num_images=2),
+            # Scenario(backend="VANILLA", num_images=4),
+        ],
+        lambda testcase_func, param_num, param:
+        f"{testcase_func.__name__}[{param.args[0]}]")
+    def test_siglip_vision_allclose_to_hf(self, scenario: Scenario):
+        """Compare output to HF"""
+        backend = scenario.backend
+        num_images = scenario.num_images
+        metadata_cls = get_attention_backend(backend).Metadata
+
+        # Create configs
+        torch.random.manual_seed(0)
+        config_dict = deepcopy(SIGLIP_CONFIG)
+        hf_config = SiglipVisionConfig.from_dict(config_dict)
+        dtype = torch.float16
+        device = torch.device('cuda')
+
+        # Prepare HF model
+        hf_model = HFSiglipVisionModel(hf_config).to(dtype).to(device).eval()
+
+        # Prepare tllm pytorch model
+        model_config = ModelConfig(
+            pretrained_config=hf_config,
+            attn_backend=backend,
+        )
+
+        tllm_model = SiglipVisionModel(model_config).to(dtype).to(device)
+        tllm_model.load_weights(hf_model.state_dict())
+
+        # Prepare inputs - create random pixel values for images
+        batch_size = num_images
+        pixel_values = torch.rand(batch_size,
+                                  hf_config.num_channels,
+                                  hf_config.image_size,
+                                  hf_config.image_size,
+                                  device=device,
+                                  dtype=dtype) * 2.0
+
+        # Run HF inference
+        with torch.inference_mode():
+            # HF model forward
+            hf_outputs = hf_model(pixel_values=pixel_values,
+                                  output_attentions=False,
+                                  output_hidden_states=True)
+
+        # Fill the metadata for tllm attn
+        seq_len = (hf_config.image_size // hf_config.patch_size)**2
+        request_ids = list(range(1, batch_size + 1))
+        prompt_lens = [seq_len] * batch_size
+
+        attn_metadata = metadata_cls(
+            seq_lens=torch.tensor([seq_len] * batch_size, dtype=torch.int),
+            num_contexts=batch_size,
+            max_num_requests=batch_size,
+            max_num_tokens=seq_len * batch_size,
+            kv_cache_manager=None,
+            request_ids=request_ids,
+            prompt_lens=prompt_lens,
+        )
+        attn_metadata.max_seq_len = seq_len * batch_size
+        attn_metadata.prepare()
+
+        # Run inference
+        with torch.inference_mode():
+            print(f"pixel_values: {pixel_values.shape}")
+            # TRT-LLM model forward
+            tllm_outputs = tllm_model(
+                pixel_values=pixel_values,
+                attn_metadata=attn_metadata,
+                output_hidden_states=True,
+            )
+
+        # compare all hidden states
+        for select_layer in range(len(hf_outputs.hidden_states)):
+            hf_ref = hf_outputs.hidden_states[select_layer]
+            tllm_res = tllm_outputs.hidden_states[select_layer]
+
+            torch.testing.assert_close(
+                hf_ref.float(),
+                tllm_res.float(),
+                rtol=1.5e-2,
+                atol=2e-2,
+                msg=
+                f"FAILED: TRT-LLM and HF hidden_states mismatch for {dtype} with {num_images} images at layer {select_layer}"
+            )
+            print(
+                f"PASSED: TRT-LLM and HF hidden_states match for {dtype} with {num_images} images at layer {select_layer}"
+            )
+
+            # ----------DEBUG----------
+            # is_close = torch.allclose(hf_ref.float(),
+            #                           tllm_res.float(),
+            #                           rtol=1.5e-2,
+            #                           atol=1.5e-2)
+            # if not is_close:
+            #     print(
+            #         f"FAILED: TRT-LLM and HF hidden_states mismatch for {dtype} with {num_images} images at layer {select_layer}"
+            #     )
+            #     print(f"hf_ref: {hf_ref}")
+            #     print(f"tllm_res: {tllm_res}")
+            #     # relative error
+            #     rel_error = torch.norm(hf_ref.float() - tllm_res.float()) / torch.norm(hf_ref.float())
+            #     print(f"relative error: {rel_error}")
+            #     print("-" * 20)
+            # else:
+            #     print(
+            #         f"PASSED: TRT-LLM and HF match for {dtype} with {num_images} images at layer {select_layer}"
+            #     )
+            # ----------DEBUG----------
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittest/_torch/modeling/test_modeling_siglip.py
+++ b/tests/unittest/_torch/modeling/test_modeling_siglip.py
@@ -99,24 +99,25 @@ class TestSiglipVisionModel(unittest.TestCase):
         tllm_outputs = tllm_model(
             pixel_values=pixel_values,
             attn_metadata=attn_metadata,
-            output_hidden_states=True,
         )
 
-        # compare all hidden states
-        for select_layer in range(len(hf_outputs.hidden_states)):
-            hf_ref = hf_outputs.hidden_states[select_layer]
-            tllm_res = tllm_outputs.hidden_states[select_layer]
+        # Compare all hidden states
+
+        for i, (hf_hs, tllm_hs) in enumerate(
+                zip(hf_outputs.hidden_states, tllm_outputs)):
+            self.assertEqual(hf_hs.shape, tllm_hs.shape,
+                             f"Shape mismatch for hidden state {i}")
 
             torch.testing.assert_close(
-                hf_ref.float(),
-                tllm_res.float(),
+                hf_hs.float(),
+                tllm_hs.float(),
                 rtol=ACCURACY_CONFIG[dtype][0],
                 atol=ACCURACY_CONFIG[dtype][1],
                 msg=
-                f"FAILED: TRT-LLM and HF hidden_states mismatch for {dtype} with {num_images} images at layer {select_layer}, the mean value of this layer is {hf_ref.mean()}"
+                f"FAILED: TRT-LLM and HF hidden_states mismatch for {dtype} with {num_images} images at layer {i}, the mean value of this layer is {hf_hs.mean()}"
             )
             print(
-                f"PASSED: TRT-LLM and HF hidden_states match for {dtype} with {num_images} images at layer {select_layer}, the mean value of this layer is {hf_ref.mean()}"
+                f"PASSED: TRT-LLM and HF hidden_states match for {dtype} with {num_images} images at layer {i}, the mean value of this layer is {hf_hs.mean()}"
             )
 
 

--- a/tests/unittest/_torch/modeling/test_modeling_siglip.py
+++ b/tests/unittest/_torch/modeling/test_modeling_siglip.py
@@ -27,7 +27,7 @@ SIGLIP_CONFIG = {
 }
 
 ACCURACY_CONFIG = {
-    torch.float16: (2e-2, 2e-2),
+    torch.float16: (2e-2, 5e-2),
 }
 
 
@@ -113,10 +113,10 @@ class TestSiglipVisionModel(unittest.TestCase):
                 rtol=ACCURACY_CONFIG[dtype][0],
                 atol=ACCURACY_CONFIG[dtype][1],
                 msg=
-                f"FAILED: TRT-LLM and HF hidden_states mismatch for {dtype} with {num_images} images at layer {select_layer}"
+                f"FAILED: TRT-LLM and HF hidden_states mismatch for {dtype} with {num_images} images at layer {select_layer}, the mean value of this layer is {hf_ref.mean()}"
             )
             print(
-                f"PASSED: TRT-LLM and HF hidden_states match for {dtype} with {num_images} images at layer {select_layer}"
+                f"PASSED: TRT-LLM and HF hidden_states match for {dtype} with {num_images} images at layer {select_layer}, the mean value of this layer is {hf_ref.mean()}"
             )
 
 


### PR DESCRIPTION
# feat: add Pytorch support of Vision Encoder for multimodal models

This PR supports Siglip and Clip vision model for multimodal models. 

## Description
The changes in this PR can be categorized into these sections:
### Model Support
**Note: Please note that in this PR, Siglip and Clip vision model are tailored for multimodal models as the visual encoder.**
1.  Support Clip vision model
2. Support Siglip vision model
3. Integrate TRT-LLM Clip vision model into existing llava-next model

#### Clip Vision Model
Here is the components break down:
| Componenet           | Module Class        |
|----------------------|---------------------|
| Self Attn            | TRTLLM              |
| Layer Norm           | torch.nn.<br>Module |
| MLP                  | TRTLLM              |
| CLIPVisionEmbeddings | HF                  |

#### Siglip Vision Model
Here is the components break down:
| Componenet           | Module Class        |
|----------------------|---------------------|
| Self Attn            | TRTLLM              |
| Layer Norm           | torch.nn.<br>Module |
| MLP                  | TRTLLM              |
| SiglipVisionEmbeddings | HF                  |

### 

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->
### Unit Test
`tests/unittest/_torch/modeling/test_modeling_clip.py`
`tests/unittest/_torch/modeling/test_modeling_siglip.py`
### Integration Test
`tests/integration/defs/test_e2e.py::test_ptp_quickstart_multimodal[llava-v1.6-mistral-7b-llava-v1.6-mistral-7b-hf-image]`

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
