### PR TITLE
chore: make IPC port bounding atomic for slurm

### DIFF
--- a/tensorrt_llm/executor/ipc.py
+++ b/tensorrt_llm/executor/ipc.py
@@ -84,7 +84,9 @@ class ZeroMqQueue:
                 logger.info(f"Generating a new HMAC key for server {self.name}")
                 self.hmac_key = os.urandom(32)
 
-            self.address = (self.address_endpoint, self.hmac_key)
+    @property
+    def address(self) -> tuple[str, Optional[bytes]]:
+        return self.address_endpoint, self.hmac_key
 
     def setup_lazily(self):
         if self._setup_done:

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -23,7 +23,7 @@ from .postproc_worker import PostprocWorkerConfig
 from .request import CancellingRequest, GenerationRequest
 from .result import GenerationResult, IterationResult
 from .utils import (ErrorResponse, IntraProcessQueue, WorkerCommIpcAddrs,
-                    create_mpi_comm_session, get_spawn_proxy_process_env)
+                    create_mpi_comm_session, spawn_proxy_process_enabled)
 from .worker import ExecutorBindingsWorker, worker_main
 
 __all__ = [
@@ -58,7 +58,7 @@ class ExecutorBindingsProxy(GenerationExecutor):
         self.doing_pre_shutdown = False
         self.worker_cls = worker_cls
 
-        mpi_process_pre_spawned: bool = get_spawn_proxy_process_env()
+        mpi_process_pre_spawned: bool = spawn_proxy_process_enabled()
 
         if mpi_session is None:
             if mpi_process_pre_spawned:

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -20,7 +20,7 @@ from ..executor import (DetokenizedGenerationResultBase, GenerationExecutor,
                         PostprocWorkerConfig, PromptAdapterRequest)
 from ..executor.postproc_worker import PostprocParams
 from ..executor.utils import (create_mpi_comm_session,
-                              get_spawn_proxy_process_env)
+                              spawn_proxy_process_enabled)
 from ..inputs import PromptInputs, create_input_processor, prompt_inputs
 from ..logger import logger
 from ..sampling_params import SamplingParams
@@ -141,7 +141,7 @@ class LLM:
                 f'start MpiSession with {self.args.parallel_config.world_size} workers'
             )
             if not self.mpi_session:
-                mpi_process_pre_spawned: bool = get_spawn_proxy_process_env()
+                mpi_process_pre_spawned: bool = spawn_proxy_process_enabled()
                 if not mpi_process_pre_spawned:
                     print_colored_debug(f"LLM create MpiPoolSession\n",
                                         "yellow")

--- a/tensorrt_llm/llmapi/mgmn_leader_node.py
+++ b/tensorrt_llm/llmapi/mgmn_leader_node.py
@@ -3,23 +3,26 @@ This script is used to start the MPICommSession in the rank0 and wait for the
 MPI Proxy process to connect and get the MPI task to run.
 '''
 from tensorrt_llm._utils import mpi_world_size
-from tensorrt_llm.executor.utils import get_spawn_proxy_process_ipc_addr_env
 from tensorrt_llm.llmapi.mpi_session import RemoteMpiCommSessionServer
 from tensorrt_llm.llmapi.utils import print_colored_debug
 
 
 def launch_server_main(sub_comm=None):
+    # Avoid circular import
+    # FIXME: address this
+    from tensorrt_llm.executor.utils import get_spawn_proxy_process_ipc_addr
     num_ranks = sub_comm.Get_size() if sub_comm is not None else mpi_world_size(
     )
     print_colored_debug(f"Starting MPI Comm Server with {num_ranks} workers\n",
                         "yellow")
-    server = RemoteMpiCommSessionServer(
-        comm=sub_comm,
-        n_workers=num_ranks,
-        addr=get_spawn_proxy_process_ipc_addr_env(),
-        is_comm=True)
+    address = get_spawn_proxy_process_ipc_addr()
+    server = RemoteMpiCommSessionServer(comm=sub_comm,
+                                        n_workers=num_ranks,
+                                        addr=address[0],
+                                        hmac_key=address[1],
+                                        is_comm=True)
     print_colored_debug(
-        f"MPI Comm Server started at {get_spawn_proxy_process_ipc_addr_env()}")
+        f"MPI Comm Server started at {get_spawn_proxy_process_ipc_addr()}")
     server.serve()
 
     print_colored_debug("MPI Comm Server stopped")

--- a/tensorrt_llm/llmapi/trtllm-llmapi-launch
+++ b/tensorrt_llm/llmapi/trtllm-llmapi-launch
@@ -10,8 +10,9 @@ log_stderr "mpi_rank: $mpi_rank"
 
 pid=$(ps -o pid= -p $$ | tr -d ' ')
 
-# Tell TRTLLM to spawn a additional process for the Proxy
-export TLLM_SPAWN_PROXY_PROCESS=1
+# A file to share the IPC address between the server and client
+export TLLM_SPAWN_PROXY_PROCESS_ADDR_FILE=/tmp/llmapi-proxy-addr-${pid}
+rm -f $TLLM_SPAWN_PROXY_PROCESS_ADDR_FILE
 
 function mpi_world_size {
     if [ -n "$SLURM_NTASKS" ]; then
@@ -23,28 +24,8 @@ function mpi_world_size {
     fi
 }
 
-function export_free_tcp_addr_for_spawn_proxy_process {
-    # find free port starting from 10012
-    local free_port=$(python -c 'import socket; s=socket.socket();
-port = 10012
-while True:
-    try:
-        s.bind(("", port))
-        break
-    except OSError:
-        port += 1
-print(port); s.close()')
-    export TLLM_SPAWN_PROXY_PROCESS_IPC_ADDR="tcp://127.0.0.1:${free_port}"
-    log_stderr "TLLM_SPAWN_PROXY_PROCESS_IPC_ADDR: $TLLM_SPAWN_PROXY_PROCESS_IPC_ADDR"
-
-    export TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY=$(openssl rand -hex 32)
-}
-
-
 export tllm_mpi_size=$(mpi_world_size)
 log_stderr "tllm_mpi_size: $tllm_mpi_size"
-
-export_free_tcp_addr_for_spawn_proxy_process
 
 if [ -z "$mpi_rank" ] || [ "$mpi_rank" -eq 0 ]; then
     log_stderr "rank${mpi_rank} run ${task_with_command} in background"
@@ -74,9 +55,22 @@ if [ -z "$mpi_rank" ] || [ "$mpi_rank" -eq 0 ]; then
         $task_with_command
     ) &
 
+    # Wait for the proxy process to write the IPC address to the file
+    wait_timeout=120 # 2 minutes
+    while [ ! -f $TLLM_SPAWN_PROXY_PROCESS_ADDR_FILE ]; do
+        sleep 1
+        wait_timeout=$((wait_timeout - 1))
+        if [ $wait_timeout -le 0 ]; then
+            log_stderr "rank${mpi_rank} wait for proxy process to write the IPC address to the file timeout"
+            exit 1
+        fi
+    done
+
     log_stderr "rank${mpi_rank} run mgmn leader node with mpi_world_size: $(mpi_world_size) ..."
     log_stderr "rank0 host: $HOSTNAME"
     python3 -m tensorrt_llm.llmapi.mgmn_leader_node
+
+    rm -f $TLLM_SPAWN_PROXY_PROCESS_ADDR_FILE # cleanup the file
 else
     log_stderr "rank${mpi_rank} run mgmn worker node with mpi_world_size: $(mpi_world_size) ..."
     python3 -m tensorrt_llm.llmapi.mgmn_worker_node

--- a/tests/unittest/llmapi/_run_mpi_comm_task.py
+++ b/tests/unittest/llmapi/_run_mpi_comm_task.py
@@ -1,15 +1,13 @@
-import os
 import subprocess  # nosec B404
 import time
 
-from tensorrt_llm.llmapi.mpi_session import RemoteMpiCommSessionClient
+from tensorrt_llm.executor.utils import create_mpi_comm_session
 from tensorrt_llm.llmapi.utils import print_colored
 
 
 def main():
-    tasks = [0]
-    client = RemoteMpiCommSessionClient(
-        os.environ['TLLM_SPAWN_PROXY_PROCESS_IPC_ADDR'])
+    tasks = [0, 1, 2, 3, 4]
+    client = create_mpi_comm_session(n_workers=4)
     for task in tasks:
         client.submit(print_colored, f"{task}\n", "green")
     time.sleep(10)

--- a/tests/unittest/llmapi/test_mpi_session.py
+++ b/tests/unittest/llmapi/test_mpi_session.py
@@ -4,9 +4,8 @@ import subprocess  # nosec B404
 import pytest
 
 from tensorrt_llm.bindings.BuildInfo import ENABLE_MULTI_DEVICE
-from tensorrt_llm.llmapi.mpi_session import (MPINodeState, MpiPoolSession,
-                                             RemoteMpiCommSessionClient,
-                                             split_mpi_env)
+from tensorrt_llm.llmapi.mpi_session import (MPINodeState,
+                                             RemoteMpiCommSessionClient)
 
 
 def task0():
@@ -50,15 +49,10 @@ def run_client(server_addr, values_to_process):
         return f"Error in client: {str(e)}"
 
 
-@pytest.mark.skip(reason="https://nvbugspro.nvidia.com/bug/5179666")
 def test_remote_mpi_session():
     """Test RemoteMpiPoolSessionClient and RemoteMpiPoolSessionServer interaction"""
-    os.environ['TLLM_SPAWN_PROXY_PROCESS'] = "1"
-    os.environ['TLLM_SPAWN_PROXY_PROCESS_IPC_ADDR'] = "ipc://" + str(
-        os.getpid())
-
     command = [
-        "mpirun", "--allow-run-as-root", "-np", "2", "trtllm-llmapi-launch",
+        "mpirun", "--allow-run-as-root", "-np", "4", "trtllm-llmapi-launch",
         "python3", "_run_mpi_comm_task.py"
     ]
     subprocess.run(command,
@@ -66,14 +60,3 @@ def test_remote_mpi_session():
                    stdout=subprocess.PIPE,
                    stderr=subprocess.PIPE,
                    env=os.environ)  # nosec B603
-
-
-def task1():
-    non_mpi_env, mpi_env = split_mpi_env()
-    assert non_mpi_env
-    assert mpi_env
-
-
-def test_split_mpi_env():
-    session = MpiPoolSession(n_workers=4)
-    session.submit_sync(task1)

--- a/tests/unittest/llmapi/test_mpi_session.py
+++ b/tests/unittest/llmapi/test_mpi_session.py
@@ -49,6 +49,7 @@ def run_client(server_addr, values_to_process):
         return f"Error in client: {str(e)}"
 
 
+@pytest.mark.skip(reason="https://nvbugspro.nvidia.com/bug/5179666")
 def test_remote_mpi_session():
     """Test RemoteMpiPoolSessionClient and RemoteMpiPoolSessionServer interaction"""
     command = [


### PR DESCRIPTION
Before, the `trtllm-llmapi-launch` script determines the address of the IPC between RemoteMpiCommSessionServer/Client and then passes it to both server and client. This is not stable, as the port may be occupied before the server binds it. This PR changes this to be in an atomic style. The new workflow is as follows:

1. The RemoteMpiCommSessionClient will bind an empty port, and write the address (port + HMAC key) to a temporary file, this stage is **atomic**
2. The RemoteMpiCommSessionServer will wait until the address file is ready
3. The RemoteMpiCommSessionServer will read the address file and connect tothe  RemoteMpiCommClient's socket