### PR TITLE
[https://nvbugs/5178445][fix] Skip blackwell tests for sm120

### DIFF
--- a/tests/integration/defs/conftest.py
+++ b/tests/integration/defs/conftest.py
@@ -1912,7 +1912,7 @@ skip_pre_hopper = pytest.mark.skipif(
     reason="This test is not supported in pre-Hopper architecture")
 
 skip_pre_blackwell = pytest.mark.skipif(
-    get_sm_version() < 100,
+    get_sm_version() < 100 or get_sm_version() >= 120,
     reason="This test is not supported in pre-Blackwell architecture")
 
 skip_post_blackwell = pytest.mark.skipif(


### PR DESCRIPTION
Most blackwell features aren't supported on sm120 yet. Skipping for now.