### PR TITLE
[feat] Add relaxed sampling for spec decode

### DIFF
--- a/examples/pytorch/quickstart_advanced.py
+++ b/examples/pytorch/quickstart_advanced.py
@@ -95,6 +95,15 @@ def add_llm_args(parser):
     parser.add_argument('--spec_decode_algo', type=str, default=None)
     parser.add_argument('--spec_decode_nextn', type=int, default=1)
     parser.add_argument('--eagle_model_dir', type=str, default=None)
+    parser.add_argument("--spec_decode_use_relaxed_sampling",
+                        action='store_true',
+                        default=False)
+    parser.add_argument("--spec_decode_relaxed_sampling_delta",
+                        type=float,
+                        default=0.1)
+    parser.add_argument("--spec_decode_relaxed_sampling_max_topk",
+                        type=float,
+                        default=3)
 
     return parser
 
@@ -132,7 +141,12 @@ def setup_llm(args):
     elif spec_decode_algo == "EAGLE3":
         spec_config = EagleDecodingConfig(
             max_draft_len=args.spec_decode_nextn,
-            pytorch_eagle_weights_path=args.eagle_model_dir)
+            pytorch_eagle_weights_path=args.eagle_model_dir,
+            greedy_sampling=not args.spec_decode_use_relaxed_sampling,
+            pytorch_relaxed_sampling_probability_delta=args.
+            spec_decode_relaxed_sampling_delta,
+            pytorch_relaxed_sampling_max_topk=args.
+            spec_decode_relaxed_sampling_max_topk)
     else:
         spec_config = None
 

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -462,7 +462,7 @@ def create_py_executor_instance(dist,
         mapping, kv_cache_manager, attention_type, cache_transceiver_config)
 
     decoder = instantiate_decoder(model_engine, executor_config, spec_decoder,
-                                  pytorch_backend_config, mapping)
+                                  pytorch_backend_config, mapping, spec_config)
 
     return PyExecutor(resource_manager,
                       scheduler,
@@ -480,7 +480,7 @@ def create_py_executor_instance(dist,
 
 
 def instantiate_decoder(model_engine, executor_config, spec_decoder,
-                        pytorch_backend_config, mapping):
+                        pytorch_backend_config, mapping, spec_config):
     if mapping.cp_config.get('cp_type') == 'star_attention':
         assert pytorch_backend_config.attn_backend == "FLASHINFER_STAR_ATTENTION", "attention backend of star attention should be 'FLASHINFER_STAR_ATTENTION'"
         decoder = TorchStarAttentionDecoder(
@@ -498,5 +498,6 @@ def instantiate_decoder(model_engine, executor_config, spec_decoder,
     else:
         decoder = TorchDecoder(
             max_seq_len=model_engine.max_seq_len,
-            mixed_decoder=pytorch_backend_config.mixed_decoder)
+            mixed_decoder=pytorch_backend_config.mixed_decoder,
+            spec_config=spec_config)
     return decoder

--- a/tensorrt_llm/_torch/speculative/eagle3.py
+++ b/tensorrt_llm/_torch/speculative/eagle3.py
@@ -118,7 +118,9 @@ class Eagle3Decoder(TorchDecoder):
 
     def _batch_decode(self, scheduled_requests, model_outputs):
         logits = model_outputs["logits"]
-        new_tokens_device = torch.argmax(logits, dim=-1)
+        new_tokens_device, logits = self._get_new_tokens_from_logits(
+            scheduled_requests, logits)
+
         if "d2t" in model_outputs:
             d2t = model_outputs["d2t"]
             new_tokens_device = d2t[new_tokens_device] + new_tokens_device

--- a/tensorrt_llm/_torch/speculative/utils.py
+++ b/tensorrt_llm/_torch/speculative/utils.py
@@ -37,7 +37,7 @@ def get_spec_decoder(max_seq_len, spec_config):
     if spec_config.spec_dec_mode.is_mtp():
         return MTPDecoder(max_seq_len, spec_config)
     if spec_config.spec_dec_mode.is_eagle3():
-        return Eagle3Decoder(max_seq_len)
+        return Eagle3Decoder(max_seq_len, spec_config=spec_config)
     else:
         return None
 

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -227,6 +227,9 @@ class EagleDecodingConfig(DecodingBaseConfig):
     num_eagle_layers: Optional[int] = None
     max_non_leaves_per_layer: Optional[int] = None
     pytorch_eagle_weights_path: Optional[str] = None
+    # See SpecConfig for details on relaxed sampling fields.
+    pytorch_relaxed_sampling_probability_delta: float = 0.1
+    pytorch_relaxed_sampling_max_topk: int = 3
 
     @classmethod
     def from_dict(cls, data: dict):
@@ -1192,7 +1195,13 @@ class LlmArgs(BaseModel):
                     self.speculative_config = Eagle3Config(
                         max_draft_tokens=self.speculative_config.max_draft_len,
                         eagle_weights_path=self.speculative_config.
-                        pytorch_eagle_weights_path)
+                        pytorch_eagle_weights_path,
+                        greedy_sampling=self.speculative_config.greedy_sampling,
+                        relaxed_sampling_probability_delta=self.
+                        speculative_config.
+                        pytorch_relaxed_sampling_probability_delta,
+                        relaxed_sampling_max_topk=self.speculative_config.
+                        pytorch_relaxed_sampling_max_topk)
 
             elif isinstance(self.speculative_config, MTPDecodingConfig):
                 from tensorrt_llm._torch.speculative import MTPConfig

--- a/tests/unittest/_torch/speculative/test_eagle3.py
+++ b/tests/unittest/_torch/speculative/test_eagle3.py
@@ -13,10 +13,33 @@ from tensorrt_llm.llmapi import EagleDecodingConfig, KvCacheConfig
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from utils.llm_data import llm_models_root
 
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../../integration'))
+from defs.common import similar
+
+# We have the reference answers hard coded here for the following reasons:
+# 1. Note having run a reference LLM makes this test faster
+# 2. For the relaxed decoding, we can't really run a reference model. By definition,
+# the text you get from the model with relaxed decoding on will be different.
+# To avoid making this test brittle, we test a similarity score with a high threshold.
+# This gives us some wiggle room in case the kernels change, for example.
+_PROMPTS = ["The capital of France is", "The president of the United States is"]
+
+_TEXT_REF_EXACT = [
+    " a city of romance, art, fashion, and cuisine. Paris is a must-visit destination for anyone who loves history, architecture, and culture. From the",
+    " the head of state and head of government of the United States. The president serves a four-year term and is limited to two terms. The president is elected through",
+]
+
+_TEXT_REF_RELAXED = [
+    " a not-to-be-missed destination for any traveler. Paris, the City of love, art, fashion, and cuisine, is a must-visit destination",
+    " the head of state and head of the United States. The president serves a four-year term and is elected through the Electoral College system. The president is responsible for",
+]
+
 
 @pytest.mark.parametrize("use_cuda_graph", [True, False],
                          ids=["enable_graphs", "disable_graphs"])
-def test_llama_eagle3(use_cuda_graph: bool):
+@pytest.mark.parametrize("use_relaxed_decoding", [True, False],
+                         ids=["use_relaxed_decoding", "use_greedy_decoding"])
+def test_llama_eagle3(use_cuda_graph: bool, use_relaxed_decoding: bool):
     total_mem_gb = torch.cuda.get_device_properties(0).total_memory / 1e9
     if total_mem_gb < 35:
         pytest.skip("Not enough memory to load target + draft model")
@@ -37,7 +60,9 @@ def test_llama_eagle3(use_cuda_graph: bool):
 
     draft_len = 4
     spec_config = EagleDecodingConfig(
-        max_draft_len=draft_len, pytorch_eagle_weights_path=eagle_model_dir)
+        max_draft_len=draft_len,
+        pytorch_eagle_weights_path=eagle_model_dir,
+        greedy_sampling=not use_relaxed_decoding)
 
     llm_spec = LLM(model=target_model_dir,
                    pytorch_backend_config=pytorch_config,
@@ -69,26 +94,18 @@ def test_llama_eagle3(use_cuda_graph: bool):
         num_tokens = len(new_tokens)
 
     accept_rate = num_accepted / num_drafted
-    assert accept_rate > 0.25
+    assert accept_rate > 0.20
 
-    prompts = [
-        "The capital of France is", "The president of the United States is"
-    ]
-    results_spec = llm_spec.generate(prompts, sampling_params)
+    results_spec = llm_spec.generate(_PROMPTS, sampling_params)
     generated_text_spec = [result.outputs[0].text for result in results_spec]
     llm_spec.shutdown()
 
-    llm_ref = LLM(model=target_model_dir,
-                  pytorch_backend_config=pytorch_config,
-                  kv_cache_config=kv_cache_config)
+    generated_text_ref = _TEXT_REF_EXACT if not use_relaxed_decoding else _TEXT_REF_RELAXED
 
-    results_ref = llm_ref.generate(prompts, sampling_params)
-    generated_text_ref = [result.outputs[0].text for result in results_ref]
-    llm_ref.shutdown()
-
-    for text_spec, text_ref in zip(generated_text_spec, generated_text_ref):
-        # The spec decode algorithm currently guarantees identical results
-        assert text_spec == text_ref
+    for text_spec in generated_text_spec:
+        assert any(
+            similar(text_spec, text_ref, threshold=0.9)
+            for text_ref in generated_text_ref)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# [feat] Add relaxed sampling for spec decode

## Description

Add relaxed sampling. This is a lossy speculative decoding method that lets us accept draft tokens without matching the target model's probability distribution exactly. See the comments for the exact details on the algorithm.

Tested with Eagle3, but applies to all spec decode methods implemented with the "two model engine" framework. 

Note that this is intended to be used for reasoning models. You're supposed to disable relaxed decoding after the thinking phase is over. We can enable this in a followup.
 
## Test Coverage

Existing test extended to cover eagle3 + relaxed decoding with/without CUDA graphs.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
