### PR TITLE
chore: Partition LlmArgs into TorchLlmArgs and TrtLlmArgs

### DIFF
--- a/tensorrt_llm/__init__.py
+++ b/tensorrt_llm/__init__.py
@@ -45,7 +45,7 @@ from .auto_parallel import AutoParallelConfig, auto_parallel
 from .builder import BuildConfig, Builder, BuilderConfig, build
 from .disaggregated_params import DisaggregatedParams
 from .functional import Tensor, constant
-from .llmapi.llm import LLM, LlmArgs
+from .llmapi import LLM, LlmArgs
 from .logger import logger
 from .mapping import Mapping
 from .models.automodel import AutoConfig, AutoModelForCausalLM

--- a/tensorrt_llm/_torch/pyexecutor/config.py
+++ b/tensorrt_llm/_torch/pyexecutor/config.py
@@ -168,9 +168,9 @@ def update_executor_config(
 
     logger.info(f"{executor_config.pytorch_backend_config}")
 
-    if build_config is not None:
-        # TODO: move to pure-Python KvCacheConfig, and remove dependency on build_config.
-        executor_config.tokens_per_block = executor_config.tokens_per_block or build_config.plugin_config.tokens_per_block
+    build_config = build_config or BuildConfig()
+    # TODO: move to pure-Python KvCacheConfig, and remove dependency on build_config.
+    executor_config.tokens_per_block = executor_config.tokens_per_block or build_config.plugin_config.tokens_per_block
 
     executor_config.hf_model_dir = hf_model_dir
     executor_config.trt_engine_dir = trt_engine_dir

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -274,12 +274,20 @@ class PyExecutor:
         if start_worker:
             self.start_worker()
 
+    def _event_loop_wrapper(self):
+        try:
+            self.event_loop()
+        except Exception as e:
+            logger.error(f"Error in event loop: {e}")
+            logger.error(traceback.format_exc())
+            raise e
+
     def start_worker(self):
         self.worker_lock.acquire()
         try:
             if self.worker_started == False:
-                self.worker_thread = threading.Thread(target=self.event_loop,
-                                                      daemon=True)
+                self.worker_thread = threading.Thread(
+                    target=self._event_loop_wrapper, daemon=True)
                 self.worker_thread.start()
                 self.worker_started = True
         finally:

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -133,6 +133,7 @@ def create_py_executor(executor_config: ExecutorConfig,
             executor_config.scheduler_config.context_chunking_policy
             if executor_config.scheduler_config.context_chunking_policy
             is not None else ContextChunkingPolicy.FIRST_COME_FIRST_SERVED)
+        assert chunk_unit_size is not None, "chunk_unit_size must be set"
         ctx_chunk_config = ContextChunkingConfig(chunking_policy,
                                                  chunk_unit_size)
     else:

--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -705,6 +705,7 @@ def worker_main(
     except Exception as e:
         logger.error(f"Failed to initialize executor on rank {mpi_rank()}: {e}")
         logger.error(traceback.format_exc())
+        print_colored_debug(f"error: {traceback.format_exc()}", "red")
         if is_leader:
             request_error_queue.put(e)
         return

--- a/tensorrt_llm/llmapi/__init__.py
+++ b/tensorrt_llm/llmapi/__init__.py
@@ -6,9 +6,10 @@ from .llm import LLM, RequestOutput
 from .llm_args import (BatchingType, CacheTransceiverConfig, CalibConfig,
                        CapacitySchedulerPolicy, ContextChunkingPolicy,
                        DynamicBatchConfig, EagleDecodingConfig,
-                       ExtendedRuntimePerfKnobConfig, KvCacheConfig,
+                       ExtendedRuntimePerfKnobConfig, KvCacheConfig, LlmArgs,
                        LookaheadDecodingConfig, MedusaDecodingConfig,
-                       MTPDecodingConfig, NGramDecodingConfig, SchedulerConfig)
+                       MTPDecodingConfig, NGramDecodingConfig, SchedulerConfig,
+                       TorchLlmArgs, TrtLlmArgs)
 from .llm_utils import (BuildConfig, KvCacheRetentionConfig, QuantAlgo,
                         QuantConfig)
 from .mpi_session import MpiCommSession
@@ -41,4 +42,7 @@ __all__ = [
     'DynamicBatchConfig',
     'CacheTransceiverConfig',
     'NGramDecodingConfig',
+    'LlmArgs',
+    'TorchLlmArgs',
+    'TrtLlmArgs',
 ]

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -10,6 +10,7 @@ from typing import Any, List, Literal, Optional, Sequence, Union
 from tqdm import tqdm
 from transformers import PreTrainedTokenizerBase
 
+from tensorrt_llm.builder import BuildConfig
 from tensorrt_llm.inputs.data import TextPrompt
 from tensorrt_llm.inputs.registry import DefaultInputProcessor
 
@@ -165,8 +166,9 @@ class LLM:
             # Due to the Executor can only accept a engine path, we need to save the engine to a directory
             self._engine_dir: Optional[Path] = None
             self._executor: Optional[GenerationExecutor] = None
-            self._workspace = tempfile.TemporaryDirectory(
-                suffix="-llm-workspace", dir=self.args.workspace)
+            if self._on_trt_backend:
+                self._workspace = tempfile.TemporaryDirectory(
+                    suffix="-llm-workspace", dir=self.args.workspace)
 
             self._hf_model_dir: Optional[Path] = None
 
@@ -185,7 +187,7 @@ class LLM:
 
     @property
     def workspace(self) -> Path:
-        return Path(self._workspace.name)
+        return Path(self._workspace.name) if self._on_trt_backend else None
 
     def generate(
         self,
@@ -292,9 +294,12 @@ class LLM:
         """
         sampling_params = self._prepare_sampling_params(sampling_params)
 
-        if sampling_params.n > self.args.build_config.max_batch_size:
+        max_batch_size = self.args.max_batch_size
+        max_batch_size = max_batch_size or self.args.build_config.max_batch_size
+
+        if sampling_params.n > max_batch_size:
             raise ValueError(
-                f"SamplingParams.n ({sampling_params.n}) should not exceed max_batch_size ({self.args.build_config.max_batch_size})"
+                f"SamplingParams.n ({sampling_params.n}) should not exceed max_batch_size ({max_batch_size})"
             )
 
         inputs = prompt_inputs(inputs)
@@ -535,11 +540,19 @@ class LLM:
                                                       self.tokenizer)
         self.tokenizer = self.input_processor.tokenizer
 
-        max_batch_size = self.args.max_batch_size or self.args.build_config.max_batch_size
-        max_num_tokens = self.args.max_num_tokens or self.args.build_config.max_num_tokens
-        max_seq_len = self.args.max_seq_len or self.args.build_config.max_seq_len
+        max_batch_size = self.args.max_batch_size
+        max_num_tokens = self.args.max_num_tokens
+        max_seq_len = self.args.max_seq_len
+
+        build_config = self.args.build_config if self._on_trt_backend else BuildConfig(
+        )
+
+        max_batch_size = max_batch_size or build_config.max_batch_size
+        max_num_tokens = max_num_tokens or build_config.max_num_tokens
+        max_seq_len = max_seq_len or build_config.max_seq_len
+
         executor_config = tllm.ExecutorConfig(
-            max_beam_width=self.args.build_config.max_beam_width,
+            max_beam_width=self.args.max_beam_width,
             scheduler_config=PybindMirror.maybe_to_pybind(
                 self.args.scheduler_config),
             batching_type=PybindMirror.maybe_to_pybind(self.args.batching_type)
@@ -565,7 +578,7 @@ class LLM:
         if self.args.peft_cache_config is not None:
             executor_config.peft_cache_config = PybindMirror.maybe_to_pybind(
                 self.args.peft_cache_config)
-        elif self.args.build_config.plugin_config.lora_plugin:
+        elif self._on_trt_backend and self.args.build_config.plugin_config.lora_plugin:
             engine_config = EngineConfig.from_json_file(self._engine_dir /
                                                         "config.json")
             lora_config = engine_config.build_config.lora_config
@@ -593,10 +606,10 @@ class LLM:
         executor_config.normalize_log_probs = self.args.normalize_log_probs
         executor_config.enable_chunked_context = self.args.enable_chunked_prefill
         executor_config.max_beam_width = self.args.max_beam_width or self.args.build_config.max_beam_width
-        if self.args.extended_runtime_perf_knob_config is not None:
+        if self._on_trt_backend and self.args.extended_runtime_perf_knob_config is not None:
             executor_config.extended_runtime_perf_knob_config = PybindMirror.maybe_to_pybind(
                 self.args.extended_runtime_perf_knob_config)
-        if self.args.cache_transceiver_config is not None:
+        if self._on_trt_backend and self.args.cache_transceiver_config is not None:
             executor_config.cache_transceiver_config = PybindMirror.maybe_to_pybind(
                 self.args.cache_transceiver_config)
         from tensorrt_llm._torch.pyexecutor.config import update_executor_config
@@ -605,7 +618,8 @@ class LLM:
             backend=self.args.backend,
             pytorch_backend_config=self.pytorch_backend_config,
             mapping=self.args.parallel_config.to_mapping(),
-            build_config=self.args.build_config,
+            build_config=self.args.build_config
+            if self._on_trt_backend else None,
             speculative_config=self.args.speculative_config,
             hf_model_dir=self._hf_model_dir,
             trt_engine_dir=self._engine_dir,
@@ -613,8 +627,9 @@ class LLM:
             max_seq_len=max_seq_len)
         executor_config.llm_parallel_config = self.args.parallel_config
         return_logits = self.args.gather_generation_logits or (
-            self.args.build_config
+            self._on_trt_backend and self.args.build_config
             and self.args.build_config.gather_context_logits)
+
         self._executor = self._executor_cls.create(
             self._engine_dir,
             executor_config=executor_config,
@@ -630,6 +645,10 @@ class LLM:
             ),
             is_llm_executor=True,
             lora_config=self.args.lora_config)
+
+    @property
+    def _on_trt_backend(self) -> bool:
+        return isinstance(self.args, TrtLlmArgs)
 
     def _try_load_tokenizer(self) -> Optional[TokenizerBase]:
         if self.args.skip_tokenizer_init:

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -115,7 +115,7 @@ class LLM:
                                                      None)
 
             llm_args_cls = TorchLlmArgs if kwargs.get(
-                'backend', None) == 'torch' else TrtLlmArgs
+                'backend', None) == 'pytorch' else TrtLlmArgs
 
             self.args = llm_args_cls.from_kwargs(
                 model=model,

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -27,8 +27,9 @@ from ..executor.utils import (create_mpi_comm_session,
 from ..inputs import PromptInputs, create_input_processor, prompt_inputs
 from ..logger import logger
 from ..sampling_params import SamplingParams
-from .llm_args import LLMARGS_EXPLICIT_DOCSTRING, PybindMirror
-from .llm_utils import (CachedModelLoader, KvCacheRetentionConfig, LlmArgs,
+from .llm_args import (LLMARGS_EXPLICIT_DOCSTRING, PybindMirror, TorchLlmArgs,
+                       TrtLlmArgs)
+from .llm_utils import (CachedModelLoader, KvCacheRetentionConfig,
                         LlmBuildStats, ModelLoader, _ModelRuntimeContext)
 from .mpi_session import MpiPoolSession, external_mpi_comm_available
 from .tokenizer import TokenizerBase, _xgrammar_tokenizer_info
@@ -112,7 +113,11 @@ class LLM:
         try:
             self.pytorch_backend_config = kwargs.pop('pytorch_backend_config',
                                                      None)
-            self.args = LlmArgs.from_kwargs(
+
+            llm_args_cls = TorchLlmArgs if kwargs.get(
+                'backend', None) == 'torch' else TrtLlmArgs
+
+            self.args = llm_args_cls.from_kwargs(
                 model=model,
                 tokenizer=tokenizer,
                 tokenizer_mode=tokenizer_mode,

--- a/tests/unittest/llmapi/apps/_test_trtllm_serve_multimodal_example.py
+++ b/tests/unittest/llmapi/apps/_test_trtllm_serve_multimodal_example.py
@@ -27,6 +27,7 @@ def temp_extra_llm_api_options_file(request):
                 "enable_block_reuse": False,
                 "free_gpu_memory_fraction": 0.6,
             },
+            "max_num_tokens": 16384,  # for pytorch backend
             # NOTE: This is for video support.
             "build_config": {
                 "max_num_tokens": 16384,

--- a/tests/unittest/llmapi/test_llm_utils.py
+++ b/tests/unittest/llmapi/test_llm_utils.py
@@ -9,12 +9,12 @@ from tensorrt_llm.llmapi.llm_utils import *
 from .test_llm import llama_model_path
 # isort: on
 
-from tensorrt_llm.llmapi.llm_utils import *
+from tensorrt_llm.llmapi.llm_args import *
 
 
 def test_ModelLoader():
     kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.4)
-    args = LlmArgs(model=llama_model_path, kv_cache_config=kv_cache_config)
+    args = TrtLlmArgs(model=llama_model_path, kv_cache_config=kv_cache_config)
     args._setup()
 
     # Test with HF model


### PR DESCRIPTION
This is the first step for landing the TorchLlmArgs, Here is the plan:

1. Partition the LlmArgs into TorchLlmArgs, TrtLlmArgs (the current stage)
2. Expand the PytorchConfig into TorchLlmArgs
3. Replace ExecutorConfig in PyT with TorchLlmArgs
4. Rename TorchLlmArgs to LlmArgs eventually when it is ready to be the default.

This PR also refined the YAML support in LlmArgs with the Pydantic builtin support in `update_llm_args_with_extra_options`.