### PR TITLE
refactor: Clean up allreduce module for Deepseek V3 model

### DIFF
--- a/cpp/tensorrt_llm/thop/allreduceOp.cpp
+++ b/cpp/tensorrt_llm/thop/allreduceOp.cpp
@@ -273,11 +273,10 @@ private:
         torch::optional<torch::Tensor> const& residual, torch::optional<torch::Tensor> const& norm_weight,
         torch::optional<torch::Tensor> const& scale, torch::optional<torch::Tensor> const& bias) noexcept
     {
+
         auto stream = at::cuda::getCurrentCUDAStream(input.get_device());
         int size = input.numel();
         int hidden_size = input.size(-1);
-
-        torch::Tensor output = torch::empty_like(input);
 
         if (mOp == AllReduceFusionOp::RESIDUAL_RMS_NORM)
         {
@@ -815,14 +814,14 @@ std::vector<torch::Tensor> allreduce(torch::Tensor input, torch::optional<torch:
 
 // residual [m, hidden_dim]
 // norm_weight [hidden_dim]
-// moe_reduction_device_num_experts [1]
-// moe_reduction_scale_input [global_num_experts, m]
-// moe_reduction_active_experts_token_input [device_num_experts, m, hidden_dim]
-// moe_reduction_token_input [m, hidden_dim]
-std::vector<torch::Tensor> moe_allreduce(torch::Tensor residual, torch::Tensor norm_weight,
-    torch::Tensor moe_reduction_device_num_experts, torch::Tensor moe_reduction_scale_input,
-    torch::Tensor moe_reduction_active_experts_token_input, torch::Tensor moe_reduction_token_input,
-    torch::optional<torch::Tensor> workspace, int64_t const rank, int64_t const nranks, double const eps)
+// device_num_experts [1]
+// scale_input [global_num_experts, m]
+// active_experts_token_input [device_num_experts, m, hidden_dim]
+// token_input [m, hidden_dim]
+std::vector<torch::Tensor> moe_allreduce(torch::Tensor const& residual, torch::Tensor const& norm_weight,
+    torch::Tensor const& device_num_experts, torch::Tensor const& scale_input,
+    torch::Tensor const& active_experts_token_input, torch::Tensor const& token_input, torch::Tensor workspace,
+    int64_t const rank, int64_t const nranks, double const eps)
 {
     auto allreduce_fusion_params = tensorrt_llm::kernels::ar_fusion::moe::MoeReductionAllReduceFusionParams();
 
@@ -833,14 +832,13 @@ std::vector<torch::Tensor> moe_allreduce(torch::Tensor residual, torch::Tensor n
 
     allreduce_fusion_params.nranks = static_cast<int>(nranks);
     allreduce_fusion_params.rank = static_cast<int>(rank);
-    allreduce_fusion_params.dtype
-        = tensorrt_llm::runtime::TorchUtils::dataType(moe_reduction_token_input.scalar_type());
+    allreduce_fusion_params.dtype = tensorrt_llm::runtime::TorchUtils::dataType(token_input.scalar_type());
     // size: num_token * hidden_dim
-    allreduce_fusion_params.size = static_cast<int>(moe_reduction_token_input.numel());
-    allreduce_fusion_params.hidden_dim = static_cast<int>(moe_reduction_active_experts_token_input.size(-1));
+    allreduce_fusion_params.size = static_cast<int>(token_input.numel());
+    allreduce_fusion_params.hidden_dim = static_cast<int>(active_experts_token_input.size(-1));
 
     // workspace: AR scratch space
-    allreduce_fusion_params.workspace = reinterpret_cast<void**>(workspace.value().mutable_data_ptr());
+    allreduce_fusion_params.workspace = reinterpret_cast<void**>(workspace.mutable_data_ptr());
 
     allreduce_fusion_params.rms_gamma = norm_weight.data_ptr();
     allreduce_fusion_params.rms_eps = static_cast<float>(eps);
@@ -850,15 +848,13 @@ std::vector<torch::Tensor> moe_allreduce(torch::Tensor residual, torch::Tensor n
 
     // MOE Reduction specific params
     allreduce_fusion_params.allreduce_in = nullptr; // for safety, set nullptr
-    allreduce_fusion_params.moe_reduction_device_num_experts
-        = static_cast<int*>(moe_reduction_device_num_experts.data_ptr());
-    allreduce_fusion_params.moe_reduction_scale_input = static_cast<float*>(moe_reduction_scale_input.data_ptr());
-    allreduce_fusion_params.moe_reduction_active_experts_token_input
-        = moe_reduction_active_experts_token_input.data_ptr();
-    allreduce_fusion_params.moe_reduction_token_input = moe_reduction_token_input.data_ptr();
+    allreduce_fusion_params.moe_reduction_device_num_experts = static_cast<int*>(device_num_experts.data_ptr());
+    allreduce_fusion_params.moe_reduction_scale_input = static_cast<float*>(scale_input.data_ptr());
+    allreduce_fusion_params.moe_reduction_active_experts_token_input = active_experts_token_input.data_ptr();
+    allreduce_fusion_params.moe_reduction_token_input = token_input.data_ptr();
 
     // output tensors
-    torch::Tensor norm_out = torch::empty_like(moe_reduction_token_input);
+    torch::Tensor norm_out = torch::empty_like(token_input);
     torch::Tensor residual_out = torch::empty_like(residual);
 
     allreduce_fusion_params.norm_out = norm_out.mutable_data_ptr();
@@ -874,15 +870,29 @@ std::vector<torch::Tensor> moe_allreduce(torch::Tensor residual, torch::Tensor n
 TORCH_LIBRARY_FRAGMENT(trtllm, m)
 {
     m.def(
-        "allreduce(Tensor input, Tensor? residual, Tensor? norm_weight, Tensor? scale, Tensor? bias, Tensor? "
-        "workspace, int[] group, int "
-        "strategy, int op, float eps) -> Tensor[]");
+        "allreduce("
+        "Tensor input,"
+        "Tensor? residual,"
+        "Tensor? norm_weight,"
+        "Tensor? scale,"
+        "Tensor? bias,"
+        "Tensor? workspace,"
+        "int[] group,"
+        "int strategy,"
+        "int op,"
+        "float eps) -> Tensor[]");
     m.def(
-        "moe_allreduce(Tensor residual, Tensor norm_weight, Tensor "
-        "moe_reduction_device_num_experts, "
-        "Tensor moe_reduction_scale_input, Tensor moe_reduction_active_experts_token_input, Tensor "
-        "moe_reduction_token_input, Tensor? workspace, "
-        "int rank, int nranks, float eps) -> Tensor[]");
+        "moe_allreduce("
+        "Tensor residual,"
+        "Tensor norm_weight,"
+        "Tensor device_num_experts,"
+        "Tensor scale_input,"
+        "Tensor active_experts_token_input,"
+        "Tensor token_input,"
+        "Tensor workspace,"
+        "int rank,"
+        "int nranks,"
+        "float eps) -> Tensor[]");
 }
 
 TORCH_LIBRARY_IMPL(trtllm, CUDA, m)

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -53,10 +53,10 @@ def _register_fake():
             return [torch.empty_like(input)]
 
     @torch.library.register_fake("trtllm::moe_allreduce")
-    def _(residual, norm_weight, moe_reduction_device_num_experts,
-          moe_reduction_scale_input, moe_reduction_active_experts_token_input,
-          moe_reduction_token_input, workspace, rank, nranks, eps):
-        norm_out = torch.empty_like(moe_reduction_token_input)
+    def _(residual, norm_weight, device_num_experts, scale_input,
+          active_experts_token_input, token_input, workspace, rank, nranks,
+          eps):
+        norm_out = torch.empty_like(token_input)
         residual_out = torch.empty_like(residual)
         return [norm_out, residual_out]
 

--- a/tensorrt_llm/_torch/distributed/__init__.py
+++ b/tensorrt_llm/_torch/distributed/__init__.py
@@ -1,11 +1,10 @@
 from .communicator import Distributed, MPIDist, PPComm, TorchDist
 from .ops import (AllReduce, AllReduceFusionOp, AllReduceParams,
-                  AllReduceStrategy, DeepseekAllReduce, allgather,
+                  AllReduceStrategy, DeepseekAllReduce, MoEAllReduce, allgather,
                   reducescatter, userbuffers_allreduce_finalize)
 
 __all__ = [
     "allgather",
-    "allreduce",
     "reducescatter",
     "userbuffers_allreduce_finalize",
     "AllReduce",
@@ -13,6 +12,7 @@ __all__ = [
     "AllReduceFusionOp",
     "AllReduceStrategy",
     "DeepseekAllReduce",
+    "MoEAllReduce",
     "TorchDist",
     "PPComm",
     "MPIDist",

--- a/tests/unittest/_torch/multi_gpu/test_allreduce.py
+++ b/tests/unittest/_torch/multi_gpu/test_allreduce.py
@@ -26,7 +26,7 @@ from utils.util import skip_pre_blackwell
 
 import tensorrt_llm
 from tensorrt_llm._torch.distributed import (AllReduce, AllReduceFusionOp,
-                                             AllReduceParams)
+                                             AllReduceParams, MoEAllReduce)
 from tensorrt_llm._torch.modules.linear import Linear, TensorParallelMode
 from tensorrt_llm._torch.modules.rms_norm import RMSNorm
 from tensorrt_llm.mapping import Mapping
@@ -66,6 +66,21 @@ def run_single_rank(tensor_parallel_size, single_rank_forward_func, input,
     try:
         single_rank_forward_func(input, residual, hidden_size, dtype,
                                  tensor_parallel_size, rank, weights, fusion_op)
+    except Exception:
+        traceback.print_exc()
+        raise
+    return True
+
+
+def run_moe_single_rank(tensor_parallel_size, single_rank_forward_func,
+                        token_input, residual, active_experts_token_input,
+                        scale, l0_weight):
+    rank = tensorrt_llm.mpi_rank()
+    torch.cuda.set_device(rank)
+    try:
+        single_rank_forward_func(token_input, residual,
+                                 active_experts_token_input, scale,
+                                 tensor_parallel_size, rank, l0_weight)
     except Exception:
         traceback.print_exc()
         raise
@@ -238,28 +253,29 @@ def run_allreduce_op(x: torch.Tensor, residual: torch.Tensor, hidden_size: int,
             assert mismatch_percentage < 0.01, f"Large mismatched elements encountered"
 
 
-@skip_pre_blackwell
 @pytest.mark.skipif(torch.cuda.device_count() < 2,
                     reason="Requires at least 2 GPUs for this test")
 @pytest.mark.parametrize("seq_len", [16, 256], ids=lambda x: f"seqlen:{x}")
 @pytest.mark.parametrize("hidden_size", [128, 7168],
                          ids=lambda x: f"hidden:{x}")
-@pytest.mark.parametrize("fusion_op", [
-    AllReduceFusionOp.NONE,
-    AllReduceFusionOp.RESIDUAL_RMS_NORM,
-    AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_FP8,
-    AllReduceFusionOp.RESIDUAL_RMS_NORM_OUT_QUANT_FP8,
-    AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_NVFP4,
-    AllReduceFusionOp.RESIDUAL_RMS_NORM_OUT_QUANT_NVFP4,
-],
-                         ids=[
-                             "none",
-                             "residual_rms_norm",
-                             "residual_rms_norm_quant_fp8",
-                             "residual_rms_norm_out_quant_fp8",
-                             "residual_rms_norm_quant_nvfp4",
-                             "residual_rms_norm_out_quant_nvfp4",
-                         ])
+@pytest.mark.parametrize(
+    "fusion_op",
+    [
+        pytest.param(AllReduceFusionOp.NONE, id="none"),
+        pytest.param(AllReduceFusionOp.RESIDUAL_RMS_NORM,
+                     id="residual_rms_norm"),
+        pytest.param(AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_FP8,
+                     id="residual_rms_norm_quant_fp8"),
+        pytest.param(AllReduceFusionOp.RESIDUAL_RMS_NORM_OUT_QUANT_FP8,
+                     id="residual_rms_norm_out_quant_fp8"),
+        pytest.param(AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_NVFP4,
+                     id="residual_rms_norm_quant_nvfp4",
+                     marks=skip_pre_blackwell),
+        pytest.param(AllReduceFusionOp.RESIDUAL_RMS_NORM_OUT_QUANT_NVFP4,
+                     id="residual_rms_norm_out_quant_nvfp4",
+                     marks=skip_pre_blackwell),
+    ],
+)
 def test_allreduce_fusion_patterns(seq_len, hidden_size, fusion_op):
     torch.manual_seed(0)
     dtype = torch.bfloat16
@@ -272,6 +288,166 @@ def test_allreduce_fusion_patterns(seq_len, hidden_size, fusion_op):
             run_single_rank,
             *zip(*[(tensor_parallel_size, run_allreduce_op, x, residual,
                     [linear_weight], hidden_size, dtype, fusion_op)] *
+                 tensor_parallel_size),
+        )
+        for r in results:
+            assert r is True
+
+
+@torch.inference_mode()
+def run_moe_allreduce_op(token_input: torch.Tensor, residual: torch.Tensor,
+                         active_experts_token_input: torch.Tensor,
+                         scale: torch.Tensor, tensor_parallel_size: int,
+                         tensor_parallel_rank: int, l0_weight: torch.Tensor):
+    torch.manual_seed(42)
+
+    # * token_input:
+    #   [num_token, 7168]
+    #   different val for different device
+    # * active_experts_token_input
+    #   [num_global_exp, num_token, 7168]
+    #   need to slice to [num_device_exp, num_token, 7168] before use
+    # * scale
+    #   [num_global_exp, num_token]
+    #   per expert per token scale
+    #   need to slice to [num_device_exp, num_token, 7168] before use
+    #   different value for each device
+
+    token_input = token_input.cuda()
+    residual = residual.cuda()
+    active_experts_token_input = active_experts_token_input.cuda()
+    scale = scale.cuda()
+
+    dtype = token_input.dtype
+    num_global_experts = scale.size(0)
+    num_device_experts = num_global_experts // tensor_parallel_size
+    tensor_num_device_experts = torch.tensor(num_device_experts,
+                                             dtype=torch.int32,
+                                             device="cuda")
+    # num_token = token_input.shape[0]
+    hidden_size = token_input.shape[1]
+
+    # Setup parameters
+    eps = 1e-5
+    norm_weight = torch.randn((hidden_size, ), dtype=dtype, device="cuda")
+
+    # Initialize MoEAllreduce
+    moe_allreduce = MoEAllReduce(mapping=Mapping(
+        world_size=tensor_parallel_size,
+        tp_size=tensor_parallel_size,
+        rank=tensor_parallel_rank,
+    )).cuda()
+
+    # Initialize RMSNorm
+    norm = RMSNorm(hidden_size=hidden_size, eps=eps, dtype=dtype).cuda()
+    norm.weight.data.copy_(norm_weight)
+
+    l0 = Linear(
+        in_features=hidden_size,
+        out_features=hidden_size,
+        bias=False,
+        dtype=dtype,
+        mapping=Mapping(
+            world_size=tensor_parallel_size,
+            tp_size=tensor_parallel_size,
+            rank=tensor_parallel_rank,
+        ),
+        tensor_parallel_mode=TensorParallelMode.ROW,
+    ).cuda()
+    l0.load_weights([dict(weight=l0_weight)])
+    token_input_chunked = torch.chunk(token_input.clone(),
+                                      tensor_parallel_size,
+                                      dim=-1)
+    fc2_output = l0(
+        token_input_chunked[tensor_parallel_rank],
+        all_reduce_params=AllReduceParams(
+            fusion_op=AllReduceFusionOp.RESIDUAL_RMS_NORM,
+            residual=residual,
+            norm_weight=norm_weight,
+            eps=eps,
+            enable_allreduce=False,
+        ),
+    )
+
+    # Define fusion operation
+    # slice [num_global_exp, num_token, 7168] -> [num_device_exp, num_token, 7168]
+    active_experts_token_input_parallel = torch.chunk(
+        active_experts_token_input.clone(), tensor_parallel_size, dim=0)
+    active_experts_token_equalized = active_experts_token_input_parallel[
+        tensor_parallel_rank]
+
+    # slice [num_global_exp, num_token] -> [num_device_exp, num_token]
+    scale_parallel = torch.chunk(scale.clone(), tensor_parallel_size, dim=0)
+    scale_equalized = scale_parallel[tensor_parallel_rank]
+
+    # Run with fusion
+    output_hidden_states, output_residual = moe_allreduce(
+        residual,
+        norm_weight,
+        tensor_num_device_experts,
+        scale_equalized,
+        active_experts_token_equalized,
+        fc2_output,
+        eps,
+    )
+
+    torch_l0 = torch.nn.Linear(in_features=hidden_size,
+                               out_features=hidden_size,
+                               bias=False,
+                               dtype=dtype)
+    torch_l0.weight.data.copy_(l0_weight)
+    torch_l0.cuda()
+
+    torch_linear_output = torch_l0(token_input)
+    # Verify with torch reference implementation
+    expert_reduction = torch.sum(active_experts_token_input *
+                                 scale.unsqueeze(-1),
+                                 dim=0)
+    torch_before_residual = expert_reduction + torch_linear_output
+    torch_residual = torch_before_residual + residual
+    torch_residual = torch_residual.to(torch.float32)
+    torch_output_hidden_states = rms_norm(torch_residual, norm_weight,
+                                          eps).to(dtype)
+
+    # Verify results are close to reference
+    torch.testing.assert_close(
+        output_hidden_states,
+        torch_output_hidden_states,
+        rtol=0.2,
+        atol=0.2,
+    )
+
+    return True
+
+
+@torch.inference_mode()
+def test_moe_allreduce_patterns():
+    torch.manual_seed(42)
+
+    seq_len = 16
+    hidden_size = 7168
+    dtype = torch.bfloat16
+    tensor_parallel_size = 2
+    num_global_experts = 4
+
+    # [num_token, 7168]
+    token_input = torch.randn((seq_len, hidden_size), dtype=dtype)
+    # [num_global_exp, num_token, 7168]
+    active_experts_token_input = torch.randn(
+        (num_global_experts, seq_len, hidden_size), dtype=dtype, device="cuda")
+    # [num_global_exp, num_token]
+    scale = torch.randn((num_global_experts, seq_len),
+                        dtype=torch.float32,
+                        device="cuda")
+    # [num_token, 7168]
+    residual = torch.randn_like(token_input)
+
+    l0_weight = torch.randn((hidden_size, hidden_size), dtype=dtype)
+    with MPIPoolExecutor(max_workers=tensor_parallel_size) as executor:
+        results = executor.map(
+            run_moe_single_rank,
+            *zip(*[(tensor_parallel_size, run_moe_allreduce_op, token_input,
+                    residual, active_experts_token_input, scale, l0_weight)] *
                  tensor_parallel_size),
         )
         for r in results:


### PR DESCRIPTION
* Replace deepseek_allreduce op with the new unified allreduce op and moe_allreduce op.
* Minor revision of moe_allreduce op arg names.