### PR TITLE
fix: [https://nvbugspro.nvidia.com/bug/5242406][fix] Fix fp8 kvcache support

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/flashinfer.py
+++ b/tensorrt_llm/_torch/attention_backend/flashinfer.py
@@ -422,11 +422,9 @@ class FlashInferAttention(AttentionBackend[FlashInferAttentionMetadata]):
     def update_quant_config(self, new_quant_config: Optional[QuantConfig]):
         self.quant_config = new_quant_config
         self.has_fp8_kv_cache = False
-        if self.quant_config and self.quant_config.layer_quant_mode.has_any_quant(
-        ):
-            quant_mode = self.quant_config.layer_quant_mode
-            if quant_mode.has_fp8_kv_cache():
-                self.has_fp8_kv_cache = True
+        if self.quant_config:
+            self.has_fp8_kv_cache = self.quant_config.layer_quant_mode.has_fp8_kv_cache(
+            )
 
     def forward(self,
                 q: torch.Tensor,

--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -108,10 +108,18 @@ class ModelConfig(Generic[TConfig]):
                 mixed_quant_config_file = model_dir / 'quant_cfg.json'
                 with open(mixed_quant_config_file) as fm:
                     mixed_quant_configs = json.load(fm)
+                    # kv_cache_quant_algo is global regardless of MIXED_PRECISION
                     kv_cache_quant_algo = mixed_quant_configs[
                         'kv_cache_quant_algo']
                     mixed_quant_configs = mixed_quant_configs[
                         'quantized_layers']
+                    if kv_cache_quant_algo is not None and quant_config.kv_cache_quant_algo is not None:
+                        if kv_cache_quant_algo != quant_config.kv_cache_quant_algo:
+                            raise RuntimeError(
+                                f"The kvcache config in 'quant_cfg.json', {kv_cache_quant_algo},"
+                                f"is different from 'hf_quant_config.json', {quant_config.kv_cache_quant_algo}!"
+                            )
+                    kv_cache_quant_algo = kv_cache_quant_algo or quant_config.kv_cache_quant_algo
 
                     for layer in mixed_quant_configs:
                         config = QuantConfig()

--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -11,9 +11,9 @@ from torch.utils._python_dispatch import TorchDispatchMode
 from torch.utils._pytree import tree_any_only
 from tqdm import tqdm
 
-from tensorrt_llm.mapping import Mapping
-
 from ...logger import logger
+from ...mapping import Mapping
+from ...models.modeling_utils import QuantConfig
 from ..attention_backend import AttentionMetadata
 from ..model_config import ModelConfig, TConfig
 from ..modules.attention import Attention
@@ -432,7 +432,13 @@ class DecoderModelForCausalLM(nn.Module,
                 # TODO: support MLA
 
         # 2. skip quant for modules in QuantConfig.exclude_modules
+        # kv_cache_quant_algo takes precedence over exclude_modules
         quant_config = self.model_config.quant_config
+        kv_cache_quant_algo = None
+        if quant_config:
+            kv_cache_quant_algo = quant_config.kv_cache_quant_algo
+        new_config = QuantConfig(kv_cache_quant_algo=kv_cache_quant_algo)
+
         if quant_config is not None:
             if quant_config.exclude_modules is not None:
                 for name, module in self.named_modules():
@@ -440,7 +446,7 @@ class DecoderModelForCausalLM(nn.Module,
                         name)
                     if is_excluded and getattr(module, "quant_config",
                                                None) is not None:
-                        module.quant_config = None
+                        module.quant_config = new_config
 
         for _, module in self.named_modules():
             if callable(getattr(module, "create_weights", None)):

--- a/tensorrt_llm/_torch/modules/fused_moe.py
+++ b/tensorrt_llm/_torch/modules/fused_moe.py
@@ -410,7 +410,8 @@ class FusedMoE(nn.Module):
         self.has_fp8_qdq = False
         self.has_fp8_block_scales = False
         self.has_nvfp4 = False
-        if self.quant_config and self.quant_config.quant_mode.has_any_quant():
+        if self.quant_config and self.quant_config.quant_mode.has_any_quant(
+                exclude_kv_cache=True):
             self.has_any_quant = True
             qc = self.quant_config
             if qc.quant_mode.has_fp8_qdq():
@@ -1128,7 +1129,8 @@ class FusedMoE(nn.Module):
             load_expert_w2_weight(w2_weight, self.w2_weight.data[expert_idx],
                                   is_trtllm_nvfp4)
 
-        if self.quant_config and self.quant_config.quant_mode.has_any_quant():
+        if self.quant_config and self.quant_config.quant_mode.has_any_quant(
+                exclude_kv_cache=True):
             if self.quant_config.quant_mode.has_fp8_qdq():
                 self._load_fp8_qdq_scales(weights)
             elif self.quant_config.quant_mode.has_nvfp4():

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -210,9 +210,9 @@ class Linear(nn.Module):
         self.has_fp8_qdq = False
         self.has_fp8_block_scales = False
         self.has_nvfp4 = False
-        # only _create_weights, and load quantized weight directly.
+
         if self.quant_config and self.quant_config.layer_quant_mode.has_any_quant(
-        ):
+                exclude_kv_cache=True):
             self.has_any_quant = True
             qc = self.quant_config
             if qc.layer_quant_mode.has_fp8_qdq():

--- a/tensorrt_llm/quantization/mode.py
+++ b/tensorrt_llm/quantization/mode.py
@@ -175,15 +175,19 @@ class QuantMode(IntFlag):
     def has_weight_quant(self):
         return self._any(self.INT4_WEIGHTS | self.INT8_WEIGHTS)
 
-    def has_any_quant(self):
-        return self._any(self.INT4_WEIGHTS
-                         | self.INT8_WEIGHTS
-                         | self.ACTIVATIONS
-                         | self.INT8_KV_CACHE | self.FP8_KV_CACHE
-                         | self.NVFP4_KV_CACHE
-                         | self.FP8_QDQ | self.FP8_ROWWISE | self.W4A8_QSERVE
-                         | self.FP8_1x128_128x128
-                         | self.NVFP4)
+    def has_any_quant(self, exclude_kv_cache: bool = False):
+        has_quant = self._any(self.INT4_WEIGHTS
+                              | self.INT8_WEIGHTS
+                              | self.ACTIVATIONS
+                              | self.FP8_QDQ | self.FP8_ROWWISE
+                              | self.W4A8_QSERVE
+                              | self.FP8_1x128_128x128
+                              | self.NVFP4)
+        if exclude_kv_cache:
+            return has_quant
+
+        return has_quant | self._any(self.INT8_KV_CACHE | self.FP8_KV_CACHE
+                                     | self.NVFP4_KV_CACHE)
 
     def set_int8_kv_cache(self):
         return self | self.INT8_KV_CACHE


### PR DESCRIPTION
## Description

- ~Make sure that`quant_config` in attention kernel is not modified later when we reset the `quant_config` in modules that are excluded from quantization.~
- Add `exclude_kv_cache` to `QuantMode.has_any_quant` which is used in Linear and FusedMoE. This was causing issues with enabling fp8 kvcache with fp16/bf16 checkpoints.
- Remove the check under `if use_paged_context_fmha and self.has_fp8_kv_cache` from trtllm attention. It doesn't make any sense because Linear quant_configs are independent from kvcache quant config. 
- Make sure to set the `kv_cache_quant_algo` with the original value when resetting `quant_config` for modules in `quant_config.exclude_modules`.


## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
