### PR TITLE
fix: Merge PP overlap and non-overlap executor loop

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -412,9 +412,10 @@ def create_py_executor_instance(dist,
             lora_config.lora_target_modules,
             lora_config.trtllm_modules_to_hf_modules)
 
-    num_micro_batches = 1
-    if mapping.has_pp:
-        num_micro_batches = mapping.pp_size + pytorch_backend_config.enable_overlap_scheduler
+    if mapping.has_pp():
+        num_micro_batches = mapping.pp_size
+    else:
+        num_micro_batches = 2 if pytorch_backend_config.enable_overlap_scheduler else 1
 
     resources["seq_slot_manager"] = SeqSlotManager(
         executor_config.max_batch_size * num_micro_batches)


### PR DESCRIPTION
In current implementation, `executor_loop_pp_overlap` uses one extra microbatch (total `pp_size + 1`) to hide latency of transferring `new_tokens_host` from last to first PP rank. But the inefficiency of smaller batch size in a microbatch negates the benefit of latency hiding. In this PR, we
1. Remove the extra micro batch for `executor_loop_pp_overlap`
2. Since only difference between them is async_decode, delete `executor_loop_pp` and rename `executor_loop_pp_overlap` as `executor_loop_pp`. Both `overlap_scheduler = true and false` use the same loop.

Future improvement: To hide latency, we would send the new_tokens asynchronously from device after decode_async.