### PR TITLE
fix: request termination in pipeline parallelism

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
+++ b/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
@@ -712,7 +712,7 @@ public:
     /// @brief Erases all previous generated tokens, only leaving the prompt.
     void clearGeneratedTokens()
     {
-        TLLM_LOG_DEBUG("emptying generated tokens for request %ld with promptlen", mRequestId, mPromptLen);
+        TLLM_LOG_DEBUG("Clearing generated tokens for request %ld with promptlen %d", mRequestId, mPromptLen);
         for (auto& beam : mTokens)
         {
             beam.resize(mPromptLen);
@@ -723,7 +723,7 @@ public:
     /// @param generatedBeamTokens The generated tokens for all beams (vector of vector of tokens)
     void setGeneratedTokens(BeamTokens const& generatedBeamTokens)
     {
-        TLLM_LOG_DEBUG("setting generated tokens for request %ld", mRequestId);
+        TLLM_LOG_DEBUG("Setting generated tokens for request %ld", mRequestId);
         assert(generatedBeamTokens.size() == static_cast<size_t>(mSamplingConfig.beamWidth));
 
         for (size_t beamId = 0; beamId < generatedBeamTokens.size(); ++beamId)

--- a/cpp/include/tensorrt_llm/executor/executor.h
+++ b/cpp/include/tensorrt_llm/executor/executor.h
@@ -635,9 +635,9 @@ public:
     /// @param skipCrossAttnBlocks Skip the cross attention transformer blocks or not.
     /// @param guidedDecodingParams The guided decoding parameters.
     /// @param languageAdapterUid Task Uid for language adapter.
-    /// @param allottedTimeMs The allotted time in milliseconds after which the request is finished with a timedOut
-    /// finish reason. The request always will exceed this time slightly, but at most with 1 forward pass. A request can
-    /// be timed-out before ever being scheduled.
+    /// @param allottedTimeMs The allotted time in milliseconds after which the request is cancelled with a timedOut
+    /// finish reason. The request may exceed this time slightly, but at most by 1 forward pass (in pipeline parallelism
+    /// that may involve multiple micro-batches). A request can be timed-out before ever being scheduled.
     // 34 parameters
     Request(VecTokens inputTokenIds, SizeType32 maxTokens, bool streaming = false,
         SamplingConfig const& samplingConfig = SamplingConfig(), OutputConfig const& outputConfig = OutputConfig(),

--- a/cpp/tensorrt_llm/batch_manager/trtEncoderModel.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtEncoderModel.cpp
@@ -402,6 +402,14 @@ void TrtEncoderModel::terminateRequest(std::shared_ptr<LlmRequest> const& llmReq
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
 }
 
+void TrtEncoderModel::terminateRequestSync(
+    std::shared_ptr<LlmRequest> const& llmReq, executor::FinishReason finishReason)
+{
+    terminateRequest(llmReq, false);
+    llmReq->finishByReason(finishReason);
+    llmReq->clearGeneratedTokens();
+}
+
 void TrtEncoderModel::fillEncoderOutputSync(RequestVector const& requestList, TensorMap outputTensors)
 {
     auto const totalTokensNb = outputTensors["encoder_output"]->getShape().d[0];

--- a/cpp/tensorrt_llm/batch_manager/trtEncoderModel.h
+++ b/cpp/tensorrt_llm/batch_manager/trtEncoderModel.h
@@ -52,6 +52,9 @@ public:
     ~TrtEncoderModel() override;
 
     void terminateRequest(std::shared_ptr<LlmRequest> const& llmRequest, bool pause = false) override;
+    void terminateRequestSync(
+        std::shared_ptr<LlmRequest> const& llmRequest, executor::FinishReason finishReason) override;
+
     void forward(RequestVector& activeRequests);
 
     void forwardSync() override;

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -726,6 +726,8 @@ void TrtGptModelInflightBatching::terminateRequest(LlmRequestPtr const& llmReq, 
 void TrtGptModelInflightBatching::terminateRequestSync(
     LlmRequestPtr const& llmRequest, executor::FinishReason finishReason)
 {
+    TLLM_LOG_DEBUG("Registering termination for request %lu with finish reason %d", llmRequest->mRequestId,
+        static_cast<int>(finishReason));
     mReqIdsToTerminate.try_emplace(llmRequest->mRequestId, finishReason);
 }
 
@@ -834,6 +836,8 @@ void TrtGptModelInflightBatching::forwardSync()
                     {
                         if (!llmReq->isGenerationToCompleteState())
                         {
+                            TLLM_LOG_DEBUG("Terminating request %lu with finish reason %d", llmReq->mRequestId,
+                                static_cast<int>(mReqIdsToTerminate[llmReq->mRequestId]));
                             terminateRequest(llmReq);
                             llmReq->finishByReason(mReqIdsToTerminate[llmReq->mRequestId]);
                             llmReq->clearGeneratedTokens();

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -834,7 +834,7 @@ void TrtGptModelInflightBatching::forwardSync()
                 {
                     if (mReqIdsToTerminate.count(llmReq->mRequestId) != 0U)
                     {
-                        if (!llmReq->isGenerationToCompleteState())
+                        if (!llmReq->isGenerationCompleteState())
                         {
                             TLLM_LOG_DEBUG("Terminating request %lu with finish reason %d", llmReq->mRequestId,
                                 static_cast<int>(mReqIdsToTerminate[llmReq->mRequestId]));

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
@@ -139,6 +139,12 @@ public:
 
     void terminateRequest(LlmRequestPtr const& llmRequest, bool pause = false) override;
 
+    /// @brief Terminate request in the next forwardSync call that includes the request.
+    /// @details This function does not terminate requests immediately. It will add the requests to the
+    ///          mReqIdsToTerminate set. The requests will be terminated in the next forwardSync call that
+    ///          includes the request in the batch.
+    void terminateRequestSync(LlmRequestPtr const& llmRequest, executor::FinishReason finishReason) override;
+
     /// @brief Function that waits for the decoding of requests in flight.
     ///        When the requests have finished or using speculative decoding, the state of requests
     ///        will become LlmRequestState::kGENERATION_COMPLETE. Else, it will be set to
@@ -534,6 +540,8 @@ private:
     std::vector<ScheduledRequests> mMicroBatchScheduledRequests;
     // Set of in-flight requests of *all* micro batches
     ReqIdsSet mInflightReqIds;
+    // Requests that should be terminated (requested from outside the model)
+    std::unordered_map<RequestIdType, executor::FinishReason> mReqIdsToTerminate;
     // Requests that the scheduler selected to be paused
     ReqIdsSet mReqIdsToPause;
     // Stats collected in last iteration

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelV1.h
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelV1.h
@@ -64,6 +64,8 @@ public:
 
     // V1 model is stateless, so nothing to do here
     void terminateRequest(std::shared_ptr<LlmRequest> const& llmRequest, bool pause = false) override{};
+    void terminateRequestSync(
+        std::shared_ptr<LlmRequest> const& llmRequest, executor::FinishReason finishReason) override{};
 
     /// @brief This override is empty and solely exists to adhere to the interface
     void forwardSync() override;

--- a/cpp/tensorrt_llm/executor/executorImpl.cpp
+++ b/cpp/tensorrt_llm/executor/executorImpl.cpp
@@ -1716,9 +1716,7 @@ void Executor::Impl::finishTimedOutRequests(RequestList const& activeRequests)
                     auto& selCancelledReqIds = mUsePipelineParallel ? mPipelineCancelledReqIds : mCancelledReqIds;
                     selCancelledReqIds.insert(request->mRequestId);
                 }
-                request->finishByReason(FinishReason::kTIMED_OUT);
-                request->clearGeneratedTokens();
-                mModel->terminateRequest(request);
+                mModel->terminateRequestSync(request, FinishReason::kTIMED_OUT);
             }
         }
     }
@@ -2132,10 +2130,7 @@ void Executor::Impl::terminateCancelledRequests(RequestList& activeRequests)
             auto reqId = req->isChild() ? req->getParentRequestId() : req->mRequestId;
             if (mCancelledReqIds.find(reqId) != mCancelledReqIds.end())
             {
-                req->setState(batch_manager::LlmRequestState::kGENERATION_COMPLETE);
-                mModel->terminateRequest(req);
-                req->finishByReason(FinishReason::kCANCELLED);
-                req->clearGeneratedTokens();
+                mModel->terminateRequestSync(req, FinishReason::kCANCELLED);
                 // Parent and child requests share the same request id.
                 // Mark it terminated first and remove from the set later.
                 terminatedReqIds.insert(reqId);

--- a/cpp/tensorrt_llm/executor/executorImpl.cpp
+++ b/cpp/tensorrt_llm/executor/executorImpl.cpp
@@ -2237,9 +2237,9 @@ void Executor::Impl::executionLoop()
         RequestList finishedRequests;
         if (!activeRequests.empty())
         {
-            forwardSync(activeRequests);
             finishTimedOutRequests(activeRequests);
             terminateCancelledRequests(activeRequests);
+            forwardSync(activeRequests);
             finishedRequests = populateNewResponses(activeRequests, inTransmissionRequests, newResponses);
             cleanupDynamicLogitsPostProcessors(finishedRequests);
             auto const iterCounter = mModel->getIterCounter();

--- a/cpp/tensorrt_llm/executor/executorImpl.cpp
+++ b/cpp/tensorrt_llm/executor/executorImpl.cpp
@@ -1716,7 +1716,6 @@ void Executor::Impl::finishTimedOutRequests(RequestList const& activeRequests)
                     auto& selCancelledReqIds = mUsePipelineParallel ? mPipelineCancelledReqIds : mCancelledReqIds;
                     selCancelledReqIds.insert(request->mRequestId);
                 }
-                mModel->terminateRequestSync(request, FinishReason::kTIMED_OUT);
             }
         }
     }
@@ -2130,7 +2129,8 @@ void Executor::Impl::terminateCancelledRequests(RequestList& activeRequests)
             auto reqId = req->isChild() ? req->getParentRequestId() : req->mRequestId;
             if (mCancelledReqIds.find(reqId) != mCancelledReqIds.end())
             {
-                mModel->terminateRequestSync(req, FinishReason::kCANCELLED);
+                auto finishReason = req->isTimedOut() ? FinishReason::kTIMED_OUT : FinishReason::kCANCELLED;
+                mModel->terminateRequestSync(req, finishReason);
                 // Parent and child requests share the same request id.
                 // Mark it terminated first and remove from the set later.
                 terminatedReqIds.insert(reqId);

--- a/cpp/tensorrt_llm/executor/model.h
+++ b/cpp/tensorrt_llm/executor/model.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include "tensorrt_llm/batch_manager/common.h"
-#include "tensorrt_llm/batch_manager/llmRequest.h"
 #include "tensorrt_llm/batch_manager/logitsPostProcessor.h"
 #include "tensorrt_llm/runtime/bufferManager.h"
 #include "tensorrt_llm/runtime/modelConfig.h"
@@ -45,6 +44,9 @@ public:
     {
         terminateRequest(llmRequest, false);
     }
+
+    /// @brief Terminate request in the next forwardSync call that includes the request.
+    virtual void terminateRequestSync(LlmRequestPtr const& llmRequest, FinishReason finishReason) = 0;
 
     /// @brief Function that synchronizes the decoder
     virtual void forwardSync() = 0;

--- a/cpp/tests/executor/executorMockTest.cpp
+++ b/cpp/tests/executor/executorMockTest.cpp
@@ -51,6 +51,8 @@ public:
     MOCK_METHOD(void, forwardSync, (), ());
     MOCK_METHOD(void, forwardAsync, (RequestList const&), ());
     MOCK_METHOD(void, terminateRequest, (std::shared_ptr<tb::LlmRequest> const& llmRequest, bool pause), ());
+    MOCK_METHOD(
+        void, terminateRequestSync, (std::shared_ptr<tb::LlmRequest> const& llmRequest, FinishReason finishReason), ());
     MOCK_METHOD(SizeType32, getMaxNumSequences, (), (const));
     MOCK_METHOD(SizeType32, getMaxInputLen, (), (const));
     MOCK_METHOD(SizeType32, getHiddenSize, (), (const));
@@ -195,6 +197,7 @@ TEST_F(GptExecutorTest, MockedModelMaxQueueSize)
     auto model = std::make_shared<MockedModel>();
 
     EXPECT_CALL(*model, terminateRequest(_, _)).Times(0);
+    EXPECT_CALL(*model, terminateRequestSync(_, _)).Times(0);
     EXPECT_CALL(*model, getVocabSizePadded()).Times(0);
     EXPECT_CALL(*model, getLogitDataType()).Times(0);
 

--- a/cpp/tests/executor/executorTest.cpp
+++ b/cpp/tests/executor/executorTest.cpp
@@ -4123,25 +4123,19 @@ TEST_P(TimeoutTest, TimeoutStreamingTest)
     {
         GTEST_SKIP() << "Skipping MultiGpu tests";
     }
-    else
+    if (val != NULL && !isMultiGpu)
     {
-        if (val != NULL && !isMultiGpu)
-        {
-            GTEST_SKIP() << "Skipping SingleGpu tests";
-        }
-
-        if (!isMultiGpu && !useOrchestratorMode)
-        {
-            GTEST_SKIP() << "Leader mode on single GPU crashes";
-        }
-
+        GTEST_SKIP() << "Skipping SingleGpu tests";
+    }
+    if (val != NULL && isMultiGpu)
+    {
         // Check that it was launched with right number of MPI ranks
         if (!useOrchestratorMode && COMM_SESSION.getSize() != 4)
         {
             // No orchestrator, need worldSize to match TP*PP
             FAIL() << "Leader mode and world size is not equal to 4";
         }
-        else if (useOrchestratorMode && COMM_SESSION.getSize() != 1)
+        if (useOrchestratorMode && COMM_SESSION.getSize() != 1)
         {
             // No orchestrator, need worldSize to match TP*PP
             FAIL() << "Orchestrator mode and World size is not equal to 1";
@@ -4336,25 +4330,19 @@ TEST_P(TimeoutTest, TimeoutNonstreamingTest)
     {
         GTEST_SKIP() << "Skipping MultiGpu tests";
     }
-    else
+    if (val != NULL && !isMultiGpu)
     {
-        if (val != NULL && !isMultiGpu)
-        {
-            GTEST_SKIP() << "Skipping SingleGpu tests";
-        }
-
-        if (!isMultiGpu && !useOrchestratorMode)
-        {
-            GTEST_SKIP() << "Leader mode on single GPU crashes";
-        }
-
+        GTEST_SKIP() << "Skipping SingleGpu tests";
+    }
+    if (val != NULL && isMultiGpu)
+    {
         // Check that it was launched with right number of MPI ranks
         if (!useOrchestratorMode && COMM_SESSION.getSize() != 4)
         {
             // No orchestrator, need worldSize to match TP*PP
             FAIL() << "Leader mode and world size is not equal to 4";
         }
-        else if (useOrchestratorMode && COMM_SESSION.getSize() != 1)
+        if (useOrchestratorMode && COMM_SESSION.getSize() != 1)
         {
             // No orchestrator, need worldSize to match TP*PP
             FAIL() << "Orchestrator mode and World size is not equal to 1";

--- a/cpp/tests/executor/executorTest.cpp
+++ b/cpp/tests/executor/executorTest.cpp
@@ -574,7 +574,7 @@ using ParamStatsType = std::tuple<int, bool>;
 using AllParamsType = std::tuple<BatchingType, bool, int, bool, bool, bool, bool, std::string, bool, bool, int>;
 using LogitsProcParamsType = std::tuple<std::string, bool, bool>;
 using GuidedDecodingParamsType = std::tuple<std::string>;
-using TimeoutTestParamsType = std ::tuple<std::string, bool>;
+using TimeoutTestParamsType = std ::tuple<std::string, bool, int>;
 
 std::string generateTestName(testing::TestParamInfo<ParamType> const& info)
 {
@@ -666,6 +666,7 @@ std::string generateTestNameTimeoutTest(testing::TestParamInfo<TimeoutTestParams
 {
     auto const modelName = std::get<0>(info.param);
     auto const& useOrchestratorMode = std::get<1>(info.param);
+    auto const beamWidth = std::get<2>(info.param);
 
     std::string name = "ExecutorTest";
     name.append("_" + modelName);
@@ -678,6 +679,7 @@ std::string generateTestNameTimeoutTest(testing::TestParamInfo<TimeoutTestParams
     {
         name.append("_LeaderMode");
     }
+    name.append("_BW" + std::to_string(beamWidth));
     return name;
 }
 
@@ -4087,7 +4089,7 @@ TEST_P(TimeoutTest, TimeoutStreamingTest)
 {
     auto const modelName = std::get<0>(GetParam());
     auto const useOrchestratorMode = std::get<1>(GetParam());
-    SizeType32 constexpr beamWidth = 2;
+    auto const beamWidth = std::get<2>(GetParam());
 
     auto executorConfig = ExecutorConfig(beamWidth);
     std::filesystem::path modelPath;
@@ -4193,7 +4195,7 @@ TEST_P(TimeoutTest, TimeoutStreamingTest)
     finishedRequest.setReturnAllGeneratedTokens(true);
     finishedRequest.setAllottedTimeMs(std::chrono::milliseconds(5000));
     SizeType32 constexpr finishedMinLength = 5;
-    SizeType32 constexpr finishedMaxLength = maxNewTokens + 1;
+    SizeType32 constexpr finishedMaxLength = maxNewTokens;
 
     std::vector<FinishReason> referenceFinishReasons
         = {FinishReason::kTIMED_OUT, FinishReason::kTIMED_OUT, FinishReason::kLENGTH};
@@ -4256,8 +4258,8 @@ TEST_P(TimeoutTest, TimeoutStreamingTest)
                         TLLM_LOG_DEBUG("%s", tokenStr.c_str());
                     }
 
-                    TLLM_LOG_DEBUG("beams' length must be bigger than %d and smaller than %d", minLengths[reqId - 1],
-                        maxLengths[reqId - 1]);
+                    TLLM_LOG_DEBUG(
+                        "beams' length must be in range [%d, %d]", minLengths[reqId - 1], maxLengths[reqId - 1]);
 
                     if (result.isFinal)
                     {
@@ -4275,7 +4277,7 @@ TEST_P(TimeoutTest, TimeoutStreamingTest)
                     EXPECT_EQ(beamWidth, actualResponse.size());
                     for (int beam = 0; beam < beamWidth; beam++)
                     {
-                        EXPECT_LT(actualResponse.at(beam).size(), maxLengths[reqId - 1]) << "for request " << reqId;
+                        EXPECT_LE(actualResponse.at(beam).size(), maxLengths[reqId - 1]) << "for request " << reqId;
                         achievedLength[reqId - 1] = std::max(
                             achievedLength[reqId - 1], static_cast<SizeType32>(actualResponse.at(beam).size()));
                     }
@@ -4295,7 +4297,8 @@ TEST_P(TimeoutTest, TimeoutNonstreamingTest)
 {
     auto const modelName = std::get<0>(GetParam());
     auto const useOrchestratorMode = std::get<1>(GetParam());
-    SizeType32 constexpr beamWidth = 2;
+    auto const beamWidth = std::get<2>(GetParam());
+
     std::optional<std::vector<SizeType32>> deviceIds = std::nullopt;
 
     auto executorConfig = ExecutorConfig(beamWidth);
@@ -4488,8 +4491,8 @@ INSTANTIATE_TEST_SUITE_P(LlamaExecutorTest, ParamCancelReqTest,
     generateTestNameCancelReq);
 
 INSTANTIATE_TEST_SUITE_P(LlamaExecutorTest, TimeoutTest,
-    testing::Combine(
-        testing::Values("llama_tp1_pp4_cp1", "llama_tp4_pp1_cp1", "llama_tp1_pp1_cp1"), testing::Values(false, true)),
+    testing::Combine(testing::Values("llama_tp1_pp4_cp1", "llama_tp4_pp1_cp1", "llama_tp1_pp1_cp1"),
+        testing::Values(false, true), testing::Values(2)),
     generateTestNameTimeoutTest);
 
 INSTANTIATE_TEST_SUITE_P(LlamaExecutorTest, LeaderApiUsageTest,


### PR DESCRIPTION
# feat: Implement synchronous request termination in batch manager

## Description

- Added `terminateRequestSync` method to `TrtEncoderModel` and `TrtGptModelInflightBatching` for handling request termination in the next `forwardSync` call.
- Updated existing request termination logic to utilize the new synchronous method, ensuring communication can finish.
- Enhanced logging for clarity in token management during request processing.

## Test Coverage

LlamaExecutorTest/ParamCancelReqTest.MultipleRequestsMultiGpuCancelRequest

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
