### PR TITLE
refactor: Introduce MpiTag enumeration and update MPI function signatures

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/decoderBuffers.h
+++ b/cpp/include/tensorrt_llm/batch_manager/decoderBuffers.h
@@ -127,9 +127,6 @@ public:
     static void bcast(DecoderOutputBuffers const& decoderOutputBuffers, DecoderBuffers const& decoderBuffers,
         bool returnLogProbs, SizeType32 maxBeamWidth, bool useMedusa, mpi::MpiComm const& commSession, int root);
 
-    static auto constexpr kMpiTagOffset = 0;
-    static auto constexpr kMpiTagUpperBound = kMpiTagOffset + 9;
-
 private:
     std::shared_ptr<mpi::MpiRequest> mRequest1;
     std::shared_ptr<mpi::MpiRequest> mRequest2;
@@ -176,10 +173,6 @@ public:
 
     static void recv(
         SlotDecoderBuffers const& slotDecoderBuffers, bool returnLogProbs, mpi::MpiComm const& commSession, int peer);
-
-    static auto constexpr kMpiTagOffset = 9;
-    static auto constexpr kMpiTagUpperBound = kMpiTagOffset + 4;
-    static_assert(kMpiTagOffset >= DecoderStepAsyncSend::kMpiTagUpperBound);
 
 private:
     std::shared_ptr<mpi::MpiRequest> mRequest1;

--- a/cpp/include/tensorrt_llm/runtime/utils/mpiTags.h
+++ b/cpp/include/tensorrt_llm/runtime/utils/mpiTags.h
@@ -21,7 +21,7 @@ namespace tensorrt_llm::mpi
 
 enum class MpiTag : int
 {
-    kDefault = -1,
+    kDefault = 0,
 
     // DecoderStepAsyncSend
     kDecoderStepNewOutputTokensHost = 0,

--- a/cpp/include/tensorrt_llm/runtime/utils/mpiTags.h
+++ b/cpp/include/tensorrt_llm/runtime/utils/mpiTags.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace tensorrt_llm::mpi
+{
+
+enum class MpiTag : int
+{
+    kDefault = -1,
+
+    // DecoderStepAsyncSend
+    kDecoderStepNewOutputTokensHost = 0,
+    kDecoderStepFinishedSumHost = 1,
+    kDecoderStepSequenceLengthsHost = 2,
+    kDecoderStepCumLogProbsHost = 3,
+    kDecoderStepLogProbsHost = 4,
+    kDecoderStepCacheIndirectionOutput = 5,
+    kDecoderStepAcceptedLengthsCumSumDevice = 6,
+    kDecoderStepAcceptedPackedPathsDevice = 7,
+    kDecoderStepFinishReasonsHost = 8,
+
+    // DecoderSlotAsyncSend
+    kDecoderSlotOutputIds = 9,
+    kDecoderSlotSequenceLengths = 10,
+    kDecoderSlotCumLogProbs = 11,
+    kDecoderSlotLogProbs = 12,
+
+    // CancelledRequestsAsyncSend
+    kCancelledRequestsNumReq = 13,
+    kCancelledRequestsIds = 14,
+
+    // RequestWithIdAsyncSend
+    kRequestWithIdNumReq = 15,
+    kRequestWithIdVecSize = 16,
+    kRequestWithIdPacked = 17,
+
+    // Executor
+    kExecutorNumActiveRequests = 18,
+    kExecutorLowestPriorityActiveHasValue = 19,
+    kExecutorLowestPriorityActive = 20,
+    kExecutorShouldExit = 21,
+
+    // TrtGptModelInflightBatching
+    kTrtGptModelInflightBatchingContextLogits = 22,
+    kTrtGptModelInflightBatchingGenerationLogits = 23,
+
+    // Orchestrator
+    kID_TAG = 127,
+    kSTATS_ID_TAG = 128,
+    kDATA_TAG = 1023,
+    kSTATS_DATA_TAG = 1024,
+
+    // LogitsThread
+    kSPEC_DEC_ID_TAG = 129,
+    kSPEC_DEC_DATA_TAG = 1025,
+};
+
+} // namespace tensorrt_llm::mpi

--- a/cpp/include/tensorrt_llm/runtime/utils/mpiTags.h
+++ b/cpp/include/tensorrt_llm/runtime/utils/mpiTags.h
@@ -60,14 +60,14 @@ enum class MpiTag : int
     kTrtGptModelInflightBatchingGenerationLogits = 23,
 
     // Orchestrator
-    kID_TAG = 127,
-    kSTATS_ID_TAG = 128,
-    kDATA_TAG = 1023,
-    kSTATS_DATA_TAG = 1024,
+    kOrchestratorId = 127,
+    kOrchestratorData = 1023,
+    kOrchestratorStatsId = 128,
+    kOrchestratorStatsData = 1024,
 
     // LogitsThread
-    kSPEC_DEC_ID_TAG = 129,
-    kSPEC_DEC_DATA_TAG = 1025,
+    kSpecDecLogitsId = 129,
+    kSpecDecLogitsData = 1025,
 };
 
 } // namespace tensorrt_llm::mpi

--- a/cpp/include/tensorrt_llm/runtime/utils/mpiUtils.h
+++ b/cpp/include/tensorrt_llm/runtime/utils/mpiUtils.h
@@ -16,7 +16,9 @@
 
 #pragma once
 
+#include "tensorrt_llm/runtime/utils/mpiTags.h"
 #include "tensorrt_llm/runtime/utils/multiDeviceUtils.h"
+
 #include <functional>
 #include <limits>
 
@@ -351,16 +353,16 @@ public:
         }
     }
 
-    std::shared_ptr<MpiRequest> sendAsync(void const* buffer, std::size_t size, MpiType dtype, int dest, int tag) const;
-
-    std::shared_ptr<MpiRequest> sendAsync(runtime::IBuffer const& buf, int dest, int tag) const;
-
-    void send(void const* buffer, std::size_t size, MpiType dtype, int dest, int tag) const;
-
-    void send(runtime::IBuffer const& buf, int dest, int tag) const;
+    std::shared_ptr<MpiRequest> sendAsync(
+        void const* buffer, std::size_t size, MpiType dtype, int dest, MpiTag tag) const;
+    std::shared_ptr<MpiRequest> sendAsync(runtime::IBuffer const& buf, int dest, MpiTag tag) const;
+    //! \deprecated This function is discouraged. Use the one with MpiTag enum instead.
+    void sendRawTag(void const* buffer, std::size_t size, MpiType dtype, int dest, int tag) const;
+    void send(void const* buffer, std::size_t size, MpiType dtype, int dest, MpiTag tag) const;
+    void send(runtime::IBuffer const& buf, int dest, MpiTag tag) const;
 
     template <typename T>
-    void sendValue(T const& value, int dest, int tag) const
+    void sendValue(T const& value, int dest, MpiTag tag) const
     {
         if constexpr (std::is_fundamental_v<std::remove_cv_t<T>>)
         {
@@ -372,12 +374,13 @@ public:
         }
     }
 
-    MPI_Status recv(void* buffer, size_t size, MpiType dtype, int source, int tag) const;
-
-    MPI_Status recv(runtime::IBuffer& buf, int source, int tag) const;
+    //! \deprecated This function is discouraged. Use the one with MpiTag enum instead.
+    MPI_Status recvRawTag(void* buffer, size_t size, MpiType dtype, int source, int tag) const;
+    MPI_Status recv(void* buffer, size_t size, MpiType dtype, int source, MpiTag tag) const;
+    MPI_Status recv(runtime::IBuffer& buf, int source, MpiTag tag) const;
 
     template <typename T>
-    MPI_Status recvValue(T& value, int source, int tag) const
+    MPI_Status recvValue(T& value, int source, MpiTag tag) const
     {
 #if ENABLE_MULTI_DEVICE
         if constexpr (std::is_fundamental_v<std::remove_cv_t<T>>)
@@ -401,14 +404,16 @@ public:
 
     void barrier() const;
 
-    void mprobe(int source, int tag, MPI_Message* msg, MPI_Status* status) const;
-    bool improbe(int source, int tag, MPI_Message* msg, MPI_Status* status) const;
+    //! \deprecated This function is discouraged. Use the one with MpiTag enum instead.
+    void mprobeRawTag(int source, int tag, MPI_Message* msg, MPI_Status* status) const;
+    void mprobe(int source, MpiTag tag, MPI_Message* msg, MPI_Status* status) const;
+    bool improbe(int source, MpiTag tag, MPI_Message* msg, MPI_Status* status) const;
 
     //! \brief Returns if a message with the specified source and tag is available
-    bool iprobe(int source, int tag, MPI_Status* status) const;
+    bool iprobe(int source, MpiTag tag, MPI_Status* status) const;
 
     //! \brief Poll every periodMs until a message is available
-    void recvPoll(int source, int tag, int periodMs) const;
+    void recvPoll(int source, MpiTag tag, int periodMs) const;
 
     bool operator==(MpiComm const& rhs) const
     {

--- a/cpp/include/tensorrt_llm/runtime/utils/mpiUtils.h
+++ b/cpp/include/tensorrt_llm/runtime/utils/mpiUtils.h
@@ -226,7 +226,16 @@ public:
     {
 #if ENABLE_MULTI_DEVICE
         // TODO: Don't ignore return status
-        MPI_Wait(&mRequest, MPI_STATUS_IGNORE);
+        TLLM_MPI_CHECK(MPI_Wait(&mRequest, MPI_STATUS_IGNORE));
+#else
+        TLLM_THROW("Multi device support is disabled.");
+#endif
+    }
+
+    void cancel()
+    {
+#if ENABLE_MULTI_DEVICE
+        TLLM_MPI_CHECK(MPI_Cancel(&mRequest));
 #else
         TLLM_THROW("Multi device support is disabled.");
 #endif

--- a/cpp/tensorrt_llm/batch_manager/generateRequestOptions.cpp
+++ b/cpp/tensorrt_llm/batch_manager/generateRequestOptions.cpp
@@ -24,17 +24,18 @@
 #include "tensorrt_llm/common/nvtxUtils.h"
 
 #include <NvInferRuntimeBase.h>
-#include <cstddef>
 
 using namespace tensorrt_llm::runtime;
+
+namespace te = tensorrt_llm::executor;
 
 namespace tensorrt_llm::batch_manager
 {
 
 std::tuple<ITensor::SharedPtr, std::vector<decoder_batch::Request>, std::vector<SamplingConfig>>
 GenerateRequestOptions::operator()(tr::ModelConfig const& modelConfig, tr::WorldConfig const& worldConfig,
-    executor::DecodingConfig const& decodingConfig, RequestVector const& contextRequests,
-    BufferManager const& bufferManager, nvinfer1::DataType logitsType, DecoderInputBuffers const& inputBuffers,
+    te::DecodingConfig const& decodingConfig, RequestVector const& contextRequests, BufferManager const& bufferManager,
+    nvinfer1::DataType logitsType, DecoderInputBuffers const& inputBuffers,
     OptionalRef<RuntimeBuffers const> buffers) const
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
@@ -171,7 +172,7 @@ std::shared_ptr<runtime::ITensor> GenerateRequestOptions::retrieveDraftLogits(tr
 
     if (mIsLeaderInOrchMode)
     {
-        executor::SpeculativeDecodingFastLogitsInfo fastLogitsInfo;
+        te::SpeculativeDecodingFastLogitsInfo fastLogitsInfo;
         std::memcpy(&fastLogitsInfo, tensor->data(), sizeof(fastLogitsInfo));
         auto logits = utils::targetModelReceiveLogits(fastLogitsInfo, modelConfig).value();
 

--- a/cpp/tensorrt_llm/batch_manager/llmRequest.cpp
+++ b/cpp/tensorrt_llm/batch_manager/llmRequest.cpp
@@ -16,7 +16,6 @@
  */
 
 #include "tensorrt_llm/batch_manager/llmRequest.h"
-#include "tensorrt_llm/runtime/utils/mpiUtils.h"
 
 namespace tensorrt_llm::batch_manager
 {

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -1762,12 +1762,13 @@ void TrtGptModelInflightBatching::postProcessRequest(
         {
             if (mWorldConfig.isLastPipelineParallelRank())
             {
-                mMpiCommPipelinePara->send(*(llmReq.getContextLogitsHost()), 0, 1);
+                mMpiCommPipelinePara->send(
+                    *(llmReq.getContextLogitsHost()), 0, mpi::MpiTag::kTrtGptModelInflightBatchingContextLogits);
             }
             else if (mWorldConfig.isFirstPipelineParallelRank())
             {
-                mMpiCommPipelinePara->recv(
-                    *(llmReq.getContextLogitsHost()), mWorldConfig.getPipelineParallelism() - 1, 1);
+                mMpiCommPipelinePara->recv(*(llmReq.getContextLogitsHost()), mWorldConfig.getPipelineParallelism() - 1,
+                    mpi::MpiTag::kTrtGptModelInflightBatchingContextLogits);
             }
         }
 
@@ -1776,12 +1777,14 @@ void TrtGptModelInflightBatching::postProcessRequest(
         {
             if (mWorldConfig.isLastPipelineParallelRank())
             {
-                mMpiCommPipelinePara->send(*(llmReq.getGenerationLogitsHost()), 0, 2);
+                mMpiCommPipelinePara->send(
+                    *(llmReq.getGenerationLogitsHost()), 0, mpi::MpiTag::kTrtGptModelInflightBatchingGenerationLogits);
             }
             else if (mWorldConfig.isFirstPipelineParallelRank())
             {
-                mMpiCommPipelinePara->recv(
-                    *(llmReq.getGenerationLogitsHost()), mWorldConfig.getPipelineParallelism() - 1, 2);
+                mMpiCommPipelinePara->recv(*(llmReq.getGenerationLogitsHost()),
+                    mWorldConfig.getPipelineParallelism() - 1,
+                    mpi::MpiTag::kTrtGptModelInflightBatchingGenerationLogits);
             }
         }
     }

--- a/cpp/tensorrt_llm/batch_manager/utils/logitsThread.cpp
+++ b/cpp/tensorrt_llm/batch_manager/utils/logitsThread.cpp
@@ -17,6 +17,14 @@
 
 #include "logitsThread.h"
 
+#include "tensorrt_llm/batch_manager/llmRequest.h"
+#include "tensorrt_llm/batch_manager/peftCacheManager.h"
+#include "tensorrt_llm/batch_manager/sequenceSlotManager.h"
+#include "tensorrt_llm/batch_manager/utils/inflightBatchingUtils.h"
+#include "tensorrt_llm/common/logger.h"
+#include "tensorrt_llm/executor/executor.h"
+#include "tensorrt_llm/runtime/utils/mpiTags.h"
+
 namespace tc = tensorrt_llm::common;
 
 namespace tensorrt_llm::batch_manager::utils
@@ -27,9 +35,6 @@ enum class FastLogitsMpiId : uint64_t
     ASK_TENSOR = 1,
     SEND_TENSOR = 2,
 };
-
-constexpr int32_t kMPI_SPEC_DEC_ID_TAG{129};
-constexpr int32_t kMPI_SPEC_DEC_DATA_TAG{1025};
 
 void draftModelSendLogitsThread(int device, std::atomic<bool>* draftModelThreadShouldExit,
     RequestVector* draftRequestsWaitingToSendLogits, std::shared_ptr<SequenceSlotManager> seqSlotManager,
@@ -47,7 +52,7 @@ void draftModelSendLogitsThread(int device, std::atomic<bool>* draftModelThreadS
 
     while (true)
     {
-        msgReady = worldComm.improbe(MPI_ANY_SOURCE, kMPI_SPEC_DEC_ID_TAG, &msg, &status);
+        msgReady = worldComm.improbe(MPI_ANY_SOURCE, mpi::MpiTag::kSPEC_DEC_ID_TAG, &msg, &status);
 
         if (!msgReady)
         {
@@ -71,7 +76,7 @@ void draftModelSendLogitsThread(int device, std::atomic<bool>* draftModelThreadS
 
         TLLM_CHECK(mpiId == FastLogitsMpiId::ASK_TENSOR);
 
-        worldComm.mprobe(MPI_ANY_SOURCE, kMPI_SPEC_DEC_DATA_TAG, &msg, &status);
+        worldComm.mprobe(MPI_ANY_SOURCE, mpi::MpiTag::kSPEC_DEC_DATA_TAG, &msg, &status);
         MPICHECK(MPI_Get_count(&status, MPI_UINT64_T, &count));
         TLLM_CHECK(count == 1);
 
@@ -103,11 +108,11 @@ void draftModelSendLogitsThread(int device, std::atomic<bool>* draftModelThreadS
         TLLM_CHECK(shape.nbDims == 2);
 
         FastLogitsMpiId constexpr id{FastLogitsMpiId::SEND_TENSOR};
-        worldComm.send(&id, 1, mpi::MpiType::kUINT64, source_rank, kMPI_SPEC_DEC_ID_TAG);
+        worldComm.send(&id, 1, mpi::MpiType::kUINT64, source_rank, mpi::MpiTag::kSPEC_DEC_ID_TAG);
 
-        worldComm.send(shape.d, 2, mpi::MpiType::kINT64, source_rank, kMPI_SPEC_DEC_DATA_TAG);
+        worldComm.send(shape.d, 2, mpi::MpiType::kINT64, source_rank, mpi::MpiTag::kSPEC_DEC_DATA_TAG);
         worldComm.send(draftLogits->data(), draftLogits->getSizeInBytes(), mpi::MpiType::kUINT8, source_rank,
-            kMPI_SPEC_DEC_DATA_TAG);
+            mpi::MpiTag::kSPEC_DEC_DATA_TAG);
 
         terminateRequest(
             *seqSlotManager, *draftRequest, maxInputLen, kvCacheManager, crossKvCacheManager, peftCacheManager);
@@ -115,20 +120,20 @@ void draftModelSendLogitsThread(int device, std::atomic<bool>* draftModelThreadS
 #endif // ENABLE_MULTI_DEVICE
 }
 
-std::optional<GenerateRequestOptions::TensorPtr> targetModelReceiveLogits(
+std::optional<runtime::ITensor::SharedPtr> targetModelReceiveLogits(
     executor::SpeculativeDecodingFastLogitsInfo const& fastLogitsInfo, runtime::ModelConfig const& modelConfig)
 {
 #if ENABLE_MULTI_DEVICE
     auto const& worldComm = tensorrt_llm::mpi::MpiComm::world();
 
     FastLogitsMpiId mpiId{FastLogitsMpiId::ASK_TENSOR};
-    worldComm.send(&mpiId, 1, mpi::MpiType::kUINT64, fastLogitsInfo.draftParticipantId, kMPI_SPEC_DEC_ID_TAG);
+    worldComm.send(&mpiId, 1, mpi::MpiType::kUINT64, fastLogitsInfo.draftParticipantId, mpi::MpiTag::kSPEC_DEC_ID_TAG);
     worldComm.send(&fastLogitsInfo.draftRequestId, 1, mpi::MpiType::kUINT64, fastLogitsInfo.draftParticipantId,
-        kMPI_SPEC_DEC_DATA_TAG);
+        mpi::MpiTag::kSPEC_DEC_DATA_TAG);
 
     MPI_Message msg;
     MPI_Status status;
-    worldComm.mprobe(fastLogitsInfo.draftParticipantId, kMPI_SPEC_DEC_ID_TAG, &msg, &status);
+    worldComm.mprobe(fastLogitsInfo.draftParticipantId, mpi::MpiTag::kSPEC_DEC_ID_TAG, &msg, &status);
 
     int32_t count;
     MPICHECK(MPI_Get_count(&status, MPI_UINT64_T, &count));
@@ -137,7 +142,7 @@ std::optional<GenerateRequestOptions::TensorPtr> targetModelReceiveLogits(
     MPICHECK(MPI_Mrecv(&mpiId, count, MPI_UINT64_T, &msg, &status));
     TLLM_CHECK(mpiId == FastLogitsMpiId::SEND_TENSOR);
 
-    worldComm.mprobe(fastLogitsInfo.draftParticipantId, kMPI_SPEC_DEC_DATA_TAG, &msg, &status);
+    worldComm.mprobe(fastLogitsInfo.draftParticipantId, mpi::MpiTag::kSPEC_DEC_DATA_TAG, &msg, &status);
 
     MPICHECK(MPI_Get_count(&status, MPI_INT64_T, &count));
     TLLM_CHECK(count == 2);
@@ -150,7 +155,7 @@ std::optional<GenerateRequestOptions::TensorPtr> targetModelReceiveLogits(
     auto tensor = tensorrt_llm::runtime::BufferManager::pinnedPool(
         runtime::ITensor::makeShape({dims[0], dims[1]}), logitsDtype);
 
-    worldComm.mprobe(fastLogitsInfo.draftParticipantId, kMPI_SPEC_DEC_DATA_TAG, &msg, &status);
+    worldComm.mprobe(fastLogitsInfo.draftParticipantId, mpi::MpiTag::kSPEC_DEC_DATA_TAG, &msg, &status);
 
     MPICHECK(MPI_Get_count(&status, MPI_UINT8_T, &count));
 

--- a/cpp/tensorrt_llm/batch_manager/utils/logitsThread.h
+++ b/cpp/tensorrt_llm/batch_manager/utils/logitsThread.h
@@ -15,25 +15,44 @@
  * limitations under the License.
  */
 
-#include "tensorrt_llm/batch_manager/generateRequestOptions.h"
-#include "tensorrt_llm/batch_manager/llmRequest.h"
-#include "tensorrt_llm/batch_manager/medusaBuffers.h"
-#include "tensorrt_llm/batch_manager/peftCacheManager.h"
-#include "tensorrt_llm/batch_manager/sequenceSlotManager.h"
-#include "tensorrt_llm/batch_manager/utils/inflightBatchingUtils.h"
-#include "tensorrt_llm/common/logger.h"
-#include "tensorrt_llm/common/nvtxUtils.h"
+#pragma once
+
+#include "tensorrt_llm/batch_manager/common.h"
+#include "tensorrt_llm/executor/executor.h"
+#include "tensorrt_llm/runtime/common.h"
+#include "tensorrt_llm/runtime/iTensor.h"
+#include "tensorrt_llm/runtime/modelConfig.h"
+
+#include <memory>
+#include <optional>
+
+namespace tensorrt_llm::batch_manager
+{
+namespace kv_cache_manager
+{
+class BaseKVCacheManager;
+} // namespace kv_cache_manager
+
+class SequenceSlotManager;
+class BasePeftCacheManager;
+class GenerateRequestOptions;
+} // namespace tensorrt_llm::batch_manager
+
+namespace tensorrt_llm::executor
+{
+struct SpeculativeDecodingFastLogitsInfo;
+} // namespace tensorrt_llm::executor
 
 namespace tensorrt_llm::batch_manager::utils
 {
 
 void draftModelSendLogitsThread(int device, std::atomic<bool>* draftModelThreadShouldExit,
     RequestVector* draftRequestsWaitingToSendLogits, std::shared_ptr<SequenceSlotManager> seqSlotManager,
-    SizeType32 maxInputLen, std::shared_ptr<kv_cache_manager::BaseKVCacheManager> kvCacheManager,
+    runtime::SizeType32 maxInputLen, std::shared_ptr<kv_cache_manager::BaseKVCacheManager> kvCacheManager,
     std::shared_ptr<kv_cache_manager::BaseKVCacheManager> crossKvCacheManager,
     std::shared_ptr<BasePeftCacheManager> peftCacheManager);
 
-std::optional<GenerateRequestOptions::TensorPtr> targetModelReceiveLogits(
+std::optional<runtime::ITensor::SharedPtr> targetModelReceiveLogits(
     executor::SpeculativeDecodingFastLogitsInfo const& fastLogitsInfo, runtime::ModelConfig const& modelConfig);
 
 } // namespace tensorrt_llm::batch_manager::utils

--- a/cpp/tensorrt_llm/common/opUtils.cpp
+++ b/cpp/tensorrt_llm/common/opUtils.cpp
@@ -14,14 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "tensorrt_llm/common/opUtils.h"
+#include "tensorrt_llm/runtime/utils/mpiTags.h"
 #include "tensorrt_llm/runtime/utils/mpiUtils.h"
 
 #include "cuda.h"
-#include <cstdint>
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
 #include <cuda_fp8.h>
+
 #include <functional>
 #include <mutex>
 #include <thread>
@@ -58,12 +60,12 @@ ncclUniqueId getUniqueId(std::set<int> const& group) noexcept
         NCCLCHECK(ncclGetUniqueId(&id));
         for (auto it = std::next(std::begin(group), 1); it != group.end(); ++it)
         {
-            COMM_SESSION.sendValue(id, *it, 0);
+            COMM_SESSION.sendValue(id, *it, tensorrt_llm::mpi::MpiTag::kDefault);
         }
     }
     else
     {
-        COMM_SESSION.recvValue(id, *group.begin(), 0);
+        COMM_SESSION.recvValue(id, *group.begin(), tensorrt_llm::mpi::MpiTag::kDefault);
     }
     TLLM_LOG_TRACE("%s stop for rank %d", __PRETTY_FUNCTION__, rank);
     return id;

--- a/cpp/tensorrt_llm/executor/cache_transmission/mpi_utils/connection.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/mpi_utils/connection.cpp
@@ -29,12 +29,12 @@ MpiConnection::MpiConnection(mpi::MpiComm const* comm, int rank)
 
 void MpiConnection::send(DataContext const& ctx, void const* data, size_t size) const
 {
-    mComm->send(data, size, mpi::MpiType::kCHAR, mRank, ctx.getTag());
+    mComm->sendRawTag(data, size, mpi::MpiType::kCHAR, mRank, ctx.getTag());
 }
 
 void MpiConnection::recv(DataContext const& ctx, void* data, size_t size) const
 {
-    mComm->recv(data, size, mpi::MpiType::kCHAR, mRank, ctx.getTag());
+    mComm->recvRawTag(data, size, mpi::MpiType::kCHAR, mRank, ctx.getTag());
 }
 
 MpiConnectionManager::MpiConnectionManager(mpi::MpiComm const* comm)

--- a/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.h
+++ b/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.h
@@ -28,10 +28,9 @@
 #include <arpa/inet.h>
 #include <ifaddrs.h>
 #endif
-#include "tensorrt_llm/common/cudaUtils.h"
-#include "tensorrt_llm/common/envUtils.h"
-#include "tensorrt_llm/common/logger.h"
 #include "tensorrt_llm/executor/cache_transmission/ucx_utils/connection.h"
+
+#include <future>
 #include <map>
 #include <memory>
 #include <string>

--- a/cpp/tensorrt_llm/executor/executorImpl.h
+++ b/cpp/tensorrt_llm/executor/executorImpl.h
@@ -48,10 +48,6 @@ namespace tensorrt_llm::executor
 class RequestWithIdAsyncSend;
 class CancelledRequestsAsyncSend;
 
-std::vector<RequestWithId> requestWithIdRecv(std::shared_ptr<tensorrt_llm::mpi::MpiComm> const& commSession, int peer);
-std::unordered_set<IdType> cancelledRequestsRecv(
-    std::shared_ptr<tensorrt_llm::mpi::MpiComm> const& commSession, int peer);
-
 class MpiMessageQueue
 {
 public:

--- a/cpp/tensorrt_llm/executor/executorImpl.h
+++ b/cpp/tensorrt_llm/executor/executorImpl.h
@@ -128,9 +128,6 @@ public:
 
     std::optional<std::shared_ptr<KVCacheEventManager>> getKVCacheEventManager() const;
 
-    static auto constexpr kMpiTagOffset = 18;
-    static auto constexpr kMpiTagUpperBound = kMpiTagOffset + 4;
-
 private:
     using RtTensorPtr = runtime::ITensor::SharedPtr;
     using CudaStreamPtr = runtime::BufferManager::CudaStreamPtr;
@@ -230,9 +227,9 @@ private:
     void cleanupDynamicLogitsPostProcessors(RequestList const& finishedRequests);
 
     void orchSendReqThread();
-    void orchRecvThread(int32_t idTag, int32_t dataTag);
+    void orchRecvThread(mpi::MpiTag idTag, mpi::MpiTag dataTag);
     void leaderRecvReqThread();
-    void leaderSendThread(MpiMessageQueue& sendQueue, int32_t idTag, int32_t dataTag);
+    void leaderSendThread(MpiMessageQueue& sendQueue, mpi::MpiTag idTag, mpi::MpiTag dataTag);
 
     void addTerminatedReqId(std::vector<Response> const& responses, IdType const& reqId);
 

--- a/cpp/tensorrt_llm/executor/orchestratorUtils.h
+++ b/cpp/tensorrt_llm/executor/orchestratorUtils.h
@@ -19,18 +19,13 @@
 #include "tensorrt_llm/executor/executor.h"
 #include "tensorrt_llm/executor/requestWithId.h"
 #include "tensorrt_llm/executor/types.h"
+
 #include <cstdint>
-#include <memory>
 #include <variant>
 #include <vector>
 
 namespace tensorrt_llm::executor
 {
-
-constexpr int32_t kMPI_ID_TAG{127};
-constexpr int32_t kMPI_STATS_ID_TAG{128};
-constexpr int32_t kMPI_DATA_TAG{1023};
-constexpr int32_t kMPI_STATS_DATA_TAG{1024};
 
 enum class MpiId : uint64_t
 {

--- a/cpp/tensorrt_llm/plugins/ncclPlugin/allreducePlugin.cpp
+++ b/cpp/tensorrt_llm/plugins/ncclPlugin/allreducePlugin.cpp
@@ -33,6 +33,7 @@ using tensorrt_llm::plugins::AllreducePlugin;
 using tensorrt_llm::kernels::AllReduceFusionOp;
 using tensorrt_llm::kernels::AllReduceStrategyType;
 using tensorrt_llm::kernels::AllReduceStrategyConfig;
+using tensorrt_llm::mpi::MpiTag;
 
 static char const* ALLREDUCE_PLUGIN_VERSION{"1"};
 static char const* ALLREDUCE_PLUGIN_NAME{"AllReduce"};
@@ -620,33 +621,36 @@ std::set<int> getLocalGroup(std::set<int> const& group)
             ranks.push_back(myRank);
             for (auto it = std::next(std::begin(group), 1); it != group.end(); ++it)
             {
-                COMM_SESSION.recvValue(rank, *it, 0);
+                COMM_SESSION.recvValue(rank, *it, MpiTag::kDefault);
                 ranks.push_back(rank);
             }
             for (auto it = std::next(std::begin(group), 1); it != group.end(); ++it)
             {
-                COMM_SESSION.send(ranks.data(), localSize, tensorrt_llm::mpi::MpiType::kINT32, *it, 0);
+                COMM_SESSION.send(ranks.data(), localSize, tensorrt_llm::mpi::MpiType::kINT32, *it, MpiTag::kDefault);
             }
 
             localRanks.clear();
             localRanks.push_back(myLocalRank);
             for (auto it = std::next(std::begin(group), 1); it != group.end(); ++it)
             {
-                COMM_SESSION.recvValue(rank, *it, 0);
+                COMM_SESSION.recvValue(rank, *it, MpiTag::kDefault);
                 localRanks.push_back(rank);
             }
             for (auto it = std::next(std::begin(group), 1); it != group.end(); ++it)
             {
-                COMM_SESSION.send(localRanks.data(), localSize, tensorrt_llm::mpi::MpiType::kINT32, *it, 0);
+                COMM_SESSION.send(
+                    localRanks.data(), localSize, tensorrt_llm::mpi::MpiType::kINT32, *it, MpiTag::kDefault);
             }
         }
         else
         {
-            COMM_SESSION.sendValue(myRank, *group.begin(), 0);
-            COMM_SESSION.recv(ranks.data(), localSize, tensorrt_llm::mpi::MpiType::kINT32, *group.begin(), 0);
+            COMM_SESSION.sendValue(myRank, *group.begin(), MpiTag::kDefault);
+            COMM_SESSION.recv(
+                ranks.data(), localSize, tensorrt_llm::mpi::MpiType::kINT32, *group.begin(), MpiTag::kDefault);
 
-            COMM_SESSION.sendValue(myLocalRank, *group.begin(), 0);
-            COMM_SESSION.recv(localRanks.data(), localSize, tensorrt_llm::mpi::MpiType::kINT32, *group.begin(), 0);
+            COMM_SESSION.sendValue(myLocalRank, *group.begin(), MpiTag::kDefault);
+            COMM_SESSION.recv(
+                localRanks.data(), localSize, tensorrt_llm::mpi::MpiType::kINT32, *group.begin(), MpiTag::kDefault);
         }
     }
 

--- a/cpp/tensorrt_llm/plugins/ncclPlugin/recvPlugin.cpp
+++ b/cpp/tensorrt_llm/plugins/ncclPlugin/recvPlugin.cpp
@@ -24,6 +24,7 @@
 using namespace nvinfer1;
 using tensorrt_llm::plugins::RecvPluginCreator;
 using tensorrt_llm::plugins::RecvPlugin;
+using tensorrt_llm::mpi::MpiTag;
 
 static char const* RECV_PLUGIN_VERSION{"1"};
 static char const* RECV_PLUGIN_NAME{"Recv"};
@@ -131,7 +132,7 @@ int RecvPlugin::initialize() noexcept
         return 0;
     }
     ncclUniqueId id;
-    COMM_SESSION.recvValue(id, mSrcRank, 0);
+    COMM_SESSION.recvValue(id, mSrcRank, MpiTag::kDefault);
 // Need static connection initialization for accurate KV cache size estimation
 #if defined(_WIN32)
     if (getenv("NCCL_RUNTIME_CONNECT") == nullptr)

--- a/cpp/tensorrt_llm/plugins/ncclPlugin/sendPlugin.cpp
+++ b/cpp/tensorrt_llm/plugins/ncclPlugin/sendPlugin.cpp
@@ -25,6 +25,7 @@
 using namespace nvinfer1;
 using tensorrt_llm::plugins::SendPluginCreator;
 using tensorrt_llm::plugins::SendPlugin;
+using tensorrt_llm::mpi::MpiTag;
 
 static char const* SEND_PLUGIN_VERSION{"1"};
 static char const* SEND_PLUGIN_NAME{"Send"};
@@ -134,7 +135,7 @@ int SendPlugin::initialize() noexcept
 
     ncclUniqueId id;
     ncclGetUniqueId(&id);
-    COMM_SESSION.sendValue(id, mTgtRank, 0);
+    COMM_SESSION.sendValue(id, mTgtRank, MpiTag::kDefault);
 // Need static connection initialization for accurate KV cache size estimation
 #if defined(_WIN32)
     if (getenv("NCCL_RUNTIME_CONNECT") == nullptr)

--- a/cpp/tensorrt_llm/runtime/ipcNvlsMemory.cpp
+++ b/cpp/tensorrt_llm/runtime/ipcNvlsMemory.cpp
@@ -71,21 +71,21 @@ void MPI_group_barrier(std::set<int> group)
         // Root receives messages from all other processes
         for (int i = 1; i < size; i++)
         {
-            COMM_SESSION.recv(&dummy, 1, MpiType::kINT32, ranks[i], 0);
+            COMM_SESSION.recv(&dummy, 1, MpiType::kINT32, ranks[i], MpiTag::kDefault);
         }
         // Root sends messages back to all other processes
         for (int i = 1; i < size; i++)
         {
-            COMM_SESSION.send(&dummy, 1, MpiType::kINT32, ranks[i], 0);
+            COMM_SESSION.send(&dummy, 1, MpiType::kINT32, ranks[i], MpiTag::kDefault);
         }
     }
     else
     {
         int dummy = 0;
         // Non-root processes send a message to root
-        COMM_SESSION.send(&dummy, 1, MpiType::kINT32, ranks[root], 0);
+        COMM_SESSION.send(&dummy, 1, MpiType::kINT32, ranks[root], MpiTag::kDefault);
         // Non-root processes receive a message from root
-        COMM_SESSION.recv(&dummy, 1, MpiType::kINT32, ranks[root], 0);
+        COMM_SESSION.recv(&dummy, 1, MpiType::kINT32, ranks[root], MpiTag::kDefault);
     }
 #else
     TLLM_THROW("MPI_group_barrier needs to be compiled with ENABLE_MULTI_DEVICE");
@@ -107,13 +107,13 @@ void MPI_group_bcast(std::set<int> group, void* buffer, int count, MpiType datat
         // Root sends message to all other processes
         for (size_t i = 1; i < ranks.size(); ++i)
         {
-            COMM_SESSION.send(buffer, count, datatype, ranks[i], 0);
+            COMM_SESSION.send(buffer, count, datatype, ranks[i], MpiTag::kDefault);
         }
     }
     else
     {
         // Non-root processes receive a message from root
-        COMM_SESSION.recv(buffer, count, datatype, ranks[root], 0);
+        COMM_SESSION.recv(buffer, count, datatype, ranks[root], MpiTag::kDefault);
     }
     MPI_group_barrier(group);
 #else

--- a/cpp/tensorrt_llm/runtime/utils/mpiUtils.cpp
+++ b/cpp/tensorrt_llm/runtime/utils/mpiUtils.cpp
@@ -297,14 +297,14 @@ void MpiComm::bcast(runtime::IBuffer& buf, int root) const
 
 std::shared_ptr<MpiRequest> MpiComm::sendAsync(void const* buffer, size_t size, MpiType dtype, int dest, int tag) const
 {
-    TLLM_LOG_DEBUG("start MPI_Isend with size %d", size);
+    TLLM_LOG_DEBUG("start MPI_Isend with dest %d, tag %d, size %d", dest, tag, size);
     std::shared_ptr<MpiRequest> r = std::make_shared<MpiRequest>();
 #if ENABLE_MULTI_DEVICE
     invokeChunked(MPI_Isend, buffer, size, getMpiDtype(dtype), dest, tag, mComm, &r->mRequest);
 #else
     TLLM_THROW("Multi device support is disabled.");
 #endif
-    TLLM_LOG_DEBUG("end MPI_Isend with size %d", size);
+    TLLM_LOG_DEBUG("end MPI_Isend with dest %d, tag %d, size %d", dest, tag, size);
     return r;
 }
 
@@ -315,13 +315,13 @@ std::shared_ptr<MpiRequest> MpiComm::sendAsync(runtime::IBuffer const& buf, int 
 
 void MpiComm::send(void const* buffer, size_t size, MpiType dtype, int dest, int tag) const
 {
-    TLLM_LOG_DEBUG("start MPI_Send with size %d", size);
+    TLLM_LOG_DEBUG("start MPI_Send with dest %d, tag %d, size %d", dest, tag, size);
 #if ENABLE_MULTI_DEVICE
     invokeChunked(MPI_Send, buffer, size, getMpiDtype(dtype), dest, tag, mComm);
 #else
     TLLM_THROW("Multi device support is disabled.");
 #endif // ENABLE_MULTI_DEVICE
-    TLLM_LOG_DEBUG("end MPI_Send with size %d", size);
+    TLLM_LOG_DEBUG("end MPI_Send with dest %d, tag %d, size %d", dest, tag, size);
 }
 
 void MpiComm::send(runtime::IBuffer const& buf, int dest, int tag) const
@@ -331,14 +331,14 @@ void MpiComm::send(runtime::IBuffer const& buf, int dest, int tag) const
 
 MPI_Status MpiComm::recv(void* buffer, size_t size, MpiType dtype, int source, int tag) const
 {
-    TLLM_LOG_DEBUG("start MPI_Recv with size %d", size);
+    TLLM_LOG_DEBUG("start MPI_Recv with source %d, tag %d, size %d", source, tag, size);
     MPI_Status status{};
 #if ENABLE_MULTI_DEVICE
     invokeChunked(MPI_Recv, buffer, size, getMpiDtype(dtype), source, tag, mComm, &status);
 #else
     TLLM_THROW("Multi device support is disabled.");
 #endif // ENABLE_MULTI_DEVICE
-    TLLM_LOG_DEBUG("end MPI_Recv with size %d", size);
+    TLLM_LOG_DEBUG("end MPI_Recv with source %d, tag %d, size %d", source, tag, size);
     return status;
 }
 

--- a/cpp/tensorrt_llm/runtime/utils/mpiUtils.cpp
+++ b/cpp/tensorrt_llm/runtime/utils/mpiUtils.cpp
@@ -295,25 +295,26 @@ void MpiComm::bcast(runtime::IBuffer& buf, int root) const
     bcast(buf.data(), buf.getSizeInBytes(), MpiType::kBYTE, root);
 }
 
-std::shared_ptr<MpiRequest> MpiComm::sendAsync(void const* buffer, size_t size, MpiType dtype, int dest, int tag) const
+std::shared_ptr<MpiRequest> MpiComm::sendAsync(
+    void const* buffer, size_t size, MpiType dtype, int dest, MpiTag tag) const
 {
-    TLLM_LOG_DEBUG("start MPI_Isend with dest %d, tag %d, size %d", dest, tag, size);
+    TLLM_LOG_DEBUG("start MPI_Isend with dest %d, tag %d, size %d", dest, static_cast<int>(tag), size);
     std::shared_ptr<MpiRequest> r = std::make_shared<MpiRequest>();
 #if ENABLE_MULTI_DEVICE
-    invokeChunked(MPI_Isend, buffer, size, getMpiDtype(dtype), dest, tag, mComm, &r->mRequest);
+    invokeChunked(MPI_Isend, buffer, size, getMpiDtype(dtype), dest, static_cast<int>(tag), mComm, &r->mRequest);
 #else
     TLLM_THROW("Multi device support is disabled.");
 #endif
-    TLLM_LOG_DEBUG("end MPI_Isend with dest %d, tag %d, size %d", dest, tag, size);
+    TLLM_LOG_DEBUG("end MPI_Isend with dest %d, tag %d, size %d", dest, static_cast<int>(tag), size);
     return r;
 }
 
-std::shared_ptr<MpiRequest> MpiComm::sendAsync(runtime::IBuffer const& buf, int dest, int tag) const
+std::shared_ptr<MpiRequest> MpiComm::sendAsync(runtime::IBuffer const& buf, int dest, MpiTag tag) const
 {
     return sendAsync(buf.data(), buf.getSizeInBytes(), MpiType::kBYTE, dest, tag);
 }
 
-void MpiComm::send(void const* buffer, size_t size, MpiType dtype, int dest, int tag) const
+void MpiComm::sendRawTag(void const* buffer, size_t size, MpiType dtype, int dest, int tag) const
 {
     TLLM_LOG_DEBUG("start MPI_Send with dest %d, tag %d, size %d", dest, tag, size);
 #if ENABLE_MULTI_DEVICE
@@ -324,12 +325,17 @@ void MpiComm::send(void const* buffer, size_t size, MpiType dtype, int dest, int
     TLLM_LOG_DEBUG("end MPI_Send with dest %d, tag %d, size %d", dest, tag, size);
 }
 
-void MpiComm::send(runtime::IBuffer const& buf, int dest, int tag) const
+void MpiComm::send(void const* buffer, size_t size, MpiType dtype, int dest, MpiTag tag) const
+{
+    sendRawTag(buffer, size, dtype, dest, static_cast<int>(tag));
+}
+
+void MpiComm::send(runtime::IBuffer const& buf, int dest, MpiTag tag) const
 {
     send(buf.data(), buf.getSizeInBytes(), MpiType::kBYTE, dest, tag);
 }
 
-MPI_Status MpiComm::recv(void* buffer, size_t size, MpiType dtype, int source, int tag) const
+MPI_Status MpiComm::recvRawTag(void* buffer, size_t size, MpiType dtype, int source, int tag) const
 {
     TLLM_LOG_DEBUG("start MPI_Recv with source %d, tag %d, size %d", source, tag, size);
     MPI_Status status{};
@@ -342,7 +348,12 @@ MPI_Status MpiComm::recv(void* buffer, size_t size, MpiType dtype, int source, i
     return status;
 }
 
-MPI_Status MpiComm::recv(runtime::IBuffer& buf, int source, int tag) const
+MPI_Status MpiComm::recv(void* buffer, size_t size, MpiType dtype, int source, MpiTag tag) const
+{
+    return recvRawTag(buffer, size, dtype, source, static_cast<int>(tag));
+}
+
+MPI_Status MpiComm::recv(runtime::IBuffer& buf, int source, MpiTag tag) const
 {
     return recv(buf.data(), buf.getSizeInBytes(), MpiType::kBYTE, source, tag);
 }
@@ -399,7 +410,7 @@ void MpiComm::allgatherv(void const* sendbuf, int sendcount, MpiType sendtype, v
 #endif // ENABLE_MULTI_DEVICE
 }
 
-void MpiComm::mprobe(int source, int tag, MPI_Message* msg, MPI_Status* status) const
+void MpiComm::mprobeRawTag(int source, int tag, MPI_Message* msg, MPI_Status* status) const
 {
 #if ENABLE_MULTI_DEVICE
     MPICHECK(MPI_Mprobe(source, tag, mComm, msg, status));
@@ -408,11 +419,16 @@ void MpiComm::mprobe(int source, int tag, MPI_Message* msg, MPI_Status* status) 
 #endif // ENABLE_MULTI_DEVICE
 }
 
-bool MpiComm::improbe(int source, int tag, MPI_Message* msg, MPI_Status* status) const
+void MpiComm::mprobe(int source, MpiTag tag, MPI_Message* msg, MPI_Status* status) const
+{
+    mprobeRawTag(source, static_cast<int>(tag), msg, status);
+}
+
+bool MpiComm::improbe(int source, MpiTag tag, MPI_Message* msg, MPI_Status* status) const
 {
 #if ENABLE_MULTI_DEVICE
     int flag{0};
-    MPICHECK(MPI_Improbe(source, tag, mComm, &flag, msg, status));
+    MPICHECK(MPI_Improbe(source, static_cast<int>(tag), mComm, &flag, msg, status));
     return flag != 0;
 #else
     TLLM_THROW("Multi device support is disabled.");
@@ -420,11 +436,11 @@ bool MpiComm::improbe(int source, int tag, MPI_Message* msg, MPI_Status* status)
 #endif
 }
 
-bool MpiComm::iprobe(int source, int tag, MPI_Status* status) const
+bool MpiComm::iprobe(int source, MpiTag tag, MPI_Status* status) const
 {
 #if ENABLE_MULTI_DEVICE
     int flag{0};
-    MPICHECK(MPI_Iprobe(source, tag, mComm, &flag, status));
+    MPICHECK(MPI_Iprobe(source, static_cast<int>(tag), mComm, &flag, status));
     return flag != 0;
 #else
     TLLM_THROW("Multi device support is disabled.");
@@ -432,7 +448,7 @@ bool MpiComm::iprobe(int source, int tag, MPI_Status* status) const
 #endif
 }
 
-void MpiComm::recvPoll(int source, int tag, int periodMs) const
+void MpiComm::recvPoll(int source, MpiTag tag, int periodMs) const
 {
     MPI_Status status;
     while (!iprobe(source, tag, &status))

--- a/cpp/tests/batch_manager/cacheTransceiverTest.cpp
+++ b/cpp/tests/batch_manager/cacheTransceiverTest.cpp
@@ -345,9 +345,9 @@ protected:
                 int64_t bufferSize = buffer.size();
                 TLLM_LOG_DEBUG(
                     tensorrt_llm::mpi::MpiComm::world().getRank(), "send bufferSize: %ld to %d", bufferSize, genRank);
-                tensorrt_llm::mpi::MpiComm::world().send(
+                tensorrt_llm::mpi::MpiComm::world().sendRawTag(
                     &bufferSize, 1, tensorrt_llm::mpi::MpiType::kINT64, genRank, 0x1F);
-                tensorrt_llm::mpi::MpiComm::world().send(
+                tensorrt_llm::mpi::MpiComm::world().sendRawTag(
                     buffer.data(), buffer.size(), tensorrt_llm::mpi::MpiType::kCHAR, genRank, 0x2F);
                 TLLM_LOG_DEBUG(tensorrt_llm::mpi::MpiComm::world().getRank(), "send buffer to %d", genRank);
                 mContextCommState = std::make_unique<tensorrt_llm::executor::kv_cache::CommState>(commState);
@@ -355,11 +355,12 @@ protected:
             else
             {
                 int64_t bufferSize;
-                tensorrt_llm::mpi::MpiComm::world().recv(&bufferSize, 1, tensorrt_llm::mpi::MpiType::kINT64, 0, 0x1F);
+                tensorrt_llm::mpi::MpiComm::world().recvRawTag(
+                    &bufferSize, 1, tensorrt_llm::mpi::MpiType::kINT64, 0, 0x1F);
                 TLLM_LOG_DEBUG(
                     tensorrt_llm::mpi::MpiComm::world().getRank(), "recv bufferSize: %ld from 0", bufferSize);
                 std::vector<char> recvBuffer(bufferSize);
-                tensorrt_llm::mpi::MpiComm::world().recv(
+                tensorrt_llm::mpi::MpiComm::world().recvRawTag(
                     recvBuffer.data(), bufferSize, tensorrt_llm::mpi::MpiType::kCHAR, 0, 0x2F);
                 TLLM_LOG_DEBUG(tensorrt_llm::mpi::MpiComm::world().getRank(), "recv buffer from 0", bufferSize);
                 std::istringstream iStream(std::string(recvBuffer.begin(), recvBuffer.end()));
@@ -752,9 +753,9 @@ protected:
                         int64_t bufferSize = buffer.size();
                         TLLM_LOG_DEBUG(tensorrt_llm::mpi::MpiComm::world().getRank(), "send bufferSize: %ld to %d",
                             bufferSize, genRank);
-                        tensorrt_llm::mpi::MpiComm::world().send(
+                        tensorrt_llm::mpi::MpiComm::world().sendRawTag(
                             &bufferSize, 1, tensorrt_llm::mpi::MpiType::kINT64, genRank, 0x1F);
-                        tensorrt_llm::mpi::MpiComm::world().send(
+                        tensorrt_llm::mpi::MpiComm::world().sendRawTag(
                             buffer.data(), buffer.size(), tensorrt_llm::mpi::MpiType::kCHAR, genRank, 0x2F);
                         TLLM_LOG_DEBUG(tensorrt_llm::mpi::MpiComm::world().getRank(), "send buffer to %d", genRank);
                     }
@@ -763,12 +764,12 @@ protected:
                 if (mIsGeneration)
                 {
                     int64_t bufferSize;
-                    tensorrt_llm::mpi::MpiComm::world().recv(
+                    tensorrt_llm::mpi::MpiComm::world().recvRawTag(
                         &bufferSize, 1, tensorrt_llm::mpi::MpiType::kINT64, 0, 0x1F);
                     TLLM_LOG_DEBUG(
                         tensorrt_llm::mpi::MpiComm::world().getRank(), "recv bufferSize: %ld from 0", bufferSize);
                     std::vector<char> recvBuffer(bufferSize);
-                    tensorrt_llm::mpi::MpiComm::world().recv(
+                    tensorrt_llm::mpi::MpiComm::world().recvRawTag(
                         recvBuffer.data(), bufferSize, tensorrt_llm::mpi::MpiType::kCHAR, 0, 0x2F);
                     TLLM_LOG_DEBUG(tensorrt_llm::mpi::MpiComm::world().getRank(), "recv buffer from 0", bufferSize);
                     std::istringstream iStream(std::string(recvBuffer.begin(), recvBuffer.end()));

--- a/cpp/tests/runtime/mpiUtilsTest.cpp
+++ b/cpp/tests/runtime/mpiUtilsTest.cpp
@@ -134,7 +134,7 @@ void testSendRecv()
     auto& comm = mpi::MpiComm::world();
     auto const rank = comm.getRank();
     auto constexpr expectedValue = static_cast<T>(42);
-    auto constexpr tag = 0;
+    auto constexpr tag = mpi::MpiTag::kDefault;
     if (rank == 0)
     {
         comm.sendValue(expectedValue, 1, tag);
@@ -171,7 +171,7 @@ void testSendMRecv()
     auto& comm = mpi::MpiComm::world();
     auto const rank = comm.getRank();
     auto constexpr expectedValue = static_cast<T>(42);
-    auto constexpr tag = 0;
+    auto constexpr tag = mpi::MpiTag::kDefault;
     if (rank == 0)
     {
         comm.sendValue(expectedValue, 1, tag);


### PR DESCRIPTION
## Description

refactor: Introduce MpiTag enumeration and update MPI function signatures
- Added a new header file `mpiTags.h` to define an enumeration for MPI tags, improving code readability and maintainability.
- Updated function signatures in `mpiUtils.h` and `mpiUtils.cpp` to use the new `MpiTag` type instead of raw integers for tags.
- Refactored various MPI calls across the codebase to utilize the new `MpiTag` enumeration, enhancing type safety and clarity.
- Removed redundant MPI tag constants from several classes, streamlining the code.

refactor: Enhance MPI logging and error handling
- Updated MPI logging to include destination and tag information for better traceability during send and receive operations.
- Added error checking for MPI_Wait and MPI_Cancel calls to ensure proper handling of multi-device requests.
- Improved code structure for clarity and maintainability.

refactor: Move executor recv functions into classes


## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
