### PR TITLE
fix:https://nvbugs/5234033 enable starcoder trt-flow with transforme…

### DIFF
--- a/tensorrt_llm/models/gpt/convert.py
+++ b/tensorrt_llm/models/gpt/convert.py
@@ -459,9 +459,9 @@ def load_weights_from_hf_model(hf_model,
                                            f'{prefix}.self_attn.k_proj', dtype)
             v_w, v_b = get_weight_and_bias(model_params,
                                            f'{prefix}.self_attn.v_proj', dtype)
-            qkv_w = torch.cat([q_w, k_w, v_w], dim=0)
-            qkv_b = torch.cat([q_b, k_b, v_b],
-                              dim=0) if q_b is not None else None
+            qkv_w = torch.cat([q_w.cuda(), k_w.cuda(), v_w.cuda()], dim=0)
+            qkv_b = torch.cat([q_b.cuda(), k_b.cuda(),
+                               v_b.cuda()], dim=0) if q_b is not None else None
         elif gpt_variant == 'persimmon':
             qkv_w, qkv_b = get_weight_and_bias(
                 model_params, f'{prefix}.self_attn.query_key_value', dtype)

--- a/tensorrt_llm/parameter.py
+++ b/tensorrt_llm/parameter.py
@@ -265,6 +265,9 @@ class Parameter:
     def _regularize_value(self, value):
         if isinstance(value, np.ndarray):
             return value
+
+        elif isinstance(value, torch.distributed.tensor.DTensor):
+            return value.to_local().cpu().numpy()
         elif isinstance(value, torch.Tensor):
             return torch_to_numpy(value)
         raise TypeError(


### PR DESCRIPTION

## Description

The recently transformer upgrading (from 4.46 to 4.51) introduces some changes on from_pretrained API.
If the host has multi-gpu, it will force load the weights on gpu devices and led the below error stack.

```bash
[rank0]:   File "/workspace/123/proj/TensorRT-LLM/tensorrt_llm/models/gpt/convert.py", line 480, in load_weights_from_hf_model
[rank0]:     qkv_b = torch.cat([q_b, k_b, v_b],
[rank0]:             ^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/torch/_compile.py", line 51, in inner
[rank0]:     return disable_fn(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/eval_frame.py", line 749, in _fn
[rank0]:     return fn(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/torch/distributed/tensor/_api.py", line 348, in __torch_dispatch__
[rank0]:     return DTensor._op_dispatcher.dispatch(
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/torch/distributed/tensor/_dispatch.py", line 183, in dispatch
[rank0]:     self.redistribute_local_args(
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/torch/distributed/tensor/_dispatch.py", line 319, in redistribute_local_args
[rank0]:     resharded_local_tensor = redistribute_local_tensor(
[rank0]:                              ^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/torch/distributed/tensor/_redistribute.py", line 213, in redistribute_local_tensor
[rank0]:     new_local_tensor = current_placement._to_replicate_tensor(
[rank0]:                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/torch/distributed/tensor/placement_types.py", line 260, in _to_replicate_tensor
[rank0]:     result = funcol.all_gather_tensor(
[rank0]:              ^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/torch/distributed/_functional_collectives.py", line 205, in all_gather_tensor
[rank0]:     tensor = torch.ops._c10d_functional.all_gather_into_tensor(
[rank0]:              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/torch/_ops.py", line 1156, in __call__
[rank0]:     return self._op(*args, **(kwargs or {}))
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]: RuntimeError: No backend type associated with device type cpu
```
Our solution is for qkv part of starcoder model, we put them on gpu side.
