### PR TITLE
fix[nvbug-5228840]: Add debug log memory infomation for memory allocation error

### DIFF
--- a/cpp/include/tensorrt_llm/common/cudaUtils.h
+++ b/cpp/include/tensorrt_llm/common/cudaUtils.h
@@ -90,7 +90,17 @@ enum class OperationType
 /* **************************** debug tools ********************************* */
 static char const* _cudaGetErrorEnum(cudaError_t error)
 {
-    return cudaGetErrorString(error);
+
+    if (error == cudaErrorMemoryAllocation)
+    {
+        size_t free, total;
+        cudaMemGetInfo(&free, &total);
+        return fmtstr("%s, free memory %d, total memory %d.", cudaGetErrorString(error), free, total).c_str();
+    }
+    else
+    {
+        return cudaGetErrorString(error);
+    }
 }
 
 static char const* _cudaGetErrorEnum(cublasStatus_t error)

--- a/cpp/include/tensorrt_llm/common/cudaUtils.h
+++ b/cpp/include/tensorrt_llm/common/cudaUtils.h
@@ -95,7 +95,7 @@ static char const* _cudaGetErrorEnum(cudaError_t error)
     {
         size_t free, total;
         cudaMemGetInfo(&free, &total);
-        return fmtstr("%s, free memory %d, total memory %d.", cudaGetErrorString(error), free, total).c_str();
+        return fmtstr("%s, free memory %ld, total memory %ld.", cudaGetErrorString(error), free, total).c_str();
     }
     else
     {


### PR DESCRIPTION
CI case failures happens flaky. Add debug log so that we can check memory status when failures happen next time.