### PR TITLE
[TRTLLM-4883][fix]: Update output speed calculation.

### DIFF
--- a/tensorrt_llm/bench/dataclasses/reporting.py
+++ b/tensorrt_llm/bench/dataclasses/reporting.py
@@ -493,8 +493,8 @@ class ReportUtility:
             f"Total Latency (ms):                               {perf['total_latency_ms']:.4f}\n"
             f"Average request latency (ms):                     {perf['avg_request_latency_ms']:.4f}\n"
             # Output Throughput includes context/first token.
-            f"Per User Output Throughput [w/ context] (tps/user): {perf['output_throughput_per_user_tok_s']:.4f}\n"
-            f"Per GPU Output Throughput (tps/gpu):                {perf['output_throughput_per_gpu_tok_s']:.4f}\n"
+            f"Per User Output Throughput [w/ ctx] (tps/user):   {perf['output_throughput_per_user_tok_s']:.4f}\n"
+            f"Per GPU Output Throughput (tps/gpu):              {perf['output_throughput_per_gpu_tok_s']:.4f}\n"
         )
 
         if streaming:

--- a/tensorrt_llm/bench/dataclasses/reporting.py
+++ b/tensorrt_llm/bench/dataclasses/reporting.py
@@ -370,6 +370,13 @@ class ReportUtility:
                         for k, v in
                         self.statistics.ttft_percentiles.model_dump().items()
                     },
+                "gen_tps_percentiles":
+                self.statistics.generation_tp_percentiles.model_dump(
+                    exclude_none=True, by_alias=True, mode='json') | {
+                        k: self.convert_to_ms(v)
+                        for k, v in self.statistics.generation_tp_percentiles.
+                        model_dump().items()
+                    },
             }
 
         spec_decoding, decoding_mode = False, None
@@ -507,15 +514,21 @@ class ReportUtility:
                 f"[TTFT] {key.upper():<7}: {ttft[key]:.4f}" for key in
                 ["minimum", "maximum", "average", "p50", "p90", "p95", "p99"])
 
+            gen_tps_stats = "\n".join(
+                f"[GTPS] {key.upper():<7}: {streaming['gen_tps_percentiles'][key]:.4f}"
+                for key in
+                ["minimum", "maximum", "average", "p50", "p90", "p95", "p99"])
+
             perf_stats += (
-                f"Average time-to-first-token [TTFT] (ms):          {streaming['avg_ttft_ms']:.4f}\n"
-                f"Average time-per-output-token [TPOT] (ms):        {streaming['avg_tpot_ms']:.4f}\n"
-                f"Per User Output Speed (tps/user) [1/avg(TPOT)]:   {streaming['token_output_speed_tok_s']:.4f}\n"
-                f"Per User Generation Throughput (tps/user):        {streaming['token_genphase_tok_per_s']:.4f}\n"
+                f"Average time-to-first-token [TTFT] (ms):   {streaming['avg_ttft_ms']:.4f}\n"
+                f"Average time-per-output-token [TPOT] (ms): {streaming['avg_tpot_ms']:.4f}\n"
+                f"Per User Output Speed (tps/user):          {streaming['token_output_speed_tok_s']:.4f}\n"
                 "\n-- Per-Request Time-per-Output-Token [TPOT] Breakdown (ms)\n\n"
                 f"{tpot_stats}\n"
                 "\n-- Per-Request Time-to-First-Token [TTFT] Breakdown (ms) \n\n"
-                f"{ttft_stats}\n")
+                f"{ttft_stats}\n"
+                "\n-- Per-Request Generation Throughput Breakdown (tps/user)\n\n"
+                f"{gen_tps_stats}\n")
 
         perf_stats += (
             "\n-- Request Latency Breakdown (ms) -----------------------\n\n"

--- a/tensorrt_llm/bench/dataclasses/reporting.py
+++ b/tensorrt_llm/bench/dataclasses/reporting.py
@@ -527,7 +527,7 @@ class ReportUtility:
                 f"{tpot_stats}\n"
                 "\n-- Per-Request Time-to-First-Token [TTFT] Breakdown (ms) \n\n"
                 f"{ttft_stats}\n"
-                "\n-- Per-Request Generation Throughput Breakdown (tps/user)\n\n"
+                "\n-- Per-Request Generation Throughput [GTPS] Breakdown (tps/user)\n\n"
                 f"{gen_tps_stats}\n")
 
         perf_stats += (

--- a/tensorrt_llm/bench/dataclasses/reporting.py
+++ b/tensorrt_llm/bench/dataclasses/reporting.py
@@ -368,6 +368,14 @@ class ReportUtility:
                         k: self.convert_to_ms(v)
                         for k, v in
                         self.statistics.ttft_percentiles.model_dump().items()
+                    },
+                # Per request generation token throughput percentiles (Genphase TPS)
+                "generation_tp_percentiles":
+                self.statistics.generation_tp_percentiles.model_dump(
+                    exclude_none=True, by_alias=True, mode='json') | {
+                        k: self.convert_to_ms(v)
+                        for k, v in self.statistics.generation_tp_percentiles.
+                        model_dump().items()
                     }
             }
 

--- a/tensorrt_llm/bench/dataclasses/reporting.py
+++ b/tensorrt_llm/bench/dataclasses/reporting.py
@@ -344,11 +344,8 @@ class ReportUtility:
                 self.statistics.per_user_time_per_output_token_ns)
 
             stats_dict["streaming_metrics"] = {
-                # Token output speed (1 / time-per-output-token)
-                # NOTE: Excludes TTFT by nature of using TPOT.
+                # NOTE: Excludes TTFT by nature as this is a genphase calculation.
                 "token_output_speed_tok_s":
-                1000.0 / avg_tpot,
-                "token_genphase_tok_per_s":
                 self.per_user_generation_token_throughput_s,
                 # Average per request time-to-first-token (TTFT)
                 "avg_ttft_ms":

--- a/tensorrt_llm/bench/dataclasses/reporting.py
+++ b/tensorrt_llm/bench/dataclasses/reporting.py
@@ -340,10 +340,15 @@ class ReportUtility:
         }
 
         if self.streaming:
+            avg_tpot = self.convert_to_ms(
+                self.statistics.per_user_time_per_output_token_ns)
+
             stats_dict["streaming_metrics"] = {
                 # Token output speed (1 / time-per-output-token)
                 # NOTE: Excludes TTFT by nature of using TPOT.
                 "token_output_speed_tok_s":
+                1000.0 / avg_tpot,
+                "token_genphase_tok_per_s":
                 self.per_user_generation_token_throughput_s,
                 # Average per request time-to-first-token (TTFT)
                 "avg_ttft_ms":
@@ -351,8 +356,7 @@ class ReportUtility:
                     self.statistics.per_user_time_to_first_token_ns),
                 # Average per request token time-per-output-token (TPOT)
                 "avg_tpot_ms":
-                self.convert_to_ms(
-                    self.statistics.per_user_time_per_output_token_ns),
+                avg_tpot,
                 # Average per request Time-per-output-token percentiles (TPOT)
                 "tpot_percentiles":
                 self.statistics.tpot_percentiles.model_dump(
@@ -509,8 +513,8 @@ class ReportUtility:
             perf_stats += (
                 f"Average time-to-first-token [TTFT] (ms):          {streaming['avg_ttft_ms']:.4f}\n"
                 f"Average time-per-output-token [TPOT] (ms):        {streaming['avg_tpot_ms']:.4f}\n"
-                f"Per User Output Speed (tps/user) [1/avg(TPOT)]:   {1000.0/itl.average:.4f}\n"
-                f"Per User Generation Throughput (tps/user):        {streaming['token_output_speed_tok_s']:.4f}\n"
+                f"Per User Output Speed (tps/user) [1/avg(TPOT)]:   {streaming['token_output_speed_tok_s']:.4f}\n"
+                f"Per User Generation Throughput (tps/user):        {streaming['token_genphase_tok_per_s']:.4f}\n"
                 "\n-- Per-Request Time-per-Output-Token [TPOT] Breakdown (ms)\n\n"
                 f"{tpot_stats}\n"
                 "\n-- Per-Request Time-to-First-Token [TTFT] Breakdown (ms) \n\n"

--- a/tensorrt_llm/bench/dataclasses/statistics.py
+++ b/tensorrt_llm/bench/dataclasses/statistics.py
@@ -165,7 +165,7 @@ class BenchmarkStatistics(BaseModel):
 
     @computed_field
     def per_user_generation_token_throughput_ns(self) -> float:
-        return 1.0 / self.tpot_percentiles.average
+        return self.generation_tp_percentiles.average
 
     @computed_field
     def request_throughput_ns(self) -> float:


### PR DESCRIPTION
## Description

The prior equation for output speed was incorrect as it didn't cover all cases. It was approximately accurate in most scenarios but could result in inaccurate representation of the genphase throughput. The PR updates the equation to aggregate the genphase throughput and then average instead of producing a calculation of `1/avg(TPOT)` across all requests.

Additionally, this MR adds the generation throughput breakdown so that we can have other stats like median, min, max available.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
