### PR TITLE
Feat: Variable-Beam-Width-Search (VBWS) part4

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
+++ b/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
@@ -1586,6 +1586,35 @@ public:
         return static_cast<float>(getMaxNumGeneratedTokens()) / mDecodingIter;
     }
 
+    /// @brief Get the beam width of the current decoding step.
+    /// @details Return `mSamplingConfig.beamWidth` in decoding modes beside Variable-Beam-Width-Search (VBWS).
+    /// Or returns a scalar value from `mSamplingConfig.beamWidthArray` indexing by `mDecodingIter` in VBWS.
+    ///
+    /// Calling in context phase, it returns the beam width of the first generation step, which is used for copying
+    /// logits (function `copyGenerationLogits` as example).
+    ///
+    /// Calling in generation phase, it returns the beam width of the input tokens in the current generation step, which
+    /// is used for computing I/O tensor shapes for TRT engine (function `RuntimeBuffers::setBufferSizes` as example).
+    ///
+    /// For example, we have a request with beamWidthArray = [2,3,4], the generation process can be:
+    ///
+    /// input_ids[1,inputLength] --->
+    /// ---> [Forward, step == 0] ---> logits[1, 1, vocabSize] ---> [BeamSearchDecoder] ---> tokens[1, 2]
+    ///     Context Phase, getBeamWidthByIter() returns 2 for copying logits
+    ///     Decoder uses beamWidthIn=2, beamWidthOut=2 to get top 2 tokens
+    /// ---> [Forward, step == 1] ---> logits[1, 2, vocabSize] ---> [BeamSearchDecoder] ---> tokens[1, 3]
+    ///     Generation phase, getBeamWidthByIter() returns 2 for computing tensor shapes
+    ///     Decoder uses beamWidthIn=2, beamWidthOut=3 to get top 3 tokens
+    /// ---> [Forward, step == 2] ---> logits[1, 3, vocabSize] ---> [BeamSearchDecoder] ---> tokens[1, 4]
+    ///     Generation phase, getBeamWidthByIter() returns 3 for computing tensor shapes
+    ///     Decoder uses beamWidthIn=3, beamWidthOut=4 to get top 4 tokens
+    /// ---> [Forward, step == 3] ---> logits[1, 4, vocabSize] ---> [BeamSearchDecoder] ---> tokens[1, 4]
+    ///     Generation phase, getBeamWidthByIter() returns 4 for computing tensor shapes
+    ///     Decoder uses beamWidthIn=4, beamWidthOut=4 to get top 4 tokens
+    /// ---> ...
+    ///     The same as normal Beam Search of `beamWidth==4`
+    [[nodiscard]] SizeType32 getBeamWidthByIter();
+
     [[nodiscard]] bool isFinished() const noexcept
     {
         return isGenerationCompleteState() || mState == LlmRequestState::kDISAGG_CONTEXT_TRANS_IN_PROGRESS;
@@ -1796,15 +1825,15 @@ public:
 protected:
     bool mIsStreaming;
 
-    // List of tokens generated at the current step, used as the input to the next step.
-    // `mLastTokens[beam] != mTokens.back()[beam]` in streaming + beam search
-    // as `mTokens` will be overwritten by the gathered tokens.
-    VecTokens mLastTokens; // [beamSize]
+    // List of tokens generated at the current step, used as the input tokens to the next step, [beamSize]
+    // `mLastTokens[beam]` is not equal to `mTokens.back()[beam]` in "Streaming + Beam Search" mode
+    // since `mTokens` will be overwritten by the gathered tokens.
+    VecTokens mLastTokens;
 
-    // List of tokens including input prompt and generated part.
-    BeamTokens mTokens; // [beamSize, mPromptLen + getMaxNumGeneratedTokens()]
+    // List of tokens including input prompt and generated part, [beamSize, mPromptLen + getMaxNumGeneratedTokens()]
+    BeamTokens mTokens;
 
-                        // Length of input prompt tokens, never changes during generation process.
+    // Length of input prompt tokens, never changes during generation process.
     SizeType32 mOrigPromptLen;
 
     // List of numbers of pre-deocded tokens on the last PP rank when using pipeline parallelism.

--- a/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
+++ b/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
@@ -1611,9 +1611,9 @@ public:
     /// ---> [Forward, step == 3] ---> logits[1, 4, vocabSize] ---> [BeamSearchDecoder] ---> tokens[1, 4]
     ///     Generation phase, getBeamWidthByIter() returns 4 for computing tensor shapes
     ///     Decoder uses beamWidthIn=4, beamWidthOut=4 to get top 4 tokens
-    /// ---> ...
-    ///     The same as normal Beam Search of `beamWidth==4`
-    [[nodiscard]] SizeType32 getBeamWidthByIter();
+    ///     i.e. the same as normal Beam Search of `beamWidth==4`
+    /// @param: forNextIteration: get beam width for next step rather than current beam width.
+    [[nodiscard]] SizeType32 getBeamWidthByIter(bool forNextIteration = false);
 
     [[nodiscard]] bool isFinished() const noexcept
     {

--- a/cpp/include/tensorrt_llm/batch_manager/runtimeBuffers.h
+++ b/cpp/include/tensorrt_llm/batch_manager/runtimeBuffers.h
@@ -180,8 +180,8 @@ public:
     //! Eagle decoding
     std::optional<runtime::EagleBuffers> eagleBuffers;
 
-    //! Language adapter routing information if language adapter is presented.
-    TensorPtr languageAdapterRoutings; // [numTokens, numLanguages]
+    //! Language adapter routing information if language adapter is presented, [numTokens, numLanguages]
+    TensorPtr languageAdapterRoutings;
 
     TensorPtr cacheIndirDecoderIOBatchedCopySrcOffsets;
     TensorPtr cacheIndirDecoderIOBatchedCopyDstOffsets;

--- a/cpp/include/tensorrt_llm/batch_manager/trtGptModelOptionalParams.h
+++ b/cpp/include/tensorrt_llm/batch_manager/trtGptModelOptionalParams.h
@@ -37,6 +37,7 @@ class TrtGptModelOptionalParams
 public:
     using SizeType32 = tensorrt_llm::runtime::SizeType32;
 
+    // 23 parameters, 23 items in initialization list
     explicit TrtGptModelOptionalParams(KvCacheConfig kvCacheConfig = KvCacheConfig{}, bool enableTrtOverlap = false,
         std::optional<std::vector<SizeType32>> deviceIds = std::nullopt, bool normalizeLogProbs = true,
         bool enableChunkedContext = true,
@@ -85,6 +86,7 @@ public:
         }
     }
 
+    // 2 parameters, 23 items in initialization list
     explicit TrtGptModelOptionalParams(executor::ExecutorConfig const& executorConfig, bool isLeaderInOrchMode)
         : TrtGptModelOptionalParams(KvCacheConfig(executorConfig.getKvCacheConfig()),
             executorConfig.getEnableTrtOverlap(),

--- a/cpp/include/tensorrt_llm/common/cudaUtils.h
+++ b/cpp/include/tensorrt_llm/common/cudaUtils.h
@@ -454,7 +454,7 @@ void printArrayInfo(T const* ptr, uint64_t nElement = 1, std::string name = "", 
     if (isDevicePtr)
     {
         tmpVec.resize(nElement);
-        tmp = tmpVec.data();
+        tmp = tmpVec.data(); // Note `data()` is not supported for vector<bool>
         check_cuda_error(cudaMemcpy(tmp, ptr, sizeInByte, cudaMemcpyDeviceToHost));
         cudaDeviceSynchronize();
     }
@@ -707,7 +707,7 @@ inline void printMatrix(T const* ptr, int nRow, int nCol, int nStride)
     {
         std::vector<T> tmpVec;
         tmpVec.resize(nRow * nStride);
-        T* tmp = tmpVec.data();
+        T* tmp = tmpVec.data(); // Note `data()` is not supported for vector<bool>
         check_cuda_error(cudaMemcpy(tmp, ptr, sizeInByte, cudaMemcpyDeviceToHost));
         cudaDeviceSynchronize();
         check_cuda_error(cudaGetLastError());

--- a/cpp/include/tensorrt_llm/common/cudaUtils.h
+++ b/cpp/include/tensorrt_llm/common/cudaUtils.h
@@ -626,6 +626,11 @@ __host__ __device__ inline void print_element_(__nv_fp8_e4m3 x)
 }
 #endif
 
+__host__ __device__ inline void print_element_(bool ui)
+{
+    printf("%7" PRIu32 " ", (unsigned int) ui);
+}
+
 __host__ __device__ inline void print_element_(uint8_t ui)
 {
     printf("%7" PRIu32 " ", (unsigned int) ui);

--- a/cpp/include/tensorrt_llm/executor/executor.h
+++ b/cpp/include/tensorrt_llm/executor/executor.h
@@ -139,8 +139,8 @@ private:
     static std::optional<SizeType32> const& checkNumReturnSequences(
         std::optional<SizeType32> const& numReturnSequences, SizeType32 beamWidth);
     static std::optional<FloatType> const& checkMinP(std::optional<FloatType> const& minP);
-    static std::optional<std::vector<SizeType32>> const& checkBeamWidthArray(
-        std::optional<std::vector<SizeType32>> const& beamWidthArray, std::optional<SizeType32> const beamWidth);
+    static std::pair<std::optional<std::vector<SizeType32>> const&, SizeType32 const> const checkBeamWidthArray(
+        std::optional<std::vector<SizeType32>> const& beamWidthArray, SizeType32 const beamWidth);
     void updateNumReturnBeams();
 
     friend class Serialization;
@@ -1426,8 +1426,7 @@ public:
         std::optional<GuidedDecodingConfig> guidedDecodingConfig = std::nullopt,
         std::optional<std::vector<AdditionalModelOutput>> additionalModelOutputs = std::nullopt,
         std::optional<CacheTransceiverConfig> cacheTransceiverConfig = std::nullopt,
-        bool gatherGenerationLogits = false, bool useVariableBeamWidthSearch = false,
-        bool promptTableOffloading = false, bool enableTrtOverlap = false);
+        bool gatherGenerationLogits = false, bool promptTableOffloading = false, bool enableTrtOverlap = false);
 
     [[nodiscard]] SizeType32 getMaxBeamWidth() const;
     [[nodiscard]] SchedulerConfig getSchedulerConfig() const;
@@ -1459,7 +1458,6 @@ public:
     [[nodiscard]] std::optional<GuidedDecodingConfig> getGuidedDecodingConfig() const;
     [[nodiscard]] std::optional<std::vector<AdditionalModelOutput>> getAdditionalModelOutputs() const;
     [[nodiscard]] bool getGatherGenerationLogits() const;
-    [[nodiscard]] bool getUseVariableBeamWidthSearch() const;
     [[nodiscard]] bool getPromptTableOffloading() const;
     [[nodiscard]] std::optional<CacheTransceiverConfig> getCacheTransceiverConfig() const;
     [[nodiscard]] bool getEnableTrtOverlap() const;
@@ -1489,7 +1487,6 @@ public:
     void setGuidedDecodingConfig(GuidedDecodingConfig const& guidedDecodingConfig);
     void setAdditionalModelOutputs(std::vector<AdditionalModelOutput> const& additionalModelOutputs);
     void setGatherGenerationLogits(bool gatherGenerationLogits);
-    void setUseVariableBeamWidthSearch(bool useVariableBeamWidthSearch);
     void setPromptTableOffloading(bool promptTableOffloading);
     void setCacheTransceiverConfig(CacheTransceiverConfig const& cacheTransceiverConfig);
     void setEnableTrtOverlap(bool enableTrtOverlap);
@@ -1573,9 +1570,6 @@ private:
 
     /// @brief Controls if generation logits should be gathered, so that returnGenerationLogits can be requested.
     bool mGatherGenerationLogits{false};
-
-    /// @brief Controls if Variable-Beam-Width-Search is enabled.
-    bool mUseVariableBeamWidthSearch{false};
 
     /// @brief Controls if prompt table offloading is enabled.
     bool mPromptTableOffloading{false};

--- a/cpp/include/tensorrt_llm/runtime/decodingInput.h
+++ b/cpp/include/tensorrt_llm/runtime/decodingInput.h
@@ -64,7 +64,6 @@ public:
     SizeType32 batchSize;
     //! The beam widths of each request, [batchSize]
     std::vector<SizeType32> beamWidths;
-
     //! The maximum value in the `stopWordsLens` tensor
     SizeType32 maxStopWordsLen;
     //! The maximum value in the `badWordsLens` tensor
@@ -97,6 +96,8 @@ public:
     //! Parameters for beam search
     //! KV cache index for beam search, [batchSize, beamWidth, maxSeqLen] on gpu
     TensorPtr cacheIndirection;
+    //! Steps of each request, for Variable-Beam-Width-Search, [batchSize]
+    std::optional<std::vector<SizeType32>> generationSteps;
 
     // Medusa
     class MedusaInputs

--- a/cpp/include/tensorrt_llm/runtime/generationInput.h
+++ b/cpp/include/tensorrt_llm/runtime/generationInput.h
@@ -109,18 +109,26 @@ public:
     //! Mandatory parameters
     SizeType32 endId;
     SizeType32 padId;
-    TensorPtr ids;     // [packedLength] or [batchSize, maxInputLength], on gpu
-    TensorPtr lengths; // [batchSize], on gpu
-    bool packed;       // indicates if ids are packed or padded to maxInputLength
+    //! [packedLength] or [batchSize, maxInputLength], on gpu
+    TensorPtr ids;
+    //! [batchSize], on gpu
+    TensorPtr lengths;
+    //! Indicates if ids are packed or padded to maxInputLength
+    bool packed;
 
     //! Optional parameters
-    TensorPtr embeddingBias;                // [vocabSizePadded], on gpu
-    TensorPtr badWordsList;                 // [2, badWordsLength] or [batchSize, 2, badWordsLength], on gpu
-    TensorPtr stopWordsList;                // [batchSize, 2, stopWordsLength], on gpu
-    std::optional<SizeType32> maxNewTokens; // max number of tokens to generate
+    //! [vocabSizePadded], on gpu
+    TensorPtr embeddingBias;
+    //! [2, badWordsLength] or [batchSize, 2, badWordsLength], on gpu
+    TensorPtr badWordsList;
+    //! [batchSize, 2, stopWordsLength], on gpu
+    TensorPtr stopWordsList;
+    //! // max number of tokens to generate
+    std::optional<SizeType32> maxNewTokens;
 
     //! Ptuning parameters
-    PromptTuningParams promptTuningParams; // See promptTuningParams.h for expected shapes
+    //! See promptTuningParams.h for expected shapes
+    PromptTuningParams promptTuningParams;
 };
 
 class GenerationInput : public GenericGenerationInput<ITensor::SharedPtr, PromptTuningParams>

--- a/cpp/include/tensorrt_llm/runtime/generationOutput.h
+++ b/cpp/include/tensorrt_llm/runtime/generationOutput.h
@@ -86,15 +86,20 @@ public:
     }
 
     //! Mandatory parameters
-    TensorPtr ids;     // [batchSize, beamWidth, maxInputLength + maxNewTokens], on gpu
-    TensorPtr lengths; // [batchSize, beamWidth], on gpu
+    //! [batchSize, beamWidth, maxInputLength + maxNewTokens], on gpu
+    TensorPtr ids;
+    //! [batchSize, beamWidth], on gpu
+    TensorPtr lengths;
 
     //! Optional parameters
-    TensorPtr cumLogProbs;      // [batchSize, beamWidth], on gpu
-    TensorPtr logProbs;         // [batchSize, beamWidth, maxInputLength + maxNewTokens], on gpu
-    TensorPtr contextLogits;    // [packedSize, vocabSizePadded] if packed
-                                // [batchSize, maxInputLength, vocabSizePadded] if not, on gpu
-    TensorPtr generationLogits; // [batchSize, beamWidth, maxOutputLength, vocabSizePadded], on gpu
+    //! [batchSize, beamWidth], on gpu
+    TensorPtr cumLogProbs;
+    //! [batchSize, beamWidth, maxInputLength + maxNewTokens], on gpu
+    TensorPtr logProbs;
+    //! // [packedSize, vocabSizePadded] if packed [batchSize, maxInputLength, vocabSizePadded] if not, on gpu
+    TensorPtr contextLogits;
+    //! // [batchSize, beamWidth, maxOutputLength, vocabSizePadded], on gpu
+    TensorPtr generationLogits;
 
     //! Callbacks
     Callback onTokenGenerated;

--- a/cpp/include/tensorrt_llm/runtime/iGptDecoderBatched.h
+++ b/cpp/include/tensorrt_llm/runtime/iGptDecoderBatched.h
@@ -62,6 +62,7 @@ public:
     }
 
     //! Mandatory parameters
+    //! Logits
     // FIXME: remove first dimension of tensors
     //! [maxDecoderSteps][batchSize][1, beamWidth, vocabSizePadded], on gpu
     std::vector<std::vector<TensorConstPtr>> logits;
@@ -74,9 +75,14 @@ public:
     //! Filled with slots in request order, [batchSize]
     TensorPtr batchSlotsRequestOrder;
 
-    //! For beam search
-    //! Indices into KV cache of different rays within one beam
-    TensorPtr cacheIndirection; // [maxBatchSize, maxBeamWidth, maxSeqLen], on gpu
+    //! For Beam Search
+    //! Indices into KV cache of different rays within one beam, [maxBatchSize, maxBeamWidth, maxSeqLen], on gpu
+    TensorPtr cacheIndirection;
+    //! The generation step of each request (for Variable-Beam-Width-Search), [batchSize]
+    std::vector<SizeType32> generationSteps;
+
+    //! For speculative decoding
+    //! Logits of draft
     //! [maxBatchSize][maxAcceptedDraftTokensPerStep][maxDraftTokens + 1, vocabSizePadded]
     std::vector<std::vector<TensorPtr>> predictedDraftLogits;
 
@@ -96,8 +102,8 @@ public:
 
     Output() = default;
 
-    // parameters for beam search
-    TensorPtr cacheIndirection; // [batchSize, maxBeamWidth, maxSeqLen], mandatory in beam search, on gpu
+    //! parameters for beam search, [batchSize, maxBeamWidth, maxSeqLen], on gpu
+    TensorPtr cacheIndirection;
 };
 
 } // namespace decoder_batch

--- a/cpp/include/tensorrt_llm/runtime/iStatefulGptDecoder.h
+++ b/cpp/include/tensorrt_llm/runtime/iStatefulGptDecoder.h
@@ -52,11 +52,13 @@ public:
         TLLM_CHECK_WITH_INFO(static_cast<bool>(this->logits), "Invalid logits tensor");
     }
 
-    // mandatory parameters
-    TensorPtr logits; // [batchSize, maxBeamWidth, vocabSizePadded], on gpu
+    //! Mandatory parameters
+    //! [batchSize, maxBeamWidth, vocabSizePadded], on gpu
+    TensorPtr logits;
 
-    // parameters for beam search
-    TensorPtr cacheIndirection; // [batchSize, maxBeamWidth, maxSeqLen] - the k/v cache index for beam search, on gpu
+    //! Parameters for Beam Search
+    //! K/V cache index for beam search, [batchSize, maxBeamWidth, maxSeqLen], on gpu
+    TensorPtr cacheIndirection;
 };
 
 class Output
@@ -66,9 +68,11 @@ public:
 
     Output() = default;
 
-    // parameters for beam search
-    TensorPtr cacheIndirection; // [batchSize, maxBeamWidth, maxSeqLen], mandatory in beam search, on gpu
-    TensorPtr sequenceLengths;  // [batchSize, maxBeamWidth], mandatory, on gpu
+    //! Mandatory for beam search
+    //! [batchSize, maxBeamWidth, maxSeqLen], on gpu
+    TensorPtr cacheIndirection;
+    //! [batchSize, maxBeamWidth], on gpu
+    TensorPtr sequenceLengths;
 };
 } // namespace decoder
 

--- a/cpp/include/tensorrt_llm/runtime/promptTuningParams.h
+++ b/cpp/include/tensorrt_llm/runtime/promptTuningParams.h
@@ -66,7 +66,7 @@ public:
 
     // Fill the tasks tensor for the batch using the provided tasksHost
     // Function assumes that the first numContextRequests requests in the batch are context requests
-    void fillTasksTensor(TensorPtr tasksHost, const SizeType32 batchSize, const SizeType32 numContextRequests,
+    void fillTasksTensor(TensorPtr tasksHost, SizeType32 batchSize, SizeType32 numContextRequests,
         std::vector<SizeType32> const& reqBeamWidths, std::vector<SizeType32> const& reqPromptLengths,
         BufferManager const& manager, bool packedInput);
 };

--- a/cpp/include/tensorrt_llm/runtime/samplingConfig.h
+++ b/cpp/include/tensorrt_llm/runtime/samplingConfig.h
@@ -18,7 +18,6 @@
 
 #include "tensorrt_llm/common/logger.h"
 #include "tensorrt_llm/executor/executor.h"
-#include "tensorrt_llm/kernels/beamSearchKernels.h"
 #include "tensorrt_llm/layers/defaultDecodingParams.h"
 #include "tensorrt_llm/runtime/common.h"
 
@@ -394,36 +393,6 @@ public:
             return std::min(numReturnSequences.value(), beamWidth);
         }
         return beamWidth;
-    }
-
-    // @brief Get the beam width of a request in a given generation step `decodingIter`.
-    // @details This function is only called for network iteration part (not for decoder part) in generation phase.
-    // The return `beamWidth` could be understood as "beamWidth of the input tokens".
-    // For normal beam search (Variable-Beam-Width-Search, VBWS is disabled), it just return its member `beamWidth`.
-    // For VBWS, it get beam width by indexing proper value in its member `beamWidthArray`.
-    // For example, we have a request with beamWidthArray = [2,3,4], the generation process can be like:
-    // input_ids --->
-    // ---> [Forward, step == 0] ---> logits[1, 1, vocabSize]   // Context Phase, forward process uses beamWidth = 1
-    // ---> [BeamSearchDecoder] ---> tokens[1, 2]               // Decoder uses beamWidth = 2
-    // ---> [Forward, step == 1] ---> logits[1, 2, vocabSize]   // decodingIter=1, beamWidth = beamWidthArray[0] = 2
-    // ---> [BeamSearchDecoder] ---> tokens[1, 3]               // Decoder changes beamWidth to 3
-    // ---> [Forward, step == 2] ---> logits[1, 3, vocabSize]   // decodingIter=2, beamWidth = beamWidthArray[1] = 3
-    // ---> [BeamSearchDecoder] ---> tokens[1, 4]               // Decoder changes beamWidth to 4
-    // ---> [Forward, step == 3] ---> logits[1, 3, vocabSize]   // decodingIter=2, beamWidth = beamWidthArray[2] = 4
-    // ...                                                      // Both forward process and decoder use beamWidth = 4
-    SizeType32 getBeamWidthByIter(int const decodingIter, int const indexSC = 0) const noexcept
-    {
-        SizeType32 reqBeamWidth = this->beamWidth; // For non-Variable-Beam-Width-Search
-        auto const& beamWidthArray = this->beamWidthArray;
-        if (beamWidthArray.has_value())
-        {
-            TLLM_CHECK_WITH_INFO(decodingIter > 0, "getBeamWidthByIter should only be called in generation phase.");
-            // Clamped `decodingIter` into [0,kMaxBeamWidthArrayLength-1] as index
-            int const index
-                = std::min(decodingIter, static_cast<int>(tensorrt_llm::kernels::kMaxBeamWidthArrayLength)) - 1;
-            reqBeamWidth = beamWidthArray.value()[indexSC][index];
-        }
-        return reqBeamWidth;
     }
 
     // Get the maximum beam width of a whole SamplingConfig

--- a/cpp/tensorrt_llm/batch_manager/encoderBuffers.cpp
+++ b/cpp/tensorrt_llm/batch_manager/encoderBuffers.cpp
@@ -486,7 +486,7 @@ void EncoderBuffers::setBufferSizes(RequestVector const& contextRequests, Reques
 
     for (auto const& llmReq : genRequests)
     {
-        auto const reqBeamWidth = llmReq->mSamplingConfig.beamWidth;
+        auto const reqBeamWidth = llmReq->getBeamWidthByIter();
         numRequests += reqBeamWidth; // tile by beam width
         maxInputLengthInBatch = std::max(maxInputLengthInBatch, llmReq->getEncoderInputLen());
     }
@@ -532,7 +532,7 @@ void EncoderBuffers::fill(
             }
             else
             {
-                auto const reqBeamWidth = llmReq->mSamplingConfig.beamWidth;
+                auto const reqBeamWidth = llmReq->getBeamWidthByIter();
                 std::fill_n(std::back_inserter(inputLengthsAll), reqBeamWidth,
                     llmReq->getEncoderOutputLen()); // although encoder output is not needed, gen phase still needs the
                                                     // encoder length info for cross kv cache. Also tile by beam width

--- a/cpp/tensorrt_llm/batch_manager/handleGenerationLogits.cpp
+++ b/cpp/tensorrt_llm/batch_manager/handleGenerationLogits.cpp
@@ -82,7 +82,7 @@ void HandleGenerationLogits::operator()(SizeType32 logitsIndex, RequestVector co
 
     for (auto const& llmReq : generationRequests)
     {
-        auto const reqBeamWidth = llmReq->mSamplingConfig.beamWidth;
+        auto const reqBeamWidth = llmReq->getBeamWidthByIter();
         auto const seqSlot = llmReq->mSeqSlot.value();
 
         auto const draftLength = llmReq->getNumDraftTokens();

--- a/cpp/tensorrt_llm/batch_manager/llmRequest.cpp
+++ b/cpp/tensorrt_llm/batch_manager/llmRequest.cpp
@@ -22,15 +22,16 @@ namespace tensorrt_llm::batch_manager
 {
 
 template <typename TTensor, typename TStream>
-runtime::SizeType32 GenericLlmRequest<TTensor, TStream>::getBeamWidthByIter()
+runtime::SizeType32 GenericLlmRequest<TTensor, TStream>::getBeamWidthByIter(bool const forNextIteration)
 {
     runtime::SizeType32 beamWidth = mSamplingConfig.beamWidth; // For non-Variable-Beam-Width-Search
     auto const& beamWidthArray = mSamplingConfig.beamWidthArray;
     if (beamWidthArray.has_value())
     {
+        auto const iter = mDecodingIter + (forNextIteration ? 1 : 0);
         // Clamped `decodingIter` into [0,kMaxBeamWidthArrayLength-1] as index
-        int const index = std::max(
-            std::min(mDecodingIter, static_cast<int>(tensorrt_llm::kernels::kMaxBeamWidthArrayLength)) - 1, 0);
+        int const index
+            = std::max(std::min(iter, static_cast<int>(tensorrt_llm::kernels::kMaxBeamWidthArrayLength)) - 1, 0);
         beamWidth = beamWidthArray.value()[0][index];
     }
     return beamWidth;

--- a/cpp/tensorrt_llm/batch_manager/llmRequest.cpp
+++ b/cpp/tensorrt_llm/batch_manager/llmRequest.cpp
@@ -16,9 +16,27 @@
  */
 
 #include "tensorrt_llm/batch_manager/llmRequest.h"
+#include "tensorrt_llm/kernels/beamSearchKernels.h"
 
 namespace tensorrt_llm::batch_manager
 {
+
+template <typename TTensor, typename TStream>
+runtime::SizeType32 GenericLlmRequest<TTensor, TStream>::getBeamWidthByIter()
+{
+    runtime::SizeType32 beamWidth = mSamplingConfig.beamWidth; // For non-Variable-Beam-Width-Search
+    auto const& beamWidthArray = mSamplingConfig.beamWidthArray;
+    if (beamWidthArray.has_value())
+    {
+        // Clamped `decodingIter` into [0,kMaxBeamWidthArrayLength-1] as index
+        int const index = std::max(
+            std::min(mDecodingIter, static_cast<int>(tensorrt_llm::kernels::kMaxBeamWidthArrayLength)) - 1, 0);
+        beamWidth = beamWidthArray.value()[0][index];
+    }
+    return beamWidth;
+}
+
+template class GenericLlmRequest<runtime::ITensor::SharedPtr>;
 
 /// Note that there is some dependency on the order of operations in this method. Modify with care!
 std::optional<executor::Response> LlmRequest::createResponse(bool useFastLogits, int32_t mpiWorldRank)

--- a/cpp/tensorrt_llm/batch_manager/runtimeBuffers.cpp
+++ b/cpp/tensorrt_llm/batch_manager/runtimeBuffers.cpp
@@ -409,7 +409,7 @@ void RuntimeBuffers::setBufferSizes(RequestVector const& contextRequests, Reques
     numGenTokens = 0;
     for (auto const& llmReq : genRequests)
     {
-        auto const reqBeamWidth = llmReq->mSamplingConfig.beamWidth;
+        auto const reqBeamWidth = llmReq->getBeamWidthByIter();
         numGenSequences += reqBeamWidth;
         auto const draftLen = llmReq->getNumDraftTokens();
         numGenTokens += draftLen + reqBeamWidth;
@@ -635,8 +635,7 @@ void RuntimeBuffers::setFromInputs(RequestVector const& contextRequests, Request
         auto numSequences = numContextRequests;
         for (auto const& llmReq : genRequests)
         {
-            auto const reqBeamWidth = llmReq->mSamplingConfig.beamWidth;
-
+            auto const reqBeamWidth = llmReq->getBeamWidthByIter();
             auto const draftLength = llmReq->getNumDraftTokens();
             auto const& draftTokens = llmReq->getDraftTokens();
             auto const numLogits = draftLength + reqBeamWidth;
@@ -735,8 +734,7 @@ void RuntimeBuffers::setFromInputs(RequestVector const& contextRequests, Request
         numSequences = numContextRequests;
         for (auto const& llmReq : genRequests)
         {
-            auto const reqBeamWidth = llmReq->mSamplingConfig.beamWidth;
-
+            auto const reqBeamWidth = llmReq->getBeamWidthByIter();
             auto const draftLength = llmReq->getNumDraftTokens();
 
             auto const contextQLength = llmReq->mPromptLen + draftLength;

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -1801,7 +1801,7 @@ void TrtGptModelInflightBatching::postProcessRequest(
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
     auto const seqSlot = llmReq.mSeqSlot.value();
-    auto const reqBeamWidth = llmReq.getBeamWidthByIter();
+    auto const reqBeamWidth = llmReq.getBeamWidthByIter(true);
     auto const& bufferManager = getBufferManager();
 
     if (llmReq.getReturnGenerationLogits() && !llmReq.getGenerationLogitsFragments().empty())

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -1310,14 +1310,15 @@ executor::DecodingMode getDecodingMode(SpeculativeDecodingMode specDecodingMode,
         {
             return decodingModeOpt.value();
         }
-        if (beamWidth == 1)
-        {
-            return executor::DecodingMode::TopKTopP();
-        }
-        return executor::DecodingMode::BeamSearch();
+        return (beamWidth == 1) ? executor::DecodingMode::TopKTopP() : executor::DecodingMode::BeamSearch();
     };
 
     auto decodingMode = getDefaultDecodingMode(decodingModeOpt);
+    // Variable-Beam-Width-Search (special mode of Beam-Search) is enabled.
+    if (decodingMode.isBeamSearch() && decodingMode.isUseVariableBeamWidthSearch())
+    {
+        TLLM_LOG_INFO("Variable-Beam-Width-Search is enabled");
+    }
     // Overwrite decoding mode when beam width is one.
     if (beamWidth == 1 && decodingMode.isBeamSearch())
     {
@@ -1401,6 +1402,7 @@ void TrtGptModelInflightBatching::createDecoder(std::optional<executor::Decoding
 
         auto const decodingMode
             = getDecodingMode(mModelConfig.getSpeculativeDecodingMode(), decodingModeOpt, mOperatingBeamWidth);
+
         if (decodingMode.isExplicitDraftTokens())
         {
             // There are no logits in Explicit draft tokens model.
@@ -1412,6 +1414,7 @@ void TrtGptModelInflightBatching::createDecoder(std::optional<executor::Decoding
                 decoderType = nvinfer1::DataType::kHALF;
             }
         }
+
         mDecoder = std::make_shared<runtime::GptDecoderBatched>(
             mRuntime->getStreamPtr(), mModelConfig.getSpeculativeDecodingMode(), decoderType);
         mDecoder->setup(decodingMode, getMaxNumSequences(), mOperatingBeamWidth, getMaxAttentionWindow(),
@@ -1422,11 +1425,11 @@ void TrtGptModelInflightBatching::createDecoder(std::optional<executor::Decoding
         {
             mDecoder->getDecoderState().setupExplicitDraftTokens(mDecoderBuffers->explicitDraftTokensBuffers);
         }
-        if (decodingMode.isLookahead())
+        else if (decodingMode.isLookahead())
         {
             mDecoder->getDecoderState().setupLookahead(mDecoderBuffers->lookaheadBuffers.value());
         }
-        if (decodingMode.isEagle())
+        else if (decodingMode.isEagle())
         {
             mDecoder->getDecoderState().setupEagle(mDecoderBuffers->eagleBuffers);
         }
@@ -1646,6 +1649,10 @@ TrtGptModelInflightBatching::prepareBuffers(
         mCrossKvCacheManager.get(), mRnnStateManager.get(), mPeftTables[bufferId], *mRuntime, mModelConfig,
         mWorldConfig, getGatherGenerationLogits(), isTrtOverlap(), allNewTokens);
 
+    // For Variable-Beam-Width-Search
+    mRuntime->setCurrentBeamWidths(
+        tensorrt_llm::batch_manager::utils::getRequestBeamWidths(contextRequests, generationRequests));
+
     mRuntime->setInputTensors(optProfileId, inputMap);
     mRuntime->setOutputTensors(optProfileId, outputMap);
 
@@ -1794,7 +1801,7 @@ void TrtGptModelInflightBatching::postProcessRequest(
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
     auto const seqSlot = llmReq.mSeqSlot.value();
-    auto const reqBeamWidth = llmReq.mSamplingConfig.beamWidth;
+    auto const reqBeamWidth = llmReq.getBeamWidthByIter();
     auto const& bufferManager = getBufferManager();
 
     if (llmReq.getReturnGenerationLogits() && !llmReq.getGenerationLogitsFragments().empty())
@@ -2042,7 +2049,7 @@ void TrtGptModelInflightBatching::copyCacheIndirectionFromOutputsToInputs(
     {
         for (auto const& llmReq : requests)
         {
-            auto const reqBeamWidth = llmReq->mSamplingConfig.beamWidth;
+            auto const reqBeamWidth = llmReq->getBeamWidthByIter();
             auto const seqSlot = llmReq->mSeqSlot.value();
             auto const copySize = static_cast<SizeType64>(cacheIndirShape.d[2]) * reqBeamWidth;
             srcOffsetsPtr[batchIdx] = seqSlot * copySize;
@@ -2153,7 +2160,7 @@ void TrtGptModelInflightBatching::updateRequests(ScheduledRequests const& schedu
         {
             continue;
         }
-        auto const reqBeamWidth = llmReq->mSamplingConfig.beamWidth;
+        auto const reqBeamWidth = llmReq->getBeamWidthByIter();
         auto const seqSlot = llmReq->mSeqSlot.value();
         auto const numGeneratedTokens = llmReq->getNumDraftTokens() + 1;
         auto const currentNumOfTokens = llmReq->getMaxBeamNumTokens();

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -2160,13 +2160,13 @@ void TrtGptModelInflightBatching::updateRequests(ScheduledRequests const& schedu
         {
             continue;
         }
-        auto const reqBeamWidth = llmReq->getBeamWidthByIter();
+        auto const reqBeamWidth = llmReq->getBeamWidthByIter(true);
         auto const seqSlot = llmReq->mSeqSlot.value();
         auto const numGeneratedTokens = llmReq->getNumDraftTokens() + 1;
         auto const currentNumOfTokens = llmReq->getMaxBeamNumTokens();
 
         // Save the accepted token logits from target model
-        if (llmReq->getReturnGenerationLogits() && mModelConfig.getSpeculativeDecodingMode().isDraftTokensExternal()
+        if (mModelConfig.getSpeculativeDecodingMode().isDraftTokensExternal() && llmReq->getReturnGenerationLogits()
             && llmReq->hasDraftTokens())
         {
             TLLM_CHECK_WITH_INFO(reqBeamWidth == 1, "Speculative decoding only works for beam width == 1");

--- a/cpp/tensorrt_llm/batch_manager/utils/inflightBatchingUtils.cpp
+++ b/cpp/tensorrt_llm/batch_manager/utils/inflightBatchingUtils.cpp
@@ -80,7 +80,7 @@ void copyGenerationLogits(RuntimeBuffers::GenerationLogitsCache& generationLogit
     TLLM_CHECK_WITH_INFO(
         !beforeDecoder || numDroppedTokens.empty(), "numDroppedTokens are only possible after decoder.");
 
-    auto const reqBeamWidth = llmReq.mSamplingConfig.beamWidth;
+    auto const reqBeamWidth = llmReq.getBeamWidthByIter();
     TLLM_CHECK_WITH_INFO(numDroppedTokens.empty() || numDroppedTokens.size() == static_cast<size_t>(reqBeamWidth),
         "Dropped tokens have to be defined for all beams.");
 
@@ -182,7 +182,7 @@ void copyAdditionalOutputs(std::vector<executor::AdditionalModelOutput> const& a
 
                 auto const srcTensorIndex = gatherContext ? srcTensorIndexWithContext : srcTensorIndexWithoutContext;
                 auto srcView = ITensor::slice(tensor, srcTensorIndex - 1, 1);
-                for (SizeType32 beam = 0; beam < llmReq->mSamplingConfig.beamWidth; beam++)
+                for (SizeType32 beam = 0; beam < llmReq->getBeamWidthByIter(); beam++)
                 {
                     auto dstView = ITensor::slice(outputTensor.second, {beam, 0}, 1);
                     manager.copy(*srcView, *dstView);
@@ -193,7 +193,7 @@ void copyAdditionalOutputs(std::vector<executor::AdditionalModelOutput> const& a
 
     for (auto const& llmReq : generationRequests)
     {
-        auto const reqBeamWidth = llmReq->mSamplingConfig.beamWidth;
+        auto const reqBeamWidth = llmReq->getBeamWidthByIter();
         for (auto const& outputTensor : llmReq->getAdditionalGenerationOutputs())
         {
             auto const& [tensor, gatherContext]
@@ -266,6 +266,20 @@ void terminateRequest(SequenceSlotManager& seqSlotManager, LlmRequest& llmReq, S
         peftCacheManager->markRequestDone(llmReq, pause);
     }
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
+}
+
+std::vector<SizeType32> getRequestBeamWidths(
+    RequestVector const& contextRequests, RequestVector const& generationRequests)
+{
+    std::vector<SizeType32> beamWidths{};
+    for (auto const& requests : {contextRequests, generationRequests})
+    {
+        for (auto const& llmReq : requests)
+        {
+            beamWidths.push_back(llmReq->getBeamWidthByIter());
+        }
+    }
+    return beamWidths;
 }
 
 void CudaGraphExecutor::create(cudaGraph_t const& graph)

--- a/cpp/tensorrt_llm/batch_manager/utils/inflightBatchingUtils.h
+++ b/cpp/tensorrt_llm/batch_manager/utils/inflightBatchingUtils.h
@@ -60,6 +60,9 @@ void terminateRequest(SequenceSlotManager& seqSlotManager, LlmRequest& llmReques
     OptionalRef<kv_cache_manager::BaseKVCacheManager> crossKvCacheManager = std::nullopt,
     OptionalRef<BasePeftCacheManager> peftCacheManager = std::nullopt, bool pause = false);
 
+std::vector<SizeType32> getRequestBeamWidths(
+    RequestVector const& contextRequests, RequestVector const& generationRequests);
+
 class CudaGraphExecutor
 {
 public:

--- a/cpp/tensorrt_llm/executor/executorConfig.cpp
+++ b/cpp/tensorrt_llm/executor/executorConfig.cpp
@@ -34,7 +34,7 @@ ExecutorConfig::ExecutorConfig(SizeType32 maxBeamWidth, SchedulerConfig schedule
     std::optional<SpeculativeDecodingConfig> specDecConfig, std::optional<GuidedDecodingConfig> guidedDecodingConfig,
     std::optional<std::vector<AdditionalModelOutput>> additionalModelOutputs,
     std::optional<CacheTransceiverConfig> cacheTransceiverConfig, bool gatherGenerationLogits,
-    bool useVariableBeamWidthSearch, bool promptTableOffloading, bool enableTrtOverlap)
+    bool promptTableOffloading, bool enableTrtOverlap)
     : mMaxBeamWidth(maxBeamWidth)
     , mSchedulerConfig(std::move(schedulerConfig))
     , mKvCacheConfig(std::move(kvCacheConfig))
@@ -61,7 +61,6 @@ ExecutorConfig::ExecutorConfig(SizeType32 maxBeamWidth, SchedulerConfig schedule
     , mAdditionalModelOutputs(std::move(additionalModelOutputs))
     , mCacheTransceiverConfig(std::move(cacheTransceiverConfig))
     , mGatherGenerationLogits(gatherGenerationLogits)
-    , mUseVariableBeamWidthSearch(useVariableBeamWidthSearch)
     , mPromptTableOffloading(promptTableOffloading)
     , mEnableTrtOverlap(enableTrtOverlap)
 {
@@ -213,11 +212,6 @@ bool ExecutorConfig::getGatherGenerationLogits() const
     return mGatherGenerationLogits;
 }
 
-bool ExecutorConfig::getUseVariableBeamWidthSearch() const
-{
-    return mUseVariableBeamWidthSearch;
-}
-
 bool ExecutorConfig::getPromptTableOffloading() const
 {
     return mPromptTableOffloading;
@@ -365,11 +359,6 @@ void ExecutorConfig::setCacheTransceiverConfig(CacheTransceiverConfig const& cac
 void ExecutorConfig::setGatherGenerationLogits(bool gatherGenerationLogits)
 {
     mGatherGenerationLogits = gatherGenerationLogits;
-}
-
-void ExecutorConfig::setUseVariableBeamWidthSearch(bool useVariableBeamWidthSearch)
-{
-    mUseVariableBeamWidthSearch = useVariableBeamWidthSearch;
 }
 
 void ExecutorConfig::setPromptTableOffloading(bool promptTableOffloading)

--- a/cpp/tensorrt_llm/executor/serialization.cpp
+++ b/cpp/tensorrt_llm/executor/serialization.cpp
@@ -996,8 +996,6 @@ ExecutorConfig Serialization::deserializeExecutorConfig(std::istream& is)
         = su::deserializeWithGetterType<decltype(&ExecutorConfig::getCacheTransceiverConfig)>(is);
     auto gatherGenerationLogits
         = su::deserializeWithGetterType<decltype(&ExecutorConfig::getGatherGenerationLogits)>(is);
-    auto useVariableBeamWidthSearch
-        = su::deserializeWithGetterType<decltype(&ExecutorConfig::getUseVariableBeamWidthSearch)>(is);
     auto promptTableOffloading = su::deserializeWithGetterType<decltype(&ExecutorConfig::getPromptTableOffloading)>(is);
     auto enableTrtOverlap = su::deserializeWithGetterType<decltype(&ExecutorConfig::getEnableTrtOverlap)>(is);
 
@@ -1006,7 +1004,7 @@ ExecutorConfig Serialization::deserializeExecutorConfig(std::istream& is)
         peftCacheConfig, std::nullopt, decodingConfig, useGpuDirectStorage, gpuWeightsPercent, maxQueueSize,
         extendedRuntimePerfKnobConfig, debugConfig, recvPollPeriodMs, maxSeqIdleMicroseconds, specDecConfig,
         guidedDecodingConfig, additionalModelOutputs, cacheTransceiverConfig, gatherGenerationLogits,
-        useVariableBeamWidthSearch, promptTableOffloading, enableTrtOverlap};
+        promptTableOffloading, enableTrtOverlap};
 }
 
 size_t Serialization::serializedSize(ExecutorConfig const& executorConfig)
@@ -1041,7 +1039,6 @@ size_t Serialization::serializedSize(ExecutorConfig const& executorConfig)
     totalSize += su::serializedSize(executorConfig.getAdditionalModelOutputs());
     totalSize += su::serializedSize(executorConfig.getCacheTransceiverConfig());
     totalSize += su::serializedSize(executorConfig.getGatherGenerationLogits());
-    totalSize += su::serializedSize(executorConfig.getUseVariableBeamWidthSearch());
     totalSize += su::serializedSize(executorConfig.getPromptTableOffloading());
     totalSize += su::serializedSize(executorConfig.getEnableTrtOverlap());
 
@@ -1078,7 +1075,6 @@ void Serialization::serialize(ExecutorConfig const& executorConfig, std::ostream
     su::serialize(executorConfig.getAdditionalModelOutputs(), os);
     su::serialize(executorConfig.getCacheTransceiverConfig(), os);
     su::serialize(executorConfig.getGatherGenerationLogits(), os);
-    su::serialize(executorConfig.getUseVariableBeamWidthSearch(), os);
     su::serialize(executorConfig.getPromptTableOffloading(), os);
     su::serialize(executorConfig.getEnableTrtOverlap(), os);
 }

--- a/cpp/tensorrt_llm/kernels/beamSearchKernels.cu
+++ b/cpp/tensorrt_llm/kernels/beamSearchKernels.cu
@@ -49,7 +49,7 @@ void invokeTopkBeamSearch(T const* logProbs, T const* bias, void* workspace, Bea
         case 4: CASE_K(4)
         case 8: CASE_K(8)
         case 16: CASE_K(16)
-#ifndef FAST_BUILD // Skip beam_width larger than 16
+#ifndef FAST_BUILD // Skip beam width > 16
         case 32: CASE_K(32)
         case 64: CASE_K(64)
         case 128: CASE_K(128)
@@ -234,67 +234,67 @@ __global__ void gatherId(int const* __restrict pStage1Id, int* __restrict pStage
     return;
 }
 
-void printBH(BeamHypotheses const& bh)
+void BeamHypotheses::print()
 {
 #if BEAM_SEARCH_DEBUG
     cudaDeviceSynchronize();
+    printf("================ print BeamHypotheses start\n");
 
-    printf("printBH ================================================================\n");
-    PRINT(bh.bReturnNormedScore);
-    PRINT(bh.bVBWS);
-    PRINT(bh.nMaxBatchSize);
-    PRINT(bh.nBatchSize);
-    PRINT(bh.nBeamWidth);
-    PRINT(bh.nBeamWidthIn);
-    PRINT(bh.nBeamWidthOut);
-    PRINT(bh.nMaxSeqLen);
-    PRINT(bh.nVocabSize);
-    PRINT(bh.nVPart);
-    PRINT(bh.nByteMaxSharedMemoryPerBlock);
-    PRINT(bh.nByteSharedMemoryStage1);
-    PRINT(bh.nByteSharedMemoryStage3);
-    size_t const mbs = bh.nMaxBatchSize;
-    size_t const nbs = bh.nBatchSize;
-    size_t const nbm = bh.nBeamWidth;
-    size_t const nbmo = bh.nBeamWidthOut;
-    size_t const msl = bh.nMaxSeqLen;
+    PRINT(this->bReturnNormedScore);
+    PRINT(this->bVBWS);
+    PRINT(this->nMaxBatchSize);
+    PRINT(this->nBatchSize);
+    PRINT(this->nBeamWidth);
+    PRINT(this->nBeamWidthIn);
+    PRINT(this->nBeamWidthOut);
+    PRINT(this->nMaxSeqLen);
+    PRINT(this->nVocabSize);
+    PRINT(this->nVPart);
+    PRINT(this->nByteMaxSharedMemoryPerBlock);
+    PRINT(this->nByteSharedMemoryStage1);
+    PRINT(this->nByteSharedMemoryStage3);
+    size_t const mbs = this->nMaxBatchSize;
+    size_t const nbs = this->nBatchSize;
+    size_t const nbm = this->nBeamWidth;
+    size_t const nbmo = this->nBeamWidthOut;
+    size_t const msl = this->nMaxSeqLen;
 
-    PH2(bh.diversityRates, nbs);
-    PH2(bh.lengthPenalties, nbs);
-    PH2(bh.earlyStoppings, nbs);
-    PH3(bh.beamWidthArraysHost, nbs * kMaxBeamWidthArrayLength, kMaxBeamWidthArrayLength);
-    PH2(bh.nBeamWidthInHost, nbs);
-    PH2(bh.nBeamWidthOutHost, nbs);
+    PH2(this->diversityRates, nbs);
+    PH2(this->lengthPenalties, nbs);
+    PH2(this->earlyStoppings, nbs);
+    PH3(this->beamWidthArraysHost, nbs * kMaxBeamWidthArrayLength, kMaxBeamWidthArrayLength);
+    PH2(this->nBeamWidthInHost, nbs);
+    PH2(this->nBeamWidthOutHost, nbs);
 
-    PH2(bh.inputLengths, nbs * nbm);
-    PH2(bh.endIds, nbs);
-    PH2(bh.batchSlots, nbs);
+    PH2(this->inputLengths, nbs * nbm);
+    PH2(this->endIds, nbs);
+    PH2(this->batchSlots, nbs);
 
-    PH3(bh.outputIds, nbs * nbm * msl, msl);
-    PH3(bh.logProbs, nbs * nbm * msl, msl);
-    PH3(bh.sequenceLengths, nbs * nbm, nbm);
-    PH3(bh.cumLogProbs, nbs * nbm, nbm);
+    PH3(this->outputIds, nbs * nbm * msl, msl);
+    PH3(this->logProbs, nbs * nbm * msl, msl);
+    PH3(this->sequenceLengths, nbs * nbm, nbm);
+    PH3(this->cumLogProbs, nbs * nbm, nbm);
 
-    PH3(bh.outputIdsCBA, mbs * nbmo * 2 * msl, msl);
-    PH3(bh.logProbsCBA, mbs * nbmo * 2 * msl, msl);
-    PH3(bh.sequenceLengthsCBA, mbs * nbmo * 2, nbmo * 2);
-    PH3(bh.cumLogProbsCBA, mbs * nbmo * 2, nbmo * 2);
-    PH3(bh.normedScoresCBA, mbs * nbmo * 2, nbmo * 2);
-    PH2(bh.numBeamsCBA, mbs);
-    PH2(bh.minNormedScoresCBA, mbs);
+    PH3(this->outputIdsCBA, mbs * nbmo * 2 * msl, msl);
+    PH3(this->logProbsCBA, mbs * nbmo * 2 * msl, msl);
+    PH3(this->sequenceLengthsCBA, mbs * nbmo * 2, nbmo * 2);
+    PH3(this->cumLogProbsCBA, mbs * nbmo * 2, nbmo * 2);
+    PH3(this->normedScoresCBA, mbs * nbmo * 2, nbmo * 2);
+    PH2(this->numBeamsCBA, mbs);
+    PH2(this->minNormedScoresCBA, mbs);
 
-    PH2(bh.batchDones, nbs);
-    uint8_t* finished = reinterpret_cast<uint8_t*>(bh.finished);
+    // PH2(this->batchDones, nbs);
+    uint8_t* finished = reinterpret_cast<uint8_t*>(this->finished);
     PH2(finished, nbs * nbm);
 
     std::vector<runtime::SizeType32> batchSlots(nbs, 0);
-    cudaMemcpy(batchSlots.data(), bh.batchSlots, sizeof(runtime::SizeType32) * nbs, cudaMemcpyDeviceToHost);
+    cudaMemcpy(batchSlots.data(), this->batchSlots, sizeof(runtime::SizeType32) * nbs, cudaMemcpyDeviceToHost);
 
     std::vector<int*> outputIdsPtr(nbs, 0);
-    cudaMemcpy(outputIdsPtr.data(), bh.outputIdsPtr, sizeof(int*) * nbs, cudaMemcpyDeviceToHost);
+    cudaMemcpy(outputIdsPtr.data(), this->outputIdsPtr, sizeof(int*) * nbs, cudaMemcpyDeviceToHost);
 
     std::vector<int*> parentIdsPtr(nbs, 0);
-    cudaMemcpy(parentIdsPtr.data(), bh.parentIdsPtr, sizeof(int*) * nbs, cudaMemcpyDeviceToHost);
+    cudaMemcpy(parentIdsPtr.data(), this->parentIdsPtr, sizeof(int*) * nbs, cudaMemcpyDeviceToHost);
     cudaDeviceSynchronize();
 
     for (int i = 0; i < nbs; ++i)
@@ -313,8 +313,10 @@ void printBH(BeamHypotheses const& bh)
     }
 
     // May not available in some context
-    // PH3(bh.outputIdsUnfinish, nbs * nbm * msl, msl);
-    // PH3(bh.parentIdsUnfinish, nbs * nbm * msl, msl);
+    // PH3(this->outputIdsUnfinish, nbs * nbm * msl, msl);
+    // PH3(this->parentIdsUnfinish, nbs * nbm * msl, msl);
+
+    printf("================ print BeamHypotheses stop\n");
 #endif
 }
 

--- a/cpp/tensorrt_llm/kernels/beamSearchKernels.cu
+++ b/cpp/tensorrt_llm/kernels/beamSearchKernels.cu
@@ -263,11 +263,8 @@ void printBH(BeamHypotheses const& bh)
     PH2(bh.lengthPenalties, nbs);
     PH2(bh.earlyStoppings, nbs);
     PH3(bh.beamWidthArraysHost, nbs * kMaxBeamWidthArrayLength, kMaxBeamWidthArrayLength);
-    PH3(bh.beamWidthArraysDevice, nbs * kMaxBeamWidthArrayLength, kMaxBeamWidthArrayLength);
     PH2(bh.nBeamWidthInHost, nbs);
     PH2(bh.nBeamWidthOutHost, nbs);
-    PH2(bh.nBeamWidthInDevice, nbs);
-    PH2(bh.nBeamWidthOutDevice, nbs);
 
     PH2(bh.inputLengths, nbs * nbm);
     PH2(bh.endIds, nbs);

--- a/cpp/tensorrt_llm/kernels/beamSearchKernels.h
+++ b/cpp/tensorrt_llm/kernels/beamSearchKernels.h
@@ -150,6 +150,7 @@ void printLogProbs(float const* x, int const nBS, int const nBMIn, int const nBM
     {                                                                                                                  \
         printf(#x "=");                                                                                                \
         print_element_(x);                                                                                             \
+        printf("\n");                                                                                                  \
     }
 
 // Host function

--- a/cpp/tensorrt_llm/kernels/beamSearchKernels.h
+++ b/cpp/tensorrt_llm/kernels/beamSearchKernels.h
@@ -61,11 +61,8 @@ struct BeamHypotheses
     float const* lengthPenalties{nullptr};          // [BS]
     int const* earlyStoppings{nullptr};             // [BS]
     int const* beamWidthArraysHost{nullptr};        // [BS, kMaxBeamWidthArrayLength]                           for VBWS
-    int const* beamWidthArraysDevice{nullptr};      // [BS, kMaxBeamWidthArrayLength]                           for VBWS
     int* nBeamWidthInHost{nullptr};                 // [BS], cpu                                                for VBWS, beam width of last forward computation
     int* nBeamWidthOutHost{nullptr};                // [BS], cpu                                                for VBWS, beam width of next forward computation
-    int* nBeamWidthInDevice{nullptr};               // [BS]                                                     for VBWS, beam width of last forward computation
-    int* nBeamWidthOutDevice{nullptr};              // [BS]                                                     for VBWS, beam width of next forward computation
 
     // Pointers from input
     int const* inputLengths{nullptr};               // [BS, BM]         %% context_length

--- a/cpp/tensorrt_llm/kernels/beamSearchKernels.h
+++ b/cpp/tensorrt_llm/kernels/beamSearchKernels.h
@@ -99,6 +99,8 @@ struct BeamHypotheses
     int const* parentIdsUnfinish{nullptr};          // [BS, BM, MSL]   %% self.parent_ids
 
     // clang-format on
+
+    void print();
 };
 
 __inline__ int padToNextPowerOfTwo(int const n)
@@ -135,8 +137,6 @@ __global__ void addCumLogProbs(T* __restrict pStage1Probs, float const* __restri
 
 __global__ void gatherId(int const* __restrict pStage1Id, int* __restrict pStage2Id, size_t const nBS,
     size_t const nBMIn, size_t const nBMOut, size_t const nV);
-
-void printBH(BeamHypotheses const& bh);
 
 void printLogProbs(float const* x, int const nBS, int const nBMIn, int const nBM, int const nV);
 

--- a/cpp/tensorrt_llm/kernels/beamSearchKernels/beamSearchKernelsTemplate.h
+++ b/cpp/tensorrt_llm/kernels/beamSearchKernels/beamSearchKernelsTemplate.h
@@ -194,7 +194,7 @@ __launch_bounds__(BLOCK_SIZE) __global__ void beamStage3Kernel(
     int const slot = bh.batchSlots[bid];
     size_t const nMBS{bh.nMaxBatchSize}; // Only for bh.logProbsTiled
     size_t const nBM{bh.nBeamWidth};
-    size_t const nBMIn{bh.bVBWS ? bh.nBeamWidthIn : bh.nBeamWidth};
+    // size_t const nBMIn{bh.bVBWS ? bh.nBeamWidthIn : bh.nBeamWidth};
     size_t const nBMOut{bh.bVBWS ? bh.nBeamWidthOut : bh.nBeamWidth};
     size_t const nMSL{bh.nMaxSeqLen};
     size_t const nV{bh.nVocabSize};
@@ -475,7 +475,7 @@ __launch_bounds__(BLOCK_SIZE) __global__ void beamStage3Kernel(
     }
     __syncthreads();
 
-    if (tid < nBMIn)
+    if (tid < nBMOut)
     {
         int const indexBatchBeam = slot * nBM + tid;
         int const step = smemSeqLen[tid];

--- a/cpp/tensorrt_llm/kernels/decodingKernels.cu
+++ b/cpp/tensorrt_llm/kernels/decodingKernels.cu
@@ -521,15 +521,11 @@ __global__ void finalizeKernel(BeamHypotheses bh)
 
 void invokeFinalize(BeamHypotheses& bh, cudaStream_t stream)
 {
-    TLLM_LOG_TRACE("%s %s start", __FILE__, __PRETTY_FUNCTION__);
-
     int const nBM = bh.nBeamWidth;
     int const nThread = min(roundUp(nBM * 2, 32), 1024);
     size_t const nByteSharedMemory = (sizeof(int) + sizeof(float)) * nBM * 2;
     finalizeKernel<<<bh.nBatchSize, nThread, nByteSharedMemory, stream>>>(bh);
     sync_check_cuda_error(stream);
-
-    TLLM_LOG_TRACE("%s %s stop", __FILE__, __PRETTY_FUNCTION__);
 }
 
 __global__ void copyBeamHypotheses(CopyBeamHypothesesStruct copyStruct)

--- a/cpp/tensorrt_llm/layers/beamSearchLayer.cu
+++ b/cpp/tensorrt_llm/layers/beamSearchLayer.cu
@@ -400,6 +400,14 @@ void BeamSearchLayer<T>::forwardAsync(std::shared_ptr<BaseDecodingOutputs> const
     int* srcCI = bufferCast<int>(*ip->srcCacheIndirection.value());
     invokeUpdateCacheIndirection(tgtCI, srcCI, bh, ip->maxAttentionWindow, ip->sinkTokenLength, getStream());
 
+    // Beam width might have been changed in Variable-Beam-Width-Search mode.
+    // So the new beam width is stored in output for the later layers.
+    // At present, all requests of a batch must have the same beam width in one generation step (or they will not
+    // be batched together). So, the beam width of the first request is taken here to reshape the buffer.
+    // Corresponding changes must be done if Diverse-Beam-Width-Search (DBWS, requests with diverse beam width in
+    // a batch in one generation step) is supported in the future.
+    op->variableBeamWidth = bh.nBeamWidthOutHost[0];
+
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
 }
 

--- a/cpp/tensorrt_llm/layers/beamSearchLayer.cu
+++ b/cpp/tensorrt_llm/layers/beamSearchLayer.cu
@@ -408,6 +408,8 @@ void BeamSearchLayer<T>::forwardAsync(std::shared_ptr<BaseDecodingOutputs> const
     // a batch in one generation step) is supported in the future.
     op->variableBeamWidth = bh.nBeamWidthOutHost[0];
 
+    bh.print();
+
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
 }
 

--- a/cpp/tensorrt_llm/layers/beamSearchLayer.cu
+++ b/cpp/tensorrt_llm/layers/beamSearchLayer.cu
@@ -69,7 +69,8 @@ namespace tensorrt_llm::layers
     }
 
 template <typename T>
-BeamSearchLayer<T>::BeamSearchLayer(DecoderDomain const& decoderDomain, std::shared_ptr<BufferManager> bufferManager)
+BeamSearchLayer<T>::BeamSearchLayer(executor::DecodingMode const& mode, DecoderDomain const& decoderDomain,
+    std::shared_ptr<BufferManager> bufferManager)
     : BaseLayer(decoderDomain, bufferManager)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
@@ -79,7 +80,7 @@ BeamSearchLayer<T>::BeamSearchLayer(DecoderDomain const& decoderDomain, std::sha
     SizeType32 const vocabSize{mDecoderDomain.getVocabSize()};
     TLLM_CHECK_WITH_INFO(beamWidth <= kMaxBeamWidth, "Beam width is larger than the maximum supported (%d > %d)",
         int(beamWidth), int(kMaxBeamWidth));
-    this->mVBWS = decoderDomain.getUseVariableBeamWidthSearch();
+    this->mVBWS = mode.isUseVariableBeamWidthSearch();
 
     allocateBuffer();
     configureBeamSearchLayer();
@@ -106,11 +107,14 @@ void BeamSearchLayer<T>::allocateBuffer()
     mEarlyStoppingHost = mBufferManager->pinnedPool(batchSizeShape, TRTDataType<int>::value);
     mEarlyStoppingDevice = mBufferManager->gpu(batchSizeShape, TRTDataType<int>::value);
 
-    mBeamWidthArrayHost = mBufferManager->pinnedPool(batchSizeXBeamWidthArraySizeShape, TRTDataType<int>::value);
-    mBeamWidthArrayDevice = mBufferManager->gpu(batchSizeXBeamWidthArraySizeShape, TRTDataType<int>::value);
+    if (this->mVBWS)
+    {
+        mBeamWidthArrayHost = mBufferManager->pinnedPool(batchSizeXBeamWidthArraySizeShape, TRTDataType<int>::value);
+        mBeamWidthArrayDevice = mBufferManager->gpu(batchSizeXBeamWidthArraySizeShape, TRTDataType<int>::value);
 
-    mBeamWidthIn = mBufferManager->pinnedPool(batchSizeShape, TRTDataType<int>::value);
-    mBeamWidthOut = mBufferManager->pinnedPool(batchSizeShape, TRTDataType<int>::value);
+        mBeamWidthIn = mBufferManager->pinnedPool(batchSizeShape, TRTDataType<int>::value);
+        mBeamWidthOut = mBufferManager->pinnedPool(batchSizeShape, TRTDataType<int>::value);
+    }
 
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
 }
@@ -293,8 +297,12 @@ void BeamSearchLayer<T>::setup(SizeType32 const batchSize, SizeType32 const beam
         mLengthPenaltyDevice, batchSlots, std::make_pair(fltMin, fltMax), "length penalty");
     fillBuffers(setupParams->earlyStopping, DefaultDecodingParams::getEarlyStopping(), mEarlyStoppingHost,
         mEarlyStoppingDevice, batchSlots, std::make_pair(-fltEpsilon, int32Max), "early stopping");
-    fillBuffers(setupParams->beamWidthArray, DefaultDecodingParams::getBeamWidthArray(), mBeamWidthArrayHost,
-        mBeamWidthArrayDevice, batchSlots, std::make_pair(-fltEpsilon, kMaxBeamWidth), "beam width array");
+
+    if (this->mVBWS)
+    {
+        fillBuffers(setupParams->beamWidthArray, DefaultDecodingParams::getBeamWidthArray(), mBeamWidthArrayHost,
+            mBeamWidthArrayDevice, batchSlots, std::make_pair(-fltEpsilon, kMaxBeamWidth), "beam width array");
+    }
 
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
 }
@@ -333,25 +341,23 @@ void BeamSearchLayer<T>::forwardAsync(std::shared_ptr<BaseDecodingOutputs> const
     bh.nByteMaxSharedMemoryPerBlock = this->mByteMaxSharedMemoryPerBlock;
     bh.nByteSharedMemoryStage1 = this->mByteSharedMemoryStage1;
     bh.nByteSharedMemoryStage3 = this->mByteSharedMemoryStage3;
-
     bh.diversityRates = bufferCast<float>(*mBeamSearchDiversityRateDevice);
     bh.lengthPenalties = bufferCast<float>(*mLengthPenaltyDevice);
     bh.earlyStoppings = bufferCast<int>(*mEarlyStoppingDevice);
-    bh.beamWidthArraysHost = bufferCast<int>(*mBeamWidthArrayHost);
-    bh.beamWidthArraysDevice = bufferCast<int>(*mBeamWidthArrayDevice);
 
-    bh.nBeamWidthInHost = bufferCast<int>(*mBeamWidthIn);
-    bh.nBeamWidthOutHost = bufferCast<int>(*mBeamWidthOut);
     if (this->mVBWS)
     {
+        bh.beamWidthArraysHost = bufferCast<int>(*mBeamWidthArrayHost);
+        bh.nBeamWidthInHost = bufferCast<int>(*mBeamWidthIn);
+        bh.nBeamWidthOutHost = bufferCast<int>(*mBeamWidthOut);
         int const* batchSlotsHost = bufferCast<int>(*ip->batchSlots);
         for (int i = 0; i < ip->localBatchSize; ++i)
         {
-            int const slot = batchSlotsHost[i];
-            int const step = ip->beamSearchSteps.value()[slot];
+            auto const slot = batchSlotsHost[i];
+            auto const step = ip->beamSearchSteps.value()[slot];
             // Clamp `step` to [0, kMaxBeamWidthArrayLength - 1], and set `indexInput=0` when step = 0 or 1
-            int const indexInput = std::min(std::max((int) step - 1, 0), (int) kMaxBeamWidthArrayLength - 1);
-            int const indexOutput = std::min((int) step, (int) kMaxBeamWidthArrayLength - 1);
+            auto const indexOutput = std::min(step, static_cast<SizeType32>(kMaxBeamWidthArrayLength) - 1);
+            auto const indexInput = std::max(indexOutput - 1, 0);
             bh.nBeamWidthInHost[i] = bh.beamWidthArraysHost[slot * kMaxBeamWidthArrayLength + indexInput];
             bh.nBeamWidthOutHost[i] = bh.beamWidthArraysHost[slot * kMaxBeamWidthArrayLength + indexOutput];
         }
@@ -360,11 +366,9 @@ void BeamSearchLayer<T>::forwardAsync(std::shared_ptr<BaseDecodingOutputs> const
     bh.inputLengths = bufferCast<SizeType32>(*ip->inputLengths.value());
     bh.endIds = bufferCast<TokenIdType>(*ip->endIds);
     bh.batchSlots = workspace->getDeviceBatchSlotsPtr(); // Device copy of `ip->batchSlots`
-
     bh.logProbsTiled = bufferCastOrNull<float>(op->outputLogProbsTiled);
     bh.sequenceLengths = bufferCast<SizeType32>(*op->sequenceLength.value());
     bh.cumLogProbs = bufferCast<float>(*op->cumLogProbs.value());
-
     bh.outputIdsCBA = op->beamHypotheses->outputIdsCBA;
     bh.logProbsCBA = op->beamHypotheses->logProbsCBA;
     bh.sequenceLengthsCBA = op->beamHypotheses->sequenceLengthsCBA;
@@ -372,10 +376,8 @@ void BeamSearchLayer<T>::forwardAsync(std::shared_ptr<BaseDecodingOutputs> const
     bh.normedScoresCBA = op->beamHypotheses->normedScoresCBA;
     bh.numBeamsCBA = op->beamHypotheses->numBeamsCBA;
     bh.minNormedScoresCBA = op->beamHypotheses->minNormedScoresCBA;
-
     bh.batchDones = op->beamHypotheses->batchDones;
     bh.finished = reinterpret_cast<FinishedState*>(bufferCast<FinishedState::UnderlyingType>(*op->finished.value()));
-
     bh.outputIdsPtr = bufferCast<TokenIdType*>(*op->outputIdsPtr);
     bh.parentIdsPtr = bufferCast<TokenIdType*>(*op->parentIdsPtr);
 

--- a/cpp/tensorrt_llm/layers/beamSearchLayer.h
+++ b/cpp/tensorrt_llm/layers/beamSearchLayer.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "tensorrt_llm/executor/types.h"
 #include "tensorrt_llm/layers/baseLayer.h"
 #include "tensorrt_llm/layers/decodingParams.h"
 #include "tensorrt_llm/runtime/common.h"
@@ -29,7 +30,8 @@ class BeamSearchLayer : public BaseLayer
     using Base = BaseLayer;
 
 public:
-    BeamSearchLayer(DecoderDomain const& decoderDomain, std::shared_ptr<runtime::BufferManager> bufferManager);
+    BeamSearchLayer(executor::DecodingMode const& mode, DecoderDomain const& decoderDomain,
+        std::shared_ptr<runtime::BufferManager> bufferManager);
 
     // Functions called before input data arrives
     [[nodiscard]] size_t getWorkspaceSize() const noexcept override;
@@ -66,8 +68,8 @@ private:
     TensorPtr mEarlyStoppingDevice;           // [batchSize] gpu
     TensorPtr mBeamWidthArrayHost;            // [batchSize, kMaxBeamWidthArrayLength] cpu
     TensorPtr mBeamWidthArrayDevice;          // [batchSize, kMaxBeamWidthArrayLength] gpu
-    TensorPtr mBeamWidthIn;                   // [batchSize] cpu, the input beamWidth of this step
-    TensorPtr mBeamWidthOut;                  // [batchSize] cpu, the output beamWidth of this step
+    TensorPtr mBeamWidthIn;                   // [batchSize] cpu, the beamWidth of last forward computation
+    TensorPtr mBeamWidthOut;                  // [batchSize] cpu, the beamWidth of next forward computation
 };
 
 } // namespace tensorrt_llm::layers

--- a/cpp/tensorrt_llm/layers/decodingLayer.cpp
+++ b/cpp/tensorrt_llm/layers/decodingLayer.cpp
@@ -47,7 +47,7 @@ DecodingLayer<T>::DecodingLayer(executor::DecodingMode const& mode, DecoderDomai
     }
     else if (mDecodingMode.isBeamSearch())
     {
-        mDecodingLayer = std::make_unique<BeamSearchLayer<T>>(decoderDomain, mBufferManager);
+        mDecodingLayer = std::make_unique<BeamSearchLayer<T>>(mDecodingMode, decoderDomain, mBufferManager);
     }
     else if (mDecodingMode.isMedusa())
     {

--- a/cpp/tensorrt_llm/layers/decodingParams.h
+++ b/cpp/tensorrt_llm/layers/decodingParams.h
@@ -79,6 +79,11 @@ public:
         return mBeamWidth;
     }
 
+    void setBeamWidth(runtime::SizeType32 beamWidth)
+    {
+        mBeamWidth = beamWidth;
+    }
+
     [[nodiscard]] runtime::SizeType32 getVocabSize() const
     {
         return mVocabSize;
@@ -514,6 +519,8 @@ public:
     std::optional<TensorPtr> numNewTokens; // [maxBatchSize], on pinned, number of tokens predicted at current iteration
     std::optional<TensorPtr> finishedSum;  // [1], on pinned
     std::optional<TensorPtr> outputLogProbsTiled; // [maxSeqLen, maxBatchSize, maxBeamWidth], on gpu
+
+    runtime::SizeType32 variableBeamWidth{1};     // For Variable-Beam-Width-Search
 };
 
 class BeamSearchOutputs : public BaseDecodingOutputs

--- a/cpp/tensorrt_llm/layers/decodingParams.h
+++ b/cpp/tensorrt_llm/layers/decodingParams.h
@@ -60,14 +60,12 @@ class DecoderDomain
 public:
     DecoderDomain(runtime::SizeType32 batchSize, runtime::SizeType32 beamWidth, runtime::SizeType32 vocabSize,
         std::optional<runtime::SizeType32> vocabSizePadded = std::nullopt,
-        std::shared_ptr<runtime::SpeculativeDecodingModule const> speculativeDecodingModule = nullptr,
-        bool const useVariableBeamWidthSearch = false)
+        std::shared_ptr<runtime::SpeculativeDecodingModule const> speculativeDecodingModule = nullptr)
         : mBatchSize(batchSize)
         , mBeamWidth(beamWidth)
         , mVocabSize(vocabSize)
         , mVocabSizePadded(vocabSizePadded.value_or(vocabSize))
         , mSpeculativeDecodingModule(std::move(speculativeDecodingModule))
-        , mUseVariableBeamWidthSearch(useVariableBeamWidthSearch)
     {
     }
 
@@ -107,18 +105,12 @@ public:
         return mSpeculativeDecodingModule;
     }
 
-    [[nodiscard]] bool getUseVariableBeamWidthSearch() const
-    {
-        return mUseVariableBeamWidthSearch;
-    }
-
 private:
     runtime::SizeType32 mBatchSize;
     runtime::SizeType32 mBeamWidth;
     runtime::SizeType32 mVocabSize;
     runtime::SizeType32 mVocabSizePadded;
     std::shared_ptr<runtime::SpeculativeDecodingModule const> mSpeculativeDecodingModule;
-    bool mUseVariableBeamWidthSearch;
 };
 
 class BaseSetupParams

--- a/cpp/tensorrt_llm/layers/decodingParams.h
+++ b/cpp/tensorrt_llm/layers/decodingParams.h
@@ -512,7 +512,6 @@ public:
     TensorPtr outputIdsPtr;     // [maxBatchSize][maxBeamWidth, maxSeqLen], on gpu and outputIdsPtr[i], on gpu
     TensorPtr outputIdsPtrHost; // [maxBatchSize][maxBeamWidth, maxSeqLen], on cpu but outputIdsPtrHost[i], on gpu
     TensorPtr parentIdsPtr;     // [maxBatchSize][maxBeamWidth, maxSeqLen], on cpu but parentIdsPtr[i], on gpu
-
     TensorPtr newTokens;        // [maxBatchSize, maxBeamWidth], on gpu, tokens predicted at current iteration.
 
     // optional parameters
@@ -520,7 +519,9 @@ public:
     std::optional<TensorPtr> finishedSum;  // [1], on pinned
     std::optional<TensorPtr> outputLogProbsTiled; // [maxSeqLen, maxBatchSize, maxBeamWidth], on gpu
 
-    runtime::SizeType32 variableBeamWidth{1};     // For Variable-Beam-Width-Search
+    // Beam width might change in Variable-Beam-Width-Search mode.
+    // So the beam width is updated in beam search layer for the later layers.
+    runtime::SizeType32 beamWidth{1};
 };
 
 class BeamSearchOutputs : public BaseDecodingOutputs

--- a/cpp/tensorrt_llm/layers/dynamicDecodeLayer.cpp
+++ b/cpp/tensorrt_llm/layers/dynamicDecodeLayer.cpp
@@ -218,7 +218,7 @@ void DynamicDecodeLayer<T>::forwardAsync(std::shared_ptr<BaseDecodingOutputs> co
 
     // Copy nextIds and transpose logits when needed
     prepareOutputData(baseOutputs, workspace->getDeviceBatchSlots(), localDecoderDomain.getBatchSize(),
-        mDecoderDomain.getBatchSize(), baseOutputs->variableBeamWidth, maxSeqLen, mDecoderDomain.getMaxDecodingTokens(),
+        mDecoderDomain.getBatchSize(), baseOutputs->beamWidth, maxSeqLen, mDecoderDomain.getMaxDecodingTokens(),
         mOutputLogProbs, getStream());
 
     mCyclicStep += 1;

--- a/cpp/tensorrt_llm/layers/dynamicDecodeLayer.cpp
+++ b/cpp/tensorrt_llm/layers/dynamicDecodeLayer.cpp
@@ -218,8 +218,8 @@ void DynamicDecodeLayer<T>::forwardAsync(std::shared_ptr<BaseDecodingOutputs> co
 
     // Copy nextIds and transpose logits when needed
     prepareOutputData(baseOutputs, workspace->getDeviceBatchSlots(), localDecoderDomain.getBatchSize(),
-        mDecoderDomain.getBatchSize(), localDecoderDomain.getBeamWidth(), maxSeqLen,
-        mDecoderDomain.getMaxDecodingTokens(), mOutputLogProbs, getStream());
+        mDecoderDomain.getBatchSize(), baseOutputs->variableBeamWidth, maxSeqLen, mDecoderDomain.getMaxDecodingTokens(),
+        mOutputLogProbs, getStream());
 
     mCyclicStep += 1;
 

--- a/cpp/tensorrt_llm/layers/stopCriteriaLayer.cpp
+++ b/cpp/tensorrt_llm/layers/stopCriteriaLayer.cpp
@@ -73,7 +73,10 @@ void StopCriteriaLayer<T>::forwardAsync(std::shared_ptr<BaseDecodingOutputs> con
     auto inputs = std::dynamic_pointer_cast<DecodingInputs>(baseInputs);
     auto outputs = std::dynamic_pointer_cast<BaseDecodingOutputs>(baseOutputs);
 
-    auto const localDecoderDomain = getLocalDecoderDomain(inputs, mDecoderDomain);
+    auto localDecoderDomain = getLocalDecoderDomain(inputs, mDecoderDomain);
+    // Beam width might have been changed in Variable-Beam-Width-Search mode
+    localDecoderDomain.setBeamWidth(baseOutputs->variableBeamWidth);
+
     auto const maxSeqLen = outputs->outputIds->getDimension<-1>();
 
     TLLM_CHECK_WITH_INFO(inputs->stopCriteriaInputs, "stopCriteriaInputs for forward is not set");

--- a/cpp/tensorrt_llm/layers/stopCriteriaLayer.cpp
+++ b/cpp/tensorrt_llm/layers/stopCriteriaLayer.cpp
@@ -75,7 +75,7 @@ void StopCriteriaLayer<T>::forwardAsync(std::shared_ptr<BaseDecodingOutputs> con
 
     auto localDecoderDomain = getLocalDecoderDomain(inputs, mDecoderDomain);
     // Beam width might have been changed in Variable-Beam-Width-Search mode
-    localDecoderDomain.setBeamWidth(baseOutputs->variableBeamWidth);
+    localDecoderDomain.setBeamWidth(baseOutputs->beamWidth);
 
     auto const maxSeqLen = outputs->outputIds->getDimension<-1>();
 

--- a/cpp/tensorrt_llm/layers/stopCriteriaLayer.h
+++ b/cpp/tensorrt_llm/layers/stopCriteriaLayer.h
@@ -64,6 +64,8 @@ private:
 
     executor::DecodingMode mDecodingMode;
     size_t mWorkspaceSize{0};
+
+    runtime::SizeType32 mVariableBeamWidth; // For Variable-Beam-Width-Search
 };
 
 } // namespace tensorrt_llm::layers

--- a/cpp/tensorrt_llm/layers/stopCriteriaLayer.h
+++ b/cpp/tensorrt_llm/layers/stopCriteriaLayer.h
@@ -64,8 +64,6 @@ private:
 
     executor::DecodingMode mDecodingMode;
     size_t mWorkspaceSize{0};
-
-    runtime::SizeType32 mVariableBeamWidth; // For Variable-Beam-Width-Search
 };
 
 } // namespace tensorrt_llm::layers

--- a/cpp/tensorrt_llm/pybind/executor/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/executor/bindings.cpp
@@ -83,6 +83,7 @@ void initBindings(pybind11::module_& m)
         .def("isLookahead", &tle::DecodingMode::isLookahead)
         .def("isExplicitDraftTokens", &tle::DecodingMode::isExplicitDraftTokens)
         .def("isEagle", &tle::DecodingMode::isEagle)
+        .def("useVariableBeamWidthSearch", &tle::DecodingMode::useVariableBeamWidthSearch)
         .def_property_readonly("name", &tle::DecodingMode::getName)
         .def(py::pickle(decodingModeGetstate, decodingModeSetstate));
 

--- a/cpp/tensorrt_llm/pybind/executor/executorConfig.cpp
+++ b/cpp/tensorrt_llm/pybind/executor/executorConfig.cpp
@@ -434,7 +434,7 @@ void initConfigBindings(pybind11::module_& m)
             c.getExtendedRuntimePerfKnobConfig(), c.getDebugConfig(), c.getRecvPollPeriodMs(),
             c.getMaxSeqIdleMicroseconds(), c.getSpecDecConfig(), c.getGuidedDecodingConfig(),
             c.getAdditionalModelOutputs(), c.getCacheTransceiverConfig(), c.getGatherGenerationLogits(),
-            c.getUseVariableBeamWidthSearch(), c.getPromptTableOffloading(), c.getEnableTrtOverlap());
+            c.getPromptTableOffloading(), c.getEnableTrtOverlap());
         auto pickle_tuple = py::make_tuple(cpp_states, py::getattr(self, "__dict__"));
         return pickle_tuple;
     };
@@ -447,7 +447,7 @@ void initConfigBindings(pybind11::module_& m)
 
         // Restore C++ data
         auto cpp_states = state[0].cast<py::tuple>();
-        if (cpp_states.size() != 29)
+        if (cpp_states.size() != 28)
         {
             throw std::runtime_error("Invalid cpp_states!");
         }
@@ -479,9 +479,8 @@ void initConfigBindings(pybind11::module_& m)
             cpp_states[23].cast<std::optional<std::vector<tle::AdditionalModelOutput>>>(), // AdditionalModelOutputs
             cpp_states[24].cast<std::optional<tle::CacheTransceiverConfig>>(),             // CacheTransceiverConfig
             cpp_states[25].cast<bool>(),                                                   // GatherGenerationLogits
-            cpp_states[26].cast<bool>(),                                                   // UseVariableBeamWidthSearch
-            cpp_states[27].cast<bool>(),                                                   // PromptTableOffloading
-            cpp_states[28].cast<bool>()                                                    // EnableTrtOverlap
+            cpp_states[26].cast<bool>(),                                                   // PromptTableOffloading
+            cpp_states[27].cast<bool>()                                                    // EnableTrtOverlap
         );
 
         auto py_state = state[1].cast<py::dict>();
@@ -517,7 +516,6 @@ void initConfigBindings(pybind11::module_& m)
                  std::optional<std::vector<tle::AdditionalModelOutput>>, // AdditionalModelOutputs
                  std::optional<tle::CacheTransceiverConfig>,             // CacheTransceiverConfig
                  bool,                                                   // GatherGenerationLogits
-                 bool,                                                   // UseVariableBeamWidthSearch
                  bool,                                                   // PromptTableOffloading
                  bool                                                    // EnableTrtOverlap
                  >(),
@@ -539,8 +537,8 @@ void initConfigBindings(pybind11::module_& m)
             py::arg("max_seq_idle_microseconds") = tle::ExecutorConfig::kDefaultMaxSeqIdleMicroseconds,
             py::arg("spec_dec_config") = py::none(), py::arg("guided_decoding_config") = py::none(),
             py::arg("additional_model_outputs") = py::none(), py::arg("cache_transceiver_config") = py::none(),
-            py::arg("gather_generation_logits") = false, py::arg("use_variable_beam_width_search") = false,
-            py::arg("mm_embedding_offloading") = false, py::arg("enable_trt_overlap") = false)
+            py::arg("gather_generation_logits") = false, py::arg("mm_embedding_offloading") = false,
+            py::arg("enable_trt_overlap") = false)
         .def_property("max_beam_width", &tle::ExecutorConfig::getMaxBeamWidth, &tle::ExecutorConfig::setMaxBeamWidth)
         .def_property("max_batch_size", &tle::ExecutorConfig::getMaxBatchSize, &tle::ExecutorConfig::setMaxBatchSize)
         .def_property("max_num_tokens", &tle::ExecutorConfig::getMaxNumTokens, &tle::ExecutorConfig::setMaxNumTokens)
@@ -586,8 +584,6 @@ void initConfigBindings(pybind11::module_& m)
             &tle::ExecutorConfig::setCacheTransceiverConfig)
         .def_property("gather_generation_logits", &tle::ExecutorConfig::getGatherGenerationLogits,
             &tle::ExecutorConfig::setGatherGenerationLogits)
-        .def_property("use_variable_beam_width_search", &tle::ExecutorConfig::getUseVariableBeamWidthSearch,
-            &tle::ExecutorConfig::setUseVariableBeamWidthSearch)
         .def_property("mm_embedding_offloading", &tle::ExecutorConfig::getPromptTableOffloading,
             &tle::ExecutorConfig::setPromptTableOffloading)
         .def_property(

--- a/cpp/tensorrt_llm/runtime/gptDecoder.cpp
+++ b/cpp/tensorrt_llm/runtime/gptDecoder.cpp
@@ -439,6 +439,12 @@ std::shared_ptr<tl::BaseDecodingInputs> prepareInputs(
     {
         forwardParams = std::make_shared<tl::DecodingInputs>(input.endIds, input.batchSlots, input.step, ite,
             input.batchSize, input.maxAttentionWindow, input.sinkTokenLength);
+
+        if (input.cacheIndirection)
+        {
+            forwardParams->srcCacheIndirection = input.cacheIndirection;
+        }
+        forwardParams->beamSearchSteps = input.generationSteps;
     }
     else if (decodingMode.isMedusa())
     {
@@ -491,11 +497,6 @@ std::shared_ptr<tl::BaseDecodingInputs> prepareInputs(
         }
     }
 
-    if (input.cacheIndirection)
-    {
-        forwardParams->srcCacheIndirection = input.cacheIndirection;
-    }
-
     if (input.embeddingBias)
     {
         forwardParams->embeddingBias = input.embeddingBias;
@@ -515,30 +516,25 @@ std::shared_ptr<tl::BaseDecodingInputs> prepareInputs(
         forwardParams->finished = input.finishReasons;
     }
 
-    // Medusa
+    // Speculative decoding
     if (decodingMode.isMedusa())
     {
         prepareMedusaInputs(input, maxBatchSize, forwardParams);
     }
-
-    // Explicit draft tokens
-    if (decodingMode.isExplicitDraftTokens())
+    else if (decodingMode.isExplicitDraftTokens())
     {
         prepareExplicitDraftTokensInput(input, forwardParams);
     }
-
-    if (decodingMode.isLookahead() && input.lookaheadInputs)
+    else if (decodingMode.isLookahead() && input.lookaheadInputs)
     {
         prepareLookaheadInputs(input, maxBatchSize, forwardParams);
         forwardParams->localBatchSize = input.batchSize;
     }
-
-    if (decodingMode.isExternalDraftTokens())
+    else if (decodingMode.isExternalDraftTokens())
     {
         prepareExternalDraftTokensInputs(input, forwardParams);
     }
-
-    if (decodingMode.isEagle())
+    else if (decodingMode.isEagle())
     {
         prepareEagleInput(input, forwardParams);
     }

--- a/cpp/tensorrt_llm/runtime/gptDecoderBatched.cpp
+++ b/cpp/tensorrt_llm/runtime/gptDecoderBatched.cpp
@@ -219,6 +219,7 @@ void GptDecoderBatched::prepareForward(
     {
         dInput.cacheIndirection = input.cacheIndirection;
         dOutput.cacheIndirection = output.cacheIndirection;
+        dInput.generationSteps = input.generationSteps; // For Variable-Beam-Width-Search
     }
 
     if (speculativeDecodingMode.isExplicitDraftTokens())

--- a/cpp/tensorrt_llm/runtime/promptTuningParams.cpp
+++ b/cpp/tensorrt_llm/runtime/promptTuningParams.cpp
@@ -19,8 +19,8 @@
 namespace tensorrt_llm::runtime
 {
 
-void PromptTuningParams::fillTasksTensor(TensorPtr tasksHost, const SizeType32 batchSize,
-    const SizeType32 numContextRequests, std::vector<SizeType32> const& reqBeamWidths,
+void PromptTuningParams::fillTasksTensor(TensorPtr tasksHost, SizeType32 const batchSize,
+    SizeType32 const numContextRequests, std::vector<SizeType32> const& reqBeamWidths,
     std::vector<SizeType32> const& reqPromptLengths, BufferManager const& manager, bool packedInput)
 {
     auto const& tasksHostShape = tasksHost->getShape();

--- a/cpp/tensorrt_llm/runtime/tllmRuntime.h
+++ b/cpp/tensorrt_llm/runtime/tllmRuntime.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "tensorrt_llm/batch_manager/llmRequest.h"
 #include "tensorrt_llm/runtime/bufferManager.h"
 #include "tensorrt_llm/runtime/common.h"
 #include "tensorrt_llm/runtime/iTensor.h"
@@ -143,6 +144,24 @@ public:
         return mUserBufferEnabled;
     }
 
+    void setCurrentBeamWidths(std::vector<SizeType32> const& beamWidth) noexcept
+    {
+        mCurrentBeamWidths = beamWidth;
+    }
+
+    [[nodiscard]] SizeType32 const& getCurrentBeamWidth() const noexcept
+    {
+        // At present, all requests of a batch must have the same beam width in one generation step (or they will not
+        // be batched together). So, the beam widths in `mCurrentBeamWidths` are the same.
+        // Corresponding changes must be done if Diverse-Beam-Width-Search (DBWS, requests with diverse beam width in
+        // a batch in one generation step) is supported in the future.
+        TLLM_CHECK_WITH_INFO(mCurrentBeamWidths.size() > 0, "`mCurrentBeamWidths` is empty.");
+        bool const isEqual = std::all_of(mCurrentBeamWidths.begin(), mCurrentBeamWidths.end(),
+            [&](int elem) { return elem == mCurrentBeamWidths.front(); });
+        TLLM_CHECK_WITH_INFO(isEqual, "beam widths in `mCurrentBeamWidths` are not all equal.");
+        return mCurrentBeamWidths.front();
+    }
+
 private:
     void cacheTensorNames();
 
@@ -218,5 +237,7 @@ private:
     std::vector<std::string> mOutputTensorNames;
 
     bool mUserBufferEnabled;
+    // For Variable-Beam-Width-Search
+    std::vector<SizeType32> mCurrentBeamWidths;
 };
 } // namespace tensorrt_llm::runtime

--- a/cpp/tests/unit_tests/executor/samplingConfigTest.cpp
+++ b/cpp/tests/unit_tests/executor/samplingConfigTest.cpp
@@ -183,10 +183,6 @@ TEST(SamplingConfigTest, invalidInputs)
         std::vector<SizeType32>{2, 3, 4, -1});
     test(false, 4, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no,
         std::vector<SizeType32>{2, 3, 4, 65536});
-
-    // max(beamWidthArray) != beamWidth
-    test(false, 4, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no, no,
-        std::vector<SizeType32>{2, 3, 4, 5});
 }
 
 TEST(SamplingConfigTest, getterSetter)

--- a/cpp/tests/unit_tests/executor/serializeUtilsTest.cpp
+++ b/cpp/tests/unit_tests/executor/serializeUtilsTest.cpp
@@ -772,7 +772,7 @@ TEST(SerializeUtilsTest, ExecutorConfig)
         texec::GuidedDecodingConfig(
             texec::GuidedDecodingConfig::GuidedDecodingBackend::kXGRAMMAR, std::initializer_list<std::string>{"eos"}),
         std::vector{tensorrt_llm::executor::AdditionalModelOutput{"output_name"}}, texec::CacheTransceiverConfig(1024),
-        true, true, true, true);
+        true, true, true);
     auto executorConfig2 = serializeDeserialize(executorConfig);
 
     EXPECT_EQ(executorConfig.getMaxBeamWidth(), executorConfig2.getMaxBeamWidth());

--- a/cpp/tests/unit_tests/layers/beamSearchLayerTest.cpp
+++ b/cpp/tests/unit_tests/layers/beamSearchLayerTest.cpp
@@ -36,12 +36,11 @@ class BeamSearchLayerTest : public BaseSamplingLayerTest<T>
 
     void initLayer(TestSamplingParams const& params) override
     {
-        auto decodingMode = (params.beamWidth > 1) ? tle::DecodingMode::BeamSearch() : tle::DecodingMode::Auto();
-
+        auto decodingMode = tle::DecodingMode::BeamSearch();
         auto const decodingDomain = tensorrt_llm::layers::DecoderDomain(
             this->maxBatchSize(), params.beamWidth, this->mVocabSize, this->mVocabSizePadded);
-        this->mSamplingLayer
-            = std::make_shared<tensorrt_llm::layers::BeamSearchLayer<T>>(decodingDomain, this->mBufferManager);
+        this->mSamplingLayer = std::make_shared<tensorrt_llm::layers::BeamSearchLayer<T>>(
+            decodingMode, decodingDomain, this->mBufferManager);
     }
 };
 

--- a/docs/source/advanced/gpt-runtime.md
+++ b/docs/source/advanced/gpt-runtime.md
@@ -173,18 +173,21 @@ value for a given parameter, the vector can be limited to a single element
 
 ***Beam-search***
 
-|      Name in TRT-LLM      |           Description           |   Data type   |      Range of value      |       Default value       |     Name in HF      |
-| :-----------------------: | :-----------------------------: | :-----------: | :----------------------: | :-----------------------: | :-----------------: |
-|        `beamWidth`        | width for beam-search algorithm |      Int      |        \[0, 1024\]       | `0` (disable beam search) |    `beam_width`     |
-| `beamSearchDiversityRate` |  diversity of generated tokens  | List\[Float\] |     \[0, $+\infty$\)     |          `0.0f`           | `diversity_penalty` |
-|      `lengthPenalty`      |    penalize longer sequences    | List\[Float\] |     \[0, $+\infty$\)     |          `0.0f`           |  `length_penalty`   |
-|      `earlyStopping`      |      see description below      |  List\[Int\]  | \($-\infty$, $+\infty$\) |            `0`            |  `early_stopping`   |
+|      Name in TRT-LLM      |           Description           |      Data type      |      Range of value      |       Default value       |     Name in HF      |
+| :-----------------------: | :-----------------------------: | :-----------------: | :----------------------: | :-----------------------: | :-----------------: |
+|        `beamWidth`        | width for beam-search algorithm |         Int         |       \[0, 1024\]        | `0` (disable beam search) |    `beam_width`     |
+| `beamSearchDiversityRate` |  diversity of generated tokens  |    List\[Float\]    |     \[0, $+\infty$\)     |          `0.0f`           | `diversity_penalty` |
+|      `lengthPenalty`      |    penalize longer sequences    |    List\[Float\]    |     \[0, $+\infty$\)     |          `0.0f`           |  `length_penalty`   |
+|      `earlyStopping`      |      see description below      |     List\[Int\]     | \($-\infty$, $+\infty$\) |            `0`            |  `early_stopping`   |
+|     `beamWidthArray`      |      see description below      | List\[List\[Int\]\] |       \[0, 1024\]        |            ``             |         no          |
 
  * Beam-search algorithm: [beam search](https://en.wikipedia.org/wiki/Beam_search).
  * Parameter `diversity_penalty` in HF is only used for `diverse beam-search decoding` (or named `Group-Beam-Search`), which is not supported by TRT-LLM yet.
  * If setting `earlyStopping = 1`, decoding will stop once `beamWidth` finished sentences are generated.
  * If setting `earlyStopping = 0`, decoding will keep going until no better sentences (with better score) can be generated.
  * If setting `earlyStopping` to other values, decoding will stop only depending on `lengthlengthPenalty`.
+ * `beamWidthArray` is a list of beam width for each step. Using `beamWidthArray = [20,40,80]` as an example,
+beam width will be 20 for the first step, 40 for second step, 80 for the later all steps.
  * The `beamWidth` parameter is a scalar value. It means that in this release of
 TensorRT-LLM, it is not possible to specify a different width for each input
 sequence. This limitation is likely to be removed in a future release.

--- a/tensorrt_llm/runtime/model_runner_cpp.py
+++ b/tensorrt_llm/runtime/model_runner_cpp.py
@@ -26,8 +26,8 @@ from .._utils import mpi_broadcast
 from ..bindings import (DataType, GptJsonConfig, KVCacheType, ModelConfig,
                         WorldConfig)
 from ..bindings import executor as trtllm
-from ..bindings.executor import (ExternalDraftTokensConfig, OrchestratorConfig,
-                                 ParallelConfig)
+from ..bindings.executor import (DecodingMode, ExternalDraftTokensConfig,
+                                 OrchestratorConfig, ParallelConfig)
 from ..builder import EngineConfig
 from ..layers import MropeParams
 from ..logger import logger
@@ -348,6 +348,10 @@ class ModelRunnerCpp(ModelRunnerMixin):
             decoding_config.lookahead_decoding_config = trtllm.LookaheadDecodingConfig(
                 w, n, g)
 
+        if use_variable_beam_width_search:
+            decoding_config.decoding_mode = DecodingMode.BeamSearch(
+            ).useVariableBeamWidthSearch(True)
+
         if max_batch_size is None:
             max_batch_size = model_config.max_batch_size
         else:
@@ -390,7 +394,6 @@ class ModelRunnerCpp(ModelRunnerMixin):
             use_gpu_direct_storage=use_gpu_direct_storage,
             gpu_weights_percent=gpu_weights_percent,
             gather_generation_logits=gather_generation_logits,
-            use_variable_beam_width_search=use_variable_beam_width_search,
         )
         trtllm_config.enable_chunked_context = enable_chunked_context
         trtllm_config.extended_runtime_perf_knob_config = extended_runtime_perf_knob_config

--- a/tests/integration/defs/accuracy/references/cnn_dailymail.yaml
+++ b/tests/integration/defs/accuracy/references/cnn_dailymail.yaml
@@ -15,6 +15,9 @@ gpt2:
   - extra_acc_spec: beam_width=256
     num_samples: 32
     accuracy: 29.422
+  - extra_acc_spec: beam_width=8;beam_width_array=[2,3,4,5]
+    num_samples: 32
+    accuracy: 26.994
 gpt2-medium:
   - accuracy: 22.730
   - quant_algo: FP8

--- a/tests/integration/defs/accuracy/test_cli_flow.py
+++ b/tests/integration/defs/accuracy/test_cli_flow.py
@@ -85,6 +85,14 @@ class TestGpt2(CliFlowAccuracyTestHarness):
                  extra_build_args=["--max_beam_width=256"],
                  extra_summarize_args=["--num_beams=256"])
 
+    def test_variable_beam_width_search(self, mocker):
+        mocker.patch.object(CnnDailymail, "MAX_BATCH_SIZE", 1)
+        self.run(extra_acc_spec="beam_width=8;beam_width_array=[2,3,4,5]",
+                 extra_build_args=["--max_beam_width=8"],
+                 extra_summarize_args=[
+                     "--num_beams=5", "--beam_width_array=[2,3,4,5]"
+                 ])
+
     def test_weight_streaming_ootb(self):
         self.run(extra_build_args=[
             "--gpt_attention_plugin=disable", "--weight_streaming",

--- a/tests/integration/test_lists/qa/examples_test_list.txt
+++ b/tests/integration/test_lists/qa/examples_test_list.txt
@@ -286,6 +286,7 @@ accuracy/test_cli_flow.py::TestGpt2::test_smooth_quant[]
 accuracy/test_cli_flow.py::TestGpt2::test_smooth_quant[per_token-per_channel]
 accuracy/test_cli_flow.py::TestGpt2::test_beam_search
 accuracy/test_cli_flow.py::TestGpt2::test_beam_search_large
+accuracy/test_cli_flow.py::TestGpt2::test_variable_beam_width_search
 accuracy/test_cli_flow.py::TestGpt2::test_weight_streaming_ootb
 accuracy/test_cli_flow.py::TestGpt2::test_weight_streaming_plugin
 accuracy/test_cli_flow.py::TestGpt2::test_cuda_graph

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -93,6 +93,7 @@ l0_a10:
   - accuracy/test_cli_flow.py::TestGpt2::test_auto_dtype # 1 min
   - accuracy/test_cli_flow.py::TestGpt2::test_beam_search # 1 min
   - accuracy/test_cli_flow.py::TestGpt2::test_beam_search_large # 6 mins
+  - accuracy/test_cli_flow.py::TestGpt2::test_variable_beam_width_search # 1 mins
   - accuracy/test_cli_flow.py::TestGpt2::test_weight_streaming_ootb # 1.5 mins
   - accuracy/test_cli_flow.py::TestGpt2::test_cuda_graph # 1 min
   - accuracy/test_cli_flow.py::TestSantacoder::test_auto_dtype # 1.5 mins

--- a/tests/unittest/api_stability/test_llm_api.py
+++ b/tests/unittest/api_stability/test_llm_api.py
@@ -20,6 +20,7 @@ class TestSamplingParams(ApiStabilityTestHarness):
     def test_get_sampling_config(self):
         expected_fields = {
             "beam_width",
+            "beam_width_array",
             "top_k",
             "top_p",
             "top_p_min",
@@ -37,7 +38,6 @@ class TestSamplingParams(ApiStabilityTestHarness):
             "no_repeat_ngram_size",
             "num_return_sequences",
             "min_p",
-            "beam_width_array",
         }
         found_fields = {
             f

--- a/tests/unittest/api_stability/test_llm_api.py
+++ b/tests/unittest/api_stability/test_llm_api.py
@@ -20,7 +20,6 @@ class TestSamplingParams(ApiStabilityTestHarness):
     def test_get_sampling_config(self):
         expected_fields = {
             "beam_width",
-            "beam_width_array",
             "top_k",
             "top_p",
             "top_p_min",
@@ -38,6 +37,7 @@ class TestSamplingParams(ApiStabilityTestHarness):
             "no_repeat_ngram_size",
             "num_return_sequences",
             "min_p",
+            "beam_width_array",
         }
         found_fields = {
             f

--- a/tests/unittest/bindings/test_executor_bindings.py
+++ b/tests/unittest/bindings/test_executor_bindings.py
@@ -1551,7 +1551,6 @@ def test_executor_config():
     assert config.guided_decoding_config is None
     assert config.additional_model_outputs is None
     assert config.gather_generation_logits is False
-    assert config.use_variable_beam_width_search is False
     assert config.use_gpu_direct_storage is False
     assert config.mm_embedding_offloading is False
     assert config.enable_trt_overlap is False
@@ -1603,8 +1602,6 @@ def test_executor_config():
         [trtllm.AdditionalModelOutput("topKLogits")],
         "gather_generation_logits":
         True,
-        "use_variable_beam_width_search":
-        True,
         "use_gpu_direct_storage":
         True,
         "mm_embedding_offloading":
@@ -1633,7 +1630,6 @@ def test_executor_config():
     assert config.additional_model_outputs[0].name == "topKLogits"
     assert config.additional_model_outputs[0].gather_context is False
     assert config.gather_generation_logits is True
-    assert config.use_variable_beam_width_search is True
     assert config.use_gpu_direct_storage is True
     assert config.mm_embedding_offloading is True
     assert config.enable_trt_overlap is True
@@ -2378,8 +2374,6 @@ def test_executor_config_pickle():
         [trtllm.AdditionalModelOutput("topKLogits")],
         "gather_generation_logits":
         True,
-        "use_variable_beam_width_search":
-        False,
         "mm_embedding_offloading":
         True,
         "enable_trt_overlap":
@@ -2425,7 +2419,6 @@ def test_executor_config_pickle():
         0].gather_context == config_copy.additional_model_outputs[
             0].gather_context
     assert config.gather_generation_logits == config_copy.gather_generation_logits
-    assert config.use_variable_beam_width_search == config_copy.use_variable_beam_width_search
     assert config.mm_embedding_offloading == config_copy.mm_embedding_offloading
     assert config.enable_trt_overlap == config_copy.enable_trt_overlap
 


### PR DESCRIPTION
## Part 4 of VBWS support.

+ Previous PRs:
    + Part 1: [link](https://github.com/NVIDIA/TensorRT-LLM/pull/3082)
    + Part 2: [link](https://github.com/NVIDIA/TensorRT-LLM/pull/3133)
    + Part 3: [link](https://github.com/NVIDIA/TensorRT-LLM/pull/3338)

## The progress of this PR

+ **Complete end-to-end support of VBWS.**
+ Remove all "useVariableBeamWidthSearch" flags in the runtime since we mark it in the `DecodeConfig`.
+ Replace `llmReq->mSamplingConfig.beamWidth` with `llmReq->getBeamWidthByIter()` in the runtime to get corresponding beam width of current generation step.
+ Adjust `MicroBatchScheduler` to schedule requests with same beam width into a batch.
+ Collect generation steps of each request in the decoder for later use by beam search layer.
+ Simplify members in beam search layer / kernels (needed in Diverse-Beam-Search, DBWS but needless in VBWS).
+ Add related unit tests (CPP + Python).
+ Update related document.
+ Other small refactor of comments and format of the code.
