### PR TITLE
chore:update .gitignore for doc building task.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,8 +42,8 @@ tensorrt_llm/bindings.pyi
 tensorrt_llm/bindings/**/*.pyi
 *docs/cpp_docs*
 *docs/source/_cpp_gen*
-docs/source/llm-api/*.rst
-docs/source/llm-api-examples/llm_*.rst
+docs/source/**/*.rst
+!docs/source/examples/index.rst
 *.swp
 
 # Testing


### PR DESCRIPTION
Update .gitignore for doc building task.
If we don't update the .gitignore,  the `git status` command's output is as below.
<img width="968" alt="image" src="https://github.com/user-attachments/assets/c9d12948-f577-4571-ba27-d5e759f3f2a6" />
