### PR TITLE
[Deepseek][fix] Fix Deepseek MTP with moe_backend=TRTLLM

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -430,8 +430,11 @@ class DecoderModelForCausalLM(nn.Module,
                             break
                 # TODO: support MLA
 
-        # 2. skip quant for modules in QuantConfig.exclude_modules
-        # kv_cache_quant_algo takes precedence over exclude_modules
+        # 2. skip quant for modules in QuantConfig.exclude_modules.
+        # kv_cache_quant_algo takes precedence over exclude_modules.
+        # kv_cache_quant_algo, if not None, is set for non-Attention
+        # modules too, which is the same practice as when there's no
+        # exclude_modules.
         quant_config = self.model_config.quant_config
         kv_cache_quant_algo = None
         if quant_config:


### PR DESCRIPTION
## Description

The MTP module in Deepseek is in bf16 in the NVFP4 checkpoint. Its quant_config is overwritten so we can disable the global NVFP4 quantization for MTP. A bug was introduced when we add the kv_cache_quant_algo to the new quant_config, which was None previously. The problem is that we use `if quant_config is None` to check if the MOE layer should be quantized or not. We should instead check `quant_config.quant_mode.has_any_quant(exclude_kv_cache=True)`.

## Test Coverage

manual, need to add CI coverage

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
