### PR TITLE
feat: Enable AutoDeploy to llm-eval example

### DIFF
--- a/examples/auto_deploy/README.md
+++ b/examples/auto_deploy/README.md
@@ -192,12 +192,11 @@ The default level is `INFO`.
 lm-evaluation-harness is supported. To run the evaluation, please use the following command:
 
 ```bash
-# model is defined the same as above. Other config args can also be specified in the model_args (comma separated).
-# You can specify any tasks supported with lm-evaluation-harness.
-cd examples/auto_deploy
-python lm_eval_ad.py \
---model autodeploy --model_args model=meta-llama/Meta-Llama-3.1-8B-Instruct,world_size=2 --tasks mmlu
+cd examples/llm-eval/lm-eval-harness
+python lm_eval_tensorrt_llm.py --model trt-llm --model_args model=<model_name>,backend=autodeploy,max_context_length=<input token length>,max_gen_toks=<output token length>,tp=<tp>,temperature=<temperature, e.g. 0>  --tasks <task_name> --batch_size <max batch size>
 ```
+
+Please also refer to the [lm-eval-harness README](https://github.com/EleutherAI/lm-evaluation-harness) for more details on available tasks and command line arguments.
 
 ### Mixed-precision Quantization using TensorRT Model Optimizer
 

--- a/examples/auto_deploy/build_and_run_flux.py
+++ b/examples/auto_deploy/build_and_run_flux.py
@@ -11,8 +11,6 @@ from tensorrt_llm._torch.auto_deploy.transformations.library.fusion import fuse_
 from tensorrt_llm._torch.auto_deploy.transformations.library.quantization import quantize
 from tensorrt_llm._torch.auto_deploy.utils.logger import ad_logger
 
-torch._dynamo.config.cache_size_limit = 100
-
 
 def generate_image(pipe: DiffusionPipeline, prompt: str, image_name: str) -> None:
     """Generate an image using the given pipeline and prompt."""

--- a/examples/llm-eval/lm-eval-harness/lm_eval_tensorrt_llm.py
+++ b/examples/llm-eval/lm-eval-harness/lm_eval_tensorrt_llm.py
@@ -83,10 +83,12 @@ class TRTLLMEvalBase(TemplateLM):
 
         self.max_gen_toks = max_gen_toks
         self.chunk_size = chunk_size
+        self.temperature = temperature
         self.backend = backend
         self.max_context_length = max_context_length
         self.moe_expert_parallel_size = moe_expert_parallel_size
         self.moe_backend = moe_backend
+        self.tokenized_requests = tokenized_requests
         trt_kv_cache_config = TRT_KvCacheConfig(enable_block_reuse=False)
         trt_kv_cache_config.free_gpu_memory_fraction = free_gpu_memory_fraction
         if max_tokens_kv_cache is not None:

--- a/examples/llm-eval/lm-eval-harness/lm_eval_tensorrt_llm.py
+++ b/examples/llm-eval/lm-eval-harness/lm_eval_tensorrt_llm.py
@@ -174,7 +174,7 @@ class TRTLLMEvalBase(TemplateLM):
                                tokenizer=self.tokenizer,
                                kv_cache_config=trt_kv_cache_config,
                                **kwargs)
-            self.max_length = self.llm.max_seq_len - 1
+            # self.max_length = self.llm.max_seq_len - 1
             logger.info("Loaded TRT-LLM engine")
 
     @property

--- a/examples/llm-eval/lm-eval-harness/lm_eval_tensorrt_llm.py
+++ b/examples/llm-eval/lm-eval-harness/lm_eval_tensorrt_llm.py
@@ -20,7 +20,7 @@ import signal
 import threading
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union
 
 import torch
 import torch.nn.functional as F
@@ -32,14 +32,23 @@ from packaging.version import parse
 from tqdm import tqdm
 
 import tensorrt_llm
-from tensorrt_llm import LLM as TORCH_LLM
 from tensorrt_llm._tensorrt_engine import LLM as TRT_LLM
+from tensorrt_llm._torch.auto_deploy.shim.interface import AutoDeployConfig
 from tensorrt_llm._torch.pyexecutor.config import PyTorchConfig
 from tensorrt_llm.bindings.executor import DecodingConfig
+from tensorrt_llm.builder import BuildConfig
 from tensorrt_llm.llmapi import KvCacheConfig as TRT_KvCacheConfig
 from tensorrt_llm.llmapi import RequestOutput, SamplingParams
 
 logger = logging.getLogger(__name__)
+
+
+# utility class to keep track of json encoded chats
+class JsonChatStr(NamedTuple):
+    prompt: str
+
+    def encode(self, encoding):
+        return self.prompt.encode(encoding)
 
 
 @register_model("trt-llm")
@@ -59,9 +68,12 @@ class TRTLLMEvalBase(TemplateLM):
         backend: str = 'trt',
         max_context_length: Optional[int] = None,
         moe_expert_parallel_size: Optional[int] = None,
+        attn_backend: Optional[str] = "TRTLLM",
         moe_backend: Optional[str] = "TRTLLM",
         enable_chunked_prefill: bool = False,
         max_num_tokens: Optional[int] = None,
+        tokenized_requests: bool = True,
+        temperature: Optional[float] = None,
         **kwargs,
     ):
         # initialize TemplateLM, copied from TemplateAPI
@@ -90,7 +102,7 @@ class TRTLLMEvalBase(TemplateLM):
         if self.tokenizer.pad_token_id is None:
             self.tokenizer.pad_token_id = self.tokenizer.eos_token_id
 
-        if self.backend == 'torch':
+        if self.backend in ['pytorch', 'autodeploy']:
             kwargs.pop('batch_size')
             if tp < 1:
                 tp = torch.cuda.device_count()
@@ -103,10 +115,27 @@ class TRTLLMEvalBase(TemplateLM):
                 pytorch_config_params["moe_backend"] = self.moe_backend
                 print(f"Info: moe_backend is set to {self.moe_backend}")
 
+            if self.backend == 'pytorch':
+                if hasattr(PyTorchConfig, "moe_backend"):
+                    pytorch_config_params["moe_backend"] = self.moe_backend
+                    print(f"Info: moe_backend is set to {self.moe_backend}")
+                pytorch_config_params["attn_backend"] = attn_backend.upper()
+                print(f"Info: attn_backend is set to {attn_backend}")
+                pytorch_config = PyTorchConfig(**pytorch_config_params)
+            elif self.backend == 'autodeploy':
+                assert self.max_context_length is not None, "max_context_length must be specified for autodeploy backend"
+                # Only FlashInfer is supported for autodeploy backend.
+                pytorch_config_params["attn_backend"] = "FlashInfer"
+                pytorch_config = AutoDeployConfig(**pytorch_config_params)
+                kwargs["build_config"] = BuildConfig(
+                    max_seq_len=self.max_context_length + self.max_gen_toks)
+            else:
+                raise ValueError(f"Invalid backend: {self.backend}")
             # stop words not currently supported by torch backend
             self.use_stop_words = False
 
-            self.llm = TORCH_LLM(
+            self.llm = TRT_LLM(
+                backend=self.backend,
                 model=model,
                 tensor_parallel_size=tp,
                 trust_remote_code=trust_remote_code,
@@ -143,8 +172,32 @@ class TRTLLMEvalBase(TemplateLM):
                                tokenizer=self.tokenizer,
                                kv_cache_config=trt_kv_cache_config,
                                **kwargs)
-            self.max_length = build_config['max_seq_len'] - 1
+            # self.max_length = build_config['max_seq_len'] - 1
             logger.info("Loaded TRT-LLM engine")
+
+    @property
+    def tokenizer_name(self) -> str:
+        """Must be defined for LM subclasses which implement Chat Templating.
+        Should return the name of the tokenizer or chat template used.
+        Used only to properly fingerprint caches when requests are being cached with `--cache_requests`, otherwise not used.
+        """
+        return ""
+
+    def apply_chat_template(
+            self,
+            chat_history: List[Dict[str, str]],
+            add_generation_prompt: bool = True) -> Union[str, JsonChatStr]:
+        """Applies a chat template to a list of chat history between user and model."""
+        if self.tokenized_requests:
+            return self.tokenizer.apply_chat_template(
+                chat_history,
+                tokenize=False,
+                add_generation_prompt=add_generation_prompt,
+                continue_final_message=not add_generation_prompt,
+            )
+        else:
+            # bit of a hack. We'll load back before sending to the API
+            return JsonChatStr(json.dumps(chat_history, ensure_ascii=False))
 
     @property
     def eot_token_id(self) -> int:
@@ -266,6 +319,8 @@ class TRTLLMEvalBase(TemplateLM):
             }
             if "max_tokens" not in kwargs_mapped:
                 kwargs_mapped["max_tokens"] = self.max_gen_toks
+            if self.temperature is not None:
+                kwargs_mapped["temperature"] = self.temperature
             return SamplingParams(**kwargs_mapped)
 
         # process requests

--- a/examples/llm-eval/lm-eval-harness/lm_eval_tensorrt_llm.py
+++ b/examples/llm-eval/lm-eval-harness/lm_eval_tensorrt_llm.py
@@ -174,7 +174,7 @@ class TRTLLMEvalBase(TemplateLM):
                                tokenizer=self.tokenizer,
                                kv_cache_config=trt_kv_cache_config,
                                **kwargs)
-            # self.max_length = build_config['max_seq_len'] - 1
+            self.max_length = self.llm.max_seq_len - 1
             logger.info("Loaded TRT-LLM engine")
 
     @property

--- a/examples/llm-eval/lm-eval-harness/requirements.txt
+++ b/examples/llm-eval/lm-eval-harness/requirements.txt
@@ -1,1 +1,1 @@
-lm_eval[api]==0.4.7
+lm_eval[api]==0.4.8

--- a/tests/unittest/pytest.ini
+++ b/tests/unittest/pytest.ini
@@ -5,7 +5,7 @@ threadleak_exclude = asyncio_\d+
 addopts = --durations=0 -W ignore::DeprecationWarning
 pythonpath =
     _torch/auto_deploy/_utils_test
-    ../../examples/auto_deploy
+    ../../examples/llm-eval/lm-eval-harness
     ../../examples/models/core
     ../../examples
 env =


### PR DESCRIPTION
# PR title

## Description

* Support autodeploy backend in the lm_eval_tensorrt_llm.py. And deprecated the lm_eval script in autodeploy.
* Enable chat templates in the lm_eval_tensorrt_llm.py
* Upgrade lm_eval to the latest release (align with modelopt)

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

python lm_eval_tensorrt_llm.py --model trt-llm --model_args model=/home/scratch.omniml_data_1/models/llama3.1/Meta-Llama-3.1-8B,backend=autodeploy,max_context_length=2048,max_gen_toks=128,tp=1,temperature=0  --tasks mmlu --batch_size 4

|      Groups      |Version|   Filter   |n-shot|  Metric   |   |Value |   |Stderr|
|------------------|------:|------------|------|-----------|---|-----:|---|-----:|
|mmlu_llama        |      1|strict_match|      |exact_match|↑  |0.6737|±  |0.0037|
| - humanities     |      1|strict_match|      |exact_match|↑  |0.6225|±  |0.0067|
| - other          |      1|strict_match|      |exact_match|↑  |0.7480|±  |0.0074|
| - social sciences|      1|strict_match|      |exact_match|↑  |0.7722|±  |0.0074|
| - stem           |      0|strict_match|      |exact_match|↑  |0.5807|±  |0.0084|

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple backends and enhanced chat templating in model evaluation, including temperature control for generation.

* **Bug Fixes**
  * Updated test configurations to use the latest model evaluation scripts and parameters, and disabled select unstable test cases.

* **Documentation**
  * Revised example commands and instructions for running model evaluation, and added a reference to the official evaluation harness documentation.

* **Chores**
  * Updated dependency version for evaluation harness.
  * Adjusted Python path settings for improved module discovery during testing.
  * Removed unused configuration in example scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->