### PR TITLE
infra/doc: Add document and CI for qwen3

### DIFF
--- a/examples/models/core/qwen/README.md
+++ b/examples/models/core/qwen/README.md
@@ -577,5 +577,31 @@ load rouge done
 [11/09/2023-02:24:06] [TRT-LLM] [I]   rougeLsum : 21.10413175647868
 ```
 
+## Qwen3
+
+TensorRT-LLM now supports Qwen3, the latest version of the Qwen model series. According to the support matrix, TensorRT-LLM provides comprehensive support for various Qwen3 model variants including:
+
+### Quick start
+
+#### Run a single inference
+
+To quickly run Qwen3, examples/pytorch/quickstart_advanced.py:
+
+python3 examples/pytorch/quickstart_advanced.py --model_dir /home/scratch.bhsueh_gpu/models/Qwen3-30B-A3B/ --kv_cache_fraction 0.6
+
+
+<!-- python3 examples/pytorch/quickstart_advanced.py --model_dir /home/scratch.bhsueh_gpu/models/Qwen3-235B-A22B-FP8 --kv_cache_fraction 0.6 --tp_size 8 -->
+
+### Evaluation
+
+1. Evaluate accuracy on the MMLU dataset:
+
+python -m tensorrt_llm.commands.eval --model=/home/scratch.bhsueh_gpu/models/Qwen3-32B/ --tokenizer=/home/scratch.bhsueh_gpu/models/Qwen3-32B/ --backend=pytorch mmlu --dataset_path=/home/scratch.trt_llm_data/llm-models/datasets/mmlu/
+[05/01/2025-13:56:15] [TRT-LLM] [I] MMLU weighted average accuracy: 79.09 (14042)
+
+<!-- python -m tensorrt_llm.commands.eval --model=/home/scratch.bhsueh_gpu/models/Qwen3-30B-A3B/ --tokenizer=/home/scratch.bhsueh_gpu/models/Qwen3-30B-A3B/ --backend=pytorch mmlu --dataset_path=/home/scratch.trt_llm_data/llm-models/datasets/mmlu/
+[05/01/2025-14:03:05] [TRT-LLM] [I] MMLU weighted average accuracy: 48.10 (14042) -->
+
+
 ## Credits
 This Qwen model example exists thanks to Tlntin (TlntinDeng01@gmail.com) and zhaohb (zhaohbcloud@126.com).

--- a/tensorrt_llm/_torch/models/__init__.py
+++ b/tensorrt_llm/_torch/models/__init__.py
@@ -14,6 +14,8 @@ from .modeling_qwen import (Qwen2ForCausalLM, Qwen2ForProcessRewardModel,
                             Qwen2ForRewardModel)
 from .modeling_qwen2vl import Qwen2_5_VLModel, Qwen2VLModel
 from .modeling_qwen_moe import Qwen2MoeForCausalLM
+from .modeling_qwen3 import Qwen3ForCausalLM
+from .modeling_qwen3_moe import Qwen3MoeForCausalLM
 from .modeling_utils import get_model_architecture
 from .modeling_vila import VilaModel
 
@@ -37,6 +39,8 @@ __all__ = [
     "VilaModel",
     "Qwen2VLModel",
     "Qwen2_5_VLModel",
+    "Qwen3ForCausalLM",
+    "Qwen3MoeForCausalLM",
 ]
 
 if transformers.__version__ >= "4.45.1":

--- a/tensorrt_llm/_torch/models/__init__.py
+++ b/tensorrt_llm/_torch/models/__init__.py
@@ -13,9 +13,9 @@ from .modeling_nemotron_nas import NemotronNASForCausalLM
 from .modeling_qwen import (Qwen2ForCausalLM, Qwen2ForProcessRewardModel,
                             Qwen2ForRewardModel)
 from .modeling_qwen2vl import Qwen2_5_VLModel, Qwen2VLModel
-from .modeling_qwen_moe import Qwen2MoeForCausalLM
 from .modeling_qwen3 import Qwen3ForCausalLM
 from .modeling_qwen3_moe import Qwen3MoeForCausalLM
+from .modeling_qwen_moe import Qwen2MoeForCausalLM
 from .modeling_utils import get_model_architecture
 from .modeling_vila import VilaModel
 

--- a/tensorrt_llm/_torch/models/modeling_qwen3.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3.py
@@ -1,0 +1,273 @@
+from typing import Optional, Tuple, Union
+
+import torch
+from torch import nn
+from transformers import Qwen3Config
+
+from tensorrt_llm.functional import PositionEmbeddingType
+
+from ..attention_backend import AttentionMetadata
+from ..attention_backend.interface import PositionalEmbeddingParams, RopeParams
+from ..model_config import ModelConfig
+from ..modules.attention import Attention
+from ..modules.decoder_layer import DecoderLayer
+from ..modules.embedding import Embedding
+from ..modules.gated_mlp import GatedMLP
+from ..modules.linear import TensorParallelMode
+from ..modules.rms_norm import RMSNorm
+from ..pipeline_interface import PipelineInterface
+from .modeling_utils import DecoderModel, DecoderModelForCausalLM, register_auto_model
+
+
+class Qwen3RMSNorm(nn.Module):
+
+    def __init__(
+        self,
+        *,
+        hidden_size: int,
+        eps: float,
+        dtype: Optional[torch.dtype] = None,
+        device: Optional[torch.device] = None,
+        has_weights: bool = True,
+    ):
+        super().__init__()
+        if has_weights:
+            self.weight = nn.Parameter(torch.ones(hidden_size, dtype=dtype, device=device))
+        else:
+            self.register_buffer("weight", torch.ones(hidden_size, dtype=dtype, device=device), persistent=False)
+        self.variance_epsilon = eps
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        residual: Optional[torch.Tensor] = ...,
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        if isinstance(residual, torch.Tensor):
+            hidden_states = hidden_states + residual.to(torch.float32)
+            residual = hidden_states.to(input_dtype)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        hidden_states = (self.weight * hidden_states).to(input_dtype)
+
+        if residual is ...:
+            return hidden_states
+        else:
+            return hidden_states, residual
+
+
+class Qwen3Attention(Attention):
+
+    def __init__(
+        self,
+        model_config: ModelConfig[Qwen3Config],
+        layer_idx: Optional[int] = None,
+    ):
+        config = model_config.pretrained_config
+        if getattr(config, "rope_scaling", None) is not None:
+            pos_embd_params = PositionalEmbeddingParams(
+                type=PositionEmbeddingType.from_string(config.rope_scaling["type"]),
+                rope=RopeParams.from_config(config),
+            )
+        else:
+            pos_embd_params = PositionalEmbeddingParams(
+                type=PositionEmbeddingType.rope_gpt_neox,
+                rope=RopeParams.from_config(config),
+            )
+
+        super().__init__(
+            hidden_size=config.hidden_size,
+            num_attention_heads=config.num_attention_heads,
+            num_key_value_heads=config.num_key_value_heads,
+            max_position_embeddings=config.max_position_embeddings,
+            bias=config.attention_bias,
+            pos_embd_params=pos_embd_params,
+            layer_idx=layer_idx,
+            dtype=config.torch_dtype,
+            dense_bias=config.attention_bias,
+            config=model_config,
+        )
+
+        self.q_norm = Qwen3RMSNorm(hidden_size=self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = Qwen3RMSNorm(hidden_size=self.head_dim, eps=config.rms_norm_eps)
+
+
+class Qwen3DecoderLayer(DecoderLayer):
+
+    def __init__(
+        self,
+        model_config: ModelConfig[Qwen3Config],
+        layer_idx: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        super().__init__()
+        self.layer_idx = layer_idx
+        config = model_config.pretrained_config
+        self.self_attn = Qwen3Attention(
+            model_config,
+            layer_idx=layer_idx,
+        )
+
+        self.mlp = GatedMLP(
+            hidden_size=config.hidden_size,
+            intermediate_size=config.intermediate_size,
+            bias=config.mlp_bias if hasattr(config, "mlp_bias") else False,
+            dtype=config.torch_dtype,
+            config=model_config,
+        )
+        self.input_layernorm = RMSNorm(
+            hidden_size=config.hidden_size, eps=config.rms_norm_eps, dtype=config.torch_dtype
+        )
+        self.post_attention_layernorm = RMSNorm(
+            hidden_size=config.hidden_size, eps=config.rms_norm_eps, dtype=config.torch_dtype
+        )
+
+    def forward(
+        self,
+        position_ids: torch.LongTensor,
+        hidden_states: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        residual: Optional[torch.Tensor],
+        mrope_config: Optional[Tuple[torch.Tensor, int]] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        if residual is None:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+
+        # Self Attention
+        hidden_states = self.self_attn(
+            position_ids=position_ids,
+            hidden_states=hidden_states,
+            attn_metadata=attn_metadata,
+            mrope_config=mrope_config,
+            **kwargs,
+        )
+
+        # Fully Connected
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        hidden_states = self.mlp(hidden_states)
+        return hidden_states, residual
+
+
+class Qwen3Model(DecoderModel):
+
+    def __init__(self, model_config: ModelConfig[Qwen3Config]):
+        super().__init__(model_config)
+        config = self.model_config
+        self.padding_idx = config.pretrained_config.pad_token_id
+
+        self.embed_tokens = Embedding(
+            config.pretrained_config.vocab_size,
+            config.pretrained_config.hidden_size,
+            dtype=config.pretrained_config.torch_dtype,
+            mapping=config.mapping,
+            tensor_parallel_mode=TensorParallelMode.COLUMN,
+            gather_output=True,
+        )
+        self.layers = nn.ModuleList(
+            [
+                Qwen3DecoderLayer(
+                    model_config,
+                    layer_idx,
+                )
+                for layer_idx in range(config.pretrained_config.num_hidden_layers)
+            ]
+        )
+        self.norm = RMSNorm(
+            hidden_size=config.pretrained_config.hidden_size,
+            eps=config.pretrained_config.rms_norm_eps,
+            dtype=config.pretrained_config.torch_dtype,
+        )
+
+    def forward(
+        self,
+        attn_metadata: AttentionMetadata,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        mrope_config: Optional[Tuple[torch.Tensor, int]] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError(
+                "You cannot specify both input_ids and inputs_embeds at the same time, and must specify either one"
+            )
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        hidden_states = inputs_embeds
+
+        residual = None
+        for decoder_layer in self.layers:
+            hidden_states, residual = decoder_layer(
+                position_ids=position_ids,
+                hidden_states=hidden_states,
+                attn_metadata=attn_metadata,
+                residual=residual,
+                mrope_config=mrope_config,
+            )
+
+        hidden_states, _ = self.norm(hidden_states, residual)
+        return hidden_states
+
+
+@register_auto_model("Qwen3ForCausalLM")
+class Qwen3ForCausalLM(DecoderModelForCausalLM[Qwen3Model, Qwen3Config]):
+
+    def __init__(
+        self,
+        model_config: ModelConfig[Qwen3Config],
+    ):
+        super().__init__(
+            Qwen3Model(model_config),
+            config=model_config,
+            hidden_size=model_config.pretrained_config.hidden_size,
+            vocab_size=model_config.pretrained_config.vocab_size,
+        )
+
+    # NOTE: Qwen2-VL needs special mrope_config so adding separate forward() function to accept 'mrope_config'.
+    def forward(
+        self,
+        attn_metadata: AttentionMetadata,
+        input_ids: torch.LongTensor = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        pipeline_interface: Optional[PipelineInterface] = None,
+        return_context_logits: bool = False,
+        mrope_config: Optional[dict] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+
+        if self._supports_pp and self.pp_size > 1:
+            output = self.model(
+                input_ids=input_ids,
+                attn_metadata=attn_metadata,
+                position_ids=position_ids,
+                inputs_embeds=inputs_embeds,
+                pipeline_interface=pipeline_interface,
+                mrope_config=mrope_config,
+            )
+
+            # No need to compute logits for non-last PP ranks
+            if self.pp_rank < self.pp_size - 1:
+                return output
+        else:
+            output = self.model(
+                input_ids=input_ids,
+                attn_metadata=attn_metadata,
+                position_ids=position_ids,
+                inputs_embeds=inputs_embeds,
+                mrope_config=mrope_config,
+            )
+
+        return self.logits_processor.forward(
+            output,
+            self.lm_head,
+            attn_metadata,
+            return_context_logits,
+        )

--- a/tensorrt_llm/_torch/models/modeling_qwen3.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3.py
@@ -58,8 +58,8 @@ class Qwen3Attention(Attention):
                                    eps=1e-6,
                                    dtype=config.torch_dtype,
                                    has_weights=True)
-       self.aux_stream = torch.cuda.Stream()
-       self.ln_events = [torch.cuda.Event(), torch.cuda.Event()]
+        self.aux_stream = torch.cuda.Stream()
+        self.ln_events = [torch.cuda.Event(), torch.cuda.Event()]
 
 class Qwen3DecoderLayer(DecoderLayer):
 

--- a/tensorrt_llm/_torch/models/modeling_qwen3.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3.py
@@ -58,7 +58,8 @@ class Qwen3Attention(Attention):
                                    eps=1e-6,
                                    dtype=config.torch_dtype,
                                    has_weights=True)
-
+       self.aux_stream = torch.cuda.Stream()
+       self.ln_events = [torch.cuda.Event(), torch.cuda.Event()]
 
 class Qwen3DecoderLayer(DecoderLayer):
 

--- a/tensorrt_llm/_torch/models/modeling_qwen3.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3.py
@@ -18,45 +18,6 @@ from ..modules.rms_norm import RMSNorm
 from ..pipeline_interface import PipelineInterface
 from .modeling_utils import DecoderModel, DecoderModelForCausalLM, register_auto_model
 
-
-class Qwen3RMSNorm(nn.Module):
-
-    def __init__(
-        self,
-        *,
-        hidden_size: int,
-        eps: float,
-        dtype: Optional[torch.dtype] = None,
-        device: Optional[torch.device] = None,
-        has_weights: bool = True,
-    ):
-        super().__init__()
-        if has_weights:
-            self.weight = nn.Parameter(torch.ones(hidden_size, dtype=dtype, device=device))
-        else:
-            self.register_buffer("weight", torch.ones(hidden_size, dtype=dtype, device=device), persistent=False)
-        self.variance_epsilon = eps
-
-    def forward(
-        self,
-        hidden_states: torch.Tensor,
-        residual: Optional[torch.Tensor] = ...,
-    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
-
-        input_dtype = hidden_states.dtype
-        hidden_states = hidden_states.to(torch.float32)
-        if isinstance(residual, torch.Tensor):
-            hidden_states = hidden_states + residual.to(torch.float32)
-            residual = hidden_states.to(input_dtype)
-        variance = hidden_states.pow(2).mean(-1, keepdim=True)
-        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
-        hidden_states = (self.weight * hidden_states).to(input_dtype)
-        if residual is ...:
-            return hidden_states
-        else:
-            return hidden_states, residual
-
-
 class Qwen3Attention(Attention):
 
     def __init__(

--- a/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
@@ -32,7 +32,7 @@ class Qwen3MoE(nn.Module):
         self.hidden_dim = config.hidden_size
         self.ffn_dim = config.intermediate_size
         self.moe_intermediate_size = config.moe_intermediate_size
-        self.shared_expert_intermediate_size = config.shared_expert_intermediate_size
+        # self.shared_expert_intermediate_size = config.shared_expert_intermediate_size # not used in qwen3
         self.num_experts = config.num_experts
         self.top_k = config.num_experts_per_tok
         self.enable_attention_dp = model_config.mapping.enable_attention_dp

--- a/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
@@ -111,7 +111,8 @@ class Qwen3MoEAttention(Attention):
                                    eps=1e-6,
                                    dtype=config.torch_dtype,
                                    has_weights=True)
-
+        self.aux_stream = torch.cuda.Stream()
+        self.ln_events = [torch.cuda.Event(), torch.cuda.Event()]
 
 class Qwen3MoEDecoderLayer(DecoderLayer):
 

--- a/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
@@ -18,7 +18,6 @@ from ..modules.fused_moe import DefaultMoeRoutingMethod, FusedMoE
 from ..modules.linear import Linear, TensorParallelMode
 from ..modules.rms_norm import RMSNorm
 from .modeling_utils import DecoderModel, DecoderModelForCausalLM, duplicate_kv_weight, register_auto_model
-from .modeling_qwen3 import Qwen3RMSNorm
 
 
 class Qwen3MoE(nn.Module):
@@ -104,8 +103,14 @@ class Qwen3MoEAttention(Attention):
             config=model_config,
         )
 
-        self.q_norm = Qwen3RMSNorm(hidden_size=self.head_dim, eps=config.rms_norm_eps)
-        self.k_norm = Qwen3RMSNorm(hidden_size=self.head_dim, eps=config.rms_norm_eps)
+        self.q_norm = RMSNorm(hidden_size=self.head_dim,
+                                   eps=1e-6,
+                                   dtype=config.torch_dtype,
+                                   has_weights=True)
+        self.k_norm = RMSNorm(hidden_size=self.head_dim,
+                                   eps=1e-6,
+                                   dtype=config.torch_dtype,
+                                   has_weights=True)
 
 
 class Qwen3MoEDecoderLayer(DecoderLayer):

--- a/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
@@ -1,0 +1,287 @@
+from typing import Dict, Optional
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from tqdm import tqdm
+from transformers import Qwen3MoeConfig
+
+from tensorrt_llm.functional import PositionEmbeddingType
+
+from ..attention_backend import AttentionMetadata
+from ..attention_backend.interface import PositionalEmbeddingParams, RopeParams
+from ..model_config import ModelConfig
+from ..modules.attention import Attention
+from ..modules.decoder_layer import DecoderLayer
+from ..modules.embedding import Embedding
+from ..modules.fused_moe import DefaultMoeRoutingMethod, FusedMoE
+from ..modules.linear import Linear, TensorParallelMode
+from ..modules.rms_norm import RMSNorm
+from .modeling_utils import DecoderModel, DecoderModelForCausalLM, duplicate_kv_weight, register_auto_model
+from .modeling_qwen3 import Qwen3RMSNorm
+
+
+class Qwen3MoE(nn.Module):
+
+    def __init__(
+        self,
+        model_config: ModelConfig[Qwen3MoeConfig],
+        aux_stream: torch.cuda.Stream,
+    ):
+        super().__init__()
+        config = model_config.pretrained_config
+        self.hidden_dim = config.hidden_size
+        self.ffn_dim = config.intermediate_size
+        self.moe_intermediate_size = config.moe_intermediate_size
+        self.shared_expert_intermediate_size = config.shared_expert_intermediate_size
+        self.num_experts = config.num_experts
+        self.top_k = config.num_experts_per_tok
+        self.enable_attention_dp = model_config.mapping.enable_attention_dp
+
+        # moe gate (linear layer) only runs in half/full precision for now
+        self.gate = Linear(self.hidden_dim, self.num_experts, bias=False, dtype=config.torch_dtype, quant_config=None)
+
+        reduce_results = True
+
+        self.experts = FusedMoE(
+            num_experts=self.num_experts,
+            routing_method=DefaultMoeRoutingMethod(top_k=self.top_k),
+            hidden_size=self.hidden_dim,
+            intermediate_size=self.moe_intermediate_size,
+            aux_stream=aux_stream,
+            dtype=config.torch_dtype,
+            reduce_results=reduce_results,
+            model_config=model_config,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+    ) -> torch.Tensor:
+        assert hidden_states.shape[-1] == self.hidden_dim
+        orig_shape = hidden_states.shape
+        hidden_states = hidden_states.view(-1, self.hidden_dim)
+
+        all_rank_num_tokens = attn_metadata.all_rank_num_tokens
+        if self.enable_attention_dp and len(all_rank_num_tokens) > 1:
+            max_num_token = max(all_rank_num_tokens)
+            hidden_states = torch.nn.functional.pad(hidden_states, (0, 0, 0, max_num_token - hidden_states.shape[0]))
+        router_logits = self.gate(hidden_states)
+        final_hidden_states = self.experts(hidden_states, router_logits, all_rank_num_tokens)
+
+        return final_hidden_states.view(orig_shape)
+
+
+class Qwen3MoEAttention(Attention):
+
+    def __init__(
+        self,
+        model_config: ModelConfig[Qwen3MoeConfig],
+        layer_idx: Optional[int] = None,
+    ):
+        config = model_config.pretrained_config
+        if getattr(config, "rope_scaling", None) is not None:
+            pos_embd_params = PositionalEmbeddingParams(
+                type=PositionEmbeddingType.from_string(config.rope_scaling["type"]),
+                rope=RopeParams.from_config(config),
+            )
+        else:
+            pos_embd_params = PositionalEmbeddingParams(
+                type=PositionEmbeddingType.rope_gpt_neox,
+                rope=RopeParams.from_config(config),
+            )
+        super().__init__(
+            hidden_size=config.hidden_size,
+            num_attention_heads=config.num_attention_heads,
+            num_key_value_heads=config.num_key_value_heads,
+            max_position_embeddings=config.max_position_embeddings,
+            bias=config.attention_bias,
+            pos_embd_params=pos_embd_params,
+            layer_idx=layer_idx,
+            dtype=config.torch_dtype,
+            dense_bias=config.attention_bias,
+            config=model_config,
+        )
+
+        self.q_norm = Qwen3RMSNorm(hidden_size=self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = Qwen3RMSNorm(hidden_size=self.head_dim, eps=config.rms_norm_eps)
+
+
+class Qwen3MoEDecoderLayer(DecoderLayer):
+
+    def __init__(self, model_config: ModelConfig[Qwen3MoeConfig], layer_idx: int, aux_stream: torch.cuda.Stream):
+        super().__init__()
+        config = model_config.pretrained_config
+        self.self_attn = Qwen3MoEAttention(
+            model_config,
+            layer_idx=layer_idx,
+        )
+
+        self.mlp = Qwen3MoE(model_config, aux_stream)
+
+        self.input_layernorm = RMSNorm(
+            hidden_size=config.hidden_size, eps=config.rms_norm_eps, dtype=config.torch_dtype
+        )
+
+        self.post_attention_layernorm = RMSNorm(
+            hidden_size=config.hidden_size, eps=config.rms_norm_eps, dtype=config.torch_dtype
+        )
+        self.layer_idx = layer_idx
+
+    def forward(
+        self,
+        position_ids: torch.LongTensor,
+        hidden_states: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        residual: Optional[torch.Tensor],
+        **kwargs,
+    ) -> torch.Tensor:
+        if residual is None:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+
+        # Self Attention
+        hidden_states = self.self_attn(
+            position_ids=position_ids,
+            hidden_states=hidden_states,
+            attn_metadata=attn_metadata,
+            **kwargs,
+        )
+
+        # Fully Connected
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        hidden_states = self.mlp(hidden_states, attn_metadata)
+        return hidden_states, residual
+
+
+class Qwen3MoEModel(DecoderModel):
+
+    def __init__(self, model_config: ModelConfig[Qwen3MoeConfig]):
+        super().__init__(model_config)
+        config = self.model_config
+        self.padding_idx = config.pretrained_config.pad_token_id
+        self.aux_stream = torch.cuda.Stream()
+
+        self.embed_tokens = Embedding(
+            config.pretrained_config.vocab_size,
+            config.pretrained_config.hidden_size,
+            dtype=config.pretrained_config.torch_dtype,
+            mapping=config.mapping,
+            tensor_parallel_mode=TensorParallelMode.COLUMN,
+            gather_output=True,
+        )
+        self.layers = nn.ModuleList(
+            [
+                Qwen3MoEDecoderLayer(
+                    model_config,
+                    layer_idx,
+                    self.aux_stream,
+                )
+                for layer_idx in range(config.pretrained_config.num_hidden_layers)
+            ]
+        )
+        self.norm = RMSNorm(
+            hidden_size=config.pretrained_config.hidden_size,
+            eps=config.pretrained_config.rms_norm_eps,
+            dtype=config.pretrained_config.torch_dtype,
+        )
+
+    def forward(
+        self,
+        attn_metadata: AttentionMetadata,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError(
+                "You cannot specify both input_ids and inputs_embeds at the same time, and must specify either one"
+            )
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        hidden_states = inputs_embeds
+
+        residual = None
+        for decoder_layer in self.layers:
+            hidden_states, residual = decoder_layer(
+                position_ids=position_ids, hidden_states=hidden_states, attn_metadata=attn_metadata, residual=residual
+            )
+
+        hidden_states, _ = self.norm(hidden_states, residual)
+        return hidden_states
+
+
+@register_auto_model("Qwen3MoeForCausalLM")
+class Qwen3MoeForCausalLM(DecoderModelForCausalLM[Qwen3MoEModel, Qwen3MoeConfig]):
+
+    def __init__(
+        self,
+        model_config: ModelConfig[Qwen3MoeConfig],
+    ):
+        super().__init__(
+            Qwen3MoEModel(model_config),
+            config=model_config,
+            hidden_size=model_config.pretrained_config.hidden_size,
+            vocab_size=model_config.pretrained_config.vocab_size,
+        )
+
+    def load_weights(self, weights: Dict):
+        tp_size = self.model_config.mapping.tp_size
+        head_dim = getattr(self.config, "head_dim", self.config.hidden_size // self.config.num_attention_heads)
+
+        def filter_weights(prefix, weights: Dict):
+            result = {}
+            for k, v in weights.items():
+                if k.startswith(prefix):
+                    new_k = k[len(prefix) + 1 :]
+                    result[new_k] = v
+            return result
+
+        params_map = {"qkv_proj": ["q_proj", "k_proj", "v_proj"], "gate_up_proj": ["gate_proj", "up_proj"]}
+        for name, module in tqdm(list(self.named_modules()), desc="Loading weights"):
+            if len(module._parameters) > 0:
+                # skip load weights if tie word embeddings is enabled and layer is lm_head
+                if self.config.tie_word_embeddings and name.startswith("lm_head"):
+                    continue
+
+                names = name.split(".")
+                if names[-1] in params_map:
+                    module_weights = []
+                    for new_name in params_map[names[-1]]:
+                        fw = filter_weights(".".join(names[:-1] + [new_name]), weights)
+                        if new_name in ["k_proj", "v_proj"]:
+                            fw = {
+                                k: (
+                                    duplicate_kv_weight(weight=v[:], head_dim=head_dim, tensor_parallel_size=tp_size)
+                                    if k in ["weight", "bias"]
+                                    else v
+                                )
+                                for k, v in fw.items()
+                            }
+                        module_weights.append(fw)
+                    module.load_weights(weights=module_weights)
+                else:
+                    module_weights = filter_weights(name, weights)
+                    if isinstance(module, FusedMoE):
+                        updated_module_weights = {}
+                        for weight_name, weight_value in module_weights.items():
+                            new_weight_name = (
+                                weight_name.replace("gate_proj", "w1")
+                                .replace("up_proj", "w3")
+                                .replace("down_proj", "w2")
+                            )
+                            updated_module_weights[new_weight_name] = weight_value
+                        del module_weights
+                        module.load_weights(weights=[updated_module_weights])
+                    elif hasattr(module, "load_weights"):
+                        module.load_weights(weights=[module_weights])
+                    else:
+                        for n, p in module._parameters.items():
+                            if p is not None:
+                                p.data.copy_(module_weights[n][:])

--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -508,7 +508,9 @@ class DecoderModelForCausalLM(nn.Module,
 
     def load_weights(self, weights: Dict):
         tp_size = self.model_config.mapping.tp_size
-        head_dim =  getattr(self.config, "head_dim",  self.config.hidden_size // self.config.num_attention_heads)
+        head_dim = getattr(
+            self.config, "head_dim",
+            self.config.hidden_size // self.config.num_attention_heads)
 
         def filter_weights(prefix, weights: Dict):
             result = {}

--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -508,7 +508,7 @@ class DecoderModelForCausalLM(nn.Module,
 
     def load_weights(self, weights: Dict):
         tp_size = self.model_config.mapping.tp_size
-        head_dim = self.config.hidden_size // self.config.num_attention_heads
+        head_dim =  getattr(self.config, "head_dim",  self.config.hidden_size // self.config.num_attention_heads)
 
         def filter_weights(prefix, weights: Dict):
             result = {}

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -188,17 +188,15 @@ class Attention(nn.Module):
                                 dim=-1)
             if hasattr(self, 'q_norm') and hasattr(self, 'k_norm'):
                 # Add qk-norm
-                q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim,
-                                    self.head_dim)
+                q_by_head = q.reshape(-1, self.head_dim)
                 q_by_head = self.q_norm(q_by_head)
                 q = q_by_head.view(q.shape)
-                k_by_head = k.view(*k.shape[:-1], k.shape[-1] // self.head_dim,
-                                    self.head_dim)
+                k_by_head = k.reshape(-1, self.head_dim)
                 k_by_head = self.k_norm(k_by_head)
-                k = k_by_head.view(k.shape)                 
+                k = k_by_head.view(k.shape)
             q, k = self.rotary_emb(position_ids, [q, k])
-
         out_scale = None
+
         if self.o_proj.has_fp8_qdq or self.o_proj.has_nvfp4 or self.o_proj.has_fp8_block_scales:
             out_scale = self.o_proj.inv_input_scale
 

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -41,8 +41,10 @@ class Attention(nn.Module):
         config = config or ModelConfig()
         self.hidden_size = hidden_size
         self.num_heads = num_attention_heads
-        self.head_dim = getattr(config.pretrained_config, "head_dim",
-                                self.hidden_size // self.num_heads)
+        if config:
+            self.head_dim = getattr(config.pretrained_config, "head_dim", self.hidden_size // self.num_heads)
+        else: 
+            self.head_dim = self.hidden_size // self.num_heads
         self.num_key_value_heads = num_key_value_heads
         self.num_key_value_groups = self.num_heads // self.num_key_value_heads
         self.max_position_embeddings = max_position_embeddings
@@ -129,6 +131,8 @@ class Attention(nn.Module):
         self.rotary_emb = None
         self.apply_rotary_emb = (not self.enable_rope_fusion
                                  and pos_embd_params is not None)
+        if config.pretrained_config and config.pretrained_config.model_type == 'qwen3':
+            self.apply_rotary_emb = True
         if self.apply_rotary_emb:
             self.rotary_emb = RotaryEmbedding(
                 pos_embd_params.rope,
@@ -182,6 +186,16 @@ class Attention(nn.Module):
         if self.apply_rotary_emb and position_ids is not None:
             q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size],
                                 dim=-1)
+            if hasattr(self, 'q_norm') and hasattr(self, 'k_norm'):
+                # Add qk-norm
+                q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim,
+                                    self.head_dim)
+                q_by_head = self.q_norm(q_by_head)
+                q = q_by_head.view(q.shape)
+                k_by_head = k.view(*k.shape[:-1], k.shape[-1] // self.head_dim,
+                                    self.head_dim)
+                k_by_head = self.k_norm(k_by_head)
+                k = k_by_head.view(k.shape)                 
             q, k = self.rotary_emb(position_ids, [q, k])
 
         out_scale = None

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -131,7 +131,7 @@ class Attention(nn.Module):
         self.rotary_emb = None
         self.apply_rotary_emb = (not self.enable_rope_fusion
                                  and pos_embd_params is not None)
-        if config.pretrained_config and config.pretrained_config.model_type == 'qwen3':
+        if config.pretrained_config and config.pretrained_config.model_type == 'qwen3' or config.pretrained_config and config.pretrained_config.model_type == 'qwen3_moe':
             self.apply_rotary_emb = True
         if self.apply_rotary_emb:
             self.rotary_emb = RotaryEmbedding(

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -42,8 +42,9 @@ class Attention(nn.Module):
         self.hidden_size = hidden_size
         self.num_heads = num_attention_heads
         if config:
-            self.head_dim = getattr(config.pretrained_config, "head_dim", self.hidden_size // self.num_heads)
-        else: 
+            self.head_dim = getattr(config.pretrained_config, "head_dim",
+                                    self.hidden_size // self.num_heads)
+        else:
             self.head_dim = self.hidden_size // self.num_heads
         self.num_key_value_heads = num_key_value_heads
         self.num_key_value_groups = self.num_heads // self.num_key_value_heads
@@ -186,15 +187,17 @@ class Attention(nn.Module):
             q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size],
                                 dim=-1)
             # Add qk-norm
-            q_l2norm = lambda: self.q_norm(q.reshape(-1, self.head_dim)).reshape(-1, self.q_size)
-            k_l2norm = lambda: self.k_norm(k.reshape(-1, self.head_dim)).reshape(-1, self.kv_size)
+            q_l2norm = lambda: self.q_norm(q.reshape(-1, self.head_dim)
+                                           ).reshape(-1, self.q_size)
+            k_l2norm = lambda: self.k_norm(k.reshape(-1, self.head_dim)
+                                           ).reshape(-1, self.kv_size)
             q, k = maybe_execute_in_parallel(
-                    q_l2norm,
-                    k_l2norm,
-                    self.ln_events[0],
-                    self.ln_events[1],
-                    self.aux_stream,
-                )
+                q_l2norm,
+                k_l2norm,
+                self.ln_events[0],
+                self.ln_events[1],
+                self.aux_stream,
+            )
             q, k = self.rotary_emb(position_ids, [q, k])
         out_scale = None
 

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -186,18 +186,28 @@ class Attention(nn.Module):
         if self.apply_rotary_emb and position_ids is not None:
             q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size],
                                 dim=-1)
-            # Add qk-norm
-            q_l2norm = lambda: self.q_norm(q.reshape(-1, self.head_dim)
-                                           ).reshape(-1, self.q_size)
-            k_l2norm = lambda: self.k_norm(k.reshape(-1, self.head_dim)
-                                           ).reshape(-1, self.kv_size)
-            q, k = maybe_execute_in_parallel(
-                q_l2norm,
-                k_l2norm,
-                self.ln_events[0],
-                self.ln_events[1],
-                self.aux_stream,
-            )
+            if hasattr(self, 'q_norm') and hasattr(self, 'k_norm'):
+                # Add qk-norm
+                if hasattr(self, 'ln_events'):
+                    q_l2norm = lambda: self.q_norm(q.reshape(-1, self.head_dim)
+                                                   ).reshape(-1, self.q_size)
+                    k_l2norm = lambda: self.k_norm(k.reshape(-1, self.head_dim)
+                                                   ).reshape(-1, self.kv_size)
+                    q, k = maybe_execute_in_parallel(
+                        q_l2norm,
+                        k_l2norm,
+                        self.ln_events[0],
+                        self.ln_events[1],
+                        self.aux_stream,
+                    )
+                else:
+                    q_by_head = q.reshape(-1, self.head_dim)
+                    q_by_head = self.q_norm(q_by_head)
+                    q = q_by_head.view(q.shape)
+                    k_by_head = k.reshape(-1, self.head_dim)
+                    k_by_head = self.k_norm(k_by_head)
+                    k = k_by_head.view(k.shape)
+
             q, k = self.rotary_emb(position_ids, [q, k])
         out_scale = None
 

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -421,6 +421,9 @@ class Linear(nn.Module):
         assert self._weights_created
 
         def _copy(dst: Parameter, src: torch.Tensor):
+            # TODO check that is it a reasonable change or not
+            if dst.dtype != src.dtype:
+                src = src.to(dst.dtype)
             assert dst.dtype == src.dtype, f"Incompatible dtype. dst: {dst.dtype}, src: {src.dtype}"
             dst.data.copy_(src)
 

--- a/tests/integration/defs/accuracy/references/cnn_dailymail.yaml
+++ b/tests/integration/defs/accuracy/references/cnn_dailymail.yaml
@@ -253,3 +253,9 @@ deepseek-ai/DeepSeek-R1:
   - quant_algo: FP8_BLOCK_SCALES
     spec_dec_algo: MTP
     accuracy: 28.706
+Qwen3/Qwen3-8B:
+  - quant_algo: FP8_BLOCK_SCALES
+    accuracy: 30
+Qwen3/Qwen3-30B-A3B:
+  - quant_algo: FP8_BLOCK_SCALES
+    accuracy: 20

--- a/tests/integration/defs/accuracy/references/mmlu.yaml
+++ b/tests/integration/defs/accuracy/references/mmlu.yaml
@@ -79,3 +79,9 @@ deepseek-ai/DeepSeek-R1:
   - quant_algo: FP8_BLOCK_SCALES
     spec_dec_algo: MTP
     accuracy: 87.573
+Qwen3/Qwen3-8B:
+  - quant_algo: FP8_BLOCK_SCALES
+    accuracy: 70
+Qwen3/Qwen3-30B-A3B:
+  - quant_algo: FP8_BLOCK_SCALES
+    accuracy: 48

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -576,3 +576,90 @@ class TestQwen2_7BInstruct(LlmapiAccuracyTestHarness):
             task = CnnDailymail(self.MODEL_NAME)
             task.evaluate(llm,
                           extra_evaluator_kwargs=self.EXTRA_EVALUATOR_KWARGS)
+
+
+class TestQwen3_8B(LlmapiAccuracyTestHarness):
+    MODEL_NAME = "Qwen3/Qwen3-8B"
+
+    @skip_pre_hopper
+    @pytest.mark.parametrize(
+        "tp_size,pp_size,ep_size,attention_dp,cuda_graph,overlap_scheduler",
+        [(1, 1, 1, False, False, True)],
+        ids=["latency"])
+    def test_fp8_block_scales(self, tp_size, pp_size, ep_size, attention_dp,
+                              cuda_graph, overlap_scheduler):
+        pytorch_config = PyTorchConfig(
+            enable_overlap_scheduler=overlap_scheduler,
+            use_cuda_graph=cuda_graph)
+
+        llm = LLM(f"{llm_models_root()}/Qwen3/Qwen3-8B-FP8",
+                  tensor_parallel_size=tp_size,
+                  pipeline_parallel_size=pp_size,
+                  moe_expert_parallel_size=ep_size,
+                  pytorch_backend_config=pytorch_config,
+                  enable_attention_dp=attention_dp)
+        with llm:
+            task = CnnDailymail(self.MODEL_NAME)
+            task.evaluate(llm)
+            task = MMLU(self.MODEL_NAME)
+            task.evaluate(llm)
+            # task = GSM8K(self.MODEL_NAME)
+            # task.evaluate(llm, extra_evaluator_kwargs=self.EXTRA_EVALUATOR_KWARGS)
+
+
+class TestQwen3_30B_A3B(LlmapiAccuracyTestHarness):
+    MODEL_NAME = "Qwen3/Qwen3-30B-A3B"
+
+    @skip_pre_hopper
+    @pytest.mark.parametrize(
+        "tp_size,pp_size,ep_size,attention_dp,cuda_graph,overlap_scheduler",
+        [(1, 1, 1, False, False, True)],
+        ids=["latency"])
+    def test_fp8_block_scales(self, tp_size, pp_size, ep_size, attention_dp,
+                              cuda_graph, overlap_scheduler):
+        pytorch_config = PyTorchConfig(
+            enable_overlap_scheduler=overlap_scheduler,
+            use_cuda_graph=cuda_graph)
+
+        llm = LLM(f"{llm_models_root()}/Qwen3/Qwen3-30B-A3B-FP8",
+                  tensor_parallel_size=tp_size,
+                  pipeline_parallel_size=pp_size,
+                  moe_expert_parallel_size=ep_size,
+                  pytorch_backend_config=pytorch_config,
+                  enable_attention_dp=attention_dp)
+        with llm:
+            # task = CnnDailymail(self.MODEL_NAME)
+            # task.evaluate(llm)
+            task = MMLU(self.MODEL_NAME)
+            task.evaluate(llm)
+            # task = GSM8K(self.MODEL_NAME)
+            # task.evaluate(llm)
+
+
+class TestQwen3_32B(LlmapiAccuracyTestHarness):
+    MODEL_NAME = "Qwen3/Qwen3-32B"
+
+    @skip_pre_hopper
+    @pytest.mark.parametrize(
+        "tp_size,pp_size,ep_size,attention_dp,cuda_graph,overlap_scheduler",
+        [(1, 1, 1, False, False, True)],
+        ids=["latency"])
+    def test_fp8_block_scales(self, tp_size, pp_size, ep_size, attention_dp,
+                              cuda_graph, overlap_scheduler):
+        pytorch_config = PyTorchConfig(
+            enable_overlap_scheduler=overlap_scheduler,
+            use_cuda_graph=cuda_graph)
+
+        llm = LLM(f"{llm_models_root()}/Qwen3/Qwen3-32B-FP8",
+                  tensor_parallel_size=tp_size,
+                  pipeline_parallel_size=pp_size,
+                  moe_expert_parallel_size=ep_size,
+                  pytorch_backend_config=pytorch_config,
+                  enable_attention_dp=attention_dp)
+        with llm:
+            task = CnnDailymail(self.MODEL_NAME)
+            task.evaluate(llm)
+            task = MMLU(self.MODEL_NAME)
+            task.evaluate(llm)
+            # task = GSM8K(self.MODEL_NAME)
+            # task.evaluate(llm)

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -42,6 +42,8 @@ l0_h100:
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_fp8_block_scales[mtp_nextn=2-cuda_graph]
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_fp8_block_scales[mtp_nextn=2-overlap_scheduler]
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_fp8_block_scales[mtp_nextn=2-attention_dp-cuda_graph-overlap_scheduler]
+  - accuracy/test_llm_api_pytorch.py::TestQwen3_8B::test_fp8_block_scales[latency]
+  - accuracy/test_llm_api_pytorch.py::TestQwen3_30B_A3B::test_fp8_block_scales[latency]
   - test_e2e.py::test_trtllm_bench_pytorch_backend_sanity[meta-llama/Llama-3.1-8B-llama-3.1-8b-False-False]
   - test_e2e.py::test_trtllm_bench_pytorch_backend_sanity[meta-llama/Llama-3.1-8B-llama-3.1-8b-instruct-hf-fp8-True-True]
   - disaggregated/test_disaggregated.py::test_disaggregated_deepseek_v3_lite_fp8_tp1_single_gpu[DeepSeek-V3-Lite-fp8]


### PR DESCRIPTION
## Description

Add the following CIs into l0_h100 

  - accuracy/test_llm_api_pytorch.py::TestQwen3_8B::test_fp8_block_scales[latency]
  - accuracy/test_llm_api_pytorch.py::TestQwen3_30B_A3B::test_fp8_block_scales[latency]

and add quickstart for qwen3.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
