### PR TITLE
feat:enable kvcache to be reused during request generation

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -711,6 +711,12 @@ public:
     //! \param blockIds Id of each block.
     void storeBlocks(std::vector<BlockKey> const& blockKeys, std::vector<KVCacheBlock::IdType> const& blockIds);
 
+    //! \brief Store block in cached blocks.
+    //! \param blockKey Key of the block.
+    //! \param blockId Id of the block.
+    //! \param prevBlock prev block.
+    void storeBlock(BlockKey const& blockKey, KVCacheBlock::IdType blockId, BlockPtr const& prevBlock);
+
     void addBlockToHashMap(BlockPtr const& block);
 
     void removeBlockFromHashMap(BlockPtr const& block);

--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -553,6 +553,8 @@ public:
 
     void storeBlocksForReuse(GenerationRequest& sequence, OptionalRef<LlmRequest const> llmRequest);
 
+    void storeNewBlock(GenerationRequest& sequence, OptionalRef<LlmRequest const> llmRequest);
+
     //! \brief Release blocks of the sequence.
     void releaseBlocks(GenerationRequest& sequence);
 
@@ -1092,6 +1094,9 @@ public:
     //! \brief Store context blocks
     void storeContextBlocks(GenerationRequest& sequence, LlmRequest const& llmRequest);
 
+    //! \brief Store newest block for reuse
+    void storeNewBlock(GenerationRequest& sequence, OptionalRef<LlmRequest const> llmRequest);
+
     [[nodiscard]] static bool isUseOneMoreBlock(
         SizeType32 windowSize, std::optional<SizeType32> maxSequenceLength, SizeType32 maxBeamWidth)
     {
@@ -1261,6 +1266,10 @@ public:
     //! \brief Store full context blocks contributed by llmRequest.
     //! \details These blocks become reusable from next step.
     virtual void storeContextBlocks(LlmRequest const& llmRequest) = 0;
+
+    //! \brief Store newest block for reuse.
+    //! \details This block become reusable from next step.
+    virtual void storeNewBlock(LlmRequest const& llmRequest) = 0;
 
     //! \brief Get the block ids of a request [per beam] **for a given window size block manager**
     [[nodiscard]] virtual std::vector<std::vector<SizeType32>> const& getCacheBlockIds(
@@ -1567,6 +1576,9 @@ public:
     //! \brief Store full context blocks contributed by llmRequest.
     //! \details These blocks become reusable from next step.
     void storeContextBlocks(LlmRequest const& llmRequest) override;
+
+    //! \brief Store newest blocks for reuse
+    void storeNewBlock(LlmRequest const& llmRequest) override;
 
     [[nodiscard]] static SizeType32 getSinkBubbleLength(SizeType32 sinkTokenLen, SizeType32 tokensPerBlock);
 

--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -711,12 +711,6 @@ public:
     //! \param blockIds Id of each block.
     void storeBlocks(std::vector<BlockKey> const& blockKeys, std::vector<KVCacheBlock::IdType> const& blockIds);
 
-    //! \brief Store block in cached blocks.
-    //! \param blockKey Key of the block.
-    //! \param blockId Id of the block.
-    //! \param prevBlock prev block.
-    void storeBlock(BlockKey const& blockKey, KVCacheBlock::IdType blockId, BlockPtr const& prevBlock);
-
     void addBlockToHashMap(BlockPtr const& block);
 
     void removeBlockFromHashMap(BlockPtr const& block);

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -1283,6 +1283,35 @@ void WindowBlockManager::storeBlocks(
     }
 }
 
+void WindowBlockManager::storeBlock(BlockKey const& blockKey, KVCacheBlock::IdType blockId, BlockPtr const& prevBlock)
+{
+    TLLM_CHECK(prevBlock != nullptr && prevBlock->getPrevBlock() != nullptr);
+    TLLM_LOG_DEBUG("%s::storeBlock - store block %d", mLogPrefix.c_str(), blockId);
+    auto& block = mAllBlocksById[blockId];
+    block->setBlockKey(blockKey, static_cast<SizeType32>(blockKey.uniqueTokens.size()) == mTokensPerBlock);
+    block->setPrevBlock(prevBlock);
+    block->setPrevBlockInSeq(prevBlock);
+    prevBlock->addNextBlock(blockKey, block);
+
+    // Sanity check. The list of stored blocks should be connected.
+    TLLM_CHECK(block->getPrevBlockInSeq() == nullptr || block->getPrevBlockInSeq()->getHash() == prevBlock->getHash());
+    auto oldHash = block->getHash();
+    auto newHash = BlockKeyHasher()(blockKey, prevBlock->getHash());
+    if (oldHash != newHash)
+    {
+        TLLM_LOG_DEBUG("#%d block hash %zx -> %zx", block->getBlockId(), oldHash, newHash);
+        removeBlockFromHashMap(block);
+        block->setHash(newHash);
+        addBlockToHashMap(block);
+    }
+    if (mEventManager)
+    {
+        std::vector<BlockPtr> storedBlocks;
+        storedBlocks.push_back(block);
+        mEventManager->enqueueStoredEvent(storedBlocks);
+    }
+}
+
 void BlockManager::replaceSharedBlock(GenerationRequest& sequence, SizeType32 windowSize, SizeType32 blockIdx)
 {
     mWindowBlockManagers.at(windowSize).replaceSharedBlock(sequence, blockIdx);
@@ -1442,6 +1471,11 @@ void WindowBlockManager::storeNewBlock(GenerationRequest& sequence, OptionalRef<
     auto const& uniqueTokens = llmRequest->getUniqueTokens(beamIdx);
     auto const& cacheBlockIds = sequence.getCacheBlockIds(mWindowSize);
 
+    if (uniqueTokens.size() == 0)
+    {
+        return;
+    }
+
     // TODO: get the caller to mark tokens as filled / not filled, so that the kv-cache manager doesn't
     // have to guess. Only (length - 1) tokens of the sequence have their kv-state recorded in kv-cache. We assume
     // the last token's state is not filled yet.
@@ -1452,7 +1486,26 @@ void WindowBlockManager::storeNewBlock(GenerationRequest& sequence, OptionalRef<
     }
     auto blockedUniqueTokens = chopVectorIntoBlocks<UniqueToken>(uniqueTokens, usableSize, mTokensPerBlock, true);
     auto blockKeys = buildBlockKeys(blockedUniqueTokens, *llmRequest);
-    storeBlocks(std::move(blockKeys), cacheBlockIds[beamIdx]);
+    if (blockKeys.size() < 2 || cacheBlockIds[beamIdx].size() < blockKeys.size())
+    {
+        // store all blocks
+        TLLM_LOG_DEBUG("%s::storeNewBlock - store all blocks", mLogPrefix.c_str());
+        storeBlocks(std::move(blockKeys), cacheBlockIds[beamIdx]);
+        return;
+    }
+
+    auto prevBlock = mAllBlocksById.at(cacheBlockIds[beamIdx][blockKeys.size() - 2]);
+
+    // If the previous block is not in the radix tree, we need to store all blocks
+    if (prevBlock->getPrevBlock() == nullptr)
+    {
+        TLLM_LOG_DEBUG("%s::storeNewBlock - store all blocks", mLogPrefix.c_str());
+        storeBlocks(std::move(blockKeys), cacheBlockIds[beamIdx]);
+        return;
+    }
+
+    TLLM_LOG_DEBUG("%s::storeNewBlock - store the last block", mLogPrefix.c_str());
+    storeBlock(blockKeys.back(), cacheBlockIds[beamIdx][blockKeys.size() - 1], prevBlock);
 }
 
 void WindowBlockManager::storeBlocksForReuse(GenerationRequest& sequence, OptionalRef<LlmRequest const> llmRequest)
@@ -2009,7 +2062,7 @@ void KVCacheManager::storeNewBlock(LlmRequest const& llmRequest)
     auto const requestId = llmRequest.mRequestId;
     auto& sequence = getSequence(requestId);
     bool const storeBlocksForReuse = sequence.getBeamWidth() == 1 && !sequence.isCyclic();
-    if (mEnableBlockReuse && storeBlocksForReuse && !sequence.isCyclic())
+    if (mEnableBlockReuse && storeBlocksForReuse)
     {
         mBlockManager.storeNewBlock(sequence, llmRequest);
     }

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -1415,6 +1415,46 @@ void BlockManager::releaseBlocks(GenerationRequest& sequence, OptionalRef<LlmReq
     }
 }
 
+void BlockManager::storeNewBlock(GenerationRequest& sequence, OptionalRef<LlmRequest const> llmRequest)
+{
+    // we store newest block for potential reuse only if:
+    // - Block reuse is enabled.
+    // - A request was provided to this function call to identify which tokens these blocks cover
+    // - Beam search is NOT enabled <=> beam width == 1
+    // - The sequence was not marked for use with cyclic kv-cache when it was added (when its context is too long to fit
+    // the max attention window).
+    // - The sequence did not switch to cyclic kv-cache during generation phase.
+    //  A sequence is cyclic if its *minimum window size* is crossed, even if other window sizes were not reached.
+    bool const storeBlocksForReuse = sequence.getBeamWidth() == 1 && llmRequest.has_value() && !sequence.isCyclic();
+    if (!storeBlocksForReuse)
+    {
+        return;
+    }
+    for (auto& [_, manager] : mWindowBlockManagers)
+    {
+        manager.storeNewBlock(sequence, llmRequest);
+    }
+}
+
+void WindowBlockManager::storeNewBlock(GenerationRequest& sequence, OptionalRef<LlmRequest const> llmRequest)
+{
+    auto constexpr beamIdx = 0;
+    auto const& uniqueTokens = llmRequest->getUniqueTokens(beamIdx);
+    auto const& cacheBlockIds = sequence.getCacheBlockIds(mWindowSize);
+
+    // TODO: get the caller to mark tokens as filled / not filled, so that the kv-cache manager doesn't
+    // have to guess. Only (length - 1) tokens of the sequence have their kv-state recorded in kv-cache. We assume
+    // the last token's state is not filled yet.
+    auto const usableSize = static_cast<runtime::SizeType32>(uniqueTokens.size()) - 1;
+    if (usableSize % mTokensPerBlock != 0)
+    {
+        return;
+    }
+    auto blockedUniqueTokens = chopVectorIntoBlocks<UniqueToken>(uniqueTokens, usableSize, mTokensPerBlock, true);
+    auto blockKeys = buildBlockKeys(blockedUniqueTokens, *llmRequest);
+    storeBlocks(std::move(blockKeys), cacheBlockIds[beamIdx]);
+}
+
 void WindowBlockManager::storeBlocksForReuse(GenerationRequest& sequence, OptionalRef<LlmRequest const> llmRequest)
 {
     auto constexpr beamIdx = 0;
@@ -1961,6 +2001,17 @@ void KVCacheManager::storeContextBlocks(LlmRequest const& llmRequest)
     if (mEnableBlockReuse && !sequence.isCyclic() && !llmRequest.isDummyRequest())
     {
         mBlockManager.storeContextBlocks(sequence, llmRequest);
+    }
+}
+
+void KVCacheManager::storeNewBlock(LlmRequest const& llmRequest)
+{
+    auto const requestId = llmRequest.mRequestId;
+    auto& sequence = getSequence(requestId);
+    bool const storeBlocksForReuse = sequence.getBeamWidth() == 1 && !sequence.isCyclic();
+    if (mEnableBlockReuse && storeBlocksForReuse && !sequence.isCyclic())
+    {
+        mBlockManager.storeNewBlock(sequence, llmRequest);
     }
 }
 

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
@@ -248,6 +248,10 @@ private:
     //! These blocks become reusable from next step.
     void storeContextBlocks(std::shared_ptr<LlmRequest> const& req);
 
+    //! @brief Store newest kv cache block for reuse.
+    //! The block become reusable from next step.
+    void storeNewBlock(std::shared_ptr<LlmRequest> const& req);
+
     //! @brief Set LayerProfiler to collect performance per layer.
     void setLayerProfiler() override;
 

--- a/cpp/tests/batch_manager/trtGptModelTest.cpp
+++ b/cpp/tests/batch_manager/trtGptModelTest.cpp
@@ -918,6 +918,7 @@ TEST_F(TrtGptModelTest, KVCacheReuseChunked)
 
     for (int const numBlocksExpectedReused : {1, 2})
     {
+<<<<<<< HEAD
         auto trtGptModelIfb = std::make_shared<TrtGptModelIfbHelper>(
             mLogger, mModelConfig, mWorldConfig, *mRawEngine, true, executorConfig, false);
         auto const cacheManager = trtGptModelIfb->getKVCacheManager();
@@ -935,20 +936,46 @@ TEST_F(TrtGptModelTest, KVCacheReuseChunked)
             tokens->begin(), tokens->begin() + numBlocksExpectedReused * tokensPerBlock);
         // Add new token to "start" a new block.
         subTokens->push_back(0);
+=======
+        for (int const maxNumIterations : {2, 6})
+>>>>>>> 63f51da91 (enable kvcache to be reused during request generation)
         {
-            auto llmRequest
-                = std::make_shared<LlmRequest>(correlationId, maxNewTokens, tokens, inSamplingConfig, false);
-            RequestList requests{llmRequest};
-            forwardRequestsToCompletion(trtGptModelIfb, requests, 6);
-            EXPECT_EQ(llmRequest->isGenerationCompleteState(), true);
-        }
-        for (size_t i = 1; i <= 2; ++i)
-        {
-            auto llmRequest
-                = std::make_shared<LlmRequest>(correlationId, maxNewTokens, subTokens, inSamplingConfig, false);
-            RequestList req{llmRequest};
-            forwardRequestsToCompletion(trtGptModelIfb, req, 5);
-            EXPECT_EQ(cacheManager->getBlockManager().getNumReusedBlocks(), i * numBlocksExpectedReused);
+            auto trtGptModelIfb = std::make_shared<TrtGptModelIfbHelper>(
+                mLogger, mModelConfig, mWorldConfig, *mRawEngine, true, optionalParams);
+            auto const cacheManager = trtGptModelIfb->getKVCacheManager();
+            auto const tokensPerBlock = cacheManager->getTokensPerBlock();
+            constexpr int numPrefillBlocks = 2;
+
+            SamplingConfig inSamplingConfig;
+            inSamplingConfig.temperature = std::vector{2.0f};
+            int correlationId = 0;
+            constexpr int maxNewTokens = 4;
+
+            auto tokens = std::make_shared<std::vector<int32_t>>(tokensPerBlock * numPrefillBlocks);
+            std::iota(std::begin(*tokens), std::end(*tokens), 1);
+            auto subTokens = std::make_shared<std::vector<int32_t>>(
+                tokens->begin(), tokens->begin() + numBlocksExpectedReused * tokensPerBlock);
+            // Add new token to "start" a new block.
+            subTokens->push_back(0);
+            {
+                auto llmRequest
+                    = std::make_shared<LlmRequest>(correlationId, maxNewTokens, tokens, inSamplingConfig, false);
+                RequestList requests{llmRequest};
+                forwardRequestsToCompletion(trtGptModelIfb, requests, maxNumIterations);
+                EXPECT_EQ(llmRequest->isGenerationCompleteState(), maxNumIterations >= maxNewTokens);
+                if (!llmRequest->isGenerationCompleteState())
+                {
+                    correlationId++;
+                }
+            }
+            for (size_t i = 1; i <= 2; ++i)
+            {
+                auto llmRequest
+                    = std::make_shared<LlmRequest>(correlationId, maxNewTokens, subTokens, inSamplingConfig, false);
+                RequestList req{llmRequest};
+                forwardRequestsToCompletion(trtGptModelIfb, req, 5);
+                EXPECT_EQ(cacheManager->getBlockManager().getNumReusedBlocks(), i * numBlocksExpectedReused);
+            }
         }
     }
 }

--- a/cpp/tests/batch_manager/trtGptModelTest.cpp
+++ b/cpp/tests/batch_manager/trtGptModelTest.cpp
@@ -918,7 +918,6 @@ TEST_F(TrtGptModelTest, KVCacheReuseChunked)
 
     for (int const numBlocksExpectedReused : {1, 2})
     {
-<<<<<<< HEAD
         auto trtGptModelIfb = std::make_shared<TrtGptModelIfbHelper>(
             mLogger, mModelConfig, mWorldConfig, *mRawEngine, true, executorConfig, false);
         auto const cacheManager = trtGptModelIfb->getKVCacheManager();
@@ -936,46 +935,20 @@ TEST_F(TrtGptModelTest, KVCacheReuseChunked)
             tokens->begin(), tokens->begin() + numBlocksExpectedReused * tokensPerBlock);
         // Add new token to "start" a new block.
         subTokens->push_back(0);
-=======
-        for (int const maxNumIterations : {2, 6})
->>>>>>> 63f51da91 (enable kvcache to be reused during request generation)
         {
-            auto trtGptModelIfb = std::make_shared<TrtGptModelIfbHelper>(
-                mLogger, mModelConfig, mWorldConfig, *mRawEngine, true, optionalParams);
-            auto const cacheManager = trtGptModelIfb->getKVCacheManager();
-            auto const tokensPerBlock = cacheManager->getTokensPerBlock();
-            constexpr int numPrefillBlocks = 2;
-
-            SamplingConfig inSamplingConfig;
-            inSamplingConfig.temperature = std::vector{2.0f};
-            int correlationId = 0;
-            constexpr int maxNewTokens = 4;
-
-            auto tokens = std::make_shared<std::vector<int32_t>>(tokensPerBlock * numPrefillBlocks);
-            std::iota(std::begin(*tokens), std::end(*tokens), 1);
-            auto subTokens = std::make_shared<std::vector<int32_t>>(
-                tokens->begin(), tokens->begin() + numBlocksExpectedReused * tokensPerBlock);
-            // Add new token to "start" a new block.
-            subTokens->push_back(0);
-            {
-                auto llmRequest
-                    = std::make_shared<LlmRequest>(correlationId, maxNewTokens, tokens, inSamplingConfig, false);
-                RequestList requests{llmRequest};
-                forwardRequestsToCompletion(trtGptModelIfb, requests, maxNumIterations);
-                EXPECT_EQ(llmRequest->isGenerationCompleteState(), maxNumIterations >= maxNewTokens);
-                if (!llmRequest->isGenerationCompleteState())
-                {
-                    correlationId++;
-                }
-            }
-            for (size_t i = 1; i <= 2; ++i)
-            {
-                auto llmRequest
-                    = std::make_shared<LlmRequest>(correlationId, maxNewTokens, subTokens, inSamplingConfig, false);
-                RequestList req{llmRequest};
-                forwardRequestsToCompletion(trtGptModelIfb, req, 5);
-                EXPECT_EQ(cacheManager->getBlockManager().getNumReusedBlocks(), i * numBlocksExpectedReused);
-            }
+            auto llmRequest
+                = std::make_shared<LlmRequest>(correlationId, maxNewTokens, tokens, inSamplingConfig, false);
+            RequestList requests{llmRequest};
+            forwardRequestsToCompletion(trtGptModelIfb, requests, 6);
+            EXPECT_EQ(llmRequest->isGenerationCompleteState(), true);
+        }
+        for (size_t i = 1; i <= 2; ++i)
+        {
+            auto llmRequest
+                = std::make_shared<LlmRequest>(correlationId, maxNewTokens, subTokens, inSamplingConfig, false);
+            RequestList req{llmRequest};
+            forwardRequestsToCompletion(trtGptModelIfb, req, 5);
+            EXPECT_EQ(cacheManager->getBlockManager().getNumReusedBlocks(), i * numBlocksExpectedReused);
         }
     }
 }

--- a/cpp/tests/executor/executorTest.cpp
+++ b/cpp/tests/executor/executorTest.cpp
@@ -3273,19 +3273,21 @@ TEST_F(GptExecutorTest, ExecutorKVCacheManager)
                         auto events = kvCacheManager->getLatestEvents(std::chrono::milliseconds(100));
                         if (req == 0)
                         {
-                            EXPECT_EQ(events.size(), 2);
+                            EXPECT_EQ(events.size(), 3);
 
                             // Store the first context block
                             EXPECT_EQ(std::get<KVCacheStoredData>(events.front().data).parentHash, std::nullopt);
                             EXPECT_EQ(std::get<KVCacheStoredData>(events.front().data).blocks.size(), 1);
+                            events.pop_front();
                             // Store the second (now completed) context block and the partial decode block.
-                            EXPECT_EQ(std::get<KVCacheStoredData>(events.back().data).blocks.size(), 2);
+                            EXPECT_EQ(std::get<KVCacheStoredData>(events.front().data).blocks.size(), 1);
+                            EXPECT_EQ(std::get<KVCacheStoredData>(events.back().data).blocks.size(), 1);
                             EXPECT_EQ(std::get<KVCacheStoredData>(events.front().data).blocks[0].blockHash,
                                 std::get<KVCacheStoredData>(events.back().data).parentHash);
                         }
                         else
                         {
-                            EXPECT_EQ(events.size(), 4);
+                            EXPECT_EQ(events.size(), 5);
 
                             // Remove a block to make room for the second context block. On the second request, we need
                             // to remove 2 blocks.
@@ -3298,7 +3300,9 @@ TEST_F(GptExecutorTest, ExecutorKVCacheManager)
                             EXPECT_EQ(std::get<KVCacheRemovedData>(events.front().data).blockHashes.size(), 1);
                             events.pop_front();
                             // Store the final context block and the decode block
-                            EXPECT_EQ(std::get<KVCacheStoredData>(events.front().data).blocks.size(), 2);
+                            EXPECT_EQ(std::get<KVCacheStoredData>(events.front().data).blocks.size(), 1);
+                            events.pop_front();
+                            EXPECT_EQ(std::get<KVCacheStoredData>(events.front().data).blocks.size(), 1);
                         }
                     }
                 }


### PR DESCRIPTION
# Feat:enable kvcache to be reused during request generation

Issue: [https://github.com/NVIDIA/TensorRT-LLM/issues/3733]

[issues/3733][feat] enable kvcache to be reused during request generation

## Description

This PR enhances the KV cache reuse logic in TensorRT-LLM by enabling **block reuse during the generation phase**, not just after request completion. Specifically:

- Introduced a new interface `storeBlocksForReuse()` in `KVCacheManager`, allowing selective caching of KV blocks **while generation is still ongoing**.
- This improves memory reuse for partially generated requests, reducing overall KV block allocation pressure in long-running or chunked scenarios.

Changes

- Added `KVCacheManager::storeBlocksForReuse(LlmRequest const&)` to allow early KV block reuse.
- Integrated block reuse logic into the generation flow, enabling reuse before full completion of a request.
- Extended the behavior verified by the existing unit test `KVCacheReuseChunked`:
  - Previously, reuse was only validated after full generation completion.
  - Now it also verifies reuse after partial generation phases.


## Test Coverage

- The existing unit test `KVCacheReuseChunked` has been extended to validate reuse during generation.
- Block reuse counters are now checked incrementally during the decoding process.


## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
