### PR TITLE
[DRAFT] setting attention prior

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
+++ b/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
@@ -1756,6 +1756,21 @@ public:
         return mRequestedBlockHashes;
     }
 
+    void setAttentionPriorIdx(SizeType32 attentionPriorIdx)
+    {
+        mAttentionPriorIdx = attentionPriorIdx;
+    }
+
+    bool hasAttentionPriorIdx() const
+    {
+        return mAttentionPriorIdx.has_value();
+    }
+
+    [[nodiscard]] SizeType32 getAttentionPriorIdx() const
+    {
+        return mAttentionPriorIdx.value();
+    }
+
     RequestIdType mRequestId;
     SizeType32 mPromptLen;
     SizeType32 mMaxNewTokens;
@@ -1852,6 +1867,9 @@ protected:
     TensorPtr mEncoderOutput;       // [numTokens, hidden_size]
     TensorPtr mEncoderHiddenStates; // [numTokens, hiddenSize] for for Pipeline-Parallelism
     TensorPtr mEncoderOutputHost;   // [mEncoderOutputLength, encoderHiddenSize]
+
+    // for attention prior, placeholder for where to focus in encoder output
+    std::optional<SizeType32> mAttentionPriorIdx;
 
     SizeType32 mDecodingIter{0};
 

--- a/cpp/include/tensorrt_llm/batch_manager/runtimeBuffers.h
+++ b/cpp/include/tensorrt_llm/batch_manager/runtimeBuffers.h
@@ -71,7 +71,7 @@ public:
     static constexpr auto kPromptVocabSizeTensorName = "prompt_vocab_size";
     static constexpr auto kMRopeRotaryCosSinTensorName = "mrope_rotary_cos_sin";
     static constexpr auto kMRopePositionDeltasTensorName = "mrope_position_deltas";
-
+    static constexpr auto kScoresTensorName = "scores";
     using SizeType32 = runtime::SizeType32;
     using TensorPtr = runtime::ITensor::SharedPtr;
     using TensorMap = runtime::ITensor::TensorMap;
@@ -150,6 +150,8 @@ private:
 
     //! Prompt-Tuning
     std::unique_ptr<PromptTuningBuffers> promptTuningBuffers;
+    // Time index of input token with the highest attention score
+    TensorPtr scores;  // [b * context_length, b * numEncoderTokens]
 
     //! Mrope
     TensorPtr mropeRotaryCosSin;
@@ -283,6 +285,10 @@ public:
     void prepareEagleBuffers(RequestVector const& contextRequests, RequestVector const& genRequests,
         DecoderBuffers& decoderBuffers, runtime::TllmRuntime const& runtime, runtime::ModelConfig const& modelConfig,
         runtime::WorldConfig const& worldConfig);
+
+    std::vector<float> getScoresHost(runtime::TllmRuntime const& runtime);
+    void setAttentionPriorIdx(RequestVector const& contextRequests, RequestVector const& genRequests,
+        runtime::TllmRuntime const& runtime);
 
 private:
     void create(SizeType32 maxBatchSize, SizeType32 maxBeamWidth, std::vector<SizeType32> const& maxAttentionWindowVec,

--- a/cpp/tensorrt_llm/batch_manager/encoderBuffers.h
+++ b/cpp/tensorrt_llm/batch_manager/encoderBuffers.h
@@ -57,6 +57,7 @@ public:
 
     // encoder output
     TensorPtr encoderOutput; // [numEncoderTokens, hiddenSize]
+    SizeType32 encoderOutputLen{};
 
     // output buffer owned by llmRequest, such that it's per-request output buffer
     // encoderBuffers class can init and reshape each buffer, without maintaining a list/set of inflight buffers
@@ -82,7 +83,6 @@ public:
 private:
     SizeType32 numRequests{};
     SizeType32 encoderInputLen{};
-    SizeType32 encoderOutputLen{};
     SizeType32 maxInputLengthInBatch{}; // max input length in a batch
 
     // prefilled with deterministic values to avoid runtime creation

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -961,6 +961,13 @@ void TrtGptModelInflightBatching::forwardAsync(RequestList const& activeRequests
 
             sync_check_cuda_error(mRuntime->getStream().get());
 
+            // forward the attention prior index to llm requests for the next iteration
+            mBuffers[getFusedBufferId()]->setAttentionPriorIdx(
+                currRequests.contextRequests,
+                currRequests.generationRequests,
+                *mRuntime
+            );
+
             // Postpone decoder setup if model does not need to setup buffers for the context phase.
             if (!mModelConfig.getSpeculativeDecodingMode().needsDecoderPrologue())
             {
@@ -1003,13 +1010,6 @@ void TrtGptModelInflightBatching::forwardAsync(RequestList const& activeRequests
                                 COMM_SESSION.getRank(), llmReq->mRequestId);
 
                             llmReq->setState(LlmRequestState::kGENERATION_IN_PROGRESS);
-
-                            // for encoder-decoder models, free encoder output buffers after decoder context phase is
-                            // completed
-                            if (llmReq->getEncoderTokens().has_value())
-                            {
-                                llmReq->freeEncoderOutputBuffers();
-                            }
                             storeContextBlocks(llmReq);
                         }
                     }


### PR DESCRIPTION
# Attention prior

Computing an attention mask based on the attention scores of previous decoder step. This is a draft PR, to trigger the pipeline. 

TODO: make attention prior optional, configurable from model config; optimize the computation, avoid copying scores to CPU.