### PR TITLE
test: Test OOB access issue in penaltyKernel for endId=-1

### DIFF
--- a/cpp/tests/unit_tests/kernels/sampling/samplingTest.h
+++ b/cpp/tests/unit_tests/kernels/sampling/samplingTest.h
@@ -65,6 +65,15 @@ void initRandom(T* ptr, size_t size, float minval, float maxval)
     }
 }
 
+template <typename T>
+void initConstant(T* ptr, size_t size, T val)
+{
+    for (size_t i = 0; i < size; ++i)
+    {
+        ptr[i] = val;
+    }
+}
+
 inline void initRandomInt(int* ptr, size_t size, int minval, int maxval)
 {
     assert(minval < maxval);


### PR DESCRIPTION
## Description

When endId=-1 is not handled properly, minLength penalty kernel accesses out-of-bounds memory just prior to output logits. In this test, input logits are laid out just before output logits in memory to reproduce the issue that last input logit is corrupted when endId=-1 is not handled correctly.

Obviously, with the fix, this corruption doesn't happen.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

$ ./tests/unit_tests/kernels/samplingKernelsTest --gtest_filter=MinLengthPenaltyOOBSafetyTest/0.VerifyMemorySafetyForNegativeEndId

$ ./tests/unit_tests/kernels/samplingKernelsTest --gtest_filter=MinLengthPenaltyOOBSafetyTest/1.VerifyMemorySafetyForNegativeEndId

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
