### PR TITLE
fix: [nvbug/5247414] Fix the perf regression cause by insufficient cache warmup.

### DIFF
--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -6,6 +6,7 @@ import tensorrt_llm.quantization.utils.fp4_utils as fp4_utils
 
 from ..autotuner import AutoTuner, TunableRunner, TuningConfig
 from ..utils import (get_last_power_of_2_num_tokens_buckets,
+                     get_power_of_2_num_tokens_buckets,
                      last_positive_power_of_2, next_positive_power_of_2)
 
 
@@ -294,8 +295,11 @@ def nvfp4_gemm(
     tuner = AutoTuner.get()
 
     tuning_config = TuningConfig(
-        dynamic_tensors=((0, 0, (get_last_power_of_2_num_tokens_buckets,
-                                 last_positive_power_of_2)), ),
+        dynamic_tensors=((0, 0, (
+            lambda x: get_power_of_2_num_tokens_buckets(8192)
+            if not to_userbuffers else get_last_power_of_2_num_tokens_buckets(
+                x), lambda x: next_positive_power_of_2(x)
+            if not to_userbuffers else last_positive_power_of_2(x))), ),
         constraints=((2, 0, fp4_scale_dims), ),
     )
 


### PR DESCRIPTION
Force tuning up to 8192 sequence length for NVFP4 linear op. Also, make this runtime-selectable with UB enabled.