### PR TITLE
Leverage trtllm-gen kernel for FC+SwiGLU

### DIFF
--- a/tensorrt_llm/_torch/modules/gated_mlp.py
+++ b/tensorrt_llm/_torch/modules/gated_mlp.py
@@ -77,9 +77,11 @@ class GatedMLP(nn.Module):
             quant_config=config.get_quant_config(),
             is_expert=is_expert,
             skip_create_weights=config.skip_create_weights,
-            # During llama4, we are using the custom kernel that performs FC+SwiGLU
-            # in one kernel.
-            use_llama4_fc_swiglu=is_llama4)
+            # # During llama4, we are using the custom kernel that performs FC+SwiGLU
+            # # in one kernel.
+            # use_llama4_fc_swiglu=is_llama4,
+            use_trtllm_gen_fc_swiglu=is_llama4,
+        )
 
         self.down_proj = Linear(
             self.intermediate_size,
@@ -91,6 +93,7 @@ class GatedMLP(nn.Module):
             quant_config=config.get_quant_config(),
             is_expert=is_expert,
             skip_create_weights=config.skip_create_weights,
+            previous_gate_up_proj=self.gate_up_proj,
         )
 
         # These two modules are mutually exclusive - either splitted_gate_up_lora or fused_gate_up_lora will be used,
@@ -115,14 +118,20 @@ class GatedMLP(nn.Module):
     ) -> torch.Tensor:
         if self.activation == F.silu:
             if self.is_llama4 and self.down_proj.has_fp8_qdq and x.shape[0] <= 4:
-                # In Llama4, we have added a custom kernel that performs both FC+SwiGLU in one
-                # kernel. This was toggled by use_llama4_fc_swiglu in the Linear layer.
-                # Currently, we are replacing a kernel that gives fp8 in and bf16 out with
-                # fp8 in and fp8 out. Since next gemm is also fp8, we will need to feed
-                # the next gemm layer's input_scale inverse to the current layer as output
-                # scaling factor.
-                h2 = self.gate_up_proj(
-                    x, inv_input_scale=self.down_proj.inv_input_scale)
+                if self.gate_up_proj.use_llama4_fc_swiglu:
+                    # In Llama4, we have added a custom kernel that performs both FC+SwiGLU in one
+                    # kernel. This was toggled by use_llama4_fc_swiglu in the Linear layer.
+                    # Currently, we are replacing a kernel that gives fp8 in and bf16 out with
+                    # fp8 in and fp8 out. Since next gemm is also fp8, we will need to feed
+                    # the next gemm layer's input_scale inverse to the current layer as output
+                    # scaling factor.
+                    print("Using Po-Han custom kernel")
+                    h2 = self.gate_up_proj(
+                        x, inv_input_scale=self.down_proj.inv_input_scale)
+                else:
+                    # Using trtllm-gen kernel for FC+SwiGLU
+                    print("Using trtllm-gen kernel")
+                    h2 = self.gate_up_proj(x)
             else:
                 h1 = self.gate_up_proj(x)
                 if lora_params is not None:

--- a/tensorrt_llm/_torch/modules/gated_mlp.py
+++ b/tensorrt_llm/_torch/modules/gated_mlp.py
@@ -77,8 +77,8 @@ class GatedMLP(nn.Module):
             quant_config=config.get_quant_config(),
             is_expert=is_expert,
             skip_create_weights=config.skip_create_weights,
-            # # During llama4, we are using the custom kernel that performs FC+SwiGLU
-            # # in one kernel.
+            # During llama4, we are using the custom kernel that performs FC+SwiGLU
+            # in one kernel.
             # use_llama4_fc_swiglu=is_llama4,
             use_trtllm_gen_fc_swiglu=is_llama4,
         )

--- a/tensorrt_llm/_torch/modules/gated_mlp.py
+++ b/tensorrt_llm/_torch/modules/gated_mlp.py
@@ -78,7 +78,7 @@ class GatedMLP(nn.Module):
             is_expert=is_expert,
             skip_create_weights=config.skip_create_weights,
             # In Llama4, we are using the custom kernel that performs FC+SwiGLU
-            use_llama4_custom_fc_swiglu_kernel=is_llama4,
+            use_llama4_fc_swiglu_kernel=is_llama4,
         )
 
         self.down_proj = Linear(
@@ -91,10 +91,10 @@ class GatedMLP(nn.Module):
             quant_config=config.get_quant_config(),
             is_expert=is_expert,
             skip_create_weights=config.skip_create_weights,
-            # In llama4, the custom kernel (triggered by use_llama4_custom_fc_swiglu_kernel)
+            # In llama4, the custom kernel (triggered by use_llama4_fc_swiglu_kernel)
             # is outputing fp8. The current setting is assuming bf16 out, so we need
             # to provide the inv_input_scale of this layer to it to offset the un-needed
-            # quantization.
+                # quantization.
             previous_gate_up_proj=self.gate_up_proj,
         )
 

--- a/tensorrt_llm/_torch/modules/gated_mlp.py
+++ b/tensorrt_llm/_torch/modules/gated_mlp.py
@@ -80,6 +80,7 @@ class GatedMLP(nn.Module):
             # During llama4, we are using the custom kernel that performs FC+SwiGLU
             # in one kernel.
             # use_llama4_fc_swiglu=is_llama4,
+            # We are replacing the llama4_fc_swiglu with trtllm-gen kernel
             use_trtllm_gen_fc_swiglu=is_llama4,
         )
 
@@ -125,12 +126,10 @@ class GatedMLP(nn.Module):
                     # fp8 in and fp8 out. Since next gemm is also fp8, we will need to feed
                     # the next gemm layer's input_scale inverse to the current layer as output
                     # scaling factor.
-                    print("Using Po-Han custom kernel")
                     h2 = self.gate_up_proj(
                         x, inv_input_scale=self.down_proj.inv_input_scale)
                 else:
                     # Using trtllm-gen kernel for FC+SwiGLU
-                    print("Using trtllm-gen kernel")
                     h2 = self.gate_up_proj(x)
             else:
                 h1 = self.gate_up_proj(x)


### PR DESCRIPTION
# Leverage trtllm-gen kernel for FC+SwiGLU

## Description

Leverage the trtllm-gen kernel for FC+SwiGLU inside the gated_mlp module for llama4.

## Test Coverage

Unit test: `verify_fc_swiglu.py` to match output for current impl in `Linear` module and swapped trtllm-gen kernel.

Accuracy:

```
# 16 expert
PYTHONPATH=/code/tensorrt_llm python3 examples/pytorch/quickstart_advanced.py --model_dir /home/scratch.crush_data/trtllm-checkpoints/bf16-16e-ckpt --tp_size 8 --use_cuda_graph --attention_backend FLASHINFER
PYTHONPATH=/code/tensorrt_llm python3 examples/pytorch/quickstart_advanced.py --model_dir /home/scratch.crush_data/trtllm-checkpoints/fp8-16e-ckpt --tp_size 8 --use_cuda_graph --attention_backend FLASHINFER

# 128 expert
PYTHONPATH=/code/tensorrt_llm python3 examples/pytorch/quickstart_advanced.py --model_dir /home/scratch.crush_data/trtllm-checkpoints/bf16-128e-ckpt --tp_size 8 --use_cuda_graph --attention_backend FLASHINFER
PYTHONPATH=/code/tensorrt_llm python3 examples/pytorch/quickstart_advanced.py --model_dir /home/scratch.crush_data/trtllm-checkpoints/fp8-128e-ckpt --tp_size 8 --use_cuda_graph --attention_backend FLASHINFER
```