### PR TITLE
fix: Update log query regex in perf integration test to match trtllm-bench reporting

### DIFF
--- a/tests/integration/defs/perf/test_perf.py
+++ b/tests/integration/defs/perf/test_perf.py
@@ -178,7 +178,7 @@ BENCH_PERF_METRIC_LOG_QUERIES = {
     PerfMetricType.INFERENCE_TIME:
     re.compile(r"Total Latency \(ms\):\s+([\d\.]+)"),
     PerfMetricType.TOKEN_THROUGHPUT:
-    re.compile(r"GPU Output Throughput \(tokens\/sec\/gpu\):\s+([\d\.]+)"),
+    re.compile(r"GPU Output Throughput \(tps\/gpu\):\s+([\d\.]+)"),
     PerfMetricType.SEQ_THROUGHPUT:
     re.compile(r"Request Throughput \(req\/sec\):\s+([\d\.]+)"),
     PerfMetricType.FIRST_TOKEN_TIME:


### PR DESCRIPTION
# PR title

Update log query regex in perf integration test to match trtllm-bench reporting.
I believe in this PR https://github.com/NVIDIA/TensorRT-LLM/pull/3923/files the change includes the behavior of reporting to print "tps/gpu" instead of "tokens/sec/gpu" for token throughput, but in perf integration tests, we still regex match for the latter - hence causing failures locally


