### PR TITLE
doc: update qwen3 document

### DIFF
--- a/examples/models/core/qwen/README.md
+++ b/examples/models/core/qwen/README.md
@@ -587,21 +587,33 @@ TensorRT-LLM now supports Qwen3, the latest version of the Qwen model series. Ac
 
 To quickly run Qwen3, examples/pytorch/quickstart_advanced.py:
 
-python3 examples/pytorch/quickstart_advanced.py --model_dir /home/scratch.bhsueh_gpu/models/Qwen3-30B-A3B/ --kv_cache_fraction 0.6
-
-
-<!-- python3 examples/pytorch/quickstart_advanced.py --model_dir /home/scratch.bhsueh_gpu/models/Qwen3-235B-A22B-FP8 --kv_cache_fraction 0.6 --tp_size 8 -->
+python3 examples/pytorch/quickstart_advanced.py --model_dir Qwen3-30B-A3B/ --kv_cache_fraction 0.6
 
 ### Evaluation
 
 1. Evaluate accuracy on the MMLU dataset:
 
-python -m tensorrt_llm.commands.eval --model=/home/scratch.bhsueh_gpu/models/Qwen3-32B/ --tokenizer=/home/scratch.bhsueh_gpu/models/Qwen3-32B/ --backend=pytorch mmlu --dataset_path=/home/scratch.trt_llm_data/llm-models/datasets/mmlu/
+```bash
+python -m tensorrt_llm.commands.eval --model=Qwen3-32B/ --tokenizer=Qwen3-32B/ --backend=pytorch mmlu --dataset_path=./datasets/mmlu/
 [05/01/2025-13:56:15] [TRT-LLM] [I] MMLU weighted average accuracy: 79.09 (14042)
+```
 
-<!-- python -m tensorrt_llm.commands.eval --model=/home/scratch.bhsueh_gpu/models/Qwen3-30B-A3B/ --tokenizer=/home/scratch.bhsueh_gpu/models/Qwen3-30B-A3B/ --backend=pytorch mmlu --dataset_path=/home/scratch.trt_llm_data/llm-models/datasets/mmlu/
-[05/01/2025-14:03:05] [TRT-LLM] [I] MMLU weighted average accuracy: 48.10 (14042) -->
+```bash
+python -m tensorrt_llm.commands.eval --model=Qwen3-30B-A3B/ --tokenizer=Qwen3-30B-A3B/ --backend=pytorch mmlu --dataset_path=./datasets/mmlu/
+[05/05/2025-11:33:02] [TRT-LLM] [I] MMLU weighted average accuracy: 79.44 (14042)
+```
 
+2. Evaluate accuracy on GSM8K dataset:
+
+```bash
+python -m tensorrt_llm.commands.eval --model=Qwen3-30B-A3B/ --tokenizer=Qwen3-30B-A3B/ --backend=pytorch gsm8k --dataset_path=./datasets/openai/gsm8k/
+[05/05/2025-12:05:40] [TRT-LLM] [I] lm-eval gsm8k results (scores normalized to range 0~100):
+|Tasks|Version|     Filter     |n-shot|  Metric   |   | Value |   |Stderr|
+|-----|------:|----------------|-----:|-----------|---|------:|---|-----:|
+|gsm8k|      3|flexible-extract|     5|exact_match|↑  |84.3063|±  |1.0019|
+|     |       |strict-match    |     5|exact_match|↑  |88.6277|±  |0.8745|
+
+```
 
 ## Credits
 This Qwen model example exists thanks to Tlntin (TlntinDeng01@gmail.com) and zhaohb (zhaohbcloud@126.com).

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -601,8 +601,6 @@ class TestQwen3_8B(LlmapiAccuracyTestHarness):
             task.evaluate(llm)
             task = MMLU(self.MODEL_NAME)
             task.evaluate(llm)
-            # task = GSM8K(self.MODEL_NAME)
-            # task.evaluate(llm, extra_evaluator_kwargs=self.EXTRA_EVALUATOR_KWARGS)
 
 
 class TestQwen3_30B_A3B(LlmapiAccuracyTestHarness):
@@ -657,5 +655,3 @@ class TestQwen3_32B(LlmapiAccuracyTestHarness):
             task.evaluate(llm)
             task = MMLU(self.MODEL_NAME)
             task.evaluate(llm)
-            # task = GSM8K(self.MODEL_NAME)
-            # task.evaluate(llm)


### PR DESCRIPTION

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
