### PR TITLE
Reduce computation for the top layer in chunked context.

### DIFF
--- a/cpp/tensorrt_llm/common/attentionOp.h
+++ b/cpp/tensorrt_llm/common/attentionOp.h
@@ -124,6 +124,9 @@ public:
         int32_t num_encoder_tokens = 0;
         kernels::MlaParams<T>* mla_param = nullptr;
 
+        // Whether to skip SDPA for context phase
+        bool skip_sdpa = false;
+
         std::string enqueueContextParamsToString() const
         {
             // variables from the params coming from the runtime
@@ -173,6 +176,7 @@ public:
             ss << "cross_kv_length: " << this->cross_kv_length << std::endl;
             ss << "encoder_input_lengths: " << this->encoder_input_lengths << std::endl;
             ss << "num_encoder_tokens: " << this->num_encoder_tokens << std::endl;
+            ss << "skip_sdpa: " << (this->skip_sdpa ? "true" : "false") << std::endl;
             return ss.str();
         }
     };

--- a/tensorrt_llm/_torch/attention_backend/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/interface.py
@@ -108,6 +108,14 @@ class AttentionMetadata:
     # The shape is (batch_size) if provided.
     prompt_lens: Optional[List[int]] = None
 
+    # The number of required context logits for each sequence in the batch.
+    # The shape is (batch_size) if provided.
+    #
+    # This is used to skip certain computation in SDPA for context phase.
+    # If not provided, default to all context logits are required.
+    # -1 means all context logits are required.
+    num_context_logits: Optional[List[int]] = None
+
     # These fields indicate whether the runtime can use various features.
     # The kernels may or may not have different behaviors when these
     # are enabled.

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -257,6 +257,7 @@ class TrtllmAttentionWrapper:
         out_dtype: Optional[torch.dtype] = None,
         is_fused_qkv: bool = True,
         update_kv_cache: bool = True,
+        skip_sdpa_for_context: bool = False,
         attention_mask: AttentionMask = PredefinedAttentionMask.CAUSAL,
     ):
         """
@@ -268,6 +269,7 @@ class TrtllmAttentionWrapper:
             out_dtype (Optional[torch.dtype]): Output data type if provided.
             is_fused_qkv (bool): Whether QKV tensor is provided.
             update_kv_cache (bool): Whether KV cache is updated.
+            skip_sdpa_for_context (bool): Whether to skip SDPA for context.
             attention_mask (AttentionMask): Attention mask. See definition of AttentionMask for accepted types. Defaults to predefined causal mask.
         Returns:
             torch.Tensor with shape (num_tokens, num_heads * head_dim).
@@ -363,6 +365,7 @@ class TrtllmAttentionWrapper:
             self.block_ids_per_seq,
             is_fused_qkv,
             update_kv_cache,
+            skip_sdpa_for_context,
             self.predicted_tokens_per_seq,
             self.layer_idx,
             self.num_heads,
@@ -657,6 +660,7 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
         k: Optional[torch.Tensor],
         v: Optional[torch.Tensor],
         metadata: TrtllmAttentionMetadata,
+        skip_sdpa_for_context: bool = False,
         out_scale: Optional[torch.Tensor] = None,
         *,
         attention_mask: AttentionMask = PredefinedAttentionMask.CAUSAL,
@@ -758,5 +762,6 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
                                   and k is None,
                                   update_kv_cache=not metadata.is_cross
                                   or k is not None,
+                                  skip_sdpa_for_context=skip_sdpa_for_context,
                                   attention_mask=attention_mask)
         return output

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -167,6 +167,7 @@ class Attention(nn.Module):
         position_ids: Optional[torch.LongTensor],
         hidden_states: torch.Tensor,
         attn_metadata: AttentionMetadata,
+        skip_sdpa_for_context: bool = False,
         attention_mask: PredefinedAttentionMask = PredefinedAttentionMask.
         CAUSAL,
         mrope_config: Optional[dict] = None,
@@ -223,6 +224,7 @@ class Attention(nn.Module):
                                             None,
                                             None,
                                             attn_metadata,
+                                            skip_sdpa_for_context,
                                             out_scale=out_scale,
                                             attention_mask=attention_mask,
                                             mrope_config=mrope_config)
@@ -237,9 +239,11 @@ class Attention(nn.Module):
                                             k.contiguous(),
                                             v.contiguous(),
                                             attn_metadata,
+                                            skip_sdpa_for_context,
                                             attention_mask=attention_mask,
                                             mrope_config=mrope_config)
 
+        # TODO(minwei)
         attn_output = self.o_proj(attn_output,
                                   all_reduce_params=all_reduce_params)
         if lora_params is not None:

--- a/tensorrt_llm/_torch/pyexecutor/decoder.py
+++ b/tensorrt_llm/_torch/pyexecutor/decoder.py
@@ -196,7 +196,6 @@ class TorchDecoder(Decoder):
 
     def _meet_max_token_stop_criteria(self, request: LlmRequest,
                                       num_tokens: int):
-
         return (num_tokens - request.py_orig_prompt_len
                 >= request.py_max_new_tokens) or (num_tokens
                                                   >= self.max_seq_len)


### PR DESCRIPTION
Only the last logit is required in context phase. Thus, we skip SDPA computation for all chunks (except the last one) for the top layer.

Though this PR only changes the behavior for llama models, this can be applied on any decoder-only models too.