### PR TITLE
Integrate trtllm-gen kernel for the QKV gemm in llama4

### DIFF
--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -127,6 +127,7 @@ class Attention(nn.Module):
             skip_create_weights=config.skip_create_weights,
             use_llama4_qkv=is_llama4,
         )
+        # Current problem size doesn't suit gemv kernel. We possibly want to switch this to trtllm-gen kernel.
         self.o_proj = Linear(
             self.hidden_size,
             self.hidden_size,


### PR DESCRIPTION
# Integrate trtllm-gen kernel for the QKV gemm in llama4

## Description

Integrate trtllm-gen kernel for QKV gemm in llama4.

Experiment results listed below (with number of sequence=32, TP8, EP1, batch size 1), and this merge request is the version from `A`.

```
current impl: 756.2626
A: 758.1391
B: 733.9629
C: 734.2719
where:

current:
    token <= 8 all goes to gemv
A
	token <=4 all goes to gemv
	token <=8 with position_id, goes to gemv
	token <=8 w/o position_id, goes to trtllm_gen
B
	token <=8, w/o position_id, goes to trtllm_gen
	otherwise, goes to gemv
C
	token < 4, gemv
	4 <= token <= 8, goes to trtllm_gen
	4 <= token <= 8 with position_id, goes to gemv
```

## Test Coverage

```
# 16 expert
PYTHONPATH=/code/tensorrt_llm python3 examples/pytorch/quickstart_advanced.py --model_dir /home/scratch.crush_data/trtllm-checkpoints/bf16-16e-ckpt --tp_size 8 --use_cuda_graph --attention_backend FLASHINFER
PYTHONPATH=/code/tensorrt_llm python3 examples/pytorch/quickstart_advanced.py --model_dir /home/scratch.crush_data/trtllm-checkpoints/fp8-16e-ckpt --tp_size 8 --use_cuda_graph --attention_backend FLASHINFER

# 128 expert
PYTHONPATH=/code/tensorrt_llm python3 examples/pytorch/quickstart_advanced.py --model_dir /home/scratch.crush_data/trtllm-checkpoints/bf16-128e-ckpt --tp_size 8 --use_cuda_graph --attention_backend FLASHINFER
PYTHONPATH=/code/tensorrt_llm python3 examples/pytorch/quickstart_advanced.py --model_dir /home/scratch.crush_data/trtllm-checkpoints/fp8-128e-ckpt --tp_size 8 --use_cuda_graph --attention_backend FLASHINFER
```
