### PR TITLE
[https://nvbugspro.nvidia.com/bug/5238626] illegal memory address when running llama 4 with cuda graph enabled

### DIFF
--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention.h
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention.h
@@ -269,15 +269,14 @@ DECLARE_MMHA_NORMAL_AND_PAGED(__nv_bfloat16);
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-template <typename T>
-inline int estimate_min_multi_block_count(int max_timesteps, int max_dynamic_shmem_per_block)
+inline int estimate_min_multi_block_count(int max_timesteps, int max_dynamic_shmem_per_block, int num_bytes_per_elt)
 {
     auto const qk_elts = static_cast<int>((max_timesteps + 1 + 4 - 1) / 4);
     int size_per_elts = 16;
 #ifndef MMHA_USE_FP32_ACUM_FOR_LOGITS
-    if (sizeof(T) != 4)
+    if (num_bytes_per_elt != 4)
     {
-        size_per_elts += 4 * sizeof(T);
+        size_per_elts += 4 * num_bytes_per_elt;
     }
 #endif
     int elts_per_block = max_dynamic_shmem_per_block / size_per_elts;

--- a/tensorrt_llm/_torch/models/modeling_llama.py
+++ b/tensorrt_llm/_torch/models/modeling_llama.py
@@ -888,12 +888,7 @@ class Llama4ForCausalLM(DecoderModelForCausalLM[Llama4Model, Llama4Config]):
                          vocab_size=model_config.pretrained_config.vocab_size)
 
     def infer_max_seq_len(self):
-        # TODO: increase to support 10M context length. There are two blockers
-        # right now:
-        # 1. We need to implement chunked attention.
-        # 2. CUDA graph warmup will crash when the cached context is that long.
-        # This only affects the TRTLLM backend; flashinfer is fine. It is
-        # most likely an issue with the kernel.
+        # TODO: implement chunked attention to support 10M context length
         return 8192
 
     def load_weights(self, weights: Dict):

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -20,7 +20,7 @@ from .decoder import (EarlyStopDecoder, TorchDecoder, TorchStarAttentionDecoder,
                       TRTLLMDecoder)
 from .kv_cache_transceiver import (AttentionTypeCpp, CacheTransBufferManager,
                                    create_kv_cache_transceiver)
-from .model_engine import (KV_CACHE_MANAGER_KEY, PyTorchModelEngine)
+from .model_engine import KV_CACHE_MANAGER_KEY, PyTorchModelEngine
 from .py_executor import PyExecutor
 from .resource_manager import (KVCacheManager, MambaHybridCacheManager,
                                PeftCacheManager, ResourceManager)

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -261,6 +261,7 @@ def estimate_max_kv_cache_tokens(py_executor: PyExecutor,
 
 def create_kv_cache_manager(model_engine: PyTorchModelEngine, mapping: Mapping,
                             executor_config: ExecutorConfig) -> KVCacheManager:
+    kv_cache_manager = None
     if executor_config.pytorch_backend_config.use_kv_cache:
         config = model_engine.model.model_config.pretrained_config
         quant_config = model_engine.model.model_config.quant_config
@@ -286,7 +287,7 @@ def create_kv_cache_manager(model_engine: PyTorchModelEngine, mapping: Mapping,
             if spec_config is not None:
                 num_hidden_layers += get_num_spec_layers(spec_config)
 
-            return KVCacheManager(
+            kv_cache_manager = KVCacheManager(
                 executor_config.kv_cache_config,
                 tensorrt_llm.bindings.internal.batch_manager.CacheType.
                 SELFKONLY,
@@ -306,7 +307,7 @@ def create_kv_cache_manager(model_engine: PyTorchModelEngine, mapping: Mapping,
             num_layers = config.hybrid_override_pattern.count("*")
             mamba_num_layers = num_mamba_layers = config.hybrid_override_pattern.count(
                 "M")
-            return MambaHybridCacheManager(
+            kv_cache_manager = MambaHybridCacheManager(
                 # mamba cache parameters
                 config.hidden_size,
                 config.ssm_state_size,
@@ -332,7 +333,7 @@ def create_kv_cache_manager(model_engine: PyTorchModelEngine, mapping: Mapping,
         else:
             if spec_config is not None:
                 num_hidden_layers += get_num_spec_layers(spec_config)
-            return KVCacheManager(
+            kv_cache_manager = KVCacheManager(
                 executor_config.kv_cache_config,
                 tensorrt_llm.bindings.internal.batch_manager.CacheType.SELF,
                 num_layers=num_hidden_layers,
@@ -346,8 +347,10 @@ def create_kv_cache_manager(model_engine: PyTorchModelEngine, mapping: Mapping,
                 num_extra_kv_tokens=0
                 if spec_config is None else spec_config.num_extra_kv_tokens,
             )
-    else:
-        return None
+        # KVCacheManager modifies the max_seq_len field, update it to executor_config
+        executor_config.max_seq_len = kv_cache_manager.max_seq_len
+
+    return kv_cache_manager, executor_config
 
 
 def create_py_executor_instance(dist,

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -20,7 +20,7 @@ from .decoder import (EarlyStopDecoder, TorchDecoder, TorchStarAttentionDecoder,
                       TRTLLMDecoder)
 from .kv_cache_transceiver import (AttentionTypeCpp, CacheTransBufferManager,
                                    create_kv_cache_transceiver)
-from .model_engine import KV_CACHE_MANAGER_KEY, PyTorchModelEngine
+from .model_engine import (KV_CACHE_MANAGER_KEY, PyTorchModelEngine)
 from .py_executor import PyExecutor
 from .resource_manager import (KVCacheManager, MambaHybridCacheManager,
                                PeftCacheManager, ResourceManager)
@@ -347,10 +347,11 @@ def create_kv_cache_manager(model_engine: PyTorchModelEngine, mapping: Mapping,
                 num_extra_kv_tokens=0
                 if spec_config is None else spec_config.num_extra_kv_tokens,
             )
-        # KVCacheManager modifies the max_seq_len field, update it to executor_config
-        executor_config.max_seq_len = kv_cache_manager.max_seq_len
+        # KVCacheManager (Non-draft) modifies the max_seq_len field, update it to executor_config
+        if model_engine.kv_cache_manager_key == KV_CACHE_MANAGER_KEY:
+            executor_config.max_seq_len = kv_cache_manager.max_seq_len
 
-    return kv_cache_manager, executor_config
+    return kv_cache_manager
 
 
 def create_py_executor_instance(dist,

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -154,11 +154,11 @@ def create_py_executor(executor_config: ExecutorConfig,
         if 'cp_type' not in mapping.cp_config:
             executor_config.kv_cache_config.max_tokens = get_token_num_for_estimation(
                 executor_config, model_engine.model.model_config)
-        kv_cache_manager, executor_config = create_kv_cache_manager(
-            model_engine, mapping, executor_config)
+        kv_cache_manager = create_kv_cache_manager(model_engine, mapping,
+                                                   executor_config)
         draft_kv_cache_manager = create_kv_cache_manager(
             draft_model_engine, mapping,
-            executor_config)[0] if draft_model_engine is not None else None
+            executor_config) if draft_model_engine is not None else None
         resources[KV_CACHE_MANAGER_KEY] = kv_cache_manager
         resources[DRAFT_KV_CACHE_MANAGER_KEY] = draft_kv_cache_manager
 
@@ -183,8 +183,8 @@ def create_py_executor(executor_config: ExecutorConfig,
         if kv_cache_max_tokens is not None:
             executor_config.kv_cache_config.max_tokens = kv_cache_max_tokens
 
-            kv_cache_manager, executor_config = create_kv_cache_manager(
-                model_engine, mapping, executor_config)
+            kv_cache_manager = create_kv_cache_manager(model_engine, mapping,
+                                                       executor_config)
             resources[KV_CACHE_MANAGER_KEY] = kv_cache_manager
 
             if model_engine.attn_metadata is not None and kv_cache_manager is not None:
@@ -195,7 +195,7 @@ def create_py_executor(executor_config: ExecutorConfig,
 
             if draft_model_engine is not None:
                 draft_kv_cache_manager = create_kv_cache_manager(
-                    draft_model_engine, mapping, executor_config)[0]
+                    draft_model_engine, mapping, executor_config)
                 resources[DRAFT_KV_CACHE_MANAGER_KEY] = draft_kv_cache_manager
                 if draft_model_engine.attn_metadata is not None and draft_kv_cache_manager is not None:
                     if pytorch_backend_config.use_cuda_graph:

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -207,6 +207,10 @@ def create_py_executor(executor_config: ExecutorConfig,
                     del draft_model_engine.attn_metadata
                     draft_model_engine.attn_metadata = None
 
+            # KVCacheManager modifies these fields, update them to executor_config
+            if kv_cache_manager is not None:
+                executor_config.max_seq_len = kv_cache_manager.max_seq_len
+
             py_executor = create_py_executor_instance(
                 dist, resources, mapping, pytorch_backend_config,
                 executor_config, ctx_chunk_config, model_engine,

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -371,7 +371,7 @@ class KVCacheManager(BaseResourceManager):
             max_tokens = mpi_comm().allreduce(max_tokens, op=MPI.MIN)
 
         # get number of blocks
-        blocks_in_primary_pool = math.floor(max_tokens / tokens_per_block)
+        blocks_in_primary_pool = math.ceil(max_tokens / tokens_per_block)
         host_cache_size = kv_cache_config.host_cache_size if kv_cache_config.host_cache_size else 0
         max_tokens_secondary = host_cache_size / cache_size_bytes_per_token
         blocks_in_secondary_pool = max(

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -371,7 +371,7 @@ class KVCacheManager(BaseResourceManager):
             max_tokens = mpi_comm().allreduce(max_tokens, op=MPI.MIN)
 
         # get number of blocks
-        blocks_in_primary_pool = math.ceil(max_tokens / tokens_per_block)
+        blocks_in_primary_pool = math.floor(max_tokens / tokens_per_block)
         host_cache_size = kv_cache_config.host_cache_size if kv_cache_config.host_cache_size else 0
         max_tokens_secondary = host_cache_size / cache_size_bytes_per_token
         blocks_in_secondary_pool = max(


### PR DESCRIPTION
# [[Nvbug 5238626](https://nvbugspro.nvidia.com/bug/5238626)] illegal memory address when running llama 4 with cuda graph enabled 

## Description

The root cause is that we create dummy generation requests with [context_length (prompt_length) set as 0](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/_torch/pyexecutor/resource_manager.py#L301), which hasn't been well handled in the MMHA kernels.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
