### PR TITLE
refactor: Copy sequence lengths once in decoder setup

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/createNewDecoderRequests.h
+++ b/cpp/include/tensorrt_llm/batch_manager/createNewDecoderRequests.h
@@ -27,8 +27,9 @@ namespace tensorrt_llm::runtime
 {
 class DecodingInput;
 class DecodingOutput;
-class SpeculativeDecodingMode;
 class GptDecoderBatched;
+class SamplingConfig;
+class SpeculativeDecodingMode;
 } // namespace tensorrt_llm::runtime
 
 namespace tensorrt_llm::batch_manager

--- a/cpp/include/tensorrt_llm/batch_manager/createNewDecoderRequests.h
+++ b/cpp/include/tensorrt_llm/batch_manager/createNewDecoderRequests.h
@@ -17,10 +17,8 @@
 
 #pragma once
 
-#include "common.h"
 #include "tensorrt_llm/common/algorithm.h"
 #include "tensorrt_llm/runtime/common.h"
-#include "tensorrt_llm/runtime/gptDecoderBatched.h"
 #include "tensorrt_llm/runtime/iTensor.h"
 #include "tensorrt_llm/runtime/modelConfig.h"
 #include "tensorrt_llm/runtime/request.h"
@@ -30,7 +28,7 @@ namespace tensorrt_llm::runtime
 class DecodingInput;
 class DecodingOutput;
 class SpeculativeDecodingMode;
-// class GptDecoderBatched;
+class GptDecoderBatched;
 } // namespace tensorrt_llm::runtime
 
 namespace tensorrt_llm::batch_manager

--- a/cpp/include/tensorrt_llm/batch_manager/decoderBuffers.h
+++ b/cpp/include/tensorrt_llm/batch_manager/decoderBuffers.h
@@ -40,14 +40,13 @@ public:
         SizeType32 maxBatchSize, SizeType32 maxDecoderSteps, runtime::BufferManager const& manager);
 
     // buffers for setup
-    TensorPtr setupBatchSlots;
     TensorPtr inputsIds;
-
-    // buffers for forward
-    TensorPtr forwardBatchSlotsRequestOrder;
-    TensorPtr forwardBatchSlotsRequestOrderDevice;
+    TensorPtr setupBatchSlots;
+    TensorPtr setupBatchSlotsDevice;
     TensorPtr fillValues;
     TensorPtr fillValuesDevice;
+
+    // buffers for forward
     std::vector<TensorPtr> forwardBatchSlots;
 };
 

--- a/cpp/include/tensorrt_llm/batch_manager/generateRequestOptions.h
+++ b/cpp/include/tensorrt_llm/batch_manager/generateRequestOptions.h
@@ -68,10 +68,6 @@ private:
         runtime::WorldConfig const& worldConfig, std::shared_ptr<runtime::ITensor> const& tensor,
         BufferManager const& bufferManager) const;
 
-    /// @brief Retrieve the embedding bias from the request. This potentially makes a copy of the tensor
-    /// to the appropriate type if the input tensor does not match it.
-    [[nodiscard]] TensorPtr getEmbeddingBias(nvinfer1::DataType logitsType, TensorPtr const& tensor) const;
-
     bool mSpeculativeDecodingFastLogits;
     bool mIsLeaderInOrchMode;
     bool mIsNormalizeLogProbs;

--- a/cpp/include/tensorrt_llm/batch_manager/generateRequestOptions.h
+++ b/cpp/include/tensorrt_llm/batch_manager/generateRequestOptions.h
@@ -64,6 +64,12 @@ public:
         OptionalRef<RuntimeBuffers const> buffers = std::nullopt) const;
 
 private:
+    [[nodiscard]] std::vector<runtime::decoder_batch::Request> createDecoderRequests(
+        RequestVector const& finishedContextRequests, TensorPtr const& inputIds,
+        executor::DecodingConfig const& decodingConfig, BufferManager const& bufferManager,
+        nvinfer1::DataType logitsType, runtime::ModelConfig const& modelConfig, runtime::WorldConfig const& worldConfig,
+        OptionalRef<RuntimeBuffers const> buffers) const;
+
     [[nodiscard]] std::shared_ptr<runtime::ITensor> retrieveDraftLogits(runtime::ModelConfig const& modelConfig,
         runtime::WorldConfig const& worldConfig, std::shared_ptr<runtime::ITensor> const& tensor,
         BufferManager const& bufferManager) const;

--- a/cpp/include/tensorrt_llm/batch_manager/generateRequestOptions.h
+++ b/cpp/include/tensorrt_llm/batch_manager/generateRequestOptions.h
@@ -59,7 +59,7 @@ public:
     std::tuple<ITensor::SharedPtr, std::vector<runtime::decoder_batch::Request>, std::vector<runtime::SamplingConfig>>
     operator()(runtime::ModelConfig const& modelConfig, runtime::WorldConfig const& worldConfig,
         executor::DecodingConfig const& decodingConfig, RequestVector const& contextRequests,
-        BufferManager const& bufferManager, nvinfer1::DataType logitsType, DecoderInputBuffers const& inputBuffers,
+        BufferManager const& bufferManager, nvinfer1::DataType logitsType, DecoderInputBuffers& inputBuffers,
         runtime::decoder::DecoderState& decoderState, SizeType32 beamWidth, runtime::CudaStream const& stream,
         OptionalRef<RuntimeBuffers const> buffers = std::nullopt) const;
 

--- a/cpp/include/tensorrt_llm/batch_manager/generateRequestOptions.h
+++ b/cpp/include/tensorrt_llm/batch_manager/generateRequestOptions.h
@@ -27,22 +27,25 @@
 #include "tensorrt_llm/runtime/samplingConfig.h"
 #include "tensorrt_llm/runtime/worldConfig.h"
 
+namespace tensorrt_llm::runtime::decoder
+{
+class DecoderState;
+} // namespace tensorrt_llm::runtime::decoder
+
 namespace tensorrt_llm::batch_manager
 {
 class RuntimeBuffers;
 class DecoderInputBuffers;
-
-namespace tr = tensorrt_llm::runtime;
 
 class GenerateRequestOptions : Algorithm
 {
 public:
     constexpr static auto name{"GenerateRequestOptions"};
 
-    using SizeType32 = tr::SizeType32;
-    using ITensor = tr::ITensor;
-    using TensorPtr = tr::ITensor::SharedPtr;
-    using BufferManager = tr::BufferManager;
+    using SizeType32 = runtime::SizeType32;
+    using ITensor = runtime::ITensor;
+    using TensorPtr = runtime::ITensor::SharedPtr;
+    using BufferManager = runtime::BufferManager;
     template <typename T>
     using OptionalRef = tensorrt_llm::common::OptionalRef<T>;
 
@@ -53,15 +56,16 @@ public:
     {
     }
 
-    std::tuple<ITensor::SharedPtr, std::vector<tr::decoder_batch::Request>, std::vector<tr::SamplingConfig>> operator()(
-        tr::ModelConfig const& modelConfig, tr::WorldConfig const& worldConfig,
+    std::tuple<ITensor::SharedPtr, std::vector<runtime::decoder_batch::Request>, std::vector<runtime::SamplingConfig>>
+    operator()(runtime::ModelConfig const& modelConfig, runtime::WorldConfig const& worldConfig,
         executor::DecodingConfig const& decodingConfig, RequestVector const& contextRequests,
         BufferManager const& bufferManager, nvinfer1::DataType logitsType, DecoderInputBuffers const& inputBuffers,
+        runtime::decoder::DecoderState& decoderState, SizeType32 beamWidth, runtime::CudaStream const& stream,
         OptionalRef<RuntimeBuffers const> buffers = std::nullopt) const;
 
 private:
-    [[nodiscard]] std::shared_ptr<runtime::ITensor> retrieveDraftLogits(tr::ModelConfig const& modelConfig,
-        tr::WorldConfig const& worldConfig, std::shared_ptr<runtime::ITensor> const& tensor,
+    [[nodiscard]] std::shared_ptr<runtime::ITensor> retrieveDraftLogits(runtime::ModelConfig const& modelConfig,
+        runtime::WorldConfig const& worldConfig, std::shared_ptr<runtime::ITensor> const& tensor,
         BufferManager const& bufferManager) const;
 
     /// @brief Retrieve the embedding bias from the request. This potentially makes a copy of the tensor

--- a/cpp/include/tensorrt_llm/batch_manager/makeDecodingBatchInputOutput.h
+++ b/cpp/include/tensorrt_llm/batch_manager/makeDecodingBatchInputOutput.h
@@ -24,13 +24,6 @@
 #include "tensorrt_llm/runtime/iGptDecoderBatched.h"
 #include "tensorrt_llm/runtime/modelConfig.h"
 
-namespace tensorrt_llm::batch_manager
-{
-class DecoderInputBuffers;
-class DecoderBuffers;
-class RuntimeBuffers;
-} // namespace tensorrt_llm::batch_manager
-
 namespace tensorrt_llm::runtime::decoder
 {
 class DecoderState;
@@ -38,16 +31,19 @@ class DecoderState;
 
 namespace tensorrt_llm::batch_manager
 {
+class DecoderInputBuffers;
+class DecoderBuffers;
+class RuntimeBuffers;
+
 class MakeDecodingBatchInputOutput : Algorithm
 {
 public:
-    template <typename T>
-    using OptionalRef = tensorrt_llm::common::OptionalRef<T>;
-
     constexpr static auto name{"MakeDecodingBatchInputOutput"};
 
     using SizeType32 = tensorrt_llm::runtime::SizeType32;
     using TensorPtr = runtime::decoder_batch::Input::TensorPtr;
+    template <typename T>
+    using OptionalRef = tensorrt_llm::common::OptionalRef<T>;
 
     MakeDecodingBatchInputOutput() = default;
 
@@ -55,8 +51,7 @@ public:
     operator()(RequestVector const& contextRequests, RequestVector const& generationRequests,
         DecoderBuffers& decoderBuffers, DecoderInputBuffers const& inputBuffers,
         runtime::decoder::DecoderState& decoderState, runtime::ModelConfig const& modelConfig,
-        SizeType32 maxNumSequences, SizeType32 beamWidth, bool isTrtOverlap, runtime::BufferManager const& manager,
-        runtime::CudaStream const& stream, OptionalRef<RuntimeBuffers> fusedRuntimeBuffers) const;
+        SizeType32 maxNumSequences, OptionalRef<RuntimeBuffers> fusedRuntimeBuffers) const;
 
     [[nodiscard]] static std::unique_ptr<runtime::decoder_batch::Input> createDecoderBatchInputs(
         std::vector<SizeType32> const& activeSlots, runtime::decoder::DecoderState const& decoderState,

--- a/cpp/tensorrt_llm/batch_manager/decoderBuffers.cpp
+++ b/cpp/tensorrt_llm/batch_manager/decoderBuffers.cpp
@@ -35,12 +35,10 @@ DecoderInputBuffers::DecoderInputBuffers(
     auto const maxBatchSizeShape = ITensor::makeShape({maxBatchSize});
     auto const nvSizeType = TRTDataType<SizeType32>::value;
 
-    setupBatchSlots = BufferManager::pinnedPool(maxBatchSizeShape, nvSizeType);
-
     inputsIds = BufferManager::pinnedPool(ITensor::makeShape({0}), TRTDataType<TokenIdType>::value);
 
-    forwardBatchSlotsRequestOrder = tensorrt_llm::runtime::BufferManager::pinnedPool(maxBatchSizeShape, nvSizeType);
-    forwardBatchSlotsRequestOrderDevice = manager.gpu(maxBatchSizeShape, nvSizeType);
+    setupBatchSlots = BufferManager::pinnedPool(maxBatchSizeShape, nvSizeType);
+    setupBatchSlotsDevice = manager.gpu(maxBatchSizeShape, nvSizeType);
 
     fillValues = tensorrt_llm::runtime::BufferManager::pinnedPool(maxBatchSizeShape, nvSizeType);
     fillValuesDevice = manager.gpu(maxBatchSizeShape, nvSizeType);

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -1761,7 +1761,7 @@ void TrtGptModelInflightBatching::executeStep(
 }
 
 void TrtGptModelInflightBatching::setupDecoderStep(
-    RequestVector const& contextRequests, RuntimeBuffers const& buffers, DecoderInputBuffers const& inputBuffers)
+    RequestVector const& contextRequests, RuntimeBuffers const& buffers, DecoderInputBuffers& inputBuffers)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
     NVTX3_SCOPED_RANGE(setupDecoderStep);

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -1771,7 +1771,8 @@ void TrtGptModelInflightBatching::setupDecoderStep(
         auto const logitsType = mRuntime->getEngine().getTensorDataType("logits");
 
         auto [batchSlots, decoderRequests, samplingConfigs] = (*mGenerateRequestOptions)(mModelConfig, mWorldConfig,
-            mDecodingConfig, contextRequests, mRuntime->getBufferManager(), logitsType, inputBuffers, buffers);
+            mDecodingConfig, contextRequests, mRuntime->getBufferManager(), logitsType, inputBuffers,
+            mDecoder->getDecoderState(), mOperatingBeamWidth, mRuntime->getStream(), buffers);
 
         if (!decoderRequests.empty())
         {
@@ -2014,8 +2015,7 @@ runtime::CudaEvent TrtGptModelInflightBatching::decoderStepAsync(ScheduledReques
     auto& decodingInput = mDecodingInputs.at(mMicroBatchId);
     std::tie(decodingInput, mDecodingOutput) = (*mMakeDecodingBatchInputOutput)(scheduledRequests.contextRequests,
         scheduledRequests.generationRequests, *mDecoderBuffers, mDecoderInputBuffers.at(fusedBufferId),
-        mDecoder->getDecoderState(), mModelConfig, getMaxNumSequences(), mOperatingBeamWidth, isTrtOverlap(),
-        mRuntime->getBufferManager(), mRuntime->getStream(), *fusedRuntimeBuffers);
+        mDecoder->getDecoderState(), mModelConfig, getMaxNumSequences(), *fusedRuntimeBuffers);
 
     auto decoderFinishEvent = mDecoder->forwardAsync(*mDecodingOutput, *decodingInput);
 

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
@@ -297,7 +297,7 @@ private:
         RequestVector const& contextRequests, RequestVector const& generationRequests, SizeType32 bufferId);
 
     void setupDecoderStep(
-        RequestVector const& contextRequests, RuntimeBuffers const& buffers, DecoderInputBuffers const& inputBuffers);
+        RequestVector const& contextRequests, RuntimeBuffers const& buffers, DecoderInputBuffers& inputBuffers);
     runtime::CudaEvent decoderStepAsync(ScheduledRequests const& scheduledRequests);
     std::vector<std::unique_ptr<DecoderStepAsyncSend>> decoderSync(
         ScheduledRequests const& scheduledRequests, std::optional<runtime::CudaEvent> const& decoderFinishEvent);

--- a/cpp/tensorrt_llm/pybind/batch_manager/algorithms.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/algorithms.cpp
@@ -141,9 +141,8 @@ void tensorrt_llm::pybind::batch_manager::algorithms::initBindings(pybind11::mod
             [](GenerateRequestOptions& self, tr::ModelConfig const& modelConfig, tr::WorldConfig const& worldConfig,
                 executor::DecodingConfig const& decodingConfig, RequestVector const& contextRequests,
                 tr::BufferManager const& bufferManager, nvinfer1::DataType logitsType,
-                DecoderInputBuffers const& inputBuffers, tr::decoder::DecoderState& decoderState,
-                tr::SizeType32 beamWidth, tr::CudaStream const& stream,
-                OptionalRef<RuntimeBuffers const> buffers = std::nullopt)
+                DecoderInputBuffers& inputBuffers, tr::decoder::DecoderState& decoderState, tr::SizeType32 beamWidth,
+                tr::CudaStream const& stream, OptionalRef<RuntimeBuffers const> buffers = std::nullopt)
             {
                 auto [batchSlots, decoderRequests, samplingConfigs] = self(modelConfig, worldConfig, decodingConfig,
                     contextRequests, bufferManager, logitsType, inputBuffers, decoderState, beamWidth, stream, buffers);

--- a/cpp/tensorrt_llm/pybind/batch_manager/algorithms.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/algorithms.cpp
@@ -141,25 +141,26 @@ void tensorrt_llm::pybind::batch_manager::algorithms::initBindings(pybind11::mod
             [](GenerateRequestOptions& self, tr::ModelConfig const& modelConfig, tr::WorldConfig const& worldConfig,
                 executor::DecodingConfig const& decodingConfig, RequestVector const& contextRequests,
                 tr::BufferManager const& bufferManager, nvinfer1::DataType logitsType,
-                DecoderInputBuffers const& inputBuffers, OptionalRef<RuntimeBuffers const> buffers = std::nullopt)
+                DecoderInputBuffers const& inputBuffers, tr::decoder::DecoderState& decoderState,
+                tr::SizeType32 beamWidth, tr::CudaStream const& stream,
+                OptionalRef<RuntimeBuffers const> buffers = std::nullopt)
             {
                 auto [batchSlots, decoderRequests, samplingConfigs] = self(modelConfig, worldConfig, decodingConfig,
-                    contextRequests, bufferManager, logitsType, inputBuffers, buffers);
+                    contextRequests, bufferManager, logitsType, inputBuffers, decoderState, beamWidth, stream, buffers);
 
                 return std::tuple{
                     runtime::Torch::tensor(batchSlots), std::move(decoderRequests), std::move(samplingConfigs)};
             },
             py::arg("model_config"), py::arg("world_config"), py::arg("decoding_config"), py::arg("context_requests"),
             py::arg("buffer_manager"), py::arg("logits_type"), py::arg("decoder_input_buffers"),
-            py::arg("buffers") = std::nullopt)
+            py::arg("decoder_state"), py::arg("beam_width"), py::arg("stream"), py::arg("buffers") = std::nullopt)
         .def("name", [](GenerateRequestOptions const&) { return GenerateRequestOptions::name; });
 
     py::class_<MakeDecodingBatchInputOutput>(m, MakeDecodingBatchInputOutput::name)
         .def(py::init())
         .def("__call__", &MakeDecodingBatchInputOutput::operator(), py::arg("context_requests"),
             py::arg("generation_requests"), py::arg("decoder_buffers"), py::arg("decoder_input_buffers"),
-            py::arg("decoder_state"), py::arg("model_config"), py::arg("max_num_sequences"), py::arg("beam_width"),
-            py::arg("is_trt_overlap"), py::arg("buffer_manager"), py::arg("stream"),
+            py::arg("decoder_state"), py::arg("model_config"), py::arg("max_num_sequences"),
             py::arg("fused_runtime_buffers") = std::nullopt)
         .def("name", [](MakeDecodingBatchInputOutput const&) { return MakeDecodingBatchInputOutput::name; });
 

--- a/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
@@ -449,9 +449,7 @@ void initBindings(pybind11::module_& m)
         .def(py::init<runtime::SizeType32, runtime::SizeType32, tr::BufferManager>(), py::arg("max_batch_size"),
             py::arg("max_tokens_per_engine_step"), py::arg("manager"))
         .def_readwrite("setup_batch_slots", &tb::DecoderInputBuffers::setupBatchSlots)
-        .def_readwrite("forward_batch_slots_request_order", &tb::DecoderInputBuffers::forwardBatchSlotsRequestOrder)
-        .def_readwrite(
-            "forward_batch_slots_request_order_device", &tb::DecoderInputBuffers::forwardBatchSlotsRequestOrderDevice)
+        .def_readwrite("setup_batch_slots_device", &tb::DecoderInputBuffers::setupBatchSlotsDevice)
         .def_readwrite("fill_values", &tb::DecoderInputBuffers::fillValues)
         .def_readwrite("fill_values_device", &tb::DecoderInputBuffers::fillValuesDevice)
         .def_readwrite("inputs_ids", &tb::DecoderInputBuffers::inputsIds)

--- a/tensorrt_llm/_torch/pyexecutor/decoder.py
+++ b/tensorrt_llm/_torch/pyexecutor/decoder.py
@@ -546,7 +546,9 @@ class TRTLLMDecoder(Decoder):
         batch_slots, decoder_requests, sampling_configs = self.algs.generate_request_options(
             self.model_config, self.world_config, self.decoding_config,
             requests, self.store["buffer_manager"], self.logits_datatype,
-            self.store["decoder_input_buffers"])
+            self.store["decoder_input_buffers"],
+            self.algs.decoder.decoder_state, self.beam_width,
+            self.store["cuda_stream"])
 
         if len(decoder_requests):
             self.algs.create_new_decoder_requests(
@@ -593,8 +595,7 @@ class TRTLLMDecoder(Decoder):
             scheduled_requests.generation_requests,
             self.store["decoder_buffers"], self.store["decoder_input_buffers"],
             self.algs.decoder.decoder_state, self.model_config,
-            self.max_num_sequences, self.beam_width, self.is_trt_overlap,
-            self.store["buffer_manager"], self.store["cuda_stream"])
+            self.max_num_sequences)
 
         self.algs.decoder.forward_async(self.decoding_output, decoding_input)
 


### PR DESCRIPTION
## Description

* Copy sequence lengths once in `setupDecoderStep` instead of in each `decoderStepAsync` iteration.
* Refactor `GenerateRequestOptions` using more fine-grained functions.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
