### PR TITLE
feat: add router_gemm and fuse_a_gemm for DeepSeek-R1 min-latency mode 

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -299,6 +299,7 @@ setup_sanitizers()
 
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda")
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr")
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xptxas --uumn")
 if(FAST_MATH)
   set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --use_fast_math")
 endif()

--- a/cpp/tensorrt_llm/kernels/communicationKernels/allReduceFusionKernels.cu
+++ b/cpp/tensorrt_llm/kernels/communicationKernels/allReduceFusionKernels.cu
@@ -436,7 +436,7 @@ public:
     int tot_access;
 };
 
-template <AllReduceFusionPattern Pattern, typename DType, int NRanks, bool Fp32Acc>
+template <AllReduceFusionPattern Pattern, typename DType, int NRanks, bool Fp32Acc, bool TriggerCompletionAtEnd = true>
 __global__ void allreduce_fusion_kernel_oneshot_lamport(AllReduceFusionParams params)
 {
     IndexHelper<DType> index_helper(params);
@@ -448,8 +448,13 @@ __global__ void allreduce_fusion_kernel_oneshot_lamport(AllReduceFusionParams pa
     int tot_access = index_helper.tot_access;
     float4 clear_vec = get_neg_zero();
     FusedOp<Pattern, DType> fused_op(params, access_id, access_id_in_token);
+
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
     cudaGridDependencySynchronize();
+    if constexpr (!TriggerCompletionAtEnd)
+    {
+        cudaTriggerProgrammaticLaunchCompletion();
+    }
 #endif
     LamportComm<NRanks> comm(params.workspace, params.rank);
     int clear_access = comm.clear_size / kElemsPerAccess<DType>;
@@ -500,9 +505,14 @@ __global__ void allreduce_fusion_kernel_oneshot_lamport(AllReduceFusionParams pa
         float4 sum_val = allreduce_sum<DType, NRanks, Fp32Acc>(vals);
         fused_op(sum_val, tidx);
     }
+
     comm.update(params.size * NRanks);
+
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-    cudaTriggerProgrammaticLaunchCompletion();
+    if constexpr (TriggerCompletionAtEnd)
+    {
+        cudaTriggerProgrammaticLaunchCompletion();
+    }
 #endif
 }
 
@@ -588,11 +598,11 @@ int get_sm_count()
     return sm_count;
 }
 
-template <AllReduceFusionPattern Pattern, typename DType, int NRanks, bool Fp32Acc>
+template <AllReduceFusionPattern Pattern, typename DType, int NRanks, bool Fp32Acc, bool TriggerCompletionAtEnd = true>
 void launch_oneshot_lamport(AllReduceFusionParams const& params, cudaLaunchConfig_t& cfg)
 {
-    TLLM_CUDA_CHECK(
-        cudaLaunchKernelEx(&cfg, allreduce_fusion_kernel_oneshot_lamport<Pattern, DType, NRanks, Fp32Acc>, params));
+    TLLM_CUDA_CHECK(cudaLaunchKernelEx(&cfg,
+        allreduce_fusion_kernel_oneshot_lamport<Pattern, DType, NRanks, Fp32Acc, TriggerCompletionAtEnd>, params));
 }
 
 template <AllReduceFusionPattern Pattern, typename DType, int NRanks, bool Fp32Acc>
@@ -674,7 +684,15 @@ void allreduce_fusion_kernel_launcher(AllReduceFusionParams const& params)
     cfg.numAttrs = SM >= 90 ? 2 : 0;
     if (oneshot)
     {
-        launch_oneshot_lamport<Pattern, DType, NRanks, Fp32Acc>(params, cfg);
+        bool trigger_completion_at_end = params.trigger_completion_at_end;
+        if (trigger_completion_at_end)
+        {
+            launch_oneshot_lamport<Pattern, DType, NRanks, Fp32Acc, true>(params, cfg);
+        }
+        else
+        {
+            launch_oneshot_lamport<Pattern, DType, NRanks, Fp32Acc, false>(params, cfg);
+        }
     }
     else
     {

--- a/cpp/tensorrt_llm/kernels/communicationKernels/allReduceFusionKernels.h
+++ b/cpp/tensorrt_llm/kernels/communicationKernels/allReduceFusionKernels.h
@@ -135,6 +135,7 @@ struct AllReduceFusionParams
     FP4QuantizationSFLayout layout = FP4QuantizationSFLayout::SWIZZLED;
     cudaStream_t stream;
     AllReduceFusionPattern pattern;
+    bool trigger_completion_at_end = true;
 };
 
 void allreduce_fusion_op(AllReduceFusionParams const& params);

--- a/cpp/tensorrt_llm/kernels/communicationKernels/moeAllReduceFusionKernels.cu
+++ b/cpp/tensorrt_llm/kernels/communicationKernels/moeAllReduceFusionKernels.cu
@@ -213,10 +213,6 @@ template <typename DType, int NRanks, bool ResidualOut, bool NormOut, bool Quant
 __global__ void moereduce_allreduce_fusion_kernel_oneshot_lamport(MoeReductionAllReduceFusionParams params)
 {
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-    asm volatile("griddepcontrol.wait;");
-#endif
-
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
     namespace cg = cooperative_groups;
     cg::cluster_group cluster = cg::this_cluster();
     cg::grid_group grid = cg::this_grid();
@@ -242,6 +238,7 @@ __global__ void moereduce_allreduce_fusion_kernel_oneshot_lamport(MoeReductionAl
     float4 clear_vec = get_neg_zero();
 
     cudaGridDependencySynchronize();
+    cudaTriggerProgrammaticLaunchCompletion();
     LamportComm<NRanks> comm(params.workspace, params.rank);
     int clear_access = comm.clear_size / kElemsPerAccess;
 
@@ -372,11 +369,6 @@ __global__ void moereduce_allreduce_fusion_kernel_oneshot_lamport(MoeReductionAl
         fused_op<ResidualOut, NormOut, QuantOut, DType>(sum_val, idx, tidx, access_id_in_token, params);
     }
     comm.update(params.size * NRanks);
-    cudaTriggerProgrammaticLaunchCompletion();
-#endif
-
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-    asm volatile("griddepcontrol.launch_dependents;");
 #endif
 }
 

--- a/cpp/tensorrt_llm/kernels/fuseAGemm.cu
+++ b/cpp/tensorrt_llm/kernels/fuseAGemm.cu
@@ -1,0 +1,798 @@
+/*
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2021, NAVER Corp.  Authored by CLOVA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdio>
+#include <tuple>
+
+#include "cuda.h"
+#include "cuda_bf16.h"
+#include "cuda_runtime.h"
+#include "tensorrt_llm/common/envUtils.h"
+#include "tensorrt_llm/kernels/fuseAGemm.h"
+using namespace tensorrt_llm::common;
+using bf16_t = __nv_bfloat16;
+
+namespace tensorrt_llm::kernels
+{
+__device__ void hmma_16_8_16_f32acc_bf16ab(
+    float (&d_reg)[4], const bf16_t (&a_reg)[8], const bf16_t (&b_reg)[4], float const (&c_reg)[4])
+{
+    uint32_t a0 = *reinterpret_cast<uint32_t const*>(a_reg + 0);
+    uint32_t a1 = *reinterpret_cast<uint32_t const*>(a_reg + 2);
+    uint32_t a2 = *reinterpret_cast<uint32_t const*>(a_reg + 4);
+    uint32_t a3 = *reinterpret_cast<uint32_t const*>(a_reg + 6);
+    uint32_t b0 = *reinterpret_cast<uint32_t const*>(b_reg + 0);
+    uint32_t b1 = *reinterpret_cast<uint32_t const*>(b_reg + 2);
+    asm volatile(
+        "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 "
+        "{%0,  %1,  %2,  %3},"
+        "{%4,  %5,  %6,  %7},"
+        "{%8,  %9},"
+        "{%10, %11, %12, %13};\n"
+        : "=f"(d_reg[0]), "=f"(d_reg[1]), "=f"(d_reg[2]), "=f"(d_reg[3])
+        : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1), "f"(d_reg[0]), "f"(d_reg[1]), "f"(d_reg[2]),
+        "f"(d_reg[3]));
+}
+
+extern "C"
+{
+    __device__ uint32_t __nvvm_get_smem_pointer(void*);
+}
+
+__device__ void ldgsts_128(void const* gPtr, void* sPtr, uint32_t pred)
+{
+    if (pred)
+    {
+        uint32_t smemPtrAsUint32 = __nvvm_get_smem_pointer(sPtr);
+        asm volatile("cp.async.cg.shared.global.L2::128B [%0], [%1], %2;\n" ::"r"(smemPtrAsUint32), "l"(gPtr), "n"(16));
+    }
+}
+
+__device__ void ldgsts_commit()
+{
+    asm volatile("cp.async.commit_group;\n" ::);
+}
+
+template <int allowedInFlightBunchCnt>
+__device__ void ldgsts_wait()
+{
+    asm volatile("cp.async.wait_group %0;\n" ::"n"(allowedInFlightBunchCnt));
+}
+
+__device__ std::tuple<int, int> hmma_c_tv2mn(int t_idx, int v_idx)
+{
+    int linear_idx = (t_idx % 4) * 32 + (t_idx / 4) * 1 + (v_idx % 2) * 16 + (v_idx / 2) * 8;
+    int m_idx = linear_idx % 16;
+    int n_idx = linear_idx / 16;
+    return std::make_tuple(m_idx, n_idx);
+}
+
+__device__ void ldsm_x4(void* smem_ptr, uint32_t* reg_ptr)
+{
+    asm volatile("ldmatrix.sync.aligned.x4.m8n8.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                 : "=r"(reg_ptr[0]), "=r"(reg_ptr[1]), "=r"(reg_ptr[2]), "=r"(reg_ptr[3])
+                 : "r"(__nvvm_get_smem_pointer(smem_ptr)));
+}
+
+template <class T>
+__device__ T* apply_swizzle_343_on_ptr(T* addr)
+{
+    uint64_t mask = reinterpret_cast<uint64_t>(addr) & 0x00000000000000380;
+    mask = mask >> 3;
+    return reinterpret_cast<T*>(reinterpret_cast<uint64_t>(addr) ^ mask);
+    // return addr;
+}
+
+template <class Type, class T>
+__device__ T apply_swizzle_343_on_elem(T elem_offset)
+{
+    T byte_offset = elem_offset / sizeof(Type);
+    T mask = byte_offset & 0x380;
+    mask = mask >> 3;
+    return (byte_offset ^ mask) * sizeof(Type);
+}
+
+template <class Type>
+__device__ int apply_swizzle_343_on_elem_row_col(int row_idx_, int col_idx_)
+{
+    // return col_idx;
+    uint32_t row_idx = *reinterpret_cast<uint32_t*>(&row_idx_);
+    uint32_t col_idx = *reinterpret_cast<uint32_t*>(&col_idx_);
+    // uint32_t row_idx_original = row_idx;
+    // uint32_t col_idx_original = col_idx;
+    row_idx = row_idx % 8;
+    row_idx = row_idx * (16 / sizeof(Type));
+    col_idx = col_idx ^ row_idx;
+    // printf("tid: %d, [%d, %d] -> [%d, %d]\n", threadIdx.x, row_idx_original, col_idx_original, row_idx, col_idx);
+    return *reinterpret_cast<int*>(&col_idx);
+}
+
+__device__ uint32_t elect_one_sync()
+{
+    uint32_t pred = 0;
+    uint32_t laneid = 0;
+    asm volatile(
+        "{\n"
+        ".reg .b32 %%rx;\n"
+        ".reg .pred %%px;\n"
+        "     elect.sync %%rx|%%px, %2;\n"
+        "@%%px mov.s32 %1, 1;\n"
+        "     mov.s32 %0, %%rx;\n"
+        "}\n"
+        : "+r"(laneid), "+r"(pred)
+        : "r"(0xFFFFFFFF));
+    return pred;
+}
+
+__device__ void initialize_barrier(uint64_t* smem_barrier, // 64 bits user-manged barrier in smem
+    int thread_count = 1)                                  // Thread count expected to arrive/wait on this barrier
+{
+    uint32_t smem_int_ptr = __nvvm_get_smem_pointer(smem_barrier);
+    asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;\n" ::"r"(smem_int_ptr), "r"(thread_count));
+}
+
+// Barrier wait
+__device__ void wait_barrier(uint64_t* smem_barrier, // 64 bits user-manged barrier in smem
+    int phase_bit)                                   // Current phase bit the barrier waiting to flip
+{
+    asm volatile(".pragma \"set knob DontInsertYield\";\n" : : : "memory"); // {$nv-internal-release}
+
+    uint32_t smem_int_ptr = __nvvm_get_smem_pointer(smem_barrier);
+    asm volatile(
+        "{\n"
+        ".reg .pred                P1;\n"
+        "LAB_WAIT:\n"
+        "mbarrier.try_wait.parity.shared::cta.b64 P1, [%0], %1;\n"
+        "@P1                       bra DONE;\n"
+        "bra                   LAB_WAIT;\n"
+        "DONE:\n"
+        "}\n" ::"r"(smem_int_ptr),
+        "r"(phase_bit));
+
+    asm volatile(".pragma \"reset knob DontInsertYield\";\n" : : : "memory"); // {$nv-internal-release}
+}
+
+__device__ bool try_wait_barrier(uint64_t* smem_ptr, int phase_bit)
+{
+    uint32_t wait_complete;
+    uint32_t smem_int_ptr = __nvvm_get_smem_pointer(smem_ptr);
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1; \n\t"
+        "mbarrier.try_wait.parity.shared::cta.b64 P1, [%1], %2; \n\t"
+        "selp.b32 %0, 1, 0, P1; \n\t"
+        "}"
+        : "=r"(wait_complete)
+        : "r"(smem_int_ptr), "r"(phase_bit));
+    return static_cast<bool>(wait_complete);
+}
+
+// Barrier arrive
+__device__ void arrive_barrier(uint64_t* smem_barrier) // 64 bits user-manged barrier in smem
+{
+    uint32_t smem_int_ptr = __nvvm_get_smem_pointer(smem_barrier);
+    asm volatile(
+        "{\n"
+        ".reg .b64 state; \n"
+        "mbarrier.arrive.shared::cta.b64   state, [%0];\n"
+        "}\n" ::"r"(smem_int_ptr));
+}
+
+__device__ void ldgsts_arrive(uint64_t* smem_barrier)
+{
+    uint32_t smem_int_ptr = __nvvm_get_smem_pointer(smem_barrier);
+    asm volatile("cp.async.mbarrier.arrive.noinc.shared.b64 [%0];" : : "r"(smem_int_ptr));
+}
+
+template <int gemm_k, int tile_m, int tile_n, int tile_k, int stage_cnt, int gemm_m>
+struct GmemLoaderA
+{
+    static constexpr int elem_bytes = 2;
+    static constexpr int vec_bytes = 16;
+    static constexpr int vec_elems = vec_bytes / elem_bytes;
+    static constexpr int thread_cnt = 64;
+    static_assert((tile_m * tile_k) % (vec_elems * thread_cnt) == 0);
+    static constexpr int a_inst_cnt_per_iter = (tile_m * tile_k) / (vec_elems * thread_cnt);
+    static_assert(gemm_k % tile_k == 0);
+    static constexpr int k_iter_cnt = gemm_k / tile_k;
+
+    __device__ GmemLoaderA(bf16_t const* gmem_a_local_, bf16_t* smem_a_, uint64_t* smem_barrier_)
+        : gmem_a(gmem_a_local_)
+        , smem_a(smem_a_)
+        , smem_barrier(smem_barrier_)
+        , local_tid(threadIdx.x % thread_cnt)
+    {
+    }
+
+    __device__ void prepare()
+    {
+// swizzle, that's what we want.
+#pragma unroll
+        for (int i = 0; i < a_inst_cnt_per_iter; i++)
+        {
+            int linear_idx = local_tid * vec_elems + i * thread_cnt * vec_elems;
+            int m_idx = linear_idx / tile_k;
+            int k_idx = linear_idx % tile_k;
+            k_idx = apply_swizzle_343_on_elem_row_col<bf16_t>(m_idx, k_idx);
+            a_smem_offsets[i] = m_idx * tile_k + k_idx;
+        }
+    }
+
+    __device__ void issue_mainloop()
+    {
+#pragma unroll 1
+        for (int loop_idx = 0; loop_idx < k_iter_cnt; loop_idx++)
+        {
+            if (need_wait)
+            {
+                wait_barrier(smem_barrier + 1 + stage_idx * 2, phase_bit);
+            }
+            int next_stage_idx = stage_idx + 1;
+            int next_phase_bit = next_stage_idx == stage_cnt ? phase_bit ^ 1 : phase_bit;
+            next_stage_idx = next_stage_idx == stage_cnt ? 0 : next_stage_idx;
+            if (loop_idx != k_iter_cnt - 1)
+            {
+                need_wait = !try_wait_barrier(smem_barrier + 1 + next_stage_idx * 2, next_phase_bit);
+            }
+
+#pragma unroll
+            for (int i = 0; i < a_inst_cnt_per_iter; i++)
+            {
+                int smem_offset = a_smem_offsets[i];
+                bf16_t* smem_ptr_this_iter = smem_a + stage_idx * tile_m * tile_k + smem_offset;
+                int linear_idx = local_tid * vec_elems + i * thread_cnt * vec_elems;
+                int m_idx = linear_idx / tile_k;
+                int k_idx = linear_idx % tile_k;
+                if (m_idx < gemm_m && k_idx < gemm_k)
+                {
+                    int gmem_offset = m_idx * gemm_k + k_idx;
+                    bf16_t const* gmem_ptr_this_iter = gmem_a + gmem_offset;
+                    ldgsts_128(gmem_ptr_this_iter, smem_ptr_this_iter, true);
+                }
+            }
+            ldgsts_arrive(smem_barrier + stage_idx * 2);
+            asm volatile(".pragma \"next knob FenceInterference\";\n" : : : "memory");
+
+            stage_idx = next_stage_idx;
+            phase_bit = next_phase_bit;
+            gmem_a += tile_k;
+        }
+    }
+
+    bf16_t const* gmem_a;
+    bf16_t* smem_a;
+    uint64_t* smem_barrier;
+    int local_tid;
+    int stage_idx = 0;
+    int phase_bit = 1;
+    bool need_wait = true;
+
+    // per smem_stage, store with swizzle information
+    int a_smem_offsets[a_inst_cnt_per_iter];
+};
+
+template <int gemm_k, int tile_m, int tile_n, int tile_k, int stage_cnt, int gemm_n>
+struct GmemLoaderB
+{
+    static constexpr int elem_bytes = 2;
+    static constexpr int vec_bytes = 16;
+    static constexpr int vec_elems = vec_bytes / elem_bytes;
+    static constexpr int thread_cnt = 64;
+    static_assert((tile_n * tile_k) % (vec_elems * thread_cnt) == 0);
+    static constexpr int b_inst_cnt_per_iter = (tile_n * tile_k) / (vec_elems * thread_cnt);
+    static_assert(gemm_k % tile_k == 0);
+    static constexpr int k_iter_cnt = gemm_k / tile_k;
+
+    __device__ GmemLoaderB(bf16_t const* gmem_b_local_, bf16_t* smem_b_, uint64_t* smem_barrier_)
+        : gmem_b(gmem_b_local_)
+        , smem_b(smem_b_)
+        , smem_barrier(smem_barrier_)
+        , local_tid(threadIdx.x % thread_cnt)
+    {
+    }
+
+    __device__ void prepare()
+    {
+// swizzle, that's what we want.
+#pragma unroll
+        for (int i = 0; i < b_inst_cnt_per_iter; i++)
+        {
+            int linear_idx = local_tid * vec_elems + i * thread_cnt * vec_elems;
+            int n_idx = linear_idx / tile_k;
+            int k_idx = linear_idx % tile_k;
+            k_idx = apply_swizzle_343_on_elem_row_col<bf16_t>(n_idx, k_idx);
+            b_smem_offsets[i] = n_idx * tile_k + k_idx;
+        }
+    }
+
+    __device__ void issue_mainloop()
+    {
+        asm volatile("griddepcontrol.wait;");
+#pragma unroll 1
+        for (int loop_idx = 0; loop_idx < k_iter_cnt; loop_idx++)
+        {
+            if (need_wait)
+            {
+                wait_barrier(smem_barrier + 1 + stage_idx * 2, phase_bit);
+            }
+            int next_stage_idx = stage_idx + 1;
+            int next_phase_bit = next_stage_idx == stage_cnt ? phase_bit ^ 1 : phase_bit;
+            next_stage_idx = next_stage_idx == stage_cnt ? 0 : next_stage_idx;
+            if (loop_idx != k_iter_cnt - 1)
+            {
+                need_wait = !try_wait_barrier(smem_barrier + 1 + next_stage_idx * 2, next_phase_bit);
+            }
+#pragma unroll
+            for (int i = 0; i < b_inst_cnt_per_iter; i++)
+            {
+                int smem_offset = b_smem_offsets[i];
+                bf16_t* smem_ptr_this_iter = smem_b + stage_idx * tile_n * tile_k + smem_offset;
+                int linear_idx = local_tid * vec_elems + i * thread_cnt * vec_elems;
+                int n_idx = linear_idx / tile_k;
+                int k_idx = linear_idx % tile_k;
+                if (n_idx < gemm_n && k_idx < gemm_k)
+                {
+                    int gmem_offset = n_idx * gemm_k + k_idx;
+                    bf16_t const* gmem_ptr_this_iter = gmem_b + gmem_offset;
+                    ldgsts_128(gmem_ptr_this_iter, smem_ptr_this_iter, true);
+                }
+            }
+            ldgsts_arrive(smem_barrier + stage_idx * 2);
+            asm volatile(".pragma \"next knob FenceInterference\";\n" : : : "memory"); // internal
+
+            stage_idx = next_stage_idx;
+            phase_bit = next_phase_bit;
+            gmem_b += tile_k;
+        }
+    }
+
+    bf16_t const* gmem_b;
+    bf16_t* smem_b;
+    uint64_t* smem_barrier;
+    int local_tid;
+    int stage_idx = 0;
+    int phase_bit = 1;
+    bool need_wait = true;
+
+    // per smem_stage, store with swizzle information
+    int b_smem_offsets[b_inst_cnt_per_iter];
+};
+
+template <int gemm_m, int gemm_n, int gemm_k, int tile_m, int tile_n, int tile_k, int stage_cnt>
+struct MmaComputer
+{
+    static constexpr int elem_bytes = 2;
+    static constexpr int thread_cnt = 128;
+    static_assert(gemm_k % tile_k == 0);
+    static_assert(tile_k % (thread_cnt / 32) == 0);
+    static constexpr int per_warp_tile_k = tile_k / (thread_cnt / 32);
+    static constexpr int k_iter_cnt = gemm_k / tile_k;
+    static constexpr int k_phase_cnt = per_warp_tile_k / 16;
+    static constexpr int m_iter_cnt = (tile_m + 15) / 16;
+    static constexpr int n_iter_cnt = (tile_n + 7) / 8; // Possible to have non-1 n_iter_cnt for ab_swap m16 case.
+    static_assert(m_iter_cnt == 1);
+    static_assert(n_iter_cnt == 1 || n_iter_cnt == 2);
+
+    __device__ MmaComputer(bf16_t* gmem_c_, bf16_t* smem_a_, bf16_t* smem_b_, uint64_t* smem_barrier_, int warp_idx_,
+        int block_m_, int block_n_)
+        : gmem_c(gmem_c_)
+        , smem_a(smem_a_)
+        , smem_b(smem_b_)
+        , smem_barrier(smem_barrier_)
+        , warp_idx(warp_idx_ - (thread_cnt / 32))
+        , block_m(block_m_)
+        , block_n(block_n_)
+    {
+    }
+
+private:
+    __device__ constexpr int internal_b_atom_func(int tid)
+    {
+        if constexpr (tile_n < 8)
+        {
+            return (tid % tile_n) + ((tid % 8) / tile_n * 0) + tid / 8 * 8 * tile_n;
+        }
+        else
+        {
+            return (tid % 8)
+                + ((tid % 32) / 8
+                    * (tile_n * 8)) /* + (tid / 32 * 0) handled by outer code... This is why we need CuTe.*/;
+        }
+    }
+
+public:
+    __device__ void prepare()
+    {
+        /*
+        A: (t) -> (16, 16) -> (tile_m, tile_k) which tile_m === 16, tile_k % 64 == 0
+                  (16,2):(1,128) on (16,16)
+           (t, k_iter) -> (tile_m, tile_k) will be: (16,2,k_iter):(1,128,256)
+
+        // This is awful!!
+        B: (t) -> (8, 32) -> (tile_n, tile_k) which tile_n could be [1,2,4,8,16] and tile_k % 64 == 0
+                  (8,4):(1,64) on (8,32)
+               or ((tile_n,8/tile_n),4):((1,0),tile_n*8) on (tile_n,32) when tile_n < 8
+               or (8,4,2):((1,tile_n*8,0) on (tile_n,32) when tile_n > 8      Awful Awful Awful
+           (t, iter) -> (tile_n, tile_k) will be: (atom_32_shape,k_iter/2,m_iter):(atom_32_stride,tile_n*32,8)
+        */
+
+#pragma unroll
+        for (int i = 0; i < k_phase_cnt; i++)
+        {
+            int linear_idx = (lane_idx % 16) + (lane_idx / 16) * 128 + i * 256;
+            int m_idx = linear_idx % tile_m;
+            int k_idx = linear_idx / tile_m + warp_k_offset_in_tile_k;
+            // printf("tid: %d ldsm a idx: [%d, %d]\n", threadIdx.x % 128, m_idx, k_idx);
+            k_idx = apply_swizzle_343_on_elem_row_col<bf16_t>(m_idx, k_idx);
+            a_smem_offsets[0][i] = m_idx * tile_k + k_idx;
+        }
+#pragma unroll
+        for (int n_iter_idx = 0; n_iter_idx < n_iter_cnt; n_iter_idx++)
+        {
+#pragma unroll
+            for (int i = 0; i < k_phase_cnt; i += 2)
+            { // Special i+=2 for B.
+                int linear_idx = internal_b_atom_func(lane_idx) + i * tile_n * 16 + n_iter_idx * 8;
+                int n_idx = linear_idx % tile_n;
+                int k_idx = linear_idx / tile_n + warp_k_offset_in_tile_k;
+                // printf("tid: %d ldsm b idx: [%d, %d]\n", threadIdx.x % 128, n_idx, k_idx);
+                k_idx = apply_swizzle_343_on_elem_row_col<bf16_t>(n_idx, k_idx);
+                b_smem_offsets[n_iter_idx][i] = n_idx * tile_k + k_idx;
+            }
+        }
+    }
+
+    __device__ void issue_mainloop()
+    {
+#pragma unroll 1
+        for (int loop_idx = 0; loop_idx < k_iter_cnt; loop_idx++)
+        {
+            wait_barrier(smem_barrier + 0 + stage_idx * 2, phase_bit);
+
+#pragma unroll
+            for (int i = 0; i < k_phase_cnt; i++)
+            {
+                int smem_offset = a_smem_offsets[0][i];
+                bf16_t* smem_ptr_this_iter = smem_a + stage_idx * tile_m * tile_k + smem_offset;
+                ldsm_x4(smem_ptr_this_iter, reinterpret_cast<uint32_t*>(a_reg[0][i]));
+            }
+
+#pragma unroll
+            for (int n_iter_idx = 0; n_iter_idx < n_iter_cnt; n_iter_idx++)
+            {
+#pragma unroll
+                for (int i = 0; i < k_phase_cnt; i += 2)
+                {
+                    int smem_offset = b_smem_offsets[n_iter_idx][i];
+                    bf16_t* smem_ptr_this_iter = smem_b + stage_idx * tile_n * tile_k + smem_offset;
+                    ldsm_x4(smem_ptr_this_iter, reinterpret_cast<uint32_t*>(b_reg[n_iter_idx][i]));
+                }
+            }
+
+#pragma unroll
+            for (int k_iter_idx = 0; k_iter_idx < k_phase_cnt; k_iter_idx++)
+            {
+#pragma unroll
+                for (int n_iter_idx = 0; n_iter_idx < n_iter_cnt; n_iter_idx++)
+                {
+                    hmma_16_8_16_f32acc_bf16ab(acc_reg[0][n_iter_idx], a_reg[0][k_iter_idx],
+                        b_reg[n_iter_idx][k_iter_idx], acc_reg[0][n_iter_idx]);
+                }
+            }
+            asm volatile(".pragma \"next knob FenceInterference\";\n" : : : "memory"); // internal
+            arrive_barrier(smem_barrier + 1 + stage_idx * 2);
+            stage_idx += 1;
+            phase_bit = stage_idx == stage_cnt ? phase_bit ^ 1 : phase_bit;
+            stage_idx = stage_idx == stage_cnt ? 0 : stage_idx;
+        }
+    }
+
+    __device__ void epi()
+    {
+        asm volatile("bar.sync %0, %1;" : : "r"(1), "r"(thread_cnt));
+        // reorganize the acc_reg
+        constexpr int thread_m = 2;
+        constexpr int thread_n = 2 * n_iter_cnt;
+        constexpr int cta_mma_n = n_iter_cnt * 8;
+        float acc_reg_reorg[thread_m][thread_n];
+
+        // (m,n) -> (v)
+        for (int i = 0; i < thread_m; i++)
+        {
+            for (int j = 0; j < thread_n; j++)
+            {
+                acc_reg_reorg[i][j] = acc_reg[0][j / 2][(j % 2) + (i * 2)];
+            }
+        }
+        /*
+        # //                 4 or 2        2       8 or 16
+        # smem_c layout: ((group_rows, group_cnt), cta_mma_n) : ((cta_mma_n, 32+group_cnt), 1)
+        def func_3(cta_mma_n, m, n):
+            group_rows = 32 // cta_mma_n
+            group_cnt = 2
+            return ((m % group_rows * cta_mma_n) + (m // group_rows * (32 + group_cnt)) + n) % 32
+        */
+
+        // 4 x cosize(smem_c_layout)
+        float* smem_c = reinterpret_cast<float*>(smem_a);
+        // coord -> index
+        auto smem_c_index_func = [&](int m_idx, int n_idx)
+        {
+            int group_rows = 32 / cta_mma_n;
+            int group_cnt = 2;
+            return (m_idx % group_rows * cta_mma_n) + (m_idx / group_rows * (32 + group_cnt)) + n_idx;
+        };
+        constexpr int cosize_smem_c = ((tile_m * cta_mma_n) / 32) * (32 + 2);
+
+// This should be optimized to STS.64 but can not be STS.128 due to the bank index.
+#pragma unroll
+        for (int m_idx_thread = 0; m_idx_thread < thread_m; m_idx_thread++)
+        {
+#pragma unroll
+            for (int n_idx_thread = 0; n_idx_thread < thread_n; n_idx_thread++)
+            {
+                int m_idx = (lane_idx / 4) + m_idx_thread * 8;
+                int n_idx = ((lane_idx % 4) * 2) + (n_idx_thread % 2) + (n_idx_thread / 2) * 8;
+                // printf("tid: %d, [%d, %d]\n", threadIdx.x % 128, m_idx, n_idx);
+                smem_c[cosize_smem_c * warp_idx + smem_c_index_func(m_idx, n_idx)]
+                    = acc_reg_reorg[m_idx_thread][n_idx_thread];
+            }
+        }
+        asm volatile("bar.sync %0, %1;" : : "r"(1), "r"(thread_cnt));
+
+        if (warp_idx == 0)
+        {
+            constexpr int final_acc_reg_cnt = (tile_m * tile_n + 31) / 32;
+            float acc_final[final_acc_reg_cnt]{};
+
+#pragma unroll
+            for (int reg_idx = 0; reg_idx < final_acc_reg_cnt; reg_idx++)
+            {
+                int linear_idx = reg_idx * 32 + lane_idx;
+                int m_idx = linear_idx % tile_m;
+                int n_idx = linear_idx / tile_m;
+                acc_final[reg_idx] += smem_c[smem_c_index_func(m_idx, n_idx) + 0 * cosize_smem_c]
+                    + smem_c[smem_c_index_func(m_idx, n_idx) + 1 * cosize_smem_c]
+                    + smem_c[smem_c_index_func(m_idx, n_idx) + 2 * cosize_smem_c]
+                    + smem_c[smem_c_index_func(m_idx, n_idx) + 3 * cosize_smem_c];
+            }
+
+#pragma unroll
+            for (int reg_idx = 0; reg_idx < final_acc_reg_cnt; reg_idx++)
+            {
+                int linear_idx = reg_idx * 32 + lane_idx;
+                int m_idx = linear_idx % tile_m;
+                int n_idx = linear_idx / tile_m;
+                // printf("lane_id: %d, [%d, %d]\n", lane_idx, m_idx, n_idx);
+                // if (m)
+                // if (m_idx < tile_m && n_idx < tile_n)
+                int g_m_idx = block_m * tile_m + m_idx;
+                int g_n_idx = block_n * tile_n + n_idx;
+                if (g_m_idx < gemm_m && g_n_idx < gemm_n)
+                {
+                    gmem_c[g_n_idx * gemm_m + g_m_idx] = acc_final[reg_idx];
+                }
+            }
+        }
+    }
+
+    bf16_t* gmem_c;
+    bf16_t* smem_a;
+    bf16_t* smem_b;
+    uint64_t* smem_barrier;
+    int warp_idx;
+    int block_m;
+    int block_n;
+    int stage_idx = 0;
+    int phase_bit = 0;
+    int lane_idx = threadIdx.x % 32;
+    int warp_k_offset_in_tile_k = warp_idx * per_warp_tile_k;
+
+    int a_smem_offsets[m_iter_cnt][k_phase_cnt];
+    int b_smem_offsets[n_iter_cnt][k_phase_cnt];
+
+    bf16_t a_reg[m_iter_cnt][k_phase_cnt][8];
+    bf16_t b_reg[n_iter_cnt][k_phase_cnt][4];
+    float acc_reg[m_iter_cnt][n_iter_cnt][4]{};
+};
+
+// AB swapped, kernel is k-major, k-major, m-major
+template <int batch_size, int gemm_m, int gemm_n, int gemm_k, int tile_m, int tile_n, int tile_k, int stage_cnt>
+__global__ __launch_bounds__(256, 1) void fuse_a_gemm_kernel(bf16_t* output, bf16_t const* mat_a, bf16_t const* mat_b)
+{
+    asm volatile(".pragma \"global knob DisableImplicitMemDesc\";\n" // internal
+                 ::
+                     : "memory");
+    asm volatile(".pragma \"global knob sectorpromotion=128\";\n" // internal
+                 ::
+                     : "memory");
+    asm volatile(" .pragma \"global knob DisableWar_SW2549067\";\n");                     // internal
+    asm volatile(".pragma \"set knob SchedMemNoAlias=LDS+LDSM+LDGSTS\";\n" ::: "memory"); // internal
+
+    constexpr int load_thread_cnt = 128;
+    constexpr int compute_thread_cnt = 128;
+    constexpr int thread_cnt = load_thread_cnt + compute_thread_cnt;
+    (void) thread_cnt;
+    static_assert(gemm_m % 16 == 0);
+    static_assert(gemm_n <= 16);
+    static_assert(gemm_k % tile_k == 0);
+    static_assert(gemm_m % tile_m == 0);
+    // static_assert(gemm_n % tile_n == 0);
+    static_assert(tile_k == 128 || tile_k == 256 || tile_k == 512
+        || tile_k == 1024); // tile_k must be larger than 64 since 4 warp splitK.
+    static_assert(tile_m == 16);
+    constexpr int g2s_vec_bytes = 16;
+    constexpr int a_elem_bytes = 2;
+    constexpr int b_elem_bytes = 2;
+    // constexpr int c_elem_bytes = 2;
+    static_assert((tile_m * a_elem_bytes + tile_n * b_elem_bytes) * tile_k * stage_cnt <= 225 * 1024);
+    static_assert((tile_m * tile_k * a_elem_bytes) % (load_thread_cnt * g2s_vec_bytes) == 0);
+    static_assert((tile_n * tile_k * b_elem_bytes) % (load_thread_cnt * g2s_vec_bytes) == 0);
+
+    extern __shared__ char smem[];
+    uint64_t* smem_barrier = reinterpret_cast<uint64_t*>(smem); // producer,consumer; producer,consumer; ...
+    bf16_t* smem_a = reinterpret_cast<bf16_t*>(smem + (stage_cnt * 8 * 2 + 1024) / 1024 * 1024);
+    bf16_t* smem_b = smem_a + tile_m * tile_k * stage_cnt;
+    // bf16_t* smem_c = smem_a;
+
+    int cta_m_idx = tile_m * blockIdx.x;
+    int cta_n_idx = tile_n * blockIdx.y;
+    bf16_t const* gmem_a_local = mat_a + cta_m_idx * gemm_k;
+    bf16_t const* gmem_b_local = mat_b + cta_n_idx * gemm_k;
+
+    int warp_idx = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    if (warp_idx == 4)
+    {
+        for (int i = 0; i < stage_cnt; i++)
+        {
+            initialize_barrier(smem_barrier + i * 2 + 0, load_thread_cnt);    // producer
+            initialize_barrier(smem_barrier + i * 2 + 1, compute_thread_cnt); // consumer
+        }
+    }
+    __syncthreads();
+
+    if (warp_idx < 2)
+    {
+        GmemLoaderA<gemm_k, tile_m, tile_n, tile_k, stage_cnt, gemm_m> a_loader(gmem_a_local, smem_a, smem_barrier);
+        a_loader.prepare();
+        a_loader.issue_mainloop();
+    }
+    else if (warp_idx < 4)
+    {
+        GmemLoaderB<gemm_k, tile_m, tile_n, tile_k, stage_cnt, gemm_n> b_loader(gmem_b_local, smem_b, smem_barrier);
+        b_loader.prepare();
+        b_loader.issue_mainloop();
+    }
+    else
+    {
+        MmaComputer<gemm_m, gemm_n, gemm_k, tile_m, tile_n, tile_k, stage_cnt> mma_computer(
+            output, smem_a, smem_b, smem_barrier, warp_idx, blockIdx.x, blockIdx.y);
+        mma_computer.prepare();
+        mma_computer.issue_mainloop();
+        mma_computer.epi();
+    }
+    // asm volatile("griddepcontrol.launch_dependents;");
+}
+
+constexpr int button_pow_of_two(int x)
+{ // 移除参数前的constexpr
+    if (x <= 0)
+    {
+        return -1;
+    }
+    int n = x - 1; // 移除内部变量前的constexpr
+    int n1 = n | (n >> 1);
+    int n2 = n1 | (n1 >> 2);
+    int n3 = n2 | (n2 >> 4);
+    int n4 = n3 | (n3 >> 8);
+    int n5 = n4 | (n4 >> 16);
+    return n5 + 1;
+}
+
+template <typename T, int kNumTokens, int kHdIn, int kHdOut>
+void invokeFuseAGemm(T* output, T const* mat_a, T const* mat_b, cudaStream_t const stream)
+{
+    constexpr int gemm_m = kHdOut;     // 2112
+    constexpr int gemm_n = kNumTokens; // 4
+    constexpr int gemm_k = kHdIn;      // 7168
+    constexpr int batch_size = 1;
+    std::swap(mat_a, mat_b);
+    constexpr int tile_m = 16;
+    constexpr int tile_n = gemm_n & (gemm_n - 1) == 0 ? gemm_n : button_pow_of_two(gemm_n);
+    constexpr int tile_k = std::max(256, 1024 / tile_n);           // 256
+    constexpr int max_stage_cnt = 1024 * 225 / ((tile_m + tile_n) * tile_k * sizeof(bf16_t));
+    constexpr int k_iter_cnt = gemm_k / tile_k;                    // 7168 / 256 = 28
+    constexpr int stage_cnt
+        = k_iter_cnt > max_stage_cnt ? max_stage_cnt : k_iter_cnt; // possible tunable for smallK > 1 wave n. // 22
+    int cta_m_cnt = (gemm_m + tile_m - 1) / tile_m;
+    int cta_n_cnt = (gemm_n + tile_n - 1) / tile_n;
+    constexpr int barrier_bytes = (stage_cnt * 16 + 1023) / 1024 * 1024; // 4096
+    constexpr int smem_bytes = ((tile_m * 2 + tile_n * 2) * tile_k * stage_cnt + barrier_bytes + 1023) / 1024
+        * 1024; // ((16 * 2 + 4 * 2) * 256 * 22 + 4096 + 1023) / 1024 * 1024 = 230399
+
+    dim3 grid(cta_m_cnt, cta_n_cnt, 1);
+    dim3 block_size(256);
+    cudaLaunchConfig_t config;
+    config.gridDim = grid;
+    config.blockDim = block_size;
+    config.dynamicSmemBytes = smem_bytes;
+    config.stream = stream;
+    cudaLaunchAttribute attrs[1];
+    attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+    attrs[0].val.programmaticStreamSerializationAllowed = tensorrt_llm::common::getEnvEnablePDL();
+    config.numAttrs = 1;
+    config.attrs = attrs;
+    if (smem_bytes >= (48 * 1024))
+    {
+        TLLM_CUDA_CHECK(cudaFuncSetAttribute(
+            fuse_a_gemm_kernel<batch_size, gemm_m, gemm_n, gemm_k, tile_m, tile_n, tile_k, stage_cnt>,
+            cudaFuncAttributeMaxDynamicSharedMemorySize, smem_bytes));
+    }
+    TLLM_CUDA_CHECK(cudaLaunchKernelEx(&config,
+        fuse_a_gemm_kernel<batch_size, gemm_m, gemm_n, gemm_k, tile_m, tile_n, tile_k, stage_cnt>, output, mat_a,
+        mat_b));
+}
+
+template void invokeFuseAGemm<__nv_bfloat16, 1, 7168, 2112>(
+    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+template void invokeFuseAGemm<__nv_bfloat16, 2, 7168, 2112>(
+    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+template void invokeFuseAGemm<__nv_bfloat16, 3, 7168, 2112>(
+    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+template void invokeFuseAGemm<__nv_bfloat16, 4, 7168, 2112>(
+    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+template void invokeFuseAGemm<__nv_bfloat16, 5, 7168, 2112>(
+    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+template void invokeFuseAGemm<__nv_bfloat16, 6, 7168, 2112>(
+    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+template void invokeFuseAGemm<__nv_bfloat16, 7, 7168, 2112>(
+    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+template void invokeFuseAGemm<__nv_bfloat16, 8, 7168, 2112>(
+    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+template void invokeFuseAGemm<__nv_bfloat16, 9, 7168, 2112>(
+    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+template void invokeFuseAGemm<__nv_bfloat16, 10, 7168, 2112>(
+    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+template void invokeFuseAGemm<__nv_bfloat16, 11, 7168, 2112>(
+    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+template void invokeFuseAGemm<__nv_bfloat16, 12, 7168, 2112>(
+    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+template void invokeFuseAGemm<__nv_bfloat16, 13, 7168, 2112>(
+    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+template void invokeFuseAGemm<__nv_bfloat16, 14, 7168, 2112>(
+    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+template void invokeFuseAGemm<__nv_bfloat16, 15, 7168, 2112>(
+    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+template void invokeFuseAGemm<__nv_bfloat16, 16, 7168, 2112>(
+    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+} // namespace tensorrt_llm::kernels

--- a/cpp/tensorrt_llm/kernels/fuseAGemm.h
+++ b/cpp/tensorrt_llm/kernels/fuseAGemm.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2021, NAVER Corp.  Authored by CLOVA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include "tensorrt_llm/common/cudaUtils.h"
+
+namespace tensorrt_llm::kernels
+{
+
+template <typename T, int kNumTokens, int kHdIn, int kHdOut>
+void invokeFuseAGemm(T* output, T const* mat_a, T const* mat_b, cudaStream_t const stream);
+
+} // namespace tensorrt_llm::kernels

--- a/cpp/tensorrt_llm/kernels/router_gemm.cu
+++ b/cpp/tensorrt_llm/kernels/router_gemm.cu
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tensorrt_llm/common/envUtils.h"
+#include "tensorrt_llm/kernels/router_gemm.h"
+using namespace tensorrt_llm::common;
+
+namespace tensorrt_llm
+{
+namespace kernels
+{
+
+// Custom FMA implementation using PTX assembly instructions
+__device__ __forceinline__ void fma(float2& d, float2 const& a, float2 const& b, float2 const& c)
+{
+    asm volatile("fma.rn.f32x2 %0, %1, %2, %3;\n"
+                 : "=l"(reinterpret_cast<uint64_t&>(d))
+                 : "l"(reinterpret_cast<uint64_t const&>(a)), "l"(reinterpret_cast<uint64_t const&>(b)),
+                 "l"(reinterpret_cast<uint64_t const&>(c)));
+}
+
+// Convert 8 bfloat16 values from a uint4 to float array - optimized conversion
+template <int VPT>
+__device__ __forceinline__ void bf16_uint4_to_float8(uint4 const& vec, float* dst)
+{
+    __nv_bfloat16* bf16_ptr = reinterpret_cast<__nv_bfloat16*>(const_cast<uint4*>(&vec));
+
+#pragma unroll
+    for (int i = 0; i < VPT; i++)
+    {
+        dst[i] = __bfloat162float(bf16_ptr[i]);
+    }
+}
+
+template <typename T, int kBlockSize, int VPT, int kNumTokens, int kNumExperts, int kHiddenDim>
+__global__ __launch_bounds__(128, 1) void router_gemm_kernel(float* out, T const* mat_a, T const* mat_b)
+{
+    // Each block handles one expert column
+    int const n_idx = blockIdx.x;
+    int const tid = threadIdx.x;
+    constexpr int kWarpSize = 32;
+    constexpr int kNumWarps = kBlockSize / kWarpSize;
+    // Constants for this kernel
+    constexpr int k_elems_per_k_iteration = VPT * kBlockSize;
+    constexpr int k_iterations = kHiddenDim / k_elems_per_k_iteration; // Total K iterations
+
+    // Initialize accumulators for all M rows
+    float acc[kNumTokens] = {};
+
+    // Shared memory for warp-level reduction
+    __shared__ float sm_reduction[kNumTokens][kNumWarps]; // kNumWarps
+
+    // B matrix is in column-major order, so we can directly load a column for the n_idx expert
+    T const* b_col = mat_b + n_idx * kHiddenDim;
+
+    // Pre-compute k_base values for each iteration to help compiler optimize
+    // int k_bases[k_iterations];
+    int k_bases[k_iterations];
+#pragma unroll
+    for (int ki = 0; ki < k_iterations; ki++)
+    {
+        k_bases[ki] = ki * k_elems_per_k_iteration + tid * VPT;
+    }
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    asm volatile("griddepcontrol.wait;");
+#endif
+
+    // Process the GEMM in chunks
+    for (int ki = 0; ki < k_iterations; ki++)
+    {
+        int const k_base = k_bases[ki];
+
+        // Load B matrix values using vector load (8 bf16 values)
+        uint4 b_vec = *reinterpret_cast<uint4 const*>(b_col + k_base);
+
+        // Convert B values to float
+        float b_float[VPT];
+        bf16_uint4_to_float8<VPT>(b_vec, b_float);
+
+// Process each token
+#pragma unroll
+        for (int m_idx = 0; m_idx < kNumTokens; m_idx++)
+        {
+            // Load both rows of A matrix using vector loads
+            uint4 a_vec = *reinterpret_cast<uint4 const*>(mat_a + (m_idx * kHiddenDim) + k_base);
+
+            // Convert A values to float
+            float a_float[VPT];
+            bf16_uint4_to_float8<VPT>(a_vec, a_float);
+
+// Process elements in this chunk
+#pragma unroll
+            for (int k = 0; k < VPT; k++)
+            {
+                float a = a_float[k];
+                float b = b_float[k];
+                acc[m_idx] += a * b;
+            }
+        }
+    }
+
+    // Perform warp-level reduction
+    int const warpSize = 32;
+    int const warpId = tid / warpSize;
+    int const laneId = tid % warpSize;
+
+    // Register for warp-level reduction results
+    float warp_result[kNumTokens];
+
+#pragma unroll
+    for (int m_idx = 0; m_idx < kNumTokens; m_idx++)
+    {
+        warp_result[m_idx] = acc[m_idx];
+    }
+
+// Perform warp-level reduction using optimized butterfly pattern
+#pragma unroll
+    for (int m = 0; m < kNumTokens; m++)
+    {
+        float sum = warp_result[m];
+
+        // Butterfly reduction pattern
+        sum += __shfl_xor_sync(0xffffffff, sum, 16);
+        sum += __shfl_xor_sync(0xffffffff, sum, 8);
+        sum += __shfl_xor_sync(0xffffffff, sum, 4);
+        sum += __shfl_xor_sync(0xffffffff, sum, 2);
+        sum += __shfl_xor_sync(0xffffffff, sum, 1);
+
+        // Only the first thread in each warp stores to shared memory
+        if (laneId == 0)
+        {
+            sm_reduction[m][warpId] = sum;
+        }
+    }
+
+    __syncthreads();
+
+    // Final reduction across warps (only first thread)
+    if (tid == 0)
+    {
+#pragma unroll
+        for (int m = 0; m < kNumTokens; m++)
+        {
+            float final_sum = 0.0f;
+
+// Sum across the kNumWarps
+#pragma unroll
+            for (int w = 0; w < kNumWarps; w++)
+            {
+                final_sum += sm_reduction[m][w];
+            }
+
+            // Write final result
+            out[m * kNumExperts + n_idx] = final_sum;
+        }
+    }
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    asm volatile("griddepcontrol.launch_dependents;");
+#endif
+}
+
+template <typename T, int kNumTokens, int kNumExperts, int kHiddenDim>
+void invokeRouterGemm(float* output, T const* mat_a, T const* mat_b, cudaStream_t stream)
+{
+    constexpr int VPT = 16 / sizeof(T);
+    constexpr int kBlockSize = 128;
+    cudaLaunchConfig_t config;
+    config.gridDim = kNumExperts;
+    config.blockDim = kBlockSize;
+    config.dynamicSmemBytes = 0;
+    config.stream = stream;
+    cudaLaunchAttribute attrs[1];
+    attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+    attrs[0].val.programmaticStreamSerializationAllowed = tensorrt_llm::common::getEnvEnablePDL();
+    config.numAttrs = 1;
+    config.attrs = attrs;
+    TLLM_CUDA_CHECK(cudaLaunchKernelEx(
+        &config, router_gemm_kernel<T, kBlockSize, VPT, kNumTokens, kNumExperts, kHiddenDim>, output, mat_a, mat_b));
+}
+
+template void tensorrt_llm::kernels::invokeRouterGemm<__nv_bfloat16, 1, 256, 7168>(
+    float*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+template void tensorrt_llm::kernels::invokeRouterGemm<__nv_bfloat16, 2, 256, 7168>(
+    float*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+template void tensorrt_llm::kernels::invokeRouterGemm<__nv_bfloat16, 3, 256, 7168>(
+    float*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+template void tensorrt_llm::kernels::invokeRouterGemm<__nv_bfloat16, 4, 256, 7168>(
+    float*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+template void tensorrt_llm::kernels::invokeRouterGemm<__nv_bfloat16, 5, 256, 7168>(
+    float*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+template void tensorrt_llm::kernels::invokeRouterGemm<__nv_bfloat16, 6, 256, 7168>(
+    float*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+template void tensorrt_llm::kernels::invokeRouterGemm<__nv_bfloat16, 7, 256, 7168>(
+    float*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+template void tensorrt_llm::kernels::invokeRouterGemm<__nv_bfloat16, 8, 256, 7168>(
+    float*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+template void tensorrt_llm::kernels::invokeRouterGemm<__nv_bfloat16, 9, 256, 7168>(
+    float*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+template void tensorrt_llm::kernels::invokeRouterGemm<__nv_bfloat16, 10, 256, 7168>(
+    float*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+template void tensorrt_llm::kernels::invokeRouterGemm<__nv_bfloat16, 11, 256, 7168>(
+    float*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+template void tensorrt_llm::kernels::invokeRouterGemm<__nv_bfloat16, 12, 256, 7168>(
+    float*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+template void tensorrt_llm::kernels::invokeRouterGemm<__nv_bfloat16, 13, 256, 7168>(
+    float*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+template void tensorrt_llm::kernels::invokeRouterGemm<__nv_bfloat16, 14, 256, 7168>(
+    float*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+template void tensorrt_llm::kernels::invokeRouterGemm<__nv_bfloat16, 15, 256, 7168>(
+    float*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+template void tensorrt_llm::kernels::invokeRouterGemm<__nv_bfloat16, 16, 256, 7168>(
+    float*, __nv_bfloat16 const*, __nv_bfloat16 const*, cudaStream_t);
+
+} // namespace kernels
+} // namespace tensorrt_llm

--- a/cpp/tensorrt_llm/kernels/router_gemm.h
+++ b/cpp/tensorrt_llm/kernels/router_gemm.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "tensorrt_llm/common/cudaUtils.h"
+#include <assert.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+namespace tensorrt_llm
+{
+namespace kernels
+{
+
+template <typename T, int kNumTokens, int kNumExperts, int kHiddenDim>
+void invokeRouterGemm(float* output, T const* mat_a, T const* mat_b, cudaStream_t stream);
+
+} // namespace kernels
+} // namespace tensorrt_llm

--- a/cpp/tensorrt_llm/thop/CMakeLists.txt
+++ b/cpp/tensorrt_llm/thop/CMakeLists.txt
@@ -54,6 +54,7 @@ add_library(
   fp4BatchedQuantize.cpp
   fp8BlockScalingGemm.cpp
   fp8Quantize.cpp
+  fuseAGemmOp.cpp
   fusedTopkSoftmax.cpp
   gatherTreeOp.cpp
   groupRmsNormOp.cpp
@@ -69,6 +70,7 @@ add_library(
   redrafterCurandOp.cpp
   reducescatterOp.cpp
   relativeAttentionBiasOp.cpp
+  routerGemmOp.cpp
   selectiveScanOp.cpp
   userbuffersFinalizeOp.cpp
   userbuffersTensor.cpp

--- a/cpp/tensorrt_llm/thop/deepseekAllreduceFusionOp.cpp
+++ b/cpp/tensorrt_llm/thop/deepseekAllreduceFusionOp.cpp
@@ -57,7 +57,8 @@ public:
     ~DeepseekAllreduceOp() = default;
 
     std::vector<torch::Tensor> run(torch::Tensor input, torch::optional<torch::Tensor> workspace,
-        torch::TensorList reduce_fusion_inputs, int64_t rank, int64_t nranks, double eps, int64_t fusion_op) noexcept
+        torch::TensorList reduce_fusion_inputs, int64_t rank, int64_t nranks, double eps, int64_t fusion_op,
+        bool trigger_completion_at_end) noexcept
     {
         auto const fusion_op_type = static_cast<AllReduceFusionOp>(int8_t(fusion_op));
 
@@ -72,6 +73,7 @@ public:
         allreduce_fusion_params.scale_out = nullptr;
         allreduce_fusion_params.residual_out = nullptr;
         allreduce_fusion_params.norm_out = nullptr;
+        allreduce_fusion_params.trigger_completion_at_end = trigger_completion_at_end;
 
         if (fusion_op_type == AllReduceFusionOp::RESIDUAL_RMS_NORM_QUANT_NVFP4
             || fusion_op_type == AllReduceFusionOp::RESIDUAL_RMS_NORM_OUT_QUANT_NVFP4)
@@ -234,7 +236,7 @@ public:
 
 std::vector<torch::Tensor> deepseekAllreduceFusion(torch::Tensor input, torch::optional<torch::Tensor> workspace,
     torch::TensorList reduce_fusion_inputs, int64_t const rank, int64_t const nranks, double const eps,
-    int64_t const fusion_op)
+    int64_t const fusion_op, bool const trigger_completion_at_end)
 {
 #if ENABLE_MULTI_DEVICE
     DeepseekAllreduceOp op;
@@ -245,7 +247,7 @@ std::vector<torch::Tensor> deepseekAllreduceFusion(torch::Tensor input, torch::o
     }
     else
     {
-        return op.run(input, workspace, reduce_fusion_inputs, rank, nranks, eps, fusion_op);
+        return op.run(input, workspace, reduce_fusion_inputs, rank, nranks, eps, fusion_op, trigger_completion_at_end);
     }
 #else
     return std::vector<torch::Tensor>();
@@ -262,7 +264,7 @@ TORCH_LIBRARY_FRAGMENT(trtllm, m)
     // 2. scale_factor: only when fusion_op == RESIDUAL_RMS_NORM_QUANT_NVFP4
     m.def(
         "deepseek_allreduce_fusion(Tensor input, Tensor? workspace, Tensor[] reduce_fusion_inputs, "
-        "int rank, int nranks, float eps, int fusion_op) -> Tensor[]");
+        "int rank, int nranks, float eps, int fusion_op, bool trigger_completion_at_end) -> Tensor[]");
 }
 
 TORCH_LIBRARY_IMPL(trtllm, CUDA, m)

--- a/cpp/tensorrt_llm/thop/fuseAGemmOp.cpp
+++ b/cpp/tensorrt_llm/thop/fuseAGemmOp.cpp
@@ -1,0 +1,104 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tensorrt_llm/common/opUtils.h"
+#include "tensorrt_llm/kernels/fuseAGemm.h"
+#include "tensorrt_llm/runtime/torchUtils.h"
+
+namespace th = torch;
+namespace tl = tensorrt_llm;
+namespace tk = tensorrt_llm::kernels;
+
+namespace torch_ext
+{
+
+namespace
+{
+template <int kBegin, int kEnd, int kHdIn, int kHdOut>
+struct LoopUnroller
+{
+    static void unroll(int num_tokens, __nv_bfloat16* output, __nv_bfloat16 const* input, __nv_bfloat16 const* weights,
+        cudaStream_t stream)
+    {
+        if (num_tokens == kBegin)
+        {
+            tk::invokeFuseAGemm<__nv_bfloat16, kBegin, kHdIn, kHdOut>(output, input, weights, stream);
+        }
+        else
+        {
+            LoopUnroller<kBegin + 1, kEnd, kHdIn, kHdOut>::unroll(num_tokens, output, input, weights, stream);
+        }
+    }
+};
+
+template <int kEnd, int kHdIn, int kHdOut>
+struct LoopUnroller<kEnd, kEnd, kHdIn, kHdOut>
+{
+    static void unroll(int num_tokens, __nv_bfloat16* output, __nv_bfloat16 const* input, __nv_bfloat16 const* weights,
+        cudaStream_t stream)
+    {
+        if (num_tokens == kEnd)
+        {
+            tk::invokeFuseAGemm<__nv_bfloat16, kEnd, kHdIn, kHdOut>(output, input, weights, stream);
+        }
+        else
+        {
+            throw std::invalid_argument("Invalid num_tokens, only supports 1 to 16");
+        }
+    }
+};
+} // namespace
+
+th::Tensor fuse_a_gemm_op(th::Tensor const& mat_a, th::Tensor const& mat_b, std::optional<at::Tensor> const& bias,
+    std::optional<c10::ScalarType> const& out_dtype)
+{
+    int const num_tokens = mat_a.size(0);
+    int const hd_in = mat_a.size(1);
+    int const hd_out = mat_b.size(1);
+    // auto const out_dtype_ = out_dtype.value_or(mat_a.scalar_type());
+    auto const out_dtype_ = out_dtype.value_or(mat_a.scalar_type());
+    auto const data_type = mat_a.scalar_type();
+    constexpr int kHdIn = 7168;
+    constexpr int kHdOut = 2112;
+    TORCH_CHECK(data_type == at::kBFloat16, "input tensor must be bfloat16");
+    TORCH_CHECK(out_dtype_ == at::kBFloat16, "output tensor must be bfloat16");
+    TORCH_CHECK(hd_in == kHdIn, "hd_in must be 7168");
+    TORCH_CHECK(hd_out == kHdOut, "hd_out must be 2112");
+    TORCH_CHECK(num_tokens >= 1 && num_tokens <= 16, "num_tokens must be between 1 and 16");
+    std::vector<int64_t> output_size = {num_tokens, hd_out};
+    th::Tensor out = th::empty(output_size, mat_a.options().dtype(out_dtype_));
+
+    auto stream = at::cuda::getCurrentCUDAStream(mat_a.get_device());
+
+    LoopUnroller<1, 16, kHdIn, kHdOut>::unroll(num_tokens, reinterpret_cast<__nv_bfloat16*>(out.mutable_data_ptr()),
+        reinterpret_cast<__nv_bfloat16 const*>(mat_a.data_ptr()),
+        reinterpret_cast<__nv_bfloat16 const*>(mat_b.data_ptr()), stream);
+
+    return out;
+}
+
+} // namespace torch_ext
+
+TORCH_LIBRARY_FRAGMENT(trtllm, m)
+{
+    m.def("fuse_a_gemm_op(Tensor mat_a, Tensor mat_b, Tensor? bias, ScalarType? out_dtype) -> (Tensor out)");
+}
+
+TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
+{
+    m.impl("fuse_a_gemm_op", &torch_ext::fuse_a_gemm_op);
+}

--- a/cpp/tensorrt_llm/thop/routerGemmOp.cpp
+++ b/cpp/tensorrt_llm/thop/routerGemmOp.cpp
@@ -1,0 +1,104 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tensorrt_llm/common/opUtils.h"
+#include "tensorrt_llm/kernels/router_gemm.h"
+#include "tensorrt_llm/runtime/torchUtils.h"
+
+namespace th = torch;
+namespace tl = tensorrt_llm;
+namespace tk = tensorrt_llm::kernels;
+
+namespace torch_ext
+{
+
+namespace
+{
+template <int kBegin, int kEnd, int kNumExperts, int kHiddenDim>
+struct LoopUnroller
+{
+    static void unroll(
+        int num_tokens, float* output, __nv_bfloat16 const* input, __nv_bfloat16 const* weights, cudaStream_t stream)
+    {
+        if (num_tokens == kBegin)
+        {
+            tk::invokeRouterGemm<__nv_bfloat16, kBegin, kNumExperts, kHiddenDim>(output, input, weights, stream);
+        }
+        else
+        {
+            LoopUnroller<kBegin + 1, kEnd, kNumExperts, kHiddenDim>::unroll(num_tokens, output, input, weights, stream);
+        }
+    }
+};
+
+template <int kEnd, int kNumExperts, int kHiddenDim>
+struct LoopUnroller<kEnd, kEnd, kNumExperts, kHiddenDim>
+{
+    static void unroll(
+        int num_tokens, float* output, __nv_bfloat16 const* input, __nv_bfloat16 const* weights, cudaStream_t stream)
+    {
+        if (num_tokens == kEnd)
+        {
+            tk::invokeRouterGemm<__nv_bfloat16, kEnd, kNumExperts, kHiddenDim>(output, input, weights, stream);
+        }
+        else
+        {
+            throw std::invalid_argument("Invalid num_tokens, only supports 1 to 16");
+        }
+    }
+};
+} // namespace
+
+th::Tensor router_gemm_op(th::Tensor const& mat_a, th::Tensor const& mat_b, std::optional<at::Tensor> const& bias,
+    std::optional<c10::ScalarType> const& out_dtype)
+{
+    int const num_tokens = mat_a.size(0);
+    int const num_experts = mat_b.size(1);
+    int const hidden_dim = mat_a.size(1);
+    auto const out_dtype_ = out_dtype.value_or(mat_a.scalar_type());
+    auto const data_type = mat_a.scalar_type();
+    constexpr int kNumExperts = 256;
+    constexpr int kHiddenDim = 7168;
+    TORCH_CHECK(mat_a.dim() == 2 && mat_b.dim() == 2);
+    TORCH_CHECK(num_experts == kNumExperts, "num_experts must be 256");
+    TORCH_CHECK(hidden_dim == kHiddenDim, "hidden_dim must be 7168");
+    TORCH_CHECK(num_tokens >= 1 && num_tokens <= 16, "num_tokens must be between 1 and 16");
+    TORCH_CHECK(out_dtype_ == torch::kFloat32, "output tensor must be float32");
+    TORCH_CHECK(data_type == torch::kBFloat16, "input tensor must be bfloat16");
+    std::vector<int64_t> output_size = {mat_a.sizes()[0], mat_b.sizes()[1]};
+    th::Tensor out = th::empty(output_size, mat_a.options().dtype(out_dtype_));
+
+    auto stream = at::cuda::getCurrentCUDAStream(mat_a.get_device());
+
+    LoopUnroller<1, 16, kNumExperts, kHiddenDim>::unroll(num_tokens, reinterpret_cast<float*>(out.mutable_data_ptr()),
+        reinterpret_cast<__nv_bfloat16 const*>(mat_a.data_ptr()),
+        reinterpret_cast<__nv_bfloat16 const*>(mat_b.data_ptr()), stream);
+
+    return out;
+}
+
+} // end namespace torch_ext
+
+TORCH_LIBRARY_FRAGMENT(trtllm, m)
+{
+    m.def("router_gemm_op(Tensor mat_a, Tensor mat_b, Tensor? bias, ScalarType? out_dtype) -> (Tensor out)");
+}
+
+TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
+{
+    m.impl("router_gemm_op", &torch_ext::router_gemm_op);
+}

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -88,6 +88,22 @@ def _register_fake():
             shape, dtype=out_dtype if out_dtype is not None else mat_a.dtype)
         return ret
 
+    @torch.library.register_fake("trtllm::router_gemm_op")
+    def _(mat_a, mat_b, bias, out_dtype):
+        shape = list(mat_a.shape)
+        shape[-1] = mat_b.shape[-1]
+        ret = mat_a.new_empty(
+            shape, dtype=out_dtype if out_dtype is not None else mat_a.dtype)
+        return ret
+
+    @torch.library.register_fake("trtllm::fuse_a_gemm_op")
+    def _(mat_a, mat_b, bias, out_dtype):
+        shape = list(mat_a.shape)
+        shape[-1] = mat_b.shape[-1]
+        ret = mat_a.new_empty(
+            shape, dtype=out_dtype if out_dtype is not None else mat_a.dtype)
+        return ret
+
     @torch.library.register_fake("trtllm::fp4_gemm")
     def _(
         mat1: torch.Tensor,

--- a/tensorrt_llm/_torch/distributed/ops.py
+++ b/tensorrt_llm/_torch/distributed/ops.py
@@ -349,6 +349,7 @@ class DeepseekAllReduce(nn.Module):
         reduce_fusion_inputs: List[torch.Tensor],
         eps: float,
         fusion_op: AllReduceFusionOp,
+        trigger_completion_at_end: bool = True,
     ) -> Tuple[torch.Tensor, ...]:
         """
         hidden_states: hidden_states of the model
@@ -357,6 +358,7 @@ class DeepseekAllReduce(nn.Module):
         fusion_op: AllReduceFusionOp Type, currently supports RMSNorm:
           * RESIDUAL_RMS_NORM: allreduce + residual + Norm
           * RESIDUAL_RMS_NORM_QUANT_NVFP4: allreduce + residual + Norm + fp4 quantization
+        trigger_completion_at_end: whether to trigger completion at the end of the allreduce
         output:
           * [hidden_states, residual] if using RESIDUAL_RMS_NORM fusion_op
           * [act_fp4, act_sf, residual] if using RESIDUAL_RMS_NORM_QUANT_NVFP4 fusion_op
@@ -370,6 +372,7 @@ class DeepseekAllReduce(nn.Module):
             nranks=self.mapping.tp_size,
             eps=eps,
             fusion_op=fusion_op,
+            trigger_completion_at_end=trigger_completion_at_end,
         )
 
         if len(output) == 0:

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -300,11 +300,16 @@ class DeepseekV3Gate(BaseMoeRoutingMethod):
             is_fused=fuse_routing_kernel)
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        # router gemm
-        logits = torch.ops.trtllm.cublas_mm(hidden_states,
-                                            self.weight.t(),
-                                            bias=None,
-                                            out_dtype=torch.float32)
+        if hidden_states.size(0) >= 1 and hidden_states.size(0) <= 16:
+            logits = torch.ops.trtllm.router_gemm_op(hidden_states,
+                                                     self.weight.t(),
+                                                     bias=None,
+                                                     out_dtype=torch.float32)
+        else:
+            logits = torch.ops.trtllm.cublas_mm(hidden_states,
+                                                self.weight.t(),
+                                                bias=None,
+                                                out_dtype=torch.float32)
         return logits
 
     def load_weights(self, weights: List[Dict]):
@@ -504,8 +509,8 @@ class Deepseekv3MoE(nn.Module):
                                                        min_latency_mode)
             return routed_output
 
-        shared_output, routed_output = maybe_execute_in_parallel(
-            _compute_shared_output, _compute_routed_output,
+        routed_output, shared_output = maybe_execute_in_parallel(
+            _compute_routed_output, _compute_shared_output,
             self.event_dict[EventType.Main],
             self.event_dict[EventType.MoeShared], self.aux_stream)
 

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -361,7 +361,11 @@ class Linear(nn.Module):
                 raise ValueError(f'unsupported quant mode: {qc.quant_mode}')
         else:
             # TODO: remove custom cublas_mm when default heuristics is good enough
-            if self.use_custom_cublas_mm:
+            if input.shape[0] >= 1 and input.shape[0] <= 16 and input.shape[
+                    1] == 7168 and weight.shape[0] == 2112:
+                output = torch.ops.trtllm.fuse_a_gemm_op(
+                    input, self.weight.t(), bias, None)
+            elif self.use_custom_cublas_mm:
                 output = torch.ops.trtllm.cublas_mm(input,
                                                     self.weight.t(),
                                                     bias,

--- a/tests/unittest/_torch/thop/test_fuse_a_gemm.py
+++ b/tests/unittest/_torch/thop/test_fuse_a_gemm.py
@@ -1,0 +1,24 @@
+import pytest
+import torch
+
+
+def fuse_a_gemm_ref(input, weight, bias, dtype):
+    logits_ref = torch.matmul(input, weight)
+    return logits_ref
+
+
+@pytest.mark.parametrize("num_tokens", [1, 2, 3, 4, 5])
+@pytest.mark.parametrize("hd_out", [2112])
+@pytest.mark.parametrize("hd_in", [7168])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+def test_fuse_a_gemm_run(num_tokens, hd_out, hd_in, dtype):
+    torch.manual_seed(24)
+    torch.cuda.manual_seed(24)
+
+    device = torch.device("cuda")
+    input = torch.randn(num_tokens, hd_in, dtype=dtype, device=device)
+    weight = torch.randn((hd_out, hd_in), dtype=dtype, device=device)
+    bias = None
+    logits = torch.ops.trtllm.fuse_a_gemm_op(input, weight.t(), bias, dtype)
+    logtis_ref = fuse_a_gemm_ref(input, weight.t(), bias, dtype)
+    assert torch.allclose(logits, logtis_ref, rtol=1e-2)

--- a/tests/unittest/_torch/thop/test_router_gemm.py
+++ b/tests/unittest/_torch/thop/test_router_gemm.py
@@ -1,0 +1,27 @@
+import pytest
+import torch
+
+
+def router_gemm_ref(input, weight, bias, dtype):
+    logits_ref = torch.matmul(input, weight)
+    return logits_ref
+
+
+@pytest.mark.parametrize(
+    "num_tokens", [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])
+@pytest.mark.parametrize("num_experts", [256])
+@pytest.mark.parametrize("hidden_size", [7168])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+def test_router_gemm_run(num_tokens, num_experts, hidden_size, dtype):
+    torch.manual_seed(24)
+    torch.cuda.manual_seed(24)
+
+    device = torch.device("cuda")
+    input = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
+    weight = torch.randn((num_experts, hidden_size), dtype=dtype, device=device)
+    bias = None
+    logits = torch.ops.trtllm.router_gemm_op(input, weight.t(), bias,
+                                             torch.float32)
+    logtis_ref = router_gemm_ref(input.float(),
+                                 weight.t().float(), bias, torch.float32)
+    assert torch.allclose(logits, logtis_ref, rtol=5e-3)


### PR DESCRIPTION
Signed-off-by: yunruis <yunruis@nvidia.com>

Fix pdl issue

Signed-off-by: Zongfei Jing <20381269+zongfeijing@users.noreply.github.com>

Delete unused code

Signed-off-by: Zongfei Jing <20381269+zongfeijing@users.noreply.github.com>

larger smem_size of fusedAgemm

PDL optimize

Signed-off-by: Zongfei Jing <20381269+zongfeijing@users.noreply.github.com>

PDL optimize for allreduce and router gemm

Signed-off-by: Zongfei Jing <20381269+zongfeijing@users.noreply.github.com>

support fuse_a_gemm and router_gemm tokens from 1-16


# PR title

feat: add router_gemm and fuse_a_gemm for DeepSeek-R1 min-latency mode

## Description

Add router_gemm and fuse_a_gemm in min-latency mode. The running tokens is limited from 1 to 16. 

- **Kernel performance**： The performance of these two kernel is 1.5~3x speed up than previous cublas method. In case of num_tokens=4, the e2e performance are below table **e2e latency(us)**

| kernel name   | ours | previous(cublas)   |
| :---        |    :----:   |          ---: |
| router_gemm |  3.9    |     11.3          |
| fuse_a_gemm |  7.6    |     11.6          |

- **Model benchmark performance**:  **300.9** TPS, while previous version(cublas) is 279 TPS, achieving 7% speedup.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
