### PR TITLE
[Infra] - Update code ownership rules for public APIs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,13 +1,15 @@
 # This file defines code ownership rules for the repository.
 
-# The rule below requires that any PR modifying public APIs must be approved by at least one member
-# of the NVIDIA/trt-llm-api-review-committee team. This approval is mandatory regardless of other
-# approvals the PR may have received. Without approval from a member of this team, PRs affecting
-# public APIs cannot be merged to main or release branches.
-# TBD @NVIDIA/trt-llm-api-review-committee
-
 # The following rule should only be uncommented on release branches (e.g., release/0.19).
 # The rule below requires that any PR to release/**/* branches must be approved by at least one member
 # of the NVIDIA/trt-llm-release-branch-approval team, regardless of who else approves the PR.
 # Without approval from a member of this team, PRs cannot be merged to release branches.
 # * @NVIDIA/trt-llm-release-branch-approval
+
+# The rule below requires that any PR modifying public APIs must be approved by at least one member
+# of the NVIDIA/trt-llm-committed-api-review-committee or NVIDIA/trt-llm-noncommitted-api-review-committee team.
+# This approval is mandatory regardless of other approvals the PR may have received. Without approval
+# from a member of this team, PRs affecting public APIs cannot be merged to main or release branches.
+/tests/unittest/api_stability/ @NVIDIA/trt-llm-committed-api-review-committee
+/tests/unittest/api_stability/references_committed/ @NVIDIA/trt-llm-committed-api-review-committee
+/tests/unittest/api_stability/references/ @NVIDIA/trt-llm-noncommitted-api-review-committee

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,5 @@
 # of the NVIDIA/trt-llm-committed-api-review-committee or NVIDIA/trt-llm-noncommitted-api-review-committee team.
 # This approval is mandatory regardless of other approvals the PR may have received. Without approval
 # from a member of this team, PRs affecting public APIs cannot be merged to main or release branches.
-/tests/unittest/api_stability/ @NVIDIA/trt-llm-committed-api-review-committee
+/tests/unittest/api_stability/ @NVIDIA/trt-llm-noncommitted-api-review-committee
 /tests/unittest/api_stability/references_committed/ @NVIDIA/trt-llm-committed-api-review-committee
-/tests/unittest/api_stability/references/ @NVIDIA/trt-llm-noncommitted-api-review-committee


### PR DESCRIPTION
Update CODEOWNERS to enforce API review requirements

- Add rules requiring API review committee approval for public API changes
- Separate rules for committed and non-committed API references