### PR TITLE
fix: change pp broadcast pattern for LPs

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1165,24 +1165,38 @@ class PyExecutor:
                             req_id)
 
     @nvtx_range("_broadcast_new_requests")
-    def _broadcast_new_requests(self, new_requests):
+    def _broadcast_new_requests(self,
+                                new_requests: List[ExecutorRequest],
+                                py_request_objects: tuple[str, dict] = None):
+        """Broadcasts new_requests and optional Python-only metadata (`py_request_objects`) across pipeline stages.
+           `py_request_objects` is a tuple of (attribute_name, {request_id: object}).
+        """
+        if py_request_objects is None:
+            payloads = new_requests
+            has_additional_py_objs = 0
+        else:
+            payloads = (new_requests, py_request_objects)
+            has_additional_py_objs = 1
+
         if not self.dist.has_pp:
-            return self.dist.broadcast(new_requests, root=0)
+            return self.dist.broadcast(payloads, root=0)
 
         # broadcast within first tp group before send/recv chain to other tp groups
         if self.dist.tp_size > 1 and self.dist.is_first_pp_rank:
-            new_requests = self.dist.tp_broadcast(new_requests, root=0)
+            payloads = self.dist.tp_broadcast(payloads, root=0)
 
         # tag = [0, num_micro_batches - 1] used for new_tokens send/recv
         tag = self.num_micro_batches
 
         # 1. send metadata: len(num_requests) and serialized buffer size
+        new_requests = payloads if not has_additional_py_objs else payloads[0]
         if self.dist.is_first_pp_rank and len(new_requests) > 0:
-            buf = np.array(bytearray(dill.dumps(new_requests)))
+            buf = np.array(bytearray(dill.dumps(payloads)))
             buf_size = len(buf)
         else:
             buf, buf_size = None, 0
-        metadata_arr = np.array([len(new_requests), buf_size])
+        metadata_arr = np.array(
+            [len(new_requests), buf_size, has_additional_py_objs])
 
         if not self.dist.is_first_pp_rank:
             self.dist.recv(metadata_arr, self.dist.prev_pp_rank, tag)
@@ -1202,10 +1216,17 @@ class PyExecutor:
                 self.dist.send(buf, self.dist.next_pp_rank, tag)
 
             if not self.dist.is_first_pp_rank:
-                new_requests = dill.loads(buf.tobytes())  # nosec B301
+                buf_data = dill.loads(buf.tobytes())  # nosec B301
+                has_additional_py_objs = metadata_arr[2]
+                if has_additional_py_objs:
+                    new_requests, py_request_objects = buf_data
+                else:
+                    new_requests = buf_data
+
                 assert len(new_requests) == num_new_requests
 
-        return new_requests
+        return new_requests if py_request_objects is None else (
+            new_requests, py_request_objects)
 
     @nvtx_range("_fetch_new_requests")
     def _fetch_new_requests(self):
@@ -1233,11 +1254,14 @@ class PyExecutor:
         if self.dist.rank == 0 and not self.dist.has_pp:
             # Preserve original `new_requests` on rank 0 since it may contain
             # Python-only objects (e.g., custom logits processors) not serializable by pybind.
-            _ = self._broadcast_new_requests(new_requests)
+            _ = self._broadcast_new_requests(new_requests, py_request_objects)
         else:
-            new_requests = self._broadcast_new_requests(new_requests)
-
-        py_request_objects = self.dist.broadcast(py_request_objects, root=0)
+            received_payload = self._broadcast_new_requests(
+                new_requests, py_request_objects)
+            if isinstance(received_payload, tuple):
+                new_requests, py_request_objects = received_payload
+            else:
+                new_requests = received_payload
 
         if py_request_objects and (self.dist.tp_size > 1
                                    or self.dist.has_pp) and self.dist.rank > 0:


### PR DESCRIPTION
## Description

Previously in https://github.com/NVIDIA/TensorRT-LLM/pull/3145, we broadcast all user-defined and pure-Python LogitProcessor functions (non-serializable w/ request's pybind object) to all ranks. In the case where LogitsProcessors are not present, there's still an empty broadcast (broadcasting `None`) to notify other ranks. 

This has caused bubbles in PP micro batching (e.g., with llama-2-70b and PP=4). This fix is to remove the broadcast but instead use `send/recv()` to pass down Py objects sequentially in PP ranks as the current PP communication pattern does. 


## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
