### PR TITLE
infra: WAR for Argument list too long of globalVars[CACHED_CHANGED_FILE_LIST]

### DIFF
--- a/jenkins/L0_MergeRequest.groovy
+++ b/jenkins/L0_MergeRequest.groovy
@@ -1025,7 +1025,7 @@ pipeline {
                         }
                     } else {
                         // WAR for "Argument list too long" error
-                        globalVars[CACHED_CHANGED_FILE_LIST] = []
+                        globalVars[CACHED_CHANGED_FILE_LIST] = null
                         launchStages(this, reuseBuild, testFilter, enableFailFast, globalVars)
                     }
                 }

--- a/jenkins/L0_MergeRequest.groovy
+++ b/jenkins/L0_MergeRequest.groovy
@@ -1024,7 +1024,8 @@ pipeline {
                             }
                         }
                     } else {
-                        // WAR for "Argument list too long" error
+                        // globalVars[CACHED_CHANGED_FILE_LIST] is only used in setupPipelineEnvironment
+                        // Reset it to null to workaround the "Argument list too long" error
                         globalVars[CACHED_CHANGED_FILE_LIST] = null
                         launchStages(this, reuseBuild, testFilter, enableFailFast, globalVars)
                     }

--- a/jenkins/L0_MergeRequest.groovy
+++ b/jenkins/L0_MergeRequest.groovy
@@ -1024,6 +1024,8 @@ pipeline {
                             }
                         }
                     } else {
+                        // WAR for "Argument list too long" error
+                        globalVars[CACHED_CHANGED_FILE_LIST] = []
                         launchStages(this, reuseBuild, testFilter, enableFailFast, globalVars)
                     }
                 }


### PR DESCRIPTION
fix the error of this : https://prod.blsm.nvidia.com/sw-tensorrt-top-1/blue/organizations/jenkins/LLM%2Fhelpers%2FBuild-SBSA/detail/Build-SBSA/14643/pipeline/

Caused by: java.io.IOException: error=7, Argument list too long
	at java.base/java.lang.ProcessImpl.forkAndExec(Native Method)
	at java.base/java.lang.ProcessImpl.<init>(ProcessImpl.java:340)
	at java.base/java.lang.ProcessImpl.start(ProcessImpl.java:271)
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1107)
	... 19 more