### PR TITLE
enh: Enable option in trtllm-bench build subcommand to avoid loading weights

### DIFF
--- a/tensorrt_llm/bench/build/build.py
+++ b/tensorrt_llm/bench/build/build.py
@@ -163,8 +163,7 @@ def apply_build_mode_settings(params):
     type=bool,
     default=False,
     help=
-    "Do not load the weights from the checkpoint. Use dummy weights instead."
-)
+    "Do not load the weights from the checkpoint. Use dummy weights instead.")
 @optgroup.group(
     "Build Engine with Dataset Information",
     cls=AllOptionGroup,

--- a/tensorrt_llm/bench/build/build.py
+++ b/tensorrt_llm/bench/build/build.py
@@ -158,6 +158,13 @@ def apply_build_mode_settings(params):
     type=click.IntRange(min=1),
     help="Maximum total length of one request, including prompt and outputs.",
 )
+@optgroup.option(
+    "--no_weights_loading",
+    type=bool,
+    default=False,
+    help=
+    "Do not load the weights from the checkpoint. Use dummy weights instead."
+)
 @optgroup.group(
     "Build Engine with Dataset Information",
     cls=AllOptionGroup,
@@ -231,6 +238,7 @@ def build_command(
     target_input_len: int = params.get("target_input_len")
     target_output_len: int = params.get("target_output_len")
 
+    load_format = "dummy" if params.get("no_weights_loading") else "auto"
     model_name = bench_env.model
     checkpoint_path = bench_env.checkpoint_path or model_name
     model_config = get_model_config(model_name, bench_env.checkpoint_path)
@@ -307,7 +315,8 @@ def build_command(
               pipeline_parallel_size=pp_size,
               build_config=build_config,
               quant_config=quant_config,
-              workspace=str(bench_env.workspace))
+              workspace=str(bench_env.workspace),
+              load_format=load_format)
     # Save the engine.
     llm.save(engine_dir)
     llm.shutdown()


### PR DESCRIPTION
# PR title

Enable option in trtllm-bench build subcommand to avoid loading weights.

* Although measuring perf numbers with dummy weights is not recommended, for some cases when we just want to pipeclean or debug orthogonal parts with trtllm-bench build subcommand being the entry-point, we don't want to waste time waiting for the safetensors to load to memory (that's probably irrelevant to our objective).
* This shaves off several minutes of iterations - something like ~7 minutes on a 253B model by avoiding all those shards.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
