### PR TITLE
[TRTLLM-5007][feat] Add multimodal hashing support (image hashing)

### DIFF
--- a/benchmarks/cpp/disaggServerBenchmark.cpp
+++ b/benchmarks/cpp/disaggServerBenchmark.cpp
@@ -534,6 +534,7 @@ texec::Request makeExecutorContextRequest(Sample const& sample, SizeType32 const
             std::nullopt,    // embeddingBias
             std::nullopt,    // speculativeDecoding
             std::nullopt,    // pTuning
+            std::nullopt,    // multimodalInput
             std::nullopt,    // multimodalEmbedding
             std::nullopt,    // mRopeConfig
             loraConfig,      // loraConfig

--- a/benchmarks/cpp/gptManagerBenchmark.cpp
+++ b/benchmarks/cpp/gptManagerBenchmark.cpp
@@ -829,6 +829,7 @@ texec::Request makeExecutorRequest(Sample const& sample, SizeType32 const& beamW
         std::nullopt,    // embeddingBias
         std::nullopt,    // speculativeDecoding
         std::nullopt,    // pTuning
+        std::nullopt,    // multimodalInput
         std::nullopt,    // multimodalEmbedding
         std::nullopt,    // mRopeConfig
         loraConfig,      // loraConfig

--- a/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
+++ b/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
@@ -98,7 +98,7 @@ public:
     using RequestPtr = std::shared_ptr<GenericLlmRequest>;
     using MillisecondsType = std::chrono::milliseconds;
 
-    // 46 parameters, 53 items in initialization list
+    // 49 parameters, 56 items in initialization list
     GenericLlmRequest(RequestIdType requestId, SizeType32 maxNewTokens, std::shared_ptr<VecTokens> const& inputTokens,
         runtime::SamplingConfig const& samplingConfig, bool isStreaming, std::optional<SizeType32> endId = std::nullopt,
         std::optional<SizeType32> padId = std::nullopt, std::optional<TensorPtr> embeddingBias = std::nullopt,
@@ -106,6 +106,9 @@ public:
         std::optional<std::shared_ptr<std::vector<SizeType32>>> positionIds = std::nullopt,
         std::optional<TensorPtr> promptEmbeddingTable = std::nullopt,
         std::optional<SizeType32> promptVocabSize = std::nullopt,
+        std::optional<std::shared_ptr<std::vector<std::vector<SizeType32>>>> multimodalHashes = std::nullopt,
+        std::optional<std::shared_ptr<std::vector<SizeType32>>> multimodalPositions = std::nullopt,
+        std::optional<std::shared_ptr<std::vector<SizeType32>>> multimodalLengths = std::nullopt,
         std::optional<TensorPtr> multimodalEmbedding = std::nullopt,
         std::optional<TensorPtr> mropeRotaryCosSin = std::nullopt,
         std::optional<SizeType32> mropePositionDeltas = std::nullopt,
@@ -151,6 +154,9 @@ public:
         , mPositionIds(std::move(positionIds))
         , mPromptEmbeddingTable(std::move(promptEmbeddingTable))
         , mPromptVocabSize(promptVocabSize)
+        , mMultimodalHashes(std::move(multimodalHashes))
+        , mMultimodalPositions(std::move(multimodalPositions))
+        , mMultimodalLengths(std::move(multimodalLengths))
         , mMultimodalEmbedding(std::move(multimodalEmbedding))
         , mMropeRotaryCosSin(std::move(mropeRotaryCosSin))
         , mMropePositionDeltas(mropePositionDeltas)
@@ -853,6 +859,21 @@ public:
     [[nodiscard]] std::optional<SizeType32> getPromptVocabSize() const
     {
         return mPromptVocabSize;
+    }
+
+    [[nodiscard]] std::optional<std::shared_ptr<std::vector<std::vector<SizeType32>>>> getMultimodalHashes() const
+    {
+        return mMultimodalHashes;
+    }
+
+    [[nodiscard]] std::optional<std::shared_ptr<std::vector<SizeType32>>> getMultimodalPositions() const
+    {
+        return mMultimodalPositions;
+    }
+
+    [[nodiscard]] std::optional<std::shared_ptr<std::vector<SizeType32>>> getMultimodalLengths() const
+    {
+        return mMultimodalLengths;
     }
 
     [[nodiscard]] std::optional<TensorPtr> getMultimodalEmbedding() const
@@ -1868,6 +1889,9 @@ protected:
 
     std::optional<TensorPtr> mPromptEmbeddingTable{std::nullopt};
     std::optional<SizeType32> mPromptVocabSize{std::nullopt};
+    std::optional<std::shared_ptr<std::vector<std::vector<SizeType32>>>> mMultimodalHashes{std::nullopt};
+    std::optional<std::shared_ptr<std::vector<SizeType32>>> mMultimodalPositions{std::nullopt};
+    std::optional<std::shared_ptr<std::vector<SizeType32>>> mMultimodalLengths{std::nullopt};
     std::optional<TensorPtr> mMultimodalEmbedding{std::nullopt};
     std::optional<TensorPtr> mMropeRotaryCosSin{std::nullopt};
     std::optional<SizeType32> mMropePositionDeltas{std::nullopt};
@@ -2127,7 +2151,7 @@ public:
     using TokenExtraIdType = Base::TokenExtraIdType;
     using VecTokenExtraIds = Base::VecTokenExtraIds;
 
-    // 46 parameters, 46 parameters in Base class constructor
+    // 49 parameters, 49 parameters in Base class constructor
     LlmRequest(RequestIdType requestId, SizeType32 maxNewTokens, std::shared_ptr<VecTokens> inputTokens,
         runtime::SamplingConfig const& samplingConfig, bool isStreaming, std::optional<SizeType32> endId = std::nullopt,
         std::optional<SizeType32> padId = std::nullopt, std::optional<TensorPtr> embeddingBias = std::nullopt,
@@ -2135,6 +2159,9 @@ public:
         std::optional<std::shared_ptr<std::vector<SizeType32>>> positionIds = std::nullopt,
         std::optional<TensorPtr> promptEmbeddingTable = std::nullopt,
         std::optional<SizeType32> promptVocabSize = std::nullopt,
+        std::optional<std::shared_ptr<std::vector<std::vector<SizeType32>>>> multimodalHashes = std::nullopt,
+        std::optional<std::shared_ptr<std::vector<SizeType32>>> multimodalPositions = std::nullopt,
+        std::optional<std::shared_ptr<std::vector<SizeType32>>> multimodalLengths = std::nullopt,
         std::optional<TensorPtr> multimodalEmbedding = std::nullopt,
         std::optional<TensorPtr> mropeRotaryCosSin = std::nullopt,
         std::optional<SizeType32> mropePositionDeltas = std::nullopt,
@@ -2163,7 +2190,8 @@ public:
         std::optional<executor::ContextPhaseParams> const& contextPhaseParams = std::nullopt)
         : Base(requestId, maxNewTokens, std::move(inputTokens), samplingConfig, isStreaming, endId, padId,
             std::move(embeddingBias), std::move(badWordsList), std::move(stopWordsList), std::move(positionIds),
-            std::move(promptEmbeddingTable), promptVocabSize, std::move(multimodalEmbedding),
+            std::move(promptEmbeddingTable), promptVocabSize, std::move(multimodalHashes),
+            std::move(multimodalPositions), std::move(multimodalLengths), std::move(multimodalEmbedding),
             std::move(mropeRotaryCosSin), mropePositionDeltas, loraTaskId, std::move(loraWeights),
             std::move(loraConfig), std::move(lookaheadConfig), std::move(kvCacheRetentionConfig), returnLogProbs,
             returnContextLogits, returnGenerationLogits, std::move(draftTokens), std::move(draftLogits),
@@ -2175,7 +2203,7 @@ public:
     {
     }
 
-    // 46 parameters, 46 parameters in Base class constructor
+    // 49 parameters, 49 parameters in Base class constructor
     LlmRequest(RequestIdType requestId, SizeType32 maxNewTokens, std::vector<TokenIdType> inputTokens,
         runtime::SamplingConfig const& samplingConfig, bool isStreaming, std::optional<SizeType32> endId = std::nullopt,
         std::optional<SizeType32> padId = std::nullopt, std::optional<TensorPtr> embeddingBias = std::nullopt,
@@ -2183,6 +2211,9 @@ public:
         std::optional<std::vector<SizeType32>> positionIds = std::nullopt,
         std::optional<TensorPtr> promptEmbeddingTable = std::nullopt,
         std::optional<SizeType32> promptVocabSize = std::nullopt,
+        std::optional<std::vector<std::vector<SizeType32>>> multimodalHashes = std::nullopt,
+        std::optional<std::vector<SizeType32>> multimodalPositions = std::nullopt,
+        std::optional<std::vector<SizeType32>> multimodalLengths = std::nullopt,
         std::optional<TensorPtr> multimodalEmbedding = std::nullopt,
         std::optional<TensorPtr> mropeRotaryCosSin = std::nullopt,
         std::optional<SizeType32> mropePositionDeltas = std::nullopt,
@@ -2212,10 +2243,19 @@ public:
             std::move(stopWordsList),
             positionIds.has_value() ? std::make_shared<std::vector<SizeType32>>(std::move(positionIds.value()))
                                     : std::optional<std::shared_ptr<std::vector<SizeType32>>>(std::nullopt),
-            std::move(promptEmbeddingTable), promptVocabSize, std::move(multimodalEmbedding),
-            std::move(mropeRotaryCosSin), mropePositionDeltas, loraTaskId, std::move(loraWeights),
-            std::move(loraConfig), lookaheadConfig, std::move(kvCacheRetentionConfig), returnLogProbs,
-            returnContextLogits, returnGenerationLogits,
+            std::move(promptEmbeddingTable), promptVocabSize,
+            multimodalHashes.has_value()
+                ? std::make_shared<std::vector<std::vector<SizeType32>>>(std::move(multimodalHashes.value()))
+                : std::optional<std::shared_ptr<std::vector<std::vector<SizeType32>>>>(std::nullopt),
+            multimodalPositions.has_value()
+                ? std::make_shared<std::vector<SizeType32>>(std::move(multimodalPositions.value()))
+                : std::optional<std::shared_ptr<std::vector<SizeType32>>>(std::nullopt),
+            multimodalLengths.has_value()
+                ? std::make_shared<std::vector<SizeType32>>(std::move(multimodalLengths.value()))
+                : std::optional<std::shared_ptr<std::vector<SizeType32>>>(std::nullopt),
+            std::move(multimodalEmbedding), std::move(mropeRotaryCosSin), mropePositionDeltas, loraTaskId,
+            std::move(loraWeights), std::move(loraConfig), lookaheadConfig, std::move(kvCacheRetentionConfig),
+            returnLogProbs, returnContextLogits, returnGenerationLogits,
             draftTokens.has_value() ? std::make_shared<VecTokens>(std::move(draftTokens.value()))
                                     : std::make_shared<VecTokens>(),
             std::move(draftLogits), excludeInputFromOutput, std::move(logitsPostProcessor),

--- a/cpp/include/tensorrt_llm/executor/executor.h
+++ b/cpp/include/tensorrt_llm/executor/executor.h
@@ -282,6 +282,27 @@ private:
     std::optional<VecTokenExtraIds> mInputTokenExtraIds;
 };
 
+/// @brief Multimodal input data class
+class MultimodalInput
+{
+public:
+    explicit MultimodalInput(std::vector<std::vector<SizeType32>> multimodalHashes,
+        std::vector<SizeType32> multimodalPositions, std::vector<SizeType32> multimodalLengths);
+
+    [[nodiscard]] std::vector<std::vector<SizeType32>> getMultimodalHashes() const;
+    [[nodiscard]] std::vector<SizeType32> getMultimodalPositions() const;
+    [[nodiscard]] std::vector<SizeType32> getMultimodalLengths() const;
+
+private:
+    friend class Serialization;
+    /// @brief The multimodal hashes
+    std::vector<std::vector<SizeType32>> mMultimodalHashes;
+    /// @brief The multimodal positions
+    std::vector<SizeType32> mMultimodalPositions;
+    /// @brief The multimodal lengths
+    std::vector<SizeType32> mMultimodalLengths;
+};
+
 /// @brief Configuration for mrope
 class MropeConfig
 {
@@ -619,6 +640,7 @@ public:
     /// @param embeddingBias The embedding bias tensor. Expected shape is [vocab_size]
     /// @param externalDraftTokensConfig The speculative decoding with external draft tokens configuration
     /// @param pTuningConfig The prompt tuning configuration
+    /// @param multimodalInput The multimodal input {multimodalHashes, multimodalPositions, multimodalLengths}
     /// @param multimodalEmbedding The multimodal embedding tensor. Expected shape is [num_multimodal_tokens,
     /// hidden_dim]
     /// @param mRopeConfig The mrope configuration
@@ -658,6 +680,7 @@ public:
         std::optional<Tensor> embeddingBias = std::nullopt,
         std::optional<ExternalDraftTokensConfig> externalDraftTokensConfig = std::nullopt,
         std::optional<PromptTuningConfig> pTuningConfig = std::nullopt,
+        std::optional<MultimodalInput> multimodalInput = std::nullopt,
         std::optional<Tensor> multimodalEmbedding = std::nullopt, std::optional<MropeConfig> mRopeConfig = std::nullopt,
         std::optional<LoraConfig> loraConfig = std::nullopt,
         std::optional<LookaheadDecodingConfig> lookaheadConfig = std::nullopt,
@@ -700,6 +723,7 @@ public:
     [[nodiscard]] std::optional<Tensor> getEmbeddingBias() const;
     [[nodiscard]] std::optional<ExternalDraftTokensConfig> getExternalDraftTokensConfig() const;
     [[nodiscard]] std::optional<PromptTuningConfig> getPromptTuningConfig() const;
+    [[nodiscard]] std::optional<MultimodalInput> getMultimodalInput() const;
     [[nodiscard]] std::optional<Tensor> getMultimodalEmbedding() const;
     [[nodiscard]] std::optional<MropeConfig> getMropeConfig() const;
     [[nodiscard]] std::optional<LoraConfig> getLoraConfig() const;
@@ -735,6 +759,7 @@ public:
     void setExternalDraftTokensConfig(ExternalDraftTokensConfig const& externalDraftTokensConfig);
     void setPromptTuningConfig(PromptTuningConfig const& pTuningConfig);
     void setMultimodalEmbedding(Tensor const& multimodalEmbedding);
+    void setMultimodalInput(MultimodalInput const& multimodalInput);
     void setMropeConfig(MropeConfig const& mRopeConfig);
     void setLoraConfig(LoraConfig const& loraConfig);
     void setLookaheadConfig(LookaheadDecodingConfig const& lookaheadConfig);

--- a/cpp/include/tensorrt_llm/executor/serialization.h
+++ b/cpp/include/tensorrt_llm/executor/serialization.h
@@ -71,6 +71,11 @@ public:
     static void serialize(PromptTuningConfig const& config, std::ostream& os);
     [[nodiscard]] static size_t serializedSize(PromptTuningConfig const& config);
 
+    // MultimodalInput
+    [[nodiscard]] static MultimodalInput deserializeMultimodalInput(std::istream& is);
+    static void serialize(MultimodalInput const& multimodalInput, std::ostream& os);
+    [[nodiscard]] static size_t serializedSize(MultimodalInput const& multimodalInput);
+
     // MropeConfig
     [[nodiscard]] static MropeConfig deserializeMropeConfig(std::istream& is);
     static void serialize(MropeConfig const& config, std::ostream& os);

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -120,7 +120,7 @@ size_t BlockKeyHasher::hash(BlockKey const& blockKey, std::size_t parentHash) no
         c = c ^ (c >> 31);
         seed ^= c + 0x9e3779b9 + (seed << 6) + (seed >> 2);
     }
-
+    // TODO: support external hashes for multimodal
     return seed;
 }
 

--- a/cpp/tensorrt_llm/executor/CMakeLists.txt
+++ b/cpp/tensorrt_llm/executor/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SRCS
     peftCacheConfig.cpp
     promptTuningConfig.cpp
     mropeConfig.cpp
+    multimodalInput.cpp
     request.cpp
     requestUtils.cpp
     requestWithId.cpp

--- a/cpp/tensorrt_llm/executor/multimodalInput.cpp
+++ b/cpp/tensorrt_llm/executor/multimodalInput.cpp
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tensorrt_llm/executor/executor.h"
+#include "tensorrt_llm/executor/types.h"
+
+namespace tensorrt_llm::executor
+{
+MultimodalInput::MultimodalInput(std::vector<std::vector<SizeType32>> multimodalHashes,
+    std::vector<SizeType32> multimodalPositions, std::vector<SizeType32> multimodalLengths)
+    : mMultimodalHashes(std::move(multimodalHashes))
+    , mMultimodalPositions(std::move(multimodalPositions))
+    , mMultimodalLengths(std::move(multimodalLengths))
+{
+}
+
+std::vector<std::vector<SizeType32>> MultimodalInput::getMultimodalHashes() const
+{
+    return mMultimodalHashes;
+}
+
+std::vector<SizeType32> MultimodalInput::getMultimodalPositions() const
+{
+    return mMultimodalPositions;
+}
+
+std::vector<SizeType32> MultimodalInput::getMultimodalLengths() const
+{
+    return mMultimodalLengths;
+}
+
+} // namespace tensorrt_llm::executor

--- a/cpp/tensorrt_llm/executor/request.cpp
+++ b/cpp/tensorrt_llm/executor/request.cpp
@@ -25,14 +25,15 @@
 
 namespace tensorrt_llm::executor
 {
-// 35 parameters
+// 36 parameters
 Request::Request(VecTokens inputTokenIds, SizeType32 maxTokens, bool streaming, SamplingConfig const& samplingConfig,
     OutputConfig const& outputConfig, std::optional<SizeType32> const& endId, std::optional<SizeType32> const& padId,
     std::optional<std::vector<SizeType32>> positionIds, std::optional<std::list<VecTokens>> badWords,
     std::optional<std::list<VecTokens>> stopWords, std::optional<Tensor> embeddingBias,
     std::optional<ExternalDraftTokensConfig> externalDraftTokensConfig, std::optional<PromptTuningConfig> pTuningConfig,
-    std::optional<Tensor> multimodalEmbedding, std::optional<MropeConfig> mRopeConfig,
-    std::optional<LoraConfig> loraConfig, std::optional<LookaheadDecodingConfig> lookaheadConfig,
+    std::optional<MultimodalInput> multimodalInput, std::optional<Tensor> multimodalEmbedding,
+    std::optional<MropeConfig> mRopeConfig, std::optional<LoraConfig> loraConfig,
+    std::optional<LookaheadDecodingConfig> lookaheadConfig,
     std::optional<KvCacheRetentionConfig> kvCacheRetentionConfig, std::optional<std::string> logitsPostProcessorName,
     std::optional<LogitsPostProcessor> logitslogitsPostProcessor, std::optional<VecTokens> encoderInputTokenIds,
     std::optional<IdType> clientId, bool returnAllGeneratedTokens, float priority, RequestType type,
@@ -43,12 +44,13 @@ Request::Request(VecTokens inputTokenIds, SizeType32 maxTokens, bool streaming, 
     std::optional<MillisecondsType> allottedTimeMs)
     : mImpl(std::make_unique<Impl>(std::move(inputTokenIds), maxTokens, streaming, samplingConfig, outputConfig, endId,
         padId, std::move(positionIds), std::move(badWords), std::move(stopWords), std::move(embeddingBias),
-        std::move(externalDraftTokensConfig), std::move(pTuningConfig), std::move(multimodalEmbedding),
-        std::move(mRopeConfig), std::move(loraConfig), lookaheadConfig, std::move(kvCacheRetentionConfig),
-        std::move(logitsPostProcessorName), std::move(logitslogitsPostProcessor), std::move(encoderInputTokenIds),
-        clientId, returnAllGeneratedTokens, priority, type, std::move(contextPhaseParams),
-        std::move(encoderInputFeatures), encoderOutputLength, crossAttentionMask, numReturnSequences, eagleConfig,
-        skipCrossAttnBlocks, std::move(guidedDecodingParams), languageAdapterUid, allottedTimeMs))
+        std::move(externalDraftTokensConfig), std::move(pTuningConfig), std::move(multimodalInput),
+        std::move(multimodalEmbedding), std::move(mRopeConfig), std::move(loraConfig), lookaheadConfig,
+        std::move(kvCacheRetentionConfig), std::move(logitsPostProcessorName), std::move(logitslogitsPostProcessor),
+        std::move(encoderInputTokenIds), clientId, returnAllGeneratedTokens, priority, type,
+        std::move(contextPhaseParams), std::move(encoderInputFeatures), encoderOutputLength, crossAttentionMask,
+        numReturnSequences, eagleConfig, skipCrossAttnBlocks, std::move(guidedDecodingParams), languageAdapterUid,
+        allottedTimeMs))
 {
 }
 
@@ -140,6 +142,11 @@ std::optional<PromptTuningConfig> Request::getPromptTuningConfig() const
 std::optional<Tensor> Request::getMultimodalEmbedding() const
 {
     return mImpl->getMultimodalEmbedding();
+}
+
+std::optional<MultimodalInput> Request::getMultimodalInput() const
+{
+    return mImpl->getMultimodalInput();
 }
 
 std::optional<MropeConfig> Request::getMropeConfig() const
@@ -300,6 +307,11 @@ void Request::setPromptTuningConfig(PromptTuningConfig const& pTuningConfig)
 void Request::setMultimodalEmbedding(Tensor const& multimodalEmbedding)
 {
     return mImpl->setMultimodalEmbedding(multimodalEmbedding);
+}
+
+void Request::setMultimodalInput(MultimodalInput const& multimodalInput)
+{
+    return mImpl->setMultimodalInput(multimodalInput);
 }
 
 void Request::setMropeConfig(MropeConfig const& mRopeConfig)

--- a/cpp/tensorrt_llm/executor/requestImpl.h
+++ b/cpp/tensorrt_llm/executor/requestImpl.h
@@ -32,15 +32,15 @@ class Request::Impl
 {
 
 public:
-    // 35 parameters, 35 items in initialization list
+    // 36 parameters, 36 items in initialization list
     Impl(VecTokens inputTokenIds, SizeType32 maxNewTokens, bool streaming, SamplingConfig const& samplingConfig,
         OutputConfig outputConfig, std::optional<TokenIdType> const& endId, std::optional<TokenIdType> const& padId,
         std::optional<std::vector<SizeType32>> positionIds, std::optional<std::list<VecTokens>> badWords,
         std::optional<std::list<VecTokens>> stopWords, std::optional<Tensor> embeddingBias,
         std::optional<ExternalDraftTokensConfig> externalDraftTokensConfig,
-        std::optional<PromptTuningConfig> pTuningConfig, std::optional<Tensor> multimodalEmbedding,
-        std::optional<MropeConfig> mRopeConfig, std::optional<LoraConfig> loraConfig,
-        std::optional<LookaheadDecodingConfig> lookaheadConfig,
+        std::optional<PromptTuningConfig> pTuningConfig, std::optional<MultimodalInput> multimodalInput,
+        std::optional<Tensor> multimodalEmbedding, std::optional<MropeConfig> mRopeConfig,
+        std::optional<LoraConfig> loraConfig, std::optional<LookaheadDecodingConfig> lookaheadConfig,
         std::optional<KvCacheRetentionConfig> kvCacheRetentionConfig,
         std::optional<std::string> logitsPostProcessorName, std::optional<LogitsPostProcessor> logitsPostProcessor,
         std::optional<VecTokens> encoderInputTokenIds, std::optional<IdType> clientId, bool returnAllGeneratedTokens,
@@ -62,6 +62,7 @@ public:
         , mEmbeddingBias(checkEmbeddingBias(std::move(embeddingBias)))
         , mExternalDraftTokensConfig(std::move(externalDraftTokensConfig))
         , mPTuningConfig(std::move(pTuningConfig))
+        , mMultimodalInput(std::move(multimodalInput))
         , mMultimodalEmbedding(std::move(multimodalEmbedding))
         , mMropeConfig(std::move(mRopeConfig))
         , mLoraConfig(std::move(loraConfig))
@@ -180,6 +181,11 @@ public:
     [[nodiscard]] std::optional<Tensor> getMultimodalEmbedding() const
     {
         return mMultimodalEmbedding;
+    }
+
+    [[nodiscard]] std::optional<MultimodalInput> getMultimodalInput() const
+    {
+        return mMultimodalInput;
     }
 
     [[nodiscard]] std::optional<MropeConfig> getMropeConfig() const
@@ -350,6 +356,11 @@ public:
         mMultimodalEmbedding = multimodalEmbedding;
     }
 
+    void setMultimodalInput(MultimodalInput const& multimodalInput)
+    {
+        mMultimodalInput = multimodalInput;
+    }
+
     void setMropeConfig(MropeConfig const& mRopeConfig)
     {
         mMropeConfig = mRopeConfig;
@@ -510,6 +521,7 @@ private:
         lambda(mEmbeddingBias);
         lambda(mExternalDraftTokensConfig);
         lambda(mPTuningConfig);
+        lambda(mMultimodalInput);
         lambda(mMultimodalEmbedding);
         lambda(mMropeConfig);
         lambda(mLoraConfig);
@@ -546,6 +558,7 @@ private:
     std::optional<Tensor> mEmbeddingBias;
     std::optional<ExternalDraftTokensConfig> mExternalDraftTokensConfig;
     std::optional<PromptTuningConfig> mPTuningConfig;
+    std::optional<MultimodalInput> mMultimodalInput;
     std::optional<Tensor> mMultimodalEmbedding;
     std::optional<MropeConfig> mMropeConfig;
     std::optional<LoraConfig> mLoraConfig;

--- a/cpp/tensorrt_llm/executor/serialization.cpp
+++ b/cpp/tensorrt_llm/executor/serialization.cpp
@@ -328,6 +328,31 @@ size_t Serialization::serializedSize(PromptTuningConfig const& config)
     return totalSize;
 }
 
+// MultimodalInput
+MultimodalInput Serialization::deserializeMultimodalInput(std::istream& is)
+{
+    auto multimodalHashes = su::deserialize<std::vector<std::vector<SizeType32>>>(is);
+    auto multimodalPositions = su::deserialize<std::vector<SizeType32>>(is);
+    auto multimodalLengths = su::deserialize<std::vector<SizeType32>>(is);
+    return MultimodalInput{std::move(multimodalHashes), std::move(multimodalPositions), std::move(multimodalLengths)};
+}
+
+void Serialization::serialize(MultimodalInput const& multimodalInput, std::ostream& os)
+{
+    su::serialize(multimodalInput.mMultimodalHashes, os);
+    su::serialize(multimodalInput.mMultimodalPositions, os);
+    su::serialize(multimodalInput.mMultimodalLengths, os);
+}
+
+size_t Serialization::serializedSize(MultimodalInput const& multimodalInput)
+{
+    size_t totalSize = 0;
+    totalSize += su::serializedSize(multimodalInput.mMultimodalHashes);
+    totalSize += su::serializedSize(multimodalInput.mMultimodalPositions);
+    totalSize += su::serializedSize(multimodalInput.mMultimodalLengths);
+    return totalSize;
+}
+
 // MropeConfig
 MropeConfig Serialization::deserializeMropeConfig(std::istream& is)
 {
@@ -657,6 +682,7 @@ Request Serialization::deserializeRequest(std::istream& is)
     auto embeddingBias = su::deserialize<std::optional<Tensor>>(is);
     auto externalDraftTokensConfig = su::deserialize<std::optional<ExternalDraftTokensConfig>>(is);
     auto pTuningConfig = su::deserialize<std::optional<PromptTuningConfig>>(is);
+    auto multimodalInput = su::deserialize<std::optional<MultimodalInput>>(is);
     auto multimodalEmbedding = su::deserialize<std::optional<Tensor>>(is);
     auto mRopeConfig = su::deserialize<std::optional<MropeConfig>>(is);
     auto loraConfig = su::deserialize<std::optional<LoraConfig>>(is);
@@ -682,15 +708,16 @@ Request Serialization::deserializeRequest(std::istream& is)
         ? std::optional<std::chrono::milliseconds>(std::chrono::milliseconds(*allottedTimeInt))
         : std::nullopt;
 
-    // 34 parameters
+    // 35 parameters
     return Request(std::move(inputTokenIds), maxNewTokens, streaming, samplingConfig, outputConfig, endId, padId,
         std::move(positionIds), std::move(badWords), std::move(stopWords), std::move(embeddingBias),
-        std::move(externalDraftTokensConfig), std::move(pTuningConfig), std::move(multimodalEmbedding),
-        std::move(mRopeConfig), std::move(loraConfig), lookaheadConfig, std::move(kvCacheRetentionConfig),
-        std::move(logitsPostProcessorName), std::nullopt, std::move(encoderInputTokenIds), clientId,
-        returnAllGeneratedTokens, priority, requestType, std::move(contextPhaseParams), std::move(encoderInputFeatures),
-        encoderOutputLength, std::move(crossAttentionMask), numReturnSequences, std::move(eagleConfig),
-        std::move(skipCrossAttnBlocks), std::move(guidedDecodingParams), languageAdapterUid, allottedTimeMs);
+        std::move(externalDraftTokensConfig), std::move(pTuningConfig), std::move(multimodalInput),
+        std::move(multimodalEmbedding), std::move(mRopeConfig), std::move(loraConfig), lookaheadConfig,
+        std::move(kvCacheRetentionConfig), std::move(logitsPostProcessorName), std::nullopt,
+        std::move(encoderInputTokenIds), clientId, returnAllGeneratedTokens, priority, requestType,
+        std::move(contextPhaseParams), std::move(encoderInputFeatures), encoderOutputLength,
+        std::move(crossAttentionMask), numReturnSequences, std::move(eagleConfig), std::move(skipCrossAttnBlocks),
+        std::move(guidedDecodingParams), languageAdapterUid, allottedTimeMs);
 }
 
 void Serialization::serialize(Request const& request, std::ostream& os)

--- a/cpp/tensorrt_llm/executor/serializeUtils.h
+++ b/cpp/tensorrt_llm/executor/serializeUtils.h
@@ -93,6 +93,7 @@ static_assert(hasSerializedSize<SamplingConfig>(size_t()));
 static_assert(hasSerializedSize<OutputConfig>(size_t()));
 static_assert(hasSerializedSize<AdditionalModelOutput>(size_t()));
 static_assert(hasSerializedSize<PromptTuningConfig>(size_t()));
+static_assert(hasSerializedSize<MultimodalInput>(size_t()));
 static_assert(hasSerializedSize<MropeConfig>(size_t()));
 static_assert(hasSerializedSize<LoraConfig>(size_t()));
 static_assert(hasSerializedSize<kv_cache::CommState>(size_t()));
@@ -190,6 +191,7 @@ static_assert(hasSerialize<SamplingConfig>(nullptr));
 static_assert(hasSerialize<OutputConfig>(nullptr));
 static_assert(hasSerialize<AdditionalModelOutput>(nullptr));
 static_assert(hasSerialize<PromptTuningConfig>(nullptr));
+static_assert(hasSerialize<MultimodalInput>(nullptr));
 static_assert(hasSerialize<MropeConfig>(nullptr));
 static_assert(hasSerialize<LoraConfig>(nullptr));
 static_assert(hasSerialize<ExternalDraftTokensConfig>(nullptr));
@@ -336,6 +338,10 @@ T deserialize(std::istream& is)
     else if constexpr (std::is_same_v<T, tensorrt_llm::executor::PromptTuningConfig>)
     {
         return Serialization::deserializePromptTuningConfig(is);
+    }
+    else if constexpr (std::is_same_v<T, tensorrt_llm::executor::MultimodalInput>)
+    {
+        return Serialization::deserializeMultimodalInput(is);
     }
     else if constexpr (std::is_same_v<T, tensorrt_llm::executor::MropeConfig>)
     {

--- a/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
@@ -191,6 +191,36 @@ void initBindings(pybind11::module_& m)
         .def_property_readonly("missed_blocks", &GenLlmReq::getMissedBlocksPerRequest)
         .def_property_readonly("kv_cache_hit_rate", &GenLlmReq::getKVCacheHitRatePerRequest)
         .def_property_readonly("llm_request_type", &GenLlmReq::getLlmRequestType)
+        .def_property_readonly("multimodal_hashes",
+            [](GenLlmReq& self)
+            {
+                std::optional<std::vector<std::vector<GenLlmReq::SizeType32>>> hashes = std::nullopt;
+                if (self.getMultimodalHashes())
+                {
+                    hashes = *self.getMultimodalHashes().value();
+                }
+                return hashes;
+            })
+        .def_property_readonly("multimodal_positions",
+            [](GenLlmReq& self)
+            {
+                std::optional<std::vector<GenLlmReq::SizeType32>> positions = std::nullopt;
+                if (self.getMultimodalPositions())
+                {
+                    positions = *self.getMultimodalPositions().value();
+                }
+                return positions;
+            })
+        .def_property_readonly("multimodal_lengths",
+            [](GenLlmReq& self)
+            {
+                std::optional<std::vector<GenLlmReq::SizeType32>> lengths = std::nullopt;
+                if (self.getMultimodalLengths())
+                {
+                    lengths = *self.getMultimodalLengths().value();
+                }
+                return lengths;
+            })
         .def_property_readonly("position_ids",
             [](GenLlmReq& self)
             {
@@ -230,6 +260,9 @@ void initBindings(pybind11::module_& m)
                      std::optional<std::vector<tb::LlmRequest::SizeType32>> position_ids,
                      std::optional<at::Tensor> prompt_embedding_table,
                      std::optional<tb::LlmRequest::SizeType32> prompt_vocab_size,
+                     std::optional<std::vector<std::vector<tb::LlmRequest::SizeType32>>> multimodal_hashes,
+                     std::optional<std::vector<tb::LlmRequest::SizeType32>> multimodal_positions,
+                     std::optional<std::vector<tb::LlmRequest::SizeType32>> multimodal_lengths,
                      std::optional<at::Tensor> multimodal_embedding, std::optional<at::Tensor> mrope_rotary_cos_sin,
                      std::optional<tb::LlmRequest::SizeType32> mrope_position_deltas,
                      std::optional<LoraTaskIdType> lora_task_id, std::optional<at::Tensor> lora_weights,
@@ -281,18 +314,19 @@ void initBindings(pybind11::module_& m)
                      auto cross_attention_mask_tensor_ptr = makeOptionalTensor(cross_attention_mask);
                      auto skip_cross_attn_blocks_tensor_ptr = makeOptionalTensor(skip_cross_attn_blocks);
 
-                     // 46 parameters
+                     // 49 parameters
                      return tb::LlmRequest{request_id, max_new_tokens, input_tokens, sampling_config, is_streaming,
                          end_id, pad_id, embedding_bias_tensor_ptr, bad_words_list_tensor_ptr,
                          stop_words_list_tensor_ptr, position_ids, prompt_embedding_table_tensor_ptr, prompt_vocab_size,
-                         multimodal_embedding_tensor_ptr, mrope_rotary_cos_sin_tensor_ptr, mrope_position_deltas,
-                         lora_task_id, lora_weights_tensor_ptr, lora_config_tensor_ptr, lookahead_config,
-                         kv_cache_retention_config, return_log_probs, return_context_logits, return_generation_logits,
-                         draft_tokens, draft_logits_tensor_ptr, exclude_input_from_output, logits_post_processor,
-                         apply_logits_post_processor_batched, encoder_input_tokens, return_encoder_output, client_id,
-                         priority, encoder_input_features_tensor_ptr, encoder_output_length,
-                         cross_attention_mask_tensor_ptr, llm_request_type, input_token_extra_ids, num_return_sequences,
-                         eagle_config, skip_cross_attn_blocks_tensor_ptr, return_perf_metrics, guided_decoding_params,
+                         multimodal_hashes, multimodal_positions, multimodal_lengths, multimodal_embedding_tensor_ptr,
+                         mrope_rotary_cos_sin_tensor_ptr, mrope_position_deltas, lora_task_id, lora_weights_tensor_ptr,
+                         lora_config_tensor_ptr, lookahead_config, kv_cache_retention_config, return_log_probs,
+                         return_context_logits, return_generation_logits, draft_tokens, draft_logits_tensor_ptr,
+                         exclude_input_from_output, logits_post_processor, apply_logits_post_processor_batched,
+                         encoder_input_tokens, return_encoder_output, client_id, priority,
+                         encoder_input_features_tensor_ptr, encoder_output_length, cross_attention_mask_tensor_ptr,
+                         llm_request_type, input_token_extra_ids, num_return_sequences, eagle_config,
+                         skip_cross_attn_blocks_tensor_ptr, return_perf_metrics, guided_decoding_params,
                          language_adapter_uid, allotted_time_ms, context_phase_params};
                  }),
             py::arg("request_id"), py::arg("max_new_tokens"), py::arg("input_tokens"), py::arg("sampling_config"),
@@ -300,18 +334,19 @@ void initBindings(pybind11::module_& m)
             py::arg("embedding_bias") = std::nullopt, py::arg("bad_words_list") = std::nullopt,
             py::arg("stop_words_list") = std::nullopt, py::arg("position_ids") = std::nullopt,
             py::arg("prompt_embedding_table") = std::nullopt, py::arg("prompt_vocab_size") = std::nullopt,
-            py::arg("multimodal_embedding") = std::nullopt, py::arg("mrope_rotary_cos_sin") = std::nullopt,
-            py::arg("mrope_position_deltas") = std::nullopt, py::arg("lora_task_id") = std::nullopt,
-            py::arg("lora_weights") = std::nullopt, py::arg("lora_config") = std::nullopt,
-            py::arg("lookahead_config") = std::nullopt, py::arg("kv_cache_retention_config") = std::nullopt,
-            py::arg("return_log_probs") = false, py::arg("return_context_logits") = false,
-            py::arg("return_generation_logits") = false, py::arg("draft_tokens") = std::nullopt,
-            py::arg("draft_logits") = std::nullopt, py::arg("exclude_input_from_output") = false,
-            py::arg("logits_post_processor") = std::nullopt, py::arg("apply_logits_post_processor_batched") = false,
-            py::arg("encoder_input_tokens") = std::nullopt, py::arg("return_encoder_output") = false,
-            py::arg("client_id") = std::nullopt, py::arg("priority") = executor::Request::kDefaultPriority,
-            py::arg("encoder_input_features") = std::nullopt, py::arg("encoder_output_len") = std::nullopt,
-            py::arg("cross_attention_mask") = std::nullopt,
+            py::arg("multimodal_hashes") = std::nullopt, py::arg("multimodal_positions") = std::nullopt,
+            py::arg("multimodal_lengths") = std::nullopt, py::arg("multimodal_embedding") = std::nullopt,
+            py::arg("mrope_rotary_cos_sin") = std::nullopt, py::arg("mrope_position_deltas") = std::nullopt,
+            py::arg("lora_task_id") = std::nullopt, py::arg("lora_weights") = std::nullopt,
+            py::arg("lora_config") = std::nullopt, py::arg("lookahead_config") = std::nullopt,
+            py::arg("kv_cache_retention_config") = std::nullopt, py::arg("return_log_probs") = false,
+            py::arg("return_context_logits") = false, py::arg("return_generation_logits") = false,
+            py::arg("draft_tokens") = std::nullopt, py::arg("draft_logits") = std::nullopt,
+            py::arg("exclude_input_from_output") = false, py::arg("logits_post_processor") = std::nullopt,
+            py::arg("apply_logits_post_processor_batched") = false, py::arg("encoder_input_tokens") = std::nullopt,
+            py::arg("return_encoder_output") = false, py::arg("client_id") = std::nullopt,
+            py::arg("priority") = executor::Request::kDefaultPriority, py::arg("encoder_input_features") = std::nullopt,
+            py::arg("encoder_output_len") = std::nullopt, py::arg("cross_attention_mask") = std::nullopt,
             py::arg_v("llm_request_type", tb::LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION,
                 "LlmRequestType.LLMREQUEST_TYPE_CONTEXT_AND_GENERATION"),
             py::arg("input_token_extra_ids") = std::nullopt, py::arg("num_return_sequences") = 1,

--- a/cpp/tensorrt_llm/pybind/batch_manager/llmRequest.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/llmRequest.cpp
@@ -75,7 +75,7 @@ std::shared_ptr<tb::LlmRequest> LlmRequest::toTrtLlm() const
         ? std::make_shared<std::vector<TokenIdType>>(*mEncoderTokens.value().get())
         : nullptr;
     auto const optEncoderInputTokens = std::optional<std::shared_ptr<std::vector<TokenIdType>>>(encoderInputTokens);
-    // 46 parameters
+    // 49 parameters
     return std::make_shared<tb::LlmRequest>(                       //
         mRequestId,                                                //
         mMaxNewTokens,                                             //
@@ -90,6 +90,9 @@ std::shared_ptr<tb::LlmRequest> LlmRequest::toTrtLlm() const
         mPositionIds,                                              //
         from_torch(mPromptEmbeddingTable),                         //
         mPromptVocabSize,                                          //
+        mMultimodalHashes,                                         //
+        mMultimodalPositions,                                      //
+        mMultimodalLengths,                                        //
         from_torch(mMultimodalEmbedding),                          //
         from_torch(mMropeRotaryCosSin),                            //
         mMropePositionDeltas,                                      //

--- a/cpp/tensorrt_llm/pybind/batch_manager/llmRequest.h
+++ b/cpp/tensorrt_llm/pybind/batch_manager/llmRequest.h
@@ -50,7 +50,7 @@ public:
     using VecTokenExtraIds = Base::VecTokenExtraIds;
     using LogitsPostProcessor = Base::LogitsPostProcessor;
 
-    // 46 parameters
+    // 49 parameters
     LlmRequest(RequestIdType requestId, SizeType32 maxNewTokens, std::vector<TokenIdType> inputTokens,
         runtime::SamplingConfig samplingConfig, bool isStreaming, std::optional<SizeType32> endId = std::nullopt,
         std::optional<SizeType32> padId = std::nullopt, std::optional<TensorPtr> embeddingBias = std::nullopt,
@@ -58,6 +58,9 @@ public:
         std::optional<std::vector<SizeType32>> positionIds = std::nullopt,
         std::optional<TensorPtr> promptEmbeddingTable = std::nullopt,
         std::optional<SizeType32> promptVocabSize = std::nullopt,
+        std::optional<std::vector<std::vector<SizeType32>>> multimodalHashes = std::nullopt,
+        std::optional<std::vector<SizeType32>> multimodalPositions = std::nullopt,
+        std::optional<std::vector<SizeType32>> multimodalLengths = std::nullopt,
         std::optional<TensorPtr> multimodalEmbedding = std::nullopt,
         std::optional<TensorPtr> mropeRotaryCosSin = std::nullopt,
         std::optional<SizeType32> mropePositionDeltas = std::nullopt,
@@ -82,20 +85,30 @@ public:
         std::optional<SizeType32> languageAdapterUid = std::nullopt,
         std::optional<MillisecondsType> allottedTimeMs = std::nullopt,
         std::optional<executor::ContextPhaseParams> const& contextPhaseParams = std::nullopt)
-        : Base(requestId,                                                                                        //
-            maxNewTokens,                                                                                        //
-            std::make_shared<std::vector<TokenIdType>>(std::move(inputTokens)),                                  //
-            samplingConfig,                                                                                      //
-            isStreaming,                                                                                         //
-            endId,                                                                                               //
-            padId,                                                                                               //
-            embeddingBias,                                                                                       //
-            badWordsList,                                                                                        //
-            stopWordsList,                                                                                       //
-            positionIds.has_value() ? std::make_shared<std::vector<SizeType32>>(std::move(positionIds.value()))  //
-                                    : std::optional<std::shared_ptr<std::vector<SizeType32>>>(std::nullopt),     //
-            promptEmbeddingTable,                                                                                //
-            promptVocabSize,                                                                                     //
+        : Base(requestId,                                                                                       //
+            maxNewTokens,                                                                                       //
+            std::make_shared<std::vector<TokenIdType>>(std::move(inputTokens)),                                 //
+            samplingConfig,                                                                                     //
+            isStreaming,                                                                                        //
+            endId,                                                                                              //
+            padId,                                                                                              //
+            embeddingBias,                                                                                      //
+            badWordsList,                                                                                       //
+            stopWordsList,                                                                                      //
+            positionIds.has_value() ? std::make_shared<std::vector<SizeType32>>(std::move(positionIds.value())) //
+                                    : std::optional<std::shared_ptr<std::vector<SizeType32>>>(std::nullopt),    //
+            promptEmbeddingTable,                                                                               //
+            promptVocabSize,                                                                                    //
+            multimodalHashes.has_value()
+                ? std::make_optional(
+                    std::make_shared<std::vector<std::vector<SizeType32>>>(std::move(multimodalHashes.value()))) //
+                : std::optional<std::shared_ptr<std::vector<std::vector<SizeType32>>>>(std::nullopt),            //
+            multimodalPositions.has_value()
+                ? std::make_shared<std::vector<SizeType32>>(std::move(multimodalPositions.value()))              //
+                : std::optional<std::shared_ptr<std::vector<SizeType32>>>(std::nullopt),                         //
+            multimodalLengths.has_value()
+                ? std::make_shared<std::vector<SizeType32>>(std::move(multimodalLengths.value()))                //
+                : std::optional<std::shared_ptr<std::vector<SizeType32>>>(std::nullopt),                         //
             multimodalEmbedding,                                                                                 //
             mropeRotaryCosSin,                                                                                   //
             mropePositionDeltas,                                                                                 //

--- a/cpp/tensorrt_llm/pybind/executor/request.cpp
+++ b/cpp/tensorrt_llm/pybind/executor/request.cpp
@@ -273,6 +273,25 @@ void initRequestBindings(pybind11::module_& m)
         .def_property_readonly("config", &tle::LoraConfig::getConfig)
         .def(py::pickle(loraConfigGetstate, loraConfigSetstate));
 
+    auto multimodalInputGetstate = [](tle::MultimodalInput const& self)
+    { return py::make_tuple(self.getMultimodalHashes(), self.getMultimodalPositions(), self.getMultimodalLengths()); };
+    auto multimodalInputSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 3)
+        {
+            throw std::runtime_error("Invalid MultimodalInput state!");
+        }
+        return tle::MultimodalInput(state[0].cast<std::vector<std::vector<SizeType32>>>(),
+            state[1].cast<std::vector<SizeType32>>(), state[2].cast<std::vector<SizeType32>>());
+    };
+    py::class_<tle::MultimodalInput>(m, "MultimodalInput")
+        .def(py::init<std::vector<std::vector<SizeType32>>, std::vector<SizeType32>, std::vector<SizeType32>>(),
+            py::arg("multimodal_hashes"), py::arg("multimodal_positions"), py::arg("multimodal_lengths"))
+        .def_property_readonly("multimodal_hashes", &tle::MultimodalInput::getMultimodalHashes)
+        .def_property_readonly("multimodal_positions", &tle::MultimodalInput::getMultimodalPositions)
+        .def_property_readonly("multimodal_lengths", &tle::MultimodalInput::getMultimodalLengths)
+        .def(py::pickle(multimodalInputGetstate, multimodalInputSetstate));
+
     auto MropeConfigGetstate = [](tle::MropeConfig const& self)
     { return py::make_tuple(self.getMRopeRotaryCosSin(), self.getMRopePositionDeltas()); };
     auto MropeConfigSetstate = [](py::tuple const& state)
@@ -499,16 +518,17 @@ void initRequestBindings(pybind11::module_& m)
         return py::make_tuple(self.getInputTokenIds(), self.getMaxTokens(), self.getStreaming(),
             self.getSamplingConfig(), self.getOutputConfig(), self.getEndId(), self.getPadId(), self.getPositionIds(),
             self.getBadWords(), self.getStopWords(), self.getEmbeddingBias(), self.getExternalDraftTokensConfig(),
-            self.getPromptTuningConfig(), self.getMultimodalEmbedding(), self.getMropeConfig(), self.getLoraConfig(),
-            self.getLookaheadConfig(), self.getKvCacheRetentionConfig(), self.getLogitsPostProcessorName(),
-            self.getLogitsPostProcessor(), self.getEncoderInputTokenIds(), self.getClientId(),
-            self.getReturnAllGeneratedTokens(), self.getPriority(), self.getRequestType(), self.getContextPhaseParams(),
-            self.getEncoderInputFeatures(), self.getEncoderOutputLength(), self.getCrossAttentionMask(),
-            self.getEagleConfig(), self.getSkipCrossAttnBlocks(), self.getGuidedDecodingParams());
+            self.getPromptTuningConfig(), self.getMultimodalInput(), self.getMultimodalEmbedding(),
+            self.getMropeConfig(), self.getLoraConfig(), self.getLookaheadConfig(), self.getKvCacheRetentionConfig(),
+            self.getLogitsPostProcessorName(), self.getLogitsPostProcessor(), self.getEncoderInputTokenIds(),
+            self.getClientId(), self.getReturnAllGeneratedTokens(), self.getPriority(), self.getRequestType(),
+            self.getContextPhaseParams(), self.getEncoderInputFeatures(), self.getEncoderOutputLength(),
+            self.getCrossAttentionMask(), self.getEagleConfig(), self.getSkipCrossAttnBlocks(),
+            self.getGuidedDecodingParams());
     };
     auto requestSetstate = [](py::tuple const& state)
     {
-        if (state.size() != 32)
+        if (state.size() != 33)
         {
             throw std::runtime_error("Invalid Request state!");
         }
@@ -518,16 +538,17 @@ void initRequestBindings(pybind11::module_& m)
             state[7].cast<std::optional<std::vector<SizeType32>>>(),
             state[8].cast<std::optional<std::list<VecTokens>>>(), state[9].cast<std::optional<std::list<VecTokens>>>(),
             state[10].cast<std::optional<Tensor>>(), state[11].cast<std::optional<tle::ExternalDraftTokensConfig>>(),
-            state[12].cast<std::optional<tle::PromptTuningConfig>>(), state[13].cast<std::optional<Tensor>>(),
-            state[14].cast<std::optional<tle::MropeConfig>>(), state[15].cast<std::optional<tle::LoraConfig>>(),
-            state[16].cast<std::optional<tle::LookaheadDecodingConfig>>(),
-            state[17].cast<std::optional<tle::KvCacheRetentionConfig>>(), state[18].cast<std::optional<std::string>>(),
-            state[19].cast<std::optional<tle::LogitsPostProcessor>>(), state[20].cast<std::optional<VecTokens>>(),
-            state[21].cast<std::optional<IdType>>(), state[22].cast<bool>(), state[23].cast<tle::PriorityType>(),
-            state[24].cast<tle::RequestType>(), state[25].cast<std::optional<tle::ContextPhaseParams>>(),
-            state[26].cast<std::optional<tle::Tensor>>(), state[27].cast<std::optional<SizeType32>>(),
-            state[28].cast<std::optional<tle::Tensor>>(), 1, state[29].cast<std::optional<tle::EagleConfig>>(),
-            state[30].cast<std::optional<tle::Tensor>>(), state[31].cast<std::optional<tle::GuidedDecodingParams>>());
+            state[12].cast<std::optional<tle::PromptTuningConfig>>(),
+            state[13].cast<std::optional<tle::MultimodalInput>>(), state[14].cast<std::optional<Tensor>>(),
+            state[15].cast<std::optional<tle::MropeConfig>>(), state[16].cast<std::optional<tle::LoraConfig>>(),
+            state[17].cast<std::optional<tle::LookaheadDecodingConfig>>(),
+            state[18].cast<std::optional<tle::KvCacheRetentionConfig>>(), state[19].cast<std::optional<std::string>>(),
+            state[20].cast<std::optional<tle::LogitsPostProcessor>>(), state[21].cast<std::optional<VecTokens>>(),
+            state[22].cast<std::optional<IdType>>(), state[23].cast<bool>(), state[24].cast<tle::PriorityType>(),
+            state[25].cast<tle::RequestType>(), state[26].cast<std::optional<tle::ContextPhaseParams>>(),
+            state[27].cast<std::optional<tle::Tensor>>(), state[28].cast<std::optional<SizeType32>>(),
+            state[29].cast<std::optional<tle::Tensor>>(), 1, state[30].cast<std::optional<tle::EagleConfig>>(),
+            state[31].cast<std::optional<tle::Tensor>>(), state[32].cast<std::optional<tle::GuidedDecodingParams>>());
     };
 
     py::class_<tle::Request> request(m, "Request", pybind11::dynamic_attr());
@@ -545,6 +566,7 @@ void initRequestBindings(pybind11::module_& m)
                  std::optional<tle::Tensor>,                    // embeddingBias
                  std::optional<tle::ExternalDraftTokensConfig>, // externalDraftTokensConfig
                  std::optional<tle::PromptTuningConfig>,        // pTuningConfig
+                 std::optional<tle::MultimodalInput>,           // multimodalInput
                  std::optional<tle::Tensor>,                    // multimodalEmbedding
                  std::optional<tle::MropeConfig>,               // mRopeConfig
                  std::optional<tle::LoraConfig>,                // loraConfig
@@ -583,6 +605,7 @@ void initRequestBindings(pybind11::module_& m)
         py::arg("embedding_bias") = py::none(),
         py::arg("external_draft_tokens_config") = py::none(),
         py::arg("prompt_tuning_config") = py::none(),
+        py::arg("multimodal_input") = py::none(),
         py::arg("multimodal_embedding") = py::none(),
         py::arg("mrope_config") = py::none(),
         py::arg("lora_config") = py::none(),
@@ -622,6 +645,7 @@ void initRequestBindings(pybind11::module_& m)
             &tle::Request::setExternalDraftTokensConfig)
         .def_property(
             "prompt_tuning_config", &tle::Request::getPromptTuningConfig, &tle::Request::setPromptTuningConfig)
+        .def_property("multimodal_input", &tle::Request::getMultimodalInput, &tle::Request::setMultimodalInput)
         .def_property(
             "multimodal_embedding", &tle::Request::getMultimodalEmbedding, &tle::Request::setMultimodalEmbedding)
         .def_property("mrope_config", &tle::Request::getMropeConfig, &tle::Request::setMropeConfig)

--- a/cpp/tests/batch_manager/trtGptModelTest.cpp
+++ b/cpp/tests/batch_manager/trtGptModelTest.cpp
@@ -931,10 +931,10 @@ TEST_F(TrtGptModelTest, PauseRequestStats)
     auto llmRequest = std::make_shared<LlmRequest>(correlationId, maxNewTokens, tokens, inSamplingConfig, false,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-        false, false, false, std::nullopt, std::nullopt, false, std::nullopt, false, std::nullopt, false, std::nullopt,
-        executor::Request::kDefaultPriority, std::nullopt, std::nullopt, std::nullopt,
-        LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION, std::nullopt, 1, std::nullopt, std::nullopt,
-        true /* returnPerfMetrics */);
+        std::nullopt, std::nullopt, std::nullopt, false, false, false, std::nullopt, std::nullopt, false, std::nullopt,
+        false, std::nullopt, false, std::nullopt, executor::Request::kDefaultPriority, std::nullopt, std::nullopt,
+        std::nullopt, LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION, std::nullopt, 1, std::nullopt,
+        std::nullopt, true /* returnPerfMetrics */);
 
     RequestList requestList{llmRequest};
 

--- a/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
@@ -766,9 +766,9 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithExtraIdTest)
     auto llmRequest0 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens, samplingConfig, isStreaming,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-        false, false, false, std::nullopt, std::nullopt, false, std::nullopt, false, std::nullopt, false, std::nullopt,
-        0.5, std::nullopt, std::nullopt, std::nullopt, LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION,
-        inputTokenExtraIds, numReturnSequences);
+        std::nullopt, std::nullopt, std::nullopt, false, false, false, std::nullopt, std::nullopt, false, std::nullopt,
+        false, std::nullopt, false, std::nullopt, 0.5, std::nullopt, std::nullopt, std::nullopt,
+        LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION, inputTokenExtraIds, numReturnSequences);
 
     GenerationRequest seq0{requestId, inputLength, beamWidth, blockManager.getWindowSizesMetadata()};
 
@@ -799,9 +799,9 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithExtraIdTest)
     auto llmRequest1 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens, samplingConfig, isStreaming,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-        false, false, false, std::nullopt, std::nullopt, false, std::nullopt, false, std::nullopt, false, std::nullopt,
-        0.5, std::nullopt, std::nullopt, std::nullopt, LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION,
-        inputTokenExtraIds, numReturnSequences);
+        std::nullopt, std::nullopt, std::nullopt, false, false, false, std::nullopt, std::nullopt, false, std::nullopt,
+        false, std::nullopt, false, std::nullopt, 0.5, std::nullopt, std::nullopt, std::nullopt,
+        LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION, inputTokenExtraIds, numReturnSequences);
     GenerationRequest seq1{requestId, inputLength, beamWidth, blockManager.getWindowSizesMetadata()};
 
     // reuse blocks 0, 1 and get new block 3
@@ -826,9 +826,9 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithExtraIdTest)
     llmRequest0 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens, samplingConfig, isStreaming,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-        false, false, false, std::nullopt, std::nullopt, false, std::nullopt, false, std::nullopt, false, std::nullopt,
-        0.5, std::nullopt, std::nullopt, std::nullopt, LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION,
-        inputTokenExtraIds, numReturnSequences);
+        std::nullopt, std::nullopt, std::nullopt, false, false, false, std::nullopt, std::nullopt, false, std::nullopt,
+        false, std::nullopt, false, std::nullopt, 0.5, std::nullopt, std::nullopt, std::nullopt,
+        LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION, inputTokenExtraIds, numReturnSequences);
     promptLen0 = llmRequest0->getNumTokens(beamIdx);
     numContextBlocks0 = tc::ceilDiv(promptLen0, blockManager.getTokensPerBlock());
     blockManager.addSequence(seq0, promptLen0, numContextBlocks0, *llmRequest0, maxAttentionWindow);
@@ -846,9 +846,9 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithExtraIdTest)
     llmRequest1 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens1, samplingConfig, isStreaming,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-        false, false, false, std::nullopt, std::nullopt, false, std::nullopt, false, std::nullopt, false, std::nullopt,
-        0.5, std::nullopt, std::nullopt, std::nullopt, LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION,
-        inputTokenExtraIds1, numReturnSequences);
+        std::nullopt, std::nullopt, std::nullopt, false, false, false, std::nullopt, std::nullopt, false, std::nullopt,
+        false, std::nullopt, false, std::nullopt, 0.5, std::nullopt, std::nullopt, std::nullopt,
+        LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION, inputTokenExtraIds1, numReturnSequences);
     promptLen1 = llmRequest1->getNumTokens(beamIdx);
     numContextBlocks1 = tc::ceilDiv(promptLen1, blockManager.getTokensPerBlock());
     blockManager.addSequence(seq1, promptLen1, numContextBlocks1, *llmRequest1, maxAttentionWindow);
@@ -873,9 +873,9 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithExtraIdTest)
     auto llmRequest2 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens, samplingConfig, isStreaming,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-        false, false, false, std::nullopt, std::nullopt, false, std::nullopt, false, std::nullopt, false, std::nullopt,
-        0.5, std::nullopt, std::nullopt, std::nullopt, LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION,
-        inputTokenExtraIds2, numReturnSequences);
+        std::nullopt, std::nullopt, std::nullopt, false, false, false, std::nullopt, std::nullopt, false, std::nullopt,
+        false, std::nullopt, false, std::nullopt, 0.5, std::nullopt, std::nullopt, std::nullopt,
+        LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION, inputTokenExtraIds2, numReturnSequences);
 
     numTokens = llmRequest2->getNumTokens(beamIdx);
     GenerationRequest seq2{requestId, numTokens, beamWidth, blockManager.getWindowSizesMetadata()};
@@ -898,9 +898,9 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithExtraIdTest)
     auto llmRequest3 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens, samplingConfig, isStreaming,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-        false, false, false, std::nullopt, std::nullopt, false, std::nullopt, false, std::nullopt, false, std::nullopt,
-        0.5, std::nullopt, std::nullopt, std::nullopt, LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION,
-        inputTokenExtraIds3, numReturnSequences);
+        std::nullopt, std::nullopt, std::nullopt, false, false, false, std::nullopt, std::nullopt, false, std::nullopt,
+        false, std::nullopt, false, std::nullopt, 0.5, std::nullopt, std::nullopt, std::nullopt,
+        LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION, inputTokenExtraIds3, numReturnSequences);
 
     numTokens = llmRequest3->getNumTokens(beamIdx);
     GenerationRequest seq3{requestId, numTokens, beamWidth, blockManager.getWindowSizesMetadata()};
@@ -962,7 +962,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithLoraTaskIdTest)
     LlmRequest::RequestIdType requestId{0};
     auto llmRequest0 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens, samplingConfig, isStreaming,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-        std::nullopt, std::nullopt, std::nullopt, loraTaskId);
+        std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, loraTaskId);
     GenerationRequest seq0{requestId, inputLength, beamWidth, blockManager.getWindowSizesMetadata()};
 
     ///////////////////////////////////////////////////////////////////////////
@@ -993,7 +993,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithLoraTaskIdTest)
     requestId = 1;
     auto llmRequest1 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens, samplingConfig, isStreaming,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-        std::nullopt, std::nullopt, std::nullopt, loraTaskId);
+        std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, loraTaskId);
     GenerationRequest seq1{requestId, inputLength, beamWidth, blockManager.getWindowSizesMetadata()};
 
     // reuse blocks 0, 1 and get new block 3
@@ -1018,7 +1018,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithLoraTaskIdTest)
     // reuse blocks 0, 1 and get new block 4
     llmRequest0 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens, samplingConfig, isStreaming,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-        std::nullopt, std::nullopt, std::nullopt, loraTaskId);
+        std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, loraTaskId);
     promptLen0 = llmRequest0->getNumTokens(beamIdx);
     numContextBlocks0 = tc::ceilDiv(promptLen0, blockManager.getTokensPerBlock());
     blockManager.addSequence(seq0, promptLen0, numContextBlocks0, *llmRequest0, maxAttentionWindow);
@@ -1037,7 +1037,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithLoraTaskIdTest)
     auto inputTokens1 = std::make_shared<VecTokens>(llmRequest1->getTokens(0));
     llmRequest1 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens1, samplingConfig, isStreaming,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-        std::nullopt, std::nullopt, std::nullopt, loraTaskId);
+        std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, loraTaskId);
     promptLen1 = llmRequest1->getNumTokens(beamIdx);
     numContextBlocks1 = tc::ceilDiv(promptLen1, blockManager.getTokensPerBlock());
     // reuse 0, 1, 2(p) ([0,1,2,3], [4,5,6,7], [8])
@@ -1063,7 +1063,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithLoraTaskIdTest)
     requestId = 2;
     auto llmRequest2 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens, samplingConfig, isStreaming,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-        std::nullopt, std::nullopt, std::nullopt, loraTaskId);
+        std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, loraTaskId);
 
     numTokens = llmRequest2->getNumTokens(beamIdx);
     GenerationRequest seq2{requestId, numTokens, beamWidth, blockManager.getWindowSizesMetadata()};
@@ -1090,7 +1090,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithLoraTaskIdTest)
     requestId = 3;
     auto llmRequest3 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens3, samplingConfig, isStreaming,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-        std::nullopt, std::nullopt, std::nullopt, loraTaskId);
+        std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, loraTaskId);
 
     numTokens = llmRequest3->getNumTokens(beamIdx);
     GenerationRequest seq3{requestId, numTokens, beamWidth, blockManager.getWindowSizesMetadata()};
@@ -1118,7 +1118,7 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithLoraTaskIdTest)
     requestId = 4;
     auto llmRequest4 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens4, samplingConfig, isStreaming,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-        std::nullopt, std::nullopt, std::nullopt, loraTaskId);
+        std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, loraTaskId);
 
     numTokens = llmRequest4->getNumTokens(beamIdx);
     GenerationRequest seq4{requestId, numTokens, beamWidth, blockManager.getWindowSizesMetadata()};
@@ -1203,10 +1203,10 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithExtraIdAndLoraTaskIdTest)
     LlmRequest::RequestIdType requestId{0};
     auto llmRequest0 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens, samplingConfig, isStreaming,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-        std::nullopt, std::nullopt, std::nullopt, loraTaskId1, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-        false, false, false, std::nullopt, std::nullopt, false, std::nullopt, false, std::nullopt, false, std::nullopt,
-        0.5, std::nullopt, std::nullopt, std::nullopt, LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION,
-        inputTokenExtraIds);
+        std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, loraTaskId1, std::nullopt,
+        std::nullopt, std::nullopt, std::nullopt, false, false, false, std::nullopt, std::nullopt, false, std::nullopt,
+        false, std::nullopt, false, std::nullopt, 0.5, std::nullopt, std::nullopt, std::nullopt,
+        LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION, inputTokenExtraIds);
 
     GenerationRequest seq0{requestId, inputLength, beamWidth, blockManager.getWindowSizesMetadata()};
 
@@ -1237,10 +1237,10 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithExtraIdAndLoraTaskIdTest)
     LlmRequest::LoraTaskIdType loraTaskId2 = static_cast<LlmRequest::LoraTaskIdType>(2);
     auto llmRequest1 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens, samplingConfig, isStreaming,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-        std::nullopt, std::nullopt, std::nullopt, loraTaskId2, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-        false, false, false, std::nullopt, std::nullopt, false, std::nullopt, false, std::nullopt, false, std::nullopt,
-        0.5, std::nullopt, std::nullopt, std::nullopt, LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION,
-        inputTokenExtraIds);
+        std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, loraTaskId2, std::nullopt,
+        std::nullopt, std::nullopt, std::nullopt, false, false, false, std::nullopt, std::nullopt, false, std::nullopt,
+        false, std::nullopt, false, std::nullopt, 0.5, std::nullopt, std::nullopt, std::nullopt,
+        LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION, inputTokenExtraIds);
     GenerationRequest seq1{requestId, inputLength, beamWidth, blockManager.getWindowSizesMetadata()};
 
     // no reuse, get new block 3, 4, 5
@@ -1263,10 +1263,10 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithExtraIdAndLoraTaskIdTest)
     // add both requests again and then remove them
     llmRequest0 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens, samplingConfig, isStreaming,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-        std::nullopt, std::nullopt, std::nullopt, loraTaskId1, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-        false, false, false, std::nullopt, std::nullopt, false, std::nullopt, false, std::nullopt, false, std::nullopt,
-        0.5, std::nullopt, std::nullopt, std::nullopt, LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION,
-        inputTokenExtraIds);
+        std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, loraTaskId1, std::nullopt,
+        std::nullopt, std::nullopt, std::nullopt, false, false, false, std::nullopt, std::nullopt, false, std::nullopt,
+        false, std::nullopt, false, std::nullopt, 0.5, std::nullopt, std::nullopt, std::nullopt,
+        LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION, inputTokenExtraIds);
     promptLen0 = llmRequest0->getNumTokens(beamIdx);
     numContextBlocks0 = tc::ceilDiv(promptLen0, blockManager.getTokensPerBlock());
     // reuse blocks 0, 1 and get new block 6
@@ -1284,10 +1284,10 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithExtraIdAndLoraTaskIdTest)
     inputTokenExtraIds1->push_back(0);
     llmRequest1 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens1, samplingConfig, isStreaming,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-        std::nullopt, std::nullopt, std::nullopt, loraTaskId2, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-        false, false, false, std::nullopt, std::nullopt, false, std::nullopt, false, std::nullopt, false, std::nullopt,
-        0.5, std::nullopt, std::nullopt, std::nullopt, LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION,
-        inputTokenExtraIds1);
+        std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, loraTaskId2, std::nullopt,
+        std::nullopt, std::nullopt, std::nullopt, false, false, false, std::nullopt, std::nullopt, false, std::nullopt,
+        false, std::nullopt, false, std::nullopt, 0.5, std::nullopt, std::nullopt, std::nullopt,
+        LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION, inputTokenExtraIds1);
     promptLen1 = llmRequest1->getNumTokens(beamIdx);
     numContextBlocks1 = tc::ceilDiv(promptLen1, blockManager.getTokensPerBlock());
     blockManager.addSequence(seq1, promptLen1, numContextBlocks1, *llmRequest1, maxAttentionWindow);
@@ -1310,10 +1310,10 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithExtraIdAndLoraTaskIdTest)
     requestId = 2;
     auto llmRequest2 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens, samplingConfig, isStreaming,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-        std::nullopt, std::nullopt, std::nullopt, loraTaskId1, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-        false, false, false, std::nullopt, std::nullopt, false, std::nullopt, false, std::nullopt, false, std::nullopt,
-        0.5, std::nullopt, std::nullopt, std::nullopt, LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION,
-        inputTokenExtraIds2);
+        std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, loraTaskId1, std::nullopt,
+        std::nullopt, std::nullopt, std::nullopt, false, false, false, std::nullopt, std::nullopt, false, std::nullopt,
+        false, std::nullopt, false, std::nullopt, 0.5, std::nullopt, std::nullopt, std::nullopt,
+        LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION, inputTokenExtraIds2);
 
     numTokens = llmRequest2->getNumTokens(beamIdx);
     GenerationRequest seq2{requestId, numTokens, beamWidth, blockManager.getWindowSizesMetadata()};
@@ -1335,10 +1335,10 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithExtraIdAndLoraTaskIdTest)
     requestId = 3;
     auto llmRequest3 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens, samplingConfig, isStreaming,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-        std::nullopt, std::nullopt, std::nullopt, loraTaskId1, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-        false, false, false, std::nullopt, std::nullopt, false, std::nullopt, false, std::nullopt, false, std::nullopt,
-        0.5, std::nullopt, std::nullopt, std::nullopt, LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION,
-        inputTokenExtraIds3);
+        std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, loraTaskId1, std::nullopt,
+        std::nullopt, std::nullopt, std::nullopt, false, false, false, std::nullopt, std::nullopt, false, std::nullopt,
+        false, std::nullopt, false, std::nullopt, 0.5, std::nullopt, std::nullopt, std::nullopt,
+        LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION, inputTokenExtraIds3);
 
     numTokens = llmRequest3->getNumTokens(beamIdx);
     GenerationRequest seq3{requestId, numTokens, beamWidth, blockManager.getWindowSizesMetadata()};
@@ -1359,10 +1359,10 @@ TEST_F(KVCacheManagerTest, BlockManagerReuseWithExtraIdAndLoraTaskIdTest)
     requestId = 4;
     auto llmRequest4 = std::make_shared<LlmRequest>(requestId, maxNewTokens, inputTokens, samplingConfig, isStreaming,
         std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-        std::nullopt, std::nullopt, std::nullopt, loraTaskId2, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-        false, false, false, std::nullopt, std::nullopt, false, std::nullopt, false, std::nullopt, false, std::nullopt,
-        0.5, std::nullopt, std::nullopt, std::nullopt, LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION,
-        inputTokenExtraIds3);
+        std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, loraTaskId2, std::nullopt,
+        std::nullopt, std::nullopt, std::nullopt, false, false, false, std::nullopt, std::nullopt, false, std::nullopt,
+        false, std::nullopt, false, std::nullopt, 0.5, std::nullopt, std::nullopt, std::nullopt,
+        LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION, inputTokenExtraIds3);
 
     numTokens = llmRequest4->getNumTokens(beamIdx);
     GenerationRequest seq4{requestId, numTokens, beamWidth, blockManager.getWindowSizesMetadata()};

--- a/cpp/tests/unit_tests/batch_manager/microBatchSchedulerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/microBatchSchedulerTest.cpp
@@ -58,6 +58,7 @@ protected:
             /*padId=*/std::nullopt, /*embeddingBias=*/std::nullopt,
             /*badWordsList=*/std::nullopt, /*stopWordsList=*/std::nullopt, /*positionIds=*/std::nullopt,
             /*promptEmbeddingTable=*/std::nullopt, /*promptVocabSize=*/std::nullopt,
+            /*multimodalHashes=*/std::nullopt, /*multimodalPos=*/std::nullopt, /*multimodalLength=*/std::nullopt,
             /*multimodalEmbedding=*/std::nullopt,
             /*mropeRotaryCosSin=*/std::nullopt, /*mropePositionDeltas*/ std::nullopt,
             /*loraTaskId=*/std::nullopt, /*loraWeights=*/std::nullopt,

--- a/cpp/tests/unit_tests/executor/requestTest.cpp
+++ b/cpp/tests/unit_tests/executor/requestTest.cpp
@@ -147,10 +147,11 @@ TEST(RequestTest, serializeDeserialize)
     auto request = Request({1, 2, 3, 4}, 11, true, SamplingConfig(), OutputConfig(), 112, 113,
         std::make_optional<std::vector<SizeType32>>({0, 1, 2, 3}), std::list<VecTokens>{{1, 2, 3}, {2, 3, 4}},
         std::nullopt, std::nullopt, ExternalDraftTokensConfig({2, 2, 2}),
-        PromptTuningConfig(embeddingTable, VecTokenExtraIds({1, 2, 3, 4})), embeddingTable, std::nullopt, std::nullopt,
-        std::nullopt, KvCacheRetentionConfig({KvCacheRetentionConfig::TokenRangeRetentionConfig(0, 1, 10)}, 10),
-        "Processor", std::nullopt, std::nullopt, 1234, false, 0.5, RequestType::REQUEST_TYPE_CONTEXT_AND_GENERATION,
-        std::nullopt, std::nullopt, std::nullopt, std::nullopt, 1, std::nullopt, std::nullopt,
+        PromptTuningConfig(embeddingTable, VecTokenExtraIds({1, 2, 3, 4})), std::nullopt, std::nullopt, std::nullopt,
+        std::nullopt, std::nullopt,
+        KvCacheRetentionConfig({KvCacheRetentionConfig::TokenRangeRetentionConfig(0, 1, 10)}, 10), "Processor",
+        std::nullopt, std::nullopt, 1234, false, 0.5, RequestType::REQUEST_TYPE_CONTEXT_AND_GENERATION, std::nullopt,
+        std::nullopt, std::nullopt, std::nullopt, 1, std::nullopt, std::nullopt,
         GuidedDecodingParams(GuidedDecodingParams::GuideType::kREGEX, "\\d+"));
 
     auto serializedSize = Serialization::serializedSize(request);

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,3 +56,4 @@ matplotlib # FIXME: this is added to make nvtx happy
 meson
 ninja
 etcd3
+blake3

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -369,6 +369,12 @@ def executor_request_to_llm_request(
         is None else executor_request.prompt_tuning_config.embedding_table,
         prompt_vocab_size=None if executor_request.prompt_tuning_config is None
         else executor_request.prompt_tuning_config.embedding_table.shape[0],
+        multimodal_hashes=None if executor_request.multimodal_input is None else
+        executor_request.multimodal_input.multimodal_hashes,
+        multimodal_positions=None if executor_request.multimodal_input is None
+        else executor_request.multimodal_input.multimodal_positions,
+        multimodal_lengths=None if executor_request.multimodal_input is None
+        else executor_request.multimodal_input.multimodal_lengths,
         multimodal_embedding=None if executor_request.multimodal_embedding
         is None else executor_request.multimodal_embedding,
         lora_task_id=executor_request.lora_config.task_id

--- a/tensorrt_llm/executor/executor.py
+++ b/tensorrt_llm/executor/executor.py
@@ -13,6 +13,7 @@ from typing import (TYPE_CHECKING, AsyncIterable, Generator, List, Optional,
 import numpy as np
 import torch
 
+from tensorrt_llm.inputs.multimodal import MultimodalInput
 from tensorrt_llm.logger import logger, set_level
 from tensorrt_llm.lora_manager import LoraConfig
 
@@ -116,6 +117,7 @@ class GenerationExecutor(ABC):
             lora_request: Optional[LoRARequest] = None,
             prompt_adapter_request: Optional[PromptAdapterRequest] = None,
             streaming: bool = False,
+            multimodal_input: Optional[MultimodalInput] = None,
             multimodal_embedding: Optional[list] = None,
             mrope_config: Optional[dict] = None,
             kv_cache_retention_config: Optional[KvCacheRetentionConfig] = None,
@@ -142,6 +144,7 @@ class GenerationExecutor(ABC):
                 lora_request=lora_request,
                 prompt_adapter_request=prompt_adapter_request,
                 streaming=streaming,
+                multimodal_input=multimodal_input,
                 multimodal_embedding=multimodal_embedding,
                 mrope_config=mrope_config,
                 kv_cache_retention_config=kv_cache_retention_config,

--- a/tensorrt_llm/executor/request.py
+++ b/tensorrt_llm/executor/request.py
@@ -5,6 +5,8 @@ from typing import List, Optional, Union
 import numpy as np
 import torch
 
+from tensorrt_llm.inputs.multimodal import MultimodalInput
+
 from ..disaggregated_params import DisaggregatedParams
 from ..llmapi.llm_utils import KvCacheRetentionConfig
 from ..sampling_params import SamplingParams
@@ -80,6 +82,7 @@ class GenerationRequest:
         lora_request: Optional[LoRARequest] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
         streaming: bool = False,
+        multimodal_input: Optional[MultimodalInput] = None,
         multimodal_embedding: Optional[list] = None,
         mrope_config: Optional[dict] = None,
         kv_cache_retention_config: Optional[KvCacheRetentionConfig] = None,
@@ -103,6 +106,7 @@ class GenerationRequest:
         self.lora_request = lora_request
         self.prompt_adapter_request = prompt_adapter_request
         self.streaming = streaming
+        self.multimodal_input = multimodal_input
         self.multimodal_embedding = multimodal_embedding
         self.mrope_config = mrope_config
         self.kv_cache_retention_config = kv_cache_retention_config

--- a/tensorrt_llm/executor/serialization.py
+++ b/tensorrt_llm/executor/serialization.py
@@ -73,6 +73,7 @@ BASE_ZMQ_CLASSES = {
     "tensorrt_llm._torch.model_config": ["MoeLoadBalancerConfig"],
     "tensorrt_llm.builder": ["BuildConfig"],
     "tensorrt_llm.disaggregated_params": ["DisaggregatedParams"],
+    "tensorrt_llm.inputs.multimodal": ["MultimodalInput"],
     "tensorrt_llm.executor.postproc_worker": [
         "PostprocArgs", "PostprocParams", "PostprocWorkerConfig",
         "PostprocWorker.Input", "PostprocWorker.Output"

--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -372,6 +372,7 @@ class GenerationExecutorWorker(GenerationExecutor):
         prompt_tuning_config = None
         multimodal_embedding = None
         mrope_config = None
+        multimodal_input = None
         if request.multimodal_embedding is not None:
             multimodal_embedding = request.multimodal_embedding
         if request.prompt_adapter_request is not None:
@@ -386,6 +387,13 @@ class GenerationExecutorWorker(GenerationExecutor):
 
         if request.mrope_config is not None:
             mrope_config = tllm.MropeConfig(**request.mrope_config)
+
+        if request.multimodal_input is not None:
+            multimodal_input = tllm.MultimodalInput(
+                multimodal_hashes=request.multimodal_input.multimodal_hashes,
+                multimodal_positions=request.multimodal_input.
+                multimodal_positions,
+                multimodal_lengths=request.multimodal_input.multimodal_lengths)
 
         context_phase_params = None
         request_type = tllm.RequestType.REQUEST_TYPE_CONTEXT_AND_GENERATION
@@ -452,6 +460,7 @@ class GenerationExecutorWorker(GenerationExecutor):
                 embedding_bias=request.sampling_params.embedding_bias,
                 lora_config=lora_config,
                 prompt_tuning_config=prompt_tuning_config,
+                multimodal_input=multimodal_input,
                 multimodal_embedding=multimodal_embedding,
                 mrope_config=mrope_config,
                 logits_post_processor_name=(

--- a/tensorrt_llm/inputs/__init__.py
+++ b/tensorrt_llm/inputs/__init__.py
@@ -1,6 +1,8 @@
 from .data import PromptInputs, TextPrompt, TokensPrompt, prompt_inputs
+from .multimodal import MultimodalInput
 from .registry import (ExtraProcessedInputs, InputProcessor,
-                       create_input_processor, register_input_processor)
+                       create_input_processor, create_input_processor_with_hash,
+                       register_input_processor)
 from .utils import (ALL_SUPPORTED_MULTIMODAL_MODELS, ConversationMessage,
                     MultimodalData, MultimodalDataTracker,
                     add_multimodal_placeholders, async_load_image,
@@ -14,12 +16,14 @@ __all__ = [
     "TokensPrompt",
     "InputProcessor",
     "create_input_processor",
+    "create_input_processor_with_hash",
     "register_input_processor",
     "ExtraProcessedInputs",
     "ALL_SUPPORTED_MULTIMODAL_MODELS",
     "ConversationMessage",
     "MultimodalDataTracker",
     "MultimodalData",
+    "MultimodalInput",
     "async_load_image",
     "async_load_video",
     "add_multimodal_placeholders",

--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -1,0 +1,263 @@
+"""Multimodal utilities for handling images and other media types in TensorRT-LLM."""
+
+from dataclasses import dataclass
+from typing import List
+
+import numpy as np
+import PIL
+import torch
+from blake3 import blake3
+from torchvision.transforms import ToPILImage
+
+# Default hasher
+default_hasher = blake3
+
+
+@dataclass
+class MultimodalInput:
+    multimodal_hashes: List[List[int]]
+    # multimodal_positions contains only the start position of each chunk
+    # This is different from mm_positions elsewhere which contains all positions of multimodal tokens
+    multimodal_positions: List[int]
+    multimodal_lengths: List[int]
+
+    def __post_init__(self):
+        """Validate input data structure and consistency."""
+        # Validate multimodal_hashes
+        if not isinstance(self.multimodal_hashes, list):
+            raise TypeError("multimodal_hashes must be a list")
+
+        # Check that hashes are lists of consistent length containing integers
+        if not all(isinstance(h, list) for h in self.multimodal_hashes):
+            raise TypeError("Each element in multimodal_hashes must be a list")
+
+        # Check consistent length of hash arrays
+        hash_lengths = [len(h) for h in self.multimodal_hashes]
+        if min(hash_lengths) != max(hash_lengths):
+            raise ValueError(
+                f"All hash arrays must have the same length, got lengths: {hash_lengths}"
+            )
+
+        # Check that positions and lengths are valid
+        if not all(isinstance(x, int) for x in self.multimodal_positions):
+            raise TypeError("multimodal_positions must contain only integers")
+
+        if not all(isinstance(x, int) for x in self.multimodal_lengths):
+            raise TypeError("multimodal_lengths must contain only integers")
+
+        # Check position and length arrays match in size
+        if len(self.multimodal_positions) != len(self.multimodal_lengths):
+            raise ValueError(
+                f"Position and length arrays must match in size: "
+                f"positions={len(self.multimodal_positions)}, lengths={len(self.multimodal_lengths)}"
+            )
+
+    @classmethod
+    def from_components(cls, mm_hashes, mm_positions, mm_lengths):
+        return cls(multimodal_hashes=mm_hashes,
+                   multimodal_positions=mm_positions,
+                   multimodal_lengths=mm_lengths)
+
+    def to_tensor(self) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Convert data to tensors"""
+        return (
+            # int32 to match the type in TRTLLM SizeType32
+            torch.tensor(self.multimodal_hashes, dtype=torch.int32),
+            torch.tensor(self.multimodal_positions, dtype=torch.int32),
+            torch.tensor(self.multimodal_lengths, dtype=torch.int32))
+
+
+# adopt from vllm : https://github.com/vllm-project/vllm/blob/main/vllm/vllm/multimodal/hash.py
+def serialize_item(obj: object) -> bytes:
+    # Simple cases
+    if isinstance(obj, str):
+        return obj.encode("utf-8")
+    if isinstance(obj, bytes):
+        return obj
+    if isinstance(obj, (int, float)):
+        return np.array(obj).tobytes()
+
+    if isinstance(obj, PIL.Image.Image):
+        return np.array(obj.convert("RGBA")).tobytes()
+    if isinstance(obj, torch.Tensor):
+        return obj.numpy().tobytes()
+    if isinstance(obj, np.ndarray):
+        return obj.tobytes()
+
+    raise ValueError(f"Unsupported object type: {type(obj)}")
+
+
+def apply_mm_hashes(mm_data, hash_lib=default_hasher):
+    """Apply hashing to multimodal data items."""
+
+    def _hash_image(image):
+        # only support single modality w/ PIL.Image.Image for now
+        # TODO: possible hash collision w/ this simplified version (vllm/PR/17378)
+        hasher = hash_lib()
+        if isinstance(image, torch.Tensor):
+            # TODO: Device tensor hashing is an open issue. Limited hashing to CPU for now.
+            image = image.cpu()
+        hasher.update(serialize_item(image))
+        return hasher.hexdigest()
+
+    mm_items = {
+        modality: items if isinstance(items, list) else [items]
+        for modality, items in mm_data.items()
+    }
+    # TODO: need to hash both modality and item to distinguish modality (vllm/PR)
+    mm_hashes = {
+        modality: [_hash_image(item) for item in items]
+        for modality, items in mm_items.items()
+    }
+    return mm_hashes
+
+
+def hexdigest_to_int32(hex_digest: str) -> list[int]:
+    """Convert a 256-bit hexadecimal digest to 8 int32 values."""
+    if len(hex_digest) != 64:
+        raise ValueError(
+            f"Expected 64 character hexadecimal string, got {len(hex_digest)}")
+
+    result = []
+    for i in range(0, 64, 8):
+        hex_chunk = hex_digest[i:i + 8]
+        value = int(hex_chunk, 16)
+        if value > 0x7FFFFFFF:  # Check if the highest bit is set (value > 2^31-1)
+            value = value - 0x100000000  # Convert to signed by subtracting 2^32
+        result.append(value)
+    return result
+
+
+def find_mm_token_lengths(mm_data, input_processor):
+    """Get multimodal token lengths from multimodal data items. """
+
+    mm_items = {
+        modality: items if isinstance(items, list) else [items]
+        for modality, items in mm_data.items()
+    }
+    num_mm_tokens = {}
+
+    for modality, items in mm_items.items():
+        if modality != "image":
+            #TODO: support other modalities
+            return []
+        if not hasattr(input_processor, "get_num_tokens_per_image"):
+            #TODO: backward compatibility for models that don't yet have get_num_tokens_per_image implemented
+            #TODO: only support qwen2_vl for now
+            return []
+
+        modality_token_lengths = []
+        for item in items:
+            if isinstance(item, torch.Tensor):
+                item = ToPILImage()(item)
+            num_tokens = input_processor.get_num_tokens_per_image(
+                image_width=item.width,
+                image_height=item.height,
+            )
+            modality_token_lengths.append(num_tokens)
+
+        num_mm_tokens[modality] = modality_token_lengths
+
+    return num_mm_tokens['image']  # flatten all mm instances to a single list
+
+
+def find_mm_token_positions(input_ids,
+                            num_mm_tokens,
+                            vocab_size,
+                            mm_token_ids=None):
+    """Get multimodal token positions using IDs > vocab_size and known lengths.
+
+    This function finds multimodal tokens (with IDs > vocab_size) and uses the
+    provided lengths in num_mm_tokens to identify where each chunk starts.
+    This works even when there are no gaps between different image sequences
+    (e.g., when all images use the same token IDs).
+
+    Args:
+        input_ids: Token sequence (tensor, list, or numpy array)
+        num_mm_tokens: List of lengths for each multimodal token chunk
+        vocab_size: Size of the model's vocabulary
+        mm_token_ids (optional): possible token ids for multimodal tokens
+
+    Returns:
+        List of starting positions for each multimodal token chunk
+    """
+    # Convert input_ids to tensor if needed
+    if not isinstance(input_ids, torch.Tensor):
+        if isinstance(input_ids, list):
+            input_ids = torch.tensor(input_ids)
+        elif isinstance(input_ids, np.ndarray):
+            input_ids = torch.from_numpy(input_ids)
+
+    # Create mask for multimodal tokens
+    if mm_token_ids is None:
+        mm_mask = input_ids >= vocab_size
+    else:
+        mm_mask = torch.isin(input_ids, mm_token_ids)
+
+    # If no multimodal tokens found, return empty list
+    if not torch.any(mm_mask):
+        return []
+
+    # Get positions of all multimodal tokens
+    mm_positions = torch.where(mm_mask)[0].tolist()
+    assert len(mm_positions) == sum(
+        num_mm_tokens
+    ), f"Number of multimodal tokens does not match sum of all lengths"
+
+    # Use num_mm_tokens to find the starting position of each chunk
+    start_positions = []
+    current_position = 0
+
+    # Process each expected length
+    for length in num_mm_tokens:
+        if current_position < len(mm_positions):
+            # Add the starting position of this chunk
+            start_positions.append(mm_positions[current_position])
+            # Move to the next chunk
+            current_position += length
+
+    return start_positions
+
+
+def validate_mm_inputs(prompt_token_ids, mm_hashes, start_positions,
+                       num_mm_tokens):
+    """Validates multimodal inputs for consistency and correctness."""
+    # Validate number of hashes matches number of chunks
+    if len(mm_hashes) != len(num_mm_tokens):
+        raise AssertionError(
+            f"Number of hashes ({len(mm_hashes)}) does not match "
+            f"number of multimodal chunks ({len(num_mm_tokens)})")
+
+    # Validate number of start positions matches number of chunks
+    if len(start_positions) != len(num_mm_tokens):
+        raise AssertionError(
+            f"Number of start positions ({len(start_positions)}) does not match "
+            f"number of multimodal chunks ({len(num_mm_tokens)})")
+    # Validate each chunk's position and length
+    prompt_len = len(prompt_token_ids)
+    # Verify start_positions are sorted
+    if not all(start_positions[i] < start_positions[i + 1]
+               for i in range(len(start_positions) - 1)):
+        raise AssertionError(
+            "start_positions must be sorted in ascending order")
+    for chunk_idx, (start_pos,
+                    chunk_len) in enumerate(zip(start_positions,
+                                                num_mm_tokens)):
+        if start_pos < 0:
+            raise AssertionError(
+                f"Invalid negative start position {start_pos} for chunk {chunk_idx}"
+            )
+
+        if start_pos + chunk_len > prompt_len:
+            raise AssertionError(
+                f"Multimodal chunk {chunk_idx} at position {start_pos} with length {chunk_len} "
+                f"exceeds input sequence length {prompt_len}")
+
+        # Check for overlap with next chunk
+        if chunk_idx < len(start_positions) - 1:
+            next_start = start_positions[chunk_idx + 1]
+            if start_pos + chunk_len > next_start:
+                raise AssertionError(
+                    f"Multimodal chunk {chunk_idx} at position {start_pos} with length {chunk_len} "
+                    f"overlaps with chunk {chunk_idx + 1} at position {next_start}"
+                )

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -5,6 +5,9 @@ from torch import nn
 from ..logger import logger
 from ..sampling_params import SamplingParams
 from .data import TextPrompt
+from .multimodal import (MultimodalInput, apply_mm_hashes, default_hasher,
+                         find_mm_token_lengths, find_mm_token_positions,
+                         hexdigest_to_int32, validate_mm_inputs)
 from .utils import ALL_SUPPORTED_MULTIMODAL_MODELS
 
 N = TypeVar("N", bound=Type[nn.Module])
@@ -139,3 +142,51 @@ def create_input_processor(model_path_or_dir: str, tokenizer):
                                        trust_remote_code=True)
 
     return DefaultInputProcessor(None, None, tokenizer)
+
+
+def create_input_processor_with_hash(
+    input_processor,
+    hash_lib=default_hasher,
+):
+    """Creates a modified processor that applies additional logic like (hashing, find mm chunk positions) to the input processor
+
+    Args:
+        original_processor: The original input processor to wrap.
+        hash_lib: hasher to use (default: blake3)
+
+    Returns:
+        A wrapped processor that modifies prompts before processing.
+    """
+
+    def input_processor_wrapper(inputs, sampling_params):
+        assert 'multi_modal_data' in inputs, "multi_modal_data must be provided for hashing support."
+        mm_data = inputs['multi_modal_data']
+        num_mm_tokens = find_mm_token_lengths(mm_data, input_processor)
+        if len(num_mm_tokens) > 0:
+            mm_hashes = apply_mm_hashes(mm_data, hash_lib)
+            prompt_token_ids, extra_processed_inputs = input_processor(
+                inputs, sampling_params)
+            start_positions = find_mm_token_positions(
+                input_ids=prompt_token_ids,  # token sequence
+                num_mm_tokens=
+                num_mm_tokens,  # list of lengths of each chunk of visual tokens
+                vocab_size=input_processor.model_config.vocab_size,
+            )
+            # flatten the hashes from dict to a single list
+            mm_hashes = [h for hashes in mm_hashes.values() for h in hashes]
+            validate_mm_inputs(prompt_token_ids, mm_hashes, start_positions,
+                               num_mm_tokens)
+            mm_hashes_int32 = [hexdigest_to_int32(h) for h in mm_hashes
+                               ]  # nested list w/ multiple int32 per hash
+
+            extra_processed_inputs[
+                "multimodal_input"] = MultimodalInput.from_components(
+                    mm_hashes_int32, start_positions, num_mm_tokens)
+            return prompt_token_ids, extra_processed_inputs
+        else:
+            # disable hashing when output num_mm_tokens is empty, when
+            # (1) other modalities are found other than image
+            # (2) models that don't have get_num_tokens_per_image implemented
+            return input_processor(inputs, sampling_params)
+
+    return input_processor_wrapper

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -347,7 +347,6 @@ class LLM:
             prompt = None
             query_token_ids = inputs.get("query_token_ids", None)
         elif "prompt" in inputs:
-            prompt = inputs['prompt']
             if 'multi_modal_data' in inputs:
                 # TODO: The current design uses a wrapper for existing input processor (input_processor_with_hash)
                 # to handle/add multimodal hashes, positions, and lengths. Now we only support image modality.
@@ -363,6 +362,7 @@ class LLM:
                 with nvtx_range_debug("input_processor"):
                     prompt_token_ids, extra_processed_inputs = self.input_processor(
                         inputs, sampling_params)
+            prompt = inputs['prompt']
             if extra_processed_inputs is not None:
                 query_token_ids = extra_processed_inputs.get('query_token_ids')
                 multimodal_embedding = extra_processed_inputs.get(

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -352,7 +352,7 @@ class LLM:
                 # to handle/add multimodal hashes, positions, and lengths. Now we only support image modality.
                 # In the future, we should refactor this to:
                 # 1. Extend support for more modalities and models
-                # 2. Decouple input processor into distinct phases (preprocessor (all preprocessing logics), vision model (fuse in model fwd), etc.)
+                # 2. Decouple input processor into distinct phases (preprocessor (all preprocessing logics), vision model (fuse in model fwd), etc.
                 input_processor_with_hash = create_input_processor_with_hash(
                     self.input_processor)
                 with nvtx_range_debug("input_processor_with_hash"):

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -27,7 +27,8 @@ from ..executor import (DetokenizedGenerationResultBase, GenerationExecutor,
 from ..executor.postproc_worker import PostprocParams
 from ..executor.utils import (create_mpi_comm_session,
                               get_spawn_proxy_process_env)
-from ..inputs import PromptInputs, create_input_processor, prompt_inputs
+from ..inputs import (PromptInputs, create_input_processor,
+                      create_input_processor_with_hash, prompt_inputs)
 from ..logger import logger
 from ..sampling_params import SamplingParams
 from .llm_args import (LLMARGS_EXPLICIT_DOCSTRING, PybindMirror, TorchLlmArgs,
@@ -337,22 +338,38 @@ class LLM:
                 sampling_params.add_special_tokens = False
 
         query_token_ids = None
+        multimodal_input = None
         multimodal_embedding = None
         mrope_config = None
         if "prompt_token_ids" in inputs:
+            # TODO: if specify prompt_token_ids, the mm hashing is not supported yet
             prompt_token_ids = inputs['prompt_token_ids']
             prompt = None
             query_token_ids = inputs.get("query_token_ids", None)
         elif "prompt" in inputs:
-            with nvtx_range_debug("input_processor"):
-                prompt_token_ids, extra_processed_inputs = self.input_processor(
-                    inputs, sampling_params)
             prompt = inputs['prompt']
+            if 'multi_modal_data' in inputs:
+                # TODO: The current design uses a wrapper for existing input processor (input_processor_with_hash)
+                # to handle/add multimodal hashes, positions, and lengths. Now we only support image modality.
+                # In the future, we should refactor this to:
+                # 1. Extend support for more modalities and models
+                # 2. Decouple input processor into distinct phases (preprocessor (all preprocessing logics), vision model (fuse in model fwd), etc.)
+                input_processor_with_hash = create_input_processor_with_hash(
+                    self.input_processor)
+                with nvtx_range_debug("input_processor_with_hash"):
+                    prompt_token_ids, extra_processed_inputs = input_processor_with_hash(
+                        inputs, sampling_params)
+            else:
+                with nvtx_range_debug("input_processor"):
+                    prompt_token_ids, extra_processed_inputs = self.input_processor(
+                        inputs, sampling_params)
             if extra_processed_inputs is not None:
                 query_token_ids = extra_processed_inputs.get('query_token_ids')
                 multimodal_embedding = extra_processed_inputs.get(
                     'mm_embedding')
                 mrope_config = extra_processed_inputs.get('mrope_config')
+                multimodal_input = extra_processed_inputs.get(
+                    'multimodal_input')
         else:
             raise TypeError(
                 f"The inputs must be type str or list of int, but got {type(inputs)}"
@@ -372,6 +389,7 @@ class LLM:
             lora_request=lora_request,
             prompt_adapter_request=prompt_adapter_request,
             streaming=streaming,
+            multimodal_input=multimodal_input,
             multimodal_embedding=multimodal_embedding,
             mrope_config=mrope_config,
             kv_cache_retention_config=kv_cache_retention_config,

--- a/tensorrt_llm/runtime/model_runner_cpp.py
+++ b/tensorrt_llm/runtime/model_runner_cpp.py
@@ -870,6 +870,8 @@ class ModelRunnerCpp(ModelRunnerMixin):
                 ]
         return prompt_tuning_configs
 
+    # TODO: add multimodal input for TRT engine backend
+
     def _prepare_mrope_executor(self, batch_input_ids_list, mrope: MropeParams):
         mrope_configs = len(batch_input_ids_list) * [None]
         if mrope != None:

--- a/tests/unittest/bindings/test_executor_bindings.py
+++ b/tests/unittest/bindings/test_executor_bindings.py
@@ -969,6 +969,17 @@ def test_multimodal_embedding():
         small_embedding), "Multimodal embedding with different shape failed"
 
 
+def test_multimodal_input():
+    multimodal_hashes = [[1, 2, 3], [4, 5, 6]]
+    multimodal_positions = [1, 2, 3]
+    multimodal_lengths = [4, 5, 6]
+    config = trtllm.MultimodalInput(multimodal_hashes, multimodal_positions,
+                                    multimodal_lengths)
+    assert config.multimodal_hashes == multimodal_hashes
+    assert config.multimodal_positions == multimodal_positions
+    assert config.multimodal_lengths == multimodal_lengths
+
+
 def test_mrope_config():
     mrope_rotary_cos_sin = torch.ones(1, 4194304)
     mrope_position_deltas = torch.tensor([-50])

--- a/triton_backend/inflight_batcher_llm/src/utils.h
+++ b/triton_backend/inflight_batcher_llm/src/utils.h
@@ -104,6 +104,11 @@ struct InputFieldsNames
     static constexpr char const* mropeRotaryCosSin = "mrope_rotary_cos_sin";
     static constexpr char const* mropePositionDeltas = "mrope_position_deltas";
 
+    // MultimodalInput
+    static constexpr char const* multimodalHashes = "multimodal_hashes";
+    static constexpr char const* multimodalPositions = "multimodal_positions";
+    static constexpr char const* multimodalLengths = "multimodal_lengths";
+
     // LoraConfig
     static constexpr char const* loraTaskId = "lora_task_id";
     static constexpr char const* loraWeights = "lora_weights";


### PR DESCRIPTION
## Description

The current design introduces a temporary wrapper (input_processor_with_hash) to centralize logic for adding extra multimodal info—such as hashes, positions, and lengths—in addition to mm_embedding.

Note: This PR does not include any actual usages of such multimodal hash (e.g., for kv_cache/mm_emb reuse etc.).

Future work includes (maybe in separate PRs):
- Extend to all TRTLLM supported multimodes (this PR only covers qwen2 for now)
- Refactoring the input processor into distinct phases (e.g. preprocessor, vision model)

## Test Coverage

`python3 quickstart_multimodal.py --model_dir Qwen/Qwen2-VL-2B-Instruct --modality image`
`tests/unittest/bindings/test_executor_bindings.py`
<To be added>

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
