### PR TITLE
Ensure PDL is enabled for fc13 swiglu

### DIFF
--- a/cpp/tensorrt_llm/kernels/llama4TiledGemmSwiGLU/fc13_swiglu_fp8_per_block.cu
+++ b/cpp/tensorrt_llm/kernels/llama4TiledGemmSwiGLU/fc13_swiglu_fp8_per_block.cu
@@ -24,10 +24,8 @@ void launch_kernel(
     config.attrs = attrs;
     config.numAttrs = 0;
 
-#if ENABLE_FDL
     attrs[config.numAttrs].id = cudaLaunchAttributeProgrammaticStreamSerialization;
     attrs[config.numAttrs++].val.programmaticStreamSerializationAllowed = 1;
-#endif
 
     cudaLaunchKernelExC(&config, (void const*) kernel_func, args);
 }


### PR DESCRIPTION
# Ensure FDL is enabled for fc13 swiglu

## Description

Enable FDL is guarded by a macro that is not defined. Enabling FDL for the gemv FC13+SwiGLU kernel allows us to overlap kernels and save time.

## Test Coverage

### Quick verification

```
# 16 expert
PYTHONPATH=/code/tensorrt_llm python3 examples/pytorch/quickstart_advanced.py --model_dir /home/scratch.crush_data/trtllm-checkpoints/bf16-16e-ckpt --tp_size 8 --use_cuda_graph --attention_backend FLASHINFER
PYTHONPATH=/code/tensorrt_llm python3 examples/pytorch/quickstart_advanced.py --model_dir /home/scratch.crush_data/trtllm-checkpoints/fp8-16e-ckpt --tp_size 8 --use_cuda_graph --attention_backend FLASHINFER

# 128 expert
PYTHONPATH=/code/tensorrt_llm python3 examples/pytorch/quickstart_advanced.py --model_dir /home/scratch.crush_data/trtllm-checkpoints/bf16-128e-ckpt --tp_size 8 --use_cuda_graph --attention_backend FLASHINFER
PYTHONPATH=/code/tensorrt_llm python3 examples/pytorch/quickstart_advanced.py --model_dir /home/scratch.crush_data/trtllm-checkpoints/fp8-128e-ckpt --tp_size 8 --use_cuda_graph --attention_backend FLASHINFER
```

### Accuracy

GPQA: `{'score:std': np.float64(0.498364839770051), 'score:stderr': 0.035507024651313425, 'score': np.float64(0.5404040404040404), 'task_name': 'gpqa_diamond'}`
MMLU:  `MMLU weighted average accuracy: 86.08 (14042)`