### PR TITLE
[nvbugs/5268808][fix] Fix the potential out-of-range-access issue of allreduce workspace.

### DIFF
--- a/tensorrt_llm/_torch/distributed/ops.py
+++ b/tensorrt_llm/_torch/distributed/ops.py
@@ -12,10 +12,11 @@ _thread_local = threading.local()
 
 
 def get_allreduce_workspace(mapping: Mapping) -> torch.LongTensor:
-    if not hasattr(_thread_local, 'allreduce_workspaces'):
-        _thread_local.allreduce_workspaces = [{}
-                                              for _ in range(mapping.pp_size)]
-    allreduce_workspaces = _thread_local.allreduce_workspaces[mapping.pp_rank]
+    if not hasattr(_thread_local, f'allreduce_workspaces_{mapping.pp_rank}'):
+        setattr(_thread_local, f'allreduce_workspaces_{mapping.pp_rank}', {})
+
+    allreduce_workspaces = getattr(_thread_local,
+                                   f'allreduce_workspaces_{mapping.pp_rank}')
     if mapping not in allreduce_workspaces:
         ipc_buffers, workspace = CustomAllReduceHelper.allocate_allreduce_fusion_workspace(
             mapping,

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -647,8 +647,8 @@ class DeepseekV3DecoderLayer(DecoderLayer):
 
     def _enable_min_latency_mode(self, num_tokens: int):
         return (num_tokens <= 128 and self.fusion_config.POST_MOE_FUSION
-                and self.is_nvfp4
-                and self.model_config.moe_backend == 'CUTLASS')
+                and self.is_nvfp4 and self.model_config.moe_backend == 'CUTLASS'
+                and not self.mapping.is_multi_node())
 
     def forward(
         self,


### PR DESCRIPTION
This issue is only found for tp=ep=8 on multi-node machine. This could be caused by the race between different tp that triggers the illegal list access.