### PR TITLE
chore: Fix pipeline break caused by previous PR (#4081) rebase + pipeline reuse

### DIFF
--- a/tensorrt_llm/_torch/distributed/__init__.py
+++ b/tensorrt_llm/_torch/distributed/__init__.py
@@ -1,7 +1,8 @@
+from tensorrt_llm.functional import AllReduceFusionOp
+
 from .communicator import Distributed, MPIDist, PPComm, TorchDist
-from .ops import (AllReduce, AllReduceFusionOp, AllReduceParams,
-                  AllReduceStrategy, MoEAllReduce, allgather, reducescatter,
-                  userbuffers_allreduce_finalize)
+from .ops import (AllReduce, AllReduceParams, AllReduceStrategy, MoEAllReduce,
+                  allgather, reducescatter, userbuffers_allreduce_finalize)
 
 __all__ = [
     "allgather",


### PR DESCRIPTION
Previous #4081 rebase could cause import issues. This quick fix will import directly from __init__ to avoid this.