### PR TITLE
feat: Improve perf of AllGather-Top1 after LMHead

### DIFF
--- a/tensorrt_llm/_torch/distributed.py
+++ b/tensorrt_llm/_torch/distributed.py
@@ -216,6 +216,53 @@ class AllReduce(nn.Module):
         return output
 
 
+def allreduce_argmax(input: torch.Tensor,
+                     all_reduce: AllReduce,
+                     padding: int = 0,
+                     dim: int = -1,
+                     keepdim: bool = False,
+                     ) -> torch.Tensor:
+
+    assert dim == -1 or dim == input.dim() - 1, "Only supports allreduce_argmax along last dimension."
+
+    tp_size = all_reduce.mapping.tp_size
+    tp_rank = all_reduce.mapping.tp_rank
+
+    # If TP1, call argmax directly.
+    if tp_size == 1:
+        return torch.argmax(input, dim, keepdim=keepdim)
+
+    # Get per-rank number of elements.
+    per_rank_elements = input.shape[dim]
+
+    # For last rank, we need to remove the padding.
+    if tp_rank == tp_size - 1 and padding > 0:
+        input = input[..., :-padding]
+
+    # First, take argmax locally.
+    local_argmax = torch.argmax(input, dim, keepdim=True)
+    local_max = input.gather(dim=dim, index=local_argmax).float()
+    local_argmax = local_argmax.squeeze(dim)
+    local_max = local_max.squeeze(dim)
+
+    # Create a tensor to store both local argmax and local max, and then use allreduce to communicate across ranks.
+    # To reduce the number of transfers, we pack int32 as float32, hoping that adding 0.0f results in identical result.
+    # Since the vocab size is almost always <2^30, there should be no NaNs or infs that will mess up the argmax.
+    expanded_max = torch.zeros(2, *local_argmax.shape, tp_size, device=input.device, dtype=torch.float)
+    expanded_max[0, ..., tp_rank] = local_argmax.int().view(dtype=torch.float)
+    expanded_max[1, ..., tp_rank] = local_max
+    expanded_max = all_reduce(expanded_max)
+
+    # Finally, take argmax again to get the global argmax.
+    argmax_rank = torch.argmax(expanded_max[1], dim=-1, keepdim=True)
+    output = expanded_max[0].gather(dim=-1, index=argmax_rank).view(dtype=torch.int32).long() + argmax_rank * per_rank_elements
+
+    if not keepdim:
+        output = output.squeeze(dim)
+
+    return output
+
+
 class DeepseekAllReduce(nn.Module):
 
     def __init__(self, mapping: Mapping):

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -2,11 +2,12 @@ import bisect
 import contextlib
 import glob
 import math
+import multiprocessing
 import os
 import traceback
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import safetensors
 import torch
@@ -115,10 +116,41 @@ def validate_and_set_kv_cache_quant(model_config: ModelConfig,
     model_config.quant_config.kv_cache_quant_algo = mapped_pyt_quant
 
 
-def load_weights(checkpoint_dir: str):
+def prefetch_files(file_names: List[str], mapping: Mapping):
+    """
+    Prefetch safetensors files to memory so that the weight loading will be much faster.
+    When multiple ranks run in parallel, each rank will prefetch some files.
+    TODO: On systems with small memory, prefetching may cause file cache thrashing, so we may want to add some
+    heuristics about when to prefetch and when not to.
+    """
+
+    def _prefetch_one_file(file_name, rank):
+        if os.path.exists(file_name):
+            logger.info(f"Rank {rank} prefetching {file_name} to memory...")
+            with open(file_name, 'rb') as f:
+                f.read()
+            logger.info(f"Rank {rank} finished prefetching {file_name}.")
+
+    # Find out the files to prefetch for the current rank.
+    # Each rank loads files with indices rank, rank + world_size, rank + 2*world_size, etc.
+    local_file_names = file_names[mapping.rank::mapping.world_size]
+
+    processes = []
+    for file_name in local_file_names:
+        process = multiprocessing.Process(target=_prefetch_one_file,
+                                          args=(file_name, mapping.rank))
+        process.start()
+        processes.append(process)
+
+    for process in processes:
+        process.join()
+
+
+def load_weights(checkpoint_dir: str, mapping: Mapping):
     weights = {}
     weight_files = glob.glob(f"{checkpoint_dir}/*.safetensors")
     if weight_files:
+        prefetch_files(weight_files, mapping)
         for file in weight_files:
             logger.info(f"Loading {file}")
             part_weights = safetensors.torch.load_file(file)
@@ -816,15 +848,16 @@ class PyTorchModelEngine(ModelEngine):
 
             if load_format == LoadFormat.AUTO:
                 if hasattr(model, 'llm_checkpoint_dir'):
-                    weights = load_weights(model.llm_checkpoint_dir)
+                    weights = load_weights(model.llm_checkpoint_dir,
+                                           self.mapping)
                 else:
-                    weights = load_weights(checkpoint_dir)
+                    weights = load_weights(checkpoint_dir, self.mapping)
 
                 model.load_weights(weights)
 
                 if self.spec_config is not None and self.spec_config.spec_dec_mode.need_load_draft_weights(
                 ):
-                    weights = load_weights(self.spec_config.draft_model_path)
+                    weights = load_weights(self.spec_config.draft_model_path, self.mapping)
                     model.load_draft_weights(weights)
 
             elif load_format == LoadFormat.DUMMY:

--- a/tensorrt_llm/_torch/speculative/utils.py
+++ b/tensorrt_llm/_torch/speculative/utils.py
@@ -65,12 +65,12 @@ def get_num_spec_layers(spec_config):
         return 0
 
 
-def get_spec_worker(spec_config):
+def get_spec_worker(spec_config, mapping):
     if spec_config.spec_dec_mode.is_mtp():
         return MTPWorker(spec_config)
     elif spec_config.spec_dec_mode.is_mtp_eagle():
         return MTPEagleWorker(spec_config)
     elif spec_config.spec_dec_mode.is_eagle3_one_model():
-        return Eagle3OneModelWorker(spec_config)
+        return Eagle3OneModelWorker(spec_config, mapping)
     else:
         return None


### PR DESCRIPTION
[feat: Improve perf of AllGather-Top1 after LMHead](https://github.com/NVIDIA/TensorRT-LLM/commit/5591b8d9151df5c1d0cdc50a76d94c499d0e2c52) 

Currently, after we run LMHead, we first run AllGather to collect the
logits for the entire vocab size, and then apply top1. This has two perf
issues: (1) AllGather is slow (2) we are doing redundant top1 across tp
ranks.

Therefore, replace the AllGather-Top1 with Top1-AllReduce-Top1. The idea
is to first get the per-rank top1, and then use AllReduce to collect the
per-rank top1 argmax/max values, and then do argmax again.

This change requires turning off the AllGather in LMHead as well as
handling the additional AllReduce in Eagle3OneModelWorker.