### PR TITLE
add changes for fp8, nemotron-nas, API

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_nemotron_nas.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nas.py
@@ -1,10 +1,12 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import torch
 from torch import nn
 from transformers import PretrainedConfig
 
 from tensorrt_llm.functional import PositionEmbeddingType
+from tensorrt_llm.lora_manager import HfLoraLoader
+from tensorrt_llm.models.convert_utils import split_matrix_tp
 
 from ..attention_backend import AttentionMetadata
 from ..attention_backend.interface import PositionalEmbeddingParams, RopeParams
@@ -75,8 +77,12 @@ class LinearAttention(nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
+        lora_params: Optional[dict] = None,
         **kwargs: Any,
     ) -> torch.Tensor:
+        if lora_params is not None:
+            raise NotImplementedError(
+                "LinearAttention with LoRA is not supported yet")
         return self.linear_attn(hidden_states)
 
 
@@ -87,7 +93,12 @@ class LinearMLP(nn.Module):
         super().__init__()
         self.linear_mlp = _create_linear_from_configs(model_config, config)
 
-    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+    def forward(self,
+                hidden_states: torch.Tensor,
+                lora_params: Optional[dict] = None) -> torch.Tensor:
+        if lora_params is not None:
+            raise NotImplementedError(
+                "LinearMLP with LoRA is not supported yet")
         return self.linear_mlp(hidden_states)
 
 
@@ -121,7 +132,8 @@ class NemotronNASDecoderLayer(DecoderLayer):
                         self.block_config.ffn.ffn_mult, config.hidden_size),
                     bias=False,
                     dtype=config.torch_dtype,
-                    config=model_config)
+                    config=model_config,
+                    layer_idx=layer_idx)
 
     def forward(
         self,
@@ -147,7 +159,7 @@ class NemotronNASDecoderLayer(DecoderLayer):
             # Fully Connected
             residual = hidden_states
             hidden_states = self.post_attention_layernorm(hidden_states)
-            hidden_states = self.mlp(hidden_states)
+            hidden_states = self.mlp(hidden_states, **kwargs)
             hidden_states = residual + hidden_states
 
         return hidden_states
@@ -165,11 +177,35 @@ class NemotronNASModel(DecoderModel):
             for block in config.block_configs
         ]
 
+        vocab_size = config.vocab_size
+        self.has_custom_embed_tokens = False
+        if hasattr(
+                model_config,
+                'lora_config') and model_config.lora_config is not None and len(
+                    model_config.lora_config.lora_dir) == 1:
+            lora_loader = HfLoraLoader(model_config.lora_config.lora_dir)
+            if lora_loader.vocab_size != 0 and lora_loader.embed_tokens is not None:
+                vocab_size = lora_loader.vocab_size
+                weight = lora_loader.embed_tokens
+                self.has_custom_embed_tokens = True
+
         self.embed_tokens = Embedding(
-            config.vocab_size,
+            vocab_size,
             config.hidden_size,
             dtype=config.torch_dtype,
         )
+
+        if self.has_custom_embed_tokens:
+            with torch.no_grad():
+                if model_config.mapping.tp_size > 1:
+                    weight = split_matrix_tp(
+                        weight,
+                        model_config.mapping.tp_size,
+                        model_config.mapping.tp_rank,
+                        dim=0)  # split by vocabulary dimension
+                x = weight.to(self.embed_tokens.dtype)
+                self.embed_tokens.weight.data.copy_(x)
+
         self.layers = nn.ModuleList([
             NemotronNASDecoderLayer(model_config, block_config, layer_idx)
             for layer_idx, block_config in enumerate(config.block_configs)

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -373,7 +373,6 @@ class Linear(nn.Module):
             lora_result = self.lora(input, lora_params, layer_idx)
             if lora_result is not None:
                 output = output + lora_result
-
         return output
 
     def _maybe_fuse_bias_into_allreduce(

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -1,4 +1,5 @@
 import copy
+from typing import Optional
 
 import tensorrt_llm
 from tensorrt_llm._utils import get_sm_version
@@ -25,7 +26,7 @@ from .py_executor import PyExecutor
 def create_py_executor(executor_config: ExecutorConfig,
                        checkpoint_dir: str = None,
                        engine_dir: str = None,
-                       lora_config: LoraConfig = None) -> PyExecutor:
+                       lora_config: Optional[LoraConfig] = None) -> PyExecutor:
     if executor_config.pytorch_backend_config is None:
         executor_config.pytorch_backend_config = PyTorchConfig()
 

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -629,9 +629,8 @@ class LLM:
         if self.runtime_context is not None:
             return self.runtime_context.tokenizer
 
-        # TODO smor- need to look more on this
-        # what should be chose as the tokenizer? the adapter or the base model?
-        # what happens if we have multiple adapters?
+        # TODO smor- need to refine what is the desired behavior if lora is enabled
+        # in terms of the tokenizer initialization process
         if hasattr(
                 self.args, "backend"
         ) and self.args.backend == "pytorch" and self.args.lora_config is not None:
@@ -643,14 +642,12 @@ class LLM:
                         tokenizer_path,
                         trust_remote_code=self.args.trust_remote_code,
                         use_fast=self.args.tokenizer_mode != 'slow')
-                    return tokenizer
+                    if tokenizer is None:
+                        tokenizer_path = self.args.model
+                    else:
+                        return tokenizer
                 except Exception:
                     tokenizer_path = self.args.model
-            elif num_lora_dirs > 1:
-                # TODO smor- currently not supported, need to determine which tokenizer to use, if possible
-                raise ValueError(
-                    f"Expecting only a single lora dir, but got {num_lora_dirs}"
-                )
             else:
                 tokenizer_path = self.args.model
         else:

--- a/tensorrt_llm/lora_manager.py
+++ b/tensorrt_llm/lora_manager.py
@@ -147,6 +147,8 @@ class LoraConfig(DictConversion):
     max_lora_rank: int = 64
     lora_target_modules: List[str] = field(default_factory=list)
     trtllm_modules_to_hf_modules: Dict[str, str] = field(default_factory=dict)
+    max_loras: int = 4
+    max_cpu_loras: int = 4
 
     def __post_init__(self):
         assert self.lora_ckpt_source in [

--- a/tests/integration/test_lists/test-db/l0_dgx_h200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_h200.yml
@@ -18,3 +18,4 @@ l0_dgx_h200:
   # - accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_fp8_blockscale[throughput] # OOM
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_fp8_blockscale[latency] # 1h
   - unittest/_torch/multi_gpu_modeling/test_llama4.py::test_llama4[pp1-ep1-enable_graph-tp8-trtllm-scout]
+  - unittest/llmapi/test_llm_pytorch.py::test_nemotron_nas_lora

--- a/tests/unittest/api_stability/references/llm.yaml
+++ b/tests/unittest/api_stability/references/llm.yaml
@@ -71,9 +71,16 @@ methods:
       workspace:
         annotation: Optional[str]
         default: null
-      lora_config:
-        annotation: Optional[tensorrt_llm.llmapi.llm_args.LoraConfig]
+      # LoRA
+      max_lora_rank:
+        annotation: Optional[int]
         default: null
+      max_loras:
+        annotation: int
+        default: 4
+      max_cpu_loras:
+        annotation: int
+        default: 4
       kwargs:
         annotation: Any
         default: inspect._empty

--- a/tests/unittest/api_stability/references_committed/llm.yaml
+++ b/tests/unittest/api_stability/references_committed/llm.yaml
@@ -47,15 +47,9 @@ methods:
       enable_lora:
         annotation: bool
         default: false
-      max_lora_rank:
-        annotation: Optional[int]
+      lora_config:
+        annotation: Optional[tensorrt_llm.llmapi.llm_args.LoraConfig]
         default: null
-      max_loras:
-        annotation: int
-        default: 4
-      max_cpu_loras:
-        annotation: int
-        default: 4
       # Prompt tuning
       enable_prompt_adapter:
         annotation: bool

--- a/tests/unittest/llmapi/test_llm_pytorch.py
+++ b/tests/unittest/llmapi/test_llm_pytorch.py
@@ -4,16 +4,25 @@ from tensorrt_llm.llmapi.tokenizer import TransformersTokenizer
 from tensorrt_llm.sampling_params import SamplingParams
 
 # isort: off
-from .test_llm import (
-    get_model_path, global_kvcache_config, llama_model_path,
-    llm_get_stats_async_test_harness, llm_get_stats_test_harness, prompts,
-    run_llm_abort_request, run_llm_with_postprocess_parallel_and_result_handler,
-    tinyllama_guided_decoding_test_harness,
-    tinyllama_logits_processor_test_harness, llama_7b_multi_lora_test_harness)
-from utils.util import force_ampere, similar, skip_gpu_memory_less_than_40gb
+from .test_llm import (get_model_path, global_kvcache_config, llama_model_path,
+                       llm_get_stats_async_test_harness,
+                       llm_get_stats_test_harness, prompts,
+                       run_llm_abort_request,
+                       run_llm_with_postprocess_parallel_and_result_handler,
+                       tinyllama_guided_decoding_test_harness,
+                       tinyllama_logits_processor_test_harness)
+from utils.util import force_ampere, similar, skip_gpu_memory_less_than_40gb, skip_gpu_memory_less_than_80gb, skip_gpu_memory_less_than_138gb
 from utils.llm_data import llm_models_root
 from tensorrt_llm.lora_manager import LoraConfig
 from tensorrt_llm.executor.request import LoRARequest
+from tensorrt_llm.models.modeling_utils import QuantConfig
+from tensorrt_llm.quantization.mode import QuantAlgo
+import tempfile
+
+import torch
+from peft import LoraConfig as PeftLoraConfig
+from peft import get_peft_model
+from transformers import AutoModelForCausalLM
 
 # isort: on
 
@@ -182,5 +191,130 @@ def test_llama_v2_13b_lora():
 
 
 @skip_gpu_memory_less_than_40gb
+def test_llama_7b_lora_default_modules() -> None:
+    from tensorrt_llm._torch.llm import LLM
+
+    lora_config = LoraConfig(max_lora_rank=64)
+
+    hf_model_dir = f"{llm_models_root()}/llama-models/llama-7b-hf"
+
+    llm = LLM(model=hf_model_dir, lora_config=lora_config)
+
+    hf_lora_dir = f"{llm_models_root()}/llama-models/luotuo-lora-7b-0.1"
+    prompts = [
+        "美国的首都在哪里? \n答案:",
+    ]
+    references = [
+        "美国的首都是华盛顿。\n\n美国的",
+    ]
+    sampling_params = SamplingParams(max_tokens=20, add_special_tokens=False)
+    lora_req = LoRARequest("luotuo", 1, hf_lora_dir)
+    lora_request = [lora_req]
+
+    outputs = llm.generate(prompts, sampling_params, lora_request=lora_request)
+
+    assert similar(outputs[0].outputs[0].text, references[0])
+
+
+@skip_gpu_memory_less_than_40gb
 def test_llama_7b_multi_lora():
     llama_7b_multi_lora_test_harness()
+
+
+# TODO smor: currently Nemotron-Super-49B-v1 with LoRA memory consumption is overly high
+# https://jirasw.nvidia.com/browse/TRTLLM-5045
+@skip_gpu_memory_less_than_138gb
+def test_nemotron_nas_lora() -> None:
+    from tensorrt_llm._torch.llm import LLM
+
+    lora_config = LoraConfig(lora_dir=[
+        f"{llm_models_root()}/nemotron-nas/Llama-3_3-Nemotron-Super-49B-v1-lora-adapter_r64"
+    ],
+                             max_lora_rank=64,
+                             max_loras=1,
+                             max_cpu_loras=1)
+
+    llm = LLM(
+        model=
+        f"{llm_models_root()}/nemotron-nas/Llama-3_3-Nemotron-Super-49B-v1",
+        lora_config=lora_config,
+    )
+
+    prompts = [
+        "Hello, how are you?",
+        "Hello, how are you?",
+    ]
+
+    sampling_params = SamplingParams(max_tokens=10, add_special_tokens=False)
+    lora_req = LoRARequest(
+        "task-0", 0,
+        f"{llm_models_root()}/nemotron-nas/Llama-3_3-Nemotron-Super-49B-v1-lora-adapter_r64"
+    )
+    lora_request = [lora_req, None]
+
+    outputs = llm.generate(prompts, sampling_params, lora_request=lora_request)
+
+    assert similar(outputs[0].outputs[0].text, outputs[1].outputs[0].text)
+
+
+@skip_gpu_memory_less_than_80gb
+def test_codellama_fp8_with_bf16_lora() -> None:
+    from tensorrt_llm._torch.llm import LLM
+
+    model_dir = f"{llm_models_root()}/codellama/CodeLlama-7b-Instruct-hf/"
+    quant_config = QuantConfig(quant_algo=QuantAlgo.FP8,
+                               kv_cache_quant_algo=QuantAlgo.FP8)
+
+    target_modules = ['attn_q', 'attn_k', 'attn_v']
+
+    # Set up temporary directory for LoRA adapters
+    with tempfile.TemporaryDirectory() as lora_dir:
+        print("Creating dummy LoRAs...")
+
+        model = AutoModelForCausalLM.from_pretrained(
+            model_dir,
+            torch_dtype=torch.bfloat16,
+            device_map="auto",
+            trust_remote_code=True,
+        )
+
+        hf_modules = ["q_proj", "k_proj", "v_proj"]
+
+        lora_config = PeftLoraConfig(r=8,
+                                     target_modules=hf_modules,
+                                     bias="none",
+                                     task_type="CAUSAL_LM")
+
+        lora_paths = []
+        for i in range(2):
+            lora_model = get_peft_model(model, lora_config)
+            for param in lora_model.parameters():
+                param.data.zero_()
+            lora_path = f"{lora_dir}/lora_{i}"
+            lora_model.save_pretrained(lora_path)
+            lora_paths.append(lora_path)
+
+        lora_config = LoraConfig(lora_dir=lora_paths,
+                                 lora_target_modules=target_modules,
+                                 max_lora_rank=8)
+
+        llm = LLM(model_dir,
+                  quant_config=quant_config,
+                  fast_build=True,
+                  lora_config=lora_config)
+
+        prompts = [
+            "Write a function that calculates the Fibonacci sequence.",
+            "Convert this C++ code to Python: int x = 0; x++;",
+        ]
+
+        lora_req1 = LoRARequest("lora-1", 0, lora_paths[0])
+        lora_req2 = LoRARequest("lora-2", 1, lora_paths[1])
+        lora_requests = [lora_req1, lora_req2]
+        sampling_params = SamplingParams(max_tokens=200)
+
+        outputs = llm.generate(prompts,
+                               sampling_params,
+                               lora_request=lora_requests)
+
+        assert len(outputs) == 2

--- a/tests/unittest/utils/util.py
+++ b/tests/unittest/utils/util.py
@@ -176,6 +176,12 @@ def skip_gpu_memory_less_than(required_memory: int):
 skip_gpu_memory_less_than_40gb = skip_gpu_memory_less_than(40 * 1024 * 1024 *
                                                            1024)
 
+skip_gpu_memory_less_than_80gb = skip_gpu_memory_less_than(80 * 1024 * 1024 *
+                                                           1024)
+
+skip_gpu_memory_less_than_138gb = skip_gpu_memory_less_than(138 * 1024 * 1024 *
+                                                            1024)
+
 
 def modelopt_installed():
     try:


### PR DESCRIPTION
# PR title

## Description

This PR includes the changes required for feature-complete support of LoRA in PyTorch flow.
It includes:
* API changes
* FP8 test
* Nemotron-NAS dummy support

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
