### PR TITLE
feat: Support Mistral Small 3.1 24B VLM in TRT workflow

### DIFF
--- a/examples/models/core/multimodal/run.py
+++ b/examples/models/core/multimodal/run.py
@@ -41,7 +41,7 @@ def print_result(model, input_text, output_text, args):
                     0][0].lower()
             elif model.model_type in [
                     'blip2', 'neva', 'phi-3-vision', 'llava_next',
-                    'phi-4-multimodal'
+                    'phi-4-multimodal', 'pixtral'
             ]:
                 assert 'singapore' in output_text[0][0].lower()
             elif model.model_type == 'video-neva':

--- a/tensorrt_llm/models/llama/config.py
+++ b/tensorrt_llm/models/llama/config.py
@@ -137,6 +137,11 @@ class LLaMAConfig(PretrainedConfig):
                 # InternLM-XComposer2 has a mask for partial lora
                 # Therefore we need an additional flag for this mask
                 has_partial_lora_mask = True
+            if hf_config.model_type == 'mistral3':
+                from transformers import Mistral3Config
+                hf_config = Mistral3Config.from_pretrained(
+                    hf_config_dir).text_config
+                hf_config.architectures = ["MistralForCausalLM"]
 
         num_key_value_heads = getattr(hf_config, "num_key_value_heads",
                                       hf_config.num_attention_heads)

--- a/tensorrt_llm/tools/multimodal_builder.py
+++ b/tensorrt_llm/tools/multimodal_builder.py
@@ -41,7 +41,7 @@ def add_multimodal_arguments(parser):
                             'fuyu', 'pix2struct', 'neva', 'kosmos-2',
                             'video-neva', 'phi-3-vision', 'phi-4-multimodal',
                             'mllama', 'internvl', 'qwen2_vl',
-                            'internlm-xcomposer2', 'qwen2_audio'
+                            'internlm-xcomposer2', 'qwen2_audio', 'pixtral'
                         ],
                         help="Model type")
     parser.add_argument(
@@ -142,6 +142,8 @@ class MultimodalEngineBuilder:
             build_qwen2_vl_engine(args)
         elif args.model_type == 'qwen2_audio':
             build_qwen2_audio_engine(args)
+        elif args.model_type == "pixtral":
+            build_pixtral_engine(args)
         else:
             raise RuntimeError(f"Invalid model type {args.model_type}")
 
@@ -1577,3 +1579,158 @@ def build_qwen2_audio_engine(args):
                          'num_mul_bins': args.num_mul_bins,
                          'max_mel_seq_len': args.max_mel_seq_len
                      })
+
+
+def build_pixtral_engine(args):
+    processor = AutoProcessor.from_pretrained(args.model_path)
+    hf_config = AutoConfig.from_pretrained(args.model_path)
+    vision_config = hf_config.vision_config
+    raw_image = Image.new(
+        'RGB',
+        [vision_config.image_size, vision_config.image_size])  # dummy image
+
+    inputs = processor(text="dummy", images=[raw_image], return_tensors="pt")
+    pixel_values = inputs["pixel_values"].to(args.device, torch.bfloat16)
+    attention_mask = torch.zeros(
+        1, vision_config.image_size // vision_config.patch_size,
+        vision_config.image_size // vision_config.patch_size).to(
+            args.device, torch.bfloat16)
+
+    # isort: off
+    from transformers.models.pixtral.modeling_pixtral import \
+        apply_rotary_pos_emb
+    from transformers import Mistral3ForConditionalGeneration
+    from transformers.models.pixtral.modeling_pixtral import (PixtralAttention,
+                                                              PixtralVisionModel
+                                                              )
+    from transformers.models.mistral3.modeling_mistral3 import (
+        Mistral3MultiModalProjector, Mistral3PatchMerger)
+    # isort: on
+    @torch.no_grad
+    def attn_forward(self,
+                     hidden_states,
+                     attention_mask,
+                     position_embeddings,
+                     output_attentions=False):
+        batch, patches, _ = hidden_states.size()
+
+        q = self.q_proj(hidden_states)
+        k = self.k_proj(hidden_states)
+        v = self.v_proj(hidden_states)
+
+        q = q.view(batch, patches, self.num_heads,
+                   self.head_dim).transpose(1, 2)
+        k = k.view(batch, patches, self.num_heads,
+                   self.head_dim).transpose(1, 2)
+        v = v.view(batch, patches, self.num_heads,
+                   self.head_dim).transpose(1, 2)
+        cos, sin = position_embeddings
+        q, k = apply_rotary_pos_emb(q, k, cos, sin, unsqueeze_dim=0)
+
+        attn_output = torch.nn.functional.scaled_dot_product_attention(
+            q, k, v, attn_mask=attention_mask).transpose(1, 2).contiguous()
+        attn_output = attn_output.reshape(batch, patches, -1)
+        attn_output = self.o_proj(attn_output)
+
+        return attn_output, None
+
+    @torch.no_grad
+    def vision_tower_forward(self, pixel_values, attention_mask):
+        patch_embeds = self.patch_conv(pixel_values)  # (bs, c, h, w)
+
+        patch_embeds = patch_embeds.flatten(2).transpose(1, 2)  # (bs, h*w, c)
+        attention_mask = attention_mask.flatten(1)  # (bs, h*w)
+
+        patch_embeds = self.ln_pre(patch_embeds)
+        position_ids = self.position_ids.flatten()  # (h*w, )
+        position_embeddings = self.patch_positional_embedding(
+            patch_embeds, position_ids)
+
+        out = self.transformer(patch_embeds,
+                               attention_mask=attention_mask,
+                               position_embeddings=position_embeddings,
+                               output_hidden_states=False,
+                               output_attentions=False,
+                               return_dict=False)[0]
+        return out
+
+    @torch.no_grad
+    def patch_merger_forward(self, image_features, attention_mask):
+        h, w = attention_mask.shape[-2:]
+        bs, n, d = image_features.shape
+        image_grid = image_features.view(bs, h, w, d).permute(0, 3, 1, 2)
+        image_features = torch.nn.functional.unfold(image_grid, 2,
+                                                    stride=2).transpose(1, 2)
+        image_features = self.merging_layer(image_features)
+        return image_features
+
+    @torch.no_grad
+    def mm_projector_forward(self, image_features, attention_mask):
+        image_features = self.norm(image_features)
+        image_features = self.patch_merger(image_features, attention_mask)
+        hidden_states = self.linear_2(self.act(self.linear_1(image_features)))
+        return hidden_states
+
+    class PixtralVisionWrapper(torch.nn.Module):
+
+        def __init__(self, vision_tower, mm_projector):
+            super().__init__()
+            self.vision_tower = vision_tower
+            self.mm_projector = mm_projector
+
+        @torch.no_grad
+        def forward(self, pixel_values, attention_mask):
+            features = self.vision_tower(pixel_values, attention_mask)
+            out = self.mm_projector(features, attention_mask)
+            return out
+
+    model = Mistral3ForConditionalGeneration.from_pretrained(args.model_path,
+                                                             torch_dtype="auto")
+    vision_tower = model.vision_tower
+    mm_projector = model.multi_modal_projector
+
+    height = width = vision_config.image_size // vision_config.patch_size
+    mesh = torch.meshgrid(torch.arange(height),
+                          torch.arange(width),
+                          indexing="ij")
+    h_grid, v_grid = torch.stack(mesh, dim=-1).chunk(2, -1)
+    ids = h_grid[..., 0] * width + v_grid[..., 0]
+    vision_tower.register_buffer("position_ids", ids)
+
+    PixtralAttention.forward = attn_forward
+    PixtralVisionModel.forward = vision_tower_forward
+
+    Mistral3PatchMerger.forward = patch_merger_forward
+    Mistral3MultiModalProjector.forward = mm_projector_forward
+
+    vision_tower = vision_tower.to(args.device, torch.bfloat16)
+    mm_projector = mm_projector.to(args.device, torch.bfloat16)
+    vision_tower.eval()
+    mm_projector.eval()
+    wrapper = PixtralVisionWrapper(vision_tower, mm_projector)
+
+    Path(args.output_dir).mkdir(parents=True, exist_ok=True)
+    part_name = 'vision'
+    onnx_dir = f"{args.output_dir}/{part_name}/onnx"
+
+    export_onnx(wrapper,
+                input=(pixel_values, attention_mask),
+                onnx_dir=onnx_dir,
+                input_names=['input', 'attention_mask'],
+                dynamic_axes={
+                    'input': {
+                        0: "batch"
+                    },
+                    'attention_mask': {
+                        0: "batch"
+                    }
+                })
+    build_trt_engine(
+        args.model_type,
+        input_sizes=[[list(pixel_values.shape[1:]) for _ in range(3)],
+                     [list(attention_mask.shape[1:]) for _ in range(3)]],
+        onnx_dir=onnx_dir,
+        engine_dir=args.output_dir,
+        max_batch_size=args.max_batch_size,
+        engine_name=f"model.engine",
+        dtype=torch.bfloat16)

--- a/tests/integration/defs/conftest.py
+++ b/tests/integration/defs/conftest.py
@@ -794,6 +794,8 @@ def multimodal_model_root(request, llm_venv):
         tllm_model_name = tllm_model_name + ".nemo"
     elif 'Llama-3.2' in tllm_model_name:
         models_root = os.path.join(llm_models_root(), 'llama-3.2-models')
+    elif 'Mistral-Small' in tllm_model_name:
+        models_root = llm_models_root()
 
     multimodal_model_root = os.path.join(models_root, tllm_model_name)
 

--- a/tests/integration/defs/examples/test_multimodal.py
+++ b/tests/integration/defs/examples/test_multimodal.py
@@ -115,7 +115,7 @@ def _test_llm_multimodal_general(llm_venv,
     mllama_model = 'Llama-3.2' in model_name
     qwen2_vl_model = 'Qwen2-VL' in model_name
     internlm_model = 'internlm-xcomposer2' in model_name
-
+    mistral_model = 'Mistral-Small' in model_name
     if enc_dec_model:
         builder_root = enc_dec_example_root
         if nougat_model:
@@ -133,6 +133,8 @@ def _test_llm_multimodal_general(llm_venv,
     elif internlm_model:
         builder_root, model_type = internlm_example_root, "internlm"
     elif llava_model or vila_model:
+        builder_root, model_type = llama_example_root, "llama"
+    elif mistral_model:
         builder_root, model_type = llama_example_root, "llama"
     elif cogvlm_model:
         builder_root, model_type = cogvlm_example_root, "cogvlm"
@@ -214,7 +216,7 @@ def _test_llm_multimodal_general(llm_venv,
     print("Build LLM engines...")
     model_name = model_name.split('/')[-1]  # Remove HF directory name
     llm_engine_dir = f"{engine_dir}/{model_name}/{world_size}-gpu"
-    if "opt" in model_name or llava_model or vila_model or gpt_model or nemotron_model or phi3_model or phi4_model or qwen2_vl_model:
+    if "opt" in model_name or llava_model or vila_model or gpt_model or nemotron_model or phi3_model or phi4_model or qwen2_vl_model or mistral_model:
         max_input_len_text = 1024
         max_output_len = 200
         if llava_next_model:
@@ -227,7 +229,9 @@ def _test_llm_multimodal_general(llm_venv,
             multimodal_len = 196
         elif phi3_model:
             multimodal_len = 5120
-        elif phi4_model:  # @B: Confirm this.
+        elif phi4_model:
+            multimodal_len = 5120
+        elif mistral_model:
             multimodal_len = 5120
         elif "fuyu" in model_name:
             multimodal_len = 2640
@@ -386,6 +390,7 @@ def _test_llm_multimodal_general(llm_venv,
     elif 'Llama-3.2' in model_name: vision_model_type = 'mllama'
     elif "Qwen2-VL" in model_name: vision_model_type = 'qwen2_vl'
     elif 'internlm' in model_name: vision_model_type = 'internlm-xcomposer2'
+    elif 'Mistral-Small' in model_name: vision_model_type = 'pixtral'
 
     vit_batch_size = batch_size
     if vision_model_type == "llava_next":
@@ -623,6 +628,7 @@ def _test_llm_multimodal_general(llm_venv,
     'Llama-3.2-11B-Vision',
     'Qwen2-VL-7B-Instruct',
     'internlm-xcomposer2-vl-7b',
+    'Mistral-Small-3.1-24B-Instruct-2503',
 ],
                          indirect=True)
 def test_llm_multimodal_general(llm_venv, llm_root, llm_datasets_root,

--- a/tests/integration/test_lists/qa/examples_test_list.txt
+++ b/tests/integration/test_lists/qa/examples_test_list.txt
@@ -181,6 +181,7 @@ examples/test_multimodal.py::test_llm_multimodal_general[llava-v1.6-mistral-7b-h
 examples/test_multimodal.py::test_llm_multimodal_general[llava-v1.6-mistral-7b-hf-vision-trtllm-pp:1-tp:2-float16-bs:1-cpp_e2e:False-nb:1]
 examples/test_multimodal.py::test_llm_multimodal_general[llava-onevision-qwen2-7b-ov-hf-pp:1-tp:1-float16-bs:1-cpp_e2e:False-nb:1]
 examples/test_multimodal.py::test_llm_multimodal_general[llava-onevision-qwen2-7b-ov-hf-video-pp:1-tp:1-float16-bs:1-cpp_e2e:False-nb:1]
+examples/test_multimodal.py::test_llm_multimodal_general[Mistral-Small-3.1-24B-Instruct-2503-pp:1-tp:1-bfloat16-bs:1-cpp_e2e:False-nb:1]
 examples/test_multimodal.py::test_llm_multimodal_general[neva-22b-pp:1-tp:1-bfloat16-bs:1-cpp_e2e:False-nb:1]
 examples/test_multimodal.py::test_llm_multimodal_general[neva-22b-pp:1-tp:1-bfloat16-bs:8-cpp_e2e:False-nb:1]
 examples/test_multimodal.py::test_llm_multimodal_general[nougat-base-pp:1-tp:1-bfloat16-bs:1-cpp_e2e:False-nb:1]

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -229,6 +229,7 @@ l0_h100:
   - examples/test_multimodal.py::test_llm_multimodal_general[Phi-3-vision-128k-instruct-pp:1-tp:1-float16-bs:1-cpp_e2e:False-nb:1]
   - examples/test_multimodal.py::test_llm_multimodal_general[Phi-3.5-vision-instruct-pp:1-tp:1-float16-bs:1-cpp_e2e:False-nb:1]
   - examples/test_multimodal.py::test_llm_multimodal_general[Phi-4-multimodal-instruct-pp:1-tp:1-float16-bs:1-cpp_e2e:False-nb:1]
+  - examples/test_multimodal.py::test_llm_multimodal_general[Mistral-Small-3.1-24B-Instruct-2503-pp:1-tp:1-bfloat16-bs:1-cpp_e2e:False-nb:1]
   - examples/test_multimodal.py::test_llm_multimodal_general[VILA1.5-3b-pp:1-tp:1-float16-bs:1-cpp_e2e:False-nb:1] # 10 mins
   - examples/test_enc_dec.py::test_llm_enc_dec_mmlu[flan-t5-small-float32-tp:1-pp:1-nb:1-enable_fp8] # 7 mins
   - examples/test_enc_dec.py::test_llm_enc_dec_general[compare_hf-bart-large-cnn-float16-enable_gemm_plugin-enable_attention_plugin-enable_paged_kv_cache-tp:1-pp:1-nb:1-enable_fp8] # 13 mins


### PR DESCRIPTION
## Description
```
# Build TRT engine for vision encoder.
$ rm -rf mistral_mm_eng/ && python examples/models/core/multimodal/build_multimodal_engine.py --model_path /home/bbuddharaju/scratch/random/hf_models/Mistral-Small-3.1-24B-Instruct-2503/ --model_type pixtral --max_batch_size 8 --output_dir mistral_mm_eng/vision/

# Create TRTLLM checkpoint for the LLM decoder.
$ rm -rf mistral_mm_llm_ckpt/ && python examples/models/core/llama/convert_checkpoint.py --model_dir /home/bbuddharaju/scratch/random/hf_models/Mistral-Small-3.1-24B-Instruct-2503/ --output_dir mistral_mm_llm_ckpt/ --dtype bfloat16

# Build TRT engine for LLM decoder.
$ rm -rf mistral_mm_eng/llm/ && trtllm-build --checkpoint_dir mistral_mm_llm_ckpt/ --output_dir mistral_mm_eng/llm/ --max_batch_size 8 --max_input_len 131072 --max_seq_len 131072 --max_multimodal_len $((131072 * 8)) --use_paged_context_fmha enable

# Run the entire pipeline.
$ python examples/models/core/multimodal/run.py --hf_model_dir /home/bbuddharaju/scratch/random/hf_models/Mistral-Small-3.1-24B-Instruct-2503/ --engine_dir mistral_mm_eng/ --visual_engine_name model.engine --batch_size 1 --enable_chunked_context --max_new_tokens 512 --temperature 0 --top_p 1 --lora_task_uids -1 --session python
```

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->
```
$ pytest tests/integration/defs/examples/test_multimodal.py::test_llm_multimodal_general[Mistral-Small-3.1-24B-Instruct-2503-pp:1-tp:1-bfloat16-bs:1-cpp_e2e:False-nb:1] -s -v
```
## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
