### PR TITLE
infra: [TRTLLM-325] Prepare for NGC release - multiplatform build

### DIFF
--- a/docker/Dockerfile.multi
+++ b/docker/Dockerfile.multi
@@ -5,8 +5,6 @@ ARG BASE_TAG=25.03-py3
 ARG TRITON_BASE_TAG=25.03-py3
 ARG DEVEL_IMAGE=devel
 
-FROM ${TRITON_IMAGE}:${TRITON_BASE_TAG} AS triton
-
 FROM ${BASE_IMAGE}:${BASE_TAG} AS base
 
 # Add NVIDIA EULA and AI Terms labels
@@ -57,15 +55,6 @@ RUN bash ./install_tensorrt.sh \
     --CUBLAS_VER=${CUBLAS_VER} && \
     rm install_tensorrt.sh
 
-ARG INSTALL_TRITON=0
-COPY --from=triton /opt/tritonserver/backends/python /opt/tritonserver/backends/python
-COPY --from=triton /opt/tritonserver/lib /opt/tritonserver/lib
-COPY --from=triton /opt/tritonserver/include /opt/tritonserver/include
-COPY --from=triton /opt/tritonserver/bin /opt/tritonserver/bin
-COPY --from=triton /opt/tritonserver/caches /opt/tritonserver/caches
-COPY docker/common/install_triton.sh install_triton.sh
-RUN bash ./install_triton.sh && rm install_triton.sh
-
 # Install latest Polygraphy
 COPY docker/common/install_polygraphy.sh install_polygraphy.sh
 RUN bash ./install_polygraphy.sh && rm install_polygraphy.sh
@@ -73,14 +62,6 @@ RUN bash ./install_polygraphy.sh && rm install_polygraphy.sh
 # Install mpi4py
 COPY docker/common/install_mpi4py.sh install_mpi4py.sh
 RUN bash ./install_mpi4py.sh && rm install_mpi4py.sh
-
-# Install NIXL
-COPY docker/common/install_nixl.sh install_nixl.sh
-RUN bash ./install_nixl.sh && rm install_nixl.sh
-
-# Install etcd
-COPY docker/common/install_etcd.sh install_etcd.sh
-RUN bash ./install_etcd.sh && rm install_etcd.sh
 
 # Install PyTorch
 ARG TORCH_INSTALL_TYPE="skip"
@@ -90,6 +71,28 @@ RUN bash ./install_pytorch.sh $TORCH_INSTALL_TYPE && rm install_pytorch.sh
 # Install OpenCV with FFMPEG support
 RUN pip3 uninstall -y opencv && rm -rf /usr/local/lib/python3*/dist-packages/cv2/
 RUN pip3 install opencv-python-headless --force-reinstall --no-deps --no-cache-dir
+
+
+FROM ${TRITON_IMAGE}:${TRITON_BASE_TAG} AS triton
+
+FROM devel AS tritondevel
+
+COPY --from=triton /opt/tritonserver/backends/python /opt/tritonserver/backends/python
+COPY --from=triton /opt/tritonserver/lib /opt/tritonserver/lib
+COPY --from=triton /opt/tritonserver/include /opt/tritonserver/include
+COPY --from=triton /opt/tritonserver/bin /opt/tritonserver/bin
+COPY --from=triton /opt/tritonserver/caches /opt/tritonserver/caches
+COPY docker/common/install_triton.sh install_triton.sh
+RUN bash ./install_triton.sh && rm install_triton.sh
+
+# Install NIXL
+COPY docker/common/install_nixl.sh install_nixl.sh
+RUN bash ./install_nixl.sh && rm install_nixl.sh
+
+# Install etcd
+COPY docker/common/install_etcd.sh install_etcd.sh
+RUN bash ./install_etcd.sh && rm install_etcd.sh
+
 
 FROM ${DEVEL_IMAGE} AS wheel
 WORKDIR /src/tensorrt_llm

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -25,7 +25,7 @@ STAGE              ?=
 # Set this to define a custom image name and tag
 IMAGE_WITH_TAG     ?= $(IMAGE_NAME)$(if $(STAGE),/$(STAGE)):$(IMAGE_TAG)
 PUSH_TO_STAGING    ?= 1
-DOCKER_BUILD_OPTS  ?= --pull
+DOCKER_BUILD_OPTS  ?= --pull --load
 DOCKER_BUILD_ARGS  ?=
 DOCKER_PROGRESS    ?= auto
 CUDA_ARCHS         ?=
@@ -41,7 +41,8 @@ GIT_COMMIT         ?= $(shell git rev-parse HEAD)
 TRT_LLM_VERSION    ?= $(shell grep '^__version__' ../tensorrt_llm/version.py | grep -o '=.*' | tr -d '= "')
 GITHUB_MIRROR      ?=
 PYTHON_VERSION     ?=
-INSTALL_TRITON     ?= 1
+NGC_STAGING_REPO   ?= nvcr.io/nvstaging/tensorrt-llm
+PLATFORM           ?= $(shell uname -m | grep -q 'aarch64' && echo "arm64" || echo "amd64")
 
 define add_local_user
 	docker build \
@@ -64,7 +65,7 @@ endef
 %_build: DEVEL_IMAGE = $(if $(findstring 1,$(JENKINS_DEVEL)),$(shell grep 'LLM_DOCKER_IMAGE = ' ../jenkins/L0_MergeRequest.groovy | grep -o '".*"' | tr -d '"'))
 %_build:
 	@echo "Building docker image: $(IMAGE_WITH_TAG)"
-	DOCKER_BUILDKIT=1 docker build $(DOCKER_BUILD_OPTS) $(DOCKER_BUILD_ARGS) \
+	docker buildx build $(DOCKER_BUILD_OPTS) $(DOCKER_BUILD_ARGS) \
 		--progress $(DOCKER_PROGRESS) \
 		$(if $(BASE_IMAGE), --build-arg BASE_IMAGE=$(BASE_IMAGE)) \
 		$(if $(BASE_TAG), --build-arg BASE_TAG=$(BASE_TAG)) \
@@ -80,7 +81,6 @@ endef
 		$(if $(GIT_COMMIT), --build-arg GIT_COMMIT="$(GIT_COMMIT)") \
 		$(if $(GITHUB_MIRROR), --build-arg GITHUB_MIRROR="$(GITHUB_MIRROR)") \
 		$(if $(PYTHON_VERSION), --build-arg PYTHON_VERSION="$(PYTHON_VERSION)") \
-		$(if $(INSTALL_TRITON), --build-arg INSTALL_TRITON="$(INSTALL_TRITON)") \
 		$(if $(STAGE), --target $(STAGE)) \
 		--file Dockerfile.multi \
 		--tag $(IMAGE_WITH_TAG) \
@@ -145,6 +145,7 @@ endif
     		$(IMAGE_WITH_TAG)$(IMAGE_TAG_SUFFIX) $(RUN_CMD)
 
 devel_%: STAGE = devel
+tritondevel_%: STAGE = tritondevel
 
 wheel_%: STAGE = wheel
 wheel_run: WORK_DIR = /src/tensorrt_llm
@@ -182,10 +183,37 @@ trtllm_%: IMAGE_NAME = $(shell grep 'IMAGE_NAME = ' ../jenkins/BuildDockerImage.
 trtllm_%: IMAGE_TAG = $(shell git rev-parse --abbrev-ref HEAD | tr '/' '_')
 trtllm_run: WORK_DIR = /app/tensorrt_llm
 
+# This requires a docker installation with multi-platform support
+ngc-devel_%: STAGE = devel
+ngc-devel_%: DOCKER_BUILD_OPTS = --pull --builder=multi-builder --platform linux/arm64,linux/amd64
+ngc-devel_%: IMAGE_NAME = $(NGC_STAGING_REPO)
+ngc-devel_%: IMAGE_TAG = $(TRT_LLM_VERSION)
+
+ngc-devel_push: DOCKER_BUILD_ARGS = --push
+ngc-devel_push: ngc-devel_build ;
+
+ngc-release_%: STAGE = release
+ngc-release_%: DOCKER_BUILD_OPTS = --pull --load --platform linux/$(PLATFORM)
+ngc-release_%: DEVEL_IMAGE = $(NGC_STAGING_REPO)/devel:$(TRT_LLM_VERSION)
+ngc-release_%: IMAGE_NAME = nvcr.io/nvstaging/tensorrt-llm
+ngc-release_%: IMAGE_TAG = $(TRT_LLM_VERSION)-$(PLATFORM)
+
+ngc-manifest_%: STAGE = release
+ngc-manifest_%: IMAGE_NAME = $(NGC_STAGING_REPO)
+ngc-manifest_%: IMAGE_TAG = $(TRT_LLM_VERSION)
+
+ngc-manifest_create:
+	docker manifest create $(IMAGE_WITH_TAG) \
+  		--amend $(IMAGE_WITH_TAG)-amd64 \
+  		--amend $(IMAGE_WITH_TAG)-arm64
+
+ngc-manifest_push:
+	docker manifest push $(IMAGE_WITH_TAG)
+
 build: devel_build ;
 
 push: devel_push ;
 
 run: devel_run ;
 
-.PHONY: build push run
+.PHONY: build push run ngc-manifest_create ngc-manifest_push

--- a/docker/common/install_etcd.sh
+++ b/docker/common/install_etcd.sh
@@ -17,13 +17,15 @@ elif [ "$ARCH" = "x86_64" ]; then
     ARCH="amd64"
 fi
 
-rm -f /tmp/etcd-${ETCD_VER}-linux-${ARCH}.tar.gz
-rm -rf /tmp/etcd-download-test && mkdir -p /tmp/etcd-download-test
+# Use a temporary location for downloading files
+TMP_DIR=$(mktemp -d)
+ETCD_TAR=${TMP_DIR}/etcd-${ETCD_VER}-linux-${ARCH}.tar.gz
 
-curl -L ${DOWNLOAD_URL}/${ETCD_VER}/etcd-${ETCD_VER}-linux-${ARCH}.tar.gz -o /tmp/etcd-${ETCD_VER}-linux-${ARCH}.tar.gz
-tar xzvf /tmp/etcd-${ETCD_VER}-linux-${ARCH}.tar.gz -C /tmp/etcd-download-test --strip-components=1
-rm -f /tmp/etcd-${ETCD_VER}-linux-${ARCH}.tar.gz
+# Download etcd binaries
+curl -L ${DOWNLOAD_URL}/${ETCD_VER}/etcd-${ETCD_VER}-linux-${ARCH}.tar.gz -o ${ETCD_TAR}
 
-mv /tmp/etcd-download-test/* /usr/local/bin/
+# Extract binaries to /usr/local/bin directly to avoid unnecessary copying
+tar xzvf ${ETCD_TAR} -C /usr/local/bin --strip-components=1
 
-rm -rf /tmp/etcd-download-test
+# Cleanup temporary files and directories
+rm -rf ${TMP_DIR}

--- a/docker/common/install_nixl.sh
+++ b/docker/common/install_nixl.sh
@@ -11,8 +11,9 @@ if [ ! -d ${UCX_INSTALL_PATH} ]; then
   cd ucx
   ./autogen.sh
   ./contrib/configure-release --prefix=${UCX_INSTALL_PATH}
-  make install -j
+  make install -j$(nproc)
   cd ..
+  rm -rf ucx  # Remove UCX source to save space
   echo "export LD_LIBRARY_PATH=${UCX_INSTALL_PATH}/lib:\$LD_LIBRARY_PATH" >> "${ENV}"
 fi
 
@@ -25,10 +26,12 @@ if [ "$(uname -m)" != "amd64" ] && [ "$(uname -m)" != "x86_64" ]; then
   EXTRA_NIXL_ARGS="-Ddisable_gds_backend=true"
 fi
 
-pip3 install meson ninja pybind11
+pip3 install --no-cache-dir meson ninja pybind11
 git clone --depth 1 -b ${NIXL_VERSION} ${NIXL_REPO}
 cd nixl
 meson setup builddir -Ducx_path=${UCX_INSTALL_PATH} ${EXTRA_NIXL_ARGS}
 cd builddir && ninja install
+cd ../..
+rm -rf nixl  # Remove NIXL source tree to save space
 
 echo "export LD_LIBRARY_PATH=/opt/nvidia/nvda_nixl/lib/${ARCH_NAME}:/opt/nvidia/nvda_nixl/lib64:\$LD_LIBRARY_PATH" >> "${ENV}"

--- a/docker/common/install_triton.sh
+++ b/docker/common/install_triton.sh
@@ -5,35 +5,33 @@ set -ex
 install_boost() {
   # Install boost version >= 1.78 for boost::span
   # Current libboost-dev apt packages are < 1.78, so install from tar.gz
-  wget -O /tmp/boost.tar.gz https://archives.boost.io/release/1.80.0/source/boost_1_80_0.tar.gz && (cd /tmp && tar xzf boost.tar.gz) && mv /tmp/boost_1_80_0/boost /usr/include/boost
-  rm -rf /tmp/boost_1_80_0
-  rm -rf /tmp/boost.tar.gz
+  wget -O /tmp/boost.tar.gz https://archives.boost.io/release/1.80.0/source/boost_1_80_0.tar.gz \
+    && tar xzf /tmp/boost.tar.gz -C /tmp \
+    && mv /tmp/boost_1_80_0/boost /usr/include/boost \
+    && rm -rf /tmp/boost_1_80_0 /tmp/boost.tar.gz
 }
 
 install_triton_deps() {
-  apt-get update && apt-get install -y \
-    pigz \
-    libxml2-dev \
-    libre2-dev \
-    libnuma-dev \
-    python3-build \
-    libb64-dev \
-    libarchive-dev \
-    datacenter-gpu-manager=1:3.3.6
-
-  install_boost
+  apt-get update \
+    && apt-get install -y --no-install-recommends \
+      pigz \
+      libxml2-dev \
+      libre2-dev \
+      libnuma-dev \
+      python3-build \
+      libb64-dev \
+      libarchive-dev \
+      datacenter-gpu-manager=1:3.3.6 \
+    && install_boost \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 }
 
-# Install Triton only if base image in Ubuntu
+# Install Triton only if base image is Ubuntu
 ID=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
-if [ "$INSTALL_TRITON" == "1" ]; then
-  if [ "$ID" == "ubuntu" ]; then
-    install_triton_deps
-  else
-    rm -rf /opt/tritonserver
-    echo "Skip Triton installation for non-Ubuntu base image"
-  fi
+if [ "$ID" == "ubuntu" ]; then
+  install_triton_deps
 else
-  echo "Skip Triton installation when INSTALL_TRITON is set to 0"
   rm -rf /opt/tritonserver
+  echo "Skip Triton installation for non-Ubuntu base image"
 fi

--- a/jenkins/Build.groovy
+++ b/jenkins/Build.groovy
@@ -16,7 +16,7 @@ AARCH64_TRIPLE = "aarch64-linux-gnu"
 
 LLM_DOCKER_IMAGE = env.dockerImage
 
-AGENT_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:pytorch-25.03-py3-x86_64-ubuntu24.04-trt10.9.0.34-skip-tritondevel-202505091630-4191"
+AGENT_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:pytorch-25.03-py3-x86_64-ubuntu24.04-trt10.9.0.34-skip-tritondevel-202505110947-4191"
 
 POD_TIMEOUT_SECONDS = env.podTimeoutSeconds ? env.podTimeoutSeconds : "21600"
 

--- a/jenkins/Build.groovy
+++ b/jenkins/Build.groovy
@@ -16,7 +16,7 @@ AARCH64_TRIPLE = "aarch64-linux-gnu"
 
 LLM_DOCKER_IMAGE = env.dockerImage
 
-AGENT_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:pytorch-25.03-py3-x86_64-ubuntu24.04-trt10.9.0.34-skip-devel-202505081324-9379"
+AGENT_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:pytorch-25.03-py3-x86_64-ubuntu24.04-trt10.9.0.34-skip-tritondevel-202505091630-4191"
 
 POD_TIMEOUT_SECONDS = env.podTimeoutSeconds ? env.podTimeoutSeconds : "21600"
 

--- a/jenkins/BuildDockerImage.groovy
+++ b/jenkins/BuildDockerImage.groovy
@@ -251,7 +251,7 @@ pipeline {
                     }
                     steps
                     {
-                        buildImage("devel", params.action, "skip")
+                        buildImage("tritondevel", params.action, "skip")
                     }
                 }
                 stage("Build x86_64-pre_cxx11_abi") {
@@ -278,7 +278,7 @@ pipeline {
                     }
                     steps
                     {
-                        buildImage("rockylinux8", params.action, "skip", "PYTHON_VERSION=3.10.12", "", "-py310")
+                        buildImage("rockylinux8", params.action, "skip", "PYTHON_VERSION=3.10.12 STAGE=tritondevel", "", "-py310")
                     }
                 }
                 stage("Build rockylinux8 x86_64-skip-py3.12") {
@@ -287,7 +287,7 @@ pipeline {
                     }
                     steps
                     {
-                        buildImage("rockylinux8", params.action, "skip", "PYTHON_VERSION=3.12.3", "", "-py312")
+                        buildImage("rockylinux8", params.action, "skip", "PYTHON_VERSION=3.12.3 STAGE=tritondevel", "", "-py312")
                     }
                 }
                 stage("Build SBSA-skip") {

--- a/jenkins/GH200ImageBuilder.groovy
+++ b/jenkins/GH200ImageBuilder.groovy
@@ -18,8 +18,8 @@ def buildImage(action, type)
     def branch = env.gitlabBranch
     def branchTag = branch.replaceAll('/', '_')
     def buildNumber = env.hostBuildNumber ? env.hostBuildNumber : BUILD_NUMBER
-    def stage = "tritondevel"
-    def tag = "sbsa-${stage}-torch_${type}-${branchTag}-${buildNumber}"
+    def stage_docker = "tritondevel"
+    def tag = "sbsa-${stage_docker}-torch_${type}-${branchTag}-${buildNumber}"
 
     // Step 1: cloning tekit source code
     // allow to checkout from forked repo, svc_tensorrt needs to have access to the repo, otherwise clone will fail
@@ -73,7 +73,7 @@ def buildImage(action, type)
             stage ("Perform '${action}' action on image") {
                 retry(3)
                 {
-                    sh "cd ${LLM_ROOT} && make -C docker ${stage}_${action} IMAGE_NAME=${IMAGE_NAME} IMAGE_TAG=${tag} TORCH_INSTALL_TYPE=${type} BUILD_TRITON=1" +
+                    sh "cd ${LLM_ROOT} && make -C docker ${stage_docker}_${action} IMAGE_NAME=${IMAGE_NAME} IMAGE_TAG=${tag} TORCH_INSTALL_TYPE=${type} BUILD_TRITON=1" +
                     " GITHUB_MIRROR=https://urm.nvidia.com/artifactory/github-go-remote"
                 }
             }

--- a/jenkins/GH200ImageBuilder.groovy
+++ b/jenkins/GH200ImageBuilder.groovy
@@ -18,7 +18,8 @@ def buildImage(action, type)
     def branch = env.gitlabBranch
     def branchTag = branch.replaceAll('/', '_')
     def buildNumber = env.hostBuildNumber ? env.hostBuildNumber : BUILD_NUMBER
-    def tag = "sbsa-devel-torch_${type}-${branchTag}-${buildNumber}"
+    def stage = "tritondevel"
+    def tag = "sbsa-${stage}-torch_${type}-${branchTag}-${buildNumber}"
 
     // Step 1: cloning tekit source code
     // allow to checkout from forked repo, svc_tensorrt needs to have access to the repo, otherwise clone will fail
@@ -72,7 +73,7 @@ def buildImage(action, type)
             stage ("Perform '${action}' action on image") {
                 retry(3)
                 {
-                    sh "cd ${LLM_ROOT} && make -C docker devel_${action} IMAGE_NAME=${IMAGE_NAME} IMAGE_TAG=${tag} TORCH_INSTALL_TYPE=${type} BUILD_TRITON=1" +
+                    sh "cd ${LLM_ROOT} && make -C docker ${stage}_${action} IMAGE_NAME=${IMAGE_NAME} IMAGE_TAG=${tag} TORCH_INSTALL_TYPE=${type} BUILD_TRITON=1" +
                     " GITHUB_MIRROR=https://urm.nvidia.com/artifactory/github-go-remote"
                 }
             }

--- a/jenkins/L0_MergeRequest.groovy
+++ b/jenkins/L0_MergeRequest.groovy
@@ -21,10 +21,10 @@ UPLOAD_PATH = env.uploadPath ? env.uploadPath : "sw-tensorrt-generic/llm-artifac
 // Container configuration
 // available tags can be found in: https://urm.nvidia.com/artifactory/sw-tensorrt-docker/tensorrt-llm/
 // [base_image_name]-[arch]-[os](-[python_version])-[trt_version]-[torch_install_type]-[stage]-[date]-[mr_id]
-LLM_DOCKER_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:pytorch-25.03-py3-x86_64-ubuntu24.04-trt10.9.0.34-skip-devel-202505081324-9379"
-LLM_SBSA_DOCKER_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:pytorch-25.03-py3-aarch64-ubuntu24.04-trt10.9.0.34-skip-devel-202505081324-9379"
-LLM_ROCKYLINUX8_PY310_DOCKER_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:cuda-12.8.1-devel-rocky8-x86_64-rocky8-py310-trt10.9.0.34-skip-devel-202505081324-9379"
-LLM_ROCKYLINUX8_PY312_DOCKER_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:cuda-12.8.1-devel-rocky8-x86_64-rocky8-py312-trt10.9.0.34-skip-devel-202505081324-9379"
+LLM_DOCKER_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:pytorch-25.03-py3-x86_64-ubuntu24.04-trt10.9.0.34-skip-tritondevel-202505091630-4191"
+LLM_SBSA_DOCKER_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:pytorch-25.03-py3-aarch64-ubuntu24.04-trt10.9.0.34-skip-tritondevel-202505091630-4191"
+LLM_ROCKYLINUX8_PY310_DOCKER_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:cuda-12.8.1-devel-rocky8-x86_64-rocky8-py310-trt10.9.0.34-skip-tritondevel-202505091630-4191"
+LLM_ROCKYLINUX8_PY312_DOCKER_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:cuda-12.8.1-devel-rocky8-x86_64-rocky8-py312-trt10.9.0.34-skip-tritondevel-202505091630-4191"
 
 LLM_ROCKYLINUX8_DOCKER_IMAGE = LLM_ROCKYLINUX8_PY310_DOCKER_IMAGE
 

--- a/jenkins/L0_MergeRequest.groovy
+++ b/jenkins/L0_MergeRequest.groovy
@@ -21,10 +21,10 @@ UPLOAD_PATH = env.uploadPath ? env.uploadPath : "sw-tensorrt-generic/llm-artifac
 // Container configuration
 // available tags can be found in: https://urm.nvidia.com/artifactory/sw-tensorrt-docker/tensorrt-llm/
 // [base_image_name]-[arch]-[os](-[python_version])-[trt_version]-[torch_install_type]-[stage]-[date]-[mr_id]
-LLM_DOCKER_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:pytorch-25.03-py3-x86_64-ubuntu24.04-trt10.9.0.34-skip-tritondevel-202505091630-4191"
-LLM_SBSA_DOCKER_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:pytorch-25.03-py3-aarch64-ubuntu24.04-trt10.9.0.34-skip-tritondevel-202505091630-4191"
-LLM_ROCKYLINUX8_PY310_DOCKER_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:cuda-12.8.1-devel-rocky8-x86_64-rocky8-py310-trt10.9.0.34-skip-tritondevel-202505091630-4191"
-LLM_ROCKYLINUX8_PY312_DOCKER_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:cuda-12.8.1-devel-rocky8-x86_64-rocky8-py312-trt10.9.0.34-skip-tritondevel-202505091630-4191"
+LLM_DOCKER_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:pytorch-25.03-py3-x86_64-ubuntu24.04-trt10.9.0.34-skip-tritondevel-202505110947-4191"
+LLM_SBSA_DOCKER_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:pytorch-25.03-py3-aarch64-ubuntu24.04-trt10.9.0.34-skip-tritondevel-202505110947-4191"
+LLM_ROCKYLINUX8_PY310_DOCKER_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:cuda-12.8.1-devel-rocky8-x86_64-rocky8-py310-trt10.9.0.34-skip-tritondevel-202505110947-4191"
+LLM_ROCKYLINUX8_PY312_DOCKER_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:cuda-12.8.1-devel-rocky8-x86_64-rocky8-py312-trt10.9.0.34-skip-tritondevel-202505110947-4191"
 
 LLM_ROCKYLINUX8_DOCKER_IMAGE = LLM_ROCKYLINUX8_PY310_DOCKER_IMAGE
 

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -35,8 +35,8 @@ linuxPkgName = ( env.targetArch == AARCH64_TRIPLE ? "tensorrt-llm-sbsa-release-s
 // available tags can be found in: https://urm.nvidia.com/artifactory/sw-tensorrt-docker/tensorrt-llm/
 // [base_image_name]-[arch]-[os](-[python_version])-[trt_version]-[torch_install_type]-[stage]-[date]-[mr_id]
 LLM_DOCKER_IMAGE = env.dockerImage
-LLM_ROCKYLINUX8_PY310_DOCKER_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:cuda-12.8.1-devel-rocky8-x86_64-rocky8-py310-trt10.9.0.34-skip-tritondevel-202505091630-4191"
-LLM_ROCKYLINUX8_PY312_DOCKER_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:cuda-12.8.1-devel-rocky8-x86_64-rocky8-py312-trt10.9.0.34-skip-tritondevel-202505091630-4191"
+LLM_ROCKYLINUX8_PY310_DOCKER_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:cuda-12.8.1-devel-rocky8-x86_64-rocky8-py310-trt10.9.0.34-skip-tritondevel-202505110947-4191"
+LLM_ROCKYLINUX8_PY312_DOCKER_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:cuda-12.8.1-devel-rocky8-x86_64-rocky8-py312-trt10.9.0.34-skip-tritondevel-202505110947-4191"
 
 // DLFW torch image
 DLFW_IMAGE = "nvcr.io/nvidia/pytorch:25.03-py3"

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -35,8 +35,8 @@ linuxPkgName = ( env.targetArch == AARCH64_TRIPLE ? "tensorrt-llm-sbsa-release-s
 // available tags can be found in: https://urm.nvidia.com/artifactory/sw-tensorrt-docker/tensorrt-llm/
 // [base_image_name]-[arch]-[os](-[python_version])-[trt_version]-[torch_install_type]-[stage]-[date]-[mr_id]
 LLM_DOCKER_IMAGE = env.dockerImage
-LLM_ROCKYLINUX8_PY310_DOCKER_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:cuda-12.8.1-devel-rocky8-x86_64-rocky8-py310-trt10.9.0.34-skip-devel-202505081324-9379"
-LLM_ROCKYLINUX8_PY312_DOCKER_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:cuda-12.8.1-devel-rocky8-x86_64-rocky8-py312-trt10.9.0.34-skip-devel-202505081324-9379"
+LLM_ROCKYLINUX8_PY310_DOCKER_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:cuda-12.8.1-devel-rocky8-x86_64-rocky8-py310-trt10.9.0.34-skip-tritondevel-202505091630-4191"
+LLM_ROCKYLINUX8_PY312_DOCKER_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:cuda-12.8.1-devel-rocky8-x86_64-rocky8-py312-trt10.9.0.34-skip-tritondevel-202505091630-4191"
 
 // DLFW torch image
 DLFW_IMAGE = "nvcr.io/nvidia/pytorch:25.03-py3"

--- a/jenkins/controlCCache.groovy
+++ b/jenkins/controlCCache.groovy
@@ -1,7 +1,7 @@
 
 import java.lang.InterruptedException
 
-DOCKER_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:pytorch-25.03-py3-x86_64-ubuntu24.04-trt10.9.0.34-skip-devel-202505081324-9379"
+DOCKER_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:pytorch-25.03-py3-x86_64-ubuntu24.04-trt10.9.0.34-skip-tritondevel-202505091630-4191"
 
 def createKubernetesPodConfig(image)
 {

--- a/jenkins/controlCCache.groovy
+++ b/jenkins/controlCCache.groovy
@@ -1,7 +1,7 @@
 
 import java.lang.InterruptedException
 
-DOCKER_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:pytorch-25.03-py3-x86_64-ubuntu24.04-trt10.9.0.34-skip-tritondevel-202505091630-4191"
+DOCKER_IMAGE = "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:pytorch-25.03-py3-x86_64-ubuntu24.04-trt10.9.0.34-skip-tritondevel-202505110947-4191"
 
 def createKubernetesPodConfig(image)
 {


### PR DESCRIPTION
# Multi-platform builds

This adds some preliminary support for multi-platform builds to the docker build system.

## Description

This adds the command

```
make -C docker multiplatform_build
```

This creates a development image for `amd64` and `arm64`.

N.B. This PR reverts changes from nvidia/TensorRT-LLM#3981.