### PR TITLE
[perf] Manually free some tensors in TrtllmAttention to reduce memory usage

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -722,6 +722,10 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
                                   update_kv_cache=not metadata.is_cross
                                   or k is not None,
                                   attention_mask=attention_mask)
+
+        # Set to None to reduce memory usage
+        self.wrapper.latent_cache = None
+        self.wrapper.q_pe = None
         return output
 
     @classmethod


### PR DESCRIPTION
Because some tensors are stored as class members of `TrtllmAttention`, the memory allocated for them are used longer than needed. This PR sets these class members to be `None` after using them in `TrtllmAttention` to reduce memory usage.