### PR TITLE
fix potential issues in allreduce fusion kernel and ut

### DIFF
--- a/cpp/tensorrt_llm/kernels/communicationKernels/allReduceFusionKernels.cu
+++ b/cpp/tensorrt_llm/kernels/communicationKernels/allReduceFusionKernels.cu
@@ -456,10 +456,10 @@ __global__ void allreduce_fusion_kernel_oneshot_lamport(AllReduceFusionParams pa
 
     for (int idx = access_id; idx < tot_access; idx += access_stride)
     {
-        float val[4];
+        alignas(16) float val[4];
         *reinterpret_cast<float4*>(val) = reinterpret_cast<float4*>(params.allreduce_in)[idx];
 #pragma unroll
-        for (int i = 0; i < kElemsPerAccess<DType> / sizeof(float); ++i)
+        for (int i = 0; i < 4; ++i)
         {
             if (is_neg_zero(val[i]))
             {

--- a/cpp/tensorrt_llm/kernels/communicationKernels/moeAllReduceFusionKernels.cu
+++ b/cpp/tensorrt_llm/kernels/communicationKernels/moeAllReduceFusionKernels.cu
@@ -317,7 +317,8 @@ __global__ void moereduce_allreduce_fusion_kernel_oneshot_lamport(MoeReductionAl
         // * AR Store
         int access_id = token_id * params.hidden_dim / kElemsPerAccess + access_id_in_token;
         int idx = access_id;
-        float val[4] = {accumulator.packed.x, accumulator.packed.y, accumulator.packed.z, accumulator.packed.w};
+        alignas(16) float val[4]
+            = {accumulator.packed.x, accumulator.packed.y, accumulator.packed.z, accumulator.packed.w};
 
 #pragma unroll
         for (int i = 0; i < 4; ++i)

--- a/cpp/tests/unit_tests/kernels/allReduce/allReduceFusionTest.cu
+++ b/cpp/tests/unit_tests/kernels/allReduce/allReduceFusionTest.cu
@@ -571,7 +571,35 @@ TEST(Kernel_AllReduceFusion, AllReduceAccuracyFixedTokenNum)
 
 TEST(Kernel_AllReduceFusion, AllReduceFusionAccuracyDifferentHiddenDim)
 {
-    using Runner = TestRunner<half, ar_fusion::AllReduceFusionPattern::kARResidualRMSNormOutFP4Quant>;
+#define TEST_AR_FUSION(DType, FusionPattern)                                                                           \
+    {                                                                                                                  \
+        using Runner = TestRunner<DType, FusionPattern>;                                                               \
+        int iter = 10;                                                                                                 \
+        std::vector<int> candidate_hidden_dim{64, 128, 256, 384, 512, 640, 768, 896};                                  \
+        int min_token_num = 1;                                                                                         \
+        int max_token_num = 2048;                                                                                      \
+        for (auto hidden_dim : candidate_hidden_dim)                                                                   \
+        {                                                                                                              \
+            Runner runner(max_token_num, hidden_dim);                                                                  \
+            for (int token_num = min_token_num; token_num <= max_token_num; token_num *= 2)                            \
+            {                                                                                                          \
+                if (rank == 0)                                                                                         \
+                {                                                                                                      \
+                    printf("[Verify] token_num %-4d, hidden_dim %-4d ...", token_num, hidden_dim);                     \
+                }                                                                                                      \
+                for (int i = 0; i < iter; ++i)                                                                         \
+                {                                                                                                      \
+                    runner.reset_io();                                                                                 \
+                    runner.run_once(&Runner::run_kernel, token_num, hidden_dim);                                       \
+                    runner.verify(token_num, hidden_dim);                                                              \
+                }                                                                                                      \
+                if (rank == 0)                                                                                         \
+                {                                                                                                      \
+                    printf("\033[32mPass!\033[0m\n");                                                                  \
+                }                                                                                                      \
+            }                                                                                                          \
+        }                                                                                                              \
+    }
     auto& comm = mpi::MpiComm::world();
     auto world_size = comm.getSize();
     auto rank = comm.getRank();
@@ -580,31 +608,16 @@ TEST(Kernel_AllReduceFusion, AllReduceFusionAccuracyDifferentHiddenDim)
         TLLM_LOG_WARNING("world size is not a multiple of 2, return");
         return;
     }
-    int iter = 10;
-    std::vector<int> candidate_hidden_dim{64, 128, 256, 384, 512, 640, 768, 896};
-    int min_token_num = 1;
-    int max_token_num = 2048;
-    for (auto hidden_dim : candidate_hidden_dim)
+    int const arch = tensorrt_llm::common::getSMVersion();
+    if (arch >= 100)
     {
-        Runner runner(max_token_num, hidden_dim);
-        for (int token_num = min_token_num; token_num <= max_token_num; token_num *= 2)
-        {
-            if (rank == 0)
-            {
-                printf("[Verify] token_num %-4d, hidden_dim %-4d ...", token_num, hidden_dim);
-            }
-            for (int i = 0; i < iter; ++i)
-            {
-                runner.reset_io();
-                runner.run_once(&Runner::run_kernel, token_num, hidden_dim);
-                runner.verify(token_num, hidden_dim);
-            }
-            if (rank == 0)
-            {
-                printf("\033[32mPass!\033[0m\n");
-            }
-        }
+        TEST_AR_FUSION(half, ar_fusion::AllReduceFusionPattern::kARResidualRMSNormOutFP4Quant);
     }
+    else
+    {
+        TEST_AR_FUSION(half, ar_fusion::AllReduceFusionPattern::kARResidualRMSNormOutFP8Quant);
+    }
+#undef TEST_AR_FUSION
 }
 
 TEST(Kernel_AllReduceFusion, AllReduceFusionAccuracyDifferentDType)
@@ -630,6 +643,7 @@ TEST(Kernel_AllReduceFusion, AllReduceFusionAccuracyDifferentDType)
         }                                                                                                              \
     }
 
+    int const arch = tensorrt_llm::common::getSMVersion();
     auto& comm = mpi::MpiComm::world();
     auto world_size = comm.getSize();
     auto rank = comm.getRank();
@@ -644,66 +658,78 @@ TEST(Kernel_AllReduceFusion, AllReduceFusionAccuracyDifferentDType)
     for (auto hidden_dim : candidate_hidden_dim)
     {
         TEST_AR_FUSION(half, ar_fusion::AllReduceFusionPattern::kAllReduce);
-        TEST_AR_FUSION(__nv_bfloat16, ar_fusion::AllReduceFusionPattern::kAllReduce);
-        TEST_AR_FUSION(float, ar_fusion::AllReduceFusionPattern::kAllReduce);
         TEST_AR_FUSION(half, ar_fusion::AllReduceFusionPattern::kARResidualRMSNorm);
-        TEST_AR_FUSION(__nv_bfloat16, ar_fusion::AllReduceFusionPattern::kARResidualRMSNorm);
-        TEST_AR_FUSION(float, ar_fusion::AllReduceFusionPattern::kARResidualRMSNorm);
         TEST_AR_FUSION(half, ar_fusion::AllReduceFusionPattern::kARResidualRMSNormOutFP8Quant);
-        TEST_AR_FUSION(__nv_bfloat16, ar_fusion::AllReduceFusionPattern::kARResidualRMSNormOutFP8Quant);
+        if (arch >= 100)
+        {
+            TEST_AR_FUSION(half, ar_fusion::AllReduceFusionPattern::kARResidualRMSNormOutFP4Quant);
+        }
+        TEST_AR_FUSION(float, ar_fusion::AllReduceFusionPattern::kAllReduce);
+        TEST_AR_FUSION(float, ar_fusion::AllReduceFusionPattern::kARResidualRMSNorm);
         TEST_AR_FUSION(float, ar_fusion::AllReduceFusionPattern::kARResidualRMSNormOutFP8Quant);
-        TEST_AR_FUSION(half, ar_fusion::AllReduceFusionPattern::kARResidualRMSNormOutFP4Quant);
-        TEST_AR_FUSION(__nv_bfloat16, ar_fusion::AllReduceFusionPattern::kARResidualRMSNormOutFP4Quant);
+#if defined(ENABLE_BF16)
+        TEST_AR_FUSION(__nv_bfloat16, ar_fusion::AllReduceFusionPattern::kAllReduce);
+        TEST_AR_FUSION(__nv_bfloat16, ar_fusion::AllReduceFusionPattern::kARResidualRMSNorm);
+        TEST_AR_FUSION(__nv_bfloat16, ar_fusion::AllReduceFusionPattern::kARResidualRMSNormOutFP8Quant);
+        if (arch >= 100)
+        {
+            TEST_AR_FUSION(__nv_bfloat16, ar_fusion::AllReduceFusionPattern::kARResidualRMSNormOutFP4Quant);
+        }
+#endif
     }
 #undef TEST_AR_FUSION
 }
 
 TEST(Kernel_AllReduceFusion, Perf)
 {
-    using Runner = TestRunner<half, ar_fusion::AllReduceFusionPattern::kARResidualRMSNormFP4Quant>;
-    auto& comm = mpi::MpiComm::world();
-    auto world_size = comm.getSize();
-    auto rank = comm.getRank();
-    if (world_size % 2)
+    int const arch = tensorrt_llm::common::getSMVersion();
+    if (arch >= 100)
     {
-        TLLM_LOG_WARNING("world size is not a multiple of 2, return");
-        return;
-    }
-    int warmup = 100, iter = 300;
-    int hidden_dim = 7168;
-    std::vector<int> candidate_token_num{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048};
-    int max_token_num = 2048;
-    Runner runner(max_token_num, hidden_dim);
-    for (auto token_num : candidate_token_num)
-    {
-        auto latency = runner.benchmark(&Runner::run_kernel, warmup, iter, token_num, hidden_dim);
-        if (rank == 0)
+        using Runner = TestRunner<half, ar_fusion::AllReduceFusionPattern::kARResidualRMSNormFP4Quant>;
+        auto& comm = mpi::MpiComm::world();
+        auto world_size = comm.getSize();
+        auto rank = comm.getRank();
+        if (world_size % 2)
         {
-            TLLM_LOG_INFO(
-                "token_num %-4d, hidden_dim %-4d, fusion kernel latency %4.4fus", token_num, hidden_dim, latency);
+            TLLM_LOG_WARNING("world size is not a multiple of 2, return");
+            return;
         }
-        auto nccl_latency = runner.benchmark(&Runner::run_nccl_allreduce, warmup, iter, token_num, hidden_dim);
-        if (rank == 0)
+        int warmup = 100, iter = 300;
+        int hidden_dim = 7168;
+        std::vector<int> candidate_token_num{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048};
+        int max_token_num = 2048;
+        Runner runner(max_token_num, hidden_dim);
+        for (auto token_num : candidate_token_num)
         {
-            TLLM_LOG_INFO("nccl allreduce latency %4.4fus", nccl_latency);
-        }
-        auto residual_latency = runner.benchmark(&Runner::run_residual_add, warmup, iter, token_num, hidden_dim);
-        if (rank == 0)
-        {
-            TLLM_LOG_INFO("residual add latency %4.4fus", residual_latency);
-        }
-        auto rms_latency = runner.benchmark(&Runner::run_rms_norm, warmup, iter, token_num, hidden_dim);
-        if (rank == 0)
-        {
-            TLLM_LOG_INFO("rms norm latency %4.4fus", rms_latency);
-        }
-        auto quant_latency = runner.benchmark(&Runner::run_fp4_quant, warmup, iter, token_num, hidden_dim);
-        if (rank == 0)
-        {
-            TLLM_LOG_INFO("fp4 quant latency %4.4fus", quant_latency);
-            auto tot_latency = nccl_latency + residual_latency + rms_latency + quant_latency;
-            TLLM_LOG_INFO("fusion kernel latency %4.4fus, nccl + ops latency %4.4fus, total speedup %2.4fx", latency,
-                tot_latency, tot_latency / latency);
+            auto latency = runner.benchmark(&Runner::run_kernel, warmup, iter, token_num, hidden_dim);
+            if (rank == 0)
+            {
+                TLLM_LOG_INFO(
+                    "token_num %-4d, hidden_dim %-4d, fusion kernel latency %4.4fus", token_num, hidden_dim, latency);
+            }
+            auto nccl_latency = runner.benchmark(&Runner::run_nccl_allreduce, warmup, iter, token_num, hidden_dim);
+            if (rank == 0)
+            {
+                TLLM_LOG_INFO("nccl allreduce latency %4.4fus", nccl_latency);
+            }
+            auto residual_latency = runner.benchmark(&Runner::run_residual_add, warmup, iter, token_num, hidden_dim);
+            if (rank == 0)
+            {
+                TLLM_LOG_INFO("residual add latency %4.4fus", residual_latency);
+            }
+            auto rms_latency = runner.benchmark(&Runner::run_rms_norm, warmup, iter, token_num, hidden_dim);
+            if (rank == 0)
+            {
+                TLLM_LOG_INFO("rms norm latency %4.4fus", rms_latency);
+            }
+            auto quant_latency = runner.benchmark(&Runner::run_fp4_quant, warmup, iter, token_num, hidden_dim);
+            if (rank == 0)
+            {
+                TLLM_LOG_INFO("fp4 quant latency %4.4fus", quant_latency);
+                auto tot_latency = nccl_latency + residual_latency + rms_latency + quant_latency;
+                TLLM_LOG_INFO("fusion kernel latency %4.4fus, nccl + ops latency %4.4fus, total speedup %2.4fx",
+                    latency, tot_latency, tot_latency / latency);
+            }
         }
     }
 }


### PR DESCRIPTION
potential issues:
1. The `float val[4]` is not aligned to 16 bytes, which may result in a misaligned address when reinterpret_cast `val` to `float4*`.
2. There is a typo in the Lamport kernel when handling `-0` in the data.
3. FP4 quant is not supported when sm < 100.