### PR TITLE
[TRTLLM-4932] Add QA accuracy tests for NIM-prioritized models

### DIFF
--- a/tests/integration/defs/accuracy/references/cnn_dailymail.yaml
+++ b/tests/integration/defs/accuracy/references/cnn_dailymail.yaml
@@ -310,7 +310,3 @@ Qwen3/Qwen3-8B:
     accuracy: 30
 nvidia/Llama-3_3-Nemotron-Super-49B-v1:
   - accuracy: 34.003
-nvidia/Llama-3.1-Nemotron-Nano-8B-v1:
-  - accuracy: 27.810
-nvidia/Llama-3_1-Nemotron-Ultra-253B-v1:
-  - accuracy: 33.378

--- a/tests/integration/defs/accuracy/references/cnn_dailymail.yaml
+++ b/tests/integration/defs/accuracy/references/cnn_dailymail.yaml
@@ -312,5 +312,5 @@ nvidia/Llama-3_3-Nemotron-Super-49B-v1:
   - accuracy: 34.003
 nvidia/Llama-3.1-Nemotron-Nano-8B-v1:
   - accuracy: 27.810
-# nvidia/Llama-3_1-Nemotron-Ultra-253B-v1:
-#   - accuracy: 34.003
+nvidia/Llama-3_1-Nemotron-Ultra-253B-v1:
+  - accuracy: 33.378

--- a/tests/integration/defs/accuracy/references/cnn_dailymail.yaml
+++ b/tests/integration/defs/accuracy/references/cnn_dailymail.yaml
@@ -315,4 +315,4 @@ nvidia/Llama-3.1-Nemotron-Nano-8B-v1:
 nvidia/Llama-3_1-Nemotron-Ultra-253B-v1:
   - accuracy: 33.378
 # microsoft/Phi-4-mini-instruct:
-#   - accuracy: 31.543
+#   - accuracy: 0.0

--- a/tests/integration/defs/accuracy/references/cnn_dailymail.yaml
+++ b/tests/integration/defs/accuracy/references/cnn_dailymail.yaml
@@ -314,5 +314,3 @@ nvidia/Llama-3.1-Nemotron-Nano-8B-v1:
   - accuracy: 27.810
 nvidia/Llama-3_1-Nemotron-Ultra-253B-v1:
   - accuracy: 33.378
-# microsoft/Phi-4-mini-instruct:
-#   - accuracy: 0.0

--- a/tests/integration/defs/accuracy/references/cnn_dailymail.yaml
+++ b/tests/integration/defs/accuracy/references/cnn_dailymail.yaml
@@ -137,6 +137,8 @@ meta-llama/Llama-3.2-1B:
   - quant_algo: FP8
     kv_cache_quant_algo: FP8
     accuracy: 27.029
+  - quant_algo: FP8
+    accuracy: 27.029
   - quant_algo: FP8_PER_CHANNEL_PER_TOKEN
     accuracy: 27.257
   - quant_algo: FP8_PER_CHANNEL_PER_TOKEN

--- a/tests/integration/defs/accuracy/references/cnn_dailymail.yaml
+++ b/tests/integration/defs/accuracy/references/cnn_dailymail.yaml
@@ -312,3 +312,5 @@ nvidia/Llama-3_3-Nemotron-Super-49B-v1:
   - accuracy: 34.003
 nvidia/Llama-3.1-Nemotron-Nano-8B-v1:
   - accuracy: 27.810
+# nvidia/Llama-3_1-Nemotron-Ultra-253B-v1:
+#   - accuracy: 34.003

--- a/tests/integration/defs/accuracy/references/cnn_dailymail.yaml
+++ b/tests/integration/defs/accuracy/references/cnn_dailymail.yaml
@@ -314,3 +314,5 @@ nvidia/Llama-3.1-Nemotron-Nano-8B-v1:
   - accuracy: 27.810
 nvidia/Llama-3_1-Nemotron-Ultra-253B-v1:
   - accuracy: 33.378
+# microsoft/Phi-4-mini-instruct:
+#   - accuracy: 31.543

--- a/tests/integration/defs/accuracy/references/gpqa_diamond.yaml
+++ b/tests/integration/defs/accuracy/references/gpqa_diamond.yaml
@@ -18,3 +18,7 @@ nvidia/Llama-3_3-Nemotron-Super-49B-v1:
   - accuracy: 44.95
   - quant_algo: FP8
     accuracy: 49.49
+nvidia/Llama-3.1-Nemotron-Nano-8B-v1:
+  - accuracy: 40.40
+# nvidia/Llama-3_1-Nemotron-Ultra-253B-v1:
+#   - accuracy: 34.003

--- a/tests/integration/defs/accuracy/references/gpqa_diamond.yaml
+++ b/tests/integration/defs/accuracy/references/gpqa_diamond.yaml
@@ -23,4 +23,4 @@ nvidia/Llama-3.1-Nemotron-Nano-8B-v1:
 nvidia/Llama-3_1-Nemotron-Ultra-253B-v1:
   - accuracy: 58.08
 # microsoft/Phi-4-mini-instruct:
-#   - accuracy: 31.543
+#   - accuracy: 0.0

--- a/tests/integration/defs/accuracy/references/gpqa_diamond.yaml
+++ b/tests/integration/defs/accuracy/references/gpqa_diamond.yaml
@@ -22,3 +22,5 @@ nvidia/Llama-3.1-Nemotron-Nano-8B-v1:
   - accuracy: 40.40
 nvidia/Llama-3_1-Nemotron-Ultra-253B-v1:
   - accuracy: 58.08
+# microsoft/Phi-4-mini-instruct:
+#   - accuracy: 31.543

--- a/tests/integration/defs/accuracy/references/gpqa_diamond.yaml
+++ b/tests/integration/defs/accuracy/references/gpqa_diamond.yaml
@@ -20,5 +20,5 @@ nvidia/Llama-3_3-Nemotron-Super-49B-v1:
     accuracy: 49.49
 nvidia/Llama-3.1-Nemotron-Nano-8B-v1:
   - accuracy: 40.40
-# nvidia/Llama-3_1-Nemotron-Ultra-253B-v1:
-#   - accuracy: 34.003
+nvidia/Llama-3_1-Nemotron-Ultra-253B-v1:
+  - accuracy: 58.08

--- a/tests/integration/defs/accuracy/references/gpqa_diamond.yaml
+++ b/tests/integration/defs/accuracy/references/gpqa_diamond.yaml
@@ -22,3 +22,6 @@ nvidia/Llama-3.1-Nemotron-Nano-8B-v1:
   - accuracy: 40.40
 nvidia/Llama-3_1-Nemotron-Ultra-253B-v1:
   - accuracy: 58.08
+  - quant_algo: FP8
+    kv_cache_quant_algo: FP8
+    accuracy: 57.07

--- a/tests/integration/defs/accuracy/references/gpqa_diamond.yaml
+++ b/tests/integration/defs/accuracy/references/gpqa_diamond.yaml
@@ -22,5 +22,3 @@ nvidia/Llama-3.1-Nemotron-Nano-8B-v1:
   - accuracy: 40.40
 nvidia/Llama-3_1-Nemotron-Ultra-253B-v1:
   - accuracy: 58.08
-# microsoft/Phi-4-mini-instruct:
-#   - accuracy: 0.0

--- a/tests/integration/defs/accuracy/references/gsm8k.yaml
+++ b/tests/integration/defs/accuracy/references/gsm8k.yaml
@@ -74,4 +74,4 @@ nvidia/Llama-3.1-Nemotron-Nano-8B-v1:
 nvidia/Llama-3_1-Nemotron-Ultra-253B-v1:
   - accuracy: 94.43
 # microsoft/Phi-4-mini-instruct:
-#   - accuracy: 31.543
+#   - accuracy: 0.0

--- a/tests/integration/defs/accuracy/references/gsm8k.yaml
+++ b/tests/integration/defs/accuracy/references/gsm8k.yaml
@@ -73,3 +73,6 @@ nvidia/Llama-3.1-Nemotron-Nano-8B-v1:
   - accuracy: 37.15
 nvidia/Llama-3_1-Nemotron-Ultra-253B-v1:
   - accuracy: 94.43
+  - quant_algo: FP8
+    kv_cache_quant_algo: FP8
+    accuracy: 94.16

--- a/tests/integration/defs/accuracy/references/gsm8k.yaml
+++ b/tests/integration/defs/accuracy/references/gsm8k.yaml
@@ -73,5 +73,3 @@ nvidia/Llama-3.1-Nemotron-Nano-8B-v1:
   - accuracy: 37.15
 nvidia/Llama-3_1-Nemotron-Ultra-253B-v1:
   - accuracy: 94.43
-# microsoft/Phi-4-mini-instruct:
-#   - accuracy: 0.0

--- a/tests/integration/defs/accuracy/references/gsm8k.yaml
+++ b/tests/integration/defs/accuracy/references/gsm8k.yaml
@@ -69,3 +69,7 @@ nvidia/Llama-3_3-Nemotron-Super-49B-v1:
     accuracy: 92.42
 nvidia/Nemotron-H-8B-Base-8K:
   - accuracy: 46.20
+nvidia/Llama-3.1-Nemotron-Nano-8B-v1:
+  - accuracy: 37.15
+# nvidia/Llama-3_1-Nemotron-Ultra-253B-v1:
+#   - accuracy: 34.003

--- a/tests/integration/defs/accuracy/references/gsm8k.yaml
+++ b/tests/integration/defs/accuracy/references/gsm8k.yaml
@@ -73,3 +73,5 @@ nvidia/Llama-3.1-Nemotron-Nano-8B-v1:
   - accuracy: 37.15
 nvidia/Llama-3_1-Nemotron-Ultra-253B-v1:
   - accuracy: 94.43
+# microsoft/Phi-4-mini-instruct:
+#   - accuracy: 31.543

--- a/tests/integration/defs/accuracy/references/gsm8k.yaml
+++ b/tests/integration/defs/accuracy/references/gsm8k.yaml
@@ -71,5 +71,5 @@ nvidia/Nemotron-H-8B-Base-8K:
   - accuracy: 46.20
 nvidia/Llama-3.1-Nemotron-Nano-8B-v1:
   - accuracy: 37.15
-# nvidia/Llama-3_1-Nemotron-Ultra-253B-v1:
-#   - accuracy: 34.003
+nvidia/Llama-3_1-Nemotron-Ultra-253B-v1:
+  - accuracy: 94.43

--- a/tests/integration/defs/accuracy/references/mmlu.yaml
+++ b/tests/integration/defs/accuracy/references/mmlu.yaml
@@ -28,6 +28,27 @@ meta-llama/Llama-3.1-8B-Instruct:
   - quant_algo: FP8
     kv_cache_quant_algo: FP8
     accuracy: 67.87
+meta-llama/Llama-3.2-1B:
+  - accuracy: 32.82
+  - quant_algo: W8A8_SQ_PER_CHANNEL_PER_TOKEN_PLUGIN
+    accuracy: 32.72
+  - quant_algo: W8A8_SQ_PER_CHANNEL
+    accuracy: 32.07
+  - quant_algo: W4A16_AWQ
+    accuracy: 30.56
+  - quant_algo: W4A16_AWQ
+    kv_cache_quant_algo: INT8
+    accuracy: 31.29
+  - quant_algo: FP8
+    kv_cache_quant_algo: FP8
+    accuracy: 31.02
+  - quant_algo: FP8_PER_CHANNEL_PER_TOKEN
+    accuracy: 33.97
+  - quant_algo: FP8_PER_CHANNEL_PER_TOKEN
+    extra_acc_spec: meta_recipe
+    accuracy: 33.87
+  - extra_acc_spec: max_attention_window_size=960
+    accuracy: 32.82
 meta-llama/Llama-3.3-70B-Instruct:
   - accuracy: 81.31
   - quant_algo: NVFP4
@@ -127,3 +148,5 @@ nvidia/Llama-3.1-Nemotron-Nano-8B-v1:
   - accuracy: 57.97
 nvidia/Nemotron-H-8B-Base-8K:
   - accuracy: 69.590
+# nvidia/Llama-3_1-Nemotron-Ultra-253B-v1:
+#   - accuracy: 34.003

--- a/tests/integration/defs/accuracy/references/mmlu.yaml
+++ b/tests/integration/defs/accuracy/references/mmlu.yaml
@@ -148,5 +148,5 @@ nvidia/Llama-3.1-Nemotron-Nano-8B-v1:
   - accuracy: 57.97
 nvidia/Nemotron-H-8B-Base-8K:
   - accuracy: 69.590
-# nvidia/Llama-3_1-Nemotron-Ultra-253B-v1:
-#   - accuracy: 34.003
+nvidia/Llama-3_1-Nemotron-Ultra-253B-v1:
+  - accuracy: 83.70

--- a/tests/integration/defs/accuracy/references/mmlu.yaml
+++ b/tests/integration/defs/accuracy/references/mmlu.yaml
@@ -151,4 +151,4 @@ nvidia/Nemotron-H-8B-Base-8K:
 nvidia/Llama-3_1-Nemotron-Ultra-253B-v1:
   - accuracy: 83.70
 # microsoft/Phi-4-mini-instruct:
-#   - accuracy: 31.543
+#   - accuracy: 0.0

--- a/tests/integration/defs/accuracy/references/mmlu.yaml
+++ b/tests/integration/defs/accuracy/references/mmlu.yaml
@@ -150,5 +150,3 @@ nvidia/Nemotron-H-8B-Base-8K:
   - accuracy: 69.590
 nvidia/Llama-3_1-Nemotron-Ultra-253B-v1:
   - accuracy: 83.70
-# microsoft/Phi-4-mini-instruct:
-#   - accuracy: 0.0

--- a/tests/integration/defs/accuracy/references/mmlu.yaml
+++ b/tests/integration/defs/accuracy/references/mmlu.yaml
@@ -29,7 +29,6 @@ meta-llama/Llama-3.1-8B-Instruct:
     kv_cache_quant_algo: FP8
     accuracy: 67.87
 meta-llama/Llama-3.2-1B:
-  - accuracy: 32.82
   - quant_algo: W8A8_SQ_PER_CHANNEL_PER_TOKEN_PLUGIN
     accuracy: 32.72
   - quant_algo: W8A8_SQ_PER_CHANNEL
@@ -150,3 +149,6 @@ nvidia/Nemotron-H-8B-Base-8K:
   - accuracy: 69.590
 nvidia/Llama-3_1-Nemotron-Ultra-253B-v1:
   - accuracy: 83.70
+  - quant_algo: FP8
+    kv_cache_quant_algo: FP8
+    accuracy: 83.36

--- a/tests/integration/defs/accuracy/references/mmlu.yaml
+++ b/tests/integration/defs/accuracy/references/mmlu.yaml
@@ -150,3 +150,5 @@ nvidia/Nemotron-H-8B-Base-8K:
   - accuracy: 69.590
 nvidia/Llama-3_1-Nemotron-Ultra-253B-v1:
   - accuracy: 83.70
+# microsoft/Phi-4-mini-instruct:
+#   - accuracy: 31.543

--- a/tests/integration/defs/accuracy/test_cli_flow.py
+++ b/tests/integration/defs/accuracy/test_cli_flow.py
@@ -725,38 +725,46 @@ class TestLlama3_2_1B(CliFlowAccuracyTestHarness):
     EXAMPLE_FOLDER = "models/core/llama"
 
     def test_auto_dtype(self):
-        self.run(dtype='auto')
+        self.run(tasks=[CnnDailymail(self.MODEL_NAME),
+                        MMLU(self.MODEL_NAME)], dtype='auto')
 
     @skip_post_blackwell
     def test_smooth_quant(self):
-        self.run(quant_algo=QuantAlgo.W8A8_SQ_PER_CHANNEL_PER_TOKEN_PLUGIN)
+        self.run(tasks=[CnnDailymail(self.MODEL_NAME),
+                        MMLU(self.MODEL_NAME)], quant_algo=QuantAlgo.W8A8_SQ_PER_CHANNEL_PER_TOKEN_PLUGIN)
 
     @skip_post_blackwell
     def test_smooth_quant_ootb(self):
-        self.run(quant_algo=QuantAlgo.W8A8_SQ_PER_CHANNEL)
+        self.run(tasks=[CnnDailymail(self.MODEL_NAME),
+                        MMLU(self.MODEL_NAME)], quant_algo=QuantAlgo.W8A8_SQ_PER_CHANNEL)
 
     @skip_post_blackwell
     def test_smooth_quant_ootb_manage_weights(self):
-        self.run(quant_algo=QuantAlgo.W8A8_SQ_PER_CHANNEL,
+        self.run(tasks=[CnnDailymail(self.MODEL_NAME),
+                        MMLU(self.MODEL_NAME)], quant_algo=QuantAlgo.W8A8_SQ_PER_CHANNEL,
                  extra_build_args=["--fast_build"])
 
     @skip_post_blackwell
     def test_int4_awq(self):
-        self.run(quant_algo=QuantAlgo.W4A16_AWQ)
+        self.run(tasks=[CnnDailymail(self.MODEL_NAME),
+                        MMLU(self.MODEL_NAME)], quant_algo=QuantAlgo.W4A16_AWQ)
 
     @skip_post_blackwell
     def test_int4_awq_int8_kv_cache(self):
-        self.run(quant_algo=QuantAlgo.W4A16_AWQ,
+        self.run(tasks=[CnnDailymail(self.MODEL_NAME),
+                        MMLU(self.MODEL_NAME)], quant_algo=QuantAlgo.W4A16_AWQ,
                  kv_cache_quant_algo=QuantAlgo.INT8)
 
     @skip_post_blackwell
     def test_int4_awq_manage_weights(self):
-        self.run(quant_algo=QuantAlgo.W4A16_AWQ,
+        self.run(tasks=[CnnDailymail(self.MODEL_NAME),
+                        MMLU(self.MODEL_NAME)], quant_algo=QuantAlgo.W4A16_AWQ,
                  extra_build_args=["--fast_build"])
 
     @skip_pre_ada
     def test_fp8(self):
-        self.run(quant_algo=QuantAlgo.FP8, kv_cache_quant_algo=QuantAlgo.FP8)
+        self.run(tasks=[CnnDailymail(self.MODEL_NAME),
+                        MMLU(self.MODEL_NAME)], quant_algo=QuantAlgo.FP8, kv_cache_quant_algo=QuantAlgo.FP8)
 
     @skip_pre_ada
     @pytest.mark.skip_less_device(2)
@@ -783,7 +791,8 @@ class TestLlama3_2_1B(CliFlowAccuracyTestHarness):
         else:
             extra_build_args.append("--reduce_fusion=disable")
 
-        self.run(quant_algo=QuantAlgo.FP8,
+        self.run(tasks=[CnnDailymail(self.MODEL_NAME),
+                        MMLU(self.MODEL_NAME)], quant_algo=QuantAlgo.FP8,
                  kv_cache_quant_algo=QuantAlgo.FP8,
                  tp_size=2,
                  extra_build_args=extra_build_args)
@@ -791,25 +800,29 @@ class TestLlama3_2_1B(CliFlowAccuracyTestHarness):
     @skip_pre_ada
     @pytest.mark.skip_less_device(2)
     def test_fp8_pp2(self):
-        self.run(quant_algo=QuantAlgo.FP8,
+        self.run(tasks=[CnnDailymail(self.MODEL_NAME),
+                        MMLU(self.MODEL_NAME)], quant_algo=QuantAlgo.FP8,
                  kv_cache_quant_algo=QuantAlgo.FP8,
                  pp_size=2)
 
     @skip_pre_ada
     @skip_post_blackwell
     def test_fp8_rowwise(self):
-        self.run(quant_algo=QuantAlgo.FP8_PER_CHANNEL_PER_TOKEN)
+        self.run(tasks=[CnnDailymail(self.MODEL_NAME),
+                        MMLU(self.MODEL_NAME)], quant_algo=QuantAlgo.FP8_PER_CHANNEL_PER_TOKEN)
 
     @skip_pre_ada
     @skip_post_blackwell
     def test_fp8_rowwise_meta_recipe(self):
-        self.run(quant_algo=QuantAlgo.FP8_PER_CHANNEL_PER_TOKEN,
+        self.run(tasks=[CnnDailymail(self.MODEL_NAME),
+                        MMLU(self.MODEL_NAME)], quant_algo=QuantAlgo.FP8_PER_CHANNEL_PER_TOKEN,
                  extra_acc_spec="meta_recipe",
                  extra_convert_args=["--use_meta_fp8_rowwise_recipe"])
 
     @pytest.mark.parametrize("max_gpu_percent", [0.1, 1.0])
     def test_weight_streaming(self, max_gpu_percent: float):
-        self.run(extra_build_args=["--weight_streaming"],
+        self.run(tasks=[CnnDailymail(self.MODEL_NAME),
+                        MMLU(self.MODEL_NAME)], extra_build_args=["--weight_streaming"],
                  extra_summarize_args=["--gpu_weights_percent=0"])
 
         for gpu_percent in [0.1, 0.5, 0.9, 1]:
@@ -819,12 +832,14 @@ class TestLlama3_2_1B(CliFlowAccuracyTestHarness):
             self.evaluate()
 
     def test_cyclic_kv_cache(self):
-        self.run(extra_acc_spec="max_attention_window_size=960",
+        self.run(tasks=[CnnDailymail(self.MODEL_NAME),
+                        MMLU(self.MODEL_NAME)], extra_acc_spec="max_attention_window_size=960",
                  extra_summarize_args=["--max_attention_window_size=960"])
 
     @pytest.mark.skip(reason="https://nvbugspro.nvidia.com/bug/5166352")
+    # TODO: Add MMLU benchmark when restoring the test
     def test_cyclic_kv_cache_beam_search(self):
-        self.run(extra_acc_spec="max_attention_window_size=960;beam_width=4",
+        self.run(tasks=[CnnDailymail(self.MODEL_NAME)], extra_acc_spec="max_attention_window_size=960;beam_width=4",
                  extra_build_args=["--max_beam_width=4"],
                  extra_summarize_args=[
                      "--max_attention_window_size=960", "--num_beams=4"

--- a/tests/integration/defs/accuracy/test_cli_flow.py
+++ b/tests/integration/defs/accuracy/test_cli_flow.py
@@ -803,17 +803,13 @@ class TestLlama3_2_1B(CliFlowAccuracyTestHarness):
     @skip_pre_ada
     @skip_post_blackwell
     def test_fp8_rowwise_meta_recipe(self):
-        self.run(tasks=[CnnDailymail(self.MODEL_NAME),
-                        MMLU(self.MODEL_NAME)],
-                 quant_algo=QuantAlgo.FP8_PER_CHANNEL_PER_TOKEN,
+        self.run(quant_algo=QuantAlgo.FP8_PER_CHANNEL_PER_TOKEN,
                  extra_acc_spec="meta_recipe",
                  extra_convert_args=["--use_meta_fp8_rowwise_recipe"])
 
     @pytest.mark.parametrize("max_gpu_percent", [0.1, 1.0])
     def test_weight_streaming(self, max_gpu_percent: float):
-        self.run(tasks=[CnnDailymail(self.MODEL_NAME),
-                        MMLU(self.MODEL_NAME)],
-                 extra_build_args=["--weight_streaming"],
+        self.run(extra_build_args=["--weight_streaming"],
                  extra_summarize_args=["--gpu_weights_percent=0"])
 
         for gpu_percent in [0.1, 0.5, 0.9, 1]:
@@ -823,16 +819,12 @@ class TestLlama3_2_1B(CliFlowAccuracyTestHarness):
             self.evaluate()
 
     def test_cyclic_kv_cache(self):
-        self.run(tasks=[CnnDailymail(self.MODEL_NAME),
-                        MMLU(self.MODEL_NAME)],
-                 extra_acc_spec="max_attention_window_size=960",
+        self.run(extra_acc_spec="max_attention_window_size=960",
                  extra_summarize_args=["--max_attention_window_size=960"])
 
     @pytest.mark.skip(reason="https://nvbugspro.nvidia.com/bug/5166352")
-    # TODO: Add MMLU benchmark when restoring the test
     def test_cyclic_kv_cache_beam_search(self):
-        self.run(tasks=[CnnDailymail(self.MODEL_NAME)],
-                 extra_acc_spec="max_attention_window_size=960;beam_width=4",
+        self.run(extra_acc_spec="max_attention_window_size=960;beam_width=4",
                  extra_build_args=["--max_beam_width=4"],
                  extra_summarize_args=[
                      "--max_attention_window_size=960", "--num_beams=4"

--- a/tests/integration/defs/accuracy/test_cli_flow.py
+++ b/tests/integration/defs/accuracy/test_cli_flow.py
@@ -725,55 +725,38 @@ class TestLlama3_2_1B(CliFlowAccuracyTestHarness):
     EXAMPLE_FOLDER = "models/core/llama"
 
     def test_auto_dtype(self):
-        self.run(tasks=[CnnDailymail(self.MODEL_NAME),
-                        MMLU(self.MODEL_NAME)],
-                 dtype='auto')
+        self.run(dtype='auto')
 
     @skip_post_blackwell
     def test_smooth_quant(self):
-        self.run(tasks=[CnnDailymail(self.MODEL_NAME),
-                        MMLU(self.MODEL_NAME)],
-                 quant_algo=QuantAlgo.W8A8_SQ_PER_CHANNEL_PER_TOKEN_PLUGIN)
+        self.run(quant_algo=QuantAlgo.W8A8_SQ_PER_CHANNEL_PER_TOKEN_PLUGIN)
 
     @skip_post_blackwell
     def test_smooth_quant_ootb(self):
-        self.run(tasks=[CnnDailymail(self.MODEL_NAME),
-                        MMLU(self.MODEL_NAME)],
-                 quant_algo=QuantAlgo.W8A8_SQ_PER_CHANNEL)
+        self.run(quant_algo=QuantAlgo.W8A8_SQ_PER_CHANNEL)
 
     @skip_post_blackwell
     def test_smooth_quant_ootb_manage_weights(self):
-        self.run(tasks=[CnnDailymail(self.MODEL_NAME),
-                        MMLU(self.MODEL_NAME)],
-                 quant_algo=QuantAlgo.W8A8_SQ_PER_CHANNEL,
+        self.run(quant_algo=QuantAlgo.W8A8_SQ_PER_CHANNEL,
                  extra_build_args=["--fast_build"])
 
     @skip_post_blackwell
     def test_int4_awq(self):
-        self.run(tasks=[CnnDailymail(self.MODEL_NAME),
-                        MMLU(self.MODEL_NAME)],
-                 quant_algo=QuantAlgo.W4A16_AWQ)
+        self.run(quant_algo=QuantAlgo.W4A16_AWQ)
 
     @skip_post_blackwell
     def test_int4_awq_int8_kv_cache(self):
-        self.run(tasks=[CnnDailymail(self.MODEL_NAME),
-                        MMLU(self.MODEL_NAME)],
-                 quant_algo=QuantAlgo.W4A16_AWQ,
+        self.run(quant_algo=QuantAlgo.W4A16_AWQ,
                  kv_cache_quant_algo=QuantAlgo.INT8)
 
     @skip_post_blackwell
     def test_int4_awq_manage_weights(self):
-        self.run(tasks=[CnnDailymail(self.MODEL_NAME),
-                        MMLU(self.MODEL_NAME)],
-                 quant_algo=QuantAlgo.W4A16_AWQ,
+        self.run(quant_algo=QuantAlgo.W4A16_AWQ,
                  extra_build_args=["--fast_build"])
 
     @skip_pre_ada
     def test_fp8(self):
-        self.run(tasks=[CnnDailymail(self.MODEL_NAME),
-                        MMLU(self.MODEL_NAME)],
-                 quant_algo=QuantAlgo.FP8,
-                 kv_cache_quant_algo=QuantAlgo.FP8)
+        self.run(quant_algo=QuantAlgo.FP8, kv_cache_quant_algo=QuantAlgo.FP8)
 
     @skip_pre_ada
     @pytest.mark.skip_less_device(2)
@@ -800,9 +783,7 @@ class TestLlama3_2_1B(CliFlowAccuracyTestHarness):
         else:
             extra_build_args.append("--reduce_fusion=disable")
 
-        self.run(tasks=[CnnDailymail(self.MODEL_NAME),
-                        MMLU(self.MODEL_NAME)],
-                 quant_algo=QuantAlgo.FP8,
+        self.run(quant_algo=QuantAlgo.FP8,
                  kv_cache_quant_algo=QuantAlgo.FP8,
                  tp_size=2,
                  extra_build_args=extra_build_args)
@@ -810,18 +791,14 @@ class TestLlama3_2_1B(CliFlowAccuracyTestHarness):
     @skip_pre_ada
     @pytest.mark.skip_less_device(2)
     def test_fp8_pp2(self):
-        self.run(tasks=[CnnDailymail(self.MODEL_NAME),
-                        MMLU(self.MODEL_NAME)],
-                 quant_algo=QuantAlgo.FP8,
+        self.run(quant_algo=QuantAlgo.FP8,
                  kv_cache_quant_algo=QuantAlgo.FP8,
                  pp_size=2)
 
     @skip_pre_ada
     @skip_post_blackwell
     def test_fp8_rowwise(self):
-        self.run(tasks=[CnnDailymail(self.MODEL_NAME),
-                        MMLU(self.MODEL_NAME)],
-                 quant_algo=QuantAlgo.FP8_PER_CHANNEL_PER_TOKEN)
+        self.run(quant_algo=QuantAlgo.FP8_PER_CHANNEL_PER_TOKEN)
 
     @skip_pre_ada
     @skip_post_blackwell

--- a/tests/integration/defs/accuracy/test_cli_flow.py
+++ b/tests/integration/defs/accuracy/test_cli_flow.py
@@ -726,45 +726,54 @@ class TestLlama3_2_1B(CliFlowAccuracyTestHarness):
 
     def test_auto_dtype(self):
         self.run(tasks=[CnnDailymail(self.MODEL_NAME),
-                        MMLU(self.MODEL_NAME)], dtype='auto')
+                        MMLU(self.MODEL_NAME)],
+                 dtype='auto')
 
     @skip_post_blackwell
     def test_smooth_quant(self):
         self.run(tasks=[CnnDailymail(self.MODEL_NAME),
-                        MMLU(self.MODEL_NAME)], quant_algo=QuantAlgo.W8A8_SQ_PER_CHANNEL_PER_TOKEN_PLUGIN)
+                        MMLU(self.MODEL_NAME)],
+                 quant_algo=QuantAlgo.W8A8_SQ_PER_CHANNEL_PER_TOKEN_PLUGIN)
 
     @skip_post_blackwell
     def test_smooth_quant_ootb(self):
         self.run(tasks=[CnnDailymail(self.MODEL_NAME),
-                        MMLU(self.MODEL_NAME)], quant_algo=QuantAlgo.W8A8_SQ_PER_CHANNEL)
+                        MMLU(self.MODEL_NAME)],
+                 quant_algo=QuantAlgo.W8A8_SQ_PER_CHANNEL)
 
     @skip_post_blackwell
     def test_smooth_quant_ootb_manage_weights(self):
         self.run(tasks=[CnnDailymail(self.MODEL_NAME),
-                        MMLU(self.MODEL_NAME)], quant_algo=QuantAlgo.W8A8_SQ_PER_CHANNEL,
+                        MMLU(self.MODEL_NAME)],
+                 quant_algo=QuantAlgo.W8A8_SQ_PER_CHANNEL,
                  extra_build_args=["--fast_build"])
 
     @skip_post_blackwell
     def test_int4_awq(self):
         self.run(tasks=[CnnDailymail(self.MODEL_NAME),
-                        MMLU(self.MODEL_NAME)], quant_algo=QuantAlgo.W4A16_AWQ)
+                        MMLU(self.MODEL_NAME)],
+                 quant_algo=QuantAlgo.W4A16_AWQ)
 
     @skip_post_blackwell
     def test_int4_awq_int8_kv_cache(self):
         self.run(tasks=[CnnDailymail(self.MODEL_NAME),
-                        MMLU(self.MODEL_NAME)], quant_algo=QuantAlgo.W4A16_AWQ,
+                        MMLU(self.MODEL_NAME)],
+                 quant_algo=QuantAlgo.W4A16_AWQ,
                  kv_cache_quant_algo=QuantAlgo.INT8)
 
     @skip_post_blackwell
     def test_int4_awq_manage_weights(self):
         self.run(tasks=[CnnDailymail(self.MODEL_NAME),
-                        MMLU(self.MODEL_NAME)], quant_algo=QuantAlgo.W4A16_AWQ,
+                        MMLU(self.MODEL_NAME)],
+                 quant_algo=QuantAlgo.W4A16_AWQ,
                  extra_build_args=["--fast_build"])
 
     @skip_pre_ada
     def test_fp8(self):
         self.run(tasks=[CnnDailymail(self.MODEL_NAME),
-                        MMLU(self.MODEL_NAME)], quant_algo=QuantAlgo.FP8, kv_cache_quant_algo=QuantAlgo.FP8)
+                        MMLU(self.MODEL_NAME)],
+                 quant_algo=QuantAlgo.FP8,
+                 kv_cache_quant_algo=QuantAlgo.FP8)
 
     @skip_pre_ada
     @pytest.mark.skip_less_device(2)
@@ -792,7 +801,8 @@ class TestLlama3_2_1B(CliFlowAccuracyTestHarness):
             extra_build_args.append("--reduce_fusion=disable")
 
         self.run(tasks=[CnnDailymail(self.MODEL_NAME),
-                        MMLU(self.MODEL_NAME)], quant_algo=QuantAlgo.FP8,
+                        MMLU(self.MODEL_NAME)],
+                 quant_algo=QuantAlgo.FP8,
                  kv_cache_quant_algo=QuantAlgo.FP8,
                  tp_size=2,
                  extra_build_args=extra_build_args)
@@ -801,7 +811,8 @@ class TestLlama3_2_1B(CliFlowAccuracyTestHarness):
     @pytest.mark.skip_less_device(2)
     def test_fp8_pp2(self):
         self.run(tasks=[CnnDailymail(self.MODEL_NAME),
-                        MMLU(self.MODEL_NAME)], quant_algo=QuantAlgo.FP8,
+                        MMLU(self.MODEL_NAME)],
+                 quant_algo=QuantAlgo.FP8,
                  kv_cache_quant_algo=QuantAlgo.FP8,
                  pp_size=2)
 
@@ -809,20 +820,23 @@ class TestLlama3_2_1B(CliFlowAccuracyTestHarness):
     @skip_post_blackwell
     def test_fp8_rowwise(self):
         self.run(tasks=[CnnDailymail(self.MODEL_NAME),
-                        MMLU(self.MODEL_NAME)], quant_algo=QuantAlgo.FP8_PER_CHANNEL_PER_TOKEN)
+                        MMLU(self.MODEL_NAME)],
+                 quant_algo=QuantAlgo.FP8_PER_CHANNEL_PER_TOKEN)
 
     @skip_pre_ada
     @skip_post_blackwell
     def test_fp8_rowwise_meta_recipe(self):
         self.run(tasks=[CnnDailymail(self.MODEL_NAME),
-                        MMLU(self.MODEL_NAME)], quant_algo=QuantAlgo.FP8_PER_CHANNEL_PER_TOKEN,
+                        MMLU(self.MODEL_NAME)],
+                 quant_algo=QuantAlgo.FP8_PER_CHANNEL_PER_TOKEN,
                  extra_acc_spec="meta_recipe",
                  extra_convert_args=["--use_meta_fp8_rowwise_recipe"])
 
     @pytest.mark.parametrize("max_gpu_percent", [0.1, 1.0])
     def test_weight_streaming(self, max_gpu_percent: float):
         self.run(tasks=[CnnDailymail(self.MODEL_NAME),
-                        MMLU(self.MODEL_NAME)], extra_build_args=["--weight_streaming"],
+                        MMLU(self.MODEL_NAME)],
+                 extra_build_args=["--weight_streaming"],
                  extra_summarize_args=["--gpu_weights_percent=0"])
 
         for gpu_percent in [0.1, 0.5, 0.9, 1]:
@@ -833,13 +847,15 @@ class TestLlama3_2_1B(CliFlowAccuracyTestHarness):
 
     def test_cyclic_kv_cache(self):
         self.run(tasks=[CnnDailymail(self.MODEL_NAME),
-                        MMLU(self.MODEL_NAME)], extra_acc_spec="max_attention_window_size=960",
+                        MMLU(self.MODEL_NAME)],
+                 extra_acc_spec="max_attention_window_size=960",
                  extra_summarize_args=["--max_attention_window_size=960"])
 
     @pytest.mark.skip(reason="https://nvbugspro.nvidia.com/bug/5166352")
     # TODO: Add MMLU benchmark when restoring the test
     def test_cyclic_kv_cache_beam_search(self):
-        self.run(tasks=[CnnDailymail(self.MODEL_NAME)], extra_acc_spec="max_attention_window_size=960;beam_width=4",
+        self.run(tasks=[CnnDailymail(self.MODEL_NAME)],
+                 extra_acc_spec="max_attention_window_size=960;beam_width=4",
                  extra_build_args=["--max_beam_width=4"],
                  extra_summarize_args=[
                      "--max_attention_window_size=960", "--num_beams=4"

--- a/tests/integration/defs/accuracy/test_cli_flow.py
+++ b/tests/integration/defs/accuracy/test_cli_flow.py
@@ -224,6 +224,73 @@ class TestLlama3_3NemotronSuper49Bv1(CliFlowAccuracyTestHarness):
                  quant_algo=QuantAlgo.FP8)
 
 
+class TestNemotronNano(CliFlowAccuracyTestHarness):
+    MODEL_NAME = "nvidia/Llama-3.1-Nemotron-Nano-8B-v1"
+    MODEL_PATH = f"{llm_models_root()}/Llama-3.1-Nemotron-Nano-8B-v1"
+    EXAMPLE_FOLDER = "models/core/llama"
+
+    def test_auto_dtype(self):
+        self.run(tasks=[MMLU(self.MODEL_NAME)], dtype='auto')
+
+
+class TestNemotronUltra(CliFlowAccuracyTestHarness):
+    MODEL_NAME = "nvidia/Llama-3_1-Nemotron-Ultra-253B-v1"
+    MODEL_PATH = f"{llm_models_root()}/nemotron-nas/Llama-3_1-Nemotron-Ultra-253B-v1"
+    EXAMPLE_FOLDER = "models/core/nemotron_nas"
+
+    @skip_pre_hopper
+    @pytest.mark.skip_less_device(8)
+    @pytest.mark.skip_device_not_contain(["H100", "B200"])
+    @parametrize_with_ids("cuda_graph", [False, True])
+    @pytest.mark.parametrize("tp_size,pp_size,ep_size", [(8, 1, 1), (8, 1, 4),
+                                                         (8, 1, 8)],
+                             ids=["tp8", "tp8ep4", "tp8ep8"])
+    def test_auto_dtype(self, cuda_graph, tp_size, pp_size, ep_size):
+        extra_summarize_args = []
+        if cuda_graph:
+            extra_summarize_args.append("--cuda_graph_mode")
+
+        self.run(tasks=[MMLU(self.MODEL_NAME)],
+                 tp_size=tp_size,
+                 pp_size=pp_size,
+                 extra_convert_args=[
+                     f"--moe_tp_size={tp_size // ep_size}",
+                     f"--moe_ep_size={ep_size}", f"--moe_renorm_mode={0}"
+                 ],
+                 extra_build_args=["--gemm_plugin=auto", "--moe_plugin=auto"],
+                 extra_summarize_args=extra_summarize_args)
+
+    @skip_pre_hopper
+    @pytest.mark.skip_less_device(8)
+    @pytest.mark.skip_device_not_contain(["H100", "B200"])
+    @parametrize_with_ids("cuda_graph", [False, True])
+    @pytest.mark.parametrize("tp_size,pp_size,ep_size", [(8, 1, 1), (8, 1, 4),
+                                                         (8, 1, 8)],
+                             ids=["tp8", "tp8ep4", "tp8ep8"])
+    def test_fp8_prequantized(self, cuda_graph, tp_size, pp_size, ep_size,
+                              mocker):
+        mocker.patch.object(
+            self.__class__, "MODEL_PATH",
+            f"{llm_models_root()}/nemotron-nas/Llama-3_1-Nemotron-Ultra-253B-v1-FP8"
+        )
+
+        extra_summarize_args = []
+        if cuda_graph:
+            extra_summarize_args.append("--cuda_graph_mode")
+
+        self.run(tasks=[MMLU(self.MODEL_NAME)],
+                 quant_algo=QuantAlgo.FP8,
+                 kv_cache_quant_algo=QuantAlgo.FP8,
+                 tp_size=tp_size,
+                 pp_size=pp_size,
+                 extra_convert_args=[
+                     f"--moe_tp_size={tp_size // ep_size}",
+                     f"--moe_ep_size={ep_size}", f"--moe_renorm_mode={0}"
+                 ],
+                 extra_build_args=["--gemm_plugin=auto", "--moe_plugin=auto"],
+                 extra_summarize_args=extra_summarize_args)
+
+
 class TestPhi2(CliFlowAccuracyTestHarness):
     MODEL_NAME = "microsoft/phi-2"
     MODEL_PATH = f"{llm_models_root()}/phi-2"

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -1155,6 +1155,10 @@ class TestPhi4MiniInstruct(LlmapiAccuracyTestHarness):
     MODEL_NAME = "microsoft/Phi-4-mini-instruct"
     MODEL_PATH = f"{llm_models_root()}/Phi-4-mini-instruct"
 
+    # @pytest.mark.skip(
+    #     reason=
+    #     "Temporarily skipping test_auto_dtype while resolving Phi-4's architecture issue."
+    # )
     def test_auto_dtype(self):
         with LLM(self.MODEL_PATH) as llm:
             task = CnnDailymail(self.MODEL_NAME)

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -964,24 +964,29 @@ class TestNemotronUltra(LlmapiAccuracyTestHarness):
             task.evaluate(llm,
                           extra_evaluator_kwargs=dict(apply_chat_template=True))
 
-    # @pytest.mark.skip_less_device(8)
-    # @pytest.mark.skip_device_not_contain(["H100", "B200"])
-    # @parametrize_with_ids("cuda_graph", [False, True])
-    # @pytest.mark.parametrize("tp_size,pp_size,ep_size", [(8, 1, 1), (8, 1, 4), (8, 1, 8)],
-    #                         ids=["tp8", "tp8ep4", "tp8ep8"])
-    # def test_fp8_tp8(self, cuda_graph, tp_size, pp_size, ep_size):
-    #     model_path = f"{llm_models_root()}/nemotron-nas/Llama-3_1-Nemotron-Ultra-253B-v1-FP8"
-    #     with LLM(model_path,
-    #             tensor_parallel_size=tp_size,
-    #             pipeline_parallel_size=pp_size,
-    #             moe_expert_parallel_size=ep_size,
-    #             use_cuda_graph=cuda_graph) as llm:
-    #         assert llm.args.quant_config.quant_algo == QuantAlgo.FP8
-    #         assert llm.args.quant_config.kv_cache_quant_algo == QuantAlgo.FP8
-    #         task = CnnDailymail(self.MODEL_NAME)
-    #         task.evaluate(llm)
-    #         task = MMLU(self.MODEL_NAME)
-    #         task.evaluate(llm)
+    @pytest.mark.skip(
+        reason=
+        "Temporarily skipping test_fp8_tp8 due to not having FP8 model on scratch."
+    )
+    @pytest.mark.skip_less_device(8)
+    @pytest.mark.skip_device_not_contain(["H100", "B200"])
+    @parametrize_with_ids("cuda_graph", [False, True])
+    @pytest.mark.parametrize("tp_size,pp_size,ep_size", [(8, 1, 1), (8, 1, 4),
+                                                         (8, 1, 8)],
+                             ids=["tp8", "tp8ep4", "tp8ep8"])
+    def test_fp8_tp8(self, cuda_graph, tp_size, pp_size, ep_size):
+        model_path = f"{llm_models_root()}/nemotron-nas/Llama-3_1-Nemotron-Ultra-253B-v1-FP8"
+        with LLM(model_path,
+                 tensor_parallel_size=tp_size,
+                 pipeline_parallel_size=pp_size,
+                 moe_expert_parallel_size=ep_size,
+                 use_cuda_graph=cuda_graph) as llm:
+            assert llm.args.quant_config.quant_algo == QuantAlgo.FP8
+            assert llm.args.quant_config.kv_cache_quant_algo == QuantAlgo.FP8
+            task = CnnDailymail(self.MODEL_NAME)
+            task.evaluate(llm)
+            task = MMLU(self.MODEL_NAME)
+            task.evaluate(llm)
 
 
 class TestNemotronH(LlmapiAccuracyTestHarness):

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -1155,10 +1155,10 @@ class TestPhi4MiniInstruct(LlmapiAccuracyTestHarness):
     MODEL_NAME = "microsoft/Phi-4-mini-instruct"
     MODEL_PATH = f"{llm_models_root()}/Phi-4-mini-instruct"
 
-    # @pytest.mark.skip(
-    #     reason=
-    #     "Temporarily skipping test_auto_dtype while resolving Phi-4's architecture issue."
-    # )
+    @pytest.mark.skip(
+        reason=
+        "Temporarily skipping test_auto_dtype while resolving Phi-4's architecture issue."
+    )
     def test_auto_dtype(self):
         with LLM(self.MODEL_PATH) as llm:
             task = CnnDailymail(self.MODEL_NAME)

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -295,36 +295,6 @@ class TestLlama4ScoutInstruct(LlmapiAccuracyTestHarness):
             task = GSM8K(self.MODEL_NAME)
             task.evaluate(llm)
 
-    @pytest.mark.skip_less_device(8)
-    @skip_pre_hopper
-    @parametrize_with_ids("cuda_graph", [False, True])
-    @parametrize_with_ids("fp8kv", [False, True])
-    @pytest.mark.parametrize("tp_size,pp_size,ep_size", [(8, 1, 1), (8, 1, 4),
-                                                         (8, 1, 8)],
-                             ids=["tp8", "tp8ep4", "tp8ep8"])
-    def test_fp8(self, cuda_graph, fp8kv, tp_size, pp_size, ep_size):
-        quant_config = QuantConfig(quant_algo=QuantAlgo.FP8)
-        if fp8kv:
-            quant_config.kv_cache_quant_algo = QuantAlgo.FP8
-            pytorch_config = PyTorchConfig(kv_cache_dtype="fp8")
-        else:
-            pytorch_config = PyTorchConfig()
-
-        with LLM(self.MODEL_PATH,
-                 tensor_parallel_size=tp_size,
-                 pipeline_parallel_size=pp_size,
-                 moe_expert_parallel_size=ep_size,
-                 use_cuda_graph=cuda_graph,
-                 quant_config=quant_config,
-                 pytorch_backend_config=pytorch_config) as llm:
-            assert llm.args.quant_config.quant_algo == QuantAlgo.FP8
-            if fp8kv:
-                assert llm.args.quant_config.kv_cache_quant_algo == QuantAlgo.FP8
-            task = MMLU(self.MODEL_NAME)
-            task.evaluate(llm)
-            task = GSM8K(self.MODEL_NAME)
-            task.evaluate(llm)
-
 
 class TestMistral7B(LlmapiAccuracyTestHarness):
     MODEL_NAME = "mistralai/Mistral-7B-v0.1"
@@ -974,8 +944,16 @@ class TestNemotronUltra(LlmapiAccuracyTestHarness):
 
     @pytest.mark.skip_less_device(8)
     @pytest.mark.skip_device_not_contain(["H100", "B200"])
-    def test_auto_dtype(self):
-        with LLM(self.MODEL_PATH) as llm:
+    @parametrize_with_ids("cuda_graph", [False, True])
+    @pytest.mark.parametrize("tp_size,pp_size,ep_size", [(8, 1, 1), (8, 1, 4),
+                                                         (8, 1, 8)],
+                             ids=["tp8", "tp8ep4", "tp8ep8"])
+    def test_auto_dtype(self, cuda_graph, tp_size, pp_size, ep_size):
+        with LLM(self.MODEL_PATH,
+                 tensor_parallel_size=tp_size,
+                 pipeline_parallel_size=pp_size,
+                 moe_expert_parallel_size=ep_size,
+                 use_cuda_graph=cuda_graph) as llm:
             task = CnnDailymail(self.MODEL_NAME)
             task.evaluate(llm)
             task = MMLU(self.MODEL_NAME)
@@ -988,15 +966,23 @@ class TestNemotronUltra(LlmapiAccuracyTestHarness):
 
     # @pytest.mark.skip_less_device(8)
     # @pytest.mark.skip_device_not_contain(["H100", "B200"])
-    # def test_fp8_tp8(self):
+    # @parametrize_with_ids("cuda_graph", [False, True])
+    # @pytest.mark.parametrize("tp_size,pp_size,ep_size", [(8, 1, 1), (8, 1, 4), (8, 1, 8)],
+    #                         ids=["tp8", "tp8ep4", "tp8ep8"])
+    # def test_fp8_tp8(self, cuda_graph, tp_size, pp_size, ep_size):
     #     model_path = f"{llm_models_root()}/nemotron-nas/Llama-3_1-Nemotron-Ultra-253B-v1-FP8"
-    #     with LLM(model_path, tensor_parallel_size=8) as llm:
+    #     with LLM(model_path,
+    #             tensor_parallel_size=tp_size,
+    #             pipeline_parallel_size=pp_size,
+    #             moe_expert_parallel_size=ep_size,
+    #             use_cuda_graph=cuda_graph) as llm:
     #         assert llm.args.quant_config.quant_algo == QuantAlgo.FP8
     #         assert llm.args.quant_config.kv_cache_quant_algo == QuantAlgo.FP8
     #         task = CnnDailymail(self.MODEL_NAME)
     #         task.evaluate(llm)
     #         task = MMLU(self.MODEL_NAME)
     #         task.evaluate(llm)
+
 
 class TestNemotronH(LlmapiAccuracyTestHarness):
     MODEL_NAME = "nvidia/Nemotron-H-8B-Base-8K"
@@ -1158,3 +1144,20 @@ class TestQwen3_32B(LlmapiAccuracyTestHarness):
             task.evaluate(llm)
             task = MMLU(self.MODEL_NAME)
             task.evaluate(llm)
+
+
+class TestPhi4MiniInstruct(LlmapiAccuracyTestHarness):
+    MODEL_NAME = "microsoft/Phi-4-mini-instruct"
+    MODEL_PATH = f"{llm_models_root()}/Phi-4-mini-instruct"
+
+    def test_auto_dtype(self):
+        with LLM(self.MODEL_PATH) as llm:
+            task = CnnDailymail(self.MODEL_NAME)
+            task.evaluate(llm)
+            task = MMLU(self.MODEL_NAME)
+            task.evaluate(llm)
+            task = GSM8K(self.MODEL_NAME)
+            task.evaluate(llm)
+            task = GPQADiamond(self.MODEL_NAME)
+            task.evaluate(llm,
+                          extra_evaluator_kwargs=dict(apply_chat_template=True))

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -927,8 +927,6 @@ class TestNemotronNano(LlmapiAccuracyTestHarness):
 
     def test_auto_dtype(self):
         with LLM(self.MODEL_PATH) as llm:
-            task = CnnDailymail(self.MODEL_NAME)
-            task.evaluate(llm)
             task = MMLU(self.MODEL_NAME)
             task.evaluate(llm)
             task = GSM8K(self.MODEL_NAME)
@@ -954,8 +952,6 @@ class TestNemotronUltra(LlmapiAccuracyTestHarness):
                  pipeline_parallel_size=pp_size,
                  moe_expert_parallel_size=ep_size,
                  use_cuda_graph=cuda_graph) as llm:
-            task = CnnDailymail(self.MODEL_NAME)
-            task.evaluate(llm)
             task = MMLU(self.MODEL_NAME)
             task.evaluate(llm)
             task = GSM8K(self.MODEL_NAME)
@@ -964,17 +960,13 @@ class TestNemotronUltra(LlmapiAccuracyTestHarness):
             task.evaluate(llm,
                           extra_evaluator_kwargs=dict(apply_chat_template=True))
 
-    @pytest.mark.skip(
-        reason=
-        "Temporarily skipping test_fp8_tp8 due to not having FP8 model on scratch."
-    )
     @pytest.mark.skip_less_device(8)
     @pytest.mark.skip_device_not_contain(["H100", "B200"])
     @parametrize_with_ids("cuda_graph", [False, True])
     @pytest.mark.parametrize("tp_size,pp_size,ep_size", [(8, 1, 1), (8, 1, 4),
                                                          (8, 1, 8)],
                              ids=["tp8", "tp8ep4", "tp8ep8"])
-    def test_fp8_tp8(self, cuda_graph, tp_size, pp_size, ep_size):
+    def test_fp8_prequantized(self, cuda_graph, tp_size, pp_size, ep_size):
         model_path = f"{llm_models_root()}/nemotron-nas/Llama-3_1-Nemotron-Ultra-253B-v1-FP8"
         with LLM(model_path,
                  tensor_parallel_size=tp_size,
@@ -983,10 +975,13 @@ class TestNemotronUltra(LlmapiAccuracyTestHarness):
                  use_cuda_graph=cuda_graph) as llm:
             assert llm.args.quant_config.quant_algo == QuantAlgo.FP8
             assert llm.args.quant_config.kv_cache_quant_algo == QuantAlgo.FP8
-            task = CnnDailymail(self.MODEL_NAME)
-            task.evaluate(llm)
             task = MMLU(self.MODEL_NAME)
             task.evaluate(llm)
+            task = GSM8K(self.MODEL_NAME)
+            task.evaluate(llm)
+            task = GPQADiamond(self.MODEL_NAME)
+            task.evaluate(llm,
+                          extra_evaluator_kwargs=dict(apply_chat_template=True))
 
 
 class TestNemotronH(LlmapiAccuracyTestHarness):

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -295,6 +295,36 @@ class TestLlama4ScoutInstruct(LlmapiAccuracyTestHarness):
             task = GSM8K(self.MODEL_NAME)
             task.evaluate(llm)
 
+    @pytest.mark.skip_less_device(8)
+    @skip_pre_hopper
+    @parametrize_with_ids("cuda_graph", [False, True])
+    @parametrize_with_ids("fp8kv", [False, True])
+    @pytest.mark.parametrize("tp_size,pp_size,ep_size", [(8, 1, 1), (8, 1, 4),
+                                                         (8, 1, 8)],
+                             ids=["tp8", "tp8ep4", "tp8ep8"])
+    def test_fp8(self, cuda_graph, fp8kv, tp_size, pp_size, ep_size):
+        quant_config = QuantConfig(quant_algo=QuantAlgo.FP8)
+        if fp8kv:
+            quant_config.kv_cache_quant_algo = QuantAlgo.FP8
+            pytorch_config = PyTorchConfig(kv_cache_dtype="fp8")
+        else:
+            pytorch_config = PyTorchConfig()
+
+        with LLM(self.MODEL_PATH,
+                 tensor_parallel_size=tp_size,
+                 pipeline_parallel_size=pp_size,
+                 moe_expert_parallel_size=ep_size,
+                 use_cuda_graph=cuda_graph,
+                 quant_config=quant_config,
+                 pytorch_backend_config=pytorch_config) as llm:
+            assert llm.args.quant_config.quant_algo == QuantAlgo.FP8
+            if fp8kv:
+                assert llm.args.quant_config.kv_cache_quant_algo == QuantAlgo.FP8
+            task = MMLU(self.MODEL_NAME)
+            task.evaluate(llm)
+            task = GSM8K(self.MODEL_NAME)
+            task.evaluate(llm)
+
 
 class TestMistral7B(LlmapiAccuracyTestHarness):
     MODEL_NAME = "mistralai/Mistral-7B-v0.1"
@@ -931,7 +961,42 @@ class TestNemotronNano(LlmapiAccuracyTestHarness):
             task.evaluate(llm)
             task = MMLU(self.MODEL_NAME)
             task.evaluate(llm)
+            task = GSM8K(self.MODEL_NAME)
+            task.evaluate(llm)
+            task = GPQADiamond(self.MODEL_NAME)
+            task.evaluate(llm,
+                          extra_evaluator_kwargs=dict(apply_chat_template=True))
 
+
+class TestNemotronUltra(LlmapiAccuracyTestHarness):
+    MODEL_NAME = "nvidia/Llama-3_1-Nemotron-Ultra-253B-v1"
+    MODEL_PATH = f"{llm_models_root()}/nemotron-nas/Llama-3_1-Nemotron-Ultra-253B-v1"
+
+    @pytest.mark.skip_less_device(8)
+    @pytest.mark.skip_device_not_contain(["H100", "B200"])
+    def test_auto_dtype(self):
+        with LLM(self.MODEL_PATH) as llm:
+            task = CnnDailymail(self.MODEL_NAME)
+            task.evaluate(llm)
+            task = MMLU(self.MODEL_NAME)
+            task.evaluate(llm)
+            task = GSM8K(self.MODEL_NAME)
+            task.evaluate(llm)
+            task = GPQADiamond(self.MODEL_NAME)
+            task.evaluate(llm,
+                          extra_evaluator_kwargs=dict(apply_chat_template=True))
+
+    # @pytest.mark.skip_less_device(8)
+    # @pytest.mark.skip_device_not_contain(["H100", "B200"])
+    # def test_fp8_tp8(self):
+    #     model_path = f"{llm_models_root()}/nemotron-nas/Llama-3_1-Nemotron-Ultra-253B-v1-FP8"
+    #     with LLM(model_path, tensor_parallel_size=8) as llm:
+    #         assert llm.args.quant_config.quant_algo == QuantAlgo.FP8
+    #         assert llm.args.quant_config.kv_cache_quant_algo == QuantAlgo.FP8
+    #         task = CnnDailymail(self.MODEL_NAME)
+    #         task.evaluate(llm)
+    #         task = MMLU(self.MODEL_NAME)
+    #         task.evaluate(llm)
 
 class TestNemotronH(LlmapiAccuracyTestHarness):
     MODEL_NAME = "nvidia/Nemotron-H-8B-Base-8K"

--- a/tests/integration/test_lists/qa/examples_test_list.txt
+++ b/tests/integration/test_lists/qa/examples_test_list.txt
@@ -453,8 +453,12 @@ accuracy/test_llm_api_pytorch.py::TestLlama3_3NemotronSuper49Bv1::test_fp8_prequ
 accuracy/test_cli_flow.py::TestLlama3_3NemotronSuper49Bv1::test_auto_dtype_tp2
 accuracy/test_cli_flow.py::TestLlama3_3NemotronSuper49Bv1::test_fp8_prequantized_tp2
 accuracy/test_llm_api_pytorch.py::TestNemotronNano::test_auto_dtype
-accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_auto_dtype
-accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_fp8_tp8
+accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_auto_dtype[tp8-cuda_graph=False]
+accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_auto_dtype[tp8ep4-cuda_graph=True]
+accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_auto_dtype[tp8ep8-cuda_graph=True]
+accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_fp8_tp8[tp8-cuda_graph=False]
+accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_fp8_tp8[tp8ep4-cuda_graph=True]
+accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_fp8_tp8[tp8ep8-cuda_graph=True]
 accuracy/test_llm_api_pytorch.py::TestNemotronH::test_auto_dtype
 accuracy/test_llm_api_pytorch.py::TestQwen2_7BInstruct::test_auto_dtype
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_8gpus[latency]

--- a/tests/integration/test_lists/qa/examples_test_list.txt
+++ b/tests/integration/test_lists/qa/examples_test_list.txt
@@ -450,12 +450,8 @@ accuracy/test_llm_api_pytorch.py::TestLlama3_3NemotronSuper49Bv1::test_fp8_prequ
 accuracy/test_cli_flow.py::TestLlama3_3NemotronSuper49Bv1::test_auto_dtype_tp2
 accuracy/test_cli_flow.py::TestLlama3_3NemotronSuper49Bv1::test_fp8_prequantized_tp2
 accuracy/test_llm_api_pytorch.py::TestNemotronNano::test_auto_dtype
-accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_auto_dtype[tp8-cuda_graph=False]
 accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_auto_dtype[tp8ep4-cuda_graph=True]
-accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_auto_dtype[tp8ep8-cuda_graph=True]
-accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_fp8_tp8[tp8-cuda_graph=False]
 accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_fp8_tp8[tp8ep4-cuda_graph=True]
-accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_fp8_tp8[tp8ep8-cuda_graph=True]
 accuracy/test_llm_api_pytorch.py::TestNemotronH::test_auto_dtype
 accuracy/test_llm_api_pytorch.py::TestQwen2_7BInstruct::test_auto_dtype
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_8gpus[latency]

--- a/tests/integration/test_lists/qa/examples_test_list.txt
+++ b/tests/integration/test_lists/qa/examples_test_list.txt
@@ -438,6 +438,9 @@ accuracy/test_llm_api_pytorch.py::TestLlama4MaverickInstruct::test_auto_dtype[tp
 accuracy/test_llm_api_pytorch.py::TestLlama4ScoutInstruct::test_auto_dtype[tp8-cuda_graph=False]
 accuracy/test_llm_api_pytorch.py::TestLlama4ScoutInstruct::test_auto_dtype[tp8ep4-cuda_graph=True]
 accuracy/test_llm_api_pytorch.py::TestLlama4ScoutInstruct::test_auto_dtype[tp8ep8-cuda_graph=True]
+accuracy/test_llm_api_pytorch.py::TestLlama4ScoutInstruct::test_fp8[tp8-]
+accuracy/test_llm_api_pytorch.py::TestLlama4ScoutInstruct::test_fp8[tp8ep4-cuda_graph]
+accuracy/test_llm_api_pytorch.py::TestLlama4ScoutInstruct::test_fp8[tp8ep8-cuda_graph]
 accuracy/test_llm_api_pytorch.py::TestMixtral8x7B::test_fp8_tp2
 accuracy/test_llm_api_pytorch.py::TestMixtral8x7B::test_nvfp4_tp2
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16[mtp_nextn=0-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=False]
@@ -450,6 +453,8 @@ accuracy/test_llm_api_pytorch.py::TestLlama3_3NemotronSuper49Bv1::test_fp8_prequ
 accuracy/test_cli_flow.py::TestLlama3_3NemotronSuper49Bv1::test_auto_dtype_tp2
 accuracy/test_cli_flow.py::TestLlama3_3NemotronSuper49Bv1::test_fp8_prequantized_tp2
 accuracy/test_llm_api_pytorch.py::TestNemotronNano::test_auto_dtype
+accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_auto_dtype
+accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_fp8_tp8
 accuracy/test_llm_api_pytorch.py::TestNemotronH::test_auto_dtype
 accuracy/test_llm_api_pytorch.py::TestQwen2_7BInstruct::test_auto_dtype
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_8gpus[latency]

--- a/tests/integration/test_lists/qa/examples_test_list.txt
+++ b/tests/integration/test_lists/qa/examples_test_list.txt
@@ -375,6 +375,14 @@ accuracy/test_cli_flow.py::TestLlama3_2_1B::test_fp8_rowwise
 accuracy/test_cli_flow.py::TestLlama3_2_1B::test_weight_streaming[1.0]
 accuracy/test_cli_flow.py::TestLlama3_2_1B::test_cyclic_kv_cache
 accuracy/test_cli_flow.py::TestLlama3_2_1B::test_cyclic_kv_cache_beam_search
+accuracy/test_llm_api_pytorch.py::TestLlama3_2_1B::test_auto_dtype
+accuracy/test_llm_api_pytorch.py::TestLlama3_2_1B::test_smooth_quant
+accuracy/test_llm_api_pytorch.py::TestLlama3_2_1B::test_smooth_quant_ootb
+accuracy/test_llm_api_pytorch.py::TestLlama3_2_1B::test_int4_awq
+accuracy/test_llm_api_pytorch.py::TestLlama3_2_1B::test_int4_awq_int8_kv_cache
+accuracy/test_llm_api_pytorch.py::TestLlama3_2_1B::test_fp8
+accuracy/test_llm_api_pytorch.py::TestLlama3_2_1B::test_fp8_pp2
+accuracy/test_llm_api_pytorch.py::TestLlama3_2_1B::test_fp8_rowwise
 accuracy/test_cli_flow.py::TestMistral7B::test_beam_search
 accuracy/test_cli_flow.py::TestMistral7B::test_fp8_tp4pp2
 accuracy/test_cli_flow.py::TestMistral7B::test_smooth_quant_tp4pp1
@@ -450,8 +458,11 @@ accuracy/test_llm_api_pytorch.py::TestLlama3_3NemotronSuper49Bv1::test_fp8_prequ
 accuracy/test_cli_flow.py::TestLlama3_3NemotronSuper49Bv1::test_auto_dtype_tp2
 accuracy/test_cli_flow.py::TestLlama3_3NemotronSuper49Bv1::test_fp8_prequantized_tp2
 accuracy/test_llm_api_pytorch.py::TestNemotronNano::test_auto_dtype
+accuracy/test_cli_flow.py::TestNemotronNano::test_auto_dtype
 accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_auto_dtype[tp8ep4-cuda_graph=True]
 accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_fp8_prequantized[tp8ep4-cuda_graph=True]
+accuracy/test_cli_flow.py::TestNemotronUltra::test_auto_dtype[tp8ep4-cuda_graph=True]
+accuracy/test_cli_flow.py::TestNemotronUltra::test_fp8_prequantized[tp8ep4-cuda_graph=True]
 accuracy/test_llm_api_pytorch.py::TestNemotronH::test_auto_dtype
 accuracy/test_llm_api_pytorch.py::TestQwen2_7BInstruct::test_auto_dtype
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_8gpus[latency]

--- a/tests/integration/test_lists/qa/examples_test_list.txt
+++ b/tests/integration/test_lists/qa/examples_test_list.txt
@@ -451,7 +451,7 @@ accuracy/test_cli_flow.py::TestLlama3_3NemotronSuper49Bv1::test_auto_dtype_tp2
 accuracy/test_cli_flow.py::TestLlama3_3NemotronSuper49Bv1::test_fp8_prequantized_tp2
 accuracy/test_llm_api_pytorch.py::TestNemotronNano::test_auto_dtype
 accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_auto_dtype[tp8ep4-cuda_graph=True]
-accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_fp8_tp8[tp8ep4-cuda_graph=True]
+accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_fp8_prequantized[tp8ep4-cuda_graph=True]
 accuracy/test_llm_api_pytorch.py::TestNemotronH::test_auto_dtype
 accuracy/test_llm_api_pytorch.py::TestQwen2_7BInstruct::test_auto_dtype
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_8gpus[latency]

--- a/tests/integration/test_lists/qa/examples_test_list.txt
+++ b/tests/integration/test_lists/qa/examples_test_list.txt
@@ -438,9 +438,6 @@ accuracy/test_llm_api_pytorch.py::TestLlama4MaverickInstruct::test_auto_dtype[tp
 accuracy/test_llm_api_pytorch.py::TestLlama4ScoutInstruct::test_auto_dtype[tp8-cuda_graph=False]
 accuracy/test_llm_api_pytorch.py::TestLlama4ScoutInstruct::test_auto_dtype[tp8ep4-cuda_graph=True]
 accuracy/test_llm_api_pytorch.py::TestLlama4ScoutInstruct::test_auto_dtype[tp8ep8-cuda_graph=True]
-accuracy/test_llm_api_pytorch.py::TestLlama4ScoutInstruct::test_fp8[tp8-]
-accuracy/test_llm_api_pytorch.py::TestLlama4ScoutInstruct::test_fp8[tp8ep4-cuda_graph]
-accuracy/test_llm_api_pytorch.py::TestLlama4ScoutInstruct::test_fp8[tp8ep8-cuda_graph]
 accuracy/test_llm_api_pytorch.py::TestMixtral8x7B::test_fp8_tp2
 accuracy/test_llm_api_pytorch.py::TestMixtral8x7B::test_nvfp4_tp2
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16[mtp_nextn=0-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=False]

--- a/tests/integration/test_lists/qa/llm_sanity_test.txt
+++ b/tests/integration/test_lists/qa/llm_sanity_test.txt
@@ -140,7 +140,7 @@ accuracy/test_llm_api_pytorch.py::TestLlama3_3NemotronSuper49Bv1::test_auto_dtyp
 accuracy/test_cli_flow.py::TestLlama3_3NemotronSuper49Bv1::test_auto_dtype_tp2
 accuracy/test_llm_api_pytorch.py::TestNemotronNano::test_auto_dtype
 accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_auto_dtype[tp8-cuda_graph=False]
-accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_fp8_tp8[tp8-cuda_graph=False]
+accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_fp8_prequantized[tp8-cuda_graph=False]
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16[mtp_nextn=0-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=False]
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_fp8_block_scales[mtp_nextn=0-fp8kv=False-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=False]
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_nvfp4[fp8kv=False-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=False]

--- a/tests/integration/test_lists/qa/llm_sanity_test.txt
+++ b/tests/integration/test_lists/qa/llm_sanity_test.txt
@@ -133,12 +133,15 @@ accuracy/test_cli_flow.py::TestLlama3_3_70BInstruct::test_nvfp4_prequantized_tp4
 accuracy/test_llm_api_pytorch.py::TestMistral7B::test_auto_dtype
 accuracy/test_llm_api_pytorch.py::TestLlama4MaverickInstruct::test_auto_dtype[tp8-cuda_graph=False]
 accuracy/test_llm_api_pytorch.py::TestLlama4ScoutInstruct::test_auto_dtype[tp8-cuda_graph=False]
+accuracy/test_llm_api_pytorch.py::TestLlama4ScoutInstruct::test_fp8[tp8-]
 accuracy/test_llm_api_pytorch.py::TestMixtral8x7B::test_fp8_tp2
 accuracy/test_llm_api_pytorch.py::TestMixtral8x7B::test_nvfp4_tp2
 accuracy/test_llm_api_pytorch.py::TestNemotronNas::test_auto_dtype_tp8
 accuracy/test_llm_api_pytorch.py::TestLlama3_3NemotronSuper49Bv1::test_auto_dtype_tp2
 accuracy/test_cli_flow.py::TestLlama3_3NemotronSuper49Bv1::test_auto_dtype_tp2
 accuracy/test_llm_api_pytorch.py::TestNemotronNano::test_auto_dtype
+accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_auto_dtype
+accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_fp8_tp8
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16[mtp_nextn=0-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=False]
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_fp8_block_scales[mtp_nextn=0-fp8kv=False-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=False]
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_nvfp4[fp8kv=False-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=False]

--- a/tests/integration/test_lists/qa/llm_sanity_test.txt
+++ b/tests/integration/test_lists/qa/llm_sanity_test.txt
@@ -139,8 +139,8 @@ accuracy/test_llm_api_pytorch.py::TestNemotronNas::test_auto_dtype_tp8
 accuracy/test_llm_api_pytorch.py::TestLlama3_3NemotronSuper49Bv1::test_auto_dtype_tp2
 accuracy/test_cli_flow.py::TestLlama3_3NemotronSuper49Bv1::test_auto_dtype_tp2
 accuracy/test_llm_api_pytorch.py::TestNemotronNano::test_auto_dtype
-accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_auto_dtype
-accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_fp8_tp8
+accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_auto_dtype[tp8-cuda_graph=False]
+accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_fp8_tp8[tp8-cuda_graph=False]
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16[mtp_nextn=0-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=False]
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_fp8_block_scales[mtp_nextn=0-fp8kv=False-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=False]
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_nvfp4[fp8kv=False-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=False]

--- a/tests/integration/test_lists/qa/llm_sanity_test.txt
+++ b/tests/integration/test_lists/qa/llm_sanity_test.txt
@@ -133,7 +133,6 @@ accuracy/test_cli_flow.py::TestLlama3_3_70BInstruct::test_nvfp4_prequantized_tp4
 accuracy/test_llm_api_pytorch.py::TestMistral7B::test_auto_dtype
 accuracy/test_llm_api_pytorch.py::TestLlama4MaverickInstruct::test_auto_dtype[tp8-cuda_graph=False]
 accuracy/test_llm_api_pytorch.py::TestLlama4ScoutInstruct::test_auto_dtype[tp8-cuda_graph=False]
-accuracy/test_llm_api_pytorch.py::TestLlama4ScoutInstruct::test_fp8[tp8-]
 accuracy/test_llm_api_pytorch.py::TestMixtral8x7B::test_fp8_tp2
 accuracy/test_llm_api_pytorch.py::TestMixtral8x7B::test_nvfp4_tp2
 accuracy/test_llm_api_pytorch.py::TestNemotronNas::test_auto_dtype_tp8
@@ -145,6 +144,7 @@ accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_fp8_tp8
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16[mtp_nextn=0-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=False]
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_fp8_block_scales[mtp_nextn=0-fp8kv=False-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=False]
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_nvfp4[fp8kv=False-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=False]
+accuracy/test_llm_api_pytorch.py::TestPhi4MiniInstruct::test_auto_dtype
 
 # Pivot to Pytorch test cases.
 test_e2e.py::test_ptp_quickstart_advanced[Llama3.1-8B-BF16-llama-3.1-model/Meta-Llama-3.1-8B]

--- a/tests/integration/test_lists/qa/llm_sanity_test.txt
+++ b/tests/integration/test_lists/qa/llm_sanity_test.txt
@@ -113,6 +113,9 @@ accuracy/test_cli_flow.py::TestLlama3_1_8B::test_fp8_rowwise_tp4[disable_gemm_al
 accuracy/test_cli_flow.py::TestLlama3_1_8B::test_autoq
 accuracy/test_cli_flow.py::TestLlama3_1_8BInstruct::test_medusa_fp8_prequantized
 accuracy/test_cli_flow.py::TestLlama3_2_1B::test_auto_dtype
+accuracy/test_llm_api_pytorch.py::TestLlama3_2_1B::test_auto_dtype
+accuracy/test_cli_flow.py::TestLlama3_3_70BInstruct::test_fp8_prequantized_tp4
+accuracy/test_cli_flow.py::TestLlama3_3_70BInstruct::test_nvfp4_prequantized_tp4
 accuracy/test_cli_flow.py::TestMistral7B::test_fp8_tp4pp2
 accuracy/test_cli_flow.py::TestMistral7B::test_beam_search
 accuracy/test_cli_flow.py::TestMixtral8x7B::test_fp8_tp2pp2
@@ -139,8 +142,11 @@ accuracy/test_llm_api_pytorch.py::TestNemotronNas::test_auto_dtype_tp8
 accuracy/test_llm_api_pytorch.py::TestLlama3_3NemotronSuper49Bv1::test_auto_dtype_tp2
 accuracy/test_cli_flow.py::TestLlama3_3NemotronSuper49Bv1::test_auto_dtype_tp2
 accuracy/test_llm_api_pytorch.py::TestNemotronNano::test_auto_dtype
+accuracy/test_cli_flow.py::TestNemotronNano::test_auto_dtype
 accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_auto_dtype[tp8-cuda_graph=False]
 accuracy/test_llm_api_pytorch.py::TestNemotronUltra::test_fp8_prequantized[tp8-cuda_graph=False]
+accuracy/test_cli_flow.py::TestNemotronUltra::test_auto_dtype[tp8-cuda_graph=False]
+accuracy/test_cli_flow.py::TestNemotronUltra::test_fp8_prequantized[tp8-cuda_graph=False]
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16[mtp_nextn=0-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=False]
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_fp8_block_scales[mtp_nextn=0-fp8kv=False-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=False]
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_nvfp4[fp8kv=False-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=False]


### PR DESCRIPTION
New tests added:
- Llama-3.2-1B: ~~added mmlu benchmark~~ - removed due to low accuracy
- Llama-3.1-Nemotron-Nano-8B-v1: added GSM8K, GPQADiamond benchmarks
- Llama-3_1-Nemotron-Ultra-253B-v1: added the entire model (FP8 variant is being added to `ftp/llm-models`)
- Phi-4-mini-instruct: added the model to the tests; skipped the test as the model likely has to be added to Torch models first (given the current error)