### PR TITLE
test(perf): Add `Phi-4-mini-instruct` to perf tests

### DIFF
--- a/tests/integration/defs/perf/test_perf.py
+++ b/tests/integration/defs/perf/test_perf.py
@@ -83,6 +83,7 @@ MODEL_PATH_DICT = {
     "gpt_350m_moe": "gpt2-medium",
     "phi_3_mini_4k_instruct": "Phi-3/Phi-3-mini-4k-instruct",
     "phi_3_mini_128k_instruct": "Phi-3/Phi-3-mini-128k-instruct",
+    "phi_4_mini_instruct": "Phi-4-mini-instruct",
 }
 # Model PATH of HuggingFace
 HF_MODEL_PATH = {
@@ -102,6 +103,7 @@ HF_MODEL_PATH = {
     "mixtral_8x7b_v0.1_instruct_hf": "mistralai/Mixtral-8x7B-Instruct-v0.1",
     "mistral_7b_v0.1_hf": "mistralai/Mistral-7B-v0.1",
     "flan_t5_base_hf": "google/flan-t5-small",
+    "phi_4_mini_instruct_hf": "microsoft/Phi-4-mini-instruct",
 }
 LORA_MODEL_PATH = {
     "llama_v2_13b": "llama-models-v2/chinese-llama-2-lora-13b",

--- a/tests/integration/test_lists/qa/trt_llm_release_perf_test.yml
+++ b/tests/integration/test_lists/qa/trt_llm_release_perf_test.yml
@@ -51,6 +51,27 @@ trt_llm_release_perf_test:
   - perf/test_perf.py::test_perf[mamba_370m-bench-float16-input_output_len:512,32]
   - perf/test_perf.py::test_perf[mamba_2.8b-bench-float16-input_output_len:128,128]
   - perf/test_perf.py::test_perf[mamba_2.8b-bench-float16-input_output_len:512,32]
+
+  # Phi-4-mini-instruct
+  # cpp
+  - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-bfloat16-maxbs:32-input_output_len:5000,500-con:1]
+  - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-bfloat16-maxbs:32-input_output_len:5000,500-quant:fp8-con:1]
+  - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-bfloat16-maxbs:32-input_output_len:500,2000-con:1]
+  - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-bfloat16-maxbs:32-input_output_len:500,2000-quant:fp8-con:1]
+  - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-bfloat16-maxbs:32-input_output_len:5000,500-con:250]
+  - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-bfloat16-maxbs:32-input_output_len:5000,500-quant:fp8-con:250]
+  - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-bfloat16-maxbs:32-input_output_len:500,2000-con:250]
+  - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-bfloat16-maxbs:32-input_output_len:500,2000-quant:fp8-con:250]
+  # pyt
+  - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-pytorch-bfloat16-maxbs:32-input_output_len:5000,500-con:1]
+  - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-pytorch-bfloat16-maxbs:32-input_output_len:5000,500-quant:fp8-con:1]
+  - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-pytorch-bfloat16-maxbs:32-input_output_len:500,2000-con:1]
+  - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-pytorch-bfloat16-maxbs:32-input_output_len:500,2000-quant:fp8-con:1]
+  - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-pytorch-bfloat16-maxbs:32-input_output_len:5000,500-con:250]
+  - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-pytorch-bfloat16-maxbs:32-input_output_len:5000,500-quant:fp8-con:250]
+  - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-pytorch-bfloat16-maxbs:32-input_output_len:500,2000-con:250]
+  - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-pytorch-bfloat16-maxbs:32-input_output_len:500,2000-quant:fp8-con:250]
+
   # Test list validation
   - test_list_validation.py::test_list_validation
 

--- a/tests/integration/test_lists/qa/trt_llm_release_perf_test.yml
+++ b/tests/integration/test_lists/qa/trt_llm_release_perf_test.yml
@@ -56,22 +56,10 @@ trt_llm_release_perf_test:
   # cpp
   - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-bfloat16-maxbs:32-input_output_len:5000,500-con:1]
   - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-bfloat16-maxbs:32-input_output_len:5000,500-quant:fp8-con:1]
-  - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-bfloat16-maxbs:32-input_output_len:500,2000-con:1]
-  - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-bfloat16-maxbs:32-input_output_len:500,2000-quant:fp8-con:1]
   - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-bfloat16-maxbs:32-input_output_len:5000,500-con:250]
   - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-bfloat16-maxbs:32-input_output_len:5000,500-quant:fp8-con:250]
   - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-bfloat16-maxbs:32-input_output_len:500,2000-con:250]
   - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-bfloat16-maxbs:32-input_output_len:500,2000-quant:fp8-con:250]
-  # pyt
-  - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-pytorch-bfloat16-maxbs:32-input_output_len:5000,500-con:1]
-  - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-pytorch-bfloat16-maxbs:32-input_output_len:5000,500-quant:fp8-con:1]
-  - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-pytorch-bfloat16-maxbs:32-input_output_len:500,2000-con:1]
-  - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-pytorch-bfloat16-maxbs:32-input_output_len:500,2000-quant:fp8-con:1]
-  - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-pytorch-bfloat16-maxbs:32-input_output_len:5000,500-con:250]
-  - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-pytorch-bfloat16-maxbs:32-input_output_len:5000,500-quant:fp8-con:250]
-  - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-pytorch-bfloat16-maxbs:32-input_output_len:500,2000-con:250]
-  - perf/test_perf.py::test_perf[phi_4_mini_instruct-bench-pytorch-bfloat16-maxbs:32-input_output_len:500,2000-quant:fp8-con:250]
-
   # Test list validation
   - test_list_validation.py::test_list_validation
 


### PR DESCRIPTION
# Description

Add `Phi-4-mini-instruct` to perf tests.

### Performance Summary

| isl | osl | quant | concurrency | backend | req/s | tps&nbsp;/gpu | avg&nbsp;latency&nbsp;ms | p50&nbsp;latency&nbsp;ms |
|----:|----:|:-----:|----:|:-------:|------:|--------------:|-------------------------:|-------------------------:|
| 5000 | 500  | - |   1 | cpp | 0.3338 |  166.9008 |   2 995.6970 |   2 995.7907 |
| 5000 | 500  | fp8  |   1 | cpp | 0.4988 |  249.3751 |   2 004.9128 |   2 004.9328 |
| 5000 | 500  | - | 250 | cpp | 3.8081 | 1 904.0392 |  51 868.0716 |  61 115.2586 |
| 5000 | 500  | fp8  | 250 | cpp | 6.3719 | 3 185.9421 |  30 968.7020 |  36 553.6290 |
|  500 | 2000 | - | 250 | cpp | 2.0002 | 4 000.3732 |  98 226.6684 | 112 118.7785 |
|  500 | 2000 | fp8  | 250 | cpp | 3.2052 | 6 410.3298 |  61 311.7553 |  69 968.9179 |

### Run Invariants

- **Model**: `phi_4_mini_instruct`
- **Precision**: BF16 baseline, FP8 quantized on-the-fly based on setting
- **Batch size**: 32
- **GPUs**: 1 H100
- **Dataset**: synthetic, 512 sequences per run
- **Benchmark tool**: `trtllm-bench`

---

### Execution Status Matrix

| backend | isl | osl | quant | concurrency | status |
|:-------:|----:|----:|:-----:|----:|:------:|
| cpp | 5000 |  500 |- |   1 | PASS |
| cpp | 5000 |  500 | fp8  |   1 | PASS |
| cpp | 5000 |  500 | - | 250 | PASS |
| cpp | 5000 |  500 | fp8  | 250 | PASS |
| cpp |  500 | 2000 | - |   1 | TIMEOUT (>3600s) |
| cpp |  500 | 2000 | fp8  |   1 | TIMEOUT (>3600s) |
| cpp |  500 | 2000 | - | 250 | PASS |
| cpp |  500 | 2000 | fp8  | 250 | PASS |
| pyt | 5000 |  500 | - |   1 | NOT&nbsp;IMPLEMENTED |
| pyt | 5000 |  500 | fp8  |   1 | NOT&nbsp;IMPLEMENTED |
| pyt | 5000 |  500 | - | 250 | NOT&nbsp;IMPLEMENTED |
| pyt | 5000 |  500 | fp8  | 250 | NOT&nbsp;IMPLEMENTED |
| pyt |  500 | 2000 | - |   1 | NOT&nbsp;IMPLEMENTED |
| pyt |  500 | 2000 | fp8  |   1 | NOT&nbsp;IMPLEMENTED |
| pyt |  500 | 2000 | - | 250 | NOT&nbsp;IMPLEMENTED |
| pyt |  500 | 2000 | fp8  | 250 | NOT&nbsp;IMPLEMENTED |
