### PR TITLE
feat: [AutoDeploy] DSV3 mla attn ref op

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_attention.py
@@ -63,9 +63,7 @@ def scaled_dot_product_attention_fake(
     query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None
 ):
     """Fake implementation of scaled_dot_product_attention."""
-    b, n, s, _ = query.shape
-    v_head_dim = value.shape[-1]
-    return torch.empty(b, n, s, v_head_dim, dtype=query.dtype, device=query.device).contiguous()
+    return torch.empty_like(query.contiguous())
 
 
 @torch.library.custom_op("attention::grouped_sdpa", mutates_args=())
@@ -103,9 +101,7 @@ def grouped_sdpa_fake(
     scale=None,
 ):
     """Fake implementation of grouped SDPA."""
-    b, n, s, _ = query.shape
-    v_head_dim = value.shape[-1]
-    return torch.empty(b, n, s, v_head_dim, dtype=query.dtype, device=query.device).contiguous()
+    return torch.empty_like(query.contiguous())
 
 
 @torch.library.custom_op("attention::bsnd_grouped_sdpa", mutates_args=())
@@ -139,9 +135,7 @@ def bsnd_grouped_sdpa_fake(
     query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None
 ):
     """Fake implementation of bnsd grouped SDPA."""
-    b, s, n, _ = query.shape
-    v_head_dim = value.shape[-1]
-    return torch.empty(b, s, n, v_head_dim, dtype=query.dtype, device=query.device).contiguous()
+    return torch.empty_like(query.contiguous())
 
 
 # Function to apply rotary positional embeddings (RoPE)

--- a/tensorrt_llm/_torch/auto_deploy/models/deepseek.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/deepseek.py
@@ -1,13 +1,11 @@
 import types
 import warnings
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional
 
 import torch
 import torch.utils.checkpoint
 from transformers import AutoModelForCausalLM
 from transformers.cache_utils import Cache
-
-from ..custom_ops.torch_attention import apply_rotary_pos_emb
 
 
 def deepseek_v3_attention(
@@ -129,89 +127,6 @@ def deepseek_v3_moe_exact(self, hidden_states):
 
 
 @torch.inference_mode()
-def deepseek_v3_attention_new_patchd(
-    self,
-    hidden_states: torch.Tensor,
-    attention_mask: Optional[torch.Tensor] = None,
-    position_ids: Optional[torch.LongTensor] = None,
-    past_key_value: Optional[Cache] = None,
-    output_attentions: bool = False,
-    use_cache: bool = False,
-    **kwargs,
-) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
-    if "padding_mask" in kwargs:
-        warnings.warn(
-            "Passing `padding_mask` is deprecated and will be removed in v4.37. "
-            "Please make sure use `attention_mask` instead.`"
-        )
-    bsz, q_len, _ = hidden_states.size()
-
-    if self.q_lora_rank is None:
-        q = self.q_proj(hidden_states)
-    else:
-        q = self.q_b_proj(self.q_a_layernorm(self.q_a_proj(hidden_states)))
-    q = q.view(bsz, q_len, self.num_heads, self.q_head_dim).transpose(1, 2)
-    q_nope, q_pe = torch.split(q, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
-
-    compressed_kv = self.kv_a_proj_with_mqa(hidden_states)
-    compressed_kv, k_pe = torch.split(
-        compressed_kv, [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
-    )
-    k_pe = k_pe.view(bsz, q_len, 1, self.qk_rope_head_dim).transpose(1, 2)
-
-    # This node will be deleted during pattern matching
-    kv = (
-        self.kv_b_proj(self.kv_a_layernorm(compressed_kv))
-        .view(bsz, q_len, self.num_heads, self.qk_nope_head_dim + self.v_head_dim)
-        .transpose(1, 2)
-    )
-
-    kv_new = self.kv_a_layernorm(compressed_kv)
-
-    # TODO:Why do we need value states here?
-    _, value_states = torch.split(kv, [self.qk_nope_head_dim, self.v_head_dim], dim=-1)
-    kv_seq_len = value_states.shape[-2]
-    if past_key_value is not None:
-        if self.layer_idx is None:
-            raise ValueError(
-                f"The cache structure has changed since version v4.36. If you are using {self.__class__.__name__} "
-                "for auto-regressive decoding with k/v caching, please make sure to initialize the attention class "
-                "with a layer index."
-            )
-        kv_seq_len += past_key_value.get_usable_length(kv_seq_len, self.layer_idx)
-    cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
-
-    q_pe, k_pe = apply_rotary_pos_emb(q_pe, k_pe, cos, sin, position_ids)
-
-    # TODO:Insert down projection node for q_nope
-
-    # Use custom op to capture mla. This does not handle KV cache
-    # as passing transformers Cache into a custom op is throwing an error.
-    # Would not be an issue, cause we intend to replace mla op with our implementation further along the pipeline
-    attn_output = torch.ops.deepseek.mla(
-        q_nope,
-        q_pe,
-        kv_new,
-        k_pe,
-        attention_mask,
-        self.softmax_scale,
-    )
-
-    # TODO:Insert up projection node for attn_output
-
-    attn_output = attn_output.transpose(1, 2).contiguous()
-
-    attn_output = attn_output.reshape(bsz, q_len, self.num_heads * self.v_head_dim)
-
-    attn_output = self.o_proj(attn_output)
-
-    if not output_attentions:
-        attn_weights = None
-
-    return attn_output, attn_weights, past_key_value
-
-
-@torch.inference_mode()
 def deepseek_v3_moe(self, hidden_states):
     """DeepSeekV3MoE forward function rewritten in Mixtral style to enable torch export."""
     identity = hidden_states
@@ -242,8 +157,8 @@ _from_config_original = AutoModelForCausalLM.from_config
 CUSTOM_MODULE_PATCHES: Dict[str, callable] = {
     "DeepseekV3MoE": deepseek_v3_moe,
     "DeepseekV2MoE": deepseek_v3_moe,
-    # "DeepseekV3Attention": deepseek_v3_attention_new_patchd,
-    # "DeepseekV2Attention": deepseek_v3_attention_new_patchd,
+    "DeepseekV3Attention": deepseek_v3_attention,
+    "DeepseekV2Attention": deepseek_v3_attention,
 }
 
 

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_patches.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_patches.py
@@ -14,7 +14,7 @@ from tensorrt_llm._torch.auto_deploy.models.deepseek import (
 )
 
 
-def _load_layer_from_model(model_name_or_path, layer_name, num_layers_to_load=1, yarn=False):
+def _load_layer_from_model(model_name_or_path, layer_name):
     """
     Loads a specific layer/module from a model without loading the entire model.
 
@@ -30,16 +30,24 @@ def _load_layer_from_model(model_name_or_path, layer_name, num_layers_to_load=1,
         config = AutoConfig.from_pretrained(model_name_or_path, trust_remote_code=True)
 
         # Load a subset of layers of the model and configure yarn
-        config.num_hidden_layers = num_layers_to_load
+        config.num_hidden_layers = 1
         config.use_cache = False
         config.first_k_dense_replace = 0
-        config.n_routed_experts = 3
-        config.num_experts_per_tok = 2
+        config.n_routed_experts = 2
+        config.num_experts_per_tok = 1
         config.n_group = 1
         config.topk_group = 1
-        config.hidden_size = 128
-        if not yarn:
-            config.rope_scaling = None
+        config.hidden_size = 8
+        config.moe_intermediate_size = 8
+        config.num_attention_heads = 2
+        config.num_key_value_heads = 2
+        config.qk_nope_head_dim = 4
+        config.qk_rope_head_dim = 2
+        config.v_head_dim = 4
+        config.intermediate_size = 8
+        config.max_position_embeddings = 7
+
+        config.rope_scaling = None
 
         # Build the model architecture (no weights loaded yet)
         model = AutoModelForCausalLM.from_config(config, trust_remote_code=True)
@@ -67,7 +75,7 @@ def _generate_ds_attention_mask(b, s):
 
 
 @pytest.mark.parametrize(
-    "model_name, module_name, patch, yarn, inputs",
+    "model_name, module_name, patch, inputs",
     [
         pytest.param(
             _hf_model_dir_or_hub_id(
@@ -76,9 +84,8 @@ def _generate_ds_attention_mask(b, s):
             ),
             "model.layers.0.self_attn",
             deepseek_v3_attention,
-            False,
             [
-                torch.randn(2, 6, 128, dtype=torch.bfloat16),
+                torch.randn(2, 6, 8, dtype=torch.bfloat16),
                 _generate_ds_attention_mask(2, 6),
                 torch.tensor([[0, 1, 2, 3, 4, 5]]),
             ],
@@ -90,14 +97,13 @@ def _generate_ds_attention_mask(b, s):
             ),
             "model.layers.0.mlp",
             deepseek_v3_moe_exact,
-            False,
-            [torch.randn(2, 6, 128, dtype=torch.bfloat16)],
+            [torch.randn(2, 6, 8, dtype=torch.bfloat16)],
         ),  # moe requires  inputs [hidden_states]
     ],
 )
-def test_module_patches(model_name, module_name, patch, yarn, inputs):
+def test_module_patches(model_name, module_name, patch, inputs):
     # Get module
-    module = _load_layer_from_model(model_name, module_name, 1, yarn)
+    module = _load_layer_from_model(model_name, module_name)
 
     # Pass test inputs to generate reference
     ref, *_ = module(*inputs)

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_patches.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_patches.py
@@ -4,7 +4,9 @@ import types
 
 import pytest
 import torch
-from transformers import AutoConfig, AutoModel
+from _model_test_utils import _hf_model_dir_or_hub_id
+from transformers import AutoConfig, AutoModelForCausalLM
+from utils.llm_data import llm_models_root
 
 from tensorrt_llm._torch.auto_deploy.models.deepseek import (
     deepseek_v3_attention,
@@ -31,11 +33,16 @@ def _load_layer_from_model(model_name_or_path, layer_name, num_layers_to_load=1,
         config.num_hidden_layers = num_layers_to_load
         config.use_cache = False
         config.first_k_dense_replace = 0
+        config.n_routed_experts = 3
+        config.num_experts_per_tok = 2
+        config.n_group = 1
+        config.topk_group = 1
+        config.hidden_size = 128
         if not yarn:
             config.rope_scaling = None
 
         # Build the model architecture (no weights loaded yet)
-        model = AutoModel.from_config(config, trust_remote_code=True)
+        model = AutoModelForCausalLM.from_config(config, trust_remote_code=True)
         model.eval()
 
         # Access the specific layer by its name
@@ -59,28 +66,32 @@ def _generate_ds_attention_mask(b, s):
     )
 
 
-# TODO (svelury): update unit test to run fast
-@pytest.mark.skip(reason="TODO: too slow for a unit test")
 @pytest.mark.parametrize(
     "model_name, module_name, patch, yarn, inputs",
     [
         pytest.param(
-            "deepseek-ai/DeepSeek-V3",
-            "layers.0.self_attn",
+            _hf_model_dir_or_hub_id(
+                f"{llm_models_root()}/DeepSeek-R1/DeepSeek-R1",
+                "deepseek-ai/DeepSeek-R1",
+            ),
+            "model.layers.0.self_attn",
             deepseek_v3_attention,
             False,
             [
-                torch.randn(2, 6, 7168, dtype=torch.bfloat16),
+                torch.randn(2, 6, 128, dtype=torch.bfloat16),
                 _generate_ds_attention_mask(2, 6),
                 torch.tensor([[0, 1, 2, 3, 4, 5]]),
             ],
         ),  # attention requires  inputs [hidden_states, attention_mask, position_ids]
         pytest.param(
-            "deepseek-ai/DeepSeek-V3",
-            "layers.0.mlp",
+            _hf_model_dir_or_hub_id(
+                f"{llm_models_root()}/DeepSeek-R1/DeepSeek-R1",
+                "deepseek-ai/DeepSeek-R1",
+            ),
+            "model.layers.0.mlp",
             deepseek_v3_moe_exact,
             False,
-            [torch.randn(2, 6, 7168, dtype=torch.bfloat16)],
+            [torch.randn(2, 6, 128, dtype=torch.bfloat16)],
         ),  # moe requires  inputs [hidden_states]
     ],
 )

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_sdpa_mla.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_sdpa_mla.py
@@ -1,0 +1,95 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+import tensorrt_llm._torch.auto_deploy  # noqa: F401
+
+
+def naive_attn(q_nope, q_pe, compressed_kv, k_pe, wkv_b, softmax_scale):
+    bsz = q_nope.shape[0]
+    q_len = q_nope.shape[2]
+    num_heads = q_nope.shape[1]
+    qk_nope_head_dim = q_nope.shape[-1]
+    v_head_dim = wkv_b.weight.shape[-1] - qk_nope_head_dim
+    qk_head_dim = qk_nope_head_dim + q_pe.shape[-1]
+    k_pe = k_pe.view(bsz, q_len, 1, q_pe.shape[-1]).transpose(1, 2)
+
+    # Up project compressed_kv
+    kv = (
+        wkv_b(compressed_kv)
+        .view(bsz, q_len, num_heads, qk_nope_head_dim + v_head_dim)
+        .transpose(1, 2)
+    )
+
+    k_nope, value_states = torch.split(kv, [qk_nope_head_dim, v_head_dim], dim=-1)
+
+    query_states = k_pe.new_empty(bsz, num_heads, q_len, qk_head_dim)
+    query_states[:, :, :, :qk_nope_head_dim] = q_nope
+    query_states[:, :, :, qk_nope_head_dim:] = q_pe
+
+    key_states = k_pe.new_empty(bsz, num_heads, q_len, qk_head_dim)
+    key_states[:, :, :, :qk_nope_head_dim] = k_nope
+    key_states[:, :, :, qk_nope_head_dim:] = k_pe
+
+    x = F.scaled_dot_product_attention(
+        query_states,
+        key_states,
+        value_states,
+        attn_mask=None,
+        is_causal=False,
+        dropout_p=0.0,
+        scale=softmax_scale,
+    ).transpose(1, 2)
+
+    return x
+
+
+def mla_attn(q_nope, q_pe, compressed_kv, k_pe, wkv_b, softmax_scale):
+    num_heads = q_nope.shape[1]
+    qk_nope_head_dim = q_nope.shape[-1]
+    v_head_dim = wkv_b.weight.shape[-1] - qk_nope_head_dim
+    kv_lora_rank = compressed_kv.shape[-1]
+
+    # Down project q_nope
+    wkv_b_weight = wkv_b.weight.view(num_heads, -1, kv_lora_rank)
+    q_nope_proj = torch.einsum("bhsd,hdc->bhsc", q_nope, wkv_b_weight[:, :qk_nope_head_dim])
+
+    # MLA ref operation
+    x = torch.ops.deepseek.mla(q_nope_proj, q_pe, compressed_kv, k_pe, None, softmax_scale)
+
+    # Up project attention scores
+    x = torch.einsum("bshc,hdc->bshd", x, wkv_b_weight[:, -v_head_dim:])
+    return x
+
+
+def test_attn():
+    # Define test configurations
+    kv_lora_rank = 4
+    bsz = 2
+    q_len = 6
+    v_head_dim = 2
+    qk_nope_head_dim = 2
+    qk_rope_head_dim = 1
+    qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
+    num_heads = 4
+    softmax_scale = qk_head_dim**-0.5
+
+    # Generate inputs
+    q_nope = torch.randn(bsz, num_heads, q_len, qk_nope_head_dim)
+    q_pe = torch.randn(bsz, num_heads, q_len, qk_rope_head_dim)
+    compressed_kv = torch.randn(bsz, q_len, kv_lora_rank)
+    k_pe = torch.randn(bsz, q_len, qk_rope_head_dim)
+
+    # Define w_kv_b projection matrix
+    wkv_b = nn.Linear(
+        kv_lora_rank, num_heads * (qk_head_dim - qk_rope_head_dim + v_head_dim), bias=False
+    )
+
+    # Compute naive attention
+    out_naive = naive_attn(q_nope, q_pe, compressed_kv, k_pe, wkv_b, softmax_scale)
+
+    # Compute MLA attention
+    out_mla = mla_attn(q_nope, q_pe, compressed_kv, k_pe, wkv_b, softmax_scale)
+
+    # Check if the two outputs are close
+    assert torch.allclose(out_naive, out_mla, rtol=1e-5, atol=1e-5)


### PR DESCRIPTION
This PR introduces MLA attn reference op that computes attention using compressed kv.
- [x] Add mla attn with compressed kv reference op. 
- [x] Add unit test to test equivalence between mla attn ref op and sdpa-style attn
- [x] Update module patches unit test to be faster