### PR TITLE
feat: [AutoDeploy] DeepseekV3 e2e support with sdpa attention

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_attention.py
@@ -63,7 +63,9 @@ def scaled_dot_product_attention_fake(
     query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None
 ):
     """Fake implementation of scaled_dot_product_attention."""
-    return torch.empty_like(query.contiguous())
+    b, n, s, _ = query.shape
+    v_head_dim = value.shape[-1]
+    return torch.empty(b, n, s, v_head_dim, dtype=query.dtype, device=query.device).contiguous()
 
 
 @torch.library.custom_op("attention::grouped_sdpa", mutates_args=())
@@ -101,7 +103,9 @@ def grouped_sdpa_fake(
     scale=None,
 ):
     """Fake implementation of grouped SDPA."""
-    return torch.empty_like(query.contiguous())
+    b, n, s, _ = query.shape
+    v_head_dim = value.shape[-1]
+    return torch.empty(b, n, s, v_head_dim, dtype=query.dtype, device=query.device).contiguous()
 
 
 @torch.library.custom_op("attention::bsnd_grouped_sdpa", mutates_args=())
@@ -135,7 +139,9 @@ def bsnd_grouped_sdpa_fake(
     query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None
 ):
     """Fake implementation of bnsd grouped SDPA."""
-    return torch.empty_like(query.contiguous())
+    b, n, s, _ = query.shape
+    v_head_dim = value.shape[-1]
+    return torch.empty(b, n, s, v_head_dim, dtype=query.dtype, device=query.device).contiguous()
 
 
 def update_kv_cache(

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_attention.py
@@ -63,9 +63,7 @@ def scaled_dot_product_attention_fake(
     query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None
 ):
     """Fake implementation of scaled_dot_product_attention."""
-    b, n, s, _ = query.shape
-    v_head_dim = value.shape[-1]
-    return torch.empty(b, n, s, v_head_dim, dtype=query.dtype, device=query.device).contiguous()
+    return query.new_empty(*query.shape[:3], value.shape[-1]).contiguous()
 
 
 @torch.library.custom_op("attention::grouped_sdpa", mutates_args=())
@@ -103,9 +101,7 @@ def grouped_sdpa_fake(
     scale=None,
 ):
     """Fake implementation of grouped SDPA."""
-    b, n, s, _ = query.shape
-    v_head_dim = value.shape[-1]
-    return torch.empty(b, n, s, v_head_dim, dtype=query.dtype, device=query.device).contiguous()
+    return query.new_empty(*query.shape[:3], value.shape[-1]).contiguous()
 
 
 @torch.library.custom_op("attention::bsnd_grouped_sdpa", mutates_args=())
@@ -139,9 +135,7 @@ def bsnd_grouped_sdpa_fake(
     query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None
 ):
     """Fake implementation of bnsd grouped SDPA."""
-    b, n, s, _ = query.shape
-    v_head_dim = value.shape[-1]
-    return torch.empty(b, n, s, v_head_dim, dtype=query.dtype, device=query.device).contiguous()
+    return query.new_empty(*query.shape[:3], value.shape[-1]).contiguous()
 
 
 def update_kv_cache(

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_attention.py
@@ -63,7 +63,7 @@ def scaled_dot_product_attention_fake(
     query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None
 ):
     """Fake implementation of scaled_dot_product_attention."""
-    return query.new_empty(*query.shape[:3], value.shape[-1]).contiguous()
+    return query.new_empty(*query.shape[:-1], value.shape[-1]).contiguous()
 
 
 @torch.library.custom_op("attention::grouped_sdpa", mutates_args=())
@@ -101,7 +101,7 @@ def grouped_sdpa_fake(
     scale=None,
 ):
     """Fake implementation of grouped SDPA."""
-    return query.new_empty(*query.shape[:3], value.shape[-1]).contiguous()
+    return query.new_empty(*query.shape[:-1], value.shape[-1]).contiguous()
 
 
 @torch.library.custom_op("attention::bsnd_grouped_sdpa", mutates_args=())
@@ -135,7 +135,7 @@ def bsnd_grouped_sdpa_fake(
     query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None
 ):
     """Fake implementation of bnsd grouped SDPA."""
-    return query.new_empty(*query.shape[:3], value.shape[-1]).contiguous()
+    return query.new_empty(*query.shape[:-1], value.shape[-1]).contiguous()
 
 
 def update_kv_cache(

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_attention.py
@@ -233,7 +233,7 @@ def flattened_mha_with_cache(
         )
 
     return y.view(
-        *bs_view, num_heads, v_head_dim
+        b, s, num_heads, v_head_dim
     )  # [bsnd] in the original view (might have some dims flattened)
 
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_attention.py
@@ -197,6 +197,7 @@ def flattened_mha_with_cache(
     #    and number of tokens per sequence are encoded in seq_len and seq_start.
     num_kv_heads, head_dim = k_cache.shape[-2:]
     v_head_dim = v_cache.shape[-1]
+    q_ndim = q.ndim
     b, s = q.shape[:2]
 
     # check for num_heads
@@ -232,8 +233,8 @@ def flattened_mha_with_cache(
             y,
         )
 
-    return y.view(
-        b, s, num_heads, v_head_dim
+    return (
+        y.view(b, s, num_heads * v_head_dim) if q_ndim == 3 else y.view(b, s, num_heads, v_head_dim)
     )  # [bsnd] in the original view (might have some dims flattened)
 
 

--- a/tensorrt_llm/_torch/auto_deploy/models/deepseek.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/deepseek.py
@@ -147,10 +147,12 @@ def deepseek_v3_moe(self, hidden_states):
 
 
 def deepseek_v3_rope(self, x, seq_len=None):
-    """DeepSeekV3 Rotary Embedding forward function rewritten to enable torch export.
+    """
+    DeepSeekV3 Rotary Embedding forward function rewritten to enable torch export.
+
     We return the full cached cos and sin values, instead of slicing them based on seq_len as this
     would cause an issue during the generate phase (when seq_len=1 from input_ids). We also move the cos
-    sin buffers to appropriate device to enable export.
+    and sin buffers to the appropriate device to enable export.
     """
 
     return (

--- a/tensorrt_llm/_torch/auto_deploy/models/deepseek.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/deepseek.py
@@ -146,13 +146,26 @@ def deepseek_v3_moe(self, hidden_states):
     return final_hidden_states.to(hidden_states.dtype)
 
 
+def deepseek_v3_rope(self, x, seq_len=None):
+    """DeepSeekV3 Rotary Embedding forward function rewritten to enable torch export.
+    We return the full cached cos and sin values, instead of slicing them based on seq_len as this
+    would cause an issue during the generate phase (when seq_len=1 from input_ids). We also move the cos
+    sin buffers to appropriate device to enable export.
+    """
+
+    return (
+        self.cos_cached.to(dtype=x.dtype).to(device=x.device),
+        self.sin_cached.to(dtype=x.dtype).to(device=x.device),
+    )
+
+
 _from_config_original = AutoModelForCausalLM.from_config
 
 CUSTOM_MODULE_PATCHES: Dict[str, callable] = {
     "DeepseekV3MoE": deepseek_v3_moe,
     "DeepseekV2MoE": deepseek_v3_moe,
-    "DeepseekV3Attention": deepseek_v3_attention,
-    "DeepseekV2Attention": deepseek_v3_attention,
+    "DeepseekV3RotaryEmbedding": deepseek_v3_rope,
+    "DeepseekV3YarnRotaryEmbedding": deepseek_v3_rope,
 }
 
 

--- a/tensorrt_llm/_torch/auto_deploy/transformations/_graph.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/_graph.py
@@ -17,6 +17,7 @@ from torch.fx.passes.tools_common import legalize_graph
 from torch.utils._pytree import _LEAF_SPEC
 
 from ..utils.logger import ad_logger
+from ..utils.node_utils import is_op
 
 
 def get_buffers_and_params(model: nn.Module) -> Dict[str, torch.Tensor]:
@@ -106,6 +107,12 @@ def move_to_device(gm: fx.GraphModule, device: DeviceLikeType) -> fx.GraphModule
             kwargs = node.kwargs.copy()
             kwargs["device"] = device
             node.kwargs = kwargs
+
+        if is_op(node, torch.ops.aten.to.device):
+            args = list(node.args)
+            args[1] = device
+            node.args = tuple(args)
+
         # move all the tensor metadata
         node.meta["val"] = pytree.tree_map(
             lambda v: v.to(device) if isinstance(v, torch.Tensor) else v,

--- a/tensorrt_llm/_torch/auto_deploy/transformations/_graph.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/_graph.py
@@ -17,7 +17,6 @@ from torch.fx.passes.tools_common import legalize_graph
 from torch.utils._pytree import _LEAF_SPEC
 
 from ..utils.logger import ad_logger
-from ..utils.node_utils import is_op
 
 
 def get_buffers_and_params(model: nn.Module) -> Dict[str, torch.Tensor]:
@@ -107,11 +106,6 @@ def move_to_device(gm: fx.GraphModule, device: DeviceLikeType) -> fx.GraphModule
             kwargs = node.kwargs.copy()
             kwargs["device"] = device
             node.kwargs = kwargs
-
-        if is_op(node, torch.ops.aten.to.device):
-            args = list(node.args)
-            args[1] = device
-            node.args = tuple(args)
 
         # move all the tensor metadata
         node.meta["val"] = pytree.tree_map(

--- a/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
@@ -229,6 +229,4 @@ class InferenceOptimizer:
 
         torch.cuda.empty_cache()
         gc.collect()
-        print("DEBUG LOG: egm_compiled")
-        print(egm_compiled.graph.print_tabular())
         return egm_compiled

--- a/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
@@ -229,4 +229,6 @@ class InferenceOptimizer:
 
         torch.cuda.empty_cache()
         gc.collect()
+        print("DEBUG LOG: egm_compiled")
+        print(egm_compiled.graph.print_tabular())
         return egm_compiled

--- a/tests/unittest/_torch/auto_deploy/integration/test_ad_build.py
+++ b/tests/unittest/_torch/auto_deploy/integration/test_ad_build.py
@@ -120,6 +120,20 @@ from utils.llm_data import llm_models_root
                 "compile_backend": "torch-simple",
             },
         ),
+        # Deepseek-V3 with torch-simple backend + simple runtime + reduced number of layer + skip loading weights
+        # TODO: remove skip loading weights once we fix fp8 weight loading
+        param_with_device_count(
+            4,
+            {
+                "model": _hf_model_dir_or_hub_id(
+                    f"{llm_models_root()}/DeepSeek-V3",
+                    "deepseek-ai/DeepSeek-V3",
+                ),
+                "compile_backend": "torch-simple",
+                "model_kwargs": {"num_hidden_layers": 6},
+                "skip_loading_weights": "True",
+            },
+        ),
     ],
 )
 def test_build_ad(world_size: Optional[int], config: Dict):

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/test_ad_build_small_multi.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/test_ad_build_small_multi.py
@@ -56,7 +56,7 @@ from utils.llm_data import llm_models_root
         ),
         # small deepseek-v3 model with world_size 2
         (
-            2,
+            4,
             {
                 "model": _hf_model_dir_or_hub_id(
                     f"{llm_models_root()}/DeepSeek-V3",
@@ -65,7 +65,8 @@ from utils.llm_data import llm_models_root
                 "runtime": "demollm",
                 "attn_backend": "TritonWithFlattenedInputs",
                 "compile_backend": "torch-simple",
-                "model_kwargs": {"num_hidden_layers": 4},
+                "model_kwargs": {"num_hidden_layers": 5},
+                "skip_loading_weights": "True",  # TODO: remove this once we fix fp8 weight loading
             },
         ),
     ],

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/test_ad_build_small_multi.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/test_ad_build_small_multi.py
@@ -12,48 +12,48 @@ from utils.llm_data import llm_models_root
 @pytest.mark.parametrize(
     "world_size, config",
     [
-        # # small llama3.1-8B model with world_size 2
-        # (
-        #     2,
-        #     {
-        #         "model": _hf_model_dir_or_hub_id(
-        #             f"{llm_models_root()}/llama-3.1-model/Llama-3.1-8B-Instruct",
-        #             "meta-llama/Meta-Llama-3.1-8B-Instruct",
-        #         ),
-        #         "runtime": "demollm",
-        #         "attn_backend": "TritonWithFlattenedInputs",
-        #         "compile_backend": "torch-simple",
-        #         "model_kwargs": {"num_hidden_layers": 2},
-        #     },
-        # ),
-        # # small llama3.1-8B model with world_size 2 + trtllm runtime + torch-opt
-        # (
-        #     2,
-        #     {
-        #         "model": _hf_model_dir_or_hub_id(
-        #             f"{llm_models_root()}/llama-3.1-model/Llama-3.1-8B-Instruct",
-        #             "meta-llama/Meta-Llama-3.1-8B-Instruct",
-        #         ),
-        #         "runtime": "trtllm",
-        #         "attn_backend": "TritonWithFlattenedInputs",
-        #         "compile_backend": "torch-opt",
-        #         "model_kwargs": {"num_hidden_layers": 2},
-        #     },
-        # ),
-        # # small Mixtral-8x7B model with world_size 2
-        # (
-        #     2,
-        #     {
-        #         "model": _hf_model_dir_or_hub_id(
-        #             f"{llm_models_root()}/Mixtral-8x7B-Instruct-v0.1",
-        #             "mistralai/Mixtral-8x7B-Instruct-v0.1",
-        #         ),
-        #         "runtime": "demollm",
-        #         "attn_backend": "TritonWithFlattenedInputs",
-        #         "compile_backend": "torch-simple",
-        #         "model_kwargs": {"num_hidden_layers": 2},
-        #     },
-        # ),
+        # small llama3.1-8B model with world_size 2
+        (
+            2,
+            {
+                "model": _hf_model_dir_or_hub_id(
+                    f"{llm_models_root()}/llama-3.1-model/Llama-3.1-8B-Instruct",
+                    "meta-llama/Meta-Llama-3.1-8B-Instruct",
+                ),
+                "runtime": "demollm",
+                "attn_backend": "TritonWithFlattenedInputs",
+                "compile_backend": "torch-simple",
+                "model_kwargs": {"num_hidden_layers": 2},
+            },
+        ),
+        # small llama3.1-8B model with world_size 2 + trtllm runtime + torch-opt
+        (
+            2,
+            {
+                "model": _hf_model_dir_or_hub_id(
+                    f"{llm_models_root()}/llama-3.1-model/Llama-3.1-8B-Instruct",
+                    "meta-llama/Meta-Llama-3.1-8B-Instruct",
+                ),
+                "runtime": "trtllm",
+                "attn_backend": "TritonWithFlattenedInputs",
+                "compile_backend": "torch-opt",
+                "model_kwargs": {"num_hidden_layers": 2},
+            },
+        ),
+        # small Mixtral-8x7B model with world_size 2
+        (
+            2,
+            {
+                "model": _hf_model_dir_or_hub_id(
+                    f"{llm_models_root()}/Mixtral-8x7B-Instruct-v0.1",
+                    "mistralai/Mixtral-8x7B-Instruct-v0.1",
+                ),
+                "runtime": "demollm",
+                "attn_backend": "TritonWithFlattenedInputs",
+                "compile_backend": "torch-simple",
+                "model_kwargs": {"num_hidden_layers": 2},
+            },
+        ),
         # small deepseek-v3 model with world_size 4
         (
             2,

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/test_ad_build_small_multi.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/test_ad_build_small_multi.py
@@ -12,51 +12,51 @@ from utils.llm_data import llm_models_root
 @pytest.mark.parametrize(
     "world_size, config",
     [
-        # small llama3.1-8B model with world_size 2
-        (
-            2,
-            {
-                "model": _hf_model_dir_or_hub_id(
-                    f"{llm_models_root()}/llama-3.1-model/Llama-3.1-8B-Instruct",
-                    "meta-llama/Meta-Llama-3.1-8B-Instruct",
-                ),
-                "runtime": "demollm",
-                "attn_backend": "TritonWithFlattenedInputs",
-                "compile_backend": "torch-simple",
-                "model_kwargs": {"num_hidden_layers": 2},
-            },
-        ),
-        # small llama3.1-8B model with world_size 2 + trtllm runtime + torch-opt
-        (
-            2,
-            {
-                "model": _hf_model_dir_or_hub_id(
-                    f"{llm_models_root()}/llama-3.1-model/Llama-3.1-8B-Instruct",
-                    "meta-llama/Meta-Llama-3.1-8B-Instruct",
-                ),
-                "runtime": "trtllm",
-                "attn_backend": "TritonWithFlattenedInputs",
-                "compile_backend": "torch-opt",
-                "model_kwargs": {"num_hidden_layers": 2},
-            },
-        ),
-        # small Mixtral-8x7B model with world_size 2
-        (
-            2,
-            {
-                "model": _hf_model_dir_or_hub_id(
-                    f"{llm_models_root()}/Mixtral-8x7B-Instruct-v0.1",
-                    "mistralai/Mixtral-8x7B-Instruct-v0.1",
-                ),
-                "runtime": "demollm",
-                "attn_backend": "TritonWithFlattenedInputs",
-                "compile_backend": "torch-simple",
-                "model_kwargs": {"num_hidden_layers": 2},
-            },
-        ),
+        # # small llama3.1-8B model with world_size 2
+        # (
+        #     2,
+        #     {
+        #         "model": _hf_model_dir_or_hub_id(
+        #             f"{llm_models_root()}/llama-3.1-model/Llama-3.1-8B-Instruct",
+        #             "meta-llama/Meta-Llama-3.1-8B-Instruct",
+        #         ),
+        #         "runtime": "demollm",
+        #         "attn_backend": "TritonWithFlattenedInputs",
+        #         "compile_backend": "torch-simple",
+        #         "model_kwargs": {"num_hidden_layers": 2},
+        #     },
+        # ),
+        # # small llama3.1-8B model with world_size 2 + trtllm runtime + torch-opt
+        # (
+        #     2,
+        #     {
+        #         "model": _hf_model_dir_or_hub_id(
+        #             f"{llm_models_root()}/llama-3.1-model/Llama-3.1-8B-Instruct",
+        #             "meta-llama/Meta-Llama-3.1-8B-Instruct",
+        #         ),
+        #         "runtime": "trtllm",
+        #         "attn_backend": "TritonWithFlattenedInputs",
+        #         "compile_backend": "torch-opt",
+        #         "model_kwargs": {"num_hidden_layers": 2},
+        #     },
+        # ),
+        # # small Mixtral-8x7B model with world_size 2
+        # (
+        #     2,
+        #     {
+        #         "model": _hf_model_dir_or_hub_id(
+        #             f"{llm_models_root()}/Mixtral-8x7B-Instruct-v0.1",
+        #             "mistralai/Mixtral-8x7B-Instruct-v0.1",
+        #         ),
+        #         "runtime": "demollm",
+        #         "attn_backend": "TritonWithFlattenedInputs",
+        #         "compile_backend": "torch-simple",
+        #         "model_kwargs": {"num_hidden_layers": 2},
+        #     },
+        # ),
         # small deepseek-v3 model with world_size 4
         (
-            4,
+            2,
             {
                 "model": _hf_model_dir_or_hub_id(
                     f"{llm_models_root()}/DeepSeek-V3",
@@ -65,7 +65,16 @@ from utils.llm_data import llm_models_root
                 "runtime": "demollm",
                 "attn_backend": "TritonWithFlattenedInputs",
                 "compile_backend": "torch-simple",
-                "model_kwargs": {"num_hidden_layers": 5},
+                "model_kwargs": {
+                    "num_hidden_layers": 6,
+                    "hidden_size": 32,
+                    "max_position_embeddings": 2048,
+                    "intermediate_size": 16,
+                    "moe_intermediate_size": 16,
+                    "n_routed_experts": 16,
+                    "num_attention_heads": 8,
+                    "num_key_value_heads": 4,
+                },
                 "skip_loading_weights": "True",  # TODO: remove this once we fix fp8 weight loading
             },
         ),

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/test_ad_build_small_multi.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/test_ad_build_small_multi.py
@@ -54,7 +54,7 @@ from utils.llm_data import llm_models_root
                 "model_kwargs": {"num_hidden_layers": 2},
             },
         ),
-        # small deepseek-v3 model with world_size 2
+        # small deepseek-v3 model with world_size 4
         (
             4,
             {

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/test_ad_build_small_multi.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/test_ad_build_small_multi.py
@@ -75,7 +75,7 @@ from utils.llm_data import llm_models_root
                     "num_attention_heads": 8,
                     "num_key_value_heads": 4,
                 },
-                "skip_loading_weights": "True",  # TODO: remove this once we fix fp8 weight loading
+                "skip_loading_weights": "True",
             },
         ),
     ],

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/test_ad_build_small_multi.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/test_ad_build_small_multi.py
@@ -54,6 +54,20 @@ from utils.llm_data import llm_models_root
                 "model_kwargs": {"num_hidden_layers": 2},
             },
         ),
+        # small deepseek-v3 model with world_size 2
+         (
+            2,
+            {
+                "model": _hf_model_dir_or_hub_id(
+                    f"{llm_models_root()}/DeepSeek-V3",
+                    "deepseek-ai/DeepSeek-V3",
+                ),
+                "runtime": "demollm",
+                "attn_backend": "TritonWithFlattenedInputs",
+                "compile_backend": "torch-simple",
+                "model_kwargs": {"num_hidden_layers": 4},
+            },
+        ),
     ],
 )
 def test_build_ad(world_size: Optional[int], config: Dict):

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/test_ad_build_small_multi.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/test_ad_build_small_multi.py
@@ -55,7 +55,7 @@ from utils.llm_data import llm_models_root
             },
         ),
         # small deepseek-v3 model with world_size 2
-         (
+        (
             2,
             {
                 "model": _hf_model_dir_or_hub_id(

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
@@ -68,30 +68,6 @@ from utils.llm_data import llm_models_root
                 "model_kwargs": {"num_hidden_layers": 2},
             },
         ),
-        # small deepseekv3model with world_size 0 (no processes are spawned) + torch-opt
-        (
-            0,
-            {
-                "model": _hf_model_dir_or_hub_id(
-                    f"{llm_models_root()}/DeepSeek-V3",
-                    "deepseek-ai/DeepSeek-V3",
-                ),
-                "runtime": "demollm",
-                "attn_backend": "TritonWithFlattenedInputs",
-                "compile_backend": "torch-simple",
-                "model_kwargs": {
-                    "num_hidden_layers": 5,
-                    "hidden_size": 32,
-                    "max_position_embeddings": 2048,
-                    "intermediate_size": 16,
-                    "moe_intermediate_size": 16,
-                    "n_routed_experts": 16,
-                    "num_attention_heads": 8,
-                    "num_key_value_heads": 4,
-                },
-                "skip_loading_weights": "True",  # TODO: remove this once we fix fp8 weight loading
-            },
-        ),
         # small deepseekv3 model with world_size 1 (processes are spawned)
         (
             1,
@@ -113,7 +89,7 @@ from utils.llm_data import llm_models_root
                     "num_attention_heads": 8,
                     "num_key_value_heads": 4,
                 },
-                "skip_loading_weights": "True",  # TODO: remove this once we fix fp8 weight loading
+                "skip_loading_weights": "True",
             },
         ),
     ],

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
@@ -68,6 +68,20 @@ from utils.llm_data import llm_models_root
                 "model_kwargs": {"num_hidden_layers": 2},
             },
         ),
+        # small deepseek-v3 model with world_size 1
+        (
+            1,
+            {
+                "model": _hf_model_dir_or_hub_id(
+                    f"{llm_models_root()}/DeepSeek-V3",
+                    "deepseek-ai/DeepSeek-V3",
+                ),
+                "runtime": "demollm",
+                "attn_backend": "TritonWithFlattenedInputs",
+                "compile_backend": "torch-simple",
+                "model_kwargs": {"num_hidden_layers": 4},
+            },
+        ),
     ],
 )
 def test_build_ad(world_size: Optional[int], config: Dict):

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
@@ -68,20 +68,6 @@ from utils.llm_data import llm_models_root
                 "model_kwargs": {"num_hidden_layers": 2},
             },
         ),
-        # small deepseek-v3 model with world_size 1
-        (
-            1,
-            {
-                "model": _hf_model_dir_or_hub_id(
-                    f"{llm_models_root()}/DeepSeek-V3",
-                    "deepseek-ai/DeepSeek-V3",
-                ),
-                "runtime": "demollm",
-                "attn_backend": "TritonWithFlattenedInputs",
-                "compile_backend": "torch-simple",
-                "model_kwargs": {"num_hidden_layers": 4},
-            },
-        ),
     ],
 )
 def test_build_ad(world_size: Optional[int], config: Dict):

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
@@ -68,6 +68,54 @@ from utils.llm_data import llm_models_root
                 "model_kwargs": {"num_hidden_layers": 2},
             },
         ),
+        # small deepseekv3model with world_size 0 (no processes are spawned) + torch-opt
+        (
+            0,
+            {
+                "model": _hf_model_dir_or_hub_id(
+                    f"{llm_models_root()}/DeepSeek-V3",
+                    "deepseek-ai/DeepSeek-V3",
+                ),
+                "runtime": "demollm",
+                "attn_backend": "TritonWithFlattenedInputs",
+                "compile_backend": "torch-simple",
+                "model_kwargs": {
+                    "num_hidden_layers": 5,
+                    "hidden_size": 32,
+                    "max_position_embeddings": 2048,
+                    "intermediate_size": 16,
+                    "moe_intermediate_size": 16,
+                    "n_routed_experts": 16,
+                    "num_attention_heads": 8,
+                    "num_key_value_heads": 4,
+                },
+                "skip_loading_weights": "True",  # TODO: remove this once we fix fp8 weight loading
+            },
+        ),
+        # small deepseekv3 model with world_size 1 (processes are spawned)
+        (
+            1,
+            {
+                "model": _hf_model_dir_or_hub_id(
+                    f"{llm_models_root()}/DeepSeek-V3",
+                    "deepseek-ai/DeepSeek-V3",
+                ),
+                "runtime": "demollm",
+                "attn_backend": "TritonWithFlattenedInputs",
+                "compile_backend": "torch-simple",
+                "model_kwargs": {
+                    "num_hidden_layers": 6,
+                    "hidden_size": 32,
+                    "max_position_embeddings": 2048,
+                    "intermediate_size": 16,
+                    "moe_intermediate_size": 16,
+                    "n_routed_experts": 16,
+                    "num_attention_heads": 8,
+                    "num_key_value_heads": 4,
+                },
+                "skip_loading_weights": "True",  # TODO: remove this once we fix fp8 weight loading
+            },
+        ),
     ],
 )
 def test_build_ad(world_size: Optional[int], config: Dict):


### PR DESCRIPTION
Support deepseekv3 e2e example without attention forward patch

- [x] Modify "TritonWithFlattenedInputs" backend to support sdpa-style attention with different head dims for v_head_dim and qk_head_dim
- [x] Add unit tests for deepseek e2e example with triton kernels (single and multigpu case) with skip_loading_weights set to True
- TODO: DeepseekV3 weights are in FP8. Need to handle this case to run e2e example with weights
- TODO: Use scale passed instead of default scale for attention op