### PR TITLE
feat: change eagle one model flag from an env var to a config in Eagle3Config

### DIFF
--- a/tensorrt_llm/_torch/speculative/eagle3.py
+++ b/tensorrt_llm/_torch/speculative/eagle3.py
@@ -21,14 +21,13 @@ class Eagle3Config(SpecConfig):
     spec_dec_name: str = "EAGLE3"
     num_layers: int = 0
     hidden_size: int = 0
+    eagle3_one_model: bool = True
 
     def __post_init__(self):
         if self.draft_model_path is None:
             raise ValueError("Path to EAGLE3 weights must be specified.")
 
-        # TODO: remove this once we have a better way to handle the one model case
-        eagle3_one_model = os.environ.get("TRTLLM_EAGLE3_ONE_MODEL", "1") == "1"
-        if eagle3_one_model:
+        if self.eagle3_one_model:
             self.spec_dec_mode = SpeculativeDecodingMode.EAGLE3_ONE_MODEL
             self.num_extra_kv_tokens = self.max_draft_tokens - 1
         else:

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -221,6 +221,7 @@ class EagleDecodingConfig(DecodingBaseConfig):
     num_eagle_layers: Optional[int] = None
     max_non_leaves_per_layer: Optional[int] = None
     pytorch_eagle_weights_path: Optional[str] = None
+    eagle3_one_model: Optional[bool] = True
 
     @classmethod
     def from_dict(cls, data: dict):
@@ -1157,7 +1158,9 @@ class LlmArgs(BaseModel):
                     self.speculative_config = Eagle3Config(
                         max_draft_tokens=self.speculative_config.max_draft_len,
                         draft_model_path=self.speculative_config.
-                        pytorch_eagle_weights_path)
+                        pytorch_eagle_weights_path,
+                        eagle3_one_model=self.speculative_config.
+                        eagle3_one_model)
 
             elif isinstance(self.speculative_config, MTPDecodingConfig):
                 from tensorrt_llm._torch.speculative import MTPConfig


### PR DESCRIPTION
## Description

We used `TRTLLM_EAGLE3_ONE_MODEL` to control whether to use one-model or two-model eagle3 implementation. As suggested by @hlu1, we change it to a config in Eagle3Config in this PR.