### PR TITLE
[TRTLLM-5273]feat/Use full attention mask if Llama3 is used as encoder and fix EarlyStopDecoder unsqueeze bug

### DIFF
--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -67,7 +67,7 @@ class ModelConfig(Generic[TConfig]):
             return True
         return model_architectures[0] not in [
             "BertForSequenceClassification", "Qwen2ForProcessRewardModel",
-            "Qwen2ForRewardModel"
+            "Qwen2ForRewardModel", "LlamaForTextEmbedding"
         ]
         # TODO: should be 'not model_type == ModelType.ENCODER_ONLY'
         # once ModelType is used in pytorch flow.

--- a/tensorrt_llm/_torch/models/modeling_llama.py
+++ b/tensorrt_llm/_torch/models/modeling_llama.py
@@ -201,6 +201,8 @@ class LlamaAttention(Attention):
             dtype=config.torch_dtype,
             config=model_config,
         )
+
+
 class Llama4MoE(nn.Module):
 
     def __init__(
@@ -506,7 +508,7 @@ class LlamaDecoderLayer(DecoderLayer):
         self.post_attention_layernorm = RMSNorm(hidden_size=config.hidden_size,
                                                 eps=config.rms_norm_eps,
                                                 dtype=config.torch_dtype)
-        
+
         self.attention_mask = PredefinedAttentionMask.CAUSAL
         if bidirectional:
             self.attention_mask = PredefinedAttentionMask.FULL
@@ -721,7 +723,9 @@ class Llama4Model(DecoderModel):
 
 class LlamaModel(DecoderModel):
 
-    def __init__(self, model_config: ModelConfig[LlamaConfig], bidirectional=False):
+    def __init__(self,
+                 model_config: ModelConfig[LlamaConfig],
+                 bidirectional=False):
         super().__init__(model_config)
         config = self.model_config.pretrained_config
         self.padding_idx = config.pad_token_id
@@ -761,11 +765,10 @@ class LlamaModel(DecoderModel):
                 self.embed_tokens.weight.data.copy_(x)
 
         self.layers = nn.ModuleList([
-            LlamaDecoderLayer(
-                model_config,
-                layer_idx,
-                bidirectional=bidirectional
-            ) for layer_idx in range(config.num_hidden_layers)
+            LlamaDecoderLayer(model_config,
+                              layer_idx,
+                              bidirectional=bidirectional)
+            for layer_idx in range(config.num_hidden_layers)
         ])
         self.norm = RMSNorm(hidden_size=config.hidden_size,
                             eps=config.rms_norm_eps,

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -83,7 +83,7 @@ class EarlyStopSampler(Sampler):
             logits = state.logits[idx]
             if logits.ndim == 1:
                 # For BERT: Add vocab_size axis to be compatible with LogitsStorage.
-                logits = logits.unsqueeze(-1)
+                logits = logits.unsqueeze(0)
             request.py_result.append_context_logits(logits)
 
 

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -82,7 +82,9 @@ class EarlyStopSampler(Sampler):
             request.set_finished_reason(FinishReason.LENGTH, 0)
             logits = state.logits[idx]
             if logits.ndim == 1:
-                # For BERT: Add vocab_size axis to be compatible with LogitsStorage.
+                # For BERT: Add axis to be compatible with LogitsStorage
+                # (LogitsStorage will interpret this dim as the prompt_len which
+                # is not relevant for outputting logits of encoder only model).
                 logits = logits.unsqueeze(0)
             request.py_result.append_context_logits(logits)
 

--- a/tests/integration/defs/test_e2e.py
+++ b/tests/integration/defs/test_e2e.py
@@ -1785,8 +1785,7 @@ def test_ptp_quickstart_bert(llm_root, llm_venv, model_name, model_path,
     tllm_logits = []
     for output in outputs:
         prompt = output.prompt
-        tllm_logit = output.context_logits.cpu(
-        )[:, 0]  # drop vocab_size dimension.
+        tllm_logit = output.context_logits.cpu()[0, :]
         print(f"Prompt: {prompt!r}, Context logits: {tllm_logit}")
         tllm_logits += [tllm_logit]
     # Stack the output


### PR DESCRIPTION
# [TRTLLM-5273]feat/Use full attention mask if Llama3 is used as encoder and fix EarlyStopDecoder unsqueeze bug

## Description

This PR adds in a flag for bidirectional_attention to `modeling_llama.py`. This is to support some customer use-cases for llama-based embedding models, see Jira TRTLLM-5273 for more details.

Additionally it fixes a bug in EarlyStopDecoder where 1d logits were being unsqueezed incorrectly, leading to incompatibility with LogitsStorage. 

Lastly it hardcodes `LlamaForTextEmbedding` as a non-generation model for now so that the customer can make their own out-of-tree example with their custom model and still leverage EarlyStopDecoder. I am in discussions with Erin Ho and Freddy Qi about how we can eliminate the need to hardcode this in the future. 

**Things To Review**

1. Should this bidirectional attention be supported via flag like the current implementation or should it be a separate class?


## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
