### PR TITLE
feat: Add Python implementation of GenerateRequestOptions

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/generateRequestOptions.h
+++ b/cpp/include/tensorrt_llm/batch_manager/generateRequestOptions.h
@@ -53,10 +53,24 @@ public:
     {
     }
 
+    /**
+     * @brief Generate decoding requests for the given context requests.
+     *        The logic of this function is replicated in `generate_request_options.py`.
+     *
+     * @param modelConfig The model configuration.
+     * @param worldConfig The world configuration.
+     * @param decodingConfig The decoding configuration.
+     * @param contextRequests The context requests.
+     * @param bufferManager The buffer manager.
+     * @param logitsType The logits type.
+     * @param inputBuffers The input buffers.
+     * @param buffers The runtime buffers.
+     * @return A tuple containing the logits, requests, and sampling configurations.
+     */
     std::tuple<ITensor::SharedPtr, std::vector<tr::decoder_batch::Request>, std::vector<tr::SamplingConfig>> operator()(
         tr::ModelConfig const& modelConfig, tr::WorldConfig const& worldConfig,
         executor::DecodingConfig const& decodingConfig, RequestVector const& contextRequests,
-        BufferManager const& bufferManager, nvinfer1::DataType logitsType, DecoderInputBuffers const& inputBuffers,
+        BufferManager const& bufferManager, nvinfer1::DataType logitsType, DecoderInputBuffers& inputBuffers,
         OptionalRef<RuntimeBuffers const> buffers = std::nullopt) const;
 
 private:

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -1761,7 +1761,7 @@ void TrtGptModelInflightBatching::executeStep(
 }
 
 void TrtGptModelInflightBatching::setupDecoderStep(
-    RequestVector const& contextRequests, RuntimeBuffers const& buffers, DecoderInputBuffers const& inputBuffers)
+    RequestVector const& contextRequests, RuntimeBuffers const& buffers, DecoderInputBuffers& inputBuffers)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
     NVTX3_SCOPED_RANGE(setupDecoderStep);

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
@@ -297,7 +297,7 @@ private:
         RequestVector const& contextRequests, RequestVector const& generationRequests, SizeType32 bufferId);
 
     void setupDecoderStep(
-        RequestVector const& contextRequests, RuntimeBuffers const& buffers, DecoderInputBuffers const& inputBuffers);
+        RequestVector const& contextRequests, RuntimeBuffers const& buffers, DecoderInputBuffers& inputBuffers);
     runtime::CudaEvent decoderStepAsync(ScheduledRequests const& scheduledRequests);
     std::vector<std::unique_ptr<DecoderStepAsyncSend>> decoderSync(
         ScheduledRequests const& scheduledRequests, std::optional<runtime::CudaEvent> const& decoderFinishEvent);

--- a/cpp/tensorrt_llm/pybind/batch_manager/algorithms.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/algorithms.cpp
@@ -141,7 +141,7 @@ void tensorrt_llm::pybind::batch_manager::algorithms::initBindings(pybind11::mod
             [](GenerateRequestOptions& self, tr::ModelConfig const& modelConfig, tr::WorldConfig const& worldConfig,
                 executor::DecodingConfig const& decodingConfig, RequestVector const& contextRequests,
                 tr::BufferManager const& bufferManager, nvinfer1::DataType logitsType,
-                DecoderInputBuffers const& inputBuffers, OptionalRef<RuntimeBuffers const> buffers = std::nullopt)
+                DecoderInputBuffers& inputBuffers, OptionalRef<RuntimeBuffers const> buffers = std::nullopt)
             {
                 auto [batchSlots, decoderRequests, samplingConfigs] = self(modelConfig, worldConfig, decodingConfig,
                     contextRequests, bufferManager, logitsType, inputBuffers, buffers);

--- a/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
@@ -109,114 +109,15 @@ void initBindings(pybind11::module_& m)
         .def("set_generated_tokens", &GenLlmReq::setGeneratedTokens, py::arg("generated_beam_tokens"))
         .def("pause", &GenLlmReq::pause, py::arg("max_input_len"))
         .def_property("max_sent_token_len", &GenLlmReq::getMaxSentTokenLen, &GenLlmReq::setMaxSentTokenLen)
-        .def("prompt_embedding_table",
-            [](GenLlmReq& self)
-            {
-                std::optional<at::Tensor> value{std::nullopt};
-                auto tensor = self.getPromptEmbeddingTable();
-                if (tensor)
-                {
-                    value = tr::Torch::tensor(*tensor);
-                }
-                return value;
-            })
-        .def("multimodal_embedding",
-            [](GenLlmReq& self)
-            {
-                std::optional<at::Tensor> value{std::nullopt};
-                auto tensor = self.getMultimodalEmbedding();
-                if (tensor)
-                {
-                    value = tr::Torch::tensor(*tensor);
-                }
-                return value;
-            })
-        .def("get_mrope_rotary_cos_sin",
-            [](GenLlmReq& self)
-            {
-                std::optional<at::Tensor> value{std::nullopt};
-                auto tensor = self.getMropeRotaryCosSin();
-                if (tensor)
-                {
-                    value = tr::Torch::tensor(*tensor);
-                }
-                return value;
-            })
-        .def("bad_words_list",
-            [](GenLlmReq& self)
-            {
-                std::optional<at::Tensor> value{std::nullopt};
-                auto tensor = self.getBadWordsList();
-                if (tensor)
-                {
-                    value = tr::Torch::tensor(*tensor);
-                }
-                return value;
-            })
-        .def_property(
-            "draft_logits",
-            [](GenLlmReq& self)
-            {
-                std::optional<at::Tensor> value{std::nullopt};
-                auto tensor = self.getDraftLogits();
-                if (tensor)
-                {
-                    value = tr::Torch::tensor(*tensor);
-                }
-                return value;
-            },
-            [](GenLlmReq& self, at::Tensor& logits)
-            { self.setDraftLogits(std::make_optional<GenLlmReq::TensorPtr>(tr::TorchView::of(logits))); })
-        .def("embedding_bias",
-            [](GenLlmReq& self)
-            {
-                std::optional<at::Tensor> value{std::nullopt};
-                auto tensor = self.getEmbeddingBias();
-                if (tensor)
-                {
-                    value = tr::Torch::tensor(*tensor);
-                }
-                return value;
-            })
-        .def_property(
-            "lora_config",
-            [](GenLlmReq& self)
-            {
-                std::optional<at::Tensor> value{std::nullopt};
-                auto tensor = self.getLoraConfig();
-                if (tensor)
-                {
-                    value = tr::Torch::tensor(*tensor);
-                }
-                return value;
-            },
-            [](GenLlmReq& self, at::Tensor& loraConfig)
-            { self.setLoraConfig(static_cast<GenLlmReq::TensorPtr>(tr::TorchView::of(loraConfig))); })
-        .def_property(
-            "lora_weights",
-            [](GenLlmReq& self)
-            {
-                std::optional<at::Tensor> value{std::nullopt};
-                auto tensor = self.getLoraWeights();
-                if (tensor)
-                {
-                    value = tr::Torch::tensor(*tensor);
-                }
-                return value;
-            },
-            [](GenLlmReq& self, at::Tensor& loraWeights)
-            { self.setLoraWeights(static_cast<GenLlmReq::TensorPtr>(tr::TorchView::of(loraWeights))); })
-        .def("stop_words_list",
-            [](GenLlmReq& self)
-            {
-                std::optional<at::Tensor> value{std::nullopt};
-                auto tensor = self.getStopWordsList();
-                if (tensor)
-                {
-                    value = tr::Torch::tensor(*tensor);
-                }
-                return value;
-            })
+        .def_property_readonly("prompt_embedding_table", &GenLlmReq::getPromptEmbeddingTable)
+        .def_property_readonly("multimodal_embedding", &GenLlmReq::getMultimodalEmbedding)
+        .def_property_readonly("mrope_rotary_cos_sin", &GenLlmReq::getMropeRotaryCosSin)
+        .def_property_readonly("bad_words_list", &GenLlmReq::getBadWordsList)
+        .def_property("draft_logits", &GenLlmReq::getDraftLogits, &GenLlmReq::setDraftLogits)
+        .def_property_readonly("embedding_bias", &GenLlmReq::getEmbeddingBias)
+        .def_property("lora_config", &GenLlmReq::getLoraConfig, &GenLlmReq::setLoraConfig)
+        .def_property("lora_weights", &GenLlmReq::getLoraWeights, &GenLlmReq::setLoraWeights)
+        .def_property_readonly("stop_words_list", &GenLlmReq::getStopWordsList)
         .def_property_readonly("prompt_vocab_size", &GenLlmReq::getPromptVocabSize)
         .def_property_readonly("mrope_position_deltas", &GenLlmReq::getMropePositionDeltas)
         .def_property_readonly("lora_task_id", &GenLlmReq::getLoraTaskId)

--- a/cpp/tensorrt_llm/pybind/runtime/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/runtime/bindings.cpp
@@ -215,23 +215,6 @@ void initBindings(pybind11::module_& m)
         .def(py::init<tr::BufferManager::CudaStreamPtr, bool>(), py::arg("stream"), py::arg("trim_pool") = false)
         .def_property_readonly("stream", &tr::BufferManager::getStream);
 
-    py::class_<tr::SpeculativeDecodingMode>(m, "SpeculativeDecodingMode")
-        .def(py::init<tr::SpeculativeDecodingMode::UnderlyingType>(), py::arg("state"))
-        .def_static("NoneType", &tr::SpeculativeDecodingMode::None)
-        .def_static("DraftTokensExternal", &tr::SpeculativeDecodingMode::DraftTokensExternal)
-        .def_static("Medusa", &tr::SpeculativeDecodingMode::Medusa)
-        .def_static("LookaheadDecoding", &tr::SpeculativeDecodingMode::LookaheadDecoding)
-        .def_static("ExplicitDraftTokens", &tr::SpeculativeDecodingMode::ExplicitDraftTokens)
-        .def_property_readonly("is_none", &tr::SpeculativeDecodingMode::isNone)
-        .def_property_readonly("is_draft_tokens_external", &tr::SpeculativeDecodingMode::isDraftTokensExternal)
-        .def_property_readonly("is_medusa", &tr::SpeculativeDecodingMode::isMedusa)
-        .def_property_readonly("is_lookahead_decoding", &tr::SpeculativeDecodingMode::isLookaheadDecoding)
-        .def_property_readonly("is_explicit_draft_tokens", &tr::SpeculativeDecodingMode::isExplicitDraftTokens)
-        .def_property_readonly("needs_kv_cache_rewind", &tr::SpeculativeDecodingMode::needsKVCacheRewind)
-        .def_property_readonly("needs_decoder_prologue", &tr::SpeculativeDecodingMode::needsDecoderPrologue)
-        .def_property_readonly("predicts_draft_tokens", &tr::SpeculativeDecodingMode::predictsDraftTokens)
-        .def_property_readonly("needs_kv_cache_rewind", &tr::SpeculativeDecodingMode::needsKVCacheRewind);
-
     py::classh<tr::TllmRuntime>(m, "TllmRuntime")
         .def(py::init(
             [](std::filesystem::path engine_path, float gpu_weights_percent = 1.0f, bool use_shape_inference = true)
@@ -281,7 +264,6 @@ void initBindings(pybind11::module_& m)
         .def_readwrite("medusa_paths", &tr::decoder_batch::Request::medusaPaths)
         .def_readwrite("medusa_tree_ids", &tr::decoder_batch::Request::medusaTreeIds)
         .def_readwrite("lookahead_runtime_config", &tr::decoder_batch::Request::lookaheadRuntimeConfig);
-    py::bind_vector<std::vector<tr::decoder_batch::Request>>(m, "VectorRequest");
 
     py::class_<tr::decoder_batch::Input>(m, "DecoderBatchInput")
         .def(py::init<std::vector<std::vector<tr::ITensor::SharedConstPtr>>, tr::SizeType32>(), py::arg("logits"),
@@ -415,4 +397,25 @@ void initBindings(pybind11::module_& m)
         .value("TWOSHOT", tensorrt_llm::kernels::AllReduceStrategyType::TWOSHOT);
 }
 
+void initBindingsEarly(py::module_& m)
+{
+    py::class_<tr::SpeculativeDecodingMode>(m, "SpeculativeDecodingMode")
+        .def(py::init<tr::SpeculativeDecodingMode::UnderlyingType>(), py::arg("state"))
+        .def_static("NoneType", &tr::SpeculativeDecodingMode::None)
+        .def_static("DraftTokensExternal", &tr::SpeculativeDecodingMode::DraftTokensExternal)
+        .def_static("Medusa", &tr::SpeculativeDecodingMode::Medusa)
+        .def_static("Eagle", &tr::SpeculativeDecodingMode::Eagle)
+        .def_static("LookaheadDecoding", &tr::SpeculativeDecodingMode::LookaheadDecoding)
+        .def_static("ExplicitDraftTokens", &tr::SpeculativeDecodingMode::ExplicitDraftTokens)
+        .def_property_readonly("is_none", &tr::SpeculativeDecodingMode::isNone)
+        .def_property_readonly("is_draft_tokens_external", &tr::SpeculativeDecodingMode::isDraftTokensExternal)
+        .def_property_readonly("is_medusa", &tr::SpeculativeDecodingMode::isMedusa)
+        .def_property_readonly("is_eagle", &tr::SpeculativeDecodingMode::isEagle)
+        .def_property_readonly("is_lookahead_decoding", &tr::SpeculativeDecodingMode::isLookaheadDecoding)
+        .def_property_readonly("is_explicit_draft_tokens", &tr::SpeculativeDecodingMode::isExplicitDraftTokens)
+        .def_property_readonly("needs_kv_cache_rewind", &tr::SpeculativeDecodingMode::needsKVCacheRewind)
+        .def_property_readonly("needs_decoder_prologue", &tr::SpeculativeDecodingMode::needsDecoderPrologue)
+        .def_property_readonly("predicts_draft_tokens", &tr::SpeculativeDecodingMode::predictsDraftTokens)
+        .def_property_readonly("needs_kv_cache_rewind", &tr::SpeculativeDecodingMode::needsKVCacheRewind);
+}
 } // namespace tensorrt_llm::pybind::runtime

--- a/cpp/tensorrt_llm/pybind/runtime/bindings.h
+++ b/cpp/tensorrt_llm/pybind/runtime/bindings.h
@@ -26,5 +26,6 @@ namespace tensorrt_llm::pybind::runtime
 {
 
 void initBindings(py::module_& m);
+void initBindingsEarly(py::module_& m);
 
 } // namespace tensorrt_llm::pybind::runtime

--- a/tensorrt_llm/_torch/pyexecutor/decoder.py
+++ b/tensorrt_llm/_torch/pyexecutor/decoder.py
@@ -10,8 +10,8 @@ from tensorrt_llm.bindings import (CudaStream, DataType, ModelConfig,
 from tensorrt_llm.bindings.executor import (DecodingConfig, DecodingMode,
                                             ExecutorConfig, FinishReason)
 from tensorrt_llm.bindings.internal.algorithms import (
-    CreateNewDecoderRequests, GenerateRequestOptions, HandleContextLogits,
-    HandleGenerationLogits, MakeDecodingBatchInputOutput)
+    CreateNewDecoderRequests, HandleContextLogits, HandleGenerationLogits,
+    MakeDecodingBatchInputOutput)
 from tensorrt_llm.bindings.internal.batch_manager import (DecoderBuffers,
                                                           DecoderInputBuffers)
 from tensorrt_llm.bindings.internal.runtime import (BufferManager,
@@ -20,6 +20,7 @@ from tensorrt_llm.bindings.internal.runtime import (BufferManager,
 from tensorrt_llm.executor.result import Logprob
 from tensorrt_llm.mapping import Mapping
 
+from .generate_request_options import GenerateRequestOptions
 from .llm_request import LlmRequest, LlmRequestState
 from .scheduler import ScheduledRequests
 
@@ -459,6 +460,7 @@ class TRTLLMDecoder(Decoder):
 
         self.model_datatype = torch_dtype_to_binding(model_dtype)
         self.logits_datatype = DataType.FLOAT
+        self.py_logits_datatype = torch.float32
         self.decoding_mode = decoding_mode
         self.executor_config = executor_config
         self.decoding_config = self.executor_config.decoding_config if self.executor_config.decoding_config else DecodingConfig(
@@ -545,7 +547,7 @@ class TRTLLMDecoder(Decoder):
     def setup_decoder_step(self, requests):
         batch_slots, decoder_requests, sampling_configs = self.algs.generate_request_options(
             self.model_config, self.world_config, self.decoding_config,
-            requests, self.store["buffer_manager"], self.logits_datatype,
+            requests, self.py_logits_datatype,
             self.store["decoder_input_buffers"])
 
         if len(decoder_requests):

--- a/tensorrt_llm/_torch/pyexecutor/generate_request_options.py
+++ b/tensorrt_llm/_torch/pyexecutor/generate_request_options.py
@@ -1,0 +1,190 @@
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+import torch
+
+from tensorrt_llm.bindings import ModelConfig, WorldConfig, SamplingConfig
+from tensorrt_llm.bindings.executor import DecodingConfig
+from tensorrt_llm.bindings.internal.batch_manager import DecoderInputBuffers, LlmRequest
+from tensorrt_llm.bindings.internal.runtime import Request
+
+
+@dataclass
+class GenerateRequestOptions:
+    """
+    Python implementation of GenerateRequestOptions.
+    Implements the logic in `generateRequestOptions.cpp`.
+    """
+    speculative_decoding_fast_logits: bool
+    is_leader_in_orch_mode: bool
+    is_normalize_log_probs: bool
+
+    def __call__(
+        self,
+        model_config: ModelConfig,
+        world_config: WorldConfig,
+        decoding_config: DecodingConfig,
+        context_requests: List[LlmRequest],
+        logits_type: torch.dtype,
+        input_buffers: DecoderInputBuffers,
+    ) -> Tuple[torch.Tensor, List[Request], List[SamplingConfig]]:
+        """Process context requests and prepare decoder requests.
+
+        Args:
+            model_config: Model configuration
+            world_config: World configuration
+            decoding_config: Decoding configuration
+            context_requests: List of context requests to process
+            logits_type: Data type for logits
+            input_buffers: Input buffers for decoder
+
+        Returns:
+            Tuple containing:
+            - Batch slots view tensor
+            - List of decoder requests
+            - List of sampling configs
+        """
+        batch_size = 0
+        decoder_input_size = 0
+
+        # Calculate batch size and decoder input size
+        for llm_req in context_requests:
+            req_tokens = llm_req.get_tokens(0)
+            if llm_req.is_last_context_chunk():
+                decoder_input_size += len(req_tokens)
+                batch_size += 1
+
+        # Resize input buffer
+        input_buffers.inputs_ids = torch.empty(decoder_input_size, dtype=torch.int32, device='cuda')
+
+        # Create batch slots view
+        batch_slots_view = input_buffers.setup_batch_slots[:batch_size]
+
+        decoder_requests = []
+        sampling_configs = []
+
+        batch_idx = 0
+        input_offset = 0
+
+        # Process each context request
+        for llm_req in context_requests:
+            if not llm_req.is_last_context_chunk():
+                continue
+
+            prompt_len = llm_req.prompt_len
+            req_tokens = torch.tensor(llm_req.get_tokens(0))
+            assert len(req_tokens) == prompt_len
+
+            # Create input view and copy tokens
+            input_view = input_buffers.inputs_ids[input_offset:input_offset + prompt_len]
+            input_view.copy_(req_tokens, non_blocking=True)
+
+            # Create decoder request
+            decoder_request = Request(
+                ids=input_view,
+                input_len=prompt_len,
+                max_new_tokens=llm_req.max_new_tokens,
+                end_id=llm_req.end_id
+            )
+
+            # Set sampling config
+            llm_req.sampling_config.normalize_log_probs = self.is_normalize_log_probs
+
+            # Handle speculative decoding
+            if model_config.speculative_decoding_mode.is_draft_tokens_external:
+                if llm_req.has_draft_tokens():
+                    draft_tokens = llm_req.draft_tokens
+                    decoder_request.draft_tokens = draft_tokens.clone(memory_format=torch.contiguous_format).pin_memory()
+                    
+                    draft_logits = llm_req.draft_logits
+                    if draft_logits is not None:
+                        decoder_request.draft_logits = self._retrieve_draft_logits(
+                            model_config, world_config, draft_logits)
+                    
+                    decoder_request.generated_tokens_per_engine_step = len(draft_tokens) + 1
+                else:
+                    decoder_request.generated_tokens_per_engine_step = 1
+            elif not model_config.speculative_decoding_mode.is_none:
+                decoder_request.generated_tokens_per_engine_step = model_config.get_max_decoding_tokens()
+
+            # Handle Medusa speculative decoding
+            if model_config.speculative_decoding_mode.is_medusa:
+                # NOTE: The logic of Medusa requires a RuntimeBuffers object.
+                raise NotImplementedError("Medusa speculative decoding is not currently supported in TRTLLMDecoder.")
+
+            # Handle lookahead decoding
+            elif model_config.speculative_decoding_mode.is_lookahead_decoding:
+                decoder_request.lookahead_runtime_config = (
+                    llm_req.get_lookahead_config() or decoding_config.get_lookahead_decoding_config()
+                )
+
+            # Handle explicit draft tokens
+            elif model_config.speculative_decoding_mode.is_explicit_draft_tokens:
+                decoder_request.dtype = model_config.get_data_type()
+
+            # Handle Eagle speculative decoding
+            elif model_config.speculative_decoding_mode.is_eagle:
+                decoder_request.eagle_config = (
+                    llm_req.get_eagle_config() or decoding_config.get_eagle_config()
+                )
+
+            # Handle embedding bias
+            if llm_req.embedding_bias is not None:
+                decoder_request.embedding_bias = self._get_embedding_bias(
+                    logits_type, llm_req.embedding_bias)
+
+            # Handle bad words list
+            if llm_req.bad_words_list is not None:
+                decoder_request.bad_words_list = llm_req.bad_words_list.clone().squeeze_(0)
+
+            # Handle stop words list
+            if llm_req.stop_words_list is not None:
+                decoder_request.stop_words_list = llm_req.stop_words_list.clone().squeeze_(0)
+
+            # Set batch slot and add to lists
+            batch_slots_view[batch_idx] = llm_req.seq_slot
+            decoder_requests.append(decoder_request)
+            sampling_configs.append(llm_req.sampling_config)
+
+            input_offset += prompt_len
+            batch_idx += 1
+
+        return batch_slots_view, decoder_requests, sampling_configs
+
+    def _retrieve_draft_logits(
+        self,
+        model_config: ModelConfig,
+        world_config: WorldConfig,
+        tensor: torch.Tensor,
+    ) -> torch.Tensor:
+        """Retrieve draft logits for speculative decoding.
+
+        Args:
+            model_config: Model configuration
+            world_config: World configuration
+            tensor: Input tensor containing draft logits
+
+        Returns:
+            Processed draft logits tensor
+        """
+        raise NotImplementedError("Draft logits are not currently supported in TRTLLMDecoder.")
+    
+    def _get_embedding_bias(self, logits_type: torch.dtype, tensor: torch.Tensor) -> torch.Tensor:
+        """Get embedding bias tensor with correct data type.
+
+        Args:
+            logits_type: Target data type for logits
+            tensor: Input embedding bias tensor
+
+        Returns:
+            Processed embedding bias tensor
+        """
+        # Return tensor if types match
+        if tensor.dtype == logits_type:
+            return tensor
+
+        # Handle FP32 to FP16 conversion
+        if tensor.dtype == torch.float32 and logits_type == torch.float16:
+            return tensor.to(logits_type, device='cuda')
+
+        raise RuntimeError("Embedding bias data type must be same as model logits type.")

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1053,11 +1053,11 @@ class PyTorchModelEngine(ModelEngine):
             prompt_lengths.append(len(prompt_tokens))
             past_seen_token_num = request.context_current_position
             num_cached_tokens_per_seq.append(past_seen_token_num)
-            multimodal_embedding = request.multimodal_embedding()
+            multimodal_embedding = request.multimodal_embedding
             if multimodal_embedding is not None:
                 multi_modal_data.append(multimodal_embedding)
 
-            mrope_rotary_cos_sin = request.get_mrope_rotary_cos_sin()
+            mrope_rotary_cos_sin = request.mrope_rotary_cos_sin
             if mrope_rotary_cos_sin is not None:
                 mrope_config['mrope_rotary_cos_sin'].append(
                     mrope_rotary_cos_sin)

--- a/tests/unittest/bindings/test_bindings_ut.py
+++ b/tests/unittest/bindings/test_bindings_ut.py
@@ -338,12 +338,12 @@ def test_llm_request():
     assert llm_request.pad_id == 99
     assert llm_request.end_id == 100
     assert llm_request.seq_slot == None
-    assert torch.equal(llm_request.prompt_embedding_table(),
+    assert torch.equal(llm_request.prompt_embedding_table,
                        kwargs["prompt_embedding_table"])
     assert llm_request.prompt_vocab_size == 2
-    assert torch.equal(llm_request.embedding_bias(), kwargs["embedding_bias"])
-    assert torch.equal(llm_request.stop_words_list(), kwargs["stop_words_list"])
-    assert torch.equal(llm_request.bad_words_list(), kwargs["bad_words_list"])
+    assert torch.equal(llm_request.embedding_bias, kwargs["embedding_bias"])
+    assert torch.equal(llm_request.stop_words_list, kwargs["stop_words_list"])
+    assert torch.equal(llm_request.bad_words_list, kwargs["bad_words_list"])
 
     assert llm_request.get_num_tokens(0) == 3
     assert llm_request.max_beam_num_tokens == 3


### PR DESCRIPTION
Add Python implementation of GenerateRequestOptions in tensorrt_llm/_torch/pyexecutor/generate_request_options.py, replicating the logic from generateRequestOptions.cpp. The implementation handles context request processing, decoder request preparation. Support for various speculative decoding modes will come at a later date (external draft tokens, Medusa, lookahead, Eagle).

Refactor C++ bindings and interfaces to support the new implementation:
- Change DecoderInputBuffers parameter from const to non-const
- Add Eagle speculative decoding mode support
- Add normalize_log_probs to SamplingConfig
- Simplify GenLlmReq property bindings

Reorganize Python bindings for better structure and type handling:
- Move SpeculativeDecodingMode bindings to early initialization
- Add custom type casters for ITensor SharedPtr and SharedConstPtr
- Improve module organization with clearer submodule structure

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
