### PR TITLE
[fix] Remove stale cublas heuristics

### DIFF
--- a/cpp/tensorrt_llm/thop/cublasScaledMM.cpp
+++ b/cpp/tensorrt_llm/thop/cublasScaledMM.cpp
@@ -52,9 +52,6 @@ using AlgoListType = std::unordered_map<std::tuple<int32_t, int32_t, int32_t>, s
 
 // bf16*bf16->fp32->bf16
 AlgoListType bf16_algo_list = {
-    // Deepseek v3/R1 fused_a
-    // [-algo66 -m_tile10 -m_stages35 -m_numsK1 -m_reduction0 -m_swizzle0 -m_custom5 -m_mma0 -m_cga2 -m_scheduling1]
-    {{8, 7168, 2112}, {10, 35, 1, 0, 0, 5, 2}},
     // Deepseek v3/R1 router gemm
     // [-algo66 -m_tile10 -m_stages35 -m_numsK1 -m_reduction0 -m_swizzle0 -m_custom3 -m_mma0 -m_cga2 -m_scheduling1]
     {{8, 7168, 256}, {10, 35, 1, 0, 0, 3, 2}},

--- a/tests/unittest/_torch/thop/test_cublas_mm.py
+++ b/tests/unittest/_torch/thop/test_cublas_mm.py
@@ -45,7 +45,10 @@ def test_cublas_mm(dtype, m, k_n):
         out_dtype=None,
     )
     ref = torch.matmul(x, w.t())
-    np.testing.assert_allclose(ref.float().cpu(), output.float().cpu())
+    np.testing.assert_allclose(ref.float().cpu(),
+                               output.float().cpu(),
+                               atol=0.01,
+                               rtol=0.01)
 
 
 @pytest.mark.parametrize(
@@ -54,7 +57,7 @@ def test_cublas_mm(dtype, m, k_n):
 )
 @pytest.mark.parametrize(
     "m",
-    [1, 4],
+    [1, 8, 512, 1024],
 )
 @pytest.mark.parametrize(
     "dtype",
@@ -76,7 +79,8 @@ def test_cublas_mm_out_fp32(dtype, m, k_n):
     ref = F.linear(x.float(), w.float())
     np.testing.assert_allclose(ref.float().cpu(),
                                output.float().cpu(),
-                               rtol=5e-3)
+                               atol=0.01,
+                               rtol=0.01)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION


## Description

This tactic was raising warnings like "CheckTactic failed with status: 15 and heuristic status: 15 with workspace size: 2.". It's no longer supported by the latest version of cublas and we should remove it.

Also fixed some flaky tests by making the atol/rtol a bit bigger.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
