### PR TITLE
chore: prevent using default stream

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -291,7 +291,6 @@ class PyTorchModelEngine(ModelEngine):
         self.batch_size = batch_size
         self.max_num_tokens = max_num_tokens
         self.max_seq_len = max_seq_len
-        self.stream = torch.cuda.Stream()
 
         self.mapping = mapping
         if mapping.has_pp():

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1910,11 +1910,10 @@ class PyTorchModelEngine(ModelEngine):
             return outputs
 
     def model_forward(self, **kwargs):
-        with torch.cuda.stream(self.stream):
-            if is_trace_enabled("TLLM_TRACE_MODEL_FORWARD"):
-                return trace_func(self.model.forward)(**kwargs)
-            else:
-                return self.model.forward(**kwargs)
+        if is_trace_enabled("TLLM_TRACE_MODEL_FORWARD"):
+            return trace_func(self.model.forward)(**kwargs)
+        else:
+            return self.model.forward(**kwargs)
 
     @nvtx_range("_forward_step")
     def _forward_step(self, inputs: Dict[str, Any],

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -709,7 +709,8 @@ class PyExecutor:
                     else:
                         with torch.cuda.nvtx.range("_forward_step_last_pp"):
                             with torch.cuda.stream(self.stream):
-                                batch_outputs = self._forward_step(scheduled_batch)
+                                batch_outputs = self._forward_step(
+                                    scheduled_batch)
                                 sample_state = self._sample_async(
                                     scheduled_batch, batch_outputs)
                                 self._update_request_states(scheduled_batch)
@@ -862,8 +863,8 @@ class PyExecutor:
                     with torch.cuda.stream(self.stream):
                         batch_outputs = self._forward_step(scheduled_batch)
 
-                        sample_state = self._sample_async(scheduled_batch,
-                                                        batch_outputs)
+                        sample_state = self._sample_async(
+                            scheduled_batch, batch_outputs)
 
                         self._update_request_states(scheduled_batch)
 
@@ -1010,11 +1011,11 @@ class PyExecutor:
                     previous_tensors_device = self.previous_batch and self.previous_batch.sample_state.device
 
                     with torch.cuda.stream(self.stream):
-                        batch_outputs = self._forward_step(scheduled_batch,
-                                                        previous_tensors_device)
+                        batch_outputs = self._forward_step(
+                            scheduled_batch, previous_tensors_device)
 
-                        sample_state = self._sample_async(scheduled_batch,
-                                                        batch_outputs)
+                        sample_state = self._sample_async(
+                            scheduled_batch, batch_outputs)
 
                     self._update_request_states(scheduled_batch)
 

--- a/tests/integration/defs/test_e2e.py
+++ b/tests/integration/defs/test_e2e.py
@@ -77,7 +77,7 @@ def _get_kv_mem_size_candidate(used_Gib, fraction):
 def _check_mem_usage(file, mem_info, ranks_num=1):
     if file is None or not TEST_MEM_USAGE:
         return
-    delta = 0.2  # 0.2 GB as buffer
+    delta = 0.3  # 0.3 GB as buffer
     peak, model_size, kv_mem_size, extra, fraction = _get_mem_info_from_log(
         file, ranks_num)
 


### PR DESCRIPTION
## Description

Currently, we don't setup a stream when we run inference and it uses the default stream now.

In this PR, we hope to setup a specific stream to prevent using the default stream directly.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
