### PR TITLE
feat:[AutoDeploy] Support Quantized MoE matcher

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe.py
@@ -3,7 +3,7 @@ from typing import List
 import torch
 import torch.nn.functional as F
 
-from ...modules.fused_moe import FusedMoE  # noqa: F401
+from tensorrt_llm._torch.modules.fused_moe import FusedMoE  # noqa: F401
 
 
 @torch.library.custom_op("moe::torch_moe", mutates_args=())
@@ -45,7 +45,7 @@ def torch_moe(
         valid_mask, selected_experts, torch.full_like(selected_experts, num_experts)
     )
     # Create one-hot encoding with an extra class.
-    one_hot = torch.nn.functional.one_hot(selected_experts_fixed, num_classes=num_experts + 1)
+    one_hot = F.one_hot(selected_experts_fixed, num_classes=num_experts + 1)
     expert_mask = one_hot[..., :num_experts].permute(2, 1, 0)
 
     for expert_idx in range(num_experts):
@@ -180,5 +180,98 @@ def trtllm_fused_moe(
     routing_weights: torch.Tensor,
     w3_w1_stacked_weight: torch.Tensor,
     w2_stacked_weight: torch.Tensor,
+) -> torch.Tensor:
+    return torch.empty_like(x)
+
+
+@torch.library.custom_op("moe::torch_fp8_moe", mutates_args=())
+def torch_fp8_moe(
+    x: torch.Tensor,
+    selected_experts: torch.Tensor,
+    routing_weights: torch.Tensor,
+    w1_weight: List[torch.Tensor],
+    w2_weight: List[torch.Tensor],
+    w3_weight: List[torch.Tensor],
+    w1_input_scale: List[torch.Tensor],
+    w2_input_scale: List[torch.Tensor],
+    w3_input_scale: List[torch.Tensor],
+    w1_weight_scale: List[torch.Tensor],
+    w2_weight_scale: List[torch.Tensor],
+    w3_weight_scale: List[torch.Tensor],
+) -> torch.Tensor:
+    """
+    FP8 MoE op using quantized linear operations.
+
+    Computes a Mixture-of-Experts layer similar to the reference moe::torch_moe op, but uses the
+    quantized FP8 linear op for expert computations.
+
+    Args:
+        x: Input tensor of shape (B, H) or (B, S, H).
+        selected_experts: Tensor (B, TOP_K) or (B*S, TOP_K) containing expert indices.
+        routing_weights: Tensor of normalized routing weights.
+        w1_weight, w2_weight, w3_weight: Lists of pre-quantized weight tensors for the three linear ops.
+        w1_input_scale, w2_input_scale, w3_input_scale: Lists of input scale tensors for the corresponding ops.
+        w1_weight_scale, w2_weight_scale, w3_weight_scale: Lists of weight scale tensors for the corresponding ops.
+
+    """
+    hidden_dim = x.shape[-1]
+    num_experts = len(w1_weight)
+
+    final_hidden_states = torch.zeros_like(x)
+    valid_mask = (selected_experts >= 0) & (selected_experts < num_experts)
+    selected_experts_fixed = torch.where(
+        valid_mask, selected_experts, torch.full_like(selected_experts, num_experts)
+    )
+    one_hot = F.one_hot(selected_experts_fixed, num_classes=num_experts + 1)
+    expert_mask = one_hot[..., :num_experts].permute(2, 1, 0)
+
+    for expert_idx in range(num_experts):
+        idx, top_x = torch.where(expert_mask[expert_idx])
+        tokens_for_expert = x[None, top_x].reshape(-1, hidden_dim)
+
+        gate_out = torch.ops.quant.fp8_linear(
+            tokens_for_expert,
+            w1_weight[expert_idx],
+            bias=None,
+            input_scale=w1_input_scale[expert_idx],
+            weight_scale=w1_weight_scale[expert_idx],
+        )
+        up_out = torch.ops.quant.fp8_linear(
+            tokens_for_expert,
+            w3_weight[expert_idx],
+            bias=None,
+            input_scale=w3_input_scale[expert_idx],
+            weight_scale=w3_weight_scale[expert_idx],
+        )
+        activated = F.silu(gate_out)
+        prod = activated * up_out
+        expert_out = torch.ops.quant.fp8_linear(
+            prod,
+            w2_weight[expert_idx],
+            bias=None,
+            input_scale=w2_input_scale[expert_idx],
+            weight_scale=w2_weight_scale[expert_idx],
+        )
+
+        current_hidden_states = expert_out * routing_weights[top_x, idx, None]
+        final_hidden_states.index_add_(0, top_x, current_hidden_states)
+
+    return final_hidden_states.view_as(x)
+
+
+@torch_fp8_moe.register_fake
+def torch_fp8_moe(
+    x: torch.Tensor,
+    selected_experts: torch.Tensor,
+    routing_weights: torch.Tensor,
+    w1_weight: List[torch.Tensor],
+    w2_weight: List[torch.Tensor],
+    w3_weight: List[torch.Tensor],
+    w1_input_scale: List[torch.Tensor],
+    w2_input_scale: List[torch.Tensor],
+    w3_input_scale: List[torch.Tensor],
+    w1_weight_scale: List[torch.Tensor],
+    w2_weight_scale: List[torch.Tensor],
+    w3_weight_scale: List[torch.Tensor],
 ) -> torch.Tensor:
     return torch.empty_like(x)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe.py
@@ -275,3 +275,105 @@ def torch_fp8_moe(
     w3_weight_scale: List[torch.Tensor],
 ) -> torch.Tensor:
     return torch.empty_like(x)
+
+
+@torch.library.custom_op("moe::torch_fp4_moe", mutates_args=())
+def torch_fp4_moe(
+    x: torch.Tensor,
+    selected_experts: torch.Tensor,
+    routing_weights: torch.Tensor,
+    w1_weight: List[torch.Tensor],
+    w2_weight: List[torch.Tensor],
+    w3_weight: List[torch.Tensor],
+    w1_input_scale: List[torch.Tensor],
+    w2_input_scale: List[torch.Tensor],
+    w3_input_scale: List[torch.Tensor],
+    w1_weight_scale: List[torch.Tensor],
+    w2_weight_scale: List[torch.Tensor],
+    w3_weight_scale: List[torch.Tensor],
+    w1_alpha: List[torch.Tensor],
+    w2_alpha: List[torch.Tensor],
+    w3_alpha: List[torch.Tensor],
+) -> torch.Tensor:
+    """
+    FP4 MoE op using quantized linear operations.
+
+    Computes a Mixture-of-Experts layer similar to the reference moe::torch_moe op,
+    but uses the NVFP4 quantized linear op for expert computations.
+
+    Args:
+        x: Input tensor of shape (B, H) or (B, S, H).
+        selected_experts: Tensor (B, TOP_K) or (B*S, TOP_K) containing expert indices.
+        routing_weights: Tensor of normalized routing weights.
+        w1_weight, w2_weight, w3_weight: Lists of pre-quantized weight tensors for the three linear ops.
+        w1_input_scale, w2_input_scale, w3_input_scale: Lists of input scale tensors.
+        w1_weight_scale, w2_weight_scale, w3_weight_scale: Lists of weight scale tensors.
+        w1_alpha, w2_alpha, w3_alpha: Lists of alpha scale tensors for FP4 quantization.
+    """
+    hidden_dim = x.shape[-1]
+    num_experts = len(w1_weight)
+
+    final_hidden_states = torch.zeros_like(x)
+    valid_mask = (selected_experts >= 0) & (selected_experts < num_experts)
+    selected_experts_fixed = torch.where(
+        valid_mask, selected_experts, torch.full_like(selected_experts, num_experts)
+    )
+    one_hot = F.one_hot(selected_experts_fixed, num_classes=num_experts + 1)
+    expert_mask = one_hot[..., :num_experts].permute(2, 1, 0)
+
+    for expert_idx in range(num_experts):
+        idx, top_x = torch.where(expert_mask[expert_idx])
+        tokens_for_expert = x[None, top_x].reshape(-1, hidden_dim)
+        gate_out = torch.ops.quant.fp4_linear(
+            tokens_for_expert,
+            w1_weight[expert_idx],
+            bias=None,
+            input_scale=w1_input_scale[expert_idx],
+            weight_scale=w1_weight_scale[expert_idx],
+            alpha=w1_alpha[expert_idx],
+        )
+        up_out = torch.ops.quant.fp4_linear(
+            tokens_for_expert,
+            w3_weight[expert_idx],
+            bias=None,
+            input_scale=w3_input_scale[expert_idx],
+            weight_scale=w3_weight_scale[expert_idx],
+            alpha=w3_alpha[expert_idx],
+        )
+        activated = F.silu(gate_out)
+        prod = activated * up_out
+        expert_out = torch.ops.quant.fp4_linear(
+            prod,
+            w2_weight[expert_idx],
+            bias=None,
+            input_scale=w2_input_scale[expert_idx],
+            weight_scale=w2_weight_scale[expert_idx],
+            alpha=w2_alpha[expert_idx],
+        )
+
+        current_hidden_states = expert_out * routing_weights[top_x, idx, None]
+        final_hidden_states.index_add_(0, top_x, current_hidden_states)
+
+    return final_hidden_states.view_as(x)
+
+
+@torch_fp4_moe.register_fake
+def torch_fp4_moe(
+    x: torch.Tensor,
+    selected_experts: torch.Tensor,
+    routing_weights: torch.Tensor,
+    w1_weight: List[torch.Tensor],
+    w2_weight: List[torch.Tensor],
+    w3_weight: List[torch.Tensor],
+    w1_input_scale: List[torch.Tensor],
+    w2_input_scale: List[torch.Tensor],
+    w3_input_scale: List[torch.Tensor],
+    w1_weight_scale: List[torch.Tensor],
+    w2_weight_scale: List[torch.Tensor],
+    w3_weight_scale: List[torch.Tensor],
+    w1_alpha: List[torch.Tensor],
+    w2_alpha: List[torch.Tensor],
+    w3_alpha: List[torch.Tensor],
+) -> torch.Tensor:
+    # Fake implementation for tracing/testing
+    return torch.empty_like(x)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe.py
@@ -151,6 +151,9 @@ def trtllm_fused_moe(
     w3_w1_stacked_weight: torch.Tensor,
     w2_stacked_weight: torch.Tensor,
 ) -> torch.Tensor:
+    hidden_dim = x.shape[-1]
+    x = x.view(-1, hidden_dim)
+
     routing_weights = routing_weights.to(torch.float32)
     selected_experts = selected_experts.to(torch.int32)
     quant_scales = []

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe.py
@@ -324,6 +324,9 @@ def torch_fp4_moe(
     for expert_idx in range(num_experts):
         idx, top_x = torch.where(expert_mask[expert_idx])
         tokens_for_expert = x[None, top_x].reshape(-1, hidden_dim)
+
+        if not tokens_for_expert.shape[0]:
+            continue  # input of shape [0, hidden_dim] breaks fp4 kernel
         gate_out = torch.ops.quant.fp4_linear(
             tokens_for_expert,
             w1_weight[expert_idx],
@@ -375,5 +378,4 @@ def torch_fp4_moe(
     w2_alpha: List[torch.Tensor],
     w3_alpha: List[torch.Tensor],
 ) -> torch.Tensor:
-    # Fake implementation for tracing/testing
     return torch.empty_like(x)

--- a/tensorrt_llm/_torch/auto_deploy/models/hf.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/hf.py
@@ -186,8 +186,9 @@ class HFFactory(ModelFactory):
         # sharded checkpoint
         if os.path.isfile(os.path.join(ckpt_path, "model.safetensors.index.json")):
             _to_maybe_empty(model, device="cpu")
-            with load_state_dict_with_assign():
-                load_sharded_checkpoint(model, ckpt_path, strict=False)
+            load_sharded_checkpoint(model, ckpt_path, strict=False)
+            # with load_state_dict_with_assign():
+            #     load_sharded_checkpoint(model, ckpt_path, strict=False)
             return
 
         # look for a single file in the directory ending with .safetensors or .pt/.pth
@@ -204,8 +205,9 @@ class HFFactory(ModelFactory):
         else:
             raise ValueError(f"No checkpoint found in {ckpt_path}")
 
-        with load_state_dict_with_assign():
-            model.load_state_dict(state_dict, strict=False)
+        model.load_state_dict(state_dict, strict=False, assign=True)
+        # with load_state_dict_with_assign():
+        #     model.load_state_dict(state_dict, strict=False)
 
     def _load_quantization_config(self):
         assert self.ckpt_path

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/ep_sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/ep_sharding.py
@@ -12,7 +12,7 @@ The sharding process consists of:
 1. Identify MoE nodes in the FX graph
 2. Compute local sharding parameters (`selected_experts` and `final_scales`) to update the routing tensors.
 3. Partition expert weight lists according to the current rank and world size,
-    and replace the MoE node’s arguments with these sharded versions.
+    and replace the MoE node's arguments with these sharded versions.
 4. Append an all_reduce node after each MoE node to aggregate outputs across devices,
     then canonicalize the modified graph.
 
@@ -39,7 +39,10 @@ def ep_shard(gm: GraphModule, rank: int, world_size: int) -> GraphModule:
     assert isinstance(gm, GraphModule), "Expecting GraphModule"
 
     for node in list(gm.graph.nodes):
-        if not is_op(node, torch.ops.moe.torch_moe):
+        if not is_op(
+            node,
+            (torch.ops.moe.torch_moe, torch.ops.moe.torch_fp8_moe, torch.ops.moe.torch_fp4_moe),
+        ):
             continue
         _insert_sharded_moe(gm, node, rank, world_size)
 
@@ -60,6 +63,8 @@ def _insert_sharded_moe(
     sharded `selected_experts` and `final_scales(router_logics)`.
     Add an all_reduce node after the moe node.
     """
+    is_fp8 = is_op(node, torch.ops.moe.torch_fp8_moe)
+    is_fp4 = is_op(node, torch.ops.moe.torch_fp4_moe)
     num_experts = len(node.args[3])
     args = list(node.args)
 
@@ -115,6 +120,13 @@ def _insert_sharded_moe(
     args[3] = w1_list_sharded
     args[4] = w2_list_sharded
     args[5] = w3_list_sharded
+
+    if is_fp8:
+        for i in range(6):
+            args[6 + i] = get_partition(args[6 + i], world_size, rank)
+    elif is_fp4:
+        for i in range(9):
+            args[6 + i] = get_partition(args[6 + i], world_size, rank)
 
     ad_logger.debug(
         f"Updated node {node}: replaced original arguments {node.args} with sharded arguments {args}."

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/fused_moe.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Callable, Dict, Optional
+from typing import Callable, Optional
 
 import torch
 from torch.fx import GraphModule, Node
@@ -19,71 +19,71 @@ def match_moe_pattern(gm: GraphModule) -> GraphModule:
     boundary_nodes = identify_regions_between_residuals(gm)
 
     for start_boundary, end_boundary in zip(boundary_nodes[:-1], boundary_nodes[1:]):
-        node = start_boundary
-        while node != end_boundary:
-            node = node.next
-            # Step 1: Identify topk nodes
-            if not is_op(node, torch.ops.aten.topk):
-                continue
+        # Step 1: Identify Expert Compute pattern
+        pattern_input_nodes, pattern_output_nodes, expert_weights = _match_expert_compute_pattern(
+            start_boundary, end_boundary
+        )
+        if not expert_weights:
+            continue
+        # TODO: naming convention to verify the order of the weight nodes
 
-            topk_node = node
+        # Step 2: Trace upwards to locate normalize_routing_weight and selected_experts:
+        arg1_list, arg2_list = _extract_index_branches_from_expert_outputs(pattern_output_nodes)
+        normalized_routing_weights = _find_lowest_common_ancessor(arg1_list)
+        if not normalized_routing_weights:
+            continue
 
-            # Identify routing_weights and selected_experts from the output of topk node
-            topk_output_mapping = {n.args[1]: n for n in topk_node.users}
-            if len(topk_output_mapping) < 2:
-                continue
-            routing_weights, selected_experts = topk_output_mapping[0], topk_output_mapping[1]
+        common_ancessor2 = _find_lowest_common_ancessor(arg2_list)
+        if not common_ancessor2:
+            continue
+        selected_experts = _bfs(
+            common_ancessor2,
+            lambda node: is_op(node, torch.ops.aten.one_hot),
+            attr_next="all_input_nodes",
+            boundary=start_boundary,
+        ).args[0]
+        if not selected_experts:
+            continue
 
-            # Step 2: Identify normalized_routing_weights
-            normalized_routing_weights = _find_normalized_routing_weights(
-                routing_weights, boundary=end_boundary
+        # Step 3: Trace upwards to find input node:
+        hidden_states = _find_lowest_common_ancessor(pattern_input_nodes)
+        if not hidden_states:
+            continue
+
+        # Step 4: Find output node with the combine pattern
+        final_hidden_state_node = _find_final_hidden_state_node(pattern_output_nodes, end_boundary)
+        if final_hidden_state_node is None:
+            continue
+
+        # Step 5: Insert the moe op into the graph.
+        ad_logger.debug(
+            f"""Found MoE Pattern: between boundary {start_boundary} and {end_boundary}.\n
+            Capturing input hidden states node: {hidden_states},
+            selected_experts node: {selected_experts}, routing_weights node: {normalized_routing_weights},
+            expert weights : {expert_weights} """
+        )
+        with graph.inserting_before(final_hidden_state_node):
+            w1_list = expert_weights["w1"]
+            w2_list = expert_weights["w2"]
+            w3_list = expert_weights["w3"]
+
+            fused_moe_node = graph.call_function(
+                torch.ops.moe.torch_moe,
+                args=(
+                    hidden_states,
+                    selected_experts,
+                    normalized_routing_weights,
+                    w1_list,
+                    w2_list,
+                    w3_list,
+                ),
             )
 
-            # Step 3: Trace backwards within the region to find the gate linear node and extract hidden_states
-            gate_linear_node = _find_gate_linear_node(topk_node, boundary=start_boundary)
-            if gate_linear_node is None:
-                continue
-            hidden_states = gate_linear_node.args[0]
+        final_hidden_state_node.replace_all_uses_with(fused_moe_node)
+        graph.erase_node(final_hidden_state_node)
 
-            # Step 4: Extract expert branch weights from the topk node (restricted by region).
-            expert_weights = _extract_expert_weights_from_topk(topk_node, boundary=end_boundary)
-            if not expert_weights:
-                continue
-
-            # Step 5: Identify the final GEMM output before the residual boundary.
-            final_hidden_state_node = _find_final_hidden_state_node(end_boundary)
-            if final_hidden_state_node is None:
-                continue
-
-            # Step 6: Insert the moe op into the graph.
-            ad_logger.debug(
-                f"""Found MoE Pattern: between boundary {start_boundary} and {end_boundary}.\n
-                Capturing gate node: {gate_linear_node}, input hidden states node: {hidden_states},
-                selected_experts node: {selected_experts}, routing_weights node: {normalized_routing_weights},
-                expert weights : {expert_weights} """
-            )
-            with graph.inserting_before(final_hidden_state_node):
-                w1_list = expert_weights["w1"]
-                w2_list = expert_weights["w2"]
-                w3_list = expert_weights["w3"]
-
-                fused_moe_node = graph.call_function(
-                    torch.ops.moe.torch_moe,
-                    args=(
-                        hidden_states,
-                        selected_experts,
-                        normalized_routing_weights,
-                        w1_list,
-                        w2_list,
-                        w3_list,
-                    ),
-                )
-
-            final_hidden_state_node.replace_all_uses_with(fused_moe_node)
-            graph.erase_node(final_hidden_state_node)
-
-            while _remove_dead_inplace_nodes_in_region(gm.graph, start_boundary, end_boundary):
-                gm.graph.eliminate_dead_code()
+        while _remove_dead_inplace_nodes_in_region(gm.graph, start_boundary, end_boundary):
+            gm.graph.eliminate_dead_code()
 
     gm = canonicalize_graph(gm)
     ad_logger.debug("After MoE Pattern Matching: " + str(gm))
@@ -153,26 +153,6 @@ def _insert_fused_moe_ops(gm: GraphModule):
         graph.erase_node(node)
 
 
-def _find_gate_linear_node(topk_node: Node, boundary: Optional[Node] = None) -> Optional[Node]:
-    """
-    Traverse backwards from the topk node to identify the gate linear op.
-    Uses a BFS over all input nodes (via "all_input_nodes") starting from topk_node,
-    returning the first node that qualifies as a linear op. The search stops if it
-    reaches the boundary node.
-    """
-    return _bfs(
-        topk_node, lambda node: is_linear_op(node), attr_next="all_input_nodes", boundary=boundary
-    )
-
-
-def _is_routing_weight(node: Node) -> bool:
-    routing_ops = {
-        torch.ops.aten.index,
-        torch.ops.aten.select,
-    }
-    return is_op(node, routing_ops)
-
-
 def _bfs(
     node: Node, target: Callable, attr_next: str = "users", boundary: Optional[Node] = None
 ) -> Node:
@@ -193,128 +173,228 @@ def _bfs(
     raise RuntimeError(f"Could not find node with target condition {target}.")
 
 
-def _find_normalized_routing_weights(
-    routing_weights_node: Node, boundary: Optional[Node] = None
-) -> Optional[Node]:
+def _find_lowest_common_ancessor(nodes: list[Node]) -> Optional[Node]:
     """
-    Starting from the routing_weights node, use BFS to locate a node that:
-      1. Is a torch.ops.aten.to op,
-      2. And its first argument is produced by a torch.ops.aten.div_ op.
+    Find the lowest common ancestor for a list of nodes in a torch.fx Graph by following
+    each node's primary branch (recursively following the first Node argument).
+
+    It first finds the LCA of the first two nodes and then
+    iteratively computes the LCA of the result with the next node, and so on.
 
     Returns:
-        The node producing the normalized routing weights, or None if not found.
+        The common ancestor Node if found, otherwise None.
     """
-    try:
-        norm_node = _bfs(
-            routing_weights_node,
-            lambda n: is_op(n, torch.ops.aten.to)
-            and len(n.args) > 0
-            and is_op(n.args[0], torch.ops.aten.div_),
-            attr_next="users",
-            boundary=boundary,
-        )
-        return norm_node
-    except RuntimeError:
+    if not nodes:
         return None
 
+    def get_parent(node: Node) -> Optional[Node]:
+        """Return the first Node-valued argument for a given node, or None if not found."""
+        for arg in node.args:
+            if isinstance(arg, Node):
+                return arg
+        return None
 
-def _get_linear_weight_from_branch(branch_node: Node):
-    def target_fn(n: Node):
-        return n.op == "call_function" and n.target == torch.ops.linear.simple.default
+    def get_depth(node: Node) -> int:
+        """
+        Recursively compute the depth of the node by following its primary branch.
+        Depth is defined as the number of steps to reach a node with no parent.
+        """
+        parent = get_parent(node)
+        if parent is None:
+            return 0
+        return 1 + get_depth(parent)
 
-    linear_node = _bfs(branch_node, target_fn, attr_next="all_input_nodes")
-    return linear_node.args[1] if linear_node is not None else None
+    def lca_two(a: Node, b: Node) -> Optional[Node]:
+        """
+        Find the lowest common ancestor of two nodes by first equalizing their depth
+        and then moving upward until a common node is found.
+        """
+        depth_a = get_depth(a)
+        depth_b = get_depth(b)
+
+        # Equalize depths
+        while depth_a > depth_b:
+            a = get_parent(a)
+            depth_a -= 1
+        while depth_b > depth_a:
+            b = get_parent(b)
+            depth_b -= 1
+
+        # Walk upward in lockstep
+        while a is not None and b is not None:
+            if a is b:
+                return a
+            a = get_parent(a)
+            b = get_parent(b)
+        return None
+
+    # Iteratively compute the LCA across all nodes.
+    common = nodes[0]
+    for node in nodes[1:]:
+        common = lca_two(common, node)
+        if common is None:
+            return None
+
+    return common
 
 
-def _extract_expert_weights_from_topk(
-    topk_node: Node, boundary: Optional[Node] = None
-) -> Dict[str, Node]:
+def _match_expert_compute_pattern(start_boundary: Node, end_boundary: Node):
     """
-    This function locates multiplication nodes where one operand comes from a routing weight slice
-    (using a heuristic) and the other is the output of an expert layer. From that expert branch, it
-    extracts the weights:
-      - w1: from the branch that goes through a silu op,
-      - w3: from the direct branch,
-      - w2: from the subsequent linear op applying the final transformation.
+    Match the expert compute pattern between the given boundaries.
 
-    Returns:
-        A dictionary with keys "w1", "w2", and "w3", each mapping to a list of corresponding weight nodes.
+    The expert compute pattern corresponds to:
+
+        (F.silu(x @ w1.t()) * (x @ w3.t())) @ w2.t()
+
+    For each expert, the function returns:
+      - pattern_input_nodes: a list of input nodes (x) used for the expert compute.
+      - pattern_output_nodes: a list of final expert output nodes (the linear op with weight w2).
+      - expert_weights: a dict with keys "w1", "w2", and "w3" mapping to lists of
+        corresponding weight nodes from the w1, w2, and w3 branches.
     """
-    candidate_expert_branches = []
+    pattern_input_nodes, pattern_output_nodes = [], []
     expert_weights = defaultdict(list)
 
-    # Step 1. Find multiplication nodes that compute:
-    #         expert_layer_output * routing_weights_slice
-    # We scan the entire graph and look for aten.mul.Tensor nodes where one operand is a routing weight.
-    node = topk_node.next
-    while node != boundary and not is_op(node, torch.ops.aten.topk):
-        if is_op(node, torch.ops.aten.mul):
-            if len(node.args) < 2:
-                continue
-            arg0, arg1 = node.args[0], node.args[1]
-            if not all(
-                isinstance(arg, torch.fx.Node) and arg.op == "call_function" for arg in (arg0, arg1)
-            ):
-                node = node.next
-                continue
-            if _is_routing_weight(arg0) != _is_routing_weight(arg1):
-                candidate_expert_branches.append(arg1 if _is_routing_weight(arg0) else arg0)
+    nodes = list(start_boundary.graph.nodes)
+    region_nodes = nodes[nodes.index(start_boundary) + 1 : nodes.index(end_boundary)]
 
-        node = node.next
-
-    # Step 2. For each candidate expert branch, try to extract the three weights.
-    for expert_branch in candidate_expert_branches:
-        w1_node = None
-        w2_node = None
-        w3_node = None
-
-        # The expert branch should eventually compute:
-        #   (F.silu(x @ w1.t()) * (x @ w3.t())) @ w2.t()
-        if is_linear_op(expert_branch):
-            w2_node = expert_branch.args[1]
-            inner = expert_branch.args[0]
-        else:
+    for node in region_nodes:
+        if not is_linear_op(node):
             continue
 
-        # The inner multiplication node should combine two branches:
-        # one computed via F.silu(x @ w1.t()) and the other computed via (x @ w3.t()).
-        if not is_op(inner, torch.ops.aten.mul):
-            continue
-        if len(inner.args) < 2:
-            continue
-        branch_a = inner.args[0]
-        branch_b = inner.args[1]
-        if is_op(branch_a, torch.ops.aten.silu):
-            w1_node = _get_linear_weight_from_branch(branch_a)
-            w3_node = _get_linear_weight_from_branch(branch_b)
-        elif is_op(branch_b, torch.ops.aten.silu):
-            w1_node = _get_linear_weight_from_branch(branch_b)
-            w3_node = _get_linear_weight_from_branch(branch_a)
-        else:
+        final_linear = node
+        # Must have at least one argument, and that first argument must be a Node.
+        if not final_linear.args or not isinstance(final_linear.args[0], Node):
             continue
 
-        if w1_node is not None and w2_node is not None and w3_node is not None:
-            expert_weights["w1"].append(w1_node)
-            expert_weights["w2"].append(w2_node)
-            expert_weights["w3"].append(w3_node)
-        else:
+        mul_node = final_linear.args[0]
+        if not is_op(mul_node, torch.ops.aten.mul) or len(mul_node.args) < 2:
             continue
 
-    return expert_weights
+        arg_a, arg_b = mul_node.args[:2]
+        # Pick the silu op from either arg_a or arg_b.
+        silu_node = (
+            arg_a
+            if (isinstance(arg_a, Node) and is_op(arg_a, torch.ops.aten.silu))
+            else arg_b
+            if (isinstance(arg_b, Node) and is_op(arg_b, torch.ops.aten.silu))
+            else None
+        )
+        if silu_node is None:
+            continue
 
-
-def _find_final_hidden_state_node(residual_node: Node) -> Optional[Node]:
-    """
-    Identify the final GEMM node (or its output) that computes the hidden_states
-    before the residual addition.
-    """
-
-    for inp in residual_node.args:
-        if isinstance(inp, Node) and is_op(
-            inp, {torch.ops.aten.reshape, torch.ops.aten.mm, torch.ops.aten.matmul}
+        if not (
+            silu_node.args
+            and isinstance(silu_node.args[0], Node)
+            and is_linear_op(silu_node.args[0])
         ):
-            return inp.args[0]
-    return None
+            continue
+        linear_w1_node = silu_node.args[0]
+
+        # The other branch should be a linear op (w3 branch).
+        linear_w3_node = arg_b if arg_a is silu_node else arg_a
+        if not (isinstance(linear_w3_node, Node) and is_linear_op(linear_w3_node)):
+            continue
+        if not (linear_w1_node.args and linear_w3_node.args):
+            continue
+
+        input_node_w1 = linear_w1_node.args[0]
+        weight_w1 = linear_w1_node.args[1] if len(linear_w1_node.args) > 1 else None
+        weight_w3 = linear_w3_node.args[1] if len(linear_w3_node.args) > 1 else None
+        weight_w2 = final_linear.args[1] if len(final_linear.args) > 1 else None
+
+        if None in (weight_w1, weight_w3, weight_w2):
+            continue
+
+        pattern_input_nodes.append(input_node_w1)
+        pattern_output_nodes.append(final_linear)
+        expert_weights["w1"].append(weight_w1)
+        expert_weights["w3"].append(weight_w3)
+        expert_weights["w2"].append(weight_w2)
+
+    return pattern_input_nodes, pattern_output_nodes, expert_weights
+
+
+def _find_final_hidden_state_node(
+    pattern_output_nodes: list[Node], end_boundary: Node
+) -> Optional[Node]:
+    """
+    Identify the final hidden state node corresponding to the combine pattern:
+
+        (expert_output * routing_weight) → index_add_
+
+    For each expert output node (from the expert compute pattern), this function:
+      1. Retrieves a multiplication node from its users.
+      2. Extracts the second argument from the multiplication node (assumed to be the index node).
+      3. Uses a BFS (via _bfs) to locate the subsequent index_add_ node (guarded by the end_boundary).
+
+    After collecting all such index_add_ nodes, the final hidden state node is determined
+    as the one that is not used by any of the other index_add_ nodes.
+
+    If any required attribute (users or args) is missing during the process or if no valid
+    final node is found, the function returns None.
+    """
+
+    if not pattern_output_nodes:
+        return None
+
+    index_add_nodes = []
+    for node in pattern_output_nodes:
+        if not node.users:
+            return None
+        mul_node = next(iter(node.users))
+        if not (hasattr(mul_node, "args") and len(mul_node.args) >= 2):
+            return None
+        index_node = mul_node.args[1]
+        index_add_node = _bfs(
+            index_node, lambda n: is_op(n, torch.ops.aten.index_add_), boundary=end_boundary
+        )
+        if not index_add_node:
+            return None
+        index_add_nodes.append(index_add_node)
+
+    # The final node is defined as the index_add_node that is not used by any other index_add_nodes
+    return next(
+        (
+            candidate
+            for candidate in index_add_nodes
+            if not any(
+                candidate in other.args for other in index_add_nodes if candidate is not other
+            )
+        ),
+        None,
+    )
+
+
+def _extract_index_branches_from_expert_outputs(
+    pattern_output_nodes: list[Node],
+) -> tuple[list[Node], list[Node]]:
+    """
+    Extract routing and experts branches from expert outputs.
+
+    For each expert output, find its multiplication user. From the
+    multiplication node's second argument (an index node),
+    extract:
+      - The first argument as the routing branch.
+      - The second argument (flattened if a list/tuple) as the experts branch.
+
+    Returns:
+        A tuple (routing_branches, experts_branches).
+    """
+    routing_branches, experts_branches = [], []
+    for out in pattern_output_nodes:
+        mul = next((u for u in out.users if is_op(u, torch.ops.aten.mul)), None)
+        if not mul or len(mul.args) < 2:
+            continue
+        idx_node = mul.args[1]
+        if not (isinstance(idx_node, Node) and is_op(idx_node, torch.ops.aten.index)):
+            continue
+        routing_branches.append(idx_node.args[0])
+        experts = idx_node.args[1]
+        experts_branches.extend(experts) if isinstance(
+            experts, (list, tuple)
+        ) else experts_branches.append(experts)
+    return routing_branches, experts_branches
 
 
 def _remove_dead_inplace_nodes_in_region(

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/fused_moe.py
@@ -20,8 +20,8 @@ def match_moe_pattern(gm: GraphModule) -> GraphModule:
 
     for start_boundary, end_boundary in zip(boundary_nodes[:-1], boundary_nodes[1:]):
         # Step 1: Identify Expert Compute pattern
-        pattern_input_nodes, pattern_output_nodes, expert_weights = _match_expert_compute_pattern(
-            start_boundary, end_boundary
+        (pattern_input_nodes, pattern_output_nodes, expert_weights, expert_scales, weight_type) = (
+            _match_expert_compute_pattern(start_boundary, end_boundary)
         )
         if not expert_weights:
             continue
@@ -55,29 +55,49 @@ def match_moe_pattern(gm: GraphModule) -> GraphModule:
         if final_hidden_state_node is None:
             continue
 
-        # Step 5: Insert the moe op into the graph.
+        # Step 5: Insert the MoE op into the graph.
         ad_logger.debug(
-            f"""Found MoE Pattern: between boundary {start_boundary} and {end_boundary}.\n
-            Capturing input hidden states node: {hidden_states},
-            selected_experts node: {selected_experts}, routing_weights node: {normalized_routing_weights},
-            expert weights : {expert_weights} """
+            f"Found MoE Pattern: between boundary {start_boundary} and {end_boundary}.\n"
+            f"Input hidden states node: {hidden_states}, "
+            f"selected_experts node: {selected_experts}, "
+            f"routing_weights node: {normalized_routing_weights}, "
+            f"expert weights: {expert_weights}, weight type: {weight_type}"
         )
         with graph.inserting_before(final_hidden_state_node):
             w1_list = expert_weights["w1"]
             w2_list = expert_weights["w2"]
             w3_list = expert_weights["w3"]
 
-            fused_moe_node = graph.call_function(
-                torch.ops.moe.torch_moe,
-                args=(
-                    hidden_states,
-                    selected_experts,
-                    normalized_routing_weights,
-                    w1_list,
-                    w2_list,
-                    w3_list,
-                ),
-            )
+            if weight_type == "fp8":
+                fused_moe_node = graph.call_function(
+                    torch.ops.moe.torch_fp8_moe,
+                    args=(
+                        hidden_states,
+                        selected_experts,
+                        normalized_routing_weights,
+                        w1_list,
+                        w2_list,
+                        w3_list,
+                        expert_scales["w1_input_scale"],
+                        expert_scales["w2_input_scale"],
+                        expert_scales["w3_input_scale"],
+                        expert_scales["w1_weight_scale"],
+                        expert_scales["w2_weight_scale"],
+                        expert_scales["w3_weight_scale"],
+                    ),
+                )
+            else:
+                fused_moe_node = graph.call_function(
+                    torch.ops.moe.torch_moe,
+                    args=(
+                        hidden_states,
+                        selected_experts,
+                        normalized_routing_weights,
+                        w1_list,
+                        w2_list,
+                        w3_list,
+                    ),
+                )
 
         final_hidden_state_node.replace_all_uses_with(fused_moe_node)
         graph.erase_node(final_hidden_state_node)
@@ -139,7 +159,8 @@ def _insert_fused_moe_ops(gm: GraphModule):
 
         with graph.inserting_before(node):
             new_node = graph.call_function(
-                torch.ops.moe.trtllm_fused_moe,
+                # TODO: torch.ops.moe.trtllm_fused_moe for unquantized models,
+                torch.ops.moe.torch_fused_moe,
                 args=(
                     hidden_states,
                     selected_experts,
@@ -238,6 +259,37 @@ def _find_lowest_common_ancessor(nodes: list[Node]) -> Optional[Node]:
     return common
 
 
+def _extract_linear_parameters(linear_node: Node) -> tuple[Node, torch.Tensor, Optional[dict], str]:
+    """
+    Given a linear op node, extract the input tensor node, weight tensor,
+    any quantization scales (if the op is quantized), and return a weight type.
+
+    For a torch.ops.linear.simple.default op:
+      - Returns (input_node, weight, None, "simple")
+
+    For a torch.ops.quant.fp8_linear op:
+      - Returns (input_node, weight, {"input_scale": input_scale, "weight_scale": weight_scale}, "fp8")
+    """
+    input_node = linear_node.args[0]
+    if is_op(linear_node, torch.ops.quant.fp8_linear):
+        weight = linear_node.args[1]
+        input_scale = linear_node.kwargs.get("input_scale", None)
+        weight_scale = linear_node.kwargs.get("weight_scale", None)
+
+        # in case input_scale and weight_scale is not provided by kwargs
+        # args layout is (input, weight, bias, input_scale, weight_scale)
+        if input_scale is None and len(linear_node.args) >= 4:
+            input_scale = linear_node.args[3]
+        if weight_scale is None and len(linear_node.args) >= 5:
+            weight_scale = linear_node.args[4]
+        return input_node, weight, {"input_scale": input_scale, "weight_scale": weight_scale}, "fp8"
+    elif is_op(linear_node, torch.ops.linear.simple):
+        weight = linear_node.args[1]
+        return input_node, weight, None, "simple"
+    else:
+        return None, None, None, ""
+
+
 def _match_expert_compute_pattern(start_boundary: Node, end_boundary: Node):
     """
     Match the expert compute pattern between the given boundaries.
@@ -246,24 +298,38 @@ def _match_expert_compute_pattern(start_boundary: Node, end_boundary: Node):
 
         (F.silu(x @ w1.t()) * (x @ w3.t())) @ w2.t()
 
-    For each expert, the function returns:
-      - pattern_input_nodes: a list of input nodes (x) used for the expert compute.
-      - pattern_output_nodes: a list of final expert output nodes (the linear op with weight w2).
-      - expert_weights: a dict with keys "w1", "w2", and "w3" mapping to lists of
-        corresponding weight nodes from the w1, w2, and w3 branches.
+    For each expert, the function extracts the input node from the w1 branch and
+    collects the weight parameters from three linear ops (w1, w3, and w2 branches).
+
+    This function supports both:
+      - torch.ops.linear.simple.default ops, and
+      - torch.ops.quant.fp8_linear ops (in which case it also extracts quantization scales).
+
+    Returns:
+        A tuple:
+          (pattern_input_nodes, pattern_output_nodes, expert_weights, expert_scales, weight_type)
+
+          - pattern_input_nodes: List of input nodes (x) used for the expert compute.
+          - pattern_output_nodes: List of final expert output nodes (the linear op with weight w2).
+          - expert_weights: Dict with keys "w1", "w2", "w3" mapping to lists of weight tensors.
+          - expert_scales: Dict with keys "w1_input_scale", "w1_weight_scale", etc., containing scale tensors
+                           (empty if weight_type is "simple").
+          - weight_type: "fp8" if FP8 ops were used, "simple" otherwise.
     """
     pattern_input_nodes, pattern_output_nodes = [], []
     expert_weights = defaultdict(list)
+    expert_scales = defaultdict(list)
+    weight_type = "simple"  # default
 
     nodes = list(start_boundary.graph.nodes)
     region_nodes = nodes[nodes.index(start_boundary) + 1 : nodes.index(end_boundary)]
 
     for node in region_nodes:
-        if not is_linear_op(node):
+        # Accept both simple and quantized linear ops.
+        if not is_linear_op(node, include_quantization=True):
             continue
 
         final_linear = node
-        # Must have at least one argument, and that first argument must be a Node.
         if not final_linear.args or not isinstance(final_linear.args[0], Node):
             continue
 
@@ -272,7 +338,6 @@ def _match_expert_compute_pattern(start_boundary: Node, end_boundary: Node):
             continue
 
         arg_a, arg_b = mul_node.args[:2]
-        # Pick the silu op from either arg_a or arg_b.
         silu_node = (
             arg_a
             if (isinstance(arg_a, Node) and is_op(arg_a, torch.ops.aten.silu))
@@ -286,25 +351,35 @@ def _match_expert_compute_pattern(start_boundary: Node, end_boundary: Node):
         if not (
             silu_node.args
             and isinstance(silu_node.args[0], Node)
-            and is_linear_op(silu_node.args[0])
+            and is_linear_op(silu_node.args[0], include_quantization=True)
         ):
             continue
         linear_w1_node = silu_node.args[0]
 
         # The other branch should be a linear op (w3 branch).
         linear_w3_node = arg_b if arg_a is silu_node else arg_a
-        if not (isinstance(linear_w3_node, Node) and is_linear_op(linear_w3_node)):
+        if not (
+            isinstance(linear_w3_node, Node)
+            and is_linear_op(linear_w3_node, include_quantization=True)
+        ):
             continue
         if not (linear_w1_node.args and linear_w3_node.args):
             continue
 
-        input_node_w1 = linear_w1_node.args[0]
-        weight_w1 = linear_w1_node.args[1] if len(linear_w1_node.args) > 1 else None
-        weight_w3 = linear_w3_node.args[1] if len(linear_w3_node.args) > 1 else None
-        weight_w2 = final_linear.args[1] if len(final_linear.args) > 1 else None
+        # Extract parameters from each linear op.
+        input_node_w1, weight_w1, quant_params_w1, wt_type_w1 = _extract_linear_parameters(
+            linear_w1_node
+        )
+        _, weight_w3, quant_params_w3, wt_type_w3 = _extract_linear_parameters(linear_w3_node)
+        _, weight_w2, quant_params_w2, wt_type_w2 = _extract_linear_parameters(final_linear)
 
         if None in (weight_w1, weight_w3, weight_w2):
             continue
+
+        # Ensure the weight type is consistent across branches.
+        if wt_type_w1 != wt_type_w3 or wt_type_w1 != wt_type_w2:
+            continue
+        weight_type = wt_type_w1
 
         pattern_input_nodes.append(input_node_w1)
         pattern_output_nodes.append(final_linear)
@@ -312,7 +387,16 @@ def _match_expert_compute_pattern(start_boundary: Node, end_boundary: Node):
         expert_weights["w3"].append(weight_w3)
         expert_weights["w2"].append(weight_w2)
 
-    return pattern_input_nodes, pattern_output_nodes, expert_weights
+        # TODO: sanity check that all experts have same weight type
+        if weight_type == "fp8":
+            expert_scales["w1_input_scale"].append(quant_params_w1["input_scale"])
+            expert_scales["w1_weight_scale"].append(quant_params_w1["weight_scale"])
+            expert_scales["w3_input_scale"].append(quant_params_w3["input_scale"])
+            expert_scales["w3_weight_scale"].append(quant_params_w3["weight_scale"])
+            expert_scales["w2_input_scale"].append(quant_params_w2["input_scale"])
+            expert_scales["w2_weight_scale"].append(quant_params_w2["weight_scale"])
+
+    return pattern_input_nodes, pattern_output_nodes, expert_weights, expert_scales, weight_type
 
 
 def _find_final_hidden_state_node(

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/fused_moe.py
@@ -89,12 +89,22 @@ def match_moe_pattern(gm: GraphModule) -> GraphModule:
             elif weight_type == "fp4":
                 fused_moe_node = graph.call_function(
                     torch.ops.moe.torch_fp4_moe,
-                    args = (
-                        hidden_states, selected_experts, normalized_routing_weights,
-                        w1_list, w2_list, w3_list,
-                        expert_scales["w1_input_scale"], expert_scales["w2_input_scale"], expert_scales["w3_input_scale"],
-                        expert_scales["w1_weight_scale"], expert_scales["w2_weight_scale"], expert_scales["w3_weight_scale"],
-                        expert_scales["w1_alpha"],       expert_scales["w2_alpha"],       expert_scales["w3_alpha"],
+                    args=(
+                        hidden_states,
+                        selected_experts,
+                        normalized_routing_weights,
+                        w1_list,
+                        w2_list,
+                        w3_list,
+                        expert_scales["w1_input_scale"],
+                        expert_scales["w2_input_scale"],
+                        expert_scales["w3_input_scale"],
+                        expert_scales["w1_weight_scale"],
+                        expert_scales["w2_weight_scale"],
+                        expert_scales["w3_weight_scale"],
+                        expert_scales["w1_alpha"],
+                        expert_scales["w2_alpha"],
+                        expert_scales["w3_alpha"],
                     ),
                 )
             else:
@@ -296,19 +306,23 @@ def _extract_linear_parameters(linear_node: Node) -> tuple[Node, torch.Tensor, O
         return input_node, weight, {"input_scale": input_scale, "weight_scale": weight_scale}, "fp8"
     elif is_op(linear_node, torch.ops.quant.fp4_linear):
         weight = linear_node.args[1]
-        input_scale  = linear_node.kwargs.get("input_scale", None)
+        input_scale = linear_node.kwargs.get("input_scale", None)
         weight_scale = linear_node.kwargs.get("weight_scale", None)
-        alpha        = linear_node.kwargs.get("alpha", None)
+        alpha = linear_node.kwargs.get("alpha", None)
         # fallback to positional args if absent
         args = linear_node.args
-        if input_scale  is None and len(args) >= 4: input_scale  = args[3]
-        if weight_scale is None and len(args) >= 5: weight_scale = args[4]
-        if alpha        is None and len(args) >= 6: alpha        = args[5]
-        return input_node, weight, {
-            "input_scale":  input_scale,
-            "weight_scale": weight_scale,
-            "alpha":        alpha
-        }, "fp4"
+        if input_scale is None and len(args) >= 4:
+            input_scale = args[3]
+        if weight_scale is None and len(args) >= 5:
+            weight_scale = args[4]
+        if alpha is None and len(args) >= 6:
+            alpha = args[5]
+        return (
+            input_node,
+            weight,
+            {"input_scale": input_scale, "weight_scale": weight_scale, "alpha": alpha},
+            "fp4",
+        )
     elif is_op(linear_node, torch.ops.linear.simple):
         weight = linear_node.args[1]
         return input_node, weight, None, "simple"

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/fused_moe.py
@@ -86,6 +86,17 @@ def match_moe_pattern(gm: GraphModule) -> GraphModule:
                         expert_scales["w3_weight_scale"],
                     ),
                 )
+            elif weight_type == "fp4":
+                fused_moe_node = graph.call_function(
+                    torch.ops.moe.torch_fp4_moe,
+                    args = (
+                        hidden_states, selected_experts, normalized_routing_weights,
+                        w1_list, w2_list, w3_list,
+                        expert_scales["w1_input_scale"], expert_scales["w2_input_scale"], expert_scales["w3_input_scale"],
+                        expert_scales["w1_weight_scale"], expert_scales["w2_weight_scale"], expert_scales["w3_weight_scale"],
+                        expert_scales["w1_alpha"],       expert_scales["w2_alpha"],       expert_scales["w3_alpha"],
+                    ),
+                )
             else:
                 fused_moe_node = graph.call_function(
                     torch.ops.moe.torch_moe,
@@ -283,6 +294,21 @@ def _extract_linear_parameters(linear_node: Node) -> tuple[Node, torch.Tensor, O
         if weight_scale is None and len(linear_node.args) >= 5:
             weight_scale = linear_node.args[4]
         return input_node, weight, {"input_scale": input_scale, "weight_scale": weight_scale}, "fp8"
+    elif is_op(linear_node, torch.ops.quant.fp4_linear):
+        weight = linear_node.args[1]
+        input_scale  = linear_node.kwargs.get("input_scale", None)
+        weight_scale = linear_node.kwargs.get("weight_scale", None)
+        alpha        = linear_node.kwargs.get("alpha", None)
+        # fallback to positional args if absent
+        args = linear_node.args
+        if input_scale  is None and len(args) >= 4: input_scale  = args[3]
+        if weight_scale is None and len(args) >= 5: weight_scale = args[4]
+        if alpha        is None and len(args) >= 6: alpha        = args[5]
+        return input_node, weight, {
+            "input_scale":  input_scale,
+            "weight_scale": weight_scale,
+            "alpha":        alpha
+        }, "fp4"
     elif is_op(linear_node, torch.ops.linear.simple):
         weight = linear_node.args[1]
         return input_node, weight, None, "simple"
@@ -395,6 +421,16 @@ def _match_expert_compute_pattern(start_boundary: Node, end_boundary: Node):
             expert_scales["w3_weight_scale"].append(quant_params_w3["weight_scale"])
             expert_scales["w2_input_scale"].append(quant_params_w2["input_scale"])
             expert_scales["w2_weight_scale"].append(quant_params_w2["weight_scale"])
+        elif weight_type == "fp4":
+            expert_scales["w1_input_scale"].append(quant_params_w1["input_scale"])
+            expert_scales["w1_weight_scale"].append(quant_params_w1["weight_scale"])
+            expert_scales["w1_alpha"].append(quant_params_w1["alpha"])
+            expert_scales["w3_input_scale"].append(quant_params_w3["input_scale"])
+            expert_scales["w3_weight_scale"].append(quant_params_w3["weight_scale"])
+            expert_scales["w3_alpha"].append(quant_params_w3["alpha"])
+            expert_scales["w2_input_scale"].append(quant_params_w2["input_scale"])
+            expert_scales["w2_weight_scale"].append(quant_params_w2["weight_scale"])
+            expert_scales["w2_alpha"].append(quant_params_w2["alpha"])
 
     return pattern_input_nodes, pattern_output_nodes, expert_weights, expert_scales, weight_type
 

--- a/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
@@ -163,7 +163,9 @@ class InferenceOptimizer:
         # RESIZE CACHE
         ############################################################################################
         # Free memory ratio is hardcoded to 0.8 for now to ensure we have enough memory for graph capture.
-        resize_kv_cache(egm, cm, free_mem_ratio=0.8)
+        resize_kv_cache(
+            egm, cm, free_mem_ratio=0.8
+        )  # currently throw an error in cm.info._set_generate_only_batch() when this is enabled
 
         ############################################################################################
         # COMPILE MODEL

--- a/tensorrt_llm/_torch/auto_deploy/utils/quantization_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/quantization_utils.py
@@ -15,7 +15,7 @@ from .node_utils import (
 )
 
 try:
-    from ...quantization.utils import float4_sf_dtype
+    from tensorrt_llm.quantization.utils.fp4_utils import float4_sf_dtype
 except ImportError:
     float4_sf_dtype = None
 

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_ad_moe_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_ad_moe_op.py
@@ -22,9 +22,9 @@ def setup_moe_test(dtype, num_experts):
     NUM_EXPERTS = num_experts
     TOP_K = 2
 
-    torch.manual_seed(0)
-    torch.cuda.manual_seed(0)
-    x = torch.randn((SEQ_LEN, HIDDEN_SIZE), dtype=dtype).cuda() * 0.5
+    torch.manual_seed(1234)
+    torch.cuda.manual_seed(1234)  # seed=0 will fail
+    x = torch.rand(SEQ_LEN, HIDDEN_SIZE, dtype=dtype).cuda() * 0.1
 
     router_logits = torch.randn((SEQ_LEN, NUM_EXPERTS), dtype=torch.float32).cuda()
     routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
@@ -40,9 +40,9 @@ def setup_moe_test(dtype, num_experts):
     fused_w2_weight = torch.empty((NUM_EXPERTS, HIDDEN_SIZE, INTERMEDIATE_SIZE), dtype=dtype).cuda()
 
     for expert_id in range(NUM_EXPERTS):
-        w1 = torch.randn((INTERMEDIATE_SIZE, HIDDEN_SIZE), dtype=dtype).cuda() * 0.5
-        w2 = torch.randn((HIDDEN_SIZE, INTERMEDIATE_SIZE), dtype=dtype).cuda() * 0.5
-        w3 = torch.randn((INTERMEDIATE_SIZE, HIDDEN_SIZE), dtype=dtype).cuda() * 0.5
+        w1 = torch.rand(INTERMEDIATE_SIZE, HIDDEN_SIZE, dtype=dtype).cuda() * 0.1
+        w2 = torch.rand(HIDDEN_SIZE, INTERMEDIATE_SIZE, dtype=dtype).cuda() * 0.1
+        w3 = torch.rand(INTERMEDIATE_SIZE, HIDDEN_SIZE, dtype=dtype).cuda() * 0.1
 
         weights[f"{expert_id}.w1.weight"] = w1
         weights[f"{expert_id}.w2.weight"] = w2

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_ad_moe_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_ad_moe_op.py
@@ -1,18 +1,23 @@
+import os
+import sys
+
 import pytest
 import torch
 import torch.nn.functional as F
-from _torch.helpers import reference_moe_torch
+from _torch_test_utils import fp8_compatible
 
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
 from tensorrt_llm._torch.modules.fused_moe import FusedMoE  # noqa: F401
 
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../../../"))
+from helpers import reference_moe_torch
 
-@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-def test_moe_op_run(dtype):
+
+def setup_moe_test(dtype, num_experts):
     SEQ_LEN = 8
     HIDDEN_SIZE = 64
     INTERMEDIATE_SIZE = 32
-    NUM_EXPERTS = 3
+    NUM_EXPERTS = num_experts
     TOP_K = 2
 
     torch.manual_seed(0)
@@ -25,18 +30,18 @@ def test_moe_op_run(dtype):
     final_scales = final_scales / final_scales.sum(dim=-1, keepdim=True)
     final_scales = final_scales.to(x.dtype)
 
-    w1_weight = []
-    w2_weight = []
-    w3_weight = []
+    w1_weight, w2_weight, w3_weight = [], [], []
     weights = {}
     fused_w3_w1_stacked_weight = torch.empty(
         (NUM_EXPERTS, INTERMEDIATE_SIZE * 2, HIDDEN_SIZE), dtype=dtype
     ).cuda()
     fused_w2_weight = torch.empty((NUM_EXPERTS, HIDDEN_SIZE, INTERMEDIATE_SIZE), dtype=dtype).cuda()
+
     for expert_id in range(NUM_EXPERTS):
         w1 = torch.randn((INTERMEDIATE_SIZE, HIDDEN_SIZE), dtype=dtype).cuda() * 0.5
         w2 = torch.randn((HIDDEN_SIZE, INTERMEDIATE_SIZE), dtype=dtype).cuda() * 0.5
         w3 = torch.randn((INTERMEDIATE_SIZE, HIDDEN_SIZE), dtype=dtype).cuda() * 0.5
+
         weights[f"{expert_id}.w1.weight"] = w1
         weights[f"{expert_id}.w2.weight"] = w2
         weights[f"{expert_id}.w3.weight"] = w3
@@ -47,6 +52,34 @@ def test_moe_op_run(dtype):
 
         fused_w3_w1_stacked_weight.data[expert_id].copy_(torch.cat([w3, w1], dim=-2))
         fused_w2_weight.data[expert_id].copy_(w2)
+
+    return (
+        x,
+        selected_experts,
+        final_scales,
+        w1_weight,
+        w2_weight,
+        w3_weight,
+        weights,
+        fused_w3_w1_stacked_weight,
+        fused_w2_weight,
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_moe_op_run(dtype):
+    num_experts = 3
+    (
+        x,
+        selected_experts,
+        final_scales,
+        w1_weight,
+        w2_weight,
+        w3_weight,
+        weights,
+        fused_w3_w1_stacked_weight,
+        fused_w2_weight,
+    ) = setup_moe_test(dtype, num_experts)
 
     with torch.inference_mode():
         output_torch_moe = torch.ops.moe.torch_moe(
@@ -71,11 +104,81 @@ def test_moe_op_run(dtype):
             fused_w3_w1_stacked_weight,
             fused_w2_weight,
         )
-
-        ref_output = reference_moe_torch(x, selected_experts, final_scales, NUM_EXPERTS, weights)
+        ref_output = reference_moe_torch(x, selected_experts, final_scales, num_experts, weights)
 
     torch.cuda.synchronize()
     torch.testing.assert_close(output_trt_fused_moe, output_torch_fused_moe, rtol=5e-2, atol=5e-2)
     torch.testing.assert_close(output_trt_fused_moe, ref_output, rtol=5e-2, atol=5e-2)
     torch.testing.assert_close(output_torch_fused_moe, ref_output, rtol=1e-5, atol=1e-5)
     torch.testing.assert_close(output_torch_moe, ref_output, rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.skipif(not fp8_compatible(), reason="Requires fp8 support")
+def test_fp8_moe_op_run(dtype):
+    num_experts = 3
+    (
+        x,
+        selected_experts,
+        final_scales,
+        w1_weight,
+        w2_weight,
+        w3_weight,
+        weights,
+        fused_w3_w1_stacked_weight,
+        fused_w2_weight,
+    ) = setup_moe_test(dtype, num_experts)
+
+    with torch.inference_mode():
+        output_torch_moe = torch.ops.moe.torch_moe(
+            x,
+            selected_experts,
+            final_scales,
+            w1_weight,
+            w2_weight,
+            w3_weight,
+        )
+
+    w1_input_scale, w2_input_scale, w3_input_scale = [], [], []
+    w1_weight_scale, w2_weight_scale, w3_weight_scale = [], [], []
+    for i in range(num_experts):
+        inp_scale_val = torch.tensor(1.0).float().cuda()
+        wt_scale_factor = 448 if dtype == torch.bfloat16 else 432  # float16 overflow with 448
+        wt_scale_val = (torch.max(torch.abs(w1_weight[i])) / wt_scale_factor).float().to("cuda")
+        w1_input_scale.append(inp_scale_val)
+        w2_input_scale.append(inp_scale_val)
+        w3_input_scale.append(inp_scale_val)
+        w1_weight_scale.append(wt_scale_val)
+        w2_weight_scale.append(wt_scale_val)
+        w3_weight_scale.append(wt_scale_val)
+        # Cast the expert weight tensors and fused weights to FP8.
+        w1_weight[i] = (w1_weight[i] / w1_weight_scale[i]).to(torch.float8_e4m3fn)
+        w2_weight[i] = (w2_weight[i] / w2_weight_scale[i]).to(torch.float8_e4m3fn)
+        w3_weight[i] = (w3_weight[i] / w3_weight_scale[i]).to(torch.float8_e4m3fn)
+        fused_w3_w1_stacked_weight[i] = (fused_w3_w1_stacked_weight[i] / w1_weight_scale[i]).to(
+            torch.float8_e4m3fn
+        )
+        fused_w2_weight[i] = (fused_w2_weight[i] / w2_weight_scale[i]).to(torch.float8_e4m3fn)
+
+    with torch.inference_mode():
+        output_torch_fp8_moe = torch.ops.moe.torch_fp8_moe(
+            x,
+            selected_experts,
+            final_scales,
+            w1_weight,
+            w2_weight,
+            w3_weight,
+            w1_input_scale,
+            w2_input_scale,
+            w3_input_scale,
+            w1_weight_scale,
+            w2_weight_scale,
+            w3_weight_scale,
+        )
+        ref_output = reference_moe_torch(x, selected_experts, final_scales, num_experts, weights)
+
+    torch.cuda.synchronize()
+    rtol = 0.5 if dtype == torch.bfloat16 else 1.5
+    atol = 0.8 if dtype == torch.bfloat16 else 1
+    torch.testing.assert_close(output_torch_fp8_moe, output_torch_moe, rtol=rtol, atol=atol)
+    torch.testing.assert_close(output_torch_fp8_moe, ref_output, rtol=rtol, atol=atol)

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_ad_moe_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_ad_moe_op.py
@@ -4,14 +4,14 @@ import sys
 import pytest
 import torch
 import torch.nn.functional as F
-from _torch_test_utils import fp8_compatible
+from _torch_test_utils import fp8_compatible, fp4_compatible, trtllm_ops_available
 
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
 from tensorrt_llm._torch.modules.fused_moe import FusedMoE  # noqa: F401
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "../../../../"))
 from helpers import reference_moe_torch
-
+from tensorrt_llm._torch.auto_deploy.utils.quantization_utils import fp4_global_scale
 
 def setup_moe_test(dtype, num_experts):
     SEQ_LEN = 8
@@ -182,3 +182,98 @@ def test_fp8_moe_op_run(dtype):
     atol = 0.8 if dtype == torch.bfloat16 else 1
     torch.testing.assert_close(output_torch_fp8_moe, output_torch_moe, rtol=rtol, atol=atol)
     torch.testing.assert_close(output_torch_fp8_moe, ref_output, rtol=rtol, atol=atol)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.skipif(
+    not fp4_compatible() or not trtllm_ops_available(),
+    reason="Requires fp4 and trtllm support",
+)
+def test_fp4_moe_op_run(dtype):
+    num_experts = 3
+    (
+        x,
+        selected_experts,
+        final_scales,
+        w1_weight,
+        w2_weight,
+        w3_weight,
+        weights,
+        _,
+        _,
+    ) = setup_moe_test(dtype, num_experts)
+
+    with torch.inference_mode():
+        output_torch_moe = torch.ops.moe.torch_moe(
+            x,
+            selected_experts,
+            final_scales,
+            w1_weight,
+            w2_weight,
+            w3_weight,
+        )
+
+    # prepare FP4 scales and quantized weights
+    w1_input_scale, w2_input_scale, w3_input_scale = [], [], []
+    w1_weight_scale, w2_weight_scale, w3_weight_scale = [], [], []
+    w1_alpha, w2_alpha, w3_alpha = [], [], []
+    scaling_vector_size = 16
+
+    for i in range(num_experts):
+        inp_scale = fp4_global_scale(x)
+        wt_scale_2_w1 = fp4_global_scale(w1_weight[i])
+        wt_scale_2_w2 = fp4_global_scale(w2_weight[i])
+        wt_scale_2_w3 = fp4_global_scale(w3_weight[i])
+
+        # quantize weights
+        w1_fp4, w1_scale = torch.ops.trtllm.fp4_quantize(
+            w1_weight[i], wt_scale_2_w1, scaling_vector_size, False
+        )
+        w2_fp4, w2_scale = torch.ops.trtllm.fp4_quantize(
+            w2_weight[i], wt_scale_2_w2, scaling_vector_size, False
+        )
+        w3_fp4, w3_scale = torch.ops.trtllm.fp4_quantize(
+            w3_weight[i], wt_scale_2_w3, scaling_vector_size, False
+        )
+        w1_weight[i] = w1_fp4
+        w2_weight[i] = w2_fp4
+        w3_weight[i] = w3_fp4
+
+        # record scales and alpha
+        w1_input_scale.append(inp_scale)
+        w2_input_scale.append(inp_scale)
+        w3_input_scale.append(inp_scale)
+        w1_weight_scale.append(w1_scale)
+        w2_weight_scale.append(w2_scale)
+        w3_weight_scale.append(w3_scale)
+        w1_alpha.append(1 / (inp_scale * wt_scale_2_w1))
+        w2_alpha.append(1 / (inp_scale * wt_scale_2_w2))
+        w3_alpha.append(1 / (inp_scale * wt_scale_2_w3))
+
+    # run FP4 MoE op
+    with torch.inference_mode():
+        output_torch_fp4_moe = torch.ops.moe.torch_fp4_moe(
+            x,
+            selected_experts,
+            final_scales,
+            w1_weight,
+            w2_weight,
+            w3_weight,
+            w1_input_scale,
+            w2_input_scale,
+            w3_input_scale,
+            w1_weight_scale,
+            w2_weight_scale,
+            w3_weight_scale,
+            w1_alpha,
+            w2_alpha,
+            w3_alpha,
+        )
+        ref_output = reference_moe_torch(
+            x, selected_experts, final_scales, num_experts, weights
+        )
+
+    torch.cuda.synchronize()
+    rtol, atol = 1.5, 1.0
+    torch.testing.assert_close(output_torch_fp4_moe, output_torch_moe, rtol=rtol, atol=atol)
+    torch.testing.assert_close(output_torch_fp4_moe, ref_output, rtol=rtol, atol=atol)

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_ad_moe_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_ad_moe_op.py
@@ -4,14 +4,16 @@ import sys
 import pytest
 import torch
 import torch.nn.functional as F
-from _torch_test_utils import fp8_compatible, fp4_compatible, trtllm_ops_available
+from _torch_test_utils import fp4_compatible, fp8_compatible, trtllm_ops_available
 
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
 from tensorrt_llm._torch.modules.fused_moe import FusedMoE  # noqa: F401
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "../../../../"))
 from helpers import reference_moe_torch
+
 from tensorrt_llm._torch.auto_deploy.utils.quantization_utils import fp4_global_scale
+
 
 def setup_moe_test(dtype, num_experts):
     SEQ_LEN = 8
@@ -269,9 +271,7 @@ def test_fp4_moe_op_run(dtype):
             w2_alpha,
             w3_alpha,
         )
-        ref_output = reference_moe_torch(
-            x, selected_experts, final_scales, num_experts, weights
-        )
+        ref_output = reference_moe_torch(x, selected_experts, final_scales, num_experts, weights)
 
     torch.cuda.synchronize()
     rtol, atol = 1.5, 1.0

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_moe_fusion.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_moe_fusion.py
@@ -1,8 +1,10 @@
+import pytest
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from _graph_test_helpers import run_test
 from _model_test_utils import MoEOpModel
+from _torch_test_utils import fp8_compatible
 
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
 from tensorrt_llm._torch.auto_deploy.transformations.library.fused_moe import (
@@ -30,17 +32,89 @@ class BlockSparseTop2MLP(nn.Module):
         return current_hidden_states
 
 
+class BlockSparseTop2MLPFP8(nn.Module):
+    def __init__(self, ffn_dim, hidden_dim, dtype=torch.bfloat16, device="cuda"):
+        super().__init__()
+        self.ffn_dim = ffn_dim
+        self.hidden_dim = hidden_dim
+        # Input scale fixed to 1.0
+        self.register_buffer("inp_scale", torch.tensor(1.0, dtype=torch.float, device=device))
+        # FP8 weight scale factor depends on dtype
+        wt_factor = 448 if dtype == torch.bfloat16 else 432
+
+        w1_fp32 = torch.randn(ffn_dim, hidden_dim, device=device)
+        w3_fp32 = torch.randn(ffn_dim, hidden_dim, device=device)
+        w2_fp32 = torch.randn(hidden_dim, ffn_dim, device=device)
+        w1_scale = (w1_fp32.abs().max() / wt_factor).float().to(device)
+        w3_scale = (w3_fp32.abs().max() / wt_factor).float().to(device)
+        w2_scale = (w2_fp32.abs().max() / wt_factor).float().to(device)
+
+        self.register_buffer("w1_scale", w1_scale)
+        self.register_buffer("w3_scale", w3_scale)
+        self.register_buffer("w2_scale", w2_scale)
+
+        w1_fp8 = (w1_fp32 / w1_scale).to(torch.float8_e4m3fn)
+        w3_fp8 = (w3_fp32 / w3_scale).to(torch.float8_e4m3fn)
+        w2_fp8 = (w2_fp32 / w2_scale).to(torch.float8_e4m3fn)
+        self.register_parameter("w1_fp8", nn.Parameter(w1_fp8))
+        self.register_parameter("w3_fp8", nn.Parameter(w3_fp8))
+        self.register_parameter("w2_fp8", nn.Parameter(w2_fp8))
+        self.act_fn = F.silu
+
+    def forward(self, hidden_states: torch.Tensor):
+        x = hidden_states
+        w1_out = torch.ops.quant.fp8_linear(
+            x,
+            self.w1_fp8,
+            bias=None,
+            input_scale=self.inp_scale,
+            weight_scale=self.w1_scale,
+        )
+        w3_out = torch.ops.quant.fp8_linear(
+            x,
+            self.w3_fp8,
+            bias=None,
+            input_scale=self.inp_scale,
+            weight_scale=self.w3_scale,
+        )
+        fused = self.act_fn(w1_out) * w3_out
+        out = torch.ops.quant.fp8_linear(
+            fused,
+            self.w2_fp8,
+            bias=None,
+            input_scale=self.inp_scale,
+            weight_scale=self.w2_scale,
+        )
+        return out
+
+
 class BlockSparseMoE(nn.Module):
-    def __init__(self, hidden_size=32, num_experts=4, intermediate_size=16):
+    def __init__(
+        self,
+        hidden_size=32,
+        num_experts=4,
+        intermediate_size=16,
+        use_fp8: bool = False,
+        dtype=torch.bfloat16,
+        device="cuda",
+    ):
         super().__init__()
         self.hidden_size = hidden_size
         self.num_experts = num_experts
-        self.intermediate_size = intermediate_size
         self.top_k = 2
-        self.gate = nn.Linear(hidden_size, num_experts)
-        self.experts = nn.ModuleList(
-            [BlockSparseTop2MLP(intermediate_size, hidden_size) for _ in range(num_experts)]
-        )
+        self.gate = nn.Linear(hidden_size, num_experts, bias=False).to(device=device, dtype=dtype)
+        expert_cls = BlockSparseTop2MLPFP8 if use_fp8 else BlockSparseTop2MLP
+        if use_fp8:
+            self.experts = nn.ModuleList(
+                [
+                    expert_cls(intermediate_size, hidden_size, dtype, device)
+                    for _ in range(num_experts)
+                ]
+            )
+        else:
+            self.experts = nn.ModuleList(
+                [expert_cls(intermediate_size, hidden_size) for _ in range(num_experts)]
+            )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         batch_size, sequence_length, hidden_dim = hidden_states.shape
@@ -75,10 +149,15 @@ class BlockSparseMoE(nn.Module):
 
 
 class MoEPatternModel(nn.Module):
-    def __init__(self):
+    def __init__(self, use_fp8: bool = False):
         super().__init__()
         self.embedding = nn.Embedding(100, 32)
-        self.block_sparse_moe = BlockSparseMoE(hidden_size=32, num_experts=2, intermediate_size=16)
+        self.block_sparse_moe = BlockSparseMoE(
+            hidden_size=32,
+            num_experts=2,
+            intermediate_size=16,
+            use_fp8=use_fp8,
+        )
 
     def forward(self, x):
         embedded = F.embedding(x, self.embedding.weight)
@@ -91,19 +170,34 @@ class MoEPatternModel(nn.Module):
         return torch.randint(0, 100, (2, 10), device=device)
 
 
-def test_moe_matching():
+@pytest.mark.parametrize(
+    "use_fp8,expected_op,skip",
+    [
+        pytest.param(False, torch.ops.moe.torch_moe, False, id="simple"),
+        pytest.param(True, torch.ops.moe.torch_fp8_moe, not fp8_compatible(), id="fp8"),
+    ],
+)
+def test_moe_matching(use_fp8, expected_op, skip):
+    if skip:
+        pytest.skip("FP8 not supported on this hardware")
     device = "cuda"
-    model = MoEPatternModel().to(device=device, dtype=torch.bfloat16)
+
+    model = MoEPatternModel(use_fp8=use_fp8).to(device=device)
+    if not use_fp8:
+        model = model.to(dtype=torch.bfloat16)
+    else:
+        model.embedding = model.embedding.to(dtype=torch.bfloat16)
+        model.block_sparse_moe.gate = model.block_sparse_moe.gate.to(dtype=torch.bfloat16)
     x = model.get_input(device=device)
 
     _ = run_test(
         model,
         x,
         match_moe_pattern,
-        lambda gm: any(is_op(n, torch.ops.moe.torch_moe) for n in gm.graph.nodes),
-        lambda num_p_og: num_p_og,
-        atol=1e-3,
-        rtol=1e-3,
+        lambda gm: any(is_op(n, expected_op) for n in gm.graph.nodes),
+        lambda num: num,
+        atol=0.05 if use_fp8 else 1e-3,
+        rtol=0.01 if use_fp8 else 1e-3,
         test_load_hook=True,
         strict_loading=True,
     )


### PR DESCRIPTION
## Description

- [X] Step 1: update moe pattern matcher to handle fp8_linear in addition to linear. Also, add the corresponding torch_fp8_moe. 
- [X] Update FP4 for the same
- [X] Update EP sharding with quantized ops
- [ ] Step 2: Handle patched case. For this, update quantize() to be able to map torch_moe to torch_fp8_moe and torch_fp4_moe based on the information in the hf_quant_config.json
- [ ] Step 3: update fuse_moe to map torch_{fp4, fp8}_moe to trtllm_{fp4, fp8}_moe 


## tests

E2E run 
```
python build_and_run_ad.py --config '{"world_size":8, "model":"/home/fridahou/models/Mixtral-8x7B-Instruct-v0.1-FP8", "attn_backend
":"FlashInfer", "compile_backend":"torch-simple", "benchmark": false}'  --model-kwargs '{}'
```

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
