### PR TITLE
[AutoDeploy] HF factory improvements

### DIFF
--- a/examples/auto_deploy/.vscode/launch.json
+++ b/examples/auto_deploy/.vscode/launch.json
@@ -8,7 +8,7 @@
             "program": "build_and_run_ad.py",
             "args": [
                 "--config",
-                "{\"batch_size\": 2, \"page_size\": 16, \"world_size\": 2, \"compile_backend\": \"torch-simple\", \"attn_backend\": \"FlashInfer\", \"model\": \"meta-llama/Meta-Llama-3.1-8B-Instruct\", \"benchmark\": false}",
+                "{\"batch_size\": 2, \"page_size\": 16, \"world_size\": 2, \"compile_backend\": \"torch-simple\", \"attn_backend\": \"FlashInfer\",\"model_factory\": \"AutoModelForCausalLM\", \"model\": \"meta-llama/Meta-Llama-3.1-8B-Instruct\", \"benchmark\": false}",
                 "--model-kwargs",
                 "{}",
                 // "{\"num_hidden_layers\": 3}",

--- a/examples/auto_deploy/.vscode/settings.json
+++ b/examples/auto_deploy/.vscode/settings.json
@@ -4,7 +4,7 @@
     // Please also modify the .env file accordingly
     "terminal.integrated.env.linux": {
         "OMPI_MCA_opal_cuda_support": "true",
-        "LD_LIBRARY_PATH": "/lib/x86_64-linux-gnu:${env:HOME}/miniconda3/envs/tekit/lib:${env:LD_LIBRARY_PATH}",
+        "LD_LIBRARY_PATH": "/lib/x86_64-linux-gnu:<PATH-TO-CONDA-ENV>/lib:${env:LD_LIBRARY_PATH}",
     },
     // STANDARD SETTINGS, DO NOT MODIFY ////////////////////////////////////////////////////////////
     "python.envFile": "${workspaceFolder}/.vscode/.env",
@@ -23,7 +23,7 @@
     // https://code.visualstudio.com/updates/v1_81#_python
     // When that happens, we can remove the --ignore-glob flag and the gpu tests will be skipped
     "python.testing.pytestArgs": [
-        "./tests",
+        "./tests/unittest/_torch/auto_deploy",
         "--no-cov",
     ],
     "files.exclude": {

--- a/examples/auto_deploy/README.md
+++ b/examples/auto_deploy/README.md
@@ -67,21 +67,21 @@ The exported graph then undergoes a series of automated transformations, includi
 
 **Bring Your Own Model**: AutoDeploy leverages `torch.export` and dynamic graph pattern matching, enabling seamless integration for a wide variety of models without relying on hard-coded architectures.
 
-Additionally, we have officially verified and fully optimized support for the following models:
+Additionally, we have officially verified support for the following models:
 
 <details>
 <summary>Click to expand supported models list</summary>
 
-| Model Series | HF Model Card | Precision | World Size | Runtime | Compile Backend ||| Attention Backend |||
-|--------------|----------------------|-----------|------------|---------|-----------------|--------------------|--------------------|--------------------|----------|----------|
-|              |               |           |            |         | torch-simple    | torch-compile    | torch-opt          | TritonWithFlattenedInputs | FlashInfer | MultiHeadLatentAttention |
-| LLaMA        | meta-llama/Llama-2-7b-chat-hf<br>meta-llama/Meta-Llama-3.1-8B-Instruct<br>meta-llama/Llama-3.1-70B-Instruct<br>codellama/CodeLlama-13b-Instruct-hf | BF16 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ | ✅ | n/a |
-| Nvidia Minitron | nvidia/Llama-3_1-Nemotron-51B-Instruct<br>nvidia/Llama-3.1-Minitron-4B-Width-Base<br>nvidia/Llama-3.1-Minitron-4B-Depth-Base | BF16 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ | ✅ | n/a |
-| Nvidia Model Optimizer | nvidia/Llama-3.1-8B-Instruct-FP8<br>nvidia/Llama-3.1-405B-Instruct-FP8 | FP8 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ | ✅ | n/a |
-| DeepSeek     | deepseek-ai/DeepSeek-R1-Distill-Llama-70B | BF16 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ | ✅ | n/a |
-| Mistral      | mistralai/Mixtral-8x7B-Instruct-v0.1<br>mistralai/Mistral-7B-Instruct-v0.3 | BF16 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ | ✅ | n/a |
-| BigCode      | bigcode/starcoder2-15b | FP32 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ | ✅ | n/a |
-| Deepseek-V3      | deepseek-ai/DeepSeek-V3 | BF16 | 1,2,4 | demollm | ✅ | ❌ | ❌ | n/a | n/a | ✅ |
+| Model Series | HF Model Card | Model Factory | Precision | World Size | Runtime | Compile Backend ||| Attention Backend |||
+|--------------|----------------------|----------------|-----------|------------|---------|-----------------|--------------------|--------------------|--------------------|----------|----------|
+|              |               |            |           |            |         | torch-simple    | torch-compile    | torch-opt          | TritonWithFlattenedInputs | FlashInfer | MultiHeadLatentAttention |
+| LLaMA        | meta-llama/Llama-2-7b-chat-hf<br>meta-llama/Meta-Llama-3.1-8B-Instruct<br>meta-llama/Llama-3.1-70B-Instruct<br>codellama/CodeLlama-13b-Instruct-hf | AutoModelForCausalLM | BF16 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ | ✅ | n/a |
+| Nvidia Minitron | nvidia/Llama-3_1-Nemotron-51B-Instruct<br>nvidia/Llama-3.1-Minitron-4B-Width-Base<br>nvidia/Llama-3.1-Minitron-4B-Depth-Base | AutoModelForCausalLM | BF16 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ | ✅ | n/a |
+| Nvidia Model Optimizer | nvidia/Llama-3.1-8B-Instruct-FP8<br>nvidia/Llama-3.1-405B-Instruct-FP8 | AutoModelForCausalLM | FP8 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ | ✅ | n/a |
+| DeepSeek     | deepseek-ai/DeepSeek-R1-Distill-Llama-70B | AutoModelForCausalLM | BF16 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ | ✅ | n/a |
+| Mistral      | mistralai/Mixtral-8x7B-Instruct-v0.1<br>mistralai/Mistral-7B-Instruct-v0.3 | AutoModelForCausalLM | BF16 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ | ✅ | n/a |
+| BigCode      | bigcode/starcoder2-15b | AutoModelForCausalLM | FP32 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ | ✅ | n/a |
+| Deepseek-V3      | deepseek-ai/DeepSeek-V3 | AutoModelForCausalLM | BF16 | 1,2,4 | demollm | ✅ | ❌ | ❌ | n/a | n/a | ✅ |
 
 </details>
 

--- a/examples/auto_deploy/simple_config.py
+++ b/examples/auto_deploy/simple_config.py
@@ -21,7 +21,7 @@ class SimpleConfig:
     # If no `model` argument is provided, the checkpoint directory is used to infer the model
     # architecture.
     model: Optional[str] = None
-    model_factory: Literal["hf"] = "hf"
+    model_factory: Literal["AutoModelForCausalLM"] = "AutoModelForCausalLM"
     skip_loading_weights: bool = False  # only load the architecture, not the weights
     customize_tokenizer: bool = False  # True: tokenizer from the model factory, False: from LLM api
 

--- a/tensorrt_llm/_torch/auto_deploy/models/factory.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/factory.py
@@ -84,20 +84,20 @@ class ModelFactory(ABC):
         """Try prefetching checkpoint."""
         pass
 
-    def load_or_random_init(self, model: nn.Module, **kwargs):
+    def load_or_random_init(self, model: nn.Module, device: DeviceLikeType):
         """Load the checkpoint into the model or randomly initialize the model.
 
         Args:
             model: The model to load the checkpoint into. Note that the model does not need to be
                 the same model that is built above but it needs to have a state dict compatible with
                 the model built above.
-            **kwargs: Keyword arguments that will be passed to torch.load.
+            device: The device to load the model on.
         """
         ad_logger.info("Loading and initializing weights.")
         if self.skip_loading_weights:
-            self._load_random_init(model, **kwargs)
+            self._load_random_init(model, device)
         else:
-            self._load_checkpoint(model, **kwargs)
+            self._load_checkpoint(model, device)
 
     @staticmethod
     def _to_maybe_empty(model: nn.Module, device: DeviceLikeType):
@@ -114,25 +114,25 @@ class ModelFactory(ABC):
         )
 
     @classmethod
-    def _load_random_init(cls, model: nn.Module, **kwargs):
+    def _load_random_init(cls, model: nn.Module, device: DeviceLikeType):
         """Randomly initialize model."""
-        cls._to_maybe_empty(model, kwargs.get("map_location"))
+        cls._to_maybe_empty(model, device)
         state_dict = model.state_dict()
         for k in state_dict:
-            state_dict[k] = torch.normal(
-                0.0, 1.0, size=state_dict[k].shape, device=kwargs.get("map_location")
-            ).to(state_dict[k].dtype)
-        model.load_state_dict(state_dict, strict=True)
+            state_dict[k] = torch.normal(0.0, 1.0, size=state_dict[k].shape, device=device).to(
+                state_dict[k].dtype
+            )
+        model.load_state_dict(state_dict, strict=True, assign=True)
 
     @abstractmethod
-    def _load_checkpoint(self, model: nn.Module, **kwargs):
+    def _load_checkpoint(self, model: nn.Module, device: DeviceLikeType):
         """Load the checkpoint into the model.
 
         Args:
             model: The model to load the checkpoint into. Note that the model does not need to be
                 the same model that is built above but it needs to have a state dict compatible with
                 the model built above.
-            **kwargs: Keyword arguments that will be passed to torch.load.
+            device: The device to load the model on.
         """
 
 

--- a/tensorrt_llm/_torch/auto_deploy/models/factory.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/factory.py
@@ -14,8 +14,9 @@ from ..utils.logger import ad_logger
 class ModelFactory(ABC):
     """An interface to return and correctly initialize a model from a desired source.
 
-    NOTE: we make the assumption that the model can be prompted with a set of input_ids of shape
-    (batch_size, seq_len) and will return a tensor of shape (batch_size, seq_len, embedding_size).
+    NOTE: we make the assumption that the model can be prompted with a set of input_ids and
+    position_ids of shape (batch_size, seq_len) and will return a tensor of shape
+    (batch_size, seq_len, embedding_size).
     """
 
     def __init__(self, model: Optional[str] = None, skip_loading_weights: bool = False, **kwargs):
@@ -47,16 +48,16 @@ class ModelFactory(ABC):
                 self, input_ids: torch.Tensor, position_ids: torch.Tensor
             ) -> Sequence[torch.Tensor]: ...
 
-        ``logits`` are assumeg to be the first output of the model, i.e.,
+        ``logits`` are assumed to be the first output of the model, i.e.,
         ``model(input_ids, position_ids)[0]`` should return a ``logits`` tensor.
 
         Moreover, we assume the following tensor shapes:
 
         .. code-block:: python
 
-            input_ids.shape = (batch_size, seq_len)
-            position_ids.shape = (batch_size, seq_len)
-            logits.shape = (batch_size, seq_len, vocab_size)
+            input_ids.shape == (batch_size, seq_len)
+            position_ids.shape == (batch_size, seq_len)
+            logits.shape == (batch_size, seq_len, vocab_size)
         """
 
     def get_quant_config(self) -> Dict:

--- a/tensorrt_llm/_torch/auto_deploy/models/hf.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/hf.py
@@ -8,12 +8,12 @@ from typing import Any, Dict, Optional
 
 import torch
 import torch.nn as nn
-from accelerate import init_empty_weights
+from accelerate import init_empty_weights, load_checkpoint_and_dispatch
+from accelerate.utils import modeling
 from huggingface_hub import snapshot_download
 from huggingface_hub.utils import HFValidationError, validate_repo_id
 from torch._prims_common import DeviceLikeType
-from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
-from transformers.modeling_utils import load_sharded_checkpoint, load_state_dict
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, PretrainedConfig
 
 from ..custom_ops.attention_interface import CacheConfig
 from ..utils.logger import ad_logger
@@ -45,22 +45,29 @@ def load_state_dict_with_assign():
         torch.nn.Module.load_state_dict = original_load_state_dict
 
 
-def _to_maybe_empty(model: nn.Module, device: DeviceLikeType):
-    """A mix of ``model.to(device)`` and ``model.to_empty(device)``.
+@contextmanager
+def hf_load_state_dict_with_device(device: DeviceLikeType):
+    """Patch HF load_state_dict to use provided device."""
+    # save the original load_state_dict method
+    original_load_state_dict = modeling.load_state_dict
 
-    If a parameter is already initialized, then we will call `to()` on it. Otherwise, we will
-    initialize it with an empty tensor on the given device.
+    # Define and apply the patched version
+    def load_state_dict_with_device(checkpoint_file, device_map=None):
+        assert device_map is None, "device_map not expected while using patch."
+        return original_load_state_dict(checkpoint_file, device_map={"": device})
 
-    """
-    model._apply(
-        lambda t: torch.empty_like(t, device=device)
-        if t.device == torch.device("meta")
-        else t.to(device)
-    )
+    # Apply the patch
+    modeling.load_state_dict = load_state_dict_with_device
+
+    try:
+        yield
+    finally:
+        # Restore the original method, even if an exception occurred
+        modeling.load_state_dict = original_load_state_dict
 
 
-@ModelFactoryRegistry.register("hf")
-class HFFactory(ModelFactory):
+@ModelFactoryRegistry.register("AutoModelForCausalLM")
+class AutoModelForCausalLMFactory(ModelFactory):
     def __init__(
         self,
         model_kwargs: Optional[Dict[str, Any]] = None,
@@ -70,9 +77,11 @@ class HFFactory(ModelFactory):
         super().__init__(**kwargs)
 
         self.model_kwargs = model_kwargs or {}
-        self.model_kwargs["use_cache"] = False
         self.tokenizer_kwargs = tokenizer_kwargs or {}
         self._quant_config = None
+
+        # heuristic to disable use_cache
+        self.model_kwargs["use_cache"] = False
 
         # prefetch the model+checkpoint
         self.prefetch_checkpoint()
@@ -100,21 +109,49 @@ class HFFactory(ModelFactory):
         """
         return type(model).forward(model, input_ids=input_ids, position_ids=position_ids)
 
+    def _recursive_update_config(self, config: PretrainedConfig, update_dict: Dict[str, Any]):
+        """
+        Recursively update a PretrainedConfig object with values from update_dict.
+
+        Args:
+            config: PretrainedConfig object to update
+            update_dict: Dictionary with values to update in the config
+
+        Returns:
+            The updated PretrainedConfig object
+        """
+        for key, value_new in update_dict.items():
+            # Check if the key exists in config
+            if not hasattr(config, key):
+                continue
+
+            target_value = getattr(config, key)
+
+            # Handle nested PretrainedConfig objects...
+            if isinstance(value_new, dict) and isinstance(target_value, PretrainedConfig):
+                # Recursively update nested configs
+                updated_value = self._recursive_update_config(target_value, value_new)
+                setattr(config, key, updated_value)
+            else:
+                # Direct update for simple values
+                setattr(config, key, value_new)
+
+        return config
+
     def build_model(self, device: DeviceLikeType) -> nn.Module:
         """Build the model on the desired device."""
         # We only support fp16 to fp4 conversion.
         if self._quant_config and self._quant_config.get("quant_algo", None) == "NVFP4":
             self.model_kwargs["torch_dtype"] = torch.half
 
-        model_config = self.autoconfig_from_pretrained(
-            self.model, trust_remote_code=True, **self.model_kwargs
-        )
+        # NOTE (lucaslie): HF doesn't recursively update nested PreTrainedConfig objects. Instead,
+        # the entire subconfig will be overwritten.
+        # we want to recursively update model_config from model_kwargs here.
+        model_config = self.autoconfig_from_pretrained(self.model, trust_remote_code=True)
+        model_config = self._recursive_update_config(model_config, self.model_kwargs)
 
         with (init_empty_weights if device == "meta" else nullcontext)():
-            default_dtype = torch.get_default_dtype()
-            torch.set_default_dtype(model_config.torch_dtype)
             model = self.automodel_from_config(model_config, trust_remote_code=True)
-            torch.set_default_dtype(default_dtype)
 
         # post-init --> this must be called explicitly for HF models the way we initialize them since
         # this "gets lost" with the init_empty_weights context manager.
@@ -163,10 +200,10 @@ class HFFactory(ModelFactory):
             is_hf_repo = False
         if is_hf_repo:
             # we don't expect to use bin files or pt/pth checkpoint files (they are quite large)
-            ignore_patterns = ["**pytorch_model*.bin*", "**.pt", "**.pth"]
+            ignore_patterns = ["*.bin", "*.pt", "*.pth"]
             # we will also ignore the .safetensors files if we skip loading weights
             if self.skip_loading_weights:
-                ignore_patterns.append("**safetensors")
+                ignore_patterns.append("*.safetensors")
             ad_logger.info("Pre-fetching checkpoint directory from HF repo.")
             fetched_dir = snapshot_download(self.model, ignore_patterns=ignore_patterns)
         else:
@@ -177,7 +214,7 @@ class HFFactory(ModelFactory):
 
         self._prefetched_path = fetched_dir
 
-    def _load_checkpoint(self, model, **kwargs):
+    def _load_checkpoint(self, model: nn.Module, device: DeviceLikeType):
         """Load the checkpoint into the model."""
         # check if we skip loading weights
         if self.skip_loading_weights:
@@ -186,31 +223,9 @@ class HFFactory(ModelFactory):
         # prefetch if needed
         self.prefetch_checkpoint()
 
-        ckpt_path = self.model
-
-        # sharded checkpoint
-        if os.path.isfile(os.path.join(ckpt_path, "model.safetensors.index.json")):
-            _to_maybe_empty(model, device="cpu")
-            with load_state_dict_with_assign():
-                load_sharded_checkpoint(model, ckpt_path, strict=False)
-            return
-
-        # look for a single file in the directory ending with .safetensors or .pt/.pth
-        safetensors_files = [f for f in os.listdir(ckpt_path) if f.endswith(".safetensors")]
-        torch_files = [f for f in os.listdir(ckpt_path) if f.endswith((".pt", ".pth"))]
-        if len(safetensors_files) > 1:
-            raise ValueError(f"Multiple .safetensors files in {ckpt_path}: {safetensors_files}")
-        elif len(safetensors_files) == 1:
-            state_dict = load_state_dict(os.path.join(ckpt_path, safetensors_files[0]))
-        elif len(torch_files) > 1:
-            raise ValueError(f"Multiple .pt/.pth files found in {ckpt_path}: {torch_files}")
-        elif len(torch_files) == 1:
-            state_dict = torch.load(os.path.join(ckpt_path, torch_files[0]), **kwargs)
-        else:
-            raise ValueError(f"No checkpoint found in {ckpt_path}")
-
-        with load_state_dict_with_assign():
-            model.load_state_dict(state_dict, strict=False)
+        # reuse the load checkpoint utility from accelerate
+        with load_state_dict_with_assign(), hf_load_state_dict_with_device(device):
+            load_checkpoint_and_dispatch(model, checkpoint=self.model)
 
     def _load_quantization_config(self):
         assert self.model

--- a/tensorrt_llm/_torch/auto_deploy/models/hf.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/hf.py
@@ -4,7 +4,7 @@ import json
 import os
 import types
 from contextlib import contextmanager, nullcontext
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Mapping, Optional
 
 import torch
 import torch.nn as nn
@@ -31,8 +31,10 @@ def load_state_dict_with_assign():
     original_load_state_dict = torch.nn.Module.load_state_dict
 
     # Define and apply the patched version
-    def load_state_dict_with_assign(*args, **kwargs):
-        return original_load_state_dict(*args, **kwargs, assign=True)
+    def load_state_dict_with_assign(
+        self, state_dict: Mapping[str, Any], strict: bool = True, assign: bool = False
+    ):
+        return original_load_state_dict(self, state_dict, strict=strict, assign=True)
 
     # Apply the patch
     torch.nn.Module.load_state_dict = load_state_dict_with_assign
@@ -53,7 +55,6 @@ def hf_load_state_dict_with_device(device: DeviceLikeType):
 
     # Define and apply the patched version
     def load_state_dict_with_device(checkpoint_file, device_map=None):
-        assert device_map is None, "device_map not expected while using patch."
         return original_load_state_dict(checkpoint_file, device_map={"": device})
 
     # Apply the patch

--- a/tensorrt_llm/_torch/auto_deploy/shim/demollm.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/demollm.py
@@ -372,7 +372,7 @@ class DemoLLM(LLM):
         self.mpi_session = None
         self.runtime_context = None
         self._tokenizer = self._try_load_tokenizer()
-        self.input_processor = create_input_processor(model, self.tokenizer)
+        self.input_processor = create_input_processor(None, self.tokenizer)
 
         # construct sequence info object
         seq_info = SequenceInfo(

--- a/tensorrt_llm/_torch/auto_deploy/shim/interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/interface.py
@@ -88,7 +88,7 @@ GetInferenceModel = Callable[[CachedSequenceInterface], nn.Module]
 @dataclass
 class AutoDeployConfig(PyTorchConfig):
     # model factory to choose from
-    model_factory: str = "hf"  # only 'hf' supported for "trtllm" runtime
+    model_factory: str = "AutoModelForCausalLM"
 
     ### MODEL EXTRA KWARGS ###
     # Extra kwargs for the model config class to customize the model config. Those arguments will

--- a/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
@@ -155,7 +155,7 @@ class InferenceOptimizer:
         ############################################################################################
 
         # load weights
-        self.factory.load_or_random_init(egm, mmap=True, map_location=cm.device)
+        self.factory.load_or_random_init(egm, device=cm.device)
 
         # move remaining parts to device
         move_to_device(egm, cm.device)

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_hf.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_hf.py
@@ -1,0 +1,154 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+import torch.nn as nn
+from accelerate.utils import modeling
+from transformers.models.llama4.configuration_llama4 import Llama4Config
+
+from tensorrt_llm._torch.auto_deploy.models.hf import (
+    AutoModelForCausalLMFactory,
+    hf_load_state_dict_with_device,
+    load_state_dict_with_assign,
+)
+
+
+class SimpleModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(10, 10)
+
+
+def test_load_state_dict_with_assign():
+    """Test that load_state_dict_with_assign correctly patches torch.nn.Module.load_state_dict."""
+    # Instead of trying to test the implementation details of the context manager,
+    # let's focus on testing its behavior - that it causes assign=True to be used
+
+    # First, let's check the behavior when assign=True is used directly
+    model1 = SimpleModel()
+    model2 = SimpleModel()
+
+    # Create a state dict with modified parameters
+    new_weight = torch.randn_like(model1.linear.weight)
+    new_bias = torch.randn_like(model1.linear.bias)
+    state_dict = {"linear.weight": new_weight, "linear.bias": new_bias}
+
+    # Load with assign=True explicitly
+    model1.load_state_dict(state_dict, assign=True)
+
+    # Now load with the context manager
+    with load_state_dict_with_assign():
+        model2.load_state_dict(state_dict)
+
+    # Both models should have identical parameters
+    assert torch.all(model1.linear.weight == model2.linear.weight)
+    assert torch.all(model1.linear.bias == model2.linear.bias)
+
+    # And both should match the new values
+    assert torch.all(model1.linear.weight == new_weight)
+    assert torch.all(model2.linear.weight == new_weight)
+
+
+def test_hf_load_state_dict_with_device():
+    """Test that hf_load_state_dict_with_device correctly patches modeling.load_state_dict."""
+    # Create mock for original load_state_dict
+    original_load_state_dict = MagicMock()
+
+    # Test with CPU device
+    with patch.object(modeling, "load_state_dict", original_load_state_dict):
+        with hf_load_state_dict_with_device(device="cpu"):
+            # Call the patched function
+            modeling.load_state_dict("dummy_checkpoint")
+
+            # Check that device was set correctly
+            original_load_state_dict.assert_called_once_with(
+                "dummy_checkpoint", device_map={"": "cpu"}
+            )
+
+            # Reset mock for next test
+            original_load_state_dict.reset_mock()
+
+        # Check that original behavior is restored
+        modeling.load_state_dict("dummy_checkpoint", device_map="original_device_map")
+        original_load_state_dict.assert_called_once_with(
+            "dummy_checkpoint", device_map="original_device_map"
+        )
+        original_load_state_dict.reset_mock()
+
+    # Test with CUDA device (if available)
+    if torch.cuda.is_available():
+        with patch.object(modeling, "load_state_dict", original_load_state_dict):
+            with hf_load_state_dict_with_device(device="cuda"):
+                # Call the patched function
+                modeling.load_state_dict("dummy_checkpoint")
+
+                # Check that device was set correctly
+                original_load_state_dict.assert_called_once_with(
+                    "dummy_checkpoint", device_map={"": "cuda"}
+                )
+
+
+@pytest.fixture
+def mock_factory():
+    with (
+        patch.object(AutoModelForCausalLMFactory, "prefetch_checkpoint"),
+        patch.object(AutoModelForCausalLMFactory, "_load_quantization_config"),
+    ):
+        # Create factory instance with mocked methods to avoid HTTP requests
+        factory = AutoModelForCausalLMFactory(model="dummy_model")
+        # Set model path directly to avoid prefetch
+        factory._prefetched_path = "/dummy/path"
+        yield factory
+
+
+def test_recursive_update_config(mock_factory):
+    """Test that _recursive_update_config correctly updates a config object recursively."""
+    # Get the mocked factory instance
+    factory = mock_factory
+
+    # Create a Llama4Config instance
+    config = Llama4Config()
+
+    # Create an update dictionary with both simple and nested values
+    update_dict = {
+        "bos_token_id": 42,  # Simple value at root level
+        "text_config": {  # Nested config update
+            "hidden_size": 4096,
+            "num_attention_heads": 32,
+        },
+        "vision_config": {  # Another nested config update
+            "hidden_size": 1024,
+            "image_size": 224,
+        },
+        "non_existent_key": "this should be ignored",  # This key doesn't exist in the config
+    }
+
+    # Apply the recursive update
+    updated_config = factory._recursive_update_config(config, update_dict)
+
+    # Check that it returns the same object
+    assert updated_config is config
+
+    # Check root level updates
+    assert config.bos_token_id == 42
+
+    # Check nested updates in text_config
+    assert config.text_config.hidden_size == 4096
+    assert config.text_config.num_attention_heads == 32
+
+    # Check nested updates in vision_config
+    assert config.vision_config.hidden_size == 1024
+    assert config.vision_config.image_size == 224
+
+    # Check that non-existent keys were ignored
+    assert not hasattr(config, "non_existent_key")
+
+    # Create a more complex update with deeper nesting
+    complex_update = {"text_config": {"rope_scaling": {"factor": 2.0, "type": "linear"}}}
+
+    # Apply the recursive update again
+    factory._recursive_update_config(config, complex_update)
+
+    # Check that complex nested updates were applied correctly
+    assert config.text_config.rope_scaling["factor"] == 2.0
+    assert config.text_config.rope_scaling["type"] == "linear"


### PR DESCRIPTION
This PR introduces several improvements to our HF model factory:

- [x] Change name to `AutoModelForCausalLM` to reflect there are separate factories for different auto model types
- [x] Better loading reusing HF utilities
- [x] Ability to correctly customize tokenizer from native HF if desired


## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
