### PR TITLE
[None][feat] Multi-block mode for Hopper spec dec XQA kernel

### DIFF
--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplCommon.h
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplCommon.h
@@ -381,5 +381,87 @@ inline int computeMultiBlockCountForMLA(XQAParams const& xqaParams, int multipro
     return 1; // disable multi-block for MLA kernel for now.
 }
 
+inline int computeMultiBlockCountSpecDecGMMA(
+    XQAParams const& xqaParams, int batch_size, int multiprocessor_count, int specDecBlocks)
+{
+    auto const userSpecified = tensorrt_llm::common::getEnvXqaBlocksPerSequence();
+    if (userSpecified.has_value())
+    {
+        return userSpecified.value();
+    }
+    int multi_block_count = 1;
+
+    int num_kv_heads = xqaParams.num_kv_heads;
+    int history_length = xqaParams.max_past_kv_length;
+
+    // skip tuning for large BS or short ISL case.
+    if (batch_size > 32 || history_length < 2048)
+    {
+        return multi_block_count;
+    }
+
+    // gridDim = dim3{specDecBlocks, multi_block, nbKVHeads * xqaParams.batch_size}
+    int single_block_count = specDecBlocks * num_kv_heads * batch_size;
+    double wave_count = (double) single_block_count / (double) multiprocessor_count;
+
+    // Multi block tuning for low CTA: populating CTAs to at most 1 wave of SMs
+    if (wave_count < 1)
+    {
+        auto highestPowerof2 = [](int x)
+        {
+            x |= x >> 1;
+            x |= x >> 2;
+            x |= x >> 4;
+            x |= x >> 8;
+            x |= x >> 16;
+            return x ^ (x >> 1);
+        };
+
+        // calculate the maximum blocks to be populated at most 1 wave
+        multi_block_count = floor(multiprocessor_count / single_block_count);
+        // make multi_block_count a power of 2 for tuning convenience.
+        multi_block_count = highestPowerof2(multi_block_count);
+        // make multi_block_count at most 64 and at least 1.
+        multi_block_count = std::min(multi_block_count, 64);
+        multi_block_count = std::max(multi_block_count, 1);
+
+        // tune only when original CTA is too small, multi_block_count is too big, and history length < 2^16
+        // For Hopper, most cases there are 114, 132, 144 SMs. For H20 about 78.
+        // single_block_count = [1..8]
+        // multi_block_count = [16,32,64,128]
+        // history_length = [1024..65536]
+        if (single_block_count <= 8 && multi_block_count >= 16 && history_length < 65536)
+        {
+            if (history_length < 2048)
+            {
+                // for history length < 2048 and low CTA, scaling is not effective, so we set a hard limit to
+                // multi_block_count = 4
+                multi_block_count = std::min(multi_block_count, 4);
+            }
+            else if (history_length < 65536)
+            {
+                // at single_block == 8, multi_block_count can only be 16. (SM / 8 ~= 16)
+                // tune only 2048 <= kvlen < 8192
+                if (single_block_count == 8 && history_length <= 8192)
+                {
+                    multi_block_count >>= 1;
+                }
+                else
+                {
+                    auto getLog2 = [](int x) { return x ? 31 - __builtin_clz(x) : -1; };
+                    auto history_length_log2 = getLog2(history_length);
+                    multi_block_count >>= 3 - (history_length_log2 - 10) / 2;
+                    // 2^15 (< 65536) -> shift 1
+                    // 2^13, 2^14 -> shift 2
+                    // 2^11, 2^12 (> 1024) -> shift 3
+                }
+            }
+        }
+        TLLM_CHECK_WITH_INFO((multi_block_count * single_block_count) <= multiprocessor_count,
+            "The adjusted MultiBlock exceed number of SMs, adding additional wave may result to perf drop.");
+    }
+    return multi_block_count;
+}
+
 } // namespace kernels
 } // namespace tensorrt_llm

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplCommon.h
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplCommon.h
@@ -450,10 +450,13 @@ inline int computeMultiBlockCountSpecDecGMMA(
                 {
                     auto getLog2 = [](int x) { return x ? 31 - __builtin_clz(x) : -1; };
                     auto history_length_log2 = getLog2(history_length);
+                    // Adjust multi_block_count based on history length using formula:
+                    // shift_amount = 3 - (log2(history_length) - 10) / 2
+                    // This gives us:
+                    // - history_length in [2^11, 2^12): shift by 3
+                    // - history_length in [2^13, 2^14): shift by 2
+                    // - history_length in [2^15, 2^16): shift by 1
                     multi_block_count >>= 3 - (history_length_log2 - 10) / 2;
-                    // 2^15 (< 65536) -> shift 1
-                    // 2^13, 2^14 -> shift 2
-                    // 2^11, 2^12 (> 1024) -> shift 3
                 }
             }
         }

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/decoderXQAImplJIT.cpp
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/decoderXQAImplJIT.cpp
@@ -441,13 +441,15 @@ void DecoderXQAImplJIT::runImpl(XQAParams const& xqaParams, KVCacheBuffer const&
         uint32_t multi_block = 1;
         if (xqaParams.multi_block_mode)
         {
-            multi_block = computeMultiBlockCount(xqaParams, xqaParams.batch_size, multiprocessor_count);
-        }
-        // A WAR to enable Hopper XQA multi-token multi_block mode
-        if (isSpecDec && isGMMAKernel)
-        {
-            multi_block = computeMultiBlockCountSpecDecGMMA(
-                xqaParams, xqaParams.batch_size, multiprocessor_count, specDecBlocks);
+            if (isSpecDec && isGMMAKernel)
+            {
+                multi_block = computeMultiBlockCountSpecDecGMMA(
+                    xqaParams, xqaParams.batch_size, multiprocessor_count, specDecBlocks);
+            }
+            else
+            {
+                multi_block = computeMultiBlockCount(xqaParams, xqaParams.batch_size, multiprocessor_count);
+            }
         }
         uint32_t const nbKVHeads = xqaParams.num_kv_heads;
         auto const gridDim = (isGMMAKernel ? dim3{specDecBlocks, multi_block, nbKVHeads * xqaParams.batch_size}

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/decoderXQAImplJIT.cpp
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/decoderXQAImplJIT.cpp
@@ -443,6 +443,12 @@ void DecoderXQAImplJIT::runImpl(XQAParams const& xqaParams, KVCacheBuffer const&
         {
             multi_block = computeMultiBlockCount(xqaParams, xqaParams.batch_size, multiprocessor_count);
         }
+        // A WAR to enable Hopper XQA multi-token multi_block mode
+        if (isSpecDec && isGMMAKernel)
+        {
+            multi_block = computeMultiBlockCountSpecDecGMMA(
+                xqaParams, xqaParams.batch_size, multiprocessor_count, specDecBlocks);
+        }
         uint32_t const nbKVHeads = xqaParams.num_kv_heads;
         auto const gridDim = (isGMMAKernel ? dim3{specDecBlocks, multi_block, nbKVHeads * xqaParams.batch_size}
                                            : dim3{multi_block, nbKVHeads, xqaParams.batch_size});

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/decoderXQAImplJIT.cpp
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/decoderXQAImplJIT.cpp
@@ -446,7 +446,7 @@ void DecoderXQAImplJIT::runImpl(XQAParams const& xqaParams, KVCacheBuffer const&
                 multi_block = computeMultiBlockCountSpecDecGMMA(
                     xqaParams, xqaParams.batch_size, multiprocessor_count, specDecBlocks);
             }
-            else
+            else if (!isSpecDec)
             {
                 multi_block = computeMultiBlockCount(xqaParams, xqaParams.batch_size, multiprocessor_count);
             }

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplPrecompiled.cpp
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplPrecompiled.cpp
@@ -287,14 +287,8 @@ public:
             void* kernelParams[] = {&maxQSeqLen, &launchParams.num_k_heads, &headGrpSize, &cuQSeqLens,
                 &launchParams.output, &xqa_q_input_ptr, &maskPtr, &launchParams.kvCacheParams, &launchParams.batch_size,
                 &launchParams.kv_scale_quant_orig, &launchParams.scratch};
+            // precompiled XQA Spec-dec kernel does not support multi-block mode
             int multi_block = 1;
-            if (xqaParams.multi_block_mode)
-            {
-                multi_block = computeMultiBlockCount(xqaParams, xqaParams.batch_size, multiprocessor_count);
-                check_cuda_error(cudaMemsetAsync(xqaParams.workspaces, 0,
-                    sizeof(int) * xqaParams.batch_size * qSeqLen * xqaParams.num_kv_heads, stream));
-                sync_check_cuda_error(stream);
-            }
             TLLM_CU_CHECK(mDriver->cuLaunchKernel(func, multi_block, xqaParams.num_kv_heads * nbTokenBlocksPerGrp,
                 xqaParams.batch_size, 128, 1, 2, shared_mem_bytes, stream, kernelParams, nullptr));
         }

--- a/cpp/tensorrt_llm/plugins/gptAttentionCommon/gptAttentionCommon.cpp
+++ b/cpp/tensorrt_llm/plugins/gptAttentionCommon/gptAttentionCommon.cpp
@@ -72,8 +72,7 @@ GPTAttentionPluginCommon::GPTAttentionPluginCommon(int layer_idx, int num_heads,
     mMaskType = mask_type;
     mBlockSparseParams = block_sparse_params;
     mType = type;
-    mMultiBlockMode
-        = is_spec_decoding_enabled ? false : true; // set to true in build time to account for enough workspace size
+    mMultiBlockMode = true;
     mEnableXQA = true;
     mKVCacheQuantMode = tc::QuantMode(kv_cache_quant_mode);
     mRemovePadding = remove_input_padding;

--- a/cpp/tensorrt_llm/plugins/gptAttentionPlugin/gptAttentionPlugin.cpp
+++ b/cpp/tensorrt_llm/plugins/gptAttentionPlugin/gptAttentionPlugin.cpp
@@ -703,8 +703,6 @@ int GPTAttentionPlugin::enqueueSome(int32_t seqIdxBeg, int32_t localNbSeq, int32
             = static_cast<bool>(reinterpret_cast<int const*>(inputs[getIdx(IdxEntry::SPEC_DECODING_USE)])[0]);
         changeSpecDecodingMode = mUseSpecDecoding != useSpecDecoding;
         mUseSpecDecoding = useSpecDecoding;
-        // change mMultiBlockMode to default
-        mMultiBlockMode = mUseSpecDecoding ? false : true;
     }
 
     [[maybe_unused]] MlaParams<T> mla_params;

--- a/cpp/tensorrt_llm/plugins/gptAttentionPlugin/gptAttentionPlugin.cpp
+++ b/cpp/tensorrt_llm/plugins/gptAttentionPlugin/gptAttentionPlugin.cpp
@@ -705,6 +705,7 @@ int GPTAttentionPlugin::enqueueSome(int32_t seqIdxBeg, int32_t localNbSeq, int32
         mUseSpecDecoding = useSpecDecoding;
         // change mMultiBlockMode to default
         mMultiBlockMode = mUseSpecDecoding ? false : true;
+        // if Hopper XQA kernel is enabled, multi block mode will be true in decoderXQAImplJIT::runImpl
     }
 
     [[maybe_unused]] MlaParams<T> mla_params;

--- a/cpp/tensorrt_llm/plugins/gptAttentionPlugin/gptAttentionPlugin.cpp
+++ b/cpp/tensorrt_llm/plugins/gptAttentionPlugin/gptAttentionPlugin.cpp
@@ -705,7 +705,6 @@ int GPTAttentionPlugin::enqueueSome(int32_t seqIdxBeg, int32_t localNbSeq, int32
         mUseSpecDecoding = useSpecDecoding;
         // change mMultiBlockMode to default
         mMultiBlockMode = mUseSpecDecoding ? false : true;
-        // if Hopper XQA kernel is enabled, multi block mode will be true in decoderXQAImplJIT::runImpl
     }
 
     [[maybe_unused]] MlaParams<T> mla_params;

--- a/cpp/tensorrt_llm/thop/attentionOp.cpp
+++ b/cpp/tensorrt_llm/thop/attentionOp.cpp
@@ -528,7 +528,6 @@ void attention_inplace(torch::Tensor q, torch::optional<torch::Tensor> k, torch:
         "Expecting 2 bools for spec-dec mode, is_spec_decoding_enabled and use_spec_decoding.");
     op->mIsSpecDecodingEnabled = spec_decoding_bool_params[0]; // is_spec_decoding_enabled
     op->mUseSpecDecoding = spec_decoding_bool_params[1];       // use_spec_decoding
-    op->mMultiBlockMode = op->mIsSpecDecodingEnabled ? false : true;
 
     if (is_mla_enable)
     {


### PR DESCRIPTION
# [feat] Multi-block mode for Hopper spec dec XQA kernel

## Description

Following [PR 3269](https://github.com/NVIDIA/TensorRT-LLM/pull/3269), it's observed that at low batch size and low draft len, the XQA hopper spec dec kernel has low CTA.

The reason is root caused to not having multi-block mode when Spec-dec is turned on.

The XQA Hopper Spec-dec kernel is launched with `gridDim = dim3{specDecBlocks, multi_block, nbKVHeads * xqaParams.batch_size}`, where 

- `specDecBlocks = divUp(specDecParams.qSeqLen, 64 / num_q_heads_over_kv)`, num_q_heads_over_kv for Llama is 8.
- `nbKVHeads` is num_kv_head per TP rank, for Llama 3, it's 8 when TP=1, 2 when TP=4, 1 when TP=8.

Before the fix, multi_block = 1.  

At a very common use case, where eagle draft length set to < 8, running TP=8, using Llama 3 70b / Llama 3.1 8b. The number of blocks launched could be only `batch_size` blocks. At BS=1, only 1 block will be launched.
```
gridDim = dim3{ divUp(7 / 8), 1, 1 * xqaParams.batch_size} # = batch_size
```

Therefore, multi-block mode is crucial for low BS, low draft length case.

## Heuristic design:

A series of sweeps was done with [xqa](https://github.com/NVIDIA/TensorRT-LLM/tree/main/cpp/kernels/xqa). The experiment showed that when original gridDim is less than a wave of SM, there is benefit for multi-block mode. Furthermore, when original block count is <= 8, 64k > ISL >= 1k, populating all SMs is not always good. The experiments are shown in Appendix.

## Speedup:

### Kernel Speedup for ISL=32k, draft length 7, batch size 2.
By increasing gridDim from (1,1,2) to (1,32,2) yield a **7.8x speedup.**
```
before: 
kernel_mha
Begins: 39.1859s
Ends: 39.1863s (+418.620 μs)
grid:  <<<1, 1, 2>>>
block: <<<128, 1, 3>>>

after: 
kernel_mha
Begins: 33.2649s
Ends: 33.265s (+52.991 μs)
grid:  <<<1, 32, 2>>>
block: <<<128, 1, 3>>>
```
### Kernel Speedup for ISL=32k, draft length 7, batch size 8.
By increasing gridDim from (1,1,8) to (1,8,8) yield a ** 5.4x speedup.**
```
before: 
kernel_mha
Begins: 62.8263s
Ends: 62.8268s (+420.063 μs)
grid:  <<<1, 1, 8>>>
block: <<<128, 1, 3>>>

after: 
kernel_mha
Begins: 42.189s
Ends: 42.1891s (+77.663 μs)
grid:  <<<1, 8, 8>>>
block: <<<128, 1, 3>>>
```

### Kernel Speedup for ISL=10k, draft length 7, batch size 8.
By increasing gridDim from (1,1,8) to (1,4,8) yield a ** 2.5x speedup.**
```
before: 
kernel_mha
Begins: 39.3397s
Ends: 39.3399s (+137.759 μs)
grid:  <<<1, 1, 8>>>
block: <<<128, 1, 3>>>

after: 
kernel_mha
Begins: 38.6683s
Ends: 38.6683s (+55.776 μs)
grid:  <<<1, 4, 8>>>
block: <<<128, 1, 3>>>
```


### Generation Step Speedup for ISL=32k, ISL=10k, ISL=1k, running TP8PP1 Llama 3 70B Eagle, Linear Tree (depth 6, max_draft_len = 7).
![image](https://github.com/user-attachments/assets/389d9860-0162-4827-84d6-3214e58f45ca)
![image](https://github.com/user-attachments/assets/543993f5-4589-450f-a8a7-3667661aaea1)
![image](https://github.com/user-attachments/assets/1c758f1b-6613-4262-b082-3df31e827c97)


## Accuracy verification:
Llama 3 70b Eagle TP8 H200
### gsm8k (not affecting anything because not multi-block mode enabled when ISL < 2k)
```
# add speculative_config in lm_eval_tensorrt_llm.py
python lm_eval_tensorrt_llm.py --model trt-llm \
    --model_args tokenizer=$HF_DIR,model=$ENGINE_DIR \
    --tasks gsm8k

# (Before:)
trt-llm (tokenizer=/scratch_1/tmp/hf_models/Meta-Llama-3-70B-Instruct,model=/scratch_1/tmp/trt_engines/Meta-Llama-3-70B-Instruct_eagle_fp8/tp8_pp1), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9075|±  | 0.008|
|     |       |strict-match    |     5|exact_match|↑  |0.9067|±  | 0.008|


# (After:)
trt-llm (tokenizer=/scratch_1/tmp/hf_models/Meta-Llama-3-70B-Instruct,model=/scratch_1/tmp/trt_engines/Meta-Llama-3-70B-Instruct_eagle_fp8/tp8_pp1), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9121|±  |0.0078|
|     |       |strict-match    |     5|exact_match|↑  |0.9121|±  |0.0078|
```

### ruler
Llama 3 70b Eagle TP4 H200
```
trt-llm (backend=trt,tokenizer=/scratch_1/tmp/hf_models/Meta-Llama-3-70B-Instruct,model=/scratch_1/tmp/trt_engines/Meta-Llama-3-70B-Instruct_eagle_fp8/tp4_pp1,max_context_length=10240,max_gen_toks=1024,eagle_decoding_config=/scratch/TensorRT-LLM-dev/AGI_BUG/eagle_decoding_config.json), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 8|  Tasks  |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
|---------|------:|------|-----:|-----:|---|-----:|---|------|
|ruler_cwe|      1|none  |     0|  4096|↑  |1.0000|±  |   N/A|
|         |       |none  |     0|  8192|↑  |0.9802|±  |   N/A|
```
note: for ruler ISL >= 16k, there seems to be error before or after this tuning.

### Longbench
Llama 3 70b Eagle TP4 H200
```
trt-llm (backend=trt,tokenizer=/scratch_1/tmp/hf_models/Meta-Llama-3-70B-Instruct,model=/scratch_1/tmp/trt_engines/Meta-Llama-3-70B-Instruct_eagle_fp8/tp4_pp1,max_context_length=18432,max_gen_toks=1024,eagle_decoding_config=/scratch/TensorRT-LLM-dev/AGI_BUG/eagle_decoding_config.json), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 8

(before)
|      Tasks       |Version|Filter|n-shot|  Metric   |   |Value |   |Stderr|                                                                                                    
|------------------|------:|------|-----:|-----------|---|-----:|---|-----:|
|longbench_2wikimqa|      2|none  |     0|qa_f1_score|↑  |0.5346|±  |0.0292|

(after)
|      Tasks       |Version|Filter|n-shot|  Metric   |   |Value |   |Stderr|
|------------------|------:|------|-----:|-----------|---|-----:|---|-----:|
|longbench_2wikimqa|      2|none  |     0|qa_f1_score|↑  |0.5358|±  |0.0291|
```


## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## Appendix

### xqa sweep result
![image (46)](https://github.com/user-attachments/assets/2a4933f3-28ad-4fb4-8b0e-a023f4996e18)
![image (43)](https://github.com/user-attachments/assets/503ef5d8-5b3a-4b25-b12a-53a14e64d3dc)
![image (44)](https://github.com/user-attachments/assets/473fd31c-9e6b-46e3-8eac-434de59803da)
![image (45)](https://github.com/user-attachments/assets/084cbb51-1ab2-42cb-b16c-63c6098afc43)
![image (42)](https://github.com/user-attachments/assets/c934efc1-4d98-4e39-90e5-79fc31164a9e)
![image (41)](https://github.com/user-attachments/assets/2232555b-97b5-4fc0-9e1e-8fd9e0fc3e26)
![image (40)](https://github.com/user-attachments/assets/6d224e26-581f-48b1-b5e4-bfb2d99e7dfa)
![image (39)](https://github.com/user-attachments/assets/ab57399f-e93f-4595-8e55-4b4294e7b458)
![image (38)](https://github.com/user-attachments/assets/9ed5f5d4-d449-4f4e-b4d0-df58c1df4eca)
![image (37)](https://github.com/user-attachments/assets/4c6af37e-8312-49ec-afe1-3d066a1168ed)

### BS=16, ISL=1024 slight regression:
```
before:
kernel_mha
Begins: 36.3784s
Ends: 36.3785s (+21.600 μs)
grid:  <<<1, 1, 16>>>
block: <<<128, 1, 3>>>

after:
kernel_mha
Begins: 39.7469s
Ends: 39.7469s (+27.584 μs)
grid:  <<<1, 8, 16>>>
block: <<<128, 1, 3>>>
```

## GitHub Bot Help


`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved tuning for multi-block count in speculative decoding with GMMA kernels, potentially enhancing performance in those scenarios.

* **Bug Fixes**
  * Refined logic for enabling or disabling multi-block mode, ensuring more predictable behavior across different decoding modes and environment variable settings.
  * Disabled multi-block mode support for the precompiled XQA Spec-decoding kernel to prevent unsupported configurations.

* **Refactor**
  * Simplified and clarified the handling of multi-block mode configuration for attention operations.
  * Removed conditional resets of multi-block mode in speculative decoding paths for more consistent behavior.
  * Forced multi-block mode to always be enabled in the GPT attention plugin common constructor for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->