### PR TITLE
[DON'T MERGER] Sharing only: Add quickstart dataset

### DIFF
--- a/cpp/include/tensorrt_llm/executor/serialization.h
+++ b/cpp/include/tensorrt_llm/executor/serialization.h
@@ -252,6 +252,11 @@ public:
     static void serialize(InflightBatchingStats const& inflightBatchingStats, std::ostream& os);
     static size_t serializedSize(InflightBatchingStats const& inflightBatchingStats);
 
+    // SpecDecStats
+    static SpecDecStats deserializeSpecDecStats(std::istream& is);
+    static void serialize(SpecDecStats const& specDecStats, std::ostream& os);
+    static size_t serializedSize(SpecDecStats const& specDecStats);
+
     // IterationStats
     static IterationStats deserializeIterationStats(std::vector<char>& buffer);
     static IterationStats deserializeIterationStats(std::istream& is);

--- a/cpp/include/tensorrt_llm/executor/types.h
+++ b/cpp/include/tensorrt_llm/executor/types.h
@@ -46,6 +46,7 @@ class Tensor;
 
 using TensorPtr = std::shared_ptr<Tensor>;
 using SizeType32 = std::int32_t;
+using SizeType64 = std::int64_t;
 using FloatType = float;
 using TokenIdType = std::int32_t;
 using VecTokens = std::vector<TokenIdType>;
@@ -294,6 +295,24 @@ struct InflightBatchingStats
     float avgNumDecodedTokensPerIter;
 };
 
+/// @brief Struct that holds speculative decoding stats
+struct SpecDecStats
+{
+    /// @brief Total number of proposed draft tokens for all requests
+    SizeType64 numDraftTokens;
+    /// @brief Total number of accepted draft tokens for all requests
+    SizeType64 numAcceptedTokens;
+    /// @brief Number of requests with at least one draft token in batch
+    SizeType64 numRequestsWithDraftTokens;
+    /// @brief Acceptance length, defined as average number of tokens produced per step for all requests with at least
+    /// one draft token
+    double acceptanceLength;
+    /// @brief Iteration latency for draft token generation only (ms)
+    double iterLatencyMS;
+    /// @brief Draft overhead, defined as iterLatencyMS (specdec) / iterLatencyMS (total)
+    double draftOverhead;
+};
+
 /// @brief Struct that holds the stats of a single iteration
 struct IterationStats
 {
@@ -341,6 +360,8 @@ struct IterationStats
     std::optional<StaticBatchingStats> staticBatchingStats;
     /// @brief Stats specific to inflight batching
     std::optional<InflightBatchingStats> inflightBatchingStats;
+    /// @brief Stats specific to speculative decoding
+    std::optional<SpecDecStats> specDecStats;
 };
 
 /// @brief Enum class that represents the state of a request

--- a/cpp/tensorrt_llm/executor/jsonSerialization.cpp
+++ b/cpp/tensorrt_llm/executor/jsonSerialization.cpp
@@ -31,11 +31,13 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(
     StaticBatchingStats, numScheduledRequests, numContextRequests, numCtxTokens, numGenTokens, emptyGenSlots);
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(InflightBatchingStats, numScheduledRequests, numContextRequests, numGenRequests,
     numPausedRequests, numCtxTokens, microBatchId, avgNumDecodedTokensPerIter);
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(SpecDecStats, numDraftTokens, numAcceptedTokens, numRequestsWithDraftTokens,
+    acceptanceLength, iterLatencyMS, draftOverhead);
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(IterationStats, timestamp, iter, iterLatencyMS, newActiveRequestsQueueLatencyMS,
     numNewActiveRequests, numActiveRequests, numQueuedRequests, numCompletedRequests, maxNumActiveRequests,
     maxBatchSizeStatic, maxBatchSizeTunerRecommended, maxBatchSizeRuntime, maxNumTokensStatic,
     maxNumTokensTunerRecommended, maxNumTokensRuntime, gpuMemUsage, cpuMemUsage, pinnedMemUsage, kvCacheStats,
-    staticBatchingStats, inflightBatchingStats);
+    staticBatchingStats, inflightBatchingStats, specDecStats);
 NLOHMANN_JSON_SERIALIZE_ENUM(RequestStage,
     {{RequestStage::kQUEUED, "QUEUED"}, {RequestStage::kCONTEXT_IN_PROGRESS, "CONTEXT_IN_PROGRESS"},
         {RequestStage::kGENERATION_IN_PROGRESS, "GENERATION_IN_PROGRESS"},

--- a/cpp/tensorrt_llm/executor/serialization.cpp
+++ b/cpp/tensorrt_llm/executor/serialization.cpp
@@ -1727,6 +1727,42 @@ size_t Serialization::serializedSize(InflightBatchingStats const& inflightBatchi
     return totalSize;
 }
 
+// SpecDecStats
+SpecDecStats Serialization::deserializeSpecDecStats(std::istream& is)
+{
+    auto numDraftTokens = su::deserialize<SizeType64>(is);
+    auto numAcceptedTokens = su::deserialize<SizeType64>(is);
+    auto numRequestsWithDraftTokens = su::deserialize<SizeType64>(is);
+    auto acceptanceLength = su::deserialize<double>(is);
+    auto iterLatencyMS = su::deserialize<double>(is);
+    auto draftOverhead = su::deserialize<double>(is);
+
+    return SpecDecStats{
+        numDraftTokens, numAcceptedTokens, numRequestsWithDraftTokens, acceptanceLength, iterLatencyMS, draftOverhead};
+}
+
+void Serialization::serialize(SpecDecStats const& state, std::ostream& os)
+{
+    su::serialize(state.numDraftTokens, os);
+    su::serialize(state.numAcceptedTokens, os);
+    su::serialize(state.numRequestsWithDraftTokens, os);
+    su::serialize(state.acceptanceLength, os);
+    su::serialize(state.iterLatencyMS, os);
+    su::serialize(state.draftOverhead, os);
+}
+
+size_t Serialization::serializedSize(SpecDecStats const& state)
+{
+    size_t totalSize = 0;
+    totalSize += su::serializedSize(state.numDraftTokens);
+    totalSize += su::serializedSize(state.numAcceptedTokens);
+    totalSize += su::serializedSize(state.numRequestsWithDraftTokens);
+    totalSize += su::serializedSize(state.acceptanceLength);
+    totalSize += su::serializedSize(state.iterLatencyMS);
+    totalSize += su::serializedSize(state.draftOverhead);
+    return totalSize;
+}
+
 // IterationStats
 
 IterationStats Serialization::deserializeIterationStats(std::istream& is)
@@ -1754,12 +1790,13 @@ IterationStats Serialization::deserializeIterationStats(std::istream& is)
     auto crossKvCacheStats = su::deserialize<std::optional<KvCacheStats>>(is);
     auto staticBatchingStats = su::deserialize<std::optional<StaticBatchingStats>>(is);
     auto inflightBatchingStats = su::deserialize<std::optional<InflightBatchingStats>>(is);
+    auto specdecStats = su::deserialize<std::optional<SpecDecStats>>(is);
 
     return IterationStats{timestamp, iter, iterLatencyMS, newActiveRequestsQueueLatencyMS, numNewActiveRequests,
         numActiveRequests, numQueuedRequests, numCompletedRequests, maxNumActiveRequests, maxBatchSizeStatic,
         maxBatchSizeTunerRecommended, maxBatchSizeRuntime, maxNumTokensStatic, maxNumTokensTunerRecommended,
         maxNumTokensRuntime, gpuMemUsage, cpuMemUsage, pinnedMemUsage, kvCacheStats, crossKvCacheStats,
-        staticBatchingStats, inflightBatchingStats};
+        staticBatchingStats, inflightBatchingStats, specdecStats};
 }
 
 IterationStats Serialization::deserializeIterationStats(std::vector<char>& buffer)
@@ -1797,6 +1834,7 @@ size_t Serialization::serializedSize(IterationStats const& iterStats)
     totalSize += su::serializedSize(iterStats.crossKvCacheStats);
     totalSize += su::serializedSize(iterStats.staticBatchingStats);
     totalSize += su::serializedSize(iterStats.inflightBatchingStats);
+    totalSize += su::serializedSize(iterStats.specDecStats);
 
     return totalSize;
 }
@@ -1825,6 +1863,7 @@ void Serialization::serialize(IterationStats const& iterStats, std::ostream& os)
     su::serialize(iterStats.crossKvCacheStats, os);
     su::serialize(iterStats.staticBatchingStats, os);
     su::serialize(iterStats.inflightBatchingStats, os);
+    su::serialize(iterStats.specDecStats, os);
 }
 
 std::vector<char> Serialization::serialize(IterationStats const& iterStats)

--- a/cpp/tensorrt_llm/executor/serializeUtils.h
+++ b/cpp/tensorrt_llm/executor/serializeUtils.h
@@ -465,6 +465,10 @@ T deserialize(std::istream& is)
     {
         return Serialization::deserializeInflightBatchingStats(is);
     }
+    else if constexpr (std::is_same_v<T, tensorrt_llm::executor::SpecDecStats>)
+    {
+        return Serialization::deserializeSpecDecStats(is);
+    }
     else if constexpr (std::is_same_v<T, tensorrt_llm::executor::IterationStats>)
     {
         return Serialization::deserializeIterationStats(is);

--- a/cpp/tensorrt_llm/pybind/executor/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/executor/bindings.cpp
@@ -132,6 +132,15 @@ void initBindings(pybind11::module_& m)
         .def_readwrite("micro_batch_id", &tle::InflightBatchingStats::microBatchId)
         .def_readwrite("avg_num_decoded_tokens_per_iter", &tle::InflightBatchingStats::avgNumDecodedTokensPerIter);
 
+    py::class_<tle::SpecDecStats>(m, "SpecDecStats")
+        .def(py::init<>())
+        .def_readwrite("num_draft_tokens", &tle::SpecDecStats::numDraftTokens)
+        .def_readwrite("num_accepted_tokens", &tle::SpecDecStats::numAcceptedTokens)
+        .def_readwrite("num_requests_with_draft_tokens", &tle::SpecDecStats::numRequestsWithDraftTokens)
+        .def_readwrite("acceptance_length", &tle::SpecDecStats::acceptanceLength)
+        .def_readwrite("iter_latency_ms", &tle::SpecDecStats::iterLatencyMS)
+        .def_readwrite("draft_overhead", &tle::SpecDecStats::draftOverhead);
+
     py::class_<tle::IterationStats>(m, "IterationStats")
         .def(py::init<>())
         .def_readwrite("timestamp", &tle::IterationStats::timestamp)
@@ -150,6 +159,7 @@ void initBindings(pybind11::module_& m)
         .def_readwrite("cross_kv_cache_stats", &tle::IterationStats::crossKvCacheStats)
         .def_readwrite("static_batching_stats", &tle::IterationStats::staticBatchingStats)
         .def_readwrite("inflight_batching_stats", &tle::IterationStats::inflightBatchingStats)
+        .def_readwrite("specdec_stats", &tle::IterationStats::specDecStats)
         .def("to_json_str",
             [](tle::IterationStats const& iterationStats)
             { return tle::JsonSerialization::toJsonStr(iterationStats); });

--- a/examples/prompt_lookup/README.md
+++ b/examples/prompt_lookup/README.md
@@ -4,10 +4,12 @@ This document shows how to build and run a model using Prompt-Lookup speculative
 
 ## Overview
 
+We provide two styles of workflow to run Prompt-Lookup (named V1 and V2 respectively) now. V1 is in TRT workflow and similar to the Draft-Target-Model workflow, running in orchestrator mode and calling `runner.generate()` multiple times to get outputs, which is more flexible for customizing but slightly more overhead. V2 is in pytorch workflow and similar to the Look-Ahead workflow, running in leader mode and calling `runner.generate()` only one time to get outputs, which provides higher performance but fixed process.
+
 The Prompt-Lookup has 3 additional hyperparameters that you need to specify to control the process of generation:
-- `prompt_lookup_num_tokens`: the number of tokens we extract from input prompt or previous generated output as draft tokens in one iteration, which the range is from 4 to 10 in common usage. Empirically, the larger the value is, the higher acceptance ratio but higher overhead is expected at the same time, so the right balance based on the models and application scenarios needs to be found.
-- `max_matching_ngram_size`: the number of tokens we get from the tail of the generated output as a pattern, which is used to match in input prompt or previous generated output. Empirically, the larger the value is, the more precise context can be matched from the existed sequence, indicating higher acceptance ratio, but the higher probability of miss-match and higher overhead appear, which fall back to normal generation (one token per iteration).
-- `device_list`: the index list of device(s) to run the model. The length of it must be the same as the TP size of the draft model engine. For instances, `device_list=[0]` means using tp_size=1 and GPU 0 for the model, `device_list=[4,5,6,7]` means using tp=4 and GPU from 4 to 7 for the model.
+- `prompt_lookup_num_tokens`: the number of tokens we extract from input prompt or previous generated output as draft tokens in one iteration, which the range is from 4 to 10 in common usage (default value: 4). Empirically, the larger the value is, the higher acceptance rate but higher overhead is expected at the same time, so the right balance based on the models and application scenarios needs to be found.
+- `max_matching_ngram_size`: the number of tokens we get from the tail of the input prompt or generated output as a pattern, which is used to match in input prompt or previous generated output (default value: 2). Empirically, the larger the value is, the more precise context can be matched from the existed sequence, indicating higher acceptance rate, but the higher probability of miss-match and higher overhead appear, which fall back to normal generation (one token per iteration).
+- `device_list`: the index list of device(s) to run the model in V1 workflow. The length of it must be the same as the TP size of the draft model engine. For instances, `device_list=[0]` means using tp_size=1 and GPU 0 for the model, `device_list=[4,5,6,7]` means using tp=4 and GPU from 4 to 7 for the model. This parameter is neddless in V2 workflow.
 
 ## Support Matrix
   * GPU Compute Capability >= 8.0 (Ampere or newer)
@@ -17,17 +19,21 @@ The Prompt-Lookup has 3 additional hyperparameters that you need to specify to c
 
 ## Usage
 
-### Build engines
+### V1 workflow
 
 + We use an open-source `llama-v2-13B` models in this example.
 + `--use_paged_context_fmha=enable` must be specified since we need KVcache reuse in this approach.
 + `--speculative_decoding_mode=draft_tokens_external` must be specified.
 + `--max_draft_len` must be specified larger or equal to `prompt_lookup_num_tokens`.
++ `---prompt_lookup_config` is corresponding configuration of Prompt-Lookup, we can see its usage in [util.py](../util.py).
+  + As an example, `[10,2,[0]]` means `prompt_lookup_num_tokens=10`, `max_matching_ngram_size=2`, and device of target model is `GPU0`.
++ `--kv_cache_enable_block_reuse` must be specified for this approach.
++ Only CPP session is supported, so `--use_py_session` must not be specified.
++ `--num_beams` can not be specified as larger than 1 since beam search is not supported in this approach yet.
 
 ```bash
-cd examples/models/core/llama
-
-python3 convert_checkpoint.py \
+# Build engine
+python3 examples/models/core/llama/convert_checkpoint.py \
     --model_dir=<Path To Llama-v2-13B repo> \
     --output_dir=./ckpt-target \
     --dtype=float16
@@ -42,34 +48,18 @@ trtllm-build \
     --max_batch_size=4 \
     --max_input_len=3200 \
     --max_seq_len=4800
-```
 
-### Run decoding
-
-+ `---prompt_lookup_config` is corresponding configuration of Prompt-Lookup, we can see its usage in [util.py](../util.py).
-  + As an example, `[10,2,[0]]` means `prompt_lookup_num_tokens=10`, `max_matching_ngram_size=2`, and  device of target model is `GPU0`.
-+ `--kv_cache_enable_block_reuse` must be specified for this approach.
-+ Only CPP session is supported, so `--use_py_session` must not be specified.
-+ `--num_beams` can not be specified as larger than 1 since beam search is not supported in this approach yet.
-
-```bash
-cd examples/models/core/llama
-
-python3 ../../../run.py \
+# Run decoding
+python3 examples/run.py \
     --tokenizer_dir <Path To Llama-v2-7B repo> \
     --engine_dir ./target-engine \
     --prompt_lookup_config="[10,2,[0]]" \
     --max_output_len=256 \
     --kv_cache_enable_block_reuse \
     --input_text="How does Draft-Sampling work?"
-```
 
-## Run summarization tasks
-
-```bash
-cd examples/models/core/llama
-
-python ../../../summarize.py \
+# Run summarization tasks
+python examples/summarize.py \
     --test_hf \
     --test_trt_llm \
     --check_accuracy \
@@ -78,4 +68,12 @@ python ../../../summarize.py \
     --batch_size=1 \
     --prompt_lookup_config="[10,2,[0]]" \
     --kv_cache_enable_block_reuse
+```
+
+### V2 workflow
+
+```bash
+python3 examples/pytorch/quickstart_advanced.py \
+    --max_matching_ngram_size=2 \
+    --spec_decode_nextn=4
 ```

--- a/examples/pytorch/README.md
+++ b/examples/pytorch/README.md
@@ -1,12 +1,12 @@
 # TRT-LLM with PyTorch
 
-Run the quick start script:
+## Run the quick start script:
 
 ```bash
 python3 quickstart.py
 ```
 
-Run the advanced usage example script:
+## Run the advanced usage example script:
 
 ```bash
 # BF16
@@ -29,8 +29,9 @@ python3 quickstart_advanced.py --model_dir nvidia/Llama-3_1-Nemotron-Ultra-253B-
 
 # Nemotron-H requires disabling cache reuse in kv cache
 python3 quickstart_advanced.py --model_dir nvidia/Nemotron-H-8B-Base-8K --disable_kv_cache_reuse --max_batch_size 8
+```
 
-Run the multimodal example script:
+## Run the multimodal example script:
 
 ```bash
 # default inputs
@@ -43,29 +44,39 @@ python3 quickstart_multimodal.py --model_dir Efficient-Large-Model/NVILA-8B --mo
 # Note: media should be either image or video. Mixing image and video is not supported.
 python3 quickstart_multimodal.py --model_dir Efficient-Large-Model/NVILA-8B --modality video --prompt "Tell me what you see in the video briefly." "Describe the scene in the video briefly." --media "https://huggingface.co/datasets/Efficient-Large-Model/VILA-inference-demos/resolve/main/OAI-sora-tokyo-walk.mp4" "https://huggingface.co/datasets/Efficient-Large-Model/VILA-inference-demos/resolve/main/world.mp4" --max_tokens 128 [--use_cuda_graph]
 ```
-## Supported Models
-| Architecture | Model | HuggingFace Example | Modality |
-|--------------|-------|---------------------|----------|
-| `BertForSequenceClassification` | BERT-based | `textattack/bert-base-uncased-yelp-polarity` | L |
-| `DeepseekV3ForCausalLM` | DeepSeek-V3 | `deepseek-ai/DeepSeek-V3` | L |
-| `Gemma3ForCausalLM` | Gemma3 | `google/gemma-3-1b-it` | L |
-| `LlavaLlamaModel` | VILA | `Efficient-Large-Model/NVILA-8B` | L + V |
-| `LlavaNextForConditionalGeneration` | LLaVA-NeXT | `llava-hf/llava-v1.6-mistral-7b-hf` | L + V |
-| `LlamaForCausalLM` | Llama 3 <br> Llama 3.1 <br> Llama 2 <br> LLaMA | `meta-llama/Meta-Llama-3.1-70B` | L |
-| `Llama4ForConditionalGeneration` | Llama 4 Scout <br> Llama 4 Maverick | `meta-llama/Llama-4-Scout-17B-16E-Instruct` <br> `meta-llama/Llama-4-Maverick-17B-128E-Instruct` | L + V |
-| `MistralForCausalLM` | Mistral | `mistralai/Mistral-7B-v0.1` | L |
-| `MixtralForCausalLM` | Mixtral | `mistralai/Mixtral-8x7B-v0.1` | L |
-| `MllamaForConditionalGeneration` | Llama 3.2 | `meta-llama/Llama-3.2-11B-Vision` | L |
-| `NemotronForCausalLM` | Nemotron-3 <br> Nemotron-4 <br> Minitron | `nvidia/Minitron-8B-Base` | L |
-| `NemotronHForCausalLM` | Nemotron-H | `nvidia/Nemotron-H-8B-Base-8K` <br> `nvidia/Nemotron-H-47B-Base-8K` <br> `nvidia/Nemotron-H-56B-Base-8K` | L |
-| `NemotronNASForCausalLM` | LLamaNemotron <br> LlamaNemotron Super <br> LlamaNemotron Ultra  | `nvidia/Llama-3_1-Nemotron-51B-Instruct` <br> `nvidia/Llama-3_3-Nemotron-Super-49B-v1` <br> `nvidia/Llama-3_1-Nemotron-Ultra-253B-v1` | L |
-| `Qwen2ForCausalLM` | QwQ, Qwen2 | `Qwen/Qwen2-7B-Instruct` | L |
-| `Qwen2ForProcessRewardModel` | Qwen2-based | `Qwen/Qwen2.5-Math-PRM-7B` | L |
-| `Qwen2ForRewardModel` | Qwen2-based | `Qwen/Qwen2.5-Math-RM-72B` | L |
-| `Qwen2VLForConditionalGeneration` | Qwen2-VL | `Qwen/Qwen2-VL-7B-Instruct` | L + V |
-| `Qwen2_5_VLForConditionalGeneration` | Qwen2.5-VL | `Qwen/Qwen2.5-VL-7B-Instruct` | L + V |
+
+### Supported Models
+|             Architecture             | Model                                                        | HuggingFace Example                                          | Modality |
+| :----------------------------------: | :----------------------------------------------------------- | :----------------------------------------------------------- | :------: |
+|   `BertForSequenceClassification`    | BERT-based                                                   | `textattack/bert-base-uncased-yelp-polarity`                 |    L     |
+|       `DeepseekV3ForCausalLM`        | DeepSeek-V3                                                  | `deepseek-ai/DeepSeek-V3 `                                   |    L     |
+|         `Gemma3ForCausalLM`          | Gemma3                                                       | `google/gemma-3-1b-it`                                       |    L     |
+|          `LlavaLlamaModel`           | VILA                                                         | `Efficient-Large-Model/NVILA-8B`                             |  L + V   |
+| `LlavaNextForConditionalGeneration`  | LLaVA-NeXT                                                   | `llava-hf/llava-v1.6-mistral-7b-hf`                          |  L + V   |
+|          `LlamaForCausalLM`          | Llama 3 <br> Llama 3.1 <br> Llama 2 <br> LLaMA               | `meta-llama/Meta-Llama-3.1-70B`                              |    L     |
+|   `Llama4ForConditionalGeneration`   | Llama 4 Scout <br> Llama 4 Maverick                          | `meta-llama/Llama-4-Scout-17B-16E-Instruct` <br> `meta-llama/Llama-4-Maverick-17B-128E-Instruct` |  L + V   |
+|         `MistralForCausalLM`         | Mistral                                                      | `mistralai/Mistral-7B-v0.1`                                  |    L     |
+|         `MixtralForCausalLM`         | Mixtral                                                      | `mistralai/Mixtral-8x7B-v0.1`                                |    L     |
+|   `MllamaForConditionalGeneration`   | Llama 3.2                                                    | `meta-llama/Llama-3.2-11B-Vision`                            |    L     |
+|        `NemotronForCausalLM`         | Nemotron-3 <br> Nemotron-4 <br> Minitron                     | `nvidia/Minitron-8B-Base`                                    |    L     |
+|        `NemotronHForCausalLM`        | Nemotron-H                                                   | `nvidia/Nemotron-H-8B-Base-8K` <br> `nvidia/Nemotron-H-47B-Base-8K` <br> `nvidia/Nemotron-H-56B-Base-8K` |    L     |
+|       `NemotronNASForCausalLM`       | LLamaNemotron <br> LlamaNemotron Super <br> LlamaNemotron Ultra | `nvidia/Llama-3_1-Nemotron-51B-Instruct` <br> `nvidia/Llama-3_3-Nemotron-Super-49B-v1` <br> `nvidia/Llama-3_1-Nemotron-Ultra-253B-v1` |    L     |
+|          `Qwen2ForCausalLM`          | QwQ, Qwen2                                                   | `Qwen/Qwen2-7B-Instruct`                                     |    L     |
+|     `Qwen2ForProcessRewardModel`     | Qwen2-based                                                  | `Qwen/Qwen2.5-Math-PRM-7B`                                   |    L     |
+|        `Qwen2ForRewardModel`         | Qwen2-based                                                  | `Qwen/Qwen2.5-Math-RM-72B`                                   |    L     |
+|  `Qwen2VLForConditionalGeneration`   | Qwen2-VL                                                     | `Qwen/Qwen2-VL-7B-Instruct`                                  |  L + V   |
+| `Qwen2_5_VLForConditionalGeneration` | Qwen2.5-VL                                                   | `Qwen/Qwen2.5-VL-7B-Instruct`                                |  L + V   |
 
 Note:
 - L: Language only
 - L + V: Language and Vision multimodal support
 - Llama 3.2 accepts vision input, but our support currently limited to text only.
+
+## Run the speculative decoding script:
+
+```bash
+# NGram drafter
+python3 examples/pytorch/quickstart_advanced.py \
+    --max_matching_ngram_size=2 \
+    --spec_decode_nextn=4
+```

--- a/examples/pytorch/quickstart_advanced.py
+++ b/examples/pytorch/quickstart_advanced.py
@@ -4,7 +4,7 @@ from tensorrt_llm import SamplingParams
 from tensorrt_llm._torch import LLM
 from tensorrt_llm._torch.pyexecutor.config import PyTorchConfig
 from tensorrt_llm.llmapi import (EagleDecodingConfig, KvCacheConfig,
-                                 MTPDecodingConfig)
+                                 MTPDecodingConfig, NGramDecodingConfig)
 
 example_prompts = [
     "Hello, my name is",
@@ -103,6 +103,7 @@ def add_llm_args(parser):
     parser.add_argument('--spec_decode_algo', type=str, default=None)
     parser.add_argument('--spec_decode_nextn', type=int, default=1)
     parser.add_argument('--eagle_model_dir', type=str, default=None)
+    parser.add_argument('--max_matching_ngram_size', type=int, default=5)
 
     # Relaxed acceptance
     parser.add_argument('--use_relaxed_acceptance_for_thinking',
@@ -130,6 +131,7 @@ def setup_llm(args):
         use_cuda_graph=args.use_cuda_graph,
         load_format=args.load_format,
         print_iter_log=args.print_iter_log,
+        enable_iter_perf_stats=args.print_iter_log,
         torch_compile_enabled=args.use_torch_compile,
         torch_compile_piecewise_cuda_graph=args.use_piecewise_cuda_graph,
         moe_backend=args.moe_backend,
@@ -154,6 +156,14 @@ def setup_llm(args):
         spec_config = EagleDecodingConfig(
             max_draft_len=args.spec_decode_nextn,
             pytorch_eagle_weights_path=args.eagle_model_dir)
+    elif spec_decode_algo == "NGRAM":
+        spec_config = NGramDecodingConfig(
+            prompt_lookup_num_tokens=args.spec_decode_nextn,
+            max_matching_ngram_size=args.max_matching_ngram_size,
+            is_keep_all=True,
+            is_use_oldest=True,
+            is_public_pool=True,
+        )
     else:
         spec_config = None
 
@@ -192,6 +202,11 @@ def main():
         prompt = output.prompt
         generated_text = output.outputs[0].text
         print(f"[{i}] Prompt: {prompt!r}, Generated text: {generated_text!r}")
+
+    if args.print_iter_log:
+        stats = llm.get_stats()
+        for stat in stats:
+            print(stat)
 
 
 if __name__ == '__main__':

--- a/examples/pytorch/quickstart_dataset.py
+++ b/examples/pytorch/quickstart_dataset.py
@@ -1,0 +1,424 @@
+import argparse
+import json
+
+from datasets import load_dataset
+
+from tensorrt_llm import SamplingParams
+from tensorrt_llm._torch import LLM
+from tensorrt_llm._torch.pyexecutor.config import PyTorchConfig
+from tensorrt_llm.llmapi import (EagleDecodingConfig, KvCacheConfig,
+                                 MTPDecodingConfig, NGramDecodingConfig)
+
+example_prompts = [
+    "system: You are a friendly chatbot who always responds in the style of a pirate\nuser: Compose an engaging travel blog post about a recent trip to Hawaii, highlighting cultural experiences and must-see attractions.\nassistant:"
+]
+
+
+class DatasetBase:
+
+    def __init__(self, dataset_name):
+        self.dataset_name = dataset_name
+
+    def load_dataset(self, size):
+        pass
+
+    def convert_to_chat_format(self, messages):
+        formatted_text = ""
+        for message in self.system_prompt + messages:
+            role = message.get('role', '')
+            content = message.get('content', '')
+            formatted_text += f"{role}:{content}\n"
+        formatted_text += "assistant:"
+        return formatted_text
+
+
+class MTBenchDataset(DatasetBase):
+
+    def __init__(self, dataset_name):
+        super().__init__(dataset_name)
+        self.system_prompt = [{
+            "role":
+            "system",
+            "content":
+            "You are a friendly chatbot who always responds in the style of a pirate",
+        }]
+        self.max_turn = 2
+
+    def load_dataset(self, size):
+        source = "lmsys/mt_bench_human_judgments"
+
+        unique = []
+        dataset = load_dataset(source, split='human')
+        full_size = len(dataset)
+        if size is None:
+            size = full_size
+        if size > full_size:
+            size = full_size
+
+        # Filter out the
+        user_messages = []
+        for i in range(len(dataset)):
+            if dataset[i]['conversation_a'][0]['content'] not in unique:
+                unique.append(dataset[i]['conversation_a'][0]['content'])
+                user_messages.append([
+                    data for data in dataset[i]['conversation_a']
+                    if data['role'] == 'user'
+                ])
+        return user_messages[:size]
+
+    def convert_to_chat_format(self, messages):
+        formatted_text = ""
+        for message in self.system_prompt + messages:
+            role = message.get('role', '')
+            content = message.get('content', '')
+            if role is not None and content is not None:
+                formatted_text += f"{role}:{content}\n"
+        formatted_text += "assistant:"
+        return formatted_text
+
+
+class AADataset(DatasetBase):
+
+    def __init__(self, dataset_name):
+        super().__init__(dataset_name)
+        self.max_turn = 1
+        self.system_prompt = [{
+            "role": "system",
+            "content": "You are a helpful assistant.",
+        }]
+
+    def load_dataset(self, size):
+        file = "/home/scratch.tjohnsen_ent/datasets/AA_dataset.txt"
+        with open(file, 'r') as f:
+            data = f.readlines()
+
+        data = [[{
+            "role": "user",
+            "content": json.loads(item).get('user_prompt')
+        }] for item in data]
+        return data[:size]
+
+    def convert_to_chat_format(self, messages):
+        formatted_text = ""
+        for message in self.system_prompt + messages:
+            role = message.get('role', '')
+            content = message.get('content', '')
+            formatted_text += f"{role}:{content}\n"
+        formatted_text += "assistant:"
+        return formatted_text
+
+
+class MagpieDataset(DatasetBase):
+
+    def __init__(self, dataset_name):
+        super().__init__(dataset_name)
+        self.max_turn = 1
+        self.system_prompt = [dict()]
+
+    def load_dataset(self, size):
+        source = "Magpie-Align/Magpie-Llama-3.1-Pro-MT-300K-Filtered"
+        dataset = load_dataset(source, split='train')
+        full_size = len(dataset)
+        turns = []
+        conversations = []
+        for data in dataset:
+            original_conversations = data.get('conversations', [])
+            processed_conversations = []
+            turn = 0
+            for conv in original_conversations:
+                match conv.get('from'):
+                    case 'human':
+                        processed_conversations.append({
+                            "role":
+                            "user",
+                            "content":
+                            conv.get('value')
+                        })
+                        turn += 1
+                    case 'gpt':
+                        processed_conversations.append({
+                            "role":
+                            "assistant",
+                            "content":
+                            conv.get('value')
+                        })
+                    case _:
+                        raise ValueError(f"Unknown role: {conv}")
+
+            conversations.append(processed_conversations)
+            turns.append(turn)
+
+        # import pdb; pdb.set_trace()
+
+        if size is None:
+            size = full_size
+        if size > full_size:
+            size = full_size
+
+        self.max_turn = max(turns[:size])
+
+        print(f"Max turn: {self.max_turn}")
+        return conversations[:size]
+
+
+def add_llm_args(parser):
+    parser.add_argument('--model_dir',
+                        type=str,
+                        required=True,
+                        help="Model checkpoint directory.")
+    parser.add_argument("--prompt",
+                        type=str,
+                        nargs="+",
+                        help="A single or a list of text prompts.")
+    parser.add_argument("--dataset",
+                        type=str,
+                        choices=['mtbench', 'aa', 'magpie'],
+                        help="The name of the dataset to use.")
+    parser.add_argument("--dataset_size",
+                        type=int,
+                        default=None,
+                        help="The size of the dataset to use.")
+    parser.add_argument("--max_turn",
+                        type=int,
+                        default=None,
+                        help="The maximum number of turns to use.")
+    # Build config
+    parser.add_argument("--max_seq_len",
+                        type=int,
+                        default=None,
+                        help="The maximum sequence length.")
+    parser.add_argument("--max_batch_size",
+                        type=int,
+                        default=2048,
+                        help="The maximum batch size.")
+    parser.add_argument(
+        "--max_num_tokens",
+        type=int,
+        default=8192,
+        help=
+        "The maximum total tokens (context + generation) across all sequences in a batch."
+    )
+
+    # Parallelism
+    parser.add_argument('--attention_backend',
+                        type=str,
+                        default='TRTLLM',
+                        choices=[
+                            'VANILLA', 'TRTLLM', 'FLASHINFER',
+                            'FLASHINFER_STAR_ATTENTION'
+                        ])
+    parser.add_argument('--moe_backend',
+                        type=str,
+                        default='CUTLASS',
+                        choices=['CUTLASS', 'TRTLLM'])
+    parser.add_argument('--enable_attention_dp',
+                        default=False,
+                        action='store_true')
+    parser.add_argument('--enable_trtllm_decoder',
+                        default=False,
+                        action='store_true')
+    parser.add_argument('--tp_size', type=int, default=1)
+    parser.add_argument('--pp_size', type=int, default=1)
+    parser.add_argument('--moe_ep_size', type=int, default=-1)
+    parser.add_argument('--moe_tp_size', type=int, default=-1)
+    parser.add_argument('--moe_cluster_size', type=int, default=-1)
+
+    # KV cache
+    parser.add_argument('--kv_cache_dtype', type=str, default='auto')
+    parser.add_argument('--disable_kv_cache_reuse',
+                        default=False,
+                        action='store_true')
+    parser.add_argument("--kv_cache_fraction", type=float, default=None)
+
+    # Runtime
+    parser.add_argument('--disable_overlap_scheduler',
+                        default=False,
+                        action='store_true')
+    parser.add_argument('--enable_chunked_prefill',
+                        default=False,
+                        action='store_true')
+    parser.add_argument('--use_cuda_graph', default=False, action='store_true')
+    parser.add_argument('--print_iter_log',
+                        default=False,
+                        action='store_true',
+                        help='Print iteration logs during execution')
+    parser.add_argument('--use_torch_compile',
+                        default=False,
+                        action='store_true',
+                        help='Use torch.compile to optimize the model')
+    parser.add_argument('--use_piecewise_cuda_graph',
+                        default=False,
+                        action='store_true',
+                        help='Use piecewise CUDA graph to optimize the model')
+
+    # Sampling
+    parser.add_argument("--max_tokens", type=int, default=2048)
+    parser.add_argument("--temperature", type=float, default=None)
+    parser.add_argument("--top_k", type=int, default=None)
+    parser.add_argument("--top_p", type=float, default=None)
+    parser.add_argument('--load_format', type=str, default='auto')
+    parser.add_argument('--return_generation_logits',
+                        default=False,
+                        action='store_true')
+    # Speculative decoding
+    parser.add_argument('--spec_decode_algo', type=str, default=None)
+    parser.add_argument('--spec_decode_nextn', type=int, default=1)
+    parser.add_argument('--eagle_model_dir', type=str, default=None)
+    parser.add_argument('--max_matching_ngram_size', type=int, default=5)
+
+    # Relaxed acceptance
+    parser.add_argument('--use_relaxed_acceptance_for_thinking',
+                        default=False,
+                        action='store_true')
+    parser.add_argument('--relaxed_topk', type=int, default=1)
+    parser.add_argument('--relaxed_delta', type=float, default=0.)
+
+    return parser
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        description="LLM models with the PyTorch workflow.")
+    parser = add_llm_args(parser)
+    args = parser.parse_args()
+    return args
+
+
+def setup_llm(args):
+    pytorch_config = PyTorchConfig(
+        disable_overlap_scheduler=args.disable_overlap_scheduler,
+        kv_cache_dtype=args.kv_cache_dtype,
+        attn_backend=args.attention_backend,
+        use_cuda_graph=args.use_cuda_graph,
+        load_format=args.load_format,
+        print_iter_log=args.print_iter_log,
+        enable_iter_perf_stats=args.print_iter_log,
+        torch_compile_enabled=args.use_torch_compile,
+        torch_compile_piecewise_cuda_graph=args.use_piecewise_cuda_graph,
+        moe_backend=args.moe_backend,
+        enable_trtllm_decoder=args.enable_trtllm_decoder)
+
+    kv_cache_config = KvCacheConfig(
+        enable_block_reuse=not args.disable_kv_cache_reuse,
+        free_gpu_memory_fraction=args.kv_cache_fraction,
+    )
+
+    spec_decode_algo = args.spec_decode_algo.upper(
+    ) if args.spec_decode_algo is not None else None
+
+    if spec_decode_algo == 'MTP':
+        spec_config = MTPDecodingConfig(
+            num_nextn_predict_layers=args.spec_decode_nextn,
+            use_relaxed_acceptance_for_thinking=args.
+            use_relaxed_acceptance_for_thinking,
+            relaxed_topk=args.relaxed_topk,
+            relaxed_delta=args.relaxed_delta)
+    elif spec_decode_algo == "EAGLE3":
+        spec_config = EagleDecodingConfig(
+            max_draft_len=args.spec_decode_nextn,
+            pytorch_eagle_weights_path=args.eagle_model_dir)
+    elif spec_decode_algo == "NGRAM":
+        spec_config = NGramDecodingConfig(
+            prompt_lookup_num_tokens=args.spec_decode_nextn,
+            max_matching_ngram_size=args.max_matching_ngram_size,
+            is_keep_all=True,
+            is_use_oldest=True,
+            is_public_pool=True,
+        )
+    else:
+        spec_config = None
+
+    llm = LLM(model=args.model_dir,
+              max_seq_len=args.max_seq_len,
+              max_batch_size=args.max_batch_size,
+              max_num_tokens=args.max_num_tokens,
+              pytorch_backend_config=pytorch_config,
+              kv_cache_config=kv_cache_config,
+              tensor_parallel_size=args.tp_size,
+              pipeline_parallel_size=args.pp_size,
+              enable_attention_dp=args.enable_attention_dp,
+              moe_expert_parallel_size=args.moe_ep_size,
+              moe_tensor_parallel_size=args.moe_tp_size,
+              moe_cluster_parallel_size=args.moe_cluster_size,
+              enable_chunked_prefill=args.enable_chunked_prefill,
+              speculative_config=spec_config)
+
+    sampling_params = SamplingParams(
+        max_tokens=args.max_tokens,
+        temperature=args.temperature,
+        top_k=args.top_k,
+        top_p=args.top_p,
+        exclude_input_from_output=True,
+        return_perf_metrics=True,
+    )
+    return llm, sampling_params
+
+
+def main():
+    args = parse_arguments()
+    llm, sampling_params = setup_llm(args)
+
+    if not args.dataset:
+        print("No dataset provided, using example prompts")
+        model_prompts = example_prompts
+        outputs = llm.generate(model_prompts, sampling_params)
+
+        for i, output in enumerate(outputs):
+            print(
+                f"[{i}] Prompt: {output.prompt!r}\nGenerated text: {output.outputs[0].text!r}"
+            )
+        return
+
+    dataset = None
+    match args.dataset:
+        case 'mtbench':
+            dataset = MTBenchDataset(args.dataset)
+        case 'aa':
+            dataset = AADataset(args.dataset)
+        case 'magpie':
+            dataset = MagpieDataset(args.dataset)
+
+    # data_items = batch x conversation
+    # conversation = turn x message
+    data_items = dataset.load_dataset(args.dataset_size)
+    current_turn = 1
+    assistant_outputs = [[] for _ in range(len(data_items))]
+    model_prompts = []
+
+    while current_turn <= dataset.max_turn and (args.max_turn is None or
+                                                current_turn <= args.max_turn):
+        for idx, conversation in enumerate(data_items):
+            assemble_messages = []
+            for i in range(current_turn):
+                assemble_messages.append(conversation[i])
+                if i < (current_turn - 1):
+                    assemble_messages.append({
+                        'role':
+                        'assistant',
+                        'content':
+                        assistant_outputs[idx][i]
+                    })
+            tokenized_prompts = dataset.convert_to_chat_format(
+                assemble_messages)
+
+            model_prompts.append(tokenized_prompts)
+        outputs = llm.generate(model_prompts, sampling_params)
+        model_prompts = []
+        for i, output in enumerate(outputs):
+            prompt = output.prompt
+            generated_text = output.outputs[0].text
+            print(
+                f"Turn {current_turn} - [{i}] Prompt: {prompt!r}\nGenerated text: {generated_text!r}"
+            )
+            assistant_outputs[i].append(generated_text)
+
+        current_turn += 1
+
+    if args.print_iter_log:
+        stats = llm.get_stats()
+        for stat in stats:
+            print(stat)
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/run.py
+++ b/examples/run.py
@@ -454,7 +454,8 @@ def main(args):
             lora_ckpt_source=args.lora_ckpt_source,
             gpu_weights_percent=args.gpu_weights_percent,
             max_output_len=args.max_output_len,
-            enable_context_fmha_fp32_acc=args.enable_context_fmha_fp32_acc)
+            enable_context_fmha_fp32_acc=args.enable_context_fmha_fp32_acc,
+        )
         if args.medusa_choices is not None:
             args.medusa_choices = ast.literal_eval(args.medusa_choices)
             assert args.temperature == 1.0, "Medusa should use temperature == 1.0"

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -448,7 +448,7 @@ def instantiate_sampler(model_engine: PyTorchModelEngine,
         assert pytorch_backend_config.attn_backend == "FLASHINFER_STAR_ATTENTION", "attention backend of star attention should be 'FLASHINFER_STAR_ATTENTION'"
         sampler = TorchStarAttentionSampler(
             max_seq_len=model_engine.max_seq_len)
-    elif model_engine.spec_config is not None:
+    elif model_engine.spec_config is not None and model_engine.spec_config.spec_dec_mode.has_spec_decoder():
         sampler = get_spec_decoder(max_seq_len=model_engine.max_seq_len,
                                    spec_config=model_engine.spec_config)
     elif pytorch_backend_config.enable_trtllm_sampler:

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -448,7 +448,8 @@ def instantiate_sampler(model_engine: PyTorchModelEngine,
         assert pytorch_backend_config.attn_backend == "FLASHINFER_STAR_ATTENTION", "attention backend of star attention should be 'FLASHINFER_STAR_ATTENTION'"
         sampler = TorchStarAttentionSampler(
             max_seq_len=model_engine.max_seq_len)
-    elif model_engine.spec_config is not None and model_engine.spec_config.spec_dec_mode.has_spec_decoder():
+    elif model_engine.spec_config is not None and model_engine.spec_config.spec_dec_mode.has_spec_decoder(
+    ):
         sampler = get_spec_decoder(max_seq_len=model_engine.max_seq_len,
                                    spec_config=model_engine.spec_config)
     elif pytorch_backend_config.enable_trtllm_sampler:

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -24,7 +24,8 @@ from tensorrt_llm.bindings.executor import (DisServingRequestStats,
                                             FinishReason, InflightBatchingStats,
                                             IterationStats, KvCacheStats,
                                             RequestStage, RequestStats,
-                                            RequestType, StaticBatchingStats)
+                                            RequestType, SpecDecStats,
+                                            StaticBatchingStats)
 from tensorrt_llm.bindings.internal.batch_manager import (LlmRequestType,
                                                           ReqIdsSet)
 from tensorrt_llm.logger import logger
@@ -512,6 +513,10 @@ class PyExecutor:
         stats.inflight_batching_stats = InflightBatchingStats()
         # staticBatchingStats is not used in pytorch path
         stats.static_batching_stats = StaticBatchingStats()
+        spec_resource_manager = self.resource_manager.resource_managers.get(
+            "spec_resource_manager")
+        if spec_resource_manager is not None:
+            stats.specdec_stats = SpecDecStats()
         return stats
 
     def _populate_req_stats(
@@ -611,6 +616,9 @@ class PyExecutor:
             scheduled_batch.paused_requests)
         stats.inflight_batching_stats.avg_num_decoded_tokens_per_iter = 0
         stats.inflight_batching_stats.micro_batch_id = 0
+        if stats.specdec_stats is not None:
+            stats.specdec_stats.draft_overhead = 0.0 if iter_latency_ms <= 0.0 else float(
+                stats.specdec_stats.iter_latency_ms) / float(iter_latency_ms)
         return stats
 
     def _append_iter_stats(self,
@@ -627,7 +635,7 @@ class PyExecutor:
                             active_requests: List[LlmRequest],
                             batch_state: BatchState):
         iter_end_time = time.time()
-        iter_latency_ms = iter_end_time - batch_state.iter_start_time
+        iter_latency_ms = (iter_end_time - batch_state.iter_start_time) * 1e3
         if batch_state.iter_stats is None:
             return
 
@@ -803,26 +811,30 @@ class PyExecutor:
                     new_requests) or got_finish_signal
                 if got_finish_signal and len(self.active_requests) == 0:
                     break
+
+                if self.kv_cache_transceiver:
+                    self._check_disagg_gen_transfer_status()
+
                 if self.enable_iter_perf_stats:
                     iter_stats = self._get_init_iter_stats(
                         len(new_requests),
                         self.new_active_requests_queue_latency_ms)
-
-                if self.kv_cache_transceiver:
-                    self._check_disagg_gen_transfer_status()
 
                 if not got_finish_signal:
                     num_dummy_request = self._get_num_dummy_request()
                 if num_dummy_request > 0:
                     self._merge_dummy_request(num_dummy_request)
 
-                if self.draft_model_engine is not None:
+                spec_config = self.model_engine.spec_config
+                if self.draft_model_engine is not None or \
+                    (spec_config is not None and spec_config.spec_dec_mode.is_ngram()):
                     self._prepare_draft_requests()
 
                 scheduled_batch, fitting_disagg_gen_init_requests, num_fitting_reqs = self._schedule(
                 )
 
                 if self.kv_cache_transceiver:
+                    # For requests that are fitting disagg gen init, also prepare resources for KV cache manager
                     self._prepare_disagg_gen_init(
                         fitting_disagg_gen_init_requests)
                     if num_fitting_reqs == 0 and not fitting_disagg_gen_init_requests:
@@ -848,9 +860,20 @@ class PyExecutor:
                 finished_requests = []
 
                 if scheduled_batch.batch_size > 0:
+                    has_ngram_iter_stats = spec_config is not None and spec_config.spec_dec_mode.is_ngram(
+                    ) and iter_stats is not None
+                    if has_ngram_iter_stats:
+                        before = time.time()
+
                     self.resource_manager.prepare_resources(scheduled_batch)
                     if self.draft_model_engine is not None:
                         self._prepare_draft_tokens(scheduled_batch)
+
+                    if has_ngram_iter_stats:
+                        self._insert_ngram_iter_stats(scheduled_batch,
+                                                      iter_stats)
+                        iter_stats.specdec_stats.iter_latency_ms = (
+                            time.time() - before) * 1e3
 
                     if self.kv_cache_transceiver:
                         # For generation requests which have completed KV cache transfer
@@ -903,8 +926,9 @@ class PyExecutor:
             # Set draft tokens here to make the KV cache manager
             # and scheduler aware of them.
             for req in self.active_requests:
-                if req.state != LlmRequestState.GENERATION_IN_PROGRESS:
-                    continue
+                # Comment this to enable providing draft tokens in context phase.
+                #if req.state != LlmRequestState.GENERATION_IN_PROGRESS:
+                #    continue
                 req.py_last_draft_tokens = req.py_draft_tokens
                 max_draft_len = self.model_engine.spec_config.max_draft_tokens
 
@@ -961,7 +985,7 @@ class PyExecutor:
 
                     if num_fitting_reqs == 0 and not fitting_disagg_gen_init_requests:
                         logger.warning(
-                            "num_fitting_reqs =0 and fitting_disagg_gen_init_requests is empty , may not have enough kvCache"
+                            "num_fitting_reqs=0 and fitting_disagg_gen_init_requests is empty, may not have enough kvCache"
                         )
                         self.kv_cache_transceiver.check_context_transfer_status(
                             1)
@@ -1676,6 +1700,43 @@ class PyExecutor:
             error_msg = str(e)
             logger.error(f"Encountered an error in sampling: {error_msg}")
             self._handle_errors(error_msg)
+
+    def _insert_ngram_iter_stats(
+        self, scheduled_requests: ScheduledRequests, iter_stats: IterationStats
+    ) -> Tuple[ScheduledRequests, Dict[int, LlmRequest]]:
+        """
+        Get statistic information from the draft tokens in NGram drafter
+        """
+        assert iter_stats is not None
+
+        total_num_draft_tokens = 0
+        total_num_accepted_tokens = 0
+        num_requests_with_draft_tokens = 0
+        for request in chain(scheduled_requests.context_requests,
+                             scheduled_requests.generation_requests):
+            num_draft_tokens = 0 if request.py_last_draft_tokens is None else len(
+                request.py_last_draft_tokens)
+            num_accepted_tokens = getattr(request,
+                                          "py_num_accepted_draft_tokens", 0)
+            if num_draft_tokens > 0:
+                total_num_draft_tokens = total_num_draft_tokens + num_draft_tokens
+                total_num_accepted_tokens = total_num_accepted_tokens + num_accepted_tokens
+                num_requests_with_draft_tokens = num_requests_with_draft_tokens + 1
+
+        if num_requests_with_draft_tokens > 0:
+            iter_stats.specdec_stats.iter_latency_ms = 0.0  # We do not coutn time in this method
+            iter_stats.specdec_stats.num_draft_tokens = total_num_draft_tokens
+            iter_stats.specdec_stats.num_accepted_tokens = total_num_accepted_tokens
+            iter_stats.specdec_stats.num_requests_with_draft_tokens = num_requests_with_draft_tokens
+            iter_stats.specdec_stats.acceptance_length = float(
+                (total_num_accepted_tokens + num_requests_with_draft_tokens
+                 )) / float(num_requests_with_draft_tokens)
+        else:
+            iter_stats.specdec_stats.iter_latency_ms = 0.0
+            iter_stats.specdec_stats.num_draft_tokens = 0
+            iter_stats.specdec_stats.num_accepted_tokens = 0
+            iter_stats.specdec_stats.num_requests_with_draft_tokens = 0
+            iter_stats.specdec_stats.acceptance_length = 1.0
 
     @nvtx_range("_prepare_draft_batch")
     def _prepare_draft_batch(

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -799,6 +799,8 @@ class PyExecutor:
         torch.cuda.set_device(self.device_id)
         got_finish_signal = False
         num_dummy_request = 0
+        is_ngram = self.model_engine.is_spec_decode and self.model_engine.spec_config.spec_dec_mode.is_ngram(
+        )
         with self._profiler() as profile_step:
             iter_start_time = time.time()
             iter_stats = None
@@ -825,9 +827,7 @@ class PyExecutor:
                 if num_dummy_request > 0:
                     self._merge_dummy_request(num_dummy_request)
 
-                spec_config = self.model_engine.spec_config
-                if self.draft_model_engine is not None or \
-                    (spec_config is not None and spec_config.spec_dec_mode.is_ngram()):
+                if self.draft_model_engine is not None or is_ngram:
                     self._prepare_draft_requests()
 
                 scheduled_batch, fitting_disagg_gen_init_requests, num_fitting_reqs = self._schedule(
@@ -860,7 +860,7 @@ class PyExecutor:
                 finished_requests = []
 
                 if scheduled_batch.batch_size > 0:
-                    has_ngram_iter_stats = spec_config is not None and spec_config.spec_dec_mode.is_ngram(
+                    has_ngram_iter_stats = is_ngram and self.model_engine.spec_config.spec_dec_mode.is_ngram(
                     ) and iter_stats is not None
                     if has_ngram_iter_stats:
                         before = time.time()

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -799,7 +799,7 @@ class PyExecutor:
         torch.cuda.set_device(self.device_id)
         got_finish_signal = False
         num_dummy_request = 0
-        is_ngram = self.model_engine.is_spec_decode and self.model_engine.spec_config.spec_dec_mode.is_ngram(
+        is_ngram = hasattr(self.model_engine, "spec_config") and self.model_engine.spec_config.spec_dec_mode.is_ngram(
         )
         with self._profiler() as profile_step:
             iter_start_time = time.time()

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -799,7 +799,9 @@ class PyExecutor:
         torch.cuda.set_device(self.device_id)
         got_finish_signal = False
         num_dummy_request = 0
-        is_ngram = hasattr(self.model_engine, "spec_config") and self.model_engine.spec_config.spec_dec_mode.is_ngram(
+        is_ngram = hasattr(
+            self.model_engine, "spec_config"
+        ) and self.model_engine.spec_config is not None and self.model_engine.spec_config.spec_dec_mode.is_ngram(
         )
         with self._profiler() as profile_step:
             iter_start_time = time.time()

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -11,7 +11,7 @@ from tensorrt_llm.quantization import KV_CACHE_QUANT_ALGO_LIST
 
 from ..attention_backend.interface import AttentionRuntimeFeatures
 from ..distributed import MPIDist
-from ..speculative import Eagle3Config, get_spec_resource_manager
+from ..speculative import Eagle3Config, NGramConfig, get_spec_resource_manager
 from ._util import (create_kv_cache_manager, create_py_executor_instance,
                     estimate_max_kv_cache_tokens, get_token_num_for_estimation,
                     instantiate_sampler, is_mla)
@@ -62,11 +62,13 @@ def create_py_executor(executor_config: ExecutorConfig,
 
     spec_config = executor_config.speculative_config
     has_draft_model_engine = isinstance(spec_config, Eagle3Config)
+    has_ngram_drafter = isinstance(spec_config, NGramConfig)
 
     attn_runtime_features = AttentionRuntimeFeatures(
         chunked_prefill=executor_config.enable_chunked_context,
         cache_reuse=executor_config.kv_cache_config.enable_block_reuse,
-        has_speculative_draft_tokens=has_draft_model_engine,
+        has_speculative_draft_tokens=has_draft_model_engine
+        or has_ngram_drafter,
     )
 
     model_engine = PyTorchModelEngine(

--- a/tensorrt_llm/_torch/speculative/__init__.py
+++ b/tensorrt_llm/_torch/speculative/__init__.py
@@ -1,6 +1,7 @@
 from .eagle3 import Eagle3Config, Eagle3SpecMetadata
 from .interface import SpecConfig, SpecMetadata
 from .mtp import MTPConfig, MTPEagleWorker, MTPSpecMetadata, MTPWorker
+from .ngram import NGramConfig
 from .utils import (get_num_spec_layers, get_spec_decoder, get_spec_metadata,
                     get_spec_resource_manager)
 
@@ -8,5 +9,5 @@ __all__ = [
     "SpecConfig", "SpecMetadata", "MTPConfig", "MTPWorker", "MTPEagleWorker",
     "Eagle3Config", "Eagle3SpecMetadata", "MTPSpecMetadata",
     "get_spec_metadata", "get_spec_resource_manager", "get_spec_decoder",
-    "get_num_spec_layers"
+    "get_num_spec_layers", "NGramConfig"
 ]

--- a/tensorrt_llm/_torch/speculative/interface.py
+++ b/tensorrt_llm/_torch/speculative/interface.py
@@ -15,6 +15,7 @@ class SpeculativeDecodingMode(IntEnum):
     MTP = auto()
     MTP_EAGLE = auto()
     EAGLE3 = auto()
+    NGRAM = auto()
     NONE = auto()
 
     def is_mtp(self):
@@ -26,6 +27,9 @@ class SpeculativeDecodingMode(IntEnum):
     def is_eagle3(self):
         return self == SpeculativeDecodingMode.EAGLE3
 
+    def is_ngram(self):
+        return self == SpeculativeDecodingMode.NGRAM
+
     def is_none(self):
         return self == SpeculativeDecodingMode.NONE
 
@@ -35,6 +39,9 @@ class SpeculativeDecodingMode(IntEnum):
     def support_overlap_scheduler(self):
         return self.is_mtp()
 
+    def has_spec_decoder(self):
+        return self.is_mtp() or self.is_eagle3()
+
     def extend_ctx(self, attention_backend: AttentionBackend):
         """
         If true, treat generation requests with draft tokens as
@@ -43,8 +50,9 @@ class SpeculativeDecodingMode(IntEnum):
         """
 
         # Fixme: only trtllm attention backend supports eagle3 generation-phase kernels on blackwell.
-        return self.is_eagle3() and not (isinstance(
-            attention_backend, TrtllmAttention) and get_sm_version() == 100)
+        return (self.is_eagle3()
+                and not (isinstance(attention_backend, TrtllmAttention)
+                         and get_sm_version() == 100)) or self.is_ngram()
 
     @staticmethod
     def from_string(name: Optional[str]) -> "SpeculativeDecodingMode":

--- a/tensorrt_llm/_torch/speculative/ngram.py
+++ b/tensorrt_llm/_torch/speculative/ngram.py
@@ -1,0 +1,213 @@
+from dataclasses import dataclass
+from itertools import chain
+from typing import List
+
+from ordered_set import OrderedSet
+
+from ..pyexecutor.llm_request import LlmRequest
+from ..pyexecutor.resource_manager import BaseResourceManager
+from ..pyexecutor.scheduler import ScheduledRequests
+from .interface import SpecConfig, SpeculativeDecodingMode
+
+
+@dataclass
+class NGramConfig(SpecConfig):
+    """
+    Configuration for N-gram drafter.
+    """
+    # The name of speculative decoding.
+    spec_dec_name = "NGRAM"
+
+    num_extra_kv_tokens: int = 0
+    max_draft_tokens: int = 0
+
+    prompt_lookup_num_tokens: int = 5
+    max_matching_ngram_size: int = 5
+    end_id: int = -1
+    is_keep_all: bool = True
+    is_use_oldest: bool = True
+    is_public_pool: bool = True
+
+    def __post_init__(self) -> None:
+        self.spec_dec_mode = SpeculativeDecodingMode.from_string(
+            self.spec_dec_name)
+        self.max_draft_tokens = self.prompt_lookup_num_tokens
+
+    def update_from_model_config(self, model_config):
+        pass
+
+
+class NGramPoolManager(BaseResourceManager):
+    """
+    This class maintains the pattern-matches pairs for NGram drafter.
+
+    For example, one of the existed pairs could be: ["I","love"] -> [["apple", "because", "it", "is"], ["banana", "and"]]
+
+    Here we call ["I","love"] as `pattern`, and [["apple", "because", "it", "is"], ["banana", "and"]] as `matches`.
+
+    `pattern` is a list of token_ids. The pool will provide corresponding draft tokens from the matches if the pattern appears at the tail of the sentence during generation.
+
+    `matches` is a list of candidate draft token_ids attaching to a pattern.
+
+    Arguments:
+        prompt_lookup_num_tokens: int
+            The length maximum of tokens for draft (can be understood as length maximum of output draft tokens)
+
+        max_matching_ngram_size: int
+            The length maximum of tokens for searching (can be understood as length maximum of input tokens for search)
+
+        is_keep_all (bool) = True
+            Whether to save all candidate pattern-matches pairs
+
+        is_use_oldest: bool = True
+            Whether to provide the oldest match when pattern is hit
+
+        is_public_pool: bool = True
+            Whether to use a common pool for all requests
+
+    Members:
+        pool: dict[tuple[int], OrderedSet[int]] or dict[int, dict[tuple[int], OrderedSet[int]]]
+            If is_public_pool == True, it maps from patterns to matches
+            If is_public_pool == False, it maps from request ID to the request-specific pool
+
+        start_index: dict[int, int]
+            It maps from request ID to the index of the prompt to update the pool in the next step
+    """
+
+    def __init__(self, config: NGramConfig, max_num_requests: int):
+
+        self.max_num_requests = max_num_requests
+        self.max_num_draft_tokens = config.max_draft_tokens
+        self.prompt_lookup_num_tokens = config.prompt_lookup_num_tokens
+        self.max_matching_ngram_size = config.max_matching_ngram_size
+        self.is_keep_all = config.is_keep_all
+        self.is_use_oldest = config.is_use_oldest  # TODO: remove this argument
+        self.is_public_pool = config.is_public_pool
+        self.pool = {}
+        self.start_index = {}
+
+    def prepare_resources(self, scheduled_batch: ScheduledRequests):
+        # Update pool and provide draft tokens for the requests
+        for request in chain(scheduled_batch.context_requests,
+                             scheduled_batch.generation_requests):
+            num_draft_tokens = 0 if request.py_last_draft_tokens is None else \
+                len(request.py_last_draft_tokens)
+            num_accepted_tokens = getattr(request,
+                                          "py_num_accepted_draft_tokens", 0)
+            num_rejected_tokens = num_draft_tokens - num_accepted_tokens
+            assert num_rejected_tokens >= 0
+
+            # Generate draft tokens
+            draft_tokens = self._get_draft_tokens(
+                request.get_tokens()[0],
+                request.request_id,
+                request.py_end_id,
+                request.py_orig_prompt_len + request.py_max_new_tokens,
+            )
+
+            # Pad to max_draft_tokens
+            pad_length = self.max_num_draft_tokens - len(draft_tokens)
+            draft_tokens.extend([request.py_end_id] * pad_length)
+            request.py_draft_tokens = draft_tokens
+
+    def update_resources(self, scheduled_batch: ScheduledRequests):
+        """
+        We do not need work after docoding part in NGram drafter
+        """
+
+    def free_resources(self, request: LlmRequest):
+        if self.is_public_pool:
+            return  # TODO: need to have a strategy to swap out the pairs
+        request_id = request.request_id
+        if request_id in self.pool:
+            self.pool.pop(request_id)
+            self.start_index.pop(request_id)
+
+    def add_dummy_requests(self, request_ids: List[int]):
+        """
+        We do not need work after docoding part in NGram drafter
+        """
+
+    def shutdown(self):
+        pass
+
+    def get_max_resource_count(self) -> int:
+        return self.max_num_requests
+
+    def get_needed_resource_to_completion(self, request: LlmRequest):
+        return 0
+
+    def print_pool(self):  # For debug
+        if self.is_public_pool:
+            logger.debug(f"Using public pool, size = {len(self.pool)}")
+            self._print_line(self.pool)
+        else:
+            logger.debug(f"Using private pool")
+            for request_id, request_map in self.pool.items():
+                logger.debug(f"Request {request_id}, size={len(request_map)}")
+                self._print_line(request_map, 4)
+
+    def _print_line(self, local_map, indentation=0):  # For debug
+        for pattern, matches in local_map.items():
+            output = " " * indentation + str(pattern) + "->"
+            for match in matches:
+                output += str(match) + ", "
+            logger.debug(output)
+
+    def _get_draft_tokens(
+        self,
+        prefix: list[int],
+        request_id: int,
+        end_id: int,
+        max_sequence_length: int,
+    ):
+        draft_tokens = [end_id]
+        prefix_len = len(prefix)
+        # Skip search if prefix is length of `max_length - 1`
+        if prefix_len >= max_sequence_length - 1:
+            return draft_tokens
+
+        if request_id not in self.start_index:  # A new request
+            self.start_index[request_id] = 0
+            if not self.is_public_pool:
+                assert len(self.pool) + 1 <= self.max_num_requests
+                self.pool[request_id] = {}
+        pool = (self.pool if self.is_public_pool else self.pool[request_id])
+
+        # Update pool
+        sequence = prefix[self.start_index[request_id]:]
+        for size in range(min(self.max_matching_ngram_size, prefix_len - 1), 0,
+                          -1):
+            # Find each possible pattern-match combination, and use tuple for hash
+            for l in range(len(sequence) - size):
+                r = min(l + size + self.prompt_lookup_num_tokens, len(sequence))
+                pattern = tuple(sequence[l:l + size])
+                new_match = tuple(sequence[l + size:r])
+                if pattern not in pool or \
+                    (not self.is_keep_all and len(match) > pool[pattern][0]):
+                    # Replace the match if
+                    # 1. the pattern does not exist in the pool
+                    # 2. only one match is kept, and the new match is longer (MRU)
+                    pool[pattern] = OrderedSet((new_match, ))
+                elif new_match not in pool[pattern]:
+                    # Update the matches if the pattern is already existed:
+                    # TODO: need a strategy to maintain the short candidates, now we just remove them
+                    # Drop all existed matches with small length
+                    for match in pool[pattern]:
+                        if len(match) < len(new_match):
+                            pool[pattern].remove(match)
+                    pool[pattern].add(new_match)
+
+        # Find match
+        for size in range(min(self.max_matching_ngram_size, prefix_len - 1), 0,
+                          -1):
+            pattern = tuple(prefix[-size:])
+            if pattern not in pool:
+                continue
+            draft_tokens = list(pool[pattern][0 if self.is_use_oldest else -1])
+            break
+        self.start_index[request_id] = max(
+            0, prefix_len -
+            (self.prompt_lookup_num_tokens + self.max_matching_ngram_size - 1))
+
+        return draft_tokens

--- a/tensorrt_llm/_torch/speculative/utils.py
+++ b/tensorrt_llm/_torch/speculative/utils.py
@@ -1,5 +1,6 @@
 from .eagle3 import Eagle3Sampler, Eagle3SpecMetadata
 from .mtp import MTPHiddenStatesManager, MTPSampler, MTPSpecMetadata
+from .ngram import NGramPoolManager
 
 
 def get_spec_metadata(spec_config,
@@ -34,6 +35,8 @@ def get_spec_resource_manager(spec_config, model_config, max_num_requests):
         return MTPHiddenStatesManager(spec_config, model_config.torch_dtype,
                                       model_config.hidden_size,
                                       max_num_requests)
+    elif spec_config.spec_dec_mode.is_ngram():
+        return NGramPoolManager(spec_config, max_num_requests)
     else:
         return None
 

--- a/tensorrt_llm/llmapi/__init__.py
+++ b/tensorrt_llm/llmapi/__init__.py
@@ -8,7 +8,7 @@ from .llm_args import (BatchingType, CacheTransceiverConfig, CalibConfig,
                        DynamicBatchConfig, EagleDecodingConfig,
                        ExtendedRuntimePerfKnobConfig, KvCacheConfig,
                        LookaheadDecodingConfig, MedusaDecodingConfig,
-                       MTPDecodingConfig, SchedulerConfig)
+                       MTPDecodingConfig, NGramDecodingConfig, SchedulerConfig)
 from .llm_utils import (BuildConfig, KvCacheRetentionConfig, QuantAlgo,
                         QuantConfig)
 from .mpi_session import MpiCommSession
@@ -40,4 +40,5 @@ __all__ = [
     'ContextChunkingPolicy',
     'DynamicBatchConfig',
     'CacheTransceiverConfig',
+    'NGramDecodingConfig',
 ]

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -194,7 +194,8 @@ class DecodingBaseConfig(BaseModel):
             "MTP": MTPDecodingConfig,
             "Medusa": MedusaDecodingConfig,
             "Eagle": EagleDecodingConfig,
-            "Lookahead": LookaheadDecodingConfig
+            "Lookahead": LookaheadDecodingConfig,
+            "NGram": NGramDecodingConfig,
         }
 
         config_class = config_classes.get(decoding_type)
@@ -233,6 +234,20 @@ class EagleDecodingConfig(DecodingBaseConfig):
         return cls(**data)
 
     decoding_type: ClassVar[str] = "Eagle"
+
+
+class NGramDecodingConfig(DecodingBaseConfig):
+    prompt_lookup_num_tokens: int = 2
+    max_matching_ngram_size: int = 4
+    is_keep_all: bool = True
+    is_use_oldest: bool = True
+    is_public_pool: bool = True
+
+    @classmethod
+    def from_dict(cls, data: dict):
+        return cls(**data)
+
+    decoding_type: ClassVar[str] = "NGram"
 
 
 class MTPDecodingConfig(DecodingBaseConfig):
@@ -870,8 +885,8 @@ class LlmArgs(BaseModel):
     # Speculative decoding parameters
     speculative_config: Optional[Union[
         LookaheadDecodingConfig, MedusaDecodingConfig, EagleDecodingConfig,
-        MTPDecodingConfig]] = Field(default=None,
-                                    description="Speculative decoding config.")
+        MTPDecodingConfig, NGramDecodingConfig]] = Field(
+            default=None, description="Speculative decoding config.")
 
     batching_type: Optional[BatchingType] = Field(default=None,
                                                   description="Batching type.")
@@ -1201,7 +1216,21 @@ class LlmArgs(BaseModel):
                         max_draft_tokens=self.speculative_config.max_draft_len,
                         eagle_weights_path=self.speculative_config.
                         pytorch_eagle_weights_path)
-
+            elif isinstance(self.speculative_config, NGramDecodingConfig):
+                self.build_config.speculative_decoding_mode = SpeculativeDecodingMode.NGRAM
+                assert self.backend == 'pytorch'
+                assert self.speculative_config.prompt_lookup_num_tokens > 0 and self.speculative_config.max_matching_ngram_size > 0
+                self.build_config.max_draft_len = self.speculative_config.max_draft_len
+                from tensorrt_llm._torch.speculative import NGramConfig
+                self.speculative_config = NGramConfig(
+                    prompt_lookup_num_tokens=self.speculative_config.
+                    prompt_lookup_num_tokens,
+                    max_matching_ngram_size=self.speculative_config.
+                    max_matching_ngram_size,
+                    is_keep_all=self.speculative_config.is_keep_all,
+                    is_use_oldest=self.speculative_config.is_use_oldest,
+                    is_public_pool=self.speculative_config.is_public_pool,
+                )
             elif isinstance(self.speculative_config, MTPDecodingConfig):
                 from tensorrt_llm._torch.speculative import MTPConfig
                 self.speculative_config = MTPConfig(

--- a/tensorrt_llm/llmapi/llm_utils.py
+++ b/tensorrt_llm/llmapi/llm_utils.py
@@ -31,8 +31,8 @@ from .build_cache import (BuildCache, BuildCacheConfig, CachedStage,
                           get_build_cache_config_from_env)
 from .llm_args import (CalibConfig, EagleDecodingConfig, KvCacheConfig, LlmArgs,
                        LookaheadDecodingConfig, MedusaDecodingConfig,
-                       MTPDecodingConfig, _ModelFormatKind, _ModelWrapper,
-                       _ParallelConfig, get_model_format,
+                       MTPDecodingConfig, NGramDecodingConfig, _ModelFormatKind,
+                       _ModelWrapper, _ParallelConfig, get_model_format,
                        update_llm_args_with_extra_dict,
                        update_llm_args_with_extra_options)
 from .mpi_session import MPINodeState, MpiSession
@@ -860,6 +860,7 @@ __all__ = [
     'LookaheadDecodingConfig',
     'MedusaDecodingConfig',
     'MTPDecodingConfig',
+    'NGramDecodingConfig',
     'ContextChunkingPolicy',
     'CapacitySchedulerPolicy',
     'BuildConfig',

--- a/tensorrt_llm/models/modeling_utils.py
+++ b/tensorrt_llm/models/modeling_utils.py
@@ -96,6 +96,7 @@ class SpeculativeDecodingMode(IntFlag):
     LOOKAHEAD_DECODING = auto()
     EXPLICIT_DRAFT_TOKENS = auto()
     EAGLE = auto()
+    NGRAM = auto()
 
     @staticmethod
     def from_arguments(args: argparse.Namespace):
@@ -111,6 +112,8 @@ class SpeculativeDecodingMode(IntFlag):
             return SpeculativeDecodingMode.EXPLICIT_DRAFT_TOKENS
         elif args.speculative_decoding_mode == "eagle":
             return SpeculativeDecodingMode.EAGLE
+        elif args.speculative_decoding_mode == "ngram":
+            return SpeculativeDecodingMode.NGRAM
         else:
             assert False, "Unknown speculative_decoding_mode " + args.speculative_decoding_mode
 

--- a/tests/unittest/_torch/speculative/test_ngram.py
+++ b/tests/unittest/_torch/speculative/test_ngram.py
@@ -1,0 +1,83 @@
+import os
+import sys
+import unittest
+
+import pytest
+import torch
+
+from tensorrt_llm import SamplingParams
+from tensorrt_llm._torch import LLM
+from tensorrt_llm._torch.pyexecutor.config import PyTorchConfig
+from tensorrt_llm.llmapi import KvCacheConfig, NGramDecodingConfig
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+from utils.llm_data import llm_models_root
+
+
+# TODO: Add cuda graph enabled tests.
+# Cuda graph cannot currently be enabled for ngram because cuda graph requires
+# spec metadata and ngram does not have it.
+@pytest.mark.parametrize("use_cuda_graph,attn_backend",
+                         [[False, "TRTLLM"], [False, "FLASHINFER"]])
+def test_llama_ngram(use_cuda_graph: bool, attn_backend: str):
+    total_mem_gb = torch.cuda.get_device_properties(0).total_memory / 1e9
+    if total_mem_gb < 31:
+        pytest.skip("Not enough memory to load target model")
+
+    models_path = llm_models_root()
+
+    pytorch_config = PyTorchConfig(
+        enable_overlap_scheduler=False,
+        use_cuda_graph=use_cuda_graph,
+        # Only create a single CUDA graph to prevent OOM in CI
+        attn_backend=attn_backend,
+        cuda_graph_batch_sizes=[1],
+    )
+
+    kv_cache_config = KvCacheConfig(enable_block_reuse=False, max_tokens=2080)
+
+    sampling_params = SamplingParams(
+        max_tokens=32,
+        temperature=0,
+    )
+    max_batch_size = 1
+
+    target_model_dir = f"{models_path}/llama-models-v2/llama-v2-13b-hf"
+
+    draft_len = 4
+    spec_config = NGramDecodingConfig(
+        prompt_lookup_num_tokens=draft_len,
+        max_matching_ngram_size=draft_len,
+        is_keep_all=True,
+        is_use_oldest=True,
+        is_public_pool=True,
+    )
+    llm_spec = LLM(model=target_model_dir,
+                   max_batch_size=max_batch_size,
+                   pytorch_backend_config=pytorch_config,
+                   kv_cache_config=kv_cache_config,
+                   speculative_config=spec_config)
+
+    prompts = [
+        "The capital of France is", "The president of the United States is"
+    ]
+    results_spec = llm_spec.generate(prompts, sampling_params)
+    generated_text_spec = [result.outputs[0].text for result in results_spec]
+    llm_spec.shutdown()
+
+    llm_ref = LLM(model=target_model_dir,
+                  max_batch_size=max_batch_size,
+                  pytorch_backend_config=pytorch_config,
+                  kv_cache_config=kv_cache_config)
+
+    results_ref = llm_ref.generate(prompts, sampling_params)
+    generated_text_ref = [result.outputs[0].text for result in results_ref]
+    llm_ref.shutdown()
+
+    for text_spec, text_ref in zip(generated_text_spec, generated_text_ref):
+        # The spec decode algorithm currently guarantees identical results
+        assert text_spec == text_ref
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittest/api_stability/references_committed/llm.yaml
+++ b/tests/unittest/api_stability/references_committed/llm.yaml
@@ -80,7 +80,7 @@ methods:
       # Speculative decoding
       speculative_config:
         annotation: Union[tensorrt_llm.llmapi.llm_args.LookaheadDecodingConfig, tensorrt_llm.llmapi.llm_utils.MedusaDecodingConfig,
-          tensorrt_llm.llmapi.llm_utils.EagleDecodingConfig, tensorrt_llm.llmapi.MTPDecodingConfig, NoneType]
+          tensorrt_llm.llmapi.llm_utils.EagleDecodingConfig, tensorrt_llm.llmapi.MTPDecodingConfig, tensorrt_llm.llmapi.llm_args.NGramDecodingConfig, NoneType]
         default: null
       # generation constraints
       max_batch_size:


### PR DESCRIPTION
# Draft: Add dataset support to quickstart_advanced.py

    Add dataset loader and formatter for mtbench, aa and magpie.
    AA dataset has single turn.
    Mtbench and magpie have two turn.
    The main function was modified to run all turns with the model generated
    response attached to the system and user prompt.
    The convert_to_chat_format function helps to format the inputs. I have
    verified that outputs are meaningful.


## Added flags:
--dataset: choices=['mtbench', 'aa', 'magpie']
--dataset_size: Truncate the full dataset to specified size.
--max_turn: Ignore turns more than specified.


## Example Usage:
MODEL="$LLM_MODEL_DATA/llm-models/llama-3.1-model/Meta-Llama-3.1-8B"
DATASET="mtbench"

python3 examples/pytorch/quickstart_dataset.py --model_dir $MODEL8B \
    --spec_decode_algo NGRAM \
    --spec_decode_nextn 5 \
    --max_matching_ngram_size 5 \
    --disable_overlap_scheduler \
    --max_tokens 60 \
    --dataset $DATASET \
    --dataset_size 10 2>&1 | tee $DATASET.10.llama.log
