### PR TITLE
draft: [Auto Deploy] Deepseek support for MLA attention with compressed kv

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_attention.py
@@ -526,12 +526,12 @@ def mla(
     Reference implementation for MLA style attention that handles compressed kv.
     """
     scores = (
-        torch.einsum("bhsc,btc->bsht", q_nope, kv) + torch.einsum("bhsr,btr->bsht", q_pe, pe)
+        torch.einsum("bhsc,btc->bhst", q_nope, kv) + torch.einsum("bhsr,btr->bhst", q_pe, pe)
     ) * softmax_scale
     if attention_mask is not None:
         scores += attention_mask.unsqueeze(1)
     scores = scores.softmax(dim=-1, dtype=torch.float32).type_as(q_nope)
-    attn_output = torch.einsum("bsht,btc->bshc", scores, kv)
+    attn_output = torch.einsum("bhst,btc->bhsc", scores, kv)
     return attn_output
 
 

--- a/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
@@ -120,7 +120,7 @@ class InferenceOptimizer:
         # Match rope
         # TODO (lucaslie): let's move this to perf optimization once TP sharding is improved
         # see https://github.com/NVIDIA/TensorRT-LLM/pull/3668#discussion_r2052714528
-        egm = match_rope_v1(egm)
+        #egm = match_rope_v1(egm)
         egm = match_rope_v2(egm)
 
         ############################################################################################

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_sdpa_mla.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_sdpa_mla.py
@@ -39,7 +39,7 @@ def naive_attn(q_nope, q_pe, compressed_kv, k_pe, wkv_b, softmax_scale):
         is_causal=False,
         dropout_p=0.0,
         scale=softmax_scale,
-    ).transpose(1, 2)
+    )
 
     return x
 
@@ -58,7 +58,7 @@ def mla_attn(q_nope, q_pe, compressed_kv, k_pe, wkv_b, softmax_scale):
     x = torch.ops.deepseek.mla(q_nope_proj, q_pe, compressed_kv, k_pe, None, softmax_scale)
 
     # Up project attention scores
-    x = torch.einsum("bshc,hdc->bshd", x, wkv_b_weight[:, -v_head_dim:])
+    x = torch.einsum("bhsc,hdc->bhsd", x, wkv_b_weight[:, -v_head_dim:])
     return x
 
 


### PR DESCRIPTION
Support MLA attention for DeepseekV3 that operates on compressed kv cache
- [x] Patch attention forward to use ref mla op. The patch will be removed to use a pattern matcher in the future
- [ ] Add Flashinfer MLA with KV cache support
- [ ] Update unit tests