### PR TITLE
test(perf): Add `Llama-3_1-Nemotron-Ultra-253B-v1` perf tests (cpp)

### DIFF
--- a/tests/integration/defs/perf/test_perf.py
+++ b/tests/integration/defs/perf/test_perf.py
@@ -58,6 +58,8 @@ MODEL_PATH_DICT = {
     "llama_v3.1_nemotron_nano_8b": "Llama-3.1-Nemotron-Nano-8B-v1",
     "llama_v3.3_nemotron_super_49b":
     "nemotron-nas/Llama-3_3-Nemotron-Super-49B-v1",
+    "llama_v3.1_nemotron_ultra_253b":
+    "nemotron-nas/Llama-3_1-Nemotron-Ultra-253B-v1",
     # "llama_30b": "llama-models/llama-30b-hf",
     "mixtral_8x7b_v0.1": "Mixtral-8x7B-v0.1",
     "mixtral_8x7b_v0.1_instruct": "Mixtral-8x7B-Instruct-v0.1",
@@ -106,6 +108,8 @@ HF_MODEL_PATH = {
     "llama_v3.1_nemotron_nano_8b_hf": "nvidia/Llama-3.1-Nemotron-Nano-8B-v1",
     "llama_v3.3_nemotron_super_49b_hf":
     "nvidia/Llama-3_3-Nemotron-Super-49B-v1",
+    "llama_v3.1_nemotron_ultra_253b_hf":
+    "nvidia/Llama-3_1-Nemotron-Ultra-253B-v1",
     "mixtral_8x7b_v0.1_hf": "mistralai/Mixtral-8x7B-v0.1",
     "mixtral_8x7b_v0.1_instruct_hf": "mistralai/Mixtral-8x7B-Instruct-v0.1",
     "mistral_7b_v0.1_hf": "mistralai/Mistral-7B-v0.1",

--- a/tests/integration/test_lists/qa/trt_llm_release_perf_test.yml
+++ b/tests/integration/test_lists/qa/trt_llm_release_perf_test.yml
@@ -180,6 +180,13 @@ trt_llm_release_perf_test:
   - perf/test_perf.py::test_perf[llama_v3.3_70b_instruct_fp8-bench-pytorch-float8-input_output_len:128,128-gpus:8]
   - perf/test_perf.py::test_perf[gpt_20b-bench-float16-maxbs:8-input_output_len:128,128-reqs:80-gpus:8]
   - perf/test_perf.py::test_perf[gpt_20b-bench-float16-maxbs:8-input_output_len:512,32-reqs:80-gpus:8]
+  # Llama-3_1-Nemotron-Ultra-253B-v1
+  # all cpp backend, bf16->fp8 post-quantized
+  - perf/test_perf.py::test_perf[llama_v3.1_nemotron_ultra_253b-bench-bfloat16-maxbs:64-input_output_len:5000,500-quant:fp8-reqs:8-con:1-tp:8-gpus:8]
+  - perf/test_perf.py::test_perf[llama_v3.1_nemotron_ultra_253b-bench-bfloat16-maxbs:64-input_output_len:500,2000-quant:fp8-reqs:8-con:1-tp:8-gpus:8]
+  - perf/test_perf.py::test_perf[llama_v3.1_nemotron_ultra_253b-bench-bfloat16-maxbs:64-input_output_len:5000,500-quant:fp8-reqs:250-con:250-tp:8-gpus:8]
+  - perf/test_perf.py::test_perf[llama_v3.1_nemotron_ultra_253b-bench-bfloat16-maxbs:64-input_output_len:500,2000-quant:fp8-reqs:250-con:250-tp:8-gpus:8]
+
 
 - condition:
     ranges:


### PR DESCRIPTION
# Description
Add `llama-3.1-nemotron-ultra-253b-v1` perf tests converage.
This only adds cpp backend for fp8. 
This is because, since a model this big rarely is used in bf16 precision, only resource-efficient to test on fp8. PyT backend fp8 requires pre-quantized fp8 checkpoints (we currently don't have it added).

### Invariants
| Setting | Value |
|---------|-------|
| GPUs / TP | 8 / 8 |
| Engine dtype | bfloat16 → quant-FP8 |
| `max_batch_size` | 64 |
| backend | cpp (TRT) | 
| benchmarking backend | `trtllm-bench` |

Four sequence profiles were benchmarked:

* **C1** & **C2** – **low concurrency**: `reqs = 8`, `con = 1`  
* **C3** & **C4** – **high concurrency**: `reqs = 250`, `con = 250`

---

## Performance Summary

| ID | Con. | Input | Output | Req/s | Output TPS<br>(tok/s) | Avg Latency<br>(ms) | TPS/GPU |
|:--:|:---:|:-----:|:------:|------:|----------------------:|--------------------:|--------:|
| **C1** | 1   | 5 000 | 500   | **0.074** | **37.08**  | 13 484 | 4.64  |
| **C2** | 1   | 500   | 2 000 | 0.020 | 40.81  | 49 011 | 5.10  |
| **C3** | 250 | 5 000 | 500   | 0.453 | 226.29 | 388 037 | 28.29 |
| **C4** | 250 | 500   | 2 000 | 0.387 | 773.77 | 433 890 | 96.72 |

---

## Latency percentiles

<details>
<summary><strong>Concurrency = 1 (C1 & C2)</strong></summary>

| Shape | P50 | P90 | P95 | P99 | Min | Max |
|-------|----:|----:|----:|----:|----:|----:|
| 5 k × 500   | 13 620 | 13 751 | 13 751 | 13 751 | 12 798 | 13 751 |
| 500 × 2 k   | 48 996 | 49 121 | 49 121 | 49 121 | 48 943 | 49 121 |

</details>

<details>
<summary><strong>Concurrency = 250 (C3 & C4)</strong></summary>

| Shape | P50 | P90 | P95 | P99 | Min | Max |
|-------|----:|----:|----:|----:|----:|----:|
| 5 k × 500   | 391 470 | 549 776 | 550 795 | 551 404 | 141 348 | 551 507 |
| 500 × 2 k   | 375 050 | 645 705 | 645 794 | 645 849 | 182 317 | 645 852 |
