### PR TITLE
refactor: Update decoder buffer and logits management

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/handleContextLogits.h
+++ b/cpp/include/tensorrt_llm/batch_manager/handleContextLogits.h
@@ -31,8 +31,8 @@ class CudaStream;
 namespace tensorrt_llm::batch_manager
 {
 
-class RuntimeBuffers;
-class DecoderBuffers;
+class DecoderInputBuffers;
+class DraftBuffers;
 class MedusaBuffers;
 
 namespace tr = tensorrt_llm::runtime;
@@ -47,10 +47,10 @@ public:
 
     HandleContextLogits() = default;
 
-    tr::SizeType32 operator()(RequestVector const& contextRequests,
-        std::vector<tr::SizeType32> const& numContextLogitsVec, tr::ITensor::SharedPtr const& logits,
-        DecoderBuffers& decoderBuffers, tr::ModelConfig const& modelConfig, tr::BufferManager const& manager,
-        tensorrt_llm::runtime::CudaStream const& stream, OptionalRef<MedusaBuffers> medusaBuffers) const;
+    tr::SizeType32 operator()(DecoderInputBuffers& inputBuffers, RequestVector const& contextRequests,
+        tr::ITensor::SharedPtr const& logits, std::vector<tr::SizeType32> const& numContextLogitsVec,
+        tr::ModelConfig const& modelConfig, tr::BufferManager const& manager, OptionalRef<DraftBuffers> draftBuffers,
+        OptionalRef<MedusaBuffers> medusaBuffers) const;
 };
 
 } // namespace tensorrt_llm::batch_manager

--- a/cpp/include/tensorrt_llm/batch_manager/handleGenerationLogits.h
+++ b/cpp/include/tensorrt_llm/batch_manager/handleGenerationLogits.h
@@ -30,8 +30,9 @@ class BufferManager;
 namespace tensorrt_llm::batch_manager
 {
 
+class DecoderInputBuffers;
+class DraftBuffers;
 class RuntimeBuffers;
-class DecoderBuffers;
 
 namespace tr = tensorrt_llm::runtime;
 
@@ -45,9 +46,10 @@ public:
 
     HandleGenerationLogits() = default;
 
-    void operator()(tr::SizeType32 logitsIndex, RequestVector const& generationRequests, DecoderBuffers& decoderBuffers,
-        tr::ModelConfig const& modelConfig, tr::BufferManager const& manager, tr::ITensor::SharedPtr const& logits,
-        OptionalRef<RuntimeBuffers> genRuntimeBuffers) const;
+    void operator()(DecoderInputBuffers& inputBuffers, RequestVector const& generationRequests,
+        tr::ITensor::SharedPtr const& logits, tr::SizeType32 logitsIndex, tr::ModelConfig const& modelConfig,
+        tr::BufferManager const& manager, OptionalRef<RuntimeBuffers> genRuntimeBuffers,
+        OptionalRef<DraftBuffers> draftBuffers) const;
 };
 
 } // namespace tensorrt_llm::batch_manager

--- a/cpp/include/tensorrt_llm/batch_manager/logitsPostProcessor.h
+++ b/cpp/include/tensorrt_llm/batch_manager/logitsPostProcessor.h
@@ -30,10 +30,6 @@ class TllmRuntime;
 namespace tensorrt_llm::batch_manager
 {
 
-class DecoderBuffers;
-
-namespace tr = tensorrt_llm::runtime;
-
 class LogitsPostProcessor : Algorithm
 {
 public:
@@ -48,8 +44,8 @@ public:
     LogitsPostProcessor() = default;
 
     bool operator()(RequestVector const& contextRequests, RequestVector const& generationRequests,
-        bool replicateLogitsPostProcessor, DecoderBuffers& decoderBuffers, tr::WorldConfig const& worldConfig,
-        tr::TllmRuntime& runtime,
+        bool replicateLogitsPostProcessor, std::vector<batch_manager::LlmRequest::TensorPtr>& seqSlotLogits,
+        runtime::WorldConfig const& worldConfig, runtime::TllmRuntime& runtime,
         std::optional<LogitsPostProcessorBatched> logitsPostProcessorBatched = std::nullopt) const;
 };
 

--- a/cpp/tensorrt_llm/batch_manager/handleContextLogits.cpp
+++ b/cpp/tensorrt_llm/batch_manager/handleContextLogits.cpp
@@ -67,9 +67,9 @@ void setupMedusaLogits(std::vector<TensorPtr>& medusaLogitsHeads, TensorPtr cons
 
 } // namespace
 
-SizeType32 HandleContextLogits::operator()(RequestVector const& contextRequests,
-    std::vector<SizeType32> const& numContextLogitsVec, TensorPtr const& logits, DecoderBuffers& decoderBuffers,
-    tr::ModelConfig const& modelConfig, BufferManager const& manager, tensorrt_llm::runtime::CudaStream const& stream,
+SizeType32 HandleContextLogits::operator()(DecoderInputBuffers& inputBuffers, RequestVector const& contextRequests,
+    tr::ITensor::SharedPtr const& logits, std::vector<tr::SizeType32> const& numContextLogitsVec,
+    tr::ModelConfig const& modelConfig, tr::BufferManager const& manager, OptionalRef<DraftBuffers> draftBuffers,
     OptionalRef<MedusaBuffers> medusaBuffers) const
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
@@ -114,13 +114,13 @@ SizeType32 HandleContextLogits::operator()(RequestVector const& contextRequests,
         // Get the logits from the last context token and draft tokens
         auto const numDecoderLogits = 1 + draftLength;
         auto const seqSlot = llmReq->mSeqSlot.value();
-        auto& decoderLogits = decoderBuffers.logits.at(seqSlot);
+        auto& decoderLogits = inputBuffers.logits.at(seqSlot);
         TensorPtr logitsView = ITensor::slice(logits, logitsIndex - numDecoderLogits, numDecoderLogits);
 
         if (modelConfig.getSpeculativeDecodingMode().hasDraftLogits())
         {
             TLLM_CHECK(medusaBuffers);
-            auto& medusaLogitsHeads = decoderBuffers.draftBuffers.predictedDraftLogits.at(seqSlot);
+            auto& medusaLogitsHeads = draftBuffers->predictedDraftLogits.at(seqSlot);
             setupMedusaLogits(medusaLogitsHeads, medusaBuffers->medusaLogitsDevice,
                 modelConfig.getSpeculativeDecodingModule().getMaxDraftPathLen(), logitsIndex - numDecoderLogits,
                 numDecoderLogits);
@@ -143,7 +143,7 @@ SizeType32 HandleContextLogits::operator()(RequestVector const& contextRequests,
             auto const logitsShape = logitsView->getShape();
             auto const logitsType = logitsView->getDataType();
             decoderLogits = manager.gpu(ITensor::makeShape({reqBeamWidth, logitsShape.d[1]}), logitsType);
-            tensorrt_llm::runtime::kernels::tileTensor(*decoderLogits, *logitsView, reqBeamWidth, stream);
+            tensorrt_llm::runtime::kernels::tileTensor(*decoderLogits, *logitsView, reqBeamWidth, manager.getStream());
             decoderLogits->unsqueeze(0);
         }
         else

--- a/cpp/tensorrt_llm/batch_manager/handleContextLogits.cpp
+++ b/cpp/tensorrt_llm/batch_manager/handleContextLogits.cpp
@@ -119,8 +119,9 @@ SizeType32 HandleContextLogits::operator()(DecoderInputBuffers& inputBuffers, Re
 
         if (modelConfig.getSpeculativeDecodingMode().hasDraftLogits())
         {
-            TLLM_CHECK(medusaBuffers);
+            TLLM_CHECK(draftBuffers);
             auto& medusaLogitsHeads = draftBuffers->predictedDraftLogits.at(seqSlot);
+            TLLM_CHECK(medusaBuffers);
             setupMedusaLogits(medusaLogitsHeads, medusaBuffers->medusaLogitsDevice,
                 modelConfig.getSpeculativeDecodingModule().getMaxDraftPathLen(), logitsIndex - numDecoderLogits,
                 numDecoderLogits);

--- a/cpp/tensorrt_llm/batch_manager/handleGenerationLogits.cpp
+++ b/cpp/tensorrt_llm/batch_manager/handleGenerationLogits.cpp
@@ -137,8 +137,10 @@ void HandleGenerationLogits::operator()(DecoderInputBuffers& inputBuffers, Reque
         }
         if (modelConfig.getSpeculativeDecodingMode().hasDraftLogits())
         {
-            TLLM_CHECK(genRuntimeBuffers);
+            TLLM_CHECK(draftBuffers);
             auto& medusaLogitsHeads = draftBuffers->predictedDraftLogits.at(seqSlot);
+            TLLM_CHECK(genRuntimeBuffers);
+            TLLM_CHECK(genRuntimeBuffers->mMedusaBuffers);
             setupMedusaLogits(medusaLogitsHeads, genRuntimeBuffers->mMedusaBuffers->medusaLogitsDevice,
                 modelConfig.getSpeculativeDecodingModule().getMaxDraftPathLen(), logitsIndex, draftLength);
         }

--- a/cpp/tensorrt_llm/batch_manager/handleGenerationLogits.cpp
+++ b/cpp/tensorrt_llm/batch_manager/handleGenerationLogits.cpp
@@ -73,9 +73,10 @@ void setupMedusaLogits(std::vector<TensorPtr>& medusaLogitsHeads, TensorPtr cons
 
 } // namespace
 
-void HandleGenerationLogits::operator()(SizeType32 logitsIndex, RequestVector const& generationRequests,
-    DecoderBuffers& decoderBuffers, tr::ModelConfig const& modelConfig, BufferManager const& manager,
-    TensorPtr const& logits, OptionalRef<RuntimeBuffers> genRuntimeBuffers) const
+void HandleGenerationLogits::operator()(DecoderInputBuffers& inputBuffers, RequestVector const& generationRequests,
+    tr::ITensor::SharedPtr const& logits, tr::SizeType32 logitsIndex, tr::ModelConfig const& modelConfig,
+    tr::BufferManager const& manager, OptionalRef<RuntimeBuffers> genRuntimeBuffers,
+    OptionalRef<DraftBuffers> draftBuffers) const
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
     NVTX3_SCOPED_RANGE(HandleGenerationLogits);
@@ -99,7 +100,7 @@ void HandleGenerationLogits::operator()(SizeType32 logitsIndex, RequestVector co
         TensorPtr logitsView = ITensor::slice(logits, logitsIndex, numLogits);
         TLLM_CHECK_DEBUG_WITH_INFO(tru::tensorHasInvalid<float>(*logitsView, manager, "logits") == false,
             "Found invalid number (NaN or Inf) in logits");
-        auto& decoderLogits = decoderBuffers.logits.at(seqSlot);
+        auto& decoderLogits = inputBuffers.logits.at(seqSlot);
         auto const logitsViewShape = logitsView->getShape();
         if (reqBeamWidth > 1)
         {
@@ -137,7 +138,7 @@ void HandleGenerationLogits::operator()(SizeType32 logitsIndex, RequestVector co
         if (modelConfig.getSpeculativeDecodingMode().hasDraftLogits())
         {
             TLLM_CHECK(genRuntimeBuffers);
-            auto& medusaLogitsHeads = decoderBuffers.draftBuffers.predictedDraftLogits.at(seqSlot);
+            auto& medusaLogitsHeads = draftBuffers->predictedDraftLogits.at(seqSlot);
             setupMedusaLogits(medusaLogitsHeads, genRuntimeBuffers->mMedusaBuffers->medusaLogitsDevice,
                 modelConfig.getSpeculativeDecodingModule().getMaxDraftPathLen(), logitsIndex, draftLength);
         }

--- a/cpp/tensorrt_llm/batch_manager/makeDecodingBatchInputOutput.cpp
+++ b/cpp/tensorrt_llm/batch_manager/makeDecodingBatchInputOutput.cpp
@@ -132,7 +132,7 @@ MakeDecodingBatchInputOutput::operator()(RequestVector const& contextRequests, R
 
     auto [activeSlots, generationSteps] = getActiveSlots(contextRequests, generationRequests);
 
-    auto decodingInput = createDecoderBatchInputs(activeSlots, decoderState, decoderBuffers.logits, maxNumSequences,
+    auto decodingInput = createDecoderBatchInputs(activeSlots, decoderState, inputBuffers.logits, maxNumSequences,
         inputBuffers.forwardBatchSlots, decoderBuffers.cacheIndirectionInput);
     decodingInput->generationSteps = generationSteps;
 

--- a/cpp/tensorrt_llm/pybind/batch_manager/algorithms.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/algorithms.cpp
@@ -100,34 +100,36 @@ void tensorrt_llm::pybind::batch_manager::algorithms::initBindings(pybind11::mod
         .def(py::init())
         .def(
             "__call__",
-            [](HandleContextLogits const& self, RequestVector const& contextRequests,
-                std::vector<tr::SizeType32> const& numContextLogitsVec, at::Tensor const& logits,
-                DecoderBuffers& decoderBuffers, tr::ModelConfig const& modelConfig, tr::BufferManager const& manager,
-                tensorrt_llm::runtime::CudaStream const& stream,
-                OptionalRef<MedusaBuffers> medusaBuffers = std::nullopt)
+            [](HandleContextLogits const& self, DecoderInputBuffers& inputBuffers, RequestVector const& contextRequests,
+                at::Tensor const& logits, std::vector<tr::SizeType32> const& numContextLogitsVec,
+                tr::ModelConfig const& modelConfig, tr::BufferManager const& manager,
+                OptionalRef<MedusaBuffers> medusaBuffers = std::nullopt,
+                OptionalRef<DraftBuffers> draftBuffers = std::nullopt)
             {
-                return self(contextRequests, numContextLogitsVec, tr::TorchView::of(logits), decoderBuffers,
-                    modelConfig, manager, stream, medusaBuffers);
+                return self(inputBuffers, contextRequests, tr::TorchView::of(logits), numContextLogitsVec, modelConfig,
+                    manager, draftBuffers, medusaBuffers);
             },
-            py::arg("context_requests"), py::arg("num_context_logits"), py::arg("logits"), py::arg("decoder_buffers"),
-            py::arg("model_config"), py::arg("buffer_manager"), py::arg("stream"),
-            py::arg("medusa_buffers") = std::nullopt)
+            py::arg("decoder_input_buffers"), py::arg("context_requests"), py::arg("logits"),
+            py::arg("num_context_logits"), py::arg("model_config"), py::arg("buffer_manager"),
+            py::arg("draft_buffers") = std::nullopt, py::arg("medusa_buffers") = std::nullopt)
         .def("name", [](HandleContextLogits const&) { return HandleContextLogits::name; });
 
     py::class_<HandleGenerationLogits>(m, HandleGenerationLogits::name)
         .def(py::init())
         .def(
             "__call__",
-            [](HandleGenerationLogits const& self, tr::SizeType32 logitsIndex, RequestVector const& generationRequests,
-                DecoderBuffers& decoderBuffers, tr::ModelConfig const& modelConfig, tr::BufferManager const& manager,
-                at::Tensor const& logits, OptionalRef<RuntimeBuffers> genRuntimeBuffers = std::nullopt)
+            [](HandleGenerationLogits const& self, DecoderInputBuffers& inputBuffers,
+                RequestVector const& generationRequests, at::Tensor const& logits, tr::SizeType32 logitsIndex,
+                tr::ModelConfig const& modelConfig, tr::BufferManager const& manager,
+                OptionalRef<RuntimeBuffers> genRuntimeBuffers = std::nullopt,
+                OptionalRef<DraftBuffers> draftBuffers = std::nullopt)
             {
-                self(logitsIndex, generationRequests, decoderBuffers, modelConfig, manager, tr::TorchView::of(logits),
-                    genRuntimeBuffers);
+                self(inputBuffers, generationRequests, tr::TorchView::of(logits), logitsIndex, modelConfig, manager,
+                    genRuntimeBuffers, draftBuffers);
             },
-            py::arg("logits_index"), py::arg("generation_requests"), py::arg("decoder_buffers"),
-            py::arg("model_config"), py::arg("buffer_manager"), py::arg("logits"),
-            py::arg("gen_runtime_buffers") = std::nullopt)
+            py::arg("decoder_input_buffers"), py::arg("generation_requests"), py::arg("logits"),
+            py::arg("logits_index"), py::arg("model_config"), py::arg("buffer_manager"),
+            py::arg("gen_runtime_buffers") = std::nullopt, py::arg("draft_buffers") = std::nullopt)
         .def("name", [](HandleGenerationLogits const&) { return HandleGenerationLogits::name; });
 
     py::class_<MakeDecodingBatchInputOutput>(m, MakeDecodingBatchInputOutput::name)

--- a/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
@@ -377,14 +377,16 @@ void initBindings(pybind11::module_& m)
             py::arg("max_num_sequences"), py::arg("model_config"), py::arg("world_config"), py::arg("buffer_manager"));
 
     py::class_<tb::DecoderInputBuffers>(m, "DecoderInputBuffers")
-        .def(py::init<runtime::SizeType32, runtime::SizeType32, tr::BufferManager>(), py::arg("max_batch_size"),
-            py::arg("max_tokens_per_engine_step"), py::arg("manager"))
+        .def(py::init<runtime::SizeType32, runtime::SizeType32, runtime::SizeType32, tr::BufferManager>(),
+            py::arg("max_num_sequences"), py::arg("max_batch_size"), py::arg("max_tokens_per_engine_step"),
+            py::arg("manager"))
         .def_readwrite("setup_batch_slots", &tb::DecoderInputBuffers::setupBatchSlots)
         .def_readwrite("setup_batch_slots_device", &tb::DecoderInputBuffers::setupBatchSlotsDevice)
         .def_readwrite("fill_values", &tb::DecoderInputBuffers::fillValues)
         .def_readwrite("fill_values_device", &tb::DecoderInputBuffers::fillValuesDevice)
         .def_readwrite("inputs_ids", &tb::DecoderInputBuffers::inputsIds)
-        .def_readwrite("forward_batch_slots", &tb::DecoderInputBuffers::forwardBatchSlots);
+        .def_readwrite("forward_batch_slots", &tb::DecoderInputBuffers::forwardBatchSlots)
+        .def_readwrite("logits", &tb::DecoderInputBuffers::logits);
 
     py::class_<tb::DecoderOutputBuffers>(m, "DecoderOutputBuffers")
         .def_readwrite("sequence_lengths_host", &tb::DecoderOutputBuffers::sequenceLengthsHost)
@@ -395,29 +397,25 @@ void initBindings(pybind11::module_& m)
         .def_readwrite("log_probs_host", &tb::DecoderOutputBuffers::logProbsHost)
         .def_readwrite("finish_reasons_host", &tb::DecoderOutputBuffers::finishReasonsHost);
 
-    py::class_<tb::DecoderBuffers::DraftBuffers>(m, "DraftBuffers")
+    py::class_<tb::DraftBuffers>(m, "DraftBuffers")
         .def(py::init())
-        .def_readwrite("next_draft_tokens_device", &tb::DecoderBuffers::DraftBuffers::nextDraftTokensDevice)
-        .def_readwrite("next_draft_tokens_host", &tb::DecoderBuffers::DraftBuffers::nextDraftTokensHost)
-        .def_readwrite(
-            "prev_draft_tokens_lengths_device", &tb::DecoderBuffers::DraftBuffers::prevDraftTokensLengthsDevice)
-        .def_readwrite("prev_draft_tokens_lengths_host", &tb::DecoderBuffers::DraftBuffers::prevDraftTokensLengthsHost)
-        .def_readwrite(
-            "next_draft_tokens_lengths_device", &tb::DecoderBuffers::DraftBuffers::nextDraftTokensLengthsDevice)
-        .def_readwrite("next_draft_tokens_lengths_host", &tb::DecoderBuffers::DraftBuffers::nextDraftTokensLengthsHost)
-        .def_readwrite(
-            "accepted_lengths_cum_sum_device", &tb::DecoderBuffers::DraftBuffers::acceptedLengthsCumSumDevice)
-        .def_readwrite("accepted_packed_paths_device", &tb::DecoderBuffers::DraftBuffers::acceptedPackedPathsDevice)
-        .def_readwrite("predicted_draft_logits", &tb::DecoderBuffers::DraftBuffers::predictedDraftLogits)
-        .def("create", &tb::DecoderBuffers::DraftBuffers::create, py::arg("max_num_sequences"),
-            py::arg("max_tokens_per_step"), py::arg("runtime"), py::arg("model_config"));
+        .def_readwrite("next_draft_tokens_device", &tb::DraftBuffers::nextDraftTokensDevice)
+        .def_readwrite("next_draft_tokens_host", &tb::DraftBuffers::nextDraftTokensHost)
+        .def_readwrite("prev_draft_tokens_lengths_device", &tb::DraftBuffers::prevDraftTokensLengthsDevice)
+        .def_readwrite("prev_draft_tokens_lengths_host", &tb::DraftBuffers::prevDraftTokensLengthsHost)
+        .def_readwrite("next_draft_tokens_lengths_device", &tb::DraftBuffers::nextDraftTokensLengthsDevice)
+        .def_readwrite("next_draft_tokens_lengths_host", &tb::DraftBuffers::nextDraftTokensLengthsHost)
+        .def_readwrite("accepted_lengths_cum_sum_device", &tb::DraftBuffers::acceptedLengthsCumSumDevice)
+        .def_readwrite("accepted_packed_paths_device", &tb::DraftBuffers::acceptedPackedPathsDevice)
+        .def_readwrite("predicted_draft_logits", &tb::DraftBuffers::predictedDraftLogits)
+        .def("create", &tb::DraftBuffers::create, py::arg("max_num_sequences"), py::arg("max_tokens_per_step"),
+            py::arg("runtime"), py::arg("model_config"));
 
     py::classh<tb::DecoderBuffers>(m, "DecoderBuffers")
         .def(py::init<runtime::SizeType32, runtime::SizeType32, runtime::SizeType32, runtime::SizeType32,
                  runtime::BufferManager const&, runtime::ModelConfig const&, runtime::WorldConfig const&>(),
             py::arg("max_num_sequences"), py::arg("max_beam_width"), py::arg("max_attention_window"),
             py::arg("max_tokens_per_step"), py::arg("buffer_manager"), py::arg("model_config"), py::arg("world_config"))
-        .def_readwrite("logits", &tb::DecoderBuffers::logits)
         .def_readwrite("cache_indirection_input", &tb::DecoderBuffers::cacheIndirectionInput)
         .def_readwrite("cache_indirection_output", &tb::DecoderBuffers::cacheIndirectionOutput)
         .def_readwrite("draft_buffers", &tb::DecoderBuffers::draftBuffers);

--- a/cpp/tests/runtime/gptDecoderBatchedTest.cpp
+++ b/cpp/tests/runtime/gptDecoderBatchedTest.cpp
@@ -348,7 +348,7 @@ void testDecoder(nvinfer1::DataType const dtype, std::vector<SamplingConfig>& sa
         decoderState.getSpeculativeDecodingMode(), maxGeneratedTokensPerStep, modelConfig, worldConfig, manager);
 
     // set up inputs and outputs
-    tb::DecoderInputBuffers inputBuffers(batchSize, maxGeneratedTokensPerStep, manager);
+    tb::DecoderInputBuffers inputBuffers(batchSize, batchSize, maxGeneratedTokensPerStep, manager);
     auto batchSlotsRange = BufferRange<SizeType32>(*inputBuffers.setupBatchSlots);
     std::iota(batchSlotsRange.begin(), batchSlotsRange.end(), 0);
 
@@ -488,7 +488,7 @@ void testDecoderWavefront(nvinfer1::DataType const dtype, std::vector<SamplingCo
         decoderState.getSpeculativeDecodingMode(), maxGeneratedTokensPerStep, modelConfig, worldConfig, manager);
 
     // set up inputs and outputs
-    tb::DecoderInputBuffers inputBuffers(batchSize, maxGeneratedTokensPerStep, manager);
+    tb::DecoderInputBuffers inputBuffers(batchSize, batchSize, maxGeneratedTokensPerStep, manager);
 
     auto decoderInputs = createDecoderInputs(batchSize, maxBeamWidth, maxSeqLength, vocabSizePadded, dataType,
         samplingConfigs, generatedTokensPerSteps, computeLogProbs, manager);
@@ -643,7 +643,7 @@ void testDecoderDraft(nvinfer1::DataType const dtype, std::vector<SamplingConfig
         decoderState.getSpeculativeDecodingMode(), maxGeneratedTokensPerStep, modelConfig, worldConfig, manager);
 
     // set up inputs and outputs
-    tb::DecoderInputBuffers inputBuffers(batchSize, maxGeneratedTokensPerStep, manager);
+    tb::DecoderInputBuffers inputBuffers(batchSize, batchSize, maxGeneratedTokensPerStep, manager);
 
     auto decoderInputs = createDecoderInputs(batchSize, maxBeamWidth, maxSeqLength, vocabSizePadded, dataType,
         samplingConfigs, generatedTokensPerSteps, false, manager);

--- a/tensorrt_llm/_torch/pyexecutor/handle_context_logits.py
+++ b/tensorrt_llm/_torch/pyexecutor/handle_context_logits.py
@@ -1,9 +1,8 @@
-from typing import List
+from typing import List, Tuple
 
 import torch
 
 from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest
-from tensorrt_llm.bindings.internal.batch_manager import DecoderInputBuffers
 from tensorrt_llm.logger import logger
 
 
@@ -11,27 +10,27 @@ class HandleContextLogits:
 
     def __call__(
         self,
-        decoder_input_buffers: DecoderInputBuffers,
         context_requests: List[LlmRequest],
         logits: torch.Tensor,
         num_context_logits_vec: List[int],
-    ) -> int:
+        max_num_sequences: int,
+    ) -> Tuple[List[torch.Tensor], int]:
         """Handle context logits for a batch of requests.
 
         Args:
-            decoder_input_buffers: Decoder input buffers for storing intermediate results
             context_requests: List of context requests to process
             logits: Input logits tensor
             num_context_logits_vec: Number of context logits for each request
+            max_num_sequences: Maximum number of sequences to process
 
         Returns:
+            List[torch.Tensor]: List of logits tensors for each request
             int: Index into logits tensor after processing all requests
         """
         logits_index = 0
 
         # Copy logits into decoderBuffers.logits
-        decoder_buffer_logits = [torch.empty(0)] * len(
-            decoder_input_buffers.logits)
+        decoder_buffer_logits = [torch.empty(0)] * max_num_sequences
         for batch_index, llm_req in enumerate(context_requests):
             num_context_logits = num_context_logits_vec[batch_index]
             draft_length = llm_req.num_draft_tokens if llm_req.is_last_context_chunk else 0
@@ -76,7 +75,4 @@ class HandleContextLogits:
             # else:
             #     decoder_buffer_logits[seq_slot] = logits_view[:logits_view.shape[0], :1, :logits_view.shape[1]]
 
-        # Needs to be done in bulk for the copy to work
-        decoder_input_buffers.logits = decoder_buffer_logits
-
-        return logits_index
+        return decoder_buffer_logits, logits_index

--- a/tensorrt_llm/_torch/pyexecutor/handle_context_logits.py
+++ b/tensorrt_llm/_torch/pyexecutor/handle_context_logits.py
@@ -3,22 +3,26 @@ from typing import List
 import torch
 
 from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest
-from tensorrt_llm.bindings.internal.batch_manager import DecoderBuffers
+from tensorrt_llm.bindings.internal.batch_manager import DecoderInputBuffers
 from tensorrt_llm.logger import logger
 
 
 class HandleContextLogits:
 
-    def __call__(self, context_requests: List[LlmRequest],
-                 num_context_logits_vec: List[int], logits: torch.Tensor,
-                 decoder_buffers: DecoderBuffers) -> int:
+    def __call__(
+        self,
+        decoder_input_buffers: DecoderInputBuffers,
+        context_requests: List[LlmRequest],
+        logits: torch.Tensor,
+        num_context_logits_vec: List[int],
+    ) -> int:
         """Handle context logits for a batch of requests.
 
         Args:
+            decoder_input_buffers: Decoder input buffers for storing intermediate results
             context_requests: List of context requests to process
-            num_context_logits_vec: Number of context logits for each request
             logits: Input logits tensor
-            decoder_buffers: Decoder buffers for storing intermediate results
+            num_context_logits_vec: Number of context logits for each request
 
         Returns:
             int: Index into logits tensor after processing all requests
@@ -26,7 +30,8 @@ class HandleContextLogits:
         logits_index = 0
 
         # Copy logits into decoderBuffers.logits
-        decoder_buffer_logits = [torch.empty(0)] * len(decoder_buffers.logits)
+        decoder_buffer_logits = [torch.empty(0)] * len(
+            decoder_input_buffers.logits)
         for batch_index, llm_req in enumerate(context_requests):
             num_context_logits = num_context_logits_vec[batch_index]
             draft_length = llm_req.num_draft_tokens if llm_req.is_last_context_chunk else 0
@@ -72,6 +77,6 @@ class HandleContextLogits:
             #     decoder_buffer_logits[seq_slot] = logits_view[:logits_view.shape[0], :1, :logits_view.shape[1]]
 
         # Needs to be done in bulk for the copy to work
-        decoder_buffers.logits = decoder_buffer_logits
+        decoder_input_buffers.logits = decoder_buffer_logits
 
         return logits_index

--- a/tensorrt_llm/_torch/pyexecutor/handle_generation_logits.py
+++ b/tensorrt_llm/_torch/pyexecutor/handle_generation_logits.py
@@ -1,19 +1,19 @@
+from typing import List
+
 import torch
 
 from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest
-from tensorrt_llm.bindings.internal.batch_manager import DecoderInputBuffers
 
 
 class HandleGenerationLogits:
 
     def __call__(
         self,
-        decoder_input_buffers: DecoderInputBuffers,
+        decoder_buffer_logits: List[torch.Tensor],
         generation_requests: list[LlmRequest],
         logits: torch.Tensor,
         logits_index: int,
     ):
-        decoder_buffer_logits = decoder_input_buffers.logits
         for llm_req in generation_requests:
             beam_width = llm_req.get_beam_width_by_iter()
             seq_slot = llm_req.seq_slot
@@ -31,5 +31,4 @@ class HandleGenerationLogits:
 
             logits_index += beam_width
 
-        # Needs to be done in bulk for the copy to work
-        decoder_input_buffers.logits = decoder_buffer_logits
+        return decoder_buffer_logits

--- a/tensorrt_llm/_torch/pyexecutor/handle_generation_logits.py
+++ b/tensorrt_llm/_torch/pyexecutor/handle_generation_logits.py
@@ -1,19 +1,19 @@
 import torch
 
 from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest
-from tensorrt_llm.bindings.internal.batch_manager import DecoderBuffers
+from tensorrt_llm.bindings.internal.batch_manager import DecoderInputBuffers
 
 
 class HandleGenerationLogits:
 
     def __call__(
         self,
-        logits_index: int,
+        decoder_input_buffers: DecoderInputBuffers,
         generation_requests: list[LlmRequest],
-        decoder_buffers: DecoderBuffers,
         logits: torch.Tensor,
+        logits_index: int,
     ):
-        decoder_buffer_logits = decoder_buffers.logits
+        decoder_buffer_logits = decoder_input_buffers.logits
         for llm_req in generation_requests:
             beam_width = llm_req.get_beam_width_by_iter()
             seq_slot = llm_req.seq_slot
@@ -32,4 +32,4 @@ class HandleGenerationLogits:
             logits_index += beam_width
 
         # Needs to be done in bulk for the copy to work
-        decoder_buffers.logits = decoder_buffer_logits
+        decoder_input_buffers.logits = decoder_buffer_logits

--- a/tensorrt_llm/_torch/pyexecutor/make_decoding_batch_input_output.py
+++ b/tensorrt_llm/_torch/pyexecutor/make_decoding_batch_input_output.py
@@ -126,7 +126,7 @@ class MakeDecodingBatchInputOutput:
 
         # Create decoder batch inputs
         decoding_input = self.create_decoder_batch_inputs(
-            active_slots, decoder_state, decoder_buffers.logits,
+            active_slots, decoder_state, decoder_input_buffers.logits,
             max_num_sequences, decoder_input_buffers.forward_batch_slots,
             decoder_buffers.cache_indirection_input)
         decoding_input.generation_steps = generation_steps

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -616,15 +616,15 @@ class TRTLLMSampler(Sampler):
             num_context_logits[
                 batch_index] = request.context_chunk_size if request.py_return_context_logits else 1
 
-        logits_index = self.algs.handle_context_logits(
-            self.store["decoder_input_buffers"],
+        decoder_buffer_logits, logits_index = self.algs.handle_context_logits(
             scheduled_requests.context_requests, model_outputs["logits"],
-            num_context_logits)
+            num_context_logits, self.max_num_sequences)
 
-        self.algs.handle_generation_logits(
-            self.store["decoder_input_buffers"],
-            scheduled_requests.generation_requests, model_outputs["logits"],
-            logits_index)
+        decoder_buffer_logits = self.algs.handle_generation_logits(
+            decoder_buffer_logits, scheduled_requests.generation_requests,
+            model_outputs["logits"], logits_index)
+
+        self.store["decoder_input_buffers"].logits = decoder_buffer_logits
 
         decoding_input, self.decoding_output = self.algs.make_decoding_batch_input_output(
             scheduled_requests.context_requests,

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -545,8 +545,21 @@ class TRTLLMSampler(Sampler):
                 self.executor_config.max_batch_size,
                 self.executor_config.max_beam_width,
             ),
-                        dtype=torch.int)
+                        dtype=torch.int),
+            "decoder_state":
+            DecoderState(dtype=self.logits_datatype,
+                         buffer_manager=buffer_manager)
         }
+
+        self.store["decoder_state"].setup(
+            max_batch_size=self.executor_config.max_batch_size,
+            max_beam_width=self.executor_config.max_beam_width,
+            max_attention_window=self.max_attention_window,
+            sink_token_length=0,
+            max_sequence_length=self.executor_config.max_seq_len,
+            model_config=self.model_config,
+            world_config=self.world_config,
+            buffer_manager=buffer_manager)
 
     def _instantiate_algorithms(self):
         self.algs = Algorithms()
@@ -558,18 +571,6 @@ class TRTLLMSampler(Sampler):
             dtype=self.logits_datatype,
             model_config=self.model_config,
             world_config=self.world_config)
-        self.algs.decoder_state = DecoderState(
-            dtype=self.logits_datatype,
-            buffer_manager=self.store["buffer_manager"])
-        self.algs.decoder_state.setup(
-            max_batch_size=self.executor_config.max_batch_size,
-            max_beam_width=self.executor_config.max_beam_width,
-            max_attention_window=self.max_attention_window,
-            sink_token_length=0,
-            max_sequence_length=self.executor_config.max_seq_len,
-            model_config=self.model_config,
-            world_config=self.world_config,
-            buffer_manager=self.store["buffer_manager"])
         self.algs.create_new_decoder_requests = CreateNewDecoderRequests(
             speculative_decoding_fast_logits=False,
             is_leader_in_orch_mode=False,
@@ -583,7 +584,7 @@ class TRTLLMSampler(Sampler):
         batch_slots, sampling_configs, lookahead_prompt, lookahead_algo_configs = self.algs.create_new_decoder_requests(
             self.model_config, self.world_config, self.decoding_config,
             requests, self.store["buffer_manager"], self.logits_datatype,
-            self.store["decoder_input_buffers"], self.algs.decoder_state,
+            self.store["decoder_input_buffers"], self.store["decoder_state"],
             self.store["cuda_stream"], self.algs.decoder.decoder_stream,
             self.executor_config.max_seq_len, self.beam_width(requests))
 
@@ -592,7 +593,7 @@ class TRTLLMSampler(Sampler):
             sampling_config = make_sampling_config(sampling_configs)
             self.algs.decoder.underlying_decoder().setup(
                 sampling_config, local_batch_size, batch_slots,
-                self.algs.decoder_state.joint_decoding_output,
+                self.store["decoder_state"].joint_decoding_output,
                 self.model_config.data_type, lookahead_prompt,
                 lookahead_algo_configs)
 
@@ -629,9 +630,10 @@ class TRTLLMSampler(Sampler):
             scheduled_requests.context_requests,
             scheduled_requests.generation_requests,
             self.store["decoder_buffers"], self.store["decoder_input_buffers"],
-            self.algs.decoder_state, self.model_config, self.max_num_sequences)
+            self.store["decoder_state"], self.model_config,
+            self.max_num_sequences)
 
-        self.algs.decoder.forward_async(self.algs.decoder_state,
+        self.algs.decoder.forward_async(self.store["decoder_state"],
                                         self.decoding_output, decoding_input)
 
         # NOTE: The following code prepares a new_tokens_device_tensor in accordance with the
@@ -644,26 +646,26 @@ class TRTLLMSampler(Sampler):
             request.seq_slot for request in scheduled_requests.all_requests
         ]
         new_tokens_device_tensor.copy_(
-            self.algs.decoder_state.all_new_tokens[0][seq_slots],
+            self.store["decoder_state"].all_new_tokens[0][seq_slots],
             non_blocking=True)
         new_tokens_device_tensor = new_tokens_device_tensor.view(-1)
 
-        new_output_tokens = self.algs.decoder_state.all_new_tokens.to(
+        new_output_tokens = self.store["decoder_state"].all_new_tokens.to(
             'cpu', non_blocking=True)
-        finished_sum = self.algs.decoder_state.finished_sum.to(
+        finished_sum = self.store["decoder_state"].finished_sum.to(
             'cpu', non_blocking=True)
-        finish_reasons = self.algs.decoder_state.finish_reasons.to(
+        finish_reasons = self.store["decoder_state"].finish_reasons.to(
             'cpu', non_blocking=True)
-        sequence_lengths = self.algs.decoder_state.sequence_lengths.to(
+        sequence_lengths = self.store["decoder_state"].sequence_lengths.to(
             'cpu', non_blocking=True)
 
         log_probs = torch.empty([0], dtype=torch.float, device='cpu')
         cum_log_probs = torch.empty([0], dtype=torch.float, device='cpu')
         if any(request.py_return_log_probs
                for request in scheduled_requests.all_requests):
-            log_probs = self.algs.decoder_state.log_probs.to('cpu',
-                                                             non_blocking=True)
-            cum_log_probs = self.algs.decoder_state.cum_log_probs.to(
+            log_probs = self.store["decoder_state"].log_probs.to(
+                'cpu', non_blocking=True)
+            cum_log_probs = self.store["decoder_state"].cum_log_probs.to(
                 'cpu', non_blocking=True)
 
         device = SampleStateTensors(new_tokens=new_tokens_device_tensor)


### PR DESCRIPTION
## Description

- Moved the handling of logits from `DecoderBuffers` to `DecoderInputBuffers`.
- Separated the `DraftBuffers` from `DecoderBuffers` to manage draft token buffers, enhancing the organization of tensor management.
- Removed `DecoderBuffers` from function signatures across various components.
- Updated Python bindings to reflect changes, maintaining compatibility with existing interfaces.

Changes to TRTLLMSampler: 
- Move decoder_state from algs to store.
- Use pure python type for decoder buffer logits.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
