### PR TITLE
Add tritonrelease container

### DIFF
--- a/docker/Dockerfile.multi
+++ b/docker/Dockerfile.multi
@@ -87,7 +87,6 @@ COPY --from=triton /opt/tritonserver/bin /opt/tritonserver/bin
 COPY --from=triton /opt/tritonserver/caches /opt/tritonserver/caches
 COPY docker/common/install_triton.sh install_triton.sh
 RUN bash ./install_triton.sh && rm install_triton.sh
-RUN rm -rf /opt/tritonserver/backends/tensorrtllm
 
 # Install NIXL
 COPY docker/common/install_nixl.sh install_nixl.sh
@@ -163,10 +162,16 @@ ARG TRT_LLM_VER
 ENV TRT_LLM_GIT_COMMIT=${GIT_COMMIT} \
     TRT_LLM_VERSION=${TRT_LLM_VER}
 
+FROM wheel AS tritonbuild
+
+WORKDIR /src/tensorrt_llm
+RUN pip install /src/tensorrt_llm/build/tensorrt_llm*.whl
+COPY ./triton_backend/ ./triton_backend/
+RUN bash ./triton_backend/inflight_batcher_llm/scripts/build.sh
+
 
 FROM release AS tritonrelease
 
 WORKDIR /app/tensorrt_llm
-COPY ./cpp/ ./cpp
 COPY ./triton_backend/ ./triton_backend/
-RUN bash ./triton_backend/inflight_batcher_llm/scripts/build.sh
+COPY --from=tritonbuild /opt/tritonserver/backends/tensorrtllm /opt/tritonserver/backends/tensorrtllm

--- a/docker/Dockerfile.multi
+++ b/docker/Dockerfile.multi
@@ -87,6 +87,7 @@ COPY --from=triton /opt/tritonserver/bin /opt/tritonserver/bin
 COPY --from=triton /opt/tritonserver/caches /opt/tritonserver/caches
 COPY docker/common/install_triton.sh install_triton.sh
 RUN bash ./install_triton.sh && rm install_triton.sh
+RUN rm -rf /opt/tritonserver/backends/tensorrtllm
 
 # Install NIXL
 COPY docker/common/install_nixl.sh install_nixl.sh
@@ -161,3 +162,11 @@ ARG GIT_COMMIT
 ARG TRT_LLM_VER
 ENV TRT_LLM_GIT_COMMIT=${GIT_COMMIT} \
     TRT_LLM_VERSION=${TRT_LLM_VER}
+
+
+FROM release AS tritonrelease
+
+WORKDIR /app/tensorrt_llm
+COPY ./cpp/ ./cpp
+COPY ./triton_backend/ ./triton_backend/
+RUN bash ./triton_backend/inflight_batcher_llm/scripts/build.sh

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -150,6 +150,7 @@ devel_%: STAGE = devel
 tritondevel_%: STAGE = tritondevel
 tritonrelease_%: STAGE = tritonrelease
 tritonrelease_%: DEVEL_IMAGE = tritondevel
+tritonrelease_run: WORK_DIR = /app/tensorrt_llm
 
 wheel_%: STAGE = wheel
 wheel_run: WORK_DIR = /src/tensorrt_llm

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -148,6 +148,8 @@ endif
 
 devel_%: STAGE = devel
 tritondevel_%: STAGE = tritondevel
+tritonrelease_%: STAGE = tritonrelease
+tritonrelease_%: DEVEL_IMAGE = tritondevel
 
 wheel_%: STAGE = wheel
 wheel_run: WORK_DIR = /src/tensorrt_llm

--- a/triton_backend/inflight_batcher_llm/CMakeLists.txt
+++ b/triton_backend/inflight_batcher_llm/CMakeLists.txt
@@ -24,7 +24,7 @@
 cmake_minimum_required(VERSION 3.17)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/set_ifndef.cmake)
 
-set_ifndef(TRTLLM_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../tensorrt_llm)
+set_ifndef(TRTLLM_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../)
 
 include_directories(${TRTLLM_DIR} ${TRTLLM_DIR}/cpp/include)
 


### PR DESCRIPTION
# Add a Triton container that contains TensorRT-LLM and Triton backend

This replaces the [old docker file](https://github.com/triton-inference-server/tensorrtllm_backend/blob/main/dockerfile/Dockerfile.trt_llm_backend) that existed in the TRT-LLM backend repo. The build can be optimized further just having something that works for now.

