### PR TITLE
feat: add dataset support for benchmark_core_model with LLMAPI

### DIFF
--- a/tests/integration/defs/triton_server/test_triton_llm.py
+++ b/tests/integration/defs/triton_server/test_triton_llm.py
@@ -3685,3 +3685,17 @@ def test_llmapi_backend(E2E_MODEL_NAME, DECOUPLED_MODE, TRITON_MAX_BATCH_SIZE,
 
             print_info("DEBUG:: run_cmd: python3 " + " ".join(run_cmd))
             venv_check_call(llm_backend_venv, run_cmd)
+
+            run_cmd = [
+                f"{llm_backend_inflight_batcher_llm_root}/benchmark_core_model.py",
+                f"--max-input-len=300",
+                f"--tensorrt-llm-model-name={E2E_MODEL_NAME}",
+                f"--protocol={protocol}",
+                f"--test-llmapi",
+                'dataset',
+                f"--dataset={os.path.join(llm_backend_dataset_root, 'mini_cnn_eval.json')}",
+                f"--tokenizer-dir=TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+            ]
+
+            print_info("DEBUG:: run_cmd: python3 " + " ".join(run_cmd))
+            venv_check_call(llm_backend_venv, run_cmd)

--- a/triton_backend/tools/inflight_batcher_llm/benchmark_core_model.py
+++ b/triton_backend/tools/inflight_batcher_llm/benchmark_core_model.py
@@ -168,8 +168,9 @@ def test_performance(client,
         print(f"[INFO] Total Latency: {latency} ms")
 
         # TODO(kaiyu): support `extract_print_stats` for http
+        # TODO(achartier): support `extract_print_stats` for LLMAPI
         data_dict = None
-        if FLAGS.protocol == "grpc":
+        if FLAGS.protocol == "grpc" and not FLAGS.test_llmapi:
             request_latencies = 0.0
             for latency in user_data._latencies:
                 request_latencies += latency

--- a/triton_backend/tools/inflight_batcher_llm/benchmark_core_model.py
+++ b/triton_backend/tools/inflight_batcher_llm/benchmark_core_model.py
@@ -13,8 +13,6 @@ from datetime import datetime
 from functools import partial
 
 import numpy as np
-from end_to_end_test import \
-    test_performance as test_performance_with_text_prompts
 from transformers import AutoTokenizer
 from utils import utils
 
@@ -75,17 +73,28 @@ def test_performance(client,
         model_name = FLAGS.tensorrt_llm_model_name[i % len(
             FLAGS.tensorrt_llm_model_name)]
         output0_len = np.ones_like([[1]]).astype(np.int32) * 100
-        inputs = [
-            utils.prepare_tensor("input_ids", input_start_ids[0],
-                                 FLAGS.protocol),
-            utils.prepare_tensor("input_lengths", input_lens[0],
-                                 FLAGS.protocol),
-            utils.prepare_tensor("request_output_len", output0_len,
-                                 FLAGS.protocol),
-        ]
+        if FLAGS.test_llmapi:
+            input_data = np.array(
+                [input_start_ids[0]], dtype=object
+            )  ## TODO: [JIRA-4496] support batching in llmapi backend and add tests here.
+            inputs = [
+                utils.prepare_tensor("text_input", input_data, FLAGS.protocol),
+                utils.prepare_tensor("sampling_param_max_tokens",
+                                     np.array([output_lens[0]], dtype=np.int32),
+                                     FLAGS.protocol),
+            ]
+        else:
+            inputs = [
+                utils.prepare_tensor("input_ids", input_start_ids[0],
+                                     FLAGS.protocol),
+                utils.prepare_tensor("input_lengths", input_lens[0],
+                                     FLAGS.protocol),
+                utils.prepare_tensor("request_output_len", output0_len,
+                                     FLAGS.protocol),
+            ]
+            append_pad_id_to_tensors(pad_id, inputs)
+            append_end_id_to_tensors(end_id, inputs)
 
-        append_pad_id_to_tensors(pad_id, inputs)
-        append_end_id_to_tensors(end_id, inputs)
         if FLAGS.decoupled:
             client.async_stream_infer(model_name, inputs, request_id=str(i))
         else:
@@ -106,16 +115,27 @@ def test_performance(client,
         model_name = FLAGS.tensorrt_llm_model_name[i % len(
             FLAGS.tensorrt_llm_model_name)]
         output0_len = np.ones_like([[1]]).astype(np.int32) * output_lens[i]
-        inputs = [
-            utils.prepare_tensor("input_ids", ids, FLAGS.protocol),
-            utils.prepare_tensor("input_lengths", input_lens[i],
-                                 FLAGS.protocol),
-            utils.prepare_tensor("request_output_len", output0_len,
-                                 FLAGS.protocol),
-        ]
+        if FLAGS.test_llmapi:
+            input_data = np.array(
+                [ids], dtype=object
+            )  ## TODO: [JIRA-4496] support batching in llmapi backend and add tests here.
+            inputs = [
+                utils.prepare_tensor("text_input", input_data, FLAGS.protocol),
+                utils.prepare_tensor("sampling_param_max_tokens",
+                                     np.array([output_lens[i]], dtype=np.int32),
+                                     FLAGS.protocol),
+            ]
+        else:
+            inputs = [
+                utils.prepare_tensor("input_ids", ids, FLAGS.protocol),
+                utils.prepare_tensor("input_lengths", input_lens[i],
+                                     FLAGS.protocol),
+                utils.prepare_tensor("request_output_len", output0_len,
+                                     FLAGS.protocol),
+            ]
 
-        append_pad_id_to_tensors(pad_id, inputs)
-        append_end_id_to_tensors(end_id, inputs)
+            append_pad_id_to_tensors(pad_id, inputs)
+            append_end_id_to_tensors(end_id, inputs)
 
         time.sleep(delays[i])
 
@@ -403,29 +423,6 @@ if __name__ == '__main__':
     ratio = []
 
     print(FLAGS.workload)
-    if FLAGS.test_llmapi:
-        assert FLAGS.workload == "dataset", "LLMAPI only supports dataset workload with text prompts"
-        FLAGS.streaming = FLAGS.decoupled
-        FLAGS.model_name = "tensorrt_llm"
-        prompts = []
-        output_lens = []
-        with open(FLAGS.dataset, 'r') as f:
-            data_dict = json.load(f)
-            for req in data_dict:
-                prompt = req['input'] + ' ' + req['instruction']
-                output = req['output']
-                # 1.3 is a magic number that converts number of words to number of tokens
-                if int(len(prompt.split(' ')) / 1.3) > FLAGS.max_input_len:
-                    continue
-                prompts.append(prompt)
-                # 1.3 is a magic number that converts number of words to number of tokens
-                output_lens.append(int(len(output.split(' ')) * 1.3))
-        test_performance_with_text_prompts(client,
-                                           prompts,
-                                           output_lens,
-                                           FLAGS,
-                                           use_llmapi=True)
-        exit(0)
     if FLAGS.workload == "dataset":
         tokenizer = AutoTokenizer.from_pretrained(FLAGS.tokenizer_dir,
                                                   legacy=False,
@@ -453,7 +450,10 @@ if __name__ == '__main__':
                 if prompt_cnt > FLAGS.num_requests:
                     break
 
-                input_start_ids.append(np.array([line], np.int32))
+                if FLAGS.test_llmapi:
+                    input_start_ids.append(prompt)
+                else:
+                    input_start_ids.append(np.array([line], np.int32))
                 input_lens.append(np.array([[len(line)]], np.int32))
                 output_lens.append(
                     int(len(output.split(' ')) * FLAGS.op_tokens_per_word))
@@ -469,6 +469,7 @@ if __name__ == '__main__':
                          delays, FLAGS, pad_id, end_id)
 
     elif FLAGS.workload == "token-norm-dist":
+        assert not FLAGS.test_llmapi, "LLMAPI does not support token-norm-dist workload yet"
         input_lens = utils.get_norm_dist_tokens(FLAGS.input_mean,
                                                 FLAGS.input_stdev,
                                                 FLAGS.num_requests)
@@ -489,6 +490,7 @@ if __name__ == '__main__':
                          delays, FLAGS)
 
     elif FLAGS.workload == "token-from-histogram":
+        assert not FLAGS.test_llmapi, "LLMAPI does not support token-from-histogram workload yet"
         input_lens_orig = utils.get_token_list_from_histogram(
             FLAGS.histogram_key + "_ip")
         output_lens_orig = utils.get_token_list_from_histogram(


### PR DESCRIPTION
# PR title

feat: add dataset support for benchmark_core_model with LLMAPI

## Description

## Test Coverage

Existing tests using benchmark core_model

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
