### PR TITLE
feat: Enhance AutoTuner inference path and code readability

### DIFF
--- a/tensorrt_llm/_torch/autotuner.py
+++ b/tensorrt_llm/_torch/autotuner.py
@@ -13,46 +13,77 @@ from tensorrt_llm.bindings.internal.runtime import delay_kernel
 from tensorrt_llm.logger import logger
 
 
-@dataclass(kw_only=True)
+@dataclass(slots=True, unsafe_hash=True)
+class DynamicTensorSpec:
+    """
+    A specification for a dynamic tensor dimension.
+    Args:
+        input_idx: The index of the input tensor.
+        dim_idx: The index of the dimension to tune.
+        gen_tuning_buckets: A tuple of values to try or a function generating values.
+        map_to_tuning_buckets: A function to map dimensions to valid values during inference.
+    """
+    input_idx: int
+    dim_idx: int
+    gen_tuning_buckets: Union[Tuple[int], Callable]
+    map_to_tuning_buckets: Callable
+
+
+@dataclass(slots=True, unsafe_hash=True)
+class ConstraintSpec:
+    """
+    A specification for a constraint on a tensor dimension.
+    Args:
+        input_idx: The index of the input tensor.
+        dim_idx: The index of the dimension to constrain.
+        infer_shape: A function to infer the shape of the dimension.
+    """
+    input_idx: int
+    dim_idx: int
+    infer_shape: Callable
+
+
+@dataclass(kw_only=True, unsafe_hash=True)
 class TuningConfig:
     """Configuration for autotuning.
 
     This class specifies all the tuning configurations for a single tuning process.
     Args:
-        dynamic_tensors (Tuple[Tuple[int, int, Tuple[Union[Tuple[int], Callable], Callable]]]):
-            how different tensor dimensions should be tuned to optimize performance. It allows
-            defining which input tensor dimensions are dynamic and how they should be tuned
-            by providing shape generators and rounding rules.
-
-            A tuple specifying tuning rules:
-            - First level key: Input tensor index (0-based)
-            - Second level key: Dimension index to tune (0-based)
-            - Value: Tuple of (shape_generator, round_rule) where:
-                - shape_generator: List of values to try or function generating values
-                - round_rule: Function to round dimensions to valid values during inference
+        dynamic_tensor_specs (Tuple[DynamicTensorSpec]): Specifications for how different tensor dimensions
+            should be tuned to optimize performance. Each spec defines:
+            - Which input tensor dimension is dynamic
+            - How to generate tuning values
+            - How to map dimensions to valid values during inference
 
             Example:
                 >>> config = TuningConfig(
-                ...     dynamic_tensors=(
-                ...         (0, 1, ((32, 64, 128), lambda x: ((x + 31) // 32) * 32)),
+                ...     dynamic_tensor_specs=(
+                ...         DynamicTensorSpec(
+                ...             input_idx=0,
+                ...             dim_idx=1,
+                ...             gen_tuning_buckets=(32, 64, 128),
+                ...             map_to_tuning_buckets=lambda x: ((x + 31) // 32) * 32
+                ...         ),
                 ...     )
                 ... )
-        constraints (Tuple[Tuple[int, int, Callable]]):
-            A tuple specifying constraints on the dimensions:
-            - First level key: Input tensor index (0-based)
-            - Second level key: Dimension index to constrain (0-based)
-            - Value: Function to apply to the dimension
+        constraint_specs (Tuple[ConstraintSpec]): Specifications for constraints on tensor dimensions.
+            Each spec defines:
+            - Which input tensor dimension is constrained
+            - How to infer the shape of the dimension based on other dimensions
 
             Example:
-            >>> config = TuningConfig(
-                ...     constraints=(
-                ...         (1, 2, lambda shapes: shapes[0][0] * 2),  # constrained dimension index and constraint function
+                >>> config = TuningConfig(
+                ...     constraint_specs=(
+                ...         ConstraintSpec(
+                ...             input_idx=1,
+                ...             dim_idx=2,
+                ...             infer_shape=lambda shapes: shapes[0][0] * 2
+                ...         ),
                 ...     )
                 ... )
     """
-    dynamic_tensors: Tuple[Tuple[int, int, Tuple[Union[Tuple[int], Callable],
-                                                 Callable]]] = ()
-    constraints: Tuple[Tuple[int, int, Callable]] = ()
+    dynamic_tensor_specs: Tuple[DynamicTensorSpec, ...] = ()
+    constraint_specs: Tuple[ConstraintSpec, ...] = ()
 
 
 @dataclass(unsafe_hash=True)
@@ -107,7 +138,8 @@ class FakeTensor:
 class TunableRunner(ABC):
 
     @abstractmethod
-    def get_valid_tactics(self, inputs: List[FakeTensor]) -> List[int]:
+    def get_valid_tactics(self, inputs: List[torch.Tensor],
+                          profile: OptimizationProfile) -> List[int]:
         """One tactic corresponding to one cuda kernel normally, but how to interpret the meaning
         of tactic is pure internal details of the runner.
 
@@ -155,102 +187,8 @@ class TunableRunner(ABC):
         """
         raise NotImplementedError
 
-    @lru_cache(maxsize=1000)
-    def find_nearest_profile(
-            self, shapes: Tuple[torch.Size],
-            dynamic_tensors: Tuple[Tuple[int, int, Tuple[Union[Tuple[int],
-                                                               Callable],
-                                                         Callable]]],
-            constraints: Tuple[Tuple[int, int, Callable]]) -> Tuple:
-        """Find the nearest optimization profile for given inputs
-        User can define their own nearest profile generation method to reduce the host overhead.
-
-        Args:
-            shapes: Tuple of input tensor shapes
-            dynamic_tensors: Tuple of dynamic tensor dimensions
-            constraints: Tuple of constraints
-
-        Return:
-            Tuple: A tuple containing:
-                - attributes: Tuple of runner attributes, sorted.
-                - profile: Tuple of input tensor shapes
-        """
-        base_profile = OptimizationProfile([[StaticDim(x) for x in s]
-                                            for s in shapes])
-
-        for input_idx, dim_idx, (_, shape_round_rule) in dynamic_tensors:
-            dim_val = base_profile.shapes[input_idx][dim_idx].val
-            nearest_opt_shape = shape_round_rule(dim_val)
-            base_profile.shapes[input_idx][dim_idx] = StaticDim(
-                nearest_opt_shape)
-
-        # Adjust the profile to satisfy the constraints
-        for input_idx, dim_idx, constraint in constraints:
-            min_value = 0
-            max_value = base_profile.shapes[input_idx][dim_idx].val
-            base_profile.shapes[input_idx][dim_idx] = DynamicDim(
-                min_value, constraint(base_profile.get_opt_shapes()), max_value)
-
-        return base_profile.get_opt_shapes()
-
-    def get_cache_key(
-        self,
-        custom_op: str,
-        input_shapes: Tuple[torch.Size],
-        tuning_config: TuningConfig,
-    ) -> Tuple:
-        """Generate a cache key for the given custom operation, runner, inputs, and profile.
-
-        Args:
-            custom_op (str): Name of the custom operation
-            runner (TunableRunner): Runner implementation
-            profile (OptimizationProfile): Optimization profile
-
-        Returns:
-            Tuple[str, str, Tuple, Tuple]: A tuple containing:
-                - custom_op: Operation name
-                - runner_key: Runner class name
-                - attribute_key: Tuple of runner attributes
-                - profile_key: Profile hash key
-        """
-        nearest_profile = self.find_nearest_profile(
-            shapes=input_shapes,
-            dynamic_tensors=tuning_config.dynamic_tensors,
-            constraints=tuning_config.constraints)
-        return (self.get_cache_key_general(custom_op),
-                self.get_cache_key_specifc(nearest_profile))
-
-    def get_cache_key_general(self, custom_op: str) -> Tuple:
-        """Generate the general part of cache key.
-        Args:
-            custom_op: Operation name
-
-        Return:
-            Tuple: A tuple containing:
-                - custom_op: Operation name
-                - runner_key: Runner class name
-        """
-        return custom_op, self.__class__.__name__
-
-    def get_cache_key_specifc(self, profile: Tuple) -> Tuple:
-        """Generate the specific part of cache key.
-        User can define their own cache key assembly method to reduce the host overhead.
-        Args:
-            profile: Tuple of input tensor shapes
-
-        Return:
-            Tuple: A tuple containing:
-                - attributes: Tuple of runner attributes, sorted.
-                - profile: Tuple of input tensor shapes
-        """
-        attributes = {
-            k: v
-            for k, v in self.__dict__.items()
-            if not callable(v) and not k.startswith("_")
-        }
-        attribute_key = tuple(attributes[key]
-                              for key in sorted(attributes.keys()))
-        return attribute_key, profile
+    def __hash__(self):
+        return hash(tuple(self.__dict__.values()))
 
 
 @contextlib.contextmanager
@@ -371,9 +309,9 @@ class AutoTuner:
             [is_cache_hit, runner_id, tactic, stored_profile]
         """
         for r in runners:
-            cache_key = r.get_cache_key(custom_op, input_shapes, tuning_config)
-
-            if cache_key in self.profiling_cache:
+            if (cache_key := AutoTuner._get_cache_key(
+                    custom_op, r, input_shapes,
+                    tuning_config)) in self.profiling_cache:
                 return True, *self.profiling_cache[cache_key]
 
         return False, 0, -1, None
@@ -415,40 +353,33 @@ class AutoTuner:
             # Record the cache miss config.
             # Expect no cache miss in inference. Thus, any cache miss should be recorded.
             if not is_cache_hit:
-                self.stats.cache_misses += 1
-                if custom_op not in self.stats.cache_miss_config_collection:
-                    self.stats.cache_miss_config_collection[custom_op] = set()
-                self.stats.cache_miss_config_collection[custom_op].add(
-                    input_shapes)
-
                 logger.debug(
                     f"[AutoTunner]: Using fallback tactic for {custom_op} with input shapes {input_shapes}"
                 )
-                assert runner == runners[0] \
-                    and tactic == -1, f"Should use fallback runner {runners[0]} and tactic {-1}, but got runner {runner} and tactic {tactic}"
+                logger.debug(
+                    f"[AutoTunner]: Generated key{AutoTuner._get_cache_key(custom_op, runners[0], input_shapes, tuning_config)}"
+                )
             return runner, tactic
 
         assert len(runners) > 0, "At least one runner is required"
         assert all([isinstance(r, TunableRunner) for r in runners]), \
             "All Given runners must be subclass of TunableRunner"
 
-        profiles = self._optimization_profiles(tuning_config.dynamic_tensors,
-                                               tuning_config.constraints,
-                                               inputs)
+        profiles = self._optimization_profiles(tuning_config, inputs)
         # Record the total configs to try
         self.stats.tuned_op_total_configs[custom_op] = len(profiles)
 
         for p in profiles:
             tensors = self._prepare_input_tensors(p, inputs)
-            is_cache_hit, runner, tactic, _ = self.search_cache(
+            is_cache_hit, runner_id, tactic, _ = self.search_cache(
                 custom_op, runners, p.get_opt_shapes(), tuning_config)
             if not is_cache_hit:
                 min_time = float('inf')
                 # Initialize runner and tactic as None in case of no valid tactic or runners are found
-                runner, tactic = None, None
-                for runner_id, r in enumerate(runners):
+                runner_id, tactic = None, None
+                for r_id, r in enumerate(runners):
                     # TODO: use FakeTensor here.
-                    valid_tactics = r.get_valid_tactics(tensors)
+                    valid_tactics = r.get_valid_tactics(tensors, p)
                     runner_arg_names = {
                         p.name
                         for p in inspect.signature(
@@ -471,27 +402,28 @@ class AutoTuner:
                                 self.stats.failed_profiling_count[
                                     custom_op] = set()
                             self.stats.failed_profiling_count[custom_op].add(
-                                r.get_cache_key(custom_op, p.get_opt_shapes(),
-                                                tuning_config))
+                                AutoTuner._get_cache_key(
+                                    custom_op, r, p.get_opt_shapes(),
+                                    tuning_config))
 
                             # Set time_measured to inf to notify the failure of the tactic. This can happen when `get_valid_tactics` mistakenly return wrong tactics
                             # or some runtime error occurs during profiling.
                             time_measured = float('inf')
                         if time_measured < min_time:
                             min_time = time_measured
-                            runner, tactic = r, tac
-                if runner is not None:
+                            runner_id, tactic = r_id, tac
+                if runner_id is not None:
                     # At least one valid (runner, tactic) pair is found
-                    cache_key = runner.get_cache_key(custom_op,
-                                                     p.get_opt_shapes(),
-                                                     tuning_config)
+                    cache_key = AutoTuner._get_cache_key(
+                        custom_op, runners[runner_id], p.get_opt_shapes(),
+                        tuning_config)
                     # inspect call stack
                     self.profiling_cache[cache_key] = (runner_id, tactic, p)
                     self.stats.tuned_op_successful_configs[
                         custom_op] = self.stats.tuned_op_successful_configs.get(
                             custom_op, 0) + 1
                     logger.debug(
-                        f"[Autotuner]: profiling chosen runner: {runner} {tactic} for {cache_key}"
+                        f"[Autotuner]: profiling chosen runner: {runners[runner_id]} {tactic} for {cache_key}"
                     )
 
         # Get the best runner and tactic from cache
@@ -546,16 +478,12 @@ class AutoTuner:
         return avg_time
 
     def _optimization_profiles(
-            self, dynamic_tensors: Tuple[Tuple[int, int, Tuple[Union[Tuple[int],
-                                                                     Callable],
-                                                               Callable]]],
-            constraints: Tuple[Tuple[int, int, Callable]],
+            self, tuning_config: TuningConfig,
             inputs: List[torch.Tensor]) -> List[OptimizationProfile]:
         """Generate optimization profiles for autotuning.
 
         Args:
-            dynamic_tensors (Tuple[Tuple[int, int, Tuple[Union[Tuple[int], Callable], Callable]]]): Tuple specifying which dimensions to tune
-            constraints (Tuple[Tuple[int, int, Callable]]): Tuple specifying constraints on the dimensions
+            tuning_config (TuningConfig): Tuning configuration
             inputs (List[torch.Tensor]): List of input tensors
 
         Returns:
@@ -563,10 +491,10 @@ class AutoTuner:
 
         Note:
             This method performs a cartesian product of all possible dimension
-            combinations specified in dynamic_tensors.
+            combinations specified in dynamic_tensor_specs.
         """
         # every dimension created from the concrete input tensor shape
-        # generate some dynamic dimension description based on the dynamic_tensors
+        # generate some dynamic dimension description based on the dynamic_tensor_specs
         base_profile = OptimizationProfile([[StaticDim(x) for x in t.size()]
                                             for t in inputs])
 
@@ -574,38 +502,84 @@ class AutoTuner:
 
         dynamic_dims = []
 
-        for input_idx, dim_idx, (shape_generater,
-                                 shape_round_rule) in dynamic_tensors:
-            assert inspect.isfunction(shape_generater) or isinstance(shape_generater, (list, tuple)), \
+        for spec in tuning_config.dynamic_tensor_specs:
+            assert inspect.isfunction(spec.gen_tuning_buckets) or isinstance(spec.gen_tuning_buckets, (list, tuple)), \
                 "The given dynamic dimension must provide a opt value generation function or a list of opt values"
-            if inspect.isfunction(shape_generater):
-                opt_shapes = shape_generater(
-                    base_profile.shapes[input_idx][dim_idx].val)
+            if inspect.isfunction(spec.gen_tuning_buckets):
+                opt_shapes = spec.gen_tuning_buckets(
+                    base_profile.shapes[spec.input_idx][spec.dim_idx].val)
             else:
-                opt_shapes = shape_generater
-            dynamic_dims.append((input_idx, dim_idx, opt_shapes))
+                opt_shapes = spec.gen_tuning_buckets
+            opt_shapes_max = tuple(opt_shapes[1:]) + (float('inf'), )
+            opt_shapes_max = {
+                v1: v2
+                for v1, v2 in zip(opt_shapes, opt_shapes_max)
+            }
+            dynamic_dims.append(
+                (spec.input_idx, spec.dim_idx, opt_shapes_max, opt_shapes))
 
         # grid search, do cartesian product for all the dynamic axis
         dim_grids = itertools.product(*[d[-1] for d in dynamic_dims])
         for opt_point in dim_grids:
             p = copy.deepcopy(base_profile)
-            for pos, (input_idx, dim_idx, _) in enumerate(dynamic_dims):
+            for pos, (input_idx, dim_idx, opt_shapes_max,
+                      opt_shapes) in enumerate(dynamic_dims):
                 opt_value = opt_point[pos]
                 #TODO: fix me, how to set the min and max?
-                min_value = 0
-                max_value = base_profile.shapes[input_idx][dim_idx].val
+                min_value = opt_value
+                max_value = opt_shapes_max[opt_value]
                 p.shapes[input_idx][dim_idx] = DynamicDim(
                     min_value, opt_value, max_value)
 
             # Adjust the profile to satisfy the constraints
-            for input_idx, dim_idx, constraint in constraints:
-                min_value = 0
-                max_value = base_profile.shapes[input_idx][dim_idx].val
-                p.shapes[input_idx][dim_idx] = DynamicDim(
-                    min_value, constraint(p.get_opt_shapes()), max_value)
+            for spec in tuning_config.constraint_specs:
+                min_value = opt_value = max_value = spec.infer_shape(
+                    p.get_opt_shapes())
+                p.shapes[spec.input_idx][spec.dim_idx] = DynamicDim(
+                    min_value, opt_value, max_value)
             generated_profiles.append(p)
             logger.debug(f"[Autotuner]: generated profile: {p}")
         return generated_profiles
+
+    @classmethod
+    @lru_cache(maxsize=None)
+    def _find_nearest_profile(cls, shapes: Tuple[torch.Size],
+                              tuning_config: TuningConfig) -> Tuple:
+        """Find the nearest optimization profile for given inputs
+        User can define their own nearest profile generation method to reduce the host overhead.
+
+        Args:
+            shapes: Tuple of input tensor shapes
+            tuning_config: Tuning configuration
+
+        Return:
+            Tuple: A tuple containing:
+                - attributes: Tuple of runner attributes, sorted.
+                - profile: Tuple of input tensor shapes
+        """
+        base_profile = list(list(shape) for shape in shapes)
+
+        for spec in tuning_config.dynamic_tensor_specs:
+            base_profile[spec.input_idx][
+                spec.dim_idx] = spec.map_to_tuning_buckets(
+                    base_profile[spec.input_idx][spec.dim_idx])
+
+        # associated dimensions dependent on other free dynamic dimensions, so assign -1 in the profile
+        for spec in tuning_config.constraint_specs:
+            base_profile[spec.input_idx][spec.dim_idx] = -1
+
+        return tuple(tuple(shape) for shape in base_profile)
+
+    @classmethod
+    def _get_cache_key(
+        cls,
+        custom_op: str,
+        runner: TunableRunner,
+        input_shapes: Tuple[torch.Size],
+        tuning_config: TuningConfig,
+    ) -> Tuple:
+        return (custom_op, runner.__class__.__name__, hash(runner),
+                cls._find_nearest_profile(input_shapes, tuning_config))
 
     def _create_tensor_like(self, origin_tensor: torch.Tensor,
                             dims: List[Dim]) -> torch.Tensor:

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -1,15 +1,14 @@
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from functools import lru_cache
+from typing import List, Optional
 
 import torch
 
-import tensorrt_llm.quantization.utils.fp4_utils as fp4_utils
-
 from ..attention_backend.interface import AttentionInputType
-from ..autotuner import AutoTuner, TunableRunner, TuningConfig
-from ..utils import (compute_swizzled_sf_shape,
+from ..autotuner import (AutoTuner, ConstraintSpec, DynamicTensorSpec,
+                         OptimizationProfile, TunableRunner, TuningConfig)
+from ..utils import (compute_swizzled_sf_shape, fp4_scale_infer_shape,
                      get_last_power_of_2_num_tokens_buckets,
-                     get_power_of_2_num_tokens_buckets,
-                     last_positive_power_of_2, next_positive_power_of_2)
+                     last_positive_power_of_2)
 
 
 # Used to WAR an issue in torch.bmm that it would break the graph when the out is not contiguous.
@@ -20,7 +19,13 @@ def bmm_out(a: torch.Tensor, b: torch.Tensor, out: torch.Tensor) -> None:
 
 class MoERunner(TunableRunner):
     # avoid overhead of creating a new runner in forward pass
-    _runner_dict: Dict[str, torch.classes.trtllm.FusedMoeRunner] = dict()
+    runner_dict = dict()
+    # TODO: only profile for min_latency_mode = False due to the error in the moe_kernels
+    tuning_config = TuningConfig(dynamic_tensor_specs=(
+        DynamicTensorSpec(0, 0, get_last_power_of_2_num_tokens_buckets(8192),
+                          lambda x: min(last_positive_power_of_2(x), 8192)),
+        DynamicTensorSpec(3, 0, (0, ), lambda x: x),
+    ))
 
     def __init__(
         self,
@@ -53,17 +58,17 @@ class MoERunner(TunableRunner):
         instance_key = (x_dtype, weight_dtype, output_dtype,
                         use_fp8_block_scaling, use_w4a8_group_scaling)
 
-        if instance_key not in MoERunner._runner_dict:
-            MoERunner._runner_dict[
+        if instance_key not in MoERunner.runner_dict:
+            MoERunner.runner_dict[
                 instance_key] = torch.classes.trtllm.FusedMoeRunner(
                     x_dtype, weight_dtype, output_dtype, use_fp8_block_scaling,
                     use_w4a8_group_scaling)
-        self._fused_moe_runner = MoERunner._runner_dict[instance_key]
-        self._is_nvfp4 = weight_dtype == torch.int64
+        self.fused_moe_runner = MoERunner.runner_dict[instance_key]
 
     def get_valid_tactics(
         self,
         inputs: List[torch.Tensor],
+        profile: OptimizationProfile,
     ) -> List[int]:
         x, _, _, min_latency_mode_tensor = inputs
         min_latency_mode = min_latency_mode_tensor.size(0) == 1
@@ -75,12 +80,12 @@ class MoERunner(TunableRunner):
         # Cannot profile configuration 4: Cutlass GEMM Tactic
         # [TensorRT-LLM][ERROR] Assertion failed: Failed to initialize cutlass TMA WS grouped gemm.
         # Should be fixed in the moe_kernels in the future.
-        invalid = (m > 128
-                   and min_latency_mode) or (m <= 128 and min_latency_mode and
-                                             (not self._is_nvfp4))
+        invalid = (m > 128 and
+                   min_latency_mode) or (m <= 128 and min_latency_mode and
+                                         (not self.weight_dtype == torch.int64))
 
         return [] if invalid else list(
-            range(self._fused_moe_runner.get_tactic_num()))
+            range(self.fused_moe_runner.get_tactic_num()))
 
     def forward(
         self,
@@ -92,7 +97,7 @@ class MoERunner(TunableRunner):
         x, fc1_expert_weights, fc2_expert_weights, min_latency_mode_tensor = inputs
         min_latency_mode = min_latency_mode_tensor.size(0) == 1
         # determine if we should use min latency mode according to the profiled seq len
-        self._fused_moe_runner.run_gemm_profile(
+        self.fused_moe_runner.run_gemm_profile(
             x,
             fc1_expert_weights,
             fc2_expert_weights,
@@ -108,6 +113,17 @@ class MoERunner(TunableRunner):
             tactic,
             do_preparation,
         )
+
+    @classmethod
+    @lru_cache(maxsize=None)
+    def refine_tuning_config(cls, tune_max_num_tokens: int):
+        cls.tuning_config = TuningConfig(dynamic_tensor_specs=(
+            DynamicTensorSpec(
+                0, 0, get_last_power_of_2_num_tokens_buckets(
+                    tune_max_num_tokens), lambda x: min(
+                        last_positive_power_of_2(x), tune_max_num_tokens)),
+            DynamicTensorSpec(3, 0, (0, ), lambda x: x),
+        ))
 
 
 @torch.library.custom_op("trtllm::fused_moe", mutates_args=())
@@ -133,19 +149,7 @@ def fused_moe(
 ) -> List[torch.Tensor]:
 
     tuner = AutoTuner.get()
-
-    tune_num_tokens_list = []
-    tune_num_tokens = next_positive_power_of_2(tune_max_num_tokens)
-    while tune_num_tokens > 0:
-        tune_num_tokens_list.append(tune_num_tokens)
-        tune_num_tokens //= 2
-    # TODO: only profile for min_latency_mode = False due to the error in the moe_kernels
-    tuning_config = TuningConfig(dynamic_tensors=(
-        # input, dim 0, all valid buckets, map a seq_len to power of 2 bucket index
-        (0, 0, (tuple(tune_num_tokens_list), next_positive_power_of_2)),
-        # min_latency_tensor, dim 0, (0 for False, 1 for True), map to it self
-        (3, 0, ((0, ), lambda x: x)),
-    ))
+    MoERunner.refine_tuning_config(tune_max_num_tokens)
 
     # TODO: set min_latency_mode always to False due to the error in the moe_kernels
     min_latency_tensor = torch.empty(0)
@@ -169,7 +173,7 @@ def fused_moe(
     _, gemm_tactic_1 = tuner.choose_one(
         "trtllm::fused_moe::gemm1",
         [moe_runner],
-        tuning_config,
+        MoERunner.tuning_config,
         [input, fc1_expert_weights, fc2_expert_weights, min_latency_tensor],
         gemm_idx=1,
     )
@@ -177,12 +181,12 @@ def fused_moe(
     _, gemm_tactic_2 = tuner.choose_one(
         "trtllm::fused_moe::gemm2",
         [moe_runner],
-        tuning_config,
+        MoERunner.tuning_config,
         [input, fc1_expert_weights, fc2_expert_weights, min_latency_tensor],
         gemm_idx=2,
     )
 
-    run_moe = moe_runner._fused_moe_runner.run_moe_min_latency if min_latency_mode else moe_runner._fused_moe_runner.run_moe
+    run_moe = moe_runner.fused_moe_runner.run_moe_min_latency if min_latency_mode else moe_runner.fused_moe_runner.run_moe
     output = run_moe(
         input,
         token_selected_experts,
@@ -223,6 +227,7 @@ def _(
     use_fp8_block_scaling: bool = False,
     use_w4a8_group_scaling: bool = False,
     min_latency_mode: bool = False,
+    tune_max_num_tokens: int = 8192,
 ):
     seq_len = input.shape[0]
     hidden_size = fc2_expert_weights.shape[1]
@@ -243,7 +248,12 @@ def _(
 
 
 class NVFP4GemmRunner(TunableRunner):
-    _runner_dict = dict()
+    runner_dict = dict()
+    tuning_config = TuningConfig(dynamic_tensor_specs=(DynamicTensorSpec(
+        0, 0, get_last_power_of_2_num_tokens_buckets,
+        last_positive_power_of_2), ),
+                                 constraint_specs=(ConstraintSpec(
+                                     2, 0, fp4_scale_infer_shape), ))
 
     def __init__(
         self,
@@ -254,16 +264,17 @@ class NVFP4GemmRunner(TunableRunner):
         self.sf_use_ue8m0 = sf_use_ue8m0
         self.output_dtype = output_dtype
         self.to_userbuffers = to_userbuffers
-        if output_dtype not in NVFP4GemmRunner._runner_dict:
-            NVFP4GemmRunner._runner_dict[
+        if output_dtype not in NVFP4GemmRunner.runner_dict:
+            NVFP4GemmRunner.runner_dict[
                 output_dtype] = torch.classes.trtllm.FP4GemmRunner(output_dtype)
-        self._nvfp4_gemm_runner = NVFP4GemmRunner._runner_dict[output_dtype]
+        self.nvfp4_gemm_runner = NVFP4GemmRunner.runner_dict[output_dtype]
 
     def get_valid_tactics(
         self,
         inputs: List[torch.Tensor],
+        profile: OptimizationProfile,
     ) -> List[int]:
-        return list(range(self._nvfp4_gemm_runner.get_num_configs()))
+        return list(range(self.nvfp4_gemm_runner.get_num_configs()))
 
     def forward(
         self,
@@ -272,7 +283,7 @@ class NVFP4GemmRunner(TunableRunner):
         do_preparation: bool = False,
     ) -> torch.Tensor:
         mat1, mat2, mat1_scale, mat2_scale, global_scale = inputs
-        return self._nvfp4_gemm_runner.run_gemm(
+        return self.nvfp4_gemm_runner.run_gemm(
             mat1,
             mat2,
             mat1_scale,
@@ -282,34 +293,6 @@ class NVFP4GemmRunner(TunableRunner):
             self.to_userbuffers,
             tactic,
         )
-
-    def find_nearest_profile(
-            self, shapes: Tuple[torch.Size],
-            dynamic_tensors: Tuple[Tuple[int, int, Tuple[Union[Tuple[int],
-                                                               Callable],
-                                                         Callable]]],
-            constraints: Tuple[Tuple[int, int, Callable]]) -> Tuple:
-        """Generate a unique profile to reduce host overhead during inference.
-        """
-        _, _, (_, shape_round_rule) = dynamic_tensors[0]
-        m, n, k = shape_round_rule(shapes[0][0]), shapes[1][0], shapes[1][1] * 2
-
-        return (m, n, k)
-
-    def get_cache_key_specifc(self, profile: Tuple) -> Tuple:
-        """Generate a unique cache key for the given profile.
-        """
-        return (self.sf_use_ue8m0, self.output_dtype), profile
-
-
-def fp4_scale_dims(input_shapes: List[torch.Tensor], sf_vec_size: int = 16):
-    """Calculate the dimensions of the fp4 scale tensor.
-
-    The shape of act_fp4 determines the dimensions of the fp4 scale tensor. And due to the first dimension of act_fp4 is dynamic and will be tuned in Autotuner, we should always keep these associated dimensions aligned.
-    """
-    out_shape, scale_shape = fp4_utils.get_fp4_shape(input_shapes[0],
-                                                     sf_vec_size)
-    return scale_shape * 2
 
 
 @torch.library.custom_op("trtllm::nvfp4_gemm", mutates_args=())
@@ -326,15 +309,6 @@ def nvfp4_gemm(
 
     tuner = AutoTuner.get()
 
-    tuning_config = TuningConfig(
-        dynamic_tensors=((0, 0, (
-            lambda x: get_power_of_2_num_tokens_buckets(8192)
-            if not to_userbuffers else get_last_power_of_2_num_tokens_buckets(
-                x), lambda x: next_positive_power_of_2(x)
-            if not to_userbuffers else last_positive_power_of_2(x))), ),
-        constraints=((2, 0, fp4_scale_dims), ),
-    )
-
     # allocate workspace for profiling
     nvfp4_gemm_runner = NVFP4GemmRunner(sf_use_ue8m0, to_userbuffers,
                                         output_dtype)
@@ -342,7 +316,7 @@ def nvfp4_gemm(
     _, best_tactic = tuner.choose_one(
         "trtllm::nvfp4_gemm::gemm",
         [nvfp4_gemm_runner],
-        tuning_config,
+        NVFP4GemmRunner.tuning_config,
         [act_fp4, weight, act_sf, weight_scale, alpha],
     )
 

--- a/tensorrt_llm/_torch/utils.py
+++ b/tensorrt_llm/_torch/utils.py
@@ -8,6 +8,7 @@ from typing import Dict, List
 import torch
 
 from tensorrt_llm._utils import TensorWrapper, convert_to_torch_tensor
+from tensorrt_llm.quantization.utils import fp4_utils
 
 is_torch_compiling_flag = False
 
@@ -213,7 +214,15 @@ def get_last_power_of_2_num_tokens_buckets(max_num_tokens) -> List[int]:
     while m >= 1:
         num_token_buckets.append(m)
         m //= 2
-    return num_token_buckets
+    return tuple(num_token_buckets)
+
+
+def fp4_scale_infer_shape(input_shapes: List[List[int]]):
+    """Calculate the dimensions of the fp4 scale tensor.
+    """
+    out_shape, scale_shape = fp4_utils.get_fp4_shape(input_shapes[0],
+                                                     sf_vec_size=16)
+    return scale_shape * 2
 
 
 _enable_piecewise_cuda_graph = True


### PR DESCRIPTION
Fix AutoTuner warmup request generating.
* The current warmup phase creates one request, which is insufficient for the warmup to cover the max_num_tokens. Revise the warmup phase to a batch of requests to cover the max_num_tokens to eliminate potential fallback cases.

Refactor AutoTuner API and reduce host overhead.
* Refine (min, opt, max) values of optimization profile setup for get_valid_tactics to achieve the correct canImplement definition.
* Refine cache key assembly process to reduce host overhead and simplify API.
* Fix lru_cache usage to reduce host overhead.
* Move tuning config initialization as one-time object in tunable runner to reduce host overhead.

Improve tuning config readability. Use dataclass to define tuning config.
