### PR TITLE
feat: forward exceptions to Python and catch OOMs

### DIFF
--- a/cpp/tensorrt_llm/common/opUtils.cpp
+++ b/cpp/tensorrt_llm/common/opUtils.cpp
@@ -50,14 +50,14 @@ namespace
 {
 
 // Get NCCL unique ID for a group of ranks.
-ncclUniqueId getUniqueId(std::set<int> const& group) noexcept
+ncclUniqueId getUniqueId(std::set<int> const& group)
 {
     auto const rank = COMM_SESSION.getRank();
     TLLM_LOG_TRACE("%s start for rank %d", __PRETTY_FUNCTION__, rank);
     ncclUniqueId id;
     if (rank == *group.begin())
     {
-        NCCLCHECK(ncclGetUniqueId(&id));
+        NCCLCHECK_THROW(ncclGetUniqueId(&id));
         for (auto it = std::next(std::begin(group), 1); it != group.end(); ++it)
         {
             COMM_SESSION.sendValue(id, *it, tensorrt_llm::mpi::MpiTag::kDefault);
@@ -122,7 +122,7 @@ std::shared_ptr<ncclComm_t> getComm(std::set<int> const& group)
 #else
     setenv("NCCL_RUNTIME_CONNECT", "0", 0);
 #endif // _WIN32
-    NCCLCHECK(ncclCommInitRank(ncclComm.get(), group.size(), id, groupRank));
+    NCCLCHECK_THROW(ncclCommInitRank(ncclComm.get(), group.size(), id, groupRank));
     commMap[group] = ncclComm;
     TLLM_LOG_TRACE("%s stop for rank %d", __PRETTY_FUNCTION__, rank);
     return ncclComm;

--- a/cpp/tensorrt_llm/common/opUtils.h
+++ b/cpp/tensorrt_llm/common/opUtils.h
@@ -199,6 +199,16 @@ inline bool isBuilding()
         }                                                                                                              \
     } while (0)
 
+#define NCCLCHECK_THROW(cmd)                                                                                           \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        ncclResult_t r = cmd;                                                                                          \
+        if (TLLM_UNLIKELY(r != ncclSuccess))                                                                           \
+        {                                                                                                              \
+            TLLM_THROW("Failed, NCCL error %s:%d '%s'\n", __FILE__, __LINE__, ncclGetErrorString(r));                  \
+        }                                                                                                              \
+    } while (0)
+
 std::unordered_map<nvinfer1::DataType, ncclDataType_t>* getDtypeMap();
 
 std::shared_ptr<ncclComm_t> getComm(std::set<int> const& group);
@@ -306,5 +316,15 @@ std::shared_ptr<cublasLtHandle_t> getCublasLtHandle();
         {                                                                                                              \
             printf("Failed, NVML error %s:%d '%s'\n", __FILE__, __LINE__, nvmlErrorString(r));                         \
             exit(EXIT_FAILURE);                                                                                        \
+        }                                                                                                              \
+    } while (0)
+
+#define NVML_CHECK_THROW(cmd)                                                                                          \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        nvmlReturn_t r = cmd;                                                                                          \
+        if (TLLM_UNLIKELY(r != NVML_SUCCESS))                                                                          \
+        {                                                                                                              \
+            TLLM_THROW("Failed, NVML error %s:%d '%s'\n", __FILE__, __LINE__, nvmlErrorString(r));                     \
         }                                                                                                              \
     } while (0)

--- a/cpp/tensorrt_llm/thop/reducescatterOp.cpp
+++ b/cpp/tensorrt_llm/thop/reducescatterOp.cpp
@@ -47,7 +47,7 @@ public:
 
     ~ReducescatterOp() = default;
 
-    int initialize() noexcept
+    int initialize()
     {
         TLLM_LOG_TRACE("%s start for rank %d", __PRETTY_FUNCTION__, COMM_SESSION.getRank());
         mNcclComm = getComm(mGroup);
@@ -55,7 +55,7 @@ public:
         return 0;
     }
 
-    torch::Tensor run(torch::Tensor const& input, torch::optional<torch::List<int64_t>> sizes) noexcept
+    torch::Tensor run(torch::Tensor const& input, torch::optional<torch::List<int64_t>> sizes)
     {
         TLLM_CHECK_WITH_INFO(mNcclComm.get() != nullptr, "mNcclComm should be initialized before used");
         auto stream = at::cuda::getCurrentCUDAStream(input.get_device());
@@ -87,7 +87,7 @@ public:
             for (int root = 0; root < static_cast<int>(mGroup.size()); ++root)
             {
                 auto split_size = sizes.value()[root];
-                NCCLCHECK(
+                NCCLCHECK_THROW(
                     ncclReduce(input.index({torch::indexing::Slice(split_offset, torch::indexing::None)}).data_ptr(),
                         output.mutable_data_ptr(), numel_base * split_size, (*getDtypeMap())[type], ncclSum, root,
                         *mNcclComm, stream));
@@ -97,7 +97,7 @@ public:
         }
         else
         {
-            NCCLCHECK(ncclReduceScatter(input.data_ptr(), output.mutable_data_ptr(), output.numel(),
+            NCCLCHECK_THROW(ncclReduceScatter(input.data_ptr(), output.mutable_data_ptr(), output.numel(),
                 (*getDtypeMap())[type], ncclSum, *mNcclComm, stream));
         }
         return output;

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -139,13 +139,17 @@ def get_token_num_for_estimation(executor_config, model_config):
         return None
 
 
-def estimate_max_kv_cache_tokens(
-        py_executor: PyExecutor, model_engine: PyTorchModelEngine,
-        executor_config: ExecutorConfig, mapping: Mapping, origin_seq_len: int,
-        ctx_chunk_config,
-        draft_model_engine: PyTorchModelEngine) -> Optional[int]:
+def estimate_max_kv_cache_tokens(py_executor: PyExecutor,
+                                 model_engine: PyTorchModelEngine,
+                                 executor_config: ExecutorConfig,
+                                 mapping: Mapping, origin_seq_len: int,
+                                 ctx_chunk_config,
+                                 draft_model_engine: PyTorchModelEngine) -> int:
     # TODO: support CP by generating dummy requests for it.
     if 'cp_type' in mapping.cp_config:
+        # This is called from create_py_executor, which ensures that
+        # executor_config.max_num_tokens is set.
+        assert executor_config.max_num_tokens is not None
         return executor_config.max_num_tokens
 
     vocab_size = model_engine.model.model_config.pretrained_config.vocab_size


### PR DESCRIPTION
# feat: forward exceptions to Python and catch OOMs

## Description

This prints some additional information when `PyExecutor` creation fails due to insufficient GPU memory.

**Note:** Commit 609e1bc2b35add3c4b054a12c405d39f98c2cf5e is from PR #4493.

For instance, in the case that `ncclCommInitRank` fails in `AllgatherOp.initialize`, the following error information is emitted.

```
RuntimeError: Executor creation failed with an error which might indicate insufficient GPU memory.

The following component could not be created: Additional executor resources (temporary for KV cache size estimation)
Total GPU memory (GiB): 95.09
Free GPU memory before component creation attempt (GiB): 0.32

Previously created components and free GPU memory before/after creation (GiB):
Model: 93.99 / 10.60
Sampler: 10.60 / 6.38
Initial KV cache (temporary for KV cache size estimation): 6.38 / 0.32

Please refer to the TensorRT-LLM documentation for information on how to control the memory usage through TensorRT-LLM configuration options. Possible options include:
  Model: reduce max_num_tokens and/or shard the model weights across GPUs by enabling pipeline and/or tensor parallelism
  Sampler: reduce max_seq_len and/or max_attention_window_size
  Initial KV cache (temporary for KV cache size estimation): reduce max_num_tokens
```

The message says *might indicate*, because the NCCL error text is "unhandled cuda error (run with NCCL_DEBUG=INFO for details)" and only running with `NCCL_DEBUG=WARN` reveals:

```
... [0] include/alloc.h:228 NCCL WARN Cuda failure 2 'out of memory'
... [0] include/alloc.h:346 NCCL WARN Failed to CUDA calloc async 32 bytes
```

But currently there is no NCCL API to get this extra information (with `ncclCommInitRank` failing, `ncclGetLastError` cannot be used).

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
