### PR TITLE
test(perf):  Pt.2 Add `Llama-3_3-Nemotron-Super-49B-v1` integration-perf-tests (cpp)

### DIFF
--- a/tests/integration/test_lists/qa/trt_llm_release_perf_test.yml
+++ b/tests/integration/test_lists/qa/trt_llm_release_perf_test.yml
@@ -285,10 +285,10 @@ trt_llm_release_perf_test:
   - perf/test_perf.py::test_perf[mixtral_8x22b_v0.1-bench-float16-input_output_len:512,512-quant:fp8-tp:4]
   # Llama-3.3-Nemotron-Super-49B-v1
   # trt backend
-  # timeout - perf/test_perf.py::test_perf[llama_v3.3_nemotron_super_49b-bench-bfloat16-maxbs:16-input_output_len:5000,500-con:1-gpus:4]
-  # timeout - perf/test_perf.py::test_perf[llama_v3.3_nemotron_super_49b-bench-bfloat16-maxbs:16-input_output_len:5000,500-quant:fp8-con:1-gpus:4]
-  # timeout - perf/test_perf.py::test_perf[llama_v3.3_nemotron_super_49b-bench-bfloat16-maxbs:16-input_output_len:500,2000-con:1-gpus:4]
-  # timeout - perf/test_perf.py::test_perf[llama_v3.3_nemotron_super_49b-bench-bfloat16-maxbs:16-input_output_len:500,2000-quant:fp8-con:1-gpus:4]
+  - perf/test_perf.py::test_perf[llama_v3.3_nemotron_super_49b-bench-bfloat16-maxbs:64-input_output_len:5000,500-reqs:4-con:1-gpus:4]
+  - perf/test_perf.py::test_perf[llama_v3.3_nemotron_super_49b-bench-bfloat16-maxbs:64-input_output_len:5000,500-quant:fp8-reqs:4-con:1-gpus:4]
+  - perf/test_perf.py::test_perf[llama_v3.3_nemotron_super_49b-bench-bfloat16-maxbs:64-input_output_len:500,2000-reqs:4-con:1-gpus:4]
+  - perf/test_perf.py::test_perf[llama_v3.3_nemotron_super_49b-bench-bfloat16-maxbs:64-input_output_len:500,2000-quant:fp8-reqs:4-con:1-gpus:4]
   - perf/test_perf.py::test_perf[llama_v3.3_nemotron_super_49b-bench-bfloat16-maxbs:16-input_output_len:5000,500-con:250-gpus:4]
   - perf/test_perf.py::test_perf[llama_v3.3_nemotron_super_49b-bench-bfloat16-maxbs:16-input_output_len:5000,500-quant:fp8-con:250-gpus:4]
   - perf/test_perf.py::test_perf[llama_v3.3_nemotron_super_49b-bench-bfloat16-maxbs:16-input_output_len:500,2000-con:250-gpus:4]


### PR DESCRIPTION
# Description
This PR adds the remaining `llama_v3.3_nemotron_super_49b` tests that previous timed-out on high-request settings.  

These tests add four new coverage points in the low-concurrency setting. (2 ctx/gen shapes × BF16/FP8)
This time, the total requests was reduced from 512->4 to fit the time budget.

## Test-plan overview
| **Invariant** | Value |
|--------------|-------|
| GPUs | 4 |
| Backend | cpp (TRT engine are built) |
| benchmarking runtime | trtllm-bench |
| max batch size | 64 |
| Requests | 4 |
| Concurrency | 1 |

**Shmoo-ed parameters**

* **Quant mode**: native BF16 &rarr; post-quantised FP8  
* **Sequence shape**:  
  * **Long-ctx / short-gen** – `input=5 000, output=500`  
  * **Short-ctx / long-gen** – `input=500, output=2 000`

---

## Throughput & latency summary

| Shape | Quant | Req/s | Output TPS<br>(tok/s) | Token TPS<br>(tok/s) | Total Latency<br>(ms) | Avg Latency<br>(ms) | TPS/GPU | TPS/User |
|:-----:|:-----:|------:|----------------------:|---------------------:|----------------------:|--------------------:|--------:|---------:|
| 5 k × 500 | BF16 | **0.1327** | 66.35 | 729.89 | 30 141 | 7 535 | 16.59 | 66.35 |
| 5 k × 500 | FP8  | 0.1902 | 95.10 | 1 046.14 | 21 030 | 5 257 | 23.78 | 95.10 |
| 500 × 2 k | BF16 | 0.0356 | 71.24 | 89.04 | 112 304 | 28 076 | 17.81 | 71.24 |
| 500 × 2 k | FP8  | 0.0507 | 101.35 | 126.69 | 78 931 | 19 733 | 25.34 | 101.35 |

---

## Latency percentiles (ms)

| Shape | Quant | P50 | P90 | P95 | P99 | Min | Max |
|-------|:-----:|----:|----:|----:|----:|----:|----:|
| 5 k × 500 | BF16 | 7 535.5 | 7 536.4 | 7 536.4 | 7 536.4 | 7 534.4 | 7 536.4 |
| 5 k × 500 | FP8  | 5 258.7 | 5 258.9 | 5 258.9 | 5 258.9 | 5 254.9 | 5 258.9 |
| 500 × 2 k | BF16 | 28 076.6 | 28 079.0 | 28 079.0 | 28 079.0 | 28 072.2 | 28 079.0 |
| 500 × 2 k | FP8  | 19 734.7 | 19 735.8 | 19 735.8 | 19 735.8 | 19 730.2 | 19 735.8 |
