### PR TITLE
[TRTLLM-5070][feat] Support FP8 KV Cache Reuse for MLA

### DIFF
--- a/cpp/tensorrt_llm/kernels/mlaKernels.cu
+++ b/cpp/tensorrt_llm/kernels/mlaKernels.cu
@@ -85,6 +85,21 @@ struct VecType<__nv_bfloat16>
     using GPTJEltType = __nv_bfloat162;
 };
 
+struct __align__(16) fp8_16_t
+{
+    __nv_fp8x4_e4m3 x;
+    __nv_fp8x4_e4m3 y;
+    __nv_fp8x4_e4m3 z;
+    __nv_fp8x4_e4m3 w;
+};
+
+template <>
+struct VecType<__nv_fp8_e4m3>
+{
+    using Type = fp8_16_t;
+    using GPTJEltType = __nv_fp8x2_e4m3;
+};
+
 template <typename T>
 struct loadPagedKVKernelTraits
 {
@@ -101,7 +116,7 @@ struct loadPagedKVKernelTraits
     static constexpr int kThreadPerHead = kVecPerHead; // for each head, we use kThreadPerHead threads to fetch all the
                                                        // kv cache data, each thread read kv cache only once.
     static constexpr int kTokenPerBlock
-        = std::is_same_v<T, float> ? 4 : 8;            // for each block, we fetch 8 token for fp16, 4 tokens for fp32.
+        = std::is_same_v<T, float> ? 4 : 8; // for each block, we fetch 4 tokens for fp32, 8 tokens for other types.
     static constexpr int kBlockSize = kThreadPerHead * kTokenPerBlock;
     static constexpr int kKVThreadPerHead = (kLoraSize * kBytesPerElem) / kBytesPerLoad;
 };
@@ -141,18 +156,51 @@ inline __device__ void quantCopy(
     static constexpr int CVT_NUM = COPY_SIZE / sizeof(__nv_fp8_e4m3) / 2;
     static_assert(COPY_SIZE % (sizeof(__nv_fp8_e4m3) * 2) == 0);
     DstVecType fragment;
+    int offset = 0;
 #pragma unroll
     for (int i = 0; i < LOOP_NUM; ++i)
     {
 #pragma unroll
         for (int j = 0; j < CVT_NUM; ++j)
         {
-            float2 val2 = cuda_cast<float2>(reinterpret_cast<SrcType2 const*>(src_fragment_ptr)[j]);
+            float2 val2 = cuda_cast<float2>(reinterpret_cast<SrcType2 const*>(src_fragment_ptr)[j + offset]);
             val2.x *= scale_val;
             val2.y *= scale_val;
             reinterpret_cast<__nv_fp8x2_e4m3*>(&fragment)[j] = __nv_fp8x2_e4m3(val2);
         }
         reinterpret_cast<DstVecType*>(dst_global_ptr)[i] = fragment;
+        offset += CVT_NUM;
+    }
+}
+
+template <typename DstType, int NUM>
+inline __device__ void dequantCopy(
+    DstType* dst_global_ptr, __nv_fp8_e4m3 const* src_fragment_ptr, float const scale_val = 1.f)
+{
+    using DstVecType = typename VecType<DstType>::Type;
+    using DstType2 =
+        typename std::conditional<sizeof(DstType) == 2, typename TypeConverter<DstType>::Type, float2>::type;
+    static constexpr int COPY_SIZE = sizeof(DstVecType);
+    static constexpr int TOTAL_COPY_SIZE = NUM * sizeof(DstType);
+    static constexpr int LOOP_NUM = TOTAL_COPY_SIZE / COPY_SIZE;
+    static_assert(TOTAL_COPY_SIZE % COPY_SIZE == 0);
+    static constexpr int CVT_NUM = COPY_SIZE / sizeof(DstType) / 2;
+    static_assert(COPY_SIZE % (sizeof(DstType) * 2) == 0);
+    DstVecType fragment;
+    int offset = 0;
+#pragma unroll
+    for (int i = 0; i < LOOP_NUM; ++i)
+    {
+#pragma unroll
+        for (int j = 0; j < CVT_NUM; ++j)
+        {
+            float2 val2 = cuda_cast<float2>(reinterpret_cast<__nv_fp8x2_e4m3 const*>(src_fragment_ptr)[j + offset]);
+            val2.x *= scale_val;
+            val2.y *= scale_val;
+            reinterpret_cast<DstType2*>(&fragment)[j] = cuda_cast<DstType2>(val2);
+        }
+        reinterpret_cast<DstVecType*>(dst_global_ptr)[i] = fragment;
+        offset += CVT_NUM;
     }
 }
 
@@ -235,27 +283,13 @@ __global__ void applyMLARopeAndAssignQKVKernelOptContext(T* qkv_output, T const*
             {
                 if (head_idx == 0)
                 {
-                    auto kDst = reinterpret_cast<T*>(kv_cache.getVBlockPtr(batch_idx, token_idx_in_kv_cache));
-                    auto inBlockIdx = kv_cache.getKVLocalIdx(
-                        token_idx_in_kv_cache, 0, TOTAL_VECS_PER_HEAD, K_VECS_PER_HEAD + head_dim_vec_idx);
-                    if (cache_type == KvCacheDataType::FP8)
-                    {
-
-                        quantCopy<T, ELTS_PER_VEC>(reinterpret_cast<__nv_fp8_e4m3*>(kDst) + inBlockIdx * 8,
-                            reinterpret_cast<T const*>(&k), quant_scale_kv_val);
-                    }
-                    else
-                        reinterpret_cast<VecT*>(kDst)[inBlockIdx] = k;
-                }
-                if (head_idx == 0)
-                {
                     auto kDst = reinterpret_cast<T*>(kv_cache.getKBlockPtr(batch_idx, token_idx_in_kv_cache));
                     auto inBlockIdx = kv_cache.getKVLocalIdx(
                         token_idx_in_kv_cache, 0, TOTAL_VECS_PER_HEAD, K_VECS_PER_HEAD + head_dim_vec_idx);
                     if (cache_type == KvCacheDataType::FP8)
                     {
 
-                        quantCopy<T, ELTS_PER_VEC>(reinterpret_cast<__nv_fp8_e4m3*>(kDst) + inBlockIdx * 8,
+                        quantCopy<T, ELTS_PER_VEC>(reinterpret_cast<__nv_fp8_e4m3*>(kDst) + inBlockIdx * ELTS_PER_VEC,
                             reinterpret_cast<T const*>(&k), quant_scale_kv_val);
                     }
                     else
@@ -302,30 +336,13 @@ __global__ void applyMLARopeAndAssignQKVKernelOptContext(T* qkv_output, T const*
             {
                 auto const src_k_global_offset = static_cast<size_t>(global_token_idx) * (c_k + ROPE_DIM);
 
-                auto kDst = reinterpret_cast<T*>(kv_cache.getVBlockPtr(batch_idx, token_idx_in_kv_cache));
-                auto inBlockIdx
-                    = kv_cache.getKVLocalIdx(token_idx_in_kv_cache, 0, TOTAL_VECS_PER_HEAD, head_dim_vec_idx);
-                if (cache_type == KvCacheDataType::FP8)
-                {
-
-                    quantCopy<T, ELTS_PER_VEC>(reinterpret_cast<__nv_fp8_e4m3*>(kDst) + inBlockIdx * 8,
-                        fuse_buf + src_k_global_offset + head_dim_idx, quant_scale_kv_val);
-                }
-                else
-                    reinterpret_cast<VecT*>(kDst)[inBlockIdx]
-                        = *reinterpret_cast<VecT const*>(&fuse_buf[src_k_global_offset + head_dim_idx]);
-            }
-            if (valid_token)
-            {
-                auto const src_k_global_offset = static_cast<size_t>(global_token_idx) * (c_k + ROPE_DIM);
-
                 auto kDst = reinterpret_cast<T*>(kv_cache.getKBlockPtr(batch_idx, token_idx_in_kv_cache));
                 auto inBlockIdx
                     = kv_cache.getKVLocalIdx(token_idx_in_kv_cache, 0, TOTAL_VECS_PER_HEAD, head_dim_vec_idx);
                 if (cache_type == KvCacheDataType::FP8)
                 {
 
-                    quantCopy<T, ELTS_PER_VEC>(reinterpret_cast<__nv_fp8_e4m3*>(kDst) + inBlockIdx * 8,
+                    quantCopy<T, ELTS_PER_VEC>(reinterpret_cast<__nv_fp8_e4m3*>(kDst) + inBlockIdx * ELTS_PER_VEC,
                         fuse_buf + src_k_global_offset + head_dim_idx, quant_scale_kv_val);
                 }
                 else
@@ -460,7 +477,8 @@ __global__ void applyMLARopeAndAssignQKVKernelGeneration(T* qkv_output, T* q_pe,
                         if (cache_type == KvCacheDataType::FP8)
                         {
 
-                            quantCopy<T, ELTS_PER_VEC>(reinterpret_cast<__nv_fp8_e4m3*>(kDst) + inBlockIdx * 8,
+                            quantCopy<T, ELTS_PER_VEC>(
+                                reinterpret_cast<__nv_fp8_e4m3*>(kDst) + inBlockIdx * ELTS_PER_VEC,
                                 reinterpret_cast<T const*>(&data), quant_scale_kv_val);
                         }
                         else
@@ -518,7 +536,7 @@ __global__ void applyMLARopeAndAssignQKVKernelGeneration(T* qkv_output, T* q_pe,
 
                     if (cache_type == KvCacheDataType::FP8)
                     {
-                        quantCopy<T, ELTS_PER_VEC>(reinterpret_cast<__nv_fp8_e4m3*>(kDst) + inBlockIdx * 8,
+                        quantCopy<T, ELTS_PER_VEC>(reinterpret_cast<__nv_fp8_e4m3*>(kDst) + inBlockIdx * ELTS_PER_VEC,
                             fuse_buf + src_kv_global_offset + head_dim_idx, quant_scale_kv_val);
                     }
                     else
@@ -592,13 +610,17 @@ __global__ void applyMLARopeAndAssignQKVKernelGeneration(T* qkv_output, T* q_pe,
     }
 }
 
-template <typename T>
+template <typename T, typename TCache>
 __global__ void loadPagedKVCacheForMLAKernel(T* compressed_kv_ptr, T* k_pe_ptr,
-    tensorrt_llm::kernels::KVBlockArray const kv_cache, int64_t const* cu_ctx_cached_kv_lens, int max_input_seq_len)
+    tensorrt_llm::kernels::KVBlockArray const kv_cache, int64_t const* cu_ctx_cached_kv_lens, int max_input_seq_len,
+    float const* kv_scale_quant_orig_ptr)
 {
-    using KT = typename tensorrt_llm::kernels::loadPagedKVKernelTraits<T>;
+    static_assert(std::is_same_v<T, TCache> || std::is_same_v<TCache, __nv_fp8_e4m3>,
+        "TCache must be either the same type as T or __nv_fp8_e4m3");
+    using KT = typename tensorrt_llm::kernels::loadPagedKVKernelTraits<TCache>;
 
     int const batch_idx = static_cast<int>(blockIdx.y);
+    float const kv_scale_quant_orig = kv_scale_quant_orig_ptr ? kv_scale_quant_orig_ptr[0] : 1.0f;
 
     size_t const head_dim_vec_idx = (threadIdx.x % KT::kVecPerHead);
     size_t const head_dim_idx = head_dim_vec_idx * KT::kElemPerLoad;
@@ -618,7 +640,7 @@ __global__ void loadPagedKVCacheForMLAKernel(T* compressed_kv_ptr, T* k_pe_ptr,
 
         if (valid_token)
         {
-            auto* kvSrc = reinterpret_cast<T*>(kv_cache.getKBlockPtr(batch_idx, token_idx_in_kv_cache));
+            auto* kvSrc = reinterpret_cast<TCache*>(kv_cache.getKBlockPtr(batch_idx, token_idx_in_kv_cache));
             // head_idx === 0
             auto kvBlockIdx
                 = kv_cache.getKVLocalIdx(token_idx_in_kv_cache, 0, KT::kVecPerHead, static_cast<int>(head_dim_vec_idx));
@@ -633,7 +655,15 @@ __global__ void loadPagedKVCacheForMLAKernel(T* compressed_kv_ptr, T* k_pe_ptr,
                 int const dstIdx = global_token_idx * KT::kLoraSize + head_dim_idx;
 
                 // copy back to compressed_kv
-                *reinterpret_cast<typename KT::VecT*>(compressed_kv_ptr + dstIdx) = src_data;
+                if constexpr (std::is_same_v<TCache, T>)
+                {
+                    *reinterpret_cast<typename KT::VecT*>(compressed_kv_ptr + dstIdx) = src_data;
+                }
+                else if constexpr (std::is_same_v<TCache, __nv_fp8_e4m3>)
+                {
+                    dequantCopy<T, KT::kElemPerLoad>(compressed_kv_ptr + dstIdx,
+                        reinterpret_cast<__nv_fp8_e4m3 const*>(&src_data), kv_scale_quant_orig);
+                }
             }
             else
             {
@@ -641,7 +671,15 @@ __global__ void loadPagedKVCacheForMLAKernel(T* compressed_kv_ptr, T* k_pe_ptr,
                 int const dstIdx = global_token_idx * KT::kRopeSize + (head_dim_idx - KT::kLoraSize);
 
                 // copy back to k_pe
-                *reinterpret_cast<typename KT::VecT*>(k_pe_ptr + dstIdx) = src_data;
+                if constexpr (std::is_same_v<TCache, T>)
+                {
+                    *reinterpret_cast<typename KT::VecT*>(k_pe_ptr + dstIdx) = src_data;
+                }
+                else if constexpr (std::is_same_v<TCache, __nv_fp8_e4m3>)
+                {
+                    dequantCopy<T, KT::kElemPerLoad>(
+                        k_pe_ptr + dstIdx, reinterpret_cast<__nv_fp8_e4m3 const*>(&src_data), kv_scale_quant_orig);
+                }
             }
         }
     }
@@ -802,12 +840,15 @@ __global__ void setPagedKVCacheForMLAKernelV2(T* output, T* const cached_k_ptr, 
 }
 
 // compressed_kv_ptr {total_uncached_tokens, d}, k_pe_ptr {total_uncached_tokens, d_rope}
-template <typename T>
+template <typename T, typename TCache>
 __global__ void appendPagedKVForMLAKernel(KVBlockArray kv_cache, T* const compressed_kv_ptr, T* const k_pe_ptr,
     int64_t const* cu_ctx_cached_kv_lens, int64_t const* cu_seq_lens, int const max_input_uncached_seq_len,
-    int head_dim)
+    int head_dim, float const* kv_scale_orig_quant_ptr)
 {
+    static_assert(std::is_same_v<T, TCache> || std::is_same_v<TCache, __nv_fp8_e4m3>,
+        "TCache must be either the same type as T or __nv_fp8_e4m3");
     using KT = typename tensorrt_llm::kernels::loadPagedKVKernelTraits<T>;
+    float const kv_scale_orig_quant = kv_scale_orig_quant_ptr ? kv_scale_orig_quant_ptr[0] : 1.0f;
 
     int const batch_idx = static_cast<int>(blockIdx.y);
 
@@ -847,7 +888,16 @@ __global__ void appendPagedKVForMLAKernel(KVBlockArray kv_cache, T* const compre
             auto* kvCacheDst = reinterpret_cast<T*>(kv_cache.getKBlockPtr(batch_idx, token_idx_in_kv_cache));
             auto kvBlockIdx
                 = kv_cache.getKVLocalIdx(token_idx_in_kv_cache, 0, KT::kVecPerHead, static_cast<int>(head_dim_vec_idx));
-            reinterpret_cast<typename KT::VecT*>(kvCacheDst)[kvBlockIdx] = src_data;
+            if constexpr (std::is_same_v<TCache, T>)
+            {
+                reinterpret_cast<typename KT::VecT*>(kvCacheDst)[kvBlockIdx] = src_data;
+            }
+            else if constexpr (std::is_same_v<TCache, __nv_fp8_e4m3>)
+            {
+                quantCopy<T, KT::kElemPerLoad>(
+                    reinterpret_cast<__nv_fp8_e4m3*>(kvCacheDst) + kvBlockIdx * KT::kElemPerLoad,
+                    reinterpret_cast<T const*>(&src_data), kv_scale_orig_quant);
+            }
         }
     }
 }
@@ -892,19 +942,19 @@ void invokeMLARopeGeneration(MlaParams<T>& params, KVCacheBuffer kv_cache_buffer
         params.dequant_scale_q, params.dequant_scale_kv, params.host_bmm1_scale);
 }
 
-template <typename T>
+template <typename T, typename TCache>
 void invokeMLALoadPagedKV(T* compressed_kv_ptr, T* k_pe_ptr, KVBlockArray& kv_cache, int const num_contexts,
     int64_t const* cu_ctx_cached_kv_lens, int const max_input_seq_len, int const lora_size, int const rope_size,
-    cudaStream_t stream)
+    float const* kv_scale_quant_orig_ptr, cudaStream_t stream)
 {
-    using KT = typename tensorrt_llm::kernels::loadPagedKVKernelTraits<T>;
+    using KT = typename tensorrt_llm::kernels::loadPagedKVKernelTraits<TCache>;
     // {seq_len / token_per_block, batch_size, head_num}
     TLLM_CHECK_WITH_INFO(lora_size == KT::kLoraSize, "lora_size should be equal to %d", KT::kLoraSize);
     TLLM_CHECK_WITH_INFO(rope_size == KT::kRopeSize, "rope_size should be equal to %d", KT::kRopeSize);
     TLLM_CHECK_WITH_INFO(lora_size + rope_size == KT::kHeadSize, "head dim should be equal to %d", KT::kHeadSize);
     dim3 grid(static_cast<int>(tensorrt_llm::common::divUp(max_input_seq_len, KT::kTokenPerBlock)), num_contexts, 1);
-    loadPagedKVCacheForMLAKernel<T><<<grid, KT::kBlockSize, 0, stream>>>(
-        compressed_kv_ptr, k_pe_ptr, kv_cache, cu_ctx_cached_kv_lens, max_input_seq_len);
+    loadPagedKVCacheForMLAKernel<T, TCache><<<grid, KT::kBlockSize, 0, stream>>>(
+        compressed_kv_ptr, k_pe_ptr, kv_cache, cu_ctx_cached_kv_lens, max_input_seq_len, kv_scale_quant_orig_ptr);
 }
 
 template <typename T>
@@ -937,18 +987,18 @@ void invokeMLASetPagedKVV2(T* output, T* const cached_k_ptr, T* const cached_v_p
         num_heads, kv_dim, rope_dim, kv_cache_tokens_per_block);
 }
 
-template <typename T>
+template <typename T, typename TCache>
 void invokeMLAAppendPagedKV(KVBlockArray& kv_cache, T* const compressed_kv_ptr, T* const k_pe_ptr,
     int const num_requests, int64_t const* cu_ctx_cached_kv_lens, int64_t const* cu_seq_lens,
-    int const max_input_uncached_seq_len, int head_dim, cudaStream_t stream)
+    int const max_input_uncached_seq_len, int head_dim, float const* kv_scale_orig_quant_ptr, cudaStream_t stream)
 {
     // just reuse the same traits as loadPagedKVKernel.
     using KT = typename tensorrt_llm::kernels::loadPagedKVKernelTraits<T>;
     TLLM_CHECK_WITH_INFO(head_dim == KT::kHeadSize, "head dim should be equal to %d", KT::kHeadSize);
     dim3 grid(
         static_cast<int>(tensorrt_llm::common::divUp(max_input_uncached_seq_len, KT::kTokenPerBlock)), num_requests, 1);
-    appendPagedKVForMLAKernel<T><<<grid, KT::kBlockSize, 0, stream>>>(kv_cache, compressed_kv_ptr, k_pe_ptr,
-        cu_ctx_cached_kv_lens, cu_seq_lens, max_input_uncached_seq_len, head_dim);
+    appendPagedKVForMLAKernel<T, TCache><<<grid, KT::kBlockSize, 0, stream>>>(kv_cache, compressed_kv_ptr, k_pe_ptr,
+        cu_ctx_cached_kv_lens, cu_seq_lens, max_input_uncached_seq_len, head_dim, kv_scale_orig_quant_ptr);
 }
 
 #define INSTANTIATE_MLA_ROPE(T, KVCacheBuffer)                                                                         \
@@ -965,10 +1015,23 @@ INSTANTIATE_MLA_ROPE(__nv_bfloat16, KVBlockArray);
 INSTANTIATE_MLA_ROPE(__nv_bfloat16, KVLinearBuffer);
 #endif
 
-#define INSTANTIATE_LOAD_KVCACHE_MLA(T)                                                                                \
-    template void invokeMLALoadPagedKV(T* compressed_kv_ptr, T* k_pe_ptr, KVBlockArray& kv_cache,                      \
+#define INSTANTIATE_RW_KVCACHE_MLA(T, TCache)                                                                          \
+    template void invokeMLALoadPagedKV<T, TCache>(T * compressed_kv_ptr, T * k_pe_ptr, KVBlockArray & kv_cache,        \
         int const num_contexts, int64_t const* cu_ctx_cached_kv_lens, int const max_input_seq_len,                     \
-        int const lora_size, int const rope_size, cudaStream_t stream);                                                \
+        int const lora_size, int const rope_size, float const* kv_scale_quant_orig_ptr, cudaStream_t stream);          \
+    template void invokeMLAAppendPagedKV<T, TCache>(KVBlockArray & kv_cache, T* const compressed_kv_ptr,               \
+        T* const k_pe_ptr, int const num_requests, int64_t const* cu_ctx_cached_kv_lens, int64_t const* cu_seq_lens,   \
+        int const max_input_uncached_seq_len, int head_dim, float const* kv_scale_orig_quant_ptr,                      \
+        cudaStream_t stream);
+
+INSTANTIATE_RW_KVCACHE_MLA(float, float);
+INSTANTIATE_RW_KVCACHE_MLA(float, __nv_fp8_e4m3);
+INSTANTIATE_RW_KVCACHE_MLA(half, half);
+INSTANTIATE_RW_KVCACHE_MLA(half, __nv_fp8_e4m3);
+INSTANTIATE_RW_KVCACHE_MLA(__nv_bfloat16, __nv_bfloat16);
+INSTANTIATE_RW_KVCACHE_MLA(__nv_bfloat16, __nv_fp8_e4m3);
+
+#define INSTANTIATE_SET_KVCACHE_MLA(T)                                                                                 \
     template void invokeMLASetPagedKV(T* output, T* const k_ptr, T* const v_ptr, T* const k_pe_ptr,                    \
         int const num_requests, int64_t const* cu_seq_lens, int const max_input_seq_len, int num_heads, int kv_dim,    \
         int rope_dim, int kv_cache_tokens_per_block, int64_t kv_token_stride, cudaStream_t stream);                    \
@@ -976,16 +1039,11 @@ INSTANTIATE_MLA_ROPE(__nv_bfloat16, KVLinearBuffer);
         T* const cached_k_pe_ptr, T* const new_k_ptr, T* const new_v_ptr, T* const new_k_pe_ptr,                       \
         int const num_requests, int64_t const* cu_ctx_cached_kv_lens, int64_t const* cu_seq_lens,                      \
         int const max_input_seq_len, int num_heads, int kv_dim, int rope_dim, int kv_cache_tokens_per_block,           \
-        cudaStream_t stream);                                                                                          \
-    template void invokeMLAAppendPagedKV(KVBlockArray& kv_cache, T* const compressed_kv_ptr, T* const k_pe_ptr,        \
-        int const num_requests, int64_t const* cu_ctx_cached_kv_lens, int64_t const* cu_seq_lens,                      \
-        int const max_input_uncached_seq_len, int head_dim, cudaStream_t stream);
+        cudaStream_t stream);
 
-INSTANTIATE_LOAD_KVCACHE_MLA(float);
-INSTANTIATE_LOAD_KVCACHE_MLA(half);
-#ifdef ENABLE_BF16
-INSTANTIATE_LOAD_KVCACHE_MLA(__nv_bfloat16);
-#endif
+INSTANTIATE_SET_KVCACHE_MLA(float);
+INSTANTIATE_SET_KVCACHE_MLA(half);
+INSTANTIATE_SET_KVCACHE_MLA(__nv_bfloat16);
 
 } // namespace kernels
 

--- a/cpp/tensorrt_llm/kernels/mlaKernels.h
+++ b/cpp/tensorrt_llm/kernels/mlaKernels.h
@@ -95,10 +95,10 @@ void invokeMLARopeContext(MlaParams<T>& params, KVCacheBuffer kv_cache_buffer, c
 template <typename T, typename KVCacheBuffer>
 void invokeMLARopeGeneration(MlaParams<T>& params, KVCacheBuffer kv_cache_buffer, cudaStream_t stream);
 
-template <typename T>
+template <typename T, typename TCache>
 void invokeMLALoadPagedKV(T* compressed_kv_ptr, T* k_pe_ptr, KVBlockArray& kv_cache, int const num_contexts,
     int64_t const* cu_ctx_cached_kv_lens, int const max_input_seq_len, int const lora_size, int const rope_size,
-    cudaStream_t stream);
+    float const* kv_scale_quant_orig_ptr, cudaStream_t stream);
 
 template <typename T>
 void invokeMLASetPagedKV(T* output, T* const k_ptr, T* const v_ptr, T* const k_pe_ptr, int const num_requests,
@@ -111,10 +111,10 @@ void invokeMLASetPagedKVV2(T* output, T* const chached_k_ptr, T* const chached_v
     int64_t const* cu_ctx_cached_kv_lens, int64_t const* cu_seq_lens, int const max_input_seq_len, int num_heads,
     int kv_dim, int rope_dim, int kv_cache_tokens_per_block, cudaStream_t stream);
 
-template <typename T>
+template <typename T, typename TCache>
 void invokeMLAAppendPagedKV(KVBlockArray& kv_cache, T* const compressed_kv_ptr, T* const k_pe_ptr,
     int const num_requests, int64_t const* cu_ctx_cached_kv_lens, int64_t const* cu_seq_lens,
-    int const max_input_uncached_seq_len, int head_dim, cudaStream_t stream);
+    int const max_input_uncached_seq_len, int head_dim, float const* kv_scale_orig_quant_ptr, cudaStream_t stream);
 
 } // namespace kernels
 } // namespace tensorrt_llm

--- a/cpp/tensorrt_llm/kernels/mlaKernels.h
+++ b/cpp/tensorrt_llm/kernels/mlaKernels.h
@@ -96,13 +96,14 @@ template <typename T, typename KVCacheBuffer>
 void invokeMLARopeGeneration(MlaParams<T>& params, KVCacheBuffer kv_cache_buffer, cudaStream_t stream);
 
 template <typename T>
-void invokeMLALoadPagedKV(T* kv_output, KVBlockArray& kv_cache, int const num_contexts,
-    int64_t const* cu_ctx_cached_kv_lens, int const max_input_seq_len, int head_dim, cudaStream_t stream);
+void invokeMLALoadPagedKV(T* compressed_kv_ptr, T* k_pe_ptr, KVBlockArray& kv_cache, int const num_contexts,
+    int64_t const* cu_ctx_cached_kv_lens, int const max_input_seq_len, int const lora_size, int const rope_size,
+    cudaStream_t stream);
 
 template <typename T>
 void invokeMLASetPagedKV(T* output, T* const k_ptr, T* const v_ptr, T* const k_pe_ptr, int const num_requests,
     int64_t const* cu_seq_lens, int const max_input_seq_len, int num_heads, int kv_dim, int rope_dim,
-    int kv_cache_tokens_per_block, cudaStream_t stream);
+    int kv_cache_tokens_per_block, int64_t kv_token_stride, cudaStream_t stream);
 
 template <typename T>
 void invokeMLASetPagedKVV2(T* output, T* const chached_k_ptr, T* const chached_v_ptr, T* const chached_k_pe_ptr,

--- a/cpp/tensorrt_llm/thop/mlaPreprocessOp.cpp
+++ b/cpp/tensorrt_llm/thop/mlaPreprocessOp.cpp
@@ -32,17 +32,18 @@ namespace torch_ext
 namespace
 {
 
-template <typename T>
+template <typename T, typename TCache>
 void loadPagedKVCacheForMLAHelper(torch::Tensor& compressed_kv, torch::Tensor& k_pe, KVBlockArray& kv_cache,
     int const num_contexts, torch::Tensor const& cu_ctx_cached_kv_lens, int const max_input_seq_len,
-    int const lora_size, int const rope_size)
+    int const lora_size, int const rope_size, float const* kv_scale_quant_orig_ptr)
 {
     auto stream = at::cuda::getCurrentCUDAStream(compressed_kv.get_device());
 
     T* compressed_kv_ptr = static_cast<T*>(compressed_kv.data_ptr());
     T* k_pe_ptr = static_cast<T*>(k_pe.data_ptr());
-    tensorrt_llm::kernels::invokeMLALoadPagedKV<T>(compressed_kv_ptr, k_pe_ptr, kv_cache, num_contexts,
-        cu_ctx_cached_kv_lens.data_ptr<int64_t>(), max_input_seq_len, lora_size, rope_size, stream);
+    tensorrt_llm::kernels::invokeMLALoadPagedKV<T, TCache>(compressed_kv_ptr, k_pe_ptr, kv_cache, num_contexts,
+        cu_ctx_cached_kv_lens.data_ptr<int64_t>(), max_input_seq_len, lora_size, rope_size, kv_scale_quant_orig_ptr,
+        stream);
 }
 
 template <typename T>
@@ -84,18 +85,20 @@ void setPagedKVCacheV2ForMLAHelper(torch::Tensor& output, torch::Tensor const& c
         kv_dim, rope_dim, kv_cache_tokens_per_block, stream);
 }
 
-template <typename T>
+template <typename T, typename TCache>
 void appendPagedKVCacheForMLAHelper(KVBlockArray& kv_cache, torch::Tensor const& compressed_kv,
     torch::Tensor const& k_pe, int const num_requests, torch::Tensor const& cu_ctx_cached_kv_lens,
-    torch::Tensor const& cu_seq_lens, int const max_input_uncached_seq_len, int head_dim)
+    torch::Tensor const& cu_seq_lens, int const max_input_uncached_seq_len, int head_dim,
+    float const* kv_scale_orig_quant_ptr)
 {
     auto stream = at::cuda::getCurrentCUDAStream(compressed_kv.get_device());
     auto* const compressed_kv_ptr = static_cast<T* const>(compressed_kv.data_ptr());
     auto* const k_pe_ptr = static_cast<T* const>(k_pe.data_ptr());
     auto* const cu_seq_lens_ptr = cu_seq_lens.data_ptr<int64_t>();
     auto* const cu_ctx_cached_kv_lens_ptr = cu_ctx_cached_kv_lens.data_ptr<int64_t>();
-    tensorrt_llm::kernels::invokeMLAAppendPagedKV(kv_cache, compressed_kv_ptr, k_pe_ptr, num_requests,
-        cu_ctx_cached_kv_lens_ptr, cu_seq_lens_ptr, max_input_uncached_seq_len, head_dim, stream);
+    tensorrt_llm::kernels::invokeMLAAppendPagedKV<T, TCache>(kv_cache, compressed_kv_ptr, k_pe_ptr, num_requests,
+        cu_ctx_cached_kv_lens_ptr, cu_seq_lens_ptr, max_input_uncached_seq_len, head_dim, kv_scale_orig_quant_ptr,
+        stream);
 }
 
 /**
@@ -110,7 +113,7 @@ void appendPagedKVCacheForMLAHelper(KVBlockArray& kv_cache, torch::Tensor const&
  * @param sink_token_length Sink token length
  * @param beam_width Beam width
  * @param kv_cache_quant_mode KV cache quantization mode
- * @param out_dtype Output data type
+ * @param orig_dtype Original data type
  * @param host_kv_cache_pool_pointers Host KV cache pool pointers
  * @param host_kv_cache_pool_mapping Host KV cache pool mapping
  * @param kv_cache_block_offsets KV cache block offsets
@@ -119,11 +122,11 @@ void appendPagedKVCacheForMLAHelper(KVBlockArray& kv_cache, torch::Tensor const&
  */
 KVBlockArray createKVBlockArray(int num_contexts, int max_blocks_per_sequence, int tokens_per_block, int head_size,
     int num_kv_heads, int attention_window_size, int sink_token_length, int beam_width,
-    tc::QuantMode kv_cache_quant_mode, torch::Dtype out_dtype, torch::Tensor const& host_kv_cache_pool_pointers,
+    tc::QuantMode kv_cache_quant_mode, torch::Dtype orig_dtype, torch::Tensor const& host_kv_cache_pool_pointers,
     torch::Tensor const& host_kv_cache_pool_mapping, torch::Tensor const& kv_cache_block_offsets, int layer_idx)
 {
-    auto const output_elem_size = torch::elementSize(out_dtype);
-    auto const cache_elem_size = kv_cache_quant_mode.hasKvCacheQuant() ? sizeof(int8_t) : output_elem_size;
+    auto const orig_elem_size = torch::elementSize(orig_dtype);
+    auto const cache_elem_size = kv_cache_quant_mode.hasKvCacheQuant() ? sizeof(int8_t) : orig_elem_size;
     auto const size_per_token = num_kv_heads * head_size * cache_elem_size;
 
     int const cyclic_attention_window_size = attention_window_size;
@@ -185,6 +188,7 @@ std::vector<torch::Tensor> loadPagedKVCacheForMLA(torch::ScalarType out_dtype, i
     float const* kv_scale_quant_orig_ptr = nullptr;
     if (kv_cache_quant_mode.hasKvCacheQuant())
     {
+        TLLM_CHECK_WITH_INFO(kv_cache_quant_mode.hasFp8KvCache(), "Only FP8 KV cache is supported for now");
         TORCH_CHECK(kv_scale_orig_quant.has_value());
         TORCH_CHECK(kv_scale_quant_orig.has_value());
         kv_scale_orig_quant_ptr = kv_scale_orig_quant.value().data_ptr<float>();
@@ -205,18 +209,44 @@ std::vector<torch::Tensor> loadPagedKVCacheForMLA(torch::ScalarType out_dtype, i
 
     if (out_dtype == torch::kFloat16)
     {
-        loadPagedKVCacheForMLAHelper<half>(outputs[0], outputs[1], kv_cache_buffer, num_contexts, cu_ctx_cached_kv_lens,
-            max_ctx_cached_kv_len, lora_size, rope_size);
+        if (kv_cache_quant_mode.hasFp8KvCache())
+        {
+            loadPagedKVCacheForMLAHelper<half, __nv_fp8_e4m3>(outputs[0], outputs[1], kv_cache_buffer, num_contexts,
+                cu_ctx_cached_kv_lens, max_ctx_cached_kv_len, lora_size, rope_size, kv_scale_quant_orig_ptr);
+        }
+        else
+        {
+            loadPagedKVCacheForMLAHelper<half, half>(outputs[0], outputs[1], kv_cache_buffer, num_contexts,
+                cu_ctx_cached_kv_lens, max_ctx_cached_kv_len, lora_size, rope_size, kv_scale_quant_orig_ptr);
+        }
     }
     else if (out_dtype == torch::kFloat32)
     {
-        loadPagedKVCacheForMLAHelper<float>(outputs[0], outputs[1], kv_cache_buffer, num_contexts,
-            cu_ctx_cached_kv_lens, max_ctx_cached_kv_len, lora_size, rope_size);
+        if (kv_cache_quant_mode.hasFp8KvCache())
+        {
+            loadPagedKVCacheForMLAHelper<float, __nv_fp8_e4m3>(outputs[0], outputs[1], kv_cache_buffer, num_contexts,
+                cu_ctx_cached_kv_lens, max_ctx_cached_kv_len, lora_size, rope_size, kv_scale_quant_orig_ptr);
+        }
+        else
+        {
+            loadPagedKVCacheForMLAHelper<float, float>(outputs[0], outputs[1], kv_cache_buffer, num_contexts,
+                cu_ctx_cached_kv_lens, max_ctx_cached_kv_len, lora_size, rope_size, kv_scale_quant_orig_ptr);
+        }
     }
     else if (out_dtype == torch::kBFloat16)
     {
-        loadPagedKVCacheForMLAHelper<__nv_bfloat16>(outputs[0], outputs[1], kv_cache_buffer, num_contexts,
-            cu_ctx_cached_kv_lens, max_ctx_cached_kv_len, lora_size, rope_size);
+        if (kv_cache_quant_mode.hasFp8KvCache())
+        {
+            loadPagedKVCacheForMLAHelper<__nv_bfloat16, __nv_fp8_e4m3>(outputs[0], outputs[1], kv_cache_buffer,
+                num_contexts, cu_ctx_cached_kv_lens, max_ctx_cached_kv_len, lora_size, rope_size,
+                kv_scale_quant_orig_ptr);
+        }
+        else
+        {
+            loadPagedKVCacheForMLAHelper<__nv_bfloat16, __nv_bfloat16>(outputs[0], outputs[1], kv_cache_buffer,
+                num_contexts, cu_ctx_cached_kv_lens, max_ctx_cached_kv_len, lora_size, rope_size,
+                kv_scale_quant_orig_ptr);
+        }
     }
 
     return outputs;
@@ -228,17 +258,16 @@ torch::Tensor setPagedKVCacheForMLA(torch::Tensor& output, torch::Tensor const& 
     int64_t const kv_cache_tokens_per_block)
 {
     TORCH_CHECK(output.numel() > 0);
-    auto output_scalar_type = output.scalar_type();
-    TORCH_CHECK(output_scalar_type == torch::kFloat16 || output_scalar_type == torch::kFloat32
-        || output_scalar_type == torch::kBFloat16);
+    auto output_dtype = output.scalar_type();
+    TORCH_CHECK(output_dtype == torch::kFloat16 || output_dtype == torch::kFloat32 || output_dtype == torch::kBFloat16);
     CHECK_TH_CUDA(output);
     CHECK_CONTIGUOUS(output);
 
     // k and v can be non-contiguous
     CHECK_TH_CUDA(k);
-    CHECK_TYPE(k, output_scalar_type);
+    CHECK_TYPE(k, output_dtype);
     CHECK_TH_CUDA(v);
-    CHECK_TYPE(v, output_scalar_type);
+    CHECK_TYPE(v, output_dtype);
     TORCH_CHECK(k.dim() == 3);
     TORCH_CHECK(v.dim() == 3);
     TORCH_CHECK(k.size(0) == v.size(0));
@@ -254,23 +283,23 @@ torch::Tensor setPagedKVCacheForMLA(torch::Tensor& output, torch::Tensor const& 
     TORCH_CHECK(k_token_stride == v_token_stride);
 
     // k_pe should be contiguous
-    CHECK_INPUT(k_pe, output_scalar_type);
+    CHECK_INPUT(k_pe, output_dtype);
 
     CHECK_INPUT(cu_seq_lens, torch::kInt64);
     TORCH_CHECK(cu_seq_lens.dim() == 1);
     TORCH_CHECK(cu_seq_lens.size(0) >= num_requests + 1);
 
-    if (output_scalar_type == torch::kFloat16)
+    if (output_dtype == torch::kFloat16)
     {
         setPagedKVCacheForMLAHelper<half>(output, k, v, k_pe, num_requests, cu_seq_lens, max_input_seq_len, num_heads,
             kv_dim, rope_dim, kv_cache_tokens_per_block, k_token_stride);
     }
-    else if (output_scalar_type == torch::kFloat32)
+    else if (output_dtype == torch::kFloat32)
     {
         setPagedKVCacheForMLAHelper<float>(output, k, v, k_pe, num_requests, cu_seq_lens, max_input_seq_len, num_heads,
             kv_dim, rope_dim, kv_cache_tokens_per_block, k_token_stride);
     }
-    else if (output_scalar_type == torch::kBFloat16)
+    else if (output_dtype == torch::kBFloat16)
     {
         setPagedKVCacheForMLAHelper<__nv_bfloat16>(output, k, v, k_pe, num_requests, cu_seq_lens, max_input_seq_len,
             num_heads, kv_dim, rope_dim, kv_cache_tokens_per_block, k_token_stride);
@@ -293,17 +322,17 @@ torch::Tensor setPagedKVCacheV2ForMLA(torch::Tensor& output, torch::Tensor const
     int64_t const num_heads, int64_t const kv_dim, int64_t const rope_dim, int64_t const kv_cache_tokens_per_block)
 {
     TORCH_CHECK(output.numel() > 0);
-    TORCH_CHECK(output.scalar_type() == torch::kFloat16 || output.scalar_type() == torch::kFloat32
-        || output.scalar_type() == torch::kBFloat16);
+    auto output_dtype = output.scalar_type();
+    TORCH_CHECK(output_dtype == torch::kFloat16 || output_dtype == torch::kFloat32 || output_dtype == torch::kBFloat16);
     CHECK_TH_CUDA(output);
     CHECK_CONTIGUOUS(output);
-    CHECK_INPUT(cached_k, output.scalar_type());
-    CHECK_INPUT(cached_v, output.scalar_type());
-    CHECK_INPUT(cached_k_pe, output.scalar_type());
+    CHECK_INPUT(cached_k, output_dtype);
+    CHECK_INPUT(cached_v, output_dtype);
+    CHECK_INPUT(cached_k_pe, output_dtype);
     TORCH_CHECK(cached_k_pe.dim() == 2);
-    CHECK_INPUT(new_k, output.scalar_type());
-    CHECK_INPUT(new_v, output.scalar_type());
-    CHECK_INPUT(new_k_pe, output.scalar_type());
+    CHECK_INPUT(new_k, output_dtype);
+    CHECK_INPUT(new_v, output_dtype);
+    CHECK_INPUT(new_k_pe, output_dtype);
     TORCH_CHECK(new_k_pe.dim() == 2);
     CHECK_INPUT(cu_ctx_cached_kv_lens, torch::kInt64);
     TORCH_CHECK(cu_ctx_cached_kv_lens.dim() == 1);
@@ -312,19 +341,19 @@ torch::Tensor setPagedKVCacheV2ForMLA(torch::Tensor& output, torch::Tensor const
     TORCH_CHECK(cu_seq_lens.dim() == 1);
     TORCH_CHECK(cu_seq_lens.size(0) >= num_requests + 1);
 
-    if (output.scalar_type() == torch::kFloat16)
+    if (output_dtype == torch::kFloat16)
     {
         setPagedKVCacheV2ForMLAHelper<half>(output, cached_k, cached_v, cached_k_pe, new_k, new_v, new_k_pe,
             num_requests, cu_ctx_cached_kv_lens, cu_seq_lens, max_input_seq_len, num_heads, kv_dim, rope_dim,
             kv_cache_tokens_per_block);
     }
-    else if (output.scalar_type() == torch::kFloat32)
+    else if (output_dtype == torch::kFloat32)
     {
         setPagedKVCacheV2ForMLAHelper<float>(output, cached_k, cached_v, cached_k_pe, new_k, new_v, new_k_pe,
             num_requests, cu_ctx_cached_kv_lens, cu_seq_lens, max_input_seq_len, num_heads, kv_dim, rope_dim,
             kv_cache_tokens_per_block);
     }
-    else if (output.scalar_type() == torch::kBFloat16)
+    else if (output_dtype == torch::kBFloat16)
     {
         setPagedKVCacheV2ForMLAHelper<__nv_bfloat16>(output, cached_k, cached_v, cached_k_pe, new_k, new_v, new_k_pe,
             num_requests, cu_ctx_cached_kv_lens, cu_seq_lens, max_input_seq_len, num_heads, kv_dim, rope_dim,
@@ -350,13 +379,13 @@ void appendPagedKVCacheForMLA(torch::Tensor const& compressed_kv, torch::Tensor 
     int64_t const tokens_per_block, int64_t const attention_window_size, int64_t const sink_token_length,
     int64_t const beam_width, int64_t const quant_mode)
 {
+    auto input_dtype = compressed_kv.scalar_type();
+    TORCH_CHECK(input_dtype == torch::kFloat16 || input_dtype == torch::kFloat32 || input_dtype == torch::kBFloat16);
     TORCH_CHECK(compressed_kv.numel() > 0);
-    TORCH_CHECK(compressed_kv.scalar_type() == torch::kFloat16 || compressed_kv.scalar_type() == torch::kFloat32
-        || compressed_kv.scalar_type() == torch::kBFloat16);
     TORCH_CHECK(compressed_kv.dim() == 2);
     CHECK_TH_CUDA(compressed_kv);
     CHECK_CONTIGUOUS(compressed_kv);
-    CHECK_INPUT(k_pe, compressed_kv.scalar_type());
+    CHECK_INPUT(k_pe, input_dtype);
     TORCH_CHECK(k_pe.dim() == 2);
     CHECK_INPUT(cu_seq_lens, torch::kInt64);
     TORCH_CHECK(cu_seq_lens.dim() == 1);
@@ -370,15 +399,15 @@ void appendPagedKVCacheForMLA(torch::Tensor const& compressed_kv, torch::Tensor 
     int max_blocks_per_sequence = kv_cache_block_offsets.size(-1);
     KVBlockArray kv_cache_buffer
         = createKVBlockArray(num_contexts, max_blocks_per_sequence, tokens_per_block, head_size,
-            1,                           // num_kv_heads is always 1 for MLA
-            attention_window_size, sink_token_length, beam_width, kv_cache_quant_mode,
-            compressed_kv.scalar_type(), // TODO(zhhuang): support more output dtypes
+            1, // num_kv_heads is always 1 for MLA
+            attention_window_size, sink_token_length, beam_width, kv_cache_quant_mode, input_dtype,
             host_kv_cache_pool_pointers, host_kv_cache_pool_mapping, kv_cache_block_offsets, layer_idx);
 
     float const* kv_scale_orig_quant_ptr = nullptr;
     float const* kv_scale_quant_orig_ptr = nullptr;
     if (kv_cache_quant_mode.hasKvCacheQuant())
     {
+        TLLM_CHECK_WITH_INFO(kv_cache_quant_mode.hasFp8KvCache(), "Only FP8 KV cache is supported for now");
         TORCH_CHECK(kv_scale_orig_quant.has_value());
         TORCH_CHECK(kv_scale_quant_orig.has_value());
         kv_scale_orig_quant_ptr = kv_scale_orig_quant.value().data_ptr<float>();
@@ -387,20 +416,46 @@ void appendPagedKVCacheForMLA(torch::Tensor const& compressed_kv, torch::Tensor 
         TLLM_CHECK(kv_scale_quant_orig_ptr != nullptr);
     }
 
-    if (compressed_kv.scalar_type() == torch::kFloat16)
+    if (input_dtype == torch::kFloat16)
     {
-        appendPagedKVCacheForMLAHelper<half>(kv_cache_buffer, compressed_kv, k_pe, num_contexts, cu_ctx_cached_kv_lens,
-            cu_seq_lens, max_input_uncached_seq_len, head_size);
+        if (kv_cache_quant_mode.hasFp8KvCache())
+        {
+            appendPagedKVCacheForMLAHelper<half, __nv_fp8_e4m3>(kv_cache_buffer, compressed_kv, k_pe, num_contexts,
+                cu_ctx_cached_kv_lens, cu_seq_lens, max_input_uncached_seq_len, head_size, kv_scale_orig_quant_ptr);
+        }
+        else
+        {
+            appendPagedKVCacheForMLAHelper<half, half>(kv_cache_buffer, compressed_kv, k_pe, num_contexts,
+                cu_ctx_cached_kv_lens, cu_seq_lens, max_input_uncached_seq_len, head_size, kv_scale_orig_quant_ptr);
+        }
     }
-    else if (compressed_kv.scalar_type() == torch::kFloat32)
+    else if (input_dtype == torch::kFloat32)
     {
-        appendPagedKVCacheForMLAHelper<float>(kv_cache_buffer, compressed_kv, k_pe, num_contexts, cu_ctx_cached_kv_lens,
-            cu_seq_lens, max_input_uncached_seq_len, head_size);
+        if (kv_cache_quant_mode.hasFp8KvCache())
+        {
+            appendPagedKVCacheForMLAHelper<float, __nv_fp8_e4m3>(kv_cache_buffer, compressed_kv, k_pe, num_contexts,
+                cu_ctx_cached_kv_lens, cu_seq_lens, max_input_uncached_seq_len, head_size, kv_scale_orig_quant_ptr);
+        }
+        else
+        {
+            appendPagedKVCacheForMLAHelper<float, float>(kv_cache_buffer, compressed_kv, k_pe, num_contexts,
+                cu_ctx_cached_kv_lens, cu_seq_lens, max_input_uncached_seq_len, head_size, kv_scale_orig_quant_ptr);
+        }
     }
-    else if (compressed_kv.scalar_type() == torch::kBFloat16)
+    else if (input_dtype == torch::kBFloat16)
     {
-        appendPagedKVCacheForMLAHelper<__nv_bfloat16>(kv_cache_buffer, compressed_kv, k_pe, num_contexts,
-            cu_ctx_cached_kv_lens, cu_seq_lens, max_input_uncached_seq_len, head_size);
+        if (kv_cache_quant_mode.hasFp8KvCache())
+        {
+            appendPagedKVCacheForMLAHelper<__nv_bfloat16, __nv_fp8_e4m3>(kv_cache_buffer, compressed_kv, k_pe,
+                num_contexts, cu_ctx_cached_kv_lens, cu_seq_lens, max_input_uncached_seq_len, head_size,
+                kv_scale_orig_quant_ptr);
+        }
+        else
+        {
+            appendPagedKVCacheForMLAHelper<__nv_bfloat16, __nv_bfloat16>(kv_cache_buffer, compressed_kv, k_pe,
+                num_contexts, cu_ctx_cached_kv_lens, cu_seq_lens, max_input_uncached_seq_len, head_size,
+                kv_scale_orig_quant_ptr);
+        }
     }
 }
 

--- a/cpp/tests/unit_tests/kernels/mlaPreprocessTest.cu
+++ b/cpp/tests/unit_tests/kernels/mlaPreprocessTest.cu
@@ -29,29 +29,38 @@
 namespace
 {
 
-// copy matched kv cache data to kv_output
-// kv_output {total_cached_token, num_head = 1, head_size(lora_size + rope_size)}
+// copy matched kv cache data to compressed_kv_output and k_pe_output
+// compressed_kv_output {total_cached_token, lora_size}
+// k_pe_output {total_cached_token, rope_size}
 // compressed_kv_cache {batch, 1 (ignore v), max_seq_len / tokens_per_block, num_head, tokens_per_block, (lora_size +
 // rope_size)}
 template <typename T>
-void loadPagedKvKernelRef(T* kv_output, tensorrt_llm::kernels::KVBlockArray const& compressed_kv_cache,
-    int num_contexts, int64_t const* cu_ctx_cached_kv_lens, int head_dim)
+void loadPagedKvKernelRef(T* compressed_kv_output, T* k_pe_output,
+    tensorrt_llm::kernels::KVBlockArray const& compressed_kv_cache, int num_contexts,
+    int64_t const* cu_ctx_cached_kv_lens, int const lora_size, int const rope_size)
 {
-
+    int const head_dim = lora_size + rope_size;
     for (int b = 0; b < num_contexts; b++)
     {
         int const global_token_offset = cu_ctx_cached_kv_lens[b];
         int const current_token_len = cu_ctx_cached_kv_lens[b + 1] - cu_ctx_cached_kv_lens[b];
         for (int s = 0; s < current_token_len; s++)
         {
+            int const global_token_idx = global_token_offset + s;
             for (int d = 0; d < head_dim; d++)
             {
                 auto const* kv_src = reinterpret_cast<T const*>(compressed_kv_cache.getKBlockPtr(b, s));
                 auto kv_block_idx = compressed_kv_cache.getKVLocalIdx(s, 0, head_dim, d);
 
-                int const global_token_idx = global_token_offset + s;
-                int const dst_idx = global_token_idx * head_dim + d;
-                kv_output[dst_idx] = kv_src[kv_block_idx];
+                auto data = kv_src[kv_block_idx];
+                if (d < lora_size)
+                {
+                    compressed_kv_output[global_token_idx * lora_size + d] = data;
+                }
+                else
+                {
+                    k_pe_output[global_token_idx * rope_size + (d - lora_size)] = data;
+                }
             }
         }
     }
@@ -63,7 +72,7 @@ void loadPagedKvKernelRef(T* kv_output, tensorrt_llm::kernels::KVBlockArray cons
 template <typename T>
 void setPagedKvCacheForMLAKernelRef(T* output, T* const k_ptr, T* const v_ptr, T* const k_pe_ptr, int num_requests,
     int64_t const* cu_seq_lens, int const max_input_seq_len, int num_heads, int uncompressed_head_size, int rope_size,
-    int kv_cache_tokens_per_block)
+    int kv_cache_tokens_per_block, int64_t kv_token_stride)
 {
     int const kv_cache_size_per_block = num_heads * kv_cache_tokens_per_block * (uncompressed_head_size + rope_size);
     int const kv_cache_block_num_per_seq
@@ -82,8 +91,7 @@ void setPagedKvCacheForMLAKernelRef(T* output, T* const k_ptr, T* const v_ptr, T
             for (int h = 0; h < num_heads; h++)
             {
                 // copy k, v
-                int const ld_kv_head_offset
-                    = (global_token_idx * num_heads * uncompressed_head_size) + (h * uncompressed_head_size);
+                int const ld_kv_head_offset = (global_token_idx * kv_token_stride) + (h * uncompressed_head_size);
                 int const ld_k_pe_head_offset = (global_token_idx * rope_size);
                 for (int d = 0; d < uncompressed_head_size; d++)
                 {
@@ -180,7 +188,7 @@ void setPagedKvCacheForMLAKernelRefV2(T* output, T* const ck_ptr, T* const cv_pt
 
 // compressed_kv_cache {batch, 1 (ignore v), max_seq_len / tokens_per_block, num_head=1, tokens_per_block, (lora_size +
 // rope_size)}
-// kv {total_uncached_tokens, h_k=1, lora_d}, k_pe {total_uncached_tokens, h_kpe=128, rope_d}
+// kv {total_uncached_tokens, h_k=1, lora_d}, k_pe {total_uncached_tokens, h_kpe=1, rope_d}
 template <typename T>
 void appendPagedKvForMLAKernelRef(tensorrt_llm::kernels::KVBlockArray& kv_cache, T* const compressed_kv_ptr,
     T* const k_pe_ptr, int const num_requests, int64_t const* cu_ctx_cached_kv_lens, int64_t const* cu_seq_lens,
@@ -247,7 +255,8 @@ protected:
         h_offset_tensor{nullptr}, h_compressed_offset_tensor{nullptr}, h_cu_ctx_cached_kv_lens{nullptr},
         h_cu_seq_lens{nullptr},
         // for kernel 1
-        d_kv_k_pe_tensor{nullptr}, h_kv_k_pe_tensor{nullptr}, h_kv_k_pe_tensor_ref{nullptr},
+        d_compressed_kv_output{nullptr}, h_compressed_kv_output{nullptr}, h_compressed_kv_output_ref{nullptr},
+        d_k_pe_output{nullptr}, h_k_pe_output{nullptr}, h_k_pe_output_ref{nullptr},
         // for kernel 2
         d_k_tensor{nullptr}, d_v_tensor{nullptr}, d_k_pe_tensor{nullptr}, h_k_tensor{nullptr}, h_v_tensor{nullptr},
         h_k_pe_tensor{nullptr},
@@ -257,8 +266,8 @@ protected:
         h_k_tensor_cached{nullptr}, h_v_tensor_cached{nullptr}, h_k_pe_tensor_cached{nullptr},
         h_k_tensor_uncached{nullptr}, h_v_tensor_uncached{nullptr}, h_k_pe_tensor_uncached{nullptr},
         // for kernel 3
-        d_compressed_kv_tensor{nullptr}, d_k_pe_full_head_tensor{nullptr}, h_compressed_kv_tensor{nullptr},
-        h_k_pe_full_head_tensor{nullptr};
+        d_compressed_kv_tensor{nullptr}, d_k_pe_one_head_tensor{nullptr}, h_compressed_kv_tensor{nullptr},
+        h_k_pe_one_head_tensor{nullptr};
 
     int mNumRequests{};
     int mMaxSeqLen{};
@@ -274,6 +283,7 @@ protected:
     int mLoraSize{};
     int mRopeSize{};
     int mUncompressedHeadSize{};
+    int64_t mKvTokenStride{};
 
     std::mt19937 gen;
 
@@ -304,6 +314,7 @@ protected:
         this->mMaxSeqLen = 0;
         this->mMaxCachedSeqLen = 0;
         this->mMaxUncachedSeqLen = 0;
+        this->mKvTokenStride = this->mNumHeadsUncompressed * this->mUncompressedHeadSize;
     }
 
     template <typename T>
@@ -494,22 +505,33 @@ protected:
                 this->h_offset_tensor->getSizeInBytes(), cudaMemcpyHostToDevice);
         }
 
-        // kv + k_pe for loadCompressedPagedKvKernel (kernel 1)
-        // std::cout << "kv_cache_tensor size: {" << this->mTotalCachedTokens << ", 1, " << this->mLoraSize +
-        // this->mRopeSize <<  "}" << std::endl;
-        this->h_kv_k_pe_tensor = tensorrt_llm::runtime::BufferManager::pinned(
-            ITensor::makeShape({this->mTotalCachedTokens, 1, this->mLoraSize + this->mRopeSize}), dtype);
-        this->h_kv_k_pe_tensor_ref = tensorrt_llm::runtime::BufferManager::pinned(
-            ITensor::makeShape({this->mTotalCachedTokens, 1, this->mLoraSize + this->mRopeSize}), dtype);
-        this->d_kv_k_pe_tensor = tensorrt_llm::runtime::BufferManager::gpuSync(
-            ITensor::makeShape({this->mTotalCachedTokens, 1, this->mLoraSize + this->mRopeSize}), dtype);
+        // compressed_kv_output + k_pe_output for loadPagedKvKernel (kernel 1)
+        this->h_compressed_kv_output = tensorrt_llm::runtime::BufferManager::pinned(
+            ITensor::makeShape({this->mTotalCachedTokens, this->mLoraSize}), dtype);
+        this->h_compressed_kv_output_ref = tensorrt_llm::runtime::BufferManager::pinned(
+            ITensor::makeShape({this->mTotalCachedTokens, this->mLoraSize}), dtype);
+        this->d_compressed_kv_output = tensorrt_llm::runtime::BufferManager::gpuSync(
+            ITensor::makeShape({this->mTotalCachedTokens, this->mLoraSize}), dtype);
+        this->h_k_pe_output = tensorrt_llm::runtime::BufferManager::pinned(
+            ITensor::makeShape({this->mTotalCachedTokens, this->mRopeSize}), dtype);
+        this->h_k_pe_output_ref = tensorrt_llm::runtime::BufferManager::pinned(
+            ITensor::makeShape({this->mTotalCachedTokens, this->mRopeSize}), dtype);
+        this->d_k_pe_output = tensorrt_llm::runtime::BufferManager::gpuSync(
+            ITensor::makeShape({this->mTotalCachedTokens, this->mRopeSize}), dtype);
         {
-            auto* kv_k_pe_ptr = bufferCast<DataType>(*(this->h_kv_k_pe_tensor));
-            auto* kv_k_pe_ref_ptr = bufferCast<DataType>(*(this->h_kv_k_pe_tensor_ref));
-            memsetZeroHost<DataType>(kv_k_pe_ptr, this->h_kv_k_pe_tensor->getSize());
-            memsetZeroHost<DataType>(kv_k_pe_ref_ptr, this->h_kv_k_pe_tensor_ref->getSize());
-            cudaMemcpy(this->d_kv_k_pe_tensor->data(), this->h_kv_k_pe_tensor->data(),
-                this->h_kv_k_pe_tensor->getSizeInBytes(), cudaMemcpyHostToDevice);
+            auto* compressed_kv_output_ptr = bufferCast<DataType>(*(this->h_compressed_kv_output));
+            auto* compressed_kv_output_ref_ptr = bufferCast<DataType>(*(this->h_compressed_kv_output_ref));
+            memsetZeroHost<DataType>(compressed_kv_output_ptr, this->h_compressed_kv_output->getSize());
+            memsetZeroHost<DataType>(compressed_kv_output_ref_ptr, this->h_compressed_kv_output_ref->getSize());
+            cudaMemcpy(this->d_compressed_kv_output->data(), this->h_compressed_kv_output->data(),
+                this->h_compressed_kv_output->getSizeInBytes(), cudaMemcpyHostToDevice);
+
+            auto* k_pe_output_ptr = bufferCast<DataType>(*(this->h_k_pe_output));
+            auto* k_pe_output_ref_ptr = bufferCast<DataType>(*(this->h_k_pe_output_ref));
+            memsetZeroHost<DataType>(k_pe_output_ptr, this->h_k_pe_output->getSize());
+            memsetZeroHost<DataType>(k_pe_output_ref_ptr, this->h_k_pe_output_ref->getSize());
+            cudaMemcpy(this->d_k_pe_output->data(), this->h_k_pe_output->data(), this->h_k_pe_output->getSizeInBytes(),
+                cudaMemcpyHostToDevice);
         }
         // k, v, k_pe for setPagedKvCacheForMLAKernel (kernel 2)
         this->h_k_tensor = tensorrt_llm::runtime::BufferManager::pinned(
@@ -597,25 +619,25 @@ protected:
             cudaMemcpy(this->d_k_pe_tensor_uncached->data(), this->h_k_pe_tensor_uncached->data(),
                 this->h_k_pe_tensor_uncached->getSizeInBytes(), cudaMemcpyHostToDevice);
         }
-        // compressed_kv, k_pe_full_head for setCompressedPagedKvForMLAKernel (kernel 3)
+        // compressed_kv, k_pe_one_head for appendPagedKvForMLAKernel (kernel 3)
         this->h_compressed_kv_tensor = tensorrt_llm::runtime::BufferManager::pinned(
             ITensor::makeShape({this->mTotalUncachedTokens, 1, this->mLoraSize}), dtype);
-        this->h_k_pe_full_head_tensor = tensorrt_llm::runtime::BufferManager::pinned(
+        this->h_k_pe_one_head_tensor = tensorrt_llm::runtime::BufferManager::pinned(
             ITensor::makeShape({this->mTotalUncachedTokens, 1, this->mRopeSize}), dtype);
         this->d_compressed_kv_tensor = tensorrt_llm::runtime::BufferManager::gpuSync(
             ITensor::makeShape({this->mTotalUncachedTokens, 1, this->mLoraSize}), dtype);
-        this->d_k_pe_full_head_tensor = tensorrt_llm::runtime::BufferManager::gpuSync(
+        this->d_k_pe_one_head_tensor = tensorrt_llm::runtime::BufferManager::gpuSync(
             ITensor::makeShape({this->mTotalUncachedTokens, 1, this->mRopeSize}), dtype);
 
         {
             auto* compressed_kv_ptr = bufferCast<DataType>(*(this->h_compressed_kv_tensor));
-            auto* k_pe_full_head_ptr = bufferCast<DataType>(*(this->h_k_pe_full_head_tensor));
+            auto* k_pe_one_head_ptr = bufferCast<DataType>(*(this->h_k_pe_one_head_tensor));
             fillArrayDataWithMod(compressed_kv_ptr, this->h_compressed_kv_tensor->getSize());
-            fillArrayDataWithMod(k_pe_full_head_ptr, this->h_k_pe_full_head_tensor->getSize());
+            fillArrayDataWithMod(k_pe_one_head_ptr, this->h_k_pe_one_head_tensor->getSize());
             cudaMemcpy(this->d_compressed_kv_tensor->data(), this->h_compressed_kv_tensor->data(),
                 this->h_compressed_kv_tensor->getSizeInBytes(), cudaMemcpyHostToDevice);
-            cudaMemcpy(this->d_k_pe_full_head_tensor->data(), this->h_k_pe_full_head_tensor->data(),
-                this->h_k_pe_full_head_tensor->getSizeInBytes(), cudaMemcpyHostToDevice);
+            cudaMemcpy(this->d_k_pe_one_head_tensor->data(), this->h_k_pe_one_head_tensor->data(),
+                this->h_k_pe_one_head_tensor->getSizeInBytes(), cudaMemcpyHostToDevice);
         }
         return true;
     }
@@ -623,32 +645,37 @@ protected:
     void PerformLoadPagedKV()
     {
         using tensorrt_llm::runtime::bufferCast;
-        auto* kv_k_pe_ptr = bufferCast<DataType>(*(this->d_kv_k_pe_tensor));
+        auto* compressed_kv_output_ptr = bufferCast<DataType>(*(this->d_compressed_kv_output));
+        auto* k_pe_output_ptr = bufferCast<DataType>(*(this->d_k_pe_output));
         auto* compressed_kv_cache_ptr = bufferCast<DataType>(*(this->d_compressed_kv_cache_tensor));
         auto* offset_ptr = bufferCast<int32_t>(*(this->d_compressed_offset_tensor));
         auto* cu_ctx_cached_kv_lens_ptr = bufferCast<int64_t>(*(this->d_cu_ctx_cached_kv_lens));
         tensorrt_llm::kernels::KVBlockArray kv_cache(this->mNumRequests, this->mMaxBlockPerSeq, this->mTokensPerBlock,
             sizeof(DataType) * 1 * (this->mLoraSize + this->mRopeSize), 0, 0, 0, 0, compressed_kv_cache_ptr, nullptr,
             reinterpret_cast<tensorrt_llm::kernels::KVBlockArrayForContextFMHA::DataType*>(offset_ptr));
-        tensorrt_llm::kernels::invokeMLALoadPagedKV<DataType>(kv_k_pe_ptr, kv_cache, this->mNumRequests,
-            cu_ctx_cached_kv_lens_ptr, this->mMaxCachedSeqLen, this->mLoraSize + this->mRopeSize, this->mStream->get());
+        tensorrt_llm::kernels::invokeMLALoadPagedKV<DataType>(compressed_kv_output_ptr, k_pe_output_ptr, kv_cache,
+            this->mNumRequests, cu_ctx_cached_kv_lens_ptr, this->mMaxCachedSeqLen, this->mLoraSize, this->mRopeSize,
+            this->mStream->get());
         cudaStreamSynchronize(this->mStream->get());
-        cudaMemcpy(this->h_kv_k_pe_tensor->data(), this->d_kv_k_pe_tensor->data(),
-            this->d_kv_k_pe_tensor->getSizeInBytes(), cudaMemcpyDeviceToHost);
+        cudaMemcpy(this->h_compressed_kv_output->data(), this->d_compressed_kv_output->data(),
+            this->d_compressed_kv_output->getSizeInBytes(), cudaMemcpyDeviceToHost);
+        cudaMemcpy(this->h_k_pe_output->data(), this->d_k_pe_output->data(), this->d_k_pe_output->getSizeInBytes(),
+            cudaMemcpyDeviceToHost);
     }
 
     void PerformLoadPagedKVRef()
     {
         using tensorrt_llm::runtime::bufferCast;
-        auto* kv_k_pe_ptr = bufferCast<DataType>(*(this->h_kv_k_pe_tensor_ref));
+        auto* compressed_kv_output_ptr = bufferCast<DataType>(*(this->h_compressed_kv_output_ref));
+        auto* k_pe_output_ptr = bufferCast<DataType>(*(this->h_k_pe_output_ref));
         auto* compressed_kv_cache_ptr = bufferCast<DataType>(*(this->h_compressed_kv_cache_tensor));
         auto* offset_ptr = bufferCast<int32_t>(*(this->h_compressed_offset_tensor));
         auto* cu_ctx_cached_kv_lens_ptr = bufferCast<int64_t>(*(this->h_cu_ctx_cached_kv_lens));
         tensorrt_llm::kernels::KVBlockArray kv_cache(this->mNumRequests, this->mMaxBlockPerSeq, this->mTokensPerBlock,
             sizeof(DataType) * 1 * (this->mLoraSize + this->mRopeSize), 0, 0, 0, 0, compressed_kv_cache_ptr, nullptr,
             reinterpret_cast<tensorrt_llm::kernels::KVBlockArrayForContextFMHA::DataType*>(offset_ptr));
-        loadPagedKvKernelRef(
-            kv_k_pe_ptr, kv_cache, this->mNumRequests, cu_ctx_cached_kv_lens_ptr, this->mLoraSize + this->mRopeSize);
+        loadPagedKvKernelRef(compressed_kv_output_ptr, k_pe_output_ptr, kv_cache, this->mNumRequests,
+            cu_ctx_cached_kv_lens_ptr, this->mLoraSize, this->mRopeSize);
     }
 
     void PerformSetPagedKV()
@@ -661,7 +688,7 @@ protected:
         auto* cu_seq_lens_ptr = bufferCast<int64_t>(*(this->d_cu_seq_lens));
         tensorrt_llm::kernels::invokeMLASetPagedKV<DataType>(kv_cache_ptr, k_ptr, v_ptr, k_pe_ptr, this->mNumRequests,
             cu_seq_lens_ptr, this->mMaxSeqLen, this->mNumHeadsUncompressed, this->mUncompressedHeadSize,
-            this->mRopeSize, this->mTokensPerBlock, this->mStream->get());
+            this->mRopeSize, this->mTokensPerBlock, this->mKvTokenStride, this->mStream->get());
         cudaStreamSynchronize(this->mStream->get());
         cudaMemcpy(this->h_kv_cache_tensor->data(), this->d_kv_cache_tensor->data(),
             this->d_kv_cache_tensor->getSizeInBytes(), cudaMemcpyDeviceToHost);
@@ -677,7 +704,7 @@ protected:
         auto* cu_seq_lens_ptr = bufferCast<int64_t>(*(this->h_cu_seq_lens));
         setPagedKvCacheForMLAKernelRef(kv_cache_ptr, k_ptr, v_ptr, k_pe_ptr, this->mNumRequests, cu_seq_lens_ptr,
             this->mMaxSeqLen, this->mNumHeadsUncompressed, this->mUncompressedHeadSize, this->mRopeSize,
-            this->mTokensPerBlock);
+            this->mTokensPerBlock, this->mKvTokenStride);
     }
 
     void PerformSetPagedKVV2()
@@ -723,7 +750,7 @@ protected:
     {
         using tensorrt_llm::runtime::bufferCast;
         auto* compressed_kv_ptr = bufferCast<DataType>(*(this->d_compressed_kv_tensor));
-        auto* k_pe_full_head_ptr = bufferCast<DataType>(*(this->d_k_pe_full_head_tensor));
+        auto* k_pe_one_head_ptr = bufferCast<DataType>(*(this->d_k_pe_one_head_tensor));
         auto* offset_ptr = bufferCast<int32_t>(*(this->d_compressed_offset_tensor));
         auto* compressed_kv_cache_ptr = bufferCast<DataType>(*(this->d_compressed_kv_cache_tensor));
         auto* cu_ctx_cached_kv_lens_ptr = bufferCast<int64_t>(*(this->d_cu_ctx_cached_kv_lens));
@@ -731,7 +758,7 @@ protected:
         tensorrt_llm::kernels::KVBlockArray kv_cache(this->mNumRequests, this->mMaxBlockPerSeq, this->mTokensPerBlock,
             sizeof(DataType) * 1 * (this->mLoraSize + this->mRopeSize), 0, 0, 0, 0, compressed_kv_cache_ptr, nullptr,
             reinterpret_cast<tensorrt_llm::kernels::KVBlockArrayForContextFMHA::DataType*>(offset_ptr));
-        tensorrt_llm::kernels::invokeMLAAppendPagedKV<DataType>(kv_cache, compressed_kv_ptr, k_pe_full_head_ptr,
+        tensorrt_llm::kernels::invokeMLAAppendPagedKV<DataType>(kv_cache, compressed_kv_ptr, k_pe_one_head_ptr,
             this->mNumRequests, cu_ctx_cached_kv_lens_ptr, cu_seq_lens_ptr, this->mMaxUncachedSeqLen,
             this->mLoraSize + this->mRopeSize, this->mStream->get());
         cudaStreamSynchronize(this->mStream->get());
@@ -743,7 +770,7 @@ protected:
     {
         using tensorrt_llm::runtime::bufferCast;
         auto* compressed_kv_ptr = bufferCast<DataType>(*(this->h_compressed_kv_tensor));
-        auto* k_pe_full_head_ptr = bufferCast<DataType>(*(this->h_k_pe_full_head_tensor));
+        auto* k_pe_one_head_ptr = bufferCast<DataType>(*(this->h_k_pe_one_head_tensor));
         auto* offset_ptr = bufferCast<int32_t>(*(this->h_compressed_offset_tensor));
         auto* compressed_kv_cache_ptr = bufferCast<DataType>(*(this->h_compressed_kv_cache_tensor_ref));
         auto* cu_ctx_cached_kv_lens_ptr = bufferCast<int64_t>(*(this->h_cu_ctx_cached_kv_lens));
@@ -752,7 +779,7 @@ protected:
             sizeof(DataType) * 1 * (this->mLoraSize + this->mRopeSize), 0, 0, 0, 0, compressed_kv_cache_ptr, nullptr,
             reinterpret_cast<tensorrt_llm::kernels::KVBlockArrayForContextFMHA::DataType*>(offset_ptr));
         // currently k_pe_head_num = 1
-        appendPagedKvForMLAKernelRef(kv_cache, compressed_kv_ptr, k_pe_full_head_ptr, this->mNumRequests,
+        appendPagedKvForMLAKernelRef(kv_cache, compressed_kv_ptr, k_pe_one_head_ptr, this->mNumRequests,
             cu_ctx_cached_kv_lens_ptr, cu_seq_lens_ptr, 1, this->mLoraSize, this->mRopeSize);
     }
 
@@ -786,28 +813,49 @@ TYPED_TEST(MlaPreprocessTest, MLAPreprocessDefault)
     sync_check_cuda_error(this->mStream->get());
     bool allEqual{true};
 
-    this->PerformLoadPagedKV();
-    sync_check_cuda_error(this->mStream->get());
-    this->PerformLoadPagedKVRef();
-    auto* kv_k_pe_ptr = bufferCast<DataType>(*(this->h_kv_k_pe_tensor));
-    auto* kv_k_pe_ref_ptr = bufferCast<DataType>(*(this->h_kv_k_pe_tensor_ref));
-    allEqual = this->CheckEqual(kv_k_pe_ref_ptr, kv_k_pe_ptr, this->h_kv_k_pe_tensor->getSize());
-    EXPECT_TRUE(allEqual);
+    {
+        this->PerformLoadPagedKV();
+        sync_check_cuda_error(this->mStream->get());
+        this->PerformLoadPagedKVRef();
+        auto* compressed_kv_output_ptr = bufferCast<DataType>(*(this->h_compressed_kv_output));
+        auto* k_pe_output_ptr = bufferCast<DataType>(*(this->h_k_pe_output));
+        auto* compressed_kv_output_ref_ptr = bufferCast<DataType>(*(this->h_compressed_kv_output_ref));
+        auto* k_pe_output_ref_ptr = bufferCast<DataType>(*(this->h_k_pe_output_ref));
+        allEqual = this->CheckEqual(
+            compressed_kv_output_ref_ptr, compressed_kv_output_ptr, this->h_compressed_kv_output->getSize());
+        EXPECT_TRUE(allEqual);
+        allEqual = this->CheckEqual(k_pe_output_ref_ptr, k_pe_output_ptr, this->h_k_pe_output->getSize());
+        EXPECT_TRUE(allEqual);
+    }
 
-    this->PerformSetPagedKVV2();
-    sync_check_cuda_error(this->mStream->get());
-    this->PerformSetPagedKVV2Ref();
-    auto* kv_cache_ptr = bufferCast<DataType>(*(this->h_kv_cache_tensor));
-    auto* kv_cache_ref_ptr = bufferCast<DataType>(*(this->h_kv_cache_tensor_ref));
-    allEqual = this->CheckEqual(kv_cache_ref_ptr, kv_cache_ptr, this->h_kv_cache_tensor->getSize());
-    EXPECT_TRUE(allEqual);
+    {
+        this->PerformSetPagedKV();
+        sync_check_cuda_error(this->mStream->get());
+        this->PerformSetPagedKVRef();
+        auto* kv_cache_ptr = bufferCast<DataType>(*(this->h_kv_cache_tensor));
+        auto* kv_cache_ref_ptr = bufferCast<DataType>(*(this->h_kv_cache_tensor_ref));
+        allEqual = this->CheckEqual(kv_cache_ref_ptr, kv_cache_ptr, this->h_kv_cache_tensor->getSize());
+        EXPECT_TRUE(allEqual);
+    }
 
-    this->PerformAppendPagedKV();
-    sync_check_cuda_error(this->mStream->get());
-    this->PerformAppendPagedKVRef();
-    auto* compressed_kv_cache_ptr = bufferCast<DataType>(*(this->h_compressed_kv_cache_tensor));
-    auto* compressed_kv_cache_ref_ptr = bufferCast<DataType>(*(this->h_compressed_kv_cache_tensor_ref));
-    allEqual = this->CheckEqual(
-        compressed_kv_cache_ref_ptr, compressed_kv_cache_ptr, this->h_compressed_kv_cache_tensor->getSize());
-    EXPECT_TRUE(allEqual);
+    {
+        this->PerformSetPagedKVV2();
+        sync_check_cuda_error(this->mStream->get());
+        this->PerformSetPagedKVV2Ref();
+        auto* kv_cache_ptr = bufferCast<DataType>(*(this->h_kv_cache_tensor));
+        auto* kv_cache_ref_ptr = bufferCast<DataType>(*(this->h_kv_cache_tensor_ref));
+        allEqual = this->CheckEqual(kv_cache_ref_ptr, kv_cache_ptr, this->h_kv_cache_tensor->getSize());
+        EXPECT_TRUE(allEqual);
+    }
+
+    {
+        this->PerformAppendPagedKV();
+        sync_check_cuda_error(this->mStream->get());
+        this->PerformAppendPagedKVRef();
+        auto* compressed_kv_cache_ptr = bufferCast<DataType>(*(this->h_compressed_kv_cache_tensor));
+        auto* compressed_kv_cache_ref_ptr = bufferCast<DataType>(*(this->h_compressed_kv_cache_tensor_ref));
+        allEqual = this->CheckEqual(
+            compressed_kv_cache_ref_ptr, compressed_kv_cache_ptr, this->h_compressed_kv_cache_tensor->getSize());
+        EXPECT_TRUE(allEqual);
+    }
 }

--- a/cpp/tests/unit_tests/kernels/mlaPreprocessTest.cu
+++ b/cpp/tests/unit_tests/kernels/mlaPreprocessTest.cu
@@ -34,12 +34,16 @@ namespace
 // k_pe_output {total_cached_token, rope_size}
 // compressed_kv_cache {batch, 1 (ignore v), max_seq_len / tokens_per_block, num_head, tokens_per_block, (lora_size +
 // rope_size)}
-template <typename T>
+template <typename T, typename TCache>
 void loadPagedKvKernelRef(T* compressed_kv_output, T* k_pe_output,
     tensorrt_llm::kernels::KVBlockArray const& compressed_kv_cache, int num_contexts,
-    int64_t const* cu_ctx_cached_kv_lens, int const lora_size, int const rope_size)
+    int64_t const* cu_ctx_cached_kv_lens, int const lora_size, int const rope_size,
+    float const* kv_scale_quant_orig_ptr)
 {
+    static_assert(std::is_same_v<T, TCache> || std::is_same_v<TCache, __nv_fp8_e4m3>,
+        "TCache must be either the same type as T or __nv_fp8_e4m3");
     int const head_dim = lora_size + rope_size;
+    float const kv_scale_quant_orig = kv_scale_quant_orig_ptr ? kv_scale_quant_orig_ptr[0] : 1.0f;
     for (int b = 0; b < num_contexts; b++)
     {
         int const global_token_offset = cu_ctx_cached_kv_lens[b];
@@ -49,10 +53,19 @@ void loadPagedKvKernelRef(T* compressed_kv_output, T* k_pe_output,
             int const global_token_idx = global_token_offset + s;
             for (int d = 0; d < head_dim; d++)
             {
-                auto const* kv_src = reinterpret_cast<T const*>(compressed_kv_cache.getKBlockPtr(b, s));
+                auto const* kv_src = reinterpret_cast<TCache const*>(compressed_kv_cache.getKBlockPtr(b, s));
                 auto kv_block_idx = compressed_kv_cache.getKVLocalIdx(s, 0, head_dim, d);
 
-                auto data = kv_src[kv_block_idx];
+                auto src_data = kv_src[kv_block_idx];
+                T data;
+                if constexpr (std::is_same_v<TCache, __nv_fp8_e4m3>)
+                {
+                    data = T(float(src_data) * kv_scale_quant_orig);
+                }
+                else
+                {
+                    data = src_data;
+                }
                 if (d < lora_size)
                 {
                     compressed_kv_output[global_token_idx * lora_size + d] = data;
@@ -189,12 +202,15 @@ void setPagedKvCacheForMLAKernelRefV2(T* output, T* const ck_ptr, T* const cv_pt
 // compressed_kv_cache {batch, 1 (ignore v), max_seq_len / tokens_per_block, num_head=1, tokens_per_block, (lora_size +
 // rope_size)}
 // kv {total_uncached_tokens, h_k=1, lora_d}, k_pe {total_uncached_tokens, h_kpe=1, rope_d}
-template <typename T>
+template <typename T, typename TCache>
 void appendPagedKvForMLAKernelRef(tensorrt_llm::kernels::KVBlockArray& kv_cache, T* const compressed_kv_ptr,
     T* const k_pe_ptr, int const num_requests, int64_t const* cu_ctx_cached_kv_lens, int64_t const* cu_seq_lens,
-    int k_pe_head_num, int lora_size, int rope_size)
+    int k_pe_head_num, int lora_size, int rope_size, float const* kv_scale_orig_quant_ptr)
 {
+    static_assert(std::is_same_v<T, TCache> || std::is_same_v<TCache, __nv_fp8_e4m3>,
+        "TCache must be either the same type as T or __nv_fp8_e4m3");
     assert(k_pe_head_num == 1);
+    float const kv_scale_orig_quant = kv_scale_orig_quant_ptr ? kv_scale_orig_quant_ptr[0] : 1.0f;
     for (int b = 0; b < num_requests; b++)
     {
         int const global_token_offset = cu_seq_lens[b] - cu_ctx_cached_kv_lens[b];
@@ -204,14 +220,24 @@ void appendPagedKvForMLAKernelRef(tensorrt_llm::kernels::KVBlockArray& kv_cache,
         {
             int const ld_kv_offset = (global_token_offset + s) * lora_size;
             int const ld_k_pe_offset = (global_token_offset + s) * k_pe_head_num * rope_size;
-            auto* kv_cache_ptr = reinterpret_cast<T*>(kv_cache.getKBlockPtr(b, cached_kv_len + s));
+            auto* kv_cache_ptr = reinterpret_cast<TCache*>(kv_cache.getKBlockPtr(b, cached_kv_len + s));
             // copy kv
             for (int d = 0; d < lora_size; d++)
             {
                 int const ld_kv_idx = ld_kv_offset + d;
                 int const kv_cache_idx_in_block
                     = kv_cache.getKVLocalIdx(cached_kv_len + s, 0, lora_size + rope_size, d);
-                kv_cache_ptr[kv_cache_idx_in_block] = compressed_kv_ptr[ld_kv_idx];
+                auto src_data = compressed_kv_ptr[ld_kv_idx];
+                TCache data;
+                if constexpr (std::is_same_v<TCache, __nv_fp8_e4m3>)
+                {
+                    data = static_cast<__nv_fp8_e4m3>(static_cast<float>(src_data) * kv_scale_orig_quant);
+                }
+                else
+                {
+                    data = src_data;
+                }
+                kv_cache_ptr[kv_cache_idx_in_block] = data;
             }
             // copy k_pe (we only copy the first head)
             for (int d = 0; d < rope_size; d++)
@@ -219,7 +245,17 @@ void appendPagedKvForMLAKernelRef(tensorrt_llm::kernels::KVBlockArray& kv_cache,
                 int const ld_k_pe_idx = ld_k_pe_offset + d;
                 int const kv_cache_idx_in_block
                     = kv_cache.getKVLocalIdx(cached_kv_len + s, 0, lora_size + rope_size, d + lora_size);
-                kv_cache_ptr[kv_cache_idx_in_block] = k_pe_ptr[ld_k_pe_idx];
+                auto src_data = k_pe_ptr[ld_k_pe_idx];
+                TCache data;
+                if constexpr (std::is_same_v<TCache, __nv_fp8_e4m3>)
+                {
+                    data = static_cast<__nv_fp8_e4m3>(static_cast<float>(src_data) * kv_scale_orig_quant);
+                }
+                else
+                {
+                    data = src_data;
+                }
+                kv_cache_ptr[kv_cache_idx_in_block] = data;
             }
         }
     }
@@ -236,11 +272,14 @@ inline bool almostEqual(float a, float b, float atol = 1e-2, float rtol = 1e-3)
 
 } // namespace
 
-template <typename _DataType>
+template <typename Typepair>
 class MlaPreprocessTest : public testing::Test
 {
 protected:
-    using DataType = _DataType;
+    using DataType = typename Typepair::first_type;
+    using TCache = typename Typepair::second_type;
+    static_assert(std::is_same_v<DataType, TCache> || std::is_same_v<TCache, __nv_fp8_e4m3>,
+        "TCache must be either the same type as DataType or __nv_fp8_e4m3");
     std::shared_ptr<tensorrt_llm::runtime::BufferManager> mBufferManager;
     std::shared_ptr<tensorrt_llm::runtime::CudaStream> mStream;
     // kv_cache shape {batch, 2(k or v), max_seq_len / tokens_per_block, num_head, tokens_per_block, head_size}
@@ -253,7 +292,8 @@ protected:
         h_compressed_kv_cache_tensor{nullptr}, h_compressed_kv_cache_tensor_ref{nullptr}, d_offset_tensor{nullptr},
         d_compressed_offset_tensor{nullptr}, d_cu_ctx_cached_kv_lens{nullptr}, d_cu_seq_lens{nullptr},
         h_offset_tensor{nullptr}, h_compressed_offset_tensor{nullptr}, h_cu_ctx_cached_kv_lens{nullptr},
-        h_cu_seq_lens{nullptr},
+        h_cu_seq_lens{nullptr}, h_kv_scale_orig_quant{nullptr}, d_kv_scale_orig_quant{nullptr},
+        h_kv_scale_quant_orig{nullptr}, d_kv_scale_quant_orig{nullptr},
         // for kernel 1
         d_compressed_kv_output{nullptr}, h_compressed_kv_output{nullptr}, h_compressed_kv_output_ref{nullptr},
         d_k_pe_output{nullptr}, h_k_pe_output{nullptr}, h_k_pe_output_ref{nullptr},
@@ -402,6 +442,32 @@ protected:
         {
             return false;
         }
+        auto cache_dtype = dtype;
+        if constexpr (std::is_same_v<TCache, __nv_fp8_e4m3>)
+        {
+            cache_dtype = nvinfer1::DataType::kFP8;
+            this->h_kv_scale_orig_quant
+                = tensorrt_llm::runtime::BufferManager::pinned(ITensor::makeShape({1}), nvinfer1::DataType::kFLOAT);
+            this->d_kv_scale_orig_quant
+                = tensorrt_llm::runtime::BufferManager::gpuSync(ITensor::makeShape({1}), nvinfer1::DataType::kFLOAT);
+            this->h_kv_scale_quant_orig
+                = tensorrt_llm::runtime::BufferManager::pinned(ITensor::makeShape({1}), nvinfer1::DataType::kFLOAT);
+            this->d_kv_scale_quant_orig
+                = tensorrt_llm::runtime::BufferManager::gpuSync(ITensor::makeShape({1}), nvinfer1::DataType::kFLOAT);
+            auto* kv_scale_orig_quant_ptr = bufferCast<float>(*(this->h_kv_scale_orig_quant));
+            auto* kv_scale_quant_orig_ptr = bufferCast<float>(*(this->h_kv_scale_quant_orig));
+            float kv_scale_orig_quant = 2.0f;
+            kv_scale_orig_quant_ptr[0] = kv_scale_orig_quant;
+            kv_scale_quant_orig_ptr[0] = 1.0 / kv_scale_orig_quant;
+            cudaMemcpy(this->d_kv_scale_orig_quant->data(), this->h_kv_scale_orig_quant->data(),
+                this->h_kv_scale_orig_quant->getSizeInBytes(), cudaMemcpyHostToDevice);
+            cudaMemcpy(this->d_kv_scale_quant_orig->data(), this->h_kv_scale_quant_orig->data(),
+                this->h_kv_scale_quant_orig->getSizeInBytes(), cudaMemcpyHostToDevice);
+        }
+        else
+        {
+            static_assert(std::is_same_v<DataType, TCache>, "TCache must be the same type as DataType");
+        }
         this->h_cu_seq_lens = tensorrt_llm::runtime::BufferManager::pinned(
             ITensor::makeShape({this->mNumRequests + 1}), nvinfer1::DataType::kINT64);
         this->h_cu_ctx_cached_kv_lens = tensorrt_llm::runtime::BufferManager::pinned(
@@ -454,11 +520,11 @@ protected:
         this->h_compressed_kv_cache_tensor = tensorrt_llm::runtime::BufferManager::pinned(
             ITensor::makeShape({this->mNumRequests, 1, this->mMaxBlockPerSeq, this->mNumHeadsCompressed,
                 this->mTokensPerBlock, this->mLoraSize + this->mRopeSize}),
-            dtype);
+            cache_dtype);
         this->h_compressed_kv_cache_tensor_ref = tensorrt_llm::runtime::BufferManager::pinned(
             ITensor::makeShape({this->mNumRequests, 1, this->mMaxBlockPerSeq, this->mNumHeadsCompressed,
                 this->mTokensPerBlock, this->mLoraSize + this->mRopeSize}),
-            dtype);
+            cache_dtype);
         this->h_offset_tensor = tensorrt_llm::runtime::BufferManager::pinned(
             ITensor::makeShape({this->mNumRequests, 2, this->mMaxBlockPerSeq}), nvinfer1::DataType::kINT32);
         this->h_compressed_offset_tensor = tensorrt_llm::runtime::BufferManager::pinned(
@@ -470,11 +536,11 @@ protected:
         this->d_compressed_kv_cache_tensor = tensorrt_llm::runtime::BufferManager::gpuSync(
             ITensor::makeShape({this->mNumRequests, 1, this->mMaxBlockPerSeq, this->mNumHeadsCompressed,
                 this->mTokensPerBlock, this->mLoraSize + this->mRopeSize}),
-            dtype);
+            cache_dtype);
         this->d_compressed_kv_cache_tensor_ref = tensorrt_llm::runtime::BufferManager::gpuSync(
             ITensor::makeShape({this->mNumRequests, 1, this->mMaxBlockPerSeq, this->mNumHeadsCompressed,
                 this->mTokensPerBlock, this->mLoraSize + this->mRopeSize}),
-            dtype);
+            cache_dtype);
         this->d_offset_tensor = tensorrt_llm::runtime::BufferManager::gpuSync(
             ITensor::makeShape({this->mNumRequests, 2, this->mMaxBlockPerSeq}), nvinfer1::DataType::kINT32);
         this->d_compressed_offset_tensor = tensorrt_llm::runtime::BufferManager::gpuSync(
@@ -482,8 +548,8 @@ protected:
         {
             auto* kv_cache_ptr = bufferCast<DataType>(*(this->h_kv_cache_tensor));
             auto* kv_cache_ref_ptr = bufferCast<DataType>(*(this->h_kv_cache_tensor_ref));
-            auto* compressed_kv_cache_ptr = bufferCast<DataType>(*(this->h_compressed_kv_cache_tensor));
-            auto* compressed_kv_cache_ref_ptr = bufferCast<DataType>(*(this->h_compressed_kv_cache_tensor_ref));
+            auto* compressed_kv_cache_ptr = bufferCast<TCache>(*(this->h_compressed_kv_cache_tensor));
+            auto* compressed_kv_cache_ref_ptr = bufferCast<TCache>(*(this->h_compressed_kv_cache_tensor_ref));
             auto* offset_ptr = bufferCast<int32_t>(*(this->h_offset_tensor));
             auto* compressed_offset_ptr = bufferCast<int32_t>(*(this->h_compressed_offset_tensor));
             fillArrayDataWithMod(compressed_kv_cache_ptr, this->h_compressed_kv_cache_tensor->getSize());
@@ -647,15 +713,20 @@ protected:
         using tensorrt_llm::runtime::bufferCast;
         auto* compressed_kv_output_ptr = bufferCast<DataType>(*(this->d_compressed_kv_output));
         auto* k_pe_output_ptr = bufferCast<DataType>(*(this->d_k_pe_output));
-        auto* compressed_kv_cache_ptr = bufferCast<DataType>(*(this->d_compressed_kv_cache_tensor));
+        auto* compressed_kv_cache_ptr = bufferCast<TCache>(*(this->d_compressed_kv_cache_tensor));
         auto* offset_ptr = bufferCast<int32_t>(*(this->d_compressed_offset_tensor));
         auto* cu_ctx_cached_kv_lens_ptr = bufferCast<int64_t>(*(this->d_cu_ctx_cached_kv_lens));
+        float* kv_scale_quant_orig_ptr = nullptr;
+        if constexpr (std::is_same_v<TCache, __nv_fp8_e4m3>)
+        {
+            kv_scale_quant_orig_ptr = bufferCast<float>(*(this->d_kv_scale_quant_orig));
+        }
         tensorrt_llm::kernels::KVBlockArray kv_cache(this->mNumRequests, this->mMaxBlockPerSeq, this->mTokensPerBlock,
-            sizeof(DataType) * 1 * (this->mLoraSize + this->mRopeSize), 0, 0, 0, 0, compressed_kv_cache_ptr, nullptr,
+            sizeof(TCache) * 1 * (this->mLoraSize + this->mRopeSize), 0, 0, 0, 0, compressed_kv_cache_ptr, nullptr,
             reinterpret_cast<tensorrt_llm::kernels::KVBlockArrayForContextFMHA::DataType*>(offset_ptr));
-        tensorrt_llm::kernels::invokeMLALoadPagedKV<DataType>(compressed_kv_output_ptr, k_pe_output_ptr, kv_cache,
-            this->mNumRequests, cu_ctx_cached_kv_lens_ptr, this->mMaxCachedSeqLen, this->mLoraSize, this->mRopeSize,
-            this->mStream->get());
+        tensorrt_llm::kernels::invokeMLALoadPagedKV<DataType, TCache>(compressed_kv_output_ptr, k_pe_output_ptr,
+            kv_cache, this->mNumRequests, cu_ctx_cached_kv_lens_ptr, this->mMaxCachedSeqLen, this->mLoraSize,
+            this->mRopeSize, kv_scale_quant_orig_ptr, this->mStream->get());
         cudaStreamSynchronize(this->mStream->get());
         cudaMemcpy(this->h_compressed_kv_output->data(), this->d_compressed_kv_output->data(),
             this->d_compressed_kv_output->getSizeInBytes(), cudaMemcpyDeviceToHost);
@@ -668,14 +739,19 @@ protected:
         using tensorrt_llm::runtime::bufferCast;
         auto* compressed_kv_output_ptr = bufferCast<DataType>(*(this->h_compressed_kv_output_ref));
         auto* k_pe_output_ptr = bufferCast<DataType>(*(this->h_k_pe_output_ref));
-        auto* compressed_kv_cache_ptr = bufferCast<DataType>(*(this->h_compressed_kv_cache_tensor));
+        auto* compressed_kv_cache_ptr = bufferCast<TCache>(*(this->h_compressed_kv_cache_tensor));
         auto* offset_ptr = bufferCast<int32_t>(*(this->h_compressed_offset_tensor));
         auto* cu_ctx_cached_kv_lens_ptr = bufferCast<int64_t>(*(this->h_cu_ctx_cached_kv_lens));
+        float* kv_scale_quant_orig_ptr = nullptr;
+        if constexpr (std::is_same_v<TCache, __nv_fp8_e4m3>)
+        {
+            kv_scale_quant_orig_ptr = bufferCast<float>(*(this->h_kv_scale_quant_orig));
+        }
         tensorrt_llm::kernels::KVBlockArray kv_cache(this->mNumRequests, this->mMaxBlockPerSeq, this->mTokensPerBlock,
-            sizeof(DataType) * 1 * (this->mLoraSize + this->mRopeSize), 0, 0, 0, 0, compressed_kv_cache_ptr, nullptr,
+            sizeof(TCache) * 1 * (this->mLoraSize + this->mRopeSize), 0, 0, 0, 0, compressed_kv_cache_ptr, nullptr,
             reinterpret_cast<tensorrt_llm::kernels::KVBlockArrayForContextFMHA::DataType*>(offset_ptr));
-        loadPagedKvKernelRef(compressed_kv_output_ptr, k_pe_output_ptr, kv_cache, this->mNumRequests,
-            cu_ctx_cached_kv_lens_ptr, this->mLoraSize, this->mRopeSize);
+        loadPagedKvKernelRef<DataType, TCache>(compressed_kv_output_ptr, k_pe_output_ptr, kv_cache, this->mNumRequests,
+            cu_ctx_cached_kv_lens_ptr, this->mLoraSize, this->mRopeSize, kv_scale_quant_orig_ptr);
     }
 
     void PerformSetPagedKV()
@@ -752,15 +828,20 @@ protected:
         auto* compressed_kv_ptr = bufferCast<DataType>(*(this->d_compressed_kv_tensor));
         auto* k_pe_one_head_ptr = bufferCast<DataType>(*(this->d_k_pe_one_head_tensor));
         auto* offset_ptr = bufferCast<int32_t>(*(this->d_compressed_offset_tensor));
-        auto* compressed_kv_cache_ptr = bufferCast<DataType>(*(this->d_compressed_kv_cache_tensor));
+        auto* compressed_kv_cache_ptr = bufferCast<TCache>(*(this->d_compressed_kv_cache_tensor));
         auto* cu_ctx_cached_kv_lens_ptr = bufferCast<int64_t>(*(this->d_cu_ctx_cached_kv_lens));
         auto* cu_seq_lens_ptr = bufferCast<int64_t>(*(this->d_cu_seq_lens));
+        float* kv_scale_orig_quant_ptr = nullptr;
+        if constexpr (std::is_same_v<TCache, __nv_fp8_e4m3>)
+        {
+            kv_scale_orig_quant_ptr = bufferCast<float>(*(this->d_kv_scale_orig_quant));
+        }
         tensorrt_llm::kernels::KVBlockArray kv_cache(this->mNumRequests, this->mMaxBlockPerSeq, this->mTokensPerBlock,
-            sizeof(DataType) * 1 * (this->mLoraSize + this->mRopeSize), 0, 0, 0, 0, compressed_kv_cache_ptr, nullptr,
+            sizeof(TCache) * 1 * (this->mLoraSize + this->mRopeSize), 0, 0, 0, 0, compressed_kv_cache_ptr, nullptr,
             reinterpret_cast<tensorrt_llm::kernels::KVBlockArrayForContextFMHA::DataType*>(offset_ptr));
-        tensorrt_llm::kernels::invokeMLAAppendPagedKV<DataType>(kv_cache, compressed_kv_ptr, k_pe_one_head_ptr,
+        tensorrt_llm::kernels::invokeMLAAppendPagedKV<DataType, TCache>(kv_cache, compressed_kv_ptr, k_pe_one_head_ptr,
             this->mNumRequests, cu_ctx_cached_kv_lens_ptr, cu_seq_lens_ptr, this->mMaxUncachedSeqLen,
-            this->mLoraSize + this->mRopeSize, this->mStream->get());
+            this->mLoraSize + this->mRopeSize, kv_scale_orig_quant_ptr, this->mStream->get());
         cudaStreamSynchronize(this->mStream->get());
         cudaMemcpy(this->h_compressed_kv_cache_tensor->data(), this->d_compressed_kv_cache_tensor->data(),
             this->d_compressed_kv_cache_tensor->getSizeInBytes(), cudaMemcpyDeviceToHost);
@@ -772,15 +853,21 @@ protected:
         auto* compressed_kv_ptr = bufferCast<DataType>(*(this->h_compressed_kv_tensor));
         auto* k_pe_one_head_ptr = bufferCast<DataType>(*(this->h_k_pe_one_head_tensor));
         auto* offset_ptr = bufferCast<int32_t>(*(this->h_compressed_offset_tensor));
-        auto* compressed_kv_cache_ptr = bufferCast<DataType>(*(this->h_compressed_kv_cache_tensor_ref));
+        auto* compressed_kv_cache_ptr = bufferCast<TCache>(*(this->h_compressed_kv_cache_tensor_ref));
         auto* cu_ctx_cached_kv_lens_ptr = bufferCast<int64_t>(*(this->h_cu_ctx_cached_kv_lens));
         auto* cu_seq_lens_ptr = bufferCast<int64_t>(*(this->h_cu_seq_lens));
+        float* kv_scale_orig_quant_ptr = nullptr;
+        if constexpr (std::is_same_v<TCache, __nv_fp8_e4m3>)
+        {
+            kv_scale_orig_quant_ptr = bufferCast<float>(*(this->h_kv_scale_orig_quant));
+        }
         tensorrt_llm::kernels::KVBlockArray kv_cache(this->mNumRequests, this->mMaxBlockPerSeq, this->mTokensPerBlock,
-            sizeof(DataType) * 1 * (this->mLoraSize + this->mRopeSize), 0, 0, 0, 0, compressed_kv_cache_ptr, nullptr,
+            sizeof(TCache) * 1 * (this->mLoraSize + this->mRopeSize), 0, 0, 0, 0, compressed_kv_cache_ptr, nullptr,
             reinterpret_cast<tensorrt_llm::kernels::KVBlockArrayForContextFMHA::DataType*>(offset_ptr));
         // currently k_pe_head_num = 1
-        appendPagedKvForMLAKernelRef(kv_cache, compressed_kv_ptr, k_pe_one_head_ptr, this->mNumRequests,
-            cu_ctx_cached_kv_lens_ptr, cu_seq_lens_ptr, 1, this->mLoraSize, this->mRopeSize);
+        appendPagedKvForMLAKernelRef<DataType, TCache>(kv_cache, compressed_kv_ptr, k_pe_one_head_ptr,
+            this->mNumRequests, cu_ctx_cached_kv_lens_ptr, cu_seq_lens_ptr, 1, this->mLoraSize, this->mRopeSize,
+            kv_scale_orig_quant_ptr);
     }
 
     template <typename T>
@@ -788,10 +875,12 @@ protected:
     {
         for (int i = 0; i < size; i++)
         {
-            if (!almostEqual(expected[i], output[i], 1e-3, 1e-3))
+            auto e = static_cast<float>(expected[i]);
+            auto o = static_cast<float>(output[i]);
+            if (!almostEqual(e, o, 1e-3, 1e-3))
             {
-                TLLM_LOG_ERROR("Mismatch input value. Position of inputs: %d, expected value: %f, output value: %f", i,
-                    static_cast<float>(expected[i]), static_cast<float>(output[i]));
+                TLLM_LOG_ERROR(
+                    "Mismatch input value. Position of inputs: %d, expected value: %f, output value: %f", i, e, o);
                 return false;
             }
         }
@@ -799,16 +888,19 @@ protected:
     }
 };
 
-using MLATypes = ::testing::Types<half, __nv_bfloat16, float>;
+using MLATypes
+    = ::testing::Types<std::pair<half, half>, std::pair<__nv_bfloat16, __nv_bfloat16>, std::pair<float, float>,
+        std::pair<half, __nv_fp8_e4m3>, std::pair<__nv_bfloat16, __nv_fp8_e4m3>, std::pair<float, __nv_fp8_e4m3>>;
 TYPED_TEST_SUITE(MlaPreprocessTest, MLATypes);
 
 TYPED_TEST(MlaPreprocessTest, MLAPreprocessDefault)
 {
     using tensorrt_llm::runtime::bufferCast;
     using DataType = typename TestFixture::DataType;
+    using TCache = typename TestFixture::TCache;
     this->mNumRequests = 8;
     this->setDefaultParams();
-    this->allocateBuffers();
+    EXPECT_TRUE(this->allocateBuffers());
 
     sync_check_cuda_error(this->mStream->get());
     bool allEqual{true};
@@ -852,8 +944,8 @@ TYPED_TEST(MlaPreprocessTest, MLAPreprocessDefault)
         this->PerformAppendPagedKV();
         sync_check_cuda_error(this->mStream->get());
         this->PerformAppendPagedKVRef();
-        auto* compressed_kv_cache_ptr = bufferCast<DataType>(*(this->h_compressed_kv_cache_tensor));
-        auto* compressed_kv_cache_ref_ptr = bufferCast<DataType>(*(this->h_compressed_kv_cache_tensor_ref));
+        auto* compressed_kv_cache_ptr = bufferCast<TCache>(*(this->h_compressed_kv_cache_tensor));
+        auto* compressed_kv_cache_ref_ptr = bufferCast<TCache>(*(this->h_compressed_kv_cache_tensor_ref));
         allEqual = this->CheckEqual(
             compressed_kv_cache_ref_ptr, compressed_kv_cache_ptr, this->h_compressed_kv_cache_tensor->getSize());
         EXPECT_TRUE(allEqual);

--- a/examples/models/core/deepseek_v3/README.md
+++ b/examples/models/core/deepseek_v3/README.md
@@ -678,7 +678,7 @@ echo "All processes completed!"
 The converted checkpoint could be used as `<YOUR_MODEL_DIR>` and consumed by other commands.
 
 ### KV Cache Reuse
-KV cache reuse is supported for MLA on SM90 and SM100. It is enabled by default and does not support FP8 KV cache right now. Due to extra operations like memcpy and GEMMs, GPU memory consumption may be higher and the E2E performance may have regression in some cases. Users could pass `KvCacheConfig(enable_block_reuse=False)` to LLM API to disable it.
+KV cache reuse is supported for MLA on SM90 and SM100. It is enabled by default. Due to extra operations like memcpy and GEMMs, GPU memory consumption may be higher and the E2E performance may have regression in some cases. Users could pass `KvCacheConfig(enable_block_reuse=False)` to LLM API to disable it.
 
 ## Notes and Troubleshooting
 

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -630,15 +630,11 @@ class TrtllmAttentionMetadata(AttentionMetadata):
             self.num_ctx_cached_tokens = cached_token_lens[:self.
                                                            num_contexts].sum(
                                                            ).item()
-            self.max_ctx_cached_token_len = cached_token_lens[:self.
-                                                              num_contexts].max(
-                                                              ).item()
             self.max_ctx_kv_len = kv_lens[:self.num_contexts].max().item()
             self.max_ctx_seq_len = self.seq_lens[:self.num_contexts].max().item(
             )
         else:
             self.num_ctx_cached_tokens = 0
-            self.max_ctx_cached_token_len = 0
             self.max_ctx_kv_len = 0
             self.max_ctx_seq_len = 0
         torch.cumsum(cached_token_lens[:self.num_contexts],

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -860,7 +860,7 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
         assert self.is_mla_enable and self.mla_params is not None
         assert metadata.kv_cache_manager is not None
 
-        if metadata.max_ctx_cached_token_len == 0:
+        if metadata.max_ctx_kv_len == 0:
             return torch.empty((0, metadata.kv_cache_manager.head_dim),
                                dtype=out_dtype,
                                device=metadata.ctx_cached_token_indptr.device)
@@ -868,11 +868,11 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
         sink_token_length = 0
         beam_width = 1
 
-        output = torch.ops.trtllm.load_paged_kv_cache_for_mla(
+        compressed_kv, k_pe = torch.ops.trtllm.load_paged_kv_cache_for_mla(
             out_dtype,
             metadata.num_contexts,
-            metadata.max_ctx_cached_token_len,
-            metadata.ctx_cached_token_indptr,
+            metadata.max_ctx_kv_len,
+            metadata.ctx_kv_indptr,
             metadata.kv_cache_block_offsets,
             metadata.host_kv_cache_block_offsets,
             metadata.kv_cache_manager.kv_cache_pool_pointers,
@@ -880,7 +880,8 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
             self.kv_scale_orig_quant,
             self.kv_scale_quant_orig,
             self.get_local_layer_idx(metadata),
-            metadata.kv_cache_manager.head_dim,
+            self.mla_params.kv_lora_rank,
+            self.mla_params.qk_rope_head_dim,
             metadata.kv_cache_manager.tokens_per_block,
             metadata.kv_cache_manager.max_seq_len,
             sink_token_length,
@@ -888,7 +889,7 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
             self.wrapper.quant_mode,
         )
 
-        return output
+        return compressed_kv, k_pe
 
     def set_paged_kv_cache_for_mla(
         self,
@@ -903,10 +904,6 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
         assert metadata.kv_cache_manager is not None
         assert paged_kv.shape[0] == metadata.num_contexts
         assert paged_kv.is_contiguous()
-
-        k = k.contiguous()
-        v = v.contiguous()
-        k_pe = k_pe.contiguous()
 
         num_contexts = metadata.num_contexts
         max_seq_len = metadata.max_ctx_kv_len

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -859,11 +859,7 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
         assert out_dtype in [torch.float16, torch.bfloat16, torch.float32]
         assert self.is_mla_enable and self.mla_params is not None
         assert metadata.kv_cache_manager is not None
-
-        if metadata.max_ctx_kv_len == 0:
-            return torch.empty((0, metadata.kv_cache_manager.head_dim),
-                               dtype=out_dtype,
-                               device=metadata.ctx_cached_token_indptr.device)
+        assert metadata.max_ctx_kv_len > 0
 
         sink_token_length = 0
         beam_width = 1

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -828,43 +828,10 @@ class MLA(nn.Module):
         position_ids: Optional[torch.LongTensor] = None,
     ) -> torch.Tensor:
         trtllm_attention = cast(TrtllmAttention, self.mha)
-        # copy past_compressed_kv and past_k_pe from paged kv cache
-        past_latent_cache = trtllm_attention.load_paged_kv_cache_for_mla(
-            attn_metadata, q.dtype)
-        assert past_latent_cache.shape[0] == attn_metadata.num_ctx_cached_tokens
-        assert past_latent_cache.shape[
-            1] == self.kv_lora_rank + self.qk_rope_head_dim
-        past_compressed_kv, past_k_pe = past_latent_cache.split(
-            [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
-
-        # compute past_k_nope and past_v from past_compressed_kv
-        # TODO: remove this contiguous by return two tensors from load_paged_kv_cache_for_mla
-        past_compressed_kv = past_compressed_kv.contiguous()
-        past_kv = self.kv_b_proj(past_compressed_kv)
-        past_k_nope, past_v = past_kv.split(
-            [
-                self.num_heads * self.qk_nope_head_dim,
-                self.num_heads * self.v_head_dim
-            ],
-            -1,
-        )
-        past_k_nope = past_k_nope.view(-1, self.num_heads,
-                                       self.qk_nope_head_dim)
-        past_v = past_v.view(-1, self.num_heads, self.v_head_dim)
-
-        # compute current k_nope and v from compressed_kv
-        kv = self.kv_b_proj(compressed_kv)
-        k_nope, v = kv.split([
-            self.num_heads * self.qk_nope_head_dim,
-            self.num_heads * self.v_head_dim
-        ],
-                             dim=-1)
-
         # split current q into q_nope and q_pe
         q_nope, q_pe = q.view([
             -1, self.num_heads, self.qk_nope_head_dim + self.qk_rope_head_dim
         ]).split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
-
         # apply rope to current q_pe and k_pe
         assert position_ids is not None
         assert position_ids.dim() == 1 or (position_ids.dim() == 2
@@ -898,29 +865,47 @@ class MLA(nn.Module):
             attn_metadata,
         )
 
-        # build full_k and full_v
-        k_nope = k_nope.view(-1, self.num_heads, self.qk_nope_head_dim)
-        v = v.view(-1, self.num_heads, self.v_head_dim)
+        # copy full_compressed_kv and full_k_pe from paged kv cache
+        full_compressed_kv, full_k_pe = trtllm_attention.load_paged_kv_cache_for_mla(
+            attn_metadata, q.dtype)
+        assert full_compressed_kv.shape[
+            0] == attn_metadata.num_ctx_cached_tokens + attn_metadata.num_ctx_tokens
+        assert full_compressed_kv.shape[1] == self.kv_lora_rank
+        assert full_k_pe.shape[
+            0] == attn_metadata.num_ctx_cached_tokens + attn_metadata.num_ctx_tokens
+        assert full_k_pe.shape[1] == self.qk_rope_head_dim
+        assert full_compressed_kv.is_contiguous()
+        assert full_k_pe.is_contiguous()
 
+        # compute full_k_nope and full_v from full_compressed_kv
+        full_kv = self.kv_b_proj(full_compressed_kv)
+        full_k_nope, full_v = full_kv.split(
+            [
+                self.num_heads * self.qk_nope_head_dim,
+                self.num_heads * self.v_head_dim
+            ],
+            -1,
+        )
+        full_k_nope = full_k_nope.view(-1, self.num_heads,
+                                       self.qk_nope_head_dim)
+        full_v = full_v.view(-1, self.num_heads, self.v_head_dim)
+
+        # build full_k and full_v
         tokens_per_block = attn_metadata.kv_cache_manager.tokens_per_block
         # paged kv cache should be initialized to 0 to avoid NaN
-        full_kv = torch.zeros([
+        paged_full_kv = torch.zeros([
             attn_metadata.num_contexts, 2,
             (attn_metadata.max_ctx_kv_len + tokens_per_block - 1) //
             tokens_per_block, self.num_heads, tokens_per_block,
             max(self.qk_nope_head_dim + self.qk_rope_head_dim, self.v_head_dim)
         ],
-                              dtype=q.dtype,
-                              device=q.device)
-
-        mla_context_kv_cache_block_offsets = trtllm_attention.set_paged_kv_cache_v2_for_mla(
-            full_kv,
-            past_k_nope,
-            past_v,
-            past_k_pe,
-            k_nope,
-            v,
-            k_pe,
+                                    dtype=q.dtype,
+                                    device=q.device)
+        mla_context_kv_cache_block_offsets = trtllm_attention.set_paged_kv_cache_for_mla(
+            paged_full_kv,
+            full_k_nope,
+            full_v,
+            full_k_pe,
             attn_metadata,
         )
 
@@ -935,10 +920,11 @@ class MLA(nn.Module):
             attention_input_type=AttentionInputType.context_only,
             latent_cache=None,
             out_scale=out_scale,
-            mla_context_paged_kv=full_kv,
+            mla_context_paged_kv=paged_full_kv,
             mla_context_kv_cache_block_offsets=
             mla_context_kv_cache_block_offsets,
         )
+
         return attn_output
 
     def forward_context(

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -924,12 +924,6 @@ class MLA(nn.Module):
             mla_context_kv_cache_block_offsets,
         )
 
-        full_compressed_kv = None
-        full_k_pe = None
-        full_k_nope = None
-        full_v = None
-        full_kv = None
-        paged_full_kv = None
         return attn_output
 
     def forward_context(

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -8,7 +8,7 @@ from tensorrt_llm.bindings.internal.batch_manager import ContextChunkingConfig
 from tensorrt_llm.logger import logger
 from tensorrt_llm.lora_manager import LoraConfig
 from tensorrt_llm.mapping import Mapping
-from tensorrt_llm.quantization import KV_CACHE_QUANT_ALGO_LIST
+from tensorrt_llm.quantization import QuantAlgo
 
 from ..attention_backend.interface import AttentionRuntimeFeatures
 from ..distributed import MPIDist
@@ -150,14 +150,16 @@ def create_py_executor(executor_config: ExecutorConfig,
         if executor_config.kv_cache_config.enable_block_reuse and not (
                 get_sm_version() >= 90 and get_sm_version() <= 100):
             logger.warning(
-                f"KV cache reuse for MLA only can be enabled on SM90/SM100, "
+                f"KV cache reuse for MLA can only be enabled on SM90/SM100, "
                 f"disable enable_block_reuse for SM{get_sm_version()}")
             executor_config.kv_cache_config.enable_block_reuse = False
 
         kv_cache_quant_algo = model_engine.model.model_config.quant_config.kv_cache_quant_algo
-        if executor_config.kv_cache_config.enable_block_reuse and kv_cache_quant_algo in KV_CACHE_QUANT_ALGO_LIST:
+        if executor_config.kv_cache_config.enable_block_reuse and not (
+                kv_cache_quant_algo == QuantAlgo.NO_QUANT
+                or kv_cache_quant_algo == QuantAlgo.FP8):
             logger.warning(
-                f"KV cache reuse for MLA only can be enabled without KV cache quantization, "
+                f"KV cache reuse for MLA can only be enabled without KV cache quantization or with FP8 quantization, "
                 f"disable enable_block_reuse for KV cache quant algorithm: {kv_cache_quant_algo}"
             )
             executor_config.kv_cache_config.enable_block_reuse = False

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -156,8 +156,8 @@ def create_py_executor(executor_config: ExecutorConfig,
 
         kv_cache_quant_algo = model_engine.model.model_config.quant_config.kv_cache_quant_algo
         if executor_config.kv_cache_config.enable_block_reuse and not (
-                kv_cache_quant_algo == QuantAlgo.NO_QUANT
-                or kv_cache_quant_algo == QuantAlgo.FP8):
+                kv_cache_quant_algo is None or kv_cache_quant_algo
+                == QuantAlgo.NO_QUANT or kv_cache_quant_algo == QuantAlgo.FP8):
             logger.warning(
                 f"KV cache reuse for MLA can only be enabled without KV cache quantization or with FP8 quantization, "
                 f"disable enable_block_reuse for KV cache quant algorithm: {kv_cache_quant_algo}"

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -462,8 +462,7 @@ class TestDeepSeekV3Lite(LlmapiAccuracyTestHarness):
         if torch_compile and attention_dp:
             pytest.skip("https://nvbugs/5252559")
         # OOM on H100 with default free_gpu_memory_fraction=0.9
-        kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.8,
-                                        enable_block_reuse=not fp8kv)
+        kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.8)
         pytorch_config = PyTorchConfig(
             disable_overlap_scheduler=not overlap_scheduler,
             use_cuda_graph=cuda_graph,
@@ -544,8 +543,7 @@ class TestDeepSeekV3Lite(LlmapiAccuracyTestHarness):
         if torch_compile and pp_size > 1:
             pytest.skip("PP with torch.compile is not supported yet.")
         # OOM on H100 with default free_gpu_memory_fraction=0.9
-        kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.8,
-                                        enable_block_reuse=not fp8kv)
+        kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.8)
         pytorch_config = PyTorchConfig(
             disable_overlap_scheduler=not overlap_scheduler,
             use_cuda_graph=cuda_graph,
@@ -597,8 +595,7 @@ class TestDeepSeekV3Lite(LlmapiAccuracyTestHarness):
                    torch_compile):
         if torch_compile and attention_dp:
             pytest.skip("https://nvbugs/5252559")
-        kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.9,
-                                        enable_block_reuse=not fp8kv)
+        kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.9)
 
         pytorch_config = PyTorchConfig(
             disable_overlap_scheduler=not overlap_scheduler,
@@ -650,8 +647,7 @@ class TestDeepSeekV3Lite(LlmapiAccuracyTestHarness):
             pytest.skip("https://nvbugs/5252559")
         if torch_compile and pp_size > 1:
             pytest.skip("PP with torch.compile is not supported yet.")
-        kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.9,
-                                        enable_block_reuse=not fp8kv)
+        kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.9)
         pytorch_config = PyTorchConfig(
             disable_overlap_scheduler=not overlap_scheduler,
             use_cuda_graph=cuda_graph,
@@ -775,8 +771,7 @@ class TestDeepSeekR1(LlmapiAccuracyTestHarness):
                          attention_dp, cuda_graph, overlap_scheduler,
                          batch_size, moe_backend):
 
-        kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.4,
-                                        enable_block_reuse=not fp8kv)
+        kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.4)
         pytorch_config = PyTorchConfig(
             disable_overlap_scheduler=not overlap_scheduler,
             use_cuda_graph=cuda_graph)


### PR DESCRIPTION
## Description

Support FP8 KV Cache Reuse for MLA.
Optimize reuse workflow as well.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
