### PR TITLE
[TRTLLM-4987][feat] Support context logits in TRTLLMSampler

### DIFF
--- a/cpp/tensorrt_llm/pybind/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/bindings.cpp
@@ -114,8 +114,14 @@ PYBIND11_MODULE(TRTLLM_PYBIND_MODULE, m)
         .def("get_device", &tr::CudaStream::getDevice);
 
     // Create submodule for executor bindings.
-    py::module_ executor_submodule = m.def_submodule("executor", "Executor bindings");
-    tensorrt_llm::pybind::executor::initBindings(executor_submodule);
+    auto mExecutor = m.def_submodule("executor", "Executor bindings");
+    auto mInternal = m.def_submodule("internal", "Internal submodule of TRTLLM runtime");
+    auto mInternalRuntime = mInternal.def_submodule("runtime", "Runtime internal bindings");
+    auto mInternalTesting = mInternal.def_submodule("testing", "Testing internal bindings");
+    auto mInternalBatchManager = mInternal.def_submodule("batch_manager", "Batch manager internal bindings");
+
+    tensorrt_llm::pybind::executor::initBindings(mExecutor);
+    tensorrt_llm::pybind::runtime::initBindingsEarly(mInternalRuntime);
 
     auto buildInfo = m.def_submodule("BuildInfo");
     buildInfo.attr("ENABLE_MULTI_DEVICE") = py::int_(ENABLE_MULTI_DEVICE);
@@ -329,6 +335,7 @@ PYBIND11_MODULE(TRTLLM_PYBIND_MODULE, m)
         .def_property_readonly("hidden_size", &tr::ModelConfig::getHiddenSize)
         .def_property_readonly("size_per_head", &tr::ModelConfig::getSizePerHead)
         .def_property_readonly("data_type", &tr::ModelConfig::getDataType)
+        .def_property_readonly("speculative_decoding_mode", &tr::ModelConfig::getSpeculativeDecodingMode)
         .def_property("head_size", &tr::ModelConfig::getSizePerHead, &tr::ModelConfig::setSizePerHead)
         .def_property(
             "num_kv_heads_per_layer", &tr::ModelConfig::getNumKvHeadsPerLayer, &tr::ModelConfig::setNumKvHeadsPerLayer)
@@ -456,10 +463,9 @@ PYBIND11_MODULE(TRTLLM_PYBIND_MODULE, m)
         .def_readwrite("num_return_sequences", &tr::SamplingConfig::numReturnSequences)
         .def_readwrite("min_p", &tr::SamplingConfig::minP)
         .def_readwrite("beam_width_array", &tr::SamplingConfig::beamWidthArray)
+        .def_readwrite("normalize_log_probs", &tr::SamplingConfig::normalizeLogProbs)
         .def(py::pickle(SamplingConfigGetState, SamplingConfigSetState))
         .def("__eq__", &tr::SamplingConfig::operator==);
-
-    py::bind_vector<std::vector<tr::SamplingConfig>>(m, "VectorSamplingConfig");
 
     m.def("make_sampling_config", &makeSamplingConfig, py::arg("configs"));
 
@@ -548,15 +554,8 @@ PYBIND11_MODULE(TRTLLM_PYBIND_MODULE, m)
         .def_property_readonly("pinned", &tr::MemoryCounters::getPinned)
         .def_property_readonly("uvm", &tr::MemoryCounters::getUVM);
 
-    auto mInternal = m.def_submodule("internal", "Internal submodule of TRTLLM runtime");
-
-    auto mInternalRuntime = mInternal.def_submodule("runtime", "Runtime internal bindings");
     tensorrt_llm::pybind::runtime::initBindings(mInternalRuntime);
-
-    auto mInternalTesting = mInternal.def_submodule("testing", "Testing internal bindings");
     tensorrt_llm::pybind::testing::initBindings(mInternalTesting);
-
-    auto mInternalBatchManager = mInternal.def_submodule("batch_manager", "Batch manager internal bindings");
     tpb::initBindings(mInternalBatchManager);
     tb::kv_cache_manager::KVCacheManagerBindings::initBindings(mInternalBatchManager);
     tb::BasePeftCacheManagerBindings::initBindings(mInternalBatchManager);

--- a/cpp/tensorrt_llm/pybind/common/customCasters.h
+++ b/cpp/tensorrt_llm/pybind/common/customCasters.h
@@ -43,8 +43,6 @@
 // Opaque bindings
 PYBIND11_MAKE_OPAQUE(tensorrt_llm::batch_manager::ReqIdsSet)
 PYBIND11_MAKE_OPAQUE(std::vector<tensorrt_llm::batch_manager::SlotDecoderBuffers>)
-PYBIND11_MAKE_OPAQUE(std::vector<tensorrt_llm::runtime::decoder_batch::Request>)
-PYBIND11_MAKE_OPAQUE(std::vector<tensorrt_llm::runtime::SamplingConfig>)
 
 // Custom casters
 namespace PYBIND11_NAMESPACE
@@ -201,6 +199,69 @@ public:
     static handle cast(tensorrt_llm::executor::Tensor const& src, return_value_policy /* policy */, handle /* parent */)
     {
         return THPVariable_Wrap(tensorrt_llm::runtime::Torch::tensor(tensorrt_llm::executor::detail::toITensor(src)));
+    }
+};
+
+template <>
+struct type_caster<tensorrt_llm::runtime::ITensor::SharedPtr>
+{
+public:
+    PYBIND11_TYPE_CASTER(tensorrt_llm::runtime::ITensor::SharedPtr, _("torch.Tensor"));
+
+    // Convert PyObject(torch.Tensor) -> tensorrt_llm::runtime::ITensor::SharedPtr
+    bool load(handle src, bool)
+    {
+        PyObject* obj = src.ptr();
+        if (THPVariable_Check(obj))
+        {
+            at::Tensor const& t = THPVariable_Unpack(obj);
+            value = std::move(tensorrt_llm::runtime::TorchView::of(t));
+            return true;
+        }
+        return false;
+    }
+
+    // Convert tensorrt_llm::runtime::ITensor::SharedPtr -> PyObject(torch.Tensor)
+    static handle cast(
+        tensorrt_llm::runtime::ITensor::SharedPtr const& src, return_value_policy /* policy */, handle /* parent */)
+    {
+        if (src == nullptr)
+        {
+            return none().release();
+        }
+        return THPVariable_Wrap(tensorrt_llm::runtime::Torch::tensor(src));
+    }
+};
+
+template <>
+struct type_caster<tensorrt_llm::runtime::ITensor::SharedConstPtr>
+{
+public:
+    PYBIND11_TYPE_CASTER(tensorrt_llm::runtime::ITensor::SharedConstPtr, _("torch.Tensor"));
+
+    // Convert PyObject(torch.Tensor) -> tensorrt_llm::runtime::ITensor::SharedConstPtr
+    bool load(handle src, bool)
+    {
+        PyObject* obj = src.ptr();
+        if (THPVariable_Check(obj))
+        {
+            at::Tensor const& t = THPVariable_Unpack(obj);
+            value = std::move(tensorrt_llm::runtime::TorchView::of(t));
+            return true;
+        }
+        return false;
+    }
+
+    // Convert tensorrt_llm::runtime::ITensor::SharedConstPtr -> PyObject(torch.Tensor)
+    static handle cast(tensorrt_llm::runtime::ITensor::SharedConstPtr const& src, return_value_policy /* policy */,
+        handle /* parent */)
+    {
+        if (src == nullptr)
+        {
+            return none().release();
+        }
+        return THPVariable_Wrap(tensorrt_llm::runtime::Torch::tensor(
+            reinterpret_cast<tensorrt_llm::runtime::ITensor::SharedPtr const&>(src)));
     }
 };
 

--- a/cpp/tensorrt_llm/pybind/runtime/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/runtime/bindings.cpp
@@ -216,23 +216,6 @@ void initBindings(pybind11::module_& m)
         .def(py::init<tr::BufferManager::CudaStreamPtr, bool>(), py::arg("stream"), py::arg("trim_pool") = false)
         .def_property_readonly("stream", &tr::BufferManager::getStream);
 
-    py::class_<tr::SpeculativeDecodingMode>(m, "SpeculativeDecodingMode")
-        .def(py::init<tr::SpeculativeDecodingMode::UnderlyingType>(), py::arg("state"))
-        .def_static("NoneType", &tr::SpeculativeDecodingMode::None)
-        .def_static("DraftTokensExternal", &tr::SpeculativeDecodingMode::DraftTokensExternal)
-        .def_static("Medusa", &tr::SpeculativeDecodingMode::Medusa)
-        .def_static("LookaheadDecoding", &tr::SpeculativeDecodingMode::LookaheadDecoding)
-        .def_static("ExplicitDraftTokens", &tr::SpeculativeDecodingMode::ExplicitDraftTokens)
-        .def_property_readonly("is_none", &tr::SpeculativeDecodingMode::isNone)
-        .def_property_readonly("is_draft_tokens_external", &tr::SpeculativeDecodingMode::isDraftTokensExternal)
-        .def_property_readonly("is_medusa", &tr::SpeculativeDecodingMode::isMedusa)
-        .def_property_readonly("is_lookahead_decoding", &tr::SpeculativeDecodingMode::isLookaheadDecoding)
-        .def_property_readonly("is_explicit_draft_tokens", &tr::SpeculativeDecodingMode::isExplicitDraftTokens)
-        .def_property_readonly("needs_kv_cache_rewind", &tr::SpeculativeDecodingMode::needsKVCacheRewind)
-        .def_property_readonly("needs_decoder_prologue", &tr::SpeculativeDecodingMode::needsDecoderPrologue)
-        .def_property_readonly("predicts_draft_tokens", &tr::SpeculativeDecodingMode::predictsDraftTokens)
-        .def_property_readonly("needs_kv_cache_rewind", &tr::SpeculativeDecodingMode::needsKVCacheRewind);
-
     py::classh<tr::TllmRuntime>(m, "TllmRuntime")
         .def(py::init(
             [](std::filesystem::path engine_path, float gpu_weights_percent = 1.0f, bool use_shape_inference = true)
@@ -282,7 +265,6 @@ void initBindings(pybind11::module_& m)
         .def_readwrite("medusa_paths", &tr::decoder_batch::Request::medusaPaths)
         .def_readwrite("medusa_tree_ids", &tr::decoder_batch::Request::medusaTreeIds)
         .def_readwrite("lookahead_runtime_config", &tr::decoder_batch::Request::lookaheadRuntimeConfig);
-    py::bind_vector<std::vector<tr::decoder_batch::Request>>(m, "VectorRequest");
 
     py::class_<tr::decoder_batch::Input>(m, "DecoderBatchInput")
         .def(py::init<std::vector<std::vector<tr::ITensor::SharedConstPtr>>, tr::SizeType32>(), py::arg("logits"),
@@ -431,4 +413,25 @@ void initBindings(pybind11::module_& m)
     initMoeBindings(m);
 }
 
+void initBindingsEarly(py::module_& m)
+{
+    py::class_<tr::SpeculativeDecodingMode>(m, "SpeculativeDecodingMode")
+        .def(py::init<tr::SpeculativeDecodingMode::UnderlyingType>(), py::arg("state"))
+        .def_static("NoneType", &tr::SpeculativeDecodingMode::None)
+        .def_static("DraftTokensExternal", &tr::SpeculativeDecodingMode::DraftTokensExternal)
+        .def_static("Medusa", &tr::SpeculativeDecodingMode::Medusa)
+        .def_static("Eagle", &tr::SpeculativeDecodingMode::Eagle)
+        .def_static("LookaheadDecoding", &tr::SpeculativeDecodingMode::LookaheadDecoding)
+        .def_static("ExplicitDraftTokens", &tr::SpeculativeDecodingMode::ExplicitDraftTokens)
+        .def_property_readonly("is_none", &tr::SpeculativeDecodingMode::isNone)
+        .def_property_readonly("is_draft_tokens_external", &tr::SpeculativeDecodingMode::isDraftTokensExternal)
+        .def_property_readonly("is_medusa", &tr::SpeculativeDecodingMode::isMedusa)
+        .def_property_readonly("is_eagle", &tr::SpeculativeDecodingMode::isEagle)
+        .def_property_readonly("is_lookahead_decoding", &tr::SpeculativeDecodingMode::isLookaheadDecoding)
+        .def_property_readonly("is_explicit_draft_tokens", &tr::SpeculativeDecodingMode::isExplicitDraftTokens)
+        .def_property_readonly("needs_kv_cache_rewind", &tr::SpeculativeDecodingMode::needsKVCacheRewind)
+        .def_property_readonly("needs_decoder_prologue", &tr::SpeculativeDecodingMode::needsDecoderPrologue)
+        .def_property_readonly("predicts_draft_tokens", &tr::SpeculativeDecodingMode::predictsDraftTokens)
+        .def_property_readonly("needs_kv_cache_rewind", &tr::SpeculativeDecodingMode::needsKVCacheRewind);
+}
 } // namespace tensorrt_llm::pybind::runtime

--- a/cpp/tensorrt_llm/pybind/runtime/bindings.h
+++ b/cpp/tensorrt_llm/pybind/runtime/bindings.h
@@ -26,5 +26,6 @@ namespace tensorrt_llm::pybind::runtime
 {
 
 void initBindings(py::module_& m);
+void initBindingsEarly(py::module_& m);
 
 } // namespace tensorrt_llm::pybind::runtime

--- a/examples/pytorch/quickstart_advanced.py
+++ b/examples/pytorch/quickstart_advanced.py
@@ -7,9 +7,9 @@ from tensorrt_llm.llmapi import (EagleDecodingConfig, KvCacheConfig,
 
 example_prompts = [
     "Hello, my name is",
-    # "The president of the United States is",
-    # "The capital of France is",
-    # "The future of AI is",
+    "The president of the United States is",
+    "The capital of France is",
+    "The future of AI is",
 ]
 
 
@@ -182,7 +182,6 @@ def setup_llm(args):
         temperature=args.temperature,
         top_k=args.top_k,
         top_p=args.top_p,
-        return_context_logits=True,
     )
     return llm, sampling_params
 
@@ -197,9 +196,7 @@ def main():
     for i, output in enumerate(outputs):
         prompt = output.prompt
         generated_text = output.outputs[0].text
-        context_logits = output.context_logits
         print(f"[{i}] Prompt: {prompt!r}, Generated text: {generated_text!r}")
-        print(f"[{i}] Context logits: {context_logits!r}")
 
 
 if __name__ == '__main__':

--- a/examples/pytorch/quickstart_advanced.py
+++ b/examples/pytorch/quickstart_advanced.py
@@ -7,9 +7,9 @@ from tensorrt_llm.llmapi import (EagleDecodingConfig, KvCacheConfig,
 
 example_prompts = [
     "Hello, my name is",
-    "The president of the United States is",
-    "The capital of France is",
-    "The future of AI is",
+    # "The president of the United States is",
+    # "The capital of France is",
+    # "The future of AI is",
 ]
 
 
@@ -182,6 +182,7 @@ def setup_llm(args):
         temperature=args.temperature,
         top_k=args.top_k,
         top_p=args.top_p,
+        return_context_logits=True,
     )
     return llm, sampling_params
 
@@ -196,7 +197,9 @@ def main():
     for i, output in enumerate(outputs):
         prompt = output.prompt
         generated_text = output.outputs[0].text
+        context_logits = output.context_logits
         print(f"[{i}] Prompt: {prompt!r}, Generated text: {generated_text!r}")
+        print(f"[{i}] Context logits: {context_logits!r}")
 
 
 if __name__ == '__main__':

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -222,6 +222,7 @@ class ADEngine(ModelEngine):
         scheduled_requests: ScheduledRequests,
         resource_manager: ResourceManager,
         new_tokens_device: Optional[torch.Tensor] = None,
+        gather_context_logits: bool = False,
     ):
         """Run forward from scheduled requests; main entrypoint that gets called by the executor."""
         # convert requests and store in sequence info object

--- a/tensorrt_llm/_torch/pyexecutor/handle_context_logits.py
+++ b/tensorrt_llm/_torch/pyexecutor/handle_context_logits.py
@@ -1,15 +1,15 @@
+from typing import List
+
 import torch
-from typing import List, Optional
 
-from tensorrt_llm.bindings.internal.batch_manager import DecoderBuffers
-from tensorrt_llm.bindings import ModelConfig
 from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest
-
+from tensorrt_llm.bindings.internal.batch_manager import DecoderBuffers
+from tensorrt_llm.logger import logger
 
 # TODO: Implement this once return generation logits is supported
 # def copy_last_context_logits(context_logits: torch.Tensor, llm_req: LlmRequest):
 #     """Copy logits from context phase to beginning of generation logits.
-    
+
 #     Usually, this concerns logits of 1 token. In speculative decoding this concerns draftLen + 1 tokens.
 #     """
 #     num_logits = context_logits.shape[0]
@@ -21,36 +21,39 @@ from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest
 
 class HandleContextLogits:
 
-    def __call__(self,
-                 context_requests: List[LlmRequest],
-                 num_context_logits_vec: List[int],
-                 logits: torch.Tensor,
+    def __call__(self, context_requests: List[LlmRequest],
+                 num_context_logits_vec: List[int], logits: torch.Tensor,
                  decoder_buffers: DecoderBuffers) -> int:
         """Handle context logits for a batch of requests.
-        
+
         Args:
             context_requests: List of context requests to process
             num_context_logits_vec: Number of context logits for each request
             logits: Input logits tensor
             decoder_buffers: Decoder buffers for storing intermediate results
-            
+
         Returns:
             int: Index into logits tensor after processing all requests
         """
         logits_index = 0
-        
+
         # Copy logits into decoderBuffers.logits
         decoder_buffer_logits = [torch.empty(0)] * len(decoder_buffers.logits)
         for batch_index, llm_req in enumerate(context_requests):
             num_context_logits = num_context_logits_vec[batch_index]
-            draft_length = llm_req.num_draft_tokens if llm_req.is_last_context_chunk() else 0
+            draft_length = llm_req.num_draft_tokens if llm_req.is_last_context_chunk(
+            ) else 0
 
             if llm_req.py_return_context_logits:
                 if llm_req.prepopulated_prompt_len > 0:
-                    print(f"Warning: Because of KV cache reuse, not all context logits could be produced for request {llm_req.request_id}.")
+                    logger.warning(
+                        f"Because of KV cache reuse, not all context logits could be produced for request {llm_req.request_id}."
+                    )
 
-                context_logits_device_view = logits[logits_index:logits_index + num_context_logits]
-                llm_req.py_result.append_context_logits(context_logits_device_view)
+                context_logits_device_view = logits[logits_index:logits_index +
+                                                    num_context_logits]
+                llm_req.py_result.append_context_logits(
+                    context_logits_device_view)
 
             logits_index += num_context_logits + draft_length
 
@@ -58,11 +61,12 @@ class HandleContextLogits:
             num_decoder_logits = 1 + draft_length
             seq_slot = llm_req.seq_slot
             logits_view = logits[logits_index - num_decoder_logits:logits_index]
-            logits_view_shape = logits_view.shape
 
-            # Create a view of logits_view with shape (logits_view_shape[0], 1, logits_view_shape[1])
+            # Create a view of logits_view with shape (logits_view.shape[0], 1, logits_view.shape[1])
             # This creates a new tensor that shares the same underlying data
-            decoder_buffer_logits[seq_slot] = logits_view[:logits_view_shape[0], :1, :logits_view_shape[1]]
+            decoder_buffer_logits[
+                seq_slot] = logits_view[:logits_view.shape[0], :1, :logits_view.
+                                        shape[1]]
 
             # TODO: Implement this once return generation logits is supported
             # # Save the last token logits of context into generation logits or
@@ -81,8 +85,8 @@ class HandleContextLogits:
             #     # tensorrt_llm.runtime.kernels.tile_tensor(decoder_logits, logits_view, req_beam_width, stream)
             #     decoder_logits = decoder_logits.unsqueeze(0)
             # else:
-            #     decoder_buffer_logits[seq_slot] = logits_view[:logits_view_shape[0], :1, :logits_view_shape[1]]
-        
+            #     decoder_buffer_logits[seq_slot] = logits_view[:logits_view.shape[0], :1, :logits_view.shape[1]]
+
         # Needs to be done in bulk for the copy to work
         decoder_buffers.logits = decoder_buffer_logits
 

--- a/tensorrt_llm/_torch/pyexecutor/handle_context_logits.py
+++ b/tensorrt_llm/_torch/pyexecutor/handle_context_logits.py
@@ -64,9 +64,8 @@ class HandleContextLogits:
 
             # Create a view of logits_view with shape (logits_view.shape[0], 1, logits_view.shape[1])
             # This creates a new tensor that shares the same underlying data
-            decoder_buffer_logits[
-                seq_slot] = logits_view[:logits_view.shape[0], :1, :logits_view.
-                                        shape[1]]
+            decoder_buffer_logits[seq_slot] = logits_view.reshape(
+                logits_view.shape[0], 1, logits_view.shape[1])
 
             # TODO: Implement this once return generation logits is supported
             # # Save the last token logits of context into generation logits or

--- a/tensorrt_llm/_torch/pyexecutor/handle_context_logits.py
+++ b/tensorrt_llm/_torch/pyexecutor/handle_context_logits.py
@@ -45,14 +45,9 @@ class HandleContextLogits:
             num_context_logits = num_context_logits_vec[batch_index]
             draft_length = llm_req.num_draft_tokens if llm_req.is_last_context_chunk() else 0
 
-            print("Is last context chunk: ", llm_req.is_last_context_chunk(), "py_return_context_logits: ", llm_req.py_return_context_logits)
-
             if llm_req.py_return_context_logits:
-                print("py_return_context_logits: ", llm_req.py_return_context_logits)
                 if llm_req.prepopulated_prompt_len > 0:
                     print(f"Warning: Because of KV cache reuse, not all context logits could be produced for request {llm_req.request_id}.")
-                
-                print("logits shape: ", logits.shape)
 
                 context_logits_device_view = logits[logits_index:logits_index + num_context_logits]
                 llm_req.py_result.append_context_logits(context_logits_device_view)

--- a/tensorrt_llm/_torch/pyexecutor/handle_context_logits.py
+++ b/tensorrt_llm/_torch/pyexecutor/handle_context_logits.py
@@ -1,0 +1,94 @@
+import torch
+from typing import List, Optional
+
+from tensorrt_llm.bindings.internal.batch_manager import DecoderBuffers
+from tensorrt_llm.bindings import ModelConfig
+from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest
+
+
+# TODO: Implement this once return generation logits is supported
+# def copy_last_context_logits(context_logits: torch.Tensor, llm_req: LlmRequest):
+#     """Copy logits from context phase to beginning of generation logits.
+    
+#     Usually, this concerns logits of 1 token. In speculative decoding this concerns draftLen + 1 tokens.
+#     """
+#     num_logits = context_logits.shape[0]
+#     for beam in range(llm_req.get_beam_width_by_iter()):
+#         # [beamWidth, mMaxNewTokens, vocabSizePadded] -> [numLogits, vocabSizePadded]
+#         beam_host_tensor = llm_req.get_generation_logits_host()[beam, :num_logits]
+#         beam_host_tensor.copy_(context_logits, non_blocking=True)
+
+
+class HandleContextLogits:
+
+    def __call__(self,
+                 context_requests: List[LlmRequest],
+                 num_context_logits_vec: List[int],
+                 logits: torch.Tensor,
+                 decoder_buffers: DecoderBuffers) -> int:
+        """Handle context logits for a batch of requests.
+        
+        Args:
+            context_requests: List of context requests to process
+            num_context_logits_vec: Number of context logits for each request
+            logits: Input logits tensor
+            decoder_buffers: Decoder buffers for storing intermediate results
+            
+        Returns:
+            int: Index into logits tensor after processing all requests
+        """
+        logits_index = 0
+        
+        # Copy logits into decoderBuffers.logits
+        decoder_buffer_logits = [torch.empty(0)] * len(decoder_buffers.logits)
+        for batch_index, llm_req in enumerate(context_requests):
+            num_context_logits = num_context_logits_vec[batch_index]
+            draft_length = llm_req.num_draft_tokens if llm_req.is_last_context_chunk() else 0
+
+            print("Is last context chunk: ", llm_req.is_last_context_chunk(), "py_return_context_logits: ", llm_req.py_return_context_logits)
+
+            if llm_req.py_return_context_logits:
+                print("py_return_context_logits: ", llm_req.py_return_context_logits)
+                if llm_req.prepopulated_prompt_len > 0:
+                    print(f"Warning: Because of KV cache reuse, not all context logits could be produced for request {llm_req.request_id}.")
+                
+                print("logits shape: ", logits.shape)
+
+                context_logits_device_view = logits[logits_index:logits_index + num_context_logits]
+                llm_req.py_result.append_context_logits(context_logits_device_view)
+
+            logits_index += num_context_logits + draft_length
+
+            # Get the logits from the last context token and draft tokens
+            num_decoder_logits = 1 + draft_length
+            seq_slot = llm_req.seq_slot
+            logits_view = logits[logits_index - num_decoder_logits:logits_index]
+            logits_view_shape = logits_view.shape
+
+            # Create a view of logits_view with shape (logits_view_shape[0], 1, logits_view_shape[1])
+            # This creates a new tensor that shares the same underlying data
+            decoder_buffer_logits[seq_slot] = logits_view[:logits_view_shape[0], :1, :logits_view_shape[1]]
+
+            # TODO: Implement this once return generation logits is supported
+            # # Save the last token logits of context into generation logits or
+            # # save the accepted token logits from target model
+            # if llm_req.get_return_generation_logits():
+            #     copy_last_context_logits(logits_view, llm_req)
+
+            # TODO: Implement this once we have beam width support
+            # Scatter the output logits to the decoderLogits
+            # req_beam_width = llm_req.get_beam_width_by_iter()
+            # if req_beam_width > 1:
+            #     # Tile logits of context requests
+            #     logits_shape = logits_view.shape
+            #     logits_type = logits_view.dtype
+            #     # decoder_logits = buffer_manager.gpu((req_beam_width, logits_shape[1]), logits_type)
+            #     # tensorrt_llm.runtime.kernels.tile_tensor(decoder_logits, logits_view, req_beam_width, stream)
+            #     decoder_logits = decoder_logits.unsqueeze(0)
+            # else:
+            #     decoder_buffer_logits[seq_slot] = logits_view[:logits_view_shape[0], :1, :logits_view_shape[1]]
+        
+        # Needs to be done in bulk for the copy to work
+        decoder_buffers.logits = decoder_buffer_logits
+
+        return logits_index

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1062,11 +1062,11 @@ class PyTorchModelEngine(ModelEngine):
             prompt_lengths.append(len(prompt_tokens))
             past_seen_token_num = request.context_current_position
             num_cached_tokens_per_seq.append(past_seen_token_num)
-            multimodal_embedding = request.multimodal_embedding()
+            multimodal_embedding = request.multimodal_embedding
             if multimodal_embedding is not None:
                 multi_modal_data.append(multimodal_embedding)
 
-            mrope_rotary_cos_sin = request.get_mrope_rotary_cos_sin()
+            mrope_rotary_cos_sin = request.mrope_rotary_cos_sin
             if mrope_rotary_cos_sin is not None:
                 mrope_config['mrope_rotary_cos_sin'].append(
                     mrope_rotary_cos_sin)
@@ -1380,7 +1380,7 @@ class PyTorchModelEngine(ModelEngine):
             gather_ids.append(len(input_ids) - 1)
             sequence_lengths.append(len(prompt_tokens))
             draft_lens.append(0)
-            multimodal_embedding = request.multimodal_embedding()
+            multimodal_embedding = request.multimodal_embedding
             if multimodal_embedding is not None:
                 multi_modal_data.append(multimodal_embedding)
 

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -66,10 +66,12 @@ class ModelEngine(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def forward(self, scheduled_requests: ScheduledRequests,
+    def forward(self,
+                scheduled_requests: ScheduledRequests,
                 resource_manager: ResourceManager,
                 new_tensors_device: Optional[SampleStateTensors],
-                extra_model_inputs: Optional[Dict[str, Any]]):
+                extra_model_inputs: Optional[Dict[str, Any]],
+                gather_context_logits: bool = False):
         raise NotImplementedError
 
     def warmup(self, resource_manager: ResourceManager) -> None:
@@ -1844,7 +1846,8 @@ class PyTorchModelEngine(ModelEngine):
                 scheduled_requests: ScheduledRequests,
                 resource_manager: ResourceManager,
                 new_tensors_device: Optional[SampleStateTensors] = None,
-                extra_model_inputs: Optional[Dict[str, Any]] = None):
+                extra_model_inputs: Optional[Dict[str, Any]] = None,
+                gather_context_logits: bool = False):
 
         kv_cache_manager = resource_manager.get_resource_manager(
             self.kv_cache_manager_key)
@@ -1866,7 +1869,7 @@ class PyTorchModelEngine(ModelEngine):
                 inputs.update(extra_model_inputs)
             self.last_spec_metadata = spec_metadata
 
-            return self._forward_step(inputs, gather_ids)
+            return self._forward_step(inputs, gather_ids, gather_context_logits)
 
         with self._maybe_pad_batch(scheduled_requests,
                                    kv_cache_manager) as scheduled_requests:
@@ -1893,12 +1896,15 @@ class PyTorchModelEngine(ModelEngine):
             self.iter_counter += 1
 
             if maybe_graph is None:
-                outputs = self._forward_step(inputs, gather_ids)
+                outputs = self._forward_step(inputs, gather_ids,
+                                             gather_context_logits)
             else:
                 if maybe_graph.needs_capture():
                     pool = maybe_graph.capture(
                         lambda inputs: self._forward_step(
-                            inputs, gather_ids=gather_ids),
+                            inputs,
+                            gather_ids=gather_ids,
+                            gather_context_logits=gather_context_logits),
                         self._cuda_graph_mem_pool,
                         extra_model_inputs,
                     )
@@ -1934,8 +1940,10 @@ class PyTorchModelEngine(ModelEngine):
             return self.model.forward(**kwargs)
 
     @nvtx_range("_forward_step")
-    def _forward_step(self, inputs: Dict[str, Any],
-                      gather_ids: Optional[torch.Tensor]) -> Dict[str, Any]:
+    def _forward_step(self,
+                      inputs: Dict[str, Any],
+                      gather_ids: Optional[torch.Tensor],
+                      gather_context_logits: bool = False) -> Dict[str, Any]:
         inputs = self._preprocess_inputs(inputs)
         if self.without_logits:
             outputs = self.model_forward(**inputs)
@@ -1945,7 +1953,8 @@ class PyTorchModelEngine(ModelEngine):
         # from speculative decoding.
         logits = self.model_forward(
             **inputs,
-            return_context_logits=gather_ids is not None,
+            return_context_logits=gather_ids is not None
+            or gather_context_logits,
         )
         if gather_ids is not None:
             return {'logits': logits[gather_ids]}

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1588,14 +1588,20 @@ class PyExecutor:
         @nvtx_range(
             f"[Executor] _forward_step: {len(scheduled_requests.context_requests)} ctx reqs, {len(scheduled_requests.generation_requests)} gen reqs"
         )
-        def forward(scheduled_requests, resource_manager, new_tensors_device):
-            return self.model_engine.forward(scheduled_requests,
-                                             resource_manager,
-                                             new_tensors_device)
+        def forward(scheduled_requests, resource_manager, new_tensors_device,
+                    gather_context_logits):
+            return self.model_engine.forward(
+                scheduled_requests,
+                resource_manager,
+                new_tensors_device,
+                gather_context_logits=gather_context_logits)
 
         try:
+            gather_context_logits = any(
+                a.py_return_context_logits
+                for a in scheduled_requests.context_requests)
             outputs = forward(scheduled_requests, self.resource_manager,
-                              new_tensors_device)
+                              new_tensors_device, gather_context_logits)
             return outputs
         except Exception as e:
             traceback.print_exc()

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -595,14 +595,17 @@ class TRTLLMSampler(Sampler):
         batch_size = scheduled_requests.batch_size
         beam_width = self.beam_width(scheduled_requests.all_requests)
 
-        logits = model_outputs["logits"].reshape((batch_size, beam_width, -1))
+        # TODO: Remove this unsqueezing once we get beam width support.
+        logits = model_outputs["logits"].unsqueeze(1)
 
         self.setup_sampler_step(scheduled_requests.context_requests)
 
-        # Note: In runtimeBuffers.cpp, num_context_logits is set to:
-        #       numContextLogits.at(batchIdx) = modelConfig.computeContextLogits() ? contextChunkSize : 1;
-        # Revisit this when we support chunked context.
         num_context_logits = [1] * batch_size
+        for batch_index, request in enumerate(
+                scheduled_requests.context_requests):
+            num_context_logits[
+                batch_index] = request.context_chunk_size if request.py_return_context_logits else 1
+
         logits_index = self.algs.handle_context_logits(
             scheduled_requests.context_requests, num_context_logits, logits,
             self.store["decoder_buffers"])

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -603,9 +603,9 @@ class TRTLLMSampler(Sampler):
         #       numContextLogits.at(batchIdx) = modelConfig.computeContextLogits() ? contextChunkSize : 1;
         # Revisit this when we support chunked context.
         num_context_logits = [1] * batch_size
-        logits_index = self.algs.handle_context_logits(scheduled_requests.context_requests,
-                                           num_context_logits, logits,
-                                           self.store["decoder_buffers"])
+        logits_index = self.algs.handle_context_logits(
+            scheduled_requests.context_requests, num_context_logits, logits,
+            self.store["decoder_buffers"])
 
         self.algs.handle_generation_logits(
             logits_index, scheduled_requests.generation_requests,

--- a/tests/unittest/bindings/test_bindings_ut.py
+++ b/tests/unittest/bindings/test_bindings_ut.py
@@ -338,12 +338,12 @@ def test_llm_request():
     assert llm_request.pad_id == 99
     assert llm_request.end_id == 100
     assert llm_request.seq_slot is None
-    assert torch.equal(llm_request.prompt_embedding_table(),
+    assert torch.equal(llm_request.prompt_embedding_table,
                        kwargs["prompt_embedding_table"])
     assert llm_request.prompt_vocab_size == 2
-    assert torch.equal(llm_request.embedding_bias(), kwargs["embedding_bias"])
-    assert torch.equal(llm_request.stop_words_list(), kwargs["stop_words_list"])
-    assert torch.equal(llm_request.bad_words_list(), kwargs["bad_words_list"])
+    assert torch.equal(llm_request.embedding_bias, kwargs["embedding_bias"])
+    assert torch.equal(llm_request.stop_words_list, kwargs["stop_words_list"])
+    assert torch.equal(llm_request.bad_words_list, kwargs["bad_words_list"])
 
     assert llm_request.get_num_tokens(0) == 3
     assert llm_request.max_beam_num_tokens == 3


### PR DESCRIPTION
# [TRTLLM-4987] Support context logits in TRTLLMSampler

## Description

This PR adds context logits support in TRTLLMSampler:

* An algorithm `handle_context_logits` is created in Python that mimics the C++ couterpart.
* Python bindings custom caster support for all TensorPtr and TensorConstPtr.
* Removed `std::vector` opaque bindings, as no reference parameters are required.
* Adjusted `test_return_logits` to also cover what is supported in TRTLLMSampler currently.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
