### PR TITLE
fix: build_config in TorchLlmArgs and avoid invalid args

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -336,7 +336,7 @@ def create_py_executor_instance(
                 "Guided decoding is not supported with overlap scheduler.")
 
     logger.info(
-        f"max_seq_len={executor_config.max_seq_len}, max_num_requests={executor_config.max_batch_size}, max_num_tokens={executor_config.max_num_tokens}"
+        f"max_seq_len={executor_config.max_seq_len}, max_num_requests={executor_config.max_batch_size}, max_num_tokens={executor_config.max_num_tokens}, max_batch_size={executor_config.max_batch_size}"
     )
 
     for key, value in pytorch_backend_config.extra_resource_managers.items():

--- a/tensorrt_llm/bench/benchmark/throughput.py
+++ b/tensorrt_llm/bench/benchmark/throughput.py
@@ -360,6 +360,10 @@ def throughput_command(
             kwargs["enable_iter_perf_stats"] = True
 
         if runtime_config.backend == 'pytorch':
+            if kwargs.pop("extended_runtime_perf_knob_config", None):
+                logger.warning(
+                    "Ignore extended_runtime_perf_knob_config for pytorch backend."
+                )
             llm = PyTorchLLM(**kwargs)
         else:
             llm = LLM(**kwargs)

--- a/tensorrt_llm/builder.py
+++ b/tensorrt_llm/builder.py
@@ -49,6 +49,9 @@ class ConfigEncoder(json.JSONEncoder):
         if isinstance(obj, KVCacheType):
             # For KVCacheType, convert it to string by split of 'KVCacheType.PAGED'.
             return obj.__str__().split('.')[-1]
+        elif hasattr(obj, 'model_dump'):
+            # Handle Pydantic models (including DecodingBaseConfig and subclasses)
+            return obj.model_dump(mode='json')
         else:
             return super().default(obj)
 

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -119,9 +119,9 @@ def get_llm_args(model: str,
         "max_seq_len": max_seq_len,
         "kv_cache_config": kv_cache_config,
         "backend": backend if backend == "pytorch" else None,
-        "_num_postprocess_workers": num_postprocess_workers,
-        "_postprocess_tokenizer_dir": tokenizer or model,
-        "_reasoning_parser": reasoning_parser,
+        "num_postprocess_workers": num_postprocess_workers,
+        "postprocess_tokenizer_dir": tokenizer or model,
+        "reasoning_parser": reasoning_parser,
     }
 
     return llm_args, llm_args_extra_dict

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -370,6 +370,8 @@ def disaggregated_mpi_worker(config_file: Optional[str], log_level: str):
         llm_args = update_llm_args_with_extra_dict(llm_args,
                                                    llm_args_extra_dict)
 
+        # Ignore the non-LLM args
+        llm_args.pop("router", None)
         _launch_disaggregated_server(config_file, llm_args)
         return
 

--- a/tensorrt_llm/executor/serialization.py
+++ b/tensorrt_llm/executor/serialization.py
@@ -10,7 +10,7 @@ import pickle  # nosec B403
 BASE_ZMQ_CLASSES = {
     "builtins": [
         "Exception", "ValueError", "NotImplementedError", "AttributeError",
-        "AssertionError"
+        "AssertionError", "RuntimeError"
     ],  # each Exception Error class needs to be added explicitly
     "collections": ["OrderedDict"],
     "datetime": ["timedelta"],

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -115,6 +115,11 @@ class LLM:
             llm_args_cls = TorchLlmArgs if kwargs.get(
                 'backend', None) == 'pytorch' else TrtLlmArgs
 
+            # check the kwargs and raise ValueError directly
+            for key in kwargs:
+                if key not in llm_args_cls.model_fields:
+                    raise ValueError(f"Invalid argument: {key}")
+
             self.args = llm_args_cls.from_kwargs(
                 model=model,
                 tokenizer=tokenizer,
@@ -567,7 +572,7 @@ class LLM:
         max_num_tokens = max_num_tokens or build_config.max_num_tokens
         max_seq_len = max_seq_len or build_config.max_seq_len
 
-        executor_config = tllm.ExecutorConfig(
+        self._executor_config = tllm.ExecutorConfig(
             max_beam_width=self.args.max_beam_width,
             scheduler_config=PybindMirror.maybe_to_pybind(
                 self.args.scheduler_config),
@@ -579,20 +584,20 @@ class LLM:
         if self.args.backend is None:
             # also set executor_config.max_seq_len in TRT workflow, to deduce default max_tokens
             if max_seq_len is not None:
-                executor_config.max_seq_len = max_seq_len
+                self._executor_config.max_seq_len = max_seq_len
             else:
                 engine_config = EngineConfig.from_json_file(self._engine_dir /
                                                             "config.json")
-                executor_config.max_seq_len = engine_config.build_config.max_seq_len
+                self._executor_config.max_seq_len = engine_config.build_config.max_seq_len
         if self.args.kv_cache_config is not None:
-            executor_config.kv_cache_config = PybindMirror.maybe_to_pybind(
+            self._executor_config.kv_cache_config = PybindMirror.maybe_to_pybind(
                 self.args.kv_cache_config)
         if os.getenv("FORCE_DETERMINISTIC", "0") == "1":
             # Disable KV cache reuse for deterministic mode
-            executor_config.kv_cache_config.enable_block_reuse = False
-            executor_config.kv_cache_config.enable_partial_reuse = False
+            self._executor_config.kv_cache_config.enable_block_reuse = False
+            self._executor_config.kv_cache_config.enable_partial_reuse = False
         if self.args.peft_cache_config is not None:
-            executor_config.peft_cache_config = PybindMirror.maybe_to_pybind(
+            self._executor_config.peft_cache_config = PybindMirror.maybe_to_pybind(
                 self.args.peft_cache_config)
         elif self._on_trt_backend and self.args.build_config.plugin_config.lora_plugin:
             engine_config = EngineConfig.from_json_file(self._engine_dir /
@@ -601,16 +606,16 @@ class LLM:
             max_lora_rank = lora_config.max_lora_rank
             num_lora_modules = engine_config.pretrained_config.num_hidden_layers * \
                 len(lora_config.lora_target_modules + lora_config.missing_qkv_modules)
-            executor_config.peft_cache_config = tllm.PeftCacheConfig(
+            self._executor_config.peft_cache_config = tllm.PeftCacheConfig(
                 num_device_module_layer=max_lora_rank * num_lora_modules *
                 self.args.max_loras,
                 num_host_module_layer=max_lora_rank * num_lora_modules *
                 self.args.max_cpu_loras,
             )
         if self.args.decoding_config is not None:
-            executor_config.decoding_config = self.args.decoding_config
+            self._executor_config.decoding_config = self.args.decoding_config
         if self.args.guided_decoding_backend == 'xgrammar':
-            executor_config.guided_decoding_config = tllm.GuidedDecodingConfig(
+            self._executor_config.guided_decoding_config = tllm.GuidedDecodingConfig(
                 backend=tllm.GuidedDecodingConfig.GuidedDecodingBackend.
                 XGRAMMAR,
                 **_xgrammar_tokenizer_info(self.tokenizer))
@@ -619,18 +624,18 @@ class LLM:
                 f"Unrecognized guided decoding backend {self.args.guided_decoding_backend}"
             )
 
-        executor_config.normalize_log_probs = self.args.normalize_log_probs
-        executor_config.enable_chunked_context = self.args.enable_chunked_prefill
-        executor_config.max_beam_width = self.args.max_beam_width or self.args.build_config.max_beam_width
+        self._executor_config.normalize_log_probs = self.args.normalize_log_probs
+        self._executor_config.enable_chunked_context = self.args.enable_chunked_prefill
+        self._executor_config.max_beam_width = self.args.max_beam_width or self.args.build_config.max_beam_width
         if self._on_trt_backend and self.args.extended_runtime_perf_knob_config is not None:
-            executor_config.extended_runtime_perf_knob_config = PybindMirror.maybe_to_pybind(
+            self._executor_config.extended_runtime_perf_knob_config = PybindMirror.maybe_to_pybind(
                 self.args.extended_runtime_perf_knob_config)
         if self.args.cache_transceiver_config is not None:
-            executor_config.cache_transceiver_config = PybindMirror.maybe_to_pybind(
+            self._executor_config.cache_transceiver_config = PybindMirror.maybe_to_pybind(
                 self.args.cache_transceiver_config)
         from tensorrt_llm._torch.pyexecutor.config import update_executor_config
         update_executor_config(
-            executor_config,
+            self._executor_config,
             backend=self.args.backend,
             pytorch_backend_config=self.args.get_pytorch_backend_config()
             if self.args.backend == "pytorch" else None,
@@ -642,14 +647,14 @@ class LLM:
             trt_engine_dir=self._engine_dir,
             max_input_len=self.args.max_input_len,
             max_seq_len=max_seq_len)
-        executor_config.llm_parallel_config = self.args.parallel_config
+        self._executor_config.llm_parallel_config = self.args.parallel_config
         return_logits = self.args.gather_generation_logits or (
             self._on_trt_backend and self.args.build_config
             and self.args.build_config.gather_context_logits)
 
         self._executor = self._executor_cls.create(
             self._engine_dir,
-            executor_config=executor_config,
+            executor_config=self._executor_config,
             batched_logits_processor=self.args.batched_logits_processor,
             model_world_size=self.args.parallel_config.world_size,
             mpi_session=self.mpi_session,

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -116,8 +116,11 @@ class LLM:
                 'backend', None) == 'pytorch' else TrtLlmArgs
 
             # check the kwargs and raise ValueError directly
+            valid_keys = set(
+                list(llm_args_cls.model_fields.keys()) +
+                ['_mpi_session', 'backend'])
             for key in kwargs:
-                if key not in llm_args_cls.model_fields:
+                if key not in valid_keys:
                     raise ValueError(
                         f"{self.__class__.__name__} got invalid argument: {key}"
                     )

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -118,7 +118,9 @@ class LLM:
             # check the kwargs and raise ValueError directly
             for key in kwargs:
                 if key not in llm_args_cls.model_fields:
-                    raise ValueError(f"Invalid argument: {key}")
+                    raise ValueError(
+                        f"{self.__class__.__name__} got invalid argument: {key}"
+                    )
 
             self.args = llm_args_cls.from_kwargs(
                 model=model,

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1034,6 +1034,15 @@ class BaseLlmArgs(BaseModel):
             tensorrt_llm.llmapi.llm_utils.BaseLlmArgs: The `BaseLlmArgs` instance.
         """
         kwargs = BaseLlmArgs._maybe_update_config_for_consistency(dict(kwargs))
+        # build_config always prioritize over flattened arguments in kwargs
+        if build_config := kwargs.pop("build_config", None):
+            if kwargs.get("backend") == "pytorch":
+                logger.warning("build_config is deprecated from PyT path.")
+            kwargs["max_batch_size"] = build_config.max_batch_size
+            kwargs["max_num_tokens"] = build_config.max_num_tokens
+            kwargs["max_seq_len"] = build_config.max_seq_len
+            kwargs["max_beam_width"] = build_config.max_beam_width
+
         ret = cls(**kwargs)
         ret._setup()
         return ret

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -939,6 +939,11 @@ class BaseLlmArgs(BaseModel):
         default=None,
         description="The parser to separate reasoning content from output.")
 
+    auto_deploy_config: Optional[object] = Field(
+        default=None,
+        description="Auto deploy config.",
+        json_schema_extra={"type": f"Optional[AutoDeployConfig]"})
+
     # TODO[Superjomn]: To deprecate this config.
     decoding_config: Optional[object] = Field(
         default=None,
@@ -1642,12 +1647,6 @@ class TorchLlmArgs(BaseLlmArgs):
 
     enable_layerwise_nvtx_marker: bool = Field(
         default=False, description="If true, enable layerwise nvtx marker.")
-
-    auto_deploy_config: Optional[object] = Field(
-        default=None,
-        description="Auto deploy config.",
-        exclude_from_json=True,
-        json_schema_extra={"type": f"Optional[AutoDeployConfig]"})
 
     load_format: Union[str, LoadFormat] = Field(
         default=LoadFormat.AUTO,

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -753,7 +753,7 @@ class BaseLlmArgs(BaseModel):
     """
     model_config = {
         "arbitrary_types_allowed": True,
-        "extra": "allow",
+        "extra": "forbid",
     }
 
     # Explicit arguments
@@ -931,18 +931,17 @@ class BaseLlmArgs(BaseModel):
     # private fields those are unstable and just for internal use
     num_postprocess_workers: int = Field(
         default=0,
-        description="The number of postprocess worker processes.",
-        alias="_num_postprocess_workers")
+        description=
+        "The number of processes for generated token postprocessing, such as detokenization and so on."
+    )
 
     postprocess_tokenizer_dir: Optional[str] = Field(
         default=None,
-        description="The postprocess tokenizer directory.",
-        alias="_postprocess_tokenizer_dir")
+        description="The path to the tokenizer directory for postprocessing.")
 
     reasoning_parser: Optional[str] = Field(
         default=None,
-        description="The parser to separate reasoning content from output.",
-        alias="_reasoning_parser")
+        description="The parser to separate reasoning content from output.")
 
     # TODO[Superjomn]: To deprecate this config.
     decoding_config: Optional[object] = Field(
@@ -958,6 +957,28 @@ class BaseLlmArgs(BaseModel):
         json_schema_extra={"type": "Optional[MpiSession]"},
         exclude=True,  # exclude from serialization
         alias="_mpi_session")
+
+    _parallel_config: Optional[object] = PrivateAttr(default=None)
+    _model_format: Optional[_ModelFormatKind] = PrivateAttr(default=None)
+    _speculative_model: Optional[str] = PrivateAttr(default=None)
+    _speculative_model_format: Optional[_ModelFormatKind] = PrivateAttr(
+        default=None)
+
+    @property
+    def parallel_config(self) -> _ParallelConfig:
+        return self._parallel_config
+
+    @property
+    def model_format(self) -> _ModelFormatKind:
+        return self._model_format
+
+    @property
+    def speculative_model(self) -> Optional[_ModelFormatKind]:
+        return self._speculative_model
+
+    @property
+    def speculative_model_format(self) -> _ModelFormatKind:
+        return self._speculative_model_format
 
     @print_traceback_on_error
     def model_post_init(self, __context: Any):
@@ -991,7 +1012,7 @@ class BaseLlmArgs(BaseModel):
         if self.moe_expert_parallel_size is None:
             self.moe_expert_parallel_size = -1
 
-        self.parallel_config = _ParallelConfig(
+        self._parallel_config = _ParallelConfig(
             tp_size=self.tensor_parallel_size,
             pp_size=self.pipeline_parallel_size,
             cp_size=self.context_parallel_size,
@@ -1081,18 +1102,18 @@ class BaseLlmArgs(BaseModel):
                     f"Invalid build_cache_config: {self.enable_build_cache}")
         model_obj = _ModelWrapper(self.model)
 
-        self.speculative_model = getattr(self.speculative_config,
-                                         "speculative_model", None)
+        self._speculative_model = getattr(self.speculative_config,
+                                          "speculative_model", None)
         speculative_model_obj = _ModelWrapper(
-            self.speculative_model
-        ) if self.speculative_model is not None else None
+            self._speculative_model
+        ) if self._speculative_model is not None else None
         if model_obj.is_local_model and self.backend not in [
                 'pytorch', 'autodeploy'
         ]:
             # Load parallel_config from the engine.
-            self.model_format = get_model_format(self.model)
+            self._model_format = get_model_format(self.model)
 
-            if self.model_format is _ModelFormatKind.TLLM_ENGINE:
+            if self._model_format is _ModelFormatKind.TLLM_ENGINE:
                 if self.build_config is not None:
                     logger.warning(
                         "The build_config is ignored for model format of TLLM_ENGINE."
@@ -1104,13 +1125,13 @@ class BaseLlmArgs(BaseModel):
                         runtime_defaults)
 
             # Load parallel_config from the checkpoint.
-            elif self.model_format is _ModelFormatKind.TLLM_CKPT:
+            elif self._model_format is _ModelFormatKind.TLLM_CKPT:
                 self._load_config_from_ckpt(model_obj.model_dir)
         else:
-            self.model_format = _ModelFormatKind.HF
+            self._model_format = _ModelFormatKind.HF
 
-        if self.speculative_model and speculative_model_obj.is_local_model:
-            self.speculative_model_format = _ModelFormatKind.HF
+        if self._speculative_model and speculative_model_obj.is_local_model:
+            self._speculative_model_format = _ModelFormatKind.HF
 
         self.quant_config = self.quant_config or QuantConfig()
 
@@ -1278,7 +1299,7 @@ class BaseLlmArgs(BaseModel):
 
     @property
     def _build_config_mutable(self) -> bool:
-        return self.model_format is not _ModelFormatKind.TLLM_ENGINE
+        return self._model_format is not _ModelFormatKind.TLLM_ENGINE
 
     def _update_plugin_config(self, key: str, value: Any):
         setattr(self.build_config.plugin_config, key, value)
@@ -1462,7 +1483,7 @@ class TorchLlmArgs(BaseLlmArgs):
 
     # Just a dummy BuildConfig to allow code reuse with the TrtLlmArgs
     build_config: Optional[object] = Field(
-        default=None,
+        default_factory=lambda: BuildConfig(),
         description="Build config.",
         exclude_from_json=True,
         json_schema_extra={"type": f"Optional[{get_type_repr(BuildConfig)}]"})
@@ -1613,7 +1634,7 @@ class TorchLlmArgs(BaseLlmArgs):
         from .._torch.model_config import MoeLoadBalancerConfig
 
         super().model_post_init(__context)
-        self.model_format = _ModelFormatKind.HF
+        self._model_format = _ModelFormatKind.HF
 
         if isinstance(self.moe_load_balancer, str):
             if not os.path.exists(self.moe_load_balancer):

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1416,8 +1416,10 @@ class TrtLlmArgs(BaseLlmArgs):
 
     # BuildConfig is introduced to give users a familiar interface to configure the model building.
     build_config: Optional[object] = Field(
-        default=None,
+        default_factory=lambda: BuildConfig(),
         description="Build config.",
+        exclude_from_json=True,
+        frozen=True,
         json_schema_extra={"type": f"Optional[{get_type_repr(BuildConfig)}]"})
 
     workspace: Optional[str] = Field(default=None,
@@ -1495,6 +1497,7 @@ class TorchLlmArgs(BaseLlmArgs):
         default_factory=lambda: BuildConfig(),
         description="Build config.",
         exclude_from_json=True,
+        frozen=True,
         json_schema_extra={"type": f"Optional[{get_type_repr(BuildConfig)}]"})
 
     # PyTorch backend specific configurations

--- a/tests/integration/defs/disaggregated/test_disaggregated_single_gpu.py
+++ b/tests/integration/defs/disaggregated/test_disaggregated_single_gpu.py
@@ -50,7 +50,6 @@ async def run_worker(kv_cache_config, pytorch_config, model_name, rank):
 
     try:
         llm = LLM(tensor_parallel_size=1,
-                  auto_parallel=False,
                   model=model_name,
                   enable_chunked_prefill=False,
                   **pytorch_config,

--- a/tests/unittest/api_stability/references/llm.yaml
+++ b/tests/unittest/api_stability/references/llm.yaml
@@ -81,6 +81,18 @@ methods:
       max_cpu_loras:
         annotation: int
         default: 4
+      # postproc worker
+      num_postprocess_workers:
+        annotation: int
+        default: 0
+      postprocess_tokenizer_dir:
+        annotation: Optional[str]
+        default: null
+      # reasoning
+      reasoning_parser:
+        annotation: Optional[str]
+        default: null
+      # kwargs
       kwargs:
         annotation: Any
         default: inspect._empty

--- a/tests/unittest/api_stability/references_committed/llm.yaml
+++ b/tests/unittest/api_stability/references_committed/llm.yaml
@@ -81,14 +81,14 @@ methods:
         annotation: Optional[int]
         default: null
       max_input_len:
-        annotation: int
-        default: 1024
+        annotation: Optional[int]
+        default: null
       max_seq_len:
         annotation: Optional[int]
         default: null
       max_beam_width:
-        annotation: int
-        default: 1
+        annotation: Optional[int]
+        default: null
       max_num_tokens:
         annotation: Optional[int]
         default: null

--- a/tests/unittest/llmapi/run_llm_with_postproc.py
+++ b/tests/unittest/llmapi/run_llm_with_postproc.py
@@ -78,8 +78,8 @@ def main(model_dir: str, tp_size: int, engine_dir: Optional[str], n: int,
 
     # Simplified postprocessing configuration
     postproc_config = {
-        "_num_postprocess_workers": tp_size,
-        "_postprocess_tokenizer_dir": model_dir,
+        "num_postprocess_workers": tp_size,
+        "postprocess_tokenizer_dir": model_dir,
     }
 
     print_colored("Enabled OAI postprocessing\n", "yellow")

--- a/tests/unittest/llmapi/test_llm.py
+++ b/tests/unittest/llmapi/test_llm.py
@@ -1963,11 +1963,11 @@ def llm_get_stats_async_test_harness(tp_size: int = 1,
         LLM_CLASS = LLM_torch
     else:
         LLM_CLASS = LLM
+        llm_args_extra["fast_build"] = True
 
     llm = LLM_CLASS(model=llama_model_path,
                     kv_cache_config=global_kvcache_config,
                     tensor_parallel_size=tp_size,
-                    fast_build=True,
                     **llm_args_extra)
 
     max_tokens = 6
@@ -2129,13 +2129,16 @@ def run_llm_with_postprocess_parallel_and_result_handler(
     post_proc_params = PostprocParams(
         post_processor=perform_faked_oai_postprocess,
         postproc_args=post_proc_args)
+    kwargs = {}
+    if backend != "pytorch":
+        kwargs["fast_build"] = True
     llm = LLM(model=llama_model_path,
               backend=backend,
               kv_cache_config=global_kvcache_config,
               tensor_parallel_size=tp_size,
               num_postprocess_workers=2,
               postprocess_tokenizer_dir=llama_model_path,
-              fast_build=True)
+              **kwargs)
     golden_result = "DEFGHI"
     for i, output in enumerate(
             llm.generate_async(prompts[0],

--- a/tests/unittest/llmapi/test_llm.py
+++ b/tests/unittest/llmapi/test_llm.py
@@ -2099,8 +2099,8 @@ def test_llm_dynamic_batch_config():
 def run_llm_with_postprocess_parallel(tp_size: int = 1):
     sampling_params = SamplingParams(max_tokens=6)
 
-    postproc_settings = dict(_num_postprocess_workers=2,
-                             _postprocess_tokenizer_dir=llama_model_path)
+    postproc_settings = dict(num_postprocess_workers=2,
+                             postprocess_tokenizer_dir=llama_model_path)
 
     llm_test_harness(llama_model_path,
                      prompts, ["D E F G H I J K"],
@@ -2131,8 +2131,8 @@ def run_llm_with_postprocess_parallel_and_result_handler(
               backend=backend,
               kv_cache_config=global_kvcache_config,
               tensor_parallel_size=tp_size,
-              _num_postprocess_workers=2,
-              _postprocess_tokenizer_dir=llama_model_path,
+              num_postprocess_workers=2,
+              postprocess_tokenizer_dir=llama_model_path,
               fast_build=True)
     golden_result = "DEFGHI"
     for i, output in enumerate(

--- a/tests/unittest/llmapi/test_llm.py
+++ b/tests/unittest/llmapi/test_llm.py
@@ -1893,10 +1893,12 @@ def llm_get_stats_test_harness(tp_size: int = 1,
     else:
         LLM_CLASS = LLM
 
+    if not pytorch_backend:
+        llm_args_extra["fast_build"] = True
+
     llm = LLM_CLASS(model=llama_model_path,
                     kv_cache_config=global_kvcache_config,
                     tensor_parallel_size=tp_size,
-                    fast_build=True,
                     **llm_args_extra)
 
     max_tokens = 5

--- a/tests/unittest/llmapi/test_llm_pytorch.py
+++ b/tests/unittest/llmapi/test_llm_pytorch.py
@@ -152,10 +152,7 @@ def llama_7b_multi_lora_test_harness(**llm_kwargs) -> None:
     # (2) provide a lora_dir to infer the lora_target_modules.
     lora_config = LoraConfig(lora_target_modules=['attn_q', 'attn_k', 'attn_v'],
                              max_lora_rank=8)
-    llm = LLM(hf_model_dir,
-              fast_build=True,
-              lora_config=lora_config,
-              **llm_kwargs)
+    llm = LLM(hf_model_dir, lora_config=lora_config, **llm_kwargs)
 
     prompts = [
         "美国的首都在哪里? \n答案:",
@@ -297,10 +294,7 @@ def test_codellama_fp8_with_bf16_lora() -> None:
                                  lora_target_modules=target_modules,
                                  max_lora_rank=8)
 
-        llm = LLM(model_dir,
-                  quant_config=quant_config,
-                  fast_build=True,
-                  lora_config=lora_config)
+        llm = LLM(model_dir, quant_config=quant_config, lora_config=lora_config)
 
         prompts = [
             "Write a function that calculates the Fibonacci sequence.",

--- a/tests/unittest/llmapi/test_llm_utils.py
+++ b/tests/unittest/llmapi/test_llm_utils.py
@@ -15,7 +15,6 @@ from tensorrt_llm.llmapi.llm_args import *
 def test_ModelLoader():
     kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.4)
     args = TrtLlmArgs(model=llama_model_path, kv_cache_config=kv_cache_config)
-    args._setup()
 
     # Test with HF model
     temp_dir = tempfile.TemporaryDirectory()
@@ -28,7 +27,7 @@ def test_ModelLoader():
 
     # Test with engine
     args.model = build_engine()
-    args._setup()
+    args.model_post_init({})
     assert args.model_format is _ModelFormatKind.TLLM_ENGINE
     print(f'engine_dir: {args.model}')
     model_loader = ModelLoader(args)
@@ -41,7 +40,7 @@ def test_CachedModelLoader():
     args = LlmArgs(model=llama_model_path,
                    kv_cache_config=KvCacheConfig(free_gpu_memory_fraction=0.4))
     args.enable_build_cache = True
-    args._setup()
+    args.model_post_init({})
     stats = LlmBuildStats()
     model_loader = CachedModelLoader(args, llm_build_stats=stats)
     engine_dir, _ = model_loader()


### PR DESCRIPTION
## Description
1. Disallow arbitrary argument in BaseLlmArgs
2. Unify the experimental argument name, remove the unnecessary preceding "_"s
3. Fix the bug of ignoring `build_config` passed to TorchLlmArgs for TorchLlmArgs