### PR TITLE
infra: [TRTLLM-5250] Add sanity check stage for ngc-release images (Build wheels for devel image)

### DIFF
--- a/jenkins/BuildDockerImage.groovy
+++ b/jenkins/BuildDockerImage.groovy
@@ -602,7 +602,7 @@ pipeline {
                         parameters: trtllm_utils.toBuildParameters(parameters),
                         propagate: false,
                     )
-                    status = handle.getBuildResult().toString()
+                    status = handle.result
 
                     if (status != "SUCCESS") {
                         error "Downstream job did not succeed"

--- a/jenkins/BuildDockerImage.groovy
+++ b/jenkins/BuildDockerImage.groovy
@@ -521,7 +521,7 @@ pipeline {
                     collectResultPodSpec = createKubernetesPodConfig("agent")
                     trtllm_utils.launchKubernetesPod(this, collectResultPodSpec, "alpine", {
                         // Install wget
-                        trtllm_utils.llmExecStepWithRetry(this, script: "apk add --no-cache wget")
+                        trtllm_utils.llmExecStepWithRetry(this, script: "apt-get update && apt-get -y install wget")
 
                         // Poll for build artifacts
                         def artifactBaseUrl = "https://urm.nvidia.com/artifactory/${UPLOAD_PATH}/"

--- a/jenkins/BuildDockerImage.groovy
+++ b/jenkins/BuildDockerImage.groovy
@@ -586,7 +586,7 @@ pipeline {
                         'globalVars': globalVarsJson,
                     ]
 
-                    echo "trigger BuildDockerImageSanityTest job, params: ${parameters}"
+                    echo "Trigger BuildDockerImageSanityTest job, params: ${parameters}"
 
                     def status = ""
                     def jobName = "/LLM/helpers/BuildDockerImageSanityTest"
@@ -595,6 +595,7 @@ pipeline {
                         parameters: trtllm_utils.toBuildParameters(parameters),
                         propagate: false,
                     )
+                    echo "Triggered job: ${handle.absoluteUrl}"
                     status = handle.result
 
                     if (status != "SUCCESS") {

--- a/jenkins/BuildDockerImage.groovy
+++ b/jenkins/BuildDockerImage.groovy
@@ -511,7 +511,7 @@ pipeline {
                 }
             }
         }
-        stage("Wait for build jobs finish") {
+        stage("Wait for Build Jobs Complete") {
             when {
                 expression {
                     RUN_SANITY_CHECK
@@ -576,7 +576,7 @@ pipeline {
                 }
             }
         }
-        stage("Sanity Check") {
+        stage("Sanity Check for NGC Images") {
             when {
                 expression {
                     RUN_SANITY_CHECK
@@ -609,7 +609,7 @@ pipeline {
                 }
             }
         }
-        stage("Register Images for Security Checks") {
+        stage("Register NGC Images for Security Checks") {
             when {
                 expression {
                     return params.nspect_id && params.action == "push"

--- a/jenkins/BuildDockerImage.groovy
+++ b/jenkins/BuildDockerImage.groovy
@@ -439,7 +439,7 @@ def getCommonParameters()
     return [
         'gitlabSourceRepoHttpUrl': LLM_REPO,
         'gitlabCommit': env.gitlabCommit,
-        'artifactPath': ARTIFACT_PATH,
+        'artifactPath': env.artifactPath,
         'uploadPath': UPLOAD_PATH,
     ]
 }

--- a/jenkins/BuildDockerImage.groovy
+++ b/jenkins/BuildDockerImage.groovy
@@ -519,7 +519,7 @@ pipeline {
             steps {
                 script {
                     collectResultPodSpec = createKubernetesPodConfig("agent")
-                    trtllm_utils.launchKubernetesPod(this, collectResultPodSpec, "alpine", {
+                    trtllm_utils.launchKubernetesPod(this, collectResultPodSpec, "python3", {
                         // Install wget
                         trtllm_utils.llmExecStepWithRetry(this, script: "apt-get update && apt-get -y install wget")
 

--- a/jenkins/BuildDockerImage.groovy
+++ b/jenkins/BuildDockerImage.groovy
@@ -527,8 +527,6 @@ pipeline {
                         def artifactBaseUrl = "https://urm.nvidia.com/artifactory/${UPLOAD_PATH}/"
                         def requiredFiles = [
                             "TensorRT-LLM-GH200.tar.gz",
-                            "tensorrt-llm-release-src-",
-                            "tensorrt-llm-sbsa-release-src-",
                             "TensorRT-LLM.tar.gz"
                         ]
                         def maxWaitMinutes = 180

--- a/jenkins/L0_MergeRequest.groovy
+++ b/jenkins/L0_MergeRequest.groovy
@@ -1092,6 +1092,7 @@ def launchStages(pipeline, reuseBuild, testFilter, enableFailFast, globalVars)
                         'branch': branch,
                         'action': "push",
                         'triggerType': env.JOB_NAME ==~ /.*PostMerge.*/ ? "post-merge" : "pre-merge",
+                        'runSanityCheck': true,
                     ]
 
                     launchJob("/LLM/helpers/BuildDockerImages", false, enableFailFast, globalVars, "x86_64", additionalParameters)

--- a/jenkins/L0_MergeRequest.groovy
+++ b/jenkins/L0_MergeRequest.groovy
@@ -142,10 +142,13 @@ def GITHUB_PR_API_URL = "github_pr_api_url"
 def CACHED_CHANGED_FILE_LIST = "cached_changed_file_list"
 @Field
 def ACTION_INFO = "action_info"
+@Field
+def IMAGE_KEY_TO_TAG = "image_key_to_tag"
 def globalVars = [
     (GITHUB_PR_API_URL): gitlabParamsFromBot.get('github_pr_api_url', null),
     (CACHED_CHANGED_FILE_LIST): null,
     (ACTION_INFO): gitlabParamsFromBot.get('action_info', null),
+    (IMAGE_KEY_TO_TAG): [:],
 ]
 
 // If not running all test stages in the L0 pre-merge, we will not update the GitLab status at the end.

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -91,6 +91,7 @@ TESTER_MEMORY = "96Gi"
 CCACHE_DIR="/mnt/sw-tensorrt-pvc/scratch.trt_ccache/llm_ccache"
 MODEL_CACHE_DIR="/scratch.trt_llm_data/llm-models"
 
+// ENABLE_NGC_DEVEL_IMAGE_TEST is currently disabled in the Jenkins BuildDockerImageSanityTest job config
 ENABLE_NGC_DEVEL_IMAGE_TEST = params.enableNgcDevelImageTest ?: false
 ENABLE_NGC_RELEASE_IMAGE_TEST = params.enableNgcReleaseImageTest ?: false
 

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -91,8 +91,8 @@ TESTER_MEMORY = "96Gi"
 CCACHE_DIR="/mnt/sw-tensorrt-pvc/scratch.trt_ccache/llm_ccache"
 MODEL_CACHE_DIR="/scratch.trt_llm_data/llm-models"
 
-ENABLE_NGC_DEVEL_IMAGE_TEST = env.enableNgcDevelImageTest ? env.enableNgcDevelImageTest.toBoolean() : false
-ENABLE_NGC_RELEASE_IMAGE_TEST = env.enableNgcReleaseImageTest ? env.enableNgcReleaseImageTest.toBoolean() : false
+ENABLE_NGC_DEVEL_IMAGE_TEST = params.enableNgcDevelImageTest ?: false
+ENABLE_NGC_RELEASE_IMAGE_TEST = params.enableNgcReleaseImageTest ?: false
 
 def uploadResults(def pipeline, SlurmCluster cluster, String nodeName, String stageName){
     withCredentials([usernamePassword(credentialsId: 'svc_tensorrt', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
@@ -2382,15 +2382,15 @@ pipeline {
             when {
                 expression {
                     // Only run the test list validation when necessary
-                    env.targetArch == X86_64_TRIPLE && testFilter[ONLY_DOCS_FILE_CHANGED] == false && !(env.JOB_NAME ==~ /.*Multi-GPU.*/)
+                    env.targetArch == X86_64_TRIPLE &&
+                    testFilter[ONLY_DOCS_FILE_CHANGED] == false &&
+                    !(env.JOB_NAME ==~ /.*Multi-GPU.*/) &&
+                    !(env.JOB_NAME ==~ /.*BuildDockerImageSanityTest.*/)
                 }
             }
             steps
             {
                 script {
-                    if (env.JOB_NAME ==~ /.*BuildDockerImageSanityTest.*/) {
-                        return
-                    }
                     launchTestListCheck(this)
                 }
             }

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -2288,11 +2288,11 @@ def launchTestJobsForImagesSanityCheck(pipeline, globalVars) {
         ],
     ]
     if (!ENABLE_NGC_DEVEL_IMAGE_TEST) {
-        testConfigs -= ["NGC Devel Image amd64", "NGC Devel Image arm64"]
+        testConfigs.removeAll(["NGC Devel Image amd64", "NGC Devel Image arm64"])
         echo "NGC Devel Image test is disabled."
     }
     if (!ENABLE_NGC_RELEASE_IMAGE_TEST) {
-        testConfigs -= ["NGC Release Image amd64", "NGC Release Image arm64"]
+        testConfigs.removeAll(["NGC Release Image amd64", "NGC Release Image arm64"])
         echo "NGC Release Image test is disabled."
     }
     // Update testConfigs image field using the map from globalVars

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -743,17 +743,6 @@ def createKubernetesPodConfig(image, type, arch = "amd64", gpuCount = 1, perfMod
                                 values:
                                 - "core"
                 nodeSelector: ${selectors}
-                initContainers:
-                - name: init-container
-                  image: urm.nvidia.com/docker/alpine:latest
-                  command: ["/bin/sh", "-c"]
-                  args:
-                  - |
-                    echo "Pre-pulling image..."
-                    docker pull ${image} || echo "Pull failed"
-                    echo "Initialization completed"
-                  securityContext:
-                    privileged: true
                 containers:
                   ${containerConfig}
                     env:

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -2326,7 +2326,7 @@ def launchTestJobsForImagesSanityCheck(pipeline, globalVars) {
                 trtllm_utils.launchKubernetesPod(pipeline, imageSanitySpec, "trt-llm", {
                     sh "env | sort"
                     def cpuArch = values.k8sArch == "amd64" ? X86_64_TRIPLE : AARCH64_TRIPLE
-                    runLLMBuildFromPackage(pipeline, cpuArch, false, "imageTest/")
+                    runLLMBuild(pipeline, cpuArch, false, "imageTest/")
                 })
             }
         }

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -492,7 +492,7 @@ String getShortenedJobName(String path)
         "L1_Custom": "l1-cus",
         "L1_Nightly": "l1-nt",
         "L1_Stable": "l1-stb",
-        "BuildDockerImageSanityTest": "l0-sanity",
+        "BuildDockerImageSanityTest": "img-check",
     ]
     def parts = path.split('/')
     // Apply nameMapping to the last part (jobName)
@@ -2273,14 +2273,14 @@ def launchTestJobsForImagesSanityCheck(pipeline, globalVars) {
             config: LINUX_AARCH64_CONFIG,
         ],
         "NGC Release Image amd64": [
-            name: "NGC-Release-Image-amd64-Sanity-Test",
+            name: "NGC-Release-Image-amd64-Sanity-Test-A10",
             gpuType: "a10",
             k8sArch: "amd64",
             wheelInstalled: true,
             config: VANILLA_CONFIG,
         ],
         "NGC Release Image arm64": [
-            name: "NGC-Release-Image-arm64-Sanity-Test",
+            name: "NGC-Release-Image-arm64-Sanity-Test-GH200",
             gpuType: "gh200",
             k8sArch: "arm64",
             wheelInstalled: true,

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -2288,11 +2288,15 @@ def launchTestJobsForImagesSanityCheck(pipeline, globalVars) {
         ],
     ]
     if (!ENABLE_NGC_DEVEL_IMAGE_TEST) {
-        testConfigs.removeAll(["NGC Devel Image amd64", "NGC Devel Image arm64"])
+        ["NGC Devel Image amd64", "NGC Devel Image arm64"].each { key ->
+            testConfigs.remove(key)
+        }
         echo "NGC Devel Image test is disabled."
     }
     if (!ENABLE_NGC_RELEASE_IMAGE_TEST) {
-        testConfigs.removeAll(["NGC Release Image amd64", "NGC Release Image arm64"])
+        ["NGC Release Image amd64", "NGC Release Image arm64"].each { key ->
+            testConfigs.remove(key)
+        }
         echo "NGC Release Image test is disabled."
     }
     // Update testConfigs image field using the map from globalVars

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -91,8 +91,8 @@ TESTER_MEMORY = "96Gi"
 CCACHE_DIR="/mnt/sw-tensorrt-pvc/scratch.trt_ccache/llm_ccache"
 MODEL_CACHE_DIR="/scratch.trt_llm_data/llm-models"
 
-ENABLE_NGC_DEVEL_IMAGE_TEST = env.enableNgcDevelImageTest ? env.enableNgcDevelImageTest : false
-ENABLE_NGC_RELEASE_IMAGE_TEST = env.enableNgcReleaseImageTest ? env.enableNgcReleaseImageTest : false
+ENABLE_NGC_DEVEL_IMAGE_TEST = env.enableNgcDevelImageTest ? env.enableNgcDevelImageTest.toBoolean() : false
+ENABLE_NGC_RELEASE_IMAGE_TEST = env.enableNgcReleaseImageTest ? env.enableNgcReleaseImageTest.toBoolean() : false
 
 def uploadResults(def pipeline, SlurmCluster cluster, String nodeName, String stageName){
     withCredentials([usernamePassword(credentialsId: 'svc_tensorrt', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -91,6 +91,9 @@ TESTER_MEMORY = "96Gi"
 CCACHE_DIR="/mnt/sw-tensorrt-pvc/scratch.trt_ccache/llm_ccache"
 MODEL_CACHE_DIR="/scratch.trt_llm_data/llm-models"
 
+ENABLE_NGC_DEVEL_IMAGE_TEST = env.enableNgcDevelImageTest ? env.enableNgcDevelImageTest : false
+ENABLE_NGC_RELEASE_IMAGE_TEST = env.enableNgcReleaseImageTest ? env.enableNgcReleaseImageTest : false
+
 def uploadResults(def pipeline, SlurmCluster cluster, String nodeName, String stageName){
     withCredentials([usernamePassword(credentialsId: 'svc_tensorrt', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
         def remote = [
@@ -2284,6 +2287,14 @@ def launchTestJobsForImagesSanityCheck(pipeline, globalVars) {
             config: LINUX_AARCH64_CONFIG,
         ],
     ]
+    if (!ENABLE_NGC_DEVEL_IMAGE_TEST) {
+        testConfigs -= ["NGC Devel Image amd64", "NGC Devel Image arm64"]
+        echo "NGC Devel Image test is disabled."
+    }
+    if (!ENABLE_NGC_RELEASE_IMAGE_TEST) {
+        testConfigs -= ["NGC Release Image amd64", "NGC Release Image arm64"]
+        echo "NGC Release Image test is disabled."
+    }
     // Update testConfigs image field using the map from globalVars
     testConfigs.each { key, config ->
         if (globalVars[IMAGE_KEY_TO_TAG] && globalVars[IMAGE_KEY_TO_TAG][key]) {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an optional post-build sanity check for Docker images, including waiting for artifact availability and running automated validation tests.
  * Introduced environment flags to enable or disable sanity checks for development and release images.
  * Improved test job management for different image types and architectures.

* **Enhancements**
  * Expanded job name mapping and test stage logic for better pipeline control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->