### PR TITLE
fix: Fix AutoTuner warmup request generating.

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -531,6 +531,50 @@ class PyTorchModelEngine(ModelEngine):
                 result = None
             return result
 
+        def get_autotune_warmup_request():
+            available_tokens = kv_cache_manager.get_num_available_tokens(
+                self.max_draft_len)
+            num_tokens_per_request = min(
+                min(available_tokens, self.max_seq_len - 1),
+                self.max_num_tokens)
+
+            available_blocks = kv_cache_manager.get_num_free_blocks()
+
+            # Calculate number of full-length requests and remaining tokens
+            # Each request has num_tokens_per_request tokens, except possibly the last one
+            full_len_request_num = self.max_num_tokens // num_tokens_per_request
+            remaining_tokens = self.max_num_tokens % num_tokens_per_request
+
+            request_num = full_len_request_num if remaining_tokens == 0 else full_len_request_num + 1
+
+            if self.max_num_tokens > available_blocks * kv_cache_manager.tokens_per_block:
+                return None, None
+
+            requests = kv_cache_manager.add_dummy_requests(
+                request_ids=list(range(full_len_request_num)),
+                token_nums=[num_tokens_per_request] * full_len_request_num,
+                is_gen=False,
+                max_num_draft_tokens=self.max_draft_len)
+
+            if remaining_tokens > 0:
+                final_request = kv_cache_manager.add_dummy_requests(
+                    request_ids=[full_len_request_num],
+                    token_nums=[remaining_tokens],
+                    is_gen=False,
+                    max_num_draft_tokens=self.max_draft_len)
+
+                requests += final_request
+
+            if spec_resource_manager is not None:
+                spec_resource_manager.add_dummy_requests(
+                    request_ids=list(range(request_num)))
+
+            result = ScheduledRequests()
+            result.context_requests = requests
+            result.generation_requests = []
+
+            return result, _create_extra_inputs(1, self.max_num_tokens)
+
         @contextlib.contextmanager
         def release_batch(result):
             try:
@@ -618,26 +662,18 @@ class PyTorchModelEngine(ModelEngine):
 
             if self.pytorch_backend_config.autotuner_enabled:
                 with no_cuda_graph(), autotune():
-                    available_tokens = kv_cache_manager.get_num_available_tokens(
-                        self.max_draft_len)
-                    num_tokens_per_request = min(
-                        min(available_tokens, self.max_seq_len - 1),
-                        self.max_num_tokens)
-                    with release_batch(
-                            get_torch_compile_warmup_request(
-                                1, num_tokens_per_request)) as batch:
+                    result, extra_model_inputs = get_autotune_warmup_request()
+                    with release_batch(result) as batch:
                         if batch is None:
                             # No KV cache space!
                             pass
                         else:
                             logger.info(
                                 f"Run autotuning warmup for batch size={1}")
-                            self.forward(
-                                batch,
-                                new_tensors_device=None,
-                                resource_manager=resource_manager,
-                                extra_model_inputs=_create_extra_inputs(
-                                    1, num_tokens_per_request))
+                            self.forward(batch,
+                                         new_tensors_device=None,
+                                         resource_manager=resource_manager,
+                                         extra_model_inputs=extra_model_inputs)
                             torch.cuda.synchronize()
 
                     logger.info(f"Autotuner Cache size after warmup " +

--- a/tensorrt_llm/_torch/utils.py
+++ b/tensorrt_llm/_torch/utils.py
@@ -207,7 +207,7 @@ def get_last_power_of_2_num_tokens_buckets(max_num_tokens) -> List[int]:
     while m >= 1:
         num_token_buckets.append(m)
         m //= 2
-    return num_token_buckets
+    return tuple(num_token_buckets)
 
 
 _enable_piecewise_cuda_graph = True


### PR DESCRIPTION
The current warmup phase creates one request, which is insufficient for the warmup to cover the max_num_tokens. Revise the warmup phase to a batch of requests to cover the max_num_tokens to eliminate potential fallback cases.

Perf collections:
* Llama 3.3: 21522.1423 tps. no regression.
* DS-R1: 6101.5090 vs. 6289.5853 tps 3% improvement. (max_seq_len=9217, max_num_requests=128, max_num_tokens=8320)