### PR TITLE
[TRTLLM-4958][feat] improve multimodal workflow with Vision + LLM inflight batching

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -121,6 +121,7 @@ else
 endif
 SOURCE_DIR        ?= $(shell readlink -f ..)
 CODE_DIR          ?= /code/tensorrt_llm
+EXTRA_VOLUMES     ?=
 CCACHE_DIR        ?= ${CODE_DIR}/cpp/.ccache
 CONAN_DIR         ?= ${CODE_DIR}/cpp/.conan
 RUN_CMD           ?=
@@ -138,6 +139,7 @@ endif
 	docker run $(DOCKER_RUN_OPTS) $(DOCKER_RUN_ARGS) \
     		$(GPU_OPTS) \
     		--volume $(SOURCE_DIR):$(CODE_DIR) \
+			$(EXTRA_VOLUMES) \
     		--env "CCACHE_DIR=${CCACHE_DIR}" \
     		--env "CCACHE_BASEDIR=${CODE_DIR}" \
     	    --env "CONAN_HOME=${CONAN_DIR}" \

--- a/docker/README.md
+++ b/docker/README.md
@@ -44,6 +44,11 @@ Containers can be started with the local user instead of `root` by appending `LO
 make -C docker devel_run LOCAL_USER=1
 ```
 
+Extra docker volumes can be mounted in addition to the source code by appending `EXTRA_VOLUMES=` to the run target:
+```bash
+make -C docker devel_run LOCAL_USER=1 EXTRA_VOLUMES="--volume /pathA:/pathA --volume /pathB:/pathB"
+```
+
 Specific CUDA architectures supported by the `wheel` can be specified WITH `CUDA_ARCHS`:
 
 ```bash

--- a/examples/pytorch/README.md
+++ b/examples/pytorch/README.md
@@ -35,14 +35,15 @@ python3 quickstart_advanced.py --model_dir nvidia/Nemotron-H-8B-Base-8K --disabl
 
 ```bash
 # default inputs
-python3 quickstart_multimodal.py --model_dir Efficient-Large-Model/NVILA-8B --modality image [--use_cuda_graph]
+TLLM_MULTIMODAL_DISAGGREGATED=1 python3 quickstart_multimodal.py --model_dir llava-hf/llava-v1.6-mistral-7b-hf --modality image [--use_cuda_graph]
 
 # user inputs
 # supported modes:
 # (1) N prompt, N media (N requests are in-flight batched)
 # (2) 1 prompt, N media
 # Note: media should be either image or video. Mixing image and video is not supported.
-python3 quickstart_multimodal.py --model_dir Efficient-Large-Model/NVILA-8B --modality video --prompt "Tell me what you see in the video briefly." "Describe the scene in the video briefly." --media "https://huggingface.co/datasets/Efficient-Large-Model/VILA-inference-demos/resolve/main/OAI-sora-tokyo-walk.mp4" "https://huggingface.co/datasets/Efficient-Large-Model/VILA-inference-demos/resolve/main/world.mp4" --max_tokens 128 [--use_cuda_graph]
+TLLM_MULTIMODAL_DISAGGREGATED=0 python3 quickstart_multimodal.py --model_dir llava-hf/llava-v1.6-mistral-7b-hf --modality video --prompt "Tell me what you see in the video briefly." "Describe the scene in the video briefly." --media "https://huggingface.co/datasets/Efficient-Large-Model/VILA-inference-demos/resolve/main/OAI-sora-tokyo-walk.mp4" "https://huggingface.co/datasets/Efficient-Large-Model/VILA-inference-demos/resolve/main/world.mp4" --max_tokens 64 [--use_cuda_graph] [--enable_overlap_scheduler]
+# use TLLM_MULTIMODAL_DISAGGREGATED to control vision+LLM in a single forward pass (0) or in separate forward pass (1)
 ```
 
 ### Supported Models

--- a/examples/pytorch/quickstart_multimodal.py
+++ b/examples/pytorch/quickstart_multimodal.py
@@ -1,8 +1,8 @@
 import argparse
 import json
 import os
-from typing import Any, Dict, List, Callable
 from functools import partial
+from typing import Any, Callable, Dict, List
 
 from quickstart_advanced import add_llm_args, setup_llm
 
@@ -29,14 +29,15 @@ example_video_prompts = [
 ]
 
 
-def prepare_multimodal_inputs(model_dir: str,
-                              modality: str,
-                              prompts: List[str],
-                              media: List[str],
-                              input_formatter: Callable,
-                              mm_loader: Callable,
-                              data_format: str = "pt",  # Options: "pt" or "pil"
-                              device: str = "cuda") -> List[Dict[str, Any]]:
+def prepare_multimodal_inputs(
+        model_dir: str,
+        modality: str,
+        prompts: List[str],
+        media: List[str],
+        input_formatter: Callable,
+        mm_loader: Callable,
+        data_format: str = "pt",  # Options: "pt" or "pil"
+        device: str = "cuda") -> List[Dict[str, Any]]:
 
     inputs = []
     if modality in ["image", "video"]:
@@ -106,12 +107,12 @@ def main():
     elif args.modality == "video":
         mm_loader = partial(default_video_loader, num_frames=args.num_frames)
     data_format = "pt"  # ["pt", "pil"]
-    device = "cuda"
+    media_input_device = "cpu"
 
     inputs = prepare_multimodal_inputs(args.model_dir, args.modality,
-                                       args.prompt, args.media,
-                                       input_formatter, mm_loader,
-                                       data_format, device)
+                                       args.prompt, args.media, input_formatter,
+                                       mm_loader, data_format,
+                                       media_input_device)
 
     outputs = llm.generate(inputs, sampling_params)
 

--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -135,6 +135,8 @@ class ModelConfig(Generic[TConfig]):
         model_dir = Path(
             transformers.utils.hub.cached_file(checkpoint_dir,
                                                'config.json')).parent
+        pretrained_config.checkpoint_dir = model_dir
+
         quant_config = QuantConfig()
         layer_quant_config = None
         # quantized ckpt in modelopt format

--- a/tensorrt_llm/_torch/pyexecutor/config.py
+++ b/tensorrt_llm/_torch/pyexecutor/config.py
@@ -19,7 +19,7 @@ class PyTorchConfig:
     """
 
     # Extra resource managers to use in addition to the KV cache manager.
-    # Each manager's prepare_resources method is called before the forward pass,
+    # Each manager's prepare_resources() is called before the forward pass,
     # and update_resources() is called after the pass finishes. free_resources()
     # is called when a request finishes.
     # The KV cache manager is guaranteed to be invoked after all of these extra

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1025,6 +1025,7 @@ class PyTorchModelEngine(ModelEngine):
         input_ids = []
         sequence_lengths = []
         prompt_lengths = []
+        orig_prompt_lengths = []
         request_ids = []
         gather_ids = []
         position_ids = []
@@ -1050,6 +1051,7 @@ class PyTorchModelEngine(ModelEngine):
             gather_ids.append(len(input_ids) - 1)
             sequence_lengths.append(len(prompt_tokens))
             prompt_lengths.append(len(prompt_tokens))
+            orig_prompt_lengths.append(len(prompt_tokens))
             past_seen_token_num = request.context_current_position
             num_cached_tokens_per_seq.append(past_seen_token_num)
             multimodal_embedding = request.multimodal_embedding()
@@ -1108,6 +1110,7 @@ class PyTorchModelEngine(ModelEngine):
                 position_ids.append(past_seen_token_num)
                 draft_lens.append(num_draft_tokens)
                 prompt_lengths.append(num_draft_tokens + 1)
+                orig_prompt_lengths.append(num_draft_tokens + 1)
                 # draft tokens
                 input_ids.extend(request.py_draft_tokens)
                 gather_ids.extend(
@@ -1148,7 +1151,7 @@ class PyTorchModelEngine(ModelEngine):
                 num_cached_tokens_per_seq.append(past_seen_token_num +
                                                  self.max_draft_len + 1)
                 prompt_lengths.append(request.py_prompt_len)
-
+                orig_prompt_lengths.append(request.py_orig_prompt_len)
             request_ids.append(request.py_request_id)
 
         sequence_lengths.extend([1] * len(generation_requests))
@@ -1176,6 +1179,7 @@ class PyTorchModelEngine(ModelEngine):
             position_ids.append(past_seen_token_num)
             num_cached_tokens_per_seq.append(past_seen_token_num)
             prompt_lengths.append(request.py_prompt_len)
+            orig_prompt_lengths.append(request.py_orig_prompt_len)
             draft_lens.append(0)
 
             request.py_batch_idx = batch_idx
@@ -1264,6 +1268,7 @@ class PyTorchModelEngine(ModelEngine):
 
         attn_metadata.request_ids = request_ids
         attn_metadata.prompt_lens = prompt_lengths
+        attn_metadata.orig_prompt_lens = orig_prompt_lengths
         attn_metadata.num_contexts = len(scheduled_requests.context_requests)
         if self.is_spec_decode and self.spec_config.spec_dec_mode.extend_ctx(
                 self.attn_backend):
@@ -1476,6 +1481,7 @@ class PyTorchModelEngine(ModelEngine):
         sequence_lengths = []
         input_ids = []
         prompt_lengths = []
+        orig_prompt_lengths = []
         request_ids = []
         gather_ids = []
         position_ids = []
@@ -1486,7 +1492,7 @@ class PyTorchModelEngine(ModelEngine):
         for request in scheduled_requests.context_requests:
             request_ids.append(request.py_request_id)
             prompt_lengths.append(request.py_prompt_len)
-
+            orig_prompt_lengths.append(request.py_orig_prompt_len)
             ctx_iter = request.ctx_iters
             ctx_blocks = request.ctx_blocks
             ctx_position_blocks = request.ctx_position_blocks
@@ -1599,7 +1605,7 @@ class PyTorchModelEngine(ModelEngine):
         for request in generation_requests:
             request_ids.append(request.py_request_id)
             prompt_lengths.append(request.py_prompt_len)
-
+            orig_prompt_lengths.append(request.py_orig_prompt_len)
             input_token_id = request.get_token(0, request.get_num_tokens(0) - 1)
             input_ids.append(input_token_id)
             gather_ids.append(len(input_ids) - 1)
@@ -1667,6 +1673,7 @@ class PyTorchModelEngine(ModelEngine):
 
         attn_metadata.request_ids = request_ids
         attn_metadata.prompt_lens = prompt_lengths
+        attn_metadata.orig_prompt_lens = orig_prompt_lengths
         attn_metadata.num_contexts = num_contexts
         attn_metadata.num_queries = num_queries
 

--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -368,10 +368,7 @@ class GenerationExecutorWorker(GenerationExecutor):
 
         prompt_token_ids = copy.deepcopy(request.prompt_token_ids)
         prompt_tuning_config = None
-        multimodal_embedding = None
         mrope_config = None
-        if request.multimodal_embedding is not None:
-            multimodal_embedding = request.multimodal_embedding
         if request.prompt_adapter_request is not None:
             self._load_prompt_adapter(request.prompt_adapter_request)
             uid = str(request.prompt_adapter_request.adapter_id)
@@ -450,7 +447,8 @@ class GenerationExecutorWorker(GenerationExecutor):
                 embedding_bias=request.sampling_params.embedding_bias,
                 lora_config=lora_config,
                 prompt_tuning_config=prompt_tuning_config,
-                multimodal_embedding=multimodal_embedding,
+                multimodal_embedding=request.multimodal_embedding
+                if request.multimodal_embedding is not None else None,
                 mrope_config=mrope_config,
                 logits_post_processor_name=(
                     tllm.Request.BATCHED_POST_PROCESSOR_NAME

--- a/tensorrt_llm/inputs/utils.py
+++ b/tensorrt_llm/inputs/utils.py
@@ -276,7 +276,8 @@ def format_qwen2_vl_input(model_dir, inputs):
 
 def default_image_loader(prompts: List[str],
                          images: Union[List[List[str]], List[str]],
-                         image_data_format: str = "pt"):
+                         image_data_format: str = "pt",
+                         device: str ="cuda"):
     if len(images) > len(prompts) and len(prompts) == 1:
         # 1 prompt + N media
         images = [images]
@@ -285,10 +286,10 @@ def default_image_loader(prompts: List[str],
         "prompt": prompt,
         "multi_modal_data": {
             "image": [
-                load_image(i, format=image_data_format, device="cuda")
+                load_image(i, format=image_data_format, device=device)
                 for i in image
             ] if isinstance(image, list) else
-            [load_image(image, format=image_data_format, device="cuda")]
+            [load_image(image, format=image_data_format, device=device)]
         }
     } for prompt, image in zip(prompts, images)]
     return inputs
@@ -297,6 +298,7 @@ def default_image_loader(prompts: List[str],
 def default_video_loader(prompts: List[str],
                          videos: Union[List[List[str]], List[str]],
                          image_data_format: str = "pt",
+                         device: str ="cuda",
                          num_frames: int = 8):
     if len(videos) > len(prompts) and len(prompts) == 1:
         # 1 prompt + N media
@@ -307,11 +309,11 @@ def default_video_loader(prompts: List[str],
         "multi_modal_data": {
             "video": [
                 load_video(
-                    i, num_frames, format=image_data_format, device="cuda")
+                    i, num_frames, format=image_data_format, device=device)
                 for i in video
             ] if isinstance(video, list) else [
                 load_video(
-                    video, num_frames, format=image_data_format, device="cuda")
+                    video, num_frames, format=image_data_format, device=device)
             ]
         }
     } for prompt, video in zip(prompts, videos)]

--- a/tensorrt_llm/inputs/utils.py
+++ b/tensorrt_llm/inputs/utils.py
@@ -277,7 +277,7 @@ def format_qwen2_vl_input(model_dir, inputs):
 def default_image_loader(prompts: List[str],
                          images: Union[List[List[str]], List[str]],
                          image_data_format: str = "pt",
-                         device: str ="cuda"):
+                         device: str = "cuda"):
     if len(images) > len(prompts) and len(prompts) == 1:
         # 1 prompt + N media
         images = [images]
@@ -298,7 +298,7 @@ def default_image_loader(prompts: List[str],
 def default_video_loader(prompts: List[str],
                          videos: Union[List[List[str]], List[str]],
                          image_data_format: str = "pt",
-                         device: str ="cuda",
+                         device: str = "cuda",
                          num_frames: int = 8):
     if len(videos) > len(prompts) and len(prompts) == 1:
         # 1 prompt + N media


### PR DESCRIPTION
## Description

**NOTE: this PR provides a problem statement and proof-of-concept solutions to the problem. We plan to address it more formally in follow-up PRs in https://github.com/NVIDIA/TensorRT-LLM/pull/4799 and https://github.com/NVIDIA/TensorRT-LLM/pull/5522, please take a look at them! this PR will be closed after the refactoring is completely done.**

Existing workflow: 
* vision forward on main process, LLM forwrad on worker process. multimodal embedding is transferred during IPC.
* many IPC D2H & H2D overhead due to the queue structure being used. Tensor pickle serialization & deserialization is involved
* vision forward is per-request run, so only allows BS=1 for vision
![old](https://github.com/user-attachments/assets/e06fb333-9d3a-499d-915f-fe450f8a63d8)
Above is the nsys for processing 3 images

Improved workflow:
* vision & LLM in the same forward, on worker process. raw image tensor is transferred during IPC.
* allows BS > 1 for vision. although enforces vision batch to immediately finish the context/prefill phase, cannot be prefilled later.
* needs to modify attn_medata struct inside forward. the overhead from the `prepare_multimodal_ifb()` call is negligible from nsys profile. but caveat is this is not yet compatible with cuda graph mode.
* the IFB token capacity estimate may be incorrect during request scheduling, because vision context length is unknown at scheduling time
![new](https://github.com/user-attachments/assets/c21a6cd2-f389-4d57-86df-3786afbea679)

Notes:
* use `TLLM_MULTIMODAL_DISAGGREGATED` to test old (=1) & new (=0, by default) for now
* use llava-next as the experimental example
* --user_cuda_graph doesn't work with this IFB mode because attn_metadata.prepare() needs to be called inside forward()

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
