### PR TITLE
chore: remove extra paths to find binaries

### DIFF
--- a/triton_backend/inflight_batcher_llm/CMakeLists.txt
+++ b/triton_backend/inflight_batcher_llm/CMakeLists.txt
@@ -151,23 +151,17 @@ find_package(Python3 COMPONENTS Interpreter Development)
 find_library(
   tensorrt_llm libtensorrt_llm.so REQUIRED
   PATHS ${Python3_SITEARCH}/tensorrt_llm/libs
-        ${TRTLLM_DIR}/cpp/build/tensorrt_llm
-        ${CMAKE_CURRENT_SOURCE_DIR}/../tensorrt_llm/cpp/build/tensorrt_llm)
+        ${TRTLLM_DIR}/cpp/build/tensorrt_llm)
 
 find_library(
   nvinfer_plugin_tensorrt_llm libnvinfer_plugin_tensorrt_llm.so REQUIRED
-  PATHS
-    ${Python3_SITEARCH}/tensorrt_llm/libs
-    ${TRTLLM_DIR}/cpp/build/tensorrt_llm/plugins
-    ${CMAKE_CURRENT_SOURCE_DIR}/../tensorrt_llm/cpp/build/tensorrt_llm/plugins)
+  PATHS ${Python3_SITEARCH}/tensorrt_llm/libs
+        ${TRTLLM_DIR}/cpp/build/tensorrt_llm/plugins)
 
 find_program(
   TRTLLM_EXECUTOR_WORKER executorWorker REQUIRED
-  PATHS
-    ${Python3_SITEARCH}/tensorrt_llm/bin
-    ${TRTLLM_DIR}/cpp/build/tensorrt_llm/executor_worker
-    ${CMAKE_CURRENT_SOURCE_DIR}/../tensorrt_llm/cpp/build/tensorrt_llm/executor_worker
-)
+  PATHS ${Python3_SITEARCH}/tensorrt_llm/bin
+        ${TRTLLM_DIR}/cpp/build/tensorrt_llm/executor_worker)
 install(
   PROGRAMS ${TRTLLM_EXECUTOR_WORKER}
   DESTINATION ${CMAKE_BINARY_DIR}


### PR DESCRIPTION
# PR title

chore: remove extra paths to find binaries

## Description

Please explain the issue and the solution in short.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
