### PR TITLE
Support loading other model's tokenizer for apple models

### DIFF
--- a/examples/auto_deploy/README.md
+++ b/examples/auto_deploy/README.md
@@ -76,12 +76,15 @@ Additionally, we have officially verified support for the following models:
 |--------------|----------------------|----------------|-----------|------------|---------|-----------------|--------------------|--------------------|--------------------|----------|----------|
 |              |               |            |           |            |         | torch-simple    | torch-compile    | torch-opt          | TritonWithFlattenedInputs | FlashInfer | MultiHeadLatentAttention |
 | LLaMA        | meta-llama/Llama-2-7b-chat-hf<br>meta-llama/Meta-Llama-3.1-8B-Instruct<br>meta-llama/Llama-3.1-70B-Instruct<br>codellama/CodeLlama-13b-Instruct-hf | AutoModelForCausalLM | BF16 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ | ✅ | n/a |
+| LLaMA-4      | meta-llama/Llama-4-Scout-17B-16E-Instruct<br>meta-llama/Llama-4-Maverick-17B-128E-Instruct | AutoModelForImageTextToText | BF16 | 1,2,4,8 | demollm, trtllm | ✅ | ✅ | ❌ | ✅ | ✅ | n/a |
 | Nvidia Minitron | nvidia/Llama-3_1-Nemotron-51B-Instruct<br>nvidia/Llama-3.1-Minitron-4B-Width-Base<br>nvidia/Llama-3.1-Minitron-4B-Depth-Base | AutoModelForCausalLM | BF16 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ | ✅ | n/a |
 | Nvidia Model Optimizer | nvidia/Llama-3.1-8B-Instruct-FP8<br>nvidia/Llama-3.1-405B-Instruct-FP8 | AutoModelForCausalLM | FP8 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ | ✅ | n/a |
 | DeepSeek     | deepseek-ai/DeepSeek-R1-Distill-Llama-70B | AutoModelForCausalLM | BF16 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ | ✅ | n/a |
 | Mistral      | mistralai/Mixtral-8x7B-Instruct-v0.1<br>mistralai/Mistral-7B-Instruct-v0.3 | AutoModelForCausalLM | BF16 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ | ✅ | n/a |
 | BigCode      | bigcode/starcoder2-15b | AutoModelForCausalLM | FP32 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ | ✅ | n/a |
 | Deepseek-V3      | deepseek-ai/DeepSeek-V3 | AutoModelForCausalLM | BF16 | 1,2,4 | demollm | ✅ | ❌ | ❌ | n/a | n/a | ✅ |
+| Phi4      | microsoft/phi-4<br>microsoft/Phi-4-reasoning<br>microsoft/Phi-4-reasoning-plus | AutoModelForCausalLM | BF16 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅ | ✅ | ✅ | n/a |
+| Phi3/2      | microsoft/Phi-3-mini-4k-instruct<br>microsoft/Phi-3-mini-128k-instruct<br>microsoft/Phi-3-medium-4k-instruct<br>microsoft/Phi-3-medium-128k-instruct<br>microsoft/Phi-3.5-mini-instruct | AutoModelForCausalLM | BF16 | 1,2,4 | demollm, trtllm | ✅ | ✅ | ✅(partly) | ✅ | ❌ | n/a |
 
 </details>
 

--- a/examples/auto_deploy/build_and_run_ad.py
+++ b/examples/auto_deploy/build_and_run_ad.py
@@ -108,7 +108,7 @@ def main(config: Optional[SimpleConfig] = None):
     print_outputs(outs)
 
     # run a benchmark for the model with batch_size == config.benchmark_bs
-    if config.benchmark:
+    if config.benchmark and config.runtime != "trtllm":
         ad_logger.info("Running benchmark...")
         keys = [
             "compile_backend",
@@ -122,13 +122,19 @@ def main(config: Optional[SimpleConfig] = None):
         benchmark(
             func=lambda: llm.generate(
                 torch.randint(0, 100, (config.benchmark_bs, config.benchmark_isl)).tolist(),
-                sampling_params=SamplingParams(max_tokens=config.benchmark_osl, top_k=None),
+                sampling_params=SamplingParams(
+                    max_tokens=config.benchmark_osl,
+                    top_k=None,
+                    ignore_eos=True,
+                ),
                 use_tqdm=False,
             ),
             num_runs=config.benchmark_num,
             log_prefix="Benchmark with " + ", ".join(f"{k}={getattr(config, k)}" for k in keys),
             results_path=config.benchmark_results_path,
         )
+    elif config.benchmark:
+        ad_logger.info("Skipping simple benchmarking for trtllm...")
     llm.shutdown()
 
 

--- a/examples/auto_deploy/build_and_run_ad.py
+++ b/examples/auto_deploy/build_and_run_ad.py
@@ -96,6 +96,7 @@ def main(config: Optional[SimpleConfig] = None):
     llm = build_llm_from_config(config)
 
     # prompt the model and print its output
+    ad_logger.info("Running example prompts...")
     outs = llm.generate(
         config.prompt,
         sampling_params=SamplingParams(
@@ -108,6 +109,7 @@ def main(config: Optional[SimpleConfig] = None):
 
     # run a benchmark for the model with batch_size == config.benchmark_bs
     if config.benchmark:
+        ad_logger.info("Running benchmark...")
         keys = [
             "compile_backend",
             "attn_backend",

--- a/examples/auto_deploy/build_and_run_ad.py
+++ b/examples/auto_deploy/build_and_run_ad.py
@@ -75,7 +75,9 @@ def build_llm_from_config(config: SimpleConfig) -> LLM:
         build_config=build_config,
         pytorch_backend_config=ad_config,
         tensor_parallel_size=config.world_size,
-        tokenizer=factory.init_tokenizer() if config.customize_tokenizer else None,
+        tokenizer=factory.init_tokenizer(config.tokenizer_name)
+        if config.customize_tokenizer
+        else None,
     )
 
     return llm

--- a/examples/auto_deploy/simple_config.py
+++ b/examples/auto_deploy/simple_config.py
@@ -47,6 +47,9 @@ class SimpleConfig:
     # [here](https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/tokenization_llama_fast.py#L127).
     # NOTE: This is only used if customize_tokenizer is True
     tokenizer_kwargs: Dict = field(default_factory=dict)
+    # Specify to load the tokenizer of another model via the model's name
+    # NOTE: This is only used if customize_tokenizer is True
+    tokenizer_name: str = None
 
     ### CONFIGURE BACKEND, RUNTIME, AND WORLD SIZE ##################################
     world_size: int = 1  # choose from number of GPUs for TP (0--> no TP, no spawned processes)

--- a/examples/auto_deploy/simple_config.py
+++ b/examples/auto_deploy/simple_config.py
@@ -76,7 +76,7 @@ class SimpleConfig:
     visualize: bool = False
 
     ### BENCHMARKING CONFIG ########################################################################
-    free_mem_ratio: float = 0.8  # specifies the fraction of available memory to occupy for cache
+    free_mem_ratio: float = 0.0  # specifies the fraction of available memory to occupy for cache
     benchmark: bool = False  # If true, set ISO to 2048 random int and OSL to 128
     benchmark_num: int = 10  # By default run 10 times and get average
     benchmark_isl: int = 2048  # input seq length for benchmarking

--- a/examples/auto_deploy/simple_config.py
+++ b/examples/auto_deploy/simple_config.py
@@ -21,7 +21,9 @@ class SimpleConfig:
     # If no `model` argument is provided, the checkpoint directory is used to infer the model
     # architecture.
     model: Optional[str] = None
-    model_factory: Literal["AutoModelForCausalLM"] = "AutoModelForCausalLM"
+    model_factory: Literal["AutoModelForCausalLM", "AutoModelForImageTextToText"] = (
+        "AutoModelForCausalLM"
+    )
     skip_loading_weights: bool = False  # only load the architecture, not the weights
     customize_tokenizer: bool = False  # True: tokenizer from the model factory, False: from LLM api
 

--- a/examples/auto_deploy/simple_config.py
+++ b/examples/auto_deploy/simple_config.py
@@ -36,6 +36,9 @@ class SimpleConfig:
     # An example model config class can be found [here](https://github.com/huggingface/transformers/blob/c409cd81777fb27aadc043ed3d8339dbc020fb3b/src/transformers/models/llama/configuration_llama.py#L26).
     model_kwargs: Dict = field(default_factory=dict)
 
+    # TODO: temp fix for dashboard to modify the number of hidden layers
+    num_hidden_layers: int = -1
+
     ### TOKENIZER EXTRA KWARGS #####################################################################
     # Extra kwargs for the tokenizer class to customize the tokenizer. Same as model_kwargs.
     # For example, the default HF Llama tokenizer can be initialized with the arguments specified
@@ -129,3 +132,6 @@ class SimpleConfig:
         # replicate prompts to get to batch_size
         prompts = self.prompt * (self.batch_size // len(self.prompt) + 1)
         self.prompt = prompts[: self.batch_size]
+
+        if self.num_hidden_layers != -1:
+            self.model_kwargs["num_hidden_layers"] = self.num_hidden_layers

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -30,10 +30,21 @@ class CacheConfig:
 class SequenceInfo:
     """A dataclass to hold information about how the sequence is laid out and stored in cache.
 
-    We assume the sequence + cache is laid out in the following way:
+    We assume the sequence + cache is laid out in the following way. Also note that we differentiate
+    between arguments that are originally part of the model/graph and arguments that are needed for
+    the attention operator when we switch to cached+flattened attention.
 
+    # ORIGINAL MODEL ARGUMENTS #####################################################################
     - input_ids: [id_0, ..., id_{s_total-1}]
       flattened sequence of [b, 1] or [1, s_total]. We use [b, 1] to denote generate-only batches.
+    - position_ids: [pos_0, ..., pos_{s_total-1}]
+      flattened sequence of [b, 1] or [1, s_total] indicating absolute position ids for every token
+      in the input_ids sequence. We use [b, 1] to denote generate-only batches.
+
+    NOTE: ``input_ids`` and ``position_ids`` are initially expected to be of shape [b, seq_len]
+    before we switch to cached+flattened attention.
+
+    # EXTRA ARGUMENTS NEEDED FOR ATTENTION OPERATORS FOR FLATTENED SEQUENCES + CACHES ##############
     - seq_len: [s_0, s_1, ..., s_{b-1}] such that s_total = sum(s_i)
       Describes how long each sequence is. For example,
       input_ids[:s_0] will correspond to sequence 0 in the batch and input_ids[s_0:s_1] will
@@ -46,6 +57,8 @@ class SequenceInfo:
     - pages_per_seq: [ps_0, ps_1, ..., ps_{b-1}] where ps_i is the number of pages allocated for
       sequence i. Note that, for example, cache_loc[p_0:p_1] will correspond to the pages associated
       with sequence 1 in the batch.
+
+    ################################################################################################
 
     Here are a couple of notes to emphasize this notation:
 
@@ -118,6 +131,9 @@ class SequenceInfo:
         # keep a list-like object of sequence lengths for simplicity as well
         self._sequence_lengths = [0] * self.max_batch_size
 
+        # indicator if extra args are activated that are needed for cached attention backends
+        self._is_cached_attn = False
+
         # call reset once to initialize the tensors
         self.reset()
 
@@ -132,23 +148,24 @@ class SequenceInfo:
             val = getattr(self, f.name)
             if isinstance(val, torch.Tensor):
                 args.append(val)
+            if len(args) >= self._num_uncached_attn_args and not self._is_cached_attn:
+                break
         return tuple(args)
 
     @property
-    def num_original_args(self) -> int:
+    def _num_uncached_attn_args(self) -> int:
         """Return the number of original graph arguments expected by the model."""
         return 2
 
     @property
-    def args_original(self) -> Tuple[torch.Tensor, ...]:
-        """Return the original graph arguments expected by the model."""
-        return self.args[: self.num_original_args]
+    def _cached_attn_arg_names(self) -> List[str]:
+        """Return extra arg names for the prepare_metadata op beyond input_ids and position_ids.
 
-    @property
-    def extra_arg_names(self) -> List[str]:
-        """Return extra arg names for the prepare_metadata op beyond input_ids and position_ids."""
+        These extra args are needed once we switch from regular attention to inserting cached
+        attention ops in the model.
+        """
         return [f.name for f in fields(self) if isinstance(getattr(self, f.name), torch.Tensor)][
-            self.num_original_args :
+            self._num_uncached_attn_args :
         ]
 
     @property
@@ -166,14 +183,10 @@ class SequenceInfo:
             # set up shape for position_ids (same as input_ids)
             dynamic_shapes[1].update(dynamic_shapes[0])
             # set up shape for extra args
-            dynamic_shapes += ({},) * len(self.extra_arg_names)
+            if self._is_cached_attn:
+                dynamic_shapes += ({},) * len(self._cached_attn_arg_names)
             self._dynamic_shapes = dynamic_shapes
         return self._dynamic_shapes
-
-    @property
-    def original_dynamic_shapes(self) -> Tuple[Dict[str, Dim]]:
-        """Return the dynamic shapes of the original graph arguments."""
-        return self.dynamic_shapes[: self.num_original_args]
 
     @property
     def num_sequences(self) -> int:
@@ -271,6 +284,23 @@ class SequenceInfo:
             num_seq = b
         return num_seq
 
+    def switch_to_cached_attn_inputs(self) -> List[str]:
+        """Switch to inputs for cached+flattened attention operators.
+
+        Returns:
+            List[str]: List of new argument names that are now activated.
+
+        This function will change the inputs provided by the interface from the arguments expected
+        by regular attention in PyTorch (SDPA-style) to the arguments needed once we use attention
+        operators with cache support and flattened sequences.
+
+        NOTE: The graph inference optimizer is responsible for ensuring the the new inputs are
+        correctly reflected in the graph after this function is called.
+        """
+        assert not self._is_cached_attn, "Cached+flattened attention already activated"
+        self._is_cached_attn = True
+        return self._cached_attn_arg_names
+
     def to(self, *args, **kwargs) -> None:
         for f in fields(self):
             val = getattr(self, f.name)
@@ -306,8 +336,8 @@ class SequenceInfo:
         self.cache_loc[:] = torch.arange(self.num_pages, dtype=torch.int, device=self.device)
         self.pages_per_seq.fill_(1)
 
-    def _set_example_sequence(self) -> None:
-        """Set an example sequence for export purposes with shape [bs, seq_len]."""
+    def set_example_sequence(self) -> None:
+        """Set an example sequence useful for testing and export purposes."""
         self.reset()
         bs, seq_len = min(2, self.max_batch_size), min(4, self.max_seq_len)
         input_ids = torch.ones(
@@ -317,8 +347,11 @@ class SequenceInfo:
             device=self.device,
         )
         self.nest_sequences(input_ids)
-        self.input_ids = self.input_ids.view(bs, seq_len)
-        self.position_ids = self.position_ids.view(bs, seq_len)
+
+        # unflatten if we are not yet using cached+flattened attention
+        if not self._is_cached_attn:
+            self.input_ids = self.input_ids.view(bs, seq_len)
+            self.position_ids = self.position_ids.view(bs, seq_len)
 
     def _set_max_num_tokens_sample(self) -> None:
         """Set an example sequence with max_num_tokens."""
@@ -333,8 +366,12 @@ class SequenceInfo:
         self.pages_per_seq.fill_(seq_len // self.page_size)
         self.nest_sequences(input_ids)
 
-    def _set_generate_only_batch(self) -> None:
-        """Set an example sequence for generate-only batch."""
+    def set_generate_only_batch(self) -> None:
+        """Set an example sequence for generate-only batch.
+
+        NOTE: this batch is already formatted as [b, 1] in both original and in the cached attention
+        mode. So we don't need to do anything mode-specific here.
+        """
         self.reset()
         self.nest_sequences([[1]] * self.max_batch_size)
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -78,7 +78,7 @@ class SequenceInfo:
     ## [UPDATE WITH CARE] TENSOR FIELDS THAT WILL BE PASSED TO PREPARE_METADATA OP #################
     # input_ids MUST ALWAYS BE THE FIRST FIELD
     input_ids: torch.Tensor = field(default_factory=lambda: torch.zeros(1, 1, dtype=torch.int))
-    position_ids: torch.Tensor = field(default_factory=lambda: torch.zeros(1, 1, dtype=torch.int))
+    position_ids: torch.Tensor = field(default_factory=lambda: torch.zeros(1, 1, dtype=torch.long))
 
     seq_len: torch.Tensor = field(default_factory=lambda: torch.ones(1, dtype=torch.int))
     input_pos: torch.Tensor = field(default_factory=lambda: torch.zeros(1, dtype=torch.int))
@@ -106,7 +106,7 @@ class SequenceInfo:
         total_tokens = min(self.max_num_tokens, self.max_batch_size * max_seq_len_adjusted)
         self._num_pages = (total_tokens) // self.page_size + (total_tokens % self.page_size > 0)
         self.input_ids = torch.ones(self.max_batch_size, 1, dtype=torch.int)
-        self.position_ids = torch.zeros(self.max_batch_size, 1, dtype=torch.int)
+        self.position_ids = torch.zeros(self.max_batch_size, 1, dtype=torch.long)
         self.seq_len = torch.empty(self.max_batch_size, dtype=torch.int)
         self.input_pos = torch.empty_like(self.seq_len)
         self.cache_loc = torch.empty(self.num_pages, dtype=torch.int)
@@ -341,7 +341,7 @@ class SequenceInfo:
     def _update_position_ids(self) -> None:
         # set new position_ids as new tensor from input_pos and seq_len via torch.arange
         position_ids_list = [
-            torch.arange(in_pos, in_pos + seq_len, dtype=torch.int)
+            torch.arange(in_pos, in_pos + seq_len, dtype=torch.long)
             for in_pos, seq_len in zip(self.input_positions, self.sequence_lengths)
         ]
         self.position_ids = torch.cat(position_ids_list, dim=0).to(self.device)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/flashinfer_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/flashinfer_attention.py
@@ -9,6 +9,7 @@ from torch.fx import Node
 
 from ..utils.cuda_graph import cuda_graph_state
 from ..utils.logger import ad_logger
+from ..utils.node_utils import extract_op_args
 from .attention_interface import (
     AttentionDescriptor,
     AttentionLayout,
@@ -399,7 +400,9 @@ class FlashInferAttention(AttentionDescriptor):
     @classmethod
     def get_constants(cls, source_attn_node: Node) -> List[Constant]:
         # Double check other arguments
-        attn_mask, dropout_p, is_causal = source_attn_node.args[3:6]
+        attn_mask, dropout_p, is_causal = extract_op_args(
+            source_attn_node, "attn_mask", "dropout_p", "is_causal"
+        )
         if attn_mask is not None or dropout_p != 0.0 or not is_causal:
             ad_logger.warning(
                 "Unsupported attention arguments for "

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/flashinfer_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/flashinfer_attention.py
@@ -71,8 +71,7 @@ class _FlashInferPlanner:
 
         self.workspace_buffer = workspace_buffer
         # NOTE (lucaslie): flashinfer fa3 backend has accuracy issue + illegal memory access issues
-        # on H100 PCIe, see https://github.com/NVIDIA/TensorRT-LLM/pull/3686 and
-        # https://github.com/flashinfer-ai/flashinfer/issues/924
+        # on H100 PCIe, see https://github.com/NVIDIA/TensorRT-LLM/issues/4504
         self.prefill_wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
             self.workspace_buffer,
             "NHD",

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_attention.py
@@ -63,7 +63,7 @@ def scaled_dot_product_attention_fake(
     query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None
 ):
     """Fake implementation of scaled_dot_product_attention."""
-    return torch.empty_like(query.contiguous())
+    return query.new_empty(*query.shape[:-1], value.shape[-1]).contiguous()
 
 
 @torch.library.custom_op("attention::grouped_sdpa", mutates_args=())
@@ -101,7 +101,7 @@ def grouped_sdpa_fake(
     scale=None,
 ):
     """Fake implementation of grouped SDPA."""
-    return torch.empty_like(query.contiguous())
+    return query.new_empty(*query.shape[:-1], value.shape[-1]).contiguous()
 
 
 @torch.library.custom_op("attention::bsnd_grouped_sdpa", mutates_args=())
@@ -135,7 +135,7 @@ def bsnd_grouped_sdpa_fake(
     query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None
 ):
     """Fake implementation of bnsd grouped SDPA."""
-    return torch.empty_like(query.contiguous())
+    return query.new_empty(*query.shape[:-1], value.shape[-1]).contiguous()
 
 
 def update_kv_cache(

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_attention.py
@@ -10,6 +10,7 @@ from torch._subclasses import FakeTensor
 from torch.fx import Node
 
 from ..utils.logger import ad_logger
+from ..utils.node_utils import extract_op_args
 from .attention_interface import (
     AttentionDescriptor,
     AttentionLayout,
@@ -364,8 +365,9 @@ class TritonWithFlattenedInputs(AttentionDescriptor):
         k_fake: FakeTensor = source_attn_node.args[1].meta["val"]
         head_dim = k_fake.shape[3]
 
-        # Double check other arguments
-        attn_mask, dropout_p, is_causal = source_attn_node.args[3:6]
+        attn_mask, dropout_p, is_causal = extract_op_args(
+            source_attn_node, "attn_mask", "dropout_p", "is_causal"
+        )
         if attn_mask is not None or dropout_p != 0.0 or not is_causal:
             ad_logger.warning(
                 "Unsupported attention arguments for "

--- a/tensorrt_llm/_torch/auto_deploy/distributed/common.py
+++ b/tensorrt_llm/_torch/auto_deploy/distributed/common.py
@@ -89,7 +89,7 @@ def get_rank_world_size() -> Tuple[int, int]:
 
 def initialize_or_skip(*args, **kwargs) -> Tuple[int, int]:
     if not dist.is_initialized():
-        initialize(*args, **kwargs)
+        return initialize(*args, **kwargs)
     return get_rank(), get_world_size()
 
 
@@ -241,6 +241,7 @@ def spawn_multiprocess_job(job: Callable[[int, int], None], size: Optional[int] 
     processes = _start_multiprocess_job(job, size)
     if processes:
         _join_multiprocess_job(processes)
+    cleanup()
 
 
 class MultiProcessExecutor:

--- a/tensorrt_llm/_torch/auto_deploy/models/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/__init__.py
@@ -1,3 +1,4 @@
 from . import hf
 from .deepseek import *
 from .factory import *
+from .phi import *

--- a/tensorrt_llm/_torch/auto_deploy/models/factory.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/factory.py
@@ -93,37 +93,52 @@ class ModelFactory(ABC):
                 the same model that is built above but it needs to have a state dict compatible with
                 the model built above.
             device: The device to load the model on.
+
+        NOTE: we always call ``self._to_maybe_random(model, device)`` as a preprocessing step
+        to ensure the model parameters already exist on the right device and have the desired dtype
+        as set in the model architecture. Moreover, initializing weights will ensure that no
+        ``assign=True`` logic is triggered during state dict loading. We want to avoid this since
+        this can interfere with things like weight sharding loading hooks. Particularly,
+        ``assign=True`` can cause OOM issues because although we shard the weight it may still
+        reference the full weight tensor in memory and hence with ``assign=True`` memory equivalent
+        to the full weight tensor and hence the full model may be reserved on each rank.
+
+        NOTE: this function will roughly allocate the following amount of memory:
+
+            * ``skip_loading_weights=True``:
+
+                .. code-block:: python
+
+                    sum(t.element_size() * t.numel() for t in model.state_dict().values())
+
+            * ``skip_loading_weights=False``:
+
+                .. code-block:: python
+
+                    sum(t.element_size() * t.numel() for t in model.state_dict().values()) +
+                    <SIZE_OF_LARGEST_CHECKPOINT_FILE>
+
         """
         ad_logger.info("Loading and initializing weights.")
-        if self.skip_loading_weights:
-            self._load_random_init(model, device)
-        else:
+        self._to_maybe_random(model, device)
+        if not self.skip_loading_weights:
             self._load_checkpoint(model, device)
 
     @staticmethod
-    def _to_maybe_empty(model: nn.Module, device: DeviceLikeType):
-        """A mix of ``model.to(device)`` and ``model.to_empty(device)``.
+    def _to_maybe_random(model: nn.Module, device: DeviceLikeType):
+        """A mix of ``model.to(device)`` and random initialization of parameters.
 
         If a parameter is already initialized, then we will call `to()` on it. Otherwise, we will
-        initialize it with an empty tensor on the given device.
+        initialize it with a random tensor on the given device.
 
+        NOTE: this utility is written in such a fashion that not more memory than what the model
+        shard needs is reserved and/or allocated.
         """
         model._apply(
-            lambda t: torch.empty_like(t, device=device)
+            lambda t: torch.normal(0.0, 1.0, size=t.shape, device=device, dtype=t.dtype)
             if t.device == torch.device("meta")
             else t.to(device)
         )
-
-    @classmethod
-    def _load_random_init(cls, model: nn.Module, device: DeviceLikeType):
-        """Randomly initialize model."""
-        cls._to_maybe_empty(model, device)
-        state_dict = model.state_dict()
-        for k in state_dict:
-            state_dict[k] = torch.normal(0.0, 1.0, size=state_dict[k].shape, device=device).to(
-                state_dict[k].dtype
-            )
-        model.load_state_dict(state_dict, strict=True, assign=True)
 
     @abstractmethod
     def _load_checkpoint(self, model: nn.Module, device: DeviceLikeType):

--- a/tensorrt_llm/_torch/auto_deploy/models/factory.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/factory.py
@@ -135,7 +135,8 @@ class ModelFactory(ABC):
         shard needs is reserved and/or allocated.
         """
         model._apply(
-            lambda t: torch.normal(0.0, 1.0, size=t.shape, device=device, dtype=t.dtype)
+            # NOTE (lucaslie): torch.normal is not supported for all dtypes
+            lambda t: torch.normal(0.0, 1.0, size=t.shape, device=device).to(t.dtype)
             if t.device == torch.device("meta")
             else t.to(device)
         )

--- a/tensorrt_llm/_torch/auto_deploy/models/hf.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/hf.py
@@ -72,6 +72,7 @@ class AutoModelForCausalLMFactory(ModelFactory):
 
         self.model_kwargs = model_kwargs or {}
         self.tokenizer_kwargs = tokenizer_kwargs or {}
+        self.tokenizer_kwargs.setdefault("trust_remote_code", True)
         self._quant_config = None
 
         # heuristic to disable use_cache

--- a/tensorrt_llm/_torch/auto_deploy/models/hf.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/hf.py
@@ -175,11 +175,14 @@ class AutoModelForCausalLMFactory(ModelFactory):
             kv_cache_dtype = None
         return CacheConfig(dtype=kv_cache_dtype)
 
-    def init_tokenizer(self) -> Optional[Any]:
-        """Initialize the tokenizer for the model."""
-        if not self.model:
+    def init_tokenizer(self, tokenizer_name: str = None) -> Optional[Any]:
+        """Initialize the tokenizer—either a custom name or the model's default."""
+        if self.model is None and tokenizer_name is None:
             return None
-        return self.autotokenizer_from_pretrained(self.model, **self.tokenizer_kwargs)
+
+        # prefer a user-specified tokenizer_name, otherwise use the model ID
+        target = tokenizer_name or self.model
+        return self.autotokenizer_from_pretrained(target, **self.tokenizer_kwargs)
 
     def _get_ignore_patterns(self, repo_id: str):
         """Get the ignore patterns for the HF repo."""

--- a/tensorrt_llm/_torch/auto_deploy/models/hf.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/hf.py
@@ -13,7 +13,13 @@ from accelerate.utils import modeling
 from huggingface_hub import HfApi, snapshot_download
 from huggingface_hub.utils import HFValidationError, filter_repo_objects, validate_repo_id
 from torch._prims_common import DeviceLikeType
-from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, PretrainedConfig
+from transformers import (
+    AutoConfig,
+    AutoModelForCausalLM,
+    AutoModelForImageTextToText,
+    AutoTokenizer,
+    PretrainedConfig,
+)
 from transformers.utils import (
     SAFE_WEIGHTS_INDEX_NAME,
     SAFE_WEIGHTS_NAME,
@@ -311,3 +317,21 @@ class AutoModelForCausalLMFactory(ModelFactory):
                 # We do not quantize lm_head.
                 if "exclude_modules" not in self._quant_config:
                     self._quant_config["exclude_modules"] = ["lm_head"]
+
+
+@ModelFactoryRegistry.register("AutoModelForImageTextToText")
+class AutoModelForImageTextToTextFactory(AutoModelForCausalLMFactory):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # additional heuristic to disable use_cache
+        self.model_kwargs["text_config"] = self.model_kwargs.get("text_config", {})
+        self.model_kwargs["text_config"]["use_cache"] = False
+
+        self.model_kwargs["text_config"]["max_position_embeddings"] = self.model_kwargs[
+            "max_position_embeddings"
+        ]
+
+    @property
+    def automodel_from_config(self):
+        return AutoModelForImageTextToText.from_config

--- a/tensorrt_llm/_torch/auto_deploy/models/hf.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/hf.py
@@ -4,16 +4,22 @@ import json
 import os
 import types
 from contextlib import contextmanager, nullcontext
-from typing import Any, Dict, Mapping, Optional
+from typing import Any, Dict, Optional, Union
 
 import torch
 import torch.nn as nn
-from accelerate import init_empty_weights, load_checkpoint_and_dispatch
+from accelerate import init_empty_weights, load_checkpoint_in_model
 from accelerate.utils import modeling
-from huggingface_hub import snapshot_download
-from huggingface_hub.utils import HFValidationError, validate_repo_id
+from huggingface_hub import HfApi, snapshot_download
+from huggingface_hub.utils import HFValidationError, filter_repo_objects, validate_repo_id
 from torch._prims_common import DeviceLikeType
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, PretrainedConfig
+from transformers.utils import (
+    SAFE_WEIGHTS_INDEX_NAME,
+    SAFE_WEIGHTS_NAME,
+    WEIGHTS_INDEX_NAME,
+    WEIGHTS_NAME,
+)
 
 from ..custom_ops.attention_interface import CacheConfig
 from ..utils.logger import ad_logger
@@ -21,35 +27,16 @@ from .factory import ModelFactory, ModelFactoryRegistry
 
 
 @contextmanager
-def load_state_dict_with_assign():
-    """
-    Context manager that temporarily patches torch.nn.Module.load_state_dict
-    to use assign=True, which directly replaces parameters in the model with those
-    from the loaded state_dict, maintaining their data type and device placement.
-    """
-    # Save the original load_state_dict method
-    original_load_state_dict = torch.nn.Module.load_state_dict
-
-    # Define and apply the patched version
-    def load_state_dict_with_assign(
-        self, state_dict: Mapping[str, Any], strict: bool = True, assign: bool = False
-    ):
-        return original_load_state_dict(self, state_dict, strict=strict, assign=True)
-
-    # Apply the patch
-    torch.nn.Module.load_state_dict = load_state_dict_with_assign
-
-    try:
-        # Allow the context body to execute
-        yield
-    finally:
-        # Restore the original method, even if an exception occurred
-        torch.nn.Module.load_state_dict = original_load_state_dict
-
-
-@contextmanager
 def hf_load_state_dict_with_device(device: DeviceLikeType):
-    """Patch HF load_state_dict to use provided device."""
+    """Patch HF load_state_dict to use provided device.
+
+    NOTE (lucaslie): this function is called by ``load_checkpoint_in_model``. We provide the device
+    map here as a patch instead of going through ``load_checkpoint_in_model``. This is because
+    otherwise ``load_checkpoint_in_model`` will execute its own state_dict loading logic instead of
+    calling ``nn.Module.load_state_dict``. However, we rely on the state dict loading hooks in
+    ``nn.Module.load_state_dict`` to correctly load the weights. By providing the device map here,
+    we can ensure that ``load_checkpoint_in_model`` will call ``nn.Module.load_state_dict``.
+    """
     # save the original load_state_dict method
     original_load_state_dict = modeling.load_state_dict
 
@@ -187,8 +174,92 @@ class AutoModelForCausalLMFactory(ModelFactory):
             return None
         return self.autotokenizer_from_pretrained(self.model, **self.tokenizer_kwargs)
 
+    def _get_ignore_patterns(self, repo_id: str):
+        """Get the ignore patterns for the HF repo."""
+        ignore_patterns = ["*.pt", "*.pth"]
+        bin_pattern = "*.bin*"
+        safetensors_pattern = "*.safetensors*"
+        if self.skip_loading_weights:
+            ignore_patterns.extend([bin_pattern, safetensors_pattern])
+            return ignore_patterns
+
+        # now check if we can identify safetensors or bin ignore patterns from the repo
+        # make this totally fail-safe...
+        try:
+            validate_repo_id(repo_id)
+            api = HfApi()
+            repo_info = api.repo_info(repo_id)
+
+            # check files in the repo
+            files = [f.rfilename for f in repo_info.siblings]
+
+            # if we have safetensors we can ignore all bin files
+            if list(filter_repo_objects(items=files, allow_patterns=[safetensors_pattern])):
+                ignore_patterns.append(bin_pattern)
+        except:  # noqa: E722
+            pass
+
+        return ignore_patterns
+
+    def _get_checkpoint_file(self, checkpoint: Union[str, os.PathLike]) -> Union[str, os.PathLike]:
+        """Get the most relevant checkpoint file from the HF checkpoint directory.
+
+        Args:
+            checkpoint: The path to the checkpoint directory or file.
+
+        Returns:
+            The path to the most relevant checkpoint file.
+
+        Following order of precedence for the checkpoint file:
+
+            1. checkpoint is a file
+            2. checkpoint dir contains SAFE_WEIGHTS_INDEX_NAME
+            3. checkpoint dir contains SAFE_WEIGHTS_NAME
+            4. checkpoint dir contains WEIGHTS_INDEX_NAME
+            5. checkpoint dir contains WEIGHTS_NAME
+
+        """
+
+        if os.path.isfile(checkpoint):
+            return checkpoint
+
+        # Verify that checkpoint is a directory
+        if not os.path.isdir(checkpoint):
+            raise ValueError(
+                f"Checkpoint path '{checkpoint}' is neither a file nor a directory, or does not exist."
+            )
+
+        # now check which is the most relevant checkpoint file
+        safe_weights_index_path = os.path.join(checkpoint, SAFE_WEIGHTS_INDEX_NAME)
+        if os.path.isfile(safe_weights_index_path):
+            return safe_weights_index_path
+
+        safe_weights_path = os.path.join(checkpoint, SAFE_WEIGHTS_NAME)
+        if os.path.isfile(safe_weights_path):
+            return safe_weights_path
+
+        weights_index_path = os.path.join(checkpoint, WEIGHTS_INDEX_NAME)
+        if os.path.isfile(weights_index_path):
+            return weights_index_path
+
+        weights_path = os.path.join(checkpoint, WEIGHTS_NAME)
+        if os.path.isfile(weights_path):
+            return weights_path
+
+        raise ValueError(
+            f"Could not find any model weights in {checkpoint}. "
+            f"Expected one of the following files: {SAFE_WEIGHTS_INDEX_NAME}, {SAFE_WEIGHTS_NAME}, "
+            f"{WEIGHTS_INDEX_NAME}, or {WEIGHTS_NAME}."
+        )
+
     def prefetch_checkpoint(self):
-        """Prefetch checkpoint from a HF repo if needed."""
+        """Prefetch checkpoint from a HF repo if needed.
+
+        We support the native HF/torch formats in the following order of precedence:
+
+            1. safetensors
+            2. pytorch_model.bin
+        """
         # already prefetched
         if self._prefetched_path:
             return
@@ -200,12 +271,8 @@ class AutoModelForCausalLMFactory(ModelFactory):
         except HFValidationError:
             is_hf_repo = False
         if is_hf_repo:
-            # we don't expect to use bin files or pt/pth checkpoint files (they are quite large)
-            ignore_patterns = ["*.bin", "*.pt", "*.pth"]
-            # we will also ignore the .safetensors files if we skip loading weights
-            if self.skip_loading_weights:
-                ignore_patterns.append("*.safetensors")
             ad_logger.info("Pre-fetching checkpoint directory from HF repo.")
+            ignore_patterns = self._get_ignore_patterns(self.model)
             fetched_dir = snapshot_download(self.model, ignore_patterns=ignore_patterns)
         else:
             fetched_dir = self.model
@@ -224,9 +291,11 @@ class AutoModelForCausalLMFactory(ModelFactory):
         # prefetch if needed
         self.prefetch_checkpoint()
 
+        # identify the most relevant checkpoint file
+        ckpt_file = self._get_checkpoint_file(self.model)
         # reuse the load checkpoint utility from accelerate
-        with load_state_dict_with_assign(), hf_load_state_dict_with_device(device):
-            load_checkpoint_and_dispatch(model, checkpoint=self.model)
+        with hf_load_state_dict_with_device(device):
+            load_checkpoint_in_model(model, checkpoint=ckpt_file)
 
     def _load_quantization_config(self):
         assert self.model

--- a/tensorrt_llm/_torch/auto_deploy/models/phi.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/phi.py
@@ -155,7 +155,12 @@ def get_model_from_config_patched(model_config, trust_remote_code):
         return model
     # handling: microsoft/Phi-3-mini-128k-instruct, microsoft/Phi-3-medium-128k-instruct
     # microsoft/Phi-3-mini-4k-instruct, microsoft/Phi-3-medium-4k-instruct
-    if not re.search(r"Phi-3-(?:mini|medium)", model_config._name_or_path):
+    # microsoft/Phi-3.5-mini-instruct
+    pattern = (
+        r"Phi-(?:3|3\.5)-"
+        r"(?:mini|medium)"
+    )
+    if not re.search(pattern, model_config._name_or_path):
         return model
     for _, module in model.named_modules():
         name = type(module).__name__

--- a/tensorrt_llm/_torch/auto_deploy/models/phi.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/phi.py
@@ -1,0 +1,171 @@
+"""
+Patch RotaryEmbedding implementations in Phi3/Phi4 models for torch.export compatibility.
+
+This module fixes two issues that break model export and state dict reloading:
+
+1. Phi3RotaryEmbedding:
+   Registers `inv_freq` as an empty buffer, leading to missing keys when loading the state dict.
+
+2. Phi3LongRoPEScaledRotaryEmbedding:
+   Dynamically initializes `short_factor` and `long_factor` during forward passes, which is incompatible
+   with torch.export.
+
+These patches move the initialization of `inv_freq` and `short_factor` into the class constructor and simplify LongRoPE
+to always use the `short_factor` path (removing dynamic updates).
+"""
+
+import math
+import re
+import types
+
+import torch
+from transformers import AutoModelForCausalLM
+
+_from_config_original = AutoModelForCausalLM.from_config
+
+
+# Additional steps in init phase to calculate and register inv_freq
+# Needed by microsoft/Phi-3-mini-128k-instruct, microsoft/Phi-3-medium-128k-instruct,
+# microsoft/Phi-3-mini-4k-instruct, microsoft/Phi-3-medium-4k-instruct
+def _patched_phi3_emb_init(
+    self,
+):
+    dev = torch.device("cpu")
+    inv = 1.0 / (
+        self.base
+        ** (torch.arange(0, self.dim, 2, dtype=torch.int64, device=dev).float() / self.dim)
+    )
+    self._buffers.pop("inv_freq", None)
+    self.register_buffer("inv_freq", inv, persistent=False)
+
+
+# copied from https://huggingface.co/microsoft/Phi-3-mini-4k-instruct/blob/main/modeling_phi3.py#L122
+# with an additional line: self.inv_freq = self.inv_freq.to(x.device)
+@torch.no_grad()
+def _patch_phi3_emb_forward(self, x, position_ids, seq_len=None):
+    self.inv_freq = self.inv_freq.to(x.device)
+    # x: [bs, num_attention_heads, seq_len, head_size]
+    if self.inv_freq is None:
+        self.inv_freq = 1.0 / (
+            self.base
+            ** (torch.arange(0, self.dim, 2, dtype=torch.int64, device=x.device).float() / self.dim)
+        )
+    inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1)
+    position_ids_expanded = position_ids[:, None, :].float()
+    # Force float32 since bfloat16 loses precision on long contexts
+    # See https://github.com/huggingface/transformers/pull/29285
+    device_type = x.device.type
+    device_type = device_type if isinstance(device_type, str) and device_type != "mps" else "cpu"
+    with torch.autocast(device_type=device_type, enabled=False):
+        freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
+        emb = torch.cat((freqs, freqs), dim=-1)
+        cos = emb.cos()
+        sin = emb.sin()
+    return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
+
+
+# Additional steps in init phase to calculate and register ext_factors
+# Needed by microsoft/Phi-3-mini-128k-instruct, microsoft/Phi-3-medium-128k-instruct
+def _patched_phi3_long_emb_init(
+    self,
+):
+    _patched_phi3_emb_init(self)
+    self.ext_factors = torch.tensor(
+        self.short_factor, dtype=torch.float32, device=torch.device("cpu")
+    )
+
+
+# Copied from https://huggingface.co/microsoft/Phi-3-mini-4k-instruct/blob/main/modeling_phi3.py#L151
+# with ext_factors calculation logic simplified
+# Needed by microsoft/Phi-3-mini-128k-instruct, microsoft/Phi-3-medium-128k-instruct
+@torch.no_grad()
+def _patch_phi3_long_emb_forward(self, x, position_ids, seq_len=None):
+    self.ext_factors = self.ext_factors.to(x.device)
+
+    inv_freq_shape = (
+        torch.arange(0, self.dim, 2, dtype=torch.int64, device=x.device).float() / self.dim
+    )
+    self.inv_freq = 1.0 / (self.ext_factors * self.base**inv_freq_shape)
+
+    inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1)
+    position_ids_expanded = position_ids[:, None, :].float()
+
+    # Force float32 since bfloat16 loses precision on long contexts
+    # See https://github.com/huggingface/transformers/pull/29285
+    device_type = x.device.type
+    device_type = device_type if isinstance(device_type, str) and device_type != "mps" else "cpu"
+    with torch.autocast(device_type=device_type, enabled=False):
+        freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
+        emb = torch.cat((freqs, freqs), dim=-1)
+
+        scale = self.max_position_embeddings / self.original_max_position_embeddings
+        if scale <= 1.0:
+            scaling_factor = 1.0
+        else:
+            scaling_factor = math.sqrt(
+                1 + math.log(scale) / math.log(self.original_max_position_embeddings)
+            )
+
+        cos = emb.cos() * scaling_factor
+        sin = emb.sin() * scaling_factor
+    return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
+
+
+# Simplify https://huggingface.co/microsoft/Phi-4-mini-instruct/blob/main/modeling_phi3.py#L383
+# needed by microsoft/Phi-4-mini-instruct
+def _patch_phi4_long_rope_update(self, position_ids, device):
+    self.original_inv_freq = self.original_inv_freq.to(device)
+    self.register_buffer("inv_freq", self.original_inv_freq, persistent=False)
+
+
+# Remove the @dynamic_rope_update decorator from transformers.models.phi3.modeling_phi3.Phi3RotaryEmbedding.forward
+# needed by microsoft/Phi-4-mini-reasoning
+@torch.no_grad()
+def _patch_phi3_emb_with_decorator_forward(self, x, position_ids):
+    inv_freq_expanded = (
+        self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+    )
+    position_ids_expanded = position_ids[:, None, :].float()
+    device_type = (
+        x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+    )
+    with torch.autocast(device_type=device_type, enabled=False):  # Force float32
+        freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
+        emb = torch.cat((freqs, freqs), dim=-1)
+        cos = emb.cos() * self.attention_scaling
+        sin = emb.sin() * self.attention_scaling
+    return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
+
+
+def get_model_from_config_patched(model_config, trust_remote_code):
+    model = _from_config_original(model_config, trust_remote_code=trust_remote_code)
+    if re.search(r"Phi-4-mini-instruct", model_config._name_or_path):
+        for _, module in model.named_modules():
+            name = type(module).__name__
+            if name == "Phi3RotaryEmbedding":
+                module._longrope_frequency_update = types.MethodType(
+                    _patch_phi4_long_rope_update, module
+                )
+        return model
+    if re.search(r"Phi-4-mini-reasoning", model_config._name_or_path):
+        for _, module in model.named_modules():
+            name = type(module).__name__
+            if name == "Phi3RotaryEmbedding":
+                module.forward = types.MethodType(_patch_phi3_emb_with_decorator_forward, module)
+        return model
+    # handling: microsoft/Phi-3-mini-128k-instruct, microsoft/Phi-3-medium-128k-instruct
+    # microsoft/Phi-3-mini-4k-instruct, microsoft/Phi-3-medium-4k-instruct
+    if not re.search(r"Phi-3-(?:mini|medium)", model_config._name_or_path):
+        return model
+    for _, module in model.named_modules():
+        name = type(module).__name__
+        if name == "Phi3RotaryEmbedding":
+            _patched_phi3_emb_init(module)
+            module.forward = types.MethodType(_patch_phi3_emb_forward, module)
+        elif name in ("Phi3LongRoPEScaledRotaryEmbedding", "Phi3SuScaledRotaryEmbedding"):
+            _patched_phi3_long_emb_init(module)
+            module.forward = types.MethodType(_patch_phi3_long_emb_forward, module)
+    return model
+
+
+AutoModelForCausalLM.from_config = get_model_from_config_patched

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -90,6 +90,12 @@ class ADEngine(ModelEngine):
     ):
         """Build the ADEngine using the AutoDeployConfig that gets passed through from the LLM."""
 
+        # update device to contain the current default device if it's in cuda
+        device = torch.device(device)
+        if device.type == "cuda" and device.index is None:
+            device = torch.device(f"cuda:{torch.cuda.current_device()}")
+        device = str(device)
+
         # construct model factory
         model_kwargs = {"max_position_embeddings": seq_info.max_seq_len, **ad_config.model_kwargs}
         factory = ModelFactoryRegistry.get(ad_config.model_factory)(

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -232,6 +232,9 @@ class ADEngine(ModelEngine):
 
         return {"logits": logits_flat}
 
+    def __del__(self):
+        dist.cleanup()
+
 
 def create_autodeploy_executor(
     executor_config: ExecutorConfig, checkpoint_dir: str = None, engine_dir: str = None

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -232,9 +232,6 @@ class ADEngine(ModelEngine):
 
         return {"logits": logits_flat}
 
-    def __del__(self):
-        dist.cleanup()
-
 
 def create_autodeploy_executor(
     executor_config: ExecutorConfig, checkpoint_dir: str = None, engine_dir: str = None

--- a/tensorrt_llm/_torch/auto_deploy/shim/interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/interface.py
@@ -28,19 +28,9 @@ class CachedSequenceInterface:
         return (*self.info.args, *self._caches.values())
 
     @property
-    def args_original(self) -> Tuple[torch.Tensor, ...]:
-        """Return the original graph arguments expected by the model."""
-        return self.info.args_original
-
-    @property
     def dynamic_shapes(self) -> Tuple[Dict[int, Any], ...]:
         """Return the dynamic shapes of all graph arguments owned by this interface (all static)."""
         return self.info.dynamic_shapes + ({},) * len(self._caches)
-
-    @property
-    def original_dynamic_shapes(self) -> Tuple[Dict[int, Any], ...]:
-        """Return the dynamic shapes of the original graph arguments."""
-        return self.info.original_dynamic_shapes
 
     def to(self, *args, **kwargs) -> None:
         self.info.to(*args, **kwargs)

--- a/tensorrt_llm/_torch/auto_deploy/transformations/_graph.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/_graph.py
@@ -1,7 +1,7 @@
 """Graph-related utilities for transformations."""
 
 from contextlib import contextmanager
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Iterator, Optional, Tuple
 
 import torch
 import torch.nn as nn
@@ -17,6 +17,7 @@ from torch.fx.passes.tools_common import legalize_graph
 from torch.utils._pytree import _LEAF_SPEC
 
 from ..utils.logger import ad_logger
+from ..utils.node_utils import is_op
 
 
 def get_buffers_and_params(model: nn.Module) -> Dict[str, torch.Tensor]:
@@ -89,14 +90,19 @@ def lift_to_meta(model: nn.Module, strict_missing: bool = True, strict_unexpecte
         )
 
 
-def move_to_device(gm: fx.GraphModule, device: DeviceLikeType) -> fx.GraphModule:
-    """Move the entire graph module to the specified device.
+def named_graphmodules(gm: fx.GraphModule) -> Iterator[Tuple[str, fx.GraphModule]]:
+    """Yield (name, submodule) for every fx.GraphModule inside gm (including gm itself)."""
+    for name, m in gm.named_modules():
+        if isinstance(m, fx.GraphModule):
+            yield name, m
 
+
+def _move_single_gm_to_device(
+    gm: GraphModule, device: torch.device, recompile_graph: bool = False
+) -> None:
+    """Move one GraphModule and its nodes to the specified device in-place.
     Partially inspired by https://github.com/pytorch/pytorch/blob/05cb98f91d49df9eadfcb3fc29bbd1b621d88860/torch/export/passes/__init__.py#L11
     """
-    # get device
-    device = torch.device(device)
-
     # move state dict
     gm.to(device)
 
@@ -106,11 +112,31 @@ def move_to_device(gm: fx.GraphModule, device: DeviceLikeType) -> fx.GraphModule
             kwargs = node.kwargs.copy()
             kwargs["device"] = device
             node.kwargs = kwargs
+
+        if is_op(node, torch.ops.aten.to.device):
+            args = list(node.args)
+            args[1] = device
+            node.args = tuple(args)
+
         # move all the tensor metadata
         node.meta["val"] = pytree.tree_map(
             lambda v: v.to(device) if isinstance(v, torch.Tensor) else v,
             node.meta.get("val"),
         )
+    if recompile_graph:
+        # recompile graph to update self generated codes in subgraph
+        gm.graph.lint()
+        gm.recompile()
+
+
+def move_to_device(gm: fx.GraphModule, device: DeviceLikeType) -> fx.GraphModule:
+    """Move the entire graph module and all sub-GraphModules to the specified device."""
+    # get device
+    device = torch.device(device)
+
+    for _, subgm in reversed(list(named_graphmodules(gm))):
+        # recompile graph to update self generated codes in subgraph
+        _move_single_gm_to_device(subgm, device, subgm is not gm)
 
 
 def _is_impure_node(node: Node) -> bool:
@@ -128,26 +154,9 @@ def _is_impure_node(node: Node) -> bool:
             node.target._nondeterministic_seeded = True
 
 
-def canonicalize_graph(
+def _canonicalize_single_gm(
     gm: GraphModule, shape_prop: bool = False, args_static: Optional[Tuple[Any, ...]] = None
 ) -> GraphModule:
-    """Canonicalize the graph of the given GraphModule.
-
-    Args:
-        gm: The GraphModule to canonicalize.
-        shape_prop: Whether to run shape propagation. Shape propagation tends to be finicky and
-            slow, so we only run it optionally.
-        args_static: A tuple of static arguments to use for shape propagation. Shape propagation
-            requires all inputs to the graph ("placeholder" nodes) to have metadata with an
-            appropriate FakeTensor argument (``node.meta["val"]``). ``args_static`` can be used to
-            infer static FakeTensor information if some placeholder nodes do not have metadata.
-            When ``meta["val"]`` is available, it will take precedence over ``args_static``.
-
-    Returns:
-        The canonicalized (cleaned-up) GraphModule.
-    """
-    ad_logger.debug(f"Before canonicalizing: {gm}")
-
     # clean up graph (needs to be done repeatedly until no more dead code)
     gm.graph.eliminate_dead_code(is_impure_node=_is_impure_node)
 
@@ -181,6 +190,32 @@ def canonicalize_graph(
 
     # lint the graph
     gm.graph.lint()
+
+
+def canonicalize_graph(
+    gm: GraphModule, shape_prop: bool = False, args_static: Optional[Tuple[Any, ...]] = None
+) -> GraphModule:
+    """Canonicalize the graph of the given GraphModule.
+
+    Args:
+        gm: The GraphModule to canonicalize.
+        shape_prop: Whether to run shape propagation. Shape propagation tends to be finicky and
+            slow, so we only run it optionally.
+        args_static: A tuple of static arguments to use for shape propagation. Shape propagation
+            requires all inputs to the graph ("placeholder" nodes) to have metadata with an
+            appropriate FakeTensor argument (``node.meta["val"]``). ``args_static`` can be used to
+            infer static FakeTensor information if some placeholder nodes do not have metadata.
+            When ``meta["val"]`` is available, it will take precedence over ``args_static``.
+
+    Returns:
+        The canonicalized (cleaned-up) GraphModule.
+    """
+    ad_logger.debug(f"Before canonicalizing: {gm}")
+
+    for _, subgm in reversed(list(named_graphmodules(gm))):
+        _canonicalize_single_gm(
+            subgm, shape_prop=shape_prop, args_static=args_static if subgm is gm else None
+        )
 
     ad_logger.debug(f"After canonicalizing: {gm}")
 

--- a/tensorrt_llm/_torch/auto_deploy/transformations/export.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/export.py
@@ -129,7 +129,6 @@ def _deduplicate_params_and_buffers(gm: fx.GraphModule):
         submod, _, name = n.target.rpartition(".")
         t_target = getattr(gm.get_submodule(submod), name)
         targets[id(t_target)].append(n)
-
     # now replace all instances of the same tensor with the same get_attr node (idx 0 in the list)
     for nodes in targets.values():
         node_kept = nodes[0]
@@ -236,10 +235,76 @@ def add_missing_load_hooks(gm: fx.GraphModule, model: nn.Module) -> fx.GraphModu
         if mod_name in hooks:
             for hook in hooks.pop(mod_name).values():
                 mod._register_load_state_dict_pre_hook(hook.hook, with_module=hook.with_module)
-
     assert not (bool(hooks)), f"""Mismatch in names of exported and source modules with hooks.
         The following module names were not found in exported module {list(hooks.keys())}"""
+
     return gm
+
+
+def add_load_hook_for_aliased_params(gm: fx.GraphModule, model: nn.Module):
+    """
+    Add a load hook to handle aliased parameters in the model.
+
+    When parameters are aliased (multiple parameter names point to the same tensor),
+    we need to ensure all aliases get the same value during loading. This hook:
+    1. Identifies groups of aliased parameters
+    2. For each group, finds a valid parameter value from the state dict
+    3. Applies that value to all aliases in the group
+
+    Args:
+        gm: The graph module to add the hook to
+        model: The source model containing the original parameter aliases
+    """
+    # Find all parameter aliases in the source model
+    param_to_names = defaultdict(list)
+    for name, param in model.named_parameters(remove_duplicate=False):
+        param_to_names[id(param)].append(name)
+
+    # Filter to only groups with multiple aliases
+    aliased_groups = [names for names in param_to_names.values() if len(names) > 1]
+
+    if not aliased_groups:
+        return gm  # No aliases to handle
+
+    def find_valid_param_value(
+        state_dict: Dict[str, torch.Tensor], param_names: List[str]
+    ) -> Optional[torch.Tensor]:
+        """Find a valid parameter value from state dict for a group of aliased parameters.
+
+        Args:
+            state_dict: The state dict being loaded
+            param_names: List of parameter names that are aliases of each other
+
+        Returns:
+            A valid tensor value if found, None otherwise
+        """
+        # First try to find a non-meta tensor value
+        value = None
+        for name in param_names:
+            if name in state_dict:
+                value = state_dict[name]
+                if value.device.type != "meta":
+                    return value
+
+        return value
+
+    def aliasing_load_pre_hook(state_dict: Dict[str, torch.Tensor], prefix: str, *args, **kwargs):
+        """Load hook that ensures aliased parameters get the same value."""
+        for group in aliased_groups:
+            # Find a valid value for this group of aliases
+            value = find_valid_param_value(state_dict, group)
+            assert value is not None, (
+                f"No valid value found in state dict for aliased parameters: {group}"
+            )
+
+            # Apply the value to all aliases
+            for name in group:
+                state_dict[name] = value
+
+            ad_logger.debug(f"Applied value from {group[0]} to aliased parameters: {group}")
+
+    # Register the hook
+    gm._register_load_state_dict_pre_hook(aliasing_load_pre_hook)
 
 
 @torch.inference_mode()
@@ -332,6 +397,9 @@ def torch_export_to_gm(
 
     # clean up devices in the graph
     _clean_up_device_info(egm)
+
+    # Add load hook to correctly load parameters that are aliased in the source model.
+    add_load_hook_for_aliased_params(egm, model)
 
     # deduplicate params and buffers
     _deduplicate_params_and_buffers(egm)

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/fusion.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/fusion.py
@@ -9,6 +9,7 @@ from torch.fx import GraphModule, Node
 from ...utils.cuda_mem_tracker import cuda_memory_tracker
 from ...utils.logger import ad_logger
 from ...utils.node_utils import (
+    add_new_attribute_to_submodule,
     extract_param_names_from_lin_node,
     get_op_overload_packet,
     is_linear_op,
@@ -17,7 +18,7 @@ from ...utils.quantization_utils import QuantizationImpl
 from .._graph import canonicalize_graph
 
 
-def _insert_fused_gemm(gm: GraphModule, idx: int, parent_node: Node, linear_nodes: List[Node]):
+def _insert_fused_gemm(gm: GraphModule, parent_node: Node, linear_nodes: List[Node]):
     """Fuse GEMMs that have the same input activation.
 
     Below, is a simple example of how the fusion works:
@@ -39,12 +40,36 @@ def _insert_fused_gemm(gm: GraphModule, idx: int, parent_node: Node, linear_node
     keys_unfused = [extract_param_names_from_lin_node(n)[0] for n in linear_nodes]
     params_unfused = [gm.get_parameter(k) for k in keys_unfused]
     sizes_unfused = [p.size(0) for p in params_unfused]
-    key_fused = f"fused_weight_{idx}"
+
+    # Register each fused_weight in a uniquely-named submodule so unused ones
+    # can be cleaned up by `gm.delete_all_unused_submodules()`. Direct attributes
+    # are not deleted automatically.
+    new_weight_key = _fuse_keys(keys_unfused)
+    new_module_name, new_param_name = new_weight_key.rsplit(".", 1)
 
     quantization_impl = QuantizationImpl.create(linear_nodes[0])
 
     def fuse_weights(tensors: List[torch.Tensor]) -> torch.Tensor:
-        """Fuse weights of linear nodes."""
+        """Fuse weights from multiple linear nodes by concatenation.
+
+        Note:
+            This function may slightly increase CUDA memory usage due to PyTorch's caching allocator behavior,
+            which rounds allocations to reduce fragmentation. Allocations are typically rounded up to powers of two
+            with subdivisions controlled by the environment variable:
+            `CUDA_PYTORCH_CUDA_ALLOC_CONF=roundup_power2_divisions:N`.
+
+            Models with irregular parameter sizes, an odd number of fused weights, or
+            unusual num_ranks sharding across GPUs are more likely to trigger rounding up, increasing memory usage.
+            For example, with `CUDA_PYTORCH_CUDA_ALLOC_CONF=roundup_power2_divisions:8`,
+            4608 * 3072 * 2 bytes = 28311552 bytes = 2^20 * 27 bytes will be rounded to 29360128 = 2^24 * 7
+
+        References:
+            - PyTorch CUDA caching allocator implementation:
+            https://github.com/pytorch/pytorch/blob/main/c10/cuda/CUDACachingAllocator.cpp
+            #L2046 for the rounding algorithm
+            - Overview of the CUDA caching allocator:
+            https://zdevito.github.io/2022/08/04/cuda-caching-allocator.html"""
+
         return torch.cat(tensors, dim=0)
 
     def split_output(tensor: torch.Tensor) -> Tuple[torch.Tensor, ...]:
@@ -70,25 +95,28 @@ def _insert_fused_gemm(gm: GraphModule, idx: int, parent_node: Node, linear_node
         param_fused = nn.Parameter(weights_fused, requires_grad=False)
 
         for scale_name, buffer in buffer_fused.items():
-            fused_buffer_name = key_fused + "_" + scale_name
-            gm.register_buffer(fused_buffer_name, buffer)
+            fused_buffer_name = new_param_name + "_" + scale_name
+            add_new_attribute_to_submodule(
+                gm, new_module_name, fused_buffer_name, buffer, is_buffer=True
+            )
 
     else:
         param_fused = nn.Parameter(fuse_weights([gm.get_parameter(k) for k in keys_unfused]))
 
-    setattr(gm, key_fused, param_fused)
+    # Register fused parameters to new submodule
+    full_new_param_name = add_new_attribute_to_submodule(
+        gm, new_module_name, new_param_name, param_fused
+    )
 
     # Handle fused_kwargs for quantized fused gemm.
     fused_kwargs = dict(linear_nodes[0].kwargs)
 
     with gm.graph.inserting_before(linear_nodes[0]):
-        get_param_node = gm.graph.get_attr(key_fused, torch.Tensor)
+        get_param_node = gm.graph.get_attr(full_new_param_name, torch.Tensor)
         if quantization_impl:
             for scale_name in quantization_impl.scale_names():
-                # Creates new nodes for the fused scales so the unfused linear ops can be fully erased.
-                fused_kwargs[scale_name] = gm.graph.create_node(
-                    "get_attr", key_fused + "_" + scale_name
-                )
+                full_new_buffer_name = full_new_param_name + "_" + scale_name
+                fused_kwargs[scale_name] = gm.graph.create_node("get_attr", full_new_buffer_name)
 
     # add new linear node + split node
     with gm.graph.inserting_before(linear_nodes[0]):
@@ -107,7 +135,36 @@ def _insert_fused_gemm(gm: GraphModule, idx: int, parent_node: Node, linear_node
 
     # Clean up deleted modules to save GPU memory
     gm.graph.eliminate_dead_code()
-    gm.delete_all_unused_submodules()
+    for key_unfused in keys_unfused:
+        submodule_name, _ = key_unfused.rsplit(".", 1)
+        gm.delete_submodule(submodule_name)
+
+
+def _fuse_keys(keys: list[str]) -> str:
+    """
+    Fuse multiple dot-separated keys into a single key with a common prefix and fused middle segments.
+
+    For Example, ["model.layers.0.q.weight", "model.layers.0.k.weight", "model.layers.1.v.weight"]
+    is fused as 'model.layers.fused__0_q__0_k__1_v.weight'
+
+    """
+    token_lists = [key.split(".") for key in keys]
+    # Check that all keys have same suffix
+    assert len(set(tokens[-1] for tokens in token_lists)) == 1
+
+    common_prefix = []
+    for tokens in zip(*token_lists):
+        if len(set(tokens)) == 1:
+            common_prefix.append(tokens[0])
+        else:
+            break
+
+    fused_parts = ["_".join(tokens[len(common_prefix) : -1]) for tokens in token_lists]
+
+    fused_str = "__".join(fused_parts)
+    final_str = f"{'.'.join(common_prefix)}.fused__{fused_str}.{token_lists[0][-1]}"
+
+    return final_str
 
 
 def fuse_gemms(gm: GraphModule) -> GraphModule:
@@ -121,7 +178,6 @@ def fuse_gemms(gm: GraphModule) -> GraphModule:
             linear_nodes[node.args[0]].append(node)
 
     # fuse linear nodes
-    idx = -1
     with cuda_memory_tracker():
         for parent_node, lin_children in linear_nodes.items():
             if len(lin_children) < 2:
@@ -130,11 +186,10 @@ def fuse_gemms(gm: GraphModule) -> GraphModule:
             ad_logger.debug(
                 f"Found linear nodes to fuse: {lin_children} with parent node: {parent_node}"
             )
-            _insert_fused_gemm(gm, idx := idx + 1, parent_node, lin_children)
+            _insert_fused_gemm(gm, parent_node, lin_children)
 
         # clean up and return
         gm = canonicalize_graph(gm)
 
     ad_logger.debug("After GEMM fusion: " + str(gm))
-    torch.cuda.empty_cache()
     return gm

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/kvcache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/kvcache.py
@@ -1,7 +1,7 @@
 """Graph transformation to automatically add kv cache into fused MHA op."""
 
 import operator
-from typing import Dict, List
+from typing import Dict
 
 import torch
 from torch.fx import Graph, GraphModule, Node
@@ -14,8 +14,18 @@ from ...utils.node_utils import get_all_input_output_nodes, is_op
 from .._graph import add_graph_input, canonicalize_graph
 
 
-def check_in_out_nodes(egm: GraphModule) -> List[Node]:
-    """Check for input and output nodes in the graph and return 1st input node."""
+def update_in_out_nodes(egm: GraphModule, cm: CachedSequenceInterface) -> GraphModule:
+    """Modify the graph module by adding new input nodes and canonicalizing the graph.
+
+    The new input nodes correspond to the extra arguments needed for cached and flattened attention.
+
+    Args:
+        egm: The graph module to analyze and modify.
+        cm: Cached sequence interface containing extra argument information.
+
+    Returns:
+        The updated GraphModule with new input nodes and a canonicalized graph.
+    """
     # loop through nodes to get input, output, and get_attr nodes
     input_nodes, output_nodes = get_all_input_output_nodes(egm.graph)
 
@@ -27,7 +37,14 @@ def check_in_out_nodes(egm: GraphModule) -> List[Node]:
     assert len(output_nodes) == 1, "Expected exactly one output node!"
     assert len(output_nodes[0].all_input_nodes) == 1, "Expected to only return final tensor output!"
 
-    return input_nodes
+    # Activate and add extra argument nodes
+    new_args = cm.info.switch_to_cached_attn_inputs()
+    for name in new_args:
+        input_nodes.append(add_graph_input(egm, name))
+
+    egm = canonicalize_graph(egm)
+
+    return egm
 
 
 def insert_cached_attention(
@@ -35,7 +52,6 @@ def insert_cached_attention(
     cm: CachedSequenceInterface,
     attn_descriptor: AttentionDescriptor,
     cache_config: CacheConfig,
-    input_nodes: List[Node],
 ) -> GraphModule:
     """Replace uncached source attention node with corresponding cached attn node."""
     # Get all attention nodes and their info objects
@@ -58,14 +74,16 @@ def insert_cached_attention(
     ad_logger.info(f"Replacing attn op {source_op} with backend {attn_descriptor.__name__}")
     ad_logger.debug(f"Before inserting {attn_descriptor=} with cache: {egm}")
 
+    # retrieve input nodes
+    input_nodes, _ = get_all_input_output_nodes(egm.graph)
+
     # insert metadata computation and extract each argument as a node
     get_metadata, num_metadata = attn_descriptor.get_prepare_metadata_op()
-    with graph.inserting_before(source_attn_nodes[0]):
+    with graph.inserting_before(input_nodes[-1].next):
         ret_node = graph.call_function(
             get_metadata,
             args=(
                 *input_nodes,
-                *(add_graph_input(egm, name) for name in cm.info.extra_arg_names),
                 cm.info.page_size,
             ),
         )

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/kvcache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/kvcache.py
@@ -132,6 +132,10 @@ def resize_kv_cache(
         f"Current cache size: {current_cache_size}, Current num pages: {current_num_pages}"
     )
 
+    if free_mem_ratio == 0.0:
+        ad_logger.info(f"Skipping cache resize for {free_mem_ratio=}")
+        return
+
     try:
         # Let's run a forward pass to get the memory usage
         cm.info._set_max_num_tokens_sample()

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/rope.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/rope.py
@@ -53,7 +53,13 @@ import torch
 from torch.fx import GraphModule, Node
 
 from ...utils.logger import ad_logger
-from ...utils.node_utils import bfs, extract_output_tuple, identify_regions_between_residuals, is_op
+from ...utils.node_utils import (
+    bfs,
+    extract_op_args,
+    extract_output_tuple,
+    identify_regions_between_residuals,
+    is_op,
+)
 from .._graph import canonicalize_graph
 
 
@@ -159,14 +165,6 @@ def match_complex_rope(gm: GraphModule) -> GraphModule:
     return gm
 
 
-def _get_default_unsqueeze_dim(op):
-    schema = next(iter(op._schemas.values()))
-    for a in schema.arguments:
-        if a.name == "unsqueeze_dim" and a.has_default_value:
-            return a.default_value
-    raise RuntimeError(f"No default unsqueeze_dim on {op}")
-
-
 def match_rope_layout(gm: GraphModule, expected_layout: str = "bsnd") -> GraphModule:
     """
     Match and transform input and output of rope ops to the layout specified to meet requirements of optimized ops.
@@ -194,15 +192,18 @@ def match_rope_layout(gm: GraphModule, expected_layout: str = "bsnd") -> GraphMo
         if not is_op(node, rope_ops):
             continue
 
-        # TODO (fridah-nv): check this and use correctly utility
-        rope_op = next(op for op in rope_ops if is_op(node, op))
         if is_op(node, torch.ops.rope.torch_apply_rope_with_complex_freqs):
-            q_node, k_node, freqs_node, *rest = node.args
-            unsq = rest[0] if rest else _get_default_unsqueeze_dim(rope_op)
-
+            q_node, k_node, freqs_node, unsq = extract_op_args(
+                node,
+                "xq",  # argument name in schema
+                "xk",
+                "freqs_cis",
+                "unsqueeze_dim",
+            )
         else:
-            q_node, k_node, cos_node, sin_node, *rest = node.args
-            unsq = rest[0] if rest else _get_default_unsqueeze_dim(rope_op)
+            q_node, k_node, cos_node, sin_node, unsq = extract_op_args(
+                node, "q", "k", "cos", "sin", "unsqueeze_dim"
+            )
 
         if unsq == 2:
             current_layout = "bsnd"
@@ -399,7 +400,13 @@ def _optimize_explicit(
 def _optimize_complex(
     graph: GraphModule, node: Node, cache: Dict[Any, Node], pos_cache: Dict[str, Node]
 ) -> None:
-    q_node, k_node, inv_freq_node = node.args
+    # q_node, k_node, inv_freq_node = node.args
+    q_node, k_node, inv_freq_node = extract_op_args(
+        node,
+        "xq",  # argument name in schema
+        "xk",
+        "freqs_cis",
+    )
 
     # Sanity check on head_dim
     if not _validate_rope_inputs(q_node, k_node):

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/rope.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/rope.py
@@ -194,10 +194,12 @@ def match_rope_layout(gm: GraphModule, expected_layout: str = "bsnd") -> GraphMo
         if not is_op(node, rope_ops):
             continue
 
+        # TODO (fridah-nv): check this and use correctly utility
         rope_op = next(op for op in rope_ops if is_op(node, op))
         if is_op(node, torch.ops.rope.torch_apply_rope_with_complex_freqs):
             q_node, k_node, freqs_node, *rest = node.args
             unsq = rest[0] if rest else _get_default_unsqueeze_dim(rope_op)
+
         else:
             q_node, k_node, cos_node, sin_node, *rest = node.args
             unsq = rest[0] if rest else _get_default_unsqueeze_dim(rope_op)

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/sharding.py
@@ -88,7 +88,7 @@ def _insert_sharded_matmul(
         return torch.tensor_split(t, ws, dim=d)[r]
 
     num_users = num_users_of_weight_node(node)
-    if num_users > 1:
+    if num_users > 1 or num_users == 0:
         ad_logger.warning(
             f"Weight node {node} has {num_users} users. This is not supported for sharding. Skipping."
         )

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/sharding.py
@@ -31,6 +31,7 @@ from ...utils.node_utils import (
     identify_regions_between_residuals,
     is_linear_op,
     is_op,
+    num_users_of_weight_node,
 )
 from ...utils.quantization_utils import QuantizationImpl
 from .._graph import canonicalize_graph
@@ -86,6 +87,12 @@ def _insert_sharded_matmul(
     ) -> torch.Tensor:
         return torch.tensor_split(t, ws, dim=d)[r]
 
+    num_users = num_users_of_weight_node(node)
+    if num_users > 1:
+        ad_logger.warning(
+            f"Weight node {node} has {num_users} users. This is not supported for sharding. Skipping."
+        )
+        return
     # get weight and bias key
     weight_key, bias_key = extract_param_names_from_lin_node(node)
 

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/sharding.py
@@ -319,3 +319,126 @@ def column_row_shard(gm: GraphModule, rank: int, world_size: int) -> GraphModule
     gm = canonicalize_graph(gm)
     ad_logger.debug("After sharding: " + str(gm))
     return gm
+
+
+def dp_bmm_shard(gm: GraphModule, rank: int, world_size: int) -> GraphModule:
+    """A transformation to apply sharding to batched matrix multiplications in the graph.
+
+    We'll shard the BMM nodes by slicing the batch dimension of input tensors into world_size number of slices.
+    After sharding each BMM node, we'll insert an all_gather node to gather the results across the different devices.
+    This transformation handles any combination of tensor types for both inputs to the BMM operation.
+
+    We'll also assume that the inputs to BMM are broadcasted across the devices already.
+    """
+    ad_logger.info("Sharding graph for BMM")
+    ad_logger.debug("Before sharding graph: " + str(gm))
+
+    if world_size < 2:
+        ad_logger.info("Skipping sharding for single device")
+        return gm
+
+    assert isinstance(gm, GraphModule), "Expecting GraphModule"
+
+    def handle_tensor(
+        bmm_node: Node, tensor_node: Node, arg_idx: int, start_idx: int, end_idx: int
+    ):
+        """Unified helper function to shard either a parameter tensor or a dynamic tensor.
+
+        Args:
+            bmm_node: The BMM node that is being processed
+            tensor_node: The input tensor node to shard
+            arg_idx: The argument index of the tensor in the BMM node
+            start_idx: Start index for sharding
+            end_idx: End index for sharding
+        """
+
+        # Define slice function for the sharding
+        def slice_tensor(t: torch.Tensor) -> torch.Tensor:
+            return t[start_idx:end_idx]
+
+        if tensor_node.op == "get_attr":
+            # Handle parameter tensor
+            weight_key = tensor_node.target
+            modname, _, param_name = weight_key.rpartition(".")
+            param = gm.get_parameter(weight_key)
+
+            # Update the parameter with its shard
+            param_new = nn.Parameter(slice_tensor(param).detach().clone(), requires_grad=True)
+            gm.get_submodule(modname).register_parameter(param_name, param_new)
+
+            # Register load state dict hook
+            gm._register_load_state_dict_pre_hook(
+                partial(
+                    _load_hook,
+                    f_split=slice_tensor,
+                    param_key=weight_key,
+                    param_shape=param_new.shape,
+                )
+            )
+        else:
+            # Handle dynamic tensor
+            with gm.graph.inserting_before(bmm_node):
+                tensor_slice = gm.graph.call_function(
+                    torch.ops.aten.slice.Tensor, args=(tensor_node, 0, start_idx, end_idx, 1)
+                )
+            # Update BMM node to use the sliced tensor
+            bmm_node.update_arg(arg_idx, tensor_slice)
+
+    for node in gm.graph.nodes:
+        if not is_op(node, {torch.ops.aten.bmm}):
+            continue
+
+        ad_logger.debug(f"Found BMM node: {node}")
+
+        # Get the input tensors
+        lhs_tensor = node.args[0]
+        rhs_tensor = node.args[1]
+
+        # Check batch sizes from meta information
+        lhs_batch_size = lhs_tensor.meta["val"].shape[0]
+        rhs_batch_size = rhs_tensor.meta["val"].shape[0]
+
+        assert lhs_batch_size == rhs_batch_size, "Batch sizes of both tensors must match"
+        bmm_batch_size = lhs_batch_size
+
+        # Calculate balanced distribution
+        base_size = bmm_batch_size // world_size
+        remainder = bmm_batch_size % world_size
+
+        # NOTE: our torch.ops.dist.all_gather doesn't support uneven splits at the moment.
+        if remainder:
+            ad_logger.warning(
+                f"BMM batch size {bmm_batch_size} is not divisible by world size {world_size}. "
+                f"This will result in uneven distribution of work across devices. Skipping."
+            )
+            continue
+
+        # Calculate start and end indices for this rank
+        if rank < remainder:
+            start_idx = rank * (base_size + 1)
+            end_idx = start_idx + base_size + 1
+        else:
+            start_idx = remainder + rank * base_size
+            end_idx = start_idx + base_size
+
+        ad_logger.debug(
+            f"Sharding BMM for rank {rank}: batch_size={bmm_batch_size}, start_idx={start_idx}, end_idx={end_idx}"
+        )
+
+        # Handle both tensors
+        handle_tensor(node, lhs_tensor, 0, start_idx, end_idx)
+        handle_tensor(node, rhs_tensor, 1, start_idx, end_idx)
+
+        # Add all_gather node after BMM to collect results
+        with gm.graph.inserting_after(node):
+            gather_node = gm.graph.call_function(
+                torch.ops.dist.all_gather,
+                args=(node, 0),  # Gather along batch dimension (0)
+            )
+            node.replace_all_uses_with(gather_node)
+            gather_node.replace_input_with(gather_node, node)
+
+    # Canonicalize and return
+    gm = canonicalize_graph(gm)
+    ad_logger.debug("After sharding BMM: " + str(gm))
+    return gm

--- a/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
@@ -16,6 +16,7 @@ from .export import torch_export_to_gm
 from .library import (
     check_in_out_nodes,
     column_row_shard,
+    dp_bmm_shard,
     eliminate_redundant_transposes,
     ep_shard,
     fuse_allreduce_residual_rmsnorm,
@@ -145,6 +146,9 @@ class InferenceOptimizer:
 
         # run EP sharding across ranks
         egm = ep_shard(egm, local_rank, world_size)
+
+        # run BMM sharding across ranks
+        egm = dp_bmm_shard(egm, local_rank, world_size)
 
         # let's run a shape propagation pass to update the graph with correct meta values for
         # subsequent optimization passes

--- a/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
@@ -209,8 +209,7 @@ class InferenceOptimizer:
         # initialize cache on correct device
         cm.initialize_caches()
 
-        # Free memory ratio is hardcoded to 0.8 for now to ensure we have enough memory for graph
-        # capture.
+        # resize kv cache to occupy the available GPU memory up to free_mem_ratio
         resize_kv_cache(egm, cm, free_mem_ratio=self.ad_config.free_mem_ratio)
 
         ############################################################################################

--- a/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
@@ -20,7 +20,6 @@ from .library import (
     ep_shard,
     fuse_allreduce_residual_rmsnorm,
     fuse_collectives,
-    fuse_gemms,
     fuse_moe,
     insert_cached_attention,
     match_attention_layout,
@@ -172,7 +171,8 @@ class InferenceOptimizer:
         egm = fuse_moe(egm)
 
         # run GEMM fusion
-        egm = fuse_gemms(egm)
+        # TODO: this is causing OOMs, so we're disabling it for now
+        # egm = fuse_gemms(egm)
 
         # check if we can fuse allreduce, residual and rmsnorm
         egm = fuse_allreduce_residual_rmsnorm(egm)

--- a/tensorrt_llm/_torch/auto_deploy/utils/cuda_mem_tracker.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/cuda_mem_tracker.py
@@ -1,3 +1,4 @@
+import gc
 from contextlib import contextmanager
 
 import torch
@@ -18,6 +19,7 @@ def cuda_memory_tracker(logger=ad_logger):
         yield
     finally:
         torch.cuda.empty_cache()
+        gc.collect()
         mem_after = torch.cuda.memory_allocated()
         leaked = mem_after - mem_before
         if leaked > 0:

--- a/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
@@ -152,7 +152,7 @@ def extract_weight_node(mm_node: Node) -> int:
 def num_users_of_weight_node(mm_node: Node) -> int:
     """Returns the number of users of the weight node of the given matmul node."""
     weight_node = extract_weight_node(mm_node)
-    return len(weight_node.users)
+    return len(weight_node.users) if weight_node is not None else 0
 
 
 def extract_param_names_from_lin_node(mm_node: Node) -> Tuple[str, Optional[str]]:

--- a/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Callable, Iterable, List, Optional, Tuple, Union
 
 import torch
+import torch.nn as nn
 from torch._ops import OpOverload, OpOverloadPacket
 from torch.fx import Graph, GraphModule, Node
 
@@ -119,18 +120,15 @@ def is_match(node: Node, names_to_skip: List[str]):
     return False
 
 
-def extract_param_names_from_lin_node(mm_node: Node) -> Tuple[str, Optional[str]]:
-    """Extracts the name of the parameter associated with the given matmul node.
-
-    Args:
-        mm_node: Matmul node in the graph.
-    """
-    # List of nodes allowed in between a get_attr node and the matmul node
-    allowed_ops = {torch.ops.aten.to.dtype}
+def extract_weight_node(mm_node: Node) -> int:
+    """Extracts the weight node from the given matmul node."""
 
     def find_get_attr_node(node: Node) -> Node:
         """Recursively traverse inputs of allowed nodes to find a node with 'get_attr' op."""
         # If node is a get_attr node return node
+        # List of nodes allowed in between a get_attr node and the matmul node
+        allowed_ops = {torch.ops.aten.to.dtype}
+
         if node.op == "get_attr":
             return node
 
@@ -144,17 +142,30 @@ def extract_param_names_from_lin_node(mm_node: Node) -> Tuple[str, Optional[str]
                 return result
         return None
 
-    assert is_linear_op(mm_node, include_quantization=True), (
-        f"Expecting linear node, Found: {mm_node}"
-    )
-    # second arg is the weight
     weight_node = mm_node.args[1]
     # for modelopt quantized graph, there will be a quantize_op
     _, weight_params, _ = get_quantization_params_from_linear_node(mm_node)
     weight_node = weight_params.input_node if weight_params else weight_node
 
-    # Find the get_attr node for the weight node so that it can be slice.
-    weight_node = find_get_attr_node(weight_node)
+    return find_get_attr_node(weight_node)
+
+
+def num_users_of_weight_node(mm_node: Node) -> int:
+    """Returns the number of users of the weight node of the given matmul node."""
+    weight_node = extract_weight_node(mm_node)
+    return len(weight_node.users)
+
+
+def extract_param_names_from_lin_node(mm_node: Node) -> Tuple[str, Optional[str]]:
+    """Extracts the name of the parameter associated with the given matmul node.
+
+    Args:
+        mm_node: Matmul node in the graph.
+    """
+    assert is_linear_op(mm_node, include_quantization=True), (
+        f"Expecting linear node, Found: {mm_node}"
+    )
+    weight_node = extract_weight_node(mm_node)
 
     assert weight_node, "Cannot identify weight parameter of linear node."
 
@@ -340,3 +351,45 @@ def extract_output_tuple(node: Node, count: int = 2):
         )
         results.append(user_node)
     return results
+
+
+def is_chunk_or_slice_op(node: Node) -> bool:
+    """Check if the node is a chunk or slice op."""
+    target_ops = {
+        torch.ops.aten.slice,
+        torch.ops.aten.chunk,
+    }
+    return is_op(node, target_ops)
+
+
+def add_new_attribute_to_submodule(
+    gm: GraphModule,
+    new_submodule_name: str,
+    new_attr_name: str,
+    new_attr: torch.Tensor,
+    is_buffer: bool = False,
+) -> str:
+    """
+    Adds a new parameter or buffer to a submodule within gm.
+    If the submodule identified by new_submodule_name does not exist,
+    it will be created. Then the new parameter or buffer is added to the submodule
+    under the attribute new_attr_name.
+    Returns:
+        A string representing the full parameter/buffer name in the format "new_submodule_name.new_attr_name".
+    """
+    try:
+        submodule = gm.get_submodule(new_submodule_name)
+        ad_logger.debug(f"Found existing submodule '{new_submodule_name}'.")
+    except AttributeError:
+        result = gm.add_submodule(new_submodule_name, nn.Module())
+        ad_logger.debug(f"Added submodule '{new_submodule_name}' with result: {result}.")
+        submodule = gm.get_submodule(new_submodule_name)
+
+    if is_buffer:
+        submodule.register_buffer(new_attr_name, new_attr)
+        ad_logger.debug(f"Set new buffer '{new_attr_name}' in submodule '{new_submodule_name}'.")
+    else:
+        submodule.register_parameter(new_attr_name, new_attr)
+        ad_logger.debug(f"Set new parameter '{new_attr_name}' in submodule '{new_submodule_name}'.")
+
+    return f"{new_submodule_name}.{new_attr_name}"

--- a/tests/unittest/_torch/auto_deploy/integration/test_ad_build.py
+++ b/tests/unittest/_torch/auto_deploy/integration/test_ad_build.py
@@ -131,6 +131,19 @@ from utils.llm_data import llm_models_root
                 "compile_backend": "torch-opt",
             },
         ),
+        # Llama4 Scout Instruct
+        param_with_device_count(
+            4,
+            {
+                "model": _hf_model_dir_or_hub_id(
+                    f"{llm_models_root()}/Llama-4-Scout-17B-16E-Instruct",
+                    "meta-llama/Llama-4-Scout-17B-16E-Instruct",
+                ),
+                "model_factory": "AutoModelForImageTextToText",
+                "compile_backend": "torch-opt",
+                "attn_backend": "FlashInfer",
+            },
+        ),
     ],
 )
 def test_build_ad(world_size: Optional[int], config: Dict):

--- a/tests/unittest/_torch/auto_deploy/integration/test_ad_build.py
+++ b/tests/unittest/_torch/auto_deploy/integration/test_ad_build.py
@@ -129,6 +129,7 @@ from utils.llm_data import llm_models_root
                     "microsoft/Phi-3-mini-4k-instruct",
                 ),
                 "compile_backend": "torch-opt",
+                "attn_backend": "TritonWithFlattenedInputs",
             },
         ),
         # Llama4 Scout Instruct
@@ -140,7 +141,7 @@ from utils.llm_data import llm_models_root
                     "meta-llama/Llama-4-Scout-17B-16E-Instruct",
                 ),
                 "model_factory": "AutoModelForImageTextToText",
-                "compile_backend": "torch-opt",
+                "compile_backend": "torch-simple",
                 "attn_backend": "FlashInfer",
             },
         ),

--- a/tests/unittest/_torch/auto_deploy/integration/test_ad_build.py
+++ b/tests/unittest/_torch/auto_deploy/integration/test_ad_build.py
@@ -147,7 +147,6 @@ from utils.llm_data import llm_models_root
     ],
 )
 def test_build_ad(world_size: Optional[int], config: Dict):
-    pytest.skip("https://nvbugs/5289305")
     simple_config = SimpleConfig(**config)
     simple_config.world_size = world_size
     simple_config.free_mem_ratio = 0.01  # we don't need the cache and it may cause OOM issues

--- a/tests/unittest/_torch/auto_deploy/integration/test_ad_build.py
+++ b/tests/unittest/_torch/auto_deploy/integration/test_ad_build.py
@@ -120,17 +120,15 @@ from utils.llm_data import llm_models_root
                 "compile_backend": "torch-simple",
             },
         ),
-        # Deepseek-V3 with torch-simple backend + simple runtime + reduced number of layer + skip loading weights
+        # Phi3-mini-4k with torch-opt backend + simple runtime
         param_with_device_count(
-            4,
+            2,
             {
                 "model": _hf_model_dir_or_hub_id(
-                    f"{llm_models_root()}/DeepSeek-V3",
-                    "deepseek-ai/DeepSeek-V3",
+                    f"{llm_models_root()}/Phi-3/Phi-3-mini-4k-instruct",
+                    "microsoft/Phi-3-mini-4k-instruct",
                 ),
-                "compile_backend": "torch-simple",
-                "model_kwargs": {"num_hidden_layers": 5},
-                "skip_loading_weights": "True",
+                "compile_backend": "torch-opt",
             },
         ),
     ],

--- a/tests/unittest/_torch/auto_deploy/integration/test_ad_build.py
+++ b/tests/unittest/_torch/auto_deploy/integration/test_ad_build.py
@@ -120,6 +120,19 @@ from utils.llm_data import llm_models_root
                 "compile_backend": "torch-simple",
             },
         ),
+        # Deepseek-V3 with torch-simple backend + simple runtime + reduced number of layer + skip loading weights
+        param_with_device_count(
+            4,
+            {
+                "model": _hf_model_dir_or_hub_id(
+                    f"{llm_models_root()}/DeepSeek-V3",
+                    "deepseek-ai/DeepSeek-V3",
+                ),
+                "compile_backend": "torch-simple",
+                "model_kwargs": {"num_hidden_layers": 5},
+                "skip_loading_weights": "True",
+            },
+        ),
     ],
 )
 def test_build_ad(world_size: Optional[int], config: Dict):

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/test_ad_build_small_multi.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/test_ad_build_small_multi.py
@@ -78,6 +78,35 @@ from utils.llm_data import llm_models_root
                 "skip_loading_weights": "True",
             },
         ),
+        # small llama4-scout model with world_size 1 (processes are spawned)
+        (
+            2,
+            {
+                "model": _hf_model_dir_or_hub_id(
+                    f"{llm_models_root()}/Llama-4-Scout-17B-16E-Instruct",
+                    "meta-llama/Llama-4-Scout-17B-16E-Instruct",
+                ),
+                "model_factory": "AutoModelForImageTextToText",
+                "runtime": "demollm",
+                "attn_backend": "FlashInfer",
+                "compile_backend": "torch-opt",
+                "customize_tokenizer": True,
+                "model_kwargs": {
+                    "text_config": {
+                        "num_hidden_layers": 2,
+                        "head_dim": 64,
+                        "Hidden_size": 512,
+                        "intermediate_size": 2048,
+                        "intermediate_size_mlp": 2048,
+                        "num_attention_heads": 16,
+                        "num_key_value_heads": 8,
+                    },
+                    "vision_config": {
+                        "num_hidden_layers": 2,
+                    },
+                },
+            },
+        ),
     ],
 )
 def test_build_ad(world_size: Optional[int], config: Dict):

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/test_ad_build_small_multi.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/test_ad_build_small_multi.py
@@ -54,6 +54,30 @@ from utils.llm_data import llm_models_root
                 "model_kwargs": {"num_hidden_layers": 2},
             },
         ),
+        # small deepseek-v3 model with world_size 4
+        (
+            2,
+            {
+                "model": _hf_model_dir_or_hub_id(
+                    f"{llm_models_root()}/DeepSeek-V3",
+                    "deepseek-ai/DeepSeek-V3",
+                ),
+                "runtime": "demollm",
+                "attn_backend": "TritonWithFlattenedInputs",
+                "compile_backend": "torch-simple",
+                "model_kwargs": {
+                    "num_hidden_layers": 6,
+                    "hidden_size": 32,
+                    "max_position_embeddings": 2048,
+                    "intermediate_size": 16,
+                    "moe_intermediate_size": 16,
+                    "n_routed_experts": 16,
+                    "num_attention_heads": 8,
+                    "num_key_value_heads": 4,
+                },
+                "skip_loading_weights": "True",
+            },
+        ),
     ],
 )
 def test_build_ad(world_size: Optional[int], config: Dict):

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_bmm_sharding.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_bmm_sharding.py
@@ -1,0 +1,84 @@
+"""Tests for basic graph sharding."""
+
+from functools import partial
+
+import pytest
+import torch
+import torch.nn as nn
+from _dist_test_utils import get_device_counts
+from _graph_test_helpers import run_test
+
+import tensorrt_llm._torch.auto_deploy.distributed.common as dist_common
+from tensorrt_llm._torch.auto_deploy.transformations.library.sharding import dp_bmm_shard
+from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
+
+
+class BMM(nn.Module):
+    def __init__(self, num_experts, num_features):
+        super().__init__()
+        self.num_experts = num_experts
+        self.num_features = num_features
+        self.gate_up_proj = nn.Parameter(
+            torch.randn(self.num_experts, self.num_features, 2 * self.num_features)
+        )
+        self.down_proj = nn.Parameter(
+            torch.randn((self.num_experts, self.num_features, self.num_features))
+        )
+        self.act_fn = torch.nn.functional.relu
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """
+        This should really not be run on a single machine, as we are reaching compute bound:
+        - the inputs are expected to be "sorted" per expert already.
+        - the weights are viewed with another dim, to match num_expert, 1, shape * num_tokens, shape
+
+        Args:
+            hidden_states (torch.Tensor): (batch_size * token_num, hidden_size)
+            selected_experts (torch.Tensor): (batch_size * token_num, top_k)
+            routing_weights (torch.Tensor): (batch_size * token_num, top_k)
+        Returns:
+            torch.Tensor
+        """
+        hidden_states = hidden_states.view(self.num_experts, -1, self.num_features)
+        gate_up = torch.bmm(hidden_states, self.gate_up_proj)
+        gate, up = gate_up.chunk(2, dim=-1)  # not supported for DTensors
+        next_states = torch.bmm((up * self.act_fn(gate)), self.down_proj)
+        next_states = next_states.view(-1, self.num_features)
+        return next_states
+
+
+def _run_job(
+    rank: int,
+    world_size: int,
+    num_experts_multiplier: int,
+) -> None:
+    # init model and input
+    batch_size = 4
+    num_features = 10
+    num_experts = num_experts_multiplier * world_size
+    model = BMM(num_experts, num_features).to(device="cuda", dtype=torch.float16)
+    x = torch.randn(batch_size * num_experts, num_features, device="cuda", dtype=torch.float16)
+
+    def _get_expected_num_params(num_p_og: int) -> int:
+        num_params = num_p_og // world_size
+        return num_params
+
+    # now run the test
+    op_expected = getattr(torch.ops.dist, "all_gather")
+    run_test(
+        model,
+        x,
+        transform=partial(dp_bmm_shard, rank=rank, world_size=world_size),
+        check_transformed_graph=lambda gm: any(is_op(n, op_expected) for n in gm.graph.nodes)
+        == (world_size > 1),
+        _get_expected_num_params=_get_expected_num_params,
+    )
+
+
+@pytest.mark.parametrize("num_experts_multiplier", [1, 2])
+@pytest.mark.parametrize("device_count", get_device_counts())
+def test_sharding(device_count: int, num_experts_multiplier: int):
+    dist_common.spawn_multiprocess_job(
+        job=partial(_run_job, num_experts_multiplier=num_experts_multiplier),
+        size=device_count,
+    )

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_hf.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_hf.py
@@ -9,7 +9,6 @@ from transformers.models.llama4.configuration_llama4 import Llama4Config
 from tensorrt_llm._torch.auto_deploy.models.hf import (
     AutoModelForCausalLMFactory,
     hf_load_state_dict_with_device,
-    load_state_dict_with_assign,
 )
 
 
@@ -17,36 +16,6 @@ class SimpleModel(nn.Module):
     def __init__(self):
         super().__init__()
         self.linear = nn.Linear(10, 10)
-
-
-def test_load_state_dict_with_assign():
-    """Test that load_state_dict_with_assign correctly patches torch.nn.Module.load_state_dict."""
-    # Instead of trying to test the implementation details of the context manager,
-    # let's focus on testing its behavior - that it causes assign=True to be used
-
-    # First, let's check the behavior when assign=True is used directly
-    model1 = SimpleModel()
-    model2 = SimpleModel()
-
-    # Create a state dict with modified parameters
-    new_weight = torch.randn_like(model1.linear.weight)
-    new_bias = torch.randn_like(model1.linear.bias)
-    state_dict = {"linear.weight": new_weight, "linear.bias": new_bias}
-
-    # Load with assign=True explicitly
-    model1.load_state_dict(state_dict, assign=True)
-
-    # Now load with the context manager
-    with load_state_dict_with_assign():
-        model2.load_state_dict(state_dict)
-
-    # Both models should have identical parameters
-    assert torch.all(model1.linear.weight == model2.linear.weight)
-    assert torch.all(model1.linear.bias == model2.linear.bias)
-
-    # And both should match the new values
-    assert torch.all(model1.linear.weight == new_weight)
-    assert torch.all(model2.linear.weight == new_weight)
 
 
 def test_hf_load_state_dict_with_device():

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
@@ -82,6 +82,35 @@ from utils.llm_data import llm_models_root
                 "model_kwargs": {"num_hidden_layers": 2},
             },
         ),
+        # small llama4-scout model with world_size 1 (processes are spawned)
+        (
+            1,
+            {
+                "model": _hf_model_dir_or_hub_id(
+                    f"{llm_models_root()}/Llama-4-Scout-17B-16E-Instruct",
+                    "meta-llama/Llama-4-Scout-17B-16E-Instruct",
+                ),
+                "model_factory": "AutoModelForImageTextToText",
+                "runtime": "demollm",
+                "attn_backend": "FlashInfer",
+                "compile_backend": "torch-opt",
+                "customize_tokenizer": True,
+                "model_kwargs": {
+                    "text_config": {
+                        "num_hidden_layers": 2,
+                        "head_dim": 64,
+                        "Hidden_size": 512,
+                        "intermediate_size": 2048,
+                        "intermediate_size_mlp": 2048,
+                        "num_attention_heads": 16,
+                        "num_key_value_heads": 8,
+                    },
+                    "vision_config": {
+                        "num_hidden_layers": 2,
+                    },
+                },
+            },
+        ),
     ],
 )
 def test_build_ad(world_size: Optional[int], config: Dict):

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
@@ -68,6 +68,30 @@ from utils.llm_data import llm_models_root
                 "model_kwargs": {"num_hidden_layers": 2},
             },
         ),
+        # small deepseekv3 model with world_size 1 (processes are spawned)
+        (
+            1,
+            {
+                "model": _hf_model_dir_or_hub_id(
+                    f"{llm_models_root()}/DeepSeek-V3",
+                    "deepseek-ai/DeepSeek-V3",
+                ),
+                "runtime": "demollm",
+                "attn_backend": "TritonWithFlattenedInputs",
+                "compile_backend": "torch-simple",
+                "model_kwargs": {
+                    "num_hidden_layers": 6,
+                    "hidden_size": 32,
+                    "max_position_embeddings": 2048,
+                    "intermediate_size": 16,
+                    "moe_intermediate_size": 16,
+                    "n_routed_experts": 16,
+                    "num_attention_heads": 8,
+                    "num_key_value_heads": 4,
+                },
+                "skip_loading_weights": "True",
+            },
+        ),
     ],
 )
 def test_build_ad(world_size: Optional[int], config: Dict):

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
@@ -68,28 +68,18 @@ from utils.llm_data import llm_models_root
                 "model_kwargs": {"num_hidden_layers": 2},
             },
         ),
-        # small deepseekv3 model with world_size 1 (processes are spawned)
+        # small Phi3-mini-4k model with world_size 1
         (
             1,
             {
                 "model": _hf_model_dir_or_hub_id(
-                    f"{llm_models_root()}/DeepSeek-V3",
-                    "deepseek-ai/DeepSeek-V3",
+                    f"{llm_models_root()}/Phi-3/Phi-3-mini-4k-instruct",
+                    "microsoft/Phi-3-mini-4k-instruct",
                 ),
                 "runtime": "demollm",
                 "attn_backend": "TritonWithFlattenedInputs",
                 "compile_backend": "torch-simple",
-                "model_kwargs": {
-                    "num_hidden_layers": 6,
-                    "hidden_size": 32,
-                    "max_position_embeddings": 2048,
-                    "intermediate_size": 16,
-                    "moe_intermediate_size": 16,
-                    "n_routed_experts": 16,
-                    "num_attention_heads": 8,
-                    "num_key_value_heads": 4,
-                },
-                "skip_loading_weights": "True",
+                "model_kwargs": {"num_hidden_layers": 2},
             },
         ),
     ],

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_kv_cache.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_kv_cache.py
@@ -10,7 +10,7 @@ from tensorrt_llm._torch.auto_deploy.custom_ops.flashinfer_attention import Flas
 from tensorrt_llm._torch.auto_deploy.custom_ops.triton_attention import TritonWithFlattenedInputs
 from tensorrt_llm._torch.auto_deploy.shim.interface import CachedSequenceInterface
 from tensorrt_llm._torch.auto_deploy.transformations.export import torch_export, torch_export_to_gm
-from tensorrt_llm._torch.auto_deploy.transformations.library import check_in_out_nodes
+from tensorrt_llm._torch.auto_deploy.transformations.library import update_in_out_nodes
 from tensorrt_llm._torch.auto_deploy.transformations.library.kvcache import insert_cached_attention
 
 
@@ -135,11 +135,11 @@ def test_sdpa_with_kv_cache(dtype, attn_descriptor, gqa_config):
     cache_config = CacheConfig()
 
     # Get input node(s)
-    input_nodes = check_in_out_nodes(gm)
+    gm_transformed = update_in_out_nodes(gm, cm)
 
     # Apply the transformation
     gm_transformed = insert_cached_attention(
-        gm, cm, attn_descriptor=attn_descriptor, cache_config=cache_config, input_nodes=input_nodes
+        gm_transformed, cm, attn_descriptor=attn_descriptor, cache_config=cache_config
     )
     gm_transformed.to("cuda")
     cm.initialize_caches()


### PR DESCRIPTION
## Description

Test command:
```
python build_and_run_ad.py --config '{"world_size":1, "model":"apple/OpenELM-3B-Instruct", "attn_backend":"FlashInfer", "compile_backend":"torch-compile", "benchmark": false,"customize_tokenizer":true, "tokenizer_name":"meta-llama/Llama-2-7b-hf"}'  --model-kwargs '{}' 
```
Need to set both `customize_tokenizer` and `tokenizer_name`,

model list:
```
apple/OpenELM-3B-Instruct
apple/OpenELM-1_1B-Instruct
apple/OpenELM-270M-Instruct
apple/OpenELM-450M-Instruct
```

Prompt output is still not coherent after loading the tokenzier, e.g.
```
 In simple words and in a single sentence, explain the concept of gravity: : 
Gravity is the force that acts between two objects due to which all bodies with mass and accelerates them towards each other.
In simple words.
Gravity.
Gravity.
Gravity.
Gravity.
Gravity.
Gravity.
G.
G.
G.
G.
In physics.
In physics.
In physics.
In physics.
In physics.
In physics.
In
```

There's warning about attention_mask not supported in the log. Not sure if that's related.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
