### PR TITLE
[nvbug 5294316] fix: Fix queued request stats

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -551,9 +551,9 @@ class PyExecutor:
                 req_stat.dis_serving_stats.kv_cache_size = req.kv_cache_size
             return req_stat
 
-        def get_queued_req_stats(req: RequestQueueItem) -> RequestStats:
+        def get_queued_req_stats(request_id: int) -> RequestStats:
             req_stat = RequestStats()
-            req_stat.id = req.id
+            req_stat.id = request_id
             req_stat.context_prefill_position = 0
             req_stat.num_generated_tokens = 0
             req_stat.avg_num_decoded_tokens_per_iter = 0
@@ -571,9 +571,10 @@ class PyExecutor:
             req_stats.append(req_stat)
 
         for req in list(self.request_queue.queue):
-            req_stat = get_queued_req_stats(req)
-            req_stat.stage = RequestStage.QUEUED
-            req_stats.append(req_stat)
+            if isinstance(req, RequestQueueItem):
+                req_stat = get_queued_req_stats(req.id)
+                req_stat.stage = RequestStage.QUEUED
+                req_stats.append(req_stat)
 
         for req in finished_requests:
             req_stat = get_req_stats(req)

--- a/tests/unittest/llmapi/test_llm.py
+++ b/tests/unittest/llmapi/test_llm.py
@@ -1926,6 +1926,53 @@ def test_llm_get_stats(return_context_logits, enable_iter_req_stats):
                                enable_iter_req_stats=enable_iter_req_stats)
 
 
+def test_llm_get_queued_stats():
+
+    enable_iter_req_stats = True
+    use_overlap = False
+    tp_size = 1
+
+    num_requests = 10
+    repeated_prompts = ["A B C"] * num_requests
+
+    llm_args_extra = {}
+    sampling_args_extra = {}
+
+    from tensorrt_llm._torch import LLM as LLM_torch
+    from tensorrt_llm._torch.pyexecutor.config import PyTorchConfig
+    llm_args_extra["pytorch_backend_config"] = PyTorchConfig(
+        enable_iter_perf_stats=True,
+        enable_iter_req_stats=enable_iter_req_stats,
+        disable_overlap_scheduler=not use_overlap)
+    LLM_CLASS = LLM_torch
+
+    llm = LLM_CLASS(model=llama_model_path,
+                    kv_cache_config=global_kvcache_config,
+                    tensor_parallel_size=tp_size,
+                    fast_build=True,
+                    max_batch_size=1,
+                    **llm_args_extra)
+
+    max_tokens = 5
+    sampling_params = SamplingParams(max_tokens=max_tokens,
+                                     **sampling_args_extra)
+
+    for output in llm.generate(repeated_prompts,
+                               sampling_params=sampling_params):
+        print(output)
+
+    results = llm.get_stats(2)
+
+    for index, result in enumerate(results):
+        if "requestStats" in result:
+            for requestStat in result["requestStats"]:
+                if requestStat["stage"] == "QUEUED":
+                    has_queue_requests = True
+                    assert requestStat["numGeneratedTokens"] == 0
+
+    assert has_queue_requests
+
+
 def llm_get_stats_async_test_harness(tp_size: int = 1,
                                      return_context_logits: bool = False,
                                      pytorch_backend: bool = False,

--- a/tests/unittest/llmapi/test_llm.py
+++ b/tests/unittest/llmapi/test_llm.py
@@ -1933,17 +1933,17 @@ def test_llm_get_queued_stats():
     tp_size = 1
 
     num_requests = 10
-    repeated_prompts = ["A B C"] * num_requests
+    repeated_prompts = ["A B C D E F G H I J K L M"] * num_requests
 
     llm_args_extra = {}
     sampling_args_extra = {}
 
     from tensorrt_llm._torch import LLM as LLM_torch
-    from tensorrt_llm._torch.pyexecutor.config import PyTorchConfig
-    llm_args_extra["pytorch_backend_config"] = PyTorchConfig(
-        enable_iter_perf_stats=True,
-        enable_iter_req_stats=enable_iter_req_stats,
-        disable_overlap_scheduler=not use_overlap)
+
+    llm_args_extra.update(
+        dict(enable_iter_perf_stats=True,
+             enable_iter_req_stats=enable_iter_req_stats,
+             disable_overlap_scheduler=not use_overlap))
     LLM_CLASS = LLM_torch
 
     llm = LLM_CLASS(model=llama_model_path,
@@ -1953,22 +1953,34 @@ def test_llm_get_queued_stats():
                     max_batch_size=1,
                     **llm_args_extra)
 
-    max_tokens = 5
+    max_tokens = 10
     sampling_params = SamplingParams(max_tokens=max_tokens,
                                      **sampling_args_extra)
 
-    for output in llm.generate(repeated_prompts,
-                               sampling_params=sampling_params):
-        print(output)
+    max_tries = 10
+    has_queue_requests = False
 
-    results = llm.get_stats(2)
+    while not has_queue_requests and max_tries > 0:
+        max_tries -= 1
+        # Generate outputs, which will queue requests
+        for output in llm.generate(repeated_prompts,
+                                   sampling_params=sampling_params):
+            print(output)
 
-    for index, result in enumerate(results):
-        if "requestStats" in result:
-            for requestStat in result["requestStats"]:
-                if requestStat["stage"] == "QUEUED":
-                    has_queue_requests = True
-                    assert requestStat["numGeneratedTokens"] == 0
+        results = llm.get_stats(2)
+
+        for index, result in enumerate(results):
+            if "requestStats" in result:
+                for requestStat in result["requestStats"]:
+                    if requestStat["stage"] == "QUEUED":
+                        has_queue_requests = True
+                        assert requestStat["numGeneratedTokens"] == 0
+
+        if not has_queue_requests:
+            print("No queued requests found, retrying...")
+            asyncio.sleep(1)
+        else:
+            print("Found queued requests, breaking out of the loop.")
 
     assert has_queue_requests
 


### PR DESCRIPTION
# [nvbug 5294316] fix: Fix queued request stats

## Description

Fixed per-request stats for queued requests

## Test Coverage

Add unit test to cover

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
