### PR TITLE
[Architecture] Redesign Linear module

### DIFF
--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import enum
 import math
+from abc import abstractmethod
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Union
 
@@ -15,8 +18,6 @@ from tensorrt_llm.mapping import Mapping
 
 from ...models.modeling_utils import QuantConfig
 from ..utils import Fp4QuantizedTensor
-
-E2M1_MAX = 6.0
 
 
 class WeightMode(str, enum.Enum):
@@ -90,56 +91,554 @@ def load_weight_shard(
     return maybe_convert_to_torch_tensor(weight, tuple(slice_obj))
 
 
-def load_weight_scales_fp8_qdq(weights: List[Dict]):
-    input_scale, weight_scale = [], []
-    for w in weights:
-        if "input_scale" in w:
-            input_scale.append(w["input_scale"][...].reshape([]))
-        if "weight_scale" in w:
-            weight_scale.append(w["weight_scale"][...].reshape([]))
-    return input_scale, weight_scale
+def copy_weight(dst: Parameter, src: torch.Tensor):
+    # TODO check that is it a reasonable change or not
+    if dst.dtype != src.dtype:
+        src = src.to(dst.dtype)
+    assert dst.dtype == src.dtype, f"Incompatible dtype. dst: {dst.dtype}, src: {src.dtype}"
+    dst.data.copy_(src)
 
 
-def load_weight_scales_nvfp4(weights: List[Dict],
-                             tp_size: int = 1,
-                             tp_rank: int = 0,
-                             tp_mode: Optional[TensorParallelMode] = None):
-    # For concatenated weights (qkv_proj / up_gate_proj), the global scaling factors and input scaling factors should be shared.
-    input_scale = None
-    weight_scale_2 = None
-    weight_scale = []
+def load_weights_vanilla_helper(module: Linear, weights: List[Dict]):
+    assert len(weights) == 1
+    device = torch.device('cuda')
 
-    device = torch.device("cuda")
+    weight = load_weight_shard(weights[0]['weight'], module.tp_size,
+                               module.tp_rank, module.tp_mode, device)
+    copy_weight(module.weight, weight)
 
-    for w in weights:
-        if "input_scale" in w:
-            if input_scale is None:
-                input_scale = w["input_scale"][...]
+    if module.bias is not None:
+        bias = load_weight_shard(weights[0]['bias'], module.tp_size,
+                                 module.tp_rank, module.tp_mode, device)
+        copy_weight(module.bias, bias)
+
+
+def load_weights_fused_qkv_helper(
+        module: Linear,
+        weights: List[Dict]) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    assert len(weights) == 3
+    device = torch.device('cuda')
+
+    q_weight = load_weight_shard(weights[0]['weight'], module.tp_size,
+                                 module.tp_rank, module.tp_mode, device)
+    k_weight = load_weight_shard(weights[1]['weight'], module.tp_size,
+                                 module.tp_rank, module.tp_mode, device)
+    v_weight = load_weight_shard(weights[2]['weight'], module.tp_size,
+                                 module.tp_rank, module.tp_mode, device)
+
+    if module.bias is not None:
+        q_bias = load_weight_shard(weights[0]['bias'], module.tp_size,
+                                   module.tp_rank, module.tp_mode, device)
+        k_bias = load_weight_shard(weights[1]['bias'], module.tp_size,
+                                   module.tp_rank, module.tp_mode, device)
+        v_bias = load_weight_shard(weights[2]['bias'], module.tp_size,
+                                   module.tp_rank, module.tp_mode, device)
+        copy_weight(module.bias, torch.cat((q_bias, k_bias, v_bias)))
+
+    return (q_weight, k_weight, v_weight)
+
+
+def load_weights_fused_gate_up_helper(
+        module: Linear,
+        weights: List[Dict]) -> tuple[torch.Tensor, torch.Tensor]:
+    assert len(weights) == 2
+    device = torch.device('cuda')
+
+    gate_weight = load_weight_shard(weights[0]['weight'], module.tp_size,
+                                    module.tp_rank, module.tp_mode, device)
+    up_weight = load_weight_shard(weights[1]['weight'], module.tp_size,
+                                  module.tp_rank, module.tp_mode, device)
+    if module.bias is not None:
+        gate_bias = load_weight_shard(weights[0]['bias'], module.tp_size,
+                                      module.tp_rank, module.tp_mode, device)
+        up_bias = load_weight_shard(weights[1]['bias'], module.tp_size,
+                                    module.tp_rank, module.tp_mode, device)
+        copy_weight(module.bias, torch.cat((up_bias, gate_bias)))
+    return (gate_weight, up_weight)
+
+
+class LinearMethodBase:
+    """
+    Base class for all linear methods.
+    """
+
+    @abstractmethod
+    def create_weights(self, module: Linear, in_features: int,
+                       out_features: int, bias: bool, dtype: torch.dtype, *args,
+                       **kwargs):
+        raise NotImplementedError
+
+    @abstractmethod
+    def apply(self, module: Linear, input: torch.Tensor,
+              bias: Optional[torch.Tensor], *args, **kwargs):
+        raise NotImplementedError
+
+    def load_weights(self, module: Linear, weights: List[Dict],
+                     weight_mode: WeightMode):
+        """
+        Load weights from the checkpoint.
+        """
+        if weight_mode == WeightMode.VANILLA:
+            self.load_weights_vanilla(module, weights)
+        elif weight_mode == WeightMode.FUSED_QKV_LINEAR:
+            self.load_weights_fused_qkv_linear(module, weights)
+        elif weight_mode == WeightMode.FUSED_GATE_UP_LINEAR:
+            self.load_weights_fused_gate_up_linear(module, weights)
+        else:
+            raise ValueError(f'unsupported weight mode: {weight_mode}')
+
+    def load_weight_scales(self, weights: List[Dict], *args, **kwargs):
+        """
+        Load quantized weight scales from the checkpoint.
+        """
+
+    @abstractmethod
+    def load_weights_vanilla(self, module: Linear, weights: List[Dict]):
+        """
+        Load weights for the VANILLA weight mode.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def load_weights_fused_qkv_linear(self, module: Linear,
+                                      weights: List[Dict]):
+        """
+        Load weights for the FUSED_QKV_LINEAR weight mode.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def load_weights_fused_gate_up_linear(self, module: Linear,
+                                          weights: List[Dict]):
+        """
+        Load weights for the FUSED_GATE_UP_LINEAR weight mode.
+        """
+        raise NotImplementedError
+
+
+class UnquantizedLinearMethod(LinearMethodBase):
+
+    def create_weights(self, module: Linear, in_features: int,
+                       out_features: int, bias: bool, dtype: torch.dtype):
+        weight_shape = (out_features, in_features)
+        module.weight = Parameter(torch.empty(weight_shape, dtype=dtype),
+                                  requires_grad=False)
+
+        if bias:
+            module.bias = Parameter(torch.empty((out_features), dtype=dtype),
+                                    requires_grad=False)
+        else:
+            module.register_parameter("bias", None)
+
+    def apply(self, module: Linear, input: torch.Tensor,
+              bias: Optional[torch.Tensor]):
+        if module.use_custom_cublas_mm:
+            output = torch.ops.trtllm.cublas_mm(input,
+                                                module.weight.t(),
+                                                bias,
+                                                out_dtype=None)
+        else:
+            output = F.linear(input, module.weight, bias)
+        return output
+
+    def load_weights_vanilla(self, module: Linear, weights: List[Dict]):
+        load_weights_vanilla_helper(module, weights)
+
+    def load_weights_fused_qkv_linear(self, module: Linear,
+                                      weights: List[Dict]):
+        q_weight, k_weight, v_weight = load_weights_fused_qkv_helper(
+            module, weights)
+        fused_weight = torch.cat((q_weight, k_weight, v_weight))
+        copy_weight(module.weight, fused_weight)
+
+    def load_weights_fused_gate_up_linear(self, module: Linear,
+                                          weights: List[Dict]):
+        gate_weight, up_weight = load_weights_fused_gate_up_helper(
+            module, weights)
+        fused_weight = torch.cat((gate_weight, up_weight))
+        copy_weight(module.weight, fused_weight)
+
+
+class FP8QDQLinearMethod(LinearMethodBase):
+
+    def create_weights(self, module: Linear, in_features: int,
+                       out_features: int, bias: bool, dtype: torch.dtype):
+        weight_shape = (out_features, in_features)
+        module.weight = Parameter(torch.empty(weight_shape,
+                                              dtype=torch.float8_e4m3fn),
+                                  requires_grad=False)
+        module.weight_scale = Parameter(torch.tensor(1., dtype=torch.float32),
+                                        requires_grad=False)
+        module.input_scale = Parameter(torch.tensor(1., dtype=torch.float32),
+                                       requires_grad=False)
+        module.inv_input_scale = Parameter(torch.tensor(1.,
+                                                        dtype=torch.float32),
+                                           requires_grad=False)
+
+        if bias:
+            module.bias = Parameter(torch.empty((out_features), dtype=dtype),
+                                    requires_grad=False)
+        else:
+            module.register_parameter("bias", None)
+
+    def apply(self, module: Linear, input: torch.Tensor,
+              bias: Optional[torch.Tensor]):
+        cur_input_scale = module.input_scale
+        if input.dtype != torch.float8_e4m3fn:
+            if module.input_scale is not None:
+                # Static quantization
+                qinput, _ = torch.ops.tensorrt_llm.static_quantize_e4m3_per_tensor(
+                    input, module.input_scale)
             else:
-                assert input_scale == w["input_scale"][
-                    ...], "The input_scale should be same for all the weights"
-        if "weight_scale" in w:
-            ws = load_weight_shard(w["weight_scale"],
-                                   tp_size,
-                                   tp_rank,
-                                   tp_mode,
-                                   device=device).contiguous()
-            assert ws.dtype == torch.float8_e4m3fn  # TODO: or e8m0 for mxfp4 recipe?
-            weight_scale.append(ws.view(fp4_utils.float4_sf_dtype))
-        if "weight_scale_2" in w:
-            if weight_scale_2 is None:
-                weight_scale_2 = w["weight_scale_2"][...]
-            else:
-                assert weight_scale_2 == w["weight_scale_2"][
-                    ...], "The weight_scale_2 should be same for all the weights"
+                # Dynamic quantization
+                qinput, cur_input_scale = torch.ops.tensorrt_llm.quantize_e4m3_per_tensor(
+                    input)
+                cur_input_scale = cur_input_scale.to(torch.float32)
 
-    # Compute scaling factor and alpha required by GEMM kernels
-    # TODO: ModelOpt's o_proj.weight_scale_2 is bfloat16, which should be float32
-    alpha = input_scale.float() * weight_scale_2.float()
-    # modelopt ckpt stores amax/(448*6), convert to (448*6)/amax
-    input_scale = 1.0 / input_scale
+        else:
+            qinput = input
 
-    return input_scale, weight_scale, alpha
+        # This op does not support bias now.
+        output = torch.ops.trtllm.cublas_scaled_mm(
+            qinput,
+            module.weight.t(),
+            scale_a=cur_input_scale,
+            scale_b=module.weight_scale,
+            bias=None,
+            out_dtype=module.dtype or input.dtype,
+        )
+        if bias is not None:
+            output = output + bias
+        return output
+
+    def load_weight_scales(self, weights: List[Dict]):
+        input_scale, weight_scale = [], []
+        for w in weights:
+            if "input_scale" in w:
+                input_scale.append(w["input_scale"][...].reshape([]))
+            if "weight_scale" in w:
+                weight_scale.append(w["weight_scale"][...].reshape([]))
+        return input_scale, weight_scale
+
+    def load_weights_vanilla(self, module: Linear, weights: List[Dict]):
+        load_weights_vanilla_helper(module, weights)
+        input_scale, weight_scale = self.load_weight_scales(weights)
+        if len(input_scale) != 0:
+            # Static quantization
+            copy_weight(module.input_scale, input_scale[0])
+            module.inv_input_scale.data = 1.0 / module.input_scale
+        else:
+            # Dynamic quantization
+            module.input_scale = None
+            module.inv_input_scale = None
+        copy_weight(module.weight_scale, weight_scale[0])
+
+    def load_weights_fused_qkv_linear(self, module: Linear,
+                                      weights: List[Dict]):
+        q_weight, k_weight, v_weight = load_weights_fused_qkv_helper(
+            module, weights)
+
+        input_scale, weight_scale = self.load_weight_scales(weights)
+        if len(input_scale) != 0:
+            # Static quantization
+            copy_weight(module.input_scale, max(input_scale))
+        else:
+            # Dynamic quantization
+            module.input_scale = None
+        copy_weight(module.weight_scale, max(weight_scale))
+
+        q_weight = q_weight.to(module.dtype) * weight_scale[0]
+        k_weight = k_weight.to(module.dtype) * weight_scale[1]
+        v_weight = v_weight.to(module.dtype) * weight_scale[2]
+
+        fused_weight = torch.cat((q_weight, k_weight, v_weight))
+        fused_weight = (fused_weight / module.weight_scale).to(
+            torch.float8_e4m3fn)
+        copy_weight(module.weight, fused_weight)
+
+    def load_weights_fused_gate_up_linear(self, module: Linear,
+                                          weights: List[Dict]):
+        input_scale, weight_scale = self.load_weight_scales(weights)
+        if len(input_scale) != 0:
+            # Static quantization
+            copy_weight(module.input_scale, max(input_scale))
+        else:
+            # Dynamic quantization
+            module.input_scale = None
+        copy_weight(module.weight_scale, max(weight_scale))
+
+        gate_weight, up_weight = load_weights_fused_gate_up_helper(
+            module, weights)
+
+        gate_weight = gate_weight.to(module.dtype) * weight_scale[0]
+        up_weight = up_weight.to(module.dtype) * weight_scale[1]
+        fused_weight = torch.cat((gate_weight, up_weight))
+        fused_weight = (fused_weight / module.weight_scale).to(
+            torch.float8_e4m3fn)
+        copy_weight(module.weight, fused_weight)
+
+
+class FP8BlockScalesLinearMethod(LinearMethodBase):
+
+    def create_weights(self, module: Linear, in_features: int,
+                       out_features: int, bias: bool, dtype: torch.dtype):
+        weight_shape = (out_features, in_features)
+
+        module.weight = Parameter(torch.empty(weight_shape,
+                                              dtype=torch.float8_e4m3fn),
+                                  requires_grad=False)
+        scale_shape = (math.ceil(out_features / 128),
+                       math.ceil(in_features / 128))
+        module.weight_scale = Parameter(torch.empty(scale_shape,
+                                                    dtype=torch.float32),
+                                        requires_grad=False)
+        # Not really used for Gemm now.
+        # Only used to quantize output of FP8 attention.
+        module.input_scale = Parameter(torch.tensor(1., dtype=torch.float32),
+                                       requires_grad=False)
+        module.inv_input_scale = Parameter(torch.tensor(1.,
+                                                        dtype=torch.float32),
+                                           requires_grad=False)
+        if bias:
+            module.bias = Parameter(torch.empty((out_features), dtype=dtype),
+                                    requires_grad=False)
+        else:
+            module.register_parameter("bias", None)
+
+    def apply(self, module: Linear, input: torch.Tensor,
+              bias: Optional[torch.Tensor]):
+        if input.dtype == torch.float8_e4m3fn:
+            input = input.to(torch.bfloat16) * module.input_scale
+        assert input.dtype == torch.bfloat16
+
+        act_input_fp8, act_input_sf = torch.ops.trtllm.fp8_quantize_1x128(input)
+
+        output = torch.ops.trtllm.fp8_block_scaling_gemm(
+            act_input_fp8, module.weight, act_input_sf, module.weight_scale)
+        if bias is not None:
+            output = output + bias
+        return output
+
+    def _get_scale_name(self, weights: List[Dict]):
+        # `weight_scale_inv` for DS recipe and  `weight_scale` for ModelOpt recipe.
+        # Actually they hold identical values of data_amax / 448.
+        scale_name = "weight_scale_inv"
+        if scale_name not in weights[0]:
+            scale_name = "weight_scale"
+        return scale_name
+
+    def load_weights_vanilla(self, module: Linear, weights: List[Dict]):
+        load_weights_vanilla_helper(module, weights)
+
+        scale_name = self._get_scale_name(weights)
+        weight_scale = load_weight_shard(weights[0][scale_name], module.tp_size,
+                                         module.tp_rank, module.tp_mode)
+        copy_weight(module.weight_scale, weight_scale)
+        if "input_scale" in weights[0]:
+            copy_weight(module.input_scale, weights[0]["input_scale"])
+            module.inv_input_scale.data = 1.0 / module.input_scale
+
+    def load_weights_fused_qkv_linear(self, module: Linear,
+                                      weights: List[Dict]):
+        q_weight, k_weight, v_weight = load_weights_fused_qkv_helper(
+            module, weights)
+        fused_weight = torch.cat((q_weight, k_weight, v_weight))
+        copy_weight(module.weight, fused_weight)
+
+        scale_name = self._get_scale_name(weights)
+        q_scale = load_weight_shard(weights[0][scale_name], module.tp_size,
+                                    module.tp_rank, module.tp_mode)
+        k_scale = load_weight_shard(weights[1][scale_name], module.tp_size,
+                                    module.tp_rank, module.tp_mode)
+        v_scale = load_weight_shard(weights[2][scale_name], module.tp_size,
+                                    module.tp_rank, module.tp_mode)
+        fused_fp8_block_scale = torch.cat((q_scale, k_scale, v_scale))
+        copy_weight(module.weight_scale, fused_fp8_block_scale)
+
+    def load_weights_fused_gate_up_linear(self, module: Linear,
+                                          weights: List[Dict]):
+        gate_weight, up_weight = load_weights_fused_gate_up_helper(
+            module, weights)
+        fused_weight = torch.cat((gate_weight, up_weight))
+        copy_weight(module.weight, fused_weight)
+
+        scale_name = self._get_scale_name(weights)
+        left_scale = load_weight_shard(weights[0][scale_name], module.tp_size,
+                                       module.tp_rank, module.tp_mode)
+        right_scale = load_weight_shard(weights[1][scale_name], module.tp_size,
+                                        module.tp_rank, module.tp_mode)
+        fused_scale = torch.cat([left_scale, right_scale], dim=0)
+        copy_weight(module.weight_scale, fused_scale)
+
+
+class NVFP4LinearMethod(LinearMethodBase):
+
+    def create_weights(self, module: Linear, in_features: int,
+                       out_features: int, bias: bool, dtype: torch.dtype):
+        module.scaling_vector_size = 16
+        assert in_features % module.scaling_vector_size == 0, f"in_features {in_features} must be divisible by scaling_vector_size {module.scaling_vector_size}"
+
+        # Quantized weights
+        module.weight = Parameter(torch.empty([out_features, in_features // 2],
+                                              dtype=fp4_utils.float4_e2m1x2),
+                                  requires_grad=False)
+
+        # FP8 per-block scaling factors. dtype must be aligned with SF_DTYPE
+        # Padding is required. See computeSFSize in quantization.h
+        nrows = fp4_utils.pad_up(out_features, 128)
+        ncols = fp4_utils.pad_up(in_features // module.scaling_vector_size, 4)
+        module.weight_scale = Parameter(torch.empty(
+            [nrows * ncols], dtype=fp4_utils.float4_sf_dtype),
+                                        requires_grad=False)
+
+        # FP32 per-tensor global scaling factor = 448*6/amax_input
+        module.input_scale = Parameter(torch.empty([1], dtype=torch.float32),
+                                       requires_grad=False)
+        module.inv_input_scale = Parameter(torch.empty([1],
+                                                       dtype=torch.float32),
+                                           requires_grad=False)
+
+        # (amax_input * amax_weight) / (448*6 * 448*6)
+        module.alpha = Parameter(torch.empty([1], dtype=torch.float32),
+                                 requires_grad=False)
+
+        if bias:
+            module.bias = Parameter(torch.empty((out_features), dtype=dtype),
+                                    requires_grad=False)
+        else:
+            module.register_parameter("bias", None)
+
+    def apply(self, module: Linear, input: torch.Tensor,
+              bias: Optional[torch.Tensor]):
+        if isinstance(input, Fp4QuantizedTensor):
+            act_fp4, act_sf = input.fp4_tensor, input.scaling_factor
+        else:
+            act_fp4, act_sf = torch.ops.trtllm.fp4_quantize(
+                input, module.input_scale, module.scaling_vector_size, False)
+
+        output = torch.ops.trtllm.nvfp4_gemm(act_fp4, module.weight, act_sf,
+                                             module.weight_scale, module.alpha,
+                                             False, module.dtype)
+        if bias is not None:
+            output = output + bias
+        return output
+
+    def load_weight_scales(self,
+                           weights: List[Dict],
+                           tp_size: int = 1,
+                           tp_rank: int = 0,
+                           tp_mode: Optional[TensorParallelMode] = None):
+        # For concatenated weights (qkv_proj / up_gate_proj), the global scaling factors and input scaling factors should be shared.
+        input_scale = None
+        weight_scale_2 = None
+        weight_scale = []
+
+        device = torch.device("cuda")
+
+        for w in weights:
+            if "input_scale" in w:
+                if input_scale is None:
+                    input_scale = w["input_scale"][...]
+                else:
+                    assert input_scale == w["input_scale"][
+                        ...], "The input_scale should be same for all the weights"
+            if "weight_scale" in w:
+                ws = load_weight_shard(w["weight_scale"],
+                                       tp_size,
+                                       tp_rank,
+                                       tp_mode,
+                                       device=device).contiguous()
+                assert ws.dtype == torch.float8_e4m3fn  # TODO: or e8m0 for mxfp4 recipe?
+                weight_scale.append(ws.view(fp4_utils.float4_sf_dtype))
+            if "weight_scale_2" in w:
+                if weight_scale_2 is None:
+                    weight_scale_2 = w["weight_scale_2"][...]
+                else:
+                    assert weight_scale_2 == w["weight_scale_2"][
+                        ...], "The weight_scale_2 should be same for all the weights"
+
+        # Compute scaling factor and alpha required by GEMM kernels
+        # TODO: ModelOpt's o_proj.weight_scale_2 is bfloat16, which should be float32
+        alpha = input_scale.float() * weight_scale_2.float()
+        # modelopt ckpt stores amax/(448*6), convert to (448*6)/amax
+        input_scale = 1.0 / input_scale
+
+        return input_scale, weight_scale, alpha
+
+    def load_weights_vanilla(self, module: Linear, weights: List[Dict]):
+        load_weights_vanilla_helper(module, weights)
+
+        input_scale, weight_scale, alpha = self.load_weight_scales(
+            weights,
+            tp_size=module.tp_size,
+            tp_rank=module.tp_rank,
+            tp_mode=module.tp_mode)
+
+        assert len(weights) == 1
+        weight_scale = weight_scale[0]
+        # Swizzle weight scale
+        weight_scale = torch.ops.tensorrt_llm.nvfp4_block_scale_interleave(
+            weight_scale)
+
+        copy_weight(module.input_scale, input_scale)
+        copy_weight(module.weight_scale, weight_scale)
+        E2M1_MAX = 6.0
+        module.inv_input_scale.data = module.input_scale / E2M1_MAX
+        copy_weight(module.alpha, alpha)
+
+    def load_weights_fused_qkv_linear(self, module: Linear,
+                                      weights: List[Dict]):
+        q_weight, k_weight, v_weight = load_weights_fused_qkv_helper(
+            module, weights)
+
+        input_scale, weight_scales, alpha = self.load_weight_scales(
+            weights,
+            tp_size=module.tp_size,
+            tp_rank=module.tp_rank,
+            tp_mode=module.tp_mode)
+        # Swizzle weight scales after concatenation
+        weight_scale = torch.cat(weight_scales, 0)
+        weight_scale = torch.ops.tensorrt_llm.nvfp4_block_scale_interleave(
+            weight_scale)
+        copy_weight(module.input_scale, input_scale)
+        copy_weight(module.weight_scale, weight_scale)
+        copy_weight(module.alpha, alpha)
+
+        fused_weight = torch.cat((q_weight, k_weight, v_weight))
+        copy_weight(module.weight, fused_weight)
+
+    def load_weights_fused_gate_up_linear(self, module: Linear,
+                                          weights: List[Dict]):
+        gate_weight, up_weight = load_weights_fused_gate_up_helper(
+            module, weights)
+        fused_weight = torch.cat((gate_weight, up_weight))
+        copy_weight(module.weight, fused_weight)
+
+        input_scale, weight_scales, alpha = self.load_weight_scales(
+            weights,
+            tp_size=module.tp_size,
+            tp_rank=module.tp_rank,
+            tp_mode=module.tp_mode)
+        # Swizzle weight scales after concatenation
+        weight_scale = torch.cat(weight_scales, 0)
+        weight_scale = torch.ops.tensorrt_llm.nvfp4_block_scale_interleave(
+            weight_scale)
+        copy_weight(module.input_scale, input_scale)
+        copy_weight(module.weight_scale, weight_scale)
+        copy_weight(module.alpha, alpha)
+
+
+def get_quant_method(quant_config: Optional[QuantConfig] = None):
+    if quant_config is None or not quant_config.layer_quant_mode.has_any_quant(
+            exclude_kv_cache=True):
+        return UnquantizedLinearMethod()
+    if quant_config.layer_quant_mode.has_fp8_qdq():
+        return FP8QDQLinearMethod()
+    if quant_config.layer_quant_mode.has_fp8_block_scales():
+        return FP8BlockScalesLinearMethod()
+    if quant_config.layer_quant_mode.has_nvfp4():
+        return NVFP4LinearMethod()
+    raise ValueError(f'unsupported quant mode: {quant_config.quant_mode}')
 
 
 class Linear(nn.Module):
@@ -207,167 +706,44 @@ class Linear(nn.Module):
     def create_weights(self):
         if self._weights_created:
             return
-        weight_shape = (self.out_features, self.in_features)
-        self.has_any_quant = False
-        self.has_fp8_qdq = False
-        self.has_fp8_block_scales = False
-        self.has_nvfp4 = False
 
-        if self.quant_config and self.quant_config.layer_quant_mode.has_any_quant(
-                exclude_kv_cache=True):
-            self.has_any_quant = True
-            qc = self.quant_config
-            if qc.layer_quant_mode.has_fp8_qdq():
-                self.has_fp8_qdq = True
-                self.weight = Parameter(torch.empty(weight_shape,
-                                                    dtype=torch.float8_e4m3fn),
-                                        requires_grad=False)
-                self.weight_scale = Parameter(torch.tensor(1.,
-                                                           dtype=torch.float32),
-                                              requires_grad=False)
-                self.input_scale = Parameter(torch.tensor(1.,
-                                                          dtype=torch.float32),
-                                             requires_grad=False)
-                self.inv_input_scale = Parameter(torch.tensor(
-                    1., dtype=torch.float32),
-                                                 requires_grad=False)
-            elif qc.layer_quant_mode.has_fp8_block_scales():
-                self.has_fp8_block_scales = True
+        self.quant_method = get_quant_method(self.quant_config)
+        self.quant_method.create_weights(self, self.in_features,
+                                         self.out_features, self.has_bias,
+                                         self.dtype)
 
-                self.weight = Parameter(torch.empty(weight_shape,
-                                                    dtype=torch.float8_e4m3fn),
-                                        requires_grad=False)
-                scale_shape = (math.ceil(self.out_features / 128),
-                               math.ceil(self.in_features / 128))
-                self.weight_scale = Parameter(torch.empty(scale_shape,
-                                                          dtype=torch.float32),
-                                              requires_grad=False)
-                # Not really used for Gemm now.
-                # Only used to quantize output of FP8 attention.
-                self.input_scale = Parameter(torch.tensor(1.,
-                                                          dtype=torch.float32),
-                                             requires_grad=False)
-                self.inv_input_scale = Parameter(torch.tensor(
-                    1., dtype=torch.float32),
-                                                 requires_grad=False)
-
-            elif qc.layer_quant_mode.has_nvfp4():
-                self.has_nvfp4 = True
-                self.scaling_vector_size = 16
-                assert self.in_features % self.scaling_vector_size == 0, f"in_features {self.in_features} must be divisible by scaling_vector_size {self.scaling_vector_size}"
-
-                # Quantized weights
-                self.weight = Parameter(torch.empty(
-                    [self.out_features, self.in_features // 2],
-                    dtype=fp4_utils.float4_e2m1x2),
-                                        requires_grad=False)
-
-                # FP8 per-block scaling factors. dtype must be aligned with SF_DTYPE
-                # Padding is required. See computeSFSize in quantization.h
-                nrows = fp4_utils.pad_up(self.out_features, 128)
-                ncols = fp4_utils.pad_up(
-                    self.in_features // self.scaling_vector_size, 4)
-                self.weight_scale = Parameter(torch.empty(
-                    [nrows * ncols], dtype=fp4_utils.float4_sf_dtype),
-                                              requires_grad=False)
-
-                # FP32 per-tensor global scaling factor = 448*6/amax_input
-                self.input_scale = Parameter(torch.empty([1],
-                                                         dtype=torch.float32),
-                                             requires_grad=False)
-                self.inv_input_scale = Parameter(torch.empty(
-                    [1], dtype=torch.float32),
-                                                 requires_grad=False)
-
-                # (amax_input*amax_weight) / (448*6*448*6)
-                self.alpha = Parameter(torch.empty([1], dtype=torch.float32),
-                                       requires_grad=False)
-            else:
-                # TODO(zhenhuanc): support other quant mode
-                raise ValueError(f'unsupported quant mode: {qc.quant_mode}')
-        else:
-            self.weight = Parameter(torch.empty(weight_shape, dtype=self.dtype),
-                                    requires_grad=False)
-
-        if self.has_bias:
-            self.bias = Parameter(torch.empty((self.out_features, ),
-                                              dtype=self.dtype),
-                                  requires_grad=False)
-        else:
-            self.register_parameter("bias", None)
         self._weights_created = True
+
+    @property
+    def has_any_quant(self):
+        assert self._weights_created
+        return self.quant_config is not None and self.quant_config.layer_quant_mode.has_any_quant(
+            exclude_kv_cache=True)
+
+    @property
+    def has_fp8_qdq(self):
+        assert self._weights_created
+        return self.quant_config is not None and self.quant_config.layer_quant_mode.has_fp8_qdq(
+        )
+
+    @property
+    def has_fp8_block_scales(self):
+        assert self._weights_created
+        return self.quant_config is not None and self.quant_config.layer_quant_mode.has_fp8_block_scales(
+        )
+
+    @property
+    def has_nvfp4(self):
+        assert self._weights_created
+        return self.quant_config is not None and self.quant_config.layer_quant_mode.has_nvfp4(
+        )
 
     def apply_linear(self,
                      input,
-                     weight,
                      bias,
                      lora_params: Optional[dict] | None = None,
                      layer_idx: Optional[int] | None = None):
-        if self.has_any_quant:
-            qc = self.quant_config
-            if self.has_fp8_qdq:
-                cur_input_scale = self.input_scale
-                if input.dtype != torch.float8_e4m3fn:
-                    if self.input_scale is not None:
-                        # Static quantization
-                        qinput, _ = torch.ops.tensorrt_llm.static_quantize_e4m3_per_tensor(
-                            input, self.input_scale)
-                    else:
-                        # Dynamic quantization
-                        qinput, cur_input_scale = torch.ops.tensorrt_llm.quantize_e4m3_per_tensor(
-                            input)
-                        cur_input_scale = cur_input_scale.to(torch.float32)
-                else:
-                    qinput = input
-                # This op does not support bias now.
-                output = torch.ops.trtllm.cublas_scaled_mm(
-                    qinput,
-                    weight.t(),
-                    scale_a=cur_input_scale,
-                    scale_b=self.weight_scale,
-                    bias=None,
-                    out_dtype=self.dtype or input.dtype,
-                )
-                if bias is not None:
-                    output = output + bias
-            elif self.has_fp8_block_scales:
-                if input.dtype == torch.float8_e4m3fn:
-                    input = input.to(torch.bfloat16) * self.input_scale
-                assert input.dtype == torch.bfloat16
-
-                act_input_fp8, act_input_sf = torch.ops.trtllm.fp8_quantize_1x128(
-                    input)
-
-                output = torch.ops.trtllm.fp8_block_scaling_gemm(
-                    act_input_fp8, self.weight, act_input_sf, self.weight_scale)
-                if bias is not None:
-                    output = output + bias
-            elif self.has_nvfp4:
-                if isinstance(input, Fp4QuantizedTensor):
-                    act_fp4, act_sf = input.fp4_tensor, input.scaling_factor
-                else:
-                    act_fp4, act_sf = torch.ops.trtllm.fp4_quantize(
-                        input, self.input_scale, self.scaling_vector_size,
-                        False)
-
-                output = torch.ops.trtllm.nvfp4_gemm(act_fp4, self.weight,
-                                                     act_sf, self.weight_scale,
-                                                     self.alpha, False,
-                                                     self.dtype)
-                if bias is not None:
-                    output = output + bias
-            else:
-                # TODO(zhenhuanc): support other quant mode
-                raise ValueError(f'unsupported quant mode: {qc.quant_mode}')
-        else:
-            # TODO: remove custom cublas_mm when default heuristics is good enough
-            if self.use_custom_cublas_mm:
-                output = torch.ops.trtllm.cublas_mm(input,
-                                                    self.weight.t(),
-                                                    bias,
-                                                    out_dtype=None)
-            else:
-                output = F.linear(input, self.weight, bias)
+        output = self.quant_method.apply(self, input, bias)
 
         if self.lora is not None and bool(lora_params):
             lora_result = self.lora(input, lora_params, layer_idx)
@@ -400,234 +776,31 @@ class Linear(nn.Module):
         lora_params: Optional[dict] = None,
         layer_idx: Optional[int] = None,
     ) -> torch.Tensor:
-        from ..distributed import allgather
-
         if self.tp_mode == TensorParallelMode.ROW:
             bias = None if (self.tp_rank > 0) else self.bias
             if self.reduce_output:
                 fuse_bias = self._maybe_fuse_bias_into_allreduce(
                     bias, all_reduce_params)
                 bias = None if fuse_bias else bias
-                output = self.apply_linear(input, self.weight, bias,
-                                           lora_params, layer_idx)
+                output = self.apply_linear(input, bias, lora_params, layer_idx)
                 output = self.all_reduce(
                     output,
                     all_reduce_params=all_reduce_params,
                 )
             else:
-                output = self.apply_linear(input, self.weight, bias,
-                                           lora_params, layer_idx)
+                output = self.apply_linear(input, bias, lora_params, layer_idx)
         elif self.tp_mode == TensorParallelMode.COLUMN:
-            output = self.apply_linear(input, self.weight, self.bias,
-                                       lora_params, layer_idx)
+            output = self.apply_linear(input, self.bias, lora_params, layer_idx)
             if self.gather_output:
+                from ..distributed import allgather
                 output = allgather(output, self.mapping)
         else:
-            output = self.apply_linear(input, self.weight, self.bias,
-                                       lora_params, layer_idx)
+            output = self.apply_linear(input, self.bias, lora_params, layer_idx)
 
         return output
 
     def load_weights(self, weights: List[Dict]):
         assert self._weights_created
 
-        def _copy(dst: Parameter, src: torch.Tensor):
-            # TODO check that is it a reasonable change or not
-            if dst.dtype != src.dtype:
-                src = src.to(dst.dtype)
-            assert dst.dtype == src.dtype, f"Incompatible dtype. dst: {dst.dtype}, src: {src.dtype}"
-            dst.data.copy_(src)
-
         weight_mode = self.weights_loading_config.weight_mode
-        quant_mode = self.quant_config.quant_mode if self.quant_config else None
-        # load weight shard onto GPU to speed up operations on the shards
-        device = torch.device('cuda')
-
-        if weight_mode == WeightMode.VANILLA:
-            assert len(weights) == 1
-
-            weight = load_weight_shard(weights[0]['weight'], self.tp_size,
-                                       self.tp_rank, self.tp_mode, device)
-            _copy(self.weight, weight)
-
-            if self.bias is not None:
-                bias = load_weight_shard(weights[0]['bias'], self.tp_size,
-                                         self.tp_rank, self.tp_mode, device)
-                _copy(self.bias, bias)
-
-            if quant_mode:
-                if quant_mode.has_fp8_qdq():
-                    input_scale, weight_scale = load_weight_scales_fp8_qdq(
-                        weights)
-                    if len(input_scale) != 0:
-                        # Static quantization
-                        _copy(self.input_scale, input_scale[0])
-                        self.inv_input_scale.data = 1.0 / self.input_scale
-                    else:
-                        # Dynamic quantization
-                        self.input_scale = None
-                        self.inv_input_scale = None
-                    _copy(self.weight_scale, weight_scale[0])
-                elif quant_mode.has_nvfp4():
-                    input_scale, weight_scale, alpha = load_weight_scales_nvfp4(
-                        weights,
-                        tp_size=self.tp_size,
-                        tp_rank=self.tp_rank,
-                        tp_mode=self.tp_mode)
-                    assert len(weights) == 1
-                    weight_scale = weight_scale[0]
-                    # Swizzle weight scale
-                    weight_scale = torch.ops.tensorrt_llm.nvfp4_block_scale_interleave(
-                        weight_scale)
-                    _copy(self.input_scale, input_scale)
-                    _copy(self.weight_scale, weight_scale)
-                    self.inv_input_scale.data = self.input_scale / E2M1_MAX
-                    _copy(self.alpha, alpha)
-
-                elif quant_mode.has_fp8_block_scales():
-                    # `weight_scale_inv` for DS recipe and  `weight_scale` for ModelOpt recipe.
-                    # Actually they hold identical values of data_amax / 448.
-                    scale_name = "weight_scale_inv"
-                    if scale_name not in weights[0]:
-                        scale_name = "weight_scale"
-                    weight_scale = load_weight_shard(weights[0][scale_name],
-                                                     self.tp_size, self.tp_rank,
-                                                     self.tp_mode, device)
-                    _copy(self.weight_scale, weight_scale)
-                    if "input_scale" in weights[0]:
-                        _copy(self.input_scale, weights[0]["input_scale"])
-                        self.inv_input_scale.data = 1.0 / self.input_scale
-
-        elif weight_mode == WeightMode.FUSED_QKV_LINEAR:
-            assert len(weights) == 3
-
-            q_weight = load_weight_shard(weights[0]['weight'], self.tp_size,
-                                         self.tp_rank, self.tp_mode, device)
-            k_weight = load_weight_shard(weights[1]['weight'], self.tp_size,
-                                         self.tp_rank, self.tp_mode, device)
-            v_weight = load_weight_shard(weights[2]['weight'], self.tp_size,
-                                         self.tp_rank, self.tp_mode, device)
-
-            if quant_mode:
-                if quant_mode.has_fp8_qdq():
-                    input_scale, weight_scale = load_weight_scales_fp8_qdq(
-                        weights)
-                    if len(input_scale) != 0:
-                        # Static quantization
-                        _copy(self.input_scale, max(input_scale))
-                    else:
-                        # Dynamic quantization
-                        self.input_scale = None
-                    _copy(self.weight_scale, max(weight_scale))
-                    q_weight = q_weight.to(self.dtype) * weight_scale[0]
-                    k_weight = k_weight.to(self.dtype) * weight_scale[1]
-                    v_weight = v_weight.to(self.dtype) * weight_scale[2]
-                elif quant_mode.has_nvfp4():
-                    input_scale, weight_scale, alpha = load_weight_scales_nvfp4(
-                        weights,
-                        tp_size=self.tp_size,
-                        tp_rank=self.tp_rank,
-                        tp_mode=self.tp_mode)
-                    # Swizzle weight scales after concatenation
-                    weight_scale = torch.cat(weight_scale, 0)
-                    weight_scale = torch.ops.tensorrt_llm.nvfp4_block_scale_interleave(
-                        weight_scale)
-                    _copy(self.input_scale, input_scale)
-                    _copy(self.weight_scale, weight_scale)
-                    _copy(self.alpha, alpha)
-                elif quant_mode.has_fp8_block_scales():
-                    scale_name = "weight_scale_inv"
-                    if scale_name not in weights[0]:
-                        scale_name = "weight_scale"
-                    q_scale = load_weight_shard(weights[0][scale_name],
-                                                self.tp_size, self.tp_rank,
-                                                self.tp_mode).contiguous()
-                    k_scale = load_weight_shard(weights[1][scale_name],
-                                                self.tp_size, self.tp_rank,
-                                                self.tp_mode).contiguous()
-                    v_scale = load_weight_shard(weights[2][scale_name],
-                                                self.tp_size, self.tp_rank,
-                                                self.tp_mode).contiguous()
-                    fused_fp8_block_scale = torch.cat(
-                        (q_scale, k_scale, v_scale))
-                    _copy(self.weight_scale, fused_fp8_block_scale)
-
-            fused_weight = torch.cat((q_weight, k_weight, v_weight))
-
-            if quant_mode and quant_mode.has_fp8_qdq():
-                fused_weight = (fused_weight / self.weight_scale).to(
-                    torch.float8_e4m3fn)
-
-            _copy(self.weight, fused_weight)
-
-            if self.bias is not None:
-                q_bias = load_weight_shard(weights[0]['bias'], self.tp_size,
-                                           self.tp_rank, self.tp_mode, device)
-                k_bias = load_weight_shard(weights[1]['bias'], self.tp_size,
-                                           self.tp_rank, self.tp_mode, device)
-                v_bias = load_weight_shard(weights[2]['bias'], self.tp_size,
-                                           self.tp_rank, self.tp_mode, device)
-                _copy(self.bias, torch.cat((q_bias, k_bias, v_bias)))
-        elif weight_mode == WeightMode.FUSED_GATE_UP_LINEAR:
-            assert len(weights) == 2
-
-            gate_weight = load_weight_shard(weights[0]['weight'], self.tp_size,
-                                            self.tp_rank, self.tp_mode, device)
-            up_weight = load_weight_shard(weights[1]['weight'], self.tp_size,
-                                          self.tp_rank, self.tp_mode, device)
-            if quant_mode:
-                if quant_mode.has_fp8_qdq():
-                    input_scale, weight_scale = load_weight_scales_fp8_qdq(
-                        weights)
-                    if len(input_scale) != 0:
-                        # Static quantization
-                        _copy(self.input_scale, max(input_scale))
-                    else:
-                        # Dynamic quantization
-                        self.input_scale = None
-                    _copy(self.weight_scale, max(weight_scale))
-                    gate_weight = gate_weight.to(self.dtype) * weight_scale[0]
-                    up_weight = up_weight.to(self.dtype) * weight_scale[1]
-                elif quant_mode.has_nvfp4():
-                    input_scale, weight_scale, alpha = load_weight_scales_nvfp4(
-                        weights,
-                        tp_size=self.tp_size,
-                        tp_rank=self.tp_rank,
-                        tp_mode=self.tp_mode)
-                    # Swizzle weight scales after concatenation
-                    weight_scale = torch.cat(weight_scale, 0)
-                    weight_scale = torch.ops.tensorrt_llm.nvfp4_block_scale_interleave(
-                        weight_scale)
-                    _copy(self.input_scale, input_scale)
-                    _copy(self.weight_scale, weight_scale)
-                    _copy(self.alpha, alpha)
-                elif quant_mode.has_fp8_block_scales():
-                    scale_name = "weight_scale_inv"
-                    if scale_name not in weights[0]:
-                        scale_name = "weight_scale"
-                    left_scale = load_weight_shard(weights[0][scale_name],
-                                                   self.tp_size, self.tp_rank,
-                                                   self.tp_mode, device)
-                    right_scale = load_weight_shard(weights[1][scale_name],
-                                                    self.tp_size, self.tp_rank,
-                                                    self.tp_mode, device)
-                    fused_scale = torch.cat([left_scale, right_scale], dim=0)
-                    _copy(self.weight_scale, fused_scale)
-
-            fused_weight = torch.cat((gate_weight, up_weight))
-
-            if quant_mode and quant_mode.has_fp8_qdq():
-                fused_weight = (fused_weight / self.weight_scale).to(
-                    torch.float8_e4m3fn)
-
-            _copy(self.weight, fused_weight)
-
-            if self.bias is not None:
-                gate_bias = load_weight_shard(weights[0]['bias'], self.tp_size,
-                                              self.tp_rank, self.tp_mode,
-                                              device)
-                up_bias = load_weight_shard(weights[1]['bias'], self.tp_size,
-                                            self.tp_rank, self.tp_mode, device)
-                _copy(self.bias, torch.cat((up_bias, gate_bias)))
-        else:
-            raise ValueError(f'unsupported weight mode: {weight_mode}')
+        self.quant_method.load_weights(self, weights, weight_mode)


### PR DESCRIPTION

## Description

Redesign the Linear module. 
- Separate out and encapsulate the quantization related logics into individual `LinearMethod` class for each `quant_config`. 
- Create separate weight loading functions for the different `weight_mode`s.
- I believe the code is much easier to follow after the refactor.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
