### PR TITLE
fix: iteration logging and typing in PyExecutor

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -209,14 +209,14 @@ def estimate_max_kv_cache_tokens(py_executor: PyExecutor,
         kv_cache_max_tokens = min(kv_cache_max_tokens, kv_cache_max_tokens_in)
 
     logger.info(f"Estimated max tokens in KV cache : {kv_cache_max_tokens}")
-    py_executor.set_gather_responses(False)
-    py_executor.enable_iter_perf_stats = origin_iter_stats
 
     py_executor.resource_manager.resource_managers.get(
         "kv_cache_manager").shutdown()
 
-    py_executor.is_warmup = False
     py_executor.shutdown()
+    py_executor.is_warmup = False
+    py_executor.set_gather_responses(False)
+    py_executor.enable_iter_perf_stats = origin_iter_stats
 
     return kv_cache_max_tokens
 

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -61,15 +61,16 @@ class RequestQueueItem:
         return self.id == SHUTDOWN_REQUEST_ID
 
 
-def _get_from_request_queue(request_queue, timeout: datetime.timedelta,
-                            max_req_count: int):
+def _get_from_request_queue(request_queue,
+                            timeout: Optional[datetime.timedelta],
+                            max_req_count: int) -> List[RequestQueueItem]:
     items = []
-    timeout = timeout.total_seconds() if timeout is not None else None
+    timeout_secs = timeout.total_seconds() if timeout is not None else None
     req_count = 0
     try:
-        if request_queue.empty() and (timeout is None or timeout > 0):
+        if request_queue.empty() and (timeout_secs is None or timeout_secs > 0):
             # if queue is empty and want to wait, wait
-            items.append(request_queue.get(timeout=timeout))
+            items.append(request_queue.get(timeout=timeout_secs))
         else:
             # if not empty or don't want to wait, just return all items in queue
             while req_count < max_req_count:
@@ -174,7 +175,7 @@ class PyExecutor:
         super(PyExecutor, self).__init__()
         self.device_id = torch.cuda.current_device()
         self.global_rank = global_mpi_rank()
-        self.request_queue = queue.Queue()
+        self.request_queue: queue.Queue[RequestQueueItem] = queue.Queue()
 
         # profile config
         self.profile_start_iters, self.profile_stop_iters = _load_iteration_indexes(
@@ -550,9 +551,9 @@ class PyExecutor:
                 req_stat.dis_serving_stats.kv_cache_size = req.kv_cache_size
             return req_stat
 
-        def get_queued_req_stats(req: LlmRequest) -> RequestStats:
+        def get_queued_req_stats(req: RequestQueueItem) -> RequestStats:
             req_stat = RequestStats()
-            req_stat.id = req.request_id
+            req_stat.id = req.id
             req_stat.context_prefill_position = 0
             req_stat.num_generated_tokens = 0
             req_stat.avg_num_decoded_tokens_per_iter = 0
@@ -571,7 +572,7 @@ class PyExecutor:
 
         for req in list(self.request_queue.queue):
             req_stat = get_queued_req_stats(req)
-            req.stage = RequestStage.QUEUED
+            req_stat.stage = RequestStage.QUEUED
             req_stats.append(req_stat)
 
         for req in finished_requests:
@@ -1042,22 +1043,15 @@ class PyExecutor:
                 if scheduled_batch.batch_size > 0:
                     self.resource_manager.prepare_resources(scheduled_batch)
 
-                    generation_requests = scheduled_batch.generation_requests
-
                     # The generation requests that are do not have batch_idx,
                     # needs to be in front of the batch due to the assumptions
                     # made in model_engine.py::_forward_step. This is only important
                     # for disaggregated serving. For non-disaggregated serving,
                     # the generation requests always have batch_idx.
-                    new_generation_requests = []
-                    for req in generation_requests:
-                        if req.py_batch_idx is None:
-                            new_generation_requests.append(req)
-
-                    for req in generation_requests:
-                        if req.py_batch_idx is not None:
-                            new_generation_requests.append(req)
-                    scheduled_batch.generation_requests = new_generation_requests
+                    scheduled_batch.generation_requests = sorted(  # stable sort
+                        scheduled_batch.generation_requests,
+                        key=lambda req: int(req.py_batch_idx is not None),
+                    )
 
                     if self.kv_cache_transceiver:
                         # For generation requests which have completed KV cache transfer
@@ -1141,7 +1135,8 @@ class PyExecutor:
             sampler_event=sampler_event,
         )
 
-    def _update_new_active_requests_queue_latency(self, new_requests):
+    def _update_new_active_requests_queue_latency(
+            self, new_requests: List[RequestQueueItem]):
         if self.enable_iter_perf_stats and self.dist.rank == 0:
             now = time.time()
             for req_item in new_requests:
@@ -1152,9 +1147,9 @@ class PyExecutor:
     @nvtx_range("_broadcast_new_requests")
     def _broadcast_new_requests(
         self,
-        new_requests: List[ExecutorRequest],
-        py_request_objects: tuple[str, dict] = None
-    ) -> tuple[List[ExecutorRequest], Optional[tuple[str, dict]]]:
+        new_requests: List[RequestQueueItem],
+        py_request_objects: Optional[tuple[str, dict]] = None,
+    ) -> tuple[List[RequestQueueItem], Optional[tuple[str, dict]]]:
         """Broadcasts new_requests and optional Python-only metadata (`py_request_objects`) across pipeline stages.
            `py_request_objects` is a tuple of (attribute_name, {request_id: object}).
         """
@@ -1180,7 +1175,7 @@ class PyExecutor:
         return payloads
 
     @nvtx_range("_fetch_new_requests")
-    def _fetch_new_requests(self):
+    def _fetch_new_requests(self) -> List[RequestQueueItem]:
         if self.enable_attention_dp:
             all_ranks_num_active_requests = []
             responses_list = self.dist.tp_allgather(len(self.active_requests))
@@ -2050,7 +2045,7 @@ class PyExecutor:
                 self.ctx_in_transmission_requests.remove(request)
 
     def _await_any_response(self,
-                            timeout: Union[float, None] = None
+                            timeout: Optional[float] = None
                             ) -> List[ExecutorResponse]:
 
         def any_responses_ready():
@@ -2068,7 +2063,7 @@ class PyExecutor:
     def _await_single_response(
             self,
             id: int,
-            timeout: Union[float, None] = None) -> List[ExecutorResponse]:
+            timeout: Optional[float] = None) -> List[ExecutorResponse]:
         with self.response_cv:
 
             def key_has_response():


### PR DESCRIPTION
# fix: iteration logging and typing in PyExecutor

## Description

This PR is a byproduct on ongoing work on another issue. It improves type annotations in `PyExecutor`.
During these changes, I discovered and corrected an issue arising for `enable_iter_req_stats=True and enable_iter_perf_stats=True`. Apparently, there are no test cases
covering this configuration at the moment.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
