### PR TITLE
chore: improve disagg test failure detection

### DIFF
--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -309,14 +309,13 @@ class GenerationExecutorProxy(GenerationExecutor):
                 break
             if any(fut.done() for fut in self.mpi_futures):
                 logger.error("Executor worker died during initialization.")
-                ready_signal = RuntimeError(
-                    "Executor worker died during initialization")
-                break
+                raise RuntimeError("Executor worker died during initialization")
             self._handle_background_error()
 
         if ready_signal != GenerationExecutorProxy.READY_SIGNAL:
             self.mpi_session.shutdown_abort(reason=ready_signal)
-            raise ready_signal
+            raise RuntimeError(
+                "Executor worker returned error") from ready_signal
 
     def _abort_all_requests(self):
         # The results can be finished during this loop, so self._results may be changed.

--- a/tensorrt_llm/executor/serialization.py
+++ b/tensorrt_llm/executor/serialization.py
@@ -9,7 +9,7 @@ import pickle  # nosec B403
 BASE_EXAMPLE_CLASSES = {
     "builtins": [
         "Exception", "ValueError", "NotImplementedError", "AttributeError",
-        "AssertionError"
+        "AssertionError", "RuntimeError"
     ],  # each Exception Error class needs to be added explicitly
     "collections": ["OrderedDict"],
     "torch._utils": ["_rebuild_tensor_v2"],

--- a/tensorrt_llm/llmapi/disagg_utils.py
+++ b/tensorrt_llm/llmapi/disagg_utils.py
@@ -73,10 +73,12 @@ def parse_disagg_config_file(yaml_config_file: str):
 
 def extract_disagg_cfg(hostname: str = 'localhost',
                        port: int = 8000,
-                       context_servers: dict = dict(),
-                       generation_servers: dict = dict(),
+                       context_servers: Optional[dict] = None,
+                       generation_servers: Optional[dict] = None,
                        conditional_disagg_config: Optional[dict] = None,
                        **kwargs: Any) -> DisaggServerConfig:
+    context_servers = context_servers or {}
+    generation_servers = generation_servers or {}
 
     # If parameters are specified outside the context_severs and generation_servers sections,
     # make sure they match
@@ -94,12 +96,13 @@ def extract_disagg_cfg(hostname: str = 'localhost',
                 # Inherit the value from the top-level
                 servers[key] = value
 
+    ctx_router_config = extract_router_config(context_servers)
+    gen_router_config = extract_router_config(generation_servers)
+
     server_configs = extract_ctx_gen_cfgs(
         type="ctx", **context_servers) + extract_ctx_gen_cfgs(
             type="gen", **generation_servers)
 
-    ctx_router_config = extract_router_config(context_servers)
-    gen_router_config = extract_router_config(generation_servers)
     ctx_router_config.server_role = ServerRole.CONTEXT
     gen_router_config.server_role = ServerRole.GENERATION
 
@@ -158,7 +161,7 @@ def extract_ctx_gen_cfgs(type: Literal['ctx', 'gen'],
 
 def extract_router_config(server_cfg: dict) -> RouterConfig:
 
-    args = server_cfg.get("router", {})
+    args = server_cfg.pop("router", {})
     router_type = args.pop("type", "round_robin")
 
     # add fields that are not specific to router

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -184,10 +184,10 @@ class LLM:
 
             self._build_model()
 
-        except Exception as e:
+        except Exception:
             if self.mpi_session is not None:
                 self.mpi_session.shutdown()
-            raise e
+            raise
 
         exception_handler.register(self, 'shutdown')
         atexit.register(LLM._shutdown_wrapper, weakref.ref(self))

--- a/tests/integration/defs/disaggregated/test_disaggregated.py
+++ b/tests/integration/defs/disaggregated/test_disaggregated.py
@@ -166,25 +166,33 @@ def run_disaggregated_test(example_dir,
                     '--server-start-timeout',
                     str(server_start_timeout)
                 ]
-                check_call(client_cmd, env=env)
+                check_call(client_cmd,
+                           env=env,
+                           poll_procs=[workers_proc, server_proc])
 
                 # Streaming client run
                 streaming_client_cmd = client_cmd + [
                     '--streaming', '-o', 'output_streaming.json'
                 ]
-                check_call(streaming_client_cmd, env=env)
+                check_call(streaming_client_cmd,
+                           env=env,
+                           poll_procs=[workers_proc, server_proc])
 
                 # Run the chat completion endpoint test only for TinyLlama
                 if test_desc == "overlap":
                     chat_client_cmd = client_cmd + [
                         '-e', 'chat', '-o', 'output_chat.json'
                     ]
-                    check_call(chat_client_cmd, env=env)
+                    check_call(chat_client_cmd,
+                               env=env,
+                               poll_procs=[workers_proc, server_proc])
 
                     streaming_chat_client_cmd = chat_client_cmd + [
                         '--streaming', '-o', 'output_streaming_chat.json'
                     ]
-                    check_call(streaming_chat_client_cmd, env=env)
+                    check_call(streaming_chat_client_cmd,
+                               env=env,
+                               poll_procs=[workers_proc, server_proc])
 
                 # Verify outputs
                 not_expected_strings = ["Berlin Berlin"]

--- a/tests/unittest/_torch/modeling/test_modeling_out_of_tree.py
+++ b/tests/unittest/_torch/modeling/test_modeling_out_of_tree.py
@@ -30,7 +30,7 @@ class TestOutOfTree(unittest.TestCase):
         kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.4)
 
         if not import_oot_code:
-            with self.assertRaises(ValueError):
+            with self.assertRaises(RuntimeError):
                 # estimate_max_kv_cache_tokens will create a request of max_num_tokens for forward.
                 # Default 8192 will exceed the max length of absolute positional embedding in OPT, leading to out of range indexing.
                 llm = LLM(model=model_dir,


### PR DESCRIPTION
# chore: improve disagg test failure detection (was "fix: make BaseLlmArgs fail on unsupported args")

## Description

~~Currently, e.g., the no-longer supported `pytorch_backend_config` keyword argument is silently ignored by `_torch.LLM.__init__()`. This PR raises an error instead.~~

Refocused PR, since upstream has addressed the original issue (see #4600).

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
