### PR TITLE
fix: large-scale EP - EP load balancer with MTP layer and route offset by EP rank

### DIFF
--- a/cpp/tensorrt_llm/kernels/moeLoadBalance/moeLoadBalanceKernels.h
+++ b/cpp/tensorrt_llm/kernels/moeLoadBalance/moeLoadBalanceKernels.h
@@ -81,9 +81,10 @@ void moeStatisticDevice(MoeLoadBalanceMetaInfo metaInfo, MoeLoadBalanceStatistic
 // @param tokenSelectedExperts: the selected experts of all tokenCount tokens, has shape of [tokenCount * topK]
 // @param tokenRoutedRankIds: output the routed slotIds of all tokenCount tokens, has shape of [tokenCount * topK]
 // @param tokenCount: the token count to compute the route
+// @param offsetByEpRank: whether to offset the round robin position by epRank
 // @param stream: the CUDA stream to be used
 void moeComputeRouteDevice(MoeLoadBalanceMetaInfo metaInfo, MoePlacementInfo placementInfo,
-    int* const tokenSelectedExperts, int* tokenRoutedSlotIds, int tokenCount, cudaStream_t stream);
+    int* const tokenSelectedExperts, int* tokenRoutedSlotIds, int tokenCount, bool offsetByEpRank, cudaStream_t stream);
 
 // @brief wait for the signal from gpu to cpu on host
 //

--- a/cpp/tests/kernels/moeLoadBalanceKernelTest.cpp
+++ b/cpp/tests/kernels/moeLoadBalanceKernelTest.cpp
@@ -528,7 +528,7 @@ TEST_P(MoeLoadBalanceRouteKernelTest, TestBasicRouting)
     generateRandomExpertSelection();
 
     moeComputeRouteDevice(mMetaInfo, mPlacementInfo, mDeviceTokenSelectedExperts, mDeviceTokenRoutedRankIds,
-        param.maxTokenCountPerRank, mStream);
+        param.maxTokenCountPerRank, false, mStream);
     ASSERT_EQ(cudaStreamSynchronize(mStream), cudaSuccess);
 
     computeExpectedRouting();
@@ -556,7 +556,7 @@ TEST_P(MoeLoadBalanceRouteKernelTest, TestInvalidExpertIds)
         cudaSuccess);
 
     moeComputeRouteDevice(mMetaInfo, mPlacementInfo, mDeviceTokenSelectedExperts, mDeviceTokenRoutedRankIds,
-        param.maxTokenCountPerRank, mStream);
+        param.maxTokenCountPerRank, false, mStream);
     ASSERT_EQ(cudaStreamSynchronize(mStream), cudaSuccess);
 
     ASSERT_EQ(cudaMemcpy(mHostTokenRoutedRankIds.data(), mDeviceTokenRoutedRankIds, mTotalTokens * sizeof(int),
@@ -575,7 +575,7 @@ TEST_P(MoeLoadBalanceRouteKernelTest, TestInvalidExpertIds)
         cudaSuccess);
 
     moeComputeRouteDevice(mMetaInfo, mPlacementInfo, mDeviceTokenSelectedExperts, mDeviceTokenRoutedRankIds,
-        param.maxTokenCountPerRank, mStream);
+        param.maxTokenCountPerRank, false, mStream);
     ASSERT_EQ(cudaStreamSynchronize(mStream), cudaSuccess);
 
     ASSERT_EQ(cudaMemcpy(mHostTokenRoutedRankIds.data(), mDeviceTokenRoutedRankIds, mTotalTokens * sizeof(int),

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -241,7 +241,7 @@ def _register_fake():
 
     @torch.library.register_fake("trtllm::moe_load_balance_routing")
     def _(single_layer_load_balancer_ptr: int,
-          token_selected_experts: torch.Tensor):
+          token_selected_experts: torch.Tensor, offset_by_ep_rank: bool):
         return torch.empty_like(token_selected_experts)
 
     @torch.library.custom_op("trtllm::group_rms_norm_base",

--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -18,7 +18,9 @@ TConfig = TypeVar("TConfig", bound=transformers.PretrainedConfig)
 @dataclass
 class MoeLoadBalancerConfig:
     num_slots: Optional[int] = None
-    initial_global_assignments: Optional[Dict[int, List[int]]] = None
+    initial_global_assignments: Optional[Dict[int,
+                                              List[int]]] = field(default=None,
+                                                                  repr=False)
     layer_updates_per_iter: int = 0
 
     num_experts: Optional[int] = field(default=None, init=False)

--- a/tensorrt_llm/_torch/modules/fused_moe.py
+++ b/tensorrt_llm/_torch/modules/fused_moe.py
@@ -1411,8 +1411,10 @@ class FusedMoE(nn.Module):
         if self.balancer_layer is None:
             token_selected_slots = token_selected_experts
         else:
+            # If attention DP is enabled, token_selected_experts is a local rank tensor,
+            # so we need to offset the round robin position by ep_rank
             token_selected_slots = self.balancer_layer.route(
-                token_selected_experts)
+                token_selected_experts, offset_by_ep_rank=self.use_dp)
 
         assert token_selected_slots.shape[
             1] == self.routing_method.experts_per_token

--- a/tensorrt_llm/_torch/modules/moe_load_balancer.py
+++ b/tensorrt_llm/_torch/modules/moe_load_balancer.py
@@ -289,18 +289,22 @@ class SingleLayerMoeLoadBalancer:
             gathered_raw_expert_ids, enabled,
             self.single_layer_load_balancer_ptr, is_first_stage, is_last_stage)
 
-    def route(self, token_selected_experts: torch.Tensor) -> torch.Tensor:
+    def route(self,
+              token_selected_experts: torch.Tensor,
+              offset_by_ep_rank: bool = False) -> torch.Tensor:
         """
         Route the tokens to experts.
 
         Args:
             token_selected_experts: The experts selected by each token
+            offset_by_ep_rank: Whether to offset the round robin position by ep_rank
 
         Returns:
             A tensor of routed slot IDs
         """
         return torch.ops.trtllm.moe_load_balance_routing(
-            token_selected_experts, self.single_layer_load_balancer_ptr)
+            token_selected_experts, offset_by_ep_rank,
+            self.single_layer_load_balancer_ptr)
 
     def py_pre_shutdown_cleanup(self):
         """


### PR DESCRIPTION
# fix: EP load balancer with MTP layer and route offset by EP rank

## Description

This PR fixes:
* EP load balancer with MTP layer

Also, it enables
* Offset round robin position by EP rank for attention DP in fused MoE


## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
