### PR TITLE
fix: Skip dummy medusa/eagle tests when WORLD_SIZE env variable is missing

### DIFF
--- a/tests/integration/defs/examples/test_eagle.py
+++ b/tests/integration/defs/examples/test_eagle.py
@@ -155,6 +155,15 @@ def test_with_dummy_eagle(hf_model_root,
     print("Build engines...")
     model_name = "eagle"
 
+    # We unset WORLD_SIZE while running tests in specific cluster nodes to
+    # deal with a bug in transformers library. Trainer initialization in
+    # get_dummy_spec_decoding_heads() function fails if WORLD_SIZE is unset.
+    # Preemptively skip tests if WORLD_SIZE is unset.
+    if os.environ.get("WORLD_SIZE") is None:
+        pytest.skip(
+            "[test_with_dummy_eagle] Skipping test due to missing WORLD_SIZE env variable."
+        )
+
     print("Creating dummy Eagle heads...")
     get_dummy_spec_decoding_heads(hf_model_dir=hf_model_root,
                                   save_dir=llm_venv.get_working_directory(),

--- a/tests/integration/defs/examples/test_medusa.py
+++ b/tests/integration/defs/examples/test_medusa.py
@@ -201,6 +201,16 @@ def test_llm_medusa_fp8_modelOpt_ckpt_1gpu(batch_size, medusa_model_roots,
 def test_with_dummy_medusa(hf_model_root, medusa_example_root, llm_venv,
                            cmodel_dir, engine_dir, batch_size, data_type,
                            num_medusa_heads, use_py_session, model_type):
+
+    # We unset WORLD_SIZE while running tests in specific cluster nodes to
+    # deal with a bug in transformers library. Trainer initialization in
+    # get_dummy_spec_decoding_heads() function fails if WORLD_SIZE is unset.
+    # Preemptively skip tests if WORLD_SIZE is unset.
+    if os.environ.get("WORLD_SIZE") is None:
+        pytest.skip(
+            "[test_with_dummy_medusa] Skipping test due to missing WORLD_SIZE env variable."
+        )
+
     print("Creating dummy Medusa heads...")
     get_dummy_spec_decoding_heads(hf_model_dir=hf_model_root,
                                   save_dir=llm_venv.get_working_directory(),


### PR DESCRIPTION
## Description

This addresses https://nvbugspro.nvidia.com/bug/5301221.

We unset `WORLD_SIZE` env variable while running tests in specific cluster nodes to deal with a bug in transformers library. Trainer initialization in `get_dummy_spec_decoding_heads()` function fails if `WORLD_SIZE` is unset. Preemptively skip tests if `WORLD_SIZE` is unset.

**_Alternative:_**
Setting `WORLD_SIZE` during `Trainer`'s init (https://github.com/NVIDIA/TensorRT-LLM/pull/4742) - I'm avoiding this as it could pollute the env.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
