### PR TITLE
[fix] Fix llama 4 long context

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_llama.py
+++ b/tensorrt_llm/_torch/models/modeling_llama.py
@@ -938,15 +938,6 @@ class LlamaForCausalLM(DecoderModelForCausalLM[LlamaModel, LlamaConfig]):
 
         return logits
 
-    def infer_max_seq_len(self):
-        if self.model_config.attn_backend.upper() != 'TRTLLM':
-            logger.warning(
-                f"Attention backend {self.model_config.attn_backend} "
-                "does not support chunked attention. Sequence length "
-                "will be limited to 8192.")
-            return 8192
-        return super().infer_max_seq_len()
-
     def load_weights(self, weights: Dict):
         super().load_weights(weights, skip_modules=["draft_model"])
 
@@ -1114,8 +1105,14 @@ class Llama4ForConditionalGeneration(DecoderModelForCausalLM[Llama4Model,
             return logits
 
     def infer_max_seq_len(self):
-        # TODO: implement chunked attention to support 10M context length
-        return 8192
+        if self.model_config.attn_backend.upper() != 'TRTLLM':
+            logger.warning(
+                f"Attention backend {self.model_config.attn_backend} "
+                "does not support chunked attention. Sequence length "
+                "will be limited to 8192.")
+            return 8192
+
+        return super().infer_max_seq_len()
 
     def load_weights(self, weights: Dict):
         new_weights = {}

--- a/tests/unittest/_torch/multi_gpu_modeling/test_llama4.py
+++ b/tests/unittest/_torch/multi_gpu_modeling/test_llama4.py
@@ -1,4 +1,3 @@
-# TODO: Enable this test when the models are checked into the llm repo!!
 from difflib import SequenceMatcher
 
 import pytest
@@ -7,6 +6,7 @@ from utils.llm_data import llm_models_root
 
 from tensorrt_llm import SamplingParams
 from tensorrt_llm._torch import LLM
+from tensorrt_llm.llmapi import KvCacheConfig
 
 
 @pytest.mark.parametrize(
@@ -34,22 +34,34 @@ def test_llama4(model_name, backend, tp_size, use_cuda_graph,
                                     and pp_size == 1):
         pytest.skip("Skip this attention DP test case to avoid too many tests")
 
-    prompts = [{
-        "prompt": "The president of the United States is"
-    }, {
-        "prompt": "<|image|>This image is of color",
-        "multi_modal_data": {
-            "image": [torch.ones(3, 1024, 1024)]
-        }
-    }]
+    prompts = [
+        {
+            "prompt": "The president of the United States is"
+        },
+        {
+            # NOTE: Long context accuracy testing (RULER) is not available in CI yet.
+            # This test cannot be removed until long context is covered.
+            "prompt":
+            "This is a very long prompt to exercise long context. Count up to 10000 from 1, 2, 3,"
+            + ", ".join(str(i) for i in range(4, 9000))
+        },
+        {
+            "prompt": "<|image|>This image is of color",
+            "multi_modal_data": {
+                "image": [torch.ones(3, 1024, 1024)]
+            }
+        },
+    ]
 
     expected_outputs = [
-        " the head of state and head of government of the", " solid white"
+        " the head of state and head of government of the", ", 8999, 9000, ",
+        " white. What is the color of the background of"
     ]
 
     pytorch_config = dict(attn_backend=backend, use_cuda_graph=use_cuda_graph)
     model_dir = str(llm_models_root() / "llama4-models" / model_name)
 
+    kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.25, )
     llm = LLM(
         model=model_dir,
         tensor_parallel_size=tp_size,
@@ -58,6 +70,8 @@ def test_llama4(model_name, backend, tp_size, use_cuda_graph,
         **pytorch_config,
         pipeline_parallel_size=pp_size,
         enable_attention_dp=enable_attention_dp,
+        kv_cache_config=kv_cache_config,
+        enable_chunked_prefill=True,
     )
     with llm:
         outputs = llm.generate(


### PR DESCRIPTION
## Description

The 8k context limitation was accidentally re-added during feat/llama4 integration. 

Since the Blackwell kernels have not landed yet, I've added an additional `get_sm_version() == 90` restriction for using the full context length.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

RULER evaluation passes
```
|  Tasks  |Version|Filter|n-shot|Metric|   | Value |   |Stderr|                                                                                                                                             
|---------|------:|------|-----:|-----:|---|------:|---|------|                                                                                                                                             
|ruler_cwe|      1|none  |     0| 16384|↑  | 0.9808|±  |   N/A|                                                                                                                                             
|         |       |none  |     0|  4096|↑  |-1.0000|±  |   N/A|     
```

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
