### PR TITLE
'entered copyBlock' format string expects %s, pass string rather than int

### DIFF
--- a/cpp/tensorrt_llm/batch_manager/kvCacheTransferManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheTransferManager.cpp
@@ -109,7 +109,7 @@ void KVCacheTransferManager::copyBlock(BlockPtr const& src, BlockPtr const& dst,
     std::optional<std::string> directory)
 {
     TLLM_LOG_DEBUG("copyBlock entered: srcId=%d, dstId=%d, isOffload=%s, mode=%d", src->getBlockId(), dst->getBlockId(),
-        (int) isOffload, static_cast<int>(mode));
+        (isOffload ? "true" : "false"), static_cast<int>(mode));
 
     if (mode == executor::KvCacheTransferMode::DRAM)
     {


### PR DESCRIPTION
Bug was introduced here:
https://github.com/NVIDIA/TensorRT-LLM/commit/812b1abf861c10b5892ea1cac17ade1bf24ced32