### PR TITLE
[Infra] - Reduce the default Pytest timeout and test Ubuntu mirrors

### DIFF
--- a/jenkins/Build.groovy
+++ b/jenkins/Build.groovy
@@ -1,4 +1,4 @@
-@Library(['bloom-jenkins-shared-lib@main', 'trtllm-jenkins-shared-lib@main']) _
+@Library(['bloom-jenkins-shared-lib@main', 'trtllm-jenkins-shared-lib@yanchaol-ubuntu-mirror']) _
 
 import groovy.transform.Field
 

--- a/jenkins/BuildDockerImage.groovy
+++ b/jenkins/BuildDockerImage.groovy
@@ -1,4 +1,4 @@
-@Library(['bloom-jenkins-shared-lib@main', 'trtllm-jenkins-shared-lib@main']) _
+@Library(['bloom-jenkins-shared-lib@main', 'trtllm-jenkins-shared-lib@yanchaol-ubuntu-mirror']) _
 
 import java.lang.Exception
 import groovy.transform.Field

--- a/jenkins/L0_MergeRequest.groovy
+++ b/jenkins/L0_MergeRequest.groovy
@@ -1,4 +1,4 @@
-@Library(['bloom-jenkins-shared-lib@main', 'trtllm-jenkins-shared-lib@main']) _
+@Library(['bloom-jenkins-shared-lib@main', 'trtllm-jenkins-shared-lib@yanchaol-ubuntu-mirror']) _
 
 import java.lang.InterruptedException
 import groovy.transform.Field

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -1,4 +1,4 @@
-@Library(['bloom-jenkins-shared-lib@main', 'trtllm-jenkins-shared-lib@main']) _
+@Library(['bloom-jenkins-shared-lib@main', 'trtllm-jenkins-shared-lib@yanchaol-ubuntu-mirror']) _
 
 import java.lang.InterruptedException
 import groovy.transform.Field
@@ -1133,13 +1133,14 @@ def runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config=VANILLA_CO
         sh 'if [ "$(id -u)" -eq 0 ]; then dmesg -C; fi'
 
         def extraInternalEnv = ""
-        // Move back to 3600 once TRTLLM-4000 gets resolved
-        def pytestTestTimeout = "7200"
+
+        // The default pytest timeout is 1800 seconds. Per-test timeout can be specified in the test-db.
+        def pytestTestTimeout = "1800"
 
         // TRT uses half of the host logic cores for engine building which is bad for multi-GPU machines.
         extraInternalEnv = "__LUNOWUD=\"-thread_pool_size=${TESTER_CORES}\""
-        // CPP test execution is timing out easily, so we always override the timeout to 7200
-        extraInternalEnv += " CPP_TEST_TIMEOUT_OVERRIDDEN=7200"
+        // CPP test execution is timing out easily, so we override the timeout to the pytest timeout.
+        extraInternalEnv += " CPP_TEST_TIMEOUT_OVERRIDDEN=${pytestTestTimeout}"
 
         def testDBList = renderTestDB(testList, llmSrc, stageName)
         testList = "${testList}_${splitId}"

--- a/tests/integration/test_lists/test-db/l0_a100.yml
+++ b/tests/integration/test_lists/test-db/l0_a100.yml
@@ -85,7 +85,7 @@ l0_a100:
   tests:
   - triton_server/test_triton.py::test_gpt_disaggregated_serving_bls[gpt-disaggregated-serving-bls]
   - triton_server/test_triton.py::test_llava[llava]
-  - triton_server/test_triton.py::test_gpt_ib[gpt-ib]
+  - triton_server/test_triton.py::test_gpt_ib[gpt-ib] TIMEOUT (90)
   - triton_server/test_triton.py::test_gpt_ib_ptuning[gpt-ib-ptuning]
   - triton_server/test_triton.py::test_gpt_2b_ib_lora[gpt-2b-ib-lora]
   - triton_server/test_triton.py::test_gpt_ib_lad[gpt-ib-lad]

--- a/tests/integration/test_lists/test-db/l0_a30.yml
+++ b/tests/integration/test_lists/test-db/l0_a30.yml
@@ -43,13 +43,13 @@ l0_a30:
   - cpp/test_unit_tests.py::test_unit_tests[common-80]
   - cpp/test_unit_tests.py::test_unit_tests[executor-80]
   - cpp/test_unit_tests.py::test_unit_tests[kernels-80]
-  - cpp/test_unit_tests.py::test_unit_tests[layers-80]
-  - cpp/test_unit_tests.py::test_unit_tests[runtime-80]
+  - cpp/test_unit_tests.py::test_unit_tests[layers-80] TIMEOUT (90)
+  - cpp/test_unit_tests.py::test_unit_tests[runtime-80] TIMEOUT (90)
   - cpp/test_unit_tests.py::test_unit_tests[thop-80]
   - cpp/test_unit_tests.py::test_unit_tests[utils-80]
-  - cpp/test_e2e.py::test_model[-gpt-80]
-  - cpp/test_e2e.py::test_model[-gpt_executor-80]
-  - cpp/test_e2e.py::test_model[-gpt_tests-80]
+  - cpp/test_e2e.py::test_model[-gpt-80] TIMEOUT (90)
+  - cpp/test_e2e.py::test_model[-gpt_executor-80] TIMEOUT (90)
+  - cpp/test_e2e.py::test_model[-gpt_tests-80] TIMEOUT (90)
 - condition:
     ranges:
       system_gpu_count:
@@ -183,10 +183,10 @@ l0_a30:
   - triton_server/test_triton.py::test_mistral[mistral]
   - triton_server/test_triton.py::test_whisper[whisper]
   - triton_server/test_triton.py::test_t5_ib[t5-ib]
-  - triton_server/test_triton.py::test_mistral_ib[mistral-ib]
+  - triton_server/test_triton.py::test_mistral_ib[mistral-ib] TIMEOUT (90)
   - triton_server/test_triton.py::test_mistral_ib_streaming[mistral-ib-streaming]
-  - triton_server/test_triton.py::test_mistral_ib_mm[mistral-ib-mm]
-  - triton_server/test_triton.py::test_gpt_ib_streaming[gpt-ib-streaming]
+  - triton_server/test_triton.py::test_mistral_ib_mm[mistral-ib-mm] TIMEOUT (90)
+  - triton_server/test_triton.py::test_gpt_ib_streaming[gpt-ib-streaming] TIMEOUT (90)
   - triton_server/test_triton.py::test_cpp_unit_tests[cpp-unit-tests]
   - triton_server/test_triton.py::test_python_bls_unit_tests[python-bls-unit-tests]
   - triton_server/test_triton.py::test_python_preproc_unit_tests[python-preproc-unit-tests]

--- a/tests/integration/test_lists/test-db/l0_dgx_h200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_h200.yml
@@ -121,7 +121,7 @@ l0_dgx_h200:
   - accuracy/test_cli_flow.py::TestLlama3_2_1B::test_fp8_tp2[disable_reduce_fusion-enable_fp8_context_fmha]
   - accuracy/test_cli_flow.py::TestLlama3_2_1B::test_fp8_tp2[enable_reduce_fusion-disable_fp8_context_fmha]
   - accuracy/test_cli_flow.py::TestPhi2::test_tp2
-  - llmapi/test_llm_e2e.py::test_llmapi_quant_llama_70b
+  - llmapi/test_llm_e2e.py::test_llmapi_quant_llama_70b TIMEOUT (90)
   - llmapi/test_llm_examples.py::test_llmapi_example_distributed_autopp_tp2
   - examples/test_enc_dec.py::test_llm_enc_dec_general[compare_hf-t5-small-float16-enable_gemm_plugin-enable_attention_plugin-disable_paged_kv_cache-tp:2-pp:2-nb:1-disable_fp8]
   - examples/test_gpt.py::test_llm_gpt2_next_prompt_tuning[use_py_session-tp2]

--- a/tests/integration/test_lists/test-db/l0_gb203.yml
+++ b/tests/integration/test_lists/test-db/l0_gb203.yml
@@ -25,7 +25,7 @@ l0_gb203:
   - examples/test_llama.py::test_llm_llama_v3_1_1node_single_gpu[llama-3.2-1b-disable_fp8]
   - examples/test_llama.py::test_llm_llama_wo_1gpu_summary[llama-7b-int4-nb:1]
   - examples/test_llama.py::test_llm_llama_wo_1gpu_summary[llama-7b-int8-nb:1]
-  - examples/test_llama.py::test_llm_llama_1gpu[llama-3.1-8b-instruct-hf-fp8-enable_fp8-float16-summarization-nb:1]
+  - examples/test_llama.py::test_llm_llama_1gpu[llama-3.1-8b-instruct-hf-fp8-enable_fp8-float16-summarization-nb:1] TIMEOUT (90)
   # - examples/test_qwen.py::test_llm_qwen1_5_7b_single_gpu_lora[qwen1.5_7b_chat-Qwen1.5-7B-Chat-750Mb-lora] # https://nvbugs/5234573
   # - examples/test_qwen.py::test_llm_qwen_single_gpu_summary[qwen2.5_1.5b_instruct-enable_paged_kv_cache-enable_remove_input_padding-enable_weight_only-enable_fmha_fp32_acc] # https://nvbugs/5234573
   - llmapi/test_llm_examples.py::test_llmapi_quickstart

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -24,7 +24,7 @@ l0_h100:
   - accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_bfloat16[attn_backend=TRTLLM-torch_compile=True]
   - accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_bfloat16[attn_backend=FLASHINFER-torch_compile=False]
   - accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_bfloat16[attn_backend=FLASHINFER-torch_compile=True]
-  - accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_chunked_prefill[attn_backend=TRTLLM]
+  - accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_chunked_prefill[attn_backend=TRTLLM] TIMEOUT (90)
   - accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_chunked_prefill[attn_backend=FLASHINFER]
   - accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_fp8[fp8kv=False-attn_backend=TRTLLM-torch_compile=False]
   - accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_fp8[fp8kv=False-attn_backend=TRTLLM-torch_compile=True]
@@ -95,7 +95,7 @@ l0_h100:
   - cpp/test_unit_tests.py::test_unit_tests[common-90]
   - cpp/test_unit_tests.py::test_unit_tests[executor-90]
   - cpp/test_unit_tests.py::test_unit_tests[kernels-90]
-  - cpp/test_unit_tests.py::test_unit_tests[layers-90]
+  - cpp/test_unit_tests.py::test_unit_tests[layers-90] TIMEOUT (90)
   - cpp/test_unit_tests.py::test_unit_tests[runtime-90]
   - cpp/test_unit_tests.py::test_unit_tests[thop-90]
   - cpp/test_unit_tests.py::test_unit_tests[utils-90]
@@ -244,7 +244,7 @@ l0_h100:
   - examples/test_multimodal.py::test_llm_multimodal_general[Mistral-Small-3.1-24B-Instruct-2503-pp:1-tp:1-bfloat16-bs:1-cpp_e2e:False-nb:1]
   - examples/test_multimodal.py::test_llm_multimodal_general[VILA1.5-3b-pp:1-tp:1-float16-bs:1-cpp_e2e:False-nb:1] # 10 mins
   - examples/test_enc_dec.py::test_llm_enc_dec_mmlu[flan-t5-small-float32-tp:1-pp:1-nb:1-enable_fp8] # 7 mins
-  - examples/test_enc_dec.py::test_llm_enc_dec_general[compare_hf-bart-large-cnn-float16-enable_gemm_plugin-enable_attention_plugin-enable_paged_kv_cache-tp:1-pp:1-nb:1-enable_fp8] # 13 mins
+  - examples/test_enc_dec.py::test_llm_enc_dec_general[compare_hf-bart-large-cnn-float16-enable_gemm_plugin-enable_attention_plugin-enable_paged_kv_cache-tp:1-pp:1-nb:1-enable_fp8] # 13 mins TIMEOUT (90)
   - examples/test_nemotron.py::test_llm_nemotron_3_8b_1gpu[bfloat16-fp8] # 18mins
   - examples/test_whisper.py::test_llm_whisper_general[large-v3-disable_gemm_plugin-disable_attention_plugin-disable_weight_only-float16-nb:1-use_python_runtime] # 8 mins
   - unittest/trt/attention/test_bert_attention.py # 12 mins


### PR DESCRIPTION
# PR title

Please write the PR title by following template:

[JIRA ticket link/nvbug link/github issue link][fix/feat/doc/infra/...] \<summary of this PR\>

For example, assume I have a PR hope to support a new feature about cache manager of Jira TRTLLM-1000 ticket, it would be like

[TRTLLM-1000][feat] Support a new feature about cache manager

## Description

Please explain the issue and the solution in short.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
