### PR TITLE
enh: Enable trtllm-bench to run LoRA PyT flow

### DIFF
--- a/benchmarks/cpp/prepare_dataset.py
+++ b/benchmarks/cpp/prepare_dataset.py
@@ -31,6 +31,7 @@ class RootArgs(BaseModel):
     task_id: int
     std_out: bool
     rand_task_id: Optional[Tuple[int, int]]
+    lora_dir: str = "loras"
 
     @field_validator('tokenizer')
     def get_tokenizer(cls,
@@ -73,6 +74,10 @@ class RootArgs(BaseModel):
               default=None,
               nargs=2,
               help="Random LoRA Tasks")
+@click.option("--lora-dir",
+              type=str,
+              default="loras",
+              help="Directory containing LoRA adapters (default: loras)")
 @click.option("--log-level",
               default="info",
               type=click.Choice(['info', 'debug']),
@@ -93,6 +98,7 @@ def cli(ctx, **kwargs):
                        random_seed=kwargs['random_seed'],
                        task_id=kwargs['task_id'],
                        rand_task_id=kwargs['rand_task_id'])
+    ctx.obj.lora_dir = kwargs['lora_dir']
 
 
 cli.add_command(dataset)

--- a/benchmarks/cpp/prepare_dataset.py
+++ b/benchmarks/cpp/prepare_dataset.py
@@ -97,8 +97,8 @@ def cli(ctx, **kwargs):
                        std_out=kwargs['stdout'],
                        random_seed=kwargs['random_seed'],
                        task_id=kwargs['task_id'],
-                       rand_task_id=kwargs['rand_task_id'])
-    ctx.obj.lora_dir = kwargs['lora_dir']
+                       rand_task_id=kwargs['rand_task_id'],
+                       lora_dir=kwargs['lora_dir'])
 
 
 cli.add_command(dataset)

--- a/benchmarks/cpp/prepare_dataset.py
+++ b/benchmarks/cpp/prepare_dataset.py
@@ -31,7 +31,7 @@ class RootArgs(BaseModel):
     task_id: int
     std_out: bool
     rand_task_id: Optional[Tuple[int, int]]
-    lora_dir: str = "loras"
+    lora_dir: Optional[str] = None
 
     @field_validator('tokenizer')
     def get_tokenizer(cls,
@@ -76,8 +76,8 @@ class RootArgs(BaseModel):
               help="Random LoRA Tasks")
 @click.option("--lora-dir",
               type=str,
-              default="loras",
-              help="Directory containing LoRA adapters (default: loras)")
+              default=None,
+              help="Directory containing LoRA adapters")
 @click.option("--log-level",
               default="info",
               type=click.Choice(['info', 'debug']),

--- a/benchmarks/cpp/utils/prepare_synthetic_data.py
+++ b/benchmarks/cpp/utils/prepare_synthetic_data.py
@@ -71,10 +71,13 @@ def token_norm_dist(root_args, **kwargs):
                 "max_output_len": max_output_len
             }, root_args.output)
     else:
-        print_text_dataset(
-            input_ids,
-            output_lens,
-        )
+        print_text_dataset(input_ids,
+                           output_lens,
+                           task_ids=task_ids if root_args.task_id != -1
+                           or root_args.rand_task_id is not None else None,
+                           lora_config={"lora_dir": root_args.lora_dir}
+                           if root_args.task_id != -1
+                           or root_args.rand_task_id is not None else None)
 
 
 @click.command()
@@ -141,7 +144,10 @@ def token_unif_dist(root_args, **kwargs):
                 "max_output_len": max_output_len
             }, root_args.output)
     else:
-        print_text_dataset(
-            input_ids,
-            output_lens,
-        )
+        print_text_dataset(input_ids,
+                           output_lens,
+                           task_ids=task_ids if root_args.task_id != -1
+                           or root_args.rand_task_id is not None else None,
+                           lora_config={"lora_dir": root_args.lora_dir}
+                           if root_args.task_id != -1
+                           or root_args.rand_task_id is not None else None)

--- a/benchmarks/cpp/utils/utils.py
+++ b/benchmarks/cpp/utils/utils.py
@@ -70,13 +70,28 @@ def multimodal_dataset_dump(multimodal_texts, multimodal_image_paths,
         json.dump(workload.model_dump(), f)
 
 
-def print_text_dataset(input_ids, output_lens):
+def print_text_dataset(input_ids, output_lens, task_ids=None, lora_config=None):
     for i, input_tokens in enumerate(input_ids):
         d = {
             "task_id": i,
             "input_ids": input_tokens,
             "output_tokens": output_lens[i]
         }
+
+        # Add LoRA request if task_ids indicate LoRA usage
+        if task_ids is not None and lora_config is not None:
+            task_id = task_ids[i]
+            if task_id != -1:  # -1 means no LoRA
+                d["lora_request"] = {
+                    "lora_name":
+                    f"lora_{task_id}",
+                    "lora_int_id":
+                    task_id,
+                    "lora_path":
+                    os.path.join(lora_config.get("lora_dir", "loras"),
+                                 str(task_id))
+                }
+
         print(json.dumps(d, separators=(',', ':'), ensure_ascii=False))
 
 

--- a/tensorrt_llm/bench/benchmark/utils/asynchronous.py
+++ b/tensorrt_llm/bench/benchmark/utils/asynchronous.py
@@ -51,10 +51,12 @@ class LlmManager:
             request_start_timestamp = time.perf_counter_ns()
             time_on_first_token = None
             # Schedule the request in the LLM API (asynchronously)
+            print(f"request.lora_request: {request.lora_request}")
             output: RequestOutput = self.llm.generate_async(
                 request.input_ids if self.modality is None else request.prompt,
                 sampling_params=sampling_params,
-                streaming=self.streaming)
+                streaming=self.streaming,
+                lora_request=request.lora_request)
             if self.streaming:
                 async for stream_output in output:
                     if time_on_first_token is None:

--- a/tensorrt_llm/bench/benchmark/utils/asynchronous.py
+++ b/tensorrt_llm/bench/benchmark/utils/asynchronous.py
@@ -51,7 +51,7 @@ class LlmManager:
             request_start_timestamp = time.perf_counter_ns()
             time_on_first_token = None
             # Schedule the request in the LLM API (asynchronously)
-            print(f"request.lora_request: {request.lora_request}")
+            logger.debug(f"request.lora_request: {request.lora_request}")
             output: RequestOutput = self.llm.generate_async(
                 request.input_ids if self.modality is None else request.prompt,
                 sampling_params=sampling_params,

--- a/tensorrt_llm/bench/dataclasses/general.py
+++ b/tensorrt_llm/bench/dataclasses/general.py
@@ -7,6 +7,7 @@ from pydantic import (AliasChoices, BaseModel, Field, computed_field,
                       model_validator)
 
 from tensorrt_llm.bench.dataclasses.statistics import PercentileStats
+from tensorrt_llm.executor.request import LoRARequest
 
 
 class BenchmarkEnvironment(BaseModel):
@@ -21,6 +22,7 @@ class InferenceRequest(BaseModel):
     output_tokens: int
     input_ids: Optional[List[int]] = Field(
         alias=AliasChoices("input_ids", "logits"))
+    lora_request: Optional[LoRARequest] = None
 
     @model_validator(mode="after")
     def verify_prompt_and_logits(self) -> InferenceRequest:

--- a/tensorrt_llm/bench/utils/data.py
+++ b/tensorrt_llm/bench/utils/data.py
@@ -7,7 +7,35 @@ from transformers import AutoTokenizer, PreTrainedTokenizer
 from tensorrt_llm.bench.dataclasses.general import (DatasetMetadata,
                                                     InferenceRequest)
 from tensorrt_llm.bench.dataclasses.statistics import PercentileStats
+
 from tensorrt_llm.inputs import default_multimodal_input_loader
+from tensorrt_llm.executor.request import LoRARequest
+from tensorrt_llm.inputs import (INPUT_FORMATTER_MAP, default_image_loader,
+                                 default_video_loader)
+
+
+def prepare_multimodal_inputs(model_dir: str,
+                              model_type: str,
+                              modality: str,
+                              prompts: List[str],
+                              media: List[List[str]],
+                              image_data_format: str = "pt",
+                              num_frames: int = 8) -> List[Dict[str, Any]]:
+    assert model_type in INPUT_FORMATTER_MAP, f"Model type {model_type} not in supported list of models: {INPUT_FORMATTER_MAP.keys()}"
+    formatter = INPUT_FORMATTER_MAP[model_type]
+
+    inputs = []
+    if modality == "image":
+        inputs = default_image_loader(prompts, media, image_data_format)
+    elif modality == "video":
+        inputs = default_video_loader(prompts, media, image_data_format,
+                                      num_frames)
+    else:
+        raise ValueError(f"Unsupported modality: {modality}")
+
+    inputs = formatter(model_dir, inputs)
+
+    return inputs
 
 
 def initialize_tokenizer(model_name: str) -> PreTrainedTokenizer:
@@ -82,6 +110,7 @@ def create_dataset_from_stream(
     media_paths = []
     all_logits = []
     task_ids = []
+    lora_requests = []
     while (line := stream.readline()) and len(task_ids) < max_requests:
         # We expect the data to come in as a JSON string.
         # For example:
@@ -93,6 +122,11 @@ def create_dataset_from_stream(
         # There once was a man who.", "output_tokens": 1000,
         # "media_paths": ["/path/to/image1.jpg", "/path/to/image2.jpg"]}
         #
+        # For LoRA data, the data should be of the form:
+        # {"prompt": "Generate an infinite response to the following:
+        # There once was a man who.", "output_tokens": 1000,
+        # "lora_request": {"lora_name": "my_lora", "lora_int_id": 1, "lora_path": "/path/to/lora"}}
+        #
         # Each line should be a complete JSON dictionary with no indentation
         # or newline characters.
         data = json.loads(line)
@@ -101,6 +135,16 @@ def create_dataset_from_stream(
         all_logits.append(data.get("input_ids", data.get("logits", None)))
         all_osl.append(data.get("output_tokens"))
         task_ids.append(data.get("task_id"))
+
+        # Parse LoRA request if present
+        lora_data = data.get("lora_request", None)
+        if lora_data:
+            lora_request = LoRARequest(lora_name=lora_data["lora_name"],
+                                       lora_int_id=lora_data["lora_int_id"],
+                                       lora_path=lora_data.get("lora_path", ""))
+            lora_requests.append(lora_request)
+        else:
+            lora_requests.append(None)
 
     if modality is not None:
         # Multimodal data need extra preprocessing
@@ -117,8 +161,8 @@ def create_dataset_from_stream(
 
     all_isl = []
     all_seq_len = []
-    for prompt, logits, osl, task_id in zip(prompts, all_logits, all_osl,
-                                            task_ids):
+    for prompt, logits, osl, task_id, lora_request in zip(
+            prompts, all_logits, all_osl, task_ids, lora_requests):
         if modality is not None:
             # NOTE: we cannot tokenize multi-modal data, handled by preprocessor
             #       so the actual sequence length is unknown until the model is run
@@ -137,6 +181,7 @@ def create_dataset_from_stream(
             prompt=prompt,
             output_tokens=output_limiter(osl),
             input_ids=logits,
+            lora_request=lora_request,
         )
         dataset.append(request)
 

--- a/tensorrt_llm/bench/utils/data.py
+++ b/tensorrt_llm/bench/utils/data.py
@@ -8,8 +8,8 @@ from tensorrt_llm.bench.dataclasses.general import (DatasetMetadata,
                                                     InferenceRequest)
 from tensorrt_llm.bench.dataclasses.statistics import PercentileStats
 
-from tensorrt_llm.inputs import default_multimodal_input_loader
 from tensorrt_llm.executor.request import LoRARequest
+from tensorrt_llm.inputs import default_multimodal_input_loader
 from tensorrt_llm.inputs import (INPUT_FORMATTER_MAP, default_image_loader,
                                  default_video_loader)
 

--- a/tensorrt_llm/bench/utils/data.py
+++ b/tensorrt_llm/bench/utils/data.py
@@ -7,35 +7,8 @@ from transformers import AutoTokenizer, PreTrainedTokenizer
 from tensorrt_llm.bench.dataclasses.general import (DatasetMetadata,
                                                     InferenceRequest)
 from tensorrt_llm.bench.dataclasses.statistics import PercentileStats
-
 from tensorrt_llm.executor.request import LoRARequest
 from tensorrt_llm.inputs import default_multimodal_input_loader
-from tensorrt_llm.inputs import (INPUT_FORMATTER_MAP, default_image_loader,
-                                 default_video_loader)
-
-
-def prepare_multimodal_inputs(model_dir: str,
-                              model_type: str,
-                              modality: str,
-                              prompts: List[str],
-                              media: List[List[str]],
-                              image_data_format: str = "pt",
-                              num_frames: int = 8) -> List[Dict[str, Any]]:
-    assert model_type in INPUT_FORMATTER_MAP, f"Model type {model_type} not in supported list of models: {INPUT_FORMATTER_MAP.keys()}"
-    formatter = INPUT_FORMATTER_MAP[model_type]
-
-    inputs = []
-    if modality == "image":
-        inputs = default_image_loader(prompts, media, image_data_format)
-    elif modality == "video":
-        inputs = default_video_loader(prompts, media, image_data_format,
-                                      num_frames)
-    else:
-        raise ValueError(f"Unsupported modality: {modality}")
-
-    inputs = formatter(model_dir, inputs)
-
-    return inputs
 
 
 def initialize_tokenizer(model_name: str) -> PreTrainedTokenizer:

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1862,6 +1862,7 @@ def update_llm_args_with_extra_dict(
         "extended_runtime_perf_knob_config": ExtendedRuntimePerfKnobConfig,
         "pytorch_backend_config": PyTorchConfig,
         "cache_transceiver_config": CacheTransceiverConfig,
+        "lora_config": LoraConfig,
     }
     for field, field_type in field_mapping.items():
         if field in llm_args_dict:

--- a/tensorrt_llm/lora_manager.py
+++ b/tensorrt_llm/lora_manager.py
@@ -201,7 +201,7 @@ class HfLoraLoader:
             raise ValueError(f"adapter_model file does not exist in {lora_dir}")
         lora_weight = load_state_dict(model_path)
         self.lora_weight = lora_weight
-        if adapter_config["modules_to_save"] is not None:
+        if adapter_config.get("modules_to_save") is not None:
             if "lm_head" in adapter_config["modules_to_save"]:
                 self.lm_head = lora_weight["base_model.model.lm_head.weight"]
                 self.vocab_size = self.lm_head.shape[0]

--- a/tests/unittest/tools/test_prepare_dataset.py
+++ b/tests/unittest/tools/test_prepare_dataset.py
@@ -1,0 +1,222 @@
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+from tests.unittest.utils.llm_data import llm_models_root
+
+# Constants for test configuration
+_DEFAULT_NUM_REQUESTS = 3
+_DEFAULT_INPUT_MEAN = 100
+_DEFAULT_INPUT_STDEV = 10
+_DEFAULT_OUTPUT_MEAN = 100
+_DEFAULT_OUTPUT_STDEV = 10
+_TEST_TASK_IDS = [0, 1, 2]
+_TOKENIZER_SUBPATH = "llama-models-v2/tinyllama-tarot-v1/"
+_PREPARE_DATASET_SCRIPT_PATH = "benchmarks/cpp/prepare_dataset.py"
+
+
+class TestPrepareDatasetLora:
+    """
+    Test suite for prepare_dataset.py CLI tool LoRA metadata generation functionality.
+
+    This test class validates that the prepare_dataset.py script correctly generates
+    LoRA request metadata when LoRA-specific parameters are provided. It covers both
+    fixed task ID and random task ID scenarios.
+    """
+
+    @pytest.fixture
+    def temp_lora_dir(self) -> str:
+        """
+        Create a temporary LoRA directory structure for testing.
+
+        Creates a temporary directory with subdirectories for each test task ID,
+        simulating the expected LoRA adapter directory structure.
+
+        Returns:
+            str: Path to the temporary LoRA directory
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            lora_dir = Path(temp_dir) / "loras"
+            # Create dummy LoRA adapter directories for each test task ID
+            for task_id in _TEST_TASK_IDS:
+                task_dir = lora_dir / str(task_id)
+                task_dir.mkdir(parents=True, exist_ok=True)
+            yield str(lora_dir)
+
+    def _build_base_command(self, llm_root: Path) -> List[str]:
+        """
+        Build the base command for running prepare_dataset.py.
+
+        Args:
+            llm_root: Path to the TensorRT-LLM root directory
+
+        Returns:
+            List[str]: Base command components
+
+        Raises:
+            pytest.skip: If LLM_MODELS_ROOT is not available
+        """
+        script_path = llm_root / _PREPARE_DATASET_SCRIPT_PATH
+        cmd = ["python3", str(script_path)]
+
+        # Add required tokenizer argument
+        model_cache = llm_models_root()
+        if model_cache is None:
+            pytest.skip("LLM_MODELS_ROOT not available")
+
+        tokenizer_dir = model_cache / _TOKENIZER_SUBPATH
+        cmd.extend(["--tokenizer", str(tokenizer_dir)])
+
+        # Always add --stdout flag since we parse stdout output
+        cmd.extend(["--stdout"])
+
+        return cmd
+
+    def _add_lora_arguments(self, cmd: List[str], **kwargs) -> None:
+        """
+        Add LoRA-specific arguments to the command.
+
+        Args:
+            cmd: Command list to modify in-place
+            **kwargs: Keyword arguments containing LoRA parameters
+        """
+        if "lora_dir" in kwargs:
+            cmd.extend(["--lora-dir", kwargs["lora_dir"]])
+        if "task_id" in kwargs:
+            cmd.extend(["--task-id", str(kwargs["task_id"])])
+        if "rand_task_id" in kwargs:
+            min_id, max_id = kwargs["rand_task_id"]
+            cmd.extend(["--rand-task-id", str(min_id), str(max_id)])
+
+    def _add_synthetic_data_arguments(self, cmd: List[str]) -> None:
+        """
+        Add synthetic data generation arguments to the command.
+
+        Args:
+            cmd: Command list to modify in-place
+        """
+        cmd.extend([
+            "token-norm-dist", "--num-requests",
+            str(_DEFAULT_NUM_REQUESTS), "--input-mean",
+            str(_DEFAULT_INPUT_MEAN), "--input-stdev",
+            str(_DEFAULT_INPUT_STDEV), "--output-mean",
+            str(_DEFAULT_OUTPUT_MEAN), "--output-stdev",
+            str(_DEFAULT_OUTPUT_STDEV)
+        ])
+
+    def _run_prepare_dataset(self, llm_root: Path, **kwargs) -> str:
+        """
+        Execute prepare_dataset.py with specified parameters and capture output.
+
+        Args:
+            llm_root: Path to the TensorRT-LLM root directory
+            **kwargs: Keyword arguments for LoRA configuration
+
+        Returns:
+            str: Standard output from the executed command
+
+        Raises:
+            subprocess.CalledProcessError: If the command execution fails
+        """
+        cmd = self._build_base_command(llm_root)
+        self._add_lora_arguments(cmd, **kwargs)
+        self._add_synthetic_data_arguments(cmd)
+
+        # Execute command and capture output
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        return result.stdout
+
+    def _parse_json_output(self, output: str) -> List[Dict[str, Any]]:
+        """
+        Parse JSON lines from prepare_dataset.py output.
+
+        Args:
+            output: Raw stdout output containing JSON lines
+
+        Returns:
+            List[Dict[str, Any]]: Parsed JSON data objects
+        """
+        lines = output.strip().split('\n')
+        json_data = []
+
+        for line in lines:
+            if line.strip():
+                try:
+                    data = json.loads(line)
+                    json_data.append(data)
+                except json.JSONDecodeError:
+                    # Skip non-JSON lines (such as debug prints)
+                    continue
+
+        return json_data
+
+    def _validate_lora_request(self,
+                               lora_request: Dict[str, Any],
+                               expected_lora_dir: str,
+                               task_id_range: Tuple[int, int] = None) -> None:
+        """Validate LoRA request structure and content."""
+        # Check required fields
+        required_fields = ["lora_name", "lora_int_id", "lora_path"]
+        for field in required_fields:
+            assert field in lora_request, f"Missing '{field}' in LoRA request"
+
+        task_id = lora_request["lora_int_id"]
+
+        # Validate task ID range if specified
+        if task_id_range:
+            min_id, max_id = task_id_range
+            assert min_id <= task_id <= max_id, f"Task ID {task_id} out of range [{min_id}, {max_id}]"
+
+        # Validate structure
+        expected_name = f"lora_{task_id}"
+        expected_path = os.path.join(expected_lora_dir, str(task_id))
+
+        assert lora_request["lora_name"] == expected_name, \
+            f"Expected LoRA name '{expected_name}', got '{lora_request['lora_name']}'"
+        assert lora_request["lora_path"] == expected_path, \
+            f"Expected LoRA path '{expected_path}', got '{lora_request['lora_path']}'"
+
+    @pytest.mark.parametrize("test_params", [
+        pytest.param({
+            "task_id": 1,
+            "description": "fixed task ID"
+        },
+                     id="fixed_task_id"),
+        pytest.param(
+            {
+                "rand_task_id": (0, 2),
+                "description": "random task ID range"
+            },
+            id="random_task_id")
+    ])
+    def test_lora_metadata_generation(self, llm_root: Path, temp_lora_dir: str,
+                                      test_params: Dict) -> None:
+        """Test LoRA metadata generation with various configurations."""
+        # Extract test parameters
+        task_id = test_params.get("task_id")
+        rand_task_id = test_params.get("rand_task_id")
+        description = test_params["description"]
+
+        # Run prepare_dataset
+        kwargs = {"lora_dir": temp_lora_dir}
+        if task_id is not None:
+            kwargs["task_id"] = task_id
+        if rand_task_id is not None:
+            kwargs["rand_task_id"] = rand_task_id
+
+        output = self._run_prepare_dataset(llm_root, **kwargs)
+        json_data = self._parse_json_output(output)
+
+        assert len(json_data) > 0, f"No JSON data generated for {description}"
+
+        # Validate LoRA requests
+        for i, item in enumerate(json_data):
+            assert "lora_request" in item, f"Missing 'lora_request' in JSON entry {i} for {description}"
+            self._validate_lora_request(item["lora_request"],
+                                        temp_lora_dir,
+                                        task_id_range=rand_task_id)

--- a/tests/unittest/tools/test_prepare_dataset.py
+++ b/tests/unittest/tools/test_prepare_dataset.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
 import pytest
+from utils.cpp_paths import llm_root  # noqa: F401
 from utils.llm_data import llm_models_root
 
 # Constants for test configuration

--- a/tests/unittest/tools/test_prepare_dataset.py
+++ b/tests/unittest/tools/test_prepare_dataset.py
@@ -6,8 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
 import pytest
-
-from tests.unittest.utils.llm_data import llm_models_root
+from utils.llm_data import llm_models_root
 
 # Constants for test configuration
 _DEFAULT_NUM_REQUESTS = 3
@@ -22,11 +21,12 @@ _PREPARE_DATASET_SCRIPT_PATH = "benchmarks/cpp/prepare_dataset.py"
 
 class TestPrepareDatasetLora:
     """
-    Test suite for prepare_dataset.py CLI tool LoRA metadata generation functionality.
+    Test suite for prepare_dataset.py CLI tool LoRA metadata generation
+    functionality.
 
-    This test class validates that the prepare_dataset.py script correctly generates
-    LoRA request metadata when LoRA-specific parameters are provided. It covers both
-    fixed task ID and random task ID scenarios.
+    This test class validates that the prepare_dataset.py script correctly
+    generates LoRA request metadata when LoRA-specific parameters are provided.
+    It covers both fixed task ID and random task ID scenarios.
     """
 
     @pytest.fixture
@@ -34,8 +34,8 @@ class TestPrepareDatasetLora:
         """
         Create a temporary LoRA directory structure for testing.
 
-        Creates a temporary directory with subdirectories for each test task ID,
-        simulating the expected LoRA adapter directory structure.
+        Creates a temporary directory with subdirectories for each test task
+        ID, simulating the expected LoRA adapter directory structure.
 
         Returns:
             str: Path to the temporary LoRA directory
@@ -111,7 +111,8 @@ class TestPrepareDatasetLora:
 
     def _run_prepare_dataset(self, llm_root: Path, **kwargs) -> str:
         """
-        Execute prepare_dataset.py with specified parameters and capture output.
+        Execute prepare_dataset.py with specified parameters and capture
+        output.
 
         Args:
             llm_root: Path to the TensorRT-LLM root directory
@@ -170,16 +171,19 @@ class TestPrepareDatasetLora:
         # Validate task ID range if specified
         if task_id_range:
             min_id, max_id = task_id_range
-            assert min_id <= task_id <= max_id, f"Task ID {task_id} out of range [{min_id}, {max_id}]"
+            assert min_id <= task_id <= max_id, (
+                f"Task ID {task_id} out of range [{min_id}, {max_id}]")
 
         # Validate structure
         expected_name = f"lora_{task_id}"
         expected_path = os.path.join(expected_lora_dir, str(task_id))
 
-        assert lora_request["lora_name"] == expected_name, \
-            f"Expected LoRA name '{expected_name}', got '{lora_request['lora_name']}'"
-        assert lora_request["lora_path"] == expected_path, \
-            f"Expected LoRA path '{expected_path}', got '{lora_request['lora_path']}'"
+        assert lora_request["lora_name"] == expected_name, (
+            f"Expected LoRA name '{expected_name}', "
+            f"got '{lora_request['lora_name']}'")
+        assert lora_request["lora_path"] == expected_path, (
+            f"Expected LoRA path '{expected_path}', "
+            f"got '{lora_request['lora_path']}'")
 
     @pytest.mark.parametrize("test_params", [
         pytest.param({
@@ -216,7 +220,8 @@ class TestPrepareDatasetLora:
 
         # Validate LoRA requests
         for i, item in enumerate(json_data):
-            assert "lora_request" in item, f"Missing 'lora_request' in JSON entry {i} for {description}"
+            assert "lora_request" in item, (
+                f"Missing 'lora_request' in JSON entry {i} for {description}")
             self._validate_lora_request(item["lora_request"],
                                         temp_lora_dir,
                                         task_id_range=rand_task_id)


### PR DESCRIPTION
# Description

This PR does some plumbing required to easily enable LoRA pathway in PyT backend from trtllm-bench itself, given an appropriate `extra-llm-api-config.yml` and `synthetic_data.json`.

## Checklist
- [x] prepare_dataset changes 
- [x] trtllm-bench and internal plumbing to accept lora metadata, locally verify it works.
- [x] unittest for prepare_dataset
- [x] documentation 
- [ ] e2e trtllm-bench with lora on pyt test (this is will be added as part of a second PR that requires some `test_perf.py`-level non-trivial changes).

## More deets

The `extra-llm-api-config.json` should include a section for lora config specifying the lora information. 
That should look something like this: 
```yaml
...
lora_config:
  lora_dir:
  - path/to/loras/0
  - /path/to/loras/1
  max_lora_rank: 64
  lora_target_modules:
  - attn_q
  - attn_k
  - attn_v
  trtllm_modules_to_hf_modules:
    attn_q: q_proj
    attn_k: k_proj
    attn_v: v_proj
...
```

The PR also includes decessary changes to `tensorrt_llm/benchmarks/cpp/prepare_dataset.py` needed to include generation requests including lora request details.
The below is an example command to generate the appropriate `synthetic_data.json` that incorporates random lora requests involving loras with task ids 0,1:

```bash
python3 /path/to/tensorrt_llm/benchmarks/cpp/prepare_dataset.py \
  --stdout \
  --rand-task-id 0 1 \
  --tokenizer=/path/to/llm-models/llama-3.1-model/Llama-3.1-8B-Instruct-FP8 \
  --lora-dir=/path/to/loras \ # assumes that the different task-specific loras are numbered subdirs (0/, 1/,..etc.) 
  token-norm-dist \
  --num-requests=100 \
  --input-mean=128 \
  --output-mean=128 \
  --input-stdev=16 \
  --output-stdev=24 \
  > path/to/synthetic_data.json
```

NOTE: The prepare_dataset.py script takes the 'parent' lora directory containing each task-specific loras, and assumes thes task-specific lora subdirectories, with their names being their respective lora task ID. 

below is how a sample request should look like when the above command is run: 
```json
{
  "task_id": 0,
  "input_ids": [
    3452, 88226, 102415, .... 
  ],
  "output_tokens": ...,
  "lora_request": {
    "lora_name": "lora_0",
    "lora_int_id": 0,
    "lora_path": "/path/to/loras/0"
  }
}
``` 