### PR TITLE
[TRTLLM-5644][infra] Update the community action to more appropriate api

### DIFF
--- a/.github/scripts/label_community_user.py
+++ b/.github/scripts/label_community_user.py
@@ -59,12 +59,21 @@ def get_nvidia_members() -> list[str]:
     return members
 
 
-def add_label_to_pr(repo_name: str, pr_number: str, label: str):
+def add_label_to_pr(repo_owner: str, repo_name: str, pr_number: str,
+                    label: str):
     """Adds a label to a pull request."""
-    url = f"{GITHUB_API_URL}/repos/NVIDIA/{repo_name}/issues/{pr_number}/labels"
+    url = f"{GITHUB_API_URL}/repos/{repo_owner}/{repo_name}/issues/{pr_number}/labels"
     payload = {"labels": [label]}
+    print(f"Attempting to add label. URL: {url}, Payload: {payload}")
     try:
         response = requests.post(url, headers=HEADERS, json=payload)
+        print(f"API Response Status Code: {response.status_code}")
+        try:
+            response_json = response.json()
+            print(f"API Response JSON: {response_json}")
+        except requests.exceptions.JSONDecodeError:
+            print(f"API Response Text (not JSON): {response.text}")
+
         response.raise_for_status()
         print(f"Successfully added label '{label}' to PR #{pr_number}.")
     except requests.exceptions.RequestException as e:
@@ -78,6 +87,8 @@ def main():
     assert pr_author, "PR_AUTHOR environment variable not set"
     pr_number = os.environ.get("PR_NUMBER")
     assert pr_number, "PR_NUMBER environment variable not set"
+    repo_owner = os.environ.get("REPO_OWNER")
+    assert repo_owner, "REPO_OWNER environment variable not set"
     repo_name = os.environ.get("REPO_NAME")
     assert repo_name, "REPO_NAME environment variable not set"
     community_label = os.environ.get("COMMUNITY_LABEL")
@@ -99,7 +110,7 @@ def main():
         print(
             f"User '{pr_author}' is a community user. Adding label '{community_label}'."
         )
-        add_label_to_pr(repo_name, pr_number, community_label)
+        add_label_to_pr(repo_owner, repo_name, pr_number, community_label)
     else:
         print(
             f"User '{pr_author}' is an NVIDIA member. No label will be added.")

--- a/.github/scripts/label_community_user.py
+++ b/.github/scripts/label_community_user.py
@@ -22,11 +22,19 @@ def check_user_membership(org: str, username: str) -> bool:
                                 timeout=10,
                                 allow_redirects=False)
 
-        if response.status_code == 204 or response.status_code == 302:
+        if response.status_code == 204:
             print(
                 f"Membership check for '{username}' in '{org}': Positive (Status {response.status_code})."
             )
             return True
+        elif response.status_code == 302:
+            detail = (
+                f"Cannot determine membership for '{username}' in '{org}' (Status 302). "
+                f"The requester token does not have organization membership privileges. "
+                f"This usually means the token is not associated with an org member."
+            )
+            print(detail)
+            raise RuntimeError(detail)
         elif response.status_code == 404:
             print(
                 f"Membership check for '{username}' in '{org}': Negative (Status {response.status_code})."

--- a/.github/scripts/label_community_user.py
+++ b/.github/scripts/label_community_user.py
@@ -3,13 +3,13 @@ import os
 import requests
 
 GITHUB_API_URL = "https://api.github.com"
-GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
-assert GITHUB_TOKEN, "GITHUB_TOKEN environment variable not set"
+AUTO_LABEL_COMMUNITY_TOKEN = os.environ.get("AUTO_LABEL_COMMUNITY_TOKEN")
+assert AUTO_LABEL_COMMUNITY_TOKEN, "AUTO_LABEL_COMMUNITY_TOKEN environment variable not set"
 
 HEADERS = {
     "Accept": "application/vnd.github.v3+json",
     "User-Agent": "PythonGitHubAction-Labeler/1.0",
-    "Authorization": f"token {GITHUB_TOKEN}",
+    "Authorization": f"token {AUTO_LABEL_COMMUNITY_TOKEN}",
 }
 
 

--- a/.github/workflows/label_community_pr.yml
+++ b/.github/workflows/label_community_pr.yml
@@ -3,6 +3,8 @@ name: Label Community PR
 on:
   pull_request:
     types: [opened]
+permissions:
+  pull-requests: write
 
 jobs:
   label_pr:
@@ -24,6 +26,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO_OWNER: ${{ github.event.repository.owner.login }}
           REPO_NAME: ${{ github.event.repository.name }}
           COMMUNITY_LABEL: "Community want to contribute"
         run: python .github/scripts/label_community_user.py

--- a/.github/workflows/label_community_pr.yml
+++ b/.github/workflows/label_community_pr.yml
@@ -3,8 +3,6 @@ name: Label Community PR
 on:
   pull_request:
     types: [opened]
-permissions:
-  pull-requests: write
 
 jobs:
   label_pr:

--- a/.github/workflows/label_community_pr.yml
+++ b/.github/workflows/label_community_pr.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Run labeling script
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AUTO_LABEL_COMMUNITY_TOKEN: ${{ secrets.AUTO_LABEL_COMMUNITY_TOKEN }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO_OWNER: ${{ github.event.repository.owner.login }}


### PR DESCRIPTION
## Description

The community identifier is fetching all nvidia members and check if the requester is in it. A better and more efficient way to do it is to use this endpoint instead 
```
curl -L \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer <YOUR-TOKEN>" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  https://api.github.com/orgs/ORG/members/USERNAME
```
cc @yuantailing 
## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
