### PR TITLE
[AutoDeploy] _AutoDeployLlmArgs as primary config object

### DIFF
--- a/examples/auto_deploy/.vscode/launch.json
+++ b/examples/auto_deploy/.vscode/launch.json
@@ -8,7 +8,7 @@
             "program": "build_and_run_ad.py",
             "args": [
                 "--config",
-                "{\"batch_size\": 2, \"page_size\": 16, \"world_size\": 2, \"compile_backend\": \"torch-simple\", \"attn_backend\": \"FlashInfer\",\"model_factory\": \"AutoModelForCausalLM\", \"model\": \"meta-llama/Meta-Llama-3.1-8B-Instruct\", \"benchmark\": false}",
+                "{\"batch_size\": 2, \"attn_page_size\": 16, \"world_size\": 2, \"compile_backend\": \"torch-simple\", \"attn_backend\": \"FlashInfer\",\"model_factory\": \"AutoModelForCausalLM\", \"model\": \"meta-llama/Meta-Llama-3.1-8B-Instruct\", \"benchmark\": false}",
                 "--model-kwargs",
                 "{}",
                 // "{\"num_hidden_layers\": 3}",

--- a/examples/auto_deploy/README.md
+++ b/examples/auto_deploy/README.md
@@ -151,7 +151,7 @@ In the below example:
 | `"mla_backend"` | Specifies implementation for multi-head latent attention |
 | `"max_seq_len"` | Maximum sequence length for inference/cache |
 | `"max_batch_size"` | Maximum dimension for statically allocated KV cache |
-| `"page_size"` | Page size for attention |
+| `"attn_page_size"` | Page size for attention |
 | `"benchmark"` | Indicates whether to run the built-in benchmark for token generation |
 
 For default values and additional configuration options, refer to the [simple_config.py](./simple_config.py) file.
@@ -236,37 +236,25 @@ Here is an example of how you can build an LLM object with AutoDeploy integratio
 
 ```
 from tensorrt_llm import LLM
-from tensorrt_llm.builder import BuildConfig
-from tensorrt_llm._torch.auto_deploy.shim import AutoDeployConfig
 
-# 1. Set up the build configuration
-build_config = BuildConfig(
-    max_seq_len=<MAX_SEQ_LEN>,
-    max_batch_size=<MAX_BS>,
-)
-build_config.plugin_config.tokens_per_block = <PAGE_SIZE>
-# if using "TritonWithFlattenedInputs" as backend, <PAGE_SIZE> should equal to <MAX_SEQ_LEN>
-# Refer to examples/auto_deploy/simple_config.py (line 109) for details.
 
-# 2. Set up AutoDeploy configuration
-# AutoDeploy will use its own cache implementation
-model_kwargs = {"use_cache":False}
-
-ad_config = AutoDeployConfig(
-    use_cuda_graph=True, # set True if using "torch-opt" as compile backend
-    torch_compile_enabled=True, # set True if using "torch-opt" as compile backend
-    model_kwargs=model_kwargs,
-    attn_backend="TritonWithFlattenedInputs", # choose between "TritonWithFlattenedInputs" and "FlashInfer"
-    skip_loading_weights=False,
-)
-
-# 3. Construct the LLM high-level interface object with autodeploy as backend
+# Construct the LLM high-level interface object with autodeploy as backend
 llm = LLM(
     model=<HF_MODEL_CARD_OR_DIR>,
     backend="autodeploy",
-    build_config=build_config,
-    auto_deploy_config=ad_config,
     tensor_parallel_size=<NUM_WORLD_RANK>,
+    use_cuda_graph=True, # set True if using "torch-opt" as compile backend
+    torch_compile_enabled=True, # set True if using "torch-opt" as compile backend
+    model_kwargs={"use_cache": False}, # AutoDeploy uses its own cache implementation
+    attn_backend="TritonWithFlattenedInputs", # choose between "TritonWithFlattenedInputs" and "FlashInfer"
+    attn_page_size=64, # page size for attention (tokens_per_block, should be == max_seq_len for triton)
+    skip_loading_weights=False,
+    model_factory="AutoModelForCausalLM", # choose appropriate model factory
+    mla_backend="MultiHeadLatentAttention", # for models that support MLA
+    free_mem_ratio=0.8, # fraction of available memory for cache
+    simple_shard_only=False, # tensor parallelism sharding strategy
+    max_seq_len=<MAX_SEQ_LEN>,
+    max_batch_size=<MAX_BATCH_SIZE>,
 )
 
 ```

--- a/examples/auto_deploy/README.md
+++ b/examples/auto_deploy/README.md
@@ -241,7 +241,7 @@ from tensorrt_llm import LLM
 # Construct the LLM high-level interface object with autodeploy as backend
 llm = LLM(
     model=<HF_MODEL_CARD_OR_DIR>,
-    backend="autodeploy",
+    backend="_autodeploy",
     tensor_parallel_size=<NUM_WORLD_RANK>,
     use_cuda_graph=True, # set True if using "torch-opt" as compile backend
     torch_compile_enabled=True, # set True if using "torch-opt" as compile backend

--- a/examples/auto_deploy/build_and_run_ad.py
+++ b/examples/auto_deploy/build_and_run_ad.py
@@ -8,10 +8,9 @@ import torch
 from simple_config import SimpleConfig
 
 from tensorrt_llm._torch.auto_deploy.models import ModelFactoryRegistry
-from tensorrt_llm._torch.auto_deploy.shim import AutoDeployConfig, DemoLLM
+from tensorrt_llm._torch.auto_deploy.shim import DemoLLM
 from tensorrt_llm._torch.auto_deploy.utils.benchmark import benchmark, store_benchmark_results
 from tensorrt_llm._torch.auto_deploy.utils.logger import ad_logger
-from tensorrt_llm.builder import BuildConfig
 from tensorrt_llm.llmapi.llm import LLM, RequestOutput
 from tensorrt_llm.sampling_params import SamplingParams
 
@@ -33,27 +32,6 @@ def get_config_and_check_args() -> SimpleConfig:
 
 def build_llm_from_config(config: SimpleConfig) -> LLM:
     """Builds a LLM object from our config."""
-    # set up builder config
-    build_config = BuildConfig(max_seq_len=config.max_seq_len, max_batch_size=config.max_batch_size)
-    build_config.plugin_config.tokens_per_block = config.page_size
-
-    # setup AD config
-    ad_config = AutoDeployConfig(
-        # Both torch-opt and torch-cudagraph invoke cudagraphs
-        use_cuda_graph=config.compile_backend in ["torch-opt", "torch-cudagraph"],
-        # Both torch-opt and torch-compile invoke torch.compile
-        torch_compile_enabled=config.compile_backend in ["torch-opt", "torch-compile"],
-        model_factory=config.model_factory,
-        model_kwargs=config.model_kwargs,
-        attn_backend=config.attn_backend,
-        mla_backend=config.mla_backend,
-        skip_loading_weights=config.skip_loading_weights,
-        cuda_graph_max_batch_size=config.max_batch_size,
-        free_mem_ratio=config.free_mem_ratio,
-        simple_shard_only=config.simple_shard_only,
-    )
-    ad_logger.info(f"AutoDeploy Config: {ad_config}")
-
     # TODO: let's see if prefetching can't be done through the LLM api?
     # I believe the "classic workflow" invoked via the LLM api can do that.
     # put everything into the HF model Factory and try pre-fetching the checkpoint
@@ -74,8 +52,20 @@ def build_llm_from_config(config: SimpleConfig) -> LLM:
     llm = llm_lookup[config.runtime](
         model=factory.model,
         backend="autodeploy",
-        build_config=build_config,
-        auto_deploy_config=ad_config,
+        max_seq_len=config.max_seq_len,
+        max_batch_size=config.max_batch_size,
+        # AutoDeploy-specific parameters
+        use_cuda_graph=config.compile_backend in ["torch-opt", "torch-cudagraph"],
+        torch_compile_enabled=config.compile_backend in ["torch-opt", "torch-compile"],
+        model_factory=config.model_factory,
+        model_kwargs=config.model_kwargs,
+        attn_backend=config.attn_backend,
+        mla_backend=config.mla_backend,
+        skip_loading_weights=config.skip_loading_weights,
+        cuda_graph_max_batch_size=config.max_batch_size,
+        free_mem_ratio=config.free_mem_ratio,
+        simple_shard_only=config.simple_shard_only,
+        attn_page_size=config.attn_page_size,  # Now passed directly as AutoDeploy parameter
         tensor_parallel_size=config.world_size,
         tokenizer=factory.init_tokenizer() if config.customize_tokenizer else None,
     )

--- a/examples/auto_deploy/build_and_run_ad.py
+++ b/examples/auto_deploy/build_and_run_ad.py
@@ -51,7 +51,7 @@ def build_llm_from_config(config: SimpleConfig) -> LLM:
     }
     llm = llm_lookup[config.runtime](
         model=factory.model,
-        backend="autodeploy",
+        backend="_autodeploy",
         max_seq_len=config.max_seq_len,
         max_batch_size=config.max_batch_size,
         # AutoDeploy-specific parameters

--- a/examples/auto_deploy/simple_config.py
+++ b/examples/auto_deploy/simple_config.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Literal, Optional, Union
 
 
+# TODO: remove and unify with AutoDeployLlmArgs
 @dataclass
 class SimpleConfig:
     """Experiment Configuration."""
@@ -55,7 +56,7 @@ class SimpleConfig:
     mla_backend: Literal["MultiHeadLatentAttention"] = "MultiHeadLatentAttention"
     max_seq_len: int = 512  # max sequence length for inference/cache
     max_batch_size: int = 8  # max dimension for statically allocated kv cache
-    page_size: int = 64  # page size for attention
+    attn_page_size: int = 64  # page size for attention
     simple_shard_only: bool = False  # if True, force simple sharding(all_gather) in TP;
     # otherwise auto-detect and use column+row (all_reduce) sharding
 
@@ -94,11 +95,8 @@ class SimpleConfig:
         # check if model was supplied
         assert self.model, "model must be supplied!"
 
-        # we don't want to loose the default values for model_kwargs unless explicitly set by the
-        # user. They are not preserved by the standard initialization process since they whole dict
-        # gets replaced by the user provided one. We don't want that though.
-        f_default = self.__dataclass_fields__["model_kwargs"].default_factory()
-        setattr(self, "model_kwargs", {**f_default, **getattr(self, "model_kwargs")})
+        # NEVER use cache
+        self.model_kwargs["use_cache"] = False
 
         # special handling for torch_dtype in model_kwargs since HF does not correctly update
         # torch_dtype string to an actual torch.dtype object (only with default)
@@ -120,7 +118,7 @@ class SimpleConfig:
 
         # No paging allowed in TritonWithFlattenedInputs
         if self.attn_backend in ["TritonWithFlattenedInputs"]:
-            self.page_size = self.max_seq_len
+            self.attn_page_size = self.max_seq_len
 
         # use min instead of max to avoid OOM for large batch size
         self.model_kwargs["max_position_embeddings"] = min(

--- a/examples/auto_deploy/simple_config.py
+++ b/examples/auto_deploy/simple_config.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Literal, Optional, Union
 
 
-# TODO: remove and unify with AutoDeployLlmArgs
+# TODO: remove and unify with _AutoDeployLlmArgs
 @dataclass
 class SimpleConfig:
     """Experiment Configuration."""

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -86,7 +86,7 @@ class SequenceInfo:
     # then the maximum number of sequences possible in the batch is min (max_batch_size, max_num_tokens // ISL).
     # Similarly, if a batch is composed of generate-only requests,
     # then the maximum number of sequences possible in the batch is min (max_batch_size, max_num_tokens).
-    max_num_tokens: int = 0
+    max_num_tokens: Optional[int] = None
 
     ## [UPDATE WITH CARE] TENSOR FIELDS THAT WILL BE PASSED TO PREPARE_METADATA OP #################
     # input_ids MUST ALWAYS BE THE FIRST FIELD
@@ -112,7 +112,7 @@ class SequenceInfo:
         # see https://github.com/NVIDIA/TensorRT-LLM/issues/4504
         max_seq_len_adjusted = self.max_seq_len + 1
 
-        if self.max_num_tokens < 1:
+        if self.max_num_tokens is None or self.max_num_tokens < 1:
             self.max_num_tokens = self.max_batch_size * max_seq_len_adjusted
         # if the provided max_num_tokens is less than the max_batch_size * max_seq_len,
         # we use the provided max_num_tokens to calculate the number of pages

--- a/tensorrt_llm/_torch/auto_deploy/shim/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/__init__.py
@@ -2,4 +2,4 @@
 
 from .ad_executor import create_autodeploy_executor
 from .demollm import DemoLLM
-from .interface import AutoDeployConfig, CachedSequenceInterface, GetInferenceModel
+from .interface import CachedSequenceInterface, GetInferenceModel

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -9,6 +9,7 @@ from tensorrt_llm._utils import nvtx_range
 from ...._utils import mpi_rank, mpi_world_size
 from ....bindings.executor import ExecutorConfig
 from ....bindings.internal.batch_manager import CacheType
+from ....llmapi.llm_args import AutoDeployLlmArgs
 from ....mapping import Mapping
 from ...distributed import MPIDist
 from ...pyexecutor.config import PyTorchConfig
@@ -27,7 +28,7 @@ from ..distributed import common as dist
 from ..models import ModelFactoryRegistry
 from ..transformations.transform import InferenceOptimizer
 from ..utils.logger import ad_logger
-from .interface import AutoDeployConfig, CachedSequenceInterface, GetInferenceModel
+from .interface import CachedSequenceInterface, GetInferenceModel
 
 
 class _CacheManagerWithFakePool(KVCacheManager):
@@ -84,11 +85,11 @@ class ADEngine(ModelEngine):
     def build_from_config(
         cls,
         model: str,
-        ad_config: AutoDeployConfig,
+        ad_config: AutoDeployLlmArgs,
         seq_info: SequenceInfo,
         device: DeviceLikeType,
     ):
-        """Build the ADEngine using the AutoDeployConfig that gets passed through from the LLM."""
+        """Build the ADEngine using the AutoDeployLlmArgs that gets passed through from the LLM."""
 
         # update device to contain the current default device if it's in cuda
         device = torch.device(device)
@@ -258,23 +259,24 @@ def create_autodeploy_executor(
     dist.initialize_or_skip(rank, world_size, port)
 
     # some config
-    if executor_config.pytorch_backend_config is None:
-        executor_config.pytorch_backend_config = AutoDeployConfig(attn_backend="FlashInfer")
+    msg = "pytorch_backend_config must be an AutoDeployLlmArgs object"
+    assert isinstance(executor_config.pytorch_backend_config, AutoDeployLlmArgs), msg
+    ad_config: AutoDeployLlmArgs = executor_config.pytorch_backend_config
 
-    max_batch_size = executor_config.max_batch_size
-    max_seq_len = executor_config.max_seq_len
-    tokens_per_block = executor_config.tokens_per_block
-    max_num_tokens = executor_config.max_num_tokens
-    ad_logger.info(f"{max_seq_len=}, {max_batch_size=}, {tokens_per_block=}, {max_num_tokens=}")
+    max_batch_size = ad_config.max_batch_size
+    max_seq_len = ad_config.max_seq_len
+    attn_page_size = ad_config.attn_page_size
+    max_num_tokens = ad_config.max_num_tokens
+    ad_logger.info(f"{max_seq_len=}, {max_batch_size=}, {attn_page_size=}, {max_num_tokens=}")
 
     # initialize model engine
     engine = ADEngine.build_from_config(
         model=checkpoint_dir,
-        ad_config=executor_config.pytorch_backend_config,
+        ad_config=ad_config,
         seq_info=SequenceInfo(
             max_seq_len=max_seq_len,
             max_batch_size=max_batch_size,
-            page_size=tokens_per_block,
+            page_size=attn_page_size,
             max_num_tokens=max_num_tokens,
         ),
         device="cuda",
@@ -282,9 +284,9 @@ def create_autodeploy_executor(
 
     # resource managers
     kv_cache_manager = _CacheManagerWithFakePool(
-        executor_config.kv_cache_config,
+        ad_config.kv_cache_config,
         num_blocks=engine.cache_seq_interface.info.num_pages,
-        tokens_per_block=tokens_per_block,
+        tokens_per_block=attn_page_size,
         max_seq_len=max_seq_len,
         max_batch_size=max_batch_size,
     )
@@ -302,18 +304,17 @@ def create_autodeploy_executor(
     sampler = TorchSampler(max_seq_len=max_seq_len)
 
     # creating the executor object
-    py_config: PyTorchConfig = executor_config.pytorch_backend_config
     py_executor = PyExecutor(
         resource_manager,
         scheduler,
         model_engine=engine,
         sampler=sampler,
         dist=mpi_dist,
-        disable_overlap_scheduler=py_config.disable_overlap_scheduler,
-        max_input_len=executor_config.max_input_len,
-        max_batch_size=executor_config.max_batch_size,
-        max_draft_tokens=executor_config.speculative_config.max_draft_tokens
-        if executor_config.speculative_config is not None
+        disable_overlap_scheduler=ad_config.disable_overlap_scheduler,
+        max_input_len=ad_config.max_input_len,
+        max_batch_size=ad_config.max_batch_size,
+        max_draft_tokens=ad_config.speculative_config.max_draft_tokens
+        if ad_config.speculative_config is not None
         else 0,
     )
     return py_executor

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -9,7 +9,7 @@ from tensorrt_llm._utils import nvtx_range
 from ...._utils import mpi_rank, mpi_world_size
 from ....bindings.executor import ExecutorConfig
 from ....bindings.internal.batch_manager import CacheType
-from ....llmapi.llm_args import AutoDeployLlmArgs
+from ....llmapi.llm_args import _AutoDeployLlmArgs
 from ....mapping import Mapping
 from ...distributed import MPIDist
 from ...pyexecutor.config import PyTorchConfig
@@ -85,11 +85,11 @@ class ADEngine(ModelEngine):
     def build_from_config(
         cls,
         model: str,
-        ad_config: AutoDeployLlmArgs,
+        ad_config: _AutoDeployLlmArgs,
         seq_info: SequenceInfo,
         device: DeviceLikeType,
     ):
-        """Build the ADEngine using the AutoDeployLlmArgs that gets passed through from the LLM."""
+        """Build the ADEngine using the _AutoDeployLlmArgs that gets passed through from the LLM."""
 
         # update device to contain the current default device if it's in cuda
         device = torch.device(device)
@@ -246,7 +246,7 @@ def create_autodeploy_executor(
 ):
     """Create an AutoDeploy executor from the given configuration and checkpoint directory.
 
-    This is the entrypoint API to the autodeploy backend.
+    This is the entrypoint API to the _autodeploy backend.
     """
     # initialize process groups
     world_size = mpi_world_size()
@@ -259,9 +259,9 @@ def create_autodeploy_executor(
     dist.initialize_or_skip(rank, world_size, port)
 
     # some config
-    msg = "pytorch_backend_config must be an AutoDeployLlmArgs object"
-    assert isinstance(executor_config.pytorch_backend_config, AutoDeployLlmArgs), msg
-    ad_config: AutoDeployLlmArgs = executor_config.pytorch_backend_config
+    msg = "pytorch_backend_config must be an _AutoDeployLlmArgs object"
+    assert isinstance(executor_config.pytorch_backend_config, _AutoDeployLlmArgs), msg
+    ad_config: _AutoDeployLlmArgs = executor_config.pytorch_backend_config
 
     max_batch_size = ad_config.max_batch_size
     max_seq_len = ad_config.max_seq_len

--- a/tensorrt_llm/_torch/auto_deploy/shim/demollm.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/demollm.py
@@ -15,7 +15,7 @@ from ....executor.request import GenerationRequest
 from ....executor.result import CompletionOutput, GenerationResult
 from ....inputs.registry import create_input_processor
 from ....llmapi.llm import LLM, RequestOutput
-from ....llmapi.llm_args import AutoDeployLlmArgs
+from ....llmapi.llm_args import _AutoDeployLlmArgs
 from ....llmapi.tokenizer import TokenizerBase
 from ....sampling_params import SamplingParams
 from ..custom_ops.attention_interface import SequenceInfo
@@ -352,7 +352,7 @@ class DemoLLM(LLM):
         **kwargs,
     ):
         try:
-            self.args: AutoDeployLlmArgs = AutoDeployLlmArgs.from_kwargs(
+            self.args: _AutoDeployLlmArgs = _AutoDeployLlmArgs.from_kwargs(
                 model=model,
                 tokenizer=tokenizer,
                 tokenizer_mode=tokenizer_mode,
@@ -362,7 +362,7 @@ class DemoLLM(LLM):
                 dtype=dtype,
                 revision=revision,
                 tokenizer_revision=tokenizer_revision,
-                backend=kwargs.pop("backend", "autodeploy"),
+                backend=kwargs.pop("backend", "_autodeploy"),
                 **kwargs,
             )
 

--- a/tensorrt_llm/_torch/auto_deploy/shim/demollm.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/demollm.py
@@ -15,7 +15,7 @@ from ....executor.request import GenerationRequest
 from ....executor.result import CompletionOutput, GenerationResult
 from ....inputs.registry import create_input_processor
 from ....llmapi.llm import LLM, RequestOutput
-from ....llmapi.llm_utils import LlmArgs
+from ....llmapi.llm_args import AutoDeployLlmArgs
 from ....llmapi.tokenizer import TokenizerBase
 from ....sampling_params import SamplingParams
 from ..custom_ops.attention_interface import SequenceInfo
@@ -349,11 +349,10 @@ class DemoLLM(LLM):
         dtype: str = "auto",
         revision: Optional[str] = None,
         tokenizer_revision: Optional[str] = None,
-        **kwargs: Any,
+        **kwargs,
     ):
         try:
-            self.pytorch_backend_config = kwargs.pop("auto_deploy_config", None)
-            self.args = LlmArgs.from_kwargs(
+            self.args: AutoDeployLlmArgs = AutoDeployLlmArgs.from_kwargs(
                 model=model,
                 tokenizer=tokenizer,
                 tokenizer_mode=tokenizer_mode,
@@ -363,6 +362,7 @@ class DemoLLM(LLM):
                 dtype=dtype,
                 revision=revision,
                 tokenizer_revision=tokenizer_revision,
+                backend=kwargs.pop("backend", "autodeploy"),
                 **kwargs,
             )
 
@@ -376,9 +376,9 @@ class DemoLLM(LLM):
 
         # construct sequence info object
         seq_info = SequenceInfo(
-            max_seq_len=self.args.build_config.max_seq_len,
-            max_batch_size=self.args.build_config.max_batch_size,
-            page_size=self.args.build_config.plugin_config.tokens_per_block,
+            max_seq_len=self.args.max_seq_len,
+            max_batch_size=self.args.max_batch_size,
+            page_size=self.args.attn_page_size,
         )
 
         # construct demo executor + engine
@@ -386,7 +386,7 @@ class DemoLLM(LLM):
             world_size=tensor_parallel_size,
             tokenizer=self.tokenizer,
             model=model,
-            ad_config=self.pytorch_backend_config,
+            ad_config=self.args.get_pytorch_backend_config(),
             seq_info=seq_info,
             device="cuda",
         )

--- a/tensorrt_llm/_torch/auto_deploy/shim/interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/interface.py
@@ -1,11 +1,9 @@
-from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Optional, Tuple, final
 
 import torch
 import torch.nn as nn
 from torch._prims_common import DeviceLikeType
 
-from ...pyexecutor.config import PyTorchConfig
 from ..custom_ops.attention_interface import GetCacheCallable, SequenceInfo
 from ..utils.logger import ad_logger
 
@@ -73,47 +71,3 @@ class CachedSequenceInterface:
 
 
 GetInferenceModel = Callable[[CachedSequenceInterface], nn.Module]
-
-
-@dataclass
-class AutoDeployConfig(PyTorchConfig):
-    # model factory to choose from
-    model_factory: str = "AutoModelForCausalLM"
-
-    ### MODEL EXTRA KWARGS ###
-    # Extra kwargs for the model config class to customize the model config. Those arguments will
-    # take precedence over the default values or config values in the model config file in the HF
-    # directory. Arguments are resolved in the following order:
-    # 1. Default values in the model config class
-    # 2. Values in the model config file in the HF directory
-    # 3. Values in the model_kwargs
-    # Note that that if the kwarg does not exist in the model config class, it will be ignored.
-    # An example model config class can be found [here](https://github.com/huggingface/transformers/blob/c409cd81777fb27aadc043ed3d8339dbc020fb3b/src/transformers/models/llama/configuration_llama.py#L26).
-    model_kwargs: Dict = field(
-        default_factory=lambda: {
-            "use_cache": False,  # to avoid using built-in cache
-        }
-    )
-
-    # attention backend to choose from
-    attn_backend: str = "TritonWithFlattenedInputs"
-    mla_backend: str = "MultiHeadLatentAttention"
-
-    # check if we should skip loading weights
-    skip_loading_weights: bool = False
-
-    # specifies the fraction of available memory to occupy for cache
-    free_mem_ratio: float = 0.8
-
-    simple_shard_only: bool = False  # if True, force simple sharding(all_gather) in TP;
-    # otherwise auto-detect and use column+row (all_reduce) sharding
-
-    def __post_init__(self):
-        # we don't want to loose the default values for model_kwargs unless explicitly set by the
-        # user. They are not preserved by the standard initialization process since they whole dict
-        # gets replaced by the user provided one. We don't want that though.
-        f_default = self.__dataclass_fields__["model_kwargs"].default_factory()
-        setattr(self, "model_kwargs", {**f_default, **getattr(self, "model_kwargs")})
-
-        # TODO (https://github.com/NVIDIA/TensorRT-LLM/issues/4364) support overlap scheduler
-        self.disable_overlap_scheduler = True

--- a/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
@@ -5,7 +5,7 @@ import gc
 import torch
 from torch.fx import GraphModule
 
-from ....llmapi.llm_args import AutoDeployLlmArgs
+from ....llmapi.llm_args import _AutoDeployLlmArgs
 from ..compile import compile_and_capture
 from ..custom_ops.attention_interface import AttentionRegistry
 from ..distributed import common as dist_ad
@@ -43,7 +43,7 @@ class InferenceOptimizer:
         self,
         factory: ModelFactory,
         *,  # TODO: temporary until we have a better config system
-        ad_config: AutoDeployLlmArgs,
+        ad_config: _AutoDeployLlmArgs,
         visualize: bool = False,
     ):
         self.factory = factory

--- a/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
@@ -5,11 +5,12 @@ import gc
 import torch
 from torch.fx import GraphModule
 
+from ....llmapi.llm_args import AutoDeployLlmArgs
 from ..compile import compile_and_capture
 from ..custom_ops.attention_interface import AttentionRegistry
 from ..distributed import common as dist_ad
 from ..models.factory import ModelFactory
-from ..shim.interface import AutoDeployConfig, CachedSequenceInterface
+from ..shim.interface import CachedSequenceInterface
 from ..utils.logger import ad_logger
 from ._graph import canonicalize_graph, lift_to_meta, move_to_device
 from .export import torch_export_to_gm
@@ -42,12 +43,10 @@ class InferenceOptimizer:
         self,
         factory: ModelFactory,
         *,  # TODO: temporary until we have a better config system
-        ad_config: AutoDeployConfig,
+        ad_config: AutoDeployLlmArgs,
         visualize: bool = False,
     ):
         self.factory = factory
-        self.attn_backend = ad_config.attn_backend
-        self.mla_backend = ad_config.mla_backend
 
         self.ad_config = ad_config
         # Map Pytorch config to AutoDeploy compile backends.
@@ -61,10 +60,6 @@ class InferenceOptimizer:
             compile_backend = "torch-simple"
         self.compile_backend = compile_backend
         self.visualize = visualize
-
-        # look up attention op
-        self.attention_op = AttentionRegistry.get(self.attn_backend)
-        self.mla_op = AttentionRegistry.get(self.mla_backend)
 
     def __call__(self, cm: CachedSequenceInterface) -> GraphModule:
         """Transform a model into an optimized inference model.
@@ -118,13 +113,15 @@ class InferenceOptimizer:
         egm = match_causal_attn_mask(egm)
 
         # Match attention layout expected by our backend
-        egm = match_attention_layout(egm, self.attention_op)
+        egm = match_attention_layout(egm, AttentionRegistry.get(self.ad_config.attn_backend))
 
         # Match rope
         egm = match_explicit_rope(egm)
         egm = match_complex_rope(egm)
         # Match RoPE layout expected by our backend
-        egm = match_rope_layout(egm, self.attention_op.get_attention_layout())
+        egm = match_rope_layout(
+            egm, AttentionRegistry.get(self.ad_config.attn_backend).get_attention_layout()
+        )
 
         ############################################################################################
         # RUN TRANSFORMATIONS ON STANDARDIZED GRAPH REPRESENTATION
@@ -200,7 +197,8 @@ class InferenceOptimizer:
         egm = update_in_out_nodes(egm, cm)
 
         # detect attention op and replace with cache-aware op
-        for attn_descriptor in [self.attention_op, self.mla_op]:
+        for a_backend in [self.ad_config.attn_backend, self.ad_config.mla_backend]:
+            attn_descriptor = AttentionRegistry.get(a_backend)
             egm = insert_cached_attention(egm, cm, attn_descriptor, self.factory.get_cache_config())
 
         # initialize cache on correct device

--- a/tensorrt_llm/bench/benchmark/throughput.py
+++ b/tensorrt_llm/bench/benchmark/throughput.py
@@ -43,7 +43,7 @@ from tensorrt_llm.sampling_params import SamplingParams
     help="Path to a serialized TRT-LLM engine.",
 )
 @optgroup.option("--backend",
-                 type=click.Choice(["pytorch", "autodeploy"]),
+                 type=click.Choice(["pytorch", "_autodeploy"]),
                  default=None,
                  help="Set to 'pytorch' for pytorch path. Default is cpp path.")
 @optgroup.option(
@@ -292,7 +292,7 @@ def throughput_command(
         logger.info(metadata.get_summary_for_print())
 
     # Engine configuration parsing
-    if backend and backend.lower() in ["pytorch", "autodeploy"]:
+    if backend and backend.lower() in ["pytorch", "_autodeploy"]:
         # If we're dealing with a model name, perform a snapshot download to
         # make sure we have a local copy of the model.
         if checkpoint_path is None:

--- a/tensorrt_llm/bench/dataclasses/configuration.py
+++ b/tensorrt_llm/bench/dataclasses/configuration.py
@@ -9,12 +9,12 @@ from pydantic import (BaseModel, Field, PositiveFloat, field_validator,
                       model_validator)
 
 import tensorrt_llm.bindings.executor as trtllm
-from tensorrt_llm._torch.auto_deploy.shim import AutoDeployConfig
 from tensorrt_llm._torch.pyexecutor.config import PyTorchConfig
 from tensorrt_llm.llmapi import (BatchingType, CapacitySchedulerPolicy,
                                  ContextChunkingPolicy, DynamicBatchConfig,
                                  ExtendedRuntimePerfKnobConfig, KvCacheConfig,
                                  SchedulerConfig)
+from tensorrt_llm.llmapi.llm_args import AutoDeployLlmArgs
 from tensorrt_llm.llmapi.llm_utils import update_llm_args_with_extra_options
 from tensorrt_llm.models.modeling_utils import SpeculativeDecodingMode
 
@@ -110,8 +110,8 @@ class PerformanceOptions:
     def get_pytorch_perf_config(self) -> PyTorchConfig:
         return self.pytorch_config
 
-    def get_autodeploy_perf_config(self) -> AutoDeployConfig:
-        ad_config = AutoDeployConfig(**self.pytorch_config)
+    def get_autodeploy_perf_config(self) -> AutoDeployLlmArgs:
+        ad_config = AutoDeployLlmArgs(**self.pytorch_config)
         ad_config.attn_backend = "FlashInfer"
         ad_config.torch_compile_enabled = True
         ad_config.skip_loading_weights = True

--- a/tensorrt_llm/bench/dataclasses/configuration.py
+++ b/tensorrt_llm/bench/dataclasses/configuration.py
@@ -14,7 +14,7 @@ from tensorrt_llm.llmapi import (BatchingType, CapacitySchedulerPolicy,
                                  ContextChunkingPolicy, DynamicBatchConfig,
                                  ExtendedRuntimePerfKnobConfig, KvCacheConfig,
                                  SchedulerConfig)
-from tensorrt_llm.llmapi.llm_args import AutoDeployLlmArgs
+from tensorrt_llm.llmapi.llm_args import _AutoDeployLlmArgs
 from tensorrt_llm.llmapi.llm_utils import update_llm_args_with_extra_options
 from tensorrt_llm.models.modeling_utils import SpeculativeDecodingMode
 
@@ -33,7 +33,7 @@ class RuntimeConfig(BaseModel):
     world_config: ExecutorWorldConfig
     decoding_config: Optional[DecodingConfig] = None
     performance_options: PerformanceOptions
-    backend: Literal["pytorch", "autodeploy", None] = None
+    backend: Literal["pytorch", "_autodeploy", None] = None
     extra_llm_api_options: Optional[str] = None
     iteration_log: Optional[Path] = None
 
@@ -77,7 +77,7 @@ class RuntimeConfig(BaseModel):
 
         backend_config_map = {
             "pytorch": self.performance_options.get_pytorch_perf_config,
-            "autodeploy": self.performance_options.get_autodeploy_perf_config
+            "_autodeploy": self.performance_options.get_autodeploy_perf_config
         }
 
         if self.backend in backend_config_map:
@@ -110,8 +110,8 @@ class PerformanceOptions:
     def get_pytorch_perf_config(self) -> PyTorchConfig:
         return self.pytorch_config
 
-    def get_autodeploy_perf_config(self) -> AutoDeployLlmArgs:
-        ad_config = AutoDeployLlmArgs(**self.pytorch_config)
+    def get_autodeploy_perf_config(self) -> _AutoDeployLlmArgs:
+        ad_config = _AutoDeployLlmArgs(**self.pytorch_config)
         ad_config.attn_backend = "FlashInfer"
         ad_config.torch_compile_enabled = True
         ad_config.skip_loading_weights = True

--- a/tensorrt_llm/bench/dataclasses/reporting.py
+++ b/tensorrt_llm/bench/dataclasses/reporting.py
@@ -236,7 +236,7 @@ class ReportUtility:
         }
 
         # Engine/Backend details
-        if self.rt_cfg.backend not in ('pytorch', 'autodeploy'):
+        if self.rt_cfg.backend not in ('pytorch', '_autodeploy'):
             config_path = self.rt_cfg.engine_dir / "config.json"
             with open(config_path, "r") as config:
                 engine_config = json.load(config)
@@ -419,7 +419,7 @@ class ReportUtility:
         decoding = stats_dict.get("decoding_stats", None)
 
         backend_info = ""
-        if self.rt_cfg.backend not in ('pytorch', 'autodeploy'):
+        if self.rt_cfg.backend not in ('pytorch', '_autodeploy'):
             config_path = self.rt_cfg.engine_dir / "config.json"
             with open(config_path, "r") as config:
                 engine_config = json.load(config)

--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -126,7 +126,7 @@ class GenerationExecutorWorker(GenerationExecutor):
                     create_py_executor
                 create_executor = create_py_executor
                 args["lora_config"] = lora_config
-            elif executor_config.backend == "autodeploy":
+            elif executor_config.backend == "_autodeploy":
                 from tensorrt_llm._torch.auto_deploy.shim.ad_executor import \
                     create_autodeploy_executor
                 create_executor = create_autodeploy_executor

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -30,8 +30,8 @@ from ..executor.utils import (create_mpi_comm_session,
 from ..inputs import PromptInputs, create_input_processor, prompt_inputs
 from ..logger import logger
 from ..sampling_params import SamplingParams
-from .llm_args import (LLMARGS_EXPLICIT_DOCSTRING, AutoDeployLlmArgs,
-                       PybindMirror, TorchLlmArgs, TrtLlmArgs)
+from .llm_args import (LLMARGS_EXPLICIT_DOCSTRING, PybindMirror, TorchLlmArgs,
+                       TrtLlmArgs, _AutoDeployLlmArgs)
 from .llm_utils import (CachedModelLoader, KvCacheRetentionConfig,
                         LlmBuildStats, ModelLoader, _ModelRuntimeContext)
 from .mpi_session import MpiPoolSession, external_mpi_comm_available
@@ -119,8 +119,8 @@ class LLM:
             backend = kwargs.get('backend', None)
             if backend == 'pytorch':
                 llm_args_cls = TorchLlmArgs
-            elif backend == 'autodeploy':
-                llm_args_cls = AutoDeployLlmArgs
+            elif backend == '_autodeploy':
+                llm_args_cls = _AutoDeployLlmArgs
             else:
                 llm_args_cls = TrtLlmArgs
 
@@ -480,7 +480,7 @@ class LLM:
                     )
                 sampling_params._setup(self.tokenizer)
             # auto enabled context and/or generation logits flags, as they are required by logprob computation for TRT backend.
-            if self.args.backend not in ["pytorch", "autodeploy"]:
+            if self.args.backend not in ["pytorch", "_autodeploy"]:
                 if sampling_params.prompt_logprobs and not sampling_params.return_context_logits:
                     sampling_params.return_context_logits = True
                     sampling_params._context_logits_auto_enabled = True
@@ -497,7 +497,7 @@ class LLM:
     def _check_arguments(self, prompt_len: int, query_len: int,
                          sampling_params: SamplingParams) -> None:
 
-        if self.args.backend in ["pytorch", "autodeploy"]:
+        if self.args.backend in ["pytorch", "_autodeploy"]:
             # TODO: remove these checks after PyTorch backend
             # fully support TopK prompt and generation logprobs.
             if sampling_params.prompt_logprobs:
@@ -509,7 +509,7 @@ class LLM:
                     f"PyTorch backend currently only supports `logprobs=1`. Received `logprobs={sampling_params.logprobs}` (Top{sampling_params.logprobs} logprobs). Please set `logprobs=1` in `sampling_params` instead."
                 )
             return
-        elif self.args.backend == "autodeploy":
+        elif self.args.backend == "_autodeploy":
             return
 
         build_config = self.args.build_config
@@ -662,7 +662,7 @@ class LLM:
             self._executor_config,
             backend=self.args.backend,
             pytorch_backend_config=self.args.get_pytorch_backend_config()
-            if self.args.backend in ["pytorch", "autodeploy"] else None,
+            if self.args.backend in ["pytorch", "_autodeploy"] else None,
             mapping=self.args.parallel_config.to_mapping(),
             build_config=self.args.build_config
             if self._on_trt_backend else None,
@@ -710,7 +710,7 @@ class LLM:
         # TODO smor- need to refine what is the desired behavior if lora is enabled
         # in terms of the tokenizer initialization process
         if hasattr(self.args, "backend") and self.args.backend in [
-                "pytorch", "autodeploy"
+                "pytorch", "_autodeploy"
         ] and self.args.lora_config is not None:
             num_lora_dirs = len(self.args.lora_config.lora_dir)
             if num_lora_dirs == 1:

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -42,7 +42,6 @@ from ..bindings.executor import (
                                  PeftCacheConfig as _PeftCacheConfig,
                                  SchedulerConfig as _SchedulerConfig) # isort: skip
 # isort: on
-from transformers import PreTrainedTokenizerBase
 
 # yapf: enable
 from ..builder import BuildConfig, EngineConfig
@@ -939,11 +938,6 @@ class BaseLlmArgs(BaseModel):
         default=None,
         description="The parser to separate reasoning content from output.")
 
-    auto_deploy_config: Optional[object] = Field(
-        default=None,
-        description="Auto deploy config.",
-        json_schema_extra={"type": f"Optional[AutoDeployConfig]"})
-
     # TODO[Superjomn]: To deprecate this config.
     decoding_config: Optional[object] = Field(
         default=None,
@@ -1155,7 +1149,7 @@ class BaseLlmArgs(BaseModel):
 
                 self.build_config.max_draft_len = self.speculative_config.max_draft_len
 
-                if self.backend != 'pytorch':
+                if self.backend not in ['pytorch', 'autodeploy']:
                     eagle_config = _EagleConfig(
                         self.speculative_config.eagle_choices,
                         self.speculative_config.greedy_sampling,
@@ -1175,7 +1169,7 @@ class BaseLlmArgs(BaseModel):
                         eagle3_one_model)
             elif isinstance(self.speculative_config, NGramDecodingConfig):
                 self.build_config.speculative_decoding_mode = SpeculativeDecodingMode.NGRAM
-                assert self.backend == 'pytorch'
+                assert self.backend in ['pytorch', 'autodeploy']
                 assert self.speculative_config.prompt_lookup_num_tokens > 0 and self.speculative_config.max_matching_ngram_size > 0
                 self.build_config.max_draft_len = self.speculative_config.max_draft_len
                 from tensorrt_llm._torch.speculative import NGramConfig
@@ -1231,9 +1225,11 @@ class BaseLlmArgs(BaseModel):
                     "lora_dir is empty, so custom embedding or lm head will not be applied."
                 )
 
-        if self.enable_lora and self.lora_config is not None and self.backend == 'pytorch':
+        if self.enable_lora and self.lora_config is not None and self.backend in [
+                'pytorch', 'autodeploy'
+        ]:
             logger.warning(
-                "enable_lora is ignored when lora_config is provided for pytorch backend."
+                f"enable_lora is ignored when lora_config is provided for {self.backend} backend."
             )
 
         if self.lora_config is not None:
@@ -1262,7 +1258,9 @@ class BaseLlmArgs(BaseModel):
         if v.parallel_config._world_size == 1 and v.build_config:
             v.build_config.plugin_config.nccl_plugin = None
 
-        if v.enable_lora and v.lora_config is None and v.backend != 'pytorch':
+        if v.enable_lora and v.lora_config is None and v.backend not in [
+                'pytorch', 'autodeploy'
+        ]:
             v.build_config.plugin_config.lora_plugin = 'auto'
             if v.max_lora_rank is not None:
                 v.build_config.lora_config.max_lora_rank = v.max_lora_rank
@@ -1714,11 +1712,6 @@ class TorchLlmArgs(BaseLlmArgs):
     def get_pytorch_backend_config(self) -> "PyTorchConfig":
         from tensorrt_llm._torch.pyexecutor.config import PyTorchConfig
 
-        # TODO: Remove this after the PyTorch backend is fully migrated to TorchLlmArgs from ExecutorConfig
-        # Just a WAR to support the auto_deploy
-        if self.auto_deploy_config is not None:
-            return self.auto_deploy_config
-
         return PyTorchConfig(
             extra_resource_managers=self.extra_resource_managers,
             use_cuda_graph=self.use_cuda_graph,
@@ -1820,6 +1813,109 @@ class TorchLlmArgs(BaseLlmArgs):
             self.cuda_graph_batch_sizes = generated_sizes
             self.cuda_graph_max_batch_size = max_batch_size
 
+        return self
+
+
+class AutoDeployLlmArgs(TorchLlmArgs):
+    """LLM arguments specifically for AutoDeploy backend.
+
+    This class extends TorchLlmArgs with AutoDeploy-specific configuration options.
+    AutoDeploy provides automatic deployment and optimization of language models
+    with various attention backends and optimization strategies.
+    """
+
+    model_factory: Literal[
+        "AutoModelForCausalLM", "AutoModelForImageTextToText"] = Field(
+            default="AutoModelForCausalLM",
+            description="The model factory to use for loading the model.",
+        )
+
+    model_kwargs: Dict[str, Any] = Field(
+        default_factory=dict,
+        description=
+        "Extra kwargs for the model config class to customize the model config. "
+        "These arguments take precedence over default values or config values in the model config "
+        "file. Arguments are resolved in order: 1) Default values in model config class, 2) Values "
+        "in model config file, 3) Values in model_kwargs. Note: if a kwarg doesn't exist in the "
+        "model config class, it will be ignored.",
+    )
+
+    mla_backend: Literal["MultiHeadLatentAttention"] = Field(
+        default="MultiHeadLatentAttention",
+        description="The Multi-Head Latent Attention backend to use.",
+    )
+
+    skip_loading_weights: bool = Field(
+        default=False,
+        description=
+        "Whether to skip loading model weights during initialization. "
+        "If True, only the model architecture is loaded.",
+    )
+
+    free_mem_ratio: float = Field(
+        default=0.8,
+        description="The fraction of available memory to allocate for cache. "
+        "Must be between 0.0 and 1.0.",
+    )
+
+    simple_shard_only: bool = Field(
+        default=False,
+        description=
+        "If True, force simple sharding (all_gather) in tensor parallelism. "
+        "If False, auto-detect and use column+row (all_reduce) sharding when possible.",
+    )
+
+    # TODO: Remove this field once tokens_per_block is properly passed through
+    attn_page_size: int = Field(
+        default=64,
+        description=
+        "Page size for attention (tokens_per_block). For TritonWithFlattenedInputs "
+        "backend, this should equal max_seq_len. Temporary field until tokens_per_block gets "
+        "properly passed through.",
+    )
+
+    @field_validator("free_mem_ratio")
+    @classmethod
+    def validate_free_mem_ratio(cls, v):
+        """Validate that free_mem_ratio is between 0.0 and 1.0."""
+        if not 0.0 <= v <= 1.0:
+            raise ValueError(
+                f"free_mem_ratio must be between 0.0 and 1.0, got {v}")
+        return v
+
+    @print_traceback_on_error
+    def model_post_init(self, __context):
+        # Modify default values that differ from TorchLlmArgs
+        new_defaults = {
+            "max_batch_size": 8,
+            "max_seq_len": 512,
+            "attn_backend": "FlashInfer",
+            # TODO: Remove this when overlap scheduler is supported (https://github.com/NVIDIA/TensorRT-LLM/issues/4364)
+            "disable_overlap_scheduler": True,
+        }
+        for k, v_default in new_defaults.items():
+            if k not in self.__pydantic_fields_set__:
+                setattr(self, k, v_default)
+
+        # NOTE: Only call super() after setting the default values since default values should be
+        # set first.
+        super().model_post_init(__context)
+
+        # Handle attn_page_size for TritonWithFlattenedInputs backend
+        if self.attn_backend == "TritonWithFlattenedInputs":
+            self.attn_page_size = self.max_seq_len
+
+        # Add max_position_embeddings to model_kwargs
+        # TODO (lucaslie): this is more HF specific than a generic model_kwargs. Ideally, we can
+        # move this to the HF model factory but we don't have access to max_seq_len there right now.
+        self.model_kwargs["max_position_embeddings"] = min(
+            self.max_seq_len,
+            self.model_kwargs.get("max_position_embeddings", self.max_seq_len),
+        )
+
+    # TODO: Remove this after the PyTorch backend is fully migrated to TorchLlmArgs from ExecutorConfig
+    def get_pytorch_backend_config(self) -> "AutoDeployLlmArgs":
+        """Return the AutoDeployLlmArgs (self) object."""
         return self
 
 

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1031,7 +1031,7 @@ class BaseLlmArgs(BaseModel):
         model_obj = _ModelWrapper(self.model)
 
         if model_obj.is_local_model and self.backend not in [
-                'pytorch', 'autodeploy'
+                'pytorch', '_autodeploy'
         ]:
             # Load parallel_config from the engine.
             model_format = get_model_format(self.model)
@@ -1149,7 +1149,7 @@ class BaseLlmArgs(BaseModel):
 
                 self.build_config.max_draft_len = self.speculative_config.max_draft_len
 
-                if self.backend not in ['pytorch', 'autodeploy']:
+                if self.backend not in ['pytorch', '_autodeploy']:
                     eagle_config = _EagleConfig(
                         self.speculative_config.eagle_choices,
                         self.speculative_config.greedy_sampling,
@@ -1169,7 +1169,7 @@ class BaseLlmArgs(BaseModel):
                         eagle3_one_model)
             elif isinstance(self.speculative_config, NGramDecodingConfig):
                 self.build_config.speculative_decoding_mode = SpeculativeDecodingMode.NGRAM
-                assert self.backend in ['pytorch', 'autodeploy']
+                assert self.backend in ['pytorch', '_autodeploy']
                 assert self.speculative_config.prompt_lookup_num_tokens > 0 and self.speculative_config.max_matching_ngram_size > 0
                 self.build_config.max_draft_len = self.speculative_config.max_draft_len
                 from tensorrt_llm._torch.speculative import NGramConfig
@@ -1226,7 +1226,7 @@ class BaseLlmArgs(BaseModel):
                 )
 
         if self.enable_lora and self.lora_config is not None and self.backend in [
-                'pytorch', 'autodeploy'
+                'pytorch', '_autodeploy'
         ]:
             logger.warning(
                 f"enable_lora is ignored when lora_config is provided for {self.backend} backend."
@@ -1259,7 +1259,7 @@ class BaseLlmArgs(BaseModel):
             v.build_config.plugin_config.nccl_plugin = None
 
         if v.enable_lora and v.lora_config is None and v.backend not in [
-                'pytorch', 'autodeploy'
+                'pytorch', '_autodeploy'
         ]:
             v.build_config.plugin_config.lora_plugin = 'auto'
             if v.max_lora_rank is not None:
@@ -1816,7 +1816,7 @@ class TorchLlmArgs(BaseLlmArgs):
         return self
 
 
-class AutoDeployLlmArgs(TorchLlmArgs):
+class _AutoDeployLlmArgs(TorchLlmArgs):
     """LLM arguments specifically for AutoDeploy backend.
 
     This class extends TorchLlmArgs with AutoDeploy-specific configuration options.
@@ -1914,8 +1914,8 @@ class AutoDeployLlmArgs(TorchLlmArgs):
         )
 
     # TODO: Remove this after the PyTorch backend is fully migrated to TorchLlmArgs from ExecutorConfig
-    def get_pytorch_backend_config(self) -> "AutoDeployLlmArgs":
-        """Return the AutoDeployLlmArgs (self) object."""
+    def get_pytorch_backend_config(self) -> "_AutoDeployLlmArgs":
+        """Return the _AutoDeployLlmArgs (self) object."""
         return self
 
 

--- a/tensorrt_llm/llmapi/llm_utils.py
+++ b/tensorrt_llm/llmapi/llm_utils.py
@@ -631,7 +631,7 @@ class CachedModelLoader:
         self.model_loader = ModelLoader(self.llm_args)
 
         if self.llm_args.backend is not None:
-            if self.llm_args.backend not in ["pytorch", "autodeploy"]:
+            if self.llm_args.backend not in ["pytorch", "_autodeploy"]:
                 raise ValueError(
                     f'backend {self.llm_args.backend} is not supported.')
 

--- a/tests/unittest/_torch/auto_deploy/_utils_test/_model_test_utils.py
+++ b/tests/unittest/_torch/auto_deploy/_utils_test/_model_test_utils.py
@@ -393,7 +393,7 @@ def get_small_model_config(model_hub_id: str, **config_kwargs) -> Dict[str, Any]
     config["free_mem_ratio"] = 0.00  # we don't need the cache and it may cause OOM issues
     config["benchmark"] = False  # No benchmark to speed up things
     config["max_tokens"] = 8  # Don't produce too many tokens to speed up things
-    config["page_size"] = 4  # Make sure paging is activated despite small max_tokens
+    config["attn_page_size"] = 4  # Make sure paging is activated despite small max_tokens
     config["max_batch_size"] = 2  # Minimum batching to speed up things
     config["prompt"] = "Hello World"
 

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/shim/test_engine.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/shim/test_engine.py
@@ -41,9 +41,9 @@ def get_inference_model(cache_seq_interface):
 
 @pytest.mark.parametrize("engine_cls", [ADEngine, DemoEngine])
 @pytest.mark.parametrize(
-    "attn_backend, page_size", [("TritonWithFlattenedInputs", 0), ("FlashInfer", 2)]
+    "attn_backend, attn_page_size", [("TritonWithFlattenedInputs", 0), ("FlashInfer", 2)]
 )
-def test_engine(engine_cls: Type[ADEngine], attn_backend: str, page_size: int):
+def test_engine(engine_cls: Type[ADEngine], attn_backend: str, attn_page_size: int):
     """Test the SimpleEngine functionality."""
 
     seed = 1234  # Set random seed for model param init
@@ -58,7 +58,7 @@ def test_engine(engine_cls: Type[ADEngine], attn_backend: str, page_size: int):
     sequence_info = SequenceInfo(
         max_seq_len=max_seq_len,
         max_batch_size=max_batch_size,
-        page_size=page_size,
+        page_size=attn_page_size,
     )
     sequence_info.to(device)
 

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/shim/test_llm_config.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/shim/test_llm_config.py
@@ -1,0 +1,203 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tensorrt_llm._torch.auto_deploy.shim.demollm import DemoLLM
+from tensorrt_llm._torch.auto_deploy.transformations.transform import InferenceOptimizer
+from tensorrt_llm.llmapi.llm import LLM
+from tensorrt_llm.llmapi.llm_args import AutoDeployLlmArgs
+
+# ================================
+# AutoDeployLlmArgs Direct Tests
+# ================================
+
+
+def test_custom_values():
+    """Test that AutoDeployLlmArgs correctly accepts custom values."""
+    custom_kwargs = {
+        "model": "test-model",
+        "model_factory": "AutoModelForImageTextToText",
+        "model_kwargs": {"custom_param": True},
+        "mla_backend": "MultiHeadLatentAttention",
+        "skip_loading_weights": True,
+        "free_mem_ratio": 0.9,
+        "simple_shard_only": True,
+        "attn_page_size": 128,
+        "attn_backend": "CustomBackend",
+        "max_seq_len": 2048,
+    }
+
+    args = AutoDeployLlmArgs(**custom_kwargs)
+
+    assert args.model_factory == "AutoModelForImageTextToText"
+    assert args.model_kwargs == {
+        "custom_param": True,
+        "max_position_embeddings": args.max_seq_len,
+    }
+    assert args.skip_loading_weights
+    assert args.free_mem_ratio == 0.9
+    assert args.simple_shard_only
+    assert args.attn_page_size == 128
+    assert args.max_seq_len == 2048
+    # attn_backend should be overridden if it was 'TRTLLM'
+    assert args.attn_backend == "CustomBackend"
+
+
+def test_free_mem_ratio_validation():
+    """Test free_mem_ratio validation."""
+    # Valid values
+    AutoDeployLlmArgs(model="test-model", free_mem_ratio=0.0)
+    AutoDeployLlmArgs(model="test-model", free_mem_ratio=1.0)
+    AutoDeployLlmArgs(model="test-model", free_mem_ratio=0.5)
+
+    # Invalid values
+    with pytest.raises(ValueError):
+        AutoDeployLlmArgs(model="test-model", free_mem_ratio=-0.1)
+    with pytest.raises(ValueError):
+        AutoDeployLlmArgs(model="test-model", free_mem_ratio=1.1)
+
+
+def test_get_pytorch_backend_config():
+    """Test that get_pytorch_backend_config returns self."""
+    args = AutoDeployLlmArgs(model="test-model")
+    assert args.get_pytorch_backend_config() is args
+
+
+# ================================
+# Config Flow Tests
+# ================================
+
+
+@pytest.fixture
+def test_config_params():
+    """Common test configuration parameters."""
+    return {
+        "model": "test-model",
+        "model_factory": "AutoModelForImageTextToText",
+        "free_mem_ratio": 0.7,
+        "simple_shard_only": True,
+        "skip_loading_weights": True,
+        "attn_page_size": 17,
+        "attn_backend": "CustomBackend",
+        "max_seq_len": 19,
+        "max_batch_size": 5,
+        "tensor_parallel_size": 3,
+    }
+
+
+@pytest.mark.parametrize(
+    "api_class,backend,extra_kwargs,expected_executor_call",
+    [
+        (DemoLLM, None, {}, True),  # DemoLLM doesn't use backend param, should call executor
+        (
+            LLM,
+            "autodeploy",
+            {"backend": "autodeploy"},
+            False,
+        ),  # LLM with autodeploy backend, no executor call
+    ],
+)
+@patch("tensorrt_llm._torch.auto_deploy.shim.demollm.DemoGenerationExecutor")
+@patch("tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface.SequenceInfo")
+@patch("tensorrt_llm._torch.auto_deploy.shim.demollm.dist_ad.initialize_or_skip")
+@patch("tensorrt_llm._torch.auto_deploy.shim.demollm.create_input_processor")
+@patch("tensorrt_llm.llmapi.llm.LLM._build_model")
+def test_config_flow(
+    mock_build_model,
+    mock_input_processor,
+    mock_dist_init,
+    mock_seq_info,
+    mock_executor,
+    api_class,
+    backend,
+    extra_kwargs,
+    expected_executor_call,
+    test_config_params,
+):
+    """Test that config flows correctly through both DemoLLM and LLM initialization."""
+    # Mock the executor and its methods for DemoLLM
+    mock_executor_instance = MagicMock()
+    mock_executor.return_value = mock_executor_instance
+
+    # Mock sequence info for DemoLLM
+    mock_seq_info_instance = MagicMock()
+    mock_seq_info.return_value = mock_seq_info_instance
+
+    # Merge extra kwargs for the specific API
+    config_params = {**test_config_params, **extra_kwargs}
+
+    # Create instance with appropriate mocking
+    with patch.object(api_class, "_try_load_tokenizer", return_value=MagicMock()):
+        instance = api_class(**config_params)
+
+    # Verify args were created correctly
+    assert hasattr(instance, "args")
+    assert isinstance(instance.args, AutoDeployLlmArgs)
+
+    # Common assertions for both APIs
+    assert instance.args.model_factory == test_config_params["model_factory"]
+    assert instance.args.free_mem_ratio == test_config_params["free_mem_ratio"]
+    assert instance.args.simple_shard_only == test_config_params["simple_shard_only"]
+    assert instance.args.skip_loading_weights == test_config_params["skip_loading_weights"]
+    assert instance.args.attn_page_size == test_config_params["attn_page_size"]
+    assert instance.args.max_seq_len == test_config_params["max_seq_len"]
+    assert instance.args.max_batch_size == test_config_params["max_batch_size"]
+
+    # Verify executor behavior for DemoLLM
+    if expected_executor_call:
+        mock_executor.assert_called_once()
+        call_kwargs = mock_executor.call_args[1]
+        assert call_kwargs["world_size"] == test_config_params["tensor_parallel_size"]
+        assert call_kwargs["model"] == test_config_params["model"]
+    else:
+        # For LLM with autodeploy backend, executor should not be called directly
+        pass
+
+
+@pytest.mark.parametrize(
+    "use_cuda_graph,torch_compile_enabled,expected_backend",
+    [
+        (True, True, "torch-opt"),
+        (True, False, "torch-cudagraph"),
+        (False, True, "torch-compile"),
+        (False, False, "torch-simple"),
+    ],
+)
+@patch("tensorrt_llm._torch.auto_deploy.models.factory.ModelFactoryRegistry.get")
+def test_compile_backend_mapping(
+    mock_factory_registry, use_cuda_graph, torch_compile_enabled, expected_backend
+):
+    """Test that compile backend is correctly determined from config."""
+    ad_config = AutoDeployLlmArgs(
+        model="test-model",
+        use_cuda_graph=use_cuda_graph,
+        torch_compile_enabled=torch_compile_enabled,
+    )
+    optimizer = InferenceOptimizer(factory=MagicMock(), ad_config=ad_config)
+    assert optimizer.compile_backend == expected_backend
+
+
+# ================================
+# Additional Edge Case Tests
+# ================================
+
+
+def test_invalid_model_factory():
+    """Test behavior with invalid model factory."""
+    # Pydantic validates Literal types at runtime, so this should raise ValidationError
+    with pytest.raises(Exception):  # Could be ValidationError or ValueError
+        AutoDeployLlmArgs(model="test-model", model_factory="InvalidFactory")
+
+
+@pytest.mark.parametrize(
+    "attn_backend,expected_attn_page_size",
+    [
+        ("FlashInfer", 64),  # Default attn_page_size
+        ("TritonWithFlattenedInputs", 1024),  # Should equal max_seq_len
+        ("CustomBackend", 64),  # Default attn_page_size
+    ],
+)
+def test_attention_backend_page_size_logic(attn_backend, expected_attn_page_size):
+    """Test attn_page_size logic for different attention backends."""
+    args = AutoDeployLlmArgs(model="test-model", attn_backend=attn_backend, max_seq_len=1024)
+    assert args.attn_page_size == expected_attn_page_size

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
@@ -7,6 +7,76 @@ from _model_test_utils import get_small_model_config
 from build_and_run_ad import main
 from simple_config import SimpleConfig
 
+from tensorrt_llm._torch.auto_deploy.models import ModelFactoryRegistry
+from tensorrt_llm._torch.auto_deploy.transformations.transform import InferenceOptimizer
+from tensorrt_llm.llmapi.llm_args import AutoDeployLlmArgs
+
+
+def _check_ad_config(simple_config: SimpleConfig, ad_config: AutoDeployLlmArgs):
+    # Verify that ad_config was captured
+    assert ad_config is not None, "ad_config should have been captured"
+
+    # Check that ad_config is an instance of AutoDeployLlmArgs
+    assert isinstance(ad_config, AutoDeployLlmArgs), (
+        f"Expected AutoDeployLlmArgs, got {type(ad_config)}"
+    )
+
+    # Fields that map directly from simple_config to ad_config
+    direct_mapping_fields = {
+        "max_batch_size",
+        "attn_backend",
+        "mla_backend",
+        "skip_loading_weights",
+        "free_mem_ratio",
+        "simple_shard_only",
+        "attn_page_size",
+        "model_factory",
+        "model_kwargs",
+    }
+
+    # Check direct mappings
+    for field_name in direct_mapping_fields:
+        if hasattr(simple_config, field_name):
+            config_value = getattr(simple_config, field_name)
+            ad_config_value = getattr(ad_config, field_name)
+            assert ad_config_value == config_value, (
+                f"Field {field_name}: expected {config_value}, got {ad_config_value}"
+            )
+
+    # for model we need to the snapshot check with the factory
+    factory = ModelFactoryRegistry.get(simple_config.model_factory)(
+        model=simple_config.model,
+        model_kwargs=simple_config.model_kwargs,
+        skip_loading_weights=True,
+    )
+    assert ad_config.model == factory.model, (
+        f"Expected model {factory.model}, got {ad_config.model}"
+    )
+
+    # world_size -> tensor_parallel_size
+    assert ad_config.tensor_parallel_size == simple_config.world_size, (
+        f"Expected tensor_parallel_size {simple_config.world_size}, got {ad_config.tensor_parallel_size}"
+    )
+
+    # compile_backend -> use_cuda_graph
+    expected_cuda_graph = simple_config.compile_backend in ["torch-opt", "torch-cudagraph"]
+    assert ad_config.use_cuda_graph == expected_cuda_graph, (
+        f"Expected use_cuda_graph {expected_cuda_graph} for {simple_config.compile_backend}, "
+        f"got {ad_config.use_cuda_graph}"
+    )
+
+    # compile_backend -> torch_compile_enabled
+    expected_torch_compile = simple_config.compile_backend in ["torch-opt", "torch-compile"]
+    assert ad_config.torch_compile_enabled == expected_torch_compile, (
+        f"Expected torch_compile_enabled {expected_torch_compile} for "
+        f"{simple_config.compile_backend}, got {ad_config.torch_compile_enabled}"
+    )
+
+    # backend should always be "autodeploy"
+    assert ad_config.backend == "autodeploy", (
+        f"Expected backend 'autodeploy', got {ad_config.backend}"
+    )
+
 
 @pytest.mark.parametrize(
     "config",
@@ -43,4 +113,17 @@ def test_build_ad(config: Dict):
     config["world_size"] = 0  # Default world_size set to 0
     simple_config = SimpleConfig(**config)
     print(f"Simple Config: {simple_config}")
-    main(simple_config)
+    original_init = InferenceOptimizer.__init__
+
+    def check_and_original_init(self, factory, *, ad_config, **kwargs):
+        _check_ad_config(simple_config, ad_config)
+        return original_init(self, factory, ad_config=ad_config, **kwargs)
+
+    # Temporarily replace the __init__ method
+    InferenceOptimizer.__init__ = check_and_original_init
+
+    try:
+        main(simple_config)
+    finally:
+        # Restore original __init__
+        InferenceOptimizer.__init__ = original_init

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
@@ -9,16 +9,16 @@ from simple_config import SimpleConfig
 
 from tensorrt_llm._torch.auto_deploy.models import ModelFactoryRegistry
 from tensorrt_llm._torch.auto_deploy.transformations.transform import InferenceOptimizer
-from tensorrt_llm.llmapi.llm_args import AutoDeployLlmArgs
+from tensorrt_llm.llmapi.llm_args import _AutoDeployLlmArgs
 
 
-def _check_ad_config(simple_config: SimpleConfig, ad_config: AutoDeployLlmArgs):
+def _check_ad_config(simple_config: SimpleConfig, ad_config: _AutoDeployLlmArgs):
     # Verify that ad_config was captured
     assert ad_config is not None, "ad_config should have been captured"
 
-    # Check that ad_config is an instance of AutoDeployLlmArgs
-    assert isinstance(ad_config, AutoDeployLlmArgs), (
-        f"Expected AutoDeployLlmArgs, got {type(ad_config)}"
+    # Check that ad_config is an instance of _AutoDeployLlmArgs
+    assert isinstance(ad_config, _AutoDeployLlmArgs), (
+        f"Expected _AutoDeployLlmArgs, got {type(ad_config)}"
     )
 
     # Fields that map directly from simple_config to ad_config
@@ -72,9 +72,9 @@ def _check_ad_config(simple_config: SimpleConfig, ad_config: AutoDeployLlmArgs):
         f"{simple_config.compile_backend}, got {ad_config.torch_compile_enabled}"
     )
 
-    # backend should always be "autodeploy"
-    assert ad_config.backend == "autodeploy", (
-        f"Expected backend 'autodeploy', got {ad_config.backend}"
+    # backend should always be "_autodeploy"
+    assert ad_config.backend == "_autodeploy", (
+        f"Expected backend '_autodeploy', got {ad_config.backend}"
     )
 
 


### PR DESCRIPTION
This PR is a follow-up to #4603 to introduce a corresponding `AutoDeployLlmArgs` pydantic model and correctly pass it through to the AutoDeploy core pipeline.

In addition, this PR deprecates the previous `AutoDeployConfig` class in favor of using `AutoDeployLlmArgs` everywhere