### PR TITLE
chore: partition LLM class into TorchLLM and TrtLLM

### DIFF
--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -14,24 +14,7 @@ The LLM API can be used for both offline or online usage. See more examples of t
     :maxdepth: 1
     :caption: LLM API Examples
 
-    llm_eagle_decoding
-    llm_guided_decoding
-    llm_inference
-    llm_inference_async
-    llm_inference_async_streaming
-    llm_inference_customize
-    llm_inference_distributed
-    llm_inference_kv_events
-    llm_logits_processor
-    llm_lookahead_decoding
-    llm_medusa_decoding
-    llm_multilora
-    llm_quantization
-    llm_eagle2_decoding
-    llm_auto_parallel
-    llm_mgmn_llm_distributed
-    llm_mgmn_trtllm_bench
-    llm_mgmn_trtllm_serve
+    %EXAMPLE_DOCS%
 
 For more details on how to fully utilize this API, check out:
 

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -14,7 +14,24 @@ The LLM API can be used for both offline or online usage. See more examples of t
     :maxdepth: 1
     :caption: LLM API Examples
 
-    %EXAMPLE_DOCS%
+    llm_eagle_decoding
+    llm_guided_decoding
+    llm_inference
+    llm_inference_async
+    llm_inference_async_streaming
+    llm_inference_customize
+    llm_inference_distributed
+    llm_inference_kv_events
+    llm_logits_processor
+    llm_lookahead_decoding
+    llm_medusa_decoding
+    llm_multilora
+    llm_quantization
+    llm_eagle2_decoding
+    llm_auto_parallel
+    llm_mgmn_llm_distributed
+    llm_mgmn_trtllm_bench
+    llm_mgmn_trtllm_serve
 
 For more details on how to fully utilize this API, check out:
 

--- a/docs/source/helper.py
+++ b/docs/source/helper.py
@@ -149,11 +149,18 @@ def generate_llmapi():
     content = underline("API Reference", "-") + "\n\n"
     for cls_name in public_classes_names:
         cls_name = cls_name.strip()
-        content += (f".. autoclass:: tensorrt_llm.llmapi.{cls_name}\n"
-                    "    :members:\n"
-                    "    :undoc-members:\n"
-                    "    :special-members: __init__\n"
-                    "    :show-inheritance:\n")
+        options = [
+            "    :members:", "    :undoc-members:", "    :show-inheritance:"
+        ]
+
+        if cls_name != 'LLM':  # Conditionally add :special-members: __init__
+            options.append("    :special-members: __init__")
+
+        if cls_name in ['TrtLLM', 'TorchLLM', 'LLM']:
+            options.append("    :inherited-members:")
+
+        content += f".. autoclass:: tensorrt_llm.llmapi.{cls_name}\n"
+        content += "\n".join(options) + "\n\n"
 
     with open(doc_path, "w+") as f:
         f.write(content)

--- a/tensorrt_llm/_torch/llm.py
+++ b/tensorrt_llm/_torch/llm.py
@@ -1,29 +1,3 @@
-from pathlib import Path
-from typing import Any, Literal, Optional, Union
+from tensorrt_llm.llmapi.llm import TorchLLM as LLM
 
-from transformers import PreTrainedTokenizerBase
-
-from ..llmapi.llm import LLM as BaseLLM
-from ..llmapi.llm import TokenizerBase
-
-
-class LLM(BaseLLM):
-
-    def __init__(self,
-                 model: str,
-                 tokenizer: Optional[Union[str, Path, TokenizerBase,
-                                           PreTrainedTokenizerBase]] = None,
-                 tokenizer_mode: Literal['auto', 'slow'] = 'auto',
-                 skip_tokenizer_init: bool = False,
-                 trust_remote_code: bool = False,
-                 tensor_parallel_size: int = 1,
-                 dtype: str = "auto",
-                 revision: Optional[str] = None,
-                 tokenizer_revision: Optional[str] = None,
-                 **kwargs: Any):
-
-        kwargs_dict = dict(kwargs)
-        kwargs_dict['backend'] = 'pytorch'
-        super().__init__(model, tokenizer, tokenizer_mode, skip_tokenizer_init,
-                         trust_remote_code, tensor_parallel_size, dtype,
-                         revision, tokenizer_revision, **kwargs_dict)
+__all__ = ['LLM']

--- a/tensorrt_llm/_torch/llm.py
+++ b/tensorrt_llm/_torch/llm.py
@@ -1,3 +1,3 @@
-from tensorrt_llm.llmapi.llm import TorchLLM as LLM
+from tensorrt_llm.llmapi.llm import _TorchLLM as LLM
 
 __all__ = ['LLM']

--- a/tensorrt_llm/llmapi/__init__.py
+++ b/tensorrt_llm/llmapi/__init__.py
@@ -2,7 +2,7 @@ from ..disaggregated_params import DisaggregatedParams
 from ..executor import CompletionOutput, RequestError
 from ..sampling_params import GuidedDecodingParams, SamplingParams
 from .build_cache import BuildCacheConfig
-from .llm import LLM, RequestOutput, TorchLLM, TrtLLM
+from .llm import LLM, RequestOutput, _TorchLLM, _TrtLLM
 # yapf: disable
 from .llm_args import (BatchingType, CacheTransceiverConfig, CalibConfig,
                        CapacitySchedulerPolicy, ContextChunkingPolicy,
@@ -50,6 +50,6 @@ __all__ = [
     'LlmArgs',
     'TorchLlmArgs',
     'TrtLlmArgs',
-    'TrtLLM',
-    'TorchLLM',
+    '_TrtLLM',
+    '_TorchLLM',
 ]

--- a/tensorrt_llm/llmapi/__init__.py
+++ b/tensorrt_llm/llmapi/__init__.py
@@ -2,7 +2,7 @@ from ..disaggregated_params import DisaggregatedParams
 from ..executor import CompletionOutput, RequestError
 from ..sampling_params import GuidedDecodingParams, SamplingParams
 from .build_cache import BuildCacheConfig
-from .llm import LLM, RequestOutput
+from .llm import LLM, RequestOutput, TorchLLM, TrtLLM
 # yapf: disable
 from .llm_args import (BatchingType, CacheTransceiverConfig, CalibConfig,
                        CapacitySchedulerPolicy, ContextChunkingPolicy,
@@ -50,4 +50,6 @@ __all__ = [
     'LlmArgs',
     'TorchLlmArgs',
     'TrtLlmArgs',
+    'TrtLLM',
+    'TorchLLM',
 ]

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -800,7 +800,7 @@ class BaseLLM:
 
 
 @append_docstring(TRT_LLM_DOCSTRING)
-class TrtLLM(BaseLLM):
+class _TrtLLM(BaseLLM):
     """LLM class is the main class for running a LLM model using TensorRT-LLM backend.
 
     Parameters:
@@ -818,6 +818,8 @@ class TrtLLM(BaseLLM):
                  revision: Optional[str] = None,
                  tokenizer_revision: Optional[str] = None,
                  **kwargs: Any) -> None:
+        # TODO: deprecate backend in LLM kwargs
+
         super().__init__(model, tokenizer, tokenizer_mode, skip_tokenizer_init,
                          trust_remote_code, tensor_parallel_size, dtype,
                          revision, tokenizer_revision, **kwargs)
@@ -853,7 +855,7 @@ class TrtLLM(BaseLLM):
 
 
 @append_docstring(TORCH_LLM_DOCSTRING)
-class TorchLLM(BaseLLM):
+class _TorchLLM(BaseLLM):
     """LLM class is the main class for running a LLM model using PyTorch backend.
 
     Parameters:
@@ -872,7 +874,9 @@ class TorchLLM(BaseLLM):
                  tokenizer_revision: Optional[str] = None,
                  **kwargs: Any) -> None:
 
-        kwargs.pop('backend', None)
+        # TODO: deprecate backend in LLM kwargs
+        kwargs.pop("backend", None)
+
         super().__init__(model,
                          tokenizer,
                          tokenizer_mode,
@@ -886,14 +890,26 @@ class TorchLLM(BaseLLM):
                          **kwargs)
 
 
-TLLM_USE_TRT_ENGINE = os.environ.get("TLLM_USE_TRT_ENGINE", "1")
+class LLM(_TrtLLM):
+
+    def __init__(self,
+                 model: Union[str, Path],
+                 tokenizer: Optional[Union[str, Path, TokenizerBase,
+                                           PreTrainedTokenizerBase]] = None,
+                 tokenizer_mode: Literal['auto', 'slow'] = 'auto',
+                 skip_tokenizer_init: bool = False,
+                 trust_remote_code: bool = False,
+                 tensor_parallel_size: int = 1,
+                 dtype: str = "auto",
+                 revision: Optional[str] = None,
+                 tokenizer_revision: Optional[str] = None,
+                 **kwargs: Any) -> None:
+        super().__init__(model, tokenizer, tokenizer_mode, skip_tokenizer_init,
+                         trust_remote_code, tensor_parallel_size, dtype,
+                         revision, tokenizer_revision, **kwargs)
 
 
-class LLM(TrtLLM if TLLM_USE_TRT_ENGINE == "1" else TorchLLM):
-    pass
-
-
-_LLM_REPR = "TrtLLM" if TLLM_USE_TRT_ENGINE == "1" else "TorchLLM"
+_LLM_REPR = "TrtLLM"
 
 # sphinx will ignore the LLM's docstring if it is not explicitly set
 LLM.__doc__ = \
@@ -904,4 +920,4 @@ LLM.__doc__ = \
     The default backend is the TensorRT backend.
 
     Parameters:
-""" + TRT_LLM_DOCSTRING if TLLM_USE_TRT_ENGINE == "1" else TORCH_LLM_DOCSTRING
+""" + TRT_LLM_DOCSTRING

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1593,9 +1593,6 @@ class TrtLlmArgs(BaseLlmArgs):
 
 LlmArgs = TrtLlmArgs
 
-LLMARGS_EXPLICIT_DOCSTRING = generate_api_docs_as_docstring(LlmArgs,
-                                                            indent=' ' * 4)
-
 
 class LoadFormat(Enum):
     AUTO = 0
@@ -2068,3 +2065,10 @@ def get_model_format(model_dir: str) -> _ModelFormatKind:
         )
     else:
         return model_format
+
+
+TRT_LLMARGS_EXPLICIT_DOCSTRING = generate_api_docs_as_docstring(TrtLlmArgs,
+                                                                indent=' ' * 4)
+TORCH_LLMARGS_EXPLICIT_DOCSTRING = generate_api_docs_as_docstring(TorchLlmArgs,
+                                                                  indent=' ' *
+                                                                  4)


### PR DESCRIPTION
This PR does
1. Create TorchLLM and TrtLLM with most of the code shared, making it ready to switch TorchLLM as the default LLM for the upcoming version
2. Keep alias of `tensorrt_llm._torch.llm.LLM` for `TorchLLM` and `tensorrt_llm.LLM` for `TrtLLM`
3. Fix the api reference doc accordingly, especially keep the existing LLM unbroken
    - Add separate API references for both TrtLLM and TorchLLM, add support for TrtLlmArgs and TorchLlmArgs.


Document:

LLM's API reference works as before:
![image](https://github.com/user-attachments/assets/09b8b0b8-9d17-49ae-b038-311c3057f7d8)

