### PR TITLE
[nvbug/5195657][fix] fix reset spec buffer and update mMaxAttentionWindowVec logic

### DIFF
--- a/cpp/tensorrt_llm/batch_manager/trtGptModel.h
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModel.h
@@ -310,10 +310,10 @@ protected:
         auto const oldMax = mMaxAttentionWindow;
         mMaxAttentionWindow = newMaxAttentionWindow;
         std::for_each(std::begin(mMaxAttentionWindowVec), std::end(mMaxAttentionWindowVec),
-            [oldMax, newMaxAttentionWindow](SizeType32 w)
+            [oldMax, newMaxAttentionWindow](SizeType32& w)
             {
                 TLLM_CHECK_DEBUG_WITH_INFO(w <= oldMax, "A window can't be larger than oldMax");
-                return std::min(w, newMaxAttentionWindow); // clamp vec to newMaxAttentionWindow
+                w = std::min(w, newMaxAttentionWindow); // clamp vec to newMaxAttentionWindow
             });
     }
 

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -563,6 +563,7 @@ void TrtGptModelInflightBatching::adjustMaxAttentionWindow(SizeType32 numPrimary
         // TODO(nhaber): This is problematic, as createBuffers edits the state of trtGptModelInflightBatching, but what
         // if there are different window values for cross+self etc. in encoder+decoder scenario...
         createBuffers(mDecodingConfig, mAdditionalModelOutputs);
+        createDecoder(mDecodingConfig.getDecodingMode());
     }
 }
 
@@ -1476,26 +1477,6 @@ void TrtGptModelInflightBatching::createBuffers(executor::DecodingConfig const& 
     }
 
     mDecodingInputs.resize(mNumMicroBatches);
-
-    // Reset the spec decoder buffers after we recreate the decoder buffers.
-    if (mDecoderState)
-    {
-        // auto const decodingMode = decodingConfig.getDecodingMode();
-        auto const decodingMode = getDecodingMode(
-            mModelConfig.getSpeculativeDecodingMode(), mDecodingConfig.getDecodingMode(), mOperatingBeamWidth);
-        if (decodingMode.isExplicitDraftTokens())
-        {
-            mDecoderState->setupExplicitDraftTokens(mDecoderBuffers->explicitDraftTokensBuffers);
-        }
-        else if (decodingMode.isLookahead())
-        {
-            mDecoderState->setupLookahead(mDecoderBuffers->lookaheadBuffers.value());
-        }
-        else if (decodingMode.isEagle())
-        {
-            mDecoderState->setupEagle(mDecoderBuffers->eagleBuffers);
-        }
-    }
 
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
 }

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -1477,6 +1477,26 @@ void TrtGptModelInflightBatching::createBuffers(executor::DecodingConfig const& 
 
     mDecodingInputs.resize(mNumMicroBatches);
 
+    // Reset the spec decoder buffers after we recreate the decoder buffers.
+    if (mDecoderState)
+    {
+        // auto const decodingMode = decodingConfig.getDecodingMode();
+        auto const decodingMode = getDecodingMode(
+            mModelConfig.getSpeculativeDecodingMode(), mDecodingConfig.getDecodingMode(), mOperatingBeamWidth);
+        if (decodingMode.isExplicitDraftTokens())
+        {
+            mDecoderState->setupExplicitDraftTokens(mDecoderBuffers->explicitDraftTokensBuffers);
+        }
+        else if (decodingMode.isLookahead())
+        {
+            mDecoderState->setupLookahead(mDecoderBuffers->lookaheadBuffers.value());
+        }
+        else if (decodingMode.isEagle())
+        {
+            mDecoderState->setupEagle(mDecoderBuffers->eagleBuffers);
+        }
+    }
+
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
 }
 


### PR DESCRIPTION
# PR title

[nvbug/5195657][fix] fix reset spec buffer and update `mMaxAttentionWindowVec` logic

## Description

Background: 
When `maxAttentionWindow` and `maxSequenceLen` are too large for at least one sequence to fit in kvCache. We will adjust `MaxAttentionWindow` and recreate the decoder again ([here](https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp#L545-L565)). 

There are two issues:
1) Eagle buffer is not reset. This will cause the subsequent program to still use the buffer created for the first time. Improperly initialized values ​​will result in errors;
2) `maxAttentionWindowVec` is not really updated, resulting in `cyclic_attention_window_size != max_attention_window_size`, which will result in the XQA kernel not being found.;



## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
