### PR TITLE
[TO-DELETE] Debugging SILMA's reduce_fusion flag

### DIFF
--- a/compare_tensors.py
+++ b/compare_tensors.py
@@ -1,0 +1,67 @@
+# import numpy as np
+
+# # Load tensors
+# a = np.load('no_fused.npy')
+# b = np.load('/tmp/tllm_debug/PP_1/TP_2/iteration_0/GemmaForCausalLM_transformer_layers_0_attention_dense_multiply_collect_L518_multiply_collect_L286_multiply_and_lora_L248__gemm_plugin_L139_PLUGIN_V2_Gemm_0_output_0_debug_final_output_NO_FUSION.npy')
+
+# # Flatten
+# a_flat = a.flatten()
+# b_flat = b.flatten()
+
+# # Ensure same shape
+# assert a_flat.shape == b_flat.shape, "Tensors must have the same shape!"
+
+# # Print header
+# print(f"{'Index':>6} | {'Tensor1 (not fused)':>25} | {'Tensor2 (fused)':>25} | Diff")
+# print("-" * 70)
+
+# # Print values side by side, highlight differences
+# for i, (x, y) in enumerate(zip(a_flat, b_flat)):
+#     diff = "DIFF" if x != y else ""
+#     print(f"{i:6d} | {x:34} | {y:34} | {diff}")
+
+# # Optionally, print summary
+# num_diff = np.sum(a_flat != b_flat)
+# print(f"\nTotal differences: {num_diff} / {a_flat.size}")
+
+import numpy as np
+
+# Load tensors
+a = np.load(
+    'NO_FUSION_GemmaForCausalLM_transformer_layers_0___add___L322_elementwise_binary_L3011_ELEMENTWISE_SUM_0_output_0_debug_residual_NO_FUSION.npy'
+)
+b = np.load(
+    'FUSION_ONLY_GemmaForCausalLM_transformer_layers_0_attention_dense_multiply_collect_L518_multiply_collect_L296_collect_and_bias_L537_allreduce_L4085_PLUGIN_V2_AllReduce_0_output_1_debug_inter_output_FUSION_ONLY_debug_residual_FUSION.npy'
+)
+
+# Flatten
+a_flat = a.flatten()
+b_flat = b.flatten()
+
+# Ensure same shape
+assert a_flat.shape == b_flat.shape, "Tensors must have the same shape!"
+
+# Print header
+print(
+    f"{'Index':>6} | {'Tensor1 (not fused)':>25} | {'Tensor2 (fused)':>25} | Close"
+)
+print("-" * 70)
+
+# Use np.isclose for elementwise comparison with default tolerances
+is_close = np.isclose(a_flat, b_flat, atol=0.15, rtol=0.05)
+
+for i, (x, y, close) in enumerate(zip(a_flat, b_flat, is_close)):
+    diff = "" if close else "DIFF"
+    print(f"{i:6d} | {x:34} | {y:34} | {diff}")
+
+# Optionally, print summary
+num_diff = np.sum(~is_close)
+print(f"\nTotal differences (not close): {num_diff} / {a_flat.size}")
+
+# Direct comparison (strict equality) - commented out:
+# num_diff_strict = np.sum(a_flat != b_flat)
+# print(f"\nTotal strict differences: {num_diff_strict} / {a_flat.size}")
+
+# Use np.allclose for overall check
+all_close = np.allclose(a_flat, b_flat)
+print(f"\nnp.allclose result: {all_close}")

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -136,7 +136,7 @@ TrtGptModelInflightBatching::TrtGptModelInflightBatching(std::shared_ptr<nvinfer
     , mDevice{runtime::utils::initDevice(worldConfig)}
     , mDecodingConfig{optionalParams.decodingConfig}
     , mExtendedRuntimePerfKnobConfig{optionalParams.extendedRuntimePerfKnobConfig}
-    , mDebugConfig{optionalParams.debugConfig}
+    , mDebugConfig{executor::DebugConfig(false, true)}
     , mAdditionalModelOutputs{worldConfig.isLastPipelineParallelRank() ? optionalParams.additionalModelOutputs
                                                                        : std::nullopt}
     , mLogger{logger ? std::move(logger) : std::make_shared<TllmLogger>()}

--- a/tensorrt_llm/functional.py
+++ b/tensorrt_llm/functional.py
@@ -25,6 +25,8 @@ import numpy as np
 import tensorrt as trt
 # isort: on
 
+from tensorrt_llm.logger import logger
+
 from . import graph_rewriting as gw
 from ._common import default_net, default_trtnet, precision
 from ._utils import (QuantModeWrapper, bf16_array, bool_array,
@@ -4037,6 +4039,18 @@ def allreduce(
     Returns:
         The tensor produced by that layer.
     '''
+    logger.info('[functional.py][allreduce] ---Beginning of allreduce---')
+
+    logger.info(
+        f'[functional.py][allreduce] Input tensor output shape: {tensor.shape}')
+    logger.info(
+        f'[functional.py][allreduce] Input tensor output dtype: {tensor.dtype}')
+    logger.info(
+        f'[functional.py][allreduce] Input tensor output content: {tensor}')
+    input_tensor_name = f"{tensor.name.replace('/', '_')}_debug_all_reduce_INPUT_tensor"
+    logger.info(
+        f'[functional.py][allreduce] Input tensor name: {input_tensor_name}')
+    tensor.mark_output(input_tensor_name)
 
     global allreduce_ub_counter
     allreduce_ub_counter += 1
@@ -4083,15 +4097,71 @@ def allreduce(
                 if all_reduce_params.fusion_op == AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_NVFP4:
                     scale_factor.mark_output("allreduce_ub_2_" +
                                              str(allreduce_ub_counter))
+                    logger.info(
+                        '[functional.py][allreduce] ---Returning from allreduce WITH NVFP4 FUSION---'
+                    )
+                    final_output.mark_output(
+                        f"{final_output.name.replace('/', '_')}_debug_final_output_WITH_FUSION"
+                    )
                     return (final_output, scale_factor), inter_output
             else:
                 assert all_reduce_params.fusion_op == AllReduceFusionOp.LAST_PROCESS_FOR_UB
                 inter_output.mark_output("allreduce_ub_1_" +
                                          str(allreduce_ub_counter))
+        if all_reduce_params.fusion_op == AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_NVFP4:
+            logger.info(
+                f'[functional.py][allreduce] NVFP4 scale factor shape: {scale_factor.shape}'
+            )
+            logger.info(
+                f'[functional.py][allreduce] NVFP4 scale factor dtype: {scale_factor.dtype}'
+            )
+            logger.info(
+                f'[functional.py][allreduce] NVFP4 scale factor content: {scale_factor}'
+            )
+        logger.info(
+            f'[functional.py][allreduce] Final output shape: {final_output.shape}'
+        )
+        logger.info(
+            f'[functional.py][allreduce] Final output dtype: {final_output.dtype}'
+        )
+        final_output_name = f"{final_output.name.replace('/', '_')}_debug_final_output_WITH_FUSION"
+        logger.info(
+            f'[functional.py][allreduce] Final output name: {final_output_name}'
+        )
+
+        logger.info(
+            f'[functional.py][allreduce] Inter output shape: {inter_output.shape}'
+        )
+        logger.info(
+            f'[functional.py][allreduce] Inter output dtype: {inter_output.dtype}'
+        )
+        logger.info(
+            f'[functional.py][allreduce] Inter output content: {inter_output}')
+
+        logger.info(
+            '[functional.py][allreduce] ---Returning from allreduce WITH FUSION---'
+        )
+        final_output.mark_output(final_output_name)
         return final_output, inter_output
     else:
         final_output = _create_tensor(layer.get_output(0),
                                       layer).cast(tensor.dtype)
+        logger.info(
+            f'[functional.py][allreduce] Final output shape: {final_output.shape}'
+        )
+        logger.info(
+            f'[functional.py][allreduce] Final output dtype: {final_output.dtype}'
+        )
+        logger.info(
+            f'[functional.py][allreduce] Final output content: {final_output}')
+        final_output_name = f"{final_output.name.replace('/', '_')}_debug_final_output_WITH_FUSION"
+        logger.info(
+            f'[functional.py][allreduce] Final output name: {final_output_name}'
+        )
+        logger.info(
+            '[functional.py][allreduce] ---Returning from allreduce WITHOUT FUSION---'
+        )
+        final_output.mark_output(final_output_name)
         return final_output
 
 

--- a/tensorrt_llm/layers/attention.py
+++ b/tensorrt_llm/layers/attention.py
@@ -19,6 +19,8 @@ import numpy as np
 import tensorrt as trt
 import torch
 
+from tensorrt_llm.logger import logger
+
 from .._common import default_net, precision
 from .._utils import (fp32_array, get_sm_version, int32_array, is_same_dtype,
                       set_obj_attrs, trt_dtype_to_np, trt_dtype_to_str)
@@ -1574,10 +1576,11 @@ class Attention(Module):
 
         if self.inner_layernorm is not None:
             context = self.inner_layernorm(context)
+        logger.info('[attention.py][forward] ---Invoking allreduce---')
         context = self.dense(context,
                              lora_runtime_params=dense_lora_params,
                              all_reduce_params=all_reduce_params)
-
+        logger.info('[attention.py][forward] ---Returning from allreduce---')
         if skip_attn is not None and not default_net(
         ).plugin_config.use_fp8_context_fmha:
             context = dense_conditional.add_output(skip_case, context)


### PR DESCRIPTION
## Description

[TO-DELETE] Debugging SILMA's reduce_fusion flag

Confirmed that only NCCL is invoked as part of the auto strategy for SILMA:

```
$ grep "AllReducePlugin strategy for rank" engine_serve_512_tp2_WITH_FUSION.txt | sort | uniq
 [0] Unknown AttrisorRT-LLM][DEBUG] AllReducePlugin strategy for rank 1: NCCL
[TensorRT-LLM][DEBUG] AllReducePlugin strategy for rank 0: NCCL
[TensorRT-LLM][DEBUG] AllReducePlugin strategy for rank 0: Nalled
[TensorRT-LLM][DEBUG] AllReducePlugin strategy for rank 0: Nrategy for rank 1: NCCL
[TensorRT-LLM][DEBUG] AllReducePlugin strategy for rank 1: NCCL
[TensorRT-LLM][DEBUG] XQA kernels are selecte[TensorRT-LLM][DEBUG] AllReducePlugin strategy for rank 0: NCCL
[TensorRT-LLM][DEBUG] XQA kernels are[TensorRT-LLM][DEBUG] AllReducePlugin strategy for rank 0: NCCL
[TensorRT-LLM][INFO] Saving tensor 'GemmaForCausalLM_transformer_layers_41_attention_dense_multiply_collect_L518_multiply_collect_L296_collect_and_bias_L537_allreduce_L4085_PLUGIN_V2_AllReduce_0_output_1_debug_inter_output_FUSION_ONLY_debug_residual_FUSION' to '/tmp/tllm_debug/PP_1/TP_2/iteration_2333/GemmaForCausalLM_transformer_layers_41_attention_dense_multiply_collect_L518_multiply[TensorRT-LLM][DEBUG] AllReducePlugin strategy for rank 1: NCCL
[TensorRT-L[TensorRT-LLM][DEBUG] AllReducePlugin strategy for rank 0: NCCL
```

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
