### PR TITLE
fix: cache-aware router related test fix

### DIFF
--- a/tests/integration/defs/disaggregated/test_disaggregated.py
+++ b/tests/integration/defs/disaggregated/test_disaggregated.py
@@ -20,6 +20,8 @@ import pytest
 from defs.conftest import skip_no_hopper
 from defs.trt_test_alternative import check_call, popen
 
+from tensorrt_llm.logger import logger
+
 
 def cleanup_output_files():
     """Clean up output files from previous runs."""
@@ -121,87 +123,85 @@ def run_disaggregated_test(example_dir,
         str(server_start_timeout), '-c', config_file
     ]
 
-    with (  # Start workers
-            open('output_workers.log', 'w') as output_workers,
-            popen(workers_cmd,
-                  stdout=output_workers,
-                  stderr=subprocess.STDOUT,
-                  env=env,
-                  cwd=cwd),
-            # Start server
-            open('output_disagg.log', 'w') as output_disagg,
-            popen(server_cmd,
-                  stdout=output_disagg,
-                  stderr=subprocess.STDOUT,
-                  env=env,
-                  cwd=cwd)):
-        client_dir = f"{example_dir}/clients"
-        for _ in range(num_iters):
-            client_cmd = [
-                'python3', f'{client_dir}/disagg_client.py', '-c',
-                f'{example_dir}/disagg_config.yaml', '-p',
-                f'{client_dir}/prompts.json', '--server-start-timeout',
-                str(server_start_timeout)
-            ]
-            check_call(client_cmd, env=env)
-
-            # Streaming client run
-            streaming_client_cmd = client_cmd + [
-                '--streaming', '-o', 'output_streaming.json'
-            ]
-            check_call(streaming_client_cmd, env=env)
-
-            # Run the chat completion endpoint test only for TinyLlama
-            if test_desc == "overlap":
-                chat_client_cmd = client_cmd + [
-                    '-e', 'chat', '-o', 'output_chat.json'
+    try:
+        with (  # Start workers
+                open('output_workers.log', 'w') as output_workers,
+                popen(workers_cmd,
+                      stdout=output_workers,
+                      stderr=subprocess.STDOUT,
+                      env=env,
+                      cwd=cwd),
+                # Start server
+                open('output_disagg.log', 'w') as output_disagg,
+                popen(server_cmd,
+                      stdout=output_disagg,
+                      stderr=subprocess.STDOUT,
+                      env=env,
+                      cwd=cwd)):
+            client_dir = f"{example_dir}/clients"
+            for _ in range(num_iters):
+                client_cmd = [
+                    'python3', f'{client_dir}/disagg_client.py', '-c',
+                    f'{example_dir}/disagg_config.yaml', '-p',
+                    f'{client_dir}/prompts.json', '--server-start-timeout',
+                    str(server_start_timeout)
                 ]
-                check_call(chat_client_cmd, env=env)
+                check_call(client_cmd, env=env)
 
-                streaming_chat_client_cmd = chat_client_cmd + [
-                    '--streaming', '-o', 'output_streaming_chat.json'
+                # Streaming client run
+                streaming_client_cmd = client_cmd + [
+                    '--streaming', '-o', 'output_streaming.json'
                 ]
-                check_call(streaming_chat_client_cmd, env=env)
+                check_call(streaming_client_cmd, env=env)
 
-            # Verify outputs
-            not_expected_strings = ["Berlin Berlin"]
+                # Run the chat completion endpoint test only for TinyLlama
+                if test_desc == "overlap":
+                    chat_client_cmd = client_cmd + [
+                        '-e', 'chat', '-o', 'output_chat.json'
+                    ]
+                    check_call(chat_client_cmd, env=env)
 
-            output_files = ['output.json', 'output_streaming.json']
-            if test_desc == "overlap":
-                # Disable streaming chat completion for overlap test
-                # due to bug
-                output_files.extend(['output_chat.json'])
+                    streaming_chat_client_cmd = chat_client_cmd + [
+                        '--streaming', '-o', 'output_streaming_chat.json'
+                    ]
+                    check_call(streaming_chat_client_cmd, env=env)
 
-            if test_desc == "gen_only":
-                continue
+                # Verify outputs
+                not_expected_strings = ["Berlin Berlin"]
 
-            for output_file in output_files:
-                with open(output_file, 'r') as f:
-                    content = f.read()
-                    if "deepseek_v3_lite" in test_desc or output_file == "output_chat.json":
-                        expected_strings = ["Berlin", "Asyncio is a"]
-                    else:
-                        expected_strings = [
-                            "The capital of Germany is Berlin",
-                            "Asyncio is a Python library"
-                        ]
-                    for expected_string in expected_strings:
-                        assert expected_string in content, f"Expected string '{expected_string}' not found in {output_file}"
-                    for not_expected_string in not_expected_strings:
-                        assert not_expected_string not in content, f"Unexpected string '{not_expected_string}' found in {output_file}"
+                output_files = ['output.json', 'output_streaming.json']
+                if test_desc == "overlap":
+                    # Disable streaming chat completion for overlap test
+                    # due to bug
+                    output_files.extend(['output_chat.json'])
 
-    # Print outputs
-    print("------------------")
-    print("Workers output:")
-    print("------------------")
-    with open('output_workers.log', 'r') as f:
-        print(f.read())
+                if test_desc == "gen_only":
+                    continue
 
-    print("\n\n------------------")
-    print("Disagg server output")
-    print("------------------")
-    with open('output_disagg.log', 'r') as f:
-        print(f.read())
+                for output_file in output_files:
+                    with open(output_file, 'r') as f:
+                        content = f.read()
+                        if "deepseek_v3_lite" in test_desc or output_file == "output_chat.json":
+                            expected_strings = ["Berlin", "Asyncio is a"]
+                        else:
+                            expected_strings = [
+                                "The capital of Germany is Berlin",
+                                "Asyncio is a Python library"
+                            ]
+                        for expected_string in expected_strings:
+                            assert expected_string in content, f"Expected string '{expected_string}' not found in {output_file}"
+                        for not_expected_string in not_expected_strings:
+                            assert not_expected_string not in content, f"Unexpected string '{not_expected_string}' found in {output_file}"
+    except Exception:
+        # Print outputs on error
+        logger.error("-------- Workers output --------")
+        with open('output_workers.log', 'r') as f:
+            logger.error(f.read())
+
+        logger.error("-------- Disagg server output --------")
+        with open('output_disagg.log', 'r') as f:
+            logger.error(f.read())
+        raise
 
 
 @pytest.mark.parametrize("llama_model_root", ['TinyLlama-1.1B-Chat-v1.0'],


### PR DESCRIPTION
# PR title

This PR cherry-picks #4597 and test fixing part of #3974.

Fix:

- 5279438: server mismatch in router test
- 5300551: eviction test failed

Improve error logging for flaky fails:

- 5301492: broken pipe
- 5303620: timeout
- 5303638: server failed to start

More detail in #4597.

## Description

Please explain the issue and the solution in short.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
