### PR TITLE
fix: params passed to BuildConfig will propagate to LlmArgs as well

### DIFF
--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1083,11 +1083,12 @@ class BaseLlmArgs(BaseModel):
                         "max_batch_size", "max_num_tokens", "max_seq_len",
                         "max_input_len", "max_beam_width"
                 ]:
-                    if key in kwargs and getattr(b, key) is not None:
-                        if kwargs[key] is not None and kwargs[key] != getattr(
-                                b, key):
+                    if getattr(b, key) is not None:
+                        if (key in kwargs and kwargs[key] is not None
+                                and kwargs[key] != getattr(b, key)):
                             logger.warning(
                                 f"overriding {key} from build_config")
+                        # build_config's value will always overwrite the corresponding option
                         kwargs[key] = getattr(b, key)
 
         ret = cls(**kwargs)


### PR DESCRIPTION
PR https://github.com/NVIDIA/TensorRT-LLM/issues/4600 introduced logic in `BaseLlmArgs` to extract relevant args from `BuildConfig` to the `BaseLlmArgs` class. However, the logic included a bug, that caused arguments to be extracted only if they already exist in the `kwargs` passed to the `BaseLlmArgs` constructor.

This PR fixes this issue, by extracting the relevant arguments regardless if they exist in the `kwargs` or not.