### PR TITLE
Coalesce text diffs in streaming requests.

### DIFF
--- a/examples/apps/fastapi_server.py
+++ b/examples/apps/fastapi_server.py
@@ -72,8 +72,10 @@ class LlmServer:
                                               sampling_params=sampling_params)
 
             async def stream_results() -> AsyncGenerator[bytes, None]:
+                last_text_len: int = 0
                 async for output in promise:
-                    yield output.outputs[0].text_diff.encode("utf-8")
+                    text_diff, last_text_len = output.outputs[0].text_diff_safe(last_text_len)
+                    yield text_diff.encode("utf-8")
 
             if streaming:
                 return StreamingResponse(stream_results())

--- a/tensorrt_llm/executor/postproc_worker.py
+++ b/tensorrt_llm/executor/postproc_worker.py
@@ -29,6 +29,9 @@ __all__ = [
 @dataclass(kw_only=True)
 class PostprocArgs:
     first_iteration: bool = True
+    last_text_len: int = 0
+    last_logprobs_len: int = 0
+    last_token_ids_len: int = 0
     num_prompt_tokens: Optional[int] = None
     tokenizer: Optional[TransformersTokenizer] = None
 

--- a/tensorrt_llm/executor/result.py
+++ b/tensorrt_llm/executor/result.py
@@ -4,7 +4,7 @@ import weakref
 from dataclasses import dataclass, field
 from queue import Empty, Queue
 from typing import (TYPE_CHECKING, Any, Callable, List, Literal, NamedTuple,
-                    Optional, TypeAlias, Union)
+                    Optional, TypeAlias, Union, Tuple)
 from weakref import WeakMethod
 
 import torch
@@ -89,8 +89,11 @@ class CompletionOutput:
     Attributes:
         length (int): The number of generated tokens.
         token_ids_diff (List[int]): Newly generated token ids.
-        logprobs_diff (List[float]): Logprobs of newly generated tokens.
-        text_diff (str): Newly generated tokens.
+
+    Accessors:
+        token_ids_diff_safe(int) -> Tuple[List[int], int]: Newly generated token ids since the given length.
+        logprobs_diff_safe(int) -> Tuple[List[float], int]: Logprobs of newly generated tokens since the given length.
+        text_diff_safe(int) -> Tuple[str, int]: Newly generated tokens since the given length.
     """
     index: int
     text: str = ""
@@ -119,17 +122,26 @@ class CompletionOutput:
     def length(self) -> int:
         return len(self.token_ids)
 
-    @property
-    def text_diff(self) -> str:
-        return self.text[self._last_text_len:]
+    def text_diff_safe(self, last_text_len) -> Tuple[str, int]:
+        return self.text[last_text_len:], len(self.text)
+
+    def logprobs_diff_safe(self, last_logprobs_len) -> Tuple[List[float], int]:
+        return self.logprobs[last_logprobs_len:], len(self.logprobs)
+
+    def token_ids_diff_safe(self, last_token_ids_len) -> Tuple[List[int], int]:
+        return self.logprobs[last_token_ids_len:], len(self.logprobs)
+
+    #@property
+    #def text_diff(self) -> str:
+    #    return self.text[self._last_text_len:]
 
     @property
     def token_ids_diff(self) -> List[int]:
         return self.token_ids[self._last_token_ids_len:]
 
-    @property
-    def logprobs_diff(self) -> List[float]:
-        return self.logprobs[self._last_logprobs_len:]
+    #@property
+    #def logprobs_diff(self) -> List[float]:
+    #    return self.logprobs[self._last_logprobs_len:]
 
 
 class GenerationResultBase:

--- a/tests/unittest/llmapi/run_llm_with_postproc.py
+++ b/tests/unittest/llmapi/run_llm_with_postproc.py
@@ -47,7 +47,7 @@ def perform_faked_oai_postprocess(rsp: GenerationResultBase,
         if finish_reason_sent[i]:
             continue
 
-        delta_text = output.text_diff
+        delta_text, args.last_text_len = output.text_diff_safe(args.last_text_len)
         delta_message = DeltaMessage(content=delta_text)
 
         choice = ChatCompletionResponseStreamChoice(index=i,


### PR DESCRIPTION
# fix/hack: Coalesce text diffs in streaming requests.

## Description

Sometimes, streaming output from openai_server will produce the same message twice and skip another message.
For example, this was a packet capture from an example bad request:

138\r\ndata: {\"id\":\"cmpl-ef21ea5a4fe640f1bea24729b7a0b07d\",\"object\":\"text_completion\",\"created\":1748849646,\"model\":\"nvidia/DeepSeek-R1-FP4\",\"choices\":[{\"index\":0,\"text\":\"**1.** \",\"logprobs\":null,\"finish_reason\":null,\"stop_reason\":null}],\"usage\":{\"prompt_tokens\":144,\"total_tokens\":305,\"completion_tokens\":**160**}}\n\n\r\n",
138\r\ndata: {\"id\":\"cmpl-6b5546146cdf41f7a0b64b2de0309288\",\"object\":\"text_completion\",\"created\":1748849646,\"model\":\"nvidia/DeepSeek-R1-FP4\",\"choices\":[{\"index\":0,\"text\":\" **Clarify**\",\"logprobs\":null,\"finish_reason\":null,\"stop_reason\":null}],\"usage\":{\"prompt_tokens\":144,\"total_tokens\":305,\"completion_tokens\":**161**}}\n\n\r\n",
...
"139\r\ndata: {\"id\":\"cmpl-1ff642a3baa14acf980a8632e744f46c\",\"object\":\"text_completion\",\"created\":1748849646,\"model\":\"nvidia/DeepSeek-R1-FP4\",\"choices\":[{\"index\":0,\"text\":\"**, there**\",\"logprobs\":null,\"finish_reason\":null,\"stop_reason\":null}],\"usage\":{\"prompt_tokens\":144,\"total_tokens\":316,\"completion_tokens\":**172**}}\n\n\r\n139\r\ndata: {\"id\":\"cmpl-5fc9048a4a9f424b9518c976083a369f\",\"object\":\"text_completion\",\"created\":1748849646,\"model\":\"nvidia/DeepSeek-R1-FP4\",\"choices\":[{\"index\":0,\"text\":\"**, there**\",\"logprobs\":null,\"finish_reason\":null,\"stop_reason\":null}],\"usage\":{\"prompt_tokens\":144,\"total_tokens\":316,\"completion_tokens\":**172**}}\n\n\r\n139\r\ndata: {\"id\":\"cmpl-5782671ed8a54e4383c0ddbac6a82b68\",\"object\":\"text_completion\",\"created\":1748849646,\"model\":\"nvidia/DeepSeek-R1-FP4\",\"choices\":[{\"index\":0,\"text\":\"**, there**\",\"logprobs\":null,\"finish_reason\":null,\"stop_reason\":null}],\"usage\":{\"prompt_tokens\":144,\"total_tokens\":316,\"completion_tokens\":**172**}}\n\n\r\n139\r\ndata: {\"id\":\"cmpl-cd64d34f1091405797f53f370064e63b\",\"object\":\"text_completion\",\"created\":1748849646,\"model\":\"nvidia/DeepSeek-R1-FP4\",\"choices\":[{\"index\":0,\"text\":\"**, there**\",\"logprobs\":null,\"finish_reason\":null,\"stop_reason\":null}],\"usage\":{\"prompt_tokens\":144,\"total_tokens\":316,\"completion_tokens\":**172**}}

In particular, completion_tokens is calculated using the current value of `output.length`, and since output is the same object at each iteration, this will always be the current output length, which is why it always says 172 after the lag spike in the above example.

As for `text_diff`, it uses an internal property of the GenerationResultBase that stores the last position. My suspicion is this last position is increased even if the generator is not being consumed, which is why there is data loss and duplicate tokens. To solve this, I keep track of the last text pos in the params object which is local to the request, and pass it into the GenerationResultBase getter. Finally, this would create a situation where you have one packet with the entire text diff, followed by a bunch of empty updates, so I added a hacky check to remove the empty updates.

This change is a little bit of a hack. It doesn't address the root cause of state updates being interleaved with streaming generator polling, but it kind of prevents these missed packets from producing corrupted output in the frontend. I would prefer a better change, but this is what I was able to come up with.

## Test Coverage

Run DeepSeek-R1-FP4
Run several extremely large prefills while performing streaming requests, to create high load. If you time it right, without this patch it will skip one packet and produce a duplicate with the same completion_tokens on each.

(Also, for some reason, I was unable to reproduce the issue with curl, but only with python aiohttp. I don't know why.)