### PR TITLE
chore: cleanup GDS Cmake interface

### DIFF
--- a/cpp/tensorrt_llm/CMakeLists.txt
+++ b/cpp/tensorrt_llm/CMakeLists.txt
@@ -141,6 +141,24 @@ add_subdirectory(runtime)
 add_subdirectory(testing)
 add_subdirectory(executor_worker)
 
+if(ENABLE_CUFILE)
+  find_library(
+    CUFILE_LIBRARY cufile HINTS ${CUDAToolkit_LIBRARY_DIR}
+                                /usr/lib/${TARGET_ARCH} /usr/local/lib)
+  if(NOT CUFILE_LIBRARY)
+    # FATAL_ERROR if user explicitly requests with GDS if CUDA's libcufile.so is
+    # not found.
+    message(
+      FATAL_ERROR
+        "cuFile library not found. Set -DENABLE_CUFILE=OFF if cufile isn't required."
+    )
+  else()
+    message(STATUS "Linking with cufile: ${CUFILE_LIBRARY}")
+  endif()
+else()
+  message(STATUS "ENABLE_CUFILE=OFF, skipping GDS linkage.")
+endif()
+
 set(BATCH_MANAGER_TARGET tensorrt_llm_batch_manager_static)
 set(BATCH_MANAGER_TARGET_ARCH ${TARGET_ARCH})
 add_subdirectory(batch_manager)
@@ -209,31 +227,16 @@ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 add_library(${SHARED_TARGET} SHARED)
 
-if(ENABLE_CUFILE)
-  find_library(
-    CUFILE_LIBRARY cufile HINTS /usr/local/cuda-12.6/targets/x86_64-linux/lib
-                                /usr/lib/x86_64-linux-gnu /usr/local/lib)
-  if(NOT CUFILE_LIBRARY)
-    # FATAL_ERROR if user explicitly requests with GDS if CUDA's libcufile.so is
-    # not found.
-    message(
-      FATAL_ERROR
-        "cuFile library not found. Set -DENABLE_CUFILE=OFF if cufile isn't required."
-    )
-  else()
-    message(STATUS "Linking with cufile: ${CUFILE_LIBRARY}")
-    target_link_libraries(${SHARED_TARGET} PUBLIC ${CUFILE_LIBRARY})
-  endif()
-else()
-  message(STATUS "ENABLE_CUFILE=OFF, skipping GDS linkage.")
-endif()
-
 set_target_properties(
   ${SHARED_TARGET}
   PROPERTIES CXX_STANDARD "17" CXX_STANDARD_REQUIRED "YES" CXX_EXTENSIONS "NO"
              LINK_FLAGS "${AS_NEEDED_FLAG} ${UNDEFINED_FLAG}")
 
 target_link_libraries(${SHARED_TARGET} PUBLIC ${TRTLLM_LINK_LIBS})
+
+if(ENABLE_CUFILE)
+  target_link_libraries(${SHARED_TARGET} PUBLIC ${CUFILE_LIBRARY})
+endif()
 
 target_link_libraries(
   ${SHARED_TARGET}

--- a/cpp/tensorrt_llm/batch_manager/CMakeLists.txt
+++ b/cpp/tensorrt_llm/batch_manager/CMakeLists.txt
@@ -95,16 +95,7 @@ set(TOP_LEVEL_DIR "${PROJECT_SOURCE_DIR}/..")
 target_compile_definitions(${BATCH_MANAGER_STATIC_TARGET}
                            PUBLIC TOP_LEVEL_DIR="${TOP_LEVEL_DIR}")
 
-# Find and link cuFile library for kvCacheTransferManager (GDS).
 if(ENABLE_CUFILE)
-  find_library(
-    CUFILE_LIBRARY
-    NAMES cufile
-    HINTS /usr/local/cuda-12.6/targets/x86_64-linux/lib
-          /usr/lib/x86_64-linux-gnu /usr/local/lib)
-  if(NOT CUFILE_LIBRARY)
-    message(FATAL_ERROR "Could not find cufile library inside container.")
-  endif()
   target_link_libraries(${BATCH_MANAGER_STATIC_TARGET} PUBLIC ${CUFILE_LIBRARY})
 endif()
 


### PR DESCRIPTION
# PR title

chore: cleanup GDS Cmake interface

## Description

* Only find the library once
* Use the generic CUDA toolkit library path (not hardcoded to 12.6)
* Use the generic target arch directory (so it works on ARM)

## Test Coverage

Build only change

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
