### PR TITLE
Raise shut down error for each request

### DIFF
--- a/tensorrt_llm/executor/executor.py
+++ b/tensorrt_llm/executor/executor.py
@@ -271,6 +271,9 @@ class GenerationExecutor(ABC):
             # We can catch some exceptions here.
             raise e
 
+    def is_shutdown(self) -> bool:
+        return self.doing_shutdown
+
     @abstractmethod
     def shutdown(self):
         pass

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -58,7 +58,6 @@ class GenerationExecutorProxy(GenerationExecutor):
         )
 
         self.workers_started = False
-        self.doing_pre_shutdown = False
         self.worker_cls = worker_cls
 
         mpi_process_pre_spawned: bool = get_spawn_proxy_process_env()
@@ -334,10 +333,10 @@ class GenerationExecutorProxy(GenerationExecutor):
             return
         print_colored_debug('Proxy.pre_shutdown...\n', "yellow")
 
-        if self.doing_pre_shutdown:
+        if self.doing_shutdown:
             return
         else:
-            self.doing_pre_shutdown = True
+            self.doing_shutdown = True
 
         self._abort_all_requests()
 
@@ -349,7 +348,7 @@ class GenerationExecutorProxy(GenerationExecutor):
         if not self.workers_started:
             return
 
-        if not self.doing_pre_shutdown:
+        if not self.doing_shutdown:
             self.pre_shutdown()
 
         print_colored_debug('Proxy.shutdown...\n', "yellow")
@@ -393,9 +392,6 @@ class GenerationExecutorProxy(GenerationExecutor):
 
         if enable_llm_debug():
             print_alive_threads()
-
-    def is_shutdown(self) -> bool:
-        return self.doing_pre_shutdown
 
     def submit(self, request: GenerationRequest) -> GenerationResult:
         """

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -394,6 +394,9 @@ class GenerationExecutorProxy(GenerationExecutor):
         if enable_llm_debug():
             print_alive_threads()
 
+    def is_shutdown(self) -> bool:
+        return self.doing_pre_shutdown
+
     def submit(self, request: GenerationRequest) -> GenerationResult:
         """
             Low-level API to the executor. Return a "future" GenerationResult

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -323,6 +323,11 @@ class BaseLLM:
         Returns:
             tensorrt_llm.llmapi.RequestOutput: The output data of the completion request to the LLM.
         """
+
+        # Check if the worker is shutting down
+        if self._executor is None or self._executor.is_shutdown():
+            raise RuntimeError("LLM is shutting down")
+
         sampling_params = self._prepare_sampling_params(sampling_params)
 
         # With pytorch backend, py_executor has logic to handle max_tokens of 1,

--- a/tests/unittest/llmapi/test_llm.py
+++ b/tests/unittest/llmapi/test_llm.py
@@ -2080,6 +2080,20 @@ def test_llm_capture_request_error():
     _test_llm_capture_request_error(tp_size=1)
 
 
+def test_llm_shutdown_executor():
+    llm = LLM(
+        model=llama_model_path,
+        kv_cache_config=global_kvcache_config,
+        fast_build=True,
+    )
+
+    llm.generate("A")
+    llm.shutdown()
+
+    with pytest.raises(RuntimeError):
+        llm.generate("A")
+
+
 def test_llm_api_jupyter_scenario():
 
     with LLM(


### PR DESCRIPTION
# Raise shut down error for each request

## Description

Currently, the client can still send requests to server when the server is shutting down. To let the router deal with this better, we raise shut down error for each inflight request and stop accepting new requests. 

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
