### PR TITLE
[fix] Add MPI barrier for proper NVLS multicast team initialization

### DIFF
--- a/cpp/tensorrt_llm/runtime/ipcNvlsMemory.cpp
+++ b/cpp/tensorrt_llm/runtime/ipcNvlsMemory.cpp
@@ -244,6 +244,9 @@ IpcNvlsHandle* ipcNvlsAllocate(size_t size, std::set<int> group)
     CUCHECK(cuDeviceGet(&dev, device_id));
     CUCHECK(cuMulticastAddDevice(handle.mc_handle, dev));
 
+    // This step needs to be completed on all processes controlling devices that should participate in a Multicast Team before memory on any device is bound to the Multicast Object.
+    MPI_group_barrier(group);
+
     // Create multicast VA
     CUCHECK(cuMemAddressReserve(&handle.mc_va, size, mc_align, 0U, 0));
     CUCHECK(cuMemMap(handle.mc_va, size, 0, handle.mc_handle, 0));


### PR DESCRIPTION
# Add MPI barrier for proper NVLS multicast team initialization

## Description

This PR fixes a critical synchronization issue in the NVLS (NVLink Shared Memory) IPC memory allocation process. The change adds a required MPI barrier after adding devices to the multicast object and before binding memory to ensure compliance with CUDA documentation.

**Root Cause:** The CUDA documentation explicitly states: _"This step needs to be completed on all processes controlling devices that should participate in a Multicast Team before memory on any device is bound to the Multicast Object."_ [CUDA doc](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#add-devices-to-multicast-objects)

**Fix:** Added `MPI_group_barrier(group)` after the `cuMulticastAddDevice() `call to ensure all participating processes have completed device registration before any process proceeds to bind memory to the multicast object via `cuMulticastBindMem()`.
Without this barrier, there was a race condition where some processes could attempt to bind memory before all devices were properly added to the multicast team, leading to undefined behavior and potential memory corruption in multi-GPU NVLS operations.
This synchronization fix ensures stable and reliable operation of NVLS multicast memory sharing across multiple GPUs and MPI ranks.

## Test Coverage

1. Multi-GPU NVLS allocation tests with various rank configurations
2. Multi-node NVLS communication reliability tests

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
