### PR TITLE
Add customized renormalized moe routing kernel for moe cutlass backend

### DIFF
--- a/cpp/tensorrt_llm/kernels/renormMoeRoutingKernels.cu
+++ b/cpp/tensorrt_llm/kernels/renormMoeRoutingKernels.cu
@@ -1,0 +1,333 @@
+/*
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cutlass/numeric_types.h"
+#include "tensorrt_llm/common/cudaTypeUtils.cuh"
+#include "tensorrt_llm/common/envUtils.h"
+#include "tensorrt_llm/kernels/renormMoeRoutingKernels.h"
+#include <cooperative_groups.h>
+#include <cooperative_groups/reduce.h>
+#include <math.h>
+
+namespace cg = cooperative_groups;
+using namespace tensorrt_llm::common;
+
+namespace tensorrt_llm::kernels
+{
+
+static constexpr int BLOCK_SIZE = 1024;
+static constexpr int WARP_SIZE = 32;
+static constexpr int WARPS_PER_BLOCK = BLOCK_SIZE / WARP_SIZE;
+
+namespace reduce_topk
+{
+template <typename T_>
+struct TopKRedType
+{
+    using T = T_;
+    static_assert(std::is_same_v<T, float> || std::is_same_v<T, cutlass::bfloat16_t>,
+        "Top K reduction only implemented for float and Bf16");
+    using TypeCmp = std::conditional_t<sizeof(T) >= 4, double, float>;
+    static constexpr int64_t Mask64 = 0x000000000000FFFF;
+    static constexpr int32_t Mask32 = 0x0000FFFF;
+
+    TypeCmp compVal;
+
+    static __host__ __device__ inline TypeCmp makeCmpVal(T val, int32_t idx = 0)
+    {
+        auto cmpVal = TypeCmp{val};
+        TypeCmp cmpValWithIdx;
+        if constexpr (sizeof(T) >= 4)
+        {
+            auto cmpValIdx64 = reinterpret_cast<int64_t&>(cmpVal) | (Mask64& int64_t{idx});
+            cmpValWithIdx = reinterpret_cast<TypeCmp&>(cmpValIdx64);
+        }
+        else
+        {
+            auto cmpValIdx32 = reinterpret_cast<int32_t&>(cmpVal) | (Mask32 & idx);
+            cmpValWithIdx = reinterpret_cast<TypeCmp&>(cmpValIdx32);
+        }
+        return cmpValWithIdx;
+    }
+
+    static __host__ __device__ inline void unpack(T& val, int32_t& idx, TypeCmp cmp)
+    {
+        if constexpr (sizeof(T) >= 4)
+        {
+            idx = static_cast<int32_t>(reinterpret_cast<int64_t&>(cmp) & Mask64);
+            auto val64 = reinterpret_cast<int64_t&>(cmp) & ~Mask64;
+            val = static_cast<float>(reinterpret_cast<double&>(val64));
+        }
+        else
+        {
+            idx = reinterpret_cast<int32_t&>(cmp) & Mask32;
+            auto val32 = reinterpret_cast<int32_t&>(cmp) >> 16;
+            val = T::bitcast(reinterpret_cast<uint16_t&>(val32));
+        }
+    }
+
+    __host__ __device__ TopKRedType() = default;
+
+    __host__ __device__ TopKRedType(T val, int32_t idx)
+        : compVal(makeCmpVal(val, idx))
+    {
+    }
+
+    __host__ __device__ operator TypeCmp() const noexcept
+    {
+        return compVal;
+    }
+
+    __device__ inline TypeCmp reduce(cg::thread_block_tile<WARP_SIZE> const& warp)
+    {
+#if defined(TLLM_GEN_ENABLE_FAST_REDUX)
+        static constexpr bool UseCg = false;
+#else
+        static constexpr bool UseCg = true;
+#endif
+        if constexpr (UseCg || sizeof(T) >= 4)
+        {
+            return cg::reduce(warp, compVal, cg::greater<TypeCmp>{});
+        }
+        else
+        {
+            float result;
+            asm("redux.sync.max.f32 %0, %1, 0xffffffff;\n" : "=f"(result) : "f"(compVal));
+            return result;
+        }
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <int K_, bool Enable_>
+struct TopKIdx
+{
+    // by default, empty
+};
+
+template <int K_>
+struct TopKIdx<K_, true>
+{
+    static constexpr int K = K_;
+    int32_t val[K];
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <int K, typename Type>
+__device__ void reduceTopK(cg::thread_block_tile<WARP_SIZE> const& warp, Type (&out)[K], int32_t (&outIdx)[K],
+    Type value, int32_t idx, Type minValue)
+{
+    static_assert(K > 0, "Top K must have K > 0");
+    static_assert(K < WARP_SIZE, "Top K must have K < WARP_SIZE");
+    using RedType = TopKRedType<Type>;
+    RedType topK{value, idx};
+    typename RedType::TypeCmp packedMax{};
+#pragma unroll
+    for (int kk = 0; kk < K; ++kk)
+    {
+        topK = kk > 0 && packedMax == topK.compVal ? RedType{minValue, idx} : topK;
+        // get the next largest value
+        packedMax = topK.reduce(warp);
+        RedType::unpack(out[kk], outIdx[kk], packedMax);
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#define TOPK_SWAP(I, J)                                                                                                \
+    {                                                                                                                  \
+        auto pairMin = min(topK[I].compVal, topK[J].compVal);                                                          \
+        auto pairMax = max(topK[I].compVal, topK[J].compVal);                                                          \
+        topK[I].compVal = pairMax;                                                                                     \
+        topK[J].compVal = pairMin;                                                                                     \
+    }
+
+template <int K, typename Type, int N, bool IsSorted = false>
+__device__ void reduceTopK(cg::thread_block_tile<WARP_SIZE> const& warp, Type (&out)[K], int32_t (&outIdx)[K],
+    Type (&value)[N], int32_t (&idx)[N], Type minValue)
+{
+    static_assert(K > 0, "Top K must have K > 0");
+    static_assert(K < WARP_SIZE, "Top K must have K < WARP_SIZE");
+    static_assert(N > 0, "Top K must have N > 1");
+    // static_assert(N <= K, "Top K must have N < K");
+    using RedType = TopKRedType<Type>;
+    RedType topK[N];
+#pragma unroll
+    for (int nn = 0; nn < N; ++nn)
+    {
+        topK[nn] = RedType{value[nn], idx[nn]};
+    }
+
+    if constexpr (!IsSorted)
+    {
+        TOPK_SWAP(0, 2);
+        TOPK_SWAP(1, 3);
+
+        TOPK_SWAP(0, 1);
+        TOPK_SWAP(2, 3);
+
+        TOPK_SWAP(1, 2);
+    }
+    typename RedType::TypeCmp packedMax{};
+#pragma unroll
+    for (int kk = 0; kk < K; ++kk)
+    {
+        bool update = kk > 0 && packedMax == topK[0].compVal;
+#pragma unroll
+        for (int nn = 0; nn < N; ++nn)
+        {
+            topK[nn] = update && nn == N - 1 ? RedType{minValue, idx[nn]} : update ? topK[nn + 1] : topK[nn];
+        }
+        // get the next largest value
+        packedMax = topK[0].reduce(warp);
+        RedType::unpack(out[kk], outIdx[kk], packedMax);
+    }
+};
+
+#undef TOPK_SWAP
+
+} // end of namespace reduce_topk
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <typename T>
+__device__ T calcSoftmax(cg::thread_block_tile<WARP_SIZE> const& warp, T score, int32_t laneIdx, int32_t NumTopExperts)
+{
+    T maxScore = T{-INFINITY};
+    if (laneIdx < NumTopExperts)
+    {
+        maxScore = score >= maxScore ? score : maxScore;
+    }
+    maxScore = cg::reduce(warp, maxScore, cg::greater<T>());
+
+    float sumScore = float{0.f};
+    float newScore;
+    // Get the summation of scores for each token
+    if (laneIdx < NumTopExperts)
+    {
+        newScore = static_cast<float>(score) - static_cast<float>(maxScore);
+        newScore = static_cast<float>(exp(newScore));
+        sumScore += newScore;
+    }
+    sumScore = cg::reduce(warp, sumScore, cg::plus<float>());
+
+    if (laneIdx < NumTopExperts)
+    {
+        score = static_cast<T>(newScore / sumScore);
+    }
+
+    return score;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <typename InputT, typename OutputT, typename IdxT, int MaxNumExperts, int MaxNumTopExperts>
+__global__ void renormMoeRoutingKernel(InputT* routerLogits, OutputT* topkValues, IdxT* topkIndices,
+    int32_t const numTokens, int32_t const numExperts, int32_t const topK)
+{
+
+    uint32_t const blockRank = blockIdx.x;
+    uint32_t const tIdx = BLOCK_SIZE * blockRank + threadIdx.x;
+    uint32_t const warpIdx = tIdx / WARP_SIZE;
+    uint32_t const laneIdx = tIdx % WARP_SIZE;
+    uint32_t const warpNum = gridDim.x * WARPS_PER_BLOCK;
+    auto block = cg::this_thread_block();
+    auto warp = cg::tiled_partition<WARP_SIZE>(block);
+
+    InputT minScore = InputT{-INFINITY};
+    for (uint32_t tokenId = warpIdx; tokenId < numTokens; tokenId += warpNum)
+    {
+        auto scoreOffset = tokenId * numExperts;
+        auto outputOffset = tokenId * topK;
+        InputT inputScore[MaxNumExperts / WARP_SIZE];
+        IdxT inputIndex[MaxNumExperts / WARP_SIZE];
+
+        InputT warpTopKScore[MaxNumTopExperts];
+        IdxT warpTopKExpertIdx[MaxNumTopExperts];
+
+        // Load scores and indices for this warp
+        for (uint32_t i = 0; i < MaxNumExperts / WARP_SIZE; ++i)
+        {
+            auto expertIdx = i * WARP_SIZE + laneIdx;
+            inputScore[i]
+                = expertIdx < numExperts ? static_cast<InputT>(routerLogits[scoreOffset + expertIdx]) : minScore;
+            inputIndex[i] = expertIdx;
+        }
+
+        // Reduce topK scores and indices for this warp
+        reduce_topk::reduceTopK(warp, warpTopKScore, warpTopKExpertIdx, inputScore, inputIndex, minScore);
+
+        // Perform softmax on topK scores
+        auto score = calcSoftmax(warp,
+            laneIdx < topK ? static_cast<float>(warpTopKScore[laneIdx]) : static_cast<float>(minScore), laneIdx, topK);
+        if (laneIdx < topK)
+        {
+            topkValues[outputOffset + laneIdx] = static_cast<OutputT>(score);
+            topkIndices[outputOffset + laneIdx] = warpTopKExpertIdx[laneIdx];
+        }
+    } // end for tokenId
+}
+
+template <typename InputT, typename OutputT, typename IdxT>
+void invokeRenormMoeRouting(InputT* routerLogits, OutputT* topkValues, IdxT* topkIndices, int64_t const numTokens,
+    int64_t const numExperts, int64_t const topK, cudaStream_t const stream)
+{
+
+    const uint32_t maxNumBlocks = 1024;
+    const uint32_t numBlocks = std::min(static_cast<uint32_t>((numTokens - 1) / WARPS_PER_BLOCK + 1), maxNumBlocks);
+
+    constexpr uint32_t maxNumExperts = 128;
+    constexpr uint32_t maxNumTopExperts = 8;
+    auto* kernelInstance = &renormMoeRoutingKernel<InputT, OutputT, IdxT, maxNumExperts, maxNumTopExperts>;
+
+    if (topK <= 4)
+    {
+        kernelInstance = &renormMoeRoutingKernel<InputT, OutputT, IdxT, maxNumExperts, 4>;
+    }
+    else if (topK <= 2)
+    {
+        kernelInstance = &renormMoeRoutingKernel<InputT, OutputT, IdxT, maxNumExperts, 2>;
+    }
+    dim3 renormMoeRoutingGridDim(numBlocks);
+    dim3 renormMoeRoutingBlockDim(BLOCK_SIZE);
+    cudaLaunchConfig_t config;
+    config.gridDim = renormMoeRoutingGridDim;
+    config.blockDim = renormMoeRoutingBlockDim;
+    config.dynamicSmemBytes = 0;
+    config.stream = stream;
+    cudaLaunchAttribute attrs[1];
+    attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+    attrs[0].val.programmaticStreamSerializationAllowed = tensorrt_llm::common::getEnvEnablePDL();
+    config.numAttrs = 1;
+    config.attrs = attrs;
+    cudaLaunchKernelEx(&config, kernelInstance, routerLogits, topkValues, topkIndices, static_cast<int32_t>(numTokens),
+        static_cast<int32_t>(numExperts), static_cast<int32_t>(topK));
+    sync_check_cuda_error(stream);
+}
+
+#define INSTANTIATE_RENORM_MOE_ROUTING(InputT, OutputT, IdxT)                                                          \
+    template void invokeRenormMoeRouting<InputT, OutputT, IdxT>(InputT * routerLogits, OutputT * topkValues,           \
+        IdxT * topkIndices, int64_t const numTokens, int64_t const numExperts, int64_t const topK,                     \
+        cudaStream_t const stream);
+
+INSTANTIATE_RENORM_MOE_ROUTING(float, float, int32_t);
+#ifdef ENABLE_BF16
+INSTANTIATE_RENORM_MOE_ROUTING(cutlass::bfloat16_t, float, int32_t);
+#endif
+
+} // namespace tensorrt_llm::kernels

--- a/cpp/tensorrt_llm/kernels/renormMoeRoutingKernels.h
+++ b/cpp/tensorrt_llm/kernels/renormMoeRoutingKernels.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include "tensorrt_llm/common/cudaUtils.h"
+
+namespace tensorrt_llm::kernels
+{
+template <typename InputT, typename OutputT, typename IdxT>
+void invokeRenormMoeRouting(InputT* routerLogits, OutputT* topkValues, IdxT* topkIndices, int64_t const numTokens,
+    int64_t const numExperts, int64_t const topK, cudaStream_t const stream);
+} // namespace tensorrt_llm::kernels

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/runner.cu
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/runner.cu
@@ -150,7 +150,7 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
         moe::dev::routingLlama4::run(routingData, stream);
     }
     else if (routingMethodType == RoutingMethodType::Renormalize /* default */
-        || routingMethodType == RoutingMethodType::Qwen3 /* Softmax -> TopK */)
+        || routingMethodType == RoutingMethodType::RenormalizeNaive /* Softmax -> TopK */)
     {
         moe::dev::routingQwen3::Data routingData;
 
@@ -161,8 +161,9 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
         routingData.mDtypeExpW = btg::Dtype::Bfloat16;
         // routingData.mDtypeElt = dtypeElt; // no-op for now as hidden_state is not input
         routingData.mUsePdl = true;
-        routingData.mDoSoftmaxBeforeTopK = routingMethodType == RoutingMethodType::Qwen3;
-        routingData.mNormTopkProb = routingMethodType == RoutingMethodType::Qwen3;
+        routingData.mDoSoftmaxBeforeTopK = routingMethodType == RoutingMethodType::RenormalizeNaive;
+        routingData.mNormTopkProb = routingMethodType == RoutingMethodType::RenormalizeNaive;
+
         routingData.mPtrScores = routingLogits;
 
         //

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/runner.h
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/runner.h
@@ -46,8 +46,8 @@ enum class RoutingMethodType : int64_t
     DeepSeekV3 = 2,
     // Llama4: Top1 -> Sigmoid
     Llama4 = 3,
-    // Qwen3: Softmax -> TopK -> Renormalize
-    Qwen3 = 4,
+    // RenormalizeNaive: Softmax -> TopK -> Renormalize
+    RenormalizeNaive = 4,
     // Unspecified
     Unspecified = 5,
 };
@@ -60,7 +60,7 @@ inline std::string serializeMoeRoutingMethodType(RoutingMethodType routingMethod
     case RoutingMethodType::Renormalize: return "Renormalize";
     case RoutingMethodType::DeepSeekV3: return "DeepSeekV3";
     case RoutingMethodType::Llama4: return "Llama4";
-    case RoutingMethodType::Qwen3: return "Qwen3";
+    case RoutingMethodType::RenormalizeNaive: return "RenormalizeNaive";
     default: TLLM_CHECK_WITH_INFO(false, "Invalid routing method"); return "";
     };
 }

--- a/cpp/tensorrt_llm/thop/CMakeLists.txt
+++ b/cpp/tensorrt_llm/thop/CMakeLists.txt
@@ -75,6 +75,7 @@ add_library(
   redrafterCurandOp.cpp
   reducescatterOp.cpp
   relativeAttentionBiasOp.cpp
+  renormMoeRoutingOp.cpp
   selectiveScanOp.cpp
   userbuffersFinalizeOp.cpp
   userbuffersTensor.cpp

--- a/cpp/tensorrt_llm/thop/renormMoeRoutingOp.cpp
+++ b/cpp/tensorrt_llm/thop/renormMoeRoutingOp.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "cutlass/numeric_types.h"
+#include "tensorrt_llm/common/opUtils.h"
+#include "tensorrt_llm/kernels/renormMoeRoutingKernels.h"
+#include "tensorrt_llm/runtime/torchUtils.h"
+
+namespace th = torch;
+namespace tl = tensorrt_llm;
+namespace tk = tensorrt_llm::kernels;
+
+namespace torch_ext
+{
+
+std::tuple<at::Tensor, at::Tensor> renorm_moe_routing_op(th::Tensor const& router_logits, int64_t topk)
+{
+    auto data_type = router_logits.scalar_type();
+    auto input_size = router_logits.sizes();
+    int64_t num_tokens = input_size[0];
+    int64_t num_experts = input_size[1];
+    TORCH_CHECK(input_size.size() == 2, "router_logits must be a 2D Tensor");
+    TORCH_CHECK(topk <= 8, "topk should be smaller than or equal to 8 for now"); //@todo: remove this restriction later
+    TORCH_CHECK(num_experts <= 128, "expert number should be smaller than or equal to 128 for now");
+
+    th::Tensor topk_values = th::empty({num_tokens, topk}, th::dtype(torch::kFloat32).device(torch::kCUDA));
+    th::Tensor topk_indices = th::empty({num_tokens, topk}, th::dtype(torch::kInt32).device(torch::kCUDA));
+
+    auto stream = at::cuda::getCurrentCUDAStream(router_logits.get_device());
+
+    switch (data_type)
+    {
+    case torch::kFloat32:
+        // Handle Float32
+        tk::invokeRenormMoeRouting<float, float, int32_t>(reinterpret_cast<float*>(router_logits.mutable_data_ptr()),
+            reinterpret_cast<float*>(topk_values.mutable_data_ptr()),
+            reinterpret_cast<int32_t*>(topk_indices.mutable_data_ptr()), num_tokens, num_experts, topk, stream);
+        break;
+    case torch::kBFloat16:
+        // Handle BFloat16
+        tk::invokeRenormMoeRouting<cutlass::bfloat16_t, float, int32_t>(
+            reinterpret_cast<cutlass::bfloat16_t*>(router_logits.mutable_data_ptr()),
+            reinterpret_cast<float*>(topk_values.mutable_data_ptr()),
+            reinterpret_cast<int32_t*>(topk_indices.mutable_data_ptr()), num_tokens, num_experts, topk, stream);
+        break;
+    default:
+        // Handle other data types
+        throw std::invalid_argument("Invalid dtype, only supports float32 and bfloat16");
+        break;
+    }
+    return {topk_indices, topk_values};
+}
+
+} // namespace torch_ext
+
+TORCH_LIBRARY_FRAGMENT(trtllm, m)
+{
+    m.def(
+        "renorm_moe_routing_op(Tensor router_logits, int topk"
+        ") -> (Tensor, Tensor)");
+}
+
+TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
+{
+    m.impl("renorm_moe_routing_op", &torch_ext::renorm_moe_routing_op);
+}

--- a/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
@@ -15,9 +15,9 @@ from ..model_config import ModelConfig
 from ..modules.decoder_layer import DecoderLayer
 from ..modules.embedding import Embedding
 from ..modules.fused_moe import (BaseMoeRoutingMethod, CutlassFusedMoE, MoE,
-                                 Qwen3MoeRoutingMethod,
-                                 RenormalizeMoeRoutingMethod, RoutingMethodType,
-                                 create_moe)
+                                 RenormalizeMoeRoutingMethod,
+                                 RenormalizeNaiveMoeRoutingMethod,
+                                 RoutingMethodType, create_moe)
 from ..modules.linear import TensorParallelMode
 from ..modules.rms_norm import RMSNorm
 from ..utils import disable_fp4_allgather
@@ -63,8 +63,8 @@ class Qwen3Gate(nn.Module):
 
     @property
     def routing_method(self) -> BaseMoeRoutingMethod:
-        if self.routing_method_type == RoutingMethodType.Qwen3:
-            return Qwen3MoeRoutingMethod(top_k=self.top_k)
+        if self.routing_method_type == RoutingMethodType.RenormalizeNaive:
+            return RenormalizeNaiveMoeRoutingMethod(top_k=self.top_k)
         elif self.routing_method_type == RoutingMethodType.Renormalize:
             return RenormalizeMoeRoutingMethod(top_k=self.top_k)
         else:

--- a/tensorrt_llm/_torch/modules/fused_moe/__init__.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/__init__.py
@@ -7,16 +7,17 @@ from .moe_load_balancer import MoeLoadBalancer
 from .routing import (BaseMoeRoutingMethod, DeepSeekV3MoeRoutingMethod,
                       DefaultMoeRoutingMethod,
                       Llama4RenormalizeMoeRoutingMethod,
-                      LoadBalancedMoeRoutingMethod, Qwen3MoeRoutingMethod,
-                      RenormalizeMoeRoutingMethod, RoutingMethodType,
+                      LoadBalancedMoeRoutingMethod, RenormalizeMoeRoutingMethod,
+                      RenormalizeNaiveMoeRoutingMethod, RoutingMethodType,
                       SparseMixerMoeRoutingMethod, StaticMoeRoutingMethod)
 
 __all__ = [
     "VanillaMoE", "CutlassFusedMoE", "TRTLLMGenFusedMoE",
-    "BaseMoeRoutingMethod", "MoeLoadBalancer", "Qwen3MoeRoutingMethod",
-    "Llama4RenormalizeMoeRoutingMethod", "SparseMixerMoeRoutingMethod",
-    "LoadBalancedMoeRoutingMethod", "StaticMoeRoutingMethod",
-    "DefaultMoeRoutingMethod", "DeepSeekV3MoeRoutingMethod",
-    "RoutingMethodType", "RenormalizeMoeRoutingMethod", "MoE",
-    "MoEWeightLoadingMode", "get_moe_cls", "create_moe"
+    "BaseMoeRoutingMethod", "MoeLoadBalancer",
+    "RenormalizeNaiveMoeRoutingMethod", "Llama4RenormalizeMoeRoutingMethod",
+    "SparseMixerMoeRoutingMethod", "LoadBalancedMoeRoutingMethod",
+    "StaticMoeRoutingMethod", "DefaultMoeRoutingMethod",
+    "DeepSeekV3MoeRoutingMethod", "RoutingMethodType",
+    "RenormalizeMoeRoutingMethod", "MoE", "MoEWeightLoadingMode", "get_moe_cls",
+    "create_moe"
 ]

--- a/tensorrt_llm/_torch/modules/fused_moe/routing.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/routing.py
@@ -18,7 +18,7 @@ class RoutingMethodType(IntEnum):
     # Llama4: Top1 -> Sigmoid
     Llama4 = 3,
     # Qwen3: Softmax -> TopK -> Renormalize
-    Qwen3 = 4,
+    RenormalizeNaive = 4,
     # Unspecified
     Unspecified = 5.
 
@@ -86,17 +86,28 @@ class RenormalizeMoeRoutingMethod(BaseMoeRoutingMethod):
     def __init__(
         self,
         top_k: int,
+        force_enable_pytorch_op: bool = False,
     ):
         super().__init__()
         self.top_k = top_k
+        self.force_enable_pytorch_op = force_enable_pytorch_op
 
-    def apply(self,
-              router_logits: torch.Tensor) -> (torch.Tensor, torch.Tensor):
+    def apply_pytorch(
+            self, router_logits: torch.Tensor) -> (torch.Tensor, torch.Tensor):
         topk_values, topk_indices = torch.topk(router_logits,
                                                k=self.top_k,
                                                dim=-1)
         return topk_indices.to(torch.int32), torch.nn.functional.softmax(
             topk_values.float(), dim=-1)
+
+    def apply(self,
+              router_logits: torch.Tensor) -> (torch.Tensor, torch.Tensor):
+        num_experts = router_logits.shape[-1]
+        if self.force_enable_pytorch_op or num_experts > 128 or self.top_k > 8:
+            return self.apply_pytorch(router_logits)
+        else:
+            return torch.ops.trtllm.renorm_moe_routing_op(
+                router_logits, self.top_k)
 
     @property
     def routing_method_type(self):
@@ -241,7 +252,7 @@ class LoadBalancedMoeRoutingMethod(BaseMoeRoutingMethod):
         return balanced_indices, balanced_values
 
 
-class Qwen3MoeRoutingMethod(BaseMoeRoutingMethod):
+class RenormalizeNaiveMoeRoutingMethod(RenormalizeMoeRoutingMethod):
 
     def __init__(self, top_k: int):
         super().__init__()
@@ -249,16 +260,10 @@ class Qwen3MoeRoutingMethod(BaseMoeRoutingMethod):
 
     def apply(self,
               router_logits: torch.Tensor) -> (torch.Tensor, torch.Tensor):
-
-        routing_weights = torch.nn.functional.softmax(router_logits,
-                                                      dim=1,
-                                                      dtype=torch.float)
-        topk_values, topk_indices = torch.topk(routing_weights,
-                                               k=self.top_k,
-                                               dim=-1)
-        topk_values /= topk_values.sum(dim=-1, keepdim=True)
+        #x = topk(softmax()); x /= x.sum() is mathematically equivalent to softmax(topk)
+        topk_indices, topk_values = self.apply_pytorch(router_logits)
         return topk_indices.to(torch.int32), topk_values
 
     @property
     def routing_method_type(self) -> RoutingMethodType:
-        return RoutingMethodType.Qwen3
+        return RoutingMethodType.RenormalizeNaive

--- a/tests/unittest/_torch/modules/test_moe_routing.py
+++ b/tests/unittest/_torch/modules/test_moe_routing.py
@@ -66,6 +66,38 @@ def test_renormalize_moe_routing(top_k):
     assert torch.allclose(scales, reference_scales)
 
 
+def gen_unique_logits(num_tokens, num_experts, dtype):
+    unique_logits = torch.rand((num_tokens, num_experts), dtype=dtype)
+
+    for i in range(unique_logits.size(0)):
+        torch.manual_seed(42 * i)
+        unique_row = torch.randperm(num_experts)
+        unique_logits[i] = unique_row.to(dtype)
+
+    return unique_logits.cuda()
+
+
+@pytest.mark.parametrize("num_tokens", [1, 30, 2000])
+@pytest.mark.parametrize("top_k", [1, 4, 8])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+def test_customized_renormalize_moe_routing(num_tokens, top_k, dtype):
+    num_experts = 128
+
+    #Because the order of equal elements is unpredictable, we use unique data to prevent any ambiguity.
+    router_logits = gen_unique_logits(num_tokens, num_experts, dtype)
+
+    routing = RenormalizeMoeRoutingMethod(top_k=top_k,
+                                          force_enable_pytorch_op=False)
+    indices, scales = routing.apply(router_logits)
+
+    ref_routing = RenormalizeMoeRoutingMethod(top_k=top_k,
+                                              force_enable_pytorch_op=True)
+    reference_indices, reference_scales = ref_routing.apply(router_logits)
+
+    assert torch.equal(indices, reference_indices)
+    assert torch.allclose(scales, reference_scales)
+
+
 def test_sparse_mixer_reference():
     routing = SparseMixerMoeRoutingMethod(top_k=2, eps=0.2)
     assert routing.experts_per_token == 2

--- a/tests/unittest/_torch/modules/test_moe_routing.py
+++ b/tests/unittest/_torch/modules/test_moe_routing.py
@@ -78,10 +78,12 @@ def gen_unique_logits(num_tokens, num_experts, dtype):
 
 
 @pytest.mark.parametrize("num_tokens", [1, 30, 2000])
-@pytest.mark.parametrize("top_k", [1, 4, 8])
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
-def test_customized_renormalize_moe_routing(num_tokens, top_k, dtype):
-    num_experts = 128
+@pytest.mark.parametrize("top_k", [2, 8])
+@pytest.mark.parametrize("dtype",
+                         [torch.bfloat16, torch.float32, torch.float16])
+@pytest.mark.parametrize("num_experts", [8, 67, 128])
+def test_customized_renormalize_moe_routing(num_tokens, top_k, num_experts,
+                                            dtype):
 
     #Because the order of equal elements is unpredictable, we use unique data to prevent any ambiguity.
     router_logits = gen_unique_logits(num_tokens, num_experts, dtype)


### PR DESCRIPTION
# Add customized renormalized moe routing kernel for moe cutlass backend
## Description
- Add pytorch op `torch.ops.trtllm.renorm_moe_routing_op` and use it when `num_experts<=128 and num_experts_per_token <= 8`.   
  Related files: cpp/tensorrt_llm/thop/renormMoeRoutingOp.cpp 
                          tensorrt_llm/_torch/modules/fused_moe/routing.py
(Hi @hlu1, since this modification is related to the MOE part. Please help review it. ）

- Add the customized kernel `renormMoeRoutingKernel`
 Related files: cpp/tensorrt_llm/kernels/renormMoeRoutingKernels.cu 
                        cpp/tensorrt_llm/kernels/renormMoeRoutingKernels.cu
- Add unit test test_customized_renormalize_moe_routing()
 Related file:  tests/unittest/_torch/modules/test_moe_routing.py
 
- Besides adding this feature, I also did a small modification for `RoutingMethodType`. By replacing the variable name `RoutingMethodType.Qwen3` with `RoutingMethodType.RenormalizeNaive.`, we hope to facilitate broader usage in the future. 
(Hi @djns99 and @rosenrodt , please help review this part.)

## Test Coverage
```
pytest -k test_customized_renormalize_moe_routing tests/unittest/_torch/modules/test_moe_routing.py
```
