### PR TITLE
fix: build_config in TorchLlmArgs and avoid arbitrary args 

### DIFF
--- a/examples/auto_deploy/README.md
+++ b/examples/auto_deploy/README.md
@@ -235,7 +235,7 @@ Here is an example of how you can build an LLM object with AutoDeploy integratio
 <summary>Click to expand the example</summary>
 
 ```
-from tensorrt_llm import LLM
+from tensorrt_llm import LLM, TorchCompileConfig
 
 
 # Construct the LLM high-level interface object with autodeploy as backend
@@ -244,7 +244,7 @@ llm = LLM(
     backend="_autodeploy",
     tensor_parallel_size=<NUM_WORLD_RANK>,
     use_cuda_graph=True, # set True if using "torch-opt" as compile backend
-    torch_compile_enabled=True, # set True if using "torch-opt" as compile backend
+    torch_compile_config=TorchCompileConfig(), # set this if using "torch-opt" as compile backend
     model_kwargs={"use_cache": False}, # AutoDeploy uses its own cache implementation
     attn_backend="TritonWithFlattenedInputs", # choose between "TritonWithFlattenedInputs" and "FlashInfer"
     attn_page_size=64, # page size for attention (tokens_per_block, should be == max_seq_len for triton)

--- a/examples/auto_deploy/build_and_run_ad.py
+++ b/examples/auto_deploy/build_and_run_ad.py
@@ -12,6 +12,7 @@ from tensorrt_llm._torch.auto_deploy.shim import DemoLLM
 from tensorrt_llm._torch.auto_deploy.utils.benchmark import benchmark, store_benchmark_results
 from tensorrt_llm._torch.auto_deploy.utils.logger import ad_logger
 from tensorrt_llm.llmapi.llm import LLM, RequestOutput
+from tensorrt_llm.llmapi.llm_args import TorchCompileConfig
 from tensorrt_llm.sampling_params import SamplingParams
 
 # Global torch config, set the torch compile cache to fix up to llama 405B
@@ -56,7 +57,9 @@ def build_llm_from_config(config: SimpleConfig) -> LLM:
         max_batch_size=config.max_batch_size,
         # AutoDeploy-specific parameters
         use_cuda_graph=config.compile_backend in ["torch-opt", "torch-cudagraph"],
-        torch_compile_enabled=config.compile_backend in ["torch-opt", "torch-compile"],
+        torch_compile_config=TorchCompileConfig()
+        if config.compile_backend in ["torch-opt", "torch-compile"]
+        else None,
         model_factory=config.model_factory,
         model_kwargs=config.model_kwargs,
         attn_backend=config.attn_backend,

--- a/examples/pytorch/quickstart_advanced.py
+++ b/examples/pytorch/quickstart_advanced.py
@@ -3,7 +3,8 @@ import argparse
 from tensorrt_llm import SamplingParams
 from tensorrt_llm._torch import LLM
 from tensorrt_llm.llmapi import (EagleDecodingConfig, KvCacheConfig,
-                                 MTPDecodingConfig, NGramDecodingConfig)
+                                 MTPDecodingConfig, NGramDecodingConfig,
+                                 TorchCompileConfig)
 
 example_prompts = [
     "Hello, my name is",
@@ -178,35 +179,39 @@ def setup_llm(args):
     else:
         spec_config = None
 
-    llm = LLM(model=args.model_dir,
-              backend='pytorch',
-              disable_overlap_scheduler=args.disable_overlap_scheduler,
-              kv_cache_dtype=args.kv_cache_dtype,
-              kv_cache_config=kv_cache_config,
-              attn_backend=args.attention_backend,
-              use_cuda_graph=args.use_cuda_graph,
-              cuda_graph_padding_enabled=args.cuda_graph_padding_enabled,
-              cuda_graph_batch_sizes=args.cuda_graph_batch_sizes,
-              load_format=args.load_format,
-              print_iter_log=args.print_iter_log,
-              enable_iter_perf_stats=args.print_iter_log,
-              torch_compile_enabled=args.use_torch_compile,
-              torch_compile_piecewise_cuda_graph=args.use_piecewise_cuda_graph,
-              moe_backend=args.moe_backend,
-              enable_trtllm_sampler=args.enable_trtllm_sampler,
-              max_seq_len=args.max_seq_len,
-              max_batch_size=args.max_batch_size,
-              max_num_tokens=args.max_num_tokens,
-              enable_attention_dp=args.enable_attention_dp,
-              tensor_parallel_size=args.tp_size,
-              pipeline_parallel_size=args.pp_size,
-              moe_expert_parallel_size=args.moe_ep_size,
-              moe_tensor_parallel_size=args.moe_tp_size,
-              moe_cluster_parallel_size=args.moe_cluster_size,
-              enable_chunked_prefill=args.enable_chunked_prefill,
-              speculative_config=spec_config,
-              trust_remote_code=args.trust_remote_code,
-              gather_generation_logits=args.return_generation_logits)
+    llm = LLM(
+        model=args.model_dir,
+        backend='pytorch',
+        disable_overlap_scheduler=args.disable_overlap_scheduler,
+        kv_cache_dtype=args.kv_cache_dtype,
+        kv_cache_config=kv_cache_config,
+        attn_backend=args.attention_backend,
+        use_cuda_graph=args.use_cuda_graph,
+        cuda_graph_padding_enabled=args.cuda_graph_padding_enabled,
+        cuda_graph_batch_sizes=args.cuda_graph_batch_sizes,
+        load_format=args.load_format,
+        print_iter_log=args.print_iter_log,
+        enable_iter_perf_stats=args.print_iter_log,
+        torch_compile_config=TorchCompileConfig(
+            torch_compile_fullgraph=args.use_torch_compile,
+            torch_compile_inductor_enabled=args.use_torch_compile,
+            torch_compile_piecewise_cuda_graph=args.use_piecewise_cuda_graph)
+        if args.use_torch_compile else None,
+        moe_backend=args.moe_backend,
+        enable_trtllm_sampler=args.enable_trtllm_sampler,
+        max_seq_len=args.max_seq_len,
+        max_batch_size=args.max_batch_size,
+        max_num_tokens=args.max_num_tokens,
+        enable_attention_dp=args.enable_attention_dp,
+        tensor_parallel_size=args.tp_size,
+        pipeline_parallel_size=args.pp_size,
+        moe_expert_parallel_size=args.moe_ep_size,
+        moe_tensor_parallel_size=args.moe_tp_size,
+        moe_cluster_parallel_size=args.moe_cluster_size,
+        enable_chunked_prefill=args.enable_chunked_prefill,
+        speculative_config=spec_config,
+        trust_remote_code=args.trust_remote_code,
+        gather_generation_logits=args.return_generation_logits)
 
     sampling_params = SamplingParams(
         max_tokens=args.max_tokens,

--- a/examples/pytorch/quickstart_advanced.py
+++ b/examples/pytorch/quickstart_advanced.py
@@ -206,7 +206,6 @@ def setup_llm(args):
               enable_chunked_prefill=args.enable_chunked_prefill,
               speculative_config=spec_config,
               trust_remote_code=args.trust_remote_code,
-              gather_context_logits=args.return_context_logits,
               gather_generation_logits=args.return_generation_logits)
 
     sampling_params = SamplingParams(

--- a/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
@@ -49,11 +49,11 @@ class InferenceOptimizer:
 
         self.ad_config = ad_config
         # Map Pytorch config to AutoDeploy compile backends.
-        if ad_config.use_cuda_graph and ad_config.torch_compile_enabled:
+        if ad_config.use_cuda_graph and ad_config.torch_compile_config:
             compile_backend = "torch-opt"
         elif ad_config.use_cuda_graph:
             compile_backend = "torch-cudagraph"
-        elif ad_config.torch_compile_enabled:
+        elif ad_config.torch_compile_config:
             compile_backend = "torch-compile"
         else:
             compile_backend = "torch-simple"

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -398,7 +398,7 @@ def create_py_executor_instance(
                 "Guided decoding is not supported with overlap scheduler.")
 
     logger.info(
-        f"max_seq_len={executor_config.max_seq_len}, max_num_requests={executor_config.max_batch_size}, max_num_tokens={executor_config.max_num_tokens}"
+        f"max_seq_len={executor_config.max_seq_len}, max_num_requests={executor_config.max_batch_size}, max_num_tokens={executor_config.max_num_tokens}, max_batch_size={executor_config.max_batch_size}"
     )
 
     for key, value in pytorch_backend_config.extra_resource_managers.items():

--- a/tensorrt_llm/bench/benchmark/throughput.py
+++ b/tensorrt_llm/bench/benchmark/throughput.py
@@ -360,6 +360,10 @@ def throughput_command(
             kwargs["enable_iter_perf_stats"] = True
 
         if runtime_config.backend == 'pytorch':
+            if kwargs.pop("extended_runtime_perf_knob_config", None):
+                logger.warning(
+                    "Ignore extended_runtime_perf_knob_config for pytorch backend."
+                )
             llm = PyTorchLLM(**kwargs)
         else:
             llm = LLM(**kwargs)

--- a/tensorrt_llm/bench/dataclasses/configuration.py
+++ b/tensorrt_llm/bench/dataclasses/configuration.py
@@ -14,7 +14,7 @@ from tensorrt_llm.llmapi import (BatchingType, CapacitySchedulerPolicy,
                                  ContextChunkingPolicy, DynamicBatchConfig,
                                  ExtendedRuntimePerfKnobConfig, KvCacheConfig,
                                  SchedulerConfig)
-from tensorrt_llm.llmapi.llm_args import _AutoDeployLlmArgs
+from tensorrt_llm.llmapi.llm_args import TorchCompileConfig, _AutoDeployLlmArgs
 from tensorrt_llm.llmapi.llm_utils import update_llm_args_with_extra_options
 from tensorrt_llm.models.modeling_utils import SpeculativeDecodingMode
 
@@ -113,7 +113,7 @@ class PerformanceOptions:
     def get_autodeploy_perf_config(self) -> _AutoDeployLlmArgs:
         ad_config = _AutoDeployLlmArgs(**self.pytorch_config)
         ad_config.attn_backend = "FlashInfer"
-        ad_config.torch_compile_enabled = True
+        ad_config.torch_compile_config = TorchCompileConfig()
         ad_config.skip_loading_weights = True
         return ad_config
 

--- a/tensorrt_llm/builder.py
+++ b/tensorrt_llm/builder.py
@@ -49,6 +49,9 @@ class ConfigEncoder(json.JSONEncoder):
         if isinstance(obj, KVCacheType):
             # For KVCacheType, convert it to string by split of 'KVCacheType.PAGED'.
             return obj.__str__().split('.')[-1]
+        elif hasattr(obj, 'model_dump'):
+            # Handle Pydantic models (including DecodingBaseConfig and subclasses)
+            return obj.model_dump(mode='json')
         else:
             return super().default(obj)
 

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -419,6 +419,8 @@ def disaggregated_mpi_worker(config_file: Optional[str], log_level: str):
         llm_args = update_llm_args_with_extra_dict(llm_args,
                                                    llm_args_extra_dict)
 
+        # Ignore the non-LLM args
+        llm_args.pop("router", None)
         _launch_disaggregated_server(config_file, llm_args)
         return
 

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -121,9 +121,9 @@ def get_llm_args(model: str,
         "max_seq_len": max_seq_len,
         "kv_cache_config": kv_cache_config,
         "backend": backend if backend == "pytorch" else None,
-        "_num_postprocess_workers": num_postprocess_workers,
-        "_postprocess_tokenizer_dir": tokenizer or model,
-        "_reasoning_parser": reasoning_parser,
+        "num_postprocess_workers": num_postprocess_workers,
+        "postprocess_tokenizer_dir": tokenizer or model,
+        "reasoning_parser": reasoning_parser,
     }
 
     return llm_args, llm_args_extra_dict

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -126,8 +126,11 @@ class LLM:
                 llm_args_cls = TrtLlmArgs
 
             # check the kwargs and raise ValueError directly
+            valid_keys = set(
+                list(llm_args_cls.model_fields.keys()) +
+                ['_mpi_session', 'backend'])
             for key in kwargs:
-                if key not in llm_args_cls.model_fields:
+                if key not in valid_keys:
                     raise ValueError(
                         f"{self.__class__.__name__} got invalid argument: {key}"
                     )

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -125,6 +125,11 @@ class LLM:
             else:
                 llm_args_cls = TrtLlmArgs
 
+            # check the kwargs and raise ValueError directly
+            for key in kwargs:
+                if key not in llm_args_cls.model_fields:
+                    raise ValueError(f"Invalid argument: {key}")
+
             self.args = llm_args_cls.from_kwargs(
                 model=model,
                 tokenizer=tokenizer,
@@ -604,7 +609,7 @@ class LLM:
         max_num_tokens = max_num_tokens or build_config.max_num_tokens
         max_seq_len = max_seq_len or build_config.max_seq_len
 
-        executor_config = tllm.ExecutorConfig(
+        self._executor_config = tllm.ExecutorConfig(
             max_beam_width=self.args.max_beam_width,
             scheduler_config=PybindMirror.maybe_to_pybind(
                 self.args.scheduler_config),
@@ -616,20 +621,20 @@ class LLM:
         if self.args.backend is None:
             # also set executor_config.max_seq_len in TRT workflow, to deduce default max_tokens
             if max_seq_len is not None:
-                executor_config.max_seq_len = max_seq_len
+                self._executor_config.max_seq_len = max_seq_len
             else:
                 engine_config = EngineConfig.from_json_file(self._engine_dir /
                                                             "config.json")
-                executor_config.max_seq_len = engine_config.build_config.max_seq_len
+                self._executor_config.max_seq_len = engine_config.build_config.max_seq_len
         if self.args.kv_cache_config is not None:
-            executor_config.kv_cache_config = PybindMirror.maybe_to_pybind(
+            self._executor_config.kv_cache_config = PybindMirror.maybe_to_pybind(
                 self.args.kv_cache_config)
         if os.getenv("FORCE_DETERMINISTIC", "0") == "1":
             # Disable KV cache reuse for deterministic mode
-            executor_config.kv_cache_config.enable_block_reuse = False
-            executor_config.kv_cache_config.enable_partial_reuse = False
+            self._executor_config.kv_cache_config.enable_block_reuse = False
+            self._executor_config.kv_cache_config.enable_partial_reuse = False
         if self.args.peft_cache_config is not None:
-            executor_config.peft_cache_config = PybindMirror.maybe_to_pybind(
+            self._executor_config.peft_cache_config = PybindMirror.maybe_to_pybind(
                 self.args.peft_cache_config)
         elif self._on_trt_backend and self.args.build_config.plugin_config.lora_plugin:
             engine_config = EngineConfig.from_json_file(self._engine_dir /
@@ -638,16 +643,16 @@ class LLM:
             max_lora_rank = lora_config.max_lora_rank
             num_lora_modules = engine_config.pretrained_config.num_hidden_layers * \
                 len(lora_config.lora_target_modules + lora_config.missing_qkv_modules)
-            executor_config.peft_cache_config = tllm.PeftCacheConfig(
+            self._executor_config.peft_cache_config = tllm.PeftCacheConfig(
                 num_device_module_layer=max_lora_rank * num_lora_modules *
                 self.args.max_loras,
                 num_host_module_layer=max_lora_rank * num_lora_modules *
                 self.args.max_cpu_loras,
             )
         if self.args.decoding_config is not None:
-            executor_config.decoding_config = self.args.decoding_config
+            self._executor_config.decoding_config = self.args.decoding_config
         if self.args.guided_decoding_backend == 'xgrammar':
-            executor_config.guided_decoding_config = tllm.GuidedDecodingConfig(
+            self._executor_config.guided_decoding_config = tllm.GuidedDecodingConfig(
                 backend=tllm.GuidedDecodingConfig.GuidedDecodingBackend.
                 XGRAMMAR,
                 **_xgrammar_tokenizer_info(self.tokenizer))
@@ -656,18 +661,18 @@ class LLM:
                 f"Unrecognized guided decoding backend {self.args.guided_decoding_backend}"
             )
 
-        executor_config.normalize_log_probs = self.args.normalize_log_probs
-        executor_config.enable_chunked_context = self.args.enable_chunked_prefill
-        executor_config.max_beam_width = self.args.max_beam_width or self.args.build_config.max_beam_width
+        self._executor_config.normalize_log_probs = self.args.normalize_log_probs
+        self._executor_config.enable_chunked_context = self.args.enable_chunked_prefill
+        self._executor_config.max_beam_width = self.args.max_beam_width or self.args.build_config.max_beam_width
         if self._on_trt_backend and self.args.extended_runtime_perf_knob_config is not None:
-            executor_config.extended_runtime_perf_knob_config = PybindMirror.maybe_to_pybind(
+            self._executor_config.extended_runtime_perf_knob_config = PybindMirror.maybe_to_pybind(
                 self.args.extended_runtime_perf_knob_config)
         if self.args.cache_transceiver_config is not None:
-            executor_config.cache_transceiver_config = PybindMirror.maybe_to_pybind(
+            self._executor_config.cache_transceiver_config = PybindMirror.maybe_to_pybind(
                 self.args.cache_transceiver_config)
         from tensorrt_llm._torch.pyexecutor.config import update_executor_config
         update_executor_config(
-            executor_config,
+            self._executor_config,
             backend=self.args.backend,
             pytorch_backend_config=self.args.get_pytorch_backend_config()
             if self.args.backend in ["pytorch", "_autodeploy"] else None,
@@ -679,14 +684,14 @@ class LLM:
             trt_engine_dir=self._engine_dir,
             max_input_len=self.args.max_input_len,
             max_seq_len=max_seq_len)
-        executor_config.llm_parallel_config = self.args.parallel_config
+        self._executor_config.llm_parallel_config = self.args.parallel_config
         return_logits = self.args.gather_generation_logits or (
             self._on_trt_backend and self.args.build_config
             and self.args.build_config.gather_context_logits)
 
         self._executor = self._executor_cls.create(
             self._engine_dir,
-            executor_config=executor_config,
+            executor_config=self._executor_config,
             batched_logits_processor=self.args.batched_logits_processor,
             model_world_size=self.args.parallel_config.world_size,
             mpi_session=self.mpi_session,

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -690,9 +690,9 @@ class LLM:
             max_input_len=self.args.max_input_len,
             max_seq_len=max_seq_len)
         self._executor_config.llm_parallel_config = self.args.parallel_config
-        return_logits = self.args.gather_generation_logits or (
-            self._on_trt_backend and self.args.build_config
-            and self.args.build_config.gather_context_logits)
+        return_logits = (self.args.gather_generation_logits
+                         or (self.args.build_config
+                             and self.args.build_config.gather_context_logits))
 
         self._executor = self._executor_cls.create(
             self._engine_dir,

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -128,7 +128,9 @@ class LLM:
             # check the kwargs and raise ValueError directly
             for key in kwargs:
                 if key not in llm_args_cls.model_fields:
-                    raise ValueError(f"Invalid argument: {key}")
+                    raise ValueError(
+                        f"{self.__class__.__name__} got invalid argument: {key}"
+                    )
 
             self.args = llm_args_cls.from_kwargs(
                 model=model,

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -938,6 +938,11 @@ class BaseLlmArgs(BaseModel):
         default=None,
         description="The parser to separate reasoning content from output.")
 
+    auto_deploy_config: Optional[object] = Field(
+        default=None,
+        description="Auto deploy config.",
+        json_schema_extra={"type": f"Optional[AutoDeployConfig]"})
+
     # TODO[Superjomn]: To deprecate this config.
     decoding_config: Optional[object] = Field(
         default=None,
@@ -1645,12 +1650,6 @@ class TorchLlmArgs(BaseLlmArgs):
 
     enable_layerwise_nvtx_marker: bool = Field(
         default=False, description="If true, enable layerwise nvtx marker.")
-
-    auto_deploy_config: Optional[object] = Field(
-        default=None,
-        description="Auto deploy config.",
-        exclude_from_json=True,
-        json_schema_extra={"type": f"Optional[AutoDeployConfig]"})
 
     load_format: Union[str, LoadFormat] = Field(
         default=LoadFormat.AUTO,

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1417,8 +1417,10 @@ class TrtLlmArgs(BaseLlmArgs):
 
     # BuildConfig is introduced to give users a familiar interface to configure the model building.
     build_config: Optional[object] = Field(
-        default=None,
+        default_factory=lambda: BuildConfig(),
         description="Build config.",
+        exclude_from_json=True,
+        frozen=True,
         json_schema_extra={"type": f"Optional[{get_type_repr(BuildConfig)}]"})
 
     workspace: Optional[str] = Field(default=None,
@@ -1517,6 +1519,7 @@ class TorchLlmArgs(BaseLlmArgs):
         default_factory=lambda: BuildConfig(),
         description="Build config.",
         exclude_from_json=True,
+        frozen=True,
         json_schema_extra={"type": f"Optional[{get_type_repr(BuildConfig)}]"})
 
     # PyTorch backend specific configurations

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -938,11 +938,6 @@ class BaseLlmArgs(BaseModel):
         default=None,
         description="The parser to separate reasoning content from output.")
 
-    auto_deploy_config: Optional[object] = Field(
-        default=None,
-        description="Auto deploy config.",
-        json_schema_extra={"type": f"Optional[AutoDeployConfig]"})
-
     # TODO[Superjomn]: To deprecate this config.
     decoding_config: Optional[object] = Field(
         default=None,
@@ -1036,7 +1031,7 @@ class BaseLlmArgs(BaseModel):
         model_obj = _ModelWrapper(self.model)
 
         if model_obj.is_local_model and self.backend not in [
-                'pytorch', 'autodeploy'
+                'pytorch', '_autodeploy'
         ]:
             # Load parallel_config from the engine.
             model_format = get_model_format(self.model)
@@ -1662,6 +1657,11 @@ class TorchLlmArgs(BaseLlmArgs):
         description=
         "If true, enable min-latency mode. Currently only used for Llama4.",
     )
+
+    auto_deploy_config: Optional[object] = Field(
+        default=None,
+        description="Auto deploy config.",
+        json_schema_extra={"type": f"Optional[object]"})
 
     @field_validator('load_format', mode='before')
     @classmethod

--- a/tests/integration/defs/disaggregated/test_disaggregated_single_gpu.py
+++ b/tests/integration/defs/disaggregated/test_disaggregated_single_gpu.py
@@ -50,7 +50,6 @@ async def run_worker(kv_cache_config, pytorch_config, model_name, rank):
 
     try:
         llm = LLM(tensor_parallel_size=1,
-                  auto_parallel=False,
                   model=model_name,
                   enable_chunked_prefill=False,
                   **pytorch_config,

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/shim/test_llm_config.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/shim/test_llm_config.py
@@ -5,7 +5,7 @@ import pytest
 from tensorrt_llm._torch.auto_deploy.shim.demollm import DemoLLM
 from tensorrt_llm._torch.auto_deploy.transformations.transform import InferenceOptimizer
 from tensorrt_llm.llmapi.llm import LLM
-from tensorrt_llm.llmapi.llm_args import _AutoDeployLlmArgs
+from tensorrt_llm.llmapi.llm_args import TorchCompileConfig, _AutoDeployLlmArgs
 
 # ================================
 # _AutoDeployLlmArgs Direct Tests
@@ -155,23 +155,23 @@ def test_config_flow(
 
 
 @pytest.mark.parametrize(
-    "use_cuda_graph,torch_compile_enabled,expected_backend",
+    "use_cuda_graph,torch_compile_config,expected_backend",
     [
-        (True, True, "torch-opt"),
-        (True, False, "torch-cudagraph"),
-        (False, True, "torch-compile"),
-        (False, False, "torch-simple"),
+        (True, TorchCompileConfig(), "torch-opt"),
+        (True, None, "torch-cudagraph"),
+        (False, TorchCompileConfig(), "torch-compile"),
+        (False, None, "torch-simple"),
     ],
 )
 @patch("tensorrt_llm._torch.auto_deploy.models.factory.ModelFactoryRegistry.get")
 def test_compile_backend_mapping(
-    mock_factory_registry, use_cuda_graph, torch_compile_enabled, expected_backend
+    mock_factory_registry, use_cuda_graph, torch_compile_config, expected_backend
 ):
     """Test that compile backend is correctly determined from config."""
     ad_config = _AutoDeployLlmArgs(
         model="test-model",
         use_cuda_graph=use_cuda_graph,
-        torch_compile_enabled=torch_compile_enabled,
+        torch_compile_config=torch_compile_config,
     )
     optimizer = InferenceOptimizer(factory=MagicMock(), ad_config=ad_config)
     assert optimizer.compile_backend == expected_backend

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
@@ -65,11 +65,11 @@ def _check_ad_config(simple_config: SimpleConfig, ad_config: _AutoDeployLlmArgs)
         f"got {ad_config.use_cuda_graph}"
     )
 
-    # compile_backend -> torch_compile_enabled
+    # compile_backend -> torch_compile_config
     expected_torch_compile = simple_config.compile_backend in ["torch-opt", "torch-compile"]
-    assert ad_config.torch_compile_enabled == expected_torch_compile, (
-        f"Expected torch_compile_enabled {expected_torch_compile} for "
-        f"{simple_config.compile_backend}, got {ad_config.torch_compile_enabled}"
+    assert bool(ad_config.torch_compile_config) == expected_torch_compile, (
+        f"Expected torch_compile_config to be {expected_torch_compile} for "
+        f"{simple_config.compile_backend}, got {ad_config.torch_compile_config}"
     )
 
     # backend should always be "_autodeploy"

--- a/tests/unittest/_torch/test_return_logits.py
+++ b/tests/unittest/_torch/test_return_logits.py
@@ -76,7 +76,6 @@ def test_generate_with_return_logits(disable_overlap_scheduler: bool,
         model=os.path.join(llm_models_root(), "llama-models-v2",
                            "TinyLlama-1.1B-Chat-v1.0"),
         kv_cache_config=global_kvcache_config,
-        gather_context_logits=gather_context_logits,
         gather_generation_logits=gather_generation_logits,
         max_batch_size=
         128,  # reduce buffer sizes, specially for generation logits

--- a/tests/unittest/_torch/test_return_logits.py
+++ b/tests/unittest/_torch/test_return_logits.py
@@ -72,10 +72,14 @@ def test_generate_with_return_logits(disable_overlap_scheduler: bool,
     if not enable_trtllm_sampler and gather_context_logits:
         pytest.skip("TorchSampler does not support gather_context_logits")
 
+    build_config = BuildConfig()
+    build_config.gather_context_logits = gather_context_logits
+
     llm = LLM(
         model=os.path.join(llm_models_root(), "llama-models-v2",
                            "TinyLlama-1.1B-Chat-v1.0"),
         kv_cache_config=global_kvcache_config,
+        build_config=build_config,
         gather_generation_logits=gather_generation_logits,
         max_batch_size=
         128,  # reduce buffer sizes, specially for generation logits
@@ -143,7 +147,6 @@ def test_generate_async_with_return_logits(disable_overlap_scheduler: bool,
                            "TinyLlama-1.1B-Chat-v1.0"),
         kv_cache_config=global_kvcache_config,
         build_config=build_config,
-        gather_context_logits=gather_context_logits,
         gather_generation_logits=gather_generation_logits,
         max_batch_size=
         128,  # reduce buffer sizes, specially for generation logits

--- a/tests/unittest/api_stability/references/llm.yaml
+++ b/tests/unittest/api_stability/references/llm.yaml
@@ -84,6 +84,18 @@ methods:
       allreduce_strategy:
         annotation: Optional[Literal['AUTO', 'NCCL', 'UB', 'MINLATENCY', 'ONESHOT', 'TWOSHOT', 'LOWPRECISION', 'MNNVL']]
         default: AUTO
+      # postproc worker
+      num_postprocess_workers:
+        annotation: int
+        default: 0
+      postprocess_tokenizer_dir:
+        annotation: Optional[str]
+        default: null
+      # reasoning
+      reasoning_parser:
+        annotation: Optional[str]
+        default: null
+      # kwargs
       kwargs:
         annotation: Any
         default: inspect._empty

--- a/tests/unittest/api_stability/references_committed/llm.yaml
+++ b/tests/unittest/api_stability/references_committed/llm.yaml
@@ -81,14 +81,14 @@ methods:
         annotation: Optional[int]
         default: null
       max_input_len:
-        annotation: int
-        default: 1024
+        annotation: Optional[int]
+        default: null
       max_seq_len:
         annotation: Optional[int]
         default: null
       max_beam_width:
-        annotation: int
-        default: 1
+        annotation: Optional[int]
+        default: null
       max_num_tokens:
         annotation: Optional[int]
         default: null

--- a/tests/unittest/api_stability/references_committed/llm.yaml
+++ b/tests/unittest/api_stability/references_committed/llm.yaml
@@ -66,10 +66,10 @@ methods:
         default: null
       # Quantization and calibration
       quant_config:
-        annotation: Optional[tensorrt_llm.models.modeling_utils.QuantConfig]
+        annotation: tensorrt_llm.models.modeling_utils.QuantConfig
         default: null
       calib_config:
-        annotation: Optional[tensorrt_llm.llmapi.llm_utils.CalibConfig]
+        annotation: tensorrt_llm.llmapi.llm_utils.CalibConfig
         default: null
       # Speculative decoding
       speculative_config:

--- a/tests/unittest/api_stability/references_committed/llm.yaml
+++ b/tests/unittest/api_stability/references_committed/llm.yaml
@@ -66,10 +66,10 @@ methods:
         default: null
       # Quantization and calibration
       quant_config:
-        annotation: tensorrt_llm.models.modeling_utils.QuantConfig
+        annotation: Optional[tensorrt_llm.models.modeling_utils.QuantConfig]
         default: null
       calib_config:
-        annotation: tensorrt_llm.llmapi.llm_utils.CalibConfig
+        annotation: Optional[tensorrt_llm.llmapi.llm_utils.CalibConfig]
         default: null
       # Speculative decoding
       speculative_config:

--- a/tests/unittest/llmapi/run_llm_with_postproc.py
+++ b/tests/unittest/llmapi/run_llm_with_postproc.py
@@ -78,8 +78,8 @@ def main(model_dir: str, tp_size: int, engine_dir: Optional[str], n: int,
 
     # Simplified postprocessing configuration
     postproc_config = {
-        "_num_postprocess_workers": tp_size,
-        "_postprocess_tokenizer_dir": model_dir,
+        "num_postprocess_workers": tp_size,
+        "postprocess_tokenizer_dir": model_dir,
     }
 
     print_colored("Enabled OAI postprocessing\n", "yellow")

--- a/tests/unittest/llmapi/test_llm.py
+++ b/tests/unittest/llmapi/test_llm.py
@@ -1906,10 +1906,12 @@ def llm_get_stats_test_harness(tp_size: int = 1,
     else:
         LLM_CLASS = LLM
 
+    if not pytorch_backend:
+        llm_args_extra["fast_build"] = True
+
     llm = LLM_CLASS(model=llama_model_path,
                     kv_cache_config=global_kvcache_config,
                     tensor_parallel_size=tp_size,
-                    fast_build=True,
                     **llm_args_extra)
 
     max_tokens = 5

--- a/tests/unittest/llmapi/test_llm.py
+++ b/tests/unittest/llmapi/test_llm.py
@@ -2033,11 +2033,11 @@ def llm_get_stats_async_test_harness(tp_size: int = 1,
         LLM_CLASS = LLM_torch
     else:
         LLM_CLASS = LLM
+        llm_args_extra["fast_build"] = True
 
     llm = LLM_CLASS(model=llama_model_path,
                     kv_cache_config=global_kvcache_config,
                     tensor_parallel_size=tp_size,
-                    fast_build=True,
                     **llm_args_extra)
 
     max_tokens = 6
@@ -2206,8 +2206,8 @@ def run_llm_with_postprocess_parallel_and_result_handler(
               backend=backend,
               kv_cache_config=global_kvcache_config,
               tensor_parallel_size=tp_size,
-              _num_postprocess_workers=2,
-              _postprocess_tokenizer_dir=llama_model_path,
+              num_postprocess_workers=2,
+              postprocess_tokenizer_dir=llama_model_path,
               **kwargs)
     golden_result = "DEFGHI"
     for i, output in enumerate(

--- a/tests/unittest/llmapi/test_llm.py
+++ b/tests/unittest/llmapi/test_llm.py
@@ -2169,8 +2169,8 @@ def test_llm_dynamic_batch_config():
 def run_llm_with_postprocess_parallel(tp_size: int = 1):
     sampling_params = SamplingParams(max_tokens=6)
 
-    postproc_settings = dict(_num_postprocess_workers=2,
-                             _postprocess_tokenizer_dir=llama_model_path)
+    postproc_settings = dict(num_postprocess_workers=2,
+                             postprocess_tokenizer_dir=llama_model_path)
 
     llm_test_harness(llama_model_path,
                      prompts, ["D E F G H I J K"],

--- a/tests/unittest/llmapi/test_llm_pytorch.py
+++ b/tests/unittest/llmapi/test_llm_pytorch.py
@@ -152,10 +152,7 @@ def llama_7b_multi_lora_test_harness(**llm_kwargs) -> None:
     # (2) provide a lora_dir to infer the lora_target_modules.
     lora_config = LoraConfig(lora_target_modules=['attn_q', 'attn_k', 'attn_v'],
                              max_lora_rank=8)
-    llm = LLM(hf_model_dir,
-              fast_build=True,
-              lora_config=lora_config,
-              **llm_kwargs)
+    llm = LLM(hf_model_dir, lora_config=lora_config, **llm_kwargs)
 
     prompts = [
         "美国的首都在哪里? \n答案:",
@@ -297,10 +294,7 @@ def test_codellama_fp8_with_bf16_lora() -> None:
                                  lora_target_modules=target_modules,
                                  max_lora_rank=8)
 
-        llm = LLM(model_dir,
-                  quant_config=quant_config,
-                  fast_build=True,
-                  lora_config=lora_config)
+        llm = LLM(model_dir, quant_config=quant_config, lora_config=lora_config)
 
         prompts = [
             "Write a function that calculates the Fibonacci sequence.",

--- a/tests/unittest/llmapi/test_llm_utils.py
+++ b/tests/unittest/llmapi/test_llm_utils.py
@@ -15,7 +15,6 @@ from tensorrt_llm.llmapi.llm_args import *
 def test_ModelLoader():
     kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.4)
     args = TrtLlmArgs(model=llama_model_path, kv_cache_config=kv_cache_config)
-    args._setup()
 
     # Test with HF model
     temp_dir = tempfile.TemporaryDirectory()
@@ -28,7 +27,7 @@ def test_ModelLoader():
 
     # Test with engine
     args.model = build_engine()
-    args._setup()
+    args.model_post_init({})
     assert args.model_format is _ModelFormatKind.TLLM_ENGINE
     print(f'engine_dir: {args.model}')
     model_loader = ModelLoader(args)
@@ -41,7 +40,7 @@ def test_CachedModelLoader():
     args = LlmArgs(model=llama_model_path,
                    kv_cache_config=KvCacheConfig(free_gpu_memory_fraction=0.4))
     args.enable_build_cache = True
-    args._setup()
+    args.model_post_init({})
     stats = LlmBuildStats()
     model_loader = CachedModelLoader(args, llm_build_stats=stats)
     engine_dir, _ = model_loader()

--- a/tests/unittest/llmapi/test_llm_utils.py
+++ b/tests/unittest/llmapi/test_llm_utils.py
@@ -14,20 +14,20 @@ from tensorrt_llm.llmapi.llm_args import *
 
 def test_ModelLoader():
     kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.4)
-    args = TrtLlmArgs(model=llama_model_path, kv_cache_config=kv_cache_config)
 
     # Test with HF model
     temp_dir = tempfile.TemporaryDirectory()
 
     def build_engine():
+        args = TrtLlmArgs(model=llama_model_path,
+                          kv_cache_config=kv_cache_config)
         model_loader = ModelLoader(args)
         engine_dir = model_loader(engine_dir=Path(temp_dir.name))
         assert engine_dir
         return engine_dir
 
     # Test with engine
-    args.model = build_engine()
-    args.model_post_init({})
+    args = TrtLlmArgs(model=build_engine(), kv_cache_config=kv_cache_config)
     assert args.model_format is _ModelFormatKind.TLLM_ENGINE
     print(f'engine_dir: {args.model}')
     model_loader = ModelLoader(args)
@@ -38,9 +38,8 @@ def test_ModelLoader():
 def test_CachedModelLoader():
     # CachedModelLoader enables engine caching and multi-gpu building
     args = LlmArgs(model=llama_model_path,
-                   kv_cache_config=KvCacheConfig(free_gpu_memory_fraction=0.4))
-    args.enable_build_cache = True
-    args.model_post_init({})
+                   kv_cache_config=KvCacheConfig(free_gpu_memory_fraction=0.4),
+                   enable_build_cache=True)
     stats = LlmBuildStats()
     model_loader = CachedModelLoader(args, llm_build_stats=stats)
     engine_dir, _ = model_loader()


### PR DESCRIPTION
This PR restores the reverted PR #4600 with some fix on the ToT

It addresses two bugs:

- The LLM class accepts arbitrary arguments without reporting errors
- `max_batch_size`, `max_seq_len` and other values from build_config are ignored
