### PR TITLE
fix:https://nvbugs/5324248

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -313,7 +313,8 @@ class PyTorchModelEngine(ModelEngine):
         if mapping.has_pp():
             init_pp_comm(mapping)
         self.dist = dist
-        ExpertStatistic.create(self.dist.rank)
+        if dist is not None:
+            ExpertStatistic.create(self.dist.rank)
         self.pytorch_backend_config = pytorch_backend_config
         self.spec_config = spec_config
         self.is_spec_decode = spec_config is not None


### PR DESCRIPTION
main branch has ut regression with this cmd

```python
pytest tests/unittest/_torch/test_pytorch_model_engine.py::PyTorchModelEngineTestCase
```

this pr fixed cases 

FAILED tests/unittest/_torch/test_pytorch_model_engine.py::PyTorchModelEngineTestCase::**test_layerwise_nvtx_marker** - TypeError: argument of type 'NoneType' is not iterable
FAILED tests/unittest/_torch/test_pytorch_model_engine.py::PyTorchModelEngineTestCase::**test_pad_generation_requests** - TypeError: argument of type 'NoneType' is not iterable
FAILED tests/unittest/_torch/test_pytorch_model_engine.py::PyTorchModelEngineTestCase::**test_position_id_preparation** - TypeError: argument of type 'NoneType' is not iterable
FAILED tests/unittest/_torch/test_pytorch_model_engine.py::PyTorchModelEngineTestCase::**test_warmup** - TypeError: argument of type 'NoneType' is not iterable