### PR TITLE
[fix] Fix W4A8 weight loading error in WInt4AFP8FusedMoEMethod

### DIFF
--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -550,13 +550,13 @@ class WInt4AFP8FusedMoEMethod(FusedMoEMethodBase):
                            module.intermediate_size_per_partition // 2)
 
         fc31_act_scale = nn.Parameter(torch.empty(1,
-                                                  self.hidden_size,
-                                                  dtype=self.dtype),
+                                                  module.hidden_size,
+                                                  dtype=module.dtype),
                                       requires_grad=False)
         module.register_parameter("fc31_act_scale", fc31_act_scale)
 
         fc2_act_scale = nn.Parameter(torch.empty(
-            1, self.intermediate_size_per_partition, 1, dtype=self.dtype),
+            1, module.intermediate_size_per_partition, 1, dtype=module.dtype),
                                      requires_grad=False)
         module.register_parameter("fc2_act_scale", fc2_act_scale)
 
@@ -701,10 +701,10 @@ class WInt4AFP8FusedMoEMethod(FusedMoEMethodBase):
         all_w3_w1_input_scales_max = torch.max(
             torch.stack(all_w3_input_scales),
             torch.stack(all_w1_input_scales)).max()
-        self.fc31_act_scale.data.copy_(
-            torch.ones_like(self.fc31_act_scale) *
+        module.fc31_act_scale.data.copy_(
+            torch.ones_like(module.fc31_act_scale) *
             (1 / all_w3_w1_input_scales_max))
-        self.fc31_alpha.data.copy_((torch.ones_like(self.fc31_alpha) *
+        module.fc31_alpha.data.copy_((torch.ones_like(module.fc31_alpha) *
                                     all_w3_w1_input_scales_max).float())
 
         all_w3_scales = [
@@ -744,11 +744,11 @@ class WInt4AFP8FusedMoEMethod(FusedMoEMethodBase):
             for expert_id in module.initial_local_expert_ids
         ]
         all_w2_input_scales_max = torch.stack(all_w2_input_scales).to(
-            self.dtype).max()
-        self.fc2_act_scale.data.copy_(
-            torch.ones_like(self.fc2_act_scale) * (1 / all_w2_input_scales_max))
-        self.fc2_alpha.data.copy_(
-            (torch.ones_like(self.fc2_alpha) * all_w2_input_scales_max).float())
+            module.dtype).max()
+        module.fc2_act_scale.data.copy_(
+            torch.ones_like(module.fc2_act_scale) * (1 / all_w2_input_scales_max))
+        module.fc2_alpha.data.copy_(
+            (torch.ones_like(module.fc2_alpha) * all_w2_input_scales_max).float())
 
         all_w2_scales = [
             load_weight_shard(weights[f"{expert_id}.w2.weight_scale_inv"],

--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -705,7 +705,7 @@ class WInt4AFP8FusedMoEMethod(FusedMoEMethodBase):
             torch.ones_like(module.fc31_act_scale) *
             (1 / all_w3_w1_input_scales_max))
         module.fc31_alpha.data.copy_((torch.ones_like(module.fc31_alpha) *
-                                    all_w3_w1_input_scales_max).float())
+                                      all_w3_w1_input_scales_max).float())
 
         all_w3_scales = [
             load_weight_shard(weights[f"{expert_id}.w3.weight_scale_inv"],
@@ -746,9 +746,10 @@ class WInt4AFP8FusedMoEMethod(FusedMoEMethodBase):
         all_w2_input_scales_max = torch.stack(all_w2_input_scales).to(
             module.dtype).max()
         module.fc2_act_scale.data.copy_(
-            torch.ones_like(module.fc2_act_scale) * (1 / all_w2_input_scales_max))
-        module.fc2_alpha.data.copy_(
-            (torch.ones_like(module.fc2_alpha) * all_w2_input_scales_max).float())
+            torch.ones_like(module.fc2_act_scale) *
+            (1 / all_w2_input_scales_max))
+        module.fc2_alpha.data.copy_((torch.ones_like(module.fc2_alpha) *
+                                     all_w2_input_scales_max).float())
 
         all_w2_scales = [
             load_weight_shard(weights[f"{expert_id}.w2.weight_scale_inv"],


### PR DESCRIPTION
## Description

The refactored fused_moe is broken by release0.20 mass integration. When loading DeepSeek-R1/V3 W4A8 weights, the following error will appear:
```
AttributeError: 'WInt4AFP8FusedMoEMethod' object has no attribute 'hidden_size'
```

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
