### PR TITLE
[TRTLLM-5921][feat] Prevent serialization of entire LoRA adapters in each request

### DIFF
--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -341,13 +341,14 @@ class GenerationExecutorWorker(GenerationExecutor):
         if mpi_rank() == 0:
             self.start_thread(self.dispatch_stats_thread)
 
-    def _load_lora_adapter(self, lora_request: LoRARequest):
-        self._lora_manager.load_from_ckpt(
+    def _load_lora_adapter(self, lora_request: LoRARequest) -> bool:
+        uids = [str(lora_request.adapter_id)]
+        return uids == self._lora_manager.load_from_ckpt(
             [lora_request.path],
             model_config=self._runtime_model_config if
             self._runtime_model_config is not None else self._lora_model_config,
             runtime_mapping=None,
-            uids=[str(lora_request.adapter_id)])
+            uids=uids)
 
     def _load_prompt_adapter(self,
                              prompt_adapter_request: PromptAdapterRequest):
@@ -359,12 +360,15 @@ class GenerationExecutorWorker(GenerationExecutor):
     def _enqueue_request(self, request: GenerationRequest) -> int:
         assert request.id is not None
         if self._lora_manager is not None and request.lora_request is not None:
-            self._load_lora_adapter(request.lora_request)
+            loaded_new_lora_adapter = self._load_lora_adapter(
+                request.lora_request)
             uid = str(request.lora_request.adapter_id)
             lora_config = tllm.LoraConfig(
                 task_id=request.lora_request.adapter_id,
-                weights=self._lora_manager.cpp_lora_weights[uid],
-                config=self._lora_manager.cpp_lora_config[uid])
+                weights=self._lora_manager.cpp_lora_weights[uid]
+                if loaded_new_lora_adapter else None,
+                config=self._lora_manager.cpp_lora_config[uid]
+                if loaded_new_lora_adapter else None)
         else:
             lora_config = None
 

--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -350,7 +350,7 @@ class GenerationExecutorWorker(GenerationExecutor):
             self._runtime_model_config is not None else self._lora_model_config,
             runtime_mapping=None,
             uids=[adapter_id])
-        return newly_loaded_uids and newly_loaded_uids[0] == adapter_id
+        return adapter_id in newly_loaded_uids
 
     def _load_prompt_adapter(self,
                              prompt_adapter_request: PromptAdapterRequest):

--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -342,13 +342,15 @@ class GenerationExecutorWorker(GenerationExecutor):
             self.start_thread(self.dispatch_stats_thread)
 
     def _load_lora_adapter(self, lora_request: LoRARequest) -> bool:
-        uids = [str(lora_request.adapter_id)]
-        return uids == self._lora_manager.load_from_ckpt(
+        """Returns True if the adapter was loaded by this call, False if it was already loaded"""
+        adapter_id = str(lora_request.adapter_id)
+        newly_loaded_uids = self._lora_manager.load_from_ckpt(
             [lora_request.path],
             model_config=self._runtime_model_config if
             self._runtime_model_config is not None else self._lora_model_config,
             runtime_mapping=None,
-            uids=uids)
+            uids=[adapter_id])
+        return newly_loaded_uids and newly_loaded_uids[0] == adapter_id
 
     def _load_prompt_adapter(self,
                              prompt_adapter_request: PromptAdapterRequest):

--- a/tensorrt_llm/lora_manager.py
+++ b/tensorrt_llm/lora_manager.py
@@ -503,6 +503,11 @@ class LoraManager(object):
         uids: Optional[List[str]] = None,
         ckpt_source: str = "hf",
     ) -> List[str]:
+        """Returns the adapter UIDs that were loaded by this call.
+
+        Note that when an adapter was already loaded before this call, it would not be
+        included in the returned list of UIDs.
+        """
         if ckpt_source == "hf":
             return self.load_from_hf(
                 model_dirs=model_dirs_or_files,
@@ -527,6 +532,11 @@ class LoraManager(object):
         runtime_mapping: Optional[Mapping] = None,
         uids: Optional[List[str]] = None,
     ) -> List[str]:
+        """Returns the adapter UIDs that were loaded by this call.
+
+        Note that when an adapter was already loaded before this call, it would not be
+        included in the returned list of UIDs.
+        """
         if runtime_mapping is None:
             runtime_mapping = Mapping()
         tp_size = runtime_mapping.tp_size
@@ -626,7 +636,12 @@ class LoraManager(object):
         uids: Optional[List[str]] = None,
         component: Optional[str] = None,
     ) -> List[str]:
-        """Lora config of https://huggingface.co/hfl/chinese-alpaca-2-lora-7b.
+        """Returns the adapter UIDs that were loaded by this call.
+
+        Note that when an adapter was already loaded before this call, it would not be
+        included in the returned list of UIDs.
+
+        Lora config of https://huggingface.co/hfl/chinese-alpaca-2-lora-7b.
 
         {
             "base_model_name_or_path": "/Llama-2-7b-hf",

--- a/tensorrt_llm/lora_manager.py
+++ b/tensorrt_llm/lora_manager.py
@@ -554,7 +554,7 @@ class LoraManager(object):
             new_model_files.append(model_file)
 
         if len(new_uids) == 0:
-            return
+            return new_uids
 
         self.lora_target_modules = model_config.lora_target_modules
 
@@ -706,7 +706,7 @@ class LoraManager(object):
             new_model_dirs.append(model_dir)
 
         if len(new_uids) == 0:
-            return
+            return new_uids
 
         lora_hf_configs = []
         for model_dir in new_model_dirs:

--- a/tensorrt_llm/lora_manager.py
+++ b/tensorrt_llm/lora_manager.py
@@ -502,16 +502,16 @@ class LoraManager(object):
         runtime_mapping: Optional[Mapping] = None,
         uids: Optional[List[str]] = None,
         ckpt_source: str = "hf",
-    ):
+    ) -> List[str]:
         if ckpt_source == "hf":
-            self.load_from_hf(
+            return self.load_from_hf(
                 model_dirs=model_dirs_or_files,
                 model_config=model_config,
                 runtime_mapping=runtime_mapping,
                 uids=uids,
             )
         elif ckpt_source == "nemo":
-            self.load_from_nemo(
+            return self.load_from_nemo(
                 model_files=model_dirs_or_files,
                 model_config=model_config,
                 runtime_mapping=runtime_mapping,
@@ -526,7 +526,7 @@ class LoraManager(object):
         model_config: Union["ModelConfig", LoraModelConfig],
         runtime_mapping: Optional[Mapping] = None,
         uids: Optional[List[str]] = None,
-    ):
+    ) -> List[str]:
         if runtime_mapping is None:
             runtime_mapping = Mapping()
         tp_size = runtime_mapping.tp_size
@@ -616,6 +616,8 @@ class LoraManager(object):
             load_from_model_file(uid, model_file)
             release_gc()
 
+        return new_uids
+
     def load_from_hf(
         self,
         model_dirs: List[str],
@@ -623,7 +625,7 @@ class LoraManager(object):
         runtime_mapping: Optional[Mapping] = None,
         uids: Optional[List[str]] = None,
         component: Optional[str] = None,
-    ):
+    ) -> List[str]:
         """Lora config of https://huggingface.co/hfl/chinese-alpaca-2-lora-7b.
 
         {
@@ -864,6 +866,8 @@ class LoraManager(object):
         for uid, model_dir, hf_config in zip(new_uids, new_model_dirs, lora_hf_configs):
             load_from_model_dir(uid, model_dir, hf_config)
             release_gc()
+
+        return new_uids
 
     @property
     def lora_weights(self):


### PR DESCRIPTION
## Description

Make LoRA pytorch to broadcast weights & config tensors only on new LoRA adapter, so when the adapter is already loaded on rank 0 (and thus, should be loaded on other ranks as well), only the adapter ID is sent in the request.

NOTE: The changes in this PR cause requests with a LoRA adapter that were previously unloaded from LoRA CPU cache not to work, as they remain in `_cpp_lora_weights` in `LoraManager` python class. It was decided that for now this flow is not supported, in favor of its significant performance boost.

## Test Coverage


## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
