### PR TITLE
feat: Optimize response handling by speeding up the serialization/deserialization

### DIFF
--- a/cpp/tensorrt_llm/executor/serialization.cpp
+++ b/cpp/tensorrt_llm/executor/serialization.cpp
@@ -946,15 +946,18 @@ Response Serialization::deserializeResponse(std::istream& is)
 {
     auto requestId = su::deserialize<IdType>(is);
     auto errOrResult = su::deserialize<std::variant<std::string, Result>>(is);
+    auto clientId = su::deserialize<std::optional<IdType>>(is);
 
-    return std::holds_alternative<std::string>(errOrResult) ? Response{requestId, std::get<std::string>(errOrResult)}
-                                                            : Response{requestId, std::get<Result>(errOrResult)};
+    return std::holds_alternative<std::string>(errOrResult)
+        ? Response{requestId, std::get<std::string>(errOrResult), clientId}
+        : Response{requestId, std::get<Result>(errOrResult), clientId};
 }
 
 void Serialization::serialize(Response const& response, std::ostream& os)
 {
     su::serialize(response.mImpl->mRequestId, os);
     su::serialize(response.mImpl->mErrOrResult, os);
+    su::serialize(response.mImpl->mClientId, os);
 }
 
 size_t Serialization::serializedSize(Response const& response)
@@ -962,6 +965,7 @@ size_t Serialization::serializedSize(Response const& response)
     size_t totalSize = 0;
     totalSize += su::serializedSize(response.mImpl->mRequestId);
     totalSize += su::serializedSize(response.mImpl->mErrOrResult);
+    totalSize += su::serializedSize(response.mImpl->mClientId);
     return totalSize;
 }
 

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -223,17 +223,12 @@ class LlmResponse:
                  py_result: PyResult):
         self._response = response
         self._py_result = py_result
-        self._has_error = response.has_error()
-        self.is_final = response.result.is_final
 
     def __getstate__(self):
-        return self._response, self._py_result, self._has_error, self.is_final
+        return self._response, self._py_result
 
     def __setstate__(self, state):
-        self._response, self._py_result, self._has_error, self.is_final = state
-
-    def has_error(self) -> bool:
-        return self._has_error
+        self._response, self._py_result = state
 
     @property
     def result(self) -> tensorrt_llm.bindings.executor.Result:

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -18,14 +18,12 @@ import torch
 
 from tensorrt_llm._utils import (global_mpi_rank, is_trace_enabled, nvtx_range,
                                  trace_func)
-
 from tensorrt_llm.bindings.executor import (DisServingRequestStats,
                                             FinishReason, InflightBatchingStats,
                                             IterationStats, KvCacheStats,
                                             RequestStage, RequestStats,
                                             RequestType, SpecDecodingStats,
                                             StaticBatchingStats)
-
 from tensorrt_llm.bindings.internal.batch_manager import (LlmRequestType,
                                                           ReqIdsSet)
 from tensorrt_llm.logger import logger

--- a/tensorrt_llm/executor/ipc.py
+++ b/tensorrt_llm/executor/ipc.py
@@ -114,6 +114,7 @@ class ZeroMqQueue:
             return False
 
     def put(self, obj: Any):
+        self.setup_lazily()
         with nvtx_range_debug("send", color="blue", category="IPC"):
             if self.use_hmac_encryption:
                 # Send pickled data with HMAC appended

--- a/tensorrt_llm/executor/ipc.py
+++ b/tensorrt_llm/executor/ipc.py
@@ -114,7 +114,6 @@ class ZeroMqQueue:
             return False
 
     def put(self, obj: Any):
-        self.setup_lazily()
         with nvtx_range_debug("send", color="blue", category="IPC"):
             if self.use_hmac_encryption:
                 # Send pickled data with HMAC appended
@@ -127,7 +126,7 @@ class ZeroMqQueue:
 
     def put_noblock(self, obj: Any):
         self.setup_lazily()
-        with nvtx_range_debug("send", color="blue", category="IPC"):
+        with nvtx_range_debug("send (noblock)", color="blue", category="IPC"):
             data = pickle.dumps(obj)  # nosec B301
             if self.use_hmac_encryption:
                 data = self._sign_data(data)

--- a/tensorrt_llm/executor/postproc_worker.py
+++ b/tensorrt_llm/executor/postproc_worker.py
@@ -184,14 +184,18 @@ class PostprocWorker:
                              | PostprocWorker.
                              Input] = await self._pull_pipe.get_async()
 
-            inputs = restore_postproc_inputs(inputs[0])
+            if inputs[0] is None:
+                self._to_stop.set()
+                yield None
+            else:
+                inputs = restore_postproc_inputs(inputs[0])
 
-            for inp in inputs:
-                if inp is None:
-                    self._to_stop.set()
-                    yield None
-                    break
-                await handle_single_input(inp, batch)
+                for inp in inputs:
+                    if inp is None:
+                        self._to_stop.set()
+                        yield None
+                        break
+                    await handle_single_input(inp, batch)
 
             yield batch
 

--- a/tensorrt_llm/executor/postproc_worker.py
+++ b/tensorrt_llm/executor/postproc_worker.py
@@ -188,7 +188,8 @@ class PostprocWorker:
                 self._to_stop.set()
                 yield None
             else:
-                inputs = restore_postproc_inputs(inputs[0])
+                inputs = restore_postproc_inputs(
+                    inputs[0]["postproc_inputs"]) + inputs[0]["other_responses"]
 
                 for inp in inputs:
                     if inp is None:

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -180,7 +180,8 @@ class GenerationExecutorProxy(GenerationExecutor):
                 self._results.pop(client_id)
 
         if not isinstance(res[0], PostprocWorker.Output):
-            res = restore_llm_responses_from_serialize_friendly_list(res[0])
+            res = restore_llm_responses_from_serialize_friendly_list(
+                res[0]["llm_responses"]) + res[0]["other_responses"]
 
         for i in res:
             global_tracer().log_instant("IPC.get")

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -155,7 +155,7 @@ class GenerationExecutorProxy(GenerationExecutor):
 
         # TODO[chunweiy]: convert the dispatch_result_task to async, that should
         # benefit from zmq.asyncio.Context
-        if (res := self.result_queue.get()) is None:
+        if (res := self.result_queue.get()) is None or res[0] is None:
             return False  # shutdown the thread
 
         async_queues = []


### PR DESCRIPTION
# Optimize response handling latency

## Description

Please explain the issue and the solution in short.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
