### PR TITLE
[TRTLLM-4770][feat] Enhance cpp executor cmake to listen to ENABLE_MU…

### DIFF
--- a/examples/cpp/executor/CMakeLists.txt
+++ b/examples/cpp/executor/CMakeLists.txt
@@ -22,10 +22,19 @@ if(NOT TRTLLM_BUILD_DIR)
   set(TRTLLM_BUILD_DIR "${TRTLLM_DIR}/cpp/build")
 endif()
 set(TRTLLM_LIB_PATH "${TRTLLM_BUILD_DIR}/tensorrt_llm/libtensorrt_llm.so")
+if(NOT EXISTS ${TRTLLM_LIB_PATH})
+  message(FATAL_ERROR "Cannot find ${TRTLLM_LIB_PATH}")
+endif()
+
 set(TRTLLM_PLUGIN_PATH
     "${TRTLLM_BUILD_DIR}/tensorrt_llm/plugins/libnvinfer_plugin_tensorrt_llm.so"
 )
 set(TRTLLM_INCLUDE_DIR "${TRTLLM_DIR}/cpp/include")
+
+option(
+  ENABLE_MULTI_DEVICE
+  "Enable multi device/instance examples building (requires MPI headers/libs)"
+  ON)
 
 # Determine CXX11 ABI compatibility
 execute_process(
@@ -47,8 +56,13 @@ set(CMAKE_VERBOSE_MAKEFILE 1)
 # Define project name
 project(executorExamples)
 
-# Compile options
-set(CMAKE_CXX_FLAGS "-Wall -pthread -lstdc++ -DENABLE_MULTI_DEVICE=1")
+# Compile options $<BOOL:${ENABLE_MULTI_DEVICE}> ?
+if(ENABLE_MULTI_DEVICE)
+  set(EMD 1)
+else()
+  set(EMD 0)
+endif()
+set(CMAKE_CXX_FLAGS "-Wall -pthread -lstdc++ -DENABLE_MULTI_DEVICE=${EMD} ")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 set(CMAKE_BUILD_TYPE release)
 
@@ -120,23 +134,25 @@ target_link_libraries(executorExampleAdvanced nvinfer_plugin_tensorrt_llm
                       cxxopts::cxxopts)
 
 # MultiInstance
+if(ENABLE_MULTI_DEVICE)
+  find_package(MPI REQUIRED)
+  message(STATUS "Using MPI_C_INCLUDE_DIRS: ${MPI_C_INCLUDE_DIRS}")
+  message(STATUS "Using MPI_C_LIBRARIES: ${MPI_C_LIBRARIES}")
+  include_directories(${MPI_C_INCLUDE_DIRS})
 
-find_package(MPI REQUIRED)
-message(STATUS "Using MPI_C_INCLUDE_DIRS: ${MPI_C_INCLUDE_DIRS}")
-message(STATUS "Using MPI_C_LIBRARIES: ${MPI_C_LIBRARIES}")
-include_directories(${MPI_C_INCLUDE_DIRS})
+  add_executable(executorExampleAdvancedMultiInstances
+                 executorExampleAdvancedMultiInstances.cpp)
+  target_link_libraries(
+    executorExampleAdvancedMultiInstances nvinfer_plugin_tensorrt_llm
+    cxxopts::cxxopts ${MPI_C_LIBRARIES})
 
-add_executable(executorExampleAdvancedMultiInstances
-               executorExampleAdvancedMultiInstances.cpp)
-target_link_libraries(
-  executorExampleAdvancedMultiInstances nvinfer_plugin_tensorrt_llm
-  cxxopts::cxxopts ${MPI_C_LIBRARIES})
+  # FastLogits
+  add_executable(executorExampleFastLogits executorExampleFastLogits.cpp)
+  target_link_libraries(executorExampleFastLogits nvinfer_plugin_tensorrt_llm
+                        cxxopts::cxxopts ${MPI_C_LIBRARIES})
 
-# FastLogits
-add_executable(executorExampleFastLogits executorExampleFastLogits.cpp)
-target_link_libraries(executorExampleFastLogits nvinfer_plugin_tensorrt_llm
-                      cxxopts::cxxopts ${MPI_C_LIBRARIES})
-
-add_executable(executorExampleDisaggregated executorExampleDisaggregated.cpp)
-target_link_libraries(executorExampleDisaggregated nvinfer_plugin_tensorrt_llm
-                      cxxopts::cxxopts ${MPI_C_LIBRARIES})
+  add_executable(executorExampleDisaggregated executorExampleDisaggregated.cpp)
+  target_link_libraries(
+    executorExampleDisaggregated nvinfer_plugin_tensorrt_llm cxxopts::cxxopts
+    ${MPI_C_LIBRARIES})
+endif()

--- a/scripts/build_cpp_examples.py
+++ b/scripts/build_cpp_examples.py
@@ -21,7 +21,7 @@ def working_directory(path: PathLike):
 
 
 def build_cpp_examples(build_dir: PathLike, trt_dir: PathLike,
-                       loglevel: int) -> None:
+                       enable_multi_device: str, loglevel: int) -> None:
     logging.basicConfig(level=loglevel,
                         format='%(asctime)s - %(levelname)s - %(message)s')
     # Convert input paths to pathlib.Path objects
@@ -52,6 +52,7 @@ def build_cpp_examples(build_dir: PathLike, trt_dir: PathLike,
             '-B',
             '.',
             f'-DTensorRT_ROOT={cmake_parse(trt_dir)}',
+            f'-DENABLE_MULTI_DEVICE={enable_multi_device}',
         ] + generator
         logging.info(f"Executing {generate_command}")
         subprocess.run(generate_command, check=True)
@@ -70,6 +71,9 @@ if __name__ == '__main__':
     parser.add_argument('--trt-dir',
                         default='/usr/local/tensorrt',
                         help='TensorRT directory path')
+    parser.add_argument('--enable-multi-device',
+                        default='ON',
+                        help='Enable multi device support (requires MPI)')
     parser.add_argument('-v',
                         '--verbose',
                         help="verbose",


### PR DESCRIPTION
Resolve github  #4770

The ccp executor cmake script was hardcoding  ENABLE_MULTI_DEVICE  to 1.
This change just allows to set that value from the cmake call.
Default value is 1 (enabled).

## Test Coverage

Build the cpp executor examples as usual.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
