### PR TITLE
fix: Updates to yarn implementation

### DIFF
--- a/tensorrt_llm/functional.py
+++ b/tensorrt_llm/functional.py
@@ -20,6 +20,7 @@ from functools import partial
 from typing import List, Optional, Sequence, Tuple, Union
 
 import numpy as np
+import torch
 
 # isort: off
 import tensorrt as trt
@@ -4835,6 +4836,7 @@ class RopeEmbeddingUtils:
     def create_fake_weight(dim: int, dtype=np.half):
         return np.random.rand(dim).astype(dtype)
 
+    # Note: When not using deepseek_yarn, make sure to set mscale_all_dim to 0.0.
     @staticmethod
     def create_sinusoidal_positions_yarn(
             num_pos: int,
@@ -4847,24 +4849,19 @@ class RopeEmbeddingUtils:
             mscale: float = 1.0,
             mscale_all_dim: float = 1.0,
             duplicate_data: bool = True,
-            dtype=np.float32):
+            dtype=torch.float32):
 
         # Copy from https://huggingface.co/deepseek-ai/DeepSeek-V2/blob/main/modeling_deepseek.py
         # Inverse dim formula to find dim based on number of rotations
-        def yarn_find_correction_dim(num_rotations,
-                                     dim,
-                                     base=10000,
-                                     max_position_embeddings=2048):
+        def yarn_find_correction_dim(num_rotations, dim, base,
+                                     max_position_embeddings):
             return (dim * math.log(max_position_embeddings /
                                    (num_rotations * 2 * math.pi))) / (
                                        2 * math.log(base))
 
         # Find dim range bounds based on rotations
-        def yarn_find_correction_range(low_rot,
-                                       high_rot,
-                                       dim,
-                                       base=10000,
-                                       max_position_embeddings=2048):
+        def yarn_find_correction_range(low_rot, high_rot, dim, base,
+                                       max_position_embeddings):
             low = math.floor(
                 yarn_find_correction_dim(low_rot, dim, base,
                                          max_position_embeddings))
@@ -4877,7 +4874,7 @@ class RopeEmbeddingUtils:
                 high = dim - 1
             return low, high  # Clamp values just in case
 
-        def yarn_get_mscale(scale=1, mscale=1):
+        def yarn_get_mscale(scale, mscale):
             if scale <= 1:
                 return 1.0
             return 0.1 * mscale * math.log(scale) + 1.0
@@ -4886,13 +4883,13 @@ class RopeEmbeddingUtils:
             if min == max:
                 max += 0.001  # Prevent singularity
 
-            linear_func = (np.arange(dim, dtype=dtype) - min) / (max - min)
-            ramp_func = np.clip(linear_func, 0, 1)
+            linear_func = (torch.arange(dim, dtype=dtype) - min) / (max - min)
+            ramp_func = torch.clamp(linear_func, 0, 1)
             return ramp_func
 
-        freq_extra = 1.0 / (base**(np.arange(0, dim, 2, dtype=dtype) / dim))
-        freq_inter = 1.0 / (scaling_factor *
-                            base**(np.arange(0, dim, 2, dtype=dtype) / dim))
+        pos_freqs = base**(torch.arange(0, dim, 2, dtype=dtype) / dim)
+        freq_extra = 1.0 / pos_freqs
+        freq_inter = 1.0 / (scaling_factor * pos_freqs)
 
         low, high = yarn_find_correction_range(
             beta_fast,
@@ -4901,28 +4898,23 @@ class RopeEmbeddingUtils:
             base,
             original_max_position_embeddings,
         )
-        inv_freq_mask = 1.0 - yarn_linear_ramp_mask(low, high,
-                                                    dim // 2).astype(dtype)
+        inv_freq_mask = (1 - yarn_linear_ramp_mask(low, high, dim // 2))
         inv_freq = freq_inter * (1 - inv_freq_mask) + freq_extra * inv_freq_mask
-        sinusoid_inp = np.expand_dims(np.einsum("i , j -> i j",
-                                                np.arange(num_pos, dtype=dtype),
-                                                inv_freq,
-                                                dtype=dtype),
-                                      axis=-1)
+        t = torch.arange(num_pos, dtype=dtype)
+        sinusoid_inp = torch.einsum("i,j -> ij", t, inv_freq).unsqueeze(-1)
 
         _mscale = float(
             yarn_get_mscale(scaling_factor, mscale) /
             yarn_get_mscale(scaling_factor, mscale_all_dim))
 
         if duplicate_data:
-            emb = np.concatenate((sinusoid_inp, sinusoid_inp), axis=-2)
+            emb = torch.cat((sinusoid_inp, sinusoid_inp), dim=-2)
         else:
             emb = sinusoid_inp
 
-        concat = np.concatenate((np.cos(emb) * _mscale, np.sin(emb) * _mscale),
-                                axis=-1)
-
-        return inv_freq, concat.reshape((1, -1)).astype(dtype)
+        concat = torch.cat((torch.cos(emb) * _mscale, torch.sin(emb) * _mscale),
+                           dim=-1)
+        return inv_freq.numpy(), concat.reshape((1, -1)).to(dtype).numpy()
 
     @staticmethod
     def rotate_every_two(tensor: Tensor) -> Tensor:


### PR DESCRIPTION
## Description

We've noticed a significant discrepancy in cos, sin embeddings from our current yarn implementation when compared to other implementations out there. This MR makes the following changes to address those:
1) Switch to torch from numpy. Surprisingly, this makes a non-trivial difference, especially cos-sin embeddings (comparison in test section). 
- The difference is quite pronounced for large values of base. Not too concerning for small values of base (like 10000).
- Also, torch handles large values of `base` well. Numpy complains like below:
```
  File "/usr/local/lib/python3.12/dist-packages/numpy/core/einsumfunc.py", line 1371, in einsum
    return c_einsum(*operands, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Iterator operand 1 dtype could not be cast from dtype('float64') to dtype('float32') according to the rule 'safe'
```
2) Remove default args for helper functions within the `create_sinusoidal_positions_yarn` function. This is just for sanity.

## Test Coverage

```
import torch
import numpy as np
import math

# Note: When not using deepseek_yarn, make sure to set mscale_all_dim to 0.0.
def create_sinusoidal_positions_yarn_old(
        num_pos: int,
        dim: int,
        base: int = 10000,
        scaling_factor: float = 1.0,
        original_max_position_embeddings: int = 4096,
        beta_fast: int = 32,
        beta_slow: int = 1,
        mscale: float = 1.0,
        mscale_all_dim: float = 1.0,
        duplicate_data: bool = True,
        dtype=torch.float32):

    # Copy from https://huggingface.co/deepseek-ai/DeepSeek-V2/blob/main/modeling_deepseek.py
    # Inverse dim formula to find dim based on number of rotations
    def yarn_find_correction_dim(num_rotations, dim, base,
                                    max_position_embeddings):
        return (dim * math.log(max_position_embeddings /
                                (num_rotations * 2 * math.pi))) / (
                                    2 * math.log(base))

    # Find dim range bounds based on rotations
    def yarn_find_correction_range(low_rot, high_rot, dim, base,
                                    max_position_embeddings):
        low = math.floor(
            yarn_find_correction_dim(low_rot, dim, base,
                                        max_position_embeddings))
        high = math.ceil(
            yarn_find_correction_dim(high_rot, dim, base,
                                        max_position_embeddings))
        if low < 0:
            low = 0
        if high > dim - 1:
            high = dim - 1
        return low, high  # Clamp values just in case

    def yarn_get_mscale(scale, mscale):
        if scale <= 1:
            return 1.0
        return 0.1 * mscale * math.log(scale) + 1.0

    def yarn_linear_ramp_mask(min, max, dim):
        if min == max:
            max += 0.001  # Prevent singularity

        linear_func = (torch.arange(dim, dtype=dtype) - min) / (max - min)
        ramp_func = torch.clamp(linear_func, 0, 1)
        return ramp_func

    pos_freqs = base**(torch.arange(0, dim, 2, dtype=dtype) / dim)
    freq_extra = 1.0 / pos_freqs
    freq_inter = 1.0 / (scaling_factor * pos_freqs)

    low, high = yarn_find_correction_range(
        beta_fast,
        beta_slow,
        dim,
        base,
        original_max_position_embeddings,
    )
    inv_freq_mask = (1 - yarn_linear_ramp_mask(low, high, dim // 2))
    inv_freq = freq_inter * (1 - inv_freq_mask) + freq_extra * inv_freq_mask
    t = torch.arange(num_pos, dtype=dtype)
    sinusoid_inp = torch.einsum("i,j -> ij", t, inv_freq).unsqueeze(-1)

    _mscale = float(
        yarn_get_mscale(scaling_factor, mscale) /
        yarn_get_mscale(scaling_factor, mscale_all_dim))

    if duplicate_data:
        emb = torch.cat((sinusoid_inp, sinusoid_inp), dim=-2)
    else:
        emb = sinusoid_inp

    concat = torch.cat((torch.cos(emb) * _mscale, torch.sin(emb) * _mscale),
                        dim=-1)
    return inv_freq.numpy(), concat.reshape((1, -1)).to(dtype).numpy()


def create_sinusoidal_positions_yarn(
        num_pos: int,
        dim: int,
        base: int = 10000,
        scaling_factor: float = 1.0,
        original_max_position_embeddings: int = 4096,
        beta_fast: int = 32,
        beta_slow: int = 1,
        mscale: float = 1.0,
        mscale_all_dim: float = 1.0,
        duplicate_data: bool = True,
        dtype=np.float32):

    # Copy from https://huggingface.co/deepseek-ai/DeepSeek-V2/blob/main/modeling_deepseek.py
    # Inverse dim formula to find dim based on number of rotations
    def yarn_find_correction_dim(num_rotations,
                                    dim,
                                    base=10000,
                                    max_position_embeddings=2048):
        return (dim * math.log(max_position_embeddings /
                                (num_rotations * 2 * math.pi))) / (
                                    2 * math.log(base))

    # Find dim range bounds based on rotations
    def yarn_find_correction_range(low_rot,
                                    high_rot,
                                    dim,
                                    base=10000,
                                    max_position_embeddings=2048):
        low = math.floor(
            yarn_find_correction_dim(low_rot, dim, base,
                                        max_position_embeddings))
        high = math.ceil(
            yarn_find_correction_dim(high_rot, dim, base,
                                        max_position_embeddings))
        if low < 0:
            low = 0
        if high > dim - 1:
            high = dim - 1
        return low, high  # Clamp values just in case

    def yarn_get_mscale(scale=1, mscale=1):
        if scale <= 1:
            return 1.0
        return 0.1 * mscale * math.log(scale) + 1.0

    def yarn_linear_ramp_mask(min, max, dim):
        if min == max:
            max += 0.001  # Prevent singularity

        linear_func = (np.arange(dim, dtype=dtype) - min) / (max - min)
        ramp_func = np.clip(linear_func, 0, 1)
        return ramp_func

    freq_extra = 1.0 / (base**(np.arange(0, dim, 2, dtype=dtype) / dim))
    freq_inter = 1.0 / (scaling_factor *
                        base**(np.arange(0, dim, 2, dtype=dtype) / dim))

    low, high = yarn_find_correction_range(
        beta_fast,
        beta_slow,
        dim,
        base,
        original_max_position_embeddings,
    )
    inv_freq_mask = 1.0 - yarn_linear_ramp_mask(low, high,
                                                dim // 2).astype(dtype)
    inv_freq = freq_inter * (1 - inv_freq_mask) + freq_extra * inv_freq_mask
    sinusoid_inp = np.expand_dims(np.einsum("i , j -> i j",
                                            np.arange(num_pos, dtype=dtype),
                                            inv_freq.astype(dtype),
                                            dtype=dtype),
                                    axis=-1)

    _mscale = float(
        yarn_get_mscale(scaling_factor, mscale) /
        yarn_get_mscale(scaling_factor, mscale_all_dim))

    if duplicate_data:
        emb = np.concatenate((sinusoid_inp, sinusoid_inp), axis=-2)
    else:
        emb = sinusoid_inp

    concat = np.concatenate((np.cos(emb) * _mscale, np.sin(emb) * _mscale),
                            axis=-1)

    return inv_freq, concat.reshape((1, -1)).astype(dtype)

if __name__=="__main__":
    beta_fast = 4.0
    beta_slow = 1.0
    mscale = 1.0
    mscale_all_dim = 0.0
    original_max_position_embeddings = 4096
    dim = 128
    base = 1000000
    scaling_factor = 64.0
    num_pos = 131072
    duplicate_data = False

    inv_freq_old, concat_old = create_sinusoidal_positions_yarn_old(num_pos, dim, base, scaling_factor, original_max_position_embeddings, beta_fast, beta_slow, mscale, mscale_all_dim, duplicate_data)
    inv_freq_new, concat_new = create_sinusoidal_positions_yarn(num_pos, dim, base, scaling_factor, original_max_position_embeddings, beta_fast, beta_slow, mscale, mscale_all_dim, duplicate_data)

    print("max diff inv_freq: ", np.max(np.abs(inv_freq_old - inv_freq_new)))
    print("mean diff inv_freq: ", np.mean(np.abs(inv_freq_old - inv_freq_new)))
    print("max diff concat: ", np.max(np.abs(concat_old - concat_new)))
    print("mean diff concat: ", np.mean(np.abs(concat_old - concat_new)))

    # max diff inv_freq:  4.2937981614699083e-08
    # mean diff inv_freq:  2.3346426545798974e-09
    # max diff concat:  0.0110615995
    # mean diff concat:  0.00015285572
```

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
