### PR TITLE
[fix][test] report individual unittests results to jenkins

### DIFF
--- a/tests/integration/defs/test_unittests.py
+++ b/tests/integration/defs/test_unittests.py
@@ -114,7 +114,7 @@ def test_unittests_v2(llm_root, llm_venv, case: str, output_dir):
     if len(case_fn) > 80:
         case_fn = case_fn[:80]
     output_xml = os.path.join(output_dir,
-                              f'sub-results-unittests-{case_fn}.xml')
+                              f'results-sub-unittests-{case_fn}.xml')
 
     command = [
         '-m',

--- a/tests/integration/defs/test_unittests.py
+++ b/tests/integration/defs/test_unittests.py
@@ -70,8 +70,11 @@ def test_unittests_v2(llm_root, llm_venv, case: str, output_dir, request):
     dry_run = False
     passed = True
 
-    nodeid = request.node.nodeid
-    test_prefix = nodeid.split('/')[0]
+    my_test_prefix = request.config.getoption("--test-prefix")
+    if my_test_prefix:
+        test_prefix = f"{my_test_prefix}/unittests"
+    else:
+        test_prefix = ""
 
     num_workers = 1
 
@@ -121,8 +124,10 @@ def test_unittests_v2(llm_root, llm_venv, case: str, output_dir, request):
 
     command = [
         '-m', 'pytest', ignore_opt, "-v", "--timeout=1600",
-        "--timeout-method=thread", f"--test-prefix={test_prefix}"
+        "--timeout-method=thread"
     ]
+    if test_prefix:
+        command += [f"--test-prefix={test_prefix}"]
 
     if dry_run:
         command += ['--collect-only']

--- a/tests/integration/defs/test_unittests.py
+++ b/tests/integration/defs/test_unittests.py
@@ -61,7 +61,7 @@ def merge_report(base_file, extra_file, output_file, is_retry=False):
     base.write(output_file, encoding="UTF-8", xml_declaration=True)
 
 
-def test_unittests_v2(llm_root, llm_venv, case: str, output_dir):
+def test_unittests_v2(llm_root, llm_venv, case: str, output_dir, request):
     import pandas as pd
     import pynvml
     pynvml.nvmlInit()
@@ -69,6 +69,9 @@ def test_unittests_v2(llm_root, llm_venv, case: str, output_dir):
     test_root = tests_path()
     dry_run = False
     passed = True
+
+    nodeid = request.node.nodeid
+    test_prefix = nodeid.split('/')[0]
 
     num_workers = 1
 
@@ -117,12 +120,8 @@ def test_unittests_v2(llm_root, llm_venv, case: str, output_dir):
                               f'results-sub-unittests-{case_fn}.xml')
 
     command = [
-        '-m',
-        'pytest',
-        ignore_opt,
-        "-v",
-        "--timeout=1600",
-        "--timeout-method=thread",
+        '-m', 'pytest', ignore_opt, "-v", "--timeout=1600",
+        "--timeout-method=thread", f"--test-prefix={test_prefix}"
     ]
 
     if dry_run:

--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -48,3 +48,28 @@ def pytest_runtest_protocol(item, nextitem):
 
                 torch.cuda.empty_cache()
             break
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--test-prefix",
+        "-P",
+        action="store",
+        default=None,
+        help=
+        "Prepend a prefix to the test names. Useful for distinguishing different test runs in a test report."
+    )
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_collection_modifyitems(session, config, items):
+    test_prefix = config.getoption("--test-prefix")
+
+    yield
+
+    if test_prefix:
+        # Override the internal nodeid of each item to contain the correct test prefix.
+        # This is needed for reporting to correctly process the test name in order to bucket
+        # it into the appropriate test suite.
+        for item in items:
+            item._nodeid = f"{test_prefix}/{item._nodeid}"


### PR DESCRIPTION
# Report individual unittests results to jenkins

This PR changes the name of the JUnit report created by `test_unittests_v2` so it will be picked up by Jenkins' JUnit plugin.
This will provide visibility into individual unittest runs, and will be useful for the engineering baseline efforts.