### PR TITLE
[TRTLLM-5278][feat] Add attention dp support to MTP relaxed acceptance

### DIFF
--- a/examples/models/core/deepseek_v3/README.md
+++ b/examples/models/core/deepseek_v3/README.md
@@ -124,10 +124,6 @@ When verifying and receiving draft tokens, there are two ways:
   python quickstart_advanced.py --model_dir <YOUR_MODEL_DIR> --spec_decode_algo MTP --spec_decode_nextn N --use_relaxed_acceptance_for_thinking --relaxed_topk 15 --relaxed_delta 0.5
   ```
 
-  Note: There are still compatibility issues between relaxed acceptance and attention_dp. These two flags cannot be enabled at the same time for now.
-
-
-
 ### Long context support
 DeepSeek-V3 model can support up to 128k context length. The following shows how to benchmark 64k and 128k input_seq_length using trtllm-bench on B200.
 To avoid OOM (out of memory) error, you need to adjust the values of "--max_batch_size", "--max_num_tokens" and "--kv_cache_free_gpu_mem_fraction".

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1508,6 +1508,10 @@ class PyExecutor:
                 max_num_draft_tokens=self.max_draft_tokens,
             )[0]
             llm_request.is_attention_dp_dummy = True
+            spec_resource_manager = self.resource_manager.get_resource_manager(
+                'spec_resource_manager')
+            if spec_resource_manager is not None:
+                spec_resource_manager.add_dummy_requests([0])
             self.active_requests.append(llm_request)
 
     @nvtx_range("_prepare_disagg_gen_init")

--- a/tests/integration/defs/test_e2e.py
+++ b/tests/integration/defs/test_e2e.py
@@ -1803,11 +1803,10 @@ def test_relaxed_acceptance_quickstart_advanced_deepseek_r1_8gpus(
             "--use_relaxed_acceptance_for_thinking",
             "--relaxed_topk=10",
             "--relaxed_delta=0.5",
+            "--enable_attention_dp",
         ],
                          stdout=running_log)
         _check_mem_usage(running_log, [85.6, 0, 0, 0], 8)
-    # TODO: relaxed acceptance is incompatible with attention dp
-    # "--enable_attention_dp"
 
 
 @pytest.mark.skip_less_device_memory(80000)


### PR DESCRIPTION
## Description

- Fixed by adding those attention dp dummy requests to the spec decoding manager.

## Test Coverage

Add `--enable_attention_dp` to test_e2e.py::test_relaxed_acceptance_quickstart_advanced_deepseek_r1_8gpus[DeepSeek-R1-DeepSeek-R1/DeepSeek-R1]