### PR TITLE
[fix][test] clear cuda cache before unittests automatically

### DIFF
--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 # # Force resource release after test
 import pytest
+import torch
 import tqdm
 
 
@@ -79,3 +80,12 @@ def pytest_sessionstart(session):
     # To counter TransformerEngine v2.3's lazy_compile deferral,
     # which will cause Pytest thinks there's a thread leakage.
     import torch._inductor.async_compile  # noqa: F401
+
+
+@pytest.fixture(autouse=True)
+def torch_empty_cache() -> None:
+    """
+    Automatically empty the torch CUDA cache before each test, to reduce risk of OOM errors.
+    """
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()


### PR DESCRIPTION
# Clear torch CUDA cache before unittests

We've encountered a case in which a test failed due to OOM errors, that were resolved by adding `torch.cuda.empty_cache` at the start of the test. This PR adds this to all unittests, so each one starts with an empty torch cuda cache and can make full use of the available device memory.