### PR TITLE
feat: Support post_proc for bench

### DIFF
--- a/tensorrt_llm/bench/benchmark/low_latency.py
+++ b/tensorrt_llm/bench/benchmark/low_latency.py
@@ -218,6 +218,7 @@ def latency_command(
             n=beam_width,
             use_beam_search=beam_width > 1,
         )
+        post_proc_params = None  # No detokenization
         llm = LLM(**kwargs)
 
         # Perform warmup if requested.
@@ -226,8 +227,8 @@ def latency_command(
             warmup_dataset = generate_warmup_dataset(requests, warmup)
             logger.info("Running warmup.")
             asyncio.run(
-                async_benchmark(llm, sampling_params, warmup_dataset, False,
-                                concurrency))
+                async_benchmark(llm, sampling_params, post_proc_params,
+                                warmup_dataset, False, concurrency))
             # WAR: IterationResult is a singleton tied to the executor.
             # Since the benchmark calls asyncio.run() multiple times (e.g., during warmup),
             # we must reset it to ensure it attaches to the correct event loop.
@@ -236,8 +237,9 @@ def latency_command(
 
         with iteration_writer.capture():
             statistics = asyncio.run(
-                async_benchmark(llm, sampling_params, requests, True,
-                                concurrency, iteration_writer.full_address))
+                async_benchmark(llm, sampling_params, post_proc_params,
+                                requests, True, concurrency,
+                                iteration_writer.full_address))
 
         logger.info(f"Benchmark done. Reporting results...")
         report_utility = ReportUtility(statistics, metadata, runtime_config,

--- a/tensorrt_llm/bench/benchmark/throughput.py
+++ b/tensorrt_llm/bench/benchmark/throughput.py
@@ -25,7 +25,6 @@ from tensorrt_llm.bench.dataclasses.reporting import ReportUtility
 from tensorrt_llm.bench.utils.data import (create_dataset_from_stream,
                                            initialize_tokenizer,
                                            update_metadata_for_multimodal)
-from tensorrt_llm.executor.postproc_worker import PostprocArgs
 from tensorrt_llm.llmapi import LLM, CapacitySchedulerPolicy
 from tensorrt_llm.logger import logger
 from tensorrt_llm.sampling_params import SamplingParams
@@ -369,7 +368,7 @@ def throughput_command(
                                          pad_id=eos_id,
                                          n=beam_width,
                                          use_beam_search=beam_width > 1)
-        post_proc_params = None # No detokenization
+        post_proc_params = None  # No detokenization
 
         # Perform warmup if requested.
         if warmup > 0:

--- a/tensorrt_llm/bench/benchmark/throughput.py
+++ b/tensorrt_llm/bench/benchmark/throughput.py
@@ -369,11 +369,7 @@ def throughput_command(
                                          pad_id=eos_id,
                                          n=beam_width,
                                          use_beam_search=beam_width > 1)
-        post_proc_args = PostprocArgs(tokenizer=checkpoint_path)
-        # post_proc_params = PostprocParams(
-        #     post_processor=None,
-        #     postproc_args=post_proc_args)
-        post_proc_params = None
+        post_proc_params = None # No detokenization
 
         # Perform warmup if requested.
         if warmup > 0:

--- a/tensorrt_llm/bench/benchmark/throughput.py
+++ b/tensorrt_llm/bench/benchmark/throughput.py
@@ -25,6 +25,7 @@ from tensorrt_llm.bench.dataclasses.reporting import ReportUtility
 from tensorrt_llm.bench.utils.data import (create_dataset_from_stream,
                                            initialize_tokenizer,
                                            update_metadata_for_multimodal)
+from tensorrt_llm.executor.postproc_worker import PostprocArgs
 from tensorrt_llm.llmapi import LLM, CapacitySchedulerPolicy
 from tensorrt_llm.logger import logger
 from tensorrt_llm.sampling_params import SamplingParams
@@ -368,6 +369,11 @@ def throughput_command(
                                          pad_id=eos_id,
                                          n=beam_width,
                                          use_beam_search=beam_width > 1)
+        post_proc_args = PostprocArgs(tokenizer=checkpoint_path)
+        # post_proc_params = PostprocParams(
+        #     post_processor=None,
+        #     postproc_args=post_proc_args)
+        post_proc_params = None
 
         # Perform warmup if requested.
         if warmup > 0:
@@ -377,6 +383,7 @@ def throughput_command(
             asyncio.run(
                 async_benchmark(llm,
                                 sampling_params,
+                                post_proc_params,
                                 warmup_dataset,
                                 False,
                                 concurrency,
@@ -391,6 +398,7 @@ def throughput_command(
             statistics = asyncio.run(
                 async_benchmark(llm,
                                 sampling_params,
+                                post_proc_params,
                                 requests,
                                 streaming,
                                 concurrency,

--- a/tensorrt_llm/bench/benchmark/utils/asynchronous.py
+++ b/tensorrt_llm/bench/benchmark/utils/asynchronous.py
@@ -12,6 +12,7 @@ from zmq.asyncio import Context
 from tensorrt_llm import LLM, SamplingParams
 from tensorrt_llm.bench.dataclasses.general import InferenceRequest
 from tensorrt_llm.bench.dataclasses.reporting import PerfItemTuple, StatsKeeper
+from tensorrt_llm.executor.postproc_worker import PostprocParams
 from tensorrt_llm.llmapi.llm import RequestOutput
 from tensorrt_llm.logger import logger
 
@@ -42,7 +43,8 @@ class LlmManager:
         self.modality = modality
 
     async def process_request(self, request: InferenceRequest,
-                              sampling_params: SamplingParams):
+                              sampling_params: SamplingParams,
+                              post_proc_params: PostprocParams):
         # Set up sampling params with inference request
         self.request_seen.set()
         sampling_params.max_tokens = request.output_tokens
@@ -54,6 +56,7 @@ class LlmManager:
             output: RequestOutput = self.llm.generate_async(
                 request.input_ids if self.modality is None else request.prompt,
                 sampling_params=sampling_params,
+                _postproc_params=post_proc_params,
                 streaming=self.streaming)
             if self.streaming:
                 async for stream_output in output:
@@ -86,10 +89,12 @@ class LlmManager:
     async def worker(self) -> None:
         while not self._stop.is_set():
             try:
-                request, sampling_params = await self._inbox.get()
+                request, sampling_params, post_proc_params = await self._inbox.get(
+                )
                 task = asyncio.create_task(
                     self.process_request(request,
-                                         sampling_params=sampling_params))
+                                         sampling_params=sampling_params,
+                                         post_proc_params=post_proc_params))
                 self._tasks.add(task)
                 task.add_done_callback(self._tasks.discard)
             except asyncio.CancelledError:
@@ -164,8 +169,9 @@ class LlmManager:
                 self.iteration_worker(iteration_addr))
 
     async def enqueue(self, request: InferenceRequest,
-                      sampling_params: SamplingParams) -> None:
-        await self._inbox.put((request, sampling_params))
+                      sampling_params: SamplingParams,
+                      post_proc_params: PostprocParams) -> None:
+        await self._inbox.put((request, sampling_params, post_proc_params))
 
 
 @asynccontextmanager
@@ -182,11 +188,12 @@ async def semaphore_guard(semaphore: Optional[asyncio.Semaphore] = None):
 async def enqueue_messages(backend: LlmManager,
                            requests: List[InferenceRequest],
                            sampling_params: SamplingParams,
+                           post_proc_params: PostprocParams,
                            submit_finished: asyncio.Event) -> None:
     num_requests = 0
     submit_start = time.perf_counter_ns()
     for request in requests:
-        await backend.enqueue(request, sampling_params)
+        await backend.enqueue(request, sampling_params, post_proc_params)
         num_requests += 1
     submit_time = (time.perf_counter_ns() - submit_start) * 1.0e-9
     logger.info(
@@ -199,6 +206,7 @@ async def enqueue_messages(backend: LlmManager,
 async def async_benchmark(
     llm: LLM,
     sampling_params: SamplingParams,
+    post_proc_params: PostprocParams,
     requests: List[InferenceRequest],
     streaming: bool,
     concurrency: int = -1,
@@ -220,7 +228,7 @@ async def async_benchmark(
 
         enqueue_task = asyncio.create_task(
             enqueue_messages(backend, requests, sampling_params,
-                             submit_finished))
+                             post_proc_params, submit_finished))
 
         logger.info("Starting benchmark...")
         while not submit_finished.is_set() or backend.busy or not outbox.empty(

--- a/tensorrt_llm/executor/postproc_worker.py
+++ b/tensorrt_llm/executor/postproc_worker.py
@@ -111,7 +111,6 @@ class PostprocWorker:
     ) -> "DetokenizedGenerationResultBase":
         from .result import DetokenizedGenerationResultBase
         assert inp.sampling_params is not None
-        assert tokenizer is not None
         return DetokenizedGenerationResultBase(
             inp.rsp.client_id,
             sampling_params=inp.sampling_params,

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -19,7 +19,7 @@ from ..llmapi.utils import (AsyncQueue, ManagedThread, _SyncQueue,
                             print_colored, print_colored_debug)
 from .executor import GenerationExecutor
 from .ipc import FusedIpcQueue, IpcQueue
-from .postproc_worker import PostprocWorkerConfig
+from .postproc_worker import PostprocWorker, PostprocWorkerConfig
 from .request import CancellingRequest, GenerationRequest
 from .result import GenerationResult, IterationResult
 from .utils import (ErrorResponse, IntraProcessQueue, WorkerCommIpcAddrs,

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -19,7 +19,7 @@ from ..llmapi.utils import (AsyncQueue, ManagedThread, _SyncQueue,
                             print_colored, print_colored_debug)
 from .executor import GenerationExecutor
 from .ipc import FusedIpcQueue, IpcQueue
-from .postproc_worker import PostprocWorker, PostprocWorkerConfig
+from .postproc_worker import PostprocWorkerConfig
 from .request import CancellingRequest, GenerationRequest
 from .result import GenerationResult, IterationResult
 from .utils import (ErrorResponse, IntraProcessQueue, WorkerCommIpcAddrs,

--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -685,7 +685,6 @@ def worker_main(
             str, Optional[bytes]] = worker_queues.result_queue_addr
 
         assert result_queues is not None
-        assert postproc_worker_config.postprocess_tokenizer_dir is not None
         postproc_worker_pool = ProcessPoolExecutor(
             max_workers=postproc_worker_config.num_postprocess_workers)
         assert isinstance(proxy_result_queue, tuple)

--- a/tests/integration/defs/test_e2e.py
+++ b/tests/integration/defs/test_e2e.py
@@ -676,7 +676,8 @@ def temp_extra_llm_api_options_file(request):
                 "kv_cache_config": {
                     "enable_block_reuse": False,
                     "max_tokens": 40000
-                }
+                },
+                "_num_postprocess_workers": 2,
             }
 
             pytorch_backend_config = {}


### PR DESCRIPTION
This allows users to set the following field in `extra-llm-api-config.yml` to enable a (experimental) feature called multiple post-processing worker, to reduce the main process pressure by splitting the post-processing to other processes.
```
_num_postprocess_workers: 2
```