### PR TITLE
CacheState fix for disabled DP

### DIFF
--- a/cpp/include/tensorrt_llm/executor/dataTransceiverState.h
+++ b/cpp/include/tensorrt_llm/executor/dataTransceiverState.h
@@ -52,7 +52,9 @@ public:
         AttentionType attentionType = AttentionType::kDEFAULT, int kvFactor = 2)
         : mModelConfig(std::move(modelConfig))
         , mParallelConfig{worldConfig.getTensorParallelism(), worldConfig.getPipelineParallelism(),
-              worldConfig.enableAttentionDP(), worldConfig.getTensorParallelRank(), worldConfig.getTensorParallelism()}
+              worldConfig.enableAttentionDP(),
+              worldConfig.enableAttentionDP() ? worldConfig.getTensorParallelRank() : 0,
+              worldConfig.enableAttentionDP() ? worldConfig.getTensorParallelism() : 0}
         , mDataType{dataType}
         , mAttentionConfig(attentionType, kvFactor)
     {
@@ -63,7 +65,8 @@ public:
         AttentionType attentionType = AttentionType::kDEFAULT, int kvFactor = 2, bool enableAttentionDP = false,
         int DPrank = 0, int DPsize = 0)
         : mModelConfig{std::move(nbKvHeadPerLayer), sizePerHead, tokensPerBlock}
-        , mParallelConfig{tensorParallelism, pipelineParallelism, enableAttentionDP, DPrank, DPsize}
+        , mParallelConfig{tensorParallelism, pipelineParallelism, enableAttentionDP, enableAttentionDP ? DPrank : 0,
+              enableAttentionDP ? DPsize : 0}
         , mDataType{dataType}
         , mAttentionConfig(attentionType, kvFactor)
     {


### PR DESCRIPTION
TRTLLM_TRY_ZCOPY_FOR_KVCACHE_TRANSFER does't [work properly](https://github.com/NVIDIA/TensorRT-LLM/blob/ddfe4fceb3e9bc7ed5ec47635e98441cc0b6885f/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp#L450) since with disabled DP prefill and decoder workers had different DPrank

