### PR TITLE
[nvbug 5333996 ][fix] Unload XQA cubins early to avoid static lifetime

### DIFF
--- a/cpp/tensorrt_llm/common/cudaDriverWrapper.cpp
+++ b/cpp/tensorrt_llm/common/cudaDriverWrapper.cpp
@@ -81,6 +81,12 @@ CUDADriverWrapper::CUDADriverWrapper()
     *reinterpret_cast<void**>(&_cuLinkCreate) = load_sym(handle, "cuLinkCreate_v2");
     *reinterpret_cast<void**>(&_cuModuleGetFunction) = load_sym(handle, "cuModuleGetFunction");
     *reinterpret_cast<void**>(&_cuModuleGetGlobal) = load_sym(handle, "cuModuleGetGlobal_v2");
+    *reinterpret_cast<void**>(&_cuLibraryGetKernel) = load_sym(handle, "cuLibraryGetKernel");
+    *reinterpret_cast<void**>(&_cuLibraryLoadData) = load_sym(handle, "cuLibraryLoadData");
+    *reinterpret_cast<void**>(&_cuLibraryGetGlobal) = load_sym(handle, "cuLibraryGetGlobal");
+    *reinterpret_cast<void**>(&_cuLibraryUnload) = load_sym(handle, "cuLibraryUnload");
+    *reinterpret_cast<void**>(&_cuKernelSetAttribute) = load_sym(handle, "cuKernelSetAttribute");
+    *reinterpret_cast<void**>(&_cuCtxGetDevice) = load_sym(handle, "cuCtxGetDevice");
     *reinterpret_cast<void**>(&_cuLinkAddFile) = load_sym(handle, "cuLinkAddFile_v2");
     *reinterpret_cast<void**>(&_cuLinkAddData) = load_sym(handle, "cuLinkAddData_v2");
     *reinterpret_cast<void**>(&_cuLaunchCooperativeKernel) = load_sym(handle, "cuLaunchCooperativeKernel");
@@ -146,6 +152,41 @@ CUresult CUDADriverWrapper::cuModuleGetFunction(CUfunction* hfunc, CUmodule hmod
 CUresult CUDADriverWrapper::cuModuleGetGlobal(CUdeviceptr* dptr, size_t* bytes, CUmodule hmod, char const* name) const
 {
     return (*_cuModuleGetGlobal)(dptr, bytes, hmod, name);
+}
+
+CUresult CUDADriverWrapper::cuLibraryGetKernel(CUkernel* pKernel, CUlibrary library, char const* name) const
+{
+    return (*_cuLibraryGetKernel)(pKernel, library, name);
+}
+
+CUresult CUDADriverWrapper::cuLibraryLoadData(CUlibrary* library, void const* code, CUjit_option* jitOptions,
+    void** jitOptionsValues, unsigned int numJitOptions, CUlibraryOption* libraryOptions, void** libraryOptionValues,
+    unsigned int numLibraryOptions) const
+{
+    return (*_cuLibraryLoadData)(library, code, jitOptions, jitOptionsValues, numJitOptions, libraryOptions,
+        libraryOptionValues, numLibraryOptions);
+}
+
+CUresult CUDADriverWrapper::cuLibraryGetGlobal(
+    CUdeviceptr* dptr, size_t* bytes, CUlibrary library, char const* name) const
+{
+    return (*_cuLibraryGetGlobal)(dptr, bytes, library, name);
+}
+
+CUresult CUDADriverWrapper::cuLibraryUnload(CUlibrary library) const
+{
+    return (*_cuLibraryUnload)(library);
+}
+
+CUresult CUDADriverWrapper::cuKernelSetAttribute(
+    CUfunction_attribute attrib, int val, CUkernel kernel, CUdevice dev) const
+{
+    return (*_cuKernelSetAttribute)(attrib, val, kernel, dev);
+}
+
+CUresult CUDADriverWrapper::cuCtxGetDevice(CUdevice* device) const
+{
+    return (*_cuCtxGetDevice)(device);
 }
 
 CUresult CUDADriverWrapper::cuLinkAddFile(CUlinkState state, CUjitInputType type, char const* path,

--- a/cpp/tensorrt_llm/common/cudaDriverWrapper.h
+++ b/cpp/tensorrt_llm/common/cudaDriverWrapper.h
@@ -60,6 +60,20 @@ public:
 
     CUresult cuModuleGetGlobal(CUdeviceptr* dptr, size_t* bytes, CUmodule hmod, char const* name) const;
 
+    CUresult cuLibraryGetKernel(CUkernel* pKernel, CUlibrary library, char const* name) const;
+
+    CUresult cuLibraryLoadData(CUlibrary* library, void const* code, CUjit_option* jitOptions, void** jitOptionsValues,
+        unsigned int numJitOptions, CUlibraryOption* libraryOptions, void** libraryOptionValues,
+        unsigned int numLibraryOptions) const;
+
+    CUresult cuLibraryGetGlobal(CUdeviceptr* dptr, size_t* bytes, CUlibrary library, char const* name) const;
+
+    CUresult cuLibraryUnload(CUlibrary library) const;
+
+    CUresult cuKernelSetAttribute(CUfunction_attribute attrib, int val, CUkernel kernel, CUdevice dev) const;
+
+    CUresult cuCtxGetDevice(CUdevice* device) const;
+
     CUresult cuLinkAddFile(CUlinkState state, CUjitInputType type, char const* path, unsigned int numOptions,
         CUjit_option* options, void** optionValues) const;
 
@@ -101,6 +115,13 @@ private:
     CUresult (*_cuModuleLoadData)(CUmodule*, void const*);
     CUresult (*_cuModuleGetFunction)(CUfunction*, CUmodule, char const*);
     CUresult (*_cuModuleGetGlobal)(CUdeviceptr*, size_t*, CUmodule, char const*);
+    CUresult (*_cuLibraryGetKernel)(CUkernel*, CUlibrary, char const*);
+    CUresult (*_cuLibraryLoadData)(
+        CUlibrary*, void const*, CUjit_option*, void**, unsigned int, CUlibraryOption*, void**, unsigned int);
+    CUresult (*_cuLibraryGetGlobal)(CUdeviceptr*, size_t*, CUlibrary, char const*);
+    CUresult (*_cuLibraryUnload)(CUlibrary);
+    CUresult (*_cuKernelSetAttribute)(CUfunction_attribute attrib, int val, CUkernel kernel, CUdevice dev);
+    CUresult (*_cuCtxGetDevice)(CUdevice* device);
     CUresult (*_cuLinkAddFile)(CUlinkState, CUjitInputType, char const*, unsigned int, CUjit_option*, void**);
     CUresult (*_cuLinkAddData)(
         CUlinkState, CUjitInputType, void*, size_t, char const*, unsigned int, CUjit_option*, void**);

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplCommon.h
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplCommon.h
@@ -308,12 +308,12 @@ void buildXQALaunchParams(XQALaunchParam<KVCacheBuffer>& launchParams, void*& in
 }
 
 template <typename T>
-std::optional<T> getGlobalVar(std::shared_ptr<tensorrt_llm::common::CUDADriverWrapper> const& driver, CUmodule hmod,
+std::optional<T> getGlobalVar(std::shared_ptr<tensorrt_llm::common::CUDADriverWrapper> const& driver, CUlibrary lib,
     char const* const name, bool required = false)
 {
     T* pVar = nullptr;
     size_t size = 0;
-    auto const error = driver->cuModuleGetGlobal(reinterpret_cast<CUdeviceptr*>(&pVar), &size, hmod, name);
+    auto const error = driver->cuLibraryGetGlobal(reinterpret_cast<CUdeviceptr*>(&pVar), &size, lib, name);
     T ret;
     switch (error)
     {

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/cubinObj.h
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/cubinObj.h
@@ -58,12 +58,17 @@ public:
         return mInitialized;
     }
 
-    XQAKernelType getKernelType() const
+    [[nodiscard]] XQAKernelType getKernelType() const
     {
         return mKernelType;
     }
 
 private:
+    [[nodiscard]] CUfunction kernel() const
+    {
+        return reinterpret_cast<CUfunction>(mKernel);
+    }
+
     static constexpr char const* kFuncName = "kernel_mha";
     static constexpr char const* kSmemName = "smemSize";
     static constexpr char const* kKernelTypeName = "kernelType";
@@ -73,8 +78,8 @@ private:
     // Fields below are undefined prior to initialize() call.
     bool mInitialized;
     std::shared_ptr<tensorrt_llm::common::CUDADriverWrapper> mDriver;
-    CUmodule mModule;
-    CUfunction mFunction;
+    CUlibrary mLibrary;
+    CUkernel mKernel;
     unsigned int mSharedMemBytes;
     XQAKernelType mKernelType;
 };

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/decoderXQAImplJIT.h
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/decoderXQAImplJIT.h
@@ -28,6 +28,8 @@ namespace tensorrt_llm
 namespace kernels
 {
 
+class DecoderXQARunnerResource;
+
 class DecoderXQAImplJIT : public DecoderXQAImpl
 {
 public:
@@ -46,6 +48,7 @@ protected:
 
 private:
     std::shared_ptr<tensorrt_llm::common::CUDADriverWrapper> mDriver;
+    std::shared_ptr<DecoderXQARunnerResource> mResource;
 
     //! Whether DecoderXQAImplJIT supports xqaParams.
     bool supportConfig(XQAParams const& xqaParams, bool forConfigurePlugin) const;

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQARunner.h
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQARunner.h
@@ -69,6 +69,8 @@ struct XQADispatchHelper<__nv_bfloat16, KVBlockArray>
 };
 #endif
 
+class DecoderXQARunnerResource;
+
 class DecoderXQARunner
 {
 public:
@@ -95,8 +97,7 @@ public:
         this->run(xqa_params, kv_cache_buffer, stream);
     }
 
-    class Resource;
-    static Resource* getResourceGlobal();
+    static std::shared_ptr<DecoderXQARunnerResource> getResourceGlobal();
 
 private:
     void prepareForRun(XQAParams const& xqa_params);
@@ -120,20 +121,20 @@ private:
     friend DecoderXQAImplJIT;
 };
 
-class DecoderXQARunner::Resource
+class DecoderXQARunnerResource
 {
 public:
-    Resource();
-    Resource(Resource const& other);
-    Resource& operator=(Resource const& other);
-    Resource(Resource&& other) = default;
-    Resource& operator=(Resource&& other) = default;
+    DecoderXQARunnerResource();
+    DecoderXQARunnerResource(DecoderXQARunnerResource const& other);
+    DecoderXQARunnerResource& operator=(DecoderXQARunnerResource const& other);
+    DecoderXQARunnerResource(DecoderXQARunnerResource&& other) = default;
+    DecoderXQARunnerResource& operator=(DecoderXQARunnerResource&& other) = default;
     // Construct from a serialized buffer.
-    Resource(void const* buffer, size_t buffer_size);
-    ~Resource() = default;
+    DecoderXQARunnerResource(void const* buffer, size_t buffer_size);
+    ~DecoderXQARunnerResource() = default;
 
     // When initialize is true, initialize cubins.
-    void merge(Resource const& other, bool initialize)
+    void merge(DecoderXQARunnerResource const& other, bool initialize)
     {
         getCubinObjRegistry()->merge(*other.getCubinObjRegistry(), initialize);
     }

--- a/cpp/tensorrt_llm/plugins/gptAttentionCommon/gptAttentionCommon.h
+++ b/cpp/tensorrt_llm/plugins/gptAttentionCommon/gptAttentionCommon.h
@@ -26,6 +26,11 @@
 #include <string>
 #include <vector>
 
+namespace tensorrt_llm::kernels
+{
+class DecoderXQARunnerResource;
+}
+
 namespace tensorrt_llm::plugins
 {
 
@@ -84,6 +89,9 @@ public:
 
 protected:
     std::string const mLayerName;
+
+private:
+    std::shared_ptr<tensorrt_llm::kernels::DecoderXQARunnerResource> mResource;
 };
 
 class GPTAttentionPluginCreatorCommon : public BaseCreator


### PR DESCRIPTION
Previously they were incorrectly managed by a static variable. So unloading could happen after cuda context destroy and can cause problems. This change use observer to manage them, and unload happens when the last user is destroyed.

Also switch to context-less loading APIs, so it's safe to switch cuda context for users.