### PR TITLE
[fix] Fixes building TRTLLM wheel with NIXL

### DIFF
--- a/docker/Dockerfile.multi
+++ b/docker/Dockerfile.multi
@@ -68,6 +68,14 @@ ARG TORCH_INSTALL_TYPE="skip"
 COPY docker/common/install_pytorch.sh install_pytorch.sh
 RUN bash ./install_pytorch.sh $TORCH_INSTALL_TYPE && rm install_pytorch.sh
 
+# Install NIXL
+COPY docker/common/install_nixl.sh install_nixl.sh
+RUN bash ./install_nixl.sh && rm install_nixl.sh
+
+# Install etcd
+COPY docker/common/install_etcd.sh install_etcd.sh
+RUN bash ./install_etcd.sh && rm install_etcd.sh
+
 # Install OpenCV with FFMPEG support
 RUN pip3 uninstall -y opencv && rm -rf /usr/local/lib/python3*/dist-packages/cv2/
 RUN pip3 install opencv-python-headless --force-reinstall --no-deps --no-cache-dir
@@ -92,14 +100,6 @@ COPY --from=triton /opt/tritonserver/bin /opt/tritonserver/bin
 COPY --from=triton /opt/tritonserver/caches /opt/tritonserver/caches
 COPY docker/common/install_triton.sh install_triton.sh
 RUN bash ./install_triton.sh && rm install_triton.sh
-
-# Install NIXL
-COPY docker/common/install_nixl.sh install_nixl.sh
-RUN bash ./install_nixl.sh && rm install_nixl.sh
-
-# Install etcd
-COPY docker/common/install_etcd.sh install_etcd.sh
-RUN bash ./install_etcd.sh && rm install_etcd.sh
 
 
 FROM ${DEVEL_IMAGE} AS wheel


### PR DESCRIPTION
## Description

Building TRTLLM wheel with NIXL support would fail. This change ensure that NIXL is installed in devel container before the wheel stage is triggered. 

## Test Coverage

### Before

`make -C docker wheel_build BUILD_WHEEL_OPTS='--extra-cmake-vars NIXL_ROOT=/opt/nvidia/nvda_nixl'`

```
102.0 CMake Error at /usr/local/cmake-3.30.2-linux-x86_64/share/cmake-3.30/Modules/FindPackageHandleStandardArgs.cmake:233 (message):
102.0   Could NOT find NIXL (missing: NIXL_INCLUDE_DIR NIXL_LIBRARY
102.0   NIXL_BUILD_LIBRARY SERDES_LIBRARY)
102.0 Call Stack (most recent call first):
102.0   /usr/local/cmake-3.30.2-linux-x86_64/share/cmake-3.30/Modules/FindPackageHandleStandardArgs.cmake:603 (_FPHSA_FAILURE_MESSAGE)
102.0   cmake/modules/FindNIXL.cmake:47 (find_package_handle_standard_args)
102.0   tensorrt_llm/executor/cache_transmission/nixl_utils/CMakeLists.txt:20 (find_package)
102.0 
102.0 
102.0 -- Configuring incomplete, errors occurred!
102.0 Traceback (most recent call last):
102.0   File "/src/tensorrt_llm/scripts/build_wheel.py", line 796, in <module>
102.0 -- Using virtual environment at: /src/tensorrt_llm/.venv-3.12 (Python 3.12)
102.0 -- Ensuring virtualenv version >=20.29.1,<22.0 is installed...
102.0 -- Creating virtual environment in /src/tensorrt_llm/.venv-3.12...
102.0 -- Installing requirements from /src/tensorrt_llm/requirements-dev.txt into /src/tensorrt_llm/.venv-3.12...
102.0 -- Found conan executable at: /src/tensorrt_llm/.venv-3.12/bin/conan
102.0 CMake Configure command: 
102.0 cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_PYT="ON" -DBUILD_PYBIND="ON" -DNVTX_DISABLE="ON" -DBUILD_MICRO_BENCHMARKS=OFF -DBUILD_WHEEL_TARGETS="tensorrt_llm;nvinfer_plugin_tensorrt_llm;bindings;th_common;benchmarks;executorWorker" -DPython_EXECUTABLE=/src/tensorrt_llm/.venv-3.12/bin/python3 -DPython3_EXECUTABLE=/src/tensorrt_llm/.venv-3.12/bin/python3  "-DNIXL_ROOT=/opt/nvidia/nvda_nixl" -DTensorRT_ROOT=/usr/local/tensorrt -DCMAKE_TOOLCHAIN_FILE=/src/tensorrt_llm/cpp/build/conan/conan_toolchain.cmake  -S "/src/tensorrt_llm/cpp"
102.0     main(**vars(args))
102.0   File "/src/tensorrt_llm/scripts/build_wheel.py", line 462, in main
102.0     build_run(cmake_configure_command)
102.0   File "/usr/lib/python3.12/subprocess.py", line 571, in run
102.0     raise CalledProcessError(retcode, process.args,
102.0 subprocess.CalledProcessError: Command 'cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_PYT="ON" -DBUILD_PYBIND="ON" -DNVTX_DISABLE="ON" -DBUILD_MICRO_BENCHMARKS=OFF -DBUILD_WHEEL_TARGETS="tensorrt_llm;nvinfer_plugin_tensorrt_llm;bindings;th_common;benchmarks;executorWorker" -DPython_EXECUTABLE=/src/tensorrt_llm/.venv-3.12/bin/python3 -DPython3_EXECUTABLE=/src/tensorrt_llm/.venv-3.12/bin/python3  "-DNIXL_ROOT=/opt/nvidia/nvda_nixl" -DTensorRT_ROOT=/usr/local/tensorrt -DCMAKE_TOOLCHAIN_FILE=/src/tensorrt_llm/cpp/build/conan/conan_toolchain.cmake  -S "/src/tensorrt_llm/cpp"' returned non-zero exit status 1.
------
Dockerfile.multi:120
--------------------
 119 |     ARG BUILD_WHEEL_ARGS="--clean --python_bindings --benchmarks"
 120 | >>> RUN --mount=type=cache,target=/root/.cache/pip --mount=type=cache,target=${CCACHE_DIR} \
 121 | >>>     python3 scripts/build_wheel.py ${BUILD_WHEEL_ARGS}
 122 |     
--------------------
ERROR: failed to solve: process "/bin/bash -c python3 scripts/build_wheel.py ${BUILD_WHEEL_ARGS}" did not complete successfully: exit code: 1
make: *** [Makefile:71: wheel_build] Error 1
make: Leaving directory '/home/tanmayv/my_repos/TensorRT-LLM/docker'
```


### After

`make -C docker wheel_build BUILD_WHEEL_OPTS='--extra-cmake-vars NIXL_ROOT=/opt/nvidia/nvda_nixl'`

>> Completes successfully!!!


## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
