### PR TITLE
[feat] Add llm args to tune python gc threshold

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -509,7 +509,9 @@ def create_py_executor_instance(
                       if spec_config is not None else 0,
                       kv_cache_transceiver=kv_cache_transceiver,
                       draft_model_engine=draft_model_engine,
-                      start_worker=start_worker)
+                      start_worker=start_worker,
+                      garbage_collection_gen0_threshold=executor_config.
+                      garbage_collection_gen0_threshold)
 
 
 def instantiate_sampler(model_engine: PyTorchModelEngine,

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -384,7 +384,8 @@ def create_py_executor_instance(
         draft_model_engine,
         start_worker,
         sampler,
-        lora_config: Optional[LoraConfig] = None) -> PyExecutor:
+        lora_config: Optional[LoraConfig] = None,
+        garbage_collection_gen0_threshold: Optional[int] = None) -> PyExecutor:
     kv_cache_manager = resources.get(KV_CACHE_MANAGER_KEY, None)
 
     spec_config = model_engine.spec_config
@@ -497,21 +498,21 @@ def create_py_executor_instance(
     kv_cache_transceiver = create_kv_cache_transceiver(
         mapping, kv_cache_manager, attention_type, cache_transceiver_config)
 
-    return PyExecutor(resource_manager,
-                      scheduler,
-                      model_engine=model_engine,
-                      sampler=sampler,
-                      dist=dist,
-                      disable_overlap_scheduler=pytorch_backend_config.
-                      disable_overlap_scheduler,
-                      max_batch_size=executor_config.max_batch_size,
-                      max_draft_tokens=spec_config.max_draft_tokens
-                      if spec_config is not None else 0,
-                      kv_cache_transceiver=kv_cache_transceiver,
-                      draft_model_engine=draft_model_engine,
-                      start_worker=start_worker,
-                      garbage_collection_gen0_threshold=executor_config.
-                      garbage_collection_gen0_threshold)
+    return PyExecutor(
+        resource_manager,
+        scheduler,
+        model_engine=model_engine,
+        sampler=sampler,
+        dist=dist,
+        disable_overlap_scheduler=pytorch_backend_config.
+        disable_overlap_scheduler,
+        max_batch_size=executor_config.max_batch_size,
+        max_draft_tokens=spec_config.max_draft_tokens
+        if spec_config is not None else 0,
+        kv_cache_transceiver=kv_cache_transceiver,
+        draft_model_engine=draft_model_engine,
+        start_worker=start_worker,
+        garbage_collection_gen0_threshold=garbage_collection_gen0_threshold)
 
 
 def instantiate_sampler(model_engine: PyTorchModelEngine,

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -16,8 +16,8 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import torch
 
-from tensorrt_llm._utils import (global_mpi_rank, is_trace_enabled, nvtx_range,
-                                 trace_func)
+from tensorrt_llm._utils import (customized_gc_thresholds, global_mpi_rank,
+                                 is_trace_enabled, nvtx_range, trace_func)
 from tensorrt_llm.bindings.executor import (DisServingRequestStats,
                                             FinishReason, InflightBatchingStats,
                                             IterationStats, KvCacheStats,
@@ -171,6 +171,7 @@ class PyExecutor:
                  max_draft_tokens: int = 0,
                  kv_cache_transceiver: KvCacheTransceiver = None,
                  draft_model_engine: Optional[ModelEngine] = None,
+                 garbage_collection_gen0_threshold: Optional[int] = 20000,
                  start_worker: bool = True):
         super(PyExecutor, self).__init__()
         self.device_id = torch.cuda.current_device()
@@ -268,6 +269,8 @@ class PyExecutor:
                 "Drafting is not supported for selected executor loop. "
                 "Please disable disagg/pipeline parallelism/overlap scheduler.")
 
+        self.garbage_collection_gen0_threshold = garbage_collection_gen0_threshold
+
         self.worker_started = False
         self.worker_lock = threading.Lock()
         if start_worker:
@@ -275,7 +278,9 @@ class PyExecutor:
 
     def _event_loop_wrapper(self):
         try:
-            self.event_loop()
+            with customized_gc_thresholds(
+                    self.garbage_collection_gen0_threshold):
+                self.event_loop()
         except Exception as e:
             logger.error(f"Error in event loop: {e}")
             logger.error(traceback.format_exc())

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -171,7 +171,7 @@ class PyExecutor:
                  max_draft_tokens: int = 0,
                  kv_cache_transceiver: KvCacheTransceiver = None,
                  draft_model_engine: Optional[ModelEngine] = None,
-                 garbage_collection_gen0_threshold: Optional[int] = 20000,
+                 garbage_collection_gen0_threshold: Optional[int] = None,
                  start_worker: bool = True):
         super(PyExecutor, self).__init__()
         self.device_id = torch.cuda.current_device()

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -176,10 +176,12 @@ def _get_mapping(executor_config: ExecutorConfig) -> Mapping:
     return mapping
 
 
-def create_py_executor(executor_config: ExecutorConfig,
-                       checkpoint_dir: str = None,
-                       engine_dir: str = None,
-                       lora_config: Optional[LoraConfig] = None) -> PyExecutor:
+def create_py_executor(
+        executor_config: ExecutorConfig,
+        checkpoint_dir: str = None,
+        engine_dir: str = None,
+        lora_config: Optional[LoraConfig] = None,
+        garbage_collection_gen0_threshold: Optional[int] = None) -> PyExecutor:
     _mangle_executor_config(executor_config)
     pytorch_backend_config = executor_config.pytorch_backend_config
 
@@ -333,7 +335,7 @@ def create_py_executor(executor_config: ExecutorConfig,
         py_executor = create_py_executor_instance(
             dist, resources, mapping, pytorch_backend_config, executor_config,
             ctx_chunk_config, model_engine, draft_model_engine, False, sampler,
-            lora_config)
+            lora_config, garbage_collection_gen0_threshold)
 
     if estimating_kv_cache:
         assert kv_cache_creator is not None
@@ -364,7 +366,8 @@ def create_py_executor(executor_config: ExecutorConfig,
             py_executor = create_py_executor_instance(
                 dist, resources, mapping, pytorch_backend_config,
                 executor_config, ctx_chunk_config, model_engine,
-                draft_model_engine, False, sampler, lora_config)
+                draft_model_engine, False, sampler, lora_config,
+                garbage_collection_gen0_threshold)
 
     py_executor.start_worker()
     return py_executor

--- a/tensorrt_llm/_utils.py
+++ b/tensorrt_llm/_utils.py
@@ -781,6 +781,23 @@ class QuantModeWrapper:
         return self.objs[index]
 
 
+PYTHON_DEFAULT_GC_THRESHOLDS = gc.get_threshold()
+
+
+@contextmanager
+def customized_gc_thresholds(gen0_threshold: int):
+    try:
+        gc.set_threshold(gen0_threshold)
+        logger.debug(
+            f'Set Python GC threshold to customized value: {gen0_threshold}')
+        yield
+    finally:
+        gc.set_threshold(*PYTHON_DEFAULT_GC_THRESHOLDS)
+        logger.debug(
+            f'Reset Python GC thresholds to default value: {PYTHON_DEFAULT_GC_THRESHOLDS}'
+        )
+
+
 @contextmanager
 def _null_context_manager():
     yield

--- a/tensorrt_llm/_utils.py
+++ b/tensorrt_llm/_utils.py
@@ -785,17 +785,20 @@ PYTHON_DEFAULT_GC_THRESHOLDS = gc.get_threshold()
 
 
 @contextmanager
-def customized_gc_thresholds(gen0_threshold: int):
+def customized_gc_thresholds(gen0_threshold: Optional[int] = None):
     try:
-        gc.set_threshold(gen0_threshold)
-        logger.debug(
-            f'Set Python GC threshold to customized value: {gen0_threshold}')
+        if gen0_threshold:
+            gc.set_threshold(gen0_threshold)
+            logger.debug(
+                f'Set Python GC threshold to customized value: {gen0_threshold}'
+            )
         yield
     finally:
-        gc.set_threshold(*PYTHON_DEFAULT_GC_THRESHOLDS)
-        logger.debug(
-            f'Reset Python GC thresholds to default value: {PYTHON_DEFAULT_GC_THRESHOLDS}'
-        )
+        if gen0_threshold:
+            gc.set_threshold(*PYTHON_DEFAULT_GC_THRESHOLDS)
+            logger.debug(
+                f'Reset Python GC thresholds to default value: {PYTHON_DEFAULT_GC_THRESHOLDS}'
+            )
 
 
 @contextmanager

--- a/tensorrt_llm/executor/executor.py
+++ b/tensorrt_llm/executor/executor.py
@@ -350,6 +350,7 @@ class GenerationExecutor(ABC):
         postproc_worker_config: Optional[PostprocWorkerConfig] = None,
         is_llm_executor: Optional[bool] = None,
         lora_config: Optional[LoraConfig] = None,
+        garbage_collection_gen0_threshold: Optional[int] = None,
     ) -> Union["GenerationExecutorProxy", "GenerationExecutorWorker"]:
         # local imports to avoid cyclic importing
         from .proxy import GenerationExecutorProxy
@@ -393,7 +394,9 @@ class GenerationExecutor(ABC):
                 model_world_size=model_world_size,
                 mpi_session=mpi_session,
                 postproc_worker_config=postproc_worker_config,
-                is_llm_executor=is_llm_executor)
+                is_llm_executor=is_llm_executor,
+                garbage_collection_gen0_threshold=
+                garbage_collection_gen0_threshold)
 
         # WAR: For the performance of gathering logits, we use single process worker
         # for TP1 to avoid the large overhead of IPC.
@@ -404,7 +407,9 @@ class GenerationExecutor(ABC):
                 "Using single process worker for TP1, this may hurt streaming generation performance."
             )
             return GenerationExecutorWorker(**worker_kwargs,
-                                            is_llm_executor=is_llm_executor)
+                                            is_llm_executor=is_llm_executor,
+                                            garbage_collection_gen0_threshold=
+                                            garbage_collection_gen0_threshold)
 
         # For single-gpu case:
         # Partition the workload to multiple process for streaming performance.
@@ -416,7 +421,9 @@ class GenerationExecutor(ABC):
                 model_world_size=model_world_size,
                 mpi_session=None,  # use mpi4py
                 postproc_worker_config=postproc_worker_config,
-                is_llm_executor=is_llm_executor)
+                is_llm_executor=is_llm_executor,
+                garbage_collection_gen0_threshold=
+                garbage_collection_gen0_threshold)
         else:
             ctx = multiprocessing.get_context("spawn")
             # The ProcessPoolExecutorSession is used to support Windows, as mpi4py cannot.
@@ -427,7 +434,9 @@ class GenerationExecutor(ABC):
                 model_world_size=model_world_size,
                 mpi_session=mpi_session,
                 postproc_worker_config=postproc_worker_config,
-                is_llm_executor=is_llm_executor)
+                is_llm_executor=is_llm_executor,
+                garbage_collection_gen0_threshold=
+                garbage_collection_gen0_threshold)
 
     def wait_first_completed(
         self, futures: List[GenerationResult]

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -44,6 +44,7 @@ class GenerationExecutorProxy(GenerationExecutor):
         worker_cls: type = GenerationExecutorWorker,
         postproc_worker_config: Optional[PostprocWorkerConfig] = None,
         is_llm_executor: Optional[bool] = None,
+        garbage_collection_gen0_threshold: Optional[int] = None,
     ) -> None:
         postproc_worker_config = postproc_worker_config or PostprocWorkerConfig(
         )
@@ -86,15 +87,14 @@ class GenerationExecutorProxy(GenerationExecutor):
 
         self.model_world_size = model_world_size
 
-        print(f"worker_kwargs: {worker_kwargs}")
-        print(f"{worker_kwargs['executor_config'].__dict__}")
-        self.garbage_collection_gen0_threshold = worker_kwargs[
-            'executor_config'].garbage_collection_gen0_threshold
+        self.garbage_collection_gen0_threshold = garbage_collection_gen0_threshold
 
         worker_kwargs = dict(**worker_kwargs,
                              worker_queues=self._setup_queues(),
                              postproc_worker_config=postproc_worker_config,
-                             is_llm_executor=False)
+                             is_llm_executor=False,
+                             garbage_collection_gen0_threshold=self.
+                             garbage_collection_gen0_threshold)
 
         if "log_level" not in worker_kwargs:
             worker_kwargs["log_level"] = logger.level

--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -117,20 +117,17 @@ class GenerationExecutorWorker(GenerationExecutor):
                 return tllm.Executor(engine, tllm.ModelType.DECODER_ONLY,
                                      executor_config)
             args = {
-                "executor_config":
-                executor_config,
-                "checkpoint_dir":
-                executor_config.hf_model_dir,
-                "engine_dir":
-                executor_config.trt_engine_dir,
-                "garbage_collection_gen0_threshold":
-                garbage_collection_gen0_threshold,
+                "executor_config": executor_config,
+                "checkpoint_dir": executor_config.hf_model_dir,
+                "engine_dir": executor_config.trt_engine_dir,
             }
             if executor_config.backend == "pytorch":
                 from tensorrt_llm._torch.pyexecutor.py_executor_creator import \
                     create_py_executor
                 create_executor = create_py_executor
                 args["lora_config"] = lora_config
+                args[
+                    "garbage_collection_gen0_threshold"] = garbage_collection_gen0_threshold
             elif executor_config.backend == "_autodeploy":
                 from tensorrt_llm._torch.auto_deploy.shim.ad_executor import \
                     create_autodeploy_executor

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -136,7 +136,6 @@ class LLM:
                 revision=revision,
                 tokenizer_revision=tokenizer_revision,
                 **kwargs)
-            print(f"LLM.args: {self.args.__dict__}")
 
         except Exception as e:
             logger.error(

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -136,6 +136,7 @@ class LLM:
                 revision=revision,
                 tokenizer_revision=tokenizer_revision,
                 **kwargs)
+            print(f"LLM.args: {self.args.__dict__}")
 
         except Exception as e:
             logger.error(
@@ -683,6 +684,7 @@ class LLM:
         return_logits = self.args.gather_generation_logits or (
             self._on_trt_backend and self.args.build_config
             and self.args.build_config.gather_context_logits)
+        executor_config.garbage_collection_gen0_threshold = self.args.garbage_collection_gen0_threshold
 
         self._executor = self._executor_cls.create(
             self._engine_dir,

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -684,7 +684,6 @@ class LLM:
         return_logits = self.args.gather_generation_logits or (
             self._on_trt_backend and self.args.build_config
             and self.args.build_config.gather_context_logits)
-        executor_config.garbage_collection_gen0_threshold = self.args.garbage_collection_gen0_threshold
 
         self._executor = self._executor_cls.create(
             self._engine_dir,
@@ -700,7 +699,9 @@ class LLM:
                 postprocess_tokenizer_dir=self.args.postprocess_tokenizer_dir,
             ),
             is_llm_executor=True,
-            lora_config=self.args.lora_config)
+            lora_config=self.args.lora_config,
+            garbage_collection_gen0_threshold=self.args.
+            garbage_collection_gen0_threshold)
 
     @property
     def _on_trt_backend(self) -> bool:

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -943,7 +943,7 @@ class BaseLlmArgs(BaseModel):
         description="The parser to separate reasoning content from output.",
         alias="_reasoning_parser")
 
-    garbage_collection_gen0_threshold: Optional[int] = Field(
+    garbage_collection_gen0_threshold: int = Field(
         default=20000,
         description=
         "Threshold for Python garbage collection of generation 0 objects."

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -944,7 +944,10 @@ class BaseLlmArgs(BaseModel):
         alias="_reasoning_parser")
 
     garbage_collection_gen0_threshold: Optional[int] = Field(
-        default=20000, description="", alias="gc_gen0_threshold")
+        default=20000,
+        description=
+        "Threshold for Python garbage collection of generation 0 objects."
+        "Lower values trigger more frequent garbage collection.")
 
     # TODO[Superjomn]: To deprecate this config.
     decoding_config: Optional[object] = Field(

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -943,6 +943,9 @@ class BaseLlmArgs(BaseModel):
         description="The parser to separate reasoning content from output.",
         alias="_reasoning_parser")
 
+    garbage_collection_gen0_threshold: Optional[int] = Field(
+        default=20000, description="", alias="gc_gen0_threshold")
+
     # TODO[Superjomn]: To deprecate this config.
     decoding_config: Optional[object] = Field(
         default=None,

--- a/tests/unittest/api_stability/references_committed/llm.yaml
+++ b/tests/unittest/api_stability/references_committed/llm.yaml
@@ -105,6 +105,9 @@ methods:
       kv_cache_config:
         annotation: tensorrt_llm.llmapi.llm_args.KvCacheConfig
         default: null
+      garbage_collection_gen0_threshold:
+        annotation: int
+        default: 20000
     return_annotation: None
   generate:
     parameters:


### PR DESCRIPTION
# [feat] Add llm args to tune python gc threshold

## Description

Our observation is that during the TRTLLM py_executor’s create_responses stage, Python GC will be invocated multiple times and will at certain point become extremely long (~200ms). The [mechanism](https://docs.python.org/3/library/gc.html#gc.set_threshold) behind is that Python will invoke GC when it detects num_of_allocation  – num_of_deallocation is larger than a certain threshold (default value is 700). In our case, we are creating (allocating) thousands of responses at the end of an iteration before sending them away in bulk, during which GC will be triggered multiple times because we are doing tens of thousands of allocations while almost no deactivations (they will be deferred until responses are out of function scope). Those GCs are pointless because none of those new response objects are dangled, but they take time (from several to hundreds of milliseconds).
 
Our plan is to increase the GC threshold to a certain heuristic value, say 20k, which should be enough to handle 2k responses,  and make it as a configurable llm-api argument in case we need to handle larger responses in the future. To minimize the potential impact on other components (e.g., OOM issue), we first will limit such change in the create_responses stage of py_executor.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
