### PR TITLE
[TRTLLM-5758] test: Add Bielik-11B-v2.2 Model Support

### DIFF
--- a/tests/integration/defs/accuracy/references/gsm8k.yaml
+++ b/tests/integration/defs/accuracy/references/gsm8k.yaml
@@ -92,3 +92,8 @@ nvidia/Llama-3_1-Nemotron-Ultra-253B-v1:
     accuracy: 94.16
 kanana-1.5-2.1b-instruct-2505:
   - accuracy: 75.81
+speakleash/Bielik-11B-v2.2-Instruct:
+  - accuracy: 41.51
+  - quant_algo: FP8
+    kv_cache_quant_algo: FP8
+    accuracy: 40.41

--- a/tests/integration/defs/accuracy/references/mmlu.yaml
+++ b/tests/integration/defs/accuracy/references/mmlu.yaml
@@ -179,3 +179,8 @@ nvidia/Llama-3_1-Nemotron-Ultra-253B-v1:
     accuracy: 83.36
 kanana-1.5-2.1b-instruct-2505:
   - accuracy: 56.89
+speakleash/Bielik-11B-v2.2-Instruct:
+  - accuracy: 64.47
+  - quant_algo: FP8
+    kv_cache_quant_algo: FP8
+    accuracy: 64.36

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -1488,3 +1488,22 @@ class TestKanana_Instruct(LlmapiAccuracyTestHarness):
             task.evaluate(llm)
             task = GSM8K(self.MODEL_NAME)
             task.evaluate(llm)
+
+
+class TestBielik11BInstruct(LlmapiAccuracyTestHarness):
+    MODEL_NAME = "speakleash/Bielik-11B-v2.2-Instruct"
+
+    def test_auto_dtype(self):
+        with LLM(f"{llm_models_root()}/Bielik-11B-v2.2-Instruct") as llm:
+            task = MMLU(self.MODEL_NAME)
+            task.evaluate(llm)
+            task = GSM8K(self.MODEL_NAME)
+            task.evaluate(llm)
+
+    @skip_pre_hopper
+    def test_fp8(self):
+        with LLM(f"{llm_models_root()}/Bielik-11B-v2.2-Instruct-FP8") as llm:
+            task = MMLU(self.MODEL_NAME)
+            task.evaluate(llm)
+            task = GSM8K(self.MODEL_NAME)
+            task.evaluate(llm)

--- a/tests/integration/test_lists/qa/examples_test_list.txt
+++ b/tests/integration/test_lists/qa/examples_test_list.txt
@@ -484,6 +484,8 @@ accuracy/test_llm_api_pytorch.py::TestQwen3_235B_A22B::test_fp8[latency]
 accuracy/test_llm_api_pytorch.py::TestQwen3_235B_A22B::test_nvfp4[throughput_latency]
 accuracy/test_llm_api_pytorch.py::TestQwen3_235B_A22B::test_nvfp4[latency]
 accuracy/test_llm_api_pytorch.py::TestKanana_Instruct::test_auto_dtype
+accuracy/test_llm_api_pytorch.py::TestBielik11BInstruct::test_auto_dtype
+accuracy/test_llm_api_pytorch.py::TestBielik11BInstruct::test_fp8
 
 test_e2e.py::test_llama_e2e[use_cpp_session-remove_input_padding-]
 test_e2e.py::test_llama_e2e[use_py_session-remove_input_padding-]


### PR DESCRIPTION
## Description

1 Eval metrics.
For bf16 model: 64.47@MMLU, 79.23@GSM8K-strict-match, 32.04@CNNDailyMail-ROUGE1
For fp8 model: 64.36@MMLU, 77.63@GSM8K-strict-match, 32.51@CNNDailyMail-ROUGE1


## Test Coverage

2 Accuracy test passed.
pytest "accuracy/test_llm_api_pytorch.py::TestBielik11BInstruct::test_auto_dtype" -vv -s
pytest "accuracy/test_llm_api_pytorch.py::TestBielik11BInstruct::test_fp8" -vv -s

3 trtllm-bench throughput passed.

4 Dummy multi-LoRA test passed.
python -m pytest tests/unittest/llmapi/test_llm_pytorch.py::test_bielik_11b_v2_2_instruct_multi_lora -v -s

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
