### PR TITLE
fix: Remove stream and wakeup features from ucxx init

### DIFF
--- a/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.cpp
@@ -106,7 +106,8 @@ UcxConnectionManager::UcxConnectionManager()
     try
     {
         TLLM_CUDA_CHECK(cudaGetDevice(&mDevice));
-        mUcxCtx = ucxx::createContext({{"RNDV_PIPELINE_ERROR_HANDLING", "y"}}, ucxx::Context::defaultFeatureFlags);
+        mUcxCtx = ucxx::createContext(
+            {{"RNDV_PIPELINE_ERROR_HANDLING", "y"}}, UCP_FEATURE_TAG | UCP_FEATURE_AM | UCP_FEATURE_RMA);
         int device = mDevice;
         try
         {


### PR DESCRIPTION
Remove unused ucxx feature flags, reference below in latest ucxx. This is enables using ucx with efa devices.

Patch was not built, needs confirmation from review that such removals are safe.

```C++
cpp/include/ucxx/context.h- static constexpr uint64_t defaultFeatureFlags =
cpp/include/ucxx/context.h-    UCP_FEATURE_TAG | UCP_FEATURE_WAKEUP | UCP_FEATURE_STREAM | UCP_FEATURE_AM |
cpp/include/ucxx/context.h-    UCP_FEATURE_RMA;  ///< Suggested default context feature flags to use.
```