### PR TITLE
Removed <think> on head of reasoning_content for DeepSeek-R1 model

### DIFF
--- a/tensorrt_llm/llmapi/reasoning_parser.py
+++ b/tensorrt_llm/llmapi/reasoning_parser.py
@@ -35,6 +35,7 @@ class DeepSeekR1Parser(BaseReasoningParser):
     """
 
     def __init__(self):
+        self.reasoning_begin = "<think>"
         self.reasoning_end = "</think>"
         self.in_reasoning = True
 
@@ -57,6 +58,8 @@ class DeepSeekR1Parser(BaseReasoningParser):
 
         splits = text.split(self.reasoning_end, maxsplit=1)
         reasoning_content = splits[0]
+        if reasoning_content.startswith(self.reasoning_begin):
+            reasoning_content = reasoning_content[len(self.reasoning_begin):]
         content = splits[1]
 
         reasoning_parser_result = self._create_reasoning_end_result(
@@ -74,6 +77,8 @@ class DeepSeekR1Parser(BaseReasoningParser):
             return reasoning_parser_result
 
         if self.in_reasoning:
+            if delta_text.startswith(self.reasoning_begin):
+                delta_text = delta_text[len(self.reasoning_begin):]
             return ReasoningParserResult(self.in_reasoning,
                                          reasoning_content=delta_text)
 


### PR DESCRIPTION
… DeepSeekR1Parser.


# Removed `<think>` on head of reasoning_content for DeepSeek-R1 model

## Description

Removed the reasoning start token `<think>` on head of reasoning_content for DeepSeek-R1 model

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

Start server:
```sh
trtllm-serve deepseek-ai/DeepSeek-R1-0528 --max_batch_size 60 --max_num_tokens 65536 --max_seq_len 65536 --kv_cache_free_gpu_memory_fraction 0.6 --port 8000 --trust_remote_code --backend pytorch --tp_size 8 --pp_size 1 --ep_size 8  --reasoning_parser deepseek-r1
```

Test commands:
```sh
# For non-stream mode
curl http://localhost:8000/v1/chat/completions -H "Content-Type: application/json" -d '{"model":"deepseek-ai/DeepSeek-R1-0528","messages":[{"role":"user","content":"tell me a joke"}],"max_tokens":600,"temperature":0.7}'

# For stream mode
curl http://localhost:8000/v1/chat/completions -H "Content-Type: application/json" -d '{"model":"deepseek-ai/DeepSeek-R1-0528","messages":[{"role":"user","content":"tell me a joke"}],"max_tokens":600,"temperature":0.7,"stream":true}'
```

You will get before fix (take non-stream mode as an example):
```json
{"id":"chatcmpl-08990ae0e70c45f88e0f1ba4dc2e760d","object":"chat.completion","created":1749781653,"model":"deepseek-ai/DeepSeek-R1-0528","choices":[{"index":0,"message":{"role":"assistant","content":"\nAhoy, matey! Here's a classic:  ...","reasoning_content":"<think>\nOkay, the user just asked for a joke.  ...","tool_calls":[]},"logprobs":null,"finish_reason":"stop","stop_reason":null,"disaggregated_params":null}],"usage":{"prompt_tokens":7,"total_tokens":327,"completion_tokens":320}}
```

You will get after fix:
```json
{"id":"chatcmpl-08990ae0e70c45f88e0f1ba4dc2e760d","object":"chat.completion","created":1749781653,"model":"deepseek-ai/DeepSeek-R1-0528","choices":[{"index":0,"message":{"role":"assistant","content":"\nAhoy, matey! Here's a classic:  ...","reasoning_content":"\nOkay, the user just asked for a joke.  ...","tool_calls":[]},"logprobs":null,"finish_reason":"stop","stop_reason":null,"disaggregated_params":null}],"usage":{"prompt_tokens":7,"total_tokens":327,"completion_tokens":320}}
```

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
