### PR TITLE
[TRTLLM-5653][infra] Run docs build only if PR contains only doc changes

### DIFF
--- a/jenkins/L0_MergeRequest.groovy
+++ b/jenkins/L0_MergeRequest.groovy
@@ -986,12 +986,13 @@ def launchStages(pipeline, reuseBuild, testFilter, enableFailFast, globalVars)
                     testStageName = "[Test-SBSA] Remote Run"
                 }
 
+                if (testFilter[(ONLY_DOCS_FILE_CHANGED)]) {
+                    echo "SBSA build job is skipped due to Jenkins configuration or conditional pipeline run"
+                    return
+                }
+
                 def stageName = "Build"
                 stage(stageName) {
-                    if (testFilter[(ONLY_DOCS_FILE_CHANGED)]) {
-                        echo "SBSA build job is skipped due to Jenkins configuration or conditional pipeline run"
-                        return
-                    }
                     def parameters = getCommonParameters()
                     String globalVarsJson = writeJSON returnText: true, json: globalVars
                     parameters += [
@@ -1024,8 +1025,8 @@ def launchStages(pipeline, reuseBuild, testFilter, enableFailFast, globalVars)
                     }
                 }
                 stage(testStageName) {
-                    if (SBSA_TEST_CHOICE == STAGE_CHOICE_SKIP || testFilter[(ONLY_DOCS_FILE_CHANGED)]) {
-                        echo "SBSA test job is skipped due to Jenkins configuration or conditional pipeline run"
+                    if (SBSA_TEST_CHOICE == STAGE_CHOICE_SKIP) {
+                        echo "SBSA test job is skipped due to Jenkins configuration"
                         return
                     }
                     try {

--- a/jenkins/L0_MergeRequest.groovy
+++ b/jenkins/L0_MergeRequest.groovy
@@ -112,6 +112,8 @@ def AUTO_TRIGGER_TAG_LIST = "auto_trigger_tag_list"
 def DEBUG_MODE = "debug"
 @Field
 def DETAILED_LOG = "detailed_log"
+@Field
+def ONLY_DOCS_FILE_CHANGED = "only_docs_file_changed"
 
 def testFilter = [
     (REUSE_STAGE_LIST): trimForStageList(gitlabParamsFromBot.get(REUSE_STAGE_LIST, null)?.tokenize(',')),
@@ -129,6 +131,7 @@ def testFilter = [
     (DEBUG_MODE): gitlabParamsFromBot.get(DEBUG_MODE, false),
     (AUTO_TRIGGER_TAG_LIST): [],
     (DETAILED_LOG): gitlabParamsFromBot.get(DETAILED_LOG, false),
+    (ONLY_DOCS_FILE_CHANGED): false,
 ]
 
 String reuseBuild = gitlabParamsFromBot.get('reuse_build', null)
@@ -320,6 +323,7 @@ def setupPipelineEnvironment(pipeline, testFilter, globalVars)
         testFilter[(MULTI_GPU_FILE_CHANGED)] = getMultiGpuFileChanged(pipeline, testFilter, globalVars)
         testFilter[(ONLY_PYTORCH_FILE_CHANGED)] = getOnlyPytorchFileChanged(pipeline, testFilter, globalVars)
         testFilter[(AUTO_TRIGGER_TAG_LIST)] = getAutoTriggerTagList(pipeline, testFilter, globalVars)
+        testFilter[(ONLY_DOCS_FILE_CHANGED)] = getOnlyDocsFileChanged(pipeline, testFilter, globalVars)
         getContainerURIs().each { k, v ->
             globalVars[k] = v
         }
@@ -682,6 +686,27 @@ def getOnlyPytorchFileChanged(pipeline, testFilter, globalVars) {
     return result
 }
 
+def getOnlyDocsFileChanged(pipeline, testFilter, globalVars) {
+    def isOfficialPostMergeJob = (env.JOB_NAME ==~ /.*PostMerge.*/)
+    if (env.alternativeTRT || isOfficialPostMergeJob) {
+        pipeline.echo("Force set ONLY_DOCS_FILE_CHANGED false.")
+        return false
+    }
+
+    def changedFileList = getMergeRequestChangedFileList(pipeline, globalVars)
+    if (!changedFileList || changedFileList.isEmpty()) {
+        return false
+    }
+
+    // Check if only docs files are changed
+    for (file in changedFileList) {
+        if (!file.startsWith("docs/")) {
+            return false
+        }
+    }
+    return true
+}
+
 def collectTestResults(pipeline, testFilter)
 {
     collectResultPodSpec = createKubernetesPodConfig("", "agent")
@@ -950,6 +975,10 @@ def launchStages(pipeline, reuseBuild, testFilter, enableFailFast, globalVars)
 
                 def stageName = "Build"
                 stage(stageName) {
+                    if (testFilter[(ONLY_DOCS_FILE_CHANGED)]) {
+                        echo "SBSA build job is skipped due to Jenkins configuration"
+                        return
+                    }
                     def parameters = getCommonParameters()
                     String globalVarsJson = writeJSON returnText: true, json: globalVars
                     parameters += [
@@ -982,7 +1011,7 @@ def launchStages(pipeline, reuseBuild, testFilter, enableFailFast, globalVars)
                     }
                 }
                 stage(testStageName) {
-                    if (SBSA_TEST_CHOICE == STAGE_CHOICE_SKIP) {
+                    if (SBSA_TEST_CHOICE == STAGE_CHOICE_SKIP || testFilter[(ONLY_DOCS_FILE_CHANGED)]) {
                         echo "SBSA test job is skipped due to Jenkins configuration"
                         return
                     }

--- a/jenkins/L0_MergeRequest.groovy
+++ b/jenkins/L0_MergeRequest.groovy
@@ -696,6 +696,7 @@ def getOnlyDocsFileChanged(pipeline, testFilter, globalVars) {
     // TODO: Add more docs path to the list, e.g. *.md files in other directories
     def docsFileList = [
         "docs/",
+        "jenkins/"
     ]
 
     def changedFileList = getMergeRequestChangedFileList(pipeline, globalVars)

--- a/jenkins/L0_MergeRequest.groovy
+++ b/jenkins/L0_MergeRequest.groovy
@@ -693,17 +693,30 @@ def getOnlyDocsFileChanged(pipeline, testFilter, globalVars) {
         return false
     }
 
+    // TODO: Add more docs path to the list, e.g. *.md files in other directories
+    def docsFileList = [
+        "docs/",
+    ]
+
     def changedFileList = getMergeRequestChangedFileList(pipeline, globalVars)
     if (!changedFileList || changedFileList.isEmpty()) {
         return false
     }
 
-    // Check if only docs files are changed
     for (file in changedFileList) {
-        if (!file.startsWith("docs/")) {
+        def isDocsFile = false
+        for (prefix in docsFileList) {
+            if (file.startsWith(prefix)) {
+                isDocsFile = true
+                break
+            }
+        }
+        if (!isDocsFile) {
+            pipeline.echo("Found non-docs file: ${file}")
             return false
         }
     }
+    pipeline.echo("Only docs files changed.")
     return true
 }
 
@@ -976,7 +989,7 @@ def launchStages(pipeline, reuseBuild, testFilter, enableFailFast, globalVars)
                 def stageName = "Build"
                 stage(stageName) {
                     if (testFilter[(ONLY_DOCS_FILE_CHANGED)]) {
-                        echo "SBSA build job is skipped due to Jenkins configuration"
+                        echo "SBSA build job is skipped due to Jenkins configuration or conditional pipeline run"
                         return
                     }
                     def parameters = getCommonParameters()
@@ -1012,7 +1025,7 @@ def launchStages(pipeline, reuseBuild, testFilter, enableFailFast, globalVars)
                 }
                 stage(testStageName) {
                     if (SBSA_TEST_CHOICE == STAGE_CHOICE_SKIP || testFilter[(ONLY_DOCS_FILE_CHANGED)]) {
-                        echo "SBSA test job is skipped due to Jenkins configuration"
+                        echo "SBSA test job is skipped due to Jenkins configuration or conditional pipeline run"
                         return
                     }
                     try {

--- a/jenkins/L0_MergeRequest.groovy
+++ b/jenkins/L0_MergeRequest.groovy
@@ -696,7 +696,6 @@ def getOnlyDocsFileChanged(pipeline, testFilter, globalVars) {
     // TODO: Add more docs path to the list, e.g. *.md files in other directories
     def docsFileList = [
         "docs/",
-        "jenkins/"
     ]
 
     def changedFileList = getMergeRequestChangedFileList(pipeline, globalVars)

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -437,6 +437,8 @@ def DEBUG_MODE = "debug"
 @Field
 def DETAILED_LOG = "detailed_log"
 @Field
+def ONLY_DOCS_FILE_CHANGED = "only_docs_file_changed"
+@Field
 def testFilter = [
     (REUSE_STAGE_LIST): null,
     (ENABLE_SKIP_TEST): false,
@@ -453,6 +455,7 @@ def testFilter = [
     (DEBUG_MODE): false,
     (AUTO_TRIGGER_TAG_LIST): [],
     (DETAILED_LOG): false,
+    (ONLY_DOCS_FILE_CHANGED): false,
 ]
 
 @Field
@@ -1885,6 +1888,16 @@ def launchTestJobs(pipeline, testFilter, dockerNode=null)
             cacheErrorAndUploadResult("${key}", values[1], {}, true)
         }
     }]]}
+
+    // Check if only docs files are changed, if true, run doc build stage only.
+    if (testFilter[(ONLY_DOCS_FILE_CHANGED)]) {
+        echo "Only docs files are changed, run doc build stage only."
+        return docBuildJobs.collectEntries{key, values -> [key, [values[0], {
+            trtllm_utils.launchKubernetesPod(pipeline, values[0], "trt-llm", {
+                values[1]()
+            })
+        }]]}
+    }
 
     // Python version and OS for sanity check
     x86SanityCheckConfigs = [

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -2268,7 +2268,8 @@ pipeline {
         {
             when {
                 expression {
-                    env.targetArch == X86_64_TRIPLE  // Only execute the check if running on x86
+                    // Only run the test list validation when necessary
+                    env.targetArch == X86_64_TRIPLE && testFilter[ONLY_DOCS_FILE_CHANGED] == false
                 }
             }
             steps

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -1889,16 +1889,6 @@ def launchTestJobs(pipeline, testFilter, dockerNode=null)
         }
     }]]}
 
-    // Check if only docs files are changed, if true, run doc build stage only.
-    if (testFilter[(ONLY_DOCS_FILE_CHANGED)]) {
-        echo "Only docs files are changed, run doc build stage only."
-        return docBuildJobs.collectEntries{key, values -> [key, [values[0], {
-            trtllm_utils.launchKubernetesPod(pipeline, values[0], "trt-llm", {
-                values[1]()
-            })
-        }]]}
-    }
-
     // Python version and OS for sanity check
     x86SanityCheckConfigs = [
         "PY312-DLFW": [
@@ -2176,6 +2166,12 @@ def launchTestJobs(pipeline, testFilter, dockerNode=null)
             parallelJobsFiltered = parallelJobsFiltered.findAll { !it.key.contains("-CPP-") && !it.key.contains("-TensorRT-") }
             println parallelJobsFiltered.keySet()
         }
+    }
+
+    if (testFilter[(ONLY_DOCS_FILE_CHANGED)]) {
+        echo "Only docs files are changed, run doc build stage only."
+        parallelJobsFiltered = docBuildJobs
+        println parallelJobsFiltered.keySet()
     }
 
     // Check --stage-list, only run the stages in stage-list.


### PR DESCRIPTION
## Description

Run docs build only if PR contains only doc changes to save infrastructure resources

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
