### PR TITLE
[nvbug 5004744][fix] rewrite completion API to avoid repetitive tokens

### DIFF
--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -106,7 +106,7 @@ class CompletionResponse(OpenAIBaseModel):
     usage: UsageInfo
     # Add prompt_tokens_ids to the response to remove the tokenization
     # in the generation server in disaggreated serving
-    prompt_token_ids: Optional[List[List[int]]] = None
+    prompt_token_ids: Optional[Union[List[List[int]], List[int]]] = None
 
 
 class CompletionResponseStreamChoice(OpenAIBaseModel):

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -127,7 +127,7 @@ class OpenAIServer:
     def create_error_response(
             message: str,
             err_type: str = "BadRequestError",
-            status_code: HTTPStatus = HTTPStatus.BAD_REQUEST) -> ErrorResponse:
+            status_code: HTTPStatus = HTTPStatus.BAD_REQUEST) -> Response:
         error_response = ErrorResponse(message=message,
                                        type=err_type,
                                        code=status_code.value)
@@ -316,10 +316,10 @@ class OpenAIServer:
 
     async def openai_completion(self, request: CompletionRequest, raw_request: Request) -> Response:
 
-        async def completion_response(promise: RequestOutput, postproc_params: Optional[PostprocParams]):
+        async def completion_response(promise: RequestOutput,
+                                      postproc_params: Optional[PostprocParams]) -> CompletionResponse:
             response = await promise
             if not self.postproc_worker_enabled:
-                pp_result: CompletionResponse
                 post_processor, args = postproc_params.post_processor, postproc_params.postproc_args
                 pp_result = post_processor(response, args)
             else:
@@ -329,7 +329,7 @@ class OpenAIServer:
                 pp_result.prompt_token_ids = response.prompt_token_ids
             return pp_result
 
-        def merge_completion_responses(responses: List[CompletionResponse]):
+        def merge_completion_responses(responses: List[CompletionResponse]) -> CompletionResponse:
             all_choices: List[CompletionResponseChoice] = []
             all_prompt_token_ids: List[List[int]] = []
             num_prompt_tokens = num_gen_tokens = 0

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -43,7 +43,6 @@ examples/test_multimodal.py::test_llm_multimodal_general[video-neva-pp:1-tp:1-bf
 examples/test_whisper.py::test_llm_whisper_general[large-v3-enable_gemm_plugin-enable_attention_plugin-disable_weight_only-float16-nb:1-use_python_runtime] SKIP (https://nvbugs/4866931)
 examples/test_nemotron.py::test_llm_nemotron_3_8b_1gpu[bfloat16-fp8] SKIP (https://nvbugs/4961624)
 examples/test_mistral.py::test_llm_mistral_v1_1gpu[mistral-7b-v0.1-float16-max_attention_window_size_4096-chunked_summarization_long] SKIP (https://nvbugs/5321371)
-test_e2e.py::test_openai_completions_example SKIP (https://nvbugspro.nvidia.com/bug/5004744)
 cpp/test_e2e.py::test_model[fp8-chatglm-90] SKIP (https://nvbugs/5034830)
 full:B200_PCIe/examples/test_mamba.py::test_llm_mamba_1gpu[mamba2-130m-float16-enable_gemm_plugin] SKIP (Disable for Blackwell)
 full:B200_PCIe/examples/test_mamba.py::test_llm_mamba_1gpu[mamba2-130m-float16-disable_gemm_plugin] SKIP (Disable for Blackwell)


### PR DESCRIPTION
## Description

This PR is fixing the repetitive token issue reported from different sources. For completion API, there maybe multiple prompts in a same request, so we have multiple `RequestOutput`, we want to process them ASAP so we [launch multiple `producer()` tasks](https://github.com/NVIDIA/TensorRT-LLM/blob/089be8912a757a938a72c4cab9ed76d10624d71e/tensorrt_llm/serve/openai_server.py#L331) and [put the result into a queue](https://github.com/NVIDIA/TensorRT-LLM/blob/089be8912a757a938a72c4cab9ed76d10624d71e/tensorrt_llm/serve/openai_server.py#L326), and then we take the result from the queue with `consumer()`.

The problem here is, there is no coordination between producer and consumer, a producer may put several times before consumer takes, but `__anext__()` function of RequestOutput returns itself (we [call it inside producer](https://github.com/NVIDIA/TensorRT-LLM/blob/089be8912a757a938a72c4cab9ed76d10624d71e/tensorrt_llm/serve/openai_server.py#L327) and put the result into the queue), which means all the entries refer to the same object, and we basically process the same thing for these entries, then we get repetitive tokens.

The fix is to create a separate task to process each `RequestOutput`, then merge their result.

## Test Coverage

Original test is enough, and completion test passed locally

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
