### PR TITLE
[TRTLLM-4406][AutoDeploy] Rename auto-deploy custom ops

### DIFF
--- a/examples/auto_deploy/build_and_run_ad.py
+++ b/examples/auto_deploy/build_and_run_ad.py
@@ -68,6 +68,7 @@ def build_llm_from_config(config: SimpleConfig) -> LLM:
         attn_page_size=config.attn_page_size,  # Now passed directly as AutoDeploy parameter
         tensor_parallel_size=config.world_size,
         tokenizer=factory.init_tokenizer() if config.customize_tokenizer else None,
+        checkpoint_device=config.checkpoint_device,
     )
 
     return llm

--- a/examples/auto_deploy/simple_config.py
+++ b/examples/auto_deploy/simple_config.py
@@ -26,6 +26,8 @@ class SimpleConfig:
         "AutoModelForCausalLM"
     )
     skip_loading_weights: bool = False  # only load the architecture, not the weights
+    checkpoint_device: Optional[str] = None  # Device on which to load the model checkpoint
+    # (defaults to the same device as the rest of the pipeline)
     customize_tokenizer: bool = False  # True: tokenizer from the model factory, False: from LLM api
 
     ### MODEL EXTRA KWARGS #########################################################################

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/_triton_attention_internal.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/_triton_attention_internal.py
@@ -168,7 +168,7 @@ def _paged_context_mha(
     )
 
 
-@torch.library.custom_op("attention::fused_mha_with_paged_cache", mutates_args=())
+@torch.library.custom_op("auto_deploy::triton_attention_fused_mha_with_paged_cache", mutates_args=())
 def fused_mha_with_paged_cache(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -415,8 +415,7 @@ def _flattened_context_mha_rope_fusion(
         num_stages=2,
     )
 
-
-@torch.library.custom_op("attention::fused_flattened_mha_with_cache_rope_fusion", mutates_args=())
+@torch.library.custom_op("auto_deploy::triton_attention_fused_flattened_mha_with_cache_rope_fusion", mutates_args=())
 def fused_flattened_mha_with_cache_rope_fusion(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -541,7 +540,7 @@ def _context_mha(
     )
 
 
-@torch.library.custom_op("attention::fused_mha_with_cache", mutates_args=())
+@torch.library.custom_op("auto_deploy::triton_attention_fused_mha_with_cache", mutates_args=())
 def fused_mha_with_cache(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -593,7 +592,7 @@ def fused_mha_fake(
     return torch.empty_like(q.contiguous())
 
 
-@torch.library.custom_op("attention::fused_flattened_mha_with_cache", mutates_args=())
+@torch.library.custom_op("auto_deploy::triton_attention_fused_flattened_mha_with_cache", mutates_args=())
 def fused_flattened_mha_with_cache(
     # Q, K, V
     q: torch.Tensor,

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/_triton_attention_internal.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/_triton_attention_internal.py
@@ -210,10 +210,10 @@ def fused_mha_with_paged_cache(
     if freqs_cis is not None:
         if s == 1:
             rope_args = (freqs_cis, input_pos, "bsnd")
-            fn_rope = torch.ops.rope.apply_rope_with_input_pos
+            fn_rope = torch.ops.auto_deploy.triton_rope_with_input_pos
         else:
             rope_args = (freqs_cis, input_pos, seq_len, seq_start)
-            fn_rope = torch.ops.rope.apply_rope_on_flattened_inputs
+            fn_rope = torch.ops.auto_deploy.triton_rope_on_flattened_inputs
         q = fn_rope(q, *rope_args)
         k = fn_rope(k, *rope_args)
 
@@ -562,8 +562,8 @@ def fused_mha_with_cache(
 
     # rope embedding
     if freqs_cis is not None:
-        q = torch.ops.rope.apply_rope_with_input_pos(q, freqs_cis, input_pos, "bsnd")
-        k = torch.ops.rope.apply_rope_with_input_pos(k, freqs_cis, input_pos, "bsnd")
+        q = torch.ops.auto_deploy.triton_rope_with_input_pos(q, freqs_cis, input_pos, "bsnd")
+        k = torch.ops.auto_deploy.triton_rope_with_input_pos(k, freqs_cis, input_pos, "bsnd")
 
     # attention (assumed layout is bsnd)
     y = torch.empty_like(q)
@@ -637,10 +637,10 @@ def fused_flattened_mha_with_cache(
     if freqs_cis.numel() > 0:
         if s == 1:
             rope_args = (freqs_cis, input_pos, "bsnd")
-            fn_rope = torch.ops.rope.apply_rope_with_input_pos
+            fn_rope = torch.ops.auto_deploy.triton_rope_with_input_pos
         else:
             rope_args = (freqs_cis, input_pos, seq_len, seq_start)
-            fn_rope = torch.ops.rope.apply_rope_on_flattened_inputs
+            fn_rope = torch.ops.auto_deploy.triton_rope_on_flattened_inputs
         q = fn_rope(q, *rope_args)
         k = fn_rope(k, *rope_args)
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/dist.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/dist.py
@@ -8,7 +8,7 @@ from ..distributed import common as dist
 from ..distributed import trtllm as trtllm_dist
 
 
-@torch.library.custom_op("dist::all_gather", mutates_args=(), device_types="cuda")
+@torch.library.custom_op("auto_deploy::torch_dist_all_gather", mutates_args=(), device_types="cuda")
 def all_gather(
     tensor: torch.Tensor, dim: int = 0, sizes: Optional[List[int]] = None
 ) -> torch.Tensor:
@@ -25,7 +25,7 @@ def all_gather_fake(tensor, dim=0):
     return torch.cat([torch.empty_like(tensor) for _ in range(dist.get_world_size())], dim=dim)
 
 
-@torch.library.custom_op("dist::all_reduce", mutates_args=(), device_types="cuda")
+@torch.library.custom_op("auto_deploy::torch_dist_all_reduce", mutates_args=(), device_types="cuda")
 def all_reduce(t: torch.Tensor) -> torch.Tensor:
     """All_reduce across the ranks. Reduction op is SUM.
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/flashinfer_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/flashinfer_attention.py
@@ -355,7 +355,7 @@ class FlashInferAttention(AttentionDescriptor):
     @classmethod
     def get_source_attention_op(cls) -> OpOverloadPacket:
         """Get the source attention op that we target for replacement."""
-        return torch.ops.attention.bsnd_grouped_sdpa
+        return torch.ops.auto_deploy.torch_attention_bsnd_grouped_sdpa
 
     @classmethod
     def get_cached_attention_op(cls) -> MHACallable:

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/flashinfer_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/flashinfer_attention.py
@@ -153,7 +153,7 @@ class _FlashInferPlanner:
 _GlobalFlashInferPlanner = _FlashInferPlanner()
 
 
-@torch.library.custom_op("attention::prepare_flashinfer_metadata", mutates_args=())
+@torch.library.custom_op("auto_deploy::flashinfer_attention_prepare_metadata", mutates_args=())
 def prepare_flashinfer_metadata(
     input_ids: torch.Tensor,
     position_ids: torch.Tensor,
@@ -228,7 +228,7 @@ def prepare_flashinfer_metadata_fake(
     )
 
 
-@torch.library.custom_op("attention::flashinfer_mha_with_cache", mutates_args=())
+@torch.library.custom_op("auto_deploy::flashinfer_attention_mha_with_cache", mutates_args=())
 def flashinfer_mha_with_cache(
     # Q, K, V
     q: torch.Tensor,
@@ -359,11 +359,11 @@ class FlashInferAttention(AttentionDescriptor):
 
     @classmethod
     def get_cached_attention_op(cls) -> MHACallable:
-        return torch.ops.attention.flashinfer_mha_with_cache
+        return torch.ops.auto_deploy.flashinfer_attention_mha_with_cache
 
     @classmethod
     def get_prepare_metadata_op(cls) -> Tuple[PrepareMetadataCallable, int]:
-        return torch.ops.attention.prepare_flashinfer_metadata, 6
+        return torch.ops.auto_deploy.flashinfer_attention_prepare_metadata, 6
 
     @classmethod
     def get_cache_initializers(

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/flashinfer_rope.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/flashinfer_rope.py
@@ -4,7 +4,7 @@ import flashinfer
 import torch
 
 
-@torch.library.custom_op("rope::flashinfer", mutates_args=())
+@torch.library.custom_op("auto_deploy::flashinfer_rope", mutates_args=())
 def apply_rope_with_input_pos_flashinfer(
     q: torch.Tensor,
     k: torch.Tensor,

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe.py
@@ -6,7 +6,7 @@ import torch.nn.functional as F
 from ...modules.fused_moe import MoE  # noqa: F401
 
 
-@torch.library.custom_op("moe::torch_moe", mutates_args=())
+@torch.library.custom_op("auto_deploy::torch_moe", mutates_args=())
 def torch_moe(
     x: torch.Tensor,
     selected_experts: torch.Tensor,
@@ -80,7 +80,7 @@ def torch_moe(
     return torch.empty_like(x)
 
 
-@torch.library.custom_op("moe::torch_fused_moe", mutates_args=())
+@torch.library.custom_op("auto_deploy::torch_moe_fused", mutates_args=())
 def torch_fused_moe(
     x: torch.Tensor,
     selected_experts: torch.Tensor,
@@ -147,7 +147,7 @@ def torch_fused_moe(
     return torch.empty_like(x)
 
 
-@torch.library.custom_op("moe::trtllm_fused_moe", mutates_args=())
+@torch.library.custom_op("auto_deploy::trtllm_moe_fused", mutates_args=())
 def trtllm_fused_moe(
     x: torch.Tensor,
     selected_experts: torch.Tensor,

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/linear.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/linear.py
@@ -8,7 +8,7 @@ from ..distributed import common as dist
 from ..distributed import trtllm as trtllm_dist
 
 
-@torch.library.custom_op("linear::simple", mutates_args=())
+@torch.library.custom_op("auto_deploy::torch_linear_simple", mutates_args=())
 def simple(input: torch.Tensor, weight: torch.Tensor, bias: Optional[torch.Tensor]) -> torch.Tensor:
     """A wrapper for the linear functional to control how it is exposed.
 
@@ -30,7 +30,7 @@ def simple_fake(input, weight, bias):
     return torch.ops.aten.linear(input, weight, bias)
 
 
-@torch.library.custom_op("linear::fused_linear_all_reduce", mutates_args=(), device_types="cuda")
+@torch.library.custom_op("auto_deploy::trtllm_dist_fused_linear_all_reduce", mutates_args=(), device_types="cuda")
 def fused_linear_all_reduce(
     input: torch.Tensor, weight: torch.Tensor, bias: Optional[torch.Tensor]
 ) -> torch.Tensor:

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mla.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mla.py
@@ -169,7 +169,7 @@ def fused_flattened_mla_with_cache_fake(
     return torch.empty_like(kv[..., -v_head_dim:])
 
 
-@torch.library.custom_op("attention::prepare_fused_mla_metadata", mutates_args=())
+@torch.library.custom_op("auto_deploy::triton_attention_prepare_fused_mla_metadata", mutates_args=())
 def prepare_fused_mla_metadata(
     input_ids: torch.Tensor,
     position_ids: torch.Tensor,
@@ -229,7 +229,7 @@ class MultiHeadLatentAttention(AttentionDescriptor):
 
     @classmethod
     def get_prepare_metadata_op(cls) -> Tuple[PrepareMetadataCallable, int]:
-        return torch.ops.attention.prepare_fused_mla_metadata, 4
+        return torch.ops.auto_deploy.triton_attention_prepare_fused_mla_metadata, 4
 
     @classmethod
     def get_cache_initializers(

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mla.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mla.py
@@ -22,7 +22,7 @@ from .triton_attention import _flattened_context_mha, _generate_mha
 Constant = Union[int, float, str, None]
 
 
-@torch.library.custom_op("attention::fused_flattened_mla_with_cache", mutates_args=())
+@torch.library.custom_op("auto_deploy::triton_attention_fused_flattened_mla_with_cache", mutates_args=())
 def fused_flattened_mla_with_cache(
     # Q, K, V
     q_nope: torch.Tensor,
@@ -225,7 +225,7 @@ class MultiHeadLatentAttention(AttentionDescriptor):
 
     @classmethod
     def get_cached_attention_op(cls) -> MHACallable:
-        return torch.ops.attention.fused_flattened_mla_with_cache
+        return torch.ops.auto_deploy.triton_attention_fused_flattened_mla_with_cache
 
     @classmethod
     def get_prepare_metadata_op(cls) -> Tuple[PrepareMetadataCallable, int]:

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mla.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mla.py
@@ -94,7 +94,7 @@ def fused_flattened_mla_with_cache(
             q_slice = q_pe[start : start + length]
             k_slice = k_pe[start : start + length]
 
-            q_rot, k_rot = torch.ops.rope.torch_apply_rope_with_qk_interleaving(
+            q_rot, k_rot = torch.ops.auto_deploy.torch_rope_with_qk_interleaving(
                 q_slice,
                 k_slice,
                 cos,

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mla.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mla.py
@@ -221,7 +221,7 @@ class MultiHeadLatentAttention(AttentionDescriptor):
 
     @classmethod
     def get_source_attention_op(cls) -> OpOverloadPacket:
-        return torch.ops.deepseek.fused_mla
+        return torch.ops.auto_deploy.torch_attention_deepseek_fused_mla
 
     @classmethod
     def get_cached_attention_op(cls) -> MHACallable:

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/quant.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/quant.py
@@ -16,7 +16,7 @@ TRTLLM_FP4_OP_AVAILABLE = True
 TRTLLM_NVFP4_SCALING_VECTOR_SIZE = 16
 
 
-@torch.library.custom_op("quant::quant_fn", mutates_args=())
+@torch.library.custom_op("auto_deploy::torch_quant_fn", mutates_args=())
 def quant_fn(x: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
     scaled_x = x / scale
     rounded_x = torch.round(scaled_x)
@@ -37,7 +37,7 @@ class QuantModule(nn.Module):
         self.register_buffer("scale", torch.tensor(scale))
 
     def forward(self, x: torch.Tensor):
-        return torch.ops.quant.quant_fn(x, self.scale)
+        return torch.ops.auto_deploy.torch_quant_fn(x, self.scale)
 
 
 FP8_MIN = torch.finfo(torch.float8_e4m3fn).min
@@ -50,7 +50,7 @@ def _to_fp8(x, scale):
     return (x / scale).clamp(FP8_MIN, FP8_MAX).to(torch.float8_e4m3fn)
 
 
-@torch.library.custom_op("quant::fp8_linear", mutates_args=())
+@torch.library.custom_op("auto_deploy::torch_quant_fp8_linear", mutates_args=())
 @torch.compile(dynamic=True)
 def fp8_linear(
     input: torch.Tensor,
@@ -105,7 +105,7 @@ def fp8_linear_fake(
     return torch.ops.aten.linear(input, weight_fp8.to(input.dtype), bias)
 
 
-@torch.library.custom_op("quant::fused_fp8_linear_all_reduce", mutates_args=())
+@torch.library.custom_op("auto_deploy::torch_quant_fused_fp8_linear_all_reduce", mutates_args=())
 @torch.compile(dynamic=True)
 def fused_fp8_linear_all_reduce(
     input: torch.Tensor,
@@ -114,7 +114,7 @@ def fused_fp8_linear_all_reduce(
     input_scale: Optional[torch.Tensor] = None,
     weight_scale: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
-    out = torch.ops.quant.fp8_linear(input, weight_fp8, bias, input_scale, weight_scale)
+    out = torch.ops.auto_deploy.torch_quant_fp8_linear(input, weight_fp8, bias, input_scale, weight_scale)
     if trtllm_dist.is_trtllm_op_available():
         return trtllm_dist.trtllm_allreduce(out, op=dist.ReduceOp.SUM)
     dist.all_reduce(out, op=dist.ReduceOp.SUM)
@@ -129,7 +129,7 @@ def fused_fp8_linear_all_reduce_fake(
     input_scale: Optional[torch.Tensor] = None,
     weight_scale: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
-    return torch.ops.quant.fp8_linear(input, weight_fp8, bias, input_scale, weight_scale)
+    return torch.ops.auto_deploy.torch_quant_fp8_linear(input, weight_fp8, bias, input_scale, weight_scale)
 
 
 class FP8Linear(nn.Linear):
@@ -146,12 +146,12 @@ class FP8Linear(nn.Linear):
             self.bias = nn.Parameter(self.bias.to(torch.half))
 
     def forward(self, x):
-        return torch.ops.quant.fp8_linear(
+        return torch.ops.auto_deploy.torch_quant_fp8_linear(
             x, self.weight, self.bias, self.input_scale, self.weight_scale
         )
 
 
-@torch.library.custom_op("quant::fp4_linear", mutates_args=())
+@torch.library.custom_op("auto_deploy::torch_quant_fp4_linear", mutates_args=())
 @torch.compile(dynamic=True)
 def fp4_linear(
     input: torch.Tensor,
@@ -218,4 +218,4 @@ def fp4_linear_fake(
     return torch.ops.aten.linear(input, weight_fp4.repeat(1, 2).to(input.dtype), bias)
 
 
-QUANT_OPS = [torch.ops.quant.fp8_linear, torch.ops.quant.fp4_linear]
+QUANT_OPS = [torch.ops.auto_deploy.torch_quant_fp8_linear, torch.ops.auto_deploy.torch_quant_fp4_linear]

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/rope.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/rope.py
@@ -4,7 +4,7 @@ import triton
 from .triton_kernels.rope import rope_fwd_flattened_kernel, rope_fwd_kernel
 
 
-@torch.library.custom_op("rope::apply_rope_with_input_pos", mutates_args=())
+@torch.library.custom_op("auto_deploy::triton_rope_with_input_pos", mutates_args=())
 def apply_rope_with_input_pos(
     x: torch.Tensor, freqs_cis: torch.Tensor, input_pos: torch.Tensor, layout: str
 ) -> torch.Tensor:
@@ -77,7 +77,7 @@ def apply_rope_with_input_pos_fake(x, freqs_cis, input_pos, layout):
     return torch.empty_like(x)
 
 
-@torch.library.custom_op("rope::apply_rope_on_flattened_inputs", mutates_args=())
+@torch.library.custom_op("auto_deploy::triton_rope_on_flattened_inputs", mutates_args=())
 def apply_rope_on_flattened_inputs(
     x: torch.Tensor,
     freqs_cis: torch.Tensor,

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_attention.py
@@ -8,7 +8,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 
-@torch.library.custom_op("attention::repeat_kv", mutates_args=())
+@torch.library.custom_op("auto_deploy::torch_attention_repeat_kv", mutates_args=())
 def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
     """
     This is the equivalent of torch.repeat_interleave(x, dim=1, repeats=n_rep). The hidden states go from (batch,
@@ -31,7 +31,7 @@ def repeat_kv_fake(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
     return torch.empty(replicated_shape, device=hidden_states.device, dtype=hidden_states.dtype)
 
 
-@torch.library.custom_op("attention::scaled_dot_product_attention", mutates_args=())
+@torch.library.custom_op("auto_deploy::torch_attention_sdpa", mutates_args=())
 def scaled_dot_product_attention(
     query: torch.Tensor,
     key: torch.Tensor,
@@ -66,7 +66,7 @@ def scaled_dot_product_attention_fake(
     return query.new_empty(*query.shape[:-1], value.shape[-1]).contiguous()
 
 
-@torch.library.custom_op("attention::grouped_sdpa", mutates_args=())
+@torch.library.custom_op("auto_deploy::torch_attention_grouped_sdpa", mutates_args=())
 def grouped_sdpa(
     query: torch.Tensor,
     key: torch.Tensor,
@@ -104,7 +104,7 @@ def grouped_sdpa_fake(
     return query.new_empty(*query.shape[:-1], value.shape[-1]).contiguous()
 
 
-@torch.library.custom_op("attention::bsnd_grouped_sdpa", mutates_args=())
+@torch.library.custom_op("auto_deploy::torch_attention_bsnd_grouped_sdpa", mutates_args=())
 def bsnd_grouped_sdpa(
     query: torch.Tensor,  # layout: [b, n, s_q, d]
     key: torch.Tensor,  # layout: [b, n, s_k, d]
@@ -162,7 +162,7 @@ def update_kv_cache(
         )
 
 
-@torch.library.custom_op("attention::fused_mla_ref", mutates_args=())
+@torch.library.custom_op("auto_deploy::torch_attention_fused_mla_ref", mutates_args=())
 def fused_mla_ref(
     q_nope: torch.Tensor,
     q_pe: torch.Tensor,
@@ -315,7 +315,7 @@ def fused_mla_ref_fake(
     return torch.empty_like(kv[..., -v_head_dim:])
 
 
-@torch.library.custom_op("deepseek::fused_mla", mutates_args=())
+@torch.library.custom_op("auto_deploy::torch_attention_deepseek_fused_mla", mutates_args=())
 def fused_mla(
     q_nope: torch.Tensor,
     q_pe: torch.Tensor,
@@ -399,7 +399,7 @@ def fused_mla(
     return torch.empty_like(kv[..., -v_head_dim:])
 
 
-@torch.library.custom_op("deepseek::mla", mutates_args=())
+@torch.library.custom_op("auto_deploy::torch_attention_deepseek_mla", mutates_args=())
 def mla(
     q_nope: torch.Tensor,  # Down projected q_nope
     q_pe: torch.Tensor,  # q_pe after applying rope

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_attention.py
@@ -215,7 +215,7 @@ def fused_mla_ref(
             q_slice = q_pe[start : start + length]
             k_slice = k_pe[start : start + length]
 
-            q_rot, k_rot = torch.ops.rope.torch_apply_rope_with_qk_interleaving(
+            q_rot, k_rot = torch.ops.auto_deploy.torch_rope_with_qk_interleaving(
                 q_slice,
                 k_slice,
                 cos,
@@ -340,7 +340,7 @@ def fused_mla(
 
     cos = cos[position_ids]
     sin = sin[position_ids]
-    q_pe, k_pe = torch.ops.rope.torch_apply_rope_with_qk_interleaving(q_pe, k_pe, cos, sin)
+    q_pe, k_pe = torch.ops.auto_deploy.torch_rope_with_qk_interleaving(q_pe, k_pe, cos, sin)
 
     query_states = k_pe.new_empty(bs, num_heads, q_len, q_head_dim)
     query_states[:, :, :, :qk_nope_head_dim] = q_nope

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_rope.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_rope.py
@@ -11,7 +11,7 @@ def rotate_half(x):
     return torch.cat((-x2, x1), dim=-1)
 
 
-@torch.library.custom_op("rope::torch_apply_rope_with_explicit_cos_sin", mutates_args=())
+@torch.library.custom_op("auto_deploy::torch_rope_with_explicit_cos_sin", mutates_args=())
 def torch_apply_rope_with_explicit_cos_sin(
     q: torch.Tensor, k: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, unsqueeze_dim: int = 1
 ) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -38,7 +38,7 @@ def torch_apply_rope_with_explicit_cos_sin_fake(
     return torch.empty_like(q), torch.empty_like(k)
 
 
-@torch.library.custom_op("rope::torch_apply_rope_with_complex_freqs", mutates_args=())
+@torch.library.custom_op("auto_deploy::torch_rope_with_complex_freqs", mutates_args=())
 def torch_apply_rope_with_complex_freqs(
     xq: torch.Tensor,
     xk: torch.Tensor,
@@ -69,7 +69,7 @@ def torch_apply_rope_with_complex_freqs_fake(
     return torch.empty_like(xq), torch.empty_like(xk)
 
 
-@torch.library.custom_op("rope::torch_apply_rope_with_qk_interleaving", mutates_args=())
+@torch.library.custom_op("auto_deploy::torch_rope_with_qk_interleaving", mutates_args=())
 def torch_apply_rope_with_qk_interleaving(
     q: torch.Tensor, k: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, unsqueeze_dim: int = 1
 ) -> Tuple[torch.Tensor, torch.Tensor]:

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_attention.py
@@ -169,7 +169,7 @@ def _flattened_context_mha(
     )
 
 
-@torch.library.custom_op("attention::flattened_mha_with_cache", mutates_args=())
+@torch.library.custom_op("auto_deploy::triton_attention_flattened_mha_with_cache", mutates_args=())
 def flattened_mha_with_cache(
     # Q, K, V
     q: torch.Tensor,
@@ -259,7 +259,7 @@ def flattened_mha_fake(
     return q.new_empty(*q.shape[:-1], v.shape[-1]).contiguous()
 
 
-@torch.library.custom_op("attention::prepare_fused_mha_metadata", mutates_args=())
+@torch.library.custom_op("auto_deploy::triton_attention_prepare_fused_mha_metadata", mutates_args=())
 def prepare_fused_mha_metadata(
     input_ids: torch.Tensor,
     position_ids: torch.Tensor,
@@ -318,11 +318,11 @@ class TritonWithFlattenedInputs(AttentionDescriptor):
 
     @classmethod
     def get_cached_attention_op(cls) -> MHACallable:
-        return torch.ops.attention.flattened_mha_with_cache
+        return torch.ops.auto_deploy.triton_attention_flattened_mha_with_cache
 
     @classmethod
     def get_prepare_metadata_op(cls) -> Tuple[PrepareMetadataCallable, int]:
-        return torch.ops.attention.prepare_fused_mha_metadata, 4
+        return torch.ops.auto_deploy.triton_attention_prepare_fused_mha_metadata, 4
 
     @classmethod
     def get_cache_initializers(

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_attention.py
@@ -314,7 +314,7 @@ class TritonWithFlattenedInputs(AttentionDescriptor):
 
     @classmethod
     def get_source_attention_op(cls) -> OpOverloadPacket:
-        return torch.ops.attention.bsnd_grouped_sdpa
+        return torch.ops.auto_deploy.torch_attention_bsnd_grouped_sdpa
 
     @classmethod
     def get_cached_attention_op(cls) -> MHACallable:

--- a/tensorrt_llm/_torch/auto_deploy/models/deepseek.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/deepseek.py
@@ -53,7 +53,7 @@ def deepseek_v3_attention(
     # Use custom op to capture mla. This does not handle KV cache
     # as passing transformers Cache into a custom op is throwing an error.
     # Would not be an issue, cause we intend to replace mla op with our implementation further along the pipeline
-    attn_output = torch.ops.deepseek.fused_mla(
+    attn_output = torch.ops.auto_deploy.deepseek_fused_mla(
         q_nope,
         q_pe,
         kv,

--- a/tensorrt_llm/_torch/auto_deploy/models/deepseek.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/deepseek.py
@@ -131,7 +131,7 @@ def deepseek_v3_moe(self, hidden_states):
     """DeepSeekV3MoE forward function rewritten in Mixtral style to enable torch export."""
 
     selected_experts, routing_weights, *_ = self.gate(hidden_states)
-    final_hidden_states = torch.ops.moe.torch_moe(
+    final_hidden_states = torch.ops.auto_deploy.torch_moe(
         hidden_states,
         selected_experts,
         routing_weights,

--- a/tensorrt_llm/_torch/auto_deploy/models/deepseek.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/deepseek.py
@@ -53,7 +53,7 @@ def deepseek_v3_attention(
     # Use custom op to capture mla. This does not handle KV cache
     # as passing transformers Cache into a custom op is throwing an error.
     # Would not be an issue, cause we intend to replace mla op with our implementation further along the pipeline
-    attn_output = torch.ops.auto_deploy.deepseek_fused_mla(
+    attn_output = torch.ops.auto_deploy.torch_attention_deepseek_fused_mla(
         q_nope,
         q_pe,
         kv,

--- a/tensorrt_llm/_torch/auto_deploy/models/qwen3.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/qwen3.py
@@ -17,7 +17,7 @@ def _forward_moe(self: Qwen3MoeSparseMoeBlock, hidden_states: torch.Tensor):
     # we cast back to the input dtype
     routing_weights = routing_weights.to(hidden_states.dtype)
 
-    final_hidden_states = torch.ops.moe.torch_moe(
+    final_hidden_states = torch.ops.auto_deploy.torch_moe(
         hidden_states,
         selected_experts,
         routing_weights,

--- a/tensorrt_llm/_torch/auto_deploy/transformations/_graph.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/_graph.py
@@ -13,7 +13,6 @@ from torch._subclasses import FakeTensor, FakeTensorMode
 from torch.fx import Graph, GraphModule, Node
 from torch.fx.passes.fake_tensor_prop import FakeTensorProp
 from torch.fx.passes.shape_prop import _extract_tensor_metadata
-from torch.fx.passes.tools_common import legalize_graph
 from torch.utils._pytree import _LEAF_SPEC
 
 from ..utils.logger import ad_logger
@@ -165,7 +164,6 @@ def _canonicalize_single_gm(
 
     # clean up graph module
     gm.delete_all_unused_submodules()
-    gm = legalize_graph(gm)
 
     # NOTE: shape_prop can be a littly finicky & slow, so we only run it optionally...
     if shape_prop:

--- a/tensorrt_llm/_torch/auto_deploy/transformations/export.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/export.py
@@ -212,7 +212,7 @@ _torch_where_patch.where_original = torch.where
 def _torch_linear_patch(
     input: torch.Tensor, weight: torch.Tensor, bias: Optional[torch.Tensor] = None
 ) -> torch.Tensor:
-    return torch.ops.linear.simple(input, weight, bias)
+    return torch.ops.auto_deploy.torch_linear_simple(input, weight, bias)
 
 
 # TODO: remove once https://github.com/pytorch/pytorch/issues/142439 is resolved

--- a/tensorrt_llm/_torch/auto_deploy/transformations/export.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/export.py
@@ -335,7 +335,7 @@ def torch_export_to_gm(
     # there is no guarantee how it is represented and we need to make sure it is easily identifiable
     # in the graph.
     sdpa_original = F.scaled_dot_product_attention
-    F.scaled_dot_product_attention = torch.ops.attention.scaled_dot_product_attention
+    F.scaled_dot_product_attention = torch.ops.auto_deploy.torch_attention_sdpa
 
     # We overwrite the linear functional as well. This basically avoids exporting the view ops
     # that are used to flatten/unflatten multiple batch dimensions of the input tensor.

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/collectives.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/collectives.py
@@ -22,8 +22,8 @@ def fuse_collectives(gm: GraphModule) -> GraphModule:
     # lookup for fused ops
     # TODO: avoid this hardcoded lookup, e.g., by generating fused ops on the fly.
     lookup = {
-        torch.ops.linear.simple: torch.ops.linear.fused_linear_all_reduce,
-        torch.ops.aten.linear: torch.ops.linear.fused_linear_all_reduce,
+        torch.ops.linear.simple: torch.ops.auto_deploy.trtllm_dist_fused_linear_all_reduce,
+        torch.ops.aten.linear: torch.ops.auto_deploy.trtllm_dist_fused_linear_all_reduce,
         torch.ops.quant.fp8_linear: torch.ops.quant.fused_fp8_linear_all_reduce,
     }
 

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/collectives.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/collectives.py
@@ -29,7 +29,7 @@ def fuse_collectives(gm: GraphModule) -> GraphModule:
 
     # go through all nodes and find all_reduce nodes
     for node in gm.graph.nodes:
-        if not is_op(node, torch.ops.dist.all_reduce):
+        if not is_op(node, torch.ops.auto_deploy.torch_dist_all_reduce):
             continue
 
         # check if args are as expected
@@ -162,7 +162,7 @@ def fuse_allreduce_residual_rmsnorm(gm: GraphModule) -> GraphModule:
 
     # Traverse all nodes
     for node in gm.graph.nodes:
-        if is_op(node, torch.ops.dist.all_reduce):
+        if is_op(node, torch.ops.auto_deploy.torch_dist_all_reduce):
             trace_and_fuse(allreduce_node=node, graph=gm.graph)
 
     gm = canonicalize_graph(gm)

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/collectives.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/collectives.py
@@ -22,7 +22,7 @@ def fuse_collectives(gm: GraphModule) -> GraphModule:
     # lookup for fused ops
     # TODO: avoid this hardcoded lookup, e.g., by generating fused ops on the fly.
     lookup = {
-        torch.ops.linear.simple: torch.ops.auto_deploy.trtllm_dist_fused_linear_all_reduce,
+        torch.ops.auto_deploy.torch_linear_simple: torch.ops.auto_deploy.trtllm_dist_fused_linear_all_reduce,
         torch.ops.aten.linear: torch.ops.auto_deploy.trtllm_dist_fused_linear_all_reduce,
         torch.ops.quant.fp8_linear: torch.ops.quant.fused_fp8_linear_all_reduce,
     }

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/collectives.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/collectives.py
@@ -24,7 +24,7 @@ def fuse_collectives(gm: GraphModule) -> GraphModule:
     lookup = {
         torch.ops.auto_deploy.torch_linear_simple: torch.ops.auto_deploy.trtllm_dist_fused_linear_all_reduce,
         torch.ops.aten.linear: torch.ops.auto_deploy.trtllm_dist_fused_linear_all_reduce,
-        torch.ops.quant.fp8_linear: torch.ops.quant.fused_fp8_linear_all_reduce,
+        torch.ops.auto_deploy.torch_quant_fp8_linear: torch.ops.auto_deploy.torch_quant_fused_fp8_linear_all_reduce,
     }
 
     # go through all nodes and find all_reduce nodes

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/ep_sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/ep_sharding.py
@@ -38,7 +38,7 @@ def ep_shard(gm: GraphModule, rank: int, world_size: int) -> GraphModule:
     assert isinstance(gm, GraphModule), "Expecting GraphModule"
     num_moe_patterns = 0
     for node in list(gm.graph.nodes):
-        if not is_op(node, torch.ops.moe.torch_moe):
+        if not is_op(node, torch.ops.auto_deploy.torch_moe):
             continue
         _insert_sharded_moe(gm, node, rank, world_size)
         num_moe_patterns += 1

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/ep_sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/ep_sharding.py
@@ -123,6 +123,6 @@ def _insert_sharded_moe(
 
     # -- add an all_reduce node --
     with gm.graph.inserting_after(node):
-        dist_node = gm.graph.call_function(torch.ops.dist.all_reduce, args=(node,))
+        dist_node = gm.graph.call_function(torch.ops.auto_deploy.torch_dist_all_reduce, args=(node,))
         node.replace_all_uses_with(dist_node)
         dist_node.replace_input_with(dist_node, node)

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/fused_moe.py
@@ -69,7 +69,7 @@ def match_moe_pattern(gm: GraphModule) -> GraphModule:
             w3_list = expert_weights["w3"]
 
             fused_moe_node = graph.call_function(
-                torch.ops.moe.torch_moe,
+                torch.ops.auto_deploy.torch_moe,
                 args=(
                     hidden_states,
                     selected_experts,
@@ -99,7 +99,7 @@ def match_moe_pattern(gm: GraphModule) -> GraphModule:
 def fuse_moe(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
     """
     Scan the FX graph and replace all calls to torch.ops.moe.torch_moe with
-    torch.ops.moe.trtllm_fused_moe.
+    torch.ops.auto_deploy.trtllm_moe_fused.
     """
     ad_logger.debug("Before MoE fusion: " + str(gm))
 
@@ -118,7 +118,7 @@ def _insert_fused_moe_ops(gm: GraphModule) -> int:
     graph = gm.graph
 
     for node in list(graph.nodes):
-        if not is_op(node, torch.ops.moe.torch_moe):
+        if not is_op(node, torch.ops.auto_deploy.torch_moe):
             continue
 
         ad_logger.debug(f"Found MoE op to fuse: {node} with args: {node.args}")
@@ -146,7 +146,7 @@ def _insert_fused_moe_ops(gm: GraphModule) -> int:
 
         with graph.inserting_before(node):
             new_node = graph.call_function(
-                torch.ops.moe.trtllm_fused_moe,
+                torch.ops.auto_deploy.trtllm_moe_fused,
                 args=(
                     hidden_states,
                     selected_experts,

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/rope.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/rope.py
@@ -47,127 +47,136 @@ TODO: Support other variants:
 
 import operator
 from collections import defaultdict
-from typing import Any, DefaultDict, Dict, List, Optional, Sequence
+from typing import Any, DefaultDict, Dict, Optional, Sequence
 
 import torch
 from torch.fx import GraphModule, Node
 
 from ...utils.logger import ad_logger
-from ...utils.node_utils import (
-    bfs,
-    extract_op_args,
-    extract_output_tuple,
-    identify_regions_between_residuals,
-    is_op,
-)
+from ...utils.node_utils import extract_op_args, extract_output_tuple, is_op
+from ...utils.pattern_matcher import Match, PatternMatcherPass, register_pattern
 from .._graph import canonicalize_graph
 
 
-def match_explicit_rope(gm: GraphModule) -> GraphModule:
-    """
-    Identify and replace RoPE subgraphs (explicit cos/sin multiplication pattern):
+def _rotate_half(x):
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
 
-      - HF-style: output = (raw * unsqueeze(cos)) + (rotate_half(raw) * unsqueeze(sin))
-      - DS-style: requires interleaving Q/K before the cos/sin mul
 
-    If exactly two such branches (query and key) are detected within each region, they're replaced
-    by a call to `rope::torch_apply_rope_with_qk_interleaving` or
-    `rope::torch_apply_rope_with_explicit_cos_sin` respectively.
-    """
+def _explicit_rope_pattern(q, k, cos, sin, unsqueeze_dim=1):
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    q_embed = (q * cos) + (_rotate_half(q) * sin)
+    k_embed = (k * cos) + (_rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+def _explicit_rope_repl(q, k, cos, sin, unsqueeze_dim):
+    return torch.ops.rope.torch_apply_rope_with_explicit_cos_sin.default(
+        q, k, cos, sin, unsqueeze_dim
+    )
+
+
+def _interleaved_rope_pattern(q, k, cos, sin, unsqueeze_dim=1):
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    b, h, s, d = q.shape
+    q = q.view(b, h, s, d // 2, 2).transpose(4, 3).reshape(b, h, s, d)
+    b, h, s, d = k.shape
+    k = k.view(b, h, s, d // 2, 2).transpose(4, 3).reshape(b, h, s, d)
+    q_embed = (q * cos) + (_rotate_half(q) * sin)
+    k_embed = (k * cos) + (_rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+def _interleaved_rope_repl(q, k, cos, sin, unsqueeze_dim):
+    return torch.ops.rope.torch_apply_rope_with_qk_interleaving.default(
+        q, k, cos, sin, unsqueeze_dim
+    )
+
+
+# exporting with {"unsqueeze_dim": 2},
+# would confuse the pattern matcher since '2' is arg of other ops
+def _complex_rope_pattern(xq, xk, freqs_cis, unsqueeze_dim=1):
+    xq_ = torch.view_as_complex(xq.float().reshape(*xq.shape[:-1], -1, 2))
+    xk_ = torch.view_as_complex(xk.float().reshape(*xk.shape[:-1], -1, 2))
+    freqs_q = freqs_cis.unsqueeze(unsqueeze_dim)
+    freqs_k = freqs_cis.unsqueeze(unsqueeze_dim)
+    xq_out = torch.view_as_real(xq_ * freqs_q).flatten(3)
+    xk_out = torch.view_as_real(xk_ * freqs_k).flatten(3)
+    return xq_out.type_as(xq), xk_out.type_as(xk)
+
+
+def _complex_rope_repl(q, k, freqs_cis, unsqueeze_dim):
+    return torch.ops.rope.torch_apply_rope_with_complex_freqs.default(
+        q, k, freqs_cis, unsqueeze_dim
+    )
+
+
+def _explicit_not_interleaved(match: Match) -> bool:
+    q, k = match.kwargs.get("q"), match.kwargs.get("k")
+    return not any(isinstance(n, Node) and _match_input_interleave_pattern(n) for n in (q, k))
+
+
+def match_rope_pattern(gm: GraphModule) -> GraphModule:
     graph = gm.graph
-    boundary_nodes: List[torch.fx.Node] = identify_regions_between_residuals(gm)
+    patterns = PatternMatcherPass()
 
-    num_explicit_rope_patterns = 0
-    for start_boundary, end_boundary in zip(boundary_nodes[:-1], boundary_nodes[1:]):
-        matches = []  # list of (match_info, is_ds)
-        node = start_boundary
-        while node != end_boundary:
-            if is_op(node, torch.ops.aten.add):
-                explicit = _match_explicit_rope_subpattern(node)
-                if explicit is not None:
-                    raw = explicit["raw_input"]
-                    # check if this raw is result of DS interleave
-                    inter = _match_input_interleave_pattern(raw)
-                    if inter is not None:
-                        ds_match = {
-                            "raw_input": inter["interleaved"],
-                            "unsqueeze_cos": explicit["unsqueeze_cos"],
-                            "unsqueeze_sin": explicit["unsqueeze_sin"],
-                            "add_node": explicit["add_node"],
-                        }
-                        matches.append((ds_match, True))
-                    else:
-                        matches.append((explicit, False))
-            node = node.next
+    # dummy shapes: can be arbitrary
+    batch_size = 8
+    seq_len = 16
+    num_heads = 8
+    hidden_size = 512
+    head_dim = hidden_size // num_heads
 
-        if not matches:
-            continue
-        if len(matches) != 2:
-            ad_logger.warning(
-                f"Expected exactly 2 legacy RoPE branches between {start_boundary} and {end_boundary}, "
-                f"found {len(matches)}."
-            )
-            continue
+    dummy_explicit = [
+        torch.randn(batch_size, num_heads, seq_len, head_dim, device="meta", dtype=torch.float16),
+        torch.randn(batch_size, num_heads, seq_len, head_dim, device="meta", dtype=torch.float16),
+        torch.randn(batch_size, seq_len, head_dim, device="meta", dtype=torch.float16),
+        torch.randn(batch_size, seq_len, head_dim, device="meta", dtype=torch.float16),
+    ]
+    dummy_complex = [
+        torch.randn(batch_size, num_heads, seq_len, head_dim, device="meta", dtype=torch.float16),
+        torch.randn(batch_size, num_heads, seq_len, head_dim, device="meta", dtype=torch.float16),
+        torch.randn(batch_size, seq_len, head_dim // 2, device="meta", dtype=torch.float16),
+    ]
+    register_pattern(
+        search_fn=_explicit_rope_pattern,
+        replace_fn=_explicit_rope_repl,
+        patterns=patterns,
+        dummy_args=dummy_explicit,
+        op_ignore_types={torch.ops.aten.slice.Tensor: (int,)},
+        scalar_workaround={"unsqueeze_dim": 1},
+        extra_check=_explicit_not_interleaved,
+    )
+    register_pattern(
+        search_fn=_interleaved_rope_pattern,
+        replace_fn=_interleaved_rope_repl,
+        patterns=patterns,
+        dummy_args=dummy_explicit,
+        op_ignore_types={
+            torch.ops.aten.slice.Tensor: (int,),
+            torch.ops.aten.reshape.default: (int,),
+            torch.ops.aten.view.default: (int,),
+        },
+        scalar_workaround={"unsqueeze_dim": 1},
+    )
+    register_pattern(
+        search_fn=_complex_rope_pattern,
+        replace_fn=_complex_rope_repl,
+        patterns=patterns,
+        dummy_args=dummy_complex,
+        op_ignore_types={
+            torch.ops.aten.reshape.default: (int,),
+        },
+        scalar_workaround={"unsqueeze_dim": 1},
+    )
 
-        (q_match, q_is_ds), (k_match, k_is_ds) = matches
-        if q_is_ds != k_is_ds:
-            ad_logger.warning("Mismatched RoPE types between q and k branches")
-            continue
-
-        if q_is_ds:
-            _process_input_interleave_rope(graph, q_match, k_match)
-        else:
-            _process_explicit_rope(graph, q_match, k_match, start_boundary)
-        num_explicit_rope_patterns += 1
-    if num_explicit_rope_patterns:
-        gm = canonicalize_graph(gm)
-    ad_logger.info(f"Found and matched {num_explicit_rope_patterns} explicit RoPE patterns")
-    return gm
-
-
-def match_complex_rope(gm: GraphModule) -> GraphModule:
-    """
-    Identify and replace RoPE subgraphs using complex multiplication pattern:
-
-      output = type_as(flatten(view_as_real(mul(view_as_complex(reshape(to_dtype(x))), unsqueeze(freqs_cis, 2)))), x)
-
-    If exactly two such branches (query and key) are detected within each region, they're replaced
-    by a call to `torch.ops.rope.torch_apply_rope_with_complex_freqs`.
-    """
-    graph = gm.graph
-    boundary_nodes: List[torch.fx.Node] = identify_regions_between_residuals(gm)
-
-    num_complex_rope_patterns = 0
-    for start_boundary, end_boundary in zip(boundary_nodes[:-1], boundary_nodes[1:]):
-        matches = []
-        node = start_boundary
-        while node != end_boundary:
-            if is_op(node, torch.ops.aten.type_as):
-                match_info = _match_complex_rope_subpattern(node)
-                if match_info:
-                    matches.append(match_info)
-            node = node.next
-
-        if not matches:
-            continue
-        if len(matches) != 2:
-            ad_logger.warning(
-                f"Expected exactly 2 complex RoPE branches between {start_boundary} and {end_boundary}, "
-                f"found {len(matches)}."
-            )
-            continue
-
-        # Assume the first matched branch is query (q), second is key (k).
-        # This assumption is based on the default ordering in the exported graph,
-        # since node naming conventions don't reliably indicate q/k branches.
-        q_match, k_match = matches
-        _process_complex_rope(graph, q_match, k_match)
-        num_complex_rope_patterns += 1
-
-    if num_complex_rope_patterns:
-        gm = canonicalize_graph(gm)
-    ad_logger.info(f"Found and matched {num_complex_rope_patterns} complex RoPE patterns")
-    return gm
+    num_matches = patterns.apply(graph)
+    gm = canonicalize_graph(gm)
+    ad_logger.info(f"Found and matched {num_matches} RoPE patterns")
+    return gm, num_matches
 
 
 def match_rope_layout(gm: GraphModule, expected_layout: str = "bsnd") -> GraphModule:
@@ -497,306 +506,6 @@ def _match_input_interleave_pattern(node: Node) -> Optional[Dict[str, Node]]:
     if not isinstance(raw_node, Node):
         return None
     return {"interleaved": raw_node}
-
-
-def _match_explicit_rope_subpattern(add_node: Node) -> Optional[Dict[str, Node]]:
-    """
-    Given an aten.add.Tensor node that is expected to compute:
-      output = (raw_input * unsqueeze(cos)) + (rotate_half(raw_input) * unsqueeze(sin))
-    where rotate_half is implemented as:
-      rotate_half(x) = cat([ -slice(x, second_half), slice(x, first_half) ], dim=-1)
-    this function inspects the structure of add_node and returns a dictionary with:
-       - "raw_input": the original q/k tensor,
-       - "unsqueeze_cos": the unsqueeze node feeding the raw multiplication,
-       - "unsqueeze_sin": the unsqueeze node feeding the rotated multiplication,
-       - "add_node": the addition node itself.
-    Returns None if the pattern does not match.
-    """
-    # Check that add_node is an add operation with two inputs.
-    if not is_op(add_node, torch.ops.aten.add):
-        return None
-    if not (len(add_node.args) == 2):
-        return None
-
-    mul1, mul2 = add_node.args
-    # Both inputs to the add should be multiplications.
-    if not is_op(mul1, torch.ops.aten.mul):
-        return None
-    if not is_op(mul2, torch.ops.aten.mul):
-        return None
-
-    # One branch should be the raw branch and the other the rotated branch.
-    # We decide by checking if one multiplication’s first argument is a cat (i.e. the rotate_half result).
-    if is_op(mul1.args[0], torch.ops.aten.cat):
-        mul_rot = mul1
-        mul_raw = mul2
-    elif is_op(mul2.args[0], torch.ops.aten.cat):
-        mul_rot = mul2
-        mul_raw = mul1
-    else:
-        return None
-
-    # Verify that both multiplications have an unsqueeze as their second argument.
-    unsqueeze_cos = mul_raw.args[1]
-    unsqueeze_sin = mul_rot.args[1]
-    if not is_op(unsqueeze_cos, torch.ops.aten.unsqueeze):
-        return None
-    if not is_op(unsqueeze_sin, torch.ops.aten.unsqueeze):
-        return None
-
-    # Check that the rotated branch is a cat of two tensors along -1.
-    cat_node = mul_rot.args[0]
-    if not is_op(cat_node, torch.ops.aten.cat):
-        return None
-    # Expecting two inputs in a list/tuple.
-    cat_inputs = cat_node.args[0]
-    if not (isinstance(cat_inputs, (list, tuple)) and len(cat_inputs) == 2):
-        return None
-
-    # One of the two inputs should be a negation of a slice, the other should be a slice.
-    first_item, second_item = cat_inputs
-    if not is_op(first_item, torch.ops.aten.neg):
-        return None
-    if not is_op(second_item, torch.ops.aten.slice):
-        return None
-
-    # The negation node should wrap a slice.
-    neg_node = first_item
-    if not (len(neg_node.args) >= 1 and is_op(neg_node.args[0], torch.ops.aten.slice)):
-        return None
-
-    # For simplicity, require that the two slice operations (the one inside neg and the one used directly)
-    # are applied on the same original tensor. This original tensor is the one being rotated.
-    slice_in_neg = neg_node.args[0]
-    if slice_in_neg.args[0] != second_item.args[0]:
-        return None
-
-    # Finally, the raw branch should multiply the original tensor (i.e. q or k) by unsqueeze_cos.
-    raw_input = mul_raw.args[0]
-    # We also expect that the tensor being sliced (and negated) is the same as raw_input.
-    if raw_input != slice_in_neg.args[0]:
-        return None
-
-    return {
-        "raw_input": raw_input,
-        "unsqueeze_cos": unsqueeze_cos,
-        "unsqueeze_sin": unsqueeze_sin,
-        "add_node": add_node,
-    }
-
-
-def _match_complex_rope_subpattern(type_as_node: Node) -> Optional[Dict[str, Node]]:
-    """
-    Given a type_as node, this function inspects the graph
-    structure and returns a dictionary with:
-       - "input": the original xq (or xk) tensor,
-       - "inv_freq": the freqs_cis tensor (before unsqueeze),
-       - "out": the type_as node corresponding to the branch output.
-
-    Expected branch structure for each output:
-        x_out = type_as( flatten( view_as_real( view_as_complex(reshape(to_dtype(x))) * unsqueeze(freqs_cis) ) ) )
-
-    Returns None if the structure does not match.
-    """
-    if not is_op(type_as_node, torch.ops.aten.type_as):
-        return None
-
-    # The type_as node should have at least one argument: its first argument is the flatten op.
-    if not (len(type_as_node.args) >= 1):
-        return None
-    flatten_node = type_as_node.args[0]
-    if not is_op(flatten_node, torch.ops.aten.flatten):
-        return None
-
-    # The input of the flatten op should be a view_as_real op.
-    if not (len(flatten_node.args) >= 1):
-        return None
-    view_as_real_node = flatten_node.args[0]
-    if not is_op(view_as_real_node, torch.ops.aten.view_as_real):
-        return None
-
-    # The input of view_as_real should be a multiplication.
-    if not (len(view_as_real_node.args) >= 1):
-        return None
-    mul_node = view_as_real_node.args[0]
-    if not is_op(mul_node, torch.ops.aten.mul):
-        return None
-    if len(mul_node.args) != 2:
-        return None
-
-    # In the multiplication, one operand should be an unsqueeze of freqs_cis and
-    #    the other operand is the output of view_as_complex.
-    if is_op(mul_node.args[0], torch.ops.aten.unsqueeze):
-        unsqueeze_node = mul_node.args[0]
-        vc_node = mul_node.args[1]
-    elif is_op(mul_node.args[1], torch.ops.aten.unsqueeze):
-        unsqueeze_node = mul_node.args[1]
-        vc_node = mul_node.args[0]
-    else:
-        return None
-
-    if not (len(unsqueeze_node.args) >= 2):
-        return None
-    unsqueeze_dim = unsqueeze_node.args[1]
-
-    inv_freq_candidate = unsqueeze_node.args[0]
-
-    # Match the view_as_complex branch.
-    if not is_op(vc_node, torch.ops.aten.view_as_complex):
-        return None
-    if not (len(vc_node.args) >= 1):
-        return None
-    reshape_node = vc_node.args[0]
-    if not is_op(reshape_node, torch.ops.aten.reshape):
-        return None
-
-    # The reshape op should get its input from a to(dtype) conversion.
-    if not (len(reshape_node.args) >= 1):
-        return None
-    to_node = reshape_node.args[0]
-    if not is_op(to_node, torch.ops.aten.to):
-        return None
-    if not (len(to_node.args) >= 1):
-        return None
-    input_tensor = to_node.args[0]
-
-    return {
-        "input": input_tensor,
-        "inv_freq": inv_freq_candidate,
-        "out": type_as_node,
-        "unsqueeze_dim": unsqueeze_dim,
-    }
-
-
-def _process_explicit_rope(
-    graph: GraphModule.graph,
-    q_match: Dict[str, Node],
-    k_match: Dict[str, Node],
-    start_boundary: Node,
-) -> None:
-    """
-    Replace matched Explicit RoPE subgraph with `rope::torch_apply_rope_with_explicit_cos_sin`.
-    """
-    q_node = q_match["raw_input"]
-    k_node = k_match["raw_input"]
-    cos_unsq = q_match["unsqueeze_cos"]
-    sin_unsq = q_match["unsqueeze_sin"]
-    cos_node = cos_unsq.args[0]
-    sin_node = sin_unsq.args[0]
-    unsq_dim = cos_unsq.args[1]
-    add_node = q_match["add_node"]
-
-    # Sanity-check: ensure cos/sin nodes trace back to aten.cos/aten.sin.
-    bfs(
-        cos_node,
-        lambda n: is_op(n, torch.ops.aten.cos),
-        attr_next="all_input_nodes",
-        boundary=start_boundary,
-    )
-    bfs(
-        sin_node,
-        lambda n: is_op(n, torch.ops.aten.sin),
-        attr_next="all_input_nodes",
-        boundary=start_boundary,
-    )
-
-    with graph.inserting_before(add_node):
-        rope_node = graph.call_function(
-            torch.ops.rope.torch_apply_rope_with_explicit_cos_sin,
-            args=(q_node, k_node, cos_node, sin_node, unsq_dim),
-        )
-
-    with graph.inserting_after(rope_node):
-        out_q = graph.call_function(operator.getitem, args=(rope_node, 0))
-        out_k = graph.call_function(operator.getitem, args=(rope_node, 1))
-
-    out_q.meta["val"] = add_node.meta.get("val", None)
-    out_k.meta["val"] = k_match["add_node"].meta.get("val", None)
-
-    q_match["add_node"].replace_all_uses_with(out_q)
-    k_match["add_node"].replace_all_uses_with(out_k)
-
-
-def _process_complex_rope(
-    graph: GraphModule.graph,
-    q_match: Dict[str, Node],
-    k_match: Dict[str, Node],
-) -> None:
-    """
-    Replace matched Complex RoPE subgraph with `rope::torch_apply_rope_with_complex_freqs`.
-    """
-    xq = q_match["input"]
-    xk = k_match["input"]
-    inv = q_match["inv_freq"]
-    usdim = q_match["unsqueeze_dim"]
-    out_node = q_match.get("out")
-
-    if inv != k_match["inv_freq"]:
-        ad_logger.warning(
-            "Mismatch of freqs_cis (inv_freq) between branches. Fail to match complex rope pattern"
-        )
-        return
-
-    with graph.inserting_before(out_node):
-        rope_node = graph.call_function(
-            torch.ops.rope.torch_apply_rope_with_complex_freqs,
-            args=(xq, xk, inv, usdim),
-        )
-
-    with graph.inserting_after(rope_node):
-        out_q = graph.call_function(operator.getitem, args=(rope_node, 0))
-        out_k = graph.call_function(operator.getitem, args=(rope_node, 1))
-
-    out_q.meta["val"] = out_node.meta.get("val", None)
-    out_k.meta["val"] = k_match["out"].meta.get("val", None)
-
-    out_node.replace_all_uses_with(out_q)
-    k_match["out"].replace_all_uses_with(out_k)
-
-
-def _process_input_interleave_rope(
-    graph: GraphModule,
-    q_match: Dict[str, Node],
-    k_match: Dict[str, Node],
-) -> None:
-    """
-    Replace a matched DS-style RoPE subgraph with a call to rope::torch_apply_rope_with_qk_interleaving.
-    Cache the one-time unsqueeze of cos/sin.
-    """
-    q_node = q_match["raw_input"]
-    k_node = k_match["raw_input"]
-    cos_node = q_match["unsqueeze_cos"].args[0]
-    sin_node = q_match["unsqueeze_sin"].args[0]
-    # A patch for the case when q_output appears before k_input in the graph
-    # Move q_output down right before its first user so that graph remains in
-    # topological order after inserting the apply rope custom op
-    q_match["add_node"] = _move_node_before_first_user(q_match["add_node"])
-
-    # Infer unsqueeze_dim from layout
-    unsq_dim = 1
-    fake = q_node.meta.get("val", None)
-    if fake is not None and len(fake.shape) == 4:
-        # if shape[1] symbolic, it's [B, S, N, D] => BSND -> head dim is 2
-        if isinstance(fake.shape[1], torch.SymInt):
-            unsq_dim = 2
-        else:
-            unsq_dim = 1
-
-    with graph.inserting_after(_get_last_node([q_node, k_node, cos_node, sin_node])):
-        ds_node = graph.call_function(
-            torch.ops.rope.torch_apply_rope_with_qk_interleaving,
-            args=(q_node, k_node, cos_node, sin_node, unsq_dim),
-        )
-
-    with graph.inserting_after(ds_node):
-        q_out = graph.call_function(operator.getitem, args=(ds_node, 0))
-        k_out = graph.call_function(operator.getitem, args=(ds_node, 1))
-
-    q_out.meta["val"] = q_match["add_node"].meta.get("val", None)
-    k_out.meta["val"] = k_match["add_node"].meta.get("val", None)
-
-    q_match["add_node"].replace_all_uses_with(q_out)
-    k_match["add_node"].replace_all_uses_with(k_out)
 
 
 def _move_node_before_first_user(node: Node) -> Node:

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/rope.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/rope.py
@@ -73,7 +73,7 @@ def _explicit_rope_pattern(q, k, cos, sin, unsqueeze_dim=1):
 
 
 def _explicit_rope_repl(q, k, cos, sin, unsqueeze_dim):
-    return torch.ops.rope.torch_apply_rope_with_explicit_cos_sin.default(
+    return torch.ops.auto_deploy.torch_rope_with_explicit_cos_sin.default(
         q, k, cos, sin, unsqueeze_dim
     )
 
@@ -91,7 +91,7 @@ def _interleaved_rope_pattern(q, k, cos, sin, unsqueeze_dim=1):
 
 
 def _interleaved_rope_repl(q, k, cos, sin, unsqueeze_dim):
-    return torch.ops.rope.torch_apply_rope_with_qk_interleaving.default(
+    return torch.ops.auto_deploy.torch_rope_with_qk_interleaving.default(
         q, k, cos, sin, unsqueeze_dim
     )
 
@@ -109,7 +109,7 @@ def _complex_rope_pattern(xq, xk, freqs_cis, unsqueeze_dim=1):
 
 
 def _complex_rope_repl(q, k, freqs_cis, unsqueeze_dim):
-    return torch.ops.rope.torch_apply_rope_with_complex_freqs.default(
+    return torch.ops.auto_deploy.torch_rope_with_complex_freqs.default(
         q, k, freqs_cis, unsqueeze_dim
     )
 
@@ -195,9 +195,9 @@ def match_rope_layout(gm: GraphModule, expected_layout: str = "bsnd") -> GraphMo
 
     graph = gm.graph
     rope_ops = {
-        torch.ops.rope.torch_apply_rope_with_explicit_cos_sin,
-        torch.ops.rope.torch_apply_rope_with_qk_interleaving,
-        torch.ops.rope.torch_apply_rope_with_complex_freqs,
+        torch.ops.auto_deploy.torch_rope_with_explicit_cos_sin,
+        torch.ops.auto_deploy.torch_rope_with_qk_interleaving,
+        torch.ops.auto_deploy.torch_rope_with_complex_freqs,
     }
 
     need_transpose = False
@@ -206,7 +206,7 @@ def match_rope_layout(gm: GraphModule, expected_layout: str = "bsnd") -> GraphMo
         if not is_op(node, rope_ops):
             continue
 
-        if is_op(node, torch.ops.rope.torch_apply_rope_with_complex_freqs):
+        if is_op(node, torch.ops.auto_deploy.torch_rope_with_complex_freqs):
             q_node, k_node, freqs_node, unsq = extract_op_args(
                 node,
                 "xq",  # argument name in schema
@@ -257,7 +257,7 @@ def match_rope_layout(gm: GraphModule, expected_layout: str = "bsnd") -> GraphMo
         q_for_op_contig.meta["val"] = q_node.meta["val"].transpose(1, 2)
         k_for_op_contig.meta["val"] = k_node.meta["val"].transpose(1, 2)
 
-        if is_op(node, torch.ops.rope.torch_apply_rope_with_complex_freqs):
+        if is_op(node, torch.ops.auto_deploy.torch_rope_with_complex_freqs):
             new_args = (
                 q_for_op_contig,
                 k_for_op_contig,
@@ -309,9 +309,9 @@ def optimize_rope(gm: GraphModule) -> GraphModule:
 
     num_rope_optimizations = 0
     for node in list(graph.nodes):
-        if is_op(node, torch.ops.rope.torch_apply_rope_with_explicit_cos_sin):
+        if is_op(node, torch.ops.auto_deploy.torch_rope_with_explicit_cos_sin):
             _optimize_explicit(graph, node, rope_flash_cache, rope_position_ids_cache)
-        elif is_op(node, torch.ops.rope.torch_apply_rope_with_complex_freqs):
+        elif is_op(node, torch.ops.auto_deploy.torch_rope_with_complex_freqs):
             _optimize_complex(graph, node, rope_flash_cache, rope_position_ids_cache)
         else:
             continue

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/rope.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/rope.py
@@ -1,6 +1,6 @@
 """
 This transformation defines two main RoPE (Rotary Positional Embedding) pattern matchers used
-to identify and replace RoPE subgraphs with a custom op (`torch.ops.rope.flashinfer`).
+to identify and replace RoPE subgraphs with a custom op (`torch.ops.auto_deploy.flashinfer_rope`).
 
 Supported RoPE variants:
 
@@ -398,7 +398,7 @@ def _optimize_explicit(
             rope_position_ids_cache=pos_cache,
         )
         flash_node = graph.call_function(
-            torch.ops.rope.flashinfer,
+            torch.ops.auto_deploy.flashinfer_rope,
             args=(q_node, k_node, position_ids, fused_cos_sin_to, True),
         )
 
@@ -478,7 +478,7 @@ def _optimize_complex(
             graph, q_node, batch_dim=0, seq_dim=1, rope_position_ids_cache=pos_cache
         )
         flash_node = graph.call_function(
-            torch.ops.rope.flashinfer,
+            torch.ops.auto_deploy.flashinfer_rope,
             args=(q_node, k_node, position_ids, cos_sin_flash, False),
         )
 

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/sharding.py
@@ -258,9 +258,9 @@ def column_row_shard(
 
     # acceptable attention nodes between sharded GEMMs
     shardable_attention_nodes = {
-        torch.ops.attention.scaled_dot_product_attention,
-        torch.ops.attention.grouped_sdpa,
-        torch.ops.attention.bsnd_grouped_sdpa,
+        torch.ops.auto_deploy.torch_attention_sdpa,
+        torch.ops.auto_deploy.torch_attention_grouped_sdpa,
+        torch.ops.auto_deploy.torch_attention_bsnd_grouped_sdpa,
     }
 
     # This is a heuristic. Basically, we assume those are okay to shard if we also encounter an

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/sharding.py
@@ -16,6 +16,7 @@ Our sharding algorithm for tensor parallelism (TP) is based on the following ste
        happens automatically via the checkpoint loading hook added in step 2c.
 """
 
+import math
 import operator
 from collections import defaultdict
 from functools import partial
@@ -71,7 +72,13 @@ def _load_hook_remove(
 
 
 def _insert_sharded_matmul(
-    gm: GraphModule, node: Node, dim: int, rank: int, world_size: int, add_dist: bool = False
+    gm: GraphModule,
+    node: Node,
+    dim: int,
+    rank: int,
+    world_size: int,
+    add_dist: bool = False,
+    min_local_shape: int = 1,
 ):
     """Replaces the matmul node with a new matmul node that accepts sharded weights.
 
@@ -83,8 +90,21 @@ def _insert_sharded_matmul(
     quantization_impl = QuantizationImpl.create(node)
 
     def split_tensor(
-        t: torch.Tensor, d: int = dim, r: int = rank, ws: int = world_size
+        t: torch.Tensor,
+        d: int = dim,
+        r: int = rank,
+        ws: int = world_size,
+        min_d_shape: int = min_local_shape,
     ) -> torch.Tensor:
+        # The local tensor shape has to be divisible by min_d_shape
+        max_split_size = t.shape[d] // min_d_shape
+        if ws > max_split_size:
+            num_groups = math.ceil(ws / max_split_size)
+            ad_logger.debug(
+                f"World size {ws} is greater than the max split size {max_split_size}. "
+                + f"Splitting tensor to {num_groups} chunks"
+            )
+            return torch.tensor_split(t, max_split_size, dim=d)[r // num_groups]
         return torch.tensor_split(t, ws, dim=d)[r]
 
     num_users = num_users_of_weight_node(node)
@@ -191,7 +211,10 @@ def _simple_shard(
 
 
 def column_row_shard(
-    gm: GraphModule, rank: int, world_size: int, simple_shard_only: bool = False
+    gm: GraphModule,
+    rank: int,
+    world_size: int,
+    simple_shard_only: bool = False,
 ) -> GraphModule:
     """A transformation to apply sharding to the model following tensor parallelism.
 
@@ -205,6 +228,9 @@ def column_row_shard(
        **all** nodes in the subgraph. The subgraph here is defined as the region between the first
        linear node to the last linear node of an identified sharding region.
     # 5. Shard the GEMM nodes or skip accordingly.
+
+    min_local_shape is the minimum size of the local tensor shard, to prevent TP parallelism
+    splitting, e.g., the individual heads into smaller shards.
     """
     ad_logger.debug("Before sharding graph: " + str(gm))
 
@@ -327,9 +353,25 @@ def column_row_shard(
 
         # If we can account for all sharded nodes, we can do a two-way shard
         # --> row_split (dim 0) + col_split (dim 1) + all_reduce
+
+        # check if we are sharding the attention block
+        if attention_nodes:
+            if len(attention_nodes) > 1:
+                # Column-row shard boundary region detection is probably wrong - there should be
+                # only one attention operation. Fall back to simple shard.
+                ad_logger.debug(f"More than one attention node: {unaccounted_nodes}")
+                _simple_shard(gm, nodes_linear, rank, world_size)
+                continue
+            # Extract head dimension. We cannot shard below the head_dim size.
+            # Assume that head_dim is the last (innermost) dimension of the tensor
+            min_local_shape = attention_nodes.pop().meta["val"].shape[-1]
+        else:
+            min_local_shape = 1
         for i, group in enumerate(nodes_linear.values()):
             for n in group:
-                _insert_sharded_matmul(gm, n, i, rank, world_size, add_dist=i > 0)
+                _insert_sharded_matmul(
+                    gm, n, i, rank, world_size, add_dist=i > 0, min_local_shape=min_local_shape
+                )
 
     # canonicalize and return
     if num_shards:

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/sharding.py
@@ -270,7 +270,7 @@ def column_row_shard(
     shardable_nodes_with_attention = {
         torch.ops.aten.view,
         torch.ops.aten.reshape,
-        torch.ops.rope.flashinfer,
+        torch.ops.auto_deploy.flashinfer_rope,
         operator.getitem,
     }
 

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/sharding.py
@@ -188,8 +188,8 @@ def _insert_sharded_matmul(
 
     # figure out the right dist op
     dist_lookup = {
-        0: (torch.ops.dist.all_gather, -1),
-        1: (torch.ops.dist.all_reduce,),
+        0: (torch.ops.auto_deploy.torch_dist_all_gather, -1),
+        1: (torch.ops.auto_deploy.torch_dist_all_reduce,),
     }
     fn_dist, *dist_args = dist_lookup[dim]
 
@@ -466,7 +466,7 @@ def dp_bmm_shard(gm: GraphModule, rank: int, world_size: int) -> GraphModule:
         base_size = bmm_batch_size // world_size
         remainder = bmm_batch_size % world_size
 
-        # NOTE: our torch.ops.dist.all_gather doesn't support uneven splits at the moment.
+        # NOTE: our torch.ops.auto_deploy.torch_dist_all_gather doesn't support uneven splits at the moment.
         if remainder:
             ad_logger.warning(
                 f"BMM batch size {bmm_batch_size} is not divisible by world size {world_size}. "
@@ -493,7 +493,7 @@ def dp_bmm_shard(gm: GraphModule, rank: int, world_size: int) -> GraphModule:
         # Add all_gather node after BMM to collect results
         with gm.graph.inserting_after(node):
             gather_node = gm.graph.call_function(
-                torch.ops.dist.all_gather,
+                torch.ops.auto_deploy.torch_dist_all_gather,
                 args=(node, 0),  # Gather along batch dimension (0)
             )
             node.replace_all_uses_with(gather_node)

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/visualization.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/visualization.py
@@ -70,7 +70,7 @@ PytorchExportedProgramAdapterImpl.add_outputs_metadata = add_outputs_metadata
 CUSTOM_OPS = (
     torch.ops.dist.all_reduce.default,
     torch.ops.aten.slice.Tensor,
-    torch.ops.attention.fused_mha_with_cache.default,
+    torch.ops.auto_deploy.triton_attention_fused_mha_with_cache.default,
     torch.ops.linear.fused_linear_all_reduce.default,
     torch.ops.linear.simple.default,
     torch.ops.aten.split_with_sizes.default,

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/visualization.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/visualization.py
@@ -68,7 +68,7 @@ PytorchExportedProgramAdapterImpl.add_outputs_metadata = add_outputs_metadata
 
 # TODO(yudong): make custom_ops configurable
 CUSTOM_OPS = (
-    torch.ops.dist.all_reduce.default,
+    torch.ops.auto_deploy.torch_dist_all_reduce.default,
     torch.ops.aten.slice.Tensor,
     torch.ops.auto_deploy.triton_attention_fused_mha_with_cache.default,
     torch.ops.linear.fused_linear_all_reduce.default,

--- a/tensorrt_llm/_torch/auto_deploy/transformations/library/visualization.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/library/visualization.py
@@ -71,8 +71,8 @@ CUSTOM_OPS = (
     torch.ops.auto_deploy.torch_dist_all_reduce.default,
     torch.ops.aten.slice.Tensor,
     torch.ops.auto_deploy.triton_attention_fused_mha_with_cache.default,
-    torch.ops.linear.fused_linear_all_reduce.default,
-    torch.ops.linear.simple.default,
+    torch.ops.auto_deploy.trtllm_dist_fused_linear_all_reduce.default,
+    torch.ops.auto_deploy.torch_linear_simple.default,
     torch.ops.aten.split_with_sizes.default,
 )
 

--- a/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
@@ -24,13 +24,12 @@ from .library import (
     insert_cached_attention,
     match_attention_layout,
     match_causal_attn_mask,
-    match_complex_rope,
     match_eager_attention,
-    match_explicit_rope,
     match_grouped_attention,
     match_moe_pattern,
     match_repeat_kv,
     match_rope_layout,
+    match_rope_pattern,
     optimize_rope,
     quantize,
     resize_kv_cache,
@@ -116,8 +115,8 @@ class InferenceOptimizer:
         egm = match_attention_layout(egm, AttentionRegistry.get(self.ad_config.attn_backend))
 
         # Match rope
-        egm = match_explicit_rope(egm)
-        egm = match_complex_rope(egm)
+        egm, _ = match_rope_pattern(egm)
+
         # Match RoPE layout expected by our backend
         egm = match_rope_layout(
             egm, AttentionRegistry.get(self.ad_config.attn_backend).get_attention_layout()

--- a/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
@@ -153,7 +153,7 @@ class InferenceOptimizer:
         ############################################################################################
 
         # load weights
-        self.factory.load_or_random_init(egm, device=cm.device)
+        self.factory.load_or_random_init(egm, device=self.ad_config.checkpoint_device or cm.device)
 
         # move remaining parts to device
         move_to_device(egm, cm.device)

--- a/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
@@ -222,7 +222,7 @@ def is_linear_op(node: Node, include_quantization: bool = False) -> bool:
     """
     lin_ops = {
         torch.ops.aten.linear,
-        torch.ops.linear.simple,
+        torch.ops.auto_deploy.torch_linear_simple,
     }
 
     if include_quantization:

--- a/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
@@ -233,8 +233,8 @@ def is_linear_op(node: Node, include_quantization: bool = False) -> bool:
 def is_dist_op(node: Node) -> bool:
     """Check if the node is a distributed op."""
     dist_ops = {
-        torch.ops.dist.all_gather,
-        torch.ops.dist.all_reduce,
+        torch.ops.auto_deploy.torch_dist_all_gather,
+        torch.ops.auto_deploy.torch_dist_all_reduce,
     }
     return is_op(node, dist_ops)
 

--- a/tensorrt_llm/_torch/auto_deploy/utils/pattern_matcher.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/pattern_matcher.py
@@ -1,0 +1,253 @@
+"""
+Utilities for registering and applying Torch-Inductor FX-based pattern matchers.
+
+Work with `torch._inductor.pattern_matcher` in PyTorch ≥ 2.7.0.
+"""
+
+import inspect
+import itertools
+import operator
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any, Callable, Iterable, NoReturn, Optional, Union
+
+import torch
+import torch.fx
+import torch.utils._pytree as pytree
+from torch._inductor.pattern_matcher import (
+    CallFunction,
+    ExclusiveKeywordArg,
+    Ignored,
+    KeywordArg,
+    Match,
+    MultiOutputPattern,
+    PatternExpr,
+    PatternMatcherPass,
+    T,
+    register_replacement,
+)
+from torch.fx import GraphModule
+
+from tensorrt_llm._torch.auto_deploy.transformations.export import torch_export_to_gm
+
+
+class WrapperModule(torch.nn.Module):
+    """
+    Wraps a stand-alone function into a torch.nn.Module so it can be exported.
+    """
+
+    def __init__(self, fn: Callable):
+        super().__init__()
+        self.fn = fn
+
+    def forward(self, *args, **kwargs):
+        return self.fn(*args, **kwargs)
+
+
+def trace_to_gm(fn: Callable, args: Sequence[torch.Tensor]) -> GraphModule:
+    """
+    Exports a function or Module into a GraphModule via torch_export_to_gm.
+    """
+    module = fn if isinstance(fn, torch.nn.Module) else WrapperModule(fn)
+    return torch_export_to_gm(module, tuple(args))
+
+
+def _not_implemented(*args: Any, **kwargs: Any) -> NoReturn:
+    raise NotImplementedError
+
+
+def _return_true(match: Match) -> bool:
+    return True
+
+
+def register_pattern(
+    search_fn: Callable,
+    replace_fn: Callable,
+    patterns: PatternMatcherPass,
+    dummy_args: Iterable[Any],
+    trace_fn: Callable[[Callable, Sequence[torch.Tensor]], GraphModule] = trace_to_gm,
+    # optional args input to our variants of `fx_to_pattern`
+    ignore_types: Sequence[type[Any]] = (),
+    op_ignore_types: Optional[Mapping[Callable[..., Any], Sequence[type[Any]]]] = None,
+    scalar_workaround: Optional[Any] = None,
+    exclusive_arg_names: Sequence[str] = (),
+    # optional args input to torch._inductor's register_replacement
+    extra_check: Callable[[Match], bool] = _return_true,
+    skip_duplicates: bool = False,
+) -> None:
+    """
+    Tracing a Python-level pattern into a GraphModule and registering its replacement.
+
+    Args:
+        search_fn:          Function defining the “before” pattern (traced for matching).
+        replace_fn:         Function or op defining the “after” replacement.
+        patterns:           PatternMatcherPass instance (passed to register_replacement).
+        dummy_args:         Inputs matching search_fn's signature used to generate
+                            the FX pattern (must reflect any real dims materialized
+                            as aten-op literals).
+        trace_fn:           Callable to export Python functions/modules into FX (e.g.
+                            torch_export_to_gm).
+        ignore_types:       Literal value types to ignore when converting an FX graph to a pattern.
+        op_ignore_types:    Per-operator mapping of argument types to ignore during pattern matching.
+        scalar_workaround:  Optional dict or value to workaround FX scalar lifting bugs.
+
+        exclusive_arg_names:Names of pattern inputs that must match exactly (not treated as ignored).
+        extra_check:        Additional run on each `Match` to decide if it should be replaced.
+        skip_duplicates:    If True, don't re-register a pattern that's already been seen.
+
+    Note:
+    1. Tensor arguments—both the inputs you pass into the pattern and any tensor args inside its ops
+    are matched purely by their place in the graph; their shape, device, and dtype are not validated.
+    2. Your `dummy_args` may use any shape, device, or dtype so long as they successfully trace
+        the pattern and do not alter the resulting FX graph.
+    3. However, `dummy_args` *can* accidentally bake in layout or type information.
+    To guard against this:
+       a. If a shape value ends up as a literal in calls like `aten.view`, `aten.slice`,
+       or `aten.reshape`, add those ops to `op_ignore_types` so their int args are ignored.
+       b. If your pattern does explicit `to(device=…)` or `to(dtype=…)` calls,
+       consider skipping those args in `op_ignore_types` too
+       c. If your pattern includes `aten.to.device` or `aten.to.dtype`,
+       FX may automatically drop that node when the dummy's device/dtype already matches the target
+       altering your graph topology. Consider registering a separate pattern to handle this case.
+    4. Numeric (integer/float) args input to the pattern will be lifted as hard-coded literals
+        in the FX graph, utilize `scalar_workaround` to detect those literals and
+        replace with args in the pattern
+        - The literal value you choose must exactly match the default kwarg in your search function.
+        - FX will treat every literal with that same value as an occurrence of your kwarg,
+        so ensure no other ops in the pattern use that same number,
+        otherwise pick a different workaround value.
+    5. register_replacement can auto-generate `search_fn_pattern` if you input `example_inputs`,
+        but that approach will fail when symbolic shapes are involved. Here
+        we explicitly trace & convert via `fx_to_pattern`.
+
+    """
+    argnames = list(inspect.signature(search_fn).parameters.keys())
+    specific_gm = trace_fn(search_fn, dummy_args)
+    pattern = fx_to_pattern_with_op_ignore(
+        specific_gm,
+        argnames=argnames,
+        ignore_types=ignore_types,
+        op_ignore_types=op_ignore_types,
+        exclusive_arg_names=exclusive_arg_names,
+        scalar_workaround=scalar_workaround,
+    )
+
+    register_replacement(
+        search_fn=search_fn,
+        replace_fn=replace_fn,
+        example_inputs=[None],
+        trace_fn=trace_fn,
+        pass_dicts=patterns,
+        search_fn_pattern=pattern,
+        extra_check=extra_check,
+        skip_duplicates=skip_duplicates,
+    )
+
+
+#   Copied from torch._inductor.pattern_matcher.fx_to_pattern
+#   with additional argument `op_ignore_types` that ignore certain types of arg for certain op type
+#   When a shape dimension is materialized as a literal argument to an aten op (e.g., slice or view);
+#   it's helpful to ignore matching args of these ops, so that the corresponding dimension of your dummy_args
+#   doesn't need to match the real runtime value
+def fx_to_pattern_with_op_ignore(
+    gm: Union[torch.fx.GraphModule, torch.fx.Graph],
+    ignore_types: Sequence[type[Any]] = (),
+    op_ignore_types: Optional[Mapping[Callable[..., Any], Sequence[type[Any]]]] = None,
+    argnames: Sequence[str] = (),
+    scalar_workaround: Union[dict[str, Union[float, int]], None] = None,
+    exclusive_arg_names: Sequence[str] = (),
+) -> PatternExpr:
+    """
+    Convert an FX graph into a PatternExpr.  This is useful for simple
+    patterns that can only match single functions and fixed-length lists.
+    """
+    # scalar_workaround is a hack to capture dropout_p
+    # see https://github.com/pytorch/pytorch/issues/97894
+    scalar_workaround = scalar_workaround or {}
+    inv_scalar_workaround = {v: k for k, v in scalar_workaround.items()}
+    assert len(inv_scalar_workaround) == len(scalar_workaround)
+
+    def process_arg(
+        x: T, ignore_types_override: Optional[Sequence[type[Any]]] = None
+    ) -> Union[T, KeywordArg, Ignored]:
+        current_ignore_types = (
+            ignore_types_override if ignore_types_override is not None else ignore_types
+        )
+        if isinstance(x, (float, int)) and x in inv_scalar_workaround:
+            return KeywordArg(inv_scalar_workaround[x])
+        if type(x) in current_ignore_types:
+            return Ignored()
+        if isinstance(x, list) and all(isinstance(y, Ignored) for y in x) and x:
+            return Ignored()
+        return x
+
+    argnum = itertools.count()
+
+    class Converter(torch.fx.Interpreter):
+        call_method = _not_implemented
+        call_module = _not_implemented
+        get_attr = _not_implemented
+
+        def placeholder(
+            self,
+            target: str,
+            args: Sequence[Any],
+            kwargs: Mapping[str, Any],  # type: ignore[override]
+        ) -> Union[ExclusiveKeywordArg, KeywordArg]:
+            n = next(argnum)
+            if n < len(argnames):
+                name = argnames[n]
+            elif argnames:
+                assert target.startswith("tangent")
+                name = target
+            else:
+                target = re.sub(r"_\d+$", "", target)  # de-mangle arg name
+                name = target
+            if name in exclusive_arg_names:
+                return ExclusiveKeywordArg(name)
+            else:
+                return KeywordArg(name)
+
+        def call_function(
+            self, target: Any, args: Sequence[Any], kwargs: Mapping[str, Any]
+        ) -> PatternExpr:
+            # build a per-op ignore list if specified
+            if op_ignore_types and target in op_ignore_types:
+                combined_ignore = tuple(ignore_types) + tuple(op_ignore_types[target])
+            else:
+                combined_ignore = None
+
+            # by default use the global or per-op ignore set
+            def _make_arg_fn(ignore_override: Optional[Sequence[type[Any]]]):
+                return lambda x: process_arg(x, ignore_override)
+
+            # special-case getitem so ints still match as indices
+            if target == operator.getitem:
+                # drop all ignores except int
+                ints_only = tuple(t for t in (combined_ignore or ignore_types) if t is not int)
+                process_arg_fn = _make_arg_fn(ints_only)
+            else:
+                process_arg_fn = _make_arg_fn(combined_ignore)
+
+            args, kwargs = pytree.tree_map(process_arg_fn, (args, kwargs))
+            if list in ignore_types:
+                # handle burned-in tensor size lists of Ignored()
+                args = [process_arg_fn(a) for a in args]
+                kwargs = {k: process_arg_fn(v) for k, v in kwargs.items()}
+
+            return CallFunction(target, *args, **kwargs)
+
+        def run_node(self, n: torch.fx.Node) -> Any:
+            rv = super().run_node(n)
+            if n.op == "output" and isinstance(rv, tuple):
+                assert len(rv) == len(n.args[0])  # type: ignore[arg-type]
+                for r, arg in zip(rv, n.args[0]):  # type: ignore[arg-type]
+                    r.users = len(arg.users)
+            else:
+                rv.users = len(n.users)
+            return rv
+
+    pattern = Converter(gm).run()  # type: ignore[arg-type]
+    if not isinstance(pattern, PatternExpr):
+        return MultiOutputPattern(pytree.tree_leaves(pattern))
+    return pattern

--- a/tensorrt_llm/_torch/auto_deploy/utils/quantization_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/quantization_utils.py
@@ -136,7 +136,7 @@ class QuantizationImpl:
 class FP8QuantizationImpl(QuantizationImpl):
     @staticmethod
     def target_op():
-        return torch.ops.quant.fp8_linear
+        return torch.ops.auto_deploy.torch_quant_fp8_linear
 
     @staticmethod
     def quantize_weight(original_weight: torch.Tensor) -> torch.Tensor:
@@ -207,7 +207,7 @@ def _shard_fp4_weight_scale(weight_scale, sharded_uint8_weight_shape, dim, rank,
 class FP4QuantizationImpl(QuantizationImpl):
     @staticmethod
     def target_op():
-        return torch.ops.quant.fp4_linear
+        return torch.ops.auto_deploy.torch_quant_fp4_linear
 
     @staticmethod
     def quantize_weight(original_weight: torch.Tensor) -> torch.Tensor:

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1797,6 +1797,12 @@ class _AutoDeployLlmArgs(TorchLlmArgs):
         "properly passed through.",
     )
 
+    checkpoint_device: Optional[str] = Field(
+        default=None,
+        description="Device on which to load the model checkpoint. "
+        "Defaults to the same device as the rest of the pipeline.",
+    )
+
     @field_validator("free_mem_ratio")
     @classmethod
     def validate_free_mem_ratio(cls, v):

--- a/tests/unittest/_torch/auto_deploy/_utils_test/_graph_test_helpers.py
+++ b/tests/unittest/_torch/auto_deploy/_utils_test/_graph_test_helpers.py
@@ -35,6 +35,7 @@ def run_test(
     test_load_hook: bool = True,
     strict_loading: bool = True,
     dynamic_shapes: Dict = None,
+    check_num_matches: int = None,  # Additional check of # patterns detected
     *args,  # Additional arguments for transform
 ) -> GraphModule:
     # run model once
@@ -54,7 +55,13 @@ def run_test(
     torch.testing.assert_close(y_model, y_gm, atol=atol, rtol=rtol)
 
     # graph transformation + check
-    gm_transformed = transform(gm, *args)
+    if check_num_matches:
+        gm_transformed, num_matches = transform(gm, *args)
+        assert check_num_matches == num_matches, (
+            f"expect {check_num_matches} matches, but got {num_matches}"
+        )
+    else:
+        gm_transformed = transform(gm, *args)
     print(gm_transformed)
     # in case buffers or other tensors were added during the transform
     gm_transformed = gm_transformed.to("cuda")

--- a/tests/unittest/_torch/auto_deploy/_utils_test/_model_test_utils.py
+++ b/tests/unittest/_torch/auto_deploy/_utils_test/_model_test_utils.py
@@ -184,7 +184,7 @@ class MoEOpModel(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
         x: Tensor of shape (batch, hidden_size)
-        Computes router logits via a gate, and then calls the MoE op via torch.moe.torch_moe.
+        Computes router logits via a gate, and then calls the MoE op via torch.ops.auto_deploy.torch_moe.
         """
 
         router_logits = self.gate(x)
@@ -197,7 +197,7 @@ class MoEOpModel(nn.Module):
         w2_list = [expert.w2 for expert in self.experts]
         w3_list = [expert.w3 for expert in self.experts]
 
-        out = torch.ops.moe.torch_moe(
+        out = torch.ops.auto_deploy.torch_moe(
             x, selected_experts, routing_weights, w1_list, w2_list, w3_list
         )
         return out

--- a/tests/unittest/_torch/auto_deploy/_utils_test/_model_test_utils.py
+++ b/tests/unittest/_torch/auto_deploy/_utils_test/_model_test_utils.py
@@ -253,9 +253,10 @@ def apply_rotary_pos_emb_complex(
     xq_complex = torch.view_as_complex(xq.float().reshape(*xq.shape[:-1], -1, 2))
     xk_complex = torch.view_as_complex(xk.float().reshape(*xk.shape[:-1], -1, 2))
     # Multiply with frequencies. Note that freqs_cis is expected to broadcast with an extra head dim.
-    freqs = freqs_cis.unsqueeze(unsqueeze_dim)
-    xq_out = torch.view_as_real(xq_complex * freqs).flatten(3)
-    xk_out = torch.view_as_real(xk_complex * freqs).flatten(3)
+    freqs_q = freqs_cis.unsqueeze(unsqueeze_dim)
+    freqs_k = freqs_cis.unsqueeze(unsqueeze_dim)
+    xq_out = torch.view_as_real(xq_complex * freqs_q).flatten(3)
+    xk_out = torch.view_as_real(xk_complex * freqs_k).flatten(3)
     return xq_out.type_as(xq), xk_out.type_as(xk)
 
 

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/custom_ops/test_dist.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/custom_ops/test_dist.py
@@ -9,14 +9,14 @@ from tensorrt_llm._torch.auto_deploy.distributed.common import spawn_multiproces
 
 def _run_all_reduce_test(rank, world_size):
     x = torch.ones(10, 10).to("cuda")
-    y = torch.ops.dist.all_reduce(x)
+    y = torch.ops.auto_deploy.torch_dist_all_reduce(x)
 
     assert torch.equal(x * world_size, y)
 
 
 def _run_all_gather_test(rank, world_size):
     x = torch.ones(10, 10).to("cuda")
-    y = torch.ops.dist.all_gather(x)
+    y = torch.ops.auto_deploy.torch_dist_all_gather(x)
 
     assert torch.sum(y) == world_size * torch.sum(x)
     assert y.shape == (world_size * x.shape[0], *x.shape[1:])

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/custom_ops/test_moe_ep.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/custom_ops/test_moe_ep.py
@@ -74,7 +74,7 @@ def _run_moe_ep_test(num_experts: int, topk: int, rank: int, world_size: int):
 
     final_scales_local = final_scales * rank_mask
 
-    output_trt = torch.ops.moe.trtllm_fused_moe(
+    output_trt = torch.ops.auto_deploy.trtllm_moe_fused(
         x,
         selected_experts_local,
         final_scales_local,

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_allreduce_residual_rmsnorm_fusion.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_allreduce_residual_rmsnorm_fusion.py
@@ -36,7 +36,7 @@ class AllreduceResidualNorm(torch.nn.Module):
         self.norm = RMSNorm(hidden_size, 1e-5, dtype)
 
     def forward(self, x, residual):
-        x = torch.ops.dist.all_reduce(x)
+        x = torch.ops.auto_deploy.torch_dist_all_reduce(x)
         y = x + residual
         normed = self.norm(y)
         return normed, y

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_bmm_sharding.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_bmm_sharding.py
@@ -64,7 +64,7 @@ def _run_job(
         return num_params
 
     # now run the test
-    op_expected = getattr(torch.ops.dist, "all_gather")
+    op_expected = getattr(torch.ops.auto_deploy, "torch_dist_all_gather")
     run_test(
         model,
         x,

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_collective_fusion.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_collective_fusion.py
@@ -79,7 +79,7 @@ def _run_job(
         (nn.Linear, "auto_deploy.trtllm_dist_fused_linear_all_reduce"),
         pytest.param(
             FP8Linear,
-            "quant.fused_fp8_linear_all_reduce",
+            "auto_deploy.torch_quant_fused_fp8_linear_all_reduce",
             marks=pytest.mark.skipif(not fp8_compatible(), reason="Requires fp8 support"),
         ),
     ),

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_collective_fusion.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_collective_fusion.py
@@ -76,7 +76,7 @@ def _run_job(
 @pytest.mark.parametrize(
     "linear_cls, dist_op_expected",
     (
-        (nn.Linear, "linear.fused_linear_all_reduce"),
+        (nn.Linear, "auto_deploy.trtllm_dist_fused_linear_all_reduce"),
         pytest.param(
             FP8Linear,
             "quant.fused_fp8_linear_all_reduce",

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_collective_fusion.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_collective_fusion.py
@@ -26,8 +26,8 @@ class MLPAllReduce(nn.Module):
         self.linear2 = cls(4 * in_features, out_features, bias=bias)
 
     def forward(self, x):
-        y = F.relu(torch.ops.dist.all_reduce(self.linear1(x)))
-        return torch.ops.dist.all_reduce(self.linear2(y))
+        y = F.relu(torch.ops.auto_deploy.torch_dist_all_reduce(self.linear1(x)))
+        return torch.ops.auto_deploy.torch_dist_all_reduce(self.linear2(y))
 
 
 def _run_job(
@@ -58,7 +58,7 @@ def _run_job(
 
     def check_transformed_graph(gm):
         return any(is_op(n, op_expected) for n in gm.graph.nodes) and not any(
-            is_op(n, torch.ops.dist.all_reduce) for n in gm.graph.nodes
+            is_op(n, torch.ops.auto_deploy.torch_dist_all_reduce) for n in gm.graph.nodes
         )
 
     # now run the test

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_ep_sharding.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_ep_sharding.py
@@ -33,7 +33,7 @@ def _run_ep_shard_job(num_experts: int, rank: int, world_size: int) -> None:
         expected_expert = num_experts_per_rank * hidden_size * intermediate_size * 3
         return n_gate + expected_expert
 
-    op_expected = torch.ops.dist.all_reduce
+    op_expected = torch.ops.auto_deploy.torch_dist_all_reduce
 
     run_test(
         model,

--- a/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_graph_sharding.py
+++ b/tests/unittest/_torch/auto_deploy/unit/multigpu/transformations/library/test_graph_sharding.py
@@ -15,6 +15,50 @@ from tensorrt_llm._torch.auto_deploy.transformations.library import column_row_s
 from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
 
 
+class GQA_Block(nn.Module):
+    def __init__(
+        self,
+        num_attention_heads: int,
+        hidden_size: int,
+        num_key_value_heads: int,
+    ):
+        super().__init__()
+        self.num_attention_heads = num_attention_heads
+        self.hidden_size = hidden_size
+        self.head_dim = self.hidden_size // self.num_attention_heads
+        self.num_key_value_heads = num_key_value_heads
+        self.is_gqa = num_key_value_heads < num_attention_heads
+        assert self.hidden_size == self.num_attention_heads * self.head_dim
+
+        # key, query, value, out projections
+        self.q_proj = nn.Linear(self.hidden_size, self.hidden_size, bias=False)
+        self.k_proj = nn.Linear(
+            self.hidden_size,
+            self.head_dim * self.num_key_value_heads,
+            bias=False,
+        )
+        self.v_proj = nn.Linear(
+            self.hidden_size,
+            self.head_dim * self.num_key_value_heads,
+            bias=False,
+        )
+
+        self.o_proj = nn.Linear(self.hidden_size, self.hidden_size, bias=False)
+
+    @torch.no_grad()
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        b, s, _ = x.shape
+
+        q = self.q_proj(x).view(b, s, -1, self.head_dim)
+        k = self.k_proj(x).view(b, s, -1, self.head_dim)
+        v = self.v_proj(x).view(b, s, -1, self.head_dim)
+
+        y = torch.ops.attention.bsnd_grouped_sdpa(q, k, v, is_causal=True)
+        y = y.contiguous().view(b, s, -1)
+
+        return self.o_proj(y)
+
+
 class MLP(nn.Module):
     def __init__(self, in_features, out_features, bias=False):
         super().__init__()
@@ -37,9 +81,30 @@ def _run_job(
 ) -> None:
     # init model and input
     batch_size = 4
-    num_features = 10
-    model = model_cls(num_features, num_features, bias=bias).to(device="cuda", dtype=torch.float16)
-    x = torch.randn(batch_size, num_features, device="cuda", dtype=torch.float16)
+    sequence_len = 8
+    num_features = 32
+
+    # GQA specific parameters
+    num_heads = 4
+    num_key_value_heads = 1
+
+    if model_cls == GQA_Block:
+        model = model_cls(
+            num_attention_heads=num_heads,
+            hidden_size=num_features,
+            num_key_value_heads=num_key_value_heads,
+        ).to(device="cuda", dtype=torch.float16)
+    else:
+        model = model_cls(num_features, num_features, bias=bias).to(
+            device="cuda", dtype=torch.float16
+        )
+    x = torch.randn(batch_size, sequence_len, num_features, device="cuda", dtype=torch.float16)
+
+    if model_cls == GQA_Block:
+        head_dim = num_features // num_heads
+        min_local_size = head_dim
+    else:
+        min_local_size = 1
 
     def _get_expected_num_params(num_p_og: int) -> int:
         num_update = 0
@@ -47,17 +112,49 @@ def _run_job(
             num_p_og -= num_features
             num_update = num_features * (rank == world_size - 1)
 
-        num_params = num_p_og // world_size + num_update
+        if min_local_size > 1:
+            # it means we are in the GQA. W_kv are partially replicated, we need to count
+            # the number of parameters manually.
+            W_q_local_size = num_features * num_features // world_size
+            W_o_local_size = W_q_local_size
+            W_k_local_size = num_features * head_dim * max(num_key_value_heads // world_size, 1)
+            W_v_local_size = W_k_local_size
+            num_params = W_q_local_size + W_k_local_size + W_v_local_size + W_o_local_size
+        else:
+            num_params = num_p_og // world_size + num_update
         return num_params
+
+    def verify_local_weight_sizes(gm) -> bool:
+        """Verify that all weight tensors have first dimension >= min_local_size after sharding."""
+        for name, param in gm.named_parameters():
+            # Only check parameters that have at least 1 dimension and are weight matrices
+            if param.dim() >= 1 and "weight" in name:
+                if param.shape[0] < min_local_size:
+                    print(
+                        f"Weight {name} has shape {param.shape}, dim {param.shape[0]} < min_local_size {min_local_size}"
+                    )
+                    return False
+        return True
 
     # now run the test
     op_expected = getattr(torch.ops.dist, dist_op_expected)
+
+    transform_func = partial(column_row_shard, rank=rank, world_size=world_size)
+
+    def combined_graph_check(gm) -> bool:
+        # Check for expected distributed operations
+        has_expected_dist_ops = any(is_op(n, op_expected) for n in gm.graph.nodes) == (
+            world_size > 1
+        )
+        # Check weight size constraints
+        weight_sizes_valid = verify_local_weight_sizes(gm)
+        return has_expected_dist_ops and weight_sizes_valid
+
     run_test(
         model,
         x,
-        transform=partial(column_row_shard, rank=rank, world_size=world_size),
-        check_transformed_graph=lambda gm: any(is_op(n, op_expected) for n in gm.graph.nodes)
-        == (world_size > 1),
+        transform=transform_func,
+        check_transformed_graph=combined_graph_check,
         _get_expected_num_params=_get_expected_num_params,
     )
 
@@ -69,6 +166,7 @@ def _run_job(
     (
         (MLP, "all_reduce"),
         (nn.Linear, "all_gather"),
+        (GQA_Block, "all_reduce"),
     ),
 )
 def test_sharding(model_cls: Type[nn.Module], dist_op_expected: str, bias: bool, device_count: int):

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_ad_moe_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_ad_moe_op.py
@@ -49,7 +49,7 @@ def test_moe_op_run(dtype):
         fused_w2_weight.data[expert_id].copy_(w2)
 
     with torch.inference_mode():
-        output_torch_moe = torch.ops.moe.torch_moe(
+        output_torch_moe = torch.ops.auto_deploy.torch_moe(
             x,
             selected_experts,
             final_scales,
@@ -57,14 +57,14 @@ def test_moe_op_run(dtype):
             w2_weight,
             w3_weight,
         )
-        output_torch_fused_moe = torch.ops.moe.torch_fused_moe(
+        output_torch_fused_moe = torch.ops.auto_deploy.torch_moe_fused(
             x,
             selected_experts,
             final_scales,
             fused_w3_w1_stacked_weight,
             fused_w2_weight,
         )
-        output_trt_fused_moe = torch.ops.moe.trtllm_fused_moe(
+        output_trt_fused_moe = torch.ops.auto_deploy.trtllm_moe_fused(
             x,
             selected_experts,
             final_scales,

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_attention_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_attention_op.py
@@ -21,7 +21,7 @@ def test_attention_op():
 
     q, k, v = (x.contiguous() for x in torch.split(qkv, 1, dim=1))
 
-    output = torch.ops.attention.fused_mha_with_cache(
+    output = torch.ops.auto_deploy.triton_attention_fused_mha_with_cache(
         q, k, v, input_positions, k_cache, v_cache, None
     )
     ref = torch.nn.functional.scaled_dot_product_attention(
@@ -66,7 +66,7 @@ def test_gqa_op(device, dtype, n_heads, group_size, seq_len):
     v_cache = torch.randn(BATCH_SIZE, CACHE_SEQ_LEN, n_kv_heads, D_HEAD, dtype=dtype, device=device)
 
     # run custom op
-    output = torch.ops.attention.fused_mha_with_cache(
+    output = torch.ops.auto_deploy.triton_attention_fused_mha_with_cache(
         q, k, v, input_positions, k_cache, v_cache, None
     )
 
@@ -274,7 +274,7 @@ def test_flat_gqa_op_with_rope(
     source = 1
     if source == 1:
         # call rope fusion kernels
-        output = torch.ops.attention.fused_flattened_mha_with_cache_rope_fusion(
+        output = torch.ops.auto_deploy.triton_attention_fused_flattened_mha_with_cache_rope_fusion(
             q,
             k,
             v,
@@ -288,7 +288,7 @@ def test_flat_gqa_op_with_rope(
         )
     else:
         # call stand-alone rope embedding kernel
-        output = torch.ops.attention.fused_flattened_mha_with_cache(
+        output = torch.ops.auto_deploy.triton_attention_fused_flattened_mha_with_cache(
             q,
             k,
             v,
@@ -466,7 +466,7 @@ def test_paged_gqa_op(
     v = torch.randn(1, seq_len.sum(), n_kv_heads * D_HEAD, **dtype_kwargs)
 
     # run op
-    output = torch.ops.attention.fused_mha_with_paged_cache(
+    output = torch.ops.auto_deploy.triton_attention_fused_mha_with_paged_cache(
         q,
         k,
         v,

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_attention_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_attention_op.py
@@ -148,7 +148,7 @@ def test_flat_gqa_op(
     v = torch.randn(1, seq_len.sum(), n_kv_heads * D_HEAD, **dtype_kwargs)
 
     # run op
-    output = torch.ops.attention.flattened_mha_with_cache(
+    output = torch.ops.auto_deploy.triton_attention_flattened_mha_with_cache(
         # Q, K, V
         q,
         k,

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_flashinfer_attention_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_flashinfer_attention_op.py
@@ -88,7 +88,7 @@ def test_flashinfer_attention_op_context(seq_length, n_heads, batch_size, dtype,
         ),
         BATCH_SIZE * SEQ_LEN,
     )
-    flashinfer_output = torch.ops.attention.flashinfer_mha_with_cache(
+    flashinfer_output = torch.ops.auto_deploy.flashinfer_attention_mha_with_cache(
         # Q, K, V
         q,
         k,
@@ -213,7 +213,7 @@ def test_flashinfer_attention_op_decode(
         ),
         BATCH_SIZE * SEQ_LEN,
     )
-    flashinfer_output = torch.ops.attention.flashinfer_mha_with_cache(
+    flashinfer_output = torch.ops.auto_deploy.flashinfer_attention_mha_with_cache(
         # Q, K, V
         q,
         k,
@@ -329,7 +329,7 @@ def test_flashinfer_attention_context_and_generate(
         ),
         BATCH_SIZE * PREFILL_SEQ_LEN,
     )
-    flashinfer_output_1 = torch.ops.attention.flashinfer_mha_with_cache(
+    flashinfer_output_1 = torch.ops.auto_deploy.flashinfer_attention_mha_with_cache(
         # Q, K, V
         q_1,
         k_1,
@@ -404,7 +404,7 @@ def test_flashinfer_attention_context_and_generate(
         ),
         BATCH_SIZE * 1,
     )
-    flashinfer_output_3 = torch.ops.attention.flashinfer_mha_with_cache(
+    flashinfer_output_3 = torch.ops.auto_deploy.flashinfer_attention_mha_with_cache(
         # Q, K, V
         q_3,
         k_3,
@@ -513,7 +513,7 @@ def test_flashinfer_attention_op_context_input_pos(seq, batch_size, n_heads, dty
         ),
         BATCH_SIZE * SEQ_LEN,
     )
-    flashinfer_output = torch.ops.attention.flashinfer_mha_with_cache(
+    flashinfer_output = torch.ops.auto_deploy.flashinfer_attention_mha_with_cache(
         # Q, K, V
         q,
         k,
@@ -660,7 +660,7 @@ def test_flashinfer_attention_with_fp8_cache(
         ),
         BATCH_SIZE * SEQ_LEN,
     )
-    flashinfer_output = torch.ops.attention.flashinfer_mha_with_cache(
+    flashinfer_output = torch.ops.auto_deploy.flashinfer_attention_mha_with_cache(
         # Q, K, V
         q,
         k,
@@ -757,7 +757,7 @@ def test_flashinfer_attention_with_paged_kvcache(seq_lengths, n_heads, dtype, de
         ),
         BATCH_SIZE * SEQ_LEN,
     )
-    flashinfer_output = torch.ops.attention.flashinfer_mha_with_cache(
+    flashinfer_output = torch.ops.auto_deploy.flashinfer_attention_mha_with_cache(
         # Q, K, V
         q,
         k,
@@ -840,7 +840,7 @@ def test_flashinfer_attention_with_paged_kvcache(seq_lengths, n_heads, dtype, de
         ),
         BATCH_SIZE * 1,
     )
-    flashinfer_output_gen = torch.ops.attention.flashinfer_mha_with_cache(
+    flashinfer_output_gen = torch.ops.auto_deploy.flashinfer_attention_mha_with_cache(
         # Q, K, V
         q_gen,
         k_gen,

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_quant.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_quant.py
@@ -20,7 +20,7 @@ def test_fp8_linear(bias):
     weight_scale = (torch.max(torch.abs(weight)) / 448).to("cuda")
     weight_fp8 = (weight / weight_scale).to(torch.float8_e4m3fn)
 
-    output_fp8_gemm = torch.ops.quant.fp8_linear(
+    output_fp8_gemm = torch.ops.auto_deploy.torch_quant_fp8_linear(
         input,
         weight_fp8,
         bias=bias,
@@ -49,7 +49,7 @@ def test_fp4_linear():
         weight, weight_scale_2, scaling_vector_size, False
     )
 
-    output_fp4_gemm = torch.ops.quant.fp4_linear(
+    output_fp4_gemm = torch.ops.auto_deploy.torch_quant_fp4_linear(
         input,
         weight_fp4,
         bias=None,

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_rope_op_variants.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_rope_op_variants.py
@@ -81,7 +81,7 @@ def test_flashinfer_custom_op_and_hf_impl(dtype, atol, rtol, head_dim):
 
     # Custom op call
     positions_flat = torch.arange(batch * seq_len, device=device)
-    custom_q, custom_k = torch.ops.rope.flashinfer(
+    custom_q, custom_k = torch.ops.auto_deploy.flashinfer_rope(
         query, key, positions_flat, cos_sin_cache_expand, True
     )
 
@@ -135,7 +135,7 @@ def test_flashinfer_custom_op_and_complex_impl(dtype, atol, rtol, head_dim):
 
     # q/k of llama4 rope is interleaved
     positions_flat = torch.arange(batch * seq_len, device=device)
-    custom_q, custom_k = torch.ops.rope.flashinfer(
+    custom_q, custom_k = torch.ops.auto_deploy.flashinfer_rope(
         query, key, positions_flat, cos_sin_cache_expand, False
     )
 

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_rope_op_variants.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_rope_op_variants.py
@@ -211,8 +211,8 @@ def test_triton_custom_op_and_hf_impl(layout, head_dim, dtype, atol, rtol):
     q_hf = q_f32.to(dtype)
     k_hf = k_f32.to(dtype)
 
-    q_out = torch.ops.rope.apply_rope_with_input_pos(q, cosin_cache, positions, layout)
-    k_out = torch.ops.rope.apply_rope_with_input_pos(k, cosin_cache, positions, layout)
+    q_out = torch.ops.auto_deploy.triton_rope_with_input_pos(q, cosin_cache, positions, layout)
+    k_out = torch.ops.auto_deploy.triton_rope_with_input_pos(k, cosin_cache, positions, layout)
 
     torch.testing.assert_close(q_hf, q_out, atol=atol, rtol=rtol)
     torch.testing.assert_close(k_hf, k_out, atol=atol, rtol=rtol)

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/triton_kernels/test_rope.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/triton_kernels/test_rope.py
@@ -34,7 +34,7 @@ def test_rope(d_head):
     y_ref = torch_rope_reference(x, freqs_cis, input_position)
     freqs_cis = freqs_cis.to("cuda")
     x_reshaped = x.unflatten(-1, (N_ELEM // 2, 2)).transpose(-1, -2).flatten(-2).contiguous()
-    y = torch.ops.rope.apply_rope_with_input_pos(
+    y = torch.ops.auto_deploy.triton_rope_with_input_pos(
         x_reshaped.to("cuda"), freqs_cis, input_position, "bsnd"
     )
     y_reshaped = y.unflatten(-1, (2, N_ELEM // 2)).transpose(-2, -1).flatten(-2).contiguous()
@@ -64,7 +64,7 @@ def test_rope_flattened(d_head):
     seq_start_indices = torch.zeros(len(SEQ_LENS), dtype=torch.int32, device="cuda")
     seq_start_indices[1:] = torch.cumsum(seq_lens[:-1], 0)
 
-    y = torch.ops.rope.apply_rope_on_flattened_inputs(
+    y = torch.ops.auto_deploy.triton_rope_on_flattened_inputs(
         x_reshaped.to("cuda"), freqs_cis, input_position, seq_lens, seq_start_indices
     )
     y_reshaped = y.unflatten(-1, (2, N_ELEM // 2)).transpose(-2, -1).flatten(-2).contiguous()

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_sdpa_mla.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_sdpa_mla.py
@@ -55,7 +55,9 @@ def mla_attn(q_nope, q_pe, compressed_kv, k_pe, wkv_b, softmax_scale):
     q_nope_proj = torch.einsum("bhsd,hdc->bhsc", q_nope, wkv_b_weight[:, :qk_nope_head_dim])
 
     # MLA ref operation
-    x = torch.ops.deepseek.mla(q_nope_proj, q_pe, compressed_kv, k_pe, None, softmax_scale)
+    x = torch.ops.auto_deploy.torch_attention_deepseek_mla(
+        q_nope_proj, q_pe, compressed_kv, k_pe, None, softmax_scale
+    )
 
     # Up project attention scores
     x = torch.einsum("bshc,hdc->bshd", x, wkv_b_weight[:, -v_head_dim:])

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_attention_matcher.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_attention_matcher.py
@@ -379,8 +379,8 @@ class GroupedAttentionModel(torch.nn.Module):
 
         # Manually apply repeat_kv to k and v
         if self.num_kv_heads != self.num_heads:
-            k = torch.ops.attention.repeat_kv(k, self.n_rep)
-            v = torch.ops.attention.repeat_kv(v, self.n_rep)
+            k = torch.ops.auto_deploy.torch_attention_repeat_kv(k, self.n_rep)
+            v = torch.ops.auto_deploy.torch_attention_repeat_kv(v, self.n_rep)
 
         # Create attention mask if needed
         attn_mask = None
@@ -396,7 +396,7 @@ class GroupedAttentionModel(torch.nn.Module):
             ).masked_fill(mask, float("-inf"))
 
         # Apply scaled dot product attention
-        attn_output = torch.ops.attention.scaled_dot_product_attention(
+        attn_output = torch.ops.auto_deploy.torch_attention_sdpa(
             q,
             k,
             v,
@@ -434,7 +434,7 @@ def test_match_repeat_kv(num_heads, num_kv_heads, model_cls):
     expected_matches = 0 if num_heads == num_kv_heads else 2
 
     def verify_matcher(gm):
-        repeat_kv_nodes = [n for n in gm.graph.nodes if is_op(n, torch.ops.attention.repeat_kv)]
+        repeat_kv_nodes = [n for n in gm.graph.nodes if is_op(n, torch.ops.auto_deploy.torch_attention_repeat_kv)]
 
         # Check that we have the expected number of replacements
         if len(repeat_kv_nodes) != expected_matches:
@@ -549,7 +549,7 @@ def test_match_eager_attention(has_mask, use_division, dropout, rtol, atol, mode
 
     def verify_matcher(gm):
         sdpa_nodes = [
-            n for n in gm.graph.nodes if is_op(n, torch.ops.attention.scaled_dot_product_attention)
+            n for n in gm.graph.nodes if is_op(n, torch.ops.auto_deploy.torch_attention_sdpa)
         ]
 
         # Check that we have the expected number of replacements
@@ -655,8 +655,8 @@ def test_counter_example():
     dynamic_shapes = model.get_dynamic_shapes()
 
     def verify_no_matches(gm):
-        # No nodes should be replaced with torch.ops.attention.repeat_kv
-        repeat_kv_nodes = [n for n in gm.graph.nodes if is_op(n, torch.ops.attention.repeat_kv)]
+        # No nodes should be replaced with torch.ops.auto_deploy.torch_attention_repeat_kv
+        repeat_kv_nodes = [n for n in gm.graph.nodes if is_op(n, torch.ops.auto_deploy.torch_attention_repeat_kv)]
         return len(repeat_kv_nodes) == 0
 
     # Ensure the pattern matcher doesn't match our counter-examples
@@ -693,7 +693,7 @@ def test_match_grouped_attention(num_heads, num_kv_heads, has_mask):
 
     def verify_matcher(gm):
         grouped_sdpa_nodes = [
-            n for n in gm.graph.nodes if is_op(n, torch.ops.attention.grouped_sdpa)
+            n for n in gm.graph.nodes if is_op(n, torch.ops.auto_deploy.torch_attention_grouped_sdpa)
         ]
 
         # Check that we have the expected number of replacements
@@ -790,8 +790,8 @@ class CausalAttentionModel(torch.nn.Module):
         # For grouped attention, repeat k and v
         if self.use_grouped_sdpa and self.num_kv_heads != self.num_heads:
             n_rep = self.num_heads // self.num_kv_heads
-            k = torch.ops.attention.repeat_kv(k, n_rep)
-            v = torch.ops.attention.repeat_kv(v, n_rep)
+            k = torch.ops.auto_deploy.torch_attention_repeat_kv(k, n_rep)
+            v = torch.ops.auto_deploy.torch_attention_repeat_kv(v, n_rep)
 
         # Create attention mask based on mask_type
         if self.mask_type == "triu":
@@ -830,7 +830,7 @@ class CausalAttentionModel(torch.nn.Module):
 
         # Choose the appropriate attention implementation
         if self.use_grouped_sdpa:
-            attn_output = torch.ops.attention.grouped_sdpa(
+            attn_output = torch.ops.auto_deploy.torch_attention_grouped_sdpa(
                 q,
                 k,
                 v,
@@ -840,7 +840,7 @@ class CausalAttentionModel(torch.nn.Module):
                 scale=1.0 / (self.head_dim**0.5),
             )
         else:
-            attn_output = torch.ops.attention.scaled_dot_product_attention(
+            attn_output = torch.ops.auto_deploy.torch_attention_sdpa(
                 q,
                 k,
                 v,
@@ -886,12 +886,12 @@ def test_match_causal_attention(mask_type, use_grouped_sdpa):
     def verify_matcher(gm):
         # Find attention operations
         if use_grouped_sdpa:
-            attn_nodes = [n for n in gm.graph.nodes if is_op(n, torch.ops.attention.grouped_sdpa)]
+            attn_nodes = [n for n in gm.graph.nodes if is_op(n, torch.ops.auto_deploy.torch_attention_grouped_sdpa)]
         else:
             attn_nodes = [
                 n
                 for n in gm.graph.nodes
-                if is_op(n, torch.ops.attention.scaled_dot_product_attention)
+                if is_op(n, torch.ops.auto_deploy.torch_attention_sdpa)
             ]
 
         if len(attn_nodes) != 1:
@@ -990,8 +990,8 @@ class Llama3CausalAttentionModel(torch.nn.Module):
         # For grouped attention, repeat k and v
         if self.use_grouped_sdpa and self.num_kv_heads != self.num_heads:
             n_rep = self.num_heads // self.num_kv_heads
-            k = torch.ops.attention.repeat_kv(k, n_rep)
-            v = torch.ops.attention.repeat_kv(v, n_rep)
+            k = torch.ops.auto_deploy.torch_attention_repeat_kv(k, n_rep)
+            v = torch.ops.auto_deploy.torch_attention_repeat_kv(v, n_rep)
 
         # Create a llama-3.1 style causal mask
         # 1. Create a full tensor with a very negative value
@@ -1026,7 +1026,7 @@ class Llama3CausalAttentionModel(torch.nn.Module):
 
         # Choose the appropriate attention implementation
         if self.use_grouped_sdpa:
-            attn_output = torch.ops.attention.grouped_sdpa(
+            attn_output = torch.ops.auto_deploy.torch_attention_grouped_sdpa(
                 q,
                 k,
                 v,
@@ -1036,7 +1036,7 @@ class Llama3CausalAttentionModel(torch.nn.Module):
                 scale=1.0 / (self.head_dim**0.5),
             )
         else:
-            attn_output = torch.ops.attention.scaled_dot_product_attention(
+            attn_output = torch.ops.auto_deploy.torch_attention_sdpa(
                 q,
                 k,
                 v,
@@ -1077,12 +1077,12 @@ def test_match_llama3_causal_attention(use_grouped_sdpa):
     def verify_matcher(gm):
         # Find attention operations
         if use_grouped_sdpa:
-            attn_nodes = [n for n in gm.graph.nodes if is_op(n, torch.ops.attention.grouped_sdpa)]
+            attn_nodes = [n for n in gm.graph.nodes if is_op(n, torch.ops.auto_deploy.torch_attention_grouped_sdpa)]
         else:
             attn_nodes = [
                 n
                 for n in gm.graph.nodes
-                if is_op(n, torch.ops.attention.scaled_dot_product_attention)
+                if is_op(n, torch.ops.auto_deploy.torch_attention_sdpa)
             ]
 
         if len(attn_nodes) != 1:
@@ -1128,7 +1128,7 @@ class MockAttentionDescriptor:
     """A mock class that mimics the AttentionDescriptor interface for testing."""
 
     layout: str = "bnsd"
-    source_attention_op: Callable = torch.ops.attention.scaled_dot_product_attention
+    source_attention_op: Callable = torch.ops.auto_deploy.torch_attention_sdpa
 
     @classmethod
     def get_attention_layout(cls) -> str:
@@ -1198,7 +1198,7 @@ class AttentionLayoutModel(torch.nn.Module):
 
         # Apply scaled dot product attention
         if self.use_grouped_sdpa:
-            attn_output = torch.ops.attention.grouped_sdpa(
+            attn_output = torch.ops.auto_deploy.torch_attention_grouped_sdpa(
                 q,
                 k,
                 v,
@@ -1208,7 +1208,7 @@ class AttentionLayoutModel(torch.nn.Module):
                 scale=1.0 / (self.head_dim**0.5),
             )
         else:
-            attn_output = torch.ops.attention.scaled_dot_product_attention(
+            attn_output = torch.ops.auto_deploy.torch_attention_sdpa(
                 q,
                 k,
                 v,
@@ -1245,7 +1245,7 @@ class BsndAttentionModel(AttentionLayoutModel):
         attn_mask = self._get_attn_mask(x) if self.has_mask else None
 
         # Apply bsnd_grouped_sdpa directly
-        attn_output = torch.ops.attention.bsnd_grouped_sdpa.default(
+        attn_output = torch.ops.auto_deploy.torch_attention_bsnd_grouped_sdpa.default(
             q,
             k,
             v,
@@ -1283,11 +1283,11 @@ def test_match_attention_layout(layout, model_config, has_mask):
     MockAttentionDescriptor.layout = layout
     if layout == "bnsd":
         if model_config.get("use_grouped_sdpa"):
-            source_op = torch.ops.attention.grouped_sdpa
+            source_op = torch.ops.auto_deploy.torch_attention_grouped_sdpa
         else:
-            source_op = torch.ops.attention.scaled_dot_product_attention
+            source_op = torch.ops.auto_deploy.torch_attention_sdpa
     else:
-        source_op = torch.ops.attention.bsnd_grouped_sdpa
+        source_op = torch.ops.auto_deploy.torch_attention_bsnd_grouped_sdpa
     MockAttentionDescriptor.source_attention_op = source_op
 
     # Create appropriate model based on model_config
@@ -1318,18 +1318,20 @@ def test_match_attention_layout(layout, model_config, has_mask):
         if model_config["type"] == "standard":
             if model_config["use_grouped_sdpa"]:
                 original_nodes = [
-                    n for n in gm.graph.nodes if is_op(n, torch.ops.attention.grouped_sdpa)
+                    n for n in gm.graph.nodes if is_op(n, torch.ops.auto_deploy.torch_attention_grouped_sdpa)
                 ]
             else:
                 original_nodes = [
                     n
                     for n in gm.graph.nodes
-                    if is_op(n, torch.ops.attention.scaled_dot_product_attention)
+                    if is_op(n, torch.ops.auto_deploy.torch_attention_sdpa)
                 ]
         else:  # already_bsnd
             original_nodes = []
 
-        bsnd_nodes = [n for n in gm.graph.nodes if is_op(n, torch.ops.attention.bsnd_grouped_sdpa)]
+        bsnd_nodes = [
+            n for n in gm.graph.nodes if is_op(n, torch.ops.auto_deploy.torch_attention_bsnd_grouped_sdpa)
+        ]
         transpose_nodes = [n for n in gm.graph.nodes if is_op(n, torch.ops.aten.transpose.int)]
 
         # Different expectations based on model type and layout

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_attention_matcher_hf.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_attention_matcher_hf.py
@@ -31,7 +31,7 @@ class MockAttentionDescriptor:
 
     @classmethod
     def get_source_attention_op(cls) -> Callable:
-        return torch.ops.attention.bsnd_grouped_sdpa
+        return torch.ops.auto_deploy.torch_attention_bsnd_grouped_sdpa
 
 
 class HFWrapper(nn.Module):
@@ -83,9 +83,9 @@ def test_match_llama_attention(config: Dict[str, Any], attn_implementation: str)
     )
 
     def verify_matcher(gm: GraphModule):
-        """Ensure that there is exactly one torch.ops.attention.bsnd_grouped_sdpa call in the graph."""
+        """Ensure that there is exactly one torch.ops.auto_deploy.torch_attention_bsnd_grouped_sdpa call in the graph."""
         nodes = gm.graph.find_nodes(
-            op="call_function", target=torch.ops.attention.bsnd_grouped_sdpa
+            op="call_function", target=torch.ops.auto_deploy.torch_attention_bsnd_grouped_sdpa
         )
         assert len(nodes) == 1, "Expected exactly one bsnd_grouped_sdpa call in the graph"
 
@@ -97,7 +97,7 @@ def test_match_llama_attention(config: Dict[str, Any], attn_implementation: str)
         )
 
         # TODO: check that there is no repeat_kv pattern left...
-        nodes = gm.graph.find_nodes(op="call_function", target=torch.ops.attention.repeat_kv)
+        nodes = gm.graph.find_nodes(op="call_function", target=torch.ops.auto_deploy.torch_attention_repeat_kv)
         assert len(nodes) == 0, "Found repeat_kv pattern in the graph"
 
         return True

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_kv_cache.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_kv_cache.py
@@ -53,7 +53,9 @@ class GQAWithSdpa(GQA):
         v = v.view(b, s, self.num_kv_heads, self.head_dim)
 
         # Use grouped SDPA in bsnd layout
-        attn_output = torch.ops.attention.bsnd_grouped_sdpa(q, k, v, None, 0.0, True, None)
+        attn_output = torch.ops.auto_deploy.torch_attention_bsnd_grouped_sdpa(
+            q, k, v, None, 0.0, True, None
+        )
 
         # SDPA output is already in [b, s, n, h_d] format
         # Reshape to [b, s, n*h_d]

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_moe_fusion.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_moe_fusion.py
@@ -100,7 +100,7 @@ def test_moe_matching():
         model,
         x,
         match_moe_pattern,
-        lambda gm: any(is_op(n, torch.ops.moe.torch_moe) for n in gm.graph.nodes),
+        lambda gm: any(is_op(n, torch.ops.auto_deploy.torch_moe) for n in gm.graph.nodes),
         lambda num_p_og: num_p_og,
         atol=1e-3,
         rtol=1e-3,
@@ -119,7 +119,7 @@ def test_moe_fusion():
         x,
         fuse_moe,
         lambda gm: any(
-            is_op(n, {torch.ops.moe.torch_fused_moe, torch.ops.moe.trtllm_fused_moe})
+            is_op(n, {torch.ops.auto_deploy.torch_moe_fused, torch.ops.auto_deploy.trtllm_moe_fused})
             for n in gm.graph.nodes
         ),
         lambda num_p_og: num_p_og,

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_quantization.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_quantization.py
@@ -61,6 +61,8 @@ def test_quantization(quant_config, atol, rtol, num_p_og):
         rtol,
         True,  # test_load_hook
         False,  # strict_loading
+        None,  # dynamic_shapes
+        None,  # check_num_matches
         quant_config,
     )
 

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_quantization.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_quantization.py
@@ -14,7 +14,7 @@ from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
 
 
 def check_quantized(gm):
-    op_expected = {torch.ops.quant.fp8_linear, torch.ops.quant.fp4_linear}
+    op_expected = {torch.ops.auto_deploy.torch_quant_fp8_linear, torch.ops.auto_deploy.torch_quant_fp4_linear}
     return any(is_op(n, op_expected) for n in gm.graph.nodes)
 
 

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_rope_transformation.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_rope_transformation.py
@@ -9,9 +9,8 @@ from _model_test_utils import (
 from torch.export import Dim
 
 from tensorrt_llm._torch.auto_deploy.transformations.library.rope import (
-    match_complex_rope,
-    match_explicit_rope,
     match_rope_layout,
+    match_rope_pattern,
     optimize_rope,
 )
 from tensorrt_llm._torch.auto_deploy.utils.node_utils import extract_output_tuple, is_op
@@ -74,7 +73,7 @@ class RoPEModel(torch.nn.Module):
         q = self.linear_q(x)
         k = self.linear_k(x)
 
-        if self.variant == "explicit":
+        if self.variant == "explicit" or self.variant == "explicit_pm":
             # reshape and permute if BNSD layout
             q = q.view(b, s, self.num_heads, self.head_dim)
             k = k.view(b, s, self.num_kv_heads, self.head_dim)
@@ -211,10 +210,10 @@ def test_rope_variants(
     dyn = model.get_dynamic_shapes()
 
     if transformation == "match":
-        fn = match_explicit_rope if variant == "explicit" else match_complex_rope
+        fn = match_rope_pattern
         check_op = (
             torch.ops.rope.torch_apply_rope_with_explicit_cos_sin
-            if variant == "explicit"
+            if variant == "explicit" or variant == "explicit_pm"
             else torch.ops.rope.torch_apply_rope_with_complex_freqs
         )
 
@@ -257,7 +256,7 @@ def test_rope_variants(
         def checker(gm):
             return any(is_op(n, torch.ops.rope.flashinfer) for n in gm.graph.nodes)
 
-    if target_layout:
+    if transformation == "match_layout":
         _ = run_test(
             model,
             x,
@@ -269,7 +268,22 @@ def test_rope_variants(
             True,  # test_load_hook
             True,  # strict_loading
             dyn,  # dynamic_shapes
+            None,  # check_num_matches
             target_layout,
+        )
+    elif transformation == "match":
+        _ = run_test(
+            model,
+            x,
+            fn,
+            checker,
+            lambda n: n,
+            atol,  # atol
+            rtol,  # rtol
+            True,  # test_load_hook
+            True,  # strict_loading
+            dyn,  # dynamic_shapes
+            1,  # check_num_matches
         )
     else:
         _ = run_test(
@@ -283,6 +297,7 @@ def test_rope_variants(
             True,  # test_load_hook
             True,  # strict_loading
             dyn,  # dynamic_shapes
+            None,  # check_num_matches
         )
 
 
@@ -368,7 +383,7 @@ def test_match_and_layout_deepseek(layout, num_heads, num_kv_heads, mode, target
     dynamic_shapes = model.get_dynamic_shapes()
 
     if mode == "match":
-        transform = match_explicit_rope
+        transform = match_rope_pattern
 
         def checker(gm):
             return any(
@@ -400,7 +415,7 @@ def test_match_and_layout_deepseek(layout, num_heads, num_kv_heads, mode, target
 
             return matched if layout != target_layout else not matched
 
-    if target_layout:
+    if mode == "match_layout":
         _ = run_test(
             model,
             x,
@@ -412,6 +427,7 @@ def test_match_and_layout_deepseek(layout, num_heads, num_kv_heads, mode, target
             True,  # test_load_hook
             True,  # strict_loading
             dynamic_shapes,  # dynamic_shapes
+            None,  # check_num_matches
             target_layout,
         )
     else:
@@ -426,4 +442,5 @@ def test_match_and_layout_deepseek(layout, num_heads, num_kv_heads, mode, target
             True,  # test_load_hook
             True,  # strict_loading
             dynamic_shapes,  # dynamic_shapes
+            1,  # check_num_matches
         )

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_rope_transformation.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_rope_transformation.py
@@ -254,7 +254,7 @@ def test_rope_variants(
         fn = optimize_rope
 
         def checker(gm):
-            return any(is_op(n, torch.ops.rope.flashinfer) for n in gm.graph.nodes)
+            return any(is_op(n, torch.ops.auto_deploy.flashinfer_rope) for n in gm.graph.nodes)
 
     if transformation == "match_layout":
         _ = run_test(

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_rope_transformation.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_rope_transformation.py
@@ -91,7 +91,7 @@ class RoPEModel(torch.nn.Module):
             if self.mode == "match":
                 q_out, k_out = apply_rotary_pos_emb_explicit(q, k, cos, sin, unsq_dim)
             else:  # optimize
-                q_out, k_out = torch.ops.rope.torch_apply_rope_with_explicit_cos_sin(
+                q_out, k_out = torch.ops.auto_deploy.torch_rope_with_explicit_cos_sin(
                     q, k, cos, sin, unsq_dim
                 )
 
@@ -119,7 +119,7 @@ class RoPEModel(torch.nn.Module):
             if self.mode == "match":
                 q_out, k_out = apply_rotary_pos_emb_complex(q, k, freqs, unsq_dim)
             else:
-                q_out, k_out = torch.ops.rope.torch_apply_rope_with_complex_freqs(
+                q_out, k_out = torch.ops.auto_deploy.torch_rope_with_complex_freqs(
                     q, k, freqs, unsq_dim
                 )
 
@@ -212,9 +212,9 @@ def test_rope_variants(
     if transformation == "match":
         fn = match_rope_pattern
         check_op = (
-            torch.ops.rope.torch_apply_rope_with_explicit_cos_sin
+            torch.ops.auto_deploy.torch_rope_with_explicit_cos_sin
             if variant == "explicit" or variant == "explicit_pm"
-            else torch.ops.rope.torch_apply_rope_with_complex_freqs
+            else torch.ops.auto_deploy.torch_rope_with_complex_freqs
         )
 
         def checker(gm):
@@ -228,8 +228,8 @@ def test_rope_variants(
                 if is_op(
                     n,
                     {
-                        torch.ops.rope.torch_apply_rope_with_explicit_cos_sin,
-                        torch.ops.rope.torch_apply_rope_with_complex_freqs,
+                        torch.ops.auto_deploy.torch_rope_with_explicit_cos_sin,
+                        torch.ops.auto_deploy.torch_rope_with_complex_freqs,
                     },
                 ):
                     q_arg, k_arg, *rest = n.args
@@ -346,7 +346,7 @@ class DSModel(torch.nn.Module):
         else:
             cos = cos[pos_ids]
             sin = sin[pos_ids]
-            q_out, k_out = torch.ops.rope.torch_apply_rope_with_qk_interleaving(
+            q_out, k_out = torch.ops.auto_deploy.torch_rope_with_qk_interleaving(
                 q, k, cos, sin, unsq_dim
             )
         if self.layout == "BNSD":
@@ -387,7 +387,7 @@ def test_match_and_layout_deepseek(layout, num_heads, num_kv_heads, mode, target
 
         def checker(gm):
             return any(
-                is_op(n, torch.ops.rope.torch_apply_rope_with_qk_interleaving)
+                is_op(n, torch.ops.auto_deploy.torch_rope_with_qk_interleaving)
                 for n in gm.graph.nodes
             )
 
@@ -396,7 +396,7 @@ def test_match_and_layout_deepseek(layout, num_heads, num_kv_heads, mode, target
 
         def checker(gm):
             for n in gm.graph.nodes:
-                if is_op(n, torch.ops.rope.torch_apply_rope_with_qk_interleaving):
+                if is_op(n, torch.ops.auto_deploy.torch_rope_with_qk_interleaving):
                     q_arg, k_arg, *rest = n.args
                     if not (
                         is_op(q_arg, torch.ops.aten.contiguous)


### PR DESCRIPTION
This PR moves all auto-deploy custom ops to the `torch.ops.auto_deploy` namespace.
The new namespace hierarchy is:

`torch.ops.auto_deploy.<kernel_source>_<op_category>_<op_name>`

| Before PR                                                                 | After PR                                                                  |
|---------------------------------------------------------------------------|----------------------------------------------------------------------------------------|
| torch.ops.attention.fused_flattened_mha_with_cache_rope_fusion            | torch.ops.auto_deploy.triton_attention_fused_flattened_mha_with_cache_rope_fusion      |
| torch.ops.attention.fused_flattened_mha_with_cache                        | torch.ops.auto_deploy.triton_attention_fused_flattened_mha_with_cache                  |
| torch.ops.attention.fused_mha_with_paged_cache                            | torch.ops.auto_deploy.triton_attention_fused_mha_with_paged_cache                      |
| torch.ops.attention.prepare_flashinfer_metadata                           | torch.ops.auto_deploy.flashinfer_attention_prepare_metadata                            |
| torch.ops.attention.flashinfer_mha_with_cache                             | torch.ops.auto_deploy.flashinfer_attention_mha_with_cache                              |
| torch.ops.moe.trtllm_fused_moe                                            | torch.ops.auto_deploy.trtllm_moe_fused                                                 |
| torch.ops.moe.torch_moe                                                   | torch.ops.auto_deploy.torch_moe                                                        |
| torch.ops.moe.torch_fused_moe                                             | torch.ops.auto_deploy.torch_moe_fused                                                  |
| torch.ops.dist.all_gather                                                 | torch.ops.auto_deploy.torch_dist_all_gather                                            |
| torch.ops.dist.all_reduce                                                 | torch.ops.auto_deploy.torch_dist_all_reduce                                            |
| torch.ops.linear.simple                                                   | torch.ops.auto_deploy.torch_linear_simple                                              |
| torch.ops.linear.fused_linear_all_reduce                                  | torch.ops.auto_deploy.trtllm_dist_linear_fused_linear_all_reduce                       |
| torch.ops.rope.flashinfer                                                 | torch.ops.auto_deploy.flashinfer_rope                                                  |
| torch.ops.attention.fused_flattened_mla_with_cache                        | torch.ops.auto_deploy.triton_attention_fused_flattened_mla_with_cache                  |
| torch.ops.attention.prepare_fused_mla_metadata                            | torch.ops.auto_deploy.triton_attention_prepare_fused_mla_metadata                      |
| torch.ops.rope.apply_rope_with_input_pos                                  | torch.ops.auto_deploy.triton_rope_apply_rope_with_input_pos                            |
| torch.ops.rope.apply_rope_on_flattened_inputs                             | torch.ops.auto_deploy.triton_rope_on_flattened_inputs                                  |
| torch.ops.rope.torch_apply_rope_with_explicit_cos_sin                     | torch.ops.auto_deploy.torch_rope_with_explicit_cos_sin                                 |
| torch.ops.rope.torch_apply_rope_with_complex_freqs                        | torch.ops.auto_deploy.torch_rope_with_complex_freqs                                    |
| torch.ops.rope.torch_rope_with_qk_interleaving                            | torch.ops.auto_deploy.torch_rope_with_qk_interleaving                                  |
| torch.ops.attention.flattened_mha_with_cache                              | torch.ops.auto_deploy.triton_attention_flattened_mha_with_cache                        |
| torch.ops.attention.prepare_fused_mha_metadata                            | torch.ops.auto_deploy.triton_attention_prepare_fused_mha_metadata                      |
| torch.ops.quant.quant_fn                                                  | torch.ops.auto_deploy.torch_quant_fn                                                   |
| torch.ops.quant.fp8_linear                                                | torch.ops.auto_deploy.torch_quant_fp8_linear                                           |
| torch.ops.quant.fp4_linear                                                | torch.ops.auto_deploy.torch_quant_fp4_linear                                           |
| torch.fused_fp8_linear_all_reduce                                         | torch.ops.auto_deploy.torch_quant_fused_fp8_linear_all_reduce                          |


See [this Slack discussion](https://nvidia.slack.com/archives/C06NESX7SH3/p1747435565534149)