### PR TITLE
test: Deprecate gpt_model_type "v1" static batching from triton_backend L0_backend_trtllm

### DIFF
--- a/triton_backend/ci/L0_backend_trtllm/custom_metrics_verification_tests.py
+++ b/triton_backend/ci/L0_backend_trtllm/custom_metrics_verification_tests.py
@@ -82,7 +82,7 @@ class CustomMetricsTest(unittest.TestCase):
 
                     return json.loads(json_string)
 
-    def _parse_triton_metrics(self, filename, is_v1):
+    def _parse_triton_metrics(self, filename):
         curl_counts = {}
         with open(filename) as metrics_file:
             for line in metrics_file:
@@ -91,12 +91,11 @@ class CustomMetricsTest(unittest.TestCase):
                     metric_output = re.sub(r"^.*?{", "{", line).split()
                     metric_key = metric_output[0]
                     metric_value = metric_output[1]
-                    key = self._convert_metric_key_to_stats_key(
-                        metric_key, is_v1)
+                    key = self._convert_metric_key_to_stats_key(metric_key)
                     curl_counts[key] = metric_value
         return curl_counts
 
-    def _convert_metric_key_to_stats_key(self, metric_output, is_v1):
+    def _convert_metric_key_to_stats_key(self, metric_output):
         # Converts:
         # '{model="tensorrt_llm",request_type="context",version="1"}'
         # to:
@@ -107,15 +106,12 @@ class CustomMetricsTest(unittest.TestCase):
             if not i.startswith('model') and not i.startswith('version')
         ][0]
         self.assertIn(key, metric_to_stat_dict)
-        if (is_v1):
-            self.assertNotIn("inflight_batcher_specific_metric", key)
-        else:
-            self.assertNotIn("v1_specific_metric", key)
+        self.assertNotIn("v1_specific_metric", key)
         return metric_to_stat_dict[key]
 
-    def _base_test(self, stats_file, metrics_file, is_v1):
+    def _base_test(self, stats_file, metrics_file):
         stats = self._parse_log_file(stats_file)
-        metrics = self._parse_triton_metrics(metrics_file, is_v1)
+        metrics = self._parse_triton_metrics(metrics_file)
         self.assertEqual(len(stats.keys()), len(metrics.keys()))
         self.assertEqual(list(stats.keys()).sort(), list(metrics.keys()).sort())
         for metric_key in stats.keys():
@@ -140,45 +136,33 @@ class CustomMetricsTest(unittest.TestCase):
                     timedelta(seconds=-1) <= difference, difference
                     <= timedelta(seconds=1))
 
-    def test_1_gpu_v1(self):
-        self._base_test("1gpu_v1_no_streaming_server.log",
-                        "1gpu_v1_no_stream_metrics.out", True)
-
     def test_1_gpu_IFB_no_stream(self):
         self._base_test("1gpu_IFB_no_streaming_server.log",
-                        "1gpu_IFB_no_stream_metrics.out", False)
+                        "1gpu_IFB_no_stream_metrics.out")
 
     def test_1_gpu_IFB_stream(self):
         self._base_test("1gpu_IFB_streaming_server.log",
-                        "1gpu_IFB_stream_metrics.out", False)
+                        "1gpu_IFB_stream_metrics.out")
 
     if AVAILABLE_GPUS >= 2:
 
-        def test_2_gpu_v1(self):
-            self._base_test("2gpu_v1_no_streaming_server.log",
-                            "2gpu_v1_no_stream_metrics.out", True)
-
         def test_2_gpu_IFB_no_stream(self):
             self._base_test("2gpu_IFB_no_streaming_server.log",
-                            "2gpu_IFB_no_stream_metrics.out", False)
+                            "2gpu_IFB_no_stream_metrics.out")
 
         def test_2_gpu_IFB_stream(self):
             self._base_test("2gpu_IFB_streaming_server.log",
-                            "2gpu_IFB_stream_metrics.out", False)
+                            "2gpu_IFB_stream_metrics.out")
 
     if AVAILABLE_GPUS >= 4:
 
-        def test_4_gpu_v1(self):
-            self._base_test("4gpu_v1_no_streaming_server.log",
-                            "4gpu_v1_no_stream_metrics.out", True)
-
         def test_4_gpu_IFB_no_stream(self):
             self._base_test("4gpu_IFB_no_streaming_server.log",
-                            "4gpu_IFB_no_stream_metrics.out", False)
+                            "4gpu_IFB_no_stream_metrics.out")
 
         def test_4_gpu_IFB_stream(self):
             self._base_test("4gpu_IFB_streaming_server.log",
-                            "4gpu_IFB_stream_metrics.out", False)
+                            "4gpu_IFB_stream_metrics.out")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# [DLIS-8353][test] Update Triton L0_backend_trtllm tests.

## Description

Static batching was deprecated in https://github.com/NVIDIA/TensorRT-LLM/pull/4092, causing `triton_backend/ci/L0_backend_trtllm` tests to be failng

`2025-06-12T23:04:29.218916Z 01O E0612 23:04:23.327379 6681 backend_model.cc:694] "ERROR: Failed to create instance: unexpected error when creating modelInstanceState: Static batching type is deprecated. Please use in-flight batching with CapacitySchedulerPolicy::kSTATIC_BATCH instead.`

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
