### PR TITLE
[TRTLLM-4501][feat] AutoTuner tuning config refactor and add tuning for kernel configs.

### DIFF
--- a/tensorrt_llm/_torch/autotuner.py
+++ b/tensorrt_llm/_torch/autotuner.py
@@ -25,8 +25,8 @@ class DynamicTensorSpec:
     """
     input_idx: int
     dim_idx: int
-    gen_tuning_buckets: Union[Tuple[int], Callable]
-    map_to_tuning_buckets: Callable
+    gen_tuning_buckets: Union[Tuple[int], Callable] = ()
+    map_to_tuning_buckets: Callable = lambda x: x
 
 
 @dataclass(slots=True, unsafe_hash=True)
@@ -43,7 +43,7 @@ class ConstraintSpec:
     infer_shape: Callable
 
 
-@dataclass(kw_only=True, unsafe_hash=True)
+@dataclass(kw_only=True)
 class TuningConfig:
     """Configuration for autotuning.
 
@@ -82,8 +82,35 @@ class TuningConfig:
                 ...     )
                 ... )
     """
+    name: Union[str, Tuple[str, ...]] = ""
     dynamic_tensor_specs: Tuple[DynamicTensorSpec, ...] = ()
     constraint_specs: Tuple[ConstraintSpec, ...] = ()
+    configs: Dict[str, Any] = field(default_factory=dict)
+    tune_max_num_tokens: int = None
+
+
+def tuning_config(
+    name: Union[str, Tuple[str, ...]] = "",
+    dynamic_tensor_specs: Tuple[DynamicTensorSpec, ...] = (),
+    constraint_specs: Tuple[ConstraintSpec, ...] = (),
+    configs: Dict[str, Any] = {},
+    tune_max_num_tokens: int = None,
+):
+
+    def decorator(func):
+        tuner = AutoTuner.get()
+        tuning_config = TuningConfig(
+            name=name,
+            dynamic_tensor_specs=dynamic_tensor_specs,
+            constraint_specs=constraint_specs,
+            configs=configs,
+            tune_max_num_tokens=tune_max_num_tokens,
+        )
+        tuner.register_tuning_config(tuning_config)
+
+        return func
+
+    return decorator
 
 
 @dataclass(unsafe_hash=True)
@@ -139,7 +166,7 @@ class TunableRunner(ABC):
 
     @abstractmethod
     def get_valid_tactics(self, inputs: List[torch.Tensor],
-                          profile: OptimizationProfile) -> List[int]:
+                          profile: OptimizationProfile, **kwargs) -> List[int]:
         """One tactic corresponding to one cuda kernel normally, but how to interpret the meaning
         of tactic is pure internal details of the runner.
 
@@ -167,7 +194,8 @@ class TunableRunner(ABC):
             inputs: List[torch.Tensor],
             *,  # all others are keyword args only
             tactic: int = -1,
-            do_preparation: bool = False) -> Any:
+            do_preparation: bool = False,
+            **kwargs) -> Any:
         """Forward pass for tunable runners.
 
         Args:
@@ -277,6 +305,7 @@ class AutoTuner:
         self.warmup = warmup
         self.stream_delay_micro_secs = stream_delay_micro_secs
         self.profiling_cache = {}
+        self.registered_tuning_configs = {}
         self.is_tuning_mode = False
 
         # Add statistics tracking
@@ -296,7 +325,7 @@ class AutoTuner:
         runners: List[TunableRunner],
         input_shapes: Tuple[torch.Size],
         tuning_config: TuningConfig,
-    ) -> Tuple[bool, int, int, OptimizationProfile]:
+    ) -> Tuple[bool, int, int, Dict[str, Any], OptimizationProfile]:
         """Search for cached profiling results matching the current configuration.
 
         Args:
@@ -306,7 +335,7 @@ class AutoTuner:
 
         Returns:
             A tuple containing:
-            [is_cache_hit, runner_id, tactic, stored_profile]
+            [is_cache_hit, runner_id, tactic, best_config, stored_profile]
         """
         for r in runners:
             if (cache_key := AutoTuner._get_cache_key(
@@ -314,10 +343,14 @@ class AutoTuner:
                     tuning_config)) in self.profiling_cache:
                 return True, *self.profiling_cache[cache_key]
 
-        return False, 0, -1, None
+        return False, 0, -1, {}, None
 
-    def choose_one(self, custom_op: str, runners: List[TunableRunner],
-                   tuning_config: TuningConfig, inputs: List[torch.Tensor],
+    def choose_one(self,
+                   custom_op: str,
+                   runners: List[TunableRunner],
+                   inputs: List[torch.Tensor],
+                   tuning_config: TuningConfig = None,
+                   tune_max_num_tokens: int = None,
                    **kwargs) -> Tuple[TunableRunner, int]:
         """Choose the best runner and tactic combination through performance profiling.
 
@@ -343,11 +376,16 @@ class AutoTuner:
 
         input_shapes = tuple(self._get_input_sizes(inputs))
 
+        tuning_config = self.get_tuning_config(
+            name=custom_op) if tuning_config is None else tuning_config
+        if tune_max_num_tokens is not None:
+            tuning_config.tune_max_num_tokens = tune_max_num_tokens
+
         # Early return if it's not tuning, use cache found one or fallback one
         if not self.is_tuning_mode:
-            is_cache_hit, runner_id, tactic, stored_profile = self.search_cache(
+            is_cache_hit, best_runner_id, best_tactic, best_configs, stored_profile = self.search_cache(
                 custom_op, runners, input_shapes, tuning_config)
-            runner = runners[runner_id]
+            best_runner = runners[best_runner_id]
             # TODO: check the stored runner and tactic can implement this shape here
             # Should not directly try (runner, tactic) here, or it will hurt a lot of inference perf.
 
@@ -360,81 +398,111 @@ class AutoTuner:
                 logger.debug(
                     f"[AutoTunner]: Generated key{AutoTuner._get_cache_key(custom_op, runners[0], input_shapes, tuning_config)}"
                 )
-            return runner, tactic
+
+            if tuning_config.configs:
+                return (best_runner, best_tactic, best_configs)
+            else:
+                return (best_runner, best_tactic)
 
         assert len(runners) > 0, "At least one runner is required"
         assert all([isinstance(r, TunableRunner) for r in runners]), \
             "All Given runners must be subclass of TunableRunner"
 
         profiles = self._optimization_profiles(tuning_config, inputs)
+        configs = self._generate_all_configs(tuning_config)
+
         # Record the total configs to try
         self.stats.tuned_op_total_configs[custom_op] = len(profiles)
 
         for p in profiles:
+            # This can depend on the configs, which is only looped over in profile_runners
             tensors = self._prepare_input_tensors(p, inputs)
-            is_cache_hit, runner_id, tactic, _ = self.search_cache(
-                custom_op, runners, p.get_opt_shapes(), tuning_config)
+            is_cache_hit, *_ = self.search_cache(custom_op, runners,
+                                                 p.get_opt_shapes(),
+                                                 tuning_config)
             if not is_cache_hit:
-                min_time = float('inf')
                 # Initialize runner and tactic as None in case of no valid tactic or runners are found
-                runner_id, tactic = None, None
-                for r_id, r in enumerate(runners):
-                    # TODO: use FakeTensor here.
-                    valid_tactics = r.get_valid_tactics(tensors, p)
-                    runner_arg_names = {
-                        p.name
-                        for p in inspect.signature(
-                            r.forward).parameters.values()
-                    }
-                    if "do_preparation" in runner_arg_names and len(
-                            valid_tactics) > 0:
-                        r(tensors, tactic=-1, do_preparation=True, **kwargs)
-                    for tac in valid_tactics:
-                        try:
-                            time_measured = self._profile_single_kernel(
-                                r, tensors, tac, **kwargs)
-                        except Exception as e:
-                            shapes = self._get_input_sizes(tensors)
-
-                            logger.error(
-                                f"[Autotuner]: Failed when profiling {r} {tac}, shapes={shapes}. Error occurred: {e}"
-                            )
-
-                            # Record the failed profiling combinations
-                            if custom_op not in self.stats.failed_profiling_count:
-                                self.stats.failed_profiling_count[
-                                    custom_op] = set()
-                            self.stats.failed_profiling_count[custom_op].add(
-                                AutoTuner._get_cache_key(
-                                    custom_op, r, p.get_opt_shapes(),
-                                    tuning_config))
-
-                            # Set time_measured to inf to notify the failure of the tactic. This can happen when `get_valid_tactics` mistakenly return wrong tactics
-                            # or some runtime error occurs during profiling.
-                            time_measured = float('inf')
-                        if time_measured < min_time:
-                            min_time = time_measured
-                            runner_id, tactic = r_id, tac
-                if runner_id is not None:
+                best_runner_id, best_tactic, best_config = self._profile_runners(
+                    custom_op, runners, tensors, p, tuning_config, configs,
+                    **kwargs)
+                if best_runner_id is not None:
                     # At least one valid (runner, tactic) pair is found
                     cache_key = AutoTuner._get_cache_key(
-                        custom_op, runners[runner_id], p.get_opt_shapes(),
+                        custom_op, runners[best_runner_id], p.get_opt_shapes(),
                         tuning_config)
                     # inspect call stack
-                    self.profiling_cache[cache_key] = (runner_id, tactic, p)
+                    self.profiling_cache[cache_key] = (best_runner_id,
+                                                       best_tactic, best_config,
+                                                       p)
                     self.stats.tuned_op_successful_configs[
                         custom_op] = self.stats.tuned_op_successful_configs.get(
                             custom_op, 0) + 1
                     logger.debug(
-                        f"[Autotuner]: profiling chosen runner: {runners[runner_id]} {tactic} for {cache_key}"
+                        f"[Autotuner]: profiling chosen runner: {runners[best_runner_id]} {best_tactic}{f' {best_config}' if best_config else ''} for {cache_key}"
                     )
 
         # Get the best runner and tactic from cache
         # If no valid tactic is found, the fallback runner and tactic will be used
-        _, runner_id, tactic, _ = self.search_cache(custom_op, runners,
-                                                    input_shapes, tuning_config)
+        _, runner_id, tactic, config, _ = self.search_cache(
+            custom_op, runners, input_shapes, tuning_config)
 
-        return runners[runner_id], tactic
+        if tuning_config.configs:
+            return (runners[runner_id], tactic, config)
+        else:
+            return (runners[runner_id], tactic)
+
+    def _profile_runners(self, custom_op: str, runners: List[TunableRunner],
+                         input_tensors: List[torch.Tensor],
+                         profile: OptimizationProfile,
+                         tuning_config: TuningConfig,
+                         configs: List[Dict[str, Any]], **kwargs) -> float:
+        min_time = float('inf')
+        best_runner_id, best_tactic, best_config = None, None, None
+        for runner_id, runner in enumerate(runners):
+            # TODO: use FakeTensor here.
+            runner_arg_names = {
+                p.name
+                for p in inspect.signature(runner.forward).parameters.values()
+            }
+            for config in configs:
+                valid_tactics = runner.get_valid_tactics(
+                    input_tensors, profile, **config)
+                if "do_preparation" in runner_arg_names and len(
+                        valid_tactics) > 0:
+                    runner(input_tensors,
+                           tactic=-1,
+                           do_preparation=True,
+                           **config,
+                           **kwargs)
+
+                for tac in valid_tactics:
+                    try:
+                        time_measured = self._profile_single_kernel(
+                            runner, input_tensors, tac, config, **kwargs)
+                    except Exception as e:
+                        # Handle None tensors for optional inputs
+                        shapes = self._get_input_sizes(input_tensors)
+
+                        logger.error(
+                            f"[Autotuner]: Failed when profiling {runner} {tac}, shapes={shapes}{f', {config}' if config else ''}. Error occurred: {e}"
+                        )
+
+                        # Record the failed profiling combinations
+                        if custom_op not in self.stats.failed_profiling_count:
+                            self.stats.failed_profiling_count[custom_op] = set()
+                        self.stats.failed_profiling_count[custom_op].add(
+                            AutoTuner._get_cache_key(custom_op, runner,
+                                                     profile.get_opt_shapes(),
+                                                     tuning_config))
+
+                        # Set time_measured to inf to notify the failure of the tactic. This can happen when `get_valid_tactics` mistakenly return wrong tactics
+                        # or some runtime error occurs during profiling.
+                        time_measured = float('inf')
+                    if time_measured < min_time:
+                        min_time = time_measured
+                        best_runner_id, best_tactic, best_config = runner_id, tac, config
+
+        return best_runner_id, best_tactic, best_config
 
     def _get_input_sizes(self, inputs: List[torch.Tensor]) -> List[torch.Size]:
 
@@ -448,7 +516,7 @@ class AutoTuner:
 
     def _profile_single_kernel(self, runner: TunableRunner,
                                inputs: List[torch.Tensor], tactic: int,
-                               **kwargs) -> float:
+                               config: Dict[str, Any], **kwargs) -> float:
         """Profile a single kernel implementation for performance measurement.
 
         Args:
@@ -467,7 +535,7 @@ class AutoTuner:
         stream = torch.cuda.current_stream()
         # warm up, no timing
         for _ in range(self.warmup):
-            runner(inputs, tactic=tactic, **kwargs)
+            runner(inputs, tactic=tactic, **config, **kwargs)
         stream.synchronize()
 
         # Delay the profiled kernel launch to eliminate affects of host time overhead in profiling.
@@ -479,7 +547,7 @@ class AutoTuner:
 
         start.record(stream=stream)
         for _ in range(self.repeat):
-            runner(inputs, tactic=tactic, **kwargs)
+            runner(inputs, tactic=tactic, **config, **kwargs)
         end.record(stream=stream)
         stream.synchronize()
 
@@ -487,7 +555,7 @@ class AutoTuner:
 
         shapes = self._get_input_sizes(inputs)
         logger.debug(
-            f"[Autotuner]: profiling {runner} {tactic}, shapes={shapes}, avg_time {avg_time}"
+            f"[Autotuner]: profiling {runner} {tactic}, shapes={shapes} {f', {config}' if config else ''}. avg_time: {avg_time:.6f}ms"
         )
 
         return avg_time
@@ -525,10 +593,23 @@ class AutoTuner:
             assert inspect.isfunction(spec.gen_tuning_buckets) or isinstance(spec.gen_tuning_buckets, (list, tuple)), \
                 "The given dynamic dimension must provide a opt value generation function or a list of opt values"
             if inspect.isfunction(spec.gen_tuning_buckets):
-                opt_shapes = spec.gen_tuning_buckets(
-                    base_profile.shapes[spec.input_idx][spec.dim_idx].val)
+                if tuning_config.tune_max_num_tokens is None:
+                    # Use the current input size as the opt value
+                    opt_shapes = spec.gen_tuning_buckets(
+                        base_profile.shapes[spec.input_idx][spec.dim_idx].val)
+                else:
+                    # Use the tune_max_num_tokens as the opt value
+                    opt_shapes = spec.gen_tuning_buckets(
+                        tuning_config.tune_max_num_tokens)
             else:
+                # Default values is an empty tuple, means that user does not want to tune this dimension.
                 opt_shapes = spec.gen_tuning_buckets
+            # Add the current input value as one of the opt values
+            opt_shapes = set(opt_shapes)
+            opt_shapes.add(
+                spec.map_to_tuning_buckets(
+                    base_profile.shapes[spec.input_idx][spec.dim_idx].val))
+            opt_shapes = sorted(list(opt_shapes))
             opt_shapes_max = tuple(opt_shapes[1:]) + (float('inf'), )
             opt_shapes_max = {
                 v1: v2
@@ -554,6 +635,8 @@ class AutoTuner:
             for spec in tuning_config.constraint_specs:
                 min_value = opt_value = max_value = spec.infer_shape(
                     p.get_opt_shapes())
+                if p.shapes[spec.input_idx] == [StaticDim(0)]:
+                    continue
                 p.shapes[spec.input_idx][spec.dim_idx] = DynamicDim(
                     min_value, opt_value, max_value)
             generated_profiles.append(p)
@@ -562,8 +645,12 @@ class AutoTuner:
 
     @classmethod
     @lru_cache(maxsize=None)
-    def _find_nearest_profile(cls, shapes: Tuple[torch.Size],
-                              tuning_config: TuningConfig) -> Tuple:
+    def _find_nearest_profile(cls,
+                              shapes: Tuple[torch.Size],
+                              dynamic_tensor_specs: Tuple[DynamicTensorSpec,
+                                                          ...],
+                              constraint_specs: Tuple[ConstraintSpec, ...],
+                              tune_max_num_tokens: int = None) -> Tuple:
         """Find the nearest optimization profile for given inputs
         User can define their own nearest profile generation method to reduce the host overhead.
 
@@ -578,13 +665,20 @@ class AutoTuner:
         """
         base_profile = list(list(shape) for shape in shapes)
 
-        for spec in tuning_config.dynamic_tensor_specs:
+        for spec in dynamic_tensor_specs:
             base_profile[spec.input_idx][
                 spec.dim_idx] = spec.map_to_tuning_buckets(
                     base_profile[spec.input_idx][spec.dim_idx])
 
+            if tune_max_num_tokens is not None:
+                base_profile[spec.input_idx][spec.dim_idx] = min(
+                    base_profile[spec.input_idx][spec.dim_idx],
+                    tune_max_num_tokens)
+
         # associated dimensions dependent on other free dynamic dimensions, so assign -1 in the profile
-        for spec in tuning_config.constraint_specs:
+        for spec in constraint_specs:
+            if base_profile[spec.input_idx] == [0]:
+                continue
             base_profile[spec.input_idx][spec.dim_idx] = -1
 
         return tuple(tuple(shape) for shape in base_profile)
@@ -598,7 +692,10 @@ class AutoTuner:
         tuning_config: TuningConfig,
     ) -> Tuple:
         return (custom_op, runner.__class__.__name__, hash(runner),
-                cls._find_nearest_profile(input_shapes, tuning_config))
+                cls._find_nearest_profile(input_shapes,
+                                          tuning_config.dynamic_tensor_specs,
+                                          tuning_config.constraint_specs,
+                                          tuning_config.tune_max_num_tokens))
 
     def _create_tensor_like(self, origin_tensor: torch.Tensor,
                             dims: List[Dim]) -> torch.Tensor:
@@ -642,6 +739,17 @@ class AutoTuner:
             tensors.append(tensor)
         return tensors
 
+    def _generate_all_configs(
+            self, tuning_config: TuningConfig) -> List[Dict[str, Any]]:
+        # If there is no config, return a list with an empty dict
+        if not tuning_config.configs:
+            return [{}]
+        logger.debug(
+            f"[Autotuner]: {tuning_config.name} all configs: {tuning_config.configs}"
+        )
+        prod = itertools.product(*tuning_config.configs.values())
+        return list(dict(zip(tuning_config.configs.keys(), p)) for p in prod)
+
     def clear_cache(self) -> None:
         """Clear the profiling cache."""
         self.profiling_cache.clear()
@@ -649,3 +757,12 @@ class AutoTuner:
     def reset_statistics(self) -> None:
         """Reset all statistics counters."""
         self.stats = AutoTunerStatistics()
+
+    def register_tuning_config(self, tuning_config: TuningConfig):
+        name = tuning_config.name
+        names = [name] if isinstance(name, str) else name
+        for name in names:
+            self.registered_tuning_configs[name] = tuning_config
+
+    def get_tuning_config(self, name: str) -> TuningConfig:
+        return self.registered_tuning_configs.get(name, TuningConfig())

--- a/tensorrt_llm/_torch/utils.py
+++ b/tensorrt_llm/_torch/utils.py
@@ -226,7 +226,6 @@ def get_power_of_2_num_tokens_buckets(max_num_tokens) -> List[int]:
     while m >= 1:
         num_token_buckets.append(m)
         m //= 2
-
     return tuple(num_token_buckets)
 
 

--- a/tests/unittest/_torch/thop/test_w4a8_mxfp4_mxfp8_gemm.py
+++ b/tests/unittest/_torch/thop/test_w4a8_mxfp4_mxfp8_gemm.py
@@ -20,6 +20,7 @@ from parameterized import parameterized
 from utils.util import skip_pre_blackwell_unittest, unittest_name_func
 
 import tensorrt_llm
+from tensorrt_llm._torch.autotuner import autotune
 
 
 class TestFunctional(unittest.TestCase):
@@ -73,9 +74,10 @@ class TestFunctional(unittest.TestCase):
         a_block_sf = torch.ops.trtllm.nvfp4_block_scale_interleave(a_block_sf)
         b_block_sf = torch.ops.trtllm.nvfp4_block_scale_interleave(b_block_sf)
 
-        c = (torch.ops.trtllm.w4a8_mxfp4_fp8_gemm(mat_a, mat_b, a_block_sf,
-                                                  b_block_sf, a_sf,
-                                                  torch.bfloat16))
+        with autotune():
+            c = (torch.ops.trtllm.w4a8_mxfp4_fp8_gemm(mat_a, mat_b, a_block_sf,
+                                                      b_block_sf, a_sf,
+                                                      torch.bfloat16))
         c_ref = (mat_a_ref @ mat_b_ref.T * a_sf).to(torch.bfloat16)
 
         assert torch.allclose(c_ref, c, atol=1e-2, rtol=1e-2)


### PR DESCRIPTION
The motivation for this PR is #4872, in which AutoTuner is applied to FP8 batched GEMM op with `tile_size` and `epilog_tile_m` to be in the argument list. Generally, there are two possible implementations.
* Encoding different configs into a list of numeric tactic IDs starting from 0. This will be implemented inside kernels and used through get_valid_tactics.
* Define each config separately and let AutoTuner iterate over the combinations. This is more readable and flexible. Users can use each part of the config directly. There is no encoding-decoding process.

We choose the second method: Adding a config entry in the tuning config to define the valid candidates for each part of the config.
* AutoTuner will loop over a search grid generated from the config combinations.
* Each config will be tuned along with the specific input profile.
* The best config will be recorded in the cache value (instead of the cache key). And it will be recovered and used in the tunable runner forward.

Other enhancements:
* Use the decorator to make the tuning config definition more natural and efficient. This is an independent enhancement.
* Allow the user to not specify the gen_tuning_buckets or the map_to_tuning_buckets function.
* Code refactoring.