### PR TITLE
fix: remove cudaStreamSynchronize when using relaxed acceptance

### DIFF
--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -54,10 +54,11 @@ class MTPHiddenStatesManager(BaseResourceManager):
         )
         if self.use_relaxed_acceptance_for_thinking:
             # The relaxed_delta for relaxed acceptance
-            self.mtp_relaxed_delta_pool = torch.zeros(
+            self.mtp_relaxed_delta_pool_host = torch.zeros(
                 (self.max_num_requests),
                 dtype=torch.float,
-                device='cuda',
+                device='cpu',
+                pin_memory=True,
             )
 
     def prepare_resources(self, scheduled_batch: ScheduledRequests):
@@ -67,7 +68,7 @@ class MTPHiddenStatesManager(BaseResourceManager):
             if req.is_first_context_chunk:
                 slot_id = self.slot_manager.add_slot(req.request_id)
                 if self.use_relaxed_acceptance_for_thinking:
-                    self.mtp_relaxed_delta_pool[slot_id] = 0.
+                    self.mtp_relaxed_delta_pool_host[slot_id] = 0.
 
     def update_resources(self, scheduled_batch: ScheduledRequests):
         pass
@@ -75,7 +76,7 @@ class MTPHiddenStatesManager(BaseResourceManager):
     def free_resources(self, request: LlmRequest):
         free_slot_id = self.slot_manager.get_slot(request.request_id)
         if self.use_relaxed_acceptance_for_thinking:
-            self.mtp_relaxed_delta_pool[free_slot_id] = 0.
+            self.mtp_relaxed_delta_pool_host[free_slot_id] = 0.
         self.slot_manager.remove_slot(request.request_id)
 
     def add_dummy_requests(self, request_ids: List[int]):
@@ -105,6 +106,8 @@ class MTPSpecMetadata(SpecMetadata):
     slot_ids: Optional[torch.Tensor] = None
     # The index of the batche inputs
     batch_indices_cuda: Optional[torch.Tensor] = None
+    # The relaxed delta for relaxed acceptance
+    relaxed_delta_cuda: Optional[torch.Tensor] = None
     # The number of sequences for speculative model/layer of different rank
     _all_rank_num_seqs: Optional[List[int]] = None
     # This is used for attention dp in the MTP Eagle worker. The numbers of input
@@ -132,6 +135,12 @@ class MTPSpecMetadata(SpecMetadata):
                 dtype=torch.long,
                 device='cuda',
             )
+            if self.mtp_hidden_states_manager.use_relaxed_acceptance_for_thinking:
+                self.relaxed_delta_cuda = torch.empty(
+                    [self.max_num_requests],
+                    dtype=torch.float,
+                    device='cuda',
+                )
         self.batch_indices_cuda = torch.empty(
             [self.max_num_requests],
             dtype=torch.int,
@@ -201,6 +210,11 @@ class MTPSpecMetadata(SpecMetadata):
                                         dtype=torch.int,
                                         pin_memory=True)
             self.slot_ids[:num_seqs].copy_(mtp_slot_ids, non_blocking=True)
+            if self.mtp_hidden_states_manager.use_relaxed_acceptance_for_thinking:
+                self.relaxed_delta_cuda[:num_seqs].copy_(
+                    self.mtp_hidden_states_manager.
+                    mtp_relaxed_delta_pool_host[mtp_slot_ids],
+                    non_blocking=True)
 
 
 class MTPSampler(TorchSampler):
@@ -786,7 +800,7 @@ class MTPWorker(nn.Module):
                                              dtype=torch.int,
                                              device=logits.device)
         if self.spec_config.use_relaxed_acceptance_for_thinking:
-            mtp_relaxed_delta_pool = spec_metadata.mtp_hidden_states_manager.mtp_relaxed_delta_pool
+            relaxed_delta_cuda = spec_metadata.relaxed_delta_cuda
 
             # context
             con_logits = logits[:num_contexts]
@@ -810,7 +824,7 @@ class MTPWorker(nn.Module):
             ctx_delta = (ctx_think_tokens_num
                          >= 1).int() * self.spec_config.relaxed_delta
             ctx_slot_ids = spec_metadata.slot_ids[:num_contexts]
-            mtp_relaxed_delta_pool.index_copy_(0, ctx_slot_ids, ctx_delta)
+            relaxed_delta_cuda.index_copy_(0, ctx_slot_ids, ctx_delta)
 
             # generation
             gen_logprobs = self.process_generation_logits(logits, num_contexts)
@@ -819,7 +833,7 @@ class MTPWorker(nn.Module):
 
             accepted_tokens, num_accepted_tokens = torch.ops.trtllm.mtp_relaxed_acceptance_op(
                 spec_metadata.slot_ids, topk_value, topk_indices, draft_tokens,
-                mtp_relaxed_delta_pool, num_accepted_tokens, accepted_tokens,
+                relaxed_delta_cuda, num_accepted_tokens, accepted_tokens,
                 mtp_num_modules, batch_size, num_contexts,
                 self.spec_config.relaxed_topk, self.spec_config.relaxed_delta,
                 self.spec_config.BEGIN_THINKING_PHASE_TOKEN,

--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -54,11 +54,10 @@ class MTPHiddenStatesManager(BaseResourceManager):
         )
         if self.use_relaxed_acceptance_for_thinking:
             # The relaxed_delta for relaxed acceptance
-            self.mtp_relaxed_delta_pool_host = torch.zeros(
+            self.mtp_relaxed_delta_pool = torch.zeros(
                 (self.max_num_requests),
                 dtype=torch.float,
-                device='cpu',
-                pin_memory=True,
+                device='cuda',
             )
 
     def prepare_resources(self, scheduled_batch: ScheduledRequests):
@@ -68,7 +67,8 @@ class MTPHiddenStatesManager(BaseResourceManager):
             if req.is_first_context_chunk:
                 slot_id = self.slot_manager.add_slot(req.request_id)
                 if self.use_relaxed_acceptance_for_thinking:
-                    self.mtp_relaxed_delta_pool_host[slot_id] = 0.
+                    self.mtp_relaxed_delta_pool[slot_id].copy_(
+                        0, non_blocking=True)
 
     def update_resources(self, scheduled_batch: ScheduledRequests):
         pass
@@ -76,7 +76,8 @@ class MTPHiddenStatesManager(BaseResourceManager):
     def free_resources(self, request: LlmRequest):
         free_slot_id = self.slot_manager.get_slot(request.request_id)
         if self.use_relaxed_acceptance_for_thinking:
-            self.mtp_relaxed_delta_pool_host[free_slot_id] = 0.
+            self.mtp_relaxed_delta_pool[free_slot_id].copy_(0,
+                                                            non_blocking=True)
         self.slot_manager.remove_slot(request.request_id)
 
     def add_dummy_requests(self, request_ids: List[int]):
@@ -106,8 +107,6 @@ class MTPSpecMetadata(SpecMetadata):
     slot_ids: Optional[torch.Tensor] = None
     # The index of the batche inputs
     batch_indices_cuda: Optional[torch.Tensor] = None
-    # The relaxed delta for relaxed acceptance
-    relaxed_delta_cuda: Optional[torch.Tensor] = None
     # The number of sequences for speculative model/layer of different rank
     _all_rank_num_seqs: Optional[List[int]] = None
     # This is used for attention dp in the MTP Eagle worker. The numbers of input
@@ -135,12 +134,6 @@ class MTPSpecMetadata(SpecMetadata):
                 dtype=torch.long,
                 device='cuda',
             )
-            if self.mtp_hidden_states_manager.use_relaxed_acceptance_for_thinking:
-                self.relaxed_delta_cuda = torch.empty(
-                    [self.max_num_requests],
-                    dtype=torch.float,
-                    device='cuda',
-                )
         self.batch_indices_cuda = torch.empty(
             [self.max_num_requests],
             dtype=torch.int,
@@ -210,11 +203,6 @@ class MTPSpecMetadata(SpecMetadata):
                                         dtype=torch.int,
                                         pin_memory=True)
             self.slot_ids[:num_seqs].copy_(mtp_slot_ids, non_blocking=True)
-            if self.mtp_hidden_states_manager.use_relaxed_acceptance_for_thinking:
-                self.relaxed_delta_cuda[:num_seqs].copy_(
-                    self.mtp_hidden_states_manager.
-                    mtp_relaxed_delta_pool_host[mtp_slot_ids],
-                    non_blocking=True)
 
 
 class MTPSampler(TorchSampler):
@@ -800,7 +788,7 @@ class MTPWorker(nn.Module):
                                              dtype=torch.int,
                                              device=logits.device)
         if self.spec_config.use_relaxed_acceptance_for_thinking:
-            relaxed_delta_cuda = spec_metadata.relaxed_delta_cuda
+            mtp_relaxed_delta_pool = spec_metadata.mtp_hidden_states_manager.mtp_relaxed_delta_pool
 
             # context
             con_logits = logits[:num_contexts]
@@ -824,7 +812,7 @@ class MTPWorker(nn.Module):
             ctx_delta = (ctx_think_tokens_num
                          >= 1).int() * self.spec_config.relaxed_delta
             ctx_slot_ids = spec_metadata.slot_ids[:num_contexts]
-            relaxed_delta_cuda.index_copy_(0, ctx_slot_ids, ctx_delta)
+            mtp_relaxed_delta_pool.index_copy_(0, ctx_slot_ids, ctx_delta)
 
             # generation
             gen_logprobs = self.process_generation_logits(logits, num_contexts)
@@ -833,7 +821,7 @@ class MTPWorker(nn.Module):
 
             accepted_tokens, num_accepted_tokens = torch.ops.trtllm.mtp_relaxed_acceptance_op(
                 spec_metadata.slot_ids, topk_value, topk_indices, draft_tokens,
-                relaxed_delta_cuda, num_accepted_tokens, accepted_tokens,
+                mtp_relaxed_delta_pool, num_accepted_tokens, accepted_tokens,
                 mtp_num_modules, batch_size, num_contexts,
                 self.spec_config.relaxed_topk, self.spec_config.relaxed_delta,
                 self.spec_config.BEGIN_THINKING_PHASE_TOKEN,


### PR DESCRIPTION
## Description
Problem: When using relaxed acceptance, there is an H2D async copy, which will cause `cudaStreamSynchronize()`. And further block the performance of the overlap scheduler.

Solution: 
Change  `xxx[id] = 0` to `xxx._copy(0, non_blocking=True)`.

#### Timeline anyasis: `cudaStreamSynchronize()` -> `cudaMemcpyAsync()`

- Before fix: 

<img width="2301" height="844" alt="image" src="https://github.com/user-attachments/assets/8d6b1bd8-aace-4c6f-aac5-e2dfff1742e8" />

- After fix: 
<img width="1587" height="826" alt="image" src="https://github.com/user-attachments/assets/a0fcf57d-9fbc-4d36-90af-c786b2522069" />


#### AR & perf anyasis: AR has not changed, TPS has increased slightly.
- before fix: 10 requests, 2K ISL, 2K OSL
```
===========================================================
= PERFORMANCE OVERVIEW 
===========================================================
Request Throughput (req/sec):                     0.1293
Total Output Throughput (tokens/sec):             264.8114
Total Token Throughput (tokens/sec):              395.6654
Total Latency (ms):                               77338.0737
Average request latency (ms):                     42532.1061
Per User Output Throughput [w/ ctx] (tps/user):   77.5910
Per GPU Output Throughput (tps/gpu):              33.1014

-- Request Latency Breakdown (ms) -----------------------

[Latency] P50    : 46398.6505
[Latency] P90    : 77337.3962
[Latency] P95    : 77337.3962
[Latency] P99    : 77337.3962
[Latency] MINIMUM: 7728.2172
[Latency] MAXIMUM: 77337.3962
[Latency] AVERAGE: 42532.1061
===========================================================
= DECODING STATISTICS (MTP)
===========================================================

-- Acceptance Rate Details --------------------------------


[AR] MINIMUM: 3.14
[AR] MAXIMUM: 3.14
[AR] AVERAGE: 3.14
[AR] P50    : 3.14
[AR] P90    : 3.14
[AR] P95    : 3.14
[AR] P99    : 3.14
===========================================================
```



- AR & perf after fix: 10 requests, 2K ISL, 2K OSL
```
===========================================================
= PERFORMANCE OVERVIEW 
===========================================================
Request Throughput (req/sec):                     0.1294
Total Output Throughput (tokens/sec):             265.0755
Total Token Throughput (tokens/sec):              396.0601
Total Latency (ms):                               77260.9941
Average request latency (ms):                     42495.1155
Per User Output Throughput [w/ ctx] (tps/user):   77.6198
Per GPU Output Throughput (tps/gpu):              33.1344

-- Request Latency Breakdown (ms) -----------------------

[Latency] P50    : 46357.6827
[Latency] P90    : 77260.3173
[Latency] P95    : 77260.3173
[Latency] P99    : 77260.3173
[Latency] MINIMUM: 7730.6795
[Latency] MAXIMUM: 77260.3173
[Latency] AVERAGE: 42495.1155
===========================================================
= DECODING STATISTICS (MTP)
===========================================================

-- Acceptance Rate Details --------------------------------


[AR] MINIMUM: 3.14
[AR] MAXIMUM: 3.14
[AR] AVERAGE: 3.14
[AR] P50    : 3.14
[AR] P90    : 3.14
[AR] P95    : 3.14
[AR] P99    : 3.14
===========================================================
```



## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **Performance Improvements**
  * Improved memory management for speculative decoding, potentially enhancing efficiency and stability during processing.

* **Bug Fixes**
  * Addressed issues related to how acceptance data is handled between CPU and GPU, resulting in more reliable speculative decoding.

End-users may notice improved performance and reliability in speculative decoding features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->