### PR TITLE
feat: Upgrade xgrammar to 0.1.18

### DIFF
--- a/examples/pytorch/guided_decoding.py
+++ b/examples/pytorch/guided_decoding.py
@@ -1,0 +1,48 @@
+###  Generate text with guided decoding and pytorch backend.
+
+from tensorrt_llm import SamplingParams
+from tensorrt_llm._torch import LLM
+from tensorrt_llm.llmapi import GuidedDecodingParams
+
+
+def main():
+
+    # Specify the guided decoding backend; xgrammar is supported currently.
+    llm = LLM(model="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+              guided_decoding_backend='xgrammar',
+              disable_overlap_scheduler=True)
+
+    # An example from json-mode-eval
+    schema = '{"title": "WirelessAccessPoint", "type": "object", "properties": {"ssid": {"title": "SSID", "type": "string"}, "securityProtocol": {"title": "SecurityProtocol", "type": "string"}, "bandwidth": {"title": "Bandwidth", "type": "string"}}, "required": ["ssid", "securityProtocol", "bandwidth"]}'
+
+    prompt = [{
+        'role':
+        'system',
+        'content':
+        "You are a helpful assistant that answers in JSON. Here's the json schema you must adhere to:\n<schema>\n{'title': 'WirelessAccessPoint', 'type': 'object', 'properties': {'ssid': {'title': 'SSID', 'type': 'string'}, 'securityProtocol': {'title': 'SecurityProtocol', 'type': 'string'}, 'bandwidth': {'title': 'Bandwidth', 'type': 'string'}}, 'required': ['ssid', 'securityProtocol', 'bandwidth']}\n</schema>\n"
+    }, {
+        'role':
+        'user',
+        'content':
+        "I'm currently configuring a wireless access point for our office network and I need to generate a JSON object that accurately represents its settings. The access point's SSID should be 'OfficeNetSecure', it uses WPA2-Enterprise as its security protocol, and it's capable of a bandwidth of up to 1300 Mbps on the 5 GHz band. This JSON object will be used to document our network configurations and to automate the setup process for additional access points in the future. Please provide a JSON object that includes these details."
+    }]
+    prompt = llm.tokenizer.apply_chat_template(prompt, tokenize=False)
+    print(f"Prompt: {prompt!r}")
+
+    output = llm.generate(prompt, sampling_params=SamplingParams(max_tokens=50))
+    print(f"Generated text (unguided): {output.outputs[0].text!r}")
+
+    output = llm.generate(
+        prompt,
+        sampling_params=SamplingParams(
+            max_tokens=50, guided_decoding=GuidedDecodingParams(json=schema)))
+    print(f"Generated text (guided): {output.outputs[0].text!r}")
+
+    # Got output like
+    # Prompt: "<|system|>\nYou are a helpful assistant that answers in JSON. Here's the json schema you must adhere to:\n<schema>\n{'title': 'WirelessAccessPoint', 'type': 'object', 'properties': {'ssid': {'title': 'SSID', 'type': 'string'}, 'securityProtocol': {'title': 'SecurityProtocol', 'type': 'string'}, 'bandwidth': {'title': 'Bandwidth', 'type': 'string'}}, 'required': ['ssid', 'securityProtocol', 'bandwidth']}\n</schema>\n</s>\n<|user|>\nI'm currently configuring a wireless access point for our office network and I need to generate a JSON object that accurately represents its settings. The access point's SSID should be 'OfficeNetSecure', it uses WPA2-Enterprise as its security protocol, and it's capable of a bandwidth of up to 1300 Mbps on the 5 GHz band. This JSON object will be used to document our network configurations and to automate the setup process for additional access points in the future. Please provide a JSON object that includes these details.</s>\n"
+    # Generated text (unguided): '<|assistant|>\nHere\'s a JSON object that accurately represents the settings of a wireless access point for our office network:\n\n```json\n{\n  "title": "WirelessAccessPoint",\n  "'
+    # Generated text (guided): '{\n  "ssid": "OfficeNetSecure",\n  "securityProtocol": "WPA2-Enterprise",\n  "bandwidth": "1300 Mbps"\n}'
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ peft
 einops
 flashinfer-python==0.2.5
 opencv-python-headless
-xgrammar==0.1.16
+xgrammar==0.1.18
 backoff
 nvtx
 matplotlib # FIXME: this is added to make nvtx happy

--- a/tensorrt_llm/__init__.py
+++ b/tensorrt_llm/__init__.py
@@ -29,6 +29,10 @@ _add_trt_llm_dll_directory()
 
 import sys
 
+# Need to import xgrammar before tensorrt_llm library,
+# otherwise `MemoryError: std::bad_alloc` pattern error will be raised.
+import xgrammar  # noqa
+
 import tensorrt_llm.functional as functional
 import tensorrt_llm.models as models
 import tensorrt_llm.quantization as quantization

--- a/tensorrt_llm/_torch/pyexecutor/grammar_matcher.py
+++ b/tensorrt_llm/_torch/pyexecutor/grammar_matcher.py
@@ -1,4 +1,5 @@
 import json
+import os
 from abc import ABC, abstractmethod
 
 import llguidance
@@ -63,7 +64,14 @@ class XGrammarMatcherFactory(GrammarMatcherFactory):
                 xgrammar.VocabType.RAW,
                 vocab_size=vocab_size_padded,
                 stop_token_ids=guided_decoding_config.stop_token_ids)
-        self._xgrammar_compiler = xgrammar.GrammarCompiler(tokenizer_info)
+        # Default cache limit is 1GB.
+        cache_limit_gb = float(os.getenv("XGRAMMAR_CACHE_LIMIT_GB", "1"))
+        cache_limit_bytes = int(cache_limit_gb * 1024 * 1024 * 1024)
+        self._xgrammar_compiler = xgrammar.GrammarCompiler(
+            tokenizer_info,
+            cache_enabled=True,
+            cache_limit_bytes=cache_limit_bytes,
+        )
 
     def create(self,
                guided_decoding_params: GuidedDecodingParams) -> XGrammarMatcher:


### PR DESCRIPTION
## Description
* Upgrade xgrammar to 0.1.18
* Add size limit for xgrammar cache.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
