### PR TITLE
feat: Dynamically remove servers in PD

### DIFF
--- a/tensorrt_llm/llmapi/disagg_utils.py
+++ b/tensorrt_llm/llmapi/disagg_utils.py
@@ -58,6 +58,7 @@ class MetadataServerConfig():
     hostname: str = "localhost"
     port: int = 2379
     health_check_timeout: float = 5.0
+    refresh_interval: float = 10.0
 
 
 def parse_disagg_config_file(yaml_config_file: str):

--- a/tensorrt_llm/serve/openai_disagg_server.py
+++ b/tensorrt_llm/serve/openai_disagg_server.py
@@ -35,14 +35,14 @@ TIMEOUT_KEEP_ALIVE = 10  # seconds.
 class OpenAIDisaggServer:
 
     def __init__(self,
-                 ctx_servers: List[str] = None,
-                 gen_servers: List[str] = None,
+                 ctx_servers: List[str],
+                 gen_servers: List[str],
                  req_timeout_secs: int = 180,
                  server_start_timeout_secs: int = 180,
                  ctx_router_config: Optional[RouterConfig] = None,
                  gen_router_config: Optional[RouterConfig] = None,
                  conditional_disagg_config: Optional[ConditionalDisaggConfig] = None,
-                 metadata_server_cfg: MetadataServerConfig = None):
+                 metadata_server_cfg: Optional[MetadataServerConfig] = None):
 
         self.ctx_servers = ctx_servers
         self.gen_servers = gen_servers
@@ -76,8 +76,8 @@ class OpenAIDisaggServer:
 
             if self.metadata_server:
                 logger.info("Starting server monitoring via metadata service")
-                await self.ctx_router.start_server_monitoring()
-                await self.gen_router.start_server_monitoring()
+                await self.ctx_router.start_server_monitoring(metadata_server_cfg.refresh_interval)
+                await self.gen_router.start_server_monitoring(metadata_server_cfg.refresh_interval)
 
             yield
 

--- a/tensorrt_llm/serve/openai_disagg_server.py
+++ b/tensorrt_llm/serve/openai_disagg_server.py
@@ -47,8 +47,8 @@ class OpenAIDisaggServer:
         self.ctx_servers = ctx_servers
         self.gen_servers = gen_servers
         self.metadata_server = create_metadata_server(metadata_server_cfg)
-        self.ctx_router = create_router(ctx_router_config, ctx_servers, self.metadata_server)
-        self.gen_router = create_router(gen_router_config, gen_servers, self.metadata_server)
+        self.ctx_router = create_router(ctx_router_config, ctx_servers, metadata_server_cfg, self.metadata_server)
+        self.gen_router = create_router(gen_router_config, gen_servers, metadata_server_cfg, self.metadata_server)
         self.conditional_disagg_config = conditional_disagg_config
 
 

--- a/tensorrt_llm/serve/router.py
+++ b/tensorrt_llm/serve/router.py
@@ -614,8 +614,8 @@ class KvCacheAwareRouter(Router):
 
 def create_router(router_config: Optional[RouterConfig],
                   servers: Optional[List[str]],
-                  metadata_server_cfg: Optional[MetadataServerConfig],
-                  metadata_server: Optional[JsonDictionary]) -> Router:
+                  metadata_server_cfg: Optional[MetadataServerConfig] = None,
+                  metadata_server: Optional[JsonDictionary] = None) -> Router:
     """
     Factory function to create different types of router instances.
 

--- a/tests/unittest/disaggregated/test_router.py
+++ b/tests/unittest/disaggregated/test_router.py
@@ -21,12 +21,10 @@ class MockMetadataServer:
         self.lock = threading.Lock()
 
     def get(self, key):
-        print("***** get *****", key)
         with self.lock:
             return self.servers.get(key)
 
     def put(self, key, value):
-        print("***** put *****", key, value)
         with self.lock:
             self.servers[key] = value
             return True
@@ -39,7 +37,6 @@ class MockMetadataServer:
             return False
 
     def add_server(self, key, url):
-        print("***** add_server *****", key, url)
         with self.lock:
             self.servers[key] = url
             return True
@@ -363,8 +360,8 @@ async def test_fetch_live_servers_context(mock_metadata_server, router_class):
                           metadata_server=mock_metadata_server)
 
     # Initial check - should be no servers
-    servers = await router.fetch_live_servers()
-    assert len(servers) == 0, "Should have no servers initially"
+    with pytest.raises(ValueError):
+        servers = await router.fetch_live_servers()
 
     # Add a server
     server_key = "trtllm/server1"


### PR DESCRIPTION
# Dynamically remove servers in PD

## Description

In this version, we assume the current flow works as the following:

1. The user will first remove the key from ETCD server. 
2. The logger will output which the server is removed.
3. The user can shut down the target server. 

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
