### PR TITLE
Fix: fix the deterministic issue in the MTP Eagle path

### DIFF
--- a/cpp/tensorrt_llm/thop/mtpOp.cpp
+++ b/cpp/tensorrt_llm/thop/mtpOp.cpp
@@ -109,8 +109,8 @@ std::tuple<th::Tensor, th::Tensor> mtp_sampling_and_accepted_draft_tokens_op(th:
     TLLM_CHECK(draftTokensSizes[0] == (numGenerationRequest * numMTPModules));
 
     auto stream = at::cuda::getCurrentCUDAStream(logits.get_device());
-    auto acceptedTokens = torch::empty(
-        {batchSize, numMTPModules + 1}, at::TensorOptions().dtype(torch::kInt32).device(logits.device()));
+    auto acceptedTokens
+        = torch::ones({batchSize, numMTPModules + 1}, at::TensorOptions().dtype(torch::kInt32).device(logits.device()));
     auto numAcceptedTokens = torch::ones({batchSize}, at::TensorOptions().dtype(torch::kInt32).device(logits.device()));
 
     // Fill params

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -980,10 +980,9 @@ class DeepseekV3MTP(DeepseekV3DecoderLayer):
         input_ids: torch.IntTensor,
         position_ids: torch.IntTensor,
         hidden_states: torch.Tensor,
-        lm_head: Linear,
         embed_tokens: Embedding,
         attn_metadata: AttentionMetadata,
-        spec_metadata: MTPSpecMetadata,
+        all_rank_num_tokens: Optional[List[int]] = None,
         **kwargs,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
 
@@ -1024,7 +1023,7 @@ class DeepseekV3MTP(DeepseekV3DecoderLayer):
         # MoE
         hidden_states = self.mlp(
             hidden_states,
-            all_rank_num_tokens=spec_metadata.all_rank_num_tokens,
+            all_rank_num_tokens=all_rank_num_tokens,
             final_all_reduce_params=AllReduceParams(
                 enable_allreduce=not (self.fusion_config.POST_MOE_FUSION
                                       or self.mapping.tp_size == 1)),

--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -1053,6 +1053,7 @@ class MTPEagleWorker(MTPWorker):
     def __init__(self, spec_config: MTPConfig):
         super().__init__(spec_config)
         self.mtp_num_modules = spec_config.num_nextn_predict_layers
+        self.is_thop = False
 
     def forward(
         self,
@@ -1123,9 +1124,8 @@ class MTPEagleWorker(MTPWorker):
             position_ids = inputs["position_ids"][gather_ids] + 1
             # update attn_metadata
             if i == 0:
-                attn_metadata._seq_lens[:attn_metadata.num_contexts].fill_(1)
-                attn_metadata._seq_lens_cuda[:attn_metadata.num_contexts].fill_(
-                    1)
+                attn_metadata._seq_lens[:batch_size].fill_(1)
+                attn_metadata._seq_lens_cuda[:batch_size].fill_(1)
                 attn_metadata.on_update()
                 # cannot run generation if their is no kv cache
                 has_kv_cache = inputs[

--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -375,9 +375,11 @@ class MTPWorker(nn.Module):
                 num_accepted_tokens=num_accepted_tokens,
                 spec_metadata=spec_metadata,
                 attn_metadata=attn_metadata)
-            hidden_states, logits = mtp_layer(lm_head=lm_head,
-                                              embed_tokens=embed_tokens,
-                                              **draft_inputs)
+            hidden_states = mtp_layer(lm_head=lm_head,
+                                      embed_tokens=embed_tokens,
+                                      **draft_inputs)
+            logits = mtp_layer.shared_head(hidden_states, lm_head,
+                                           attn_metadata).float()
             previous_layer_draft_tokens = self.draft_sampler(logits)
             next_draft_tokens.append(previous_layer_draft_tokens)
 
@@ -1066,6 +1068,7 @@ class MTPEagleWorker(MTPWorker):
     ):
         batch_size = attn_metadata.num_seqs
         num_contexts = attn_metadata.num_contexts
+        num_gens = batch_size - num_contexts
 
         # Sample and verify draft tokens
         raw_logits = logits
@@ -1079,21 +1082,35 @@ class MTPEagleWorker(MTPWorker):
 
         # Prepare inputs for the 1st MTP layer
         position_ids = position_ids.squeeze(0)
-        inputs = self.prepare_drafter_inputs(
-            input_ids=input_ids,
-            position_ids=position_ids,
-            hidden_states=hidden_states,
-            accepted_tokens=accepted_tokens,
-            num_accepted_tokens=num_accepted_tokens,
-            attn_metadata=attn_metadata,
-            spec_metadata=spec_metadata)
+        last_tokens_idx = torch.cumsum(
+            attn_metadata.seq_lens_cuda, dim=0, dtype=torch.long) - 1
+        inputs = self.prepare_drafter_inputs(input_ids=input_ids,
+                                             position_ids=position_ids,
+                                             last_tokens_idx=last_tokens_idx,
+                                             hidden_states=hidden_states,
+                                             accepted_tokens=accepted_tokens,
+                                             attn_metadata=attn_metadata,
+                                             spec_metadata=spec_metadata)
 
         # Predict draft tokens
         next_draft_tokens = []
         for i in range(self.mtp_num_modules):
-            hidden_states, logits = mtp_layers[0](lm_head=lm_head,
-                                                  embed_tokens=embed_tokens,
-                                                  **inputs)
+            hidden_states = mtp_layers[0](lm_head=lm_head,
+                                          embed_tokens=embed_tokens,
+                                          **inputs)
+            if i == 0:
+                start_ids_gen = (spec_metadata.batch_indices_cuda[:num_gens] *
+                                 (self.mtp_num_modules + 1)).long()
+                gather_ids_gen = (start_ids_gen +
+                                  num_accepted_tokens[num_contexts:] - 1 +
+                                  attn_metadata.num_ctx_tokens)
+                gather_ids = torch.concat(
+                    [last_tokens_idx[:num_contexts], gather_ids_gen], dim=0)
+            else:
+                # All of the seq_len are 1, use batch_indices_cuda as gather_ids
+                gather_ids = spec_metadata.batch_indices_cuda[:batch_size]
+            logits = mtp_layers[0].shared_head(hidden_states[gather_ids],
+                                               lm_head, attn_metadata, True)
             new_draft_token = self.draft_sampler(logits)
             next_draft_tokens.append(new_draft_token)
             # update inputs
@@ -1102,17 +1119,29 @@ class MTPEagleWorker(MTPWorker):
                 dim=0,
                 dtype=torch.long,
             ) - 1
-            position_ids = inputs["position_ids"][last_tokens] + 1
-            hidden_states = hidden_states[last_tokens]
-            attn_metadata._seq_lens[:attn_metadata.num_contexts].fill_(1)
-            attn_metadata._seq_lens_cuda[:attn_metadata.num_contexts].fill_(1)
-            attn_metadata.on_update()
-            # cannot run generation if their is no kv cache
-            if inputs["attn_metadata"].kv_cache_manager is not None:
-                attn_metadata.host_request_types[:attn_metadata.
-                                                 num_contexts].fill_(1)
-                attn_metadata.num_contexts = 0
-                if i == 0 and num_contexts > 0 and attn_metadata.enable_flash_mla:
+            hidden_states = hidden_states[gather_ids]
+            position_ids = inputs["position_ids"][gather_ids] + 1
+            # update attn_metadata
+            if i == 0:
+                attn_metadata._seq_lens[:attn_metadata.num_contexts].fill_(1)
+                attn_metadata._seq_lens_cuda[:attn_metadata.num_contexts].fill_(
+                    1)
+                attn_metadata.on_update()
+                # cannot run generation if their is no kv cache
+                has_kv_cache = inputs[
+                    "attn_metadata"].kv_cache_manager is not None
+                if has_kv_cache:
+                    attn_metadata.host_request_types[:attn_metadata.
+                                                     num_contexts].fill_(1)
+                    attn_metadata.num_contexts = 0
+                # update kv_lens_cuda
+                if hasattr(attn_metadata, 'kv_lens_cuda'):
+                    attn_metadata.kv_lens_cuda[num_contexts:batch_size] -= (
+                        self.mtp_num_modules -
+                        num_accepted_tokens[num_contexts:])
+                    attn_metadata.kv_lens_cuda[:num_contexts] += 1
+                # update metadata for flash mla
+                if has_kv_cache and num_contexts > 0 and attn_metadata.enable_flash_mla:
                     reorder_block_ids_per_seq = torch.cat([
                         attn_metadata.
                         kv_block_ids_per_seq[num_contexts:batch_size],
@@ -1120,7 +1149,7 @@ class MTPEagleWorker(MTPWorker):
                     ])
                     attn_metadata.block_ids_per_seq[:batch_size, :].copy_(
                         reorder_block_ids_per_seq, non_blocking=True)
-            if hasattr(attn_metadata, 'kv_lens_cuda'):
+            elif hasattr(attn_metadata, 'kv_lens_cuda'):
                 attn_metadata.kv_lens_cuda[:batch_size] += 1
             # support attention dp
             if spec_metadata.all_rank_num_tokens is not None:
@@ -1159,22 +1188,15 @@ class MTPEagleWorker(MTPWorker):
         self,
         input_ids: torch.IntTensor,
         position_ids: torch.IntTensor,
+        last_tokens_idx: torch.LongTensor,
         hidden_states: torch.Tensor,
         accepted_tokens: torch.Tensor,
-        num_accepted_tokens: torch.Tensor,
         attn_metadata: AttentionMetadata,
         spec_metadata: MTPSpecMetadata,
     ):
-        batch_size = attn_metadata.num_seqs
         num_contexts = attn_metadata.num_contexts
-        num_gens = batch_size - num_contexts
-        num_ctx_tokens = attn_metadata.num_ctx_tokens
-        hidden_size = hidden_states.shape[1]
-        last_tokens_idx = torch.cumsum(
-            attn_metadata.seq_lens_cuda, dim=0, dtype=torch.long) - 1
 
         # context
-        hidden_states_ctx = hidden_states[:attn_metadata.num_ctx_tokens, :]
         input_ctx_ids = input_ids[:attn_metadata.num_ctx_tokens]
         input_ids_ctx = torch.empty_like(input_ctx_ids,
                                          dtype=torch.int32,
@@ -1182,38 +1204,12 @@ class MTPEagleWorker(MTPWorker):
         input_ids_ctx[:-1].copy_(input_ctx_ids[1:])
         input_ids_ctx[
             last_tokens_idx[:num_contexts]] = accepted_tokens[:num_contexts, 0]
-        position_ids_ctx = position_ids[:num_ctx_tokens]
 
         # generation
-        gen_batch_idx = spec_metadata.batch_indices_cuda[:num_gens]
-        gen_token_idx = num_accepted_tokens[num_contexts:] - 1
-        hidden_states_gen = hidden_states[attn_metadata.num_ctx_tokens:, :]
-        hidden_states_gen = hidden_states_gen.reshape(num_gens,
-                                                      self.mtp_num_modules + 1,
-                                                      hidden_size)
-        hidden_states_gen = hidden_states_gen[gen_batch_idx, gen_token_idx, :]
-        accepted_tokens_gen = accepted_tokens[num_contexts:, :]
-        input_ids_gen = accepted_tokens_gen[gen_batch_idx, gen_token_idx]
-        position_ids_gen = position_ids[num_ctx_tokens:].reshape(
-            num_gens, self.mtp_num_modules + 1)
-        position_ids_gen = position_ids_gen[gen_batch_idx, gen_token_idx]
+        input_ids_gen = accepted_tokens[num_contexts:, :].flatten()
 
         # get draft inputs
         input_ids = torch.concat([input_ids_ctx, input_ids_gen], dim=0)
-        hidden_states = torch.concat([hidden_states_ctx, hidden_states_gen],
-                                     dim=0)
-        position_ids = torch.concat([position_ids_ctx, position_ids_gen], dim=0)
-
-        # change attn_metadata
-        attn_metadata._seq_lens[num_contexts:batch_size].fill_(1)
-        attn_metadata._seq_lens_cuda[num_contexts:batch_size].fill_(1)
-        attn_metadata.on_update()
-        if hasattr(attn_metadata, 'kv_lens_cuda'):
-            # Note that it's important to not free the seq_lens_cuda
-            # buffer once the graph has been captured also - this will invalidate
-            # the graph and force an expensive recapture.
-            attn_metadata.kv_lens_cuda[num_contexts:batch_size] -= (
-                self.mtp_num_modules + 1 - num_accepted_tokens[num_contexts:])
 
         return {
             "input_ids": input_ids,

--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -745,12 +745,13 @@ class MTPWorker(nn.Module):
             logits = logits.unsqueeze(0)
 
         # The return buffer
-        accepted_tokens = torch.empty((batch_size, (mtp_num_modules + 1)),
-                                      dtype=torch.int,
-                                      device=logits.device)
-        num_accepted_tokens = torch.ones(batch_size,
+        if self.spec_config.use_relaxed_acceptance_for_thinking or not self.is_thop:
+            accepted_tokens = torch.ones((batch_size, (mtp_num_modules + 1)),
                                          dtype=torch.int,
                                          device=logits.device)
+            num_accepted_tokens = torch.ones(batch_size,
+                                             dtype=torch.int,
+                                             device=logits.device)
         if self.spec_config.use_relaxed_acceptance_for_thinking:
             mtp_relaxed_delta_pool = spec_metadata.mtp_hidden_states_manager.mtp_relaxed_delta_pool
 
@@ -1068,7 +1069,6 @@ class MTPEagleWorker(MTPWorker):
     def __init__(self, spec_config: MTPConfig):
         super().__init__(spec_config)
         self.mtp_num_modules = spec_config.num_nextn_predict_layers
-        self.is_thop = False
 
     def forward(
         self,


### PR DESCRIPTION
## Description

This PR updates the first draft forward in the MTP Eagle path to use all accepted tokens instead of just the last one. This allows the KV cache for the draft layer to be updated.

Before this fix, each iteration, the KV cache didn't store the key/value pair for the last draft token (let's call it D) because it was the output of the last draft forward pass. For this last draft token, we call it D. In the next iteration, if all draft tokens were accepted, we'd use the newly generated tokens as inputs for the first draft forward. But since the KV cache had incorrect key/value data for token D, identical inputs could produce different draft tokens.

With this fix, the KV cache will be updated in the first draft forward each iteration, making MTP Eagle deterministic.

I tested the DS-R1-FP4 model with the same dataset and on the same node (with BS=1). The acceptance rate will increase a little bit:

Before the changes:
```
===========================================================
= PERFORMANCE OVERVIEW 
===========================================================
Request Throughput (req/sec):                     0.1530
Total Output Throughput (tokens/sec):             313.0214
Total Token Throughput (tokens/sec):              472.7368
Total Latency (ms):                               65372.5274
Average request latency (ms):                     6537.2043
Per User Output Throughput [w/ ctx] (tps/user):   313.3934
Per GPU Output Throughput (tps/gpu):              39.1277

-- Acceptance Rate Details --------------------------------
[AR] MINIMUM: 2.69
[AR] MAXIMUM: 3.08
[AR] AVERAGE: 2.81
[AR] P50    : 2.80
[AR] P90    : 3.08
[AR] P95    : 3.08
[AR] P99    : 3.08
```

After:
```
===========================================================
= PERFORMANCE OVERVIEW 
===========================================================
Request Throughput (req/sec):                     0.1544
Total Output Throughput (tokens/sec):             316.0127
Total Token Throughput (tokens/sec):              477.2701
Total Latency (ms):                               64747.4007
Average request latency (ms):                     6474.6948
Per User Output Throughput [w/ ctx] (tps/user):   316.3113
Per GPU Output Throughput (tps/gpu):              39.5016

-- Acceptance Rate Details --------------------------------
[AR] MINIMUM: 2.75
[AR] MAXIMUM: 3.07
[AR] AVERAGE: 2.83
[AR] P50    : 2.84
[AR] P90    : 3.07
[AR] P95    : 3.07
[AR] P99    : 3.07
```

For the model accuracy, with this fix, I enabled MTP Ealge and tested GPQA diamond twice with the same random seed. We got the same results 70.202 ± 3.2586, which is expected.