### PR TITLE
[refactor] Remove SpecConfig boilerplate

### DIFF
--- a/examples/pytorch/quickstart_advanced.py
+++ b/examples/pytorch/quickstart_advanced.py
@@ -160,7 +160,7 @@ def setup_llm(args):
             )
 
         spec_config = MTPDecodingConfig(
-            num_nextn_predict_layers=args.spec_decode_nextn,
+            max_draft_len=args.spec_decode_nextn,
             use_relaxed_acceptance_for_thinking=args.
             use_relaxed_acceptance_for_thinking,
             relaxed_topk=args.relaxed_topk,
@@ -168,12 +168,12 @@ def setup_llm(args):
     elif spec_decode_algo == "EAGLE3":
         spec_config = EagleDecodingConfig(
             max_draft_len=args.spec_decode_nextn,
-            pytorch_weights_path=args.draft_model_dir,
+            speculative_model=args.draft_model_dir,
             eagle3_one_model=args.use_one_model)
     elif spec_decode_algo == "DRAFT_TARGET":
         spec_config = DraftTargetDecodingConfig(
             max_draft_len=args.spec_decode_nextn,
-            pytorch_weights_path=args.draft_model_dir)
+            speculative_model=args.draft_model_dir)
     elif spec_decode_algo == "NGRAM":
         spec_config = NGramDecodingConfig(
             prompt_lookup_num_tokens=args.spec_decode_nextn,

--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -68,7 +68,7 @@ class ModelConfig(Generic[TConfig]):
     # to support mixed quantization.
     skip_create_weights_in_init: bool = False
 
-    spec_config: Optional["SpecConfig"] = None
+    spec_config: Optional["DecodingBaseConfig"] = None
     lora_config: Optional["LoraConfig"] = None
 
     is_generation: bool = True

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -214,7 +214,7 @@ class DeepseekV3Attention(MLA):
         aux_stream: Optional[torch.cuda.Stream] = None,
     ):
         config = model_config.pretrained_config
-        predicted_tokens_per_seq = model_config.spec_config.num_nextn_predict_layers + 1 if model_config.spec_config is not None else 1
+        predicted_tokens_per_seq = model_config.spec_config.max_draft_len + 1 if model_config.spec_config is not None else 1
         super().__init__(hidden_size=config.hidden_size,
                          num_attention_heads=config.num_attention_heads,
                          num_key_value_heads=config.num_key_value_heads,
@@ -1064,7 +1064,7 @@ class DeepseekV3ForCausalLM(DecoderModelForCausalLM[DeepseekV3Model,
 
         self.model_nextn = 0
         if model_config.spec_config is not None:
-            model_nextn = model_config.spec_config.num_nextn_predict_layers
+            model_nextn = model_config.spec_config.max_draft_len
             ckpt_nextn = self.config.num_nextn_predict_layers
             self.num_hidden_layers = self.config.num_hidden_layers
             assert ckpt_nextn > 0, "There is not MTP modules in the checkpoint."

--- a/tensorrt_llm/_torch/models/modeling_speculative.py
+++ b/tensorrt_llm/_torch/models/modeling_speculative.py
@@ -340,7 +340,7 @@ class SpecDecOneEngineForCausalLM(DecoderModelForCausalLM[TModel, TConfig],
                 model_config, 'spec_config', None
         ) and model_config.spec_config.spec_dec_mode.use_one_engine():
             draft_config = ModelConfig.from_pretrained(
-                model_config.spec_config.draft_model_path,
+                model_config.spec_config.speculative_model,
                 trust_remote_code=True,
                 attn_backend=model_config.attn_backend,
                 moe_backend=model_config.moe_backend,

--- a/tensorrt_llm/_torch/pyexecutor/config.py
+++ b/tensorrt_llm/_torch/pyexecutor/config.py
@@ -8,7 +8,6 @@ from ...llmapi.llm_args import LoadFormat
 from ...logger import logger
 from ...mapping import Mapping
 from ..model_config import MoeLoadBalancerConfig
-from ..speculative import SpecConfig
 from .resource_manager import BaseResourceManager
 
 
@@ -109,7 +108,7 @@ def update_executor_config(
         pytorch_backend_config: Optional[PyTorchConfig] = None,
         mapping: Optional[Mapping] = None,
         build_config: Optional[BuildConfig] = None,
-        speculative_config: Optional[SpecConfig] = None,
+        speculative_config: Optional["DecodingBaseConfig"] = None,
         hf_model_dir: Optional[str] = None,
         trt_engine_dir: Optional[str] = None,
         max_input_len: Optional[int] = None,

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -23,6 +23,7 @@ import tensorrt_llm.bindings.internal.userbuffers as ub
 from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest
 from tensorrt_llm._torch.pyexecutor.sampler import SampleStateTensors
 from tensorrt_llm._torch.speculative.mtp import SampleStateTensorsMTP
+from tensorrt_llm._torch.speculative.utils import get_num_extra_kv_tokens
 from tensorrt_llm._utils import (is_trace_enabled, local_mpi_rank,
                                  local_mpi_size, nvtx_range, release_gc,
                                  torch_dtype_to_str, trace_func)
@@ -51,7 +52,7 @@ from ..models.modeling_utils import (DecoderModelForCausalLM, MetaInitMode,
                                      timing)
 from ..modules.fused_moe.moe_load_balancer import (
     MoeLoadBalancer, MoeLoadBalancerIterContext, maybe_create_moe_load_balancer)
-from ..speculative import SpecConfig, SpecMetadata, get_spec_metadata
+from ..speculative import SpecMetadata, get_spec_metadata
 from ..utils import (get_model_extra_attrs, set_torch_compiling,
                      with_model_extra_attrs)
 from .config import LoadFormat, PyTorchConfig
@@ -331,7 +332,7 @@ class PyTorchModelEngine(ModelEngine):
         mapping: Optional[Mapping] = None,
         attn_runtime_features: Optional[AttentionRuntimeFeatures] = None,
         dist: Optional[MPIDist] = None,
-        spec_config: Optional[SpecConfig] = None,
+        spec_config: Optional["DecodingBaseConfig"] = None,
         guided_decoding_config: Optional[GuidedDecodingConfig] = None,
         lora_config: Optional[LoraConfig] = None,
         is_draft_model: bool = False,
@@ -432,8 +433,7 @@ class PyTorchModelEngine(ModelEngine):
 
         if self.is_spec_decode:
             self.spec_metadata = None
-            self.spec_config.update_from_model_config(self.model.config)
-            max_num_draft_tokens = self.spec_config.max_draft_tokens * batch_size
+            max_num_draft_tokens = self.spec_config.max_draft_len * batch_size
             self.draft_tokens_cuda = torch.empty((max_num_draft_tokens, ),
                                                  dtype=torch.int,
                                                  device='cuda')
@@ -449,7 +449,7 @@ class PyTorchModelEngine(ModelEngine):
                                                              device='cuda')
             self.without_logits = self.spec_config.spec_dec_mode.without_logits(
             )
-            self.max_draft_len = spec_config.max_draft_tokens
+            self.max_draft_len = spec_config.max_draft_len
         else:
             self.without_logits = False
             self.max_draft_len = 0
@@ -818,6 +818,7 @@ class PyTorchModelEngine(ModelEngine):
         if no_cache:
             return get_spec_metadata(
                 self.spec_config,
+                self.model.config,
                 self.batch_size,
                 max_num_tokens=self.max_num_tokens,
                 spec_resource_manager=spec_resource_manager,
@@ -827,6 +828,7 @@ class PyTorchModelEngine(ModelEngine):
             return self.spec_metadata
         self.spec_metadata = get_spec_metadata(
             self.spec_config,
+            self.model.config,
             self.batch_size,
             max_num_tokens=self.max_num_tokens,
             spec_resource_manager=spec_resource_manager,
@@ -910,7 +912,7 @@ class PyTorchModelEngine(ModelEngine):
     def _maybe_get_cuda_graph(
         self,
         batch: ScheduledRequests,
-        spec_config: Optional[SpecConfig] = None
+        spec_config: Optional["DecodingBaseConfig"] = None
     ) -> Optional[DecodingCUDAGraphRunner]:
         """
         Get a CUDA graph runner or return None (e.g. if CUDA graphs are disabled
@@ -920,7 +922,7 @@ class PyTorchModelEngine(ModelEngine):
         if ExpertStatistic.set_iter(self.iter_counter):
             return None
 
-        spec_max_draft_tokens = spec_config.max_draft_tokens if self.is_spec_decode else 0
+        spec_max_draft_tokens = spec_config.max_draft_len if self.is_spec_decode else 0
         can_run_cuda_graph = batch.can_run_cuda_graph
         batch_size = len(batch.generation_requests)
         if self._run_cuda_graphs and self.enable_attention_dp and self.mapping.tp_size > 1:
@@ -1035,7 +1037,7 @@ class PyTorchModelEngine(ModelEngine):
 
                 if self.spec_config is not None and self.spec_config.spec_dec_mode.need_load_draft_weights(
                 ):
-                    weights = load_weights(self.spec_config.draft_model_path)
+                    weights = load_weights(self.spec_config.speculative_model)
                     model.load_draft_weights(weights)
 
             elif load_format == LoadFormat.DUMMY:
@@ -1231,7 +1233,7 @@ class PyTorchModelEngine(ModelEngine):
         if not self._disable_overlap_scheduler and self.is_spec_decode:
             spec_dec_mode = self.spec_config.spec_dec_mode
             assert spec_dec_mode.support_overlap_scheduler(
-            ), f"{self.spec_config.spec_dec_name} does not support overlap scheduler"
+            ), f"{self.spec_config.spec_dec_mode} does not support overlap scheduler"
 
         # will contain previous batch indices of generation requests
         previous_batch_indices = []
@@ -1440,7 +1442,7 @@ class PyTorchModelEngine(ModelEngine):
             use_cache=True,
             num_cached_tokens_per_seq=num_cached_tokens_per_seq,
             num_extra_kv_tokens=0 if self.spec_config is None else
-            self.spec_config.num_extra_kv_tokens)
+            get_num_extra_kv_tokens(self.spec_config))
         attn_metadata.kv_cache_manager = kv_cache_manager
 
         attn_metadata.prepare()

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -17,6 +17,7 @@ import torch
 
 from tensorrt_llm._torch.pyexecutor.resource_manager import ResourceManagerType
 from tensorrt_llm._torch.pyexecutor.seq_slot_manager import SeqSlotManager
+from tensorrt_llm._torch.speculative.utils import get_draft_model_prompt
 from tensorrt_llm._utils import (customized_gc_thresholds, global_mpi_rank,
                                  is_trace_enabled, nvtx_range, trace_func)
 from tensorrt_llm.bindings.executor import (DisServingRequestStats,
@@ -979,7 +980,7 @@ class PyExecutor:
                 if req.state != LlmRequestState.GENERATION_IN_PROGRESS:
                     continue
                 req.py_last_draft_tokens = req.py_draft_tokens
-                max_draft_len = self.model_engine.spec_config.max_draft_tokens
+                max_draft_len = self.model_engine.spec_config.max_draft_len
 
                 if max_draft_len > 0:
                     req.py_draft_tokens = [0] * max_draft_len
@@ -1784,9 +1785,10 @@ class PyExecutor:
                 num_rejected_tokens = num_draft_tokens - num_accepted_tokens
                 assert num_rejected_tokens >= 0
 
-                spec_config = self.model_engine.spec_config
+                spec_mode = self.model_engine.spec_config.spec_dec_mode
                 beam_idx = 0
-                input_tokens = spec_config.get_draft_model_prompt(
+                input_tokens = get_draft_model_prompt(
+                    spec_mode,
                     request.get_tokens()[beam_idx])
 
                 def create_new_request(input_tokens):

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -19,7 +19,8 @@ from tensorrt_llm.quantization import QuantAlgo
 
 from ..attention_backend.interface import AttentionRuntimeFeatures
 from ..distributed import MPIDist
-from ..speculative import NGramConfig, get_spec_resource_manager
+from ..speculative import get_spec_resource_manager
+from ..speculative.utils import get_num_extra_kv_tokens
 from ._util import (KvCacheCreator, create_py_executor_instance,
                     instantiate_sampler, is_mla)
 from .config import PyTorchConfig
@@ -194,7 +195,7 @@ def create_py_executor(
     has_draft_model_engine = False
     if spec_config is not None:
         has_draft_model_engine = spec_config.spec_dec_mode.has_draft_model()
-    has_ngram_drafter = isinstance(spec_config, NGramConfig)
+    has_ngram_drafter = spec_config.spec_dec_mode.is_ngram()
 
     attn_runtime_features = AttentionRuntimeFeatures(
         chunked_prefill=executor_config.enable_chunked_context,
@@ -227,10 +228,10 @@ def create_py_executor(
             draft_spec_config = copy.copy(spec_config)
             # The draft model won't have any draft tokens attached to
             # generation requests when we invoke it autoregressively
-            draft_spec_config.max_draft_tokens = 0
+            draft_spec_config.max_draft_len = 0
 
             draft_model_engine = PyTorchModelEngine(
-                spec_config.draft_model_path,
+                spec_config.speculative_model,
                 pytorch_backend_config,
                 batch_size=executor_config.max_batch_size,
                 max_num_tokens=executor_config.max_num_tokens,
@@ -255,11 +256,11 @@ def create_py_executor(
     if not pytorch_backend_config.disable_overlap_scheduler:
         max_seq_len = model_engine.max_seq_len + 1
         if spec_config is not None:
-            max_seq_len += spec_config.max_draft_tokens
+            max_seq_len += spec_config.max_draft_len
 
     if spec_config is not None:
-        max_seq_len += spec_config.num_extra_kv_tokens
-        max_seq_len += spec_config.max_draft_tokens
+        max_seq_len += get_num_extra_kv_tokens(spec_config)
+        max_seq_len += spec_config.max_draft_len
 
     executor_config.max_seq_len = max_seq_len
     executor_config.max_num_tokens = model_engine.max_num_tokens

--- a/tensorrt_llm/_torch/speculative/__init__.py
+++ b/tensorrt_llm/_torch/speculative/__init__.py
@@ -1,14 +1,11 @@
-from .draft_target import DraftTargetConfig
-from .eagle3 import Eagle3Config, Eagle3SpecMetadata
-from .interface import SpecConfig, SpecMetadata
-from .mtp import MTPConfig, MTPEagleWorker, MTPSpecMetadata, MTPWorker
-from .ngram import NGramConfig
+from .eagle3 import Eagle3SpecMetadata
+from .interface import SpecMetadata
+from .mtp import MTPEagleWorker, MTPSpecMetadata, MTPWorker
 from .utils import (get_num_spec_layers, get_spec_decoder, get_spec_metadata,
                     get_spec_resource_manager, get_spec_worker)
 
 __all__ = [
-    "SpecConfig", "SpecMetadata", "MTPConfig", "MTPEagleWorker",
-    "MTPSpecMetadata", "MTPWorker", "Eagle3Config", "Eagle3SpecMetadata",
-    "get_spec_metadata", "get_spec_resource_manager", "get_spec_decoder",
-    "get_num_spec_layers", "get_spec_worker", "NGramConfig", "DraftTargetConfig"
+    "SpecMetadata", "MTPEagleWorker", "MTPSpecMetadata", "MTPWorker",
+    "Eagle3SpecMetadata", "get_spec_metadata", "get_spec_resource_manager",
+    "get_spec_decoder", "get_num_spec_layers", "get_spec_worker"
 ]

--- a/tensorrt_llm/_torch/speculative/draft_target.py
+++ b/tensorrt_llm/_torch/speculative/draft_target.py
@@ -1,28 +1,6 @@
 from dataclasses import dataclass
 
-import torch
-
-from .interface import SpecConfig, SpecMetadata, SpeculativeDecodingMode
-
-
-@dataclass
-class DraftTargetConfig(SpecConfig):
-    spec_dec_name: str = "DRAFT_TARGET"
-
-    def __post_init__(self):
-        if self.draft_model_path is None:
-            raise ValueError("Path to Draft weights must be specified.")
-
-        self.spec_dec_mode = SpeculativeDecodingMode.from_string(
-            self.spec_dec_name)
-        self.num_extra_kv_tokens = 0
-
-    def update_from_model_config(self, model_config):
-        pass
-
-    def get_draft_model_prompt(self,
-                               input_tokens: torch.Tensor) -> torch.Tensor:
-        return input_tokens
+from .interface import SpecMetadata
 
 
 @dataclass

--- a/tensorrt_llm/_torch/speculative/eagle3.py
+++ b/tensorrt_llm/_torch/speculative/eagle3.py
@@ -4,7 +4,6 @@ from typing import List, Optional, Tuple
 import torch
 from torch import nn
 
-from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 
 from ..attention_backend import AttentionMetadata
@@ -12,40 +11,8 @@ from ..pyexecutor.llm_request import LlmRequest
 from ..pyexecutor.resource_manager import BaseResourceManager, SlotManager
 from ..pyexecutor.sampler import TorchSampler
 from ..pyexecutor.scheduler import ScheduledRequests
-from .interface import SpecConfig, SpecMetadata, SpeculativeDecodingMode
+from .interface import SpecMetadata
 from .mtp import MTPSampler
-
-
-@dataclass
-class Eagle3Config(SpecConfig):
-    spec_dec_name: str = "EAGLE3"
-    num_layers: int = 0
-    hidden_size: int = 0
-    eagle3_one_model: bool = True
-
-    def __post_init__(self):
-        if self.draft_model_path is None:
-            raise ValueError("Path to EAGLE3 weights must be specified.")
-
-        if self.eagle3_one_model:
-            self.spec_dec_mode = SpeculativeDecodingMode.EAGLE3_ONE_MODEL
-            self.num_extra_kv_tokens = self.max_draft_tokens - 1
-        else:
-            self.spec_dec_mode = SpeculativeDecodingMode.from_string(
-                self.spec_dec_name)
-        logger.info(f"EAGLE3 Config: {self}")
-
-    def update_from_model_config(self, model_config):
-        self.num_layers = model_config.num_hidden_layers
-        self.hidden_size = model_config.hidden_size
-        self.dtype = model_config.torch_dtype
-
-    def get_draft_model_prompt(self,
-                               input_tokens: torch.Tensor) -> torch.Tensor:
-        """
-        Eagle3 always throws away the first token when processing draft inputs
-        """
-        return input_tokens[1:]
 
 
 class Eagle3ResourceManager(BaseResourceManager):
@@ -55,11 +22,11 @@ class Eagle3ResourceManager(BaseResourceManager):
     and one for the draft model. Use this class to manage the hidden states.
     """
 
-    def __init__(self, config: Eagle3Config, dtype: torch.dtype,
+    def __init__(self, config: "EagleDecodingConfig", dtype: torch.dtype,
                  hidden_size: int, max_num_requests: int, max_seq_len: int,
                  max_num_tokens: int):
         self.dtype = dtype
-        self.max_draft_tokens = config.max_draft_tokens
+        self.max_draft_tokens = config.max_draft_len
         self.hidden_size = hidden_size
         self.max_num_requests = max_num_requests
         self.max_seq_len = max_seq_len
@@ -287,10 +254,10 @@ class Eagle3OneModelSampler(MTPSampler):
 
 class Eagle3OneModelWorker(nn.Module):
 
-    def __init__(self, spec_config: Eagle3Config, mapping: Mapping):
+    def __init__(self, spec_config: "EagleDecodingConfig", mapping: Mapping):
         super().__init__()
         self.spec_config = spec_config
-        self.max_draft_tokens = self.spec_config.max_draft_tokens
+        self.max_draft_tokens = self.spec_config.max_draft_len
         self.mapping = mapping
 
     @torch.compile(mode="max-autotune-no-cudagraphs")

--- a/tensorrt_llm/_torch/speculative/interface.py
+++ b/tensorrt_llm/_torch/speculative/interface.py
@@ -7,7 +7,6 @@ import torch
 
 from ..._utils import get_sm_version
 from ..attention_backend.trtllm import AttentionBackend, TrtllmAttention
-from ..model_config import TConfig
 
 
 class SpeculativeDecodingMode(IntEnum):
@@ -16,7 +15,7 @@ class SpeculativeDecodingMode(IntEnum):
     EAGLE3 = auto()
     EAGLE3_ONE_MODEL = auto()
     NGRAM = auto()
-    DRAFT_TARGET = auto()
+    DRAFTTARGET = auto()
     NONE = auto()
 
     def is_mtp(self):
@@ -41,7 +40,7 @@ class SpeculativeDecodingMode(IntEnum):
         return self == SpeculativeDecodingMode.NONE
 
     def is_draft_target(self):
-        return self == SpeculativeDecodingMode.DRAFT_TARGET
+        return self == SpeculativeDecodingMode.DRAFTTARGET
 
     def without_logits(self):
         return self.is_mtp() or self.is_eagle3_one_model()
@@ -90,38 +89,6 @@ class SpeculativeDecodingMode(IntEnum):
         if name is None:
             return SpeculativeDecodingMode.NONE
         return SpeculativeDecodingMode[name.upper()]
-
-
-@dataclass
-class SpecConfig:
-    """
-    Configuration for speculative decoding.
-    """
-    # The name of speculative decoding.
-    spec_dec_name = None
-    # The mode of speculative decoding.
-    spec_dec_mode: SpeculativeDecodingMode = SpeculativeDecodingMode.NONE
-    # The max number of draft tokens
-    max_draft_tokens: int = 1024
-    # The path to the draft model
-    draft_model_path: Optional[str] = None
-    # The number of extra kv tokens
-    num_extra_kv_tokens: int = 0
-
-    def __post_init__(self) -> None:
-        self.spec_dec_mode = SpeculativeDecodingMode.from_string(
-            self.spec_dec_name)
-
-    def update_from_model_config(self, model_config: TConfig):
-        pass
-
-    def get_draft_model_prompt(self,
-                               input_tokens: torch.Tensor) -> torch.Tensor:
-        """
-        Override for spec dec modes that need to preprocess prompt
-        tokens before passing them to the draft model.
-        """
-        return input_tokens
 
 
 @dataclass

--- a/tensorrt_llm/_torch/speculative/ngram.py
+++ b/tensorrt_llm/_torch/speculative/ngram.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from typing import List
 
 from ordered_set import OrderedSet
@@ -6,34 +5,6 @@ from ordered_set import OrderedSet
 from ..pyexecutor.llm_request import LlmRequest
 from ..pyexecutor.resource_manager import BaseResourceManager
 from ..pyexecutor.scheduler import ScheduledRequests
-from .interface import SpecConfig, SpeculativeDecodingMode
-
-
-@dataclass
-class NGramConfig(SpecConfig):
-    """
-    Configuration for N-gram drafter.
-    """
-    # The name of speculative decoding.
-    spec_dec_name = "NGRAM"
-
-    num_extra_kv_tokens: int = 0
-    max_draft_tokens: int = 0
-
-    prompt_lookup_num_tokens: int = 5
-    max_matching_ngram_size: int = 5
-    end_id: int = -1
-    is_keep_all: bool = True
-    is_use_oldest: bool = True
-    is_public_pool: bool = True
-
-    def __post_init__(self) -> None:
-        self.spec_dec_mode = SpeculativeDecodingMode.from_string(
-            self.spec_dec_name)
-        self.max_draft_tokens = self.prompt_lookup_num_tokens
-
-    def update_from_model_config(self, model_config):
-        pass
 
 
 class NGramPoolManager(BaseResourceManager):
@@ -73,7 +44,7 @@ class NGramPoolManager(BaseResourceManager):
             It maps from request ID to the index of the prompt to update the pool in the next step
     """
 
-    def __init__(self, config: NGramConfig, max_num_requests: int):
+    def __init__(self, config: "NGramDecodingConfig", max_num_requests: int):
 
         self.max_num_requests = max_num_requests
         self.max_num_draft_tokens = config.max_draft_tokens

--- a/tensorrt_llm/_torch/speculative/utils.py
+++ b/tensorrt_llm/_torch/speculative/utils.py
@@ -1,48 +1,50 @@
+import torch
+
 from tensorrt_llm._torch.pyexecutor.sampler import TorchSampler
-from tensorrt_llm._torch.speculative.interface import SpecConfig
 
 from .draft_target import DraftTargetSpecMetadata
 from .eagle3 import (Eagle3OneModelSampler, Eagle3OneModelSpecMetadata,
                      Eagle3OneModelWorker, Eagle3ResourceManager,
                      Eagle3SpecMetadata)
+from .interface import SpeculativeDecodingMode
 from .mtp import (MTPEagleWorker, MTPHiddenStatesManager, MTPSampler,
                   MTPSpecMetadata, MTPWorker)
 from .ngram import NGramPoolManager
 
 
 def get_spec_metadata(spec_config,
+                      model_config,
                       max_num_requests,
                       max_num_tokens,
                       spec_resource_manager=None,
                       is_draft_model=False):
     if spec_config.spec_dec_mode.is_mtp():
-        return MTPSpecMetadata(
-            max_draft_tokens=spec_config.max_draft_tokens,
-            spec_dec_mode=spec_config.spec_dec_mode,
-            mtp_num_modules=spec_config.num_nextn_predict_layers,
-            max_num_requests=max_num_requests,
-            mtp_hidden_states_manager=spec_resource_manager)
+        return MTPSpecMetadata(max_draft_tokens=spec_config.max_draft_len,
+                               spec_dec_mode=spec_config.spec_dec_mode,
+                               mtp_num_modules=spec_config.max_draft_len,
+                               max_num_requests=max_num_requests,
+                               mtp_hidden_states_manager=spec_resource_manager)
     elif spec_config.spec_dec_mode.is_eagle3():
-        return Eagle3SpecMetadata(max_draft_tokens=spec_config.max_draft_tokens,
+        return Eagle3SpecMetadata(max_draft_tokens=spec_config.max_draft_len,
                                   spec_dec_mode=spec_config.spec_dec_mode,
                                   max_num_requests=max_num_requests,
-                                  num_layers=spec_config.num_layers,
-                                  hidden_size=spec_config.hidden_size,
+                                  num_layers=model_config.num_hidden_layers,
+                                  hidden_size=model_config.hidden_size,
                                   max_num_tokens=max_num_tokens,
-                                  dtype=spec_config.dtype,
+                                  dtype=model_config.torch_dtype,
                                   is_draft_model=is_draft_model,
                                   eagle3_resource_manager=spec_resource_manager)
     elif spec_config.spec_dec_mode.is_eagle3_one_model():
         return Eagle3OneModelSpecMetadata(
-            max_draft_tokens=spec_config.max_draft_tokens,
+            max_draft_tokens=spec_config.max_draft_len,
             spec_dec_mode=spec_config.spec_dec_mode,
             max_num_requests=max_num_requests,
-            num_layers=spec_config.num_layers,
-            hidden_size=spec_config.hidden_size,
+            num_layers=model_config.num_hidden_layers,
+            hidden_size=model_config.hidden_size,
             max_num_tokens=max_num_tokens)
     elif spec_config.spec_dec_mode.is_draft_target():
         return DraftTargetSpecMetadata(
-            max_draft_tokens=spec_config.max_draft_tokens,
+            max_draft_tokens=spec_config.max_draft_len,
             spec_dec_mode=spec_config.spec_dec_mode,
             max_num_requests=max_num_requests)
     else:
@@ -80,10 +82,10 @@ def get_spec_resource_manager(spec_config,
         return None
 
 
-def get_spec_decoder(sampler_args: TorchSampler.Args, spec_config: SpecConfig):
+def get_spec_decoder(sampler_args: TorchSampler.Args,
+                     spec_config: "DecodingBaseConfig"):
     if spec_config.spec_dec_mode.is_mtp():
-        return MTPSampler(sampler_args,
-                          nextn=spec_config.num_nextn_predict_layers)
+        return MTPSampler(sampler_args, nextn=spec_config.max_draft_len)
     if spec_config.spec_dec_mode.is_eagle3():
         # TorchSampler handles Eagle3 gracefully, by integrating d2t into the sampling process
         return TorchSampler(sampler_args)
@@ -95,7 +97,7 @@ def get_spec_decoder(sampler_args: TorchSampler.Args, spec_config: SpecConfig):
 
 def get_num_spec_layers(spec_config):
     if spec_config.spec_dec_mode.is_mtp():
-        return spec_config.num_nextn_predict_layers
+        return spec_config.max_draft_len
     elif spec_config.spec_dec_mode.is_eagle3_one_model():
         return 1
     else:
@@ -111,3 +113,26 @@ def get_spec_worker(spec_config, mapping):
         return Eagle3OneModelWorker(spec_config, mapping)
     else:
         return None
+
+
+def get_draft_model_prompt(spec_dec_mode: SpeculativeDecodingMode,
+                           input_tokens: torch.Tensor) -> torch.Tensor:
+    """
+    Can be used to modify prompts for speculative algorithms that need to update tokens
+    before drafting.
+    """
+    if spec_dec_mode.is_eagle3():
+        # EAGLE3 always throws away the first token when processing draft inputs
+        return input_tokens[1:]
+    return input_tokens
+
+
+def get_num_extra_kv_tokens(spec_config):
+    """
+    Implementation detail for one model implementations of speculative decoding. Extra
+    KV cache tokens are required.
+    """
+    if spec_config.spec_dec_mode.is_eagle3_one_model(
+    ) or spec_config.spec_dec_mode.is_mtp():
+        return spec_config.max_draft_len - 1
+    return 0

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1,4 +1,5 @@
 import copy
+import functools
 import json
 import math
 import os
@@ -219,6 +220,28 @@ class DecodingBaseConfig(BaseModel):
     def _check_fields(self):
         pass
 
+    def supports_backend(self, backend: str) -> bool:
+        """
+        Override if the speculation algorithm does not support
+        a subset of the possible backends.
+        """
+        return True
+
+    def validate(self) -> None:
+        """
+        Do any additional error checking here.
+        """
+
+    @functools.cached_property
+    def spec_dec_mode(self):
+        # spec_dec_mode has more functionality than the raw decoding_mode string.
+        # Use an alias for the import here to avoid name collisions with the one for the
+        # TRT backend.
+        from tensorrt_llm._torch.speculative.interface import \
+            SpeculativeDecodingMode as TorchSpeculativeDecodingMode
+        return TorchSpeculativeDecodingMode.from_string(
+            self.decoding_type.upper())
+
 
 class MedusaDecodingConfig(DecodingBaseConfig):
     medusa_choices: Optional[List[List[int]]] = None
@@ -230,6 +253,9 @@ class MedusaDecodingConfig(DecodingBaseConfig):
 
     decoding_type: ClassVar[str] = "Medusa"
 
+    def supports_backend(self, backend: str) -> bool:
+        return backend not in ("pytorch", "_autodeploy")
+
 
 class EagleDecodingConfig(DecodingBaseConfig):
     eagle_choices: Optional[List[List[int]]] = None
@@ -239,7 +265,6 @@ class EagleDecodingConfig(DecodingBaseConfig):
     dynamic_tree_max_topK: Optional[int] = None
     num_eagle_layers: Optional[int] = None
     max_non_leaves_per_layer: Optional[int] = None
-    pytorch_weights_path: Optional[str] = None
     eagle3_one_model: Optional[bool] = True
 
     @classmethod
@@ -247,6 +272,18 @@ class EagleDecodingConfig(DecodingBaseConfig):
         return cls(**data)
 
     decoding_type: ClassVar[str] = "Eagle"
+
+    def validate(self) -> None:
+        if self.speculative_model is None:
+            raise ValueError("Draft model must be provided for EAGLE")
+
+    @functools.cached_property
+    def spec_dec_mode(self):
+        from tensorrt_llm._torch.speculative.interface import \
+            SpeculativeDecodingMode as TorchSpeculativeDecodingMode
+        if self.eagle3_one_model:
+            return TorchSpeculativeDecodingMode.EAGLE3_ONE_MODEL
+        return TorchSpeculativeDecodingMode.EAGLE3
 
 
 class NGramDecodingConfig(DecodingBaseConfig):
@@ -282,9 +319,11 @@ class NGramDecodingConfig(DecodingBaseConfig):
 
     decoding_type: ClassVar[str] = "NGram"
 
+    def supports_backend(self, backend: str) -> bool:
+        return backend == "pytorch"
+
 
 class DraftTargetDecodingConfig(DecodingBaseConfig):
-    pytorch_weights_path: Optional[str] = None
 
     @classmethod
     def from_dict(cls, data: dict):
@@ -292,19 +331,39 @@ class DraftTargetDecodingConfig(DecodingBaseConfig):
 
     decoding_type: ClassVar[str] = "DraftTarget"
 
+    def supports_backend(self, backend: str) -> bool:
+        return backend == "pytorch"
+
 
 class MTPDecodingConfig(DecodingBaseConfig):
-    num_nextn_predict_layers: Optional[int] = 1
     use_relaxed_acceptance_for_thinking: Optional[bool] = False
     relaxed_topk: Optional[int] = 1
     relaxed_delta: Optional[float] = 0.
     use_mtp_vanilla: Optional[bool] = False
+
+    # TODO: Hard code for DeepSeek R1
+    # When encounter <think>, start thinking phase.
+    # When encounter </think>, end thinking phase.
+    # <think> [thinking phase] </think> [real output]
+    BEGIN_THINKING_PHASE_TOKEN: int = 128798
+    END_THINKING_PHASE_TOKEN: int = 128799
 
     @classmethod
     def from_dict(cls, data: dict):
         return cls(**data)
 
     decoding_type: ClassVar[str] = "MTP"
+
+    def supports_backend(self, backend: str) -> bool:
+        return backend == "pytorch"
+
+    @functools.cached_property
+    def spec_dec_mode(self):
+        from tensorrt_llm._torch.speculative.interface import \
+            SpeculativeDecodingMode as TorchSpeculativeDecodingMode
+        if self.max_draft_len == 1 and not self.use_mtp_vanilla:
+            return TorchSpeculativeDecodingMode.MTP_EAGLE
+        return TorchSpeculativeDecodingMode.MTP
 
 
 class PybindMirror(ABC):
@@ -595,6 +654,9 @@ class LookaheadDecodingConfig(DecodingBaseConfig, PybindMirror):
         return _LookaheadDecodingConfig(self.max_window_size,
                                         self.max_ngram_size,
                                         self.max_verification_set_size)
+
+    def supports_backend(self, backend: str) -> bool:
+        return backend not in ("pytorch", "_autodeploy")
 
     decoding_type: ClassVar[str] = "Lookahead"
 
@@ -1273,6 +1335,13 @@ class BaseLlmArgs(BaseModel):
     @model_validator(mode="after")
     def validate_speculative_config(self):
         if self.speculative_config:
+            if not self.speculative_config.supports_backend(self.backend):
+                raise ValueError(
+                    f"Speculation type {self.speculative_config.decoding_type} does not "
+                    f"support backend {self.backend}")
+
+            # Below, we only need to set speculative_decoding_mode/decoding_config for speculation
+            # on the TRT backend.
             if isinstance(self.speculative_config, LookaheadDecodingConfig):
                 lookahead_config = self.speculative_config
                 # Update the build config
@@ -1286,6 +1355,7 @@ class BaseLlmArgs(BaseModel):
                     decoding_mode=DecodingMode.Lookahead(),
                     lookahead_decoding_config=PybindMirror.maybe_to_pybind(
                         lookahead_config))
+
             elif isinstance(self.speculative_config, MedusaDecodingConfig):
                 self.build_config.speculative_decoding_mode = SpeculativeDecodingMode.MEDUSA
 
@@ -1294,6 +1364,16 @@ class BaseLlmArgs(BaseModel):
                 self.decoding_config = DecodingConfig(
                     decoding_mode=DecodingMode.Medusa(),
                     medusa_choices=self.speculative_config.medusa_choices)
+
+            elif isinstance(self.speculative_config, DraftTargetDecodingConfig):
+                self.build_config.speculative_decoding_mode = SpeculativeDecodingMode.DRAFT_TOKENS_EXTERNAL
+                assert self.speculative_config.max_draft_len > 0
+                self.build_config.max_draft_len = self.speculative_config.max_draft_len
+
+            elif isinstance(self.speculative_config, MTPDecodingConfig):
+                assert self.speculative_config.max_draft_len > 0
+                self.build_config.max_draft_len = self.speculative_config.max_draft_len
+
             elif isinstance(self.speculative_config, EagleDecodingConfig):
                 self.build_config.speculative_decoding_mode = SpeculativeDecodingMode.EAGLE
                 assert self.speculative_config.max_draft_len > 0
@@ -1310,53 +1390,13 @@ class BaseLlmArgs(BaseModel):
                     self.decoding_config = DecodingConfig(
                         decoding_mode=DecodingMode.Eagle(),
                         eagle_config=eagle_config)
-                else:
-                    from tensorrt_llm._torch.speculative import Eagle3Config
-                    self.speculative_config = Eagle3Config(
-                        max_draft_tokens=self.speculative_config.max_draft_len,
-                        draft_model_path=self.speculative_config.
-                        pytorch_weights_path,
-                        eagle3_one_model=self.speculative_config.
-                        eagle3_one_model)
+
             elif isinstance(self.speculative_config, NGramDecodingConfig):
-                self.build_config.speculative_decoding_mode = SpeculativeDecodingMode.NGRAM
-                assert self.backend in ['pytorch', '_autodeploy']
                 assert self.speculative_config.prompt_lookup_num_tokens > 0 and self.speculative_config.max_matching_ngram_size > 0
                 self.build_config.max_draft_len = self.speculative_config.max_draft_len
-                from tensorrt_llm._torch.speculative import NGramConfig
-                self.speculative_config = NGramConfig(
-                    prompt_lookup_num_tokens=self.speculative_config.
-                    prompt_lookup_num_tokens,
-                    max_matching_ngram_size=self.speculative_config.
-                    max_matching_ngram_size,
-                    is_keep_all=self.speculative_config.is_keep_all,
-                    is_use_oldest=self.speculative_config.is_use_oldest,
-                    is_public_pool=self.speculative_config.is_public_pool,
-                )
-            elif isinstance(self.speculative_config, DraftTargetDecodingConfig):
-                self.build_config.speculative_decoding_mode = SpeculativeDecodingMode.DRAFT_TOKENS_EXTERNAL
-                assert self.backend == 'pytorch'
-                assert self.speculative_config.max_draft_len > 0
-                self.build_config.max_draft_len = self.speculative_config.max_draft_len
-                from tensorrt_llm._torch.speculative import DraftTargetConfig
-                self.speculative_config = DraftTargetConfig(
-                    max_draft_tokens=self.speculative_config.max_draft_len,
-                    draft_model_path=self.speculative_config.
-                    pytorch_weights_path)
-            elif isinstance(self.speculative_config, MTPDecodingConfig):
-                from tensorrt_llm._torch.speculative import MTPConfig
-                self.speculative_config = MTPConfig(
-                    num_nextn_predict_layers=self.speculative_config.
-                    num_nextn_predict_layers,
-                    max_batch_size=self.build_config.max_batch_size,
-                    use_relaxed_acceptance_for_thinking=self.speculative_config.
-                    use_relaxed_acceptance_for_thinking,
-                    relaxed_topk=self.speculative_config.relaxed_topk,
-                    relaxed_delta=self.speculative_config.relaxed_delta,
-                    use_mtp_vanilla=self.speculative_config.use_mtp_vanilla)
             else:
                 raise ValueError(
-                    f"Speculative config type not recognized: {self.speculative_config}"
+                    f"Unregonized speculative config type {type(self.speculative_config)}"
                 )
         else:
             self.decoding_config = None


### PR DESCRIPTION
## Description

Adding new speculation algorithms is a big pain right now. One of the reasons is that developers are forced to duplicate the config objects: one object is user-facing, and another is internal/inherits from `SpecConfig`. The internal one only has a few extra pieces of functionality. This PR deduplicates all the speculation configs - the amount of boilderplate required for adding a new algorithm is reduced. 

* Removes `SpecConfig` and its derived classes. The `DecodingConfig` that the user passes to the `LLM` can now be used directly.
* Removes extra functionality in `SpecConfig` that isn't strictly necessary. This is to avoid confusing users. This includes `update_from_model_config` (we can just pass the `ModelConfig` to `get_spec_metadata` instead) and `get_draft_prompt_tokens` (moved to `speculative/utils.py`).
* Also removed `num_extra_kv_tokens`. There's no need to put it in the config object; this can be derived from the `spec_dec_mode`. We can move the logic to `utils.py` as well. 
* `spec_dec_mode` is now derived as a `cached_property` of `DecodingConfig`, which avoids us having to remember to put it in `__post_init__` whenever we add a new spec algorithm. 

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

Manually tested:

- [x] EAGLE3
- [x] EAGLE3 one-model
- [x] MTP (tested model loading, crashes on main)
- [x] EAGLE-style MTP (tested model loading, crashes on main)
- [x] Draft/target

NGram is currently broken on main, will test when the fix lands. I am additionally relying on existing unit tests in CI.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
