### PR TITLE
refactor: Speculative decoding buffers part 2

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/decoderBuffers.h
+++ b/cpp/include/tensorrt_llm/batch_manager/decoderBuffers.h
@@ -16,15 +16,12 @@
 
 #pragma once
 
-#include "tensorrt_llm/runtime/eagleBuffers.h"
-#include "tensorrt_llm/runtime/explicitDraftTokensBuffers.h"
+#include "tensorrt_llm/runtime/bufferManager.h"
 #include "tensorrt_llm/runtime/iTensor.h"
-#include "tensorrt_llm/runtime/lookaheadBuffers.h"
 #include "tensorrt_llm/runtime/modelConfig.h"
 #include "tensorrt_llm/runtime/utils/mpiUtils.h"
 #include "tensorrt_llm/runtime/worldConfig.h"
 
-#include <optional>
 #include <vector>
 
 namespace tensorrt_llm::batch_manager

--- a/cpp/include/tensorrt_llm/batch_manager/decoderBuffers.h
+++ b/cpp/include/tensorrt_llm/batch_manager/decoderBuffers.h
@@ -36,6 +36,8 @@ public:
     explicit DecoderInputBuffers(SizeType32 maxNumSequences, SizeType32 maxBatchSize, SizeType32 maxDecoderSteps,
         runtime::BufferManager const& manager);
 
+    void setupMedusaLogits(SizeType32 maxNumSequences, runtime::ModelConfig const& modelConfig);
+
     //! Buffers for decoder setup
 
     //! Input IDs of new requests, [maxBatchSize]
@@ -55,6 +57,10 @@ public:
     //! Logits for all batch slots, [maxNumSequences]
     //! The vector is sparse, only slots in forwardBatchSlots are used.
     std::vector<TensorPtr> logits;
+
+    //! Logits for speculative decoding (Medusa)
+    //! [maxBatchSize][maxAcceptedDraftTokensPerStep][maxDraftTokens + 1, vocabSizePadded]
+    std::vector<std::vector<runtime::ITensor::SharedPtr>> predictedDraftLogits;
 };
 
 class DecoderOutputBuffers
@@ -91,8 +97,6 @@ public:
     TensorPtr nextDraftTokensLengthsHost;   // [mMaxNumRequests]
     TensorPtr acceptedLengthsCumSumDevice;  // [mMaxNumRequests+1]
     TensorPtr acceptedPackedPathsDevice;    // [mMaxNumRequests * maxAcceptedTokens]
-    std::vector<std::vector<runtime::ITensor::SharedPtr>>
-        predictedDraftLogits;               // [mMaxNumRequests][mMaxNumHeads][maxDraftTokens + 1, vocabSize]
 
     void create(SizeType32 maxNumSequences, SizeType32 maxTokensPerStep, runtime::BufferManager const& manager,
         runtime::ModelConfig const& modelConfig);

--- a/cpp/include/tensorrt_llm/batch_manager/decoderBuffers.h
+++ b/cpp/include/tensorrt_llm/batch_manager/decoderBuffers.h
@@ -80,38 +80,20 @@ public:
     void enableLookaheadDecoding(SizeType32 maxNumSequences, SizeType32 maxTokensPerStep);
     void disableLookaheadDecoding(SizeType32 maxNumSequences);
 
+    void setupSpeculativeDecoding(
+        SizeType32 maxNumSequences, SizeType32 maxTokensPerStep, runtime::ModelConfig const& modelConfig);
+
     TensorPtr sequenceLengthsHost; // [mMaxNumRequests, beamWidth], pinned host tensor
     TensorPtr newOutputTokensHost; // [maxTokensPerStep, mMaxNumRequests, beamWidth]
     TensorPtr cumLogProbsHost;     // [mMaxNumRequests, beamWidth]
     TensorPtr logProbsHost;        // [mMaxNumRequests, beamWidth, maxSeqLen]
     TensorPtr finishedSumHost;     // [mMaxNumRequests], pinned host tensor
     TensorPtr finishReasonsHost;   // [mMaxNumRequests, beamWidth], pinned host tensor
-};
 
-class DraftBuffers
-{
-public:
-    using SizeType32 = runtime::SizeType32;
-    using TensorPtr = runtime::ITensor::SharedPtr;
-
+    // speculative decoding buffers
     TensorPtr nextDraftTokensHost;        // [mMaxNumRequests, maxTokensPerStep-1]
     TensorPtr prevDraftTokensLengthsHost; // [mMaxNumRequests]
     TensorPtr nextDraftTokensLengthsHost; // [mMaxNumRequests]
-
-    void create(SizeType32 maxNumSequences, SizeType32 maxTokensPerStep, runtime::BufferManager const& manager,
-        runtime::ModelConfig const& modelConfig);
-};
-
-class DecoderBuffers
-{
-public:
-    using SizeType32 = runtime::SizeType32;
-    using TensorPtr = runtime::ITensor::SharedPtr;
-
-    DraftBuffers draftBuffers;
-
-    DecoderBuffers(SizeType32 maxNumSequences, SizeType32 maxTokensPerStep, runtime::BufferManager const& manager,
-        runtime::ModelConfig const& modelConfig, runtime::WorldConfig const& worldConfig);
 };
 
 class DecoderStepAsyncSend

--- a/cpp/include/tensorrt_llm/batch_manager/decoderBuffers.h
+++ b/cpp/include/tensorrt_llm/batch_manager/decoderBuffers.h
@@ -24,6 +24,11 @@
 
 #include <vector>
 
+namespace tensorrt_llm::runtime::decoder
+{
+class DecoderState;
+}
+
 namespace tensorrt_llm::batch_manager
 {
 
@@ -89,14 +94,9 @@ public:
     using SizeType32 = runtime::SizeType32;
     using TensorPtr = runtime::ITensor::SharedPtr;
 
-    TensorPtr nextDraftTokensDevice;        // [mMaxNumRequests, maxTokensPerStep-1]
-    TensorPtr nextDraftTokensHost;          // [mMaxNumRequests, maxTokensPerStep-1]
-    TensorPtr prevDraftTokensLengthsDevice; // [mMaxNumRequests]
-    TensorPtr prevDraftTokensLengthsHost;   // [mMaxNumRequests]
-    TensorPtr nextDraftTokensLengthsDevice; // [mMaxNumRequests]
-    TensorPtr nextDraftTokensLengthsHost;   // [mMaxNumRequests]
-    TensorPtr acceptedLengthsCumSumDevice;  // [mMaxNumRequests+1]
-    TensorPtr acceptedPackedPathsDevice;    // [mMaxNumRequests * maxAcceptedTokens]
+    TensorPtr nextDraftTokensHost;        // [mMaxNumRequests, maxTokensPerStep-1]
+    TensorPtr prevDraftTokensLengthsHost; // [mMaxNumRequests]
+    TensorPtr nextDraftTokensLengthsHost; // [mMaxNumRequests]
 
     void create(SizeType32 maxNumSequences, SizeType32 maxTokensPerStep, runtime::BufferManager const& manager,
         runtime::ModelConfig const& modelConfig);
@@ -120,19 +120,19 @@ public:
     using SizeType32 = runtime::SizeType32;
     using TensorPtr = runtime::ITensor::SharedPtr;
 
-    DecoderStepAsyncSend(DecoderOutputBuffers const& decoderOutputBuffers, DraftBuffers const& draftBuffers,
-        TensorPtr const& cacheIndirectionOutput, bool returnLogProbs, SizeType32 maxBeamWidth, bool useMedusa,
-        mpi::MpiComm const& commSession, int peer);
+    DecoderStepAsyncSend(DecoderOutputBuffers const& decoderOutputBuffers,
+        runtime::decoder::DecoderState const& decoderState, bool returnLogProbs, SizeType32 maxBeamWidth,
+        bool useMedusa, mpi::MpiComm const& commSession, int peer);
 
     ~DecoderStepAsyncSend();
 
-    static void recv(DecoderOutputBuffers const& decoderOutputBuffers, DraftBuffers const& draftBuffers,
-        TensorPtr const& cacheIndirectionOutput, bool returnLogProbs, SizeType32 maxBeamWidth, bool useMedusa,
-        mpi::MpiComm const& commSession, int peer);
+    static void recv(DecoderOutputBuffers const& decoderOutputBuffers,
+        runtime::decoder::DecoderState const& decoderState, bool returnLogProbs, SizeType32 maxBeamWidth,
+        bool useMedusa, mpi::MpiComm const& commSession, int peer);
 
-    static void bcast(DecoderOutputBuffers const& decoderOutputBuffers, DraftBuffers const& draftBuffers,
-        TensorPtr const& cacheIndirectionOutput, bool returnLogProbs, SizeType32 maxBeamWidth, bool useMedusa,
-        mpi::MpiComm const& commSession, int root);
+    static void bcast(DecoderOutputBuffers const& decoderOutputBuffers,
+        runtime::decoder::DecoderState const& decoderState, bool returnLogProbs, SizeType32 maxBeamWidth,
+        bool useMedusa, mpi::MpiComm const& commSession, int root);
 
 private:
     std::unique_ptr<mpi::MpiRequest> mRequest1;

--- a/cpp/include/tensorrt_llm/batch_manager/handleContextLogits.h
+++ b/cpp/include/tensorrt_llm/batch_manager/handleContextLogits.h
@@ -32,10 +32,7 @@ namespace tensorrt_llm::batch_manager
 {
 
 class DecoderInputBuffers;
-class DraftBuffers;
 class MedusaBuffers;
-
-namespace tr = tensorrt_llm::runtime;
 
 class HandleContextLogits : Algorithm
 {
@@ -47,9 +44,9 @@ public:
 
     HandleContextLogits() = default;
 
-    tr::SizeType32 operator()(DecoderInputBuffers& inputBuffers, RequestVector const& contextRequests,
-        tr::ITensor::SharedPtr const& logits, std::vector<tr::SizeType32> const& numContextLogitsVec,
-        tr::ModelConfig const& modelConfig, tr::BufferManager const& manager, OptionalRef<DraftBuffers> draftBuffers,
+    runtime::SizeType32 operator()(DecoderInputBuffers& inputBuffers, RequestVector const& contextRequests,
+        runtime::ITensor::SharedPtr const& logits, std::vector<runtime::SizeType32> const& numContextLogitsVec,
+        runtime::ModelConfig const& modelConfig, runtime::BufferManager const& manager,
         OptionalRef<MedusaBuffers> medusaBuffers) const;
 };
 

--- a/cpp/include/tensorrt_llm/batch_manager/handleGenerationLogits.h
+++ b/cpp/include/tensorrt_llm/batch_manager/handleGenerationLogits.h
@@ -31,10 +31,8 @@ namespace tensorrt_llm::batch_manager
 {
 
 class DecoderInputBuffers;
-class DraftBuffers;
 class RuntimeBuffers;
-
-namespace tr = tensorrt_llm::runtime;
+class MedusaBuffers;
 
 class HandleGenerationLogits : Algorithm
 {
@@ -47,9 +45,9 @@ public:
     HandleGenerationLogits() = default;
 
     void operator()(DecoderInputBuffers& inputBuffers, RequestVector const& generationRequests,
-        tr::ITensor::SharedPtr const& logits, tr::SizeType32 logitsIndex, tr::ModelConfig const& modelConfig,
-        tr::BufferManager const& manager, OptionalRef<RuntimeBuffers> genRuntimeBuffers,
-        OptionalRef<DraftBuffers> draftBuffers) const;
+        runtime::ITensor::SharedPtr const& logits, runtime::SizeType32 logitsIndex,
+        runtime::ModelConfig const& modelConfig, runtime::BufferManager const& manager,
+        OptionalRef<RuntimeBuffers> genRuntimeBuffers, OptionalRef<MedusaBuffers> medusaBuffers) const;
 };
 
 } // namespace tensorrt_llm::batch_manager

--- a/cpp/include/tensorrt_llm/batch_manager/makeDecodingBatchInputOutput.h
+++ b/cpp/include/tensorrt_llm/batch_manager/makeDecodingBatchInputOutput.h
@@ -32,7 +32,6 @@ class DecoderState;
 namespace tensorrt_llm::batch_manager
 {
 class DecoderInputBuffers;
-class DecoderBuffers;
 class RuntimeBuffers;
 
 class MakeDecodingBatchInputOutput : Algorithm
@@ -48,10 +47,9 @@ public:
     MakeDecodingBatchInputOutput() = default;
 
     std::unique_ptr<runtime::decoder_batch::Input> operator()(RequestVector const& contextRequests,
-        RequestVector const& generationRequests, DecoderBuffers& decoderBuffers,
-        DecoderInputBuffers const& inputBuffers, runtime::decoder::DecoderState& decoderState,
-        runtime::ModelConfig const& modelConfig, SizeType32 maxNumSequences,
-        OptionalRef<RuntimeBuffers> fusedRuntimeBuffers) const;
+        RequestVector const& generationRequests, DecoderInputBuffers const& inputBuffers,
+        runtime::decoder::DecoderState& decoderState, runtime::ModelConfig const& modelConfig,
+        SizeType32 maxNumSequences, OptionalRef<RuntimeBuffers> fusedRuntimeBuffers) const;
 
     [[nodiscard]] static std::unique_ptr<runtime::decoder_batch::Input> createDecoderBatchInputs(
         std::vector<SizeType32> const& activeSlots, runtime::decoder::DecoderState const& decoderState,

--- a/cpp/include/tensorrt_llm/batch_manager/runtimeBuffers.h
+++ b/cpp/include/tensorrt_llm/batch_manager/runtimeBuffers.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include "tensorrt_llm/batch_manager/common.h"
-#include "tensorrt_llm/batch_manager/decoderBuffers.h"
 #include "tensorrt_llm/batch_manager/rnnStateManager.h"
 #include "tensorrt_llm/common/optionalRef.h"
 #include "tensorrt_llm/runtime/eagleBuffers.h"
@@ -237,7 +236,7 @@ public:
     TensorPtr seqSlots;
     TensorPtr seqSlotsDevice;
     TensorPtr sortedSeqSlots;
-    //! TODO: move into decoderBuffers.DraftBuffers
+    //! For KV cache rewind
     TensorPtr seqSlotRemappingHost;   // [numSequences]
     TensorPtr seqSlotRemappingDevice; // [numSequences]
 

--- a/cpp/include/tensorrt_llm/batch_manager/updateDecoderBuffers.h
+++ b/cpp/include/tensorrt_llm/batch_manager/updateDecoderBuffers.h
@@ -34,7 +34,6 @@ class DecoderState;
 namespace tensorrt_llm::batch_manager
 {
 
-class DecoderBuffers;
 class DecoderOutputBuffers;
 
 class UpdateDecoderBuffers : Algorithm
@@ -44,10 +43,9 @@ public:
 
     UpdateDecoderBuffers() = default;
 
-    runtime::CudaEvent operator()(runtime::ModelConfig const& modelConfig, DecoderBuffers& decoderBuffers,
-        DecoderOutputBuffers& decoderOutputBuffers, runtime::BufferManager const& copyBufferManager,
-        runtime::decoder::DecoderState const& decoderState, bool returnLogProbs,
-        runtime::CudaEvent const& decoderFinishEvent) const;
+    runtime::CudaEvent operator()(runtime::ModelConfig const& modelConfig, DecoderOutputBuffers& decoderOutputBuffers,
+        runtime::BufferManager const& copyBufferManager, runtime::decoder::DecoderState const& decoderState,
+        bool returnLogProbs, runtime::CudaEvent const& decoderFinishEvent) const;
 };
 
 } // namespace tensorrt_llm::batch_manager

--- a/cpp/tensorrt_llm/batch_manager/decoderBuffers.cpp
+++ b/cpp/tensorrt_llm/batch_manager/decoderBuffers.cpp
@@ -52,6 +52,19 @@ DecoderInputBuffers::DecoderInputBuffers(
     logits.resize(maxNumSequences);
 }
 
+void DecoderInputBuffers::setupMedusaLogits(SizeType32 maxNumSequences, ModelConfig const& modelConfig)
+{
+    if (modelConfig.getSpeculativeDecodingMode().isMedusa())
+    {
+        auto const maxDraftPathLen = modelConfig.getSpeculativeDecodingModule().getMaxDraftPathLen();
+        predictedDraftLogits.resize(maxNumSequences);
+        for (auto& medusaLogitsHead : predictedDraftLogits)
+        {
+            medusaLogitsHead.resize(maxDraftPathLen);
+        }
+    }
+}
+
 DecoderOutputBuffers::DecoderOutputBuffers(SizeType32 maxNumSequences, SizeType32 maxBeamWidth, SizeType32 maxSeqLen,
     SizeType32 maxTokensPerStep, BufferManager const& manager)
 {
@@ -117,16 +130,6 @@ void DraftBuffers::create(SizeType32 maxNumSequences, SizeType32 maxTokensPerSte
                 = BufferManager::pinned(ITensor::makeShape({maxNumSequences}), nvinfer1::DataType::kINT32);
             prevDraftTokensLengthsHost
                 = BufferManager::pinned(ITensor::makeShape({maxNumSequences}), nvinfer1::DataType::kINT32);
-        }
-    }
-
-    if (speculativeDecodingMode.isMedusa())
-    {
-        auto const maxDraftPathLen = modelConfig.getSpeculativeDecodingModule().getMaxDraftPathLen();
-        predictedDraftLogits.resize(maxNumSequences);
-        for (auto& medusaLogitsHead : predictedDraftLogits)
-        {
-            medusaLogitsHead.resize(maxDraftPathLen);
         }
     }
 

--- a/cpp/tensorrt_llm/batch_manager/handleContextLogits.cpp
+++ b/cpp/tensorrt_llm/batch_manager/handleContextLogits.cpp
@@ -26,6 +26,7 @@
 #include "tensorrt_llm/runtime/runtimeKernels.h"
 #include "tensorrt_llm/runtime/utils/debugUtils.h"
 
+namespace tr = tensorrt_llm::runtime;
 namespace tru = tensorrt_llm::runtime::utils;
 
 namespace tensorrt_llm::batch_manager
@@ -69,7 +70,7 @@ void setupMedusaLogits(std::vector<TensorPtr>& medusaLogitsHeads, TensorPtr cons
 
 SizeType32 HandleContextLogits::operator()(DecoderInputBuffers& inputBuffers, RequestVector const& contextRequests,
     tr::ITensor::SharedPtr const& logits, std::vector<tr::SizeType32> const& numContextLogitsVec,
-    tr::ModelConfig const& modelConfig, tr::BufferManager const& manager, OptionalRef<DraftBuffers> draftBuffers,
+    tr::ModelConfig const& modelConfig, tr::BufferManager const& manager,
     OptionalRef<MedusaBuffers> medusaBuffers) const
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
@@ -119,8 +120,7 @@ SizeType32 HandleContextLogits::operator()(DecoderInputBuffers& inputBuffers, Re
 
         if (modelConfig.getSpeculativeDecodingMode().hasDraftLogits())
         {
-            TLLM_CHECK(draftBuffers);
-            auto& medusaLogitsHeads = draftBuffers->predictedDraftLogits.at(seqSlot);
+            auto& medusaLogitsHeads = inputBuffers.predictedDraftLogits.at(seqSlot);
             TLLM_CHECK(medusaBuffers);
             setupMedusaLogits(medusaLogitsHeads, medusaBuffers->medusaLogitsDevice,
                 modelConfig.getSpeculativeDecodingModule().getMaxDraftPathLen(), logitsIndex - numDecoderLogits,

--- a/cpp/tensorrt_llm/batch_manager/logitsPostProcessor.cpp
+++ b/cpp/tensorrt_llm/batch_manager/logitsPostProcessor.cpp
@@ -17,13 +17,11 @@
 
 #include "tensorrt_llm/batch_manager/logitsPostProcessor.h"
 
-#include "tensorrt_llm/batch_manager/decoderBuffers.h"
 #include "tensorrt_llm/batch_manager/llmRequest.h"
 #include "tensorrt_llm/batch_manager/runtimeBuffers.h"
 #include "tensorrt_llm/common/nvtxUtils.h"
 #include "tensorrt_llm/runtime/iTensor.h"
 #include "tensorrt_llm/runtime/tllmRuntime.h"
-#include "tensorrt_llm/runtime/utils/debugUtils.h"
 
 namespace tr = tensorrt_llm::runtime;
 

--- a/cpp/tensorrt_llm/batch_manager/makeDecodingBatchInputOutput.cpp
+++ b/cpp/tensorrt_llm/batch_manager/makeDecodingBatchInputOutput.cpp
@@ -135,7 +135,7 @@ std::unique_ptr<tr::decoder_batch::Input> MakeDecodingBatchInputOutput::operator
 
     if (modelConfig.getSpeculativeDecodingMode().hasDraftLogits())
     {
-        decodingInput->predictedDraftLogits = decoderBuffers.draftBuffers.predictedDraftLogits;
+        decodingInput->predictedDraftLogits = inputBuffers.predictedDraftLogits;
     }
 
     if (modelConfig.getSpeculativeDecodingMode().isExplicitDraftTokens())

--- a/cpp/tensorrt_llm/batch_manager/makeDecodingBatchInputOutput.cpp
+++ b/cpp/tensorrt_llm/batch_manager/makeDecodingBatchInputOutput.cpp
@@ -121,7 +121,7 @@ std::pair<std::vector<SizeType32>, std::vector<SizeType32>> getActiveSlots(
 } // namespace
 
 std::unique_ptr<tr::decoder_batch::Input> MakeDecodingBatchInputOutput::operator()(RequestVector const& contextRequests,
-    RequestVector const& generationRequests, DecoderBuffers& decoderBuffers, DecoderInputBuffers const& inputBuffers,
+    RequestVector const& generationRequests, DecoderInputBuffers const& inputBuffers,
     runtime::decoder::DecoderState& decoderState, runtime::ModelConfig const& modelConfig, SizeType32 maxNumSequences,
     OptionalRef<RuntimeBuffers> fusedRuntimeBuffers) const
 {

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -2132,34 +2132,30 @@ std::vector<std::unique_ptr<DecoderStepAsyncSend>> TrtGptModelInflightBatching::
     {
         if (broadcastPostDecoder())
         {
-            DecoderStepAsyncSend::bcast(decoderOutputBuffers, mDecoderBuffers->draftBuffers,
-                mDecoderState->getCacheIndirectionOutput(), returnLogProbs, mOperatingBeamWidth,
+            DecoderStepAsyncSend::bcast(decoderOutputBuffers, *mDecoderState, returnLogProbs, mOperatingBeamWidth,
                 mModelConfig.getSpeculativeDecodingMode().needsKVCacheRewind(), *mMpiCommTensorPara, 0);
         }
 
         if (mWorldConfig.isPipelineParallel())
         {
             auto const peerSend = 0;
-            asyncHandles.emplace_back(
-                std::make_unique<DecoderStepAsyncSend>(decoderOutputBuffers, mDecoderBuffers->draftBuffers,
-                    mDecoderState->getCacheIndirectionOutput(), returnLogProbs, mOperatingBeamWidth,
-                    mModelConfig.getSpeculativeDecodingMode().needsKVCacheRewind(), *mMpiCommPipelinePara, peerSend));
+            asyncHandles.emplace_back(std::make_unique<DecoderStepAsyncSend>(decoderOutputBuffers, *mDecoderState,
+                returnLogProbs, mOperatingBeamWidth, mModelConfig.getSpeculativeDecodingMode().needsKVCacheRewind(),
+                *mMpiCommPipelinePara, peerSend));
         }
     }
     else
     {
         auto const peerRecv = mWorldConfig.isFirstPipelineParallelRank() ? mWorldConfig.getPipelineParallelism() - 1
                                                                          : mWorldConfig.getPipelineParallelRank() - 1;
-        DecoderStepAsyncSend::recv(decoderOutputBuffers, mDecoderBuffers->draftBuffers,
-            mDecoderState->getCacheIndirectionOutput(), returnLogProbs, mOperatingBeamWidth,
+        DecoderStepAsyncSend::recv(decoderOutputBuffers, *mDecoderState, returnLogProbs, mOperatingBeamWidth,
             mModelConfig.getSpeculativeDecodingMode().needsKVCacheRewind(), *mMpiCommPipelinePara, peerRecv);
         auto const peerSend = mWorldConfig.getPipelineParallelRank() + 1;
         if (peerSend != mWorldConfig.getPipelineParallelism() - 1)
         {
-            asyncHandles.emplace_back(
-                std::make_unique<DecoderStepAsyncSend>(decoderOutputBuffers, mDecoderBuffers->draftBuffers,
-                    mDecoderState->getCacheIndirectionOutput(), returnLogProbs, mOperatingBeamWidth,
-                    mModelConfig.getSpeculativeDecodingMode().needsKVCacheRewind(), *mMpiCommPipelinePara, peerSend));
+            asyncHandles.emplace_back(std::make_unique<DecoderStepAsyncSend>(decoderOutputBuffers, *mDecoderState,
+                returnLogProbs, mOperatingBeamWidth, mModelConfig.getSpeculativeDecodingMode().needsKVCacheRewind(),
+                *mMpiCommPipelinePara, peerSend));
         }
     }
     TLLM_CHECK_WITH_INFO(asyncHandles.size() <= 2, "Up to two decoder step async handles expected");
@@ -2452,11 +2448,11 @@ void TrtGptModelInflightBatching::rewindKVCacheBlocks(SizeType32 numSequences)
     }
 
     tensorrt_llm::runtime::kernels::invokeUpdateKVBlockArrayDraftTokenLocation(
-        *mDecoderBuffers->draftBuffers.acceptedLengthsCumSumDevice,
-        *mDecoderBuffers->draftBuffers.acceptedPackedPathsDevice, *runtimeBuffers.sequenceLengthsDevice,
-        pointerArrayPtr, offsetArrayPtr, localNbLayers, numSequences, mRewindInputs.numKvHeads, sizeInBytesPerKVHead,
-        commonRewindLen, rewindLens, *runtimeBuffers.seqSlotRemappingDevice, *runtimeBuffers.sortedSeqSlots,
-        getMaxAttentionWindow(), mRewindInputs.maxBlocksPerSeq, tokensPerBlock, mRewindInputs.isUseOneMoreBlock,
+        *mDecoderState->getAcceptedLengthsCumSum(), *mDecoderState->getAcceptedPackedPaths(),
+        *runtimeBuffers.sequenceLengthsDevice, pointerArrayPtr, offsetArrayPtr, localNbLayers, numSequences,
+        mRewindInputs.numKvHeads, sizeInBytesPerKVHead, commonRewindLen, rewindLens,
+        *runtimeBuffers.seqSlotRemappingDevice, *runtimeBuffers.sortedSeqSlots, getMaxAttentionWindow(),
+        mRewindInputs.maxBlocksPerSeq, tokensPerBlock, mRewindInputs.isUseOneMoreBlock,
         mRuntime->getStreamPtr()->get());
 
     sync_check_cuda_error(mRuntime->getStream().get());

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -1482,10 +1482,9 @@ void TrtGptModelInflightBatching::createBuffers(executor::DecodingConfig const& 
         mDecoderInputBuffers.back().setupMedusaLogits(getMaxNumSequences(), mModelConfig);
         mDecoderOutputBuffers.emplace_back(getMaxNumSequences(), mOperatingBeamWidth, getMaxSequenceLen(),
             mModelConfig.getMaxDecodingTokens(), mRuntime->getBufferManager());
+        mDecoderOutputBuffers.back().setupSpeculativeDecoding(
+            getMaxNumSequences(), mModelConfig.getMaxDecodingTokens(), mModelConfig);
     }
-
-    mDecoderBuffers = std::make_unique<DecoderBuffers>(getMaxNumSequences(), mModelConfig.getMaxDecodingTokens(),
-        mRuntime->getBufferManager(), mModelConfig, mWorldConfig);
 
     mSlotDecoderBuffers.clear();
     for (SizeType32 i = 0; i < getMaxNumSequences(); ++i)
@@ -2046,15 +2045,14 @@ runtime::CudaEvent TrtGptModelInflightBatching::decoderStepAsync(ScheduledReques
 
     auto& decodingInput = mDecodingInputs.at(mMicroBatchId);
     decodingInput = (*mMakeDecodingBatchInputOutput)(scheduledRequests.contextRequests,
-        scheduledRequests.generationRequests, *mDecoderBuffers, mDecoderInputBuffers.at(fusedBufferId), *mDecoderState,
-        mModelConfig, getMaxNumSequences(), *fusedRuntimeBuffers);
+        scheduledRequests.generationRequests, mDecoderInputBuffers.at(fusedBufferId), *mDecoderState, mModelConfig,
+        getMaxNumSequences(), *fusedRuntimeBuffers);
 
     auto decoderFinishEvent = mDecoder->forwardAsync(*mDecoderState, *decodingInput);
 
     auto const returnLogProbs = batchReturnLogProbs(scheduledRequests);
-    auto updateDecoderBuffersEvent
-        = (*mUpdateDecoderBuffers)(mModelConfig, *mDecoderBuffers, mDecoderOutputBuffers.at(fusedBufferId),
-            mRuntime->getBufferManager(), *mDecoderState, returnLogProbs, decoderFinishEvent);
+    auto updateDecoderBuffersEvent = (*mUpdateDecoderBuffers)(mModelConfig, mDecoderOutputBuffers.at(fusedBufferId),
+        mRuntime->getBufferManager(), *mDecoderState, returnLogProbs, decoderFinishEvent);
 
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
     return updateDecoderBuffersEvent;
@@ -2178,13 +2176,6 @@ void TrtGptModelInflightBatching::updateRequests(ScheduledRequests const& schedu
     auto const* const decoderFinishedSumPtr = bufferCast<SizeType32 const>(*decoderOutputBuffers.finishedSumHost);
     auto const* const cumLogProbsPtr = bufferCast<float const>(*decoderOutputBuffers.cumLogProbsHost);
     auto const* const logProbsPtr = bufferCast<float const>(*decoderOutputBuffers.logProbsHost);
-    auto const* const nextDraftTokensHostData = mModelConfig.getSpeculativeDecodingMode().predictsDraftTokens()
-        ? bufferCast<TokenIdType const>(*mDecoderBuffers->draftBuffers.nextDraftTokensHost)
-        : nullptr;
-    auto const* const nextDraftTokensLengthsHostData = mModelConfig.getSpeculativeDecodingMode().predictsDraftTokens()
-            && mModelConfig.getSpeculativeDecodingMode().variableDraftLength()
-        ? bufferCast<SizeType32 const>(*mDecoderBuffers->draftBuffers.nextDraftTokensLengthsHost)
-        : nullptr;
     auto const* const finishReasonsHostData
         = bufferCast<kernels::FinishedState>(*decoderOutputBuffers.finishReasonsHost);
 
@@ -2288,10 +2279,14 @@ void TrtGptModelInflightBatching::updateRequests(ScheduledRequests const& schedu
             auto nextDraftTokensLen = mModelConfig.getSpeculativeDecodingModule().getMaxDecodingDraftTokens();
             if (mModelConfig.getSpeculativeDecodingMode().variableDraftLength())
             {
+                auto const* const nextDraftTokensLengthsHostData
+                    = bufferCast<SizeType32 const>(*decoderOutputBuffers.nextDraftTokensLengthsHost);
                 nextDraftTokensLen = nextDraftTokensLengthsHostData[seqSlot];
             }
             TLLM_CHECK(nextDraftTokensLen <= maxDraftTokensLen);
 
+            auto const* const nextDraftTokensHostData
+                = bufferCast<TokenIdType const>(*decoderOutputBuffers.nextDraftTokensHost);
             auto draftTokensShared
                 = std::make_shared<std::vector<TokenIdType>>(nextDraftTokensHostData + seqSlot * maxDraftTokensLen,
                     nextDraftTokensHostData + seqSlot * maxDraftTokensLen + nextDraftTokensLen);
@@ -2419,6 +2414,7 @@ void TrtGptModelInflightBatching::rewindKVCacheBlocks(SizeType32 numSequences)
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
     auto const bufferId = getFusedBufferId();
     auto& runtimeBuffers = *mBuffers.at(bufferId);
+    auto& decoderOutputBuffers = mDecoderOutputBuffers.at(bufferId);
 
     auto localNbLayers = mModelConfig.getNbAttentionLayers(
         mWorldConfig.getPipelineParallelism(), mWorldConfig.getPipelineParallelRank());
@@ -2444,7 +2440,7 @@ void TrtGptModelInflightBatching::rewindKVCacheBlocks(SizeType32 numSequences)
     if (mModelConfig.getSpeculativeDecodingMode().variableDraftLength())
     {
         commonRewindLen = 0;
-        rewindLens = bufferCast<SizeType32 const>(*mDecoderBuffers->draftBuffers.prevDraftTokensLengthsHost);
+        rewindLens = bufferCast<SizeType32 const>(*decoderOutputBuffers.prevDraftTokensLengthsHost);
     }
 
     tensorrt_llm::runtime::kernels::invokeUpdateKVBlockArrayDraftTokenLocation(

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
@@ -74,7 +74,6 @@ class DecoderStepAsyncSend;
 class DecoderSlotAsyncSend;
 class DecoderInputBuffers;
 class DecoderOutputBuffers;
-class DecoderBuffers;
 class SlotDecoderBuffers;
 class LlmRequest;
 class RuntimeBuffers;
@@ -541,8 +540,6 @@ private:
     std::vector<DecoderInputBuffers> mDecoderInputBuffers;
     // Decoder output buffers for each micro batch.
     std::vector<DecoderOutputBuffers> mDecoderOutputBuffers;
-    // Global buffer to interface with decoder. Slots in this buffer are selected by mSeqSlotManager.
-    std::unique_ptr<DecoderBuffers> mDecoderBuffers;
     // Buffers for each slot in the decoder
     std::vector<std::unique_ptr<SlotDecoderBuffers>> mSlotDecoderBuffers;
     // PEFT table for each micro batch

--- a/cpp/tensorrt_llm/batch_manager/updateDecoderBuffers.cpp
+++ b/cpp/tensorrt_llm/batch_manager/updateDecoderBuffers.cpp
@@ -30,9 +30,9 @@ using ITensor = runtime::ITensor;
 using SizeType32 = tensorrt_llm::runtime::SizeType32;
 
 runtime::CudaEvent UpdateDecoderBuffers::operator()(runtime::ModelConfig const& modelConfig,
-    DecoderBuffers& decoderBuffers, DecoderOutputBuffers& decoderOutputBuffers,
-    runtime::BufferManager const& copyBufferManager, runtime::decoder::DecoderState const& decoderState,
-    bool returnLogProbs, runtime::CudaEvent const& decoderFinishEvent) const
+    DecoderOutputBuffers& decoderOutputBuffers, runtime::BufferManager const& copyBufferManager,
+    runtime::decoder::DecoderState const& decoderState, bool returnLogProbs,
+    runtime::CudaEvent const& decoderFinishEvent) const
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
     NVTX3_SCOPED_RANGE(updateDecoderBuffers);
@@ -57,14 +57,14 @@ runtime::CudaEvent UpdateDecoderBuffers::operator()(runtime::ModelConfig const& 
     if (modelConfig.getSpeculativeDecodingMode().predictsDraftTokens())
     {
         // TODO: keep data on device for next iteration
-        copyBufferManager.copy(*decoderState.getNextDraftTokens(), *decoderBuffers.draftBuffers.nextDraftTokensHost);
+        copyBufferManager.copy(*decoderState.getNextDraftTokens(), *decoderOutputBuffers.nextDraftTokensHost);
 
         if (modelConfig.getSpeculativeDecodingMode().variableDraftLength())
         {
             copyBufferManager.copy(
-                *decoderState.getNextDraftTokensLengths(), *decoderBuffers.draftBuffers.nextDraftTokensLengthsHost);
+                *decoderState.getNextDraftTokensLengths(), *decoderOutputBuffers.nextDraftTokensLengthsHost);
             copyBufferManager.copy(
-                *decoderState.getPrevDraftTokensLengths(), *decoderBuffers.draftBuffers.prevDraftTokensLengthsHost);
+                *decoderState.getPrevDraftTokensLengths(), *decoderOutputBuffers.prevDraftTokensLengthsHost);
         }
     }
 

--- a/cpp/tensorrt_llm/batch_manager/updateDecoderBuffers.cpp
+++ b/cpp/tensorrt_llm/batch_manager/updateDecoderBuffers.cpp
@@ -57,25 +57,15 @@ runtime::CudaEvent UpdateDecoderBuffers::operator()(runtime::ModelConfig const& 
     if (modelConfig.getSpeculativeDecodingMode().predictsDraftTokens())
     {
         // TODO: keep data on device for next iteration
-        decoderBuffers.draftBuffers.nextDraftTokensDevice = decoderState.getNextDraftTokens();
-        copyBufferManager.copy(
-            *decoderBuffers.draftBuffers.nextDraftTokensDevice, *decoderBuffers.draftBuffers.nextDraftTokensHost);
+        copyBufferManager.copy(*decoderState.getNextDraftTokens(), *decoderBuffers.draftBuffers.nextDraftTokensHost);
 
         if (modelConfig.getSpeculativeDecodingMode().variableDraftLength())
         {
-            decoderBuffers.draftBuffers.nextDraftTokensLengthsDevice = decoderState.getNextDraftTokensLengths();
-            decoderBuffers.draftBuffers.prevDraftTokensLengthsDevice = decoderState.getPrevDraftTokensLengths();
-            copyBufferManager.copy(*decoderBuffers.draftBuffers.nextDraftTokensLengthsDevice,
-                *decoderBuffers.draftBuffers.nextDraftTokensLengthsHost);
-            copyBufferManager.copy(*decoderBuffers.draftBuffers.prevDraftTokensLengthsDevice,
-                *decoderBuffers.draftBuffers.prevDraftTokensLengthsHost);
+            copyBufferManager.copy(
+                *decoderState.getNextDraftTokensLengths(), *decoderBuffers.draftBuffers.nextDraftTokensLengthsHost);
+            copyBufferManager.copy(
+                *decoderState.getPrevDraftTokensLengths(), *decoderBuffers.draftBuffers.prevDraftTokensLengthsHost);
         }
-    }
-
-    if (modelConfig.getSpeculativeDecodingMode().needsKVCacheRewind())
-    {
-        decoderBuffers.draftBuffers.acceptedLengthsCumSumDevice = decoderState.getAcceptedLengthsCumSum();
-        decoderBuffers.draftBuffers.acceptedPackedPathsDevice = decoderState.getAcceptedPackedPaths();
     }
 
     runtime::CudaEvent copyEvent{};

--- a/cpp/tensorrt_llm/batch_manager/utils/logitsThread.cpp
+++ b/cpp/tensorrt_llm/batch_manager/utils/logitsThread.cpp
@@ -24,6 +24,7 @@
 #include "tensorrt_llm/common/logger.h"
 #include "tensorrt_llm/executor/executor.h"
 #include "tensorrt_llm/runtime/utils/mpiTags.h"
+#include "tensorrt_llm/runtime/utils/mpiUtils.h"
 
 namespace tc = tensorrt_llm::common;
 

--- a/cpp/tensorrt_llm/pybind/batch_manager/algorithms.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/algorithms.cpp
@@ -103,15 +103,14 @@ void tensorrt_llm::pybind::batch_manager::algorithms::initBindings(pybind11::mod
             [](HandleContextLogits const& self, DecoderInputBuffers& inputBuffers, RequestVector const& contextRequests,
                 at::Tensor const& logits, std::vector<tr::SizeType32> const& numContextLogitsVec,
                 tr::ModelConfig const& modelConfig, tr::BufferManager const& manager,
-                OptionalRef<MedusaBuffers> medusaBuffers = std::nullopt,
-                OptionalRef<DraftBuffers> draftBuffers = std::nullopt)
+                OptionalRef<MedusaBuffers> medusaBuffers = std::nullopt)
             {
                 return self(inputBuffers, contextRequests, tr::TorchView::of(logits), numContextLogitsVec, modelConfig,
-                    manager, draftBuffers, medusaBuffers);
+                    manager, medusaBuffers);
             },
             py::arg("decoder_input_buffers"), py::arg("context_requests"), py::arg("logits"),
             py::arg("num_context_logits"), py::arg("model_config"), py::arg("buffer_manager"),
-            py::arg("draft_buffers") = std::nullopt, py::arg("medusa_buffers") = std::nullopt)
+            py::arg("medusa_buffers") = std::nullopt)
         .def("name", [](HandleContextLogits const&) { return HandleContextLogits::name; });
 
     py::class_<HandleGenerationLogits>(m, HandleGenerationLogits::name)
@@ -122,14 +121,14 @@ void tensorrt_llm::pybind::batch_manager::algorithms::initBindings(pybind11::mod
                 RequestVector const& generationRequests, at::Tensor const& logits, tr::SizeType32 logitsIndex,
                 tr::ModelConfig const& modelConfig, tr::BufferManager const& manager,
                 OptionalRef<RuntimeBuffers> genRuntimeBuffers = std::nullopt,
-                OptionalRef<DraftBuffers> draftBuffers = std::nullopt)
+                OptionalRef<MedusaBuffers> medusaBuffers = std::nullopt)
             {
                 self(inputBuffers, generationRequests, tr::TorchView::of(logits), logitsIndex, modelConfig, manager,
-                    genRuntimeBuffers, draftBuffers);
+                    genRuntimeBuffers, medusaBuffers);
             },
             py::arg("decoder_input_buffers"), py::arg("generation_requests"), py::arg("logits"),
             py::arg("logits_index"), py::arg("model_config"), py::arg("buffer_manager"),
-            py::arg("gen_runtime_buffers") = std::nullopt, py::arg("draft_buffers") = std::nullopt)
+            py::arg("gen_runtime_buffers") = std::nullopt, py::arg("medusa_buffers") = std::nullopt)
         .def("name", [](HandleGenerationLogits const&) { return HandleGenerationLogits::name; });
 
     py::class_<MakeDecodingBatchInputOutput>(m, MakeDecodingBatchInputOutput::name)

--- a/cpp/tensorrt_llm/pybind/batch_manager/algorithms.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/algorithms.cpp
@@ -134,9 +134,8 @@ void tensorrt_llm::pybind::batch_manager::algorithms::initBindings(pybind11::mod
     py::class_<MakeDecodingBatchInputOutput>(m, MakeDecodingBatchInputOutput::name)
         .def(py::init())
         .def("__call__", &MakeDecodingBatchInputOutput::operator(), py::arg("context_requests"),
-            py::arg("generation_requests"), py::arg("decoder_buffers"), py::arg("decoder_input_buffers"),
-            py::arg("decoder_state"), py::arg("model_config"), py::arg("max_num_sequences"),
-            py::arg("fused_runtime_buffers") = std::nullopt)
+            py::arg("generation_requests"), py::arg("decoder_input_buffers"), py::arg("decoder_state"),
+            py::arg("model_config"), py::arg("max_num_sequences"), py::arg("fused_runtime_buffers") = std::nullopt)
         .def("name", [](MakeDecodingBatchInputOutput const&) { return MakeDecodingBatchInputOutput::name; });
 
     py::class_<LogitsPostProcessor>(m, LogitsPostProcessor::name)
@@ -174,8 +173,8 @@ void tensorrt_llm::pybind::batch_manager::algorithms::initBindings(pybind11::mod
 
     py::class_<UpdateDecoderBuffers>(m, UpdateDecoderBuffers::name)
         .def(py::init())
-        .def("__call__", &UpdateDecoderBuffers::operator(), py::arg("model_config"), py::arg("decoder_buffers"),
-            py::arg("decoder_output_buffers"), py::arg("copy_buffer_manager"), py::arg("decoder_state"),
-            py::arg("return_log_probs"), py::arg("decoder_finish_event"))
+        .def("__call__", &UpdateDecoderBuffers::operator(), py::arg("model_config"), py::arg("decoder_output_buffers"),
+            py::arg("copy_buffer_manager"), py::arg("decoder_state"), py::arg("return_log_probs"),
+            py::arg("decoder_finish_event"))
         .def("name", [](UpdateDecoderBuffers const&) { return UpdateDecoderBuffers::name; });
 }

--- a/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
@@ -418,7 +418,6 @@ void initBindings(pybind11::module_& m)
         .def_readwrite("next_draft_tokens_lengths_host", &tb::DraftBuffers::nextDraftTokensLengthsHost)
         .def_readwrite("accepted_lengths_cum_sum_device", &tb::DraftBuffers::acceptedLengthsCumSumDevice)
         .def_readwrite("accepted_packed_paths_device", &tb::DraftBuffers::acceptedPackedPathsDevice)
-        .def_readwrite("predicted_draft_logits", &tb::DraftBuffers::predictedDraftLogits)
         .def("create", &tb::DraftBuffers::create, py::arg("max_num_sequences"), py::arg("max_tokens_per_step"),
             py::arg("runtime"), py::arg("model_config"));
 

--- a/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
@@ -410,14 +410,9 @@ void initBindings(pybind11::module_& m)
 
     py::class_<tb::DraftBuffers>(m, "DraftBuffers")
         .def(py::init())
-        .def_readwrite("next_draft_tokens_device", &tb::DraftBuffers::nextDraftTokensDevice)
         .def_readwrite("next_draft_tokens_host", &tb::DraftBuffers::nextDraftTokensHost)
-        .def_readwrite("prev_draft_tokens_lengths_device", &tb::DraftBuffers::prevDraftTokensLengthsDevice)
         .def_readwrite("prev_draft_tokens_lengths_host", &tb::DraftBuffers::prevDraftTokensLengthsHost)
-        .def_readwrite("next_draft_tokens_lengths_device", &tb::DraftBuffers::nextDraftTokensLengthsDevice)
         .def_readwrite("next_draft_tokens_lengths_host", &tb::DraftBuffers::nextDraftTokensLengthsHost)
-        .def_readwrite("accepted_lengths_cum_sum_device", &tb::DraftBuffers::acceptedLengthsCumSumDevice)
-        .def_readwrite("accepted_packed_paths_device", &tb::DraftBuffers::acceptedPackedPathsDevice)
         .def("create", &tb::DraftBuffers::create, py::arg("max_num_sequences"), py::arg("max_tokens_per_step"),
             py::arg("runtime"), py::arg("model_config"));
 

--- a/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
@@ -408,21 +408,6 @@ void initBindings(pybind11::module_& m)
         .def_readwrite("log_probs_host", &tb::DecoderOutputBuffers::logProbsHost)
         .def_readwrite("finish_reasons_host", &tb::DecoderOutputBuffers::finishReasonsHost);
 
-    py::class_<tb::DraftBuffers>(m, "DraftBuffers")
-        .def(py::init())
-        .def_readwrite("next_draft_tokens_host", &tb::DraftBuffers::nextDraftTokensHost)
-        .def_readwrite("prev_draft_tokens_lengths_host", &tb::DraftBuffers::prevDraftTokensLengthsHost)
-        .def_readwrite("next_draft_tokens_lengths_host", &tb::DraftBuffers::nextDraftTokensLengthsHost)
-        .def("create", &tb::DraftBuffers::create, py::arg("max_num_sequences"), py::arg("max_tokens_per_step"),
-            py::arg("runtime"), py::arg("model_config"));
-
-    py::classh<tb::DecoderBuffers>(m, "DecoderBuffers")
-        .def(py::init<runtime::SizeType32, runtime::SizeType32, runtime::BufferManager const&,
-                 runtime::ModelConfig const&, runtime::WorldConfig const&>(),
-            py::arg("max_num_sequences"), py::arg("max_tokens_per_step"), py::arg("buffer_manager"),
-            py::arg("model_config"), py::arg("world_config"))
-        .def_readwrite("draft_buffers", &tb::DecoderBuffers::draftBuffers);
-
     py::class_<tb::SlotDecoderBuffers>(m, "SlotDecoderBuffers")
         .def(py::init<runtime::SizeType32, runtime::SizeType32, runtime::BufferManager const&>(),
             py::arg("max_beam_width"), py::arg("max_seq_len"), py::arg("buffer_manager"))

--- a/cpp/tensorrt_llm/pybind/batch_manager/buffers.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/buffers.cpp
@@ -17,7 +17,6 @@
 
 #include "buffers.h"
 
-#include "tensorrt_llm/batch_manager/decoderBuffers.h"
 #include "tensorrt_llm/batch_manager/kvCacheManager.h"
 #include "tensorrt_llm/batch_manager/runtimeBuffers.h"
 #include "tensorrt_llm/batch_manager/transformerBuffers.h"

--- a/cpp/tests/runtime/gptDecoderBatchedTest.cpp
+++ b/cpp/tests/runtime/gptDecoderBatchedTest.cpp
@@ -318,14 +318,8 @@ void testDecoder(nvinfer1::DataType const dtype, std::vector<SamplingConfig>& sa
     decoder.setup(decodingMode, batchSize, maxBeamWidth, dataType, modelConfig, worldConfig);
 
     decoder::DecoderState decoderState(dataType, manager);
-    if (!modelConfig.getSpeculativeDecodingMode().isNone())
-    {
-        decoderState.allocateSpeculativeDecodingBuffers(modelConfig.getSpeculativeDecodingMode(), dtype, manager);
-    }
     decoderState.setup(
         batchSize, maxBeamWidth, maxAttentionWindow, sinkTokenLength, maxSeqLength, modelConfig, worldConfig, manager);
-    decoderState.setupSpeculativeDecoding(
-        decoderState.getSpeculativeDecodingMode(), maxGeneratedTokensPerStep, modelConfig, worldConfig, manager);
 
     // set up inputs and outputs
     tb::DecoderInputBuffers inputBuffers(batchSize, batchSize, maxGeneratedTokensPerStep, manager);
@@ -458,14 +452,8 @@ void testDecoderWavefront(nvinfer1::DataType const dtype, std::vector<SamplingCo
     decoder.setup(decodingMode, batchSize, maxBeamWidth, dataType, modelConfig, worldConfig);
 
     decoder::DecoderState decoderState(dataType, manager);
-    if (!modelConfig.getSpeculativeDecodingMode().isNone())
-    {
-        decoderState.allocateSpeculativeDecodingBuffers(modelConfig.getSpeculativeDecodingMode(), dtype, manager);
-    }
     decoderState.setup(
         batchSize, maxBeamWidth, maxAttentionWindow, sinkTokenLength, maxSeqLength, modelConfig, worldConfig, manager);
-    decoderState.setupSpeculativeDecoding(
-        decoderState.getSpeculativeDecodingMode(), maxGeneratedTokensPerStep, modelConfig, worldConfig, manager);
 
     // set up inputs and outputs
     tb::DecoderInputBuffers inputBuffers(batchSize, batchSize, maxGeneratedTokensPerStep, manager);

--- a/tensorrt_llm/_torch/pyexecutor/make_decoding_batch_input_output.py
+++ b/tensorrt_llm/_torch/pyexecutor/make_decoding_batch_input_output.py
@@ -88,7 +88,6 @@ class MakeDecodingBatchInputOutput:
         self,
         context_requests: List[LlmRequest],
         generation_requests: List[LlmRequest],
-        decoder_buffers,
         decoder_input_buffers,
         decoder_state,
         model_config,
@@ -99,7 +98,6 @@ class MakeDecodingBatchInputOutput:
         Args:
             context_requests: List of context requests
             generation_requests: List of generation requests
-            decoder_buffers: Decoder buffers
             decoder_input_buffers: Decoder input buffers
             decoder_state: Current decoder state
             model_config: Model configuration
@@ -135,11 +133,9 @@ class MakeDecodingBatchInputOutput:
         )
         decoding_input.generation_steps = generation_steps
 
-        # Handle speculative decoding modes
-        if model_config.speculative_decoding_mode.has_draft_logits:
-            decoding_input.predicted_draft_logits = decoder_buffers.draft_buffers.predicted_draft_logits
+        # TODO: Handle speculative decoding modes.
+        # fused_runtime_buffers is not created in the pytorch framework.
 
-        # TODO: fused_runtime_buffers is not created in the pytorch framework.
         # if model_config.speculative_decoding_mode.is_explicit_draft_tokens:
         #     if fused_runtime_buffers is None:
         #         raise RuntimeError("Fused runtime buffers required for explicit draft tokens")

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -16,8 +16,7 @@ from tensorrt_llm.bindings import (CudaStream, DataType, ModelConfig,
 from tensorrt_llm.bindings.executor import (DecodingConfig, DecodingMode,
                                             ExecutorConfig, FinishReason)
 from tensorrt_llm.bindings.internal.algorithms import CreateNewDecoderRequests
-from tensorrt_llm.bindings.internal.batch_manager import (DecoderBuffers,
-                                                          DecoderInputBuffers)
+from tensorrt_llm.bindings.internal.batch_manager import DecoderInputBuffers
 from tensorrt_llm.bindings.internal.runtime import (BufferManager, DecoderState,
                                                     GptDecoderBatched)
 from tensorrt_llm.executor.result import Logprob
@@ -477,10 +476,6 @@ class TRTLLMSampler(Sampler):
             cuda_stream,
             "buffer_manager":
             buffer_manager,
-            "decoder_buffers":
-            DecoderBuffers(self.max_num_sequences, self.MAX_DECODING_TOKENS,
-                           buffer_manager, self.model_config,
-                           self.world_config),
             "decoder_input_buffers":
             DecoderInputBuffers(self.max_num_sequences,
                                 self.executor_config.max_batch_size,
@@ -560,22 +555,21 @@ class TRTLLMSampler(Sampler):
             num_context_logits[
                 batch_index] = request.context_chunk_size if request.py_return_context_logits else 1
 
-        decoder_buffer_logits, logits_index = self.algs.handle_context_logits(
+        decoder_logits, logits_index = self.algs.handle_context_logits(
             scheduled_requests.context_requests, model_outputs["logits"],
             num_context_logits, self.max_num_sequences)
 
-        decoder_buffer_logits = self.algs.handle_generation_logits(
-            decoder_buffer_logits, scheduled_requests.generation_requests,
+        decoder_logits = self.algs.handle_generation_logits(
+            decoder_logits, scheduled_requests.generation_requests,
             model_outputs["logits"], logits_index)
 
-        self.store["decoder_input_buffers"].logits = decoder_buffer_logits
+        self.store["decoder_input_buffers"].logits = decoder_logits
 
         decoding_input = self.algs.make_decoding_batch_input_output(
             scheduled_requests.context_requests,
             scheduled_requests.generation_requests,
-            self.store["decoder_buffers"], self.store["decoder_input_buffers"],
-            self.store["decoder_state"], self.model_config,
-            self.max_num_sequences)
+            self.store["decoder_input_buffers"], self.store["decoder_state"],
+            self.model_config, self.max_num_sequences)
 
         self.algs.decoder.forward_async(self.store["decoder_state"],
                                         decoding_input)


### PR DESCRIPTION
## Description

Remove `DraftBuffers` class and integrate components into `DecoderInputBuffers` and `DecoderOutputBuffers`. 

Please see commit messages for details.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
