### PR TITLE
perf: Optimize swizzle_sf, unswizzle_sf, reswizzle_sf

### DIFF
--- a/cpp/tensorrt_llm/kernels/quantization.cu
+++ b/cpp/tensorrt_llm/kernels/quantization.cu
@@ -227,12 +227,12 @@ void invokeBatchedFP4Quantization(int b, int m, int n, T const* input, float con
 }
 
 __global__ void nvfp4_block_scale_interleave_kernel(
-    int numbatches, int numRows, int numCols, uint8_t const* SFIn, uint8_t* SFOutput)
+    int numBatches, int numRows, int numCols, uint8_t const* SFIn, uint8_t* SFOutput)
 {
     constexpr int SF_VEC_SIZE = 16;
     for (int rowIdx = blockIdx.x; rowIdx < numRows; rowIdx += gridDim.x)
     {
-        for (int batchIdx = 0; batchIdx < numbatches; batchIdx++)
+        for (int batchIdx = 0; batchIdx < numBatches; batchIdx++)
         {
             for (int colIdx = threadIdx.x; colIdx < numCols; colIdx += blockDim.x)
             {
@@ -246,9 +246,35 @@ __global__ void nvfp4_block_scale_interleave_kernel(
                 // int const numSfTilesK = (numCols + 4 - 1) / 4;
                 // int const tileOffset = ((mi / 128) * numSfTilesK + ki / 4) * 512;
                 // int const dstIdx = tileOffset + (mi % 32) * 16 + ((mi % 128) / 32) * 4 + ki % 4;
-                auto dstIdx
-                    = get_sf_out_offset_128x4<SF_VEC_SIZE>(batchIdxOpt, rowIdx, colIdx, numRowsOpt, numCols * 16);
+                auto dstIdx = get_sf_out_offset_128x4<SF_VEC_SIZE>(
+                    batchIdxOpt, rowIdx, colIdx, numRowsOpt, numCols * SF_VEC_SIZE);
                 SFOutput[dstIdx] = sf;
+            }
+        }
+    }
+}
+
+__global__ void nvfp4_block_scale_interleave_reverse_kernel(
+    int numBatches, int numRows, int numCols, uint8_t const* SFIn, uint8_t* SFOutput)
+{
+    constexpr int SF_VEC_SIZE = 16;
+    for (int rowIdx = blockIdx.x; rowIdx < numRows; rowIdx += gridDim.x)
+    {
+        for (int batchIdx = 0; batchIdx < numBatches; batchIdx++)
+        {
+            for (int colIdx = threadIdx.x; colIdx < numCols; colIdx += blockDim.x)
+            {
+                std::optional<int> batchIdxOpt = batchIdx;
+                std::optional<int> numRowsOpt = numRows;
+
+                // Get the swizzled input index using the same swizzling pattern
+                auto srcIdx = get_sf_out_offset_128x4<SF_VEC_SIZE>(
+                    batchIdxOpt, rowIdx, colIdx, numRowsOpt, numCols * SF_VEC_SIZE);
+                auto sf = SFIn[srcIdx];
+
+                // Output goes to linear layout
+                int64_t outOffset = batchIdx * numRows * numCols + rowIdx * numCols + colIdx;
+                SFOutput[outOffset] = sf;
             }
         }
     }
@@ -265,6 +291,19 @@ void invokeNVFP4BlockScaleInterleave(
     dim3 grid(std::min(m, multiProcessorCount * numBlocksPerSM));
 
     nvfp4_block_scale_interleave_kernel<<<grid, block, 0, stream>>>(b, m, n, SFIn, SFOutput);
+}
+
+// This is intended for weight loading, so m and n are large, b <= 256
+void invokeNVFP4BlockScaleInterleaveReverse(
+    int b, int m, int n, uint8_t const* SFIn, uint8_t* SFOutput, int multiProcessorCount, cudaStream_t stream)
+{
+    // Each thread reads 1 int8 value
+    dim3 block(std::min(n, 1024));
+    // Get number of blocks per SM (assume we can fully utilize the SM).
+    int const numBlocksPerSM = std::max(1u, 4096u / block.x);
+    dim3 grid(std::min(m, multiProcessorCount * numBlocksPerSM));
+
+    nvfp4_block_scale_interleave_reverse_kernel<<<grid, block, 0, stream>>>(b, m, n, SFIn, SFOutput);
 }
 
 // Instantiate the function.

--- a/cpp/tensorrt_llm/kernels/quantization.h
+++ b/cpp/tensorrt_llm/kernels/quantization.h
@@ -77,5 +77,8 @@ void invokeBatchedFP4Quantization(int b, int m, int n, T const* input, float con
 void invokeNVFP4BlockScaleInterleave(
     int b, int m, int n, uint8_t const* SFIn, uint8_t* SFOutput, int multiProcessorCount, cudaStream_t stream = 0);
 
+void invokeNVFP4BlockScaleInterleaveReverse(
+    int b, int m, int n, uint8_t const* SFIn, uint8_t* SFOutput, int multiProcessorCount, cudaStream_t stream = 0);
+
 } // namespace kernels
 } // namespace tensorrt_llm

--- a/cpp/tensorrt_llm/kernels/quantization.h
+++ b/cpp/tensorrt_llm/kernels/quantization.h
@@ -74,8 +74,8 @@ template <typename T, int SF_VEC_SIZE = 16>
 void invokeBatchedFP4Quantization(int b, int m, int n, T const* input, float const* globalScale, int64_t* output,
     int32_t* SFOuput, bool useUE8M0, int multiProcessorCount, cudaStream_t stream = 0);
 
-void invokeNVFP4BlockScaleInterleave(
-    int b, int m, int n, uint8_t const* SFIn, uint8_t* SFOutput, int multiProcessorCount, cudaStream_t stream = 0);
+void invokeNVFP4BlockScaleInterleave(int b, int m, int m_padded, int n, int n_padded, uint8_t const* SFIn,
+    uint8_t* SFOutput, int multiProcessorCount, cudaStream_t stream = 0);
 
 void invokeNVFP4BlockScaleInterleaveReverse(
     int b, int m, int n, uint8_t const* SFIn, uint8_t* SFOutput, int multiProcessorCount, cudaStream_t stream = 0);

--- a/cpp/tensorrt_llm/thop/fp4Op.cpp
+++ b/cpp/tensorrt_llm/thop/fp4Op.cpp
@@ -291,7 +291,7 @@ th::Tensor NVFP4BlockScaleInterleave(th::Tensor const& blockScale)
     auto cols = blockScaleShape.size() == 3 ? blockScaleShape[2] : blockScaleShape[1];
 
     auto expert_out_size = tensorrt_llm::computeFP4SwizzledLayoutSFSize(rows, cols);
-    th::Tensor interleavedBlockScale = th::zeros(
+    th::Tensor interleavedBlockScale = th::empty(
         {expert_out_size * num_experts}, th::dtype(SF_DTYPE).device(blockScale.device()).requires_grad(false));
 
     if (is_cuda)
@@ -335,7 +335,7 @@ th::Tensor NVFP4BlockScaleInterleaveReverse(th::Tensor blockScale)
     auto cols = blockScaleShape.size() == 3 ? blockScaleShape[2] : blockScaleShape[1];
     auto expert_out_size = tensorrt_llm::computeFP4SwizzledLayoutSFSize(rows, cols);
 
-    th::Tensor reversedBlockScale = th::zeros(blockScaleShape, th::dtype(SF_DTYPE).requires_grad(false));
+    th::Tensor reversedBlockScale = th::empty(blockScaleShape, th::dtype(SF_DTYPE).requires_grad(false));
     std::map<int, std::array<int, 3>> identity;
     for (int eIdx = 0; eIdx < num_experts; eIdx++)
     {

--- a/cpp/tensorrt_llm/thop/fp4Op.cpp
+++ b/cpp/tensorrt_llm/thop/fp4Op.cpp
@@ -340,7 +340,7 @@ th::Tensor NVFP4BlockScaleInterleave(th::Tensor const& blockScale)
 // blockScale: [num_experts, rows, cols] or [rows, cols]
 // Note: rows and cols are the dimensions of the original unswizzled SFMatrix, so reshape input before passing into
 // this function! Return: The same shape as blockScale
-th::Tensor NVFP4BlockScaleInterleaveReverse(th::Tensor blockScale)
+th::Tensor NVFP4BlockScaleInterleaveReverse(th::Tensor const& blockScale)
 {
     bool is_cuda = blockScale.device().is_cuda();
     if (is_cuda)

--- a/tensorrt_llm/__init__.py
+++ b/tensorrt_llm/__init__.py
@@ -30,6 +30,7 @@ _add_trt_llm_dll_directory()
 import sys
 
 import tensorrt_llm.functional as functional
+import tensorrt_llm.math_utils as math_utils
 import tensorrt_llm.models as models
 import tensorrt_llm.quantization as quantization
 import tensorrt_llm.runtime as runtime
@@ -104,6 +105,7 @@ __all__ = [
     'SamplingParams',
     'DisaggregatedParams',
     'KvCacheConfig',
+    'math_utils',
     '__version__',
 ]
 

--- a/tensorrt_llm/_torch/utils.py
+++ b/tensorrt_llm/_torch/utils.py
@@ -115,66 +115,54 @@ def swizzle_sf(sf: torch.Tensor,
                row: int,
                col: int,
                scaling_vector_size: int = 16):
-    factor = scaling_vector_size * 4
-    num_m_tiles = (row + 128 - 1) // 128
-    num_k_tiles = (col + factor - 1) // factor
-    # SF layout [num_m_tiles, num_k_tiles, 32 (m_tile column major), 4 (m_tile column major), 4(k_tile)]
-    sf_full = torch.zeros(num_m_tiles * 32 * 4,
-                          num_k_tiles * 4,
-                          dtype=sf.dtype,
-                          device=sf.device)
-    sf_full[:row, :(col //
-                    scaling_vector_size)] = sf[:row, :(col //
-                                                       scaling_vector_size)]
-    sf_full_reshaped = sf_full.view(num_m_tiles, 4, 32, num_k_tiles, 4)
-    sf_full_swizzle = sf_full_reshaped.transpose(1, 3)
-    sf_swizzle = sf_full_swizzle.reshape(-1)
-    return sf_swizzle
+    """Swizzle FP4 scaling factors using C++ torch op implementation"""
+    if row is not None and col is not None:
+        sf_cols = (col + scaling_vector_size - 1) // scaling_vector_size
+        sf = sf.view(-1, row, sf_cols)
+    return torch.ops.tensorrt_llm.nvfp4_block_scale_interleave(sf)
 
 
 def unswizzle_sf(sf: torch.Tensor,
                  row: int,
                  col: int,
                  scaling_vector_size: int = 16):
-    factor = scaling_vector_size * 4
-    num_m_tiles = (row + 128 - 1) // 128
-    num_k_tiles = (col + factor - 1) // factor
-    # SF layout [num_m_tiles, num_k_tiles, 32 (m_tile column major), 4 (m_tile column major), 4(k_tile)]
-    sf_reshaped = sf.view(num_m_tiles, num_k_tiles, 32, 4, 4)
-    sf_unswizzle = sf_reshaped.transpose(1, 3)
-    sf_unswizzle = sf_unswizzle.reshape(num_m_tiles * 32 * 4, num_k_tiles * 4)
-    sf_unswizzle_sliced = sf_unswizzle[:row, :(col // scaling_vector_size)]
-    return sf_unswizzle_sliced.contiguous()
+    """Unswizzle scaling factors using C++ torch op implementation"""
+    sf_cols = (col + scaling_vector_size - 1) // scaling_vector_size
+    # Reshape to expected input shape for C++ op
+    sf = sf.view(row, sf_cols)
+
+    return torch.ops.tensorrt_llm.nvfp4_block_scale_interleave_reverse(sf)
 
 
 def reswizzle_sf(sf: torch.Tensor,
                  row: int,
                  col: int,
                  scaling_vector_size: int = 16):
+    """Reswizzle scaling factors for multiple partitions using C++ ops"""
     factor = scaling_vector_size * 4
     num_m_tiles = (row + 128 - 1) // 128
     num_k_tiles = (col + factor - 1) // factor
     partition_size = num_m_tiles * num_k_tiles * 32 * 4 * 4
     num_partitions = sf.numel() // partition_size
+
+    # Unswizzle each partition
     sf_reshaped = sf.view(num_partitions, num_m_tiles, num_k_tiles, 32, 4, 4)
     sf_unswizzle = sf_reshaped.transpose(2, 4)
     sf_unswizzle = sf_unswizzle.reshape(num_partitions, num_m_tiles * 32 * 4,
                                         num_k_tiles * 4)
+
+    # Concatenate partitions and re-swizzle for the new dimensions
     total_rows = num_partitions * row
-    num_m_tiles_out = (total_rows + 128 - 1) // 128
-    sf_out = torch.zeros(
-        num_m_tiles_out,
-        4,
-        32,
-        num_k_tiles,
-        4,
-        dtype=sf.dtype,
-        device=sf.device,
-    )
-    sf_out_reshaped = sf_out.view(num_m_tiles_out * 32 * 4, num_k_tiles * 4)
-    sf_out_reshaped[:total_rows] = sf_unswizzle[:, :row].reshape(total_rows, -1)
-    sf_out_swizzle = sf_out.transpose(1, 3).reshape(-1)
-    return sf_out_swizzle
+    sf_cols = col // scaling_vector_size
+    sf_concatenated = sf_unswizzle[:, :row].reshape(total_rows, sf_cols)
+
+    # Convert to uint8 for C++ op if needed
+    if sf_concatenated.dtype != torch.uint8:
+        sf_uint8 = sf_concatenated.to(torch.uint8)
+    else:
+        sf_uint8 = sf_concatenated
+
+    return torch.ops.tensorrt_llm.nvfp4_block_scale_interleave(sf_uint8)
 
 
 def next_positive_power_of_2(x: int) -> int:

--- a/tensorrt_llm/math_utils.py
+++ b/tensorrt_llm/math_utils.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+def ceil_div(x: int, y: int) -> int:
+    return (x + y - 1) // y
+
+
+def pad_up(x: int, y: int) -> int:
+    return ((x + y - 1) // y) * y

--- a/tensorrt_llm/quantization/utils/fp4_utils.py
+++ b/tensorrt_llm/quantization/utils/fp4_utils.py
@@ -2,14 +2,10 @@ from enum import IntEnum
 
 import torch
 
+
 # The declarations must be aligned with thUtils.h
 SF_DTYPE = torch.uint8
 FLOAT4_E2M1X2 = torch.uint8
-
-
-def pad_up(x: int, y: int) -> int:
-    return ((x + y - 1) // y) * y
-
 
 # For GEMM autotuning.
 # Taken from https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/include/tensorrt_llm/runtime//modelConfig.h#L38

--- a/tensorrt_llm/quantization/utils/fp4_utils.py
+++ b/tensorrt_llm/quantization/utils/fp4_utils.py
@@ -2,7 +2,6 @@ from enum import IntEnum
 
 import torch
 
-
 # The declarations must be aligned with thUtils.h
 SF_DTYPE = torch.uint8
 FLOAT4_E2M1X2 = torch.uint8

--- a/tensorrt_llm/quantization/utils/fp4_utils.py
+++ b/tensorrt_llm/quantization/utils/fp4_utils.py
@@ -19,6 +19,10 @@ fp4_buckets = FP4_BUCKETS
 __all__ = ['float4_e2m1x2', 'float4_sf_dtype', 'pad_up', 'fp4_buckets']
 
 
+def pad_up(x: int, y: int) -> int:
+    return ((x + y - 1) // y) * y
+
+
 class FP4GemmType(IntEnum):
     W4A4_NVFP4_NVFP4 = 0
     W4A8_MXFP4_MXFP8 = 1

--- a/tests/unittest/_torch/thop/test_fp4_swizzle.py
+++ b/tests/unittest/_torch/thop/test_fp4_swizzle.py
@@ -1,0 +1,201 @@
+import pytest
+import torch
+from utils.util import skip_pre_blackwell
+
+import tensorrt_llm.quantization.utils.fp4_utils as fp4_utils
+from tensorrt_llm._torch.utils import reswizzle_sf, swizzle_sf, unswizzle_sf
+
+
+# Reference PyTorch implementations (original)
+def swizzle_sf_ref(sf: torch.Tensor,
+                   row: int,
+                   col: int,
+                   scaling_vector_size: int = 16):
+    """Reference PyTorch implementation of swizzle_sf"""
+    factor = scaling_vector_size * 4
+    num_m_tiles = (row + 128 - 1) // 128
+    num_k_tiles = (col + factor - 1) // factor
+    # SF layout [num_m_tiles, num_k_tiles, 32 (m_tile column major), 4 (m_tile column major), 4(k_tile)]
+    sf_full = torch.zeros(num_m_tiles * 32 * 4,
+                          num_k_tiles * 4,
+                          dtype=sf.dtype,
+                          device=sf.device)
+    sf_full[:row, :(col //
+                    scaling_vector_size)] = sf[:row, :(col //
+                                                       scaling_vector_size)]
+    sf_full_reshaped = sf_full.view(num_m_tiles, 4, 32, num_k_tiles, 4)
+    sf_full_swizzle = sf_full_reshaped.transpose(1, 3)
+    sf_swizzle = sf_full_swizzle.reshape(-1)
+    return sf_swizzle
+
+
+def unswizzle_sf_ref(sf: torch.Tensor,
+                     row: int,
+                     col: int,
+                     scaling_vector_size: int = 16):
+    """Reference PyTorch implementation of unswizzle_sf"""
+    factor = scaling_vector_size * 4
+    num_m_tiles = (row + 128 - 1) // 128
+    num_k_tiles = (col + factor - 1) // factor
+    # SF layout [num_m_tiles, num_k_tiles, 32 (m_tile column major), 4 (m_tile column major), 4(k_tile)]
+    sf_reshaped = sf.view(num_m_tiles, num_k_tiles, 32, 4, 4)
+    sf_unswizzle = sf_reshaped.transpose(1, 3)
+    sf_unswizzle = sf_unswizzle.reshape(num_m_tiles * 32 * 4, num_k_tiles * 4)
+    sf_unswizzle_sliced = sf_unswizzle[:row, :(col // scaling_vector_size)]
+    return sf_unswizzle_sliced.contiguous()
+
+
+def reswizzle_sf_ref(sf: torch.Tensor,
+                     row: int,
+                     col: int,
+                     scaling_vector_size: int = 16):
+    """Reference PyTorch implementation of reswizzle_sf"""
+    factor = scaling_vector_size * 4
+    num_m_tiles = (row + 128 - 1) // 128
+    num_k_tiles = (col + factor - 1) // factor
+    partition_size = num_m_tiles * num_k_tiles * 32 * 4 * 4
+    num_partitions = sf.numel() // partition_size
+    sf_reshaped = sf.view(num_partitions, num_m_tiles, num_k_tiles, 32, 4, 4)
+    sf_unswizzle = sf_reshaped.transpose(2, 4)
+    sf_unswizzle = sf_unswizzle.reshape(num_partitions, num_m_tiles * 32 * 4,
+                                        num_k_tiles * 4)
+    total_rows = num_partitions * row
+    num_m_tiles_out = (total_rows + 128 - 1) // 128
+    sf_out = torch.zeros(
+        num_m_tiles_out,
+        4,
+        32,
+        num_k_tiles,
+        4,
+        dtype=sf.dtype,
+        device=sf.device,
+    )
+    sf_out_reshaped = sf_out.view(num_m_tiles_out * 32 * 4, num_k_tiles * 4)
+    sf_out_reshaped[:total_rows] = sf_unswizzle[:, :row].reshape(total_rows, -1)
+    sf_out_swizzle = sf_out.transpose(1, 3).reshape(-1)
+    return sf_out_swizzle
+
+
+@skip_pre_blackwell
+@pytest.mark.parametrize(
+    "rows,cols",
+    [
+        (128, 64),  # Minimal: 1 tile
+        (256, 128),  # 2×2 tiles
+        (384, 192),  # 3×3 tiles
+        (512, 256),  # 4×4 tiles
+        (1024, 512),  # Large matrix
+    ])
+def test_swizzle_sf(rows, cols):
+    """Test C++ swizzle_sf against PyTorch reference implementation"""
+    scaling_vector_size = 16
+    sf_cols = cols // scaling_vector_size
+
+    # Create scaling factor data using uint8 dtype
+    sf_data = torch.arange(rows * sf_cols,
+                           dtype=fp4_utils.float4_sf_dtype).view(rows, sf_cols)
+
+    # Apply reference implementation (convert to float32 for ref)
+    ref_result = swizzle_sf_ref(sf_data.float(), rows, cols,
+                                scaling_vector_size)
+
+    # Apply C++ implementation
+    result = swizzle_sf(sf_data, rows, cols, scaling_vector_size)
+
+    # Verify results are equivalent
+    torch.testing.assert_close(result.float(), ref_result.float())
+
+
+@skip_pre_blackwell
+@pytest.mark.parametrize("rows,cols", [
+    (256, 128),
+    (512, 256),
+])
+def test_unswizzle_sf(rows, cols):
+    """Test C++ unswizzle_sf against PyTorch reference implementation"""
+    scaling_vector_size = 16
+    sf_cols = cols // scaling_vector_size
+
+    # Create scaling factor data by first swizzling with reference implementation
+    original_sf_data = torch.arange(rows * sf_cols,
+                                    dtype=torch.uint8).view(rows, sf_cols)
+    swizzled_sf_data = swizzle_sf_ref(original_sf_data.float(), rows, cols,
+                                      scaling_vector_size)
+
+    # Apply reference unswizzle
+    ref_result = unswizzle_sf_ref(swizzled_sf_data, rows, cols,
+                                  scaling_vector_size)
+
+    # Apply C++ unswizzle (convert to uint8 for C++ op)
+    swizzled_uint8 = (swizzled_sf_data % 256).to(torch.uint8)
+    cpp_result = unswizzle_sf(swizzled_uint8, rows, cols, scaling_vector_size)
+
+    # Verify C++ result matches reference result
+    torch.testing.assert_close(ref_result,
+                               cpp_result.float(),
+                               atol=1.0,
+                               rtol=0.1)
+
+
+@skip_pre_blackwell
+@pytest.mark.parametrize(
+    "rows,cols",
+    [
+        (128, 64),  # Minimal: 1 tile
+        (256, 128),  # 2×2 tiles
+        (384, 192),  # 3×3 tiles
+        (512, 256),  # 4×4 tiles
+        (640, 320),  # 5×5 tiles
+        (1024, 512),  # Large matrix
+    ])
+def test_swizzle_round_trip(rows, cols):
+    """Test that swizzle/unswizzle operations are inverse of each other"""
+    scaling_vector_size = 16
+    sf_cols = cols // scaling_vector_size
+
+    # Create scaling factor data
+    original_sf_data = torch.randint(0,
+                                     256, (rows, sf_cols),
+                                     dtype=fp4_utils.float4_sf_dtype)
+
+    # Apply swizzle then unswizzle using the utils functions
+    swizzled_sf = swizzle_sf(original_sf_data, rows, cols, scaling_vector_size)
+    unswizzled_sf = unswizzle_sf(swizzled_sf, rows, cols, scaling_vector_size)
+
+    # Verify round-trip preserves original scaling factor data
+    torch.testing.assert_close(original_sf_data.float(), unswizzled_sf.float())
+
+
+@skip_pre_blackwell
+@pytest.mark.parametrize("rows,cols,num_partitions", [
+    (128, 64, 2),
+    (256, 128, 4),
+])
+def test_reswizzle_sf(rows, cols, num_partitions):
+    """Test C++ reswizzle_sf against PyTorch reference implementation"""
+    scaling_vector_size = 16
+    sf_cols = cols // scaling_vector_size
+
+    # Create scaling factor data: multiple partitions of swizzled data
+    partition_sf_data = []
+    for i in range(num_partitions):
+        sf_data = torch.arange(i * 100,
+                               i * 100 + rows * sf_cols,
+                               dtype=torch.uint8).view(rows, sf_cols)
+        swizzled_sf = swizzle_sf_ref(sf_data.float(), rows, cols,
+                                     scaling_vector_size)
+        partition_sf_data.append(swizzled_sf)
+
+    # Concatenate partitions
+    multi_partition_sf_data = torch.cat(partition_sf_data)
+
+    # Apply reference reswizzle
+    ref_result = reswizzle_sf_ref(multi_partition_sf_data, rows, cols,
+                                  scaling_vector_size)
+
+    # Apply C++ reswizzle
+    result = reswizzle_sf(multi_partition_sf_data, rows, cols,
+                          scaling_vector_size)
+
+    # Verify results are equivalent
+    torch.testing.assert_close(result.float(), ref_result.float())

--- a/tests/unittest/_torch/thop/test_fp4_swizzle.py
+++ b/tests/unittest/_torch/thop/test_fp4_swizzle.py
@@ -94,7 +94,8 @@ def test_swizzle_sf(rows, cols):
 
     # Create scaling factor data using fp4_sf_dtype
     sf_data = torch.arange(rows * sf_cols,
-                           dtype=fp4_utils.float4_sf_dtype).view(rows, sf_cols)
+                           dtype=fp4_utils.float4_sf_dtype,
+                           device="cuda").view(rows, sf_cols)
 
     # Apply reference implementation
     ref_result = swizzle_sf_ref(sf_data, rows, cols, scaling_vector_size)
@@ -118,8 +119,8 @@ def test_unswizzle_sf(rows, cols):
 
     # Create scaling factor data by first swizzling with reference implementation
     original_sf_data = torch.arange(rows * sf_cols,
-                                    dtype=fp4_utils.float4_sf_dtype).view(
-                                        rows, sf_cols)
+                                    dtype=fp4_utils.float4_sf_dtype,
+                                    device="cuda").view(rows, sf_cols)
     swizzled_sf_data = swizzle_sf_ref(original_sf_data, rows, cols,
                                       scaling_vector_size)
 
@@ -152,7 +153,8 @@ def test_swizzle_round_trip(rows, cols):
     # Create scaling factor data
     original_sf_data = torch.randint(0,
                                      256, (rows, sf_cols),
-                                     dtype=fp4_utils.float4_sf_dtype)
+                                     dtype=fp4_utils.float4_sf_dtype,
+                                     device="cuda")
 
     # Apply swizzle then unswizzle using the utils functions
     swizzled_sf = swizzle_sf(original_sf_data, rows, cols, scaling_vector_size)
@@ -177,8 +179,8 @@ def test_reswizzle_sf(rows, cols, num_partitions):
     for i in range(num_partitions):
         sf_data = torch.arange(i * 100,
                                i * 100 + rows * sf_cols,
-                               dtype=fp4_utils.float4_sf_dtype).view(
-                                   rows, sf_cols)
+                               dtype=fp4_utils.float4_sf_dtype,
+                               device="cuda").view(rows, sf_cols)
         swizzled_sf = swizzle_sf_ref(sf_data, rows, cols, scaling_vector_size)
         partition_sf_data.append(swizzled_sf)
 


### PR DESCRIPTION
# PR title

Please write the PR title by following template:

[JIRA ticket link/nvbug link/github issue link][fix/feat/doc/infra/...] \<summary of this PR\>

For example, assume I have a PR hope to support a new feature about cache manager of Jira TRTLLM-1000 ticket, it would be like

[TRTLLM-1000][feat] Support a new feature about cache manager

## Description

Use CPP OPs to implement `swizzle_sf`, `unswizzle_sf`, `reswizzle_sf`.
The original PyTorch versions are kept in test_fp4_swizzle.py as reference implementation.
Compared to the PyTorch implementation, the kernel/CUDA API calls are reduced.

|              | CPP OP           | PyTorch Ref                      |
| ------------ | ---------------- | -------------------------------- |
| swizzle_sf   | 1 custom kernel  | 2 elementwise kernels + 1 memcpy |
| unswizzle_sf | 1 custom kernel  | 1 elementwise kernel             |
| reswizzle_sf | 2 custom kernels + 1 elementwise kernel | 3 elementwise kernels + 1 memcpy |



## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

test_fp4_swizzle.py

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
