### PR TITLE
[TRTLLM-3442] feat: added beam search support to the PyTorch Workflow

### DIFF
--- a/cpp/tensorrt_llm/pybind/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/kvCacheManager.cpp
@@ -392,13 +392,14 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(py::module_& m)
             })
         .def("copy_batch_block_offsets",
             [](tbk::BaseKVCacheManager& self, at::Tensor output,
-                std::vector<tb::LlmRequest::RequestIdType> const& requestIds)
+                std::vector<tb::LlmRequest::RequestIdType> const& requestIds, SizeType32 const beamWidth,
+                SizeType32 const offset)
             {
                 auto _output = from_torch(output);
                 TLLM_CHECK_WITH_INFO(_output.has_value(), "Invalid output tensor.");
                 for (size_t i = 0; i < requestIds.size(); ++i)
                 {
-                    self.copyBlockOffsets(*(_output.value()), i, requestIds[i]);
+                    self.copyBlockOffsets(*(_output.value()), i * beamWidth + offset, requestIds[i]);
                 }
             })
         .def(

--- a/cpp/tensorrt_llm/pybind/runtime/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/runtime/bindings.cpp
@@ -338,6 +338,8 @@ void initBindings(pybind11::module_& m)
             py::arg("model_config"), py::arg("world_config"), py::arg("buffer_manager"))
         .def_property_readonly("joint_decoding_input", &tr::decoder::DecoderState::getJointDecodingInput)
         .def_property_readonly("joint_decoding_output", &tr::decoder::DecoderState::getJointDecodingOutput)
+        .def_property_readonly("cache_indirection_input", &tr::decoder::DecoderState::getCacheIndirectionInput)
+        .def_property_readonly("cache_indirection_output", &tr::decoder::DecoderState::getCacheIndirectionOutput)
         .def_property_readonly(
             "sequence_lengths", py::overload_cast<>(&tr::decoder::DecoderState::getSequenceLengths, py::const_))
         .def("get_sequence_lengths",

--- a/cpp/tensorrt_llm/pybind/runtime/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/runtime/bindings.cpp
@@ -388,6 +388,8 @@ void initBindings(pybind11::module_& m)
             py::arg("max_beam_width"), py::arg("dtype"), py::arg("model_config"), py::arg("world_config"))
         .def("forward_async", &tr::GptDecoderBatched::forwardAsync, py::arg("decoder_state"), py::arg("input"))
         .def("underlying_decoder", &tr::GptDecoderBatched::getUnderlyingDecoder, py::return_value_policy::reference)
+        .def("finalize", &tr::GptDecoderBatched::finalize, py::arg("decoder_state"), py::arg("batch_idx"),
+            py::arg("sampling_config"), py::arg("streaming"))
         .def_property_readonly(
             "decoder_stream",
             [](tr::GptDecoderBatched& self) -> tr::CudaStream const& { return *self.getDecoderStream(); },

--- a/examples/pytorch/quickstart_advanced.py
+++ b/examples/pytorch/quickstart_advanced.py
@@ -247,34 +247,23 @@ def main():
 
     for i, output in enumerate(outputs):
         prompt = output.prompt
-        if (args.max_beam_width == 1):
-            generated_text = output.outputs[0].text
+        for beam_idx, beam in enumerate(output.outputs):
+            generated_text = beam.text
+            # Skip printing the beam_idx if no beam search was used
+            beam_id_text = f"[{beam_idx}]" if args.max_beam_width > 1 else ""
             print(
-                f"[{i}] Prompt: {prompt!r}, Generated text: {generated_text!r}")
+                f"[{i}]{beam_id_text} Prompt: {prompt!r}, Generated text: {generated_text!r}"
+            )
             if args.return_context_logits:
-                print(f"[{i}] Context logits: {output.context_logits}")
+                print(
+                    f"[{i}]{beam_id_text} Context logits: {output.context_logits}"
+                )
             if args.return_generation_logits:
                 print(
-                    f"[{i}] Generation logits: {output.outputs[0].generation_logits}"
+                    f"[{i}]{beam_id_text} Generation logits: {beam.generation_logits}"
                 )
             if args.logprobs:
-                print(f"[{i}] Logprobs: {output.outputs[0].logprobs}")
-        else:
-            for beam_idx, beam in enumerate(output.outputs):
-                generated_text = beam.text
-                print(
-                    f"[{i}][{beam_idx}] Prompt: {prompt!r}, Generated text: {generated_text!r}"
-                )
-                if args.return_context_logits:
-                    print(
-                        f"[{i}][{beam_idx}] Context logits: {output.context_logits}"
-                    )
-                if args.return_generation_logits:
-                    print(
-                        f"[{i}][{beam_idx}] Generation logits: {beam.generation_logits}"
-                    )
-                if args.logprobs:
-                    print(f"[{i}][{beam_idx}] Logprobs: {beam.logprobs}")
+                print(f"[{i}]{beam_id_text} Logprobs: {beam.logprobs}")
 
 
 if __name__ == '__main__':

--- a/examples/pytorch/quickstart_advanced.py
+++ b/examples/pytorch/quickstart_advanced.py
@@ -105,6 +105,7 @@ def add_llm_args(parser):
     parser.add_argument("--top_k", type=int, default=None)
     parser.add_argument("--top_p", type=float, default=None)
     parser.add_argument('--load_format', type=str, default='auto')
+    parser.add_argument('--max_beam_width', type=int, default=1)
 
     # Speculative decoding
     parser.add_argument('--spec_decode_algo', type=str, default=None)
@@ -221,7 +222,8 @@ def setup_llm(args):
         enable_chunked_prefill=args.enable_chunked_prefill,
         speculative_config=spec_config,
         trust_remote_code=args.trust_remote_code,
-        gather_generation_logits=args.return_generation_logits)
+        gather_generation_logits=args.return_generation_logits,
+        max_beam_width=args.max_beam_width)
 
     sampling_params = SamplingParams(
         max_tokens=args.max_tokens,
@@ -230,7 +232,9 @@ def setup_llm(args):
         top_p=args.top_p,
         return_context_logits=args.return_context_logits,
         return_generation_logits=args.return_generation_logits,
-        logprobs=args.logprobs)
+        logprobs=args.logprobs,
+        n=args.max_beam_width,
+        use_beam_search=args.max_beam_width > 1)
     return llm, sampling_params
 
 
@@ -243,17 +247,34 @@ def main():
 
     for i, output in enumerate(outputs):
         prompt = output.prompt
-        generated_text = output.outputs[0].text
-        print(f"[{i}] Prompt: {prompt!r}, Generated text: {generated_text!r}")
-
-        if args.return_context_logits:
-            print(f"[{i}] Context logits: {output.context_logits}")
-        if args.return_generation_logits:
+        if (args.max_beam_width == 1):
+            generated_text = output.outputs[0].text
             print(
-                f"[{i}] Generation logits: {output.outputs[0].generation_logits}"
-            )
-        if args.logprobs:
-            print(f"[{i}] Logprobs: {output.outputs[0].logprobs}")
+                f"[{i}] Prompt: {prompt!r}, Generated text: {generated_text!r}")
+            if args.return_context_logits:
+                print(f"[{i}] Context logits: {output.context_logits}")
+            if args.return_generation_logits:
+                print(
+                    f"[{i}] Generation logits: {output.outputs[0].generation_logits}"
+                )
+            if args.logprobs:
+                print(f"[{i}] Logprobs: {output.outputs[0].logprobs}")
+        else:
+            for beam_idx, beam in enumerate(output.outputs):
+                generated_text = beam.text
+                print(
+                    f"[{i}][{beam_idx}] Prompt: {prompt!r}, Generated text: {generated_text!r}"
+                )
+                if args.return_context_logits:
+                    print(
+                        f"[{i}][{beam_idx}] Context logits: {output.context_logits}"
+                    )
+                if args.return_generation_logits:
+                    print(
+                        f"[{i}][{beam_idx}] Generation logits: {beam.generation_logits}"
+                    )
+                if args.logprobs:
+                    print(f"[{i}][{beam_idx}] Logprobs: {beam.logprobs}")
 
 
 if __name__ == '__main__':

--- a/tensorrt_llm/_torch/attention_backend/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/interface.py
@@ -45,6 +45,8 @@ class AttentionMetadata:
     max_num_requests: int
     # The max number of tokens in all requests in a single batch.
     max_num_tokens: int
+    # The max number of sequences in a single batch.
+    max_num_sequences: int
     # The KV cache manager.
     kv_cache_manager: KVCacheManager
     mapping: Optional[Mapping] = None

--- a/tensorrt_llm/_torch/attention_backend/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/interface.py
@@ -46,7 +46,7 @@ class AttentionMetadata:
     # The max number of tokens in all requests in a single batch.
     max_num_tokens: int
     # The max number of sequences in a single batch.
-    max_num_sequences: int
+    max_num_sequences: Optional[int] = None
     # The KV cache manager.
     kv_cache_manager: KVCacheManager
     mapping: Optional[Mapping] = None

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -591,6 +591,10 @@ class TrtllmAttentionMetadata(AttentionMetadata):
 
     def __post_init__(self) -> None:
         super().__post_init__()
+        # Set a default value, as max_num_sequences is not always set.
+        if self.max_num_sequences is None:
+            self.max_num_sequences = self.max_num_requests
+
         self.prompt_lens_cuda = torch.empty(
             (self.max_num_sequences, ),
             device='cuda',

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -592,7 +592,7 @@ class TrtllmAttentionMetadata(AttentionMetadata):
     def __post_init__(self) -> None:
         super().__post_init__()
         self.prompt_lens_cuda = torch.empty(
-            (self.max_num_requests, ),
+            (self.max_num_sequences, ),
             device='cuda',
             dtype=torch.int,
         )
@@ -617,8 +617,8 @@ class TrtllmAttentionMetadata(AttentionMetadata):
         if self.kv_cache_manager is not None:
             self.kv_cache_block_offsets = torch.empty(
                 [
-                    self.kv_cache_manager.num_pools, self.max_num_requests *
-                    self.beam_width, 2, self.kv_cache_manager.max_blocks_per_seq
+                    self.kv_cache_manager.num_pools, self.max_num_sequences, 2,
+                    self.kv_cache_manager.max_blocks_per_seq
                 ],
                 dtype=torch.int32,
                 device='cuda',

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -519,7 +519,6 @@ class TrtllmAttentionMetadata(AttentionMetadata):
 
     # TrtllmAttention needs to know the beam width and access to the cache indirection buffer,
     # when beam search is enabled.
-    # TODO -- put this into the parent class instead?
     beam_width: int = 1
     cache_indirection: Optional[torch.Tensor] = None
 
@@ -739,7 +738,6 @@ class TrtllmAttentionMetadata(AttentionMetadata):
         # kv block offsets
         assert self.request_ids is not None
         if self.kv_cache_manager is not None:
-            # TODO -- skip unnecessary copies
             # Copy blocks for all context requests
             self.kv_cache_manager.impl.copy_batch_block_offsets(
                 self.host_kv_cache_block_offsets,

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -257,6 +257,7 @@ def create_autodeploy_executor(executor_config: ExecutorConfig, checkpoint_dir: 
     msg = "pytorch_backend_config must be an AD LlmArgs object"
     assert isinstance(executor_config.pytorch_backend_config, LlmArgs), msg
     ad_config: LlmArgs = executor_config.pytorch_backend_config
+    assert ad_config.max_beam_width <= 1, "_autodeploy + beam_search is not supported"
 
     max_num_sequences = ad_config.max_batch_size * dist_mapping.pp_size
     # some derivative properties
@@ -317,5 +318,6 @@ def create_autodeploy_executor(executor_config: ExecutorConfig, checkpoint_dir: 
         max_input_len=ad_config.max_input_len,
         max_batch_size=ad_config.max_batch_size,
         max_draft_tokens=max_draft_tokens,
+        max_beam_width=ad_config.max_beam_width,
     )
     return py_executor

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -220,6 +220,7 @@ class ADEngine(ModelEngine):
         resource_manager: ResourceManager,
         new_tokens_device: Optional[torch.Tensor] = None,
         gather_context_logits: bool = False,
+        cache_indirection_buffer: Optional[torch.Tensor] = None,
     ):
         """Run forward from scheduled requests; main entrypoint that gets called by the executor."""
         # convert requests and store in sequence info object

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -169,7 +169,9 @@ class KvCacheCreator:
             num_cache_blocks += (num_req_tokens +
                                  executor_config.tokens_per_block -
                                  1) // executor_config.tokens_per_block
-        return num_cache_blocks * executor_config.tokens_per_block
+        # Multiply by beam width, to prevent rescaling of the max_seq_len caused by the influence of beam width during the preparation for kv_cache_estimation
+        return num_cache_blocks * executor_config.tokens_per_block * self._dummy_reqs[
+            0].sampling_config.beam_width
 
     def try_prepare_estimation(self) -> bool:
         """Prepare for possible KV cache capacity estimation.
@@ -366,13 +368,10 @@ class KvCacheCreator:
                 mapping=mapping,
                 dtype=kv_cache_dtype,
                 spec_config=spec_config,
-<<<<<<< HEAD
                 max_num_tokens=executor_config.max_num_tokens,
-                model_config=binding_model_config)
-=======
+                model_config=binding_model_config,
                 max_beam_width=executor_config.max_beam_width,
             )
->>>>>>> bceaf63bb (feat: added beam search support to the PyTorch Workflow)
         # KVCacheManager (Non-draft) modifies the max_seq_len field, update it to executor_config
         if model_engine.kv_cache_manager_key == ResourceManagerType.KV_CACHE_MANAGER:
             executor_config.max_seq_len = kv_cache_manager.max_seq_len

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -537,6 +537,7 @@ def create_py_executor_instance(
         disable_overlap_scheduler=pytorch_backend_config.
         disable_overlap_scheduler,
         max_batch_size=executor_config.max_batch_size,
+        max_beam_width=executor_config.max_beam_width,
         max_draft_tokens=spec_config.max_draft_tokens
         if spec_config is not None else 0,
         kv_cache_transceiver=kv_cache_transceiver,

--- a/tensorrt_llm/_torch/pyexecutor/handle_generation_logits.py
+++ b/tensorrt_llm/_torch/pyexecutor/handle_generation_logits.py
@@ -27,7 +27,8 @@ class HandleGenerationLogits:
                 decoder_buffer_logits[seq_slot] = logits_view.unsqueeze(1)
 
             if llm_req.py_return_generation_logits:
-                llm_req.py_result.append_generation_logits(logits_view)
+                llm_req.py_result.append_generation_logits(
+                    decoder_buffer_logits[seq_slot])
 
             logits_index += beam_width
 

--- a/tensorrt_llm/_torch/pyexecutor/handle_generation_logits.py
+++ b/tensorrt_llm/_torch/pyexecutor/handle_generation_logits.py
@@ -17,19 +17,21 @@ class HandleGenerationLogits:
         for llm_req in generation_requests:
             beam_width = llm_req.get_beam_width_by_iter()
             seq_slot = llm_req.seq_slot
+            draft_length = llm_req.num_draft_tokens
+            num_logits = beam_width + draft_length
+            num_tokens = 1 + draft_length
 
-            # logits_view shape: [beamWidth, vocabSize]
-            logits_view = logits[logits_index:logits_index + beam_width]
+            # logits_view shape: [num_tokens, beam_width, vocab_size]
+            logits_view = logits[logits_index:logits_index + beam_width +
+                                 draft_length].reshape(num_tokens, beam_width,
+                                                       -1)
 
-            if beam_width > 1:
-                decoder_buffer_logits[seq_slot] = logits_view.unsqueeze(0)
-            else:
-                decoder_buffer_logits[seq_slot] = logits_view.unsqueeze(1)
+            decoder_buffer_logits[seq_slot] = logits_view
 
             if llm_req.py_return_generation_logits:
                 llm_req.py_result.append_generation_logits(
                     decoder_buffer_logits[seq_slot])
 
-            logits_index += beam_width
+            logits_index += num_logits
 
         return decoder_buffer_logits

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -146,7 +146,9 @@ class LogProbStorage:
         log_probs: [beam_width, num_tokens]
         cum_log_probs: [beam_width]
         """
-        self.beam_width = -1
+        # reinitialize the storage to clear the lists
+        self._init(log_probs)
+        # append the new values
         self.append(log_probs, cum_log_probs)
 
 

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -139,6 +139,16 @@ class LogProbStorage:
                 self.cum_log_probs[beam_idx] += sum(
                     next(iter(prob.values())).logprob for prob in probs)
 
+    def set_log_probs(self, log_probs: list[TokenLogprobs],
+                      cum_log_probs: list[float]):
+        """
+        Reset the storage and refill it with new values
+        log_probs: [beam_width, num_tokens]
+        cum_log_probs: [beam_width]
+        """
+        self.beam_width = -1
+        self.append(log_probs, cum_log_probs)
+
 
 class PyResult:
     """PyResult reimplements some features of `bindings.executor.Result` in Python"""
@@ -173,6 +183,16 @@ class PyResult:
                          cum_log_probs: Optional[list[float]] = None):
         if self._log_probs:
             self._log_probs.append(log_probs, cum_log_probs)
+
+    def set_log_probs(self, log_probs: list[TokenLogprobs],
+                      cum_log_probs: list[float]):
+        """
+        Set log_probs and cum_log_probs to the new values
+        log_probs: [beam_width, num_tokens]
+        cum_log_probs: [beam_width]
+        """
+        if self._log_probs:
+            self._log_probs.set_log_probs(log_probs, cum_log_probs)
 
     @property
     def context_logits(self) -> torch.Tensor | None:

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1460,7 +1460,7 @@ class PyTorchModelEngine(ModelEngine):
                 cache_indirection_buffer)
             #Copy cache indirection to local buffer with offsets changing:  seq_slots[i] -> i
             cache_indirection_attention[:num_generation_requests].copy_(
-                cache_indirection_buffer[seq_slots], non_blocking=False)
+                cache_indirection_buffer[seq_slots])
             attn_metadata.cache_indirection = cache_indirection_attention
             attn_metadata.beam_width = self.max_beam_width
         else:

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1330,6 +1330,7 @@ class PyTorchModelEngine(ModelEngine):
                     past_seen_token_num = request.max_beam_num_tokens - 1
                 else:
                     # the request has previous tensor
+                    previous_batch_indices.append(request.py_batch_idx)
                     past_seen_token_num = request.max_beam_num_tokens
 
                 position_ids.append(past_seen_token_num)
@@ -1339,8 +1340,6 @@ class PyTorchModelEngine(ModelEngine):
                 sequence_lengths.append(1)
                 gather_ids.append(len(position_ids) - 1)
 
-            if new_tokens_device is not None and not request.is_dummy and request.py_batch_idx is not None:
-                previous_batch_indices.append(request.py_batch_idx)
             request_ids.append(request.py_request_id)
             seq_slots.append(request.seq_slot)
             request.py_batch_idx = request.seq_slot

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -73,12 +73,14 @@ class ModelEngine(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def forward(self,
-                scheduled_requests: ScheduledRequests,
-                resource_manager: ResourceManager,
-                new_tensors_device: Optional[SampleStateTensors],
-                gather_context_logits: bool = False,
-                cache_indirection_buffer: Optional[torch.Tensor] = None):
+    def forward(
+        self,
+        scheduled_requests: ScheduledRequests,
+        resource_manager: ResourceManager,
+        new_tensors_device: Optional[SampleStateTensors],
+        gather_context_logits: bool = False,
+        cache_indirection_buffer: Optional[torch.Tensor] = None,
+    ):
         raise NotImplementedError
 
     def warmup(self, resource_manager: ResourceManager) -> None:
@@ -2031,12 +2033,14 @@ class PyTorchModelEngine(ModelEngine):
 
     @torch.inference_mode()
     @with_model_extra_attrs(lambda self: self.model.extra_attrs)
-    def forward(self,
-                scheduled_requests: ScheduledRequests,
-                resource_manager: ResourceManager,
-                new_tensors_device: Optional[SampleStateTensors] = None,
-                gather_context_logits: bool = False,
-                cache_indirection_buffer: Optional[torch.Tensor] = None):
+    def forward(
+        self,
+        scheduled_requests: ScheduledRequests,
+        resource_manager: ResourceManager,
+        new_tensors_device: Optional[SampleStateTensors] = None,
+        gather_context_logits: bool = False,
+        cache_indirection_buffer: Optional[torch.Tensor] = None,
+    ):
 
         kv_cache_manager = resource_manager.get_resource_manager(
             self.kv_cache_manager_key)

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -812,6 +812,7 @@ class PyTorchModelEngine(ModelEngine):
             return self.attn_backend.Metadata(
                 max_num_requests=self.batch_size,
                 max_num_tokens=self.max_num_tokens,
+                max_num_sequences=self.batch_size * self.max_beam_width,
                 kv_cache_manager=None,
                 mapping=self.mapping,
                 runtime_features=self.attn_runtime_features,
@@ -827,6 +828,7 @@ class PyTorchModelEngine(ModelEngine):
         self.attn_metadata = self.attn_backend.Metadata(
             max_num_requests=self.batch_size,
             max_num_tokens=self.max_num_tokens,
+            max_num_sequences=self.batch_size * self.max_beam_width,
             kv_cache_manager=kv_cache_manager,
             mapping=self.mapping,
             runtime_features=self.attn_runtime_features,

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1429,10 +1429,13 @@ class PyTorchModelEngine(ModelEngine):
             batch_and_beam_indices = ( # TODO -- fix this
                 self.max_beam_width *
                 self.previous_batch_indices_cuda[:previous_batchs])
+            # reshape to expose the beam_width as its own dimension and add the beam id to each beam for each request
             batch_and_beam_indices = batch_and_beam_indices.reshape(
                 -1, self.max_beam_width) + torch.arange(
                     self.max_beam_width, device=batch_and_beam_indices.device)
             batch_and_beam_indices = batch_and_beam_indices.reshape(-1)
+            self.input_ids_cuda[num_tokens:num_tokens + previous_batchs].copy_(
+                new_tokens_device[batch_and_beam_indices], non_blocking=True)
 
         position_ids = torch.tensor(position_ids,
                                     dtype=torch.int,

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1181,7 +1181,6 @@ class PyTorchModelEngine(ModelEngine):
         mrope_config = defaultdict(list)
         gen_request_seq_slots = []  # per generation request
 
-
         for request in scheduled_requests.context_requests:
             request_ids.append(request.py_request_id)
             all_prompt_tokens = request.get_tokens(0)

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1330,7 +1330,6 @@ class PyTorchModelEngine(ModelEngine):
                     past_seen_token_num = request.max_beam_num_tokens - 1
                 else:
                     # the request has previous tensor
-                    previous_batch_indices.append(request.py_batch_idx)
                     past_seen_token_num = request.max_beam_num_tokens
 
                 position_ids.append(past_seen_token_num)
@@ -1340,6 +1339,8 @@ class PyTorchModelEngine(ModelEngine):
                 sequence_lengths.append(1)
                 gather_ids.append(len(position_ids) - 1)
 
+            if new_tokens_device is not None and not request.is_dummy and request.py_batch_idx is not None:
+                previous_batch_indices.append(request.py_batch_idx)
             request_ids.append(request.py_request_id)
             seq_slots.append(request.seq_slot)
             request.py_batch_idx = request.seq_slot

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -270,7 +270,9 @@ class PyExecutor:
             self.event_loop = self._executor_loop_pp
         else:
             self.event_loop = self._executor_loop if disable_overlap_scheduler else self._executor_loop_overlap
-
+        if not disable_overlap_scheduler and model_engine.max_beam_width > 1:
+            raise NotImplementedError(
+                "Overlap scheduler is not supported for beam search.")
         if is_trace_enabled("TLLM_TRACE_EXECUTOR_LOOP"):
             self.event_loop = trace_func(self.event_loop)
 

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1619,19 +1619,22 @@ class PyExecutor:
             f"[Executor] _forward_step {self.model_engine.iter_counter}: {len(scheduled_requests.context_requests)} ctx reqs, {len(scheduled_requests.generation_requests)} gen reqs"
         )
         def forward(scheduled_requests, resource_manager, new_tensors_device,
-                    gather_context_logits):
+                    gather_context_logits, cache_indirection_buffer):
             return self.model_engine.forward(
                 scheduled_requests,
                 resource_manager,
                 new_tensors_device,
-                gather_context_logits=gather_context_logits)
+                gather_context_logits=gather_context_logits,
+                cache_indirection_buffer=cache_indirection_buffer)
 
         try:
             gather_context_logits = any(
                 a.py_return_context_logits
                 for a in scheduled_requests.context_requests)
+            cache_indirection_buffer = self.sampler.get_cache_indirection()
             outputs = forward(scheduled_requests, self.resource_manager,
-                              new_tensors_device, gather_context_logits)
+                              new_tensors_device, gather_context_logits,
+                              cache_indirection_buffer)
             return outputs
         except Exception as e:
             traceback.print_exc()

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -172,6 +172,7 @@ class PyExecutor:
                  disable_overlap_scheduler: bool = False,
                  max_input_len: int = 2048,
                  max_batch_size: int = 8,
+                 max_beam_width: int = 1,
                  max_draft_tokens: int = 0,
                  kv_cache_transceiver: KvCacheTransceiver = None,
                  draft_model_engine: Optional[ModelEngine] = None,
@@ -205,6 +206,7 @@ class PyExecutor:
         self.enqueue_lock = threading.Lock()
         self.active = True
         self.next_req_id = max_batch_size  # The first max_batch_size request IDs are reserved for dummy requests
+        self.max_beam_width = max_beam_width
         self.max_draft_tokens = max_draft_tokens
         self.print_log = model_engine.pytorch_backend_config.print_iter_log
         self.enable_iter_perf_stats = model_engine.pytorch_backend_config.enable_iter_perf_stats
@@ -1232,7 +1234,7 @@ class PyExecutor:
                 valid_new_requests.append(req_item)
         # Check if the beam width of the requests is equal to the max_beam_width
         for req_item in valid_new_requests:
-            assert req_item.request.sampling_config.beam_width == self.model_engine.max_beam_width, f"Request beam width {req_item.request.sampling_config.beam_width} is not equal to max_beam_width {self.model_engine.max_beam_width}. This is not supported!"
+            assert req_item.request.sampling_config.beam_width == self.max_beam_width, f"Request beam width {req_item.request.sampling_config.beam_width} is not equal to max_beam_width {self.max_beam_width}. This is not supported!"
         new_requests = valid_new_requests
 
         if py_request_objects and (self.dist.tp_size > 1

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1230,6 +1230,9 @@ class PyExecutor:
                 break
             else:
                 valid_new_requests.append(req_item)
+        # Check if the beam width of the requests is equal to the max_beam_width
+        for req_item in valid_new_requests:
+            assert req_item.request.sampling_config.beam_width == self.model_engine.max_beam_width, f"Request beam width {req_item.request.sampling_config.beam_width} is not equal to max_beam_width {self.model_engine.max_beam_width}. This is not supported!"
         new_requests = valid_new_requests
 
         if py_request_objects and (self.dist.tp_size > 1

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -230,6 +230,7 @@ def create_py_executor(
             checkpoint_dir,
             pytorch_backend_config,
             batch_size=executor_config.max_batch_size,
+            max_beam_width=executor_config.max_beam_width,
             max_num_tokens=executor_config.max_num_tokens,
             max_seq_len=executor_config.max_seq_len,
             mapping=mapping,
@@ -252,6 +253,7 @@ def create_py_executor(
                 spec_config.draft_model_path,
                 pytorch_backend_config,
                 batch_size=executor_config.max_batch_size,
+                max_beam_width=executor_config.max_beam_width,
                 max_num_tokens=executor_config.max_num_tokens,
                 # Note: The draft model engine will infer its own max_seq_len.
                 # We'll stop drafting when we hit the max.

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -261,7 +261,7 @@ class KVCacheManager(BaseResourceManager):
             'tokens_per_block': tokens_per_block,
             'blocks_per_window': blocks_per_window,
             'max_num_sequences': max_batch_size,
-            'max_beam_width': self.max_beam_width,  # TODO: more than 1 beam?
+            'max_beam_width': self.max_beam_width,
             'max_attention_window_vec': self.max_attention_window_vec,
             'temp_attention_window_inputs': temp_attention_window_inputs,
             'dtype': dtype,

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -113,25 +113,26 @@ def get_pp_layers(
 class KVCacheManager(BaseResourceManager):
 
     def __init__(
-            self,
-            kv_cache_config: KvCacheConfigCpp,
-            kv_cache_type: CacheTypeCpp,
-            *,
-            num_layers: int,
-            num_kv_heads: Union[int, List[Optional[int]]],
-            head_dim: int,
-            tokens_per_block: int,
-            # Note that max_seq_len is not necessarily equal to kv_cache_config.num_tokens.
-            # It's derived from the model's BuildConfig for consistency with the C++ backend.
-            max_seq_len: int,
-            max_batch_size: int,
-            mapping: Mapping,
-            dtype: DataType = DataType.HALF,
-            spec_config: Optional["SpecConfig"] = None,
-            layer_mask: Optional[List[bool]] = None,
+        self,
+        kv_cache_config: KvCacheConfigCpp,
+        kv_cache_type: CacheTypeCpp,
+        *,
+        num_layers: int,
+        num_kv_heads: Union[int, List[Optional[int]]],
+        head_dim: int,
+        tokens_per_block: int,
+        # Note that max_seq_len is not necessarily equal to kv_cache_config.num_tokens.
+        # It's derived from the model's BuildConfig for consistency with the C++ backend.
+        max_seq_len: int,
+        max_batch_size: int,
+        mapping: Mapping,
+        dtype: DataType = DataType.HALF,
+        spec_config: Optional["SpecConfig"] = None,
+        layer_mask: Optional[List[bool]] = None,
         max_num_tokens: int = 8192,
         model_config: Optional[ModelConfig] = None,
-            max_beam_width: int = 1) -> None:
+        max_beam_width: int = 1,
+    ) -> None:
         self.mapping = mapping
         self.dtype = dtype
         self.kv_cache_type = kv_cache_type

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -175,7 +175,6 @@ class KVCacheManager(BaseResourceManager):
         self.tokens_per_block = tokens_per_block
         self.max_seq_len = max_seq_len
         self.max_batch_size = max_batch_size
-        self.max_beam_width = max_beam_width
         self.kv_factor = 1 if kv_cache_type == CacheTypeCpp.SELFKONLY else 2
         # Some speculative decoding methods need to use different kv lengths for the
         # draft/target layers. Add extra tokens to handle this issue.
@@ -262,7 +261,7 @@ class KVCacheManager(BaseResourceManager):
             'tokens_per_block': tokens_per_block,
             'blocks_per_window': blocks_per_window,
             'max_num_sequences': max_batch_size,
-            'max_beam_width': self.max_beam_width,
+            'max_beam_width': max_beam_width,
             'max_attention_window_vec': self.max_attention_window_vec,
             'temp_attention_window_inputs': temp_attention_window_inputs,
             'dtype': dtype,

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -236,7 +236,8 @@ class KVCacheManager(BaseResourceManager):
             tokens_per_block=tokens_per_block,
             sink_token_length=sink_token_length,
             max_seq_len=self.max_seq_len,
-            max_beam_width=self.max_beam_width,)
+            max_beam_width=max_beam_width,
+        )
 
         if kv_cache_type != CacheTypeCpp.SELF:
             assert len(
@@ -658,6 +659,7 @@ class KVCacheManager(BaseResourceManager):
         tokens_per_block: int,
         sink_token_length: int,
         max_seq_len: int,
+        max_beam_width: int,
     ) -> Tuple[BlocksPerWindow, int, List[int]]:
         """
         Validate and adjust attention windows against their upper bounds if needed.
@@ -673,7 +675,6 @@ class KVCacheManager(BaseResourceManager):
         Returns:
             Tuple of (adjusted_blocks_per_window, adjusted_max_seq_len, adjusted_max_attention_window_vec)
         """
-        max_beam_width = 1  # TODO: support more than 1 beam?
         window_adjustments = {}
         # Validate each window size in blocks_per_window against its upper bound
         for window_size, (blocks_in_primary_pool,

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -713,7 +713,7 @@ class TRTLLMSampler(Sampler):
 
         finalize_events = {}
 
-        for request in all_requests:
+        for request in scheduled_requests.all_requests:
             if request.is_context_init_state:
                 continue
 
@@ -786,7 +786,7 @@ class TRTLLMSampler(Sampler):
                     request, True)
         # post process all requests if necessary
         if beam_width > 1:
-            for request in all_requests:
+            for request in scheduled_requests.all_requests:
                 if request.request_id in finalize_events:
                     self._post_process_request(
                         request, finalize_events[request.request_id])

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -619,7 +619,7 @@ class TRTLLMSampler(Sampler):
     def sample_async(self, scheduled_requests: ScheduledRequests,
                      model_outputs) -> SampleStateTRTLLM:
         batch_size = scheduled_requests.batch_size
-        all_requests = scheduled_requests.all_requests
+        all_requests = scheduled_requests.all_requests()
         beam_width = self.beam_width(all_requests)
         if (batch_size > 1 and beam_width > 1
                 and any(request.py_return_log_probs
@@ -713,7 +713,7 @@ class TRTLLMSampler(Sampler):
 
         finalize_events = {}
 
-        for request in scheduled_requests.all_requests:
+        for request in requests:
             if request.is_context_init_state:
                 continue
 
@@ -785,7 +785,7 @@ class TRTLLMSampler(Sampler):
                     request, True)
         # post process all requests if necessary
         if beam_width > 1:
-            for request in scheduled_requests.all_requests:
+            for request in requests:
                 if request.request_id in finalize_events:
                     self._post_process_request(
                         request, finalize_events[request.request_id])

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -813,16 +813,14 @@ class TRTLLMSampler(Sampler):
         finalize_event.synchronize()
 
         # Get these values again, as they might have changed during the finalize step
-        output_ids_host = self.store["decoder_state"].gathered_ids.to(
-            'cpu', non_blocking=False)
+        output_ids_host = self.store["decoder_state"].gathered_ids.to('cpu')
         sequence_lengths_host = self.store["decoder_state"].sequence_lengths.to(
-            'cpu', non_blocking=False)
+            'cpu')
 
         if request.py_return_log_probs:
-            log_probs_host = self.store["decoder_state"].log_probs.to(
-                'cpu', non_blocking=False)
+            log_probs_host = self.store["decoder_state"].log_probs.to('cpu')
             cum_log_probs_host = self.store["decoder_state"].cum_log_probs.to(
-                'cpu', non_blocking=False)
+                'cpu')
 
         generated_tokens = [[0]] * beam_width
         log_probs = [[] for _ in range(beam_width)]

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -757,8 +757,7 @@ class TRTLLMSampler(Sampler):
                                                                   beam].item())
 
                 finished_state = FinishedState(
-                    state.host.finish_reasons[seq_slot,
-                                              beam].item())
+                    state.host.finish_reasons[seq_slot, beam].item())
                 if finished_state.is_finished:
                     finish_reason = finished_state.to_finish_reason()
                     request.set_finished_reason(finish_reason, beam)

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -797,8 +797,9 @@ class TRTLLMSampler(Sampler):
     def _finalize_request(self, request: LlmRequest, streaming: bool):
         """ Finalizes the request. This is necessary for beam search. """
         seq_slot = request.seq_slot
-        event = self.algs.decoder.finalize(self.algs.decoder_state, seq_slot,
-                                           request.sampling_config, streaming)
+        event = self.algs.decoder.finalize(self.store["decoder_state"],
+                                           seq_slot, request.sampling_config,
+                                           streaming)
         return event
 
     def _post_process_request(self, request: LlmRequest,
@@ -813,15 +814,15 @@ class TRTLLMSampler(Sampler):
         finalize_event.synchronize()
 
         # Get these values again, as they might have changed during the finalize step
-        output_ids_host = self.algs.decoder_state.gathered_ids.to(
+        output_ids_host = self.store["decoder_state"].gathered_ids.to(
             'cpu', non_blocking=False)
-        sequence_lengths_host = self.algs.decoder_state.sequence_lengths.to(
+        sequence_lengths_host = self.store["decoder_state"].sequence_lengths.to(
             'cpu', non_blocking=False)
 
         if request.py_return_log_probs:
-            log_probs_host = self.algs.decoder_state.log_probs.to(
+            log_probs_host = self.store["decoder_state"].log_probs.to(
                 'cpu', non_blocking=False)
-            cum_log_probs_host = self.algs.decoder_state.cum_log_probs.to(
+            cum_log_probs_host = self.store["decoder_state"].cum_log_probs.to(
                 'cpu', non_blocking=False)
 
         generated_tokens = [[0]] * beam_width

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -643,7 +643,7 @@ class TRTLLMSampler(Sampler):
             decoder_logits, scheduled_requests.generation_requests,
             model_outputs["logits"], logits_index)
 
-        self.store["decoder_input_buffers"].logits = decoder_buffer_logits
+        self.store["decoder_input_buffers"].logits = decoder_logits
 
         # For beam search, cache indirection needs to be updated
         if (beam_width > 1):

--- a/tests/integration/test_lists/test-db/l0_a30.yml
+++ b/tests/integration/test_lists/test-db/l0_a30.yml
@@ -18,7 +18,6 @@ l0_a30:
   - unittest/_torch/modeling -k "modeling_qwen"
   - unittest/_torch/modeling -k "modeling_qwen_moe"
   - unittest/_torch/auto_deploy/unit/singlegpu
-  - unittest/_torch/test_beam_search.py
 - condition:
     ranges:
       system_gpu_count:

--- a/tests/integration/test_lists/test-db/l0_a30.yml
+++ b/tests/integration/test_lists/test-db/l0_a30.yml
@@ -18,6 +18,7 @@ l0_a30:
   - unittest/_torch/modeling -k "modeling_qwen"
   - unittest/_torch/modeling -k "modeling_qwen_moe"
   - unittest/_torch/auto_deploy/unit/singlegpu
+  - unittest/_torch/test_beam_search.py
 - condition:
     ranges:
       system_gpu_count:

--- a/tests/unittest/_torch/test_beam_search.py
+++ b/tests/unittest/_torch/test_beam_search.py
@@ -1,0 +1,96 @@
+import os
+
+import pytest
+from utils.llm_data import llm_models_root
+from utils.util import force_ampere, similar
+
+from tensorrt_llm import SamplingParams
+from tensorrt_llm._torch import LLM
+from tensorrt_llm.llmapi.llm_utils import KvCacheConfig
+
+prompts = [
+    "Born in north-east France, Soyer trained as a",
+    "The future of AI is",
+]
+expected_outputs = {
+    "Born in north-east France, Soyer trained as a": [
+        "painter in Paris before moving to London in",
+        "painter and sculptor in Paris before moving"
+    ],
+    "The future of AI is":
+    ["bright, but it's not without", "bright, but it's not going"],
+}
+
+global_kvcache_config = KvCacheConfig(max_tokens=10000)
+
+
+@force_ampere  # Save H100 resource
+@pytest.mark.parametrize("return_log_probs", [True, False])
+@pytest.mark.parametrize("gather_generation_logits", [True, False])
+@pytest.mark.parametrize("gather_context_logits", [True, False])
+@pytest.mark.parametrize("enable_trtllm_sampler", [True])
+@pytest.mark.parametrize("disable_overlap_scheduler", [True, False])
+@pytest.mark.parametrize("max_beam_width", [2])
+@pytest.mark.parametrize("max_tokens", [8])
+@pytest.mark.parametrize("num_prompts", [1, 2])
+def test_beam_search_output_shapes(disable_overlap_scheduler: bool,
+                                   enable_trtllm_sampler: bool,
+                                   gather_context_logits: bool,
+                                   gather_generation_logits: bool,
+                                   return_log_probs: bool, max_beam_width: int,
+                                   max_tokens: int, num_prompts: int):
+    if not enable_trtllm_sampler:
+        pytest.skip(
+            "Beam search currently is only supported with TRTLLMSampler")
+    if return_log_probs and num_prompts > 1:
+        pytest.skip(
+            "Beam search currently does not support return_log_probs with multiple prompts"
+        )
+    llm = LLM(
+        model=os.path.join(llm_models_root(), "llama-models-v2",
+                           "TinyLlama-1.1B-Chat-v1.0"),
+        kv_cache_config=global_kvcache_config,
+        gather_generation_logits=gather_generation_logits,
+        max_batch_size=
+        128,  # reduce buffer sizes, specially for generation logits
+        max_seq_len=128,
+        enable_trtllm_sampler=enable_trtllm_sampler,
+        disable_overlap_scheduler=disable_overlap_scheduler,
+        max_beam_width=max_beam_width,
+    )
+    sampling_params = SamplingParams(
+        max_tokens=max_tokens,
+        top_k=None,
+        top_p=None,
+        n=max_beam_width,
+        use_beam_search=max_beam_width > 1,
+        return_context_logits=gather_context_logits,
+        return_generation_logits=gather_generation_logits,
+        logprobs=return_log_probs,
+    )
+    with llm:
+        for output_idx, output in enumerate(
+                llm.generate(prompts[:num_prompts],
+                             sampling_params=sampling_params)):
+            if gather_context_logits:
+                assert output.context_logits is not None
+                assert len(
+                    output.prompt_token_ids) == output.context_logits.shape[0]
+            else:
+                assert output.context_logits is None
+            assert len(output.outputs) == max_beam_width
+            for beam_idx, beam in enumerate(output.outputs):
+                if gather_generation_logits:
+                    gen_logits = beam.generation_logits
+                    assert gen_logits is not None
+                    assert gen_logits.ndim == 2
+                    assert gen_logits.shape[0] == sampling_params.max_tokens
+                else:
+                    assert beam.generation_logits is None
+
+                if return_log_probs:
+                    assert len(beam.logprobs) == sampling_params.max_tokens
+                else:
+                    assert len(beam.logprobs) == 0
+                assert similar(beam.text,
+                               expected_outputs[prompts[output_idx]][beam_idx])

--- a/tests/unittest/_torch/test_beam_search.py
+++ b/tests/unittest/_torch/test_beam_search.py
@@ -27,13 +27,11 @@ global_kvcache_config = KvCacheConfig(max_tokens=10000)
 @pytest.mark.parametrize("return_log_probs", [True, False])
 @pytest.mark.parametrize("gather_generation_logits", [True, False])
 @pytest.mark.parametrize("gather_context_logits", [True, False])
-@pytest.mark.parametrize("disable_overlap_scheduler", [True, False])
 @pytest.mark.parametrize("max_beam_width", [2])
 @pytest.mark.parametrize("num_output_beams", [1, 2])
 @pytest.mark.parametrize("max_tokens", [8])
 @pytest.mark.parametrize("num_prompts", [1, 2])
-def test_beam_search_output_shapes(disable_overlap_scheduler: bool,
-                                   gather_context_logits: bool,
+def test_beam_search_output_shapes(gather_context_logits: bool,
                                    gather_generation_logits: bool,
                                    return_log_probs: bool, max_beam_width: int,
                                    num_output_beams: int, max_tokens: int,
@@ -51,8 +49,8 @@ def test_beam_search_output_shapes(disable_overlap_scheduler: bool,
         128,  # reduce buffer sizes, specially for generation logits
         max_seq_len=128,
         enable_trtllm_sampler=True,
-        disable_overlap_scheduler=disable_overlap_scheduler,
         max_beam_width=max_beam_width,
+        disable_overlap_scheduler=True,
     )
     sampling_params = SamplingParams(
         max_tokens=max_tokens,

--- a/tests/unittest/_torch/test_beam_search.py
+++ b/tests/unittest/_torch/test_beam_search.py
@@ -27,7 +27,6 @@ global_kvcache_config = KvCacheConfig(max_tokens=10000)
 @pytest.mark.parametrize("return_log_probs", [True, False])
 @pytest.mark.parametrize("gather_generation_logits", [True, False])
 @pytest.mark.parametrize("gather_context_logits", [True, False])
-@pytest.mark.parametrize("enable_trtllm_sampler", [True])
 @pytest.mark.parametrize("disable_overlap_scheduler", [True, False])
 @pytest.mark.parametrize("max_beam_width", [2])
 @pytest.mark.parametrize("max_tokens", [8])
@@ -38,9 +37,6 @@ def test_beam_search_output_shapes(disable_overlap_scheduler: bool,
                                    gather_generation_logits: bool,
                                    return_log_probs: bool, max_beam_width: int,
                                    max_tokens: int, num_prompts: int):
-    if not enable_trtllm_sampler:
-        pytest.skip(
-            "Beam search currently is only supported with TRTLLMSampler")
     if return_log_probs and num_prompts > 1:
         pytest.skip(
             "Beam search currently does not support return_log_probs with multiple prompts"
@@ -59,8 +55,6 @@ def test_beam_search_output_shapes(disable_overlap_scheduler: bool,
     )
     sampling_params = SamplingParams(
         max_tokens=max_tokens,
-        top_k=None,
-        top_p=None,
         n=max_beam_width,
         use_beam_search=max_beam_width > 1,
         return_context_logits=gather_context_logits,

--- a/tests/unittest/_torch/test_beam_search.py
+++ b/tests/unittest/_torch/test_beam_search.py
@@ -4,8 +4,7 @@ import pytest
 from utils.llm_data import llm_models_root
 from utils.util import force_ampere, similar
 
-from tensorrt_llm import SamplingParams
-from tensorrt_llm._torch import LLM
+from tensorrt_llm import LLM, SamplingParams
 from tensorrt_llm.llmapi.llm_utils import KvCacheConfig
 
 prompts = [

--- a/tests/unittest/_torch/test_beam_search.py
+++ b/tests/unittest/_torch/test_beam_search.py
@@ -32,7 +32,6 @@ global_kvcache_config = KvCacheConfig(max_tokens=10000)
 @pytest.mark.parametrize("max_tokens", [8])
 @pytest.mark.parametrize("num_prompts", [1, 2])
 def test_beam_search_output_shapes(disable_overlap_scheduler: bool,
-                                   enable_trtllm_sampler: bool,
                                    gather_context_logits: bool,
                                    gather_generation_logits: bool,
                                    return_log_probs: bool, max_beam_width: int,
@@ -49,7 +48,7 @@ def test_beam_search_output_shapes(disable_overlap_scheduler: bool,
         max_batch_size=
         128,  # reduce buffer sizes, specially for generation logits
         max_seq_len=128,
-        enable_trtllm_sampler=enable_trtllm_sampler,
+        enable_trtllm_sampler=True,
         disable_overlap_scheduler=disable_overlap_scheduler,
         max_beam_width=max_beam_width,
     )


### PR DESCRIPTION
## Description

- Added Basic Beam Search support for the PyTorch Workflow. 
- Return Context Logits and Generation Logits support for beam search is provided
- Return Logprobs Support is only provided for a single prompt
- Tests were run using TinyLlama model 

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
