### PR TITLE
[TRTLLM-5825][fix] Fix torch LoRA TP

### DIFF
--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -282,6 +282,7 @@ class ModelConfig(Generic[TConfig]):
 
         num_heads = self.pretrained_config.num_attention_heads // (
             self.mapping.tp_size * self.mapping.cp_size)
+        hidden_size = self.pretrained_config.hidden_size // self.mapping.tp_size
 
         model_config_cpp = ModelConfigCpp(
             vocab_size=self.pretrained_config.vocab_size,
@@ -289,7 +290,7 @@ class ModelConfig(Generic[TConfig]):
             num_attention_layers=self.pretrained_config.num_hidden_layers,
             num_rnn_layers=0,
             num_heads=num_heads,
-            hidden_size=self.pretrained_config.hidden_size,
+            hidden_size=hidden_size,
             data_type=torch_dtype_to_binding(
                 self.pretrained_config.torch_dtype))
 
@@ -317,7 +318,7 @@ class ModelConfig(Generic[TConfig]):
         if "head_size" in self.pretrained_config:
             head_size = self.pretrained_config.head_size
         else:
-            head_size = self.pretrained_config.hidden_size // num_heads
+            head_size = hidden_size // num_heads
 
         model_config_cpp.mlp_hidden_size = mlp_hidden_size
         model_config_cpp.size_per_head = head_size

--- a/tests/integration/test_lists/test-db/l0_dgx_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_h100.yml
@@ -17,7 +17,7 @@ l0_dgx_h100:
   # ------------- PyTorch tests ---------------
   - unittest/_torch/multi_gpu
   - unittest/_torch/auto_deploy/unit/multigpu
-  - unittest/llmapi/test_llm_multi_gpu_pytorch.py -m "gpu4"
+  - unittest/llmapi/test_llm_multi_gpu_pytorch.py -m "gpu4 or gpu2"
   - accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_bfloat16_4gpus[tp4-attn_backend=TRTLLM-torch_compile=False]
   - accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_bfloat16_4gpus[tp4-attn_backend=TRTLLM-torch_compile=True]
   - accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_bfloat16_4gpus[tp2pp2-attn_backend=TRTLLM-torch_compile=False]


### PR DESCRIPTION
## Description

1. The torch LoRA TP tests in `unittest/llmapi/test_llm_multi_gpu_pytorch.py` were not running so far on CI because they use just 2 GPUs, while the DGX has 4, and the pytest command line filtered only the tests marked with `@pytest.mark.gpu4`, so I fixed the pytest command line to also run tests marked with `@pytest.mark.gpu2`.
2. Fixed `ModelConfig.get_bindings_model_config` method calculations to be like `gptJsonConfig.cpp::createModelConfig`, as stated in `get_bindings_model_config` docstring.

## Test Coverage

Torch LoRA TP>1 tests:
1. `tests/unittest/llmapi/test_llm_multi_gpu_pytorch.py::test_llama_v2_13b_lora_tp2`
2. `tests/unittest/llmapi/test_llm_multi_gpu_pytorch.py::test_llama_7b_multi_lora_tp2`

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
