### PR TITLE
[TRTLLM-5493] Add core infrastructure to enable loading of custom checkpoint formats

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -23,7 +23,7 @@ services:
 
     volumes:
       - ${SOURCE_DIR}:/workspaces/tensorrt_llm
-      - ${LOCAL_HF_HOME}:/huggingface  # HF cache
+        # - ${LOCAL_HF_HOME}:/huggingface  # HF cache
 
     environment:
       - CCACHE_DIR=/workspaces/tensorrt_llm/cpp/.ccache

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -23,7 +23,7 @@ services:
 
     volumes:
       - ${SOURCE_DIR}:/workspaces/tensorrt_llm
-        # - ${LOCAL_HF_HOME}:/huggingface  # HF cache
+      - ${LOCAL_HF_HOME}:/huggingface  # HF cache
 
     environment:
       - CCACHE_DIR=/workspaces/tensorrt_llm/cpp/.ccache

--- a/tensorrt_llm/_torch/__init__.py
+++ b/tensorrt_llm/_torch/__init__.py
@@ -1,4 +1,5 @@
 from .llm import LLM
 from .model_config import MoeLoadBalancerConfig
+from .models.checkpoints.base_checkpoint_loader import BaseCheckpointLoader
 
-__all__ = ["LLM", "MoeLoadBalancerConfig"]
+__all__ = ["LLM", "MoeLoadBalancerConfig", "BaseCheckpointLoader"]

--- a/tensorrt_llm/_torch/models/checkpoints/__init__.py
+++ b/tensorrt_llm/_torch/models/checkpoints/__init__.py
@@ -1,0 +1,18 @@
+from .base_checkpoint_loader import BaseCheckpointLoader
+from .hf.checkpoint_loader import HfCheckpointLoader
+from .hf.config_loader import HfConfigLoader
+from .hf.gemma3_weight_mapper import Gemma3HfWeightMapper
+from .hf.llama4_weight_mapper import Llama4HfWeightMapper
+from .hf.mixtral_weight_mapper import MixtralHfWeightMapper
+from .hf.nemotron_h_weight_mapper import NemotronHHfWeightMapper
+from .hf.qwen2_moe_weight_mapper import Qwen2MoeHfWeightMapper
+from .hf.qwen3_moe_weight_mapper import Qwen3MoeHfWeightMapper
+from .hf.weight_loader import HfWeightLoader
+from .hf.weight_mapper import HfWeightMapper
+
+__all__ = [
+    "HfConfigLoader", "HfWeightLoader", "HfWeightMapper",
+    "BaseCheckpointLoader", "HfCheckpointLoader", "NemotronHHfWeightMapper",
+    "Gemma3HfWeightMapper", "MixtralHfWeightMapper", "Llama4HfWeightMapper",
+    "Qwen2MoeHfWeightMapper", "Qwen3MoeHfWeightMapper"
+]

--- a/tensorrt_llm/_torch/models/checkpoints/auto_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/auto_mapper.py
@@ -1,0 +1,17 @@
+from typing import Optional
+
+from tensorrt_llm._torch.models.modeling_utils import MODEL_CLASS_MAPPER_MAPPING
+
+
+class AutoCheckpointMapper():
+
+    @staticmethod
+    def get(format: str, name: Optional[str] = None) -> "BaseWeightMapper":
+        if name is not None:
+            try:
+                return MODEL_CLASS_MAPPER_MAPPING[f'{name}_{format}']()
+            except KeyError:  # no mapper for this model architecture, resort to default
+                # TODO smor- a potential bug here, if the class isn't added to __init__, it will return the default mapper
+                return MODEL_CLASS_MAPPER_MAPPING[format]()
+        else:
+            return MODEL_CLASS_MAPPER_MAPPING[format]()

--- a/tensorrt_llm/_torch/models/checkpoints/base_checkpoint_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/base_checkpoint_loader.py
@@ -1,0 +1,87 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+from torch import nn
+
+from tensorrt_llm._torch.model_config import ModelConfig
+from tensorrt_llm._torch.models.checkpoints.auto_mapper import \
+    AutoCheckpointMapper
+from tensorrt_llm._torch.models.checkpoints.base_config_loader import \
+    BaseConfigLoader
+from tensorrt_llm._torch.models.checkpoints.base_weight_loader import \
+    BaseWeightLoader
+from tensorrt_llm._torch.models.checkpoints.base_weight_mapper import \
+    BaseWeightMapper
+from tensorrt_llm._torch.models.modeling_utils import \
+    CHECKPOINT_LOADER_FORMAT_DEFAULT_MAPPING
+
+
+class BaseCheckpointLoader(ABC):
+
+    @abstractmethod
+    def get_default_weight_loader(self) -> BaseWeightLoader:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_default_config_loader(self) -> BaseConfigLoader:
+        raise NotImplementedError
+
+    @abstractmethod
+    def cleanup(self) -> None:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def weight_loader(self) -> BaseWeightLoader:
+        ...
+
+    @property
+    @abstractmethod
+    def weight_mapper(self) -> BaseWeightMapper:
+        ...
+
+    @property
+    @abstractmethod
+    def config_loader(self) -> BaseConfigLoader:
+        ...
+
+    @property
+    @abstractmethod
+    def checkpoint_format(self) -> str:
+        ...
+
+    def load_config(self, checkpoint_dir: str, **kwargs) -> ModelConfig:
+        return self.config_loader.load(checkpoint_dir, **kwargs)
+
+    def load_weights(self, checkpoint_dir: str, **kwargs) -> dict[str, Any]:
+        return self.weight_loader.load_weights(checkpoint_dir, **kwargs)
+
+    @classmethod
+    def get(cls, checkpoint_format: str, **kwargs) -> "BaseCheckpointLoader":
+        try:
+            return CHECKPOINT_LOADER_FORMAT_DEFAULT_MAPPING[checkpoint_format](
+                **kwargs)
+        except KeyError:
+            raise ValueError(
+                f"Checkpoint loader for format {checkpoint_format} not found, "
+                f"available formats are: {CHECKPOINT_LOADER_FORMAT_DEFAULT_MAPPING.keys()}"
+            )
+
+    def get_initilized_weight_mapper(self, model: nn.Module,
+                                     config: ModelConfig) -> BaseWeightMapper:
+        weight_mapper = None
+        if self.weight_mapper is not None:
+            self.weight_mapper.init_model_and_config(model, config)
+            return self.weight_mapper
+        else:
+            # The name of the registered mapper should be the model architecture
+            if config.pretrained_config and config.pretrained_config.architectures:
+                model_arch = config.pretrained_config.architectures[0]
+            else:
+                raise ValueError(
+                    "Cannot determine model architecture from config")
+            weight_mapper = AutoCheckpointMapper.get(self.checkpoint_format,
+                                                     model_arch)
+            weight_mapper.init_model_and_config(model, config)
+            self.weight_mapper = weight_mapper
+            return weight_mapper

--- a/tensorrt_llm/_torch/models/checkpoints/base_config_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/base_config_loader.py
@@ -1,0 +1,13 @@
+from abc import ABC, abstractmethod
+
+from tensorrt_llm._torch.model_config import ModelConfig
+
+
+class BaseConfigLoader(ABC):
+
+    @abstractmethod
+    def load(self, checkpoint_dir: str, **kwargs) -> ModelConfig:
+        pass
+
+    def cleanup(self) -> None:
+        pass

--- a/tensorrt_llm/_torch/models/checkpoints/base_weight_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/base_weight_loader.py
@@ -1,0 +1,20 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class BaseWeightLoader(ABC):
+
+    @abstractmethod
+    def load_weights(self, checkpoint_dir: str) -> dict[str, Any]:
+        """
+        Loads weights from a checkpoint directory.
+
+        Args:
+            checkpoint_dir: A path to the checkpoint directory.
+
+        Returns:
+            A dictionary where keys are tensor names and values are the tensors.
+        """
+
+    def cleanup(self) -> None:
+        pass

--- a/tensorrt_llm/_torch/models/checkpoints/base_weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/base_weight_mapper.py
@@ -1,0 +1,165 @@
+from abc import ABC, abstractmethod
+from typing import Callable, List, Union
+
+from torch import nn
+
+from tensorrt_llm._torch.model_config import ModelConfig, TConfig
+from tensorrt_llm._torch.models.modeling_utils import DecoderModelForCausalLM
+
+
+class BaseWeightMapper(ABC):
+
+    def __init__(self):
+        self._callbacks: list[Callable] = []
+        self._mapping: dict = {}
+        self._skip_modules = []
+        self._model: Union[nn.Module, DecoderModelForCausalLM] | None = None
+        self._config: TConfig | None = None
+
+    def init_model_and_config(self, model: Union[nn.Module,
+                                                 DecoderModelForCausalLM],
+                              config: TConfig):
+        self._model = model
+        self._config = config
+
+        if not hasattr(model, 'model_config') or not isinstance(
+                model.model_config, ModelConfig):
+            raise ValueError("model must have a model_config attribute")
+        if not hasattr(model, 'config'):
+            raise ValueError("model must have a config attribute")
+
+        self._tp_size = 1 if model.model_config.mapping.enable_attention_dp else model.model_config.mapping.tp_size
+        self._num_kv_heads = model.config.num_key_value_heads if hasattr(
+            model.config, 'num_key_value_heads'
+        ) and model.config.num_key_value_heads is not None else model.config.num_attention_heads
+
+        self.map_weights()
+
+    def cleanup(self) -> None:
+        self._model = None
+        self._config = None
+
+    @abstractmethod
+    def map_weights(self) -> None:
+        """
+        Maps weights from TRT-LLM to a source state dictionary (e.g., Hugging Face)
+        """
+
+    @abstractmethod
+    def apply_callbacks(self, module: nn.Module, module_name: str,
+                        module_names_breakdown: list[str],
+                        weights: dict) -> list[dict]:
+        """
+        Applies a series of transformation functions to an internal representation
+        of weights or to guide the mapping process. The exact behavior might depend
+        on the implementation (e.g., storing callbacks to be applied later).
+
+        Args:
+            module: The module to apply the callbacks to
+            module_name: The specific module name (e.g., 'qkv_proj', 'gate_up_proj')
+            module_names_breakdown: List of module path components for building full paths
+            weights: The weights dictionary to process
+        """
+
+    def rename_by_params_map(self, params_map: dict[str, str],
+                             weights: dict) -> dict:
+        """
+        Rename weight keys according to regex pattern matching.
+
+        Args:
+            pattern_mapping: A dictionary mapping regex patterns to replacement strings. The key is HF name pattern, and the value is corresponding TRT-LLM name pattern.
+                The patterns will be used to match keys in the weights dict and replace
+                them according to the replacement string, which can use regex backreferences.
+                Example:
+                HF name: vision_model.encoder.layers.1.self_attn.out_proj.{weight,bias}
+                TRT-LLM name: vision_model.encoder.layers.1.self_attn.o_proj.{weight,bias}
+                Then the pattern_mapping could be:
+                pattern_mapping = {
+                    r'(.*?)out_proj(.*)': r'\1o_proj\2'
+                }
+            weights: A dictionary of weights
+
+        Returns:
+            A dictionary of weights with renamed keys
+        """
+        import re
+
+        # Create a new dictionary to store the renamed weights
+        renamed_weights = {}
+
+        # Keep track of keys that have been matched by a pattern
+        matched_keys = set()
+
+        # Process each key in the weights dictionary
+        for key in list(weights.keys()):
+            # Check each pattern for a match
+            for pattern, replacement in params_map.items():
+                if re.match(pattern, key):
+                    # Create the new key by applying the regex replacement
+                    new_key = re.sub(pattern, replacement, key)
+                    # Store the weight with the new key
+                    renamed_weights[new_key] = weights[key]
+                    matched_keys.add(key)
+                    break
+
+            # If the key wasn't matched by any pattern, keep it as is
+            if key not in matched_keys:
+                renamed_weights[key] = weights[key]
+
+        return renamed_weights
+
+    def preprocess_weights(self, weights: dict) -> dict:
+        """
+        Preprocess weights before starting the loading process.
+        """
+        ...
+
+    def handle_manual_copy(self, module_name: str, module_weights: dict, n: str,
+                           p: nn.Parameter) -> None:
+        p.data.copy_(module_weights[n][:])
+
+    def does_require_special_handling(self, module_name: str) -> bool:
+        return module_name in self.mapping
+
+    def is_special_instance_module(self, module: nn.Module) -> bool:
+        return False
+
+    def handle_special_instance_module(self, module: nn.Module,
+                                       module_name: str,
+                                       module_weights: dict) -> None:
+        raise NotImplementedError()
+
+    @property
+    def skip_modules(self) -> List[str]:
+        return self._skip_modules
+
+    def add_skip_modules(self, value: List[str]) -> None:
+        self._skip_modules.extend(value)
+
+    def should_skip_module(self, module_name: str) -> bool:
+        return any(skip_module in module_name
+                   for skip_module in self._skip_modules)
+
+    def filter_weights(self, prefix: str, weights: dict) -> dict:
+        result = {}
+        for k, v in weights.items():
+            if k.startswith(prefix):
+                new_k = k[len(prefix) + 1:]
+                result[new_k] = v
+        return result
+
+    @property
+    def mapping(self) -> dict:
+        return self._mapping
+
+    @property
+    def config(self) -> TConfig:
+        if self._config is None:
+            raise RuntimeError("Weight mapper is not initialized")
+        return self._config
+
+    @property
+    def model(self) -> Union[nn.Module, DecoderModelForCausalLM]:
+        if self._model is None:
+            raise RuntimeError("Weight mapper is not initialized")
+        return self._model

--- a/tensorrt_llm/_torch/models/checkpoints/hf/checkpoint_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/checkpoint_loader.py
@@ -1,0 +1,75 @@
+from typing import Optional
+
+from tensorrt_llm._torch.models.checkpoints.base_checkpoint_loader import \
+    BaseCheckpointLoader
+from tensorrt_llm._torch.models.checkpoints.base_config_loader import \
+    BaseConfigLoader
+from tensorrt_llm._torch.models.checkpoints.base_weight_loader import \
+    BaseWeightLoader
+from tensorrt_llm._torch.models.checkpoints.base_weight_mapper import \
+    BaseWeightMapper
+from tensorrt_llm._torch.models.checkpoints.hf.config_loader import \
+    HfConfigLoader
+from tensorrt_llm._torch.models.checkpoints.hf.weight_loader import \
+    HfWeightLoader
+from tensorrt_llm._torch.models.modeling_utils import register_checkpoint_loader
+
+
+@register_checkpoint_loader("HF")
+class HfCheckpointLoader(BaseCheckpointLoader):
+
+    def __init__(self,
+                 *,
+                 weight_loader: Optional[BaseWeightLoader] = None,
+                 weight_mapper: Optional[BaseWeightMapper] = None,
+                 config_loader: Optional[BaseConfigLoader] = None):
+        if weight_loader is None:
+            self._weight_loader = self.get_default_weight_loader()
+        else:
+            self._weight_loader = weight_loader
+        if config_loader is None:
+            self._config_loader = self.get_default_config_loader()
+        else:
+            self._config_loader = config_loader
+        self._weight_mapper = weight_mapper
+        self._checkpoint_format = "HF"
+
+    def cleanup(self) -> None:
+        # Clean up weight mapper first as it may hold model references
+        if self._weight_mapper is not None:
+            self._weight_mapper.cleanup()
+            self._weight_mapper = None
+
+        if self._weight_loader is not None:
+            self._weight_loader.cleanup()
+            self._weight_loader = None
+
+        if self._config_loader is not None:
+            self._config_loader.cleanup()
+            self._config_loader = None
+
+    def get_default_weight_loader(self) -> HfWeightLoader:
+        return HfWeightLoader()
+
+    def get_default_config_loader(self) -> HfConfigLoader:
+        return HfConfigLoader()
+
+    @property
+    def weight_loader(self) -> BaseWeightLoader:
+        return self._weight_loader
+
+    @property
+    def weight_mapper(self) -> Optional[BaseWeightMapper]:
+        return self._weight_mapper
+
+    @weight_mapper.setter
+    def weight_mapper(self, value: BaseWeightMapper) -> None:
+        self._weight_mapper = value
+
+    @property
+    def config_loader(self) -> Optional[BaseConfigLoader]:
+        return self._config_loader
+
+    @property
+    def checkpoint_format(self) -> str:
+        return self._checkpoint_format

--- a/tensorrt_llm/_torch/models/checkpoints/hf/config_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/config_loader.py
@@ -1,0 +1,11 @@
+from tensorrt_llm._torch.model_config import ModelConfig
+from tensorrt_llm._torch.models.checkpoints.base_config_loader import \
+    BaseConfigLoader
+from tensorrt_llm._torch.models.modeling_utils import register_config_loader
+
+
+@register_config_loader("HF")
+class HfConfigLoader(BaseConfigLoader):
+
+    def load(self, checkpoint_dir: str, **kwargs) -> ModelConfig:
+        return ModelConfig.from_pretrained(checkpoint_dir, **kwargs)

--- a/tensorrt_llm/_torch/models/checkpoints/hf/gemma3_weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/gemma3_weight_mapper.py
@@ -1,0 +1,34 @@
+from torch import nn
+
+from tensorrt_llm._torch.models.checkpoints.hf.weight_mapper import \
+    HfWeightMapper
+from tensorrt_llm._torch.models.modeling_utils import register_mapper
+
+
+@register_mapper("HF", "Gemma3ForCausalLM")
+class Gemma3HfWeightMapper(HfWeightMapper):
+
+    def should_skip_module(self, module_name: str) -> bool:
+        if self.model.config.tie_word_embeddings and module_name.startswith(
+                "lm_head"):
+            return True
+
+        # Skip loading weights for embedding and lm_head if LoRA is enabled and has custom values
+        if hasattr(self.model, "model") and hasattr(
+                self.model.model, 'has_custom_embed_tokens'
+        ) and self.model.model.has_custom_embed_tokens and module_name == "model.embed_tokens":
+            return True
+        if hasattr(
+                self.model, 'has_custom_lm_head'
+        ) and self.model.has_custom_lm_head and module_name == "lm_head":
+            return True
+
+        return any(skip_module in module_name
+                   for skip_module in self._skip_modules)
+
+    def handle_manual_copy(self, module_name: str, module_weights: dict, n: str,
+                           p: nn.Parameter) -> None:
+        if 'norm' in module_name:
+            p.data.copy_(module_weights[n][:] + 1)
+        else:
+            super().handle_manual_copy(module_name, module_weights, n, p)

--- a/tensorrt_llm/_torch/models/checkpoints/hf/llama4_weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/llama4_weight_mapper.py
@@ -1,0 +1,22 @@
+from tensorrt_llm._torch.models.checkpoints.hf.weight_mapper import \
+    HfWeightMapper
+from tensorrt_llm._torch.models.modeling_utils import register_mapper
+
+
+@register_mapper("HF", "Llama4ForConditionalGeneration")
+class Llama4HfWeightMapper(HfWeightMapper):
+    """
+    Weight mapper for Llama4ForConditionalGeneration that handles the
+    'language_model.' prefix removal from weight keys.
+    """
+
+    def filter_weights(self, prefix: str, weights: dict) -> dict:
+        transformed_weights = {}
+        for key, value in weights.items():
+            if key.startswith("language_model."):
+                new_key = key[len("language_model."):]
+                transformed_weights[new_key] = value
+            else:
+                transformed_weights[key] = value
+
+        return super().filter_weights(prefix, transformed_weights)

--- a/tensorrt_llm/_torch/models/checkpoints/hf/mixtral_weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/mixtral_weight_mapper.py
@@ -1,0 +1,26 @@
+from torch import nn
+
+from tensorrt_llm._torch.models.checkpoints.base_weight_mapper import \
+    BaseWeightMapper
+from tensorrt_llm._torch.models.modeling_utils import register_mapper
+
+
+@register_mapper("HF", "MixtralForCausalLM")
+class MixtralHfWeightMapper(BaseWeightMapper):
+
+    def map_weights(self) -> None:
+        self.mapping.update({
+            'qkv_proj': ['q_proj', 'k_proj', 'v_proj'],
+        })
+
+    def apply_callbacks(self, module: nn.Module, module_name: str,
+                        module_names_breakdown: list[str],
+                        weights: dict) -> list[dict]:
+        module_weights = []
+
+        for new_name in self.mapping[module_name]:
+            fw = self.filter_weights(
+                '.'.join(module_names_breakdown + [new_name]), weights)
+            module_weights.append(fw)
+
+        return module_weights

--- a/tensorrt_llm/_torch/models/checkpoints/hf/nemotron_h_weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/nemotron_h_weight_mapper.py
@@ -1,0 +1,99 @@
+import torch
+
+from tensorrt_llm._torch.models.checkpoints.hf.weight_mapper import \
+    HfWeightMapper
+from tensorrt_llm._torch.models.modeling_nemotron_h import split
+from tensorrt_llm._torch.models.modeling_utils import register_mapper
+
+
+@register_mapper("HF", "NemotronHForCausalLM")
+class NemotronHHfWeightMapper(HfWeightMapper):
+
+    def preprocess_weights(self, weights: dict) -> dict:
+        config = self.config.pretrained_config
+        tp_size = self.config.mapping.tp_size
+        tp_rank = self.config.mapping.tp_rank
+        d_inner = config.hidden_size * config.expand
+        n_groups = config.n_groups
+        d_state = config.ssm_state_size
+        nheads = d_inner // config.mamba_head_dim
+
+        new_weights = {}
+        for name, _ in weights.items():
+            key = name
+
+            # change backbone root name to model
+            if "backbone" in key:
+                key = key.replace("backbone", "model")
+
+            # change embedding layer to embed_token
+            if "embeddings" in key:
+                key = key.replace("embeddings", "embed_tokens")
+
+            if "A_log" in key:
+                key = key.replace("A_log", "A")
+
+            if "_scale" in key and weights[name].dim() == 0:
+                new_weights[key] = weights[name]
+            elif "A" in key:
+                w = split(weights[name], tp_size, tp_rank)
+                w = w.to(torch.float32)
+                w = -torch.exp(w)
+                new_weights[key] = w
+            elif "D" in key:
+                w = split(weights[name], tp_size, tp_rank)
+                w = w.to(torch.float32)
+                new_weights[key] = w
+            elif "dt_bias" in key:
+                w = split(weights[name], tp_size, tp_rank)
+                w = w.to(torch.float32)
+                new_weights[key] = w
+            elif "mixer.in_proj" in key:
+                w = weights[name]
+                in_proj_z, in_proj_x, in_proj_b, in_proj_c, in_proj_dt = torch.split(
+                    w, [
+                        d_inner, d_inner, n_groups * d_state,
+                        n_groups * d_state, nheads
+                    ],
+                    dim=0)
+
+                w = []
+                for rank in range(tp_size):
+                    in_proj_z_rank = split(in_proj_z, tp_size, rank)
+                    in_proj_x_rank = split(in_proj_x, tp_size, rank)
+                    in_proj_b_rank = split(in_proj_b, tp_size, rank)
+                    in_proj_c_rank = split(in_proj_c, tp_size, rank)
+                    in_proj_dt_rank = split(in_proj_dt, tp_size, rank)
+                    y = torch.concat([
+                        in_proj_z_rank, in_proj_x_rank, in_proj_b_rank,
+                        in_proj_c_rank, in_proj_dt_rank
+                    ])
+                    w.append(y)
+
+                w = torch.concat(w).contiguous()
+                new_weights[key] = w
+            elif "conv1d" in key:
+                w = weights[name]
+                # removing dim(1) because we are using Linear to store conv1d weights
+                if "weight" in key:
+                    w = w.squeeze(1)
+
+                conv_x, conv_b, conv_c = torch.split(
+                    w, [d_inner, n_groups * d_state, n_groups * d_state], dim=0)
+
+                w = []
+                for rank in range(tp_size):
+                    conv_x_rank = split(conv_x, tp_size, rank)
+                    conv_b_rank = split(conv_b, tp_size, rank)
+                    conv_c_rank = split(conv_c, tp_size, rank)
+                    y = torch.concat([conv_x_rank, conv_b_rank, conv_c_rank])
+                    w.append(y)
+                w = torch.concat(w).contiguous()
+                new_weights[key] = w
+            elif "mixer.norm.weight" in key:
+                w = split(weights[name], tp_size, tp_rank)
+                new_weights[key] = w
+            else:
+                new_weights[key] = weights[name]
+
+        return new_weights

--- a/tensorrt_llm/_torch/models/checkpoints/hf/qwen2_moe_weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/qwen2_moe_weight_mapper.py
@@ -1,0 +1,26 @@
+from torch import nn
+
+from tensorrt_llm._torch.models.checkpoints.hf.weight_mapper import \
+    HfWeightMapper
+from tensorrt_llm._torch.models.modeling_utils import register_mapper
+from tensorrt_llm._torch.modules.fused_moe.interface import MoE
+
+
+@register_mapper("HF", "Qwen2MoeForCausalLM")
+class Qwen2MoeHfWeightMapper(HfWeightMapper):
+
+    def is_special_instance_module(self, module: nn.Module) -> bool:
+        return isinstance(module, MoE)
+
+    def handle_special_instance_module(self, module: nn.Module,
+                                       module_name: str,
+                                       module_weights: dict) -> None:
+        if isinstance(module, MoE):
+            updated_module_weights = {}
+            for weight_name, weight_value in module_weights.items():
+                new_weight_name = weight_name.replace(
+                    "gate_proj", "w1").replace("up_proj",
+                                               "w3").replace("down_proj", "w2")
+                updated_module_weights[new_weight_name] = weight_value
+            del module_weights
+            module.load_weights(weights=[updated_module_weights])

--- a/tensorrt_llm/_torch/models/checkpoints/hf/qwen3_moe_weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/qwen3_moe_weight_mapper.py
@@ -1,0 +1,39 @@
+from torch import nn
+
+from tensorrt_llm._torch.models.checkpoints.hf.qwen2_moe_weight_mapper import \
+    Qwen2MoeHfWeightMapper
+from tensorrt_llm._torch.models.modeling_utils import register_mapper
+
+
+@register_mapper("HF", "Qwen3MoeForCausalLM")
+class Qwen3MoeHfWeightMapper(Qwen2MoeHfWeightMapper):
+
+    def should_skip_module(self, module_name: str) -> bool:
+        if module_name.startswith("draft_model"):
+            return True
+        return super().should_skip_module(module_name)
+
+    def _duplicate_kv_weights(self, module: nn.Module, new_name: str,
+                              weights: dict):
+        tensors_to_duplicate = ["weight", "bias"]
+        if module.quant_config.quant_mode.has_nvfp4():
+            tensors_to_duplicate.append("weight_scale")
+        if module.quant_config.quant_mode.has_fp8_block_scales():
+            tensors_to_duplicate.append("weight_scale_inv")
+
+        if new_name in ['k_proj', 'v_proj']:
+            num_kv_heads_list = [self._num_kv_heads
+                                 ] * len(weights) if isinstance(
+                                     self._num_kv_heads,
+                                     int) else self._num_kv_heads
+            processed_weights = {
+                k:
+                self._duplicate_kv(weight=v[:],
+                                   num_kv_heads=num_kv_heads_list[i],
+                                   tensor_parallel_size=self._tp_size)
+                if k in tensors_to_duplicate else v
+                for i, (k, v) in enumerate(weights.items())
+            }
+            return processed_weights
+
+        return weights

--- a/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
@@ -1,0 +1,123 @@
+import glob
+import multiprocessing
+import os
+from typing import Any, List
+
+import psutil
+import safetensors
+import torch
+import tqdm
+
+from tensorrt_llm._torch.models.checkpoints.base_weight_loader import \
+    BaseWeightLoader
+from tensorrt_llm._torch.models.modeling_utils import (
+    register_checkpoint_weight_loader, run_concurrently)
+from tensorrt_llm._utils import local_mpi_rank, local_mpi_size
+from tensorrt_llm.logger import logger
+
+
+@register_checkpoint_weight_loader("HF")
+class HfWeightLoader(BaseWeightLoader):
+    """
+    Loads weights from SafeTensors/bin/pth files.
+    """
+
+    def load_weights(self, checkpoint_dir: str) -> dict[str, Any]:
+        weight_files = glob.glob(f"{checkpoint_dir}/*.safetensors")
+        if weight_files:
+            # Prefetch the weight files to CPU memory if the size is less than 90% of the available memory.
+            # This is a heuristic to avoid prefetching files that are too large and causing file cache thrashing.
+            prefetch_size = sum(os.path.getsize(file) for file in weight_files)
+            # If the layer number is overridden, it indicates that only a subset of layers are loaded.
+            # Prefetching all layers is unnecessary.
+            num_layers = int(os.environ.get("TLLM_OVERRIDE_LAYER_NUM", "0"))
+            enable_prefetch = prefetch_size < psutil.virtual_memory(
+            ).available * 0.9 and num_layers == 0
+            if enable_prefetch:
+                logger.info(
+                    f"Prefetching {prefetch_size / (1024**3):.2f}GB checkpoint files."
+                )
+                self.prefetch_files(weight_files)
+
+            return self._load_weights_in_parallel(
+                weight_files, self._load_safetensors_file,
+                "Loading safetensors weights in parallel")
+
+        weight_files = glob.glob(f"{checkpoint_dir}/*.bin")
+        if not weight_files:
+            weight_files = glob.glob(f"{checkpoint_dir}/*.pth")
+
+        if weight_files:
+            return self._load_weights_in_parallel(
+                weight_files, self._load_bin_or_path_file,
+                "Loading bin weights in parallel")
+
+        raise RuntimeError(f"No weight files found in {checkpoint_dir}.")
+
+    def _load_weights_in_parallel(self, weight_files: List[str], load_func,
+                                  description: str) -> dict[str, Any]:
+        """
+        Load weight files in parallel using the specified loading function.
+
+        Args:
+            weight_files: List of weight file paths
+            load_func: Function to load individual weight files
+            description: Description for the progress bar
+
+        Returns:
+            Dictionary containing all loaded weights
+        """
+        weights = {}
+        pbar = tqdm.tqdm(total=len(weight_files), desc=description)
+
+        # Note that the function is called with a tuple of arguments, hence we need to wrap the arguments in a tuple via [(w,) for w in weight_files]
+        # specifically the comma right after the w is important to make it a tuple.
+        run_concurrently(load_func, [(w, ) for w in weight_files],
+                         reduce_func=weights.update,
+                         pbar=pbar)
+
+        return weights
+
+    @staticmethod
+    def _load_safetensors_file(file):
+        return safetensors.torch.load_file(file)
+
+    @staticmethod
+    def _load_bin_or_path_file(file):
+        try:
+            part_weights = torch.load(file,
+                                      weights_only=True,
+                                      map_location='cpu',
+                                      mmap=True)
+        except Exception:
+            logger.warning(
+                f"Failed to load {file} with mmap=True, fallback to mmap=False")
+            part_weights = torch.load(file,
+                                      weights_only=True,
+                                      map_location='cpu',
+                                      mmap=False)
+        finally:
+            return part_weights
+
+    def _prefetch_one_file(self, file_name):
+        if os.path.exists(file_name):
+            logger.info(f"Prefetching {file_name} to memory...")
+            with open(file_name, 'rb') as f:
+                f.read()
+            logger.info(f"Finished prefetching {file_name}.")
+
+    def prefetch_files(self, file_names: List[str]):
+        """
+        Prefetch safetensors files to memory so that the weight loading will be much faster.
+        When multiple ranks run in parallel, each rank will prefetch some files.
+        """
+        # Find out the files to prefetch for the current rank.
+        # Each rank loads files with indices local_rank, local_rank + local_mpi_size, local_rank + 2*local_mpi_size, etc.
+        local_file_names = file_names[local_mpi_rank()::local_mpi_size()]
+        if len(local_file_names) == 0:
+            return
+
+        max_processes = min(multiprocessing.cpu_count() * 2, 16,
+                            len(local_file_names))
+        with multiprocessing.Pool(processes=max_processes) as pool:
+            pool.map(self._prefetch_one_file, local_file_names)

--- a/tensorrt_llm/_torch/models/checkpoints/hf/weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/weight_mapper.py
@@ -1,0 +1,101 @@
+import torch
+from torch import nn
+
+from tensorrt_llm._torch.models.modeling_utils import register_mapper
+
+from ..base_weight_mapper import BaseWeightMapper
+
+
+@register_mapper("HF")
+class HfWeightMapper(BaseWeightMapper):
+
+    def __init__(self):
+        super().__init__()
+        self._callbacks = [
+            self._duplicate_kv_weights,
+        ]
+
+    def map_weights(self) -> None:
+        self.mapping.update({
+            'qkv_proj': ['q_proj', 'k_proj', 'v_proj'],
+            'gate_up_proj': ['gate_proj', 'up_proj']
+        })
+
+    def apply_callbacks(self, module: nn.Module, module_name: str,
+                        module_names_breakdown: list[str],
+                        weights: dict) -> list[dict]:
+        module_weights = []
+
+        for new_name in self._mapping[module_name]:
+            fw = self.filter_weights(
+                '.'.join(module_names_breakdown + [new_name]), weights)
+            for callback in self._callbacks:
+                fw = callback(module, new_name, fw)
+            module_weights.append(fw)
+
+        return module_weights
+
+    def should_skip_module(self, module_name: str) -> bool:
+        if self.model.config.tie_word_embeddings and module_name.startswith(
+                "lm_head"):
+            return True
+
+        # Skip loading weights for embedding and lm_head if LoRA is enabled and has custom values
+        if hasattr(self.model, "model") and hasattr(
+                self.model.model, 'has_custom_embed_tokens'
+        ) and self.model.model.has_custom_embed_tokens and module_name == "model.embed_tokens":
+            return True
+        if hasattr(
+                self.model, 'has_custom_lm_head'
+        ) and self.model.has_custom_lm_head and module_name == "lm_head":
+            return True
+
+        # WAR: better solution is that llama has its own load_weights function.
+        if module_name.split('.')[-1] == 'next_layer_layernorm':
+            return True
+
+        return super().should_skip_module(module_name)
+
+    def _duplicate_kv_weights(self, module: nn.Module, new_name: str,
+                              weights: dict):
+        if new_name in ['k_proj', 'v_proj']:
+            num_kv_heads_list = [self._num_kv_heads
+                                 ] * len(weights) if isinstance(
+                                     self._num_kv_heads,
+                                     int) else self._num_kv_heads
+            processed_weights = {
+                k:
+                self._duplicate_kv(weight=v[:],
+                                   num_kv_heads=num_kv_heads_list[i],
+                                   tensor_parallel_size=self._tp_size)
+                if k in ["weight", "bias"] else v
+                for i, (k, v) in enumerate(weights.items())
+            }
+            return processed_weights
+
+        return weights
+
+    def _duplicate_kv(self, weight: torch.Tensor, num_kv_heads: int,
+                      tensor_parallel_size: int):
+
+        if num_kv_heads >= tensor_parallel_size:
+            assert num_kv_heads % tensor_parallel_size == 0
+            return weight
+
+        assert tensor_parallel_size % num_kv_heads == 0
+        reps = tensor_parallel_size // num_kv_heads
+
+        # bias
+        if weight.ndim == 1:
+            return weight.repeat_interleave(reps)
+
+        # weight and scale
+        assert weight.shape[0] % num_kv_heads == 0
+        size_per_kv_head = weight.shape[0] // num_kv_heads
+        weight = weight.reshape(num_kv_heads, size_per_kv_head,
+                                -1)[:,
+                                    None, :, :].expand(num_kv_heads, reps,
+                                                       size_per_kv_head,
+                                                       weight.shape[1])
+        return weight.reshape(num_kv_heads * reps * size_per_kv_head,
+                              -1).clone().detach()

--- a/tensorrt_llm/_torch/models/modeling_gemma3.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma3.py
@@ -3,10 +3,11 @@ from typing import Dict, Optional, Tuple
 
 import torch
 from torch import nn
-from tqdm import tqdm
 from transformers import Gemma3TextConfig
 from transformers.activations import ACT2FN
 
+from tensorrt_llm._torch.models.checkpoints.base_weight_mapper import \
+    BaseWeightMapper
 from tensorrt_llm.functional import PositionEmbeddingType, RotaryScalingType
 from tensorrt_llm.mapping import Mapping
 
@@ -23,7 +24,6 @@ from ..modules.linear import Linear, TensorParallelMode
 from ..modules.multi_stream_utils import maybe_execute_in_parallel
 from ..modules.rms_norm import RMSNorm
 from .modeling_utils import (DecoderModel, DecoderModelForCausalLM,
-                             duplicate_kv_weight, filter_weights,
                              register_auto_model)
 
 
@@ -486,61 +486,5 @@ class Gemma3ForCausalLM(DecoderModelForCausalLM[Gemma3TextModel,
             return_context_logits,
         )
 
-    # This is a modified version of the load_weights function in modeling_utils.py with the
-    # minor change for Gemma3 RMSNorm.
-    def load_weights(self, weights: Dict):
-        tp_size = self.model_config.mapping.tp_size
-        num_kv_heads = self.config.num_key_value_heads
-
-        params_map = {
-            'qkv_proj': ['q_proj', 'k_proj', 'v_proj'],
-            'gate_up_proj': ['gate_proj', 'up_proj']
-        }
-
-        for name, module in tqdm(list(self.named_modules()),
-                                 desc="Loading weights"):
-            if len(module._parameters) > 0:
-                # skip load weights if tie word embeddings is enabled and layer is lm_head
-                if self.config.tie_word_embeddings and name.startswith(
-                        "lm_head"):
-                    continue
-
-                # Skip loading weights for embedding and lm_head if LoRA is enabled.
-                if hasattr(
-                        self.model_config, 'lora_config'
-                ) and self.model_config.lora_config is not None and len(
-                        self.model_config.lora_config.lora_dir) == 1 and (
-                            name == "model.embed_tokens" or name == "lm_head"):
-                    continue
-
-                names = name.split('.')
-                if names[-1] in params_map:
-                    module_weights = []
-                    for new_name in params_map[names[-1]]:
-                        fw = filter_weights('.'.join(names[:-1] + [new_name]),
-                                            weights)
-                        if new_name in ['k_proj', 'v_proj']:
-                            fw = {
-                                k:
-                                duplicate_kv_weight(
-                                    weight=v[:],
-                                    num_kv_heads=num_kv_heads,
-                                    tensor_parallel_size=tp_size)
-                                if k in ["weight", "bias"] else v
-                                for k, v in fw.items()
-                            }
-
-                        module_weights.append(fw)
-                    module.load_weights(weights=module_weights)
-                else:
-                    module_weights = filter_weights(name, weights)
-                    if hasattr(module, 'load_weights'):
-                        module.load_weights(weights=[module_weights])
-                    else:
-                        for n, p in module._parameters.items():
-                            if p is not None:
-                                # Gemma3 RMSNorm uses +1 just like LayerNorm-1P.
-                                if 'norm' in names[-1]:
-                                    p.data.copy_(module_weights[n][:] + 1)
-                                else:
-                                    p.data.copy_(module_weights[n][:])
+    def load_weights(self, weights: Dict, weight_mapper: BaseWeightMapper):
+        super().load_weights(weights, weight_mapper)

--- a/tensorrt_llm/_torch/models/modeling_llama.py
+++ b/tensorrt_llm/_torch/models/modeling_llama.py
@@ -11,6 +11,8 @@ from transformers.models.llama4.modeling_llama4 import Llama4MultiModalProjector
 
 from tensorrt_llm._torch.distributed import (AllReduce, AllReduceFusionOp,
                                              AllReduceParams, MoEAllReduce)
+from tensorrt_llm._torch.models.checkpoints.base_weight_mapper import \
+    BaseWeightMapper
 from tensorrt_llm.functional import PositionEmbeddingType
 from tensorrt_llm.logger import logger
 from tensorrt_llm.lora_manager import HfLoraLoader
@@ -917,16 +919,8 @@ class Llama4ForConditionalGeneration(SpecDecOneEngineForCausalLM[Llama4Model,
 
         return super().infer_max_seq_len()
 
-    def load_weights(self, weights: Dict):
-        new_weights = {}
-        for key, tensor in weights.items():
-            if key.startswith("language_model."):
-                new_key = key[len("language_model."):]
-                new_weights[new_key] = tensor
-            else:
-                new_weights[key] = tensor
-
-        super().load_weights(new_weights)
+    def load_weights(self, weights: Dict, weight_mapper: BaseWeightMapper):
+        super().load_weights(weights, weight_mapper)
 
         for idx, layer in enumerate(
                 self.model.layers[:self.config.num_hidden_layers]):

--- a/tensorrt_llm/_torch/models/modeling_mixtral.py
+++ b/tensorrt_llm/_torch/models/modeling_mixtral.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Optional
 
 import torch
 from torch import nn
@@ -16,7 +16,7 @@ from ..modules.fused_moe import RenormalizeMoeRoutingMethod, create_moe
 from ..modules.linear import Linear
 from ..modules.rms_norm import RMSNorm
 from .modeling_utils import (DecoderModel, DecoderModelForCausalLM,
-                             filter_weights, register_auto_model)
+                             register_auto_model)
 
 
 class MixtralMoE(nn.Module):
@@ -215,27 +215,3 @@ class MixtralForCausalLM(DecoderModelForCausalLM[MixtralModel,
                          config=model_config,
                          hidden_size=model_config.pretrained_config.hidden_size,
                          vocab_size=model_config.pretrained_config.vocab_size)
-
-    def load_weights(self, weights: Dict):
-
-        params_map = {
-            'qkv_proj': ['q_proj', 'k_proj', 'v_proj'],
-        }
-
-        for name, module in self.named_modules():
-            if len(module._parameters) > 0:
-                names = name.split('.')
-                if names[-1] in params_map:
-                    module_weights = []
-                    for new_name in params_map[names[-1]]:
-                        module_weights.append(
-                            filter_weights('.'.join(names[:-1] + [new_name]),
-                                           weights))
-                    module.load_weights(weights=module_weights)
-                else:
-                    module_weights = filter_weights(name, weights)
-                    if hasattr(module, 'load_weights'):
-                        module.load_weights(weights=[module_weights])
-                    else:
-                        for n, p in module.named_parameters():
-                            p.data.copy_(module_weights[n][:])

--- a/tensorrt_llm/_torch/models/modeling_nemotron_h.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_h.py
@@ -13,13 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, Optional
+from typing import Optional
 
 import torch
 from torch import nn
 from torch.nn import functional as F
 from transformers import AutoConfig, PretrainedConfig
 
+from tensorrt_llm._torch.models.checkpoints.base_weight_mapper import \
+    BaseWeightMapper
 from tensorrt_llm._torch.modules.mamba.mamba2_metadata import Mamba2Metadata
 
 from ..attention_backend import AttentionMetadata
@@ -254,94 +256,9 @@ class NemotronHForCausalLM(DecoderModelForCausalLM[NemotronHModel,
             vocab_size=model_config.pretrained_config.vocab_size,
         )
 
-    def load_weights(self, weights: Dict):
-        config = self.model_config.pretrained_config
-        tp_size = self.model_config.mapping.tp_size
-        tp_rank = self.model_config.mapping.tp_rank
-        d_inner = config.hidden_size * config.expand
-        n_groups = config.n_groups
-        d_state = config.ssm_state_size
-        nheads = d_inner // config.mamba_head_dim
-
-        new_weights = {}
-        for name, params in weights.items():
-            key = name
-
-            # change backbone root name to model
-            if "backbone" in key:
-                key = key.replace("backbone", "model")
-
-            # change embedding layer to embed_token
-            if "embeddings" in key:
-                key = key.replace("embeddings", "embed_tokens")
-
-            if "A_log" in key:
-                key = key.replace("A_log", "A")
-
-            if "_scale" in key and weights[name].dim() == 0:
-                new_weights[key] = weights[name]
-            elif "A" in key:
-                w = split(weights[name], tp_size, tp_rank)
-                w = w.to(torch.float32)
-                w = -torch.exp(w)
-                new_weights[key] = w
-            elif "D" in key:
-                w = split(weights[name], tp_size, tp_rank)
-                w = w.to(torch.float32)
-                new_weights[key] = w
-            elif "dt_bias" in key:
-                w = split(weights[name], tp_size, tp_rank)
-                w = w.to(torch.float32)
-                new_weights[key] = w
-            elif "mixer.in_proj" in key:
-                w = weights[name]
-                in_proj_z, in_proj_x, in_proj_b, in_proj_c, in_proj_dt = torch.split(
-                    w, [
-                        d_inner, d_inner, n_groups * d_state,
-                        n_groups * d_state, nheads
-                    ],
-                    dim=0)
-
-                w = []
-                for rank in range(tp_size):
-                    in_proj_z_rank = split(in_proj_z, tp_size, rank)
-                    in_proj_x_rank = split(in_proj_x, tp_size, rank)
-                    in_proj_b_rank = split(in_proj_b, tp_size, rank)
-                    in_proj_c_rank = split(in_proj_c, tp_size, rank)
-                    in_proj_dt_rank = split(in_proj_dt, tp_size, rank)
-                    y = torch.concat([
-                        in_proj_z_rank, in_proj_x_rank, in_proj_b_rank,
-                        in_proj_c_rank, in_proj_dt_rank
-                    ])
-                    w.append(y)
-
-                w = torch.concat(w).contiguous()
-                new_weights[key] = w
-            elif "conv1d" in key:
-                w = weights[name]
-                # removing dim(1) because we are using Linear to store conv1d weights
-                if "weight" in key:
-                    w = w.squeeze(1)
-
-                conv_x, conv_b, conv_c = torch.split(
-                    w, [d_inner, n_groups * d_state, n_groups * d_state], dim=0)
-
-                w = []
-                for rank in range(tp_size):
-                    conv_x_rank = split(conv_x, tp_size, rank)
-                    conv_b_rank = split(conv_b, tp_size, rank)
-                    conv_c_rank = split(conv_c, tp_size, rank)
-                    y = torch.concat([conv_x_rank, conv_b_rank, conv_c_rank])
-                    w.append(y)
-                w = torch.concat(w).contiguous()
-                new_weights[key] = w
-            elif "mixer.norm.weight" in key:
-                w = split(weights[name], tp_size, tp_rank)
-                new_weights[key] = w
-            else:
-                new_weights[key] = weights[name]
-
-        super().load_weights(new_weights)
+    def load_weights(self, weights: dict, weight_mapper: BaseWeightMapper):
+        new_weights = weight_mapper.preprocess_weights(weights)
+        super().load_weights(new_weights, weight_mapper)
 
 
 AutoConfig.register(NemotronHConfig.model_type, NemotronHConfig)

--- a/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
@@ -3,8 +3,10 @@ from typing import Dict, List, Optional
 
 import torch
 from torch import nn
-from tqdm import tqdm
 from transformers import Qwen3MoeConfig
+
+from tensorrt_llm._torch.models.checkpoints.base_weight_mapper import \
+    BaseWeightMapper
 
 from ..attention_backend import AttentionMetadata
 from ..distributed import (AllReduce, AllReduceFusionOp, AllReduceParams,
@@ -12,7 +14,7 @@ from ..distributed import (AllReduce, AllReduceFusionOp, AllReduceParams,
 from ..model_config import ModelConfig
 from ..modules.decoder_layer import DecoderLayer
 from ..modules.embedding import Embedding
-from ..modules.fused_moe import (BaseMoeRoutingMethod, CutlassFusedMoE, MoE,
+from ..modules.fused_moe import (BaseMoeRoutingMethod, CutlassFusedMoE,
                                  RenormalizeMoeRoutingMethod,
                                  RenormalizeNaiveMoeRoutingMethod,
                                  RoutingMethodType, TRTLLMGenFusedMoE,
@@ -23,9 +25,7 @@ from ..speculative import SpecMetadata
 from ..utils import disable_fp4_allgather
 from .modeling_qwen3 import Qwen3Attention
 from .modeling_speculative import SpecDecOneEngineForCausalLM
-from .modeling_utils import (DecoderModel, EagerFusionConfig,
-                             duplicate_kv_weight, filter_weights,
-                             register_auto_model)
+from .modeling_utils import DecoderModel, EagerFusionConfig, register_auto_model
 
 
 class Qwen3Gate(nn.Module):
@@ -394,67 +394,9 @@ class Qwen3MoeForCausalLM(SpecDecOneEngineForCausalLM[Qwen3MoEModel,
             model_config,
         )
 
-    def load_weights(self, weights: Dict):
-        tp_size = self.model_config.mapping.tp_size
-        enable_attention_dp = self.model_config.mapping.enable_attention_dp
+    def load_weights(self, weights: dict, weight_mapper: BaseWeightMapper):
+        super().load_weights(weights, weight_mapper)
 
-        num_kv_heads = self.config.num_key_value_heads
-
-        params_map = {
-            "qkv_proj": ["q_proj", "k_proj", "v_proj"],
-            "gate_up_proj": ["gate_proj", "up_proj"]
-        }
-        for name, module in tqdm(list(self.named_modules()),
-                                 desc="Loading weights"):
-            if len(module._parameters) > 0:
-                # skip load weights if tie word embeddings is enabled and layer is lm_head
-                if self.config.tie_word_embeddings and name.startswith(
-                        "lm_head") or name.startswith("draft_model"):
-                    continue
-
-                names = name.split(".")
-                if names[-1] in params_map:
-                    module_weights = []
-                    for new_name in params_map[names[-1]]:
-                        fw = filter_weights(".".join(names[:-1] + [new_name]),
-                                            weights)
-                        tensors_need_duplication = ["weight", "bias"]
-                        if module.quant_config.quant_mode.has_nvfp4():
-                            tensors_need_duplication.append("weight_scale")
-                        if module.quant_config.quant_mode.has_fp8_block_scales(
-                        ):
-                            tensors_need_duplication.append("weight_scale_inv")
-                        if new_name in ["k_proj", "v_proj"]:
-                            fw = {
-                                k: (duplicate_kv_weight(
-                                    weight=v[:],
-                                    num_kv_heads=num_kv_heads,
-                                    tensor_parallel_size=tp_size
-                                    if not enable_attention_dp else 1)
-                                    if k in tensors_need_duplication else v)
-                                for k, v in fw.items()
-                            }
-                        module_weights.append(fw)
-                    module.load_weights(weights=module_weights)
-                else:
-                    module_weights = filter_weights(name, weights)
-                    if isinstance(module, MoE):
-                        updated_module_weights = {}
-                        for weight_name, weight_value in module_weights.items():
-                            new_weight_name = (weight_name.replace(
-                                "gate_proj",
-                                "w1").replace("up_proj",
-                                              "w3").replace("down_proj", "w2"))
-                            updated_module_weights[
-                                new_weight_name] = weight_value
-                        del module_weights
-                        module.load_weights(weights=[updated_module_weights])
-                    elif hasattr(module, "load_weights"):
-                        module.load_weights(weights=[module_weights])
-                    else:
-                        for n, p in module._parameters.items():
-                            if p is not None:
-                                p.data.copy_(module_weights[n][:])
         for idx, layer in enumerate(
                 self.model.layers[:self.config.num_hidden_layers]):
             if idx == self.config.num_hidden_layers - 1:

--- a/tensorrt_llm/_torch/models/modeling_qwen_moe.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen_moe.py
@@ -1,9 +1,8 @@
-from typing import Dict, Optional
+from typing import Optional
 
 import torch
 import torch.nn.functional as F
 from torch import nn
-from tqdm import tqdm
 from transformers import Qwen2MoeConfig
 
 from tensorrt_llm.functional import PositionEmbeddingType
@@ -14,12 +13,11 @@ from ..model_config import ModelConfig
 from ..modules.attention import Attention
 from ..modules.decoder_layer import DecoderLayer
 from ..modules.embedding import Embedding
-from ..modules.fused_moe import DefaultMoeRoutingMethod, MoE, create_moe
+from ..modules.fused_moe import DefaultMoeRoutingMethod, create_moe
 from ..modules.gated_mlp import GatedMLP
 from ..modules.linear import Linear, TensorParallelMode
 from ..modules.rms_norm import RMSNorm
 from .modeling_utils import (DecoderModel, DecoderModelForCausalLM,
-                             duplicate_kv_weight, filter_weights,
                              register_auto_model)
 
 
@@ -255,57 +253,3 @@ class Qwen2MoeForCausalLM(DecoderModelForCausalLM[QwenMoeModel,
                          config=model_config,
                          hidden_size=model_config.pretrained_config.hidden_size,
                          vocab_size=model_config.pretrained_config.vocab_size)
-
-    def load_weights(self, weights: Dict):
-        tp_size = self.model_config.mapping.tp_size
-        num_kv_heads = self.config.num_key_value_heads
-
-        params_map = {
-            'qkv_proj': ['q_proj', 'k_proj', 'v_proj'],
-            'gate_up_proj': ['gate_proj', 'up_proj']
-        }
-        for name, module in tqdm(list(self.named_modules()),
-                                 desc="Loading weights"):
-            if len(module._parameters) > 0:
-                # skip load weights if tie word embeddings is enabled and layer is lm_head
-                if self.config.tie_word_embeddings and name.startswith(
-                        "lm_head"):
-                    continue
-
-                names = name.split('.')
-                if names[-1] in params_map:
-                    module_weights = []
-                    for new_name in params_map[names[-1]]:
-                        fw = filter_weights('.'.join(names[:-1] + [new_name]),
-                                            weights)
-                        if new_name in ['k_proj', 'v_proj']:
-                            fw = {
-                                k:
-                                duplicate_kv_weight(
-                                    weight=v[:],
-                                    num_kv_heads=num_kv_heads,
-                                    tensor_parallel_size=tp_size)
-                                if k in ["weight", "bias"] else v
-                                for k, v in fw.items()
-                            }
-                        module_weights.append(fw)
-                    module.load_weights(weights=module_weights)
-                else:
-                    module_weights = filter_weights(name, weights)
-                    if isinstance(module, MoE):
-                        updated_module_weights = {}
-                        for weight_name, weight_value in module_weights.items():
-                            new_weight_name = weight_name.replace(
-                                "gate_proj",
-                                "w1").replace("up_proj",
-                                              "w3").replace("down_proj", "w2")
-                            updated_module_weights[
-                                new_weight_name] = weight_value
-                        del module_weights
-                        module.load_weights(weights=[updated_module_weights])
-                    elif hasattr(module, 'load_weights'):
-                        module.load_weights(weights=[module_weights])
-                    else:
-                        for n, p in module._parameters.items():
-                            if p is not None:
-                                p.data.copy_(module_weights[n][:])

--- a/tensorrt_llm/_torch/models/modeling_speculative.py
+++ b/tensorrt_llm/_torch/models/modeling_speculative.py
@@ -4,6 +4,8 @@ import torch
 from torch import nn
 from transformers import LlamaConfig
 
+from tensorrt_llm._torch.models.checkpoints.base_weight_mapper import \
+    BaseWeightMapper
 from tensorrt_llm.functional import PositionEmbeddingType
 
 from ..attention_backend import AttentionMetadata
@@ -264,7 +266,7 @@ class Eagle3ForCausalLM(DecoderModelForCausalLM[Eagle3DraftModel, LlamaConfig]):
             return_context_logits,
         )
 
-    def load_weights(self, weights: Dict):
+    def load_weights(self, weights: Dict, weight_mapper: BaseWeightMapper):
         new_weights = {}
         for k, v in weights.items():
             if 'lm_head' not in k:
@@ -274,9 +276,12 @@ class Eagle3ForCausalLM(DecoderModelForCausalLM[Eagle3DraftModel, LlamaConfig]):
                 new_k = k
             new_weights[new_k] = v
         if self.load_lm_head_from_target:
-            super().load_weights(new_weights, skip_modules=['lm_head'])
+            super().load_weights(weights=new_weights,
+                                 weight_mapper=weight_mapper,
+                                 skip_modules=['lm_head'])
         else:
-            super().load_weights(new_weights)
+            super().load_weights(weights=new_weights,
+                                 weight_mapper=weight_mapper)
 
     def load_weights_from_target_model(self,
                                        target_model: torch.nn.Module) -> None:
@@ -401,9 +406,16 @@ class SpecDecOneEngineForCausalLM(DecoderModelForCausalLM[TModel, TConfig],
 
         return logits
 
-    def load_weights(self, weights: Dict):
-        super().load_weights(weights, skip_modules=["draft_model"])
+    def load_weights(self,
+                     weights: Dict,
+                     weight_mapper: Optional[BaseWeightMapper] = None):
+        super().load_weights(weights=weights,
+                             weight_mapper=weight_mapper,
+                             skip_modules=["draft_model"])
 
-    def load_draft_weights(self, weights: Dict):
-        self.draft_model.load_weights(weights)
+    def load_draft_weights(self,
+                           weights: Dict,
+                           weight_mapper: Optional[BaseWeightMapper] = None):
+        self.draft_model.load_weights(weights=weights,
+                                      weight_mapper=weight_mapper)
         self.draft_model.load_weights_from_target_model(self)

--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -524,12 +524,25 @@ class DecoderModelForCausalLM(nn.Module,
             return_context_logits,
         )
 
-    def load_weights(self, weights: Dict, skip_modules: List[str] = []):
+    def load_weights(self,
+                     weights: Dict,
+                     weight_mapper: Optional["BaseWeightMapper"] = None,
+                     skip_modules: List[str] = []):
+        # TODO smor- this solution is a temporary solution to load weights while we are still using
+        # the old checkpoint format loading process. Once checkpoint format is unified
+        # this method will be removed.
         preload_weight_modules = getattr(self, "preload_weight_modules", None)
-        _load_weights_impl(self,
-                           weights,
-                           skip_modules,
-                           preload_weight_modules=preload_weight_modules)
+        if weight_mapper is None:
+            _load_weights_impl(self,
+                               weights,
+                               skip_modules,
+                               preload_weight_modules=preload_weight_modules)
+        else:
+            _load_weights_impl_v2(self,
+                                  weights,
+                                  weight_mapper,
+                                  skip_modules,
+                                  preload_weight_modules=preload_weight_modules)
 
     def infer_max_seq_len(self) -> int:
         # Modified from tensorrt_llm/builder.py _init_max_seq_len
@@ -558,6 +571,10 @@ class DecoderModelForCausalLM(nn.Module,
 
 
 MODEL_CLASS_MAPPING = {}
+MODEL_CLASS_MAPPER_MAPPING = {}
+MODEL_CLASS_CHECKPOINT_WEIGHT_LOADER_DEFAULT_MAPPING = {}
+MODEL_CLASS_CONFIG_LOADER_DEFAULT_MAPPING = {}
+CHECKPOINT_LOADER_FORMAT_DEFAULT_MAPPING = {}
 
 
 def register_auto_model(name: str):
@@ -567,6 +584,59 @@ def register_auto_model(name: str):
         return cls
 
     return decorator
+
+
+def register_mapper(format: str, name: Optional[str] = None):
+
+    def decorator(cls):
+        if name is not None:
+            # set cls for model name and format pair
+            MODEL_CLASS_MAPPER_MAPPING[f'{name}_{format}'] = cls
+        else:
+            # resort to the default per format
+            MODEL_CLASS_MAPPER_MAPPING[format] = cls
+        return cls
+
+    return decorator
+
+
+def register_checkpoint_weight_loader(name: str):
+
+    def decorator(cls):
+        MODEL_CLASS_CHECKPOINT_WEIGHT_LOADER_DEFAULT_MAPPING[name] = cls
+        return cls
+
+    return decorator
+
+
+def register_checkpoint_loader(name: str):
+
+    def decorator(cls):
+        CHECKPOINT_LOADER_FORMAT_DEFAULT_MAPPING[name] = cls
+        return cls
+
+    return decorator
+
+
+def register_config_loader(name: str):
+
+    def decorator(cls):
+        MODEL_CLASS_CONFIG_LOADER_DEFAULT_MAPPING[name] = cls
+        return cls
+
+    return decorator
+
+
+def get_checkpoint_weight_loader(name: str) -> Type["BaseWeightLoader"]:
+    if name not in MODEL_CLASS_CHECKPOINT_WEIGHT_LOADER_DEFAULT_MAPPING:
+        raise ValueError(f"Default checkpoint weight loader {name} not found.")
+    return MODEL_CLASS_CHECKPOINT_WEIGHT_LOADER_DEFAULT_MAPPING[name]
+
+
+def get_config_loader(name: str) -> Type["BaseConfigLoader"]:
+    if name not in MODEL_CLASS_CONFIG_LOADER_DEFAULT_MAPPING:
+        raise ValueError(f"Default config loader {name} not found.")
+    return MODEL_CLASS_CONFIG_LOADER_DEFAULT_MAPPING[name]
 
 
 def get_model_architecture(
@@ -587,7 +657,6 @@ def get_model_architecture(
 def rename_weights_with_regex(pattern_mapping: Dict[str, str], weights: Dict):
     """
     Rename weight keys according to regex pattern matching.
-
     Args:
         pattern_mapping: A dictionary mapping regex patterns to replacement strings. The key is HF name pattern, and the value is corresponding TRT-LLM name pattern.
             The patterns will be used to match keys in the weights dict and replace
@@ -600,7 +669,6 @@ def rename_weights_with_regex(pattern_mapping: Dict[str, str], weights: Dict):
                 r'(.*?)out_proj(.*)': r'\1o_proj\2'
             }
         weights: A dictionary of weights
-
     Returns:
         A dictionary of weights with renamed keys
     """
@@ -683,6 +751,9 @@ def _load_weights_impl(model: Union[nn.Module, DecoderModelForCausalLM],
                        preload_weight_modules: Optional[List[str]] = None):
     # TODO: remove preload_weight_modules - it is a workaround for min-latency llama4 model loading where
     # we need some order in the module loading. Once this is resolved, we can remove this workaround.
+    # TODO smor- this method is here as a temporary solution to load weights.
+    # Once checkpoint format is unified, this method will be removed.
+
     if not hasattr(model, 'model_config') or not isinstance(
             model.model_config, ModelConfig):
         raise ValueError("model must have a model_config attribute")
@@ -756,6 +827,74 @@ def _load_weights_impl(model: Union[nn.Module, DecoderModelForCausalLM],
                     for n, p in module._parameters.items():
                         if p is not None:
                             p.data.copy_(module_weights[n][:])
+
+    if os.environ.get("TRT_LLM_DISABLE_LOAD_WEIGHTS_IN_PARALLEL",
+                      False) in ["True", "true", "1", "yes", "y"]:
+        for name, module in tqdm(list(model.named_modules()),
+                                 desc="Loading weights"):
+            load_single_module(name, module)
+    else:
+        all_modules = dict(model.named_modules())
+        serial_load_modules = []
+        if preload_weight_modules is not None:
+            for module in preload_weight_modules:
+                serial_load_modules.extend([
+                    name for name in all_modules.keys() if name.endswith(module)
+                ])
+            logger.info(f"Serial load modules: {serial_load_modules}")
+            pbar = tqdm(serial_load_modules, desc="Loading weights serially")
+            for module in serial_load_modules:
+                # logger.info(f"Loading weights for {module} in serial")
+                load_single_module(module, all_modules[module])
+                pbar.update(1)
+                del all_modules[module]
+            pbar.close()
+
+        pbar = tqdm(list(model.named_modules()),
+                    desc="Loading weights concurrently")
+        args_list = [(name, module) for name, module in model.named_modules()
+                     if name not in serial_load_modules]
+        run_concurrently(load_single_module, args_list, pbar=pbar)
+
+
+def _load_weights_impl_v2(model: Union[nn.Module, DecoderModelForCausalLM],
+                          weights: Dict,
+                          weight_mapper: "BaseWeightMapper",
+                          skip_modules: List[str] = [],
+                          params_map: Optional[Dict[str, str]] = None,
+                          preload_weight_modules: Optional[List[str]] = None):
+    # TODO: remove preload_weight_modules - it is a workaround for min-latency llama4 model loading where
+    # we need some order in the module loading. Once this is resolved, we can remove this workaround.
+    weight_mapper.add_skip_modules(skip_modules)
+    if params_map is not None:
+        weights = weight_mapper.rename_by_params_map(params_map, weights)
+        logger.info(f"Renamed weights with params_map: {params_map}")
+
+    def load_single_module(name, module):
+        if len(module._parameters) > 0:
+            if weight_mapper.should_skip_module(name):
+                return
+
+            names = name.split('.')
+            module_names_breakdown, module_name = names[:-1], names[-1]
+
+            if weight_mapper.does_require_special_handling(module_name):
+                module_weights = weight_mapper.apply_callbacks(
+                    module, module_name, module_names_breakdown, weights)
+                module.load_weights(weights=module_weights)
+            else:
+                module_weights = weight_mapper.filter_weights(name, weights)
+                if weight_mapper.is_special_instance_module(module):
+                    weight_mapper.handle_special_instance_module(
+                        module, module_name, module_weights)
+
+                elif hasattr(module, 'load_weights'):
+                    module.load_weights(weights=[module_weights])
+                else:
+                    for n, p in module._parameters.items():
+                        if p is not None:
+                            weight_mapper.handle_manual_copy(
+                                module_name, module_weights, n, p)
 
     if os.environ.get("TRT_LLM_DISABLE_LOAD_WEIGHTS_IN_PARALLEL",
                       False) in ["True", "true", "1", "yes", "y"]:

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -472,7 +472,6 @@ def create_py_executor_instance(
         num_lora_modules = model_engine.model.model_config.pretrained_config.num_hidden_layers * \
             len(lora_config.lora_target_modules + lora_config.missing_qkv_modules)
 
-        # TODO smor- need to figure out how to set these values
         executor_config.peft_cache_config = trtllm.PeftCacheConfig(
             num_device_module_layer=max_lora_rank * num_lora_modules *
             lora_config.max_loras,

--- a/tensorrt_llm/_torch/pyexecutor/config.py
+++ b/tensorrt_llm/_torch/pyexecutor/config.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Union
 
+from tensorrt_llm._torch.models.checkpoints.base_checkpoint_loader import \
+    BaseCheckpointLoader
 from tensorrt_llm.bindings.executor import ExecutorConfig
 
 from ...builder import BuildConfig
@@ -117,7 +119,9 @@ def update_executor_config(
         speculative_config: Optional["DecodingBaseConfig"] = None,
         hf_model_dir: Optional[str] = None,
         max_input_len: Optional[int] = None,
-        max_seq_len: Optional[int] = None):
+        max_seq_len: Optional[int] = None,
+        checkpoint_format: Optional[str] = None,
+        checkpoint_loader: Optional[BaseCheckpointLoader] = None):
     if backend is None:
         return
 
@@ -145,3 +149,31 @@ def update_executor_config(
 
     if max_seq_len is not None:
         executor_config.max_seq_len = max_seq_len
+
+    executor_config.checkpoint_loader = _construct_checkpoint_loader(
+        backend, checkpoint_loader, checkpoint_format)
+
+
+def _construct_checkpoint_loader(
+        backend: str, checkpoint_loader: Optional[BaseCheckpointLoader],
+        checkpoint_format: Optional[str]) -> Optional[BaseCheckpointLoader]:
+    if backend == "_autodeploy":
+        return None
+
+    from tensorrt_llm._torch.models.checkpoints.base_checkpoint_loader import \
+        BaseCheckpointLoader
+    from tensorrt_llm._torch.models.modeling_utils import (
+        get_checkpoint_weight_loader, get_config_loader)
+
+    if checkpoint_loader is None:
+        checkpoint_weight_loader = get_checkpoint_weight_loader(
+            checkpoint_format)()
+        config_loader = get_config_loader(checkpoint_format)()
+
+        checkpoint_loader = BaseCheckpointLoader.get(
+            checkpoint_format=checkpoint_format,
+            weight_loader=checkpoint_weight_loader,
+            weight_mapper=None,
+            config_loader=config_loader)
+
+    return checkpoint_loader

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -2,28 +2,24 @@ import bisect
 import contextlib
 import functools
 import gc
-import glob
 import inspect
 import math
-import multiprocessing
 import os
 import traceback
 import weakref
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
-import psutil
-import safetensors
 import torch
 import torch._dynamo.config
-import tqdm
 
 import tensorrt_llm.bindings.internal.userbuffers as ub
+from tensorrt_llm._torch.models.checkpoints.base_checkpoint_loader import \
+    BaseCheckpointLoader
 from tensorrt_llm._torch.pyexecutor.sampler import SampleStateTensors
 from tensorrt_llm._torch.speculative.mtp import SampleStateTensorsMTP
-from tensorrt_llm._utils import (is_trace_enabled, local_mpi_rank,
-                                 local_mpi_size, nvtx_range, release_gc,
+from tensorrt_llm._utils import (is_trace_enabled, nvtx_range, release_gc,
                                  torch_dtype_to_str, trace_func)
 from tensorrt_llm.bindings.executor import GuidedDecodingConfig
 from tensorrt_llm.inputs.multimodal import MultimodalParams
@@ -48,7 +44,7 @@ from ..metadata import KVCacheParams
 from ..model_config import ModelConfig, MoeLoadBalancerConfig
 from ..models import AutoModelForCausalLM
 from ..models.modeling_utils import (DecoderModelForCausalLM, MetaInitMode,
-                                     run_concurrently, timing)
+                                     timing)
 from ..modules.fused_moe.moe_load_balancer import (
     MoeLoadBalancer, MoeLoadBalancerIterContext, maybe_create_moe_load_balancer)
 from ..speculative import SpecMetadata, get_spec_metadata
@@ -138,99 +134,6 @@ def validate_and_set_kv_cache_quant(model_config: ModelConfig,
     # We have an open ended KV cache in the checkpoint
     # and we have a specified override.
     model_config.quant_config.kv_cache_quant_algo = mapped_pyt_quant
-
-
-def _prefetch_one_file(file_name):
-    if os.path.exists(file_name):
-        logger.info(f"Prefetching {file_name} to memory...")
-        with open(file_name, 'rb') as f:
-            f.read()
-        logger.info(f"Finished prefetching {file_name}.")
-
-
-def prefetch_files(file_names: List[str]):
-    """
-    Prefetch safetensors files to memory so that the weight loading will be much faster.
-    When multiple ranks run in parallel, each rank will prefetch some files.
-    """
-
-    # Find out the files to prefetch for the current rank.
-    # Each rank loads files with indices local_rank, local_rank + local_mpi_size, local_rank + 2*local_mpi_size, etc.
-    local_file_names = file_names[local_mpi_rank()::local_mpi_size()]
-    if len(local_file_names) == 0:
-        return
-
-    max_processes = min(multiprocessing.cpu_count() * 2, 16,
-                        len(local_file_names))
-    with multiprocessing.Pool(processes=max_processes) as pool:
-        pool.map(_prefetch_one_file, local_file_names)
-
-
-def load_weights(checkpoint_dir: str):
-    weights = {}
-    weight_files = glob.glob(f"{checkpoint_dir}/*.safetensors")
-    if weight_files:
-        # Prefetch the weight files to CPU memory if the size is less than 90% of the available memory.
-        # This is a heuristic to avoid prefetching files that are too large and causing file cache thrashing.
-        prefetch_size = sum(os.path.getsize(file) for file in weight_files)
-        # If the layer number is overridden, it indicates that only a subset of layers are loaded.
-        # Prefetching all layers is unnecessary.
-        num_layers = int(os.environ.get("TLLM_OVERRIDE_LAYER_NUM", "0"))
-        enable_prefetch = prefetch_size < psutil.virtual_memory(
-        ).available * 0.9 and num_layers == 0
-        if enable_prefetch:
-            logger.info(
-                f"Prefetching {prefetch_size / (1024**3):.2f}GB checkpoint files."
-            )
-            prefetch_files(weight_files)
-
-        def load_safetensors_file(file):
-            return safetensors.torch.load_file(file)
-
-        pbar = tqdm.tqdm(total=len(weight_files),
-                         desc="Loading safetensors weights in parallel")
-
-        # Note that the function is called with a tuple of arguments, hence we need to wrap the arguments in a tuple via [(w,) for w in weight_files]
-        # specifically the comma right after the w is important to make it a tuple.
-        run_concurrently(load_safetensors_file, [(w, ) for w in weight_files],
-                         reduce_func=weights.update,
-                         pbar=pbar)
-
-        return weights
-
-    weight_files = glob.glob(f"{checkpoint_dir}/*.bin")
-    if not weight_files:
-        weight_files = glob.glob(f"{checkpoint_dir}/*.pth")
-
-    if weight_files:
-
-        def load_bin_or_path_file(file):
-            try:
-                part_weights = torch.load(file,
-                                          weights_only=True,
-                                          map_location='cpu',
-                                          mmap=True)
-            except Exception:
-                logger.warning(
-                    f"Failed to load {file} with mmap=True, fallback to mmap=False"
-                )
-                part_weights = torch.load(file,
-                                          weights_only=True,
-                                          map_location='cpu',
-                                          mmap=False)
-            finally:
-                return part_weights
-
-        pbar = tqdm.tqdm(total=len(weight_files),
-                         desc="Loading bin weights in parallel")
-        # Note that the function is called with a tuple of arguments, hence we need to wrap the arguments in a tuple via [(w,) for w in weight_files]
-        # specifically the comma right after the w is important to make it a tuple.
-        run_concurrently(load_bin_or_path_file, [(w, ) for w in weight_files],
-                         reduce_func=weights.update,
-                         pbar=pbar)
-        return weights
-
-    raise RuntimeError(f"No weight files found in {checkpoint_dir}.")
 
 
 def initialize_dummy_weights(
@@ -346,6 +249,7 @@ class PyTorchModelEngine(ModelEngine):
         *,
         model_path: str,
         pytorch_backend_config: PyTorchConfig,
+        checkpoint_loader: BaseCheckpointLoader,
         batch_size: int = 8,
         max_beam_width: int = 1,
         max_num_tokens: int = 8192,
@@ -384,6 +288,7 @@ class PyTorchModelEngine(ModelEngine):
         self.model = self._load_model(
             model_path,
             mapping=self.mapping,
+            checkpoint_loader=checkpoint_loader,
             attn_backend=attn_backend,
             moe_backend=pytorch_backend_config.moe_backend,
             load_format=pytorch_backend_config.load_format,
@@ -1023,13 +928,15 @@ class PyTorchModelEngine(ModelEngine):
 
     def _load_model(self,
                     checkpoint_dir: str,
+                    checkpoint_loader: BaseCheckpointLoader,
                     load_format: LoadFormat,
                     max_num_tokens: int,
                     moe_max_num_tokens: Optional[int] = None,
                     moe_load_balancer: Optional[MoeLoadBalancerConfig] = None,
                     lora_config: Optional[LoraConfig] = None,
                     **kwargs):
-        config = ModelConfig.from_pretrained(
+
+        config = checkpoint_loader.load_config(
             checkpoint_dir,
             trust_remote_code=True,
             enable_min_latency=self.pytorch_backend_config.enable_min_latency,
@@ -1082,20 +989,24 @@ class PyTorchModelEngine(ModelEngine):
             logger.info(
                 f"Use {rank_model_storage / (1024**3):.2f} GB for model weights."
             )
-
             if load_format == LoadFormat.AUTO:
                 if hasattr(model, 'llm_checkpoint_dir'):
-                    weights = load_weights(model.llm_checkpoint_dir)
+                    weights = checkpoint_loader.load_weights(
+                        model.llm_checkpoint_dir)
                 else:
-                    weights = load_weights(checkpoint_dir)
+                    weights = checkpoint_loader.load_weights(checkpoint_dir)
 
-                model.load_weights(weights)
+                weight_mapper = checkpoint_loader.get_initilized_weight_mapper(
+                    model, config)
+                self._call_load_weights(model.load_weights, weights,
+                                        weight_mapper)
 
                 if self.spec_config is not None and self.spec_config.spec_dec_mode.need_load_draft_weights(
                 ):
-                    weights = load_weights(
+                    weights = checkpoint_loader.load_weights(
                         self.spec_config.speculative_model_dir)
-                    model.load_draft_weights(weights)
+                    self._call_load_weights(model.load_draft_weights, weights,
+                                            weight_mapper)
 
             elif load_format == LoadFormat.DUMMY:
                 initialize_dummy_weights(model)
@@ -1113,6 +1024,16 @@ class PyTorchModelEngine(ModelEngine):
 
             torch.cuda.current_stream().synchronize()
         return model
+
+    def _call_load_weights(self, load_method, weights, weight_mapper):
+        # TODO smor- this is a temporary solution to load weights.
+        # Once checkpoint format is unified, this method will be removed.
+        from inspect import getfullargspec
+        args = getfullargspec(load_method).args
+        if "weight_mapper" in args:
+            load_method(weights, weight_mapper=weight_mapper)
+        else:
+            load_method(weights)
 
     def _init_max_seq_len(self):
         inferred_max_seq_len = self.model.infer_max_seq_len()

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -239,6 +239,7 @@ def create_py_executor(
             spec_config=spec_config,
             guided_decoding_config=executor_config.guided_decoding_config,
             lora_config=lora_config,
+            checkpoint_loader=executor_config.checkpoint_loader,
         )
 
     if has_draft_model_engine:
@@ -262,6 +263,7 @@ def create_py_executor(
                 attn_runtime_features=attn_runtime_features,
                 dist=dist,
                 spec_config=draft_spec_config,
+                checkpoint_loader=executor_config.checkpoint_loader,
                 is_draft_model=True,
             )
             draft_model_engine.kv_cache_manager_key = ResourceManagerType.DRAFT_KV_CACHE_MANAGER

--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -567,6 +567,12 @@ class GenerationExecutorWorker(GenerationExecutor):
             self.engine.shutdown()
             self.engine = None
 
+            if hasattr(
+                    self._executor_config, "checkpoint_loader"
+            ) and self._executor_config.checkpoint_loader is not None:
+                self._executor_config.checkpoint_loader.cleanup()
+                self._executor_config.checkpoint_loader = None
+
         # Check if there are any errors from the threads before shutdown.
         self._handle_background_error()
 

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -970,7 +970,11 @@ class _TorchLLM(BaseLLM):
             speculative_config=self.args.speculative_config,
             hf_model_dir=self._hf_model_dir,
             max_input_len=self.args.max_input_len,
-            max_seq_len=max_seq_len)
+            max_seq_len=max_seq_len,
+            checkpoint_format=None if self.args.backend == "_autodeploy" else
+            self.args.checkpoint_format,
+            checkpoint_loader=None if self.args.backend == "_autodeploy" else
+            self.args.checkpoint_loader)
 
         # TODO: revisit gather_context_logits
         return_logits = self.args.gather_generation_logits

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1872,6 +1872,18 @@ class TorchLlmArgs(BaseLlmArgs):
                 'LOWPRECISION',
                 'MNNVL']] = Field(default='AUTO',
                                   description="Allreduce strategy to use.")
+    checkpoint_loader: Optional[object] = Field(
+        default=None,
+        description="The checkpoint loader to use for this LLM instance.",
+        json_schema_extra={
+            "type": "Optional[tensorrt_llm._torch.BaseCheckpointLoader]"
+        },
+    )
+
+    checkpoint_format: Optional[str] = Field(
+        default=None,
+        description="The format of the provided checkpoint.",
+    )
 
     # PrivateVars
     _quant_config: Optional[QuantConfig] = PrivateAttr(default=None)
@@ -1924,6 +1936,22 @@ class TorchLlmArgs(BaseLlmArgs):
         if self.stream_interval <= 0:
             raise ValueError(
                 f"stream_interval must be positive, got {self.stream_interval}")
+        return self
+
+    @model_validator(mode="after")
+    def validate_checkpoint_format(self):
+        if self.checkpoint_format is not None and self.checkpoint_loader is not None:
+            logger.warning(
+                "checkpoint_format and checkpoint_loader are both provided, "
+                "checkpoint_loader will be ignored.")
+            self.checkpoint_loader = None
+
+        if self.checkpoint_format is None and self.checkpoint_loader is None:
+            logger.info(
+                "neither checkpoint_format nor checkpoint_loader were provided, "
+                "checkpoint_format will be set to HF.")
+            self.checkpoint_format = "HF"
+
         return self
 
     @staticmethod

--- a/tests/unittest/_torch/modeling/test_modeling_gemma3.py
+++ b/tests/unittest/_torch/modeling/test_modeling_gemma3.py
@@ -14,6 +14,8 @@ from tensorrt_llm._torch.attention_backend import FlashInferAttentionMetadata
 from tensorrt_llm._torch.attention_backend.utils import get_attention_backend
 from tensorrt_llm._torch.metadata import KVCacheParams
 from tensorrt_llm._torch.model_config import ModelConfig
+from tensorrt_llm._torch.models.checkpoints.hf.gemma3_weight_mapper import \
+    Gemma3HfWeightMapper
 from tensorrt_llm._torch.models.modeling_gemma3 import Gemma3ForCausalLM
 from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
 from tensorrt_llm.bindings.executor import KvCacheConfig
@@ -268,7 +270,9 @@ class TestGemma3(unittest.TestCase):
         model_config = ModelConfig(pretrained_config=gemma3_config,
                                    attn_backend=backend)
         gemma3 = Gemma3ForCausalLM(model_config).to(dtype).to(device)
-        gemma3.load_weights(hf_gemma3.state_dict())
+        weight_mapper = Gemma3HfWeightMapper()
+        weight_mapper.init_model_and_config(gemma3, model_config)
+        gemma3.load_weights(hf_gemma3.state_dict(), weight_mapper)
 
         kv_cache_manager = self.get_kv_cache_manager(
             dtype=dtype,

--- a/tests/unittest/_torch/modeling/test_modeling_llama_min_latency.py
+++ b/tests/unittest/_torch/modeling/test_modeling_llama_min_latency.py
@@ -14,6 +14,8 @@ import tensorrt_llm
 from tensorrt_llm._torch.attention_backend.utils import get_attention_backend
 from tensorrt_llm._torch.metadata import KVCacheParams
 from tensorrt_llm._torch.model_config import ModelConfig
+from tensorrt_llm._torch.models.checkpoints.hf.llama4_weight_mapper import \
+    Llama4HfWeightMapper
 from tensorrt_llm._torch.models.modeling_llama import \
     Llama4ForConditionalGeneration
 from tensorrt_llm._torch.pyexecutor.config import PyTorchConfig
@@ -284,7 +286,10 @@ class TestLlama4MinLatency(unittest.TestCase):
             model_config.pytorch_backend_config = PyTorchConfig(
                 enable_min_latency=enable_min_latency)
             llama = Llama4ForConditionalGeneration(model_config)
-            llama.load_weights(hf_llama.state_dict())
+            weight_mapper = Llama4HfWeightMapper()
+            weight_mapper.init_model_and_config(llama, model_config)
+            llama.load_weights(hf_llama.state_dict(),
+                               weight_mapper=weight_mapper)
 
         num_blocks = 1
         tokens_per_block = 128

--- a/tests/unittest/_torch/modeling/test_modeling_mixtral.py
+++ b/tests/unittest/_torch/modeling/test_modeling_mixtral.py
@@ -12,6 +12,8 @@ import tensorrt_llm
 from tensorrt_llm._torch.attention_backend.utils import get_attention_backend
 from tensorrt_llm._torch.metadata import KVCacheParams
 from tensorrt_llm._torch.model_config import ModelConfig
+from tensorrt_llm._torch.models.checkpoints.hf.mixtral_weight_mapper import \
+    MixtralHfWeightMapper
 from tensorrt_llm._torch.models.modeling_mixtral import MixtralForCausalLM
 from tensorrt_llm._torch.pyexecutor.cuda_graph_runner import \
     DecodingCUDAGraphRunner
@@ -206,7 +208,9 @@ class TestMixtral(unittest.TestCase):
             model_config = ModelConfig(pretrained_config=mixtral_config,
                                        attn_backend=backend)
             mixtral = MixtralForCausalLM(model_config)
-            mixtral.load_weights(hf_mixtral.state_dict())
+            weight_mapper = MixtralHfWeightMapper()
+            weight_mapper.init_model_and_config(mixtral, mixtral_config)
+            mixtral.load_weights(hf_mixtral.state_dict(), weight_mapper)
 
         num_blocks = 1
         tokens_per_block = 128

--- a/tests/unittest/_torch/modeling/test_modeling_qwen_moe.py
+++ b/tests/unittest/_torch/modeling/test_modeling_qwen_moe.py
@@ -12,6 +12,8 @@ import tensorrt_llm
 from tensorrt_llm._torch.attention_backend.utils import get_attention_backend
 from tensorrt_llm._torch.metadata import KVCacheParams
 from tensorrt_llm._torch.model_config import ModelConfig
+from tensorrt_llm._torch.models.checkpoints.hf.qwen2_moe_weight_mapper import \
+    Qwen2MoeHfWeightMapper
 from tensorrt_llm._torch.models.modeling_qwen_moe import Qwen2MoeForCausalLM
 from tensorrt_llm._torch.pyexecutor.cuda_graph_runner import \
     DecodingCUDAGraphRunner
@@ -210,7 +212,9 @@ class TestQwenMoe(unittest.TestCase):
         model_config = ModelConfig(pretrained_config=qwen_moe_config,
                                    attn_backend=backend)
         qwen_moe = Qwen2MoeForCausalLM(model_config).to(device)
-        qwen_moe.load_weights(hf_qwen_moe.state_dict())
+        weight_mapper = Qwen2MoeHfWeightMapper()
+        weight_mapper.init_model_and_config(qwen_moe, qwen_moe_config)
+        qwen_moe.load_weights(hf_qwen_moe.state_dict(), weight_mapper)
 
         num_blocks = 1
         tokens_per_block = 128

--- a/tests/unittest/_torch/test_pytorch_model_engine.py
+++ b/tests/unittest/_torch/test_pytorch_model_engine.py
@@ -69,6 +69,7 @@ class DummyModelEngine(PyTorchModelEngine):
                           rank=tensorrt_llm.mpi_rank())
         super().__init__(model_path="",
                          pytorch_backend_config=pytorch_backend_config,
+                         checkpoint_loader=None,
                          batch_size=batch_size,
                          max_seq_len=max_seq_len,
                          mapping=mapping)

--- a/tests/unittest/api_stability/references/llm.yaml
+++ b/tests/unittest/api_stability/references/llm.yaml
@@ -66,6 +66,12 @@ methods:
       cuda_graph_config:
         annotation: Optional[tensorrt_llm.llmapi.llm_args.CudaGraphConfig]
         default: null
+      checkpoint_loader:
+        annotation: Optional[tensorrt_llm._torch.BaseCheckpointLoader]
+        default: null
+      checkpoint_format:
+        annotation: Optional[str]
+        default: null
       disable_overlap_scheduler:
         annotation: bool
         default: False


### PR DESCRIPTION
# PR title

[TRTLLM-5493][feat] Add core infrastructure to enable loading of custom checkpoint formats

## Description

Currently, the PyTorch backend requires supported models to be in HF format. This imposes a significant burden on internal and external research teams, especially those experimenting with custom checkpoint formats (e.g., MCore, NeMo).

The HF requirement forces teams to add a manual checkpoint conversion step from their own format to HF. This conversion is time-consuming and error prone. Both ADLR team and external customers have identified this as a major blocker in using the PyTorch workflow.

The current PR will include:
* Core infrastructure changes
* HF "vanilla" implementation of all major components
* Propagation of relevant changes to the engine and LLM parts

Since the first PR became too large, support for all other non-default models (i.e., models that don’t use modeling_utils.py’s default load_weights method) will be added in a separate PR. To mitigate this, the current PR includes both the old `load_weights` functionality and new one. This way, every model which uses default HF loader will use the new structured code (`_load_weights_impl_experimental`), while models that implements their own version of `load_weights` will use the old implementation (`_load_weights_impl`). 

In subsequent PRs, we'll make sure to remove this temporary solution and unify the `load_weights` process. This only was done as an intermediate step 

## Test Coverage

Will be added in a subsequent PR