### PR TITLE
[test] speedup TRT accuracy tests

### DIFF
--- a/tests/integration/defs/accuracy/accuracy_core.py
+++ b/tests/integration/defs/accuracy/accuracy_core.py
@@ -426,7 +426,7 @@ class CliFlowAccuracyTestHarness:
         self.env = env
 
     def convert(self):
-        print("Converting model to TensorRT-LLM checkpoint...")
+        logger.info("Converting model to TensorRT-LLM checkpoint...")
 
         is_prequantized = False
         for quant_config_file in [
@@ -528,7 +528,7 @@ class CliFlowAccuracyTestHarness:
         venv_check_call(self.llm_venv, convert_cmd)
 
     def build(self):
-        print("Building engines...")
+        logger.info("Building engines...")
         max_batch_size = max(task.MAX_BATCH_SIZE for task in self.tasks)
         max_input_len = max(task.MAX_INPUT_LEN for task in self.tasks)
         max_seq_len = max(task.MAX_INPUT_LEN + task.MAX_OUTPUT_LEN
@@ -547,7 +547,7 @@ class CliFlowAccuracyTestHarness:
         check_call(" ".join(build_cmd), shell=True, env=self.llm_venv._new_env)
 
     def summarize(self, task: AccuracyTask):
-        print("Running summarize...")
+        logger.info("Running summarize...")
         summarize_cmd = [
             f"{self.llm_root}/examples/summarize.py",
             f"--engine_dir={self.engine_dir}",
@@ -611,7 +611,7 @@ class CliFlowAccuracyTestHarness:
                  str(world_size), "--allow-run-as-root"], summarize_cmd)
 
     def mmlu(self, task: AccuracyTask):
-        print("Running mmlu...")
+        logger.info("Running mmlu...")
         num_samples, threshold = task.get_num_samples_and_threshold(
             dtype=self.dtype,
             quant_algo=self.quant_algo,
@@ -638,14 +638,14 @@ class CliFlowAccuracyTestHarness:
         check_call(" ".join(mmlu_cmd), shell=True, env=self.llm_venv._new_env)
 
     def eval_long_context(self, task: AccuracyTask):
-        print("Running construct_synthetic_dataset...")
+        logger.info("Running construct_synthetic_dataset...")
         data_gen_cmd = [
             f"{self.llm_root}/examples/infinitebench/construct_synthetic_dataset.py",
             "--test_case=build_passkey", f"--test_level={task.LEVEL}"
         ]
         venv_check_call(self.llm_venv, data_gen_cmd)
 
-        print("Running eval_long_context...")
+        logger.info("Running eval_long_context...")
         eval_cmd = [
             f"{self.llm_root}/examples/eval_long_context.py", "--task=passkey",
             f"--engine_dir={self.engine_dir}",

--- a/tests/integration/defs/accuracy/test_cli_flow.py
+++ b/tests/integration/defs/accuracy/test_cli_flow.py
@@ -419,7 +419,7 @@ class TestVicuna7B(CliFlowAccuracyTestHarness):
     @parametrize_with_ids("cuda_graph", [False, True])
     def test_medusa(self, cuda_graph, mocker):
         mocker.patch.object(self.__class__, "EXAMPLE_FOLDER", "medusa")
-        mocker.patch.object(CnnDailymail, "MAX_BATCH_SIZE", 8)
+        #mocker.patch.object(CnnDailymail, "MAX_BATCH_SIZE", 8)
 
         extra_summarize_args = [
             "--medusa_choices=[[0], [0, 0], [1], [0, 1], [2], [0, 0, 0], [1, 0], [0, 2], [3], [0, 3], [4], [0, 4], [2, 0], [0, 5], [0, 0, 1], [5], [0, 6], [6], [0, 7], [0, 1, 0], [1, 1], [7], [0, 8], [0, 0, 2], [3, 0], [0, 9], [8], [9], [1, 0, 0], [0, 2, 0], [1, 2], [0, 0, 3], [4, 0], [2, 1], [0, 0, 4], [0, 0, 5], [0, 0, 0, 0], [0, 1, 1], [0, 0, 6], [0, 3, 0], [5, 0], [1, 3], [0, 0, 7], [0, 0, 8], [0, 0, 9], [6, 0], [0, 4, 0], [1, 4], [7, 0], [0, 1, 2], [2, 0, 0], [3, 1], [2, 2], [8, 0], [0, 5, 0], [1, 5], [1, 0, 1], [0, 2, 1], [9, 0], [0, 6, 0], [0, 0, 0, 1], [1, 6], [0, 7, 0]]"

--- a/tests/integration/defs/accuracy/test_cli_flow.py
+++ b/tests/integration/defs/accuracy/test_cli_flow.py
@@ -419,7 +419,7 @@ class TestVicuna7B(CliFlowAccuracyTestHarness):
     @parametrize_with_ids("cuda_graph", [False, True])
     def test_medusa(self, cuda_graph, mocker):
         mocker.patch.object(self.__class__, "EXAMPLE_FOLDER", "medusa")
-        #mocker.patch.object(CnnDailymail, "MAX_BATCH_SIZE", 8)
+        mocker.patch.object(CnnDailymail, "MAX_BATCH_SIZE", 8)
 
         extra_summarize_args = [
             "--medusa_choices=[[0], [0, 0], [1], [0, 1], [2], [0, 0, 0], [1, 0], [0, 2], [3], [0, 3], [4], [0, 4], [2, 0], [0, 5], [0, 0, 1], [5], [0, 6], [6], [0, 7], [0, 1, 0], [1, 1], [7], [0, 8], [0, 0, 2], [3, 0], [0, 9], [8], [9], [1, 0, 0], [0, 2, 0], [1, 2], [0, 0, 3], [4, 0], [2, 1], [0, 0, 4], [0, 0, 5], [0, 0, 0, 0], [0, 1, 1], [0, 0, 6], [0, 3, 0], [5, 0], [1, 3], [0, 0, 7], [0, 0, 8], [0, 0, 9], [6, 0], [0, 4, 0], [1, 4], [7, 0], [0, 1, 2], [2, 0, 0], [3, 1], [2, 2], [8, 0], [0, 5, 0], [1, 5], [1, 0, 1], [0, 2, 1], [9, 0], [0, 6, 0], [0, 0, 0, 1], [1, 6], [0, 7, 0]]"


### PR DESCRIPTION
# Speedup TRT accuracy tests

TRT accuracy tests involve `convert` and `build` stages, and different cases of the same suite often use the exact same flags to `convert_checkpoint.py` or to `trtllm-build`.

This PR introduces a new `TempDirLRUCache` that caches the checkpoint and engine directories from each test case, and reuses them in case a case uses the exact same flags.

This optimization can potentially reduce the test time of some cases by several minutes.