### PR TITLE
tests: Set kv cache free memory fraction in test case

### DIFF
--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -1349,7 +1349,9 @@ class TestNemotronUltra(LlmapiAccuracyTestHarness):
                  tensor_parallel_size=tp_size,
                  pipeline_parallel_size=pp_size,
                  moe_expert_parallel_size=ep_size,
-                 use_cuda_graph=cuda_graph) as llm:
+                 use_cuda_graph=cuda_graph,
+                 kv_cache_config=KvCacheConfig(
+                     free_gpu_memory_fraction=0.85)) as llm:
             assert llm.args.quant_config.quant_algo == QuantAlgo.FP8
             assert llm.args.quant_config.kv_cache_quant_algo == QuantAlgo.FP8
             task = MMLU(self.MODEL_NAME)


### PR DESCRIPTION
Refer to https://nvbugspro.nvidia.com/bug/5340908.
This failure is caused by commit 7e6d06d5d which can get more kv cache memory during memory estimation, however it means less memory left for buffer.
After testing, this case can pass with free memory fraction of 0.85 and it get more kv cache memory than code without commit 7e6d06d5d.
So we can has this commit and set a memory fraction in case.