### PR TITLE
[TRTLLM-5965] perf: Optimize MoE sort kernels for large-scale EP

### DIFF
--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/include/moe_kernels.h
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/include/moe_kernels.h
@@ -396,7 +396,7 @@ public:
         float const* const fc2_fp8_dequant, TmaWarpSpecializedGroupedGemmInput::ElementSF const* fc2_fp4_act_flat,
         QuantParams quant_params, float const* const token_topk_unpermuted_scales,
         float const* const token_topk_permuted_scales, int const* const unpermuted_row_to_permuted_row,
-        int const* permuted_row_to_unpermuted_row, int const* const expert_for_source_row,
+        int const* permuted_row_to_unpermuted_row, int const* const token_selected_experts,
         int64_t const* const num_valid_tokens_ptr, int64_t const num_rows, int64_t const expanded_num_rows,
         int64_t const hidden_size, int64_t const inter_size, int const num_experts_per_node,
         int64_t const experts_per_token, float const** alpha_scale_ptr_array, bool use_lora, void* fc2_lora,
@@ -549,7 +549,7 @@ public:
         float const* const fc2_fp8_dequant, TmaWarpSpecializedGroupedGemmInput::ElementSF const* fc2_fp4_act_flat,
         QuantParams quant_params, float const* const token_topk_unpermuted_scales,
         float const* const token_topk_permuted_scales, int const* const unpermuted_row_to_permuted_row,
-        int const* permuted_row_to_unpermuted_row, int const* const expert_for_source_row,
+        int const* permuted_row_to_unpermuted_row, int const* const token_selected_experts,
         int64_t const* const num_valid_tokens_ptr, int64_t const num_rows, int64_t const expanded_num_rows,
         int64_t const hidden_size, int64_t const inter_size, int const num_experts_per_node,
         int64_t const experts_per_token, float const** alpha_scale_ptr_array, bool use_lora, void* fc2_lora,
@@ -586,7 +586,7 @@ public:
         float const* const fc2_fp8_dequant, TmaWarpSpecializedGroupedGemmInput::ElementSF const* fc2_fp4_act_flat,
         QuantParams quant_params, float const* const token_topk_unpermuted_scales,
         float const* const token_topk_permuted_scales, int const* const unpermuted_row_to_permuted_row,
-        int const* permuted_row_to_unpermuted_row, int const* const expert_for_source_row,
+        int const* permuted_row_to_unpermuted_row, int const* const token_selected_experts,
         int64_t const* const num_valid_tokens_ptr, int64_t const num_rows, int64_t const expanded_num_rows,
         int64_t const hidden_size, int64_t const inter_size, int const num_experts_per_node,
         int64_t const experts_per_token, float const** alpha_scale_ptr_array, bool use_lora, void* fc2_lora,
@@ -600,7 +600,7 @@ public:
             static_cast<WeightType const*>(fc2_expert_weights), static_cast<ScaleBiasType const*>(fc2_expert_biases),
             static_cast<ScaleBiasType const*>(fc2_int_scales), fc2_fp8_dequant, fc2_fp4_act_flat, quant_params,
             token_topk_unpermuted_scales, token_topk_permuted_scales, unpermuted_row_to_permuted_row,
-            permuted_row_to_unpermuted_row, expert_for_source_row, num_valid_tokens_ptr, num_rows, expanded_num_rows,
+            permuted_row_to_unpermuted_row, token_selected_experts, num_valid_tokens_ptr, num_rows, expanded_num_rows,
             hidden_size, inter_size, num_experts_per_node, experts_per_token, alpha_scale_ptr_array, use_lora, fc2_lora,
             stream, parallelism_config, enable_alltoall, config, min_latency_mode, num_active_experts_per,
             active_expert_global_ids);
@@ -738,7 +738,7 @@ private:
         OutputType* const final_output, int64_t const* const expert_first_token_offset,
         WeightType const* const fc2_expert_weights, ScaleBiasType const* const fc2_expert_biases,
         float const* const token_topk_unpermuted_scales, int const* const unpermuted_row_to_permuted_row,
-        int const* const permuted_row_to_unpermuted_row, int const* const expert_for_source_row,
+        int const* const permuted_row_to_unpermuted_row, int const* const token_selected_experts,
         int64_t const* const num_valid_tokens_ptr, int64_t const num_rows, int64_t const expanded_num_rows,
         int64_t const hidden_size, int64_t const inter_size, int64_t const num_experts_per_node, int64_t const k,
         MOEParallelismConfig parallelism_config, bool const enable_alltoall, QuantParams& quant_params,
@@ -755,7 +755,7 @@ private:
     std::optional<cutlass_extensions::CutlassGemmConfig> gemm2_config_;
 
     // Pointers
-    int* permuted_source_token_ids_{};
+    int* permuted_row_to_unpermuted_row_{};
     int* permuted_token_selected_experts_{};
     int* blocked_expert_counts_{};
     int* blocked_expert_counts_cumsum_{};

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/include/moe_kernels.h
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/include/moe_kernels.h
@@ -87,32 +87,6 @@ struct LoraParams
 
 namespace cutlass_kernels
 {
-static inline size_t pad_to_multiple_of_16(size_t const& input)
-{
-    static constexpr int ALIGNMENT = 16;
-    return ALIGNMENT * ((input + ALIGNMENT - 1) / ALIGNMENT);
-}
-
-class CubKeyValueSorter
-{
-public:
-    CubKeyValueSorter();
-
-    CubKeyValueSorter(int const num_experts_per_node);
-
-    void updateNumExperts(int const num_experts_per_node);
-
-    static size_t getWorkspaceSize(size_t const num_key_value_pairs, int const num_experts_per_node);
-
-    void run(void* workspace, size_t const workspace_size, int const* keys_in, int* keys_out, int const* values_in,
-        int* values_out, size_t const num_key_value_pairs, cudaStream_t stream);
-
-private:
-    static int expertsToBits(int experts);
-    int num_experts_;
-    int num_bits_;
-};
-
 /**
  * \brief Describes what parallelism mode the MoE is using
  *
@@ -413,7 +387,7 @@ public:
         int const num_experts_per_node, ActivationType fc1_activation_type, float const** alpha_scale_ptr_array,
         bool bias_is_broadcast, bool use_deepseek_fp8_block_scale, cudaStream_t stream,
         cutlass_extensions::CutlassGemmConfig config, bool min_latency_mode, int* num_active_experts_per,
-        int* active_expert_global_ids, int start_expert)
+        int* active_expert_global_ids)
         = 0;
 
     virtual void gemm2(void const* const input, void* const gemm_output, void* const final_output,
@@ -428,7 +402,7 @@ public:
         int64_t const experts_per_token, float const** alpha_scale_ptr_array, bool use_lora, void* fc2_lora,
         bool use_deepseek_fp8_block_scale, cudaStream_t stream, MOEParallelismConfig parallelism_config,
         bool const enable_alltoall, cutlass_extensions::CutlassGemmConfig config, bool min_latency_mode,
-        int* num_active_experts_per, int* active_expert_global_ids, int start_expert)
+        int* num_active_experts_per, int* active_expert_global_ids)
         = 0;
 
     virtual std::pair<TmaWarpSpecializedGroupedGemmInput, TmaWarpSpecializedGroupedGemmInput>
@@ -565,7 +539,7 @@ public:
         int64_t const num_rows, int64_t const expanded_num_rows, int64_t const hidden_size, int64_t const inter_size,
         int const num_experts_per_node, ActivationType fc1_activation_type, float const** alpha_scale_ptr_array,
         bool bias_is_broadcast, cudaStream_t stream, cutlass_extensions::CutlassGemmConfig config,
-        bool min_latency_mode, int* num_active_experts_per, int* active_expert_global_ids, int start_expert);
+        bool min_latency_mode, int* num_active_experts_per, int* active_expert_global_ids);
 
     static void gemm2(MoeGemmRunner<T, WeightType, OutputType, ScaleBiasType>& gemm_runner,
         DeepSeekBlockScaleGemmRunner* fp8_blockscale_gemm_runner, T const* const input, void* const gemm_output,
@@ -581,7 +555,7 @@ public:
         int64_t const experts_per_token, float const** alpha_scale_ptr_array, bool use_lora, void* fc2_lora,
         cudaStream_t stream, MOEParallelismConfig parallelism_config, bool const enable_alltoall,
         cutlass_extensions::CutlassGemmConfig config, bool min_latency_mode, int* num_active_experts_per,
-        int* active_expert_global_ids, int start_expert);
+        int* active_expert_global_ids);
 
     // Overrides to allow us to forward on to the internal functions with the pointers using the correct type
     void gemm1(void const* const input, void* const output, void* const intermediate_result,
@@ -594,7 +568,7 @@ public:
         int const num_experts_per_node, ActivationType fc1_activation_type, float const** alpha_scale_ptr_array,
         bool bias_is_broadcast, bool use_deepseek_fp8_block_scale, cudaStream_t stream,
         cutlass_extensions::CutlassGemmConfig config, bool min_latency_mode, int* num_active_experts_per,
-        int* active_expert_global_ids, int start_expert) override
+        int* active_expert_global_ids) override
     {
         auto* block_scale_gemm_runner = use_deepseek_fp8_block_scale ? getDeepSeekBlockScaleGemmRunner() : nullptr;
         return Self::gemm1(moe_gemm_runner_, block_scale_gemm_runner, static_cast<T const*>(input),
@@ -603,7 +577,7 @@ public:
             num_valid_tokens_ptr, static_cast<ScaleBiasType const*>(fc1_int_scales), fc1_fp8_dequant, fc2_fp8_quant,
             fc1_fp4_act_flat, fc2_fp4_act_flat, quant_params, num_rows, expanded_num_rows, hidden_size, inter_size,
             num_experts_per_node, fc1_activation_type, alpha_scale_ptr_array, bias_is_broadcast, stream, config,
-            min_latency_mode, num_active_experts_per, active_expert_global_ids, start_expert);
+            min_latency_mode, num_active_experts_per, active_expert_global_ids);
     }
 
     void gemm2(void const* const input, void* const gemm_output, void* const final_output,
@@ -618,7 +592,7 @@ public:
         int64_t const experts_per_token, float const** alpha_scale_ptr_array, bool use_lora, void* fc2_lora,
         bool use_deepseek_fp8_block_scale, cudaStream_t stream, MOEParallelismConfig parallelism_config,
         bool const enable_alltoall, cutlass_extensions::CutlassGemmConfig config, bool min_latency_mode,
-        int* num_active_experts_per, int* active_expert_global_ids, int start_expert) override
+        int* num_active_experts_per, int* active_expert_global_ids) override
     {
         auto* block_scale_gemm_runner = use_deepseek_fp8_block_scale ? getDeepSeekBlockScaleGemmRunner() : nullptr;
         return Self::gemm2(moe_gemm_runner_, block_scale_gemm_runner, static_cast<T const*>(input), gemm_output,
@@ -629,7 +603,7 @@ public:
             expanded_dest_row_to_expanded_source_row, expert_for_source_row, num_valid_tokens_ptr, num_rows,
             expanded_num_rows, hidden_size, inter_size, num_experts_per_node, experts_per_token, alpha_scale_ptr_array,
             use_lora, fc2_lora, stream, parallelism_config, enable_alltoall, config, min_latency_mode,
-            num_active_experts_per, active_expert_global_ids, start_expert);
+            num_active_experts_per, active_expert_global_ids);
     }
 
     virtual size_t getGemmWorkspaceSize(int num_experts_per_node) const override
@@ -766,7 +740,7 @@ private:
         float const* const token_topk_unpermuted_scales, int const* const expanded_source_row_to_expanded_dest_row,
         int const* const expanded_dest_row_to_expanded_source_row, int const* const expert_for_source_row,
         int64_t const* const num_valid_tokens_ptr, int64_t const num_rows, int64_t const expanded_num_rows,
-        int64_t const hidden_size, int64_t const inter_size, int const num_experts_per_node, int64_t const k,
+        int64_t const hidden_size, int64_t const inter_size, int64_t const num_experts_per_node, int64_t const k,
         MOEParallelismConfig parallelism_config, bool const enable_alltoall, QuantParams& quant_params,
         cudaStream_t stream);
 
@@ -774,7 +748,6 @@ private:
         int64_t const* num_valid_tokens_ptr, int64_t const expanded_num_rows, int64_t const seq_len, bool const use_awq,
         cudaStream_t stream);
 
-    CubKeyValueSorter sorter_;
     MoeGemmRunner<T, WeightType, OutputType, ScaleBiasType> moe_gemm_runner_;
     std::unique_ptr<DeepSeekBlockScaleGemmRunner> blockscale_gemm_runner_;
 
@@ -782,11 +755,11 @@ private:
     std::optional<cutlass_extensions::CutlassGemmConfig> gemm2_config_;
 
     // Pointers
-    int* unpermuted_token_selected_experts_{};
-    int* unpermuted_source_token_ids_{};
     int* permuted_source_token_ids_{};
     int* permuted_token_selected_experts_{};
-    char* sorter_ws_{};
+    int* block_expert_counts_{};
+    int* block_expert_counts_cumsum_{};
+    int* block_source_token_ids_{};
     T* permuted_data_{};
     float* permuted_token_final_scales_{};
 
@@ -859,7 +832,6 @@ public:
         mParallelismConfig = parallelism_config;
         mEnableAlltoall = enable_alltoall;
         mSM = common::getSMVersion();
-        mSorter.updateNumExperts(mNumExpertsPerNode);
 
         mScalingType = TmaWarpSpecializedGroupedGemmInput::FpXBlockScalingType::NONE;
         if (dtype == nvinfer1::DataType::kFP8
@@ -883,7 +855,6 @@ public:
         cudaStream_t const& stream);
 
     CutlassMoeFCRunnerInterface* mInterface;
-    CubKeyValueSorter mSorter;
 
     GemmToProfile mGemmToProfile = GemmToProfile::Undefined;
     std::vector<Config> mAllTacticsSaved;

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_kernels.cu
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_kernels.cu
@@ -593,17 +593,17 @@ __global__ void blockExpertPrefixSumKernel(int const* token_selected_experts, in
     }
 
     int const has_matched = expanded_token_id >= 0 ? 1 : 0;
-    int indice;
-    BlockScan(temp_storage).ExclusiveSum(has_matched, indice);
+    int index;
+    BlockScan(temp_storage).ExclusiveSum(has_matched, index);
 
     if (has_matched)
     {
-        block_source_token_ids[target_expert_id * num_tokens + block_id * kNumTokensPerBlock + indice]
+        block_source_token_ids[target_expert_id * num_tokens + block_id * kNumTokensPerBlock + index]
             = expanded_token_id;
     }
     if (threadIdx.x == kNumTokensPerBlock - 1)
     {
-        block_expert_counts[target_expert_id * num_blocks_per_seq + block_id] = indice + has_matched;
+        block_expert_counts[target_expert_id * num_blocks_per_seq + block_id] = index + has_matched;
     }
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_kernels.cu
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_kernels.cu
@@ -1526,8 +1526,8 @@ template <class InputActivationsType, class ExpandedActivationsType>
 void expandInputRowsKernelLauncher(InputActivationsType const* unpermuted_input,
     ExpandedActivationsType* permuted_output, float const* unpermuted_scales, float* permuted_scales,
     int const* permuted_row_to_unpermuted_row, int64_t const num_rows, int64_t const cols, int const k,
-    int const num_experts_per_node, float const* fc1_act_global_scale, bool use_per_expert_act_scale, int64_t* expert_first_token_offset,
-    TmaWarpSpecializedGroupedGemmInput::ElementSF* fc1_act_sf_flat,
+    int const num_experts_per_node, float const* fc1_act_global_scale, bool use_per_expert_act_scale,
+    int64_t* expert_first_token_offset, TmaWarpSpecializedGroupedGemmInput::ElementSF* fc1_act_sf_flat,
     TmaWarpSpecializedGroupedGemmInput::ElementSF const* input_sf, cudaStream_t stream)
 {
 #ifdef ENABLE_FP4
@@ -1565,8 +1565,8 @@ void expandInputRowsKernelLauncher(InputActivationsType const* unpermuted_input,
     config.numAttrs = 1;
     config.attrs = attrs;
     cudaLaunchKernelEx(&config, func, unpermuted_input, permuted_output, unpermuted_scales, permuted_scales,
-        permuted_row_to_unpermuted_row, num_rows, cols, k, fc1_act_global_scale, use_per_expert_act_scale, expert_first_token_offset,
-        fc1_act_sf_flat, input_sf, num_experts_per_node);
+        permuted_row_to_unpermuted_row, num_rows, cols, k, fc1_act_global_scale, use_per_expert_act_scale,
+        expert_first_token_offset, fc1_act_sf_flat, input_sf, num_experts_per_node);
 }
 
 enum class ScaleMode : int

--- a/cpp/tensorrt_llm/thop/moeUtilOp.cpp
+++ b/cpp/tensorrt_llm/thop/moeUtilOp.cpp
@@ -48,7 +48,7 @@ void runPermute(void const* input_activations_void, void const* input_sf_void, i
     int* unpermuted_token_selected_experts_, int* unpermuted_source_token_ids_, int* permuted_source_token_ids_,
     int* permuted_token_selected_experts_, T* permuted_data_, char* sorter_ws_, int64_t* expert_first_token_offset_,
     float* permuted_token_final_scales_, int* expanded_source_row_to_expanded_dest_row,
-    cutlass_kernels::MOEParallelismConfig parallelism_config, cutlass_kernels::CubKeyValueSorter sorter_, bool use_lora,
+    cutlass_kernels::MOEParallelismConfig parallelism_config, kernels::CubKeyValueSorter sorter_, bool use_lora,
     kernels::LoraParams& lora_params, bool use_fp8_block_scaling, bool min_latency_mode,
     cutlass_kernels::MoeMinLatencyParams& min_latency_params, cudaStream_t stream)
 {
@@ -121,7 +121,7 @@ moe_permute_op(torch::Tensor const& input, torch::Tensor const& token_selected_e
     int64_t const tp_rank, int64_t const ep_size, int64_t const ep_rank, int64_t const cluster_size,
     int64_t const cluster_rank, bool min_latency_mode, bool use_fp8_block_scaling)
 {
-    cutlass_kernels::CubKeyValueSorter sorter_;
+    kernels::CubKeyValueSorter sorter_;
 
     TORCH_CHECK(cluster_size == 1 && cluster_rank == 0, "smart_router is supported in min_latency mode");
     TORCH_CHECK(min_latency_mode == false, "min_latency_mode is not supported now");
@@ -179,7 +179,7 @@ moe_permute_op(torch::Tensor const& input, torch::Tensor const& token_selected_e
 
     size_t const sorter_size = min_latency_mode
         ? 0
-        : cutlass_kernels::CubKeyValueSorter::getWorkspaceSize(num_rows * experts_per_token, num_experts_per_node);
+        : kernels::CubKeyValueSorter::getWorkspaceSize(num_rows * experts_per_token, num_experts_per_node);
     auto sorter_ws_tensor = torch::empty(
         {static_cast<int64_t>(sorter_size)}, torch::dtype(torch::kChar).device(torch::kCUDA).requires_grad(false));
 

--- a/cpp/tests/unit_tests/kernels/mixtureOfExpertsTest.cu
+++ b/cpp/tests/unit_tests/kernels/mixtureOfExpertsTest.cu
@@ -2136,8 +2136,8 @@ TEST_F(MixtureOfExpertsProfilerTest, TestGeneratedProfilerDistribution)
 #define GET_WS_PTR(type, name) auto* name = reinterpret_cast<type>(workspace + workspaces.at(#name).second)
 
             GET_WS_PTR(int64_t*, expert_first_token_offset);
-            GET_WS_PTR(int*, source_to_dest);
-            GET_WS_PTR(int*, dest_to_source);
+            GET_WS_PTR(int*, unpermuted_row_to_permuted_row);
+            GET_WS_PTR(int*, permuted_row_to_unpermuted_row);
 #ifdef USING_OSS_CUTLASS_MOE_GEMM
             GET_WS_PTR(int*, token_selected_experts);
 #else
@@ -2149,10 +2149,10 @@ TEST_F(MixtureOfExpertsProfilerTest, TestGeneratedProfilerDistribution)
             {
                 auto host_expert_first_token_offset_size = getDataFromDevice(
                     expert_first_token_offset + sample * (num_experts_per_node + 1), num_experts_per_node + 1);
-                auto host_source_to_dest_map
-                    = getDataFromDevice(source_to_dest + sample * expanded_num_tokens, expanded_num_tokens);
-                auto host_dest_to_source_map
-                    = getDataFromDevice(dest_to_source + sample * expanded_num_tokens, expanded_num_tokens);
+                auto host_unpermuted_row_to_permuted_row_map = getDataFromDevice(
+                    unpermuted_row_to_permuted_row + sample * expanded_num_tokens, expanded_num_tokens);
+                auto host_permuted_row_to_unpermuted_row_map = getDataFromDevice(
+                    permuted_row_to_unpermuted_row + sample * expanded_num_tokens, expanded_num_tokens);
 #ifdef USING_OSS_CUTLASS_MOE_GEMM
                 auto host_token_selected_experts
                     = getDataFromDevice(token_selected_experts + sample * expanded_num_tokens, expanded_num_tokens);
@@ -2229,8 +2229,8 @@ TEST_F(MixtureOfExpertsProfilerTest, TestGeneratedProfilerDistribution)
                             int64_t dest_location = host_expert_first_token_offset_size[expert_idx]
                                 + calculated_routing_values[expert_idx];
 
-                            ASSERT_EQ(host_source_to_dest_map[source_location], dest_location);
-                            ASSERT_EQ(host_dest_to_source_map[dest_location], source_location);
+                            ASSERT_EQ(host_unpermuted_row_to_permuted_row_map[source_location], dest_location);
+                            ASSERT_EQ(host_permuted_row_to_unpermuted_row_map[dest_location], source_location);
 
                             calculated_routing_values[expert_idx]++;
                         }

--- a/cpp/tests/unit_tests/kernels/mixtureOfExpertsTest.cu
+++ b/cpp/tests/unit_tests/kernels/mixtureOfExpertsTest.cu
@@ -2225,12 +2225,12 @@ TEST_F(MixtureOfExpertsProfilerTest, TestGeneratedProfilerDistribution)
                         if (expert_idx < num_experts)
 #endif
                         {
-                            int64_t source_location = k_idx * num_tokens + token_idx;
-                            int64_t dest_location = host_expert_first_token_offset_size[expert_idx]
+                            int64_t unpermuted_row = k_idx * num_tokens + token_idx;
+                            int64_t permuted_row = host_expert_first_token_offset_size[expert_idx]
                                 + calculated_routing_values[expert_idx];
 
-                            ASSERT_EQ(host_unpermuted_row_to_permuted_row_map[source_location], dest_location);
-                            ASSERT_EQ(host_permuted_row_to_unpermuted_row_map[dest_location], source_location);
+                            ASSERT_EQ(host_unpermuted_row_to_permuted_row_map[unpermuted_row], permuted_row);
+                            ASSERT_EQ(host_permuted_row_to_unpermuted_row_map[permuted_row], unpermuted_row);
 
                             calculated_routing_values[expert_idx]++;
                         }

--- a/cpp/tests/unit_tests/kernels/mixtureOfExpertsTest.cu
+++ b/cpp/tests/unit_tests/kernels/mixtureOfExpertsTest.cu
@@ -2118,7 +2118,7 @@ TEST_F(MixtureOfExpertsProfilerTest, TestGeneratedProfilerDistribution)
 #ifdef USING_OSS_CUTLASS_MOE_GEMM
             backend.init(this->mMoERunner, GemmProfilerBackend::GemmToProfile::GEMM_1, nvinfer1::DataType::kHALF,
                 nvinfer1::DataType::kHALF, nvinfer1::DataType::kHALF, num_experts, k, 1024, 4096, mGroupSize, {}, false,
-                mUseLora, /*min_latency_mode=*/false, /*need_weights=*/true, MOEParallelismConfig{1, 0, ep, ep - 1},
+                mUseLora, /*min_latency_mode=*/false, /*need_weights=*/true, MOEParallelismConfig{1, 0, ep, 0},
                 /*enable_alltoall=*/false);
 #else
             backend.init(this->mMoERunner, GemmProfilerBackend::GemmToProfile::GEMM_1, nvinfer1::DataType::kHALF,
@@ -2138,8 +2138,11 @@ TEST_F(MixtureOfExpertsProfilerTest, TestGeneratedProfilerDistribution)
             GET_WS_PTR(int64_t*, expert_first_token_offset);
             GET_WS_PTR(int*, source_to_dest);
             GET_WS_PTR(int*, dest_to_source);
+#ifdef USING_OSS_CUTLASS_MOE_GEMM
+            GET_WS_PTR(int*, token_selected_experts);
+#else
             GET_WS_PTR(int*, unpermuted_selected_experts);
-
+#endif
 #undef GET_WS_PTR
 
             for (int sample = 0; sample < backend.NUM_ROUTING_SAMPLES; sample++)
@@ -2150,19 +2153,29 @@ TEST_F(MixtureOfExpertsProfilerTest, TestGeneratedProfilerDistribution)
                     = getDataFromDevice(source_to_dest + sample * expanded_num_tokens, expanded_num_tokens);
                 auto host_dest_to_source_map
                     = getDataFromDevice(dest_to_source + sample * expanded_num_tokens, expanded_num_tokens);
+#ifdef USING_OSS_CUTLASS_MOE_GEMM
+                auto host_token_selected_experts
+                    = getDataFromDevice(token_selected_experts + sample * expanded_num_tokens, expanded_num_tokens);
+#else
                 auto host_token_selected_experts = getDataFromDevice(
                     unpermuted_selected_experts + sample * expanded_num_tokens, expanded_num_tokens);
+#endif
 
                 std::vector<int64_t> calculated_routing_values(num_experts_per_node + 1, 0);
                 int skipped = 0;
                 for (auto v : host_token_selected_experts)
                 {
+#ifndef USING_OSS_CUTLASS_MOE_GEMM
                     ASSERT_TRUE(v < num_experts_per_node || (v == num_experts_per_node && ep > 1))
                         << "v " << v << " num_experts_per_node " << num_experts_per_node << " ep " << ep;
-                    skipped += (v == num_experts_per_node);
+#endif
                     if (v < num_experts_per_node)
                     {
                         calculated_routing_values[v]++;
+                    }
+                    else
+                    {
+                        skipped++;
                     }
                 }
 
@@ -2206,7 +2219,11 @@ TEST_F(MixtureOfExpertsProfilerTest, TestGeneratedProfilerDistribution)
                         int64_t idx = token_idx * k + k_idx;
                         int64_t expert_idx = host_token_selected_experts[idx];
 
+#ifdef USING_OSS_CUTLASS_MOE_GEMM
+                        if (expert_idx < num_experts_per_node)
+#else
                         if (expert_idx < num_experts)
+#endif
                         {
                             int64_t source_location = k_idx * num_tokens + token_idx;
                             int64_t dest_location = host_expert_first_token_offset_size[expert_idx]


### PR DESCRIPTION
# [TRTLLM-5965] perf: Optimize MoE sort kernels for large-scale EP

## Description

This PR implements the sort logics before MoE GEMMs, and replaces the original CUB sort invocation.

In a typical large-scale EP workload (EP=32 and per-gpu batch=128):

* Before this PR: 5 kernels
    * buildExpertMapsKernel: 10.3 us
    * CUB sort (three kernels): 11.9 us
    * computeExpertFirstTokenOffsetKernel: 4.6 us
    * In addition, we see significant bubbles between CUB kernels on B200.
![image](https://github.com/user-attachments/assets/8b604765-bd2a-4579-914e-4d2dc8c9f672)

* After this PR: 3 kernels
   * blockExpertPrefixSumKernel: 2.3 us 
   * globalExpertPrefixSumKernel: 2.3 us 
   * mergeExpertPrefixSumKernel: 2.4 us
![image](https://github.com/user-attachments/assets/d5de9709-ab1f-406e-bbe6-19e22a71acbb)

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
