### PR TITLE
test: Reduce number of C++ test cases

### DIFF
--- a/cpp/tests/batch_manager/trtGptModelRealDecoderTest.cpp
+++ b/cpp/tests/batch_manager/trtGptModelRealDecoderTest.cpp
@@ -1051,7 +1051,7 @@ INSTANTIATE_TEST_SUITE_P(GptTests, ParamTest,
             ),
         testing::Values(std::nullopt, 1280),       // maxTokensInPagedKvCache
         testing::Values(std::nullopt, 0.4),        // freeGpuMemoryFraction
-        testing::Values(false, true),              // enableTrtOverlap
+        testing::Values(true),                     // enableTrtOverlap
         testing::Values(false),                    // enableChunkedContext
         testing::Values(false),                    // enableStreamingMode
         testing::Values(false),                    // enableCudaGraphMode
@@ -1077,7 +1077,7 @@ INSTANTIATE_TEST_SUITE_P(GptRandomEndIdTests, ParamTest,
             ),
         testing::Values(std::nullopt, 1280),       // maxTokensInPagedKvCache
         testing::Values(std::nullopt, 0.4),        // freeGpuMemoryFraction
-        testing::Values(false, true),              // enableTrtOverlap
+        testing::Values(true),                     // enableTrtOverlap
         testing::Values(false),                    // enableChunkedContext
         testing::Values(false),                    // enableStreamingMode
         testing::Values(false),                    // enableCudaGraphMode
@@ -1101,7 +1101,7 @@ INSTANTIATE_TEST_SUITE_P(GptKVOffloadingTest, ParamTest,
         testing::Values(BeamConfig{1, {1}}),
         testing::Values(256),               // maxTokensInPagedKvCache
         testing::Values(std::nullopt, 0.4), // freeGpuMemoryFraction
-        testing::Values(false, true),       // enableTrtOverlap
+        testing::Values(true),              // enableTrtOverlap
         testing::Values(false),             // enableChunkedContext
         testing::Values(false),             // enableStreamingMode
         testing::Values(false),             // enableCudaGraphMode
@@ -1134,7 +1134,7 @@ INSTANTIATE_TEST_SUITE_P(GptCudaGraphTests, ParamTest,
         testing::Values(std::nullopt),             // maxTokensInPagedKvCache
         testing::Values(0.4),                      // freeGpuMemoryFraction
         testing::Values(false),                    // enableTrtOverlap
-        testing::Values(false, true),              // enableChunkedContext
+        testing::Values(true),                     // enableChunkedContext
         testing::Values(false),                    // enableStreamingMode
         testing::Values(true),                     // enableCudaGraphMode
         testing::Values(std::nullopt),             // hostCacheSize
@@ -1184,8 +1184,8 @@ INSTANTIATE_TEST_SUITE_P(GptNProfilesTests, ParamTest,
             ),
         testing::Values(std::nullopt, 1280),       // maxTokensInPagedKvCache
         testing::Values(std::nullopt, 0.4),        // freeGpuMemoryFraction
-        testing::Values(false, true),              // enableTrtOverlap
-        testing::Values(false, true),              // enableChunkedContext
+        testing::Values(true),                     // enableTrtOverlap
+        testing::Values(true),                     // enableChunkedContext
         testing::Values(false),                    // enableStreamingMode
         testing::Values(false),                    // enableCudaGraphMode
         testing::Values(std::nullopt),             // hostCacheSize
@@ -1570,7 +1570,7 @@ INSTANTIATE_TEST_SUITE_P(MedusaTests, ParamTest,
         testing::Values(std::nullopt), // maxTokensInPagedKvCache
         testing::Values(0.4),          // freeGpuMemoryFraction
         testing::Values(false),        // enableTrtOverlap
-        testing::Values(false, true),  // enableChunkedContext
+        testing::Values(true),         // enableChunkedContext
         testing::Values(false),        // enableStreamingMode
         testing::Values(true, false),  // enableCudaGraphMode
         testing::Values(std::nullopt), // hostCacheSize
@@ -1594,7 +1594,7 @@ INSTANTIATE_TEST_SUITE_P(EagleTests, ParamTest,
         testing::Values(std::nullopt), // maxTokensInPagedKvCache
         testing::Values(0.4),          // freeGpuMemoryFraction
         testing::Values(false),        // enableTrtOverlap
-        testing::Values(false, true),  // enableChunkedContext
+        testing::Values(true),         // enableChunkedContext
         testing::Values(false),        // enableStreamingMode
         testing::Values(true, false),  // enableCudaGraphMode
         testing::Values(std::nullopt), // hostCacheSize
@@ -1644,7 +1644,7 @@ INSTANTIATE_TEST_SUITE_P(ExplicitDraftTokensDecodingTests, ParamTest,
         testing::Values(std::nullopt),       // maxTokensInPagedKvCache
         testing::Values(0.4),                // freeGpuMemoryFraction
         testing::Values(false),              // enableTrtOverlap
-        testing::Values(false, true),        // enableChunkedContext
+        testing::Values(true),               // enableChunkedContext
         testing::Values(false),              // enableStreamingMode
         testing::Values(false),              // enableCudaGraphMode
         testing::Values(std::nullopt),       // hostCacheSize

--- a/cpp/tests/batch_manager/trtGptModelRealDecoderTest.cpp
+++ b/cpp/tests/batch_manager/trtGptModelRealDecoderTest.cpp
@@ -1042,7 +1042,7 @@ INSTANTIATE_TEST_SUITE_P(GptTests, ParamTest,
                 .useGptAttentionPlugin()
                 .setKVCacheType(KVCacheType::kDISABLED)
                 .usePackedInput()),
-        testing::Values(TrtGptModelType::InflightBatching, TrtGptModelType::InflightFusedBatching),
+        testing::Values(TrtGptModelType::InflightFusedBatching),
         testing::Values(
             TrtGptModelIfbTestType::BULK, TrtGptModelIfbTestType::WAVEFRONT, TrtGptModelIfbTestType::RANDOM),
         testing::Values(
@@ -1068,7 +1068,7 @@ INSTANTIATE_TEST_SUITE_P(GptRandomEndIdTests, ParamTest,
                 .useGptAttentionPlugin()
                 .setKVCacheType(KVCacheType::kPAGED)
                 .usePackedInput()),
-        testing::Values(TrtGptModelType::InflightBatching, TrtGptModelType::InflightFusedBatching),
+        testing::Values(TrtGptModelType::InflightFusedBatching),
         testing::Values(
             TrtGptModelIfbTestType::BULK, TrtGptModelIfbTestType::WAVEFRONT, TrtGptModelIfbTestType::RANDOM),
         testing::Values(
@@ -1095,7 +1095,7 @@ INSTANTIATE_TEST_SUITE_P(GptKVOffloadingTest, ParamTest,
                 .setKVCacheType(KVCacheType::kPAGED)
                 .usePackedInput()
                 .setKVCacheReuse(true)),
-        testing::Values(TrtGptModelType::InflightBatching, TrtGptModelType::InflightFusedBatching),
+        testing::Values(TrtGptModelType::InflightFusedBatching),
         testing::Values(
             TrtGptModelIfbTestType::BULK, TrtGptModelIfbTestType::WAVEFRONT, TrtGptModelIfbTestType::RANDOM),
         testing::Values(BeamConfig{1, {1}}),
@@ -1176,8 +1176,7 @@ INSTANTIATE_TEST_SUITE_P(GptNProfilesTests, ParamTest,
                             .usePackedInput()
                             .setKVCacheType(KVCacheType::kPAGED)
                             .useMultipleProfiles()),
-        testing::Values(TrtGptModelType::InflightBatching, TrtGptModelType::InflightFusedBatching),
-        testing::Values(TrtGptModelIfbTestType::BULK),
+        testing::Values(TrtGptModelType::InflightFusedBatching), testing::Values(TrtGptModelIfbTestType::BULK),
         testing::Values(
             // TODO: enable more tests when mixed beam width is supported
             BeamConfig{1, {1}}, BeamConfig{2, {2}} // , BeamConfig{2, {1, 2}}
@@ -1214,7 +1213,7 @@ INSTANTIATE_TEST_SUITE_P(GptSqTests, ParamTest,
                 .usePackedInput()
                 .setKVCacheType(KVCacheType::kDISABLED)
                 .setQuantMethod(QuantMethod::kSMOOTH_QUANT)),
-        testing::Values(TrtGptModelType::InflightBatching),
+        testing::Values(TrtGptModelType::InflightFusedBatching),
         testing::Values(
             TrtGptModelIfbTestType::BULK, TrtGptModelIfbTestType::WAVEFRONT, TrtGptModelIfbTestType::RANDOM),
         testing::Values(
@@ -1243,7 +1242,7 @@ INSTANTIATE_TEST_SUITE_P(DISABLED_GptChunkedContextTests, ParamTest,
                 .usePackedInput()
                 .setKVCacheType(KVCacheType::kPAGED)
                 .setMaxInputLength(128)),
-        testing::Values(TrtGptModelType::InflightBatching, TrtGptModelType::InflightFusedBatching),
+        testing::Values(TrtGptModelType::InflightFusedBatching),
         testing::Values(TrtGptModelIfbTestType::BULK), // TrtGptModelIfbTestType
         testing::Values(BeamConfig{1, {1}}),           // beam config
         testing::Values(257),                          // maxTokensInPagedKvCache
@@ -1272,7 +1271,7 @@ INSTANTIATE_TEST_SUITE_P(GptChunkedLongContextTests, ParamTest,
                 .setKVCacheType(KVCacheType::kPAGED)
                 .useDraftTokensExternalDecoding()
                 .setDraftTokens(5)),
-        testing::Values(TrtGptModelType::InflightBatching, TrtGptModelType::InflightFusedBatching),
+        testing::Values(TrtGptModelType::InflightFusedBatching),
         testing::Values(TrtGptModelIfbTestType::BULK, TrtGptModelIfbTestType::WAVEFRONT,
             TrtGptModelIfbTestType::RANDOM), // TrtGptModelIfbTestType
         testing::Values(BeamConfig{1, {1}}), // beam config
@@ -1310,7 +1309,7 @@ INSTANTIATE_TEST_SUITE_P(GptDraftTests, ParamTest,
                 .replaceLogits()
                 .collectGenerationLogitsFile()
                 .collectContextLogitsFile()),
-        testing::Values(TrtGptModelType::InflightBatching, TrtGptModelType::InflightFusedBatching),
+        testing::Values(TrtGptModelType::InflightFusedBatching),
         testing::Values(
             TrtGptModelIfbTestType::BULK, TrtGptModelIfbTestType::WAVEFRONT, TrtGptModelIfbTestType::RANDOM),
         testing::Values(BeamConfig{1, {1}}), // beamConfig
@@ -1391,7 +1390,7 @@ INSTANTIATE_TEST_SUITE_P(GptjTests, ParamTest,
                 .usePackedInput()
 
                 ),
-        testing::Values(TrtGptModelType::InflightBatching, TrtGptModelType::InflightFusedBatching),
+        testing::Values(TrtGptModelType::InflightFusedBatching),
         // WAR: disable wavefront and random tests on because of switched beams
         testing::Values(TrtGptModelIfbTestType::BULK
             /* , TrtGptModelIfbTestType::WAVEFRONT, TrtGptModelIfbTestType::RANDOM */),
@@ -1488,7 +1487,7 @@ INSTANTIATE_TEST_SUITE_P(LlamaTests, ParamTest,
                 .useTensorParallelism(2)
 
                 ),
-        testing::Values(TrtGptModelType::InflightBatching, TrtGptModelType::InflightFusedBatching),
+        testing::Values(TrtGptModelType::InflightFusedBatching),
         testing::Values(
             TrtGptModelIfbTestType::BULK, TrtGptModelIfbTestType::WAVEFRONT, TrtGptModelIfbTestType::RANDOM),
         testing::Values(
@@ -1665,7 +1664,7 @@ INSTANTIATE_TEST_SUITE_P(GptjFP8Tests, ParamTest,
                 .usePackedInput()
 
                 ),
-        testing::Values(TrtGptModelType::InflightBatching, TrtGptModelType::InflightFusedBatching),
+        testing::Values(TrtGptModelType::InflightFusedBatching),
         testing::Values(
             TrtGptModelIfbTestType::BULK, TrtGptModelIfbTestType::WAVEFRONT, TrtGptModelIfbTestType::RANDOM),
         testing::Values(

--- a/cpp/tests/executor/disaggExecutorTest.cpp
+++ b/cpp/tests/executor/disaggExecutorTest.cpp
@@ -291,8 +291,8 @@ void runDisaggTest(tensorrt_llm::testing::disaggexecutor::DisaggExecutorLeader& 
             ++iter;
         }
         EXPECT_LT(iter, maxWaitMs);
-        testData.verifyOutput(tokens, givenInputLengths, nbGivenInputs, streaming, outConfig.excludeInputFromOutput,
-            flakyTestInfo, isSpeculativeDecoding, returnAllGeneratedTokens, beamWidth, numReturnSequences, false);
+        testData.verifyOutput(tokens, givenInputLengths, streaming, outConfig.excludeInputFromOutput, flakyTestInfo,
+            isSpeculativeDecoding, beamWidth, numReturnSequences, false);
     }
     comm.barrier();
     if (executor.isGenerationRank())
@@ -449,8 +449,8 @@ void runDisaggTest(DisaggExecutorOrchestrator& executor, tensorrt_llm::runtime::
             ++iter;
         }
         EXPECT_LT(iter, maxWaitMs);
-        testData.verifyOutput(tokens, givenInputLengths, nbGivenInputs, streaming, outConfig.excludeInputFromOutput,
-            flakyTestInfo, isSpeculativeDecoding, returnAllGeneratedTokens, beamWidth, numReturnSequences, false);
+        testData.verifyOutput(tokens, givenInputLengths, streaming, outConfig.excludeInputFromOutput, flakyTestInfo,
+            isSpeculativeDecoding, beamWidth, numReturnSequences, false);
     }
     comm.barrier();
 }
@@ -1110,8 +1110,8 @@ TEST_P(ConditionalDisaggParamsTest, DisaggTokenComparison)
             ++iter;
         }
         EXPECT_LT(iter, mMaxWaitMs);
-        testData.verifyOutput(tokens, givenInputLengths, nbGivenInputs, streaming, outConfig.excludeInputFromOutput,
-            flakyTestInfo, isSpeculativeDecoding, false, beamWidth, numReturnSequences, false);
+        testData.verifyOutput(tokens, givenInputLengths, streaming, outConfig.excludeInputFromOutput, flakyTestInfo,
+            isSpeculativeDecoding, beamWidth, numReturnSequences, false);
     }
     world_comm.barrier();
 #else

--- a/cpp/tests/executor/executorTest.cpp
+++ b/cpp/tests/executor/executorTest.cpp
@@ -4512,10 +4512,10 @@ INSTANTIATE_TEST_SUITE_P(LlamaExecutorTest, AllParamsTest,
     testing::Combine(                                                                   //
         testing::Values(false, true),                                                   // streaming
         testing::Values(1, 2),                                                          // beamWidth
-        testing::Values(true),                                                          // computeLogProbs
+        testing::Values(false),                                                         // computeLogProbs
         testing::Values(false, true),                                                   // excludeInputInOutput
-        testing::Values(true),                                                          // returnContextLogits
-        testing::Values(true),                                                          // returnGenerationLogits
+        testing::Values(false),                                                         // returnContextLogits
+        testing::Values(false),                                                         // returnGenerationLogits
         testing::Values("llama_tp1_pp4_cp1", "llama_tp4_pp1_cp1", "llama_tp2_pp2_cp1"), // modelName
         testing::Values(false, true),                                                   // useOrchestratorMode
         testing::Values(false),                                                         // returnAllGeneratedTokens

--- a/cpp/tests/executor/executorTest.cpp
+++ b/cpp/tests/executor/executorTest.cpp
@@ -4391,7 +4391,7 @@ TEST_P(TimeoutTest, TimeoutNonstreamingTest)
     VecTokens finishedTokens{101, 102, 103, 104};
     auto finishedRequest
         = Request(finishedTokens, maxNewTokens, false, tensorrt_llm::executor::SamplingConfig(beamWidth));
-    finishedRequest.setAllottedTimeMs(std::chrono::milliseconds(5000));
+    finishedRequest.setAllottedTimeMs(std::chrono::milliseconds(6000));
     std::vector<std::vector<int>> finishedReponse
         = {{101, 102, 103, 104, 49849, 225, 49849, 232, 55742}, {101, 102, 103, 104, 49849, 225, 49849, 232, 29082}};
 

--- a/cpp/tests/executor/executorTest.cpp
+++ b/cpp/tests/executor/executorTest.cpp
@@ -2128,10 +2128,6 @@ TEST_P(AllParamsTest, TokenComparison)
     {
         GTEST_SKIP() << "Test does not support returnAllGeneratedTokens without streaming";
     }
-    if (returnAllGeneratedTokens && outConfig.returnLogProbs)
-    {
-        GTEST_SKIP() << "Skip returnAllGeneratedTokens with outConfig.returnLogProbs to reduce number of tests";
-    }
 
     std::optional<std::vector<SizeType32>> participantIds = std::nullopt;
 
@@ -4499,10 +4495,10 @@ INSTANTIATE_TEST_SUITE_P(GptExecutorTest, AllParamsTest,
     testing::Combine(                 //
         testing::Values(false, true), // streaming
         testing::Values(1, 2),        // beamWidth
-        testing::Values(false, true), // computeLogProbs
+        testing::Values(true),        // computeLogProbs
         testing::Values(false, true), // excludeInputInOutput
-        testing::Values(false, true), // returnContextLogits
-        testing::Values(false, true), // returnGenerationLogits
+        testing::Values(true),        // returnContextLogits
+        testing::Values(true),        // returnGenerationLogits
         testing::Values("gpt"),       // modelName
         testing::Values(false, true), // useOrchestratorMode
         testing::Values(false, true), // returnAllGeneratedTokens
@@ -4514,10 +4510,10 @@ INSTANTIATE_TEST_SUITE_P(LlamaExecutorTest, AllParamsTest,
     testing::Combine(                                                                   //
         testing::Values(false, true),                                                   // streaming
         testing::Values(1, 2),                                                          // beamWidth
-        testing::Values(false, true),                                                   // computeLogProbs
+        testing::Values(true),                                                          // computeLogProbs
         testing::Values(false, true),                                                   // excludeInputInOutput
-        testing::Values(false, true),                                                   // returnContextLogits
-        testing::Values(false, true),                                                   // returnGenerationLogits
+        testing::Values(true),                                                          // returnContextLogits
+        testing::Values(true),                                                          // returnGenerationLogits
         testing::Values("llama_tp1_pp4_cp1", "llama_tp4_pp1_cp1", "llama_tp2_pp2_cp1"), // modelName
         testing::Values(false, true),                                                   // useOrchestratorMode
         testing::Values(false),                                                         // returnAllGeneratedTokens

--- a/cpp/tests/executor/executorTest.cpp
+++ b/cpp/tests/executor/executorTest.cpp
@@ -567,13 +567,22 @@ TEST_F(GptExecutorTest, GenerationChangeEndId)
     }
 }
 
+// stream, excludeInputFromOutput, beamWidth
 using ParamType = std::tuple<bool, bool, int>;
+// streaming, useOrchestratorMode, beamWidth, numReturnSequences, modelName
 using ParamCancelReqType = std::tuple<bool, bool, int, int, std::string>;
+// streaming, modelName
 using LeaderApiUsageType = std::tuple<bool, std::string>;
+// iterStatsMaxIterations, useOrchestratorMode
 using ParamStatsType = std::tuple<int, bool>;
+// streaming, beamWidth, computeLogProbs, excludeInputInOutput, returnContextLogits, returnGenerationLogits, modelName,
+// useOrchestratorMode, returnAllGeneratedTokens, numReturnSequences
 using AllParamsType = std::tuple<bool, int, bool, bool, bool, bool, std::string, bool, bool, int>;
+// modelName, batched, replicated
 using LogitsProcParamsType = std::tuple<std::string, bool, bool>;
+// modelName
 using GuidedDecodingParamsType = std::tuple<std::string>;
+// modelName, useOrchestratorMode, beamWidth
 using TimeoutTestParamsType = std ::tuple<std::string, bool, int>;
 
 std::string generateTestName(testing::TestParamInfo<ParamType> const& info)
@@ -4447,28 +4456,43 @@ TEST_P(TimeoutTest, TimeoutNonstreamingTest)
 }
 
 INSTANTIATE_TEST_SUITE_P(GptExecutorTest, ParamTest,
-    testing::Combine(testing::Values(false, true), // streaming
-        testing::Values(false, true),              // excludeInputFromOutput
-        testing::Values(1, 2)                      // beamWidth
+    testing::Combine(                 //
+        testing::Values(false, true), // streaming
+        testing::Values(false, true), // excludeInputFromOutput
+        testing::Values(1, 2)         // beamWidth
         ),
     generateTestName);
 
 INSTANTIATE_TEST_SUITE_P(GptExecutorTest, ParamStatsTest,
-    testing::Combine(testing::Values(0, 1000), testing::Values(false, true)), generateTestNameStats);
+    testing::Combine(                //
+        testing::Values(0, 1000),    // iterStatsMaxIterations
+        testing::Values(false, true) // useOrchestratorMode
+        ),
+    generateTestNameStats);
 
 INSTANTIATE_TEST_SUITE_P(LlamaExecutorTest, ParamCancelReqTest,
-    testing::Combine(testing::Values(false, true), testing::Values(false, true), testing::Values(1, 2),
-        testing::Values(1, 2), testing::Values("llama_tp1_pp4_cp1", "llama_tp4_pp1_cp1", "llama_tp2_pp2_cp1")),
+    testing::Combine(                                                                  //
+        testing::Values(false, true),                                                  // streaming
+        testing::Values(false, true),                                                  // useOrchestratorMode
+        testing::Values(1, 2),                                                         // beamWidth
+        testing::Values(1, 2),                                                         // numReturnSequences
+        testing::Values("llama_tp1_pp4_cp1", "llama_tp4_pp1_cp1", "llama_tp2_pp2_cp1") // modelName
+        ),
     generateTestNameCancelReq);
 
 INSTANTIATE_TEST_SUITE_P(LlamaExecutorTest, TimeoutTest,
-    testing::Combine(testing::Values("llama_tp1_pp4_cp1", "llama_tp4_pp1_cp1", "llama_tp1_pp1_cp1"),
-        testing::Values(false, true), testing::Values(2)),
+    testing::Combine(                                                                   //
+        testing::Values("llama_tp1_pp4_cp1", "llama_tp4_pp1_cp1", "llama_tp1_pp1_cp1"), // modelName
+        testing::Values(false, true),                                                   // useOrchestratorMode
+        testing::Values(2)                                                              // beamWidth
+        ),
     generateTestNameTimeoutTest);
 
 INSTANTIATE_TEST_SUITE_P(LlamaExecutorTest, LeaderApiUsageTest,
-    testing::Combine(
-        testing::Values(false, true), testing::Values("llama_tp1_pp4_cp1", "llama_tp4_pp1_cp1", "llama_tp2_pp2_cp1")),
+    testing::Combine(                                                                  //
+        testing::Values(false, true),                                                  // streaming
+        testing::Values("llama_tp1_pp4_cp1", "llama_tp4_pp1_cp1", "llama_tp2_pp2_cp1") // modelName
+        ),
     generateTestNameLeaderApiUsage);
 
 INSTANTIATE_TEST_SUITE_P(GptExecutorTest, AllParamsTest,
@@ -4594,9 +4618,12 @@ INSTANTIATE_TEST_SUITE_P(ChatGlm3ExecutorTest, AllParamsTest,
     generateTestNameAllParams);
 
 INSTANTIATE_TEST_SUITE_P(LlamaExecutorTest, LogitsProcParamsTest,
-    testing::Combine(
-        testing::Values("llama_tp1_pp1_cp1", "llama_tp4_pp1_cp1", "llama_tp2_pp2_cp1", "llama_tp1_pp4_cp1"),
-        testing::Values(false, true), testing::Values(false, true)),
+    testing::Combine(                                                                            //
+        testing::Values(
+            "llama_tp1_pp1_cp1", "llama_tp4_pp1_cp1", "llama_tp2_pp2_cp1", "llama_tp1_pp4_cp1"), // modelName
+        testing::Values(false, true),                                                            // batched
+        testing::Values(false, true)                                                             // replicated
+        ),
     generateTestNameLogitsProc);
 
 INSTANTIATE_TEST_SUITE_P(GptExecutorGuidedDecodingTest, GuidedDecodingParamsTest,

--- a/cpp/tests/utils/common.h
+++ b/cpp/tests/utils/common.h
@@ -187,9 +187,8 @@ public:
         tr::BufferManager& manager, executor::OutputConfig const& outConfig, ModelIds const& modelIds);
 
     void verifyOutput(std::unordered_map<SizeType32, std::vector<executor::BeamTokens>> const& resultTokens,
-        std::vector<SizeType32> const& givenInputLengths, SizeType32 nbGivenInputs, bool streaming,
-        bool excludeInputFromOutput, FlakyTestInfo flakyTestInfo, bool isSpeculativeDecoding,
-        bool returnAllGeneratedTokens, SizeType32 reqBeamWidth, SizeType32 numReturnSequences,
+        std::vector<SizeType32> const& givenInputLengths, bool streaming, bool excludeInputFromOutput,
+        FlakyTestInfo flakyTestInfo, bool isSpeculativeDecoding, SizeType32 reqBeamWidth, SizeType32 numReturnSequences,
         bool isNonGreedySampling);
 
     void verifyLogProbs(bool computeLogProbs, bool streaming, bool excludeInputFromOutput, SizeType32 inputLength,

--- a/tests/integration/defs/cpp/test_multi_gpu.py
+++ b/tests/integration/defs/cpp/test_multi_gpu.py
@@ -478,12 +478,7 @@ def test_enc_dec(build_google_tests, multi_gpu_model, build_dir):
 
 @pytest.mark.parametrize("build_google_tests", ["80", "86", "89", "90"],
                          indirect=True)
-@pytest.mark.parametrize("mode", [
-    "orchestrator",
-    pytest.param(
-        "leader",
-        marks=pytest.mark.skip("https://nvbugspro.nvidia.com/bug/5026255"))
-])
+@pytest.mark.parametrize("mode", ["orchestrator", "leader"])
 @pytest.mark.parametrize("multi_gpu_model", ["llama"], indirect=True)
 def test_llama_executor(build_google_tests, multi_gpu_model, mode, lora_setup,
                         build_dir):


### PR DESCRIPTION
## Description

- Always enable TRT overlap and chunked context in `trtGptModelRealDecoderTest`.
- Use only `InflightFusedBatching` in most `trtGptModelRealDecoderTest` tests. 
- Improve documentation in executor tests.
- Refactor `TokenComparison` executor test and improve output verification (Fix log probs verification with `returnAllGeneratedTokens` enabled).
-  Always enable `computeLogProbs`, `returnContextLogits`, and `returnGenerationLogits` in executor tests.
- Re-enable executor leader tests.
- Refactor ParamCancelReqTest executor test (Create requests with different parameters instead of using test parameters).
- Refactor LeaderApiUsageTest and enable (Create requests with different parameters instead of using test parameters).    

## Test Durations 

Before numbers from post-merge 2127.

| Test Case | Before | After |
|-----------|--|--|
| A30-CPP-1/cpp/test_e2e.py::test_model[-gpt_executor-80] | 2596.86s | 1556.37s |
| A30-CPP-2/cpp/test_e2e.py::test_model[-gpt-80] | 2196.60s | 1503.43s |
| A30-CPP-3/cpp/test_e2e.py::test_model[-gpt_tests-80] | 1595.81s | 1226.72s |
| H100_PCIe-CPP-2/cpp/test_e2e.py::test_model[fp8-llama-90] | 944.47s | 384.55s |
| DGX_H100-4_GPUs-CPP-1/cpp/test_multi_gpu.py::test_trt_gpt_real_decoder[llama-90] | 327.91s | 167.66s |
| DGX_H100-4_GPUs-CPP-1/cpp/test_multi_gpu.py::test_llama_executor[llama-orchestrator-90] | 526.56s | 296.48s |
| DGX_H100-4_GPUs-CPP-1/cpp/test_multi_gpu.py::test_llama_executor[llama-leader-90] | - | 125.93s |

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
