### PR TITLE
Draft: chore: add the sequence block of context request

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -877,6 +877,8 @@ public:
 
     void releaseBlocks(GenerationRequest& sequence, OptionalRef<LlmRequest const> llmRequest = std::nullopt);
 
+    void storeBlocksForReuse(GenerationRequest& sequence, OptionalRef<LlmRequest const> llmRequest = std::nullopt);
+
     void schedulingReleaseBlocks(LlmRequest::RequestIdType requestId);
 
     void releaseLastBlock(GenerationRequest& sequence, SizeType32 windowSize);
@@ -1222,6 +1224,8 @@ public:
         OptionalRef<LlmRequest> llmRequest = std::nullopt)
         = 0;
 
+    virtual void addSequenceForBlockReuse(LlmRequest::RequestIdType requestId, OptionalRef<LlmRequest const> llmRequest = std::nullopt) = 0;
+
     virtual void removeSequence(
         LlmRequest::RequestIdType requestId, OptionalRef<LlmRequest const> llmRequest = std::nullopt)
         = 0;
@@ -1508,6 +1512,8 @@ public:
     /// inputLength - 1 tokens and populate prepopulatedPromptLen.
     void addSequence(LlmRequest::RequestIdType requestId, SizeType32 inputLength, SizeType32 beamWidth,
         OptionalRef<LlmRequest> llmRequest = std::nullopt) override;
+
+    void addSequenceForBlockReuse(LlmRequest::RequestIdType requestId, OptionalRef<LlmRequest const> llmRequest = std::nullopt) override;
 
     void removeSequence(
         LlmRequest::RequestIdType requestId, OptionalRef<LlmRequest const> llmRequest = std::nullopt) override;

--- a/cpp/tensorrt_llm/pybind/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/kvCacheManager.cpp
@@ -102,6 +102,12 @@ public:
             void, tbk::BaseKVCacheManager, addSequence, requestId, inputLength, beamWidth, llmRequest);
     }
 
+    void addSequenceForBlockReuse(tb::LlmRequest::RequestIdType requestId,
+        tensorrt_llm::common::OptionalRef<tb::LlmRequest const> llmRequest = std::nullopt) override
+    {
+        PYBIND11_OVERLOAD_PURE(void, tbk::BaseKVCacheManager, addSequenceForBlockReuse, requestId, llmRequest);
+    }
+
     void removeSequence(tb::LlmRequest::RequestIdType requestId,
         tensorrt_llm::common::OptionalRef<tb::LlmRequest const> llmRequest = std::nullopt) override
     {
@@ -341,6 +347,7 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(py::module_& m)
         .def("add_token", &BaseKVCacheManager::addToken)
         .def("add_sequence", &BaseKVCacheManager::addSequence)
         .def("remove_sequence", &BaseKVCacheManager::removeSequence)
+        .def("add_sequence_for_block_reuse", &BaseKVCacheManager::addSequenceForBlockReuse)
         .def("scheduling_remove_sequence", &BaseKVCacheManager::schedulingRemoveSequence)
         .def("get_block_pool_pointers",
             [](tbk::BaseKVCacheManager& self)

--- a/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
@@ -369,7 +369,7 @@ class Qwen3MoEModel(DecoderModel):
         hidden_states = inputs_embeds
 
         residual = None
-        for idx, decoder_layer in enumerate(self.layers):
+        for decoder_layer in self.layers:
             hidden_states, residual = decoder_layer(position_ids=position_ids,
                                                     hidden_states=hidden_states,
                                                     attn_metadata=attn_metadata,

--- a/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
@@ -263,7 +263,6 @@ class Qwen3MoEDecoderLayer(DecoderLayer):
             do_finalize=do_finalize,
         )
 
-        # print(f"self.layer_idx: {self.layer_idx}, do_finalize: {do_finalize}, spec_metadata is not None: {spec_metadata is not None}")
         if self.fusion_config.POST_MOE_FUSION:
             if do_finalize:
                 if spec_metadata:

--- a/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
@@ -263,11 +263,12 @@ class Qwen3MoEDecoderLayer(DecoderLayer):
             do_finalize=do_finalize,
         )
 
-        if spec_metadata:
-            spec_metadata.maybe_capture_hidden_states(self.layer_idx,
-                                                      hidden_states, residual)
+        # print(f"self.layer_idx: {self.layer_idx}, do_finalize: {do_finalize}, spec_metadata is not None: {spec_metadata is not None}")
         if self.fusion_config.POST_MOE_FUSION:
             if do_finalize:
+                if spec_metadata:
+                    spec_metadata.maybe_capture_hidden_states(
+                        self.layer_idx, hidden_states, residual)
                 hidden_states, residual = self.allreduce(
                     hidden_states,
                     all_reduce_params=AllReduceParams(
@@ -296,7 +297,15 @@ class Qwen3MoEDecoderLayer(DecoderLayer):
                 )
                 hidden_states, residual = self.moe_allreduce(
                     fc2_output, all_reduce_params=moe_all_reduce_params)
+
+                if spec_metadata:
+                    spec_metadata.maybe_capture_hidden_states(
+                        self.layer_idx, hidden_states, residual)
+
         else:
+            if spec_metadata:
+                spec_metadata.maybe_capture_hidden_states(
+                    self.layer_idx, hidden_states, residual)
             if self.next_layer_layernorm is not None:
                 hidden_states, residual = self.next_layer_layernorm(
                     hidden_states, residual)
@@ -361,7 +370,7 @@ class Qwen3MoEModel(DecoderModel):
         hidden_states = inputs_embeds
 
         residual = None
-        for decoder_layer in self.layers:
+        for idx, decoder_layer in enumerate(self.layers):
             hidden_states, residual = decoder_layer(position_ids=position_ids,
                                                     hidden_states=hidden_states,
                                                     attn_metadata=attn_metadata,

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -377,6 +377,9 @@ class KVCacheManager(BaseResourceManager):
                 if request.py_rewind_len > 0:
                     self.rewind_kv_cache(request, request.py_rewind_len)
 
+        for request in scheduled_batch.context_requests:
+            self.impl.add_sequence_for_block_reuse(request.py_request_id, request)
+
     def free_resources(self, request: LlmRequest):
         self.impl.remove_sequence(request.py_request_id, request)
 


### PR DESCRIPTION
## PR Description

### Problem Statement
In the block reuse scenario, when multiple requests with identical sequences are processed in the same batch, the system cannot reuse sequence blocks if the first request is still in progress.

### Current Issue

Consider the following scenario:
Iteration 1: Server receives Request 1 with sequence S and processes it first
Iteration 2: Server receives Request 2 with the same sequence S
In this case, Request 2 should be able to reuse the blocks from Request 1. However, the current implementation only stores Request 1's blocks when the request completes, preventing Request 2 from accessing the cached blocks during its execution.

### Solution
This PR introduces a new function addSequenceForBlockReuse for context requests in the update_resource method. This enhancement allows the server to make KV cache blocks available for reuse immediately after the context phase completes, rather than waiting for the entire request to finish.

### Benefits
Enables immediate block reuse for subsequent requests with identical sequences
Improves overall system efficiency by reducing redundant KV cache computations
Maintains the existing block reuse functionality while extending its applicability to in-progress requests

### Technical Details
The addSequenceForBlockReuse function is called during the context phase completion, making the prompt's KV cache blocks available for reuse by new requests that arrive while the original request is still generating tokens.