### PR TITLE
[fix][ci] dont build wheel for cpp tests

### DIFF
--- a/tests/integration/defs/cpp/conftest.py
+++ b/tests/integration/defs/cpp/conftest.py
@@ -154,14 +154,13 @@ def build_google_tests(request, build_dir):
 
     print(f"Using CUDA arch: {cuda_arch}")
 
-    build_trt_llm(
-        cuda_architectures=cuda_arch,
-        job_count=12,
-        use_ccache=True,
-        clean=True,
-        trt_root="/usr/local/tensorrt",
-        nixl_root="/opt/nvidia/nvda_nixl",
-    )
+    build_trt_llm(cuda_architectures=cuda_arch,
+                  job_count=12,
+                  use_ccache=True,
+                  clean=True,
+                  trt_root="/usr/local/tensorrt",
+                  nixl_root="/opt/nvidia/nvda_nixl",
+                  skip_building_wheel=True)
 
     make_google_tests = [
         "cmake",


### PR DESCRIPTION
# [fix] Skip build wheel for CPP tests

The wheel building portion of `build_wheel.py` can take several minutes, and is not needed for CPP testing.