### PR TITLE
feature: support to nemotron-h-4b

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_nemotron_h.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_h.py
@@ -137,7 +137,7 @@ class NemotronHLayer(DecoderLayer):
             self.mixer = Mamba2Mixer(d_model=config.hidden_size,
                                      d_state=config.ssm_state_size,
                                      d_conv=config.conv_kernel,
-                                     num_heads=config.mamba_num_heads,
+                                     nheads=config.mamba_num_heads,
                                      n_groups=config.n_groups,
                                      head_dim=config.mamba_head_dim,
                                      chunk_size=config.chunk_size,

--- a/tensorrt_llm/_torch/models/modeling_nemotron_h.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_h.py
@@ -137,7 +137,7 @@ class NemotronHLayer(DecoderLayer):
             self.mixer = Mamba2Mixer(d_model=config.hidden_size,
                                      d_state=config.ssm_state_size,
                                      d_conv=config.conv_kernel,
-                                     expand=config.expand,
+                                     num_heads=config.mamba_num_heads,
                                      n_groups=config.n_groups,
                                      head_dim=config.mamba_head_dim,
                                      chunk_size=config.chunk_size,
@@ -247,6 +247,8 @@ class NemotronHForCausalLM(DecoderModelForCausalLM[NemotronHModel,
                 for k in model_config.quant_config.exclude_modules
             ]
 
+        model_config.pretrained_config.head_dim = model_config.pretrained_config.attention_head_dim
+
         super().__init__(
             NemotronHModel(model_config),
             config=model_config,
@@ -258,7 +260,7 @@ class NemotronHForCausalLM(DecoderModelForCausalLM[NemotronHModel,
         config = self.model_config.pretrained_config
         tp_size = self.model_config.mapping.tp_size
         tp_rank = self.model_config.mapping.tp_rank
-        d_inner = config.hidden_size * config.expand
+        d_inner = config.mamba_head_dim * config.mamba_num_heads
         n_groups = config.n_groups
         d_state = config.ssm_state_size
         nheads = d_inner // config.mamba_head_dim

--- a/tensorrt_llm/_torch/models/modeling_nemotron_h.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_h.py
@@ -247,6 +247,9 @@ class NemotronHForCausalLM(DecoderModelForCausalLM[NemotronHModel,
                 for k in model_config.quant_config.exclude_modules
             ]
 
+        # Nemotron-H config.json uses attention_head_dim instead of head_dim which makes the
+        # attention module use the wrong head_dim, based on hidden_size and num_attention_heads.
+        # for this model, we need to override the head_dim to attention_head_dim.
         model_config.pretrained_config.head_dim = model_config.pretrained_config.attention_head_dim
 
         super().__init__(

--- a/tensorrt_llm/_torch/modules/mamba/mamba2_mixer.py
+++ b/tensorrt_llm/_torch/modules/mamba/mamba2_mixer.py
@@ -38,7 +38,7 @@ class Mamba2Mixer(nn.Module):
         d_model: int,
         d_state: int,
         d_conv: int,
-        expand: int,
+        num_heads: int,
         n_groups: int,
         head_dim: int,
         chunk_size: int,
@@ -60,7 +60,7 @@ class Mamba2Mixer(nn.Module):
         tp_rank = config.mapping.tp_rank
         tp_size = config.mapping.tp_size
 
-        d_inner = d_model * expand
+        d_inner = head_dim * num_heads
         nheads = d_inner // head_dim
         d_in_proj = 2 * d_inner + 2 * n_groups * d_state + nheads
         conv_dim = d_inner + 2 * n_groups * d_state

--- a/tensorrt_llm/_torch/modules/mamba/mamba2_mixer.py
+++ b/tensorrt_llm/_torch/modules/mamba/mamba2_mixer.py
@@ -38,7 +38,7 @@ class Mamba2Mixer(nn.Module):
         d_model: int,
         d_state: int,
         d_conv: int,
-        num_heads: int,
+        nheads: int,
         n_groups: int,
         head_dim: int,
         chunk_size: int,
@@ -60,8 +60,7 @@ class Mamba2Mixer(nn.Module):
         tp_rank = config.mapping.tp_rank
         tp_size = config.mapping.tp_size
 
-        d_inner = head_dim * num_heads
-        nheads = d_inner // head_dim
+        d_inner = head_dim * nheads
         d_in_proj = 2 * d_inner + 2 * n_groups * d_state + nheads
         conv_dim = d_inner + 2 * n_groups * d_state
 

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -319,7 +319,7 @@ class KvCacheCreator:
                 config.hidden_size,
                 config.ssm_state_size,
                 config.conv_kernel,
-                config.expand,
+                config.mamba_num_heads,
                 config.n_groups,
                 config.mamba_head_dim,
                 mamba_num_layers,

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -518,7 +518,7 @@ class MambaCacheManager(BaseResourceManager):
         d_model: int,
         d_state: int,
         d_conv: int,
-        expand: int,
+        num_heads: int,
         n_groups: int,
         head_dim: int,
         num_layers: int,
@@ -532,7 +532,7 @@ class MambaCacheManager(BaseResourceManager):
         tp_size = mapping.tp_size
 
         # derive mamba parameters for conv and ssm states
-        d_inner = d_model * expand
+        d_inner = head_dim * num_heads
         conv_dim = d_inner + 2 * n_groups * d_state
         nheads = d_inner // head_dim
 
@@ -649,7 +649,7 @@ class MambaHybridCacheManager(KVCacheManager, MambaCacheManager):
         mamba_d_model: int,
         mamba_d_state: int,
         mamba_d_conv: int,
-        mamba_expand: int,
+        mamba_num_heads: int,
         mamba_n_groups: int,
         mamba_head_dim: int,
         mamba_num_layers: int,
@@ -682,7 +682,7 @@ class MambaHybridCacheManager(KVCacheManager, MambaCacheManager):
             mamba_d_model,
             mamba_d_state,
             mamba_d_conv,
-            mamba_expand,
+            mamba_num_heads,
             mamba_n_groups,
             mamba_head_dim,
             mamba_num_layers,

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -518,7 +518,7 @@ class MambaCacheManager(BaseResourceManager):
         d_model: int,
         d_state: int,
         d_conv: int,
-        num_heads: int,
+        nheads: int,
         n_groups: int,
         head_dim: int,
         num_layers: int,
@@ -532,9 +532,8 @@ class MambaCacheManager(BaseResourceManager):
         tp_size = mapping.tp_size
 
         # derive mamba parameters for conv and ssm states
-        d_inner = head_dim * num_heads
+        d_inner = head_dim * nheads
         conv_dim = d_inner + 2 * n_groups * d_state
-        nheads = d_inner // head_dim
 
         # check that can be partitioned
         assert nheads % tp_size == 0, "nheads must be divisible by tp_size"


### PR DESCRIPTION
# feature: support to nemotron-h-4b

## Description

This PR adds support for [Nemotron-H-4B](https://arxiv.org/pdf/2504.11409) @tomeras91 @suyoggupta 

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
