### PR TITLE
[5356427] fix: Remove the seq_len of 4096 from FP8 block scale MoE tuning configs.

### DIFF
--- a/tensorrt_llm/_torch/custom_ops/trtllm_gen_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/trtllm_gen_custom_ops.py
@@ -4,7 +4,8 @@ from typing import List, Tuple
 
 import torch
 
-from tensorrt_llm._torch.utils import last_positive_power_of_2
+from tensorrt_llm._torch.utils import (get_last_power_of_2_num_tokens_buckets,
+                                       last_positive_power_of_2)
 
 from ..autotuner import (AutoTuner, ConstraintSpec, DynamicTensorSpec,
                          OptimizationProfile, TunableRunner, TuningConfig)
@@ -123,8 +124,8 @@ class FP8BlockScaleMoERunner(TunableRunner):
         HIDDEN_STATES_IDX = 2
         TUNED_DIM = 0
 
-        m_values = (1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096)
-        round_rule = lambda x: last_positive_power_of_2(x)
+        m_values = get_last_power_of_2_num_tokens_buckets(2048)
+        round_rule = lambda x: min(last_positive_power_of_2(x), 2048)
 
         specs = (DynamicTensorSpec(HIDDEN_STATES_IDX, TUNED_DIM, m_values,
                                    round_rule), )

--- a/tests/unittest/_torch/thop/test_moe.py
+++ b/tests/unittest/_torch/thop/test_moe.py
@@ -579,8 +579,6 @@ def quant_dequant_per_tensor_fp8(a):
                          ids=["autotune", "no_autotune"])
 def test_moe_fp8(num_tokens, expert_info, hidden_size, intermediate_size,
                  use_autotune):
-    if use_autotune:
-        pytest.skip("https://nvbugs/5356427")
     torch.random.manual_seed(0)
 
     #


### PR DESCRIPTION
The seq_len of 4096 will cause some unknown CUDA illegal memory access issue if run with some other tests consecutively.
Put a saturated upper bound for any sequence length larger than it.