### PR TITLE
[TRTLLM-1316] refactor: Remove unnecessary pipeline parallelism logic from postProcessRequest

### DIFF
--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -1842,40 +1842,6 @@ void TrtGptModelInflightBatching::postProcessRequest(
         bufferManager.getStream().synchronize();
     }
 
-    if (mWorldConfig.isPipelineParallel())
-    {
-        // Send context logits from last to first PP rank
-        if (llmReq.getReturnContextLogits())
-        {
-            if (mWorldConfig.isLastPipelineParallelRank())
-            {
-                mMpiCommPipelinePara->send(
-                    *(llmReq.getContextLogitsHost()), 0, mpi::MpiTag::kTrtGptModelInflightBatchingContextLogits);
-            }
-            else if (mWorldConfig.isFirstPipelineParallelRank())
-            {
-                mMpiCommPipelinePara->recv(*(llmReq.getContextLogitsHost()), mWorldConfig.getPipelineParallelism() - 1,
-                    mpi::MpiTag::kTrtGptModelInflightBatchingContextLogits);
-            }
-        }
-
-        // Send generation logits from last to first PP rank
-        if (llmReq.getReturnGenerationLogits())
-        {
-            if (mWorldConfig.isLastPipelineParallelRank())
-            {
-                mMpiCommPipelinePara->send(
-                    *(llmReq.getGenerationLogitsHost()), 0, mpi::MpiTag::kTrtGptModelInflightBatchingGenerationLogits);
-            }
-            else if (mWorldConfig.isFirstPipelineParallelRank())
-            {
-                mMpiCommPipelinePara->recv(*(llmReq.getGenerationLogitsHost()),
-                    mWorldConfig.getPipelineParallelism() - 1,
-                    mpi::MpiTag::kTrtGptModelInflightBatchingGenerationLogits);
-            }
-        }
-    }
-
     if (reqBeamWidth == 1)
     {
         TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);

--- a/cpp/tests/executor/executorTest.cpp
+++ b/cpp/tests/executor/executorTest.cpp
@@ -1901,7 +1901,7 @@ namespace
 void runTest(Executor& executor, fs::path const& inputPath, ModelIds const& modelIds,
     FlakyTestInfo const& flakyTestInfo, bool streaming, SizeType32 const vocabSizePadded, BeamResult const& beamResult,
     OutputConfig const& outConfig, bool isSpeculativeDecoding, int maxWaitMs, bool returnAllGeneratedTokens,
-    SizeType32 const numReturnSequences, bool isNonGreedySampling)
+    SizeType32 const numReturnSequences, bool isNonGreedySampling, SizeType32 const modelParallelism)
 {
     auto const beamWidth = beamResult.beamWidth;
 
@@ -1948,7 +1948,6 @@ void runTest(Executor& executor, fs::path const& inputPath, ModelIds const& mode
 
     auto& comm = tensorrt_llm::mpi::MpiComm::world();
     auto const worldRank = comm.getRank();
-    auto const worldSize = comm.getSize();
 
     // Expected return sizes.
     auto const numSequences = beamWidth > 1 ? 1 : numReturnSequences;
@@ -2021,15 +2020,18 @@ void runTest(Executor& executor, fs::path const& inputPath, ModelIds const& mode
 
                     if (!isNonGreedySampling)
                     {
+                        float const logitsAtol = modelParallelism > 1 ? 1e-1 : 1e-2;
+                        float const logitsRtol = modelParallelism > 1 ? 1e-2 : 1e-3;
+
                         testData.verifyLogProbs(outConfig.returnLogProbs, streaming, outConfig.excludeInputFromOutput,
                             givenInputLengths.at(batchId), beamWidth, beamTokens, cumLogProbs, logProbs, batchId,
                             flakyTestInfo);
                         testData.validateContextLogits(outConfig.returnContextLogits, givenInputLengths.at(batchId),
-                            beamWidth, contextLogits, vocabSizePadded, batchId);
+                            beamWidth, contextLogits, vocabSizePadded, batchId, logitsAtol, logitsRtol);
                         testData.validateGenerationLogits(outConfig.returnGenerationLogits, result.isSequenceFinal,
                             streaming, outConfig.excludeInputFromOutput, givenInputLengths.at(batchId),
                             reqMaxNewTokens.at(batchId), beamWidth, beamTokens, genLogits, vocabSizePadded, batchId,
-                            returnAllGeneratedTokens);
+                            returnAllGeneratedTokens, logitsAtol, logitsRtol);
                     }
 
                     // Ignore first iteration as it doesn't use draft tokens
@@ -2063,12 +2065,14 @@ void runTest(Executor& executor, fs::path const& inputPath, ModelIds const& mode
 void runTest(fs::path const& modelPath, ExecutorConfig const& executorConfig, fs::path const& inputPath,
     ModelIds const& modelIds, FlakyTestInfo const& flakyTestInfo, bool streaming, SizeType32 const vocabSizePadded,
     BeamResult const& beamResult, OutputConfig const& outConfig, bool isSpeculativeDecoding, int maxWaitMs,
-    bool returnAllGeneratedTokens, SizeType32 const numReturnSequences, bool isNonGreedySampling)
+    bool returnAllGeneratedTokens, SizeType32 const numReturnSequences, bool isNonGreedySampling,
+    SizeType32 const modelParallelism)
 {
     auto executor = Executor{modelPath, ModelType::kDECODER_ONLY, executorConfig};
 
     runTest(executor, inputPath, modelIds, flakyTestInfo, streaming, vocabSizePadded, beamResult, outConfig,
-        isSpeculativeDecoding, maxWaitMs, returnAllGeneratedTokens, numReturnSequences, isNonGreedySampling);
+        isSpeculativeDecoding, maxWaitMs, returnAllGeneratedTokens, numReturnSequences, isNonGreedySampling,
+        modelParallelism);
 }
 
 ExecutorConfig createExecutorConfig(SizeType32 maxBeamWidth, bool useOrchestratorMode, bool gatherGenerationLogits,
@@ -2193,6 +2197,12 @@ TEST_P(AllParamsTest, TokenComparison)
             beamResult.resultsFile = resultsPath / PathUtil::FP16_PLUGIN_PACKED_PAGED_RESULT_TP2_PP2_FILE();
             modelPath = LLAMA_MODEL_PATH / PathUtil::FP16_GPT_ATTENTION_PACKED_PAGED_DIR() / "tp2-pp2-cp1-gpu";
         }
+        beamResult.genLogitsFile = resultsPath / PathUtil::FP16_PLUGIN_PACKED_PAGED_GENERATION_LOGITS_TP4_PP1_FILE();
+        if (outConfig.returnLogProbs)
+        {
+            beamResult.cumLogProbsFile = resultsPath / PathUtil::FP16_PLUGIN_PACKED_PAGED_CUM_LOG_PROBS_TP4_PP1_FILE();
+            beamResult.logProbsFile = resultsPath / PathUtil::FP16_PLUGIN_PACKED_PAGED_LOG_PROBS_TP4_PP1_FILE();
+        }
     }
     else if (modelName == "medusa")
     {
@@ -2283,9 +2293,9 @@ TEST_P(AllParamsTest, TokenComparison)
             GTEST_SKIP() << "Skipping Llama test";
         }
 
-        if (outConfig.returnLogProbs || outConfig.returnContextLogits || outConfig.returnGenerationLogits)
+        if (outConfig.returnContextLogits)
         {
-            GTEST_SKIP() << "Skipping logits and log probs tests for mpi runs";
+            GTEST_SKIP() << "Skipping context logits tests for mpi runs";
         }
 
         // Check that it was launched with right number of MPI ranks
@@ -2302,11 +2312,12 @@ TEST_P(AllParamsTest, TokenComparison)
     }
     auto decoderJsonConfig = tensorrt_llm::runtime::GptJsonConfig::parse(modelPath / "config.json");
 
-    auto modelTP = decoderJsonConfig.getTensorParallelism();
-    auto modelPP = decoderJsonConfig.getPipelineParallelism();
+    auto const modelTP = decoderJsonConfig.getTensorParallelism();
+    auto const modelPP = decoderJsonConfig.getPipelineParallelism();
+    auto const modelParallelism = modelTP * modelPP;
     int deviceCount = -1;
     TLLM_CUDA_CHECK(cudaGetDeviceCount(&deviceCount));
-    std::optional<std::vector<SizeType32>> deviceIds = std::vector<SizeType32>(modelTP * modelPP);
+    std::optional<std::vector<SizeType32>> deviceIds = std::vector<SizeType32>(modelParallelism);
     for (auto i = 0; i < deviceIds->size(); i++)
     {
         deviceIds->at(i) = i % deviceCount;
@@ -2354,7 +2365,8 @@ TEST_P(AllParamsTest, TokenComparison)
         std::move(deviceIds), std::move(participantIds));
 
     runTest(modelPath, executorConfig, inputPath, modelIds, flakyTestInfo, streaming, vocabSizePadded, beamResult,
-        outConfig, isSpeculativeDecoding, mMaxWaitMs, returnAllGeneratedTokens, numReturnSequences, false);
+        outConfig, isSpeculativeDecoding, mMaxWaitMs, returnAllGeneratedTokens, numReturnSequences, false,
+        modelParallelism);
 }
 
 TEST_F(GptExecutorTest, ChangeBeamWidth)
@@ -2455,7 +2467,7 @@ void doTokenComparisonChangeBeamWidth(bool enableReuse, SizeType32 maxWaitMs)
         beamResult.genLogitsFile = resultsPath / PathUtil::FP16_PLUGIN_PACKED_PAGED_GENERATION_LOGITS_FILE();
 
         runTest(executor, inputPath, modelIds, flakyTestInfo, streaming, vocabSizePadded, beamResult, outConfig,
-            isSpeculativeDecoding, maxWaitMs, false, 1, false);
+            isSpeculativeDecoding, maxWaitMs, false, 1, false, 1);
     }
 }
 
@@ -2497,7 +2509,7 @@ TEST_F(GptExecutorTest, NReturnRandomness)
     beamResult.genLogitsFile = resultsPath / PathUtil::FP16_PLUGIN_PACKED_PAGED_GENERATION_LOGITS_FILE();
 
     runTest(executor, inputPath, modelIds, flakyTestInfo, streaming, vocabSizePadded, beamResult, outConfig,
-        isSpeculativeDecoding, mMaxWaitMs, false, 1, true);
+        isSpeculativeDecoding, mMaxWaitMs, false, 1, true, 1);
 }
 
 TEST_F(GptExecutorTest, TimedOut)

--- a/cpp/tests/executor/executorTest.cpp
+++ b/cpp/tests/executor/executorTest.cpp
@@ -4538,10 +4538,10 @@ INSTANTIATE_TEST_SUITE_P(LlamaExecutorTest, AllParamsTest,
     testing::Combine(                                                                   //
         testing::Values(false, true),                                                   // streaming
         testing::Values(1, 2),                                                          // beamWidth
-        testing::Values(false),                                                         // computeLogProbs
+        testing::Values(true),                                                          // computeLogProbs
         testing::Values(false, true),                                                   // excludeInputInOutput
         testing::Values(false),                                                         // returnContextLogits
-        testing::Values(false),                                                         // returnGenerationLogits
+        testing::Values(true),                                                          // returnGenerationLogits
         testing::Values("llama_tp1_pp4_cp1", "llama_tp4_pp1_cp1", "llama_tp2_pp2_cp1"), // modelName
         testing::Values(false, true),                                                   // useOrchestratorMode
         testing::Values(false),                                                         // returnAllGeneratedTokens

--- a/cpp/tests/resources/scripts/generate_expected_gpt_output.py
+++ b/cpp/tests/resources/scripts/generate_expected_gpt_output.py
@@ -65,27 +65,22 @@ def generate_output(engine: str,
 
     base_output_name = os.path.splitext(model_spec_obj.get_results_file())[0]
 
-    output_logits_args = []
-    if output_logits:
-        logits_file = base_output_name + '_logits.npy'
-        output_logits_args = [
-            '--output_logits_npy',
-            str(output_dir / logits_file),
-            '--output_generation_logits',
-        ]
-
-    results_file = str(output_dir / (base_output_name + '.npy'))
-    results_csv = str(output_dir / (base_output_name + '.csv'))
-
     args_list = [
-        '--engine_dir',
-        str(engine_dir), '--input_file',
-        str(input_file), '--tokenizer_dir',
-        str(models_dir / model), '--output_npy', results_file, '--output_csv',
-        results_csv, '--max_output_len',
-        str(max_output_len), '--num_beams',
-        str(num_beams), '--use_py_session'
-    ] + output_logits_args
+        f'--engine_dir={engine_dir}',
+        f'--input_file={input_file}',
+        f'--tokenizer_dir={models_dir / model}',
+        f'--output_npy={output_dir / (base_output_name + ".npy")}',
+        f'--output_csv={output_dir / (base_output_name + ".csv")}',
+        f'--max_output_len={max_output_len}',
+        f'--num_beams={num_beams}',
+        '--use_py_session',
+    ]
+
+    if output_logits:
+        args_list.extend([
+            f'--output_logits_npy={output_dir / (base_output_name + "_logits.npy")}',
+            '--output_generation_logits',
+        ])
 
     # Generate context_fmha_fp32_acc enabled results for GptExecutorTest.GenerationLogitsEarlyStop
     if model_spec_obj.get_enable_context_fmha_fp32_acc():
@@ -93,14 +88,12 @@ def generate_output(engine: str,
 
     if output_cum_log_probs:
         args_list.extend([
-            '--output_cum_log_probs_npy',
-            f'{output_dir / model_spec_obj.get_cum_log_probs_file()}'
+            f'--output_cum_log_probs_npy={output_dir / model_spec_obj.get_cum_log_probs_file()}'
         ])
 
     if output_log_probs:
         args_list.extend([
-            '--output_log_probs_npy',
-            f'{output_dir / model_spec_obj.get_log_probs_file()}'
+            f'--output_log_probs_npy={output_dir / model_spec_obj.get_log_probs_file()}'
         ])
 
     args = run.parse_arguments(args_list)

--- a/cpp/tests/resources/scripts/generate_expected_llama_output.py
+++ b/cpp/tests/resources/scripts/generate_expected_llama_output.py
@@ -107,6 +107,15 @@ def generate_outputs(num_beams, only_multi_gpu=False):
         print(
             f'Generating outputs for Llama FP16 with TP={tp_size}, PP={pp_size} and CP={cp_size}'
         )
+
+        output_logits = False
+        output_log_probs = False
+        output_cum_log_probs = False
+        if tp_size == 4 and pp_size == 1:
+            output_logits = True
+            output_log_probs = True
+            output_cum_log_probs = True
+
         model_spec_obj.use_tensor_parallelism(tp_size)
         model_spec_obj.use_pipeline_parallelism(pp_size)
         model_spec_obj.use_context_parallelism(cp_size)
@@ -115,7 +124,10 @@ def generate_outputs(num_beams, only_multi_gpu=False):
                         tp_size=tp_size,
                         pp_size=pp_size,
                         cp_size=cp_size,
-                        model_spec_obj=model_spec_obj)
+                        model_spec_obj=model_spec_obj,
+                        output_logits=output_logits,
+                        output_log_probs=output_log_probs,
+                        output_cum_log_probs=output_cum_log_probs)
 
 
 if __name__ == '__main__':

--- a/cpp/tests/resources/scripts/generate_expected_llama_output.py
+++ b/cpp/tests/resources/scripts/generate_expected_llama_output.py
@@ -16,6 +16,7 @@
 
 import argparse as _arg
 import os
+import time
 from pathlib import Path
 
 from mpi4py.MPI import COMM_WORLD
@@ -105,8 +106,9 @@ def generate_outputs(num_beams, only_multi_gpu=False):
 
     for tp_size, pp_size, cp_size in tp_pp_cp_sizes:
         print(
-            f'Generating outputs for Llama FP16 with TP={tp_size}, PP={pp_size} and CP={cp_size}'
+            f'Generating outputs for Llama FP16 with TP={tp_size}, PP={pp_size}, CP={cp_size}, BW={num_beams}'
         )
+        start_time = time.time()
 
         output_logits = False
         output_log_probs = False
@@ -128,6 +130,11 @@ def generate_outputs(num_beams, only_multi_gpu=False):
                         output_logits=output_logits,
                         output_log_probs=output_log_probs,
                         output_cum_log_probs=output_cum_log_probs)
+
+        duration = time.time() - start_time
+        print(
+            f"Generating outputs for Llama FP16 with TP={tp_size}, PP={pp_size}, CP={cp_size}, BW={num_beams} took {duration} seconds"
+        )
 
 
 if __name__ == '__main__':

--- a/cpp/tests/utils/common.h
+++ b/cpp/tests/utils/common.h
@@ -101,6 +101,10 @@ public:
     static std::string FP16_PLUGIN_PACKED_PAGED_RESULT_TP1_PP4_FILE();
     static std::string FP16_PLUGIN_PACKED_PAGED_RESULT_TP1_PP2_FILE();
     static std::string FP16_PLUGIN_PACKED_PAGED_RESULT_TP2_PP1_FILE();
+    static std::string FP16_PLUGIN_PACKED_PAGED_CONTEXT_LOGITS_TP4_PP1_FILE();
+    static std::string FP16_PLUGIN_PACKED_PAGED_GENERATION_LOGITS_TP4_PP1_FILE();
+    static std::string FP16_PLUGIN_PACKED_PAGED_CUM_LOG_PROBS_TP4_PP1_FILE();
+    static std::string FP16_PLUGIN_PACKED_PAGED_LOG_PROBS_TP4_PP1_FILE();
     // GptExecutorTest.GenerationLogitsEarlyStop requires to use context_fmha_fp32_acc flag in runtime for better
     // accuracy
     static std::string FP16_PLUGIN_PACKED_PAGED_GATHER_CONTEXTFMHAFP32ACC_RESULT_FILE();
@@ -198,12 +202,13 @@ public:
         FlakyTestInfo flakyTestInfo);
 
     void validateContextLogits(bool getContextLogits, SizeType32 inputLength, SizeType32 beamWidth,
-        std::optional<executor::Tensor> const& contextLogits, SizeType32 vocabSizePadded, SizeType32 batchId);
+        std::optional<executor::Tensor> const& contextLogits, SizeType32 vocabSizePadded, SizeType32 batchId,
+        float atol = 1e-2, float rtol = 1e-3);
 
     void validateGenerationLogits(bool getGenLogits, bool isFinal, bool streaming, bool excludeInputFromOutput,
         SizeType32 inputLength, SizeType32 maxOutputLen, SizeType32 beamWidth, executor::BeamTokens const& beamTokens,
         std::optional<executor::Tensor> const& genLogits, SizeType32 vocabSizePadded, SizeType32 batchId,
-        bool returnAllGeneratedTokens);
+        bool returnAllGeneratedTokens, float atol = 1e-2, float rtol = 1e-3);
 
     SizeType32 nbGivenInputs{};
     SizeType32 beamWidth{};


### PR DESCRIPTION
## Description

- Enable logits validation for multi-gpu executor tests.
- Slightly increase timeout to accommodate for longer generation time.
- Remove unnecessary pipeline parallelism logic from postProcessRequest. Logits don't need to be sent to first pipeline rank because responses are generated on last rank.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
