### PR TITLE
[TRTLLM-6104] feat: add request_perf_metrics to LLMAPI

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
+++ b/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
@@ -1235,17 +1235,12 @@ public:
         return mPerfMetrics;
     }
 
-    void setFirstScheduledTime(executor::RequestPerfMetrics::TimePoint const& time)
+    void setFirstScheduledTime()
     {
         if (mPerfMetrics.timingMetrics.firstScheduledTime == executor::RequestPerfMetrics::TimePoint{})
         {
-            mPerfMetrics.timingMetrics.firstScheduledTime = time;
+            mPerfMetrics.timingMetrics.firstScheduledTime = std::chrono::steady_clock::now();
         }
-    }
-
-    void createFirstScheduledTime()
-    {
-        setFirstScheduledTime(std::chrono::steady_clock::now());
     }
 
     [[nodiscard]] bool constexpr isStreaming() const noexcept

--- a/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
+++ b/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
@@ -1243,6 +1243,11 @@ public:
         }
     }
 
+    void createFirstScheduledTime()
+    {
+        setFirstScheduledTime(std::chrono::steady_clock::now());
+    }
+
     [[nodiscard]] bool constexpr isStreaming() const noexcept
     {
         return mIsStreaming;

--- a/cpp/tensorrt_llm/batch_manager/assignReqSeqSlots.cpp
+++ b/cpp/tensorrt_llm/batch_manager/assignReqSeqSlots.cpp
@@ -34,7 +34,7 @@ void tensorrt_llm::batch_manager::AssignReqSeqSlots::operator()(SequenceSlotMana
                 || (llmReq->isDisaggGenerationTransmissionComplete());
             if (isReqNew && llmReq->getReturnPerfMetrics())
             {
-                llmReq->setFirstScheduledTime(std::chrono::steady_clock::now());
+                llmReq->setFirstScheduledTime();
             }
             auto const reqSeqSlot = seqSlotManager.getSequenceSlot(isReqNew, llmReq->mRequestId);
             TLLM_CHECK_WITH_INFO(reqSeqSlot, "Unable to get batch slot for reqId");

--- a/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
@@ -250,7 +250,8 @@ void initBindings(pybind11::module_& m)
                     self.setDraftTokens(std::make_shared<GenLlmReq::VecTokens>(draftTokens.value()));
                 }
             })
-        .def_property("is_dummy_request", &GenLlmReq::isDummyRequest, &GenLlmReq::setIsDummyRequest);
+        .def_property("is_dummy_request", &GenLlmReq::isDummyRequest, &GenLlmReq::setIsDummyRequest)
+        .def_property_readonly("return_perf_metrics", &GenLlmReq::getReturnPerfMetrics);
 
     py::classh<tb::LlmRequest, GenLlmReq>(m, "LlmRequest", pybind11::dynamic_attr())
         .def(py::init(

--- a/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
@@ -373,7 +373,8 @@ void initBindings(pybind11::module_& m)
             })
         .def("move_prompt_embedding_table_to_gpu", &tb::LlmRequest::movePromptEmbeddingTableToGpu, py::arg("manager"))
         .def("move_lora_weights_to_gpu", &tb::LlmRequest::moveLoraWeightsToGpu, py::arg("manager"))
-        .def("finish_by_reason", &tb::LlmRequest::finishByReason, py::arg("finish_reason"));
+        .def("finish_by_reason", &tb::LlmRequest::finishByReason, py::arg("finish_reason"))
+        .def("create_first_scheduled_time", &tb::LlmRequest::createFirstScheduledTime);
 
     py::classh<tb::SequenceSlotManager>(m, "SequenceSlotManager")
         .def(py::init<tb::SequenceSlotManager::SlotIdType, uint64_t>(), py::arg("max_num_slots"),

--- a/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
@@ -374,7 +374,8 @@ void initBindings(pybind11::module_& m)
         .def("move_prompt_embedding_table_to_gpu", &tb::LlmRequest::movePromptEmbeddingTableToGpu, py::arg("manager"))
         .def("move_lora_weights_to_gpu", &tb::LlmRequest::moveLoraWeightsToGpu, py::arg("manager"))
         .def("finish_by_reason", &tb::LlmRequest::finishByReason, py::arg("finish_reason"))
-        .def("create_first_scheduled_time", &tb::LlmRequest::createFirstScheduledTime);
+        .def("create_first_scheduled_time", &tb::LlmRequest::createFirstScheduledTime)
+        .def("update_perf_metrics", &tb::LlmRequest::updatePerfMetrics, py::arg("iter_counter"));
 
     py::classh<tb::SequenceSlotManager>(m, "SequenceSlotManager")
         .def(py::init<tb::SequenceSlotManager::SlotIdType, uint64_t>(), py::arg("max_num_slots"),

--- a/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
@@ -375,7 +375,7 @@ void initBindings(pybind11::module_& m)
         .def("move_prompt_embedding_table_to_gpu", &tb::LlmRequest::movePromptEmbeddingTableToGpu, py::arg("manager"))
         .def("move_lora_weights_to_gpu", &tb::LlmRequest::moveLoraWeightsToGpu, py::arg("manager"))
         .def("finish_by_reason", &tb::LlmRequest::finishByReason, py::arg("finish_reason"))
-        .def("create_first_scheduled_time", &tb::LlmRequest::createFirstScheduledTime)
+        .def("set_first_scheduled_time", &tb::LlmRequest::setFirstScheduledTime)
         .def("update_perf_metrics", &tb::LlmRequest::updatePerfMetrics, py::arg("iter_counter"));
 
     py::classh<tb::SequenceSlotManager>(m, "SequenceSlotManager")

--- a/cpp/tensorrt_llm/pybind/executor/request.cpp
+++ b/cpp/tensorrt_llm/pybind/executor/request.cpp
@@ -840,7 +840,6 @@ void initRequestBindings(pybind11::module_& m)
         .def_readwrite("context_phase_params", &tle::Result::contextPhaseParams)
         .def_readwrite("request_perf_metrics", &tle::Result::requestPerfMetrics)
         .def_readwrite("additional_outputs", &tle::Result::additionalOutputs)
-        .def_readwrite("context_phase_params", &tle::Result::contextPhaseParams)
         .def(py::pickle(resultGetstate, resultSetstate));
 
     m.def("deserialize_result",

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -252,6 +252,7 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
             return_generation_logits: bool = False,
             return_logits_device_memory: bool = True,
             exclude_last_generation_logits: bool = False,
+            return_perf_metrics: bool = False,
             stop_words_list: list[list[int]] | None = None,
             **kwargs):
         self.py_logits_post_processors = kwargs.pop("py_logits_post_processors",
@@ -262,6 +263,7 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
             return_log_probs=return_log_probs,
             return_context_logits=False,
             return_generation_logits=False,
+            return_perf_metrics=return_perf_metrics,
             stop_words_list=torch.tensor(stop_words_list, dtype=torch.int32)
             if stop_words_list else None,
             **kwargs)
@@ -408,6 +410,7 @@ def executor_request_to_llm_request(
         return_log_probs=executor_request.output_config.return_log_probs,
         return_context_logits=executor_request.output_config.
         return_context_logits,
+        return_perf_metrics=executor_request.output_config.return_perf_metrics,
         return_generation_logits=executor_request.output_config.
         return_generation_logits,
         exclude_last_generation_logits=exclude_last_generation_logits,

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -2062,6 +2062,8 @@ class PyExecutor:
             request.draft_tokens = request.py_draft_tokens
             request.decoding_iter = request.py_decoding_iter
 
+            request.update_perf_metrics(self.model_engine.iter_counter)
+
             request_done = False
             if self.model_engine.iter_counter % self.stream_interval == 0 or request.is_finished:
                 response = request.create_response(False, self.dist.rank)

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -2062,7 +2062,8 @@ class PyExecutor:
             request.draft_tokens = request.py_draft_tokens
             request.decoding_iter = request.py_decoding_iter
 
-            request.update_perf_metrics(self.model_engine.iter_counter)
+            if request.return_perf_metrics:
+                request.update_perf_metrics(self.model_engine.iter_counter)
 
             request_done = False
             if self.model_engine.iter_counter % self.stream_interval == 0 or request.is_finished:

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1809,6 +1809,7 @@ class PyExecutor:
                         max_new_tokens=request.py_max_new_tokens,
                         input_tokens=input_tokens,
                         sampling_config=request.sampling_config,
+                        return_perf_metrics=request.return_perf_metrics,
                         is_streaming=False)
 
                     draft_batch.context_requests.append(new_request)
@@ -1818,6 +1819,7 @@ class PyExecutor:
                         max_new_tokens=request.py_max_new_tokens,
                         input_tokens=input_tokens[:-1],
                         sampling_config=request.sampling_config,
+                        return_perf_metrics=request.return_perf_metrics,
                         is_streaming=False)
                     # Explicitly add the last token so get_last_tokens() returns
                     # the right value
@@ -1830,6 +1832,7 @@ class PyExecutor:
                         max_new_tokens=request.py_max_new_tokens,
                         input_tokens=input_tokens,
                         sampling_config=request.sampling_config,
+                        return_perf_metrics=request.return_perf_metrics,
                         is_streaming=False)
                     new_request.context_chunk_size = num_accepted_tokens + 1
                     new_request.context_current_position = len(

--- a/tensorrt_llm/_torch/pyexecutor/seq_slot_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/seq_slot_manager.py
@@ -23,7 +23,8 @@ class SeqSlotManager(BaseResourceManager):
                 llm_req.is_disagg_generation_transmission_complete:
                 llm_req.seq_slot = self.slot_manager.add_slot(
                     llm_req.request_id)
-                llm_req.create_first_scheduled_time()
+                if llm_req.return_perf_metrics:
+                    llm_req.create_first_scheduled_time()
 
     def free_resources(self, request: LlmRequest) -> None:
         self.slot_manager.remove_slot(request.request_id)

--- a/tensorrt_llm/_torch/pyexecutor/seq_slot_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/seq_slot_manager.py
@@ -23,6 +23,7 @@ class SeqSlotManager(BaseResourceManager):
                 llm_req.is_disagg_generation_transmission_complete:
                 llm_req.seq_slot = self.slot_manager.add_slot(
                     llm_req.request_id)
+                llm_req.create_first_scheduled_time()
 
     def free_resources(self, request: LlmRequest) -> None:
         self.slot_manager.remove_slot(request.request_id)

--- a/tensorrt_llm/_torch/pyexecutor/seq_slot_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/seq_slot_manager.py
@@ -24,7 +24,7 @@ class SeqSlotManager(BaseResourceManager):
                 llm_req.seq_slot = self.slot_manager.add_slot(
                     llm_req.request_id)
                 if llm_req.return_perf_metrics:
-                    llm_req.create_first_scheduled_time()
+                    llm_req.set_first_scheduled_time()
 
     def free_resources(self, request: LlmRequest) -> None:
         self.slot_manager.remove_slot(request.request_id)

--- a/tensorrt_llm/executor/result.py
+++ b/tensorrt_llm/executor/result.py
@@ -84,6 +84,7 @@ class CompletionOutput:
         stop_reason (int, str, optional): The stop string or token id that caused the completion to stop, None if the completion finished for some other reason. Defaults to None.
         generation_logits (torch.Tensor, optional): The logits on the generated output token ids. Defaults to None.
         disaggregated_params (tensorrt_llm.disaggregated_params.DisaggregatedParams, optional): Parameters needed for disaggregated serving. Includes the type of request, the first generated tokens, the context request id and the any additional state needing to be transferred from context and generation instances. Defaults to None.
+        request_perf_metrics (tensorrt_llm.executor.RequestPerfMetrics, optional): Performance metrics for the request. Defaults to None.
 
     Attributes:
         length (int): The number of generated tokens.
@@ -102,6 +103,7 @@ class CompletionOutput:
     stop_reason: Optional[Union[int, str]] = None
     generation_logits: Optional[torch.Tensor] = None
     disaggregated_params: Optional[DisaggregatedParams] = None
+    request_perf_metrics: Optional[tllm.RequestPerfMetrics] = None
 
     # hidden fields for tracking the diffs
     _last_text_len: int = field(default=0, init=False, repr=False)
@@ -236,6 +238,9 @@ class GenerationResultBase:
         if finish_reasons and finish_reasons[
                 src_idx] == tllm.FinishReason.CANCELLED:
             output.finish_reason = 'cancelled'
+
+        if response_tensors.request_perf_metrics is not None:
+            output.request_perf_metrics = response_tensors.request_perf_metrics
 
         if self._done:
             if finish_reasons[src_idx] == tllm.FinishReason.END_ID:

--- a/tensorrt_llm/executor/result.py
+++ b/tensorrt_llm/executor/result.py
@@ -84,7 +84,7 @@ class CompletionOutput:
         stop_reason (int, str, optional): The stop string or token id that caused the completion to stop, None if the completion finished for some other reason. Defaults to None.
         generation_logits (torch.Tensor, optional): The logits on the generated output token ids. Defaults to None.
         disaggregated_params (tensorrt_llm.disaggregated_params.DisaggregatedParams, optional): Parameters needed for disaggregated serving. Includes the type of request, the first generated tokens, the context request id and the any additional state needing to be transferred from context and generation instances. Defaults to None.
-        request_perf_metrics (tensorrt_llm.executor.RequestPerfMetrics, optional): Performance metrics for the request. Defaults to None.
+        request_perf_metrics (tensorrt_llm.bindings.executor.RequestPerfMetrics, optional): Performance metrics for the request. Defaults to None.
 
     Attributes:
         length (int): The number of generated tokens.

--- a/tests/unittest/api_stability/references/completion_output.yaml
+++ b/tests/unittest/api_stability/references/completion_output.yaml
@@ -7,6 +7,9 @@ methods:
       disaggregated_params:
         annotation: Optional[tensorrt_llm.disaggregated_params.DisaggregatedParams]
         default: null
+      request_perf_metrics:
+        annotation: Optional[tensorrt_llm.bindings.executor.RequestPerfMetrics]
+        default: null
     return_annotation: None
 properties:
   length:

--- a/tests/unittest/bindings/test_executor_bindings.py
+++ b/tests/unittest/bindings/test_executor_bindings.py
@@ -1124,6 +1124,9 @@ def test_result():
     result.finish_reasons = [trtllm.FinishReason.LENGTH]
     result.sequence_index = 1
     result.is_sequence_final = True
+    result.decoding_iter = 1
+    result.request_perf_metrics = trtllm.RequestPerfMetrics()
+    result.request_perf_metrics.last_iter = 33
     result.additional_outputs = [
         trtllm.AdditionalOutput("topKLogits", torch.ones(1, 4, 100))
     ]
@@ -1137,10 +1140,44 @@ def test_result():
     assert result.finish_reasons == [trtllm.FinishReason.LENGTH]
     assert result.sequence_index == 1
     assert result.is_sequence_final is True
+    assert result.decoding_iter == 1
+    assert result.request_perf_metrics is not None
+    assert result.request_perf_metrics.last_iter == 33
     assert len(result.additional_outputs) == 1
     additional_output = result.additional_outputs[0]
     assert additional_output.name == "topKLogits"
     assert (additional_output.output == torch.ones(1, 4, 100)).all()
+
+
+def test_result_pickle():
+    result = trtllm.Result()
+    result.is_final = True
+    result.output_token_ids = [[1, 2, 3]]
+    result.cum_log_probs = [1.0, 2.0, 3.0]
+    result.log_probs = [[1.0, 2.0, 3.0]]
+    result.context_logits = torch.ones(3, 100)
+    result.generation_logits = torch.ones(1, 3, 100)
+    result.encoder_output = torch.ones(1, 1)
+    result.finish_reasons = [trtllm.FinishReason.LENGTH]
+    result.sequence_index = 1
+    result.is_sequence_final = True
+    result.decoding_iter = 1
+    result.request_perf_metrics = trtllm.RequestPerfMetrics()
+    result.request_perf_metrics.last_iter = 33
+    result_str = pickle.dumps(result)
+    result_copy = pickle.loads(result_str)
+    assert result.is_final == result_copy.is_final
+    assert result.output_token_ids == result_copy.output_token_ids
+    assert result.cum_log_probs == result_copy.cum_log_probs
+    assert result.log_probs == result_copy.log_probs
+    assert (result.context_logits == result_copy.context_logits).all()
+    assert (result.generation_logits == result_copy.generation_logits).all()
+    assert (result.encoder_output == result_copy.encoder_output).all()
+    assert result.finish_reasons == result_copy.finish_reasons
+    assert result.sequence_index == result_copy.sequence_index
+    assert result.is_sequence_final == result_copy.is_sequence_final
+    assert result.decoding_iter == result_copy.decoding_iter
+    assert result.request_perf_metrics.last_iter == result_copy.request_perf_metrics.last_iter
 
 
 def test_response():
@@ -2189,6 +2226,50 @@ def test_kv_event_stream_timeout(model_path):
     # Make sure that it actually waited
     assert abs(end - start) > datetime.timedelta(milliseconds=900)
     assert len(events) == 0
+
+
+def test_request_perf_metrics_pickle():
+    metrics = trtllm.RequestPerfMetrics()
+    random_delta = datetime.timedelta(seconds=42, milliseconds=123)
+
+    metrics.timing_metrics.arrival_time = random_delta
+    metrics.timing_metrics.first_scheduled_time = 2 * random_delta
+    metrics.timing_metrics.first_token_time = 3 * random_delta
+    metrics.timing_metrics.last_token_time = 4 * random_delta
+    metrics.timing_metrics.kv_cache_transfer_start = 5 * random_delta
+    metrics.timing_metrics.kv_cache_transfer_end = 6 * random_delta
+    metrics.timing_metrics.kv_cache_size = 1024
+    metrics.kv_cache_metrics.num_total_allocated_blocks = 1
+    metrics.kv_cache_metrics.num_new_allocated_blocks = 1
+    metrics.kv_cache_metrics.num_reused_blocks = 0
+    metrics.kv_cache_metrics.num_missed_blocks = 1
+    metrics.kv_cache_metrics.kv_cache_hit_rate = 0
+    metrics.speculative_decoding.acceptance_rate = 0.5
+    metrics.speculative_decoding.total_accepted_draft_tokens = 2
+    metrics.speculative_decoding.total_draft_tokens = 4
+    metrics.first_iter = 0
+    metrics.iter = 40
+    metrics.last_iter = 50
+    metrics_str = pickle.dumps(metrics)
+    metrics_copy = pickle.loads(metrics_str)
+    assert metrics.timing_metrics.arrival_time == metrics_copy.timing_metrics.arrival_time
+    assert metrics.timing_metrics.first_scheduled_time == metrics_copy.timing_metrics.first_scheduled_time
+    assert metrics.timing_metrics.first_token_time == metrics_copy.timing_metrics.first_token_time
+    assert metrics.timing_metrics.last_token_time == metrics_copy.timing_metrics.last_token_time
+    assert metrics.timing_metrics.kv_cache_transfer_start == metrics_copy.timing_metrics.kv_cache_transfer_start
+    assert metrics.timing_metrics.kv_cache_transfer_end == metrics_copy.timing_metrics.kv_cache_transfer_end
+    assert metrics.timing_metrics.kv_cache_size == metrics_copy.timing_metrics.kv_cache_size
+    assert metrics.kv_cache_metrics.num_total_allocated_blocks == metrics_copy.kv_cache_metrics.num_total_allocated_blocks
+    assert metrics.kv_cache_metrics.num_new_allocated_blocks == metrics_copy.kv_cache_metrics.num_new_allocated_blocks
+    assert metrics.kv_cache_metrics.num_reused_blocks == metrics_copy.kv_cache_metrics.num_reused_blocks
+    assert metrics.kv_cache_metrics.num_missed_blocks == metrics_copy.kv_cache_metrics.num_missed_blocks
+    assert metrics.kv_cache_metrics.kv_cache_hit_rate == metrics_copy.kv_cache_metrics.kv_cache_hit_rate
+    assert metrics.speculative_decoding.acceptance_rate == metrics_copy.speculative_decoding.acceptance_rate
+    assert metrics.speculative_decoding.total_accepted_draft_tokens == metrics_copy.speculative_decoding.total_accepted_draft_tokens
+    assert metrics.speculative_decoding.total_draft_tokens == metrics_copy.speculative_decoding.total_draft_tokens
+    assert metrics.first_iter == metrics_copy.first_iter
+    assert metrics.iter == metrics_copy.iter
+    assert metrics.last_iter == metrics_copy.last_iter
 
 
 def test_iteration_stats():


### PR DESCRIPTION
# PR title

[TRTLLM-6104] feat: add request_perf_metrics to LLMAPI

## Description

Implement pickle serialization for perf metrics

Update fields as required in the torch backend

## Test Coverage

test_llm_perf_metrics
New pickle tests in test_executor_bindings

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
