### PR TITLE
[CI] Run shorter deepseek tests in pre-merge

### DIFF
--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -1398,6 +1398,10 @@ def runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config=VANILLA_CO
                 "--perf-log-formats yaml"
             ]
         }
+        // run shorter test versions for pre-merge
+        if (!testFilter[(IS_POST_MERGE)]) {
+            testCmdLine += ["--pre-merge"]
+        }
         // Test Coverage
         def TRTLLM_WHL_PATH = sh(returnStdout: true, script: "pip3 show tensorrt_llm | grep Location | cut -d ' ' -f 2").replaceAll("\\s","")
         sh "echo ${TRTLLM_WHL_PATH}"

--- a/tests/integration/defs/conftest.py
+++ b/tests/integration/defs/conftest.py
@@ -1976,6 +1976,9 @@ def pytest_addoption(parser):
         help=
         "It is useful when using such prefix to mapping waive lists for specific GPU, such as 'GH200'"
     )
+    parser.addoption("--pre-merge",
+                     action="store_true",
+                     help="Shorten some tests for pre-merge CI.")
     parser.addoption("--regexp",
                      "-R",
                      action='store',
@@ -2144,6 +2147,14 @@ def all_pytest_items():
     filtering has been applied.
     """
     return ALL_PYTEST_ITEMS
+
+
+@pytest.fixture(scope="session")
+def pre_merge(request) -> bool:
+    """
+    Is True if `--pre-merge` was passed in pytest cmdline.
+    """
+    return bool(request.config.getoption("--pre-merge"))
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
# [CI] Run shorter deepseek tests in pre-merge

This PR adds an optional `--pre-merge` flag to pytest to signal to tests that they may perform faster logic as they are running in a pre-merge pipeline.

This flag is used in DeepSeek accuracy tests to run GSM8K instead of GSM8K+MMLU in pre-merge.