### PR TITLE
feat: add MultimodalParams & putting all multimodal params into it and refactor HyperCLOVAX & Qwen2/2.5-VL

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_gemma3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma3vl.py
@@ -100,8 +100,10 @@ class Gemma3InputProcessor(InputProcessor):
             "pixel_values"]
         input_ids = preprocess_outputs[0]["mm_processor_kwargs"]["input_ids"]
         mm_features = self._process(pixel_values)
+        multimodal_data = {}
+        multimodal_data["multimodal_embedding"] = mm_features
         return input_ids[0].to(torch.int32).tolist(), {
-            "mm_embedding": mm_features
+            "multimodal_data": multimodal_data
         }
 
 
@@ -163,7 +165,7 @@ class Gemma3Model(PreTrainedModel):
 
         multimodal_params = kwargs.get("multimodal_params", [])
         mm_embed = [
-            multimodal_param.multimodal_embedding
+            multimodal_param.multimodal_data["multimodal_embedding"]
             for multimodal_param in multimodal_params
         ]
         assert mm_embed == [] or len(

--- a/tensorrt_llm/_torch/models/modeling_gemma3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma3vl.py
@@ -163,7 +163,7 @@ class Gemma3Model(PreTrainedModel):
 
         multimodal_params = kwargs.get("multimodal_params", [])
         mm_embed = [
-            multimodal_param.mm_embedding
+            multimodal_param.multimodal_embedding
             for multimodal_param in multimodal_params
         ]
         assert mm_embed == [] or len(

--- a/tensorrt_llm/_torch/models/modeling_gemma3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma3vl.py
@@ -161,7 +161,11 @@ class Gemma3Model(PreTrainedModel):
             f"[Gemma3Model::forward]{num_context_requests=}, {num_generation_requests=}"
         )
 
-        mm_embed = kwargs.get("multi_modal_data", [])
+        multimodal_params = kwargs.get("multimodal_params", [])
+        mm_embed = [
+            multimodal_param.mm_embedding
+            for multimodal_param in multimodal_params
+        ]
         assert mm_embed == [] or len(
             mm_embed
         ) == num_context_requests, "Number of multimodal features (if provided) should be equal to number of context requests"

--- a/tensorrt_llm/_torch/models/modeling_llama.py
+++ b/tensorrt_llm/_torch/models/modeling_llama.py
@@ -851,7 +851,10 @@ class Llama4InputProcessor(InputProcessor):
             mm_embeds = self.encoder.multi_modal_projector(mm_embeds)
             # for fuse_input_embeds
             token_ids[token_ids == self.image_token_index] = self.vocab_size + 1
-            return token_ids.tolist(), {"mm_embedding": mm_embeds}
+
+            multimodal_data = {}
+            multimodal_data["multimodal_embedding"] = mm_embeds
+            return token_ids.tolist(), {"multimodal_data": multimodal_data}
         else:
             return processed["input_ids"].squeeze().tolist(), {}
 
@@ -882,8 +885,12 @@ class Llama4ForConditionalGeneration(SpecDecOneEngineForCausalLM[Llama4Model,
         spec_metadata: Optional[SpecMetadata] = None,
         **kwargs,
     ) -> torch.Tensor:
-        mm_embed = kwargs.get("multi_modal_data", [])
-        if mm_embed:
+        multimodal_params = kwargs.get("multimodal_params", [])
+        if multimodal_params:
+            mm_embed = [
+                multimodal_param.multimodal_data["multimodal_embedding"]
+                for multimodal_param in multimodal_params
+            ]
             _, inputs_embeds = fuse_input_embeds(self.model.embed_tokens,
                                                  input_ids, mm_embed)
         return super().forward(attn_metadata,

--- a/tensorrt_llm/_torch/models/modeling_llava_next.py
+++ b/tensorrt_llm/_torch/models/modeling_llava_next.py
@@ -210,8 +210,10 @@ class LlavaNextInputProcessor(InputProcessor):
         mm_features = torch.stack(
             [self._process(tensor) for tensor in mm_tensor])
         fused_input_ids, mm_features = self._postprocess(input_ids, mm_features)
+        multimodal_data = {}
+        multimodal_data["multimodal_embedding"] = mm_features
         return fused_input_ids.to(torch.int32).tolist(), {
-            "mm_embedding": mm_features
+            "multimodal_data": multimodal_data
         }
 
 
@@ -273,7 +275,7 @@ class LlavaNextModel(PreTrainedModel):
 
         multimodal_params = kwargs.get("multimodal_params", [])
         mm_embed = [
-            multimodal_param.multimodal_embedding
+            multimodal_param.multimodal_data["multimodal_embedding"]
             for multimodal_param in multimodal_params
         ]
         assert mm_embed == [] or len(

--- a/tensorrt_llm/_torch/models/modeling_llava_next.py
+++ b/tensorrt_llm/_torch/models/modeling_llava_next.py
@@ -271,7 +271,11 @@ class LlavaNextModel(PreTrainedModel):
         num_context_requests, num_generation_requests = attn_metadata.num_contexts, attn_metadata.num_generations
         logger.debug(f"{num_context_requests=}, {num_generation_requests=}")
 
-        mm_embed = kwargs.get("multi_modal_data", [])
+        multimodal_params = kwargs.get("multimodal_params", [])
+        mm_embed = [
+            multimodal_param.mm_embedding
+            for multimodal_param in multimodal_params
+        ]
         assert mm_embed == [] or len(
             mm_embed
         ) == num_context_requests, "Number of multimodal features (if provided) should be equal to number of context requests"

--- a/tensorrt_llm/_torch/models/modeling_llava_next.py
+++ b/tensorrt_llm/_torch/models/modeling_llava_next.py
@@ -273,7 +273,7 @@ class LlavaNextModel(PreTrainedModel):
 
         multimodal_params = kwargs.get("multimodal_params", [])
         mm_embed = [
-            multimodal_param.mm_embedding
+            multimodal_param.multimodal_embedding
             for multimodal_param in multimodal_params
         ]
         assert mm_embed == [] or len(

--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -568,11 +568,8 @@ class Qwen2VLModelBase(PreTrainedModel):
         mrope_config = {}
 
         if len(multimodal_params) > 0:
-            assert len(
-                multimodal_params
-            ) == num_context_requests, f"Number of multimodal tensors ({len(multimodal_params)}) should be equal to number of context requests ({num_context_requests}) in the batch."
-
-            mm_embeds = self.mm_encoder.forward(multimodal_params)
+            mm_embeds = self.mm_encoder.forward(
+                multimodal_params[:num_context_requests])
             mrope_config = self._parse_mrope_config(multimodal_params)
 
         input_ids, input_embeds = fuse_input_embeds(self.llm.model.embed_tokens,

--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -28,24 +28,16 @@ class Qwen2VLInputProcessorBase(InputProcessor):
                  trust_remote_code: bool = True):
         self.model_config = model_config
         self.tokenizer = tokenizer
+        # TODO: change to True and also change the acoording test result
         self.use_fast = False
+        self.device = 'cuda'
         self.processor = AutoProcessor.from_pretrained(
             model_path,
             use_fast=self.use_fast,
             trust_remote_code=trust_remote_code)
 
-        # NOTE: Using attn_implementation='flash_attention_2' to avoid the issue of vision model's GPU OOM.
-        model = self.get_model_class().from_pretrained(
-            model_path,
-            torch_dtype=model_config.torch_dtype,
-            attn_implementation='flash_attention_2')
-        self.device = 'cuda'
-        self.visual = model.visual.to(self.device)
+        self.tllm_multimodal_token_id = self.model_config.vocab_size + 1
         self._post_init_()
-
-    @classmethod
-    def get_model_class(cls) -> type[PreTrainedModel]:
-        raise NotImplementedError()
 
     @classmethod
     def get_rope_index(
@@ -284,34 +276,13 @@ class Qwen2VLInputProcessorBase(InputProcessor):
                               return_tensors='pt',
                               **mm_processor_kwargs)
 
-    def _process(self, pixel_values: torch.Tensor,
-                 pixel_values_videos: torch.Tensor,
-                 image_grid_thw: torch.Tensor,
-                 video_grid_thw: torch.Tensor) -> torch.Tensor:
-        embeds = []
-
-        if pixel_values is not None:
-            pixel_values = pixel_values.to(self.visual.dtype)
-            embeds.append(self.visual(pixel_values, grid_thw=image_grid_thw))
-
-        if pixel_values_videos is not None:
-            pixel_values_videos = pixel_values_videos.to(self.visual.dtype)
-            embeds.append(
-                self.visual(pixel_values_videos, grid_thw=video_grid_thw))
-
-        if embeds:
-            return torch.cat(embeds, dim=1)
-        return None
-
     def _postprocess(self, input_ids: torch.IntTensor) -> torch.IntTensor:
-        # NOTE: Qwen2-VL's input processor is doing all the work for fusing input_ids with mm_tokens. So, we just replace mm_tokens with expanded out-of-vocab ids
-
+        # NOTE: Qwen2-VL's input processor is doing all the work for fusing input_ids with mm_tokens. 
+        # So, we just replace mm_tokens with expanded out-of-vocab ids
         masks = (input_ids == self.model_config.image_token_id) | (
             input_ids == self.model_config.vision_token_id) | (
                 input_ids == self.model_config.video_token_id)
-        cumulative_counts = masks.cumsum(dim=-1)
-        values = (self.model_config.vocab_size - 1) + cumulative_counts
-        input_ids[masks] = values[masks]
+        input_ids[masks] = self.tllm_multimodal_token_id
         return input_ids
 
     def get_mrope_config(
@@ -363,17 +334,25 @@ class Qwen2VLInputProcessorBase(InputProcessor):
 
         processed_inputs = self._preprocess(text_prompt, mm_data,
                                             mm_processor_kwargs).to(self.device)
-        if mm_data:
-            mm_features = self._process(
-                processed_inputs.get('pixel_values', None),
-                processed_inputs.get('pixel_values_videos', None),
-                processed_inputs.get('image_grid_thw', None),
-                processed_inputs.get('video_grid_thw', None))
-        else:
-            mm_features = None
+        
+        if not mm_data:
+            fused_input_ids = processed_inputs['input_ids']
+            return fused_input_ids.to(torch.int32).tolist(), {}
+
+        pixel_values = processed_inputs.get('pixel_values', None)
+        pixel_values_videos = processed_inputs.get('pixel_values_videos', None)
+        assert pixel_values is not None or pixel_values_videos is not None, "No multimodal data found"
+        
+        mm_data = {}
+        if pixel_values is not None:
+            mm_data["image"] = {"pixel_values": pixel_values, 
+                                "image_grid_thw": processed_inputs.get('image_grid_thw')}
+        if pixel_values_videos is not None:
+            mm_data["video"] = {"pixel_values_videos": pixel_values_videos, 
+                                "video_grid_thw": processed_inputs.get('video_grid_thw')}
 
         input_ids = processed_inputs['input_ids']
-
+        # TODO: We can move this to the LLM-side.
         mrope_config = self.get_mrope_config(
             input_ids, processed_inputs.get('image_grid_thw', None),
             processed_inputs.get('video_grid_thw', None),
@@ -383,23 +362,79 @@ class Qwen2VLInputProcessorBase(InputProcessor):
         fused_input_ids = self._postprocess(input_ids[0])
 
         return fused_input_ids.to(torch.int32).tolist(), {
-            "mm_embedding": mm_features,
-            "mrope_config": mrope_config
+            "mrope_config": mrope_config,
+            "mm_data": mm_data,
         }
 
+class Qwen2VisionModelBase:
+    def __init__(self, pretrained_config: PretrainedConfig, model_class: type[PreTrainedModel]):
+        self.pretrained_config = pretrained_config
+        self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
-class Qwen2VLInputProcessor(Qwen2VLInputProcessorBase):
+        model_path = self.pretrained_config._name_or_path
+        # TODO: Change the model class to TRT-LLM's Qwen2VisionModel
+        # NOTE: Using attn_implementation='flash_attention_2' to avoid the issue of vision model's GPU OOM.
+        model = model_class.from_pretrained(
+            model_path,
+            torch_dtype=self.pretrained_config.torch_dtype,
+            attn_implementation='flash_attention_2').eval()
+        self.visual = model.visual.to(self.device)
+    
+    def _parse_and_batch_mm_data(self, mm_data: List[Dict[str, Any]]) -> Tuple[Dict[str, Any], Dict[str, List[Any]]]:
 
-    @classmethod
-    def get_model_class(cls):
-        return Qwen2VLForConditionalGeneration
+        pixel_values_list = []
+        pixel_values_videos_list = []
+        image_grid_thw_list = []
+        video_grid_thw_list = []
+        
+        for mm_content in mm_data:
+            # Process images if present
+            if "image" in mm_content and mm_content["image"]:
+                pixel_values_list.append(mm_content["image"]["pixel_values"])
+                image_grid_thw_list.append(mm_content["image"]["image_grid_thw"])
+            
+            # Process videos if present
+            if "video" in mm_content and mm_content["video"]:
+                pixel_values_videos_list.append(mm_content["video"]["pixel_values_videos"])
+                video_grid_thw_list.append(mm_content["video"]["video_grid_thw"])
+        
+        # Concatenate tensors
+        mm_content_dict = {}
+        if pixel_values_list:
+            mm_content_dict["pixel_values"] = torch.cat(pixel_values_list, dim=0) if len(pixel_values_list) > 1 else pixel_values_list[0]
+        if pixel_values_videos_list:
+            mm_content_dict["pixel_values_videos"] = torch.cat(pixel_values_videos_list, dim=0) if len(pixel_values_videos_list) > 1 else pixel_values_videos_list[0]
+        
+        # Prepare extra data
+        mm_extra_data = {}
+        if image_grid_thw_list:
+            mm_extra_data["image_grid_thw"] = torch.cat(image_grid_thw_list, dim=0) if len(image_grid_thw_list) > 1 else image_grid_thw_list[0]
+        if video_grid_thw_list:
+            mm_extra_data["video_grid_thw"] = torch.cat(video_grid_thw_list, dim=0) if len(video_grid_thw_list) > 1 else video_grid_thw_list[0]
+        
+        return mm_content_dict, mm_extra_data
 
+    @torch.inference_mode()
+    def forward(self, mm_data: List[Dict[str, Any]]):
 
-class Qwen2_5_VLInputProcessor(Qwen2VLInputProcessorBase):
+        mm_content_data, mm_extra_data = self._parse_and_batch_mm_data(mm_data)
+        pixel_values = mm_content_data.get("pixel_values", None)
+        pixel_values_videos = mm_content_data.get("pixel_values_videos", None)
+        
+        image_grid_thw = mm_extra_data.get("image_grid_thw", None)
+        video_grid_thw = mm_extra_data.get("video_grid_thw", None)
+        
+        embeds = []
+        if pixel_values is not None:
+            pixel_values = pixel_values.to(self.visual.dtype)
+            embeds.append(self.visual(pixel_values, grid_thw=image_grid_thw))
 
-    @classmethod
-    def get_model_class(cls):
-        return Qwen2_5_VLForConditionalGeneration
+        if pixel_values_videos is not None:
+            pixel_values_videos = pixel_values_videos.to(self.visual.dtype)
+            embeds.append(
+                self.visual(pixel_values_videos, grid_thw=video_grid_thw))
+
+        return embeds
 
 
 class Qwen2VLModelBase(PreTrainedModel):
@@ -413,7 +448,7 @@ class Qwen2VLModelBase(PreTrainedModel):
         model_config.pretrained_config.rope_scaling['type'] = 'mrope'
         config = model_config.pretrained_config
 
-        assert model_config.attn_backend == 'TRTLLM', "Qwen2VL only supports TRTLLM backend now"
+        assert model_config.attn_backend == 'TRTLLM', "Qwen2/2.5-VL only supports TRTLLM backend now"
         super().__init__(config)
 
         self.model_config = model_config
@@ -458,26 +493,29 @@ class Qwen2VLModelBase(PreTrainedModel):
             f"num_context_requests: {num_context_requests}, num_generation_requests: {num_generation_requests}"
         )
 
-        mm_embed = kwargs.get("multi_modal_data", [])
-
-        error_msg = "Number of multimodal features (if provided) should be equal to number of context requests"
-        assert mm_embed == [] or len(
-            mm_embed) == num_context_requests, error_msg
-
-        input_ids, input_embeds = fuse_input_embeds(self.llm.model.embed_tokens,
-                                                    input_ids, mm_embed)
+        mm_data = kwargs.get("mm_data", [])
+        mm_embeds = []
+        if len(mm_data) > 0:
+            assert len(
+                mm_data
+            ) == num_context_requests, f"Number of multimodal tensors ({len(mm_data)}) should be equal to number of context requests ({num_context_requests}) in the batch."
+            mm_embeds = self.mm_encoder.forward(mm_data)
 
         mrope_config = kwargs.get("mrope_config", {})
         if mrope_config:
             if mrope_rotary_cos_sin := mrope_config.get('mrope_rotary_cos_sin'):
+                assert len(mrope_rotary_cos_sin) == num_context_requests, f"Number of mrope_rotary_cos_sin ({len(mrope_rotary_cos_sin)}) should be equal to number of context requests ({num_context_requests}) in the batch."
                 mrope_config['mrope_rotary_cos_sin'] = torch.cat(
                     mrope_rotary_cos_sin, dim=0)
 
             if mrope_position_deltas := mrope_config.get(
                     'mrope_position_deltas'):
+                assert len(mrope_position_deltas) == num_generation_requests, f"Number of mrope_position_deltas ({len(mrope_position_deltas)}) should be equal to number of generation requests ({num_generation_requests}) in the batch."
                 mrope_config['mrope_position_deltas'] = torch.cat(
                     mrope_position_deltas, dim=0)
 
+        input_ids, input_embeds = fuse_input_embeds(self.llm.model.embed_tokens,
+                                            input_ids, mm_embeds)
         output_prob = self.llm.forward(
             attn_metadata=attn_metadata,
             input_ids=input_ids,
@@ -485,17 +523,21 @@ class Qwen2VLModelBase(PreTrainedModel):
             inputs_embeds=input_embeds,
             return_context_logits=return_context_logits,
             mrope_config=mrope_config)
+
         logger.debug(f'output shape: {output_prob.shape}')
         return output_prob
 
 
 @register_auto_model("Qwen2VLForConditionalGeneration")
-@register_input_processor(Qwen2VLInputProcessor, model_type="qwen2_vl")
+@register_input_processor(Qwen2VLInputProcessorBase, model_type="qwen2_vl")
 class Qwen2VLModel(Qwen2VLModelBase):
-    pass
-
+    def __init__(self, model_config: ModelConfig[PretrainedConfig], *args, **kwargs):
+        self.mm_encoder = Qwen2VisionModelBase(model_config.pretrained_config, Qwen2VLForConditionalGeneration)
+        super().__init__(model_config, *args, **kwargs)
 
 @register_auto_model("Qwen2_5_VLForConditionalGeneration")
-@register_input_processor(Qwen2_5_VLInputProcessor, model_type="qwen2_5_vl")
+@register_input_processor(Qwen2VLInputProcessorBase, model_type="qwen2_5_vl")
 class Qwen2_5_VLModel(Qwen2VLModelBase):
-    pass
+    def __init__(self, model_config: ModelConfig[PretrainedConfig], *args, **kwargs):
+        super().__init__(model_config, *args, **kwargs)
+        self.mm_encoder = Qwen2VisionModelBase(model_config.pretrained_config, Qwen2_5_VLForConditionalGeneration)

--- a/tensorrt_llm/_torch/models/modeling_vila.py
+++ b/tensorrt_llm/_torch/models/modeling_vila.py
@@ -1107,8 +1107,10 @@ class VilaInputProcessor(InputProcessor):
         )  # use_fast uses Pytorch GPU preprocessing, otherwise uses PIL CPU preprocessing
         mm_features = self._process(mm_tensor, block_sizes)
         fused_input_ids, mm_features = self._postprocess(input_ids, mm_features)
+        multimodal_data = {}
+        multimodal_data["multimodal_embedding"] = mm_features
         return fused_input_ids.to(torch.int32).tolist(), {
-            "mm_embedding": mm_features
+            "multimodal_data": multimodal_data
         }
 
 
@@ -1163,7 +1165,7 @@ class VilaModel(PreTrainedModel):
         num_context_requests, num_generation_requests = attn_metadata.num_contexts, attn_metadata.num_generations
         multimodal_params = kwargs.get("multimodal_params", [])
         mm_embed = [
-            multimodal_param.multimodal_embedding
+            multimodal_param.multimodal_data["multimodal_embedding"]
             for multimodal_param in multimodal_params
         ]
 

--- a/tensorrt_llm/_torch/models/modeling_vila.py
+++ b/tensorrt_llm/_torch/models/modeling_vila.py
@@ -1161,7 +1161,11 @@ class VilaModel(PreTrainedModel):
         """
 
         num_context_requests, num_generation_requests = attn_metadata.num_contexts, attn_metadata.num_generations
-        mm_embed = kwargs.get("multi_modal_data", [])
+        multimodal_params = kwargs.get("multimodal_params", [])
+        mm_embed = [
+            multimodal_param.mm_embedding
+            for multimodal_param in multimodal_params
+        ]
 
         assert mm_embed == [] or len(
             mm_embed

--- a/tensorrt_llm/_torch/models/modeling_vila.py
+++ b/tensorrt_llm/_torch/models/modeling_vila.py
@@ -1163,7 +1163,7 @@ class VilaModel(PreTrainedModel):
         num_context_requests, num_generation_requests = attn_metadata.num_contexts, attn_metadata.num_generations
         multimodal_params = kwargs.get("multimodal_params", [])
         mm_embed = [
-            multimodal_param.mm_embedding
+            multimodal_param.multimodal_embedding
             for multimodal_param in multimodal_params
         ]
 

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -463,6 +463,5 @@ def executor_request_to_llm_request(
         priority=0.5,
         llm_request_type=llm_request_type,
         context_phase_params=executor_request.context_phase_params,
-        py_mm_data=getattr(executor_request, "py_mm_data",
-                                     None))
+        py_mm_data=getattr(executor_request, "py_mm_data", None))
     return llm_request

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -282,7 +282,7 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
         self.py_logits_post_processors = kwargs.pop("py_logits_post_processors",
                                                     None)
         # Multimodal data
-        self.py_mm_data = kwargs.pop("py_mm_data", None)
+        self.py_multimodal_data = kwargs.pop("py_multimodal_data", None)
         super().__init__(
             *args,
             client_id=client_id,
@@ -402,6 +402,22 @@ def executor_request_to_llm_request(
     stop_words_list = convert_wordlist(
         executor_request.stop_words) if executor_request.stop_words else None
 
+    # Extract multimodal fields from executor request
+    multimodal_hashes = None
+    multimodal_positions = None
+    multimodal_lengths = None
+    if executor_request.multimodal_input is not None:
+        multimodal_hashes = executor_request.multimodal_input.multimodal_hashes
+        multimodal_positions = executor_request.multimodal_input.multimodal_positions
+        multimodal_lengths = executor_request.multimodal_input.multimodal_lengths
+
+    # Extract mrope fields
+    mrope_rotary_cos_sin = None
+    mrope_position_deltas = None
+    if executor_request.mrope_config is not None:
+        mrope_rotary_cos_sin = executor_request.mrope_config.mrope_rotary_cos_sin
+        mrope_position_deltas = executor_request.mrope_config.mrope_position_deltas
+
     llm_request = LlmRequest(
         request_id=req_id,
         max_new_tokens=executor_request.max_tokens,
@@ -421,24 +437,18 @@ def executor_request_to_llm_request(
         is None else executor_request.prompt_tuning_config.embedding_table,
         prompt_vocab_size=None if executor_request.prompt_tuning_config is None
         else executor_request.prompt_tuning_config.embedding_table.shape[0],
-        multimodal_hashes=None if executor_request.multimodal_input is None else
-        executor_request.multimodal_input.multimodal_hashes,
-        multimodal_positions=None if executor_request.multimodal_input is None
-        else executor_request.multimodal_input.multimodal_positions,
-        multimodal_lengths=None if executor_request.multimodal_input is None
-        else executor_request.multimodal_input.multimodal_lengths,
-        multimodal_embedding=None if executor_request.multimodal_embedding
-        is None else executor_request.multimodal_embedding,
+        multimodal_hashes=multimodal_hashes,
+        multimodal_positions=multimodal_positions,
+        multimodal_lengths=multimodal_lengths,
+        multimodal_embedding=executor_request.multimodal_embedding,
         lora_task_id=executor_request.lora_config.task_id
         if executor_request.lora_config is not None else None,
         lora_weights=executor_request.lora_config.weights
         if executor_request.lora_config is not None else None,
         lora_config=executor_request.lora_config.config
         if executor_request.lora_config is not None else None,
-        mrope_rotary_cos_sin=None if executor_request.mrope_config is None else
-        executor_request.mrope_config.mrope_rotary_cos_sin,
-        mrope_position_deltas=None if executor_request.mrope_config is None else
-        executor_request.mrope_config.mrope_position_deltas,
+        mrope_rotary_cos_sin=mrope_rotary_cos_sin,
+        mrope_position_deltas=mrope_position_deltas,
         lookahead_config=None,
         return_log_probs=executor_request.output_config.return_log_probs,
         return_context_logits=executor_request.output_config.
@@ -463,5 +473,6 @@ def executor_request_to_llm_request(
         priority=0.5,
         llm_request_type=llm_request_type,
         context_phase_params=executor_request.context_phase_params,
-        py_mm_data=getattr(executor_request, "py_mm_data", None))
+        py_multimodal_data=getattr(executor_request, "py_multimodal_data",
+                                   None))
     return llm_request

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -281,6 +281,8 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
             **kwargs):
         self.py_logits_post_processors = kwargs.pop("py_logits_post_processors",
                                                     None)
+        # Multimodal data
+        self.py_mm_data = kwargs.pop("py_mm_data", None)
         super().__init__(
             *args,
             client_id=client_id,
@@ -460,6 +462,7 @@ def executor_request_to_llm_request(
         if executor_request.client_id is not None else req_id,
         priority=0.5,
         llm_request_type=llm_request_type,
-        context_phase_params=executor_request.context_phase_params)
-
+        context_phase_params=executor_request.context_phase_params,
+        py_mm_data=getattr(executor_request, "py_mm_data",
+                                     None))
     return llm_request

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1495,7 +1495,8 @@ class PyTorchModelEngine(ModelEngine):
             self.position_ids_cuda[:total_num_tokens].unsqueeze(0),
             'inputs_embeds': None,
             'multi_modal_data': multi_modal_data,
-            'mrope_config': mrope_config
+            'mrope_config': mrope_config,
+            'mm_data': py_mm_data
         }
 
         if bool(lora_params):

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1176,10 +1176,9 @@ class PyTorchModelEngine(ModelEngine):
         gather_ids = []
         position_ids = []  # per sequence
         num_cached_tokens_per_seq = []  # per sequence
-        multi_modal_data = []
         draft_tokens = []
         draft_lens = []
-        mrope_config = defaultdict(list)
+        multimodal_params_list = []
         gen_request_seq_slots = []  # per generation request
 
         for request in scheduled_requests.context_requests:

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1200,8 +1200,7 @@ class PyTorchModelEngine(ModelEngine):
 
             # Multimodal
             multimodal_params = MultimodalParams(
-                multimodal_data=request.py_multimodal_data, )
-            multimodal_params.strip_for_context()
+                multimodal_data=request.py_multimodal_data)
             multimodal_params.to_device("multimodal_data",
                                         "cuda",
                                         pin_memory=True)
@@ -1238,7 +1237,7 @@ class PyTorchModelEngine(ModelEngine):
                 generation_requests.append(request)
             # Multimodal
             multimodal_params = MultimodalParams(
-                multimodal_data=request.py_multimodal_data, )
+                multimodal_data=request.py_multimodal_data)
             multimodal_params.strip_for_generation()
             multimodal_params.to_device("multimodal_data",
                                         "cuda",

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1197,7 +1197,6 @@ class PyTorchModelEngine(ModelEngine):
             prompt_lengths.append(len(prompt_tokens))
             past_seen_token_num = begin_compute
             num_cached_tokens_per_seq.append(past_seen_token_num)
-            request.py_batch_idx = py_batch_idx(request)
 
             # Multimodal
             multimodal_params = MultimodalParams(

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1198,31 +1198,27 @@ class PyTorchModelEngine(ModelEngine):
             past_seen_token_num = begin_compute
             num_cached_tokens_per_seq.append(past_seen_token_num)
 
-            if request.multimodal_embedding is not None:
+            multimodal_embedding = request.multimodal_embedding
+            if multimodal_embedding is not None:
                 # TODO: Visit later once we have the SharedTensor.
-                request.multimodal_embedding = torch.tensor(
-                    request.multimodal_embedding,
-                    dtype=torch.float32,
-                    pin_memory=True)
-                request.multimodal_embedding = request.multimodal_embedding.to(
+                multimodal_embedding = multimodal_embedding.pin_memory(
+                ) if multimodal_embedding.device == 'cpu' else multimodal_embedding
+                multimodal_embedding = multimodal_embedding.to(
                     'cuda', non_blocking=True)
 
-            if request.mrope_rotary_cos_sin is not None:
+            mrope_rotary_cos_sin = request.mrope_rotary_cos_sin
+            if mrope_rotary_cos_sin is not None:
                 # TODO: Visit later once we have the SharedTensor.
-                mrope_rotary_cos_sin_tensor = torch.tensor(
-                    request.mrope_rotary_cos_sin,
-                    dtype=torch.float32,
-                    pin_memory=True)
-                mrope_rotary_cos_sin_tensor = mrope_rotary_cos_sin_tensor.to(
+                mrope_rotary_cos_sin = mrope_rotary_cos_sin.pin_memory(
+                ) if mrope_rotary_cos_sin.device == 'cpu' else mrope_rotary_cos_sin
+                mrope_rotary_cos_sin = mrope_rotary_cos_sin.to(
                     'cuda', non_blocking=True)
-            else:
-                mrope_rotary_cos_sin_tensor = None
+
             # Create MultimodalParams from request data
             multimodal_params = MultimodalParams(
-                multimodal_embedding=request.multimodal_embedding,
-                mrope_config={
-                    'mrope_rotary_cos_sin': mrope_rotary_cos_sin_tensor
-                } if mrope_rotary_cos_sin_tensor is not None else None,
+                multimodal_embedding=multimodal_embedding,
+                mrope_config={'mrope_rotary_cos_sin': mrope_rotary_cos_sin}
+                if mrope_rotary_cos_sin is not None else {},
                 multimodal_data=request.py_multimodal_data,
             )
 

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1208,10 +1208,10 @@ class PyExecutor:
         if self.dist.rank == 0:
             py_logits_post_processors = self._collect_py_objects_from_requests(
                 new_requests, "py_logits_post_processors")
-            py_mm_data = self._collect_py_objects_from_requests(
-                new_requests, "py_mm_data")
+            py_multimodal_data = self._collect_py_objects_from_requests(
+                new_requests, "py_multimodal_data")
             py_request_objects = tuple(
-                filter(None, [py_logits_post_processors, py_mm_data]))
+                filter(None, [py_logits_post_processors, py_multimodal_data]))
         else:
             py_request_objects = None
 

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1210,7 +1210,8 @@ class PyExecutor:
                 new_requests, "py_logits_post_processors")
             py_mm_data = self._collect_py_objects_from_requests(
                 new_requests, "py_mm_data")
-            py_request_objects = tuple(filter(None, [py_logits_post_processors, py_mm_data]))
+            py_request_objects = tuple(
+                filter(None, [py_logits_post_processors, py_mm_data]))
         else:
             py_request_objects = None
 

--- a/tensorrt_llm/executor/executor.py
+++ b/tensorrt_llm/executor/executor.py
@@ -13,7 +13,7 @@ from typing import (TYPE_CHECKING, AsyncIterable, Generator, List, Optional,
 import numpy as np
 import torch
 
-from tensorrt_llm.inputs.multimodal import MultimodalInput
+from tensorrt_llm.inputs.multimodal import MultimodalParams
 from tensorrt_llm.logger import logger, set_level
 from tensorrt_llm.lora_manager import LoraConfig
 
@@ -116,13 +116,10 @@ class GenerationExecutor(ABC):
         lora_request: Optional[LoRARequest] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
         streaming: bool = False,
-        multimodal_input: Optional[MultimodalInput] = None,
-        multimodal_embedding: Optional[list] = None,
-        mrope_config: Optional[dict] = None,
         kv_cache_retention_config: Optional[KvCacheRetentionConfig] = None,
         disaggregated_params: Optional[DisaggregatedParams] = None,
         postproc_params: Optional[PostprocParams] = None,
-        mm_data: Optional[dict] = None,
+        multimodal_params: Optional[MultimodalParams] = None,
     ) -> GenerationResult:
         """Generate output for the given prompt token ids in the asynchronous mode.
         Asynchronous generation accepts single prompt only.
@@ -144,12 +141,9 @@ class GenerationExecutor(ABC):
                 lora_request=lora_request,
                 prompt_adapter_request=prompt_adapter_request,
                 streaming=streaming,
-                multimodal_input=multimodal_input,
-                multimodal_embedding=multimodal_embedding,
-                mrope_config=mrope_config,
                 kv_cache_retention_config=kv_cache_retention_config,
                 disaggregated_params=disaggregated_params,
-                mm_data=mm_data))
+                multimodal_params=multimodal_params))
         return result
 
     def generate(

--- a/tensorrt_llm/executor/executor.py
+++ b/tensorrt_llm/executor/executor.py
@@ -109,21 +109,20 @@ class GenerationExecutor(ABC):
         pass
 
     def generate_async(
-            self,
-            prompt_token_ids: List[int],
-            sampling_params: SamplingParams,
-            query_token_ids: Optional[Union[torch.Tensor, np.ndarray,
-                                            list]] = None,
-            lora_request: Optional[LoRARequest] = None,
-            prompt_adapter_request: Optional[PromptAdapterRequest] = None,
-            streaming: bool = False,
-            multimodal_input: Optional[MultimodalInput] = None,
-            multimodal_embedding: Optional[list] = None,
-            mrope_config: Optional[dict] = None,
-            kv_cache_retention_config: Optional[KvCacheRetentionConfig] = None,
-            disaggregated_params: Optional[DisaggregatedParams] = None,
-            postproc_params: Optional[PostprocParams] = None,
-            mm_data: Optional[dict] = None,
+        self,
+        prompt_token_ids: List[int],
+        sampling_params: SamplingParams,
+        query_token_ids: Optional[Union[torch.Tensor, np.ndarray, list]] = None,
+        lora_request: Optional[LoRARequest] = None,
+        prompt_adapter_request: Optional[PromptAdapterRequest] = None,
+        streaming: bool = False,
+        multimodal_input: Optional[MultimodalInput] = None,
+        multimodal_embedding: Optional[list] = None,
+        mrope_config: Optional[dict] = None,
+        kv_cache_retention_config: Optional[KvCacheRetentionConfig] = None,
+        disaggregated_params: Optional[DisaggregatedParams] = None,
+        postproc_params: Optional[PostprocParams] = None,
+        mm_data: Optional[dict] = None,
     ) -> GenerationResult:
         """Generate output for the given prompt token ids in the asynchronous mode.
         Asynchronous generation accepts single prompt only.

--- a/tensorrt_llm/executor/executor.py
+++ b/tensorrt_llm/executor/executor.py
@@ -122,7 +122,8 @@ class GenerationExecutor(ABC):
             mrope_config: Optional[dict] = None,
             kv_cache_retention_config: Optional[KvCacheRetentionConfig] = None,
             disaggregated_params: Optional[DisaggregatedParams] = None,
-            postproc_params: Optional[PostprocParams] = None
+            postproc_params: Optional[PostprocParams] = None,
+            mm_data: Optional[dict] = None,
     ) -> GenerationResult:
         """Generate output for the given prompt token ids in the asynchronous mode.
         Asynchronous generation accepts single prompt only.
@@ -148,7 +149,8 @@ class GenerationExecutor(ABC):
                 multimodal_embedding=multimodal_embedding,
                 mrope_config=mrope_config,
                 kv_cache_retention_config=kv_cache_retention_config,
-                disaggregated_params=disaggregated_params))
+                disaggregated_params=disaggregated_params,
+                mm_data=mm_data))
         return result
 
     def generate(

--- a/tensorrt_llm/executor/request.py
+++ b/tensorrt_llm/executor/request.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Union
 import numpy as np
 import torch
 
-from tensorrt_llm.inputs.multimodal import MultimodalInput
+from tensorrt_llm.inputs.multimodal import MultimodalParams
 
 from ..disaggregated_params import DisaggregatedParams
 from ..llmapi.llm_utils import KvCacheRetentionConfig
@@ -82,13 +82,10 @@ class GenerationRequest:
         lora_request: Optional[LoRARequest] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
         streaming: bool = False,
-        multimodal_input: Optional[MultimodalInput] = None,
-        multimodal_embedding: Optional[list] = None,
-        mrope_config: Optional[dict] = None,
         kv_cache_retention_config: Optional[KvCacheRetentionConfig] = None,
         disaggregated_params: Optional[DisaggregatedParams] = None,
         postproc_params: Optional[PostprocParams] = None,
-        mm_data: Optional[dict] = None,
+        multimodal_params: Optional[MultimodalParams] = None,
     ):
         if isinstance(prompt_token_ids, list):
             self.prompt_token_ids = prompt_token_ids
@@ -107,13 +104,10 @@ class GenerationRequest:
         self.lora_request = lora_request
         self.prompt_adapter_request = prompt_adapter_request
         self.streaming = streaming
-        self.multimodal_input = multimodal_input
-        self.multimodal_embedding = multimodal_embedding
-        self.mrope_config = mrope_config
+        self.multimodal_params = multimodal_params
         self.kv_cache_retention_config = kv_cache_retention_config
         self.id: Optional[int] = None
         self.disaggregated_params = disaggregated_params
-        self.mm_data = mm_data
 
     def set_id(self, id):
         assert self.id is None, f"Request ID is already set: {self.id}"

--- a/tensorrt_llm/executor/request.py
+++ b/tensorrt_llm/executor/request.py
@@ -88,6 +88,7 @@ class GenerationRequest:
         kv_cache_retention_config: Optional[KvCacheRetentionConfig] = None,
         disaggregated_params: Optional[DisaggregatedParams] = None,
         postproc_params: Optional[PostprocParams] = None,
+        mm_data: Optional[dict] = None,
     ):
         if isinstance(prompt_token_ids, list):
             self.prompt_token_ids = prompt_token_ids
@@ -112,6 +113,7 @@ class GenerationRequest:
         self.kv_cache_retention_config = kv_cache_retention_config
         self.id: Optional[int] = None
         self.disaggregated_params = disaggregated_params
+        self.mm_data = mm_data
 
     def set_id(self, id):
         assert self.id is None, f"Request ID is already set: {self.id}"

--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -469,6 +469,7 @@ class GenerationExecutorWorker(GenerationExecutor):
                 lora_config=lora_config,
                 prompt_tuning_config=prompt_tuning_config,
                 multimodal_input=multimodal_input,
+                #NOTE: `multimodal_embedding` and `mrope_config` will be in MultimodalParams.multimodal_data. And this will be handled below by `py_multimodal_data`.
                 multimodal_embedding=None,
                 mrope_config=None,
                 logits_post_processor_name=(

--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -479,6 +479,10 @@ class GenerationExecutorWorker(GenerationExecutor):
                 context_phase_params=context_phase_params,
                 type=request_type)
 
+            if self._is_pytorch_backend:
+                if request.mm_data is not None:
+                    executor_request.py_mm_data = request.mm_data
+
             if self._is_pytorch_backend and request.sampling_params.logits_processor:
                 # For PyTorch backend, we attach logits processors as a dynamic Python attribute
                 # instead of using the C++ binding, since the latter will cause PyCapsule pickling issues.

--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -101,7 +101,22 @@ class MultimodalParams:
                                              Union[torch.Tensor,
                                                    List[Any]]]]] = field(
                                                        default_factory=dict)
-    """Raw multimodal data by modality (e.g., image pixels, video frames)."""
+    """Processed multimodal data after AutoProcessor's process() by modality (e.g., image pixels, video pixel values).
+    It should be in the form of {modality: {item_str: item_data}}
+    e.g.
+    {
+        "image": {
+            "pixel_values": torch.Tensor(),
+            "image_height": torch.Tensor() or List[int],
+            "image_width": torch.Tensor() or List[int]
+        },
+        "video": {
+            "pixel_values": torch.Tensor(),
+            "video_height": torch.Tensor() or List[int],
+            "video_width": torch.Tensor() or List[int]
+        },
+    }
+    """
 
     # Model-specific configurations
     mrope_config: Optional[Dict[str, Any]] = None

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -386,9 +386,6 @@ class BaseLLM:
                 query_token_ids = extra_processed_inputs.get('query_token_ids')
                 # Create unified MultimodalParams
                 multimodal_params = MultimodalParams(
-                    multimodal_embedding=extra_processed_inputs.get(
-                        'mm_embedding'),
-                    mrope_config=extra_processed_inputs.get('mrope_config'),
                     multimodal_input=extra_processed_inputs.get(
                         'multimodal_input'),
                     multimodal_data=extra_processed_inputs.get(

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -13,6 +13,7 @@ from tqdm import tqdm
 from transformers import PreTrainedTokenizerBase
 
 from tensorrt_llm.inputs.data import TextPrompt
+from tensorrt_llm.inputs.multimodal import MultimodalParams
 from tensorrt_llm.inputs.registry import DefaultInputProcessor
 
 from .._utils import nvtx_range_debug
@@ -357,11 +358,8 @@ class BaseLLM:
                 sampling_params.add_special_tokens = False
 
         query_token_ids = None
-        # NOTE: Multimodal related data
-        multimodal_input = None
-        multimodal_embedding = None
-        mrope_config = None
-        mm_data = None
+        multimodal_params = None
+
         if "prompt_token_ids" in inputs:
             # TODO: if specify prompt_token_ids, the mm hashing is not supported yet
             prompt_token_ids = inputs['prompt_token_ids']
@@ -386,13 +384,18 @@ class BaseLLM:
             prompt = inputs['prompt']
             if extra_processed_inputs is not None:
                 query_token_ids = extra_processed_inputs.get('query_token_ids')
-                # NOTE: Multimodal related data
-                multimodal_embedding = extra_processed_inputs.get(
-                    'mm_embedding')
-                mrope_config = extra_processed_inputs.get('mrope_config')
-                multimodal_input = extra_processed_inputs.get(
-                    'multimodal_input')
-                mm_data = extra_processed_inputs.get('mm_data')
+                # Create unified MultimodalParams
+                multimodal_params = MultimodalParams(
+                    multimodal_embedding=extra_processed_inputs.get(
+                        'mm_embedding'),
+                    mrope_config=extra_processed_inputs.get('mrope_config'),
+                    multimodal_input=extra_processed_inputs.get(
+                        'multimodal_input'),
+                    multimodal_data=extra_processed_inputs.get(
+                        'multimodal_data'))
+                # Only pass it if it has content
+                if not multimodal_params.has_content():
+                    multimodal_params = None
         else:
             raise TypeError(
                 f"The inputs must be type str or list of int, but got {type(inputs)}"
@@ -412,13 +415,10 @@ class BaseLLM:
             lora_request=lora_request,
             prompt_adapter_request=prompt_adapter_request,
             streaming=streaming,
-            multimodal_input=multimodal_input,
-            multimodal_embedding=multimodal_embedding,
-            mrope_config=mrope_config,
             kv_cache_retention_config=kv_cache_retention_config,
             disaggregated_params=disaggregated_params,
             postproc_params=_postproc_params,
-            mm_data=mm_data,
+            multimodal_params=multimodal_params,
         )
 
         return RequestOutput._from_generation_result(result, prompt,

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -357,9 +357,11 @@ class BaseLLM:
                 sampling_params.add_special_tokens = False
 
         query_token_ids = None
+        # NOTE: Multimodal related data
         multimodal_input = None
         multimodal_embedding = None
         mrope_config = None
+        mm_data = None
         if "prompt_token_ids" in inputs:
             # TODO: if specify prompt_token_ids, the mm hashing is not supported yet
             prompt_token_ids = inputs['prompt_token_ids']
@@ -384,11 +386,13 @@ class BaseLLM:
             prompt = inputs['prompt']
             if extra_processed_inputs is not None:
                 query_token_ids = extra_processed_inputs.get('query_token_ids')
+                # NOTE: Multimodal related data
                 multimodal_embedding = extra_processed_inputs.get(
                     'mm_embedding')
                 mrope_config = extra_processed_inputs.get('mrope_config')
                 multimodal_input = extra_processed_inputs.get(
                     'multimodal_input')
+                mm_data = extra_processed_inputs.get('mm_data')
         else:
             raise TypeError(
                 f"The inputs must be type str or list of int, but got {type(inputs)}"
@@ -414,6 +418,7 @@ class BaseLLM:
             kv_cache_retention_config=kv_cache_retention_config,
             disaggregated_params=disaggregated_params,
             postproc_params=_postproc_params,
+            mm_data=mm_data,
         )
 
         return RequestOutput._from_generation_result(result, prompt,

--- a/tests/unittest/llmapi/apps/_test_openai_chat_multimodal.py
+++ b/tests/unittest/llmapi/apps/_test_openai_chat_multimodal.py
@@ -188,7 +188,7 @@ def test_single_chat_session_video(client: openai.OpenAI, model_name: str):
             "type": "text",
             "text": content_text
         }, {
-            "type": "image_url",
+            "type": "video_url",
             "video_url": {
                 "url": video_url
             }


### PR DESCRIPTION
## Description

This PR adds mm_data element so that we could transfer easily mm_related_data.
Also, refactor the Qwen2/2.5-VL & HyperCLOVAX-Vision accordingly.
Especially, moving Qwen2/2.5-VL's encoder into the LLM.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
