### PR TITLE
[https://nvbugs/5302040][feat] Add whisper support (Bert Attention on SM100 and GPTAttention for cross attention on SM100)

### DIFF
--- a/cpp/tensorrt_llm/common/attentionOp.cpp
+++ b/cpp/tensorrt_llm/common/attentionOp.cpp
@@ -2616,7 +2616,7 @@ int AttentionOp::initialize() noexcept
         fmhaParams.attnLogitSoftcappingScale = mAttnLogitSoftcappingScale;
         fmhaParams.hasAlibi = isALiBi();
         fmhaParams.scaleAlibi = isAliBiWithScale();
-	fmhaParams.dataTypeOut = data_type;
+        fmhaParams.dataTypeOut = data_type;
 
         // Load kernels from the pre-compiled cubins.
         mFmhaDispatcher.reset(new FmhaDispatcher(fmhaParams));

--- a/cpp/tensorrt_llm/common/attentionOp.cpp
+++ b/cpp/tensorrt_llm/common/attentionOp.cpp
@@ -2616,6 +2616,7 @@ int AttentionOp::initialize() noexcept
         fmhaParams.attnLogitSoftcappingScale = mAttnLogitSoftcappingScale;
         fmhaParams.hasAlibi = isALiBi();
         fmhaParams.scaleAlibi = isAliBiWithScale();
+	fmhaParams.dataTypeOut = data_type;
 
         // Load kernels from the pre-compiled cubins.
         mFmhaDispatcher.reset(new FmhaDispatcher(fmhaParams));

--- a/cpp/tensorrt_llm/common/attentionOp.cpp
+++ b/cpp/tensorrt_llm/common/attentionOp.cpp
@@ -2616,7 +2616,6 @@ int AttentionOp::initialize() noexcept
         fmhaParams.attnLogitSoftcappingScale = mAttnLogitSoftcappingScale;
         fmhaParams.hasAlibi = isALiBi();
         fmhaParams.scaleAlibi = isAliBiWithScale();
-        fmhaParams.dataTypeOut = data_type;
 
         // Load kernels from the pre-compiled cubins.
         mFmhaDispatcher.reset(new FmhaDispatcher(fmhaParams));

--- a/cpp/tensorrt_llm/plugins/bertAttentionPlugin/bertAttentionPlugin.cpp
+++ b/cpp/tensorrt_llm/plugins/bertAttentionPlugin/bertAttentionPlugin.cpp
@@ -520,10 +520,12 @@ int BertAttentionPlugin::enqueueImpl(nvinfer1::PluginTensorDesc const* inputDesc
                 cudaMemsetAsync(fmhaParams.outputPtr, 0, ring_block_output_size, stream);
                 cudaMemcpyAsync(fmhaParams.tileCounterPtr, fmha_scheduler_counter_h, sizeof(uint32_t),
                     cudaMemcpyHostToDevice, stream);
-		if(tensorrt_llm::common::getSMVersion() >= 100 && tensorrt_llm::common::getSMVersion() < 120){
+                if (tensorrt_llm::common::getSMVersion() >= 100 && tensorrt_llm::common::getSMVersion() < 120)
+                {
                     mFmhaDispatcher->run(fmhaParams);
                 }
-                else{
+                else
+                {
                     mFMHARunner->run(fmhaParams);
                 }
                 if (iter != 0)
@@ -709,7 +711,8 @@ int BertAttentionPlugin::enqueueImpl(nvinfer1::PluginTensorDesc const* inputDesc
             }
 
             // Run the fmha kernel.
-	    if(tensorrt_llm::common::getSMVersion() >= 100 && tensorrt_llm::common::getSMVersion() < 120){
+            if (tensorrt_llm::common::getSMVersion() >= 100 && tensorrt_llm::common::getSMVersion() < 120)
+            {
 
                 // TODO: set it correctly for contiguous kv buffer (cross-attention).
                 fmhaParams.totalKvSeqLen = num_tokens;
@@ -722,8 +725,9 @@ int BertAttentionPlugin::enqueueImpl(nvinfer1::PluginTensorDesc const* inputDesc
                 fmhaParams.scaleBmm2Ptr = scale_bmm2_ptr;
                 fmhaParams.forceFp32Acc = mFMHAForceFP32Acc;
                 mFmhaDispatcher->run(fmhaParams);
-
-            } else{
+            }
+            else
+            {
                 // Run the fmha kernel.
                 mFMHARunner->run(fmhaParams);
             }
@@ -970,24 +974,25 @@ int BertAttentionPlugin::initialize() noexcept
         }
 
         // Load kernels from the pre-compiled cubins.
-	if(tensorrt_llm::common::getSMVersion() >= 100){
+        if (tensorrt_llm::common::getSMVersion() >= 100)
+        {
             // // The KV input data type. The default is same as dataType.
             fmhaParams.dataTypeKv = data_type;
             fmhaParams.forceFp32Acc = false;
             fmhaParams.headSizeV = mHeadSize;
 
-
-            // Load kernels from the pre-compiled cubins for blackwell.         
+            // Load kernels from the pre-compiled cubins for blackwell.
             mFmhaDispatcher.reset(new FmhaDispatcher(fmhaParams));
             // Fall back to unfused MHA kernels if not supported for blackwell.
             mEnableContextFMHA = mFmhaDispatcher->isSupported();
         }
-        else{
+        else
+        {
             // Load kernels from the pre-compiled cubins.
             mFMHARunner.reset(new FusedMHARunnerV2(fmhaParams));
             // Fall back to unfused MHA kernels if not supported.
             mEnableContextFMHA = mFMHARunner->isFmhaSupported();
-	}
+        }
     }
 
 #if ENABLE_MULTI_DEVICE

--- a/cpp/tensorrt_llm/plugins/bertAttentionPlugin/bertAttentionPlugin.cpp
+++ b/cpp/tensorrt_llm/plugins/bertAttentionPlugin/bertAttentionPlugin.cpp
@@ -959,25 +959,14 @@ int BertAttentionPlugin::initialize() noexcept
         }
 
         // Load kernels from the pre-compiled cubins.
-        if (tensorrt_llm::common::getSMVersion() >= 100)
-        {
-            // // The KV input data type. The default is same as dataType.
-            fmhaParams.dataTypeKv = data_type;
-            fmhaParams.forceFp32Acc = false;
-            fmhaParams.headSizeV = mHeadSize;
+        // The KV input data type. The default is same as dataType.
+        fmhaParams.dataTypeKv = data_type;
+        fmhaParams.headSizeV = mHeadSize;
 
-            // Load kernels from the pre-compiled cubins for blackwell.
-            mFmhaDispatcher.reset(new FmhaDispatcher(fmhaParams));
-            // Fall back to unfused MHA kernels if not supported for blackwell.
-            mEnableContextFMHA = mFmhaDispatcher->isSupported();
-        }
-        else
-        {
-            // Load kernels from the pre-compiled cubins.
-            mFMHARunner.reset(new FusedMHARunnerV2(fmhaParams));
-            // Fall back to unfused MHA kernels if not supported.
-            mEnableContextFMHA = mFMHARunner->isFmhaSupported();
-        }
+        // Load kernels from the pre-compiled cubins.
+        mFmhaDispatcher.reset(new FmhaDispatcher(fmhaParams));
+        // Fall back to unfused MHA kernels if not supported.
+        mEnableContextFMHA = mFmhaDispatcher->isSupported();
     }
 
 #if ENABLE_MULTI_DEVICE

--- a/cpp/tensorrt_llm/plugins/bertAttentionPlugin/bertAttentionPlugin.cpp
+++ b/cpp/tensorrt_llm/plugins/bertAttentionPlugin/bertAttentionPlugin.cpp
@@ -520,14 +520,8 @@ int BertAttentionPlugin::enqueueImpl(nvinfer1::PluginTensorDesc const* inputDesc
                 cudaMemsetAsync(fmhaParams.outputPtr, 0, ring_block_output_size, stream);
                 cudaMemcpyAsync(fmhaParams.tileCounterPtr, fmha_scheduler_counter_h, sizeof(uint32_t),
                     cudaMemcpyHostToDevice, stream);
-                if (tensorrt_llm::common::getSMVersion() >= 100 && tensorrt_llm::common::getSMVersion() < 120)
-                {
-                    mFmhaDispatcher->run(fmhaParams);
-                }
-                else
-                {
-                    mFMHARunner->run(fmhaParams);
-                }
+                mFmhaDispatcher->run(fmhaParams);
+                mFMHARunner->run(fmhaParams);
                 if (iter != 0)
                 {
                     invokeRecoverFromRA<T>((T*) context_buf_, (float*) ring_softmax_accu_stats_buf_,

--- a/cpp/tensorrt_llm/plugins/bertAttentionPlugin/bertAttentionPlugin.cpp
+++ b/cpp/tensorrt_llm/plugins/bertAttentionPlugin/bertAttentionPlugin.cpp
@@ -520,7 +520,12 @@ int BertAttentionPlugin::enqueueImpl(nvinfer1::PluginTensorDesc const* inputDesc
                 cudaMemsetAsync(fmhaParams.outputPtr, 0, ring_block_output_size, stream);
                 cudaMemcpyAsync(fmhaParams.tileCounterPtr, fmha_scheduler_counter_h, sizeof(uint32_t),
                     cudaMemcpyHostToDevice, stream);
-                mFMHARunner->run(fmhaParams);
+		if(tensorrt_llm::common::getSMVersion() >= 100 && tensorrt_llm::common::getSMVersion() < 120){
+                    mFmhaDispatcher->run(fmhaParams);
+                }
+                else{
+                    mFMHARunner->run(fmhaParams);
+                }
                 if (iter != 0)
                 {
                     invokeRecoverFromRA<T>((T*) context_buf_, (float*) ring_softmax_accu_stats_buf_,
@@ -704,7 +709,24 @@ int BertAttentionPlugin::enqueueImpl(nvinfer1::PluginTensorDesc const* inputDesc
             }
 
             // Run the fmha kernel.
-            mFMHARunner->run(fmhaParams);
+	    if(tensorrt_llm::common::getSMVersion() >= 100 && tensorrt_llm::common::getSMVersion() < 120){
+
+                // TODO: set it correctly for contiguous kv buffer (cross-attention).
+                fmhaParams.totalKvSeqLen = num_tokens;
+
+                fmhaParams.cuKvSeqLenPtr = cu_seqlens;
+                fmhaParams.cuMaskRowsPtr = cu_seqlens;
+                fmhaParams.tileCounterPtr = fmha_tile_counter_ptr;
+
+                fmhaParams.scaleBmm1Ptr = scale_bmm1_ptr;
+                fmhaParams.scaleBmm2Ptr = scale_bmm2_ptr;
+                fmhaParams.forceFp32Acc = mFMHAForceFP32Acc;
+                mFmhaDispatcher->run(fmhaParams);
+
+            } else{
+                // Run the fmha kernel.
+                mFMHARunner->run(fmhaParams);
+            }
             sync_check_cuda_error(stream);
             if (mSageAttn)
             {
@@ -948,10 +970,24 @@ int BertAttentionPlugin::initialize() noexcept
         }
 
         // Load kernels from the pre-compiled cubins.
-        mFMHARunner.reset(new FusedMHARunnerV2(fmhaParams));
+	if(tensorrt_llm::common::getSMVersion() >= 100){
+            // // The KV input data type. The default is same as dataType.
+            fmhaParams.dataTypeKv = data_type;
+            fmhaParams.forceFp32Acc = false;
+            fmhaParams.headSizeV = mHeadSize;
 
-        // Fall back to unfused MHA kernels if not supported.
-        mEnableContextFMHA = mFMHARunner->isFmhaSupported();
+
+            // Load kernels from the pre-compiled cubins for blackwell.         
+            mFmhaDispatcher.reset(new FmhaDispatcher(fmhaParams));
+            // Fall back to unfused MHA kernels if not supported for blackwell.
+            mEnableContextFMHA = mFmhaDispatcher->isSupported();
+        }
+        else{
+            // Load kernels from the pre-compiled cubins.
+            mFMHARunner.reset(new FusedMHARunnerV2(fmhaParams));
+            // Fall back to unfused MHA kernels if not supported.
+            mEnableContextFMHA = mFMHARunner->isFmhaSupported();
+	}
     }
 
 #if ENABLE_MULTI_DEVICE

--- a/cpp/tensorrt_llm/plugins/bertAttentionPlugin/bertAttentionPlugin.h
+++ b/cpp/tensorrt_llm/plugins/bertAttentionPlugin/bertAttentionPlugin.h
@@ -18,7 +18,6 @@
 
 #include "tensorrt_llm/common/cublasMMWrapper.h"
 #include "tensorrt_llm/common/quantization.h"
-#include "tensorrt_llm/kernels/contextFusedMultiHeadAttention/fmhaRunner.h"
 #include "tensorrt_llm/kernels/fmhaDispatcher.h"
 #include "tensorrt_llm/kernels/gptKernels.h"
 #include "tensorrt_llm/plugins/common/plugin.h"
@@ -115,7 +114,6 @@ private:
     cudaStream_t mNcclStream;
 
     // The default copy constructor will leave them as nullptr. clone() shall initialize it.
-    UniqPtrWNullCopy<tensorrt_llm::kernels::FusedMHARunnerV2> mFMHARunner;
     UniqPtrWNullCopy<tensorrt_llm::kernels::FmhaDispatcher> mFmhaDispatcher;
     UniqPtrWNullCopy<tensorrt_llm::common::CublasMMWrapper> mCublasWrapper;
 };

--- a/cpp/tensorrt_llm/plugins/bertAttentionPlugin/bertAttentionPlugin.h
+++ b/cpp/tensorrt_llm/plugins/bertAttentionPlugin/bertAttentionPlugin.h
@@ -19,6 +19,7 @@
 #include "tensorrt_llm/common/cublasMMWrapper.h"
 #include "tensorrt_llm/common/quantization.h"
 #include "tensorrt_llm/kernels/contextFusedMultiHeadAttention/fmhaRunner.h"
+#include "tensorrt_llm/kernels/fmhaDispatcher.h"
 #include "tensorrt_llm/kernels/gptKernels.h"
 #include "tensorrt_llm/plugins/common/plugin.h"
 #include "tensorrt_llm/runtime/utils/mpiUtils.h"
@@ -115,6 +116,7 @@ private:
 
     // The default copy constructor will leave them as nullptr. clone() shall initialize it.
     UniqPtrWNullCopy<tensorrt_llm::kernels::FusedMHARunnerV2> mFMHARunner;
+    UniqPtrWNullCopy<tensorrt_llm::kernels::FmhaDispatcher> mFmhaDispatcher;
     UniqPtrWNullCopy<tensorrt_llm::common::CublasMMWrapper> mCublasWrapper;
 };
 

--- a/tensorrt_llm/functional.py
+++ b/tensorrt_llm/functional.py
@@ -29,7 +29,7 @@ import tensorrt as trt
 from . import graph_rewriting as gw
 from ._common import default_net, default_trtnet, precision
 from ._utils import (QuantModeWrapper, bf16_array, bool_array,
-                     dim_resolve_negative, dim_to_trt_axes, dims_array,
+                     dim_resolve_negative, dim_to_trt_axes, dims_array, get_sm_version,
                      fp16_array, fp32_array, int32_array, int64_array,
                      np_dtype_to_trt, str_dtype_to_trt, trt_dtype_to_np,
                      trt_dtype_to_str)
@@ -5719,7 +5719,8 @@ def gpt_attention(
     if (attention_mask is not None) or (attention_packed_mask is not None):
         # context fmha needs packed mask.
         assert attention_packed_mask is not None
-        mask_type = AttentionMaskType.custom_mask
+        if get_sm_version() < 100:
+            mask_type = AttentionMaskType.custom_mask
 
     mask_type_filed = trt.PluginField("mask_type",
                                       np.array([int(mask_type)], np.int32),
@@ -5844,7 +5845,7 @@ def gpt_attention(
     if attention_mask is not None and mask_type == AttentionMaskType.custom_mask:
         # useFullCustomMask
         plug_inputs += [attention_mask]
-    if attention_packed_mask is not None:
+    if attention_packed_mask is not None and get_sm_version() < 100:
         # usePackedCustomMask
         plug_inputs += [attention_packed_mask]
     if use_cache:

--- a/tensorrt_llm/functional.py
+++ b/tensorrt_llm/functional.py
@@ -29,10 +29,10 @@ import tensorrt as trt
 from . import graph_rewriting as gw
 from ._common import default_net, default_trtnet, precision
 from ._utils import (QuantModeWrapper, bf16_array, bool_array,
-                     dim_resolve_negative, dim_to_trt_axes, dims_array, get_sm_version,
-                     fp16_array, fp32_array, int32_array, int64_array,
-                     np_dtype_to_trt, str_dtype_to_trt, trt_dtype_to_np,
-                     trt_dtype_to_str)
+                     dim_resolve_negative, dim_to_trt_axes, dims_array,
+                     fp16_array, fp32_array, get_sm_version, int32_array,
+                     int64_array, np_dtype_to_trt, str_dtype_to_trt,
+                     trt_dtype_to_np, trt_dtype_to_str)
 from .network import PluginInfo, set_np_weight, set_plugin_info
 from .plugin import TRT_LLM_PLUGIN_NAMESPACE, current_all_reduce_helper
 from .quantization import QuantMode

--- a/tensorrt_llm/layers/attention.py
+++ b/tensorrt_llm/layers/attention.py
@@ -1755,8 +1755,6 @@ class BertAttention(Module):
         if default_net().plugin_config.bert_attention_plugin:
             # TRT plugin mode
             assert input_lengths is not None
-            assert get_sm_version() < 100 or get_sm_version() >= 120, \
-                "bert_attention_plugin does not support SM100"
             context = bert_attention(
                 qkv,
                 input_lengths,

--- a/tensorrt_llm/layers/attention.py
+++ b/tensorrt_llm/layers/attention.py
@@ -20,8 +20,8 @@ import tensorrt as trt
 import torch
 
 from .._common import default_net, precision
-from .._utils import (fp32_array, get_sm_version, int32_array, is_same_dtype,
-                      set_obj_attrs, trt_dtype_to_np, trt_dtype_to_str)
+from .._utils import (fp32_array, int32_array, is_same_dtype, set_obj_attrs,
+                      trt_dtype_to_np, trt_dtype_to_str)
 
 # isort: off
 from ..functional import (


### PR DESCRIPTION
# [nvbugs/5302040] feat. Add whisper support (Bert Attention on SM100 and GPTAttention for cross attention on SM100)

## Description
- Add bert attention plugin for Blackwell: 
    implement with fmhaDispatcher
  
- Add same seq_len causal mask support for gpt attention on cross attention:
    fix mask type and fix mask plugin layer





Please explain the issue and the solution in short.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU compatibility for BERT/GPT attention across architectures.
  * Limited use of custom/packed attention masks to older GPUs (SM < 100), preventing issues on newer devices.
  * Removed an unnecessary hardware guard, enabling the attention plugin on additional GPUs.

* **Refactor**
  * Internal attention kernel dispatch and initialization updated for more robust execution and support checks.
  * No public API changes; behavior remains the same for supported configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->