### PR TITLE
[TRTLLM-4926][feat] Reimplement metrics endpoint with stats about requests

### DIFF
--- a/tensorrt_llm/serve/postprocess_handlers.py
+++ b/tensorrt_llm/serve/postprocess_handlers.py
@@ -97,12 +97,12 @@ def apply_reasoning_parser(args: ChatPostprocArgs, output_index: int, text: str,
 
 
 @nvtx_range_debug("chat_stream_post_processor")
-def chat_stream_post_processor(rsp: GenerationResultBase, args: ChatPostprocArgs) -> List[str]:
+def chat_stream_post_processor(rsp: GenerationResultBase, args: ChatPostprocArgs) -> List[ChatCompletionStreamResponse]:
 
     def yield_first_chat(num_tokens: int,
                          idx: int,
                          role: str = None,
-                         content: str = None):
+                         content: str = None) -> ChatCompletionStreamResponse:
         choice_data = ChatCompletionResponseStreamChoice(index=idx,
                                                          delta=DeltaMessage(
                                                              role=role,
@@ -114,10 +114,9 @@ def chat_stream_post_processor(rsp: GenerationResultBase, args: ChatPostprocArgs
             chunk.usage = UsageInfo(prompt_tokens=num_tokens,
                                     total_tokens=num_tokens,
                                     completion_tokens=0)
-        data = chunk.model_dump_json(exclude_none=True)
-        return data
+        return chunk
 
-    res: List[str] = []
+    res: List[ChatCompletionStreamResponse] = []
     finish_reason_sent = [False] * args.num_choices
     prompt_tokens = args.num_prompt_tokens
     if stream_option := args.stream_options:
@@ -128,9 +127,9 @@ def chat_stream_post_processor(rsp: GenerationResultBase, args: ChatPostprocArgs
         include_continuous_usage = False
     if args.first_iteration:
         for i in range(args.num_choices):
-            res.append(f"data: {yield_first_chat(prompt_tokens, i, role=args.role)} \n\n")
+            res.append(yield_first_chat(prompt_tokens, i, role=args.role))
             if args.echo and args.last_message_content:
-                res.append(f"data: {yield_first_chat(prompt_tokens, i, content=args.last_message_content)} \n\n")
+                res.append(yield_first_chat(prompt_tokens, i, content=args.last_message_content))
         args.first_iteration = False
 
     for output in rsp.outputs:
@@ -174,8 +173,7 @@ def chat_stream_post_processor(rsp: GenerationResultBase, args: ChatPostprocArgs
             chunk.usage = UsageInfo(prompt_tokens=prompt_tokens,
                                     completion_tokens=output.length,
                                     total_tokens=output.length + prompt_tokens)
-        data = chunk.model_dump_json(exclude_none=True)
-        res.append(f"data: {data}\n\n")
+        res.append(chunk)
 
     if include_usage and rsp._done:
         completion_tokens = sum(output.length
@@ -188,8 +186,7 @@ def chat_stream_post_processor(rsp: GenerationResultBase, args: ChatPostprocArgs
 
         final_usage_chunk = ChatCompletionStreamResponse(
             choices=[], model=args.model, usage=final_usage)
-        final_usage_data = final_usage_chunk.model_dump_json()
-        res.append(f"data: {final_usage_data}\n\n")
+        res.append(final_usage_chunk)
     return res
 
 
@@ -271,8 +268,8 @@ class CompletionPostprocArgs(PostprocArgs):
 
 
 @nvtx_range_debug("completion_stream_post_processor")
-def completion_stream_post_processor(rsp: DetokenizedGenerationResultBase, args: CompletionPostprocArgs) -> List[str]:
-    res: List[str] = []
+def completion_stream_post_processor(rsp: DetokenizedGenerationResultBase, args: CompletionPostprocArgs) -> List[CompletionStreamResponse]:
+    res: List[CompletionStreamResponse] = []
     prompt_tokens = args.num_prompt_tokens
     if stream_option := args.stream_options:
         include_usage = stream_option.include_usage
@@ -296,8 +293,7 @@ def completion_stream_post_processor(rsp: DetokenizedGenerationResultBase, args:
             chunk.usage = UsageInfo(prompt_tokens=prompt_tokens,
                                     completion_tokens=output.length,
                                     total_tokens=output.length + prompt_tokens)
-        data = chunk.model_dump_json(exclude_unset=False)
-        res.append(f"data: {data}\n\n")
+        res.append(chunk)
 
     if include_usage and rsp._done:
         completion_tokens = sum(output.length
@@ -308,10 +304,9 @@ def completion_stream_post_processor(rsp: DetokenizedGenerationResultBase, args:
             total_tokens=prompt_tokens + completion_tokens,
         )
 
-        final_usage_chunk = ChatCompletionStreamResponse(
+        final_usage_chunk = CompletionStreamResponse(
             choices=[], model=args.model, usage=final_usage)
-        final_usage_data = final_usage_chunk.model_dump_json()
-        res.append(f"data: {final_usage_data}\n\n")
+        res.append(final_usage_chunk)
     args.first_iteration = False
     return res
 


### PR DESCRIPTION
[TRTLLM-4926][feat] Reimplement metrics endpoint with stats about requests

## Description

Partial implementation of prometheus metrics.
* #4926

This does not implement iteration stats. Things such as kv cache usage and token miss rate are not implemented. It's just high level stats about number of requests and number of iterations.

The implementation uses a file in /dev/shm to synchronize data between the worker and host process. A fixed-length encoding is used to guarantee the length of the file does not change between reads, and data is written and read using atomic syscalls to avoid any synchronization overhead.

Example output of /metrics
```
pytrtllm:num_requests_running{model_name="deepseek-ai/DeepSeek-V3-0324"} 1.0
pytrtllm:num_requests_waiting{model_name="deepseek-ai/DeepSeek-V3-0324"} 0.0
pytrtllm:prompt_tokens_total{model_name="deepseek-ai/DeepSeek-V3-0324"} 201121.0
pytrtllm:generation_tokens_total{model_name="deepseek-ai/DeepSeek-V3-0324"} 81896.0
pytrtllm:request_completed_total{model_name="deepseek-ai/DeepSeek-V3-0324"} 707.0
pytrtllm:request_cancelled_total{model_name="deepseek-ai/DeepSeek-V3-0324"} 0.0
pytrtllm:request_failed_total{model_name="deepseek-ai/DeepSeek-V3-0324"} 0.0
pytrtllm:request_started_total{model_name="deepseek-ai/DeepSeek-V3-0324"} 708.0
pytrtllm:request_success_total{finished_reason="length",model_name="deepseek-ai/DeepSeek-V3-0324"} 521.0
pytrtllm:num_requests_swapped{model_name="deepseek-ai/DeepSeek-V3-0324"} 0.0
pytrtllm:iteration_tokens_total_sum{model_name="deepseek-ai/DeepSeek-V3-0324"} 283017.0
pytrtllm:iteration_tokens_total_count{model_name="deepseek-ai/DeepSeek-V3-0324"} 18254.0
pytrtllm:time_per_output_token_seconds_sum{model_name="deepseek-ai/DeepSeek-V3-0324"} 4331.138105630875
pytrtllm:time_per_output_token_seconds_count{model_name="deepseek-ai/DeepSeek-V3-0324"} 18254.0
pytrtllm:request_prompt_tokens_total_sum{model_name="deepseek-ai/DeepSeek-V3-0324"} 201121.0
pytrtllm:request_prompt_tokens_total_count{model_name="deepseek-ai/DeepSeek-V3-0324"} 18254.0
pytrtllm:request_generation_tokens_total_sum{model_name="deepseek-ai/DeepSeek-V3-0324"} 81896.0
pytrtllm:request_generation_tokens_total_count{model_name="deepseek-ai/DeepSeek-V3-0324"} 18254.0
pytrtllm:request_success_total{finished_reason="stop",model_name="deepseek-ai/DeepSeek-V3-0324"} 186.0
```

Currently depends on #5559 to be merged first.

## Test Coverage

None