### PR TITLE
Implement --served_model_name and improve command line parsing

### DIFF
--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import os
 import signal  # Added import
 import subprocess  # nosec B404
@@ -274,7 +275,7 @@ def launch_server(host: str,
     type=str,
     default=None,
     help=
-    "Path to a YAML file that overwrites the parameters specified by trtllm-serve."
+    "JSON that overwrites the parameters specified by trtllm-serve."
 )
 @click.option(
     "--reasoning_parser",
@@ -344,8 +345,7 @@ def serve(model: str,
 
     llm_args_extra_dict = {}
     if extra_llm_api_options is not None:
-        with open(extra_llm_api_options, 'r') as f:
-            llm_args_extra_dict = yaml.safe_load(f)
+        llm_args_extra_dict = json.loads(extra_llm_api_options)
     llm_args = update_llm_args_with_extra_dict(llm_args, llm_args_extra_dict)
 
     metadata_server_cfg = parse_metadata_server_config_file(

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -52,6 +52,7 @@ class OpenAIServer:
     def __init__(self,
                  llm: LLM,
                  model: str,
+                 served_model_name: str | None,
                  server_role: Optional[ServerRole],
                  metadata_server_cfg: MetadataServerConfig):
         self.llm = llm
@@ -73,7 +74,9 @@ class OpenAIServer:
             self.model_config = None
 
         model_dir = Path(model)
-        if model_dir.exists() and model_dir.is_dir():
+        if served_model_name is not None:
+            self.model = served_model_name
+        elif model_dir.exists() and model_dir.is_dir():
             self.model = model_dir.name
         else:
             self.model = model


### PR DESCRIPTION
[feat] Implement --served_model_name and improve command line parsing

## Description

Adds new `--served_model_name`, `--host_cache_size`, `--kv_cache_dtype` and `--enable_chunked_prefill` arguments.

Some are currently possible using extra llm options. served_model_name is a new feature.

## Test Coverage

None