### PR TITLE
fix: Investigate Gemma3 1B decoder output discrepancy

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_gemma3.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma3.py
@@ -65,7 +65,7 @@ class Gemma3Attention(Attention):
         self.attention_window_size = None
         if is_sliding:
             rope_params.theta = 10000
-            self.attention_window_size = config.sliding_window
+            self.attention_window_size = config.sliding_window - 1  # Gemma3 sliding window isn't inclusive.
         pos_embd_params = PositionalEmbeddingParams(
             type=PositionEmbeddingType.rope_gpt_neox,
             rope=rope_params,
@@ -107,7 +107,6 @@ class Gemma3Attention(Attention):
         **kwargs,
     ) -> torch.Tensor:
 
-        attention_window_size = self.attention_window_size or attn_metadata.max_seq_len
         return super().forward(position_ids=position_ids,
                                hidden_states=hidden_states,
                                attn_metadata=attn_metadata,
@@ -115,7 +114,7 @@ class Gemma3Attention(Attention):
                                mrope_config=mrope_config,
                                all_reduce_params=all_reduce_params,
                                lora_params=lora_params,
-                               attention_window_size=attention_window_size,
+                               attention_window_size=self.attention_window_size,
                                **kwargs)
 
     def apply_qk_norm(self, q, k):

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -437,7 +437,12 @@ class TestGemma3_1BInstruct(LlmapiAccuracyTestHarness):
     MODEL_PATH = f"{llm_models_root()}/gemma/gemma-3-1b-it/"
 
     def test_auto_dtype(self):
-        with LLM(self.MODEL_PATH) as llm:
+        # Disabling kv cache reuse as a WAR to deal with gaps in kernel support for Gemma3's non-inclusive sliding window size.
+        kv_cache_config = KvCacheConfig(
+            enable_block_reuse=False,
+            enable_partial_reuse=False,
+        )
+        with LLM(self.MODEL_PATH, kv_cache_config=kv_cache_config) as llm:
             task = CnnDailymail(self.MODEL_NAME)
             task.evaluate(llm)
 

--- a/tests/unittest/_torch/modeling/test_modeling_gemma3.py
+++ b/tests/unittest/_torch/modeling/test_modeling_gemma3.py
@@ -1,0 +1,300 @@
+import unittest
+from copy import deepcopy
+from dataclasses import dataclass
+
+import torch
+from parameterized import parameterized
+from transformers import Gemma3Config
+from transformers import Gemma3ForCausalLM as HFGemma3ForCausalLM
+from transformers.cache_utils import HybridCache
+
+import tensorrt_llm
+from tensorrt_llm._torch.attention_backend.utils import get_attention_backend
+from tensorrt_llm._torch.metadata import KVCacheParams
+from tensorrt_llm._torch.model_config import ModelConfig
+from tensorrt_llm._torch.models.modeling_gemma3 import Gemma3ForCausalLM
+from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
+from tensorrt_llm.bindings.executor import KvCacheConfig
+from tensorrt_llm.mapping import Mapping
+
+# This is copied from https://huggingface.co/google/gemma-3-1b-it/blob/main/config.json.
+# Updated to have 1 local layer and 1 global layer. Sliding window size updated to 4.
+GEMMA3_1B_MINI_CONFIG = {
+    "architectures": ["Gemma3ForCausalLM"],
+    "attention_bias": False,
+    "attention_dropout": 0.0,
+    "attn_logit_softcapping": None,
+    "bos_token_id": 2,
+    "cache_implementation": "hybrid",
+    "eos_token_id": [1, 106],
+    "final_logit_softcapping": None,
+    "head_dim": 256,
+    "hidden_activation": "gelu_pytorch_tanh",
+    "hidden_size": 1152,
+    "initializer_range": 0.02,
+    "intermediate_size": 6912,
+    "max_position_embeddings": 32768,
+    "model_type": "gemma3_text",
+    "num_attention_heads": 4,
+    "num_hidden_layers": 2,  # Modified for testing.
+    "num_key_value_heads": 1,
+    "pad_token_id": 0,
+    "query_pre_attn_scalar": 256,
+    "rms_norm_eps": 1e-06,
+    "rope_local_base_freq": 10000,
+    "rope_scaling": None,
+    "rope_theta": 1000000,
+    "sliding_window": 4,  # Modified for testing.
+    "sliding_window_pattern": 2,  # Modified for testing.
+    "torch_dtype": "bfloat16",
+    "transformers_version": "4.50.0.dev0",
+    "use_cache": True,
+    "vocab_size": 262144
+}
+
+
+@dataclass(repr=False)
+class Scenario:
+    backend: str
+
+    def __repr__(self) -> str:
+        return f"backend:{self.backend.lower()}"
+
+
+class TestGemma3(unittest.TestCase):
+
+    def get_kv_cache_manager(self, dtype: torch.dtype, config: Gemma3Config,
+                             tokens_per_block: int, max_seq_len: int,
+                             batch_size: int, num_blocks: int):
+        if dtype == torch.half:
+            kv_cache_dtype = tensorrt_llm.bindings.DataType.HALF
+        elif dtype == torch.bfloat16:
+            kv_cache_dtype = tensorrt_llm.bindings.DataType.BF16
+        else:
+            raise ValueError("Invalid dtype")
+
+        mapping = Mapping(world_size=1, tp_size=1, rank=0)
+        kv_cache_config = KvCacheConfig(enable_block_reuse=False,
+                                        enable_partial_reuse=False,
+                                        copy_on_partial_reuse=False,
+                                        max_tokens=num_blocks *
+                                        tokens_per_block)
+        kv_cache_manager = KVCacheManager(
+            kv_cache_config,
+            tensorrt_llm.bindings.internal.batch_manager.CacheType.SELF,
+            num_layers=config.num_hidden_layers,
+            num_kv_heads=config.num_key_value_heads,
+            head_dim=config.head_dim,
+            tokens_per_block=tokens_per_block,
+            max_seq_len=max_seq_len,
+            max_batch_size=batch_size,
+            mapping=mapping,
+            dtype=kv_cache_dtype,
+        )
+        return kv_cache_manager
+
+    def test_gemma3_sanity(self):
+
+        config_dict = deepcopy(GEMMA3_1B_MINI_CONFIG)
+        gemma3_config = Gemma3Config.from_dict(config_dict)
+
+        dtype = gemma3_config.torch_dtype
+        device = torch.device('cuda')
+
+        model_config = ModelConfig(pretrained_config=gemma3_config)
+        gemma3 = Gemma3ForCausalLM(model_config).to(device)
+
+        input_ids = torch.tensor([100, 200, 300, 400, 500, 600, 700, 800],
+                                 dtype=torch.int,
+                                 device=device)
+
+        context_sequence_lengths = [3, 2, 1]
+        sequence_lengths = context_sequence_lengths + [1, 1]
+        past_seen_tokens = [0, 0, 0, 62, 75]
+        request_ids = list(range(len(sequence_lengths)))
+        token_nums = (torch.tensor(past_seen_tokens) +
+                      torch.tensor(sequence_lengths)).tolist()
+        prompt_lens = token_nums[:3] + past_seen_tokens[3:]
+
+        num_blocks = 100
+        tokens_per_block = 128
+        max_seq_len = num_blocks * tokens_per_block
+        batch_size = len(context_sequence_lengths) + 2
+        kv_cache_manager = self.get_kv_cache_manager(
+            dtype=dtype,
+            config=gemma3_config,
+            tokens_per_block=tokens_per_block,
+            max_seq_len=max_seq_len,
+            batch_size=batch_size,
+            num_blocks=num_blocks)
+        kv_cache_manager.add_dummy_requests(request_ids, token_nums)
+
+        metadata_cls = get_attention_backend(model_config.attn_backend).Metadata
+        attn_metadata = metadata_cls(
+            seq_lens=torch.tensor(sequence_lengths, dtype=torch.int),
+            num_contexts=len(context_sequence_lengths),
+            kv_cache_params=KVCacheParams(
+                use_cache=True,
+                num_cached_tokens_per_seq=past_seen_tokens,
+            ),
+            kv_cache_manager=kv_cache_manager,
+            request_ids=request_ids,
+            prompt_lens=prompt_lens,
+            max_num_requests=len(context_sequence_lengths) + 2,
+            max_num_tokens=8192,
+        )
+
+        position_ids = []
+        for i, tokens in enumerate(past_seen_tokens):
+            seq_len = context_sequence_lengths[i] if i < len(
+                context_sequence_lengths) else 1
+            position_id = torch.arange(tokens,
+                                       tokens + seq_len,
+                                       device=input_ids.device)
+            position_ids.append(position_id)
+
+        position_ids = torch.cat(position_ids).unsqueeze(0)
+
+        with torch.inference_mode():
+            attn_metadata.prepare()
+            logits = gemma3.forward(input_ids=input_ids,
+                                    position_ids=position_ids,
+                                    attn_metadata=attn_metadata)
+
+        self.assertEqual(len(past_seen_tokens), logits.shape[0])
+
+        with torch.inference_mode():
+            attn_metadata.prepare()
+            logits = gemma3.forward(input_ids=input_ids,
+                                    position_ids=position_ids,
+                                    attn_metadata=attn_metadata,
+                                    return_context_logits=True)
+        self.assertEqual(input_ids.shape, logits.shape[:-1])
+
+        kv_cache_manager.shutdown()
+
+    @parameterized.expand([
+        Scenario(backend="TRTLLM"),
+        Scenario(backend="VANILLA"),
+    ], lambda testcase_func, param_num, param:
+                          f"{testcase_func.__name__}[{param.args[0]}]")
+    @torch.no_grad()
+    def test_gemma3_allclose_to_hf(self, scenario: Scenario) -> None:
+        """
+        Compare output to HF.
+        """
+        backend = scenario.backend
+        metadata_cls = get_attention_backend(backend).Metadata
+
+        torch.random.manual_seed(0)
+        config_dict = deepcopy(GEMMA3_1B_MINI_CONFIG)
+        gemma3_config = Gemma3Config.from_dict(config_dict)
+        dtype = gemma3_config.torch_dtype
+        device = torch.device('cuda')
+
+        num_blocks = 1
+        tokens_per_block = 128
+        max_seq_len = num_blocks * tokens_per_block
+        batch_size = 1
+
+        hf_gemma3 = HFGemma3ForCausalLM(gemma3_config).to(dtype).to(
+            device).eval()
+        hf_cache = HybridCache(config=gemma3_config,
+                               max_batch_size=batch_size,
+                               max_cache_len=10,
+                               device=device,
+                               dtype=dtype)
+
+        model_config = ModelConfig(pretrained_config=gemma3_config,
+                                   attn_backend=backend)
+        gemma3 = Gemma3ForCausalLM(model_config).to(dtype).to(device)
+        gemma3.load_weights(hf_gemma3.state_dict())
+
+        kv_cache_manager = self.get_kv_cache_manager(
+            dtype=dtype,
+            config=gemma3_config,
+            tokens_per_block=tokens_per_block,
+            max_seq_len=max_seq_len,
+            batch_size=batch_size,
+            num_blocks=num_blocks)
+
+        # Context phase.
+        input_ids = torch.tensor([100, 200, 300, 400, 500, 600, 700, 800],
+                                 dtype=torch.int32,
+                                 device=device)
+        num_cached_tokens_per_seq = [0]
+        request_ids = [1]
+        token_nums = [input_ids.size(-1)]
+        prompt_lens = [input_ids.size(-1)]
+        kv_cache_manager.add_dummy_requests(request_ids, token_nums)
+
+        attn_metadata = metadata_cls(
+            seq_lens=torch.tensor([input_ids.size(-1)], dtype=torch.int),
+            num_contexts=1,
+            kv_cache_params=KVCacheParams(
+                use_cache=True,
+                num_cached_tokens_per_seq=num_cached_tokens_per_seq,
+            ),
+            max_num_requests=1,
+            max_num_tokens=8192,
+            kv_cache_manager=kv_cache_manager,
+            request_ids=request_ids,
+            prompt_lens=prompt_lens,
+        )
+        position_ids = [torch.arange(0, input_ids.size(-1), dtype=torch.int32)]
+        position_ids = torch.cat(position_ids).unsqueeze(0).cuda()
+
+        with torch.inference_mode():
+            attn_metadata.prepare()
+            logits = gemma3.forward(input_ids=input_ids,
+                                    position_ids=position_ids,
+                                    attn_metadata=attn_metadata)
+            ref = hf_gemma3.forward(input_ids=input_ids.unsqueeze(0),
+                                    position_ids=position_ids,
+                                    past_key_values=hf_cache,
+                                    use_cache=True)
+            torch.testing.assert_close(logits,
+                                       ref.logits[:, -1].float(),
+                                       atol=0.05,
+                                       rtol=0.05)
+
+        # Generation phase.
+        gen_input_ids = torch.tensor([900], dtype=torch.int, device=device)
+        num_cached_tokens_per_seq = [input_ids.size(-1)]
+        attn_metadata = metadata_cls(
+            seq_lens=torch.tensor([gen_input_ids.size(-1)], dtype=torch.int),
+            num_contexts=0,
+            kv_cache_params=KVCacheParams(
+                use_cache=True,
+                num_cached_tokens_per_seq=num_cached_tokens_per_seq,
+            ),
+            kv_cache_manager=kv_cache_manager,
+            request_ids=request_ids,
+            prompt_lens=prompt_lens,
+            max_num_requests=1,
+            max_num_tokens=8192,
+        )
+
+        gen_position_ids = [
+            torch.arange(input_ids.size(-1),
+                         input_ids.size(-1) + gen_input_ids.size(-1))
+        ]
+        gen_position_ids = torch.cat(gen_position_ids).unsqueeze(0).cuda()
+        with torch.inference_mode():
+            attn_metadata.prepare()
+            logits = gemma3.forward(input_ids=gen_input_ids,
+                                    position_ids=gen_position_ids,
+                                    attn_metadata=attn_metadata)
+            ref = hf_gemma3.forward(input_ids=gen_input_ids.unsqueeze(0),
+                                    position_ids=gen_position_ids,
+                                    past_key_values=hf_cache,
+                                    use_cache=True,
+                                    cache_position=torch.IntTensor(
+                                        [input_ids.size(-1)]).to(device),
+                                    last_cache_position=input_ids.size(-1) + 1)
+            torch.testing.assert_close(logits,
+                                       ref.logits[:, -1].float(),
+                                       atol=0.05,
+                                       rtol=0.05)
+
+        kv_cache_manager.shutdown()


### PR DESCRIPTION
## Description

This MR investigates discrepancy noted by stakeholders in Gemma3 decoder outputs when compared to reference HF implementation.

Key findings:
- Gemma3's sliding window isn't left-inclusive in their HF reference implementation. TRTLLM's attention backends (trtllm, flashinfer, vanilla attention(with changes in this MR)) are left-inclusive.
- Subtle difference in position embedding math introduces non-trivial delta in logits. If applying position embeddings is turned off, atol and rtol could be brought down significantly.

Changes in this MR:
- Unit test with a miniature version of Gemma3 1B. Has one local layer (window size=4) and one global layer.
- Improved functionality in vanilla backend: q_scaling, sliding_window. Using vanilla backend has been very useful for debugging.
- Disabling KV cache reuse when working with Gemma3 because the new sliding window size 511 passed on to the attention layer isn't playing well with fmhaRunner.
```
$ python3 examples/pytorch/quickstart_advanced.py --model_dir /home/scratch.trt_llm_data/llm-models/gemma/gemma-3-1b-it/ --max_tokens 2048 --max_seq_len 2048 --prompt "Write me a really long Shakespeare play." --disable_kv_cache_reuse
```


## Test Coverage

```
$ pytest tests/unittest/_torch/modeling/test_modeling_gemma3.py::TestGemma3::test_gemma3_allclose_to_hf[backend:trtllm] -s -v
$ pytest tests/unittest/_torch/modeling/test_modeling_gemma3.py::TestGemma3::test_gemma3_allclose_to_hf[backend:vanilla] -s -v
$ pytest tests/unittest/_torch/modeling/test_modeling_gemma3.py::TestGemma3::test_gemma3_sanity -s -v
$ pytest tests/integration/defs/accuracy/test_llm_api_pytorch.py::TestGemma3_1BInstruct::test_auto_dtype -s -v
```

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
