### PR TITLE
[feat][test] reuse MPI pool executor across tests

### DIFF
--- a/tests/unittest/_torch/multi_gpu/test_allreduce.py
+++ b/tests/unittest/_torch/multi_gpu/test_allreduce.py
@@ -281,6 +281,7 @@ def run_allreduce_op(x: torch.Tensor, residual: torch.Tensor, hidden_size: int,
                      marks=skip_pre_blackwell),
     ],
 )
+@pytest.mark.parametrize("mpi_pool_executor", [2], indirect=True)
 def test_allreduce_fusion_patterns(seq_len, hidden_size, fusion_op,
                                    mpi_pool_executor):
     torch.manual_seed(0)

--- a/tests/unittest/_torch/multi_gpu/test_allreduce.py
+++ b/tests/unittest/_torch/multi_gpu/test_allreduce.py
@@ -40,6 +40,9 @@ MPI.pickle.__init__(
     pickle.HIGHEST_PROTOCOL,
 )
 
+# needed since we reuse the mpi executor pool, first test running will leak a thread
+pytestmark = pytest.mark.threadleak(enabled=False)
+
 
 def fp8_quant(input, scale):
     finfo = torch.finfo(torch.float8_e4m3fn)

--- a/tests/unittest/_torch/multi_gpu/test_allreduce.py
+++ b/tests/unittest/_torch/multi_gpu/test_allreduce.py
@@ -285,7 +285,7 @@ def test_allreduce_fusion_patterns(seq_len, hidden_size, fusion_op,
                                    mpi_pool_executor):
     torch.manual_seed(0)
     dtype = torch.bfloat16
-    tensor_parallel_size = 2
+    tensor_parallel_size = mpi_pool_executor.num_workers
     x = torch.randn((seq_len, hidden_size), dtype=dtype)
     residual = torch.randn_like(x)
     linear_weight = torch.randn((hidden_size, hidden_size), dtype=dtype)
@@ -436,7 +436,7 @@ def test_moe_allreduce_patterns(mpi_pool_executor):
     seq_len = 16
     hidden_size = 7168
     dtype = torch.bfloat16
-    tensor_parallel_size = 2
+    tensor_parallel_size = mpi_pool_executor.num_workers
     num_global_experts = 4
 
     # [num_token, 7168]
@@ -554,7 +554,7 @@ def test_moe_finalize_allreduce_patterns(mpi_pool_executor):
     seq_len = 16
     hidden_size = 7168
     dtype = torch.bfloat16
-    tensor_parallel_size = 2
+    tensor_parallel_size = mpi_pool_executor.num_workers
     top_k = 8
 
     shared_expert_output = torch.randn((seq_len, hidden_size), dtype=dtype)

--- a/tests/unittest/_torch/multi_gpu/test_user_buffers.py
+++ b/tests/unittest/_torch/multi_gpu/test_user_buffers.py
@@ -7,7 +7,6 @@ import pytest
 import torch
 import torch.nn as nn
 from mpi4py import MPI
-from mpi4py.futures import MPIPoolExecutor
 from utils.util import skip_pre_blackwell_unittest
 
 import tensorrt_llm
@@ -29,6 +28,9 @@ MPI.pickle.__init__(
     cloudpickle.loads,
     pickle.HIGHEST_PROTOCOL,
 )
+
+# needed since we reuse the mpi executor pool, first test running will leak a thread
+pytestmark = pytest.mark.threadleak(enabled=False)
 
 
 def init_userbuffers_allocator(tp_size, rank, max_ub_size):
@@ -170,7 +172,8 @@ def run_single_rank_ar_rms_norm(tensor_parallel_size, a, b, c, gamma):
                     reason='needs 2 GPUs to run this test')
 @pytest.mark.parametrize("mnk", [(256, 512, 256), (32, 16, 64)],
                          ids=lambda x: f"m{x[0]}_n{x[1]}_k{x[2]}")
-def test_user_buffers_ar_rms_norm(mnk):
+@pytest.mark.parametrize("mpi_pool_executor", [2], indirect=True)
+def test_user_buffers_ar_rms_norm(mnk, mpi_pool_executor):
     torch.manual_seed(42)
     tensor_parallel_size = 2
     dtype = torch.float16
@@ -182,13 +185,11 @@ def test_user_buffers_ar_rms_norm(mnk):
     c = torch.randn((m, n), dtype=dtype)
     gamma = torch.randn((n), dtype=dtype)
 
-    with MPIPoolExecutor(max_workers=tensor_parallel_size) as executor:
-        results = executor.map(
-            run_single_rank_ar_rms_norm,
-            *zip(*[(tensor_parallel_size, a, b, c, gamma)] *
-                 tensor_parallel_size))
-        for r in results:
-            assert r is True
+    results = mpi_pool_executor.map(
+        run_single_rank_ar_rms_norm,
+        *zip(*[(tensor_parallel_size, a, b, c, gamma)] * tensor_parallel_size))
+    for r in results:
+        assert r is True
 
 
 def run_single_rank_ar_rms_norm_fp8(tensor_parallel_size, a, b, c, gamma,
@@ -262,7 +263,8 @@ def run_single_rank_ar_rms_norm_fp8(tensor_parallel_size, a, b, c, gamma,
 
 @pytest.mark.skipif(torch.cuda.device_count() < 2,
                     reason='needs 2 GPUs to run this test')
-def test_user_buffers_basic():
+@pytest.mark.parametrize("mpi_pool_executor", [2], indirect=True)
+def test_user_buffers_basic(mpi_pool_executor):
     torch.manual_seed(42)
     tensor_parallel_size = 2
     dtype = torch.float32
@@ -272,19 +274,19 @@ def test_user_buffers_basic():
     a = torch.randn((m, k), dtype=dtype)
     b = torch.randn((k, n), dtype=dtype)
     c = torch.randn((m, n), dtype=dtype)
-    with MPIPoolExecutor(max_workers=tensor_parallel_size) as executor:
-        results = executor.map(
-            run_single_rank,
-            *zip(*[(tensor_parallel_size, a, b, c)] * tensor_parallel_size))
-        for r in results:
-            assert r is True
+    results = mpi_pool_executor.map(
+        run_single_rank,
+        *zip(*[(tensor_parallel_size, a, b, c)] * tensor_parallel_size))
+    for r in results:
+        assert r is True
 
 
 @pytest.mark.skipif(torch.cuda.device_count() < 2,
                     reason='needs 2 GPUs to run this test')
 @pytest.mark.parametrize("mnk", [(256, 512, 256), (32, 16, 64)],
                          ids=lambda x: f"m{x[0]}_n{x[1]}_k{x[2]}")
-def test_user_buffers_ar_rms_norm_fp8(mnk):
+@pytest.mark.parametrize("mpi_pool_executor", [2], indirect=True)
+def test_user_buffers_ar_rms_norm_fp8(mnk, mpi_pool_executor):
     torch.manual_seed(42)
     tensor_parallel_size = 2
     dtype = torch.float16
@@ -297,13 +299,12 @@ def test_user_buffers_ar_rms_norm_fp8(mnk):
     gamma = torch.randn((n), dtype=dtype)
     scale = torch.randn((1), dtype=torch.float32)
 
-    with MPIPoolExecutor(max_workers=tensor_parallel_size) as executor:
-        results = executor.map(
-            run_single_rank_ar_rms_norm_fp8,
-            *zip(*[(tensor_parallel_size, a, b, c, gamma, scale)] *
-                 tensor_parallel_size))
-        for r in results:
-            assert r is True
+    results = mpi_pool_executor.map(
+        run_single_rank_ar_rms_norm_fp8,
+        *zip(*[(tensor_parallel_size, a, b, c, gamma, scale)] *
+             tensor_parallel_size))
+    for r in results:
+        assert r is True
 
 
 class UBTestModel(nn.Module):
@@ -535,7 +536,8 @@ def run_single_rank_ub_pass(
 @pytest.mark.parametrize("tokens", [256, 16], ids=lambda x: f"_tokens{x}")
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16],
                          ids=lambda x: "fp16" if x == torch.float16 else "bf16")
-def test_user_buffers_pass(hidden, tokens, dtype):
+@pytest.mark.parametrize("mpi_pool_executor", [2], indirect=True)
+def test_user_buffers_pass(hidden, tokens, dtype, mpi_pool_executor):
     torch.manual_seed(42)
     tensor_parallel_size = 2
 
@@ -559,17 +561,16 @@ def test_user_buffers_pass(hidden, tokens, dtype):
     l4_input_scale = torch.full((1, ), 0.1, dtype=torch.float32)
     l4_weight_scale = torch.full((1, ), 0.1, dtype=torch.float32)
 
-    with MPIPoolExecutor(max_workers=tensor_parallel_size) as executor:
-        results = executor.map(
-            run_single_rank_ub_pass,
-            *zip(*[(tensor_parallel_size, input, l0_weight, l0_input_scale,
-                    l0_weight_scale, l1_weight, l1_input_scale, l1_weight_scale,
-                    l2_weight, l2_input_scale, l2_weight_scale, l3_weight,
-                    l3_input_scale, l3_weight_scale, l4_weight, l4_input_scale,
-                    l4_weight_scale, norm0_gamma, norm1_gamma, norm2_gamma)] *
-                 tensor_parallel_size))
-        for r in results:
-            assert r is True
+    results = mpi_pool_executor.map(
+        run_single_rank_ub_pass,
+        *zip(*[(tensor_parallel_size, input, l0_weight, l0_input_scale,
+                l0_weight_scale, l1_weight, l1_input_scale, l1_weight_scale,
+                l2_weight, l2_input_scale, l2_weight_scale, l3_weight,
+                l3_input_scale, l3_weight_scale, l4_weight, l4_input_scale,
+                l4_weight_scale, norm0_gamma, norm1_gamma, norm2_gamma)] *
+             tensor_parallel_size))
+    for r in results:
+        assert r is True
 
 
 def run_single_rank_ar_rms_norm_fp4(tensor_parallel_size, a, b, c, gamma):
@@ -656,8 +657,9 @@ def run_single_rank_ar_rms_norm_fp4(tensor_parallel_size, a, b, c, gamma):
                     reason='needs 2 GPUs to run this test')
 @pytest.mark.parametrize("mnk", [(256, 512, 256), (32, 64, 64)],
                          ids=lambda x: f"m{x[0]}_n{x[1]}_k{x[2]}")
+@pytest.mark.parametrize("mpi_pool_executor", [2], indirect=True)
 @skip_pre_blackwell_unittest
-def test_user_buffers_ar_rms_norm_fp4(mnk):
+def test_user_buffers_ar_rms_norm_fp4(mnk, mpi_pool_executor):
     torch.manual_seed(42)
     tensor_parallel_size = 2
     dtype = torch.float16
@@ -669,13 +671,11 @@ def test_user_buffers_ar_rms_norm_fp4(mnk):
     c = torch.randn((m, n), dtype=dtype)
     gamma = torch.randn((n), dtype=dtype)
 
-    with MPIPoolExecutor(max_workers=tensor_parallel_size) as executor:
-        results = executor.map(
-            run_single_rank_ar_rms_norm_fp4,
-            *zip(*[(tensor_parallel_size, a, b, c, gamma)] *
-                 tensor_parallel_size))
-        for r in results:
-            assert r is True
+    results = mpi_pool_executor.map(
+        run_single_rank_ar_rms_norm_fp4,
+        *zip(*[(tensor_parallel_size, a, b, c, gamma)] * tensor_parallel_size))
+    for r in results:
+        assert r is True
 
 
 class UBMMAddModel(nn.Module):
@@ -786,7 +786,8 @@ def run_single_rank_ub_mm_add_pass(tensor_parallel_size, num_tokens,
 @pytest.mark.parametrize("tokens", [256, 16], ids=lambda x: f"_tokens{x}")
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16],
                          ids=lambda x: "fp16" if x == torch.float16 else "bf16")
-def test_user_buffers_mm_add_prologue(hidden, tokens, dtype):
+@pytest.mark.parametrize("mpi_pool_executor", [2], indirect=True)
+def test_user_buffers_mm_add_prologue(hidden, tokens, dtype, mpi_pool_executor):
     torch.manual_seed(42)
     tensor_parallel_size = 2
 
@@ -794,13 +795,12 @@ def test_user_buffers_mm_add_prologue(hidden, tokens, dtype):
     norm1_gamma = torch.randn((hidden, ), dtype=dtype)
     norm2_gamma = torch.randn((hidden, ), dtype=dtype)
 
-    with MPIPoolExecutor(max_workers=tensor_parallel_size) as executor:
-        results = executor.map(
-            run_single_rank_ub_mm_add_pass,
-            *zip(*[(tensor_parallel_size, tokens, hidden, dtype, norm0_gamma,
-                    norm1_gamma, norm2_gamma)] * tensor_parallel_size))
-        for r in results:
-            assert r is True
+    results = mpi_pool_executor.map(
+        run_single_rank_ub_mm_add_pass,
+        *zip(*[(tensor_parallel_size, tokens, hidden, dtype, norm0_gamma,
+                norm1_gamma, norm2_gamma)] * tensor_parallel_size))
+    for r in results:
+        assert r is True
 
 
 class UBFp4TestModel(nn.Module):
@@ -1035,8 +1035,9 @@ def run_single_rank_ub_pass_fp4(
 @pytest.mark.parametrize("tokens", [256, 16], ids=lambda x: f"_tokens{x}")
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16],
                          ids=lambda x: "fp16" if x == torch.float16 else "bf16")
+@pytest.mark.parametrize("mpi_pool_executor", [2], indirect=True)
 @skip_pre_blackwell_unittest
-def test_user_buffers_fp4_pass(hidden, tokens, dtype):
+def test_user_buffers_fp4_pass(hidden, tokens, dtype, mpi_pool_executor):
     torch.manual_seed(43)
     tensor_parallel_size = 2
 
@@ -1074,14 +1075,13 @@ def test_user_buffers_fp4_pass(hidden, tokens, dtype):
     l3_res = l2_res @ l3_weight.t()
     l3_res_scale = fp4_scale(l3_res)
 
-    with MPIPoolExecutor(max_workers=tensor_parallel_size) as executor:
-        results = executor.map(
-            run_single_rank_ub_pass_fp4,
-            *zip(*[(tensor_parallel_size, input, l0_weight, input_scale,
-                    l0_weight_scale, l1_weight, l0_res_scale, l1_weight_scale,
-                    l2_weight, l1_res_scale, l2_weight_scale, l3_weight,
-                    l2_res_scale, l3_weight_scale, l4_weight, l3_res_scale,
-                    l4_weight_scale, norm0_gamma, norm1_gamma, norm2_gamma)] *
-                 tensor_parallel_size))
-        for r in results:
-            assert r is True
+    results = mpi_pool_executor.map(
+        run_single_rank_ub_pass_fp4,
+        *zip(*[(tensor_parallel_size, input, l0_weight, input_scale,
+                l0_weight_scale, l1_weight, l0_res_scale, l1_weight_scale,
+                l2_weight, l1_res_scale, l2_weight_scale, l3_weight,
+                l2_res_scale, l3_weight_scale, l4_weight, l3_res_scale,
+                l4_weight_scale, norm0_gamma, norm1_gamma, norm2_gamma)] *
+             tensor_parallel_size))
+    for r in results:
+        assert r is True

--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -98,5 +98,8 @@ def mpi_pool_executor(request):
     """
     Start an MPIPoolExecutor with `request.param` workers.
     """
-    with MPIPoolExecutor(request.param) as executor:
+    num_workers = request.param
+    with MPIPoolExecutor(num_workers) as executor:
+        # make the number of workers visible to tests
+        setattr(executor, "num_workers", num_workers)
         yield executor

--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -16,6 +16,7 @@
 import pytest
 import torch
 import tqdm
+from mpi4py.futures import MPIPoolExecutor
 
 
 def pytest_configure(config):
@@ -89,3 +90,15 @@ def torch_empty_cache() -> None:
     """
     if torch.cuda.is_available():
         torch.cuda.empty_cache()
+
+
+@pytest.fixture(scope="module")
+def mpi_pool_executor() -> MPIPoolExecutor:
+    if torch.cuda.is_available():
+        max_workers = torch.cuda.device_count()
+    else:
+        # should be enough for our tests
+        max_workers = 8
+
+    with MPIPoolExecutor(max_workers=max_workers) as executor:
+        yield executor

--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -95,5 +95,8 @@ def torch_empty_cache() -> None:
 
 @pytest.fixture(scope="module", params=[2, 4, 8])
 def mpi_pool_executor(request):
+    """
+    Start an MPIPoolExecutor with `request.param` workers.
+    """
     with MPIPoolExecutor(request.param) as executor:
         yield executor

--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # # Force resource release after test
+
 import pytest
 import torch
 import tqdm
@@ -92,13 +93,7 @@ def torch_empty_cache() -> None:
         torch.cuda.empty_cache()
 
 
-@pytest.fixture(scope="module")
-def mpi_pool_executor() -> MPIPoolExecutor:
-    if torch.cuda.is_available():
-        max_workers = torch.cuda.device_count()
-    else:
-        # should be enough for our tests
-        max_workers = 8
-
-    with MPIPoolExecutor(max_workers=max_workers) as executor:
+@pytest.fixture(scope="module", params=[2, 4, 8])
+def mpi_pool_executor(request):
+    with MPIPoolExecutor(request.param) as executor:
         yield executor


### PR DESCRIPTION
# [feat][test] reuse MPI pool executor across tests

Initializing an `MPIPoolExecutor` involves some delay, and it accumulates with parameterization. This PR makes the pool executor a module-scoped fixture to be reused by multiple tests, reducing test times significantly.