### PR TITLE
feat: KV events for sliding window attention

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheEventManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheEventManager.h
@@ -44,13 +44,13 @@ public:
     KVCacheEventManager(KVCacheEventManager&& other) = delete;
     KVCacheEventManager& operator=(KVCacheEventManager&& other) = delete;
 
-    void enqueueCreatedEvent(std::vector<SizeType32> const& numBlocksPerCacheLevel);
+    void enqueueCreatedEvent(std::vector<SizeType32> const& numBlocksPerCacheLevel, SizeType32 windowSize);
 
-    void enqueueStoredEvent(std::vector<BlockPtr> const& blocks);
+    void enqueueStoredEvent(std::vector<BlockPtr> const& blocks, SizeType32 windowSize);
 
-    void enqueueRemovedEvent(BlockPtr const& block);
+    void enqueueRemovedEvent(BlockPtr const& block, SizeType32 windowSize);
 
-    void enqueueUpdatedEvent(executor::KVCacheUpdatedData const& data);
+    void enqueueUpdatedEvent(executor::KVCacheUpdatedData const& data, SizeType32 windowSize);
 
     // Get events in mEvents. If there are no events, wait for a maximum of `timeout` milliseconds.
     std::deque<executor::KVCacheEvent> getEvents(std::optional<std::chrono::milliseconds> timeout);

--- a/cpp/include/tensorrt_llm/executor/executor.h
+++ b/cpp/include/tensorrt_llm/executor/executor.h
@@ -1709,12 +1709,14 @@ using KVCacheEventData = std::variant<KVCacheCreatedData, KVCacheStoredData, KVC
 struct KVCacheEvent
 {
 
-    KVCacheEvent(IdType eventId, KVCacheEventData data);
+    KVCacheEvent(IdType eventId, KVCacheEventData data, SizeType32 windowSize);
 
     /// @brief The unique id of this event
     IdType eventId;
     /// @brief The data corresponding to this event
     KVCacheEventData data;
+    /// @brief The sliding window size
+    SizeType32 windowSize;
 };
 
 /// @brief Exposes a limited set of KV cache manager functionalities

--- a/cpp/tensorrt_llm/executor/executor.cpp
+++ b/cpp/tensorrt_llm/executor/executor.cpp
@@ -132,9 +132,10 @@ std::optional<std::shared_ptr<KVCacheEventManager>> Executor::getKVCacheEventMan
     return mImpl->getKVCacheEventManager();
 }
 
-KVCacheEvent::KVCacheEvent(size_t eventId, KVCacheEventData data)
+KVCacheEvent::KVCacheEvent(size_t eventId, KVCacheEventData data, SizeType32 windowSize)
     : eventId{eventId}
     , data{std::move(data)}
+    , windowSize{windowSize}
 {
 }
 

--- a/cpp/tensorrt_llm/pybind/executor/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/executor/bindings.cpp
@@ -239,7 +239,8 @@ void initBindings(pybind11::module_& m)
 
     py::class_<tle::KVCacheEvent>(executor_kv_cache, "KVCacheEvent")
         .def_readonly("event_id", &tle::KVCacheEvent::eventId)
-        .def_readonly("data", &tle::KVCacheEvent::data);
+        .def_readonly("data", &tle::KVCacheEvent::data)
+        .def_readonly("window_size", &tle::KVCacheEvent::windowSize);
 
     py::class_<tle::KVCacheEventManager, std::shared_ptr<tle::KVCacheEventManager>>(
         executor_kv_cache, "KVCacheEventManager")


### PR DESCRIPTION
# PR title

KV events for sliding window attention

## Description

Currently, KV event emission is broken in the case of models with variable sliding window attention. This is where the sliding window size varies between layers. Mapping to TRT-LLM, this is where there are multiple `WindowBlockManager`s. 

Currenlty, when we have multiple `WindowBlockManager`s, they emit events to the same event manager, with no way to distinguish between events corresponding to different window sizes.

This MR adds a window_size field to the `KvCacheEvent`, which allows event consumers to distinguish between events corresponding to different window sizes.

## Test Coverage

Tests for this new field were added in `cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp`
