### PR TITLE
chore: remove cuda_graph_ prefix from cuda_graph_config filed members.

### DIFF
--- a/docs/source/blogs/Best_perf_practice_on_DeepSeek-R1_in_TensorRT-LLM.md
+++ b/docs/source/blogs/Best_perf_practice_on_DeepSeek-R1_in_TensorRT-LLM.md
@@ -196,20 +196,20 @@ We are seeing meaningful speedup using FP8 KV cache, thus refreshing the numbers
 ```bash
 cat >./extra-llm-api-config.yml <<EOF
 pytorch_backend_config:
-  use_cuda_graph: true
-  cuda_graph_padding_enabled: true
-  cuda_graph_batch_sizes:
-  - 896
-  - 512
-  - 256
-  - 128
-  - 64
-  - 32
-  - 16
-  - 8
-  - 4
-  - 2
-  - 1
+  cuda_graph_config:
+    padding_enabled: true
+    batch_sizes:
+    - 896
+    - 512
+    - 256
+    - 128
+    - 64
+    - 32
+    - 16
+    - 8
+    - 4
+    - 2
+    - 1
   print_iter_log: true
   kv_cache_dtype: fp8
 enable_attention_dp: true
@@ -264,19 +264,19 @@ YOUR_DATA_PATH=./dataset.txt
 
 cat >./extra-llm-api-config.yml <<EOF
 pytorch_backend_config:
-    use_cuda_graph: true
-    cuda_graph_padding_enabled: true
-    cuda_graph_batch_sizes:
-    - 1
-    - 2
-    - 4
-    - 8
-    - 16
-    - 32
-    - 64
-    - 128
-    - 256
-    - 384
+    cuda_graph_config:
+      padding_enabled: true
+      batch_sizes:
+      - 1
+      - 2
+      - 4
+      - 8
+      - 16
+      - 32
+      - 64
+      - 128
+      - 256
+      - 384
     print_iter_log: ${PRINT_ITER_LOG}
 enable_attention_dp: true
 EOF

--- a/docs/source/performance/perf-overview.md
+++ b/docs/source/performance/perf-overview.md
@@ -200,24 +200,24 @@ trtllm-bench --model $model_name throughput --dataset $dataset_file --backend py
 
 `llm_options.yml`
 ```yaml
-use_cuda_graph: true
-cuda_graph_padding_enabled: true
-cuda_graph_batch_sizes:
-  - 1
-  - 2
-  - 4
-  - 8
-  - 16
-  - 32
-  - 64
-  - 128
-  - 256
-  - 384
-  - 512
-  - 1024
-  - 2048
-  - 4096
-  - 8192
+cuda_graph_config:
+  padding_enabled: true
+  batch_sizes:
+    - 1
+    - 2
+    - 4
+    - 8
+    - 16
+    - 32
+    - 64
+    - 128
+    - 256
+    - 384
+    - 512
+    - 1024
+    - 2048
+    - 4096
+    - 8192
 ```
 
 In majority of cases, we also use a higher KV cache percentage by setting `--kv_cache_free_gpu_mem_fraction 0.95` in the benchmark command. This allows us to obtain better performance than the default setting of `0.90`. We fall back to `0.90` if we hit an out of memory issue.

--- a/examples/llm-api/llm_mgmn_trtllm_bench.sh
+++ b/examples/llm-api/llm_mgmn_trtllm_bench.sh
@@ -74,8 +74,6 @@ srun -l \
 
         # This is optional
         cat > /tmp/pytorch_extra_args.txt << EOF
-use_cuda_graph: false
-cuda_graph_padding_enabled: false
 print_iter_log: true
 enable_attention_dp: false
 EOF

--- a/examples/models/core/deepseek_v3/README.md
+++ b/examples/models/core/deepseek_v3/README.md
@@ -141,9 +141,9 @@ python /app/tensorrt_llm/benchmarks/cpp/prepare_dataset.py \
         --num-requests 24 > /tmp/benchmarking_64k.txt
 
 cat <<EOF > /tmp/extra-llm-api-config.yml
-use_cuda_graph: true
-cuda_graph_padding_enabled: true
-cuda_graph_batch_sizes: [1, 4, 8, 12]
+cuda_graph_config:
+  padding_enabled: true
+  batch_sizes: [1, 4, 8, 12]
 EOF
 
 trtllm-bench -m deepseek-ai/DeepSeek-R1 --model_path ${DS_R1_NVFP4_MODEL_PATH} throughput \
@@ -168,9 +168,9 @@ python /app/tensorrt_llm/benchmarks/cpp/prepare_dataset.py \
         --num-requests 4 > /tmp/benchmarking_128k.txt
 
 cat <<EOF > /tmp/extra-llm-api-config.yml
-use_cuda_graph: true
-cuda_graph_padding_enabled: true
-cuda_graph_batch_sizes: [1, 2]
+cuda_graph_config:
+  padding_enabled: true
+  batch_sizes: [1, 2]
 moe_max_num_tokens: 16384
 EOF
 
@@ -236,19 +236,19 @@ To serve the model using `trtllm-serve`:
 
 ```bash
 cat >./extra-llm-api-config.yml <<EOF
-use_cuda_graph: true
-cuda_graph_padding_enabled: true
-cuda_graph_batch_sizes:
-  - 1
-  - 2
-  - 4
-  - 8
-  - 16
-  - 32
-  - 64
-  - 128
-  - 256
-  - 384
+cuda_graph_config:
+  padding_enabled: true
+  batch_sizes:
+    - 1
+    - 2
+    - 4
+    - 8
+    - 16
+    - 32
+    - 64
+    - 128
+    - 256
+    - 384
 print_iter_log: true
 enable_attention_dp: true
 EOF
@@ -315,19 +315,19 @@ And you can launch two generation servers on port 8002 and 8003 with:
 export TRTLLM_USE_UCX_KVCACHE=1
 
 cat >./gen-extra-llm-api-config.yml <<EOF
-use_cuda_graph: true
-cuda_graph_padding_enabled: true
-cuda_graph_batch_sizes:
-  - 1
-  - 2
-  - 4
-  - 8
-  - 16
-  - 32
-  - 64
-  - 128
-  - 256
-  - 384
+cuda_graph_config:
+  padding_enabled: true
+  batch_sizes:
+    - 1
+    - 2
+    - 4
+    - 8
+    - 16
+    - 32
+    - 64
+    - 128
+    - 256
+    - 384
 print_iter_log: true
 enable_attention_dp: true
 EOF
@@ -537,19 +537,19 @@ python3 /path/to/TensorRT-LLM/benchmarks/cpp/prepare_dataset.py \
     --input-mean=1024 --output-mean=2048 --input-stdev=0 --output-stdev=0 > /tmp/dataset.txt
 
 cat >/path/to/TensorRT-LLM/extra-llm-api-config.yml <<EOF
-use_cuda_graph: true
-cuda_graph_padding_enabled: true
-cuda_graph_batch_sizes:
-  - 1
-  - 2
-  - 4
-  - 8
-  - 16
-  - 32
-  - 64
-  - 128
-  - 256
-  - 384
+cuda_graph_config:
+  padding_enabled: true
+  batch_sizes:
+    - 1
+    - 2
+    - 4
+    - 8
+    - 16
+    - 32
+    - 64
+    - 128
+    - 256
+    - 384
 print_iter_log: true
 enable_attention_dp: true
 EOF

--- a/examples/models/core/qwen/README.md
+++ b/examples/models/core/qwen/README.md
@@ -733,19 +733,19 @@ To serve the model using `trtllm-serve`:
 
 ```bash
 cat >./extra-llm-api-config.yml <<EOF
-use_cuda_graph: true
-cuda_graph_padding_enabled: true
-cuda_graph_batch_sizes:
-- 1
-- 2
-- 4
-- 8
-- 16
-- 32
-- 64
-- 128
-- 256
-- 384
+cuda_graph_config:
+  padding_enabled: true
+  batch_sizes:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
+  - 64
+  - 128
+  - 256
+  - 384
 print_iter_log: true
 enable_attention_dp: true
 EOF
@@ -809,19 +809,19 @@ And you can launch two generation servers on port 8002 and 8003 with:
 export TRTLLM_USE_UCX_KVCACHE=1
 
 cat >./gen-extra-llm-api-config.yml <<EOF
-use_cuda_graph: true
-cuda_graph_padding_enabled: true
-cuda_graph_batch_sizes:
-  - 1
-  - 2
-  - 4
-  - 8
-  - 16
-  - 32
-  - 64
-  - 128
-  - 256
-  - 384
+cuda_graph_config:
+  padding_enabled: true
+  batch_sizes:
+    - 1
+    - 2
+    - 4
+    - 8
+    - 16
+    - 32
+    - 64
+    - 128
+    - 256
+    - 384
 print_iter_log: true
 enable_attention_dp: true
 EOF

--- a/examples/pytorch/quickstart_advanced.py
+++ b/examples/pytorch/quickstart_advanced.py
@@ -187,8 +187,8 @@ def setup_llm(args):
         spec_config = None
 
     cuda_graph_config = CudaGraphConfig(
-        cuda_graph_batch_sizes=args.cuda_graph_batch_sizes,
-        cuda_graph_padding_enabled=args.cuda_graph_padding_enabled,
+        batch_sizes=args.cuda_graph_batch_sizes,
+        padding_enabled=args.cuda_graph_padding_enabled,
     ) if args.use_cuda_graph else None
     llm = LLM(
         model=args.model_dir,

--- a/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
@@ -194,10 +194,7 @@ class InferenceOptimizer:
 
         cm.info.set_generate_only_batch()
         compiler_kwargs = {
-            "cuda_graph_batch_sizes": self.ad_config.cuda_graph_config.cuda_graph_batch_sizes
-            if hasattr(self.ad_config, "cuda_graph_config")
-            and self.ad_config.cuda_graph_config is not None
-            else None,
+            "cuda_graph_batch_sizes": self.ad_config.cuda_graph_batch_sizes,
             "num_batched_inputs": 2,  # TODO (lucaslie): improve once we have a config system...
         }
         egm_compiled = compile_and_capture(

--- a/tensorrt_llm/bench/benchmark/utils/general.py
+++ b/tensorrt_llm/bench/benchmark/utils/general.py
@@ -149,9 +149,9 @@ def get_settings(params: dict, dataset_metadata: DatasetMetadata, model: str,
 
     pyt_options = {
         "cuda_graph_config": {
-            "cuda_graph_padding_enabled":
+            "padding_enabled":
             True,
-            "cuda_graph_max_batch_size":
+            "max_batch_size":
             max_batch_size if cuda_graph_batch_sizes is None else 0,
         },
         "kv_cache_dtype": kv_cache_dtype,

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -95,9 +95,8 @@ class TestLlama3_1_8BInstruct(LlmapiAccuracyTestHarness):
             enable_fullgraph=True) if torch_compile else None
         pytorch_config = dict(
             torch_compile_config=torch_compile_config,
-            cuda_graph_config=CudaGraphConfig(
-                cuda_graph_padding_enabled=torch_compile,
-                cuda_graph_batch_sizes=[4]),
+            cuda_graph_config=CudaGraphConfig(padding_enabled=torch_compile,
+                                              batch_sizes=[4]),
             attn_backend=attn_backend,
             disable_overlap_scheduler=torch_compile,
         )
@@ -123,9 +122,8 @@ class TestLlama3_1_8BInstruct(LlmapiAccuracyTestHarness):
             enable_fullgraph=True) if torch_compile else None
         pytorch_config = dict(
             torch_compile_config=torch_compile_config,
-            cuda_graph_config=CudaGraphConfig(
-                cuda_graph_padding_enabled=torch_compile,
-                cuda_graph_batch_sizes=[4]),
+            cuda_graph_config=CudaGraphConfig(padding_enabled=torch_compile,
+                                              batch_sizes=[4]),
             attn_backend=attn_backend,
             disable_overlap_scheduler=torch_compile,
         )
@@ -149,9 +147,8 @@ class TestLlama3_1_8BInstruct(LlmapiAccuracyTestHarness):
             enable_fullgraph=True) if torch_compile else None
         pytorch_config = dict(
             torch_compile_config=torch_compile_config,
-            cuda_graph_config=CudaGraphConfig(
-                cuda_graph_padding_enabled=torch_compile,
-                cuda_graph_batch_sizes=[4]),
+            cuda_graph_config=CudaGraphConfig(padding_enabled=torch_compile,
+                                              batch_sizes=[4]),
             attn_backend=attn_backend,
             disable_overlap_scheduler=torch_compile,
         )
@@ -189,9 +186,8 @@ class TestLlama3_1_8BInstruct(LlmapiAccuracyTestHarness):
             enable_fullgraph=True) if torch_compile else None
         pytorch_config = dict(
             torch_compile_config=torch_compile_config,
-            cuda_graph_config=CudaGraphConfig(
-                cuda_graph_padding_enabled=torch_compile,
-                cuda_graph_batch_sizes=[4]),
+            cuda_graph_config=CudaGraphConfig(padding_enabled=torch_compile,
+                                              batch_sizes=[4]),
             attn_backend=attn_backend,
             disable_overlap_scheduler=torch_compile,
         )
@@ -231,7 +227,7 @@ class TestLlama3_1_8BInstruct(LlmapiAccuracyTestHarness):
     def test_eagle3(self):
         pytorch_config = dict(
             disable_overlap_scheduler=True,
-            cuda_graph_config=CudaGraphConfig(cuda_graph_batch_sizes=[1]),
+            cuda_graph_config=CudaGraphConfig(batch_sizes=[1]),
         )
         kv_cache_config = KvCacheConfig(enable_block_reuse=False)
 
@@ -709,8 +705,8 @@ class TestDeepSeekV3Lite(LlmapiAccuracyTestHarness):
         pytorch_config = dict(
             disable_overlap_scheduler=False,
             cuda_graph_config=CudaGraphConfig(
-                cuda_graph_max_batch_size=512,
-                cuda_graph_padding_enabled=True,
+                max_batch_size=512,
+                padding_enabled=True,
             ),
         )
         llm = LLM(f"{llm_models_root()}/DeepSeek-V3-Lite/fp8",
@@ -734,8 +730,7 @@ class TestDeepSeekV3Lite(LlmapiAccuracyTestHarness):
             mtp_config = MTPDecodingConfig(num_nextn_predict_layers=mtp_nextn)
         pytorch_config = dict(
             disable_overlap_scheduler=False,
-            cuda_graph_config=CudaGraphConfig(
-                cuda_graph_padding_enabled=True, ),
+            cuda_graph_config=CudaGraphConfig(padding_enabled=True),
         )
         quant_config = QuantConfig()
         quant_config.quant_algo = QuantAlgo.FP8_BLOCK_SCALES
@@ -1609,7 +1604,6 @@ class TestQwen3_8B(LlmapiAccuracyTestHarness):
                   overlap_scheduler):
         pytorch_config = dict(
             disable_overlap_scheduler=not overlap_scheduler,
-            #   cuda_graph_config=CudaGraphConfig() if cuda_graph else None
             cuda_graph_config=CudaGraphConfig() if cuda_graph else None)
 
         llm = LLM(f"{llm_models_root()}/Qwen3/Qwen3-8B",
@@ -1829,7 +1823,7 @@ class TestKanana_Instruct(LlmapiAccuracyTestHarness):
     def test_auto_dtype(self):
         "RCCA: https://nvbugspro.nvidia.com/bug/5310520"
         pytorch_config = dict(cuda_graph_config=CudaGraphConfig(
-            cuda_graph_padding_enabled=True, cuda_graph_max_batch_size=384))
+            padding_enabled=True, max_batch_size=384))
         with LLM(self.MODEL_PATH, **pytorch_config,
                  enable_attention_dp=True) as llm:
             task = MMLU(self.MODEL_NAME)

--- a/tests/integration/defs/disaggregated/test_configs/disagg_config_ctxtp2_gentp2_deepseek_v3_lite_attention_dp_overlap_cuda_graph.yaml
+++ b/tests/integration/defs/disaggregated/test_configs/disagg_config_ctxtp2_gentp2_deepseek_v3_lite_attention_dp_overlap_cuda_graph.yaml
@@ -17,7 +17,7 @@ generation_servers:
   pipeline_parallel_size: 1
   enable_attention_dp: true
   cuda_graph_config:
-    cuda_graph_padding_enabled: False
+    padding_enabled: False
   disable_overlap_scheduler: False
   urls:
       - "localhost:8002"

--- a/tests/integration/defs/disaggregated/test_configs/disagg_config_ctxtp2_gentp2_deepseek_v3_lite_overlap_cuda_graph.yaml
+++ b/tests/integration/defs/disaggregated/test_configs/disagg_config_ctxtp2_gentp2_deepseek_v3_lite_overlap_cuda_graph.yaml
@@ -15,7 +15,7 @@ generation_servers:
   tensor_parallel_size: 2
   pipeline_parallel_size: 1
   cuda_graph_config:
-    cuda_graph_padding_enabled: False
+    padding_enabled: False
   disable_overlap_scheduler: False
   urls:
       - "localhost:8002"

--- a/tests/integration/defs/disaggregated/test_configs/disagg_config_cuda_graph_padding.yaml
+++ b/tests/integration/defs/disaggregated/test_configs/disagg_config_cuda_graph_padding.yaml
@@ -13,7 +13,7 @@ context_servers:
     free_gpu_memory_fraction: 0.2
     enable_partial_reuse: False
   cuda_graph_config:
-    cuda_graph_batch_sizes: [1,3000]
+    batch_sizes: [1,3000]
   disable_overlap_scheduler: True
   urls:
       - "localhost:8001"
@@ -28,8 +28,8 @@ generation_servers:
     free_gpu_memory_fraction: 0.2
     enable_partial_reuse: False
   cuda_graph_config:
-    cuda_graph_padding_enabled: True
-    cuda_graph_batch_sizes: [1,4,8,16,24,32]
+    padding_enabled: True
+    batch_sizes: [1,4,8,16,24,32]
   disable_overlap_scheduler: True
   urls:
       - "localhost:8002"

--- a/tests/integration/defs/perf/pytorch_model_config.py
+++ b/tests/integration/defs/perf/pytorch_model_config.py
@@ -30,7 +30,7 @@ def get_model_yaml_config(model_label: str,
     base_config = {
         'print_iter_log': True,
         'cuda_graph_config': {
-            'cuda_graph_padding_enabled': True,
+            'padding_enabled': True,
         },
     }
     if 'kv_cache_dtype' in model_label:
@@ -86,8 +86,8 @@ def get_model_yaml_config(model_label: str,
             'config': {
                 'print_iter_log': True,
                 'cuda_graph_config': {
-                    'cuda_graph_padding_enabled': True,
-                    'cuda_graph_batch_sizes': [1, 512, 1024, 2048]
+                    'padding_enabled': True,
+                    'batch_sizes': [1, 512, 1024, 2048]
                 }
             }
         },

--- a/tests/integration/defs/stress_test/stress_test.py
+++ b/tests/integration/defs/stress_test/stress_test.py
@@ -519,10 +519,8 @@ def stress_test(config,
         if config.backend == "pytorch":
             extra_llm_options.update({
                 "cuda_graph_config": {
-                    "cuda_graph_padding_enabled":
-                    True,
-                    "cuda_graph_batch_sizes":
-                    [1, 2, 4, 8, 16, 32, 64, 128, 256, 384],
+                    "padding_enabled": True,
+                    "batch_sizes": [1, 2, 4, 8, 16, 32, 64, 128, 256, 384],
                 },
                 "print_iter_log": True,
             })

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -182,46 +182,44 @@ def test_PeftCacheConfig_declaration():
 class TestTorchLlmArgsCudaGraphSettings:
 
     def test_cuda_graph_batch_sizes_case_0(self):
-        # set both cuda_graph_batch_sizes and cuda_graph_max_batch_size, and
+        # set both cuda_graph_batch_sizes and cuda_graph_config.max_batch_size, and
         # cuda_graph_batch_sizes is not equal to generated
         with pytest.raises(ValueError):
             TorchLlmArgs(
                 model=llama_model_path,
-                cuda_graph_config=CudaGraphConfig(
-                    cuda_graph_batch_sizes=[1, 2, 3],
-                    cuda_graph_max_batch_size=128),
+                cuda_graph_config=CudaGraphConfig(batch_sizes=[1, 2, 3],
+                                                  max_batch_size=128),
             )
 
     def test_cuda_graph_batch_sizes_case_0_1(self):
-        # set both cuda_graph_batch_sizes and cuda_graph_max_batch_size, and
+        # set both cuda_graph_batch_sizes and cuda_graph_config.max_batch_size, and
         # cuda_graph_batch_sizes is equal to generated
-        args = TorchLlmArgs(model=llama_model_path,
-                            cuda_graph_config=CudaGraphConfig(
-                                cuda_graph_batch_sizes=CudaGraphConfig.
-                                _generate_cuda_graph_batch_sizes(128, True),
-                                cuda_graph_padding_enabled=True,
-                                cuda_graph_max_batch_size=128))
-        assert args.cuda_graph_config.cuda_graph_batch_sizes == CudaGraphConfig._generate_cuda_graph_batch_sizes(
+        args = TorchLlmArgs(
+            model=llama_model_path,
+            cuda_graph_config=CudaGraphConfig(
+                batch_sizes=CudaGraphConfig._generate_cuda_graph_batch_sizes(
+                    128, True),
+                padding_enabled=True,
+                max_batch_size=128))
+        assert args.cuda_graph_config.batch_sizes == CudaGraphConfig._generate_cuda_graph_batch_sizes(
             128, True)
-        assert args.cuda_graph_config.cuda_graph_max_batch_size == 128
+        assert args.cuda_graph_config.max_batch_size == 128
 
     def test_cuda_graph_batch_sizes_case_1(self):
         # set cuda_graph_batch_sizes only
         args = TorchLlmArgs(model=llama_model_path,
                             cuda_graph_config=CudaGraphConfig(
-                                cuda_graph_batch_sizes=[1, 2, 4],
-                                cuda_graph_padding_enabled=True))
-        assert args.cuda_graph_config.cuda_graph_batch_sizes == [1, 2, 4]
+                                batch_sizes=[1, 2, 4], padding_enabled=True))
+        assert args.cuda_graph_config.batch_sizes == [1, 2, 4]
 
     def test_cuda_graph_batch_sizes_case_2(self):
-        # set cuda_graph_max_batch_size only
+        # set cuda_graph_config.max_batch_size only
         args = TorchLlmArgs(model=llama_model_path,
                             cuda_graph_config=CudaGraphConfig(
-                                cuda_graph_max_batch_size=128,
-                                cuda_graph_padding_enabled=True))
-        assert args.cuda_graph_config.cuda_graph_batch_sizes == CudaGraphConfig._generate_cuda_graph_batch_sizes(
+                                max_batch_size=128, padding_enabled=True))
+        assert args.cuda_graph_config.batch_sizes == CudaGraphConfig._generate_cuda_graph_batch_sizes(
             128, True)
-        assert args.cuda_graph_config.cuda_graph_max_batch_size == 128
+        assert args.cuda_graph_config.max_batch_size == 128
 
 
 class TestTrtLlmArgs:


### PR DESCRIPTION
It's a post-clean PR for #5014.

We just remove the **cuda_graph_** prefix for cuda_graph_config field members, e.g, `cuda_graph_config.cuda_graph_batch_sizes`-->`cuda_graph_config.batch_sizes `