### PR TITLE
[fix][ci] missing class names in post-merge test reports

### DIFF
--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -1644,7 +1644,7 @@ def checkStageNameSet(stageNames, jobKeys, paramName) {
 }
 
 def checkStageName(stageNames) {
-    invalidStageName = stageNames.findAll { !(it ==~ /[-\+\w\[\]\(\)]+/) }
+    invalidStageName = stageNames.findAll { !(it ==~ /[-\+\w\[\]]+/) }
     if (invalidStageName) {
         throw new Exception("Invalid stage name: [${invalidStageName}], we only support chars '-+_[]0-9a-zA-Z' .")
     }
@@ -1701,7 +1701,7 @@ def launchTestJobs(pipeline, testFilter, dockerNode=null)
         "DGX_H100-4_GPUs-PyTorch-DeepSeek-1": ["dgx-h100-x4", "l0_dgx_h100", 1, 2, 4],
         "DGX_H100-4_GPUs-PyTorch-DeepSeek-2": ["dgx-h100-x4", "l0_dgx_h100", 2, 2, 4],
         "DGX_H100-4_GPUs-PyTorch-Others-1": ["dgx-h100-x4", "l0_dgx_h100", 1, 1, 4],
-        "DGX_H100-4_GPUs-Triton-(Post-Merge)-1": ["dgx-h100-x4", "l0_dgx_h100", 1, 1, 4],
+        "DGX_H100-4_GPUs-Triton-Post-Merge-1": ["dgx-h100-x4", "l0_dgx_h100", 1, 1, 4],
         "DGX_H100-4_GPUs-CPP-1": ["dgx-h100-x4", "l0_dgx_h100", 1, 1, 4],
         "A10-PyTorch-1": ["a10", "l0_a10", 1, 1],
         "A10-CPP-1": ["a10", "l0_a10", 1, 1],
@@ -1737,46 +1737,46 @@ def launchTestJobs(pipeline, testFilter, dockerNode=null)
         "RTX5080-TensorRT-2": ["rtx-5080", "l0_gb203", 2, 2],
         // Currently post-merge test stages only run tests with "stage: post_merge" mako
         // in the test-db. This behavior may change in the future.
-        "A10-PyTorch-(Post-Merge)-1": ["a10", "l0_a10", 1, 1],
-        "A10-TensorRT-(Post-Merge)-1": ["a10", "l0_a10", 1, 2],
-        "A10-TensorRT-(Post-Merge)-2": ["a10", "l0_a10", 2, 2],
-        "A30-TensorRT-(Post-Merge)-1": ["a30", "l0_a30", 1, 6],
-        "A30-TensorRT-(Post-Merge)-2": ["a30", "l0_a30", 2, 6],
-        "A30-TensorRT-(Post-Merge)-3": ["a30", "l0_a30", 3, 6],
-        "A30-TensorRT-(Post-Merge)-4": ["a30", "l0_a30", 4, 6],
-        "A30-TensorRT-(Post-Merge)-5": ["a30", "l0_a30", 5, 6],
-        "A30-TensorRT-(Post-Merge)-6": ["a30", "l0_a30", 6, 6],
-        "A30-CPP-(Post-Merge)-1": ["a30", "l0_a30", 1, 1],
-        "A30-Triton-(Post-Merge)-1": ["a30", "l0_a30", 1, 2],
-        "A30-Triton-(Post-Merge)-2": ["a30", "l0_a30", 2, 2],
-        "A100X-TensorRT-(Post-Merge)-1": ["a100x", "l0_a100", 1, 6],
-        "A100X-TensorRT-(Post-Merge)-2": ["a100x", "l0_a100", 2, 6],
-        "A100X-TensorRT-(Post-Merge)-3": ["a100x", "l0_a100", 3, 6],
-        "A100X-TensorRT-(Post-Merge)-4": ["a100x", "l0_a100", 4, 6],
-        "A100X-TensorRT-(Post-Merge)-5": ["a100x", "l0_a100", 5, 6],
-        "A100X-TensorRT-(Post-Merge)-6": ["a100x", "l0_a100", 6, 6],
-        "A100X-Triton-(Post-Merge)-1": ["a100x", "l0_a100", 1, 2],
-        "A100X-Triton-(Post-Merge)-2": ["a100x", "l0_a100", 2, 2],
-        "L40S-TensorRT-(Post-Merge)-1": ["l40s", "l0_l40s", 1, 5],
-        "L40S-TensorRT-(Post-Merge)-2": ["l40s", "l0_l40s", 2, 5],
-        "L40S-TensorRT-(Post-Merge)-3": ["l40s", "l0_l40s", 3, 5],
-        "L40S-TensorRT-(Post-Merge)-4": ["l40s", "l0_l40s", 4, 5],
-        "L40S-TensorRT-(Post-Merge)-5": ["l40s", "l0_l40s", 5, 5],
-        "H100_PCIe-PyTorch-(Post-Merge)-1": ["h100-cr", "l0_h100", 1, 1],
-        "H100_PCIe-CPP-(Post-Merge)-1": ["h100-cr", "l0_h100", 1, 1],
-        "H100_PCIe-TensorRT-(Post-Merge)-1": ["h100-cr", "l0_h100", 1, 5],
-        "H100_PCIe-TensorRT-(Post-Merge)-2": ["h100-cr", "l0_h100", 2, 5],
-        "H100_PCIe-TensorRT-(Post-Merge)-3": ["h100-cr", "l0_h100", 3, 5],
-        "H100_PCIe-TensorRT-(Post-Merge)-4": ["h100-cr", "l0_h100", 4, 5],
-        "H100_PCIe-TensorRT-(Post-Merge)-5": ["h100-cr", "l0_h100", 5, 5],
-        "B200_PCIe-Triton-(Post-Merge)-1": ["b100-ts2", "l0_b200", 1, 1],
+        "A10-PyTorch-Post-Merge-1": ["a10", "l0_a10", 1, 1],
+        "A10-TensorRT-Post-Merge-1": ["a10", "l0_a10", 1, 2],
+        "A10-TensorRT-Post-Merge-2": ["a10", "l0_a10", 2, 2],
+        "A30-TensorRT-Post-Merge-1": ["a30", "l0_a30", 1, 6],
+        "A30-TensorRT-Post-Merge-2": ["a30", "l0_a30", 2, 6],
+        "A30-TensorRT-Post-Merge-3": ["a30", "l0_a30", 3, 6],
+        "A30-TensorRT-Post-Merge-4": ["a30", "l0_a30", 4, 6],
+        "A30-TensorRT-Post-Merge-5": ["a30", "l0_a30", 5, 6],
+        "A30-TensorRT-Post-Merge-6": ["a30", "l0_a30", 6, 6],
+        "A30-CPP-Post-Merge-1": ["a30", "l0_a30", 1, 1],
+        "A30-Triton-Post-Merge-1": ["a30", "l0_a30", 1, 2],
+        "A30-Triton-Post-Merge-2": ["a30", "l0_a30", 2, 2],
+        "A100X-TensorRT-Post-Merge-1": ["a100x", "l0_a100", 1, 6],
+        "A100X-TensorRT-Post-Merge-2": ["a100x", "l0_a100", 2, 6],
+        "A100X-TensorRT-Post-Merge-3": ["a100x", "l0_a100", 3, 6],
+        "A100X-TensorRT-Post-Merge-4": ["a100x", "l0_a100", 4, 6],
+        "A100X-TensorRT-Post-Merge-5": ["a100x", "l0_a100", 5, 6],
+        "A100X-TensorRT-Post-Merge-6": ["a100x", "l0_a100", 6, 6],
+        "A100X-Triton-Post-Merge-1": ["a100x", "l0_a100", 1, 2],
+        "A100X-Triton-Post-Merge-2": ["a100x", "l0_a100", 2, 2],
+        "L40S-TensorRT-Post-Merge-1": ["l40s", "l0_l40s", 1, 5],
+        "L40S-TensorRT-Post-Merge-2": ["l40s", "l0_l40s", 2, 5],
+        "L40S-TensorRT-Post-Merge-3": ["l40s", "l0_l40s", 3, 5],
+        "L40S-TensorRT-Post-Merge-4": ["l40s", "l0_l40s", 4, 5],
+        "L40S-TensorRT-Post-Merge-5": ["l40s", "l0_l40s", 5, 5],
+        "H100_PCIe-PyTorch-Post-Merge-1": ["h100-cr", "l0_h100", 1, 1],
+        "H100_PCIe-CPP-Post-Merge-1": ["h100-cr", "l0_h100", 1, 1],
+        "H100_PCIe-TensorRT-Post-Merge-1": ["h100-cr", "l0_h100", 1, 5],
+        "H100_PCIe-TensorRT-Post-Merge-2": ["h100-cr", "l0_h100", 2, 5],
+        "H100_PCIe-TensorRT-Post-Merge-3": ["h100-cr", "l0_h100", 3, 5],
+        "H100_PCIe-TensorRT-Post-Merge-4": ["h100-cr", "l0_h100", 4, 5],
+        "H100_PCIe-TensorRT-Post-Merge-5": ["h100-cr", "l0_h100", 5, 5],
+        "B200_PCIe-Triton-Post-Merge-1": ["b100-ts2", "l0_b200", 1, 1],
         "H100_PCIe-TensorRT-Perf-1": ["h100-cr", "l0_perf", 1, 1],
         "H100_PCIe-PyTorch-Perf-1": ["h100-cr", "l0_perf", 1, 1],
-        "DGX_H200-8_GPUs-PyTorch-(Post-Merge)-1": ["dgx-h200-x8", "l0_dgx_h200", 1, 1, 8],
-        "DGX_H200-4_GPUs-PyTorch-(Post-Merge)-1": ["dgx-h200-x4", "l0_dgx_h200", 1, 1, 4],
-        "DGX_H200-4_GPUs-TensorRT-(Post-Merge)-1": ["dgx-h200-x4", "l0_dgx_h200", 1, 3, 4],
-        "DGX_H200-4_GPUs-TensorRT-(Post-Merge)-2": ["dgx-h200-x4", "l0_dgx_h200", 2, 3, 4],
-        "DGX_H200-4_GPUs-TensorRT-(Post-Merge)-3": ["dgx-h200-x4", "l0_dgx_h200", 3, 3, 4],
+        "DGX_H200-8_GPUs-PyTorch-Post-Merge-1": ["dgx-h200-x8", "l0_dgx_h200", 1, 1, 8],
+        "DGX_H200-4_GPUs-PyTorch-Post-Merge-1": ["dgx-h200-x4", "l0_dgx_h200", 1, 1, 4],
+        "DGX_H200-4_GPUs-TensorRT-Post-Merge-1": ["dgx-h200-x4", "l0_dgx_h200", 1, 3, 4],
+        "DGX_H200-4_GPUs-TensorRT-Post-Merge-2": ["dgx-h200-x4", "l0_dgx_h200", 2, 3, 4],
+        "DGX_H200-4_GPUs-TensorRT-Post-Merge-3": ["dgx-h200-x4", "l0_dgx_h200", 3, 3, 4],
     ]
 
     parallelJobs = x86TestConfigs.collectEntries{key, values -> [key, [createKubernetesPodConfig(LLM_DOCKER_IMAGE, values[0], "amd64", values[4] ?: 1, key.contains("Perf")), {
@@ -1792,8 +1792,8 @@ def launchTestJobs(pipeline, testFilter, dockerNode=null)
     fullSet = parallelJobs.keySet()
 
     x86SlurmTestConfigs = [
-        "RTXPro6000-PyTorch-(Post-Merge)-1": ["rtx-pro-6000", "l0_rtx_pro_6000", 1, 1],
-        "DGX_B200-4_GPUs-PyTorch-(Post-Merge)-1": ["b200-4-gpus", "l0_dgx_b200", 1, 1, 4],
+        "RTXPro6000-PyTorch-Post-Merge-1": ["rtx-pro-6000", "l0_rtx_pro_6000", 1, 1],
+        "DGX_B200-4_GPUs-PyTorch-Post-Merge-1": ["b200-4-gpus", "l0_dgx_b200", 1, 1, 4],
     ]
     fullSet += x86SlurmTestConfigs.keySet()
 
@@ -1813,18 +1813,18 @@ def launchTestJobs(pipeline, testFilter, dockerNode=null)
     // Try to match what are being tested on x86 H100_PCIe.
     // The total machine time is scaled proportionally according to the number of each GPU.
     SBSATestConfigs = [
-        "GH200-TensorRT-(Post-Merge)-1": ["gh200", "l0_gh200", 1, 2],
-        "GH200-TensorRT-(Post-Merge)-2": ["gh200", "l0_gh200", 2, 2],
+        "GH200-TensorRT-Post-Merge-1": ["gh200", "l0_gh200", 1, 2],
+        "GH200-TensorRT-Post-Merge-2": ["gh200", "l0_gh200", 2, 2],
     ]
     fullSet += SBSATestConfigs.keySet()
 
     SBSASlurmTestConfigs = [
-        "GB200-4_GPUs-PyTorch-(Post-Merge)-1": ["gb200-4-gpus", "l0_gb200", 1, 1, 4],
+        "GB200-4_GPUs-PyTorch-Post-Merge-1": ["gb200-4-gpus", "l0_gb200", 1, 1, 4],
     ]
     fullSet += SBSASlurmTestConfigs.keySet()
 
     multiNodesSBSAConfigs = [
-        "GB200-8_GPUs-2_Nodes-PyTorch-(Post-Merge)-1": ["gb200-multi-node", "l0_gb200_multi_nodes", 1, 1, 8, 2],
+        "GB200-8_GPUs-2_Nodes-PyTorch-Post-Merge-1": ["gb200-multi-node", "l0_gb200_multi_nodes", 1, 1, 8, 2],
     ]
     fullSet += multiNodesSBSAConfigs.keySet()
 

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -1701,7 +1701,7 @@ def launchTestJobs(pipeline, testFilter, dockerNode=null)
         "DGX_H100-4_GPUs-PyTorch-DeepSeek-1": ["dgx-h100-x4", "l0_dgx_h100", 1, 2, 4],
         "DGX_H100-4_GPUs-PyTorch-DeepSeek-2": ["dgx-h100-x4", "l0_dgx_h100", 2, 2, 4],
         "DGX_H100-4_GPUs-PyTorch-Others-1": ["dgx-h100-x4", "l0_dgx_h100", 1, 1, 4],
-        "DGX_H100-4_GPUs-Triton-[Post-Merge]-1": ["dgx-h100-x4", "l0_dgx_h100", 1, 1, 4],
+        "DGX_H100-4_GPUs-Triton-(Post-Merge)-1": ["dgx-h100-x4", "l0_dgx_h100", 1, 1, 4],
         "DGX_H100-4_GPUs-CPP-1": ["dgx-h100-x4", "l0_dgx_h100", 1, 1, 4],
         "A10-PyTorch-1": ["a10", "l0_a10", 1, 1],
         "A10-CPP-1": ["a10", "l0_a10", 1, 1],
@@ -1737,46 +1737,46 @@ def launchTestJobs(pipeline, testFilter, dockerNode=null)
         "RTX5080-TensorRT-2": ["rtx-5080", "l0_gb203", 2, 2],
         // Currently post-merge test stages only run tests with "stage: post_merge" mako
         // in the test-db. This behavior may change in the future.
-        "A10-PyTorch-[Post-Merge]-1": ["a10", "l0_a10", 1, 1],
-        "A10-TensorRT-[Post-Merge]-1": ["a10", "l0_a10", 1, 2],
-        "A10-TensorRT-[Post-Merge]-2": ["a10", "l0_a10", 2, 2],
-        "A30-TensorRT-[Post-Merge]-1": ["a30", "l0_a30", 1, 6],
-        "A30-TensorRT-[Post-Merge]-2": ["a30", "l0_a30", 2, 6],
-        "A30-TensorRT-[Post-Merge]-3": ["a30", "l0_a30", 3, 6],
-        "A30-TensorRT-[Post-Merge]-4": ["a30", "l0_a30", 4, 6],
-        "A30-TensorRT-[Post-Merge]-5": ["a30", "l0_a30", 5, 6],
-        "A30-TensorRT-[Post-Merge]-6": ["a30", "l0_a30", 6, 6],
-        "A30-CPP-[Post-Merge]-1": ["a30", "l0_a30", 1, 1],
-        "A30-Triton-[Post-Merge]-1": ["a30", "l0_a30", 1, 2],
-        "A30-Triton-[Post-Merge]-2": ["a30", "l0_a30", 2, 2],
-        "A100X-TensorRT-[Post-Merge]-1": ["a100x", "l0_a100", 1, 6],
-        "A100X-TensorRT-[Post-Merge]-2": ["a100x", "l0_a100", 2, 6],
-        "A100X-TensorRT-[Post-Merge]-3": ["a100x", "l0_a100", 3, 6],
-        "A100X-TensorRT-[Post-Merge]-4": ["a100x", "l0_a100", 4, 6],
-        "A100X-TensorRT-[Post-Merge]-5": ["a100x", "l0_a100", 5, 6],
-        "A100X-TensorRT-[Post-Merge]-6": ["a100x", "l0_a100", 6, 6],
-        "A100X-Triton-[Post-Merge]-1": ["a100x", "l0_a100", 1, 2],
-        "A100X-Triton-[Post-Merge]-2": ["a100x", "l0_a100", 2, 2],
-        "L40S-TensorRT-[Post-Merge]-1": ["l40s", "l0_l40s", 1, 5],
-        "L40S-TensorRT-[Post-Merge]-2": ["l40s", "l0_l40s", 2, 5],
-        "L40S-TensorRT-[Post-Merge]-3": ["l40s", "l0_l40s", 3, 5],
-        "L40S-TensorRT-[Post-Merge]-4": ["l40s", "l0_l40s", 4, 5],
-        "L40S-TensorRT-[Post-Merge]-5": ["l40s", "l0_l40s", 5, 5],
-        "H100_PCIe-PyTorch-[Post-Merge]-1": ["h100-cr", "l0_h100", 1, 1],
-        "H100_PCIe-CPP-[Post-Merge]-1": ["h100-cr", "l0_h100", 1, 1],
-        "H100_PCIe-TensorRT-[Post-Merge]-1": ["h100-cr", "l0_h100", 1, 5],
-        "H100_PCIe-TensorRT-[Post-Merge]-2": ["h100-cr", "l0_h100", 2, 5],
-        "H100_PCIe-TensorRT-[Post-Merge]-3": ["h100-cr", "l0_h100", 3, 5],
-        "H100_PCIe-TensorRT-[Post-Merge]-4": ["h100-cr", "l0_h100", 4, 5],
-        "H100_PCIe-TensorRT-[Post-Merge]-5": ["h100-cr", "l0_h100", 5, 5],
-        "B200_PCIe-Triton-[Post-Merge]-1": ["b100-ts2", "l0_b200", 1, 1],
+        "A10-PyTorch-(Post-Merge)-1": ["a10", "l0_a10", 1, 1],
+        "A10-TensorRT-(Post-Merge)-1": ["a10", "l0_a10", 1, 2],
+        "A10-TensorRT-(Post-Merge)-2": ["a10", "l0_a10", 2, 2],
+        "A30-TensorRT-(Post-Merge)-1": ["a30", "l0_a30", 1, 6],
+        "A30-TensorRT-(Post-Merge)-2": ["a30", "l0_a30", 2, 6],
+        "A30-TensorRT-(Post-Merge)-3": ["a30", "l0_a30", 3, 6],
+        "A30-TensorRT-(Post-Merge)-4": ["a30", "l0_a30", 4, 6],
+        "A30-TensorRT-(Post-Merge)-5": ["a30", "l0_a30", 5, 6],
+        "A30-TensorRT-(Post-Merge)-6": ["a30", "l0_a30", 6, 6],
+        "A30-CPP-(Post-Merge)-1": ["a30", "l0_a30", 1, 1],
+        "A30-Triton-(Post-Merge)-1": ["a30", "l0_a30", 1, 2],
+        "A30-Triton-(Post-Merge)-2": ["a30", "l0_a30", 2, 2],
+        "A100X-TensorRT-(Post-Merge)-1": ["a100x", "l0_a100", 1, 6],
+        "A100X-TensorRT-(Post-Merge)-2": ["a100x", "l0_a100", 2, 6],
+        "A100X-TensorRT-(Post-Merge)-3": ["a100x", "l0_a100", 3, 6],
+        "A100X-TensorRT-(Post-Merge)-4": ["a100x", "l0_a100", 4, 6],
+        "A100X-TensorRT-(Post-Merge)-5": ["a100x", "l0_a100", 5, 6],
+        "A100X-TensorRT-(Post-Merge)-6": ["a100x", "l0_a100", 6, 6],
+        "A100X-Triton-(Post-Merge)-1": ["a100x", "l0_a100", 1, 2],
+        "A100X-Triton-(Post-Merge)-2": ["a100x", "l0_a100", 2, 2],
+        "L40S-TensorRT-(Post-Merge)-1": ["l40s", "l0_l40s", 1, 5],
+        "L40S-TensorRT-(Post-Merge)-2": ["l40s", "l0_l40s", 2, 5],
+        "L40S-TensorRT-(Post-Merge)-3": ["l40s", "l0_l40s", 3, 5],
+        "L40S-TensorRT-(Post-Merge)-4": ["l40s", "l0_l40s", 4, 5],
+        "L40S-TensorRT-(Post-Merge)-5": ["l40s", "l0_l40s", 5, 5],
+        "H100_PCIe-PyTorch-(Post-Merge)-1": ["h100-cr", "l0_h100", 1, 1],
+        "H100_PCIe-CPP-(Post-Merge)-1": ["h100-cr", "l0_h100", 1, 1],
+        "H100_PCIe-TensorRT-(Post-Merge)-1": ["h100-cr", "l0_h100", 1, 5],
+        "H100_PCIe-TensorRT-(Post-Merge)-2": ["h100-cr", "l0_h100", 2, 5],
+        "H100_PCIe-TensorRT-(Post-Merge)-3": ["h100-cr", "l0_h100", 3, 5],
+        "H100_PCIe-TensorRT-(Post-Merge)-4": ["h100-cr", "l0_h100", 4, 5],
+        "H100_PCIe-TensorRT-(Post-Merge)-5": ["h100-cr", "l0_h100", 5, 5],
+        "B200_PCIe-Triton-(Post-Merge)-1": ["b100-ts2", "l0_b200", 1, 1],
         "H100_PCIe-TensorRT-Perf-1": ["h100-cr", "l0_perf", 1, 1],
         "H100_PCIe-PyTorch-Perf-1": ["h100-cr", "l0_perf", 1, 1],
-        "DGX_H200-8_GPUs-PyTorch-[Post-Merge]-1": ["dgx-h200-x8", "l0_dgx_h200", 1, 1, 8],
-        "DGX_H200-4_GPUs-PyTorch-[Post-Merge]-1": ["dgx-h200-x4", "l0_dgx_h200", 1, 1, 4],
-        "DGX_H200-4_GPUs-TensorRT-[Post-Merge]-1": ["dgx-h200-x4", "l0_dgx_h200", 1, 3, 4],
-        "DGX_H200-4_GPUs-TensorRT-[Post-Merge]-2": ["dgx-h200-x4", "l0_dgx_h200", 2, 3, 4],
-        "DGX_H200-4_GPUs-TensorRT-[Post-Merge]-3": ["dgx-h200-x4", "l0_dgx_h200", 3, 3, 4],
+        "DGX_H200-8_GPUs-PyTorch-(Post-Merge)-1": ["dgx-h200-x8", "l0_dgx_h200", 1, 1, 8],
+        "DGX_H200-4_GPUs-PyTorch-(Post-Merge)-1": ["dgx-h200-x4", "l0_dgx_h200", 1, 1, 4],
+        "DGX_H200-4_GPUs-TensorRT-(Post-Merge)-1": ["dgx-h200-x4", "l0_dgx_h200", 1, 3, 4],
+        "DGX_H200-4_GPUs-TensorRT-(Post-Merge)-2": ["dgx-h200-x4", "l0_dgx_h200", 2, 3, 4],
+        "DGX_H200-4_GPUs-TensorRT-(Post-Merge)-3": ["dgx-h200-x4", "l0_dgx_h200", 3, 3, 4],
     ]
 
     parallelJobs = x86TestConfigs.collectEntries{key, values -> [key, [createKubernetesPodConfig(LLM_DOCKER_IMAGE, values[0], "amd64", values[4] ?: 1, key.contains("Perf")), {
@@ -1792,8 +1792,8 @@ def launchTestJobs(pipeline, testFilter, dockerNode=null)
     fullSet = parallelJobs.keySet()
 
     x86SlurmTestConfigs = [
-        "RTXPro6000-PyTorch-[Post-Merge]-1": ["rtx-pro-6000", "l0_rtx_pro_6000", 1, 1],
-        "DGX_B200-4_GPUs-PyTorch-[Post-Merge]-1": ["b200-4-gpus", "l0_dgx_b200", 1, 1, 4],
+        "RTXPro6000-PyTorch-(Post-Merge)-1": ["rtx-pro-6000", "l0_rtx_pro_6000", 1, 1],
+        "DGX_B200-4_GPUs-PyTorch-(Post-Merge)-1": ["b200-4-gpus", "l0_dgx_b200", 1, 1, 4],
     ]
     fullSet += x86SlurmTestConfigs.keySet()
 
@@ -1813,18 +1813,18 @@ def launchTestJobs(pipeline, testFilter, dockerNode=null)
     // Try to match what are being tested on x86 H100_PCIe.
     // The total machine time is scaled proportionally according to the number of each GPU.
     SBSATestConfigs = [
-        "GH200-TensorRT-[Post-Merge]-1": ["gh200", "l0_gh200", 1, 2],
-        "GH200-TensorRT-[Post-Merge]-2": ["gh200", "l0_gh200", 2, 2],
+        "GH200-TensorRT-(Post-Merge)-1": ["gh200", "l0_gh200", 1, 2],
+        "GH200-TensorRT-(Post-Merge)-2": ["gh200", "l0_gh200", 2, 2],
     ]
     fullSet += SBSATestConfigs.keySet()
 
     SBSASlurmTestConfigs = [
-        "GB200-4_GPUs-PyTorch-[Post-Merge]-1": ["gb200-4-gpus", "l0_gb200", 1, 1, 4],
+        "GB200-4_GPUs-PyTorch-(Post-Merge)-1": ["gb200-4-gpus", "l0_gb200", 1, 1, 4],
     ]
     fullSet += SBSASlurmTestConfigs.keySet()
 
     multiNodesSBSAConfigs = [
-        "GB200-8_GPUs-2_Nodes-PyTorch-[Post-Merge]-1": ["gb200-multi-node", "l0_gb200_multi_nodes", 1, 1, 8, 2],
+        "GB200-8_GPUs-2_Nodes-PyTorch-(Post-Merge)-1": ["gb200-multi-node", "l0_gb200_multi_nodes", 1, 1, 8, 2],
     ]
     fullSet += multiNodesSBSAConfigs.keySet()
 

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -1644,7 +1644,7 @@ def checkStageNameSet(stageNames, jobKeys, paramName) {
 }
 
 def checkStageName(stageNames) {
-    invalidStageName = stageNames.findAll { !(it ==~ /[-\+\w\[\]]+/) }
+    invalidStageName = stageNames.findAll { !(it ==~ /[-\+\w\[\]\(\)]+/) }
     if (invalidStageName) {
         throw new Exception("Invalid stage name: [${invalidStageName}], we only support chars '-+_[]0-9a-zA-Z' .")
     }


### PR DESCRIPTION
# [fix][ci] missing class names in post-merge test reports

Seems like junit reports empty class names  if the class contains square brackets, which we insert with our test prefix in post-merge stages.
Thie PR replaces these square brackets with normal brackets, which seem to work fine.