### PR TITLE
refactor: Clean up DecodingInput and DecodingOutput

### DIFF
--- a/cpp/include/tensorrt_llm/runtime/decodingInput.h
+++ b/cpp/include/tensorrt_llm/runtime/decodingInput.h
@@ -36,21 +36,6 @@ public:
 
     DecodingInput() = default;
 
-    DecodingInput(SizeType32 maxLength, SizeType32 maxAttentionWindow, SizeType32 sinkTokenLength, SizeType32 batchSize,
-        TensorConstPtr logits, TensorPtr endIds, TensorConstPtr batchSlots)
-        : step{maxLength}
-        , maxLength{maxLength}
-        , maxAttentionWindow{maxAttentionWindow}
-        , sinkTokenLength{sinkTokenLength}
-        , batchSize{batchSize}
-        , logits{std::move(logits)}
-        , endIds{std::move(endIds)}
-        , batchSlots{std::move(batchSlots)}
-    {
-        TLLM_CHECK_WITH_INFO(static_cast<bool>(this->logits), "Invalid logits tensor");
-        TLLM_CHECK_WITH_INFO(static_cast<bool>(this->endIds), "Invalid endIds tensor");
-    }
-
     //! Mandatory parameters
     //! The index of the decoding step we are on. Only used in Python runtime
     SizeType32 step{};
@@ -69,10 +54,8 @@ public:
     //! The maximum value in the `badWordsLens` tensor
     SizeType32 maxBadWordsLen{};
     //! The output of the model forward computation, a probability distribution over the vocabulary
-    //! [batchSize, beamWidth, vocabSizePadded] on gpu
-    TensorConstPtr logits;
-    //! Another view on the logits, [batchSize][beamWidth, vocabSizePadded] on gpu
-    std::optional<std::vector<TensorConstPtr>> logitsVec;
+    //! [batchSize][numGenTokens, beamWidth, vocabSizePadded] on gpu
+    std::vector<TensorConstPtr> logitsVec;
     //! The end ids, [batchSize * beamWidth] on gpu
     TensorConstPtr endIds;
     //! Address map of the linear batch id to to the seq slots, [batchSize] on pinned, int32_t

--- a/cpp/include/tensorrt_llm/runtime/decodingOutput.h
+++ b/cpp/include/tensorrt_llm/runtime/decodingOutput.h
@@ -68,13 +68,6 @@ public:
 
     DecodingOutput() = default;
 
-    explicit DecodingOutput(TensorPtr ids, TensorPtr gatheredIds)
-        : ids{std::move(ids)}
-        , gatheredIds{std::move(gatheredIds)}
-    {
-        TLLM_CHECK_WITH_INFO(static_cast<bool>(this->ids), "Invalid ids tensor");
-    }
-
     //! Mandatory parameters
     //! Previously generated token ids for all steps before DecodingInput.step, [BS, BM, MSL]
     TensorPtr ids;

--- a/cpp/tensorrt_llm/runtime/decoderState.cpp
+++ b/cpp/tensorrt_llm/runtime/decoderState.cpp
@@ -73,7 +73,6 @@ void DecoderState::setupBuffers(nvinfer1::DataType dtype, BufferManager const& b
 
     auto& dInput = mJointDecodingInput;
     TLLM_CHECK(static_cast<bool>(dInput));
-    dInput->logits = bufferManager.emptyTensor(MemoryType::kGPU, nvFloatType);
     dInput->endIds = bufferManager.emptyTensor(MemoryType::kGPU, nvTokenIdType);
     dInput->batchSlots = bufferManager.emptyTensor(MemoryType::kPINNEDPOOL, nvSizeType);
 

--- a/cpp/tensorrt_llm/runtime/gptDecoder.cpp
+++ b/cpp/tensorrt_llm/runtime/gptDecoder.cpp
@@ -470,21 +470,11 @@ std::shared_ptr<tl::BaseDecodingInputs> prepareInputs(
     // No logits for explicit draft tokens and eagle
     if (!decodingMode.isExplicitDraftTokens() && !decodingMode.isEagle())
     {
-        if (input.logitsVec)
+        for (auto const& logits : input.logitsVec)
         {
-            std::vector<TensorConstPtr> logitsVec;
-            for (auto const& logits : input.logitsVec.value())
-            {
-                TLLM_CHECK(logits->getDataType() == TRTDataType<T>::value);
-                logitsVec.push_back(logits);
-            }
-            forwardParams->logitsVec = logitsVec;
+            TLLM_CHECK(logits->getDataType() == TRTDataType<T>::value);
         }
-        else if (input.logits)
-        {
-            TLLM_CHECK(input.logits->getDataType() == TRTDataType<T>::value);
-            forwardParams->logits = input.logits;
-        }
+        forwardParams->logitsVec = input.logitsVec;
     }
 
     if (input.embeddingBias)

--- a/cpp/tests/runtime/gptDecoderTest.cpp
+++ b/cpp/tests/runtime/gptDecoderTest.cpp
@@ -108,16 +108,27 @@ void testDecoder(nvinfer1::DataType const dtype, SamplingConfig const& samplingC
     decoder->setup(samplingConfig, batchSize, batchSlots);
 
     // set up inputs
-    auto logits = std::shared_ptr(
-        manager.gpu(ITensor::makeShape({batchSize, beamWidth, vocabSizePadded}), modelConfig.getDataType()));
-    manager.setZero(*logits);
+    std::vector<std::shared_ptr<ITensor const>> logitsVec;
+    for (auto i = 0; i < batchSize; ++i)
+    {
+        auto logits = manager.gpu(ITensor::makeShape({1, beamWidth, vocabSizePadded}), modelConfig.getDataType());
+        manager.setZero(*logits);
+        logitsVec.push_back(std::move(logits));
+    }
 
     int constexpr endId{50257};
     std::vector<int> const endIdsVec(batchSize * beamWidth, endId);
     auto endIds
         = std::shared_ptr(manager.copyFrom(endIdsVec, ITensor::makeShape({batchSize, beamWidth}), MemoryType::kGPU));
 
-    DecodingInput inputs{maxInputLength, maxSeqLength, sinkTokenLength, batchSize, logits, endIds, batchSlots};
+    DecodingInput inputs;
+    inputs.maxLength = maxInputLength;
+    inputs.maxAttentionWindow = maxSeqLength;
+    inputs.sinkTokenLength = sinkTokenLength;
+    inputs.batchSize = batchSize;
+    inputs.logitsVec = logitsVec;
+    inputs.endIds = endIds;
+    inputs.batchSlots = batchSlots;
 
     std::vector<std::int32_t> inputLengthsVec(batchSize * beamWidth, 0);
     inputs.lengths = manager.copyFrom(inputLengthsVec, ITensor::makeShape({batchSize * beamWidth}), MemoryType::kGPU);

--- a/cpp/tests/unit_tests/kernels/decodingKernelTest.cpp
+++ b/cpp/tests/unit_tests/kernels/decodingKernelTest.cpp
@@ -359,11 +359,11 @@ public:
         auto const jointOutputIdsShape = ITensor::makeShape({batchSize, beamWidth, maxSeqLen});
 
         { // prevent reusing these vars after std::move
-            auto dummyLogits = mBufferManager->emptyTensor(MemoryType::kGPU, nvFloatType);
             auto endIds = mBufferManager->emptyTensor(MemoryType::kGPU, nvTokenIdType);
             auto batchSlots = mBufferManager->emptyTensor(MemoryType::kPINNED, nvSizeType);
-            decodingInput = std::make_unique<DecodingInput>(
-                0, 0, 0, 0, std::move(dummyLogits), std::move(endIds), std::move(batchSlots));
+            decodingInput = std::make_unique<DecodingInput>();
+            decodingInput->endIds = std::move(endIds);
+            decodingInput->batchSlots = std::move(batchSlots);
         }
         auto& dInput = *decodingInput;
 

--- a/cpp/tests/unit_tests/kernels/decodingKernelTest.cpp
+++ b/cpp/tests/unit_tests/kernels/decodingKernelTest.cpp
@@ -384,7 +384,9 @@ public:
             auto gatheredIds = mBufferManager->gpu(jointOutputIdsShape, nvTokenIdType);
             mBufferManager->setZero(*gatheredIds);
 
-            decodingOutput = std::make_unique<DecodingOutput>(std::move(ids), std::move(gatheredIds));
+            decodingOutput = std::make_unique<DecodingOutput>();
+            decodingOutput->ids = std::move(ids);
+            decodingOutput->gatheredIds = std::move(gatheredIds);
         }
         auto& dOutput = *decodingOutput;
 

--- a/cpp/tests/unit_tests/kernels/decodingKernelTest.cpp
+++ b/cpp/tests/unit_tests/kernels/decodingKernelTest.cpp
@@ -20,6 +20,7 @@
 #include "tensorrt_llm/kernels/speculativeDecoding/externalDraftTokensKernels.h"
 #include "tensorrt_llm/kernels/speculativeDecoding/medusaDecodingKernels.h"
 #include "tensorrt_llm/runtime/bufferManager.h"
+#include "tensorrt_llm/runtime/decoderState.h"
 #include "tensorrt_llm/runtime/runtimeKernels.h"
 
 #include <curand_kernel.h>
@@ -326,20 +327,14 @@ public:
 
     using TensorPtr = ITensor::SharedPtr;
 
-    using DecodingOutputPtr = std::unique_ptr<DecodingOutput>;
-    DecodingOutputPtr decodingOutput{nullptr};
-
-    SamplingConfig samplingConfig = SamplingConfig();
-
     std::shared_ptr<tensorrt_llm::runtime::CudaStream> mStream{nullptr};
     std::shared_ptr<tensorrt_llm::runtime::BufferManager> mBufferManager{nullptr};
 
+    std::unique_ptr<tensorrt_llm::runtime::decoder::DecoderState> mDecodingState{nullptr};
+
     SamplingConfig mSamplingConfig;
 
-    using DecodingInputPtr = std::unique_ptr<DecodingInput>;
-    DecodingInputPtr decodingInput{nullptr};
-
-    TensorPtr targetOut{nullptr};
+    TensorPtr mTargetOut{nullptr};
 
     void SetUp() override
     {
@@ -350,66 +345,30 @@ public:
     // create the empty buffers with the correct shapes and zero them
     void createBuffers()
     {
-        auto constexpr nvTokenIdType = TRTDataType<TokenIdType>::value;
-        auto constexpr nvSizeType = TRTDataType<SizeType32>::value;
-        auto constexpr nvFloatType = TRTDataType<float>::value;
+        SizeType32 constexpr tensorParallelism{1};
+        SizeType32 constexpr pipelineParallelism{1};
+        SizeType32 constexpr contextParallelism{1};
+        SizeType32 constexpr localRank{0};
+        WorldConfig const worldConfig{tensorParallelism, pipelineParallelism, contextParallelism, localRank};
 
-        auto const maxBatchSizeShape = ITensor::makeShape({batchSize});
-        auto const maxBatchSizeXmaxBeamWidth = ITensor::makeShape({batchSize, beamWidth});
+        SizeType32 constexpr vocabSize{51200};
+        SizeType32 constexpr nbAttentionLayers{2};
+        SizeType32 constexpr nbRnnLayers{0};
+        SizeType32 constexpr nbHeads{16};
+        SizeType32 constexpr hiddenSize{1024};
+        nvinfer1::DataType constexpr dtype{nvinfer1::DataType::kFLOAT};
+        ModelConfig modelConfig{
+            vocabSize, nbAttentionLayers + nbRnnLayers, nbAttentionLayers, nbRnnLayers, nbHeads, hiddenSize, dtype};
+
+        mDecodingState = std::make_unique<tensorrt_llm::runtime::decoder::DecoderState>();
+        mDecodingState->setup(
+            batchSize, beamWidth, maxSeqLen, 0, maxSeqLen, dtype, modelConfig, worldConfig, *mBufferManager);
+
+        auto constexpr nvTokenIdType = TRTDataType<TokenIdType>::value;
         auto const jointOutputIdsShape = ITensor::makeShape({batchSize, beamWidth, maxSeqLen});
 
-        { // prevent reusing these vars after std::move
-            auto endIds = mBufferManager->emptyTensor(MemoryType::kGPU, nvTokenIdType);
-            auto batchSlots = mBufferManager->emptyTensor(MemoryType::kPINNED, nvSizeType);
-            decodingInput = std::make_unique<DecodingInput>();
-            decodingInput->endIds = std::move(endIds);
-            decodingInput->batchSlots = std::move(batchSlots);
-        }
-        auto& dInput = *decodingInput;
-
-        dInput.maxLength = maxSeqLen;
-
-        const_cast<ITensor&>(*dInput.endIds).reshape(maxBatchSizeShape);
-        const_cast<ITensor&>(*dInput.batchSlots).reshape(maxBatchSizeShape);
-        const_cast<ITensor&>(*dInput.endIds).reshape(maxBatchSizeShape);
-        const_cast<ITensor&>(*dInput.batchSlots).reshape(maxBatchSizeShape);
-        auto& inputLengths = const_cast<ITensor&>(*dInput.lengths);
-        dInput.lengths = mBufferManager->gpu(maxBatchSizeXmaxBeamWidth, nvSizeType);
-        mBufferManager->setZero(const_cast<ITensor&>(*dInput.lengths));
-
-        { // prevent reusing these vars after std::move
-
-            auto ids = mBufferManager->gpu(jointOutputIdsShape, nvTokenIdType);
-            mBufferManager->setZero(*ids);
-            auto gatheredIds = mBufferManager->gpu(jointOutputIdsShape, nvTokenIdType);
-            mBufferManager->setZero(*gatheredIds);
-
-            decodingOutput = std::make_unique<DecodingOutput>();
-            decodingOutput->ids = std::move(ids);
-            decodingOutput->gatheredIds = std::move(gatheredIds);
-        }
-        auto& dOutput = *decodingOutput;
-
-        dOutput.logProbs = mBufferManager->gpu(jointOutputIdsShape, nvFloatType);
-        mBufferManager->setZero(*dOutput.logProbs);
-        dOutput.logProbsTiled = mBufferManager->gpu(ITensor::makeShape({maxSeqLen, batchSize, beamWidth}), nvFloatType);
-        mBufferManager->setZero(*dOutput.logProbsTiled);
-        dOutput.lengths = mBufferManager->gpu(ITensor::makeShape({batchSize, beamWidth}), nvSizeType);
-        mBufferManager->setZero(*dOutput.lengths);
-        dOutput.cumLogProbs = mBufferManager->gpu(maxBatchSizeXmaxBeamWidth, nvFloatType);
-        mBufferManager->setZero(*dOutput.cumLogProbs);
-
-        dOutput.beamHypotheses.empty(*mBufferManager);
-        dOutput.beamHypotheses.reshape(batchSize, beamWidth, maxSeqLen);
-
-        dOutput.finishReasons
-            = mBufferManager->gpu(maxBatchSizeXmaxBeamWidth, TRTDataType<tk::FinishedState::UnderlyingType>::value);
-        mBufferManager->setZero(*dOutput.finishReasons);
-        dOutput.parentIds = mBufferManager->gpu(jointOutputIdsShape, nvTokenIdType);
-        mBufferManager->setZero(*dOutput.parentIds);
-
-        targetOut = mBufferManager->gpu(jointOutputIdsShape, nvTokenIdType);
-        mBufferManager->setZero(*targetOut);
+        mTargetOut = mBufferManager->gpu(jointOutputIdsShape, nvTokenIdType);
+        mBufferManager->setZero(*mTargetOut);
     }
 
     // clang-format off
@@ -422,12 +381,15 @@ public:
         auto constexpr nvSizeType = TRTDataType<SizeType32>::value;
         auto constexpr nvFloatType = TRTDataType<float>::value;
 
+        auto const decodingInput = mDecodingState->getJointDecodingInput();
+        auto const decodingOutput = mDecodingState->getJointDecodingOutput();
+
         std::vector<SizeType32> len = {3, 3, 3, 3, 3};
-        TensorPtr inputLengths{ITensor::slice(constPointerCast(decodingInput->lengths), 0, 1)};
+        TensorPtr inputLengths{ITensor::slice(constPointerCast(decodingInput.lengths), 0, 1)};
         mBufferManager->copy(len.data(),*inputLengths);
 
         std::vector<SizeType32> eid = {0};
-        TensorPtr endIds{ITensor::slice(constPointerCast(decodingInput->endIds), 0, 1)};
+        TensorPtr endIds{ITensor::slice(constPointerCast(decodingInput.endIds), 0, 1)};
         mBufferManager->copy(eid.data(),*endIds);
 
         std::vector<std::vector<float>> logProbs =
@@ -439,7 +401,7 @@ public:
             {-2.96689, -1.63675, -2.31329, -0.0377979, -2.2442, -1.57552, -0.310524, -0.696636, -3.62298}
         };
         for (SizeType32 it = 0; it < logProbs.size(); it++){
-            fillTensorAtIndex(decodingOutput->logProbs, it, logProbs[it], true, mBufferManager);
+            fillTensorAtIndex(decodingOutput.logProbs, it, logProbs[it], true, mBufferManager);
         }
 
         std::vector<std::vector<float>> logProbsTiled =
@@ -455,17 +417,17 @@ public:
             {-2.41985, -2.61479, -1.01671, -3.62298, -1.26586},
             {-0.844337, -0.922832, -0.427682, -0.419985, -1.85996}
         };
-        TensorPtr logProbsTiledView = ITensor::view(decodingOutput->logProbsTiled,ITensor::makeShape({maxSeqLen*batchSize, beamWidth}));
+        TensorPtr logProbsTiledView = ITensor::view(decodingOutput.logProbsTiled,ITensor::makeShape({maxSeqLen*batchSize, beamWidth}));
         for (SizeType32 it = 0; it < logProbsTiled.size(); it++){
             auto logProbsSlice = ITensor::slice(logProbsTiledView, it+3,1);
             mBufferManager->copy(logProbsTiled[it].data(),*logProbsSlice);
         }
 
         std::vector<SizeType32> outputLenghts = {13, 13, 13, 13, 13};
-        mBufferManager->copy(outputLenghts.data(),*decodingOutput->lengths);
+        mBufferManager->copy(outputLenghts.data(),*decodingOutput.lengths);
 
         std::vector<float> cumLogProbs = {-15.0458, -15.4681, -15.8323, -15.8424, -16.0614};
-        mBufferManager->copy(cumLogProbs.data(),*decodingOutput->cumLogProbs);
+        mBufferManager->copy(cumLogProbs.data(),*decodingOutput.cumLogProbs);
 
         std::vector<std::vector<TokenIdType>> outputIdsCBA =
         {
@@ -474,7 +436,7 @@ public:
         };
         for(SizeType32 it = 0; it < outputIdsCBA.size(); it++)
         {
-            fillTensorAtIndex(decodingOutput->beamHypotheses.outputIdsCBA, it, outputIdsCBA[it], true, mBufferManager);
+            fillTensorAtIndex(decodingOutput.beamHypotheses.outputIdsCBA, it, outputIdsCBA[it], true, mBufferManager);
         }
 
         std::vector<std::vector<float>> logProbsCBA =
@@ -484,29 +446,29 @@ public:
         };
         for(SizeType32 it = 0; it < logProbsCBA.size(); it++)
         {
-            fillTensorAtIndex(decodingOutput->beamHypotheses.logProbsCBA, it, logProbsCBA[it], true, mBufferManager);
+            fillTensorAtIndex(decodingOutput.beamHypotheses.logProbsCBA, it, logProbsCBA[it], true, mBufferManager);
         }
 
         std::vector<SizeType32> sequenceLengthsCBA = {10, 10, 0, 0, 0, 0, 0, 0, 0, 0};
-        mBufferManager->copy(sequenceLengthsCBA.data(), *decodingOutput->beamHypotheses.sequenceLengthsCBA);
+        mBufferManager->copy(sequenceLengthsCBA.data(), *decodingOutput.beamHypotheses.sequenceLengthsCBA);
 
         std::vector<float> cumLogProbsCBA = {-13.6336, -13.8988, 0, 0, 0, 0, 0, 0, 0, 0};
-        mBufferManager->copy(cumLogProbsCBA.data(), *decodingOutput->beamHypotheses.cumLogProbsCBA);
+        mBufferManager->copy(cumLogProbsCBA.data(), *decodingOutput.beamHypotheses.cumLogProbsCBA);
 
         std::vector<float> normedScoresCBA = {-1.7042, -1.73735, 0, 0, 0, 0, 0, 0, 0, 0};
-        mBufferManager->copy(normedScoresCBA.data(), *decodingOutput->beamHypotheses.normedScoresCBA);
+        mBufferManager->copy(normedScoresCBA.data(), *decodingOutput.beamHypotheses.normedScoresCBA);
 
         std::vector<SizeType32> numBeamsCBA = {2};
-        mBufferManager->copy(numBeamsCBA.data(), *decodingOutput->beamHypotheses.numBeamsCBA);
+        mBufferManager->copy(numBeamsCBA.data(), *decodingOutput.beamHypotheses.numBeamsCBA);
 
         std::vector<float> minNormedScoresCBA = {-1.73735};
-        mBufferManager->copy(minNormedScoresCBA.data(), *decodingOutput->beamHypotheses.minNormedScoresCBA);
+        mBufferManager->copy(minNormedScoresCBA.data(), *decodingOutput.beamHypotheses.minNormedScoresCBA);
 
         std::vector<SizeType32> batchDones = {0};
-        mBufferManager->copy(batchDones.data(), *decodingOutput->beamHypotheses.batchDones);
+        mBufferManager->copy(batchDones.data(), *decodingOutput.beamHypotheses.batchDones);
 
         std::vector<uint8_t> finishReasons = {4, 4, 4, 4, 4};
-        mBufferManager->copy(finishReasons.data(), *decodingOutput->finishReasons);
+        mBufferManager->copy(finishReasons.data(), *decodingOutput.finishReasons);
 
         std::vector<std::vector<TokenIdType>> ids =
         {
@@ -518,7 +480,7 @@ public:
         };
         for(SizeType32 it = 0; it < ids.size(); it++)
         {
-            fillTensorAtIndex(decodingOutput->ids, it, ids[it], true, mBufferManager);
+            fillTensorAtIndex(decodingOutput.ids, it, ids[it], true, mBufferManager);
         }
 
         std::vector<std::vector<SizeType32>> parentIds =
@@ -531,7 +493,7 @@ public:
         };
         for(SizeType32 it = 0; it < parentIds.size(); it++)
         {
-            fillTensorAtIndex(decodingOutput->parentIds, it, parentIds[it], true, mBufferManager);
+            fillTensorAtIndex(decodingOutput.parentIds, it, parentIds[it], true, mBufferManager);
         }
 
         std::vector<std::vector<TokenIdType>> targetOutput =
@@ -544,7 +506,7 @@ public:
         };
         for(SizeType32 it = 0; it < targetOutput.size(); it++)
         {
-            fillTensorAtIndex(targetOut, it, targetOutput[it], true, mBufferManager);
+            fillTensorAtIndex(mTargetOut, it, targetOutput[it], true, mBufferManager);
         }
     }
 
@@ -555,12 +517,15 @@ public:
         auto constexpr nvSizeType = TRTDataType<SizeType32>::value;
         auto constexpr nvFloatType = TRTDataType<float>::value;
 
+        auto const decodingInput = mDecodingState->getJointDecodingInput();
+        auto const decodingOutput = mDecodingState->getJointDecodingOutput();
+
         std::vector<SizeType32> len = {3, 3, 3, 3, 3};
-        TensorPtr inputLengths{ITensor::slice(constPointerCast(decodingInput->lengths), 0, 1)};
+        TensorPtr inputLengths{ITensor::slice(constPointerCast(decodingInput.lengths), 0, 1)};
         mBufferManager->copy(len.data(),*inputLengths);
 
         std::vector<SizeType32> eid = {0};
-        TensorPtr endIds{ITensor::slice(constPointerCast(decodingInput->endIds), 0, 1)};
+        TensorPtr endIds{ITensor::slice(constPointerCast(decodingInput.endIds), 0, 1)};
         mBufferManager->copy(eid.data(),*endIds);
 
         std::vector<std::vector<float> >logProbs =
@@ -572,7 +537,7 @@ public:
             {-2.96689, -1.63675, -2.31329, -0.0377979, -1.31451, -3.85214, -1.72914}
         };
         for (SizeType32 it = 0; it < logProbs.size(); it++){
-            fillTensorAtIndex(decodingOutput->logProbs, it, logProbs[it], true, mBufferManager);
+            fillTensorAtIndex(decodingOutput.logProbs, it, logProbs[it], true, mBufferManager);
         }
 
         std::vector<std::vector<float>> logProbsTiled =
@@ -586,16 +551,16 @@ public:
             {-0.310524, -0.534199, -0.74379, -2.86232, -1.72914},
             {-0.696636, -0.493615, -0.237725, -3.07164, -3.11851}
         };
-        TensorPtr logProbsTiledView = ITensor::view(decodingOutput->logProbsTiled,ITensor::makeShape({maxSeqLen*batchSize, beamWidth}));
+        TensorPtr logProbsTiledView = ITensor::view(decodingOutput.logProbsTiled,ITensor::makeShape({maxSeqLen*batchSize, beamWidth}));
         for (SizeType32 it = 0; it < logProbsTiled.size(); it++){
             auto logProbsSlice = ITensor::slice(logProbsTiledView, it+3,1);
             mBufferManager->copy(logProbsTiled[it].data(),*logProbsSlice);
         }
         std::vector<SizeType32> outputLenghts = {11, 11, 11, 11, 11};
-        mBufferManager->copy(outputLenghts.data(),*decodingOutput->lengths);
+        mBufferManager->copy(outputLenghts.data(),*decodingOutput.lengths);
 
         std::vector<float> cumLogProbs = {-11.7816, -11.9304, -14.0883, -14.1566, -14.2035};
-        mBufferManager->copy(cumLogProbs.data(),*decodingOutput->cumLogProbs);
+        mBufferManager->copy(cumLogProbs.data(),*decodingOutput.cumLogProbs);
 
         std::vector<std::vector<TokenIdType>> outputIdsCBA =
         {
@@ -604,7 +569,7 @@ public:
         };
         for(SizeType32 it = 0; it < outputIdsCBA.size(); it++)
         {
-            fillTensorAtIndex(decodingOutput->beamHypotheses.outputIdsCBA, it, outputIdsCBA[it], true, mBufferManager);
+            fillTensorAtIndex(decodingOutput.beamHypotheses.outputIdsCBA, it, outputIdsCBA[it], true, mBufferManager);
         }
 
         std::vector<std::vector<float>> logProbsCBA =
@@ -614,29 +579,29 @@ public:
         };
         for(SizeType32 it = 0; it < logProbsCBA.size(); it++)
         {
-            fillTensorAtIndex(decodingOutput->beamHypotheses.logProbsCBA, it, logProbsCBA[it], true, mBufferManager);
+            fillTensorAtIndex(decodingOutput.beamHypotheses.logProbsCBA, it, logProbsCBA[it], true, mBufferManager);
         }
 
         std::vector<SizeType32> sequenceLengthsCBA  = {10, 10, 0, 0, 0, 0, 0, 0, 0, 0};
-        mBufferManager->copy(sequenceLengthsCBA.data(), *decodingOutput->beamHypotheses.sequenceLengthsCBA);
+        mBufferManager->copy(sequenceLengthsCBA.data(), *decodingOutput.beamHypotheses.sequenceLengthsCBA);
 
         std::vector<float> cumLogProbsCBA = {-13.6336, -13.8988, 0, 0, 0, 0, 0, 0, 0, 0};
-        mBufferManager->copy(cumLogProbsCBA.data(), *decodingOutput->beamHypotheses.cumLogProbsCBA);
+        mBufferManager->copy(cumLogProbsCBA.data(), *decodingOutput.beamHypotheses.cumLogProbsCBA);
 
         std::vector<float> normedScoresCBA = {-1.7042, -1.73735, 0, 0, 0, 0, 0, 0, 0, 0};
-        mBufferManager->copy(normedScoresCBA.data(), *decodingOutput->beamHypotheses.normedScoresCBA);
+        mBufferManager->copy(normedScoresCBA.data(), *decodingOutput.beamHypotheses.normedScoresCBA);
 
         std::vector<SizeType32> numBeamsCBA = {2};
-        mBufferManager->copy(numBeamsCBA.data(), *decodingOutput->beamHypotheses.numBeamsCBA);
+        mBufferManager->copy(numBeamsCBA.data(), *decodingOutput.beamHypotheses.numBeamsCBA);
 
         std::vector<float> minNormedScoresCBA = {-1.73735};
-        mBufferManager->copy(minNormedScoresCBA.data(), *decodingOutput->beamHypotheses.minNormedScoresCBA);
+        mBufferManager->copy(minNormedScoresCBA.data(), *decodingOutput.beamHypotheses.minNormedScoresCBA);
 
         std::vector<SizeType32> batchDones = {0};
-        mBufferManager->copy(batchDones.data(), *decodingOutput->beamHypotheses.batchDones);
+        mBufferManager->copy(batchDones.data(), *decodingOutput.beamHypotheses.batchDones);
 
         std::vector<uint8_t> finishReasons = {4, 4, 4, 4, 4};
-        mBufferManager->copy(finishReasons.data(), *decodingOutput->finishReasons);
+        mBufferManager->copy(finishReasons.data(), *decodingOutput.finishReasons);
 
         std::vector<std::vector<TokenIdType>> ids =
         {
@@ -648,7 +613,7 @@ public:
         };
         for(SizeType32 it = 0; it < ids.size(); it++)
         {
-            fillTensorAtIndex(decodingOutput->ids, it, ids[it], true, mBufferManager);
+            fillTensorAtIndex(decodingOutput.ids, it, ids[it], true, mBufferManager);
         }
 
         std::vector<std::vector<SizeType32>> parentIds =
@@ -661,7 +626,7 @@ public:
         };
         for(SizeType32 it = 0; it < parentIds.size(); it++)
         {
-            fillTensorAtIndex(decodingOutput->parentIds, it, parentIds[it], true, mBufferManager);
+            fillTensorAtIndex(decodingOutput.parentIds, it, parentIds[it], true, mBufferManager);
         }
 
         std::vector<std::vector<TokenIdType>> targetOutput =
@@ -674,7 +639,7 @@ public:
         };
         for(SizeType32 it = 0; it < targetOutput.size(); it++)
         {
-            fillTensorAtIndex(targetOut, it, targetOutput[it], true, mBufferManager);
+            fillTensorAtIndex(mTargetOut, it, targetOutput[it], true, mBufferManager);
         }
     }
 
@@ -682,12 +647,11 @@ public:
 
     bool checkResult()
     {
-
-        TensorPtr reference = this->mBufferManager->copyFrom((*targetOut), tensorrt_llm::runtime::MemoryType::kCPU);
+        auto const reference = this->mBufferManager->copyFrom(*mTargetOut, tensorrt_llm::runtime::MemoryType::kCPU);
         auto referencePtr = bufferCast<TokenIdType>(*reference);
 
-        TensorPtr real
-            = this->mBufferManager->copyFrom((*decodingOutput->gatheredIds), tensorrt_llm::runtime::MemoryType::kCPU);
+        auto const real = this->mBufferManager->copyFrom(
+            *mDecodingState->getGatheredIds(), tensorrt_llm::runtime::MemoryType::kCPU);
         auto realPtr = bufferCast<TokenIdType>(*real);
 
         bool allEqual = true;
@@ -709,7 +673,8 @@ TEST_F(TestGatherTree, GatherTreeNoSwap)
     createBuffers();
     hardcodeBuffersLen10();
     cudaDeviceSynchronize();
-    kernels::gatherTree(*decodingOutput, *decodingInput, mSamplingConfig, *mStream);
+    kernels::gatherTree(
+        mDecodingState->getJointDecodingOutput(), mDecodingState->getJointDecodingInput(), mSamplingConfig, *mStream);
     cudaDeviceSynchronize();
 
     EXPECT_TRUE(checkResult());
@@ -720,7 +685,8 @@ TEST_F(TestGatherTree, GatherTreeWithSwap)
     createBuffers();
     hardcodeBuffersLen8();
     cudaDeviceSynchronize();
-    kernels::gatherTree(*decodingOutput, *decodingInput, mSamplingConfig, *mStream);
+    kernels::gatherTree(
+        mDecodingState->getJointDecodingOutput(), mDecodingState->getJointDecodingInput(), mSamplingConfig, *mStream);
     cudaDeviceSynchronize();
 
     EXPECT_TRUE(checkResult());


### PR DESCRIPTION
## Description

- Remove the constructors from DecodingInput and DecodingOutput that accepted multiple parameters, transitioning to a default constructors. (They where only used in a test.)
- Remove the now unused single tensor logits path. Always use a vector of logits in the decoder.
- Refactor DecodingKernelTest: Use DecoderState instead of individual DecodingInput and DecodingOutput.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
