### PR TITLE
[fix] fix log probs and add for mtp and completion requests

### DIFF
--- a/cpp/tensorrt_llm/kernels/speculativeDecoding/mtpKernels.h
+++ b/cpp/tensorrt_llm/kernels/speculativeDecoding/mtpKernels.h
@@ -62,7 +62,9 @@ struct MTPSampleAndAcceptDraftTokensParam
     void* __restrict__ logits;
     int* draftTokens;
     int* targetTokens;
+    float* targetTokenLogprobs;
     int* acceptedTokens;
+    float* logprobs;
     int* numAcceptedTokens;
 };
 

--- a/cpp/tensorrt_llm/thop/mtpOp.cpp
+++ b/cpp/tensorrt_llm/thop/mtpOp.cpp
@@ -86,8 +86,8 @@ std::tuple<th::Tensor, th::Tensor> mtp_prepare_drafter_inputs_op(th::Tensor& inp
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////
-std::tuple<th::Tensor, th::Tensor> mtp_sampling_and_accepted_draft_tokens_op(th::Tensor& logits,
-    th::Tensor& draftTokens, th::Tensor& targetTokens, int64_t numMTPModules, int64_t batchSize,
+std::tuple<th::Tensor, th::Tensor, th::Tensor> mtp_sampling_and_accepted_draft_tokens_op(th::Tensor& logits,
+    th::Tensor& draftTokens, th::Tensor& targetTokens, th::Tensor& targetTokenLogprobs, int64_t numMTPModules, int64_t batchSize,
     int64_t numContextRequest, int64_t vocabSize)
 {
     int const numGenerationRequest = batchSize - numContextRequest;
@@ -105,6 +105,8 @@ std::tuple<th::Tensor, th::Tensor> mtp_sampling_and_accepted_draft_tokens_op(th:
     auto stream = at::cuda::getCurrentCUDAStream(logits.get_device());
     auto acceptedTokens
         = torch::ones({batchSize, numMTPModules + 1}, at::TensorOptions().dtype(torch::kInt32).device(logits.device()));
+    auto logprobs
+        = torch::zeros({batchSize, numMTPModules + 1}, at::TensorOptions().dtype(torch::kFloat32).device(logits.device()));
     auto numAcceptedTokens = torch::ones({batchSize}, at::TensorOptions().dtype(torch::kInt32).device(logits.device()));
 
     // Fill params
@@ -116,6 +118,8 @@ std::tuple<th::Tensor, th::Tensor> mtp_sampling_and_accepted_draft_tokens_op(th:
     params.draftTokens = reinterpret_cast<int*>(draftTokens.data_ptr());
     params.targetTokens = reinterpret_cast<int*>(targetTokens.data_ptr());
     params.acceptedTokens = reinterpret_cast<int*>(acceptedTokens.data_ptr());
+    params.targetTokenLogprobs = reinterpret_cast<float*>(targetTokenLogprobs.data_ptr());
+    params.logprobs = reinterpret_cast<float*>(logprobs.data_ptr());
     params.numAcceptedTokens = reinterpret_cast<int*>(numAcceptedTokens.data_ptr());
     params.logits = logits.data_ptr();
 
@@ -139,7 +143,7 @@ std::tuple<th::Tensor, th::Tensor> mtp_sampling_and_accepted_draft_tokens_op(th:
         break;
     }
 
-    return std::make_tuple(acceptedTokens, numAcceptedTokens);
+    return std::make_tuple(acceptedTokens, numAcceptedTokens, logprobs);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -284,8 +288,8 @@ TORCH_LIBRARY_FRAGMENT(trtllm, m)
 {
     m.def(
         "mtp_sampling_and_accepted_draft_tokens_op(Tensor logits, Tensor draftTokens, Tensor "
-        "targetTokens, int numMTPModules, "
-        "int batchSize, int numContextRequest, int vocabSize) -> (Tensor, Tensor)");
+        "targetTokens, Tensor targetTokenLogprobs, int numMTPModules, "
+        "int batchSize, int numContextRequest, int vocabSize) -> (Tensor, Tensor, Tensor)");
 }
 
 TORCH_LIBRARY_IMPL(trtllm, CUDA, m)

--- a/examples/apps/fastapi_server.py
+++ b/examples/apps/fastapi_server.py
@@ -72,8 +72,10 @@ class LlmServer:
                                               sampling_params=sampling_params)
 
             async def stream_results() -> AsyncGenerator[bytes, None]:
+                last_text_len: int = 0
                 async for output in promise:
-                    yield output.outputs[0].text_diff.encode("utf-8")
+                    text_diff, last_text_len = output.outputs[0].text_diff_safe(last_text_len)
+                    yield text_diff.encode("utf-8")
 
             if streaming:
                 return StreamingResponse(stream_results())

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -353,7 +353,7 @@ def _register_fake():
     @torch.library.register_fake(
         "trtllm::mtp_sampling_and_accepted_draft_tokens_op")
     def _(logits: torch.Tensor, draft_tokens: torch.Tensor,
-          target_tokens: torch.Tensor, num_mtp_modules: int, batch_size: int,
+          target_tokens: torch.Tensor, target_token_logprobs: torch.Tensor, num_mtp_modules: int, batch_size: int,
           num_context_request: int, vocab_size: int):
         return logits.new_empty((batch_size, num_mtp_modules + 1),
                                 dtype=torch.int32), logits.new_empty(

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -1,3 +1,4 @@
+import copy
 from dataclasses import dataclass
 from typing import List, Optional, Union
 
@@ -310,9 +311,14 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
             mpi_world_rank=0) -> tensorrt_llm.bindings.executor.Response | None:
         result, is_final = super().create_serialized_result(
             use_fast_logits, mpi_world_rank)
+        py_result = None
+        if response:
+            py_result = copy.copy(self.py_result)
+            if self.py_result._log_probs:
+                self.py_result._log_probs = LogProbStorage()
         return LlmResponse(
             request_id=self.py_request_id,
-            result=LlmResult(result, self.py_result, is_final),
+            result=LlmResult(result, py_result, is_final),
             client_id=self.py_client_id) if len(result) > 0 else None
 
     @property

--- a/tensorrt_llm/executor/postproc_worker.py
+++ b/tensorrt_llm/executor/postproc_worker.py
@@ -29,6 +29,9 @@ __all__ = [
 @dataclass(kw_only=True)
 class PostprocArgs:
     first_iteration: bool = True
+    last_text_len: int = 0
+    last_logprobs_len: int = 0
+    last_token_ids_len: int = 0
     num_prompt_tokens: Optional[int] = None
     tokenizer: Optional[TransformersTokenizer] = None
 

--- a/tensorrt_llm/executor/result.py
+++ b/tensorrt_llm/executor/result.py
@@ -4,7 +4,7 @@ import weakref
 from dataclasses import dataclass, field
 from queue import Empty, Queue
 from typing import (TYPE_CHECKING, Any, Callable, List, Literal, NamedTuple,
-                    Optional, TypeAlias, Union)
+                    Optional, TypeAlias, Union, Tuple)
 from weakref import WeakMethod
 
 import torch
@@ -89,8 +89,11 @@ class CompletionOutput:
     Attributes:
         length (int): The number of generated tokens.
         token_ids_diff (List[int]): Newly generated token ids.
-        logprobs_diff (List[float]): Logprobs of newly generated tokens.
-        text_diff (str): Newly generated tokens.
+
+    Accessors:
+        token_ids_diff_safe(int) -> Tuple[List[int], int]: Newly generated token ids since the given length.
+        logprobs_diff_safe(int) -> Tuple[List[float], int]: Logprobs of newly generated tokens since the given length.
+        text_diff_safe(int) -> Tuple[str, int]: Newly generated tokens since the given length.
     """
     index: int
     text: str = ""
@@ -119,17 +122,26 @@ class CompletionOutput:
     def length(self) -> int:
         return len(self.token_ids)
 
-    @property
-    def text_diff(self) -> str:
-        return self.text[self._last_text_len:]
+    def text_diff_safe(self, last_text_len) -> Tuple[str, int]:
+        return self.text[last_text_len:], len(self.text)
+
+    def logprobs_diff_safe(self, last_logprobs_len) -> Tuple[List[float], int]:
+        return self.logprobs[last_logprobs_len:], len(self.logprobs)
+
+    def token_ids_diff_safe(self, last_token_ids_len) -> Tuple[List[int], int]:
+        return self.logprobs[last_token_ids_len:], len(self.logprobs)
+
+    #@property
+    #def text_diff(self) -> str:
+    #    return self.text[self._last_text_len:]
 
     @property
     def token_ids_diff(self) -> List[int]:
         return self.token_ids[self._last_token_ids_len:]
 
-    @property
-    def logprobs_diff(self) -> List[float]:
-        return self.logprobs[self._last_logprobs_len:]
+    #@property
+    #def logprobs_diff(self) -> List[float]:
+    #    return self.logprobs[self._last_logprobs_len:]
 
 
 class GenerationResultBase:

--- a/tensorrt_llm/executor/result.py
+++ b/tensorrt_llm/executor/result.py
@@ -123,13 +123,16 @@ class CompletionOutput:
         return len(self.token_ids)
 
     def text_diff_safe(self, last_text_len) -> Tuple[str, int]:
-        return self.text[last_text_len:], len(self.text)
+        l = len(self.text)
+        return self.text[last_text_len:l], l
 
     def logprobs_diff_safe(self, last_logprobs_len) -> Tuple[List[float], int]:
-        return self.logprobs[last_logprobs_len:], len(self.logprobs)
+        l = len(self.logprobs)
+        return self.logprobs[last_logprobs_len:l], l
 
     def token_ids_diff_safe(self, last_token_ids_len) -> Tuple[List[int], int]:
-        return self.logprobs[last_token_ids_len:], len(self.logprobs)
+        l = len(self.token_ids)
+        return self.token_ids[last_token_ids_len:l], l
 
     #@property
     #def text_diff(self) -> str:
@@ -237,7 +240,7 @@ class GenerationResultBase:
 
         if response_tensors.log_probs is not None:
             output._last_logprobs_len = len(output.logprobs)
-            output.logprobs = response_tensors.log_probs[src_idx]
+            output.logprobs.extend(response_tensors.log_probs[src_idx])
             # overcome some WAR in the cpp executor
             if finish_reasons[src_idx] != tllm.FinishReason.CANCELLED:
                 assert len(output.logprobs) == output.length

--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -249,15 +249,9 @@ class CompletionRequest(OpenAIBaseModel):
 
             # TODO: migrate to use logprobs and prompt_logprobs
             _return_log_probs=self.logprobs,
+            logprobs=self.logprobs,
         )
         return sampling_params
-
-    @model_validator(mode="before")
-    @classmethod
-    def check_logprobs(cls, data):
-        if data.get("logprobs"):
-            raise ValueError("logprobs is not supported")
-        return data
 
     @model_validator(mode="before")
     @classmethod
@@ -540,6 +534,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
 
             # TODO: migrate to use logprobs and prompt_logprobs
             _return_log_probs=self.logprobs,
+            logprobs=self.logprobs,
         )
         return sampling_params
 

--- a/tests/unittest/_torch/speculative/test_mtp.py
+++ b/tests/unittest/_torch/speculative/test_mtp.py
@@ -322,7 +322,7 @@ class TestMTPSampleAndAcceptDraftTokens(unittest.TestCase):
         for is_thop in [True, False]:
             mtpworker.is_thop = is_thop
             # TODO: add unit tests for relaxed acceptance
-            accepted_tokens, num_accepted_tokens = mtpworker.sample_and_accept_draft_tokens(
+            accepted_tokens, num_accepted_tokens, log_probs = mtpworker.sample_and_accept_draft_tokens(
                 None, logits, spec_metadata, attn_metadata)
 
             torch.testing.assert_close(num_accepted_tokens,

--- a/tests/unittest/llmapi/run_llm_with_postproc.py
+++ b/tests/unittest/llmapi/run_llm_with_postproc.py
@@ -47,7 +47,7 @@ def perform_faked_oai_postprocess(rsp: GenerationResultBase,
         if finish_reason_sent[i]:
             continue
 
-        delta_text = output.text_diff
+        delta_text, args.last_text_len = output.text_diff_safe(args.last_text_len)
         delta_message = DeltaMessage(content=delta_text)
 
         choice = ChatCompletionResponseStreamChoice(index=i,


### PR DESCRIPTION
fix log probs and add for mtp and completion requests
Part of feature parity with pytorch #3700

Note: Based on top of #4923 since changes to how `output.logprobs_diff` is calculated was required to avoid a race condition with mismatched token id lengths.

## Description

Logprobs currently only works for chat completion, and non-mtp backend. It also has some race conditions which causes the number of returned logprobs to be incorrect sometimes.

## Test Coverage

TestMTPSampleAndAcceptDraftTokens calls mtpworker.sample_and_accept_draft_tokens but does not verify the resulting log_probs.
