### PR TITLE
[feat] Implement pytorch sampler for MTP

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import psutil
 import safetensors
+from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest
 import torch
 import torch._dynamo.config
 
@@ -336,6 +337,7 @@ class PyTorchModelEngine(ModelEngine):
         lora_config: Optional[LoraConfig] = None,
         is_draft_model: bool = False,
     ):
+        torch.manual_seed(0)
         self.ub_buffers = None
         self.batch_size = batch_size
         self.max_num_tokens = max_num_tokens
@@ -450,6 +452,18 @@ class PyTorchModelEngine(ModelEngine):
             self.without_logits = self.spec_config.spec_dec_mode.without_logits(
             )
             self.max_draft_len = spec_config.max_draft_tokens
+            self.temperatures_cuda = torch.empty((self.batch_size * (self.max_draft_len + 1), ),
+                                               dtype=torch.float,
+                                               device='cuda')
+            self.top_k_cuda = torch.empty((self.batch_size * (self.max_draft_len + 1), ),
+                                          dtype=torch.int,
+                                          device='cuda')
+            self.top_p_cuda = torch.empty((self.batch_size * (self.max_draft_len + 1), ),
+                                          dtype=torch.float,
+                                          device='cuda')
+            self.min_p_cuda = torch.empty((self.batch_size * (self.max_draft_len + 1), ),
+                                          dtype=torch.float,
+                                          device='cuda')
         else:
             self.without_logits = False
             self.max_draft_len = 0
@@ -1152,6 +1166,10 @@ class PyTorchModelEngine(ModelEngine):
         draft_tokens = []
         draft_lens = []
         mrope_config = defaultdict(list)
+        temperatures = []
+        top_k = []
+        top_p = []
+        min_p = []
 
         mtp_batch_idx = 0  # Temporary: MTP (and Eagle3OneModel) remain the only samplers to index new_tokens serially
 
@@ -1162,6 +1180,39 @@ class PyTorchModelEngine(ModelEngine):
             batch_idx = mtp_batch_idx
             mtp_batch_idx += 1
             return batch_idx
+
+        def get_request_temperature(request: LlmRequest) -> float:
+            if not request.sampling_config.temperature:
+                return 0.7
+            temperature = request.sampling_config.temperature[0]
+            if 0 < temperature < 1e-2:
+                # temperature less than 0.01 may cause numerical errors
+                temperature = 0.01
+            return temperature
+
+        def get_request_top_k(request: LlmRequest) -> int:
+            if not request.sampling_config.top_k:
+                top_k = 0
+            else:
+                top_k = request.sampling_config.top_k[0]
+            # flashinfer expects k > d for no top_k filter
+            if top_k <= 0:
+                top_k = 2147483647
+            return top_k
+
+        def get_request_top_p(request: LlmRequest) -> float:
+            if not request.sampling_config.top_p:
+                top_p = 1.0
+            else:
+                top_p = request.sampling_config.top_p[0]
+            return top_p
+
+        def get_request_min_p(request: LlmRequest) -> float:
+            if not request.sampling_config.min_p:
+                min_p = 0.0
+            else:
+                min_p = request.sampling_config.min_p[0]
+            return min_p
 
         for request in scheduled_requests.context_requests:
             request_ids.append(request.py_request_id)
@@ -1192,6 +1243,11 @@ class PyTorchModelEngine(ModelEngine):
                 ) if mrope_rotary_cos_sin.device == 'cpu' else mrope_rotary_cos_sin
                 mrope_config['mrope_rotary_cos_sin'].append(
                     mrope_rotary_cos_sin.to('cuda', non_blocking=True))
+            temperatures.append(get_request_temperature(request))
+            top_k.append(get_request_top_k(request))
+            top_p.append(get_request_top_p(request))
+            min_p.append(get_request_min_p(request))
+
             request.py_batch_idx = py_batch_idx(request)
 
         num_ctx_requests = len(scheduled_requests.context_requests)
@@ -1273,6 +1329,10 @@ class PyTorchModelEngine(ModelEngine):
                               past_seen_token_num + 1 + num_draft_tokens)))
                 num_cached_tokens_per_seq.append(past_seen_token_num)
                 request_ids.append(request.py_request_id)
+                temperatures.extend([get_request_temperature(request)] * (num_draft_tokens + 1))
+                top_k.extend([get_request_top_k(request)] * (num_draft_tokens + 1))
+                top_p.extend([get_request_top_p(request)] * (num_draft_tokens + 1))
+                min_p.extend([get_request_min_p(request)] * (num_draft_tokens + 1))
                 # update batch index
                 request.py_batch_idx = py_batch_idx(request)
             else:
@@ -1301,6 +1361,10 @@ class PyTorchModelEngine(ModelEngine):
                                                  self.max_draft_len + 1)
                 prompt_lengths.append(request.py_prompt_len)
                 request_ids.append(request.py_request_id)
+                temperatures.extend([get_request_temperature(request)] * (self.max_draft_len + 1))
+                top_k.extend([get_request_top_k(request)] * (self.max_draft_len + 1))
+                top_p.extend([get_request_top_p(request)] * (self.max_draft_len + 1))
+                min_p.extend([get_request_min_p(request)] * (self.max_draft_len + 1))
 
         sequence_lengths.extend([1] * len(generation_requests))
         gather_ids.extend(
@@ -1329,6 +1393,10 @@ class PyTorchModelEngine(ModelEngine):
             prompt_lengths.append(request.py_prompt_len)
             draft_lens.append(0)
 
+            temperatures.extend([get_request_temperature(request)] * (self.max_draft_len + 1))
+            top_k.extend([get_request_top_k(request)] * (self.max_draft_len + 1))
+            top_p.extend([get_request_top_p(request)] * (self.max_draft_len + 1))
+            min_p.extend([get_request_min_p(request)] * (self.max_draft_len + 1))
             request.py_batch_idx = py_batch_idx(request)
 
         previous_batch_len = len(previous_batch_indices)
@@ -1420,6 +1488,18 @@ class PyTorchModelEngine(ModelEngine):
             self.gather_ids_cuda[:len(gather_ids)].copy_(torch.tensor(
                 gather_ids, dtype=torch.int, pin_memory=True),
                                                          non_blocking=True)
+            self.temperatures_cuda[:len(temperatures)].copy_(torch.tensor(
+                temperatures, dtype=torch.float, pin_memory=True),
+                                                        non_blocking=True)
+            self.top_k_cuda[:len(top_k)].copy_(torch.tensor(
+                top_k, dtype=torch.int, pin_memory=True),
+                                                        non_blocking=True)
+            self.top_p_cuda[:len(top_p)].copy_(torch.tensor(
+                top_p, dtype=torch.float, pin_memory=True),
+                                                        non_blocking=True)
+            self.min_p_cuda[:len(min_p)].copy_(torch.tensor(
+                min_p, dtype=torch.float, pin_memory=True),
+                                                        non_blocking=True)
 
         if not attn_metadata.is_cuda_graph:
             # Assumes seq lens do not change between CUDA graph invocations. This applies
@@ -1469,6 +1549,12 @@ class PyTorchModelEngine(ModelEngine):
                                                                 total_draft_lens]
             spec_metadata.request_ids = request_ids
             spec_metadata.gather_ids = self.gather_ids_cuda[:len(gather_ids)]
+            spec_metadata.temperatures = self.temperatures_cuda[:len(temperatures)]
+            spec_metadata.top_k = self.top_k_cuda[:len(top_k)]
+            spec_metadata.top_p = self.top_p_cuda[:len(top_p)]
+            spec_metadata.min_p = self.min_p_cuda[:len(min_p)]
+            # if attn_metadata.is_cuda_graph and not torch.cuda.is_current_stream_capturing():
+                # spec_metadata.generator = torch.Generator(device='cpu').manual_seed(0)
             spec_metadata.num_generations = len(
                 scheduled_requests.generation_requests)
             spec_metadata.num_tokens = total_num_tokens

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -1,9 +1,10 @@
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, Optional
 
 import torch
+import flashinfer
 
 from tensorrt_llm._torch.pyexecutor.handle_context_logits import \
     HandleContextLogits
@@ -148,6 +149,160 @@ def top_p_sampling_batch(logits: torch.Tensor, top_p: float = 0.9):
     next_tokens = torch.multinomial(softmax, num_samples=1).squeeze(-1)
     return next_tokens, softmax
 
+def flashinfer_sample(
+    logits: torch.Tensor,
+    k: Optional[torch.Tensor],
+    p: Optional[torch.Tensor],
+    generator: Optional[torch.Generator] = None,
+) -> torch.Tensor:
+    """Sample from the logits using FlashInfer.
+
+    Statistically, this function is equivalent to the `random_sample` function.
+    However, this function is faster because it avoids sorting the logits tensor
+    via rejection sampling.
+
+    NOTE: The outputs of this function do not necessarily match the outputs of
+    the `random_sample` function. It only guarantees that the outputs are
+    statistically equivalent.
+
+    NOTE: This function includes CPU-GPU synchronization, while `random_sample`
+    does not. Call this function at the end of the forward pass to minimize
+    the synchronization overhead.
+    """
+    assert not (k is None and p is None)
+    if k is None:
+        # Top-p only.
+        probs = logits.softmax(dim=-1, dtype=torch.float32)
+        next_token_ids = flashinfer.sampling.top_p_sampling_from_probs(
+            probs, p, deterministic=True, generator=generator)
+    elif p is None:
+        # Top-k only.
+        probs = logits.softmax(dim=-1, dtype=torch.float32)
+        next_token_ids = flashinfer.sampling.top_k_sampling_from_probs(
+            probs, k, deterministic=True, generator=generator)
+    else:
+        # Both top-k and top-p.
+        next_token_ids = flashinfer.sampling.top_k_top_p_sampling_from_logits(
+            logits, k, p, deterministic=True, generator=generator)
+    return next_token_ids.view(-1).long()
+
+def forward_native(
+    logits: torch.Tensor,
+    k: Optional[torch.Tensor],
+    p: Optional[torch.Tensor],
+) -> torch.Tensor:
+    """
+    PyTorch-native implementation of top-k and top-p sampling.
+
+    The logits tensor may be updated in-place.
+    """
+    logits = apply_top_k_top_p(logits, k, p)
+    probs = logits.softmax(dim=-1, dtype=torch.float32)
+    return random_sample(probs)
+
+def random_sample(
+    probs: torch.Tensor,
+) -> torch.Tensor:
+    """Randomly sample from the probabilities.
+
+    We use this function instead of torch.multinomial because torch.multinomial
+    causes CPU-GPU synchronization.
+    """
+    q = torch.empty_like(probs)
+    q.exponential_()
+    return probs.div_(q).argmax(dim=-1).view(-1)
+
+def apply_min_p(
+    logits: torch.Tensor,
+    min_p: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Filters logits using adaptive probability thresholding.
+    """
+    # Convert logits to probability distribution
+    probability_values = torch.nn.functional.softmax(logits, dim=-1)
+    # Calculate maximum probabilities per sequence
+    max_probabilities = torch.amax(probability_values,
+                                    dim=-1,
+                                    keepdim=True)
+    # Reshape min_p for broadcasting
+    adjusted_min_p = min_p.unsqueeze(1) * max_probabilities
+    # Identify valid tokens using threshold comparison
+    valid_token_mask = probability_values >= adjusted_min_p
+    # Apply mask using boolean indexing
+    logits[~valid_token_mask] = -float('inf')
+    return logits
+
+def apply_top_k_top_p(
+    logits: torch.Tensor,
+    k: Optional[torch.Tensor],
+    p: Optional[torch.Tensor],
+) -> torch.Tensor:
+    """Apply top-k and top-p masks to the logits.
+
+    If a top-p is used, this function will sort the logits tensor,
+    which can be slow for large batches.
+
+    The logits tensor may be updated in-place.
+    """
+    logits_sort, logits_idx = logits.sort(dim=-1, descending=False)
+    if k is not None:
+        # Apply top-k.
+        top_k_mask = logits_sort.size(1) - k.to(torch.long)  # shape: B
+        top_k_mask = top_k_mask.clamp(min=0)
+        # Get all the top_k values.
+        top_k_mask = logits_sort.gather(1, top_k_mask.unsqueeze(dim=1))
+        top_k_mask = logits_sort < top_k_mask
+        logits_sort.masked_fill_(top_k_mask, -float("inf"))
+    if p is not None:
+        # Apply top-p.
+        probs_sort = logits_sort.softmax(dim=-1)
+        probs_sum = torch.cumsum(probs_sort, dim=-1, out=probs_sort)
+        top_p_mask = probs_sum <= 1 - p.unsqueeze(dim=1)
+        # at least one
+        top_p_mask[:, -1] = False
+        logits_sort.masked_fill_(top_p_mask, -float("inf"))
+    # Re-sort the probabilities.
+    logits = logits_sort.scatter(dim=-1, index=logits_idx, src=logits_sort)
+    return logits
+
+def greedy_sample(logits: torch.Tensor) -> torch.Tensor:
+    return logits.argmax(dim=-1).view(-1)
+
+def apply_temperature(
+    logits: torch.Tensor,
+    temp: torch.Tensor,
+) -> torch.Tensor:
+    # Use in-place division to avoid creating a new tensor.
+    return logits.div_(temp.unsqueeze(dim=1))
+
+def sampling_batch(
+        logits: torch.Tensor,
+        temperatures: torch.Tensor,
+        top_k: torch.Tensor,
+        top_p: torch.Tensor,
+        min_p: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+    raw_probs = torch.softmax(logits, dim=-1)
+    greedy_sampled = greedy_sample(logits)
+    logits = apply_temperature(logits, temperatures)
+    logits = apply_min_p(logits, min_p)
+    # if not torch.cuda.is_current_stream_capturing():
+    #     generator = torch.Generator(device="cuda")
+    #     generator.manual_seed(0)
+    # next_tokens = flashinfer_sample(adjusted_logits, top_k, top_p, generator)
+    # logits = apply_top_k_top_p(logits, top_k, top_p)
+    random_sampled = forward_native(logits, top_k, top_p)
+    next_tokens = torch.where(
+            temperatures < 1e-5,
+            greedy_sampled,
+            random_sampled,
+            out=greedy_sampled,  # Reuse tensor
+        )
+    token_probs = torch.gather(raw_probs, dim=1,
+                               index=next_tokens.unsqueeze(1)).squeeze(-1)
+    log_probs = torch.log(token_probs)
+    return next_tokens, log_probs
 
 def greedy_search_sampling_batch(logits):
     next_tokens = torch.argmax(logits, dim=-1)

--- a/tensorrt_llm/_torch/speculative/interface.py
+++ b/tensorrt_llm/_torch/speculative/interface.py
@@ -153,6 +153,14 @@ class SpecMetadata:
     seq_lens: Optional[List[int]] = None
     # The gather ids for logits.
     gather_ids: Optional[torch.Tensor] = None
+    # The temperatures for requests.
+    temperatures: Optional[torch.Tensor] = None
+    # The top_k for requests.
+    top_k: Optional[torch.Tensor] = None
+    # The top_p for requests.
+    top_p: Optional[torch.Tensor] = None
+    # The min_p for requests.
+    min_p: Optional[torch.Tensor] = None
     # The number of tokens for speculative model/layer
     num_tokens: int = 0
     # The number of tokens for speculative model/layer of different rank

--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -9,7 +9,7 @@ from tensorrt_llm.bindings.executor import FinishReason
 from ..attention_backend import AttentionMetadata
 from ..pyexecutor.llm_request import LlmRequest, LlmRequestState
 from ..pyexecutor.resource_manager import BaseResourceManager, SlotManager
-from ..pyexecutor.sampler import SampleState, SampleStateTensors, TorchSampler
+from ..pyexecutor.sampler import SampleState, SampleStateTensors, TorchSampler, greedy_search_sampling_batch, sampling_batch
 from ..pyexecutor.scheduler import ScheduledRequests
 from .interface import SpecConfig, SpecMetadata, SpeculativeDecodingMode
 
@@ -863,7 +863,7 @@ class MTPWorker(nn.Module):
                     mtp_num_modules, batch_size, num_contexts, logits.shape[-1])
             else:
                 # Do greedy sampling for the input logits
-                target_tokens = torch.argmax(logits, dim=-1)
+                target_tokens, target_log_probs = sampling_batch(logits, spec_metadata.temperatures, spec_metadata.top_k, spec_metadata.top_p, spec_metadata.min_p)
 
                 # context
                 accepted_tokens[:num_contexts, 0] = target_tokens[:num_contexts]

--- a/tensorrt_llm/llmapi/tokenizer.py
+++ b/tensorrt_llm/llmapi/tokenizer.py
@@ -78,8 +78,10 @@ class TransformersTokenizer(TokenizerBase):
             self,
             ids: Union[int, List[int]],
             skip_special_tokens: bool = False) -> Union[str, List[str]]:
-        return self.tokenizer.convert_ids_to_tokens(
-            ids, skip_special_tokens=skip_special_tokens)
+        # DeepSeek vocabulary has token ids not mapped to any tokens, these will get converted to None
+        # by the tokenizer. We need to filter them out.
+        return [token for token in self.tokenizer.convert_ids_to_tokens(
+            ids, skip_special_tokens=skip_special_tokens) if token is not None]
 
     def convert_tokens_to_string(
             self,


### PR DESCRIPTION
[feat] Implement pytorch sampler for MTP

## Description

Previously, speculative decoding was always greedy and does not support sampling parameters.

This PR implements temperature, top-p, top-k and min-p sampling parameters in python when using MTP speculative decoding (for DeepSeek).

This also adds a log-probs return value from the pytorch sampler (Intended to be used together with #5620)

Future work: support this pytorch sampler for non-MTP models. Figure out why it is faster than the C++ sampler.

## Test Coverage

None