### PR TITLE
[Bug] attention DP doesn't work with embedding TP

### DIFF
--- a/tensorrt_llm/_torch/modules/embedding.py
+++ b/tensorrt_llm/_torch/modules/embedding.py
@@ -37,6 +37,10 @@ class LMHead(Linear):
         mapping = mapping or Mapping()
         tp_size = mapping.tp_size
 
+        # Attention DP doesn't work with embedding parallelization.
+        if mapping.enable_attention_dp:
+            tensor_parallel_mode = None
+
         if tensor_parallel_mode == TensorParallelMode.ROW:
             local_in_features = math.ceil(embedding_dim / tp_size)
             self.padding_size = tp_size * local_in_features - embedding_dim


### PR DESCRIPTION
The embedding TP should be disabled when the attention DP is used. 