### PR TITLE
Refactor the control message transceiver with ZeroMQ

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,3 +20,6 @@
 [submodule "3rdparty/xgrammar"]
 	path = 3rdparty/xgrammar
 	url = https://github.com/mlc-ai/xgrammar.git
+[submodule "3rdparty/cppzmq"]
+	path = 3rdparty/cppzmq
+	url = https://github.com/zeromq/cppzmq.git

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -197,7 +197,8 @@ include_directories(
   ${3RDPARTY_DIR}/cutlass/tools/util/include
   ${3RDPARTY_DIR}/NVTX/include
   ${3RDPARTY_DIR}/json/include
-  ${3RDPARTY_DIR}/pybind11/include)
+  ${3RDPARTY_DIR}/pybind11/include
+  ${3RDPARTY_DIR}/cppzmq)
 
 if(${CUDAToolkit_VERSION} VERSION_GREATER_EQUAL "11")
   add_definitions("-DENABLE_BF16")
@@ -453,6 +454,8 @@ if(ENABLE_UCX)
 else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DENABLE_UCX=0")
 endif()
+
+find_package(cppzmq REQUIRED)
 
 list(APPEND COMMON_HEADER_DIRS)
 include_directories(${COMMON_HEADER_DIRS})

--- a/cpp/tensorrt_llm/batch_manager/CMakeLists.txt
+++ b/cpp/tensorrt_llm/batch_manager/CMakeLists.txt
@@ -38,6 +38,7 @@ set(SRCS
     loraBuffers.cpp
     makeDecodingBatchInputOutput.cpp
     medusaBuffers.cpp
+    metaTransceiver.cpp
     microBatchScheduler.cpp
     pauseRequests.cpp
     peftCacheManager.cpp
@@ -94,6 +95,10 @@ set_property(TARGET ${BATCH_MANAGER_STATIC_TARGET}
 set(TOP_LEVEL_DIR "${PROJECT_SOURCE_DIR}/..")
 target_compile_definitions(${BATCH_MANAGER_STATIC_TARGET}
                            PUBLIC TOP_LEVEL_DIR="${TOP_LEVEL_DIR}")
+
+target_include_directories(${BATCH_MANAGER_STATIC_TARGET}
+                           PUBLIC ${ZeroMQ_INCLUDE_DIRS})
+target_link_libraries(${BATCH_MANAGER_STATIC_TARGET} PUBLIC ${ZeroMQ_LIBRARIES})
 
 if(ENABLE_CUFILE)
   target_link_libraries(${BATCH_MANAGER_STATIC_TARGET} PUBLIC ${CUFILE_LIBRARY})

--- a/cpp/tensorrt_llm/batch_manager/metaTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/metaTransceiver.cpp
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "metaTransceiver.h"
+#include <zmq.hpp>
+
+namespace tensorrt_llm::batch_manager
+{
+void MetaTransceiver::send(void const* data, size_t size)
+{
+    zmq::message_t message(data, size);
+    mSocket.send(message, zmq::send_flags::none);
+    TLLM_LOG_DEBUG("Sent message to IP %s", mEndpoint.c_str());
+}
+
+void MetaTransceiver::recv(void* data, size_t size)
+{
+    zmq::message_t message;
+    mSocket.recv(message, zmq::recv_flags::none);
+    TLLM_CHECK_WITH_INFO(message.size() == size, "Received message size does not match");
+    memcpy(data, message.data(), size);
+    TLLM_LOG_DEBUG("Received message from IP %s", mEndpoint.c_str());
+}
+} // namespace tensorrt_llm::batch_manager

--- a/cpp/tensorrt_llm/batch_manager/metaTransceiver.h
+++ b/cpp/tensorrt_llm/batch_manager/metaTransceiver.h
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include "tensorrt_llm/common/assert.h"
+#include "tensorrt_llm/common/logger.h"
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include <zmq.hpp>
+
+namespace tensorrt_llm::batch_manager
+{
+
+class MetaTransceiver
+{
+public:
+    MetaTransceiver(bool isServer, std::optional<std::string> endpoint = std::nullopt)
+        : mContext(1)
+        , mIsServer(isServer)
+    {
+        if (mIsServer)
+        {
+            mSocket = zmq::socket_t(mContext, zmq::socket_type::sub);
+            if (endpoint)
+            {
+                mSocket.set(zmq::sockopt::subscribe, "");
+                mSocket.bind(endpoint.value());
+                mEndpoint = endpoint.value();
+            }
+            else
+            {
+                mSocket.bind("tcp://127.0.0.1:*");
+                mEndpoint = mSocket.get(zmq::sockopt::last_endpoint);
+            }
+            TLLM_LOG_INFO("MetaTransceiver bound to %s", mEndpoint.c_str());
+        }
+        else
+        {
+            mSocket = zmq::socket_t(mContext, zmq::socket_type::pub);
+        }
+    }
+
+    ~MetaTransceiver()
+    {
+        mSocket.close();
+        mContext.close();
+    }
+
+    void connect(std::string const& endpoint)
+    {
+        mEndpoint = endpoint;
+        TLLM_CHECK_WITH_INFO(!mIsServer, "Only client can connect to an endpoint");
+        mSocket.connect(endpoint);
+    }
+
+    void send(void const* data, size_t size);
+
+    void recv(void* data, size_t size);
+
+    std::string getEndpoint() const
+    {
+        return mEndpoint;
+    }
+
+private:
+    bool mIsServer;
+    zmq::context_t mContext;
+    zmq::socket_t mSocket;
+    std::string mEndpoint;
+};
+} // namespace tensorrt_llm::batch_manager

--- a/cpp/tests/batch_manager/CMakeLists.txt
+++ b/cpp/tests/batch_manager/CMakeLists.txt
@@ -19,3 +19,6 @@ add_gtest(peftCacheManagerTest peftCacheManagerTest.cpp)
 add_gtest(trtEncoderModelTest trtEncoderModelTest.cpp)
 add_gtest(guidedDecoderTest guidedDecoderTest.cpp)
 add_gtest(blockKeyTest blockKeyTest.cpp)
+
+add_gtest(metaTransceiverTest metaTransceiverTest.cpp)
+target_link_libraries(metaTransceiverTest PRIVATE ${ZeroMQ_LIBRARIES})

--- a/cpp/tests/batch_manager/metaTransceiverTest.cpp
+++ b/cpp/tests/batch_manager/metaTransceiverTest.cpp
@@ -1,0 +1,286 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: NVIDIA TensorRT Source Code License Agreement
+ */
+
+#include "tensorrt_llm/batch_manager/metaTransceiver.h"
+#include "tensorrt_llm/batch_manager/dataTransceiver.h"
+#include "tensorrt_llm/common/logger.h"
+#include "tensorrt_llm/runtime/utils/mpiUtils.h"
+
+#include "gtest/gtest.h"
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+
+using namespace tensorrt_llm::batch_manager;
+
+// ---------------------------------------
+//     RealMetaTransceiverTest
+// ---------------------------------------
+
+class RealMetaTransceiverTest : public ::testing::Test
+{
+protected:
+    void SetUp() override {}
+
+    void TearDown() override {}
+
+    size_t setUpCommunicator()
+    {
+        // Initialize MPI for multi-process testing
+        tensorrt_llm::mpi::initialize(tensorrt_llm::mpi::MpiThreadSupport::THREAD_MULTIPLE);
+        mComm = std::addressof(tensorrt_llm::mpi::MpiComm::world());
+        mWorldSize = mComm->getSize();
+        mRank = mComm->getRank();
+
+        // Determine if this process is sender or receiver
+        isSender = mRank % 2 == 0; // Even ranks are senders
+
+        return mWorldSize;
+    }
+
+    void setUpMetaTransceiver()
+    {
+        // Set up ZMQ endpoints based on rank
+        if (isSender)
+        {
+            // Sender process - create MetaTransceiver and connect to receivers
+            mTransceiver = std::make_unique<MetaTransceiver>(false);
+            mTransceiver->connect("tcp://10.78.7.63:5555");
+        }
+        else
+        {
+            // Receiver process - create MetaTransceiver and bind to port
+            mTransceiver = std::make_unique<MetaTransceiver>(true, "tcp://10.78.7.63:5555");
+        }
+    }
+
+    std::string createPlainTestMessage(std::string const& messageType, int messageId)
+    {
+        return "{\"type\":\"" + messageType + "\",\"id\":" + std::to_string(messageId) + "}";
+    }
+
+    RequestInfo createRequestInfo()
+    {
+        auto state = std::make_unique<tensorrt_llm::executor::DataTransceiverState>();
+        state->setCommState(tensorrt_llm::executor::kv_cache::CommState{12, "127.0.0.1"});
+        state->setCacheState(
+            tensorrt_llm::executor::kv_cache::CacheState{10, 12, 128, 128, 8, 8, nvinfer1::DataType::kFLOAT});
+        return RequestInfo{1, *state};
+    }
+
+    bool isSender{false};
+    tensorrt_llm::mpi::MpiComm const* mComm;
+    size_t mWorldSize{0};
+    int mRank{0};
+    std::unique_ptr<MetaTransceiver> mTransceiver;
+};
+
+TEST_F(RealMetaTransceiverTest, BasicSendReceive)
+{
+    auto worldSize = setUpCommunicator();
+    if (worldSize != 2)
+    {
+        GTEST_SKIP() << "mpirun with 2 processes is required to run this test.";
+    }
+
+    setUpMetaTransceiver();
+
+    // Synchronize processes before starting communication
+    mComm->barrier();
+
+    std::string testMessage = createPlainTestMessage("test_request", 1);
+
+    if (isSender)
+    {
+        // Wait for receiver to be ready
+        std::this_thread::sleep_for(std::chrono::seconds(5));
+
+        // Sender process (rank 0)
+        TLLM_LOG_INFO("Sender (rank %d): Sending message to %s", mRank, mTransceiver->getEndpoint().c_str());
+
+        // Send message to receiver
+        mTransceiver->send(testMessage.c_str(), testMessage.size());
+    }
+    else
+    {
+        // Receiver process (rank 1)
+        TLLM_LOG_INFO("Receiver (rank %d): Waiting for message", mRank);
+
+        // Wait for message from sender
+        std::string receivedMessage(testMessage.size(), '\0');
+        mTransceiver->recv(receivedMessage.data(), testMessage.size());
+
+        // Verify received message
+        EXPECT_TRUE(testMessage == receivedMessage);
+    }
+
+    mComm->barrier();
+}
+
+TEST_F(RealMetaTransceiverTest, SerializedSendReceive)
+{
+    auto worldSize = setUpCommunicator();
+    if (worldSize != 2)
+    {
+        GTEST_SKIP() << "mpirun with 2 processes is required to run this test.";
+    }
+
+    setUpMetaTransceiver();
+
+    // Synchronize processes before starting communication
+    mComm->barrier();
+
+    RequestInfo testMessage = createRequestInfo();
+
+    if (isSender)
+    {
+        // Wait for receiver to be ready
+        std::this_thread::sleep_for(std::chrono::seconds(5));
+
+        // Sender process (rank 0)
+        TLLM_LOG_INFO("Sender (rank %d): Sending message to %s", mRank, mTransceiver->getEndpoint().c_str());
+
+        // Send message to receiver
+        std::ostringstream oss;
+        RequestInfo::serialize(testMessage, oss);
+        auto const& serializedInfo = oss.str();
+        mTransceiver->send(serializedInfo.c_str(), serializedInfo.size());
+    }
+    else
+    {
+        // Receiver process (rank 1)
+        TLLM_LOG_INFO("Receiver (rank %d): Waiting for message", mRank);
+
+        // Wait for message from sender
+        std::ostringstream oss;
+        RequestInfo::serialize(testMessage, oss);
+        size_t messageSize = RequestInfo::serializedSize(testMessage);
+
+        std::string serializedInfo;
+        serializedInfo.resize(messageSize);
+        mTransceiver->recv(serializedInfo.data(), messageSize);
+        std::istringstream iss(serializedInfo);
+        auto receivedMessage = RequestInfo::deserialize(iss);
+
+        // Verify received message
+        EXPECT_TRUE(testMessage == receivedMessage);
+    }
+
+    mComm->barrier();
+}
+
+// TEST_F(RealMetaTransceiverTest, AsyncCommunication)
+// {
+//     auto worldSize = setUpCommunicator();
+//     if (worldSize != 2)
+//     {
+//         GTEST_SKIP() << "mpirun with 2 processes is required to run this test.";
+//     }
+
+//     setUpMetaTransceiver();
+//     mComm->barrier();
+
+//     if (isSender)
+//     {
+//         // Launch async send operations
+//         std::string executorId = "executor_1";
+//         std::vector<std::future<void>> sendFutures;
+//         std::vector<std::future<std::string>> receiveFutures;
+
+//         for (int i = 0; i < 3; ++i)
+//         {
+//             // Async send
+//             sendFutures.push_back(std::async(std::launch::async, [this, executorId, i]()
+//             {
+//                 std::string message = createTestMessage("async_request", i);
+//                 mTransceiver->send(executorId, message);
+//             }));
+
+//             // Async receive
+//             receiveFutures.push_back(std::async(std::launch::async, [this, executorId]() -> std::string
+//             {
+//                 std::string response;
+//                 return mTransceiver->receive(executorId, response);
+//             }));
+//         }
+
+//         // Wait for all operations to complete
+//         for (auto& future : sendFutures)
+//         {
+//             future.get();
+//         }
+
+//         for (int i = 0; i < 3; ++i)
+//         {
+//             auto response = receiveFutures[i].get();
+//             EXPECT_TRUE(response.find("async_response") != std::string::npos);
+//         }
+//     }
+//     else
+//     {
+//         // Handle async requests
+//         for (int i = 0; i < 3; ++i)
+//         {
+//             std::string receivedMessage;
+//             auto message = mTransceiver->receive("", receivedMessage);
+
+//             EXPECT_TRUE(message.find("async_request") != std::string::npos);
+
+//             // Send async response
+//             std::string responseMessage = createTestMessage("async_response", i);
+//             std::string senderExecutorId = "executor_0";
+//             mTransceiver->send(senderExecutorId, responseMessage);
+//         }
+//     }
+
+//     mComm->barrier();
+// }
+
+// // Test with 4 processes (2 senders, 2 receivers)
+// TEST_F(RealMetaTransceiverTest, MultiProcessCommunication)
+// {
+//     auto worldSize = setUpCommunicator();
+//     if (worldSize != 4)
+//     {
+//         GTEST_SKIP() << "mpirun with 4 processes is required to run this test.";
+//     }
+
+//     setUpMetaTransceiver();
+//     mComm->barrier();
+
+//     if (isSender)
+//     {
+//         // Sender processes (rank 0, 2)
+//         int receiverRank = mRank + 1;  // Send to next rank
+//         std::string executorId = "executor_" + std::to_string(receiverRank);
+//         std::string testMessage = createTestMessage("multi_request", mRank);
+
+//         mTransceiver->send(executorId, testMessage);
+
+//         std::string response;
+//         auto receivedMessage = mTransceiver->receive(executorId, response);
+
+//         EXPECT_TRUE(receivedMessage.find("multi_response") != std::string::npos);
+//         EXPECT_TRUE(receivedMessage.find("sender_rank\":" + std::to_string(receiverRank)) != std::string::npos);
+//     }
+//     else
+//     {
+//         // Receiver processes (rank 1, 3)
+//         std::string receivedMessage;
+//         auto message = mTransceiver->receive("", receivedMessage);
+
+//         EXPECT_TRUE(message.find("multi_request") != std::string::npos);
+
+//         // Send response back to sender
+//         int senderRank = mRank - 1;  // Send to previous rank
+//         std::string senderExecutorId = "executor_" + std::to_string(senderRank);
+//         std::string responseMessage = createTestMessage("multi_response", mRank);
+//         mTransceiver->send(senderExecutorId, responseMessage);
+//     }
+
+//     mComm->barrier();
+// }


### PR DESCRIPTION
# Refactor the control message transceiver with ZeroMQ


## Description

In current implementation, we use ucxx connection for both control message and kv cache data. In order to decouple the control message and support more flexibility, we use ZeroMQ to transfer any type of metadata. 

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
