### PR TITLE
feat: Add Qwen3 model support

### DIFF
--- a/tensorrt_llm/models/__init__.py
+++ b/tensorrt_llm/models/__init__.py
@@ -193,6 +193,7 @@ MODEL_MAP = {
     'Qwen2ForSequenceClassification': QWenForCausalLM,
     'Qwen2VLForConditionalGeneration': QWenForCausalLM,
     'Qwen2VLModel': QWenForCausalLM,
+    'Qwen3ForCausalLM': QWenForCausalLM,
     'WhisperEncoder': WhisperEncoder,
     'EncoderModel': EncoderModel,
     'DecoderModel': DecoderModel,

--- a/tensorrt_llm/models/qwen/config.py
+++ b/tensorrt_llm/models/qwen/config.py
@@ -105,7 +105,7 @@ class QWenConfig(PretrainedConfig):
             hf_config.architectures = ['Qwen2ForCausalLM']
 
         valid_types = ('qwen', 'qwen2', 'qwen2_moe', 'qwen2_llava_onevision',
-                       'qwen2_vl', 'qwen2_audio')
+                       'qwen2_vl', 'qwen2_audio', 'qwen3', 'qwen3_moe')
         assert qwen_type in valid_types, f"Unsupported Qwen type: {qwen_type}, only {valid_types} are acceptable."
         num_key_value_heads = getattr(hf_config, "num_key_value_heads",
                                       hf_config.num_attention_heads)
@@ -114,7 +114,12 @@ class QWenConfig(PretrainedConfig):
         hidden_act = getattr(hf_config, "hidden_act", "silu")
         if qwen_type == "qwen2_moe":
             hidden_act = "swiglu"
-        attn_bias = True  # All existing Qwen models have attn bias
+        
+        # Qwen3 models have no attention bias, while legacy models have bias
+        if qwen_type in ('qwen3', 'qwen3_moe'):
+            attn_bias = False  # Qwen3 models have no attn bias
+        else:
+            attn_bias = True  # Legacy Qwen models have attn bias
         rotary_scaling = getattr(hf_config, "rope_scaling", None)
         seq_length = getattr(hf_config, "seq_length", 8192)
         use_logn_attn = getattr(hf_config, "use_logn_attn", False)

--- a/tensorrt_llm/models/qwen/convert.py
+++ b/tensorrt_llm/models/qwen/convert.py
@@ -655,6 +655,24 @@ def convert_hf_qwen(hf_model,
                                        plugin_weight_only_quant_type, dtype,
                                        use_gemm_woq_plugin))
 
+        # Qwen3: Add q_norm and k_norm weight conversion
+        if qwen_type in ('qwen3', 'qwen3_moe'):
+            # Process q_norm.weight
+            q_norm_weight = get_weight(model_params, prefix + key_list[0] + 'q_norm', dtype)
+            weights.update(
+                get_tllm_linear_weight(q_norm_weight, tllm_prex + 'attention.q_layernorm.',
+                                       None, False,  # LayerNorm should not be quantized
+                                       plugin_weight_only_quant_type, dtype,
+                                       use_gemm_woq_plugin))
+            
+            # Process k_norm.weight  
+            k_norm_weight = get_weight(model_params, prefix + key_list[0] + 'k_norm', dtype)
+            weights.update(
+                get_tllm_linear_weight(k_norm_weight, tllm_prex + 'attention.k_layernorm.',
+                                       None, False,  # LayerNorm should not be quantized
+                                       plugin_weight_only_quant_type, dtype,
+                                       use_gemm_woq_plugin))
+
         if qwen_type == "qwen2_moe" and moe_config and moe_config.has_moe():
 
             # shared_expert for qwen2_moe
@@ -1039,7 +1057,7 @@ def load_weights_from_hf_gptq_model(hf_model, config: QWenConfig):
 
     model_params = {k: v for k, v in hf_model.state_dict().items()}
     torch.cuda.empty_cache()
-    valid_types = ('qwen', 'qwen2', 'qwen2_vl')
+    valid_types = ('qwen', 'qwen2', 'qwen2_vl', 'qwen3', 'qwen3_moe')
     assert qwen_type in valid_types, f"Unsupported Qwen type: {qwen_type}, only {valid_types} are supported for GPTQ."
     layer_prefix = "transformer.h." if qwen_type == 'qwen' else "model.layers."
     key_list = get_qwen_key_list(qwen_type)


### PR DESCRIPTION
- Add Qwen3ForCausalLM mapping in models/__init__.py
- Update config.py to support Qwen3 architecture with qwen3/qwen3_moe types
- Add Qwen3 weight conversion logic in convert.py
- Implement Qwen3-specific model modifications in model.py
- Support attention_bias=False and qk_layernorm=True for Qwen3
- Enable FP16 and FP8 quantization for Qwen3
