### PR TITLE
test: Validate and add accuracy& perf tests for Ministral-8B-Instruct[-FP8](pytorch only)

### DIFF
--- a/tests/integration/defs/accuracy/references/gsm8k.yaml
+++ b/tests/integration/defs/accuracy/references/gsm8k.yaml
@@ -108,3 +108,8 @@ speakleash/Bielik-11B-v2.2-Instruct:
     accuracy: 40.41
 google/gemma-3-1b-it:
   - accuracy: 25.52 # score getting from lm-eval with HF implementation
+mistralai/Ministral-8B-Instruct-2410:
+  - accuracy: 79.25
+  - quant_algo: FP8
+    kv_cache_quant_algo: FP8
+    accuracy: 78.35

--- a/tests/integration/defs/accuracy/references/mmlu.yaml
+++ b/tests/integration/defs/accuracy/references/mmlu.yaml
@@ -188,3 +188,8 @@ speakleash/Bielik-11B-v2.2-Instruct:
   - quant_algo: FP8
     kv_cache_quant_algo: FP8
     accuracy: 64.36
+mistralai/Ministral-8B-Instruct-2410:
+  - accuracy: 66.35
+  - quant_algo: FP8
+    kv_cache_quant_algo: FP8
+    accuracy: 65.96

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -463,15 +463,6 @@ class TestMinistral8BInstruct(LlmapiAccuracyTestHarness):
             task = MMLU(self.MODEL_NAME)
             task.evaluate(llm)
 
-    def test_auto_dtype_comprehensive(self):
-        with LLM(self.MODEL_PATH) as llm:
-            # Test multiple datasets for comprehensive evaluation
-            task = MMLU(self.MODEL_NAME)
-            task.evaluate(llm)
-
-            task = GSM8K(self.MODEL_NAME)
-            task.evaluate(llm)
-
     @skip_pre_ada
     def test_fp8(self):
         # Test with FP8 quantization if pre-quantized model is available

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -451,6 +451,42 @@ class TestMistral7B(LlmapiAccuracyTestHarness):
             task.evaluate(llm)
 
 
+class TestMinistral8BInstruct(LlmapiAccuracyTestHarness):
+    MODEL_NAME = "mistralai/Ministral-8B-Instruct-2410"
+    MODEL_PATH = f"{llm_models_root()}/Ministral-8B-Instruct-2410"
+
+    def test_auto_dtype_gsm8k(self):
+        with LLM(self.MODEL_PATH) as llm:
+            task = GSM8K(self.MODEL_NAME)
+            task.evaluate(llm)
+
+            task = MMLU(self.MODEL_NAME)
+            task.evaluate(llm)
+
+    def test_auto_dtype_comprehensive(self):
+        with LLM(self.MODEL_PATH) as llm:
+            # Test multiple datasets for comprehensive evaluation
+            task = MMLU(self.MODEL_NAME)
+            task.evaluate(llm)
+
+            task = GSM8K(self.MODEL_NAME)
+            task.evaluate(llm)
+
+    @skip_pre_ada
+    def test_fp8(self):
+        # Test with FP8 quantization if pre-quantized model is available
+        model_path = f"{llm_models_root()}/Ministral-8B-Instruct-2410-FP8"
+        try:
+            with LLM(model_path) as llm:
+                assert llm.args.quant_config.quant_algo == QuantAlgo.FP8
+                task = GSM8K(self.MODEL_NAME)
+                task.evaluate(llm)
+                task = MMLU(self.MODEL_NAME)
+                task.evaluate(llm)
+        except (FileNotFoundError, OSError):
+            pytest.skip("FP8 pre-quantized Ministral-8B model not available")
+
+
 class TestGemma3_1BInstruct(LlmapiAccuracyTestHarness):
     MODEL_NAME = "google/gemma-3-1b-it"
     MODEL_PATH = f"{llm_models_root()}/gemma/gemma-3-1b-it/"

--- a/tests/integration/defs/perf/pytorch_model_config.py
+++ b/tests/integration/defs/perf/pytorch_model_config.py
@@ -150,13 +150,7 @@ def get_model_yaml_config(model_label: str,
         lora_config = {
             'lora_config': {
                 'lora_dir': lora_dirs if lora_dirs is not None else [],
-                'max_lora_rank': 64,
-                'lora_target_modules': ['attn_q', 'attn_k', 'attn_v'],
-                'trtllm_modules_to_hf_modules': {
-                    "attn_q": "q_proj",
-                    "attn_k": "k_proj",
-                    "attn_v": "v_proj"
-                }
+                'max_lora_rank': 64
             }
         }
         base_config.update(lora_config)

--- a/tests/integration/defs/perf/test_perf.py
+++ b/tests/integration/defs/perf/test_perf.py
@@ -78,6 +78,8 @@ MODEL_PATH_DICT = {
     "modelopt-hf-model-hub/Mixtral-8x7B-Instruct-v0.1-fp4",
     "mixtral_8x22b_v0.1": "Mixtral-8x22B-v0.1",
     "mistral_7b_v0.1": "mistral-7b-v0.1",
+    "ministral_8b": "Ministral-8B-Instruct-2410",
+    "ministral_8b_fp8": "Ministral-8B-Instruct-2410-FP8",
     "deepseek_r1_fp8": "DeepSeek-R1/DeepSeek-R1",
     "deepseek_r1_nvfp4": "DeepSeek-R1/DeepSeek-R1-FP4",
     "deepseek_v3_lite_fp8": "DeepSeek-V3-Lite/fp8",
@@ -131,6 +133,7 @@ HF_MODEL_PATH = {
     "mixtral_8x7b_v0.1_hf": "mistralai/Mixtral-8x7B-v0.1",
     "mixtral_8x7b_v0.1_instruct_hf": "mistralai/Mixtral-8x7B-Instruct-v0.1",
     "mistral_7b_v0.1_hf": "mistralai/Mistral-7B-v0.1",
+    "ministral_8b_hf": "mistralai/Ministral-8B-Instruct-2410",
     "flan_t5_base_hf": "google/flan-t5-small",
     "phi_4_mini_instruct_hf": "microsoft/Phi-4-mini-instruct",
 }

--- a/tests/integration/defs/perf/test_perf.py
+++ b/tests/integration/defs/perf/test_perf.py
@@ -141,6 +141,8 @@ LORA_MODEL_PATH = {
     "llama_v2_13b": "llama-models-v2/chinese-llama-2-lora-13b",
     "mixtral_8x7b_0.1": "chinese-mixtral-lora",
     "llama_v3.1_8b_instruct_fp8": "lora/llama-3-chinese-8b-instruct-v2-lora/",
+    "ministral_8b":
+    "lora/ministral/Ministral-8B-Instruct-2410-Loras-Dummy",  # Dummy LoRA for Ministral
 }
 
 TIMING_CACHE_DIR = os.environ.get("TIMING_CACHE_DIR", "")

--- a/tests/integration/test_lists/qa/trt_llm_release_perf_test.yml
+++ b/tests/integration/test_lists/qa/trt_llm_release_perf_test.yml
@@ -50,7 +50,7 @@ trt_llm_release_perf_test:
   - perf/test_perf.py::test_perf[ministral_8b_fp8-bench-pytorch-float8-input_output_len:500,2000-reqs:500-con:250]
 
   # Ministral-8B LoRA tests (using dummy Mistral LoRA checkpoint)
-  - perf/test_perf.py::test_perf[ministral_8b-bench-pytorch-bfloat16-input_output_len:128,128-loras:1-reqs:100-con:2]
+  - perf/test_perf.py::test_perf[ministral_8b-bench-pytorch-bfloat16-maxbs:2-maxnt:1024-input_output_len:128,128-loras:1-reqs:8-con:2]
 
   # E2E ENC-DEC
   - perf/test_perf.py::test_perf[bart_large_cnn-cppmanager-exe-plugin_ifb-float16-input_output_len:128,20]

--- a/tests/integration/test_lists/qa/trt_llm_release_perf_test.yml
+++ b/tests/integration/test_lists/qa/trt_llm_release_perf_test.yml
@@ -53,6 +53,9 @@ trt_llm_release_perf_test:
   - perf/test_perf.py::test_perf[ministral_8b_fp8-bench-pytorch-float8-input_output_len:512,32-reqs:500-con:250]
   - perf/test_perf.py::test_perf[ministral_8b_fp8-bench-pytorch-streaming-float8-input_output_len:128,128]
 
+  # Ministral-8B LoRA tests (using dummy Mistral LoRA checkpoint)
+  - perf/test_perf.py::test_perf[ministral_8b-bench-pytorch-bfloat16-input_output_len:128,128-loras:1-reqs:100-con:2]
+
   # E2E ENC-DEC
   - perf/test_perf.py::test_perf[bart_large_cnn-cppmanager-exe-plugin_ifb-float16-input_output_len:128,20]
   - perf/test_perf.py::test_perf[mbart_large_50_many_to_one_mmt-cppmanager-exe-plugin_ifb-float16-input_output_len:128,20]

--- a/tests/integration/test_lists/qa/trt_llm_release_perf_test.yml
+++ b/tests/integration/test_lists/qa/trt_llm_release_perf_test.yml
@@ -38,20 +38,16 @@ trt_llm_release_perf_test:
   - perf/test_perf.py::test_perf[mistral_7b_v0.1-bench-float16-input_output_len:128,128]
 
   # Ministral-8B
-  - perf/test_perf.py::test_perf[ministral_8b-bench-pytorch-bfloat16-maxbs:512-maxnt:5000-input_output_len:5000,500-reqs:8-con:1]
-  - perf/test_perf.py::test_perf[ministral_8b-bench-pytorch-bfloat16-input_output_len:128,128-reqs:8-con:1]
-  - perf/test_perf.py::test_perf[ministral_8b-bench-pytorch-bfloat16-input_output_len:512,32-reqs:8-con:1]
-  - perf/test_perf.py::test_perf[ministral_8b-bench-pytorch-bfloat16-input_output_len:128,128-reqs:500-con:250]
-  - perf/test_perf.py::test_perf[ministral_8b-bench-pytorch-bfloat16-input_output_len:512,32-reqs:500-con:250]
-  - perf/test_perf.py::test_perf[ministral_8b-bench-pytorch-streaming-bfloat16-input_output_len:128,128]
+  - perf/test_perf.py::test_perf[ministral_8b-bench-pytorch-bfloat16-maxbs:1-maxnt:5000-input_output_len:5000,500-reqs:8-con:1]
+  - perf/test_perf.py::test_perf[ministral_8b-bench-pytorch-bfloat16-maxbs:1-input_output_len:500,2000-reqs:8-con:1]
+  - perf/test_perf.py::test_perf[ministral_8b-bench-pytorch-bfloat16-maxnt:5000-input_output_len:5000,500-reqs:500-con:250]
+  - perf/test_perf.py::test_perf[ministral_8b-bench-pytorch-bfloat16-input_output_len:500,2000-reqs:500-con:250]
 
   # Ministral-8B FP8
-  - perf/test_perf.py::test_perf[ministral_8b_fp8-bench-pytorch-float8-maxbs:512-maxnt:5000-input_output_len:5000,500-reqs:8-con:1]
-  - perf/test_perf.py::test_perf[ministral_8b_fp8-bench-pytorch-float8-input_output_len:128,128-reqs:8-con:1]
-  - perf/test_perf.py::test_perf[ministral_8b_fp8-bench-pytorch-float8-input_output_len:512,32-reqs:8-con:1]
-  - perf/test_perf.py::test_perf[ministral_8b_fp8-bench-pytorch-float8-input_output_len:128,128-reqs:500-con:250]
-  - perf/test_perf.py::test_perf[ministral_8b_fp8-bench-pytorch-float8-input_output_len:512,32-reqs:500-con:250]
-  - perf/test_perf.py::test_perf[ministral_8b_fp8-bench-pytorch-streaming-float8-input_output_len:128,128]
+  - perf/test_perf.py::test_perf[ministral_8b_fp8-bench-pytorch-float8-maxbs:1-maxnt:5000-input_output_len:5000,500-reqs:8-con:1]
+  - perf/test_perf.py::test_perf[ministral_8b_fp8-bench-pytorch-float8-maxbs:1-input_output_len:500,2000-reqs:8-con:1]
+  - perf/test_perf.py::test_perf[ministral_8b_fp8-bench-pytorch-float8-maxnt:5000-input_output_len:5000,500-reqs:500-con:250]
+  - perf/test_perf.py::test_perf[ministral_8b_fp8-bench-pytorch-float8-input_output_len:500,2000-reqs:500-con:250]
 
   # Ministral-8B LoRA tests (using dummy Mistral LoRA checkpoint)
   - perf/test_perf.py::test_perf[ministral_8b-bench-pytorch-bfloat16-input_output_len:128,128-loras:1-reqs:100-con:2]

--- a/tests/integration/test_lists/qa/trt_llm_release_perf_test.yml
+++ b/tests/integration/test_lists/qa/trt_llm_release_perf_test.yml
@@ -37,6 +37,22 @@ trt_llm_release_perf_test:
   - perf/test_perf.py::test_perf[starcoder2_3b-bench-pytorch-float16-input_output_len:512,200]
   - perf/test_perf.py::test_perf[mistral_7b_v0.1-bench-float16-input_output_len:128,128]
 
+  # Ministral-8B
+  - perf/test_perf.py::test_perf[ministral_8b-bench-pytorch-bfloat16-maxbs:512-maxnt:5000-input_output_len:5000,500-reqs:8-con:1]
+  - perf/test_perf.py::test_perf[ministral_8b-bench-pytorch-bfloat16-input_output_len:128,128-reqs:8-con:1]
+  - perf/test_perf.py::test_perf[ministral_8b-bench-pytorch-bfloat16-input_output_len:512,32-reqs:8-con:1]
+  - perf/test_perf.py::test_perf[ministral_8b-bench-pytorch-bfloat16-input_output_len:128,128-reqs:500-con:250]
+  - perf/test_perf.py::test_perf[ministral_8b-bench-pytorch-bfloat16-input_output_len:512,32-reqs:500-con:250]
+  - perf/test_perf.py::test_perf[ministral_8b-bench-pytorch-streaming-bfloat16-input_output_len:128,128]
+
+  # Ministral-8B FP8
+  - perf/test_perf.py::test_perf[ministral_8b_fp8-bench-pytorch-float8-maxbs:512-maxnt:5000-input_output_len:5000,500-reqs:8-con:1]
+  - perf/test_perf.py::test_perf[ministral_8b_fp8-bench-pytorch-float8-input_output_len:128,128-reqs:8-con:1]
+  - perf/test_perf.py::test_perf[ministral_8b_fp8-bench-pytorch-float8-input_output_len:512,32-reqs:8-con:1]
+  - perf/test_perf.py::test_perf[ministral_8b_fp8-bench-pytorch-float8-input_output_len:128,128-reqs:500-con:250]
+  - perf/test_perf.py::test_perf[ministral_8b_fp8-bench-pytorch-float8-input_output_len:512,32-reqs:500-con:250]
+  - perf/test_perf.py::test_perf[ministral_8b_fp8-bench-pytorch-streaming-float8-input_output_len:128,128]
+
   # E2E ENC-DEC
   - perf/test_perf.py::test_perf[bart_large_cnn-cppmanager-exe-plugin_ifb-float16-input_output_len:128,20]
   - perf/test_perf.py::test_perf[mbart_large_50_many_to_one_mmt-cppmanager-exe-plugin_ifb-float16-input_output_len:128,20]


### PR DESCRIPTION
- [x] Manually quantize using modelopt and add pre-quantized fp8 checkpoints of ministral-8b-instruct to model cache
- [x] Add perf tests (low-conc, high-conc) for both bf16 and fp8 
- [x] Validate perf tests run on Hopper, Blackwell
- [x] Add Accuracy tests (GSM8k, MMLU) for ministral-8b 16-bit and 8-bit
- [x] Validate accuracy tests on hopper, blackwell
- [x] Generate dummy LoRA checkpoints for ministral and add it in model cache : https://gitlab-master.nvidia.com/ftp/llm-models/-/merge_requests/341/diffs 
- [x] Add LoRA perf tests
- [x] Validate LoRA works

---


## Perf summary

| Test Configuration | Throughput (tps) | Latency (ms) |
|-------------------|------------------|--------------|
| **Ministral-8B BF16** | | |
| 5000/500, 8req, con:1 | 91.7 | 5,455 |
| 500/2000, 8req, con:1 | 95.9 | 20,855 |
| 5000/500, 500req, con:250 | 82 | 1,134,834|
| 500/2000, 500req, con:250 | 3751 | 108,828 |
| **Ministral-8B FP8** | | |
| 5000/500, 8req, con:1 | 158.2 | 3,161 |
| 500/2000, 8req, con:1 | 163.7 | 12,219 |
| 5000/500, 500req, con:250 | 140.8 | 665,924 |
| 500/2000, 500req, con:250 | 7,866 | 63,184 |
| **Ministral-8B LoRA** | | |
| 128/128, 8req, con:2, bs:2 | 191.7 | 1,205 |

**Legend:** `input_len/output_len, requests, concurrency`