### PR TITLE
[None][infra] Update the auto-community label action to be triggered every hour

### DIFF
--- a/.github/scripts/label_community_user.py
+++ b/.github/scripts/label_community_user.py
@@ -201,7 +201,6 @@ def main():
         pr_author = pr["user"]["login"]
         existing_labels = {label["name"] for label in pr["labels"]}
 
-        # skip if already has the community label
         if community_label in existing_labels:
             print(
                 f"PR #{pr_number} by {pr_author} already has community label, skipping"

--- a/.github/workflows/label_community_pr.yml
+++ b/.github/workflows/label_community_pr.yml
@@ -2,7 +2,7 @@ name: Label Community PR
 
 on:
   schedule:
-    - cron: '5 * * * *'  # every 5 minutes
+    - cron: '0 * * * *'  # every hour at minute 0
   workflow_dispatch:     # manual trigger option
     inputs:
       time_window_minutes:

--- a/.github/workflows/label_community_pr.yml
+++ b/.github/workflows/label_community_pr.yml
@@ -1,8 +1,9 @@
 name: Label Community PR
 
 on:
-  pull_request:
-    types: [opened]
+  schedule:
+    - cron: '0 * * * *'  # every hour at minute 0
+  workflow_dispatch:     # manual trigger option
 
 jobs:
   label_pr:
@@ -22,9 +23,7 @@ jobs:
       - name: Run labeling script
         env:
           AUTO_LABEL_COMMUNITY_TOKEN: ${{ secrets.AUTO_LABEL_COMMUNITY_TOKEN }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO_OWNER: ${{ github.event.repository.owner.login }}
+          REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
           COMMUNITY_LABEL: "Community want to contribute"
         run: python .github/scripts/label_community_user.py

--- a/.github/workflows/label_community_pr.yml
+++ b/.github/workflows/label_community_pr.yml
@@ -2,8 +2,14 @@ name: Label Community PR
 
 on:
   schedule:
-    - cron: '0 * * * *'  # every hour at minute 0
+    - cron: '5 * * * *'  # every 5 minutes
   workflow_dispatch:     # manual trigger option
+    inputs:
+      time_window_minutes:
+        description: 'Time window in minutes to look back for PRs'
+        required: false
+        default: 65
+        type: number
 
 jobs:
   label_pr:
@@ -26,4 +32,5 @@ jobs:
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
           COMMUNITY_LABEL: "Community want to contribute"
+          TIME_WINDOW_MINUTES: ${{ inputs.time_window_minutes || 65 }}
         run: python .github/scripts/label_community_user.py


### PR DESCRIPTION
## Description

[Previous attempt](https://github.com/NVIDIA/TensorRT-LLM/pull/4883) to label the community PRs is unsuccessful because in github, the actions are executed under the fork's context. Which means that the token we've set in the `NVIDIA/TensorRT-LLM` repo won't be accessible by the github action due to [security reasons](https://stackoverflow.com/questions/76952023/how-to-make-github-actions-safely-access-secrets-for-prs-created-from-forks). See also [this run](https://github.com/NVIDIA/TensorRT-LLM/actions/runs/16011484207/job/45170002724). You can see the `AUTO_COMMUNITY_LABEL_TOKEN` was passed into the github action with an empty value, while a non-empty value was set. 
```
Run python .github/scripts/label_community_user.py
  python .github/scripts/label_community_user.py
  shell: /usr/bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/[3](https://github.com/NVIDIA/TensorRT-LLM/actions/runs/16011484207/job/45170002724#step:5:3).13.5/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.13.5/x6[4](https://github.com/NVIDIA/TensorRT-LLM/actions/runs/16011484207/job/45170002724#step:5:4)/lib
    AUTO_LABEL_COMMUNITY_TOKEN: 
    PR_AUTHOR: venkywonka
    PR_NUMBER: [5](https://github.com/NVIDIA/TensorRT-LLM/actions/runs/16011484207/job/45170002724#step:5:5)654
    REPO_OWNER: NVIDIA
    REPO_NAME: TensorRT-LLM
    COMMUNITY_LABEL: Community want to contribute
Traceback (most recent call last):
  File "/home/runner/work/TensorRT-LLM/TensorRT-LLM/.github/scripts/label_community_user.py", line [8](https://github.com/NVIDIA/TensorRT-LLM/actions/runs/16011484207/job/45170002724#step:5:8), in <module>
    assert AUTO_LABEL_COMMUNITY_TOKEN, "AUTO_LABEL_COMMUNITY_TOKEN environment variable not set"
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: AUTO_LABEL_COMMUNITY_TOKEN environment variable not set
```

As the solution, we plan to change the event trigger from "every PR creation" into "every hour". This way, the github action will be run under the base repo's context, and we can successfully access the secret token without exposing. 

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
