### PR TITLE
MTP and derivatives: Align sample state with trtllm sampler sample state

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -25,6 +25,7 @@ LlmRequestType = tensorrt_llm.bindings.internal.batch_manager.LlmRequestType
 ExecutorRequest = tllm_executor.Request
 ExecutorResponse = tllm_executor.Response
 ExecutorSamplingConfig = tllm_executor.SamplingConfig
+FinishReason = tllm_executor.FinishReason
 
 REQUEST_TYPE_MAPPING = {
     tllm_executor.RequestType.REQUEST_TYPE_CONTEXT_AND_GENERATION:
@@ -318,6 +319,11 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
     @property
     def is_dummy(self):
         return self.is_attention_dp_dummy or self.is_cuda_graph_dummy or self.is_dummy_request
+
+    def finish_by(self, reason: FinishReason, beam: int) -> None:
+        """CPP finish by reason does not support beam_width > 1"""
+        self.state = LlmRequestState.GENERATION_COMPLETE
+        self.set_finished_reason(reason, beam)
 
 
 def convert_wordlist(word_list) -> List[List[int]]:

--- a/tensorrt_llm/_torch/speculative/eagle3.py
+++ b/tensorrt_llm/_torch/speculative/eagle3.py
@@ -472,12 +472,14 @@ class Eagle3OneModelWorker(nn.Module):
                 Draft token ids. Flattened.
         '''
 
-        draft_tokens = torch.argmax(logits, dim=-1).type(torch.int32)
+        draft_tokens = torch.argmax(logits, dim=-1)
 
         # Apply d2t (offsets between draft model dictionary and main model dictionary).
         if hasattr(draft_model.model,
                    "d2t") and draft_model.model.d2t is not None:
             draft_tokens = draft_model.model.d2t[draft_tokens] + draft_tokens
+
+        draft_tokens = draft_tokens.type(torch.int32)
 
         return draft_tokens
 

--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -304,7 +304,7 @@ class MTPSampler(TorchSampler):
             self._request_common_handling(req, next_draft_tokens_list)
 
     def sample_async(self, scheduled_requests: ScheduledRequests,
-                     outputs) -> SampleStateMTP:
+                     outputs: dict[str, torch.Tensor]) -> SampleStateMTP:
         # new_tokens_device: accepted tokens, device tensor, shape: batch_size, nextn + 1
         # new_tokens_lens_device: accepted lengths, device tensor, shape: batch_size
         # next_draft_tokens_device: predicted draft tokens, device tensor, shape: batch_size, nextn
@@ -316,8 +316,10 @@ class MTPSampler(TorchSampler):
 
         o_new_tokens = outputs['new_tokens'][:len(requests)]
         o_new_tokens_lens = outputs['new_tokens_lens'][:len(requests)]
-        o_next_draft_tokens = outputs['next_draft_tokens'][:len(requests)]
-        o_next_new_tokens = outputs['next_new_tokens'][:len(requests)]
+        o_next_draft_tokens = outputs['next_draft_tokens'][:len(requests)].to(
+            dtype=torch.int, non_blocking=True)
+        o_next_new_tokens = outputs['next_new_tokens'][:len(requests)].to(
+            dtype=torch.int, non_blocking=True)
 
         new_tokens = self.store.new_tokens
         next_new_tokens = self.store.next_new_tokens

--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -316,10 +316,8 @@ class MTPSampler(TorchSampler):
 
         o_new_tokens = outputs['new_tokens'][:len(requests)]
         o_new_tokens_lens = outputs['new_tokens_lens'][:len(requests)]
-        o_next_draft_tokens = outputs['next_draft_tokens'][:len(requests)].to(
-            dtype=torch.int, non_blocking=True)
-        o_next_new_tokens = outputs['next_new_tokens'][:len(requests)].to(
-            dtype=torch.int, non_blocking=True)
+        o_next_draft_tokens = outputs['next_draft_tokens'][:len(requests)]
+        o_next_new_tokens = outputs['next_new_tokens'][:len(requests)]
 
         new_tokens = self.store.new_tokens
         next_new_tokens = self.store.next_new_tokens


### PR DESCRIPTION
This PR moves MTPSampler and derivatives to use the universal `seq_slot` indexing for sampling. 
This is the last piece of the puzzle: After this, *all* of the samplers will use this format.
See: https://github.com/NVIDIA/TensorRT-LLM/commit/6ee94c7ac89f3b2beb1d44f6dc44135464891e3b

Running trtllm-bench on `/home/scratch.trt_llm_data/llm-models/DeepSeek-V3-Lite/fp8`:
<details>
<summary>Script</summary>

```shell
#!/bin/bash
set -x
set -e

folder_model=/home/scratch.trt_llm_data/llm-models/DeepSeek-V3-Lite/fp8
input_len=512
output_len=512
concurrency=24
dataset=./dataset_fp8kv.txt

python3 benchmarks/cpp/prepare_dataset.py --tokenizer=${folder_model} --stdout token-norm-dist --num-requests=$((concurrency * 2)) --input-mean=${input_len} --output-mean=${output_len} --input-stdev=0 --output-stdev=0 > ${dataset}

config=./config.yml
cat > ${config} << EOF
cuda_graph_config:
padding_enabled: true
batch_sizes: [1, 2, 4, 8, 16, 32]
print_iter_log: true
enable_attention_dp: false
speculative_config:
decoding_type: MTP
num_nextn_predict_layers: 2
EOF

trtllm-bench --model ${folder_model} throughput --dataset ${dataset} --backend pytorch --extra_llm_api_options ${config} --max_batch_size 64 --max_num_tokens 1536 --kv_cache_free_gpu_mem_fraction 0.9 --concurrency 128 --num_requests $((concurrency * 2))
```
</details>

### Branch:
```shell
Request Throughput (req/sec):                     2.7208
Total Output Throughput (tokens/sec):             1393.0585
Total Token Throughput (tokens/sec):              2786.1169
Total Latency (ms):                               17641.7577
Average request latency (ms):                     16688.4654
Per User Output Throughput [w/ ctx] (tps/user):   30.7073
Per GPU Output Throughput (tps/gpu):              1393.0585
```
### Main:
```shell
Request Throughput (req/sec):                     2.8101
Total Output Throughput (tokens/sec):             1438.7663
Total Token Throughput (tokens/sec):              2877.5326
Total Latency (ms):                               17081.3007
Average request latency (ms):                     16137.2014
Per User Output Throughput [w/ ctx] (tps/user):   31.7566
Per GPU Output Throughput (tps/gpu):              1438.7663
```

<hr/>

(For reference: perf for [naive commit](https://github.com/NVIDIA/TensorRT-LLM/pull/5675/commits/eccd31e0ef24500c7038d31f3d7589b13059d0ea) that uses a loop rather than index_copy_):
```shell
Request Throughput (req/sec):                     2.5508    
Total Output Throughput (tokens/sec):             1306.0251 
Total Token Throughput (tokens/sec):              2612.0503 
Total Latency (ms):                               18817.4021
Average request latency (ms):                     17720.8861
Per User Output Throughput [w/ ctx] (tps/user):   28.9234   
Per GPU Output Throughput (tps/gpu):              1306.0251 
```