### PR TITLE
chore: move remaining TRT code into _tensorrt_engine

### DIFF
--- a/tensorrt_llm/__init__.py
+++ b/tensorrt_llm/__init__.py
@@ -51,7 +51,7 @@ from .builder import BuildConfig, Builder, BuilderConfig, build
 from .disaggregated_params import DisaggregatedParams
 from .functional import Tensor, constant
 from .llmapi import LLM, LlmArgs
-from .llmapi.llm_args import LlmArgs, TorchLlmArgs, TrtLlmArgs
+from .llmapi.llm_args import LlmArgs, TorchLlmArgs
 from .logger import logger
 from .mapping import Mapping
 from .models.automodel import AutoConfig, AutoModelForCausalLM
@@ -105,7 +105,6 @@ __all__ = [
     'LLM',
     'LlmArgs',
     'TorchLlmArgs',
-    'TrtLlmArgs',
     'SamplingParams',
     'DisaggregatedParams',
     'KvCacheConfig',

--- a/tensorrt_llm/_tensorrt_engine/__init__.py
+++ b/tensorrt_llm/_tensorrt_engine/__init__.py
@@ -1,3 +1,9 @@
-from tensorrt_llm.llmapi.llm import _TrtLLM as LLM
+from .llm import LLM
+from .llm_args import CalibConfig, ExtendedRuntimePerfKnobConfig, TrtLlmArgs
 
-__all__ = ['LLM']
+__all__ = [
+    'LLM',
+    'TrtLlmArgs',
+    'CalibConfig',
+    'ExtendedRuntimePerfKnobConfig',
+]

--- a/tensorrt_llm/_tensorrt_engine/llm.py
+++ b/tensorrt_llm/_tensorrt_engine/llm.py
@@ -1,0 +1,196 @@
+import os
+import shutil
+from pathlib import Path
+from typing import Any, Literal, Optional, Union
+
+from transformers import PreTrainedTokenizerBase
+
+from ..bindings import executor as tllm
+from ..builder import EngineConfig
+from ..executor import PostprocWorkerConfig
+from ..inputs import create_input_processor
+from ..llmapi.llm import BaseLLM
+from ..llmapi.mpi_session import external_mpi_comm_available
+from ..llmapi.tokenizer import TokenizerBase, _xgrammar_tokenizer_info
+# TODO[chunweiy]: move the following symbols back to utils scope, and remove the following import
+from ..llmapi.utils import append_docstring, print_colored_debug
+from ..logger import logger
+from .llm_args import TRT_LLMARGS_EXPLICIT_DOCSTRING, PybindMirror
+
+TRT_LLM_DOCSTRING = TRT_LLMARGS_EXPLICIT_DOCSTRING + """
+
+    Attributes:
+        tokenizer (tensorrt_llm.llmapi.tokenizer.TokenizerBase, optional): The tokenizer loaded by LLM instance, if any.
+        workspace (pathlib.Path): The directory to store intermediate files.
+        llm_id (str): The unique ID of the LLM instance.
+"""
+
+
+@append_docstring(TRT_LLM_DOCSTRING)
+class LLM(BaseLLM):
+    """LLM class is the main class for running a LLM model using TensorRT-LLM backend.
+
+    Parameters:
+"""
+
+    def __init__(self,
+                 model: Union[str, Path],
+                 tokenizer: Optional[Union[str, Path, TokenizerBase,
+                                           PreTrainedTokenizerBase]] = None,
+                 tokenizer_mode: Literal['auto', 'slow'] = 'auto',
+                 skip_tokenizer_init: bool = False,
+                 trust_remote_code: bool = False,
+                 tensor_parallel_size: int = 1,
+                 dtype: str = "auto",
+                 revision: Optional[str] = None,
+                 tokenizer_revision: Optional[str] = None,
+                 **kwargs: Any) -> None:
+        # TODO: deprecate backend in LLM kwargs
+
+        super().__init__(model, tokenizer, tokenizer_mode, skip_tokenizer_init,
+                         trust_remote_code, tensor_parallel_size, dtype,
+                         revision, tokenizer_revision, **kwargs)
+
+    @property
+    def workspace(self) -> Path:
+        return Path(self._workspace.name) if self._on_trt_backend else None
+
+    def save(self, engine_dir: str) -> None:
+        """Save the built engine to the given path.
+
+        Args:
+            engine_dir (str): The path to save the engine.
+        """
+        logger.info(f"Save model to {engine_dir}")
+        if self._engine_dir is None:
+            raise RuntimeError("The engine is not built yet.")
+
+        if self._engine_dir.absolute() == os.path.abspath(engine_dir):
+            return
+
+        if not self.mpi_session or not self.mpi_session.is_comm_session():
+            shutil.copytree(self._engine_dir, engine_dir, dirs_exist_ok=True)
+        else:
+            # NFS is fragile, so we copy files one by one
+            target_engine_dir = Path(engine_dir)
+            target_engine_dir.mkdir(parents=True, exist_ok=True)
+            # copy files one by one
+            for file in self._engine_dir.iterdir():
+                print_colored_debug(
+                    f"Copying {file} to {target_engine_dir / file.name}\n")
+                shutil.copy(file, target_engine_dir / file.name)
+
+    def _build_model(self):
+        super()._build_model()
+        # update the model_dir to a local dir for the runtime, such as tokenizer loading.
+        if self._engine_dir is not None:
+            self.args.model = self._engine_dir
+
+        # Tokenizer loading should be after calling model_loader(), since model_loader() may download the model from HF hub.
+        # It should also be before bindings ExecutorConfig, which may depend on tokenizer info.
+        self._tokenizer = self._try_load_tokenizer()
+
+        # Multimodal special handling:
+        # 1. Default load_tokenizer may fail because MM has different tokenizer configuration. Hence we initialize it inside input processor
+        # 2. May need to modify model weights for MM (e.g., resize vocab embedding). We must do such operation via input processor's __init__
+        self.input_processor = create_input_processor(self._hf_model_dir,
+                                                      self.tokenizer)
+        self.tokenizer = self.input_processor.tokenizer
+
+        max_batch_size = self.args.max_batch_size
+        max_num_tokens = self.args.max_num_tokens
+        max_seq_len = self.args.max_seq_len
+
+        build_config = self.args.build_config
+
+        max_batch_size = max_batch_size or build_config.max_batch_size
+        max_num_tokens = max_num_tokens or build_config.max_num_tokens
+        max_seq_len = max_seq_len or build_config.max_seq_len
+
+        self._executor_config = tllm.ExecutorConfig(
+            max_beam_width=self.args.max_beam_width,
+            scheduler_config=PybindMirror.maybe_to_pybind(
+                self.args.scheduler_config),
+            batching_type=PybindMirror.maybe_to_pybind(self.args.batching_type)
+            or tllm.BatchingType.INFLIGHT,
+            max_batch_size=max_batch_size,
+            max_num_tokens=max_num_tokens,
+            gather_generation_logits=self.args.gather_generation_logits,
+            fail_fast_on_attention_window_too_large=getattr(
+                self.args, 'fail_fast_on_attention_window_too_large', False))
+
+        # also set executor_config.max_seq_len in TRT workflow, to deduce default max_tokens
+        if max_seq_len is not None:
+            self._executor_config.max_seq_len = max_seq_len
+        else:
+            engine_config = EngineConfig.from_json_file(self._engine_dir /
+                                                        "config.json")
+            self._executor_config.max_seq_len = engine_config.build_config.max_seq_len
+
+        if self.args.kv_cache_config is not None:
+            self._executor_config.kv_cache_config = PybindMirror.maybe_to_pybind(
+                self.args.kv_cache_config)
+        if os.getenv("FORCE_DETERMINISTIC", "0") == "1":
+            # Disable KV cache reuse for deterministic mode
+            self._executor_config.kv_cache_config.enable_block_reuse = False
+            self._executor_config.kv_cache_config.enable_partial_reuse = False
+        if self.args.peft_cache_config is not None:
+            self._executor_config.peft_cache_config = PybindMirror.maybe_to_pybind(
+                self.args.peft_cache_config)
+        elif self.args.build_config.plugin_config.lora_plugin:
+            engine_config = EngineConfig.from_json_file(self._engine_dir /
+                                                        "config.json")
+            lora_config = engine_config.build_config.lora_config
+            max_lora_rank = lora_config.max_lora_rank
+            num_lora_modules = engine_config.pretrained_config.num_hidden_layers * \
+                len(lora_config.lora_target_modules + lora_config.missing_qkv_modules)
+            self._executor_config.peft_cache_config = tllm.PeftCacheConfig(
+                num_device_module_layer=max_lora_rank * num_lora_modules *
+                self.args.max_loras,
+                num_host_module_layer=max_lora_rank * num_lora_modules *
+                self.args.max_cpu_loras,
+            )
+        if self.args.decoding_config is not None:
+            self._executor_config.decoding_config = self.args.decoding_config
+        if self.args.guided_decoding_backend == 'xgrammar':
+            self._executor_config.guided_decoding_config = tllm.GuidedDecodingConfig(
+                backend=tllm.GuidedDecodingConfig.GuidedDecodingBackend.
+                XGRAMMAR,
+                **_xgrammar_tokenizer_info(self.tokenizer))
+        elif self.args.guided_decoding_backend is not None:
+            raise ValueError(
+                f"Unsupported guided decoding backend {self.args.guided_decoding_backend}"
+            )
+
+        self._executor_config.normalize_log_probs = self.args.normalize_log_probs
+        self._executor_config.enable_chunked_context = self.args.enable_chunked_prefill
+        self._executor_config.max_beam_width = self.args.max_beam_width or self.args.build_config.max_beam_width
+        if self.args.extended_runtime_perf_knob_config is not None:
+            self._executor_config.extended_runtime_perf_knob_config = PybindMirror.maybe_to_pybind(
+                self.args.extended_runtime_perf_knob_config)
+        if self.args.cache_transceiver_config is not None:
+            self._executor_config.cache_transceiver_config = PybindMirror.maybe_to_pybind(
+                self.args.cache_transceiver_config)
+        self._executor_config.llm_parallel_config = self.args.parallel_config
+        return_logits = (self.args.gather_generation_logits
+                         or (self.args.build_config
+                             and self.args.build_config.gather_context_logits))
+
+        self._executor = self._executor_cls.create(
+            self._engine_dir,
+            executor_config=self._executor_config,
+            batched_logits_processor=self.args.batched_logits_processor,
+            model_world_size=self.args.parallel_config.world_size,
+            mpi_session=self.mpi_session,
+            reuse_mpi_comm=external_mpi_comm_available(
+                self.args.parallel_config.world_size),
+            return_logits=return_logits,
+            postproc_worker_config=PostprocWorkerConfig(
+                num_postprocess_workers=self.args.num_postprocess_workers,
+                postprocess_tokenizer_dir=self.args.postprocess_tokenizer_dir,
+            ),
+            is_llm_executor=True,
+            lora_config=self.args.lora_config)
+
+
+__all__ = ["LLM"]

--- a/tensorrt_llm/_tensorrt_engine/llm_args.py
+++ b/tensorrt_llm/_tensorrt_engine/llm_args.py
@@ -1,0 +1,251 @@
+from typing import Any, Dict, Literal, Optional
+
+from pydantic import Field, PrivateAttr, field_validator, model_validator
+
+# yapf: disable
+# isort: off
+from ..bindings.executor import (CacheTransceiverConfig as _CacheTransceiverConfig,
+                                 CapacitySchedulerPolicy as _CapacitySchedulerPolicy,
+                                 ContextChunkingPolicy as _ContextChunkingPolicy,
+                                 DecodingConfig,
+                                 DecodingMode,
+                                 DynamicBatchConfig as _DynamicBatchConfig,
+                                 EagleConfig as _EagleConfig,
+                                 ExecutorConfig as _ExecutorConfig,
+                                 ExtendedRuntimePerfKnobConfig as _ExtendedRuntimePerfKnobConfig,
+                                 KvCacheConfig as _KvCacheConfig,
+                                 LookaheadDecodingConfig as _LookaheadDecodingConfig,
+                                 PeftCacheConfig as _PeftCacheConfig,
+                                 SchedulerConfig as _SchedulerConfig) # isort: skip
+# isort: on
+
+
+from ..auto_parallel import AutoParallelConfig, infer_cluster_config
+from ..builder import BuildConfig
+from ..llmapi.build_cache import BuildCacheConfig
+from ..llmapi.llm_args import (BaseLlmArgs, BatchingType, PybindMirror,
+                               QuantConfig, StrictBaseModel)
+from ..llmapi.utils import generate_api_docs_as_docstring, get_type_repr
+
+
+class CalibConfig(StrictBaseModel):
+    """
+    Calibration configuration.
+    """
+    device: Literal['cuda',
+                    'cpu'] = Field(default='cuda',
+                                   description="The device to run calibration.")
+    calib_dataset: str = Field(
+        default='cnn_dailymail',
+        description="The name or local path of calibration dataset.")
+    calib_batches: int = Field(
+        default=512,
+        description="The number of batches that the calibration runs.")
+    calib_batch_size: int = Field(
+        default=1, description="The batch size that the calibration runs.")
+    calib_max_seq_length: int = Field(
+        default=512,
+        description="The maximum sequence length that the calibration runs.")
+    random_seed: int = Field(
+        default=1234, description="The random seed used for calibration.")
+    tokenizer_max_seq_length: int = Field(
+        default=2048,
+        description=
+        "The maximum sequence length to initialize tokenizer for calibration.")
+
+    @classmethod
+    def from_dict(cls, config: dict) -> 'CalibConfig':
+        """Create a CalibConfig instance from a dict.
+
+        Args:
+            config (dict): The dict used to create CalibConfig.
+
+        Returns:
+            tensorrt_llm.llmapi.CalibConfig: The CalibConfig created from dict.
+        """
+        return cls(**config)
+
+    def to_dict(self) -> dict:
+        """Dump a CalibConfig instance to a dict.
+
+        Returns:
+            dict: The dict dumped from CalibConfig.
+        """
+        return self.model_dump()
+
+
+
+@PybindMirror.mirror_pybind_fields(_ExtendedRuntimePerfKnobConfig)
+class ExtendedRuntimePerfKnobConfig(StrictBaseModel, PybindMirror):
+    """
+    Configuration for extended runtime performance knobs.
+    """
+
+    multi_block_mode: bool = Field(
+        default=True, description="Whether to use multi-block mode.")
+
+    enable_context_fmha_fp32_acc: bool = Field(
+        default=False,
+        description="Whether to enable context FMHA FP32 accumulation.")
+
+    cuda_graph_mode: bool = Field(default=False,
+                                  description="Whether to use CUDA graph mode.")
+
+    cuda_graph_cache_size: int = Field(
+        default=0,
+        description=
+        "Number of cuda graphs to be cached in the runtime. The larger the cache, the better the perf, but more GPU memory is consumed."
+    )
+
+    def _to_pybind(self):
+        res = _ExtendedRuntimePerfKnobConfig(
+            multi_block_mode=self.multi_block_mode,
+            enable_context_fmha_fp32_acc=self.enable_context_fmha_fp32_acc)
+        res.cuda_graph_mode = self.cuda_graph_mode
+        res.cuda_graph_cache_size = self.cuda_graph_cache_size
+        return res
+
+class TrtLlmArgs(BaseLlmArgs):
+
+    auto_parallel: bool = Field(
+        default=False,
+        description="Enable auto parallel mode.",
+        deprecated=
+        "Use tensor_parallel_size/pipeline_parallel_size/xxx_parallel_size instead.",
+    )
+
+    auto_parallel_world_size: Optional[int] = Field(
+        default=None,
+        description="The world size for auto parallel mode.",
+        deprecated=
+        "Use tensor_parallel_size/pipeline_parallel_size/xxx_parallel_size instead.",
+    )
+
+    enable_tqdm: bool = Field(default=False,
+                              description="Enable tqdm for progress bar.")
+
+    workspace: Optional[str] = Field(default=None,
+                                     description="The workspace for the model.")
+
+    # Once set, the model will reuse the build_cache
+    enable_build_cache: object = Field(
+        default=False,
+        description="Enable build cache.",
+        json_schema_extra={
+            "type": f"Union[{get_type_repr(BuildCacheConfig)}, bool]"
+        })
+
+    extended_runtime_perf_knob_config: Optional[
+        ExtendedRuntimePerfKnobConfig] = Field(
+            default=None, description="Extended runtime perf knob config.")
+
+    calib_config: Optional[CalibConfig] = Field(
+        default=None, description="Calibration config.", validate_default=True)
+
+    # Quantization and calibration configurations
+    quant_config: Optional[QuantConfig] = Field(
+        default=None, description="Quantization config.", validate_default=True)
+
+    embedding_parallel_mode: str = Field(
+        default='SHARDING_ALONG_VOCAB',
+        description="The embedding parallel mode.")
+
+    fast_build: bool = Field(default=False, description="Enable fast build.")
+
+    # BuildConfig is introduced to give users a familiar interface to configure the model building.
+    build_config: Optional[object] = Field(
+        default=None,
+        description="Build config.",
+        json_schema_extra={"type": f"Optional[{get_type_repr(BuildConfig)}]"})
+
+    # Prompt adapter arguments
+    enable_prompt_adapter: bool = Field(default=False,
+                                        description="Enable prompt adapter.")
+
+    max_prompt_adapter_token: int = Field(
+        default=0, description="The maximum number of prompt adapter tokens.")
+
+    batching_type: Optional[BatchingType] = Field(default=None,
+                                                  description="Batching type.")
+
+    normalize_log_probs: bool = Field(
+        default=False, description="Normalize log probabilities.")
+
+    # Private attributes
+    _auto_parallel_config: Optional[AutoParallelConfig] = PrivateAttr(
+        default=None)
+    # This is used to hold the options for convert_checkpoint
+    _convert_checkpoint_options: Dict[str,
+                                      Any] = PrivateAttr(default_factory=dict)
+
+    @property
+    def auto_parallel_config(self) -> AutoParallelConfig:
+        return self._auto_parallel_config
+
+    @field_validator('calib_config', mode='before')
+    @classmethod
+    def init_calib_config(cls, v):
+        if v is None:
+            return CalibConfig()
+        return v
+
+    @field_validator("quant_config", mode='before')
+    @classmethod
+    def validate_quant_config(cls, v, info):
+        if v is None:
+            v = QuantConfig()
+        return v
+
+    @model_validator(mode="after")
+    def setup_embedding_parallel_mode(self):
+        if self.embedding_parallel_mode == 'NONE':
+            self._convert_checkpoint_options['use_parallel_embedding'] = False
+        elif self.embedding_parallel_mode == 'SHARDING_ALONG_VOCAB':
+            self._convert_checkpoint_options['use_parallel_embedding'] = True
+            self._convert_checkpoint_options['embedding_sharding_dim'] = 0
+        elif self.embedding_parallel_mode == 'SHARDING_ALONG_HIDDEN':
+            self._convert_checkpoint_options['use_parallel_embedding'] = True
+            self._convert_checkpoint_options['embedding_sharding_dim'] = 1
+        # No else clause needed since validation already happened
+        return self
+
+    @model_validator(mode="after")
+    def validate_auto_parallel(self):
+        self._auto_parallel_config = AutoParallelConfig(
+            sharded_io_allowlist=[
+                "past_key_value_\\d+",
+                "present_key_value_\\d*",
+            ],
+            same_buffer_io={
+                "past_key_value_(\\d+)": "present_key_value_\\1",
+            },
+            **infer_cluster_config(),
+        )
+
+        self.parallel_config.auto_parallel = self.auto_parallel
+
+        if self.parallel_config.auto_parallel:
+            self.parallel_config.world_size = self.auto_parallel_world_size
+
+        return self
+
+    @model_validator(mode="after")
+    def validate_enable_build_cache(self):
+        if not self.enable_build_cache:
+            return self
+        self.enable_build_cache = BuildCacheConfig() if isinstance(
+            self.enable_build_cache, bool) else self.enable_build_cache
+        if not isinstance(self.enable_build_cache, BuildCacheConfig):
+            raise ValueError(
+                f"Invalid build_cache_config: {self.enable_build_cache}")
+        return self
+
+    @model_validator(mode="after")
+    def validate_kv_cache_dtype(self):
+        assert self.kv_cache_config.dtype == "auto", "KvCacheConfig.dtype is not supported by the TensorRT backend."
+        return self
+
+
+
+TRT_LLMARGS_EXPLICIT_DOCSTRING = generate_api_docs_as_docstring(TrtLlmArgs,
+                                                                indent=' ' * 4)

--- a/tensorrt_llm/bench/dataclasses/configuration.py
+++ b/tensorrt_llm/bench/dataclasses/configuration.py
@@ -9,11 +9,11 @@ from pydantic import (BaseModel, Field, PositiveFloat, field_validator,
                       model_validator)
 
 import tensorrt_llm.bindings.executor as trtllm
+from tensorrt_llm._tensorrt_engine import ExtendedRuntimePerfKnobConfig
 from tensorrt_llm._torch.pyexecutor.config import PyTorchConfig
 from tensorrt_llm.llmapi import (BatchingType, CapacitySchedulerPolicy,
                                  ContextChunkingPolicy, DynamicBatchConfig,
-                                 ExtendedRuntimePerfKnobConfig, KvCacheConfig,
-                                 SchedulerConfig)
+                                 KvCacheConfig, SchedulerConfig)
 from tensorrt_llm.llmapi.llm_utils import update_llm_args_with_extra_options
 from tensorrt_llm.models.modeling_utils import SpeculativeDecodingMode
 

--- a/tensorrt_llm/executor/__init__.py
+++ b/tensorrt_llm/executor/__init__.py
@@ -1,10 +1,11 @@
-from .executor import *
-from .postproc_worker import *
-from .proxy import *
-from .request import *
-from .result import *
+from .executor import CppExecutorError, GenerationExecutor
+from .postproc_worker import PostprocWorker, PostprocWorkerConfig
+from .proxy import GenerationExecutorProxy
+from .request import GenerationRequest, LoRARequest, PromptAdapterRequest
+from .result import (CompletionOutput, DetokenizedGenerationResultBase,
+                     GenerationResult, GenerationResultBase, IterationResult)
 from .utils import RequestError
-from .worker import *
+from .worker import GenerationExecutorWorker
 
 __all__ = [
     "PostprocWorker",
@@ -14,6 +15,8 @@ __all__ = [
     "PromptAdapterRequest",
     "GenerationExecutorWorker",
     "GenerationExecutorProxy",
+    "CppExecutorError",
+    "GenerationExecutor",
     "RequestError",
     "CompletionOutput",
     "GenerationResultBase",

--- a/tensorrt_llm/llmapi/__init__.py
+++ b/tensorrt_llm/llmapi/__init__.py
@@ -4,14 +4,13 @@ from ..sampling_params import GuidedDecodingParams, SamplingParams
 from .build_cache import BuildCacheConfig
 from .llm import LLM, RequestOutput
 # yapf: disable
-from .llm_args import (BatchingType, CacheTransceiverConfig, CalibConfig,
-                       CapacitySchedulerPolicy, ContextChunkingPolicy,
-                       CudaGraphConfig, DraftTargetDecodingConfig,
-                       DynamicBatchConfig, EagleDecodingConfig,
-                       ExtendedRuntimePerfKnobConfig, KvCacheConfig, LlmArgs,
+from .llm_args import (CacheTransceiverConfig, CapacitySchedulerPolicy,
+                       ContextChunkingPolicy, CudaGraphConfig,
+                       DraftTargetDecodingConfig, DynamicBatchConfig,
+                       EagleDecodingConfig, KvCacheConfig, LlmArgs,
                        LookaheadDecodingConfig, MedusaDecodingConfig, MoeConfig,
                        MTPDecodingConfig, NGramDecodingConfig, SchedulerConfig,
-                       TorchCompileConfig, TorchLlmArgs, TrtLlmArgs,
+                       TorchCompileConfig, TorchLlmArgs,
                        UserProvidedDecodingConfig)
 from .llm_utils import (BuildConfig, KvCacheRetentionConfig, QuantAlgo,
                         QuantConfig)
@@ -37,12 +36,9 @@ __all__ = [
     'BuildConfig',
     'QuantConfig',
     'QuantAlgo',
-    'CalibConfig',
     'BuildCacheConfig',
     'RequestError',
     'MpiCommSession',
-    'ExtendedRuntimePerfKnobConfig',
-    'BatchingType',
     'ContextChunkingPolicy',
     'DynamicBatchConfig',
     'CacheTransceiverConfig',
@@ -52,5 +48,4 @@ __all__ = [
     'DraftTargetDecodingConfig',
     'LlmArgs',
     'TorchLlmArgs',
-    'TrtLlmArgs',
 ]

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -1,7 +1,6 @@
 import atexit
 import json
 import os
-import shutil
 import socket
 import tempfile
 import time
@@ -18,7 +17,6 @@ from tensorrt_llm.inputs.registry import DefaultInputProcessor
 
 from .._utils import nvtx_range_debug
 from ..bindings import executor as tllm
-from ..builder import EngineConfig
 from ..disaggregated_params import DisaggregatedParams
 from ..executor import (DetokenizedGenerationResultBase, GenerationExecutor,
                         GenerationResult, IterationResult, LoRARequest,
@@ -30,9 +28,8 @@ from ..inputs import (PromptInputs, create_input_processor,
                       create_input_processor_with_hash, prompt_inputs)
 from ..logger import logger
 from ..sampling_params import SamplingParams
-from .llm_args import (TORCH_LLMARGS_EXPLICIT_DOCSTRING,
-                       TRT_LLMARGS_EXPLICIT_DOCSTRING, PybindMirror,
-                       TorchLlmArgs, TrtLlmArgs)
+from .llm_args import (TORCH_LLMARGS_EXPLICIT_DOCSTRING, PybindMirror,
+                       TorchLlmArgs)
 from .llm_utils import (CachedModelLoader, KvCacheRetentionConfig,
                         LlmBuildStats, ModelLoader, _ModelRuntimeContext)
 from .mpi_session import MpiPoolSession, external_mpi_comm_available
@@ -84,14 +81,6 @@ class RequestOutput(DetokenizedGenerationResultBase, GenerationResult):
         ]
 
 
-TRT_LLM_DOCSTRING = TRT_LLMARGS_EXPLICIT_DOCSTRING + """
-
-    Attributes:
-        tokenizer (tensorrt_llm.llmapi.tokenizer.TokenizerBase, optional): The tokenizer loaded by LLM instance, if any.
-        workspace (pathlib.Path): The directory to store intermediate files.
-        llm_id (str): The unique ID of the LLM instance.
-"""
-
 TORCH_LLM_DOCSTRING = TORCH_LLMARGS_EXPLICIT_DOCSTRING + """
 
     Attributes:
@@ -117,6 +106,9 @@ class BaseLLM:
                  revision: Optional[str] = None,
                  tokenizer_revision: Optional[str] = None,
                  **kwargs: Any) -> None:
+
+        from .._tensorrt_engine.llm_args import \
+            TrtLlmArgs  # avoid circular import
 
         self._executor_cls = kwargs.pop("executor_cls", GenerationExecutor)
         self._llm_id = None
@@ -158,6 +150,8 @@ class BaseLLM:
             logger.error(
                 f"Failed to parse the arguments for the LLM constructor: {e}")
             raise e
+
+        self._on_trt_backend = isinstance(self.args, TrtLlmArgs)
 
         print_colored_debug(f"LLM.args.mpi_session: {self.args.mpi_session}\n",
                             "yellow")
@@ -610,10 +604,6 @@ class BaseLLM:
                                              self.llm_build_stats))
         self._engine_dir, self._hf_model_dir = model_loader()
 
-    @property
-    def _on_trt_backend(self) -> bool:
-        return isinstance(self.args, TrtLlmArgs)
-
     def _try_load_tokenizer(self) -> Optional[TokenizerBase]:
         if self.args.skip_tokenizer_init:
             return None
@@ -694,173 +684,6 @@ class BaseLLM:
 
     def __del__(self):
         self.shutdown()
-
-
-@append_docstring(TRT_LLM_DOCSTRING)
-class _TrtLLM(BaseLLM):
-    """LLM class is the main class for running a LLM model using TensorRT-LLM backend.
-
-    Parameters:
-"""
-
-    def __init__(self,
-                 model: Union[str, Path],
-                 tokenizer: Optional[Union[str, Path, TokenizerBase,
-                                           PreTrainedTokenizerBase]] = None,
-                 tokenizer_mode: Literal['auto', 'slow'] = 'auto',
-                 skip_tokenizer_init: bool = False,
-                 trust_remote_code: bool = False,
-                 tensor_parallel_size: int = 1,
-                 dtype: str = "auto",
-                 revision: Optional[str] = None,
-                 tokenizer_revision: Optional[str] = None,
-                 **kwargs: Any) -> None:
-        # TODO: deprecate backend in LLM kwargs
-
-        super().__init__(model, tokenizer, tokenizer_mode, skip_tokenizer_init,
-                         trust_remote_code, tensor_parallel_size, dtype,
-                         revision, tokenizer_revision, **kwargs)
-
-    @property
-    def workspace(self) -> Path:
-        return Path(self._workspace.name) if self._on_trt_backend else None
-
-    def save(self, engine_dir: str) -> None:
-        """Save the built engine to the given path.
-
-        Args:
-            engine_dir (str): The path to save the engine.
-        """
-        logger.info(f"Save model to {engine_dir}")
-        if self._engine_dir is None:
-            raise RuntimeError("The engine is not built yet.")
-
-        if self._engine_dir.absolute() == os.path.abspath(engine_dir):
-            return
-
-        if not self.mpi_session or not self.mpi_session.is_comm_session():
-            shutil.copytree(self._engine_dir, engine_dir, dirs_exist_ok=True)
-        else:
-            # NFS is fragile, so we copy files one by one
-            target_engine_dir = Path(engine_dir)
-            target_engine_dir.mkdir(parents=True, exist_ok=True)
-            # copy files one by one
-            for file in self._engine_dir.iterdir():
-                print_colored_debug(
-                    f"Copying {file} to {target_engine_dir / file.name}\n")
-                shutil.copy(file, target_engine_dir / file.name)
-
-    def _build_model(self):
-        super()._build_model()
-        # update the model_dir to a local dir for the runtime, such as tokenizer loading.
-        if self._engine_dir is not None:
-            self.args.model = self._engine_dir
-
-        # Tokenizer loading should be after calling model_loader(), since model_loader() may download the model from HF hub.
-        # It should also be before bindings ExecutorConfig, which may depend on tokenizer info.
-        self._tokenizer = self._try_load_tokenizer()
-
-        # Multimodal special handling:
-        # 1. Default load_tokenizer may fail because MM has different tokenizer configuration. Hence we initialize it inside input processor
-        # 2. May need to modify model weights for MM (e.g., resize vocab embedding). We must do such operation via input processor's __init__
-        self.input_processor = create_input_processor(self._hf_model_dir,
-                                                      self.tokenizer)
-        self.tokenizer = self.input_processor.tokenizer
-
-        max_batch_size = self.args.max_batch_size
-        max_num_tokens = self.args.max_num_tokens
-        max_seq_len = self.args.max_seq_len
-
-        build_config = self.args.build_config
-
-        max_batch_size = max_batch_size or build_config.max_batch_size
-        max_num_tokens = max_num_tokens or build_config.max_num_tokens
-        max_seq_len = max_seq_len or build_config.max_seq_len
-
-        self._executor_config = tllm.ExecutorConfig(
-            max_beam_width=self.args.max_beam_width,
-            scheduler_config=PybindMirror.maybe_to_pybind(
-                self.args.scheduler_config),
-            batching_type=PybindMirror.maybe_to_pybind(self.args.batching_type)
-            or tllm.BatchingType.INFLIGHT,
-            max_batch_size=max_batch_size,
-            max_num_tokens=max_num_tokens,
-            gather_generation_logits=self.args.gather_generation_logits,
-            fail_fast_on_attention_window_too_large=getattr(
-                self.args, 'fail_fast_on_attention_window_too_large', False))
-
-        # also set executor_config.max_seq_len in TRT workflow, to deduce default max_tokens
-        if max_seq_len is not None:
-            self._executor_config.max_seq_len = max_seq_len
-        else:
-            engine_config = EngineConfig.from_json_file(self._engine_dir /
-                                                        "config.json")
-            self._executor_config.max_seq_len = engine_config.build_config.max_seq_len
-
-        if self.args.kv_cache_config is not None:
-            self._executor_config.kv_cache_config = PybindMirror.maybe_to_pybind(
-                self.args.kv_cache_config)
-        if os.getenv("FORCE_DETERMINISTIC", "0") == "1":
-            # Disable KV cache reuse for deterministic mode
-            self._executor_config.kv_cache_config.enable_block_reuse = False
-            self._executor_config.kv_cache_config.enable_partial_reuse = False
-        if self.args.peft_cache_config is not None:
-            self._executor_config.peft_cache_config = PybindMirror.maybe_to_pybind(
-                self.args.peft_cache_config)
-        elif self.args.build_config.plugin_config.lora_plugin:
-            engine_config = EngineConfig.from_json_file(self._engine_dir /
-                                                        "config.json")
-            lora_config = engine_config.build_config.lora_config
-            max_lora_rank = lora_config.max_lora_rank
-            num_lora_modules = engine_config.pretrained_config.num_hidden_layers * \
-                len(lora_config.lora_target_modules + lora_config.missing_qkv_modules)
-            self._executor_config.peft_cache_config = tllm.PeftCacheConfig(
-                num_device_module_layer=max_lora_rank * num_lora_modules *
-                self.args.max_loras,
-                num_host_module_layer=max_lora_rank * num_lora_modules *
-                self.args.max_cpu_loras,
-            )
-        if self.args.decoding_config is not None:
-            self._executor_config.decoding_config = self.args.decoding_config
-        if self.args.guided_decoding_backend == 'xgrammar':
-            self._executor_config.guided_decoding_config = tllm.GuidedDecodingConfig(
-                backend=tllm.GuidedDecodingConfig.GuidedDecodingBackend.
-                XGRAMMAR,
-                **_xgrammar_tokenizer_info(self.tokenizer))
-        elif self.args.guided_decoding_backend is not None:
-            raise ValueError(
-                f"Unsupported guided decoding backend {self.args.guided_decoding_backend}"
-            )
-
-        self._executor_config.normalize_log_probs = self.args.normalize_log_probs
-        self._executor_config.enable_chunked_context = self.args.enable_chunked_prefill
-        self._executor_config.max_beam_width = self.args.max_beam_width or self.args.build_config.max_beam_width
-        if self.args.extended_runtime_perf_knob_config is not None:
-            self._executor_config.extended_runtime_perf_knob_config = PybindMirror.maybe_to_pybind(
-                self.args.extended_runtime_perf_knob_config)
-        if self.args.cache_transceiver_config is not None:
-            self._executor_config.cache_transceiver_config = PybindMirror.maybe_to_pybind(
-                self.args.cache_transceiver_config)
-        self._executor_config.llm_parallel_config = self.args.parallel_config
-        return_logits = (self.args.gather_generation_logits
-                         or (self.args.build_config
-                             and self.args.build_config.gather_context_logits))
-
-        self._executor = self._executor_cls.create(
-            self._engine_dir,
-            executor_config=self._executor_config,
-            batched_logits_processor=self.args.batched_logits_processor,
-            model_world_size=self.args.parallel_config.world_size,
-            mpi_session=self.mpi_session,
-            reuse_mpi_comm=external_mpi_comm_available(
-                self.args.parallel_config.world_size),
-            return_logits=return_logits,
-            postproc_worker_config=PostprocWorkerConfig(
-                num_postprocess_workers=self.args.num_postprocess_workers,
-                postprocess_tokenizer_dir=self.args.postprocess_tokenizer_dir,
-            ),
-            is_llm_executor=True,
-            lora_config=self.args.lora_config)
 
 
 @append_docstring(TORCH_LLM_DOCSTRING)
@@ -1010,6 +833,8 @@ class _TorchLLM(BaseLLM):
     def _validate_args_for_torch_backend(self, kwargs: dict) -> None:
         """Validate that users don't pass TrtLlmArgs-specific arguments when using PyTorch backend.
         """
+        from .._tensorrt_engine.llm_args import \
+            TrtLlmArgs  # avoid circular import
         trtllm_fields = set(TrtLlmArgs.model_fields.keys())
         torchllm_fields = set(TorchLlmArgs.model_fields.keys())
 

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -5,7 +5,7 @@ import math
 import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from enum import Enum, EnumMeta
+from enum import Enum, EnumMeta, StrEnum
 from pathlib import Path
 from typing import (TYPE_CHECKING, Any, ClassVar, Dict, List, Literal, Optional,
                     TypeAlias, Union)
@@ -22,15 +22,13 @@ from tensorrt_llm.lora_manager import (LoraConfig,
                                        get_default_trtllm_modules_to_hf_modules)
 
 from .._utils import mpi_rank
-from ..auto_parallel import AutoParallelConfig, infer_cluster_config
 
 if TYPE_CHECKING:
     from tensorrt_llm._torch.pyexecutor.config import PyTorchConfig
 
 # yapf: disable
 # isort: off
-from ..bindings.executor import (
-                                 BatchingType as _BatchingType,
+from ..bindings.executor import (BatchingType as _BatchingType,
                                  CacheTransceiverBackendType as _CacheTransceiverBackendType,
                                  CacheTransceiverConfig as _CacheTransceiverConfig,
                                  CapacitySchedulerPolicy as _CapacitySchedulerPolicy,
@@ -264,52 +262,6 @@ class _ParallelConfig:
                        moe_tp_size=self.moe_tp_size,
                        moe_ep_size=self.moe_ep_size,
                        auto_parallel=self.auto_parallel)
-
-
-class CalibConfig(StrictBaseModel):
-    """
-    Calibration configuration.
-    """
-    device: Literal['cuda',
-                    'cpu'] = Field(default='cuda',
-                                   description="The device to run calibration.")
-    calib_dataset: str = Field(
-        default='cnn_dailymail',
-        description="The name or local path of calibration dataset.")
-    calib_batches: int = Field(
-        default=512,
-        description="The number of batches that the calibration runs.")
-    calib_batch_size: int = Field(
-        default=1, description="The batch size that the calibration runs.")
-    calib_max_seq_length: int = Field(
-        default=512,
-        description="The maximum sequence length that the calibration runs.")
-    random_seed: int = Field(
-        default=1234, description="The random seed used for calibration.")
-    tokenizer_max_seq_length: int = Field(
-        default=2048,
-        description=
-        "The maximum sequence length to initialize tokenizer for calibration.")
-
-    @classmethod
-    def from_dict(cls, config: dict) -> 'CalibConfig':
-        """Create a CalibConfig instance from a dict.
-
-        Args:
-            config (dict): The dict used to create CalibConfig.
-
-        Returns:
-            tensorrt_llm.llmapi.CalibConfig: The CalibConfig created from dict.
-        """
-        return cls(**config)
-
-    def to_dict(self) -> dict:
-        """Dump a CalibConfig instance to a dict.
-
-        Returns:
-            dict: The dict dumped from CalibConfig.
-        """
-        return self.model_dump()
 
 
 class _ModelFormatKind(Enum):
@@ -897,37 +849,6 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
             use_uvm=self.use_uvm)
 
 
-@PybindMirror.mirror_pybind_fields(_ExtendedRuntimePerfKnobConfig)
-class ExtendedRuntimePerfKnobConfig(StrictBaseModel, PybindMirror):
-    """
-    Configuration for extended runtime performance knobs.
-    """
-
-    multi_block_mode: bool = Field(
-        default=True, description="Whether to use multi-block mode.")
-
-    enable_context_fmha_fp32_acc: bool = Field(
-        default=False,
-        description="Whether to enable context FMHA FP32 accumulation.")
-
-    cuda_graph_mode: bool = Field(default=False,
-                                  description="Whether to use CUDA graph mode.")
-
-    cuda_graph_cache_size: int = Field(
-        default=0,
-        description=
-        "Number of cuda graphs to be cached in the runtime. The larger the cache, the better the perf, but more GPU memory is consumed."
-    )
-
-    def _to_pybind(self):
-        res = _ExtendedRuntimePerfKnobConfig(
-            multi_block_mode=self.multi_block_mode,
-            enable_context_fmha_fp32_acc=self.enable_context_fmha_fp32_acc)
-        res.cuda_graph_mode = self.cuda_graph_mode
-        res.cuda_graph_cache_size = self.cuda_graph_cache_size
-        return res
-
-
 @PybindMirror.mirror_pybind_fields(_CacheTransceiverConfig)
 class CacheTransceiverConfig(StrictBaseModel, PybindMirror):
     """
@@ -1485,6 +1406,8 @@ class BaseLlmArgs(StrictBaseModel):
 
     @model_validator(mode="after")
     def validate_build_config_remaining(self):
+        from .._tensorrt_engine.llm_args import \
+            TrtLlmArgs  # avoid circular import
         is_trt_llm_args = isinstance(self, TrtLlmArgs)
 
         # TODO: remove the checker when manage weights support all data types
@@ -1707,147 +1630,6 @@ class BaseLlmArgs(StrictBaseModel):
                 moe_cluster_size=moe_cluster_size,
                 moe_tp_size=moe_tp_size,
                 moe_ep_size=moe_ep_size)
-
-
-class TrtLlmArgs(BaseLlmArgs):
-
-    auto_parallel: bool = Field(
-        default=False,
-        description="Enable auto parallel mode.",
-        deprecated=
-        "Use tensor_parallel_size/pipeline_parallel_size/xxx_parallel_size instead.",
-    )
-
-    auto_parallel_world_size: Optional[int] = Field(
-        default=None,
-        description="The world size for auto parallel mode.",
-        deprecated=
-        "Use tensor_parallel_size/pipeline_parallel_size/xxx_parallel_size instead.",
-    )
-
-    enable_tqdm: bool = Field(default=False,
-                              description="Enable tqdm for progress bar.")
-
-    workspace: Optional[str] = Field(default=None,
-                                     description="The workspace for the model.")
-
-    # Once set, the model will reuse the build_cache
-    enable_build_cache: object = Field(
-        default=False,
-        description="Enable build cache.",
-        json_schema_extra={
-            "type": f"Union[{get_type_repr(BuildCacheConfig)}, bool]"
-        })
-
-    extended_runtime_perf_knob_config: Optional[
-        ExtendedRuntimePerfKnobConfig] = Field(
-            default=None, description="Extended runtime perf knob config.")
-
-    calib_config: Optional[CalibConfig] = Field(
-        default=None, description="Calibration config.", validate_default=True)
-
-    # Quantization and calibration configurations
-    quant_config: Optional[QuantConfig] = Field(
-        default=None, description="Quantization config.", validate_default=True)
-
-    embedding_parallel_mode: str = Field(
-        default='SHARDING_ALONG_VOCAB',
-        description="The embedding parallel mode.")
-
-    fast_build: bool = Field(default=False, description="Enable fast build.")
-
-    # BuildConfig is introduced to give users a familiar interface to configure the model building.
-    build_config: Optional[object] = Field(
-        default=None,
-        description="Build config.",
-        json_schema_extra={"type": f"Optional[{get_type_repr(BuildConfig)}]"})
-
-    # Prompt adapter arguments
-    enable_prompt_adapter: bool = Field(default=False,
-                                        description="Enable prompt adapter.")
-
-    max_prompt_adapter_token: int = Field(
-        default=0, description="The maximum number of prompt adapter tokens.")
-
-    batching_type: Optional[BatchingType] = Field(default=None,
-                                                  description="Batching type.")
-
-    normalize_log_probs: bool = Field(
-        default=False, description="Normalize log probabilities.")
-
-    # Private attributes
-    _auto_parallel_config: Optional[AutoParallelConfig] = PrivateAttr(
-        default=None)
-    # This is used to hold the options for convert_checkpoint
-    _convert_checkpoint_options: Dict[str,
-                                      Any] = PrivateAttr(default_factory=dict)
-
-    @property
-    def auto_parallel_config(self) -> AutoParallelConfig:
-        return self._auto_parallel_config
-
-    @field_validator('calib_config', mode='before')
-    @classmethod
-    def init_calib_config(cls, v):
-        if v is None:
-            return CalibConfig()
-        return v
-
-    @field_validator("quant_config", mode='before')
-    @classmethod
-    def validate_quant_config(cls, v, info):
-        if v is None:
-            v = QuantConfig()
-        return v
-
-    @model_validator(mode="after")
-    def setup_embedding_parallel_mode(self):
-        if self.embedding_parallel_mode == 'NONE':
-            self._convert_checkpoint_options['use_parallel_embedding'] = False
-        elif self.embedding_parallel_mode == 'SHARDING_ALONG_VOCAB':
-            self._convert_checkpoint_options['use_parallel_embedding'] = True
-            self._convert_checkpoint_options['embedding_sharding_dim'] = 0
-        elif self.embedding_parallel_mode == 'SHARDING_ALONG_HIDDEN':
-            self._convert_checkpoint_options['use_parallel_embedding'] = True
-            self._convert_checkpoint_options['embedding_sharding_dim'] = 1
-        # No else clause needed since validation already happened
-        return self
-
-    @model_validator(mode="after")
-    def validate_auto_parallel(self):
-        self._auto_parallel_config = AutoParallelConfig(
-            sharded_io_allowlist=[
-                "past_key_value_\\d+",
-                "present_key_value_\\d*",
-            ],
-            same_buffer_io={
-                "past_key_value_(\\d+)": "present_key_value_\\1",
-            },
-            **infer_cluster_config(),
-        )
-
-        self.parallel_config.auto_parallel = self.auto_parallel
-
-        if self.parallel_config.auto_parallel:
-            self.parallel_config.world_size = self.auto_parallel_world_size
-
-        return self
-
-    @model_validator(mode="after")
-    def validate_enable_build_cache(self):
-        if not self.enable_build_cache:
-            return self
-        self.enable_build_cache = BuildCacheConfig() if isinstance(
-            self.enable_build_cache, bool) else self.enable_build_cache
-        if not isinstance(self.enable_build_cache, BuildCacheConfig):
-            raise ValueError(
-                f"Invalid build_cache_config: {self.enable_build_cache}")
-        return self
-
-    @model_validator(mode="after")
-    def validate_kv_cache_dtype(self):
-        assert self.kv_cache_config.dtype == "auto", "KvCacheConfig.dtype is not supported by the TensorRT backend."
-        return self
 
 
 class LoadFormat(Enum):
@@ -2310,8 +2092,6 @@ def get_model_format(model_dir: str,
 
 LlmArgs = TorchLlmArgs
 
-TRT_LLMARGS_EXPLICIT_DOCSTRING = generate_api_docs_as_docstring(TrtLlmArgs,
-                                                                indent=' ' * 4)
 TORCH_LLMARGS_EXPLICIT_DOCSTRING = generate_api_docs_as_docstring(TorchLlmArgs,
                                                                   indent=' ' *
                                                                   4)

--- a/tensorrt_llm/llmapi/llm_utils.py
+++ b/tensorrt_llm/llmapi/llm_utils.py
@@ -21,7 +21,6 @@ from ..bindings.executor import (BatchingType, CapacitySchedulerPolicy,
                                  KvCacheRetentionConfig, SchedulerConfig)
 # yapf: enable
 from ..builder import BuildConfig, Engine, build
-from ..llmapi.llm_args import TrtLlmArgs
 from ..logger import logger
 from ..mapping import Mapping
 from ..models.automodel import MODEL_MAP, AutoConfig, AutoModelForCausalLM
@@ -29,7 +28,8 @@ from ..models.modeling_utils import PretrainedConfig, QuantAlgo, QuantConfig
 from ..module import Module
 from .build_cache import (BuildCache, BuildCacheConfig, CachedStage,
                           get_build_cache_config_from_env)
-from .llm_args import (CalibConfig, CudaGraphConfig, DraftTargetDecodingConfig,
+# yapf: disable
+from .llm_args import (CudaGraphConfig, DraftTargetDecodingConfig,
                        EagleDecodingConfig, KvCacheConfig, LlmArgs,
                        LookaheadDecodingConfig, MedusaDecodingConfig,
                        MTPDecodingConfig, NGramDecodingConfig,
@@ -37,6 +37,7 @@ from .llm_args import (CalibConfig, CudaGraphConfig, DraftTargetDecodingConfig,
                        _ModelWrapper, _ParallelConfig,
                        update_llm_args_with_extra_dict,
                        update_llm_args_with_extra_options)
+# yapf: enable
 from .mpi_session import MPINodeState, MpiSession
 from .tokenizer import TransformersTokenizer, load_hf_tokenizer
 # TODO[chunweiy]: move the following symbols back to utils scope, and remove the following import
@@ -103,6 +104,9 @@ class ModelLoader:
                  llm_args: LlmArgs,
                  workspace: Optional[str | tempfile.TemporaryDirectory] = None,
                  llm_build_stats: Optional["LlmBuildStats"] = None):
+        from .._tensorrt_engine.llm_args import \
+            TrtLlmArgs  # avoid circular import
+
         self.llm_args = llm_args
         self._workspace = workspace or tempfile.TemporaryDirectory()
         self.llm_build_stats = llm_build_stats or LlmBuildStats()
@@ -870,7 +874,6 @@ __all__ = [
     'BuildConfig',
     'BuildCacheConfig',
     'QuantConfig',
-    'CalibConfig',
     'CudaGraphConfig',
     'KvCacheConfig',
     'CachedModelLoader',

--- a/tests/unittest/llmapi/test_llm.py
+++ b/tests/unittest/llmapi/test_llm.py
@@ -27,6 +27,7 @@ import transformers
 
 from tensorrt_llm import LLM as LLM_torch
 from tensorrt_llm._tensorrt_engine import LLM
+from tensorrt_llm._tensorrt_engine import TrtLlmArgs as LlmArgs
 from tensorrt_llm.bindings import executor as tllm
 from tensorrt_llm.executor import (GenerationExecutorWorker, LoRARequest,
                                    PromptAdapterRequest, RequestError)
@@ -34,7 +35,6 @@ from tensorrt_llm.llmapi import (BuildCacheConfig, EagleDecodingConfig,
                                  KvCacheConfig, KvCacheRetentionConfig,
                                  LookaheadDecodingConfig, MedusaDecodingConfig,
                                  RequestOutput)
-from tensorrt_llm.llmapi import TrtLlmArgs as LlmArgs
 from tensorrt_llm.llmapi.llm_args import DynamicBatchConfig, SchedulerConfig
 from tensorrt_llm.llmapi.llm_utils import (BuildConfig, QuantAlgo, QuantConfig,
                                            _ParallelConfig)


### PR DESCRIPTION
# PR title

Please write the PR title by following template:

[JIRA ticket link/nvbug link/github issue link][fix/feat/doc/infra/...] \<summary of this PR\>

For example, assume I have a PR hope to support a new feature about cache manager of Jira TRTLLM-1000 ticket, it would be like

[TRTLLM-1000][feat] Support a new feature about cache manager

## Description

Please explain the issue and the solution in short.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new class for running large language models with TensorRT backend, offering enhanced configuration options for calibration, quantization, and performance tuning.
  * Added explicit configuration classes for calibration and runtime performance knobs.

* **Refactor**
  * Updated public APIs to explicitly export or remove certain configuration classes, clarifying module boundaries.
  * Consolidated TensorRT-specific argument handling into the TensorRT engine module and removed it from the general API.
  * Removed the dedicated TensorRT backend class from the main API and integrated backend detection into the base model class.

* **Chores**
  * Improved import organization and updated test imports to reflect new module structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->