### PR TITLE
[TRTLLM-5878] add stage for image registration to nspect

### DIFF
--- a/jenkins/BuildDockerImage.groovy
+++ b/jenkins/BuildDockerImage.groovy
@@ -90,8 +90,8 @@ def createKubernetesPodConfig(type, arch = "amd64", build_wheel = false)
     {
     case "agent":
         containerConfig = """
-                  - name: alpine
-                    image: urm.nvidia.com/docker/alpine:latest
+                  - name: python3
+                    image: urm.nvidia.com/docker/python:3.12-slim
                     command: ['cat']
                     tty: true
                     resources:
@@ -491,6 +491,46 @@ pipeline {
                     writeFile file: "imageKeyToTag.json", text: imageKeyToTagJson
                     archiveArtifacts artifacts: 'imageKeyToTag.json', fingerprint: true
                     trtllm_utils.uploadArtifacts("imageKeyToTag.json", "${UPLOAD_PATH}/")
+                }
+            }
+        }
+        stage("Register Images") {
+            when {
+                expression {
+                    return params.nspect_id && params.action == "push"
+                }
+            }
+            steps {
+                script {
+                    container("python3") {
+                        sh "pip3 install --upgrade pip"
+                        sh "pip3 install --upgrade requests"
+                        def nspect_commit = "170c09aa35d5dacdc40611dd907f8801742fd5e4"
+                        withCredentials([string(credentialsId: "TRTLLM_NSPECT_REPO", variable: "NSPECT_REPO")]) {
+                            trtllm_utils.checkoutSource("${NSPECT_REPO}", nspect_commit, "nspect")
+                        }
+                        def nspect_env = params.nspect_env ? params.nspect_env : "prod"
+                        def program_version_name = params.program_version_name ? params.program_version_name : "PostMerge"
+                        def cmd = """./nspect/nspect.py \
+                            --env ${nspect_env} \
+                            --nspect_id ${params.nspect_id} \
+                            --program_version_name '${program_version_name}' \
+                            """
+                        if (params.register_images) {
+                            cmd += "--register "
+                        }
+                        if (params.osrb_ticket) {
+                            cmd += "--osrb_ticket ${params.osrb_ticket} "
+                        }
+                        if (params.wait_success_seconds) {
+                            cmd += "--check_launch_api "
+                            cmd += "--wait_success ${params.wait_success_seconds} "
+                        }
+                        cmd += imageKeyToTag.values().join(" ")
+                        withCredentials([usernamePassword(credentialsId: "NSPECT_CLIENT-${nspect_env}", usernameVariable: 'NSPECT_CLIENT_ID', passwordVariable: 'NSPECT_CLIENT_SECRET')]) {
+                            sh cmd
+                        }
+                    }
                 }
             }
         }

--- a/jenkins/BuildDockerImage.groovy
+++ b/jenkins/BuildDockerImage.groovy
@@ -494,7 +494,7 @@ pipeline {
                 }
             }
         }
-        stage("Register Images") {
+        stage("Register Images for Security Checks") {
             when {
                 expression {
                     return params.nspect_id && params.action == "push"
@@ -503,8 +503,8 @@ pipeline {
             steps {
                 script {
                     container("python3") {
-                        sh "pip3 install --upgrade pip"
-                        sh "pip3 install --upgrade requests"
+                        trtllm_utils.llmExecStepWithRetry(pipeline, script: "pip3 install --upgrade pip")
+                        trtllm_utils.llmExecStepWithRetry(pipeline, script: "pip3 install --upgrade requests")
                         def nspect_commit = "170c09aa35d5dacdc40611dd907f8801742fd5e4"
                         withCredentials([string(credentialsId: "TRTLLM_NSPECT_REPO", variable: "NSPECT_REPO")]) {
                             trtllm_utils.checkoutSource("${NSPECT_REPO}", nspect_commit, "nspect")


### PR DESCRIPTION
# PR title

Please write the PR title by following template:

[JIRA ticket link/nvbug link/github issue link][fix/feat/doc/infra/...] \<summary of this PR\>

For example, assume I have a PR hope to support a new feature about cache manager of Jira TRTLLM-1000 ticket, it would be like

[TRTLLM-1000][feat] Support a new feature about cache manager

## Description

Please explain the issue and the solution in short.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
