### PR TITLE
[TRTLLM-5061] chore: add status tags to LLM API reference

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,0 +1,19 @@
+.tag {
+  padding: 2px 5px;
+  border-radius: 4px;
+  font-size: 0.8em;
+  margin-right: 5px;
+  color: #000;
+}
+
+code.beta {
+  display: inline-block;
+  background-color: #007bff;
+  color: #fff;
+}
+
+code.prototype {
+  display: inline-block;
+  background-color: #fd7e14;
+  color: #fff;
+}

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -8,12 +8,18 @@
 
 code.beta {
   display: inline-block;
-  background-color: #007bff;
-  color: #fff;
+  background-color: #6c757d;
+  color: #999;
 }
 
 code.prototype {
   display: inline-block;
   background-color: #fd7e14;
+  color: #fff;
+}
+
+code.deprecated {
+  display: inline-block;
+  background-color: red;
   color: #fff;
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 
 import pygit2
+from docutils import nodes
 
 sys.path.insert(0, os.path.abspath('.'))
 
@@ -60,10 +61,14 @@ extensions = [
     'sphinx_togglebutton',
 ]
 
+autodoc_member_order = 'bysource'
 autodoc_pydantic_model_show_json = True
 autodoc_pydantic_model_show_config_summary = True
 autodoc_pydantic_field_doc_policy = "description"
 autodoc_pydantic_model_show_field_list = True  # Display field list with descriptions
+autodoc_pydantic_model_member_order = "groupwise"
+autodoc_pydantic_model_hide_pydantic_methods = True
+autodoc_pydantic_field_list_validators = False
 
 myst_url_schemes = {
     "http":
@@ -143,9 +148,30 @@ CPP_GEN_DIR = os.path.join(SCRIPT_DIR, '_cpp_gen')
 print('CPP_INCLUDE_DIR', CPP_INCLUDE_DIR)
 print('CPP_GEN_DIR', CPP_GEN_DIR)
 
+html_css_files = [
+    'custom.css',
+]
+
+
+def experimental_role(name,
+                      rawtext,
+                      text,
+                      lineno,
+                      inliner,
+                      options={},
+                      content=[]):
+    """A custom role to mark fields as experimental."""
+    node = nodes.literal(text, text, classes=['experimental'])
+    return [node], []
+
 
 def setup(app):
     from helper import generate_examples, generate_llmapi
+
+    from tensorrt_llm.llmapi.utils import DocTagger
+    DocTagger()()
+
+    app.add_role('experimental', experimental_role)
 
     generate_examples()
     generate_llmapi()

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -69,6 +69,8 @@ autodoc_pydantic_model_show_field_list = True  # Display field list with descrip
 autodoc_pydantic_model_member_order = "groupwise"
 autodoc_pydantic_model_hide_pydantic_methods = True
 autodoc_pydantic_field_list_validators = False
+autodoc_pydantic_settings_signature_prefix = ""  # remove any prefix
+autodoc_pydantic_settings_hide_reused_validator = True  # hide all the validator should be better
 
 myst_url_schemes = {
     "http":
@@ -153,25 +155,20 @@ html_css_files = [
 ]
 
 
-def experimental_role(name,
-                      rawtext,
-                      text,
-                      lineno,
-                      inliner,
-                      options={},
-                      content=[]):
-    """A custom role to mark fields as experimental."""
-    node = nodes.literal(text, text, classes=['experimental'])
+def tag_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+    """A custom role for displaying tags."""
+    tag_name = text.lower()
+    node = nodes.literal(text, text, classes=['tag', tag_name])
     return [node], []
 
 
 def setup(app):
     from helper import generate_examples, generate_llmapi
 
-    from tensorrt_llm.llmapi.utils import DocTagger
-    DocTagger()()
+    from tensorrt_llm.llmapi.utils import tag_llm_params
+    tag_llm_params()
 
-    app.add_role('experimental', experimental_role)
+    app.add_role('tag', tag_role)
 
     generate_examples()
     generate_llmapi()

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -155,8 +155,10 @@ html_css_files = [
 ]
 
 
-def tag_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+def tag_role(name, rawtext, text, lineno, inliner, options=None, content=None):
     """A custom role for displaying tags."""
+    options = options or {}
+    content = content or []
     tag_name = text.lower()
     node = nodes.literal(text, text, classes=['tag', tag_name])
     return [node], []

--- a/docs/source/custom.css
+++ b/docs/source/custom.css
@@ -1,8 +1,0 @@
-.experimental {
-  background-color: #ffc107; /* A yellow background */
-  color: #000;
-  padding: 2px 5px;
-  border-radius: 4px;
-  font-size: 0.8em;
-  margin-right: 5px;
-}

--- a/docs/source/custom.css
+++ b/docs/source/custom.css
@@ -1,0 +1,8 @@
+.experimental {
+  background-color: #ffc107; /* A yellow background */
+  color: #000;
+  padding: 2px 5px;
+  border-radius: 4px;
+  font-size: 0.8em;
+  margin-right: 5px;
+}

--- a/docs/source/helper.py
+++ b/docs/source/helper.py
@@ -304,11 +304,13 @@ def generate_llmapi():
             "    :members:", "    :undoc-members:", "    :show-inheritance:"
         ]
 
-        if cls_name != 'LLM':  # Conditionally add :special-members: __init__
+        if cls_name not in ['LLM', 'TorchLlmArgs', 'TrtLlmArgs', 'LlmArgs'
+                            ]:  # Conditionally add :special-members: __init__
             options.append("    :special-members: __init__")
+        elif cls_name in ["TorchLlmArgs", "TrtLlmArgs"]:
+            options.insert(0, "    :inherited-members: BaseModel")
 
-        if cls_name in ['TrtLLM', 'TorchLLM', 'LLM']:
-            options.append("    :inherited-members:")
+        options.append("    :member-order: groupwise")
 
         content += f".. autoclass:: tensorrt_llm.llmapi.{cls_name}\n"
         content += "\n".join(options) + "\n\n"

--- a/docs/source/helper.py
+++ b/docs/source/helper.py
@@ -286,6 +286,18 @@ def extract_all_and_eval(file_path):
     return local_vars
 
 
+def get_pydantic_methods() -> list[str]:
+    from pydantic import BaseModel
+
+    class Dummy(BaseModel):
+        pass
+
+    methods = set(
+        [method for method in dir(Dummy) if not method.startswith('_')])
+    methods.discard("__init__")
+    return list(methods)
+
+
 def generate_llmapi():
     root_dir = Path(__file__).parent.parent.parent.resolve()
 
@@ -301,16 +313,18 @@ def generate_llmapi():
     for cls_name in public_classes_names:
         cls_name = cls_name.strip()
         options = [
-            "    :members:", "    :undoc-members:", "    :show-inheritance:"
+            "    :members:",
+            "    :undoc-members:",
+            "    :show-inheritance:",
+            "    :special-members: __init__",
+            "    :member-order: groupwise",
         ]
 
-        if cls_name not in ['LLM', 'TorchLlmArgs', 'TrtLlmArgs', 'LlmArgs'
-                            ]:  # Conditionally add :special-members: __init__
-            options.append("    :special-members: __init__")
-        elif cls_name in ["TorchLlmArgs", "TrtLlmArgs"]:
-            options.insert(0, "    :inherited-members: BaseModel")
-
-        options.append("    :member-order: groupwise")
+        options.append("    :inherited-members:")
+        if cls_name in ["TorchLlmArgs", "TrtLlmArgs"]:
+            # exclude tons of methods from Pydantic
+            options.append(
+                f"    :exclude-members: {','.join(get_pydantic_methods())}")
 
         content += f".. autoclass:: tensorrt_llm.llmapi.{cls_name}\n"
         content += "\n".join(options) + "\n\n"

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -40,7 +40,7 @@ from .tokenizer import (TokenizerBase, _llguidance_tokenizer_info,
                         _xgrammar_tokenizer_info)
 # TODO[chunweiy]: move the following symbols back to utils scope, and remove the following import
 from .utils import (append_docstring, exception_handler, get_device_count,
-                    print_colored_debug)
+                    print_colored_debug, set_api_status)
 
 
 class RequestOutput(DetokenizedGenerationResultBase, GenerationResult):
@@ -212,6 +212,7 @@ class BaseLLM:
         atexit.register(LLM._shutdown_wrapper, weakref.ref(self))
 
     @property
+    @set_api_status("beta")
     def llm_id(self) -> str:
         if self._llm_id is None:
             hostname = socket.gethostname()
@@ -422,6 +423,7 @@ class BaseLLM:
         return RequestOutput._from_generation_result(result, prompt,
                                                      self.tokenizer)
 
+    @set_api_status("beta")
     def get_stats(self, timeout: Optional[float] = 2) -> List[dict]:
         '''Get iteration statistics from the runtime.
         To collect statistics, call this function after prompts have been submitted with LLM().generate().
@@ -435,6 +437,7 @@ class BaseLLM:
         '''
         return self._executor.get_stats(timeout=timeout)
 
+    @set_api_status("beta")
     def get_stats_async(self, timeout: Optional[float] = 2) -> IterationResult:
         '''Get iteration statistics from the runtime.
         To collect statistics, you can call this function in an async coroutine or the /metrics endpoint (if you're using trtllm-serve)
@@ -448,6 +451,7 @@ class BaseLLM:
         '''
         return self._executor.aget_stats(timeout=timeout)
 
+    @set_api_status("beta")
     def get_kv_cache_events(self, timeout: Optional[float] = 2) -> List[dict]:
         '''Get iteration KV events from the runtime.
 
@@ -469,6 +473,7 @@ class BaseLLM:
         '''
         return self._executor.get_kv_events(timeout=timeout)
 
+    @set_api_status("beta")
     def get_kv_cache_events_async(self,
                                   timeout: Optional[float] = 2
                                   ) -> IterationResult:
@@ -659,6 +664,7 @@ class BaseLLM:
     def tokenizer(self, tokenizer: TokenizerBase):
         self._tokenizer = tokenizer
 
+    @set_api_status("beta")
     def shutdown(self) -> None:
         if hasattr(self, "_executor") and self._executor is not None:
             self._executor.shutdown()
@@ -1036,13 +1042,11 @@ class LLM(_TorchLLM):
                          revision, tokenizer_revision, **kwargs)
 
 
-_LLM_REPR = "TorchLLM"
-
 # sphinx will ignore the LLM's docstring if it is not explicitly set
 LLM.__doc__ = \
     f"""LLM class is the main class for running a LLM model.
 
-    This class is an alias of {_LLM_REPR}.
+    For more details about the arguments, please refer to :class:`TorchLlmArgs`.
 
     Parameters:
 """ + TORCH_LLM_DOCSTRING

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1008,8 +1008,8 @@ class BaseLlmArgs(BaseModel):
 
     moe_cluster_parallel_size: Optional[int] = Field(
         default=None,
-        description="The cluster parallel size for MoE models's expert weights."
-    )
+        description="The cluster parallel size for MoE models's expert weights.",
+        status="beta")
 
     moe_tensor_parallel_size: Optional[int] = Field(
         default=None,
@@ -1869,7 +1869,8 @@ class TorchLlmArgs(BaseLlmArgs):
         status="beta")
 
     moe_config: MoeConfig = Field(default_factory=MoeConfig,
-                                  description="MoE config.")
+                                  description="MoE config.",
+                                  status="beta")
 
     attn_backend: str = Field(default='TRTLLM',
                               description="Attention backend to use.",
@@ -1888,7 +1889,9 @@ class TorchLlmArgs(BaseLlmArgs):
         status="prototype")
 
     enable_iter_perf_stats: bool = Field(
-        default=False, description="Enable iteration performance statistics.")
+        default=False,
+        description="Enable iteration performance statistics.",
+        status="prototype")
 
     enable_iter_req_stats: bool = Field(
         default=False,

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -71,9 +71,9 @@ def Field(default: Any = ...,
     Args:
         default: The default value for the field
         status: Optional status indicator that gets added to json_schema_extra.
-           - None: stable
-           - "beta": beta, recommended to use according to the latest documentation
-           - "prototype": prototype, not recommended to use
+            - None: Stable.
+            - "beta": Recommended for use per the latest documentation.
+            - "prototype": Not yet stable and subject to breaking changes; intended for experimentation only.
         **kwargs: All other arguments passed to the original Pydantic Field
 
     Returns:
@@ -1155,7 +1155,10 @@ class BaseLlmArgs(BaseModel):
     decoding_config: Optional[object] = Field(
         default=None,
         description="The decoding config.",
-        json_schema_extra={"type": "Optional[DecodingConfig]"},
+        json_schema_extra={
+            "type": "Optional[tensorrt_llm.llmapi.llm_args.DecodingConfig]"
+        },
+        status="deprecated",
         deprecated="Use speculative_config instead.",
     )
 

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -64,7 +64,7 @@ from .utils import generate_api_docs_as_docstring, get_type_repr
 
 def Field(default: Any = ...,
           *,
-          status: Optional[Literal["prototype", "beta"]] = None,
+          status: Optional[Literal["prototype", "beta", "deprecated"]] = None,
           **kwargs: Any) -> Any:
     """Custom Field wrapper that adds status to json_schema_extra.
 
@@ -1045,16 +1045,23 @@ class BaseLlmArgs(BaseModel):
     max_lora_rank: Optional[int] = Field(
         default=None,
         description="The maximum LoRA rank.",
-        deprecated="Use lora_config.max_lora_rank instead.")
+        deprecated="Use lora_config.max_lora_rank instead.",
+        status="deprecated",
+    )
 
-    max_loras: int = Field(default=4,
-                           description="The maximum number of LoRA.",
-                           deprecated="Use lora_config.max_loras instead.")
+    max_loras: int = Field(
+        default=4,
+        description="The maximum number of LoRA.",
+        deprecated="Use lora_config.max_loras instead.",
+        status="deprecated",
+    )
 
     max_cpu_loras: int = Field(
         default=4,
         description="The maximum number of LoRA on CPU.",
-        deprecated="Use lora_config.max_cpu_loras instead.")
+        deprecated="Use lora_config.max_cpu_loras instead.",
+        status="deprecated",
+    )
 
     lora_config: Optional[LoraConfig] = Field(
         default=None, description="LoRA configuration for the model.")
@@ -1164,6 +1171,7 @@ class BaseLlmArgs(BaseModel):
         description="The backend to use for this LLM instance.",
         exclude_json_schema=True,  # hide from API references
         validate_default=True,
+        status="deprecated",
     )
 
     _parallel_config: Optional[object] = PrivateAttr(default=None)
@@ -1843,7 +1851,9 @@ class TorchLlmArgs(BaseLlmArgs):
         default=None,
         description="Build config.",
         exclude_from_json=True,
-        json_schema_extra={"type": f"Optional[{get_type_repr(BuildConfig)}]"})
+        json_schema_extra={"type": f"Optional[{get_type_repr(BuildConfig)}]"},
+        status="deprecated",
+    )
 
     # PyTorch backend specific configurations
     garbage_collection_gen0_threshold: int = Field(

--- a/tensorrt_llm/llmapi/utils.py
+++ b/tensorrt_llm/llmapi/utils.py
@@ -493,7 +493,7 @@ def generate_api_docs_as_docstring(model: Type[BaseModel],
     for field_name, field_info in schema['properties'].items():
         if field_name.startswith("_"):  # skip private fields
             continue
-        if field_info.get("deprecated", False):
+        if field_info.get("status", None) == "deprecated":
             continue
 
         field_type = field_info.get('type', None)

--- a/tensorrt_llm/llmapi/utils.py
+++ b/tensorrt_llm/llmapi/utils.py
@@ -20,6 +20,7 @@ import filelock
 import huggingface_hub
 import psutil
 import torch
+import yaml
 from huggingface_hub import snapshot_download
 from pydantic import BaseModel
 from tqdm.auto import tqdm
@@ -546,3 +547,54 @@ def get_type_repr(cls):
     if module_name == 'builtins':  # Special case for built-in types
         return cls.__qualname__
     return f"{module_name}.{cls.__qualname__}"
+
+
+class DocTagger:
+    TRT_ROOT = Path(__file__).parent.parent.parent
+
+    def __call__(self):
+        self.amend_llm_args()
+
+    def load_yaml(self, yaml_path: str) -> None:
+        with open(yaml_path, 'r') as f:
+            yaml_data = yaml.load(f, Loader=yaml.FullLoader)
+            return yaml_data
+
+    def amend_llm_args(self):
+        # background:
+        # There are two yaml files:
+        #  - references/llm.yaml: experimental APIs
+        #  - committed_references/llm.yaml: stable APIs
+        # We need to decorate the experimental fields with `:experimental:`
+        from .llm_args import LlmArgs
+
+        llm_args_yaml_path = self.TRT_ROOT / "tests" / "unittest" / "api_stability" / "references" / "llm.yaml"
+        assert llm_args_yaml_path.exists(
+        ), f"LLM args yaml path {llm_args_yaml_path} does not exist"
+        llm_args_yaml = self.load_yaml(llm_args_yaml_path)
+
+        experimental_fields = []
+        for field_name, field_info in llm_args_yaml["methods"]["__init__"][
+                "parameters"].items():
+            experimental_fields.append(field_name)
+        self.amend_pydantic_field_description_with_tags(LlmArgs,
+                                                        experimental_fields,
+                                                        "experimental")
+
+    def amend_pydantic_field_description_with_tags(self, cls: Type[BaseModel],
+                                                   field_names: list[str],
+                                                   tag: str) -> None:
+        """Amend the description of the fields with tags.
+        e.g. `:experimental:`
+
+        Args:
+            cls: The Pydantic BaseModel class.
+            field_names: The names of the fields to amend.
+            tag: The tag to add to the fields.
+        """
+        assert field_names
+        for field_name in field_names:
+            field = cls.model_fields[field_name]
+            cls.model_fields[
+                field_name].description = f":{tag}: {field.description}"
+        cls.model_rebuild(force=True)

--- a/tensorrt_llm/llmapi/utils.py
+++ b/tensorrt_llm/llmapi/utils.py
@@ -546,3 +546,91 @@ def get_type_repr(cls):
     if module_name == 'builtins':  # Special case for built-in types
         return cls.__qualname__
     return f"{module_name}.{cls.__qualname__}"
+
+
+class ApiParamTagger:
+    ''' A helper to tag the api doc according to the status of the fields.
+    The status is set in the json_schema_extra of the field.
+    '''
+
+    def __call__(self, cls: Type[BaseModel]) -> None:
+        self.process_pydantic_model(cls)
+
+    def process_pydantic_model(self, cls: Type[BaseModel]) -> None:
+        """Process the Pydantic model to add tags to the fields.
+        """
+        for field_name, field_info in cls.model_fields.items():
+            if field_info.json_schema_extra and 'status' in field_info.json_schema_extra:
+                status = field_info.json_schema_extra['status']
+                self.amend_pydantic_field_description_with_tags(
+                    cls, [field_name], status)
+
+    def amend_pydantic_field_description_with_tags(self, cls: Type[BaseModel],
+                                                   field_names: list[str],
+                                                   tag: str) -> None:
+        """Amend the description of the fields with tags.
+        e.g. :tag:`beta` or :tag:`prototype`
+        Args:
+            cls: The Pydantic BaseModel class.
+            field_names: The names of the fields to amend.
+            tag: The tag to add to the fields.
+        """
+        assert field_names
+        for field_name in field_names:
+            field = cls.model_fields[field_name]
+            cls.model_fields[
+                field_name].description = f":tag:`{tag}` {field.description}"
+        cls.model_rebuild(force=True)
+
+
+def tag_llm_params():
+    from tensorrt_llm.llmapi.llm_args import LlmArgs
+    ApiParamTagger()(LlmArgs)
+
+
+class ApiStatusRegistry:
+    ''' A registry to store the status of the api.
+
+    usage:
+
+    @ApiStatusRegistry.set_api_status("beta")
+    def my_method(self, *args, **kwargs):
+        pass
+
+    class App:
+        @ApiStatusRegistry.set_api_status("beta")
+        def my_method(self, *args, **kwargs):
+            pass
+    '''
+    method_to_status = {}
+
+    @classmethod
+    def set_api_status(cls, status: str):
+
+        def decorator(func):
+            # Use qualified name to support class methods
+            if func.__qualname__ in cls.method_to_status:
+                logger.debug(
+                    f"Method {func.__qualname__} already has a status, skipping the decorator"
+                )
+                return func
+            cls.method_to_status[func.__qualname__] = status
+            func.__doc__ = cls.amend_api_doc_with_status_tags(func)
+            return func
+
+        return decorator
+
+    @classmethod
+    def get_api_status(cls, method: Callable) -> Optional[str]:
+        return cls.method_to_status.get(method.__qualname__, None)
+
+    @classmethod
+    def amend_api_doc_with_status_tags(cls, method: Callable) -> str:
+        status = cls.get_api_status(method)
+        if status is None:
+            return method.__doc__
+        return f":tag:`{status}` {method.__doc__}"
+
+
+set_api_status = ApiStatusRegistry().set_api_status
+get_api_status = ApiStatusRegistry().get_api_status

--- a/tests/unittest/_torch/test_beam_search.py
+++ b/tests/unittest/_torch/test_beam_search.py
@@ -63,7 +63,7 @@ def llm_cuda_graph(fixed_params, input_prompts):
         enable_trtllm_sampler=True,
         max_beam_width=fixed_params["max_beam_width"],
         disable_overlap_scheduler=False,
-        cuda_graph_config=CudaGraphConfig(enabled=True),
+        cuda_graph_config=CudaGraphConfig(),
     )
 
 

--- a/tests/unittest/api_stability/api_stability_core.py
+++ b/tests/unittest/api_stability/api_stability_core.py
@@ -448,7 +448,7 @@ class ApiStabilityTestHarness:
     def test_api_status(self):
         """ Check that the API status (prototype | beta) matches the llm.yaml.
         Note that, only the non-committed APIs are checked, the committed APIs
-        are treated as stable..
+        are treated as stable.
         """
         from tensorrt_llm.llmapi.llm_args import TorchLlmArgs
 
@@ -466,6 +466,18 @@ class ApiStabilityTestHarness:
 
         def check_status(field_name, reference_status, context=""):
             actual_status = get_actual_status(field_name)
+            if actual_status is None:
+                raise AssertionError(
+                    f"Status is not set for the non-committed {context}'{field_name}', "
+                    "please update the field with Field(..., status='<status>'), "
+                    "status could be either 'beta' or 'prototype'.")
+
+            if reference_status is None:
+                raise AssertionError(
+                    f"Status is not set for {context}'{field_name}' in reference/llm.yaml, "
+                    "please update the field with Field(..., status='<status>'), "
+                    "status could be either 'beta' or 'prototype'.")
+
             if actual_status != reference_status:
                 raise AssertionError(
                     f"Status mismatch for {context}'{field_name}': "

--- a/tests/unittest/api_stability/references/llm.yaml
+++ b/tests/unittest/api_stability/references/llm.yaml
@@ -9,6 +9,7 @@ methods:
       moe_cluster_parallel_size:
         annotation: Optional[int]
         default: null
+        status: beta
       enable_attention_dp:
         annotation: bool
         default: False
@@ -69,9 +70,11 @@ methods:
       backend:
         annotation: Optional[str]
         default: null
+        status: deprecated
       build_config:
         annotation: Optional[tensorrt_llm.llmapi.llm_args.BuildConfig]
         default: null
+        status: deprecated
       cuda_graph_config:
         annotation: Optional[tensorrt_llm.llmapi.llm_args.CudaGraphConfig]
         default: null
@@ -87,6 +90,7 @@ methods:
       disable_overlap_scheduler:
         annotation: bool
         default: False
+        status: beta
       moe_config:
         annotation: tensorrt_llm.llmapi.llm_args.MoeConfig
         status: beta
@@ -110,6 +114,7 @@ methods:
       enable_iter_perf_stats:
         annotation: bool
         default: False
+        status: prototype
       enable_iter_req_stats:
         annotation: bool
         default: False
@@ -167,27 +172,32 @@ methods:
         annotation: Optional[float]
         default: 2
     return_annotation: List[dict]
+    status: beta
   get_kv_cache_events_async:
     parameters:
       timeout:
         annotation: Optional[float]
         default: 2
     return_annotation: tensorrt_llm.executor.result.IterationResult
+    status: beta
   get_stats:
     parameters:
       timeout:
         annotation: Optional[float]
         default: 2
     return_annotation: List[dict]
+    status: beta
   get_stats_async:
     parameters:
       timeout:
         annotation: Optional[float]
         default: 2
     return_annotation: tensorrt_llm.executor.result.IterationResult
+    status: beta
   shutdown:
     parameters: {}
     return_annotation: None
+    status: beta
 properties:
   llm_id:
     annotation: str

--- a/tests/unittest/api_stability/references/llm.yaml
+++ b/tests/unittest/api_stability/references/llm.yaml
@@ -147,6 +147,10 @@ methods:
         annotation: Optional[Literal['AUTO', 'NCCL', 'UB', 'MINLATENCY', 'ONESHOT', 'TWOSHOT', 'LOWPRECISION', 'MNNVL']]
         default: AUTO
         status: beta
+      decoding_config:
+        annotation: Optional[tensorrt_llm.llmapi.llm_args.DecodingConfig]
+        default: null
+        status: deprecated
     return_annotation: None
   generate:
     parameters:

--- a/tests/unittest/api_stability/references/llm.yaml
+++ b/tests/unittest/api_stability/references/llm.yaml
@@ -5,61 +5,66 @@ methods:
       gpus_per_node:
         annotation: Optional[int]
         default: null
+        status: beta
       moe_cluster_parallel_size:
         annotation: Optional[int]
         default: null
       enable_attention_dp:
         annotation: bool
         default: False
+        status: beta
       cp_config:
         annotation: Optional[dict]
         default: null
+        status: prototype
       # Stats
       iter_stats_max_iterations:
         annotation: Optional[int]
         default: null
+        status: prototype
       request_stats_max_iterations:
         annotation: Optional[int]
         default: null
+        status: prototype
       # Bindings and mirrored configs
       peft_cache_config:
         annotation: Optional[tensorrt_llm.llmapi.llm_args.PeftCacheConfig]
         default: null
+        status: prototype
       scheduler_config:
         annotation: tensorrt_llm.llmapi.llm_args.SchedulerConfig
         default: null
+        status: prototype
       cache_transceiver_config:
         annotation: Optional[tensorrt_llm.llmapi.llm_args.CacheTransceiverConfig]
         default: null
-      batching_type:
-        annotation: Optional[tensorrt_llm.llmapi.llm_args.BatchingType]
-        default: null
-      normalize_log_probs:
-        annotation: bool
-        default: False
+        status: prototype
       gather_generation_logits:
         annotation: bool
         default: False
+        status: prototype
       num_postprocess_workers:
         annotation: int
         default: 0
+        status: prototype
       postprocess_tokenizer_dir:
         annotation: Optional[str]
         default: null
-      stream_interval:
-        annotation: int
-        default: 1
+        status: prototype
       # reasoning
       reasoning_parser:
         annotation: Optional[str]
         default: null
+        status: prototype
       # Runtime behavior
       fail_fast_on_attention_window_too_large:
         annotation: bool
         default: false
+        status: prototype
       garbage_collection_gen0_threshold:
         annotation: int
         default: 20000
+        status: beta
       # Misc
       backend:
         annotation: Optional[str]
@@ -70,57 +75,73 @@ methods:
       cuda_graph_config:
         annotation: Optional[tensorrt_llm.llmapi.llm_args.CudaGraphConfig]
         default: null
+        status: beta
       checkpoint_loader:
         annotation: Optional[tensorrt_llm._torch.BaseCheckpointLoader]
         default: null
+        status: prototype
       checkpoint_format:
         annotation: Optional[str]
         default: null
+        status: prototype
       disable_overlap_scheduler:
         annotation: bool
         default: False
       moe_config:
         annotation: tensorrt_llm.llmapi.llm_args.MoeConfig
+        status: beta
         default: null
       attn_backend:
         annotation: str
         default: TRTLLM
+        status: beta
       enable_mixed_sampler:
         annotation: bool
         default: False
+        status: beta
       enable_trtllm_sampler:
         annotation: bool
         default: False
+        status: prototype
       kv_cache_dtype:
         annotation: str
         default: auto
+        status: prototype
       enable_iter_perf_stats:
         annotation: bool
         default: False
       enable_iter_req_stats:
         annotation: bool
         default: False
+        status: prototype
       print_iter_log:
         annotation: bool
         default: False
+        status: beta
       torch_compile_config:
         annotation: Optional[tensorrt_llm.llmapi.llm_args.TorchCompileConfig]
         default: null
+        status: prototype
       enable_autotuner:
         annotation: bool
         default: True
+        status: prototype
       enable_layerwise_nvtx_marker:
         annotation: bool
         default: False
+        status: beta
       enable_min_latency:
         annotation: bool
         default: False
+        status: beta
       force_dynamic_quantization:
         annotation: bool
         default: False
+        status: prototype
       allreduce_strategy:
         annotation: Optional[Literal['AUTO', 'NCCL', 'UB', 'MINLATENCY', 'ONESHOT', 'TWOSHOT', 'LOWPRECISION', 'MNNVL']]
         default: AUTO
+        status: beta
     return_annotation: None
   generate:
     parameters:

--- a/tests/unittest/api_stability/references_committed/llm.yaml
+++ b/tests/unittest/api_stability/references_committed/llm.yaml
@@ -90,6 +90,9 @@ methods:
       kv_cache_config:
         annotation: tensorrt_llm.llmapi.llm_args.KvCacheConfig
         default: null
+      stream_interval:
+        annotation: int
+        default: 1
 
       kwargs:
         annotation: Any

--- a/tests/unittest/llmapi/test_utils.py
+++ b/tests/unittest/llmapi/test_utils.py
@@ -1,8 +1,0 @@
-from tensorrt_llm.llmapi import LlmArgs
-from tensorrt_llm.llmapi.utils import DocTagger, generate_api_docs_as_docstring
-
-
-def test_doc_tagger():
-    doc_tagger = DocTagger()
-    doc_tagger()
-    print(generate_api_docs_as_docstring(LlmArgs))

--- a/tests/unittest/llmapi/test_utils.py
+++ b/tests/unittest/llmapi/test_utils.py
@@ -1,0 +1,24 @@
+from tensorrt_llm.llmapi.utils import ApiStatusRegistry
+
+
+def test_api_status_registry():
+
+    @ApiStatusRegistry.set_api_status("beta")
+    def _my_method(self, *args, **kwargs):
+        pass
+
+    assert ApiStatusRegistry.get_api_status(_my_method) == "beta"
+
+    @ApiStatusRegistry.set_api_status("prototype")
+    def _my_method(self, *args, **kwargs):
+        pass
+
+    assert ApiStatusRegistry.get_api_status(_my_method) == "prototype"
+
+    class App:
+
+        @ApiStatusRegistry.set_api_status("beta")
+        def _my_method(self, *args, **kwargs):
+            pass
+
+    assert ApiStatusRegistry.get_api_status(App._my_method) == "beta"

--- a/tests/unittest/llmapi/test_utils.py
+++ b/tests/unittest/llmapi/test_utils.py
@@ -1,0 +1,8 @@
+from tensorrt_llm.llmapi import LlmArgs
+from tensorrt_llm.llmapi.utils import DocTagger, generate_api_docs_as_docstring
+
+
+def test_doc_tagger():
+    doc_tagger = DocTagger()
+    doc_tagger()
+    print(generate_api_docs_as_docstring(LlmArgs))


### PR DESCRIPTION
## Motivation
- Add clear "prototype", "beta" tags to the API reference
- Print warning logs when users touch the unstable ("beta", "prototype") APIs

## Change
Add "prototype" and "beta" tags to all the APIs those not in the "committed_reference", note that, only the non-committed APIs has the tag.

<img width="694" height="572" alt="image" src="https://github.com/user-attachments/assets/163c63b8-dbe0-4f23-b403-f15aabae3589" />

There are two deprecated knobs:
<img width="1628" height="566" alt="image" src="https://github.com/user-attachments/assets/76e44777-706a-4e85-9707-0d4a423f4063" />

### Update to the LlmArgs development
For the non-committed APIs:

- Each API field should add consistent `status` metadata, the status could be either "beta" or "prototype"
   - In LlmArgs or other Pydantic classes, `xxx_field = Field(..., status="beta")`
   - In `reference/llm.yaml`, add `status: beta`
- Each API method should add consistent status metadata
   - Add `@set_api_status("beta")` on the target method
   - Add `status: beta` in the `reference/llm.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced visual tags and styling in documentation to highlight beta, prototype, and deprecated features.
  * Added status annotations ("beta", "prototype", "deprecated") to API parameters and methods, now visible in documentation.
  * Implemented warnings for usage of unstable (beta/prototype) features in certain argument classes.

* **Bug Fixes**
  * Improved exclusion of deprecated and unstable fields from generated documentation.

* **Tests**
  * Added tests to verify correct tagging and status annotation of API methods and parameters.
  * Enhanced API stability tests to check for consistency of status metadata.

* **Documentation**
  * Updated documentation configuration and reference files to reflect new status tags and styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->