### PR TITLE
fix: auto-load sliding window config for VSWA models

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -189,6 +189,14 @@ class KVCacheManager(BaseResourceManager):
             self.max_attention_window_vec = kv_cache_config.max_attention_window.copy(
             )  # Make a copy to avoid modifying original
 
+            # NOTE: For global layers without sliding window, the initial
+            # window size is set to the maximum value (2^31-1) of int32 in
+            # llm_args. Here we clamp it to max_seq_len.
+            self.max_attention_window_vec = [
+                min(max_seq_len, window)
+                for window in self.max_attention_window_vec
+            ]
+
         sink_token_length = (kv_cache_config.sink_token_length
                              if kv_cache_config.sink_token_length is not None
                              else 0)

--- a/tensorrt_llm/commands/eval.py
+++ b/tensorrt_llm/commands/eval.py
@@ -22,7 +22,8 @@ from .. import LLM as PyTorchLLM
 from .._tensorrt_engine import LLM
 from ..evaluate import (GSM8K, MMLU, CnnDailymail, GPQADiamond, GPQAExtended,
                         GPQAMain, JsonModeEval)
-from ..llmapi import BuildConfig, KvCacheConfig
+from ..llmapi import BuildConfig
+from ..llmapi.llm_args import create_kv_cache_config
 from ..llmapi.llm_utils import update_llm_args_with_extra_options
 from ..logger import logger, severity_map
 
@@ -108,8 +109,10 @@ def main(ctx, model: str, tokenizer: Optional[str], log_level: str,
                                max_beam_width=max_beam_width,
                                max_seq_len=max_seq_len)
 
-    kv_cache_config = KvCacheConfig(
-        free_gpu_memory_fraction=kv_cache_free_gpu_memory_fraction)
+    kv_cache_config = create_kv_cache_config(
+        free_gpu_memory_fraction=kv_cache_free_gpu_memory_fraction,
+        model_path=model,
+        max_seq_len=max_seq_len)
 
     if backend == "tensorrt":
         backend = None

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -16,12 +16,12 @@ from tensorrt_llm._tensorrt_engine import LLM
 from tensorrt_llm._utils import mpi_rank
 from tensorrt_llm.executor.utils import LlmLauncherEnvs
 from tensorrt_llm.llmapi import (BuildConfig, CapacitySchedulerPolicy,
-                                 DynamicBatchConfig, KvCacheConfig,
-                                 SchedulerConfig)
+                                 DynamicBatchConfig, SchedulerConfig)
 from tensorrt_llm.llmapi.disagg_utils import (CtxGenServerConfig,
                                               MetadataServerConfig, ServerRole,
                                               parse_disagg_config_file,
                                               parse_metadata_server_config_file)
+from tensorrt_llm.llmapi.llm_args import create_kv_cache_config
 from tensorrt_llm.llmapi.llm_utils import update_llm_args_with_extra_dict
 from tensorrt_llm.llmapi.mpi_session import find_free_port
 from tensorrt_llm.llmapi.reasoning_parser import ReasoningParserFactory
@@ -94,8 +94,10 @@ def get_llm_args(model: str,
                                max_num_tokens=max_num_tokens,
                                max_beam_width=max_beam_width,
                                max_seq_len=max_seq_len)
-    kv_cache_config = KvCacheConfig(
-        free_gpu_memory_fraction=free_gpu_memory_fraction)
+    kv_cache_config = create_kv_cache_config(
+        free_gpu_memory_fraction=free_gpu_memory_fraction,
+        model_path=model,
+        max_seq_len=max_seq_len)
 
     dynamic_batch_config = DynamicBatchConfig(
         enable_batch_size_tuning=True,

--- a/tensorrt_llm/scaffolding/worker.py
+++ b/tensorrt_llm/scaffolding/worker.py
@@ -6,7 +6,7 @@ from transformers import AutoTokenizer
 
 from tensorrt_llm import LLM
 from tensorrt_llm.executor import GenerationExecutor
-from tensorrt_llm.llmapi.llm_args import KvCacheConfig
+from tensorrt_llm.llmapi.llm_args import create_kv_cache_config
 from tensorrt_llm.sampling_params import SamplingParams
 
 from .task import GenerationTask, Task, TaskStatus
@@ -137,8 +137,9 @@ class TRTLLMWorker(Worker):
         kv_cache_free_gpu_memory_fraction: float = 0.9,
         disable_overlap_scheduler: bool = False,
     ):
-        kv_cache_config = KvCacheConfig(
-            free_gpu_memory_fraction=kv_cache_free_gpu_memory_fraction, )
+        kv_cache_config = create_kv_cache_config(
+            free_gpu_memory_fraction=kv_cache_free_gpu_memory_fraction,
+            model_path=model_dir)
 
         tokenizer = AutoTokenizer.from_pretrained(
             model_dir,


### PR DESCRIPTION
LLM API now automatically sets sliding window `max_attention_window` of KvCacheConfig from HuggingFace config to enable VSWA without manual KvCacheConfig setup.

*Limitation*: Only supports (Local, Local, ..., Local, Global) patterns. Models with different VSWA patterns require manual configuration.

And, since VSWA does not support KV cache reuse yet, it is automatically disabled. It will be resolved after #4983 .

