### PR TITLE
[TRTLLM-5881] feat: Integrate TRT-LLM Gen FP4 block scale MoE with Pytorch workflow kernel autotuner

### DIFF
--- a/cpp/tensorrt_llm/thop/fp4BlockScaleMoe.cpp
+++ b/cpp/tensorrt_llm/thop/fp4BlockScaleMoe.cpp
@@ -25,8 +25,9 @@ namespace torch_ext
 {
 namespace btg = batchedGemm::trtllm::gen;
 using tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::Routing::RoutingMethodType;
+using MoeRunnerType = tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::MoE::Runner;
 
-std::vector<torch::Tensor> fp4_block_scale_moe_runner(torch::Tensor const& routing_logits,
+std::vector<torch::Tensor> run_fp4_block_scale_moe_runner(torch::Tensor const& routing_logits,
     torch::optional<torch::Tensor> const& routing_bias, torch::Tensor const& hidden_states,
     torch::Tensor const& hidden_states_scale, torch::Tensor const& gemm1_weights,
     torch::Tensor const& gemm1_weights_scale, torch::Tensor const& gemm2_weights,
@@ -35,7 +36,7 @@ std::vector<torch::Tensor> fp4_block_scale_moe_runner(torch::Tensor const& routi
     int64_t const num_experts, int64_t const top_k, std::optional<int64_t> const n_group,
     std::optional<int64_t> const topk_group, int64_t const intermediate_size, int64_t const local_expert_offset,
     int64_t const local_num_experts, std::optional<double> const routed_scaling_factor, int64_t const tile_tokens_dim,
-    int64_t const routing_method_type, bool const do_finalize)
+    int64_t const routing_method_type, bool const do_finalize, MoeRunnerType& moe_runner, int64_t const moeConfigIndex)
 {
     auto const sm = tensorrt_llm::common::getSMVersion();
     TORCH_CHECK(sm == 100, "Only SM100 is supported by FP4 block scale MOE");
@@ -43,6 +44,8 @@ std::vector<torch::Tensor> fp4_block_scale_moe_runner(torch::Tensor const& routi
             || routing_logits.scalar_type() == at::ScalarType::BFloat16,
         "routing_logits must be float or bfloat16.");
     TORCH_CHECK(routing_logits.dim() == 2, "routing_logits must be 2D.");
+    TORCH_CHECK(routing_logits.sizes()[0] == hidden_states.sizes()[0],
+        "routing_logits and hidden_states must have the same number of tokens.");
     TORCH_CHECK(routing_logits.sizes()[1] == num_experts, "routing_logits has incorrect shape.");
     if (routing_bias.has_value())
     {
@@ -261,13 +264,7 @@ std::vector<torch::Tensor> fp4_block_scale_moe_runner(torch::Tensor const& routi
     args.output2_scales_scalar = output2_scales_scalar.data_ptr<float>();
     args.do_finalize = do_finalize;
 
-    tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::MoE::Runner moe_runner(
-        args.mDtypeElt, args.mUseDeepSeekFp8, tile_tokens_dim);
-
-    auto const moeConfigIndex = moe_runner.getDefaultValidConfigIndex(
-        args.top_k, args.hidden_size, args.intermediate_size, args.local_num_experts, args.num_tokens);
-
-    auto workspace_sizes = moe_runner.getWorkspaceSizeInBytes(args, moeConfigIndex);
+    auto const workspace_sizes = moe_runner.getWorkspaceSizeInBytes(args, moeConfigIndex);
 
     at::Tensor workspace_fc1 = at::detail::empty_cuda(
         {std::get<0>(workspace_sizes)}, at::ScalarType::Char, hidden_states.device(), std::nullopt);
@@ -286,6 +283,63 @@ std::vector<torch::Tensor> fp4_block_scale_moe_runner(torch::Tensor const& routi
     return {output};
 }
 
+// Wrapped the TRTLLM-Gen kernel runner in a Torch custom class to allow
+// use with the torch workflow autotuner class.
+class FP4BlockScaleMoeRunner : public torch::CustomClassHolder
+{
+public:
+    explicit FP4BlockScaleMoeRunner(int64_t tileTokensDim)
+        : mTileTokensDim(tileTokensDim)
+    {
+        mRunner = std::make_unique<RunnerType>(mDtypeElt, mUseDeepSeekFp8, mTileTokensDim);
+    }
+
+    [[nodiscard]] std::vector<torch::Tensor> run(torch::Tensor const& routing_logits,
+        torch::optional<torch::Tensor> const& routing_bias, torch::Tensor const& hidden_states,
+        torch::Tensor const& hidden_states_scale, torch::Tensor const& gemm1_weights,
+        torch::Tensor const& gemm1_weights_scale, torch::Tensor const& gemm2_weights,
+        torch::Tensor const& gemm2_weights_scale, torch::Tensor const& output1_scales_scalar,
+        torch::Tensor const& output1_scales_gate_scalar, torch::Tensor const& output2_scales_scalar,
+        int64_t const num_experts, int64_t const top_k, std::optional<int64_t> const n_group,
+        std::optional<int64_t> const topk_group, int64_t const intermediate_size, int64_t const local_expert_offset,
+        int64_t const local_num_experts, std::optional<double> const routed_scaling_factor,
+        int64_t const routing_method_type, bool const do_finalize, int64_t moeConfigIndex)
+    {
+
+        // Autotuner has requested a default or 'fallback' config index
+        if (moeConfigIndex == -1)
+        {
+            auto const num_tokens = hidden_states.sizes()[0];
+
+            // 2x FP4 per byte element
+            auto const hidden_size = 2 * hidden_states.sizes()[1];
+
+            moeConfigIndex = mRunner->getDefaultValidConfigIndex(
+                top_k, hidden_size, intermediate_size, local_num_experts, num_tokens);
+        }
+
+        return run_fp4_block_scale_moe_runner(routing_logits, routing_bias, hidden_states, hidden_states_scale,
+            gemm1_weights, gemm1_weights_scale, gemm2_weights, gemm2_weights_scale, output1_scales_scalar,
+            output1_scales_gate_scalar, output2_scales_scalar, num_experts, top_k, n_group, topk_group,
+            intermediate_size, local_expert_offset, local_num_experts, routed_scaling_factor, mTileTokensDim,
+            routing_method_type, do_finalize, *mRunner, moeConfigIndex);
+    }
+
+    [[nodiscard]] std::vector<int64_t> getValidConfigs(
+        int64_t topK, int64_t hiddenSize, int64_t intermediateSize, int64_t numLocalExperts, int64_t numTokens) const
+    {
+        return mRunner->getValidConfigIndices(topK, hiddenSize, intermediateSize, numLocalExperts, numTokens);
+    }
+
+private:
+    using RunnerType = tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::MoE::Runner;
+
+    std::unique_ptr<RunnerType> mRunner;
+    btg::Dtype mDtypeElt{btg::Dtype::E2m1};
+    bool mUseDeepSeekFp8{false};
+    int64_t mTileTokensDim;
+};
+
 torch::Tensor shuffleMatrix(torch::Tensor matrix, torch::Tensor permuteIndices)
 {
     return torch::index_select(matrix, 0, permuteIndices);
@@ -295,36 +349,10 @@ torch::Tensor shuffleMatrix(torch::Tensor matrix, torch::Tensor permuteIndices)
 
 TORCH_LIBRARY_FRAGMENT(trtllm, m)
 {
-    m.def(
-        "fp4_block_scale_moe_runner("
-        "Tensor routing_logits,"
-        "Tensor? routing_bias,"
-        "Tensor hidden_states,"
-        "Tensor hidden_states_scale,"
-        "Tensor gemm1_weights,"
-        "Tensor gemm1_weights_scale,"
-        "Tensor gemm2_weights,"
-        "Tensor gemm2_weights_scale,"
-        "Tensor output1_scale_scalar,"
-        "Tensor output1_scale_gate_scalar,"
-        "Tensor output2_scale_scalar,"
-        "int num_experts,"
-        "int top_k,"
-        "int? n_group,"
-        "int? topk_group,"
-        "int intermediate_size,"
-        "int local_expert_offset,"
-        "int local_num_experts,"
-        "float? routed_scaling_factor,"
-        "int tile_tokens_dim,"
-        "int routing_method_type,"
-        "bool do_finalize) -> Tensor[]");
-}
-
-// Accepts CUDA tensor only
-TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
-{
-    m.impl("fp4_block_scale_moe_runner", &torch_ext::fp4_block_scale_moe_runner);
+    m.class_<torch_ext::FP4BlockScaleMoeRunner>("FP4BlockScaleMoERunner")
+        .def(torch::init<int64_t>())
+        .def("get_valid_configs", &torch_ext::FP4BlockScaleMoeRunner::getValidConfigs)
+        .def("run_moe", &torch_ext::FP4BlockScaleMoeRunner::run);
 }
 
 // Accepts both CPU and CUDA tensors

--- a/tensorrt_llm/_torch/custom_ops/trtllm_gen_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/trtllm_gen_custom_ops.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import torch
 
@@ -9,6 +9,249 @@ from tensorrt_llm._torch.utils import (get_last_power_of_2_num_tokens_buckets,
 
 from ..autotuner import (AutoTuner, ConstraintSpec, DynamicTensorSpec,
                          OptimizationProfile, TunableRunner, TuningConfig)
+
+
+@dataclass(frozen=True)
+class FP4BlockScaleMoEInputs:
+
+    routing_logits: torch.Tensor
+    routing_bias: Optional[torch.Tensor]
+    hidden_states: torch.Tensor
+    hidden_states_scale: torch.Tensor
+    gemm1_weights: torch.Tensor
+    gemm1_weights_scale: torch.Tensor
+    gemm2_weights: torch.Tensor
+    gemm2_weights_scale: torch.Tensor
+    output1_scale_scalar: torch.Tensor
+    output1_scale_gate_scalar: torch.Tensor
+    output2_scale_scalar: torch.Tensor
+
+
+class FP4BlockScaleMoERunner(TunableRunner):
+
+    runner_dict = dict()
+    tuning_config = None
+
+    def __init__(self, num_experts: int, top_k: int, n_group: Optional[int],
+                 topk_group: Optional[int], intermediate_size: int,
+                 local_expert_offset: int, local_num_experts: int,
+                 routed_scaling_factor: Optional[float], tile_tokens_dim: int,
+                 routing_method_type: int, do_finalize: bool):
+
+        self.num_experts = num_experts
+        self.top_k = top_k
+        self.n_group = n_group
+        self.topk_group = topk_group
+        self.intermediate_size = intermediate_size
+        self.local_expert_offset = local_expert_offset
+        self.local_num_experts = local_num_experts
+        self.routed_scaling_factor = routed_scaling_factor
+        self.tile_tokens_dim = tile_tokens_dim
+        self.routing_method_type = routing_method_type
+        self.do_finalize = do_finalize
+
+        FP4BlockScaleMoERunner.tuning_config = FP4BlockScaleMoERunner.get_tuning_config(
+        )
+
+        instance_key = (
+            self.top_k,
+            self.intermediate_size,
+            self.local_num_experts,
+            self.tile_tokens_dim,
+        )
+
+        if instance_key not in FP4BlockScaleMoERunner.runner_dict:
+            FP4BlockScaleMoERunner.runner_dict[
+                instance_key] = torch.classes.trtllm.FP4BlockScaleMoERunner(
+                    tile_tokens_dim)
+
+        self.kernel_runner = FP4BlockScaleMoERunner.runner_dict[instance_key]
+
+    # The hash is used by the autotuner to get the cache key, so we hash on members
+    # that influence tactic validity here. e.g. we are tuning FC1 and FC2
+    # so the routing type does not matter
+    def __hash__(self):
+        return hash((
+            self.top_k,
+            self.intermediate_size,
+            self.local_num_experts,
+            self.tile_tokens_dim,
+        ))
+
+    # __eq__ and __hash__ must agree
+    def __eq__(self, other):
+        if not isinstance(other, FP4BlockScaleMoERunner):
+            return False
+
+        return (self.top_k == other.top_k
+                and self.intermediate_size == other.intermediate_size
+                and self.local_num_experts == other.local_num_experts
+                and self.tile_tokens_dim == other.tile_tokens_dim)
+
+    def forward(
+        self,
+        inputs: List[torch.Tensor],
+        tactic: int = -1,
+    ) -> torch.Tensor:
+
+        args = FP4BlockScaleMoEInputs(*inputs)
+
+        return self.kernel_runner.run_moe(
+            args.routing_logits, args.routing_bias, args.hidden_states,
+            args.hidden_states_scale, args.gemm1_weights,
+            args.gemm1_weights_scale, args.gemm2_weights,
+            args.gemm2_weights_scale, args.output1_scale_scalar,
+            args.output1_scale_gate_scalar, args.output2_scale_scalar,
+            self.num_experts, self.top_k, self.n_group, self.topk_group,
+            self.intermediate_size, self.local_expert_offset,
+            self.local_num_experts, self.routed_scaling_factor,
+            self.routing_method_type, self.do_finalize, tactic)
+
+    def get_valid_tactics(
+        self,
+        inputs: List[torch.Tensor],
+        profile: OptimizationProfile,
+    ) -> List[int]:
+
+        args = FP4BlockScaleMoEInputs(*inputs)
+
+        num_tokens = args.hidden_states.shape[0]
+
+        # The hidden size is actually 2 * hidden_size because we pack 2x e2m1
+        # into 1 byte.
+        hidden_size = args.hidden_states.shape[1] * 2
+
+        tactics = self.kernel_runner.get_valid_configs(self.top_k, hidden_size,
+                                                       self.intermediate_size,
+                                                       self.local_num_experts,
+                                                       num_tokens)
+
+        return tactics
+
+    @classmethod
+    def get_dynamic_tensor_specs(cls) -> Tuple[DynamicTensorSpec, ...]:
+        HIDDEN_STATES_IDX = 2
+        TUNED_DIM = 0
+        MAX_PROFILE_BUCKET = 4096
+
+        m_values = get_last_power_of_2_num_tokens_buckets(MAX_PROFILE_BUCKET)
+        round_rule = lambda x: min(last_positive_power_of_2(x),
+                                   MAX_PROFILE_BUCKET)
+
+        specs = (DynamicTensorSpec(HIDDEN_STATES_IDX, TUNED_DIM, m_values,
+                                   round_rule), )
+
+        return specs
+
+    @classmethod
+    def get_constraint_specs(cls) -> Tuple[ConstraintSpec, ...]:
+
+        def _constrain_to_num_tokens(shapes: Tuple[torch.Size]) -> int:
+            HIDDEN_STATES_IDX = 2
+            NUM_TOKENS_DIM = 0
+
+            num_tokens = shapes[HIDDEN_STATES_IDX][NUM_TOKENS_DIM]
+
+            return num_tokens
+
+        def _constrain_fp4_linear_layout(shapes: Tuple[torch.Size]) -> int:
+            HIDDEN_STATES_IDX = 2
+            NUM_TOKENS_DIM = 0
+            HIDDEN_SIZE_DIM = 1
+
+            num_tokens = shapes[HIDDEN_STATES_IDX][NUM_TOKENS_DIM]
+
+            # The hidden size is actually 2 * hidden_size because we pack 2x e2m1
+            hidden_size = shapes[HIDDEN_STATES_IDX][HIDDEN_SIZE_DIM] * 2
+
+            sf_linear_size = num_tokens * (hidden_size // 16)
+
+            return sf_linear_size
+
+        HIDDEN_STATES_SCALE_IDX = 3
+        CONSTRAINED_HS_SCALE_DIM = 0
+
+        constraint_hidden_states_scale = ConstraintSpec(
+            HIDDEN_STATES_SCALE_IDX, CONSTRAINED_HS_SCALE_DIM,
+            _constrain_fp4_linear_layout)
+
+        ROUTER_LOGITS_IDX = 0
+        CONSTRAINED_RL_DIM = 0
+
+        constraint_routing_logits = ConstraintSpec(ROUTER_LOGITS_IDX,
+                                                   CONSTRAINED_RL_DIM,
+                                                   _constrain_to_num_tokens)
+
+        constraint_specs_tuple = (
+            constraint_hidden_states_scale,
+            constraint_routing_logits,
+        )
+
+        return constraint_specs_tuple
+
+    @classmethod
+    @lru_cache(maxsize=None)
+    def get_tuning_config(cls) -> TuningConfig:
+
+        dynamic_tensor_specs = cls.get_dynamic_tensor_specs()
+        constraint_specs = cls.get_constraint_specs()
+
+        tuning_config = TuningConfig(dynamic_tensor_specs=dynamic_tensor_specs,
+                                     constraint_specs=constraint_specs)
+
+        return tuning_config
+
+
+@torch.library.custom_op("trtllm::fp4_block_scale_moe_runner", mutates_args=())
+def fp4_block_scale_moe_runner(routing_logits: torch.Tensor,
+                               routing_bias: Optional[torch.Tensor],
+                               hidden_states: torch.Tensor,
+                               hidden_states_scale: torch.Tensor,
+                               gemm1_weights: torch.Tensor,
+                               gemm1_weights_scale: torch.Tensor,
+                               gemm2_weights: torch.Tensor,
+                               gemm2_weights_scale: torch.Tensor,
+                               output1_scale_scalar: torch.Tensor,
+                               output1_scale_gate_scalar: torch.Tensor,
+                               output2_scale_scalar: torch.Tensor,
+                               num_experts: int, top_k: int,
+                               n_group: Optional[int],
+                               topk_group: Optional[int],
+                               intermediate_size: int, local_expert_offset: int,
+                               local_num_experts: int,
+                               routed_scaling_factor: Optional[float],
+                               tile_tokens_dim: int, routing_method_type: int,
+                               do_finalize: bool) -> List[torch.Tensor]:
+
+    tuner = AutoTuner.get()
+
+    kernel_runner = FP4BlockScaleMoERunner(
+        num_experts, top_k, n_group, topk_group, intermediate_size,
+        local_expert_offset, local_num_experts, routed_scaling_factor,
+        tile_tokens_dim, routing_method_type, do_finalize)
+
+    inputs = [
+        routing_logits,
+        routing_bias,
+        hidden_states,
+        hidden_states_scale,
+        gemm1_weights,
+        gemm1_weights_scale,
+        gemm2_weights,
+        gemm2_weights_scale,
+        output1_scale_scalar,
+        output1_scale_gate_scalar,
+        output2_scale_scalar,
+    ]
+
+    _, best_tactic = tuner.choose_one(
+        "trtllm::fp4_block_scale_moe_runner",
+        [kernel_runner],
+        kernel_runner.tuning_config,
+        inputs,
+    )
+
+    return kernel_runner(inputs, tactic=best_tactic)
 
 
 @dataclass(frozen=True)

--- a/tests/unittest/_torch/thop/test_moe.py
+++ b/tests/unittest/_torch/thop/test_moe.py
@@ -671,299 +671,353 @@ def test_moe_fp8(num_tokens, expert_info, hidden_size, intermediate_size,
     reason="The kernel only supports Blackwell. Current SM is %d." %
     getSMVersion(),
 )
-@pytest.mark.parametrize("num_tokens", [1, 1024, 4096])
-@pytest.mark.parametrize("hidden_size", [1024])
-@pytest.mark.parametrize("intermediate_size", [1024, 768, 384, 192])
-@pytest.mark.parametrize(
-    "routing_info",
-    [
-        pytest.param(
-            {
-                "num_experts": 256,
-                "top_k": 8,
-                "padding": 8,
-                "n_groups": 8,
-                "top_k_groups": 4,
-                "routed_scaling": 2.5,
-                "has_routing_bias": True,
-                "routing_method_type": RoutingMethodType.DeepSeekV3
-            },
-            id="RoutingDSv3"),
-        pytest.param(
-            {
-                "num_experts": 72,
-                "top_k": 6,
-                "padding": 8,
-                "n_groups": 1,
-                "top_k_groups": 1,
-                "routed_scaling": 2.5,
-                "has_routing_bias": True,
-                "routing_method_type": RoutingMethodType.DeepSeekV3
-            },
-            id="RoutingDSlite"),
-        pytest.param(
-            {
-                "num_experts": 128,
-                "top_k": 8,
-                "padding": 8,
-                "n_groups": None,
-                "top_k_groups": None,
-                "routed_scaling": None,
-                "has_routing_bias": False,
-                "routing_method_type": RoutingMethodType.Renormalize
-            },
-            id="RoutingRenormalize"),
-        pytest.param(
-            {
-                "num_experts": 128,
-                "top_k": 8,
-                "padding": 8,
-                "n_groups": None,
-                "top_k_groups": None,
-                "routed_scaling": None,
-                "has_routing_bias": False,
-                "routing_method_type": RoutingMethodType.RenormalizeNaive
-            },
-            id="RoutingRenormalizeNaive"),
-    ],
-)
-def test_moe_fp4(num_tokens, hidden_size, intermediate_size, routing_info):
-    torch.random.manual_seed(0)
+class TestMoeFp4:
+    """
+    Test the NVFP4 MoE. As autotune also covers the actual MoE, we can run the test
+    with autotune by default. We add a separate test for no autotune to ensure that
+    the default tactic selection works. This reduces unnecessary test runs for CI
+    """
 
-    #
-    # Data Generation
-    #
+    @pytest.mark.parametrize("num_tokens", [1, 1024, 4096])
+    @pytest.mark.parametrize("hidden_size", [1024])
+    @pytest.mark.parametrize("intermediate_size", [1024, 768, 384, 192])
+    @pytest.mark.parametrize(
+        "routing_info",
+        [
+            pytest.param(
+                {
+                    "num_experts": 256,
+                    "top_k": 8,
+                    "padding": 8,
+                    "n_groups": 8,
+                    "top_k_groups": 4,
+                    "routed_scaling": 2.5,
+                    "has_routing_bias": True,
+                    "routing_method_type": RoutingMethodType.DeepSeekV3
+                },
+                id="RoutingDSv3"),
+            pytest.param(
+                {
+                    "num_experts": 72,
+                    "top_k": 6,
+                    "padding": 8,
+                    "n_groups": 1,
+                    "top_k_groups": 1,
+                    "routed_scaling": 2.5,
+                    "has_routing_bias": True,
+                    "routing_method_type": RoutingMethodType.DeepSeekV3
+                },
+                id="RoutingDSlite"),
+            pytest.param(
+                {
+                    "num_experts": 128,
+                    "top_k": 8,
+                    "padding": 8,
+                    "n_groups": None,
+                    "top_k_groups": None,
+                    "routed_scaling": None,
+                    "has_routing_bias": False,
+                    "routing_method_type": RoutingMethodType.Renormalize
+                },
+                id="RoutingRenormalize"),
+            pytest.param(
+                {
+                    "num_experts": 128,
+                    "top_k": 8,
+                    "padding": 8,
+                    "n_groups": None,
+                    "top_k_groups": None,
+                    "routed_scaling": None,
+                    "has_routing_bias": False,
+                    "routing_method_type": RoutingMethodType.RenormalizeNaive
+                },
+                id="RoutingRenormalizeNaive"),
+        ],
+    )
+    def test_autotune(self, num_tokens, hidden_size, intermediate_size,
+                      routing_info):
 
-    top_k = routing_info["top_k"]
-    # FIXME: set to TileN size
-    padding = routing_info["padding"]
-    n_groups = routing_info["n_groups"]
-    top_k_groups = routing_info["top_k_groups"]
-    routed_scaling = routing_info["routed_scaling"]
-    num_experts = routing_info["num_experts"]
-    routing_method_type = routing_info["routing_method_type"]
-    tile_tokens_dim = 8
+        self.run_moe_fp4_test(num_tokens,
+                              hidden_size,
+                              intermediate_size,
+                              routing_info,
+                              use_autotune=True)
 
-    assert top_k <= num_experts
-    assert top_k <= 8
-    if (top_k_groups is not None) and (n_groups is not None):
-        assert top_k_groups <= 4
-        assert num_experts > n_groups
-        assert num_experts % n_groups == 0
-        assert num_experts % 4 == 0
-        assert top_k < (top_k_groups * num_experts / n_groups)
+    @pytest.mark.parametrize("num_tokens", [1])
+    @pytest.mark.parametrize("hidden_size", [1024])
+    @pytest.mark.parametrize("intermediate_size", [1024])
+    @pytest.mark.parametrize(
+        "routing_info",
+        [
+            pytest.param(
+                {
+                    "num_experts": 256,
+                    "top_k": 8,
+                    "padding": 8,
+                    "n_groups": 8,
+                    "top_k_groups": 4,
+                    "routed_scaling": 2.5,
+                    "has_routing_bias": True,
+                    "routing_method_type": RoutingMethodType.DeepSeekV3
+                },
+                id="RoutingDSv3"),
+        ],
+    )
+    def test_no_autotune(self, num_tokens, hidden_size, intermediate_size,
+                         routing_info):
 
-    if routing_method_type == RoutingMethodType.DeepSeekV3:
-        expert_logits = torch.randn((num_tokens, num_experts),
-                                    device='cuda').to(torch.float)
-    elif routing_method_type == RoutingMethodType.RenormalizeNaive or routing_method_type == RoutingMethodType.Renormalize:
-        expert_logits = torch.randn((num_tokens, num_experts),
-                                    device='cuda').to(torch.bfloat16)
+        self.run_moe_fp4_test(num_tokens,
+                              hidden_size,
+                              intermediate_size,
+                              routing_info,
+                              use_autotune=False)
 
-    if routing_info["has_routing_bias"]:
-        routing_bias = torch.randn(num_experts,
-                                   device="cuda",
-                                   dtype=torch.bfloat16)
-    else:
-        routing_bias = None
+    def run_moe_fp4_test(self, num_tokens: int, hidden_size: int,
+                         intermediate_size: int, routing_info: dict,
+                         use_autotune: bool) -> None:
 
-    hidden_states = 2 * torch.randn(
-        (num_tokens, hidden_size), device='cuda', dtype=torch.bfloat16)
-    gemm1_weights = torch.randn(
-        (num_experts, 2 * intermediate_size, hidden_size),
-        device='cuda',
-        dtype=torch.bfloat16)
-    gemm2_weights = torch.randn((num_experts, hidden_size, intermediate_size),
-                                device='cuda',
-                                dtype=torch.bfloat16)
+        torch.random.manual_seed(0)
 
-    use_ue8m0 = False
-    # Quantize hidden states. Produces scales for activations in 128x4 layout for ref impl.
-    hidden_states_fp4_bytes, hidden_states_scale_fp4_bytes, hidden_states_scale_global = quant_fp4(
-        hidden_states, use_ue8m0, True)
-    # We do it twice to get the linear layout for scales for the FP4 kernels.
-    _, hidden_states_scale_linear_fp4_bytes, _ = quant_fp4(
-        hidden_states, use_ue8m0, False)
+        #
+        # Data Generation
+        #
 
-    hidden_states_fp4 = hidden_states_fp4_bytes.reshape(
-        num_tokens, hidden_size // 2)  # packed fp4
+        top_k = routing_info["top_k"]
+        # FIXME: set to TileN size
+        padding = routing_info["padding"]
+        n_groups = routing_info["n_groups"]
+        top_k_groups = routing_info["top_k_groups"]
+        routed_scaling = routing_info["routed_scaling"]
+        num_experts = routing_info["num_experts"]
+        routing_method_type = routing_info["routing_method_type"]
+        tile_tokens_dim = 8
 
-    hidden_states_scale_linear_fp4 = hidden_states_scale_linear_fp4_bytes.view(
-        torch.float8_e4m3fn)  # fp8 scaling factors
+        assert top_k <= num_experts
+        assert top_k <= 8
+        if (top_k_groups is not None) and (n_groups is not None):
+            assert top_k_groups <= 4
+            assert num_experts > n_groups
+            assert num_experts % n_groups == 0
+            assert num_experts % 4 == 0
+            assert top_k < (top_k_groups * num_experts / n_groups)
 
-    # Quantize the weights for FC1. Produces scales for weights in 128x4 layout for ref impl.
-    gemm1_weights_fp4_bytes, gemm1_scales_fp4_bytes, gemm1_scales_global = quant_fp4_batches(
-        gemm1_weights, num_experts, use_ue8m0, True)
-    # We do it twice to get the linear layout for scales for the FP4 kernels.
-    _, gemm1_scales_linear_fp4_bytes, _ = quant_fp4_batches(
-        gemm1_weights, num_experts, use_ue8m0, False)
+        if routing_method_type == RoutingMethodType.DeepSeekV3:
+            expert_logits = torch.randn((num_tokens, num_experts),
+                                        device='cuda').to(torch.float)
+        elif routing_method_type == RoutingMethodType.RenormalizeNaive or routing_method_type == RoutingMethodType.Renormalize:
+            expert_logits = torch.randn((num_tokens, num_experts),
+                                        device='cuda').to(torch.bfloat16)
 
-    gemm1_weights_fp4 = gemm1_weights_fp4_bytes.view(
-        torch.float8_e4m3fn).reshape(num_experts, 2 * intermediate_size,
-                                     hidden_size // 2)  # packed fp4
-    gemm1_scales_linear_fp4 = gemm1_scales_linear_fp4_bytes.view(
-        torch.float8_e4m3fn).reshape(num_experts, 2 * intermediate_size,
-                                     hidden_size // 16)  # fp8 scaling factors
+        if routing_info["has_routing_bias"]:
+            routing_bias = torch.randn(num_experts,
+                                       device="cuda",
+                                       dtype=torch.bfloat16)
+        else:
+            routing_bias = None
 
-    # Quantize the weights for FC2. Produces scales for weights in 128x4 layout for ref impl.
-    gemm2_weights_fp4_bytes, gemm2_scales_fp4_bytes, gemm2_scales_global = quant_fp4_batches(
-        gemm2_weights, num_experts, use_ue8m0, True)
-    # We do it twice to get the linear layout for scales for the FP4 kernels.
-    _, gemm2_scales_linear_fp4_bytes, _ = quant_fp4_batches(
-        gemm2_weights, num_experts, use_ue8m0, False)
+        hidden_states = 2 * torch.randn(
+            (num_tokens, hidden_size), device='cuda', dtype=torch.bfloat16)
+        gemm1_weights = torch.randn(
+            (num_experts, 2 * intermediate_size, hidden_size),
+            device='cuda',
+            dtype=torch.bfloat16)
+        gemm2_weights = torch.randn(
+            (num_experts, hidden_size, intermediate_size),
+            device='cuda',
+            dtype=torch.bfloat16)
 
-    gemm2_weights_fp4 = gemm2_weights_fp4_bytes.view(
-        torch.float8_e4m3fn).reshape(num_experts, hidden_size,
-                                     intermediate_size // 2)  # packed fp4
-    gemm2_scales_linear_fp4 = gemm2_scales_linear_fp4_bytes.view(
-        torch.float8_e4m3fn).reshape(num_experts, hidden_size,
-                                     intermediate_size //
-                                     16)  # fp8 scaling factors
-    if routing_method_type == RoutingMethodType.DeepSeekV3:
-        permute_info, scores = routing_reference_no_aux(expert_logits,
-                                                        routing_bias, top_k,
-                                                        n_groups, top_k_groups,
-                                                        routed_scaling, padding)
-    elif routing_method_type == RoutingMethodType.Renormalize:
-        permute_info, scores = routing_reference_renormalize(
-            expert_logits, top_k, num_experts, padding)
-    elif routing_method_type == RoutingMethodType.RenormalizeNaive:
-        permute_info, scores = routing_reference_renormalize_naive(
-            expert_logits, top_k, num_experts, padding)
+        use_ue8m0 = False
+        # Quantize hidden states. Produces scales for activations in 128x4 layout for ref impl.
+        hidden_states_fp4_bytes, hidden_states_scale_fp4_bytes, hidden_states_scale_global = quant_fp4(
+            hidden_states, use_ue8m0, True)
+        # We do it twice to get the linear layout for scales for the FP4 kernels.
+        _, hidden_states_scale_linear_fp4_bytes, _ = quant_fp4(
+            hidden_states, use_ue8m0, False)
 
-    args = moe_args(num_tokens, num_experts, hidden_size, intermediate_size,
-                    top_k, padding, hidden_states_fp4_bytes,
-                    hidden_states_scale_fp4_bytes, hidden_states_scale_global,
-                    scores, gemm1_weights_fp4_bytes, gemm1_scales_fp4_bytes,
-                    gemm1_scales_global, gemm2_weights_fp4_bytes,
-                    gemm2_scales_fp4_bytes, gemm2_scales_global, permute_info,
-                    False)
-    #
-    # Run the reference implementations
-    #
-    # It is important to run the reference implementation before the TRT-LLM kernel
-    # because the MoE shuffles the weights in-place.
-    output_dequant_reference, args_dequant = run_moe_reference_fp4(args)
+        hidden_states_fp4 = hidden_states_fp4_bytes.reshape(
+            num_tokens, hidden_size // 2)  # packed fp4
 
-    # FIXME: this depends on the kernel internals
-    epilogue_tile_m = 128
+        hidden_states_scale_linear_fp4 = hidden_states_scale_linear_fp4_bytes.view(
+            torch.float8_e4m3fn)  # fp8 scaling factors
 
-    # Reorder rows of W1 and scales for fused gated activation
-    gemm1_weights_fp4_interleaved = []
-    gemm1_scales_fp4_interleaved = []
-    for i in range(num_experts):
-        gemm1_weights_fp4_interleaved.append(
-            reorder_rows_for_gated_act_gemm(gemm1_weights_fp4[i].clone()))
-        gemm1_scales_fp4_interleaved.append(
-            reorder_rows_for_gated_act_gemm(gemm1_scales_linear_fp4[i].clone()))
+        # Quantize the weights for FC1. Produces scales for weights in 128x4 layout for ref impl.
+        gemm1_weights_fp4_bytes, gemm1_scales_fp4_bytes, gemm1_scales_global = quant_fp4_batches(
+            gemm1_weights, num_experts, use_ue8m0, True)
+        # We do it twice to get the linear layout for scales for the FP4 kernels.
+        _, gemm1_scales_linear_fp4_bytes, _ = quant_fp4_batches(
+            gemm1_weights, num_experts, use_ue8m0, False)
 
-    # Stack weights and scales for all experts
-    gemm1_weights_fp4_interleaved = torch.stack(
-        gemm1_weights_fp4_interleaved).reshape(num_experts,
-                                               2 * intermediate_size,
-                                               hidden_size // 2)
-    gemm1_scales_fp4_interleaved = torch.stack(
-        gemm1_scales_fp4_interleaved).reshape(num_experts,
-                                              2 * intermediate_size,
-                                              hidden_size // 16)
+        gemm1_weights_fp4 = gemm1_weights_fp4_bytes.view(
+            torch.float8_e4m3fn).reshape(num_experts, 2 * intermediate_size,
+                                         hidden_size // 2)  # packed fp4
+        gemm1_scales_linear_fp4 = gemm1_scales_linear_fp4_bytes.view(
+            torch.float8_e4m3fn).reshape(num_experts, 2 * intermediate_size,
+                                         hidden_size //
+                                         16)  # fp8 scaling factors
 
-    # Shuffle weights and scaling factors for transposed mma output
-    gemm1_weights_fp4_shuffled = []
-    gemm1_scales_fp4_shuffled = []
-    gemm2_weights_fp4_shuffled = []
-    gemm2_scales_fp4_shuffled = []
-    for i in range(num_experts):
-        gemm1_weights_fp4_shuffled.append(
-            shuffle_matrix_a(gemm1_weights_fp4_interleaved[i].view(torch.uint8),
-                             epilogue_tile_m))
-        gemm1_scales_fp4_shuffled.append(
-            shuffle_matrix_sf_a(
-                gemm1_scales_fp4_interleaved[i].view(torch.uint8),
-                epilogue_tile_m))
+        # Quantize the weights for FC2. Produces scales for weights in 128x4 layout for ref impl.
+        gemm2_weights_fp4_bytes, gemm2_scales_fp4_bytes, gemm2_scales_global = quant_fp4_batches(
+            gemm2_weights, num_experts, use_ue8m0, True)
+        # We do it twice to get the linear layout for scales for the FP4 kernels.
+        _, gemm2_scales_linear_fp4_bytes, _ = quant_fp4_batches(
+            gemm2_weights, num_experts, use_ue8m0, False)
 
-        gemm2_weights_fp4_shuffled.append(
-            shuffle_matrix_a(gemm2_weights_fp4[i].view(torch.uint8),
-                             epilogue_tile_m))
-        gemm2_scales_fp4_shuffled.append(
-            shuffle_matrix_sf_a(gemm2_scales_linear_fp4[i].view(torch.uint8),
-                                epilogue_tile_m))
+        gemm2_weights_fp4 = gemm2_weights_fp4_bytes.view(
+            torch.float8_e4m3fn).reshape(num_experts, hidden_size,
+                                         intermediate_size // 2)  # packed fp4
+        gemm2_scales_linear_fp4 = gemm2_scales_linear_fp4_bytes.view(
+            torch.float8_e4m3fn).reshape(num_experts, hidden_size,
+                                         intermediate_size //
+                                         16)  # fp8 scaling factors
+        if routing_method_type == RoutingMethodType.DeepSeekV3:
+            permute_info, scores = routing_reference_no_aux(
+                expert_logits, routing_bias, top_k, n_groups, top_k_groups,
+                routed_scaling, padding)
+        elif routing_method_type == RoutingMethodType.Renormalize:
+            permute_info, scores = routing_reference_renormalize(
+                expert_logits, top_k, num_experts, padding)
+        elif routing_method_type == RoutingMethodType.RenormalizeNaive:
+            permute_info, scores = routing_reference_renormalize_naive(
+                expert_logits, top_k, num_experts, padding)
 
-    # Stack weights for all experts
-    gemm1_weights_fp4_shuffled = torch.stack(gemm1_weights_fp4_shuffled)
-    gemm1_scales_fp4_shuffled = torch.stack(gemm1_scales_fp4_shuffled).view(
-        torch.float8_e4m3fn).reshape(num_experts, 2 * intermediate_size,
-                                     hidden_size // 16)
+        args = moe_args(num_tokens, num_experts, hidden_size, intermediate_size,
+                        top_k, padding, hidden_states_fp4_bytes,
+                        hidden_states_scale_fp4_bytes,
+                        hidden_states_scale_global, scores,
+                        gemm1_weights_fp4_bytes, gemm1_scales_fp4_bytes,
+                        gemm1_scales_global, gemm2_weights_fp4_bytes,
+                        gemm2_scales_fp4_bytes, gemm2_scales_global,
+                        permute_info, False)
+        #
+        # Run the reference implementations
+        #
+        # It is important to run the reference implementation before the TRT-LLM kernel
+        # because the MoE shuffles the weights in-place.
+        output_dequant_reference, args_dequant = run_moe_reference_fp4(args)
 
-    gemm2_weights_fp4_shuffled = torch.stack(gemm2_weights_fp4_shuffled)
-    gemm2_scales_fp4_shuffled = torch.stack(gemm2_scales_fp4_shuffled).view(
-        torch.float8_e4m3fn).reshape(num_experts, hidden_size,
-                                     intermediate_size // 16)
+        # FIXME: this depends on the kernel internals
+        epilogue_tile_m = 128
 
-    #
-    # Run the TRT-LLM kernel
-    #
+        # Reorder rows of W1 and scales for fused gated activation
+        gemm1_weights_fp4_interleaved = []
+        gemm1_scales_fp4_interleaved = []
+        for i in range(num_experts):
+            gemm1_weights_fp4_interleaved.append(
+                reorder_rows_for_gated_act_gemm(gemm1_weights_fp4[i].clone()))
+            gemm1_scales_fp4_interleaved.append(
+                reorder_rows_for_gated_act_gemm(
+                    gemm1_scales_linear_fp4[i].clone()))
 
-    # c_global_sf: fc2_input_scale
-    scale_c_fc1 = args_dequant.c_global_sf * (
-        1.0 / args.gemm1_scales_global) * (1.0 /
-                                           args.hidden_states_scale_global)
+        # Stack weights and scales for all experts
+        gemm1_weights_fp4_interleaved = torch.stack(
+            gemm1_weights_fp4_interleaved).reshape(num_experts,
+                                                   2 * intermediate_size,
+                                                   hidden_size // 2)
+        gemm1_scales_fp4_interleaved = torch.stack(
+            gemm1_scales_fp4_interleaved).reshape(num_experts,
+                                                  2 * intermediate_size,
+                                                  hidden_size // 16)
 
-    # self.fc31_alpha
-    scale_gate_fc1 = (1.0 / args.gemm1_scales_global) * (
-        1.0 / args.hidden_states_scale_global)
+        # Shuffle weights and scaling factors for transposed mma output
+        gemm1_weights_fp4_shuffled = []
+        gemm1_scales_fp4_shuffled = []
+        gemm2_weights_fp4_shuffled = []
+        gemm2_scales_fp4_shuffled = []
+        for i in range(num_experts):
+            gemm1_weights_fp4_shuffled.append(
+                shuffle_matrix_a(
+                    gemm1_weights_fp4_interleaved[i].view(torch.uint8),
+                    epilogue_tile_m))
+            gemm1_scales_fp4_shuffled.append(
+                shuffle_matrix_sf_a(
+                    gemm1_scales_fp4_interleaved[i].view(torch.uint8),
+                    epilogue_tile_m))
 
-    # self.fc2_alpha
-    scale_c_fc2 = (1.0 / args_dequant.c_global_sf) * (1.0 /
-                                                      args.gemm2_scales_global)
+            gemm2_weights_fp4_shuffled.append(
+                shuffle_matrix_a(gemm2_weights_fp4[i].view(torch.uint8),
+                                 epilogue_tile_m))
+            gemm2_scales_fp4_shuffled.append(
+                shuffle_matrix_sf_a(
+                    gemm2_scales_linear_fp4[i].view(torch.uint8),
+                    epilogue_tile_m))
 
-    output = torch.ops.trtllm.fp4_block_scale_moe_runner(
-        expert_logits,
-        routing_bias,
-        hidden_states_fp4,
-        hidden_states_scale_linear_fp4,
-        gemm1_weights_fp4_shuffled,
-        gemm1_scales_fp4_shuffled,
-        gemm2_weights_fp4_shuffled,
-        gemm2_scales_fp4_shuffled,
-        scale_c_fc1,
-        scale_gate_fc1,
-        scale_c_fc2,
-        num_experts,
-        top_k,
-        n_groups,
-        top_k_groups,
-        intermediate_size,
-        0,
-        num_experts,
-        routed_scaling,
-        tile_tokens_dim,
-        routing_method_type,
-        do_finalize=True)
+        # Stack weights for all experts
+        gemm1_weights_fp4_shuffled = torch.stack(gemm1_weights_fp4_shuffled)
+        gemm1_scales_fp4_shuffled = torch.stack(gemm1_scales_fp4_shuffled).view(
+            torch.float8_e4m3fn).reshape(num_experts, 2 * intermediate_size,
+                                         hidden_size // 16)
 
-    output_dequant_actual = output[0].to(torch.float)
+        gemm2_weights_fp4_shuffled = torch.stack(gemm2_weights_fp4_shuffled)
+        gemm2_scales_fp4_shuffled = torch.stack(gemm2_scales_fp4_shuffled).view(
+            torch.float8_e4m3fn).reshape(num_experts, hidden_size,
+                                         intermediate_size // 16)
 
-    #
-    # Check the results
-    #
-    def check_accuracy(a, b, atol, rtol, percent):
-        if torch.any(torch.isnan(a)):
-            raise Exception("NaN in a")
-        if torch.any(torch.isnan(b)):
-            raise Exception("NaN in b")
-        assert a.shape == b.shape
-        left = torch.abs(a - b)
-        right = atol + rtol * torch.abs(b)
-        count = torch.sum(left > right)
-        mismatch_percent = count / a.numel()
-        if mismatch_percent > 1 - percent:
-            raise Exception("Mismatch percentage is %f for rtol %f" %
-                            (mismatch_percent, rtol))
+        #
+        # Run the TRT-LLM kernel
+        #
 
-    check_accuracy(output_dequant_reference,
-                   output_dequant_actual,
-                   atol=0.1,
-                   rtol=0.85,
-                   percent=0.925)
+        # c_global_sf: fc2_input_scale
+        scale_c_fc1 = args_dequant.c_global_sf * (
+            1.0 / args.gemm1_scales_global) * (1.0 /
+                                               args.hidden_states_scale_global)
+
+        # self.fc31_alpha
+        scale_gate_fc1 = (1.0 / args.gemm1_scales_global) * (
+            1.0 / args.hidden_states_scale_global)
+
+        # self.fc2_alpha
+        scale_c_fc2 = (1.0 / args_dequant.c_global_sf) * (
+            1.0 / args.gemm2_scales_global)
+
+        with autotune(use_autotune):
+            output = torch.ops.trtllm.fp4_block_scale_moe_runner(
+                expert_logits,
+                routing_bias,
+                hidden_states_fp4,
+                hidden_states_scale_linear_fp4,
+                gemm1_weights_fp4_shuffled,
+                gemm1_scales_fp4_shuffled,
+                gemm2_weights_fp4_shuffled,
+                gemm2_scales_fp4_shuffled,
+                scale_c_fc1,
+                scale_gate_fc1,
+                scale_c_fc2,
+                num_experts,
+                top_k,
+                n_groups,
+                top_k_groups,
+                intermediate_size,
+                0,
+                num_experts,
+                routed_scaling,
+                tile_tokens_dim,
+                routing_method_type,
+                do_finalize=True)
+
+        output_dequant_actual = output[0].to(torch.float)
+
+        #
+        # Check the results
+        #
+        def check_accuracy(a, b, atol, rtol, percent):
+            if torch.any(torch.isnan(a)):
+                raise Exception("NaN in a")
+            if torch.any(torch.isnan(b)):
+                raise Exception("NaN in b")
+            assert a.shape == b.shape
+            left = torch.abs(a - b)
+            right = atol + rtol * torch.abs(b)
+            count = torch.sum(left > right)
+            mismatch_percent = count / a.numel()
+            if mismatch_percent > 1 - percent:
+                raise Exception("Mismatch percentage is %f for rtol %f" %
+                                (mismatch_percent, rtol))
+
+        check_accuracy(output_dequant_reference,
+                       output_dequant_actual,
+                       atol=0.1,
+                       rtol=0.85,
+                       percent=0.925)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Description

Adds autotune support for fp4 blockscale MoE.
The changes to the test are an attempt to avoid unnecessary duplication of test cases in CI. To that end, test everything with autotune by default. Add one non-autotune case to ensure default/fallback config selection still works.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
