### PR TITLE
fix: Skip rope scaling for local layers in Gemma3 VLM

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/flashinfer.py
+++ b/tensorrt_llm/_torch/attention_backend/flashinfer.py
@@ -1,3 +1,4 @@
+import math
 import os
 import weakref
 from dataclasses import dataclass, field
@@ -39,6 +40,8 @@ class PlanParams:
 
     attention_mask_type: AttentionMaskType
     attention_mask_data: Optional[torch.Tensor] = None
+    sm_scale: Optional[float] = None
+    window_left: Optional[int] = None
 
 
 @dataclass(kw_only=True)
@@ -309,13 +312,23 @@ class FlashInferAttentionMetadata(AttentionMetadata):
              q_dtype: torch.dtype,
              kv_dtype: torch.dtype,
              attention_mask_type: int,
+             q_scaling: Optional[float] = None,
+             attention_window_size: Optional[int] = None,
              attention_mask_data: Optional[torch.Tensor] = None) -> PlanParams:
+
+        sm_scale = None
+        if q_scaling is not None:
+            sm_scale = 1 / (math.sqrt(head_dim) * q_scaling)
+
         plan_params = PlanParams(
             num_heads=num_heads,
             num_kv_heads=num_kv_heads,
             head_dim=head_dim,
             q_dtype=q_dtype,
             kv_dtype=kv_dtype,
+            sm_scale=sm_scale,
+            window_left=attention_window_size
+            if attention_window_size is not None else -1,
             attention_mask_type=AttentionMaskType(attention_mask_type),
             attention_mask_data=attention_mask_data)
         return self._plan_with_params(plan_params)
@@ -363,6 +376,8 @@ class FlashInferAttentionMetadata(AttentionMetadata):
                 plan_params.head_dim,
                 self.page_size,
                 causal=is_causal,
+                sm_scale=plan_params.sm_scale,
+                window_left=plan_params.window_left,
                 q_data_type=plan_params.q_dtype,
                 kv_data_type=plan_params.kv_dtype,
             )
@@ -398,6 +413,8 @@ class FlashInferAttentionMetadata(AttentionMetadata):
                 plan_params.num_kv_heads,
                 plan_params.head_dim,
                 self.page_size,
+                sm_scale=plan_params.sm_scale,
+                window_left=plan_params.window_left,
                 q_data_type=plan_params.q_dtype,
                 kv_data_type=plan_params.kv_dtype,
             )
@@ -431,6 +448,7 @@ class FlashInferAttention(AttentionBackend[FlashInferAttentionMetadata]):
         head_dim: int,
         num_kv_heads: Optional[int] = None,
         quant_config: Optional[QuantConfig] = None,
+        q_scaling: Optional[float] = None,
         skip_create_weights_in_init: bool = False,
         **kwargs,
     ):
@@ -438,6 +456,7 @@ class FlashInferAttention(AttentionBackend[FlashInferAttentionMetadata]):
                          quant_config, **kwargs)
         if not skip_create_weights_in_init:
             self.update_quant_config(self.quant_config)
+        self.q_scaling = q_scaling
 
     def update_quant_config(self, new_quant_config: Optional[QuantConfig]):
         self.quant_config = new_quant_config
@@ -452,6 +471,7 @@ class FlashInferAttention(AttentionBackend[FlashInferAttentionMetadata]):
                 v: Optional[torch.Tensor],
                 metadata: FlashInferAttentionMetadata,
                 *,
+                attention_window_size: Optional[int] = None,
                 attention_mask: AttentionMask = PredefinedAttentionMask.CAUSAL,
                 **kwargs) -> torch.Tensor:
         if attention_mask == PredefinedAttentionMask.CAUSAL:
@@ -463,10 +483,18 @@ class FlashInferAttention(AttentionBackend[FlashInferAttentionMetadata]):
         else:
             raise ValueError("Unexpected attention mask type")
 
-        return forward_pattern(q, k, v, self.num_heads, self.head_dim,
-                               self.num_kv_heads, self.layer_idx,
-                               self.has_fp8_kv_cache, attention_mask_type,
-                               attention_mask_data)
+        return forward_pattern(q=q,
+                               k=k,
+                               v=v,
+                               num_heads=self.num_heads,
+                               head_dim=self.head_dim,
+                               num_kv_heads=self.num_kv_heads,
+                               layer_idx=self.layer_idx,
+                               has_fp8_kv_cache=self.has_fp8_kv_cache,
+                               attention_mask_type=attention_mask_type,
+                               q_scaling=self.q_scaling,
+                               attention_mask_data=attention_mask_data,
+                               attention_window_size=attention_window_size)
 
 
 @torch.library.custom_op("trtllm::flashinfer_forward", mutates_args=())
@@ -480,7 +508,9 @@ def forward_pattern(
     layer_idx: int,
     has_fp8_kv_cache: bool,
     attention_mask_type: int,
-    attention_mask_data: Optional[torch.Tensor],
+    q_scaling: Optional[float] = None,
+    attention_mask_data: Optional[torch.Tensor] = None,
+    attention_window_size: Optional[int] = None,
 ) -> torch.Tensor:
     '''
     Wrapping the flashinfer forward as a custom op is required to fix `torch.compile` graph breaks,
@@ -548,6 +578,8 @@ def forward_pattern(
                                 head_dim,
                                 q_dtype=q.dtype,
                                 kv_dtype=kv_cache.dtype,
+                                q_scaling=q_scaling,
+                                attention_window_size=attention_window_size,
                                 attention_mask_type=attention_mask_type,
                                 attention_mask_data=attention_mask_data)
 

--- a/tensorrt_llm/_torch/models/modeling_gemma3.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma3.py
@@ -7,7 +7,7 @@ from tqdm import tqdm
 from transformers import Gemma3TextConfig
 from transformers.activations import ACT2FN
 
-from tensorrt_llm.functional import PositionEmbeddingType
+from tensorrt_llm.functional import PositionEmbeddingType, RotaryScalingType
 from tensorrt_llm.mapping import Mapping
 
 from ..attention_backend import AttentionMetadata
@@ -64,7 +64,9 @@ class Gemma3Attention(Attention):
         rope_params = RopeParams.from_config(config)
         self.attention_window_size = None
         if is_sliding:
-            rope_params.theta = 10000
+            rope_params.theta = config.rope_local_base_freq
+            rope_params.scale_type = RotaryScalingType.none
+            rope_params.scale = 1.0
             self.attention_window_size = config.sliding_window - 1  # Gemma3 sliding window isn't inclusive.
         pos_embd_params = PositionalEmbeddingParams(
             type=PositionEmbeddingType.rope_gpt_neox,


### PR DESCRIPTION
## Description
Gemma3 VLMs (5B, 12B, 27B) have rope scaling only for global layers and not local layers. This MR applies this fix. Also, adds changes to support `q_scaling` and `sliding_window` in FlashInfer backend.

The fix significantly improves quality of VLM output.
```
$ python3 examples/pytorch/quickstart_multimodal.py --model_dir ../random/hf_models/gemma-3-4b-it/ --modality image --prompt "Describe this image in detail." --media "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/bee.jpg" --image_format pil

BEFORE: "Here's a detailed description of the image description of the image:\n\nHere's of the image:\n\nThis is a close-up shot of a vibrant and colorful garden scene featuring a cluster of pink cosmos flowers in bloom with a bee. The image of cosmos flowers and a bee. \n\n**Composition:"

AFTER: "Here's a detailed description of the image:\n\n**Overall Impression:**\n\nThe image is a close-up shot of a vibrant garden scene, focusing on a cluster of pink cosmos flowers and a busy bee. It has a soft, slightly blurred background, drawing the viewer's attention to the central subjects.\n\n"
```

Consolidates previous Gemma3 1B test with new Gemma3 27B VLM test.

## Test Coverage
```
$ pytest tests/unittest/_torch/modeling/test_modeling_gemma3.py::TestGemma3::test_gemma3_allclose_to_hf[backend:flashinfer_config:27b] -s -v
$ pytest tests/unittest/_torch/modeling/test_modeling_gemma3.py::TestGemma3::test_gemma3_allclose_to_hf[backend:trtllm_config:27b] -s -v
$ pytest tests/unittest/_torch/modeling/test_modeling_gemma3.py::TestGemma3::test_gemma3_allclose_to_hf[backend:vanilla_config:27b] -s -v
$ pytest tests/unittest/_torch/modeling/test_modeling_gemma3.py::TestGemma3::test_gemma3_allclose_to_hf[backend:flashinfer_config:1b] -s -v
$ pytest tests/unittest/_torch/modeling/test_modeling_gemma3.py::TestGemma3::test_gemma3_allclose_to_hf[backend:trtllm_config:1b] -s -v
$ pytest tests/unittest/_torch/modeling/test_modeling_gemma3.py::TestGemma3::test_gemma3_allclose_to_hf[backend:vanilla_config:1b] -s -v
```
## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
