### PR TITLE
infra: add a customizable container config for engineer development efficiency

### DIFF
--- a/docker/Dockerfile.custom
+++ b/docker/Dockerfile.custom
@@ -1,0 +1,14 @@
+# The customized container for personal development purpose.
+# Only used if `$CUSTOMIZE_CONTAINER` and `LOCAL_USER` are set to 1.
+#
+# Tip: use `git update-index --skip-worktree ./docker/Dockerfile.custom`
+# to skip the file from git tracking **locally** if you have customized your container config.
+# Use `git update-index --no-skip-worktree ./docker/Dockerfile.custom` to unskip.
+
+ARG IMAGE_TAG_WITH_SUFFIX
+
+FROM ${IMAGE_TAG_WITH_SUFFIX} AS base
+
+# Below are the instructions for the customized container.
+# The instructions in this file shall be kept empty in the official repo.
+# RUN sudo apt-get update && sudo apt-get install -y zsh

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -67,6 +67,16 @@ define add_local_user
 		..
 endef
 
+# Customize the container for personal development use.
+define customize_container
+	docker build \
+		--progress $(DOCKER_PROGRESS) \
+		--build-arg IMAGE_TAG_WITH_SUFFIX=$(1) \
+		--file Dockerfile.custom \
+		--tag $(1) \
+		..
+endef
+
 # Rewrite `/tensorrt-llm:` in image tag with `/tensorrt-llm-staging:` to avoid directly overwriting
 define rewrite_tag
 $(shell echo $(IMAGE_WITH_TAG) | sed "s/\/tensorrt-llm:/\/tensorrt-llm-staging:/g")
@@ -144,6 +154,13 @@ ifeq ($(DOCKER_PULL),1)
 endif
 ifeq ($(LOCAL_USER),1)
 	$(call add_local_user,$(IMAGE_WITH_TAG))
+endif
+ifeq ($(CUSTOMIZE_CONTAINER),1)
+  ifeq ($(LOCAL_USER),1)
+	  $(call customize_container,$(IMAGE_WITH_TAG)$(IMAGE_TAG_SUFFIX))
+  else
+	  $(warning "CUSTOMIZE_CONTAINER=1" is ignored because LOCAL_USER is not set to 1)
+endif
 endif
 	docker run $(DOCKER_RUN_OPTS) $(DOCKER_RUN_ARGS) \
     		$(GPU_OPTS) \


### PR DESCRIPTION
Enabling the engineers to personalize the tools configs in the container - no need to install tools each time after container built and invoked. Only available if `LOCAL_USER=1`.

Usage:
1. Define the container instructions in `docker/Dockerfile.customize`.
2. Build the container with `make -C docker build CUSTOMIZE_CONTAINER=1 LOCAL_USER=1`.
