### PR TITLE
Fix : fix moe regression for sm120

### DIFF
--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/CMakeLists.txt
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/CMakeLists.txt
@@ -116,7 +116,7 @@ function(add_instantiations library base_dir)
 
       if(${ARCH} EQUAL 90)
         process_target(${TARGET_NAME} true false)
-      elseif(${ARCH} EQUAL 100)
+      elseif(${ARCH} GREATER_EQUAL 100)
         process_target(${TARGET_NAME} false true)
       endif()
     endif()


### PR DESCRIPTION
# PR title

Fix : fix moe regression for sm120

## Description

Fix assertion failure "Assertion failed: Could not find valid config when calculating workspace size" on SM120 