### PR TITLE
[TRTLLM-6091][docs] Update docs/trtllm sampler 1.0

### DIFF
--- a/docs/source/1.0/features/sampling.md
+++ b/docs/source/1.0/features/sampling.md
@@ -74,10 +74,9 @@ The PyTorch backend supports guided decoding with the XGrammar and Low-level Gui
 To enable guided decoding, you must:
 
 1. Set the `guided_decoding_backend` parameter to `'xgrammar'` or `'llguidance'` in the `LLM` class
-2. Disable overlap scheduling using the `disable_overlap_scheduler` parameter of the `LLM` class
-3. Create a [`GuidedDecodingParams`](../../../../tensorrt_llm/sampling_params.py#L14) object with the desired format specification
+2. Create a [`GuidedDecodingParams`](../../../../tensorrt_llm/sampling_params.py#L14) object with the desired format specification
     * Note: Depending on the type of format, a different parameter needs to be chosen to construct the object (`json`, `regex`, `grammar`, `strucutral_tag`).
-4. Pass the `GuidedDecodingParams` object to the `guided_decoding` parameter of the `SamplingParams` object
+3. Pass the `GuidedDecodingParams` object to the `guided_decoding` parameter of the `SamplingParams` object
 
 The following example demonstrates guided decoding with JSON format:
 
@@ -86,8 +85,7 @@ from tensorrt_llm import LLM, SamplingParams
 from tensorrt_llm.llmapi import GuidedDecodingParams
 
 llm = LLM(model='nvidia/Llama-3.1-8B-Instruct-FP8',
-          guided_decoding_backend='xgrammar',
-          disable_overlap_scheduler=True)
+          guided_decoding_backend='xgrammar')
 structure = '{"title": "Example JSON", "type": "object", "properties": {...}}'
 guided_decoding_params = GuidedDecodingParams(json=structure)
 sampling_params = SamplingParams(
@@ -110,6 +108,9 @@ To use a custom logits processor:
 The following example demonstrates logits processing:
 
 ```python
+import torch
+from typing import List, Optional
+
 from tensorrt_llm import LLM, SamplingParams
 from tensorrt_llm.sampling_params import LogitsProcessor
 

--- a/docs/source/1.0/features/sampling.md
+++ b/docs/source/1.0/features/sampling.md
@@ -1,9 +1,14 @@
 # Sampling
-The PyTorch backend supports most of the sampling features that are supported on the C++ backend, such as temperature, top-k and top-p sampling, beam search, stop words, bad words, penalty, context and generation logits, and log probs.
+The PyTorch backend supports most of the sampling features that are supported on the C++ backend, such as temperature, top-k and top-p sampling, beam search, stop words, bad words, penalty, context and generation logits, and log probability.
 
 ## General usage
 
-In order to use this feature, it is necessary to enable option `enable_trtllm_sampler` in the `LLM` class, and pass a `SamplingParams` object with the desired options as well. The following example prepares two identical prompts which will give different results due to the sampling parameters chosen:
+To use the feature:
+
+1. Enable the `enable_trtllm_sampler` option in the `LLM` class
+2. Pass a `SamplingParams` object with the desired options to the `generate()` function
+
+The following example prepares two identical prompts which will give different results due to the sampling parameters chosen:
 
 ```python
 from tensorrt_llm import LLM
@@ -18,7 +23,7 @@ llm.generate(["Hello, my name is",
             "Hello, my name is"], sampling_params)
 ```
 
-When using speculative decoders such as MTP or Eagle-3, the `enable_trtllm_sampler` option is not yet supported and therefore the subset of sampling options available is more restricted.
+Note: The `enable_trtllm_sampler` option is not currently supported when using speculative decoders, such as MTP or Eagle-3, so there is a smaller subset of sampling options available.
 
 ## Beam search
 
@@ -33,7 +38,7 @@ To enable beam search, you must:
 Parameter Configuration:
 - `best_of`: Controls the number of beams processed during generation (beam width)
 - `n`: Controls the number of output sequences returned (can be less than `best_of`)
-- If `best_of` is omitted, it will be implicitly set to `n`
+- If `best_of` is omitted, the number of beams processed defaults to `n`
 - `max_beam_width` in the `LLM` class must equal `best_of` in `SamplingParams`
 
 The following example demonstrates beam search with a beam width of 4, returning the top 3 sequences:

--- a/docs/source/1.0/features/sampling.md
+++ b/docs/source/1.0/features/sampling.md
@@ -1,6 +1,7 @@
 # Sampling
+The PyTorch backend supports most of the sampling features that are supported on the C++ backend, such as temperature, top-k and top-p sampling, beam search, stop words, bad words, penalty, context and generation logits, and log probs.
 
-The PyTorch backend supports most of the sampling features that are supported on the C++ backend, such as temperature, top-k and top-p sampling, stop words, bad words, penalty, context and generation logits, and log probs.
+## General usage
 
 In order to use this feature, it is necessary to enable option `enable_trtllm_sampler` in the `LLM` class, and pass a `SamplingParams` object with the desired options as well. The following example prepares two identical prompts which will give different results due to the sampling parameters chosen:
 
@@ -18,3 +19,36 @@ llm.generate(["Hello, my name is",
 ```
 
 When using speculative decoders such as MTP or Eagle-3, the `enable_trtllm_sampler` option is not yet supported and therefore the subset of sampling options available is more restricted.
+
+## Beam search
+
+Beam search is a decoding strategy that maintains multiple candidate sequences (beams) during text generation, exploring different possible continuations to find higher quality outputs. Unlike greedy decoding or sampling, beam search considers multiple hypotheses simultaneously.
+
+To enable beam search, you must:
+
+1. Enable the `use_beam_search` option in the `SamplingParams` object
+2. Set the `max_beam_width` parameter in the `LLM` class to match the `best_of` parameter in `SamplingParams`
+3. Disable overlap scheduling using the `disable_overlap_scheduler` parameter of the `LLM` class
+
+Parameter Configuration:
+- `best_of`: Controls the number of beams processed during generation (beam width)
+- `n`: Controls the number of output sequences returned (can be less than `best_of`)
+- If `best_of` is omitted, it will be implicitly set to `n`
+- `max_beam_width` in the `LLM` class must equal `best_of` in `SamplingParams`
+
+The following example demonstrates beam search with a beam width of 4, returning the top 3 sequences:
+
+```python
+from tensorrt_llm import LLM
+llm = LLM(model='nvidia/Llama-3.1-8B-Instruct-FP8',
+          enable_trtllm_sampler=True,
+          max_beam_width=4,   # must equal SamplingParams.best_of
+          disable_overlap_scheduler=True)
+sampling_params = SamplingParams(
+        best_of=4,   # must equal LLM.max_beam_width
+        use_beam_search=True,
+        n=3,         # return top 3 sequences
+    )
+llm.generate(["Hello, my name is",
+            "Hello, my name is"], sampling_params)
+```

--- a/docs/source/1.0/features/sampling.md
+++ b/docs/source/1.0/features/sampling.md
@@ -11,7 +11,7 @@ To use the feature:
 The following example prepares two identical prompts which will give different results due to the sampling parameters chosen:
 
 ```python
-from tensorrt_llm import LLM
+from tensorrt_llm import LLM, SamplingParams
 llm = LLM(model='nvidia/Llama-3.1-8B-Instruct-FP8',
           enable_trtllm_sampler=True)
 sampling_params = SamplingParams(
@@ -34,6 +34,7 @@ To enable beam search, you must:
 1. Enable the `use_beam_search` option in the `SamplingParams` object
 2. Set the `max_beam_width` parameter in the `LLM` class to match the `best_of` parameter in `SamplingParams`
 3. Disable overlap scheduling using the `disable_overlap_scheduler` parameter of the `LLM` class
+4. Disable the usage of CUDA Graphs by passing `None` to the `cuda_graph_config` parameter of the `LLM` class
 
 Parameter Configuration:
 - `best_of`: Controls the number of beams processed during generation (beam width)
@@ -44,11 +45,12 @@ Parameter Configuration:
 The following example demonstrates beam search with a beam width of 4, returning the top 3 sequences:
 
 ```python
-from tensorrt_llm import LLM
+from tensorrt_llm import LLM, SamplingParams
 llm = LLM(model='nvidia/Llama-3.1-8B-Instruct-FP8',
           enable_trtllm_sampler=True,
           max_beam_width=4,   # must equal SamplingParams.best_of
-          disable_overlap_scheduler=True)
+          disable_overlap_scheduler=True,
+          cuda_graph_config=None)
 sampling_params = SamplingParams(
         best_of=4,   # must equal LLM.max_beam_width
         use_beam_search=True,

--- a/docs/source/1.0/features/sampling.md
+++ b/docs/source/1.0/features/sampling.md
@@ -78,7 +78,7 @@ To enable guided decoding, you must:
     * Note: Depending on the type of format, a different parameter needs to be chosen to construct the object (`json`, `regex`, `grammar`, `strucutral_tag`).
 3. Pass the `GuidedDecodingParams` object to the `guided_decoding` parameter of the `SamplingParams` object
 
-The following example demonstrates guided decoding with JSON format:
+The following example demonstrates guided decoding with a JSON schema:
 
 ```python
 from tensorrt_llm import LLM, SamplingParams
@@ -91,7 +91,7 @@ guided_decoding_params = GuidedDecodingParams(json=structure)
 sampling_params = SamplingParams(
         guided_decoding=guided_decoding_params,
     )
-llm.generate(["Generate a JSON response"], sampling_params)
+llm.generate("Generate a JSON response", sampling_params)
 ```
 
 You can find a more detailed example on guided decoding [here](../../../../examples/llm-api/llm_guided_decoding.py).
@@ -123,7 +123,7 @@ class MyCustomLogitsProcessor(LogitsProcessor):
         client_id: Optional[int]
     ) -> None:
         # Implement your custom inplace logits processing logic
-        logits = 2 * logits
+        logits *= logits
 
 llm = LLM(model='nvidia/Llama-3.1-8B-Instruct-FP8')
 sampling_params = SamplingParams(


### PR DESCRIPTION
## Description

Added Documentation for TRTLLM Sampling. Reused the old Documentation and added a new section regarding Beam Search

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
