### PR TITLE
[TRTLLM-6262] Fix Llama4 Scout FP4 crash issue

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_llama.py
+++ b/tensorrt_llm/_torch/models/modeling_llama.py
@@ -159,8 +159,11 @@ class Llama4Attention(Attention):
             q = self._attention_scaling(q, position_ids)
 
         out_scale = None
+        out_scale_sf = None
         if self.o_proj.has_fp8_qdq or self.o_proj.has_nvfp4 or self.o_proj.has_fp8_block_scales:
             out_scale = self.o_proj.inv_input_scale
+        if self.o_proj.has_nvfp4 and self.support_nvfp4_output:
+            out_scale_sf = self.o_proj.input_scale
 
         q, k, v = self.convert_qkv(q, k, v)
         attn_output = self.attn.forward(q,
@@ -168,6 +171,7 @@ class Llama4Attention(Attention):
                                         v,
                                         attn_metadata,
                                         out_scale=out_scale,
+                                        out_scale_sf=out_scale_sf,
                                         attention_mask=attention_mask,
                                         mrope_config=mrope_config)
 


### PR DESCRIPTION
# [TRTLLM-6262] Fix Llama4 Scout FP4 crash issue

## Description

This PR is to fix Llama4 Scout FP4 crashing issue due to out_scale_sf is None in _forward_nope.

FP4 output prompts:

```
[0] Prompt: 'Hello, my name is', Generated text: ' Cherub, and I am a sophomore. I am a native Chinese, and I am going to study in the United States. My major is English language and Literature. \nI have a strong interest in the field of English teaching, and I hope to study in the US to learn about the advanced teaching methods and develop'
[1] Prompt: 'The president of the United States is', Generated text: ' sponsoring a new educational initiative with a large- scale Federal services program under a jurisdiction of the federal cabinet. The president calls the agency or subsidized schools, "Schoolabaellot40005 program," and also advocacy intervention plan. The program is sponsored by federal jurisdiction under Title V, which is regulated under governmental legisl'
[2] Prompt: 'The capital of France is', Generated text: ' Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris. The capital of France is Paris'
[3] Prompt: 'The future of AI is', Generated text: ' often considered to be solved by machines, but it's not that today. The AI Revolution is underway, but it's not being built by with human minds. – The Verolein Bellringa, AI researcher, says that "the best way to predict what the future of AI will be is to learn from the'
```

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
