### PR TITLE
[nvbug 5327706][fix] fix mgmn postprocess error

### DIFF
--- a/tests/unittest/llmapi/run_llm_with_postproc.py
+++ b/tests/unittest/llmapi/run_llm_with_postproc.py
@@ -6,64 +6,11 @@ from typing import Optional
 
 import click
 
-from tensorrt_llm.executor import GenerationResultBase
-from tensorrt_llm.executor.postproc_worker import PostprocArgs, PostprocParams
+from tensorrt_llm.executor.postproc_worker import PostprocParams
 from tensorrt_llm.llmapi import LLM, KvCacheConfig, SamplingParams
 from tensorrt_llm.llmapi.utils import print_colored
-from tensorrt_llm.serve.openai_protocol import (
-    ChatCompletionResponseStreamChoice, ChatCompletionStreamResponse,
-    DeltaMessage)
-
-
-def perform_faked_oai_postprocess(rsp: GenerationResultBase,
-                                  args: PostprocArgs):
-    first_iteration = len(rsp.outputs[0].token_ids) == 1
-    num_choices = 1
-    finish_reason_sent = [False] * num_choices
-    role = "assistant"
-    model = "LLaMA"
-
-    def yield_first_chat(idx: int, role: str = None, content: str = None):
-        choice_data = ChatCompletionResponseStreamChoice(index=idx,
-                                                         delta=DeltaMessage(
-                                                             role=role,
-                                                             content=content),
-                                                         finish_reason=None)
-        chunk = ChatCompletionStreamResponse(choices=[choice_data], model=model)
-
-        data = chunk.model_dump_json(exclude_unset=True)
-        return data
-
-    res = []
-    if first_iteration:
-        for i in range(num_choices):
-            res.append(f"data: {yield_first_chat(i, role=role)} \n\n")
-    first_iteration = False
-
-    for output in rsp.outputs:
-        i = output.index
-
-        if finish_reason_sent[i]:
-            continue
-
-        delta_text = output.text_diff
-        delta_message = DeltaMessage(content=delta_text)
-
-        choice = ChatCompletionResponseStreamChoice(index=i,
-                                                    delta=delta_message,
-                                                    finish_reason=None)
-        if output.finish_reason is not None:
-            choice.finish_reason = output.finish_reason
-            choice.stop_reason = output.stop_reason
-            finish_reason_sent[i] = True
-        chunk = ChatCompletionStreamResponse(choices=[choice], model=model)
-        data = chunk.model_dump_json(exclude_unset=True)
-        res.append(f"data: {data}\n\n")
-
-    if rsp._done:
-        res.append(f"data: [DONE]\n\n")
-
-    return res
+from tensorrt_llm.serve.postprocess_handlers import (ChatPostprocArgs,
+                                                     chat_stream_post_processor)
 
 
 @click.command()
@@ -98,9 +45,11 @@ def main(model_dir: str, tp_size: int, engine_dir: Optional[str], n: int,
                                      n=n,
                                      best_of=best_of,
                                      top_k=top_k)
+    postproc_args = ChatPostprocArgs(role="assistant",
+                                     model="TinyLlama-1.1B-Chat-v1.0")
     postproc_params = PostprocParams(
-        post_processor=perform_faked_oai_postprocess,
-        postproc_args=PostprocArgs(),
+        post_processor=chat_stream_post_processor,
+        postproc_args=postproc_args,
     )
 
     prompt = "A B C D E F"

--- a/tests/unittest/llmapi/test_llm_multi_gpu.py
+++ b/tests/unittest/llmapi/test_llm_multi_gpu.py
@@ -322,7 +322,6 @@ def test_llm_multi_node_pytorch(nworkers: int):
 
 @skip_single_gpu
 def test_llm_multi_node_with_postproc():
-    pytest.skip("https://nvbugspro.nvidia.com/bug/5327706")
     nworkers = 2
     test_case_file = os.path.join(os.path.dirname(__file__),
                                   "run_llm_with_postproc.py")


### PR DESCRIPTION
## Description

Current implementation doesn't support user-defined postprocess function outside of TRTLLM lib, this PR removes the function defined in `./tests` and use what defines in core lib.

## Test Coverage

Fix the current test

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
