### PR TITLE
[fix] Catch inference failures in `trtllm-bench`

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1084,6 +1084,7 @@ class PyExecutor:
 
                     sample_state = self._sample_async(scheduled_batch,
                                                       batch_outputs)
+                    assert sample_state is not None, "Sampling failed"
 
                     self._update_request_states(scheduled_batch)
 

--- a/tensorrt_llm/bench/benchmark/utils/asynchronous.py
+++ b/tensorrt_llm/bench/benchmark/utils/asynchronous.py
@@ -57,44 +57,48 @@ class LlmManager:
         self.request_seen.set()
         sampling_params.max_tokens = request.output_tokens
 
-        async with semaphore_guard(self._concurrency_semaphore):
-            request_start_timestamp = time.perf_counter_ns()
-            time_on_first_token = None
-            # Schedule the request in the LLM API (asynchronously)
-            logger.debug(f"request.lora_request: {request.lora_request}")
-            output: RequestOutput = self.llm.generate_async(
-                request.input_ids if self.modality is None else request.prompt,
-                sampling_params=sampling_params,
-                _postproc_params=post_proc_params,
-                streaming=self.streaming,
-                lora_request=request.lora_request)
-            if self.streaming:
-                async for stream_output in output:
-                    if time_on_first_token is None:
-                        time_on_first_token = time.perf_counter_ns()
-                response = stream_output
-            else:
-                # Wait for the response to return to us.
-                response: RequestOutput = await output.aresult()
+        try:
+            async with semaphore_guard(self._concurrency_semaphore):
+                request_start_timestamp = time.perf_counter_ns()
+                time_on_first_token = None
+                # Schedule the request in the LLM API (asynchronously)
+                logger.debug(f"request.lora_request: {request.lora_request}")
+                output: RequestOutput = self.llm.generate_async(
+                    request.input_ids
+                    if self.modality is None else request.prompt,
+                    sampling_params=sampling_params,
+                    _postproc_params=post_proc_params,
+                    streaming=self.streaming,
+                    lora_request=request.lora_request)
+                if self.streaming:
+                    async for stream_output in output:
+                        if time_on_first_token is None:
+                            time_on_first_token = time.perf_counter_ns()
+                            response = stream_output
+                else:
+                    # Wait for the response to return to us.
+                    response: RequestOutput = await output.aresult()
 
-        response_end_timestamp = time.perf_counter_ns()
+            response_end_timestamp = time.perf_counter_ns()
 
-        # Mark that the response returned. Construct a record to send to statistics.
-        tokens = list(chain(*[beam.token_ids for beam in response.outputs]))
-        request_perf_item = PerfItemTuple(
-            start_timestamp=request_start_timestamp,
-            end_timestamp=response_end_timestamp,
-            request_id=response.request_id,
-            num_input_tokens=len(output.prompt_token_ids),
-            response_is_final=response.finished,
-            error=False,
-            tokens=tokens,
-            decoding_iteration=response.decoding_iter,
-            time_on_first_token=time_on_first_token,
-        )
+            # Mark that the response returned. Construct a record to send to statistics.
+            tokens = list(chain(*[beam.token_ids for beam in response.outputs]))
+            request_perf_item = PerfItemTuple(
+                start_timestamp=request_start_timestamp,
+                end_timestamp=response_end_timestamp,
+                request_id=response.request_id,
+                num_input_tokens=len(output.prompt_token_ids),
+                response_is_final=response.finished,
+                error=False,
+                tokens=tokens,
+                decoding_iteration=response.decoding_iter,
+                time_on_first_token=time_on_first_token,
+            )
 
-        # Register the new request perf items in the outbound queue for statistics keeping
-        await self._outbox.put(request_perf_item)
+            # Register the new request perf items in the outbound queue for statistics keeping
+            await self._outbox.put(request_perf_item)
+        except asyncio.CancelledError:
+            pass
 
     async def worker(self) -> None:
         while not self._stop.is_set():


### PR DESCRIPTION
## Description

This PR adds several checks that ensures `trtllm-bench` does not hang indefinitely if an exception is thrown during inference:
* `asyncio` tasks are checked for errors when done, and the manager is stopped if an error occurs.
* Number of perf items is checked against the number of requests submitted.
* `CancelError`s are caught for a cleaner traceback.
* Added an assert in `py_executor.py` to check for sampling failures.