### PR TITLE
fix: VSWA KV cache calculation

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -852,15 +852,6 @@ public:
         std::shared_ptr<KVCacheEventManager> eventManager = nullptr, bool enableHashKey = false,
         bool enablePartialReuse = true, bool copyOnPartialReuse = true);
 
-    //! \brief Calculate the proportional share each window size receives of the total memory pool
-    //! \details Example:       (uniqueWindowSizeToLayers={1024: [1], 4096: [0, 4, 5], 8192: [2, 3]})
-    //!          Would Return:  {1024: 0.0345, 4096: 0.4138, 8192: 0.5517} [sums to 1.0].
-    //!          See: TEST_F(KVCacheManagerTest, BlockManagerTestWindowSizeToShare).
-    //! \return Map<windowSize, share> where share is a float between 0 and 1. Shares sum to 1.0.
-    static std::map<SizeType32, float> calculateWindowSizeToShare(
-        std::map<SizeType32, std::vector<SizeType32>> const& uniqueWindowSizeToLayers,
-        std::map<SizeType32, SizeType32> const& cacheSizePerTokenPerWindowSize);
-
     void allocatePools(bool useUvm);
 
     void addSequence(GenerationRequest& sequence, SizeType32 inputLength, SizeType32 numContextBlocks,

--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -311,6 +311,11 @@ class ModelConfig(Generic[TConfig]):
         else:
             model_config_cpp.tokens_per_block = tokens_per_block
 
+        num_kv_heads = getattr(
+            self.pretrained_config, "num_key_value_heads",
+            num_heads) // (self.mapping.tp_size * self.mapping.cp_size)
+        model_config_cpp.set_num_kv_heads(num_kv_heads)
+
         mlp_hidden_size = None
         if self.pretrained_config.intermediate_size is not None:
             mlp_hidden_size = self.pretrained_config.intermediate_size // self.mapping.tp_size


### PR DESCRIPTION
This PR is *a reference PR* to share the issue and algorithm before fixing KV cache calculation issue. In a short-term, we will fix the calculation at each Torch / TRT backend instead of directly fixing KvCacheManager, which depends so many modules. So to minimize side effects and risks, we will firstly fix at each backend side as a workaround. In a long-term, it will be fixed at the KvCacheManager side as in this PR.