### PR TITLE
test: reduce redundant test cases for TRTLLM Gen FP8 MoE

### DIFF
--- a/tests/unittest/_torch/thop/test_moe.py
+++ b/tests/unittest/_torch/thop/test_moe.py
@@ -583,7 +583,8 @@ class TestMoeFP8:
                                              (72, 1, 1, 6), (256, 8, 4, 8)])
     @pytest.mark.parametrize("hidden_size", [512])
     @pytest.mark.parametrize("intermediate_size", [512])
-    def test_autotune(self, num_tokens: int, expert_info: Tuple[int],
+    def test_autotune(self, num_tokens: int, expert_info: Tuple[int, int, int,
+                                                                int],
                       hidden_size: int, intermediate_size: int):
 
         self.run_moe_fp8_test(num_tokens,
@@ -596,7 +597,8 @@ class TestMoeFP8:
     @pytest.mark.parametrize("expert_info", [(32, 8, 4, 8)])
     @pytest.mark.parametrize("hidden_size", [512])
     @pytest.mark.parametrize("intermediate_size", [512])
-    def test_no_autotune(self, num_tokens: int, expert_info: Tuple[int],
+    def test_no_autotune(self, num_tokens: int, expert_info: Tuple[int, int,
+                                                                   int, int],
                          hidden_size: int, intermediate_size: int):
 
         self.run_moe_fp8_test(num_tokens,
@@ -605,7 +607,8 @@ class TestMoeFP8:
                               intermediate_size,
                               use_autotune=False)
 
-    def run_moe_fp8_test(self, num_tokens: int, expert_info: Tuple[int],
+    def run_moe_fp8_test(self, num_tokens: int, expert_info: Tuple[int, int,
+                                                                   int, int],
                          hidden_size: int, intermediate_size: int,
                          use_autotune: bool):
         torch.random.manual_seed(0)


### PR DESCRIPTION
## Description

As autotune also covers the actual MoE, we can run the test  with autotune by default. We add a separate test with less parametrization for no autotune to ensure that the default tactic selection works. This reduces unnecessary test runs. From 32 cases to 17.

## Test Coverage

`tests/unnittest/_torch/thop/test_moe.py`

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
