### PR TITLE
[TRTLLM-5863][feat] Support Weight-Only-Quantization in PyTorch Workflow

### DIFF
--- a/cpp/tensorrt_llm/thop/CMakeLists.txt
+++ b/cpp/tensorrt_llm/thop/CMakeLists.txt
@@ -85,6 +85,7 @@ add_library(
   selectiveScanOp.cpp
   userbuffersFinalizeOp.cpp
   userbuffersTensor.cpp
+  weightOnlyQuantGemm.cpp
   weightOnlyQuantOp.cpp
   mtpOp.cpp
   loraOp.cpp

--- a/cpp/tensorrt_llm/thop/weightOnlyQuantGemm.cpp
+++ b/cpp/tensorrt_llm/thop/weightOnlyQuantGemm.cpp
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tensorrt_llm/common/cudaUtils.h"
+#include "tensorrt_llm/kernels/cutlass_kernels/fpA_intB_gemm/fpA_intB_gemm.h"
+#include "tensorrt_llm/thop/thUtils.h"
+#include "cutlass/numeric_types.h"
+
+#include <ATen/cuda/EmptyTensor.h>
+#include <optional>
+
+using namespace tensorrt_llm::kernels::cutlass_kernels;
+using namespace tensorrt_llm::kernels;
+
+namespace torch_ext
+{
+
+using WeightOnlyGemmRunnerPtr = std::shared_ptr<CutlassFpAIntBGemmRunnerInterface>;
+
+namespace
+{
+void check_input_dtypes(torch::Tensor const& mat_a, torch::Tensor const& mat_b)
+{
+    TORCH_CHECK(mat_a.scalar_type() == at::ScalarType::BFloat16 || 
+                mat_a.scalar_type() == at::ScalarType::Half,
+                "Activation matrix dtype must be BF16 or FP16");
+    
+    TORCH_CHECK(mat_b.scalar_type() == at::ScalarType::Char, "Weight matrix dtype must be INT8");
+}
+
+#define DISPATCH_ACTIVATION_TYPE(scalar_type, ...)                                                                   \
+    if (scalar_type == at::ScalarType::Half)                                                                         \
+    {                                                                                                                \
+        using ActivationType = half;                                                                                 \
+        __VA_ARGS__();                                                                                               \ 
+    }                                                                                                                \
+    else if (scalar_type == at::ScalarType::BFloat16)                                                                \
+    {                                                                                                                \
+        using ActivationType = __nv_bfloat16;                                                                        \
+        __VA_ARGS__();                                                                                               \
+    }                                                                                                                \
+    else                                                                                                             \
+    {                                                                                                                \
+        TORCH_CHECK(false, "Unsupported activation type");                                                           \
+    }
+
+#define DISPATCH_WEIGHT_TYPE(scalar_type, ...)                                                                       \
+    if (scalar_type == at::ScalarType::Char)                                                                         \
+    {                                                                                                                \
+        using WeightType = uint8_t;                                                                                  \
+        __VA_ARGS__();                                                                                               \
+    }                                                                                                                \
+    else if (scalar_type == at::ScalarType::QUInt4x2)                                                                \
+    {                                                                                                                \
+        using WeightType = cutlass::uint4b_t;                                                                        \
+        __VA_ARGS__();                                                                                               \
+    }                                                                                                                \
+    else                                                                                                             \
+    {                                                                                                                \
+        TORCH_CHECK(false, "Unsupported weight type");                                                               \
+    }
+
+WeightOnlyGemmRunnerPtr get_gemm_runner(at::ScalarType dtype_a, at::ScalarType dtype_b)
+{
+    WeightOnlyGemmRunnerPtr result;
+    
+    DISPATCH_ACTIVATION_TYPE(dtype_a,
+        [&]
+        {
+            using ADtypeStatic = ActivationType;
+            DISPATCH_WEIGHT_TYPE(dtype_b,
+                [&]
+                {
+                    using BDtypeStatic = WeightType;
+                    result = std::make_unique<CutlassFpAIntBGemmRunner<ADtypeStatic, BDtypeStatic, 
+                        cutlass::WeightOnlyQuantOp::PER_COLUMN_SCALE_ONLY>>();
+                })
+        })
+    
+    return result;
+}
+
+} // namespace
+
+torch::Tensor weight_only_quant_gemm(
+    torch::Tensor const& mat_a, 
+    torch::Tensor const& mat_b,
+    torch::ScalarType weight_type,
+    torch::Tensor const& weight_scales,
+    std::optional<c10::ScalarType> out_dtype)
+{
+    check_input_dtypes(mat_a, mat_b);
+    
+    TORCH_CHECK(mat_a.dim() == 2, "mat_a must be a matrix");
+    TORCH_CHECK(mat_b.dim() == 2, "mat_b must be a matrix");
+    TORCH_CHECK(mat_a.sizes()[1] == mat_b.sizes()[0], "mat_a and mat_b shapes cannot be multiplied");
+    
+    auto const m = mat_a.sizes()[0];
+    auto const n = mat_b.sizes()[1];
+    auto const k = mat_a.sizes()[1];
+    auto real_n = n;
+    if (weight_type == at::ScalarType::QUInt4x2)
+    {
+        real_n = n * 2;
+    }
+    TORCH_CHECK(k % 16 == 0, "K must be a multiple of 16, (K=", k, ")");
+    TORCH_CHECK(n % 16 == 0, "N must be a multiple of 16, (N=", n, ")");
+
+    auto const dtype = out_dtype.value_or(mat_a.scalar_type());
+    at::Tensor out = at::detail::empty_cuda({m, real_n}, dtype, mat_a.device(), std::nullopt);
+    auto stream = at::cuda::getCurrentCUDAStream(mat_a.get_device());
+    
+    auto gemm_runner = get_gemm_runner(mat_a.scalar_type(), weight_type);
+
+    auto workspace_size = gemm_runner->getWorkspaceSize(m, real_n, k);
+    at::Tensor workspace;
+    char* workspace_ptr = nullptr;
+    if (workspace_size > 0)
+    {
+        workspace = at::detail::empty_cuda({static_cast<int64_t>(workspace_size)}, 
+                                          at::ScalarType::Byte, mat_a.device(), std::nullopt);
+        workspace_ptr = static_cast<char*>(workspace.data_ptr());
+    }
+    
+    auto configs = gemm_runner->getConfigs();
+    TORCH_CHECK(!configs.empty(), "No valid GEMM configurations available");
+    auto gemm_config = configs[0];
+    
+    gemm_runner->gemm(mat_a.data_ptr(), mat_b.data_ptr(), weight_scales.data_ptr(),
+                     out.data_ptr(), m, real_n, k, gemm_config,
+                     workspace_ptr, workspace_size, stream);
+
+    return out;
+}
+
+} // namespace torch_ext
+
+TORCH_LIBRARY_FRAGMENT(trtllm, m)
+{
+    m.def("weight_only_quant_gemm(Tensor mat_a, Tensor mat_b, ScalarType weight_type, Tensor weight_scales, "
+          "ScalarType? out_dtype=None) -> Tensor");
+}
+
+TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
+{
+    m.impl("weight_only_quant_gemm", &torch_ext::weight_only_quant_gemm);
+}

--- a/cpp/tensorrt_llm/thop/weightOnlyQuantGemm.cpp
+++ b/cpp/tensorrt_llm/thop/weightOnlyQuantGemm.cpp
@@ -13,11 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+#include "weightOnlyQuantGemm.h"
+#include "cutlass/numeric_types.h"
+#include "cutlass_extensions/gemm_configs.h"
 #include "tensorrt_llm/common/cudaUtils.h"
+#include "tensorrt_llm/kernels/cutlass_kernels/cutlass_heuristic.h"
 #include "tensorrt_llm/kernels/cutlass_kernels/fpA_intB_gemm/fpA_intB_gemm.h"
 #include "tensorrt_llm/thop/thUtils.h"
-#include "cutlass/numeric_types.h"
 
 #include <ATen/cuda/EmptyTensor.h>
 #include <optional>
@@ -28,133 +30,132 @@ using namespace tensorrt_llm::kernels;
 namespace torch_ext
 {
 
-using WeightOnlyGemmRunnerPtr = std::shared_ptr<CutlassFpAIntBGemmRunnerInterface>;
-
 namespace
 {
-void check_input_dtypes(torch::Tensor const& mat_a, torch::Tensor const& mat_b)
+void check_input_dtypes(at::Tensor const& mat_a, at::Tensor const& mat_b)
 {
-    TORCH_CHECK(mat_a.scalar_type() == at::ScalarType::BFloat16 || 
-                mat_a.scalar_type() == at::ScalarType::Half,
-                "Activation matrix dtype must be BF16 or FP16");
-    
+    TORCH_CHECK(mat_a.scalar_type() == at::ScalarType::BFloat16 || mat_a.scalar_type() == at::ScalarType::Half,
+        "Activation matrix dtype must be BF16 or FP16");
+
     TORCH_CHECK(mat_b.scalar_type() == at::ScalarType::Char, "Weight matrix dtype must be INT8");
 }
 
-#define DISPATCH_ACTIVATION_TYPE(scalar_type, ...)                                                                   \
-    if (scalar_type == at::ScalarType::Half)                                                                         \
-    {                                                                                                                \
-        using ActivationType = half;                                                                                 \
-        __VA_ARGS__();                                                                                               \ 
-    }                                                                                                                \
-    else if (scalar_type == at::ScalarType::BFloat16)                                                                \
-    {                                                                                                                \
-        using ActivationType = __nv_bfloat16;                                                                        \
-        __VA_ARGS__();                                                                                               \
-    }                                                                                                                \
-    else                                                                                                             \
-    {                                                                                                                \
-        TORCH_CHECK(false, "Unsupported activation type");                                                           \
+#define DISPATCH_ACTIVATION_TYPE(scalar_type, ...)                                                                     \
+    if (scalar_type == at::ScalarType::Half)                                                                           \
+    {                                                                                                                  \
+        using ActivationType = half;                                                                                   \
+        __VA_ARGS__();                                                                                                 \
+    }                                                                                                                  \
+    else if (scalar_type == at::ScalarType::BFloat16)                                                                  \
+    {                                                                                                                  \
+        using ActivationType = __nv_bfloat16;                                                                          \
+        __VA_ARGS__();                                                                                                 \
+    }                                                                                                                  \
+    else                                                                                                               \
+    {                                                                                                                  \
+        TORCH_CHECK(false, "Unsupported activation type");                                                             \
     }
 
-#define DISPATCH_WEIGHT_TYPE(scalar_type, ...)                                                                       \
-    if (scalar_type == at::ScalarType::Char)                                                                         \
-    {                                                                                                                \
-        using WeightType = uint8_t;                                                                                  \
-        __VA_ARGS__();                                                                                               \
-    }                                                                                                                \
-    else if (scalar_type == at::ScalarType::QUInt4x2)                                                                \
-    {                                                                                                                \
-        using WeightType = cutlass::uint4b_t;                                                                        \
-        __VA_ARGS__();                                                                                               \
-    }                                                                                                                \
-    else                                                                                                             \
-    {                                                                                                                \
-        TORCH_CHECK(false, "Unsupported weight type");                                                               \
+#define DISPATCH_WEIGHT_TYPE(scalar_type, ...)                                                                         \
+    if (scalar_type == at::ScalarType::Char)                                                                           \
+    {                                                                                                                  \
+        using WeightType = uint8_t;                                                                                    \
+        __VA_ARGS__();                                                                                                 \
+    }                                                                                                                  \
+    else if (scalar_type == at::ScalarType::QUInt4x2)                                                                  \
+    {                                                                                                                  \
+        using WeightType = cutlass::uint4b_t;                                                                          \
+        __VA_ARGS__();                                                                                                 \
+    }                                                                                                                  \
+    else                                                                                                               \
+    {                                                                                                                  \
+        TORCH_CHECK(false, "Unsupported weight type");                                                                 \
     }
-
-WeightOnlyGemmRunnerPtr get_gemm_runner(at::ScalarType dtype_a, at::ScalarType dtype_b)
-{
-    WeightOnlyGemmRunnerPtr result;
-    
-    DISPATCH_ACTIVATION_TYPE(dtype_a,
-        [&]
-        {
-            using ADtypeStatic = ActivationType;
-            DISPATCH_WEIGHT_TYPE(dtype_b,
-                [&]
-                {
-                    using BDtypeStatic = WeightType;
-                    result = std::make_unique<CutlassFpAIntBGemmRunner<ADtypeStatic, BDtypeStatic, 
-                        cutlass::WeightOnlyQuantOp::PER_COLUMN_SCALE_ONLY>>();
-                })
-        })
-    
-    return result;
-}
 
 } // namespace
 
-torch::Tensor weight_only_quant_gemm(
-    torch::Tensor const& mat_a, 
-    torch::Tensor const& mat_b,
-    torch::ScalarType weight_type,
-    torch::Tensor const& weight_scales,
-    std::optional<c10::ScalarType> out_dtype)
+WeightOnlyQuantGemmRunner::WeightOnlyQuantGemmRunner(at::ScalarType activation_dtype, at::ScalarType weight_dtype)
+    : mActivationDtype(activation_dtype)
+    , mWeightDtype(weight_dtype)
+{
+    DISPATCH_ACTIVATION_TYPE(activation_dtype,
+        [&]
+        {
+            using ADtypeStatic = ActivationType;
+            DISPATCH_WEIGHT_TYPE(weight_dtype,
+                [&]
+                {
+                    using BDtypeStatic = WeightType;
+                    mGemmRunner = std::make_shared<CutlassFpAIntBGemmRunner<ADtypeStatic, BDtypeStatic,
+                        cutlass::WeightOnlyQuantOp::PER_COLUMN_SCALE_ONLY>>();
+                })
+        })
+    mConfigs = mGemmRunner->getConfigs();
+    TORCH_CHECK(!mConfigs.empty(), "Failed to get CUTLASS configs for WeightOnlyQuantGemmRunner with activation type ",
+        c10::toString(mActivationDtype), ", weight type ", c10::toString(mWeightDtype));
+}
+
+at::Tensor WeightOnlyQuantGemmRunner::runGemm(at::Tensor const& mat_a, at::Tensor const& mat_b,
+    at::Tensor const& weight_scales, int64_t config_idx, std::optional<c10::ScalarType> out_dtype)
 {
     check_input_dtypes(mat_a, mat_b);
-    
+
     TORCH_CHECK(mat_a.dim() == 2, "mat_a must be a matrix");
     TORCH_CHECK(mat_b.dim() == 2, "mat_b must be a matrix");
     TORCH_CHECK(mat_a.sizes()[1] == mat_b.sizes()[0], "mat_a and mat_b shapes cannot be multiplied");
-    
+    TORCH_CHECK(mat_a.is_cuda() && mat_b.is_cuda() && weight_scales.is_cuda(), "All input tensors must be on CUDA");
+
     auto const m = mat_a.sizes()[0];
-    auto const n = mat_b.sizes()[1];
     auto const k = mat_a.sizes()[1];
+    auto const n = mat_b.sizes()[1];
     auto real_n = n;
-    if (weight_type == at::ScalarType::QUInt4x2)
+    if (mWeightDtype == at::ScalarType::QUInt4x2)
     {
         real_n = n * 2;
     }
-    TORCH_CHECK(k % 16 == 0, "K must be a multiple of 16, (K=", k, ")");
-    TORCH_CHECK(n % 16 == 0, "N must be a multiple of 16, (N=", n, ")");
 
-    auto const dtype = out_dtype.value_or(mat_a.scalar_type());
+    auto const dtype = out_dtype.value_or(mActivationDtype);
     at::Tensor out = at::detail::empty_cuda({m, real_n}, dtype, mat_a.device(), std::nullopt);
     auto stream = at::cuda::getCurrentCUDAStream(mat_a.get_device());
-    
-    auto gemm_runner = get_gemm_runner(mat_a.scalar_type(), weight_type);
 
-    auto workspace_size = gemm_runner->getWorkspaceSize(m, real_n, k);
+    auto workspace_size = mGemmRunner->getWorkspaceSize(m, real_n, k);
     at::Tensor workspace;
     char* workspace_ptr = nullptr;
     if (workspace_size > 0)
     {
-        workspace = at::detail::empty_cuda({static_cast<int64_t>(workspace_size)}, 
-                                          at::ScalarType::Byte, mat_a.device(), std::nullopt);
+        workspace = at::detail::empty_cuda(
+            {static_cast<int64_t>(workspace_size)}, at::ScalarType::Byte, mat_a.device(), std::nullopt);
         workspace_ptr = static_cast<char*>(workspace.data_ptr());
     }
-    
-    auto configs = gemm_runner->getConfigs();
-    TORCH_CHECK(!configs.empty(), "No valid GEMM configurations available");
-    auto gemm_config = configs[0];
-    
-    gemm_runner->gemm(mat_a.data_ptr(), mat_b.data_ptr(), weight_scales.data_ptr(),
-                     out.data_ptr(), m, real_n, k, gemm_config,
-                     workspace_ptr, workspace_size, stream);
+
+    tensorrt_llm::cutlass_extensions::CutlassGemmConfig gemm_config_to_use;
+    if (config_idx >= 0 && config_idx < getNumConfigs())
+    {
+        gemm_config_to_use = mConfigs.at(config_idx);
+    }
+    else
+    {
+        gemm_config_to_use = mConfigs.at(0);
+    }
+
+    mGemmRunner->gemm(mat_a.data_ptr(), mat_b.data_ptr(), weight_scales.data_ptr(), out.data_ptr(), m, real_n, k,
+        gemm_config_to_use, workspace_ptr, workspace_size, stream);
 
     return out;
+}
+
+int64_t WeightOnlyQuantGemmRunner::getNumConfigs() const
+{
+    TORCH_CHECK(mGemmRunner, "WeightOnlyQuantGemmRunner not initialized properly.");
+    return static_cast<int64_t>(mConfigs.size());
 }
 
 } // namespace torch_ext
 
 TORCH_LIBRARY_FRAGMENT(trtllm, m)
 {
-    m.def("weight_only_quant_gemm(Tensor mat_a, Tensor mat_b, ScalarType weight_type, Tensor weight_scales, "
-          "ScalarType? out_dtype=None) -> Tensor");
-}
-
-TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
-{
-    m.impl("weight_only_quant_gemm", &torch_ext::weight_only_quant_gemm);
+    m.class_<torch_ext::WeightOnlyQuantGemmRunner>("WeightOnlyQuantGemmRunner")
+        .def(torch::init<at::ScalarType, at::ScalarType>())
+        .def("run_gemm", &torch_ext::WeightOnlyQuantGemmRunner::runGemm)
+        .def("get_num_configs", &torch_ext::WeightOnlyQuantGemmRunner::getNumConfigs);
 }

--- a/cpp/tensorrt_llm/thop/weightOnlyQuantGemm.h
+++ b/cpp/tensorrt_llm/thop/weightOnlyQuantGemm.h
@@ -18,7 +18,12 @@
 
 #include "cutlass_extensions/gemm_configs.h"
 #include "cutlass_extensions/weight_only_quant_op.h"
+#include "tensorrt_llm/common/cudaUtils.h"
+#include "tensorrt_llm/kernels/cutlass_kernels/cutlass_heuristic.h"
 #include "tensorrt_llm/kernels/cutlass_kernels/fpA_intB_gemm/fpA_intB_gemm.h"
+#include "tensorrt_llm/thop/thUtils.h"
+#include "tensorrt_llm/thop/userbuffersTensor.h"
+
 #include <torch/extension.h>
 
 using namespace tensorrt_llm::kernels::cutlass_kernels;
@@ -34,7 +39,7 @@ public:
     explicit WeightOnlyQuantGemmRunner(at::ScalarType activation_dtype, at::ScalarType weight_dtype);
 
     at::Tensor runGemm(at::Tensor const& mat_a, at::Tensor const& mat_b, at::Tensor const& weight_scales,
-        int64_t config_idx, std::optional<c10::ScalarType> out_dtype);
+        int64_t config_idx, bool to_userbuffers, std::optional<c10::ScalarType> out_dtype);
 
     int64_t getNumConfigs() const;
 

--- a/cpp/tensorrt_llm/thop/weightOnlyQuantGemm.h
+++ b/cpp/tensorrt_llm/thop/weightOnlyQuantGemm.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "cutlass_extensions/gemm_configs.h"
+#include "cutlass_extensions/weight_only_quant_op.h"
+#include "tensorrt_llm/kernels/cutlass_kernels/fpA_intB_gemm/fpA_intB_gemm.h"
+#include <torch/extension.h>
+
+using namespace tensorrt_llm::kernels::cutlass_kernels;
+using namespace tensorrt_llm::kernels;
+
+namespace torch_ext
+{
+using WeightOnlyQuantGemmRunnerPtr = std::shared_ptr<CutlassFpAIntBGemmRunnerInterface>;
+
+class WeightOnlyQuantGemmRunner : public torch::CustomClassHolder
+{
+public:
+    explicit WeightOnlyQuantGemmRunner(at::ScalarType activation_dtype, at::ScalarType weight_dtype);
+
+    at::Tensor runGemm(at::Tensor const& mat_a, at::Tensor const& mat_b, at::Tensor const& weight_scales,
+        int64_t config_idx, std::optional<c10::ScalarType> out_dtype);
+
+    int64_t getNumConfigs() const;
+
+private:
+    WeightOnlyQuantGemmRunnerPtr mGemmRunner;
+    at::ScalarType mActivationDtype;
+    at::ScalarType mWeightDtype;
+    std::vector<tensorrt_llm::cutlass_extensions::CutlassGemmConfig> mConfigs;
+};
+
+} // namespace torch_ext

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -156,6 +156,13 @@ def _register_fake():
         n = b.shape[0]
         return a.new_empty((m, n), dtype=torch.bfloat16)
 
+    @torch.library.register_fake("trtllm::weight_only_quant_gemm")
+    def _(a, b, b_type, b_scale, out_dtype=None):
+        m = a.shape[0]
+        n = b.shape[1]
+        dtype = out_dtype if out_dtype is not None else a.dtype
+        return a.new_empty((m, n), dtype=dtype)
+
     @torch.library.register_fake(
         "tensorrt_llm::static_quantize_e4m3_per_tensor")
     def _(input: torch.Tensor, scale: torch.Tensor):

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -156,13 +156,6 @@ def _register_fake():
         n = b.shape[0]
         return a.new_empty((m, n), dtype=torch.bfloat16)
 
-    @torch.library.register_fake("trtllm::weight_only_quant_gemm")
-    def _(a, b, b_type, b_scale, out_dtype=None):
-        m = a.shape[0]
-        n = b.shape[1]
-        dtype = out_dtype if out_dtype is not None else a.dtype
-        return a.new_empty((m, n), dtype=dtype)
-
     @torch.library.register_fake(
         "tensorrt_llm::static_quantize_e4m3_per_tensor")
     def _(input: torch.Tensor, scale: torch.Tensor):

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -675,6 +675,92 @@ def _(
                              dtype=output_dtype)
 
 
+class WeightOnlyQuantGemmRunner(TunableRunner):
+    runner_dict = dict()
+    tuning_config = TuningConfig(dynamic_tensor_specs=(
+        DynamicTensorSpec(0, 0, get_last_power_of_2_num_tokens_buckets,
+                          last_positive_power_of_2), ))
+
+    def __init__(
+        self,
+        activation_dtype: torch.dtype,
+        weight_dtype: torch.dtype,
+        output_dtype: torch.dtype,
+        to_userbuffers: bool,
+    ):
+        self.output_dtype = output_dtype
+        self.to_userbuffers = to_userbuffers
+        instance_key = (activation_dtype, weight_dtype)
+        if instance_key not in WeightOnlyQuantGemmRunner.runner_dict:
+            WeightOnlyQuantGemmRunner.runner_dict[
+                instance_key] = torch.classes.trtllm.WeightOnlyQuantGemmRunner(
+                    activation_dtype, weight_dtype)
+        self.weight_only_quant_gemm_runner = WeightOnlyQuantGemmRunner.runner_dict[
+            instance_key]
+
+    def get_valid_tactics(
+        self,
+        inputs: List[torch.Tensor],
+        profile: OptimizationProfile,
+    ) -> List[int]:
+        return list(range(self.weight_only_quant_gemm_runner.get_num_configs()))
+
+    def forward(
+        self,
+        inputs: List[torch.Tensor],
+        tactic: int = -1,
+    ) -> torch.Tensor:
+        activation, weight, weight_scale = inputs
+        return self.weight_only_quant_gemm_runner.run_gemm(
+            activation,
+            weight,
+            weight_scale,
+            tactic,
+            self.output_dtype,
+        )
+
+
+@torch.library.custom_op("trtllm::weight_only_quant_gemm", mutates_args=())
+def weight_only_quant_gemm(
+    activation: torch.Tensor,
+    weight: torch.Tensor,
+    weight_dtype: torch.dtype,
+    weight_scale: torch.Tensor,
+    output_dtype: torch.dtype,
+    to_userbuffers: bool = False,
+) -> torch.Tensor:
+
+    tuner = AutoTuner.get()
+
+    # allocate workspace for profiling
+    weight_only_quant_gemm_runner = WeightOnlyQuantGemmRunner(
+        activation.dtype, weight_dtype, output_dtype, to_userbuffers)
+
+    _, best_tactic = tuner.choose_one(
+        "trtllm::weight_only_quant_gemm::gemm",
+        [weight_only_quant_gemm_runner],
+        WeightOnlyQuantGemmRunner.tuning_config,
+        [activation, weight, weight_scale],
+    )
+
+    return weight_only_quant_gemm_runner(
+        inputs=[activation, weight, weight_scale], tactic=best_tactic)
+
+
+@weight_only_quant_gemm.register_fake
+def _(
+    activation: torch.Tensor,
+    weight: torch.Tensor,
+    weight_type: torch.dtype,
+    weight_scale: torch.Tensor,
+    output_dtype: torch.dtype = None,
+    to_userbuffers: bool = False,
+) -> torch.Tensor:
+    dtype = output_dtype if output_dtype is not None else activation.dtype
+    return activation.new_empty((activation.size(0), weight.size(1)),
+                                dtype=dtype)
+
+
 class FinegrainedMixedDtypeGemm(TunableRunner):
     _runner_dict = dict()
     MAX_SUPPORTED_SM_VERSION = 90

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -716,6 +716,7 @@ class WeightOnlyQuantGemmRunner(TunableRunner):
             weight,
             weight_scale,
             tactic,
+            self.to_userbuffers,
             self.output_dtype,
         )
 

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -116,12 +116,17 @@ def load_weights_vanilla_helper(module: Linear, weights: List[Dict]):
     weight = load_weight_shard(weights[0]['weight'], module.tp_size,
                                module.tp_rank, module.tp_mode, device)
 
-    if module.has_w4a16_awq or module.has_w4a8_awq:
+    if module.has_w4a16_awq or module.has_weight_only_quant:
         # NOTE: without the preprocess during the runtime, the gemm output nan's. in order to use the preprocess_weights_for_mixed_gemm
         # we need to cast the weight to int8 first.
-        activation_dtype = torch.float16 if module.has_w4a16_awq else torch.float8_e4m3fn
+        activation_dtype = torch.float8_e4m3fn if module.has_w4a8_awq else torch.float16
+        if module.has_w4a16_awq or module.quant_config.layer_quant_mode.is_int4_weight_only(
+        ):
+            quant_mode = torch.quint4x2
+        elif module.quant_config.layer_quant_mode.is_int8_weight_only():
+            quant_mode = torch.int8
         weight = preprocess_weights_for_mixed_gemm(
-            weight.T.to(torch.int8).contiguous().cpu(), torch.quint4x2,
+            weight.T.to(torch.int8).contiguous().cpu(), quant_mode,
             activation_dtype).cuda().contiguous()
 
     copy_weight(module.weight, weight)
@@ -233,6 +238,20 @@ class LinearMethodBase(ABC):
         Load weights for the FUSED_GATE_UP_LINEAR weight mode.
         """
         raise NotImplementedError
+
+    def _get_weight_dtype_and_id(self,
+                                 module: Linear) -> tuple[torch.dtype, int]:
+        """
+        get weight dtype and weight_id for weight only quantization mode
+        """
+        if module.quant_config.layer_quant_mode.is_int8_weight_only():
+            return torch.int8, 1
+        elif module.quant_config.layer_quant_mode.is_int4_weight_only():
+            return torch.quint4x2, 2
+        else:
+            raise ValueError(
+                f"Unsupported quant_mode: {module.quant_config.layer_quant_mode}"
+            )
 
 
 class UnquantizedLinearMethod(LinearMethodBase):
@@ -882,6 +901,122 @@ class W4A8MXFP4FP8LinearMethod(LinearMethodBase):
         copy_weight(module.weight_scale, weight_scale)
 
 
+class WeightOnlyQuantLinearMethod(LinearMethodBase):
+
+    def create_weights(self, module: Linear, in_features: int,
+                       out_features: int, bias: bool,
+                       dtype: torch.dtype) -> None:
+
+        _, weight_id = self._get_weight_dtype_and_id(module)
+
+        # Quantized weights (int4 weights are packed into int8)
+        module.weight = Parameter(torch.empty(
+            (in_features, out_features // weight_id), dtype=torch.int8),
+                                  requires_grad=False)
+
+        module.weight_scale = Parameter(torch.empty((out_features),
+                                                    dtype=dtype),
+                                        requires_grad=False)
+
+        if bias:
+            module.bias = Parameter(torch.empty((out_features), dtype=dtype),
+                                    requires_grad=False)
+        else:
+            module.register_parameter("bias", None)
+
+    def apply(self, module: Linear, input: torch.Tensor,
+              bias: Optional[torch.Tensor]) -> torch.Tensor:
+
+        weight_dtype, _ = self._get_weight_dtype_and_id(module)
+        bias = bias.contiguous() if bias is not None else None
+
+        output = torch.ops.trtllm.weight_only_quant_gemm(
+            input.to(module.dtype).contiguous(), module.weight, weight_dtype,
+            module.weight_scale, module.dtype)
+
+        return output
+
+    def load_weight_scales(
+            self,
+            weights: List[Dict],
+            tp_size: int = 1,
+            tp_rank: int = 0,
+            tp_mode: Optional[TensorParallelMode] = None) -> List[torch.Tensor]:
+        device = torch.device("cuda")
+        q_weight_scale = load_weight_shard(weights[0]['weight_scale'],
+                                           tp_size,
+                                           tp_rank,
+                                           tp_mode,
+                                           device=device)
+        k_weight_scale = load_weight_shard(weights[1]['weight_scale'],
+                                           tp_size,
+                                           tp_rank,
+                                           tp_mode,
+                                           device=device)
+        v_weight_scale = load_weight_shard(weights[2]['weight_scale'],
+                                           tp_size,
+                                           tp_rank,
+                                           tp_mode,
+                                           device=device)
+        weight_scales = [q_weight_scale, k_weight_scale, v_weight_scale]
+
+        return weight_scales
+
+    def load_weights_vanilla(self, module: Linear, weights: List[Dict]) -> None:
+        load_weights_vanilla_helper(module, weights)
+
+        device = torch.device('cuda')
+        weight_scale = load_weight_shard(weights[0]['weight_scale'],
+                                         module.tp_size, module.tp_rank,
+                                         module.tp_mode, device)
+
+        copy_weight(module.weight_scale, weight_scale)
+
+    def load_weights_fused_qkv_linear(self, module: Linear,
+                                      weights: List[Dict]) -> None:
+        q_weight, k_weight, v_weight = load_weights_fused_qkv_helper(
+            module, weights)
+
+        fused_weight = torch.cat((q_weight, k_weight, v_weight))
+
+        weight_dtype, _ = self._get_weight_dtype_and_id(module)
+        fused_weight = preprocess_weights_for_mixed_gemm(
+            fused_weight.to(torch.int8).T.contiguous().cpu(), weight_dtype,
+            torch.float16).cuda().contiguous()
+
+        copy_weight(module.weight, fused_weight)
+
+        weight_scales = self.load_weight_scales(weights)
+
+        # Create concatenated weight scale tensor
+        cat_weight_scale = torch.cat(weight_scales, dim=0)
+        copy_weight(module.weight_scale, cat_weight_scale)
+
+    def load_weights_fused_gate_up_linear(self, module: Linear,
+                                          weights: List[Dict]) -> None:
+        device = torch.device('cuda')
+        weight_dtype, _ = self._get_weight_dtype_and_id(module)
+
+        gate_weight, up_weight = load_weights_fused_gate_up_helper(
+            module, weights)
+        fused_weight = torch.cat((gate_weight, up_weight))
+
+        fused_weight = preprocess_weights_for_mixed_gemm(
+            fused_weight.to(torch.int8).T.contiguous().cpu(), weight_dtype,
+            torch.float16).cuda().contiguous()
+
+        copy_weight(module.weight, fused_weight)
+
+        left_scale = load_weight_shard(weights[0]['weight_scale'],
+                                       module.tp_size, module.tp_rank,
+                                       module.tp_mode, device).contiguous()
+        right_scale = load_weight_shard(weights[1]['weight_scale'],
+                                        module.tp_size, module.tp_rank,
+                                        module.tp_mode, device).contiguous()
+        fused_scale = torch.cat([left_scale, right_scale], dim=0)
+        copy_weight(module.weight_scale, fused_scale)
+
+
 class W4A16_AWQ_LinearMethod(LinearMethodBase):
 
     def create_weights(self, module: Linear, in_features: int,
@@ -1278,6 +1413,9 @@ def get_quant_method(quant_config: Optional[QuantConfig] = None):
         return NVFP4LinearMethod()
     if quant_config.layer_quant_mode.has_w4a8_mxfp4_fp8():
         return W4A8MXFP4FP8LinearMethod()
+    if quant_config.layer_quant_mode.is_weight_only(
+    ) and not quant_config.layer_quant_mode.has_per_group_scaling():
+        return WeightOnlyQuantLinearMethod()
     if quant_config.layer_quant_mode.is_int4_weight_only_per_group(
     ) and quant_config.quant_algo == QuantAlgo.W4A16_AWQ:
         return W4A16_AWQ_LinearMethod()
@@ -1400,6 +1538,12 @@ class Linear(nn.Module):
     def has_nvfp4(self):
         assert self._weights_created
         return self.quant_config is not None and self.quant_config.layer_quant_mode.has_nvfp4(
+        )
+
+    @property
+    def has_weight_only_quant(self):
+        assert self._weights_created
+        return self.quant_config is not None and self.quant_config.layer_quant_mode.is_weight_only(
         )
 
     @property

--- a/tensorrt_llm/quantization/functional.py
+++ b/tensorrt_llm/quantization/functional.py
@@ -959,7 +959,7 @@ def preprocess_weights_for_mixed_gemm(tensor: torch.Tensor,
         tensor = tensor.unsqueeze(0)
     elif sm_ >= 90:
         sm_ = 80
-    if sm_ >= 120:
+    if sm_ > 90:
         sm_ = 80
 
     permutation_map = {

--- a/tests/unittest/_torch/thop/test_weight_only_quant_gemm.py
+++ b/tests/unittest/_torch/thop/test_weight_only_quant_gemm.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import subprocess
+import sys
+
+import pytest
+import torch
+from _torch.helpers import calc_diff
+from utils.util import getSMVersion
+
+def weight_only_quant_gemm_reference(a, b, b_scales):
+    a_dtype = a.dtype
+    a = a.to(dtype=torch.float)
+    b = b.to(dtype=torch.float)
+    b_scales = b_scales.to(dtype=torch.float)
+    # Do matmul
+    ref = torch.matmul(a, b * b_scales)
+
+    return ref.to(dtype=a_dtype)
+
+def woq_tolerence_calculate(output, output_ref, b_dtype):
+    if b_dtype == torch.int8:
+        bits_in_type = 8
+    elif b_dtype == torch.quint4x2:
+        bits_in_type = 4
+    quant_range_scale = 1.0 / float(1 << (bits_in_type - 1))
+    max_val = torch.max(abs(output_ref)).item()
+    atol = (max_val * quant_range_scale) * 1.5  # allow for rounding
+
+    return atol
+
+
+@pytest.mark.skipif(
+    getSMVersion() != 90,
+    reason="The test is for Hopper only. Current SM is %d." % getSMVersion(),
+)
+@pytest.mark.parametrize(
+    "k, n",
+    [(7168, 2112), (1536, 24576), (512, 32768), (16384, 7168), (7168, 4096),
+     (2048, 7168), (1024, 1024)],
+)
+@pytest.mark.parametrize(
+    "m",
+    [7, 64, 128, 4096],
+)
+@pytest.mark.parametrize(
+    "a_dtype",
+    [torch.float16, torch.bfloat16],
+)
+@pytest.mark.parametrize(
+    "b_dtype",
+    [torch.int8, torch.quint4x2],
+)
+def test_weight_only_quant_gemm(a_dtype, b_dtype, m, k, n):
+    torch.random.manual_seed(0)
+
+    a = torch.randn((m, k), dtype=a_dtype, device="cuda")
+    b = torch.rand((k, n), dtype=a_dtype, device="cuda") * 2 - 1.0
+    ref_b, processed_b, b_scales = torch.ops.trtllm._symmetric_quantize_last_axis_of_batched_matrix(
+        b.cpu(), b_dtype)
+    if b_dtype == torch.quint4x2:
+        ref_b = torch.ops.trtllm.unpack_int4_packed_tensor_to_int8(ref_b.cpu())
+
+    output = torch.ops.trtllm.weight_only_quant_gemm(a, processed_b.cuda(), b_dtype, b_scales.cuda(), a_dtype)
+
+    output_ref = weight_only_quant_gemm_reference(a, ref_b.cuda(), b_scales.cuda())
+
+    # check accuracy
+    diff = calc_diff(output, output_ref)
+    assert diff < 1e-3, f"Difference {diff} >= 1e-3"
+    atol = woq_tolerence_calculate(output, output_ref, b_dtype)
+    torch.testing.assert_close(output_ref, output, atol=atol, rtol=1e-7)

--- a/tests/unittest/_torch/thop/test_weight_only_quant_gemm.py
+++ b/tests/unittest/_torch/thop/test_weight_only_quant_gemm.py
@@ -58,6 +58,8 @@ def woq_tolerence_calculate(output, output_ref, b_dtype):
     [torch.int8, torch.quint4x2],
 )
 def test_weight_only_quant_gemm(a_dtype, b_dtype, m, k, n):
+    import tensorrt_llm  # noqa: F401
+
     torch.random.manual_seed(0)
 
     # generate a, int4/int8 b, and scales

--- a/tests/unittest/_torch/thop/test_weight_only_quant_linear.py
+++ b/tests/unittest/_torch/thop/test_weight_only_quant_linear.py
@@ -1,0 +1,60 @@
+import pytest
+import torch
+
+from tensorrt_llm._torch.autotuner import autotune
+from tensorrt_llm._torch.modules.linear import Linear
+from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
+
+
+@pytest.mark.parametrize("weights_dtype", [torch.int8, torch.quint4x2])
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.float16, torch.bfloat16],
+)
+def test_weight_only_quant_linear(dtype, weights_dtype):
+
+    SEQ_LEN = 10
+    HIDDEN_SIZE = 128
+    OUT_FEATURES = 64
+    torch.manual_seed(0)
+    x = torch.randn((SEQ_LEN, HIDDEN_SIZE), dtype=dtype, device="cuda")
+    w = torch.rand(
+        (HIDDEN_SIZE, OUT_FEATURES), dtype=dtype, device="cuda") * 2 - 1.0
+
+    # w: int8 or int4x2 weight, w_processed: preprocessed weight, w_scales: scale of w
+    w, w_processed, w_scales = torch.ops.trtllm._symmetric_quantize_last_axis_of_batched_matrix(
+        w.cpu(), weights_dtype)
+    w_processed = w_processed.cuda()
+    w_scales = w_scales.cuda()
+
+    if weights_dtype == torch.int8:
+        qc = QuantConfig(quant_algo=QuantAlgo.W8A16, group_size=1)
+    elif weights_dtype == torch.quint4x2:
+        qc = QuantConfig(quant_algo=QuantAlgo.W4A16, group_size=1)
+    else:
+        raise ValueError(f"Unsupported weights_dtype: {weights_dtype}")
+
+    linear_woq = Linear(in_features=HIDDEN_SIZE,
+                        out_features=OUT_FEATURES,
+                        bias=False,
+                        dtype=dtype,
+                        quant_config=qc)
+
+    linear_woq.load_weights([{
+        'weight': w.T.cuda(),
+        'weight_scale': w_scales.cuda(),
+    }])
+
+    linear_woq = linear_woq.cuda()
+
+    torch.testing.assert_close(linear_woq.weight, w_processed)
+
+    with torch.inference_mode(), autotune():
+        output = linear_woq.forward(x)
+
+    # ref linear
+    with torch.inference_mode():
+        output_ref = torch.ops.trtllm.weight_only_quant_gemm(
+            x.contiguous(), w_processed, weights_dtype, w_scales, dtype)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(output, output_ref)

--- a/tests/unittest/_torch/thop/test_weight_only_quant_linear.py
+++ b/tests/unittest/_torch/thop/test_weight_only_quant_linear.py
@@ -24,6 +24,7 @@ def test_weight_only_quant_linear(dtype, weights_dtype):
     # w: int8 or int4x2 weight, w_processed: preprocessed weight, w_scales: scale of w
     w, w_processed, w_scales = torch.ops.trtllm._symmetric_quantize_last_axis_of_batched_matrix(
         w.cpu(), weights_dtype)
+    w = w.cuda()
     w_processed = w_processed.cuda()
     w_scales = w_scales.cuda()
 
@@ -41,8 +42,8 @@ def test_weight_only_quant_linear(dtype, weights_dtype):
                         quant_config=qc)
 
     linear_woq.load_weights([{
-        'weight': w.T.cuda(),
-        'weight_scale': w_scales.cuda(),
+        'weight': w.T,
+        'weight_scale': w_scales,
     }])
 
     linear_woq = linear_woq.cuda()


### PR DESCRIPTION
Add support of both INT4 and INT8 weight-only-quantization in PyTorch workflow.

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced support for weight-only quantized linear layers, enabling efficient inference with quantized weights.
  * Added a CUDA-accelerated weight-only quantized GEMM operator with Python bindings for high-performance matrix multiplication.
  * Integrated a new linear method for weight-only quantization into the module, supporting various quantization formats.

* **Bug Fixes**
  * Adjusted preprocessing logic for mixed GEMM to improve compatibility with specific hardware architectures.

* **Tests**
  * Added comprehensive unit tests for the new weight-only quantized GEMM operator and linear layer to ensure correctness and numerical accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->