### PR TITLE
draft: nanobind in pipeline

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,3 +20,6 @@
 [submodule "3rdparty/xgrammar"]
 	path = 3rdparty/xgrammar
 	url = https://github.com/mlc-ai/xgrammar.git
+[submodule "3rdparty/nanobind"]
+	path = 3rdparty/nanobind
+	url = https://github.com/wjakob/nanobind

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -198,7 +198,7 @@ set(TRT_LIB TensorRT::NvInfer)
 get_filename_component(TRT_LLM_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR} PATH)
 
 set(3RDPARTY_DIR ${TRT_LLM_ROOT_DIR}/3rdparty)
-if(BINDING_TYPE STREQUAL "pybind")
+if(BINDING_TYPE STREQUAL "pybind" OR BUILD_DEEP_EP)
   add_subdirectory(${3RDPARTY_DIR}/pybind11
                    ${CMAKE_CURRENT_BINARY_DIR}/pybind11)
 endif()
@@ -217,7 +217,7 @@ include_directories(
   ${3RDPARTY_DIR}/cutlass/tools/util/include
   ${3RDPARTY_DIR}/NVTX/include
   ${3RDPARTY_DIR}/json/include)
-if(BINDING_TYPE STREQUAL "pybind")
+if(BINDING_TYPE STREQUAL "pybind" OR BUILD_DEEP_EP)
   include_directories(${3RDPARTY_DIR}/pybind11/include)
 endif()
 if(BINDING_TYPE STREQUAL "nanobind")

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -198,8 +198,14 @@ set(TRT_LIB TensorRT::NvInfer)
 get_filename_component(TRT_LLM_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR} PATH)
 
 set(3RDPARTY_DIR ${TRT_LLM_ROOT_DIR}/3rdparty)
-add_subdirectory(${3RDPARTY_DIR}/pybind11 ${CMAKE_CURRENT_BINARY_DIR}/pybind11)
-add_subdirectory(${3RDPARTY_DIR}/nanobind ${CMAKE_CURRENT_BINARY_DIR}/nanobind)
+if(BINDING_TYPE STREQUAL "pybind")
+  add_subdirectory(${3RDPARTY_DIR}/pybind11
+                   ${CMAKE_CURRENT_BINARY_DIR}/pybind11)
+endif()
+if(BINDING_TYPE STREQUAL "nanobind")
+  add_subdirectory(${3RDPARTY_DIR}/nanobind
+                   ${CMAKE_CURRENT_BINARY_DIR}/nanobind)
+endif()
 
 # include as system to suppress warnings
 include_directories(
@@ -210,9 +216,13 @@ include_directories(
   ${3RDPARTY_DIR}/cutlass/include
   ${3RDPARTY_DIR}/cutlass/tools/util/include
   ${3RDPARTY_DIR}/NVTX/include
-  ${3RDPARTY_DIR}/json/include
-  ${3RDPARTY_DIR}/pybind11/include
-  ${3RDPARTY_DIR}/nanobind/include)
+  ${3RDPARTY_DIR}/json/include)
+if(BINDING_TYPE STREQUAL "pybind")
+  include_directories(${3RDPARTY_DIR}/pybind11/include)
+endif()
+if(BINDING_TYPE STREQUAL "nanobind")
+  include_directories(${3RDPARTY_DIR}/nanobind/include)
+endif()
 
 if(${CUDAToolkit_VERSION} VERSION_GREATER_EQUAL "11")
   add_definitions("-DENABLE_BF16")

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -28,8 +28,6 @@ project(tensorrt_llm LANGUAGES CXX)
 
 # Build options
 option(BUILD_PYT "Build in PyTorch TorchScript class mode" ON)
-option(BUILD_PYBIND "Build Python bindings for C++ runtime and batch manager"
-       ON)
 option(BUILD_TESTS "Build Google tests" ON)
 option(BUILD_BENCHMARKS "Build benchmarks" ON)
 option(BUILD_MICRO_BENCHMARKS "Build C++ micro benchmarks" OFF)
@@ -67,6 +65,11 @@ endif()
 # Add TensorRT-LLM Gen export interface and CUDA support
 add_compile_definitions("TLLM_GEN_EXPORT_INTERFACE")
 add_compile_definitions("TLLM_ENABLE_CUDA")
+
+set(BINDING_TYPE
+    "pybind"
+    CACHE STRING
+          "Binding type of Python bindings for C++ runtime and batch manager")
 
 set(INTERNAL_CUTLASS_KERNELS_PATH
     ""
@@ -196,6 +199,7 @@ get_filename_component(TRT_LLM_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR} PATH)
 
 set(3RDPARTY_DIR ${TRT_LLM_ROOT_DIR}/3rdparty)
 add_subdirectory(${3RDPARTY_DIR}/pybind11 ${CMAKE_CURRENT_BINARY_DIR}/pybind11)
+add_subdirectory(${3RDPARTY_DIR}/nanobind ${CMAKE_CURRENT_BINARY_DIR}/nanobind)
 
 # include as system to suppress warnings
 include_directories(
@@ -207,7 +211,8 @@ include_directories(
   ${3RDPARTY_DIR}/cutlass/tools/util/include
   ${3RDPARTY_DIR}/NVTX/include
   ${3RDPARTY_DIR}/json/include
-  ${3RDPARTY_DIR}/pybind11/include)
+  ${3RDPARTY_DIR}/pybind11/include
+  ${3RDPARTY_DIR}/nanobind/include)
 
 if(${CUDAToolkit_VERSION} VERSION_GREATER_EQUAL "11")
   add_definitions("-DENABLE_BF16")

--- a/cpp/tensorrt_llm/CMakeLists.txt
+++ b/cpp/tensorrt_llm/CMakeLists.txt
@@ -302,8 +302,12 @@ if(BUILD_PYT)
   add_subdirectory(thop)
 endif()
 
-if(BUILD_PYBIND)
+if(BINDING_TYPE STREQUAL "pybind")
   add_subdirectory(pybind)
+endif()
+
+if(BINDING_TYPE STREQUAL "nanobind")
+  add_subdirectory(nanobind)
 endif()
 
 if(BUILD_DEEP_EP)

--- a/cpp/tensorrt_llm/nanobind/CMakeLists.txt
+++ b/cpp/tensorrt_llm/nanobind/CMakeLists.txt
@@ -3,7 +3,7 @@ set(TRTLLM_NB_MODULE
     ${TRTLLM_NB_MODULE}
     PARENT_SCOPE)
 
-set(SRCS ../runtime/ipcNvlsMemory.cpp bindings.cpp)
+set(SRCS ../runtime/ipcNvlsMemory.cu bindings.cpp)
 
 include_directories(${PROJECT_SOURCE_DIR}/include)
 

--- a/cpp/tensorrt_llm/nanobind/CMakeLists.txt
+++ b/cpp/tensorrt_llm/nanobind/CMakeLists.txt
@@ -1,0 +1,33 @@
+set(TRTLLM_NB_MODULE bindings)
+set(TRTLLM_NB_MODULE
+    ${TRTLLM_NB_MODULE}
+    PARENT_SCOPE)
+
+set(SRCS ../runtime/ipcNvlsMemory.cpp bindings.cpp)
+
+include_directories(${PROJECT_SOURCE_DIR}/include)
+
+nanobind_add_module(${TRTLLM_NB_MODULE} ${SRCS})
+
+set_property(TARGET ${TRTLLM_NB_MODULE} PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+target_link_directories(${TRTLLM_NB_MODULE} PUBLIC
+                        "${TORCH_INSTALL_PREFIX}/lib")
+
+target_link_libraries(
+  ${TRTLLM_NB_MODULE}
+  PUBLIC ${SHARED_TARGET} ${UNDEFINED_FLAG} ${NO_AS_NEEDED_FLAG}
+         ${Python3_LIBRARIES} ${TORCH_LIBRARIES} torch_python)
+
+target_compile_definitions(
+  ${TRTLLM_NB_MODULE} PUBLIC TRTLLM_NB_MODULE=${TRTLLM_NB_MODULE}
+                             NB_DETAILED_ERROR_MESSAGES=1)
+
+if(NOT WIN32)
+  set_target_properties(
+    ${TRTLLM_NB_MODULE}
+    PROPERTIES
+      LINK_FLAGS
+      "-Wl,-rpath,'$ORIGIN/libs' -Wl,-rpath,'$ORIGIN/../nvidia/nccl/lib' ${AS_NEEDED_FLAG} ${UNDEFINED_FLAG}"
+  )
+endif()

--- a/cpp/tensorrt_llm/nanobind/CMakeLists.txt
+++ b/cpp/tensorrt_llm/nanobind/CMakeLists.txt
@@ -1,6 +1,6 @@
-set(TRTLLM_PYBIND_MODULE bindings)
-set(TRTLLM_PYBIND_MODULE
-    ${TRTLLM_PYBIND_MODULE}
+set(TRTLLM_NB_MODULE bindings)
+set(TRTLLM_NB_MODULE
+    ${TRTLLM_NB_MODULE}
     PARENT_SCOPE)
 
 set(SRCS
@@ -23,21 +23,20 @@ set(SRCS
 
 include_directories(${PROJECT_SOURCE_DIR}/include)
 
-pybind11_add_module(${TRTLLM_PYBIND_MODULE} ${SRCS})
+nanobind_add_module(${TRTLLM_NB_MODULE} ${SRCS})
 
-set_property(TARGET ${TRTLLM_PYBIND_MODULE} PROPERTY POSITION_INDEPENDENT_CODE
-                                                     ON)
+set_property(TARGET ${TRTLLM_NB_MODULE} PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-target_link_directories(${TRTLLM_PYBIND_MODULE} PUBLIC
+target_link_directories(${TRTLLM_NB_MODULE} PUBLIC
                         "${TORCH_INSTALL_PREFIX}/lib")
 
 if(ENABLE_NVSHMEM)
-  target_link_libraries(${TRTLLM_PYBIND_MODULE} PUBLIC nvshmem::nvshmem_host
-                                                       nvshmem::nvshmem_device)
+  target_link_libraries(${TRTLLM_NB_MODULE} PUBLIC nvshmem::nvshmem_host
+                                                   nvshmem::nvshmem_device)
 endif()
 
 target_link_libraries(
-  ${TRTLLM_PYBIND_MODULE}
+  ${TRTLLM_NB_MODULE}
   PUBLIC ${SHARED_TARGET}
          ${UNDEFINED_FLAG}
          ${NO_AS_NEEDED_FLAG}
@@ -46,12 +45,12 @@ target_link_libraries(
          torch_python
          ${CUDA_NVML_LIB})
 target_compile_definitions(
-  ${TRTLLM_PYBIND_MODULE} PUBLIC TRTLLM_PYBIND_MODULE=${TRTLLM_PYBIND_MODULE}
-                                 PYBIND11_DETAILED_ERROR_MESSAGES=1)
+  ${TRTLLM_NB_MODULE} PUBLIC TRTLLM_NB_MODULE=${TRTLLM_NB_MODULE}
+                             PYBIND11_DETAILED_ERROR_MESSAGES=1)
 
 if(NOT WIN32)
   set_target_properties(
-    ${TRTLLM_PYBIND_MODULE}
+    ${TRTLLM_NB_MODULE}
     PROPERTIES
       LINK_FLAGS
       "-Wl,-rpath,'$ORIGIN/libs' -Wl,-rpath,'$ORIGIN/../nvidia/nccl/lib' -Wl,-rpath,'${CUDA_TOOLKIT_ROOT_DIR}/targets/x86_64-linux/lib/stubs' ${AS_NEEDED_FLAG} ${UNDEFINED_FLAG}"

--- a/cpp/tensorrt_llm/nanobind/CMakeLists.txt
+++ b/cpp/tensorrt_llm/nanobind/CMakeLists.txt
@@ -1,33 +1,59 @@
-set(TRTLLM_NB_MODULE bindings)
-set(TRTLLM_NB_MODULE
-    ${TRTLLM_NB_MODULE}
+set(TRTLLM_PYBIND_MODULE bindings)
+set(TRTLLM_PYBIND_MODULE
+    ${TRTLLM_PYBIND_MODULE}
     PARENT_SCOPE)
 
-set(SRCS ../runtime/ipcNvlsMemory.cu bindings.cpp)
+set(SRCS
+    batch_manager/algorithms.cpp
+    batch_manager/bindings.cpp
+    batch_manager/buffers.cpp
+    batch_manager/cacheTransceiver.cpp
+    batch_manager/kvCacheManager.cpp
+    batch_manager/llmRequest.cpp
+    executor/bindings.cpp
+    executor/executor.cpp
+    executor/executorConfig.cpp
+    executor/request.cpp
+    runtime/bindings.cpp
+    testing/modelSpecBinding.cpp
+    runtime/moeBindings.cpp
+    userbuffers/bindings.cpp
+    ../runtime/ipcNvlsMemory.cu
+    bindings.cpp)
 
 include_directories(${PROJECT_SOURCE_DIR}/include)
 
-nanobind_add_module(${TRTLLM_NB_MODULE} ${SRCS})
+pybind11_add_module(${TRTLLM_PYBIND_MODULE} ${SRCS})
 
-set_property(TARGET ${TRTLLM_NB_MODULE} PROPERTY POSITION_INDEPENDENT_CODE ON)
+set_property(TARGET ${TRTLLM_PYBIND_MODULE} PROPERTY POSITION_INDEPENDENT_CODE
+                                                     ON)
 
-target_link_directories(${TRTLLM_NB_MODULE} PUBLIC
+target_link_directories(${TRTLLM_PYBIND_MODULE} PUBLIC
                         "${TORCH_INSTALL_PREFIX}/lib")
 
-target_link_libraries(
-  ${TRTLLM_NB_MODULE}
-  PUBLIC ${SHARED_TARGET} ${UNDEFINED_FLAG} ${NO_AS_NEEDED_FLAG}
-         ${Python3_LIBRARIES} ${TORCH_LIBRARIES} torch_python)
+if(ENABLE_NVSHMEM)
+  target_link_libraries(${TRTLLM_PYBIND_MODULE} PUBLIC nvshmem::nvshmem_host
+                                                       nvshmem::nvshmem_device)
+endif()
 
+target_link_libraries(
+  ${TRTLLM_PYBIND_MODULE}
+  PUBLIC ${SHARED_TARGET}
+         ${UNDEFINED_FLAG}
+         ${NO_AS_NEEDED_FLAG}
+         ${Python3_LIBRARIES}
+         ${TORCH_LIBRARIES}
+         torch_python
+         ${CUDA_NVML_LIB})
 target_compile_definitions(
-  ${TRTLLM_NB_MODULE} PUBLIC TRTLLM_NB_MODULE=${TRTLLM_NB_MODULE}
-                             NB_DETAILED_ERROR_MESSAGES=1)
+  ${TRTLLM_PYBIND_MODULE} PUBLIC TRTLLM_PYBIND_MODULE=${TRTLLM_PYBIND_MODULE}
+                                 PYBIND11_DETAILED_ERROR_MESSAGES=1)
 
 if(NOT WIN32)
   set_target_properties(
-    ${TRTLLM_NB_MODULE}
+    ${TRTLLM_PYBIND_MODULE}
     PROPERTIES
       LINK_FLAGS
-      "-Wl,-rpath,'$ORIGIN/libs' -Wl,-rpath,'$ORIGIN/../nvidia/nccl/lib' ${AS_NEEDED_FLAG} ${UNDEFINED_FLAG}"
+      "-Wl,-rpath,'$ORIGIN/libs' -Wl,-rpath,'$ORIGIN/../nvidia/nccl/lib' -Wl,-rpath,'${CUDA_TOOLKIT_ROOT_DIR}/targets/x86_64-linux/lib/stubs' ${AS_NEEDED_FLAG} ${UNDEFINED_FLAG}"
   )
 endif()

--- a/cpp/tensorrt_llm/nanobind/batch_manager/algorithms.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/algorithms.cpp
@@ -37,67 +37,64 @@
 #include "tensorrt_llm/runtime/torchView.h"
 
 #include <ATen/core/TensorBody.h>
-#include <pybind11/cast.h>
-#include <pybind11/functional.h>
-#include <pybind11/operators.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/list.h>
+#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/tuple.h>
+#include <nanobind/stl/vector.h>
 #include <torch/extension.h>
 
 #include <optional>
 
-namespace py = pybind11;
+namespace nb = nanobind;
 
 namespace tr = tensorrt_llm::runtime;
 using namespace tensorrt_llm::batch_manager;
 
-void tensorrt_llm::pybind::batch_manager::algorithms::initBindings(pybind11::module_& m)
+void tensorrt_llm::nanobind::batch_manager::algorithms::initBindings(nb::module_& m)
 {
-    py::class_<CapacityScheduler>(m, CapacityScheduler::name)
-        .def(py::init<SizeType32, executor::CapacitySchedulerPolicy, bool, bool, LlmRequestState, LlmRequestState>(),
-            py::arg("max_num_requests"), py::arg("capacity_scheduler_policy"), py::arg("has_kv_cache_manager"),
-            py::arg("two_step_lookahead") = false,
-            py::arg_v("no_schedule_until_state", LlmRequestState::kCONTEXT_INIT, "LlmRequestState.CONTEXT_INIT"),
-            py::arg_v("no_schedule_after_state", LlmRequestState::kGENERATION_COMPLETE,
-                "LlmRequestState.GENERATION_COMPLETE"))
-        .def("__call__", &CapacityScheduler::operator(), py::arg("active_requests"),
-            py::arg("kv_cache_manager") = nullptr, py::arg("peft_cache_manager") = nullptr,
-            py::arg("cross_kv_cache_manager") = nullptr)
+    nb::class_<CapacityScheduler>(m, CapacityScheduler::name)
+        .def(nb::init<SizeType32, executor::CapacitySchedulerPolicy, bool, bool, LlmRequestState, LlmRequestState>(),
+            nb::arg("max_num_requests"), nb::arg("capacity_scheduler_policy"), nb::arg("has_kv_cache_manager"),
+            nb::arg("two_step_lookahead") = false, nb::arg("no_schedule_until_state") = LlmRequestState::kCONTEXT_INIT,
+            nb::arg("no_schedule_after_state") = LlmRequestState::kGENERATION_COMPLETE)
+        .def("__call__", &CapacityScheduler::operator(), nb::arg("active_requests"),
+            nb::arg("kv_cache_manager") = nullptr, nb::arg("peft_cache_manager") = nullptr,
+            nb::arg("cross_kv_cache_manager") = nullptr)
         .def("name", [](CapacityScheduler const&) { return CapacityScheduler::name; });
 
-    py::class_<MicroBatchScheduler>(m, MicroBatchScheduler::name)
-        .def(py::init<std::optional<batch_scheduler::ContextChunkingConfig>, std::optional<SizeType32>, LlmRequestState,
+    nb::class_<MicroBatchScheduler>(m, MicroBatchScheduler::name)
+        .def(nb::init<std::optional<batch_scheduler::ContextChunkingConfig>, std::optional<SizeType32>, LlmRequestState,
                  LlmRequestState>(),
-            py::arg("ctx_chunk_config") = std::nullopt, py::arg("max_context_length") = std::nullopt,
-            py::arg_v("no_schedule_until_state", LlmRequestState::kCONTEXT_INIT, "LlmRequestState.CONTEXT_INIT"),
-            py::arg_v("no_schedule_after_state", LlmRequestState::kGENERATION_COMPLETE,
-                "LlmRequestState.GENERATION_COMPLETE"))
-        .def("__call__", &MicroBatchScheduler::operator(), py::arg("active_requests"), py::arg("inflight_req_ids"),
-            py::arg("max_batch_size_runtime"), py::arg("max_num_tokens_runtime"))
+            nb::arg("ctx_chunk_config") = std::nullopt, nb::arg("max_context_length") = std::nullopt,
+            nb::arg("no_schedule_until_state") = LlmRequestState::kCONTEXT_INIT,
+            nb::arg("no_schedule_after_state") = LlmRequestState::kGENERATION_COMPLETE)
+        .def("__call__", &MicroBatchScheduler::operator(), nb::arg("active_requests"), nb::arg("inflight_req_ids"),
+            nb::arg("max_batch_size_runtime"), nb::arg("max_num_tokens_runtime"))
         .def("name", [](MicroBatchScheduler const&) { return MicroBatchScheduler::name; });
 
-    py::class_<PauseRequests>(m, PauseRequests::name)
-        .def(py::init<SizeType32>(), py::arg("max_input_len"))
-        .def("__call__", &PauseRequests::operator(), py::arg("requests_to_pause"), py::arg("inflight_req_ids"),
-            py::arg("req_ids_to_pause"), py::arg("pause_flagged"), py::arg("seq_slot_manager"),
-            py::arg("kv_cache_manager") = std::nullopt, py::arg("cross_kv_cache_manager") = std::nullopt,
-            py::arg("peft_cache_manager") = std::nullopt)
+    nb::class_<PauseRequests>(m, PauseRequests::name)
+        .def(nb::init<SizeType32>(), nb::arg("max_input_len"))
+        .def("__call__", &PauseRequests::operator(), nb::arg("requests_to_pause"), nb::arg("inflight_req_ids"),
+            nb::arg("req_ids_to_pause"), nb::arg("pause_flagged"), nb::arg("seq_slot_manager"),
+            nb::arg("kv_cache_manager") = std::nullopt, nb::arg("cross_kv_cache_manager") = std::nullopt,
+            nb::arg("peft_cache_manager") = std::nullopt)
         .def("name", [](PauseRequests const&) { return PauseRequests::name; });
 
-    py::class_<AssignReqSeqSlots>(m, AssignReqSeqSlots::name)
-        .def(py::init())
-        .def("__call__", &AssignReqSeqSlots::operator(), py::arg("seq_slot_manager"), py::arg("context_requests"),
-            py::arg("generation_requests"))
+    nb::class_<AssignReqSeqSlots>(m, AssignReqSeqSlots::name)
+        .def(nb::init<>())
+        .def("__call__", &AssignReqSeqSlots::operator(), nb::arg("seq_slot_manager"), nb::arg("context_requests"),
+            nb::arg("generation_requests"))
         .def("name", [](AssignReqSeqSlots const&) { return AssignReqSeqSlots::name; });
 
-    py::class_<AllocateKvCache>(m, AllocateKvCache::name)
-        .def(py::init())
-        .def("__call__", &AllocateKvCache::operator(), py::arg("kv_cache_manager"), py::arg("context_requests"),
-            py::arg("generation_requests"), py::arg("model_config"), py::arg("cross_kv_cache_manager") = std::nullopt)
+    nb::class_<AllocateKvCache>(m, AllocateKvCache::name)
+        .def(nb::init<>())
+        .def("__call__", &AllocateKvCache::operator(), nb::arg("kv_cache_manager"), nb::arg("context_requests"),
+            nb::arg("generation_requests"), nb::arg("model_config"), nb::arg("cross_kv_cache_manager") = std::nullopt)
         .def("name", [](AllocateKvCache const&) { return AllocateKvCache::name; });
 
-    py::class_<HandleContextLogits>(m, HandleContextLogits::name)
-        .def(py::init())
+    nb::class_<HandleContextLogits>(m, HandleContextLogits::name)
+        .def(nb::init<>())
         .def(
             "__call__",
             [](HandleContextLogits const& self, DecoderInputBuffers& inputBuffers, RequestVector const& contextRequests,
@@ -108,13 +105,13 @@ void tensorrt_llm::pybind::batch_manager::algorithms::initBindings(pybind11::mod
                 return self(inputBuffers, contextRequests, tr::TorchView::of(logits), numContextLogitsVec, modelConfig,
                     manager, medusaBuffers);
             },
-            py::arg("decoder_input_buffers"), py::arg("context_requests"), py::arg("logits"),
-            py::arg("num_context_logits"), py::arg("model_config"), py::arg("buffer_manager"),
-            py::arg("medusa_buffers") = std::nullopt)
+            nb::arg("decoder_input_buffers"), nb::arg("context_requests"), nb::arg("logits"),
+            nb::arg("num_context_logits"), nb::arg("model_config"), nb::arg("buffer_manager"),
+            nb::arg("draft_buffers") = std::nullopt)
         .def("name", [](HandleContextLogits const&) { return HandleContextLogits::name; });
 
-    py::class_<HandleGenerationLogits>(m, HandleGenerationLogits::name)
-        .def(py::init())
+    nb::class_<HandleGenerationLogits>(m, HandleGenerationLogits::name)
+        .def(nb::init<>())
         .def(
             "__call__",
             [](HandleGenerationLogits const& self, DecoderInputBuffers& inputBuffers,
@@ -126,28 +123,28 @@ void tensorrt_llm::pybind::batch_manager::algorithms::initBindings(pybind11::mod
                 self(inputBuffers, generationRequests, tr::TorchView::of(logits), logitsIndex, modelConfig, manager,
                     genRuntimeBuffers, medusaBuffers);
             },
-            py::arg("decoder_input_buffers"), py::arg("generation_requests"), py::arg("logits"),
-            py::arg("logits_index"), py::arg("model_config"), py::arg("buffer_manager"),
-            py::arg("gen_runtime_buffers") = std::nullopt, py::arg("medusa_buffers") = std::nullopt)
+            nb::arg("decoder_input_buffers"), nb::arg("generation_requests"), nb::arg("logits"),
+            nb::arg("logits_index"), nb::arg("model_config"), nb::arg("buffer_manager"),
+            nb::arg("gen_runtime_buffers") = std::nullopt, nb::arg("medusa_buffers") = std::nullopt)
         .def("name", [](HandleGenerationLogits const&) { return HandleGenerationLogits::name; });
 
-    py::class_<MakeDecodingBatchInputOutput>(m, MakeDecodingBatchInputOutput::name)
-        .def(py::init())
-        .def("__call__", &MakeDecodingBatchInputOutput::operator(), py::arg("context_requests"),
-            py::arg("generation_requests"), py::arg("decoder_input_buffers"), py::arg("decoder_state"),
-            py::arg("model_config"), py::arg("max_num_sequences"), py::arg("fused_runtime_buffers") = std::nullopt)
+    nb::class_<MakeDecodingBatchInputOutput>(m, MakeDecodingBatchInputOutput::name)
+        .def(nb::init<>())
+        .def("__call__", &MakeDecodingBatchInputOutput::operator(), nb::arg("context_requests"),
+            nb::arg("generation_requests"), nb::arg("decoder_input_buffers"), nb::arg("decoder_state"),
+            nb::arg("model_config"), nb::arg("max_num_sequences"), nb::arg("fused_runtime_buffers") = std::nullopt)
         .def("name", [](MakeDecodingBatchInputOutput const&) { return MakeDecodingBatchInputOutput::name; });
 
-    py::class_<LogitsPostProcessor>(m, LogitsPostProcessor::name)
-        .def(py::init())
-        .def("__call__", &LogitsPostProcessor::operator(), py::arg("context_requests"), py::arg("generation_requests"),
-            py::arg("replicate_logits_post_processor"), py::arg("decoder_buffers"), py::arg("world_config"),
-            py::arg("runtime"), py::arg("logits_post_processor_batched") = std::nullopt)
+    nb::class_<LogitsPostProcessor>(m, LogitsPostProcessor::name)
+        .def(nb::init<>())
+        .def("__call__", &LogitsPostProcessor::operator(), nb::arg("context_requests"), nb::arg("generation_requests"),
+            nb::arg("replicate_logits_post_processor"), nb::arg("decoder_buffers"), nb::arg("world_config"),
+            nb::arg("runtime"), nb::arg("logits_post_processor_batched") = std::nullopt)
         .def("name", [](LogitsPostProcessor const&) { return LogitsPostProcessor::name; });
 
-    py::class_<CreateNewDecoderRequests>(m, CreateNewDecoderRequests::name)
-        .def(py::init<bool, bool, bool>(), py::arg("speculative_decoding_fast_logits"),
-            py::arg("is_leader_in_orch_mode"), py::arg("is_normalize_log_probs"))
+    nb::class_<CreateNewDecoderRequests>(m, CreateNewDecoderRequests::name)
+        .def(nb::init<bool, bool, bool>(), nb::arg("speculative_decoding_fast_logits"),
+            nb::arg("is_leader_in_orch_mode"), nb::arg("is_normalize_log_probs"))
         .def(
             "__call__",
             [](CreateNewDecoderRequests& self, tr::ModelConfig const& modelConfig, tr::WorldConfig const& worldConfig,
@@ -165,16 +162,16 @@ void tensorrt_llm::pybind::batch_manager::algorithms::initBindings(pybind11::mod
                 return std::tuple{runtime::Torch::tensor(batchSlots), std::move(samplingConfigs),
                     std::move(lookaheadPrompt), std::move(lookaheadAlgoConfigs)};
             },
-            py::arg("model_config"), py::arg("world_config"), py::arg("decoding_config"), py::arg("context_requests"),
-            py::arg("buffer_manager"), py::arg("logits_type"), py::arg("decoder_input_buffers"),
-            py::arg("decoder_state"), py::arg("runtime_stream"), py::arg("decoder_stream"),
-            py::arg("max_sequence_length"), py::arg("beam_width"), py::arg("medusa_buffers") = std::nullopt)
+            nb::arg("model_config"), nb::arg("world_config"), nb::arg("decoding_config"), nb::arg("context_requests"),
+            nb::arg("buffer_manager"), nb::arg("logits_type"), nb::arg("decoder_input_buffers"),
+            nb::arg("decoder_state"), nb::arg("runtime_stream"), nb::arg("decoder_stream"),
+            nb::arg("max_sequence_length"), nb::arg("beam_width"), nb::arg("medusa_buffers") = std::nullopt)
         .def("name", [](CreateNewDecoderRequests const&) { return CreateNewDecoderRequests::name; });
 
-    py::class_<UpdateDecoderBuffers>(m, UpdateDecoderBuffers::name)
-        .def(py::init())
-        .def("__call__", &UpdateDecoderBuffers::operator(), py::arg("model_config"), py::arg("decoder_output_buffers"),
-            py::arg("copy_buffer_manager"), py::arg("decoder_state"), py::arg("return_log_probs"),
-            py::arg("decoder_finish_event"))
+    nb::class_<UpdateDecoderBuffers>(m, "UpdateDecoderBuffers")
+        .def(nb::init<>())
+        .def("__call__", &UpdateDecoderBuffers::operator(), nb::arg("model_config"), nb::arg("decoder_output_buffers"),
+            nb::arg("copy_buffer_manager"), nb::arg("decoder_state"), nb::arg("return_log_probs"),
+            nb::arg("decoder_finish_event"))
         .def("name", [](UpdateDecoderBuffers const&) { return UpdateDecoderBuffers::name; });
 }

--- a/cpp/tensorrt_llm/nanobind/batch_manager/algorithms.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/algorithms.cpp
@@ -1,0 +1,180 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "algorithms.h"
+#include "tensorrt_llm/batch_manager/allocateKvCache.h"
+#include "tensorrt_llm/batch_manager/assignReqSeqSlots.h"
+#include "tensorrt_llm/batch_manager/capacityScheduler.h"
+#include "tensorrt_llm/batch_manager/createNewDecoderRequests.h"
+#include "tensorrt_llm/batch_manager/handleContextLogits.h"
+#include "tensorrt_llm/batch_manager/handleGenerationLogits.h"
+#include "tensorrt_llm/batch_manager/kvCacheManager.h"
+#include "tensorrt_llm/batch_manager/llmRequest.h"
+#include "tensorrt_llm/batch_manager/logitsPostProcessor.h"
+#include "tensorrt_llm/batch_manager/makeDecodingBatchInputOutput.h"
+#include "tensorrt_llm/batch_manager/medusaBuffers.h"
+#include "tensorrt_llm/batch_manager/microBatchScheduler.h"
+#include "tensorrt_llm/batch_manager/pauseRequests.h"
+#include "tensorrt_llm/batch_manager/peftCacheManager.h"
+#include "tensorrt_llm/batch_manager/runtimeBuffers.h"
+#include "tensorrt_llm/batch_manager/updateDecoderBuffers.h"
+#include "tensorrt_llm/runtime/decoderState.h"
+#include "tensorrt_llm/runtime/torch.h"
+#include "tensorrt_llm/runtime/torchView.h"
+
+#include <ATen/core/TensorBody.h>
+#include <pybind11/cast.h>
+#include <pybind11/functional.h>
+#include <pybind11/operators.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <torch/extension.h>
+
+#include <optional>
+
+namespace py = pybind11;
+
+namespace tr = tensorrt_llm::runtime;
+using namespace tensorrt_llm::batch_manager;
+
+void tensorrt_llm::pybind::batch_manager::algorithms::initBindings(pybind11::module_& m)
+{
+    py::class_<CapacityScheduler>(m, CapacityScheduler::name)
+        .def(py::init<SizeType32, executor::CapacitySchedulerPolicy, bool, bool, LlmRequestState, LlmRequestState>(),
+            py::arg("max_num_requests"), py::arg("capacity_scheduler_policy"), py::arg("has_kv_cache_manager"),
+            py::arg("two_step_lookahead") = false,
+            py::arg_v("no_schedule_until_state", LlmRequestState::kCONTEXT_INIT, "LlmRequestState.CONTEXT_INIT"),
+            py::arg_v("no_schedule_after_state", LlmRequestState::kGENERATION_COMPLETE,
+                "LlmRequestState.GENERATION_COMPLETE"))
+        .def("__call__", &CapacityScheduler::operator(), py::arg("active_requests"),
+            py::arg("kv_cache_manager") = nullptr, py::arg("peft_cache_manager") = nullptr,
+            py::arg("cross_kv_cache_manager") = nullptr)
+        .def("name", [](CapacityScheduler const&) { return CapacityScheduler::name; });
+
+    py::class_<MicroBatchScheduler>(m, MicroBatchScheduler::name)
+        .def(py::init<std::optional<batch_scheduler::ContextChunkingConfig>, std::optional<SizeType32>, LlmRequestState,
+                 LlmRequestState>(),
+            py::arg("ctx_chunk_config") = std::nullopt, py::arg("max_context_length") = std::nullopt,
+            py::arg_v("no_schedule_until_state", LlmRequestState::kCONTEXT_INIT, "LlmRequestState.CONTEXT_INIT"),
+            py::arg_v("no_schedule_after_state", LlmRequestState::kGENERATION_COMPLETE,
+                "LlmRequestState.GENERATION_COMPLETE"))
+        .def("__call__", &MicroBatchScheduler::operator(), py::arg("active_requests"), py::arg("inflight_req_ids"),
+            py::arg("max_batch_size_runtime"), py::arg("max_num_tokens_runtime"))
+        .def("name", [](MicroBatchScheduler const&) { return MicroBatchScheduler::name; });
+
+    py::class_<PauseRequests>(m, PauseRequests::name)
+        .def(py::init<SizeType32>(), py::arg("max_input_len"))
+        .def("__call__", &PauseRequests::operator(), py::arg("requests_to_pause"), py::arg("inflight_req_ids"),
+            py::arg("req_ids_to_pause"), py::arg("pause_flagged"), py::arg("seq_slot_manager"),
+            py::arg("kv_cache_manager") = std::nullopt, py::arg("cross_kv_cache_manager") = std::nullopt,
+            py::arg("peft_cache_manager") = std::nullopt)
+        .def("name", [](PauseRequests const&) { return PauseRequests::name; });
+
+    py::class_<AssignReqSeqSlots>(m, AssignReqSeqSlots::name)
+        .def(py::init())
+        .def("__call__", &AssignReqSeqSlots::operator(), py::arg("seq_slot_manager"), py::arg("context_requests"),
+            py::arg("generation_requests"))
+        .def("name", [](AssignReqSeqSlots const&) { return AssignReqSeqSlots::name; });
+
+    py::class_<AllocateKvCache>(m, AllocateKvCache::name)
+        .def(py::init())
+        .def("__call__", &AllocateKvCache::operator(), py::arg("kv_cache_manager"), py::arg("context_requests"),
+            py::arg("generation_requests"), py::arg("model_config"), py::arg("cross_kv_cache_manager") = std::nullopt)
+        .def("name", [](AllocateKvCache const&) { return AllocateKvCache::name; });
+
+    py::class_<HandleContextLogits>(m, HandleContextLogits::name)
+        .def(py::init())
+        .def(
+            "__call__",
+            [](HandleContextLogits const& self, DecoderInputBuffers& inputBuffers, RequestVector const& contextRequests,
+                at::Tensor const& logits, std::vector<tr::SizeType32> const& numContextLogitsVec,
+                tr::ModelConfig const& modelConfig, tr::BufferManager const& manager,
+                OptionalRef<MedusaBuffers> medusaBuffers = std::nullopt)
+            {
+                return self(inputBuffers, contextRequests, tr::TorchView::of(logits), numContextLogitsVec, modelConfig,
+                    manager, medusaBuffers);
+            },
+            py::arg("decoder_input_buffers"), py::arg("context_requests"), py::arg("logits"),
+            py::arg("num_context_logits"), py::arg("model_config"), py::arg("buffer_manager"),
+            py::arg("medusa_buffers") = std::nullopt)
+        .def("name", [](HandleContextLogits const&) { return HandleContextLogits::name; });
+
+    py::class_<HandleGenerationLogits>(m, HandleGenerationLogits::name)
+        .def(py::init())
+        .def(
+            "__call__",
+            [](HandleGenerationLogits const& self, DecoderInputBuffers& inputBuffers,
+                RequestVector const& generationRequests, at::Tensor const& logits, tr::SizeType32 logitsIndex,
+                tr::ModelConfig const& modelConfig, tr::BufferManager const& manager,
+                OptionalRef<RuntimeBuffers> genRuntimeBuffers = std::nullopt,
+                OptionalRef<MedusaBuffers> medusaBuffers = std::nullopt)
+            {
+                self(inputBuffers, generationRequests, tr::TorchView::of(logits), logitsIndex, modelConfig, manager,
+                    genRuntimeBuffers, medusaBuffers);
+            },
+            py::arg("decoder_input_buffers"), py::arg("generation_requests"), py::arg("logits"),
+            py::arg("logits_index"), py::arg("model_config"), py::arg("buffer_manager"),
+            py::arg("gen_runtime_buffers") = std::nullopt, py::arg("medusa_buffers") = std::nullopt)
+        .def("name", [](HandleGenerationLogits const&) { return HandleGenerationLogits::name; });
+
+    py::class_<MakeDecodingBatchInputOutput>(m, MakeDecodingBatchInputOutput::name)
+        .def(py::init())
+        .def("__call__", &MakeDecodingBatchInputOutput::operator(), py::arg("context_requests"),
+            py::arg("generation_requests"), py::arg("decoder_input_buffers"), py::arg("decoder_state"),
+            py::arg("model_config"), py::arg("max_num_sequences"), py::arg("fused_runtime_buffers") = std::nullopt)
+        .def("name", [](MakeDecodingBatchInputOutput const&) { return MakeDecodingBatchInputOutput::name; });
+
+    py::class_<LogitsPostProcessor>(m, LogitsPostProcessor::name)
+        .def(py::init())
+        .def("__call__", &LogitsPostProcessor::operator(), py::arg("context_requests"), py::arg("generation_requests"),
+            py::arg("replicate_logits_post_processor"), py::arg("decoder_buffers"), py::arg("world_config"),
+            py::arg("runtime"), py::arg("logits_post_processor_batched") = std::nullopt)
+        .def("name", [](LogitsPostProcessor const&) { return LogitsPostProcessor::name; });
+
+    py::class_<CreateNewDecoderRequests>(m, CreateNewDecoderRequests::name)
+        .def(py::init<bool, bool, bool>(), py::arg("speculative_decoding_fast_logits"),
+            py::arg("is_leader_in_orch_mode"), py::arg("is_normalize_log_probs"))
+        .def(
+            "__call__",
+            [](CreateNewDecoderRequests& self, tr::ModelConfig const& modelConfig, tr::WorldConfig const& worldConfig,
+                executor::DecodingConfig const& decodingConfig, RequestVector const& contextRequests,
+                tr::BufferManager const& bufferManager, nvinfer1::DataType logitsType,
+                DecoderInputBuffers& inputBuffers, runtime::decoder::DecoderState& decoderState,
+                tensorrt_llm::runtime::CudaStream const& runtimeStream,
+                tensorrt_llm::runtime::CudaStream const& decoderStream, SizeType32 maxSequenceLength,
+                SizeType32 beamWidth, OptionalRef<MedusaBuffers const> medusaBuffers = std::nullopt)
+            {
+                auto [batchSlots, samplingConfigs, lookaheadPrompt, lookaheadAlgoConfigs] = self(modelConfig,
+                    worldConfig, decodingConfig, contextRequests, bufferManager, logitsType, inputBuffers, decoderState,
+                    runtimeStream, decoderStream, maxSequenceLength, beamWidth, medusaBuffers);
+
+                return std::tuple{runtime::Torch::tensor(batchSlots), std::move(samplingConfigs),
+                    std::move(lookaheadPrompt), std::move(lookaheadAlgoConfigs)};
+            },
+            py::arg("model_config"), py::arg("world_config"), py::arg("decoding_config"), py::arg("context_requests"),
+            py::arg("buffer_manager"), py::arg("logits_type"), py::arg("decoder_input_buffers"),
+            py::arg("decoder_state"), py::arg("runtime_stream"), py::arg("decoder_stream"),
+            py::arg("max_sequence_length"), py::arg("beam_width"), py::arg("medusa_buffers") = std::nullopt)
+        .def("name", [](CreateNewDecoderRequests const&) { return CreateNewDecoderRequests::name; });
+
+    py::class_<UpdateDecoderBuffers>(m, UpdateDecoderBuffers::name)
+        .def(py::init())
+        .def("__call__", &UpdateDecoderBuffers::operator(), py::arg("model_config"), py::arg("decoder_output_buffers"),
+            py::arg("copy_buffer_manager"), py::arg("decoder_state"), py::arg("return_log_probs"),
+            py::arg("decoder_finish_event"))
+        .def("name", [](UpdateDecoderBuffers const&) { return UpdateDecoderBuffers::name; });
+}

--- a/cpp/tensorrt_llm/nanobind/batch_manager/algorithms.h
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/algorithms.h
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "tensorrt_llm/pybind/common/customCasters.h"
+#include <pybind11/pybind11.h>
+
+namespace tensorrt_llm::pybind::batch_manager::algorithms
+{
+
+void initBindings(pybind11::module_& m);
+
+}

--- a/cpp/tensorrt_llm/nanobind/batch_manager/algorithms.h
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/algorithms.h
@@ -17,12 +17,12 @@
 
 #pragma once
 
-#include "tensorrt_llm/pybind/common/customCasters.h"
-#include <pybind11/pybind11.h>
+#include "tensorrt_llm/nanobind/common/customCasters.h"
+#include <nanobind/nanobind.h>
 
-namespace tensorrt_llm::pybind::batch_manager::algorithms
+namespace tensorrt_llm::nanobind::batch_manager::algorithms
 {
 
-void initBindings(pybind11::module_& m);
+void initBindings(nb::module_& m);
 
 }

--- a/cpp/tensorrt_llm/nanobind/batch_manager/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/bindings.cpp
@@ -25,47 +25,43 @@
 #include "tensorrt_llm/batch_manager/rnnStateManager.h"
 #include "tensorrt_llm/batch_manager/runtimeBuffers.h"
 #include "tensorrt_llm/batch_manager/sequenceSlotManager.h"
-#include "tensorrt_llm/pybind/common/bindTypes.h"
+#include "tensorrt_llm/nanobind/common/bindTypes.h"
 #include "tensorrt_llm/runtime/gptDecoderBatched.h"
 #include "tensorrt_llm/runtime/runtimeKernels.h"
 #include "tensorrt_llm/runtime/torch.h"
 #include "tensorrt_llm/runtime/torchView.h"
 
 #include <ATen/ATen.h>
-#include <pybind11/chrono.h>
-#include <pybind11/functional.h>
-#include <pybind11/operators.h>
-#include <pybind11/stl.h>
-#include <pybind11/stl_bind.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/tuple.h>
+#include <nanobind/stl/unique_ptr.h>
+#include <nanobind/stl/vector.h>
 #include <torch/extension.h>
 #include <tuple>
 
-namespace py = pybind11;
+namespace nb = nanobind;
 namespace tb = tensorrt_llm::batch_manager;
 namespace tle = tensorrt_llm::executor;
 namespace tr = tensorrt_llm::runtime;
 
 using namespace tensorrt_llm::runtime;
 
-namespace tensorrt_llm::pybind::batch_manager
+namespace tensorrt_llm::nanobind::batch_manager
 {
 
-void initBindings(pybind11::module_& m)
+void initBindings(nb::module_& m)
 {
     using GenLlmReq = tb::GenericLlmRequest<runtime::ITensor::SharedPtr>;
 
     // Create and register exceptions in module scope
-    static PyObject* peft_exc = PyErr_NewException(
-        "tensorrt_llm.bindings.internal.batch_manager.PeftTaskNotCachedException", nullptr, nullptr);
-    static PyObject* lora_exc
-        = PyErr_NewException("tensorrt_llm.bindings.internal.batch_manager.LoraCacheFullException", nullptr, nullptr);
-
-    m.add_object("PeftTaskNotCachedException", py::handle(peft_exc));
-    m.add_object("LoraCacheFullException", py::handle(lora_exc));
+    nb::exception<tb::PeftTaskNotCachedException>(m, "PeftTaskNotCachedException");
+    nb::exception<tr::LoraCacheFullException>(m, "LoraCacheFullException");
 
     // Register with no captures
-    py::register_exception_translator(
-        [](std::exception_ptr p)
+    nb::register_exception_translator(
+        [](std::exception_ptr const& p, void*)
         {
             try
             {
@@ -74,127 +70,192 @@ void initBindings(pybind11::module_& m)
             }
             catch (const tb::PeftTaskNotCachedException& e)
             {
-                PyErr_SetString(peft_exc, e.what());
+                PyErr_SetString(nb::type<tb::PeftTaskNotCachedException>().ptr(), e.what());
             }
             catch (const tr::LoraCacheFullException& e)
             {
-                PyErr_SetString(lora_exc, e.what());
+                PyErr_SetString(nb::type<tr::LoraCacheFullException>().ptr(), e.what());
             }
         });
 
     PybindUtils::bindSet<tb::ReqIdsSet>(m, "ReqIdsSet");
 
-    py::enum_<tb::LlmRequestType>(m, "LlmRequestType")
+    nb::enum_<tb::LlmRequestType>(m, "LlmRequestType")
         .value("LLMREQUEST_TYPE_CONTEXT_AND_GENERATION", tb::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION)
         .value("LLMREQUEST_TYPE_CONTEXT_ONLY", tb::LLMREQUEST_TYPE_CONTEXT_ONLY)
         .value("LLMREQUEST_TYPE_GENERATION_ONLY", tb::LLMREQUEST_TYPE_GENERATION_ONLY)
         .export_values();
 
-    py::class_<tb::batch_scheduler::ContextChunkingConfig>(m, "ContextChunkingConfig")
-        .def(py::init<tle::ContextChunkingPolicy, tensorrt_llm::runtime::SizeType32>(), py::arg("chunking_policy"),
-            py::arg("chunk_unit_size"))
-        .def_readwrite("chunking_policy", &tb::batch_scheduler::ContextChunkingConfig::chunkingPolicy)
-        .def_readwrite("chunk_unit_size", &tb::batch_scheduler::ContextChunkingConfig::chunkUnitSize);
+    nb::class_<tb::batch_scheduler::ContextChunkingConfig>(m, "ContextChunkingConfig")
+        .def(nb::init<tle::ContextChunkingPolicy, tensorrt_llm::runtime::SizeType32>(), nb::arg("chunking_policy"),
+            nb::arg("chunk_unit_size"))
+        .def_rw("chunking_policy", &tb::batch_scheduler::ContextChunkingConfig::chunkingPolicy)
+        .def_rw("chunk_unit_size", &tb::batch_scheduler::ContextChunkingConfig::chunkUnitSize);
 
-    py::classh<GenLlmReq>(m, "GenericLlmRequest")
-        .def("set_exclude_input_from_output", &GenLlmReq::setExcludeInputFromOutput, py::arg("exclude"))
-        .def("get_num_tokens", &GenLlmReq::getNumTokens, py::arg("beam"))
-        .def_property_readonly("max_beam_num_tokens", &GenLlmReq::getMaxBeamNumTokens)
-        .def("get_token", &GenLlmReq::getToken, py::arg("beam"), py::arg("pos"))
-        .def("get_tokens", py::overload_cast<GenLlmReq::SizeType32>(&GenLlmReq::getTokens, py::const_), py::arg("beam"))
-        .def("get_tokens", py::overload_cast<>(&GenLlmReq::getTokens, py::const_))
-        .def("get_last_tokens", py::overload_cast<GenLlmReq::SizeType32>(&GenLlmReq::getLastTokens), py::arg("beam"))
-        .def("get_last_tokens", py::overload_cast<>(&GenLlmReq::getLastTokens))
-        .def("get_beam_width_by_iter", &GenLlmReq::getBeamWidthByIter, py::arg("for_next_iteration") = false)
-        .def_property_readonly("max_num_generated_tokens", &GenLlmReq::getMaxNumGeneratedTokens)
-        .def("add_new_token", &GenLlmReq::addNewToken, py::arg("token"), py::arg("beam"))
-        .def("add_new_tokens", &GenLlmReq::addNewTokens, py::arg("beam_tokens"))
-        .def_property_readonly("num_draft_tokens", &GenLlmReq::getNumDraftTokens)
-        .def("set_generated_tokens", &GenLlmReq::setGeneratedTokens, py::arg("generated_beam_tokens"))
-        .def("pause", &GenLlmReq::pause, py::arg("max_input_len"))
-        .def_property("max_sent_token_len", &GenLlmReq::getMaxSentTokenLen, &GenLlmReq::setMaxSentTokenLen)
-        .def_property_readonly("prompt_embedding_table", &GenLlmReq::getPromptEmbeddingTable)
-        .def_property_readonly("multimodal_embedding", &GenLlmReq::getMultimodalEmbedding)
-        .def_property_readonly("mrope_rotary_cos_sin", &GenLlmReq::getMropeRotaryCosSin)
-        .def_property_readonly("bad_words_list", &GenLlmReq::getBadWordsList)
-        .def_property("draft_logits", &GenLlmReq::getDraftLogits, &GenLlmReq::setDraftLogits)
-        .def_property_readonly("embedding_bias", &GenLlmReq::getEmbeddingBias)
-        .def_property("lora_config", &GenLlmReq::getLoraConfig, &GenLlmReq::setLoraConfig)
-        .def_property("lora_weights", &GenLlmReq::getLoraWeights, &GenLlmReq::setLoraWeights)
-        .def_property_readonly("stop_words_list", &GenLlmReq::getStopWordsList)
-        .def_property_readonly("context_logits", &GenLlmReq::getContextLogitsHost)
-        .def_property_readonly("generation_logits", &GenLlmReq::getGenerationLogitsHost)
-        .def_property_readonly("prompt_vocab_size", &GenLlmReq::getPromptVocabSize)
-        .def_property_readonly("mrope_position_deltas", &GenLlmReq::getMropePositionDeltas)
-        .def_property_readonly("lora_task_id", &GenLlmReq::getLoraTaskId)
-        .def_property_readonly("lookahead_config", &GenLlmReq::getLookaheadConfig)
-        .def_property("context_chunk_size", &GenLlmReq::getContextChunkSize, &GenLlmReq::setContextChunkSize)
-        .def_property("decoding_iter", &GenLlmReq::getDecodingIter, &GenLlmReq::setDecodingIter)
-        .def_readwrite("request_id", &GenLlmReq::mRequestId)
-        .def_readwrite("prompt_len", &GenLlmReq::mPromptLen)
-        .def_readwrite("max_new_tokens", &GenLlmReq::mMaxNewTokens)
-        .def_readwrite("sampling_config", &GenLlmReq::mSamplingConfig)
-        .def_property("state", &GenLlmReq::getState, &GenLlmReq::setState)
-        .def_property("streaming", &GenLlmReq::isStreaming, &GenLlmReq::setStreaming)
-        .def_readwrite("end_id", &GenLlmReq::mEndId)
-        .def_readwrite("pad_id", &GenLlmReq::mPadId)
-        .def_readwrite("seq_slot", &GenLlmReq::mSeqSlot)
-        .def_property_readonly("return_log_probs", &GenLlmReq::returnLogProbs)
-        .def_property_readonly("return_context_logits", &GenLlmReq::getReturnContextLogits)
-        .def_property_readonly("return_generation_logits", &GenLlmReq::getReturnGenerationLogits)
-        .def_property_readonly("log_probs", py::overload_cast<>(&GenLlmReq::getLogProbs, py::const_))
-        .def("get_log_probs", py::overload_cast<GenLlmReq::SizeType32>(&GenLlmReq::getLogProbs, py::const_))
-        .def("set_log_probs", &GenLlmReq::setLogProbs, py::arg("log_probs"), py::arg("beam"))
-        .def("set_return_encoder_output", &GenLlmReq::setReturnEncoderOutput, py::arg("return_encoder_output"))
+    nb::class_<GenLlmReq>(m, "GenericLlmRequest")
+        .def("set_exclude_input_from_output", &GenLlmReq::setExcludeInputFromOutput, nb::arg("exclude"))
+        .def("get_num_tokens", &GenLlmReq::getNumTokens, nb::arg("beam"))
+        .def_prop_ro("max_beam_num_tokens", &GenLlmReq::getMaxBeamNumTokens)
+        .def("get_token", &GenLlmReq::getToken, nb::arg("beam"), nb::arg("pos"))
+        .def("get_tokens", nb::overload_cast<GenLlmReq::SizeType32>(&GenLlmReq::getTokens, nb::const_), nb::arg("beam"))
+        .def("get_tokens", nb::overload_cast<>(&GenLlmReq::getTokens, nb::const_))
+        .def("get_last_tokens", nb::overload_cast<GenLlmReq::SizeType32>(&GenLlmReq::getLastTokens), nb::arg("beam"))
+        .def("get_last_tokens", nb::overload_cast<>(&GenLlmReq::getLastTokens))
+        .def("get_beam_width_by_iter", &GenLlmReq::getBeamWidthByIter, nb::arg("for_next_iteration") = false)
+        .def_prop_ro("max_num_generated_tokens", &GenLlmReq::getMaxNumGeneratedTokens)
+        .def("add_new_token", &GenLlmReq::addNewToken, nb::arg("token"), nb::arg("beam"))
+        .def("add_new_tokens", &GenLlmReq::addNewTokens, nb::arg("beam_tokens"))
+        .def_prop_ro("num_draft_tokens", &GenLlmReq::getNumDraftTokens)
+        .def("set_generated_tokens", &GenLlmReq::setGeneratedTokens, nb::arg("generated_beam_tokens"))
+        .def("pause", &GenLlmReq::pause, nb::arg("max_input_len"))
+        .def_prop_rw("max_sent_token_len", &GenLlmReq::getMaxSentTokenLen, &GenLlmReq::setMaxSentTokenLen)
+        .def_prop_ro("prompt_embedding_table", &GenLlmReq::getPromptEmbeddingTable)
+        .def_prop_ro("multimodal_embedding", &GenLlmReq::getMultimodalEmbedding)
+        .def_prop_ro("mrope_rotary_cos_sin", &GenLlmReq::getMropeRotaryCosSin)
+        .def_prop_ro("bad_words_list", &GenLlmReq::getBadWordsList)
+        .def_prop_rw("draft_logits", &GenLlmReq::getDraftLogits, &GenLlmReq::setDraftLogits)
+        .def_prop_ro("embedding_bias", &GenLlmReq::getEmbeddingBias)
+        .def_prop_rw("lora_config", &GenLlmReq::getLoraConfig, &GenLlmReq::setLoraConfig)
+        .def_prop_rw("lora_weights", &GenLlmReq::getLoraWeights, &GenLlmReq::setLoraWeights)
+        .def_prop_ro("stop_words_list", &GenLlmReq::getStopWordsList)
+        .def_prop_ro("context_logits", &GenLlmReq::getContextLogitsHost)
+        .def_prop_ro("generation_logits", &GenLlmReq::getGenerationLogitsHost)
+        .def_prop_ro("prompt_vocab_size", &GenLlmReq::getPromptVocabSize)
+        .def_prop_ro("mrope_position_deltas", &GenLlmReq::getMropePositionDeltas)
+        .def_prop_ro("lora_task_id", &GenLlmReq::getLoraTaskId)
+        .def_prop_ro("lookahead_config", &GenLlmReq::getLookaheadConfig)
+        .def_prop_rw("context_chunk_size", &GenLlmReq::getContextChunkSize, &GenLlmReq::setContextChunkSize)
+        .def_prop_rw("decoding_iter", &GenLlmReq::getDecodingIter, &GenLlmReq::setDecodingIter)
+        .def_rw("request_id", &GenLlmReq::mRequestId)
+        .def_rw("prompt_len", &GenLlmReq::mPromptLen)
+        .def_rw("max_new_tokens", &GenLlmReq::mMaxNewTokens)
+        .def_rw("sampling_config", &GenLlmReq::mSamplingConfig)
+        .def_prop_rw("state", &GenLlmReq::getState, &GenLlmReq::setState)
+        .def_prop_rw("streaming", &GenLlmReq::isStreaming, &GenLlmReq::setStreaming)
+        .def_rw("end_id", &GenLlmReq::mEndId)
+        .def_rw("pad_id", &GenLlmReq::mPadId)
+        .def_rw("seq_slot", &GenLlmReq::mSeqSlot)
+        .def_prop_ro("return_log_probs", &GenLlmReq::returnLogProbs)
+        .def_prop_ro("return_context_logits", &GenLlmReq::getReturnContextLogits)
+        .def_prop_ro("return_generation_logits", &GenLlmReq::getReturnGenerationLogits)
+        .def_prop_ro("log_probs", nb::overload_cast<>(&GenLlmReq::getLogProbs, nb::const_))
+        .def("get_log_probs", nb::overload_cast<GenLlmReq::SizeType32>(&GenLlmReq::getLogProbs, nb::const_))
+        .def("set_log_probs", &GenLlmReq::setLogProbs, nb::arg("log_probs"), nb::arg("beam"))
+        .def("set_return_encoder_output", &GenLlmReq::setReturnEncoderOutput, nb::arg("return_encoder_output"))
         .def("get_return_encoder_output", &GenLlmReq::getReturnEncoderOutput)
-        .def("priority", py::overload_cast<>(&GenLlmReq::priority, py::const_))
-        .def("set_priority", py::overload_cast<tle::PriorityType>(&GenLlmReq::setPriority))
-        .def_property_readonly("cum_log_probs", &GenLlmReq::getCumLogProbs)
-        .def("set_cum_log_prob", &GenLlmReq::setCumLogProb, py::arg("cum_log_prob"), py::arg("beam"))
+        .def("priority", nb::overload_cast<>(&GenLlmReq::priority, nb::const_))
+        .def("set_priority", nb::overload_cast<tle::PriorityType>(&GenLlmReq::setPriority))
+        .def_prop_ro("cum_log_probs", &GenLlmReq::getCumLogProbs)
+        .def("set_cum_log_prob", &GenLlmReq::setCumLogProb, nb::arg("cum_log_prob"), nb::arg("beam"))
         .def("update_num_tokens_per_iteration", &GenLlmReq::updateNumTokensPerIteration,
-            py::arg("num_tokens_per_iteration"), py::arg("model_config"))
-        .def_property_readonly("orig_prompt_len", &GenLlmReq::getOrigPromptLen)
+            nb::arg("num_tokens_per_iteration"), nb::arg("model_config"))
+        .def_prop_ro("orig_prompt_len", &GenLlmReq::getOrigPromptLen)
         .def("has_draft_tokens", &GenLlmReq::hasDraftTokens)
         .def("move_to_next_context_chunk", &GenLlmReq::moveToNextContextChunk)
-        .def_property_readonly("is_last_context_chunk", &GenLlmReq::isLastContextChunk)
-        .def_property_readonly("is_first_context_chunk", &GenLlmReq::isFirstContextChunk)
-        .def_property_readonly("context_remaining_length", &GenLlmReq::getContextRemainingLength)
-        .def_property_readonly("context_logits", &GenLlmReq::getContextLogitsHost)
-        .def_property_readonly("num_draft_tokens", &GenLlmReq::getNumDraftTokens)
-        .def("set_finished_reason", &GenLlmReq::setFinishedReason, py::arg("finish_reason"), py::arg("beam"))
-        .def_property_readonly("is_finished", &GenLlmReq::isFinished)
-        .def_property_readonly("is_finished_due_to_length", &GenLlmReq::isFinishedDueToLength)
-        .def_property(
+        .def_prop_ro("is_last_context_chunk", &GenLlmReq::isLastContextChunk)
+        .def_prop_ro("is_first_context_chunk", &GenLlmReq::isFirstContextChunk)
+        .def_prop_ro("context_remaining_length", &GenLlmReq::getContextRemainingLength)
+        .def_prop_ro("context_logits", &GenLlmReq::getContextLogitsHost)
+        .def_prop_ro("num_draft_tokens", &GenLlmReq::getNumDraftTokens)
+        .def("set_finished_reason", &GenLlmReq::setFinishedReason, nb::arg("finish_reason"), nb::arg("beam"))
+        .def_prop_ro("is_finished", &GenLlmReq::isFinished)
+        .def_prop_ro("is_finished_due_to_length", &GenLlmReq::isFinishedDueToLength)
+        .def_prop_rw(
             "context_current_position", &GenLlmReq::getContextCurrentPosition, &GenLlmReq::setContextCurrentPosition)
-        .def_property_readonly("prepopulated_prompt_len", &GenLlmReq::getPrepopulatedPromptLen)
-        .def_property(
-            "guided_decoding_params", &GenLlmReq::getGuidedDecodingParams, &GenLlmReq::setGuidedDecodingParams)
-        .def_property_readonly("context_phase_params", &GenLlmReq::getContextPhaseParams)
-        .def_property_readonly("is_context_only_request", &GenLlmReq::isContextOnlyRequest)
-        .def_property_readonly("is_generation_only_request", &GenLlmReq::isGenerationOnlyRequest)
-        .def_property_readonly("is_generation_complete_state", &GenLlmReq::isGenerationCompleteState)
-        .def_property_readonly("is_context_finished", &GenLlmReq::isContextFinished)
-        .def_property_readonly("is_disagg_generation_init_state", &GenLlmReq::isDisaggGenerationInitState)
-        .def_property_readonly(
-            "is_disagg_generation_transmission_complete", &GenLlmReq::isDisaggGenerationTransmissionComplete)
-        .def_property_readonly(
+        .def_prop_ro("prepopulated_prompt_len", &GenLlmReq::getPrepopulatedPromptLen)
+        .def_prop_rw("guided_decoding_params", &GenLlmReq::getGuidedDecodingParams, &GenLlmReq::setGuidedDecodingParams)
+        .def_prop_ro("context_phase_params", &GenLlmReq::getContextPhaseParams)
+        .def_prop_ro("is_context_only_request", &GenLlmReq::isContextOnlyRequest)
+        .def_prop_ro("is_generation_only_request", &GenLlmReq::isGenerationOnlyRequest)
+        .def_prop_ro("is_context_finished", &GenLlmReq::isContextFinished)
+        .def_prop_ro("is_disagg_generation_init_state", &GenLlmReq::isDisaggGenerationInitState)
+        .def_prop_ro("is_disagg_generation_transmission_complete", &GenLlmReq::isDisaggGenerationTransmissionComplete)
+        .def_prop_ro(
             "is_disagg_generation_transmission_in_progress", &GenLlmReq::isDisaggGenerationTransmissionInProgress)
-        .def_property_readonly("is_context_init_state", &GenLlmReq::isContextInitState)
-        .def_property_readonly("is_generation_in_progress_state", &GenLlmReq::isGenerationInProgressState)
-        .def_property_readonly("is_disagg_context_transmission_state", &GenLlmReq::isDisaggContextTransmissionState)
-        .def_property_readonly("is_disagg_context_complete_state", &GenLlmReq::isDisaggContextCompleteState)
-        .def_property_readonly("stage", &GenLlmReq::getRequestStage)
-        .def_property_readonly("kv_cache_transfer_time_ms", &GenLlmReq::getKvCacheTransferTimeMS)
-        .def_property_readonly("kv_cache_size", &GenLlmReq::getKvCacheSize)
-        .def_property_readonly("avg_decoded_tokens_per_iter", &GenLlmReq::getAvgDecodedTokensPerIter)
-        .def_property_readonly("alloc_total_blocks", &GenLlmReq::getAllocTotalBlocksPerRequest)
-        .def_property_readonly("alloc_new_blocks", &GenLlmReq::getAllocNewBlocksPerRequest)
-        .def("alloc_context_logits", &GenLlmReq::allocContextLogitsHost, py::arg("vocab_size"), py::arg("logit_dtype"))
-        .def_property_readonly("reused_blocks", &GenLlmReq::getReusedBlocksPerRequest)
-        .def_property_readonly("missed_blocks", &GenLlmReq::getMissedBlocksPerRequest)
-        .def_property_readonly("kv_cache_hit_rate", &GenLlmReq::getKVCacheHitRatePerRequest)
-        .def_property_readonly("llm_request_type", &GenLlmReq::getLlmRequestType)
-        .def_property_readonly("multimodal_hashes",
+        .def_prop_ro("is_context_init_state", &GenLlmReq::isContextInitState)
+        .def_prop_ro("is_generation_in_progress_state", &GenLlmReq::isGenerationInProgressState)
+        .def_prop_ro("is_disagg_context_transmission_state", &GenLlmReq::isDisaggContextTransmissionState)
+        .def_prop_ro("is_disagg_context_complete_state", &GenLlmReq::isDisaggContextCompleteState)
+        .def_prop_ro("stage", &GenLlmReq::getRequestStage)
+        .def_prop_ro("kv_cache_transfer_time_ms", &GenLlmReq::getKvCacheTransferTimeMS)
+        .def_prop_ro("kv_cache_size", &GenLlmReq::getKvCacheSize)
+        .def_prop_ro("avg_decoded_tokens_per_iter", &GenLlmReq::getAvgDecodedTokensPerIter)
+        .def_prop_ro("alloc_total_blocks", &GenLlmReq::getAllocTotalBlocksPerRequest)
+        .def_prop_ro("alloc_new_blocks", &GenLlmReq::getAllocNewBlocksPerRequest)
+        .def("alloc_context_logits", &GenLlmReq::allocContextLogitsHost, nb::arg("vocab_size"), nb::arg("logit_dtype"))
+        .def_prop_ro("reused_blocks", &GenLlmReq::getReusedBlocksPerRequest)
+        .def_prop_ro("missed_blocks", &GenLlmReq::getMissedBlocksPerRequest)
+        .def_prop_ro("kv_cache_hit_rate", &GenLlmReq::getKVCacheHitRatePerRequest)
+        .def_prop_ro("llm_request_type", &GenLlmReq::getLlmRequestType)
+        .def_prop_ro("prompt_vocab_size", &GenLlmReq::getPromptVocabSize)
+        .def_prop_ro("mrope_position_deltas", &GenLlmReq::getMropePositionDeltas)
+        .def_prop_ro("lora_task_id", &GenLlmReq::getLoraTaskId)
+        .def_prop_ro("lookahead_config", &GenLlmReq::getLookaheadConfig)
+        .def_prop_rw("context_chunk_size", &GenLlmReq::getContextChunkSize, &GenLlmReq::setContextChunkSize)
+        .def_prop_rw("decoding_iter", &GenLlmReq::getDecodingIter, &GenLlmReq::setDecodingIter)
+        .def_rw("request_id", &GenLlmReq::mRequestId)
+        .def_rw("prompt_len", &GenLlmReq::mPromptLen)
+        .def_rw("max_new_tokens", &GenLlmReq::mMaxNewTokens)
+        .def_rw("sampling_config", &GenLlmReq::mSamplingConfig)
+        .def_prop_rw("state", &GenLlmReq::getState, &GenLlmReq::setState)
+        .def_prop_rw("streaming", &GenLlmReq::isStreaming, &GenLlmReq::setStreaming)
+        .def_rw("end_id", &GenLlmReq::mEndId)
+        .def_rw("pad_id", &GenLlmReq::mPadId)
+        .def_rw("seq_slot", &GenLlmReq::mSeqSlot)
+        .def_prop_ro("return_log_probs", &GenLlmReq::returnLogProbs)
+        .def_prop_ro("return_context_logits", &GenLlmReq::getReturnContextLogits)
+        .def_prop_ro("return_generation_logits", &GenLlmReq::getReturnGenerationLogits)
+        .def_prop_ro("log_probs", nb::overload_cast<>(&GenLlmReq::getLogProbs, nb::const_))
+        .def("get_log_probs", nb::overload_cast<GenLlmReq::SizeType32>(&GenLlmReq::getLogProbs, nb::const_))
+        .def("set_log_probs", &GenLlmReq::setLogProbs, nb::arg("log_probs"), nb::arg("beam"))
+        .def("set_return_encoder_output", &GenLlmReq::setReturnEncoderOutput, nb::arg("return_encoder_output"))
+        .def("get_return_encoder_output", &GenLlmReq::getReturnEncoderOutput)
+        .def("priority", nb::overload_cast<>(&GenLlmReq::priority, nb::const_))
+        .def("set_priority", nb::overload_cast<tle::PriorityType>(&GenLlmReq::setPriority))
+        .def_prop_ro("cum_log_probs", &GenLlmReq::getCumLogProbs)
+        .def("set_cum_log_prob", &GenLlmReq::setCumLogProb, nb::arg("cum_log_prob"), nb::arg("beam"))
+        .def("update_num_tokens_per_iteration", &GenLlmReq::updateNumTokensPerIteration,
+            nb::arg("num_tokens_per_iteration"), nb::arg("model_config"))
+        .def_prop_ro("orig_prompt_len", &GenLlmReq::getOrigPromptLen)
+        .def("has_draft_tokens", &GenLlmReq::hasDraftTokens)
+        .def("move_to_next_context_chunk", &GenLlmReq::moveToNextContextChunk)
+        .def_prop_ro("is_last_context_chunk", &GenLlmReq::isLastContextChunk)
+        .def_prop_ro("is_first_context_chunk", &GenLlmReq::isFirstContextChunk)
+        .def_prop_ro("context_remaining_length", &GenLlmReq::getContextRemainingLength)
+        .def_prop_ro("context_logits", &GenLlmReq::getContextLogitsHost)
+        .def_prop_ro("num_draft_tokens", &GenLlmReq::getNumDraftTokens)
+        .def("set_finished_reason", &GenLlmReq::setFinishedReason, nb::arg("finish_reason"), nb::arg("beam"))
+        .def_prop_ro("is_finished", &GenLlmReq::isFinished)
+        .def_prop_ro("is_finished_due_to_length", &GenLlmReq::isFinishedDueToLength)
+        .def_prop_rw(
+            "context_current_position", &GenLlmReq::getContextCurrentPosition, &GenLlmReq::setContextCurrentPosition)
+        .def_prop_ro("prepopulated_prompt_len", &GenLlmReq::getPrepopulatedPromptLen)
+        .def_prop_rw("guided_decoding_params", &GenLlmReq::getGuidedDecodingParams, &GenLlmReq::setGuidedDecodingParams)
+        .def_prop_ro("context_phase_params", &GenLlmReq::getContextPhaseParams)
+        .def_prop_ro("is_context_only_request", &GenLlmReq::isContextOnlyRequest)
+        .def_prop_ro("is_generation_only_request", &GenLlmReq::isGenerationOnlyRequest)
+        .def_prop_ro("is_generation_complete_state", &GenLlmReq::isGenerationCompleteState)
+        .def_prop_ro("is_context_finished", &GenLlmReq::isContextFinished)
+        .def_prop_ro("is_disagg_generation_init_state", &GenLlmReq::isDisaggGenerationInitState)
+        .def_prop_ro("is_disagg_generation_transmission_complete", &GenLlmReq::isDisaggGenerationTransmissionComplete)
+        .def_prop_ro(
+            "is_disagg_generation_transmission_in_progress", &GenLlmReq::isDisaggGenerationTransmissionInProgress)
+        .def_prop_ro("is_context_init_state", &GenLlmReq::isContextInitState)
+        .def_prop_ro("is_generation_in_progress_state", &GenLlmReq::isGenerationInProgressState)
+        .def_prop_ro("is_disagg_context_transmission_state", &GenLlmReq::isDisaggContextTransmissionState)
+        .def_prop_ro("is_disagg_context_complete_state", &GenLlmReq::isDisaggContextCompleteState)
+        .def_prop_ro("stage", &GenLlmReq::getRequestStage)
+        .def_prop_ro("kv_cache_transfer_time_ms", &GenLlmReq::getKvCacheTransferTimeMS)
+        .def_prop_ro("kv_cache_size", &GenLlmReq::getKvCacheSize)
+        .def_prop_ro("avg_decoded_tokens_per_iter", &GenLlmReq::getAvgDecodedTokensPerIter)
+        .def_prop_ro("alloc_total_blocks", &GenLlmReq::getAllocTotalBlocksPerRequest)
+        .def_prop_ro("alloc_new_blocks", &GenLlmReq::getAllocNewBlocksPerRequest)
+        .def("alloc_context_logits", &GenLlmReq::allocContextLogitsHost, nb::arg("vocab_size"), nb::arg("logit_dtype"))
+        .def_prop_ro("reused_blocks", &GenLlmReq::getReusedBlocksPerRequest)
+        .def_prop_ro("missed_blocks", &GenLlmReq::getMissedBlocksPerRequest)
+        .def_prop_ro("kv_cache_hit_rate", &GenLlmReq::getKVCacheHitRatePerRequest)
+        .def_prop_ro("llm_request_type", &GenLlmReq::getLlmRequestType)
+        .def_prop_ro("multimodal_hashes",
             [](GenLlmReq& self)
             {
                 std::optional<std::vector<std::vector<GenLlmReq::SizeType32>>> hashes = std::nullopt;
@@ -204,7 +265,7 @@ void initBindings(pybind11::module_& m)
                 }
                 return hashes;
             })
-        .def_property_readonly("multimodal_positions",
+        .def_prop_ro("multimodal_positions",
             [](GenLlmReq& self)
             {
                 std::optional<std::vector<GenLlmReq::SizeType32>> positions = std::nullopt;
@@ -214,7 +275,7 @@ void initBindings(pybind11::module_& m)
                 }
                 return positions;
             })
-        .def_property_readonly("multimodal_lengths",
+        .def_prop_ro("multimodal_lengths",
             [](GenLlmReq& self)
             {
                 std::optional<std::vector<GenLlmReq::SizeType32>> lengths = std::nullopt;
@@ -224,7 +285,7 @@ void initBindings(pybind11::module_& m)
                 }
                 return lengths;
             })
-        .def_property_readonly("position_ids",
+        .def_prop_ro("position_ids",
             [](GenLlmReq& self)
             {
                 std::optional<std::vector<GenLlmReq::SizeType32>> positionIds = std::nullopt;
@@ -234,7 +295,7 @@ void initBindings(pybind11::module_& m)
                 }
                 return positionIds;
             })
-        .def_property(
+        .def_prop_rw(
             "draft_tokens",
             [](GenLlmReq& self)
             {
@@ -252,185 +313,184 @@ void initBindings(pybind11::module_& m)
                     self.setDraftTokens(std::make_shared<GenLlmReq::VecTokens>(draftTokens.value()));
                 }
             })
-        .def_property("is_dummy_request", &GenLlmReq::isDummyRequest, &GenLlmReq::setIsDummyRequest)
-        .def_property_readonly("return_perf_metrics", &GenLlmReq::getReturnPerfMetrics);
+        .def_prop_rw("is_dummy_request", &GenLlmReq::isDummyRequest, &GenLlmReq::setIsDummyRequest)
+        .def_prop_ro("return_perf_metrics", &GenLlmReq::getReturnPerfMetrics);
 
-    py::classh<tb::LlmRequest, GenLlmReq>(m, "LlmRequest", pybind11::dynamic_attr())
-        .def(py::init(
-                 [](tb::LlmRequest::RequestIdType request_id, tb::LlmRequest::SizeType32 max_new_tokens,
-                     std::vector<tb::LlmRequest::TokenIdType> input_tokens, runtime::SamplingConfig sampling_config,
-                     bool is_streaming, std::optional<tb::LlmRequest::SizeType32> end_id,
-                     std::optional<tb::LlmRequest::SizeType32> pad_id, std::optional<at::Tensor> embedding_bias,
-                     std::optional<at::Tensor> bad_words_list, std::optional<at::Tensor> stop_words_list,
-                     std::optional<std::vector<tb::LlmRequest::SizeType32>> position_ids,
-                     std::optional<at::Tensor> prompt_embedding_table,
-                     std::optional<tb::LlmRequest::SizeType32> prompt_vocab_size,
-                     std::optional<std::vector<std::vector<tb::LlmRequest::SizeType32>>> multimodal_hashes,
-                     std::optional<std::vector<tb::LlmRequest::SizeType32>> multimodal_positions,
-                     std::optional<std::vector<tb::LlmRequest::SizeType32>> multimodal_lengths,
-                     std::optional<at::Tensor> multimodal_embedding, std::optional<at::Tensor> mrope_rotary_cos_sin,
-                     std::optional<tb::LlmRequest::SizeType32> mrope_position_deltas,
-                     std::optional<LoraTaskIdType> lora_task_id, std::optional<at::Tensor> lora_weights,
-                     std::optional<at::Tensor> lora_config,
-                     std::optional<executor::LookaheadDecodingConfig> lookahead_config,
-                     std::optional<executor::KvCacheRetentionConfig> kv_cache_retention_config, bool return_log_probs,
-                     bool return_context_logits, bool return_generation_logits,
-                     std::optional<tb::LlmRequest::VecTokens> draft_tokens, std::optional<at::Tensor> draft_logits,
-                     bool exclude_input_from_output,
-                     std::optional<tb::LlmRequest::LogitsPostProcessor> logits_post_processor,
-                     bool apply_logits_post_processor_batched,
-                     std::optional<tb::LlmRequest::VecTokens> encoder_input_tokens, bool return_encoder_output,
-                     std::optional<tb::LlmRequest::RequestIdType> client_id, executor::PriorityType priority,
-                     std::optional<at::Tensor> encoder_input_features,
-                     std::optional<tb::LlmRequest::SizeType32> encoder_output_length,
-                     std::optional<at::Tensor> cross_attention_mask, tb::LlmRequestType llm_request_type,
-                     std::optional<tb::LlmRequest::VecTokenExtraIds> input_token_extra_ids,
-                     tb::LlmRequest::SizeType32 num_return_sequences, std::optional<executor::EagleConfig> eagle_config,
-                     std::optional<at::Tensor> skip_cross_attn_blocks, bool return_perf_metrics,
-                     std::optional<executor::GuidedDecodingParams> guided_decoding_params,
-                     std::optional<tb::LlmRequest::SizeType32> language_adapter_uid,
-                     std::optional<tb::LlmRequest::MillisecondsType> allotted_time_ms,
-                     std::optional<executor::ContextPhaseParams> context_phase_params)
-                 {
-                     auto makeOptionalTensor = [](std::optional<at::Tensor> const& atTensor, bool unsqueeze = false)
-                     {
-                         std::optional<tb::LlmRequest::TensorPtr> tensorPtr = std::nullopt;
-                         if (atTensor)
-                         {
-                             tensorPtr = tr::TorchView::of(atTensor.value());
-                             if (unsqueeze)
-                             {
-                                 (*tensorPtr)->unsqueeze(0);
-                             }
-                         }
-                         return tensorPtr;
-                     };
+    nb::class_<tb::LlmRequest, GenLlmReq>(m, "LlmRequest", nb::dynamic_attr())
+        .def(
+            "__init__",
+            [](tb::LlmRequest* self, tb::LlmRequest::RequestIdType request_id,
+                tb::LlmRequest::SizeType32 max_new_tokens, std::vector<tb::LlmRequest::TokenIdType> input_tokens,
+                runtime::SamplingConfig sampling_config, bool is_streaming,
+                std::optional<tb::LlmRequest::SizeType32> end_id, std::optional<tb::LlmRequest::SizeType32> pad_id,
+                std::optional<at::Tensor> embedding_bias, std::optional<at::Tensor> bad_words_list,
+                std::optional<at::Tensor> stop_words_list,
+                std::optional<std::vector<tb::LlmRequest::SizeType32>> position_ids,
+                std::optional<at::Tensor> prompt_embedding_table,
+                std::optional<tb::LlmRequest::SizeType32> prompt_vocab_size,
+                std::optional<std::vector<std::vector<tb::LlmRequest::SizeType32>>> multimodal_hashes,
+                std::optional<std::vector<tb::LlmRequest::SizeType32>> multimodal_positions,
+                std::optional<std::vector<tb::LlmRequest::SizeType32>> multimodal_lengths,
+                std::optional<at::Tensor> multimodal_embedding, std::optional<at::Tensor> mrope_rotary_cos_sin,
+                std::optional<tb::LlmRequest::SizeType32> mrope_position_deltas,
+                std::optional<LoraTaskIdType> lora_task_id, std::optional<at::Tensor> lora_weights,
+                std::optional<at::Tensor> lora_config,
+                std::optional<executor::LookaheadDecodingConfig> lookahead_config,
+                std::optional<executor::KvCacheRetentionConfig> kv_cache_retention_config, bool return_log_probs,
+                bool return_context_logits, bool return_generation_logits,
+                std::optional<tb::LlmRequest::VecTokens> draft_tokens, std::optional<at::Tensor> draft_logits,
+                bool exclude_input_from_output,
+                std::optional<tb::LlmRequest::LogitsPostProcessor> logits_post_processor,
+                bool apply_logits_post_processor_batched, std::optional<tb::LlmRequest::VecTokens> encoder_input_tokens,
+                bool return_encoder_output, std::optional<tb::LlmRequest::RequestIdType> client_id,
+                executor::PriorityType priority, std::optional<at::Tensor> encoder_input_features,
+                std::optional<tb::LlmRequest::SizeType32> encoder_output_length,
+                std::optional<at::Tensor> cross_attention_mask, tb::LlmRequestType llm_request_type,
+                std::optional<tb::LlmRequest::VecTokenExtraIds> input_token_extra_ids,
+                tb::LlmRequest::SizeType32 num_return_sequences, std::optional<executor::EagleConfig> eagle_config,
+                std::optional<at::Tensor> skip_cross_attn_blocks, bool return_perf_metrics,
+                std::optional<executor::GuidedDecodingParams> guided_decoding_params,
+                std::optional<tb::LlmRequest::SizeType32> language_adapter_uid,
+                std::optional<tb::LlmRequest::MillisecondsType> allotted_time_ms,
+                std::optional<executor::ContextPhaseParams> context_phase_params)
+            {
+                auto makeOptionalTensor = [](std::optional<at::Tensor> const& atTensor, bool unsqueeze = false)
+                {
+                    std::optional<tb::LlmRequest::TensorPtr> tensorPtr = std::nullopt;
+                    if (atTensor)
+                    {
+                        tensorPtr = tr::TorchView::of(atTensor.value());
+                        if (unsqueeze)
+                        {
+                            (*tensorPtr)->unsqueeze(0);
+                        }
+                    }
+                    return tensorPtr;
+                };
 
-                     auto embedding_bias_tensor_ptr = makeOptionalTensor(embedding_bias, true);
-                     auto bad_words_list_tensor_ptr = makeOptionalTensor(bad_words_list, true);
-                     auto stop_words_list_tensor_ptr = makeOptionalTensor(stop_words_list, true);
-                     auto prompt_embedding_table_tensor_ptr = makeOptionalTensor(prompt_embedding_table);
-                     auto multimodal_embedding_tensor_ptr = makeOptionalTensor(multimodal_embedding);
-                     auto lora_weights_tensor_ptr = makeOptionalTensor(lora_weights);
-                     auto mrope_rotary_cos_sin_tensor_ptr = makeOptionalTensor(mrope_rotary_cos_sin);
-                     auto lora_config_tensor_ptr = makeOptionalTensor(lora_config);
-                     auto draft_logits_tensor_ptr = makeOptionalTensor(draft_logits);
-                     auto encoder_input_features_tensor_ptr = makeOptionalTensor(encoder_input_features);
-                     auto cross_attention_mask_tensor_ptr = makeOptionalTensor(cross_attention_mask);
-                     auto skip_cross_attn_blocks_tensor_ptr = makeOptionalTensor(skip_cross_attn_blocks);
+                auto embedding_bias_tensor_ptr = makeOptionalTensor(embedding_bias, true);
+                auto bad_words_list_tensor_ptr = makeOptionalTensor(bad_words_list, true);
+                auto stop_words_list_tensor_ptr = makeOptionalTensor(stop_words_list, true);
+                auto prompt_embedding_table_tensor_ptr = makeOptionalTensor(prompt_embedding_table);
+                auto multimodal_embedding_tensor_ptr = makeOptionalTensor(multimodal_embedding);
+                auto lora_weights_tensor_ptr = makeOptionalTensor(lora_weights);
+                auto mrope_rotary_cos_sin_tensor_ptr = makeOptionalTensor(mrope_rotary_cos_sin);
+                auto lora_config_tensor_ptr = makeOptionalTensor(lora_config);
+                auto draft_logits_tensor_ptr = makeOptionalTensor(draft_logits);
+                auto encoder_input_features_tensor_ptr = makeOptionalTensor(encoder_input_features);
+                auto cross_attention_mask_tensor_ptr = makeOptionalTensor(cross_attention_mask);
+                auto skip_cross_attn_blocks_tensor_ptr = makeOptionalTensor(skip_cross_attn_blocks);
 
-                     // 49 parameters
-                     return tb::LlmRequest{request_id, max_new_tokens, input_tokens, sampling_config, is_streaming,
-                         end_id, pad_id, embedding_bias_tensor_ptr, bad_words_list_tensor_ptr,
-                         stop_words_list_tensor_ptr, position_ids, prompt_embedding_table_tensor_ptr, prompt_vocab_size,
-                         multimodal_hashes, multimodal_positions, multimodal_lengths, multimodal_embedding_tensor_ptr,
-                         mrope_rotary_cos_sin_tensor_ptr, mrope_position_deltas, lora_task_id, lora_weights_tensor_ptr,
-                         lora_config_tensor_ptr, lookahead_config, kv_cache_retention_config, return_log_probs,
-                         return_context_logits, return_generation_logits, draft_tokens, draft_logits_tensor_ptr,
-                         exclude_input_from_output, logits_post_processor, apply_logits_post_processor_batched,
-                         encoder_input_tokens, return_encoder_output, client_id, priority,
-                         encoder_input_features_tensor_ptr, encoder_output_length, cross_attention_mask_tensor_ptr,
-                         llm_request_type, input_token_extra_ids, num_return_sequences, eagle_config,
-                         skip_cross_attn_blocks_tensor_ptr, return_perf_metrics, guided_decoding_params,
-                         language_adapter_uid, allotted_time_ms, context_phase_params};
-                 }),
-            py::arg("request_id"), py::arg("max_new_tokens"), py::arg("input_tokens"), py::arg("sampling_config"),
-            py::arg("is_streaming"), py::arg("end_id") = std::nullopt, py::arg("pad_id") = std::nullopt,
-            py::arg("embedding_bias") = std::nullopt, py::arg("bad_words_list") = std::nullopt,
-            py::arg("stop_words_list") = std::nullopt, py::arg("position_ids") = std::nullopt,
-            py::arg("prompt_embedding_table") = std::nullopt, py::arg("prompt_vocab_size") = std::nullopt,
-            py::arg("multimodal_hashes") = std::nullopt, py::arg("multimodal_positions") = std::nullopt,
-            py::arg("multimodal_lengths") = std::nullopt, py::arg("multimodal_embedding") = std::nullopt,
-            py::arg("mrope_rotary_cos_sin") = std::nullopt, py::arg("mrope_position_deltas") = std::nullopt,
-            py::arg("lora_task_id") = std::nullopt, py::arg("lora_weights") = std::nullopt,
-            py::arg("lora_config") = std::nullopt, py::arg("lookahead_config") = std::nullopt,
-            py::arg("kv_cache_retention_config") = std::nullopt, py::arg("return_log_probs") = false,
-            py::arg("return_context_logits") = false, py::arg("return_generation_logits") = false,
-            py::arg("draft_tokens") = std::nullopt, py::arg("draft_logits") = std::nullopt,
-            py::arg("exclude_input_from_output") = false, py::arg("logits_post_processor") = std::nullopt,
-            py::arg("apply_logits_post_processor_batched") = false, py::arg("encoder_input_tokens") = std::nullopt,
-            py::arg("return_encoder_output") = false, py::arg("client_id") = std::nullopt,
-            py::arg("priority") = executor::Request::kDefaultPriority, py::arg("encoder_input_features") = std::nullopt,
-            py::arg("encoder_output_len") = std::nullopt, py::arg("cross_attention_mask") = std::nullopt,
-            py::arg_v("llm_request_type", tb::LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION,
-                "LlmRequestType.LLMREQUEST_TYPE_CONTEXT_AND_GENERATION"),
-            py::arg("input_token_extra_ids") = std::nullopt, py::arg("num_return_sequences") = 1,
-            py::arg("eagle_config") = std::nullopt, py::arg("skip_cross_attn_blocks") = std::nullopt,
-            py::arg("return_perf_metrics") = false, py::arg("guided_decoding_params") = std::nullopt,
-            py::arg("language_adapter_uid") = std::nullopt, py::arg("allotted_time_ms") = std::nullopt,
-            py::arg("context_phase_params") = std::nullopt)
-        .def("validate", &tb::LlmRequest::validate, py::arg("max_input_len"), py::arg("max_seq_len"),
-            py::arg("max_draft_len"), py::arg("vocab_size_padded"), py::arg("max_endocer_input_len") = std::nullopt,
-            py::arg("enable_kv_cache_reuse") = false)
-        .def("create_response", &tb::LlmRequest::createResponse, py::arg("use_fast_logits") = false,
-            py::arg("mpi_world_rank") = 0)
-        .def("create_result", &tb::LlmRequest::createResult, py::arg("use_fast_logits") = false,
-            py::arg("mpi_world_rank") = 0)
+                // 49 parameters
+                new (self) tb::LlmRequest{request_id, max_new_tokens, input_tokens, sampling_config, is_streaming,
+                    end_id, pad_id, embedding_bias_tensor_ptr, bad_words_list_tensor_ptr, stop_words_list_tensor_ptr,
+                    position_ids, prompt_embedding_table_tensor_ptr, prompt_vocab_size, multimodal_hashes,
+                    multimodal_positions, multimodal_lengths, multimodal_embedding_tensor_ptr,
+                    mrope_rotary_cos_sin_tensor_ptr, mrope_position_deltas, lora_task_id, lora_weights_tensor_ptr,
+                    lora_config_tensor_ptr, lookahead_config, kv_cache_retention_config, return_log_probs,
+                    return_context_logits, return_generation_logits, draft_tokens, draft_logits_tensor_ptr,
+                    exclude_input_from_output, logits_post_processor, apply_logits_post_processor_batched,
+                    encoder_input_tokens, return_encoder_output, client_id, priority, encoder_input_features_tensor_ptr,
+                    encoder_output_length, cross_attention_mask_tensor_ptr, llm_request_type, input_token_extra_ids,
+                    num_return_sequences, eagle_config, skip_cross_attn_blocks_tensor_ptr, return_perf_metrics,
+                    guided_decoding_params, language_adapter_uid, allotted_time_ms, context_phase_params};
+            },
+            nb::arg("request_id"), nb::arg("max_new_tokens"), nb::arg("input_tokens"), nb::arg("sampling_config"),
+            nb::arg("is_streaming"), nb::arg("end_id") = std::nullopt, nb::arg("pad_id") = std::nullopt,
+            nb::arg("embedding_bias") = std::nullopt, nb::arg("bad_words_list") = std::nullopt,
+            nb::arg("stop_words_list") = std::nullopt, nb::arg("position_ids") = std::nullopt,
+            nb::arg("prompt_embedding_table") = std::nullopt, nb::arg("prompt_vocab_size") = std::nullopt,
+            nb::arg("multimodal_hashes") = std::nullopt, nb::arg("multimodal_positions") = std::nullopt,
+            nb::arg("multimodal_lengths") = std::nullopt, nb::arg("multimodal_embedding") = std::nullopt,
+            nb::arg("mrope_rotary_cos_sin") = std::nullopt, nb::arg("mrope_position_deltas") = std::nullopt,
+            nb::arg("lora_task_id") = std::nullopt, nb::arg("lora_weights") = std::nullopt,
+            nb::arg("lora_config") = std::nullopt, nb::arg("lookahead_config") = std::nullopt,
+            nb::arg("kv_cache_retention_config") = std::nullopt, nb::arg("return_log_probs") = false,
+            nb::arg("return_context_logits") = false, nb::arg("return_generation_logits") = false,
+            nb::arg("draft_tokens") = std::nullopt, nb::arg("draft_logits") = std::nullopt,
+            nb::arg("exclude_input_from_output") = false, nb::arg("logits_post_processor") = std::nullopt,
+            nb::arg("apply_logits_post_processor_batched") = false, nb::arg("encoder_input_tokens") = std::nullopt,
+            nb::arg("return_encoder_output") = false, nb::arg("client_id") = std::nullopt,
+            nb::arg("priority") = executor::Request::kDefaultPriority, nb::arg("encoder_input_features") = std::nullopt,
+            nb::arg("encoder_output_len") = std::nullopt, nb::arg("cross_attention_mask") = std::nullopt,
+            nb::arg("llm_request_type") = tb::LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION,
+            nb::arg("input_token_extra_ids") = std::nullopt, nb::arg("num_return_sequences") = 1,
+            nb::arg("eagle_config") = std::nullopt, nb::arg("skip_cross_attn_blocks") = std::nullopt,
+            nb::arg("return_perf_metrics") = false, nb::arg("guided_decoding_params") = std::nullopt,
+            nb::arg("language_adapter_uid") = std::nullopt, nb::arg("allotted_time_ms") = std::nullopt,
+            nb::arg("context_phase_params") = std::nullopt)
+        .def("validate", &tb::LlmRequest::validate, nb::arg("max_input_len"), nb::arg("max_seq_len"),
+            nb::arg("max_draft_len"), nb::arg("vocab_size_padded"), nb::arg("max_endocer_input_len") = std::nullopt,
+            nb::arg("enable_kv_cache_reuse") = false)
+        .def("create_response", &tb::LlmRequest::createResponse, nb::arg("use_fast_logits") = false,
+            nb::arg("mpi_world_rank") = 0)
+        .def("create_result", &tb::LlmRequest::createResult, nb::arg("use_fast_logits") = false,
+            nb::arg("mpi_world_rank") = 0)
         .def("create_serialized_result",
             [](tb::LlmRequest& self, bool use_fast_logits = false, int mpi_world_rank = 0)
             {
                 std::vector<char> serialized_result;
                 bool is_final = false;
                 self.createSerializedResult(serialized_result, is_final, use_fast_logits, mpi_world_rank);
-                return std::make_tuple(py::bytes(serialized_result.data(), serialized_result.size()), is_final);
+                return std::make_tuple(nb::bytes(serialized_result.data(), serialized_result.size()), is_final);
             })
-        .def("move_prompt_embedding_table_to_gpu", &tb::LlmRequest::movePromptEmbeddingTableToGpu, py::arg("manager"))
-        .def("move_lora_weights_to_gpu", &tb::LlmRequest::moveLoraWeightsToGpu, py::arg("manager"))
-        .def("finish_by_reason", &tb::LlmRequest::finishByReason, py::arg("finish_reason"))
+        .def("move_prompt_embedding_table_to_gpu", &tb::LlmRequest::movePromptEmbeddingTableToGpu, nb::arg("manager"))
+        .def("move_lora_weights_to_gpu", &tb::LlmRequest::moveLoraWeightsToGpu, nb::arg("manager"))
+        .def("finish_by_reason", &tb::LlmRequest::finishByReason, nb::arg("finish_reason"))
         .def("set_first_scheduled_time", &tb::LlmRequest::setFirstScheduledTime)
-        .def("update_perf_metrics", &tb::LlmRequest::updatePerfMetrics, py::arg("iter_counter"));
+        .def("update_perf_metrics", &tb::LlmRequest::updatePerfMetrics, nb::arg("iter_counter"));
 
-    py::classh<tb::SequenceSlotManager>(m, "SequenceSlotManager")
-        .def(py::init<tb::SequenceSlotManager::SlotIdType, uint64_t>(), py::arg("max_num_slots"),
-            py::arg("max_sequence_idle_microseconds"))
-        .def("get_sequence_slot", &tb::SequenceSlotManager::getSequenceSlot, py::arg("start_flag"),
-            py::arg("sequence_id"))
-        .def("free_sequence_slot", &tb::SequenceSlotManager::freeSequenceSlot, py::arg("sequence_id"))
+    nb::class_<tb::SequenceSlotManager>(m, "SequenceSlotManager")
+        .def(nb::init<tb::SequenceSlotManager::SlotIdType, uint64_t>(), nb::arg("max_num_slots"),
+            nb::arg("max_sequence_idle_microseconds"))
+        .def("get_sequence_slot", &tb::SequenceSlotManager::getSequenceSlot, nb::arg("start_flag"),
+            nb::arg("sequence_id"))
+        .def("free_sequence_slot", &tb::SequenceSlotManager::freeSequenceSlot, nb::arg("sequence_id"))
         .def("free_idle_sequence_slots", &tb::SequenceSlotManager::freeIdleSequenceSlots);
 
-    py::classh<tb::rnn_state_manager::RnnStateManager>(m, "RnnStateManager")
-        .def(py::init<tr::SizeType32, tr::ModelConfig, tr::WorldConfig, tr::BufferManager>(),
-            py::arg("max_num_sequences"), py::arg("model_config"), py::arg("world_config"), py::arg("buffer_manager"));
+    nb::class_<tb::rnn_state_manager::RnnStateManager>(m, "RnnStateManager")
+        .def(nb::init<tr::SizeType32, tr::ModelConfig, tr::WorldConfig, tr::BufferManager>(),
+            nb::arg("max_num_sequences"), nb::arg("model_config"), nb::arg("world_config"), nb::arg("buffer_manager"));
 
-    py::class_<tb::DecoderInputBuffers>(m, "DecoderInputBuffers")
-        .def(py::init<runtime::SizeType32, runtime::SizeType32, runtime::SizeType32, tr::BufferManager>(),
-            py::arg("max_num_sequences"), py::arg("max_batch_size"), py::arg("max_tokens_per_engine_step"),
-            py::arg("manager"))
-        .def_readwrite("setup_batch_slots", &tb::DecoderInputBuffers::setupBatchSlots)
-        .def_readwrite("setup_batch_slots_device", &tb::DecoderInputBuffers::setupBatchSlotsDevice)
-        .def_readwrite("fill_values", &tb::DecoderInputBuffers::fillValues)
-        .def_readwrite("fill_values_device", &tb::DecoderInputBuffers::fillValuesDevice)
-        .def_readwrite("inputs_ids", &tb::DecoderInputBuffers::inputsIds)
-        .def_readwrite("forward_batch_slots", &tb::DecoderInputBuffers::forwardBatchSlots)
-        .def_readwrite("logits", &tb::DecoderInputBuffers::logits);
+    nb::class_<tb::DecoderInputBuffers>(m, "DecoderInputBuffers")
+        .def(nb::init<runtime::SizeType32, runtime::SizeType32, runtime::SizeType32, tr::BufferManager>(),
+            nb::arg("max_num_sequences"), nb::arg("max_batch_size"), nb::arg("max_tokens_per_engine_step"),
+            nb::arg("manager"))
+        .def_rw("setup_batch_slots", &tb::DecoderInputBuffers::setupBatchSlots)
+        .def_rw("setup_batch_slots_device", &tb::DecoderInputBuffers::setupBatchSlotsDevice)
+        .def_rw("fill_values", &tb::DecoderInputBuffers::fillValues)
+        .def_rw("fill_values_device", &tb::DecoderInputBuffers::fillValuesDevice)
+        .def_rw("inputs_ids", &tb::DecoderInputBuffers::inputsIds)
+        .def_rw("forward_batch_slots", &tb::DecoderInputBuffers::forwardBatchSlots)
+        .def_rw("logits", &tb::DecoderInputBuffers::logits);
 
-    py::class_<tb::DecoderOutputBuffers>(m, "DecoderOutputBuffers")
-        .def_readwrite("sequence_lengths_host", &tb::DecoderOutputBuffers::sequenceLengthsHost)
-        .def_readwrite("finished_sum_host", &tb::DecoderOutputBuffers::finishedSumHost)
-        .def_property_readonly("new_output_tokens_host",
+    nb::class_<tb::DecoderOutputBuffers>(m, "DecoderOutputBuffers")
+        .def_rw("sequence_lengths_host", &tb::DecoderOutputBuffers::sequenceLengthsHost)
+        .def_rw("finished_sum_host", &tb::DecoderOutputBuffers::finishedSumHost)
+        .def_prop_ro("new_output_tokens_host",
             [](tb::DecoderOutputBuffers& self) { return tr::Torch::tensor(self.newOutputTokensHost); })
-        .def_readwrite("cum_log_probs_host", &tb::DecoderOutputBuffers::cumLogProbsHost)
-        .def_readwrite("log_probs_host", &tb::DecoderOutputBuffers::logProbsHost)
-        .def_readwrite("finish_reasons_host", &tb::DecoderOutputBuffers::finishReasonsHost);
+        .def_rw("cum_log_probs_host", &tb::DecoderOutputBuffers::cumLogProbsHost)
+        .def_rw("log_probs_host", &tb::DecoderOutputBuffers::logProbsHost)
+        .def_rw("finish_reasons_host", &tb::DecoderOutputBuffers::finishReasonsHost);
 
-    py::class_<tb::SlotDecoderBuffers>(m, "SlotDecoderBuffers")
-        .def(py::init<runtime::SizeType32, runtime::SizeType32, runtime::BufferManager const&>(),
-            py::arg("max_beam_width"), py::arg("max_seq_len"), py::arg("buffer_manager"))
-        .def_readwrite("output_ids", &tb::SlotDecoderBuffers::outputIds)
-        .def_readwrite("output_ids_host", &tb::SlotDecoderBuffers::outputIdsHost)
-        .def_readwrite("sequence_lengths_host", &tb::SlotDecoderBuffers::sequenceLengthsHost)
-        .def_readwrite("cum_log_probs", &tb::SlotDecoderBuffers::cumLogProbs)
-        .def_readwrite("cum_log_probs_host", &tb::SlotDecoderBuffers::cumLogProbsHost)
-        .def_readwrite("log_probs", &tb::SlotDecoderBuffers::logProbs)
-        .def_readwrite("log_probs_host", &tb::SlotDecoderBuffers::logProbsHost)
-        .def_readwrite("finish_reasons_host", &tb::SlotDecoderBuffers::finishReasonsHost);
+    nb::class_<tb::SlotDecoderBuffers>(m, "SlotDecoderBuffers")
+        .def(nb::init<runtime::SizeType32, runtime::SizeType32, runtime::BufferManager const&>(),
+            nb::arg("max_beam_width"), nb::arg("max_seq_len"), nb::arg("buffer_manager"))
+        .def_rw("output_ids", &tb::SlotDecoderBuffers::outputIds)
+        .def_rw("output_ids_host", &tb::SlotDecoderBuffers::outputIdsHost)
+        .def_rw("sequence_lengths_host", &tb::SlotDecoderBuffers::sequenceLengthsHost)
+        .def_rw("cum_log_probs", &tb::SlotDecoderBuffers::cumLogProbs)
+        .def_rw("cum_log_probs_host", &tb::SlotDecoderBuffers::cumLogProbsHost)
+        .def_rw("log_probs", &tb::SlotDecoderBuffers::logProbs)
+        .def_rw("log_probs_host", &tb::SlotDecoderBuffers::logProbsHost)
+        .def_rw("finish_reasons_host", &tb::SlotDecoderBuffers::finishReasonsHost);
 
-    py::class_<tb::MedusaBuffers>(m, "MedusaBuffers")
-        .def(py::init<runtime::SizeType32, runtime::SizeType32, runtime::BufferManager const&,
+    nb::class_<tb::MedusaBuffers>(m, "MedusaBuffers")
+        .def(nb::init<runtime::SizeType32, runtime::SizeType32, runtime::BufferManager const&,
                  runtime::ModelConfig const&, runtime::WorldConfig const&, executor::DecodingConfig const&,
                  runtime::TllmRuntime const&>(),
-            py::arg("max_beam_width"), py::arg("max_seq_len"), py::arg("buffer_manager"), py::arg("model_config"),
-            py::arg("world_config"), py::arg("decoding_config"), py::arg("runtime"));
+            nb::arg("max_beam_width"), nb::arg("max_seq_len"), nb::arg("buffer_manager"), nb::arg("model_config"),
+            nb::arg("world_config"), nb::arg("decoding_config"), nb::arg("runtime"));
 
     m.def(
         "add_new_tokens_to_requests",
@@ -444,7 +504,7 @@ void initBindings(pybind11::module_& m)
                 requests[i]->addNewToken(tokens[i], beam_idx);
             }
         },
-        py::arg("requests"), py::arg("tokens"), py::arg("beam_idx"),
+        nb::arg("requests"), nb::arg("tokens"), nb::arg("beam_idx"),
         "Add new tokens to multiple LLM requests. The tokens vector should contain tokens for beam beam_idx of all "
         "requests in order.");
 
@@ -523,9 +583,9 @@ void initBindings(pybind11::module_& m)
 
             return decodingInput;
         },
-        py::arg("context_requests"), py::arg("generation_requests"), py::arg("logits"), py::arg("beam_width"),
-        py::arg("num_context_logits_prefix_sum"), py::arg("decoder_input_buffers"), py::arg("decoder_state"),
-        py::arg("buffer_manager"), "Make decoding batch input.");
+        nb::arg("context_requests"), nb::arg("generation_requests"), nb::arg("logits"), nb::arg("beam_width"),
+        nb::arg("num_context_logits_prefix_sum"), nb::arg("decoder_input_buffers"), nb::arg("decoder_state"),
+        nb::arg("buffer_manager"), "Make decoding batch input.");
 }
 
-} // namespace tensorrt_llm::pybind::batch_manager
+} // namespace tensorrt_llm::nanobind::batch_manager

--- a/cpp/tensorrt_llm/nanobind/batch_manager/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/bindings.cpp
@@ -1,0 +1,531 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bindings.h"
+
+#include "tensorrt_llm/batch_manager/common.h"
+#include "tensorrt_llm/batch_manager/decoderBuffers.h"
+#include "tensorrt_llm/batch_manager/medusaBuffers.h"
+#include "tensorrt_llm/batch_manager/microBatchScheduler.h"
+#include "tensorrt_llm/batch_manager/peftCacheManager.h"
+#include "tensorrt_llm/batch_manager/rnnStateManager.h"
+#include "tensorrt_llm/batch_manager/runtimeBuffers.h"
+#include "tensorrt_llm/batch_manager/sequenceSlotManager.h"
+#include "tensorrt_llm/pybind/common/bindTypes.h"
+#include "tensorrt_llm/runtime/gptDecoderBatched.h"
+#include "tensorrt_llm/runtime/runtimeKernels.h"
+#include "tensorrt_llm/runtime/torch.h"
+#include "tensorrt_llm/runtime/torchView.h"
+
+#include <ATen/ATen.h>
+#include <pybind11/chrono.h>
+#include <pybind11/functional.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <torch/extension.h>
+#include <tuple>
+
+namespace py = pybind11;
+namespace tb = tensorrt_llm::batch_manager;
+namespace tle = tensorrt_llm::executor;
+namespace tr = tensorrt_llm::runtime;
+
+using namespace tensorrt_llm::runtime;
+
+namespace tensorrt_llm::pybind::batch_manager
+{
+
+void initBindings(pybind11::module_& m)
+{
+    using GenLlmReq = tb::GenericLlmRequest<runtime::ITensor::SharedPtr>;
+
+    // Create and register exceptions in module scope
+    static PyObject* peft_exc = PyErr_NewException(
+        "tensorrt_llm.bindings.internal.batch_manager.PeftTaskNotCachedException", nullptr, nullptr);
+    static PyObject* lora_exc
+        = PyErr_NewException("tensorrt_llm.bindings.internal.batch_manager.LoraCacheFullException", nullptr, nullptr);
+
+    m.add_object("PeftTaskNotCachedException", py::handle(peft_exc));
+    m.add_object("LoraCacheFullException", py::handle(lora_exc));
+
+    // Register with no captures
+    py::register_exception_translator(
+        [](std::exception_ptr p)
+        {
+            try
+            {
+                if (p)
+                    std::rethrow_exception(p);
+            }
+            catch (const tb::PeftTaskNotCachedException& e)
+            {
+                PyErr_SetString(peft_exc, e.what());
+            }
+            catch (const tr::LoraCacheFullException& e)
+            {
+                PyErr_SetString(lora_exc, e.what());
+            }
+        });
+
+    PybindUtils::bindSet<tb::ReqIdsSet>(m, "ReqIdsSet");
+
+    py::enum_<tb::LlmRequestType>(m, "LlmRequestType")
+        .value("LLMREQUEST_TYPE_CONTEXT_AND_GENERATION", tb::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION)
+        .value("LLMREQUEST_TYPE_CONTEXT_ONLY", tb::LLMREQUEST_TYPE_CONTEXT_ONLY)
+        .value("LLMREQUEST_TYPE_GENERATION_ONLY", tb::LLMREQUEST_TYPE_GENERATION_ONLY)
+        .export_values();
+
+    py::class_<tb::batch_scheduler::ContextChunkingConfig>(m, "ContextChunkingConfig")
+        .def(py::init<tle::ContextChunkingPolicy, tensorrt_llm::runtime::SizeType32>(), py::arg("chunking_policy"),
+            py::arg("chunk_unit_size"))
+        .def_readwrite("chunking_policy", &tb::batch_scheduler::ContextChunkingConfig::chunkingPolicy)
+        .def_readwrite("chunk_unit_size", &tb::batch_scheduler::ContextChunkingConfig::chunkUnitSize);
+
+    py::classh<GenLlmReq>(m, "GenericLlmRequest")
+        .def("set_exclude_input_from_output", &GenLlmReq::setExcludeInputFromOutput, py::arg("exclude"))
+        .def("get_num_tokens", &GenLlmReq::getNumTokens, py::arg("beam"))
+        .def_property_readonly("max_beam_num_tokens", &GenLlmReq::getMaxBeamNumTokens)
+        .def("get_token", &GenLlmReq::getToken, py::arg("beam"), py::arg("pos"))
+        .def("get_tokens", py::overload_cast<GenLlmReq::SizeType32>(&GenLlmReq::getTokens, py::const_), py::arg("beam"))
+        .def("get_tokens", py::overload_cast<>(&GenLlmReq::getTokens, py::const_))
+        .def("get_last_tokens", py::overload_cast<GenLlmReq::SizeType32>(&GenLlmReq::getLastTokens), py::arg("beam"))
+        .def("get_last_tokens", py::overload_cast<>(&GenLlmReq::getLastTokens))
+        .def("get_beam_width_by_iter", &GenLlmReq::getBeamWidthByIter, py::arg("for_next_iteration") = false)
+        .def_property_readonly("max_num_generated_tokens", &GenLlmReq::getMaxNumGeneratedTokens)
+        .def("add_new_token", &GenLlmReq::addNewToken, py::arg("token"), py::arg("beam"))
+        .def("add_new_tokens", &GenLlmReq::addNewTokens, py::arg("beam_tokens"))
+        .def_property_readonly("num_draft_tokens", &GenLlmReq::getNumDraftTokens)
+        .def("set_generated_tokens", &GenLlmReq::setGeneratedTokens, py::arg("generated_beam_tokens"))
+        .def("pause", &GenLlmReq::pause, py::arg("max_input_len"))
+        .def_property("max_sent_token_len", &GenLlmReq::getMaxSentTokenLen, &GenLlmReq::setMaxSentTokenLen)
+        .def_property_readonly("prompt_embedding_table", &GenLlmReq::getPromptEmbeddingTable)
+        .def_property_readonly("multimodal_embedding", &GenLlmReq::getMultimodalEmbedding)
+        .def_property_readonly("mrope_rotary_cos_sin", &GenLlmReq::getMropeRotaryCosSin)
+        .def_property_readonly("bad_words_list", &GenLlmReq::getBadWordsList)
+        .def_property("draft_logits", &GenLlmReq::getDraftLogits, &GenLlmReq::setDraftLogits)
+        .def_property_readonly("embedding_bias", &GenLlmReq::getEmbeddingBias)
+        .def_property("lora_config", &GenLlmReq::getLoraConfig, &GenLlmReq::setLoraConfig)
+        .def_property("lora_weights", &GenLlmReq::getLoraWeights, &GenLlmReq::setLoraWeights)
+        .def_property_readonly("stop_words_list", &GenLlmReq::getStopWordsList)
+        .def_property_readonly("context_logits", &GenLlmReq::getContextLogitsHost)
+        .def_property_readonly("generation_logits", &GenLlmReq::getGenerationLogitsHost)
+        .def_property_readonly("prompt_vocab_size", &GenLlmReq::getPromptVocabSize)
+        .def_property_readonly("mrope_position_deltas", &GenLlmReq::getMropePositionDeltas)
+        .def_property_readonly("lora_task_id", &GenLlmReq::getLoraTaskId)
+        .def_property_readonly("lookahead_config", &GenLlmReq::getLookaheadConfig)
+        .def_property("context_chunk_size", &GenLlmReq::getContextChunkSize, &GenLlmReq::setContextChunkSize)
+        .def_property("decoding_iter", &GenLlmReq::getDecodingIter, &GenLlmReq::setDecodingIter)
+        .def_readwrite("request_id", &GenLlmReq::mRequestId)
+        .def_readwrite("prompt_len", &GenLlmReq::mPromptLen)
+        .def_readwrite("max_new_tokens", &GenLlmReq::mMaxNewTokens)
+        .def_readwrite("sampling_config", &GenLlmReq::mSamplingConfig)
+        .def_property("state", &GenLlmReq::getState, &GenLlmReq::setState)
+        .def_property("streaming", &GenLlmReq::isStreaming, &GenLlmReq::setStreaming)
+        .def_readwrite("end_id", &GenLlmReq::mEndId)
+        .def_readwrite("pad_id", &GenLlmReq::mPadId)
+        .def_readwrite("seq_slot", &GenLlmReq::mSeqSlot)
+        .def_property_readonly("return_log_probs", &GenLlmReq::returnLogProbs)
+        .def_property_readonly("return_context_logits", &GenLlmReq::getReturnContextLogits)
+        .def_property_readonly("return_generation_logits", &GenLlmReq::getReturnGenerationLogits)
+        .def_property_readonly("log_probs", py::overload_cast<>(&GenLlmReq::getLogProbs, py::const_))
+        .def("get_log_probs", py::overload_cast<GenLlmReq::SizeType32>(&GenLlmReq::getLogProbs, py::const_))
+        .def("set_log_probs", &GenLlmReq::setLogProbs, py::arg("log_probs"), py::arg("beam"))
+        .def("set_return_encoder_output", &GenLlmReq::setReturnEncoderOutput, py::arg("return_encoder_output"))
+        .def("get_return_encoder_output", &GenLlmReq::getReturnEncoderOutput)
+        .def("priority", py::overload_cast<>(&GenLlmReq::priority, py::const_))
+        .def("set_priority", py::overload_cast<tle::PriorityType>(&GenLlmReq::setPriority))
+        .def_property_readonly("cum_log_probs", &GenLlmReq::getCumLogProbs)
+        .def("set_cum_log_prob", &GenLlmReq::setCumLogProb, py::arg("cum_log_prob"), py::arg("beam"))
+        .def("update_num_tokens_per_iteration", &GenLlmReq::updateNumTokensPerIteration,
+            py::arg("num_tokens_per_iteration"), py::arg("model_config"))
+        .def_property_readonly("orig_prompt_len", &GenLlmReq::getOrigPromptLen)
+        .def("has_draft_tokens", &GenLlmReq::hasDraftTokens)
+        .def("move_to_next_context_chunk", &GenLlmReq::moveToNextContextChunk)
+        .def_property_readonly("is_last_context_chunk", &GenLlmReq::isLastContextChunk)
+        .def_property_readonly("is_first_context_chunk", &GenLlmReq::isFirstContextChunk)
+        .def_property_readonly("context_remaining_length", &GenLlmReq::getContextRemainingLength)
+        .def_property_readonly("context_logits", &GenLlmReq::getContextLogitsHost)
+        .def_property_readonly("num_draft_tokens", &GenLlmReq::getNumDraftTokens)
+        .def("set_finished_reason", &GenLlmReq::setFinishedReason, py::arg("finish_reason"), py::arg("beam"))
+        .def_property_readonly("is_finished", &GenLlmReq::isFinished)
+        .def_property_readonly("is_finished_due_to_length", &GenLlmReq::isFinishedDueToLength)
+        .def_property(
+            "context_current_position", &GenLlmReq::getContextCurrentPosition, &GenLlmReq::setContextCurrentPosition)
+        .def_property_readonly("prepopulated_prompt_len", &GenLlmReq::getPrepopulatedPromptLen)
+        .def_property(
+            "guided_decoding_params", &GenLlmReq::getGuidedDecodingParams, &GenLlmReq::setGuidedDecodingParams)
+        .def_property_readonly("context_phase_params", &GenLlmReq::getContextPhaseParams)
+        .def_property_readonly("is_context_only_request", &GenLlmReq::isContextOnlyRequest)
+        .def_property_readonly("is_generation_only_request", &GenLlmReq::isGenerationOnlyRequest)
+        .def_property_readonly("is_generation_complete_state", &GenLlmReq::isGenerationCompleteState)
+        .def_property_readonly("is_context_finished", &GenLlmReq::isContextFinished)
+        .def_property_readonly("is_disagg_generation_init_state", &GenLlmReq::isDisaggGenerationInitState)
+        .def_property_readonly(
+            "is_disagg_generation_transmission_complete", &GenLlmReq::isDisaggGenerationTransmissionComplete)
+        .def_property_readonly(
+            "is_disagg_generation_transmission_in_progress", &GenLlmReq::isDisaggGenerationTransmissionInProgress)
+        .def_property_readonly("is_context_init_state", &GenLlmReq::isContextInitState)
+        .def_property_readonly("is_generation_in_progress_state", &GenLlmReq::isGenerationInProgressState)
+        .def_property_readonly("is_disagg_context_transmission_state", &GenLlmReq::isDisaggContextTransmissionState)
+        .def_property_readonly("is_disagg_context_complete_state", &GenLlmReq::isDisaggContextCompleteState)
+        .def_property_readonly("stage", &GenLlmReq::getRequestStage)
+        .def_property_readonly("kv_cache_transfer_time_ms", &GenLlmReq::getKvCacheTransferTimeMS)
+        .def_property_readonly("kv_cache_size", &GenLlmReq::getKvCacheSize)
+        .def_property_readonly("avg_decoded_tokens_per_iter", &GenLlmReq::getAvgDecodedTokensPerIter)
+        .def_property_readonly("alloc_total_blocks", &GenLlmReq::getAllocTotalBlocksPerRequest)
+        .def_property_readonly("alloc_new_blocks", &GenLlmReq::getAllocNewBlocksPerRequest)
+        .def("alloc_context_logits", &GenLlmReq::allocContextLogitsHost, py::arg("vocab_size"), py::arg("logit_dtype"))
+        .def_property_readonly("reused_blocks", &GenLlmReq::getReusedBlocksPerRequest)
+        .def_property_readonly("missed_blocks", &GenLlmReq::getMissedBlocksPerRequest)
+        .def_property_readonly("kv_cache_hit_rate", &GenLlmReq::getKVCacheHitRatePerRequest)
+        .def_property_readonly("llm_request_type", &GenLlmReq::getLlmRequestType)
+        .def_property_readonly("multimodal_hashes",
+            [](GenLlmReq& self)
+            {
+                std::optional<std::vector<std::vector<GenLlmReq::SizeType32>>> hashes = std::nullopt;
+                if (self.getMultimodalHashes())
+                {
+                    hashes = *self.getMultimodalHashes().value();
+                }
+                return hashes;
+            })
+        .def_property_readonly("multimodal_positions",
+            [](GenLlmReq& self)
+            {
+                std::optional<std::vector<GenLlmReq::SizeType32>> positions = std::nullopt;
+                if (self.getMultimodalPositions())
+                {
+                    positions = *self.getMultimodalPositions().value();
+                }
+                return positions;
+            })
+        .def_property_readonly("multimodal_lengths",
+            [](GenLlmReq& self)
+            {
+                std::optional<std::vector<GenLlmReq::SizeType32>> lengths = std::nullopt;
+                if (self.getMultimodalLengths())
+                {
+                    lengths = *self.getMultimodalLengths().value();
+                }
+                return lengths;
+            })
+        .def_property_readonly("position_ids",
+            [](GenLlmReq& self)
+            {
+                std::optional<std::vector<GenLlmReq::SizeType32>> positionIds = std::nullopt;
+                if (self.getPositionIds())
+                {
+                    positionIds = *self.getPositionIds().value();
+                }
+                return positionIds;
+            })
+        .def_property(
+            "draft_tokens",
+            [](GenLlmReq& self)
+            {
+                std::optional<GenLlmReq::VecTokens> draftTokens = std::nullopt;
+                if (self.hasDraftTokens())
+                {
+                    draftTokens = *self.getDraftTokens();
+                }
+                return draftTokens;
+            },
+            [](GenLlmReq& self, std::optional<GenLlmReq::VecTokens> const& draftTokens)
+            {
+                if (draftTokens)
+                {
+                    self.setDraftTokens(std::make_shared<GenLlmReq::VecTokens>(draftTokens.value()));
+                }
+            })
+        .def_property("is_dummy_request", &GenLlmReq::isDummyRequest, &GenLlmReq::setIsDummyRequest)
+        .def_property_readonly("return_perf_metrics", &GenLlmReq::getReturnPerfMetrics);
+
+    py::classh<tb::LlmRequest, GenLlmReq>(m, "LlmRequest", pybind11::dynamic_attr())
+        .def(py::init(
+                 [](tb::LlmRequest::RequestIdType request_id, tb::LlmRequest::SizeType32 max_new_tokens,
+                     std::vector<tb::LlmRequest::TokenIdType> input_tokens, runtime::SamplingConfig sampling_config,
+                     bool is_streaming, std::optional<tb::LlmRequest::SizeType32> end_id,
+                     std::optional<tb::LlmRequest::SizeType32> pad_id, std::optional<at::Tensor> embedding_bias,
+                     std::optional<at::Tensor> bad_words_list, std::optional<at::Tensor> stop_words_list,
+                     std::optional<std::vector<tb::LlmRequest::SizeType32>> position_ids,
+                     std::optional<at::Tensor> prompt_embedding_table,
+                     std::optional<tb::LlmRequest::SizeType32> prompt_vocab_size,
+                     std::optional<std::vector<std::vector<tb::LlmRequest::SizeType32>>> multimodal_hashes,
+                     std::optional<std::vector<tb::LlmRequest::SizeType32>> multimodal_positions,
+                     std::optional<std::vector<tb::LlmRequest::SizeType32>> multimodal_lengths,
+                     std::optional<at::Tensor> multimodal_embedding, std::optional<at::Tensor> mrope_rotary_cos_sin,
+                     std::optional<tb::LlmRequest::SizeType32> mrope_position_deltas,
+                     std::optional<LoraTaskIdType> lora_task_id, std::optional<at::Tensor> lora_weights,
+                     std::optional<at::Tensor> lora_config,
+                     std::optional<executor::LookaheadDecodingConfig> lookahead_config,
+                     std::optional<executor::KvCacheRetentionConfig> kv_cache_retention_config, bool return_log_probs,
+                     bool return_context_logits, bool return_generation_logits,
+                     std::optional<tb::LlmRequest::VecTokens> draft_tokens, std::optional<at::Tensor> draft_logits,
+                     bool exclude_input_from_output,
+                     std::optional<tb::LlmRequest::LogitsPostProcessor> logits_post_processor,
+                     bool apply_logits_post_processor_batched,
+                     std::optional<tb::LlmRequest::VecTokens> encoder_input_tokens, bool return_encoder_output,
+                     std::optional<tb::LlmRequest::RequestIdType> client_id, executor::PriorityType priority,
+                     std::optional<at::Tensor> encoder_input_features,
+                     std::optional<tb::LlmRequest::SizeType32> encoder_output_length,
+                     std::optional<at::Tensor> cross_attention_mask, tb::LlmRequestType llm_request_type,
+                     std::optional<tb::LlmRequest::VecTokenExtraIds> input_token_extra_ids,
+                     tb::LlmRequest::SizeType32 num_return_sequences, std::optional<executor::EagleConfig> eagle_config,
+                     std::optional<at::Tensor> skip_cross_attn_blocks, bool return_perf_metrics,
+                     std::optional<executor::GuidedDecodingParams> guided_decoding_params,
+                     std::optional<tb::LlmRequest::SizeType32> language_adapter_uid,
+                     std::optional<tb::LlmRequest::MillisecondsType> allotted_time_ms,
+                     std::optional<executor::ContextPhaseParams> context_phase_params)
+                 {
+                     auto makeOptionalTensor = [](std::optional<at::Tensor> const& atTensor, bool unsqueeze = false)
+                     {
+                         std::optional<tb::LlmRequest::TensorPtr> tensorPtr = std::nullopt;
+                         if (atTensor)
+                         {
+                             tensorPtr = tr::TorchView::of(atTensor.value());
+                             if (unsqueeze)
+                             {
+                                 (*tensorPtr)->unsqueeze(0);
+                             }
+                         }
+                         return tensorPtr;
+                     };
+
+                     auto embedding_bias_tensor_ptr = makeOptionalTensor(embedding_bias, true);
+                     auto bad_words_list_tensor_ptr = makeOptionalTensor(bad_words_list, true);
+                     auto stop_words_list_tensor_ptr = makeOptionalTensor(stop_words_list, true);
+                     auto prompt_embedding_table_tensor_ptr = makeOptionalTensor(prompt_embedding_table);
+                     auto multimodal_embedding_tensor_ptr = makeOptionalTensor(multimodal_embedding);
+                     auto lora_weights_tensor_ptr = makeOptionalTensor(lora_weights);
+                     auto mrope_rotary_cos_sin_tensor_ptr = makeOptionalTensor(mrope_rotary_cos_sin);
+                     auto lora_config_tensor_ptr = makeOptionalTensor(lora_config);
+                     auto draft_logits_tensor_ptr = makeOptionalTensor(draft_logits);
+                     auto encoder_input_features_tensor_ptr = makeOptionalTensor(encoder_input_features);
+                     auto cross_attention_mask_tensor_ptr = makeOptionalTensor(cross_attention_mask);
+                     auto skip_cross_attn_blocks_tensor_ptr = makeOptionalTensor(skip_cross_attn_blocks);
+
+                     // 49 parameters
+                     return tb::LlmRequest{request_id, max_new_tokens, input_tokens, sampling_config, is_streaming,
+                         end_id, pad_id, embedding_bias_tensor_ptr, bad_words_list_tensor_ptr,
+                         stop_words_list_tensor_ptr, position_ids, prompt_embedding_table_tensor_ptr, prompt_vocab_size,
+                         multimodal_hashes, multimodal_positions, multimodal_lengths, multimodal_embedding_tensor_ptr,
+                         mrope_rotary_cos_sin_tensor_ptr, mrope_position_deltas, lora_task_id, lora_weights_tensor_ptr,
+                         lora_config_tensor_ptr, lookahead_config, kv_cache_retention_config, return_log_probs,
+                         return_context_logits, return_generation_logits, draft_tokens, draft_logits_tensor_ptr,
+                         exclude_input_from_output, logits_post_processor, apply_logits_post_processor_batched,
+                         encoder_input_tokens, return_encoder_output, client_id, priority,
+                         encoder_input_features_tensor_ptr, encoder_output_length, cross_attention_mask_tensor_ptr,
+                         llm_request_type, input_token_extra_ids, num_return_sequences, eagle_config,
+                         skip_cross_attn_blocks_tensor_ptr, return_perf_metrics, guided_decoding_params,
+                         language_adapter_uid, allotted_time_ms, context_phase_params};
+                 }),
+            py::arg("request_id"), py::arg("max_new_tokens"), py::arg("input_tokens"), py::arg("sampling_config"),
+            py::arg("is_streaming"), py::arg("end_id") = std::nullopt, py::arg("pad_id") = std::nullopt,
+            py::arg("embedding_bias") = std::nullopt, py::arg("bad_words_list") = std::nullopt,
+            py::arg("stop_words_list") = std::nullopt, py::arg("position_ids") = std::nullopt,
+            py::arg("prompt_embedding_table") = std::nullopt, py::arg("prompt_vocab_size") = std::nullopt,
+            py::arg("multimodal_hashes") = std::nullopt, py::arg("multimodal_positions") = std::nullopt,
+            py::arg("multimodal_lengths") = std::nullopt, py::arg("multimodal_embedding") = std::nullopt,
+            py::arg("mrope_rotary_cos_sin") = std::nullopt, py::arg("mrope_position_deltas") = std::nullopt,
+            py::arg("lora_task_id") = std::nullopt, py::arg("lora_weights") = std::nullopt,
+            py::arg("lora_config") = std::nullopt, py::arg("lookahead_config") = std::nullopt,
+            py::arg("kv_cache_retention_config") = std::nullopt, py::arg("return_log_probs") = false,
+            py::arg("return_context_logits") = false, py::arg("return_generation_logits") = false,
+            py::arg("draft_tokens") = std::nullopt, py::arg("draft_logits") = std::nullopt,
+            py::arg("exclude_input_from_output") = false, py::arg("logits_post_processor") = std::nullopt,
+            py::arg("apply_logits_post_processor_batched") = false, py::arg("encoder_input_tokens") = std::nullopt,
+            py::arg("return_encoder_output") = false, py::arg("client_id") = std::nullopt,
+            py::arg("priority") = executor::Request::kDefaultPriority, py::arg("encoder_input_features") = std::nullopt,
+            py::arg("encoder_output_len") = std::nullopt, py::arg("cross_attention_mask") = std::nullopt,
+            py::arg_v("llm_request_type", tb::LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION,
+                "LlmRequestType.LLMREQUEST_TYPE_CONTEXT_AND_GENERATION"),
+            py::arg("input_token_extra_ids") = std::nullopt, py::arg("num_return_sequences") = 1,
+            py::arg("eagle_config") = std::nullopt, py::arg("skip_cross_attn_blocks") = std::nullopt,
+            py::arg("return_perf_metrics") = false, py::arg("guided_decoding_params") = std::nullopt,
+            py::arg("language_adapter_uid") = std::nullopt, py::arg("allotted_time_ms") = std::nullopt,
+            py::arg("context_phase_params") = std::nullopt)
+        .def("validate", &tb::LlmRequest::validate, py::arg("max_input_len"), py::arg("max_seq_len"),
+            py::arg("max_draft_len"), py::arg("vocab_size_padded"), py::arg("max_endocer_input_len") = std::nullopt,
+            py::arg("enable_kv_cache_reuse") = false)
+        .def("create_response", &tb::LlmRequest::createResponse, py::arg("use_fast_logits") = false,
+            py::arg("mpi_world_rank") = 0)
+        .def("create_result", &tb::LlmRequest::createResult, py::arg("use_fast_logits") = false,
+            py::arg("mpi_world_rank") = 0)
+        .def("create_serialized_result",
+            [](tb::LlmRequest& self, bool use_fast_logits = false, int mpi_world_rank = 0)
+            {
+                std::vector<char> serialized_result;
+                bool is_final = false;
+                self.createSerializedResult(serialized_result, is_final, use_fast_logits, mpi_world_rank);
+                return std::make_tuple(py::bytes(serialized_result.data(), serialized_result.size()), is_final);
+            })
+        .def("move_prompt_embedding_table_to_gpu", &tb::LlmRequest::movePromptEmbeddingTableToGpu, py::arg("manager"))
+        .def("move_lora_weights_to_gpu", &tb::LlmRequest::moveLoraWeightsToGpu, py::arg("manager"))
+        .def("finish_by_reason", &tb::LlmRequest::finishByReason, py::arg("finish_reason"))
+        .def("set_first_scheduled_time", &tb::LlmRequest::setFirstScheduledTime)
+        .def("update_perf_metrics", &tb::LlmRequest::updatePerfMetrics, py::arg("iter_counter"));
+
+    py::classh<tb::SequenceSlotManager>(m, "SequenceSlotManager")
+        .def(py::init<tb::SequenceSlotManager::SlotIdType, uint64_t>(), py::arg("max_num_slots"),
+            py::arg("max_sequence_idle_microseconds"))
+        .def("get_sequence_slot", &tb::SequenceSlotManager::getSequenceSlot, py::arg("start_flag"),
+            py::arg("sequence_id"))
+        .def("free_sequence_slot", &tb::SequenceSlotManager::freeSequenceSlot, py::arg("sequence_id"))
+        .def("free_idle_sequence_slots", &tb::SequenceSlotManager::freeIdleSequenceSlots);
+
+    py::classh<tb::rnn_state_manager::RnnStateManager>(m, "RnnStateManager")
+        .def(py::init<tr::SizeType32, tr::ModelConfig, tr::WorldConfig, tr::BufferManager>(),
+            py::arg("max_num_sequences"), py::arg("model_config"), py::arg("world_config"), py::arg("buffer_manager"));
+
+    py::class_<tb::DecoderInputBuffers>(m, "DecoderInputBuffers")
+        .def(py::init<runtime::SizeType32, runtime::SizeType32, runtime::SizeType32, tr::BufferManager>(),
+            py::arg("max_num_sequences"), py::arg("max_batch_size"), py::arg("max_tokens_per_engine_step"),
+            py::arg("manager"))
+        .def_readwrite("setup_batch_slots", &tb::DecoderInputBuffers::setupBatchSlots)
+        .def_readwrite("setup_batch_slots_device", &tb::DecoderInputBuffers::setupBatchSlotsDevice)
+        .def_readwrite("fill_values", &tb::DecoderInputBuffers::fillValues)
+        .def_readwrite("fill_values_device", &tb::DecoderInputBuffers::fillValuesDevice)
+        .def_readwrite("inputs_ids", &tb::DecoderInputBuffers::inputsIds)
+        .def_readwrite("forward_batch_slots", &tb::DecoderInputBuffers::forwardBatchSlots)
+        .def_readwrite("logits", &tb::DecoderInputBuffers::logits);
+
+    py::class_<tb::DecoderOutputBuffers>(m, "DecoderOutputBuffers")
+        .def_readwrite("sequence_lengths_host", &tb::DecoderOutputBuffers::sequenceLengthsHost)
+        .def_readwrite("finished_sum_host", &tb::DecoderOutputBuffers::finishedSumHost)
+        .def_property_readonly("new_output_tokens_host",
+            [](tb::DecoderOutputBuffers& self) { return tr::Torch::tensor(self.newOutputTokensHost); })
+        .def_readwrite("cum_log_probs_host", &tb::DecoderOutputBuffers::cumLogProbsHost)
+        .def_readwrite("log_probs_host", &tb::DecoderOutputBuffers::logProbsHost)
+        .def_readwrite("finish_reasons_host", &tb::DecoderOutputBuffers::finishReasonsHost);
+
+    py::class_<tb::SlotDecoderBuffers>(m, "SlotDecoderBuffers")
+        .def(py::init<runtime::SizeType32, runtime::SizeType32, runtime::BufferManager const&>(),
+            py::arg("max_beam_width"), py::arg("max_seq_len"), py::arg("buffer_manager"))
+        .def_readwrite("output_ids", &tb::SlotDecoderBuffers::outputIds)
+        .def_readwrite("output_ids_host", &tb::SlotDecoderBuffers::outputIdsHost)
+        .def_readwrite("sequence_lengths_host", &tb::SlotDecoderBuffers::sequenceLengthsHost)
+        .def_readwrite("cum_log_probs", &tb::SlotDecoderBuffers::cumLogProbs)
+        .def_readwrite("cum_log_probs_host", &tb::SlotDecoderBuffers::cumLogProbsHost)
+        .def_readwrite("log_probs", &tb::SlotDecoderBuffers::logProbs)
+        .def_readwrite("log_probs_host", &tb::SlotDecoderBuffers::logProbsHost)
+        .def_readwrite("finish_reasons_host", &tb::SlotDecoderBuffers::finishReasonsHost);
+
+    py::class_<tb::MedusaBuffers>(m, "MedusaBuffers")
+        .def(py::init<runtime::SizeType32, runtime::SizeType32, runtime::BufferManager const&,
+                 runtime::ModelConfig const&, runtime::WorldConfig const&, executor::DecodingConfig const&,
+                 runtime::TllmRuntime const&>(),
+            py::arg("max_beam_width"), py::arg("max_seq_len"), py::arg("buffer_manager"), py::arg("model_config"),
+            py::arg("world_config"), py::arg("decoding_config"), py::arg("runtime"));
+
+    m.def(
+        "add_new_tokens_to_requests",
+        [](std::vector<std::shared_ptr<tb::LlmRequest>>& requests,
+            std::vector<tb::LlmRequest::TokenIdType> const& tokens, int beam_idx)
+        {
+            TLLM_CHECK_WITH_INFO(requests.size() == tokens.size(), "Expected the same number of requests and tokens.");
+
+            for (int i = 0; i < requests.size(); ++i)
+            {
+                requests[i]->addNewToken(tokens[i], beam_idx);
+            }
+        },
+        py::arg("requests"), py::arg("tokens"), py::arg("beam_idx"),
+        "Add new tokens to multiple LLM requests. The tokens vector should contain tokens for beam beam_idx of all "
+        "requests in order.");
+
+    m.def(
+        "make_decoding_batch_input",
+        [](std::vector<std::shared_ptr<tb::LlmRequest>>& contextRequests,
+            std::vector<std::shared_ptr<tb::LlmRequest>>& genRequests, tr::ITensor::SharedPtr logits, int beamWidth,
+            std::vector<int> const& numContextLogitsPrefixSum, tb::DecoderInputBuffers const& decoderInputBuffers,
+            runtime::decoder::DecoderState& decoderState, tr::BufferManager const& manager)
+        {
+            std::vector<int> activeSlots;
+            std::vector<int> generationSteps;
+            std::vector<std::vector<tr::ITensor::SharedConstPtr>> logitsVec = {{}};
+
+            for (int i = 0; i < contextRequests.size(); ++i)
+            {
+                if (contextRequests[i]->isLastContextChunk())
+                {
+                    activeSlots.push_back(*contextRequests[i]->mSeqSlot);
+                    generationSteps.push_back(contextRequests[i]->getDecodingIter());
+                    auto contextLogitsOffset = numContextLogitsPrefixSum[i + 1] - 1;
+                    tr::ITensor::SharedPtr logitsView = ITensor::slice(logits, contextLogitsOffset, 1);
+
+                    if (beamWidth > 1)
+                    {
+                        // Tile logits of context requests
+                        auto const logitsShape = logitsView->getShape();
+                        auto const logitsType = logitsView->getDataType();
+                        auto decoderLogits = manager.gpu(ITensor::makeShape({beamWidth, logitsShape.d[1]}), logitsType);
+                        tensorrt_llm::runtime::kernels::tileTensor(
+                            *decoderLogits, *logitsView, beamWidth, manager.getStream());
+                        decoderLogits->unsqueeze(0);
+                        logitsVec[0].push_back(std::move(decoderLogits));
+                    }
+                    else
+                    {
+                        logitsView->unsqueeze(1);
+                        logitsVec[0].push_back(std::move(logitsView));
+                    }
+                }
+            }
+
+            auto genLogitsOffset = numContextLogitsPrefixSum.back();
+            for (int i = 0; i < genRequests.size(); ++i)
+            {
+                if (genRequests[i]->isGenerationInProgressState())
+                {
+                    activeSlots.push_back(*genRequests[i]->mSeqSlot);
+                    generationSteps.push_back(genRequests[i]->getDecodingIter());
+
+                    auto logitsOffset = genLogitsOffset + i * beamWidth;
+                    auto numberOfLogits = beamWidth;
+                    tr::ITensor::SharedPtr logitsView = ITensor::slice(logits, logitsOffset, numberOfLogits);
+                    logitsView->unsqueeze(0);
+                    logitsVec[0].push_back(std::move(logitsView));
+                }
+            }
+
+            auto& batchSlots = decoderInputBuffers.forwardBatchSlots;
+            batchSlots[0]->resize(activeSlots.size());
+            auto batchSlotsRange = tr::BufferRange<SizeType32>(*batchSlots[0]);
+            for (int i = 0; i < activeSlots.size(); ++i)
+            {
+                batchSlotsRange[i] = activeSlots[i];
+            }
+
+            auto decodingInput = std::make_unique<tr::decoder_batch::Input>(logitsVec, 1);
+            decodingInput->batchSlots = batchSlots;
+
+            auto const maxBeamWidth = decoderState.getMaxBeamWidth();
+            if (maxBeamWidth > 1)
+            {
+                // For Variable-Beam-Width-Search
+                decoderState.getJointDecodingInput().generationSteps = generationSteps;
+            }
+
+            return decodingInput;
+        },
+        py::arg("context_requests"), py::arg("generation_requests"), py::arg("logits"), py::arg("beam_width"),
+        py::arg("num_context_logits_prefix_sum"), py::arg("decoder_input_buffers"), py::arg("decoder_state"),
+        py::arg("buffer_manager"), "Make decoding batch input.");
+}
+
+} // namespace tensorrt_llm::pybind::batch_manager

--- a/cpp/tensorrt_llm/nanobind/batch_manager/bindings.h
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/bindings.h
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "tensorrt_llm/pybind/common/customCasters.h"
+#include <pybind11/pybind11.h>
+
+namespace tensorrt_llm::pybind::batch_manager
+{
+
+void initBindings(pybind11::module_& m);
+
+}

--- a/cpp/tensorrt_llm/nanobind/batch_manager/bindings.h
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/bindings.h
@@ -17,12 +17,11 @@
 
 #pragma once
 
-#include "tensorrt_llm/pybind/common/customCasters.h"
-#include <pybind11/pybind11.h>
+#include "tensorrt_llm/nanobind/common/customCasters.h"
 
-namespace tensorrt_llm::pybind::batch_manager
+namespace tensorrt_llm::nanobind::batch_manager
 {
 
-void initBindings(pybind11::module_& m);
+void initBindings(nb::module_& m);
 
 }

--- a/cpp/tensorrt_llm/nanobind/batch_manager/buffers.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/buffers.cpp
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "buffers.h"
+
+#include "tensorrt_llm/batch_manager/kvCacheManager.h"
+#include "tensorrt_llm/batch_manager/runtimeBuffers.h"
+#include "tensorrt_llm/batch_manager/transformerBuffers.h"
+
+#include <ATen/ATen.h>
+#include <pybind11/functional.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <torch/extension.h>
+
+namespace py = pybind11;
+namespace tb = tensorrt_llm::batch_manager;
+namespace tr = tensorrt_llm::runtime;
+
+using tr::SizeType32;
+
+namespace tensorrt_llm::pybind::batch_manager
+{
+
+void Buffers::initBindings(pybind11::module_& m)
+{
+    py::class_<tb::TransformerBuffers>(m, "TransformerBuffers")
+        .def(py::init<SizeType32, SizeType32, std::vector<SizeType32> const&, SizeType32, SizeType32,
+                 runtime::TllmRuntime const&, runtime::ModelConfig const&, runtime::WorldConfig const&>(),
+            py::arg("max_batch_size"), py::arg("max_beam_width"), py::arg("max_attention_window_vec"),
+            py::arg("max_attention_window"), py::arg("sink_token_len"), py::arg("runtime"), py::arg("model_config"),
+            py::arg("world_config"))
+        .def("reshape", &tb::TransformerBuffers::reshape, py::arg("num_sequences"), py::arg("num_input_tokens"))
+        .def("reshape_kv_tensors", &tb::TransformerBuffers::reshapeKvTensors, py::arg("max_batch_size"),
+            py::arg("max_beam_width"), py::arg("max_blocks_per_seq"), py::arg("kv_cache_type"), py::arg("num_pools"),
+            py::arg("buffer_manager"))
+        .def("get_buffers", &tb::TransformerBuffers::getBuffers, py::arg("input_buffers"), py::arg("output_buffers"),
+            py::arg("model_config"))
+        .def("copy_position_ids", &tb::TransformerBuffers::copyPositionIds, py::arg("runtime"),
+            py::arg("position_ids_host"), py::arg("is_chat_glm"), py::arg("decoder_position_ids"))
+        .def("copy_kv_block_offsets", &tb::TransformerBuffers::copyKvBlockOffsets, py::arg("context_requests"),
+            py::arg("gen_requests"), py::arg("kv_cache_manager"), py::arg("cross_kv_cache_manager"),
+            py::arg("buffer_manager"))
+        .def("copy_cache_indirection", &tb::TransformerBuffers::copyCacheIndirection, py::arg("gen_requests"),
+            py::arg("decoder_cache_indirection_output"), py::arg("runtime"))
+        .def_readwrite("past_key_value_lengths", &tb::TransformerBuffers::pastKeyValueLengths)
+        .def_readwrite("position_ids", &tb::TransformerBuffers::positionIds)
+        .def_readwrite("max_attention_windows", &tb::TransformerBuffers::maxAttentionWindows)
+        .def_readwrite("sink_token_lengths", &tb::TransformerBuffers::sinkTokenLengths)
+        .def_readwrite("cache_indirection", &tb::TransformerBuffers::cacheIndirection)
+        .def_readwrite("kv_cache_block_offsets_host", &tb::TransformerBuffers::kvCacheBlockOffsetsHost)
+        .def_readwrite("kv_cache_block_offsets_device", &tb::TransformerBuffers::kvCacheBlockOffsetsDevice)
+        .def_readwrite("cross_kv_cache_block_pool_pointers", &tb::TransformerBuffers::crossKvCacheBlockPoolPointers)
+        .def_readwrite("cross_kv_cache_block_offsets_host", &tb::TransformerBuffers::crossKvCacheBlockOffsetsHost)
+        .def_readwrite("cross_kv_cache_block_offsets_device", &tb::TransformerBuffers::crossKvCacheBlockOffsetsDevice)
+        .def_readwrite("cache_indir_batched_copy_src_offsets", &tb::TransformerBuffers::cacheIndirBatchedCopySrcOffsets)
+        .def_readwrite("cache_indir_batched_copy_dst_offsets", &tb::TransformerBuffers::cacheIndirBatchedCopyDstOffsets)
+        .def_readwrite("cache_indir_batched_copy_sizes", &tb::TransformerBuffers::cacheIndirBatchedCopySizes)
+        .def_readwrite("fill_values_alt", &tb::TransformerBuffers::fillValuesAlt)
+        .def_readwrite("fill_values_alt_device", &tb::TransformerBuffers::fillValuesAltDevice)
+        .def_readwrite("seq_slots_alt", &tb::TransformerBuffers::seqSlotsAlt)
+        .def_readwrite("seq_slots_alt_device", &tb::TransformerBuffers::seqSlotsAltDevice);
+
+    py::classh<tb::RuntimeBuffers>(m, "RuntimeBuffers")
+        .def(py::init<SizeType32, SizeType32, std::vector<SizeType32> const&, SizeType32, SizeType32,
+                 runtime::TllmRuntime const&, runtime::ModelConfig const&, runtime::WorldConfig const&,
+                 executor::DecodingConfig const&, bool, std::optional<SizeType32>>(),
+            py::arg("max_batch_size"), py::arg("max_beam_width"), py::arg("max_attention_window_vec"),
+            py::arg("max_attention_window"), py::arg("sink_token_len"), py::arg("runtime"), py::arg("model_config"),
+            py::arg("world_config"), py::arg("decoding_config"), py::arg("gather_generation_logits"),
+            py::arg("max_num_tokens") = std::nullopt)
+        .def_readwrite("transformer_buffers", &tb::RuntimeBuffers::transformerBuffers)
+        .def_readwrite("num_context_logits", &tb::RuntimeBuffers::numContextLogits)
+        .def_readwrite("cache_indir_decoder_io_batched_copy_src_offsets",
+            &tb::RuntimeBuffers::cacheIndirDecoderIOBatchedCopySrcOffsets)
+        .def_readwrite("cache_indir_decoder_io_batched_copy_dst_offsets",
+            &tb::RuntimeBuffers::cacheIndirDecoderIOBatchedCopyDstOffsets)
+        .def_readwrite(
+            "cache_indir_decoder_io_batched_copy_sizes", &tb::RuntimeBuffers::cacheIndirDecoderIOBatchedCopySizes)
+        .def_readwrite("logits", &tb::RuntimeBuffers::logits)
+        .def_readwrite("seq_slots", &tb::RuntimeBuffers::seqSlots)
+        .def_readwrite("seq_slots_device", &tb::RuntimeBuffers::seqSlotsDevice)
+        .def_readwrite("sorted_seq_slots", &tb::RuntimeBuffers::sortedSeqSlots)
+        .def_readwrite("seq_slot_remapping_host", &tb::RuntimeBuffers::seqSlotRemappingHost)
+        .def_readwrite("seq_slot_remapping_device", &tb::RuntimeBuffers::seqSlotRemappingDevice)
+        .def_readwrite("cache_indir_decoder_io_batched_copy_src_offsets_slice_device",
+            &tb::RuntimeBuffers::mCacheIndirDecoderIOBatchedCopySrcOffsetsSliceDevice)
+        .def_readwrite("cache_indir_decoder_io_batched_copy_dst_offsets_slice_device",
+            &tb::RuntimeBuffers::mCacheIndirDecoderIOBatchedCopyDstOffsetsSliceDevice)
+        .def_readwrite("cache_indir_decoder_io_batched_copy_copy_sizes_device",
+            &tb::RuntimeBuffers::mCacheIndirDecoderIOBatchedCopyCopySizesDevice);
+}
+} // namespace tensorrt_llm::pybind::batch_manager

--- a/cpp/tensorrt_llm/nanobind/batch_manager/buffers.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/buffers.cpp
@@ -22,87 +22,89 @@
 #include "tensorrt_llm/batch_manager/transformerBuffers.h"
 
 #include <ATen/ATen.h>
-#include <pybind11/functional.h>
-#include <pybind11/operators.h>
-#include <pybind11/stl.h>
-#include <pybind11/stl_bind.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/unique_ptr.h>
+#include <nanobind/stl/vector.h>
 #include <torch/extension.h>
 
-namespace py = pybind11;
+namespace nb = nanobind;
 namespace tb = tensorrt_llm::batch_manager;
 namespace tr = tensorrt_llm::runtime;
 
 using tr::SizeType32;
 
-namespace tensorrt_llm::pybind::batch_manager
+namespace tensorrt_llm::nanobind::batch_manager
 {
 
-void Buffers::initBindings(pybind11::module_& m)
+void Buffers::initBindings(nb::module_& m)
 {
-    py::class_<tb::TransformerBuffers>(m, "TransformerBuffers")
-        .def(py::init<SizeType32, SizeType32, std::vector<SizeType32> const&, SizeType32, SizeType32,
+    nb::class_<tb::TransformerBuffers>(m, "TransformerBuffers")
+        .def(nb::init<SizeType32, SizeType32, std::vector<SizeType32> const&, SizeType32, SizeType32,
                  runtime::TllmRuntime const&, runtime::ModelConfig const&, runtime::WorldConfig const&>(),
-            py::arg("max_batch_size"), py::arg("max_beam_width"), py::arg("max_attention_window_vec"),
-            py::arg("max_attention_window"), py::arg("sink_token_len"), py::arg("runtime"), py::arg("model_config"),
-            py::arg("world_config"))
-        .def("reshape", &tb::TransformerBuffers::reshape, py::arg("num_sequences"), py::arg("num_input_tokens"))
-        .def("reshape_kv_tensors", &tb::TransformerBuffers::reshapeKvTensors, py::arg("max_batch_size"),
-            py::arg("max_beam_width"), py::arg("max_blocks_per_seq"), py::arg("kv_cache_type"), py::arg("num_pools"),
-            py::arg("buffer_manager"))
-        .def("get_buffers", &tb::TransformerBuffers::getBuffers, py::arg("input_buffers"), py::arg("output_buffers"),
-            py::arg("model_config"))
-        .def("copy_position_ids", &tb::TransformerBuffers::copyPositionIds, py::arg("runtime"),
-            py::arg("position_ids_host"), py::arg("is_chat_glm"), py::arg("decoder_position_ids"))
-        .def("copy_kv_block_offsets", &tb::TransformerBuffers::copyKvBlockOffsets, py::arg("context_requests"),
-            py::arg("gen_requests"), py::arg("kv_cache_manager"), py::arg("cross_kv_cache_manager"),
-            py::arg("buffer_manager"))
-        .def("copy_cache_indirection", &tb::TransformerBuffers::copyCacheIndirection, py::arg("gen_requests"),
-            py::arg("decoder_cache_indirection_output"), py::arg("runtime"))
-        .def_readwrite("past_key_value_lengths", &tb::TransformerBuffers::pastKeyValueLengths)
-        .def_readwrite("position_ids", &tb::TransformerBuffers::positionIds)
-        .def_readwrite("max_attention_windows", &tb::TransformerBuffers::maxAttentionWindows)
-        .def_readwrite("sink_token_lengths", &tb::TransformerBuffers::sinkTokenLengths)
-        .def_readwrite("cache_indirection", &tb::TransformerBuffers::cacheIndirection)
-        .def_readwrite("kv_cache_block_offsets_host", &tb::TransformerBuffers::kvCacheBlockOffsetsHost)
-        .def_readwrite("kv_cache_block_offsets_device", &tb::TransformerBuffers::kvCacheBlockOffsetsDevice)
-        .def_readwrite("cross_kv_cache_block_pool_pointers", &tb::TransformerBuffers::crossKvCacheBlockPoolPointers)
-        .def_readwrite("cross_kv_cache_block_offsets_host", &tb::TransformerBuffers::crossKvCacheBlockOffsetsHost)
-        .def_readwrite("cross_kv_cache_block_offsets_device", &tb::TransformerBuffers::crossKvCacheBlockOffsetsDevice)
-        .def_readwrite("cache_indir_batched_copy_src_offsets", &tb::TransformerBuffers::cacheIndirBatchedCopySrcOffsets)
-        .def_readwrite("cache_indir_batched_copy_dst_offsets", &tb::TransformerBuffers::cacheIndirBatchedCopyDstOffsets)
-        .def_readwrite("cache_indir_batched_copy_sizes", &tb::TransformerBuffers::cacheIndirBatchedCopySizes)
-        .def_readwrite("fill_values_alt", &tb::TransformerBuffers::fillValuesAlt)
-        .def_readwrite("fill_values_alt_device", &tb::TransformerBuffers::fillValuesAltDevice)
-        .def_readwrite("seq_slots_alt", &tb::TransformerBuffers::seqSlotsAlt)
-        .def_readwrite("seq_slots_alt_device", &tb::TransformerBuffers::seqSlotsAltDevice);
+            nb::arg("max_batch_size"), nb::arg("max_beam_width"), nb::arg("max_attention_window_vec"),
+            nb::arg("max_attention_window"), nb::arg("sink_token_len"), nb::arg("runtime"), nb::arg("model_config"),
+            nb::arg("world_config"))
+        .def("reshape", &tb::TransformerBuffers::reshape, nb::arg("num_sequences"), nb::arg("num_input_tokens"))
+        .def("reshape_kv_tensors", &tb::TransformerBuffers::reshapeKvTensors, nb::arg("max_batch_size"),
+            nb::arg("max_beam_width"), nb::arg("max_blocks_per_seq"), nb::arg("kv_cache_type"), nb::arg("num_pools"),
+            nb::arg("buffer_manager"))
+        .def("get_buffers", &tb::TransformerBuffers::getBuffers, nb::arg("input_buffers"), nb::arg("output_buffers"),
+            nb::arg("model_config"))
+        .def("copy_position_ids", &tb::TransformerBuffers::copyPositionIds, nb::arg("runtime"),
+            nb::arg("position_ids_host"), nb::arg("is_chat_glm"), nb::arg("decoder_position_ids"))
+        .def("copy_kv_block_offsets", &tb::TransformerBuffers::copyKvBlockOffsets, nb::arg("context_requests"),
+            nb::arg("gen_requests"), nb::arg("kv_cache_manager"), nb::arg("cross_kv_cache_manager"),
+            nb::arg("buffer_manager"))
+        .def("copy_cache_indirection", &tb::TransformerBuffers::copyCacheIndirection, nb::arg("gen_requests"),
+            nb::arg("decoder_cache_indirection_output"), nb::arg("runtime"))
+        .def_rw("past_key_value_lengths", &tb::TransformerBuffers::pastKeyValueLengths)
+        .def_rw("position_ids", &tb::TransformerBuffers::positionIds)
+        .def_rw("max_attention_windows", &tb::TransformerBuffers::maxAttentionWindows)
+        .def_rw("sink_token_lengths", &tb::TransformerBuffers::sinkTokenLengths)
+        .def_rw("cache_indirection", &tb::TransformerBuffers::cacheIndirection)
+        .def_rw("kv_cache_block_offsets_host", &tb::TransformerBuffers::kvCacheBlockOffsetsHost)
+        .def_rw("kv_cache_block_offsets_device", &tb::TransformerBuffers::kvCacheBlockOffsetsDevice)
+        .def_rw("cross_kv_cache_block_pool_pointers", &tb::TransformerBuffers::crossKvCacheBlockPoolPointers)
+        .def_rw("cross_kv_cache_block_offsets_host", &tb::TransformerBuffers::crossKvCacheBlockOffsetsHost)
+        .def_rw("cross_kv_cache_block_offsets_device", &tb::TransformerBuffers::crossKvCacheBlockOffsetsDevice)
+        .def_rw("cache_indir_batched_copy_src_offsets", &tb::TransformerBuffers::cacheIndirBatchedCopySrcOffsets)
+        .def_rw("cache_indir_batched_copy_dst_offsets", &tb::TransformerBuffers::cacheIndirBatchedCopyDstOffsets)
+        .def_rw("cache_indir_batched_copy_sizes", &tb::TransformerBuffers::cacheIndirBatchedCopySizes)
+        .def_rw("fill_values_alt", &tb::TransformerBuffers::fillValuesAlt)
+        .def_rw("fill_values_alt_device", &tb::TransformerBuffers::fillValuesAltDevice)
+        .def_rw("seq_slots_alt", &tb::TransformerBuffers::seqSlotsAlt)
+        .def_rw("seq_slots_alt_device", &tb::TransformerBuffers::seqSlotsAltDevice);
 
-    py::classh<tb::RuntimeBuffers>(m, "RuntimeBuffers")
-        .def(py::init<SizeType32, SizeType32, std::vector<SizeType32> const&, SizeType32, SizeType32,
+    nb::class_<tb::RuntimeBuffers>(m, "RuntimeBuffers")
+        .def(nb::init<SizeType32, SizeType32, std::vector<SizeType32> const&, SizeType32, SizeType32,
                  runtime::TllmRuntime const&, runtime::ModelConfig const&, runtime::WorldConfig const&,
                  executor::DecodingConfig const&, bool, std::optional<SizeType32>>(),
-            py::arg("max_batch_size"), py::arg("max_beam_width"), py::arg("max_attention_window_vec"),
-            py::arg("max_attention_window"), py::arg("sink_token_len"), py::arg("runtime"), py::arg("model_config"),
-            py::arg("world_config"), py::arg("decoding_config"), py::arg("gather_generation_logits"),
-            py::arg("max_num_tokens") = std::nullopt)
-        .def_readwrite("transformer_buffers", &tb::RuntimeBuffers::transformerBuffers)
-        .def_readwrite("num_context_logits", &tb::RuntimeBuffers::numContextLogits)
-        .def_readwrite("cache_indir_decoder_io_batched_copy_src_offsets",
+            nb::arg("max_batch_size"), nb::arg("max_beam_width"), nb::arg("max_attention_window_vec"),
+            nb::arg("max_attention_window"), nb::arg("sink_token_len"), nb::arg("runtime"), nb::arg("model_config"),
+            nb::arg("world_config"), nb::arg("decoding_config"), nb::arg("gather_generation_logits"),
+            nb::arg("max_num_tokens") = std::nullopt)
+        // todo: test this
+        .def_prop_rw(
+            "transformer_buffers", [](tb::RuntimeBuffers& self) { return self.transformerBuffers.get(); },
+            [](tb::RuntimeBuffers& self, tb::TransformerBuffers* val) { self.transformerBuffers.reset(val); })
+        .def_rw("num_context_logits", &tb::RuntimeBuffers::numContextLogits)
+        .def_rw("cache_indir_decoder_io_batched_copy_src_offsets",
             &tb::RuntimeBuffers::cacheIndirDecoderIOBatchedCopySrcOffsets)
-        .def_readwrite("cache_indir_decoder_io_batched_copy_dst_offsets",
+        .def_rw("cache_indir_decoder_io_batched_copy_dst_offsets",
             &tb::RuntimeBuffers::cacheIndirDecoderIOBatchedCopyDstOffsets)
-        .def_readwrite(
-            "cache_indir_decoder_io_batched_copy_sizes", &tb::RuntimeBuffers::cacheIndirDecoderIOBatchedCopySizes)
-        .def_readwrite("logits", &tb::RuntimeBuffers::logits)
-        .def_readwrite("seq_slots", &tb::RuntimeBuffers::seqSlots)
-        .def_readwrite("seq_slots_device", &tb::RuntimeBuffers::seqSlotsDevice)
-        .def_readwrite("sorted_seq_slots", &tb::RuntimeBuffers::sortedSeqSlots)
-        .def_readwrite("seq_slot_remapping_host", &tb::RuntimeBuffers::seqSlotRemappingHost)
-        .def_readwrite("seq_slot_remapping_device", &tb::RuntimeBuffers::seqSlotRemappingDevice)
-        .def_readwrite("cache_indir_decoder_io_batched_copy_src_offsets_slice_device",
+        .def_rw("cache_indir_decoder_io_batched_copy_sizes", &tb::RuntimeBuffers::cacheIndirDecoderIOBatchedCopySizes)
+        .def_rw("logits", &tb::RuntimeBuffers::logits)
+        .def_rw("seq_slots", &tb::RuntimeBuffers::seqSlots)
+        .def_rw("seq_slots_device", &tb::RuntimeBuffers::seqSlotsDevice)
+        .def_rw("sorted_seq_slots", &tb::RuntimeBuffers::sortedSeqSlots)
+        .def_rw("seq_slot_remapping_host", &tb::RuntimeBuffers::seqSlotRemappingHost)
+        .def_rw("seq_slot_remapping_device", &tb::RuntimeBuffers::seqSlotRemappingDevice)
+        .def_rw("cache_indir_decoder_io_batched_copy_src_offsets_slice_device",
             &tb::RuntimeBuffers::mCacheIndirDecoderIOBatchedCopySrcOffsetsSliceDevice)
-        .def_readwrite("cache_indir_decoder_io_batched_copy_dst_offsets_slice_device",
+        .def_rw("cache_indir_decoder_io_batched_copy_dst_offsets_slice_device",
             &tb::RuntimeBuffers::mCacheIndirDecoderIOBatchedCopyDstOffsetsSliceDevice)
-        .def_readwrite("cache_indir_decoder_io_batched_copy_copy_sizes_device",
+        .def_rw("cache_indir_decoder_io_batched_copy_copy_sizes_device",
             &tb::RuntimeBuffers::mCacheIndirDecoderIOBatchedCopyCopySizesDevice);
 }
-} // namespace tensorrt_llm::pybind::batch_manager
+} // namespace tensorrt_llm::nanobind::batch_manager

--- a/cpp/tensorrt_llm/nanobind/batch_manager/buffers.h
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/buffers.h
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "tensorrt_llm/pybind/common/customCasters.h"
+#include <pybind11/pybind11.h>
+
+namespace tensorrt_llm::pybind::batch_manager
+{
+class Buffers
+{
+public:
+    static void initBindings(pybind11::module_& m);
+};
+} // namespace tensorrt_llm::pybind::batch_manager

--- a/cpp/tensorrt_llm/nanobind/batch_manager/buffers.h
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/buffers.h
@@ -17,14 +17,13 @@
 
 #pragma once
 
-#include "tensorrt_llm/pybind/common/customCasters.h"
-#include <pybind11/pybind11.h>
+#include "tensorrt_llm/nanobind/common/customCasters.h"
 
-namespace tensorrt_llm::pybind::batch_manager
+namespace tensorrt_llm::nanobind::batch_manager
 {
 class Buffers
 {
 public:
-    static void initBindings(pybind11::module_& m);
+    static void initBindings(nb::module_& m);
 };
-} // namespace tensorrt_llm::pybind::batch_manager
+} // namespace tensorrt_llm::nanobind::batch_manager

--- a/cpp/tensorrt_llm/nanobind/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/cacheTransceiver.cpp
@@ -1,0 +1,106 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cacheTransceiver.h"
+#include "tensorrt_llm/batch_manager/cacheTransceiver.h"
+#include "tensorrt_llm/batch_manager/kvCacheManager.h"
+#include "tensorrt_llm/executor/executor.h"
+#include <ATen/ATen.h>
+#include <pybind11/functional.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <torch/extension.h>
+
+using SizeType32 = tensorrt_llm::runtime::SizeType32;
+
+namespace tb = tensorrt_llm::batch_manager;
+
+namespace
+{
+
+class PyCacheTransceiver : public tb::BaseCacheTransceiver
+{
+public:
+    // using BaseCacheTransceiver::BaseCacheTransceiver; // Inherit constructors
+
+    void respondAndSendAsync(tb::LlmRequest* llmRequest) override
+    {
+        PYBIND11_OVERLOAD_PURE(void, tb::BaseCacheTransceiver, respondAndSendAsync, llmRequest);
+    }
+
+    void requestAndReceiveSync(tb::LlmRequest* llmRequest) override
+    {
+        PYBIND11_OVERLOAD_PURE(void, tb::BaseCacheTransceiver, requestAndReceiveSync, llmRequest);
+    }
+
+    void requestAndReceiveAsync(tb::LlmRequest* llmRequest) override
+    {
+        PYBIND11_OVERLOAD_PURE(void, tb::BaseCacheTransceiver, requestAndReceiveAsync, llmRequest);
+    }
+
+    void checkContextTransferStatus(std::optional<int> const& atLeastRequestNum = std::nullopt) override
+    {
+        PYBIND11_OVERLOAD_PURE(void, tb::BaseCacheTransceiver, checkContextTransferStatus, atLeastRequestNum);
+    }
+
+    void checkGenTransferStatus(std::optional<int> const& atLeastRequestNum = std::nullopt) override
+    {
+        PYBIND11_OVERLOAD_PURE(void, tb::BaseCacheTransceiver, checkGenTransferStatus, atLeastRequestNum);
+    }
+
+    bool checkGenTransferComplete() const override
+    {
+        PYBIND11_OVERLOAD_PURE(bool, tb::BaseCacheTransceiver, checkGenTransferComplete);
+    }
+};
+} // namespace
+
+void tb::CacheTransceiverBindings::initBindings(py::module_& m)
+{
+    py::classh<tb::BaseCacheTransceiver, PyCacheTransceiver>(m, "BaseCacheTransceiver")
+        .def("respond_and_send_async", &BaseCacheTransceiver::respondAndSendAsync)
+        .def("request_and_receive_sync", &BaseCacheTransceiver::requestAndReceiveSync)
+        .def("request_and_receive_async", &BaseCacheTransceiver::requestAndReceiveAsync)
+        .def("check_context_transfer_status", &BaseCacheTransceiver::checkContextTransferStatus)
+        .def("check_gen_transfer_status", &BaseCacheTransceiver::checkGenTransferStatus)
+        .def("check_gen_transfer_complete", &BaseCacheTransceiver::checkGenTransferComplete);
+
+    py::enum_<tb::CacheTransceiver::CommType>(m, "CommType")
+        .value("UNKNOWN", tb::CacheTransceiver::CommType::UNKNOWN)
+        .value("MPI", tb::CacheTransceiver::CommType::MPI)
+        .value("UCX", tb::CacheTransceiver::CommType::UCX)
+        .value("NIXL", tb::CacheTransceiver::CommType::NIXL);
+
+    py::enum_<executor::kv_cache::CacheState::AttentionType>(m, "AttentionType")
+        .value("DEFAULT", executor::kv_cache::CacheState::AttentionType::kDEFAULT)
+        .value("MLA", executor::kv_cache::CacheState::AttentionType::kMLA);
+
+    py::classh<tb::CacheTransceiver, tb::BaseCacheTransceiver>(m, "CacheTransceiver")
+        .def(py::init<tb::kv_cache_manager::BaseKVCacheManager*, tb::CacheTransceiver::CommType,
+                 std::vector<SizeType32>, SizeType32, SizeType32, runtime::WorldConfig, nvinfer1::DataType,
+                 executor::kv_cache::CacheState::AttentionType, std::optional<executor::CacheTransceiverConfig>>(),
+            py::arg("cache_manager"), py::arg("comm_type"), py::arg("num_kv_heads_per_layer"), py::arg("size_per_head"),
+            py::arg("tokens_per_block"), py::arg("world_config"), py::arg("dtype"), py::arg("attention_type"),
+            py::arg("cache_transceiver_config") = std::nullopt);
+
+    py::class_<tb::kv_cache_manager::CacheTransBufferManager>(m, "CacheTransBufferManager")
+        .def(py::init<tb::kv_cache_manager::BaseKVCacheManager*, std::optional<size_t>>(), py::arg("cache_manager"),
+            py::arg("max_num_tokens") = std::nullopt)
+        .def_static("pre_alloc_buffer_size", &tb::kv_cache_manager::CacheTransBufferManager::preAllocBufferSize,
+            py::arg("max_num_tokens") = std::nullopt);
+}

--- a/cpp/tensorrt_llm/nanobind/batch_manager/cacheTransceiver.h
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/cacheTransceiver.h
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "tensorrt_llm/pybind/common/customCasters.h"
+#include <pybind11/pybind11.h>
+
+namespace tensorrt_llm::batch_manager
+{
+class CacheTransceiverBindings
+{
+public:
+    static void initBindings(pybind11::module_& m);
+};
+} // namespace tensorrt_llm::batch_manager

--- a/cpp/tensorrt_llm/nanobind/batch_manager/cacheTransceiver.h
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/cacheTransceiver.h
@@ -17,14 +17,13 @@
 
 #pragma once
 
-#include "tensorrt_llm/pybind/common/customCasters.h"
-#include <pybind11/pybind11.h>
+#include "tensorrt_llm/nanobind/common/customCasters.h"
 
 namespace tensorrt_llm::batch_manager
 {
 class CacheTransceiverBindings
 {
 public:
-    static void initBindings(pybind11::module_& m);
+    static void initBindings(nb::module_& m);
 };
 } // namespace tensorrt_llm::batch_manager

--- a/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.cpp
@@ -18,21 +18,29 @@
 #include "kvCacheManager.h"
 #include "tensorrt_llm/batch_manager/kvCacheManager.h"
 #include "tensorrt_llm/batch_manager/peftCacheManager.h"
-#include "tensorrt_llm/pybind/common/bindTypes.h"
+#include "tensorrt_llm/nanobind/common/bindTypes.h"
 #include "tensorrt_llm/runtime/torch.h"
 #include "tensorrt_llm/runtime/torchView.h"
 
 #include <ATen/ATen.h>
-#include <pybind11/functional.h>
-#include <pybind11/operators.h>
-#include <pybind11/stl.h>
-#include <pybind11/stl_bind.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/operators.h>
+#include <nanobind/stl/bind_vector.h>
+#include <nanobind/stl/chrono.h>
+#include <nanobind/stl/map.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/tuple.h>
+#include <nanobind/stl/unique_ptr.h>
+#include <nanobind/stl/vector.h>
+#include <nanobind/trampoline.h>
 #include <torch/extension.h>
 
 namespace tb = tensorrt_llm::batch_manager;
 namespace tbk = tensorrt_llm::batch_manager::kv_cache_manager;
 namespace tr = tensorrt_llm::runtime;
-namespace py = pybind11;
+namespace nb = nanobind;
 using BlockKey = tbk::BlockKey;
 using VecUniqueTokens = tensorrt_llm::runtime::VecUniqueTokens;
 using SizeType32 = tensorrt_llm::runtime::SizeType32;
@@ -54,185 +62,176 @@ std::optional<tensorrt_llm::runtime::ITensor::UniquePtr> from_torch(std::optiona
 class PyKvCacheManager : public tbk::BaseKVCacheManager
 {
 public:
+    NB_TRAMPOLINE(tbk::BaseKVCacheManager, 28);
+
     // using BaseKVCacheManager::BaseKVCacheManager; // Inherit constructors
     void allocatePools(bool useUvm = false) override
     {
-        PYBIND11_OVERLOAD_PURE(void, tbk::BaseKVCacheManager, allocatePools, useUvm);
+        NB_OVERRIDE_PURE(allocatePools, useUvm);
     }
 
     void releasePools() override
     {
-        PYBIND11_OVERLOAD_PURE(void, tbk::BaseKVCacheManager, releasePools);
+        NB_OVERRIDE_PURE(releasePools);
     }
 
     void startScheduling() override
     {
-        PYBIND11_OVERLOAD_PURE(void, tbk::BaseKVCacheManager, startScheduling);
+        NB_OVERRIDE_PURE(startScheduling);
     }
 
     SizeType32 getTokensPerBlock() const override
     {
-        PYBIND11_OVERLOAD_PURE(SizeType32, tbk::BaseKVCacheManager, getTokensPerBlock);
+        NB_OVERRIDE_PURE(getTokensPerBlock);
     }
 
     SizeType32 getMaxNumBlocks() const override
     {
-        PYBIND11_OVERLOAD_PURE(SizeType32, tbk::BaseKVCacheManager, getMaxNumBlocks);
+        NB_OVERRIDE_PURE(getMaxNumBlocks);
     }
 
     SizeType32 getNumPools() const override
     {
-        PYBIND11_OVERLOAD_PURE(SizeType32, tbk::BaseKVCacheManager, getNumPools);
+        NB_OVERRIDE_PURE(getNumPools);
     }
 
     tbk::KvCacheStats getKvCacheStats() const override
     {
-        PYBIND11_OVERLOAD_PURE(tbk::KvCacheStats, tbk::BaseKVCacheManager, getKvCacheStats);
+        NB_OVERRIDE_PURE(getKvCacheStats);
     }
 
     void addToken(tb::LlmRequest::RequestIdType requestId) override
     {
-        PYBIND11_OVERLOAD_PURE(void, tbk::BaseKVCacheManager, addToken, requestId);
+        NB_OVERRIDE_PURE(addToken, requestId);
     }
 
     void addSequence(tb::LlmRequest::RequestIdType requestId, SizeType32 inputLength, SizeType32 beamWidth,
         tensorrt_llm::common::OptionalRef<tb::LlmRequest> llmRequest = std::nullopt) override
     {
-        PYBIND11_OVERLOAD_PURE(
-            void, tbk::BaseKVCacheManager, addSequence, requestId, inputLength, beamWidth, llmRequest);
+        NB_OVERRIDE_PURE(addSequence, requestId, inputLength, beamWidth, llmRequest);
     }
 
     void removeSequence(tb::LlmRequest::RequestIdType requestId,
         tensorrt_llm::common::OptionalRef<tb::LlmRequest const> llmRequest = std::nullopt) override
     {
-        PYBIND11_OVERLOAD_PURE(void, tbk::BaseKVCacheManager, removeSequence, requestId, llmRequest);
+        NB_OVERRIDE_PURE(removeSequence, requestId, llmRequest);
     }
 
     tbk::GenerationRequest const& getSequence(tb::LlmRequest::RequestIdType requestId) const override
     {
-        PYBIND11_OVERLOAD_PURE(tbk::GenerationRequest const&, tbk::BaseKVCacheManager, getSequence, requestId);
+        NB_OVERRIDE_PURE(getSequence, requestId);
     }
 
     void schedulingRemoveSequence(tb::LlmRequest::RequestIdType requestId) override
     {
-        PYBIND11_OVERLOAD_PURE(void, tbk::BaseKVCacheManager, schedulingRemoveSequence, requestId);
+        NB_OVERRIDE_PURE(schedulingRemoveSequence, requestId);
     }
 
     tensorrt_llm::runtime::ITensor::SharedPtr getBlockPoolPointers() const override
     {
-        PYBIND11_OVERLOAD_PURE(
-            tensorrt_llm::runtime::ITensor::UniquePtr, tbk::BaseKVCacheManager, getBlockPoolPointers);
+        NB_OVERRIDE_PURE(getBlockPoolPointers);
     }
 
     tensorrt_llm::runtime::ITensor::SharedPtr getLayerToPoolMapping() const override
     {
-        PYBIND11_OVERLOAD_PURE(
-            tensorrt_llm::runtime::ITensor::UniquePtr, tbk::BaseKVCacheManager, getLayerToPoolMapping);
+        NB_OVERRIDE_PURE(getLayerToPoolMapping);
     }
 
     void getBlockOffsetsOfBatch(tensorrt_llm::runtime::ITensor& output, SizeType32 firstBatchSlotIdx,
         SizeType32 batchSize, SizeType32 beamWidth) const override
     {
-        PYBIND11_OVERLOAD_PURE(
-            void, tbk::BaseKVCacheManager, getBlockOffsetsOfBatch, output, firstBatchSlotIdx, batchSize, beamWidth);
+        NB_OVERRIDE_PURE(getBlockOffsetsOfBatch, output, firstBatchSlotIdx, batchSize, beamWidth);
     }
 
     SizeType32 copyBlockOffsets(tensorrt_llm::runtime::ITensor& output, SizeType32 outputSlotOffset,
         tb::LlmRequest::RequestIdType requestId) const override
     {
-        PYBIND11_OVERLOAD_PURE(
-            SizeType32, tbk::BaseKVCacheManager, copyBlockOffsets, output, outputSlotOffset, requestId);
+        NB_OVERRIDE_PURE(copyBlockOffsets, output, outputSlotOffset, requestId);
     }
 
     bool isEnableBlockReuse() const override
     {
-        PYBIND11_OVERLOAD_PURE(bool, tbk::BaseKVCacheManager, isEnableBlockReuse);
+        NB_OVERRIDE_PURE(isEnableBlockReuse);
     }
 
     void rewindKVCache(tb::LlmRequest::RequestIdType requestId, SizeType32 rewindLengths) override
     {
-        PYBIND11_OVERLOAD_PURE(void, tbk::BaseKVCacheManager, rewindKVCache, requestId, rewindLengths);
+        NB_OVERRIDE_PURE(rewindKVCache, requestId, rewindLengths);
     }
 
     bool isCrossKv() const override
     {
-        PYBIND11_OVERLOAD_PURE(bool, tbk::BaseKVCacheManager, isCrossKv);
+        NB_OVERRIDE_PURE(isCrossKv);
     }
 
     std::optional<BlockKey> findNewContextBlock(
         VecUniqueTokens const& uniqueTokens, tb::LlmRequest const& llmRequest) const override
     {
-        PYBIND11_OVERLOAD_PURE(
-            std::optional<BlockKey>, tbk::BaseKVCacheManager, findNewContextBlock, uniqueTokens, llmRequest);
+        NB_OVERRIDE_PURE(findNewContextBlock, uniqueTokens, llmRequest);
     }
 
     void storeContextBlocks(tb::LlmRequest const& llmRequest) override
     {
-        PYBIND11_OVERLOAD_PURE(void, tbk::BaseKVCacheManager, storeContextBlocks, llmRequest);
+        NB_OVERRIDE_PURE(storeContextBlocks, llmRequest);
     }
 
     std::vector<std::vector<SizeType32>> const& getCacheBlockIds(
         tb::LlmRequest::RequestIdType requestId, SizeType32 windowSize) const override
     {
-        PYBIND11_OVERLOAD_PURE(std::vector<std::vector<SizeType32>> const&, tbk::BaseKVCacheManager, getCacheBlockIds,
-            requestId, windowSize);
+        NB_OVERRIDE_PURE(getCacheBlockIds, requestId, windowSize);
     }
 
     std::vector<std::vector<std::vector<SizeType32>>> getBatchCacheBlockIds(
         std::vector<tb::LlmRequest::RequestIdType> const& requestIds, SizeType32 windowSize) const override
     {
-        PYBIND11_OVERLOAD_PURE(std::vector<std::vector<std::vector<SizeType32>>>, tbk::BaseKVCacheManager,
-            getBatchCacheBlockIds, requestIds, windowSize);
+        NB_OVERRIDE_PURE(getBatchCacheBlockIds, requestIds, windowSize);
     }
 
     std::vector<SizeType32> getNewlyAllocatedBlockIds(
         tb::LlmRequest::RequestIdType requestId, SizeType32 windowSize) const override
     {
-        PYBIND11_OVERLOAD_PURE(
-            std::vector<SizeType32>, tbk::BaseKVCacheManager, getNewlyAllocatedBlockIds, requestId, windowSize);
+        NB_OVERRIDE_PURE(getNewlyAllocatedBlockIds, requestId, windowSize);
     }
 
     SizeType32 getUsedNumBlocks() const override
     {
-        PYBIND11_OVERLOAD_PURE(SizeType32, tbk::BaseKVCacheManager, getUsedNumBlocks);
+        NB_OVERRIDE_PURE(getUsedNumBlocks);
     }
 
     SizeType32 getNumFreeBlocks() const override
     {
-        PYBIND11_OVERLOAD_PURE(SizeType32, tbk::BaseKVCacheManager, getNumFreeBlocks);
+        NB_OVERRIDE_PURE(getNumFreeBlocks);
     }
 
     tbk::BlockManager const& getBlockManager() const override
     {
-        PYBIND11_OVERLOAD_PURE(tbk::BlockManager const&, tbk::BaseKVCacheManager, getBlockManager);
+        NB_OVERRIDE_PURE(getBlockManager);
     }
 
     std::deque<tensorrt_llm::executor::KVCacheEvent> getLatestEvents(
         std::optional<std::chrono::milliseconds> timeout = std::nullopt) const override
     {
-        PYBIND11_OVERLOAD_PURE(
-            std::deque<tensorrt_llm::executor::KVCacheEvent>, tbk::BaseKVCacheManager, getLatestEvents, timeout);
+        NB_OVERRIDE_PURE(getLatestEvents, timeout);
     }
 
     tensorrt_llm::runtime::ITensor::SharedPtr getPrimaryPool(SizeType32 layer_idx) const override
     {
-        PYBIND11_OVERLOAD_PURE(
-            tensorrt_llm::runtime::ITensor::SharedPtr, tbk::BaseKVCacheManager, getPrimaryPool, layer_idx);
+        NB_OVERRIDE_PURE(getPrimaryPool, layer_idx);
     }
 
     SizeType32 getPoolLayerIdx(SizeType32 layer_idx) const override
     {
-        PYBIND11_OVERLOAD_PURE(SizeType32, tbk::BaseKVCacheManager, getPoolLayerIdx, layer_idx);
+        NB_OVERRIDE_PURE(getPoolLayerIdx, layer_idx);
     }
 
     void refreshBlocks() override
     {
-        PYBIND11_OVERLOAD_PURE(void, tbk::BaseKVCacheManager, refreshBlocks);
+        NB_OVERRIDE_PURE(refreshBlocks);
     }
 
     void flushIterationEvents() override
     {
-        PYBIND11_OVERLOAD_PURE(void, tbk::BaseKVCacheManager, flushIterationEvents);
+        NB_OVERRIDE_PURE(flushIterationEvents);
     }
 };
 
@@ -242,99 +241,100 @@ class PyBasePeftCacheManager : public tb::BasePeftCacheManager
 public:
     ~PyBasePeftCacheManager() override = default;
 
+    NB_TRAMPOLINE(tb::BasePeftCacheManager, 8);
+
     void addRequestPeft(tb::BasePeftCacheManager::LlmRequestPtr llmRequest, bool tryGpuCache = true) override
     {
-        PYBIND11_OVERLOAD_PURE(void, tb::BasePeftCacheManager, addRequestPeft, llmRequest, tryGpuCache);
+        NB_OVERRIDE_PURE(addRequestPeft, llmRequest, tryGpuCache);
     }
 
     tb::BasePeftCacheManager::PeftTable ensureBatch(tb::RequestVector const& contextRequests,
         tb::RequestVector const& generationRequests, bool resetGpuCache = false) override
     {
-        PYBIND11_OVERLOAD_PURE(tb::BasePeftCacheManager::PeftTable, tb::BasePeftCacheManager, ensureBatch,
-            contextRequests, generationRequests, resetGpuCache);
+        NB_OVERRIDE_PURE(ensureBatch, contextRequests, generationRequests, resetGpuCache);
     }
 
     void resetDeviceCache() override
     {
-        PYBIND11_OVERLOAD_PURE(void, tb::BasePeftCacheManager, resetDeviceCache);
+        NB_OVERRIDE_PURE(resetDeviceCache);
     }
 
     void markRequestDone(tb::LlmRequest const& llmReq, bool pause = false) override
     {
-        PYBIND11_OVERLOAD_PURE(void, tb::BasePeftCacheManager, markRequestDone, llmReq, pause);
+        NB_OVERRIDE_PURE(markRequestDone, llmReq, pause);
     }
 
     tr::SizeType32 getMaxDevicePages() const override
     {
-        PYBIND11_OVERLOAD_PURE(tr::SizeType32, tb::BasePeftCacheManager, getMaxDevicePages);
+        NB_OVERRIDE_PURE(getMaxDevicePages);
     }
 
     tr::SizeType32 getMaxHostPages() const override
     {
-        PYBIND11_OVERLOAD_PURE(tr::SizeType32, tb::BasePeftCacheManager, getMaxHostPages);
+        NB_OVERRIDE_PURE(getMaxHostPages);
     }
 
     tr::SizeType32 determineNumPages(std::shared_ptr<tb::LlmRequest> llmRequest) const override
     {
-        PYBIND11_OVERLOAD_PURE(tr::SizeType32, tb::BasePeftCacheManager, determineNumPages, llmRequest);
+        NB_OVERRIDE_PURE(determineNumPages, llmRequest);
     }
 
     bool enabled() const override
     {
-        PYBIND11_OVERLOAD_PURE(bool, tb::BasePeftCacheManager, enabled);
+        NB_OVERRIDE_PURE(enabled);
     }
 };
 } // namespace
 
-void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(py::module_& m)
+void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(nb::module_& m)
 {
-    py::class_<tbk::KvCacheStats>(m, "KvCacheStats")
-        .def(py::init<>())
-        .def_readwrite("max_num_blocks", &tbk::KvCacheStats::maxNumBlocks)
-        .def_readwrite("free_num_blocks", &tbk::KvCacheStats::freeNumBlocks)
-        .def_readwrite("used_num_blocks", &tbk::KvCacheStats::usedNumBlocks)
-        .def_readwrite("tokens_per_block", &tbk::KvCacheStats::toksPerBlock)
-        .def_readwrite("alloc_total_blocks", &tbk::KvCacheStats::allocTotalBlocks)
-        .def_readwrite("alloc_new_blocks", &tbk::KvCacheStats::allocNewBlocks)
-        .def_readwrite("reused_blocks", &tbk::KvCacheStats::reusedBlocks)
-        .def_readwrite("missed_blocks", &tbk::KvCacheStats::missedBlocks)
-        .def_readwrite("cache_hit_rate", &tbk::KvCacheStats::cacheHitRate);
+    nb::class_<tbk::KvCacheStats>(m, "KvCacheStats")
+        .def(nb::init<>())
+        .def_rw("max_num_blocks", &tbk::KvCacheStats::maxNumBlocks)
+        .def_rw("free_num_blocks", &tbk::KvCacheStats::freeNumBlocks)
+        .def_rw("used_num_blocks", &tbk::KvCacheStats::usedNumBlocks)
+        .def_rw("tokens_per_block", &tbk::KvCacheStats::toksPerBlock)
+        .def_rw("alloc_total_blocks", &tbk::KvCacheStats::allocTotalBlocks)
+        .def_rw("alloc_new_blocks", &tbk::KvCacheStats::allocNewBlocks)
+        .def_rw("reused_blocks", &tbk::KvCacheStats::reusedBlocks)
+        .def_rw("missed_blocks", &tbk::KvCacheStats::missedBlocks)
+        .def_rw("cache_hit_rate", &tbk::KvCacheStats::cacheHitRate);
 
-    py::class_<tbk::TempAttentionWindowInputs>(m, "TempAttentionWindowInputs")
-        .def(py::init<>())
-        .def_readwrite("paged_context_fmha", &tbk::TempAttentionWindowInputs::pagedContextFMHA)
-        .def_readwrite("max_input_len", &tbk::TempAttentionWindowInputs::maxInputLen)
-        .def_readwrite("max_num_tokens", &tbk::TempAttentionWindowInputs::maxNumTokens);
+    nb::class_<tbk::TempAttentionWindowInputs>(m, "TempAttentionWindowInputs")
+        .def(nb::init<>())
+        .def_rw("paged_context_fmha", &tbk::TempAttentionWindowInputs::pagedContextFMHA)
+        .def_rw("max_input_len", &tbk::TempAttentionWindowInputs::maxInputLen)
+        .def_rw("max_num_tokens", &tbk::TempAttentionWindowInputs::maxNumTokens);
 
-    py::class_<tbk::BlockKey>(m, "BlockKey")
-        .def(py::init<>())
-        .def(py::init<VecTokens const&, std::optional<tr::LoraTaskIdType>>(), py::arg("tokens"),
-            py::arg("lora_task_id") = std::nullopt)
-        .def(py::init<bool, std::optional<tr::LoraTaskIdType>, VecUniqueTokens const&>(), py::arg("uses_extra_ids"),
-            py::arg("lora_task_id"), py::arg("unique_tokens"))
-        .def_readonly("uses_extra_ids", &tbk::BlockKey::usesExtraIds)
-        .def_readonly("lora_task_id", &tbk::BlockKey::loraTaskId)
-        .def_readonly("unique_tokens", &tbk::BlockKey::uniqueTokens);
+    nb::class_<tbk::BlockKey>(m, "BlockKey")
+        .def(nb::init<>())
+        .def(nb::init<VecTokens const&, std::optional<tr::LoraTaskIdType>>(), nb::arg("tokens"),
+            nb::arg("lora_task_id") = std::nullopt)
+        .def(nb::init<bool, std::optional<tr::LoraTaskIdType>, VecUniqueTokens const&>(), nb::arg("uses_extra_ids"),
+            nb::arg("lora_task_id"), nb::arg("unique_tokens"))
+        .def_ro("uses_extra_ids", &tbk::BlockKey::usesExtraIds)
+        .def_ro("lora_task_id", &tbk::BlockKey::loraTaskId)
+        .def_ro("unique_tokens", &tbk::BlockKey::uniqueTokens);
 
-    py::class_<tbk::BlockKeyHasher>(m, "BlockKeyHasher")
-        .def_static("hash", &tbk::BlockKeyHasher::hash, py::arg("block_key"), py::arg("parent_hash") = 0);
+    nb::class_<tbk::BlockKeyHasher>(m, "BlockKeyHasher")
+        .def_static("hash", &tbk::BlockKeyHasher::hash, nb::arg("block_key"), nb::arg("parent_hash") = 0);
 
-    py::class_<tbk::KVCacheEventManager, std::shared_ptr<tbk::KVCacheEventManager>>(m, "KVCacheEventManager")
-        .def(py::init<size_t>(), py::arg("max_kv_event_entries"));
+    nb::class_<tbk::KVCacheEventManager>(m, "KVCacheEventManager")
+        .def(nb::init<size_t>(), nb::arg("max_kv_event_entries"));
 
-    py::classh<tbk::BaseKVCacheManager, PyKvCacheManager>(m, "BaseKVCacheManager")
-        .def_static("calculate_max_num_blocks", &tbk::BaseKVCacheManager::calculateMaxNumBlocks, py::arg("config"),
-            py::arg("is_cross_attention"), py::arg("dtype"), py::arg("model_config"), py::arg("world_config"),
-            py::arg("window_size_to_layers"), py::arg("allotted_primary_mem_bytes"),
-            py::arg("allotted_secondary_mem_bytes"), py::arg("extra_cost_memory"), py::arg("kv_factor"))
+    nb::class_<tbk::BaseKVCacheManager, PyKvCacheManager>(m, "BaseKVCacheManager")
+        .def_static("calculate_max_num_blocks", &tbk::BaseKVCacheManager::calculateMaxNumBlocks, nb::arg("config"),
+            nb::arg("is_cross_attention"), nb::arg("dtype"), nb::arg("model_config"), nb::arg("world_config"),
+            nb::arg("window_size_to_layers"), nb::arg("allotted_primary_mem_bytes"),
+            nb::arg("allotted_secondary_mem_bytes"), nb::arg("extra_cost_memory"), nb::arg("kv_factor"))
         .def("allocate_pools", &BaseKVCacheManager::allocatePools)
         .def("release_pools", &BaseKVCacheManager::releasePools)
         .def("start_scheduling", &BaseKVCacheManager::startScheduling)
-        .def_property_readonly("tokens_per_block", &BaseKVCacheManager::getTokensPerBlock)
-        .def_property_readonly("max_num_blocks", &BaseKVCacheManager::getMaxNumBlocks)
-        .def_property_readonly("num_pools", &BaseKVCacheManager::getNumPools)
+        .def_prop_ro("tokens_per_block", &BaseKVCacheManager::getTokensPerBlock)
+        .def_prop_ro("max_num_blocks", &BaseKVCacheManager::getMaxNumBlocks)
+        .def_prop_ro("num_pools", &BaseKVCacheManager::getNumPools)
         .def("get_kv_cache_stats", &BaseKVCacheManager::getKvCacheStats)
-        .def_property_readonly("max_blocks_per_seq",
+        .def_prop_ro("max_blocks_per_seq",
             [](tbk::BaseKVCacheManager& self) { return self.getOffsetTableDimensions().maxBlocksPerSeq; })
         .def("get_needed_blocks_one_step", &BaseKVCacheManager::getNeededBlocksOneStep)
         .def("get_remaining_blocks_to_completion", &BaseKVCacheManager::getRemainingBlocksToCompletion)
@@ -412,63 +412,65 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(py::module_& m)
                 }
                 return self.getLatestEvents(std::nullopt);
             },
-            py::arg("timeout_ms") = std::nullopt)
-        .def_property_readonly("enable_block_reuse", &BaseKVCacheManager::isEnableBlockReuse)
+            nb::arg("timeout_ms") = std::nullopt)
+        .def_prop_ro("enable_block_reuse", &BaseKVCacheManager::isEnableBlockReuse)
         .def("rewind_kv_cache", &BaseKVCacheManager::rewindKVCache)
-        .def_property_readonly("cross_kv", &BaseKVCacheManager::isCrossKv)
+        .def_prop_ro("cross_kv", &BaseKVCacheManager::isCrossKv)
         .def("store_context_blocks", &BaseKVCacheManager::storeContextBlocks)
         .def("get_cache_block_ids", &BaseKVCacheManager::getCacheBlockIds)
         .def("get_batch_cache_block_ids", &BaseKVCacheManager::getBatchCacheBlockIds)
         .def("get_newly_allocated_block_ids", &BaseKVCacheManager::getNewlyAllocatedBlockIds)
         .def("flush_iteration_events", &BaseKVCacheManager::flushIterationEvents);
 
-    py::enum_<tbk::CacheType>(m, "CacheType")
+    nb::bind_vector<std::vector<std::vector<SizeType32>>>(m, "CacheBlockIds");
+
+    nb::enum_<tbk::CacheType>(m, "CacheType")
         .value("SELF", tbk::CacheType::kSELF)
         .value("CROSS", tbk::CacheType::kCROSS)
         .value("SELFKONLY", tbk::CacheType::kSELFKONLY);
 
-    py::classh<tbk::KVCacheManager, tbk::BaseKVCacheManager>(m, "KVCacheManager")
-        .def(py::init<std::vector<SizeType32> const&, SizeType32, SizeType32,
+    nb::class_<tbk::KVCacheManager, tbk::BaseKVCacheManager>(m, "KVCacheManager")
+        .def(nb::init<std::vector<SizeType32> const&, SizeType32, SizeType32,
                  std::map<SizeType32, std::tuple<SizeType32, SizeType32>> const&, SizeType32, SizeType32,
                  std::vector<SizeType32> const&, std::optional<tbk::TempAttentionWindowInputs> const&,
-                 nvinfer1::DataType, SizeType32, bool, int64_t, bool, bool, tbk::CacheType,
-                 std::optional<tensorrt_llm::executor::RetentionPriority>, std::shared_ptr<tbk::KVCacheEventManager>,
-                 bool, bool>(),
-            py::arg("num_kv_heads_per_layer"), py::arg("size_per_head"), py::arg("tokens_per_block"),
-            py::arg("blocks_per_window"), py::arg("max_num_sequences"), py::arg("max_beam_width"),
-            py::arg("max_attention_window_vec"), py::arg("temp_attention_window_inputs"), py::arg("dtype"),
-            py::arg("sink_token_length"), py::arg("stream"), py::arg("max_sequence_length"),
-            py::arg("enable_block_reuse") = false, py::arg("onboard_blocks") = true,
-            py::arg_v("cache_type", tbk::CacheType::kSELF, "bindings.internal.batch_manager.CacheType.SELF"),
-            py::arg("secondary_offload_min_priority") = std::nullopt, py::arg("event_manager") = nullptr,
-            py::arg("enable_partial_reuse") = true, py::arg("copy_on_partial_reuse") = true);
+                 nvinfer1::DataType, SizeType32, int64_t, std::optional<runtime::SizeType32>, bool, bool,
+                 tbk::CacheType, std::optional<tensorrt_llm::executor::RetentionPriority>,
+                 std::shared_ptr<tbk::KVCacheEventManager>, bool, bool>(),
+            nb::arg("num_kv_heads_per_layer"), nb::arg("size_per_head"), nb::arg("tokens_per_block"),
+            nb::arg("blocks_per_window"), nb::arg("max_num_sequences"), nb::arg("max_beam_width"),
+            nb::arg("max_attention_window_vec"), nb::arg("temp_attention_window_inputs").none(), nb::arg("dtype"),
+            nb::arg("sink_token_length"), nb::arg("stream"), nb::arg("max_sequence_length").none(),
+            nb::arg("enable_block_reuse") = false, nb::arg("onboard_blocks") = true,
+            nb::arg("cache_type") = tbk::CacheType::kSELF, nb::arg("secondary_offload_min_priority") = std::nullopt,
+            nb::arg("event_manager") = nullptr, nb::arg("enable_partial_reuse") = true,
+            nb::arg("copy_on_partial_reuse") = true);
 }
 
-void tb::BasePeftCacheManagerBindings::initBindings(py::module_& m)
+void tb::BasePeftCacheManagerBindings::initBindings(nb::module_& m)
 {
-    py::classh<tb::BasePeftCacheManager, PyBasePeftCacheManager>(m, "BasePeftCacheManager")
-        .def("add_request_peft", &tb::BasePeftCacheManager::addRequestPeft, py::arg("request"),
-            py::arg("try_gpu_cache") = true)
+    nb::class_<tb::BasePeftCacheManager, PyBasePeftCacheManager>(m, "BasePeftCacheManager")
+        .def("add_request_peft", &tb::BasePeftCacheManager::addRequestPeft, nb::arg("request"),
+            nb::arg("try_gpu_cache") = true)
         .def(
             "ensure_batch",
             [](tb::BasePeftCacheManager& self, tb::RequestVector const& contextRequests,
                 tb::RequestVector const& generationRequests, bool resetGpuCache)
             {
-                py::gil_scoped_release release;
+                nb::gil_scoped_release release;
                 return self.ensureBatch(contextRequests, generationRequests, resetGpuCache);
             },
-            py::arg("context_requests"), py::arg("generation_requests"), py::arg("reset_gpu_cache") = false)
+            nb::arg("context_requests"), nb::arg("generation_requests"), nb::arg("reset_gpu_cache") = false)
         .def("reset_device_cache", &tb::BasePeftCacheManager::resetDeviceCache)
-        .def("mark_request_done", &tb::BasePeftCacheManager::markRequestDone, py::arg("request"),
-            py::arg("pause") = false)
-        .def_property_readonly("max_device_pages", &tb::BasePeftCacheManager::getMaxDevicePages)
-        .def_property_readonly("max_host_pages", &tb::BasePeftCacheManager::getMaxHostPages)
-        .def("determine_num_pages", &tb::BasePeftCacheManager::determineNumPages, py::arg("request"))
-        .def_property_readonly("enabled", &tb::BasePeftCacheManager::enabled);
+        .def("mark_request_done", &tb::BasePeftCacheManager::markRequestDone, nb::arg("request"),
+            nb::arg("pause") = false)
+        .def_prop_ro("max_device_pages", &tb::BasePeftCacheManager::getMaxDevicePages)
+        .def_prop_ro("max_host_pages", &tb::BasePeftCacheManager::getMaxHostPages)
+        .def("determine_num_pages", &tb::BasePeftCacheManager::determineNumPages, nb::arg("request"))
+        .def_prop_ro("enabled", &tb::BasePeftCacheManager::enabled);
 
-    py::classh<tb::PeftCacheManager, tb::BasePeftCacheManager>(m, "PeftCacheManager")
-        .def(py::init<tb::PeftCacheManagerConfig, tr::ModelConfig, tr::WorldConfig, tr::BufferManager>(),
-            py::arg("config"), py::arg("model_config"), py::arg("world_config"), py::arg("buffer_manager"));
+    nb::class_<tb::PeftCacheManager, tb::BasePeftCacheManager>(m, "PeftCacheManager")
+        .def(nb::init<tb::PeftCacheManagerConfig, tr::ModelConfig, tr::WorldConfig, tr::BufferManager>(),
+            nb::arg("config"), nb::arg("model_config"), nb::arg("world_config"), nb::arg("buffer_manager"));
 
-    py::classh<tb::NoOpPeftCacheManager, tb::BasePeftCacheManager>(m, "NoOpPeftCacheManager").def(py::init());
+    nb::class_<tb::NoOpPeftCacheManager, tb::BasePeftCacheManager>(m, "NoOpPeftCacheManager").def(nb::init<>());
 }

--- a/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.cpp
@@ -1,0 +1,474 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "kvCacheManager.h"
+#include "tensorrt_llm/batch_manager/kvCacheManager.h"
+#include "tensorrt_llm/batch_manager/peftCacheManager.h"
+#include "tensorrt_llm/pybind/common/bindTypes.h"
+#include "tensorrt_llm/runtime/torch.h"
+#include "tensorrt_llm/runtime/torchView.h"
+
+#include <ATen/ATen.h>
+#include <pybind11/functional.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <torch/extension.h>
+
+namespace tb = tensorrt_llm::batch_manager;
+namespace tbk = tensorrt_llm::batch_manager::kv_cache_manager;
+namespace tr = tensorrt_llm::runtime;
+namespace py = pybind11;
+using BlockKey = tbk::BlockKey;
+using VecUniqueTokens = tensorrt_llm::runtime::VecUniqueTokens;
+using SizeType32 = tensorrt_llm::runtime::SizeType32;
+using TokenIdType = tensorrt_llm::runtime::TokenIdType;
+using VecTokens = std::vector<TokenIdType>;
+using CudaStreamPtr = std::shared_ptr<tensorrt_llm::runtime::CudaStream>;
+
+namespace
+{
+std::optional<tensorrt_llm::runtime::ITensor::UniquePtr> from_torch(std::optional<at::Tensor> torchPtr)
+{
+    if (torchPtr)
+    {
+        return tr::TorchView::of(torchPtr.value());
+    }
+    return std::nullopt;
+}
+
+class PyKvCacheManager : public tbk::BaseKVCacheManager
+{
+public:
+    // using BaseKVCacheManager::BaseKVCacheManager; // Inherit constructors
+    void allocatePools(bool useUvm = false) override
+    {
+        PYBIND11_OVERLOAD_PURE(void, tbk::BaseKVCacheManager, allocatePools, useUvm);
+    }
+
+    void releasePools() override
+    {
+        PYBIND11_OVERLOAD_PURE(void, tbk::BaseKVCacheManager, releasePools);
+    }
+
+    void startScheduling() override
+    {
+        PYBIND11_OVERLOAD_PURE(void, tbk::BaseKVCacheManager, startScheduling);
+    }
+
+    SizeType32 getTokensPerBlock() const override
+    {
+        PYBIND11_OVERLOAD_PURE(SizeType32, tbk::BaseKVCacheManager, getTokensPerBlock);
+    }
+
+    SizeType32 getMaxNumBlocks() const override
+    {
+        PYBIND11_OVERLOAD_PURE(SizeType32, tbk::BaseKVCacheManager, getMaxNumBlocks);
+    }
+
+    SizeType32 getNumPools() const override
+    {
+        PYBIND11_OVERLOAD_PURE(SizeType32, tbk::BaseKVCacheManager, getNumPools);
+    }
+
+    tbk::KvCacheStats getKvCacheStats() const override
+    {
+        PYBIND11_OVERLOAD_PURE(tbk::KvCacheStats, tbk::BaseKVCacheManager, getKvCacheStats);
+    }
+
+    void addToken(tb::LlmRequest::RequestIdType requestId) override
+    {
+        PYBIND11_OVERLOAD_PURE(void, tbk::BaseKVCacheManager, addToken, requestId);
+    }
+
+    void addSequence(tb::LlmRequest::RequestIdType requestId, SizeType32 inputLength, SizeType32 beamWidth,
+        tensorrt_llm::common::OptionalRef<tb::LlmRequest> llmRequest = std::nullopt) override
+    {
+        PYBIND11_OVERLOAD_PURE(
+            void, tbk::BaseKVCacheManager, addSequence, requestId, inputLength, beamWidth, llmRequest);
+    }
+
+    void removeSequence(tb::LlmRequest::RequestIdType requestId,
+        tensorrt_llm::common::OptionalRef<tb::LlmRequest const> llmRequest = std::nullopt) override
+    {
+        PYBIND11_OVERLOAD_PURE(void, tbk::BaseKVCacheManager, removeSequence, requestId, llmRequest);
+    }
+
+    tbk::GenerationRequest const& getSequence(tb::LlmRequest::RequestIdType requestId) const override
+    {
+        PYBIND11_OVERLOAD_PURE(tbk::GenerationRequest const&, tbk::BaseKVCacheManager, getSequence, requestId);
+    }
+
+    void schedulingRemoveSequence(tb::LlmRequest::RequestIdType requestId) override
+    {
+        PYBIND11_OVERLOAD_PURE(void, tbk::BaseKVCacheManager, schedulingRemoveSequence, requestId);
+    }
+
+    tensorrt_llm::runtime::ITensor::SharedPtr getBlockPoolPointers() const override
+    {
+        PYBIND11_OVERLOAD_PURE(
+            tensorrt_llm::runtime::ITensor::UniquePtr, tbk::BaseKVCacheManager, getBlockPoolPointers);
+    }
+
+    tensorrt_llm::runtime::ITensor::SharedPtr getLayerToPoolMapping() const override
+    {
+        PYBIND11_OVERLOAD_PURE(
+            tensorrt_llm::runtime::ITensor::UniquePtr, tbk::BaseKVCacheManager, getLayerToPoolMapping);
+    }
+
+    void getBlockOffsetsOfBatch(tensorrt_llm::runtime::ITensor& output, SizeType32 firstBatchSlotIdx,
+        SizeType32 batchSize, SizeType32 beamWidth) const override
+    {
+        PYBIND11_OVERLOAD_PURE(
+            void, tbk::BaseKVCacheManager, getBlockOffsetsOfBatch, output, firstBatchSlotIdx, batchSize, beamWidth);
+    }
+
+    SizeType32 copyBlockOffsets(tensorrt_llm::runtime::ITensor& output, SizeType32 outputSlotOffset,
+        tb::LlmRequest::RequestIdType requestId) const override
+    {
+        PYBIND11_OVERLOAD_PURE(
+            SizeType32, tbk::BaseKVCacheManager, copyBlockOffsets, output, outputSlotOffset, requestId);
+    }
+
+    bool isEnableBlockReuse() const override
+    {
+        PYBIND11_OVERLOAD_PURE(bool, tbk::BaseKVCacheManager, isEnableBlockReuse);
+    }
+
+    void rewindKVCache(tb::LlmRequest::RequestIdType requestId, SizeType32 rewindLengths) override
+    {
+        PYBIND11_OVERLOAD_PURE(void, tbk::BaseKVCacheManager, rewindKVCache, requestId, rewindLengths);
+    }
+
+    bool isCrossKv() const override
+    {
+        PYBIND11_OVERLOAD_PURE(bool, tbk::BaseKVCacheManager, isCrossKv);
+    }
+
+    std::optional<BlockKey> findNewContextBlock(
+        VecUniqueTokens const& uniqueTokens, tb::LlmRequest const& llmRequest) const override
+    {
+        PYBIND11_OVERLOAD_PURE(
+            std::optional<BlockKey>, tbk::BaseKVCacheManager, findNewContextBlock, uniqueTokens, llmRequest);
+    }
+
+    void storeContextBlocks(tb::LlmRequest const& llmRequest) override
+    {
+        PYBIND11_OVERLOAD_PURE(void, tbk::BaseKVCacheManager, storeContextBlocks, llmRequest);
+    }
+
+    std::vector<std::vector<SizeType32>> const& getCacheBlockIds(
+        tb::LlmRequest::RequestIdType requestId, SizeType32 windowSize) const override
+    {
+        PYBIND11_OVERLOAD_PURE(std::vector<std::vector<SizeType32>> const&, tbk::BaseKVCacheManager, getCacheBlockIds,
+            requestId, windowSize);
+    }
+
+    std::vector<std::vector<std::vector<SizeType32>>> getBatchCacheBlockIds(
+        std::vector<tb::LlmRequest::RequestIdType> const& requestIds, SizeType32 windowSize) const override
+    {
+        PYBIND11_OVERLOAD_PURE(std::vector<std::vector<std::vector<SizeType32>>>, tbk::BaseKVCacheManager,
+            getBatchCacheBlockIds, requestIds, windowSize);
+    }
+
+    std::vector<SizeType32> getNewlyAllocatedBlockIds(
+        tb::LlmRequest::RequestIdType requestId, SizeType32 windowSize) const override
+    {
+        PYBIND11_OVERLOAD_PURE(
+            std::vector<SizeType32>, tbk::BaseKVCacheManager, getNewlyAllocatedBlockIds, requestId, windowSize);
+    }
+
+    SizeType32 getUsedNumBlocks() const override
+    {
+        PYBIND11_OVERLOAD_PURE(SizeType32, tbk::BaseKVCacheManager, getUsedNumBlocks);
+    }
+
+    SizeType32 getNumFreeBlocks() const override
+    {
+        PYBIND11_OVERLOAD_PURE(SizeType32, tbk::BaseKVCacheManager, getNumFreeBlocks);
+    }
+
+    tbk::BlockManager const& getBlockManager() const override
+    {
+        PYBIND11_OVERLOAD_PURE(tbk::BlockManager const&, tbk::BaseKVCacheManager, getBlockManager);
+    }
+
+    std::deque<tensorrt_llm::executor::KVCacheEvent> getLatestEvents(
+        std::optional<std::chrono::milliseconds> timeout = std::nullopt) const override
+    {
+        PYBIND11_OVERLOAD_PURE(
+            std::deque<tensorrt_llm::executor::KVCacheEvent>, tbk::BaseKVCacheManager, getLatestEvents, timeout);
+    }
+
+    tensorrt_llm::runtime::ITensor::SharedPtr getPrimaryPool(SizeType32 layer_idx) const override
+    {
+        PYBIND11_OVERLOAD_PURE(
+            tensorrt_llm::runtime::ITensor::SharedPtr, tbk::BaseKVCacheManager, getPrimaryPool, layer_idx);
+    }
+
+    SizeType32 getPoolLayerIdx(SizeType32 layer_idx) const override
+    {
+        PYBIND11_OVERLOAD_PURE(SizeType32, tbk::BaseKVCacheManager, getPoolLayerIdx, layer_idx);
+    }
+
+    void refreshBlocks() override
+    {
+        PYBIND11_OVERLOAD_PURE(void, tbk::BaseKVCacheManager, refreshBlocks);
+    }
+
+    void flushIterationEvents() override
+    {
+        PYBIND11_OVERLOAD_PURE(void, tbk::BaseKVCacheManager, flushIterationEvents);
+    }
+};
+
+// TODO: Deduplicate executor bindings KvCacheStats
+class PyBasePeftCacheManager : public tb::BasePeftCacheManager
+{
+public:
+    ~PyBasePeftCacheManager() override = default;
+
+    void addRequestPeft(tb::BasePeftCacheManager::LlmRequestPtr llmRequest, bool tryGpuCache = true) override
+    {
+        PYBIND11_OVERLOAD_PURE(void, tb::BasePeftCacheManager, addRequestPeft, llmRequest, tryGpuCache);
+    }
+
+    tb::BasePeftCacheManager::PeftTable ensureBatch(tb::RequestVector const& contextRequests,
+        tb::RequestVector const& generationRequests, bool resetGpuCache = false) override
+    {
+        PYBIND11_OVERLOAD_PURE(tb::BasePeftCacheManager::PeftTable, tb::BasePeftCacheManager, ensureBatch,
+            contextRequests, generationRequests, resetGpuCache);
+    }
+
+    void resetDeviceCache() override
+    {
+        PYBIND11_OVERLOAD_PURE(void, tb::BasePeftCacheManager, resetDeviceCache);
+    }
+
+    void markRequestDone(tb::LlmRequest const& llmReq, bool pause = false) override
+    {
+        PYBIND11_OVERLOAD_PURE(void, tb::BasePeftCacheManager, markRequestDone, llmReq, pause);
+    }
+
+    tr::SizeType32 getMaxDevicePages() const override
+    {
+        PYBIND11_OVERLOAD_PURE(tr::SizeType32, tb::BasePeftCacheManager, getMaxDevicePages);
+    }
+
+    tr::SizeType32 getMaxHostPages() const override
+    {
+        PYBIND11_OVERLOAD_PURE(tr::SizeType32, tb::BasePeftCacheManager, getMaxHostPages);
+    }
+
+    tr::SizeType32 determineNumPages(std::shared_ptr<tb::LlmRequest> llmRequest) const override
+    {
+        PYBIND11_OVERLOAD_PURE(tr::SizeType32, tb::BasePeftCacheManager, determineNumPages, llmRequest);
+    }
+
+    bool enabled() const override
+    {
+        PYBIND11_OVERLOAD_PURE(bool, tb::BasePeftCacheManager, enabled);
+    }
+};
+} // namespace
+
+void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(py::module_& m)
+{
+    py::class_<tbk::KvCacheStats>(m, "KvCacheStats")
+        .def(py::init<>())
+        .def_readwrite("max_num_blocks", &tbk::KvCacheStats::maxNumBlocks)
+        .def_readwrite("free_num_blocks", &tbk::KvCacheStats::freeNumBlocks)
+        .def_readwrite("used_num_blocks", &tbk::KvCacheStats::usedNumBlocks)
+        .def_readwrite("tokens_per_block", &tbk::KvCacheStats::toksPerBlock)
+        .def_readwrite("alloc_total_blocks", &tbk::KvCacheStats::allocTotalBlocks)
+        .def_readwrite("alloc_new_blocks", &tbk::KvCacheStats::allocNewBlocks)
+        .def_readwrite("reused_blocks", &tbk::KvCacheStats::reusedBlocks)
+        .def_readwrite("missed_blocks", &tbk::KvCacheStats::missedBlocks)
+        .def_readwrite("cache_hit_rate", &tbk::KvCacheStats::cacheHitRate);
+
+    py::class_<tbk::TempAttentionWindowInputs>(m, "TempAttentionWindowInputs")
+        .def(py::init<>())
+        .def_readwrite("paged_context_fmha", &tbk::TempAttentionWindowInputs::pagedContextFMHA)
+        .def_readwrite("max_input_len", &tbk::TempAttentionWindowInputs::maxInputLen)
+        .def_readwrite("max_num_tokens", &tbk::TempAttentionWindowInputs::maxNumTokens);
+
+    py::class_<tbk::BlockKey>(m, "BlockKey")
+        .def(py::init<>())
+        .def(py::init<VecTokens const&, std::optional<tr::LoraTaskIdType>>(), py::arg("tokens"),
+            py::arg("lora_task_id") = std::nullopt)
+        .def(py::init<bool, std::optional<tr::LoraTaskIdType>, VecUniqueTokens const&>(), py::arg("uses_extra_ids"),
+            py::arg("lora_task_id"), py::arg("unique_tokens"))
+        .def_readonly("uses_extra_ids", &tbk::BlockKey::usesExtraIds)
+        .def_readonly("lora_task_id", &tbk::BlockKey::loraTaskId)
+        .def_readonly("unique_tokens", &tbk::BlockKey::uniqueTokens);
+
+    py::class_<tbk::BlockKeyHasher>(m, "BlockKeyHasher")
+        .def_static("hash", &tbk::BlockKeyHasher::hash, py::arg("block_key"), py::arg("parent_hash") = 0);
+
+    py::class_<tbk::KVCacheEventManager, std::shared_ptr<tbk::KVCacheEventManager>>(m, "KVCacheEventManager")
+        .def(py::init<size_t>(), py::arg("max_kv_event_entries"));
+
+    py::classh<tbk::BaseKVCacheManager, PyKvCacheManager>(m, "BaseKVCacheManager")
+        .def_static("calculate_max_num_blocks", &tbk::BaseKVCacheManager::calculateMaxNumBlocks, py::arg("config"),
+            py::arg("is_cross_attention"), py::arg("dtype"), py::arg("model_config"), py::arg("world_config"),
+            py::arg("window_size_to_layers"), py::arg("allotted_primary_mem_bytes"),
+            py::arg("allotted_secondary_mem_bytes"), py::arg("extra_cost_memory"), py::arg("kv_factor"))
+        .def("allocate_pools", &BaseKVCacheManager::allocatePools)
+        .def("release_pools", &BaseKVCacheManager::releasePools)
+        .def("start_scheduling", &BaseKVCacheManager::startScheduling)
+        .def_property_readonly("tokens_per_block", &BaseKVCacheManager::getTokensPerBlock)
+        .def_property_readonly("max_num_blocks", &BaseKVCacheManager::getMaxNumBlocks)
+        .def_property_readonly("num_pools", &BaseKVCacheManager::getNumPools)
+        .def("get_kv_cache_stats", &BaseKVCacheManager::getKvCacheStats)
+        .def_property_readonly("max_blocks_per_seq",
+            [](tbk::BaseKVCacheManager& self) { return self.getOffsetTableDimensions().maxBlocksPerSeq; })
+        .def("get_needed_blocks_one_step", &BaseKVCacheManager::getNeededBlocksOneStep)
+        .def("get_remaining_blocks_to_completion", &BaseKVCacheManager::getRemainingBlocksToCompletion)
+        .def("add_token", &BaseKVCacheManager::addToken)
+        .def("add_sequence", &BaseKVCacheManager::addSequence)
+        .def("remove_sequence", &BaseKVCacheManager::removeSequence)
+        .def("scheduling_remove_sequence", &BaseKVCacheManager::schedulingRemoveSequence)
+        .def("get_block_pool_pointers",
+            [](tbk::BaseKVCacheManager& self)
+            {
+                std::optional<at::Tensor> block_pool_pointers{std::nullopt};
+                auto tensor = self.getBlockPoolPointers();
+                if (tensor)
+                {
+                    std::shared_ptr<tensorrt_llm::runtime::ITensor> _tensor = std::move(tensor);
+                    block_pool_pointers = tr::Torch::tensor(_tensor);
+                }
+                return block_pool_pointers;
+            })
+        .def("get_layer_to_pool_mapping",
+            [](tbk::BaseKVCacheManager& self)
+            {
+                std::optional<at::Tensor> layer_to_pool_mapping{std::nullopt};
+                auto tensor = self.getLayerToPoolMapping();
+                if (tensor)
+                {
+                    std::shared_ptr<tensorrt_llm::runtime::ITensor> _tensor = std::move(tensor);
+                    layer_to_pool_mapping = tr::Torch::tensor(_tensor);
+                }
+                return layer_to_pool_mapping;
+            })
+        .def("get_primary_pool_data",
+            [](tbk::BaseKVCacheManager& self, SizeType32 layer_idx) -> at::Tensor
+            {
+                auto pool = tr::Torch::tensor(self.getPrimaryPool(layer_idx));
+                auto pool_layer_idx = self.getPoolLayerIdx(layer_idx);
+                return pool.index({torch::indexing::Slice(), pool_layer_idx});
+            })
+        .def("get_block_offsets_of_batch",
+            [](tbk::BaseKVCacheManager& self, at::Tensor output, SizeType32 firstBatchSlotIdx, SizeType32 batchSize,
+                SizeType32 beamWidth)
+            {
+                auto _output = from_torch(output);
+                TLLM_CHECK_WITH_INFO(_output.has_value(), "Invalid output tensor.");
+                self.getBlockOffsetsOfBatch(*(_output.value()), firstBatchSlotIdx, batchSize, beamWidth);
+            })
+        .def("copy_block_offsets",
+            [](tbk::BaseKVCacheManager& self, at::Tensor output, SizeType32 outputSlotOffset,
+                tb::LlmRequest::RequestIdType requestId)
+            {
+                auto _output = from_torch(output);
+                TLLM_CHECK_WITH_INFO(_output.has_value(), "Invalid output tensor.");
+                auto maxBlockCount = self.copyBlockOffsets(*(_output.value()), outputSlotOffset, requestId);
+                return maxBlockCount;
+            })
+        .def("copy_batch_block_offsets",
+            [](tbk::BaseKVCacheManager& self, at::Tensor output,
+                std::vector<tb::LlmRequest::RequestIdType> const& requestIds, SizeType32 const beamWidth,
+                SizeType32 const offset)
+            {
+                auto _output = from_torch(output);
+                TLLM_CHECK_WITH_INFO(_output.has_value(), "Invalid output tensor.");
+                for (size_t i = 0; i < requestIds.size(); ++i)
+                {
+                    self.copyBlockOffsets(*(_output.value()), i * beamWidth + offset, requestIds[i]);
+                }
+            })
+        .def(
+            "get_latest_events",
+            [](tbk::BaseKVCacheManager& self, std::optional<double> timeout_ms = std::nullopt)
+            {
+                if (timeout_ms)
+                {
+                    return self.getLatestEvents(std::chrono::milliseconds(static_cast<int64_t>(*timeout_ms)));
+                }
+                return self.getLatestEvents(std::nullopt);
+            },
+            py::arg("timeout_ms") = std::nullopt)
+        .def_property_readonly("enable_block_reuse", &BaseKVCacheManager::isEnableBlockReuse)
+        .def("rewind_kv_cache", &BaseKVCacheManager::rewindKVCache)
+        .def_property_readonly("cross_kv", &BaseKVCacheManager::isCrossKv)
+        .def("store_context_blocks", &BaseKVCacheManager::storeContextBlocks)
+        .def("get_cache_block_ids", &BaseKVCacheManager::getCacheBlockIds)
+        .def("get_batch_cache_block_ids", &BaseKVCacheManager::getBatchCacheBlockIds)
+        .def("get_newly_allocated_block_ids", &BaseKVCacheManager::getNewlyAllocatedBlockIds)
+        .def("flush_iteration_events", &BaseKVCacheManager::flushIterationEvents);
+
+    py::enum_<tbk::CacheType>(m, "CacheType")
+        .value("SELF", tbk::CacheType::kSELF)
+        .value("CROSS", tbk::CacheType::kCROSS)
+        .value("SELFKONLY", tbk::CacheType::kSELFKONLY);
+
+    py::classh<tbk::KVCacheManager, tbk::BaseKVCacheManager>(m, "KVCacheManager")
+        .def(py::init<std::vector<SizeType32> const&, SizeType32, SizeType32,
+                 std::map<SizeType32, std::tuple<SizeType32, SizeType32>> const&, SizeType32, SizeType32,
+                 std::vector<SizeType32> const&, std::optional<tbk::TempAttentionWindowInputs> const&,
+                 nvinfer1::DataType, SizeType32, bool, int64_t, bool, bool, tbk::CacheType,
+                 std::optional<tensorrt_llm::executor::RetentionPriority>, std::shared_ptr<tbk::KVCacheEventManager>,
+                 bool, bool>(),
+            py::arg("num_kv_heads_per_layer"), py::arg("size_per_head"), py::arg("tokens_per_block"),
+            py::arg("blocks_per_window"), py::arg("max_num_sequences"), py::arg("max_beam_width"),
+            py::arg("max_attention_window_vec"), py::arg("temp_attention_window_inputs"), py::arg("dtype"),
+            py::arg("sink_token_length"), py::arg("stream"), py::arg("max_sequence_length"),
+            py::arg("enable_block_reuse") = false, py::arg("onboard_blocks") = true,
+            py::arg_v("cache_type", tbk::CacheType::kSELF, "bindings.internal.batch_manager.CacheType.SELF"),
+            py::arg("secondary_offload_min_priority") = std::nullopt, py::arg("event_manager") = nullptr,
+            py::arg("enable_partial_reuse") = true, py::arg("copy_on_partial_reuse") = true);
+}
+
+void tb::BasePeftCacheManagerBindings::initBindings(py::module_& m)
+{
+    py::classh<tb::BasePeftCacheManager, PyBasePeftCacheManager>(m, "BasePeftCacheManager")
+        .def("add_request_peft", &tb::BasePeftCacheManager::addRequestPeft, py::arg("request"),
+            py::arg("try_gpu_cache") = true)
+        .def(
+            "ensure_batch",
+            [](tb::BasePeftCacheManager& self, tb::RequestVector const& contextRequests,
+                tb::RequestVector const& generationRequests, bool resetGpuCache)
+            {
+                py::gil_scoped_release release;
+                return self.ensureBatch(contextRequests, generationRequests, resetGpuCache);
+            },
+            py::arg("context_requests"), py::arg("generation_requests"), py::arg("reset_gpu_cache") = false)
+        .def("reset_device_cache", &tb::BasePeftCacheManager::resetDeviceCache)
+        .def("mark_request_done", &tb::BasePeftCacheManager::markRequestDone, py::arg("request"),
+            py::arg("pause") = false)
+        .def_property_readonly("max_device_pages", &tb::BasePeftCacheManager::getMaxDevicePages)
+        .def_property_readonly("max_host_pages", &tb::BasePeftCacheManager::getMaxHostPages)
+        .def("determine_num_pages", &tb::BasePeftCacheManager::determineNumPages, py::arg("request"))
+        .def_property_readonly("enabled", &tb::BasePeftCacheManager::enabled);
+
+    py::classh<tb::PeftCacheManager, tb::BasePeftCacheManager>(m, "PeftCacheManager")
+        .def(py::init<tb::PeftCacheManagerConfig, tr::ModelConfig, tr::WorldConfig, tr::BufferManager>(),
+            py::arg("config"), py::arg("model_config"), py::arg("world_config"), py::arg("buffer_manager"));
+
+    py::classh<tb::NoOpPeftCacheManager, tb::BasePeftCacheManager>(m, "NoOpPeftCacheManager").def(py::init());
+}

--- a/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.h
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.h
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "tensorrt_llm/pybind/common/customCasters.h"
+#include <pybind11/pybind11.h>
+
+namespace tensorrt_llm::batch_manager::kv_cache_manager
+{
+class KVCacheManagerBindings
+{
+public:
+    static void initBindings(pybind11::module_& m);
+};
+} // namespace tensorrt_llm::batch_manager::kv_cache_manager
+
+namespace tensorrt_llm::batch_manager
+{
+class BasePeftCacheManagerBindings
+{
+public:
+    static void initBindings(pybind11::module_& m);
+};
+} // namespace tensorrt_llm::batch_manager

--- a/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.h
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.h
@@ -17,15 +17,14 @@
 
 #pragma once
 
-#include "tensorrt_llm/pybind/common/customCasters.h"
-#include <pybind11/pybind11.h>
+#include "tensorrt_llm/nanobind/common/customCasters.h"
 
 namespace tensorrt_llm::batch_manager::kv_cache_manager
 {
 class KVCacheManagerBindings
 {
 public:
-    static void initBindings(pybind11::module_& m);
+    static void initBindings(nb::module_& m);
 };
 } // namespace tensorrt_llm::batch_manager::kv_cache_manager
 
@@ -34,6 +33,6 @@ namespace tensorrt_llm::batch_manager
 class BasePeftCacheManagerBindings
 {
 public:
-    static void initBindings(pybind11::module_& m);
+    static void initBindings(nb::module_& m);
 };
 } // namespace tensorrt_llm::batch_manager

--- a/cpp/tensorrt_llm/nanobind/batch_manager/llmRequest.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/llmRequest.cpp
@@ -17,7 +17,7 @@
 #include "llmRequest.h"
 
 #include "tensorrt_llm/batch_manager/llmRequest.h"
-#include "tensorrt_llm/pybind/common/bindTypes.h"
+#include "tensorrt_llm/nanobind/common/bindTypes.h"
 #include "tensorrt_llm/runtime/torch.h"
 #include "tensorrt_llm/runtime/torchUtils.h"
 #include "tensorrt_llm/runtime/torchView.h"
@@ -31,7 +31,7 @@ namespace tb = tensorrt_llm::batch_manager;
 namespace tr = tensorrt_llm::runtime;
 namespace tle = tensorrt_llm::executor;
 
-using namespace tensorrt_llm::pybind::batch_manager;
+using namespace tensorrt_llm::nanobind::batch_manager;
 
 using LlmRequestPtr = std::shared_ptr<tb::LlmRequest>;
 using RequestList = std::list<LlmRequestPtr>;

--- a/cpp/tensorrt_llm/nanobind/batch_manager/llmRequest.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/llmRequest.cpp
@@ -1,0 +1,130 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "llmRequest.h"
+
+#include "tensorrt_llm/batch_manager/llmRequest.h"
+#include "tensorrt_llm/pybind/common/bindTypes.h"
+#include "tensorrt_llm/runtime/torch.h"
+#include "tensorrt_llm/runtime/torchUtils.h"
+#include "tensorrt_llm/runtime/torchView.h"
+
+#include <ATen/ATen.h>
+#include <torch/extension.h>
+
+#include <memory>
+
+namespace tb = tensorrt_llm::batch_manager;
+namespace tr = tensorrt_llm::runtime;
+namespace tle = tensorrt_llm::executor;
+
+using namespace tensorrt_llm::pybind::batch_manager;
+
+using LlmRequestPtr = std::shared_ptr<tb::LlmRequest>;
+using RequestList = std::list<LlmRequestPtr>;
+
+namespace
+{
+
+std::optional<tb::LlmRequest::TensorPtr> from_torch(std::optional<LlmRequest::TensorPtr> torchPtr)
+{
+    if (torchPtr)
+    {
+        return tr::TorchView::of(torchPtr.value());
+    }
+    return std::nullopt;
+}
+
+} // namespace
+
+std::optional<tb::LlmRequest::LogitsPostProcessor> LlmRequest::callbackAdapter(
+    std::optional<LlmRequest::LogitsPostProcessor> callback)
+{
+    if (!callback)
+    {
+        return std::nullopt;
+    }
+
+    return [callback](RequestIdType reqId, tr::ITensor::SharedPtr& tensor, tb::LlmRequest::BeamTokens const& tokens,
+               tr::BufferManager::CudaStreamPtr stream, std::optional<RequestIdType> clientId)
+    {
+        at::Tensor atTensor = tr::Torch::tensor(tensor);
+        callback.value()(reqId, atTensor, tokens, runtime::TorchUtils::stream(*stream).unwrap(), clientId);
+    };
+}
+
+std::shared_ptr<tb::LlmRequest> LlmRequest::toTrtLlm() const
+{
+
+    auto const draftTokens = std::make_shared<std::vector<TokenIdType>>(*mDraftTokens.get());
+    auto const optDraftTokens = std::optional<std::shared_ptr<std::vector<TokenIdType>>>(draftTokens);
+    auto const encoderInputTokens = mEncoderTokens.has_value()
+        ? std::make_shared<std::vector<TokenIdType>>(*mEncoderTokens.value().get())
+        : nullptr;
+    auto const optEncoderInputTokens = std::optional<std::shared_ptr<std::vector<TokenIdType>>>(encoderInputTokens);
+    // 49 parameters
+    return std::make_shared<tb::LlmRequest>(                       //
+        mRequestId,                                                //
+        mMaxNewTokens,                                             //
+        std::make_shared<std::vector<TokenIdType>>(mTokens.at(0)), //
+        mSamplingConfig,                                           //
+        mIsStreaming,                                              //
+        mEndId,                                                    //
+        mPadId,                                                    //
+        from_torch(mEmbeddingBias),                                //
+        from_torch(mBadWordsList),                                 //
+        from_torch(mStopWordsList),                                //
+        mPositionIds,                                              //
+        from_torch(mPromptEmbeddingTable),                         //
+        mPromptVocabSize,                                          //
+        mMultimodalHashes,                                         //
+        mMultimodalPositions,                                      //
+        mMultimodalLengths,                                        //
+        from_torch(mMultimodalEmbedding),                          //
+        from_torch(mMropeRotaryCosSin),                            //
+        mMropePositionDeltas,                                      //
+        mLoraTaskId,                                               //
+        from_torch(mLoraWeights),                                  //
+        from_torch(mLoraConfig),                                   //
+        mLookaheadConfig,                                          //
+        mKvCacheRetentionConfig,                                   //
+        mReturnLogProbs,                                           //
+        mReturnContextLogits,                                      //
+        mReturnGenerationLogits,                                   //
+        optDraftTokens,                                            //
+        from_torch(mDraftLogits),                                  //
+        mExcludeInputFromOutput,                                   //
+        callbackAdapter(mLogitsPostProcessor),                     //
+        mApplyLogitsPostProcessorBatched,                          //
+        optEncoderInputTokens,                                     //
+        mReturnEncoderOutput,                                      //
+        mClientId,                                                 //
+        mPriority,                                                 //
+        from_torch(mEncoderInputFeatures),                         //
+        mEncoderOutputLength,                                      //
+        from_torch(mCrossAttentionMask),                           //
+        getLlmRequestType(),                                       //
+        std::nullopt,                                              // inputTokenExtraIds
+        mNumReturnSequences,                                       //
+        mEagleConfig,                                              //
+        from_torch(mSkipCrossAttnBlocks),                          //
+        false,                                                     // returnPerfMetrics
+        mGuidedDecodingParams,                                     //
+        mLanguageAdapterUid,                                       //
+        mAllottedTimeMs,                                           //
+        mContextPhaseParams                                        //
+    );
+}

--- a/cpp/tensorrt_llm/nanobind/batch_manager/llmRequest.h
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/llmRequest.h
@@ -1,0 +1,159 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "tensorrt_llm/batch_manager/llmRequest.h"
+#include "tensorrt_llm/pybind/common/customCasters.h"
+
+#include <ATen/ATen.h>
+#include <ATen/ops/tensor.h>
+#include <memory>
+#include <optional>
+#include <pybind11/pybind11.h>
+
+namespace tensorrt_llm::pybind::batch_manager
+{
+
+namespace tb = tensorrt_llm::batch_manager;
+
+/* Unfortunately, torch's default pybind bindings don't know about c10::cuda::CUDAStream,
+ * so we have to pass the more generic c10::Stream, and convert it back to a full-fledged
+ * torch.cuda.Stream in python. See example in test/bindings/test_gpt_manager.py
+ */
+class LlmRequest : public tb::GenericLlmRequest<at::Tensor, c10::Stream>
+{
+public:
+    using Base = GenericLlmRequest<at::Tensor, c10::Stream>;
+    using TensorPtr = Base::TensorPtr;
+    using SizeType32 = Base::SizeType32;
+    using TokenIdType = Base::TokenIdType;
+    using RequestIdType = Base::RequestIdType;
+    using LoraTaskIdType = Base::LoraTaskIdType;
+    using VecLogProbs = Base::VecLogProbs;
+    using BeamTokens = Base::BeamTokens;
+    using VecTokens = Base::VecTokens;
+    using VecTokenExtraIds = Base::VecTokenExtraIds;
+    using LogitsPostProcessor = Base::LogitsPostProcessor;
+
+    // 49 parameters
+    LlmRequest(RequestIdType requestId, SizeType32 maxNewTokens, std::vector<TokenIdType> inputTokens,
+        runtime::SamplingConfig samplingConfig, bool isStreaming, std::optional<SizeType32> endId = std::nullopt,
+        std::optional<SizeType32> padId = std::nullopt, std::optional<TensorPtr> embeddingBias = std::nullopt,
+        std::optional<TensorPtr> badWordsList = std::nullopt, std::optional<TensorPtr> stopWordsList = std::nullopt,
+        std::optional<std::vector<SizeType32>> positionIds = std::nullopt,
+        std::optional<TensorPtr> promptEmbeddingTable = std::nullopt,
+        std::optional<SizeType32> promptVocabSize = std::nullopt,
+        std::optional<std::vector<std::vector<SizeType32>>> multimodalHashes = std::nullopt,
+        std::optional<std::vector<SizeType32>> multimodalPositions = std::nullopt,
+        std::optional<std::vector<SizeType32>> multimodalLengths = std::nullopt,
+        std::optional<TensorPtr> multimodalEmbedding = std::nullopt,
+        std::optional<TensorPtr> mropeRotaryCosSin = std::nullopt,
+        std::optional<SizeType32> mropePositionDeltas = std::nullopt,
+        std::optional<LoraTaskIdType> loraTaskId = std::nullopt, std::optional<TensorPtr> loraWeights = std::nullopt,
+        std::optional<TensorPtr> loraConfig = std::nullopt,
+        std::optional<executor::LookaheadDecodingConfig> lookaheadConfig = std::nullopt,
+        std::optional<executor::KvCacheRetentionConfig> kvCacheRetentionConfig = std::nullopt,
+        bool returnLogProbs = false, bool returnContextLogits = false, bool returnGenerationLogits = false,
+        std::optional<VecTokens> draftTokens = std::nullopt, std::optional<TensorPtr> draftLogits = std::nullopt,
+        bool excludeInputFromOutput = false, std::optional<LogitsPostProcessor> logitsPostProcessor = std::nullopt,
+        bool applyLogitsPostProcessorBatched = false, std::optional<VecTokens> encoderInputTokens = std::nullopt,
+        bool returnEncoderOutput = false, std::optional<RequestIdType> clientId = std::nullopt,
+        executor::PriorityType priority = executor::Request::kDefaultPriority,
+        std::optional<TensorPtr> encoderInputFeatures = std::nullopt,
+        std::optional<SizeType32> encoderOutputLength = std::nullopt,
+        std::optional<TensorPtr> crossAttentionMask = std::nullopt,
+        tb::LlmRequestType llmRequestType = tb::LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION,
+        std::optional<VecTokenExtraIds> inputTokenExtraIds = std::nullopt, SizeType32 numReturnSequences = 1,
+        std::optional<executor::EagleConfig> eagleConfig = std::nullopt,
+        std::optional<TensorPtr> skipCrossAttnBlocks = std::nullopt, bool returnPerfMetrics = false,
+        std::optional<executor::GuidedDecodingParams> guidedDecodingParams = std::nullopt,
+        std::optional<SizeType32> languageAdapterUid = std::nullopt,
+        std::optional<MillisecondsType> allottedTimeMs = std::nullopt,
+        std::optional<executor::ContextPhaseParams> const& contextPhaseParams = std::nullopt)
+        : Base(requestId,                                                                                       //
+            maxNewTokens,                                                                                       //
+            std::make_shared<std::vector<TokenIdType>>(std::move(inputTokens)),                                 //
+            samplingConfig,                                                                                     //
+            isStreaming,                                                                                        //
+            endId,                                                                                              //
+            padId,                                                                                              //
+            embeddingBias,                                                                                      //
+            badWordsList,                                                                                       //
+            stopWordsList,                                                                                      //
+            positionIds.has_value() ? std::make_shared<std::vector<SizeType32>>(std::move(positionIds.value())) //
+                                    : std::optional<std::shared_ptr<std::vector<SizeType32>>>(std::nullopt),    //
+            promptEmbeddingTable,                                                                               //
+            promptVocabSize,                                                                                    //
+            multimodalHashes.has_value()
+                ? std::make_optional(
+                    std::make_shared<std::vector<std::vector<SizeType32>>>(std::move(multimodalHashes.value()))) //
+                : std::optional<std::shared_ptr<std::vector<std::vector<SizeType32>>>>(std::nullopt),            //
+            multimodalPositions.has_value()
+                ? std::make_shared<std::vector<SizeType32>>(std::move(multimodalPositions.value()))              //
+                : std::optional<std::shared_ptr<std::vector<SizeType32>>>(std::nullopt),                         //
+            multimodalLengths.has_value()
+                ? std::make_shared<std::vector<SizeType32>>(std::move(multimodalLengths.value()))                //
+                : std::optional<std::shared_ptr<std::vector<SizeType32>>>(std::nullopt),                         //
+            multimodalEmbedding,                                                                                 //
+            mropeRotaryCosSin,                                                                                   //
+            mropePositionDeltas,                                                                                 //
+            loraTaskId,                                                                                          //
+            loraWeights,                                                                                         //
+            loraConfig,                                                                                          //
+            lookaheadConfig,                                                                                     //
+            kvCacheRetentionConfig,                                                                              //
+            returnLogProbs,                                                                                      //
+            returnContextLogits,                                                                                 //
+            returnGenerationLogits,                                                                              //
+            draftTokens.has_value() ? std::make_shared<VecTokens>(std::move(draftTokens.value()))                //
+                                    : std::make_shared<VecTokens>(),                                             //
+            draftLogits,                                                                                         //
+            excludeInputFromOutput,                                                                              //
+            logitsPostProcessor,                                                                                 //
+            applyLogitsPostProcessorBatched,                                                                     //
+            encoderInputTokens ? std::make_optional(std::make_shared<VecTokens>(std::move(*encoderInputTokens))) //
+                               : std::optional<std::shared_ptr<VecTokens>>(std::nullopt),                        //
+            returnEncoderOutput,                                                                                 //
+            clientId,                                                                                            //
+            priority,                                                                                            //
+            encoderInputFeatures,                                                                                //
+            encoderOutputLength,                                                                                 //
+            crossAttentionMask,                                                                                  //
+            llmRequestType,                                                                                      //
+            inputTokenExtraIds                                                                                   //
+                ? std::make_optional(std::make_shared<VecTokenExtraIds>(std::move(*inputTokenExtraIds)))         //
+                : std::optional<std::shared_ptr<VecTokenExtraIds>>(std::nullopt),                                //
+            numReturnSequences,                                                                                  //
+            eagleConfig,                                                                                         //
+            skipCrossAttnBlocks,                                                                                 //
+            returnPerfMetrics,                                                                                   //
+            guidedDecodingParams,                                                                                //
+            languageAdapterUid,                                                                                  //
+            allottedTimeMs,                                                                                      //
+            contextPhaseParams                                                                                   //
+        )
+    {
+    }
+
+    static std::optional<tb::LlmRequest::LogitsPostProcessor> callbackAdapter(
+        std::optional<LlmRequest::LogitsPostProcessor> callback);
+
+    [[nodiscard]] std::shared_ptr<tensorrt_llm::batch_manager::LlmRequest> toTrtLlm() const;
+};
+
+} // namespace tensorrt_llm::pybind::batch_manager

--- a/cpp/tensorrt_llm/nanobind/batch_manager/llmRequest.h
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/llmRequest.h
@@ -18,20 +18,19 @@
 #pragma once
 
 #include "tensorrt_llm/batch_manager/llmRequest.h"
-#include "tensorrt_llm/pybind/common/customCasters.h"
+#include "tensorrt_llm/nanobind/common/customCasters.h"
 
 #include <ATen/ATen.h>
 #include <ATen/ops/tensor.h>
 #include <memory>
 #include <optional>
-#include <pybind11/pybind11.h>
 
-namespace tensorrt_llm::pybind::batch_manager
+namespace tensorrt_llm::nanobind::batch_manager
 {
 
 namespace tb = tensorrt_llm::batch_manager;
 
-/* Unfortunately, torch's default pybind bindings don't know about c10::cuda::CUDAStream,
+/* Unfortunately, torch's default nanobind bindings don't know about c10::cuda::CUDAStream,
  * so we have to pass the more generic c10::Stream, and convert it back to a full-fledged
  * torch.cuda.Stream in python. See example in test/bindings/test_gpt_manager.py
  */
@@ -156,4 +155,4 @@ public:
     [[nodiscard]] std::shared_ptr<tensorrt_llm::batch_manager::LlmRequest> toTrtLlm() const;
 };
 
-} // namespace tensorrt_llm::pybind::batch_manager
+} // namespace tensorrt_llm::nanobind::batch_manager

--- a/cpp/tensorrt_llm/nanobind/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/bindings.cpp
@@ -15,26 +15,30 @@
  * limitations under the License.
  */
 
-#include <pybind11/cast.h>
-#include <pybind11/functional.h>
-#include <pybind11/operators.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/bind_vector.h>
+#include <nanobind/stl/filesystem.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/tuple.h>
+#include <nanobind/stl/unique_ptr.h>
+
 #include <torch/extension.h>
 #include <vector>
 
 #include "tensorrt_llm/batch_manager/peftCacheManagerConfig.h"
 #include "tensorrt_llm/common/quantization.h"
-#include "tensorrt_llm/pybind/batch_manager/algorithms.h"
-#include "tensorrt_llm/pybind/batch_manager/bindings.h"
-#include "tensorrt_llm/pybind/batch_manager/buffers.h"
-#include "tensorrt_llm/pybind/batch_manager/cacheTransceiver.h"
-#include "tensorrt_llm/pybind/batch_manager/kvCacheManager.h"
-#include "tensorrt_llm/pybind/batch_manager/llmRequest.h"
-#include "tensorrt_llm/pybind/executor/bindings.h"
-#include "tensorrt_llm/pybind/runtime/bindings.h"
-#include "tensorrt_llm/pybind/testing/modelSpecBinding.h"
-#include "tensorrt_llm/pybind/userbuffers/bindings.h"
+#include "tensorrt_llm/nanobind/batch_manager/algorithms.h"
+#include "tensorrt_llm/nanobind/batch_manager/bindings.h"
+#include "tensorrt_llm/nanobind/batch_manager/buffers.h"
+#include "tensorrt_llm/nanobind/batch_manager/cacheTransceiver.h"
+#include "tensorrt_llm/nanobind/batch_manager/kvCacheManager.h"
+#include "tensorrt_llm/nanobind/batch_manager/llmRequest.h"
+#include "tensorrt_llm/nanobind/executor/bindings.h"
+#include "tensorrt_llm/nanobind/runtime/bindings.h"
+#include "tensorrt_llm/nanobind/testing/modelSpecBinding.h"
+#include "tensorrt_llm/nanobind/userbuffers/bindings.h"
 #include "tensorrt_llm/runtime/common.h"
 #include "tensorrt_llm/runtime/cudaStream.h"
 #include "tensorrt_llm/runtime/gptJsonConfig.h"
@@ -42,11 +46,12 @@
 #include "tensorrt_llm/runtime/memoryCounters.h"
 #include "tensorrt_llm/runtime/samplingConfig.h"
 #include "tensorrt_llm/runtime/utils/mpiUtils.h"
+#include <iostream>
 
-namespace py = pybind11;
+namespace nb = nanobind;
 namespace tb = tensorrt_llm::batch_manager;
 namespace tbk = tensorrt_llm::batch_manager::kv_cache_manager;
-namespace tpb = tensorrt_llm::pybind::batch_manager;
+namespace tpb = tensorrt_llm::nanobind::batch_manager;
 namespace tc = tensorrt_llm::common;
 namespace tr = tensorrt_llm::runtime;
 namespace tle = tensorrt_llm::executor;
@@ -55,8 +60,8 @@ using TokenIdType = tr::TokenIdType;
 template <typename T>
 using OptVec = std::optional<std::vector<T>>;
 
-#if not defined(TRTLLM_PYBIND_MODULE)
-#error "TRTLLM_PYBIND_MODULE must be defined"
+#if not defined(TRTLLM_NB_MODULE)
+#error "TRTLLM_NB_MODULE must be defined"
 #endif
 
 namespace
@@ -67,13 +72,14 @@ tr::SamplingConfig makeSamplingConfig(std::vector<tr::SamplingConfig> const& con
 }
 } // namespace
 
-PYBIND11_MODULE(TRTLLM_PYBIND_MODULE, m)
+NB_MODULE(TRTLLM_NB_MODULE, m)
 {
     m.doc() = "TensorRT-LLM Python bindings for C++ runtime";
-    m.attr("binding_type") = "pybind";
+    m.attr("binding_type") = "nanobind";
+    nb::set_leak_warnings(false);
 
     // Create MpiComm binding first since it's used in the executor bindings
-    py::classh<tensorrt_llm::mpi::MpiComm>(m, "MpiComm")
+    nb::class_<tensorrt_llm::mpi::MpiComm>(m, "MpiComm")
         .def_static("rank",
             []()
             {
@@ -102,14 +108,15 @@ PYBIND11_MODULE(TRTLLM_PYBIND_MODULE, m)
                 tensorrt_llm::mpi::MpiComm::setSession(world.split(color, rank));
             });
 
-    py::classh<tr::CudaStream>(m, "CudaStream")
-        .def(py::init(
-                 [](py::object py_stream)
-                 {
-                     cudaStream_t stream = reinterpret_cast<cudaStream_t>(py_stream.cast<uintptr_t>());
-                     return tr::CudaStream{stream};
-                 }),
-            py::arg("stream_ptr"))
+    nb::class_<tr::CudaStream>(m, "CudaStream")
+        .def(
+            "__init__",
+            [](tr::CudaStream* self, nb::object py_stream)
+            {
+                cudaStream_t stream = reinterpret_cast<cudaStream_t>(nb::cast<uintptr_t>(py_stream));
+                new (self) tr::CudaStream{stream};
+            },
+            nb::arg("stream_ptr"))
         .def("get_device", &tr::CudaStream::getDevice);
 
     // Create submodule for executor bindings.
@@ -119,35 +126,35 @@ PYBIND11_MODULE(TRTLLM_PYBIND_MODULE, m)
     auto mInternalTesting = mInternal.def_submodule("testing", "Testing internal bindings");
     auto mInternalBatchManager = mInternal.def_submodule("batch_manager", "Batch manager internal bindings");
 
-    tensorrt_llm::pybind::executor::initBindings(mExecutor);
-    tensorrt_llm::pybind::runtime::initBindingsEarly(mInternalRuntime);
+    tensorrt_llm::nanobind::executor::initBindings(mExecutor);
+    tensorrt_llm::nanobind::runtime::initBindingsEarly(mInternalRuntime);
 
     auto buildInfo = m.def_submodule("BuildInfo");
-    buildInfo.attr("ENABLE_MULTI_DEVICE") = py::int_(ENABLE_MULTI_DEVICE);
+    buildInfo.attr("ENABLE_MULTI_DEVICE") = nb::int_(ENABLE_MULTI_DEVICE);
 
-    py::class_<tb::PeftCacheManagerConfig>(m, "PeftCacheManagerConfig")
-        .def(py::init<SizeType32, SizeType32, SizeType32, SizeType32, SizeType32, SizeType32, SizeType32, SizeType32,
+    nb::class_<tb::PeftCacheManagerConfig>(m, "PeftCacheManagerConfig")
+        .def(nb::init<SizeType32, SizeType32, SizeType32, SizeType32, SizeType32, SizeType32, SizeType32, SizeType32,
                  SizeType32, std::optional<float>, std::optional<size_t>, std::optional<std::string>>(),
-            py::arg("num_host_module_layer") = 0, py::arg("num_device_module_layer") = 0,
-            py::arg("optimal_adapter_size") = 8, py::arg("max_adapter_size") = 64, py::arg("num_put_workers") = 1,
-            py::arg("num_ensure_workers") = 1, py::arg("num_copy_streams") = 1,
-            py::arg("max_pages_per_block_host") = 24, py::arg("max_pages_per_block_device") = 8,
-            py::arg("device_cache_percent") = std::nullopt, py::arg("host_cache_size") = std::nullopt,
-            py::arg("lora_prefetch_dir") = std::nullopt)
-        .def_readwrite("num_host_module_layer", &tb::PeftCacheManagerConfig::numHostModuleLayer)
-        .def_readwrite("num_device_module_layer", &tb::PeftCacheManagerConfig::numDeviceModuleLayer)
-        .def_readwrite("optimal_adapter_size", &tb::PeftCacheManagerConfig::optimalAdapterSize)
-        .def_readwrite("max_adapter_size", &tb::PeftCacheManagerConfig::maxAdapterSize)
-        .def_readwrite("num_put_workers", &tb::PeftCacheManagerConfig::numPutWorkers)
-        .def_readwrite("num_ensure_workers", &tb::PeftCacheManagerConfig::numEnsureWorkers)
-        .def_readwrite("num_copy_streams", &tb::PeftCacheManagerConfig::numCopyStreams)
-        .def_readwrite("max_pages_per_block_host", &tb::PeftCacheManagerConfig::maxPagesPerBlockHost)
-        .def_readwrite("max_pages_per_block_device", &tb::PeftCacheManagerConfig::maxPagesPerBlockDevice)
-        .def_readwrite("device_cache_percent", &tb::PeftCacheManagerConfig::deviceCachePercent)
-        .def_readwrite("host_cache_size", &tb::PeftCacheManagerConfig::hostCacheSize)
-        .def_readwrite("lora_prefetch_dir", &tb::PeftCacheManagerConfig::loraPrefetchDir);
+            nb::arg("num_host_module_layer") = 0, nb::arg("num_device_module_layer") = 0,
+            nb::arg("optimal_adapter_size") = 8, nb::arg("max_adapter_size") = 64, nb::arg("num_put_workers") = 1,
+            nb::arg("num_ensure_workers") = 1, nb::arg("num_copy_streams") = 1,
+            nb::arg("max_pages_per_block_host") = 24, nb::arg("max_pages_per_block_device") = 8,
+            nb::arg("device_cache_percent") = std::nullopt, nb::arg("host_cache_size") = std::nullopt,
+            nb::arg("lora_prefetch_dir") = std::nullopt)
+        .def_rw("num_host_module_layer", &tb::PeftCacheManagerConfig::numHostModuleLayer)
+        .def_rw("num_device_module_layer", &tb::PeftCacheManagerConfig::numDeviceModuleLayer)
+        .def_rw("optimal_adapter_size", &tb::PeftCacheManagerConfig::optimalAdapterSize)
+        .def_rw("max_adapter_size", &tb::PeftCacheManagerConfig::maxAdapterSize)
+        .def_rw("num_put_workers", &tb::PeftCacheManagerConfig::numPutWorkers)
+        .def_rw("num_ensure_workers", &tb::PeftCacheManagerConfig::numEnsureWorkers)
+        .def_rw("num_copy_streams", &tb::PeftCacheManagerConfig::numCopyStreams)
+        .def_rw("max_pages_per_block_host", &tb::PeftCacheManagerConfig::maxPagesPerBlockHost)
+        .def_rw("max_pages_per_block_device", &tb::PeftCacheManagerConfig::maxPagesPerBlockDevice)
+        .def_rw("device_cache_percent", &tb::PeftCacheManagerConfig::deviceCachePercent)
+        .def_rw("host_cache_size", &tb::PeftCacheManagerConfig::hostCacheSize)
+        .def_rw("lora_prefetch_dir", &tb::PeftCacheManagerConfig::loraPrefetchDir);
 
-    py::enum_<nvinfer1::DataType>(m, "DataType")
+    nb::enum_<nvinfer1::DataType>(m, "DataType")
         .value("FLOAT", nvinfer1::DataType::kFLOAT)
         .value("HALF", nvinfer1::DataType::kHALF)
         .value("INT8", nvinfer1::DataType::kINT8)
@@ -159,24 +166,24 @@ PYBIND11_MODULE(TRTLLM_PYBIND_MODULE, m)
         .value("INT64", nvinfer1::DataType::kINT64)
         .export_values();
 
-    py::enum_<tr::ModelConfig::ModelVariant>(m, "GptModelVariant")
+    nb::enum_<tr::ModelConfig::ModelVariant>(m, "GptModelVariant")
         .value("GPT", tr::ModelConfig::ModelVariant::kGpt)
         .value("GLM", tr::ModelConfig::ModelVariant::kGlm)
         .value("CHATGLM", tr::ModelConfig::ModelVariant::kChatGlm)
         .value("MAMBA", tr::ModelConfig::ModelVariant::kMamba)
         .value("RECURRENTGEMMA", tr::ModelConfig::ModelVariant::kRecurrentGemma);
 
-    py::enum_<tr::ModelConfig::KVCacheType>(m, "KVCacheType")
+    nb::enum_<tr::ModelConfig::KVCacheType>(m, "KVCacheType")
         .value("CONTINUOUS", tr::ModelConfig::KVCacheType::kCONTINUOUS)
         .value("PAGED", tr::ModelConfig::KVCacheType::kPAGED)
         .value("DISABLED", tr::ModelConfig::KVCacheType::kDISABLED)
-        .def(py::init(&tr::ModelConfig::KVCacheTypeFromString));
+        .def("from_string", tr::ModelConfig::KVCacheTypeFromString);
 
-    py::enum_<tr::ModelConfig::LayerType>(m, "LayerType")
+    nb::enum_<tr::ModelConfig::LayerType>(m, "LayerType")
         .value("ATTENTION", tr::ModelConfig::LayerType::kATTENTION)
         .value("RECURRENT", tr::ModelConfig::LayerType::kRECURRENT);
 
-    py::enum_<tr::LoraModule::ModuleType>(m, "LoraModuleType")
+    nb::enum_<tr::LoraModule::ModuleType>(m, "LoraModuleType")
         .value("INVALID", tr::LoraModule::ModuleType::kINVALID)
         .value("ATTN_QKV", tr::LoraModule::ModuleType::kATTN_QKV)
         .value("ATTN_Q", tr::LoraModule::ModuleType::kATTN_Q)
@@ -198,23 +205,23 @@ PYBIND11_MODULE(TRTLLM_PYBIND_MODULE, m)
         .value("MLP_ROUTER", tr::LoraModule::ModuleType::kMLP_ROUTER)
         .value("MLP_GATE_UP", tr::LoraModule::ModuleType::kMLP_GATE_UP);
 
-    py::class_<tr::LoraModule>(m, "LoraModule")
-        .def(py::init<tr::LoraModule::ModuleType, SizeType32, SizeType32, bool, bool, SizeType32, SizeType32>(),
-            py::arg("module_type"), py::arg("in_dim"), py::arg("out_dim"), py::arg("in_dim_first"),
-            py::arg("out_dim_first"), py::arg("in_tp_split_dim"), py::arg("out_tp_split_dim"))
-        .def_property_readonly("module_type", &tr::LoraModule::name)
-        .def_property_readonly("in_dim", &tr::LoraModule::inDim)
-        .def_property_readonly("out_dim", &tr::LoraModule::outDim)
-        .def_property_readonly("in_dim_first", &tr::LoraModule::inDimFirst)
-        .def_property_readonly("out_dim_first", &tr::LoraModule::outDimFirst)
-        .def_property_readonly("in_tp_split_dim", &tr::LoraModule::inTpSplitDim)
-        .def_property_readonly("out_tp_split_dim", &tr::LoraModule::outTpSplitDim)
-        .def_static("create_lora_modules", &tr::LoraModule::createLoraModules, py::arg("lora_module_names"),
-            py::arg("hidden_size"), py::arg("mlp_hidden_size"), py::arg("num_attention_heads"),
-            py::arg("num_kv_attention_heads"), py::arg("attention_head_size"), py::arg("tp_size") = 1,
-            py::arg("num_experts") = 0);
+    nb::class_<tr::LoraModule>(m, "LoraModule")
+        .def(nb::init<tr::LoraModule::ModuleType, SizeType32, SizeType32, bool, bool, SizeType32, SizeType32>(),
+            nb::arg("module_type"), nb::arg("in_dim"), nb::arg("out_dim"), nb::arg("in_dim_first"),
+            nb::arg("out_dim_first"), nb::arg("in_tp_split_dim"), nb::arg("out_tp_split_dim"))
+        .def_prop_ro("module_type", &tr::LoraModule::name)
+        .def_prop_ro("in_dim", &tr::LoraModule::inDim)
+        .def_prop_ro("out_dim", &tr::LoraModule::outDim)
+        .def_prop_ro("in_dim_first", &tr::LoraModule::inDimFirst)
+        .def_prop_ro("out_dim_first", &tr::LoraModule::outDimFirst)
+        .def_prop_ro("in_tp_split_dim", &tr::LoraModule::inTpSplitDim)
+        .def_prop_ro("out_tp_split_dim", &tr::LoraModule::outTpSplitDim)
+        .def_static("create_lora_modules", &tr::LoraModule::createLoraModules, nb::arg("lora_module_names"),
+            nb::arg("hidden_size"), nb::arg("mlp_hidden_size"), nb::arg("num_attention_heads"),
+            nb::arg("num_kv_attention_heads"), nb::arg("attention_head_size"), nb::arg("tp_size") = 1,
+            nb::arg("num_experts") = 0);
 
-    py::class_<tc::QuantMode>(m, "QuantMode")
+    nb::class_<tc::QuantMode>(m, "QuantMode")
         .def_static("none", &tc::QuantMode::none)
         .def_static("int4_weights", &tc::QuantMode::int4Weights)
         .def_static("int8_weights", &tc::QuantMode::int8Weights)
@@ -225,219 +232,221 @@ PYBIND11_MODULE(TRTLLM_PYBIND_MODULE, m)
         .def_static("int8_kv_cache", &tc::QuantMode::int8KvCache)
         .def_static("fp8_kv_cache", &tc::QuantMode::fp8KvCache)
         .def_static("fp8_qdq", &tc::QuantMode::fp8Qdq)
-        .def_property_readonly("value", &tc::QuantMode::value)
-        .def("is_set", &tc::QuantMode::isSet, py::arg("mode"))
-        .def_property_readonly("has_int4_weights", &tc::QuantMode::hasInt4Weights)
-        .def_property_readonly("has_int8_weights", &tc::QuantMode::hasInt8Weights)
-        .def_property_readonly("has_activations", &tc::QuantMode::hasActivations)
-        .def_property_readonly("has_per_channel_scaling", &tc::QuantMode::hasPerChannelScaling)
-        .def_property_readonly("has_per_token_scaling", &tc::QuantMode::hasPerTokenScaling)
-        .def_property_readonly("has_per_group_scaling", &tc::QuantMode::hasPerGroupScaling)
-        .def_property_readonly("has_static_activation_scaling", &tc::QuantMode::hasStaticActivationScaling)
-        .def_property_readonly("has_int8_kv_cache", &tc::QuantMode::hasInt8KvCache)
-        .def_property_readonly("has_fp8_kv_cache", &tc::QuantMode::hasFp8KvCache)
-        .def_property_readonly("has_fp8_qdq", &tc::QuantMode::hasFp8Qdq)
-        .def_property_readonly("has_nvfp4", &tc::QuantMode::hasNvfp4)
-        .def_property_readonly("has_w4a8_mxfp4_fp8", &tc::QuantMode::hasW4a8Mxfp4Fp8)
-        .def_property_readonly("has_kv_cache_quant", &tc::QuantMode::hasKvCacheQuant)
-        .def_static("from_description", &tc::QuantMode::fromDescription, py::arg("quantize_weights"),
-            py::arg("quantize_activations"), py::arg("per_token"), py::arg("per_channel"), py::arg("per_group"),
-            py::arg("use_int4_weights"), py::arg("use_int8_kv_cache"), py::arg("use_fp8_kv_kache"),
-            py::arg("use_fp8_qdq"), py::arg("use_fp8_rowwise"), py::arg("use_w4a8_qserve"), py::arg("use_nvfp4"),
-            py::arg("use_fp8_block_scales"), py::arg("use_w4a8_mxfp4_fp8"))
-        .def_static("use_smooth_quant", &tc::QuantMode::useSmoothQuant, py::arg("per_token") = false,
-            py::arg("per_channel") = false)
-        .def_static("use_weight_only", &tc::QuantMode::useWeightOnly, py::arg("use_int4_weights") = false,
-            py::arg("per_group") = false)
-        .def_static("from_quant_algo", &tc::QuantMode::fromQuantAlgo, py::arg("quant_algo") = py::none(),
-            py::arg("kv_cache_quant_algo") = py::none())
-        .def(py::self + py::self)
-        .def(py::self += py::self)
-        .def(py::self - py::self)
-        .def(py::self -= py::self)
-        .def(py::self == py::self)
-        .def(py::self != py::self);
+        .def_prop_ro("value", &tc::QuantMode::value)
+        .def("is_set", &tc::QuantMode::isSet, nb::arg("mode"))
+        .def_prop_ro("has_int4_weights", &tc::QuantMode::hasInt4Weights)
+        .def_prop_ro("has_int8_weights", &tc::QuantMode::hasInt8Weights)
+        .def_prop_ro("has_activations", &tc::QuantMode::hasActivations)
+        .def_prop_ro("has_per_channel_scaling", &tc::QuantMode::hasPerChannelScaling)
+        .def_prop_ro("has_per_token_scaling", &tc::QuantMode::hasPerTokenScaling)
+        .def_prop_ro("has_per_group_scaling", &tc::QuantMode::hasPerGroupScaling)
+        .def_prop_ro("has_static_activation_scaling", &tc::QuantMode::hasStaticActivationScaling)
+        .def_prop_ro("has_int8_kv_cache", &tc::QuantMode::hasInt8KvCache)
+        .def_prop_ro("has_fp8_kv_cache", &tc::QuantMode::hasFp8KvCache)
+        .def_prop_ro("has_fp8_qdq", &tc::QuantMode::hasFp8Qdq)
+        .def_prop_ro("has_nvfp4", &tc::QuantMode::hasNvfp4)
+        .def_prop_ro("has_w4a8_mxfp4_fp8", &tc::QuantMode::hasW4a8Mxfp4Fp8)
+        .def_prop_ro("has_kv_cache_quant", &tc::QuantMode::hasKvCacheQuant)
+        .def_static("from_description", &tc::QuantMode::fromDescription, nb::arg("quantize_weights"),
+            nb::arg("quantize_activations"), nb::arg("per_token"), nb::arg("per_channel"), nb::arg("per_group"),
+            nb::arg("use_int4_weights"), nb::arg("use_int8_kv_cache"), nb::arg("use_fp8_kv_kache"),
+            nb::arg("use_fp8_qdq"), nb::arg("use_fp8_rowwise"), nb::arg("use_w4a8_qserve"), nb::arg("use_nvfp4"),
+            nb::arg("use_fp8_block_scales"), nb::arg("use_w4a8_mxfp4_fp8"))
+        .def_static("use_smooth_quant", &tc::QuantMode::useSmoothQuant, nb::arg("per_token") = false,
+            nb::arg("per_channel") = false)
+        .def_static("use_weight_only", &tc::QuantMode::useWeightOnly, nb::arg("use_int4_weights") = false,
+            nb::arg("per_group") = false)
+        .def_static("from_quant_algo", &tc::QuantMode::fromQuantAlgo, nb::arg("quant_algo") = nb::none(),
+            nb::arg("kv_cache_quant_algo") = nb::none())
+        .def("__add__", [](tc::QuantMode const& self, tc::QuantMode const& other) { return self + other; })
+        .def("__iadd__", [](tc::QuantMode& self, tc::QuantMode const& other) { return self += other; })
+        .def("__sub__", [](tc::QuantMode const& self, tc::QuantMode const& other) { return self - other; })
+        .def("__isub__", [](tc::QuantMode& self, tc::QuantMode const& other) { return self -= other; })
+        .def("__eq__", [](tc::QuantMode const& self, tc::QuantMode const& other) { return self == other; })
+        .def("__ne__", [](tc::QuantMode const& self, tc::QuantMode const& other) { return self != other; });
 
-    py::class_<tr::ModelConfig>(m, "ModelConfig")
-        .def(py::init<SizeType32, SizeType32, SizeType32, SizeType32, SizeType32, SizeType32, nvinfer1::DataType>(),
-            py::arg("vocab_size"), py::arg("num_layers"), py::arg("num_attention_layers"), py::arg("num_rnn_layers"),
-            py::arg("num_heads"), py::arg("hidden_size"), py::arg("data_type"))
-        .def_property_readonly("vocab_size", &tr::ModelConfig::getVocabSize)
-        .def("vocab_size_padded", &tr::ModelConfig::getVocabSizePadded, py::arg("world_size"))
-        .def("num_layers", &tr::ModelConfig::getNbLayers, py::arg("pipeline_parallelism") = 1,
-            py::arg("pipeline_parallelism_rank") = 0)
-        .def("num_attention_layers", &tr::ModelConfig::getNbAttentionLayers, py::arg("pipeline_parallelism") = 1,
-            py::arg("pipeline_parallelism_rank") = 0)
-        .def("num_rnn_layers", &tr::ModelConfig::getNbRnnLayers, py::arg("pipeline_parallelism") = 1,
-            py::arg("pipeline_parallelism_rank") = 0)
-        .def("num_kv_heads", &tr::ModelConfig::getNbKvHeads, py::arg("layer_idx"))
-        .def("set_num_kv_heads", &tr::ModelConfig::setNbKvHeads, py::arg("num_kv_heads"))
-        .def_property_readonly("num_heads", &tr::ModelConfig::getNbHeads)
-        .def_property_readonly("hidden_size", &tr::ModelConfig::getHiddenSize)
-        .def_property_readonly("size_per_head", &tr::ModelConfig::getSizePerHead)
-        .def_property_readonly("data_type", &tr::ModelConfig::getDataType)
-        .def_property_readonly("speculative_decoding_mode", &tr::ModelConfig::getSpeculativeDecodingMode)
-        .def_property("head_size", &tr::ModelConfig::getSizePerHead, &tr::ModelConfig::setSizePerHead)
-        .def_property(
+    nb::class_<tr::ModelConfig>(m, "ModelConfig")
+        .def(nb::init<SizeType32, SizeType32, SizeType32, SizeType32, SizeType32, SizeType32, nvinfer1::DataType>(),
+            nb::arg("vocab_size"), nb::arg("num_layers"), nb::arg("num_attention_layers"), nb::arg("num_rnn_layers"),
+            nb::arg("num_heads"), nb::arg("hidden_size"), nb::arg("data_type"))
+        .def_prop_ro("vocab_size", &tr::ModelConfig::getVocabSize)
+        .def("vocab_size_padded", &tr::ModelConfig::getVocabSizePadded, nb::arg("world_size"))
+        .def("num_layers", &tr::ModelConfig::getNbLayers, nb::arg("pipeline_parallelism") = 1,
+            nb::arg("pipeline_parallelism_rank") = 0)
+        .def("num_attention_layers", &tr::ModelConfig::getNbAttentionLayers, nb::arg("pipeline_parallelism") = 1,
+            nb::arg("pipeline_parallelism_rank") = 0)
+        .def("num_rnn_layers", &tr::ModelConfig::getNbRnnLayers, nb::arg("pipeline_parallelism") = 1,
+            nb::arg("pipeline_parallelism_rank") = 0)
+        .def("num_kv_heads", &tr::ModelConfig::getNbKvHeads, nb::arg("layer_idx"))
+        .def("set_num_kv_heads", &tr::ModelConfig::setNbKvHeads, nb::arg("num_kv_heads"))
+        .def_prop_ro("num_heads", &tr::ModelConfig::getNbHeads)
+        .def_prop_ro("hidden_size", &tr::ModelConfig::getHiddenSize)
+        .def_prop_ro("size_per_head", &tr::ModelConfig::getSizePerHead)
+        .def_prop_ro("data_type", &tr::ModelConfig::getDataType)
+        .def_prop_ro("speculative_decoding_mode", &tr::ModelConfig::getSpeculativeDecodingMode)
+        .def_prop_rw("head_size", &tr::ModelConfig::getSizePerHead, &tr::ModelConfig::setSizePerHead)
+        .def_prop_rw(
             "num_kv_heads_per_layer", &tr::ModelConfig::getNumKvHeadsPerLayer, &tr::ModelConfig::setNumKvHeadsPerLayer)
-        .def_property("use_gpt_attention_plugin",
-            py::overload_cast<>(&tr::ModelConfig::useGptAttentionPlugin, py::const_),
-            py::overload_cast<bool>(&tr::ModelConfig::useGptAttentionPlugin))
-        .def_property("use_packed_input", py::overload_cast<>(&tr::ModelConfig::usePackedInput, py::const_),
-            py::overload_cast<bool>(&tr::ModelConfig::usePackedInput))
-        .def_property("kv_cache_type", py::overload_cast<>(&tr::ModelConfig::getKVCacheType, py::const_),
-            py::overload_cast<tr::ModelConfig::KVCacheType>(&tr::ModelConfig::setKVCacheType))
-        .def_property("tokens_per_block", &tr::ModelConfig::getTokensPerBlock, &tr::ModelConfig::setTokensPerBlock)
-        .def_property("quant_mode", &tr::ModelConfig::getQuantMode, &tr::ModelConfig::setQuantMode)
-        .def_property_readonly("supports_inflight_batching", &tr::ModelConfig::supportsInflightBatching)
-        .def_property("max_batch_size", &tr::ModelConfig::getMaxBatchSize, &tr::ModelConfig::setMaxBatchSize)
-        .def_property("max_beam_width", &tr::ModelConfig::getMaxBeamWidth, &tr::ModelConfig::setMaxBeamWidth)
-        .def_property("max_input_len", &tr::ModelConfig::getMaxInputLen, &tr::ModelConfig::setMaxInputLen)
-        .def_property("max_seq_len", &tr::ModelConfig::getMaxSequenceLen, &tr::ModelConfig::setMaxSequenceLen)
-        .def_property("max_num_tokens", &tr::ModelConfig::getMaxNumTokens, &tr::ModelConfig::setMaxNumTokens)
-        .def_property("max_prompt_embedding_table_size", &tr::ModelConfig::getMaxPromptEmbeddingTableSize,
+        .def_prop_rw("use_gpt_attention_plugin",
+            nb::overload_cast<>(&tr::ModelConfig::useGptAttentionPlugin, nb::const_),
+            nb::overload_cast<bool>(&tr::ModelConfig::useGptAttentionPlugin))
+        .def_prop_rw("use_packed_input", nb::overload_cast<>(&tr::ModelConfig::usePackedInput, nb::const_),
+            nb::overload_cast<bool>(&tr::ModelConfig::usePackedInput))
+        .def_prop_rw("kv_cache_type", nb::overload_cast<>(&tr::ModelConfig::getKVCacheType, nb::const_),
+            nb::overload_cast<tr::ModelConfig::KVCacheType>(&tr::ModelConfig::setKVCacheType))
+        .def_prop_rw("tokens_per_block", &tr::ModelConfig::getTokensPerBlock, &tr::ModelConfig::setTokensPerBlock)
+        .def_prop_rw("quant_mode", &tr::ModelConfig::getQuantMode, &tr::ModelConfig::setQuantMode)
+        .def_prop_ro("supports_inflight_batching", &tr::ModelConfig::supportsInflightBatching)
+        .def_prop_rw("max_batch_size", &tr::ModelConfig::getMaxBatchSize, &tr::ModelConfig::setMaxBatchSize)
+        .def_prop_rw("max_beam_width", &tr::ModelConfig::getMaxBeamWidth, &tr::ModelConfig::setMaxBeamWidth)
+        .def_prop_rw("max_input_len", &tr::ModelConfig::getMaxInputLen, &tr::ModelConfig::setMaxInputLen)
+        .def_prop_rw("max_seq_len", &tr::ModelConfig::getMaxSequenceLen, &tr::ModelConfig::setMaxSequenceLen)
+        .def_prop_rw("max_num_tokens", &tr::ModelConfig::getMaxNumTokens, &tr::ModelConfig::setMaxNumTokens)
+        .def_prop_rw("max_prompt_embedding_table_size", &tr::ModelConfig::getMaxPromptEmbeddingTableSize,
             &tr::ModelConfig::setMaxPromptEmbeddingTableSize)
-        .def_property_readonly("use_prompt_tuning", &tr::ModelConfig::usePromptTuning)
-        .def_property_readonly("use_mrope", &tr::ModelConfig::useMrope)
-        .def_property("use_lora_plugin", py::overload_cast<>(&tr::ModelConfig::useLoraPlugin, py::const_),
-            py::overload_cast<bool>(&tr::ModelConfig::useLoraPlugin))
-        .def_property("layer_types", &tr::ModelConfig::getLayerTypes, &tr::ModelConfig::setLayerTypes)
-        .def_property("compute_context_logits", py::overload_cast<>(&tr::ModelConfig::computeContextLogits, py::const_),
-            py::overload_cast<bool>(&tr::ModelConfig::computeContextLogits))
-        .def_property("compute_generation_logits",
-            py::overload_cast<>(&tr::ModelConfig::computeGenerationLogits, py::const_),
-            py::overload_cast<bool>(&tr::ModelConfig::computeGenerationLogits))
-        .def_property("model_variant", &tr::ModelConfig::getModelVariant, &tr::ModelConfig::setModelVariant)
-        .def_property(
-            "use_cross_attention", &tr::ModelConfig::useCrossAttention, &tr::ModelConfig::setUseCrossAttention)
-        .def_property("lora_modules", &tr::ModelConfig::getLoraModules, &tr::ModelConfig::setLoraModules)
-        .def_property("max_lora_rank", &tr::ModelConfig::getMaxLoraRank, &tr::ModelConfig::setMaxLoraRank)
-        .def_property("mlp_hidden_size", &tr::ModelConfig::getMlpHiddenSize, &tr::ModelConfig::setMlpHiddenSize)
-        .def_property("size_per_head", &tr::ModelConfig::getSizePerHead, &tr::ModelConfig::setSizePerHead);
+        .def_prop_ro("use_prompt_tuning", &tr::ModelConfig::usePromptTuning)
+        .def_prop_ro("use_mrope", &tr::ModelConfig::useMrope)
+        .def_prop_rw("use_lora_plugin", nb::overload_cast<>(&tr::ModelConfig::useLoraPlugin, nb::const_),
+            nb::overload_cast<bool>(&tr::ModelConfig::useLoraPlugin))
+        .def_prop_rw("layer_types", &tr::ModelConfig::getLayerTypes, &tr::ModelConfig::setLayerTypes)
+        .def_prop_rw("compute_context_logits", nb::overload_cast<>(&tr::ModelConfig::computeContextLogits, nb::const_),
+            nb::overload_cast<bool>(&tr::ModelConfig::computeContextLogits))
+        .def_prop_rw("compute_generation_logits",
+            nb::overload_cast<>(&tr::ModelConfig::computeGenerationLogits, nb::const_),
+            nb::overload_cast<bool>(&tr::ModelConfig::computeGenerationLogits))
+        .def_prop_rw("model_variant", &tr::ModelConfig::getModelVariant, &tr::ModelConfig::setModelVariant)
+        .def_prop_rw("use_cross_attention", &tr::ModelConfig::useCrossAttention, &tr::ModelConfig::setUseCrossAttention)
+        .def_prop_rw("lora_modules", &tr::ModelConfig::getLoraModules, &tr::ModelConfig::setLoraModules)
+        .def_prop_rw("max_lora_rank", &tr::ModelConfig::getMaxLoraRank, &tr::ModelConfig::setMaxLoraRank)
+        .def_prop_rw("mlp_hidden_size", &tr::ModelConfig::getMlpHiddenSize, &tr::ModelConfig::setMlpHiddenSize)
+        .def_prop_rw("size_per_head", &tr::ModelConfig::getSizePerHead, &tr::ModelConfig::setSizePerHead);
 
-    py::class_<tr::WorldConfig>(m, "WorldConfig")
-        .def(py::init<SizeType32, SizeType32, SizeType32, SizeType32, SizeType32,
+    nb::class_<tr::WorldConfig>(m, "WorldConfig")
+        .def(nb::init<SizeType32, SizeType32, SizeType32, SizeType32, SizeType32,
                  std::optional<std::vector<SizeType32>> const&, bool>(),
-            py::arg("tensor_parallelism") = 1, py::arg("pipeline_parallelism") = 1, py::arg("context_parallelism") = 1,
-            py::arg("rank") = 0, py::arg("gpus_per_node") = tr::WorldConfig::kDefaultGpusPerNode,
-            py::arg("device_ids") = py::none(), py::arg("enable_attention_dp") = false)
-        .def_property_readonly("size", &tr::WorldConfig::getSize)
-        .def_property_readonly("tensor_parallelism", &tr::WorldConfig::getTensorParallelism)
-        .def_property_readonly("pipeline_parallelism", &tr::WorldConfig::getPipelineParallelism)
-        .def_property_readonly("context_parallelism", &tr::WorldConfig::getContextParallelism)
-        .def_property_readonly("is_tensor_parallel", &tr::WorldConfig::isTensorParallel)
-        .def_property_readonly("is_pipeline_parallel", &tr::WorldConfig::isPipelineParallel)
-        .def_property_readonly("is_context_parallel", &tr::WorldConfig::isContextParallel)
-        .def_property_readonly("rank", &tr::WorldConfig::getRank)
-        .def_property_readonly("local_rank", &tr::WorldConfig::getLocalRank)
-        .def_property_readonly("node_rank", &tr::WorldConfig::getNodeRank)
-        .def_property_readonly("gpus_per_node", &tr::WorldConfig::getGpusPerNode)
-        .def_property_readonly("gpus_per_group", &tr::WorldConfig::getGpusPerGroup)
-        .def_property_readonly("device", &tr::WorldConfig::getDevice)
-        .def_property_readonly("pipeline_parallel_rank", &tr::WorldConfig::getPipelineParallelRank)
-        .def_property_readonly("tensor_parallel_rank", &tr::WorldConfig::getTensorParallelRank)
-        .def_property_readonly("context_parallel_rank", &tr::WorldConfig::getContextParallelRank)
-        .def_property_readonly("enable_attention_dp", &tr::WorldConfig::enableAttentionDP)
+            nb::arg("tensor_parallelism") = 1, nb::arg("pipeline_parallelism") = 1, nb::arg("context_parallelism") = 1,
+            nb::arg("rank") = 0, nb::arg("gpus_per_node") = tr::WorldConfig::kDefaultGpusPerNode,
+            nb::arg("device_ids") = nb::none(), nb::arg("enable_attention_dp") = false)
+        .def_prop_ro("size", &tr::WorldConfig::getSize)
+        .def_prop_ro("tensor_parallelism", &tr::WorldConfig::getTensorParallelism)
+        .def_prop_ro("pipeline_parallelism", &tr::WorldConfig::getPipelineParallelism)
+        .def_prop_ro("context_parallelism", &tr::WorldConfig::getContextParallelism)
+        .def_prop_ro("is_tensor_parallel", &tr::WorldConfig::isTensorParallel)
+        .def_prop_ro("is_pipeline_parallel", &tr::WorldConfig::isPipelineParallel)
+        .def_prop_ro("is_context_parallel", &tr::WorldConfig::isContextParallel)
+        .def_prop_ro("rank", &tr::WorldConfig::getRank)
+        .def_prop_ro("local_rank", &tr::WorldConfig::getLocalRank)
+        .def_prop_ro("node_rank", &tr::WorldConfig::getNodeRank)
+        .def_prop_ro("gpus_per_node", &tr::WorldConfig::getGpusPerNode)
+        .def_prop_ro("gpus_per_group", &tr::WorldConfig::getGpusPerGroup)
+        .def_prop_ro("device", &tr::WorldConfig::getDevice)
+        .def_prop_ro("pipeline_parallel_rank", &tr::WorldConfig::getPipelineParallelRank)
+        .def_prop_ro("tensor_parallel_rank", &tr::WorldConfig::getTensorParallelRank)
+        .def_prop_ro("context_parallel_rank", &tr::WorldConfig::getContextParallelRank)
+        .def_prop_ro("enable_attention_dp", &tr::WorldConfig::enableAttentionDP)
         .def_static("mpi",
-            py::overload_cast<SizeType32, std::optional<SizeType32>, std::optional<SizeType32>,
+            nb::overload_cast<SizeType32, std::optional<SizeType32>, std::optional<SizeType32>,
                 std::optional<SizeType32>, std::optional<std::vector<SizeType32>> const&, bool>(&tr::WorldConfig::mpi),
-            py::arg("gpus_per_node") = tr::WorldConfig::kDefaultGpusPerNode, py::arg("tensor_parallelism") = py::none(),
-            py::arg("pipeline_parallelism") = py::none(), py::arg("context_parallelism") = py::none(),
-            py::arg("device_ids") = py::none(), py::arg("enable_attention_dp") = false);
+            nb::arg("gpus_per_node") = tr::WorldConfig::kDefaultGpusPerNode, nb::arg("tensor_parallelism") = nb::none(),
+            nb::arg("pipeline_parallelism") = nb::none(), nb::arg("context_parallelism") = nb::none(),
+            nb::arg("device_ids") = nb::none(), nb::arg("enable_attention_dp") = false);
 
-    auto SamplingConfigGetState = [](tr::SamplingConfig const& config) -> py::tuple
+    auto SamplingConfigGetState = [](tr::SamplingConfig const& config) -> nb::tuple
     {
-        return py::make_tuple(config.beamWidth, config.temperature, config.minLength, config.repetitionPenalty,
+        return nb::make_tuple(config.beamWidth, config.temperature, config.minLength, config.repetitionPenalty,
             config.presencePenalty, config.frequencyPenalty, config.topK, config.topP, config.randomSeed,
             config.topPDecay, config.topPMin, config.topPResetIds, config.beamSearchDiversityRate, config.lengthPenalty,
             config.earlyStopping, config.noRepeatNgramSize, config.numReturnSequences, config.minP,
             config.beamWidthArray);
     };
-    auto SamplingConfigSetState = [](py::tuple t) -> tr::SamplingConfig
+    auto SamplingConfigSetState = [](tr::SamplingConfig& self, nb::tuple t) -> tr::SamplingConfig
     {
         assert(t.size() == 19);
 
         tr::SamplingConfig config;
-        config.beamWidth = t[0].cast<SizeType32>();
-        config.temperature = t[1].cast<OptVec<float>>();
-        config.minLength = t[2].cast<OptVec<SizeType32>>();
-        config.repetitionPenalty = t[3].cast<OptVec<float>>();
-        config.presencePenalty = t[4].cast<OptVec<float>>();
-        config.frequencyPenalty = t[5].cast<OptVec<float>>();
-        config.topK = t[6].cast<OptVec<SizeType32>>();
-        config.topP = t[7].cast<OptVec<float>>();
-        config.randomSeed = t[8].cast<OptVec<uint64_t>>();
-        config.topPDecay = t[9].cast<OptVec<float>>();
-        config.topPMin = t[10].cast<OptVec<float>>();
-        config.topPResetIds = t[11].cast<OptVec<TokenIdType>>();
-        config.beamSearchDiversityRate = t[12].cast<OptVec<float>>();
-        config.lengthPenalty = t[13].cast<OptVec<float>>();
-        config.earlyStopping = t[14].cast<OptVec<SizeType32>>();
-        config.noRepeatNgramSize = t[15].cast<OptVec<SizeType32>>();
-        config.numReturnSequences = t[16].cast<SizeType32>();
-        config.minP = t[17].cast<OptVec<float>>();
-        config.beamWidthArray = t[18].cast<OptVec<std::vector<SizeType32>>>();
+        config.beamWidth = nb::cast<SizeType32>(t[0]);
+        config.temperature = nb::cast<OptVec<float>>(t[1]);
+        config.minLength = nb::cast<OptVec<SizeType32>>(t[2]);
+        config.repetitionPenalty = nb::cast<OptVec<float>>(t[3]);
+        config.presencePenalty = nb::cast<OptVec<float>>(t[4]);
+        config.frequencyPenalty = nb::cast<OptVec<float>>(t[5]);
+        config.topK = nb::cast<OptVec<SizeType32>>(t[6]);
+        config.topP = nb::cast<OptVec<float>>(t[7]);
+        config.randomSeed = nb::cast<OptVec<uint64_t>>(t[8]);
+        config.topPDecay = nb::cast<OptVec<float>>(t[9]);
+        config.topPMin = nb::cast<OptVec<float>>(t[10]);
+        config.topPResetIds = nb::cast<OptVec<TokenIdType>>(t[11]);
+        config.beamSearchDiversityRate = nb::cast<OptVec<float>>(t[12]);
+        config.lengthPenalty = nb::cast<OptVec<float>>(t[13]);
+        config.earlyStopping = nb::cast<OptVec<SizeType32>>(t[14]);
+        config.noRepeatNgramSize = nb::cast<OptVec<SizeType32>>(t[15]);
+        config.numReturnSequences = nb::cast<SizeType32>(t[16]);
+        config.minP = nb::cast<OptVec<float>>(t[17]);
+        config.beamWidthArray = nb::cast<OptVec<std::vector<SizeType32>>>(t[18]);
 
         return config;
     };
 
-    py::classh<tr::SamplingConfig>(m, "SamplingConfig")
-        .def(py::init<SizeType32>(), py::arg("beam_width") = 1)
-        .def(py::init<tle::SamplingConfig, std::optional<tle::ExternalDraftTokensConfig>>(),
-            py::arg("executor_sample_config"), py::arg("external_draft_tokens_config") = std::nullopt)
-        .def_readwrite("beam_width", &tr::SamplingConfig::beamWidth)
-        .def_readwrite("temperature", &tr::SamplingConfig::temperature)
-        .def_readwrite("min_length", &tr::SamplingConfig::minLength)
-        .def_readwrite("repetition_penalty", &tr::SamplingConfig::repetitionPenalty)
-        .def_readwrite("presence_penalty", &tr::SamplingConfig::presencePenalty)
-        .def_readwrite("frequency_penalty", &tr::SamplingConfig::frequencyPenalty)
-        .def_readwrite("top_k", &tr::SamplingConfig::topK)
-        .def_readwrite("top_p", &tr::SamplingConfig::topP)
-        .def_readwrite("random_seed", &tr::SamplingConfig::randomSeed)
-        .def_readwrite("top_p_decay", &tr::SamplingConfig::topPDecay)
-        .def_readwrite("top_p_min", &tr::SamplingConfig::topPMin)
-        .def_readwrite("top_p_reset_ids", &tr::SamplingConfig::topPResetIds)
-        .def_readwrite("beam_search_diversity_rate", &tr::SamplingConfig::beamSearchDiversityRate)
-        .def_readwrite("length_penalty", &tr::SamplingConfig::lengthPenalty)
-        .def_readwrite("early_stopping", &tr::SamplingConfig::earlyStopping)
-        .def_readwrite("no_repeat_ngram_size", &tr::SamplingConfig::noRepeatNgramSize)
-        .def_readwrite("num_return_sequences", &tr::SamplingConfig::numReturnSequences)
-        .def_readwrite("min_p", &tr::SamplingConfig::minP)
-        .def_readwrite("beam_width_array", &tr::SamplingConfig::beamWidthArray)
-        .def_readwrite("normalize_log_probs", &tr::SamplingConfig::normalizeLogProbs)
-        .def(py::pickle(SamplingConfigGetState, SamplingConfigSetState))
+    nb::class_<tr::SamplingConfig>(m, "SamplingConfig")
+        .def(nb::init<SizeType32>(), nb::arg("beam_width") = 1)
+        .def(nb::init<tle::SamplingConfig, std::optional<tle::ExternalDraftTokensConfig>>(),
+            nb::arg("executor_sample_config"), nb::arg("external_draft_tokens_config") = std::nullopt)
+        .def_rw("beam_width", &tr::SamplingConfig::beamWidth)
+        .def_rw("temperature", &tr::SamplingConfig::temperature)
+        .def_rw("min_length", &tr::SamplingConfig::minLength)
+        .def_rw("repetition_penalty", &tr::SamplingConfig::repetitionPenalty)
+        .def_rw("presence_penalty", &tr::SamplingConfig::presencePenalty)
+        .def_rw("frequency_penalty", &tr::SamplingConfig::frequencyPenalty)
+        .def_rw("top_k", &tr::SamplingConfig::topK)
+        .def_rw("top_p", &tr::SamplingConfig::topP)
+        .def_rw("random_seed", &tr::SamplingConfig::randomSeed)
+        .def_rw("top_p_decay", &tr::SamplingConfig::topPDecay)
+        .def_rw("top_p_min", &tr::SamplingConfig::topPMin)
+        .def_rw("top_p_reset_ids", &tr::SamplingConfig::topPResetIds)
+        .def_rw("beam_search_diversity_rate", &tr::SamplingConfig::beamSearchDiversityRate)
+        .def_rw("length_penalty", &tr::SamplingConfig::lengthPenalty)
+        .def_rw("early_stopping", &tr::SamplingConfig::earlyStopping)
+        .def_rw("no_repeat_ngram_size", &tr::SamplingConfig::noRepeatNgramSize)
+        .def_rw("num_return_sequences", &tr::SamplingConfig::numReturnSequences)
+        .def_rw("min_p", &tr::SamplingConfig::minP)
+        .def_rw("beam_width_array", &tr::SamplingConfig::beamWidthArray)
+        .def_rw("normalize_log_probs", &tr::SamplingConfig::normalizeLogProbs)
+        .def("__getstate__", SamplingConfigGetState)
+        .def("__setstate__", SamplingConfigSetState)
         .def("__eq__", &tr::SamplingConfig::operator==);
 
-    m.def("make_sampling_config", &makeSamplingConfig, py::arg("configs"));
+    nb::bind_vector<std::vector<tr::SamplingConfig>>(m, "VectorSamplingConfig");
 
-    py::class_<tr::GptJsonConfig>(m, "GptJsonConfig")
-        .def(py::init<std::string, std::string, std::string, SizeType32, SizeType32, SizeType32, SizeType32,
+    m.def("make_sampling_config", &makeSamplingConfig, nb::arg("configs"));
+
+    nb::class_<tr::GptJsonConfig>(m, "GptJsonConfig")
+        .def(nb::init<std::string, std::string, std::string, SizeType32, SizeType32, SizeType32, SizeType32,
                  tr::ModelConfig, std::optional<tr::RuntimeDefaults>>(),
-            py::arg("name"), py::arg("version"), py::arg("precision"), py::arg("tensor_parallelism"),
-            py::arg("pipeline_parallelism"), py::arg("context_parallelism"), py::arg("gpus_per_node"),
-            py::arg("model_config"), py::arg("runtime_defaults") = py::none())
-        .def_static("parse", py::overload_cast<std::string const&>(&tr::GptJsonConfig::parse), py::arg("json"))
+            nb::arg("name"), nb::arg("version"), nb::arg("precision"), nb::arg("tensor_parallelism"),
+            nb::arg("pipeline_parallelism"), nb::arg("context_parallelism"), nb::arg("gpus_per_node"),
+            nb::arg("model_config"), nb::arg("runtime_defaults") = nb::none())
+        .def_static("parse", nb::overload_cast<std::string const&>(&tr::GptJsonConfig::parse), nb::arg("json"))
         .def_static(
-            "parse_file", py::overload_cast<std::filesystem::path const&>(&tr::GptJsonConfig::parse), py::arg("path"))
-        .def_property_readonly("model_config", &tr::GptJsonConfig::getModelConfig)
-        .def_property_readonly("name", &tr::GptJsonConfig::getName)
-        .def_property_readonly("version", &tr::GptJsonConfig::getVersion)
-        .def_property_readonly("precision", &tr::GptJsonConfig::getPrecision)
-        .def_property_readonly("tensor_parallelism", &tr::GptJsonConfig::getTensorParallelism)
-        .def_property_readonly("pipeline_parallelism", &tr::GptJsonConfig::getPipelineParallelism)
-        .def_property_readonly("context_parallelism", &tr::GptJsonConfig::getContextParallelism)
-        .def_property_readonly("gpus_per_node", &tr::GptJsonConfig::getGpusPerNode)
-        .def_property_readonly("world_size", &tr::GptJsonConfig::getWorldSize)
-        .def_property_readonly("runtime_defaults", &tr::GptJsonConfig::getRuntimeDefaults)
+            "parse_file", nb::overload_cast<std::filesystem::path const&>(&tr::GptJsonConfig::parse), nb::arg("path"))
+        .def_prop_ro("model_config", &tr::GptJsonConfig::getModelConfig)
+        .def_prop_ro("name", &tr::GptJsonConfig::getName)
+        .def_prop_ro("version", &tr::GptJsonConfig::getVersion)
+        .def_prop_ro("precision", &tr::GptJsonConfig::getPrecision)
+        .def_prop_ro("tensor_parallelism", &tr::GptJsonConfig::getTensorParallelism)
+        .def_prop_ro("pipeline_parallelism", &tr::GptJsonConfig::getPipelineParallelism)
+        .def_prop_ro("context_parallelism", &tr::GptJsonConfig::getContextParallelism)
+        .def_prop_ro("gpus_per_node", &tr::GptJsonConfig::getGpusPerNode)
+        .def_prop_ro("world_size", &tr::GptJsonConfig::getWorldSize)
+        .def_prop_ro("runtime_defaults", &tr::GptJsonConfig::getRuntimeDefaults)
         .def("engine_filename",
-            py::overload_cast<tr::WorldConfig const&, std::string const&>(
-                &tr::GptJsonConfig::engineFilename, py::const_),
-            py::arg("world_config"), py::arg("model"))
+            nb::overload_cast<tr::WorldConfig const&, std::string const&>(
+                &tr::GptJsonConfig::engineFilename, nb::const_),
+            nb::arg("world_config"), nb::arg("model"))
         .def("engine_filename",
-            py::overload_cast<tr::WorldConfig const&>(&tr::GptJsonConfig::engineFilename, py::const_),
-            py::arg("world_config"));
+            nb::overload_cast<tr::WorldConfig const&>(&tr::GptJsonConfig::engineFilename, nb::const_),
+            nb::arg("world_config"));
 
-    py::enum_<tb::LlmRequestState>(m, "LlmRequestState")
+    nb::enum_<tb::LlmRequestState>(m, "LlmRequestState")
         .value("UNKNOWN", tb::LlmRequestState::kUNKNOWN)
         .value("ENCODER_INIT", tb::LlmRequestState::kENCODER_INIT)
         .value("CONTEXT_INIT", tb::LlmRequestState::kCONTEXT_INIT)
@@ -451,15 +460,15 @@ PYBIND11_MODULE(TRTLLM_PYBIND_MODULE, m)
         .value("DISAGG_GENERATION_TRANS_COMPLETE", tb::LlmRequestState::kDISAGG_GENERATION_TRANS_COMPLETE)
         .value("DISAGG_CONTEXT_INIT_AND_TRANS", tb::LlmRequestState::kDISAGG_CONTEXT_INIT_AND_TRANS);
 
-    py::class_<tr::MemoryCounters>(m, "MemoryCounters")
-        .def_static("instance", &tr::MemoryCounters::getInstance, py::return_value_policy::reference)
-        .def_property_readonly("gpu", &tr::MemoryCounters::getGpu)
-        .def_property_readonly("cpu", &tr::MemoryCounters::getCpu)
-        .def_property_readonly("pinned", &tr::MemoryCounters::getPinned)
-        .def_property_readonly("uvm", &tr::MemoryCounters::getUVM);
+    nb::class_<tr::MemoryCounters>(m, "MemoryCounters")
+        .def_static("instance", &tr::MemoryCounters::getInstance, nb::rv_policy::reference)
+        .def_prop_ro("gpu", &tr::MemoryCounters::getGpu)
+        .def_prop_ro("cpu", &tr::MemoryCounters::getCpu)
+        .def_prop_ro("pinned", &tr::MemoryCounters::getPinned)
+        .def_prop_ro("uvm", &tr::MemoryCounters::getUVM);
 
-    tensorrt_llm::pybind::runtime::initBindings(mInternalRuntime);
-    tensorrt_llm::pybind::testing::initBindings(mInternalTesting);
+    tensorrt_llm::nanobind::runtime::initBindings(mInternalRuntime);
+    tensorrt_llm::nanobind::testing::initBindings(mInternalTesting);
     tpb::initBindings(mInternalBatchManager);
     tb::kv_cache_manager::KVCacheManagerBindings::initBindings(mInternalBatchManager);
     tb::BasePeftCacheManagerBindings::initBindings(mInternalBatchManager);
@@ -473,15 +482,15 @@ PYBIND11_MODULE(TRTLLM_PYBIND_MODULE, m)
     tensorrt_llm::kernels::userbuffers::UserBufferBindings::initBindings(mUserbuffers);
 
     // NVLS allocators
-    py::class_<tr::IpcNvlsHandle>(m, "IpcNvlsHandle")
-        .def(py::init<>())
-        .def_readwrite("uc_ptr", &tr::IpcNvlsHandle::uc_ptr)
-        .def_readwrite("mc_ptr", &tr::IpcNvlsHandle::mc_ptr)
-        .def_readwrite("size", &tr::IpcNvlsHandle::size)
+    nb::class_<tr::IpcNvlsHandle>(m, "IpcNvlsHandle")
+        .def(nb::init<>())
+        .def_rw("uc_ptr", &tr::IpcNvlsHandle::uc_ptr)
+        .def_rw("mc_ptr", &tr::IpcNvlsHandle::mc_ptr)
+        .def_rw("size", &tr::IpcNvlsHandle::size)
         .def("get_ipc_ptrs",
             [](tr::IpcNvlsHandle& self) { return reinterpret_cast<uintptr_t>(self.ipc_uc_ptrs.data()); });
 
-    m.def("ipc_nvls_allocate", &tr::ipcNvlsAllocate, py::return_value_policy::reference);
+    m.def("ipc_nvls_allocate", &tr::ipcNvlsAllocate, nb::rv_policy::reference);
     m.def("ipc_nvls_free", &tr::ipcNvlsFree);
     m.def("ipc_nvls_supported", &tr::ipcNvlsSupported);
 }

--- a/cpp/tensorrt_llm/nanobind/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/bindings.cpp
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <nanobind/nanobind.h>
+
+#if not defined(TRTLLM_NB_MODULE)
+#error "TRTLLM_NB_MODULE must be defined"
+#endif
+
+NB_MODULE(TRTLLM_NB_MODULE, m)
+{
+    m.doc() = "TensorRT-LLM Python bindings for C++ runtime";
+    m.attr("binding_type") = "nanobind";
+}

--- a/cpp/tensorrt_llm/nanobind/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/bindings.cpp
@@ -15,14 +15,473 @@
  * limitations under the License.
  */
 
-#include <nanobind/nanobind.h>
+#include <pybind11/cast.h>
+#include <pybind11/functional.h>
+#include <pybind11/operators.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <torch/extension.h>
+#include <vector>
 
-#if not defined(TRTLLM_NB_MODULE)
-#error "TRTLLM_NB_MODULE must be defined"
+#include "tensorrt_llm/batch_manager/peftCacheManagerConfig.h"
+#include "tensorrt_llm/common/quantization.h"
+#include "tensorrt_llm/pybind/batch_manager/algorithms.h"
+#include "tensorrt_llm/pybind/batch_manager/bindings.h"
+#include "tensorrt_llm/pybind/batch_manager/buffers.h"
+#include "tensorrt_llm/pybind/batch_manager/cacheTransceiver.h"
+#include "tensorrt_llm/pybind/batch_manager/kvCacheManager.h"
+#include "tensorrt_llm/pybind/batch_manager/llmRequest.h"
+#include "tensorrt_llm/pybind/executor/bindings.h"
+#include "tensorrt_llm/pybind/runtime/bindings.h"
+#include "tensorrt_llm/pybind/testing/modelSpecBinding.h"
+#include "tensorrt_llm/pybind/userbuffers/bindings.h"
+#include "tensorrt_llm/runtime/common.h"
+#include "tensorrt_llm/runtime/cudaStream.h"
+#include "tensorrt_llm/runtime/gptJsonConfig.h"
+#include "tensorrt_llm/runtime/ipcNvlsMemory.h"
+#include "tensorrt_llm/runtime/memoryCounters.h"
+#include "tensorrt_llm/runtime/samplingConfig.h"
+#include "tensorrt_llm/runtime/utils/mpiUtils.h"
+
+namespace py = pybind11;
+namespace tb = tensorrt_llm::batch_manager;
+namespace tbk = tensorrt_llm::batch_manager::kv_cache_manager;
+namespace tpb = tensorrt_llm::pybind::batch_manager;
+namespace tc = tensorrt_llm::common;
+namespace tr = tensorrt_llm::runtime;
+namespace tle = tensorrt_llm::executor;
+using SizeType32 = tr::SizeType32;
+using TokenIdType = tr::TokenIdType;
+template <typename T>
+using OptVec = std::optional<std::vector<T>>;
+
+#if not defined(TRTLLM_PYBIND_MODULE)
+#error "TRTLLM_PYBIND_MODULE must be defined"
 #endif
 
-NB_MODULE(TRTLLM_NB_MODULE, m)
+namespace
+{
+tr::SamplingConfig makeSamplingConfig(std::vector<tr::SamplingConfig> const& configs)
+{
+    return tr::SamplingConfig(configs);
+}
+} // namespace
+
+PYBIND11_MODULE(TRTLLM_PYBIND_MODULE, m)
 {
     m.doc() = "TensorRT-LLM Python bindings for C++ runtime";
-    m.attr("binding_type") = "nanobind";
+    m.attr("binding_type") = "pybind";
+
+    // Create MpiComm binding first since it's used in the executor bindings
+    py::classh<tensorrt_llm::mpi::MpiComm>(m, "MpiComm")
+        .def_static("rank",
+            []()
+            {
+                auto& session = tensorrt_llm::mpi::MpiComm::session();
+                return session.tensorrt_llm::mpi::MpiComm::getRank();
+            })
+        .def_static("size",
+            []()
+            {
+                auto& session = tensorrt_llm::mpi::MpiComm::session();
+                return session.tensorrt_llm::mpi::MpiComm::getSize();
+            })
+        .def_static("local_size",
+            []()
+            {
+                auto& session = tensorrt_llm::mpi::MpiComm::localSession();
+                return session.tensorrt_llm::mpi::MpiComm::getSize();
+            })
+        .def_static("local_init", []() { tensorrt_llm::mpi::MpiComm::localSession(); })
+        .def_static("set_raw_mpi_session_by_fortran_handle",
+            [](int64_t fortran_handle) { tensorrt_llm::mpi::MpiComm::setRawSessionByFortran(fortran_handle); })
+        .def_static("split",
+            [](size_t color, size_t rank)
+            {
+                auto& world = tensorrt_llm::mpi::MpiComm::world();
+                tensorrt_llm::mpi::MpiComm::setSession(world.split(color, rank));
+            });
+
+    py::classh<tr::CudaStream>(m, "CudaStream")
+        .def(py::init(
+                 [](py::object py_stream)
+                 {
+                     cudaStream_t stream = reinterpret_cast<cudaStream_t>(py_stream.cast<uintptr_t>());
+                     return tr::CudaStream{stream};
+                 }),
+            py::arg("stream_ptr"))
+        .def("get_device", &tr::CudaStream::getDevice);
+
+    // Create submodule for executor bindings.
+    auto mExecutor = m.def_submodule("executor", "Executor bindings");
+    auto mInternal = m.def_submodule("internal", "Internal submodule of TRTLLM runtime");
+    auto mInternalRuntime = mInternal.def_submodule("runtime", "Runtime internal bindings");
+    auto mInternalTesting = mInternal.def_submodule("testing", "Testing internal bindings");
+    auto mInternalBatchManager = mInternal.def_submodule("batch_manager", "Batch manager internal bindings");
+
+    tensorrt_llm::pybind::executor::initBindings(mExecutor);
+    tensorrt_llm::pybind::runtime::initBindingsEarly(mInternalRuntime);
+
+    auto buildInfo = m.def_submodule("BuildInfo");
+    buildInfo.attr("ENABLE_MULTI_DEVICE") = py::int_(ENABLE_MULTI_DEVICE);
+
+    py::class_<tb::PeftCacheManagerConfig>(m, "PeftCacheManagerConfig")
+        .def(py::init<SizeType32, SizeType32, SizeType32, SizeType32, SizeType32, SizeType32, SizeType32, SizeType32,
+                 SizeType32, std::optional<float>, std::optional<size_t>, std::optional<std::string>>(),
+            py::arg("num_host_module_layer") = 0, py::arg("num_device_module_layer") = 0,
+            py::arg("optimal_adapter_size") = 8, py::arg("max_adapter_size") = 64, py::arg("num_put_workers") = 1,
+            py::arg("num_ensure_workers") = 1, py::arg("num_copy_streams") = 1,
+            py::arg("max_pages_per_block_host") = 24, py::arg("max_pages_per_block_device") = 8,
+            py::arg("device_cache_percent") = std::nullopt, py::arg("host_cache_size") = std::nullopt,
+            py::arg("lora_prefetch_dir") = std::nullopt)
+        .def_readwrite("num_host_module_layer", &tb::PeftCacheManagerConfig::numHostModuleLayer)
+        .def_readwrite("num_device_module_layer", &tb::PeftCacheManagerConfig::numDeviceModuleLayer)
+        .def_readwrite("optimal_adapter_size", &tb::PeftCacheManagerConfig::optimalAdapterSize)
+        .def_readwrite("max_adapter_size", &tb::PeftCacheManagerConfig::maxAdapterSize)
+        .def_readwrite("num_put_workers", &tb::PeftCacheManagerConfig::numPutWorkers)
+        .def_readwrite("num_ensure_workers", &tb::PeftCacheManagerConfig::numEnsureWorkers)
+        .def_readwrite("num_copy_streams", &tb::PeftCacheManagerConfig::numCopyStreams)
+        .def_readwrite("max_pages_per_block_host", &tb::PeftCacheManagerConfig::maxPagesPerBlockHost)
+        .def_readwrite("max_pages_per_block_device", &tb::PeftCacheManagerConfig::maxPagesPerBlockDevice)
+        .def_readwrite("device_cache_percent", &tb::PeftCacheManagerConfig::deviceCachePercent)
+        .def_readwrite("host_cache_size", &tb::PeftCacheManagerConfig::hostCacheSize)
+        .def_readwrite("lora_prefetch_dir", &tb::PeftCacheManagerConfig::loraPrefetchDir);
+
+    py::enum_<nvinfer1::DataType>(m, "DataType")
+        .value("FLOAT", nvinfer1::DataType::kFLOAT)
+        .value("HALF", nvinfer1::DataType::kHALF)
+        .value("INT8", nvinfer1::DataType::kINT8)
+        .value("INT32", nvinfer1::DataType::kINT32)
+        .value("BOOL", nvinfer1::DataType::kBOOL)
+        .value("UINT8", nvinfer1::DataType::kUINT8)
+        .value("FP8", nvinfer1::DataType::kFP8)
+        .value("BF16", nvinfer1::DataType::kBF16)
+        .value("INT64", nvinfer1::DataType::kINT64)
+        .export_values();
+
+    py::enum_<tr::ModelConfig::ModelVariant>(m, "GptModelVariant")
+        .value("GPT", tr::ModelConfig::ModelVariant::kGpt)
+        .value("GLM", tr::ModelConfig::ModelVariant::kGlm)
+        .value("CHATGLM", tr::ModelConfig::ModelVariant::kChatGlm)
+        .value("MAMBA", tr::ModelConfig::ModelVariant::kMamba)
+        .value("RECURRENTGEMMA", tr::ModelConfig::ModelVariant::kRecurrentGemma);
+
+    py::enum_<tr::ModelConfig::KVCacheType>(m, "KVCacheType")
+        .value("CONTINUOUS", tr::ModelConfig::KVCacheType::kCONTINUOUS)
+        .value("PAGED", tr::ModelConfig::KVCacheType::kPAGED)
+        .value("DISABLED", tr::ModelConfig::KVCacheType::kDISABLED)
+        .def(py::init(&tr::ModelConfig::KVCacheTypeFromString));
+
+    py::enum_<tr::ModelConfig::LayerType>(m, "LayerType")
+        .value("ATTENTION", tr::ModelConfig::LayerType::kATTENTION)
+        .value("RECURRENT", tr::ModelConfig::LayerType::kRECURRENT);
+
+    py::enum_<tr::LoraModule::ModuleType>(m, "LoraModuleType")
+        .value("INVALID", tr::LoraModule::ModuleType::kINVALID)
+        .value("ATTN_QKV", tr::LoraModule::ModuleType::kATTN_QKV)
+        .value("ATTN_Q", tr::LoraModule::ModuleType::kATTN_Q)
+        .value("ATTN_K", tr::LoraModule::ModuleType::kATTN_K)
+        .value("ATTN_V", tr::LoraModule::ModuleType::kATTN_V)
+        .value("ATTN_DENSE", tr::LoraModule::ModuleType::kATTN_DENSE)
+        .value("MLP_H_TO_4H", tr::LoraModule::ModuleType::kMLP_H_TO_4H)
+        .value("MLP_4H_TO_H", tr::LoraModule::ModuleType::kMLP_4H_TO_H)
+        .value("MLP_GATE", tr::LoraModule::ModuleType::kMLP_GATE)
+        .value("CROSS_ATTN_QKV", tr::LoraModule::ModuleType::kCROSS_ATTN_QKV)
+        .value("CROSS_ATTN_Q", tr::LoraModule::ModuleType::kCROSS_ATTN_Q)
+        .value("CROSS_ATTN_K", tr::LoraModule::ModuleType::kCROSS_ATTN_K)
+        .value("CROSS_ATTN_V", tr::LoraModule::ModuleType::kCROSS_ATTN_V)
+        .value("CROSS_ATTN_DENSE", tr::LoraModule::ModuleType::kCROSS_ATTN_DENSE)
+        .value("MOE_H_TO_4H", tr::LoraModule::ModuleType::kMOE_H_TO_4H)
+        .value("MOE_4H_TO_H", tr::LoraModule::ModuleType::kMOE_4H_TO_H)
+        .value("MOE_GATE", tr::LoraModule::ModuleType::kMOE_GATE)
+        .value("MOE_ROUTER", tr::LoraModule::ModuleType::kMOE_ROUTER)
+        .value("MLP_ROUTER", tr::LoraModule::ModuleType::kMLP_ROUTER)
+        .value("MLP_GATE_UP", tr::LoraModule::ModuleType::kMLP_GATE_UP);
+
+    py::class_<tr::LoraModule>(m, "LoraModule")
+        .def(py::init<tr::LoraModule::ModuleType, SizeType32, SizeType32, bool, bool, SizeType32, SizeType32>(),
+            py::arg("module_type"), py::arg("in_dim"), py::arg("out_dim"), py::arg("in_dim_first"),
+            py::arg("out_dim_first"), py::arg("in_tp_split_dim"), py::arg("out_tp_split_dim"))
+        .def_property_readonly("module_type", &tr::LoraModule::name)
+        .def_property_readonly("in_dim", &tr::LoraModule::inDim)
+        .def_property_readonly("out_dim", &tr::LoraModule::outDim)
+        .def_property_readonly("in_dim_first", &tr::LoraModule::inDimFirst)
+        .def_property_readonly("out_dim_first", &tr::LoraModule::outDimFirst)
+        .def_property_readonly("in_tp_split_dim", &tr::LoraModule::inTpSplitDim)
+        .def_property_readonly("out_tp_split_dim", &tr::LoraModule::outTpSplitDim)
+        .def_static("create_lora_modules", &tr::LoraModule::createLoraModules, py::arg("lora_module_names"),
+            py::arg("hidden_size"), py::arg("mlp_hidden_size"), py::arg("num_attention_heads"),
+            py::arg("num_kv_attention_heads"), py::arg("attention_head_size"), py::arg("tp_size") = 1,
+            py::arg("num_experts") = 0);
+
+    py::class_<tc::QuantMode>(m, "QuantMode")
+        .def_static("none", &tc::QuantMode::none)
+        .def_static("int4_weights", &tc::QuantMode::int4Weights)
+        .def_static("int8_weights", &tc::QuantMode::int8Weights)
+        .def_static("activations", &tc::QuantMode::activations)
+        .def_static("per_channel_scaling", &tc::QuantMode::perChannelScaling)
+        .def_static("per_token_scaling", &tc::QuantMode::perTokenScaling)
+        .def_static("per_group_scaling", &tc::QuantMode::perGroupScaling)
+        .def_static("int8_kv_cache", &tc::QuantMode::int8KvCache)
+        .def_static("fp8_kv_cache", &tc::QuantMode::fp8KvCache)
+        .def_static("fp8_qdq", &tc::QuantMode::fp8Qdq)
+        .def_property_readonly("value", &tc::QuantMode::value)
+        .def("is_set", &tc::QuantMode::isSet, py::arg("mode"))
+        .def_property_readonly("has_int4_weights", &tc::QuantMode::hasInt4Weights)
+        .def_property_readonly("has_int8_weights", &tc::QuantMode::hasInt8Weights)
+        .def_property_readonly("has_activations", &tc::QuantMode::hasActivations)
+        .def_property_readonly("has_per_channel_scaling", &tc::QuantMode::hasPerChannelScaling)
+        .def_property_readonly("has_per_token_scaling", &tc::QuantMode::hasPerTokenScaling)
+        .def_property_readonly("has_per_group_scaling", &tc::QuantMode::hasPerGroupScaling)
+        .def_property_readonly("has_static_activation_scaling", &tc::QuantMode::hasStaticActivationScaling)
+        .def_property_readonly("has_int8_kv_cache", &tc::QuantMode::hasInt8KvCache)
+        .def_property_readonly("has_fp8_kv_cache", &tc::QuantMode::hasFp8KvCache)
+        .def_property_readonly("has_fp8_qdq", &tc::QuantMode::hasFp8Qdq)
+        .def_property_readonly("has_nvfp4", &tc::QuantMode::hasNvfp4)
+        .def_property_readonly("has_w4a8_mxfp4_fp8", &tc::QuantMode::hasW4a8Mxfp4Fp8)
+        .def_property_readonly("has_kv_cache_quant", &tc::QuantMode::hasKvCacheQuant)
+        .def_static("from_description", &tc::QuantMode::fromDescription, py::arg("quantize_weights"),
+            py::arg("quantize_activations"), py::arg("per_token"), py::arg("per_channel"), py::arg("per_group"),
+            py::arg("use_int4_weights"), py::arg("use_int8_kv_cache"), py::arg("use_fp8_kv_kache"),
+            py::arg("use_fp8_qdq"), py::arg("use_fp8_rowwise"), py::arg("use_w4a8_qserve"), py::arg("use_nvfp4"),
+            py::arg("use_fp8_block_scales"), py::arg("use_w4a8_mxfp4_fp8"))
+        .def_static("use_smooth_quant", &tc::QuantMode::useSmoothQuant, py::arg("per_token") = false,
+            py::arg("per_channel") = false)
+        .def_static("use_weight_only", &tc::QuantMode::useWeightOnly, py::arg("use_int4_weights") = false,
+            py::arg("per_group") = false)
+        .def_static("from_quant_algo", &tc::QuantMode::fromQuantAlgo, py::arg("quant_algo") = py::none(),
+            py::arg("kv_cache_quant_algo") = py::none())
+        .def(py::self + py::self)
+        .def(py::self += py::self)
+        .def(py::self - py::self)
+        .def(py::self -= py::self)
+        .def(py::self == py::self)
+        .def(py::self != py::self);
+
+    py::class_<tr::ModelConfig>(m, "ModelConfig")
+        .def(py::init<SizeType32, SizeType32, SizeType32, SizeType32, SizeType32, SizeType32, nvinfer1::DataType>(),
+            py::arg("vocab_size"), py::arg("num_layers"), py::arg("num_attention_layers"), py::arg("num_rnn_layers"),
+            py::arg("num_heads"), py::arg("hidden_size"), py::arg("data_type"))
+        .def_property_readonly("vocab_size", &tr::ModelConfig::getVocabSize)
+        .def("vocab_size_padded", &tr::ModelConfig::getVocabSizePadded, py::arg("world_size"))
+        .def("num_layers", &tr::ModelConfig::getNbLayers, py::arg("pipeline_parallelism") = 1,
+            py::arg("pipeline_parallelism_rank") = 0)
+        .def("num_attention_layers", &tr::ModelConfig::getNbAttentionLayers, py::arg("pipeline_parallelism") = 1,
+            py::arg("pipeline_parallelism_rank") = 0)
+        .def("num_rnn_layers", &tr::ModelConfig::getNbRnnLayers, py::arg("pipeline_parallelism") = 1,
+            py::arg("pipeline_parallelism_rank") = 0)
+        .def("num_kv_heads", &tr::ModelConfig::getNbKvHeads, py::arg("layer_idx"))
+        .def("set_num_kv_heads", &tr::ModelConfig::setNbKvHeads, py::arg("num_kv_heads"))
+        .def_property_readonly("num_heads", &tr::ModelConfig::getNbHeads)
+        .def_property_readonly("hidden_size", &tr::ModelConfig::getHiddenSize)
+        .def_property_readonly("size_per_head", &tr::ModelConfig::getSizePerHead)
+        .def_property_readonly("data_type", &tr::ModelConfig::getDataType)
+        .def_property_readonly("speculative_decoding_mode", &tr::ModelConfig::getSpeculativeDecodingMode)
+        .def_property("head_size", &tr::ModelConfig::getSizePerHead, &tr::ModelConfig::setSizePerHead)
+        .def_property(
+            "num_kv_heads_per_layer", &tr::ModelConfig::getNumKvHeadsPerLayer, &tr::ModelConfig::setNumKvHeadsPerLayer)
+        .def_property("use_gpt_attention_plugin",
+            py::overload_cast<>(&tr::ModelConfig::useGptAttentionPlugin, py::const_),
+            py::overload_cast<bool>(&tr::ModelConfig::useGptAttentionPlugin))
+        .def_property("use_packed_input", py::overload_cast<>(&tr::ModelConfig::usePackedInput, py::const_),
+            py::overload_cast<bool>(&tr::ModelConfig::usePackedInput))
+        .def_property("kv_cache_type", py::overload_cast<>(&tr::ModelConfig::getKVCacheType, py::const_),
+            py::overload_cast<tr::ModelConfig::KVCacheType>(&tr::ModelConfig::setKVCacheType))
+        .def_property("tokens_per_block", &tr::ModelConfig::getTokensPerBlock, &tr::ModelConfig::setTokensPerBlock)
+        .def_property("quant_mode", &tr::ModelConfig::getQuantMode, &tr::ModelConfig::setQuantMode)
+        .def_property_readonly("supports_inflight_batching", &tr::ModelConfig::supportsInflightBatching)
+        .def_property("max_batch_size", &tr::ModelConfig::getMaxBatchSize, &tr::ModelConfig::setMaxBatchSize)
+        .def_property("max_beam_width", &tr::ModelConfig::getMaxBeamWidth, &tr::ModelConfig::setMaxBeamWidth)
+        .def_property("max_input_len", &tr::ModelConfig::getMaxInputLen, &tr::ModelConfig::setMaxInputLen)
+        .def_property("max_seq_len", &tr::ModelConfig::getMaxSequenceLen, &tr::ModelConfig::setMaxSequenceLen)
+        .def_property("max_num_tokens", &tr::ModelConfig::getMaxNumTokens, &tr::ModelConfig::setMaxNumTokens)
+        .def_property("max_prompt_embedding_table_size", &tr::ModelConfig::getMaxPromptEmbeddingTableSize,
+            &tr::ModelConfig::setMaxPromptEmbeddingTableSize)
+        .def_property_readonly("use_prompt_tuning", &tr::ModelConfig::usePromptTuning)
+        .def_property_readonly("use_mrope", &tr::ModelConfig::useMrope)
+        .def_property("use_lora_plugin", py::overload_cast<>(&tr::ModelConfig::useLoraPlugin, py::const_),
+            py::overload_cast<bool>(&tr::ModelConfig::useLoraPlugin))
+        .def_property("layer_types", &tr::ModelConfig::getLayerTypes, &tr::ModelConfig::setLayerTypes)
+        .def_property("compute_context_logits", py::overload_cast<>(&tr::ModelConfig::computeContextLogits, py::const_),
+            py::overload_cast<bool>(&tr::ModelConfig::computeContextLogits))
+        .def_property("compute_generation_logits",
+            py::overload_cast<>(&tr::ModelConfig::computeGenerationLogits, py::const_),
+            py::overload_cast<bool>(&tr::ModelConfig::computeGenerationLogits))
+        .def_property("model_variant", &tr::ModelConfig::getModelVariant, &tr::ModelConfig::setModelVariant)
+        .def_property(
+            "use_cross_attention", &tr::ModelConfig::useCrossAttention, &tr::ModelConfig::setUseCrossAttention)
+        .def_property("lora_modules", &tr::ModelConfig::getLoraModules, &tr::ModelConfig::setLoraModules)
+        .def_property("max_lora_rank", &tr::ModelConfig::getMaxLoraRank, &tr::ModelConfig::setMaxLoraRank)
+        .def_property("mlp_hidden_size", &tr::ModelConfig::getMlpHiddenSize, &tr::ModelConfig::setMlpHiddenSize)
+        .def_property("size_per_head", &tr::ModelConfig::getSizePerHead, &tr::ModelConfig::setSizePerHead);
+
+    py::class_<tr::WorldConfig>(m, "WorldConfig")
+        .def(py::init<SizeType32, SizeType32, SizeType32, SizeType32, SizeType32,
+                 std::optional<std::vector<SizeType32>> const&, bool>(),
+            py::arg("tensor_parallelism") = 1, py::arg("pipeline_parallelism") = 1, py::arg("context_parallelism") = 1,
+            py::arg("rank") = 0, py::arg("gpus_per_node") = tr::WorldConfig::kDefaultGpusPerNode,
+            py::arg("device_ids") = py::none(), py::arg("enable_attention_dp") = false)
+        .def_property_readonly("size", &tr::WorldConfig::getSize)
+        .def_property_readonly("tensor_parallelism", &tr::WorldConfig::getTensorParallelism)
+        .def_property_readonly("pipeline_parallelism", &tr::WorldConfig::getPipelineParallelism)
+        .def_property_readonly("context_parallelism", &tr::WorldConfig::getContextParallelism)
+        .def_property_readonly("is_tensor_parallel", &tr::WorldConfig::isTensorParallel)
+        .def_property_readonly("is_pipeline_parallel", &tr::WorldConfig::isPipelineParallel)
+        .def_property_readonly("is_context_parallel", &tr::WorldConfig::isContextParallel)
+        .def_property_readonly("rank", &tr::WorldConfig::getRank)
+        .def_property_readonly("local_rank", &tr::WorldConfig::getLocalRank)
+        .def_property_readonly("node_rank", &tr::WorldConfig::getNodeRank)
+        .def_property_readonly("gpus_per_node", &tr::WorldConfig::getGpusPerNode)
+        .def_property_readonly("gpus_per_group", &tr::WorldConfig::getGpusPerGroup)
+        .def_property_readonly("device", &tr::WorldConfig::getDevice)
+        .def_property_readonly("pipeline_parallel_rank", &tr::WorldConfig::getPipelineParallelRank)
+        .def_property_readonly("tensor_parallel_rank", &tr::WorldConfig::getTensorParallelRank)
+        .def_property_readonly("context_parallel_rank", &tr::WorldConfig::getContextParallelRank)
+        .def_property_readonly("enable_attention_dp", &tr::WorldConfig::enableAttentionDP)
+        .def_static("mpi",
+            py::overload_cast<SizeType32, std::optional<SizeType32>, std::optional<SizeType32>,
+                std::optional<SizeType32>, std::optional<std::vector<SizeType32>> const&, bool>(&tr::WorldConfig::mpi),
+            py::arg("gpus_per_node") = tr::WorldConfig::kDefaultGpusPerNode, py::arg("tensor_parallelism") = py::none(),
+            py::arg("pipeline_parallelism") = py::none(), py::arg("context_parallelism") = py::none(),
+            py::arg("device_ids") = py::none(), py::arg("enable_attention_dp") = false);
+
+    auto SamplingConfigGetState = [](tr::SamplingConfig const& config) -> py::tuple
+    {
+        return py::make_tuple(config.beamWidth, config.temperature, config.minLength, config.repetitionPenalty,
+            config.presencePenalty, config.frequencyPenalty, config.topK, config.topP, config.randomSeed,
+            config.topPDecay, config.topPMin, config.topPResetIds, config.beamSearchDiversityRate, config.lengthPenalty,
+            config.earlyStopping, config.noRepeatNgramSize, config.numReturnSequences, config.minP,
+            config.beamWidthArray);
+    };
+    auto SamplingConfigSetState = [](py::tuple t) -> tr::SamplingConfig
+    {
+        assert(t.size() == 19);
+
+        tr::SamplingConfig config;
+        config.beamWidth = t[0].cast<SizeType32>();
+        config.temperature = t[1].cast<OptVec<float>>();
+        config.minLength = t[2].cast<OptVec<SizeType32>>();
+        config.repetitionPenalty = t[3].cast<OptVec<float>>();
+        config.presencePenalty = t[4].cast<OptVec<float>>();
+        config.frequencyPenalty = t[5].cast<OptVec<float>>();
+        config.topK = t[6].cast<OptVec<SizeType32>>();
+        config.topP = t[7].cast<OptVec<float>>();
+        config.randomSeed = t[8].cast<OptVec<uint64_t>>();
+        config.topPDecay = t[9].cast<OptVec<float>>();
+        config.topPMin = t[10].cast<OptVec<float>>();
+        config.topPResetIds = t[11].cast<OptVec<TokenIdType>>();
+        config.beamSearchDiversityRate = t[12].cast<OptVec<float>>();
+        config.lengthPenalty = t[13].cast<OptVec<float>>();
+        config.earlyStopping = t[14].cast<OptVec<SizeType32>>();
+        config.noRepeatNgramSize = t[15].cast<OptVec<SizeType32>>();
+        config.numReturnSequences = t[16].cast<SizeType32>();
+        config.minP = t[17].cast<OptVec<float>>();
+        config.beamWidthArray = t[18].cast<OptVec<std::vector<SizeType32>>>();
+
+        return config;
+    };
+
+    py::classh<tr::SamplingConfig>(m, "SamplingConfig")
+        .def(py::init<SizeType32>(), py::arg("beam_width") = 1)
+        .def(py::init<tle::SamplingConfig, std::optional<tle::ExternalDraftTokensConfig>>(),
+            py::arg("executor_sample_config"), py::arg("external_draft_tokens_config") = std::nullopt)
+        .def_readwrite("beam_width", &tr::SamplingConfig::beamWidth)
+        .def_readwrite("temperature", &tr::SamplingConfig::temperature)
+        .def_readwrite("min_length", &tr::SamplingConfig::minLength)
+        .def_readwrite("repetition_penalty", &tr::SamplingConfig::repetitionPenalty)
+        .def_readwrite("presence_penalty", &tr::SamplingConfig::presencePenalty)
+        .def_readwrite("frequency_penalty", &tr::SamplingConfig::frequencyPenalty)
+        .def_readwrite("top_k", &tr::SamplingConfig::topK)
+        .def_readwrite("top_p", &tr::SamplingConfig::topP)
+        .def_readwrite("random_seed", &tr::SamplingConfig::randomSeed)
+        .def_readwrite("top_p_decay", &tr::SamplingConfig::topPDecay)
+        .def_readwrite("top_p_min", &tr::SamplingConfig::topPMin)
+        .def_readwrite("top_p_reset_ids", &tr::SamplingConfig::topPResetIds)
+        .def_readwrite("beam_search_diversity_rate", &tr::SamplingConfig::beamSearchDiversityRate)
+        .def_readwrite("length_penalty", &tr::SamplingConfig::lengthPenalty)
+        .def_readwrite("early_stopping", &tr::SamplingConfig::earlyStopping)
+        .def_readwrite("no_repeat_ngram_size", &tr::SamplingConfig::noRepeatNgramSize)
+        .def_readwrite("num_return_sequences", &tr::SamplingConfig::numReturnSequences)
+        .def_readwrite("min_p", &tr::SamplingConfig::minP)
+        .def_readwrite("beam_width_array", &tr::SamplingConfig::beamWidthArray)
+        .def_readwrite("normalize_log_probs", &tr::SamplingConfig::normalizeLogProbs)
+        .def(py::pickle(SamplingConfigGetState, SamplingConfigSetState))
+        .def("__eq__", &tr::SamplingConfig::operator==);
+
+    m.def("make_sampling_config", &makeSamplingConfig, py::arg("configs"));
+
+    py::class_<tr::GptJsonConfig>(m, "GptJsonConfig")
+        .def(py::init<std::string, std::string, std::string, SizeType32, SizeType32, SizeType32, SizeType32,
+                 tr::ModelConfig, std::optional<tr::RuntimeDefaults>>(),
+            py::arg("name"), py::arg("version"), py::arg("precision"), py::arg("tensor_parallelism"),
+            py::arg("pipeline_parallelism"), py::arg("context_parallelism"), py::arg("gpus_per_node"),
+            py::arg("model_config"), py::arg("runtime_defaults") = py::none())
+        .def_static("parse", py::overload_cast<std::string const&>(&tr::GptJsonConfig::parse), py::arg("json"))
+        .def_static(
+            "parse_file", py::overload_cast<std::filesystem::path const&>(&tr::GptJsonConfig::parse), py::arg("path"))
+        .def_property_readonly("model_config", &tr::GptJsonConfig::getModelConfig)
+        .def_property_readonly("name", &tr::GptJsonConfig::getName)
+        .def_property_readonly("version", &tr::GptJsonConfig::getVersion)
+        .def_property_readonly("precision", &tr::GptJsonConfig::getPrecision)
+        .def_property_readonly("tensor_parallelism", &tr::GptJsonConfig::getTensorParallelism)
+        .def_property_readonly("pipeline_parallelism", &tr::GptJsonConfig::getPipelineParallelism)
+        .def_property_readonly("context_parallelism", &tr::GptJsonConfig::getContextParallelism)
+        .def_property_readonly("gpus_per_node", &tr::GptJsonConfig::getGpusPerNode)
+        .def_property_readonly("world_size", &tr::GptJsonConfig::getWorldSize)
+        .def_property_readonly("runtime_defaults", &tr::GptJsonConfig::getRuntimeDefaults)
+        .def("engine_filename",
+            py::overload_cast<tr::WorldConfig const&, std::string const&>(
+                &tr::GptJsonConfig::engineFilename, py::const_),
+            py::arg("world_config"), py::arg("model"))
+        .def("engine_filename",
+            py::overload_cast<tr::WorldConfig const&>(&tr::GptJsonConfig::engineFilename, py::const_),
+            py::arg("world_config"));
+
+    py::enum_<tb::LlmRequestState>(m, "LlmRequestState")
+        .value("UNKNOWN", tb::LlmRequestState::kUNKNOWN)
+        .value("ENCODER_INIT", tb::LlmRequestState::kENCODER_INIT)
+        .value("CONTEXT_INIT", tb::LlmRequestState::kCONTEXT_INIT)
+        .value("GENERATION_IN_PROGRESS", tb::LlmRequestState::kGENERATION_IN_PROGRESS)
+        .value("GENERATION_TO_COMPLETE", tb::LlmRequestState::kGENERATION_TO_COMPLETE)
+        .value("GENERATION_COMPLETE", tb::LlmRequestState::kGENERATION_COMPLETE)
+        .value("DISAGG_GENERATION_INIT", tb::LlmRequestState::kDISAGG_GENERATION_INIT)
+        .value("DISAGG_CONTEXT_TRANS_IN_PROGRESS", tb::LlmRequestState::kDISAGG_CONTEXT_TRANS_IN_PROGRESS)
+        .value("DISAGG_CONTEXT_COMPLETE", tb::LlmRequestState::kDISAGG_CONTEXT_COMPLETE)
+        .value("DISAGG_GENERATION_TRANS_IN_PROGRESS", tb::LlmRequestState::kDISAGG_GENERATION_TRANS_IN_PROGRESS)
+        .value("DISAGG_GENERATION_TRANS_COMPLETE", tb::LlmRequestState::kDISAGG_GENERATION_TRANS_COMPLETE)
+        .value("DISAGG_CONTEXT_INIT_AND_TRANS", tb::LlmRequestState::kDISAGG_CONTEXT_INIT_AND_TRANS);
+
+    py::class_<tr::MemoryCounters>(m, "MemoryCounters")
+        .def_static("instance", &tr::MemoryCounters::getInstance, py::return_value_policy::reference)
+        .def_property_readonly("gpu", &tr::MemoryCounters::getGpu)
+        .def_property_readonly("cpu", &tr::MemoryCounters::getCpu)
+        .def_property_readonly("pinned", &tr::MemoryCounters::getPinned)
+        .def_property_readonly("uvm", &tr::MemoryCounters::getUVM);
+
+    tensorrt_llm::pybind::runtime::initBindings(mInternalRuntime);
+    tensorrt_llm::pybind::testing::initBindings(mInternalTesting);
+    tpb::initBindings(mInternalBatchManager);
+    tb::kv_cache_manager::KVCacheManagerBindings::initBindings(mInternalBatchManager);
+    tb::BasePeftCacheManagerBindings::initBindings(mInternalBatchManager);
+    tb::CacheTransceiverBindings::initBindings(mInternalBatchManager);
+    tpb::Buffers::initBindings(mInternalBatchManager);
+
+    auto mInternalAlgorithms = mInternal.def_submodule("algorithms", "Algorithms internal bindings");
+    tpb::algorithms::initBindings(mInternalAlgorithms);
+
+    auto mUserbuffers = mInternal.def_submodule("userbuffers", "User buffers internal bindings");
+    tensorrt_llm::kernels::userbuffers::UserBufferBindings::initBindings(mUserbuffers);
+
+    // NVLS allocators
+    py::class_<tr::IpcNvlsHandle>(m, "IpcNvlsHandle")
+        .def(py::init<>())
+        .def_readwrite("uc_ptr", &tr::IpcNvlsHandle::uc_ptr)
+        .def_readwrite("mc_ptr", &tr::IpcNvlsHandle::mc_ptr)
+        .def_readwrite("size", &tr::IpcNvlsHandle::size)
+        .def("get_ipc_ptrs",
+            [](tr::IpcNvlsHandle& self) { return reinterpret_cast<uintptr_t>(self.ipc_uc_ptrs.data()); });
+
+    m.def("ipc_nvls_allocate", &tr::ipcNvlsAllocate, py::return_value_policy::reference);
+    m.def("ipc_nvls_free", &tr::ipcNvlsFree);
+    m.def("ipc_nvls_supported", &tr::ipcNvlsSupported);
 }

--- a/cpp/tensorrt_llm/nanobind/common/bindTypes.h
+++ b/cpp/tensorrt_llm/nanobind/common/bindTypes.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "tensorrt_llm/pybind/common/customCasters.h"
+#include <pybind11/pybind11.h>
+
+namespace PybindUtils
+{
+
+namespace py = pybind11;
+
+template <typename T>
+void bindList(py::module& m, std::string const& name)
+{
+    py::class_<T>(m, name.c_str())
+        .def(py::init())
+        .def("push_back", [](T& lst, const typename T::value_type& value) { lst.push_back(value); })
+        .def("pop_back", [](T& lst) { lst.pop_back(); })
+        .def("push_front", [](T& lst, const typename T::value_type& value) { lst.push_front(value); })
+        .def("pop_front", [](T& lst) { lst.pop_front(); })
+        .def("__len__", [](T const& lst) { return lst.size(); })
+        .def(
+            "__iter__", [](T& lst) { return py::make_iterator(lst.begin(), lst.end()); }, py::keep_alive<0, 1>())
+        .def("__getitem__",
+            [](T const& lst, size_t index)
+            {
+                if (index >= lst.size())
+                    throw py::index_error();
+                auto it = lst.begin();
+                std::advance(it, index);
+                return *it;
+            })
+        .def("__setitem__",
+            [](T& lst, size_t index, const typename T::value_type& value)
+            {
+                if (index >= lst.size())
+                    throw py::index_error();
+                auto it = lst.begin();
+                std::advance(it, index);
+                *it = value;
+            });
+}
+
+template <typename T>
+void bindSet(py::module& m, std::string const& name)
+{
+    py::class_<T>(m, name.c_str())
+        .def(py::init())
+        .def("clear", &T::clear)
+        .def("size", &T::size)
+        .def("insert", [](T& s, typename T::value_type const& value) { s.insert(value); })
+        .def("erase", py::overload_cast<typename T::value_type const&>(&T::erase))
+        .def("__len__", [](T const& lst) { return lst.size(); })
+        .def("__contains__", [](T const& s, typename T::value_type x) { return s.find(x) != s.end(); })
+        .def(
+            "__iter__", [](T& s) { return py::make_iterator(s.begin(), s.end()); }, py::keep_alive<0, 1>())
+        .def("__eq__", [](T const& s, T const& other) { return s == other; })
+        .def(py::pickle(
+            [](T const& s) { // __getstate__
+                /* Return a tuple that fully encodes the state of the object */
+                return py::make_tuple(std::vector<typename T::value_type>(s.begin(), s.end()));
+            },
+            [](py::tuple t) { // __setstate__
+                if (t.size() != 1)
+                    throw std::runtime_error("Invalid state!");
+                /* Create a new C++ instance */
+                T s;
+                /* Assign any additional state */
+                auto state_list = t[0].cast<std::vector<typename T::value_type>>();
+                for (auto& item : state_list)
+                {
+                    s.insert(item);
+                }
+                return s;
+            }));
+}
+
+} // namespace PybindUtils

--- a/cpp/tensorrt_llm/nanobind/common/customCasters.h
+++ b/cpp/tensorrt_llm/nanobind/common/customCasters.h
@@ -17,12 +17,6 @@
 
 #pragma once
 
-#include "pybind11/cast.h"
-#include "pybind11/detail/common.h"
-#include "pybind11/detail/descr.h"
-#include "pybind11/pybind11.h"
-#include "pybind11/pytypes.h"
-
 #include "tensorrt_llm/batch_manager/common.h"
 #include "tensorrt_llm/batch_manager/decoderBuffers.h"
 #include "tensorrt_llm/common/optionalRef.h"
@@ -32,33 +26,82 @@
 #include "tensorrt_llm/runtime/torch.h"
 #include "tensorrt_llm/runtime/torchView.h"
 
+#include <ATen/DLConvertor.h>
+#include <deque>
 #include <filesystem>
-#include <pybind11/stl_bind.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/filesystem.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
+#include <torch/csrc/autograd/python_variable.h>
+#include <torch/csrc/autograd/variable.h>
 #include <torch/extension.h>
+#include <torch/torch.h>
 
 // Pybind requires to have a central include in order for type casters to work.
 // Opaque bindings add a type caster, so they have the same requirement.
 // See the warning in https://pybind11.readthedocs.io/en/stable/advanced/cast/custom.html
 
 // Opaque bindings
-PYBIND11_MAKE_OPAQUE(tensorrt_llm::batch_manager::ReqIdsSet)
-PYBIND11_MAKE_OPAQUE(std::vector<tensorrt_llm::batch_manager::SlotDecoderBuffers>)
+NB_MAKE_OPAQUE(tensorrt_llm::batch_manager::ReqIdsSet)
+NB_MAKE_OPAQUE(std::vector<tensorrt_llm::batch_manager::SlotDecoderBuffers>)
+NB_MAKE_OPAQUE(std::vector<tensorrt_llm::runtime::decoder_batch::Request>)
+NB_MAKE_OPAQUE(std::vector<tensorrt_llm::runtime::SamplingConfig>)
+NB_MAKE_OPAQUE(std::vector<std::vector<tensorrt_llm::runtime::SizeType32>>)
+
+namespace nb = nanobind;
 
 // Custom casters
-namespace PYBIND11_NAMESPACE
+namespace NB_NAMESPACE
 {
 
 namespace detail
 {
+
+template <typename T, typename Alloc>
+struct type_caster<std::deque<T, Alloc>>
+{
+    using Type = std::deque<T, Alloc>;
+    NB_TYPE_CASTER(Type, const_name("List"));
+
+    bool from_python(handle src, uint8_t flags, cleanup_list* cleanup) noexcept
+    {
+        sequence seq(src, nanobind::detail::borrow_t{});
+        value.clear();
+        make_caster<T> caster;
+        for (auto const& item : seq)
+        {
+            if (!caster.from_python(item, flags, cleanup))
+                return false;
+            value.push_back(caster.operator T&());
+        }
+        return true;
+    }
+
+    static handle from_cpp(Type const& deque, rv_policy policy, cleanup_list* cleanup) noexcept
+    {
+        nb::list list;
+
+        for (auto const& item : deque)
+        {
+            nb::object py_item = steal(make_caster<T>::from_cpp(item, policy, cleanup));
+            if (!py_item)
+                return {};
+            list.append(py_item);
+        }
+        return list.release();
+    }
+};
 
 template <typename T>
 struct type_caster<tensorrt_llm::common::OptionalRef<T>>
 {
     using value_conv = make_caster<T>;
 
-    PYBIND11_TYPE_CASTER(tensorrt_llm::common::OptionalRef<T>, value_conv::name);
+    NB_TYPE_CASTER(tensorrt_llm::common::OptionalRef<T>, value_conv::Name);
 
-    bool load(handle src, bool convert)
+    bool from_python(handle src, uint8_t flags, cleanup_list* cleanup)
     {
         if (src.is_none())
         {
@@ -68,7 +111,7 @@ struct type_caster<tensorrt_llm::common::OptionalRef<T>>
         }
 
         value_conv conv;
-        if (!conv.load(src, convert))
+        if (!conv.from_python(src, flags, cleanup))
             return false;
 
         // Create an OptionalRef with a reference to the converted value
@@ -76,12 +119,12 @@ struct type_caster<tensorrt_llm::common::OptionalRef<T>>
         return true;
     }
 
-    static handle cast(tensorrt_llm::common::OptionalRef<T> const& src, return_value_policy policy, handle parent)
+    static handle from_cpp(tensorrt_llm::common::OptionalRef<T> const& src, rv_policy policy, cleanup_list* cleanup)
     {
         if (!src.has_value())
             return none().release();
 
-        return value_conv::cast(*src, policy, parent);
+        return value_conv::from_cpp(*src, policy, cleanup);
     }
 };
 
@@ -101,21 +144,21 @@ private:
     }
 
 public:
-    static handle cast(T const& path, return_value_policy, handle)
+    static handle from_cpp(T const& path, rv_policy, cleanup_list* cleanup)
     {
         if (auto py_str = unicode_from_fs_native(path.native()))
         {
-            return module_::import("pathlib").attr("Path")(reinterpret_steal<object>(py_str)).release();
+            return module_::import_("pathlib").attr("Path")(steal<object>(py_str), cleanup).release();
         }
         return nullptr;
     }
 
-    bool load(handle handle, bool)
+    bool from_python(handle src, uint8_t flags, cleanup_list* cleanup)
     {
         PyObject* native = nullptr;
         if constexpr (std::is_same_v<typename T::value_type, char>)
         {
-            if (PyUnicode_FSConverter(handle.ptr(), &native) != 0)
+            if (PyUnicode_FSConverter(src.ptr(), &native) != 0)
             {
                 if (auto* c_str = PyBytes_AsString(native))
                 {
@@ -127,7 +170,7 @@ public:
         }
         else if constexpr (std::is_same_v<typename T::value_type, wchar_t>)
         {
-            if (PyUnicode_FSDecoder(handle.ptr(), &native) != 0)
+            if (PyUnicode_FSDecoder(src.ptr(), &native) != 0)
             {
                 if (auto* c_str = PyUnicode_AsWideCharString(native, nullptr))
                 {
@@ -146,30 +189,25 @@ public:
         return true;
     }
 
-    PYBIND11_TYPE_CASTER(T, const_name("os.PathLike"));
-};
-
-template <>
-struct type_caster<std::filesystem::path> : public PathCaster<std::filesystem::path>
-{
+    NB_TYPE_CASTER(T, const_name("os.PathLike"));
 };
 
 template <>
 class type_caster<tensorrt_llm::executor::StreamPtr>
 {
 public:
-    PYBIND11_TYPE_CASTER(tensorrt_llm::executor::StreamPtr, _("int"));
+    NB_TYPE_CASTER(tensorrt_llm::executor::StreamPtr, const_name("int"));
 
-    bool load([[maybe_unused]] handle src, bool)
+    bool from_python([[maybe_unused]] handle src, uint8_t flags, cleanup_list* cleanup)
     {
-        auto stream_ptr = src.cast<uintptr_t>();
+        auto stream_ptr = nanobind::cast<uintptr_t>(src);
         value = std::make_shared<tensorrt_llm::runtime::CudaStream>(reinterpret_cast<cudaStream_t>(stream_ptr));
 
         return true;
     }
 
-    static handle cast(
-        tensorrt_llm::executor::StreamPtr const& src, return_value_policy /* policy */, handle /* parent */)
+    static handle from_cpp(
+        tensorrt_llm::executor::StreamPtr const& src, rv_policy /* policy */, cleanup_list* /* cleanup */)
     {
         // Return cudaStream_t as integer.
         return PyLong_FromVoidPtr(src->get());
@@ -180,10 +218,10 @@ template <>
 struct type_caster<tensorrt_llm::executor::Tensor>
 {
 public:
-    PYBIND11_TYPE_CASTER(tensorrt_llm::executor::Tensor, _("torch.Tensor"));
+    NB_TYPE_CASTER(tensorrt_llm::executor::Tensor, const_name("torch.Tensor"));
 
     // Convert PyObject(torch.Tensor) -> tensorrt_llm::executor::Tensor
-    bool load(handle src, bool)
+    bool from_python(handle src, uint8_t flags, cleanup_list* cleanup)
     {
         PyObject* obj = src.ptr();
         if (THPVariable_Check(obj))
@@ -196,7 +234,8 @@ public:
     }
 
     // Convert tensorrt_llm::executor::Tensor -> PyObject(torch.Tensor)
-    static handle cast(tensorrt_llm::executor::Tensor const& src, return_value_policy /* policy */, handle /* parent */)
+    static handle from_cpp(
+        tensorrt_llm::executor::Tensor const& src, rv_policy /* policy */, cleanup_list* /* cleanup */)
     {
         return THPVariable_Wrap(tensorrt_llm::runtime::Torch::tensor(tensorrt_llm::executor::detail::toITensor(src)));
     }
@@ -206,10 +245,10 @@ template <>
 struct type_caster<tensorrt_llm::runtime::ITensor::SharedPtr>
 {
 public:
-    PYBIND11_TYPE_CASTER(tensorrt_llm::runtime::ITensor::SharedPtr, _("torch.Tensor"));
+    NB_TYPE_CASTER(tensorrt_llm::runtime::ITensor::SharedPtr, const_name("torch.Tensor"));
 
     // Convert PyObject(torch.Tensor) -> tensorrt_llm::runtime::ITensor::SharedPtr
-    bool load(handle src, bool)
+    bool from_python(handle src, uint8_t, cleanup_list*)
     {
         PyObject* obj = src.ptr();
         if (THPVariable_Check(obj))
@@ -222,8 +261,8 @@ public:
     }
 
     // Convert tensorrt_llm::runtime::ITensor::SharedPtr -> PyObject(torch.Tensor)
-    static handle cast(
-        tensorrt_llm::runtime::ITensor::SharedPtr const& src, return_value_policy /* policy */, handle /* parent */)
+    static handle from_cpp(
+        tensorrt_llm::runtime::ITensor::SharedPtr const& src, rv_policy /* policy */, cleanup_list* /* cleanup */)
     {
         if (src == nullptr)
         {
@@ -237,10 +276,10 @@ template <>
 struct type_caster<tensorrt_llm::runtime::ITensor::SharedConstPtr>
 {
 public:
-    PYBIND11_TYPE_CASTER(tensorrt_llm::runtime::ITensor::SharedConstPtr, _("torch.Tensor"));
+    NB_TYPE_CASTER(tensorrt_llm::runtime::ITensor::SharedConstPtr, const_name("torch.Tensor"));
 
     // Convert PyObject(torch.Tensor) -> tensorrt_llm::runtime::ITensor::SharedConstPtr
-    bool load(handle src, bool)
+    bool from_python(handle src, uint8_t, cleanup_list*)
     {
         PyObject* obj = src.ptr();
         if (THPVariable_Check(obj))
@@ -253,8 +292,8 @@ public:
     }
 
     // Convert tensorrt_llm::runtime::ITensor::SharedConstPtr -> PyObject(torch.Tensor)
-    static handle cast(tensorrt_llm::runtime::ITensor::SharedConstPtr const& src, return_value_policy /* policy */,
-        handle /* parent */)
+    static handle from_cpp(
+        tensorrt_llm::runtime::ITensor::SharedConstPtr const& src, rv_policy /* policy */, cleanup_list* /* cleanup */)
     {
         if (src == nullptr)
         {
@@ -265,5 +304,56 @@ public:
     }
 };
 
+template <>
+struct type_caster<at::Tensor>
+{
+    NB_TYPE_CASTER(at::Tensor, const_name("torch.Tensor"));
+
+    bool from_python(nb::handle src, uint8_t, cleanup_list*) noexcept
+    {
+        try
+        {
+            // Convert Python object to DLPack capsule
+            nb::object capsule = nb::getattr(src, "__dlpack__")();
+            DLManagedTensor* dl_managed
+                = static_cast<DLManagedTensor*>(PyCapsule_GetPointer(capsule.ptr(), "dltensor"));
+            PyCapsule_SetDestructor(capsule.ptr(), nullptr); // Disable capsule's deleter
+            // Convert DLPack to at::Tensor (zero-copy)
+            value = at::fromDLPack(dl_managed).alias();
+            return true;
+        }
+        catch (std::exception const& e)
+        {
+            std::cerr << "Error converting to at::Tensor: " << e.what() << std::endl;
+            return false;
+        }
+    }
+
+    static handle from_cpp(at::Tensor tensor, rv_policy, cleanup_list*) noexcept
+    {
+        // Convert at::Tensor to DLPack
+        DLManagedTensor* dl_managed = at::toDLPack(tensor);
+        if (!dl_managed)
+            return nullptr;
+
+        // Create Python capsule
+        nanobind::object capsule = nb::steal(PyCapsule_New(dl_managed, "dltensor",
+            [](PyObject* obj)
+            {
+                DLManagedTensor* dl = static_cast<DLManagedTensor*>(PyCapsule_GetPointer(obj, "dltensor"));
+                dl->deleter(dl);
+            }));
+        if (!capsule.is_valid())
+        {
+            dl_managed->deleter(dl_managed);
+            return nullptr;
+        }
+        // Convert capsule to torch.Tensor
+        nanobind::module_ torch = nanobind::module_::import_("torch");
+        nanobind::object result = torch.attr("from_dlpack")(capsule);
+        capsule.release();
+        return result.release();
+    }
+};
 } // namespace detail
-} // namespace PYBIND11_NAMESPACE
+} // namespace NB_NAMESPACE

--- a/cpp/tensorrt_llm/nanobind/common/customCasters.h
+++ b/cpp/tensorrt_llm/nanobind/common/customCasters.h
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "pybind11/cast.h"
+#include "pybind11/detail/common.h"
+#include "pybind11/detail/descr.h"
+#include "pybind11/pybind11.h"
+#include "pybind11/pytypes.h"
+
+#include "tensorrt_llm/batch_manager/common.h"
+#include "tensorrt_llm/batch_manager/decoderBuffers.h"
+#include "tensorrt_llm/common/optionalRef.h"
+#include "tensorrt_llm/runtime/cudaStream.h"
+#include "tensorrt_llm/runtime/request.h"
+#include "tensorrt_llm/runtime/samplingConfig.h"
+#include "tensorrt_llm/runtime/torch.h"
+#include "tensorrt_llm/runtime/torchView.h"
+
+#include <filesystem>
+#include <pybind11/stl_bind.h>
+#include <torch/extension.h>
+
+// Pybind requires to have a central include in order for type casters to work.
+// Opaque bindings add a type caster, so they have the same requirement.
+// See the warning in https://pybind11.readthedocs.io/en/stable/advanced/cast/custom.html
+
+// Opaque bindings
+PYBIND11_MAKE_OPAQUE(tensorrt_llm::batch_manager::ReqIdsSet)
+PYBIND11_MAKE_OPAQUE(std::vector<tensorrt_llm::batch_manager::SlotDecoderBuffers>)
+
+// Custom casters
+namespace PYBIND11_NAMESPACE
+{
+
+namespace detail
+{
+
+template <typename T>
+struct type_caster<tensorrt_llm::common::OptionalRef<T>>
+{
+    using value_conv = make_caster<T>;
+
+    PYBIND11_TYPE_CASTER(tensorrt_llm::common::OptionalRef<T>, value_conv::name);
+
+    bool load(handle src, bool convert)
+    {
+        if (src.is_none())
+        {
+            // If the Python object is None, create an empty OptionalRef
+            value = tensorrt_llm::common::OptionalRef<T>();
+            return true;
+        }
+
+        value_conv conv;
+        if (!conv.load(src, convert))
+            return false;
+
+        // Create an OptionalRef with a reference to the converted value
+        value = tensorrt_llm::common::OptionalRef<T>(conv);
+        return true;
+    }
+
+    static handle cast(tensorrt_llm::common::OptionalRef<T> const& src, return_value_policy policy, handle parent)
+    {
+        if (!src.has_value())
+            return none().release();
+
+        return value_conv::cast(*src, policy, parent);
+    }
+};
+
+template <typename T>
+struct PathCaster
+{
+
+private:
+    static PyObject* unicode_from_fs_native(std::string const& w)
+    {
+        return PyUnicode_DecodeFSDefaultAndSize(w.c_str(), ssize_t(w.size()));
+    }
+
+    static PyObject* unicode_from_fs_native(std::wstring const& w)
+    {
+        return PyUnicode_FromWideChar(w.c_str(), ssize_t(w.size()));
+    }
+
+public:
+    static handle cast(T const& path, return_value_policy, handle)
+    {
+        if (auto py_str = unicode_from_fs_native(path.native()))
+        {
+            return module_::import("pathlib").attr("Path")(reinterpret_steal<object>(py_str)).release();
+        }
+        return nullptr;
+    }
+
+    bool load(handle handle, bool)
+    {
+        PyObject* native = nullptr;
+        if constexpr (std::is_same_v<typename T::value_type, char>)
+        {
+            if (PyUnicode_FSConverter(handle.ptr(), &native) != 0)
+            {
+                if (auto* c_str = PyBytes_AsString(native))
+                {
+                    // AsString returns a pointer to the internal buffer, which
+                    // must not be free'd.
+                    value = c_str;
+                }
+            }
+        }
+        else if constexpr (std::is_same_v<typename T::value_type, wchar_t>)
+        {
+            if (PyUnicode_FSDecoder(handle.ptr(), &native) != 0)
+            {
+                if (auto* c_str = PyUnicode_AsWideCharString(native, nullptr))
+                {
+                    // AsWideCharString returns a new string that must be free'd.
+                    value = c_str; // Copies the string.
+                    PyMem_Free(c_str);
+                }
+            }
+        }
+        Py_XDECREF(native);
+        if (PyErr_Occurred())
+        {
+            PyErr_Clear();
+            return false;
+        }
+        return true;
+    }
+
+    PYBIND11_TYPE_CASTER(T, const_name("os.PathLike"));
+};
+
+template <>
+struct type_caster<std::filesystem::path> : public PathCaster<std::filesystem::path>
+{
+};
+
+template <>
+class type_caster<tensorrt_llm::executor::StreamPtr>
+{
+public:
+    PYBIND11_TYPE_CASTER(tensorrt_llm::executor::StreamPtr, _("int"));
+
+    bool load([[maybe_unused]] handle src, bool)
+    {
+        auto stream_ptr = src.cast<uintptr_t>();
+        value = std::make_shared<tensorrt_llm::runtime::CudaStream>(reinterpret_cast<cudaStream_t>(stream_ptr));
+
+        return true;
+    }
+
+    static handle cast(
+        tensorrt_llm::executor::StreamPtr const& src, return_value_policy /* policy */, handle /* parent */)
+    {
+        // Return cudaStream_t as integer.
+        return PyLong_FromVoidPtr(src->get());
+    }
+};
+
+template <>
+struct type_caster<tensorrt_llm::executor::Tensor>
+{
+public:
+    PYBIND11_TYPE_CASTER(tensorrt_llm::executor::Tensor, _("torch.Tensor"));
+
+    // Convert PyObject(torch.Tensor) -> tensorrt_llm::executor::Tensor
+    bool load(handle src, bool)
+    {
+        PyObject* obj = src.ptr();
+        if (THPVariable_Check(obj))
+        {
+            at::Tensor const& t = THPVariable_Unpack(obj);
+            value = tensorrt_llm::executor::detail::ofITensor(tensorrt_llm::runtime::TorchView::of(t));
+            return true;
+        }
+        return false;
+    }
+
+    // Convert tensorrt_llm::executor::Tensor -> PyObject(torch.Tensor)
+    static handle cast(tensorrt_llm::executor::Tensor const& src, return_value_policy /* policy */, handle /* parent */)
+    {
+        return THPVariable_Wrap(tensorrt_llm::runtime::Torch::tensor(tensorrt_llm::executor::detail::toITensor(src)));
+    }
+};
+
+template <>
+struct type_caster<tensorrt_llm::runtime::ITensor::SharedPtr>
+{
+public:
+    PYBIND11_TYPE_CASTER(tensorrt_llm::runtime::ITensor::SharedPtr, _("torch.Tensor"));
+
+    // Convert PyObject(torch.Tensor) -> tensorrt_llm::runtime::ITensor::SharedPtr
+    bool load(handle src, bool)
+    {
+        PyObject* obj = src.ptr();
+        if (THPVariable_Check(obj))
+        {
+            at::Tensor const& t = THPVariable_Unpack(obj);
+            value = std::move(tensorrt_llm::runtime::TorchView::of(t));
+            return true;
+        }
+        return false;
+    }
+
+    // Convert tensorrt_llm::runtime::ITensor::SharedPtr -> PyObject(torch.Tensor)
+    static handle cast(
+        tensorrt_llm::runtime::ITensor::SharedPtr const& src, return_value_policy /* policy */, handle /* parent */)
+    {
+        if (src == nullptr)
+        {
+            return none().release();
+        }
+        return THPVariable_Wrap(tensorrt_llm::runtime::Torch::tensor(src));
+    }
+};
+
+template <>
+struct type_caster<tensorrt_llm::runtime::ITensor::SharedConstPtr>
+{
+public:
+    PYBIND11_TYPE_CASTER(tensorrt_llm::runtime::ITensor::SharedConstPtr, _("torch.Tensor"));
+
+    // Convert PyObject(torch.Tensor) -> tensorrt_llm::runtime::ITensor::SharedConstPtr
+    bool load(handle src, bool)
+    {
+        PyObject* obj = src.ptr();
+        if (THPVariable_Check(obj))
+        {
+            at::Tensor const& t = THPVariable_Unpack(obj);
+            value = std::move(tensorrt_llm::runtime::TorchView::of(t));
+            return true;
+        }
+        return false;
+    }
+
+    // Convert tensorrt_llm::runtime::ITensor::SharedConstPtr -> PyObject(torch.Tensor)
+    static handle cast(tensorrt_llm::runtime::ITensor::SharedConstPtr const& src, return_value_policy /* policy */,
+        handle /* parent */)
+    {
+        if (src == nullptr)
+        {
+            return none().release();
+        }
+        return THPVariable_Wrap(tensorrt_llm::runtime::Torch::tensor(
+            reinterpret_cast<tensorrt_llm::runtime::ITensor::SharedPtr const&>(src)));
+    }
+};
+
+} // namespace detail
+} // namespace PYBIND11_NAMESPACE

--- a/cpp/tensorrt_llm/nanobind/executor/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/executor/bindings.cpp
@@ -22,48 +22,46 @@
 #include "tensorrt_llm/executor/executor.h"
 #include "tensorrt_llm/executor/types.h"
 
-#include <pybind11/cast.h>
-#include <pybind11/chrono.h>
-#include <pybind11/functional.h>
-#include <pybind11/operators.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/tuple.h>
+#include <nanobind/stl/variant.h>
 #include <optional>
 
-namespace py = pybind11;
+namespace nb = nanobind;
 namespace tle = tensorrt_llm::executor;
 using SizeType32 = tle::SizeType32;
 
-namespace tensorrt_llm::pybind::executor
+namespace tensorrt_llm::nanobind::executor
 {
 
 template <typename T>
-void instantiateEventDiff(pybind11::module& m, std::string const& name)
+void instantiateEventDiff(nb::module_& m, std::string const& name)
 {
-    py::class_<tle::KVCacheEventDiff<T>>(m, ("KVCacheEventDiff" + name).c_str())
-        .def_readonly("old_value", &tle::KVCacheEventDiff<T>::oldValue)
-        .def_readonly("new_value", &tle::KVCacheEventDiff<T>::newValue);
+    nb::class_<tle::KVCacheEventDiff<T>>(m, ("KVCacheEventDiff" + name).c_str())
+        .def_ro("old_value", &tle::KVCacheEventDiff<T>::oldValue)
+        .def_ro("new_value", &tle::KVCacheEventDiff<T>::newValue);
 }
 
-void initBindings(pybind11::module_& m)
+void initBindings(nb::module_& m)
 {
     m.attr("__version__") = tle::version();
-    py::enum_<tle::ModelType>(m, "ModelType")
+    nb::enum_<tle::ModelType>(m, "ModelType")
         .value("DECODER_ONLY", tle::ModelType::kDECODER_ONLY)
         .value("ENCODER_ONLY", tle::ModelType::kENCODER_ONLY)
         .value("ENCODER_DECODER", tle::ModelType::kENCODER_DECODER);
 
-    auto decodingModeGetstate = [](tle::DecodingMode const& self) { return py::make_tuple(self.getState()); };
-    auto decodingModeSetstate = [](py::tuple const& state)
+    auto decodingModeGetstate = [](tle::DecodingMode const& self) { return nb::make_tuple(self.getState()); };
+    auto decodingModeSetstate = [](tle::DecodingMode& self, nb::tuple const& state)
     {
         if (state.size() != 1)
         {
             throw std::runtime_error("Invalid state!");
         }
-        return tle::DecodingMode(state[0].cast<tle::DecodingMode::UnderlyingType>());
+        new (&self) tle::DecodingMode(nb::cast<tle::DecodingMode::UnderlyingType>(state[0]));
     };
-    py::class_<tle::DecodingMode>(m, "DecodingMode")
+    nb::class_<tle::DecodingMode>(m, "DecodingMode")
         .def("Auto", &tle::DecodingMode::Auto)
         .def("TopK", &tle::DecodingMode::TopK)
         .def("TopP", &tle::DecodingMode::TopP)
@@ -84,171 +82,181 @@ void initBindings(pybind11::module_& m)
         .def("isExplicitDraftTokens", &tle::DecodingMode::isExplicitDraftTokens)
         .def("isEagle", &tle::DecodingMode::isEagle)
         .def("useVariableBeamWidthSearch", &tle::DecodingMode::useVariableBeamWidthSearch)
-        .def_property_readonly("name", &tle::DecodingMode::getName)
-        .def(py::pickle(decodingModeGetstate, decodingModeSetstate));
+        .def_prop_ro("name", &tle::DecodingMode::getName)
+        .def("__getstate__", decodingModeGetstate)
+        .def("__setstate__", decodingModeSetstate);
 
-    py::enum_<tle::CapacitySchedulerPolicy>(m, "CapacitySchedulerPolicy")
+    nb::enum_<tle::CapacitySchedulerPolicy>(m, "CapacitySchedulerPolicy")
         .value("MAX_UTILIZATION", tle::CapacitySchedulerPolicy::kMAX_UTILIZATION)
         .value("GUARANTEED_NO_EVICT", tle::CapacitySchedulerPolicy::kGUARANTEED_NO_EVICT)
         .value("STATIC_BATCH", tle::CapacitySchedulerPolicy::kSTATIC_BATCH);
 
-    py::enum_<tle::ContextChunkingPolicy>(m, "ContextChunkingPolicy")
+    nb::enum_<tle::ContextChunkingPolicy>(m, "ContextChunkingPolicy")
         .value("EQUAL_PROGRESS", tle::ContextChunkingPolicy::kEQUAL_PROGRESS)
         .value("FIRST_COME_FIRST_SERVED", tle::ContextChunkingPolicy::kFIRST_COME_FIRST_SERVED);
 
-    py::enum_<tle::CommunicationType>(m, "CommunicationType").value("MPI", tle::CommunicationType::kMPI);
+    nb::enum_<tle::CommunicationType>(m, "CommunicationType").value("MPI", tle::CommunicationType::kMPI);
 
-    py::enum_<tle::CommunicationMode>(m, "CommunicationMode")
+    nb::enum_<tle::CommunicationMode>(m, "CommunicationMode")
         .value("LEADER", tle::CommunicationMode::kLEADER)
         .value("ORCHESTRATOR", tle::CommunicationMode::kORCHESTRATOR);
 
-    py::class_<tle::KvCacheStats>(m, "KvCacheStats")
-        .def(py::init<>())
-        .def_readwrite("max_num_blocks", &tle::KvCacheStats::maxNumBlocks)
-        .def_readwrite("free_num_blocks", &tle::KvCacheStats::freeNumBlocks)
-        .def_readwrite("used_num_blocks", &tle::KvCacheStats::usedNumBlocks)
-        .def_readwrite("tokens_per_block", &tle::KvCacheStats::tokensPerBlock)
-        .def_readwrite("alloc_total_blocks", &tle::KvCacheStats::allocTotalBlocks)
-        .def_readwrite("alloc_new_blocks", &tle::KvCacheStats::allocNewBlocks)
-        .def_readwrite("reused_blocks", &tle::KvCacheStats::reusedBlocks)
-        .def_readwrite("missed_blocks", &tle::KvCacheStats::missedBlocks)
-        .def_readwrite("cache_hit_rate", &tle::KvCacheStats::cacheHitRate);
+    nb::class_<tle::KvCacheStats>(m, "KvCacheStats")
+        .def(nb::init<>())
+        .def_rw("max_num_blocks", &tle::KvCacheStats::maxNumBlocks)
+        .def_rw("free_num_blocks", &tle::KvCacheStats::freeNumBlocks)
+        .def_rw("used_num_blocks", &tle::KvCacheStats::usedNumBlocks)
+        .def_rw("tokens_per_block", &tle::KvCacheStats::tokensPerBlock)
+        .def_rw("alloc_total_blocks", &tle::KvCacheStats::allocTotalBlocks)
+        .def_rw("alloc_new_blocks", &tle::KvCacheStats::allocNewBlocks)
+        .def_rw("reused_blocks", &tle::KvCacheStats::reusedBlocks)
+        .def_rw("missed_blocks", &tle::KvCacheStats::missedBlocks)
+        .def_rw("cache_hit_rate", &tle::KvCacheStats::cacheHitRate);
 
-    py::class_<tle::StaticBatchingStats>(m, "StaticBatchingStats")
-        .def(py::init<>())
-        .def_readwrite("num_scheduled_requests", &tle::StaticBatchingStats::numScheduledRequests)
-        .def_readwrite("num_context_requests", &tle::StaticBatchingStats::numContextRequests)
-        .def_readwrite("num_ctx_tokens", &tle::StaticBatchingStats::numCtxTokens)
-        .def_readwrite("num_gen_tokens", &tle::StaticBatchingStats::numGenTokens)
-        .def_readwrite("empty_gen_slots", &tle::StaticBatchingStats::emptyGenSlots);
+    nb::class_<tle::StaticBatchingStats>(m, "StaticBatchingStats")
+        .def(nb::init<>())
+        .def_rw("num_scheduled_requests", &tle::StaticBatchingStats::numScheduledRequests)
+        .def_rw("num_context_requests", &tle::StaticBatchingStats::numContextRequests)
+        .def_rw("num_ctx_tokens", &tle::StaticBatchingStats::numCtxTokens)
+        .def_rw("num_gen_tokens", &tle::StaticBatchingStats::numGenTokens)
+        .def_rw("empty_gen_slots", &tle::StaticBatchingStats::emptyGenSlots);
 
-    py::class_<tle::InflightBatchingStats>(m, "InflightBatchingStats")
-        .def(py::init<>())
-        .def_readwrite("num_scheduled_requests", &tle::InflightBatchingStats::numScheduledRequests)
-        .def_readwrite("num_context_requests", &tle::InflightBatchingStats::numContextRequests)
-        .def_readwrite("num_gen_requests", &tle::InflightBatchingStats::numGenRequests)
-        .def_readwrite("num_paused_requests", &tle::InflightBatchingStats::numPausedRequests)
-        .def_readwrite("num_ctx_tokens", &tle::InflightBatchingStats::numCtxTokens)
-        .def_readwrite("micro_batch_id", &tle::InflightBatchingStats::microBatchId)
-        .def_readwrite("avg_num_decoded_tokens_per_iter", &tle::InflightBatchingStats::avgNumDecodedTokensPerIter);
+    nb::class_<tle::InflightBatchingStats>(m, "InflightBatchingStats")
+        .def(nb::init<>())
+        .def_rw("num_scheduled_requests", &tle::InflightBatchingStats::numScheduledRequests)
+        .def_rw("num_context_requests", &tle::InflightBatchingStats::numContextRequests)
+        .def_rw("num_gen_requests", &tle::InflightBatchingStats::numGenRequests)
+        .def_rw("num_paused_requests", &tle::InflightBatchingStats::numPausedRequests)
+        .def_rw("num_ctx_tokens", &tle::InflightBatchingStats::numCtxTokens)
+        .def_rw("micro_batch_id", &tle::InflightBatchingStats::microBatchId)
+        .def_rw("avg_num_decoded_tokens_per_iter", &tle::InflightBatchingStats::avgNumDecodedTokensPerIter);
 
-    py::class_<tle::SpecDecodingStats>(m, "SpecDecodingStats")
-        .def(py::init<>())
-        .def_readwrite("num_draft_tokens", &tle::SpecDecodingStats::numDraftTokens)
-        .def_readwrite("num_accepted_tokens", &tle::SpecDecodingStats::numAcceptedTokens)
-        .def_readwrite("num_requests_with_draft_tokens", &tle::SpecDecodingStats::numRequestsWithDraftTokens)
-        .def_readwrite("acceptance_length", &tle::SpecDecodingStats::acceptanceLength)
-        .def_readwrite("iter_latency_ms", &tle::SpecDecodingStats::iterLatencyMS)
-        .def_readwrite("draft_overhead", &tle::SpecDecodingStats::draftOverhead);
+    nb::class_<tle::SpecDecodingStats>(m, "SpecDecodingStats")
+        .def(nb::init<>())
+        .def_rw("num_draft_tokens", &tle::SpecDecodingStats::numDraftTokens)
+        .def_rw("num_accepted_tokens", &tle::SpecDecodingStats::numAcceptedTokens)
+        .def_rw("num_requests_with_draft_tokens", &tle::SpecDecodingStats::numRequestsWithDraftTokens)
+        .def_rw("acceptance_length", &tle::SpecDecodingStats::acceptanceLength)
+        .def_rw("iter_latency_ms", &tle::SpecDecodingStats::iterLatencyMS)
+        .def_rw("draft_overhead", &tle::SpecDecodingStats::draftOverhead);
 
-    py::class_<tle::IterationStats>(m, "IterationStats")
-        .def(py::init<>())
-        .def_readwrite("timestamp", &tle::IterationStats::timestamp)
-        .def_readwrite("iter", &tle::IterationStats::iter)
-        .def_readwrite("iter_latency_ms", &tle::IterationStats::iterLatencyMS)
-        .def_readwrite("new_active_requests_queue_latency_ms", &tle::IterationStats::newActiveRequestsQueueLatencyMS)
-        .def_readwrite("num_new_active_requests", &tle::IterationStats::numNewActiveRequests)
-        .def_readwrite("num_active_requests", &tle::IterationStats::numActiveRequests)
-        .def_readwrite("num_queued_requests", &tle::IterationStats::numQueuedRequests)
-        .def_readwrite("num_completed_requests", &tle::IterationStats::numCompletedRequests)
-        .def_readwrite("max_num_active_requests", &tle::IterationStats::maxNumActiveRequests)
-        .def_readwrite("gpu_mem_usage", &tle::IterationStats::gpuMemUsage)
-        .def_readwrite("cpu_mem_usage", &tle::IterationStats::cpuMemUsage)
-        .def_readwrite("pinned_mem_usage", &tle::IterationStats::pinnedMemUsage)
-        .def_readwrite("kv_cache_stats", &tle::IterationStats::kvCacheStats)
-        .def_readwrite("cross_kv_cache_stats", &tle::IterationStats::crossKvCacheStats)
-        .def_readwrite("static_batching_stats", &tle::IterationStats::staticBatchingStats)
-        .def_readwrite("inflight_batching_stats", &tle::IterationStats::inflightBatchingStats)
-        .def_readwrite("specdec_stats", &tle::IterationStats::specDecodingStats)
+    nb::class_<tle::IterationStats>(m, "IterationStats")
+        .def(nb::init<>())
+        .def_rw("timestamp", &tle::IterationStats::timestamp)
+        .def_rw("iter", &tle::IterationStats::iter)
+        .def_rw("iter_latency_ms", &tle::IterationStats::iterLatencyMS)
+        .def_rw("new_active_requests_queue_latency_ms", &tle::IterationStats::newActiveRequestsQueueLatencyMS)
+        .def_rw("num_new_active_requests", &tle::IterationStats::numNewActiveRequests)
+        .def_rw("num_active_requests", &tle::IterationStats::numActiveRequests)
+        .def_rw("num_queued_requests", &tle::IterationStats::numQueuedRequests)
+        .def_rw("num_completed_requests", &tle::IterationStats::numCompletedRequests)
+        .def_rw("max_num_active_requests", &tle::IterationStats::maxNumActiveRequests)
+        .def_rw("gpu_mem_usage", &tle::IterationStats::gpuMemUsage)
+        .def_rw("cpu_mem_usage", &tle::IterationStats::cpuMemUsage)
+        .def_rw("pinned_mem_usage", &tle::IterationStats::pinnedMemUsage)
+        .def_rw("kv_cache_stats", &tle::IterationStats::kvCacheStats)
+        .def_rw("cross_kv_cache_stats", &tle::IterationStats::crossKvCacheStats)
+        .def_rw("static_batching_stats", &tle::IterationStats::staticBatchingStats)
+        .def_rw("inflight_batching_stats", &tle::IterationStats::inflightBatchingStats)
+        .def_rw("specdec_stats", &tle::IterationStats::specDecodingStats)
         .def("to_json_str",
             [](tle::IterationStats const& iterationStats)
             { return tle::JsonSerialization::toJsonStr(iterationStats); });
 
-    py::class_<tle::DebugTensorsPerIteration>(m, "DebugTensorsPerIteration")
-        .def(py::init<>())
-        .def_readwrite("iter", &tle::DebugTensorsPerIteration::iter)
-        .def_readwrite("debug_tensors", &tle::DebugTensorsPerIteration::debugTensors);
+    nb::class_<tle::DebugTensorsPerIteration>(m, "DebugTensorsPerIteration")
+        .def(nb::init<>())
+        .def_rw("iter", &tle::DebugTensorsPerIteration::iter)
+        .def_rw("debug_tensors", &tle::DebugTensorsPerIteration::debugTensors);
 
-    py::enum_<tle::RequestStage>(m, "RequestStage")
+    nb::enum_<tle::RequestStage>(m, "RequestStage")
         .value("QUEUED", tle::RequestStage::kQUEUED)
         .value("ENCODER_IN_PROGRESS", tle::RequestStage::kENCODER_IN_PROGRESS)
         .value("CONTEXT_IN_PROGRESS", tle::RequestStage::kCONTEXT_IN_PROGRESS)
         .value("GENERATION_IN_PROGRESS", tle::RequestStage::kGENERATION_IN_PROGRESS)
         .value("GENERATION_COMPLETE", tle::RequestStage::kGENERATION_COMPLETE);
 
-    py::class_<tle::DisServingRequestStats>(m, "DisServingRequestStats")
-        .def(py::init<>())
-        .def_readwrite("kv_cache_transfer_ms", &tle::DisServingRequestStats::kvCacheTransferMS)
-        .def_readwrite("kv_cache_size", &tle::DisServingRequestStats::kvCacheSize);
+    nb::class_<tle::DisServingRequestStats>(m, "DisServingRequestStats")
+        .def(nb::init<>())
+        .def_rw("kv_cache_transfer_ms", &tle::DisServingRequestStats::kvCacheTransferMS)
+        .def_rw("kv_cache_size", &tle::DisServingRequestStats::kvCacheSize);
 
-    py::class_<tle::RequestStats>(m, "RequestStats")
-        .def(py::init<>())
-        .def_readwrite("id", &tle::RequestStats::id)
-        .def_readwrite("stage", &tle::RequestStats::stage)
-        .def_readwrite("context_prefill_position", &tle::RequestStats::contextPrefillPosition)
-        .def_readwrite("num_generated_tokens", &tle::RequestStats::numGeneratedTokens)
-        .def_readwrite("avg_num_decoded_tokens_per_iter", &tle::RequestStats::avgNumDecodedTokensPerIter)
-        .def_readwrite("scheduled", &tle::RequestStats::scheduled)
-        .def_readwrite("paused", &tle::RequestStats::paused)
-        .def_readwrite("dis_serving_stats", &tle::RequestStats::disServingStats)
-        .def_readwrite("alloc_total_blocks_per_request", &tle::RequestStats::allocTotalBlocksPerRequest)
-        .def_readwrite("alloc_new_blocks_per_request", &tle::RequestStats::allocNewBlocksPerRequest)
-        .def_readwrite("reused_blocks_per_request", &tle::RequestStats::reusedBlocksPerRequest)
-        .def_readwrite("missed_blocks_per_request", &tle::RequestStats::missedBlocksPerRequest)
-        .def_readwrite("kv_cache_hit_rate_per_request", &tle::RequestStats::kvCacheHitRatePerRequest)
+    nb::class_<tle::RequestStats>(m, "RequestStats")
+        .def(nb::init<>())
+        .def_rw("id", &tle::RequestStats::id)
+        .def_rw("stage", &tle::RequestStats::stage)
+        .def_rw("context_prefill_position", &tle::RequestStats::contextPrefillPosition)
+        .def_rw("num_generated_tokens", &tle::RequestStats::numGeneratedTokens)
+        .def_rw("avg_num_decoded_tokens_per_iter", &tle::RequestStats::avgNumDecodedTokensPerIter)
+        .def_rw("scheduled", &tle::RequestStats::scheduled)
+        .def_rw("paused", &tle::RequestStats::paused)
+        .def_rw("dis_serving_stats", &tle::RequestStats::disServingStats)
+        .def_rw("alloc_total_blocks_per_request", &tle::RequestStats::allocTotalBlocksPerRequest)
+        .def_rw("alloc_new_blocks_per_request", &tle::RequestStats::allocNewBlocksPerRequest)
+        .def_rw("reused_blocks_per_request", &tle::RequestStats::reusedBlocksPerRequest)
+        .def_rw("missed_blocks_per_request", &tle::RequestStats::missedBlocksPerRequest)
+        .def_rw("kv_cache_hit_rate_per_request", &tle::RequestStats::kvCacheHitRatePerRequest)
         .def("to_json_str",
             [](tle::RequestStats const& iterationStats) { return tle::JsonSerialization::toJsonStr(iterationStats); });
 
-    py::class_<tle::RequestStatsPerIteration>(m, "RequestStatsPerIteration")
-        .def(py::init<>())
-        .def_readwrite("iter", &tle::RequestStatsPerIteration::iter)
-        .def_readwrite("request_stats", &tle::RequestStatsPerIteration::requestStats)
+    nb::class_<tle::RequestStatsPerIteration>(m, "RequestStatsPerIteration")
+        .def(nb::init<>())
+        .def_rw("iter", &tle::RequestStatsPerIteration::iter)
+        .def_rw("request_stats", &tle::RequestStatsPerIteration::requestStats)
         .def("to_json_str",
             [](tle::RequestStatsPerIteration const& iterationStats)
             { return tle::JsonSerialization::toJsonStr(iterationStats); });
 
-    py::module_ executor_kv_cache = m.def_submodule("kv_cache", "Executor KV Cache Manager");
+    nb::module_ executor_kv_cache = m.def_submodule("kv_cache", "Executor KV Cache Manager");
 
-    py::class_<tle::KVCacheCreatedData>(executor_kv_cache, "KVCacheCreatedData")
-        .def_readonly("num_blocks_per_cache_level", &tle::KVCacheCreatedData::numBlocksPerCacheLevel);
+    nb::class_<tle::KVCacheCreatedData>(executor_kv_cache, "KVCacheCreatedData")
+        .def_ro("num_blocks_per_cache_level", &tle::KVCacheCreatedData::numBlocksPerCacheLevel);
 
-    py::class_<tensorrt_llm::runtime::UniqueToken>(executor_kv_cache, "UniqueToken")
-        .def_readonly("token_id", &tensorrt_llm::runtime::UniqueToken::tokenId)
-        .def_readonly("token_extra_id", &tensorrt_llm::runtime::UniqueToken::tokenExtraId);
+    nb::class_<tensorrt_llm::runtime::UniqueToken>(executor_kv_cache, "UniqueToken")
+        .def_ro("token_id", &tensorrt_llm::runtime::UniqueToken::tokenId)
+        .def_ro("token_extra_id", &tensorrt_llm::runtime::UniqueToken::tokenExtraId);
 
-    py::class_<tle::KVCacheStoredBlockData>(executor_kv_cache, "KVCacheStoredBlockData")
-        .def_readonly("block_hash", &tle::KVCacheStoredBlockData::blockHash)
-        .def_readonly("tokens", &tle::KVCacheStoredBlockData::tokens)
-        .def_readonly("lora_id", &tle::KVCacheStoredBlockData::loraId)
-        .def_readonly("cache_level", &tle::KVCacheStoredBlockData::cacheLevel)
-        .def_readonly("priority", &tle::KVCacheStoredBlockData::priority);
+    nb::class_<tle::KVCacheStoredBlockData>(executor_kv_cache, "KVCacheStoredBlockData")
+        .def_ro("block_hash", &tle::KVCacheStoredBlockData::blockHash)
+        .def_ro("tokens", &tle::KVCacheStoredBlockData::tokens)
+        .def_ro("lora_id", &tle::KVCacheStoredBlockData::loraId)
+        .def_ro("cache_level", &tle::KVCacheStoredBlockData::cacheLevel)
+        .def_ro("priority", &tle::KVCacheStoredBlockData::priority);
 
-    py::class_<tle::KVCacheStoredData>(executor_kv_cache, "KVCacheStoredData")
-        .def_readonly("parent_hash", &tle::KVCacheStoredData::parentHash)
-        .def_readonly("blocks", &tle::KVCacheStoredData::blocks);
+    nb::class_<tle::KVCacheStoredData>(executor_kv_cache, "KVCacheStoredData")
+        .def_ro("parent_hash", &tle::KVCacheStoredData::parentHash)
+        .def_ro("blocks", &tle::KVCacheStoredData::blocks);
 
-    py::class_<tle::KVCacheRemovedData>(executor_kv_cache, "KVCacheRemovedData")
-        .def_readonly("block_hashes", &tle::KVCacheRemovedData::blockHashes);
+    nb::class_<tle::KVCacheRemovedData>(executor_kv_cache, "KVCacheRemovedData")
+        .def_ro("block_hashes", &tle::KVCacheRemovedData::blockHashes);
 
     instantiateEventDiff<SizeType32>(executor_kv_cache, "Int");
 
-    py::class_<tle::KVCacheUpdatedData>(executor_kv_cache, "KVCacheUpdatedData")
-        .def_readonly("block_hash", &tle::KVCacheUpdatedData::blockHash)
-        .def_readonly("cache_level", &tle::KVCacheUpdatedData::cacheLevel)
-        .def_readonly("priority", &tle::KVCacheUpdatedData::priority);
+    nb::class_<tle::KVCacheUpdatedData>(executor_kv_cache, "KVCacheUpdatedData")
+        .def_ro("block_hash", &tle::KVCacheUpdatedData::blockHash)
+        .def_ro("cache_level", &tle::KVCacheUpdatedData::cacheLevel)
+        .def_ro("priority", &tle::KVCacheUpdatedData::priority);
 
-    py::class_<tle::KVCacheEvent>(executor_kv_cache, "KVCacheEvent")
-        .def_readonly("event_id", &tle::KVCacheEvent::eventId)
-        .def_readonly("data", &tle::KVCacheEvent::data)
-        .def_readonly("window_size", &tle::KVCacheEvent::windowSize);
+    nb::class_<tle::KVCacheEvent>(executor_kv_cache, "KVCacheEvent")
+        .def_ro("event_id", &tle::KVCacheEvent::eventId)
+        .def_ro("data", &tle::KVCacheEvent::data)
+        .def_ro("window_size", &tle::KVCacheEvent::windowSize);
 
-    py::class_<tle::KVCacheEventManager, std::shared_ptr<tle::KVCacheEventManager>>(
-        executor_kv_cache, "KVCacheEventManager")
-        .def("get_latest_events", &tle::KVCacheEventManager::getLatestEvents, py::arg("timeout") = std::nullopt);
+    nb::class_<tle::KVCacheEventManager>(executor_kv_cache, "KVCacheEventManager")
+        .def(
+            "get_latest_events",
+            [](tle::KVCacheEventManager& self, std::optional<double> timeout_ms = std::nullopt)
+            {
+                if (timeout_ms)
+                {
+                    return self.getLatestEvents(std::chrono::milliseconds(static_cast<int64_t>(*timeout_ms)));
+                }
+                return self.getLatestEvents(std::nullopt);
+            },
+            nb::arg("timeout_ms") = std::nullopt);
 
-    tensorrt_llm::pybind::executor::initRequestBindings(m);
-    tensorrt_llm::pybind::executor::initConfigBindings(m);
-    tensorrt_llm::pybind::executor::Executor::initBindings(m);
+    tensorrt_llm::nanobind::executor::initRequestBindings(m);
+    tensorrt_llm::nanobind::executor::initConfigBindings(m);
+    tensorrt_llm::nanobind::executor::Executor::initBindings(m);
 }
 
-} // namespace tensorrt_llm::pybind::executor
+} // namespace tensorrt_llm::nanobind::executor

--- a/cpp/tensorrt_llm/nanobind/executor/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/executor/bindings.cpp
@@ -1,0 +1,254 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bindings.h"
+#include "executor.h"
+#include "executorConfig.h"
+#include "request.h"
+#include "tensorrt_llm/executor/executor.h"
+#include "tensorrt_llm/executor/types.h"
+
+#include <pybind11/cast.h>
+#include <pybind11/chrono.h>
+#include <pybind11/functional.h>
+#include <pybind11/operators.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <optional>
+
+namespace py = pybind11;
+namespace tle = tensorrt_llm::executor;
+using SizeType32 = tle::SizeType32;
+
+namespace tensorrt_llm::pybind::executor
+{
+
+template <typename T>
+void instantiateEventDiff(pybind11::module& m, std::string const& name)
+{
+    py::class_<tle::KVCacheEventDiff<T>>(m, ("KVCacheEventDiff" + name).c_str())
+        .def_readonly("old_value", &tle::KVCacheEventDiff<T>::oldValue)
+        .def_readonly("new_value", &tle::KVCacheEventDiff<T>::newValue);
+}
+
+void initBindings(pybind11::module_& m)
+{
+    m.attr("__version__") = tle::version();
+    py::enum_<tle::ModelType>(m, "ModelType")
+        .value("DECODER_ONLY", tle::ModelType::kDECODER_ONLY)
+        .value("ENCODER_ONLY", tle::ModelType::kENCODER_ONLY)
+        .value("ENCODER_DECODER", tle::ModelType::kENCODER_DECODER);
+
+    auto decodingModeGetstate = [](tle::DecodingMode const& self) { return py::make_tuple(self.getState()); };
+    auto decodingModeSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 1)
+        {
+            throw std::runtime_error("Invalid state!");
+        }
+        return tle::DecodingMode(state[0].cast<tle::DecodingMode::UnderlyingType>());
+    };
+    py::class_<tle::DecodingMode>(m, "DecodingMode")
+        .def("Auto", &tle::DecodingMode::Auto)
+        .def("TopK", &tle::DecodingMode::TopK)
+        .def("TopP", &tle::DecodingMode::TopP)
+        .def("TopKTopP", &tle::DecodingMode::TopKTopP)
+        .def("BeamSearch", &tle::DecodingMode::BeamSearch)
+        .def("Medusa", &tle::DecodingMode::Medusa)
+        .def("Lookahead", &tle::DecodingMode::Lookahead)
+        .def("ExplicitDraftTokens", &tle::DecodingMode::ExplicitDraftTokens)
+        .def("Eagle", &tle::DecodingMode::Eagle)
+        .def("isAuto", &tle::DecodingMode::isAuto)
+        .def("isTopK", &tle::DecodingMode::isTopK)
+        .def("isTopP", &tle::DecodingMode::isTopP)
+        .def("isTopKorTopP", &tle::DecodingMode::isTopKorTopP)
+        .def("isTopKandTopP", &tle::DecodingMode::isTopKandTopP)
+        .def("isBeamSearch", &tle::DecodingMode::isBeamSearch)
+        .def("isMedusa", &tle::DecodingMode::isMedusa)
+        .def("isLookahead", &tle::DecodingMode::isLookahead)
+        .def("isExplicitDraftTokens", &tle::DecodingMode::isExplicitDraftTokens)
+        .def("isEagle", &tle::DecodingMode::isEagle)
+        .def("useVariableBeamWidthSearch", &tle::DecodingMode::useVariableBeamWidthSearch)
+        .def_property_readonly("name", &tle::DecodingMode::getName)
+        .def(py::pickle(decodingModeGetstate, decodingModeSetstate));
+
+    py::enum_<tle::CapacitySchedulerPolicy>(m, "CapacitySchedulerPolicy")
+        .value("MAX_UTILIZATION", tle::CapacitySchedulerPolicy::kMAX_UTILIZATION)
+        .value("GUARANTEED_NO_EVICT", tle::CapacitySchedulerPolicy::kGUARANTEED_NO_EVICT)
+        .value("STATIC_BATCH", tle::CapacitySchedulerPolicy::kSTATIC_BATCH);
+
+    py::enum_<tle::ContextChunkingPolicy>(m, "ContextChunkingPolicy")
+        .value("EQUAL_PROGRESS", tle::ContextChunkingPolicy::kEQUAL_PROGRESS)
+        .value("FIRST_COME_FIRST_SERVED", tle::ContextChunkingPolicy::kFIRST_COME_FIRST_SERVED);
+
+    py::enum_<tle::CommunicationType>(m, "CommunicationType").value("MPI", tle::CommunicationType::kMPI);
+
+    py::enum_<tle::CommunicationMode>(m, "CommunicationMode")
+        .value("LEADER", tle::CommunicationMode::kLEADER)
+        .value("ORCHESTRATOR", tle::CommunicationMode::kORCHESTRATOR);
+
+    py::class_<tle::KvCacheStats>(m, "KvCacheStats")
+        .def(py::init<>())
+        .def_readwrite("max_num_blocks", &tle::KvCacheStats::maxNumBlocks)
+        .def_readwrite("free_num_blocks", &tle::KvCacheStats::freeNumBlocks)
+        .def_readwrite("used_num_blocks", &tle::KvCacheStats::usedNumBlocks)
+        .def_readwrite("tokens_per_block", &tle::KvCacheStats::tokensPerBlock)
+        .def_readwrite("alloc_total_blocks", &tle::KvCacheStats::allocTotalBlocks)
+        .def_readwrite("alloc_new_blocks", &tle::KvCacheStats::allocNewBlocks)
+        .def_readwrite("reused_blocks", &tle::KvCacheStats::reusedBlocks)
+        .def_readwrite("missed_blocks", &tle::KvCacheStats::missedBlocks)
+        .def_readwrite("cache_hit_rate", &tle::KvCacheStats::cacheHitRate);
+
+    py::class_<tle::StaticBatchingStats>(m, "StaticBatchingStats")
+        .def(py::init<>())
+        .def_readwrite("num_scheduled_requests", &tle::StaticBatchingStats::numScheduledRequests)
+        .def_readwrite("num_context_requests", &tle::StaticBatchingStats::numContextRequests)
+        .def_readwrite("num_ctx_tokens", &tle::StaticBatchingStats::numCtxTokens)
+        .def_readwrite("num_gen_tokens", &tle::StaticBatchingStats::numGenTokens)
+        .def_readwrite("empty_gen_slots", &tle::StaticBatchingStats::emptyGenSlots);
+
+    py::class_<tle::InflightBatchingStats>(m, "InflightBatchingStats")
+        .def(py::init<>())
+        .def_readwrite("num_scheduled_requests", &tle::InflightBatchingStats::numScheduledRequests)
+        .def_readwrite("num_context_requests", &tle::InflightBatchingStats::numContextRequests)
+        .def_readwrite("num_gen_requests", &tle::InflightBatchingStats::numGenRequests)
+        .def_readwrite("num_paused_requests", &tle::InflightBatchingStats::numPausedRequests)
+        .def_readwrite("num_ctx_tokens", &tle::InflightBatchingStats::numCtxTokens)
+        .def_readwrite("micro_batch_id", &tle::InflightBatchingStats::microBatchId)
+        .def_readwrite("avg_num_decoded_tokens_per_iter", &tle::InflightBatchingStats::avgNumDecodedTokensPerIter);
+
+    py::class_<tle::SpecDecodingStats>(m, "SpecDecodingStats")
+        .def(py::init<>())
+        .def_readwrite("num_draft_tokens", &tle::SpecDecodingStats::numDraftTokens)
+        .def_readwrite("num_accepted_tokens", &tle::SpecDecodingStats::numAcceptedTokens)
+        .def_readwrite("num_requests_with_draft_tokens", &tle::SpecDecodingStats::numRequestsWithDraftTokens)
+        .def_readwrite("acceptance_length", &tle::SpecDecodingStats::acceptanceLength)
+        .def_readwrite("iter_latency_ms", &tle::SpecDecodingStats::iterLatencyMS)
+        .def_readwrite("draft_overhead", &tle::SpecDecodingStats::draftOverhead);
+
+    py::class_<tle::IterationStats>(m, "IterationStats")
+        .def(py::init<>())
+        .def_readwrite("timestamp", &tle::IterationStats::timestamp)
+        .def_readwrite("iter", &tle::IterationStats::iter)
+        .def_readwrite("iter_latency_ms", &tle::IterationStats::iterLatencyMS)
+        .def_readwrite("new_active_requests_queue_latency_ms", &tle::IterationStats::newActiveRequestsQueueLatencyMS)
+        .def_readwrite("num_new_active_requests", &tle::IterationStats::numNewActiveRequests)
+        .def_readwrite("num_active_requests", &tle::IterationStats::numActiveRequests)
+        .def_readwrite("num_queued_requests", &tle::IterationStats::numQueuedRequests)
+        .def_readwrite("num_completed_requests", &tle::IterationStats::numCompletedRequests)
+        .def_readwrite("max_num_active_requests", &tle::IterationStats::maxNumActiveRequests)
+        .def_readwrite("gpu_mem_usage", &tle::IterationStats::gpuMemUsage)
+        .def_readwrite("cpu_mem_usage", &tle::IterationStats::cpuMemUsage)
+        .def_readwrite("pinned_mem_usage", &tle::IterationStats::pinnedMemUsage)
+        .def_readwrite("kv_cache_stats", &tle::IterationStats::kvCacheStats)
+        .def_readwrite("cross_kv_cache_stats", &tle::IterationStats::crossKvCacheStats)
+        .def_readwrite("static_batching_stats", &tle::IterationStats::staticBatchingStats)
+        .def_readwrite("inflight_batching_stats", &tle::IterationStats::inflightBatchingStats)
+        .def_readwrite("specdec_stats", &tle::IterationStats::specDecodingStats)
+        .def("to_json_str",
+            [](tle::IterationStats const& iterationStats)
+            { return tle::JsonSerialization::toJsonStr(iterationStats); });
+
+    py::class_<tle::DebugTensorsPerIteration>(m, "DebugTensorsPerIteration")
+        .def(py::init<>())
+        .def_readwrite("iter", &tle::DebugTensorsPerIteration::iter)
+        .def_readwrite("debug_tensors", &tle::DebugTensorsPerIteration::debugTensors);
+
+    py::enum_<tle::RequestStage>(m, "RequestStage")
+        .value("QUEUED", tle::RequestStage::kQUEUED)
+        .value("ENCODER_IN_PROGRESS", tle::RequestStage::kENCODER_IN_PROGRESS)
+        .value("CONTEXT_IN_PROGRESS", tle::RequestStage::kCONTEXT_IN_PROGRESS)
+        .value("GENERATION_IN_PROGRESS", tle::RequestStage::kGENERATION_IN_PROGRESS)
+        .value("GENERATION_COMPLETE", tle::RequestStage::kGENERATION_COMPLETE);
+
+    py::class_<tle::DisServingRequestStats>(m, "DisServingRequestStats")
+        .def(py::init<>())
+        .def_readwrite("kv_cache_transfer_ms", &tle::DisServingRequestStats::kvCacheTransferMS)
+        .def_readwrite("kv_cache_size", &tle::DisServingRequestStats::kvCacheSize);
+
+    py::class_<tle::RequestStats>(m, "RequestStats")
+        .def(py::init<>())
+        .def_readwrite("id", &tle::RequestStats::id)
+        .def_readwrite("stage", &tle::RequestStats::stage)
+        .def_readwrite("context_prefill_position", &tle::RequestStats::contextPrefillPosition)
+        .def_readwrite("num_generated_tokens", &tle::RequestStats::numGeneratedTokens)
+        .def_readwrite("avg_num_decoded_tokens_per_iter", &tle::RequestStats::avgNumDecodedTokensPerIter)
+        .def_readwrite("scheduled", &tle::RequestStats::scheduled)
+        .def_readwrite("paused", &tle::RequestStats::paused)
+        .def_readwrite("dis_serving_stats", &tle::RequestStats::disServingStats)
+        .def_readwrite("alloc_total_blocks_per_request", &tle::RequestStats::allocTotalBlocksPerRequest)
+        .def_readwrite("alloc_new_blocks_per_request", &tle::RequestStats::allocNewBlocksPerRequest)
+        .def_readwrite("reused_blocks_per_request", &tle::RequestStats::reusedBlocksPerRequest)
+        .def_readwrite("missed_blocks_per_request", &tle::RequestStats::missedBlocksPerRequest)
+        .def_readwrite("kv_cache_hit_rate_per_request", &tle::RequestStats::kvCacheHitRatePerRequest)
+        .def("to_json_str",
+            [](tle::RequestStats const& iterationStats) { return tle::JsonSerialization::toJsonStr(iterationStats); });
+
+    py::class_<tle::RequestStatsPerIteration>(m, "RequestStatsPerIteration")
+        .def(py::init<>())
+        .def_readwrite("iter", &tle::RequestStatsPerIteration::iter)
+        .def_readwrite("request_stats", &tle::RequestStatsPerIteration::requestStats)
+        .def("to_json_str",
+            [](tle::RequestStatsPerIteration const& iterationStats)
+            { return tle::JsonSerialization::toJsonStr(iterationStats); });
+
+    py::module_ executor_kv_cache = m.def_submodule("kv_cache", "Executor KV Cache Manager");
+
+    py::class_<tle::KVCacheCreatedData>(executor_kv_cache, "KVCacheCreatedData")
+        .def_readonly("num_blocks_per_cache_level", &tle::KVCacheCreatedData::numBlocksPerCacheLevel);
+
+    py::class_<tensorrt_llm::runtime::UniqueToken>(executor_kv_cache, "UniqueToken")
+        .def_readonly("token_id", &tensorrt_llm::runtime::UniqueToken::tokenId)
+        .def_readonly("token_extra_id", &tensorrt_llm::runtime::UniqueToken::tokenExtraId);
+
+    py::class_<tle::KVCacheStoredBlockData>(executor_kv_cache, "KVCacheStoredBlockData")
+        .def_readonly("block_hash", &tle::KVCacheStoredBlockData::blockHash)
+        .def_readonly("tokens", &tle::KVCacheStoredBlockData::tokens)
+        .def_readonly("lora_id", &tle::KVCacheStoredBlockData::loraId)
+        .def_readonly("cache_level", &tle::KVCacheStoredBlockData::cacheLevel)
+        .def_readonly("priority", &tle::KVCacheStoredBlockData::priority);
+
+    py::class_<tle::KVCacheStoredData>(executor_kv_cache, "KVCacheStoredData")
+        .def_readonly("parent_hash", &tle::KVCacheStoredData::parentHash)
+        .def_readonly("blocks", &tle::KVCacheStoredData::blocks);
+
+    py::class_<tle::KVCacheRemovedData>(executor_kv_cache, "KVCacheRemovedData")
+        .def_readonly("block_hashes", &tle::KVCacheRemovedData::blockHashes);
+
+    instantiateEventDiff<SizeType32>(executor_kv_cache, "Int");
+
+    py::class_<tle::KVCacheUpdatedData>(executor_kv_cache, "KVCacheUpdatedData")
+        .def_readonly("block_hash", &tle::KVCacheUpdatedData::blockHash)
+        .def_readonly("cache_level", &tle::KVCacheUpdatedData::cacheLevel)
+        .def_readonly("priority", &tle::KVCacheUpdatedData::priority);
+
+    py::class_<tle::KVCacheEvent>(executor_kv_cache, "KVCacheEvent")
+        .def_readonly("event_id", &tle::KVCacheEvent::eventId)
+        .def_readonly("data", &tle::KVCacheEvent::data)
+        .def_readonly("window_size", &tle::KVCacheEvent::windowSize);
+
+    py::class_<tle::KVCacheEventManager, std::shared_ptr<tle::KVCacheEventManager>>(
+        executor_kv_cache, "KVCacheEventManager")
+        .def("get_latest_events", &tle::KVCacheEventManager::getLatestEvents, py::arg("timeout") = std::nullopt);
+
+    tensorrt_llm::pybind::executor::initRequestBindings(m);
+    tensorrt_llm::pybind::executor::initConfigBindings(m);
+    tensorrt_llm::pybind::executor::Executor::initBindings(m);
+}
+
+} // namespace tensorrt_llm::pybind::executor

--- a/cpp/tensorrt_llm/nanobind/executor/bindings.h
+++ b/cpp/tensorrt_llm/nanobind/executor/bindings.h
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "tensorrt_llm/pybind/common/customCasters.h"
+#include <pybind11/pybind11.h>
+
+namespace tensorrt_llm::pybind::executor
+{
+
+// Register bindings for executor API.
+void initBindings(pybind11::module_& m);
+
+} // namespace tensorrt_llm::pybind::executor

--- a/cpp/tensorrt_llm/nanobind/executor/bindings.h
+++ b/cpp/tensorrt_llm/nanobind/executor/bindings.h
@@ -17,13 +17,12 @@
 
 #pragma once
 
-#include "tensorrt_llm/pybind/common/customCasters.h"
-#include <pybind11/pybind11.h>
+#include "tensorrt_llm/nanobind/common/customCasters.h"
 
-namespace tensorrt_llm::pybind::executor
+namespace tensorrt_llm::nanobind::executor
 {
 
 // Register bindings for executor API.
-void initBindings(pybind11::module_& m);
+void initBindings(nb::module_& m);
 
-} // namespace tensorrt_llm::pybind::executor
+} // namespace tensorrt_llm::nanobind::executor

--- a/cpp/tensorrt_llm/nanobind/executor/executor.cpp
+++ b/cpp/tensorrt_llm/nanobind/executor/executor.cpp
@@ -1,0 +1,191 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "executor.h"
+#include "tensorrt_llm/common/assert.h"
+#include "tensorrt_llm/common/logger.h"
+#include "tensorrt_llm/executor/tensor.h"
+
+#include <pybind11/chrono.h>
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+namespace py = pybind11;
+namespace tle = tensorrt_llm::executor;
+
+namespace
+{
+tle::Tensor numpyToTensor(py::array const& array)
+{
+    auto npDtype = array.dtype();
+    tle::DataType dtype;
+    if (npDtype.is(py::dtype("float16")))
+    {
+        dtype = tle::DataType::kFP16;
+    }
+    else if (npDtype.is(py::dtype("float32")))
+    {
+        dtype = tle::DataType::kFP32;
+    }
+    else if (npDtype.is(py::dtype("int8")))
+    {
+        dtype = tle::DataType::kINT8;
+    }
+    else if (npDtype.is(py::dtype("int32")))
+    {
+        dtype = tle::DataType::kINT32;
+    }
+    else if (npDtype.is(py::dtype("int64")))
+    {
+        dtype = tle::DataType::kINT64;
+    }
+    else if (npDtype.attr("kind").cast<std::string>() == "V" && npDtype.attr("itemsize").cast<int>() == 1
+        && npDtype.attr("metadata")["dtype"].cast<std::string>() == "float8")
+    {
+        dtype = tle::DataType::kFP8;
+    }
+    else if (npDtype.attr("kind").cast<std::string>() == "V" && npDtype.attr("itemsize").cast<int>() == 2
+        && npDtype.attr("metadata")["dtype"].cast<std::string>() == "bfloat16")
+    {
+        dtype = tle::DataType::kBF16;
+    }
+    else
+    {
+        TLLM_THROW("Unsupported numpy dtype: " + npDtype.attr("name").cast<std::string>());
+    }
+
+    tle::Shape shape(array.shape(), array.ndim());
+
+    return tle::Tensor::of(dtype, const_cast<void*>(array.data()), shape);
+}
+} // namespace
+
+namespace tensorrt_llm::pybind::executor
+{
+
+Executor::Executor(
+    std::filesystem::path const& modelPath, tle::ModelType modelType, tle::ExecutorConfig const& executorConfig)
+{
+    mExecutor = std::make_unique<tle::Executor>(modelPath, modelType, executorConfig);
+}
+
+Executor::Executor(std::filesystem::path const& encoderModelPath, std::filesystem::path const& decoderModelPath,
+    tle::ModelType modelType, tle::ExecutorConfig const& executorConfig)
+{
+    mExecutor = std::make_unique<tle::Executor>(encoderModelPath, decoderModelPath, modelType, executorConfig);
+}
+
+Executor::Executor(pybind11::buffer engineBuffer, std::string const& jsonConfigStr, tle::ModelType modelType,
+    tle::ExecutorConfig const& executorConfig, std::optional<pybind11::dict> managedWeights)
+{
+    py::buffer_info info = engineBuffer.request();
+    uint8_t const* data = reinterpret_cast<uint8_t const*>(info.ptr);
+    size_t size = info.size;
+    std::optional<std::map<std::string, tle::Tensor>> managedWeightsMap = std::nullopt;
+    if (managedWeights.has_value() && !managedWeights.value().empty())
+    {
+        managedWeightsMap = std::map<std::string, tle::Tensor>();
+        for (auto const& item : managedWeights.value())
+        {
+            std::string name = item.first.cast<std::string>();
+            py::array array = item.second.cast<py::array>();
+            managedWeightsMap->emplace(name, numpyToTensor(array));
+        }
+    }
+    mExecutor = std::make_unique<tle::Executor>(
+        tle::BufferView(data, size), jsonConfigStr, modelType, executorConfig, managedWeightsMap);
+}
+
+Executor::Executor(std::string const& encoderEngineBuffer, std::string const& encoderJsonConfigStr,
+    std::string const& decoderEngineBuffer, std::string const& decoderJsonConfigStr, tle::ModelType modelType,
+    tle::ExecutorConfig const& executorConfig)
+{
+    uint8_t const* encoderData = reinterpret_cast<uint8_t const*>(encoderEngineBuffer.data());
+    size_t encoderSize = encoderEngineBuffer.size();
+    uint8_t const* decoderData = reinterpret_cast<uint8_t const*>(decoderEngineBuffer.data());
+    size_t decoderSize = decoderEngineBuffer.size();
+    mExecutor = std::make_unique<tle::Executor>(tle::BufferView(encoderData, encoderSize), encoderJsonConfigStr,
+        tle::BufferView(decoderData, decoderSize), decoderJsonConfigStr, modelType, executorConfig);
+}
+
+py::object Executor::enter()
+{
+    TLLM_CHECK(static_cast<bool>(mExecutor));
+    return py::cast(this);
+}
+
+void Executor::exit(
+    [[maybe_unused]] py::handle type, [[maybe_unused]] py::handle value, [[maybe_unused]] py::handle traceback)
+{
+    shutdown();
+    mExecutor = nullptr;
+}
+
+void Executor::shutdown()
+{
+    // NOTE: we must release the GIL here. Executor has spawned a thread for the execution loop. That thread must be
+    // able to do forward progress for the shutdown process to succeed. It takes the GIL during its callbacks, so
+    // we release it now. Note that we shouldn't do anything related to python objects after that.
+    TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
+    py::gil_scoped_release release;
+    mExecutor->shutdown();
+    TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
+}
+
+void Executor::initBindings(py::module_& m)
+{
+    py::class_<Executor>(m, "Executor")
+        .def(py::init<std::filesystem::path const&, tle::ModelType, tle::ExecutorConfig const&>(),
+            py::arg("model_path"), py::arg("model_type"), py::arg("executor_config"))
+        .def(py::init<std::filesystem::path const&, std::filesystem::path const&, tle::ModelType,
+                 tle::ExecutorConfig const&>(),
+            py::arg("encoder_model_path"), py::arg("decoder_model_path"), py::arg("model_type"),
+            py::arg("executor_config"))
+        .def(py::init<py::buffer, std::string const&, tle::ModelType, tle::ExecutorConfig const&, py::dict>(),
+            py::arg("engine_buffer"), py::arg("json_config_str"), py::arg("model_type"), py::arg("executor_config"),
+            py::arg("managed_weights") = py::dict())
+        .def(py::init<std::string const&, std::string const&, std::string const&, std::string const&, tle::ModelType,
+                 tle::ExecutorConfig const&>(),
+            py::arg("encoder_engine_buffer"), py::arg("encoder_json_config_str"), py::arg("decoder_engine_buffer"),
+            py::arg("decoder_json_config_str"), py::arg("model_type"), py::arg("executor_config"))
+        .def("shutdown", &Executor::shutdown)
+        .def("__enter__", &Executor::enter)
+        .def("__exit__", &Executor::exit)
+        .def("enqueue_request", &Executor::enqueueRequest, py::arg("request"))
+        .def("enqueue_requests", &Executor::enqueueRequests, py::arg("requests"))
+        .def("await_responses",
+            py::overload_cast<std::optional<std::chrono::milliseconds> const&>(&Executor::awaitResponses),
+            py::arg("timeout") = py::none())
+        .def("await_responses",
+            py::overload_cast<tle::IdType const&, std::optional<std::chrono::milliseconds> const&>(
+                &Executor::awaitResponses),
+            py::arg("id"), py::arg("timeout") = py::none())
+        .def("await_responses",
+            py::overload_cast<std::vector<tle::IdType> const&, std::optional<std::chrono::milliseconds> const&>(
+                &Executor::awaitResponses),
+            py::arg("ids"), py::arg("timeout") = py::none())
+        .def("get_num_responses_ready", &Executor::getNumResponsesReady, py::arg("id") = py::none())
+        .def("cancel_request", &Executor::cancelRequest, py::arg("id") = py::none())
+        .def("get_latest_iteration_stats", &Executor::getLatestIterationStats)
+        .def("get_latest_request_stats", &Executor::getLatestRequestStats)
+        .def("get_latest_debug_tensors", &Executor::getLatestDebugTensors)
+        .def("can_enqueue_requests", &Executor::canEnqueueRequests)
+        .def("get_kv_cache_event_manager", &Executor::getKVCacheEventManager);
+}
+
+} // namespace tensorrt_llm::pybind::executor

--- a/cpp/tensorrt_llm/nanobind/executor/executor.cpp
+++ b/cpp/tensorrt_llm/nanobind/executor/executor.cpp
@@ -20,62 +20,111 @@
 #include "tensorrt_llm/common/logger.h"
 #include "tensorrt_llm/executor/tensor.h"
 
-#include <pybind11/chrono.h>
-#include <pybind11/numpy.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/chrono.h>
+#include <nanobind/stl/filesystem.h>
+#include <nanobind/stl/map.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
+#include <torch/extension.h>
 
-namespace py = pybind11;
+namespace nb = nanobind;
 namespace tle = tensorrt_llm::executor;
+
+namespace nanobind::detail
+{ // todo
+
+template <>
+struct dtype_traits<half>
+{
+    static constexpr dlpack::dtype value{
+        (uint8_t) dlpack::dtype_code::Float, // type code
+        16,                                  // size in bits
+        1                                    // lanes (simd), usually set to 1
+    };
+    static constexpr auto name = const_name("float16");
+};
+} // namespace nanobind::detail
 
 namespace
 {
-tle::Tensor numpyToTensor(py::array const& array)
+// todo: test this
+tle::Tensor numpyToTensor(nb::ndarray<nb::numpy> const& array)
 {
     auto npDtype = array.dtype();
+    char kind = '\0';
+    switch (npDtype.code)
+    {
+    case static_cast<uint8_t>(nb::dlpack::dtype_code::Int):
+        kind = 'i'; // signed integer
+        break;
+    case static_cast<uint8_t>(nb::dlpack::dtype_code::UInt):
+        kind = 'u'; // unsigned integer
+        break;
+    case static_cast<uint8_t>(nb::dlpack::dtype_code::Float):
+        kind = 'f'; // floating point
+        break;
+    case static_cast<uint8_t>(nb::dlpack::dtype_code::Bfloat):
+        kind = 'f'; // brain floating point (treat as float kind)
+        break;
+    case static_cast<uint8_t>(nb::dlpack::dtype_code::Complex):
+        kind = 'c'; // complex
+        break;
+    default:
+        kind = 'V'; // void/other
+        break;
+    }
     tle::DataType dtype;
-    if (npDtype.is(py::dtype("float16")))
+    if (npDtype == nb::dtype<half>())
     {
         dtype = tle::DataType::kFP16;
     }
-    else if (npDtype.is(py::dtype("float32")))
+    else if (npDtype == nb::dtype<float>())
     {
         dtype = tle::DataType::kFP32;
     }
-    else if (npDtype.is(py::dtype("int8")))
+    else if (npDtype == nb::dtype<int8_t>())
     {
         dtype = tle::DataType::kINT8;
     }
-    else if (npDtype.is(py::dtype("int32")))
+    else if (npDtype == nb::dtype<int32_t>())
     {
         dtype = tle::DataType::kINT32;
     }
-    else if (npDtype.is(py::dtype("int64")))
+    else if (npDtype == nb::dtype<int64_t>())
     {
         dtype = tle::DataType::kINT64;
     }
-    else if (npDtype.attr("kind").cast<std::string>() == "V" && npDtype.attr("itemsize").cast<int>() == 1
-        && npDtype.attr("metadata")["dtype"].cast<std::string>() == "float8")
+    // kind == Void
+    else if (kind == 'V' && array.itemsize() == 1)
     {
         dtype = tle::DataType::kFP8;
     }
-    else if (npDtype.attr("kind").cast<std::string>() == "V" && npDtype.attr("itemsize").cast<int>() == 2
-        && npDtype.attr("metadata")["dtype"].cast<std::string>() == "bfloat16")
+    else if (kind == 'V' && array.itemsize() == 2)
     {
         dtype = tle::DataType::kBF16;
     }
     else
     {
-        TLLM_THROW("Unsupported numpy dtype: " + npDtype.attr("name").cast<std::string>());
+        TLLM_THROW("Unsupported numpy dtype.");
     }
 
-    tle::Shape shape(array.shape(), array.ndim());
+    std::vector<int64_t> dims;
+    for (size_t i = 0; i < array.ndim(); ++i)
+    {
+        dims.push_back(static_cast<int64_t>(array.shape(i)));
+    }
+    tle::Shape shape(dims.data(), dims.size());
 
     return tle::Tensor::of(dtype, const_cast<void*>(array.data()), shape);
 }
+
 } // namespace
 
-namespace tensorrt_llm::pybind::executor
+namespace tensorrt_llm::nanobind::executor
 {
 
 Executor::Executor(
@@ -90,20 +139,19 @@ Executor::Executor(std::filesystem::path const& encoderModelPath, std::filesyste
     mExecutor = std::make_unique<tle::Executor>(encoderModelPath, decoderModelPath, modelType, executorConfig);
 }
 
-Executor::Executor(pybind11::buffer engineBuffer, std::string const& jsonConfigStr, tle::ModelType modelType,
-    tle::ExecutorConfig const& executorConfig, std::optional<pybind11::dict> managedWeights)
+Executor::Executor(nb::bytes const& engineBuffer, std::string const& jsonConfigStr, tle::ModelType modelType,
+    tle::ExecutorConfig const& executorConfig, std::optional<nb::dict> managedWeights)
 {
-    py::buffer_info info = engineBuffer.request();
-    uint8_t const* data = reinterpret_cast<uint8_t const*>(info.ptr);
-    size_t size = info.size;
+    uint8_t const* data = static_cast<uint8_t const*>(engineBuffer.data());
+    size_t size = engineBuffer.size();
     std::optional<std::map<std::string, tle::Tensor>> managedWeightsMap = std::nullopt;
     if (managedWeights.has_value() && !managedWeights.value().empty())
     {
         managedWeightsMap = std::map<std::string, tle::Tensor>();
         for (auto const& item : managedWeights.value())
         {
-            std::string name = item.first.cast<std::string>();
-            py::array array = item.second.cast<py::array>();
+            std::string name = nb::cast<std::string>(item.first);
+            nb::ndarray<nb::numpy> array = nb::cast<nb::ndarray<nb::numpy>>(item.second);
             managedWeightsMap->emplace(name, numpyToTensor(array));
         }
     }
@@ -123,14 +171,14 @@ Executor::Executor(std::string const& encoderEngineBuffer, std::string const& en
         tle::BufferView(decoderData, decoderSize), decoderJsonConfigStr, modelType, executorConfig);
 }
 
-py::object Executor::enter()
+nb::object Executor::enter()
 {
     TLLM_CHECK(static_cast<bool>(mExecutor));
-    return py::cast(this);
+    return nb::cast(this);
 }
 
 void Executor::exit(
-    [[maybe_unused]] py::handle type, [[maybe_unused]] py::handle value, [[maybe_unused]] py::handle traceback)
+    [[maybe_unused]] nb::handle type, [[maybe_unused]] nb::handle value, [[maybe_unused]] nb::handle traceback)
 {
     shutdown();
     mExecutor = nullptr;
@@ -142,45 +190,45 @@ void Executor::shutdown()
     // able to do forward progress for the shutdown process to succeed. It takes the GIL during its callbacks, so
     // we release it now. Note that we shouldn't do anything related to python objects after that.
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
-    py::gil_scoped_release release;
+    nb::gil_scoped_release release;
     mExecutor->shutdown();
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
 }
 
-void Executor::initBindings(py::module_& m)
+void Executor::initBindings(nb::module_& m)
 {
-    py::class_<Executor>(m, "Executor")
-        .def(py::init<std::filesystem::path const&, tle::ModelType, tle::ExecutorConfig const&>(),
-            py::arg("model_path"), py::arg("model_type"), py::arg("executor_config"))
-        .def(py::init<std::filesystem::path const&, std::filesystem::path const&, tle::ModelType,
+    nb::class_<Executor>(m, "Executor")
+        .def(nb::init<std::filesystem::path const&, tle::ModelType, tle::ExecutorConfig const&>(),
+            nb::arg("model_path"), nb::arg("model_type"), nb::arg("executor_config"))
+        .def(nb::init<std::filesystem::path const&, std::filesystem::path const&, tle::ModelType,
                  tle::ExecutorConfig const&>(),
-            py::arg("encoder_model_path"), py::arg("decoder_model_path"), py::arg("model_type"),
-            py::arg("executor_config"))
-        .def(py::init<py::buffer, std::string const&, tle::ModelType, tle::ExecutorConfig const&, py::dict>(),
-            py::arg("engine_buffer"), py::arg("json_config_str"), py::arg("model_type"), py::arg("executor_config"),
-            py::arg("managed_weights") = py::dict())
-        .def(py::init<std::string const&, std::string const&, std::string const&, std::string const&, tle::ModelType,
+            nb::arg("encoder_model_path"), nb::arg("decoder_model_path"), nb::arg("model_type"),
+            nb::arg("executor_config"))
+        .def(nb::init<nb::bytes, std::string const&, tle::ModelType, tle::ExecutorConfig const&, nb::dict>(),
+            nb::arg("engine_buffer"), nb::arg("json_config_str"), nb::arg("model_type"), nb::arg("executor_config"),
+            nb::arg("managed_weights") = nb::dict())
+        .def(nb::init<std::string const&, std::string const&, std::string const&, std::string const&, tle::ModelType,
                  tle::ExecutorConfig const&>(),
-            py::arg("encoder_engine_buffer"), py::arg("encoder_json_config_str"), py::arg("decoder_engine_buffer"),
-            py::arg("decoder_json_config_str"), py::arg("model_type"), py::arg("executor_config"))
+            nb::arg("encoder_engine_buffer"), nb::arg("encoder_json_config_str"), nb::arg("decoder_engine_buffer"),
+            nb::arg("decoder_json_config_str"), nb::arg("model_type"), nb::arg("executor_config"))
         .def("shutdown", &Executor::shutdown)
         .def("__enter__", &Executor::enter)
         .def("__exit__", &Executor::exit)
-        .def("enqueue_request", &Executor::enqueueRequest, py::arg("request"))
-        .def("enqueue_requests", &Executor::enqueueRequests, py::arg("requests"))
+        .def("enqueue_request", &Executor::enqueueRequest, nb::arg("request"))
+        .def("enqueue_requests", &Executor::enqueueRequests, nb::arg("requests"))
         .def("await_responses",
-            py::overload_cast<std::optional<std::chrono::milliseconds> const&>(&Executor::awaitResponses),
-            py::arg("timeout") = py::none())
+            nb::overload_cast<std::optional<std::chrono::milliseconds> const&>(&Executor::awaitResponses),
+            nb::arg("timeout") = nb::none())
         .def("await_responses",
-            py::overload_cast<tle::IdType const&, std::optional<std::chrono::milliseconds> const&>(
+            nb::overload_cast<tle::IdType const&, std::optional<std::chrono::milliseconds> const&>(
                 &Executor::awaitResponses),
-            py::arg("id"), py::arg("timeout") = py::none())
+            nb::arg("id"), nb::arg("timeout") = nb::none())
         .def("await_responses",
-            py::overload_cast<std::vector<tle::IdType> const&, std::optional<std::chrono::milliseconds> const&>(
+            nb::overload_cast<std::vector<tle::IdType> const&, std::optional<std::chrono::milliseconds> const&>(
                 &Executor::awaitResponses),
-            py::arg("ids"), py::arg("timeout") = py::none())
-        .def("get_num_responses_ready", &Executor::getNumResponsesReady, py::arg("id") = py::none())
-        .def("cancel_request", &Executor::cancelRequest, py::arg("id") = py::none())
+            nb::arg("ids"), nb::arg("timeout") = nb::none())
+        .def("get_num_responses_ready", &Executor::getNumResponsesReady, nb::arg("id") = nb::none())
+        .def("cancel_request", &Executor::cancelRequest, nb::arg("id") = nb::none())
         .def("get_latest_iteration_stats", &Executor::getLatestIterationStats)
         .def("get_latest_request_stats", &Executor::getLatestRequestStats)
         .def("get_latest_debug_tensors", &Executor::getLatestDebugTensors)
@@ -188,4 +236,4 @@ void Executor::initBindings(py::module_& m)
         .def("get_kv_cache_event_manager", &Executor::getKVCacheEventManager);
 }
 
-} // namespace tensorrt_llm::pybind::executor
+} // namespace tensorrt_llm::nanobind::executor

--- a/cpp/tensorrt_llm/nanobind/executor/executor.h
+++ b/cpp/tensorrt_llm/nanobind/executor/executor.h
@@ -1,0 +1,129 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "tensorrt_llm/executor/executor.h"
+#include "tensorrt_llm/executor/types.h"
+#include "tensorrt_llm/pybind/common/customCasters.h"
+#include <pybind11/pybind11.h>
+
+namespace tle = tensorrt_llm::executor;
+
+namespace tensorrt_llm::pybind::executor
+{
+
+class Executor
+{
+public:
+    Executor(
+        std::filesystem::path const& modelPath, tle::ModelType modelType, tle::ExecutorConfig const& executorConfig);
+
+    Executor(std::filesystem::path const& encoderModelPath, std::filesystem::path const& decoderModelPath,
+        tle::ModelType modelType, tle::ExecutorConfig const& executorConfig);
+
+    Executor(pybind11::buffer engineBuffer, std::string const& jsonConfigStr, tle::ModelType modelType,
+        tle::ExecutorConfig const& executorConfig, std::optional<pybind11::dict> managedWeights);
+
+    Executor(std::string const& encoderEngineBuffer, std::string const& encoderJsonConfigStr,
+        std::string const& decoderEngineBuffer, std::string const& decoderJsonConfigStr, tle::ModelType modelType,
+        tle::ExecutorConfig const& executorConfig);
+
+    pybind11::object enter();
+    void exit([[maybe_unused]] pybind11::handle type, [[maybe_unused]] pybind11::handle value,
+        [[maybe_unused]] pybind11::handle traceback);
+    void shutdown();
+
+    [[nodiscard]] tle::IdType enqueueRequest(tle::Request const& request)
+    {
+        return mExecutor->enqueueRequest(request);
+    }
+
+    [[nodiscard]] std::vector<tle::IdType> enqueueRequests(std::vector<tle::Request> const& requests)
+    {
+        return mExecutor->enqueueRequests(requests);
+    }
+
+    [[nodiscard]] std::vector<tle::Response> awaitResponses(
+        std::optional<std::chrono::milliseconds> const& timeout = std::nullopt)
+    {
+        // Await responses blocks until a response is received. Release GIL so that it can be ran in a background
+        // thread.
+        pybind11::gil_scoped_release release;
+        return mExecutor->awaitResponses(timeout);
+    }
+
+    [[nodiscard]] std::vector<tle::Response> awaitResponses(
+        tle::IdType const& requestId, std::optional<std::chrono::milliseconds> const& timeout = std::nullopt)
+    {
+        // Await responses blocks until a response is received. Release GIL so that it can be ran in a background
+        // thread.
+        pybind11::gil_scoped_release release;
+        return mExecutor->awaitResponses(requestId, timeout);
+    }
+
+    [[nodiscard]] std::vector<std::vector<tle::Response>> awaitResponses(std::vector<tle::IdType> const& requestIds,
+        std::optional<std::chrono::milliseconds> const& timeout = std::nullopt)
+    {
+        // Await responses blocks until a response is received. Release GIL so that it can be ran in a background
+        // thread.
+        pybind11::gil_scoped_release release;
+        return mExecutor->awaitResponses(requestIds, timeout);
+    }
+
+    [[nodiscard]] tle::SizeType32 getNumResponsesReady(std::optional<tle::IdType> const& requestId = std::nullopt) const
+    {
+        return mExecutor->getNumResponsesReady(requestId);
+    }
+
+    void cancelRequest(tle::IdType requestId)
+    {
+        mExecutor->cancelRequest(requestId);
+    }
+
+    std::deque<tle::IterationStats> getLatestIterationStats()
+    {
+        return mExecutor->getLatestIterationStats();
+    }
+
+    std::deque<tle::RequestStatsPerIteration> getLatestRequestStats()
+    {
+        return mExecutor->getLatestRequestStats();
+    }
+
+    std::deque<tle::DebugTensorsPerIteration> getLatestDebugTensors()
+    {
+        return mExecutor->getLatestDebugTensors();
+    }
+
+    [[nodiscard]] bool canEnqueueRequests() const
+    {
+        return mExecutor->canEnqueueRequests();
+    }
+
+    [[nodiscard]] std::optional<std::shared_ptr<tle::KVCacheEventManager>> getKVCacheEventManager() const
+    {
+        return mExecutor->getKVCacheEventManager();
+    }
+
+    static void initBindings(pybind11::module_& m);
+
+private:
+    std::unique_ptr<tle::Executor> mExecutor;
+};
+
+} // namespace tensorrt_llm::pybind::executor

--- a/cpp/tensorrt_llm/nanobind/executor/executor.h
+++ b/cpp/tensorrt_llm/nanobind/executor/executor.h
@@ -19,12 +19,14 @@
 
 #include "tensorrt_llm/executor/executor.h"
 #include "tensorrt_llm/executor/types.h"
-#include "tensorrt_llm/pybind/common/customCasters.h"
-#include <pybind11/pybind11.h>
+#include "tensorrt_llm/nanobind/common/customCasters.h"
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
 
+namespace nb = nanobind;
 namespace tle = tensorrt_llm::executor;
 
-namespace tensorrt_llm::pybind::executor
+namespace tensorrt_llm::nanobind::executor
 {
 
 class Executor
@@ -36,16 +38,16 @@ public:
     Executor(std::filesystem::path const& encoderModelPath, std::filesystem::path const& decoderModelPath,
         tle::ModelType modelType, tle::ExecutorConfig const& executorConfig);
 
-    Executor(pybind11::buffer engineBuffer, std::string const& jsonConfigStr, tle::ModelType modelType,
-        tle::ExecutorConfig const& executorConfig, std::optional<pybind11::dict> managedWeights);
+    Executor(nb::bytes const& engineBuffer, std::string const& jsonConfigStr, tle::ModelType modelType,
+        tle::ExecutorConfig const& executorConfig, std::optional<nb::dict> managedWeights);
 
     Executor(std::string const& encoderEngineBuffer, std::string const& encoderJsonConfigStr,
         std::string const& decoderEngineBuffer, std::string const& decoderJsonConfigStr, tle::ModelType modelType,
         tle::ExecutorConfig const& executorConfig);
 
-    pybind11::object enter();
-    void exit([[maybe_unused]] pybind11::handle type, [[maybe_unused]] pybind11::handle value,
-        [[maybe_unused]] pybind11::handle traceback);
+    nb::object enter();
+    void exit(
+        [[maybe_unused]] nb::handle type, [[maybe_unused]] nb::handle value, [[maybe_unused]] nb::handle traceback);
     void shutdown();
 
     [[nodiscard]] tle::IdType enqueueRequest(tle::Request const& request)
@@ -63,7 +65,7 @@ public:
     {
         // Await responses blocks until a response is received. Release GIL so that it can be ran in a background
         // thread.
-        pybind11::gil_scoped_release release;
+        nb::gil_scoped_release release;
         return mExecutor->awaitResponses(timeout);
     }
 
@@ -72,7 +74,7 @@ public:
     {
         // Await responses blocks until a response is received. Release GIL so that it can be ran in a background
         // thread.
-        pybind11::gil_scoped_release release;
+        nb::gil_scoped_release release;
         return mExecutor->awaitResponses(requestId, timeout);
     }
 
@@ -81,7 +83,7 @@ public:
     {
         // Await responses blocks until a response is received. Release GIL so that it can be ran in a background
         // thread.
-        pybind11::gil_scoped_release release;
+        nb::gil_scoped_release release;
         return mExecutor->awaitResponses(requestIds, timeout);
     }
 
@@ -120,10 +122,10 @@ public:
         return mExecutor->getKVCacheEventManager();
     }
 
-    static void initBindings(pybind11::module_& m);
+    static void initBindings(nb::module_& m);
 
 private:
     std::unique_ptr<tle::Executor> mExecutor;
 };
 
-} // namespace tensorrt_llm::pybind::executor
+} // namespace tensorrt_llm::nanobind::executor

--- a/cpp/tensorrt_llm/nanobind/executor/executorConfig.cpp
+++ b/cpp/tensorrt_llm/nanobind/executor/executorConfig.cpp
@@ -20,415 +20,432 @@
 #include "tensorrt_llm/executor/types.h"
 #include "tensorrt_llm/runtime/cudaStream.h"
 #include "tensorrt_llm/runtime/utils/mpiUtils.h"
-#include <optional>
-#include <pybind11/cast.h>
-#include <pybind11/functional.h>
-#include <pybind11/operators.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/function.h>
+#include <nanobind/stl/map.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/pair.h>
+#include <nanobind/stl/set.h>
+#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/unordered_map.h>
+#include <nanobind/stl/unordered_set.h>
+#include <nanobind/stl/vector.h>
 #include <torch/torch.h>
 #include <vector>
 
-namespace py = pybind11;
+namespace nb = nanobind;
 namespace tle = tensorrt_llm::executor;
 using SizeType32 = tle::SizeType32;
 using RuntimeDefaults = tensorrt_llm::runtime::RuntimeDefaults;
 
-namespace tensorrt_llm::pybind::executor
+namespace tensorrt_llm::nanobind::executor
 {
 
-void initConfigBindings(pybind11::module_& m)
+void initConfigBindings(nb::module_& m)
 {
-    py::enum_<tle::BatchingType>(m, "BatchingType")
+    nb::enum_<tle::BatchingType>(m, "BatchingType")
         .value("STATIC", tle::BatchingType::kSTATIC)
         .value("INFLIGHT", tle::BatchingType::kINFLIGHT);
 
     auto dynamicBatchConfigGetstate = [](tle::DynamicBatchConfig const& self)
     {
-        return py::make_tuple(self.getEnableBatchSizeTuning(), self.getEnableMaxNumTokensTuning(),
+        return nb::make_tuple(self.getEnableBatchSizeTuning(), self.getEnableMaxNumTokensTuning(),
             self.getDynamicBatchMovingAverageWindow(), self.getBatchSizeTable());
     };
-    auto dynamicBatchConfigSetstate = [](py::tuple const& state)
+    auto dynamicBatchConfigSetstate = [](tle::DynamicBatchConfig& self, nb::tuple const& state)
     {
         if (state.size() != 4)
         {
             throw std::runtime_error("Invalid state!");
         }
-        return tle::DynamicBatchConfig(state[0].cast<bool>(), state[1].cast<bool>(), state[2].cast<SizeType32>(),
-            state[3].cast<std::vector<std::pair<SizeType32, SizeType32>>>());
+        new (&self) tle::DynamicBatchConfig(nb::cast<bool>(state[0]), nb::cast<bool>(state[1]),
+            nb::cast<SizeType32>(state[2]), nb::cast<std::vector<std::pair<SizeType32, SizeType32>>>(state[3]));
     };
-    py::class_<tle::DynamicBatchConfig>(m, "DynamicBatchConfig")
-        .def(py::init<bool, bool, SizeType32>(), py::arg("enable_batch_size_tuning"),
-            py::arg("enable_max_num_tokens_tuning"), py::arg("dynamic_batch_moving_average_window"))
-        .def_property_readonly("enable_batch_size_tuning", &tle::DynamicBatchConfig::getEnableBatchSizeTuning)
-        .def_property_readonly("enable_max_num_tokens_tuning", &tle::DynamicBatchConfig::getEnableMaxNumTokensTuning)
-        .def_property_readonly(
+    nb::class_<tle::DynamicBatchConfig>(m, "DynamicBatchConfig")
+        .def(nb::init<bool, bool, SizeType32>(), nb::arg("enable_batch_size_tuning"),
+            nb::arg("enable_max_num_tokens_tuning"), nb::arg("dynamic_batch_moving_average_window"))
+        .def_prop_ro("enable_batch_size_tuning", &tle::DynamicBatchConfig::getEnableBatchSizeTuning)
+        .def_prop_ro("enable_max_num_tokens_tuning", &tle::DynamicBatchConfig::getEnableMaxNumTokensTuning)
+        .def_prop_ro(
             "dynamic_batch_moving_average_window", &tle::DynamicBatchConfig::getDynamicBatchMovingAverageWindow)
-        .def(py::pickle(dynamicBatchConfigGetstate, dynamicBatchConfigSetstate));
+        .def("__getstate__", dynamicBatchConfigGetstate)
+        .def("__setstate__", dynamicBatchConfigSetstate);
 
-    auto schedulerConfigSetstate = [](py::tuple const& state)
+    auto schedulerConfigSetstate = [](tle::SchedulerConfig& self, nb::tuple const& state)
     {
         if (state.size() != 3)
         {
             throw std::runtime_error("Invalid state!");
         }
-        return tle::SchedulerConfig(state[0].cast<tle::CapacitySchedulerPolicy>(),
-            state[1].cast<std::optional<tle::ContextChunkingPolicy>>(),
-            state[2].cast<std::optional<tle::DynamicBatchConfig>>());
+        new (&self) tle::SchedulerConfig(nb::cast<tle::CapacitySchedulerPolicy>(state[0]),
+            nb::cast<std::optional<tle::ContextChunkingPolicy>>(state[1]),
+            nb::cast<std::optional<tle::DynamicBatchConfig>>(state[2]));
     };
     auto schedulerConfigGetstate = [](tle::SchedulerConfig const& self)
     {
-        return py::make_tuple(
+        return nb::make_tuple(
             self.getCapacitySchedulerPolicy(), self.getContextChunkingPolicy(), self.getDynamicBatchConfig());
     };
-    py::class_<tle::SchedulerConfig>(m, "SchedulerConfig")
-        .def(py::init<tle::CapacitySchedulerPolicy, std::optional<tle::ContextChunkingPolicy>,
+    nb::class_<tle::SchedulerConfig>(m, "SchedulerConfig")
+        .def(nb::init<tle::CapacitySchedulerPolicy, std::optional<tle::ContextChunkingPolicy>,
                  std::optional<tle::DynamicBatchConfig>>(),
-            py::arg_v("capacity_scheduler_policy", tle::CapacitySchedulerPolicy::kGUARANTEED_NO_EVICT,
-                "CapacitySchedulerPolicy.GUARANTEED_NO_EVICT"),
-            py::arg("context_chunking_policy") = py::none(), py::arg("dynamic_batch_config") = py::none())
-        .def_property_readonly("capacity_scheduler_policy", &tle::SchedulerConfig::getCapacitySchedulerPolicy)
-        .def_property_readonly("context_chunking_policy", &tle::SchedulerConfig::getContextChunkingPolicy)
-        .def_property_readonly("dynamic_batch_config", &tle::SchedulerConfig::getDynamicBatchConfig)
-        .def(py::pickle(schedulerConfigGetstate, schedulerConfigSetstate));
+            nb::arg("capacity_scheduler_policy") = tle::CapacitySchedulerPolicy::kGUARANTEED_NO_EVICT,
+            nb::arg("context_chunking_policy") = nb::none(), nb::arg("dynamic_batch_config") = nb::none())
+        .def_prop_ro("capacity_scheduler_policy", &tle::SchedulerConfig::getCapacitySchedulerPolicy)
+        .def_prop_ro("context_chunking_policy", &tle::SchedulerConfig::getContextChunkingPolicy)
+        .def_prop_ro("dynamic_batch_config", &tle::SchedulerConfig::getDynamicBatchConfig)
+        .def("__getstate__", schedulerConfigGetstate)
+        .def("__setstate__", schedulerConfigSetstate);
 
-    py::class_<RuntimeDefaults>(m, "RuntimeDefaults")
-        .def(py::init<std::optional<std::vector<SizeType32>>, std::optional<SizeType32>>(),
-            py::arg("max_attention_window") = py::none(), py::arg("sink_token_length") = py::none())
-        .def_readonly("max_attention_window", &RuntimeDefaults::maxAttentionWindowVec)
-        .def_readonly("sink_token_length", &RuntimeDefaults::sinkTokenLength);
+    nb::class_<RuntimeDefaults>(m, "RuntimeDefaults")
+        .def(nb::init<std::optional<std::vector<SizeType32>>, std::optional<SizeType32>>(),
+            nb::arg("max_attention_window") = nb::none(), nb::arg("sink_token_length") = nb::none())
+        .def_ro("max_attention_window", &RuntimeDefaults::maxAttentionWindowVec)
+        .def_ro("sink_token_length", &RuntimeDefaults::sinkTokenLength);
 
     auto kvCacheConfigGetstate = [](tle::KvCacheConfig const& self)
     {
-        return py::make_tuple(self.getEnableBlockReuse(), self.getMaxTokens(), self.getMaxAttentionWindowVec(),
+        return nb::make_tuple(self.getEnableBlockReuse(), self.getMaxTokens(), self.getMaxAttentionWindowVec(),
             self.getSinkTokenLength(), self.getFreeGpuMemoryFraction(), self.getHostCacheSize(),
             self.getOnboardBlocks(), self.getCrossKvCacheFraction(), self.getSecondaryOffloadMinPriority(),
             self.getEventBufferMaxSize(), self.getEnablePartialReuse(), self.getCopyOnPartialReuse(), self.getUseUvm());
     };
-    auto kvCacheConfigSetstate = [](py::tuple const& state)
+    auto kvCacheConfigSetstate = [](tle::KvCacheConfig& self, nb::tuple const& state)
     {
         if (state.size() != 13)
         {
             throw std::runtime_error("Invalid state!");
         }
-        return tle::KvCacheConfig(state[0].cast<bool>(), state[1].cast<std::optional<SizeType32>>(),
-            state[2].cast<std::optional<std::vector<SizeType32>>>(), state[3].cast<std::optional<SizeType32>>(),
-            state[4].cast<std::optional<float>>(), state[5].cast<std::optional<size_t>>(), state[6].cast<bool>(),
-            state[7].cast<std::optional<float>>(), state[8].cast<std::optional<tle::RetentionPriority>>(),
-            state[9].cast<size_t>(), state[10].cast<bool>(), state[11].cast<bool>(), state[12].cast<bool>());
+        new (&self) tle::KvCacheConfig(nb::cast<bool>(state[0]), nb::cast<std::optional<SizeType32>>(state[1]),
+            nb::cast<std::optional<std::vector<SizeType32>>>(state[2]), nb::cast<std::optional<SizeType32>>(state[3]),
+            nb::cast<std::optional<float>>(state[4]), nb::cast<std::optional<size_t>>(state[5]),
+            nb::cast<bool>(state[6]), nb::cast<std::optional<float>>(state[7]),
+            nb::cast<std::optional<tle::RetentionPriority>>(state[8]), nb::cast<size_t>(state[9]),
+            nb::cast<bool>(state[10]), nb::cast<bool>(state[11]), nb::cast<bool>(state[12]));
     };
-    py::class_<tle::KvCacheConfig>(m, "KvCacheConfig")
-        .def(py::init<bool, std::optional<SizeType32> const&, std::optional<std::vector<SizeType32>> const&,
+    nb::class_<tle::KvCacheConfig>(m, "KvCacheConfig")
+        .def(nb::init<bool, std::optional<SizeType32> const&, std::optional<std::vector<SizeType32>> const&,
                  std::optional<SizeType32> const&, std::optional<float> const&, std::optional<size_t> const&, bool,
                  std::optional<float> const&, std::optional<tle::RetentionPriority>, size_t const&, bool, bool, bool,
                  std::optional<RuntimeDefaults> const&>(),
-            py::arg("enable_block_reuse") = true, py::arg("max_tokens") = py::none(),
-            py::arg("max_attention_window") = py::none(), py::arg("sink_token_length") = py::none(),
-            py::arg("free_gpu_memory_fraction") = py::none(), py::arg("host_cache_size") = py::none(),
-            py::arg("onboard_blocks") = true, py::arg("cross_kv_cache_fraction") = py::none(),
-            py::arg("secondary_offload_min_priority") = py::none(), py::arg("event_buffer_max_size") = 0, py::kw_only(),
-            py::arg("enable_partial_reuse") = true, py::arg("copy_on_partial_reuse") = true, py::arg("use_uvm") = false,
-            py::arg("runtime_defaults") = py::none())
-        .def_property(
+            nb::arg("enable_block_reuse") = true, nb::arg("max_tokens") = nb::none(),
+            nb::arg("max_attention_window") = nb::none(), nb::arg("sink_token_length") = nb::none(),
+            nb::arg("free_gpu_memory_fraction") = nb::none(), nb::arg("host_cache_size") = nb::none(),
+            nb::arg("onboard_blocks") = true, nb::arg("cross_kv_cache_fraction") = nb::none(),
+            nb::arg("secondary_offload_min_priority") = nb::none(), nb::arg("event_buffer_max_size") = 0, nb::kw_only(),
+            nb::arg("enable_partial_reuse") = true, nb::arg("copy_on_partial_reuse") = true, nb::arg("use_uvm") = false,
+            nb::arg("runtime_defaults") = nb::none())
+        .def_prop_rw(
             "enable_block_reuse", &tle::KvCacheConfig::getEnableBlockReuse, &tle::KvCacheConfig::setEnableBlockReuse)
-        .def_property("max_tokens", &tle::KvCacheConfig::getMaxTokens, &tle::KvCacheConfig::setMaxTokens)
-        .def_property("max_attention_window", &tle::KvCacheConfig::getMaxAttentionWindowVec,
+        .def_prop_rw("max_tokens", &tle::KvCacheConfig::getMaxTokens, &tle::KvCacheConfig::setMaxTokens)
+        .def_prop_rw("max_attention_window", &tle::KvCacheConfig::getMaxAttentionWindowVec,
             &tle::KvCacheConfig::setMaxAttentionWindowVec)
-        .def_property(
+        .def_prop_rw(
             "sink_token_length", &tle::KvCacheConfig::getSinkTokenLength, &tle::KvCacheConfig::setSinkTokenLength)
-        .def_property("free_gpu_memory_fraction", &tle::KvCacheConfig::getFreeGpuMemoryFraction,
+        .def_prop_rw("free_gpu_memory_fraction", &tle::KvCacheConfig::getFreeGpuMemoryFraction,
             &tle::KvCacheConfig::setFreeGpuMemoryFraction)
-        .def_property("host_cache_size", &tle::KvCacheConfig::getHostCacheSize, &tle::KvCacheConfig::setHostCacheSize)
-        .def_property("onboard_blocks", &tle::KvCacheConfig::getOnboardBlocks, &tle::KvCacheConfig::setOnboardBlocks)
-        .def_property("cross_kv_cache_fraction", &tle::KvCacheConfig::getCrossKvCacheFraction,
+        .def_prop_rw("host_cache_size", &tle::KvCacheConfig::getHostCacheSize, &tle::KvCacheConfig::setHostCacheSize)
+        .def_prop_rw("onboard_blocks", &tle::KvCacheConfig::getOnboardBlocks, &tle::KvCacheConfig::setOnboardBlocks)
+        .def_prop_rw("cross_kv_cache_fraction", &tle::KvCacheConfig::getCrossKvCacheFraction,
             &tle::KvCacheConfig::setCrossKvCacheFraction)
-        .def_property("secondary_offload_min_priority", &tle::KvCacheConfig::getSecondaryOffloadMinPriority,
+        .def_prop_rw("secondary_offload_min_priority", &tle::KvCacheConfig::getSecondaryOffloadMinPriority,
             &tle::KvCacheConfig::setSecondaryOffloadMinPriority)
-        .def_property("event_buffer_max_size", &tle::KvCacheConfig::getEventBufferMaxSize,
+        .def_prop_rw("event_buffer_max_size", &tle::KvCacheConfig::getEventBufferMaxSize,
             &tle::KvCacheConfig::setEventBufferMaxSize)
-        .def_property("enable_partial_reuse", &tle::KvCacheConfig::getEnablePartialReuse,
+        .def_prop_rw("enable_partial_reuse", &tle::KvCacheConfig::getEnablePartialReuse,
             &tle::KvCacheConfig::setEnablePartialReuse)
-        .def_property("copy_on_partial_reuse", &tle::KvCacheConfig::getCopyOnPartialReuse,
+        .def_prop_rw("copy_on_partial_reuse", &tle::KvCacheConfig::getCopyOnPartialReuse,
             &tle::KvCacheConfig::setCopyOnPartialReuse)
-        .def_property("use_uvm", &tle::KvCacheConfig::getUseUvm, &tle::KvCacheConfig::setUseUvm)
+        .def_prop_rw("use_uvm", &tle::KvCacheConfig::getUseUvm, &tle::KvCacheConfig::setUseUvm)
         .def("fill_empty_fields_from_runtime_defaults", &tle::KvCacheConfig::fillEmptyFieldsFromRuntimeDefaults)
-        .def(py::pickle(kvCacheConfigGetstate, kvCacheConfigSetstate));
+        .def("__getstate__", kvCacheConfigGetstate)
+        .def("__setstate__", kvCacheConfigSetstate);
 
-    py::class_<tle::OrchestratorConfig>(m, "OrchestratorConfig")
-        .def(py::init<bool, std::string, std::shared_ptr<mpi::MpiComm>, bool>(), py::arg("is_orchestrator") = true,
-            py::arg("worker_executable_path") = "", py::arg("orch_leader_comm") = nullptr,
-            py::arg("spawn_processes") = true)
-        .def_property(
+    nb::class_<tle::OrchestratorConfig>(m, "OrchestratorConfig")
+        .def(nb::init<bool, std::string, std::shared_ptr<mpi::MpiComm>, bool>(), nb::arg("is_orchestrator") = true,
+            nb::arg("worker_executable_path") = "", nb::arg("orch_leader_comm").none() = nullptr,
+            nb::arg("spawn_processes") = true)
+        .def_prop_rw(
             "is_orchestrator", &tle::OrchestratorConfig::getIsOrchestrator, &tle::OrchestratorConfig::setIsOrchestrator)
-        .def_property("worker_executable_path", &tle::OrchestratorConfig::getWorkerExecutablePath,
+        .def_prop_rw("worker_executable_path", &tle::OrchestratorConfig::getWorkerExecutablePath,
             &tle::OrchestratorConfig::setWorkerExecutablePath)
-        .def_property("orch_leader_comm", &tle::OrchestratorConfig::getOrchLeaderComm,
+        .def_prop_rw("orch_leader_comm", &tle::OrchestratorConfig::getOrchLeaderComm,
             &tle::OrchestratorConfig::setOrchLeaderComm)
-        .def_property("spawn_processes", &tle::OrchestratorConfig::getSpawnProcesses,
+        .def_prop_rw("spawn_processes", &tle::OrchestratorConfig::getSpawnProcesses,
             &tle::OrchestratorConfig::setSpawnProcesses);
 
     auto parallelConfigGetstate = [](tle::ParallelConfig const& self)
     {
-        return py::make_tuple(self.getCommunicationType(), self.getCommunicationMode(), self.getDeviceIds(),
+        return nb::make_tuple(self.getCommunicationType(), self.getCommunicationMode(), self.getDeviceIds(),
             self.getParticipantIds(), self.getOrchestratorConfig(), self.getNumNodes());
     };
-    auto parallelConfigSetstate = [](py::tuple const& state)
+    auto parallelConfigSetstate = [](tle::ParallelConfig& self, nb::tuple const& state)
     {
         if (state.size() != 6)
         {
             throw std::runtime_error("Invalid state!");
         }
-        return tle::ParallelConfig(state[0].cast<tle::CommunicationType>(), state[1].cast<tle::CommunicationMode>(),
-            state[2].cast<std::optional<std::vector<SizeType32>>>(),
-            state[3].cast<std::optional<std::vector<SizeType32>>>(),
-            state[4].cast<std::optional<tle::OrchestratorConfig>>(), state[5].cast<std::optional<SizeType32>>());
+        new (&self) tle::ParallelConfig(nb::cast<tle::CommunicationType>(state[0]),
+            nb::cast<tle::CommunicationMode>(state[1]), nb::cast<std::optional<std::vector<SizeType32>>>(state[2]),
+            nb::cast<std::optional<std::vector<SizeType32>>>(state[3]),
+            nb::cast<std::optional<tle::OrchestratorConfig>>(state[4]), nb::cast<std::optional<SizeType32>>(state[5]));
     };
-    py::class_<tle::ParallelConfig>(m, "ParallelConfig")
-        .def(py::init<tle::CommunicationType, tle::CommunicationMode, std::optional<std::vector<SizeType32>> const&,
+    nb::class_<tle::ParallelConfig>(m, "ParallelConfig")
+        .def(nb::init<tle::CommunicationType, tle::CommunicationMode, std::optional<std::vector<SizeType32>> const&,
                  std::optional<std::vector<SizeType32>> const&, std::optional<tle::OrchestratorConfig> const&,
                  std::optional<SizeType32> const&>(),
-            py::arg_v("communication_type", tle::CommunicationType::kMPI, "CommunicationType.MPI"),
-            py::arg_v("communication_mode", tle::CommunicationMode::kLEADER, "CommunicationMode.LEADER"),
-            py::arg("device_ids") = py::none(), py::arg("participant_ids") = py::none(),
-            py::arg("orchestrator_config") = py::none(), py::arg("num_nodes") = py::none())
-        .def_property("communication_type", &tle::ParallelConfig::getCommunicationType,
+            nb::arg("communication_type") = tle::CommunicationType::kMPI,
+            nb::arg("communication_mode") = tle::CommunicationMode::kLEADER, nb::arg("device_ids") = nb::none(),
+            nb::arg("participant_ids") = nb::none(), nb::arg("orchestrator_config") = nb::none(),
+            nb::arg("num_nodes") = nb::none())
+        .def_prop_rw("communication_type", &tle::ParallelConfig::getCommunicationType,
             &tle::ParallelConfig::setCommunicationType)
-        .def_property("communication_mode", &tle::ParallelConfig::getCommunicationMode,
+        .def_prop_rw("communication_mode", &tle::ParallelConfig::getCommunicationMode,
             &tle::ParallelConfig::setCommunicationMode)
-        .def_property("device_ids", &tle::ParallelConfig::getDeviceIds, &tle::ParallelConfig::setDeviceIds)
-        .def_property(
+        .def_prop_rw("device_ids", &tle::ParallelConfig::getDeviceIds, &tle::ParallelConfig::setDeviceIds)
+        .def_prop_rw(
             "participant_ids", &tle::ParallelConfig::getParticipantIds, &tle::ParallelConfig::setParticipantIds)
-        .def_property("orchestrator_config", &tle::ParallelConfig::getOrchestratorConfig,
+        .def_prop_rw("orchestrator_config", &tle::ParallelConfig::getOrchestratorConfig,
             &tle::ParallelConfig::setOrchestratorConfig)
-        .def_property("num_nodes", &tle::ParallelConfig::getNumNodes, &tle::ParallelConfig::setNumNodes)
-        .def(py::pickle(parallelConfigGetstate, parallelConfigSetstate));
+        .def_prop_rw("num_nodes", &tle::ParallelConfig::getNumNodes, &tle::ParallelConfig::setNumNodes)
+        .def("__getstate__", parallelConfigGetstate)
+        .def("__setstate__", parallelConfigSetstate);
 
-    auto peftCacheConfigSetstate = [](py::tuple const& state)
+    auto peftCacheConfigSetstate = [](tle::PeftCacheConfig& self, nb::tuple const& state)
     {
         if (state.size() != 11)
         {
             throw std::runtime_error("Invalid state!");
         }
-        return tle::PeftCacheConfig(state[0].cast<SizeType32>(), state[1].cast<SizeType32>(),
-            state[2].cast<SizeType32>(), state[3].cast<SizeType32>(), state[4].cast<SizeType32>(),
-            state[5].cast<SizeType32>(), state[6].cast<SizeType32>(), state[7].cast<SizeType32>(),
-            state[8].cast<SizeType32>(), state[9].cast<std::optional<float>>(),
-            state[10].cast<std::optional<size_t>>());
+        new (&self) tle::PeftCacheConfig(nb::cast<SizeType32>(state[0]), nb::cast<SizeType32>(state[1]),
+            nb::cast<SizeType32>(state[2]), nb::cast<SizeType32>(state[3]), nb::cast<SizeType32>(state[4]),
+            nb::cast<SizeType32>(state[5]), nb::cast<SizeType32>(state[6]), nb::cast<SizeType32>(state[7]),
+            nb::cast<SizeType32>(state[8]), nb::cast<std::optional<float>>(state[9]),
+            nb::cast<std::optional<size_t>>(state[10]));
     };
     auto peftCacheConfigGetstate = [](tle::PeftCacheConfig const& self)
     {
-        return py::make_tuple(self.getNumHostModuleLayer(), self.getNumDeviceModuleLayer(),
+        return nb::make_tuple(self.getNumHostModuleLayer(), self.getNumDeviceModuleLayer(),
             self.getOptimalAdapterSize(), self.getMaxAdapterSize(), self.getNumPutWorkers(), self.getNumEnsureWorkers(),
             self.getNumCopyStreams(), self.getMaxPagesPerBlockHost(), self.getMaxPagesPerBlockDevice(),
             self.getDeviceCachePercent(), self.getHostCacheSize());
     };
-    py::class_<tle::PeftCacheConfig>(m, "PeftCacheConfig")
-        .def(py::init<SizeType32, SizeType32, SizeType32, SizeType32, SizeType32, SizeType32, SizeType32, SizeType32,
+    nb::class_<tle::PeftCacheConfig>(m, "PeftCacheConfig")
+        .def(nb::init<SizeType32, SizeType32, SizeType32, SizeType32, SizeType32, SizeType32, SizeType32, SizeType32,
                  SizeType32, std::optional<float> const&, std::optional<size_t> const&,
                  std::optional<std::string> const&>(),
-            py::arg("num_host_module_layer") = 0, py::arg("num_device_module_layer") = 0,
-            py::arg("optimal_adapter_size") = 8, py::arg("max_adapter_size") = 64, py::arg("num_put_workers") = 1,
-            py::arg("num_ensure_workers") = 1, py::arg("num_copy_streams") = 1,
-            py::arg("max_pages_per_block_host") = 24, py::arg("max_pages_per_block_device") = 8,
-            py::arg("device_cache_percent") = py::none(), py::arg("host_cache_size") = py::none(),
-            py::arg("lora_prefetch_dir") = py::none())
-        .def_property_readonly("num_host_module_layer", &tle::PeftCacheConfig::getNumHostModuleLayer)
-        .def_property_readonly("num_device_module_layer", &tle::PeftCacheConfig::getNumDeviceModuleLayer)
-        .def_property_readonly("optimal_adapter_size", &tle::PeftCacheConfig::getOptimalAdapterSize)
-        .def_property_readonly("max_adapter_size", &tle::PeftCacheConfig::getMaxAdapterSize)
-        .def_property_readonly("num_put_workers", &tle::PeftCacheConfig::getNumPutWorkers)
-        .def_property_readonly("num_ensure_workers", &tle::PeftCacheConfig::getNumEnsureWorkers)
-        .def_property_readonly("num_copy_streams", &tle::PeftCacheConfig::getNumCopyStreams)
-        .def_property_readonly("max_pages_per_block_host", &tle::PeftCacheConfig::getMaxPagesPerBlockHost)
-        .def_property_readonly("max_pages_per_block_device", &tle::PeftCacheConfig::getMaxPagesPerBlockDevice)
-        .def_property_readonly("device_cache_percent", &tle::PeftCacheConfig::getDeviceCachePercent)
-        .def_property_readonly("host_cache_size", &tle::PeftCacheConfig::getHostCacheSize)
-        .def_property_readonly("lora_prefetch_dir", &tle::PeftCacheConfig::getLoraPrefetchDir)
-        .def(py::pickle(peftCacheConfigGetstate, peftCacheConfigSetstate));
+            nb::arg("num_host_module_layer") = 0, nb::arg("num_device_module_layer") = 0,
+            nb::arg("optimal_adapter_size") = 8, nb::arg("max_adapter_size") = 64, nb::arg("num_put_workers") = 1,
+            nb::arg("num_ensure_workers") = 1, nb::arg("num_copy_streams") = 1,
+            nb::arg("max_pages_per_block_host") = 24, nb::arg("max_pages_per_block_device") = 8,
+            nb::arg("device_cache_percent") = nb::none(), nb::arg("host_cache_size") = nb::none(),
+            nb::arg("lora_prefetch_dir") = nb::none())
+        .def_prop_ro("num_host_module_layer", &tle::PeftCacheConfig::getNumHostModuleLayer)
+        .def_prop_ro("num_device_module_layer", &tle::PeftCacheConfig::getNumDeviceModuleLayer)
+        .def_prop_ro("optimal_adapter_size", &tle::PeftCacheConfig::getOptimalAdapterSize)
+        .def_prop_ro("max_adapter_size", &tle::PeftCacheConfig::getMaxAdapterSize)
+        .def_prop_ro("num_put_workers", &tle::PeftCacheConfig::getNumPutWorkers)
+        .def_prop_ro("num_ensure_workers", &tle::PeftCacheConfig::getNumEnsureWorkers)
+        .def_prop_ro("num_copy_streams", &tle::PeftCacheConfig::getNumCopyStreams)
+        .def_prop_ro("max_pages_per_block_host", &tle::PeftCacheConfig::getMaxPagesPerBlockHost)
+        .def_prop_ro("max_pages_per_block_device", &tle::PeftCacheConfig::getMaxPagesPerBlockDevice)
+        .def_prop_ro("device_cache_percent", &tle::PeftCacheConfig::getDeviceCachePercent)
+        .def_prop_ro("host_cache_size", &tle::PeftCacheConfig::getHostCacheSize)
+        .def_prop_ro("lora_prefetch_dir", &tle::PeftCacheConfig::getLoraPrefetchDir)
+        .def("__getstate__", peftCacheConfigGetstate)
+        .def("__setstate__", peftCacheConfigSetstate);
 
     auto decodingConfigGetstate = [](tle::DecodingConfig const& self)
     {
-        return py::make_tuple(
+        return nb::make_tuple(
             self.getDecodingMode(), self.getLookaheadDecodingConfig(), self.getMedusaChoices(), self.getEagleConfig());
     };
-    auto decodingConfigSetstate = [](py::tuple const& state)
+    auto decodingConfigSetstate = [](tle::DecodingConfig& self, nb::tuple const& state)
     {
         if (state.size() != 4)
         {
             throw std::runtime_error("Invalid state!");
         }
-        return tle::DecodingConfig(state[0].cast<std::optional<tle::DecodingMode>>(), // DecodingMode
-            state[1].cast<std::optional<tle::LookaheadDecodingConfig>>(),             // LookaheadDecodingConfig
-            state[2].cast<std::optional<tle::MedusaChoices>>(),                       // MedusaChoices
-            state[3].cast<std::optional<tle::EagleConfig>>()                          // EagleConfig
+        new (&self) tle::DecodingConfig(nb::cast<std::optional<tle::DecodingMode>>(state[0]), // DecodingMode
+            nb::cast<std::optional<tle::LookaheadDecodingConfig>>(state[1]),                  // LookaheadDecodingConfig
+            nb::cast<std::optional<tle::MedusaChoices>>(state[2]),                            // MedusaChoices
+            nb::cast<std::optional<tle::EagleConfig>>(state[3])                               // EagleConfig
         );
     };
-    py::class_<tle::DecodingConfig>(m, "DecodingConfig")
-        .def(py::init<std::optional<tle::DecodingMode>, std::optional<tle::LookaheadDecodingConfig>,
+    nb::class_<tle::DecodingConfig>(m, "DecodingConfig")
+        .def(nb::init<std::optional<tle::DecodingMode>, std::optional<tle::LookaheadDecodingConfig>,
                  std::optional<tle::MedusaChoices>, std::optional<tle::EagleConfig>>(),
-            py::arg("decoding_mode") = py::none(), py::arg("lookahead_decoding_config") = py::none(),
-            py::arg("medusa_choices") = py::none(), py::arg("eagle_config") = py::none())
-        .def_property("decoding_mode", &tle::DecodingConfig::getDecodingMode, &tle::DecodingConfig::setDecodingMode)
-        .def_property("lookahead_decoding_config", &tle::DecodingConfig::getLookaheadDecodingConfig,
+            nb::arg("decoding_mode") = nb::none(), nb::arg("lookahead_decoding_config") = nb::none(),
+            nb::arg("medusa_choices") = nb::none(), nb::arg("eagle_config") = nb::none())
+        .def_prop_rw("decoding_mode", &tle::DecodingConfig::getDecodingMode, &tle::DecodingConfig::setDecodingMode)
+        .def_prop_rw("lookahead_decoding_config", &tle::DecodingConfig::getLookaheadDecodingConfig,
             &tle::DecodingConfig::setLookaheadDecodingConfig)
-        .def_property("medusa_choices", &tle::DecodingConfig::getMedusaChoices, &tle::DecodingConfig::setMedusaChoices)
-        .def_property("eagle_config", &tle::DecodingConfig::getEagleConfig, &tle::DecodingConfig::setEagleConfig)
-        .def(py::pickle(decodingConfigGetstate, decodingConfigSetstate));
+        .def_prop_rw("medusa_choices", &tle::DecodingConfig::getMedusaChoices, &tle::DecodingConfig::setMedusaChoices)
+        .def_prop_rw("eagle_config", &tle::DecodingConfig::getEagleConfig, &tle::DecodingConfig::setEagleConfig)
+        .def("__getstate__", decodingConfigGetstate)
+        .def("__setstate__", decodingConfigSetstate);
 
     auto debugConfigGetstate = [](tle::DebugConfig const& self)
     {
-        return py::make_tuple(self.getDebugInputTensors(), self.getDebugOutputTensors(), self.getDebugTensorNames(),
+        return nb::make_tuple(self.getDebugInputTensors(), self.getDebugOutputTensors(), self.getDebugTensorNames(),
             self.getDebugTensorsMaxIterations());
     };
-    auto debugConfigSetstate = [](py::tuple const& state)
+    auto debugConfigSetstate = [](tle::DebugConfig& self, nb::tuple const& state)
     {
         if (state.size() != 4)
         {
             throw std::runtime_error("Invalid state!");
         }
-        return tle::DebugConfig(state[0].cast<bool>(), state[1].cast<bool>(), state[2].cast<std::vector<std::string>>(),
-            state[3].cast<SizeType32>());
+        new (&self) tle::DebugConfig(nb::cast<bool>(state[0]), nb::cast<bool>(state[1]),
+            nb::cast<std::vector<std::string>>(state[2]), nb::cast<SizeType32>(state[3]));
     };
-    py::class_<tle::DebugConfig>(m, "DebugConfig")
-        .def(py::init<bool, bool, std::vector<std::string>, SizeType32>(), py::arg("debug_input_tensors") = false,
-            py::arg("debug_output_tensors") = false, py::arg("debug_tensor_names") = py::none(),
-            py::arg("debug_tensors_max_iterations") = false)
-        .def_property(
+    nb::class_<tle::DebugConfig>(m, "DebugConfig")
+        .def(nb::init<bool, bool, std::vector<std::string>, SizeType32>(), nb::arg("debug_input_tensors") = false,
+            nb::arg("debug_output_tensors") = false, nb::arg("debug_tensor_names") = nb::none(),
+            nb::arg("debug_tensors_max_iterations") = false)
+        .def_prop_rw(
             "debug_input_tensors", &tle::DebugConfig::getDebugInputTensors, &tle::DebugConfig::setDebugInputTensors)
-        .def_property(
+        .def_prop_rw(
             "debug_output_tensors", &tle::DebugConfig::getDebugOutputTensors, &tle::DebugConfig::setDebugOutputTensors)
-        .def_property(
+        .def_prop_rw(
             "debug_tensor_names", &tle::DebugConfig::getDebugTensorNames, &tle::DebugConfig::setDebugTensorNames)
-        .def_property("debug_tensors_max_iterations", &tle::DebugConfig::getDebugTensorsMaxIterations,
+        .def_prop_rw("debug_tensors_max_iterations", &tle::DebugConfig::getDebugTensorsMaxIterations,
             &tle::DebugConfig::setDebugTensorsMaxIterations)
-        .def(py::pickle(debugConfigGetstate, debugConfigSetstate));
+        .def("__getstate__", debugConfigGetstate)
+        .def("__setstate__", debugConfigSetstate);
 
     auto logitsPostProcessorConfigGetstate = [](tle::LogitsPostProcessorConfig const& self)
-    { return py::make_tuple(self.getProcessorMap(), self.getProcessorBatched(), self.getReplicate()); };
+    { return nb::make_tuple(self.getProcessorMap(), self.getProcessorBatched(), self.getReplicate()); };
 
-    auto logitsPostProcessorConfigSetstate = [](py::tuple const& state)
+    auto logitsPostProcessorConfigSetstate = [](tle::LogitsPostProcessorConfig& self, nb::tuple const& state)
     {
         if (state.size() != 3)
         {
             throw std::runtime_error("Invalid LogitsPostProcessorConfig state!");
         }
-        return tle::LogitsPostProcessorConfig(state[0].cast<std::optional<tle::LogitsPostProcessorMap>>(),
-            state[1].cast<std::optional<tle::LogitsPostProcessorBatched>>(), state[2].cast<bool>());
+        new (&self) tle::LogitsPostProcessorConfig(nb::cast<std::optional<tle::LogitsPostProcessorMap>>(state[0]),
+            nb::cast<std::optional<tle::LogitsPostProcessorBatched>>(state[1]), nb::cast<bool>(state[2]));
     };
 
-    py::class_<tle::LogitsPostProcessorConfig>(m, "LogitsPostProcessorConfig")
-        .def(py::init<std::optional<tle::LogitsPostProcessorMap>, std::optional<tle::LogitsPostProcessorBatched>,
+    nb::class_<tle::LogitsPostProcessorConfig>(m, "LogitsPostProcessorConfig")
+        .def(nb::init<std::optional<tle::LogitsPostProcessorMap>, std::optional<tle::LogitsPostProcessorBatched>,
                  bool>(),
-            py::arg("processor_map") = py::none(), py::arg("processor_batched") = py::none(),
-            py::arg("replicate") = true)
-        .def_property("processor_map", &tle::LogitsPostProcessorConfig::getProcessorMap,
+            nb::arg("processor_map") = nb::none(), nb::arg("processor_batched") = nb::none(),
+            nb::arg("replicate") = true)
+        .def_prop_rw("processor_map", &tle::LogitsPostProcessorConfig::getProcessorMap,
             &tle::LogitsPostProcessorConfig::setProcessorMap)
-        .def_property("processor_batched", &tle::LogitsPostProcessorConfig::getProcessorBatched,
+        .def_prop_rw("processor_batched", &tle::LogitsPostProcessorConfig::getProcessorBatched,
             &tle::LogitsPostProcessorConfig::setProcessorBatched)
-        .def_property(
+        .def_prop_rw(
             "replicate", &tle::LogitsPostProcessorConfig::getReplicate, &tle::LogitsPostProcessorConfig::setReplicate)
-        .def(py::pickle(logitsPostProcessorConfigGetstate, logitsPostProcessorConfigSetstate));
+        .def("__getstate__", logitsPostProcessorConfigGetstate)
+        .def("__setstate__", logitsPostProcessorConfigSetstate);
 
-    auto extendedRuntimePerfKnobConfigSetstate = [](py::tuple const& state)
+    auto extendedRuntimePerfKnobConfigSetstate = [](tle::ExtendedRuntimePerfKnobConfig& self, nb::tuple const& state)
     {
         if (state.size() != 4)
         {
             throw std::runtime_error("Invalid extendedRuntimePerfKnobConfig state!");
         }
-        return tle::ExtendedRuntimePerfKnobConfig(
-            state[0].cast<bool>(), state[1].cast<bool>(), state[2].cast<bool>(), state[2].cast<SizeType32>());
+        new (&self) tle::ExtendedRuntimePerfKnobConfig(nb::cast<bool>(state[0]), nb::cast<bool>(state[1]),
+            nb::cast<bool>(state[2]), nb::cast<SizeType32>(state[2]));
     };
     auto extendedRuntimePerfKnobConfigGetstate = [](tle::ExtendedRuntimePerfKnobConfig const& self)
     {
-        return py::make_tuple(self.getMultiBlockMode(), self.getEnableContextFMHAFP32Acc(), self.getCudaGraphMode(),
+        return nb::make_tuple(self.getMultiBlockMode(), self.getEnableContextFMHAFP32Acc(), self.getCudaGraphMode(),
             self.getCudaGraphCacheSize());
     };
-    py::class_<tle::ExtendedRuntimePerfKnobConfig>(m, "ExtendedRuntimePerfKnobConfig")
+    nb::class_<tle::ExtendedRuntimePerfKnobConfig>(m, "ExtendedRuntimePerfKnobConfig")
         .def(
-            py::init<bool, bool>(), py::arg("multi_block_mode") = true, py::arg("enable_context_fmha_fp32_acc") = false)
-        .def_property("multi_block_mode", &tle::ExtendedRuntimePerfKnobConfig::getMultiBlockMode,
+            nb::init<bool, bool>(), nb::arg("multi_block_mode") = true, nb::arg("enable_context_fmha_fp32_acc") = false)
+        .def_prop_rw("multi_block_mode", &tle::ExtendedRuntimePerfKnobConfig::getMultiBlockMode,
             &tle::ExtendedRuntimePerfKnobConfig::setMultiBlockMode)
-        .def_property("enable_context_fmha_fp32_acc", &tle::ExtendedRuntimePerfKnobConfig::getEnableContextFMHAFP32Acc,
+        .def_prop_rw("enable_context_fmha_fp32_acc", &tle::ExtendedRuntimePerfKnobConfig::getEnableContextFMHAFP32Acc,
             &tle::ExtendedRuntimePerfKnobConfig::setEnableContextFMHAFP32Acc)
-        .def_property("cuda_graph_mode", &tle::ExtendedRuntimePerfKnobConfig::getCudaGraphMode,
+        .def_prop_rw("cuda_graph_mode", &tle::ExtendedRuntimePerfKnobConfig::getCudaGraphMode,
             &tle::ExtendedRuntimePerfKnobConfig::setCudaGraphMode)
-        .def_property("cuda_graph_cache_size", &tle::ExtendedRuntimePerfKnobConfig::getCudaGraphCacheSize,
+        .def_prop_rw("cuda_graph_cache_size", &tle::ExtendedRuntimePerfKnobConfig::getCudaGraphCacheSize,
             &tle::ExtendedRuntimePerfKnobConfig::setCudaGraphCacheSize)
-        .def(py::pickle(extendedRuntimePerfKnobConfigGetstate, extendedRuntimePerfKnobConfigSetstate));
+        .def("__getstate__", extendedRuntimePerfKnobConfigGetstate)
+        .def("__setstate__", extendedRuntimePerfKnobConfigSetstate);
 
     auto SpeculativeDecodingConfigGetState
-        = [](tle::SpeculativeDecodingConfig const& self) { return py::make_tuple(self.fastLogits); };
-    auto SpeculativeDecodingConfigSetState = [](py::tuple const& state)
+        = [](tle::SpeculativeDecodingConfig const& self) { return nb::make_tuple(self.fastLogits); };
+    auto SpeculativeDecodingConfigSetState = [](tle::SpeculativeDecodingConfig& self, nb::tuple const& state)
     {
         if (state.size() != 1)
         {
             throw std::runtime_error("Invalid SpeculativeDecodingConfig state!");
         }
-        return tle::SpeculativeDecodingConfig(state[0].cast<bool>());
+        new (&self) tle::SpeculativeDecodingConfig(nb::cast<bool>(state[0]));
     };
-    py::class_<tle::SpeculativeDecodingConfig>(m, "SpeculativeDecodingConfig")
-        .def(py::init<bool>(), py::arg("fast_logits") = false)
-        .def_readwrite("fast_logits", &tle::SpeculativeDecodingConfig::fastLogits)
-        .def(py::pickle(SpeculativeDecodingConfigGetState, SpeculativeDecodingConfigSetState));
+    nb::class_<tle::SpeculativeDecodingConfig>(m, "SpeculativeDecodingConfig")
+        .def(nb::init<bool>(), nb::arg("fast_logits") = false)
+        .def_rw("fast_logits", &tle::SpeculativeDecodingConfig::fastLogits)
+        .def("__getstate__", SpeculativeDecodingConfigGetState)
+        .def("__setstate__", SpeculativeDecodingConfigSetState);
 
     // Guided decoding config
-    auto pyGuidedDecodingConfig = py::class_<tle::GuidedDecodingConfig>(m, "GuidedDecodingConfig");
+    auto pyGuidedDecodingConfig = nb::class_<tle::GuidedDecodingConfig>(m, "GuidedDecodingConfig");
 
-    py::enum_<tle::GuidedDecodingConfig::GuidedDecodingBackend>(pyGuidedDecodingConfig, "GuidedDecodingBackend")
+    nb::enum_<tle::GuidedDecodingConfig::GuidedDecodingBackend>(pyGuidedDecodingConfig, "GuidedDecodingBackend")
         .value("XGRAMMAR", tle::GuidedDecodingConfig::GuidedDecodingBackend::kXGRAMMAR)
         .value("LLGUIDANCE", tle::GuidedDecodingConfig::GuidedDecodingBackend::kLLGUIDANCE);
 
     auto guidedDecodingConfigGetstate = [](tle::GuidedDecodingConfig const& self) {
-        return py::make_tuple(
+        return nb::make_tuple(
             self.getBackend(), self.getEncodedVocab(), self.getTokenizerStr(), self.getStopTokenIds());
     };
-    auto guidedDecodingConfigSetstate = [](py::tuple state)
+    auto guidedDecodingConfigSetstate = [](tle::GuidedDecodingConfig& self, nb::tuple state)
     {
         if (state.size() != 4)
         {
             throw std::runtime_error("Invalid GuidedDecodingConfig state!");
         }
-        return tle::GuidedDecodingConfig(state[0].cast<tle::GuidedDecodingConfig::GuidedDecodingBackend>(),
-            state[1].cast<std::optional<std::vector<std::string>>>(), state[2].cast<std::optional<std::string>>(),
-            state[3].cast<std::optional<std::vector<tle::TokenIdType>>>());
+        new (&self) tle::GuidedDecodingConfig(nb::cast<tle::GuidedDecodingConfig::GuidedDecodingBackend>(state[0]),
+            nb::cast<std::optional<std::vector<std::string>>>(state[1]), nb::cast<std::optional<std::string>>(state[2]),
+            nb::cast<std::optional<std::vector<tle::TokenIdType>>>(state[3]));
     };
 
     pyGuidedDecodingConfig
-        .def(py::init<tle::GuidedDecodingConfig::GuidedDecodingBackend, std::optional<std::vector<std::string>>,
+        .def(nb::init<tle::GuidedDecodingConfig::GuidedDecodingBackend, std::optional<std::vector<std::string>>,
                  std::optional<std::string>, std::optional<std::vector<tle::TokenIdType>>>(),
-            py::arg("backend"), py::arg("encoded_vocab") = py::none(), py::arg("tokenizer_str") = py::none(),
-            py::arg("stop_token_ids") = py::none())
-        .def_property("backend", &tle::GuidedDecodingConfig::getBackend, &tle::GuidedDecodingConfig::setBackend)
-        .def_property(
+            nb::arg("backend"), nb::arg("encoded_vocab") = nb::none(), nb::arg("tokenizer_str") = nb::none(),
+            nb::arg("stop_token_ids") = nb::none())
+        .def_prop_rw("backend", &tle::GuidedDecodingConfig::getBackend, &tle::GuidedDecodingConfig::setBackend)
+        .def_prop_rw(
             "encoded_vocab", &tle::GuidedDecodingConfig::getEncodedVocab, &tle::GuidedDecodingConfig::setEncodedVocab)
-        .def_property(
+        .def_prop_rw(
             "tokenizer_str", &tle::GuidedDecodingConfig::getTokenizerStr, &tle::GuidedDecodingConfig::setTokenizerStr)
-        .def_property(
+        .def_prop_rw(
             "stop_token_ids", &tle::GuidedDecodingConfig::getStopTokenIds, &tle::GuidedDecodingConfig::setStopTokenIds)
-        .def(py::pickle(guidedDecodingConfigGetstate, guidedDecodingConfigSetstate));
+        .def("__getstate__", guidedDecodingConfigGetstate)
+        .def("__setstate__", guidedDecodingConfigSetstate);
 
     auto cacheTransceiverConfigGetstate
-        = [](tle::CacheTransceiverConfig const& self) { return py::make_tuple(self.getMaxNumTokens()); };
-    auto cacheTransceiverConfigSetstate = [](py::tuple const& state)
+        = [](tle::CacheTransceiverConfig const& self) { return nb::make_tuple(self.getMaxNumTokens()); };
+    auto cacheTransceiverConfigSetstate = [](tle::CacheTransceiverConfig& self, nb::tuple const& state)
     {
         if (state.size() != 1)
         {
             throw std::runtime_error("Invalid CacheTransceiverConfig state!");
         }
-        return tle::CacheTransceiverConfig(state[0].cast<std::optional<size_t>>());
+        new (&self) tle::CacheTransceiverConfig(nb::cast<std::optional<size_t>>(state[0]));
     };
 
-    py::class_<tle::CacheTransceiverConfig>(m, "CacheTransceiverConfig")
-        .def(py::init<std::optional<size_t>>(), py::arg("max_num_tokens") = py::none())
-        .def_property("max_num_tokens", &tle::CacheTransceiverConfig::getMaxNumTokens,
+    nb::class_<tle::CacheTransceiverConfig>(m, "CacheTransceiverConfig")
+        .def(nb::init<std::optional<size_t>>(), nb::arg("max_num_tokens") = nb::none())
+        .def_prop_rw("max_num_tokens", &tle::CacheTransceiverConfig::getMaxNumTokens,
             &tle::CacheTransceiverConfig::setMaxNumTokens)
-        .def(py::pickle(cacheTransceiverConfigGetstate, cacheTransceiverConfigSetstate));
+        .def("__getstate__", cacheTransceiverConfigGetstate)
+        .def("__setstate__", cacheTransceiverConfigSetstate);
 
-    auto executorConfigGetState = [](py::object const& self)
+    auto executorConfigGetState = [](nb::object const& self)
     {
-        auto& c = self.cast<tle::ExecutorConfig&>();
+        auto& c = nb::cast<tle::ExecutorConfig&>(self);
         // Return a tuple containing C++ data and the Python __dict__
-        auto cpp_states = py::make_tuple(c.getMaxBeamWidth(), c.getSchedulerConfig(), c.getKvCacheConfig(),
+        auto cpp_states = nb::make_tuple(c.getMaxBeamWidth(), c.getSchedulerConfig(), c.getKvCacheConfig(),
             c.getEnableChunkedContext(), c.getNormalizeLogProbs(), c.getIterStatsMaxIterations(),
             c.getRequestStatsMaxIterations(), c.getBatchingType(), c.getMaxBatchSize(), c.getMaxNumTokens(),
             c.getParallelConfig(), c.getPeftCacheConfig(), c.getLogitsPostProcessorConfig(), c.getDecodingConfig(),
@@ -437,61 +454,64 @@ void initConfigBindings(pybind11::module_& m)
             c.getMaxSeqIdleMicroseconds(), c.getSpecDecConfig(), c.getGuidedDecodingConfig(),
             c.getAdditionalModelOutputs(), c.getCacheTransceiverConfig(), c.getGatherGenerationLogits(),
             c.getPromptTableOffloading(), c.getEnableTrtOverlap());
-        auto pickle_tuple = py::make_tuple(cpp_states, py::getattr(self, "__dict__"));
+        auto pickle_tuple = nb::make_tuple(cpp_states, nb::getattr(self, "__dict__"));
         return pickle_tuple;
     };
-    auto executorConfigSetState = [](py::tuple const& state)
+
+    auto executorConfigSetState = [](nb::object self, nb::tuple const& state)
     {
         if (state.size() != 2)
         {
             throw std::runtime_error("Invalid state!");
         }
 
-        // Restore C++ data
-        auto cpp_states = state[0].cast<py::tuple>();
+        auto cpp_states = nb::cast<nb::tuple>(state[0]);
         if (cpp_states.size() != 28)
         {
             throw std::runtime_error("Invalid cpp_states!");
         }
 
-        auto ec = tle::ExecutorConfig(                                            //
-            cpp_states[0].cast<SizeType32>(),                                     // MaxBeamWidth
-            cpp_states[1].cast<tle::SchedulerConfig>(),                           // SchedulerConfig
-            cpp_states[2].cast<tle::KvCacheConfig>(),                             // KvCacheConfig
-            cpp_states[3].cast<bool>(),                                           // EnableChunkedContext
-            cpp_states[4].cast<bool>(),                                           // NormalizeLogProbs
-            cpp_states[5].cast<SizeType32>(),                                     // IterStatsMaxIterations
-            cpp_states[6].cast<SizeType32>(),                                     // RequestStatsMaxIterations
-            cpp_states[7].cast<tle::BatchingType>(),                              // BatchingType
-            cpp_states[8].cast<std::optional<SizeType32>>(),                      // MaxBatchSize
-            cpp_states[9].cast<std::optional<SizeType32>>(),                      // MaxNumTokens
-            cpp_states[10].cast<std::optional<tle::ParallelConfig>>(),            // ParallelConfig
-            cpp_states[11].cast<std::optional<tle::PeftCacheConfig>>(),           // PeftCacheConfig
-            cpp_states[12].cast<std::optional<tle::LogitsPostProcessorConfig>>(), // LogitsPostProcessorConfig
-            cpp_states[13].cast<std::optional<tle::DecodingConfig>>(),            // DecodingConfig
-            cpp_states[14].cast<bool>(),                                          // UseGpuDirectStorage
-            cpp_states[15].cast<float>(),                                         // GpuWeightsPercent
-            cpp_states[16].cast<std::optional<SizeType32>>(),                     // MaxQueueSize
-            cpp_states[17].cast<tle::ExtendedRuntimePerfKnobConfig>(),            // ExtendedRuntimePerfKnobConfig
-            cpp_states[18].cast<std::optional<tle::DebugConfig>>(),               // DebugConfig
-            cpp_states[19].cast<SizeType32>(),                                    // RecvPollPeriodMs
-            cpp_states[20].cast<uint64_t>(),                                      // MaxSeqIdleMicroseconds
-            cpp_states[21].cast<std::optional<tle::SpeculativeDecodingConfig>>(), // SpecDecConfig
-            cpp_states[22].cast<std::optional<tle::GuidedDecodingConfig>>(),      // GuidedDecodingConfig
-            cpp_states[23].cast<std::optional<std::vector<tle::AdditionalModelOutput>>>(), // AdditionalModelOutputs
-            cpp_states[24].cast<std::optional<tle::CacheTransceiverConfig>>(),             // CacheTransceiverConfig
-            cpp_states[25].cast<bool>(),                                                   // GatherGenerationLogits
-            cpp_states[26].cast<bool>(),                                                   // PromptTableOffloading
-            cpp_states[27].cast<bool>()                                                    // EnableTrtOverlap
+        // Restore C++ data
+        tle::ExecutorConfig* cpp_self = nb::inst_ptr<tle::ExecutorConfig>(self);
+        new (cpp_self) tle::ExecutorConfig(                                          //
+            nb::cast<SizeType32>(cpp_states[0]),                                     // MaxBeamWidth
+            nb::cast<tle::SchedulerConfig>(cpp_states[1]),                           // SchedulerConfig
+            nb::cast<tle::KvCacheConfig>(cpp_states[2]),                             // KvCacheConfig
+            nb::cast<bool>(cpp_states[3]),                                           // EnableChunkedContext
+            nb::cast<bool>(cpp_states[4]),                                           // NormalizeLogProbs
+            nb::cast<SizeType32>(cpp_states[5]),                                     // IterStatsMaxIterations
+            nb::cast<SizeType32>(cpp_states[6]),                                     // RequestStatsMaxIterations
+            nb::cast<tle::BatchingType>(cpp_states[7]),                              // BatchingType
+            nb::cast<std::optional<SizeType32>>(cpp_states[8]),                      // MaxBatchSize
+            nb::cast<std::optional<SizeType32>>(cpp_states[9]),                      // MaxNumTokens
+            nb::cast<std::optional<tle::ParallelConfig>>(cpp_states[10]),            // ParallelConfig
+            nb::cast<std::optional<tle::PeftCacheConfig>>(cpp_states[11]),           // PeftCacheConfig
+            nb::cast<std::optional<tle::LogitsPostProcessorConfig>>(cpp_states[12]), // LogitsPostProcessorConfig
+            nb::cast<std::optional<tle::DecodingConfig>>(cpp_states[13]),            // DecodingConfig
+            nb::cast<bool>(cpp_states[14]),                                          // UseGpuDirectStorage
+            nb::cast<float>(cpp_states[15]),                                         // GpuWeightsPercent
+            nb::cast<std::optional<SizeType32>>(cpp_states[16]),                     // MaxQueueSize
+            nb::cast<tle::ExtendedRuntimePerfKnobConfig>(cpp_states[17]),            // ExtendedRuntimePerfKnobConfig
+            nb::cast<std::optional<tle::DebugConfig>>(cpp_states[18]),               // DebugConfig
+            nb::cast<SizeType32>(cpp_states[19]),                                    // RecvPollPeriodMs
+            nb::cast<uint64_t>(cpp_states[20]),                                      // MaxSeqIdleMicroseconds
+            nb::cast<std::optional<tle::SpeculativeDecodingConfig>>(cpp_states[21]), // SpecDecConfig
+            nb::cast<std::optional<tle::GuidedDecodingConfig>>(cpp_states[22]),      // GuidedDecodingConfig
+            nb::cast<std::optional<std::vector<tle::AdditionalModelOutput>>>(cpp_states[23]), // AdditionalModelOutputs
+            nb::cast<std::optional<tle::CacheTransceiverConfig>>(cpp_states[24]),             // CacheTransceiverConfig
+            nb::cast<bool>(cpp_states[25]),                                                   // GatherGenerationLogits
+            nb::cast<bool>(cpp_states[26]),                                                   // PromptTableOffloading
+            nb::cast<bool>(cpp_states[27])                                                    // EnableTrtOverlap
         );
 
-        auto py_state = state[1].cast<py::dict>();
+        auto py_state = nb::cast<nb::dict>(state[1]);
+        self.attr("__dict__").attr("update")(py_state);
 
-        return std::make_pair(ec, py_state);
+        nb::inst_mark_ready(self);
     };
 
-    py::class_<tle::ExecutorConfig>(m, "ExecutorConfig", pybind11::dynamic_attr())
-        .def(py::init<                                                   //
+    nb::class_<tle::ExecutorConfig>(m, "ExecutorConfig", nb::dynamic_attr())
+        .def(nb::init<                                                   //
                  SizeType32,                                             // MaxBeamWidth
                  tle::SchedulerConfig const&,                            // SchedulerConfig
                  tle::KvCacheConfig const&,                              // KvCacheConfig
@@ -521,76 +541,74 @@ void initConfigBindings(pybind11::module_& m)
                  bool,                                                   // PromptTableOffloading
                  bool                                                    // EnableTrtOverlap
                  >(),
-            py::arg("max_beam_width") = 1, py::arg_v("scheduler_config", tle::SchedulerConfig(), "SchedulerConfig()"),
-            py::arg_v("kv_cache_config", tle::KvCacheConfig(), "KvCacheConfig()"),
-            py::arg("enable_chunked_context") = false, py::arg("normalize_log_probs") = true,
-            py::arg("iter_stats_max_iterations") = tle::ExecutorConfig::kDefaultIterStatsMaxIterations,
-            py::arg("request_stats_max_iterations") = tle::ExecutorConfig::kDefaultRequestStatsMaxIterations,
-            py::arg_v("batching_type", tle::BatchingType::kINFLIGHT, "BatchingType.INFLIGHT"),
-            py::arg("max_batch_size") = py::none(), py::arg("max_num_tokens") = py::none(),
-            py::arg("parallel_config") = py::none(),
-            py::arg_v("peft_cache_config", tle::PeftCacheConfig(), "PeftCacheConfig()"),
-            py::arg("logits_post_processor_config") = py::none(), py::arg("decoding_config") = py::none(),
-            py::arg("use_gpu_direct_storage") = false, py::arg("gpu_weights_percent") = 1.0,
-            py::arg("max_queue_size") = py::none(),
-            py::arg_v("extended_runtime_perf_knob_config", tle::ExtendedRuntimePerfKnobConfig(),
-                "ExtendedRuntimePerfKnobConfig()"),
-            py::arg("debug_config") = py::none(), py::arg("recv_poll_period_ms") = 0,
-            py::arg("max_seq_idle_microseconds") = tle::ExecutorConfig::kDefaultMaxSeqIdleMicroseconds,
-            py::arg("spec_dec_config") = py::none(), py::arg("guided_decoding_config") = py::none(),
-            py::arg("additional_model_outputs") = py::none(), py::arg("cache_transceiver_config") = py::none(),
-            py::arg("gather_generation_logits") = false, py::arg("mm_embedding_offloading") = false,
-            py::arg("enable_trt_overlap") = false)
-        .def_property("max_beam_width", &tle::ExecutorConfig::getMaxBeamWidth, &tle::ExecutorConfig::setMaxBeamWidth)
-        .def_property("max_batch_size", &tle::ExecutorConfig::getMaxBatchSize, &tle::ExecutorConfig::setMaxBatchSize)
-        .def_property("max_num_tokens", &tle::ExecutorConfig::getMaxNumTokens, &tle::ExecutorConfig::setMaxNumTokens)
-        .def_property(
+            nb::arg("max_beam_width") = 1, nb::arg("scheduler_config") = tle::SchedulerConfig(),
+            nb::arg("kv_cache_config") = tle::KvCacheConfig(), nb::arg("enable_chunked_context") = false,
+            nb::arg("normalize_log_probs") = true,
+            nb::arg("iter_stats_max_iterations") = tle::ExecutorConfig::kDefaultIterStatsMaxIterations,
+            nb::arg("request_stats_max_iterations") = tle::ExecutorConfig::kDefaultRequestStatsMaxIterations,
+            nb::arg("batching_type") = tle::BatchingType::kINFLIGHT, nb::arg("max_batch_size") = nb::none(),
+            nb::arg("max_num_tokens") = nb::none(), nb::arg("parallel_config") = nb::none(),
+            nb::arg("peft_cache_config") = tle::PeftCacheConfig(), nb::arg("logits_post_processor_config") = nb::none(),
+            nb::arg("decoding_config") = nb::none(), nb::arg("use_gpu_direct_storage") = false,
+            nb::arg("gpu_weights_percent") = 1.0, nb::arg("max_queue_size") = nb::none(),
+            nb::arg("extended_runtime_perf_knob_config") = tle::ExtendedRuntimePerfKnobConfig(),
+            nb::arg("debug_config") = nb::none(), nb::arg("recv_poll_period_ms") = 0,
+            nb::arg("max_seq_idle_microseconds") = tle::ExecutorConfig::kDefaultMaxSeqIdleMicroseconds,
+            nb::arg("spec_dec_config") = nb::none(), nb::arg("guided_decoding_config") = nb::none(),
+            nb::arg("additional_model_outputs") = nb::none(), nb::arg("cache_transceiver_config") = nb::none(),
+            nb::arg("gather_generation_logits") = false, nb::arg("mm_embedding_offloading") = false,
+            nb::arg("enable_trt_overlap") = false)
+        .def_prop_rw("max_beam_width", &tle::ExecutorConfig::getMaxBeamWidth, &tle::ExecutorConfig::setMaxBeamWidth)
+        .def_prop_rw("max_batch_size", &tle::ExecutorConfig::getMaxBatchSize, &tle::ExecutorConfig::setMaxBatchSize)
+        .def_prop_rw("max_num_tokens", &tle::ExecutorConfig::getMaxNumTokens, &tle::ExecutorConfig::setMaxNumTokens)
+        .def_prop_rw(
             "scheduler_config", &tle::ExecutorConfig::getSchedulerConfigRef, &tle::ExecutorConfig::setSchedulerConfig)
-        .def_property(
+        .def_prop_rw(
             "kv_cache_config", &tle::ExecutorConfig::getKvCacheConfigRef, &tle::ExecutorConfig::setKvCacheConfig)
-        .def_property("enable_chunked_context", &tle::ExecutorConfig::getEnableChunkedContext,
+        .def_prop_rw("enable_chunked_context", &tle::ExecutorConfig::getEnableChunkedContext,
             &tle::ExecutorConfig::setEnableChunkedContext)
-        .def_property("normalize_log_probs", &tle::ExecutorConfig::getNormalizeLogProbs,
+        .def_prop_rw("normalize_log_probs", &tle::ExecutorConfig::getNormalizeLogProbs,
             &tle::ExecutorConfig::setNormalizeLogProbs)
-        .def_property("iter_stats_max_iterations", &tle::ExecutorConfig::getIterStatsMaxIterations,
+        .def_prop_rw("iter_stats_max_iterations", &tle::ExecutorConfig::getIterStatsMaxIterations,
             &tle::ExecutorConfig::setIterStatsMaxIterations)
-        .def_property("request_stats_max_iterations", &tle::ExecutorConfig::getRequestStatsMaxIterations,
+        .def_prop_rw("request_stats_max_iterations", &tle::ExecutorConfig::getRequestStatsMaxIterations,
             &tle::ExecutorConfig::setRequestStatsMaxIterations)
-        .def_property("batching_type", &tle::ExecutorConfig::getBatchingType, &tle::ExecutorConfig::setBatchingType)
-        .def_property(
+        .def_prop_rw("batching_type", &tle::ExecutorConfig::getBatchingType, &tle::ExecutorConfig::setBatchingType)
+        .def_prop_rw(
             "parallel_config", &tle::ExecutorConfig::getParallelConfig, &tle::ExecutorConfig::setParallelConfig)
-        .def_property(
+        .def_prop_rw(
             "peft_cache_config", &tle::ExecutorConfig::getPeftCacheConfig, &tle::ExecutorConfig::setPeftCacheConfig)
-        .def_property("logits_post_processor_config", &tle::ExecutorConfig::getLogitsPostProcessorConfig,
+        .def_prop_rw("logits_post_processor_config", &tle::ExecutorConfig::getLogitsPostProcessorConfig,
             &tle::ExecutorConfig::setLogitsPostProcessorConfig)
-        .def_property(
+        .def_prop_rw(
             "decoding_config", &tle::ExecutorConfig::getDecodingConfig, &tle::ExecutorConfig::setDecodingConfig)
-        .def_property("use_gpu_direct_storage", &tle::ExecutorConfig::getUseGpuDirectStorage,
+        .def_prop_rw("use_gpu_direct_storage", &tle::ExecutorConfig::getUseGpuDirectStorage,
             &tle::ExecutorConfig::setUseGpuDirectStorage)
-        .def_property("gpu_weights_percent", &tle::ExecutorConfig::getGpuWeightsPercent,
+        .def_prop_rw("gpu_weights_percent", &tle::ExecutorConfig::getGpuWeightsPercent,
             &tle::ExecutorConfig::setGpuWeightsPercent)
-        .def_property("max_queue_size", &tle::ExecutorConfig::getMaxQueueSize, &tle::ExecutorConfig::setMaxQueueSize)
-        .def_property("extended_runtime_perf_knob_config", &tle::ExecutorConfig::getExtendedRuntimePerfKnobConfig,
+        .def_prop_rw("max_queue_size", &tle::ExecutorConfig::getMaxQueueSize, &tle::ExecutorConfig::setMaxQueueSize)
+        .def_prop_rw("extended_runtime_perf_knob_config", &tle::ExecutorConfig::getExtendedRuntimePerfKnobConfig,
             &tle::ExecutorConfig::setExtendedRuntimePerfKnobConfig)
-        .def_property("debug_config", &tle::ExecutorConfig::getDebugConfig, &tle::ExecutorConfig::setDebugConfig)
-        .def_property(
+        .def_prop_rw("debug_config", &tle::ExecutorConfig::getDebugConfig, &tle::ExecutorConfig::setDebugConfig)
+        .def_prop_rw(
             "recv_poll_period_ms", &tle::ExecutorConfig::getRecvPollPeriodMs, &tle::ExecutorConfig::setRecvPollPeriodMs)
-        .def_property("max_seq_idle_microseconds", &tle::ExecutorConfig::getMaxSeqIdleMicroseconds,
+        .def_prop_rw("max_seq_idle_microseconds", &tle::ExecutorConfig::getMaxSeqIdleMicroseconds,
             &tle::ExecutorConfig::setMaxSeqIdleMicroseconds)
-        .def_property("spec_dec_config", &tle::ExecutorConfig::getSpecDecConfig, &tle::ExecutorConfig::setSpecDecConfig)
-        .def_property("guided_decoding_config", &tle::ExecutorConfig::getGuidedDecodingConfig,
+        .def_prop_rw("spec_dec_config", &tle::ExecutorConfig::getSpecDecConfig, &tle::ExecutorConfig::setSpecDecConfig)
+        .def_prop_rw("guided_decoding_config", &tle::ExecutorConfig::getGuidedDecodingConfig,
             &tle::ExecutorConfig::setGuidedDecodingConfig)
-        .def_property("additional_model_outputs", &tle::ExecutorConfig::getAdditionalModelOutputs,
+        .def_prop_rw("additional_model_outputs", &tle::ExecutorConfig::getAdditionalModelOutputs,
             &tle::ExecutorConfig::setAdditionalModelOutputs)
-        .def_property("cache_transceiver_config", &tle::ExecutorConfig::getCacheTransceiverConfig,
+        .def_prop_rw("cache_transceiver_config", &tle::ExecutorConfig::getCacheTransceiverConfig,
             &tle::ExecutorConfig::setCacheTransceiverConfig)
-        .def_property("gather_generation_logits", &tle::ExecutorConfig::getGatherGenerationLogits,
+        .def_prop_rw("gather_generation_logits", &tle::ExecutorConfig::getGatherGenerationLogits,
             &tle::ExecutorConfig::setGatherGenerationLogits)
-        .def_property("mm_embedding_offloading", &tle::ExecutorConfig::getPromptTableOffloading,
+        .def_prop_rw("mm_embedding_offloading", &tle::ExecutorConfig::getPromptTableOffloading,
             &tle::ExecutorConfig::setPromptTableOffloading)
-        .def_property(
+        .def_prop_rw(
             "enable_trt_overlap", &tle::ExecutorConfig::getEnableTrtOverlap, &tle::ExecutorConfig::setEnableTrtOverlap)
-        .def(py::pickle(executorConfigGetState, executorConfigSetState));
+        .def("__getstate__", executorConfigGetState)
+        .def("__setstate__", executorConfigSetState);
 }
 
-} // namespace tensorrt_llm::pybind::executor
+} // namespace tensorrt_llm::nanobind::executor

--- a/cpp/tensorrt_llm/nanobind/executor/executorConfig.cpp
+++ b/cpp/tensorrt_llm/nanobind/executor/executorConfig.cpp
@@ -1,0 +1,596 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "executorConfig.h"
+#include "tensorrt_llm/executor/executor.h"
+#include "tensorrt_llm/executor/types.h"
+#include "tensorrt_llm/runtime/cudaStream.h"
+#include "tensorrt_llm/runtime/utils/mpiUtils.h"
+#include <optional>
+#include <pybind11/cast.h>
+#include <pybind11/functional.h>
+#include <pybind11/operators.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <torch/torch.h>
+#include <vector>
+
+namespace py = pybind11;
+namespace tle = tensorrt_llm::executor;
+using SizeType32 = tle::SizeType32;
+using RuntimeDefaults = tensorrt_llm::runtime::RuntimeDefaults;
+
+namespace tensorrt_llm::pybind::executor
+{
+
+void initConfigBindings(pybind11::module_& m)
+{
+    py::enum_<tle::BatchingType>(m, "BatchingType")
+        .value("STATIC", tle::BatchingType::kSTATIC)
+        .value("INFLIGHT", tle::BatchingType::kINFLIGHT);
+
+    auto dynamicBatchConfigGetstate = [](tle::DynamicBatchConfig const& self)
+    {
+        return py::make_tuple(self.getEnableBatchSizeTuning(), self.getEnableMaxNumTokensTuning(),
+            self.getDynamicBatchMovingAverageWindow(), self.getBatchSizeTable());
+    };
+    auto dynamicBatchConfigSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 4)
+        {
+            throw std::runtime_error("Invalid state!");
+        }
+        return tle::DynamicBatchConfig(state[0].cast<bool>(), state[1].cast<bool>(), state[2].cast<SizeType32>(),
+            state[3].cast<std::vector<std::pair<SizeType32, SizeType32>>>());
+    };
+    py::class_<tle::DynamicBatchConfig>(m, "DynamicBatchConfig")
+        .def(py::init<bool, bool, SizeType32>(), py::arg("enable_batch_size_tuning"),
+            py::arg("enable_max_num_tokens_tuning"), py::arg("dynamic_batch_moving_average_window"))
+        .def_property_readonly("enable_batch_size_tuning", &tle::DynamicBatchConfig::getEnableBatchSizeTuning)
+        .def_property_readonly("enable_max_num_tokens_tuning", &tle::DynamicBatchConfig::getEnableMaxNumTokensTuning)
+        .def_property_readonly(
+            "dynamic_batch_moving_average_window", &tle::DynamicBatchConfig::getDynamicBatchMovingAverageWindow)
+        .def(py::pickle(dynamicBatchConfigGetstate, dynamicBatchConfigSetstate));
+
+    auto schedulerConfigSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 3)
+        {
+            throw std::runtime_error("Invalid state!");
+        }
+        return tle::SchedulerConfig(state[0].cast<tle::CapacitySchedulerPolicy>(),
+            state[1].cast<std::optional<tle::ContextChunkingPolicy>>(),
+            state[2].cast<std::optional<tle::DynamicBatchConfig>>());
+    };
+    auto schedulerConfigGetstate = [](tle::SchedulerConfig const& self)
+    {
+        return py::make_tuple(
+            self.getCapacitySchedulerPolicy(), self.getContextChunkingPolicy(), self.getDynamicBatchConfig());
+    };
+    py::class_<tle::SchedulerConfig>(m, "SchedulerConfig")
+        .def(py::init<tle::CapacitySchedulerPolicy, std::optional<tle::ContextChunkingPolicy>,
+                 std::optional<tle::DynamicBatchConfig>>(),
+            py::arg_v("capacity_scheduler_policy", tle::CapacitySchedulerPolicy::kGUARANTEED_NO_EVICT,
+                "CapacitySchedulerPolicy.GUARANTEED_NO_EVICT"),
+            py::arg("context_chunking_policy") = py::none(), py::arg("dynamic_batch_config") = py::none())
+        .def_property_readonly("capacity_scheduler_policy", &tle::SchedulerConfig::getCapacitySchedulerPolicy)
+        .def_property_readonly("context_chunking_policy", &tle::SchedulerConfig::getContextChunkingPolicy)
+        .def_property_readonly("dynamic_batch_config", &tle::SchedulerConfig::getDynamicBatchConfig)
+        .def(py::pickle(schedulerConfigGetstate, schedulerConfigSetstate));
+
+    py::class_<RuntimeDefaults>(m, "RuntimeDefaults")
+        .def(py::init<std::optional<std::vector<SizeType32>>, std::optional<SizeType32>>(),
+            py::arg("max_attention_window") = py::none(), py::arg("sink_token_length") = py::none())
+        .def_readonly("max_attention_window", &RuntimeDefaults::maxAttentionWindowVec)
+        .def_readonly("sink_token_length", &RuntimeDefaults::sinkTokenLength);
+
+    auto kvCacheConfigGetstate = [](tle::KvCacheConfig const& self)
+    {
+        return py::make_tuple(self.getEnableBlockReuse(), self.getMaxTokens(), self.getMaxAttentionWindowVec(),
+            self.getSinkTokenLength(), self.getFreeGpuMemoryFraction(), self.getHostCacheSize(),
+            self.getOnboardBlocks(), self.getCrossKvCacheFraction(), self.getSecondaryOffloadMinPriority(),
+            self.getEventBufferMaxSize(), self.getEnablePartialReuse(), self.getCopyOnPartialReuse(), self.getUseUvm());
+    };
+    auto kvCacheConfigSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 13)
+        {
+            throw std::runtime_error("Invalid state!");
+        }
+        return tle::KvCacheConfig(state[0].cast<bool>(), state[1].cast<std::optional<SizeType32>>(),
+            state[2].cast<std::optional<std::vector<SizeType32>>>(), state[3].cast<std::optional<SizeType32>>(),
+            state[4].cast<std::optional<float>>(), state[5].cast<std::optional<size_t>>(), state[6].cast<bool>(),
+            state[7].cast<std::optional<float>>(), state[8].cast<std::optional<tle::RetentionPriority>>(),
+            state[9].cast<size_t>(), state[10].cast<bool>(), state[11].cast<bool>(), state[12].cast<bool>());
+    };
+    py::class_<tle::KvCacheConfig>(m, "KvCacheConfig")
+        .def(py::init<bool, std::optional<SizeType32> const&, std::optional<std::vector<SizeType32>> const&,
+                 std::optional<SizeType32> const&, std::optional<float> const&, std::optional<size_t> const&, bool,
+                 std::optional<float> const&, std::optional<tle::RetentionPriority>, size_t const&, bool, bool, bool,
+                 std::optional<RuntimeDefaults> const&>(),
+            py::arg("enable_block_reuse") = true, py::arg("max_tokens") = py::none(),
+            py::arg("max_attention_window") = py::none(), py::arg("sink_token_length") = py::none(),
+            py::arg("free_gpu_memory_fraction") = py::none(), py::arg("host_cache_size") = py::none(),
+            py::arg("onboard_blocks") = true, py::arg("cross_kv_cache_fraction") = py::none(),
+            py::arg("secondary_offload_min_priority") = py::none(), py::arg("event_buffer_max_size") = 0, py::kw_only(),
+            py::arg("enable_partial_reuse") = true, py::arg("copy_on_partial_reuse") = true, py::arg("use_uvm") = false,
+            py::arg("runtime_defaults") = py::none())
+        .def_property(
+            "enable_block_reuse", &tle::KvCacheConfig::getEnableBlockReuse, &tle::KvCacheConfig::setEnableBlockReuse)
+        .def_property("max_tokens", &tle::KvCacheConfig::getMaxTokens, &tle::KvCacheConfig::setMaxTokens)
+        .def_property("max_attention_window", &tle::KvCacheConfig::getMaxAttentionWindowVec,
+            &tle::KvCacheConfig::setMaxAttentionWindowVec)
+        .def_property(
+            "sink_token_length", &tle::KvCacheConfig::getSinkTokenLength, &tle::KvCacheConfig::setSinkTokenLength)
+        .def_property("free_gpu_memory_fraction", &tle::KvCacheConfig::getFreeGpuMemoryFraction,
+            &tle::KvCacheConfig::setFreeGpuMemoryFraction)
+        .def_property("host_cache_size", &tle::KvCacheConfig::getHostCacheSize, &tle::KvCacheConfig::setHostCacheSize)
+        .def_property("onboard_blocks", &tle::KvCacheConfig::getOnboardBlocks, &tle::KvCacheConfig::setOnboardBlocks)
+        .def_property("cross_kv_cache_fraction", &tle::KvCacheConfig::getCrossKvCacheFraction,
+            &tle::KvCacheConfig::setCrossKvCacheFraction)
+        .def_property("secondary_offload_min_priority", &tle::KvCacheConfig::getSecondaryOffloadMinPriority,
+            &tle::KvCacheConfig::setSecondaryOffloadMinPriority)
+        .def_property("event_buffer_max_size", &tle::KvCacheConfig::getEventBufferMaxSize,
+            &tle::KvCacheConfig::setEventBufferMaxSize)
+        .def_property("enable_partial_reuse", &tle::KvCacheConfig::getEnablePartialReuse,
+            &tle::KvCacheConfig::setEnablePartialReuse)
+        .def_property("copy_on_partial_reuse", &tle::KvCacheConfig::getCopyOnPartialReuse,
+            &tle::KvCacheConfig::setCopyOnPartialReuse)
+        .def_property("use_uvm", &tle::KvCacheConfig::getUseUvm, &tle::KvCacheConfig::setUseUvm)
+        .def("fill_empty_fields_from_runtime_defaults", &tle::KvCacheConfig::fillEmptyFieldsFromRuntimeDefaults)
+        .def(py::pickle(kvCacheConfigGetstate, kvCacheConfigSetstate));
+
+    py::class_<tle::OrchestratorConfig>(m, "OrchestratorConfig")
+        .def(py::init<bool, std::string, std::shared_ptr<mpi::MpiComm>, bool>(), py::arg("is_orchestrator") = true,
+            py::arg("worker_executable_path") = "", py::arg("orch_leader_comm") = nullptr,
+            py::arg("spawn_processes") = true)
+        .def_property(
+            "is_orchestrator", &tle::OrchestratorConfig::getIsOrchestrator, &tle::OrchestratorConfig::setIsOrchestrator)
+        .def_property("worker_executable_path", &tle::OrchestratorConfig::getWorkerExecutablePath,
+            &tle::OrchestratorConfig::setWorkerExecutablePath)
+        .def_property("orch_leader_comm", &tle::OrchestratorConfig::getOrchLeaderComm,
+            &tle::OrchestratorConfig::setOrchLeaderComm)
+        .def_property("spawn_processes", &tle::OrchestratorConfig::getSpawnProcesses,
+            &tle::OrchestratorConfig::setSpawnProcesses);
+
+    auto parallelConfigGetstate = [](tle::ParallelConfig const& self)
+    {
+        return py::make_tuple(self.getCommunicationType(), self.getCommunicationMode(), self.getDeviceIds(),
+            self.getParticipantIds(), self.getOrchestratorConfig(), self.getNumNodes());
+    };
+    auto parallelConfigSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 6)
+        {
+            throw std::runtime_error("Invalid state!");
+        }
+        return tle::ParallelConfig(state[0].cast<tle::CommunicationType>(), state[1].cast<tle::CommunicationMode>(),
+            state[2].cast<std::optional<std::vector<SizeType32>>>(),
+            state[3].cast<std::optional<std::vector<SizeType32>>>(),
+            state[4].cast<std::optional<tle::OrchestratorConfig>>(), state[5].cast<std::optional<SizeType32>>());
+    };
+    py::class_<tle::ParallelConfig>(m, "ParallelConfig")
+        .def(py::init<tle::CommunicationType, tle::CommunicationMode, std::optional<std::vector<SizeType32>> const&,
+                 std::optional<std::vector<SizeType32>> const&, std::optional<tle::OrchestratorConfig> const&,
+                 std::optional<SizeType32> const&>(),
+            py::arg_v("communication_type", tle::CommunicationType::kMPI, "CommunicationType.MPI"),
+            py::arg_v("communication_mode", tle::CommunicationMode::kLEADER, "CommunicationMode.LEADER"),
+            py::arg("device_ids") = py::none(), py::arg("participant_ids") = py::none(),
+            py::arg("orchestrator_config") = py::none(), py::arg("num_nodes") = py::none())
+        .def_property("communication_type", &tle::ParallelConfig::getCommunicationType,
+            &tle::ParallelConfig::setCommunicationType)
+        .def_property("communication_mode", &tle::ParallelConfig::getCommunicationMode,
+            &tle::ParallelConfig::setCommunicationMode)
+        .def_property("device_ids", &tle::ParallelConfig::getDeviceIds, &tle::ParallelConfig::setDeviceIds)
+        .def_property(
+            "participant_ids", &tle::ParallelConfig::getParticipantIds, &tle::ParallelConfig::setParticipantIds)
+        .def_property("orchestrator_config", &tle::ParallelConfig::getOrchestratorConfig,
+            &tle::ParallelConfig::setOrchestratorConfig)
+        .def_property("num_nodes", &tle::ParallelConfig::getNumNodes, &tle::ParallelConfig::setNumNodes)
+        .def(py::pickle(parallelConfigGetstate, parallelConfigSetstate));
+
+    auto peftCacheConfigSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 11)
+        {
+            throw std::runtime_error("Invalid state!");
+        }
+        return tle::PeftCacheConfig(state[0].cast<SizeType32>(), state[1].cast<SizeType32>(),
+            state[2].cast<SizeType32>(), state[3].cast<SizeType32>(), state[4].cast<SizeType32>(),
+            state[5].cast<SizeType32>(), state[6].cast<SizeType32>(), state[7].cast<SizeType32>(),
+            state[8].cast<SizeType32>(), state[9].cast<std::optional<float>>(),
+            state[10].cast<std::optional<size_t>>());
+    };
+    auto peftCacheConfigGetstate = [](tle::PeftCacheConfig const& self)
+    {
+        return py::make_tuple(self.getNumHostModuleLayer(), self.getNumDeviceModuleLayer(),
+            self.getOptimalAdapterSize(), self.getMaxAdapterSize(), self.getNumPutWorkers(), self.getNumEnsureWorkers(),
+            self.getNumCopyStreams(), self.getMaxPagesPerBlockHost(), self.getMaxPagesPerBlockDevice(),
+            self.getDeviceCachePercent(), self.getHostCacheSize());
+    };
+    py::class_<tle::PeftCacheConfig>(m, "PeftCacheConfig")
+        .def(py::init<SizeType32, SizeType32, SizeType32, SizeType32, SizeType32, SizeType32, SizeType32, SizeType32,
+                 SizeType32, std::optional<float> const&, std::optional<size_t> const&,
+                 std::optional<std::string> const&>(),
+            py::arg("num_host_module_layer") = 0, py::arg("num_device_module_layer") = 0,
+            py::arg("optimal_adapter_size") = 8, py::arg("max_adapter_size") = 64, py::arg("num_put_workers") = 1,
+            py::arg("num_ensure_workers") = 1, py::arg("num_copy_streams") = 1,
+            py::arg("max_pages_per_block_host") = 24, py::arg("max_pages_per_block_device") = 8,
+            py::arg("device_cache_percent") = py::none(), py::arg("host_cache_size") = py::none(),
+            py::arg("lora_prefetch_dir") = py::none())
+        .def_property_readonly("num_host_module_layer", &tle::PeftCacheConfig::getNumHostModuleLayer)
+        .def_property_readonly("num_device_module_layer", &tle::PeftCacheConfig::getNumDeviceModuleLayer)
+        .def_property_readonly("optimal_adapter_size", &tle::PeftCacheConfig::getOptimalAdapterSize)
+        .def_property_readonly("max_adapter_size", &tle::PeftCacheConfig::getMaxAdapterSize)
+        .def_property_readonly("num_put_workers", &tle::PeftCacheConfig::getNumPutWorkers)
+        .def_property_readonly("num_ensure_workers", &tle::PeftCacheConfig::getNumEnsureWorkers)
+        .def_property_readonly("num_copy_streams", &tle::PeftCacheConfig::getNumCopyStreams)
+        .def_property_readonly("max_pages_per_block_host", &tle::PeftCacheConfig::getMaxPagesPerBlockHost)
+        .def_property_readonly("max_pages_per_block_device", &tle::PeftCacheConfig::getMaxPagesPerBlockDevice)
+        .def_property_readonly("device_cache_percent", &tle::PeftCacheConfig::getDeviceCachePercent)
+        .def_property_readonly("host_cache_size", &tle::PeftCacheConfig::getHostCacheSize)
+        .def_property_readonly("lora_prefetch_dir", &tle::PeftCacheConfig::getLoraPrefetchDir)
+        .def(py::pickle(peftCacheConfigGetstate, peftCacheConfigSetstate));
+
+    auto decodingConfigGetstate = [](tle::DecodingConfig const& self)
+    {
+        return py::make_tuple(
+            self.getDecodingMode(), self.getLookaheadDecodingConfig(), self.getMedusaChoices(), self.getEagleConfig());
+    };
+    auto decodingConfigSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 4)
+        {
+            throw std::runtime_error("Invalid state!");
+        }
+        return tle::DecodingConfig(state[0].cast<std::optional<tle::DecodingMode>>(), // DecodingMode
+            state[1].cast<std::optional<tle::LookaheadDecodingConfig>>(),             // LookaheadDecodingConfig
+            state[2].cast<std::optional<tle::MedusaChoices>>(),                       // MedusaChoices
+            state[3].cast<std::optional<tle::EagleConfig>>()                          // EagleConfig
+        );
+    };
+    py::class_<tle::DecodingConfig>(m, "DecodingConfig")
+        .def(py::init<std::optional<tle::DecodingMode>, std::optional<tle::LookaheadDecodingConfig>,
+                 std::optional<tle::MedusaChoices>, std::optional<tle::EagleConfig>>(),
+            py::arg("decoding_mode") = py::none(), py::arg("lookahead_decoding_config") = py::none(),
+            py::arg("medusa_choices") = py::none(), py::arg("eagle_config") = py::none())
+        .def_property("decoding_mode", &tle::DecodingConfig::getDecodingMode, &tle::DecodingConfig::setDecodingMode)
+        .def_property("lookahead_decoding_config", &tle::DecodingConfig::getLookaheadDecodingConfig,
+            &tle::DecodingConfig::setLookaheadDecodingConfig)
+        .def_property("medusa_choices", &tle::DecodingConfig::getMedusaChoices, &tle::DecodingConfig::setMedusaChoices)
+        .def_property("eagle_config", &tle::DecodingConfig::getEagleConfig, &tle::DecodingConfig::setEagleConfig)
+        .def(py::pickle(decodingConfigGetstate, decodingConfigSetstate));
+
+    auto debugConfigGetstate = [](tle::DebugConfig const& self)
+    {
+        return py::make_tuple(self.getDebugInputTensors(), self.getDebugOutputTensors(), self.getDebugTensorNames(),
+            self.getDebugTensorsMaxIterations());
+    };
+    auto debugConfigSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 4)
+        {
+            throw std::runtime_error("Invalid state!");
+        }
+        return tle::DebugConfig(state[0].cast<bool>(), state[1].cast<bool>(), state[2].cast<std::vector<std::string>>(),
+            state[3].cast<SizeType32>());
+    };
+    py::class_<tle::DebugConfig>(m, "DebugConfig")
+        .def(py::init<bool, bool, std::vector<std::string>, SizeType32>(), py::arg("debug_input_tensors") = false,
+            py::arg("debug_output_tensors") = false, py::arg("debug_tensor_names") = py::none(),
+            py::arg("debug_tensors_max_iterations") = false)
+        .def_property(
+            "debug_input_tensors", &tle::DebugConfig::getDebugInputTensors, &tle::DebugConfig::setDebugInputTensors)
+        .def_property(
+            "debug_output_tensors", &tle::DebugConfig::getDebugOutputTensors, &tle::DebugConfig::setDebugOutputTensors)
+        .def_property(
+            "debug_tensor_names", &tle::DebugConfig::getDebugTensorNames, &tle::DebugConfig::setDebugTensorNames)
+        .def_property("debug_tensors_max_iterations", &tle::DebugConfig::getDebugTensorsMaxIterations,
+            &tle::DebugConfig::setDebugTensorsMaxIterations)
+        .def(py::pickle(debugConfigGetstate, debugConfigSetstate));
+
+    auto logitsPostProcessorConfigGetstate = [](tle::LogitsPostProcessorConfig const& self)
+    { return py::make_tuple(self.getProcessorMap(), self.getProcessorBatched(), self.getReplicate()); };
+
+    auto logitsPostProcessorConfigSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 3)
+        {
+            throw std::runtime_error("Invalid LogitsPostProcessorConfig state!");
+        }
+        return tle::LogitsPostProcessorConfig(state[0].cast<std::optional<tle::LogitsPostProcessorMap>>(),
+            state[1].cast<std::optional<tle::LogitsPostProcessorBatched>>(), state[2].cast<bool>());
+    };
+
+    py::class_<tle::LogitsPostProcessorConfig>(m, "LogitsPostProcessorConfig")
+        .def(py::init<std::optional<tle::LogitsPostProcessorMap>, std::optional<tle::LogitsPostProcessorBatched>,
+                 bool>(),
+            py::arg("processor_map") = py::none(), py::arg("processor_batched") = py::none(),
+            py::arg("replicate") = true)
+        .def_property("processor_map", &tle::LogitsPostProcessorConfig::getProcessorMap,
+            &tle::LogitsPostProcessorConfig::setProcessorMap)
+        .def_property("processor_batched", &tle::LogitsPostProcessorConfig::getProcessorBatched,
+            &tle::LogitsPostProcessorConfig::setProcessorBatched)
+        .def_property(
+            "replicate", &tle::LogitsPostProcessorConfig::getReplicate, &tle::LogitsPostProcessorConfig::setReplicate)
+        .def(py::pickle(logitsPostProcessorConfigGetstate, logitsPostProcessorConfigSetstate));
+
+    auto extendedRuntimePerfKnobConfigSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 4)
+        {
+            throw std::runtime_error("Invalid extendedRuntimePerfKnobConfig state!");
+        }
+        return tle::ExtendedRuntimePerfKnobConfig(
+            state[0].cast<bool>(), state[1].cast<bool>(), state[2].cast<bool>(), state[2].cast<SizeType32>());
+    };
+    auto extendedRuntimePerfKnobConfigGetstate = [](tle::ExtendedRuntimePerfKnobConfig const& self)
+    {
+        return py::make_tuple(self.getMultiBlockMode(), self.getEnableContextFMHAFP32Acc(), self.getCudaGraphMode(),
+            self.getCudaGraphCacheSize());
+    };
+    py::class_<tle::ExtendedRuntimePerfKnobConfig>(m, "ExtendedRuntimePerfKnobConfig")
+        .def(
+            py::init<bool, bool>(), py::arg("multi_block_mode") = true, py::arg("enable_context_fmha_fp32_acc") = false)
+        .def_property("multi_block_mode", &tle::ExtendedRuntimePerfKnobConfig::getMultiBlockMode,
+            &tle::ExtendedRuntimePerfKnobConfig::setMultiBlockMode)
+        .def_property("enable_context_fmha_fp32_acc", &tle::ExtendedRuntimePerfKnobConfig::getEnableContextFMHAFP32Acc,
+            &tle::ExtendedRuntimePerfKnobConfig::setEnableContextFMHAFP32Acc)
+        .def_property("cuda_graph_mode", &tle::ExtendedRuntimePerfKnobConfig::getCudaGraphMode,
+            &tle::ExtendedRuntimePerfKnobConfig::setCudaGraphMode)
+        .def_property("cuda_graph_cache_size", &tle::ExtendedRuntimePerfKnobConfig::getCudaGraphCacheSize,
+            &tle::ExtendedRuntimePerfKnobConfig::setCudaGraphCacheSize)
+        .def(py::pickle(extendedRuntimePerfKnobConfigGetstate, extendedRuntimePerfKnobConfigSetstate));
+
+    auto SpeculativeDecodingConfigGetState
+        = [](tle::SpeculativeDecodingConfig const& self) { return py::make_tuple(self.fastLogits); };
+    auto SpeculativeDecodingConfigSetState = [](py::tuple const& state)
+    {
+        if (state.size() != 1)
+        {
+            throw std::runtime_error("Invalid SpeculativeDecodingConfig state!");
+        }
+        return tle::SpeculativeDecodingConfig(state[0].cast<bool>());
+    };
+    py::class_<tle::SpeculativeDecodingConfig>(m, "SpeculativeDecodingConfig")
+        .def(py::init<bool>(), py::arg("fast_logits") = false)
+        .def_readwrite("fast_logits", &tle::SpeculativeDecodingConfig::fastLogits)
+        .def(py::pickle(SpeculativeDecodingConfigGetState, SpeculativeDecodingConfigSetState));
+
+    // Guided decoding config
+    auto pyGuidedDecodingConfig = py::class_<tle::GuidedDecodingConfig>(m, "GuidedDecodingConfig");
+
+    py::enum_<tle::GuidedDecodingConfig::GuidedDecodingBackend>(pyGuidedDecodingConfig, "GuidedDecodingBackend")
+        .value("XGRAMMAR", tle::GuidedDecodingConfig::GuidedDecodingBackend::kXGRAMMAR)
+        .value("LLGUIDANCE", tle::GuidedDecodingConfig::GuidedDecodingBackend::kLLGUIDANCE);
+
+    auto guidedDecodingConfigGetstate = [](tle::GuidedDecodingConfig const& self) {
+        return py::make_tuple(
+            self.getBackend(), self.getEncodedVocab(), self.getTokenizerStr(), self.getStopTokenIds());
+    };
+    auto guidedDecodingConfigSetstate = [](py::tuple state)
+    {
+        if (state.size() != 4)
+        {
+            throw std::runtime_error("Invalid GuidedDecodingConfig state!");
+        }
+        return tle::GuidedDecodingConfig(state[0].cast<tle::GuidedDecodingConfig::GuidedDecodingBackend>(),
+            state[1].cast<std::optional<std::vector<std::string>>>(), state[2].cast<std::optional<std::string>>(),
+            state[3].cast<std::optional<std::vector<tle::TokenIdType>>>());
+    };
+
+    pyGuidedDecodingConfig
+        .def(py::init<tle::GuidedDecodingConfig::GuidedDecodingBackend, std::optional<std::vector<std::string>>,
+                 std::optional<std::string>, std::optional<std::vector<tle::TokenIdType>>>(),
+            py::arg("backend"), py::arg("encoded_vocab") = py::none(), py::arg("tokenizer_str") = py::none(),
+            py::arg("stop_token_ids") = py::none())
+        .def_property("backend", &tle::GuidedDecodingConfig::getBackend, &tle::GuidedDecodingConfig::setBackend)
+        .def_property(
+            "encoded_vocab", &tle::GuidedDecodingConfig::getEncodedVocab, &tle::GuidedDecodingConfig::setEncodedVocab)
+        .def_property(
+            "tokenizer_str", &tle::GuidedDecodingConfig::getTokenizerStr, &tle::GuidedDecodingConfig::setTokenizerStr)
+        .def_property(
+            "stop_token_ids", &tle::GuidedDecodingConfig::getStopTokenIds, &tle::GuidedDecodingConfig::setStopTokenIds)
+        .def(py::pickle(guidedDecodingConfigGetstate, guidedDecodingConfigSetstate));
+
+    auto cacheTransceiverConfigGetstate
+        = [](tle::CacheTransceiverConfig const& self) { return py::make_tuple(self.getMaxNumTokens()); };
+    auto cacheTransceiverConfigSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 1)
+        {
+            throw std::runtime_error("Invalid CacheTransceiverConfig state!");
+        }
+        return tle::CacheTransceiverConfig(state[0].cast<std::optional<size_t>>());
+    };
+
+    py::class_<tle::CacheTransceiverConfig>(m, "CacheTransceiverConfig")
+        .def(py::init<std::optional<size_t>>(), py::arg("max_num_tokens") = py::none())
+        .def_property("max_num_tokens", &tle::CacheTransceiverConfig::getMaxNumTokens,
+            &tle::CacheTransceiverConfig::setMaxNumTokens)
+        .def(py::pickle(cacheTransceiverConfigGetstate, cacheTransceiverConfigSetstate));
+
+    auto executorConfigGetState = [](py::object const& self)
+    {
+        auto& c = self.cast<tle::ExecutorConfig&>();
+        // Return a tuple containing C++ data and the Python __dict__
+        auto cpp_states = py::make_tuple(c.getMaxBeamWidth(), c.getSchedulerConfig(), c.getKvCacheConfig(),
+            c.getEnableChunkedContext(), c.getNormalizeLogProbs(), c.getIterStatsMaxIterations(),
+            c.getRequestStatsMaxIterations(), c.getBatchingType(), c.getMaxBatchSize(), c.getMaxNumTokens(),
+            c.getParallelConfig(), c.getPeftCacheConfig(), c.getLogitsPostProcessorConfig(), c.getDecodingConfig(),
+            c.getUseGpuDirectStorage(), c.getGpuWeightsPercent(), c.getMaxQueueSize(),
+            c.getExtendedRuntimePerfKnobConfig(), c.getDebugConfig(), c.getRecvPollPeriodMs(),
+            c.getMaxSeqIdleMicroseconds(), c.getSpecDecConfig(), c.getGuidedDecodingConfig(),
+            c.getAdditionalModelOutputs(), c.getCacheTransceiverConfig(), c.getGatherGenerationLogits(),
+            c.getPromptTableOffloading(), c.getEnableTrtOverlap());
+        auto pickle_tuple = py::make_tuple(cpp_states, py::getattr(self, "__dict__"));
+        return pickle_tuple;
+    };
+    auto executorConfigSetState = [](py::tuple const& state)
+    {
+        if (state.size() != 2)
+        {
+            throw std::runtime_error("Invalid state!");
+        }
+
+        // Restore C++ data
+        auto cpp_states = state[0].cast<py::tuple>();
+        if (cpp_states.size() != 28)
+        {
+            throw std::runtime_error("Invalid cpp_states!");
+        }
+
+        auto ec = tle::ExecutorConfig(                                            //
+            cpp_states[0].cast<SizeType32>(),                                     // MaxBeamWidth
+            cpp_states[1].cast<tle::SchedulerConfig>(),                           // SchedulerConfig
+            cpp_states[2].cast<tle::KvCacheConfig>(),                             // KvCacheConfig
+            cpp_states[3].cast<bool>(),                                           // EnableChunkedContext
+            cpp_states[4].cast<bool>(),                                           // NormalizeLogProbs
+            cpp_states[5].cast<SizeType32>(),                                     // IterStatsMaxIterations
+            cpp_states[6].cast<SizeType32>(),                                     // RequestStatsMaxIterations
+            cpp_states[7].cast<tle::BatchingType>(),                              // BatchingType
+            cpp_states[8].cast<std::optional<SizeType32>>(),                      // MaxBatchSize
+            cpp_states[9].cast<std::optional<SizeType32>>(),                      // MaxNumTokens
+            cpp_states[10].cast<std::optional<tle::ParallelConfig>>(),            // ParallelConfig
+            cpp_states[11].cast<std::optional<tle::PeftCacheConfig>>(),           // PeftCacheConfig
+            cpp_states[12].cast<std::optional<tle::LogitsPostProcessorConfig>>(), // LogitsPostProcessorConfig
+            cpp_states[13].cast<std::optional<tle::DecodingConfig>>(),            // DecodingConfig
+            cpp_states[14].cast<bool>(),                                          // UseGpuDirectStorage
+            cpp_states[15].cast<float>(),                                         // GpuWeightsPercent
+            cpp_states[16].cast<std::optional<SizeType32>>(),                     // MaxQueueSize
+            cpp_states[17].cast<tle::ExtendedRuntimePerfKnobConfig>(),            // ExtendedRuntimePerfKnobConfig
+            cpp_states[18].cast<std::optional<tle::DebugConfig>>(),               // DebugConfig
+            cpp_states[19].cast<SizeType32>(),                                    // RecvPollPeriodMs
+            cpp_states[20].cast<uint64_t>(),                                      // MaxSeqIdleMicroseconds
+            cpp_states[21].cast<std::optional<tle::SpeculativeDecodingConfig>>(), // SpecDecConfig
+            cpp_states[22].cast<std::optional<tle::GuidedDecodingConfig>>(),      // GuidedDecodingConfig
+            cpp_states[23].cast<std::optional<std::vector<tle::AdditionalModelOutput>>>(), // AdditionalModelOutputs
+            cpp_states[24].cast<std::optional<tle::CacheTransceiverConfig>>(),             // CacheTransceiverConfig
+            cpp_states[25].cast<bool>(),                                                   // GatherGenerationLogits
+            cpp_states[26].cast<bool>(),                                                   // PromptTableOffloading
+            cpp_states[27].cast<bool>()                                                    // EnableTrtOverlap
+        );
+
+        auto py_state = state[1].cast<py::dict>();
+
+        return std::make_pair(ec, py_state);
+    };
+
+    py::class_<tle::ExecutorConfig>(m, "ExecutorConfig", pybind11::dynamic_attr())
+        .def(py::init<                                                   //
+                 SizeType32,                                             // MaxBeamWidth
+                 tle::SchedulerConfig const&,                            // SchedulerConfig
+                 tle::KvCacheConfig const&,                              // KvCacheConfig
+                 bool,                                                   // EnableChunkedContext
+                 bool,                                                   // NormalizeLogProbs
+                 SizeType32,                                             // IterStatsMaxIterations
+                 SizeType32,                                             // RequestStatsMaxIterations
+                 tle::BatchingType,                                      // BatchingType
+                 std::optional<SizeType32>,                              // MaxBatchSize
+                 std::optional<SizeType32>,                              // MaxNumTokens
+                 std::optional<tle::ParallelConfig>,                     // ParallelConfig
+                 tle::PeftCacheConfig const&,                            // PeftCacheConfig
+                 std::optional<tle::LogitsPostProcessorConfig>,          // LogitsPostProcessorConfig
+                 std::optional<tle::DecodingConfig>,                     // DecodingConfig
+                 bool,                                                   // UseGpuDirectStorage
+                 float,                                                  // GpuWeightsPercent
+                 std::optional<SizeType32>,                              // MaxQueueSize
+                 tle::ExtendedRuntimePerfKnobConfig const&,              // ExtendedRuntimePerfKnobConfig
+                 std::optional<tle::DebugConfig>,                        // DebugConfig
+                 SizeType32,                                             // RecvPollPeriodMs
+                 uint64_t,                                               // MaxSeqIdleMicroseconds
+                 std::optional<tle::SpeculativeDecodingConfig>,          // SpecDecConfig
+                 std::optional<tle::GuidedDecodingConfig>,               // GuidedDecodingConfig
+                 std::optional<std::vector<tle::AdditionalModelOutput>>, // AdditionalModelOutputs
+                 std::optional<tle::CacheTransceiverConfig>,             // CacheTransceiverConfig
+                 bool,                                                   // GatherGenerationLogits
+                 bool,                                                   // PromptTableOffloading
+                 bool                                                    // EnableTrtOverlap
+                 >(),
+            py::arg("max_beam_width") = 1, py::arg_v("scheduler_config", tle::SchedulerConfig(), "SchedulerConfig()"),
+            py::arg_v("kv_cache_config", tle::KvCacheConfig(), "KvCacheConfig()"),
+            py::arg("enable_chunked_context") = false, py::arg("normalize_log_probs") = true,
+            py::arg("iter_stats_max_iterations") = tle::ExecutorConfig::kDefaultIterStatsMaxIterations,
+            py::arg("request_stats_max_iterations") = tle::ExecutorConfig::kDefaultRequestStatsMaxIterations,
+            py::arg_v("batching_type", tle::BatchingType::kINFLIGHT, "BatchingType.INFLIGHT"),
+            py::arg("max_batch_size") = py::none(), py::arg("max_num_tokens") = py::none(),
+            py::arg("parallel_config") = py::none(),
+            py::arg_v("peft_cache_config", tle::PeftCacheConfig(), "PeftCacheConfig()"),
+            py::arg("logits_post_processor_config") = py::none(), py::arg("decoding_config") = py::none(),
+            py::arg("use_gpu_direct_storage") = false, py::arg("gpu_weights_percent") = 1.0,
+            py::arg("max_queue_size") = py::none(),
+            py::arg_v("extended_runtime_perf_knob_config", tle::ExtendedRuntimePerfKnobConfig(),
+                "ExtendedRuntimePerfKnobConfig()"),
+            py::arg("debug_config") = py::none(), py::arg("recv_poll_period_ms") = 0,
+            py::arg("max_seq_idle_microseconds") = tle::ExecutorConfig::kDefaultMaxSeqIdleMicroseconds,
+            py::arg("spec_dec_config") = py::none(), py::arg("guided_decoding_config") = py::none(),
+            py::arg("additional_model_outputs") = py::none(), py::arg("cache_transceiver_config") = py::none(),
+            py::arg("gather_generation_logits") = false, py::arg("mm_embedding_offloading") = false,
+            py::arg("enable_trt_overlap") = false)
+        .def_property("max_beam_width", &tle::ExecutorConfig::getMaxBeamWidth, &tle::ExecutorConfig::setMaxBeamWidth)
+        .def_property("max_batch_size", &tle::ExecutorConfig::getMaxBatchSize, &tle::ExecutorConfig::setMaxBatchSize)
+        .def_property("max_num_tokens", &tle::ExecutorConfig::getMaxNumTokens, &tle::ExecutorConfig::setMaxNumTokens)
+        .def_property(
+            "scheduler_config", &tle::ExecutorConfig::getSchedulerConfigRef, &tle::ExecutorConfig::setSchedulerConfig)
+        .def_property(
+            "kv_cache_config", &tle::ExecutorConfig::getKvCacheConfigRef, &tle::ExecutorConfig::setKvCacheConfig)
+        .def_property("enable_chunked_context", &tle::ExecutorConfig::getEnableChunkedContext,
+            &tle::ExecutorConfig::setEnableChunkedContext)
+        .def_property("normalize_log_probs", &tle::ExecutorConfig::getNormalizeLogProbs,
+            &tle::ExecutorConfig::setNormalizeLogProbs)
+        .def_property("iter_stats_max_iterations", &tle::ExecutorConfig::getIterStatsMaxIterations,
+            &tle::ExecutorConfig::setIterStatsMaxIterations)
+        .def_property("request_stats_max_iterations", &tle::ExecutorConfig::getRequestStatsMaxIterations,
+            &tle::ExecutorConfig::setRequestStatsMaxIterations)
+        .def_property("batching_type", &tle::ExecutorConfig::getBatchingType, &tle::ExecutorConfig::setBatchingType)
+        .def_property(
+            "parallel_config", &tle::ExecutorConfig::getParallelConfig, &tle::ExecutorConfig::setParallelConfig)
+        .def_property(
+            "peft_cache_config", &tle::ExecutorConfig::getPeftCacheConfig, &tle::ExecutorConfig::setPeftCacheConfig)
+        .def_property("logits_post_processor_config", &tle::ExecutorConfig::getLogitsPostProcessorConfig,
+            &tle::ExecutorConfig::setLogitsPostProcessorConfig)
+        .def_property(
+            "decoding_config", &tle::ExecutorConfig::getDecodingConfig, &tle::ExecutorConfig::setDecodingConfig)
+        .def_property("use_gpu_direct_storage", &tle::ExecutorConfig::getUseGpuDirectStorage,
+            &tle::ExecutorConfig::setUseGpuDirectStorage)
+        .def_property("gpu_weights_percent", &tle::ExecutorConfig::getGpuWeightsPercent,
+            &tle::ExecutorConfig::setGpuWeightsPercent)
+        .def_property("max_queue_size", &tle::ExecutorConfig::getMaxQueueSize, &tle::ExecutorConfig::setMaxQueueSize)
+        .def_property("extended_runtime_perf_knob_config", &tle::ExecutorConfig::getExtendedRuntimePerfKnobConfig,
+            &tle::ExecutorConfig::setExtendedRuntimePerfKnobConfig)
+        .def_property("debug_config", &tle::ExecutorConfig::getDebugConfig, &tle::ExecutorConfig::setDebugConfig)
+        .def_property(
+            "recv_poll_period_ms", &tle::ExecutorConfig::getRecvPollPeriodMs, &tle::ExecutorConfig::setRecvPollPeriodMs)
+        .def_property("max_seq_idle_microseconds", &tle::ExecutorConfig::getMaxSeqIdleMicroseconds,
+            &tle::ExecutorConfig::setMaxSeqIdleMicroseconds)
+        .def_property("spec_dec_config", &tle::ExecutorConfig::getSpecDecConfig, &tle::ExecutorConfig::setSpecDecConfig)
+        .def_property("guided_decoding_config", &tle::ExecutorConfig::getGuidedDecodingConfig,
+            &tle::ExecutorConfig::setGuidedDecodingConfig)
+        .def_property("additional_model_outputs", &tle::ExecutorConfig::getAdditionalModelOutputs,
+            &tle::ExecutorConfig::setAdditionalModelOutputs)
+        .def_property("cache_transceiver_config", &tle::ExecutorConfig::getCacheTransceiverConfig,
+            &tle::ExecutorConfig::setCacheTransceiverConfig)
+        .def_property("gather_generation_logits", &tle::ExecutorConfig::getGatherGenerationLogits,
+            &tle::ExecutorConfig::setGatherGenerationLogits)
+        .def_property("mm_embedding_offloading", &tle::ExecutorConfig::getPromptTableOffloading,
+            &tle::ExecutorConfig::setPromptTableOffloading)
+        .def_property(
+            "enable_trt_overlap", &tle::ExecutorConfig::getEnableTrtOverlap, &tle::ExecutorConfig::setEnableTrtOverlap)
+        .def(py::pickle(executorConfigGetState, executorConfigSetState));
+}
+
+} // namespace tensorrt_llm::pybind::executor

--- a/cpp/tensorrt_llm/nanobind/executor/executorConfig.h
+++ b/cpp/tensorrt_llm/nanobind/executor/executorConfig.h
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "tensorrt_llm/pybind/common/customCasters.h"
+#include <pybind11/pybind11.h>
+
+namespace tensorrt_llm::pybind::executor
+{
+
+// Register bindings for executor API.
+void initConfigBindings(pybind11::module_& m);
+
+} // namespace tensorrt_llm::pybind::executor

--- a/cpp/tensorrt_llm/nanobind/executor/executorConfig.h
+++ b/cpp/tensorrt_llm/nanobind/executor/executorConfig.h
@@ -17,13 +17,12 @@
 
 #pragma once
 
-#include "tensorrt_llm/pybind/common/customCasters.h"
-#include <pybind11/pybind11.h>
+#include "tensorrt_llm/nanobind/common/customCasters.h"
 
-namespace tensorrt_llm::pybind::executor
+namespace tensorrt_llm::nanobind::executor
 {
 
 // Register bindings for executor API.
-void initConfigBindings(pybind11::module_& m);
+void initConfigBindings(nb::module_& m);
 
-} // namespace tensorrt_llm::pybind::executor
+} // namespace tensorrt_llm::nanobind::executor

--- a/cpp/tensorrt_llm/nanobind/executor/request.cpp
+++ b/cpp/tensorrt_llm/nanobind/executor/request.cpp
@@ -24,18 +24,20 @@
 #include "tensorrt_llm/executor/types.h"
 #include "tensorrt_llm/runtime/cudaStream.h"
 
-#include <pybind11/cast.h>
-#include <pybind11/chrono.h>
-#include <pybind11/functional.h>
-#include <pybind11/operators.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/chrono.h>
+#include <nanobind/stl/list.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/tuple.h>
+#include <nanobind/stl/vector.h>
 #include <sstream>
 
 #include <optional>
 #include <vector>
 
-namespace py = pybind11;
+namespace nb = nanobind;
 namespace tle = tensorrt_llm::executor;
 using Tensor = tle::Tensor;
 using SizeType32 = tle::SizeType32;
@@ -44,17 +46,17 @@ using VecTokens = tle::VecTokens;
 using IdType = tle::IdType;
 using VecTokenExtraIds = tle::VecTokenExtraIds;
 
-namespace tensorrt_llm::pybind::executor
+namespace tensorrt_llm::nanobind::executor
 {
 
-void initRequestBindings(pybind11::module_& m)
+void initRequestBindings(nb::module_& m)
 {
-    py::enum_<tle::RequestType>(m, "RequestType")
+    nb::enum_<tle::RequestType>(m, "RequestType")
         .value("REQUEST_TYPE_CONTEXT_AND_GENERATION", tle::RequestType::REQUEST_TYPE_CONTEXT_AND_GENERATION)
         .value("REQUEST_TYPE_CONTEXT_ONLY", tle::RequestType::REQUEST_TYPE_CONTEXT_ONLY)
         .value("REQUEST_TYPE_GENERATION_ONLY", tle::RequestType::REQUEST_TYPE_GENERATION_ONLY);
 
-    py::enum_<tle::FinishReason>(m, "FinishReason")
+    nb::enum_<tle::FinishReason>(m, "FinishReason")
         .value("NOT_FINISHED", tle::FinishReason::kNOT_FINISHED)
         .value("END_ID", tle::FinishReason::kEND_ID)
         .value("STOP_WORDS", tle::FinishReason::kSTOP_WORDS)
@@ -62,48 +64,48 @@ void initRequestBindings(pybind11::module_& m)
         .value("TIMED_OUT", tle::FinishReason::kTIMED_OUT)
         .value("CANCELLED", tle::FinishReason::kCANCELLED);
 
-    py::enum_<tle::KvCacheTransferMode>(m, "KvCacheTransferMode")
+    nb::enum_<tle::KvCacheTransferMode>(m, "KvCacheTransferMode")
         .value("DRAM", tle::KvCacheTransferMode::DRAM)
         .value("GDS", tle::KvCacheTransferMode::GDS)
         .value("POSIX_DEBUG_FALLBACK", tle::KvCacheTransferMode::POSIX_DEBUG_FALLBACK);
 
     auto samplingConfigGetstate = [](tle::SamplingConfig const& self)
     {
-        return py::make_tuple(self.getBeamWidth(), self.getTopK(), self.getTopP(), self.getTopPMin(),
+        return nb::make_tuple(self.getBeamWidth(), self.getTopK(), self.getTopP(), self.getTopPMin(),
             self.getTopPResetIds(), self.getTopPDecay(), self.getSeed(), self.getTemperature(), self.getMinTokens(),
             self.getBeamSearchDiversityRate(), self.getRepetitionPenalty(), self.getPresencePenalty(),
             self.getFrequencyPenalty(), self.getLengthPenalty(), self.getEarlyStopping(), self.getNoRepeatNgramSize(),
             self.getNumReturnSequences(), self.getMinP(), self.getBeamWidthArray());
     };
-    auto samplingConfigSetstate = [](py::tuple const& state)
+    auto samplingConfigSetstate = [](tle::SamplingConfig& samplingConfig, nb::tuple const& state)
     {
         if (state.size() != 19)
         {
             throw std::runtime_error("Invalid SamplingConfig state!");
         }
-        return tle::SamplingConfig(state[0].cast<SizeType32>(),      // BeamWidth
-            state[1].cast<std::optional<SizeType32>>(),              // TopK
-            state[2].cast<std::optional<FloatType>>(),               // TopP
-            state[3].cast<std::optional<FloatType>>(),               // TopPMin
-            state[4].cast<std::optional<tle::TokenIdType>>(),        // TopPResetIds
-            state[5].cast<std::optional<FloatType>>(),               // TopPDecay
-            state[6].cast<std::optional<tle::RandomSeedType>>(),     // Seed
-            state[7].cast<std::optional<FloatType>>(),               // Temperature
-            state[8].cast<std::optional<SizeType32>>(),              // MinTokens
-            state[9].cast<std::optional<FloatType>>(),               // BeamSearchDiversityRate
-            state[10].cast<std::optional<FloatType>>(),              // RepetitionPenalty
-            state[11].cast<std::optional<FloatType>>(),              // PresencePenalty
-            state[12].cast<std::optional<FloatType>>(),              // FrequencyPenalty
-            state[13].cast<std::optional<FloatType>>(),              // LengthPenalty
-            state[14].cast<std::optional<SizeType32>>(),             // EarlyStopping
-            state[15].cast<std::optional<SizeType32>>(),             // NoRepeatNgramSize
-            state[16].cast<std::optional<SizeType32>>(),             // NumReturnSequences
-            state[17].cast<std::optional<FloatType>>(),              // MinP
-            state[18].cast<std::optional<std::vector<SizeType32>>>() // BeamWidthArray
+        new (&samplingConfig) tle::SamplingConfig(nb::cast<SizeType32>(state[0]), // BeamWidth
+            nb::cast<std::optional<SizeType32>>(state[1]),                        // TopK
+            nb::cast<std::optional<FloatType>>(state[2]),                         // TopP
+            nb::cast<std::optional<FloatType>>(state[3]),                         // TopPMin
+            nb::cast<std::optional<tle::TokenIdType>>(state[4]),                  // TopPResetIds
+            nb::cast<std::optional<FloatType>>(state[5]),                         // TopPDecay
+            nb::cast<std::optional<tle::RandomSeedType>>(state[6]),               // Seed
+            nb::cast<std::optional<FloatType>>(state[7]),                         // Temperature
+            nb::cast<std::optional<SizeType32>>(state[8]),                        // MinTokens
+            nb::cast<std::optional<FloatType>>(state[9]),                         // BeamSearchDiversityRate
+            nb::cast<std::optional<FloatType>>(state[10]),                        // RepetitionPenalty
+            nb::cast<std::optional<FloatType>>(state[11]),                        // PresencePenalty
+            nb::cast<std::optional<FloatType>>(state[12]),                        // FrequencyPenalty
+            nb::cast<std::optional<FloatType>>(state[13]),                        // LengthPenalty
+            nb::cast<std::optional<SizeType32>>(state[14]),                       // EarlyStopping
+            nb::cast<std::optional<SizeType32>>(state[15]),                       // NoRepeatNgramSize
+            nb::cast<std::optional<SizeType32>>(state[16]),                       // NumReturnSequences
+            nb::cast<std::optional<FloatType>>(state[17]),                        // MinP
+            nb::cast<std::optional<std::vector<SizeType32>>>(state[18])           // BeamWidthArray
         );
     };
-    py::class_<tle::SamplingConfig>(m, "SamplingConfig")
-        .def(py::init<tle::SizeType32,
+    nb::class_<tle::SamplingConfig>(m, "SamplingConfig")
+        .def(nb::init<tle::SizeType32,
                  std::optional<tle::SizeType32> const&,             // beamWidth
                  std::optional<tle::FloatType> const&,              // topP
                  std::optional<tle::FloatType> const&,              // topPMin
@@ -124,213 +126,226 @@ void initRequestBindings(pybind11::module_& m)
                  std::optional<std::vector<tle::SizeType32>> const& // beamWidthArray
                  >(),
             // clang-format off
-            py::arg("beam_width") = 1,
-            py::kw_only(),
-            py::arg("top_k") = py::none(),
-            py::arg("top_p") = py::none(),
-            py::arg("top_p_min") = py::none(),
-            py::arg("top_p_reset_ids") = py::none(),
-            py::arg("top_p_decay") = py::none(),
-            py::arg("seed") = py::none(),
-            py::arg("temperature") = py::none(),
-            py::arg("min_tokens") = py::none(),
-            py::arg("beam_search_diversity_rate") = py::none(),
-            py::arg("repetition_penalty") = py::none(),
-            py::arg("presence_penalty") = py::none(),
-            py::arg("frequency_penalty") = py::none(),
-            py::arg("length_penalty") = py::none(),
-            py::arg("early_stopping") = py::none(),
-            py::arg("no_repeat_ngram_size") = py::none(),
-            py::arg("num_return_sequences") = py::none(),
-            py::arg("min_p") = py::none(),
-            py::arg("beam_width_array") = py::none())               // clang-format on
-        .def_property("beam_width", &tle::SamplingConfig::getBeamWidth, &tle::SamplingConfig::setBeamWidth)
-        .def_property("top_k", &tle::SamplingConfig::getTopK, &tle::SamplingConfig::setTopK)
-        .def_property("top_p", &tle::SamplingConfig::getTopP, &tle::SamplingConfig::setTopP)
-        .def_property("top_p_min", &tle::SamplingConfig::getTopPMin, &tle::SamplingConfig::setTopPMin)
-        .def_property("top_p_reset_ids", &tle::SamplingConfig::getTopPResetIds, &tle::SamplingConfig::setTopPResetIds)
-        .def_property("top_p_decay", &tle::SamplingConfig::getTopPDecay, &tle::SamplingConfig::setTopPDecay)
-        .def_property("seed", &tle::SamplingConfig::getSeed, &tle::SamplingConfig::setSeed)
-        .def_property("temperature", &tle::SamplingConfig::getTemperature, &tle::SamplingConfig::setTemperature)
-        .def_property("min_tokens", &tle::SamplingConfig::getMinTokens, &tle::SamplingConfig::setMinTokens)
-        .def_property("beam_search_diversity_rate", &tle::SamplingConfig::getBeamSearchDiversityRate,
+            nb::arg("beam_width") = 1,
+            nb::kw_only(),
+            nb::arg("top_k") = nb::none(),
+            nb::arg("top_p") = nb::none(),
+            nb::arg("top_p_min") = nb::none(),
+            nb::arg("top_p_reset_ids") = nb::none(),
+            nb::arg("top_p_decay") = nb::none(),
+            nb::arg("seed") = nb::none(),
+            nb::arg("temperature") = nb::none(),
+            nb::arg("min_tokens") = nb::none(),
+            nb::arg("beam_search_diversity_rate") = nb::none(),
+            nb::arg("repetition_penalty") = nb::none(),
+            nb::arg("presence_penalty") = nb::none(),
+            nb::arg("frequency_penalty") = nb::none(),
+            nb::arg("length_penalty") = nb::none(),
+            nb::arg("early_stopping") = nb::none(),
+            nb::arg("no_repeat_ngram_size") = nb::none(),
+            nb::arg("num_return_sequences") = nb::none(),
+            nb::arg("min_p") = nb::none(),
+            nb::arg("beam_width_array") = nb::none())               // clang-format on
+        .def_prop_rw("beam_width", &tle::SamplingConfig::getBeamWidth, &tle::SamplingConfig::setBeamWidth)
+        .def_prop_rw("top_k", &tle::SamplingConfig::getTopK, &tle::SamplingConfig::setTopK)
+        .def_prop_rw("top_p", &tle::SamplingConfig::getTopP, &tle::SamplingConfig::setTopP)
+        .def_prop_rw("top_p_min", &tle::SamplingConfig::getTopPMin, &tle::SamplingConfig::setTopPMin)
+        .def_prop_rw("top_p_reset_ids", &tle::SamplingConfig::getTopPResetIds, &tle::SamplingConfig::setTopPResetIds)
+        .def_prop_rw("top_p_decay", &tle::SamplingConfig::getTopPDecay, &tle::SamplingConfig::setTopPDecay)
+        .def_prop_rw("seed", &tle::SamplingConfig::getSeed, &tle::SamplingConfig::setSeed)
+        .def_prop_rw("temperature", &tle::SamplingConfig::getTemperature, &tle::SamplingConfig::setTemperature)
+        .def_prop_rw("min_tokens", &tle::SamplingConfig::getMinTokens, &tle::SamplingConfig::setMinTokens)
+        .def_prop_rw("beam_search_diversity_rate", &tle::SamplingConfig::getBeamSearchDiversityRate,
             &tle::SamplingConfig::setBeamSearchDiversityRate)
-        .def_property("repetition_penalty", &tle::SamplingConfig::getRepetitionPenalty,
+        .def_prop_rw("repetition_penalty", &tle::SamplingConfig::getRepetitionPenalty,
             &tle::SamplingConfig::setRepetitionPenalty)
-        .def_property("presence_penalty", &tle::SamplingConfig::getPresencePenalty,
+        .def_prop_rw("presence_penalty", &tle::SamplingConfig::getPresencePenalty,
             [](tle::SamplingConfig& self, std::optional<FloatType> v) { self.setPresencePenalty(v); })
-        .def_property(
+        .def_prop_rw(
             "frequency_penalty", &tle::SamplingConfig::getFrequencyPenalty, &tle::SamplingConfig::setFrequencyPenalty)
-        .def_property("length_penalty", &tle::SamplingConfig::getLengthPenalty, &tle::SamplingConfig::setLengthPenalty)
-        .def_property("early_stopping", &tle::SamplingConfig::getEarlyStopping, &tle::SamplingConfig::setEarlyStopping)
-        .def_property("no_repeat_ngram_size", &tle::SamplingConfig::getNoRepeatNgramSize,
+        .def_prop_rw("length_penalty", &tle::SamplingConfig::getLengthPenalty, &tle::SamplingConfig::setLengthPenalty)
+        .def_prop_rw("early_stopping", &tle::SamplingConfig::getEarlyStopping, &tle::SamplingConfig::setEarlyStopping)
+        .def_prop_rw("no_repeat_ngram_size", &tle::SamplingConfig::getNoRepeatNgramSize,
             &tle::SamplingConfig::setNoRepeatNgramSize)
-        .def_property("num_return_sequences", &tle::SamplingConfig::getNumReturnSequences,
+        .def_prop_rw("num_return_sequences", &tle::SamplingConfig::getNumReturnSequences,
             &tle::SamplingConfig::setNumReturnSequences)
-        .def_property("min_p", &tle::SamplingConfig::getMinP, &tle::SamplingConfig::setMinP)
-        .def_property(
+        .def_prop_rw("min_p", &tle::SamplingConfig::getMinP, &tle::SamplingConfig::setMinP)
+        .def_prop_rw(
             "beam_width_array", &tle::SamplingConfig::getBeamWidthArray, &tle::SamplingConfig::setBeamWidthArray)
-        .def(py::pickle(samplingConfigGetstate, samplingConfigSetstate));
+        .def("__getstate__", samplingConfigGetstate)
+        .def("__setstate__", samplingConfigSetstate);
 
     auto additionalModelOutputGetstate
-        = [](tle::AdditionalModelOutput const& self) { return py::make_tuple(self.name, self.gatherContext); };
-    auto additionalModelOutputSetstate = [](py::tuple const& state)
+        = [](tle::AdditionalModelOutput const& self) { return nb::make_tuple(self.name, self.gatherContext); };
+    auto additionalModelOutputSetstate = [](tle::AdditionalModelOutput& additionalModelOutput, nb::tuple const& state)
     {
         if (state.size() != 2)
         {
             throw std::runtime_error("Invalid AdditionalModelOutput state!");
         }
-        return tle::AdditionalModelOutput(state[0].cast<std::string>(), state[1].cast<bool>());
+        new (&additionalModelOutput)
+            tle::AdditionalModelOutput(nb::cast<std::string>(state[0]), nb::cast<bool>(state[1]));
     };
-    py::class_<tle::AdditionalModelOutput>(m, "AdditionalModelOutput")
-        .def(py::init<std::string, bool>(), py::arg("name"), py::arg("gather_context") = false)
-        .def_readwrite("name", &tle::AdditionalModelOutput::name)
-        .def_readwrite("gather_context", &tle::AdditionalModelOutput::gatherContext)
-        .def(py::pickle(additionalModelOutputGetstate, additionalModelOutputSetstate));
+    nb::class_<tle::AdditionalModelOutput>(m, "AdditionalModelOutput")
+        .def(nb::init<std::string, bool>(), nb::arg("name"), nb::arg("gather_context") = false)
+        .def_rw("name", &tle::AdditionalModelOutput::name)
+        .def_rw("gather_context", &tle::AdditionalModelOutput::gatherContext)
+        .def("__getstate__", additionalModelOutputGetstate)
+        .def("__setstate__", additionalModelOutputSetstate);
 
     auto outputConfigGetstate = [](tle::OutputConfig const& self)
     {
-        return py::make_tuple(self.returnLogProbs, self.returnContextLogits, self.returnGenerationLogits,
+        return nb::make_tuple(self.returnLogProbs, self.returnContextLogits, self.returnGenerationLogits,
             self.excludeInputFromOutput, self.returnEncoderOutput, self.returnPerfMetrics, self.additionalModelOutputs);
     };
-    auto outputConfigSetstate = [](py::tuple const& state)
+    auto outputConfigSetstate = [](tle::OutputConfig& outputConfig, nb::tuple const& state)
     {
         if (state.size() != 7)
         {
             throw std::runtime_error("Invalid OutputConfig state!");
         }
-        return tle::OutputConfig(state[0].cast<bool>(), state[1].cast<bool>(), state[2].cast<bool>(),
-            state[3].cast<bool>(), state[4].cast<bool>(), state[5].cast<bool>(),
-            state[6].cast<std::optional<std::vector<tle::AdditionalModelOutput>>>());
+        new (&outputConfig) tle::OutputConfig(nb::cast<bool>(state[0]), nb::cast<bool>(state[1]),
+            nb::cast<bool>(state[2]), nb::cast<bool>(state[3]), nb::cast<bool>(state[4]), nb::cast<bool>(state[5]),
+            nb::cast<std::optional<std::vector<tle::AdditionalModelOutput>>>(state[6]));
     };
-    py::class_<tle::OutputConfig>(m, "OutputConfig")
-        .def(py::init<bool, bool, bool, bool, bool, bool, std::optional<std::vector<tle::AdditionalModelOutput>>>(),
-            py::arg("return_log_probs") = false, py::arg("return_context_logits") = false,
-            py::arg("return_generation_logits") = false, py::arg("exclude_input_from_output") = false,
-            py::arg("return_encoder_output") = false, py::arg("return_perf_metrics") = false,
-            py::arg("additional_model_outputs") = py::none())
-        .def_readwrite("return_log_probs", &tle::OutputConfig::returnLogProbs)
-        .def_readwrite("return_context_logits", &tle::OutputConfig::returnContextLogits)
-        .def_readwrite("return_generation_logits", &tle::OutputConfig::returnGenerationLogits)
-        .def_readwrite("exclude_input_from_output", &tle::OutputConfig::excludeInputFromOutput)
-        .def_readwrite("return_encoder_output", &tle::OutputConfig::returnEncoderOutput)
-        .def_readwrite("return_perf_metrics", &tle::OutputConfig::returnPerfMetrics)
-        .def_readwrite("additional_model_outputs", &tle::OutputConfig::additionalModelOutputs)
-        .def(py::pickle(outputConfigGetstate, outputConfigSetstate));
+    nb::class_<tle::OutputConfig>(m, "OutputConfig")
+        .def(nb::init<bool, bool, bool, bool, bool, bool, std::optional<std::vector<tle::AdditionalModelOutput>>>(),
+            nb::arg("return_log_probs").none() = false, nb::arg("return_context_logits") = false,
+            nb::arg("return_generation_logits") = false, nb::arg("exclude_input_from_output") = false,
+            nb::arg("return_encoder_output") = false, nb::arg("return_perf_metrics") = false,
+            nb::arg("additional_model_outputs") = nb::none())
+        .def_rw("return_log_probs", &tle::OutputConfig::returnLogProbs)
+        .def_rw("return_context_logits", &tle::OutputConfig::returnContextLogits)
+        .def_rw("return_generation_logits", &tle::OutputConfig::returnGenerationLogits)
+        .def_rw("exclude_input_from_output", &tle::OutputConfig::excludeInputFromOutput)
+        .def_rw("return_encoder_output", &tle::OutputConfig::returnEncoderOutput)
+        .def_rw("return_perf_metrics", &tle::OutputConfig::returnPerfMetrics)
+        .def_rw("additional_model_outputs", &tle::OutputConfig::additionalModelOutputs)
+        .def("__getstate__", outputConfigGetstate)
+        .def("__setstate__", outputConfigSetstate);
 
     auto externalDraftTokensConfigGetstate = [](tle::ExternalDraftTokensConfig const& self)
-    { return py::make_tuple(self.getTokens(), self.getLogits(), self.getAcceptanceThreshold()); };
-    auto externalDraftTokensConfigSetstate = [](py::tuple const& state)
+    { return nb::make_tuple(self.getTokens(), self.getLogits(), self.getAcceptanceThreshold()); };
+    auto externalDraftTokensConfigSetstate
+        = [](tle::ExternalDraftTokensConfig& externalDraftTokensConfig, nb::tuple const& state)
     {
         if (state.size() != 3)
         {
             throw std::runtime_error("Invalid ExternalDraftTokensConfig state!");
         }
-        return tle::ExternalDraftTokensConfig(state[0].cast<VecTokens>(), state[1].cast<std::optional<Tensor>>(),
-            state[2].cast<std::optional<FloatType>>());
+        new (&externalDraftTokensConfig) tle::ExternalDraftTokensConfig(nb::cast<VecTokens>(state[0]),
+            nb::cast<std::optional<Tensor>>(state[1]), nb::cast<std::optional<FloatType>>(state[2]));
     };
-    py::class_<tle::ExternalDraftTokensConfig>(m, "ExternalDraftTokensConfig")
-        .def(py::init<VecTokens, std::optional<Tensor>, std::optional<FloatType> const&, std::optional<bool>>(),
-            py::arg("tokens"), py::arg("logits") = py::none(), py::arg("acceptance_threshold") = py::none(),
-            py::arg("fast_logits") = py::none())
-        .def_property_readonly("tokens", &tle::ExternalDraftTokensConfig::getTokens)
-        .def_property_readonly("logits", &tle::ExternalDraftTokensConfig::getLogits)
-        .def_property_readonly("acceptance_threshold", &tle::ExternalDraftTokensConfig::getAcceptanceThreshold)
-        .def(py::pickle(externalDraftTokensConfigGetstate, externalDraftTokensConfigSetstate))
-        .def_property_readonly("fast_logits", &tle::ExternalDraftTokensConfig::getFastLogits);
+    nb::class_<tle::ExternalDraftTokensConfig>(m, "ExternalDraftTokensConfig")
+        .def(nb::init<VecTokens, std::optional<Tensor>, std::optional<FloatType> const&, std::optional<bool>>(),
+            nb::arg("tokens"), nb::arg("logits") = nb::none(), nb::arg("acceptance_threshold") = nb::none(),
+            nb::arg("fast_logits") = nb::none())
+        .def_prop_ro("tokens", &tle::ExternalDraftTokensConfig::getTokens)
+        .def_prop_ro("logits", &tle::ExternalDraftTokensConfig::getLogits)
+        .def_prop_ro("acceptance_threshold", &tle::ExternalDraftTokensConfig::getAcceptanceThreshold)
+        .def("__getstate__", externalDraftTokensConfigGetstate)
+        .def("__setstate__", externalDraftTokensConfigSetstate)
+        .def_prop_ro("fast_logits", &tle::ExternalDraftTokensConfig::getFastLogits);
 
     auto promptTuningConfigGetstate = [](tle::PromptTuningConfig const& self)
-    { return py::make_tuple(self.getEmbeddingTable(), self.getInputTokenExtraIds()); };
-    auto promptTuningConfigSetstate = [](py::tuple const& state)
+    { return nb::make_tuple(self.getEmbeddingTable(), self.getInputTokenExtraIds()); };
+    auto promptTuningConfigSetstate = [](tle::PromptTuningConfig& promptTuningConfig, nb::tuple const& state)
     {
         if (state.size() != 2)
         {
             throw std::runtime_error("Invalid PromptTuningConfig state!");
         }
-        return tle::PromptTuningConfig(state[0].cast<Tensor>(), state[1].cast<std::optional<VecTokenExtraIds>>());
+        new (&promptTuningConfig)
+            tle::PromptTuningConfig(nb::cast<Tensor>(state[0]), nb::cast<std::optional<VecTokenExtraIds>>(state[1]));
     };
-    py::class_<tle::PromptTuningConfig>(m, "PromptTuningConfig")
-        .def(py::init<Tensor, std::optional<VecTokenExtraIds>>(), py::arg("embedding_table"),
-            py::arg("input_token_extra_ids") = py::none())
-        .def_property_readonly("embedding_table", &tle::PromptTuningConfig::getEmbeddingTable)
-        .def_property_readonly("input_token_extra_ids", &tle::PromptTuningConfig::getInputTokenExtraIds)
-        .def(py::pickle(promptTuningConfigGetstate, promptTuningConfigSetstate));
+    nb::class_<tle::PromptTuningConfig>(m, "PromptTuningConfig")
+        .def(nb::init<Tensor, std::optional<VecTokenExtraIds>>(), nb::arg("embedding_table"),
+            nb::arg("input_token_extra_ids") = nb::none())
+        .def_prop_ro("embedding_table", &tle::PromptTuningConfig::getEmbeddingTable)
+        .def_prop_ro("input_token_extra_ids", &tle::PromptTuningConfig::getInputTokenExtraIds)
+        .def("__getstate__", promptTuningConfigGetstate)
+        .def("__setstate__", promptTuningConfigSetstate);
 
     auto loraConfigGetstate = [](tle::LoraConfig const& self)
-    { return py::make_tuple(self.getTaskId(), self.getWeights(), self.getConfig()); };
-    auto loraConfigSetstate = [](py::tuple const& state)
+    { return nb::make_tuple(self.getTaskId(), self.getWeights(), self.getConfig()); };
+    auto loraConfigSetstate = [](tle::LoraConfig& loraConfig, nb::tuple const& state)
     {
         if (state.size() != 3)
         {
             throw std::runtime_error("Invalid LoraConfig state!");
         }
-        return tle::LoraConfig(
-            state[0].cast<IdType>(), state[1].cast<std::optional<Tensor>>(), state[2].cast<std::optional<Tensor>>());
+        new (&loraConfig) tle::LoraConfig(nb::cast<IdType>(state[0]), nb::cast<std::optional<Tensor>>(state[1]),
+            nb::cast<std::optional<Tensor>>(state[2]));
     };
-    py::class_<tle::LoraConfig>(m, "LoraConfig")
-        .def(py::init<uint64_t, std::optional<Tensor>, std::optional<Tensor>>(), py::arg("task_id"),
-            py::arg("weights") = py::none(), py::arg("config") = py::none())
-        .def_property_readonly("task_id", &tle::LoraConfig::getTaskId)
-        .def_property_readonly("weights", &tle::LoraConfig::getWeights)
-        .def_property_readonly("config", &tle::LoraConfig::getConfig)
-        .def(py::pickle(loraConfigGetstate, loraConfigSetstate));
+    nb::class_<tle::LoraConfig>(m, "LoraConfig")
+        .def(nb::init<uint64_t, std::optional<Tensor>, std::optional<Tensor>>(), nb::arg("task_id"),
+            nb::arg("weights") = nb::none(), nb::arg("config") = nb::none())
+        .def_prop_ro("task_id", &tle::LoraConfig::getTaskId)
+        .def_prop_ro("weights", &tle::LoraConfig::getWeights)
+        .def_prop_ro("config", &tle::LoraConfig::getConfig)
+        .def("__getstate__", loraConfigGetstate)
+        .def("__setstate__", loraConfigSetstate);
 
     auto multimodalInputGetstate = [](tle::MultimodalInput const& self)
-    { return py::make_tuple(self.getMultimodalHashes(), self.getMultimodalPositions(), self.getMultimodalLengths()); };
-    auto multimodalInputSetstate = [](py::tuple const& state)
+    { return nb::make_tuple(self.getMultimodalHashes(), self.getMultimodalPositions(), self.getMultimodalLengths()); };
+    auto multimodalInputSetstate = [](tle::MultimodalInput& multimodalInput, nb::tuple const& state)
     {
         if (state.size() != 3)
         {
             throw std::runtime_error("Invalid MultimodalInput state!");
         }
-        return tle::MultimodalInput(state[0].cast<std::vector<std::vector<SizeType32>>>(),
-            state[1].cast<std::vector<SizeType32>>(), state[2].cast<std::vector<SizeType32>>());
+        new (&multimodalInput) tle::MultimodalInput(nb::cast<std::vector<std::vector<SizeType32>>>(state[0]),
+            nb::cast<std::vector<SizeType32>>(state[1]), nb::cast<std::vector<SizeType32>>(state[2]));
     };
-    py::class_<tle::MultimodalInput>(m, "MultimodalInput")
-        .def(py::init<std::vector<std::vector<SizeType32>>, std::vector<SizeType32>, std::vector<SizeType32>>(),
-            py::arg("multimodal_hashes"), py::arg("multimodal_positions"), py::arg("multimodal_lengths"))
-        .def_property_readonly("multimodal_hashes", &tle::MultimodalInput::getMultimodalHashes)
-        .def_property_readonly("multimodal_positions", &tle::MultimodalInput::getMultimodalPositions)
-        .def_property_readonly("multimodal_lengths", &tle::MultimodalInput::getMultimodalLengths)
-        .def(py::pickle(multimodalInputGetstate, multimodalInputSetstate));
+    nb::class_<tle::MultimodalInput>(m, "MultimodalInput")
+        .def(nb::init<std::vector<std::vector<SizeType32>>, std::vector<SizeType32>, std::vector<SizeType32>>(),
+            nb::arg("multimodal_hashes"), nb::arg("multimodal_positions"), nb::arg("multimodal_lengths"))
+        .def_prop_ro("multimodal_hashes", &tle::MultimodalInput::getMultimodalHashes)
+        .def_prop_ro("multimodal_positions", &tle::MultimodalInput::getMultimodalPositions)
+        .def_prop_ro("multimodal_lengths", &tle::MultimodalInput::getMultimodalLengths)
+        .def("__getstate__", multimodalInputGetstate)
+        .def("__setstate__", multimodalInputSetstate);
 
     auto MropeConfigGetstate = [](tle::MropeConfig const& self)
-    { return py::make_tuple(self.getMRopeRotaryCosSin(), self.getMRopePositionDeltas()); };
-    auto MropeConfigSetstate = [](py::tuple const& state)
+    { return nb::make_tuple(self.getMRopeRotaryCosSin(), self.getMRopePositionDeltas()); };
+    auto MropeConfigSetstate = [](tle::MropeConfig& mropeConfig, nb::tuple const& state)
     {
         if (state.size() != 2)
         {
             throw std::runtime_error("Invalid MropeConfig state!");
         }
-        return tle::MropeConfig(state[0].cast<tle::Tensor>(), state[1].cast<SizeType32>());
+        new (&mropeConfig) tle::MropeConfig(nb::cast<tle::Tensor>(state[0]), nb::cast<SizeType32>(state[1]));
     };
-    py::class_<tle::MropeConfig>(m, "MropeConfig")
-        .def(py::init<Tensor, SizeType32>(), py::arg("mrope_rotary_cos_sin"), py::arg("mrope_position_deltas"))
-        .def_property_readonly("mrope_rotary_cos_sin", &tle::MropeConfig::getMRopeRotaryCosSin)
-        .def_property_readonly("mrope_position_deltas", &tle::MropeConfig::getMRopePositionDeltas)
-        .def(py::pickle(MropeConfigGetstate, MropeConfigSetstate));
+    nb::class_<tle::MropeConfig>(m, "MropeConfig")
+        .def(nb::init<Tensor, SizeType32>(), nb::arg("mrope_rotary_cos_sin"), nb::arg("mrope_position_deltas"))
+        .def_prop_ro("mrope_rotary_cos_sin", &tle::MropeConfig::getMRopeRotaryCosSin)
+        .def_prop_ro("mrope_position_deltas", &tle::MropeConfig::getMRopePositionDeltas)
+        .def("__getstate__", MropeConfigGetstate)
+        .def("__setstate__", MropeConfigSetstate);
 
     auto lookaheadDecodingConfigGetstate = [](tle::LookaheadDecodingConfig const& self)
-    { return py::make_tuple(self.getWindowSize(), self.getNgramSize(), self.getVerificationSetSize()); };
-    auto lookaheadDecodingConfigSetstate = [](py::tuple const& state)
+    { return nb::make_tuple(self.getWindowSize(), self.getNgramSize(), self.getVerificationSetSize()); };
+    auto lookaheadDecodingConfigSetstate
+        = [](tle::LookaheadDecodingConfig& lookaheadDecodingConfig, nb::tuple const& state)
     {
         if (state.size() != 3)
         {
             throw std::runtime_error("Invalid LookaheadDecodingConfig state!");
         }
-        return tle::LookaheadDecodingConfig(
-            state[0].cast<SizeType32>(), state[1].cast<SizeType32>(), state[2].cast<SizeType32>());
+        new (&lookaheadDecodingConfig) tle::LookaheadDecodingConfig(
+            nb::cast<SizeType32>(state[0]), nb::cast<SizeType32>(state[1]), nb::cast<SizeType32>(state[2]));
     };
-    py::class_<tle::LookaheadDecodingConfig>(m, "LookaheadDecodingConfig")
-        .def(py::init<SizeType32, SizeType32, SizeType32>(), py::arg("max_window_size"), py::arg("max_ngram_size"),
-            py::arg("max_verification_set_size"))
-        .def_property_readonly("max_window_size", &tle::LookaheadDecodingConfig::getWindowSize)
-        .def_property_readonly("max_ngram_size", &tle::LookaheadDecodingConfig::getNgramSize)
-        .def_property_readonly("max_verification_set_size", &tle::LookaheadDecodingConfig::getVerificationSetSize)
+    nb::class_<tle::LookaheadDecodingConfig>(m, "LookaheadDecodingConfig")
+        .def(nb::init<SizeType32, SizeType32, SizeType32>(), nb::arg("max_window_size"), nb::arg("max_ngram_size"),
+            nb::arg("max_verification_set_size"))
+        .def_prop_ro("max_window_size", &tle::LookaheadDecodingConfig::getWindowSize)
+        .def_prop_ro("max_ngram_size", &tle::LookaheadDecodingConfig::getNgramSize)
+        .def_prop_ro("max_verification_set_size", &tle::LookaheadDecodingConfig::getVerificationSetSize)
         .def("calculate_speculative_resource", &tle::LookaheadDecodingConfig::calculateSpeculativeResource)
         .def_static(
             "calculate_speculative_resource_tuple", &tle::LookaheadDecodingConfig::calculateSpeculativeResourceTuple)
-        .def(py::pickle(lookaheadDecodingConfigGetstate, lookaheadDecodingConfigSetstate))
+        .def("__getstate__", lookaheadDecodingConfigGetstate)
+        .def("__setstate__", lookaheadDecodingConfigSetstate)
         .def_static("get_default_lookahead_decoding_window",
             []() { return tle::LookaheadDecodingConfig::kDefaultLookaheadDecodingWindow; })
         .def_static("get_default_lookahead_decoding_ngram",
@@ -339,65 +354,68 @@ void initRequestBindings(pybind11::module_& m)
             []() { return tle::LookaheadDecodingConfig::kDefaultLookaheadDecodingVerificationSet; });
 
     auto TokenRangeRetentionConfigGetstate = [](tle::KvCacheRetentionConfig::TokenRangeRetentionConfig const& self)
-    { return py::make_tuple(self.tokenStart, self.tokenEnd, self.priority, self.durationMs); };
-    auto TokenRangeRetentionConfigSetstate = [](py::tuple const& state)
+    { return nb::make_tuple(self.tokenStart, self.tokenEnd, self.priority, self.durationMs); };
+    auto TokenRangeRetentionConfigSetstate
+        = [](tle::KvCacheRetentionConfig::TokenRangeRetentionConfig& tokenRangeRetentionConfig, nb::tuple const& state)
     {
         if (state.size() != 4)
         {
             throw std::runtime_error("Invalid state!");
         }
-        return tle::KvCacheRetentionConfig::TokenRangeRetentionConfig(state[0].cast<SizeType32>(),
-            state[1].cast<std::optional<SizeType32>>(), state[2].cast<tle::RetentionPriority>(),
-            state[3].cast<std::optional<std::chrono::milliseconds>>());
+        new (&tokenRangeRetentionConfig) tle::KvCacheRetentionConfig::TokenRangeRetentionConfig(
+            nb::cast<SizeType32>(state[0]), nb::cast<std::optional<SizeType32>>(state[1]),
+            nb::cast<tle::RetentionPriority>(state[2]), nb::cast<std::optional<std::chrono::milliseconds>>(state[3]));
     };
     auto kvCacheRetentionConfigGetstate = [](tle::KvCacheRetentionConfig const& self)
     {
-        return py::make_tuple(self.getTokenRangeRetentionConfigs(), self.getDecodeRetentionPriority(),
+        return nb::make_tuple(self.getTokenRangeRetentionConfigs(), self.getDecodeRetentionPriority(),
             self.getDecodeDurationMs(), self.getTransferMode(), self.getDirectory());
     };
-    auto kvCacheRetentionConfigSetstate = [](py::tuple const& state)
+    auto kvCacheRetentionConfigSetstate
+        = [](tle::KvCacheRetentionConfig& kvCacheRetentionConfig, nb::tuple const& state)
     {
         if (state.size() != 5)
         {
             throw std::runtime_error("Invalid state!");
         }
-        return tle::KvCacheRetentionConfig(
-            state[0].cast<std::vector<tle::KvCacheRetentionConfig::TokenRangeRetentionConfig>>(),
-            state[1].cast<tle::RetentionPriority>(), state[2].cast<std::optional<std::chrono::milliseconds>>(),
-            state[3].cast<tle::KvCacheTransferMode>(), state[4].cast<std::optional<std::string>>());
+        new (&kvCacheRetentionConfig) tle::KvCacheRetentionConfig(
+            nb::cast<std::vector<tle::KvCacheRetentionConfig::TokenRangeRetentionConfig>>(state[0]),
+            nb::cast<tle::RetentionPriority>(state[1]), nb::cast<std::optional<std::chrono::milliseconds>>(state[2]),
+            nb::cast<tle::KvCacheTransferMode>(state[3]), nb::cast<std::optional<std::string>>(state[4]));
     };
 
-    auto kvCacheRetentionConfig = py::class_<tle::KvCacheRetentionConfig>(m, "KvCacheRetentionConfig");
+    auto kvCacheRetentionConfig = nb::class_<tle::KvCacheRetentionConfig>(m, "KvCacheRetentionConfig");
 
-    py::class_<tle::KvCacheRetentionConfig::TokenRangeRetentionConfig>(
+    nb::class_<tle::KvCacheRetentionConfig::TokenRangeRetentionConfig>(
         kvCacheRetentionConfig, "TokenRangeRetentionConfig")
-        .def(py::init<SizeType32, std::optional<SizeType32>, tle::RetentionPriority,
+        .def(nb::init<SizeType32, std::optional<SizeType32>, tle::RetentionPriority,
                  std::optional<std::chrono::milliseconds>>(),
-            py::arg("token_start"), py::arg("token_end"), py::arg("priority"), py::arg("duration_ms") = py::none())
-        .def_readwrite("token_start", &tle::KvCacheRetentionConfig::TokenRangeRetentionConfig::tokenStart)
-        .def_readwrite("token_end", &tle::KvCacheRetentionConfig::TokenRangeRetentionConfig::tokenEnd)
-        .def_readwrite("priority", &tle::KvCacheRetentionConfig::TokenRangeRetentionConfig::priority)
-        .def_readwrite("duration_ms", &tle::KvCacheRetentionConfig::TokenRangeRetentionConfig::durationMs)
-        .def(py::pickle(TokenRangeRetentionConfigGetstate, TokenRangeRetentionConfigSetstate))
+            nb::arg("token_start"), nb::arg("token_end"), nb::arg("priority"), nb::arg("duration_ms") = nb::none())
+        .def_rw("token_start", &tle::KvCacheRetentionConfig::TokenRangeRetentionConfig::tokenStart)
+        .def_rw("token_end", &tle::KvCacheRetentionConfig::TokenRangeRetentionConfig::tokenEnd)
+        .def_rw("priority", &tle::KvCacheRetentionConfig::TokenRangeRetentionConfig::priority)
+        .def_rw("duration_ms", &tle::KvCacheRetentionConfig::TokenRangeRetentionConfig::durationMs)
+        .def("__getstate__", TokenRangeRetentionConfigGetstate)
+        .def("__setstate__", TokenRangeRetentionConfigSetstate)
         .def("__eq__", &tle::KvCacheRetentionConfig::TokenRangeRetentionConfig::operator==);
 
     // There's a circular dependency between the declaration of the TokenRangeRetentionPriority and
     // KvCacheRetentionConfig bindings. Defer definition of the KvCacheRetentionConfig bindings until the
     // TokenRangeRetentionPriority bindings have been defined.
     kvCacheRetentionConfig
-        .def(py::init<std::vector<tle::KvCacheRetentionConfig::TokenRangeRetentionConfig>, tle::RetentionPriority,
+        .def(nb::init<std::vector<tle::KvCacheRetentionConfig::TokenRangeRetentionConfig>, tle::RetentionPriority,
                  std::optional<std::chrono::milliseconds>, tle::KvCacheTransferMode, std::optional<std::string>>(),
-            py::arg("token_range_retention_configs"),
-            py::arg("decode_retention_priority") = tle::KvCacheRetentionConfig::kDefaultRetentionPriority,
-            py::arg("decode_duration_ms") = py::none(),
-            py::arg_v("transfer_mode", tle::KvCacheTransferMode::DRAM, "DRAM"), py::arg("directory") = py::none())
-        .def_property_readonly(
-            "token_range_retention_configs", &tle::KvCacheRetentionConfig::getTokenRangeRetentionConfigs)
-        .def_property_readonly("decode_retention_priority", &tle::KvCacheRetentionConfig::getDecodeRetentionPriority)
-        .def_property_readonly("decode_duration_ms", &tle::KvCacheRetentionConfig::getDecodeDurationMs)
-        .def_property_readonly("transfer_mode", &tle::KvCacheRetentionConfig::getTransferMode)
-        .def_property_readonly("directory", &tle::KvCacheRetentionConfig::getDirectory)
-        .def(py::pickle(kvCacheRetentionConfigGetstate, kvCacheRetentionConfigSetstate))
+            nb::arg("token_range_retention_configs"),
+            nb::arg("decode_retention_priority") = tle::KvCacheRetentionConfig::kDefaultRetentionPriority,
+            nb::arg("decode_duration_ms") = nb::none(), nb::arg("transfer_mode") = tle::KvCacheTransferMode::DRAM,
+            nb::arg("directory") = nb::none())
+        .def_prop_ro("token_range_retention_configs", &tle::KvCacheRetentionConfig::getTokenRangeRetentionConfigs)
+        .def_prop_ro("decode_retention_priority", &tle::KvCacheRetentionConfig::getDecodeRetentionPriority)
+        .def_prop_ro("decode_duration_ms", &tle::KvCacheRetentionConfig::getDecodeDurationMs)
+        .def_prop_ro("transfer_mode", &tle::KvCacheRetentionConfig::getTransferMode)
+        .def_prop_ro("directory", &tle::KvCacheRetentionConfig::getDirectory)
+        .def("__getstate__", kvCacheRetentionConfigGetstate)
+        .def("__setstate__", kvCacheRetentionConfigSetstate)
         .def("__eq__", &tle::KvCacheRetentionConfig::operator==);
 
     auto ContextPhaseParamsGetState = [](tle::ContextPhaseParams const& self)
@@ -405,13 +423,13 @@ void initRequestBindings(pybind11::module_& m)
         if (self.getState() != nullptr)
         {
             auto serializedState = self.getSerializedState();
-            return py::make_tuple(self.getFirstGenTokens(), self.getReqId(),
-                py::bytes(serializedState.data(), serializedState.size()), self.getDraftTokens());
+            return nb::make_tuple(self.getFirstGenTokens(), self.getReqId(),
+                nb::bytes(serializedState.data(), serializedState.size()), self.getDraftTokens());
         }
-        return py::make_tuple(self.getFirstGenTokens(), self.getReqId(), py::none(), self.getDraftTokens());
+        return nb::make_tuple(self.getFirstGenTokens(), self.getReqId(), nb::none(), self.getDraftTokens());
     };
 
-    auto ContextPhaseParamsSetState = [](py::tuple const& state)
+    auto ContextPhaseParamsSetState = [](tle::ContextPhaseParams& contextPhaseParams, nb::tuple const& state)
     {
         if (state.size() != 4)
         {
@@ -419,76 +437,84 @@ void initRequestBindings(pybind11::module_& m)
         }
         if (!state[2].is_none())
         {
-            auto opaque_state = state[2].cast<py::bytes>();
-            auto opaque_state_str_view = std::string_view(opaque_state.cast<std::string_view>());
-            return std::make_unique<tle::ContextPhaseParams>(state[0].cast<VecTokens>(),
-                state[1].cast<tle::ContextPhaseParams::RequestIdType>(),
+            auto opaque_state = nb::cast<nb::bytes>(state[2]);
+            auto opaque_state_str_view = std::string_view(opaque_state.c_str(), opaque_state.size());
+            new (&contextPhaseParams) tle::ContextPhaseParams(nb::cast<VecTokens>(state[0]),
+                nb::cast<tle::ContextPhaseParams::RequestIdType>(state[1]),
                 std::vector<char>(opaque_state_str_view.begin(), opaque_state_str_view.end()),
-                state[3].cast<std::optional<VecTokens>>());
+                nb::cast<std::optional<VecTokens>>(state[3]));
         }
-        return std::make_unique<tle::ContextPhaseParams>(state[0].cast<VecTokens>(),
-            state[1].cast<tle::ContextPhaseParams::RequestIdType>(), state[3].cast<std::optional<VecTokens>>());
+        new (&contextPhaseParams) tle::ContextPhaseParams(nb::cast<VecTokens>(state[0]),
+            nb::cast<tle::ContextPhaseParams::RequestIdType>(state[1]), nb::cast<std::optional<VecTokens>>(state[3]));
     };
 
-    py::class_<tle::ContextPhaseParams>(m, "ContextPhaseParams")
-        .def(py::init(
-            [](VecTokens const& first_gen_tokens, tle::ContextPhaseParams::RequestIdType req_id,
-                std::optional<py::bytes> const& opaque_state, std::optional<VecTokens> const& draft_tokens)
+    nb::class_<tle::ContextPhaseParams>(m, "ContextPhaseParams")
+        .def("__init__",
+            [](tle::ContextPhaseParams const& self, VecTokens const& first_gen_tokens,
+                tle::ContextPhaseParams::RequestIdType req_id, std::optional<nb::bytes> const& opaque_state,
+                std::optional<VecTokens> const& draft_tokens)
             {
                 if (opaque_state)
                 {
-                    auto opaque_state_str_view = std::string_view(opaque_state.value().cast<std::string_view>());
+                    auto opaque_state_str_view
+                        = std::string_view(opaque_state.value().c_str(), opaque_state.value().size());
                     return std::make_unique<tle::ContextPhaseParams>(first_gen_tokens, req_id,
                         std::vector<char>(opaque_state_str_view.begin(), opaque_state_str_view.end()), draft_tokens);
                 }
                 return std::make_unique<tle::ContextPhaseParams>(first_gen_tokens, req_id, draft_tokens);
-            }))
-        .def_property_readonly("first_gen_tokens", &tle::ContextPhaseParams::getFirstGenTokens)
-        .def_property_readonly("draft_tokens", &tle::ContextPhaseParams::getDraftTokens)
-        .def_property_readonly("req_id", &tle::ContextPhaseParams::getReqId)
-        .def_property_readonly("opaque_state",
+            })
+        .def_prop_ro("first_gen_tokens", [](tle::ContextPhaseParams const& self) { return self.getFirstGenTokens(); })
+        .def_prop_ro("draft_tokens", [](tle::ContextPhaseParams const& self) { return self.getDraftTokens(); })
+        // .def("draft_tokens", &tle::ContextPhaseParams::getDraftTokens, nb::rv_policy::reference_internal)
+        // .def("first_gen_tokens", &tle::ContextPhaseParams::getFirstGenTokens,
+        // nb::rv_policy::reference_internal)//todo
+        .def_prop_ro("req_id", &tle::ContextPhaseParams::getReqId)
+        .def_prop_ro("opaque_state",
             [](tle::ContextPhaseParams const& self)
             {
-                std::optional<py::bytes> opaque_state{std::nullopt};
+                std::optional<nb::bytes> opaque_state{std::nullopt};
                 if (self.getState() != nullptr)
                 {
                     auto serializedState = self.getSerializedState();
-                    opaque_state = py::bytes(serializedState.data(), serializedState.size());
+                    opaque_state = nb::bytes(serializedState.data(), serializedState.size());
                 }
                 return opaque_state;
             })
-        .def(py::pickle(ContextPhaseParamsGetState, ContextPhaseParamsSetState));
+        .def("__getstate__", ContextPhaseParamsGetState)
+        .def("__setstate__", ContextPhaseParamsSetState);
 
     auto EagleDecodingConfigGetstate = [](tle::EagleConfig const& self)
     {
-        return py::make_tuple(self.getEagleChoices(), self.isGreedySampling(), self.getPosteriorThreshold(),
+        return nb::make_tuple(self.getEagleChoices(), self.isGreedySampling(), self.getPosteriorThreshold(),
             self.useDynamicTree(), self.getDynamicTreeMaxTopK());
     };
-    auto EagleDecodingConfigSetstate = [](py::tuple const& state)
+    auto EagleDecodingConfigSetstate = [](tle::EagleConfig& eagleConfig, nb::tuple const& state)
     {
         if (state.size() != 5)
         {
             throw std::runtime_error("Invalid EagleConfig state!");
         }
-        return tle::EagleConfig(state[0].cast<std::optional<tle::EagleChoices>>(), state[1].cast<bool>(),
-            state[2].cast<std::optional<float>>(), state[3].cast<bool>(), state[4].cast<std::optional<SizeType32>>());
+        new (&eagleConfig) tle::EagleConfig(nb::cast<std::optional<tle::EagleChoices>>(state[0]),
+            nb::cast<bool>(state[1]), nb::cast<std::optional<float>>(state[2]), nb::cast<bool>(state[3]),
+            nb::cast<std::optional<SizeType32>>(state[4]));
     };
-    py::class_<tle::EagleConfig>(m, "EagleConfig")
-        .def(py::init<std::optional<tle::EagleChoices>, bool, std::optional<float>, bool, std::optional<SizeType32>>(),
-            py::arg("eagle_choices") = py::none(), py::arg("greedy_sampling") = true,
-            py::arg("posterior_threshold") = py::none(), py::arg("use_dynamic_tree") = false,
-            py::arg("dynamic_tree_max_topK") = py::none())
-        .def_property_readonly("eagle_choices", &tle::EagleConfig::getEagleChoices)
-        .def_property_readonly("greedy_sampling", &tle::EagleConfig::isGreedySampling)
-        .def_property_readonly("posterior_threshold", &tle::EagleConfig::getPosteriorThreshold)
-        .def_property_readonly("use_dynamic_tree", &tle::EagleConfig::useDynamicTree)
-        .def_property_readonly("dynamic_tree_max_topK", &tle::EagleConfig::getDynamicTreeMaxTopK)
-        .def(py::pickle(EagleDecodingConfigGetstate, EagleDecodingConfigSetstate));
+    nb::class_<tle::EagleConfig>(m, "EagleConfig")
+        .def(nb::init<std::optional<tle::EagleChoices>, bool, std::optional<float>, bool, std::optional<SizeType32>>(),
+            nb::arg("eagle_choices") = nb::none(), nb::arg("greedy_sampling") = true,
+            nb::arg("posterior_threshold") = nb::none(), nb::arg("use_dynamic_tree") = false,
+            nb::arg("dynamic_tree_max_topK") = nb::none())
+        .def_prop_ro("eagle_choices", &tle::EagleConfig::getEagleChoices)
+        .def_prop_ro("greedy_sampling", &tle::EagleConfig::isGreedySampling)
+        .def_prop_ro("posterior_threshold", &tle::EagleConfig::getPosteriorThreshold)
+        .def_prop_ro("use_dynamic_tree", &tle::EagleConfig::useDynamicTree)
+        .def_prop_ro("dynamic_tree_max_topK", &tle::EagleConfig::getDynamicTreeMaxTopK)
+        .def("__getstate__", EagleDecodingConfigGetstate)
+        .def("__setstate__", EagleDecodingConfigSetstate);
 
     // Guided decoding params
-    auto pyGuidedDecodingParams = py::class_<tle::GuidedDecodingParams>(m, "GuidedDecodingParams");
+    auto pyGuidedDecodingParams = nb::class_<tle::GuidedDecodingParams>(m, "GuidedDecodingParams");
 
-    py::enum_<tle::GuidedDecodingParams::GuideType>(pyGuidedDecodingParams, "GuideType")
+    nb::enum_<tle::GuidedDecodingParams::GuideType>(pyGuidedDecodingParams, "GuideType")
         .value("JSON", tle::GuidedDecodingParams::GuideType::kJSON)
         .value("JSON_SCHEMA", tle::GuidedDecodingParams::GuideType::kJSON_SCHEMA)
         .value("REGEX", tle::GuidedDecodingParams::GuideType::kREGEX)
@@ -496,28 +522,29 @@ void initRequestBindings(pybind11::module_& m)
         .value("STRUCTURAL_TAG", tle::GuidedDecodingParams::GuideType::kSTRUCTURAL_TAG);
 
     auto guidedDecodingParamsGetstate
-        = [](tle::GuidedDecodingParams const& self) { return py::make_tuple(self.getGuideType(), self.getGuide()); };
+        = [](tle::GuidedDecodingParams const& self) { return nb::make_tuple(self.getGuideType(), self.getGuide()); };
 
-    auto guidedDecodingParamsSetstate = [](py::tuple state)
+    auto guidedDecodingParamsSetstate = [](tle::GuidedDecodingParams& guidedDecodingParams, nb::tuple const& state)
     {
         if (state.size() != 2)
         {
             throw std::runtime_error("Invalid GuidedDecodingParams state!");
         }
-        return tle::GuidedDecodingParams(
-            state[0].cast<tle::GuidedDecodingParams::GuideType>(), state[1].cast<std::optional<std::string>>());
+        new (&guidedDecodingParams) tle::GuidedDecodingParams(
+            nb::cast<tle::GuidedDecodingParams::GuideType>(state[0]), nb::cast<std::optional<std::string>>(state[1]));
     };
 
     pyGuidedDecodingParams
-        .def(py::init<tle::GuidedDecodingParams::GuideType, std::optional<std::string>>(), py::arg("guide_type"),
-            py::arg("guide") = py::none())
-        .def_property_readonly("guide_type", &tle::GuidedDecodingParams::getGuideType)
-        .def_property_readonly("guide", &tle::GuidedDecodingParams::getGuide)
-        .def(py::pickle(guidedDecodingParamsGetstate, guidedDecodingParamsSetstate));
+        .def(nb::init<tle::GuidedDecodingParams::GuideType, std::optional<std::string>>(), nb::arg("guide_type"),
+            nb::arg("guide") = nb::none())
+        .def_prop_ro("guide_type", &tle::GuidedDecodingParams::getGuideType)
+        .def_prop_ro("guide", &tle::GuidedDecodingParams::getGuide)
+        .def("__getstate__", guidedDecodingParamsGetstate)
+        .def("__setstate__", guidedDecodingParamsSetstate);
 
     auto requestGetstate = [](tle::Request const& self)
     {
-        return py::make_tuple(self.getInputTokenIds(), self.getMaxTokens(), self.getStreaming(),
+        return nb::make_tuple(self.getInputTokenIds(), self.getMaxTokens(), self.getStreaming(),
             self.getSamplingConfig(), self.getOutputConfig(), self.getEndId(), self.getPadId(), self.getPositionIds(),
             self.getBadWords(), self.getStopWords(), self.getEmbeddingBias(), self.getExternalDraftTokensConfig(),
             self.getPromptTuningConfig(), self.getMultimodalInput(), self.getMultimodalEmbedding(),
@@ -528,34 +555,38 @@ void initRequestBindings(pybind11::module_& m)
             self.getCrossAttentionMask(), self.getEagleConfig(), self.getSkipCrossAttnBlocks(),
             self.getGuidedDecodingParams());
     };
-    auto requestSetstate = [](py::tuple const& state)
+    auto requestSetstate = [](tle::Request& request, nb::tuple const& state)
     {
         if (state.size() != 33)
         {
             throw std::runtime_error("Invalid Request state!");
         }
-        return std::make_unique<tle::Request>(state[0].cast<VecTokens>(), state[1].cast<SizeType32>(),
-            state[2].cast<bool>(), state[3].cast<tle::SamplingConfig>(), state[4].cast<tle::OutputConfig>(),
-            state[5].cast<std::optional<SizeType32>>(), state[6].cast<std::optional<SizeType32>>(),
-            state[7].cast<std::optional<std::vector<SizeType32>>>(),
-            state[8].cast<std::optional<std::list<VecTokens>>>(), state[9].cast<std::optional<std::list<VecTokens>>>(),
-            state[10].cast<std::optional<Tensor>>(), state[11].cast<std::optional<tle::ExternalDraftTokensConfig>>(),
-            state[12].cast<std::optional<tle::PromptTuningConfig>>(),
-            state[13].cast<std::optional<tle::MultimodalInput>>(), state[14].cast<std::optional<Tensor>>(),
-            state[15].cast<std::optional<tle::MropeConfig>>(), state[16].cast<std::optional<tle::LoraConfig>>(),
-            state[17].cast<std::optional<tle::LookaheadDecodingConfig>>(),
-            state[18].cast<std::optional<tle::KvCacheRetentionConfig>>(), state[19].cast<std::optional<std::string>>(),
-            state[20].cast<std::optional<tle::LogitsPostProcessor>>(), state[21].cast<std::optional<VecTokens>>(),
-            state[22].cast<std::optional<IdType>>(), state[23].cast<bool>(), state[24].cast<tle::PriorityType>(),
-            state[25].cast<tle::RequestType>(), state[26].cast<std::optional<tle::ContextPhaseParams>>(),
-            state[27].cast<std::optional<tle::Tensor>>(), state[28].cast<std::optional<SizeType32>>(),
-            state[29].cast<std::optional<tle::Tensor>>(), 1, state[30].cast<std::optional<tle::EagleConfig>>(),
-            state[31].cast<std::optional<tle::Tensor>>(), state[32].cast<std::optional<tle::GuidedDecodingParams>>());
+        new (&request) tle::Request(nb::cast<VecTokens>(state[0]), nb::cast<SizeType32>(state[1]),
+            nb::cast<bool>(state[2]), nb::cast<tle::SamplingConfig>(state[3]), nb::cast<tle::OutputConfig>(state[4]),
+            nb::cast<std::optional<SizeType32>>(state[5]), nb::cast<std::optional<SizeType32>>(state[6]),
+            nb::cast<std::optional<std::vector<SizeType32>>>(state[7]),
+            nb::cast<std::optional<std::list<VecTokens>>>(state[8]),
+            nb::cast<std::optional<std::list<VecTokens>>>(state[9]), nb::cast<std::optional<Tensor>>(state[10]),
+            nb::cast<std::optional<tle::ExternalDraftTokensConfig>>(state[11]),
+            nb::cast<std::optional<tle::PromptTuningConfig>>(state[12]),
+            nb::cast<std::optional<tle::MultimodalInput>>(state[13]), nb::cast<std::optional<Tensor>>(state[14]),
+            nb::cast<std::optional<tle::MropeConfig>>(state[15]), nb::cast<std::optional<tle::LoraConfig>>(state[16]),
+            nb::cast<std::optional<tle::LookaheadDecodingConfig>>(state[17]),
+            nb::cast<std::optional<tle::KvCacheRetentionConfig>>(state[18]),
+            nb::cast<std::optional<std::string>>(state[19]),
+            nb::cast<std::optional<tle::LogitsPostProcessor>>(state[20]), nb::cast<std::optional<VecTokens>>(state[21]),
+            nb::cast<std::optional<IdType>>(state[22]), nb::cast<bool>(state[23]),
+            nb::cast<tle::PriorityType>(state[24]), nb::cast<tle::RequestType>(state[25]),
+            nb::cast<std::optional<tle::ContextPhaseParams>>(state[26]),
+            nb::cast<std::optional<tle::Tensor>>(state[27]), nb::cast<std::optional<SizeType32>>(state[28]),
+            nb::cast<std::optional<tle::Tensor>>(state[29]), 1, nb::cast<std::optional<tle::EagleConfig>>(state[30]),
+            nb::cast<std::optional<tle::Tensor>>(state[31]),
+            nb::cast<std::optional<tle::GuidedDecodingParams>>(state[32]));
     };
 
-    py::class_<tle::Request> request(m, "Request", pybind11::dynamic_attr());
+    nb::class_<tle::Request> request(m, "Request", nb::dynamic_attr());
     request
-        .def(py::init<tle::VecTokens,                           // inputTokenIds
+        .def(nb::init<tle::VecTokens,                           // inputTokenIds
                  tle::SizeType32,                               // maxTokens
                  bool,                                          // streaming
                  tle::SamplingConfig const&,                    // samplingConfig
@@ -593,254 +624,263 @@ void initRequestBindings(pybind11::module_& m)
                  std::optional<tle::MillisecondsType>           // allottedTimeMs
                  >(),
             // clang-format off
-        py::arg("input_token_ids"),
-        py::arg("max_tokens"),
-        py::kw_only(),
-        py::arg("streaming") = false,
-        py::arg_v("sampling_config", tle::SamplingConfig(), "SamplingConfig()"),
-        py::arg_v("output_config", tle::OutputConfig(), "OutputConfig()"),
-        py::arg("end_id") = py::none(),
-        py::arg("pad_id") = py::none(),
-        py::arg("position_ids") = py::none(),
-        py::arg("bad_words") = py::none(),
-        py::arg("stop_words") = py::none(),
-        py::arg("embedding_bias") = py::none(),
-        py::arg("external_draft_tokens_config") = py::none(),
-        py::arg("prompt_tuning_config") = py::none(),
-        py::arg("multimodal_input") = py::none(),
-        py::arg("multimodal_embedding") = py::none(),
-        py::arg("mrope_config") = py::none(),
-        py::arg("lora_config") = py::none(),
-        py::arg("lookahead_config") = py::none(),
-        py::arg("kv_cache_retention_config") = py::none(),
-        py::arg("logits_post_processor_name") = py::none(),
-        py::arg("logits_post_processor") = py::none(),
-        py::arg("encoder_input_token_ids") = py::none(),
-        py::arg("client_id") = py::none(),
-        py::arg("return_all_generated_tokens") = false,
-        py::arg("priority") = tle::Request::kDefaultPriority,
-        py::arg_v("type", tle::RequestType::REQUEST_TYPE_CONTEXT_AND_GENERATION,
-            "RequestType.REQUEST_TYPE_CONTEXT_AND_GENERATION"),
-        py::arg("context_phase_params") = py::none(),
-        py::arg("encoder_input_features") = py::none(),
-        py::arg("encoder_output_length") = py::none(),
-        py::arg("cross_attention_mask") = py::none(),
-        py::arg("num_return_sequences") = 1,
-        py::arg("eagle_config") = py::none(),
-        py::arg("skip_cross_attn_blocks") = py::none(),
-        py::arg("guided_decoding_params") = py::none(),
-        py::arg("language_adapter_uid") = py::none(),
-        py::arg("allotted_time_ms") = py::none()
+        nb::arg("input_token_ids"),
+        nb::arg("max_tokens"),
+        nb::kw_only(),
+        nb::arg("streaming") = false,
+        nb::arg("sampling_config") = tle::SamplingConfig(),
+        nb::arg("output_config") = tle::OutputConfig(),
+        nb::arg("end_id") = nb::none(),
+        nb::arg("pad_id") = nb::none(),
+        nb::arg("position_ids") = nb::none(),
+        nb::arg("bad_words") = nb::none(),
+        nb::arg("stop_words") = nb::none(),
+        nb::arg("embedding_bias") = nb::none(),
+        nb::arg("external_draft_tokens_config") = nb::none(),
+        nb::arg("prompt_tuning_config") = nb::none(),
+        nb::arg("multimodal_input") = nb::none(),
+        nb::arg("multimodal_embedding") = nb::none(),
+        nb::arg("mrope_config") = nb::none(),
+        nb::arg("lora_config") = nb::none(),
+        nb::arg("lookahead_config") = nb::none(),
+        nb::arg("kv_cache_retention_config") = nb::none(),
+        nb::arg("logits_post_processor_name") = nb::none(),
+        nb::arg("logits_post_processor") = nb::none(),
+        nb::arg("encoder_input_token_ids") = nb::none(),
+        nb::arg("client_id") = nb::none(),
+        nb::arg("return_all_generated_tokens") = false,
+        nb::arg("priority") = tle::Request::kDefaultPriority,
+        nb::arg("type") = tle::RequestType::REQUEST_TYPE_CONTEXT_AND_GENERATION,
+        nb::arg("context_phase_params") = nb::none(),
+        nb::arg("encoder_input_features") = nb::none(),
+        nb::arg("encoder_output_length") = nb::none(),
+        nb::arg("cross_attention_mask") = nb::none(),
+        nb::arg("num_return_sequences") = 1,
+        nb::arg("eagle_config") = nb::none(),
+        nb::arg("skip_cross_attn_blocks") = nb::none(),
+        nb::arg("guided_decoding_params") = nb::none(),
+        nb::arg("language_adapter_uid") = nb::none(),
+        nb::arg("allotted_time_ms") = nb::none()
     )          // clang-format on
-        .def_property_readonly("input_token_ids", &tle::Request::getInputTokenIds)
-        .def_property_readonly("max_tokens", &tle::Request::getMaxTokens)
-        .def_property("streaming", &tle::Request::getStreaming, &tle::Request::setStreaming)
-        .def_property("sampling_config", &tle::Request::getSamplingConfig, &tle::Request::setSamplingConfig)
-        .def_property("output_config", &tle::Request::getOutputConfig, &tle::Request::setOutputConfig)
-        .def_property("end_id", &tle::Request::getEndId, &tle::Request::setEndId)
-        .def_property("pad_id", &tle::Request::getPadId, &tle::Request::setPadId)
-        .def_property("position_ids", &tle::Request::getPositionIds, &tle::Request::setPositionIds)
-        .def_property("bad_words", &tle::Request::getBadWords, &tle::Request::setBadWords)
-        .def_property("stop_words", &tle::Request::getStopWords, &tle::Request::setStopWords)
-        .def_property("embedding_bias", &tle::Request::getEmbeddingBias, &tle::Request::setEmbeddingBias)
-        .def_property("external_draft_tokens_config", &tle::Request::getExternalDraftTokensConfig,
+        .def_prop_ro("input_token_ids", &tle::Request::getInputTokenIds)
+        .def_prop_ro("max_tokens", &tle::Request::getMaxTokens)
+        .def_prop_rw("streaming", &tle::Request::getStreaming, &tle::Request::setStreaming)
+        .def_prop_rw("sampling_config", &tle::Request::getSamplingConfig, &tle::Request::setSamplingConfig)
+        .def_prop_rw("output_config", &tle::Request::getOutputConfig, &tle::Request::setOutputConfig)
+        .def_prop_rw("end_id", &tle::Request::getEndId, &tle::Request::setEndId)
+        .def_prop_rw("pad_id", &tle::Request::getPadId, &tle::Request::setPadId)
+        .def_prop_rw("position_ids", &tle::Request::getPositionIds, &tle::Request::setPositionIds)
+        .def_prop_rw("bad_words", &tle::Request::getBadWords, &tle::Request::setBadWords)
+        .def_prop_rw("stop_words", &tle::Request::getStopWords, &tle::Request::setStopWords)
+        .def_prop_rw("embedding_bias", &tle::Request::getEmbeddingBias, &tle::Request::setEmbeddingBias)
+        .def_prop_rw("external_draft_tokens_config", &tle::Request::getExternalDraftTokensConfig,
             &tle::Request::setExternalDraftTokensConfig)
-        .def_property(
-            "prompt_tuning_config", &tle::Request::getPromptTuningConfig, &tle::Request::setPromptTuningConfig)
-        .def_property("multimodal_input", &tle::Request::getMultimodalInput, &tle::Request::setMultimodalInput)
-        .def_property(
+        .def_prop_rw("prompt_tuning_config", &tle::Request::getPromptTuningConfig, &tle::Request::setPromptTuningConfig)
+        .def_prop_rw("multimodal_input", &tle::Request::getMultimodalInput, &tle::Request::setMultimodalInput)
+        .def_prop_rw(
             "multimodal_embedding", &tle::Request::getMultimodalEmbedding, &tle::Request::setMultimodalEmbedding)
-        .def_property("mrope_config", &tle::Request::getMropeConfig, &tle::Request::setMropeConfig)
-        .def_property("lora_config", &tle::Request::getLoraConfig, &tle::Request::setLoraConfig)
-        .def_property("lookahead_config", &tle::Request::getLookaheadConfig, &tle::Request::setLookaheadConfig)
-        .def_property("kv_cache_retention_config", &tle::Request::getKvCacheRetentionConfig,
+        .def_prop_rw("mrope_config", &tle::Request::getMropeConfig, &tle::Request::setMropeConfig)
+        .def_prop_rw("lora_config", &tle::Request::getLoraConfig, &tle::Request::setLoraConfig)
+        .def_prop_rw("lookahead_config", &tle::Request::getLookaheadConfig, &tle::Request::setLookaheadConfig)
+        .def_prop_rw("kv_cache_retention_config", &tle::Request::getKvCacheRetentionConfig,
             &tle::Request::setKvCacheRetentionConfig)
-        .def_property("logits_post_processor_name", &tle::Request::getLogitsPostProcessorName,
+        .def_prop_rw("logits_post_processor_name", &tle::Request::getLogitsPostProcessorName,
             &tle::Request::setLogitsPostProcessorName)
-        .def_property(
+        .def_prop_rw(
             "logits_post_processor", &tle::Request::getLogitsPostProcessor, &tle::Request::setLogitsPostProcessor)
-        .def_property(
+        .def_prop_rw(
             "encoder_input_token_ids", &tle::Request::getEncoderInputTokenIds, &tle::Request::setEncoderInputTokenIds)
-        .def_property("client_id", &tle::Request::getClientId, &tle::Request::setClientId)
-        .def_property("return_all_generated_tokens", &tle::Request::getReturnAllGeneratedTokens,
+        .def_prop_rw("client_id", &tle::Request::getClientId, &tle::Request::setClientId)
+        .def_prop_rw("return_all_generated_tokens", &tle::Request::getReturnAllGeneratedTokens,
             &tle::Request::setReturnAllGeneratedTokens)
-        .def_property("request_type", &tle::Request::getRequestType, &tle::Request::setRequestType)
-        .def_property(
+        .def_prop_rw("request_type", &tle::Request::getRequestType, &tle::Request::setRequestType)
+        .def_prop_rw(
             "encoder_input_features", &tle::Request::getEncoderInputFeatures, &tle::Request::setEncoderInputFeatures)
-        .def_property(
-            "cross_attention_mask", &tle::Request::getCrossAttentionMask, &tle::Request::setCrossAttentionMask)
-        .def_property("eagle_config", &tle::Request::getEagleConfig, &tle::Request::setEagleConfig)
-        .def_property(
+        .def_prop_rw("cross_attention_mask", &tle::Request::getCrossAttentionMask, &tle::Request::setCrossAttentionMask)
+        .def_prop_rw("eagle_config", &tle::Request::getEagleConfig, &tle::Request::setEagleConfig)
+        .def_prop_rw(
             "skip_cross_attn_blocks", &tle::Request::getSkipCrossAttnBlocks, &tle::Request::setSkipCrossAttnBlocks)
-        .def_property(
+        .def_prop_rw(
             "guided_decoding_params", &tle::Request::getGuidedDecodingParams, &tle::Request::setGuidedDecodingParams)
-        .def_property("allotted_time_ms", &tle::Request::getAllottedTimeMs, &tle::Request::setAllottedTimeMs)
-        .def_property(
-            "context_phase_params", &tle::Request::getContextPhaseParams, &tle::Request::setContextPhaseParams)
-        .def(py::pickle(requestGetstate, requestSetstate));
+        .def_prop_rw("allotted_time_ms", &tle::Request::getAllottedTimeMs, &tle::Request::setAllottedTimeMs)
+        .def_prop_rw("context_phase_params", &tle::Request::getContextPhaseParams, &tle::Request::setContextPhaseParams)
+        .def("__getstate__", requestGetstate)
+        .def("__setstate__", requestSetstate);
     request.attr("BATCHED_POST_PROCESSOR_NAME") = tle::Request::kBatchedPostProcessorName;
 
-    py::class_<tle::SpeculativeDecodingFastLogitsInfo>(m, "SpeculativeDecodingFastLogitsInfo")
-        .def(py::init<>())
-        .def_readwrite("draft_request_id", &tle::SpeculativeDecodingFastLogitsInfo::draftRequestId)
-        .def_readwrite("draft_participant_id", &tle::SpeculativeDecodingFastLogitsInfo::draftParticipantId)
+    nb::class_<tle::SpeculativeDecodingFastLogitsInfo>(m, "SpeculativeDecodingFastLogitsInfo")
+        .def(nb::init<>())
+        .def_rw("draft_request_id", &tle::SpeculativeDecodingFastLogitsInfo::draftRequestId)
+        .def_rw("draft_participant_id", &tle::SpeculativeDecodingFastLogitsInfo::draftParticipantId)
         .def("to_tensor", &tle::SpeculativeDecodingFastLogitsInfo::toTensor);
 
-    auto requestPerfMetrics = py::class_<tle::RequestPerfMetrics>(m, "RequestPerfMetrics");
+    auto requestPerfMetrics = nb::class_<tle::RequestPerfMetrics>(m, "RequestPerfMetrics");
 
     auto timingMetricsGetstate = [](tle::RequestPerfMetrics::TimingMetrics const& self)
     {
-        return py::make_tuple(self.arrivalTime, self.firstScheduledTime, self.firstTokenTime, self.lastTokenTime,
+        return nb::make_tuple(self.arrivalTime, self.firstScheduledTime, self.firstTokenTime, self.lastTokenTime,
             self.kvCacheTransferStart, self.kvCacheTransferEnd, self.kvCacheSize);
     };
-    auto timingMetricsSetstate = [](py::tuple const& state)
+    auto timingMetricsSetstate = [](tle::RequestPerfMetrics::TimingMetrics& timingMetrics, nb::tuple const& state)
     {
         if (state.size() != 7)
         {
             throw std::runtime_error("Invalid TimingMetrics state!");
         }
-        return tle::RequestPerfMetrics::TimingMetrics{state[0].cast<tle::RequestPerfMetrics::TimePoint>(),
-            state[1].cast<tle::RequestPerfMetrics::TimePoint>(), state[2].cast<tle::RequestPerfMetrics::TimePoint>(),
-            state[3].cast<tle::RequestPerfMetrics::TimePoint>(), state[4].cast<tle::RequestPerfMetrics::TimePoint>(),
-            state[5].cast<tle::RequestPerfMetrics::TimePoint>(), state[6].cast<size_t>()};
+        new (&timingMetrics)
+            tle::RequestPerfMetrics::TimingMetrics{nb::cast<tle::RequestPerfMetrics::TimePoint>(state[0]),
+                nb::cast<tle::RequestPerfMetrics::TimePoint>(state[1]),
+                nb::cast<tle::RequestPerfMetrics::TimePoint>(state[2]),
+                nb::cast<tle::RequestPerfMetrics::TimePoint>(state[3]),
+                nb::cast<tle::RequestPerfMetrics::TimePoint>(state[4]),
+                nb::cast<tle::RequestPerfMetrics::TimePoint>(state[5]), nb::cast<size_t>(state[6])};
     };
-    py::class_<tle::RequestPerfMetrics::TimingMetrics>(m, "TimingMetrics")
-        .def(py::init<>())
-        .def_readwrite("arrival_time", &tle::RequestPerfMetrics::TimingMetrics::arrivalTime)
-        .def_readwrite("first_scheduled_time", &tle::RequestPerfMetrics::TimingMetrics::firstScheduledTime)
-        .def_readwrite("first_token_time", &tle::RequestPerfMetrics::TimingMetrics::firstTokenTime)
-        .def_readwrite("last_token_time", &tle::RequestPerfMetrics::TimingMetrics::lastTokenTime)
-        .def_readwrite("kv_cache_transfer_start", &tle::RequestPerfMetrics::TimingMetrics::kvCacheTransferStart)
-        .def_readwrite("kv_cache_transfer_end", &tle::RequestPerfMetrics::TimingMetrics::kvCacheTransferEnd)
-        .def_readwrite("kv_cache_size", &tle::RequestPerfMetrics::TimingMetrics::kvCacheSize)
-        .def(py::pickle(timingMetricsGetstate, timingMetricsSetstate));
+    nb::class_<tle::RequestPerfMetrics::TimingMetrics>(m, "TimingMetrics")
+        .def(nb::init<>())
+        .def_rw("arrival_time", &tle::RequestPerfMetrics::TimingMetrics::arrivalTime)
+        .def_rw("first_scheduled_time", &tle::RequestPerfMetrics::TimingMetrics::firstScheduledTime)
+        .def_rw("first_token_time", &tle::RequestPerfMetrics::TimingMetrics::firstTokenTime)
+        .def_rw("last_token_time", &tle::RequestPerfMetrics::TimingMetrics::lastTokenTime)
+        .def_rw("kv_cache_transfer_start", &tle::RequestPerfMetrics::TimingMetrics::kvCacheTransferStart)
+        .def_rw("kv_cache_transfer_end", &tle::RequestPerfMetrics::TimingMetrics::kvCacheTransferEnd)
+        .def_rw("kv_cache_size", &tle::RequestPerfMetrics::TimingMetrics::kvCacheSize)
+        .def("__getstate__", timingMetricsGetstate)
+        .def("__setstate__", timingMetricsSetstate);
 
     auto kvCacheMetricsGetstate = [](tle::RequestPerfMetrics::KvCacheMetrics const& self)
     {
-        return py::make_tuple(self.numTotalAllocatedBlocks, self.numNewAllocatedBlocks, self.numReusedBlocks,
+        return nb::make_tuple(self.numTotalAllocatedBlocks, self.numNewAllocatedBlocks, self.numReusedBlocks,
             self.numMissedBlocks, self.kvCacheHitRate);
     };
-    auto kvCacheMetricsSetstate = [](py::tuple const& state)
+    auto kvCacheMetricsSetstate = [](tle::RequestPerfMetrics::KvCacheMetrics& kvCacheMetrics, nb::tuple const& state)
     {
         if (state.size() != 5)
         {
             throw std::runtime_error("Invalid KvCacheMetrics state!");
         }
-        return tle::RequestPerfMetrics::KvCacheMetrics{state[0].cast<SizeType32>(), state[1].cast<SizeType32>(),
-            state[2].cast<SizeType32>(), state[3].cast<SizeType32>(), state[4].cast<float>()};
+        new (&kvCacheMetrics)
+            tle::RequestPerfMetrics::KvCacheMetrics{nb::cast<SizeType32>(state[0]), nb::cast<SizeType32>(state[1]),
+                nb::cast<SizeType32>(state[2]), nb::cast<SizeType32>(state[3]), nb::cast<float>(state[4])};
     };
-    py::class_<tle::RequestPerfMetrics::KvCacheMetrics>(m, "KvCacheMetrics")
-        .def(py::init<>())
-        .def_readwrite("num_total_allocated_blocks", &tle::RequestPerfMetrics::KvCacheMetrics::numTotalAllocatedBlocks)
-        .def_readwrite("num_new_allocated_blocks", &tle::RequestPerfMetrics::KvCacheMetrics::numNewAllocatedBlocks)
-        .def_readwrite("num_reused_blocks", &tle::RequestPerfMetrics::KvCacheMetrics::numReusedBlocks)
-        .def_readwrite("num_missed_blocks", &tle::RequestPerfMetrics::KvCacheMetrics::numMissedBlocks)
-        .def_readwrite("kv_cache_hit_rate", &tle::RequestPerfMetrics::KvCacheMetrics::kvCacheHitRate)
-        .def(py::pickle(kvCacheMetricsGetstate, kvCacheMetricsSetstate));
+    nb::class_<tle::RequestPerfMetrics::KvCacheMetrics>(m, "KvCacheMetrics")
+        .def(nb::init<>())
+        .def_rw("num_total_allocated_blocks", &tle::RequestPerfMetrics::KvCacheMetrics::numTotalAllocatedBlocks)
+        .def_rw("num_new_allocated_blocks", &tle::RequestPerfMetrics::KvCacheMetrics::numNewAllocatedBlocks)
+        .def_rw("num_reused_blocks", &tle::RequestPerfMetrics::KvCacheMetrics::numReusedBlocks)
+        .def_rw("num_missed_blocks", &tle::RequestPerfMetrics::KvCacheMetrics::numMissedBlocks)
+        .def_rw("kv_cache_hit_rate", &tle::RequestPerfMetrics::KvCacheMetrics::kvCacheHitRate)
+        .def("__getstate__", kvCacheMetricsGetstate)
+        .def("__setstate__", kvCacheMetricsSetstate);
 
     auto speculativeDecodingMetricsGetstate = [](tle::RequestPerfMetrics::SpeculativeDecodingMetrics const& self)
-    { return py::make_tuple(self.acceptanceRate, self.totalAcceptedDraftTokens, self.totalDraftTokens); };
-    auto speculativeDecodingMetricsSetstate = [](py::tuple const& state)
+    { return nb::make_tuple(self.acceptanceRate, self.totalAcceptedDraftTokens, self.totalDraftTokens); };
+    auto speculativeDecodingMetricsSetstate
+        = [](tle::RequestPerfMetrics::SpeculativeDecodingMetrics& speculativeDecodingMetrics, nb::tuple const& state)
     {
         if (state.size() != 3)
         {
             throw std::runtime_error("Invalid SpeculativeDecodingMetrics state!");
         }
-        return tle::RequestPerfMetrics::SpeculativeDecodingMetrics{
-            state[0].cast<float>(), state[1].cast<SizeType32>(), state[2].cast<SizeType32>()};
+        new (&speculativeDecodingMetrics) tle::RequestPerfMetrics::SpeculativeDecodingMetrics{
+            nb::cast<float>(state[0]), nb::cast<SizeType32>(state[1]), nb::cast<SizeType32>(state[2])};
     };
 
-    py::class_<tle::RequestPerfMetrics::SpeculativeDecodingMetrics>(m, "SpeculativeDecodingMetrics")
-        .def(py::init<>())
-        .def_readwrite("acceptance_rate", &tle::RequestPerfMetrics::SpeculativeDecodingMetrics::acceptanceRate)
-        .def_readwrite("total_accepted_draft_tokens",
+    nb::class_<tle::RequestPerfMetrics::SpeculativeDecodingMetrics>(m, "SpeculativeDecodingMetrics")
+        .def(nb::init<>())
+        .def_rw("acceptance_rate", &tle::RequestPerfMetrics::SpeculativeDecodingMetrics::acceptanceRate)
+        .def_rw("total_accepted_draft_tokens",
             &tle::RequestPerfMetrics::SpeculativeDecodingMetrics::totalAcceptedDraftTokens)
-        .def_readwrite("total_draft_tokens", &tle::RequestPerfMetrics::SpeculativeDecodingMetrics::totalDraftTokens)
-        .def(py::pickle(speculativeDecodingMetricsGetstate, speculativeDecodingMetricsSetstate));
+        .def_rw("total_draft_tokens", &tle::RequestPerfMetrics::SpeculativeDecodingMetrics::totalDraftTokens)
+        .def("__getstate__", speculativeDecodingMetricsGetstate)
+        .def("__setstate__", speculativeDecodingMetricsSetstate);
 
     auto requestPerfMetricsGetstate = [](tle::RequestPerfMetrics const& self)
     {
-        return py::make_tuple(self.timingMetrics, self.kvCacheMetrics, self.speculativeDecoding, self.firstIter,
+        return nb::make_tuple(self.timingMetrics, self.kvCacheMetrics, self.speculativeDecoding, self.firstIter,
             self.lastIter, self.iter);
     };
-    auto requestPerfMetricsSetstate = [](py::tuple const& state)
+    auto requestPerfMetricsSetstate = [](tle::RequestPerfMetrics& requestPerfMetrics, nb::tuple const& state)
     {
         if (state.size() != 6)
         {
             throw std::runtime_error("Invalid RequestPerfMetrics state!");
         }
-        return tle::RequestPerfMetrics{state[0].cast<tle::RequestPerfMetrics::TimingMetrics>(),
-            state[1].cast<tle::RequestPerfMetrics::KvCacheMetrics>(),
-            state[2].cast<tle::RequestPerfMetrics::SpeculativeDecodingMetrics>(),
-            state[3].cast<std::optional<tle::IterationType>>(), state[4].cast<std::optional<tle::IterationType>>(),
-            state[5].cast<std::optional<tle::IterationType>>()};
+        new (&requestPerfMetrics) tle::RequestPerfMetrics{nb::cast<tle::RequestPerfMetrics::TimingMetrics>(state[0]),
+            nb::cast<tle::RequestPerfMetrics::KvCacheMetrics>(state[1]),
+            nb::cast<tle::RequestPerfMetrics::SpeculativeDecodingMetrics>(state[2]),
+            nb::cast<std::optional<tle::IterationType>>(state[3]),
+            nb::cast<std::optional<tle::IterationType>>(state[4]),
+            nb::cast<std::optional<tle::IterationType>>(state[5])};
     };
 
     // There's a circular dependency between the declaration of the TimingMetrics and RequestPerfMetrics bindings.
     // Defer definition of the RequestPerfMetrics bindings until the TimingMetrics have been defined.
-    requestPerfMetrics.def(py::init<>())
-        .def_readwrite("timing_metrics", &tle::RequestPerfMetrics::timingMetrics)
-        .def_readwrite("kv_cache_metrics", &tle::RequestPerfMetrics::kvCacheMetrics)
-        .def_readwrite("speculative_decoding", &tle::RequestPerfMetrics::speculativeDecoding)
-        .def_readwrite("first_iter", &tle::RequestPerfMetrics::firstIter)
-        .def_readwrite("last_iter", &tle::RequestPerfMetrics::lastIter)
-        .def_readwrite("iter", &tle::RequestPerfMetrics::iter)
-        .def(py::pickle(requestPerfMetricsGetstate, requestPerfMetricsSetstate));
+    requestPerfMetrics.def(nb::init<>())
+        .def_rw("timing_metrics", &tle::RequestPerfMetrics::timingMetrics)
+        .def_rw("kv_cache_metrics", &tle::RequestPerfMetrics::kvCacheMetrics)
+        .def_rw("speculative_decoding", &tle::RequestPerfMetrics::speculativeDecoding)
+        .def_rw("first_iter", &tle::RequestPerfMetrics::firstIter)
+        .def_rw("last_iter", &tle::RequestPerfMetrics::lastIter)
+        .def_rw("iter", &tle::RequestPerfMetrics::iter)
+        .def("__getstate__", requestPerfMetricsGetstate)
+        .def("__setstate__", requestPerfMetricsSetstate);
 
-    py::class_<tle::AdditionalOutput>(m, "AdditionalOutput")
-        .def(py::init([](std::string const& name, tle::Tensor const& output)
-            { return std::make_unique<tle::AdditionalOutput>(name, output); }))
-        .def_readwrite("name", &tle::AdditionalOutput::name)
-        .def_readwrite("output", &tle::AdditionalOutput::output);
+    nb::class_<tle::AdditionalOutput>(m, "AdditionalOutput")
+        .def("__init__ ",
+            [](tle::AdditionalOutput const& self, std::string const& name, tle::Tensor const& output)
+            { return std::make_unique<tle::AdditionalOutput>(name, output); })
+        .def_rw("name", &tle::AdditionalOutput::name)
+        .def_rw("output", &tle::AdditionalOutput::output);
 
-    auto resultSetstate = [](py::tuple const& state)
+    auto resultSetstate = [](tle::Result& result, nb::tuple const& state)
     {
         if (state.size() != 13)
         {
             throw std::runtime_error("Invalid Request state!");
         }
-        tle::Result result;
-        result.isFinal = state[0].cast<bool>();
-        result.outputTokenIds = state[1].cast<std::vector<VecTokens>>();
-        result.cumLogProbs = state[2].cast<std::optional<std::vector<float>>>();
-        result.logProbs = state[3].cast<std::optional<std::vector<std::vector<float>>>>();
-        result.contextLogits = state[4].cast<std::optional<Tensor>>();
-        result.generationLogits = state[5].cast<std::optional<Tensor>>();
-        result.encoderOutput = state[6].cast<std::optional<Tensor>>();
-        result.finishReasons = state[7].cast<std::vector<tle::FinishReason>>();
-        result.sequenceIndex = state[8].cast<SizeType32>();
-        result.isSequenceFinal = state[9].cast<bool>();
-        result.decodingIter = state[10].cast<SizeType32>();
-        result.contextPhaseParams = state[11].cast<std::optional<tle::ContextPhaseParams>>();
-        result.requestPerfMetrics = state[12].cast<std::optional<tle::RequestPerfMetrics>>();
-        return std::make_unique<tle::Result>(result);
+        new (&result) tle::Result();
+        result.isFinal = nb::cast<bool>(state[0]);
+        result.outputTokenIds = nb::cast<std::vector<VecTokens>>(state[1]);
+        result.cumLogProbs = nb::cast<std::optional<std::vector<float>>>(state[2]);
+        result.logProbs = nb::cast<std::optional<std::vector<std::vector<float>>>>(state[3]);
+        result.contextLogits = nb::cast<std::optional<Tensor>>(state[4]);
+        result.generationLogits = nb::cast<std::optional<Tensor>>(state[5]);
+        result.encoderOutput = nb::cast<std::optional<Tensor>>(state[6]);
+        result.finishReasons = nb::cast<std::vector<tle::FinishReason>>(state[7]);
+        result.sequenceIndex = nb::cast<SizeType32>(state[8]);
+        result.isSequenceFinal = nb::cast<bool>(state[9]);
+        result.decodingIter = nb::cast<SizeType32>(state[10]);
+        result.contextPhaseParams = nb::cast<std::optional<tle::ContextPhaseParams>>(state[11]);
+        result.requestPerfMetrics = nb::cast<std::optional<tle::RequestPerfMetrics>>(state[12]);
     };
 
     auto resultGetstate = [](tle::Result const& self)
     {
-        return py::make_tuple(self.isFinal, self.outputTokenIds, self.cumLogProbs, self.logProbs, self.contextLogits,
+        return nb::make_tuple(self.isFinal, self.outputTokenIds, self.cumLogProbs, self.logProbs, self.contextLogits,
             self.generationLogits, self.encoderOutput, self.finishReasons, self.sequenceIndex, self.isSequenceFinal,
             self.decodingIter, self.contextPhaseParams, self.requestPerfMetrics);
     };
 
-    py::class_<tle::Result>(m, "Result")
-        .def(py::init<>())
-        .def_readwrite("is_final", &tle::Result::isFinal)
-        .def_readwrite("output_token_ids", &tle::Result::outputTokenIds)
-        .def_readwrite("cum_log_probs", &tle::Result::cumLogProbs)
-        .def_readwrite("log_probs", &tle::Result::logProbs)
-        .def_readwrite("context_logits", &tle::Result::contextLogits)
-        .def_readwrite("generation_logits", &tle::Result::generationLogits)
-        .def_readwrite("spec_dec_fast_logits_info", &tle::Result::specDecFastLogitsInfo)
-        .def_readwrite("encoder_output", &tle::Result::encoderOutput)
-        .def_readwrite("finish_reasons", &tle::Result::finishReasons)
-        .def_readwrite("sequence_index", &tle::Result::sequenceIndex)
-        .def_readwrite("is_sequence_final", &tle::Result::isSequenceFinal)
-        .def_readwrite("decoding_iter", &tle::Result::decodingIter)
-        .def_readwrite("context_phase_params", &tle::Result::contextPhaseParams)
-        .def_readwrite("request_perf_metrics", &tle::Result::requestPerfMetrics)
-        .def_readwrite("additional_outputs", &tle::Result::additionalOutputs)
-        .def(py::pickle(resultGetstate, resultSetstate));
+    nb::class_<tle::Result>(m, "Result")
+        .def(nb::init<>())
+        .def_rw("is_final", &tle::Result::isFinal)
+        .def_rw("output_token_ids", &tle::Result::outputTokenIds)
+        .def_rw("cum_log_probs", &tle::Result::cumLogProbs)
+        .def_rw("log_probs", &tle::Result::logProbs)
+        .def_rw("context_logits", &tle::Result::contextLogits)
+        .def_rw("generation_logits", &tle::Result::generationLogits)
+        .def_rw("spec_dec_fast_logits_info", &tle::Result::specDecFastLogitsInfo)
+        .def_rw("encoder_output", &tle::Result::encoderOutput)
+        .def_rw("finish_reasons", &tle::Result::finishReasons)
+        .def_rw("sequence_index", &tle::Result::sequenceIndex)
+        .def_rw("is_sequence_final", &tle::Result::isSequenceFinal)
+        .def_rw("decoding_iter", &tle::Result::decodingIter)
+        .def_rw("context_phase_params", &tle::Result::contextPhaseParams)
+        .def_rw("request_perf_metrics", &tle::Result::requestPerfMetrics)
+        .def_rw("additional_outputs", &tle::Result::additionalOutputs)
+        .def_rw("context_phase_params", &tle::Result::contextPhaseParams)
+        .def("__getstate__", resultGetstate)
+        .def("__setstate__", resultSetstate);
 
     m.def("deserialize_result",
         [](std::string& x)
@@ -849,29 +889,37 @@ void initRequestBindings(pybind11::module_& m)
             return tle::serialize_utils::deserialize<tle::Result>(is);
         });
 
-    auto responseGetstate = [](tle::Response const& self)
-    { return py::make_tuple(self.getRequestId(), self.getResult(), self.getClientId()); };
+    m.def("deserialize_result",
+        [](nb::bytes& x)
+        {
+            std::string str(x.c_str(), x.size());
+            std::istringstream is(str);
+            return tle::serialize_utils::deserialize<tle::Result>(is);
+        });
 
-    auto responseSetstate = [](py::tuple const& state)
+    auto responseGetstate = [](tle::Response const& self)
+    { return nb::make_tuple(self.getRequestId(), self.getResult(), self.getClientId()); };
+
+    auto responseSetstate = [](tle::Response& response, nb::tuple const& state)
     {
         if (state.size() != 3)
         {
             throw std::runtime_error("Invalid Request state!");
         }
-        return std::make_unique<tle::Response>(
-            state[0].cast<SizeType32>(), state[1].cast<tle::Result>(), state[2].cast<SizeType32>());
+        new (&response) tle::Response(
+            nb::cast<SizeType32>(state[0]), nb::cast<tle::Result>(state[1]), nb::cast<SizeType32>(state[2]));
     };
 
-    py::class_<tle::Response>(m, "Response")
-        .def(py::init<IdType, std::string, std::optional<IdType>>(), py::arg("request_id"), py::arg("error_msg"),
-            py::arg("client_id") = std::nullopt)
-        .def(py::init<IdType, tle::Result, std::optional<IdType>>(), py::arg("request_id"), py::arg("result"),
-            py::arg("client_id") = std::nullopt)
-        .def_property_readonly("request_id", &tle::Response::getRequestId)
-        .def_property_readonly("client_id", &tle::Response::getClientId)
+    nb::class_<tle::Response>(m, "Response")
+        .def(nb::init<IdType, std::string, std::optional<IdType>>(), nb::arg("request_id"), nb::arg("error_msg"),
+            nb::arg("client_id") = std::nullopt)
+        .def(nb::init<IdType, tle::Result, std::optional<IdType>>(), nb::arg("request_id"), nb::arg("result"),
+            nb::arg("client_id") = std::nullopt)
+        .def_prop_ro("request_id", &tle::Response::getRequestId)
+        .def_prop_ro("client_id", &tle::Response::getClientId)
         .def("has_error", &tle::Response::hasError)
-        .def_property_readonly("error_msg", &tle::Response::getErrorMsg)
-        .def_property_readonly("result", &tle::Response::getResult)
+        .def_prop_ro("error_msg", &tle::Response::getErrorMsg)
+        .def_prop_ro("result", &tle::Response::getResult)
         .def("clear_context_logits",
             [](tle::Response& self)
             {
@@ -890,7 +938,8 @@ void initRequestBindings(pybind11::module_& m)
                     result.generationLogits.reset();
                 }
             })
-        .def(py::pickle(responseGetstate, responseSetstate));
+        .def("__getstate__", responseGetstate)
+        .def("__setstate__", responseSetstate);
 }
 
-} // namespace tensorrt_llm::pybind::executor
+} // namespace tensorrt_llm::nanobind::executor

--- a/cpp/tensorrt_llm/nanobind/executor/request.cpp
+++ b/cpp/tensorrt_llm/nanobind/executor/request.cpp
@@ -1,0 +1,896 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "request.h"
+#include "tensorrt_llm/common/assert.h"
+#include "tensorrt_llm/common/logger.h"
+#include "tensorrt_llm/executor/executor.h"
+#include "tensorrt_llm/executor/serializeUtils.h"
+#include "tensorrt_llm/executor/tensor.h"
+#include "tensorrt_llm/executor/types.h"
+#include "tensorrt_llm/runtime/cudaStream.h"
+
+#include <pybind11/cast.h>
+#include <pybind11/chrono.h>
+#include <pybind11/functional.h>
+#include <pybind11/operators.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <sstream>
+
+#include <optional>
+#include <vector>
+
+namespace py = pybind11;
+namespace tle = tensorrt_llm::executor;
+using Tensor = tle::Tensor;
+using SizeType32 = tle::SizeType32;
+using FloatType = tle::FloatType;
+using VecTokens = tle::VecTokens;
+using IdType = tle::IdType;
+using VecTokenExtraIds = tle::VecTokenExtraIds;
+
+namespace tensorrt_llm::pybind::executor
+{
+
+void initRequestBindings(pybind11::module_& m)
+{
+    py::enum_<tle::RequestType>(m, "RequestType")
+        .value("REQUEST_TYPE_CONTEXT_AND_GENERATION", tle::RequestType::REQUEST_TYPE_CONTEXT_AND_GENERATION)
+        .value("REQUEST_TYPE_CONTEXT_ONLY", tle::RequestType::REQUEST_TYPE_CONTEXT_ONLY)
+        .value("REQUEST_TYPE_GENERATION_ONLY", tle::RequestType::REQUEST_TYPE_GENERATION_ONLY);
+
+    py::enum_<tle::FinishReason>(m, "FinishReason")
+        .value("NOT_FINISHED", tle::FinishReason::kNOT_FINISHED)
+        .value("END_ID", tle::FinishReason::kEND_ID)
+        .value("STOP_WORDS", tle::FinishReason::kSTOP_WORDS)
+        .value("LENGTH", tle::FinishReason::kLENGTH)
+        .value("TIMED_OUT", tle::FinishReason::kTIMED_OUT)
+        .value("CANCELLED", tle::FinishReason::kCANCELLED);
+
+    py::enum_<tle::KvCacheTransferMode>(m, "KvCacheTransferMode")
+        .value("DRAM", tle::KvCacheTransferMode::DRAM)
+        .value("GDS", tle::KvCacheTransferMode::GDS)
+        .value("POSIX_DEBUG_FALLBACK", tle::KvCacheTransferMode::POSIX_DEBUG_FALLBACK);
+
+    auto samplingConfigGetstate = [](tle::SamplingConfig const& self)
+    {
+        return py::make_tuple(self.getBeamWidth(), self.getTopK(), self.getTopP(), self.getTopPMin(),
+            self.getTopPResetIds(), self.getTopPDecay(), self.getSeed(), self.getTemperature(), self.getMinTokens(),
+            self.getBeamSearchDiversityRate(), self.getRepetitionPenalty(), self.getPresencePenalty(),
+            self.getFrequencyPenalty(), self.getLengthPenalty(), self.getEarlyStopping(), self.getNoRepeatNgramSize(),
+            self.getNumReturnSequences(), self.getMinP(), self.getBeamWidthArray());
+    };
+    auto samplingConfigSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 19)
+        {
+            throw std::runtime_error("Invalid SamplingConfig state!");
+        }
+        return tle::SamplingConfig(state[0].cast<SizeType32>(),      // BeamWidth
+            state[1].cast<std::optional<SizeType32>>(),              // TopK
+            state[2].cast<std::optional<FloatType>>(),               // TopP
+            state[3].cast<std::optional<FloatType>>(),               // TopPMin
+            state[4].cast<std::optional<tle::TokenIdType>>(),        // TopPResetIds
+            state[5].cast<std::optional<FloatType>>(),               // TopPDecay
+            state[6].cast<std::optional<tle::RandomSeedType>>(),     // Seed
+            state[7].cast<std::optional<FloatType>>(),               // Temperature
+            state[8].cast<std::optional<SizeType32>>(),              // MinTokens
+            state[9].cast<std::optional<FloatType>>(),               // BeamSearchDiversityRate
+            state[10].cast<std::optional<FloatType>>(),              // RepetitionPenalty
+            state[11].cast<std::optional<FloatType>>(),              // PresencePenalty
+            state[12].cast<std::optional<FloatType>>(),              // FrequencyPenalty
+            state[13].cast<std::optional<FloatType>>(),              // LengthPenalty
+            state[14].cast<std::optional<SizeType32>>(),             // EarlyStopping
+            state[15].cast<std::optional<SizeType32>>(),             // NoRepeatNgramSize
+            state[16].cast<std::optional<SizeType32>>(),             // NumReturnSequences
+            state[17].cast<std::optional<FloatType>>(),              // MinP
+            state[18].cast<std::optional<std::vector<SizeType32>>>() // BeamWidthArray
+        );
+    };
+    py::class_<tle::SamplingConfig>(m, "SamplingConfig")
+        .def(py::init<tle::SizeType32,
+                 std::optional<tle::SizeType32> const&,             // beamWidth
+                 std::optional<tle::FloatType> const&,              // topP
+                 std::optional<tle::FloatType> const&,              // topPMin
+                 std::optional<tle::TokenIdType> const&,            // topPResetIds
+                 std::optional<tle::FloatType> const&,              // topPDecay
+                 std::optional<tle::RandomSeedType> const&,         // seed
+                 std::optional<tle::FloatType> const&,              // temperature
+                 std::optional<tle::SizeType32> const&,             // minTokens
+                 std::optional<tle::FloatType> const&,              // beamSearchDiversityRate
+                 std::optional<tle::FloatType> const&,              // repetitionPenalty
+                 std::optional<tle::FloatType> const&,              // presencePenalty
+                 std::optional<tle::FloatType> const&,              // frequencyPenalty
+                 std::optional<tle::FloatType> const&,              // lengthPenalty
+                 std::optional<tle::SizeType32> const&,             // earlyStopping
+                 std::optional<tle::SizeType32> const&,             // noRepeatNgramSize
+                 std::optional<tle::SizeType32> const&,             // numReturnSequences
+                 std::optional<tle::FloatType> const&,              // minP
+                 std::optional<std::vector<tle::SizeType32>> const& // beamWidthArray
+                 >(),
+            // clang-format off
+            py::arg("beam_width") = 1,
+            py::kw_only(),
+            py::arg("top_k") = py::none(),
+            py::arg("top_p") = py::none(),
+            py::arg("top_p_min") = py::none(),
+            py::arg("top_p_reset_ids") = py::none(),
+            py::arg("top_p_decay") = py::none(),
+            py::arg("seed") = py::none(),
+            py::arg("temperature") = py::none(),
+            py::arg("min_tokens") = py::none(),
+            py::arg("beam_search_diversity_rate") = py::none(),
+            py::arg("repetition_penalty") = py::none(),
+            py::arg("presence_penalty") = py::none(),
+            py::arg("frequency_penalty") = py::none(),
+            py::arg("length_penalty") = py::none(),
+            py::arg("early_stopping") = py::none(),
+            py::arg("no_repeat_ngram_size") = py::none(),
+            py::arg("num_return_sequences") = py::none(),
+            py::arg("min_p") = py::none(),
+            py::arg("beam_width_array") = py::none())               // clang-format on
+        .def_property("beam_width", &tle::SamplingConfig::getBeamWidth, &tle::SamplingConfig::setBeamWidth)
+        .def_property("top_k", &tle::SamplingConfig::getTopK, &tle::SamplingConfig::setTopK)
+        .def_property("top_p", &tle::SamplingConfig::getTopP, &tle::SamplingConfig::setTopP)
+        .def_property("top_p_min", &tle::SamplingConfig::getTopPMin, &tle::SamplingConfig::setTopPMin)
+        .def_property("top_p_reset_ids", &tle::SamplingConfig::getTopPResetIds, &tle::SamplingConfig::setTopPResetIds)
+        .def_property("top_p_decay", &tle::SamplingConfig::getTopPDecay, &tle::SamplingConfig::setTopPDecay)
+        .def_property("seed", &tle::SamplingConfig::getSeed, &tle::SamplingConfig::setSeed)
+        .def_property("temperature", &tle::SamplingConfig::getTemperature, &tle::SamplingConfig::setTemperature)
+        .def_property("min_tokens", &tle::SamplingConfig::getMinTokens, &tle::SamplingConfig::setMinTokens)
+        .def_property("beam_search_diversity_rate", &tle::SamplingConfig::getBeamSearchDiversityRate,
+            &tle::SamplingConfig::setBeamSearchDiversityRate)
+        .def_property("repetition_penalty", &tle::SamplingConfig::getRepetitionPenalty,
+            &tle::SamplingConfig::setRepetitionPenalty)
+        .def_property("presence_penalty", &tle::SamplingConfig::getPresencePenalty,
+            [](tle::SamplingConfig& self, std::optional<FloatType> v) { self.setPresencePenalty(v); })
+        .def_property(
+            "frequency_penalty", &tle::SamplingConfig::getFrequencyPenalty, &tle::SamplingConfig::setFrequencyPenalty)
+        .def_property("length_penalty", &tle::SamplingConfig::getLengthPenalty, &tle::SamplingConfig::setLengthPenalty)
+        .def_property("early_stopping", &tle::SamplingConfig::getEarlyStopping, &tle::SamplingConfig::setEarlyStopping)
+        .def_property("no_repeat_ngram_size", &tle::SamplingConfig::getNoRepeatNgramSize,
+            &tle::SamplingConfig::setNoRepeatNgramSize)
+        .def_property("num_return_sequences", &tle::SamplingConfig::getNumReturnSequences,
+            &tle::SamplingConfig::setNumReturnSequences)
+        .def_property("min_p", &tle::SamplingConfig::getMinP, &tle::SamplingConfig::setMinP)
+        .def_property(
+            "beam_width_array", &tle::SamplingConfig::getBeamWidthArray, &tle::SamplingConfig::setBeamWidthArray)
+        .def(py::pickle(samplingConfigGetstate, samplingConfigSetstate));
+
+    auto additionalModelOutputGetstate
+        = [](tle::AdditionalModelOutput const& self) { return py::make_tuple(self.name, self.gatherContext); };
+    auto additionalModelOutputSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 2)
+        {
+            throw std::runtime_error("Invalid AdditionalModelOutput state!");
+        }
+        return tle::AdditionalModelOutput(state[0].cast<std::string>(), state[1].cast<bool>());
+    };
+    py::class_<tle::AdditionalModelOutput>(m, "AdditionalModelOutput")
+        .def(py::init<std::string, bool>(), py::arg("name"), py::arg("gather_context") = false)
+        .def_readwrite("name", &tle::AdditionalModelOutput::name)
+        .def_readwrite("gather_context", &tle::AdditionalModelOutput::gatherContext)
+        .def(py::pickle(additionalModelOutputGetstate, additionalModelOutputSetstate));
+
+    auto outputConfigGetstate = [](tle::OutputConfig const& self)
+    {
+        return py::make_tuple(self.returnLogProbs, self.returnContextLogits, self.returnGenerationLogits,
+            self.excludeInputFromOutput, self.returnEncoderOutput, self.returnPerfMetrics, self.additionalModelOutputs);
+    };
+    auto outputConfigSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 7)
+        {
+            throw std::runtime_error("Invalid OutputConfig state!");
+        }
+        return tle::OutputConfig(state[0].cast<bool>(), state[1].cast<bool>(), state[2].cast<bool>(),
+            state[3].cast<bool>(), state[4].cast<bool>(), state[5].cast<bool>(),
+            state[6].cast<std::optional<std::vector<tle::AdditionalModelOutput>>>());
+    };
+    py::class_<tle::OutputConfig>(m, "OutputConfig")
+        .def(py::init<bool, bool, bool, bool, bool, bool, std::optional<std::vector<tle::AdditionalModelOutput>>>(),
+            py::arg("return_log_probs") = false, py::arg("return_context_logits") = false,
+            py::arg("return_generation_logits") = false, py::arg("exclude_input_from_output") = false,
+            py::arg("return_encoder_output") = false, py::arg("return_perf_metrics") = false,
+            py::arg("additional_model_outputs") = py::none())
+        .def_readwrite("return_log_probs", &tle::OutputConfig::returnLogProbs)
+        .def_readwrite("return_context_logits", &tle::OutputConfig::returnContextLogits)
+        .def_readwrite("return_generation_logits", &tle::OutputConfig::returnGenerationLogits)
+        .def_readwrite("exclude_input_from_output", &tle::OutputConfig::excludeInputFromOutput)
+        .def_readwrite("return_encoder_output", &tle::OutputConfig::returnEncoderOutput)
+        .def_readwrite("return_perf_metrics", &tle::OutputConfig::returnPerfMetrics)
+        .def_readwrite("additional_model_outputs", &tle::OutputConfig::additionalModelOutputs)
+        .def(py::pickle(outputConfigGetstate, outputConfigSetstate));
+
+    auto externalDraftTokensConfigGetstate = [](tle::ExternalDraftTokensConfig const& self)
+    { return py::make_tuple(self.getTokens(), self.getLogits(), self.getAcceptanceThreshold()); };
+    auto externalDraftTokensConfigSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 3)
+        {
+            throw std::runtime_error("Invalid ExternalDraftTokensConfig state!");
+        }
+        return tle::ExternalDraftTokensConfig(state[0].cast<VecTokens>(), state[1].cast<std::optional<Tensor>>(),
+            state[2].cast<std::optional<FloatType>>());
+    };
+    py::class_<tle::ExternalDraftTokensConfig>(m, "ExternalDraftTokensConfig")
+        .def(py::init<VecTokens, std::optional<Tensor>, std::optional<FloatType> const&, std::optional<bool>>(),
+            py::arg("tokens"), py::arg("logits") = py::none(), py::arg("acceptance_threshold") = py::none(),
+            py::arg("fast_logits") = py::none())
+        .def_property_readonly("tokens", &tle::ExternalDraftTokensConfig::getTokens)
+        .def_property_readonly("logits", &tle::ExternalDraftTokensConfig::getLogits)
+        .def_property_readonly("acceptance_threshold", &tle::ExternalDraftTokensConfig::getAcceptanceThreshold)
+        .def(py::pickle(externalDraftTokensConfigGetstate, externalDraftTokensConfigSetstate))
+        .def_property_readonly("fast_logits", &tle::ExternalDraftTokensConfig::getFastLogits);
+
+    auto promptTuningConfigGetstate = [](tle::PromptTuningConfig const& self)
+    { return py::make_tuple(self.getEmbeddingTable(), self.getInputTokenExtraIds()); };
+    auto promptTuningConfigSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 2)
+        {
+            throw std::runtime_error("Invalid PromptTuningConfig state!");
+        }
+        return tle::PromptTuningConfig(state[0].cast<Tensor>(), state[1].cast<std::optional<VecTokenExtraIds>>());
+    };
+    py::class_<tle::PromptTuningConfig>(m, "PromptTuningConfig")
+        .def(py::init<Tensor, std::optional<VecTokenExtraIds>>(), py::arg("embedding_table"),
+            py::arg("input_token_extra_ids") = py::none())
+        .def_property_readonly("embedding_table", &tle::PromptTuningConfig::getEmbeddingTable)
+        .def_property_readonly("input_token_extra_ids", &tle::PromptTuningConfig::getInputTokenExtraIds)
+        .def(py::pickle(promptTuningConfigGetstate, promptTuningConfigSetstate));
+
+    auto loraConfigGetstate = [](tle::LoraConfig const& self)
+    { return py::make_tuple(self.getTaskId(), self.getWeights(), self.getConfig()); };
+    auto loraConfigSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 3)
+        {
+            throw std::runtime_error("Invalid LoraConfig state!");
+        }
+        return tle::LoraConfig(
+            state[0].cast<IdType>(), state[1].cast<std::optional<Tensor>>(), state[2].cast<std::optional<Tensor>>());
+    };
+    py::class_<tle::LoraConfig>(m, "LoraConfig")
+        .def(py::init<uint64_t, std::optional<Tensor>, std::optional<Tensor>>(), py::arg("task_id"),
+            py::arg("weights") = py::none(), py::arg("config") = py::none())
+        .def_property_readonly("task_id", &tle::LoraConfig::getTaskId)
+        .def_property_readonly("weights", &tle::LoraConfig::getWeights)
+        .def_property_readonly("config", &tle::LoraConfig::getConfig)
+        .def(py::pickle(loraConfigGetstate, loraConfigSetstate));
+
+    auto multimodalInputGetstate = [](tle::MultimodalInput const& self)
+    { return py::make_tuple(self.getMultimodalHashes(), self.getMultimodalPositions(), self.getMultimodalLengths()); };
+    auto multimodalInputSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 3)
+        {
+            throw std::runtime_error("Invalid MultimodalInput state!");
+        }
+        return tle::MultimodalInput(state[0].cast<std::vector<std::vector<SizeType32>>>(),
+            state[1].cast<std::vector<SizeType32>>(), state[2].cast<std::vector<SizeType32>>());
+    };
+    py::class_<tle::MultimodalInput>(m, "MultimodalInput")
+        .def(py::init<std::vector<std::vector<SizeType32>>, std::vector<SizeType32>, std::vector<SizeType32>>(),
+            py::arg("multimodal_hashes"), py::arg("multimodal_positions"), py::arg("multimodal_lengths"))
+        .def_property_readonly("multimodal_hashes", &tle::MultimodalInput::getMultimodalHashes)
+        .def_property_readonly("multimodal_positions", &tle::MultimodalInput::getMultimodalPositions)
+        .def_property_readonly("multimodal_lengths", &tle::MultimodalInput::getMultimodalLengths)
+        .def(py::pickle(multimodalInputGetstate, multimodalInputSetstate));
+
+    auto MropeConfigGetstate = [](tle::MropeConfig const& self)
+    { return py::make_tuple(self.getMRopeRotaryCosSin(), self.getMRopePositionDeltas()); };
+    auto MropeConfigSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 2)
+        {
+            throw std::runtime_error("Invalid MropeConfig state!");
+        }
+        return tle::MropeConfig(state[0].cast<tle::Tensor>(), state[1].cast<SizeType32>());
+    };
+    py::class_<tle::MropeConfig>(m, "MropeConfig")
+        .def(py::init<Tensor, SizeType32>(), py::arg("mrope_rotary_cos_sin"), py::arg("mrope_position_deltas"))
+        .def_property_readonly("mrope_rotary_cos_sin", &tle::MropeConfig::getMRopeRotaryCosSin)
+        .def_property_readonly("mrope_position_deltas", &tle::MropeConfig::getMRopePositionDeltas)
+        .def(py::pickle(MropeConfigGetstate, MropeConfigSetstate));
+
+    auto lookaheadDecodingConfigGetstate = [](tle::LookaheadDecodingConfig const& self)
+    { return py::make_tuple(self.getWindowSize(), self.getNgramSize(), self.getVerificationSetSize()); };
+    auto lookaheadDecodingConfigSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 3)
+        {
+            throw std::runtime_error("Invalid LookaheadDecodingConfig state!");
+        }
+        return tle::LookaheadDecodingConfig(
+            state[0].cast<SizeType32>(), state[1].cast<SizeType32>(), state[2].cast<SizeType32>());
+    };
+    py::class_<tle::LookaheadDecodingConfig>(m, "LookaheadDecodingConfig")
+        .def(py::init<SizeType32, SizeType32, SizeType32>(), py::arg("max_window_size"), py::arg("max_ngram_size"),
+            py::arg("max_verification_set_size"))
+        .def_property_readonly("max_window_size", &tle::LookaheadDecodingConfig::getWindowSize)
+        .def_property_readonly("max_ngram_size", &tle::LookaheadDecodingConfig::getNgramSize)
+        .def_property_readonly("max_verification_set_size", &tle::LookaheadDecodingConfig::getVerificationSetSize)
+        .def("calculate_speculative_resource", &tle::LookaheadDecodingConfig::calculateSpeculativeResource)
+        .def_static(
+            "calculate_speculative_resource_tuple", &tle::LookaheadDecodingConfig::calculateSpeculativeResourceTuple)
+        .def(py::pickle(lookaheadDecodingConfigGetstate, lookaheadDecodingConfigSetstate))
+        .def_static("get_default_lookahead_decoding_window",
+            []() { return tle::LookaheadDecodingConfig::kDefaultLookaheadDecodingWindow; })
+        .def_static("get_default_lookahead_decoding_ngram",
+            []() { return tle::LookaheadDecodingConfig::kDefaultLookaheadDecodingNgram; })
+        .def_static("get_default_lookahead_decoding_verification_set",
+            []() { return tle::LookaheadDecodingConfig::kDefaultLookaheadDecodingVerificationSet; });
+
+    auto TokenRangeRetentionConfigGetstate = [](tle::KvCacheRetentionConfig::TokenRangeRetentionConfig const& self)
+    { return py::make_tuple(self.tokenStart, self.tokenEnd, self.priority, self.durationMs); };
+    auto TokenRangeRetentionConfigSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 4)
+        {
+            throw std::runtime_error("Invalid state!");
+        }
+        return tle::KvCacheRetentionConfig::TokenRangeRetentionConfig(state[0].cast<SizeType32>(),
+            state[1].cast<std::optional<SizeType32>>(), state[2].cast<tle::RetentionPriority>(),
+            state[3].cast<std::optional<std::chrono::milliseconds>>());
+    };
+    auto kvCacheRetentionConfigGetstate = [](tle::KvCacheRetentionConfig const& self)
+    {
+        return py::make_tuple(self.getTokenRangeRetentionConfigs(), self.getDecodeRetentionPriority(),
+            self.getDecodeDurationMs(), self.getTransferMode(), self.getDirectory());
+    };
+    auto kvCacheRetentionConfigSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 5)
+        {
+            throw std::runtime_error("Invalid state!");
+        }
+        return tle::KvCacheRetentionConfig(
+            state[0].cast<std::vector<tle::KvCacheRetentionConfig::TokenRangeRetentionConfig>>(),
+            state[1].cast<tle::RetentionPriority>(), state[2].cast<std::optional<std::chrono::milliseconds>>(),
+            state[3].cast<tle::KvCacheTransferMode>(), state[4].cast<std::optional<std::string>>());
+    };
+
+    auto kvCacheRetentionConfig = py::class_<tle::KvCacheRetentionConfig>(m, "KvCacheRetentionConfig");
+
+    py::class_<tle::KvCacheRetentionConfig::TokenRangeRetentionConfig>(
+        kvCacheRetentionConfig, "TokenRangeRetentionConfig")
+        .def(py::init<SizeType32, std::optional<SizeType32>, tle::RetentionPriority,
+                 std::optional<std::chrono::milliseconds>>(),
+            py::arg("token_start"), py::arg("token_end"), py::arg("priority"), py::arg("duration_ms") = py::none())
+        .def_readwrite("token_start", &tle::KvCacheRetentionConfig::TokenRangeRetentionConfig::tokenStart)
+        .def_readwrite("token_end", &tle::KvCacheRetentionConfig::TokenRangeRetentionConfig::tokenEnd)
+        .def_readwrite("priority", &tle::KvCacheRetentionConfig::TokenRangeRetentionConfig::priority)
+        .def_readwrite("duration_ms", &tle::KvCacheRetentionConfig::TokenRangeRetentionConfig::durationMs)
+        .def(py::pickle(TokenRangeRetentionConfigGetstate, TokenRangeRetentionConfigSetstate))
+        .def("__eq__", &tle::KvCacheRetentionConfig::TokenRangeRetentionConfig::operator==);
+
+    // There's a circular dependency between the declaration of the TokenRangeRetentionPriority and
+    // KvCacheRetentionConfig bindings. Defer definition of the KvCacheRetentionConfig bindings until the
+    // TokenRangeRetentionPriority bindings have been defined.
+    kvCacheRetentionConfig
+        .def(py::init<std::vector<tle::KvCacheRetentionConfig::TokenRangeRetentionConfig>, tle::RetentionPriority,
+                 std::optional<std::chrono::milliseconds>, tle::KvCacheTransferMode, std::optional<std::string>>(),
+            py::arg("token_range_retention_configs"),
+            py::arg("decode_retention_priority") = tle::KvCacheRetentionConfig::kDefaultRetentionPriority,
+            py::arg("decode_duration_ms") = py::none(),
+            py::arg_v("transfer_mode", tle::KvCacheTransferMode::DRAM, "DRAM"), py::arg("directory") = py::none())
+        .def_property_readonly(
+            "token_range_retention_configs", &tle::KvCacheRetentionConfig::getTokenRangeRetentionConfigs)
+        .def_property_readonly("decode_retention_priority", &tle::KvCacheRetentionConfig::getDecodeRetentionPriority)
+        .def_property_readonly("decode_duration_ms", &tle::KvCacheRetentionConfig::getDecodeDurationMs)
+        .def_property_readonly("transfer_mode", &tle::KvCacheRetentionConfig::getTransferMode)
+        .def_property_readonly("directory", &tle::KvCacheRetentionConfig::getDirectory)
+        .def(py::pickle(kvCacheRetentionConfigGetstate, kvCacheRetentionConfigSetstate))
+        .def("__eq__", &tle::KvCacheRetentionConfig::operator==);
+
+    auto ContextPhaseParamsGetState = [](tle::ContextPhaseParams const& self)
+    {
+        if (self.getState() != nullptr)
+        {
+            auto serializedState = self.getSerializedState();
+            return py::make_tuple(self.getFirstGenTokens(), self.getReqId(),
+                py::bytes(serializedState.data(), serializedState.size()), self.getDraftTokens());
+        }
+        return py::make_tuple(self.getFirstGenTokens(), self.getReqId(), py::none(), self.getDraftTokens());
+    };
+
+    auto ContextPhaseParamsSetState = [](py::tuple const& state)
+    {
+        if (state.size() != 4)
+        {
+            throw std::runtime_error("Invalid ContextPhaseParams state!");
+        }
+        if (!state[2].is_none())
+        {
+            auto opaque_state = state[2].cast<py::bytes>();
+            auto opaque_state_str_view = std::string_view(opaque_state.cast<std::string_view>());
+            return std::make_unique<tle::ContextPhaseParams>(state[0].cast<VecTokens>(),
+                state[1].cast<tle::ContextPhaseParams::RequestIdType>(),
+                std::vector<char>(opaque_state_str_view.begin(), opaque_state_str_view.end()),
+                state[3].cast<std::optional<VecTokens>>());
+        }
+        return std::make_unique<tle::ContextPhaseParams>(state[0].cast<VecTokens>(),
+            state[1].cast<tle::ContextPhaseParams::RequestIdType>(), state[3].cast<std::optional<VecTokens>>());
+    };
+
+    py::class_<tle::ContextPhaseParams>(m, "ContextPhaseParams")
+        .def(py::init(
+            [](VecTokens const& first_gen_tokens, tle::ContextPhaseParams::RequestIdType req_id,
+                std::optional<py::bytes> const& opaque_state, std::optional<VecTokens> const& draft_tokens)
+            {
+                if (opaque_state)
+                {
+                    auto opaque_state_str_view = std::string_view(opaque_state.value().cast<std::string_view>());
+                    return std::make_unique<tle::ContextPhaseParams>(first_gen_tokens, req_id,
+                        std::vector<char>(opaque_state_str_view.begin(), opaque_state_str_view.end()), draft_tokens);
+                }
+                return std::make_unique<tle::ContextPhaseParams>(first_gen_tokens, req_id, draft_tokens);
+            }))
+        .def_property_readonly("first_gen_tokens", &tle::ContextPhaseParams::getFirstGenTokens)
+        .def_property_readonly("draft_tokens", &tle::ContextPhaseParams::getDraftTokens)
+        .def_property_readonly("req_id", &tle::ContextPhaseParams::getReqId)
+        .def_property_readonly("opaque_state",
+            [](tle::ContextPhaseParams const& self)
+            {
+                std::optional<py::bytes> opaque_state{std::nullopt};
+                if (self.getState() != nullptr)
+                {
+                    auto serializedState = self.getSerializedState();
+                    opaque_state = py::bytes(serializedState.data(), serializedState.size());
+                }
+                return opaque_state;
+            })
+        .def(py::pickle(ContextPhaseParamsGetState, ContextPhaseParamsSetState));
+
+    auto EagleDecodingConfigGetstate = [](tle::EagleConfig const& self)
+    {
+        return py::make_tuple(self.getEagleChoices(), self.isGreedySampling(), self.getPosteriorThreshold(),
+            self.useDynamicTree(), self.getDynamicTreeMaxTopK());
+    };
+    auto EagleDecodingConfigSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 5)
+        {
+            throw std::runtime_error("Invalid EagleConfig state!");
+        }
+        return tle::EagleConfig(state[0].cast<std::optional<tle::EagleChoices>>(), state[1].cast<bool>(),
+            state[2].cast<std::optional<float>>(), state[3].cast<bool>(), state[4].cast<std::optional<SizeType32>>());
+    };
+    py::class_<tle::EagleConfig>(m, "EagleConfig")
+        .def(py::init<std::optional<tle::EagleChoices>, bool, std::optional<float>, bool, std::optional<SizeType32>>(),
+            py::arg("eagle_choices") = py::none(), py::arg("greedy_sampling") = true,
+            py::arg("posterior_threshold") = py::none(), py::arg("use_dynamic_tree") = false,
+            py::arg("dynamic_tree_max_topK") = py::none())
+        .def_property_readonly("eagle_choices", &tle::EagleConfig::getEagleChoices)
+        .def_property_readonly("greedy_sampling", &tle::EagleConfig::isGreedySampling)
+        .def_property_readonly("posterior_threshold", &tle::EagleConfig::getPosteriorThreshold)
+        .def_property_readonly("use_dynamic_tree", &tle::EagleConfig::useDynamicTree)
+        .def_property_readonly("dynamic_tree_max_topK", &tle::EagleConfig::getDynamicTreeMaxTopK)
+        .def(py::pickle(EagleDecodingConfigGetstate, EagleDecodingConfigSetstate));
+
+    // Guided decoding params
+    auto pyGuidedDecodingParams = py::class_<tle::GuidedDecodingParams>(m, "GuidedDecodingParams");
+
+    py::enum_<tle::GuidedDecodingParams::GuideType>(pyGuidedDecodingParams, "GuideType")
+        .value("JSON", tle::GuidedDecodingParams::GuideType::kJSON)
+        .value("JSON_SCHEMA", tle::GuidedDecodingParams::GuideType::kJSON_SCHEMA)
+        .value("REGEX", tle::GuidedDecodingParams::GuideType::kREGEX)
+        .value("EBNF_GRAMMAR", tle::GuidedDecodingParams::GuideType::kEBNF_GRAMMAR)
+        .value("STRUCTURAL_TAG", tle::GuidedDecodingParams::GuideType::kSTRUCTURAL_TAG);
+
+    auto guidedDecodingParamsGetstate
+        = [](tle::GuidedDecodingParams const& self) { return py::make_tuple(self.getGuideType(), self.getGuide()); };
+
+    auto guidedDecodingParamsSetstate = [](py::tuple state)
+    {
+        if (state.size() != 2)
+        {
+            throw std::runtime_error("Invalid GuidedDecodingParams state!");
+        }
+        return tle::GuidedDecodingParams(
+            state[0].cast<tle::GuidedDecodingParams::GuideType>(), state[1].cast<std::optional<std::string>>());
+    };
+
+    pyGuidedDecodingParams
+        .def(py::init<tle::GuidedDecodingParams::GuideType, std::optional<std::string>>(), py::arg("guide_type"),
+            py::arg("guide") = py::none())
+        .def_property_readonly("guide_type", &tle::GuidedDecodingParams::getGuideType)
+        .def_property_readonly("guide", &tle::GuidedDecodingParams::getGuide)
+        .def(py::pickle(guidedDecodingParamsGetstate, guidedDecodingParamsSetstate));
+
+    auto requestGetstate = [](tle::Request const& self)
+    {
+        return py::make_tuple(self.getInputTokenIds(), self.getMaxTokens(), self.getStreaming(),
+            self.getSamplingConfig(), self.getOutputConfig(), self.getEndId(), self.getPadId(), self.getPositionIds(),
+            self.getBadWords(), self.getStopWords(), self.getEmbeddingBias(), self.getExternalDraftTokensConfig(),
+            self.getPromptTuningConfig(), self.getMultimodalInput(), self.getMultimodalEmbedding(),
+            self.getMropeConfig(), self.getLoraConfig(), self.getLookaheadConfig(), self.getKvCacheRetentionConfig(),
+            self.getLogitsPostProcessorName(), self.getLogitsPostProcessor(), self.getEncoderInputTokenIds(),
+            self.getClientId(), self.getReturnAllGeneratedTokens(), self.getPriority(), self.getRequestType(),
+            self.getContextPhaseParams(), self.getEncoderInputFeatures(), self.getEncoderOutputLength(),
+            self.getCrossAttentionMask(), self.getEagleConfig(), self.getSkipCrossAttnBlocks(),
+            self.getGuidedDecodingParams());
+    };
+    auto requestSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 33)
+        {
+            throw std::runtime_error("Invalid Request state!");
+        }
+        return std::make_unique<tle::Request>(state[0].cast<VecTokens>(), state[1].cast<SizeType32>(),
+            state[2].cast<bool>(), state[3].cast<tle::SamplingConfig>(), state[4].cast<tle::OutputConfig>(),
+            state[5].cast<std::optional<SizeType32>>(), state[6].cast<std::optional<SizeType32>>(),
+            state[7].cast<std::optional<std::vector<SizeType32>>>(),
+            state[8].cast<std::optional<std::list<VecTokens>>>(), state[9].cast<std::optional<std::list<VecTokens>>>(),
+            state[10].cast<std::optional<Tensor>>(), state[11].cast<std::optional<tle::ExternalDraftTokensConfig>>(),
+            state[12].cast<std::optional<tle::PromptTuningConfig>>(),
+            state[13].cast<std::optional<tle::MultimodalInput>>(), state[14].cast<std::optional<Tensor>>(),
+            state[15].cast<std::optional<tle::MropeConfig>>(), state[16].cast<std::optional<tle::LoraConfig>>(),
+            state[17].cast<std::optional<tle::LookaheadDecodingConfig>>(),
+            state[18].cast<std::optional<tle::KvCacheRetentionConfig>>(), state[19].cast<std::optional<std::string>>(),
+            state[20].cast<std::optional<tle::LogitsPostProcessor>>(), state[21].cast<std::optional<VecTokens>>(),
+            state[22].cast<std::optional<IdType>>(), state[23].cast<bool>(), state[24].cast<tle::PriorityType>(),
+            state[25].cast<tle::RequestType>(), state[26].cast<std::optional<tle::ContextPhaseParams>>(),
+            state[27].cast<std::optional<tle::Tensor>>(), state[28].cast<std::optional<SizeType32>>(),
+            state[29].cast<std::optional<tle::Tensor>>(), 1, state[30].cast<std::optional<tle::EagleConfig>>(),
+            state[31].cast<std::optional<tle::Tensor>>(), state[32].cast<std::optional<tle::GuidedDecodingParams>>());
+    };
+
+    py::class_<tle::Request> request(m, "Request", pybind11::dynamic_attr());
+    request
+        .def(py::init<tle::VecTokens,                           // inputTokenIds
+                 tle::SizeType32,                               // maxTokens
+                 bool,                                          // streaming
+                 tle::SamplingConfig const&,                    // samplingConfig
+                 tle::OutputConfig const&,                      // outputConfig
+                 std::optional<tle::SizeType32> const&,         // endId
+                 std::optional<tle::SizeType32> const&,         // padId
+                 std::optional<std::vector<SizeType32>>,        // positionIds
+                 std::optional<std::list<tle::VecTokens>>,      // badWords
+                 std::optional<std::list<tle::VecTokens>>,      // stopWords
+                 std::optional<tle::Tensor>,                    // embeddingBias
+                 std::optional<tle::ExternalDraftTokensConfig>, // externalDraftTokensConfig
+                 std::optional<tle::PromptTuningConfig>,        // pTuningConfig
+                 std::optional<tle::MultimodalInput>,           // multimodalInput
+                 std::optional<tle::Tensor>,                    // multimodalEmbedding
+                 std::optional<tle::MropeConfig>,               // mRopeConfig
+                 std::optional<tle::LoraConfig>,                // loraConfig
+                 std::optional<tle::LookaheadDecodingConfig>,   // lookaheadConfig
+                 std::optional<tle::KvCacheRetentionConfig>,    // kvCacheRetentionConfig
+                 std::optional<std::string>,                    // logitsPostProcessorName
+                 std::optional<tle::LogitsPostProcessor>,       // logitsPostProcessor
+                 std::optional<tle::VecTokens>,                 // encoderInputTokenIds
+                 std::optional<tle::IdType>,                    // clientId
+                 bool,                                          // returnAllGeneratedTokens
+                 tle::PriorityType,                             // priority
+                 tle::RequestType,                              // type
+                 std::optional<tle::ContextPhaseParams>,        // contextPhaseParams
+                 std::optional<tle::Tensor>,                    // encoderInputFeatures
+                 std::optional<tle::SizeType32>,                // encoderOutputLength
+                 std::optional<tle::Tensor>,                    // crossAttentionMask
+                 SizeType32,                                    // numReturnSequences
+                 std::optional<tle::EagleConfig>,               // eagleConfig
+                 std::optional<tle::Tensor>,                    // skipCrossAttnBlocks
+                 std::optional<tle::GuidedDecodingParams>,      // guidedDecodingParams
+                 std::optional<tle::SizeType32>,                // languageAdapterUid
+                 std::optional<tle::MillisecondsType>           // allottedTimeMs
+                 >(),
+            // clang-format off
+        py::arg("input_token_ids"),
+        py::arg("max_tokens"),
+        py::kw_only(),
+        py::arg("streaming") = false,
+        py::arg_v("sampling_config", tle::SamplingConfig(), "SamplingConfig()"),
+        py::arg_v("output_config", tle::OutputConfig(), "OutputConfig()"),
+        py::arg("end_id") = py::none(),
+        py::arg("pad_id") = py::none(),
+        py::arg("position_ids") = py::none(),
+        py::arg("bad_words") = py::none(),
+        py::arg("stop_words") = py::none(),
+        py::arg("embedding_bias") = py::none(),
+        py::arg("external_draft_tokens_config") = py::none(),
+        py::arg("prompt_tuning_config") = py::none(),
+        py::arg("multimodal_input") = py::none(),
+        py::arg("multimodal_embedding") = py::none(),
+        py::arg("mrope_config") = py::none(),
+        py::arg("lora_config") = py::none(),
+        py::arg("lookahead_config") = py::none(),
+        py::arg("kv_cache_retention_config") = py::none(),
+        py::arg("logits_post_processor_name") = py::none(),
+        py::arg("logits_post_processor") = py::none(),
+        py::arg("encoder_input_token_ids") = py::none(),
+        py::arg("client_id") = py::none(),
+        py::arg("return_all_generated_tokens") = false,
+        py::arg("priority") = tle::Request::kDefaultPriority,
+        py::arg_v("type", tle::RequestType::REQUEST_TYPE_CONTEXT_AND_GENERATION,
+            "RequestType.REQUEST_TYPE_CONTEXT_AND_GENERATION"),
+        py::arg("context_phase_params") = py::none(),
+        py::arg("encoder_input_features") = py::none(),
+        py::arg("encoder_output_length") = py::none(),
+        py::arg("cross_attention_mask") = py::none(),
+        py::arg("num_return_sequences") = 1,
+        py::arg("eagle_config") = py::none(),
+        py::arg("skip_cross_attn_blocks") = py::none(),
+        py::arg("guided_decoding_params") = py::none(),
+        py::arg("language_adapter_uid") = py::none(),
+        py::arg("allotted_time_ms") = py::none()
+    )          // clang-format on
+        .def_property_readonly("input_token_ids", &tle::Request::getInputTokenIds)
+        .def_property_readonly("max_tokens", &tle::Request::getMaxTokens)
+        .def_property("streaming", &tle::Request::getStreaming, &tle::Request::setStreaming)
+        .def_property("sampling_config", &tle::Request::getSamplingConfig, &tle::Request::setSamplingConfig)
+        .def_property("output_config", &tle::Request::getOutputConfig, &tle::Request::setOutputConfig)
+        .def_property("end_id", &tle::Request::getEndId, &tle::Request::setEndId)
+        .def_property("pad_id", &tle::Request::getPadId, &tle::Request::setPadId)
+        .def_property("position_ids", &tle::Request::getPositionIds, &tle::Request::setPositionIds)
+        .def_property("bad_words", &tle::Request::getBadWords, &tle::Request::setBadWords)
+        .def_property("stop_words", &tle::Request::getStopWords, &tle::Request::setStopWords)
+        .def_property("embedding_bias", &tle::Request::getEmbeddingBias, &tle::Request::setEmbeddingBias)
+        .def_property("external_draft_tokens_config", &tle::Request::getExternalDraftTokensConfig,
+            &tle::Request::setExternalDraftTokensConfig)
+        .def_property(
+            "prompt_tuning_config", &tle::Request::getPromptTuningConfig, &tle::Request::setPromptTuningConfig)
+        .def_property("multimodal_input", &tle::Request::getMultimodalInput, &tle::Request::setMultimodalInput)
+        .def_property(
+            "multimodal_embedding", &tle::Request::getMultimodalEmbedding, &tle::Request::setMultimodalEmbedding)
+        .def_property("mrope_config", &tle::Request::getMropeConfig, &tle::Request::setMropeConfig)
+        .def_property("lora_config", &tle::Request::getLoraConfig, &tle::Request::setLoraConfig)
+        .def_property("lookahead_config", &tle::Request::getLookaheadConfig, &tle::Request::setLookaheadConfig)
+        .def_property("kv_cache_retention_config", &tle::Request::getKvCacheRetentionConfig,
+            &tle::Request::setKvCacheRetentionConfig)
+        .def_property("logits_post_processor_name", &tle::Request::getLogitsPostProcessorName,
+            &tle::Request::setLogitsPostProcessorName)
+        .def_property(
+            "logits_post_processor", &tle::Request::getLogitsPostProcessor, &tle::Request::setLogitsPostProcessor)
+        .def_property(
+            "encoder_input_token_ids", &tle::Request::getEncoderInputTokenIds, &tle::Request::setEncoderInputTokenIds)
+        .def_property("client_id", &tle::Request::getClientId, &tle::Request::setClientId)
+        .def_property("return_all_generated_tokens", &tle::Request::getReturnAllGeneratedTokens,
+            &tle::Request::setReturnAllGeneratedTokens)
+        .def_property("request_type", &tle::Request::getRequestType, &tle::Request::setRequestType)
+        .def_property(
+            "encoder_input_features", &tle::Request::getEncoderInputFeatures, &tle::Request::setEncoderInputFeatures)
+        .def_property(
+            "cross_attention_mask", &tle::Request::getCrossAttentionMask, &tle::Request::setCrossAttentionMask)
+        .def_property("eagle_config", &tle::Request::getEagleConfig, &tle::Request::setEagleConfig)
+        .def_property(
+            "skip_cross_attn_blocks", &tle::Request::getSkipCrossAttnBlocks, &tle::Request::setSkipCrossAttnBlocks)
+        .def_property(
+            "guided_decoding_params", &tle::Request::getGuidedDecodingParams, &tle::Request::setGuidedDecodingParams)
+        .def_property("allotted_time_ms", &tle::Request::getAllottedTimeMs, &tle::Request::setAllottedTimeMs)
+        .def_property(
+            "context_phase_params", &tle::Request::getContextPhaseParams, &tle::Request::setContextPhaseParams)
+        .def(py::pickle(requestGetstate, requestSetstate));
+    request.attr("BATCHED_POST_PROCESSOR_NAME") = tle::Request::kBatchedPostProcessorName;
+
+    py::class_<tle::SpeculativeDecodingFastLogitsInfo>(m, "SpeculativeDecodingFastLogitsInfo")
+        .def(py::init<>())
+        .def_readwrite("draft_request_id", &tle::SpeculativeDecodingFastLogitsInfo::draftRequestId)
+        .def_readwrite("draft_participant_id", &tle::SpeculativeDecodingFastLogitsInfo::draftParticipantId)
+        .def("to_tensor", &tle::SpeculativeDecodingFastLogitsInfo::toTensor);
+
+    auto requestPerfMetrics = py::class_<tle::RequestPerfMetrics>(m, "RequestPerfMetrics");
+
+    auto timingMetricsGetstate = [](tle::RequestPerfMetrics::TimingMetrics const& self)
+    {
+        return py::make_tuple(self.arrivalTime, self.firstScheduledTime, self.firstTokenTime, self.lastTokenTime,
+            self.kvCacheTransferStart, self.kvCacheTransferEnd, self.kvCacheSize);
+    };
+    auto timingMetricsSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 7)
+        {
+            throw std::runtime_error("Invalid TimingMetrics state!");
+        }
+        return tle::RequestPerfMetrics::TimingMetrics{state[0].cast<tle::RequestPerfMetrics::TimePoint>(),
+            state[1].cast<tle::RequestPerfMetrics::TimePoint>(), state[2].cast<tle::RequestPerfMetrics::TimePoint>(),
+            state[3].cast<tle::RequestPerfMetrics::TimePoint>(), state[4].cast<tle::RequestPerfMetrics::TimePoint>(),
+            state[5].cast<tle::RequestPerfMetrics::TimePoint>(), state[6].cast<size_t>()};
+    };
+    py::class_<tle::RequestPerfMetrics::TimingMetrics>(m, "TimingMetrics")
+        .def(py::init<>())
+        .def_readwrite("arrival_time", &tle::RequestPerfMetrics::TimingMetrics::arrivalTime)
+        .def_readwrite("first_scheduled_time", &tle::RequestPerfMetrics::TimingMetrics::firstScheduledTime)
+        .def_readwrite("first_token_time", &tle::RequestPerfMetrics::TimingMetrics::firstTokenTime)
+        .def_readwrite("last_token_time", &tle::RequestPerfMetrics::TimingMetrics::lastTokenTime)
+        .def_readwrite("kv_cache_transfer_start", &tle::RequestPerfMetrics::TimingMetrics::kvCacheTransferStart)
+        .def_readwrite("kv_cache_transfer_end", &tle::RequestPerfMetrics::TimingMetrics::kvCacheTransferEnd)
+        .def_readwrite("kv_cache_size", &tle::RequestPerfMetrics::TimingMetrics::kvCacheSize)
+        .def(py::pickle(timingMetricsGetstate, timingMetricsSetstate));
+
+    auto kvCacheMetricsGetstate = [](tle::RequestPerfMetrics::KvCacheMetrics const& self)
+    {
+        return py::make_tuple(self.numTotalAllocatedBlocks, self.numNewAllocatedBlocks, self.numReusedBlocks,
+            self.numMissedBlocks, self.kvCacheHitRate);
+    };
+    auto kvCacheMetricsSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 5)
+        {
+            throw std::runtime_error("Invalid KvCacheMetrics state!");
+        }
+        return tle::RequestPerfMetrics::KvCacheMetrics{state[0].cast<SizeType32>(), state[1].cast<SizeType32>(),
+            state[2].cast<SizeType32>(), state[3].cast<SizeType32>(), state[4].cast<float>()};
+    };
+    py::class_<tle::RequestPerfMetrics::KvCacheMetrics>(m, "KvCacheMetrics")
+        .def(py::init<>())
+        .def_readwrite("num_total_allocated_blocks", &tle::RequestPerfMetrics::KvCacheMetrics::numTotalAllocatedBlocks)
+        .def_readwrite("num_new_allocated_blocks", &tle::RequestPerfMetrics::KvCacheMetrics::numNewAllocatedBlocks)
+        .def_readwrite("num_reused_blocks", &tle::RequestPerfMetrics::KvCacheMetrics::numReusedBlocks)
+        .def_readwrite("num_missed_blocks", &tle::RequestPerfMetrics::KvCacheMetrics::numMissedBlocks)
+        .def_readwrite("kv_cache_hit_rate", &tle::RequestPerfMetrics::KvCacheMetrics::kvCacheHitRate)
+        .def(py::pickle(kvCacheMetricsGetstate, kvCacheMetricsSetstate));
+
+    auto speculativeDecodingMetricsGetstate = [](tle::RequestPerfMetrics::SpeculativeDecodingMetrics const& self)
+    { return py::make_tuple(self.acceptanceRate, self.totalAcceptedDraftTokens, self.totalDraftTokens); };
+    auto speculativeDecodingMetricsSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 3)
+        {
+            throw std::runtime_error("Invalid SpeculativeDecodingMetrics state!");
+        }
+        return tle::RequestPerfMetrics::SpeculativeDecodingMetrics{
+            state[0].cast<float>(), state[1].cast<SizeType32>(), state[2].cast<SizeType32>()};
+    };
+
+    py::class_<tle::RequestPerfMetrics::SpeculativeDecodingMetrics>(m, "SpeculativeDecodingMetrics")
+        .def(py::init<>())
+        .def_readwrite("acceptance_rate", &tle::RequestPerfMetrics::SpeculativeDecodingMetrics::acceptanceRate)
+        .def_readwrite("total_accepted_draft_tokens",
+            &tle::RequestPerfMetrics::SpeculativeDecodingMetrics::totalAcceptedDraftTokens)
+        .def_readwrite("total_draft_tokens", &tle::RequestPerfMetrics::SpeculativeDecodingMetrics::totalDraftTokens)
+        .def(py::pickle(speculativeDecodingMetricsGetstate, speculativeDecodingMetricsSetstate));
+
+    auto requestPerfMetricsGetstate = [](tle::RequestPerfMetrics const& self)
+    {
+        return py::make_tuple(self.timingMetrics, self.kvCacheMetrics, self.speculativeDecoding, self.firstIter,
+            self.lastIter, self.iter);
+    };
+    auto requestPerfMetricsSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 6)
+        {
+            throw std::runtime_error("Invalid RequestPerfMetrics state!");
+        }
+        return tle::RequestPerfMetrics{state[0].cast<tle::RequestPerfMetrics::TimingMetrics>(),
+            state[1].cast<tle::RequestPerfMetrics::KvCacheMetrics>(),
+            state[2].cast<tle::RequestPerfMetrics::SpeculativeDecodingMetrics>(),
+            state[3].cast<std::optional<tle::IterationType>>(), state[4].cast<std::optional<tle::IterationType>>(),
+            state[5].cast<std::optional<tle::IterationType>>()};
+    };
+
+    // There's a circular dependency between the declaration of the TimingMetrics and RequestPerfMetrics bindings.
+    // Defer definition of the RequestPerfMetrics bindings until the TimingMetrics have been defined.
+    requestPerfMetrics.def(py::init<>())
+        .def_readwrite("timing_metrics", &tle::RequestPerfMetrics::timingMetrics)
+        .def_readwrite("kv_cache_metrics", &tle::RequestPerfMetrics::kvCacheMetrics)
+        .def_readwrite("speculative_decoding", &tle::RequestPerfMetrics::speculativeDecoding)
+        .def_readwrite("first_iter", &tle::RequestPerfMetrics::firstIter)
+        .def_readwrite("last_iter", &tle::RequestPerfMetrics::lastIter)
+        .def_readwrite("iter", &tle::RequestPerfMetrics::iter)
+        .def(py::pickle(requestPerfMetricsGetstate, requestPerfMetricsSetstate));
+
+    py::class_<tle::AdditionalOutput>(m, "AdditionalOutput")
+        .def(py::init([](std::string const& name, tle::Tensor const& output)
+            { return std::make_unique<tle::AdditionalOutput>(name, output); }))
+        .def_readwrite("name", &tle::AdditionalOutput::name)
+        .def_readwrite("output", &tle::AdditionalOutput::output);
+
+    auto resultSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 13)
+        {
+            throw std::runtime_error("Invalid Request state!");
+        }
+        tle::Result result;
+        result.isFinal = state[0].cast<bool>();
+        result.outputTokenIds = state[1].cast<std::vector<VecTokens>>();
+        result.cumLogProbs = state[2].cast<std::optional<std::vector<float>>>();
+        result.logProbs = state[3].cast<std::optional<std::vector<std::vector<float>>>>();
+        result.contextLogits = state[4].cast<std::optional<Tensor>>();
+        result.generationLogits = state[5].cast<std::optional<Tensor>>();
+        result.encoderOutput = state[6].cast<std::optional<Tensor>>();
+        result.finishReasons = state[7].cast<std::vector<tle::FinishReason>>();
+        result.sequenceIndex = state[8].cast<SizeType32>();
+        result.isSequenceFinal = state[9].cast<bool>();
+        result.decodingIter = state[10].cast<SizeType32>();
+        result.contextPhaseParams = state[11].cast<std::optional<tle::ContextPhaseParams>>();
+        result.requestPerfMetrics = state[12].cast<std::optional<tle::RequestPerfMetrics>>();
+        return std::make_unique<tle::Result>(result);
+    };
+
+    auto resultGetstate = [](tle::Result const& self)
+    {
+        return py::make_tuple(self.isFinal, self.outputTokenIds, self.cumLogProbs, self.logProbs, self.contextLogits,
+            self.generationLogits, self.encoderOutput, self.finishReasons, self.sequenceIndex, self.isSequenceFinal,
+            self.decodingIter, self.contextPhaseParams, self.requestPerfMetrics);
+    };
+
+    py::class_<tle::Result>(m, "Result")
+        .def(py::init<>())
+        .def_readwrite("is_final", &tle::Result::isFinal)
+        .def_readwrite("output_token_ids", &tle::Result::outputTokenIds)
+        .def_readwrite("cum_log_probs", &tle::Result::cumLogProbs)
+        .def_readwrite("log_probs", &tle::Result::logProbs)
+        .def_readwrite("context_logits", &tle::Result::contextLogits)
+        .def_readwrite("generation_logits", &tle::Result::generationLogits)
+        .def_readwrite("spec_dec_fast_logits_info", &tle::Result::specDecFastLogitsInfo)
+        .def_readwrite("encoder_output", &tle::Result::encoderOutput)
+        .def_readwrite("finish_reasons", &tle::Result::finishReasons)
+        .def_readwrite("sequence_index", &tle::Result::sequenceIndex)
+        .def_readwrite("is_sequence_final", &tle::Result::isSequenceFinal)
+        .def_readwrite("decoding_iter", &tle::Result::decodingIter)
+        .def_readwrite("context_phase_params", &tle::Result::contextPhaseParams)
+        .def_readwrite("request_perf_metrics", &tle::Result::requestPerfMetrics)
+        .def_readwrite("additional_outputs", &tle::Result::additionalOutputs)
+        .def(py::pickle(resultGetstate, resultSetstate));
+
+    m.def("deserialize_result",
+        [](std::string& x)
+        {
+            std::istringstream is(x);
+            return tle::serialize_utils::deserialize<tle::Result>(is);
+        });
+
+    auto responseGetstate = [](tle::Response const& self)
+    { return py::make_tuple(self.getRequestId(), self.getResult(), self.getClientId()); };
+
+    auto responseSetstate = [](py::tuple const& state)
+    {
+        if (state.size() != 3)
+        {
+            throw std::runtime_error("Invalid Request state!");
+        }
+        return std::make_unique<tle::Response>(
+            state[0].cast<SizeType32>(), state[1].cast<tle::Result>(), state[2].cast<SizeType32>());
+    };
+
+    py::class_<tle::Response>(m, "Response")
+        .def(py::init<IdType, std::string, std::optional<IdType>>(), py::arg("request_id"), py::arg("error_msg"),
+            py::arg("client_id") = std::nullopt)
+        .def(py::init<IdType, tle::Result, std::optional<IdType>>(), py::arg("request_id"), py::arg("result"),
+            py::arg("client_id") = std::nullopt)
+        .def_property_readonly("request_id", &tle::Response::getRequestId)
+        .def_property_readonly("client_id", &tle::Response::getClientId)
+        .def("has_error", &tle::Response::hasError)
+        .def_property_readonly("error_msg", &tle::Response::getErrorMsg)
+        .def_property_readonly("result", &tle::Response::getResult)
+        .def("clear_context_logits",
+            [](tle::Response& self)
+            {
+                if (!self.hasError())
+                {
+                    auto& result = const_cast<tle::Result&>(self.getResult());
+                    result.contextLogits.reset();
+                }
+            })
+        .def("clear_generation_logits",
+            [](tle::Response& self)
+            {
+                if (!self.hasError())
+                {
+                    auto& result = const_cast<tle::Result&>(self.getResult());
+                    result.generationLogits.reset();
+                }
+            })
+        .def(py::pickle(responseGetstate, responseSetstate));
+}
+
+} // namespace tensorrt_llm::pybind::executor

--- a/cpp/tensorrt_llm/nanobind/executor/request.h
+++ b/cpp/tensorrt_llm/nanobind/executor/request.h
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "tensorrt_llm/pybind/common/customCasters.h"
+#include <pybind11/pybind11.h>
+
+namespace tensorrt_llm::pybind::executor
+{
+
+// Register bindings for executor API.
+void initRequestBindings(pybind11::module_& m);
+
+} // namespace tensorrt_llm::pybind::executor

--- a/cpp/tensorrt_llm/nanobind/executor/request.h
+++ b/cpp/tensorrt_llm/nanobind/executor/request.h
@@ -17,13 +17,12 @@
 
 #pragma once
 
-#include "tensorrt_llm/pybind/common/customCasters.h"
-#include <pybind11/pybind11.h>
+#include "tensorrt_llm/nanobind/common/customCasters.h"
 
-namespace tensorrt_llm::pybind::executor
+namespace tensorrt_llm::nanobind::executor
 {
 
 // Register bindings for executor API.
-void initRequestBindings(pybind11::module_& m);
+void initRequestBindings(::nanobind::module_& m);
 
-} // namespace tensorrt_llm::pybind::executor
+} // namespace tensorrt_llm::nanobind::executor

--- a/cpp/tensorrt_llm/nanobind/runtime/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/runtime/bindings.cpp
@@ -42,123 +42,73 @@
 
 #include <ATen/ATen.h>
 #include <c10/cuda/CUDAStream.h>
-#include <pybind11/stl.h>
-#include <pybind11/stl_bind.h>
-#include <torch/extension.h>
+#include <nanobind/stl/vector.h>
 
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/operators.h>
+#include <nanobind/stl/bind_vector.h>
+#include <nanobind/stl/filesystem.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/unique_ptr.h>
+#include <nanobind/trampoline.h>
+#include <torch/extension.h>
 namespace tr = tensorrt_llm::runtime;
 namespace te = tensorrt_llm::executor;
 
-class PyITensor : public tensorrt_llm::runtime::ITensor
+// Add custom type caster for void*
+namespace nanobind::detail
 {
-public:
-    /* Inherit the constructors */
-    using ITensor::ITensor;
+template <>
+struct type_caster<void*>
+{
+    NB_TYPE_CASTER(void*, const_name("void*"));
 
-    [[nodiscard]] void* data() override
+    bool from_python(handle src, uint8_t, cleanup_list*) noexcept
     {
-        PYBIND11_OVERRIDE_PURE(void*, /* Return type */
-            ITensor,                  /* Parent class */
-            data                      /* Name of function in C++ (must match Python name) */
-                                      /* Argument(s) */
-        );
+        if (PyCapsule_CheckExact(src.ptr()))
+        {
+            value = PyCapsule_GetPointer(src.ptr(), nullptr);
+            return true;
+        }
+        return false;
     }
 
-    [[nodiscard]] void const* data() const override
+    static handle from_cpp(void* src, rv_policy policy, cleanup_list*) noexcept
     {
-        PYBIND11_OVERRIDE_PURE(void const*, /* Return type */
-            ITensor,                        /* Parent class */
-            data                            /* Name of function in C++ (must match Python name) */
-                                            /* Argument(s) */
-        );
-    }
-
-    [[nodiscard]] std::size_t getSize() const override
-    {
-        PYBIND11_OVERRIDE_PURE(std::size_t, /* Return type */
-            ITensor,                        /* Parent class */
-            getSize                         /* Name of function in C++ (must match Python name) */
-                                            /* Argument(s) */
-        );
-    }
-
-    [[nodiscard]] std::size_t getCapacity() const override
-    {
-        PYBIND11_OVERRIDE_PURE(std::size_t, /* Return type */
-            ITensor,                        /* Parent class */
-            getCapacity                     /* Name of function in C++ (must match Python name) */
-                                            /* Argument(s) */
-        );
-    }
-
-    [[nodiscard]] DataType getDataType() const override
-    {
-        PYBIND11_OVERRIDE_PURE(DataType, /* Return type */
-            ITensor,                     /* Parent class */
-            getDataType                  /* Name of function in C++ (must match Python name) */
-                                         /* Argument(s) */
-        );
-    }
-
-    [[nodiscard]] tr::MemoryType getMemoryType() const override
-    {
-        PYBIND11_OVERRIDE_PURE(tr::MemoryType, /* Return type */
-            ITensor,                           /* Parent class */
-            getMemoryType                      /* Name of function in C++ (must match Python name) */
-                                               /* Argument(s) */
-        );
-    }
-
-    [[nodiscard]] char const* getMemoryTypeName() const override
-    {
-        PYBIND11_OVERRIDE_PURE(char const*, /* Return type */
-            ITensor,                        /* Parent class */
-            getMemoryTypeName               /* Name of function in C++ (must match Python name) */
-                                            /* Argument(s) */
-        );
-    }
-
-    virtual void resize(std::size_t newSize) override
-    {
-        PYBIND11_OVERRIDE_PURE(void, /* Return type */
-            ITensor,                 /* Parent class */
-            resize                   /* Name of function in C++ (must match Python name) */
-                                     /* Argument(s) */
-        );
-    }
-
-    void release() override
-    {
-        PYBIND11_OVERRIDE_PURE(void, /* Return type */
-            ITensor,                 /* Parent class */
-            release                  /* Name of function in C++ (must match Python name) */
-                                     /* Argument(s) */
-        );
-    }
-
-    [[nodiscard]] Shape const& getShape() const override
-    {
-        PYBIND11_OVERRIDE_PURE(Shape const&, /* Return type */
-            ITensor,                         /* Parent class */
-            getShape                         /* Name of function in C++ (must match Python name) */
-                                             /* Argument(s) */
-        );
-    }
-
-    void reshape(Shape const& dims) override
-    {
-        PYBIND11_OVERRIDE_PURE(void, /* Return type */
-            ITensor,                 /* Parent class */
-            reshape,                 /* Name of function in C++ (must match Python name) */
-            dims                     /* Argument(s) */
-        );
+        return capsule(src, [](void*) noexcept {});
     }
 };
+
+template <>
+struct type_caster<void const*>
+{
+    NB_TYPE_CASTER(void const*, const_name("const void*"));
+
+    bool from_python(handle src, uint8_t, cleanup_list*) noexcept
+    {
+        if (PyCapsule_CheckExact(src.ptr()))
+        {
+            value = PyCapsule_GetPointer(src.ptr(), nullptr);
+            return true;
+        }
+        return false;
+    }
+
+    static handle from_cpp(void const* src, rv_policy policy, cleanup_list*) noexcept
+    {
+        return capsule(const_cast<void*>(src), [](void*) noexcept {});
+    }
+};
+} // namespace nanobind::detail
 
 class PyIGptDecoder : public tr::IGptDecoder
 {
 public:
-    using tr::IGptDecoder::IGptDecoder; // Inherit constructors
+    NB_TRAMPOLINE(tr::IGptDecoder, 5);
+
+    // using tr::IGptDecoder::IGptDecoder; // Inherit constructors
 
     void setup(tr::SamplingConfig const& samplingConfig, size_t batchSize,
         tr::DecodingInput::TensorConstPtr const& batchSlots,
@@ -167,147 +117,161 @@ public:
         std::optional<std::vector<tr::ITensor::SharedConstPtr>> const& lookaheadPrompt = std::nullopt,
         std::optional<std::vector<te::LookaheadDecodingConfig>> const& lookaheadAlgoConfigs = std::nullopt) override
     {
-        PYBIND11_OVERRIDE_PURE(void, IGptDecoder, setup, samplingConfig, batchSize, batchSlots, output,
-            explicitDraftTokensDType, lookaheadPrompt, lookaheadAlgoConfigs);
+        NB_OVERRIDE_PURE(setup, samplingConfig, batchSize, batchSlots, output, explicitDraftTokensDType,
+            lookaheadPrompt, lookaheadAlgoConfigs);
     }
 
     void forwardAsync(tr::DecodingOutput& output, tr::DecodingInput const& input) override
     {
-        PYBIND11_OVERRIDE_PURE(void, IGptDecoder, forwardAsync, output, input);
+        NB_OVERRIDE_PURE(forwardAsync, output, input);
     }
 
     void forwardSync(tr::DecodingOutput& output, tr::DecodingInput const& input) override
     {
-        PYBIND11_OVERRIDE_PURE(void, IGptDecoder, forwardSync, output, input);
+        NB_OVERRIDE_PURE(forwardSync, output, input);
     }
 
     tr::SamplingConfig const& getSamplingConfig() override
     {
-        PYBIND11_OVERRIDE_PURE(tr::SamplingConfig const&, IGptDecoder, getSamplingConfig);
+        NB_OVERRIDE_PURE(getSamplingConfig);
     }
 
     void disableLookahead(std::optional<tr::SamplingConfig> const& samplingConfig, tr::SizeType32 batchSize,
         tr::DecodingInput::TensorConstPtr batchSlots) override
     {
-        PYBIND11_OVERRIDE_PURE(void, IGptDecoder, disableLookahead, samplingConfig, batchSize, batchSlots);
+        NB_OVERRIDE_PURE(disableLookahead, samplingConfig, batchSize, batchSlots);
     }
 };
 
-namespace tensorrt_llm::pybind::runtime
+namespace tensorrt_llm::nanobind::runtime
 {
 
-void initBindings(pybind11::module_& m)
+void initBindings(nb::module_& m)
 {
-    py::classh<tr::ITensor, PyITensor>(m, "ITensor").def(py::init());
-    py::class_<tr::LoraCache::TaskLayerModuleConfig>(m, "TaskLayerModuleConfig")
-        .def(py::init<>())
-        .def_readwrite("page_id", &tr::LoraCache::TaskLayerModuleConfig::pageId)
-        .def_readwrite("slot_idx", &tr::LoraCache::TaskLayerModuleConfig::slotIdx)
-        .def_readwrite("in_size", &tr::LoraCache::TaskLayerModuleConfig::inSize)
-        .def_readwrite("out_size", &tr::LoraCache::TaskLayerModuleConfig::outSize)
-        .def_readwrite("module_id", &tr::LoraCache::TaskLayerModuleConfig::moduleId)
-        .def_readwrite("layer_id", &tr::LoraCache::TaskLayerModuleConfig::layerId)
-        .def_readwrite("adapter_size", &tr::LoraCache::TaskLayerModuleConfig::adapterSize)
-        .def_readwrite("num_slots", &tr::LoraCache::TaskLayerModuleConfig::numSlots)
-        .def_readwrite("weights_in_pointer", &tr::LoraCache::TaskLayerModuleConfig::weightsInPointer)
-        .def_readwrite("weights_out_pointer", &tr::LoraCache::TaskLayerModuleConfig::weightsOutPointer)
-        .def_readwrite("scaling_vec_pointer", &tr::LoraCache::TaskLayerModuleConfig::scalingVecPointer)
-        .def(py::self == py::self);
 
-    py::classh<tr::BufferManager>(m, "BufferManager")
-        .def(py::init<tr::BufferManager::CudaStreamPtr, bool>(), py::arg("stream"), py::arg("trim_pool") = false)
-        .def_property_readonly("stream", &tr::BufferManager::getStream);
+    nb::class_<tr::LoraCache::TaskLayerModuleConfig>(m, "TaskLayerModuleConfig")
+        .def(nb::init<>())
+        .def_rw("page_id", &tr::LoraCache::TaskLayerModuleConfig::pageId)
+        .def_rw("slot_idx", &tr::LoraCache::TaskLayerModuleConfig::slotIdx)
+        .def_rw("in_size", &tr::LoraCache::TaskLayerModuleConfig::inSize)
+        .def_rw("out_size", &tr::LoraCache::TaskLayerModuleConfig::outSize)
+        .def_rw("module_id", &tr::LoraCache::TaskLayerModuleConfig::moduleId)
+        .def_rw("layer_id", &tr::LoraCache::TaskLayerModuleConfig::layerId)
+        .def_rw("adapter_size", &tr::LoraCache::TaskLayerModuleConfig::adapterSize)
+        .def_rw("num_slots", &tr::LoraCache::TaskLayerModuleConfig::numSlots)
+        .def_rw("weights_in_pointer", &tr::LoraCache::TaskLayerModuleConfig::weightsInPointer)
+        .def_rw("weights_out_pointer", &tr::LoraCache::TaskLayerModuleConfig::weightsOutPointer)
+        .def_rw("scaling_vec_pointer", &tr::LoraCache::TaskLayerModuleConfig::scalingVecPointer)
+        .def("__eq__",
+            [](tr::LoraCache::TaskLayerModuleConfig const& self, tr::LoraCache::TaskLayerModuleConfig const& other)
+            { return self == other; });
+    // .def(nb::self == nb::self);
 
-    py::classh<tr::TllmRuntime>(m, "TllmRuntime")
-        .def(py::init(
-            [](std::filesystem::path engine_path, float gpu_weights_percent = 1.0f, bool use_shape_inference = true)
+    nb::class_<tr::BufferManager>(m, "BufferManager")
+        .def(nb::init<tr::BufferManager::CudaStreamPtr, bool>(), nb::arg("stream"), nb::arg("trim_pool") = false)
+        .def_prop_ro("stream", &tr::BufferManager::getStream);
+
+    nb::class_<tr::TllmRuntime>(m, "TllmRuntime")
+        .def(
+            "__init__",
+            [](tr::TllmRuntime* self, std::filesystem::path engine_path, float gpu_weights_percent = 1.0f,
+                bool use_shape_inference = true)
             {
                 // Using default logger by passing nullptr
-                return new tr::TllmRuntime(
-                    tr::RawEngine(engine_path), nullptr, gpu_weights_percent, use_shape_inference);
-            }))
-        .def(py::init(
-            [](py::buffer engine_buffer, float gpu_weights_percent = 1.0f, bool use_shape_inference = true)
+                new (self)
+                    tr::TllmRuntime(tr::RawEngine(engine_path), nullptr, gpu_weights_percent, use_shape_inference);
+            },
+            nb::arg("engine_path"), nb::arg("gpu_weights_percent") = 1.0f, nb::arg("use_shape_inference") = true)
+        .def(
+            "__init__",
+            [](tr::TllmRuntime* self, nb::ndarray<nb::numpy, uint8_t> engine_buffer, float gpu_weights_percent = 1.0f,
+                bool use_shape_inference = true)
             {
-                py::buffer_info info = engine_buffer.request();
-                if (info.ndim != 1)
+                // nb::buffer_info info = engine_buffer.request();
+                // nb::ndarray<nb::numpy, uint8_t> arr = engine_buffer.ensure<uint8_t>();
+                // nb::ndarray<nb::numpy, uint8_t> arr =  nb::cast<nb::ndarray<nb::numpy, uint8_t>>(engine_buffer);
+                if (engine_buffer.ndim() != 1)
                     throw std::runtime_error("Expected 1-D array for engine buffer");
-                return new tr::TllmRuntime(
-                    tr::RawEngine(info.ptr, info.shape[0]), nullptr, gpu_weights_percent, use_shape_inference);
-            }))
-        .def_property_readonly("num_contexts", &tr::TllmRuntime::getNbContexts)
-        .def_property_readonly("num_profiles", &tr::TllmRuntime::getNbProfiles)
-        .def("get_opt_profile_id", &tr::TllmRuntime::getOptProfileId, py::arg("num_tokens"), py::arg("split_points"))
+                new (self) tr::TllmRuntime(
+                    // tr::RawEngine(info.ptr, info.shape[0]), nullptr, gpu_weights_percent, use_shape_inference);
+                    tr::RawEngine(engine_buffer.data(), engine_buffer.size()), nullptr, gpu_weights_percent,
+                    use_shape_inference);
+            },
+            nb::arg("engine_buffer"), nb::arg("gpu_weights_percent") = 1.0f, nb::arg("use_shape_inference") = true)
+        .def_prop_ro("num_contexts", &tr::TllmRuntime::getNbContexts)
+        .def_prop_ro("num_profiles", &tr::TllmRuntime::getNbProfiles)
+        .def("get_opt_profile_id", &tr::TllmRuntime::getOptProfileId, nb::arg("num_tokens"), nb::arg("split_points"))
         .def("clear_contexts", &tr::TllmRuntime::clearContexts)
-        .def("execute_context", &tr::TllmRuntime::executeContext, py::arg("context_id"))
-        .def_property_readonly("stream_ptr", &tr::TllmRuntime::getStreamPtr)
-        .def_property_readonly("buffer_manager",
+        .def("execute_context", &tr::TllmRuntime::executeContext, nb::arg("context_id"))
+        .def_prop_ro("stream_ptr", &tr::TllmRuntime::getStreamPtr)
+        .def_prop_ro("buffer_manager",
             static_cast<tr::BufferManager& (tr::TllmRuntime::*) ()>(&tr::TllmRuntime::getBufferManager))
         .def("set_layer_profiler", &tr::TllmRuntime::setLayerProfiler)
-        .def("has_layer_profiler", &tr::TllmRuntime::hasLayerProfiler, py::arg("context_id"))
-        .def_property_readonly("layer_profiler_info", &tr::TllmRuntime::getLayerProfileInfo)
-        .def("report_to_profiler", &tr::TllmRuntime::reportToProfiler, py::arg("context_id"))
-        .def_property_readonly("logits_dtype_from_engine",
+        .def("has_layer_profiler", &tr::TllmRuntime::hasLayerProfiler, nb::arg("context_id"))
+        .def_prop_ro("layer_profiler_info", &tr::TllmRuntime::getLayerProfileInfo)
+        .def("report_to_profiler", &tr::TllmRuntime::reportToProfiler, nb::arg("context_id"))
+        .def_prop_ro("logits_dtype_from_engine",
             [](tr::TllmRuntime& self) { return self.getEngine().getTensorDataType("logits"); });
 
-    py::class_<tr::decoder_batch::Request>(m, "Request")
-        .def(py::init<tr::decoder_batch::Request::TensorConstPtr, tr::SizeType32, std::optional<tr::SizeType32>,
+    nb::class_<tr::decoder_batch::Request>(m, "Request")
+        .def(nb::init<tr::decoder_batch::Request::TensorConstPtr, tr::SizeType32, std::optional<tr::SizeType32>,
                  std::optional<tr::SizeType32>>(),
-            py::arg("ids"), py::arg("input_len"), py::arg("max_new_tokens") = std::nullopt,
-            py::arg("end_id") = std::nullopt)
-        .def_readwrite("ids", &tr::decoder_batch::Request::ids)
-        .def_readwrite("input_len", &tr::decoder_batch::Request::inputLen)
-        .def_readwrite("max_new_tokens", &tr::decoder_batch::Request::maxNewTokens)
-        .def_readwrite("end_id", &tr::decoder_batch::Request::endId)
-        .def_readwrite("draft_logits", &tr::decoder_batch::Request::draftLogits)
-        .def_readwrite("embedding_bias", &tr::decoder_batch::Request::embeddingBias)
-        .def_readwrite("bad_words_list", &tr::decoder_batch::Request::badWordsList)
-        .def_readwrite("stop_words_list", &tr::decoder_batch::Request::stopWordsList)
-        .def_readwrite("generated_tokens_per_engine_step", &tr::decoder_batch::Request::generatedTokensPerEngineStep)
-        .def_readwrite("medusa_paths", &tr::decoder_batch::Request::medusaPaths)
-        .def_readwrite("medusa_tree_ids", &tr::decoder_batch::Request::medusaTreeIds)
-        .def_readwrite("lookahead_runtime_config", &tr::decoder_batch::Request::lookaheadRuntimeConfig);
+            nb::arg("ids"), nb::arg("input_len"), nb::arg("max_new_tokens") = std::nullopt,
+            nb::arg("end_id") = std::nullopt)
+        .def_rw("ids", &tr::decoder_batch::Request::ids)
+        .def_rw("input_len", &tr::decoder_batch::Request::inputLen)
+        .def_rw("max_new_tokens", &tr::decoder_batch::Request::maxNewTokens)
+        .def_rw("end_id", &tr::decoder_batch::Request::endId)
+        .def_rw("draft_logits", &tr::decoder_batch::Request::draftLogits)
+        .def_rw("embedding_bias", &tr::decoder_batch::Request::embeddingBias)
+        .def_rw("bad_words_list", &tr::decoder_batch::Request::badWordsList)
+        .def_rw("stop_words_list", &tr::decoder_batch::Request::stopWordsList)
+        .def_rw("generated_tokens_per_engine_step", &tr::decoder_batch::Request::generatedTokensPerEngineStep)
+        .def_rw("medusa_paths", &tr::decoder_batch::Request::medusaPaths)
+        .def_rw("medusa_tree_ids", &tr::decoder_batch::Request::medusaTreeIds)
+        .def_rw("lookahead_runtime_config", &tr::decoder_batch::Request::lookaheadRuntimeConfig);
+    nb::bind_vector<std::vector<tr::decoder_batch::Request>>(m, "VectorRequest");
 
-    py::class_<tr::decoder_batch::Input>(m, "DecoderBatchInput")
-        .def(py::init<std::vector<std::vector<tr::ITensor::SharedConstPtr>>, tr::SizeType32>(), py::arg("logits"),
-            py::arg("max_decoding_engine_tokens"))
-        .def(py::init<std::vector<tr::ITensor::SharedConstPtr>>(), py::arg("logits"))
-        .def_readwrite("logits", &tr::decoder_batch::Input::logits)
-        .def_readwrite("max_decoder_steps", &tr::decoder_batch::Input::maxDecoderSteps)
-        .def_readwrite("batch_slots", &tr::decoder_batch::Input::batchSlots);
+    nb::class_<tr::decoder_batch::Input>(m, "DecoderBatchInput")
+        .def(nb::init<std::vector<std::vector<tr::ITensor::SharedConstPtr>>, tr::SizeType32>(), nb::arg("logits"),
+            nb::arg("max_decoding_engine_tokens"))
+        .def(nb::init<std::vector<tr::ITensor::SharedConstPtr>>(), nb::arg("logits"))
+        .def_rw("logits", &tr::decoder_batch::Input::logits)
+        .def_rw("max_decoder_steps", &tr::decoder_batch::Input::maxDecoderSteps)
+        .def_rw("batch_slots", &tr::decoder_batch::Input::batchSlots);
 
-    py::class_<tr::LookaheadDecodingBuffers>(m, "LookaheadDecodingBuffers")
-        .def(py::init<tr::SizeType32, tr::SizeType32, tr::BufferManager const&>(), py::arg("max_num_sequences"),
-            py::arg("max_tokens_per_step"), py::arg("buffer_manager"))
-        .def_readwrite("generation_lengths", &tr::LookaheadDecodingBuffers::generationLengths)
-        .def_readwrite("position_offsets", &tr::LookaheadDecodingBuffers::positionOffsets)
-        .def_readwrite("packed_masks", &tr::LookaheadDecodingBuffers::packedMasks)
-        .def_readwrite("position_ids", &tr::LookaheadDecodingBuffers::positionIds);
+    nb::class_<tr::LookaheadDecodingBuffers>(m, "LookaheadDecodingBuffers")
+        .def(nb::init<tr::SizeType32, tr::SizeType32, tr::BufferManager const&>(), nb::arg("max_num_sequences"),
+            nb::arg("max_tokens_per_step"), nb::arg("buffer_manager"))
+        .def_rw("generation_lengths", &tr::LookaheadDecodingBuffers::generationLengths)
+        .def_rw("position_offsets", &tr::LookaheadDecodingBuffers::positionOffsets)
+        .def_rw("packed_masks", &tr::LookaheadDecodingBuffers::packedMasks)
+        .def_rw("position_ids", &tr::LookaheadDecodingBuffers::positionIds);
 
-    py::class_<tr::ExplicitDraftTokensBuffers::Inputs>(m, "ExplicitDraftTokensBuffersInputs")
-        .def("create", &tr::ExplicitDraftTokensBuffers::Inputs::create, py::arg("max_num_sequences"),
-            py::arg("runtime"), py::arg("model_config"), py::arg("world_config"))
-        .def_readwrite("temperatures", &tr::ExplicitDraftTokensBuffers::Inputs::temperatures)
-        .def_readwrite("position_ids_base", &tr::ExplicitDraftTokensBuffers::Inputs::positionIdsBase)
-        .def_readwrite("generation_lengths", &tr::ExplicitDraftTokensBuffers::Inputs::generationLengths)
-        .def_readwrite("random_data_sample", &tr::ExplicitDraftTokensBuffers::Inputs::randomDataSample)
-        .def_readwrite("random_data_validation", &tr::ExplicitDraftTokensBuffers::Inputs::randomDataValidation)
-        .def_readwrite("draft_tokens", &tr::ExplicitDraftTokensBuffers::Inputs::draftTokens)
-        .def_readwrite("draft_indices", &tr::ExplicitDraftTokensBuffers::Inputs::draftIndices)
-        .def_readwrite("draft_probs", &tr::ExplicitDraftTokensBuffers::Inputs::draftProbs)
-        .def_readwrite("packed_masks", &tr::ExplicitDraftTokensBuffers::Inputs::packedMasks)
-        .def_readwrite("position_ids", &tr::ExplicitDraftTokensBuffers::Inputs::positionIds)
-        .def_readwrite("max_gen_length_host", &tr::ExplicitDraftTokensBuffers::Inputs::maxGenLengthHost)
-        .def_readwrite("generation_lengths_host", &tr::ExplicitDraftTokensBuffers::Inputs::generationLengthsHost);
+    nb::class_<tr::ExplicitDraftTokensBuffers::Inputs>(m, "ExplicitDraftTokensBuffersInputs")
+        .def("create", &tr::ExplicitDraftTokensBuffers::Inputs::create, nb::arg("max_num_sequences"),
+            nb::arg("runtime"), nb::arg("model_config"), nb::arg("world_config"))
+        .def_rw("temperatures", &tr::ExplicitDraftTokensBuffers::Inputs::temperatures)
+        .def_rw("position_ids_base", &tr::ExplicitDraftTokensBuffers::Inputs::positionIdsBase)
+        .def_rw("generation_lengths", &tr::ExplicitDraftTokensBuffers::Inputs::generationLengths)
+        .def_rw("random_data_sample", &tr::ExplicitDraftTokensBuffers::Inputs::randomDataSample)
+        .def_rw("random_data_validation", &tr::ExplicitDraftTokensBuffers::Inputs::randomDataValidation)
+        .def_rw("draft_tokens", &tr::ExplicitDraftTokensBuffers::Inputs::draftTokens)
+        .def_rw("draft_indices", &tr::ExplicitDraftTokensBuffers::Inputs::draftIndices)
+        .def_rw("draft_probs", &tr::ExplicitDraftTokensBuffers::Inputs::draftProbs)
+        .def_rw("packed_masks", &tr::ExplicitDraftTokensBuffers::Inputs::packedMasks)
+        .def_rw("position_ids", &tr::ExplicitDraftTokensBuffers::Inputs::positionIds)
+        .def_rw("max_gen_length_host", &tr::ExplicitDraftTokensBuffers::Inputs::maxGenLengthHost)
+        .def_rw("generation_lengths_host", &tr::ExplicitDraftTokensBuffers::Inputs::generationLengthsHost);
 
-    py::class_<tr::DecodingInput>(m, "DecodingInput");
-    py::class_<tr::DecodingOutput>(m, "DecodingOutput");
+    nb::class_<tr::DecodingInput>(m, "DecodingInput");
+    nb::class_<tr::DecodingOutput>(m, "DecodingOutput");
 
-    py::class_<tr::CudaEvent>(m, "CudaEvent")
-        .def(py::init<unsigned int>(), py::arg("flags") = cudaEventDisableTiming)
+    nb::class_<tr::CudaEvent>(m, "CudaEvent")
+        .def(nb::init<unsigned int>(), nb::arg("flags") = cudaEventDisableTiming)
         .def("synchronize", &tr::CudaEvent::synchronize);
 
-    py::class_<tr::IGptDecoder, PyIGptDecoder>(m, "IGptDecoder")
+    nb::class_<tr::IGptDecoder, PyIGptDecoder>(m, "IGptDecoder")
         .def(
             "setup",
             [](tr::IGptDecoder& self, tr::SamplingConfig const& samplingConfig, size_t batchSize,
@@ -320,82 +284,80 @@ void initBindings(pybind11::module_& m)
                 self.setup(samplingConfig, batchSize, std::move(tensorPtrBatchSlots), output, explicitDraftTokensDType,
                     lookaheadPrompt, lookaheadAlgoConfigs);
             },
-            py::arg("sampling_config"), py::arg("batch_size"), py::arg("batch_slots"), py::arg("output") = std::nullopt,
-            py::arg("explicit_draft_tokens_d_type") = std::nullopt, py::arg("lookahead_prompt") = std::nullopt,
-            py::arg("lookahead_algo_configs") = std::nullopt);
+            nb::arg("sampling_config"), nb::arg("batch_size"), nb::arg("batch_slots"), nb::arg("output") = std::nullopt,
+            nb::arg("explicit_draft_tokens_d_type") = std::nullopt, nb::arg("lookahead_prompt") = std::nullopt,
+            nb::arg("lookahead_algo_configs") = std::nullopt);
 
-    py::class_<tr::decoder::DecoderState>(m, "DecoderState")
-        .def(py::init<>())
-        .def("setup", &tr::decoder::DecoderState::setup, py::arg("max_batch_size"), py::arg("max_beam_width"),
-            py::arg("max_attention_window"), py::arg("sink_token_length"), py::arg("max_sequence_length"),
-            py::arg("dtype"), py::arg("model_config"), py::arg("world_config"), py::arg("buffer_manager"))
-        .def("setup_cache_indirection", &tr::decoder::DecoderState::setupCacheIndirection, py::arg("max_batch_size"),
-            py::arg("max_beam_width"), py::arg("max_attention_window"), py::arg("buffer_manager"))
+    nb::class_<tr::decoder::DecoderState>(m, "DecoderState")
+        .def(nb::init<>())
+        .def("setup", &tr::decoder::DecoderState::setup, nb::arg("max_batch_size"), nb::arg("max_beam_width"),
+            nb::arg("max_attention_window"), nb::arg("sink_token_length"), nb::arg("max_sequence_length"),
+            nb::arg("dtype"), nb::arg("model_config"), nb::arg("world_config"), nb::arg("buffer_manager"))
+        .def("setup_cache_indirection", &tr::decoder::DecoderState::setupCacheIndirection, nb::arg("max_batch_size"),
+            nb::arg("max_beam_width"), nb::arg("max_attention_window"), nb::arg("buffer_manager"))
         .def("setup_speculative_decoding", &tr::decoder::DecoderState::setupSpeculativeDecoding,
-            py::arg("speculative_decoding_mode"), py::arg("max_tokens_per_engine_step"), py::arg("dtype"),
-            py::arg("model_config"), py::arg("world_config"), py::arg("buffer_manager"))
-        .def_property_readonly("joint_decoding_input", &tr::decoder::DecoderState::getJointDecodingInput)
-        .def_property_readonly("joint_decoding_output", &tr::decoder::DecoderState::getJointDecodingOutput)
-        .def_property_readonly("cache_indirection_input", &tr::decoder::DecoderState::getCacheIndirectionInput)
-        .def_property_readonly("cache_indirection_output", &tr::decoder::DecoderState::getCacheIndirectionOutput)
-        .def_property_readonly(
-            "sequence_lengths", py::overload_cast<>(&tr::decoder::DecoderState::getSequenceLengths, py::const_))
+            nb::arg("speculative_decoding_mode"), nb::arg("max_tokens_per_engine_step"), nb::arg("dtype"),
+            nb::arg("model_config"), nb::arg("world_config"), nb::arg("buffer_manager"))
+        .def_prop_ro("joint_decoding_input", &tr::decoder::DecoderState::getJointDecodingInput)
+        .def_prop_ro("joint_decoding_output", &tr::decoder::DecoderState::getJointDecodingOutput)
+        .def_prop_ro("cache_indirection_input", &tr::decoder::DecoderState::getCacheIndirectionInput)
+        .def_prop_ro("cache_indirection_output", &tr::decoder::DecoderState::getCacheIndirectionOutput)
+        .def_prop_ro(
+            "sequence_lengths", nb::overload_cast<>(&tr::decoder::DecoderState::getSequenceLengths, nb::const_))
         .def("get_sequence_lengths",
-            py::overload_cast<tr::SizeType32>(&tr::decoder::DecoderState::getSequenceLengths, py::const_),
-            py::arg("batch_idx"))
-        .def_property_readonly("all_new_tokens", &tr::decoder::DecoderState::getAllNewTokens)
-        .def_property_readonly("finished_sum", &tr::decoder::DecoderState::getFinishedSum)
-        .def_property_readonly("finish_reasons", &tr::decoder::DecoderState::getFinishReasons)
-        .def_property_readonly("ids", py::overload_cast<>(&tr::decoder::DecoderState::getIds, py::const_))
-        .def("get_ids", py::overload_cast<tr::SizeType32>(&tr::decoder::DecoderState::getIds, py::const_),
-            py::arg("batch_idx"))
-        .def_property_readonly(
-            "gathered_ids", py::overload_cast<>(&tr::decoder::DecoderState::getGatheredIds, py::const_))
+            nb::overload_cast<tr::SizeType32>(&tr::decoder::DecoderState::getSequenceLengths, nb::const_),
+            nb::arg("batch_idx"))
+        .def_prop_ro("all_new_tokens", &tr::decoder::DecoderState::getAllNewTokens)
+        .def_prop_ro("finished_sum", &tr::decoder::DecoderState::getFinishedSum)
+        .def_prop_ro("finish_reasons", &tr::decoder::DecoderState::getFinishReasons)
+        .def_prop_ro("ids", nb::overload_cast<>(&tr::decoder::DecoderState::getIds, nb::const_))
+        .def("get_ids", nb::overload_cast<tr::SizeType32>(&tr::decoder::DecoderState::getIds, nb::const_),
+            nb::arg("batch_idx"))
+        .def_prop_ro("gathered_ids", nb::overload_cast<>(&tr::decoder::DecoderState::getGatheredIds, nb::const_))
         .def("get_gathered_ids",
-            py::overload_cast<tr::SizeType32>(&tr::decoder::DecoderState::getGatheredIds, py::const_),
-            py::arg("batch_idx"))
-        .def_property_readonly("parent_ids", &tr::decoder::DecoderState::getParentIds)
-        .def_property_readonly(
-            "cum_log_probs", py::overload_cast<>(&tr::decoder::DecoderState::getCumLogProbs, py::const_))
+            nb::overload_cast<tr::SizeType32>(&tr::decoder::DecoderState::getGatheredIds, nb::const_),
+            nb::arg("batch_idx"))
+        .def_prop_ro("parent_ids", &tr::decoder::DecoderState::getParentIds)
+        .def_prop_ro("cum_log_probs", nb::overload_cast<>(&tr::decoder::DecoderState::getCumLogProbs, nb::const_))
         .def("get_cum_log_probs",
-            py::overload_cast<tr::SizeType32>(&tr::decoder::DecoderState::getCumLogProbs, py::const_),
-            py::arg("batch_idx"))
-        .def_property_readonly("log_probs", py::overload_cast<>(&tr::decoder::DecoderState::getLogProbs, py::const_))
-        .def("get_log_probs", py::overload_cast<tr::SizeType32>(&tr::decoder::DecoderState::getLogProbs, py::const_),
-            py::arg("batch_idx"))
-        .def_property_readonly("next_draft_tokens", &tr::decoder::DecoderState::getNextDraftTokens)
-        .def_property_readonly("prev_draft_tokens_lengths", &tr::decoder::DecoderState::getPrevDraftTokensLengths)
-        .def_property_readonly("next_draft_tokens_lengths", &tr::decoder::DecoderState::getNextDraftTokensLengths)
-        .def_property_readonly("accepted_lengths_cum_sum", &tr::decoder::DecoderState::getAcceptedLengthsCumSum)
-        .def_property_readonly("accepted_packed_paths", &tr::decoder::DecoderState::getAcceptedPackedPaths)
-        .def_property_readonly("finished_steps", &tr::decoder::DecoderState::getFinishedSteps)
-        .def_property_readonly("max_beam_width", &tr::decoder::DecoderState::getMaxBeamWidth)
-        .def_property_readonly("max_sequence_length", &tr::decoder::DecoderState::getMaxSequenceLength)
-        .def_property_readonly("max_decoding_decoder_tokens", &tr::decoder::DecoderState::getMaxDecodingDecoderTokens)
-        .def_property_readonly("max_decoding_engine_tokens", &tr::decoder::DecoderState::getMaxDecodingEngineTokens)
-        .def_property_readonly("num_decoding_engine_tokens",
-            py::overload_cast<>(&tr::decoder::DecoderState::getNumDecodingEngineTokens, py::const_))
+            nb::overload_cast<tr::SizeType32>(&tr::decoder::DecoderState::getCumLogProbs, nb::const_),
+            nb::arg("batch_idx"))
+        .def_prop_ro("log_probs", nb::overload_cast<>(&tr::decoder::DecoderState::getLogProbs, nb::const_))
+        .def("get_log_probs", nb::overload_cast<tr::SizeType32>(&tr::decoder::DecoderState::getLogProbs, nb::const_),
+            nb::arg("batch_idx"))
+        .def_prop_ro("next_draft_tokens", &tr::decoder::DecoderState::getNextDraftTokens)
+        .def_prop_ro("prev_draft_tokens_lengths", &tr::decoder::DecoderState::getPrevDraftTokensLengths)
+        .def_prop_ro("next_draft_tokens_lengths", &tr::decoder::DecoderState::getNextDraftTokensLengths)
+        .def_prop_ro("accepted_lengths_cum_sum", &tr::decoder::DecoderState::getAcceptedLengthsCumSum)
+        .def_prop_ro("accepted_packed_paths", &tr::decoder::DecoderState::getAcceptedPackedPaths)
+        .def_prop_ro("finished_steps", &tr::decoder::DecoderState::getFinishedSteps)
+        .def_prop_ro("max_beam_width", &tr::decoder::DecoderState::getMaxBeamWidth)
+        .def_prop_ro("max_sequence_length", &tr::decoder::DecoderState::getMaxSequenceLength)
+        .def_prop_ro("max_decoding_decoder_tokens", &tr::decoder::DecoderState::getMaxDecodingDecoderTokens)
+        .def_prop_ro("max_decoding_engine_tokens", &tr::decoder::DecoderState::getMaxDecodingEngineTokens)
+        .def_prop_ro("num_decoding_engine_tokens",
+            nb::overload_cast<>(&tr::decoder::DecoderState::getNumDecodingEngineTokens, nb::const_))
         .def("get_num_decoding_engine_tokens",
-            py::overload_cast<tr::SizeType32>(&tr::decoder::DecoderState::getNumDecodingEngineTokens, py::const_),
-            py::arg("batch_idx"))
+            nb::overload_cast<tr::SizeType32>(&tr::decoder::DecoderState::getNumDecodingEngineTokens, nb::const_),
+            nb::arg("batch_idx"))
         .def("set_num_decoding_engine_tokens", &tr::decoder::DecoderState::setNumDecodingEngineTokens,
-            py::arg("batch_idx"), py::arg("num_tokens"))
-        .def_property_readonly("speculative_decoding_mode", &tr::decoder::DecoderState::getSpeculativeDecodingMode)
-        .def_property("generation_steps", &tr::decoder::DecoderState::getGenerationSteps,
+            nb::arg("batch_idx"), nb::arg("num_tokens"))
+        .def_prop_ro("speculative_decoding_mode", &tr::decoder::DecoderState::getSpeculativeDecodingMode)
+        .def_prop_rw("generation_steps", &tr::decoder::DecoderState::getGenerationSteps,
             &tr::decoder::DecoderState::setGenerationSteps);
 
-    py::class_<tr::GptDecoderBatched>(m, "GptDecoderBatched")
-        .def(py::init<tr::GptDecoderBatched::CudaStreamPtr>(), py::arg("stream"))
-        .def("setup", &tr::GptDecoderBatched::setup, py::arg("mode"), py::arg("max_batch_size"),
-            py::arg("max_beam_width"), py::arg("dtype"), py::arg("model_config"), py::arg("world_config"))
-        .def("forward_async", &tr::GptDecoderBatched::forwardAsync, py::arg("decoder_state"), py::arg("input"))
-        .def("underlying_decoder", &tr::GptDecoderBatched::getUnderlyingDecoder, py::return_value_policy::reference)
-        .def("finalize", &tr::GptDecoderBatched::finalize, py::arg("decoder_state"), py::arg("batch_idx"),
-            py::arg("sampling_config"), py::arg("streaming"))
-        .def_property_readonly(
+    nb::class_<tr::GptDecoderBatched>(m, "GptDecoderBatched")
+        .def(nb::init<tr::GptDecoderBatched::CudaStreamPtr>(), nb::arg("stream"))
+        .def("setup", &tr::GptDecoderBatched::setup, nb::arg("mode"), nb::arg("max_batch_size"),
+            nb::arg("max_beam_width"), nb::arg("dtype"), nb::arg("model_config"), nb::arg("world_config"))
+        .def("forward_async", &tr::GptDecoderBatched::forwardAsync, nb::arg("output"), nb::arg("input"))
+        .def("underlying_decoder", &tr::GptDecoderBatched::getUnderlyingDecoder, nb::rv_policy::reference)
+        .def("finalize", &tr::GptDecoderBatched::finalize, nb::arg("decoder_state"), nb::arg("batch_idx"),
+            nb::arg("sampling_config"), nb::arg("streaming"))
+        .def_prop_ro(
             "decoder_stream",
             [](tr::GptDecoderBatched& self) -> tr::CudaStream const& { return *self.getDecoderStream(); },
-            py::return_value_policy::reference);
+            nb::rv_policy::reference);
 
     m.def(
         "lamport_initialize_all",
@@ -412,10 +374,10 @@ void initBindings(pybind11::module_& m)
         "Lmaport initialize buffer");
     m.def(
         "delay_kernel",
-        [](int64_t delay_micro_secs, py::object py_stream)
+        [](int64_t delay_micro_secs, nb::object py_stream)
         {
             // Get the raw stream handle from PyTorch stream object
-            auto stream_ptr = py_stream.attr("cuda_stream").cast<int64_t>();
+            auto stream_ptr = nb::cast<int64_t>(py_stream.attr("cuda_stream"));
             cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_ptr);
             tensorrt_llm::kernels::invokeDelayStreamKernel(delay_micro_secs, stream);
         },
@@ -425,12 +387,12 @@ void initBindings(pybind11::module_& m)
         [](int32_t tp_size) { return tensorrt_llm::kernels::max_workspace_size_lowprecision(tp_size); },
         "Calculate the maximum workspace size needed for low precision all-reduce operations");
 
-    py::class_<tensorrt_llm::runtime::McastGPUBuffer>(m, "McastGPUBuffer")
-        .def(py::init<size_t, uint32_t, uint32_t, at::Device, bool>())
+    nb::class_<tensorrt_llm::runtime::McastGPUBuffer>(m, "McastGPUBuffer")
+        .def(nb::init<size_t, uint32_t, uint32_t, at::Device, bool>())
         .def("get_uc_buffer", &tensorrt_llm::runtime::McastGPUBuffer::getUCBuffer)
         .def("get_mc_buffer", &tensorrt_llm::runtime::McastGPUBuffer::getMCBuffer);
 
-    py::enum_<tensorrt_llm::kernels::AllReduceFusionOp>(m, "AllReduceFusionOp")
+    nb::enum_<tensorrt_llm::kernels::AllReduceFusionOp>(m, "AllReduceFusionOp")
         .value("NONE", tensorrt_llm::kernels::AllReduceFusionOp::NONE)
         .value("RESIDUAL_RMS_NORM", tensorrt_llm::kernels::AllReduceFusionOp::RESIDUAL_RMS_NORM)
         .value("LAST_PROCESS_FOR_UB", tensorrt_llm::kernels::AllReduceFusionOp::LAST_PROCESS_FOR_UB)
@@ -442,7 +404,7 @@ void initBindings(pybind11::module_& m)
         .value("RESIDUAL_RMS_NORM_OUT_QUANT_FP8",
             tensorrt_llm::kernels::AllReduceFusionOp::RESIDUAL_RMS_NORM_OUT_QUANT_FP8);
 
-    py::enum_<tensorrt_llm::kernels::AllReduceStrategyType>(m, "AllReduceStrategy")
+    nb::enum_<tensorrt_llm::kernels::AllReduceStrategyType>(m, "AllReduceStrategy")
         .value("NCCL", tensorrt_llm::kernels::AllReduceStrategyType::NCCL)
         .value("MIN_LATENCY", tensorrt_llm::kernels::AllReduceStrategyType::MIN_LATENCY)
         .value("AUTO", tensorrt_llm::kernels::AllReduceStrategyType::AUTO)
@@ -454,28 +416,28 @@ void initBindings(pybind11::module_& m)
     initMoeBindings(m);
 }
 
-void initBindingsEarly(py::module_& m)
+void initBindingsEarly(nb::module_& m)
 {
-    py::class_<tr::SpeculativeDecodingMode>(m, "SpeculativeDecodingMode")
-        .def(py::init<tr::SpeculativeDecodingMode::UnderlyingType>(), py::arg("state"))
+    nb::class_<tr::SpeculativeDecodingMode>(m, "SpeculativeDecodingMode")
+        .def(nb::init<tr::SpeculativeDecodingMode::UnderlyingType>(), nb::arg("state"))
         .def_static("NoneType", &tr::SpeculativeDecodingMode::None)
         .def_static("DraftTokensExternal", &tr::SpeculativeDecodingMode::DraftTokensExternal)
         .def_static("Medusa", &tr::SpeculativeDecodingMode::Medusa)
         .def_static("Eagle", &tr::SpeculativeDecodingMode::Eagle)
         .def_static("LookaheadDecoding", &tr::SpeculativeDecodingMode::LookaheadDecoding)
         .def_static("ExplicitDraftTokens", &tr::SpeculativeDecodingMode::ExplicitDraftTokens)
-        .def_property_readonly("is_none", &tr::SpeculativeDecodingMode::isNone)
-        .def_property_readonly("is_draft_tokens_external", &tr::SpeculativeDecodingMode::isDraftTokensExternal)
-        .def_property_readonly("is_medusa", &tr::SpeculativeDecodingMode::isMedusa)
-        .def_property_readonly("is_eagle", &tr::SpeculativeDecodingMode::isEagle)
-        .def_property_readonly("is_lookahead_decoding", &tr::SpeculativeDecodingMode::isLookaheadDecoding)
-        .def_property_readonly("is_explicit_draft_tokens", &tr::SpeculativeDecodingMode::isExplicitDraftTokens)
-        .def_property_readonly("updates_position_ids", &tr::SpeculativeDecodingMode::updatesPositionIds)
-        .def_property_readonly("requires_attention_mask", &tr::SpeculativeDecodingMode::requiresAttentionMask)
-        .def_property_readonly("predicts_draft_tokens", &tr::SpeculativeDecodingMode::predictsDraftTokens)
-        .def_property_readonly("needs_kv_cache_rewind", &tr::SpeculativeDecodingMode::needsKVCacheRewind)
-        .def_property_readonly("variable_draft_length", &tr::SpeculativeDecodingMode::variableDraftLength)
-        .def_property_readonly("has_draft_logits", &tr::SpeculativeDecodingMode::hasDraftLogits)
-        .def_property_readonly("needs_decoder_prologue", &tr::SpeculativeDecodingMode::needsDecoderPrologue);
+        .def_prop_ro("is_none", &tr::SpeculativeDecodingMode::isNone)
+        .def_prop_ro("is_draft_tokens_external", &tr::SpeculativeDecodingMode::isDraftTokensExternal)
+        .def_prop_ro("is_medusa", &tr::SpeculativeDecodingMode::isMedusa)
+        .def_prop_ro("is_eagle", &tr::SpeculativeDecodingMode::isEagle)
+        .def_prop_ro("is_lookahead_decoding", &tr::SpeculativeDecodingMode::isLookaheadDecoding)
+        .def_prop_ro("is_explicit_draft_tokens", &tr::SpeculativeDecodingMode::isExplicitDraftTokens)
+        .def_prop_ro("updates_position_ids", &tr::SpeculativeDecodingMode::updatesPositionIds)
+        .def_prop_ro("requires_attention_mask", &tr::SpeculativeDecodingMode::requiresAttentionMask)
+        .def_prop_ro("predicts_draft_tokens", &tr::SpeculativeDecodingMode::predictsDraftTokens)
+        .def_prop_ro("needs_kv_cache_rewind", &tr::SpeculativeDecodingMode::needsKVCacheRewind)
+        .def_prop_ro("variable_draft_length", &tr::SpeculativeDecodingMode::variableDraftLength)
+        .def_prop_ro("has_draft_logits", &tr::SpeculativeDecodingMode::hasDraftLogits)
+        .def_prop_ro("needs_decoder_prologue", &tr::SpeculativeDecodingMode::needsDecoderPrologue);
 }
-} // namespace tensorrt_llm::pybind::runtime
+} // namespace tensorrt_llm::nanobind::runtime

--- a/cpp/tensorrt_llm/nanobind/runtime/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/runtime/bindings.cpp
@@ -1,0 +1,481 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bindings.h"
+#include "moeBindings.h"
+#include "tensorrt_llm/kernels/communicationKernels/allReduceWorkspace.h"
+#include "tensorrt_llm/kernels/communicationKernels/customLowPrecisionAllReduceKernels.h"
+#include "tensorrt_llm/kernels/customAllReduceKernels.h"
+#include "tensorrt_llm/kernels/delayStream.h"
+#include "tensorrt_llm/runtime/cudaEvent.h"
+#include "tensorrt_llm/runtime/cudaStream.h"
+#include "tensorrt_llm/runtime/decoderState.h"
+#include "tensorrt_llm/runtime/decodingInput.h"
+#include "tensorrt_llm/runtime/decodingOutput.h"
+#include "tensorrt_llm/runtime/gptDecoder.h"
+#include "tensorrt_llm/runtime/gptDecoderBatched.h"
+#include "tensorrt_llm/runtime/iBuffer.h"
+#include "tensorrt_llm/runtime/iGptDecoderBatched.h"
+#include "tensorrt_llm/runtime/iTensor.h"
+#include "tensorrt_llm/runtime/ipcUtils.h"
+#include "tensorrt_llm/runtime/lookaheadBuffers.h"
+#include "tensorrt_llm/runtime/loraCache.h"
+#include "tensorrt_llm/runtime/mcastGPUBuffer.h"
+#include "tensorrt_llm/runtime/request.h"
+#include "tensorrt_llm/runtime/speculativeDecodingMode.h"
+#include "tensorrt_llm/runtime/tllmRuntime.h"
+#include "tensorrt_llm/runtime/torchView.h"
+
+#include <ATen/ATen.h>
+#include <c10/cuda/CUDAStream.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <torch/extension.h>
+
+namespace tr = tensorrt_llm::runtime;
+namespace te = tensorrt_llm::executor;
+
+class PyITensor : public tensorrt_llm::runtime::ITensor
+{
+public:
+    /* Inherit the constructors */
+    using ITensor::ITensor;
+
+    [[nodiscard]] void* data() override
+    {
+        PYBIND11_OVERRIDE_PURE(void*, /* Return type */
+            ITensor,                  /* Parent class */
+            data                      /* Name of function in C++ (must match Python name) */
+                                      /* Argument(s) */
+        );
+    }
+
+    [[nodiscard]] void const* data() const override
+    {
+        PYBIND11_OVERRIDE_PURE(void const*, /* Return type */
+            ITensor,                        /* Parent class */
+            data                            /* Name of function in C++ (must match Python name) */
+                                            /* Argument(s) */
+        );
+    }
+
+    [[nodiscard]] std::size_t getSize() const override
+    {
+        PYBIND11_OVERRIDE_PURE(std::size_t, /* Return type */
+            ITensor,                        /* Parent class */
+            getSize                         /* Name of function in C++ (must match Python name) */
+                                            /* Argument(s) */
+        );
+    }
+
+    [[nodiscard]] std::size_t getCapacity() const override
+    {
+        PYBIND11_OVERRIDE_PURE(std::size_t, /* Return type */
+            ITensor,                        /* Parent class */
+            getCapacity                     /* Name of function in C++ (must match Python name) */
+                                            /* Argument(s) */
+        );
+    }
+
+    [[nodiscard]] DataType getDataType() const override
+    {
+        PYBIND11_OVERRIDE_PURE(DataType, /* Return type */
+            ITensor,                     /* Parent class */
+            getDataType                  /* Name of function in C++ (must match Python name) */
+                                         /* Argument(s) */
+        );
+    }
+
+    [[nodiscard]] tr::MemoryType getMemoryType() const override
+    {
+        PYBIND11_OVERRIDE_PURE(tr::MemoryType, /* Return type */
+            ITensor,                           /* Parent class */
+            getMemoryType                      /* Name of function in C++ (must match Python name) */
+                                               /* Argument(s) */
+        );
+    }
+
+    [[nodiscard]] char const* getMemoryTypeName() const override
+    {
+        PYBIND11_OVERRIDE_PURE(char const*, /* Return type */
+            ITensor,                        /* Parent class */
+            getMemoryTypeName               /* Name of function in C++ (must match Python name) */
+                                            /* Argument(s) */
+        );
+    }
+
+    virtual void resize(std::size_t newSize) override
+    {
+        PYBIND11_OVERRIDE_PURE(void, /* Return type */
+            ITensor,                 /* Parent class */
+            resize                   /* Name of function in C++ (must match Python name) */
+                                     /* Argument(s) */
+        );
+    }
+
+    void release() override
+    {
+        PYBIND11_OVERRIDE_PURE(void, /* Return type */
+            ITensor,                 /* Parent class */
+            release                  /* Name of function in C++ (must match Python name) */
+                                     /* Argument(s) */
+        );
+    }
+
+    [[nodiscard]] Shape const& getShape() const override
+    {
+        PYBIND11_OVERRIDE_PURE(Shape const&, /* Return type */
+            ITensor,                         /* Parent class */
+            getShape                         /* Name of function in C++ (must match Python name) */
+                                             /* Argument(s) */
+        );
+    }
+
+    void reshape(Shape const& dims) override
+    {
+        PYBIND11_OVERRIDE_PURE(void, /* Return type */
+            ITensor,                 /* Parent class */
+            reshape,                 /* Name of function in C++ (must match Python name) */
+            dims                     /* Argument(s) */
+        );
+    }
+};
+
+class PyIGptDecoder : public tr::IGptDecoder
+{
+public:
+    using tr::IGptDecoder::IGptDecoder; // Inherit constructors
+
+    void setup(tr::SamplingConfig const& samplingConfig, size_t batchSize,
+        tr::DecodingInput::TensorConstPtr const& batchSlots,
+        std::optional<tr::DecodingOutput> const& output = std::nullopt,
+        std::optional<nvinfer1::DataType> explicitDraftTokensDType = std::nullopt,
+        std::optional<std::vector<tr::ITensor::SharedConstPtr>> const& lookaheadPrompt = std::nullopt,
+        std::optional<std::vector<te::LookaheadDecodingConfig>> const& lookaheadAlgoConfigs = std::nullopt) override
+    {
+        PYBIND11_OVERRIDE_PURE(void, IGptDecoder, setup, samplingConfig, batchSize, batchSlots, output,
+            explicitDraftTokensDType, lookaheadPrompt, lookaheadAlgoConfigs);
+    }
+
+    void forwardAsync(tr::DecodingOutput& output, tr::DecodingInput const& input) override
+    {
+        PYBIND11_OVERRIDE_PURE(void, IGptDecoder, forwardAsync, output, input);
+    }
+
+    void forwardSync(tr::DecodingOutput& output, tr::DecodingInput const& input) override
+    {
+        PYBIND11_OVERRIDE_PURE(void, IGptDecoder, forwardSync, output, input);
+    }
+
+    tr::SamplingConfig const& getSamplingConfig() override
+    {
+        PYBIND11_OVERRIDE_PURE(tr::SamplingConfig const&, IGptDecoder, getSamplingConfig);
+    }
+
+    void disableLookahead(std::optional<tr::SamplingConfig> const& samplingConfig, tr::SizeType32 batchSize,
+        tr::DecodingInput::TensorConstPtr batchSlots) override
+    {
+        PYBIND11_OVERRIDE_PURE(void, IGptDecoder, disableLookahead, samplingConfig, batchSize, batchSlots);
+    }
+};
+
+namespace tensorrt_llm::pybind::runtime
+{
+
+void initBindings(pybind11::module_& m)
+{
+    py::classh<tr::ITensor, PyITensor>(m, "ITensor").def(py::init());
+    py::class_<tr::LoraCache::TaskLayerModuleConfig>(m, "TaskLayerModuleConfig")
+        .def(py::init<>())
+        .def_readwrite("page_id", &tr::LoraCache::TaskLayerModuleConfig::pageId)
+        .def_readwrite("slot_idx", &tr::LoraCache::TaskLayerModuleConfig::slotIdx)
+        .def_readwrite("in_size", &tr::LoraCache::TaskLayerModuleConfig::inSize)
+        .def_readwrite("out_size", &tr::LoraCache::TaskLayerModuleConfig::outSize)
+        .def_readwrite("module_id", &tr::LoraCache::TaskLayerModuleConfig::moduleId)
+        .def_readwrite("layer_id", &tr::LoraCache::TaskLayerModuleConfig::layerId)
+        .def_readwrite("adapter_size", &tr::LoraCache::TaskLayerModuleConfig::adapterSize)
+        .def_readwrite("num_slots", &tr::LoraCache::TaskLayerModuleConfig::numSlots)
+        .def_readwrite("weights_in_pointer", &tr::LoraCache::TaskLayerModuleConfig::weightsInPointer)
+        .def_readwrite("weights_out_pointer", &tr::LoraCache::TaskLayerModuleConfig::weightsOutPointer)
+        .def_readwrite("scaling_vec_pointer", &tr::LoraCache::TaskLayerModuleConfig::scalingVecPointer)
+        .def(py::self == py::self);
+
+    py::classh<tr::BufferManager>(m, "BufferManager")
+        .def(py::init<tr::BufferManager::CudaStreamPtr, bool>(), py::arg("stream"), py::arg("trim_pool") = false)
+        .def_property_readonly("stream", &tr::BufferManager::getStream);
+
+    py::classh<tr::TllmRuntime>(m, "TllmRuntime")
+        .def(py::init(
+            [](std::filesystem::path engine_path, float gpu_weights_percent = 1.0f, bool use_shape_inference = true)
+            {
+                // Using default logger by passing nullptr
+                return new tr::TllmRuntime(
+                    tr::RawEngine(engine_path), nullptr, gpu_weights_percent, use_shape_inference);
+            }))
+        .def(py::init(
+            [](py::buffer engine_buffer, float gpu_weights_percent = 1.0f, bool use_shape_inference = true)
+            {
+                py::buffer_info info = engine_buffer.request();
+                if (info.ndim != 1)
+                    throw std::runtime_error("Expected 1-D array for engine buffer");
+                return new tr::TllmRuntime(
+                    tr::RawEngine(info.ptr, info.shape[0]), nullptr, gpu_weights_percent, use_shape_inference);
+            }))
+        .def_property_readonly("num_contexts", &tr::TllmRuntime::getNbContexts)
+        .def_property_readonly("num_profiles", &tr::TllmRuntime::getNbProfiles)
+        .def("get_opt_profile_id", &tr::TllmRuntime::getOptProfileId, py::arg("num_tokens"), py::arg("split_points"))
+        .def("clear_contexts", &tr::TllmRuntime::clearContexts)
+        .def("execute_context", &tr::TllmRuntime::executeContext, py::arg("context_id"))
+        .def_property_readonly("stream_ptr", &tr::TllmRuntime::getStreamPtr)
+        .def_property_readonly("buffer_manager",
+            static_cast<tr::BufferManager& (tr::TllmRuntime::*) ()>(&tr::TllmRuntime::getBufferManager))
+        .def("set_layer_profiler", &tr::TllmRuntime::setLayerProfiler)
+        .def("has_layer_profiler", &tr::TllmRuntime::hasLayerProfiler, py::arg("context_id"))
+        .def_property_readonly("layer_profiler_info", &tr::TllmRuntime::getLayerProfileInfo)
+        .def("report_to_profiler", &tr::TllmRuntime::reportToProfiler, py::arg("context_id"))
+        .def_property_readonly("logits_dtype_from_engine",
+            [](tr::TllmRuntime& self) { return self.getEngine().getTensorDataType("logits"); });
+
+    py::class_<tr::decoder_batch::Request>(m, "Request")
+        .def(py::init<tr::decoder_batch::Request::TensorConstPtr, tr::SizeType32, std::optional<tr::SizeType32>,
+                 std::optional<tr::SizeType32>>(),
+            py::arg("ids"), py::arg("input_len"), py::arg("max_new_tokens") = std::nullopt,
+            py::arg("end_id") = std::nullopt)
+        .def_readwrite("ids", &tr::decoder_batch::Request::ids)
+        .def_readwrite("input_len", &tr::decoder_batch::Request::inputLen)
+        .def_readwrite("max_new_tokens", &tr::decoder_batch::Request::maxNewTokens)
+        .def_readwrite("end_id", &tr::decoder_batch::Request::endId)
+        .def_readwrite("draft_logits", &tr::decoder_batch::Request::draftLogits)
+        .def_readwrite("embedding_bias", &tr::decoder_batch::Request::embeddingBias)
+        .def_readwrite("bad_words_list", &tr::decoder_batch::Request::badWordsList)
+        .def_readwrite("stop_words_list", &tr::decoder_batch::Request::stopWordsList)
+        .def_readwrite("generated_tokens_per_engine_step", &tr::decoder_batch::Request::generatedTokensPerEngineStep)
+        .def_readwrite("medusa_paths", &tr::decoder_batch::Request::medusaPaths)
+        .def_readwrite("medusa_tree_ids", &tr::decoder_batch::Request::medusaTreeIds)
+        .def_readwrite("lookahead_runtime_config", &tr::decoder_batch::Request::lookaheadRuntimeConfig);
+
+    py::class_<tr::decoder_batch::Input>(m, "DecoderBatchInput")
+        .def(py::init<std::vector<std::vector<tr::ITensor::SharedConstPtr>>, tr::SizeType32>(), py::arg("logits"),
+            py::arg("max_decoding_engine_tokens"))
+        .def(py::init<std::vector<tr::ITensor::SharedConstPtr>>(), py::arg("logits"))
+        .def_readwrite("logits", &tr::decoder_batch::Input::logits)
+        .def_readwrite("max_decoder_steps", &tr::decoder_batch::Input::maxDecoderSteps)
+        .def_readwrite("batch_slots", &tr::decoder_batch::Input::batchSlots);
+
+    py::class_<tr::LookaheadDecodingBuffers>(m, "LookaheadDecodingBuffers")
+        .def(py::init<tr::SizeType32, tr::SizeType32, tr::BufferManager const&>(), py::arg("max_num_sequences"),
+            py::arg("max_tokens_per_step"), py::arg("buffer_manager"))
+        .def_readwrite("generation_lengths", &tr::LookaheadDecodingBuffers::generationLengths)
+        .def_readwrite("position_offsets", &tr::LookaheadDecodingBuffers::positionOffsets)
+        .def_readwrite("packed_masks", &tr::LookaheadDecodingBuffers::packedMasks)
+        .def_readwrite("position_ids", &tr::LookaheadDecodingBuffers::positionIds);
+
+    py::class_<tr::ExplicitDraftTokensBuffers::Inputs>(m, "ExplicitDraftTokensBuffersInputs")
+        .def("create", &tr::ExplicitDraftTokensBuffers::Inputs::create, py::arg("max_num_sequences"),
+            py::arg("runtime"), py::arg("model_config"), py::arg("world_config"))
+        .def_readwrite("temperatures", &tr::ExplicitDraftTokensBuffers::Inputs::temperatures)
+        .def_readwrite("position_ids_base", &tr::ExplicitDraftTokensBuffers::Inputs::positionIdsBase)
+        .def_readwrite("generation_lengths", &tr::ExplicitDraftTokensBuffers::Inputs::generationLengths)
+        .def_readwrite("random_data_sample", &tr::ExplicitDraftTokensBuffers::Inputs::randomDataSample)
+        .def_readwrite("random_data_validation", &tr::ExplicitDraftTokensBuffers::Inputs::randomDataValidation)
+        .def_readwrite("draft_tokens", &tr::ExplicitDraftTokensBuffers::Inputs::draftTokens)
+        .def_readwrite("draft_indices", &tr::ExplicitDraftTokensBuffers::Inputs::draftIndices)
+        .def_readwrite("draft_probs", &tr::ExplicitDraftTokensBuffers::Inputs::draftProbs)
+        .def_readwrite("packed_masks", &tr::ExplicitDraftTokensBuffers::Inputs::packedMasks)
+        .def_readwrite("position_ids", &tr::ExplicitDraftTokensBuffers::Inputs::positionIds)
+        .def_readwrite("max_gen_length_host", &tr::ExplicitDraftTokensBuffers::Inputs::maxGenLengthHost)
+        .def_readwrite("generation_lengths_host", &tr::ExplicitDraftTokensBuffers::Inputs::generationLengthsHost);
+
+    py::class_<tr::DecodingInput>(m, "DecodingInput");
+    py::class_<tr::DecodingOutput>(m, "DecodingOutput");
+
+    py::class_<tr::CudaEvent>(m, "CudaEvent")
+        .def(py::init<unsigned int>(), py::arg("flags") = cudaEventDisableTiming)
+        .def("synchronize", &tr::CudaEvent::synchronize);
+
+    py::class_<tr::IGptDecoder, PyIGptDecoder>(m, "IGptDecoder")
+        .def(
+            "setup",
+            [](tr::IGptDecoder& self, tr::SamplingConfig const& samplingConfig, size_t batchSize,
+                at::Tensor const& batchSlots, std::optional<tr::DecodingOutput> const& output = std::nullopt,
+                std::optional<nvinfer1::DataType> explicitDraftTokensDType = std::nullopt,
+                std::optional<std::vector<tr::ITensor::SharedConstPtr>> const& lookaheadPrompt = std::nullopt,
+                std::optional<std::vector<te::LookaheadDecodingConfig>> const& lookaheadAlgoConfigs = std::nullopt)
+            {
+                auto tensorPtrBatchSlots = tr::TorchView::of(batchSlots);
+                self.setup(samplingConfig, batchSize, std::move(tensorPtrBatchSlots), output, explicitDraftTokensDType,
+                    lookaheadPrompt, lookaheadAlgoConfigs);
+            },
+            py::arg("sampling_config"), py::arg("batch_size"), py::arg("batch_slots"), py::arg("output") = std::nullopt,
+            py::arg("explicit_draft_tokens_d_type") = std::nullopt, py::arg("lookahead_prompt") = std::nullopt,
+            py::arg("lookahead_algo_configs") = std::nullopt);
+
+    py::class_<tr::decoder::DecoderState>(m, "DecoderState")
+        .def(py::init<>())
+        .def("setup", &tr::decoder::DecoderState::setup, py::arg("max_batch_size"), py::arg("max_beam_width"),
+            py::arg("max_attention_window"), py::arg("sink_token_length"), py::arg("max_sequence_length"),
+            py::arg("dtype"), py::arg("model_config"), py::arg("world_config"), py::arg("buffer_manager"))
+        .def("setup_cache_indirection", &tr::decoder::DecoderState::setupCacheIndirection, py::arg("max_batch_size"),
+            py::arg("max_beam_width"), py::arg("max_attention_window"), py::arg("buffer_manager"))
+        .def("setup_speculative_decoding", &tr::decoder::DecoderState::setupSpeculativeDecoding,
+            py::arg("speculative_decoding_mode"), py::arg("max_tokens_per_engine_step"), py::arg("dtype"),
+            py::arg("model_config"), py::arg("world_config"), py::arg("buffer_manager"))
+        .def_property_readonly("joint_decoding_input", &tr::decoder::DecoderState::getJointDecodingInput)
+        .def_property_readonly("joint_decoding_output", &tr::decoder::DecoderState::getJointDecodingOutput)
+        .def_property_readonly("cache_indirection_input", &tr::decoder::DecoderState::getCacheIndirectionInput)
+        .def_property_readonly("cache_indirection_output", &tr::decoder::DecoderState::getCacheIndirectionOutput)
+        .def_property_readonly(
+            "sequence_lengths", py::overload_cast<>(&tr::decoder::DecoderState::getSequenceLengths, py::const_))
+        .def("get_sequence_lengths",
+            py::overload_cast<tr::SizeType32>(&tr::decoder::DecoderState::getSequenceLengths, py::const_),
+            py::arg("batch_idx"))
+        .def_property_readonly("all_new_tokens", &tr::decoder::DecoderState::getAllNewTokens)
+        .def_property_readonly("finished_sum", &tr::decoder::DecoderState::getFinishedSum)
+        .def_property_readonly("finish_reasons", &tr::decoder::DecoderState::getFinishReasons)
+        .def_property_readonly("ids", py::overload_cast<>(&tr::decoder::DecoderState::getIds, py::const_))
+        .def("get_ids", py::overload_cast<tr::SizeType32>(&tr::decoder::DecoderState::getIds, py::const_),
+            py::arg("batch_idx"))
+        .def_property_readonly(
+            "gathered_ids", py::overload_cast<>(&tr::decoder::DecoderState::getGatheredIds, py::const_))
+        .def("get_gathered_ids",
+            py::overload_cast<tr::SizeType32>(&tr::decoder::DecoderState::getGatheredIds, py::const_),
+            py::arg("batch_idx"))
+        .def_property_readonly("parent_ids", &tr::decoder::DecoderState::getParentIds)
+        .def_property_readonly(
+            "cum_log_probs", py::overload_cast<>(&tr::decoder::DecoderState::getCumLogProbs, py::const_))
+        .def("get_cum_log_probs",
+            py::overload_cast<tr::SizeType32>(&tr::decoder::DecoderState::getCumLogProbs, py::const_),
+            py::arg("batch_idx"))
+        .def_property_readonly("log_probs", py::overload_cast<>(&tr::decoder::DecoderState::getLogProbs, py::const_))
+        .def("get_log_probs", py::overload_cast<tr::SizeType32>(&tr::decoder::DecoderState::getLogProbs, py::const_),
+            py::arg("batch_idx"))
+        .def_property_readonly("next_draft_tokens", &tr::decoder::DecoderState::getNextDraftTokens)
+        .def_property_readonly("prev_draft_tokens_lengths", &tr::decoder::DecoderState::getPrevDraftTokensLengths)
+        .def_property_readonly("next_draft_tokens_lengths", &tr::decoder::DecoderState::getNextDraftTokensLengths)
+        .def_property_readonly("accepted_lengths_cum_sum", &tr::decoder::DecoderState::getAcceptedLengthsCumSum)
+        .def_property_readonly("accepted_packed_paths", &tr::decoder::DecoderState::getAcceptedPackedPaths)
+        .def_property_readonly("finished_steps", &tr::decoder::DecoderState::getFinishedSteps)
+        .def_property_readonly("max_beam_width", &tr::decoder::DecoderState::getMaxBeamWidth)
+        .def_property_readonly("max_sequence_length", &tr::decoder::DecoderState::getMaxSequenceLength)
+        .def_property_readonly("max_decoding_decoder_tokens", &tr::decoder::DecoderState::getMaxDecodingDecoderTokens)
+        .def_property_readonly("max_decoding_engine_tokens", &tr::decoder::DecoderState::getMaxDecodingEngineTokens)
+        .def_property_readonly("num_decoding_engine_tokens",
+            py::overload_cast<>(&tr::decoder::DecoderState::getNumDecodingEngineTokens, py::const_))
+        .def("get_num_decoding_engine_tokens",
+            py::overload_cast<tr::SizeType32>(&tr::decoder::DecoderState::getNumDecodingEngineTokens, py::const_),
+            py::arg("batch_idx"))
+        .def("set_num_decoding_engine_tokens", &tr::decoder::DecoderState::setNumDecodingEngineTokens,
+            py::arg("batch_idx"), py::arg("num_tokens"))
+        .def_property_readonly("speculative_decoding_mode", &tr::decoder::DecoderState::getSpeculativeDecodingMode)
+        .def_property("generation_steps", &tr::decoder::DecoderState::getGenerationSteps,
+            &tr::decoder::DecoderState::setGenerationSteps);
+
+    py::class_<tr::GptDecoderBatched>(m, "GptDecoderBatched")
+        .def(py::init<tr::GptDecoderBatched::CudaStreamPtr>(), py::arg("stream"))
+        .def("setup", &tr::GptDecoderBatched::setup, py::arg("mode"), py::arg("max_batch_size"),
+            py::arg("max_beam_width"), py::arg("dtype"), py::arg("model_config"), py::arg("world_config"))
+        .def("forward_async", &tr::GptDecoderBatched::forwardAsync, py::arg("decoder_state"), py::arg("input"))
+        .def("underlying_decoder", &tr::GptDecoderBatched::getUnderlyingDecoder, py::return_value_policy::reference)
+        .def("finalize", &tr::GptDecoderBatched::finalize, py::arg("decoder_state"), py::arg("batch_idx"),
+            py::arg("sampling_config"), py::arg("streaming"))
+        .def_property_readonly(
+            "decoder_stream",
+            [](tr::GptDecoderBatched& self) -> tr::CudaStream const& { return *self.getDecoderStream(); },
+            py::return_value_policy::reference);
+
+    m.def(
+        "lamport_initialize_all",
+        [](intptr_t buffer_0, intptr_t buffer_1, intptr_t buffer_2, size_t size)
+        {
+            tr::lamportInitializeAll(reinterpret_cast<void*>(buffer_0), reinterpret_cast<void*>(buffer_1),
+                reinterpret_cast<void*>(buffer_2), size);
+        },
+        "Lamport initialize all buffers");
+    m.def(
+        "lamport_initialize",
+        [](intptr_t buffer, size_t size)
+        { tensorrt_llm::kernels::ar_fusion::lamport_initialize(reinterpret_cast<void*>(buffer), size, 0); },
+        "Lmaport initialize buffer");
+    m.def(
+        "delay_kernel",
+        [](int64_t delay_micro_secs, py::object py_stream)
+        {
+            // Get the raw stream handle from PyTorch stream object
+            auto stream_ptr = py_stream.attr("cuda_stream").cast<int64_t>();
+            cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_ptr);
+            tensorrt_llm::kernels::invokeDelayStreamKernel(delay_micro_secs, stream);
+        },
+        "Delay kernel launch on the default stream");
+    m.def(
+        "max_workspace_size_lowprecision",
+        [](int32_t tp_size) { return tensorrt_llm::kernels::max_workspace_size_lowprecision(tp_size); },
+        "Calculate the maximum workspace size needed for low precision all-reduce operations");
+
+    py::class_<tensorrt_llm::runtime::McastGPUBuffer>(m, "McastGPUBuffer")
+        .def(py::init<size_t, uint32_t, uint32_t, at::Device, bool>())
+        .def("get_uc_buffer", &tensorrt_llm::runtime::McastGPUBuffer::getUCBuffer)
+        .def("get_mc_buffer", &tensorrt_llm::runtime::McastGPUBuffer::getMCBuffer);
+
+    py::enum_<tensorrt_llm::kernels::AllReduceFusionOp>(m, "AllReduceFusionOp")
+        .value("NONE", tensorrt_llm::kernels::AllReduceFusionOp::NONE)
+        .value("RESIDUAL_RMS_NORM", tensorrt_llm::kernels::AllReduceFusionOp::RESIDUAL_RMS_NORM)
+        .value("LAST_PROCESS_FOR_UB", tensorrt_llm::kernels::AllReduceFusionOp::LAST_PROCESS_FOR_UB)
+        .value("RESIDUAL_RMS_PREPOST_NORM", tensorrt_llm::kernels::AllReduceFusionOp::RESIDUAL_RMS_PREPOST_NORM)
+        .value("RESIDUAL_RMS_NORM_QUANT_FP8", tensorrt_llm::kernels::AllReduceFusionOp::RESIDUAL_RMS_NORM_QUANT_FP8)
+        .value("RESIDUAL_RMS_NORM_QUANT_NVFP4", tensorrt_llm::kernels::AllReduceFusionOp::RESIDUAL_RMS_NORM_QUANT_NVFP4)
+        .value("RESIDUAL_RMS_NORM_OUT_QUANT_NVFP4",
+            tensorrt_llm::kernels::AllReduceFusionOp::RESIDUAL_RMS_NORM_OUT_QUANT_NVFP4)
+        .value("RESIDUAL_RMS_NORM_OUT_QUANT_FP8",
+            tensorrt_llm::kernels::AllReduceFusionOp::RESIDUAL_RMS_NORM_OUT_QUANT_FP8);
+
+    py::enum_<tensorrt_llm::kernels::AllReduceStrategyType>(m, "AllReduceStrategy")
+        .value("NCCL", tensorrt_llm::kernels::AllReduceStrategyType::NCCL)
+        .value("MIN_LATENCY", tensorrt_llm::kernels::AllReduceStrategyType::MIN_LATENCY)
+        .value("AUTO", tensorrt_llm::kernels::AllReduceStrategyType::AUTO)
+        .value("UB", tensorrt_llm::kernels::AllReduceStrategyType::UB)
+        .value("ONESHOT", tensorrt_llm::kernels::AllReduceStrategyType::ONESHOT)
+        .value("TWOSHOT", tensorrt_llm::kernels::AllReduceStrategyType::TWOSHOT);
+
+    // Initialize MoeLoadBalancer bindings
+    initMoeBindings(m);
+}
+
+void initBindingsEarly(py::module_& m)
+{
+    py::class_<tr::SpeculativeDecodingMode>(m, "SpeculativeDecodingMode")
+        .def(py::init<tr::SpeculativeDecodingMode::UnderlyingType>(), py::arg("state"))
+        .def_static("NoneType", &tr::SpeculativeDecodingMode::None)
+        .def_static("DraftTokensExternal", &tr::SpeculativeDecodingMode::DraftTokensExternal)
+        .def_static("Medusa", &tr::SpeculativeDecodingMode::Medusa)
+        .def_static("Eagle", &tr::SpeculativeDecodingMode::Eagle)
+        .def_static("LookaheadDecoding", &tr::SpeculativeDecodingMode::LookaheadDecoding)
+        .def_static("ExplicitDraftTokens", &tr::SpeculativeDecodingMode::ExplicitDraftTokens)
+        .def_property_readonly("is_none", &tr::SpeculativeDecodingMode::isNone)
+        .def_property_readonly("is_draft_tokens_external", &tr::SpeculativeDecodingMode::isDraftTokensExternal)
+        .def_property_readonly("is_medusa", &tr::SpeculativeDecodingMode::isMedusa)
+        .def_property_readonly("is_eagle", &tr::SpeculativeDecodingMode::isEagle)
+        .def_property_readonly("is_lookahead_decoding", &tr::SpeculativeDecodingMode::isLookaheadDecoding)
+        .def_property_readonly("is_explicit_draft_tokens", &tr::SpeculativeDecodingMode::isExplicitDraftTokens)
+        .def_property_readonly("updates_position_ids", &tr::SpeculativeDecodingMode::updatesPositionIds)
+        .def_property_readonly("requires_attention_mask", &tr::SpeculativeDecodingMode::requiresAttentionMask)
+        .def_property_readonly("predicts_draft_tokens", &tr::SpeculativeDecodingMode::predictsDraftTokens)
+        .def_property_readonly("needs_kv_cache_rewind", &tr::SpeculativeDecodingMode::needsKVCacheRewind)
+        .def_property_readonly("variable_draft_length", &tr::SpeculativeDecodingMode::variableDraftLength)
+        .def_property_readonly("has_draft_logits", &tr::SpeculativeDecodingMode::hasDraftLogits)
+        .def_property_readonly("needs_decoder_prologue", &tr::SpeculativeDecodingMode::needsDecoderPrologue);
+}
+} // namespace tensorrt_llm::pybind::runtime

--- a/cpp/tensorrt_llm/nanobind/runtime/bindings.h
+++ b/cpp/tensorrt_llm/nanobind/runtime/bindings.h
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "tensorrt_llm/pybind/common/customCasters.h"
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace tensorrt_llm::pybind::runtime
+{
+
+void initBindings(py::module_& m);
+void initBindingsEarly(py::module_& m);
+
+} // namespace tensorrt_llm::pybind::runtime

--- a/cpp/tensorrt_llm/nanobind/runtime/bindings.h
+++ b/cpp/tensorrt_llm/nanobind/runtime/bindings.h
@@ -17,15 +17,15 @@
 
 #pragma once
 
-#include "tensorrt_llm/pybind/common/customCasters.h"
-#include <pybind11/pybind11.h>
+#include "tensorrt_llm/nanobind/common/customCasters.h"
+#include <nanobind/nanobind.h>
 
-namespace py = pybind11;
+namespace nb = nanobind;
 
-namespace tensorrt_llm::pybind::runtime
+namespace tensorrt_llm::nanobind::runtime
 {
 
-void initBindings(py::module_& m);
-void initBindingsEarly(py::module_& m);
+void initBindings(nb::module_& m);
+void initBindingsEarly(nb::module_& m);
 
-} // namespace tensorrt_llm::pybind::runtime
+} // namespace tensorrt_llm::nanobind::runtime

--- a/cpp/tensorrt_llm/nanobind/runtime/moeBindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/runtime/moeBindings.cpp
@@ -1,0 +1,127 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "moeBindings.h"
+#include "tensorrt_llm/runtime/moeLoadBalancer/hostAccessibleDeviceAllocator.h"
+#include "tensorrt_llm/runtime/moeLoadBalancer/moeLoadBalancer.h"
+#include <pybind11/functional.h>
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <vector>
+
+namespace py = pybind11;
+namespace tr = tensorrt_llm::runtime;
+namespace tk = tensorrt_llm::kernels;
+
+namespace tensorrt_llm::pybind::runtime
+{
+
+void pyDoReplication(tk::MoeLoadBalanceMetaInfo const& metaInfo, std::vector<float>& expertLoadFactor,
+    tr::MoePlacementCpuInfo* cpuPlacement)
+{
+    TLLM_CHECK_WITH_INFO(
+        metaInfo.expertCount == expertLoadFactor.size(), "expert_count and expert_load_factor size mismatch");
+    tr::doReplication(metaInfo, expertLoadFactor.data(), cpuPlacement);
+};
+
+void pyDoPlacement(tk::MoeLoadBalanceMetaInfo const& metaInfo, std::vector<float>& expertLoadFactor,
+    tr::MoePlacementCpuInfo* cpuPlacement)
+{
+    TLLM_CHECK_WITH_INFO(
+        metaInfo.expertCount == expertLoadFactor.size(), "expert_count and expert_load_factor size mismatch");
+    tr::doPlacement(metaInfo, expertLoadFactor.data(), cpuPlacement);
+};
+
+void initMoeBindings(pybind11::module_& m)
+{
+    // Bind MoeWeight struct
+    py::class_<tr::MoeWeight>(m, "MoeWeight")
+        .def(py::init<>())
+        .def_property("weight_ptr", &tr::MoeWeight::getWeightPtr, &tr::MoeWeight::setWeightPtr)
+        .def_readwrite("height", &tr::MoeWeight::mHeight)
+        .def_readwrite("width", &tr::MoeWeight::mWidth)
+        .def_readwrite("pitch", &tr::MoeWeight::mPitch)
+        .def("__repr__",
+            [](tr::MoeWeight const& self)
+            {
+                return "<MoeWeight ptr=" + std::to_string(self.getWeightPtr())
+                    + " height=" + std::to_string(self.mHeight) + " width=" + std::to_string(self.mWidth)
+                    + " pitch=" + std::to_string(self.mPitch) + ">";
+            });
+
+    // Bind MoeLoadBalanceMetaInfo struct
+    py::class_<tk::MoeLoadBalanceMetaInfo>(m, "MoeLoadBalanceMetaInfo")
+        .def(py::init<int, int, int, int, int>(), py::arg("expert_count"), py::arg("top_k"), py::arg("ep_rank"),
+            py::arg("ep_size"), py::arg("slot_count_per_rank"))
+        .def_readwrite("expert_count", &tk::MoeLoadBalanceMetaInfo::expertCount)
+        .def_readwrite("top_k", &tk::MoeLoadBalanceMetaInfo::topK)
+        .def_readwrite("ep_rank", &tk::MoeLoadBalanceMetaInfo::epRank)
+        .def_readwrite("ep_size", &tk::MoeLoadBalanceMetaInfo::epSize)
+        .def_readwrite("slot_count_per_rank", &tk::MoeLoadBalanceMetaInfo::slotCountPerRank);
+
+    // Bind MoePlacementCpuInfo struct
+    py::class_<tr::MoePlacementCpuInfo>(m, "MoePlacementCpuInfo")
+        .def(py::init<>())
+        .def_readwrite("expert_replica_count", &tr::MoePlacementCpuInfo::expertReplicaCount)
+        .def_readwrite("rank_expert_ids", &tr::MoePlacementCpuInfo::rankExpertIds);
+
+    // Bind SingleLayerMoeLoadBalancer class
+    py::class_<tr::SingleLayerMoeLoadBalancer, std::shared_ptr<tr::SingleLayerMoeLoadBalancer>>(
+        m, "SingleLayerMoeLoadBalancer")
+        .def("add_single_weight_slot", &tr::SingleLayerMoeLoadBalancer::addSingleWeightSlot, py::arg("slot_id"),
+            py::arg("name"), py::arg("weight_slot"), "Add a single weight slot for a specific slot ID")
+        .def("add_single_host_weight", &tr::SingleLayerMoeLoadBalancer::addSingleHostWeight, py::arg("expert_id"),
+            py::arg("name"), py::arg("host_weight"), "Add a single host weight for a specific expert ID")
+        .def("set_initial_weight_assignments", &tr::SingleLayerMoeLoadBalancer::setInitialWeightAssignments,
+            py::arg("initial_weight_assignments"), "Set initial weight assignments for each slot")
+        .def("get_pointer", &tr::SingleLayerMoeLoadBalancer::getSelfPtr,
+            "Get the pointer of the SingleLayerMoeLoadBalancer")
+        .def("get_layer_id", &tr::SingleLayerMoeLoadBalancer::getLayerId,
+            "Get the layer id of the SingleLayerMoeLoadBalancer");
+
+    // Bind MoeLoadBalancer class
+    py::class_<tr::MoeLoadBalancer>(m, "MoeLoadBalancer")
+        .def(py::init<int, int, int>(), py::arg("ep_rank"), py::arg("ep_size"), py::arg("layer_updates_per_iter"),
+            "Initialize the MoeLoadBalancer with the specified expert parallel rank, size, and update frequency")
+        .def("set_use_gpu_memcpy", &tr::MoeLoadBalancer::setUseGpuMemcpy, py::arg("use_gpu_memcpy"),
+            "Set whether to use GPU memcpy for weight updates")
+        .def("add_layer", &tr::MoeLoadBalancer::AddLayer, py::arg("expert_count"), py::arg("top_k"),
+            py::arg("slot_count_per_rank"), "Add a new MOE layer to the load balancer")
+        .def("finalize_model", &tr::MoeLoadBalancer::finalizeModel,
+            "Finalize the model structure, must be called after all layers are added")
+        .def("set_warm_up_iter_count", &tr::MoeLoadBalancer::setWarmUpIterCount, py::arg("iter_count"),
+            "Set the number of warm-up iterations")
+        .def("start_iter", &tr::MoeLoadBalancer::startIter, py::arg("iter_id"), py::arg("enable_statistic"),
+            py::arg("enable_update_weights"), "Start a new iteration with the given ID and settings")
+        .def("end_iter", &tr::MoeLoadBalancer::endIter, py::arg("iter_id"), "End the iteration with the given ID")
+        .def("shutdown", &tr::MoeLoadBalancer::shutdown, "Shutdown the load balancer and clean up resources");
+
+    m.def("is_host_accessible_device_memory_supported", &tr::HostAccessibleDeviceAllocator::isSupported,
+        "If current system support host accessible device memory");
+
+    // Bind do_replication function for testing
+    m.def("do_replication", &pyDoReplication, py::arg("meta_info"), py::arg("expert_load_factor"),
+        py::arg("cpu_placement"), "Do replication");
+
+    // Bind do_placement function for testing
+    m.def("do_placement", &pyDoPlacement, py::arg("meta_info"), py::arg("expert_load_factor"), py::arg("cpu_placement"),
+        "Do placement");
+}
+
+} // namespace tensorrt_llm::pybind::runtime

--- a/cpp/tensorrt_llm/nanobind/runtime/moeBindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/runtime/moeBindings.cpp
@@ -18,18 +18,15 @@
 #include "moeBindings.h"
 #include "tensorrt_llm/runtime/moeLoadBalancer/hostAccessibleDeviceAllocator.h"
 #include "tensorrt_llm/runtime/moeLoadBalancer/moeLoadBalancer.h"
-#include <pybind11/functional.h>
-#include <pybind11/numpy.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <pybind11/stl_bind.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/shared_ptr.h>
 #include <vector>
 
-namespace py = pybind11;
+namespace nb = nanobind;
 namespace tr = tensorrt_llm::runtime;
 namespace tk = tensorrt_llm::kernels;
 
-namespace tensorrt_llm::pybind::runtime
+namespace tensorrt_llm::nanobind::runtime
 {
 
 void pyDoReplication(tk::MoeLoadBalanceMetaInfo const& metaInfo, std::vector<float>& expertLoadFactor,
@@ -48,15 +45,15 @@ void pyDoPlacement(tk::MoeLoadBalanceMetaInfo const& metaInfo, std::vector<float
     tr::doPlacement(metaInfo, expertLoadFactor.data(), cpuPlacement);
 };
 
-void initMoeBindings(pybind11::module_& m)
+void initMoeBindings(nb::module_& m)
 {
     // Bind MoeWeight struct
-    py::class_<tr::MoeWeight>(m, "MoeWeight")
-        .def(py::init<>())
-        .def_property("weight_ptr", &tr::MoeWeight::getWeightPtr, &tr::MoeWeight::setWeightPtr)
-        .def_readwrite("height", &tr::MoeWeight::mHeight)
-        .def_readwrite("width", &tr::MoeWeight::mWidth)
-        .def_readwrite("pitch", &tr::MoeWeight::mPitch)
+    nb::class_<tr::MoeWeight>(m, "MoeWeight")
+        .def(nb::init<>())
+        .def_prop_rw("weight_ptr", &tr::MoeWeight::getWeightPtr, &tr::MoeWeight::setWeightPtr)
+        .def_rw("height", &tr::MoeWeight::mHeight)
+        .def_rw("width", &tr::MoeWeight::mWidth)
+        .def_rw("pitch", &tr::MoeWeight::mPitch)
         .def("__repr__",
             [](tr::MoeWeight const& self)
             {
@@ -66,62 +63,61 @@ void initMoeBindings(pybind11::module_& m)
             });
 
     // Bind MoeLoadBalanceMetaInfo struct
-    py::class_<tk::MoeLoadBalanceMetaInfo>(m, "MoeLoadBalanceMetaInfo")
-        .def(py::init<int, int, int, int, int>(), py::arg("expert_count"), py::arg("top_k"), py::arg("ep_rank"),
-            py::arg("ep_size"), py::arg("slot_count_per_rank"))
-        .def_readwrite("expert_count", &tk::MoeLoadBalanceMetaInfo::expertCount)
-        .def_readwrite("top_k", &tk::MoeLoadBalanceMetaInfo::topK)
-        .def_readwrite("ep_rank", &tk::MoeLoadBalanceMetaInfo::epRank)
-        .def_readwrite("ep_size", &tk::MoeLoadBalanceMetaInfo::epSize)
-        .def_readwrite("slot_count_per_rank", &tk::MoeLoadBalanceMetaInfo::slotCountPerRank);
+    nb::class_<tk::MoeLoadBalanceMetaInfo>(m, "MoeLoadBalanceMetaInfo")
+        .def(nb::init<int, int, int, int, int>(), nb::arg("expert_count"), nb::arg("top_k"), nb::arg("ep_rank"),
+            nb::arg("ep_size"), nb::arg("slot_count_per_rank"))
+        .def_rw("expert_count", &tk::MoeLoadBalanceMetaInfo::expertCount)
+        .def_rw("top_k", &tk::MoeLoadBalanceMetaInfo::topK)
+        .def_rw("ep_rank", &tk::MoeLoadBalanceMetaInfo::epRank)
+        .def_rw("ep_size", &tk::MoeLoadBalanceMetaInfo::epSize)
+        .def_rw("slot_count_per_rank", &tk::MoeLoadBalanceMetaInfo::slotCountPerRank);
 
     // Bind MoePlacementCpuInfo struct
-    py::class_<tr::MoePlacementCpuInfo>(m, "MoePlacementCpuInfo")
-        .def(py::init<>())
-        .def_readwrite("expert_replica_count", &tr::MoePlacementCpuInfo::expertReplicaCount)
-        .def_readwrite("rank_expert_ids", &tr::MoePlacementCpuInfo::rankExpertIds);
+    nb::class_<tr::MoePlacementCpuInfo>(m, "MoePlacementCpuInfo")
+        .def(nb::init<>())
+        .def_rw("expert_replica_count", &tr::MoePlacementCpuInfo::expertReplicaCount)
+        .def_rw("rank_expert_ids", &tr::MoePlacementCpuInfo::rankExpertIds);
 
     // Bind SingleLayerMoeLoadBalancer class
-    py::class_<tr::SingleLayerMoeLoadBalancer, std::shared_ptr<tr::SingleLayerMoeLoadBalancer>>(
-        m, "SingleLayerMoeLoadBalancer")
-        .def("add_single_weight_slot", &tr::SingleLayerMoeLoadBalancer::addSingleWeightSlot, py::arg("slot_id"),
-            py::arg("name"), py::arg("weight_slot"), "Add a single weight slot for a specific slot ID")
-        .def("add_single_host_weight", &tr::SingleLayerMoeLoadBalancer::addSingleHostWeight, py::arg("expert_id"),
-            py::arg("name"), py::arg("host_weight"), "Add a single host weight for a specific expert ID")
+    nb::class_<tr::SingleLayerMoeLoadBalancer>(m, "SingleLayerMoeLoadBalancer")
+        .def("add_single_weight_slot", &tr::SingleLayerMoeLoadBalancer::addSingleWeightSlot, nb::arg("slot_id"),
+            nb::arg("name"), nb::arg("weight_slot"), "Add a single weight slot for a specific slot ID")
+        .def("add_single_host_weight", &tr::SingleLayerMoeLoadBalancer::addSingleHostWeight, nb::arg("expert_id"),
+            nb::arg("name"), nb::arg("host_weight"), "Add a single host weight for a specific expert ID")
         .def("set_initial_weight_assignments", &tr::SingleLayerMoeLoadBalancer::setInitialWeightAssignments,
-            py::arg("initial_weight_assignments"), "Set initial weight assignments for each slot")
+            nb::arg("initial_weight_assignments"), "Set initial weight assignments for each slot")
         .def("get_pointer", &tr::SingleLayerMoeLoadBalancer::getSelfPtr,
             "Get the pointer of the SingleLayerMoeLoadBalancer")
         .def("get_layer_id", &tr::SingleLayerMoeLoadBalancer::getLayerId,
             "Get the layer id of the SingleLayerMoeLoadBalancer");
 
     // Bind MoeLoadBalancer class
-    py::class_<tr::MoeLoadBalancer>(m, "MoeLoadBalancer")
-        .def(py::init<int, int, int>(), py::arg("ep_rank"), py::arg("ep_size"), py::arg("layer_updates_per_iter"),
+    nb::class_<tr::MoeLoadBalancer>(m, "MoeLoadBalancer")
+        .def(nb::init<int, int, int>(), nb::arg("ep_rank"), nb::arg("ep_size"), nb::arg("layer_updates_per_iter"),
             "Initialize the MoeLoadBalancer with the specified expert parallel rank, size, and update frequency")
-        .def("set_use_gpu_memcpy", &tr::MoeLoadBalancer::setUseGpuMemcpy, py::arg("use_gpu_memcpy"),
+        .def("set_use_gpu_memcpy", &tr::MoeLoadBalancer::setUseGpuMemcpy, nb::arg("use_gpu_memcpy"),
             "Set whether to use GPU memcpy for weight updates")
-        .def("add_layer", &tr::MoeLoadBalancer::AddLayer, py::arg("expert_count"), py::arg("top_k"),
-            py::arg("slot_count_per_rank"), "Add a new MOE layer to the load balancer")
+        .def("add_layer", &tr::MoeLoadBalancer::AddLayer, nb::arg("expert_count"), nb::arg("top_k"),
+            nb::arg("slot_count_per_rank"), "Add a new MOE layer to the load balancer")
         .def("finalize_model", &tr::MoeLoadBalancer::finalizeModel,
             "Finalize the model structure, must be called after all layers are added")
-        .def("set_warm_up_iter_count", &tr::MoeLoadBalancer::setWarmUpIterCount, py::arg("iter_count"),
+        .def("set_warm_up_iter_count", &tr::MoeLoadBalancer::setWarmUpIterCount, nb::arg("iter_count"),
             "Set the number of warm-up iterations")
-        .def("start_iter", &tr::MoeLoadBalancer::startIter, py::arg("iter_id"), py::arg("enable_statistic"),
-            py::arg("enable_update_weights"), "Start a new iteration with the given ID and settings")
-        .def("end_iter", &tr::MoeLoadBalancer::endIter, py::arg("iter_id"), "End the iteration with the given ID")
+        .def("start_iter", &tr::MoeLoadBalancer::startIter, nb::arg("iter_id"), nb::arg("enable_statistic"),
+            nb::arg("enable_update_weights"), "Start a new iteration with the given ID and settings")
+        .def("end_iter", &tr::MoeLoadBalancer::endIter, nb::arg("iter_id"), "End the iteration with the given ID")
         .def("shutdown", &tr::MoeLoadBalancer::shutdown, "Shutdown the load balancer and clean up resources");
 
     m.def("is_host_accessible_device_memory_supported", &tr::HostAccessibleDeviceAllocator::isSupported,
         "If current system support host accessible device memory");
 
     // Bind do_replication function for testing
-    m.def("do_replication", &pyDoReplication, py::arg("meta_info"), py::arg("expert_load_factor"),
-        py::arg("cpu_placement"), "Do replication");
+    m.def("do_replication", &pyDoReplication, nb::arg("meta_info"), nb::arg("expert_load_factor"),
+        nb::arg("cpu_placement"), "Do replication");
 
     // Bind do_placement function for testing
-    m.def("do_placement", &pyDoPlacement, py::arg("meta_info"), py::arg("expert_load_factor"), py::arg("cpu_placement"),
+    m.def("do_placement", &pyDoPlacement, nb::arg("meta_info"), nb::arg("expert_load_factor"), nb::arg("cpu_placement"),
         "Do placement");
 }
 
-} // namespace tensorrt_llm::pybind::runtime
+} // namespace tensorrt_llm::nanobind::runtime

--- a/cpp/tensorrt_llm/nanobind/runtime/moeBindings.h
+++ b/cpp/tensorrt_llm/nanobind/runtime/moeBindings.h
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace tensorrt_llm::pybind::runtime
+{
+
+void initMoeBindings(pybind11::module_& m);
+
+} // namespace tensorrt_llm::pybind::runtime

--- a/cpp/tensorrt_llm/nanobind/runtime/moeBindings.h
+++ b/cpp/tensorrt_llm/nanobind/runtime/moeBindings.h
@@ -17,11 +17,13 @@
 
 #pragma once
 
-#include <pybind11/pybind11.h>
+#include <nanobind/nanobind.h>
 
-namespace tensorrt_llm::pybind::runtime
+#include "tensorrt_llm/nanobind/common/customCasters.h"
+
+namespace tensorrt_llm::nanobind::runtime
 {
 
-void initMoeBindings(pybind11::module_& m);
+void initMoeBindings(nb::module_& m);
 
-} // namespace tensorrt_llm::pybind::runtime
+} // namespace tensorrt_llm::nanobind::runtime

--- a/cpp/tensorrt_llm/nanobind/testing/modelSpecBinding.cpp
+++ b/cpp/tensorrt_llm/nanobind/testing/modelSpecBinding.cpp
@@ -1,0 +1,85 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "modelSpecBinding.h"
+#include "tensorrt_llm/testing/modelSpec.h"
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+namespace py = pybind11;
+using tensorrt_llm::testing::ModelSpec;
+using tensorrt_llm::testing::KVCacheType;
+using tensorrt_llm::testing::QuantMethod;
+using tensorrt_llm::testing::OutputContentType;
+
+namespace tensorrt_llm::pybind::testing
+{
+
+void initBindings(py::module_& m)
+{
+    py::enum_<QuantMethod>(m, "QuantMethod", py::arithmetic(), "Quantization Method")
+        .value("NONE", QuantMethod::kNONE, "No Quantization")
+        .value("SMOOTH_QUANT", QuantMethod::kSMOOTH_QUANT, "Smooth Quantization");
+
+    py::enum_<OutputContentType>(m, "OutputContentType", py::arithmetic(), "Output Content Type")
+        .value("NONE", OutputContentType::kNONE, "No Output Content")
+        .value("CONTEXT_LOGITS", OutputContentType::kCONTEXT_LOGITS, "Context Logits")
+        .value("GENERATION_LOGITS", OutputContentType::kGENERATION_LOGITS, "Generation Logits")
+        .value("LOG_PROBS", OutputContentType::kLOG_PROBS, "Log Probs")
+        .value("CUM_LOG_PROBS", OutputContentType::kCUM_LOG_PROBS, "Cumulative Log");
+
+    py::class_<ModelSpec>(m, "ModelSpec")
+        .def(py::init<std::string const&, nvinfer1::DataType>())
+        .def("use_gpt_plugin", &ModelSpec::useGptAttentionPlugin)
+        .def("use_packed_input", &ModelSpec::usePackedInput)
+        .def("set_kv_cache_type", &ModelSpec::setKVCacheType)
+        .def("use_decoder_per_request", &ModelSpec::useDecoderPerRequest)
+        .def("use_tensor_parallelism", &ModelSpec::useTensorParallelism)
+        .def("use_pipeline_parallelism", &ModelSpec::usePipelineParallelism)
+        .def("use_context_parallelism", &ModelSpec::useContextParallelism)
+        .def("set_draft_tokens", &ModelSpec::setDraftTokens)
+        .def("use_accept_by_logits", &ModelSpec::useAcceptByLogits)
+        .def("use_mamba_plugin", &ModelSpec::useMambaPlugin)
+        .def("gather_logits", &ModelSpec::gatherLogits)
+        .def("replace_logits", &ModelSpec::replaceLogits)
+        .def("return_log_probs", &ModelSpec::returnLogProbs)
+        .def("smoke_test", &ModelSpec::smokeTest)
+        .def("use_medusa", &ModelSpec::useMedusa)
+        .def("use_eagle", &ModelSpec::useEagle)
+        .def("use_lookahead_decoding", &ModelSpec::useLookaheadDecoding)
+        .def("use_explicit_draft_tokens_decoding", &ModelSpec::useExplicitDraftTokensDecoding)
+        .def("use_draft_tokens_external_decoding", &ModelSpec::useDraftTokensExternalDecoding)
+        .def("use_logits", &ModelSpec::useLogits)
+        .def("use_multiple_profiles", &ModelSpec::useMultipleProfiles)
+        .def("set_max_input_length", &ModelSpec::setMaxInputLength)
+        .def("set_max_output_length", &ModelSpec::setMaxOutputLength)
+        .def("set_quant_method", &ModelSpec::setQuantMethod)
+        .def("use_lora_plugin", &ModelSpec::useLoraPlugin)
+        .def("get_input_file", &ModelSpec::getInputFile)
+        .def("get_model_path", &ModelSpec::getModelPath)
+        .def("get_results_file", &ModelSpec::getResultsFile)
+        .def("get_generation_logits_file", &ModelSpec::getGenerationLogitsFile)
+        .def("get_context_logits_file", &ModelSpec::getContextLogitsFile)
+        .def("get_cum_log_probs_file", &ModelSpec::getCumLogProbsFile)
+        .def("get_log_probs_file", &ModelSpec::getLogProbsFile)
+        .def("enable_context_fmha_fp32_acc", &ModelSpec::enableContextFMHAFp32Acc)
+        .def("get_enable_context_fmha_fp32_acc", &ModelSpec::getEnableContextFMHAFp32Acc)
+        .def("__copy__", [](ModelSpec const& self) { return ModelSpec(self); });
+}
+
+} // namespace tensorrt_llm::pybind::testing

--- a/cpp/tensorrt_llm/nanobind/testing/modelSpecBinding.cpp
+++ b/cpp/tensorrt_llm/nanobind/testing/modelSpecBinding.cpp
@@ -18,58 +18,59 @@
 #include "modelSpecBinding.h"
 #include "tensorrt_llm/testing/modelSpec.h"
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
+#include <nanobind/nanobind.h>
 
-namespace py = pybind11;
+namespace nb = nanobind;
 using tensorrt_llm::testing::ModelSpec;
 using tensorrt_llm::testing::KVCacheType;
 using tensorrt_llm::testing::QuantMethod;
 using tensorrt_llm::testing::OutputContentType;
 
-namespace tensorrt_llm::pybind::testing
+namespace tensorrt_llm::nanobind::testing
 {
 
-void initBindings(py::module_& m)
+void initBindings(nb::module_& m)
 {
-    py::enum_<QuantMethod>(m, "QuantMethod", py::arithmetic(), "Quantization Method")
+    nb::enum_<QuantMethod>(m, "QuantMethod", nb::is_arithmetic(), "Quantization Method")
         .value("NONE", QuantMethod::kNONE, "No Quantization")
         .value("SMOOTH_QUANT", QuantMethod::kSMOOTH_QUANT, "Smooth Quantization");
 
-    py::enum_<OutputContentType>(m, "OutputContentType", py::arithmetic(), "Output Content Type")
+    nb::enum_<OutputContentType>(m, "OutputContentType", nb::is_arithmetic(), "Output Content Type")
         .value("NONE", OutputContentType::kNONE, "No Output Content")
         .value("CONTEXT_LOGITS", OutputContentType::kCONTEXT_LOGITS, "Context Logits")
         .value("GENERATION_LOGITS", OutputContentType::kGENERATION_LOGITS, "Generation Logits")
         .value("LOG_PROBS", OutputContentType::kLOG_PROBS, "Log Probs")
         .value("CUM_LOG_PROBS", OutputContentType::kCUM_LOG_PROBS, "Cumulative Log");
 
-    py::class_<ModelSpec>(m, "ModelSpec")
-        .def(py::init<std::string const&, nvinfer1::DataType>())
-        .def("use_gpt_plugin", &ModelSpec::useGptAttentionPlugin)
-        .def("use_packed_input", &ModelSpec::usePackedInput)
-        .def("set_kv_cache_type", &ModelSpec::setKVCacheType)
-        .def("use_decoder_per_request", &ModelSpec::useDecoderPerRequest)
-        .def("use_tensor_parallelism", &ModelSpec::useTensorParallelism)
-        .def("use_pipeline_parallelism", &ModelSpec::usePipelineParallelism)
-        .def("use_context_parallelism", &ModelSpec::useContextParallelism)
-        .def("set_draft_tokens", &ModelSpec::setDraftTokens)
-        .def("use_accept_by_logits", &ModelSpec::useAcceptByLogits)
-        .def("use_mamba_plugin", &ModelSpec::useMambaPlugin)
-        .def("gather_logits", &ModelSpec::gatherLogits)
-        .def("replace_logits", &ModelSpec::replaceLogits)
-        .def("return_log_probs", &ModelSpec::returnLogProbs)
-        .def("smoke_test", &ModelSpec::smokeTest)
-        .def("use_medusa", &ModelSpec::useMedusa)
-        .def("use_eagle", &ModelSpec::useEagle)
-        .def("use_lookahead_decoding", &ModelSpec::useLookaheadDecoding)
-        .def("use_explicit_draft_tokens_decoding", &ModelSpec::useExplicitDraftTokensDecoding)
-        .def("use_draft_tokens_external_decoding", &ModelSpec::useDraftTokensExternalDecoding)
+    nb::class_<ModelSpec>(m, "ModelSpec")
+        .def(nb::init<std::string const&, nvinfer1::DataType>())
+        .def("use_gpt_plugin", &ModelSpec::useGptAttentionPlugin, nb::rv_policy::reference_internal)
+        .def("use_packed_input", &ModelSpec::usePackedInput, nb::rv_policy::reference_internal)
+        .def("set_kv_cache_type", &ModelSpec::setKVCacheType, nb::rv_policy::reference_internal)
+        .def("use_decoder_per_request", &ModelSpec::useDecoderPerRequest, nb::rv_policy::reference_internal)
+        .def("use_tensor_parallelism", &ModelSpec::useTensorParallelism, nb::rv_policy::reference_internal)
+        .def("use_pipeline_parallelism", &ModelSpec::usePipelineParallelism, nb::rv_policy::reference_internal)
+        .def("use_context_parallelism", &ModelSpec::useContextParallelism, nb::rv_policy::reference_internal)
+        .def("set_draft_tokens", &ModelSpec::setDraftTokens, nb::rv_policy::reference_internal)
+        .def("use_accept_by_logits", &ModelSpec::useAcceptByLogits, nb::rv_policy::reference_internal)
+        .def("use_mamba_plugin", &ModelSpec::useMambaPlugin, nb::rv_policy::reference_internal)
+        .def("gather_logits", &ModelSpec::gatherLogits, nb::rv_policy::reference_internal)
+        .def("replace_logits", &ModelSpec::replaceLogits, nb::rv_policy::reference_internal)
+        .def("return_log_probs", &ModelSpec::returnLogProbs, nb::rv_policy::reference_internal)
+        .def("smoke_test", &ModelSpec::smokeTest, nb::rv_policy::reference_internal)
+        .def("use_medusa", &ModelSpec::useMedusa, nb::rv_policy::reference_internal)
+        .def("use_eagle", &ModelSpec::useEagle, nb::rv_policy::reference_internal)
+        .def("use_lookahead_decoding", &ModelSpec::useLookaheadDecoding, nb::rv_policy::reference_internal)
+        .def("use_explicit_draft_tokens_decoding", &ModelSpec::useExplicitDraftTokensDecoding,
+            nb::rv_policy::reference_internal)
+        .def("use_draft_tokens_external_decoding", &ModelSpec::useDraftTokensExternalDecoding,
+            nb::rv_policy::reference_internal)
         .def("use_logits", &ModelSpec::useLogits)
-        .def("use_multiple_profiles", &ModelSpec::useMultipleProfiles)
-        .def("set_max_input_length", &ModelSpec::setMaxInputLength)
-        .def("set_max_output_length", &ModelSpec::setMaxOutputLength)
-        .def("set_quant_method", &ModelSpec::setQuantMethod)
-        .def("use_lora_plugin", &ModelSpec::useLoraPlugin)
+        .def("use_multiple_profiles", &ModelSpec::useMultipleProfiles, nb::rv_policy::reference_internal)
+        .def("set_max_input_length", &ModelSpec::setMaxInputLength, nb::rv_policy::reference_internal)
+        .def("set_max_output_length", &ModelSpec::setMaxOutputLength, nb::rv_policy::reference_internal)
+        .def("set_quant_method", &ModelSpec::setQuantMethod, nb::rv_policy::reference_internal)
+        .def("use_lora_plugin", &ModelSpec::useLoraPlugin, nb::rv_policy::reference_internal)
         .def("get_input_file", &ModelSpec::getInputFile)
         .def("get_model_path", &ModelSpec::getModelPath)
         .def("get_results_file", &ModelSpec::getResultsFile)
@@ -77,9 +78,9 @@ void initBindings(py::module_& m)
         .def("get_context_logits_file", &ModelSpec::getContextLogitsFile)
         .def("get_cum_log_probs_file", &ModelSpec::getCumLogProbsFile)
         .def("get_log_probs_file", &ModelSpec::getLogProbsFile)
-        .def("enable_context_fmha_fp32_acc", &ModelSpec::enableContextFMHAFp32Acc)
+        .def("enable_context_fmha_fp32_acc", &ModelSpec::enableContextFMHAFp32Acc, nb::rv_policy::reference_internal)
         .def("get_enable_context_fmha_fp32_acc", &ModelSpec::getEnableContextFMHAFp32Acc)
         .def("__copy__", [](ModelSpec const& self) { return ModelSpec(self); });
 }
 
-} // namespace tensorrt_llm::pybind::testing
+} // namespace tensorrt_llm::nanobind::testing

--- a/cpp/tensorrt_llm/nanobind/testing/modelSpecBinding.h
+++ b/cpp/tensorrt_llm/nanobind/testing/modelSpecBinding.h
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "tensorrt_llm/pybind/common/customCasters.h"
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace tensorrt_llm::pybind::testing
+{
+
+void initBindings(py::module_& m);
+
+} // namespace tensorrt_llm::pybind::testing

--- a/cpp/tensorrt_llm/nanobind/testing/modelSpecBinding.h
+++ b/cpp/tensorrt_llm/nanobind/testing/modelSpecBinding.h
@@ -17,14 +17,14 @@
 
 #pragma once
 
-#include "tensorrt_llm/pybind/common/customCasters.h"
-#include <pybind11/pybind11.h>
+#include "tensorrt_llm/nanobind/common/customCasters.h"
+#include <nanobind/nanobind.h>
 
-namespace py = pybind11;
+namespace nb = nanobind;
 
-namespace tensorrt_llm::pybind::testing
+namespace tensorrt_llm::nanobind::testing
 {
 
-void initBindings(py::module_& m);
+void initBindings(nb::module_& m);
 
-} // namespace tensorrt_llm::pybind::testing
+} // namespace tensorrt_llm::nanobind::testing

--- a/cpp/tensorrt_llm/nanobind/userbuffers/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/userbuffers/bindings.cpp
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bindings.h"
+#include "tensorrt_llm/kernels/userbuffers/ub_interface.h"
+#include "tensorrt_llm/kernels/userbuffers/userbuffersManager.h"
+
+namespace py = pybind11;
+namespace tub = tensorrt_llm::runtime::ub;
+
+namespace tensorrt_llm::kernels::userbuffers
+{
+
+void UserBufferBindings::initBindings(pybind11::module_& m)
+{
+    py::class_<tub::UBBuffer>(m, "UBBuffer")
+        .def_readonly("size", &tub::UBBuffer::size)
+        .def_property_readonly("addr", [](tub::UBBuffer& self) { return reinterpret_cast<intptr_t>(self.addr); })
+        .def_readonly("handle", &tub::UBBuffer::handle)
+        .def("invalid", &tub::UBBuffer::invalid);
+
+    m.def("ub_initialize", [](int tp_size) { tub::ub_initialize(tp_size); });
+    m.def("ub_is_initialized", &tub::ub_is_initialized);
+    m.def("ub_allocate", [](size_t bytes) { return tub::ub_allocate(bytes); });
+    m.def("ub_deallocate", [](intptr_t addr) { return tub::ub_deallocate(reinterpret_cast<void*>(addr)); });
+    m.def("ub_get", &tub::ub_get);
+    m.def("ub_supported", &tub::ub_supported);
+
+    m.def("initialize_userbuffers_manager", &tub::initialize_userbuffers_manager);
+}
+} // namespace tensorrt_llm::kernels::userbuffers

--- a/cpp/tensorrt_llm/nanobind/userbuffers/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/userbuffers/bindings.cpp
@@ -18,19 +18,20 @@
 #include "bindings.h"
 #include "tensorrt_llm/kernels/userbuffers/ub_interface.h"
 #include "tensorrt_llm/kernels/userbuffers/userbuffersManager.h"
+#include <nanobind/nanobind.h>
 
-namespace py = pybind11;
+namespace nb = nanobind;
 namespace tub = tensorrt_llm::runtime::ub;
 
 namespace tensorrt_llm::kernels::userbuffers
 {
 
-void UserBufferBindings::initBindings(pybind11::module_& m)
+void UserBufferBindings::initBindings(nb::module_& m)
 {
-    py::class_<tub::UBBuffer>(m, "UBBuffer")
-        .def_readonly("size", &tub::UBBuffer::size)
-        .def_property_readonly("addr", [](tub::UBBuffer& self) { return reinterpret_cast<intptr_t>(self.addr); })
-        .def_readonly("handle", &tub::UBBuffer::handle)
+    nb::class_<tub::UBBuffer>(m, "UBBuffer")
+        .def_ro("size", &tub::UBBuffer::size)
+        .def_prop_ro("addr", [](tub::UBBuffer& self) { return reinterpret_cast<intptr_t>(self.addr); })
+        .def_ro("handle", &tub::UBBuffer::handle)
         .def("invalid", &tub::UBBuffer::invalid);
 
     m.def("ub_initialize", [](int tp_size) { tub::ub_initialize(tp_size); });

--- a/cpp/tensorrt_llm/nanobind/userbuffers/bindings.h
+++ b/cpp/tensorrt_llm/nanobind/userbuffers/bindings.h
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "tensorrt_llm/pybind/common/customCasters.h"
+#include <pybind11/pybind11.h>
+
+namespace tensorrt_llm::kernels::userbuffers
+{
+class UserBufferBindings
+{
+public:
+    static void initBindings(pybind11::module_& m);
+};
+} // namespace tensorrt_llm::kernels::userbuffers

--- a/cpp/tensorrt_llm/nanobind/userbuffers/bindings.h
+++ b/cpp/tensorrt_llm/nanobind/userbuffers/bindings.h
@@ -17,14 +17,13 @@
 
 #pragma once
 
-#include "tensorrt_llm/pybind/common/customCasters.h"
-#include <pybind11/pybind11.h>
+#include "tensorrt_llm/nanobind/common/customCasters.h"
 
 namespace tensorrt_llm::kernels::userbuffers
 {
 class UserBufferBindings
 {
 public:
-    static void initBindings(pybind11::module_& m);
+    static void initBindings(nb::module_& m);
 };
 } // namespace tensorrt_llm::kernels::userbuffers

--- a/cpp/tensorrt_llm/pybind/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/bindings.cpp
@@ -70,6 +70,7 @@ tr::SamplingConfig makeSamplingConfig(std::vector<tr::SamplingConfig> const& con
 PYBIND11_MODULE(TRTLLM_PYBIND_MODULE, m)
 {
     m.doc() = "TensorRT-LLM Python bindings for C++ runtime";
+    m.attr("binding_type") = "pybind";
 
     // Create MpiComm binding first since it's used in the executor bindings
     py::classh<tensorrt_llm::mpi::MpiComm>(m, "MpiComm")

--- a/cpp/tensorrt_llm/pybind/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/bindings.cpp
@@ -170,7 +170,8 @@ PYBIND11_MODULE(TRTLLM_PYBIND_MODULE, m)
         .value("CONTINUOUS", tr::ModelConfig::KVCacheType::kCONTINUOUS)
         .value("PAGED", tr::ModelConfig::KVCacheType::kPAGED)
         .value("DISABLED", tr::ModelConfig::KVCacheType::kDISABLED)
-        .def(py::init(&tr::ModelConfig::KVCacheTypeFromString));
+        .def(py::init(&tr::ModelConfig::KVCacheTypeFromString))
+        .def("from_string", &tr::ModelConfig::KVCacheTypeFromString);
 
     py::enum_<tr::ModelConfig::LayerType>(m, "LayerType")
         .value("ATTENTION", tr::ModelConfig::LayerType::kATTENTION)

--- a/cpp/tests/resources/scripts/build_gpt_engines.py
+++ b/cpp/tests/resources/scripts/build_gpt_engines.py
@@ -92,9 +92,7 @@ def build_engines(model_cache: Optional[str] = None,
         else:
             url_prefix = "file://"
 
-        model_url = url_prefix + str(
-            Path(model_cache) /
-            model_name) if model_cache else "https://huggingface.co/gpt2"
+        model_url = "https://huggingface.co/gpt2"
         run_command([
             "git", "clone", model_url, "--single-branch", "--no-local",
             model_name

--- a/examples/models/core/llama/summarize_long.py
+++ b/examples/models/core/llama/summarize_long.py
@@ -97,7 +97,7 @@ def TRTLLaMA(args, config):
     quantization_config = pretrained_config['quantization']
 
     build_config = config['build_config']
-    kv_cache_type = KVCacheType(build_config['kv_cache_type'])
+    kv_cache_type = KVCacheType.from_string(build_config['kv_cache_type'])
     plugin_config = build_config['plugin_config']
 
     dtype = pretrained_config['dtype']

--- a/examples/models/core/qwen2audio/run.py
+++ b/examples/models/core/qwen2audio/run.py
@@ -122,7 +122,8 @@ class QWenInfer(object):
         num_kv_heads = config["pretrained_config"].get("num_key_value_heads",
                                                        num_heads)
         if "kv_cache_type" in config["build_config"]:
-            kv_cache_type = KVCacheType(config["build_config"]["kv_cache_type"])
+            kv_cache_type = KVCacheType.from_string(
+                config["build_config"]["kv_cache_type"])
         else:
             kv_cache_type = KVCacheType.CONTINUOUS
 

--- a/examples/models/core/qwenvl/run.py
+++ b/examples/models/core/qwenvl/run.py
@@ -118,7 +118,8 @@ class QWenInfer(object):
         num_kv_heads = config["pretrained_config"].get("num_key_value_heads",
                                                        num_heads)
         if "kv_cache_type" in config["build_config"]:
-            kv_cache_type = KVCacheType(config["build_config"]["kv_cache_type"])
+            kv_cache_type = KVCacheType.from_string(
+                config["build_config"]["kv_cache_type"])
         else:
             kv_cache_type = KVCacheType.CONTINUOUS
 

--- a/jenkins/Build.groovy
+++ b/jenkins/Build.groovy
@@ -48,12 +48,23 @@ CONFIG_LINUX_AARCH64 = "linux_aarch64"
 def CONFIG_LINUX_AARCH64_LLVM = "linux_aarch64_LLVM"
 
 @Field
+def CONFIG_LINUX_X86_64_NANOBIND = "linux_x86_64_Nanobind"
+
+@Field
+def CONFIG_LINUX_AARCH64_NANOBIND = "linux_aarch64_Nanobind"
+
+@Field
 def BUILD_CONFIGS = [
   // Vanilla TARNAME is used for packaging in runLLMPackage
   // cmake-vars cannot be empty, so passing (default) multi-device configuration.
   (CONFIG_LINUX_X86_64_VANILLA) : [
     (WHEEL_EXTRA_ARGS) : "--extra-cmake-vars ENABLE_MULTI_DEVICE=1 --extra-cmake-vars WARNING_IS_ERROR=ON --extra-cmake-vars NIXL_ROOT=/opt/nvidia/nvda_nixl --micro_benchmarks",
     (TARNAME) : "TensorRT-LLM.tar.gz",
+    (WHEEL_ARCHS): "80-real;86-real;89-real;90-real;100-real;120-real",
+  ],
+  (CONFIG_LINUX_X86_64_NANOBIND) : [
+    (WHEEL_EXTRA_ARGS) : "--binding_type nanobind --extra-cmake-vars ENABLE_MULTI_DEVICE=1 --extra-cmake-vars WARNING_IS_ERROR=ON --extra-cmake-vars NIXL_ROOT=/opt/nvidia/nvda_nixl --micro_benchmarks",
+    (TARNAME) : "nanobind-TensorRT-LLM.tar.gz",
     (WHEEL_ARCHS): "80-real;86-real;89-real;90-real;100-real;120-real",
   ],
   (CONFIG_LINUX_X86_64_SINGLE_DEVICE) : [
@@ -69,6 +80,11 @@ def BUILD_CONFIGS = [
   (CONFIG_LINUX_AARCH64): [
     (WHEEL_EXTRA_ARGS) : "--extra-cmake-vars WARNING_IS_ERROR=ON",
     (TARNAME) : "TensorRT-LLM-GH200.tar.gz",
+    (WHEEL_ARCHS): "90-real;100-real;120-real",
+  ],
+  (CONFIG_LINUX_AARCH64_NANOBIND): [
+    (WHEEL_EXTRA_ARGS) : "--binding_type nanobind --extra-cmake-vars WARNING_IS_ERROR=ON",
+    (TARNAME) : "nanobind-TensorRT-LLM-GH200.tar.gz",
     (WHEEL_ARCHS): "90-real;100-real;120-real",
   ],
   (CONFIG_LINUX_AARCH64_LLVM) : [
@@ -521,6 +537,8 @@ def launchStages(pipeline, cpu_arch, enableFailFast, globalVars)
             pipeline, cpu_arch == AARCH64_TRIPLE ? CONFIG_LINUX_AARCH64 : CONFIG_LINUX_X86_64_VANILLA),
         "Build TRT-LLM LLVM": [LLM_DOCKER_IMAGE] + prepareLLMBuild(
             pipeline, cpu_arch == AARCH64_TRIPLE ? CONFIG_LINUX_AARCH64_LLVM : CONFIG_LINUX_X86_64_LLVM),
+        "Build TRT-LLM Nanobind": [LLM_DOCKER_IMAGE] + prepareLLMBuild(
+            pipeline, cpu_arch == AARCH64_TRIPLE ? CONFIG_LINUX_AARCH64_NANOBIND : CONFIG_LINUX_X86_64_NANOBIND),
     ]
 
     if (cpu_arch == X86_64_TRIPLE) {

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -65,12 +65,16 @@ def LLVM_CONFIG = "LLVM"
 LINUX_AARCH64_CONFIG = "linux_aarch64"
 
 @Field
+def NANOBIND_CONFIG = "Nanobind"
+
+@Field
 def BUILD_CONFIGS = [
   // Vanilla TARNAME is used for packaging in runLLMPackage
   (VANILLA_CONFIG) : [(TARNAME) : "TensorRT-LLM.tar.gz"],
   (SINGLE_DEVICE_CONFIG) : [(TARNAME) : "single-device-TensorRT-LLM.tar.gz"],
   (LLVM_CONFIG) : [(TARNAME) : "llvm-TensorRT-LLM.tar.gz"],
   (LINUX_AARCH64_CONFIG) : [(TARNAME) : "TensorRT-LLM-GH200.tar.gz"],
+  (NANOBIND_CONFIG) : [(TARNAME) : "nanobind-TensorRT-LLM.tar.gz"],
 ]
 
 // TODO: Move common variables to an unified location
@@ -1711,6 +1715,7 @@ def launchTestJobs(pipeline, testFilter, dockerNode=null)
         "A10-TensorRT-4": ["a10", "l0_a10", 4, 6],
         "A10-TensorRT-5": ["a10", "l0_a10", 5, 6],
         "A10-TensorRT-6": ["a10", "l0_a10", 6, 6],
+        "A10-Nanobind": ["a10", "l0_nanobind_test", 1, 1],
         "A30-Triton-1": ["a30", "l0_a30", 1, 1],
         "A30-PyTorch-1": ["a30", "l0_a30", 1, 2],
         "A30-PyTorch-2": ["a30", "l0_a30", 2, 2],
@@ -1786,6 +1791,9 @@ def launchTestJobs(pipeline, testFilter, dockerNode=null)
         }
         if (key.contains("llvm")) {
             config = LLVM_CONFIG
+        }
+        if (key.contains("Nanobind")) {
+            config = NANOBIND_CONFIG
         }
         runLLMTestlistOnPlatform(pipeline, values[0], values[1], config, key.contains("Perf"), key, values[2], values[3])
     }]]}
@@ -2058,7 +2066,6 @@ def launchTestJobs(pipeline, testFilter, dockerNode=null)
 
     multiGpuJobs = parallelJobs.findAll{(it.key.contains("4_GPUs") || it.key.contains("8_GPUs")) && !it.key.contains("Post-Merge")}
     println multiGpuJobs.keySet()
-    multiGpuJobsPostMerge = parallelJobs.findAll{(it.key.contains("4_GPUs") || it.key.contains("8_GPUs")) && it.key.contains("Post-Merge")}
 
     parallelJobs += docBuildJobs
     parallelJobs += sanityCheckJobs

--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -299,6 +299,7 @@ def main(*,
          skip_building_wheel: bool = False,
          linking_install_binary: bool = False,
          python_bindings: bool = True,
+         binding_type: str = "pybind",
          benchmarks: bool = False,
          micro_benchmarks: bool = False,
          nvtx: bool = False,
@@ -396,6 +397,39 @@ def main(*,
         clear_folder(build_dir)  # Keep the folder in case it is mounted.
     build_dir.mkdir(parents=True, exist_ok=True)
 
+    def get_binding_type_from_cache():
+        cmake_cache_file = build_dir / "CMakeCache.txt"
+        if not cmake_cache_file.exists():
+            return None
+
+        with open(cmake_cache_file, 'r') as f:
+            for line in f:
+                if line.startswith("BINDING_TYPE:STRING="):
+                    cashed_binding_type = line.split("=", 1)[1].strip()
+                    if cashed_binding_type in ['pybind', 'nanobind']:
+                        return cashed_binding_type
+            return None
+
+    cached_binding_type = get_binding_type_from_cache()
+
+    if not first_build and cached_binding_type != binding_type:
+        # Clean up of previous binding build artifacts
+        nanobind_dir = build_dir / "tensorrt_llm" / "nanobind"
+        if nanobind_dir.exists():
+            rmtree(nanobind_dir)
+        nanobind_stub_file = project_dir / "tensorrt_llm" / "bindings.pyi"
+        if nanobind_stub_file.exists():
+            nanobind_stub_file.unlink()
+
+        pybind_dir = build_dir / "tensorrt_llm" / "pybind"
+        if pybind_dir.exists():
+            rmtree(pybind_dir)
+        pybind_stub_dir = project_dir / "tensorrt_llm" / "bindings"
+        if pybind_stub_dir.exists():
+            rmtree(pybind_stub_dir)
+
+        configure_cmake = True
+
     if use_ccache:
         cmake_def_args.append(
             f"-DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache"
@@ -411,12 +445,10 @@ def main(*,
 
     if cpp_only:
         build_pyt = "OFF"
-        build_pybind = "OFF"
         build_deep_ep = "OFF"
     else:
         targets.extend(["th_common", "bindings", "deep_ep"])
         build_pyt = "ON"
-        build_pybind = "ON"
         build_deep_ep = "ON"
 
     if benchmarks:
@@ -456,7 +488,7 @@ def main(*,
                 )
             cmake_def_args = " ".join(cmake_def_args)
             cmake_configure_command = (
-                f'cmake -DCMAKE_BUILD_TYPE="{build_type}" -DBUILD_PYT="{build_pyt}" -DBUILD_PYBIND="{build_pybind}" -DBUILD_DEEP_EP="{build_deep_ep}"'
+                f'cmake -DCMAKE_BUILD_TYPE="{build_type}" -DBUILD_PYT="{build_pyt}" -DBINDING_TYPE="{binding_type}" -DBUILD_DEEP_EP="{build_deep_ep}"'
                 f' -DNVTX_DISABLE="{disable_nvtx}" -DBUILD_MICRO_BENCHMARKS={build_micro_benchmarks}'
                 f' -DBUILD_WHEEL_TARGETS="{";".join(targets)}"'
                 f' -DPython_EXECUTABLE={venv_python} -DPython3_EXECUTABLE={venv_python}'
@@ -614,25 +646,26 @@ def main(*,
 
     if not cpp_only:
 
-        def get_pybind_lib(subdirectory, name):
-            pybind_build_dir = (build_dir / "tensorrt_llm" / subdirectory)
+        def get_binding_lib(subdirectory, name):
+            binding_build_dir = (build_dir / "tensorrt_llm" / subdirectory)
             if on_windows:
-                pybind_lib = list(pybind_build_dir.glob(f"{name}.*.pyd"))
+                binding_lib = list(binding_build_dir.glob(f"{name}.*.pyd"))
             else:
-                pybind_lib = list(pybind_build_dir.glob(f"{name}.*.so"))
+                binding_lib = list(binding_build_dir.glob(f"{name}.*.so"))
 
             assert len(
-                pybind_lib
-            ) == 1, f"Exactly one pybind library should be present: {pybind_lib}"
-            return pybind_lib[0]
+                binding_lib
+            ) == 1, f"Exactly one binding library should be present: {binding_lib}"
+            return binding_lib[0]
 
-        install_file(get_pybind_lib("pybind", "bindings"), pkg_dir)
+        install_file(get_binding_lib(binding_type, "bindings"), pkg_dir)
 
         with (build_dir / "tensorrt_llm" / "deep_ep" /
               "cuda_architectures.txt").open() as f:
             deep_ep_cuda_architectures = f.read().strip().strip(";")
         if deep_ep_cuda_architectures:
-            install_file(get_pybind_lib("deep_ep", "deep_ep_cpp_tllm"), pkg_dir)
+            install_file(get_binding_lib("deep_ep", "deep_ep_cpp_tllm"),
+                         pkg_dir)
             install_tree(build_dir / "tensorrt_llm" / "deep_ep" / "python" /
                          "deep_ep",
                          deep_ep_dir,
@@ -651,30 +684,38 @@ def main(*,
                 lib_dir / "nvshmem")
         if not skip_stubs:
             with working_directory(project_dir):
-                build_run(f"\"{venv_python}\" -m pip install pybind11-stubgen")
+                if binding_type == "nanobind":
+                    build_run(f"\"{venv_python}\" -m pip install nanobind")
+                else:
+                    build_run(
+                        f"\"{venv_python}\" -m pip install pybind11-stubgen")
             with working_directory(pkg_dir):
                 if on_windows:
-                    stubgen = "stubgen.py"
-                    stubgen_contents = """
-                    # Loading torch, trt before bindings is required to avoid import errors on windows.
-                    # isort: off
-                    import torch
-                    import tensorrt as trt
-                    # isort: on
-                    import os
-                    import platform
+                    if binding_type == "nanobind":
+                        print("Windows not yet supported for nanobind stubs")
+                        exit(1)
+                    else:
+                        stubgen = "stubgen.py"
+                        stubgen_contents = """
+                        # Loading torch, trt before bindings is required to avoid import errors on windows.
+                        # isort: off
+                        import torch
+                        import tensorrt as trt
+                        # isort: on
+                        import os
+                        import platform
 
-                    from pybind11_stubgen import main
+                        from pybind11_stubgen import main
 
-                    if __name__ == "__main__":
-                        # Load dlls from `libs` directory before launching bindings.
-                        if platform.system() == "Windows":
-                            os.add_dll_directory(r\"{lib_dir}\")
-                        main()
-                    """.format(lib_dir=lib_dir)
-                    (pkg_dir / stubgen).write_text(dedent(stubgen_contents))
-                    build_run(f"\"{venv_python}\" {stubgen} -o . bindings")
-                    (pkg_dir / stubgen).unlink()
+                        if __name__ == "__main__":
+                            # Load dlls from `libs` directory before launching bindings.
+                            if platform.system() == "Windows":
+                                os.add_dll_directory(r\"{lib_dir}\")
+                            main()
+                        """.format(lib_dir=lib_dir)
+                        (pkg_dir / stubgen).write_text(dedent(stubgen_contents))
+                        build_run(f"\"{venv_python}\" {stubgen} -o . bindings")
+                        (pkg_dir / stubgen).unlink()
                 else:
                     env_ld = os.environ.copy()
 
@@ -702,14 +743,18 @@ def main(*,
                             exit(1)
 
                     env_ld["LD_LIBRARY_PATH"] = new_library_path
-
-                    build_run(
-                        f"\"{venv_python}\" -m pybind11_stubgen -o . bindings --exit-code",
-                        env=env_ld)
-                    if deep_ep_cuda_architectures:
+                    if binding_type == "nanobind":
                         build_run(
-                            f"\"{venv_python}\" -m pybind11_stubgen -o . deep_ep_cpp_tllm --exit-code",
+                            f"\"{venv_python}\" -m nanobind.stubgen -m bindings -O .",
                             env=env_ld)
+                    else:
+                        build_run(
+                            f"\"{venv_python}\" -m pybind11_stubgen -o . bindings --exit-code",
+                            env=env_ld)
+                        if deep_ep_cuda_architectures:
+                            build_run(
+                                f"\"{venv_python}\" -m pybind11_stubgen -o . deep_ep_cpp_tllm --exit-code",
+                                env=env_ld)
 
     if not skip_building_wheel:
         if dist_dir is None:
@@ -820,6 +865,10 @@ def add_arguments(parser: ArgumentParser):
         "-p",
         action="store_true",
         help="(deprecated) Build the python bindings for the C++ runtime.")
+    parser.add_argument("--binding_type",
+                        choices=["pybind", "nanobind"],
+                        default="pybind",
+                        help="Which binding type to build: pybind, nanobind")
     parser.add_argument("--benchmarks",
                         action="store_true",
                         help="Build the benchmarks for the C++ runtime.")

--- a/setup.py
+++ b/setup.py
@@ -49,9 +49,9 @@ def parse_requirements(filename: os.PathLike):
 
 
 def sanity_check():
-    bindings_path = Path(__file__).resolve().parent / "tensorrt_llm"
-    if not ((bindings_path / "bindings").exists() or
-            (bindings_path / "bindings.pyi").exists()):
+    tensorrt_llm_path = Path(__file__).resolve().parent / "tensorrt_llm"
+    if not ((tensorrt_llm_path / "bindings").exists() or
+            (tensorrt_llm_path / "bindings.pyi").exists()):
         raise ImportError(
             'The `bindings` module does not exist. Please check the package integrity. '
             'If you are attempting to use the pip development mode (editable installation), '

--- a/setup.py
+++ b/setup.py
@@ -49,9 +49,9 @@ def parse_requirements(filename: os.PathLike):
 
 
 def sanity_check():
-    bindings_path = Path(
-        __file__).resolve().parent / "tensorrt_llm" / "bindings"
-    if not bindings_path.exists():
+    bindings_path = Path(__file__).resolve().parent / "tensorrt_llm"
+    if not ((bindings_path / "bindings").exists() or
+            (bindings_path / "bindings.pyi").exists()):
         raise ImportError(
             'The `bindings` module does not exist. Please check the package integrity. '
             'If you are attempting to use the pip development mode (editable installation), '

--- a/tensorrt_llm/builder.py
+++ b/tensorrt_llm/builder.py
@@ -572,7 +572,7 @@ class BuildConfig:
         max_prompt_embedding_table_size = config.pop(
             'max_prompt_embedding_table_size', 0)
 
-        kv_cache_type = KVCacheType(
+        kv_cache_type = KVCacheType.from_string(
             config.pop('kv_cache_type')) if 'plugin_config' in config else None
         gather_context_logits = config.pop('gather_context_logits', False)
         gather_generation_logits = config.pop('gather_generation_logits', False)

--- a/tensorrt_llm/commands/build.py
+++ b/tensorrt_llm/commands/build.py
@@ -41,12 +41,16 @@ from tensorrt_llm.quantization.mode import QuantAlgo
 def enum_type(enum_class):
 
     def parse_enum(value):
-        try:
-            return enum_class[value.upper()]
-        except KeyError:
-            raise argparse.ArgumentTypeError(
-                f"Invalid value '{value}'. Expected one of {[e.name.lower() for e in enum_class]}"
-            )
+        if isinstance(value, enum_class):
+            return value
+
+        if isinstance(value, str):
+            return enum_class.from_string(value)
+
+        valid_values = [e.name for e in enum_class]
+        raise argparse.ArgumentTypeError(
+            f"Invalid value '{value}' of type {type(value).__name__}. Expected one of {valid_values}"
+        )
 
     return parse_enum
 

--- a/tensorrt_llm/commands/build.py
+++ b/tensorrt_llm/commands/build.py
@@ -38,6 +38,19 @@ from tensorrt_llm.plugin import PluginConfig, add_plugin_argument
 from tensorrt_llm.quantization.mode import QuantAlgo
 
 
+def enum_type(enum_class):
+
+    def parse_enum(value):
+        try:
+            return enum_class[value.upper()]
+        except KeyError:
+            raise argparse.ArgumentTypeError(
+                f"Invalid value '{value}'. Expected one of {[e.name.lower() for e in enum_class]}"
+            )
+
+    return parse_enum
+
+
 def parse_arguments():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -56,6 +69,7 @@ def parse_arguments():
         type=str,
         default=None,
         help="The file path that saves TensorRT-LLM build config.")
+
     parser.add_argument(
         '--model_cls_file',
         type=str,
@@ -131,7 +145,7 @@ def parse_arguments():
     parser.add_argument(
         '--kv_cache_type',
         default=argparse.SUPPRESS,
-        type=KVCacheType,
+        type=enum_type(KVCacheType),
         help=
         "Set KV cache type (continuous, paged, or disabled). For disabled case, KV cache is disabled and only context phase is allowed."
     )

--- a/tensorrt_llm/runtime/model_runner.py
+++ b/tensorrt_llm/runtime/model_runner.py
@@ -86,7 +86,7 @@ def _builder_to_model_config(config: dict) -> Tuple[ModelConfig, dict]:
     dtype = builder_config['precision']
     tp_size = builder_config['tensor_parallel']
     pp_size = builder_config.get('pipeline_parallel', 1)
-    kv_cache_type = KVCacheType(builder_config.get('kv_cache_type'))
+    kv_cache_type = KVCacheType.from_string(builder_config.get('kv_cache_type'))
     world_size = tp_size * pp_size
     assert world_size == mpi_world_size(), \
         f'Engine world size ({tp_size} * {pp_size}) != Runtime world size ({mpi_world_size()})'

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -188,3 +188,18 @@ l0_a10:
   tests:
   - stress_test/stress_test.py::test_run_stress_test[llama-v3-8b-instruct-hf_tp1-stress_time_300s_timeout_450s-MAX_UTILIZATION-pytorch-stress-test]
   - stress_test/stress_test.py::test_run_stress_test[llama-v3-8b-instruct-hf_tp1-stress_time_300s_timeout_450s-GUARANTEED_NO_EVICT-pytorch-stress-test]
+l0_nanobind_test:
+- condition:
+    ranges:
+      system_gpu_count:
+        gte: 1
+        lte: 1
+    wildcards:
+      gpu:
+      - '*a10*'
+      linux_distribution_name: ubuntu*
+    terms:
+      stage: pre_merge
+      backend: tensorrt
+  tests:
+  - unittest/bindings

--- a/tests/unittest/bindings/test_bindings_ut.py
+++ b/tests/unittest/bindings/test_bindings_ut.py
@@ -5,6 +5,7 @@ import time
 from pathlib import Path
 
 import numpy as np
+import pytest
 import torch
 from utils.runtime_defaults import assert_runtime_defaults_are_parsed_correctly
 
@@ -309,6 +310,8 @@ def test_gpt_json_config():
                                                  strict_keys=strict_keys)
 
 
+@pytest.mark.skipif(_tb.binding_type == "nanobind",
+                    reason="Test not supported for nanobind yet")
 def test_llm_request():
     beam_width = 2
     sampling_config = _tb.SamplingConfig(beam_width)
@@ -418,6 +421,8 @@ def test_Mpicomm():
     assert size2 == session_size
 
 
+@pytest.mark.skipif(_tb.binding_type == "nanobind",
+                    reason="Test not supported for nanobind yet")
 def test_SamplingConfig_pickle():
     config = _tb.SamplingConfig()
     config.beam_width = 5
@@ -497,6 +502,8 @@ def test_KvCache_events_binding():
     torch.cuda.empty_cache()
 
 
+@pytest.mark.skipif(_tb.binding_type == "nanobind",
+                    reason="Test not supported for nanobind yet")
 def test_ReqIdsSet_pickle():
     ids = _tb.internal.batch_manager.ReqIdsSet()
     ids1 = pickle.loads(pickle.dumps(ids))

--- a/tests/unittest/bindings/test_executor_bindings.py
+++ b/tests/unittest/bindings/test_executor_bindings.py
@@ -14,6 +14,7 @@ import torch
 from binding_test_utils import *
 from pydantic import BaseModel
 
+import tensorrt_llm.bindings as _tb
 import tensorrt_llm.bindings.executor as trtllm
 import tensorrt_llm.version as trtllm_version
 from tensorrt_llm.models.modeling_utils import PretrainedConfig
@@ -484,6 +485,8 @@ def test_get_num_responses_ready(streaming: bool,
     assert executor.get_num_responses_ready() == num_expected_responses
 
 
+@pytest.mark.skipif(_tb.binding_type == "nanobind",
+                    reason="Test not supported for nanobind yet")
 @pytest.mark.parametrize("batching_type", [trtllm.BatchingType.INFLIGHT])
 @pytest.mark.parametrize("streaming", [False, True])
 @pytest.mark.parametrize("beam_width", [1])
@@ -688,6 +691,8 @@ def test_token_comparison(batching_type: trtllm.BatchingType, streaming: bool,
     verify_output(tokens, test_data, given_input_lengths)
 
 
+@pytest.mark.skipif(_tb.binding_type == "nanobind",
+                    reason="Test not supported for nanobind yet")
 @pytest.mark.parametrize("streaming", [False, True])
 @pytest.mark.parametrize("beam_width", [1])
 def test_finish_reason(streaming: bool, beam_width: int, model_files,
@@ -1112,6 +1117,8 @@ def test_spec_dec_fast_logits_info():
     assert fast_logits_info.draft_participant_id == 5
 
 
+@pytest.mark.skipif(_tb.binding_type == "nanobind",
+                    reason="Test not supported for nanobind yet")
 def test_result():
     result = trtllm.Result()
     result.is_final = True
@@ -1149,6 +1156,8 @@ def test_result():
     assert (additional_output.output == torch.ones(1, 4, 100)).all()
 
 
+@pytest.mark.skipif(_tb.binding_type == "nanobind",
+                    reason="Test not supported for nanobind yet")
 def test_result_pickle():
     result = trtllm.Result()
     result.is_final = True
@@ -1495,6 +1504,8 @@ def test_eagle_config():
         assert getattr(config, k) == v
 
 
+@pytest.mark.skipif(_tb.binding_type == "nanobind",
+                    reason="Test not supported for nanobind yet")
 def test_eagle_config_pickle():
     config = trtllm.EagleConfig([[0, 0], [0, 1]], False, 0.5)
     config_copy = pickle.loads(pickle.dumps(config))
@@ -1867,6 +1878,8 @@ def test_logits_post_processor(model_files, model_path):
     assert tokens[-max_tokens:] == [42] * max_tokens
 
 
+@pytest.mark.skipif(_tb.binding_type == "nanobind",
+                    reason="Test not supported for nanobind yet")
 def test_logits_post_processor_batched(model_files, model_path):
 
     # Define the logits post-processor callback
@@ -2141,6 +2154,8 @@ def test_request_perf_metrics_kv_cache(model_path):
     assert kv_cache_metrics.kv_cache_hit_rate == 1.0
 
 
+@pytest.mark.skipif(_tb.binding_type == "nanobind",
+                    reason="Test not supported for nanobind yet")
 @pytest.mark.parametrize("exclude_input_from_output", [False, True])
 def test_request_perf_metrics_draft(model_path_draft_tokens_external,
                                     exclude_input_from_output: bool):
@@ -2221,7 +2236,9 @@ def test_kv_event_stream_timeout(model_path):
     assert len(events) == 1
 
     start = datetime.datetime.now()
-    events = cache_manager.get_latest_events(datetime.timedelta(seconds=1))
+    timeout = datetime.timedelta(
+        seconds=1) if _tb.binding_type == "pybind" else 1000
+    events = cache_manager.get_latest_events(timeout)
     end = datetime.datetime.now()
     # Make sure that it actually waited
     assert abs(end - start) > datetime.timedelta(milliseconds=900)


### PR DESCRIPTION
# PR title

This PR contains:
- Nanobind bindings
- Nanobind build in CI
- Nanobind build tested with unittests in CI

## Description

This migration is not complete and still contains some errors that will be resolved in upcoming PRs.

I also enabled unittests for the nanobind build in the CI. Since the bindings still contain some errors, there are some unittests failing. I am skipping these tests for nanobind until the binding is complete. 

The migration from pybind11 to nanobind is mainly very repetitive. I believe it is therefore easiest to directly compare the difference between the pybind and nanobind version for all files, as they usually follow the same pattern.

I tried to list the main differences between pybind11 and nanobind for our code base.
They are approx. sorted by how often they occur.

- **Simple renamings**

| pybind11                         | nanobind                                         |
|----------------------------------|--------------------------------------------------|
| `PYBIND11_MODULE(..)`            | `NB_MODULE(..)`                                  |
| `PYBIND11_OVERRIDE_*(..)`        | `NB_OVERRIDE_*(..)`                              |
| `reinterpret_borrow<T>(x)`       | `borrow<T>(x)`                                   |
| `reinterpret_steal<T>(x)`        | `steal<T>(x)`                                    |
| `.def_readwrite(..)`             | `.def_rw(..)`                                    |
| `.def_readonly(..)`              | `.def_ro(..)`                                    |
| `.def_property(..)`              | `.def_prop_rw(..)`                               |
| `.def_property_readonly(..)`     | `.def_prop_ro(..)`                               |
| `register_exception<T>`          | `exception<T>`                                   |
|`classh` | `class_`|

- **Type caster headers**

| pybind11 | nanobind |
|---|---|
|Used just one include <pybind11/stl.h>for all type casters | uses specific headers for type casters <nanobind/stl/...>. See documentation [<pybind11/stl.h>](https://nanobind.readthedocs.io/en/latest/exchanging.html#option-1-type-casters) |
| supports type caster for `std::deque` | No support for `std::deque`. Created a custom caster instead and [reached out to owners](https://github.com/wjakob/nanobind/discussions/1102#discussion-8563313) for support of `std:deque`  |

- **Custom constructors**

| pybind11| nanobind|
|---|---|
| Could be specified as a lambda function returning an instance of the desired type: `.def(py::init([](int) { return MyType(...); }));` | Changed to **in-place** construction:  `.def("__init__", [](MyType *t) { new (t) MyType(...); });` See documentation https://nanobind.readthedocs.io/en/latest/porting.html#custom-constructors |


- **Replacements**

| pybind11| nanobind|
|---|---|
| `object.cast<Type>()` | standalone function: `nb::cast<Type>(object)`|
|`py::arg_v("param_name", default_value, "doc_string_description")` | no argument docstring description: `nb::arg("param_name") = default_value` |

Replaced numpy array class `py::array` with `nb::ndarray<>`. See documentation https://nanobind.readthedocs.io/en/latest/ndarray.html#the-nb-ndarray-class
This class does not support nonstandard arithmetic types. I overloaded `nanobind::detail::dtype_traits` to support datatype `half`. See documentation https://nanobind.readthedocs.io/en/latest/ndarray.html#nonstandard-arithmetic-types

- **Trampoline classes**

| pybind11| nanobind|
|---|---|
| `PYBIND11_OVERRIDE_*(..)` with base type and return value arguments| `NB_OVERRIDE_*()` without these arguments. The class also requires one [NB_TRAMPOLINE(parent, size)](https://nanobind.readthedocs.io/en/latest/api_extra.html#c.NB_TRAMPOLINE) declaration.See documentation https://nanobind.readthedocs.io/en/latest/porting.html#trampoline-classes` |

- **Pickling**

| pybind11 | nanobind|
|---|---|
|Use `py::pickle()` to bind `__getstate__` and `__setstate__` functions | expose the `__getstate__` and `__setstate__` methods. Changed `__setstate__` construction to **in-place**. See documentation https://nanobind.readthedocs.io/en/latest/classes.html#pickling |

There is a special case in set state function `executorConfigSetState`. The class `ExecutorConfig` allows to have dynamic attributes (attributes added in Python code). The set state function has to restore the C++ data, as well as the attributes from python. Nanobind then has to be informed inform the instance object is fully constructed via [nb::inst_mark_ready()](https://nanobind.readthedocs.io/en/latest/api_core.html#_CPPv4N8nanobind15inst_mark_readyE6handle)

- **None arguments**
Nanobind refuses conversions from `None` to `nullptr` by default. In order to except `None` in an argument binding: Either call `.none()` of `nb::arg` or specify an `nb::none()` default arguments. See documentation https://nanobind.readthedocs.io/en/latest/functions.html#none-arguments

- **Custom type casters**
See documentation: https://nanobind.readthedocs.io/en/latest/porting.html#type-casters

| pybind11 | nanobind|
|---|---|
|`load()` | `from_python()` with different signature|
|`cast()` | `from_cpp()` with different signature|
| | Created custom caster for `at::Tensor` and `std::deque`|

- **Exceptions**

For the exceptions `- PeftTaskNotCachedException` and `LoraCacheFullException`, I created custom exceptions with `nb::exception<T>`. See documentation: https://nanobind.readthedocs.io/en/latest/exceptions.html#handling-custom-exceptions

## Test Coverage

I am running the same unit tests that we have for pybind in `tests/unittests/bindings`. However, since the migration is incomplete, I am skipping the failing tests for nanobind.

Current state:
**95 passed, 28 skipped**

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
