### PR TITLE
feat: Custom masking utils for Gemma3 VLM

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/interface.py
@@ -501,8 +501,14 @@ class PredefinedAttentionMask(str, Enum):
     FULL = "full"
 
 
-# May extend to custom attention mask type
-AttentionMask = Union[PredefinedAttentionMask]
+class CustomAttentionMask(str, Enum):
+    """
+    Custom attention mask types
+    """
+    CUSTOM = "custom"
+
+
+AttentionMask = Union[PredefinedAttentionMask, CustomAttentionMask]
 
 
 class AttentionBackend(Generic[TMetadata]):

--- a/tensorrt_llm/_torch/models/modeling_gemma3.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma3.py
@@ -10,8 +10,9 @@ from transformers.activations import ACT2FN
 from tensorrt_llm.functional import PositionEmbeddingType, RotaryScalingType
 from tensorrt_llm.mapping import Mapping
 
-from ..attention_backend import AttentionMetadata
-from ..attention_backend.interface import (PositionalEmbeddingParams,
+from ..attention_backend import AttentionMetadata, FlashInferAttentionMetadata
+from ..attention_backend.interface import (AttentionMask, CustomAttentionMask,
+                                           PositionalEmbeddingParams,
                                            PredefinedAttentionMask, RopeParams)
 from ..distributed import AllReduceParams
 from ..model_config import ModelConfig
@@ -101,14 +102,19 @@ class Gemma3Attention(Attention):
         position_ids: Optional[torch.IntTensor],
         hidden_states: torch.Tensor,
         attn_metadata: AttentionMetadata,
-        attention_mask: PredefinedAttentionMask = PredefinedAttentionMask.
-        CAUSAL,
+        attention_mask: AttentionMask = PredefinedAttentionMask.CAUSAL,
         mrope_config: Optional[dict] = None,
         all_reduce_params: Optional[AllReduceParams] = None,
         lora_params: Optional[dict] = None,
+        attention_mask_data: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> torch.Tensor:
 
+        if attention_mask_data is not None:
+            assert isinstance(
+                attn_metadata, FlashInferAttentionMetadata
+            ), "Only FlashInfer backend supports custom attention mask currently."
+            assert attention_mask == CustomAttentionMask.CUSTOM
         return super().forward(position_ids=position_ids,
                                hidden_states=hidden_states,
                                attn_metadata=attn_metadata,
@@ -117,6 +123,7 @@ class Gemma3Attention(Attention):
                                all_reduce_params=all_reduce_params,
                                lora_params=lora_params,
                                attention_window_size=self.attention_window_size,
+                               attention_mask_data=attention_mask_data,
                                **kwargs)
 
     def apply_qk_norm(self, q, k):
@@ -214,6 +221,7 @@ class Gemma3DecoderLayer(DecoderLayer):
         hidden_states: torch.Tensor,
         attn_metadata: AttentionMetadata,
         residual: Optional[torch.Tensor] = None,
+        attention_mask_data: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> torch.Tensor:
 
@@ -223,6 +231,9 @@ class Gemma3DecoderLayer(DecoderLayer):
             position_ids=position_ids,
             hidden_states=hidden_states,
             attn_metadata=attn_metadata,
+            attention_mask=CustomAttentionMask.CUSTOM if attention_mask_data
+            is not None else PredefinedAttentionMask.CAUSAL,
+            attention_mask_data=attention_mask_data,
             **kwargs,
         )
         hidden_states = self.post_attention_layernorm(hidden_states)
@@ -267,6 +278,8 @@ class Gemma3TextModel(DecoderModel):
         input_ids: Optional[torch.IntTensor] = None,
         position_ids: Optional[torch.IntTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
+        local_attention_mask_data: Optional[torch.Tensor] = None,
+        global_attention_mask_data: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> torch.Tensor:
         if (input_ids is None) ^ (inputs_embeds is not None):
@@ -280,9 +293,13 @@ class Gemma3TextModel(DecoderModel):
         hidden_states = inputs_embeds.to(self.dtype)
 
         for decoder_layer in self.layers:
-            hidden_states = decoder_layer(position_ids=position_ids,
-                                          hidden_states=hidden_states,
-                                          attn_metadata=attn_metadata)
+            hidden_states = decoder_layer(
+                position_ids=position_ids,
+                hidden_states=hidden_states,
+                attn_metadata=attn_metadata,
+                attention_mask_data=local_attention_mask_data
+                if decoder_layer.self_attn.is_sliding else
+                global_attention_mask_data)
 
         hidden_states = self.norm(hidden_states)
         return hidden_states
@@ -301,6 +318,99 @@ class Gemma3ForCausalLM(DecoderModelForCausalLM[Gemma3TextModel,
                          hidden_size=model_config.pretrained_config.hidden_size,
                          vocab_size=model_config.pretrained_config.vocab_size)
 
+    def get_context_mask(
+        self,
+        image_token_mask: torch.BoolTensor,
+        effective_sliding_window: Optional[int] = None,
+    ):
+        """
+        Returns an attention mask such that text tokens attend to each other in causal fashion while image
+        tokens attend in causal fashion as well as to all other image tokens in a bidirectional manner.
+        Args:
+            image_token_mask: A boolean tensor of shape (sequence_length,) where True indicates an image token.
+            effective_sliding_window: The effective sliding window size for the attention mask. Default is None, which means no sliding window.
+            For Gemma3, this is the sliding window size from config (e.g. 512 for 1B model).
+        Returns:
+            A boolean attention mask of shape (sequence_length, sequence_length).
+        """
+        device = image_token_mask.device
+        sequence_length = len(image_token_mask)
+        if effective_sliding_window is None or effective_sliding_window >= sequence_length:
+            causal_mask = torch.arange(
+                sequence_length, device=device).unsqueeze(0) <= torch.arange(
+                    sequence_length, device=device).unsqueeze(1)
+        else:
+            attention_mask_1 = (torch.arange(sequence_length,
+                                             device=device).unsqueeze(0)
+                                <= torch.arange(sequence_length,
+                                                device=device).unsqueeze(1))
+            attention_mask_2 = (
+                torch.arange(sequence_length, device=device).unsqueeze(0)
+                > torch.arange(sequence_length, device=device).unsqueeze(1) -
+                effective_sliding_window)
+            causal_mask = attention_mask_1 & attention_mask_2
+
+        # Apply a bidirectional mask for image tokens.
+        token_type_ids = torch.zeros(sequence_length,
+                                     dtype=torch.int32,
+                                     device=device)
+        # 1 for image tokens, 0 for text tokens.
+        token_type_ids[image_token_mask] = 1
+        token_type_mask = token_type_ids.unsqueeze(
+            0) == token_type_ids.unsqueeze(1)
+        # If text token, do not change anything.
+        token_type_mask[token_type_ids == 0] = False
+        causal_mask = causal_mask.masked_fill(token_type_mask, True)
+        return causal_mask
+
+    # ASSUMPTIONS:
+    # 1) Chunked prefill is disabled to avoid chunking image tokens as they need bidirectional attention.
+    # 2) KV cache reuse is disabled to avoid partially matched image tokens (entire image must be reused to get things correct).
+    def get_flashinfer_attention_mask(
+            self,
+            image_token_mask: torch.BoolTensor,
+            attn_metadata: AttentionMetadata,
+            effective_sliding_window: Optional[int] = None) -> torch.Tensor:
+        """
+        This is specifically needed for context phase requests. Currently, we don't create custom mask for generation requests because FlashInfer backend
+        doesn't use it anyway and there's nothing special we need to do for generation requests.
+        - This function will only be called for a batch when there's at least one context request in the batch with image tokens.
+        - In context phase, each sample's input_ids may have a mix of image tokens and text tokens where tokens corresponding to an image
+        appear as a contiguous blob. Example: torch.IntTensor([2, 3, 4, 5, img_idx, img_idx, img_idx, ..., img_idx, 100])
+        - While the text tokens attend to other tokens in a causal fashion, image tokens attend to others in a causal fashion and well as
+        attend to other image tokens in a bidirectional manner. Hence, the need for custom masking.
+        Args:
+            image_token_mask: A boolean tensor of shape (len(input_ids),) where True indicates an image token. This corresponds to concatenated
+            list of tokens for all samples in the batch.
+            attn_metadata: The attention metadata for the batch.
+            effective_sliding_window: The effective sliding window size for the attention mask. Default is None, which means no sliding window.
+            For Gemma3, this is the sliding window size from config (e.g. 512 for 1B model).
+        Returns:
+            A flattened boolean mask of shape (sum(q_len[i] * k_len[i] for i in range(batch_size)).
+        """
+
+        assert isinstance(
+            attn_metadata, FlashInferAttentionMetadata
+        ), "Only FlashInfer backend supports custom mask currently."
+        num_contexts = attn_metadata.num_contexts
+        assert num_contexts > 0, "There should be at least one context request in the batch for custom mask."
+
+        qo_indptr = attn_metadata.qo_indptr[:num_contexts + 1]
+        cached_token_lens = attn_metadata.cached_token_lens[:num_contexts]
+        assert (cached_token_lens == 0).all(
+        ), "cached_token_lens should be 0 for context requests since chunked prefill and kv cache reuse must be disabled."
+
+        # Create masks for context requests.
+        context_mask_list = []
+        for i in range(num_contexts):
+            mask_i = self.get_context_mask(
+                image_token_mask=image_token_mask[qo_indptr[i]:qo_indptr[i +
+                                                                         1]],
+                effective_sliding_window=effective_sliding_window,
+            )
+            context_mask_list.append(mask_i.flatten())
+        return torch.cat(context_mask_list, dim=0).contiguous()
+
     def forward(
         self,
         attn_metadata: AttentionMetadata,
@@ -308,14 +418,31 @@ class Gemma3ForCausalLM(DecoderModelForCausalLM[Gemma3TextModel,
         position_ids: Optional[torch.IntTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         return_context_logits: bool = False,
+        image_token_mask: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> torch.Tensor:
+
+        local_attention_mask_data = None
+        global_attention_mask_data = None
+        if image_token_mask is not None:
+            global_attention_mask_data = self.get_flashinfer_attention_mask(
+                image_token_mask=image_token_mask,
+                attn_metadata=attn_metadata,
+                effective_sliding_window=None,
+            )
+            local_attention_mask_data = self.get_flashinfer_attention_mask(
+                image_token_mask=image_token_mask,
+                attn_metadata=attn_metadata,
+                effective_sliding_window=self.config.sliding_window,
+            )
 
         output = self.model(
             input_ids=input_ids,
             attn_metadata=attn_metadata,
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
+            local_attention_mask_data=local_attention_mask_data,
+            global_attention_mask_data=global_attention_mask_data,
         )
 
         return self.logits_processor.forward(

--- a/tensorrt_llm/_torch/models/modeling_gemma3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma3vl.py
@@ -101,7 +101,7 @@ class Gemma3InputProcessor(InputProcessor):
         input_ids = preprocess_outputs[0]["mm_processor_kwargs"]["input_ids"]
         mm_features = self._process(pixel_values)
         multimodal_data = {}
-        multimodal_data["multimodal_embedding"] = mm_features
+        multimodal_data["multimodal_embedding"] = mm_features.squeeze(dim=0)
         return input_ids[0].to(torch.int32).tolist(), {
             "multimodal_data": multimodal_data
         }
@@ -129,6 +129,7 @@ class Gemma3Model(PreTrainedModel):
 
         self.model_config = model_config
         self.vocab_size = config.text_config.vocab_size
+        self.sliding_window = config.text_config.sliding_window
         self.model_dtype = getattr(config.text_config, "torch_dtype",
                                    torch.float16)
         logger.info(f"[Gemma3Model::__init__]{self.dtype=} {self.model_dtype=}")
@@ -172,12 +173,24 @@ class Gemma3Model(PreTrainedModel):
             mm_embed
         ) == num_context_requests, "Number of multimodal features (if provided) should be equal to number of context requests"
 
+        mm_token_ids = torch.tensor([self.image_token_index
+                                     ]).to(input_ids.device)
+        mm_token_mask = None
+        if len(mm_embed) > 0:
+            # Get token type ids. 0 corresponds to text tokens, 1 corresponds to image tokens.
+            mm_token_mask = torch.isin(input_ids, mm_token_ids)
         input_ids, inputs_embeds = fuse_input_embeds(
             embedding_layer=self.llm.model.embed_tokens,
             input_ids=input_ids,
             mm_embeds=mm_embed,
             mm_token_ids=torch.tensor([self.image_token_index
                                        ]).to(input_ids.device))
-        logits = self.llm.forward(attn_metadata, input_ids, position_ids,
-                                  inputs_embeds, return_context_logits)
+        logits = self.llm.forward(
+            attn_metadata=attn_metadata,
+            input_ids=input_ids,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+            return_context_logits=return_context_logits,
+            image_token_mask=mm_token_mask,
+        )
         return logits

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -11,7 +11,8 @@ from tensorrt_llm.mapping import Mapping
 
 from ..attention_backend import (AttentionInputType, AttentionMetadata,
                                  TrtllmAttention, TrtllmAttentionMetadata)
-from ..attention_backend.interface import (PositionalEmbeddingParams,
+from ..attention_backend.interface import (AttentionMask,
+                                           PositionalEmbeddingParams,
                                            PredefinedAttentionMask)
 from ..attention_backend.utils import create_attention, get_attention_backend
 from ..distributed import AllReduceParams
@@ -226,12 +227,12 @@ class Attention(nn.Module):
         position_ids: Optional[torch.IntTensor],
         hidden_states: Union[torch.Tensor, Fp4QuantizedTensor],
         attn_metadata: AttentionMetadata,
-        attention_mask: PredefinedAttentionMask = PredefinedAttentionMask.
-        CAUSAL,
+        attention_mask: AttentionMask = PredefinedAttentionMask.CAUSAL,
         mrope_config: Optional[dict] = None,
         all_reduce_params: Optional[AllReduceParams] = None,
         lora_params: Optional[dict] = None,
         attention_window_size: Optional[int] = None,
+        attention_mask_data: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> torch.Tensor:
         """
@@ -241,12 +242,12 @@ class Attention(nn.Module):
             position_ids (Optional[torch.IntTensor]): The position IDs.
             hidden_states (torch.Tensor): The hidden states.
             attn_metadata (AttentionMetadata): The attention metadata.
-            attention_mask (PredefinedAttentionMask): The attention mask type.
+            attention_mask (AttentionMask): The attention mask type.
             mrope_config (Optional[dict]): The MROPE configuration.
             all_reduce_params (Optional[AllReduceParams]): The all reduce parameters.
             lora_params (Optional[dict]): The LoRA parameters.
             attention_window_size (Optional[int]): The attention window size.
-
+            attention_mask_data (Optional[torch.Tensor]): The attention mask data.
         Returns:
             torch.Tensor: The output tensor.
         """
@@ -284,7 +285,8 @@ class Attention(nn.Module):
             out_scale_sf=out_scale_sf,
             attention_mask=attention_mask,
             mrope_config=mrope_config,
-            attention_window_size=attention_window_size)
+            attention_window_size=attention_window_size,
+            attention_mask_data=attention_mask_data)
         hidden_states = attn_output
         attn_output = self.o_proj(attn_output,
                                   all_reduce_params=all_reduce_params,

--- a/tests/unittest/_torch/modeling/test_modeling_gemma3.py
+++ b/tests/unittest/_torch/modeling/test_modeling_gemma3.py
@@ -9,6 +9,7 @@ from transformers import Gemma3ForCausalLM as HFGemma3ForCausalLM
 from transformers.cache_utils import HybridCache
 
 import tensorrt_llm
+from tensorrt_llm._torch.attention_backend import FlashInferAttentionMetadata
 from tensorrt_llm._torch.attention_backend.utils import get_attention_backend
 from tensorrt_llm._torch.metadata import KVCacheParams
 from tensorrt_llm._torch.model_config import ModelConfig
@@ -132,8 +133,8 @@ class TestGemma3(unittest.TestCase):
 
     def test_gemma3_sanity(self):
 
-        config_dict = deepcopy(
-            GEMMA3_1B_CONFIG)  # Using 1B config for sanity test.
+        # Using 1B config for sanity test.
+        config_dict = deepcopy(GEMMA3_1B_CONFIG)
         gemma3_config = Gemma3Config.from_dict(config_dict)
 
         dtype = gemma3_config.torch_dtype
@@ -303,16 +304,26 @@ class TestGemma3(unittest.TestCase):
         position_ids = [torch.arange(0, input_ids.size(-1), dtype=torch.int32)]
         position_ids = torch.cat(position_ids).unsqueeze(0).cuda()
 
+        # This helps us better test the custom masking utils for Gemma3 VLM as well
+        # as SWA plumbing for FlashInfer. All tokens being text tokens should yield
+        # same results as using global or local attention for appropriate layers.
+        if backend == "FLASHINFER":
+            image_token_mask = torch.tensor(
+                [False, False, False, False, False, False, False, False],
+                device=device)
+        else:
+            image_token_mask = None
+
         with torch.inference_mode():
             attn_metadata.prepare()
             logits = gemma3.forward(input_ids=input_ids,
                                     position_ids=position_ids,
-                                    attn_metadata=attn_metadata)
+                                    attn_metadata=attn_metadata,
+                                    image_token_mask=image_token_mask)
             ref = hf_gemma3.forward(input_ids=input_ids.unsqueeze(0),
                                     position_ids=position_ids,
                                     past_key_values=hf_cache,
                                     use_cache=True)
-
             torch.testing.assert_close(logits,
                                        ref.logits[:, -1].float(),
                                        atol=0.05,
@@ -358,3 +369,142 @@ class TestGemma3(unittest.TestCase):
                                        rtol=0.05)
 
         kv_cache_manager.shutdown()
+
+    def test_gemma3_flashinfer_mask(self):
+        config_dict = deepcopy(GEMMA3_1B_CONFIG)
+        gemma3_config = Gemma3Config.from_dict(config_dict)
+
+        dtype = gemma3_config.torch_dtype
+        device = torch.device('cuda')
+
+        model_config = ModelConfig(pretrained_config=gemma3_config,
+                                   attn_backend="FLASHINFER")
+        gemma3 = Gemma3ForCausalLM(model_config).to(device)
+
+        input_ids = torch.tensor([100, 200, 300, 400, 500, 600, 700, 800],
+                                 dtype=torch.int,
+                                 device=device)
+
+        context_sequence_lengths = [3, 2, 1]
+        sequence_lengths = context_sequence_lengths + [1, 1]
+        past_seen_tokens = [0, 0, 0, 2, 1]
+        request_ids = list(range(len(sequence_lengths)))
+        token_nums = (torch.tensor(past_seen_tokens) +
+                      torch.tensor(sequence_lengths)).tolist()
+        prompt_lens = token_nums[:3] + past_seen_tokens[3:]
+
+        num_blocks = 100
+        tokens_per_block = 128
+        max_seq_len = num_blocks * tokens_per_block
+        batch_size = len(context_sequence_lengths) + 2
+        kv_cache_manager = self.get_kv_cache_manager(
+            dtype=dtype,
+            config=gemma3_config,
+            tokens_per_block=tokens_per_block,
+            max_seq_len=max_seq_len,
+            batch_size=batch_size,
+            num_blocks=num_blocks)
+        kv_cache_manager.add_dummy_requests(request_ids, token_nums)
+
+        metadata_cls = get_attention_backend(model_config.attn_backend).Metadata
+        assert metadata_cls == FlashInferAttentionMetadata
+        attn_metadata = metadata_cls(
+            seq_lens=torch.tensor(sequence_lengths, dtype=torch.int),
+            num_contexts=len(context_sequence_lengths),
+            kv_cache_params=KVCacheParams(
+                use_cache=True,
+                num_cached_tokens_per_seq=past_seen_tokens,
+            ),
+            kv_cache_manager=kv_cache_manager,
+            request_ids=request_ids,
+            prompt_lens=prompt_lens,
+            max_num_requests=len(context_sequence_lengths) + 2,
+            max_num_tokens=8192,
+        )
+        attn_metadata.prepare()
+
+        # Test for case where all tokens are text tokens. `test_gemma3_global_mask` and `test_gemma3_local_mask`
+        # test for individual requests where there's a mix of text and image tokens.
+        image_token_mask = torch.tensor(
+            [False, False, False, False, False, False, False, False],
+            device=device)
+        causal_mask = gemma3.get_flashinfer_attention_mask(
+            image_token_mask=image_token_mask, attn_metadata=attn_metadata)
+        # Causal mask for context request 1.
+        ctx_request_1_mask = torch.tensor(
+            [[True, False, False], [True, True, False], [True, True, True]],
+            device=device)
+        # Causal mask for context request 2.
+        ctx_request_2_mask = torch.tensor([[True, False], [True, True]],
+                                          device=device)
+        # Causal mask for context request 3.
+        ctx_request_3_mask = torch.tensor([[True]], device=device)
+
+        expected_causal_mask = torch.cat([
+            ctx_request_1_mask.flatten(),
+            ctx_request_2_mask.flatten(),
+            ctx_request_3_mask.flatten(),
+        ],
+                                         dim=0)
+        torch.testing.assert_close(causal_mask, expected_causal_mask)
+
+    def test_gemma3_global_context_mask(self) -> None:
+        config_dict = deepcopy(GEMMA3_1B_CONFIG)
+        gemma3_config = Gemma3Config.from_dict(config_dict)
+        device = torch.device('cuda')
+        model_config = ModelConfig(pretrained_config=gemma3_config,
+                                   attn_backend="FLASHINFER")
+        gemma3 = Gemma3ForCausalLM(model_config).to(device)
+
+        image_token_mask = torch.tensor(
+            [False, False, True, True, True, True, False, False], device=device)
+        attention_mask = gemma3.get_context_mask(
+            image_token_mask=image_token_mask, effective_sliding_window=None)
+
+        # Text tokens attend to each other in causal fashion. Image tokens attend in causal fashion
+        # as well as to all other image tokens.
+        expected_attention_mask = torch.tensor(
+            [[True, False, False, False, False, False, False, False],
+             [True, True, False, False, False, False, False, False],
+             [True, True, True, True, True, True, False, False],
+             [True, True, True, True, True, True, False, False],
+             [True, True, True, True, True, True, False, False],
+             [True, True, True, True, True, True, False, False],
+             [True, True, True, True, True, True, True, False],
+             [True, True, True, True, True, True, True, True]],
+            device=device)
+        torch.testing.assert_close(attention_mask, expected_attention_mask)
+
+        # Even for a sliding window larger than sequence length, the attention mask is the same as the global mask.
+        attention_mask = gemma3.get_context_mask(
+            image_token_mask=image_token_mask, effective_sliding_window=10)
+        torch.testing.assert_close(attention_mask, expected_attention_mask)
+
+        # Even for sliding window same as sequence length, the attention mask is the same as the global mask.
+        attention_mask = gemma3.get_context_mask(
+            image_token_mask=image_token_mask, effective_sliding_window=8)
+        torch.testing.assert_close(attention_mask, expected_attention_mask)
+
+    def test_gemma3_local_context_mask(self) -> None:
+        config_dict = deepcopy(GEMMA3_1B_CONFIG)
+        gemma3_config = Gemma3Config.from_dict(config_dict)
+        device = torch.device('cuda')
+        model_config = ModelConfig(pretrained_config=gemma3_config,
+                                   attn_backend="FLASHINFER")
+        gemma3 = Gemma3ForCausalLM(model_config).to(device)
+
+        image_token_mask = torch.tensor(
+            [False, False, True, True, True, True, False, False], device=device)
+        attention_mask = gemma3.get_context_mask(
+            image_token_mask=image_token_mask, effective_sliding_window=2)
+        expected_attention_mask = torch.tensor(
+            [[True, False, False, False, False, False, False, False],
+             [True, True, False, False, False, False, False, False],
+             [False, True, True, True, True, True, False, False],
+             [False, False, True, True, True, True, False, False],
+             [False, False, True, True, True, True, False, False],
+             [False, False, True, True, True, True, False, False],
+             [False, False, False, False, False, True, True, False],
+             [False, False, False, False, False, False, True, True]],
+            device=device)
+        torch.testing.assert_close(attention_mask, expected_attention_mask)


### PR DESCRIPTION
## Description
This MR:
- Adds masking utilities needed for context phase requests with image tokens in Gemma3 VLMs.
- Also, enables `custom_mask` usage in FlashInfer backend.

Background about custom mask:
- The function `get_flashinfer_attention_mask` will only be called for a batch when there's at least one context request in the batch with image tokens.
- In context phase, each sample's `input_ids` may have a mix of `image` ([image_token_idx](https://huggingface.co/google/gemma-3-4b-it/blob/main/config.json#L11)) and `text` tokens where tokens corresponding to an image appear as a contiguous blob.
Example: torch.IntTensor([2, 3, 4, 5, img_idx, img_idx, img_idx, ..., img_idx, 100])
- While the text tokens attend to other tokens in a causal fashion, image tokens attend to others in a causal fashion and well as attend to other image tokens in a bidirectional manner. Hence, the need for custom masking.

This MR has a nice visualization of the attention mask for global attention and sliding window attention:
https://github.com/huggingface/transformers/pull/38295

Request for reviewers:
I'd appreciate your comments on the two strong assumptions of disabling chunked prefill and KV Cache reuse to get the bidirectional masking right. My thoughts:
- Chunked prefill must be disabled (unless chunk_size=max_input_len, which doesn't make sense) because image tokens can appear anywhere in the `input_ids` and bidirectionality will be lost if chunking breaks an image input blob into separate chunks.
- KV cache reuse is disabled to avoid partially matched image tokens. Either all tokens of an image must be reused or none at all.

```
$ python3 examples/pytorch/quickstart_multimodal.py --model_dir ../random/hf_models/gemma-3-27b-it/ --modality image --image_format pil --attention_backend FLASHINFER --disable_kv_cache_reuse
```

## Test Coverage
Following tests validate masking utils.
```
$ pytest tests/unittest/_torch/modeling/test_modeling_gemma3.py::TestGemma3::test_gemma3_local_context_mask -s -v
$ pytest tests/unittest/_torch/modeling/test_modeling_gemma3.py::TestGemma3::test_gemma3_global_context_mask -s -v
$ pytest tests/unittest/_torch/modeling/test_modeling_gemma3.py::TestGemma3::test_gemma3_flashinfer_mask -s -v
```

Following tests validate masking utils as well as custom mask usage by FlashInfer backend.
```
$ pytest tests/unittest/_torch/modeling/test_modeling_gemma3.py::TestGemma3::test_gemma3_allclose_to_hf[backend:flashinfer_config:1b] -s -v
$ pytest tests/unittest/_torch/modeling/test_modeling_gemma3.py::TestGemma3::test_gemma3_allclose_to_hf[backend:flashinfer_config:27b] -s -v
```

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
