### PR TITLE
cherry-pick: [fix: nvbugs/5355493] Correctly clamp max sequence len to max attention window

### DIFF
--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -559,7 +559,7 @@ TrtGptModelInflightBatching::clampWindowSizesToFitAtLeastOneSequence(BlocksPerWi
     TLLM_LOG_WARNING("maxAttentionWindowVec too large to fit at least one sequence in kvCache. Old: %s, New: %s",
         common::vec2str(getMaxAttentionWindowVec()).c_str(), common::vec2str(newMaxAttentionWindowVec).c_str());
     setMaxAttentionWindowVec(newMaxAttentionWindowVec);
-    if (getMaxSequenceLen() < getMaxAttentionWindow())
+    if (getMaxSequenceLen() > getMaxAttentionWindow())
     {
         TLLM_LOG_WARNING("maxSequenceLen is reduced to maxAttentionWindow: %d", getMaxAttentionWindow());
         setMaxSequenceLen(getMaxAttentionWindow());

--- a/cpp/tests/batch_manager/trtGptModelTest.cpp
+++ b/cpp/tests/batch_manager/trtGptModelTest.cpp
@@ -1211,19 +1211,16 @@ TEST_F(TrtGptModelTest, ClampSeqLenToAttentionWindow)
     auto constexpr maxAttentionWindow = 65536;
     auto constexpr maxSequenceLen = maxAttentionWindow + 1;
 
-    executor::KvCacheConfig kvCacheConfig;
-    kvCacheConfig.setMaxAttentionWindowVec(std::vector<SizeType32>{maxAttentionWindow});
-    kvCacheConfig.setFreeGpuMemoryFraction(0.0001); // minuscule amount of memory to force a clamp
-
-    executor::ExecutorConfig executorConfig;
-    executorConfig.setKvCacheConfig(kvCacheConfig);
-    executorConfig.setMaxBeamWidth(mBeamWidth);
+    TrtGptModelOptionalParams optionalParams;
+    optionalParams.kvCacheConfig.maxAttentionWindowVec = std::vector<SizeType32>{maxAttentionWindow};
+    optionalParams.kvCacheConfig.freeGpuMemoryFraction = 0.0001; // minuscule amount of memory to force a clamp
+    optionalParams.maxBeamWidth = mBeamWidth;
 
     auto modelConfig = mModelConfig;
     modelConfig.setMaxSequenceLen(maxSequenceLen);
 
-    auto trtGptModel = std::make_shared<TrtGptModelIfbHelper>(
-        mLogger, modelConfig, mWorldConfig, *mRawEngine, true, executorConfig, false);
+    auto trtGptModel
+        = std::make_shared<TrtGptModelIfbHelper>(mLogger, modelConfig, mWorldConfig, *mRawEngine, true, optionalParams);
     EXPECT_LT(trtGptModel->getMaxAttentionWindow(), maxAttentionWindow);
     EXPECT_EQ(trtGptModel->getMaxSequenceLen(), trtGptModel->getMaxAttentionWindow());
 }


### PR DESCRIPTION
Cherry-picked https://github.com/NVIDIA/TensorRT-LLM/pull/5720 from main.