### PR TITLE
[Model load] Fix llama min-latency model load

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_llama.py
+++ b/tensorrt_llm/_torch/models/modeling_llama.py
@@ -624,6 +624,7 @@ class Llama4Model(DecoderModel):
         self.num_hidden_layers = config.num_hidden_layers
         self.aux_stream = torch.cuda.Stream()
         self.mapping = model_config.mapping
+        self.serial_load_weights = []
 
         if self.model_config.mapping.enable_attention_dp:
             self.embed_tokens = Embedding(
@@ -646,6 +647,7 @@ class Llama4Model(DecoderModel):
         if model_config.enable_min_latency:
             from .modeling_llama_min_latency import Llama4MinLatencyDecoderLayer
             DecoderLayerClass = Llama4MinLatencyDecoderLayer
+            self.serial_load_weights = ["gate_up_proj"]
 
         self.layers = nn.ModuleList([
             DecoderLayerClass(
@@ -878,6 +880,7 @@ class Llama4ForConditionalGeneration(SpecDecOneEngineForCausalLM[Llama4Model,
         model_config.pretrained_config = model_config.pretrained_config.text_config
         model_config.pretrained_config.architectures = architectures
         super().__init__(Llama4Model(model_config), model_config)
+        self.serial_load_weights = self.model.serial_load_weights
 
     def forward(
         self,

--- a/tensorrt_llm/_torch/models/modeling_llama.py
+++ b/tensorrt_llm/_torch/models/modeling_llama.py
@@ -624,7 +624,7 @@ class Llama4Model(DecoderModel):
         self.num_hidden_layers = config.num_hidden_layers
         self.aux_stream = torch.cuda.Stream()
         self.mapping = model_config.mapping
-        self.serial_load_weights = []
+        self.preload_weight_modules = []
 
         if self.model_config.mapping.enable_attention_dp:
             self.embed_tokens = Embedding(
@@ -647,7 +647,7 @@ class Llama4Model(DecoderModel):
         if model_config.enable_min_latency:
             from .modeling_llama_min_latency import Llama4MinLatencyDecoderLayer
             DecoderLayerClass = Llama4MinLatencyDecoderLayer
-            self.serial_load_weights = ["gate_up_proj"]
+            self.preload_weight_modules = ["gate_up_proj"]
 
         self.layers = nn.ModuleList([
             DecoderLayerClass(
@@ -880,7 +880,7 @@ class Llama4ForConditionalGeneration(SpecDecOneEngineForCausalLM[Llama4Model,
         model_config.pretrained_config = model_config.pretrained_config.text_config
         model_config.pretrained_config.architectures = architectures
         super().__init__(Llama4Model(model_config), model_config)
-        self.serial_load_weights = self.model.serial_load_weights
+        self.preload_weight_modules = self.model.preload_weight_modules
 
     def forward(
         self,

--- a/tensorrt_llm/_torch/models/modeling_llama_min_latency.py
+++ b/tensorrt_llm/_torch/models/modeling_llama_min_latency.py
@@ -98,6 +98,9 @@ class Llama4MinLatencyLinear(Linear):
         # After loading weights, calculate the combined scale (input_scale * weight_scale) for special kernels and
         # trtllm-gen kernels.
         if self.has_fp8_qdq:
+            if self.weight_scale.device != self.input_scale.device:
+                self.weight_scale = torch.nn.Parameter(
+                    self.weight_scale.to(self.input_scale.device))
             self.combined_scale = self.input_scale * self.weight_scale
 
             # If this is gate_up_proj + swiglu and trtllm-gen kernels will be used, we need to reorder the weights

--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -525,11 +525,11 @@ class DecoderModelForCausalLM(nn.Module,
         )
 
     def load_weights(self, weights: Dict, skip_modules: List[str] = []):
-        serial_load_weights = getattr(self, "serial_load_weights", None)
+        preload_weight_modules = getattr(self, "preload_weight_modules", None)
         _load_weights_impl(self,
                            weights,
                            skip_modules,
-                           serial_load_weights=serial_load_weights)
+                           preload_weight_modules=preload_weight_modules)
 
     def infer_max_seq_len(self) -> int:
         # Modified from tensorrt_llm/builder.py _init_max_seq_len
@@ -680,7 +680,7 @@ def _load_weights_impl(model: Union[nn.Module, DecoderModelForCausalLM],
                        weights: Dict,
                        skip_modules: List[str] = [],
                        params_map: Optional[Dict[str, str]] = None,
-                       serial_load_weights: Optional[List[str]] = None):
+                       preload_weight_modules: Optional[List[str]] = None):
     if not hasattr(model, 'model_config') or not isinstance(
             model.model_config, ModelConfig):
         raise ValueError("model must have a model_config attribute")
@@ -762,9 +762,9 @@ def _load_weights_impl(model: Union[nn.Module, DecoderModelForCausalLM],
             load_single_module(name, module)
     else:
         all_modules = dict(model.named_modules())
-        if serial_load_weights is not None:
-            serial_load_modules = []
-            for module in serial_load_weights:
+        serial_load_modules = []
+        if preload_weight_modules is not None:
+            for module in preload_weight_modules:
                 serial_load_modules.extend([
                     name for name in all_modules.keys() if name.endswith(module)
                 ])

--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -681,6 +681,8 @@ def _load_weights_impl(model: Union[nn.Module, DecoderModelForCausalLM],
                        skip_modules: List[str] = [],
                        params_map: Optional[Dict[str, str]] = None,
                        preload_weight_modules: Optional[List[str]] = None):
+    # TODO: remove preload_weight_modules - it is a workaround for min-latency llama4 model loading where
+    # we need some order in the module loading. Once this is resolved, we can remove this workaround.
     if not hasattr(model, 'model_config') or not isinstance(
             model.model_config, ModelConfig):
         raise ValueError("model must have a model_config attribute")


### PR DESCRIPTION
[Model load] Fix llama min-latency model load

## Description

Loading llama4 with min latency flag (`enable_min_latency: true` ) requires the model to be loaded in a certain order. Specifically, the `gate_up_proj` has to be loaded before other modules. This PR enables support for specifying a list of modules that should be loaded in serial before concurrently loading all the remaining modules. 

Tested manually via 
```
trtllm-serve nvidia/Llama-4-Maverick-17B-128E-Instruct-FP8 --host 0.0.0.0 --port 8000 --backend pytorch --tp_size 8 --ep_size 1 --trust_remote_code --extra_llm_api_options c.yaml --kv_cache_free_gpu_memory_fraction 0.75
```

with `c.yaml`:
```
enable_attention_dp: false
enable_min_latency: true
cuda_graph_config:
  max_batch_size: 256
  padding_enabled: true
```