### PR TITLE
Waive unittest failures introduced by PR#5345 (removal of `ScaffoldingOutput` class)

### DIFF
--- a/tests/unittest/scaffolding/test_parallel_process.py
+++ b/tests/unittest/scaffolding/test_parallel_process.py
@@ -4,9 +4,10 @@ import time
 from enum import Enum
 from typing import List
 
+import pytest
+
 from tensorrt_llm.scaffolding import (Controller, ParallelProcess,
-                                      ScaffoldingLlm, ScaffoldingOutput, Task,
-                                      TaskStatus, Worker)
+                                      ScaffoldingLlm, Task, TaskStatus, Worker)
 
 
 class DummyTask(Task):
@@ -20,9 +21,11 @@ class DummyTask(Task):
         task = DummyTask(2)
         return task
 
-    def create_scaffolding_output(self) -> "ScaffoldingOutput":
+    # TODO: Fix when ScaffoldingOutput is replaced with GenerationResult
+    # def create_scaffolding_output(self) -> "ScaffoldingOutput":
+    def create_scaffolding_output(self):
         self.verify()
-        return ScaffoldingOutput()
+        return None
 
     def verify(self):
         for i in range(len(self.numbers)):
@@ -31,7 +34,9 @@ class DummyTask(Task):
 
 class DummyControllerBase(Controller):
 
-    def generate(self, prompt: str, **kwargs) -> ScaffoldingOutput:
+    # TODO: Fix when ScaffoldingOutput is replaced with GenerationResult
+    # def generate(self, prompt: str, **kwargs) -> ScaffoldingOutput:
+    def generate(self, prompt: str, **kwargs):
         task = DummyTask.create_from_prompt(prompt)
         yield from self.process([task], **kwargs)
         return task.create_scaffolding_output()
@@ -58,7 +63,8 @@ class DummyController(DummyControllerBase):
 
 
 # The flag to enable parallel process
-# We can use this flag to compare the performance of parallel process and sequence process
+# We can use this flag to compare the performance of parallel process
+# and sequence process
 ENABLE_PARALLEL_PROCESS = True
 
 
@@ -119,6 +125,7 @@ def parallel_process_helper_run_and_verify(controllers):
     llm.shutdown()
 
 
+@pytest.skip(reason="ScaffoldingOutput removed in PR #5345, needs refactoring")
 def test_parallel_process_helper():
     NUM_CONTROLLERS = 3
     controllers = []
@@ -130,6 +137,7 @@ def test_parallel_process_helper():
     parallel_process_helper_run_and_verify(controllers)
 
 
+@pytest.skip(reason="ScaffoldingOutput removed in PR #5345, needs refactoring")
 def test_parallel_process_helper_with_two_level():
     NUM_CONTROLLERS_LEVEL_1 = 2
     NUM_CONTROLLERS_LEVEL_2 = 2

--- a/tests/unittest/scaffolding/test_task_collection.py
+++ b/tests/unittest/scaffolding/test_task_collection.py
@@ -2,10 +2,11 @@ import copy
 from enum import Enum
 from typing import List
 
+import pytest
+
 from tensorrt_llm.scaffolding import (Controller, ParallelProcess,
-                                      ScaffoldingLlm, ScaffoldingOutput, Task,
-                                      TaskCollection, TaskStatus, Worker,
-                                      with_task_collection)
+                                      ScaffoldingLlm, Task, TaskCollection,
+                                      TaskStatus, Worker, with_task_collection)
 
 
 class DummyTask(Task):
@@ -19,8 +20,10 @@ class DummyTask(Task):
         task = DummyTask()
         return task
 
-    def create_scaffolding_output(self) -> "ScaffoldingOutput":
-        return ScaffoldingOutput()
+    # TODO: Fix when ScaffoldingOutput is replaced with GenerationResult
+    # def create_scaffolding_output(self) -> "ScaffoldingOutput":
+    def create_scaffolding_output(self):
+        return None
 
     def verify(self):
         assert self.before_flag, "task.before_flag has not been set to True"
@@ -52,14 +55,17 @@ class DummyControllerBase(Controller):
         super().__init__()
         self.expected_task_count = expected_task_count
 
-    def generate(self, prompt: str, **kwargs) -> ScaffoldingOutput:
+    # TODO: Fix when ScaffoldingOutput is replaced with GenerationResult
+    # def generate(self, prompt: str, **kwargs) -> ScaffoldingOutput:
+    def generate(self, prompt: str, **kwargs):
         task = DummyTask.create_from_prompt(prompt)
         yield from self.process([task], **kwargs)
         return task.create_scaffolding_output()
 
     def verify(self):
         assert self.task_collections[
-            "dummy"].task_count == self.expected_task_count, "task count is not as expected"
+            "dummy"].task_count == self.expected_task_count, (
+                "task count is not as expected")
 
 
 @with_task_collection("dummy", DummyTaskCollection)
@@ -121,6 +127,7 @@ def run(controller, expected_task_count):
     llm.shutdown()
 
 
+@pytest.skip(reason="ScaffoldingOutput removed in PR #5345, needs refactoring")
 def test_dummy_task_collection():
     controller = DummyController(1)
     run(controller, 1)


### PR DESCRIPTION
#5345 introduced changes not accounting for unintentional unittest breakages. Worse, this was not exposed as it was merged without running L0. 

This waives those breaking tests.