### PR TITLE
[refactor] Move vision parts from processor to model for Gemma3

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_gemma3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma3vl.py
@@ -1,18 +1,15 @@
 import copy
-import os
 from typing import List, Optional, Tuple
 
 import torch
-import torch.nn as nn
-from transformers import (AutoConfig, AutoModel, AutoProcessor, Gemma3Config,
+from transformers import (AutoModel, AutoProcessor, Gemma3Config,
                           PretrainedConfig, PreTrainedModel)
-from transformers.modeling_utils import load_sharded_checkpoint
+from transformers.modeling_utils import no_init_weights
 from transformers.models.gemma3.modeling_gemma3 import Gemma3MultiModalProjector
 
 from ..._utils import nvtx_range
 from ...inputs import (ExtraProcessedInputs, InputProcessor, TextPrompt,
                        register_input_processor)
-from ...llmapi.utils import download_hf_model
 from ...logger import logger
 from ...sampling_params import SamplingParams
 from ..attention_backend import AttentionMetadata
@@ -32,79 +29,50 @@ class Gemma3InputProcessor(InputProcessor):
         self.model_config = model_config
         self.device = 'cuda'
 
-        # Determine the actual local path for model files
-        if os.path.isdir(model_path):
-            local_model_path = model_path
-        else:
-            local_model_path = download_hf_model(model_path)
-
-        # Partially load the model to reduce memory usage(Vision tower and multi-modal projector)
-        hf_model_config = AutoConfig.from_pretrained(local_model_path)
-        self.dtype = hf_model_config.text_config.torch_dtype
-        module_dict = nn.ModuleDict({
-            "vision_tower":
-            AutoModel.from_config(hf_model_config.vision_config),
-            "multi_modal_projector":
-            Gemma3MultiModalProjector(hf_model_config)
-        })
-        missing_keys, _ = load_sharded_checkpoint(module_dict,
-                                                  local_model_path,
-                                                  strict=False)
-        assert len(missing_keys) == 0, f"Missing keys: {missing_keys}"
-        hf_vision_tower = module_dict["vision_tower"].to(self.dtype).to(
-            self.device)
-        hf_mm_projector = module_dict["multi_modal_projector"].to(
-            self.dtype).to(self.device)
-
-        # Use HF vision tower. To be replaced with TRTLLM vision tower.
-        self.vision_tower = hf_vision_tower
-
-        # Use HF multi-modal projector
-        self.mm_projector = hf_mm_projector
-
     @nvtx_range("[Vision] preprocess")
     def _preprocess(self, inputs):
         text_prompt, mm_data = inputs.get("prompt"), inputs.get(
             "multi_modal_data", {})
-        assert 'image' in mm_data
-        processor_output = self.processor(text=text_prompt,
-                                          images=mm_data["image"][0],
-                                          return_dict=True,
-                                          return_tensors="pt",
-                                          device=self.device).to(
-                                              'cuda', dtype=torch.bfloat16)
-        result_dict = {}
-        result_dict["prompt"] = inputs["prompt"]
-        result_dict["multimodal_data"] = {
-            "image": [processor_output["pixel_values"]]
-        }
-        result_dict["mm_processor_kwargs"] = {}
-        for key in ["input_ids", "token_type_ids", "pixel_values"]:
-            result_dict["mm_processor_kwargs"][key] = processor_output[key]
+        if mm_data and "image" not in mm_data:
+            raise KeyError("Expected image data in multimodal data for Gemma3.")
 
-        return [result_dict]
+        images = mm_data.get("image")
+        if images and len(images) != 1:
+            raise ValueError(
+                f"Expected at most one image for processing, got {len(images)}."
+            )
 
-    @nvtx_range("[Vision] process")
-    def _process(self, pixel_values):
-        image_features: Tuple[torch.Tensor] = self.vision_tower(
-            pixel_values).last_hidden_state
-        image_features = self.mm_projector(image_features)
-        return image_features
+        image = images[0] if images else None
+        do_rescale = self.processor.image_processor.do_rescale
+        if isinstance(image, torch.Tensor):
+            do_rescale = False
+        processor_output = self.processor(
+            text=text_prompt,
+            images=image,
+            do_rescale=do_rescale,
+            return_tensors="pt",
+            device=self.device).to(dtype=torch.bfloat16)
+
+        input_ids = processor_output["input_ids"]
+        pixel_values = processor_output.get("pixel_values")
+
+        return input_ids, pixel_values
 
     @torch.inference_mode()
     def __call__(
         self, inputs: TextPrompt, sampling_params: SamplingParams
     ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
-        preprocess_outputs = self._preprocess(inputs)
-        pixel_values = preprocess_outputs[0]["mm_processor_kwargs"][
-            "pixel_values"]
-        input_ids = preprocess_outputs[0]["mm_processor_kwargs"]["input_ids"]
-        mm_features = self._process(pixel_values)
-        multimodal_data = {}
-        multimodal_data["multimodal_embedding"] = mm_features.squeeze(dim=0)
-        return input_ids[0].to(torch.int32).tolist(), {
-            "multimodal_data": multimodal_data
-        }
+        input_ids, pixel_values = self._preprocess(inputs)
+        multimodal_data = None
+        if pixel_values is not None:
+            multimodal_data = {
+                "multimodal_data": {
+                    "image": {
+                        "pixel_values": pixel_values
+                    }
+                },
+            }
+        return input_ids[0].to(torch.int32).tolist(), multimodal_data
 
 
 @register_auto_model("Gemma3ForConditionalGeneration")
@@ -134,13 +102,36 @@ class Gemma3Model(PreTrainedModel):
                                    torch.float16)
         logger.info(f"[Gemma3Model::__init__]{self.dtype=} {self.model_dtype=}")
 
+        device = torch.device("cuda")
+        # Use HF implementations. They should eventually be replaced with TRTLLM counterparts.
+        # NOTE: we init the weights after transferring to the `device` since it can take a much
+        # longer time to initialize them on the CPU.
+        with no_init_weights():
+            self.vision_tower = AutoModel.from_config(
+                config.vision_config).eval().to(device)
+            self.mm_projector = Gemma3MultiModalProjector(config).eval().to(
+                device)
+
         self.post_config()
         self.is_loaded = True
 
     def load_weights(self, weights):
+        llm_weights = filter_weights("language_model", weights)
+        self.llm.load_weights(llm_weights)
 
-        weights = filter_weights("language_model", weights)
-        self.llm.load_weights(weights)
+        _load_weights_into_hf_module(
+            model=self.vision_tower,
+            weights=weights,
+            prefix="vision_tower",
+            model_name="vision tower",
+        )
+
+        _load_weights_into_hf_module(
+            model=self.mm_projector,
+            weights=weights,
+            prefix="multi_modal_projector",
+            model_name="multi modal projector",
+        )
 
     def post_config(self):
         self.config = self.llm.config
@@ -165,26 +156,34 @@ class Gemma3Model(PreTrainedModel):
         )
 
         multimodal_params = kwargs.get("multimodal_params", [])
-        mm_embed = [
-            multimodal_param.multimodal_data["multimodal_embedding"]
+        pixel_values = [
+            multimodal_param.multimodal_data["image"]["pixel_values"]
             for multimodal_param in multimodal_params
         ]
-        assert mm_embed == [] or len(
-            mm_embed
+        assert pixel_values == [] or len(
+            pixel_values
         ) == num_context_requests, "Number of multimodal features (if provided) should be equal to number of context requests"
 
         mm_token_ids = torch.tensor([self.image_token_index
                                      ]).to(input_ids.device)
         mm_token_mask = None
-        if len(mm_embed) > 0:
+        mm_embeds = []
+        if len(pixel_values) > 0:
+            # The shape of `image_features` is `[B, T, embed_dim]`.
+            image_features = self._get_image_features(
+                pixel_values=torch.cat(pixel_values))
+            # We need to reshape it to `[B * T, embed_dim]` before passing to `fuse_input_embeds`.
+            B, T, embed_dim = image_features.shape
+            mm_embeds = [image_features.reshape(B * T, embed_dim).contiguous()]
+
             # Get token type ids. 0 corresponds to text tokens, 1 corresponds to image tokens.
             mm_token_mask = torch.isin(input_ids, mm_token_ids)
+
         input_ids, inputs_embeds = fuse_input_embeds(
             embedding_layer=self.llm.model.embed_tokens,
             input_ids=input_ids,
-            mm_embeds=mm_embed,
-            mm_token_ids=torch.tensor([self.image_token_index
-                                       ]).to(input_ids.device))
+            mm_embeds=mm_embeds,
+            mm_token_ids=mm_token_ids)
         logits = self.llm.forward(
             attn_metadata=attn_metadata,
             input_ids=input_ids,
@@ -194,3 +193,25 @@ class Gemma3Model(PreTrainedModel):
             image_token_mask=mm_token_mask,
         )
         return logits
+
+    @nvtx_range("[Vision] process")
+    def _get_image_features(self, pixel_values):
+        with torch.autocast(device_type="cuda", dtype=self.dtype):
+            image_features: Tuple[torch.Tensor] = self.vision_tower(
+                pixel_values).last_hidden_state
+            image_features = self.mm_projector(image_features)
+        return image_features
+
+
+def _load_weights_into_hf_module(
+    model: torch.nn.Module,
+    weights: dict,
+    prefix: str,
+    model_name: str,
+) -> None:
+    filtered_weights = filter_weights(prefix, weights)
+    missing_keys, _ = model.load_state_dict(filtered_weights)
+    if len(missing_keys) > 0:
+        raise KeyError(
+            f"Missing the following keys for the {model_name} in the checkpoint: "
+            f"[{', '.join(missing_keys)}].")


### PR DESCRIPTION
* Why?

In order to take advantage of (in-flight) batching, we want the heavy, GPU-intensive model operations to happen in the model's forward method, not in the input processor.

* What?

This commit moves the vision tower and multimodal projector out of the input processor and into the model, alongside the language model, for Gemma3.

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
