### PR TITLE
[TRTLLM] Request logging.

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -192,7 +192,8 @@ class PyExecutor:
             PROFILE_START_STOP_ENV_VAR_NAME)
         self.gc_nvtx_watcher_handle = _gc_nvtx_watcher()
         self.is_warmup = False  # During warmup, we don't enable the profiler
-        self.log_forward_step = os.environ.get(TLLM_LOG_ENGINE_FORWARD_STEP_ENV_VAR_NAME, "0") == "1"
+        self.log_forward_step = os.environ.get(
+            TLLM_LOG_ENGINE_FORWARD_STEP_ENV_VAR_NAME, "0") == "1"
 
         # related modules
         self.resource_manager = resource_manager
@@ -1632,7 +1633,10 @@ class PyExecutor:
                       scheduled_requests,
                       new_tensors_device: Optional[SampleStateTensors] = None):
         if self.log_forward_step:
-            logger.info(f"forward_step {len(scheduled_requests.context_requests)} ctx reqs, {len(scheduled_requests.generation_requests)} gen reqs")
+            logger.info(
+                f"forward_step {len(scheduled_requests.context_requests)} ctx reqs, {len(scheduled_requests.generation_requests)} gen reqs"
+            )
+
         @nvtx_range(
             f"[Executor] _forward_step {self.model_engine.iter_counter}: {len(scheduled_requests.context_requests)} ctx reqs, {len(scheduled_requests.generation_requests)} gen reqs"
         )
@@ -1654,7 +1658,9 @@ class PyExecutor:
                               new_tensors_device, gather_context_logits,
                               cache_indirection_buffer)
             if self.log_forward_step:
-                logger.info(f"completed forward_step {len(scheduled_requests.context_requests)} ctx reqs, {len(scheduled_requests.generation_requests)} gen reqs")
+                logger.info(
+                    f"completed forward_step {len(scheduled_requests.context_requests)} ctx reqs, {len(scheduled_requests.generation_requests)} gen reqs"
+                )
             return outputs
         except Exception as e:
             traceback.print_exc()

--- a/tensorrt_llm/logger.py
+++ b/tensorrt_llm/logger.py
@@ -15,6 +15,7 @@
 import logging
 import os
 import sys
+import time
 from typing import Optional
 
 import tensorrt as trt
@@ -62,9 +63,11 @@ class Logger(metaclass=Singleton):
         self._logger = logging.getLogger(self.PREFIX)
         self._logger.propagate = False
         handler = logging.StreamHandler(stream=sys.stdout)
-        handler.setFormatter(
-            logging.Formatter(fmt="[%(asctime)s] %(message)s", datefmt="%m/%d/%Y-%H:%M:%S")
+        formatter = logging.Formatter(
+            fmt="[%(asctime)s.%(msecs)03d UTC] %(message)s", datefmt="%m/%d/%Y-%H:%M:%S"
         )
+        formatter.converter = time.gmtime
+        handler.setFormatter(formatter)
         self._logger.addHandler(handler)
         self._logger.setLevel(severity_map[min_severity][1])
         self._polygraphy_logger = G_LOGGER

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -105,7 +105,7 @@ class OpenAIServer:
             self.llm.shutdown()
 
         self.app = FastAPI(lifespan=lifespan)
-        
+
         @self.app.middleware("http")
         async def add_process_time_header(request: Request, call_next):
             start_time = time.perf_counter()

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 import asyncio
 import signal
-import traceback
 import time
+import traceback
 import uuid
-            
 from contextlib import asynccontextmanager
 from datetime import datetime
 from http import HTTPStatus


### PR DESCRIPTION
# PR title
[TRTLLM] Endpoint request logging

## Description

Adds support to enable more detailed logging of endpoint interaction with requests. Specifically:
1. Add a request id via `uuid` to track requests. This is also returned to the client to help correlate logs.
2. Add an environment variable `TLLM_LOG_ENGINE_FORWARD_STEP` which when set to 1 logs the start and end of the executor forward step. This is disabled by default as there is a large overhead expected.
3. Adds log statements when responses are returned for both streaming (multiple log entries) and non-streaming (single completion).

## Sample output :

5 non-streaming requests with forward step logging disabled:
```
[07/09/2025-23:07:49] [TRT-LLM] [I] Received request c1627587-927f-4717-bad4-7266c9960d32 at 32142.770581067
[07/09/2025-23:07:49] [TRT-LLM] [I] Received request 6cf19bd4-d226-4b46-a996-f1be2ca3164e at 32142.771139221
[07/09/2025-23:07:49] [TRT-LLM] [I] Received request 0fc748ec-5876-4503-8d77-18ebace6a3d4 at 32142.771229015
[07/09/2025-23:07:49] [TRT-LLM] [I] Received request e7a2c452-788f-4f7c-b778-b31c0abe30a2 at 32142.771298309
[07/09/2025-23:07:49] [TRT-LLM] [I] Received request 9b388797-6a64-4d0a-bbc9-695d4dfee032 at 32142.77136317
[07/09/2025-23:07:50] [TRT-LLM] [I] Response started c1627587-927f-4717-bad4-7266c9960d32 at 32143.546522802
[07/09/2025-23:07:50] [TRT-LLM] [I] Response started e7a2c452-788f-4f7c-b778-b31c0abe30a2 at 32143.552281314
[07/09/2025-23:07:50] [TRT-LLM] [I] Response started 0fc748ec-5876-4503-8d77-18ebace6a3d4 at 32143.55246955
[07/09/2025-23:07:50] [TRT-LLM] [I] Response started 6cf19bd4-d226-4b46-a996-f1be2ca3164e at 32143.552588598
[07/09/2025-23:07:50] [TRT-LLM] [I] Response started 9b388797-6a64-4d0a-bbc9-695d4dfee032 at 32143.552711462
```


5 streaming requests with forward step logging disabled:
```
[07/09/2025-23:08:11] [TRT-LLM] [I] Received request 516de389-aa66-4368-9d06-b4e230ddda27 at 32165.180763259
[07/09/2025-23:08:11] [TRT-LLM] [I] Received request dbf4cfde-f809-4abd-9fe6-cf352dd13f4f at 32165.180908453
[07/09/2025-23:08:11] [TRT-LLM] [I] Received request 0b752c60-8210-4910-a65a-3d74d51ca768 at 32165.180984415
[07/09/2025-23:08:11] [TRT-LLM] [I] Received request 66f01fbe-52c1-4532-afd3-ca78d87d8d35 at 32165.181055892
[07/09/2025-23:08:11] [TRT-LLM] [I] Received request e9c617a9-82da-4e1c-a7bf-a214325005cc at 32165.181117297
[07/09/2025-23:08:11] [TRT-LLM] [I] Response started 516de389-aa66-4368-9d06-b4e230ddda27 at 32165.183931652
[07/09/2025-23:08:11] [TRT-LLM] [I] Response started dbf4cfde-f809-4abd-9fe6-cf352dd13f4f at 32165.184146247
[07/09/2025-23:08:11] [TRT-LLM] [I] Response started 0b752c60-8210-4910-a65a-3d74d51ca768 at 32165.184297353
[07/09/2025-23:08:11] [TRT-LLM] [I] Response started 66f01fbe-52c1-4532-afd3-ca78d87d8d35 at 32165.184428352
[07/09/2025-23:08:11] [TRT-LLM] [I] Response started e9c617a9-82da-4e1c-a7bf-a214325005cc at 32165.1845536
[07/09/2025-23:08:12] [TRT-LLM] [I] generation completed for request 516de389-aa66-4368-9d06-b4e230ddda27
[07/09/2025-23:08:12] [TRT-LLM] [I] generation completed for request 66f01fbe-52c1-4532-afd3-ca78d87d8d35
[07/09/2025-23:08:12] [TRT-LLM] [I] generation completed for request 0b752c60-8210-4910-a65a-3d74d51ca768
[07/09/2025-23:08:12] [TRT-LLM] [I] generation completed for request e9c617a9-82da-4e1c-a7bf-a214325005cc
[07/09/2025-23:08:12] [TRT-LLM] [I] generation completed for request dbf4cfde-f809-4abd-9fe6-cf352dd13f4f
```
Note in the streaming case, the `response started` appears before the response is generated as this happens when the response is created, however the streaming response is generated after this line. The `generation completed` marks the actual completion of the streaming response. 