### PR TITLE
feat: Add support for Triton request cancellation

### DIFF
--- a/tests/integration/defs/triton_server/test_triton_llm.py
+++ b/tests/integration/defs/triton_server/test_triton_llm.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 import pytest
+import torch
 import yaml
 
 sys.path.append(os.path.join(os.environ["LLM_ROOT"], "triton_backend"))
@@ -3632,6 +3633,9 @@ def test_llmapi_backend(E2E_MODEL_NAME, DECOUPLED_MODE, TRITON_MAX_BATCH_SIZE,
                         llm_backend_inflight_batcher_llm_root, llm_backend_venv,
                         llm_backend_dataset_root):
     llm_backend_repo_root = os.environ["LLM_BACKEND_ROOT"]
+
+    if torch.cuda.device_count() < int(TENSOR_PARALLEL_SIZE):
+        pytest.skip("Skipping. Not enough GPUs.")
 
     # Prepare model repo
     new_model_repo = os.path.join(llm_backend_repo_root, "triton_repo")

--- a/tests/integration/defs/triton_server/test_triton_llm.py
+++ b/tests/integration/defs/triton_server/test_triton_llm.py
@@ -3712,6 +3712,20 @@ def test_llmapi_backend(E2E_MODEL_NAME, DECOUPLED_MODE, TRITON_MAX_BATCH_SIZE,
             print_info("DEBUG:: run_cmd: python3 " + " ".join(run_cmd))
             venv_check_call(llm_backend_venv, run_cmd)
 
+            # Test request cancellation with stop request
+            run_cmd = [
+                f"{llm_backend_repo_root}/tools/llmapi_client.py",
+                "--request-output-len=200", '--stop-after-ms=25'
+            ]
+
+            output = venv_check_output(llm_backend_venv, run_cmd)
+            assert 'Request is cancelled' in output
+
+            # Test request cancellation with  request cancel
+            run_cmd += ['--stop-via-request-cancel']
+            output = venv_check_output(llm_backend_venv, run_cmd)
+            assert 'Request is cancelled' in output
+
 
 @pytest.mark.parametrize("E2E_MODEL_NAME", ["ensemble", "tensorrt_llm_bls"])
 @pytest.mark.parametrize("ACCUMULATE_TOKEN", ["False"])

--- a/triton_backend/all_models/llmapi/tensorrt_llm/1/model.py
+++ b/triton_backend/all_models/llmapi/tensorrt_llm/1/model.py
@@ -443,12 +443,13 @@ class TritonPythonModel:
 
             # Send the last response which contains all the outputs if not streaming.
             if not streaming:
-                was_cancelled = False
-
                 # If the request was cancelled, we don't need to send the last response
                 with self.lock:
-                    if not triton_req_id in self.req_id_to_request_data:
-                        was_cancelled = True
+                    was_cancelled = triton_req_id not in self.req_id_to_request_data
+                    if not was_cancelled:
+                        # Remove the request from the request data map so the cancellation loop stops querying
+                        # is_cancelled() on the request
+                        del self.req_id_to_request_data[triton_req_id]
 
                 if not was_cancelled:
                     response_sender.send(

--- a/triton_backend/all_models/llmapi/tensorrt_llm/1/model.py
+++ b/triton_backend/all_models/llmapi/tensorrt_llm/1/model.py
@@ -306,11 +306,6 @@ class TritonPythonModel:
             finally:
                 if response_flag == pb_utils.TRITONSERVER_RESPONSE_COMPLETE_FINAL:
                     self._ongoing_request_count -= 1
-                    with self.lock:
-                        if self.running:
-                            self.cancellation_thread.join()
-                            self.cancellation_thread = None
-                            self.running = False
 
     def cancellation_loop(self):
         """Checks if any pending requests have been cancelled."""

--- a/triton_backend/all_models/llmapi/tensorrt_llm/config.pbtxt
+++ b/triton_backend/all_models/llmapi/tensorrt_llm/config.pbtxt
@@ -142,6 +142,12 @@ input [
     data_type: TYPE_BOOL
     dims: [1]
     optional: true
+  },
+  {
+    name: "stop"
+    data_type: TYPE_BOOL
+    dims: [ 1 ]
+    optional: true
   }
 ]
 ###################################################################

--- a/triton_backend/tools/llmapi_client.py
+++ b/triton_backend/tools/llmapi_client.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python
+# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import queue
+import sys
+import time
+from functools import partial
+
+import numpy as np
+import tritonclient.grpc as grpcclient
+from tritonclient.utils import InferenceServerException, np_to_triton_dtype
+
+
+def prepare_tensor(name, input):
+    t = grpcclient.InferInput(name, input.shape,
+                              np_to_triton_dtype(input.dtype))
+    t.set_data_from_numpy(input)
+    return t
+
+
+def _prepare_inputs(prompt, output_len):
+    inputs = [
+        prepare_tensor("text_input", prompt),
+        prepare_tensor("sampling_param_max_tokens",
+                       np.array([output_len], dtype=np.int32)),
+    ]
+    return inputs
+
+
+def prepare_stop_signals():
+
+    inputs = [
+        grpcclient.InferInput('text_input', [1], "BYTES"),
+        grpcclient.InferInput('stop', [1], "BOOL"),
+    ]
+
+    inputs[0].set_data_from_numpy(np.empty([1], dtype=np.bytes_))
+    inputs[1].set_data_from_numpy(np.array([True], dtype='bool'))
+
+    return inputs
+
+
+class UserData:
+
+    def __init__(self):
+        self._completed_requests = queue.Queue()
+
+
+def callback(user_data, result, error):
+    if error:
+        user_data._completed_requests.put(error)
+    else:
+        user_data._completed_requests.put(result)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        required=False,
+        default=False,
+        help="Enable verbose output",
+    )
+    parser.add_argument(
+        "-u",
+        "--url",
+        type=str,
+        required=False,
+        default="localhost:8001",
+        help="Inference server URL. Default is localhost:8001.",
+    )
+    parser.add_argument('--text',
+                        type=str,
+                        required=False,
+                        default='Born in north-east France, Soyer trained as a',
+                        help='Input text')
+
+    parser.add_argument(
+        "-s",
+        "--ssl",
+        action="store_true",
+        required=False,
+        default=False,
+        help="Enable SSL encrypted channel to the server",
+    )
+    parser.add_argument(
+        "-t",
+        "--stream-timeout",
+        type=float,
+        required=False,
+        default=None,
+        help="Stream timeout in seconds. Default is None.",
+    )
+    parser.add_argument(
+        "-C",
+        "--grpc-compression-algorithm",
+        type=str,
+        required=False,
+        default=None,
+        help=
+        "The compression algorithm to be used when sending request to server. Default is None.",
+    )
+    parser.add_argument(
+        "-S",
+        "--streaming",
+        action="store_true",
+        required=False,
+        default=False,
+        help="Enable streaming mode. Default is False.",
+    )
+    parser.add_argument(
+        "-r",
+        "--root-certificates",
+        type=str,
+        required=False,
+        default=None,
+        help="File holding PEM-encoded root certificates. Default is None.",
+    )
+    parser.add_argument(
+        "-p",
+        "--private-key",
+        type=str,
+        required=False,
+        default=None,
+        help="File holding PEM-encoded private key. Default is None.",
+    )
+    parser.add_argument(
+        "-x",
+        "--certificate-chain",
+        type=str,
+        required=False,
+        default=None,
+        help="File holding PEM-encoded certificate chain. Default is None.",
+    )
+    parser.add_argument(
+        "--request-output-len",
+        type=int,
+        required=False,
+        default=16,
+        help="Request output length",
+    )
+    parser.add_argument(
+        '--stop-after-ms',
+        type=int,
+        required=False,
+        default=0,
+        help='Early stop the generation after a few milliseconds')
+    parser.add_argument(
+        "--stop-via-request-cancel",
+        action="store_true",
+        required=False,
+        default=False,
+        help="Early stop use request cancellation instead of stop request")
+
+    parser.add_argument('--request-id',
+                        type=str,
+                        default='1',
+                        required=False,
+                        help='The request_id for the request')
+    parser.add_argument(
+        "--return-perf-metrics",
+        action="store_true",
+        required=False,
+        default=False,
+        help="Return per-request perf metrics",
+    )
+    parser.add_argument('--model-name',
+                        type=str,
+                        required=False,
+                        default='tensorrt_llm',
+                        help='Specify model name')
+
+    FLAGS = parser.parse_args()
+
+    input_data = np.array([FLAGS.text], dtype=object)
+
+    output_len = FLAGS.request_output_len
+
+    inputs = _prepare_inputs(input_data, output_len)
+
+    stop_inputs = None
+    if FLAGS.stop_after_ms > 0 and not FLAGS.stop_via_request_cancel:
+        stop_inputs = prepare_stop_signals()
+
+    request_id = FLAGS.request_id
+    user_data = UserData()
+    with grpcclient.InferenceServerClient(
+            url=FLAGS.url,
+            verbose=FLAGS.verbose,
+            ssl=FLAGS.ssl,
+            root_certificates=FLAGS.root_certificates,
+            private_key=FLAGS.private_key,
+            certificate_chain=FLAGS.certificate_chain,
+    ) as triton_client:
+        try:
+            # Send request
+            infer_future = triton_client.async_infer(
+                FLAGS.model_name,
+                inputs,
+                outputs=None,
+                request_id=request_id,
+                callback=partial(callback, user_data),
+                parameters={'Streaming': FLAGS.streaming})
+
+            expected_responses = 1
+
+            if FLAGS.stop_after_ms > 0:
+
+                time.sleep(FLAGS.stop_after_ms / 1000.0)
+
+                if FLAGS.stop_via_request_cancel:
+                    infer_future.cancel()
+                else:
+                    triton_client.async_infer(
+                        FLAGS.model_name,
+                        stop_inputs,
+                        request_id=request_id,
+                        callback=partial(callback, user_data),
+                        parameters={'Streaming': FLAGS.streaming})
+
+            processed_count = 0
+            while processed_count < expected_responses:
+                try:
+                    result = user_data._completed_requests.get()
+                    print("Got completed request", flush=True)
+                except Exception:
+                    break
+
+                if type(result) == InferenceServerException:
+                    if result.status() == "StatusCode.CANCELLED":
+                        print("Request is cancelled")
+                    else:
+                        print("Received an error from server:")
+                        print(result)
+                        raise result
+                else:
+                    print(
+                        f'Output text: {result.as_numpy("text_output")[0].decode("utf-8")}'
+                    )
+
+                processed_count += 1
+
+        except Exception as e:
+            err = "Encountered error: " + str(e)
+            print(err)
+            sys.exit(err)
+
+        sys.exit(0)


### PR DESCRIPTION
# PR title

feat: Add support for Triton request cancellation

## Description

Handle request cancellation in Triton torch backend:
* Add handling for stop signal
* Add cancellation thread checking for cancellation status every ms

Add llmapi_client script to test the feature

Extend existing test to check cancellation works

## Test Coverage

test_llmapi_backend

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
