### PR TITLE
[NvBug 5378370] fix: Fix alltoall for llama4 (apply_router_weight_on_input=True)

### DIFF
--- a/cpp/tensorrt_llm/thop/moeCommOp.cpp
+++ b/cpp/tensorrt_llm/thop/moeCommOp.cpp
@@ -87,15 +87,13 @@ moeCommPrepareIndicesOp(torch::Tensor gatheredTargetRankIds, c10::optional<torch
 }
 
 void moeLocalGatherOp(torch::Tensor recvRankCumSum, torch::Tensor localGatherIndices, torch::Tensor gatheredExpertIds,
-    torch::Tensor gatheredScales, torch::Tensor localExpertIds, torch::Tensor localScales, int64_t maxTokenCountPerRank,
-    int64_t expertCount, int64_t topK, int64_t epRank, int64_t epSize)
+    c10::optional<torch::Tensor> gatheredScales, torch::Tensor localExpertIds, c10::optional<torch::Tensor> localScales,
+    int64_t maxTokenCountPerRank, int64_t expertCount, int64_t topK, int64_t epRank, int64_t epSize)
 {
     CHECK_INPUT(recvRankCumSum, torch::kInt32);
     CHECK_INPUT(localGatherIndices, torch::kInt32);
     CHECK_INPUT(gatheredExpertIds, torch::kInt32);
-    CHECK_INPUT(gatheredScales, torch::kFloat32);
     CHECK_INPUT(localExpertIds, torch::kInt32);
-    CHECK_INPUT(localScales, torch::kFloat32);
 
     TORCH_CHECK(maxTokenCountPerRank > 0, "maxTokenCountPerRank must be greater than 0");
     TORCH_CHECK(expertCount > 0, "expertCount must be greater than 0");
@@ -107,17 +105,31 @@ void moeLocalGatherOp(torch::Tensor recvRankCumSum, torch::Tensor localGatherInd
     TORCH_CHECK(recvRankCumSum.size(0) == epSize, "recvRankCumSum must have epSize elements");
     TORCH_CHECK(localGatherIndices.dim() == 1, "localGatherIndices must be a 1D tensor");
     TORCH_CHECK(gatheredExpertIds.dim() == 2, "gatheredExpertIds must be a 2D tensor");
-    TORCH_CHECK(gatheredScales.dim() == 2, "gatheredScales must be a 2D tensor");
     TORCH_CHECK(localExpertIds.dim() == 2, "localExpertIds must be a 2D tensor");
-    TORCH_CHECK(localScales.dim() == 2, "localScales must be a 2D tensor");
     TORCH_CHECK(gatheredExpertIds.size(1) == topK, "gatheredExpertIds must have topK columns");
-    TORCH_CHECK(gatheredScales.size(1) == topK, "gatheredScales must have topK columns");
     TORCH_CHECK(localExpertIds.size(1) == topK, "localExpertIds must have topK columns");
-    TORCH_CHECK(localScales.size(1) == topK, "localScales must have topK columns");
 
     int localMaxTokenCount = static_cast<int>(localGatherIndices.size(0));
     TORCH_CHECK(localExpertIds.size(0) == localMaxTokenCount, "localExpertIds must have localMaxTokenCount rows");
-    TORCH_CHECK(localScales.size(0) == localMaxTokenCount, "localScales must have localMaxTokenCount rows");
+
+    TORCH_CHECK(gatheredScales.has_value() == localScales.has_value(),
+        "gatheredScales and localScales must be both valid or both invalid");
+    float const* gatheredScalesPtr = nullptr;
+    float* localScalesPtr = nullptr;
+    if (gatheredScales.has_value())
+    {
+        CHECK_INPUT(gatheredScales.value(), torch::kFloat32);
+        CHECK_INPUT(localScales.value(), torch::kFloat32);
+
+        TORCH_CHECK(gatheredScales->dim() == 2, "gatheredScales must be a 2D tensor");
+        TORCH_CHECK(gatheredScales->size(1) == topK, "gatheredScales must have topK columns");
+        TORCH_CHECK(localScales->dim() == 2, "localScales must be a 2D tensor");
+        TORCH_CHECK(localScales->size(1) == topK, "localScales must have topK columns");
+        TORCH_CHECK(localScales->size(0) == localMaxTokenCount, "localScales must have localMaxTokenCount rows");
+
+        gatheredScalesPtr = gatheredScales->data_ptr<float>();
+        localScalesPtr = localScales->data_ptr<float>();
+    }
 
     auto stream = at::cuda::getCurrentCUDAStream();
 
@@ -128,7 +140,7 @@ void moeLocalGatherOp(torch::Tensor recvRankCumSum, torch::Tensor localGatherInd
     tensorrt_llm::kernels::MoeEpWorldInfo worldInfo = {static_cast<int>(epSize), static_cast<int>(epRank)};
     tensorrt_llm::kernels::moeLocalGather(worldInfo, expertParallelInfo, maxTokenCountPerRank, localMaxTokenCount,
         recvRankCumSum.data_ptr<int>(), localGatherIndices.data_ptr<int>(), gatheredExpertIds.data_ptr<int>(),
-        gatheredScales.data_ptr<float>(), localExpertIds.data_ptr<int>(), localScales.data_ptr<float>(), stream);
+        gatheredScalesPtr, localExpertIds.data_ptr<int>(), localScalesPtr, stream);
 }
 
 void moeCommOp(torch::Tensor input, torch::Tensor sendRankCumSum, torch::Tensor sendIndices, torch::Tensor output,
@@ -287,8 +299,7 @@ TORCH_LIBRARY_FRAGMENT(trtllm, m)
     m.def(
         "moe_comm_prepare_indices(Tensor gathered_target_rank_ids, Tensor? real_rank_token_count_cum_sum, int "
         "max_token_count_per_rank, int expert_count, int top_k, int ep_rank, int ep_size) -> (Tensor, Tensor, Tensor, "
-        "Tensor, "
-        "Tensor, Tensor)");
+        "Tensor, Tensor, Tensor)");
 }
 
 TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
@@ -299,10 +310,9 @@ TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
 TORCH_LIBRARY_FRAGMENT(trtllm, m)
 {
     m.def(
-        "moe_local_gather(Tensor recv_rank_cum_sum, Tensor local_gather_indices, Tensor gathered_expert_ids, Tensor "
+        "moe_local_gather(Tensor recv_rank_cum_sum, Tensor local_gather_indices, Tensor gathered_expert_ids, Tensor? "
         "gathered_scales, Tensor local_expert_ids, Tensor local_scales, int max_token_count_per_rank, int "
-        "expert_count, int "
-        "top_k, int ep_rank, int ep_size) -> ()");
+        "expert_count, int top_k, int ep_rank, int ep_size) -> ()");
 }
 
 TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
@@ -314,8 +324,7 @@ TORCH_LIBRARY_FRAGMENT(trtllm, m)
 {
     m.def(
         "moe_comm(Tensor input, Tensor send_rank_cum_sum, Tensor send_indices, Tensor output, Tensor "
-        "recv_rank_cum_sum, "
-        "Tensor recv_indices, Tensor all_workspaces, int ep_rank, int ep_size) -> ()");
+        "recv_rank_cum_sum, Tensor recv_indices, Tensor all_workspaces, int ep_rank, int ep_size) -> ()");
 }
 
 TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
@@ -347,11 +356,8 @@ TORCH_LIBRARY_FRAGMENT(trtllm, m)
 {
     m.def(
         "mnnvl_moe_alltoallv_prepare_without_allgather(Tensor experts_ids, Tensor scales, Tensor? experts_statics, "
-        "Tensor allWorkspace, int "
-        "max_token_count_per_rank, int ep_rank, int ep_size, int expert_count, int slot_count, int top_k) -> (Tensor, "
-        "Tensor, Tensor, "
-        "Tensor, "
-        "Tensor, Tensor, Tensor, Tensor?)");
+        "Tensor allWorkspace, int max_token_count_per_rank, int ep_rank, int ep_size, int expert_count, int "
+        "slot_count, int top_k) -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor?)");
 }
 
 TORCH_LIBRARY_IMPL(trtllm, CUDA, m)

--- a/cpp/tensorrt_llm/thop/moeCommOp.cpp
+++ b/cpp/tensorrt_llm/thop/moeCommOp.cpp
@@ -311,7 +311,7 @@ TORCH_LIBRARY_FRAGMENT(trtllm, m)
 {
     m.def(
         "moe_local_gather(Tensor recv_rank_cum_sum, Tensor local_gather_indices, Tensor gathered_expert_ids, Tensor? "
-        "gathered_scales, Tensor local_expert_ids, Tensor local_scales, int max_token_count_per_rank, int "
+        "gathered_scales, Tensor local_expert_ids, Tensor? local_scales, int max_token_count_per_rank, int "
         "expert_count, int top_k, int ep_rank, int ep_size) -> ()");
 }
 

--- a/tensorrt_llm/_mnnvl_utils.py
+++ b/tensorrt_llm/_mnnvl_utils.py
@@ -406,9 +406,9 @@ class MnnvlMoe:
     @staticmethod
     def mnnvl_moe_alltoallv_prepare(
         gathered_target_rank_ids: torch.Tensor,
-        real_rank_token_count_cumsum: torch.Tensor,
+        real_rank_token_count_cumsum: Optional[torch.Tensor],
         gathered_expert_ids: torch.Tensor,
-        gathered_scales: torch.Tensor,
+        gathered_scales: Optional[torch.Tensor],
         max_token_count_per_rank: int,
         expert_count: int,
         top_k: int,
@@ -437,9 +437,15 @@ class MnnvlMoe:
         local_expert_ids = torch.empty(
             local_token_allocation_count, top_k, dtype=torch.int32, device=torch.device("cuda")
         )
-        local_scales = torch.empty(
-            local_token_allocation_count, top_k, dtype=torch.float32, device=torch.device("cuda")
-        )
+        if gathered_scales is None:
+            local_scales = None
+        else:
+            local_scales = torch.empty(
+                local_token_allocation_count,
+                top_k,
+                dtype=torch.float32,
+                device=torch.device("cuda"),
+            )
 
         torch.ops.trtllm.moe_local_gather(
             recv_rank_count_cumsum,

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -182,7 +182,7 @@ def _register_fake():
     @torch.library.register_fake("trtllm::moe_comm_prepare_indices")
     def _(
         gathered_target_rank_ids: torch.Tensor,
-        real_rank_token_count_cum_sum,
+        real_rank_token_count_cum_sum: Optional[torch.Tensor],
         max_token_count_per_rank: int,
         expert_count: int,
         top_k: int,
@@ -220,9 +220,9 @@ def _register_fake():
         recv_rank_cum_sum: torch.Tensor,
         local_gather_indices: torch.Tensor,
         gathered_expert_ids: torch.Tensor,
-        gathered_scales: torch.Tensor,
+        gathered_scales: Optional[torch.Tensor],
         local_expert_ids: torch.Tensor,
-        local_scales: torch.Tensor,
+        local_scales: Optional[torch.Tensor],
         max_token_count_per_rank: int,
         expert_count: int,
         top_k: int,

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
@@ -125,6 +125,7 @@ class CutlassFusedMoE(MoE):
 
         if self.apply_router_weight_on_input:
             assert self.routing_method.top_k == 1, "Current walkaround only supports top-1 routing"
+
         if self.quant_config and self.quant_config.quant_mode.has_any_quant(
                 exclude_kv_cache=True):
             if not (self.quant_config.quant_mode.has_nvfp4()
@@ -214,7 +215,6 @@ class CutlassFusedMoE(MoE):
         assert token_selected_experts.dtype == torch.int32
 
         if self.apply_router_weight_on_input:
-            assert self.routing_method.top_k == 1, "Current workaround only supports top-1 routing"
             assert x.dtype != torch.float8_e4m3fn, "Current workaround for apply_router_weight_on_input does not support fp8 input"
             x = x * token_final_scales.to(x.dtype)
             # TODO: remove this once we have correct fusedmoe kernel ready

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_wide_ep.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_wide_ep.py
@@ -886,7 +886,8 @@ class WideEPMoE(MoE):
                     (0, 0, 0,
                      all_rank_max_num_tokens - token_selected_slots.shape[0]),
                     'constant', self.num_slots)
-            if all_rank_max_num_tokens > token_final_scales.shape[0]:
+            if token_final_scales is not None and all_rank_max_num_tokens > token_final_scales.shape[
+                    0]:
                 token_final_scales = torch.nn.functional.pad(
                     token_final_scales,
                     (0, 0, 0,
@@ -902,10 +903,11 @@ class WideEPMoE(MoE):
                 gathered_token_selected_slots.contiguous(),
                 start_dim=0,
                 end_dim=-2)
-            gathered_token_final_scales = torch.flatten(
-                gathered_token_final_scales.contiguous(),
-                start_dim=0,
-                end_dim=-2)
+            if gathered_token_final_scales is not None:
+                gathered_token_final_scales = torch.flatten(
+                    gathered_token_final_scales.contiguous(),
+                    start_dim=0,
+                    end_dim=-2)
             gathered_target_rank_ids = MnnvlMoe.compute_target_rank_id(
                 gathered_token_selected_slots, self.num_slots, self.ep_size)
             alltoall_info, token_selected_slots, token_final_scales = MnnvlMoe.mnnvl_moe_alltoallv_prepare(

--- a/tests/unittest/_torch/thop/test_moe_alltoall.py
+++ b/tests/unittest/_torch/thop/test_moe_alltoall.py
@@ -716,12 +716,10 @@ class TestMoeAlltoAllSingleGPU(unittest.TestCase):
         for i in range(total_recv_token_count):
             for j in range(top_k):
                 expert_id = int(prepared_local_experts_cpu[i][j])
-                assert expert_id == slot_count or compute_target_rank(
-                    expert_id) == ep_rank
-                scale = float(prepared_local_scales_cpu[i][j])
-                if expert_id == slot_count:
-                    assert scale < 1e-6
-                else:
+                assert 0 <= expert_id and expert_id <= slot_count
+                if expert_id < slot_count:
+                    assert compute_target_rank(expert_id) == ep_rank
+                    scale = float(prepared_local_scales_cpu[i][j])
                     assert scale > 1e-6
 
         gathered_expert_statics_cpu = gathered_expert_statics.cpu()


### PR DESCRIPTION
# [NvBug 5378370] fix: Fix alltoall for llama4 (apply_router_weight_on_input=True)

LLaMA 4 has `apply_router_weight_on_input=True`, which leads to `token_final_scales=None`.

This PR fixes all alltoall paths for `token_final_scales=None`.


## Description

Please explain the issue and the solution in short.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
