### PR TITLE
[feat] Support option 'served_model_name'

### DIFF
--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -137,7 +137,7 @@ def launch_server(host: str,
                   server_role: Optional[ServerRole] = None):
 
     backend = llm_args["backend"]
-    model = llm_args["model"]
+    served_model_name = llm_args["served_model_name"] if llm_args["served_model_name"] is not None else llm_args["model"]
 
     if backend == 'pytorch':
         llm = PyTorchLLM(**llm_args)
@@ -145,7 +145,7 @@ def launch_server(host: str,
         llm = LLM(**llm_args)
 
     server = OpenAIServer(llm=llm,
-                          model=model,
+                          model=served_model_name,
                           server_role=server_role,
                           metadata_server_cfg=metadata_server_cfg)
 
@@ -154,6 +154,10 @@ def launch_server(host: str,
 
 @click.command("serve")
 @click.argument("model", type=str)
+@click.option("--served_model_name",
+              type=str,
+              default=None,
+              help="Model name of the OpenAI server.")
 @click.option("--tokenizer",
               type=str,
               default=None,


### PR DESCRIPTION
# [feat] Support option 'served_model_name'

## Description

while use local path model, i want a served_model_name option like vllm


