### PR TITLE
[None] [fix] improve kvcache allocation in PyTorch runtime

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -192,6 +192,8 @@ struct KvCacheStats
     float cacheHitRate;
     // Number of free blocks for every configured attention-window size.
     std::map<SizeType32, SizeType32> numFreeBlocksPerWindowSize;
+    // GPU bytes allocated for KV-cache
+    std::size_t allocatedBytes{};
 };
 
 // Basic building block of a paged KV cache - a single
@@ -1474,6 +1476,7 @@ public:
                                                                    : static_cast<float>(kvCacheStats.reusedBlocks)
                 / static_cast<float>(kvCacheStats.reusedBlocks + kvCacheStats.missedBlocks);
         kvCacheStats.numFreeBlocksPerWindowSize = getNumFreeBlocksPerWindowSize();
+        kvCacheStats.allocatedBytes = mAllocatedBytes;
         return kvCacheStats;
     }
 
@@ -1677,6 +1680,8 @@ private:
     runtime::ITensor::SharedPtr mBlockPoolPointers;
     runtime::ITensor::SharedPtr mLayerToPoolMapping;
     runtime::ITensor::SharedPtr mBlockScalePoolPointers;
+    // GPU bytes allocated for KV-cache
+    std::size_t mAllocatedBytes{0};
 };
 
 } // namespace tensorrt_llm::batch_manager::kv_cache_manager

--- a/cpp/include/tensorrt_llm/executor/executor.h
+++ b/cpp/include/tensorrt_llm/executor/executor.h
@@ -1006,7 +1006,8 @@ public:
         std::optional<RetentionPriority> secondaryOffloadMinPriority = std::nullopt, size_t eventBufferMaxSize = 0,
         bool enablePartialReuse = true, bool copyOnPartialReuse = true, bool useUvm = false,
         SizeType32 attentionDpEventsGatherPeriodMs = 5,
-        std::optional<tensorrt_llm::runtime::RuntimeDefaults> const& runtimeDefaults = std::nullopt);
+        std::optional<tensorrt_llm::runtime::RuntimeDefaults> const& runtimeDefaults = std::nullopt,
+        uint64_t const& maxGpuTotalBytes = 0);
 
     [[nodiscard]] bool getEnableBlockReuse() const;
     [[nodiscard]] bool getEnablePartialReuse() const;
@@ -1022,11 +1023,12 @@ public:
     [[nodiscard]] size_t getEventBufferMaxSize() const;
     [[nodiscard]] bool getUseUvm() const;
     [[nodiscard]] SizeType32 getAttentionDpEventsGatherPeriodMs() const;
+    [[nodiscard]] uint64_t getMaxGpuTotalBytes() const;
 
     void setEnableBlockReuse(bool enableBlockReuse);
     void setEnablePartialReuse(bool enablePartialReuse);
     void setCopyOnPartialReuse(bool copyOnPartialReuse);
-    void setMaxTokens(SizeType32 maxTokens);
+    void setMaxTokens(std::optional<SizeType32> maxTokens);
     void setMaxAttentionWindowVec(std::vector<SizeType32> maxAttentionWindowVec);
     void setSinkTokenLength(SizeType32 sinkTokenLength);
     void setFreeGpuMemoryFraction(FloatType freeGpuMemoryFraction);
@@ -1037,6 +1039,7 @@ public:
     void setEventBufferMaxSize(size_t eventBufferMaxSize);
     void setUseUvm(bool useUvm);
     void setAttentionDpEventsGatherPeriodMs(SizeType32 attentionDpEventsGatherPeriodMs);
+    void setMaxGpuTotalBytes(uint64_t maxGpuTotalBytes);
 
     void fillEmptyFieldsFromRuntimeDefaults(tensorrt_llm::runtime::RuntimeDefaults const& runtimeDefaults);
 
@@ -1095,6 +1098,10 @@ private:
 
     /// @brief The period in milliseconds to gather attention DP events across ranks
     SizeType32 mAttentionDpEventsGatherPeriodMs;
+    /// @brief The maximum size in bytes of GPU memory that can be allocated for the KV cache.
+    /// If both mMaxGpuTotalBytes and mFreeGpuMemoryFraction are specified, memory corresponding to the minimum will
+    /// be allocated.
+    uint64_t mMaxGpuTotalBytes;
 };
 
 /// @brief Configuration class for the runtime perf knobs

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -1681,27 +1681,29 @@ void KVCacheManager::allocatePools(bool useUvm)
     mBlockManager.allocatePools(useUvm);
     auto const numPools = mBlockManager.getNumPools();
 
+    uint64_t cacheSizeBytes = 0;
+    for (SizeType32 poolIdx = 0; poolIdx < numPools; poolIdx++)
+    {
+        auto const cacheShape = mBlockManager.getPrimaryPool(poolIdx)->getShape();
+        auto const cacheVolume = ITensor::volume(cacheShape);
+#ifdef ENABLE_FP4
+        auto const isFp4 = mDataType == nvinfer1::DataType::kFP4;
+#else
+        auto const isFp4 = false;
+#endif
+        if (!isFp4)
+        {
+            cacheSizeBytes += cacheVolume * BufferDataType(mDataType).getSize();
+        }
+        else
+        {
+            cacheSizeBytes += (cacheVolume * 4) / 8;
+        }
+    }
+    // Save the total number of bytes allocated for the KV-cache for KvCacheStats
+    mAllocatedBytes = cacheSizeBytes;
     if (tc::Logger::getLogger()->getLevel() <= tc::Logger::INFO)
     {
-        uint64_t cacheSizeBytes = 0;
-        for (SizeType32 poolIdx = 0; poolIdx < numPools; poolIdx++)
-        {
-            auto const cacheShape = mBlockManager.getPrimaryPool(poolIdx)->getShape();
-            auto const cacheVolume = ITensor::volume(cacheShape);
-#ifdef ENABLE_FP4
-            auto const isFp4 = mDataType == nvinfer1::DataType::kFP4;
-#else
-            auto const isFp4 = false;
-#endif
-            if (!isFp4)
-            {
-                cacheSizeBytes += cacheVolume * BufferDataType(mDataType).getSize();
-            }
-            else
-            {
-                cacheSizeBytes += (cacheVolume * 4) / 8;
-            }
-        }
 
         TLLM_LOG_INFO("Number of tokens per block: %d.", mBlockManager.getTokensPerBlock());
         auto const maxNumTokens = mBlockManager.getNumPrimaryBlocks() * mBlockManager.getTokensPerBlock();

--- a/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.cpp
@@ -303,7 +303,8 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(nb::module_& m)
         .def_rw("reused_blocks", &tbk::KvCacheStats::reusedBlocks)
         .def_rw("missed_blocks", &tbk::KvCacheStats::missedBlocks)
         .def_rw("cache_hit_rate", &tbk::KvCacheStats::cacheHitRate)
-        .def_rw("num_free_blocks_per_window_size", &tbk::KvCacheStats::numFreeBlocksPerWindowSize);
+        .def_rw("num_free_blocks_per_window_size", &tbk::KvCacheStats::numFreeBlocksPerWindowSize)
+        .def_ro("allocated_bytes", &tbk::KvCacheStats::allocatedBytes);
 
     nb::class_<tbk::TempAttentionWindowInputs>(m, "TempAttentionWindowInputs")
         .def(nb::init<>())

--- a/cpp/tensorrt_llm/pybind/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/kvCacheManager.cpp
@@ -299,7 +299,8 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(py::module_& m)
         .def_readwrite("reused_blocks", &tbk::KvCacheStats::reusedBlocks)
         .def_readwrite("missed_blocks", &tbk::KvCacheStats::missedBlocks)
         .def_readwrite("cache_hit_rate", &tbk::KvCacheStats::cacheHitRate)
-        .def_readwrite("num_free_blocks_per_window_size", &tbk::KvCacheStats::numFreeBlocksPerWindowSize);
+        .def_readwrite("num_free_blocks_per_window_size", &tbk::KvCacheStats::numFreeBlocksPerWindowSize)
+        .def_readonly("allocated_bytes", &tbk::KvCacheStats::allocatedBytes);
 
     py::class_<tbk::TempAttentionWindowInputs>(m, "TempAttentionWindowInputs")
         .def(py::init<>())

--- a/cpp/tensorrt_llm/pybind/executor/executorConfig.cpp
+++ b/cpp/tensorrt_llm/pybind/executor/executorConfig.cpp
@@ -104,11 +104,11 @@ void initConfigBindings(pybind11::module_& m)
             self.getSinkTokenLength(), self.getFreeGpuMemoryFraction(), self.getHostCacheSize(),
             self.getOnboardBlocks(), self.getCrossKvCacheFraction(), self.getSecondaryOffloadMinPriority(),
             self.getEventBufferMaxSize(), self.getEnablePartialReuse(), self.getCopyOnPartialReuse(), self.getUseUvm(),
-            self.getAttentionDpEventsGatherPeriodMs());
+            self.getAttentionDpEventsGatherPeriodMs(), self.getMaxGpuTotalBytes());
     };
     auto kvCacheConfigSetstate = [](py::tuple const& state)
     {
-        if (state.size() != 14)
+        if (state.size() != 15)
         {
             throw std::runtime_error("Invalid state!");
         }
@@ -117,20 +117,21 @@ void initConfigBindings(pybind11::module_& m)
             state[4].cast<std::optional<float>>(), state[5].cast<std::optional<size_t>>(), state[6].cast<bool>(),
             state[7].cast<std::optional<float>>(), state[8].cast<std::optional<tle::RetentionPriority>>(),
             state[9].cast<size_t>(), state[10].cast<bool>(), state[11].cast<bool>(), state[12].cast<bool>(),
-            state[13].cast<SizeType32>());
+            state[13].cast<SizeType32>(), std::nullopt, state[14].cast<uint64_t>());
     };
     py::class_<tle::KvCacheConfig>(m, "KvCacheConfig")
         .def(py::init<bool, std::optional<SizeType32> const&, std::optional<std::vector<SizeType32>> const&,
                  std::optional<SizeType32> const&, std::optional<float> const&, std::optional<size_t> const&, bool,
                  std::optional<float> const&, std::optional<tle::RetentionPriority>, size_t const&, bool, bool, bool,
-                 SizeType32, std::optional<RuntimeDefaults> const&>(),
+                 SizeType32, std::optional<RuntimeDefaults> const&, uint64_t const&>(),
             py::arg("enable_block_reuse") = true, py::arg("max_tokens") = py::none(),
             py::arg("max_attention_window") = py::none(), py::arg("sink_token_length") = py::none(),
             py::arg("free_gpu_memory_fraction") = py::none(), py::arg("host_cache_size") = py::none(),
             py::arg("onboard_blocks") = true, py::arg("cross_kv_cache_fraction") = py::none(),
             py::arg("secondary_offload_min_priority") = py::none(), py::arg("event_buffer_max_size") = 0, py::kw_only(),
             py::arg("enable_partial_reuse") = true, py::arg("copy_on_partial_reuse") = true, py::arg("use_uvm") = false,
-            py::arg("attention_dp_events_gather_period_ms") = 5, py::arg("runtime_defaults") = py::none())
+            py::arg("attention_dp_events_gather_period_ms") = 5, py::arg("runtime_defaults") = py::none(),
+            py::arg("max_gpu_total_bytes") = 0)
         .def_property(
             "enable_block_reuse", &tle::KvCacheConfig::getEnableBlockReuse, &tle::KvCacheConfig::setEnableBlockReuse)
         .def_property("max_tokens", &tle::KvCacheConfig::getMaxTokens, &tle::KvCacheConfig::setMaxTokens)
@@ -140,6 +141,8 @@ void initConfigBindings(pybind11::module_& m)
             "sink_token_length", &tle::KvCacheConfig::getSinkTokenLength, &tle::KvCacheConfig::setSinkTokenLength)
         .def_property("free_gpu_memory_fraction", &tle::KvCacheConfig::getFreeGpuMemoryFraction,
             &tle::KvCacheConfig::setFreeGpuMemoryFraction)
+        .def_property(
+            "max_gpu_total_bytes", &tle::KvCacheConfig::getMaxGpuTotalBytes, &tle::KvCacheConfig::setMaxGpuTotalBytes)
         .def_property("host_cache_size", &tle::KvCacheConfig::getHostCacheSize, &tle::KvCacheConfig::setHostCacheSize)
         .def_property("onboard_blocks", &tle::KvCacheConfig::getOnboardBlocks, &tle::KvCacheConfig::setOnboardBlocks)
         .def_property("cross_kv_cache_fraction", &tle::KvCacheConfig::getCrossKvCacheFraction,

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -98,8 +98,7 @@ class KvCacheCreator:
             fraction = 0.9
         return fraction
 
-    def _cal_max_tokens(self, peak_memory, total_gpu_memory, fraction,
-                        alloc_kv_tokens: int) -> int:
+    def _get_kv_size_per_token(self):
         model_config = self._model_engine.model.model_config
         mapping = self._mapping
         kv_size_per_token = self._get_cache_size_per_token(
@@ -108,18 +107,25 @@ class KvCacheCreator:
             draft_model_config = self._draft_model_engine.model.model_config
             kv_size_per_token += self._get_cache_size_per_token(
                 draft_model_config, mapping)
+        return kv_size_per_token
+
+    def _cal_max_memory(self, peak_memory, total_gpu_memory, fraction,
+                        allocated_bytes: int) -> int:
+        """
+        Calculate the max KV cache capacity.
+
+        NOTE: `allocated_bytes` is the total KV-cache memory that must be pre-allocated during the estimation phase (for both the main and draft models) so the estimation run can complete successfully. When computing `available_kv_mem`, add this amount back in.
+        """
+        kv_size_per_token = self._get_kv_size_per_token()
 
         available_kv_mem = (total_gpu_memory - peak_memory +
-                            alloc_kv_tokens * kv_size_per_token) * fraction
+                            allocated_bytes) * fraction
         logger.info(
             f"Peak memory during memory usage profiling (torch + non-torch): {peak_memory / (GB):.2f} GiB, "
             f"available KV cache memory when calculating max tokens: {available_kv_mem / (GB):.2f} GiB, "
             f"fraction is set {fraction}, kv size is {kv_size_per_token}. device total memory {total_gpu_memory / (GB):.2f} GiB, "
-            f", tmp kv_mem { (alloc_kv_tokens * kv_size_per_token) / (GB):.2f} GiB"
-        )
-        max_tokens = int((available_kv_mem) // kv_size_per_token)
-        max_tokens = max(max_tokens, 0)
-        return max_tokens
+            f", tmp kv_mem { (allocated_bytes) / (GB):.2f} GiB")
+        return int(available_kv_mem)
 
     def _create_dummy_context_requests(
             self, input_seq_len: int) -> List[trtllm.Request]:
@@ -187,12 +193,17 @@ class KvCacheCreator:
         estimating_kv_cache = False
         if 'cp_type' not in self._mapping.cp_config:
             estimating_kv_cache = True
-            self._executor_config.kv_cache_config.max_tokens = self._get_token_num_for_estimation(
-            )
+            max_attention_window_from_config = self._executor_config.kv_cache_config.max_attention_window
+            max_seq_len = max(
+                max_attention_window_from_config
+            ) if max_attention_window_from_config is not None else self._executor_config.max_seq_len
+            self._executor_config.kv_cache_config.max_tokens = max(
+                self._get_token_num_for_estimation(), max_seq_len)
         return estimating_kv_cache
 
-    def estimate_max_tokens(self, py_executor: PyExecutor) -> None:
+    def configure_kv_cache_capacity(self, py_executor: PyExecutor) -> None:
         """Perform KV cache capacity estimation.
+        NOTE: for VSWA case, we calculate and set kv cache memory instead of using max_tokens in kv_cache_config.
 
         This updates `kv_cache_config`.
         """
@@ -258,19 +269,74 @@ class KvCacheCreator:
         logger.info(
             f"Memory used outside torch (e.g., NCCL and CUDA graphs) in memory usage profiling: {extra_cost / (GB):.2f} GiB"
         )
+
+        # get kv cache stats for both model and draft model
         kv_stats = py_executor.resource_manager.resource_managers.get(
             ResourceManagerType.KV_CACHE_MANAGER).get_kv_cache_stats()
+        kv_stats_draft = py_executor.resource_manager.resource_managers.get(
+            ResourceManagerType.DRAFT_KV_CACHE_MANAGER).get_kv_cache_stats(
+            ) if self._draft_model_engine is not None else None
 
-        kv_cache_max_tokens = self._cal_max_tokens(
-            peak_memory, total_gpu_memory, fraction,
-            kv_stats.max_num_blocks * kv_stats.tokens_per_block)
+        # get total allocated bytes
+        allocated_bytes = kv_stats.allocated_bytes + (
+            kv_stats_draft.allocated_bytes if kv_stats_draft is not None else 0)
 
+        # calculate max memory from peak memory and free gpu memory fraction
+        kv_cache_max_memory = self._cal_max_memory(peak_memory,
+                                                   total_gpu_memory, fraction,
+                                                   allocated_bytes)
+
+        max_attention_window = executor_config.kv_cache_config.max_attention_window
+        is_vswa = max_attention_window and len(max_attention_window) > 1
+
+        # NOTE:
+        # KvCacheCreator currently controls KV-cache capacity using two parameters in KVCacheConfig:
+        #   • max_tokens
+        #   • max_gpu_total_bytes
+        # Ideally, the internal logic would rely solely on max_gpu_total_bytes,
+        # leaving max_tokens as a user-defined constraint.
+
+        # ---------------------------handle max_tokens---------------------------------
+        # if user provided max_tokens, calculate max memory from max_tokens
         if self._max_kv_tokens_in is not None:
-            kv_cache_max_tokens = min(kv_cache_max_tokens,
-                                      self._max_kv_tokens_in)
+            # raise error if it is VSWA case
+            if is_vswa:
+                logger.warning(
+                    "max_tokens should not be set for VSWA case as it is ambiguous concept for VSWA."
+                )
+            # calculate max memory from max_tokens
+            kv_cache_max_memory_from_max_tokens = self._max_kv_tokens_in * self._get_kv_size_per_token(
+            )
+            kv_cache_max_memory = min(kv_cache_max_memory,
+                                      kv_cache_max_memory_from_max_tokens)
+            logger.info(
+                f"max_tokens={self._max_kv_tokens_in} is provided, max_memory is set to {kv_cache_max_memory / (GB):.2f} GiB"
+            )
+        if is_vswa:
+            # For VSWA KvCacheManager now it can only use max_gpu_total_bytes
+            executor_config.kv_cache_config.max_tokens = None
+        else:
+            # For non-VSWA KvCacheManager, its logic still relies on max_tokens, need to improve in the future.
+            executor_config.kv_cache_config.max_tokens = int(
+                kv_cache_max_memory // self._get_kv_size_per_token())
+        # ---------------------------handle max_tokens---------------------------------
 
-        logger.info(f"Estimated max tokens in KV cache : {kv_cache_max_tokens}")
-        executor_config.kv_cache_config.max_tokens = kv_cache_max_tokens
+        # ---------------------------handle max_gpu_total_bytes---------------------------------
+        # if user provided max_gpu_total_bytes, set max memory from max_gpu_total_bytes
+        if executor_config.kv_cache_config.max_gpu_total_bytes > 0:
+            kv_cache_max_memory = min(
+                kv_cache_max_memory,
+                executor_config.kv_cache_config.max_gpu_total_bytes)
+            logger.info(
+                f"max_gpu_total_bytes={executor_config.kv_cache_config.max_gpu_total_bytes / (GB):.2f} GiB is provided, max_memory is set to {kv_cache_max_memory / (GB):.2f} GiB"
+            )
+
+        logger.info(
+            f"Estimated max memory in KV cache : {kv_cache_max_memory / (GB):.2f} GiB"
+        )
+        # set max_gpu_total_bytes
+        executor_config.kv_cache_config.max_gpu_total_bytes = kv_cache_max_memory
+        # ---------------------------handle max_gpu_total_bytes---------------------------------
 
     def _create_kv_cache_manager(
             self, model_engine: PyTorchModelEngine) -> KVCacheManager:

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -287,7 +287,7 @@ class KvCacheCreator:
                                                    allocated_bytes)
 
         max_attention_window = executor_config.kv_cache_config.max_attention_window
-        is_vswa = max_attention_window and len(max_attention_window) > 1
+        is_vswa = max_attention_window and len(set(max_attention_window)) > 1
 
         # NOTE:
         # KvCacheCreator currently controls KV-cache capacity using two parameters in KVCacheConfig:

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -193,12 +193,8 @@ class KvCacheCreator:
         estimating_kv_cache = False
         if 'cp_type' not in self._mapping.cp_config:
             estimating_kv_cache = True
-            max_attention_window_from_config = self._executor_config.kv_cache_config.max_attention_window
-            max_seq_len = max(
-                max_attention_window_from_config
-            ) if max_attention_window_from_config is not None else self._executor_config.max_seq_len
-            self._executor_config.kv_cache_config.max_tokens = max(
-                self._get_token_num_for_estimation(), max_seq_len)
+            self._executor_config.kv_cache_config.max_tokens = self._get_token_num_for_estimation(
+            )
         return estimating_kv_cache
 
     def configure_kv_cache_capacity(self, py_executor: PyExecutor) -> None:

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -428,7 +428,7 @@ def create_py_executor(
         assert kv_cache_creator is not None
         with mem_monitor.observe_creation_stage(
                 _ExecutorCreationStage.MODEL_EXTRA):
-            kv_cache_creator.estimate_max_tokens(py_executor)
+            kv_cache_creator.configure_kv_cache_capacity(py_executor)
         kv_cache_creator.teardown_managers(resources)
         del py_executor  # free before constructing new
 

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -250,7 +250,7 @@ class KVCacheManager(BaseResourceManager):
                              else 0)
 
         # Determine if this is VSWA (Variable Sliding Window Attention)
-        self.is_vswa = len(self.max_attention_window_vec) > 1
+        self.is_vswa = len(set(self.max_attention_window_vec)) > 1
 
         # Calculate blocks per window using appropriate method
         if self.is_vswa:

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -991,6 +991,11 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
     )
     use_uvm: bool = Field(default=False,
                           description="Whether to use UVM for the KV cache.")
+    max_gpu_total_bytes: int = Field(
+        default=0,
+        description=
+        "The maximum size in bytes of GPU memory that can be allocated for the KV cache. If both `max_gpu_total_bytes` and `free_gpu_memory_fraction` are specified, memory corresponding to the minimum will be allocated."
+    )
 
     # This is a pure python field, not a pybind field. It is only for the Pytorch backend.
     dtype: str = Field(default="auto",
@@ -1021,7 +1026,15 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
             use_uvm=self.use_uvm,
             attention_dp_events_gather_period_ms=self.
             attention_dp_events_gather_period_ms,
-        )
+            max_gpu_total_bytes=self.max_gpu_total_bytes)
+
+    @field_validator('max_gpu_total_bytes')
+    @classmethod
+    def validate_max_gpu_total_bytes(cls, v: int):
+        if v < 0:
+            raise ValueError(
+                "kv_cache_config.max_gpu_total_bytes must be non-negative")
+        return v
 
 
 @PybindMirror.mirror_pybind_fields(_ExtendedRuntimePerfKnobConfig)

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1057,14 +1057,6 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
                 raise ValueError(
                     "kv_cache_config.max_attention_window values must be positive"
                 )
-
-        # Must not be a redundant repetition of a shorter pattern
-        n = len(v)
-        for k in range(1, n):
-            if n % k == 0 and v == v[:k] * (n // k):
-                raise ValueError(
-                    f"kv_cache_config.max_attention_window should contain only the minimal repeating pattern; use {v[:k]} instead of {v}"
-                )
         return v
 
 

--- a/tests/integration/defs/conftest.py
+++ b/tests/integration/defs/conftest.py
@@ -2386,3 +2386,12 @@ def timeout_manager(timeout_from_command_line, timeout_from_marker):
         timeout_value = timeout_from_command_line
 
     return TimeoutManager(timeout_value)
+
+
+@pytest.fixture
+def torch_empty_cache() -> None:
+    """
+    Manually empty the torch CUDA cache before each test, to reduce risk of OOM errors.
+    """
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()

--- a/tests/integration/defs/disaggregated/test_disaggregated_single_gpu.py
+++ b/tests/integration/defs/disaggregated/test_disaggregated_single_gpu.py
@@ -350,6 +350,7 @@ def test_disaggregated_llama_context_capacity(model, enable_cuda_graph,
 @pytest.mark.parametrize("spec_dec_model_path", ["EAGLE3-LLaMA3.1-Instruct-8B"])
 @pytest.mark.parametrize("generation_overlap", [False])
 @pytest.mark.parametrize("eagle3_one_model", [True, False])
+@pytest.mark.usefixtures("torch_empty_cache")
 def test_disaggregated_spec_dec_batch_slot_limit(model, spec_dec_model_path,
                                                  generation_overlap,
                                                  eagle3_one_model):

--- a/tests/unittest/_torch/executor/test_resource_manager.py
+++ b/tests/unittest/_torch/executor/test_resource_manager.py
@@ -3,6 +3,8 @@ import pathlib
 import subprocess
 import sys
 import unittest
+from typing import NamedTuple, Tuple
+from unittest.mock import patch
 
 import numpy as np
 import torch
@@ -13,11 +15,13 @@ from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest
 from tensorrt_llm._torch.pyexecutor.resource_manager import (KVCacheManager,
                                                              PeftCacheConfig,
                                                              PeftCacheManager)
+from tensorrt_llm.bindings import LayerType
 from tensorrt_llm.bindings import ModelConfig as ModelConfigCpp
 from tensorrt_llm.bindings import executor as tllm
 from tensorrt_llm.bindings.internal.batch_manager import \
     PeftTaskNotCachedException
 from tensorrt_llm.lora_helper import LoraConfig
+from tensorrt_llm.mapping import Mapping
 
 DataType = tensorrt_llm.bindings.DataType
 LoraModule = tensorrt_llm.bindings.LoraModule
@@ -543,6 +547,148 @@ class TestResourceManager(unittest.TestCase):
                     f"Memory bytes: {memory_bytes}\n"
                     f"Actual: {adjusted_max_attention_window_vec}\n"
                     f"Expected: {expected_max_attention_window_vec}")
+
+    @staticmethod
+    def _create_model_config_for_kv_cache_manager() -> ModelConfigCpp:
+        """
+        Create a simple model config for KVCacheManager test.
+        """
+
+        model_config_params = {
+            "vocab_size": 0,
+            "num_layers": 4,
+            "num_attention_layers": 4,
+            "num_rnn_layers": 0,
+            "num_heads": 64,
+            "hidden_size": 64,
+            "data_type": DataType.HALF
+        }
+        num_kv_heads = 8
+
+        model_config = ModelConfigCpp(**model_config_params)
+        model_config.layer_types = [LayerType.ATTENTION
+                                    ] * model_config.num_attention_layers()
+        model_config.set_num_kv_heads(num_kv_heads)
+
+        return model_config
+
+    @staticmethod
+    def _create_kv_cache_config_for_kv_cache_manager(
+            params: dict) -> tllm.KvCacheConfig:
+        """
+        Create a KV cache config for KVCacheManager test.
+        """
+        return tllm.KvCacheConfig(**params)
+
+    def test_calculate_max_num_blocks_from_cpp(self):
+        # Construct a minimal mapping (single-rank, no TP/PP)
+        mapping = Mapping(world_size=1, tp_size=1, pp_size=1)
+
+        # Construct model config
+        model_config = TestResourceManager._create_model_config_for_kv_cache_manager(
+        )
+
+        # Construct KV cache config
+        free_gpu_memory_fraction = 0.1
+        max_attention_window = [64, 128]
+        max_gpu_total_bytes = 32 * 1024 * 1024  # 32MB
+        enable_block_reuse = False
+        host_cache_size = 32 * 1024 * 1024  # 32MB
+
+        # mock values for torch.cuda.mem_get_info to return a fixed value
+        fixed_free_mem = 128 * 1024 * 1024  # 128MB
+        fixed_total_mem = 256 * 1024 * 1024  # 256MB
+
+        class MemTestCase(NamedTuple):
+            case_name: str
+            kv_cache_config_params: dict
+            expected_memory_bytes: Tuple[
+                int,
+                int]  # (primary_pool_memory_bytes, secondary_pool_memory_bytes)
+
+        test_cases = [
+            # Case 1:
+            # max_gpu_total_bytes is set, even if free_gpu_memory_fraction is set, we will use max_gpu_total_bytes
+            # host_cache_size is set, we will use host_cache_size
+            MemTestCase(
+                case_name="max_gpu_total_bytes is set, host_cache_size is set",
+                kv_cache_config_params={
+                    "max_attention_window": max_attention_window,
+                    "free_gpu_memory_fraction": free_gpu_memory_fraction,
+                    "max_gpu_total_bytes": max_gpu_total_bytes,
+                    "enable_block_reuse": enable_block_reuse,
+                    "host_cache_size": host_cache_size,
+                },
+                expected_memory_bytes=(max_gpu_total_bytes, host_cache_size),
+            ),
+
+            # Case 2:
+            # max_gpu_total_bytes is not set, we will use free_gpu_memory_fraction
+            # host_cache_size is not set, we will use 0
+            MemTestCase(
+                case_name=
+                "max_gpu_total_bytes is not set, host_cache_size is not set",
+                kv_cache_config_params={
+                    "max_attention_window": max_attention_window,
+                    "free_gpu_memory_fraction": free_gpu_memory_fraction,
+                    "enable_block_reuse": enable_block_reuse,
+                },
+                # NOTE: use np.float32 to avoid float precision issue between python(double in most cases) and cpp binding(float)
+                expected_memory_bytes=(int(
+                    fixed_free_mem * np.float32(free_gpu_memory_fraction)), 0),
+            ),
+        ]
+
+        tokens_per_block = 32
+        model_config.tokens_per_block = tokens_per_block
+        max_seq_len = max(max_attention_window)
+        max_batch_size = 1
+        max_beam_width = 1
+
+        for case_name, kv_cache_config_params, expected_memory_bytes in test_cases:
+            with self.subTest(case=case_name):
+                kv_cache_config = TestResourceManager._create_kv_cache_config_for_kv_cache_manager(
+                    kv_cache_config_params)
+                with patch('torch.cuda.mem_get_info',
+                           return_value=(fixed_free_mem, fixed_total_mem)):
+                    # Create a real KVCacheManager, it will run calculate_max_num_blocks_from_cpp in __init__
+                    manager = KVCacheManager(
+                        kv_cache_config=kv_cache_config,
+                        kv_cache_type=tensorrt_llm.bindings.internal.
+                        batch_manager.CacheType.SELF,
+                        num_layers=model_config.num_attention_layers(),
+                        num_kv_heads=model_config.num_kv_heads(
+                            0
+                        ),  # NOTE: assume same number of kv heads for all layers
+                        head_dim=model_config.head_size,
+                        tokens_per_block=tokens_per_block,
+                        max_seq_len=max_seq_len,
+                        max_batch_size=max_batch_size,
+                        mapping=mapping,
+                        dtype=model_config.data_type,
+                        model_config=model_config,
+                        max_beam_width=max_beam_width,
+                    )
+                    try:
+                        expected_primary, expected_secondary = expected_memory_bytes
+                        self.assertEqual(
+                            manager._primary_pool_memory_bytes,
+                            expected_primary,
+                            f"Test case '{case_name}' failed.\n"
+                            f"Expected primary pool memory bytes: {expected_primary}\n"
+                            f"Actual primary pool memory bytes: {manager._primary_pool_memory_bytes}"
+                        )
+                        self.assertEqual(
+                            manager._secondary_pool_memory_bytes,
+                            expected_secondary,
+                            f"Test case '{case_name}' failed.\n"
+                            f"Expected secondary pool memory bytes: {expected_secondary}\n"
+                            f"Actual secondary pool memory bytes: {manager._secondary_pool_memory_bytes}"
+                        )
+                    except Exception as e:
+                        self.fail(f"Test case '{case_name}' failed: {e}")
+                    finally:
+                        manager.shutdown()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# fix/improve kvcache allocation in PyTorch runtime

## Background
We found significant memory under-allocation when using VSWA KvCacheManager. One reason is that PyTorch runtime uses estimated 'max_tokens' to constrain KV cache allocation, while 'max_tokens' is a strange(and potentially ambiguous) concept in Variable Sliding Window Attention KV Cache.

## TL;DR
Previously, we used `max_tokens` to limit the KV cache memory usage, but that method didn't work for VSWA's KV cache. This PR refines the KV cache estimation logic (mainly in `KVCacheCreator`) by directly enforcing a memory size limit. 
Besides, this PR also contains these minor fixes:
1. Improve estimation phase to avoid potential OOM issues for long sequence with CUDA Graph.
2. Add optional `torch.cuda.empty_cache` pytest fixture to avoid potential OOM in CI
Big shout out to @jaedeok-nvidia, @ixlmar and @Funatiq for their suggestions and reviews!

## Description

Currently, the PyTorch path includes a [step](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py#L396) that estimates available free memory for the KV cache, calculates the corresponding 'max_tokens', and [updates](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/_torch/pyexecutor/_util.py#L267) the kv_cache_config accordingly.


However, the existing logic significantly limits memory allocation, as it assumes a homogeneous attention model ([nvbug](https://nvbugspro.nvidia.com/bug/5380887)). 

Additionally, the 'max_tokens' concept doesn't align well with VSWA scenarios, as its definition is "_The maximum number of tokens that should be stored in the KV cache_". In VSWA case, "tokens stored in KV cache" is a bit "coarse-grained", as the in-window tokens are "fully in KV cache", while the out-of-window tokens are "partially in KV cache" because of non-homogeneous attention.

## Proposed Solution 

An alternative approach could be to **directly compute the allocated memory size during the estimation step**.

### Advantages:
1. Aligns naturally with the block distribution function `KVCacheManagerCpp.calculate_max_num_blocks` ([link](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/_torch/pyexecutor/resource_manager.py#L642)), which already expects a memory size parameter.
3. Provides greater flexibility, particularly beneficial for future scenarios such as dynamic memory allocation in VSWA.

### Implementation Details

1. This PR introduces a new field, `mMaxGpuTotalBytes` (exposed as `max_gpu_total_bytes` in Python), in `KvCacheConfig`.  
2. Currently, `KvCacheCreator` is responsible for building and estimating KV caches. With this PR, it also calculates the estimated in-memory size of the KV cache and uses the `max_gpu_total_bytes` setting from `KvCacheConfig` to limit memory allocation.  
4. Within `KVCacheManager`, the VSWA path uses a C++ binding function (see `calculate_max_num_blocks_from_cpp`) that takes a memory size as input to determine KV blocks. For non-VSWA cases, it still uses its own Python function, but future efforts aim to unify both approaches, as discussed [here](https://nvidia.slack.com/archives/C059LSY62BT/p1748549582863269).

### ~~"Hack" to achieve this~~
~~One hack is to interpret `freeGpuMemoryFraction` as **the fraction of total GPU memory** reserved for the KV cache. This allows us to avoid adding an extra field, but we should clearly document this usage to prevent confusion. (Perhaps add a clarifying comment in the code?)~~
 
## Test Coverage
`tests/unittest/_torch/test_resource_manager.py`
<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Add option to cap KV-cache GPU memory via max_gpu_total_bytes (used with existing fraction limit).
  - KV-cache stats now report allocated GPU bytes; exposed in Python.
  - Automatic KV-cache sizing moved to a memory-based approach, accounting for main/draft models and VSWA.

- **Refactor**
  - Public API renamed: estimate_max_tokens → configure_kv_cache_capacity; executor creation uses the new flow.

- **Tests**
  - New fixture clears CUDA cache before tests; applied to an existing disaggregated single-GPU test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->