### PR TITLE
fix: Fix Build Error in Local User Container

### DIFF
--- a/docker/Dockerfile.multi
+++ b/docker/Dockerfile.multi
@@ -87,6 +87,10 @@ RUN pip3 install --upgrade --no-cache-dir \
     "protobuf>=4.25.8" \
     "jupyter-core>=5.8.1"
 
+# WAR: build containers only contain stub version of libnvidia-ml.so and not the real version.
+# Need to create symbolic link to prevent errors.
+RUN ln -s libnvidia-ml.so $(find /usr -name *libnvidia-ml.so).1
+
 FROM ${TRITON_IMAGE}:${TRITON_BASE_TAG} AS triton
 
 FROM devel AS tritondevel

--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -723,27 +723,15 @@ def main(*,
                     if 'LD_LIBRARY_PATH' in env_ld:
                         new_library_path += f":{env_ld['LD_LIBRARY_PATH']}"
 
-                    result = build_run("find /usr -name *libnvidia-ml.so*",
+                    result = build_run("find /usr -name *libnvidia-ml.so.1",
                                        capture_output=True,
                                        text=True)
-                    assert result.returncode == 0, f"Failed to run find *libnvidia-ml.so*: {result.stderr}"
-
-                    # Build containers only contain stub version of libnvidia-ml.so and not the real version.
-                    # If real version not in system, we need to create symbolic link to stub version to prevent import errors.
+                    assert result.returncode == 0, f"Failed to run find *libnvidia-ml.so.1: {result.stderr}"
                     if "libnvidia-ml.so.1" not in result.stdout:
-                        if "libnvidia-ml.so" in result.stdout:
-                            line = result.stdout.splitlines()[0]
-                            path = os.path.dirname(line)
-                            new_library_path += f":{path}"
-                            sudo_prefix = "sudo " if os.geteuid() != 0 else ""
-                            build_run(
-                                f"{sudo_prefix}ln -s {line} {path}/libnvidia-ml.so.1"
-                            )
-                        else:
-                            print(
-                                f"Failed to find libnvidia-ml.so: {result.stderr}",
-                                file=sys.stderr)
-                            exit(1)
+                        print(
+                            f"Failed to find libnvidia-ml.so.1: {result.stderr}",
+                            file=sys.stderr)
+                        exit(1)
 
                     env_ld["LD_LIBRARY_PATH"] = new_library_path
                     if binding_type == "nanobind":

--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -735,7 +735,10 @@ def main(*,
                             line = result.stdout.splitlines()[0]
                             path = os.path.dirname(line)
                             new_library_path += f":{path}"
-                            build_run(f"ln -s {line} {path}/libnvidia-ml.so.1")
+                            sudo_prefix = "sudo " if os.geteuid() != 0 else ""
+                            build_run(
+                                f"{sudo_prefix}ln -s {line} {path}/libnvidia-ml.so.1"
+                            )
                         else:
                             print(
                                 f"Failed to find libnvidia-ml.so: {result.stderr}",


### PR DESCRIPTION
# fix: Fix Build Error in Local User Container

## Description

When building TRT-LLM in a local user container started by `make -C docker run LOCAL_USER=1`, will meet the following error:

```
ln: failed to create symbolic link '/usr/local/cuda-12.9/targets/x86_64-linux/lib/stubs/libnvidia-ml.so.1': Permission denied
Traceback (most recent call last):
  File "/code/tensorrt_llm/scripts/build_wheel.py", line 855, in <module>
    main(**vars(args))
  File "/code/tensorrt_llm/scripts/build_wheel.py", line 697, in main
    build_run(f"ln -s {line} {path}/libnvidia-ml.so.1")
  File "/usr/lib/python3.12/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command 'ln -s /usr/local/cuda-12.9/targets/x86_64-linux/lib/stubs/libnvidia-ml.so /usr/local/cuda-12.9/targets/x86_64-linux/lib/stubs/libnvidia-ml.so.1' returned non-zero exit status 1.
```

This MR adds `sudo` to the command if current user is not `root`.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of NVIDIA library detection in build scripts to prevent errors related to missing or stubbed `libnvidia-ml.so.1` in containers.
  * Enhanced error messaging and script reliability when required NVIDIA libraries are not found during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->