### PR TITLE
[fix] Add detokenization-based stop word logic to LLM API

### DIFF
--- a/tensorrt_llm/executor/result.py
+++ b/tensorrt_llm/executor/result.py
@@ -139,10 +139,12 @@ class GenerationResultBase:
                  id: int,
                  sampling_params: SamplingParams,
                  background_error_handler: Optional[Callable] = None,
-                 postproc_params: "Optional[PostprocParams]" = None):
+                 postproc_params: "Optional[PostprocParams]" = None,
+                 streaming: bool = False):
         self.id = id
         self.sampling_params = sampling_params
         self.postproc_params = postproc_params
+        self._streaming = streaming
         self.disaggregated_params = None
         self.decoding_iter = 0
         self._done = False
@@ -197,6 +199,71 @@ class GenerationResultBase:
     def context_logits(self) -> Optional[torch.Tensor]:
         return self._context_logits
 
+    def _handle_streaming_stop_detection(self, output, new_tokens):
+        """Handle stop word detection for streaming responses"""
+        if not self.sampling_params.stop:
+            return False
+
+        if not hasattr(self, '_streaming_state'):
+            self._streaming_state = {}
+
+        # Get or initialize accumulated text for THIS SPECIFIC output
+        output_id = id(output)
+        if output_id not in self._streaming_state:
+            self._streaming_state[output_id] = {"accumulated_text": ""}
+
+        accumulated_text = self._streaming_state[output_id]["accumulated_text"]
+
+        if not hasattr(self, 'tokenizer') or self.tokenizer is None:
+            print(f"DEBUG: ERROR - No tokenizer for streaming!")
+            return False
+
+        new_text = self.tokenizer.decode(new_tokens, skip_special_tokens=True)
+        full_text = accumulated_text + new_text
+
+        print(f"DEBUG: Streaming - accumulated: '{accumulated_text}'")
+        print(f"DEBUG: Streaming - new text: '{new_text}'")
+        print(f"DEBUG: Streaming - full text: '{full_text}'")
+
+        for stop_reason, _ in self.sampling_params._get_stop_reasons_and_words(
+        ):
+            if isinstance(stop_reason, str) and stop_reason in full_text:
+                print(f"DEBUG: Streaming - found stop word '{stop_reason}'!")
+
+                stop_pos = full_text.find(stop_reason)
+                if not self.sampling_params.include_stop_str_in_output:
+                    truncated_text = full_text[:stop_pos]
+                else:
+                    truncated_text = full_text[:stop_pos + len(stop_reason)]
+
+                print(f"DEBUG: Before update - output.text: '{output.text}'")
+                print(
+                    f"DEBUG: Before update - output._last_text_len: {output._last_text_len}"
+                )
+
+                output.token_ids = self.tokenizer.encode(
+                    truncated_text, add_special_tokens=False)
+                output.text = truncated_text
+                output.finish_reason = 'stop'
+                output.stop_reason = stop_reason
+
+                print(f"DEBUG: After update - output.text: '{output.text}'")
+                print(
+                    f"DEBUG: After update - output._last_text_len: {output._last_text_len}"
+                )
+                print(
+                    f"DEBUG: After update - output.text_diff: '{output.text_diff}'"
+                )
+
+                if output_id in self._streaming_state:
+                    del self._streaming_state[output_id]
+
+                print(f"DEBUG: Streaming - truncated to: '{truncated_text}'")
+                return True
+
+        self._streaming_state[output_id]["accumulated_text"] = full_text
+        return False
+
     def _handle_sequence(self,
                          finish_reasons,
                          response_tensors,
@@ -204,16 +271,36 @@ class GenerationResultBase:
                          logprobs_result=None):
         """ Handle a single sequence in the response. """
 
+        print(
+            f"DEBUG: _handle_sequence called - sequence_index: {sequence_index}"
+        )
+        print(f"DEBUG: finish_reasons: {finish_reasons}")
+        print(
+            f"DEBUG: finish_reason for this sequence: {finish_reasons[sequence_index] if sequence_index < len(finish_reasons) else 'N/A'}"
+        )
+
         seq_idx = sequence_index
         src_idx = sequence_index if self.sampling_params.use_beam_search else 0
 
         output = self._outputs[seq_idx]
         output.disaggregated_params = self.disaggregated_params
         output._last_token_ids_len = len(output.token_ids)
+
+        # Get new tokens for this step
+        new_tokens = response_tensors.output_token_ids[src_idx]
+
         if self.sampling_params.use_beam_search:
             # Beam search enforces returning all generated tokens
             output.token_ids = response_tensors.output_token_ids[src_idx]
         else:
+            if self._streaming and self.sampling_params.stop:
+                print(
+                    f"DEBUG: Streaming stop detection - new tokens: {new_tokens}"
+                )
+                if self._handle_streaming_stop_detection(output, new_tokens):
+                    print(f"DEBUG: Stop word detected in streaming mode!")
+                    self._done = True
+                    return
             output.token_ids.extend(response_tensors.output_token_ids[src_idx])
 
         if response_tensors.cum_log_probs is not None:
@@ -247,19 +334,91 @@ class GenerationResultBase:
             output.request_perf_metrics = response_tensors.request_perf_metrics
 
         if self._done:
+            print(
+                f"DEBUG: About to check finish_reason: {finish_reasons[src_idx]}"
+            )
+
             if finish_reasons[src_idx] == tllm.FinishReason.END_ID:
                 output.finish_reason = 'stop'
-            elif finish_reasons[src_idx] == tllm.FinishReason.STOP_WORDS:
-                output.finish_reason = 'stop'
-                for stop_reason, stop_ids in self.sampling_params._get_stop_reasons_and_words(
-                ):
-                    if output.token_ids[-len(stop_ids):] == stop_ids:
-                        output.stop_reason = stop_reason
-                        if not self.sampling_params.include_stop_str_in_output:
-                            output.token_ids = output.token_ids[:-len(stop_ids)]
-                        break
+            # elif finish_reasons[src_idx] == tllm.FinishReason.STOP_WORDS:
+            #     output.finish_reason = 'stop'
+            #     for stop_reason, stop_ids in self.sampling_params._get_stop_reasons_and_words(
+            #     ):
+            #         if output.token_ids[-len(stop_ids):] == stop_ids:
+            #             output.stop_reason = stop_reason
+            #             if not self.sampling_params.include_stop_str_in_output:
+            #                 output.token_ids = output.token_ids[:-len(stop_ids)]
+            #             break
+            # elif finish_reasons[src_idx] == tllm.FinishReason.LENGTH:
+            #     output.finish_reason = 'length'
             elif finish_reasons[src_idx] == tllm.FinishReason.LENGTH:
-                output.finish_reason = 'length'
+                # For non-streaming or when streaming is complete
+                if not self._streaming or not self.sampling_params.stop:
+                    print(f"DEBUG: ENTERING LENGTH PROCESSING!")
+
+                    print(
+                        f"DEBUG: self has tokenizer: {hasattr(self, 'tokenizer')}"
+                    )
+                    if hasattr(self, 'tokenizer'):
+                        print(f"DEBUG: tokenizer is: {self.tokenizer}")
+                    else:
+                        print(f"DEBUG: No tokenizer found!")
+                        output.finish_reason = 'length'
+
+                    print(
+                        f"DEBUG: About to detokenize {len(output.token_ids)} tokens"
+                    )
+                    print(f"DEBUG: Token IDs: {output.token_ids}")
+
+                    generated_text = self.tokenizer.decode(
+                        output.token_ids, skip_special_tokens=True)
+                    print(f"DEBUG: Detokenized text: '{generated_text}'")
+
+                    print(
+                        f"DEBUG: About to check stop words: {self.sampling_params.stop}"
+                    )
+
+                    for stop_reason, _ in self.sampling_params._get_stop_reasons_and_words(
+                    ):
+                        print(f"DEBUG: Checking stop_reason: {stop_reason}")
+                        if isinstance(stop_reason,
+                                      str) and stop_reason in generated_text:
+                            print(
+                                f"DEBUG: FOUND STOP WORD '{stop_reason}' in text!"
+                            )
+                            output.finish_reason = 'stop'
+                            output.stop_reason = stop_reason
+
+                            stop_pos = generated_text.find(stop_reason)
+                            print(
+                                f"DEBUG: Stop word found at position: {stop_pos}"
+                            )
+
+                            if not self.sampling_params.include_stop_str_in_output:
+                                truncated_text = generated_text[:stop_pos]
+                                output.token_ids = self.tokenizer.encode(
+                                    truncated_text, add_special_tokens=False)
+                                print(
+                                    f"DEBUG: Truncated text (excluded stop word): '{truncated_text}'"
+                                )
+                            else:
+                                truncated_text = generated_text[:stop_pos +
+                                                                len(stop_reason
+                                                                    )]
+                                output.token_ids = self.tokenizer.encode(
+                                    truncated_text, add_special_tokens=False)
+                                print(
+                                    f"DEBUG: Truncated text (included stop word): '{truncated_text}'"
+                                )
+                            break
+                    else:
+                        print(
+                            f"DEBUG: No stop words found, setting finish_reason to 'length'"
+                        )
+                        output.finish_reason = 'length'
+                else:
+                    # For streaming, stop detection already happened above
+                    output.finish_reason = 'length'
             elif finish_reasons[src_idx] == tllm.FinishReason.TIMED_OUT:
                 output.finish_reason = 'timeout'
             # For disaggregated serving, finish reason might be NOT_FINISHED which is ok
@@ -278,6 +437,10 @@ class GenerationResultBase:
     def _handle_response(self,
                          response: Union["PostprocWorker.Output", tllm.Response,
                                          ResponseWrapper, ErrorResponse]):
+        print(
+            f"DEBUG: _handle_response called with response type: {type(response)}"
+        )
+
         if isinstance(response, ResponseWrapper):
             logprobs_result = response.logprobs
             response = response._response
@@ -297,6 +460,7 @@ class GenerationResultBase:
                         handler := self._background_error_handler()):
                     handler(response.error)
         elif is_llm_response(response):
+            print(f"DEBUG: Processing LLM response")
             if response.has_error():
                 if self._background_error_handler is not None and (
                         handler := self._background_error_handler()):
@@ -318,6 +482,7 @@ class GenerationResultBase:
                     draft_tokens=context_phase_params.draft_tokens)
 
             finish_reasons = response_result.finish_reasons
+            print(f"DEBUG: finish_reasons: {finish_reasons}")
             # output_token_ids = (beams, tokens)
             if self.sampling_params.use_beam_search:
                 for beam_idx, _ in enumerate(response_result.output_token_ids):
@@ -422,6 +587,7 @@ class GenerationResult(GenerationResultBase):
             generation_request.sampling_params,
             background_error_handler,
             postproc_params=generation_request.postproc_params,
+            streaming=generation_request.streaming,
         )
         self._generation_request = generation_request
         self._streaming = generation_request.streaming

--- a/tensorrt_llm/executor/result.py
+++ b/tensorrt_llm/executor/result.py
@@ -369,7 +369,8 @@ class GenerationResultBase:
                     tokenizer = None
                     if (self.postproc_params
                             and self.postproc_params.postproc_args
-                            and self.postproc_params.postproc_args.tokenizer):
+                            and self.postproc_params.postproc_args.tokenizer
+                            is not None):
                         tokenizer = self.postproc_params.postproc_args.tokenizer
                     elif hasattr(self,
                                  'tokenizer') and self.tokenizer is not None:

--- a/tensorrt_llm/executor/result.py
+++ b/tensorrt_llm/executor/result.py
@@ -228,6 +228,10 @@ class GenerationResultBase:
             output.logprobs = response_tensors.log_probs[src_idx]
             # overcome some WAR in the cpp executor
             if finish_reasons[src_idx] != tllm.FinishReason.CANCELLED:
+                if len(output.logprobs) > output.length:
+                    # LlmResult holds a reference to LogProbStorage, which may be updated by the worker before the result is serialized.
+                    # Therefore, we treat extra logprobs/logits as expected and only consume what's needed.
+                    output.logprobs = output.logprobs[:output.length]
                 assert len(output.logprobs) == output.length
         if response_tensors.generation_logits is not None:
             output.generation_logits = response_tensors.generation_logits[

--- a/tensorrt_llm/executor/result.py
+++ b/tensorrt_llm/executor/result.py
@@ -348,8 +348,8 @@ class GenerationResultBase:
                     if output_id in self._streaming_state:
                         del self._streaming_state[output_id]
 
-            if finish_reasons[src_idx] == tllm.FinishReason.END_ID:
-                output.finish_reason = 'stop'
+            # if finish_reasons[src_idx] == tllm.FinishReason.END_ID:
+            #     output.finish_reason = 'stop'
             # elif finish_reasons[src_idx] == tllm.FinishReason.STOP_WORDS:
             #     output.finish_reason = 'stop'
             #     for stop_reason, stop_ids in self.sampling_params._get_stop_reasons_and_words(
@@ -361,7 +361,16 @@ class GenerationResultBase:
             #             break
             # elif finish_reasons[src_idx] == tllm.FinishReason.LENGTH:
             #     output.finish_reason = 'length'
-            elif finish_reasons[src_idx] == tllm.FinishReason.LENGTH:
+            if (finish_reasons[src_idx] == tllm.FinishReason.END_ID
+                    or finish_reasons[src_idx] == tllm.FinishReason.LENGTH):
+
+                # For END_ID, set finish_reason to 'stop' initially
+                if finish_reasons[src_idx] == tllm.FinishReason.END_ID:
+                    output.finish_reason = 'stop'
+                # For END_ID, set finish_reason to 'length' initially
+                elif finish_reasons[src_idx] == tllm.FinishReason.LENGTH:
+                    output.finish_reason = 'length'
+
                 # For non-streaming or when streaming is complete
                 if not self._streaming or not self.sampling_params.stop:
                     print(f"DEBUG: ENTERING LENGTH PROCESSING!")
@@ -428,14 +437,12 @@ class GenerationResultBase:
                             print(
                                 f"DEBUG: No stop words found, setting finish_reason to 'length'"
                             )
-                            output.finish_reason = 'length'
                     else:
                         print(
                             f"DEBUG: No tokenizer available for detokenization")
-                        output.finish_reason = 'length'
                 else:
                     # For streaming, stop detection already happened above
-                    output.finish_reason = 'length'
+                    pass
             elif finish_reasons[src_idx] == tllm.FinishReason.TIMED_OUT:
                 output.finish_reason = 'timeout'
             # For disaggregated serving, finish reason might be NOT_FINISHED which is ok

--- a/tensorrt_llm/executor/result.py
+++ b/tensorrt_llm/executor/result.py
@@ -228,10 +228,6 @@ class GenerationResultBase:
             output.logprobs = response_tensors.log_probs[src_idx]
             # overcome some WAR in the cpp executor
             if finish_reasons[src_idx] != tllm.FinishReason.CANCELLED:
-                if len(output.logprobs) > output.length:
-                    # LlmResult holds a reference to LogProbStorage, which may be updated by the worker before the result is serialized.
-                    # Therefore, we treat extra logprobs/logits as expected and only consume what's needed.
-                    output.logprobs = output.logprobs[:output.length]
                 assert len(output.logprobs) == output.length
         if response_tensors.generation_logits is not None:
             output.generation_logits = response_tensors.generation_logits[
@@ -414,6 +410,7 @@ class DetokenizedGenerationResultBase(GenerationResultBase):
 
                             beam_output.finish_reason = 'stop'
                             beam_output.stop_reason = stop_reason
+                            self.abort()
                             self._done = True
                             break
 

--- a/tensorrt_llm/sampling_params.py
+++ b/tensorrt_llm/sampling_params.py
@@ -383,10 +383,6 @@ class SamplingParams:
         return self.return_generation_logits and not self._generation_logits_auto_enabled
 
     def _setup(self, tokenizer, add_special_tokens: bool = False) -> "SamplingParams":
-        print(
-            f"DEBUG: SamplingParams._setup - stop = {self.stop}, add_special_tokens = {add_special_tokens}"
-        )
-
         if self.end_id is None:
             self.end_id = tokenizer.eos_token_id
             self.pad_id = tokenizer.pad_token_id
@@ -401,11 +397,9 @@ class SamplingParams:
 
         if self.stop is not None:
             strs = [self.stop] if isinstance(self.stop, str) else self.stop
-            print(f"DEBUG: Tokenizing stop strings: {strs}")
             self._stop_word_ids = [
                 tokenizer.encode(s, add_special_tokens=add_special_tokens) for s in strs
             ]
-            print(f"DEBUG: _stop_word_ids = {self._stop_word_ids}")
 
         return self
 
@@ -429,23 +423,17 @@ class SamplingParams:
         if self.stop_token_ids:
             words = [[i] for i in self.stop_token_ids]
 
-        # Don't add _stop_word_ids since we're using detokenization-based detection
-        # This disables the C++ engine's token-based stop detection
-
-        # if self.stop is None:
-        #     return words
-        # else:
-        #     if self._stop_word_ids is None:
-        #         raise RuntimeError(
-        #             f"{self.__class__.__name__}.stop ({self.stop}) is not processed by tokenizer, "
-        #             "please call the setup method."
-        #         )
-        #     return words + self._stop_word_ids
-
-        return words
+        if self.stop is None:
+            return words
+        else:
+            if self._stop_word_ids is None:
+                raise RuntimeError(
+                    f"{self.__class__.__name__}.stop ({self.stop}) is not processed by tokenizer, "
+                    "please call the setup method."
+                )
+            return words + self._stop_word_ids
 
     def _get_stop_reasons_and_words(self) -> List[Tuple[Union[str, int], List[List[int]]]]:
-        print("DEBUG: _get_stop_reasons_and_words called")
         stop_reasons = []
         if self.stop_token_ids is not None:
             stop_reasons.extend(self.stop_token_ids)
@@ -454,11 +442,7 @@ class SamplingParams:
                 stop_reasons.append(self.stop)
             else:
                 stop_reasons.extend(self.stop)
-
-        # For detokenization-based approach, return empty word lists
-        stop_words = [[] for _ in stop_reasons]  # Empty lists for each stop reason
-        print(f"DEBUG: Returning stop_reasons: {stop_reasons}, stop_words: {stop_words}")
-
+        stop_words = self._get_stop_words()
         return list(zip(stop_reasons, stop_words))
 
     def _get_sampling_config(self) -> tllme.SamplingConfig:

--- a/tests/unittest/_torch/test_trtllm_sampler.py
+++ b/tests/unittest/_torch/test_trtllm_sampler.py
@@ -49,8 +49,8 @@ def test_trtllm_sampler(model_path, test_case):
         "The capital of Bolivia is",
     ]
 
-    expected_outputs = [["circumnavigation of the world."], ["Paris."],
-                        ["La Paz."]]
+    expected_outputs = [["circumnavigation of the world"], ["Paris"],
+                        ["La Paz"]]
 
     # Test configuration
     max_new_tokens = test_case["max_new_tokens"]


### PR DESCRIPTION
## Description

[fix] Add detokenization-based stop word logic to LLM API. Currently, stop words might get encoded differently depending on the context they appear in.

## Test Coverage

Tested with:

- Non-streaming:

```
curl -X 'POST' 'http://localhost:8000/v1/chat/completions' \
-H "Content-Type: application/json" \
-d '{
"model": "google/gemma-3-1b-it",
"messages": [
{
"role": "user",
"content": "Say exactly: Hello there! How can I help"
}
],
"stop": ["How"],
"max_tokens": 5,
"stream": false
}'

INFO:     ::1:56148 - "POST /v1/chat/completions HTTP/1.1" 200 OK
{"id":"chatcmpl-db9c85c72cee4be2941e7c1a258d3a72","object":"chat.completion","created":1752295720,"model":"google/gemma-3-1b-it","choices":[{"index":0,"message":{"role":"assistant","content":"Hello there! ","reasoning_content":null,"tool_calls":[]},"logprobs":null,"finish_reason":"stop","stop_reason":"How","disaggregated_params":null}],"usage":{"prompt_tokens":19,"total_tokens":23,"completion_tokens":4},"prompt_token_ids":null}
```

- Streaming:

```
curl -X 'POST' 'http://localhost:8000/v1/chat/completions' \
-H "Content-Type: application/json" \
-d '{
"model": "google/gemma-3-1b-it",
"messages": [
{
"role": "user",
"content": "Say exactly: Hello there! How can I help"
}
],
"stop": ["How"],
"max_tokens": 5,
"stream": true
}'

INFO:     ::1:59476 - "POST /v1/chat/completions HTTP/1.1" 200 OK
data: {"id":"chatcmpl-ec665de7e48744c18cca02f0b96e9509","object":"chat.completion.chunk","created":1752295062,"model":"google/gemma-3-1b-it","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[]}}]} 
data: {"id":"chatcmpl-802428fc6c794ef2b9919c782ac4e267","object":"chat.completion.chunk","created":1752295062,"model":"google/gemma-3-1b-it","choices":[{"index":0,"delta":{"content":"Hello","tool_calls":[]}}]}
data: {"id":"chatcmpl-5fa76b4661094e98b3a8852b4d6200ab","object":"chat.completion.chunk","created":1752295062,"model":"google/gemma-3-1b-it","choices":[{"index":0,"delta":{"content":" there","tool_calls":[]}}]}
data: {"id":"chatcmpl-f9779e1d504f4513834f4746ec27d745","object":"chat.completion.chunk","created":1752295062,"model":"google/gemma-3-1b-it","choices":[{"index":0,"delta":{"content":"!","tool_calls":[]}}]}
data: {"id":"chatcmpl-b8c5b73633524838abcf56aff064c2d4","object":"chat.completion.chunk","created":1752295063,"model":"google/gemma-3-1b-it","choices":[{"index":0,"delta":{"content":" ","tool_calls":[]},"finish_reason":"stop","stop_reason":"How"}]}
data: [DONE]
```

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting and handling stop words in generated text after detokenization, allowing output to be truncated based on specified stop strings.
* **Tests**
  * Introduced new tests to verify stop word detection and handling in both standard and streaming generation modes.
  * Updated test expectations to align with new stop word handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->