### PR TITLE
[nvbug/5308432] fix: extend triton exit time for test_llava

### DIFF
--- a/tests/integration/defs/triton_server/test_triton_llm.py
+++ b/tests/integration/defs/triton_server/test_triton_llm.py
@@ -2491,7 +2491,7 @@ def test_llava(
     # NOTE
     # Due to mpi init error, manually set PMIX_MCA_gds=hash (ref: https://github.com/open-mpi/ompi/issues/6981)
     check_call(
-        f"PMIX_MCA_gds=hash python3 {launch_server_py} --world_size=1 --model_repo={new_model_repo}",
+        f"PMIX_MCA_gds=hash python3 {launch_server_py} --world_size=1 --model_repo={new_model_repo} --exit_timeout=300",
         shell=True)
     check_server_ready()
     # Run Test

--- a/triton_backend/scripts/launch_triton_server.py
+++ b/triton_backend/scripts/launch_triton_server.py
@@ -187,13 +187,9 @@ def get_cmd(world_size,
             cmd += ['-n', '1']
         if trtllm_llmapi_launch:
             cmd += ['trtllm-llmapi-launch']
+        cmd += [tritonserver, f'--model-repository={model_repo}']
         if exit_timeout:
-            cmd += [
-                tritonserver, f'--model-repository={model_repo}',
-                f'--exit-timeout-secs={exit_timeout}'
-            ]
-        else:
-            cmd += [tritonserver, f'--model-repository={model_repo}']
+            cmd += [f'--exit-timeout-secs={exit_timeout}']
 
         # Add port configuration
         cmd = add_port_config(cmd, grpc_port, http_port, metrics_port)

--- a/triton_backend/scripts/launch_triton_server.py
+++ b/triton_backend/scripts/launch_triton_server.py
@@ -103,7 +103,12 @@ def parse_arguments():
         help='Launch tritonserver with trtllm-llmapi-launch',
         default=False,
     )
-
+    parser.add_argument(
+        '--exit_timeout',
+        type=int,
+        help='Exit timeout in seconds',
+        default=None,
+    )
     return parser.parse_args()
 
 
@@ -152,9 +157,20 @@ def add_port_config(cmd, grpc_port, http_port, metrics_port):
     return cmd
 
 
-def get_cmd(world_size, tritonserver, grpc_port, http_port, metrics_port,
-            model_repo, log, log_file, tensorrt_llm_model_name, oversubscribe,
-            multimodal_gpu0_cuda_mem_pool_bytes, no_mpi, trtllm_llmapi_launch):
+def get_cmd(world_size,
+            tritonserver,
+            grpc_port,
+            http_port,
+            metrics_port,
+            model_repo,
+            log,
+            log_file,
+            tensorrt_llm_model_name,
+            oversubscribe,
+            multimodal_gpu0_cuda_mem_pool_bytes,
+            no_mpi,
+            trtllm_llmapi_launch,
+            exit_timeout=None):
     if no_mpi:
         assert world_size == 1, "world size must be 1 when using no-mpi"
 
@@ -171,7 +187,13 @@ def get_cmd(world_size, tritonserver, grpc_port, http_port, metrics_port,
             cmd += ['-n', '1']
         if trtllm_llmapi_launch:
             cmd += ['trtllm-llmapi-launch']
-        cmd += [tritonserver, f'--model-repository={model_repo}']
+        if exit_timeout:
+            cmd += [
+                tritonserver, f'--model-repository={model_repo}',
+                f'--exit-timeout-secs={exit_timeout}'
+            ]
+        else:
+            cmd += [tritonserver, f'--model-repository={model_repo}']
 
         # Add port configuration
         cmd = add_port_config(cmd, grpc_port, http_port, metrics_port)
@@ -221,7 +243,7 @@ if __name__ == '__main__':
                   args.http_port, args.metrics_port, args.model_repo, args.log,
                   args.log_file, args.tensorrt_llm_model_name,
                   args.oversubscribe, args.multimodal_gpu0_cuda_mem_pool_bytes,
-                  args.no_mpi, args.trtllm_llmapi_launch)
+                  args.no_mpi, args.trtllm_llmapi_launch, args.exit_timeout)
     env = os.environ.copy()
     if args.multi_model:
         if not args.disable_spawn_processes:


### PR DESCRIPTION
# [nvbugs/5308432] 

Increase the default client timeout to 300.
- nvbugs/5308432
[TensorRT-LLM][L0][Post-Merge][main][release/0.20] [A30-Triton-Python-[Post-Merge]-1] / test_llava timeout

## Description

Please explain the issue and the solution in short.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
