### PR TITLE
feat: Update Gemma3 Vision Encoder

### DIFF
--- a/tensorrt_llm/_torch/models/__init__.py
+++ b/tensorrt_llm/_torch/models/__init__.py
@@ -5,7 +5,7 @@ from .modeling_bert import BertForSequenceClassification
 from .modeling_clip import CLIPVisionModel
 from .modeling_deepseekv3 import DeepseekV3ForCausalLM
 from .modeling_gemma3 import Gemma3ForCausalLM
-from .modeling_gemma3vl import Gemma3Model
+from .modeling_gemma3vl import Gemma3VLM
 from .modeling_hyperclovax import HCXVisionForCausalLM
 from .modeling_llama import LlamaForCausalLM
 from .modeling_llava_next import LlavaNextModel
@@ -31,8 +31,8 @@ __all__ = [
     "CLIPVisionModel",
     "DeepseekV3ForCausalLM",
     "Gemma3ForCausalLM",
+    "Gemma3VLM",
     "HCXVisionForCausalLM",
-    "Gemma3Model",
     "LlamaForCausalLM",
     "LlavaNextModel",
     "MistralForCausalLM",

--- a/tensorrt_llm/_torch/models/modeling_siglip.py
+++ b/tensorrt_llm/_torch/models/modeling_siglip.py
@@ -23,7 +23,9 @@ class SiglipVisionTransformer(nn.Module):
     For example, it is different from the regular SiglipVisionTransformer in the sense that it does not return a pooled output.
     """
 
-    def __init__(self, model_config: ModelConfig[SiglipVisionConfig]):
+    def __init__(self,
+                 model_config: ModelConfig[SiglipVisionConfig],
+                 use_post_layernorm: bool = False):
         super().__init__()
         config = model_config.pretrained_config
         self.config = config
@@ -32,6 +34,9 @@ class SiglipVisionTransformer(nn.Module):
         self.encoder = SiglipEncoder(model_config)
         if hasattr(config, "vision_use_head"):
             assert not config.vision_use_head, "Currently, we only support vision_use_head = False"
+        self.post_layernorm = nn.LayerNorm(
+            config.hidden_size,
+            eps=config.layer_norm_eps) if use_post_layernorm else nn.Identity()
 
     def forward(
         self,
@@ -52,16 +57,23 @@ class SiglipVisionTransformer(nn.Module):
             attn_metadata=attn_metadata,
         )
 
+        encoder_outputs_list = list(encoder_outputs)
+        encoder_outputs_list[-1] = self.post_layernorm(encoder_outputs_list[-1])
+        encoder_outputs = tuple(encoder_outputs_list)
+
         return encoder_outputs
 
 
 @register_auto_model("SiglipVisionModel")
 class SiglipVisionModel(nn.Module):
 
-    def __init__(self, model_config: ModelConfig[SiglipVisionConfig]):
+    def __init__(self,
+                 model_config: ModelConfig[SiglipVisionConfig],
+                 use_post_layernorm: bool = False):
         super().__init__()
         self.config = model_config.pretrained_config
-        self.vision_model = SiglipVisionTransformer(model_config)
+        self.vision_model = SiglipVisionTransformer(
+            model_config, use_post_layernorm=use_post_layernorm)
         self.model_config = model_config
         self.metadata_cls = get_attention_backend(
             model_config.attn_backend).Metadata

--- a/tests/integration/test_lists/qa/examples_test_list.txt
+++ b/tests/integration/test_lists/qa/examples_test_list.txt
@@ -522,6 +522,7 @@ test_e2e.py::test_ptp_quickstart_multimodal[qwen2.5-vl-7b-instruct-Qwen2.5-VL-7B
 test_e2e.py::test_ptp_quickstart_multimodal[mistral-small-3.1-24b-instruct-Mistral-Small-3.1-24B-Instruct-2503-image-True]
 test_e2e.py::test_ptp_quickstart_multimodal[mistral-small-3.1-24b-instruct-Mistral-Small-3.1-24B-Instruct-2503-image-False]
 test_e2e.py::test_ptp_quickstart_multimodal[gemma-3-27b-it-gemma/gemma-3-27b-it-image-False]
+test_e2e.py::test_ptp_quickstart_multimodal[gemma-3-27b-it-gemma/gemma-3-27b-it-image-True]
 test_e2e.py::test_ptp_quickstart_bert[VANILLA-BertForSequenceClassification-bert/bert-base-uncased-yelp-polarity]
 test_e2e.py::test_ptp_quickstart_bert[TRTLLM-BertForSequenceClassification-bert/bert-base-uncased-yelp-polarity]
 test_e2e.py::test_ptp_star_attention_example[Llama3.1-8B-BF16-llama-3.1-model/Meta-Llama-3.1-8B]

--- a/tests/integration/test_lists/test-db/l0_l40s.yml
+++ b/tests/integration/test_lists/test-db/l0_l40s.yml
@@ -17,6 +17,7 @@ l0_l40s:
   - unittest/_torch/modeling -k "modeling_mllama"
   - unittest/_torch/modeling -k "modeling_out_of_tree"
   - unittest/_torch/modeling -k "modeling_vila"
+  - unittest/_torch/modeling -k "modeling_siglip"
   - test_e2e.py::test_ptp_scaffolding[DeepSeek-R1-Distill-Qwen-7B-DeepSeek-R1/DeepSeek-R1-Distill-Qwen-7B]
   - test_e2e.py::test_ptp_quickstart_multimodal[NVILA-8B-FP16-vila/NVILA-8B-image-False]
   - test_e2e.py::test_ptp_quickstart_multimodal[NVILA-8B-FP16-vila/NVILA-8B-video-False]

--- a/tests/unittest/_torch/modeling/test_modeling_siglip.py
+++ b/tests/unittest/_torch/modeling/test_modeling_siglip.py
@@ -11,7 +11,7 @@ from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.models.modeling_siglip import SiglipVisionModel
 
 # use the default config from HF (https://github.com/huggingface/transformers/blob/main/src/transformers/models/siglip/configuration_siglip.py#L126-L147)
-SIGLIP_CONFIG = {
+DEFAULT_SIGLIP_CONFIG = {
     "hidden_size": 768,
     "intermediate_size": 3072,
     "num_hidden_layers": 12,
@@ -26,8 +26,21 @@ SIGLIP_CONFIG = {
     "vision_use_head": False,
 }
 
+# Comes from https://huggingface.co/google/gemma-3-27b-it/blob/main/config.json.
+GEMMA3_SIGLIP_CONFIG = {
+    "hidden_size": 1152,
+    "image_size": 896,
+    "intermediate_size": 4304,
+    "model_type": "siglip_vision_model",
+    "num_attention_heads": 16,
+    "num_hidden_layers": 27,
+    "patch_size": 14,
+    "vision_use_head": False
+}
+
 ACCURACY_CONFIG = {
-    torch.float16: (2e-2, 5e-2),
+    'default': (2e-2, 5e-2),
+    'gemma3': (5e-1, 5e-1),
 }
 
 
@@ -36,9 +49,10 @@ class Scenario:
     backend: str
     num_images: int
     dtype: torch.dtype
+    config_name: str
 
     def __repr__(self) -> str:
-        return f"backend:{self.backend.lower()}_num_images:{self.num_images}_dtype:{self.dtype}"
+        return f"backend:{self.backend.lower()}_num_images:{self.num_images}_dtype:{self.dtype}_config_name:{self.config_name}"
 
 
 class TestSiglipVisionModel(unittest.TestCase):
@@ -48,9 +62,22 @@ class TestSiglipVisionModel(unittest.TestCase):
         torch.random.manual_seed(1234)
 
     @parameterized.expand([
-        Scenario(backend="VANILLA", num_images=2, dtype=torch.float16),
-        Scenario(backend="TRTLLM", num_images=2, dtype=torch.float16),
-        Scenario(backend="TRTLLM", num_images=21, dtype=torch.float16),
+        Scenario(backend="VANILLA",
+                 num_images=2,
+                 dtype=torch.float16,
+                 config_name="default"),
+        Scenario(backend="TRTLLM",
+                 num_images=2,
+                 dtype=torch.float16,
+                 config_name="default"),
+        Scenario(backend="TRTLLM",
+                 num_images=1,
+                 dtype=torch.bfloat16,
+                 config_name="gemma3"),
+        Scenario(backend="TRTLLM",
+                 num_images=21,
+                 dtype=torch.float16,
+                 config_name="default"),
     ], lambda testcase_func, param_num, param:
                           f"{testcase_func.__name__}[{param.args[0]}]")
     def test_siglip_vision_allclose_to_hf(self, scenario: Scenario):
@@ -58,10 +85,16 @@ class TestSiglipVisionModel(unittest.TestCase):
         backend = scenario.backend
         num_images = scenario.num_images
         dtype = scenario.dtype
+        config_name = scenario.config_name
         device = torch.device('cuda')
 
         # Create configs
-        config_dict = deepcopy(SIGLIP_CONFIG)
+        if config_name == "default":
+            config_dict = deepcopy(DEFAULT_SIGLIP_CONFIG)
+        elif config_name == "gemma3":
+            config_dict = deepcopy(GEMMA3_SIGLIP_CONFIG)
+        else:
+            raise ValueError(f"Invalid config name: {config_name}")
         hf_config = SiglipVisionConfig.from_dict(config_dict)
 
         # Prepare HF model
@@ -111,13 +144,13 @@ class TestSiglipVisionModel(unittest.TestCase):
             torch.testing.assert_close(
                 hf_hs.float(),
                 tllm_hs.float(),
-                rtol=ACCURACY_CONFIG[dtype][0],
-                atol=ACCURACY_CONFIG[dtype][1],
+                rtol=ACCURACY_CONFIG[config_name][0],
+                atol=ACCURACY_CONFIG[config_name][1],
                 msg=
-                f"FAILED: TRT-LLM and HF hidden_states mismatch for {dtype} with {num_images} images at layer {i}, the mean value of this layer is {hf_hs.mean()}"
+                f"FAILED: TRT-LLM and HF hidden_states mismatch for {dtype} with {num_images} images at layer {i}: max diff is {(hf_hs - tllm_hs).abs().max()}, mean diff is {(hf_hs - tllm_hs).abs().mean()}"
             )
             print(
-                f"PASSED: TRT-LLM and HF hidden_states match for {dtype} with {num_images} images at layer {i}, the mean value of this layer is {hf_hs.mean()}"
+                f"PASSED: TRT-LLM and HF hidden_states match for {dtype} with {num_images} images at layer {i}: max diff is {(hf_hs - tllm_hs).abs().max()}, mean diff is {(hf_hs - tllm_hs).abs().mean()}"
             )
 
 


### PR DESCRIPTION
## Description

This MR updates:
- Replaces HF vision encoder with TRTLLM SiglipVisionEncoder.
- Our SiglipVisionEncoder had a missing `post_layernorm` which seems to be set to identity for most other models but not Gemma3. So, added it.
- Does minor clean up and gets cuda graph working for Gemma3.

```
$ python3 examples/llm-api/quickstart_multimodal.py --model_dir ../random/hf_models/gemma-3-27b-it/ --modality image --image_format pil --attention_backend FLASHINFER --disable_kv_cache_reuse
```

## Test Coverage
```
$ pytest tests/integration/defs/test_e2e.py::test_ptp_quickstart_multimodal[gemma-3-27b-it-gemma/gemma-3-27b-it-image-True] -s -v
$ pytest tests/unittest/_torch/modeling/test_modeling_siglip.py::TestSiglipVisionModel::test_siglip_vision_allclose_to_hf[backend:trtllm_num_images:1_dtype:torch.bfloat16_config_name:gemma3] -s -v
```

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
