### PR TITLE
[TRTLLM-5271][feat] best_of/n for pytorch workflow

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
+++ b/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
@@ -467,6 +467,9 @@ public:
         initialize(req.getInputTokenIds(), req.getOutputConfig().returnLogProbs);
     }
 
+    GenericLlmRequest(GenericLlmRequest&& request) = default;
+    GenericLlmRequest(GenericLlmRequest const& request) = default;
+
     void setExcludeInputFromOutput(bool exclude)
     {
         mExcludeInputFromOutput = exclude;
@@ -2317,6 +2320,9 @@ public:
         mLookaheadConfig = request.getLookaheadConfig();
         mKvCacheRetentionConfig = request.getKvCacheRetentionConfig();
     }
+
+    LlmRequest(LlmRequest&& request) = default;
+    LlmRequest(LlmRequest const& request) = default;
 
     /// @brief  Create a Response from the current state of the request
     /// @details Note that there is some dependency on the order of operations in this method. Modify with care!

--- a/cpp/tensorrt_llm/nanobind/batch_manager/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/bindings.cpp
@@ -187,6 +187,8 @@ void initBindings(nb::module_& m)
         .def_prop_ro("missed_blocks", &GenLlmReq::getMissedBlocksPerRequest)
         .def_prop_ro("kv_cache_hit_rate", &GenLlmReq::getKVCacheHitRatePerRequest)
         .def_prop_ro("llm_request_type", &GenLlmReq::getLlmRequestType)
+        .def_prop_ro("parent_request_id", &GenLlmReq::getParentRequestId)
+        .def_prop_ro("is_child", &GenLlmReq::isChild)
         .def_prop_ro("multimodal_hashes",
             [](GenLlmReq& self)
             {
@@ -356,6 +358,7 @@ void initBindings(nb::module_& m)
             nb::arg("enable_kv_cache_reuse") = false)
         .def("create_response", &tb::LlmRequest::createResponse, nb::arg("use_fast_logits") = false,
             nb::arg("mpi_world_rank") = 0)
+        .def("create_child_request", &tb::LlmRequest::createChildRequest, nb::arg("child_id"))
         .def("create_result", &tb::LlmRequest::createResult, nb::arg("use_fast_logits") = false,
             nb::arg("mpi_world_rank") = 0)
         .def("create_serialized_result",

--- a/cpp/tensorrt_llm/nanobind/batch_manager/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/bindings.cpp
@@ -353,6 +353,7 @@ void initBindings(nb::module_& m)
             nb::arg("return_perf_metrics") = false, nb::arg("guided_decoding_params") = std::nullopt,
             nb::arg("language_adapter_uid") = std::nullopt, nb::arg("allotted_time_ms") = std::nullopt,
             nb::arg("context_phase_params") = std::nullopt)
+        .def(nb::init<tb::LlmRequest const&>())
         .def("validate", &tb::LlmRequest::validate, nb::arg("max_input_len"), nb::arg("max_seq_len"),
             nb::arg("max_draft_len"), nb::arg("vocab_size_padded"), nb::arg("max_endocer_input_len") = std::nullopt,
             nb::arg("enable_kv_cache_reuse") = false)

--- a/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
@@ -192,6 +192,8 @@ void initBindings(pybind11::module_& m)
         .def_property_readonly("missed_blocks", &GenLlmReq::getMissedBlocksPerRequest)
         .def_property_readonly("kv_cache_hit_rate", &GenLlmReq::getKVCacheHitRatePerRequest)
         .def_property_readonly("llm_request_type", &GenLlmReq::getLlmRequestType)
+        .def_property_readonly("parent_request_id", &GenLlmReq::getParentRequestId)
+        .def_property_readonly("is_child", &GenLlmReq::isChild)
         .def_property_readonly("multimodal_hashes",
             [](GenLlmReq& self)
             {
@@ -254,7 +256,7 @@ void initBindings(pybind11::module_& m)
         .def_property_readonly("return_perf_metrics", &GenLlmReq::getReturnPerfMetrics);
 
     py::classh<tb::LlmRequest, GenLlmReq>(m, "LlmRequest", pybind11::dynamic_attr())
-        .def(py::init(
+        .def(py::init<>(
                  [](tb::LlmRequest::RequestIdType request_id, tb::LlmRequest::SizeType32 max_new_tokens,
                      std::vector<tb::LlmRequest::TokenIdType> input_tokens, runtime::SamplingConfig sampling_config,
                      bool is_streaming, std::optional<tb::LlmRequest::SizeType32> end_id,
@@ -357,11 +359,14 @@ void initBindings(pybind11::module_& m)
             py::arg("return_perf_metrics") = false, py::arg("guided_decoding_params") = std::nullopt,
             py::arg("language_adapter_uid") = std::nullopt, py::arg("allotted_time_ms") = std::nullopt,
             py::arg("context_phase_params") = std::nullopt)
+        .def(py::init<tb::LlmRequest const&>())
+        //.def(py::init<tb::LlmRequest&&>())
         .def("validate", &tb::LlmRequest::validate, py::arg("max_input_len"), py::arg("max_seq_len"),
             py::arg("max_draft_len"), py::arg("vocab_size_padded"), py::arg("max_endocer_input_len") = std::nullopt,
             py::arg("enable_kv_cache_reuse") = false)
         .def("create_response", &tb::LlmRequest::createResponse, py::arg("use_fast_logits") = false,
             py::arg("mpi_world_rank") = 0)
+        .def("create_child_request", &tb::LlmRequest::createChildRequest, py::arg("child_id"))
         .def("create_result", &tb::LlmRequest::createResult, py::arg("use_fast_logits") = false,
             py::arg("mpi_world_rank") = 0)
         .def("create_serialized_result",

--- a/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
@@ -360,7 +360,6 @@ void initBindings(pybind11::module_& m)
             py::arg("language_adapter_uid") = std::nullopt, py::arg("allotted_time_ms") = std::nullopt,
             py::arg("context_phase_params") = std::nullopt)
         .def(py::init<tb::LlmRequest const&>())
-        //.def(py::init<tb::LlmRequest&&>())
         .def("validate", &tb::LlmRequest::validate, py::arg("max_input_len"), py::arg("max_seq_len"),
             py::arg("max_draft_len"), py::arg("vocab_size_padded"), py::arg("max_endocer_input_len") = std::nullopt,
             py::arg("enable_kv_cache_reuse") = false)

--- a/examples/llm-api/quickstart_advanced.py
+++ b/examples/llm-api/quickstart_advanced.py
@@ -232,9 +232,13 @@ def setup_llm(args, **kwargs):
     )
 
     use_beam_search = args.max_beam_width > 1
-    if use_beam_search and args.n == 1:
-        # If beam search is used, set n to the beam width.
-        args.n = args.max_beam_width
+    best_of = args.best_of or args.n
+    if use_beam_search:
+        if args.n == 1 and args.best_of is None:
+            args.n = args.max_beam_width
+        assert best_of <= args.max_beam_width, f"best_of: {best_of}, max_beam_width: {args.max_beam_width}"
+
+    assert best_of >= args.n, f"In sampling mode best_of value: {best_of} should be less or equal to n: {args.n}"
 
     sampling_params = SamplingParams(
         max_tokens=args.max_tokens,
@@ -245,7 +249,7 @@ def setup_llm(args, **kwargs):
         return_generation_logits=args.return_generation_logits,
         logprobs=args.logprobs,
         n=args.n,
-        best_of=args.best_of or args.n,
+        best_of=best_of,
         use_beam_search=use_beam_search)
     return llm, sampling_params
 

--- a/examples/llm-api/quickstart_advanced.py
+++ b/examples/llm-api/quickstart_advanced.py
@@ -236,7 +236,7 @@ def setup_llm(args, **kwargs):
     if use_beam_search:
         if args.n == 1 and args.best_of is None:
             args.n = args.max_beam_width
-        assert best_of <= args.max_beam_width, f"best_of: {best_of}, max_beam_width: {args.max_beam_width}"
+        assert best_of <= args.max_beam_width, f"beam width: {best_of}, should be less or equal to max_beam_width: {args.max_beam_width}"
 
     assert best_of >= args.n, f"In sampling mode best_of value: {best_of} should be less or equal to n: {args.n}"
 

--- a/examples/llm-api/quickstart_advanced.py
+++ b/examples/llm-api/quickstart_advanced.py
@@ -195,6 +195,7 @@ def setup_llm(args, **kwargs):
         batch_sizes=args.cuda_graph_batch_sizes,
         enable_padding=args.cuda_graph_padding_enabled,
     ) if args.use_cuda_graph else None
+
     llm = LLM(
         model=args.model_dir,
         backend='pytorch',
@@ -230,18 +231,22 @@ def setup_llm(args, **kwargs):
         **kwargs,
     )
 
+    use_beam_search = args.max_beam_width > 1
+    if use_beam_search and args.n == 1:
+        # If beam search is used, set n to the beam width.
+        args.n = args.max_beam_width
+
     sampling_params = SamplingParams(
         max_tokens=args.max_tokens,
         temperature=args.temperature,
         top_k=args.top_k,
         top_p=args.top_p,
-        best_of=args.max_beam_width
-        if args.max_beam_width > 1 else args.best_of,
         return_context_logits=args.return_context_logits,
         return_generation_logits=args.return_generation_logits,
         logprobs=args.logprobs,
         n=args.n,
-        use_beam_search=args.max_beam_width > 1)
+        best_of=args.best_of or args.n,
+        use_beam_search=use_beam_search)
     return llm, sampling_params
 
 

--- a/tensorrt_llm/_torch/pyexecutor/executor_request_queue.py
+++ b/tensorrt_llm/_torch/pyexecutor/executor_request_queue.py
@@ -163,23 +163,18 @@ class ExecutorRequestQueue:
 
     def _get_request_id(self):
         # (next_request_id + 1) % UINT64_MAX
+        current_id = self.next_request_id
         self.next_request_id = (self.next_request_id + 1) & ((1 << 64) - 1)
-        return self.next_request_id
+        return current_id
 
     def _generate_child_request_ids(
             self, request: ExecutorRequest) -> List[int] | None:
         """ Generate child request IDs if needed. """
         child_req_ids = None
-        sampling_config = request.sampling_config
-        beam_width = (sampling_config.beam_width
-                      if sampling_config.beam_width else 1)
-        num_return_sequences = (sampling_config.num_return_sequences
-                                if sampling_config.num_return_sequences else 1)
-
-        # Create child requests if beam_width == 1 and num_return_sequences > 1.
-        if beam_width == 1 and num_return_sequences > 1:
+        num_children = self._get_num_child_requests(request)
+        if num_children > 0:
             child_req_ids = []
-            for _ in range(num_return_sequences - 1):
+            for _ in range(num_children):
                 child_req_id = self._get_request_id()
                 if self.enable_iter_perf_stats:
                     self.start_times[child_req_id] = time.time()
@@ -599,8 +594,8 @@ class ExecutorRequestQueue:
                     req_item.id, req_item.request, req_item.child_req_ids,
                     self._should_exclude_last_generation_logits())
                 req_with_children.append(req)
-                if req.children:
-                    req_with_children.extend(req.children)
+                if req.child_requests:
+                    req_with_children.extend(req.child_requests)
             return req_with_children
 
     def _merge_star_attention_requests(self,

--- a/tensorrt_llm/_torch/pyexecutor/executor_request_queue.py
+++ b/tensorrt_llm/_torch/pyexecutor/executor_request_queue.py
@@ -123,7 +123,6 @@ class ExecutorRequestQueue:
                 req_item.child_req_ids) if req_item.child_req_ids else 0
             if (req_count + 1 + num_children) > max_req_count:
                 break
-            req_count += 1 + num_children
             req_item = waiting_queue.popleft()
             can_process = self._can_process_attention_dp_request(
                 req_item, scheduling_all_ranks_num_active_requests
@@ -131,7 +130,8 @@ class ExecutorRequestQueue:
 
             if can_process:
                 items.append(req_item)
-                else:
+                req_count += 1 + num_children
+            else:
                 pending_requests.append(req_item)
 
         # Put the pending requests back to the waiting queue

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -334,7 +334,7 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
                                   return_log_probs, return_context_logits,
                                   return_generation_logits,
                                   exclude_last_generation_logits)
-        self.children = []
+        self.child_requests = []
 
     def is_generation_only_request(self):
         return self.py_llm_request_type == LlmRequestType.LLMREQUEST_TYPE_GENERATION_ONLY
@@ -377,14 +377,14 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
         py_request.py_batch_idx = None
         py_request.py_seq_slot = None
 
-        py_request.children = []
+        py_request.child_requests = []
 
         assert py_request.is_child
         assert py_request.request_id == child.request_id
         assert py_request.parent_request_id == self.request_id
         assert py_request.sampling_config.random_seed != self.sampling_config.random_seed
 
-        self.children.append(py_request)
+        self.child_requests.append(py_request)
 
 
 def convert_wordlist(word_list) -> List[List[int]]:

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -515,8 +515,6 @@ def executor_request_to_llm_request(
     if child_req_ids:
         for child_id in child_req_ids:
             llm_request.create_child_request(child_id)
-    #         llm_request.children.append(
-    #             llm_request.create_child_request(child_id))
 
     return llm_request
 

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1451,7 +1451,7 @@ class PyExecutor:
                 if responses_list is not None:
                     for resp in responses_list:
                         if resp is not None:
-                            gather_responses.append(resp)
+                            gather_responses.extend(resp)
                     responses = gather_responses
         logger.debug(
             f'after gather, rank = {self.dist.rank}, responses = {responses}')

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -170,7 +170,7 @@ class PyExecutor:
         self.disable_overlap_scheduler = disable_overlap_scheduler
 
         # enqueue and _fetch_new_requests used data
-        self.next_req_id = max_batch_size  # The first max_batch_size request IDs are reserved for dummy requests
+        self.active = True
         self.max_beam_width = max_beam_width
         self.max_draft_len = max_draft_len
         self.print_log = model_engine.pytorch_backend_config.print_iter_log
@@ -283,32 +283,6 @@ class PyExecutor:
 
     def __exit__(self):
         self.shutdown()
-
-    def _get_request_id(self):
-        # (next_req_id + 1) % UINT64_MAX
-        self.next_req_id = (self.next_req_id + 1) & ((1 << 64) - 1)
-        return self.next_req_id
-
-    def _generate_child_request_ids(
-            self, request: ExecutorRequest) -> List[int] | None:
-        """ Generate child request IDs if needed. """
-        child_req_ids = None
-        sampling_config = request.sampling_config
-        beam_width = (sampling_config.beam_width
-                      if sampling_config.beam_width else 1)
-        num_return_sequences = (sampling_config.num_return_sequences
-                                if sampling_config.num_return_sequences else 1)
-
-        # Create child requests if beam_width == 1 and num_return_sequences > 1.
-        if beam_width == 1 and num_return_sequences > 1:
-            child_req_ids = []
-            for _ in range(num_return_sequences - 1):
-                child_req_id = self._get_request_id()
-                if self.enable_iter_perf_stats:
-                    self.start_times[child_req_id] = time.time()
-                child_req_ids.append(child_req_id)
-
-        return child_req_ids
 
     def enqueue_requests(self, requests: List[ExecutorRequest]):
         """

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1546,11 +1546,7 @@ class PyExecutor:
             if request_done:
                 if request.is_disagg_context_transmission_state:
                     self.ctx_in_transmission_requests.append(request)
-                else:
-                    if response.result.is_final:
-                        requests_to_terminate.append(request)
-                        # for child in request.children:
-                        #     requests_to_terminate.append(child)
+                requests_to_terminate.append(request)
             else:
                 new_active_requests.append(request)
         self.active_requests.clear()

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -8,7 +8,7 @@ import time
 import traceback
 import weakref
 from contextlib import contextmanager
-from typing import Dict, List, Optional, Union
+from typing import List, Optional, Tuple, Union
 
 import torch
 from cuda import cudart
@@ -1546,7 +1546,8 @@ class PyExecutor:
             if request_done:
                 if request.is_disagg_context_transmission_state:
                     self.ctx_in_transmission_requests.append(request)
-                requests_to_terminate.append(request)
+                else:
+                    requests_to_terminate.append(request)
             else:
                 new_active_requests.append(request)
         self.active_requests.clear()

--- a/tests/unittest/_torch/test_best_of_n.py
+++ b/tests/unittest/_torch/test_best_of_n.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+from utils.llm_data import llm_models_root
 from utils.util import force_ampere, similar
 
 from tensorrt_llm import LLM, SamplingParams
@@ -33,7 +34,8 @@ def expected_outputs():
 
 @pytest.fixture(scope="module")
 def llm():
-    return LLM(model=os.path.join("/model"),
+    return LLM(model=os.path.join(llm_models_root(), "llama-models-v2",
+                                  "TinyLlama-1.1B-Chat-v1.0"),
                kv_cache_config=KvCacheConfig(max_tokens=1000),
                max_batch_size=8,
                max_seq_len=64,

--- a/tests/unittest/_torch/test_best_of_n.py
+++ b/tests/unittest/_torch/test_best_of_n.py
@@ -66,10 +66,10 @@ def test_create_child_request(n: int):
             parent.request_id + parent.sampling_config.num_return_sequences):
         parent.create_child_request(child_id)
 
-    assert len(
-        parent.children) == parent.sampling_config.num_return_sequences - 1
+    assert len(parent.child_requests
+               ) == parent.sampling_config.num_return_sequences - 1
 
-    for ind, child in enumerate(parent.children):
+    for ind, child in enumerate(parent.child_requests):
         assert child.request_id == ind + parent.request_id + 1
         assert child.py_request_id == child.request_id
         assert child.parent_request_id == parent.request_id
@@ -88,7 +88,7 @@ def test_create_child_request(n: int):
         assert child.get_tokens() == parent.get_tokens()
         assert child.get_tokens() is not parent.get_tokens()
 
-        assert child.children == []
+        assert child.child_requests == []
 
 
 @force_ampere  # Save H100 resource

--- a/tests/unittest/_torch/test_best_of_n.py
+++ b/tests/unittest/_torch/test_best_of_n.py
@@ -1,0 +1,53 @@
+import os
+
+import pytest
+from utils.llm_data import llm_models_root
+from utils.util import force_ampere, similar
+
+from tensorrt_llm import LLM, SamplingParams
+from tensorrt_llm.llmapi.llm_utils import KvCacheConfig
+
+prompts = [
+    "Born in north-east France, Soyer trained as a",
+    "The future of AI is",
+]
+expected_outputs = {
+    "Born in north-east France, Soyer trained as a": [
+        "lawyer and was a member of the French Resistance",
+        "cook before turning to painting."
+    ],
+    "The future of AI is": [
+        "all about human-machine collaboration.",
+        "more promising than you think."
+    ],
+}
+
+global_kvcache_config = KvCacheConfig(max_tokens=10000)
+
+
+@force_ampere  # Save H100 resource
+@pytest.mark.parametrize("n", [2])
+@pytest.mark.parametrize("best_of", [None, 3])
+def test_n_outputs(n: int, best_of: int):
+    llm = LLM(model=os.path.join(llm_models_root(), "llama-models-v2",
+                                 "TinyLlama-1.1B-Chat-v1.0"),
+              kv_cache_config=global_kvcache_config,
+              max_batch_size=128,
+              max_seq_len=128,
+              enable_trtllm_sampler=True)
+    sampling_params = SamplingParams(
+        n=n,
+        best_of=best_of,
+        temperature=0.8,  # ensure different outputs
+        top_p=0.95,  # ensure different outputs
+        use_beam_search=False)
+    with llm:
+        for output_idx, output in enumerate(
+                llm.generate(prompts, sampling_params=sampling_params)):
+
+            assert len(output.outputs) == n
+
+            for idx, sequence in enumerate(output.outputs):
+                if n == best_of:
+                    assert similar(sequence.text,
+                                   expected_outputs[prompts[output_idx]][idx])

--- a/tests/unittest/_torch/test_best_of_n.py
+++ b/tests/unittest/_torch/test_best_of_n.py
@@ -1,53 +1,133 @@
 import os
 
 import pytest
-from utils.llm_data import llm_models_root
 from utils.util import force_ampere, similar
 
 from tensorrt_llm import LLM, SamplingParams
+from tensorrt_llm._torch.pyexecutor.llm_request import (LlmRequest,
+                                                        SamplingConfig)
 from tensorrt_llm.llmapi.llm_utils import KvCacheConfig
 
-prompts = [
-    "Born in north-east France, Soyer trained as a",
-    "The future of AI is",
-]
-expected_outputs = {
-    "Born in north-east France, Soyer trained as a": [
-        "lawyer and was a member of the French Resistance",
-        "cook before turning to painting."
-    ],
-    "The future of AI is": [
-        "all about human-machine collaboration.",
-        "more promising than you think."
-    ],
-}
 
-global_kvcache_config = KvCacheConfig(max_tokens=10000)
+@pytest.fixture(scope="module")
+def input_prompts():
+    return [
+        "Born in north-east France, Soyer trained as a",
+        "The future of AI is",
+    ]
+
+
+@pytest.fixture(scope="module")
+def expected_outputs():
+    return {
+        "Born in north-east France, Soyer trained as a": [
+            "lawyer and was a member of the French Resistance",
+            "cook before turning to painting."
+        ],
+        "The future of AI is": [
+            "all about human-machine collaboration.",
+            "more promising than you think."
+        ],
+    }
+
+
+@pytest.fixture(scope="module")
+def llm():
+    return LLM(model=os.path.join("/model"),
+               kv_cache_config=KvCacheConfig(max_tokens=1000),
+               max_batch_size=8,
+               max_seq_len=64,
+               enable_trtllm_sampler=True,
+               disable_overlap_scheduler=True)
+
+
+@force_ampere  # Save H100 resource
+@pytest.mark.parametrize("n", [1, 2, 3])
+def test_create_child_request(n: int):
+    sampling_config = SamplingConfig()
+    setattr(sampling_config, 'top_p', [0.9])
+    setattr(sampling_config, 'num_return_sequences', n)
+
+    parent = LlmRequest(
+        request_id=1,
+        max_new_tokens=10,
+        input_tokens=[1, 2, 3],
+        sampling_config=sampling_config,
+        is_streaming=False,
+        client_id=50,
+        return_log_probs=True,
+        return_context_logits=True,
+    )
+
+    for child_id in range(
+            parent.request_id + 1,
+            parent.request_id + parent.sampling_config.num_return_sequences):
+        parent.create_child_request(child_id)
+
+    assert len(
+        parent.children) == parent.sampling_config.num_return_sequences - 1
+
+    for ind, child in enumerate(parent.children):
+        assert child.request_id == ind + parent.request_id + 1
+        assert child.py_request_id == child.request_id
+        assert child.parent_request_id == parent.request_id
+
+        assert child.py_client_id == 50
+        assert child.py_max_new_tokens == 10
+
+        assert child.py_return_log_probs == parent.py_return_log_probs
+        assert child.py_return_context_logits == parent.py_return_context_logits
+
+        assert child.py_batch_idx is None
+
+        # Verify parent - child independence
+        assert child.py_result is not None
+        assert child.py_result is not parent.py_result
+        assert child.get_tokens() == parent.get_tokens()
+        assert child.get_tokens() is not parent.get_tokens()
+
+        assert child.children == []
 
 
 @force_ampere  # Save H100 resource
 @pytest.mark.parametrize("n", [2])
 @pytest.mark.parametrize("best_of", [None, 3])
-def test_n_outputs(n: int, best_of: int):
-    llm = LLM(model=os.path.join(llm_models_root(), "llama-models-v2",
-                                 "TinyLlama-1.1B-Chat-v1.0"),
-              kv_cache_config=global_kvcache_config,
-              max_batch_size=128,
-              max_seq_len=128,
-              enable_trtllm_sampler=True)
+@pytest.mark.threadleak(enabled=False)
+def test_n_outputs(n: int, best_of: int, llm, input_prompts, expected_outputs):
     sampling_params = SamplingParams(
         n=n,
         best_of=best_of,
         temperature=0.8,  # ensure different outputs
         top_p=0.95,  # ensure different outputs
         use_beam_search=False)
-    with llm:
-        for output_idx, output in enumerate(
-                llm.generate(prompts, sampling_params=sampling_params)):
+    for output_idx, output in enumerate(
+            llm.generate(input_prompts, sampling_params=sampling_params)):
 
-            assert len(output.outputs) == n
+        assert len(output.outputs) == n
 
-            for idx, sequence in enumerate(output.outputs):
-                if n == best_of:
-                    assert similar(sequence.text,
-                                   expected_outputs[prompts[output_idx]][idx])
+        for idx, sequence in enumerate(output.outputs):
+            if n == best_of:
+                assert similar(sequence.text,
+                               expected_outputs[input_prompts[output_idx]][idx])
+
+
+@pytest.mark.parametrize("n", [3])
+@pytest.mark.threadleak(enabled=False)
+def test_async_n_outputs(n: int, llm, input_prompts):
+    sampling_params = SamplingParams(
+        n=n,
+        temperature=0.8,  # ensure different outputs
+        top_p=0.95,  # ensure different outputs
+        use_beam_search=False)
+
+    # Asynchronously submit many requests to exceed max batch size.
+    futures = []
+    for _ in range(5):
+        for prompt in input_prompts:
+            future = llm.generate_async(prompt, sampling_params)
+            futures.append(future)
+
+    # Expect no error raised and each result contains n outputs.
+    for _, future in enumerate(futures):
+        request_output = future.result()
+        assert len(request_output.outputs) == n


### PR DESCRIPTION
# best_of/n feature for pytorch workflow

## Description

Adds support for child request and multiple sequence generation without beam search

## Test Coverage

unittest/_torch/test_best_of_n.py

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for generating multiple output sequences and "best-of" sampling via new arguments in the advanced quickstart script.
  * Enabled creation and management of hierarchical (parent-child) LLM requests, with Python bindings and tracking for child requests.
  * Exposed new read-only properties and methods in Python bindings for enhanced request introspection and child request creation.
  * Enhanced request queue management to support child request IDs, including latency tracking and merging logic.
  * Updated response handling to unify processing with list-based structures and improved cancellation checks for child requests.
* **Bug Fixes**
  * Improved handling and cleanup of child requests during cancellation and response processing.
* **Tests**
  * Introduced new tests to validate multi-output and best-of sampling features.
  * Added tests covering child request creation and request queue behavior with child requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->