### PR TITLE
[Issue 5927][fix] Avoid memory calls during broadcast for single GPU

### DIFF
--- a/tensorrt_llm/_utils.py
+++ b/tensorrt_llm/_utils.py
@@ -471,27 +471,27 @@ local_comm = mpi_comm().Split_type(split_type=OMPI_COMM_TYPE_HOST)
 
 
 def mpi_rank():
-    return mpi_comm().Get_rank() if ENABLE_MULTI_DEVICE else 0
+    return mpi_comm().Get_rank() if is_multi_device_enable() else 0
 
 
 def global_mpi_rank():
-    return MPI.COMM_WORLD.Get_rank() if ENABLE_MULTI_DEVICE else 0
+    return MPI.COMM_WORLD.Get_rank() if is_multi_device_enable() else 0
 
 
 def global_mpi_size():
-    return MPI.COMM_WORLD.Get_size() if ENABLE_MULTI_DEVICE else 1
+    return MPI.COMM_WORLD.Get_size() if is_multi_device_enable() else 1
 
 
 def mpi_world_size():
-    return mpi_comm().Get_size() if ENABLE_MULTI_DEVICE else 1
+    return mpi_comm().Get_size() if is_multi_device_enable() else 1
 
 
 def local_mpi_rank():
-    return local_comm.Get_rank() if ENABLE_MULTI_DEVICE else 0
+    return local_comm.Get_rank() if is_multi_device_enable() else 0
 
 
 def local_mpi_size():
-    return local_comm.Get_size() if ENABLE_MULTI_DEVICE else 1
+    return local_comm.Get_size() if is_multi_device_enable() else 1
 
 
 def default_gpus_per_node():
@@ -504,54 +504,54 @@ def default_gpus_per_node():
 
 
 def mpi_barrier():
-    if ENABLE_MULTI_DEVICE:
+    if is_multi_device_enable():
         mpi_comm().Barrier()
 
 
 def mpi_broadcast(obj, root=0):
-    return mpi_comm().bcast(obj, root) if ENABLE_MULTI_DEVICE else obj
+    return mpi_comm().bcast(obj, root) if is_multi_device_enable() else obj
 
 
 def mpi_allgather(obj):
-    return mpi_comm().allgather(obj) if ENABLE_MULTI_DEVICE else obj
+    return mpi_comm().allgather(obj) if is_multi_device_enable() else obj
 
 
 def mpi_isend(buf, dest, tag=0):
     # isend in buf-like objects (e.g. numpy array)
-    # return request handle if ENABLE_MULTI_DEVICE
-    if ENABLE_MULTI_DEVICE:
+    # return request handle if is_multi_device_enable()
+    if is_multi_device_enable():
         return mpi_comm().Isend(buf, dest, tag=tag)
     return None
 
 
 def mpi_send(buf, dest, tag=0):
     # send in buf-like objects (e.g. numpy array)
-    # return request handle if ENABLE_MULTI_DEVICE
-    if ENABLE_MULTI_DEVICE:
+    # return request handle if is_multi_device_enable()
+    if is_multi_device_enable():
         mpi_comm().Send(buf, dest, tag=tag)
     return None
 
 
 def mpi_recv(buf, source, tag):
     # recv in buf-like object (e.g. numpy array)
-    if ENABLE_MULTI_DEVICE:
+    if is_multi_device_enable():
         return mpi_comm().Recv(buf, source, tag=tag)
     return None
 
 
 def mpi_send_object(obj, dest, tag=0):
-    if ENABLE_MULTI_DEVICE:
+    if is_multi_device_enable():
         mpi_comm().send(obj, dest=dest, tag=tag)
 
 
 def mpi_isend_object(obj, dest, tag=0):
-    if ENABLE_MULTI_DEVICE:
+    if is_multi_device_enable():
         return mpi_comm().isend(obj, dest=dest, tag=tag)
     return None
 
 
 def mpi_recv_object(source, tag):
-    if ENABLE_MULTI_DEVICE:
+    if is_multi_device_enable():
         return mpi_comm().recv(source=source, tag=tag)
     return None
 
@@ -1079,3 +1079,13 @@ class KVCacheEventSerializer:
             "token_id": data.token_id,
             "token_extra_id": data.token_extra_id
         }
+
+def is_multi_device_enable():
+    """
+    This method evaluates if we are running on multiple GPUs and the flag ENABLE_MULTI_DEVICE is set.
+    So we can avoid broadcast calls on single GPU.
+    see: https://github.com/NVIDIA/TensorRT-LLM/issues/5927
+    ENABLE_MULTI_DEVICE is true by default when building tensorrt-llm so we need to also check
+    the number of devices
+    """
+    return local_comm.Get_size() > 1 and ENABLE_MULTI_DEVICE

--- a/tensorrt_llm/_utils.py
+++ b/tensorrt_llm/_utils.py
@@ -471,27 +471,27 @@ local_comm = mpi_comm().Split_type(split_type=OMPI_COMM_TYPE_HOST)
 
 
 def mpi_rank():
-    return mpi_comm().Get_rank() if is_multi_device_enable() else 0
+    return mpi_comm().Get_rank() if ENABLE_MULTI_DEVICE else 0
 
 
 def global_mpi_rank():
-    return MPI.COMM_WORLD.Get_rank() if is_multi_device_enable() else 0
+    return MPI.COMM_WORLD.Get_rank() if ENABLE_MULTI_DEVICE else 0
 
 
 def global_mpi_size():
-    return MPI.COMM_WORLD.Get_size() if is_multi_device_enable() else 1
+    return MPI.COMM_WORLD.Get_size() if ENABLE_MULTI_DEVICE else 1
 
 
 def mpi_world_size():
-    return mpi_comm().Get_size() if is_multi_device_enable() else 1
+    return mpi_comm().Get_size() if ENABLE_MULTI_DEVICE else 1
 
 
 def local_mpi_rank():
-    return local_comm.Get_rank() if is_multi_device_enable() else 0
+    return local_comm.Get_rank() if ENABLE_MULTI_DEVICE else 0
 
 
 def local_mpi_size():
-    return local_comm.Get_size() if is_multi_device_enable() else 1
+    return local_comm.Get_size() if ENABLE_MULTI_DEVICE else 1
 
 
 def default_gpus_per_node():
@@ -504,7 +504,7 @@ def default_gpus_per_node():
 
 
 def mpi_barrier():
-    if is_multi_device_enable():
+    if ENABLE_MULTI_DEVICE:
         mpi_comm().Barrier()
 
 
@@ -513,13 +513,13 @@ def mpi_broadcast(obj, root=0):
 
 
 def mpi_allgather(obj):
-    return mpi_comm().allgather(obj) if is_multi_device_enable() else obj
+    return mpi_comm().allgather(obj) if ENABLE_MULTI_DEVICE else obj
 
 
 def mpi_isend(buf, dest, tag=0):
     # isend in buf-like objects (e.g. numpy array)
     # return request handle if is_multi_device_enable()
-    if is_multi_device_enable():
+    if ENABLE_MULTI_DEVICE:
         return mpi_comm().Isend(buf, dest, tag=tag)
     return None
 
@@ -527,31 +527,31 @@ def mpi_isend(buf, dest, tag=0):
 def mpi_send(buf, dest, tag=0):
     # send in buf-like objects (e.g. numpy array)
     # return request handle if is_multi_device_enable()
-    if is_multi_device_enable():
+    if ENABLE_MULTI_DEVICE:
         mpi_comm().Send(buf, dest, tag=tag)
     return None
 
 
 def mpi_recv(buf, source, tag):
     # recv in buf-like object (e.g. numpy array)
-    if is_multi_device_enable():
+    if ENABLE_MULTI_DEVICE:
         return mpi_comm().Recv(buf, source, tag=tag)
     return None
 
 
 def mpi_send_object(obj, dest, tag=0):
-    if is_multi_device_enable():
+    if ENABLE_MULTI_DEVICE:
         mpi_comm().send(obj, dest=dest, tag=tag)
 
 
 def mpi_isend_object(obj, dest, tag=0):
-    if is_multi_device_enable():
+    if ENABLE_MULTI_DEVICE:
         return mpi_comm().isend(obj, dest=dest, tag=tag)
     return None
 
 
 def mpi_recv_object(source, tag):
-    if is_multi_device_enable():
+    if ENABLE_MULTI_DEVICE:
         return mpi_comm().recv(source=source, tag=tag)
     return None
 
@@ -1089,4 +1089,4 @@ def is_multi_device_enable():
     ENABLE_MULTI_DEVICE is true by default when building tensorrt-llm so we need to also check
     the number of devices
     """
-    return local_comm.Get_size() > 1 and ENABLE_MULTI_DEVICE
+    return local_mpi_size() > 1

--- a/tensorrt_llm/_utils.py
+++ b/tensorrt_llm/_utils.py
@@ -518,7 +518,7 @@ def mpi_allgather(obj):
 
 def mpi_isend(buf, dest, tag=0):
     # isend in buf-like objects (e.g. numpy array)
-    # return request handle if is_multi_device_enable()
+    # return request handle if ENABLE_MULTI_DEVICE
     if ENABLE_MULTI_DEVICE:
         return mpi_comm().Isend(buf, dest, tag=tag)
     return None
@@ -526,7 +526,7 @@ def mpi_isend(buf, dest, tag=0):
 
 def mpi_send(buf, dest, tag=0):
     # send in buf-like objects (e.g. numpy array)
-    # return request handle if is_multi_device_enable()
+    # return request handle if ENABLE_MULTI_DEVICE
     if ENABLE_MULTI_DEVICE:
         mpi_comm().Send(buf, dest, tag=tag)
     return None

--- a/tensorrt_llm/_utils.py
+++ b/tensorrt_llm/_utils.py
@@ -1080,11 +1080,12 @@ class KVCacheEventSerializer:
             "token_extra_id": data.token_extra_id
         }
 
+
 def is_multi_device_enable():
     """
     This method evaluates if we are running on multiple GPUs and the flag ENABLE_MULTI_DEVICE is set.
     So we can avoid broadcast calls on single GPU.
-    see: https://github.com/NVIDIA/TensorRT-LLM/issues/5927
+    Issue: https://github.com/NVIDIA/TensorRT-LLM/issues/5927
     ENABLE_MULTI_DEVICE is true by default when building tensorrt-llm so we need to also check
     the number of devices
     """


### PR DESCRIPTION
This PR attemps to avoid calling to cudaMemcopyAsync for single GPUs for different MPI operations. 
For example testing Qwen2-VL-7B-Instruct for prefill phase:
Before:
<img width="791" height="221" alt="Screenshot 2025-07-14 at 10 52 07" src="https://github.com/user-attachments/assets/3566ddad-5832-4cba-9fb9-ed55ca22e024" />
After:
<img width="1063" height="281" alt="Screenshot 2025-07-14 at 10 52 31" src="https://github.com/user-attachments/assets/045a8209-7754-44d0-88c9-9843c35add6f" />

This helps reduce the TTFT
**Before**
```
============ Serving Benchmark Result ============
Successful requests:                     1         
Benchmark duration (s):                  0.63      
Total input tokens:                      59        
Total generated tokens:                  30        
Request throughput (req/s):              1.58      
Input token throughput (tok/s):          93.35     
Output token throughput (tok/s):         47.46     
Output tokens/sec/user (excl. 1st tok):  63.9      
---------------Time to First Token----------------
Mean TTFT (ms):                          177.09    
Median TTFT (ms):                        177.09    
P99 TTFT (ms):                           177.09    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          15.64     
Median TPOT (ms):                        15.64     
P99 TPOT (ms):                           15.64     
---------------Inter-token Latency----------------
Mean ITL (ms):                           15.64     
Median ITL (ms):                         15.65     
P99 ITL (ms):                            16.11     
==================================================
```
**After**
```
============ Serving Benchmark Result ============
Successful requests:                     1         
Benchmark duration (s):                  0.57      
Total input tokens:                      59        
Total generated tokens:                  30        
Request throughput (req/s):              1.74      
Input token throughput (tok/s):          102.74    
Output token throughput (tok/s):         52.24     
Output tokens/sec/user (excl. 1st tok):  63.9      
---------------Time to First Token----------------
Mean TTFT (ms):                          119.77    
Median TTFT (ms):                        119.77    
P99 TTFT (ms):                           119.77    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          15.64     
Median TPOT (ms):                        15.64     
P99 TPOT (ms):                           15.64     
---------------Inter-token Latency----------------
Mean ITL (ms):                           15.64     
Median ITL (ms):                         15.69     
P99 ITL (ms):                            16.07     
==================================================
```

benchmark tool: ```https://github.com/CentML/flexible-inference-bench```

command: ```fib benchmark -n 1 -rps inf --dataset-name random --prefix-text "Please describe the image, and indicate as many details as possible" --ignore-input-distribution --output-token-distribution uniform 30 31 --base-url http://localhost:9010 --seed 42 --backend openai-chat --model Qwen/Qwen2-VL-7B-Instruct --endpoint /v1/chat/completions --num-of-imgs-per-req 1 --img-ratios-per-req 128x128 --send-image-with-base64```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved detection of multi-device mode to more accurately reflect when multiple GPUs are in use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->