### PR TITLE
[Fix] check for ImportError or ModuleNotFoundError for deep_ep_utils

### DIFF
--- a/tensorrt_llm/_torch/modules/fused_moe/deep_ep_utils.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/deep_ep_utils.py
@@ -12,7 +12,7 @@ from tensorrt_llm.mapping import Mapping
 try:
     from tensorrt_llm.deep_ep import Buffer
     deep_ep_installed = True
-except ModuleNotFoundError:
+except ImportError:
     deep_ep_installed = False
 
 


### PR DESCRIPTION
When `deep_ep` is not available, it will throw an `ImportError` and hence this conditional check will fail since the exception is not caught