### PR TITLE
[TRTLLM-3971][feat] low precision all2all

### DIFF
--- a/cpp/tensorrt_llm/kernels/quantization.cu
+++ b/cpp/tensorrt_llm/kernels/quantization.cu
@@ -413,6 +413,11 @@ __global__ void cvt_fp4_to_fp16(int m, int n, uint32_t const* input, uint32_t co
         if constexpr (PER_TOKEN_GLOBAL_SCALE)
         {
             globalScaleVal = globalScale[rowIdx];
+            // if globalScaleVal is inf, set it to 1.0f
+            if (__isinf(globalScaleVal))
+            {
+                globalScaleVal = 1.0f;
+            }
         }
         scaleFloat *= globalScaleVal;
 

--- a/cpp/tensorrt_llm/kernels/quantization.h
+++ b/cpp/tensorrt_llm/kernels/quantization.h
@@ -76,7 +76,8 @@ void invokePerTokenQuantization(QuantT* dst, T const* src, int64_t const numRows
 
 template <typename T, int SF_VEC_SIZE = 16>
 void invokeFP4Quantization(int b, int m, int n, T const* input, float const* globalScale, int64_t* output,
-    int32_t* SFOuput, bool useUE8M0, QuantizationSFLayout layout, int multiProcessorCount, cudaStream_t stream = 0);
+    int32_t* SFOuput, bool useUE8M0, QuantizationSFLayout layout, int multiProcessorCount, bool perTokenGlobalScale,
+    cudaStream_t stream = 0);
 
 template <typename T>
 void invokeMxFP8Quantization(int b, int m, int n, int padded_n, T const* input, int64_t* output, int32_t* SFOuput,
@@ -84,7 +85,8 @@ void invokeMxFP8Quantization(int b, int m, int n, int padded_n, T const* input, 
 
 template <typename T, int SF_VEC_SIZE = 16>
 void invokeFP4Dequantization(int m, int n, int64_t const* input, int32_t const* SFInput, float const* globalScale,
-    T* output, bool useUE8M0, FP4QuantizationSFLayout layout, int multiProcessorCount, cudaStream_t stream = 0);
+    T* output, bool useUE8M0, FP4QuantizationSFLayout layout, int multiProcessorCount, bool perTokenGlobalScale,
+    cudaStream_t stream = 0);
 
 void invokeBlockScaleInterleave(int b, int m, int m_padded, int n, int n_padded, uint8_t const* SFIn, uint8_t* SFOutput,
     int multiProcessorCount, cudaStream_t stream = 0);

--- a/cpp/tensorrt_llm/kernels/quantization.h
+++ b/cpp/tensorrt_llm/kernels/quantization.h
@@ -85,7 +85,7 @@ void invokeMxFP8Quantization(int b, int m, int n, int padded_n, T const* input, 
 
 template <typename T, int SF_VEC_SIZE = 16>
 void invokeFP4Dequantization(int m, int n, int64_t const* input, int32_t const* SFInput, float const* globalScale,
-    T* output, bool useUE8M0, FP4QuantizationSFLayout layout, int multiProcessorCount, bool perTokenGlobalScale,
+    T* output, bool useUE8M0, QuantizationSFLayout layout, int multiProcessorCount, bool perTokenGlobalScale,
     cudaStream_t stream = 0);
 
 void invokeBlockScaleInterleave(int b, int m, int m_padded, int n, int n_padded, uint8_t const* SFIn, uint8_t* SFOutput,

--- a/cpp/tensorrt_llm/kernels/quantization.h
+++ b/cpp/tensorrt_llm/kernels/quantization.h
@@ -82,6 +82,10 @@ template <typename T>
 void invokeMxFP8Quantization(int b, int m, int n, int padded_n, T const* input, int64_t* output, int32_t* SFOuput,
     QuantizationSFLayout layout, int multiProcessorCount, cudaStream_t stream = 0);
 
+template <typename T, int SF_VEC_SIZE = 16>
+void invokeFP4Dequantization(int m, int n, int64_t const* input, int32_t const* SFInput, float const* globalScale,
+    T* output, bool useUE8M0, FP4QuantizationSFLayout layout, int multiProcessorCount, cudaStream_t stream = 0);
+
 void invokeBlockScaleInterleave(int b, int m, int m_padded, int n, int n_padded, uint8_t const* SFIn, uint8_t* SFOutput,
     int multiProcessorCount, cudaStream_t stream = 0);
 

--- a/cpp/tensorrt_llm/thop/fp4Quantize.cpp
+++ b/cpp/tensorrt_llm/thop/fp4Quantize.cpp
@@ -29,7 +29,7 @@
 namespace torch_ext
 {
 // self: [M, K], fp16/bf16/fp8_quantized
-// globalScale: [1] float, = (448 * 6) / self.abs().max(). Not used when sfUseUE8M0 is true.
+// globalScale: [1] or [M] float, = (448 * 6) / self.abs().max(). Not used when sfUseUE8M0 is true.
 // nvfp4: sfVecSize = 16, sfUseUE8M0 = false
 // mxfp4: sfVecSize = 32, sfUseUE8M0 = true
 // alignment: sfVecSize
@@ -72,6 +72,14 @@ std::tuple<at::Tensor, at::Tensor> fp4_quantize(at::Tensor const& self, std::opt
     auto const k = inputShape[rank - 1];
     TORCH_CHECK(k % sfVecSize == 0);
 
+    // Check globalScale shape - support both [1] and [m] shapes
+    auto const& numGlobalScales = globalScale.numel();
+    TORCH_CHECK(numGlobalScales == 1 || numGlobalScales == m,
+        "Number of global scales must be 1 (shared) or match number of rows in input tensor (", m, "), but got ",
+        numGlobalScales);
+
+    bool isPerTokenGlobalScale = numGlobalScales == m;
+
     std::vector<int64_t> outputShape(inputShape.begin(), inputShape.end());
     outputShape[rank - 1] = k / 2;
 
@@ -92,7 +100,7 @@ std::tuple<at::Tensor, at::Tensor> fp4_quantize(at::Tensor const& self, std::opt
     tensorrt_llm::kernels::invokeFP4Quantization<T, SF_VEC_SIZE>(1, m, k, reinterpret_cast<T*>(self.data_ptr()),       \
         globalScalePtr, reinterpret_cast<int64_t*>(valueE2M1.data_ptr()),                                              \
         reinterpret_cast<int32_t*>(scaleFP8SF.data_ptr()), sfUseUE8M0, layout, mMultiProcessorCount,                   \
-        at::cuda::getCurrentCUDAStream(self.get_device()));
+        isPerTokenGlobalScale, at::cuda::getCurrentCUDAStream(self.get_device()));
 
     if (sfUseUE8M0)
     {
@@ -156,7 +164,7 @@ std::tuple<at::Tensor, at::Tensor> fp4_quantize(at::Tensor const& self, std::opt
 
 // fp4Tensor: [M, K / 2], FLOAT4_E2M1X2
 // scaleFactors: ceil(M / 128) * 128 * ceil(K / sfVecSize / 4) * 4, SF_DTYPE (UE4M3 or UE8M0)
-// globalScale: [1] float, = (448 * 6) / original_tensor.abs().max()
+// globalScale: [1] or [M] float, = (448 * 6) / original_tensor.abs().max()
 // sfVecSize: 16 for nvfp4, 32 for mxfp4 (not supported yet)
 // sfUseUE8M0: false for nvfp4, true for mxfp4
 // isSfSwizzledLayout: bool, if true, the scale factors are stored in swizzled layout
@@ -181,6 +189,16 @@ at::Tensor fp4_dequantize(at::Tensor const& fp4Tensor, at::Tensor const& scaleFa
         m *= inputShape[i];
     }
     auto const k = inputShape[rank - 1] * 2; // FP4 is packed, so K is double the last dimension
+
+    // Check globalScale shape - support both [1] and [m] shapes
+    auto const& numGlobalScales = globalScale.numel();
+    TORCH_CHECK(numGlobalScales == 1 || numGlobalScales == m,
+        "Number of global scales must be 1 (shared) or match number of rows in input tensor (", m, "), but got ",
+        numGlobalScales);
+
+    bool isPerTokenGlobalScale = numGlobalScales == m;
+
+    // No special handling needed for per-token global scaling - the kernel handles it now
 
     // Determine output data type
     torch::ScalarType outputScalarType;
@@ -216,7 +234,7 @@ at::Tensor fp4_dequantize(at::Tensor const& fp4Tensor, at::Tensor const& scaleFa
 #define LAUNCH_FP4_DEQUANTIZE_KERNEL(T)                                                                                \
     tensorrt_llm::kernels::invokeFP4Dequantization(m, k, reinterpret_cast<int64_t const*>(fp4Tensor.data_ptr()),       \
         reinterpret_cast<int32_t const*>(scaleFactors.data_ptr()), globalScale.data_ptr<float>(),                      \
-        reinterpret_cast<T*>(output.data_ptr()), sfUseUE8M0, layout, mMultiProcessorCount,                             \
+        reinterpret_cast<T*>(output.data_ptr()), sfUseUE8M0, layout, mMultiProcessorCount, isPerTokenGlobalScale,      \
         at::cuda::getCurrentCUDAStream(fp4Tensor.get_device()));
 
     if (output.scalar_type() == at::ScalarType::Half)

--- a/cpp/tensorrt_llm/thop/fp4Quantize.h
+++ b/cpp/tensorrt_llm/thop/fp4Quantize.h
@@ -26,4 +26,8 @@ namespace torch_ext
 {
 std::tuple<at::Tensor, at::Tensor> fp4_quantize(at::Tensor const& self, std::optional<at::Tensor> const& globalScale,
     int64_t sfVecSize, bool sfUseUE8M0, bool isSfSwizzledLayout);
-}
+
+torch::Tensor fp4_dequantize(torch::Tensor const& fp4Tensor, torch::Tensor const& scaleFactors,
+    torch::Tensor const& globalScale, int64_t sfVecSize, bool sfUseUE8M0, bool isSfSwizzledLayout,
+    std::string const& outputDataType);
+} // namespace torch_ext

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_wide_ep.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_wide_ep.py
@@ -536,7 +536,7 @@ class WideEPMoE(MoE):
                             self.fc31_input_scale,
                             self.scaling_vector_size,
                             sfUseUE8M0=False,
-                            swizzedLayout=False)
+                            isSfSwizzledLayout=False)
                     x_sf = x_sf.view((x_row, -1))
 
             elif self.has_deepseek_fp8_block_scales:

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_wide_ep.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_wide_ep.py
@@ -252,7 +252,7 @@ class WideEPMoE(MoE):
         if os.environ.get("TRTLLM_MOE_DISABLE_ALLTOALLV", "0") == "1":
             return AlltoallMethodType.NotEnabled
 
-        if mapping.moe_ep_size <= top_k:
+        if mapping.moe_ep_size < top_k:
             return AlltoallMethodType.NotEnabled
 
         if MnnvlMemory.supports_mnnvl():

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_wide_ep.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_wide_ep.py
@@ -684,6 +684,7 @@ class WideEPMoE(MoE):
                     self.dummy_allreduce()
                 final_hidden_states = self.alltoall_combine(
                     final_hidden_states, alltoall_info, token_count)
+
             elif self.alltoall_method_type == AlltoallMethodType.DeepEP:
                 final_hidden_states = self.unpad_tensors(
                     padded, final_hidden_states)

--- a/tests/unittest/_torch/thop/test_fp4_dequantize.py
+++ b/tests/unittest/_torch/thop/test_fp4_dequantize.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import torch
+from parameterized import parameterized
+from utils.util import unittest_name_func
+
+import tensorrt_llm
+
+
+class TestFP4Dequantize(unittest.TestCase):
+    """Test suite for FP4 quantization and dequantization accuracy validation."""
+
+    def setUp(self):
+        tensorrt_llm.logger.set_level("warning")
+        torch.manual_seed(42)
+        torch.cuda.manual_seed(42)
+
+    @parameterized.expand(
+        [(seq_len, hidden_dim, swizzled_layout, output_dtype)
+         for seq_len in [1, 128, 512] for hidden_dim in [32, 128, 1024, 7168]
+         for swizzled_layout in [True, False]
+         for output_dtype in ["float16", "bfloat16", "float32"]],
+        name_func=unittest_name_func,
+    )
+    def test_compare_cpu_gpu_implementations(self, seq_len, hidden_dim,
+                                             swizzled_layout, output_dtype):
+        """Compare GPU dequantization with CPU reference implementation."""
+        # Create test tensor with parameterized dimensions and dtype
+        test_tensor = torch.randn(seq_len,
+                                  hidden_dim,
+                                  dtype=torch.float16,
+                                  device='cuda')
+
+        # Create global scale factor
+        global_scale = (448 * 6) / test_tensor.abs().max().float()
+
+        sf_vec_size = 16
+        sf_use_ue8m0 = False
+
+        # Quantize using GPU
+        fp4_tensor, scale_factors = torch.ops.trtllm.fp4_quantize(
+            test_tensor, global_scale, sf_vec_size, sf_use_ue8m0,
+            swizzled_layout)
+
+        # Dequantize using GPU
+        dequantized_gpu = torch.ops.trtllm.fp4_dequantize(
+            fp4_tensor, scale_factors, 1.0 / global_scale, sf_vec_size,
+            sf_use_ue8m0, swizzled_layout, output_dtype)
+
+        # Dequantize using CPU reference
+        dequantized_cpu = torch.ops.tensorrt_llm.e2m1_and_ufp8sf_scale_to_float_v2(
+            fp4_tensor.cpu(),
+            scale_factors.cpu(),
+            (1.0 / global_scale).cpu(),
+            sf_vec_size,
+            1,  # sf_type (1 for UE4M3)
+            swizzled_layout)
+
+        # Compare results
+        self.assertTrue(
+            torch.allclose(dequantized_cpu,
+                           dequantized_gpu.cpu().to(dequantized_cpu.dtype),
+                           atol=1e-2,
+                           rtol=1e-2))


### PR DESCRIPTION
# PR title

Low precision alltoall for moe combine function

## Description

In the `WIDEEP` moe backend, nvfp4 can be used for alltoall to reduce communication volume.

How to enable it:

Set the environment variable `TRTLLM_MOE_USE_LOW_PRECISION_ALLTOALL_COMBINE` to `1`.
Precision: now we support `fp4` and `fp8`
Set the environment variable `TRTLLM_MOE_LOW_PRECISION_ALLTOALL_COMBINE_DTYPE` to `fp4` or `fp8`


## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for FP4 dequantization, enabling conversion of quantized FP4 tensors back to floating-point types (float16, bfloat16, float32) with flexible scaling options.
  * Enhanced quantization and dequantization functions to support both shared and per-token global scaling.
  * Introduced low-precision (FP4/FP8) alltoall combine functionality for improved efficiency in MoE workflows.
  * Added auxiliary CUDA stream and event handling for overlapping operations and improved performance in MoE modules.

* **Bug Fixes**
  * Improved argument validation and handling for quantization and dequantization functions.

* **Tests**
  * Added comprehensive unit tests to verify the accuracy of FP4 quantization and dequantization across multiple configurations.

* **Chores**
  * Updated command-line options and enums to support new MoE backend choices and auxiliary stream types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->