### PR TITLE
[fix] Move NCCL group in all-gather and reduce-scatter OPs outside the outer loop

### DIFF
--- a/cpp/tensorrt_llm/thop/allgatherOp.cpp
+++ b/cpp/tensorrt_llm/thop/allgatherOp.cpp
@@ -82,8 +82,8 @@ public:
             auto output = torch::empty(outputShape, input.options());
             if (use_nccl_allgather)
             {
-                NCCLCHECK_THROW(ncclAllGather(input.data_ptr(), output.mutable_data_ptr(), input.numel(),
-                    (*getDtypeMap())[type], *mNcclComm, stream));
+                ncclAllGather(input.data_ptr(), output.mutable_data_ptr(), input.numel(), (*getDtypeMap())[type],
+                    *mNcclComm, stream);
             }
             else
             {
@@ -93,15 +93,15 @@ public:
                 for (int root = 0; root < static_cast<int>(mGroup.size()); ++root)
                 {
                     auto split_size = sizes.value()[root];
-                    NCCLCHECK_THROW(ncclBroadcast(input.data_ptr(),
+                    ncclBroadcast(input.data_ptr(),
                         output.index({torch::indexing::Slice(split_offset, torch::indexing::None)}).mutable_data_ptr(),
-                        numel_base * split_size, (*getDtypeMap())[type], root, *mNcclComm, stream));
+                        numel_base * split_size, (*getDtypeMap())[type], root, *mNcclComm, stream);
                     split_offset += split_size;
                 }
             }
             output_list.push_back(output);
         }
-        ncclGroupEnd();
+        NCCLCHECK_THROW(ncclGroupEnd());
         return output_list;
     }
 

--- a/cpp/tensorrt_llm/thop/allgatherOp.cpp
+++ b/cpp/tensorrt_llm/thop/allgatherOp.cpp
@@ -55,68 +55,59 @@ public:
         return 0;
     }
 
-    torch::Tensor run(torch::Tensor input, torch::optional<torch::List<int64_t>> sizes)
-    {
-        TLLM_CHECK_WITH_INFO(mNcclComm.get() != nullptr, "mNcclComm should be initialized before used");
-        auto stream = at::cuda::getCurrentCUDAStream(input.get_device());
-        auto type = tensorrt_llm::runtime::TorchUtils::dataType(input.scalar_type());
-        std::vector<int64_t> outputShape = input.sizes().vec();
-        if (sizes.has_value())
-        {
-            outputShape[0] = std::accumulate(sizes.value().begin(), sizes.value().end(), 0, std::plus<>{});
-        }
-        else
-        {
-            outputShape[0] *= mGroup.size();
-        }
-        auto output = torch::empty(outputShape, input.options());
-        bool use_nccl_allgather = !sizes.has_value()
-            || std::all_of(sizes.value().begin(), sizes.value().end(),
-                [&sizes](int64_t size) { return size == sizes.value()[0]; });
-        if (use_nccl_allgather)
-        {
-            NCCLCHECK_THROW(ncclAllGather(input.data_ptr(), output.mutable_data_ptr(), input.numel(),
-                (*getDtypeMap())[type], *mNcclComm, stream));
-        }
-        else
-        {
-            size_t numel_base = std::accumulate(outputShape.cbegin() + 1, outputShape.cend(), 1, std::multiplies<>{});
-            int64_t split_offset = 0;
-            ncclGroupStart();
-            for (int root = 0; root < static_cast<int>(mGroup.size()); ++root)
-            {
-                auto split_size = sizes.value()[root];
-                NCCLCHECK_THROW(ncclBroadcast(input.data_ptr(),
-                    output.index({torch::indexing::Slice(split_offset, torch::indexing::None)}).mutable_data_ptr(),
-                    numel_base * split_size, (*getDtypeMap())[type], root, *mNcclComm, stream));
-                split_offset += split_size;
-            }
-            ncclGroupEnd();
-        }
-        return output;
-    }
-
     std::vector<torch::Tensor> run_list(torch::TensorList input_list, torch::optional<torch::List<int64_t>> sizes)
     {
-        std::vector<torch::Tensor> output_list;
-        output_list.reserve(input_list.size());
+        TLLM_CHECK_WITH_INFO(mNcclComm.get() != nullptr, "mNcclComm should be initialized before used");
         bool use_nccl_allgather = !sizes.has_value()
             || std::all_of(sizes.value().begin(), sizes.value().end(),
                 [&sizes](int64_t size) { return size == sizes.value()[0]; });
-        if (use_nccl_allgather)
-        {
-            ncclGroupStart();
-        }
+        int64_t sum_sizes
+            = sizes.has_value() ? std::accumulate(sizes.value().begin(), sizes.value().end(), 0, std::plus<>{}) : 0;
+        std::vector<torch::Tensor> output_list;
+        output_list.reserve(input_list.size());
+        ncclGroupStart();
         for (auto const& input : input_list)
         {
-            auto output = run(input, sizes);
+            auto stream = at::cuda::getCurrentCUDAStream(input.get_device());
+            auto type = tensorrt_llm::runtime::TorchUtils::dataType(input.scalar_type());
+            std::vector<int64_t> outputShape = input.sizes().vec();
+            if (sizes.has_value())
+            {
+                outputShape[0] = sum_sizes;
+            }
+            else
+            {
+                outputShape[0] *= mGroup.size();
+            }
+            auto output = torch::empty(outputShape, input.options());
+            if (use_nccl_allgather)
+            {
+                NCCLCHECK_THROW(ncclAllGather(input.data_ptr(), output.mutable_data_ptr(), input.numel(),
+                    (*getDtypeMap())[type], *mNcclComm, stream));
+            }
+            else
+            {
+                size_t numel_base
+                    = std::accumulate(outputShape.cbegin() + 1, outputShape.cend(), 1, std::multiplies<>{});
+                int64_t split_offset = 0;
+                for (int root = 0; root < static_cast<int>(mGroup.size()); ++root)
+                {
+                    auto split_size = sizes.value()[root];
+                    NCCLCHECK_THROW(ncclBroadcast(input.data_ptr(),
+                        output.index({torch::indexing::Slice(split_offset, torch::indexing::None)}).mutable_data_ptr(),
+                        numel_base * split_size, (*getDtypeMap())[type], root, *mNcclComm, stream));
+                    split_offset += split_size;
+                }
+            }
             output_list.push_back(output);
         }
-        if (use_nccl_allgather)
-        {
-            ncclGroupEnd();
-        }
+        ncclGroupEnd();
         return output_list;
+    }
+
+    torch::Tensor run(torch::Tensor input, torch::optional<torch::List<int64_t>> sizes)
+    {
+        return run_list({input}, sizes)[0];
     }
 
 private:


### PR DESCRIPTION
# PR title

Please write the PR title by following template:

[JIRA ticket link/nvbug link/github issue link][fix/feat/doc/infra/...] \<summary of this PR\>

For example, assume I have a PR hope to support a new feature about cache manager of Jira TRTLLM-1000 ticket, it would be like

[TRTLLM-1000][feat] Support a new feature about cache manager

## Description

Please explain the issue and the solution in short.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
