### PR TITLE
refactor: Enhanced handling of decoder requests and logits within the batch manager

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/decoderBuffers.h
+++ b/cpp/include/tensorrt_llm/batch_manager/decoderBuffers.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "tensorrt_llm/batch_manager/common.h"
 #include "tensorrt_llm/runtime/bufferManager.h"
 #include "tensorrt_llm/runtime/iTensor.h"
 #include "tensorrt_llm/runtime/modelConfig.h"
@@ -38,8 +39,8 @@ public:
     using SizeType32 = runtime::SizeType32;
     using TensorPtr = runtime::ITensor::SharedPtr;
 
-    explicit DecoderInputBuffers(SizeType32 maxNumSequences, SizeType32 maxBatchSize, SizeType32 maxDecoderSteps,
-        runtime::BufferManager const& manager);
+    explicit DecoderInputBuffers(
+        SizeType32 maxBatchSize, SizeType32 maxDecoderSteps, runtime::BufferManager const& manager);
 
     void setupMedusaLogits(SizeType32 maxNumSequences, runtime::ModelConfig const& modelConfig);
 
@@ -56,11 +57,13 @@ public:
 
     //! Buffers for decoder forward
 
+    //! Requests for considered in decoder forward
+    RequestVector decoderRequests;
+
     //! Batch slots for all decoder steps, [maxDecoderSteps][maxBatchSize]
     std::vector<TensorPtr> forwardBatchSlots;
 
-    //! Logits for all batch slots, [maxNumSequences]
-    //! The vector is sparse, only slots in forwardBatchSlots are used.
+    //! Logits of decoder requests
     std::vector<TensorPtr> logits;
 
     //! Logits for speculative decoding (Medusa)

--- a/cpp/include/tensorrt_llm/batch_manager/guidedDecoder.h
+++ b/cpp/include/tensorrt_llm/batch_manager/guidedDecoder.h
@@ -29,6 +29,7 @@ class GrammarCompiler;
 
 namespace tensorrt_llm::batch_manager
 {
+class DecoderInputBuffers;
 
 class GuidedDecoder
 {
@@ -40,8 +41,7 @@ public:
     GuidedDecoder(executor::GuidedDecodingConfig const& guidedDecodingConfig, SizeType32 maxNumSequences,
         SizeType32 vocabSizePadded, nvinfer1::DataType logitsDtype, runtime::BufferManager const& runtimeBufferManager);
     void build(ScheduledRequests const& scheduledRequests);
-    void execute(ScheduledRequests const& scheduledRequests, runtime::BufferManager const& runtimeBufferManager,
-        std::vector<TensorPtr> const& decoderBuffersLogits);
+    void execute(DecoderInputBuffers const& decoderInputBuffers, runtime::BufferManager const& runtimeBufferManager);
 
 private:
     executor::GuidedDecodingConfig::GuidedDecodingBackend mGuidedDecodingBackend;

--- a/cpp/include/tensorrt_llm/batch_manager/logitsPostProcessor.h
+++ b/cpp/include/tensorrt_llm/batch_manager/logitsPostProcessor.h
@@ -29,6 +29,7 @@ class CudaStream;
 
 namespace tensorrt_llm::batch_manager
 {
+class DecoderInputBuffers;
 
 class LogitsPostProcessor : Algorithm
 {
@@ -44,10 +45,8 @@ public:
 
     LogitsPostProcessor() = default;
 
-    bool operator()(RequestVector const& contextRequests, RequestVector const& generationRequests,
-        bool replicateLogitsPostProcessor, std::vector<batch_manager::LlmRequest::TensorPtr>& seqSlotLogits,
+    bool operator()(DecoderInputBuffers& inputBuffers, bool replicateLogitsPostProcessor,
         runtime::WorldConfig const& worldConfig, CudaStreamPtr const& stream,
-        std::optional<LogitsPostProcessorBatched> logitsPostProcessorBatched = std::nullopt) const;
         std::optional<LogitsPostProcessorBatched> logitsPostProcessorBatched = std::nullopt) const;
 };
 

--- a/cpp/include/tensorrt_llm/batch_manager/logitsPostProcessor.h
+++ b/cpp/include/tensorrt_llm/batch_manager/logitsPostProcessor.h
@@ -24,7 +24,7 @@
 
 namespace tensorrt_llm::runtime
 {
-class TllmRuntime;
+class CudaStream;
 }
 
 namespace tensorrt_llm::batch_manager
@@ -33,10 +33,11 @@ namespace tensorrt_llm::batch_manager
 class LogitsPostProcessor : Algorithm
 {
 public:
+    using CudaStreamPtr = std::shared_ptr<runtime::CudaStream>;
+
     using LogitsPostProcessorBatched = std::function<void(std::vector<batch_manager::LlmRequest::RequestIdType> const&,
         std::vector<batch_manager::LlmRequest::TensorPtr>&,
-        std::vector<std::reference_wrapper<batch_manager::LlmRequest::BeamTokens const>> const&,
-        runtime::BufferManager::CudaStreamPtr const&,
+        std::vector<std::reference_wrapper<batch_manager::LlmRequest::BeamTokens const>> const&, CudaStreamPtr const&,
         std::vector<std::optional<batch_manager::LlmRequest::RequestIdType>> const&)>;
 
     constexpr static auto name{"LogitsPostProcessor"};
@@ -45,7 +46,8 @@ public:
 
     bool operator()(RequestVector const& contextRequests, RequestVector const& generationRequests,
         bool replicateLogitsPostProcessor, std::vector<batch_manager::LlmRequest::TensorPtr>& seqSlotLogits,
-        runtime::WorldConfig const& worldConfig, runtime::TllmRuntime& runtime,
+        runtime::WorldConfig const& worldConfig, CudaStreamPtr const& stream,
+        std::optional<LogitsPostProcessorBatched> logitsPostProcessorBatched = std::nullopt) const;
         std::optional<LogitsPostProcessorBatched> logitsPostProcessorBatched = std::nullopt) const;
 };
 

--- a/cpp/include/tensorrt_llm/batch_manager/makeDecodingBatchInputOutput.h
+++ b/cpp/include/tensorrt_llm/batch_manager/makeDecodingBatchInputOutput.h
@@ -46,8 +46,7 @@ public:
 
     MakeDecodingBatchInputOutput() = default;
 
-    std::unique_ptr<runtime::decoder_batch::Input> operator()(RequestVector const& contextRequests,
-        RequestVector const& generationRequests, DecoderInputBuffers const& inputBuffers,
+    std::unique_ptr<runtime::decoder_batch::Input> operator()(DecoderInputBuffers& inputBuffers,
         runtime::decoder::DecoderState& decoderState, runtime::ModelConfig const& modelConfig,
         SizeType32 maxNumSequences, OptionalRef<RuntimeBuffers> fusedRuntimeBuffers) const;
 

--- a/cpp/tensorrt_llm/batch_manager/decoderBuffers.cpp
+++ b/cpp/tensorrt_llm/batch_manager/decoderBuffers.cpp
@@ -31,7 +31,7 @@ namespace tensorrt_llm::batch_manager
 {
 
 DecoderInputBuffers::DecoderInputBuffers(
-    SizeType32 maxNumSequences, SizeType32 maxBatchSize, SizeType32 maxDecoderSteps, BufferManager const& manager)
+    SizeType32 maxBatchSize, SizeType32 maxDecoderSteps, BufferManager const& manager)
 {
     auto const maxBatchSizeShape = ITensor::makeShape({maxBatchSize});
     auto const nvSizeType = TRTDataType<SizeType32>::value;
@@ -49,8 +49,6 @@ DecoderInputBuffers::DecoderInputBuffers(
     {
         forwardBatchSlots.emplace_back(BufferManager::pinnedPool(ITensor::makeShape({maxBatchSize}), nvSizeType));
     }
-
-    logits.resize(maxNumSequences);
 }
 
 void DecoderInputBuffers::setupMedusaLogits(SizeType32 maxNumSequences, ModelConfig const& modelConfig)

--- a/cpp/tensorrt_llm/batch_manager/guidedDecoder.cpp
+++ b/cpp/tensorrt_llm/batch_manager/guidedDecoder.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "tensorrt_llm/batch_manager/guidedDecoder.h"
+#include "tensorrt_llm/batch_manager/decoderBuffers.h"
 #include "tensorrt_llm/batch_manager/llmRequest.h"
 #include "tensorrt_llm/kernels/logitsBitmask.h"
 
@@ -136,8 +137,7 @@ void GuidedDecoder::build(ScheduledRequests const& scheduledRequests)
     }
 }
 
-void GuidedDecoder::execute(ScheduledRequests const& scheduledRequests, BufferManager const& runtimeBufferManager,
-    std::vector<TensorPtr> const& decoderBuffersLogits)
+void GuidedDecoder::execute(DecoderInputBuffers const& decoderInputBuffers, BufferManager const& runtimeBufferManager)
 {
     auto const& stream = runtimeBufferManager.getStream();
 
@@ -150,32 +150,28 @@ void GuidedDecoder::execute(ScheduledRequests const& scheduledRequests, BufferMa
     mCopyBufferManager.getStream().record(event);
     stream.wait(event);
 
-    SizeType32 batchIdx{0};
-    if (mGuidedDecodingBackend == executor::GuidedDecodingConfig::GuidedDecodingBackend::kXGRAMMAR)
+    if (mGuidedDecodingBackend == executor::GuidedDecodingConfig::GuidedDecodingBackend::kXGRAMMAR
+        && !decoderInputBuffers.decoderRequests.empty())
     {
-        for (auto const& requests : {scheduledRequests.contextRequests, scheduledRequests.generationRequests})
+        SizeType32 batchIdx{0};
+        for (size_t requestIdx = 0; requestIdx < decoderInputBuffers.decoderRequests.size(); ++requestIdx)
         {
-            for (auto const& llmReq : requests)
+            auto const& llmReq = decoderInputBuffers.decoderRequests.at(requestIdx);
+
+            auto const& guidedDecodingParams = llmReq->getGuidedDecodingParams();
+            if (guidedDecodingParams.has_value())
             {
-                if (llmReq->isContextInitState() && !llmReq->isLastContextChunk())
-                {
-                    continue;
-                }
-                auto const& guidedDecodingParams = llmReq->getGuidedDecodingParams();
-                if (guidedDecodingParams.has_value())
-                {
-                    auto const seqSlot = llmReq->mSeqSlot.value();
+                auto const seqSlot = llmReq->mSeqSlot.value();
 
-                    auto const& logits = decoderBuffersLogits.at(seqSlot);
-                    auto const logitsBitmask = ITensor::at(mLogitsBitmask, {seqSlot});
+                auto const& logits = decoderInputBuffers.logits.at(requestIdx);
+                auto const logitsBitmask = ITensor::at(mLogitsBitmask, {seqSlot});
 
-                    // Use void* to unify the code for different mLogitsDtype
-                    *reinterpret_cast<void**>(ITensor::at(mLogitsPtrVecHost, {batchIdx})->data()) = logits->data();
-                    *reinterpret_cast<void**>(ITensor::at(mLogitsBitmaskPtrVecHost, {batchIdx})->data())
-                        = logitsBitmask->data();
+                // Use void* to unify the code for different mLogitsDtype
+                *reinterpret_cast<void**>(ITensor::at(mLogitsPtrVecHost, {batchIdx})->data()) = logits->data();
+                *reinterpret_cast<void**>(ITensor::at(mLogitsBitmaskPtrVecHost, {batchIdx})->data())
+                    = logitsBitmask->data();
 
-                    ++batchIdx;
-                }
+                ++batchIdx;
             }
         }
         if (batchIdx > 0)

--- a/cpp/tensorrt_llm/batch_manager/handleContextLogits.cpp
+++ b/cpp/tensorrt_llm/batch_manager/handleContextLogits.cpp
@@ -76,6 +76,13 @@ SizeType32 HandleContextLogits::operator()(DecoderInputBuffers& inputBuffers, Re
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
     NVTX3_SCOPED_RANGE(HandleContextLogits);
 
+    auto& decoderRequests = inputBuffers.decoderRequests;
+    decoderRequests.clear();
+    decoderRequests.reserve(contextRequests.size());
+    auto& allDecoderLogits = inputBuffers.logits;
+    allDecoderLogits.clear();
+    allDecoderLogits.reserve(contextRequests.size());
+
     SizeType32 batchIndex{0};
     SizeType32 logitsIndex{0};
     // Copy logits into decoderBuffers.logits
@@ -115,7 +122,6 @@ SizeType32 HandleContextLogits::operator()(DecoderInputBuffers& inputBuffers, Re
         // Get the logits from the last context token and draft tokens
         auto const numDecoderLogits = 1 + draftLength;
         auto const seqSlot = llmReq->mSeqSlot.value();
-        auto& decoderLogits = inputBuffers.logits.at(seqSlot);
         TensorPtr logitsView = ITensor::slice(logits, logitsIndex - numDecoderLogits, numDecoderLogits);
 
         if (modelConfig.getSpeculativeDecodingMode().hasDraftLogits())
@@ -136,21 +142,28 @@ SizeType32 HandleContextLogits::operator()(DecoderInputBuffers& inputBuffers, Re
 
         TLLM_CHECK_DEBUG_WITH_INFO(tru::tensorHasInvalid<float>(*logitsView, manager, "logits") == false,
             "Found invalid number (NaN or Inf) in logits");
-        // Scatter the output logits to the decoderLogits
-        auto const reqBeamWidth = llmReq->getBeamWidthByIter();
-        if (reqBeamWidth > 1)
+
+        if (llmReq->isLastContextChunk())
         {
-            // Tile logits of context requests
-            auto const& logitsShape = logitsView->getShape();
-            auto const logitsType = logitsView->getDataType();
-            decoderLogits = manager.gpu(ITensor::makeShape({reqBeamWidth, logitsShape.d[1]}), logitsType);
-            tensorrt_llm::runtime::kernels::tileTensor(*decoderLogits, *logitsView, reqBeamWidth, manager.getStream());
-            decoderLogits->unsqueeze(0);
-        }
-        else
-        {
-            decoderLogits = logitsView;
-            decoderLogits->unsqueeze(1);
+            TensorPtr decoderLogits;
+            auto const reqBeamWidth = llmReq->getBeamWidthByIter();
+            if (reqBeamWidth > 1)
+            {
+                // Tile logits of context requests
+                auto const& logitsShape = logitsView->getShape();
+                auto const logitsType = logitsView->getDataType();
+                decoderLogits = manager.gpu(ITensor::makeShape({reqBeamWidth, logitsShape.d[1]}), logitsType);
+                tensorrt_llm::runtime::kernels::tileTensor(
+                    *decoderLogits, *logitsView, reqBeamWidth, manager.getStream());
+                decoderLogits->unsqueeze(0);
+            }
+            else
+            {
+                decoderLogits = logitsView;
+                decoderLogits->unsqueeze(1);
+            }
+            decoderRequests.push_back(llmReq);
+            allDecoderLogits.emplace_back(std::move(decoderLogits));
         }
 
         ++batchIndex;

--- a/cpp/tensorrt_llm/batch_manager/handleContextLogits.cpp
+++ b/cpp/tensorrt_llm/batch_manager/handleContextLogits.cpp
@@ -141,7 +141,7 @@ SizeType32 HandleContextLogits::operator()(DecoderInputBuffers& inputBuffers, Re
         if (reqBeamWidth > 1)
         {
             // Tile logits of context requests
-            auto const logitsShape = logitsView->getShape();
+            auto const& logitsShape = logitsView->getShape();
             auto const logitsType = logitsView->getDataType();
             decoderLogits = manager.gpu(ITensor::makeShape({reqBeamWidth, logitsShape.d[1]}), logitsType);
             tensorrt_llm::runtime::kernels::tileTensor(*decoderLogits, *logitsView, reqBeamWidth, manager.getStream());
@@ -149,9 +149,8 @@ SizeType32 HandleContextLogits::operator()(DecoderInputBuffers& inputBuffers, Re
         }
         else
         {
-            auto const logitsViewShape = logitsView->getShape();
-            decoderLogits
-                = ITensor::view(logitsView, ITensor::makeShape({logitsViewShape.d[0], 1, logitsViewShape.d[1]}));
+            decoderLogits = logitsView;
+            decoderLogits->unsqueeze(1);
         }
 
         ++batchIndex;

--- a/cpp/tensorrt_llm/batch_manager/handleGenerationLogits.cpp
+++ b/cpp/tensorrt_llm/batch_manager/handleGenerationLogits.cpp
@@ -102,7 +102,7 @@ void HandleGenerationLogits::operator()(DecoderInputBuffers& inputBuffers, Reque
         TLLM_CHECK_DEBUG_WITH_INFO(tru::tensorHasInvalid<float>(*logitsView, manager, "logits") == false,
             "Found invalid number (NaN or Inf) in logits");
         auto& decoderLogits = inputBuffers.logits.at(seqSlot);
-        auto const logitsViewShape = logitsView->getShape();
+
         if (reqBeamWidth > 1)
         {
             decoderLogits = logitsView;
@@ -110,8 +110,8 @@ void HandleGenerationLogits::operator()(DecoderInputBuffers& inputBuffers, Reque
         }
         else
         {
-            decoderLogits
-                = ITensor::view(logitsView, ITensor::makeShape({logitsViewShape.d[0], 1, logitsViewShape.d[1]}));
+            decoderLogits = logitsView;
+            decoderLogits->unsqueeze(1);
         }
 
         if (llmReq->getReturnGenerationLogits())

--- a/cpp/tensorrt_llm/batch_manager/logitsPostProcessor.cpp
+++ b/cpp/tensorrt_llm/batch_manager/logitsPostProcessor.cpp
@@ -17,6 +17,7 @@
 
 #include "tensorrt_llm/batch_manager/logitsPostProcessor.h"
 
+#include "tensorrt_llm/batch_manager/decoderBuffers.h"
 #include "tensorrt_llm/batch_manager/llmRequest.h"
 #include "tensorrt_llm/batch_manager/runtimeBuffers.h"
 #include "tensorrt_llm/common/nvtxUtils.h"
@@ -31,9 +32,9 @@ using TensorPtr = runtime::ITensor::SharedPtr;
 using ITensor = runtime::ITensor;
 using SizeType32 = tensorrt_llm::runtime::SizeType32;
 
-bool LogitsPostProcessor::operator()(RequestVector const& contextRequests, RequestVector const& generationRequests,
-    bool replicateLogitsPostProcessor, std::vector<TensorPtr>& seqSlotLogits, tr::WorldConfig const& worldConfig,
-    CudaStreamPtr const& stream, std::optional<LogitsPostProcessorBatched> logitsPostProcessorBatched) const
+bool LogitsPostProcessor::operator()(DecoderInputBuffers& inputBuffers, bool replicateLogitsPostProcessor,
+    tr::WorldConfig const& worldConfig, CudaStreamPtr const& stream,
+    std::optional<LogitsPostProcessorBatched> logitsPostProcessorBatched) const
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
     NVTX3_SCOPED_RANGE(LogitsPostProcessor);
@@ -45,34 +46,27 @@ bool LogitsPostProcessor::operator()(RequestVector const& contextRequests, Reque
     std::vector<std::optional<LlmRequest::RequestIdType>> clientIdsVec;
 
     bool logitsPostProcessorIsApplied = false;
-    for (auto const& requests : {contextRequests, generationRequests})
+    for (size_t batchIdx = 0; batchIdx < inputBuffers.decoderRequests.size(); ++batchIdx)
     {
-        for (auto const& llmReq : requests)
+        auto const& llmReq = inputBuffers.decoderRequests.at(batchIdx);
+        auto& logits = inputBuffers.logits.at(batchIdx);
+
+        // Invoke non-batched processor or collect arguments for batched processor
+        if (llmReq->mLogitsPostProcessor)
         {
-            if (llmReq->isContextInitState() ? llmReq->isLastContextChunk() : llmReq->isGenerationInProgressState())
+            logitsPostProcessorIsApplied = true;
+            if (replicateLogitsPostProcessor || worldConfig.isFirstTensorParallelRank())
             {
-                // Invoke non-batched processor or collect arguments for batched processor
-                if (llmReq->mLogitsPostProcessor)
-                {
-                    logitsPostProcessorIsApplied = true;
-                    if (replicateLogitsPostProcessor || worldConfig.isFirstTensorParallelRank())
-                    {
-                        auto& logits = seqSlotLogits.at(llmReq->mSeqSlot.value());
-                        (*llmReq->mLogitsPostProcessor)(
-                            llmReq->mRequestId, logits, llmReq->getTokens(), stream, llmReq->mClientId);
-                    }
-                }
-                else if (llmReq->mApplyLogitsPostProcessorBatched)
-                {
-                    reqIdsVec.push_back(llmReq->mRequestId);
-
-                    auto& logits = seqSlotLogits.at(llmReq->mSeqSlot.value());
-                    logitsVec.push_back(logits);
-
-                    beamTokensVec.emplace_back(llmReq->getTokens());
-                    clientIdsVec.push_back(llmReq->mClientId);
-                }
+                (*llmReq->mLogitsPostProcessor)(
+                    llmReq->mRequestId, logits, llmReq->getTokens(), stream, llmReq->mClientId);
             }
+        }
+        else if (llmReq->mApplyLogitsPostProcessorBatched)
+        {
+            reqIdsVec.push_back(llmReq->mRequestId);
+            logitsVec.push_back(logits);
+            beamTokensVec.emplace_back(llmReq->getTokens());
+            clientIdsVec.push_back(llmReq->mClientId);
         }
     }
 

--- a/cpp/tensorrt_llm/batch_manager/makeDecodingBatchInputOutput.cpp
+++ b/cpp/tensorrt_llm/batch_manager/makeDecodingBatchInputOutput.cpp
@@ -33,7 +33,7 @@ using TensorPtr = MakeDecodingBatchInputOutput::TensorPtr;
 
 std::unique_ptr<tr::decoder_batch::Input> MakeDecodingBatchInputOutput::createDecoderBatchInputs(
     std::vector<SizeType32> const& activeSlots, runtime::decoder::DecoderState const& decoderState,
-    std::vector<TensorPtr> const& logits, SizeType32 maxNumSequences, std::vector<TensorPtr> const& batchSlots)
+    std::vector<TensorPtr> const& decoderLogits, SizeType32 maxNumSequences, std::vector<TensorPtr> const& batchSlots)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
 
@@ -47,40 +47,35 @@ std::unique_ptr<tr::decoder_batch::Input> MakeDecodingBatchInputOutput::createDe
         batchSlots.at(step)->resize(maxNumSequences);
     }
 
-    std::vector<SizeType32> batchIdx(maxDecoderSteps);
+    auto constexpr singleRequest = 1;
+
+    std::vector<SizeType32> batchSizes(maxDecoderSteps);
+    std::vector<std::vector<tr::ITensor::SharedConstPtr>> batchLogits(maxDecoderSteps);
     auto maxActiveDecoderSteps = 1;
-    for (auto const slot : activeSlots)
+    for (size_t batchIdx = 0; batchIdx < activeSlots.size(); ++batchIdx)
     {
+        auto const slot = activeSlots.at(batchIdx);
+        auto const& logits = decoderLogits.at(batchIdx);
+
         auto const numDecoderSteps = common::ceilDiv(numDecodingEngineTokens.at(slot), maxDecodingDecoderTokens);
         maxActiveDecoderSteps = std::max(maxActiveDecoderSteps, numDecoderSteps);
         for (SizeType32 step = 0; step < numDecoderSteps; ++step)
         {
             auto batchSlotsRange = tr::BufferRange<SizeType32>(*batchSlots.at(step));
-            batchSlotsRange[batchIdx[step]] = slot;
-            batchIdx[step]++;
+            batchSlotsRange[batchSizes[step]] = slot;
+            batchSizes[step]++;
+            TensorPtr logitsSlice = tr::ITensor::slice(logits, step, singleRequest);
+            batchLogits[step].emplace_back(std::move(logitsSlice));
         }
     }
 
     for (SizeType32 step = 0; step < maxDecoderSteps; ++step)
     {
-        batchSlots.at(step)->resize(batchIdx[step]);
+        batchSlots.at(step)->resize(batchSizes[step]);
     }
+    batchLogits.resize(maxActiveDecoderSteps);
 
-    auto constexpr singleRequest = 1;
-    std::vector<std::vector<tr::ITensor::SharedConstPtr>> logitsVec(maxActiveDecoderSteps);
-    for (SizeType32 step = 0; step < maxActiveDecoderSteps; ++step)
-    {
-        auto batchSlotsRange = tr::BufferRange<SizeType32>(*batchSlots.at(step));
-
-        for (auto slot : batchSlotsRange)
-        {
-            auto const& targetLogits = logits.at(slot);
-            TensorPtr logitsSlice = tr::ITensor::slice(targetLogits, step, singleRequest);
-            logitsVec.at(step).push_back(logitsSlice);
-        }
-    }
-
-    auto decodingInput = std::make_unique<tr::decoder_batch::Input>(logitsVec, maxActiveDecoderSteps);
+    auto decodingInput = std::make_unique<tr::decoder_batch::Input>(batchLogits, maxActiveDecoderSteps);
     decodingInput->batchSlots = batchSlots;
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
     return decodingInput;
@@ -89,21 +84,14 @@ std::unique_ptr<tr::decoder_batch::Input> MakeDecodingBatchInputOutput::createDe
 namespace
 {
 
-std::pair<std::vector<SizeType32>, std::vector<SizeType32>> getActiveSlots(
-    RequestVector const& contextRequests, RequestVector const& generationRequests)
+std::pair<std::vector<SizeType32>, std::vector<SizeType32>> getActiveSlots(RequestVector const& decoderRequests)
 {
     std::vector<SizeType32> activeSlots;
     std::vector<SizeType32> generationSteps;
-    for (auto const& requests : {contextRequests, generationRequests})
+    for (auto const& llmReq : decoderRequests)
     {
-        for (auto const& llmReq : requests)
-        {
-            if (llmReq->isGenerationInProgressState() || llmReq->isLastContextChunk())
-            {
-                activeSlots.push_back(llmReq->mSeqSlot.value());
-                generationSteps.push_back(llmReq->getDecodingIter());
-            }
-        }
+        activeSlots.push_back(llmReq->mSeqSlot.value());
+        generationSteps.push_back(llmReq->getDecodingIter());
     }
 
     return {activeSlots, generationSteps};
@@ -167,14 +155,13 @@ void setEagleInputs(tr::DecodingInput& dInput, RuntimeBuffers const& fusedRuntim
 
 } // namespace
 
-std::unique_ptr<tr::decoder_batch::Input> MakeDecodingBatchInputOutput::operator()(RequestVector const& contextRequests,
-    RequestVector const& generationRequests, DecoderInputBuffers const& inputBuffers,
+std::unique_ptr<tr::decoder_batch::Input> MakeDecodingBatchInputOutput::operator()(DecoderInputBuffers& inputBuffers,
     runtime::decoder::DecoderState& decoderState, runtime::ModelConfig const& modelConfig, SizeType32 maxNumSequences,
     OptionalRef<RuntimeBuffers> fusedRuntimeBuffers) const
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
 
-    auto [activeSlots, generationSteps] = getActiveSlots(contextRequests, generationRequests);
+    auto [activeSlots, generationSteps] = getActiveSlots(inputBuffers.decoderRequests);
 
     auto decodingInput = createDecoderBatchInputs(
         activeSlots, decoderState, inputBuffers.logits, maxNumSequences, inputBuffers.forwardBatchSlots);

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -2023,9 +2023,9 @@ runtime::CudaEvent TrtGptModelInflightBatching::decoderStepAsync(ScheduledReques
         copyCacheIndirectionFromOutputsToInputs(scheduledRequests, genBufferId);
     }
 
-    mLogitsPostProcessorIsApplied
-        = (*mLogitsPostProcessor)(scheduledRequests.contextRequests, scheduledRequests.generationRequests,
-            mReplicateLogitsPostProcessor, seqSlotLogits, mWorldConfig, *mRuntime, mLogitsPostProcessorBatched);
+    mLogitsPostProcessorIsApplied = (*mLogitsPostProcessor)(scheduledRequests.contextRequests,
+        scheduledRequests.generationRequests, mReplicateLogitsPostProcessor, seqSlotLogits, mWorldConfig,
+        mRuntime->getStreamPtr(), mLogitsPostProcessorBatched);
 
     if (mGuidedDecoder)
     {

--- a/cpp/tensorrt_llm/pybind/batch_manager/algorithms.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/algorithms.cpp
@@ -133,16 +133,16 @@ void tensorrt_llm::pybind::batch_manager::algorithms::initBindings(pybind11::mod
 
     py::class_<MakeDecodingBatchInputOutput>(m, MakeDecodingBatchInputOutput::name)
         .def(py::init())
-        .def("__call__", &MakeDecodingBatchInputOutput::operator(), py::arg("context_requests"),
-            py::arg("generation_requests"), py::arg("decoder_input_buffers"), py::arg("decoder_state"),
-            py::arg("model_config"), py::arg("max_num_sequences"), py::arg("fused_runtime_buffers") = std::nullopt)
+        .def("__call__", &MakeDecodingBatchInputOutput::operator(), py::arg("decoder_input_buffers"),
+            py::arg("decoder_state"), py::arg("model_config"), py::arg("max_num_sequences"),
+            py::arg("fused_runtime_buffers") = std::nullopt)
         .def("name", [](MakeDecodingBatchInputOutput const&) { return MakeDecodingBatchInputOutput::name; });
 
     py::class_<LogitsPostProcessor>(m, LogitsPostProcessor::name)
         .def(py::init())
-        .def("__call__", &LogitsPostProcessor::operator(), py::arg("context_requests"), py::arg("generation_requests"),
-            py::arg("replicate_logits_post_processor"), py::arg("decoder_buffers"), py::arg("world_config"),
-            py::arg("runtime"), py::arg("logits_post_processor_batched") = std::nullopt)
+        .def("__call__", &LogitsPostProcessor::operator(), py::arg("decoder_input_buffers"),
+            py::arg("replicate_logits_post_processor"), py::arg("world_config"), py::arg("stream"),
+            py::arg("logits_post_processor_batched") = std::nullopt)
         .def("name", [](LogitsPostProcessor const&) { return LogitsPostProcessor::name; });
 
     py::class_<CreateNewDecoderRequests>(m, CreateNewDecoderRequests::name)

--- a/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
@@ -393,16 +393,16 @@ void initBindings(pybind11::module_& m)
             py::arg("max_num_sequences"), py::arg("model_config"), py::arg("world_config"), py::arg("buffer_manager"));
 
     py::class_<tb::DecoderInputBuffers>(m, "DecoderInputBuffers")
-        .def(py::init<runtime::SizeType32, runtime::SizeType32, runtime::SizeType32, tr::BufferManager>(),
-            py::arg("max_num_sequences"), py::arg("max_batch_size"), py::arg("max_tokens_per_engine_step"),
-            py::arg("manager"))
+        .def(py::init<runtime::SizeType32, runtime::SizeType32, tr::BufferManager>(), py::arg("max_batch_size"),
+            py::arg("max_tokens_per_engine_step"), py::arg("manager"))
         .def_readwrite("setup_batch_slots", &tb::DecoderInputBuffers::setupBatchSlots)
         .def_readwrite("setup_batch_slots_device", &tb::DecoderInputBuffers::setupBatchSlotsDevice)
         .def_readwrite("fill_values", &tb::DecoderInputBuffers::fillValues)
         .def_readwrite("fill_values_device", &tb::DecoderInputBuffers::fillValuesDevice)
         .def_readwrite("inputs_ids", &tb::DecoderInputBuffers::inputsIds)
         .def_readwrite("forward_batch_slots", &tb::DecoderInputBuffers::forwardBatchSlots)
-        .def_readwrite("logits", &tb::DecoderInputBuffers::logits);
+        .def_readwrite("logits", &tb::DecoderInputBuffers::logits)
+        .def_readwrite("decoder_requests", &tb::DecoderInputBuffers::decoderRequests);
 
     py::class_<tb::DecoderOutputBuffers>(m, "DecoderOutputBuffers")
         .def_readwrite("sequence_lengths_host", &tb::DecoderOutputBuffers::sequenceLengthsHost)

--- a/cpp/tests/runtime/gptDecoderBatchedTest.cpp
+++ b/cpp/tests/runtime/gptDecoderBatchedTest.cpp
@@ -322,7 +322,7 @@ void testDecoder(nvinfer1::DataType const dtype, std::vector<SamplingConfig>& sa
         modelConfig, worldConfig, manager);
 
     // set up inputs and outputs
-    tb::DecoderInputBuffers inputBuffers(batchSize, batchSize, maxGeneratedTokensPerStep, manager);
+    tb::DecoderInputBuffers inputBuffers(batchSize, maxGeneratedTokensPerStep, manager);
     auto batchSlotsRange = BufferRange<SizeType32>(*inputBuffers.setupBatchSlots);
     std::iota(batchSlotsRange.begin(), batchSlotsRange.end(), 0);
 
@@ -456,7 +456,7 @@ void testDecoderWavefront(nvinfer1::DataType const dtype, std::vector<SamplingCo
         modelConfig, worldConfig, manager);
 
     // set up inputs and outputs
-    tb::DecoderInputBuffers inputBuffers(batchSize, batchSize, maxGeneratedTokensPerStep, manager);
+    tb::DecoderInputBuffers inputBuffers(batchSize, maxGeneratedTokensPerStep, manager);
 
     auto decoderInputs = createDecoderInputs(
         batchSize, vocabSizePadded, dataType, samplingConfigs, generatedTokensPerSteps, computeLogProbs, manager);
@@ -610,7 +610,7 @@ void testDecoderDraft(nvinfer1::DataType const dtype, std::vector<SamplingConfig
     }
 
     // set up inputs and outputs
-    tb::DecoderInputBuffers inputBuffers(batchSize, batchSize, maxGeneratedTokensPerStep, manager);
+    tb::DecoderInputBuffers inputBuffers(batchSize, maxGeneratedTokensPerStep, manager);
 
     auto decoderInputs = createDecoderInputs(
         batchSize, vocabSizePadded, dataType, samplingConfigs, generatedTokensPerSteps, false, manager);

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -536,8 +536,7 @@ class TRTLLMSampler(Sampler):
             "buffer_manager":
             buffer_manager,
             "decoder_input_buffers": [
-                DecoderInputBuffers(self.max_num_sequences,
-                                    self.executor_config.max_batch_size,
+                DecoderInputBuffers(self.executor_config.max_batch_size,
                                     self.MAX_DECODING_TOKENS, buffer_manager)
                 for _ in range(self.num_micro_batches)
             ],


### PR DESCRIPTION
## Description

- Filter requests and store logits in HandleContextLogits and HandleGenerationLogits.
- Refactored DecoderInputBuffers to hold decoder requests and logits in request order.
- Updated GuidedDecoder and LogitsPostProcessor to utilize DecoderInputBuffers directly.
- Adjusted related tests and bindings to reflect changes in the DecoderInputBuffers interface.

This change streamlines the interaction between components and improves clarity in managing decoder inputs and outputs.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
