### PR TITLE
fix: Add $HOME/.local/bin to PATH when running docker in local user mode

### DIFF
--- a/docker/Dockerfile.user
+++ b/docker/Dockerfile.user
@@ -21,3 +21,5 @@ RUN (getent group ${GROUP_ID} || groupadd --gid ${GROUP_ID} ${GROUP_NAME}) && \
     rm -rf /var/lib/apt/lists/*
 
 USER ${USER_NAME}
+
+ENV PATH="/home/${USER_NAME}/.local/bin:$PATH"

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -152,11 +152,11 @@ endif
     		$(if $(and $(filter 1,$(LOCAL_USER)),$(shell [ -w "$(USER_CACHE_DIR)" ] && echo 1)),--volume $(USER_CACHE_DIR):/home/$(USER_NAME)/.cache:rw) \
     		--env "CCACHE_DIR=$(CCACHE_DIR)" \
     		--env "CCACHE_BASEDIR=$(CODE_DIR)" \
-			--env "CONAN_HOME=$(CONAN_DIR)" \
+    		--env "CONAN_HOME=$(CONAN_DIR)" \
     		--workdir $(WORK_DIR) \
     		--hostname $(shell hostname)-$* \
     		--name $(CONTAINER_NAME)-$*-$(USER_NAME) \
-			--tmpfs /tmp:exec \
+    		--tmpfs /tmp:exec \
     		$(IMAGE_WITH_TAG)$(IMAGE_TAG_SUFFIX) $(RUN_CMD)
 
 devel_%: STAGE = devel


### PR DESCRIPTION
# Minor fix for Docker with `LOCAL_USER=1`

This adds `$HOME/.local/bin` to the `PATH` environment variable when `docker` is executed in local user mode. This enables building without a separate virtual environment for Python.