### PR TITLE
[FIX] Fix of build with ENABLE_MULTI_DEVICE=0. Fix Qwen-VL fail with request wo MM data

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -346,7 +346,7 @@ class Qwen2VLInputProcessorBase(InputProcessor):
                                             mm_processor_kwargs).to(self.device)
 
         if not mm_data:
-            fused_input_ids = processed_inputs['input_ids']
+            fused_input_ids = processed_inputs['input_ids'][0]
             return fused_input_ids.to(torch.int32).tolist(), {}
 
         pixel_values = processed_inputs.get('pixel_values', None)

--- a/tensorrt_llm/llmapi/mpi_session.py
+++ b/tensorrt_llm/llmapi/mpi_session.py
@@ -11,6 +11,7 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple, TypeVar
 
 import zmq
+from mpi4py.futures import MPIPoolExecutor
 
 from tensorrt_llm.bindings.BuildInfo import ENABLE_MULTI_DEVICE
 from tensorrt_llm.logger import logger
@@ -20,7 +21,7 @@ from .utils import print_colored, print_colored_debug
 
 if ENABLE_MULTI_DEVICE:
     import mpi4py
-    from mpi4py.futures import MPICommExecutor, MPIPoolExecutor
+    from mpi4py.futures import MPICommExecutor
 
     from tensorrt_llm._utils import global_mpi_size, mpi_world_size
 


### PR DESCRIPTION
## Description

This PR fixes 2 bugs

1. Build with `ENABLE_MULTI_DEVICE=0` was broken due to missed import of `mpi4py`
2. Qwen-VL models family didn't work with text only input (wo MM input). The reason is incorrect format of `input_ids` returned by `Qwen2VLInputProcessorBase`. It returns `[[...]]` instead of `[...]`. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input handling for cases without multimodal data, ensuring more accurate processing of input IDs.

* **Chores**
  * Updated internal dependencies to ensure consistent availability of parallel processing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->