### PR TITLE
[fix] Correct handling of NVFP4 block scaling factors in preprocessing for MoE

### DIFF
--- a/tensorrt_llm/models/modeling_utils.py
+++ b/tensorrt_llm/models/modeling_utils.py
@@ -1806,7 +1806,9 @@ def preprocess_perlayer_weights(weights,
         # Interleave block scale for NVFP4 plugin.
         for name in list(weights):
             if name.endswith('weights_scaling_factor'):
-                out_features, in_features = weights[name].shape
+                # in some MoE cases, weights can have one more dimension for experts
+                # This is handled in nvfp4_block_scale_interleave as commented on NVFP4BlockScaleInterleave in cpp/tensorrt_llm/thop/fp4Op.cpp
+                *maybe_experts, out_features, in_features = weights[name].shape
                 nrows = fp4_utils.pad_up(out_features, 128)
                 ncols = fp4_utils.pad_up(in_features, 4)
                 new_name = name.replace('weights_scaling_factor',
@@ -1816,8 +1818,9 @@ def preprocess_perlayer_weights(weights,
                     new_name +
                     "_interleaved"] = torch.ops.trtllm.nvfp4_block_scale_interleave(
                         weights[name].view(fp4_utils.float4_sf_dtype).cpu(
-                        ).contiguous()).reshape(nrows, ncols).view(
-                            fp4_utils.float4_sf_dtype)
+                        ).contiguous()).reshape(*maybe_experts, nrows,
+                                                ncols).view(
+                                                    fp4_utils.float4_sf_dtype)
                 weights.pop(name)
             if name.endswith('weights_scaling_factor_2'):
                 new_name = name.replace('weights_scaling_factor_2',


### PR DESCRIPTION


# [fix] Correct handling of NVFP4 block scaling factors in preprocessing for MoE


## Description

When pre-processing the NVFP4 block scaling factors, the code of generating the interleaved version of the block scaling factors do not consider the case of MoE, such as in Mixtral 8x7B. In such MoE cases, the block scaling factor tensor will be 3 dimension instead of 2. The extra dimension is num-experts.

The actual interleave operator of nvfp4_block_scale_interleave has a clear comment on the impl function (NVFP4BlockScaleInterleave in cpp/tensorrt_llm/thop/fp4Op.cpp) that for MoE case, the block scale may be of shape [num_experts, rows, cols]:

https://github.com/NVIDIA/TensorRT-LLM/blob/edab7532dd40f1baae13c9ca73696d5386ba232a/cpp/tensorrt_llm/thop/fp4Op.cpp#L277

fix it by adding the missing optional dimension



## Test Coverage

code has been tested using Nvidia internal MLPerf-inference Mixtral 8x7b inference codebase

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
