### PR TITLE
fix TMA error with GEMM+AR on TP=2

### DIFF
--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/allreduce_gemm/allreduce_gemm_impl_sm100.h
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/allreduce_gemm/allreduce_gemm_impl_sm100.h
@@ -221,9 +221,6 @@ public:
             {
                 MPI_group_barrier(_ranks);
             }
-
-            TLLM_CUDA_CHECK(cudaStreamCreate(&_memcpy_stream));
-            TLLM_CUDA_CHECK(cudaEventCreate(&_fork_join_event));
         }
 
         int free() override
@@ -267,8 +264,6 @@ public:
         DeviceAllocationNvls<BarrierT> _tile_barriers;
         DeviceAllocationNvls<BarrierT> _completion_barriers;
         DeviceAllocationNvls<ElementD> _stage_buf;
-        cudaStream_t _memcpy_stream;
-        cudaEvent_t _fork_join_event;
     };
 
     GemmAllReduceImplTwoshot_Sm100()

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/allreduce_gemm/allreduce_gemm_impl_sm90.h
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/allreduce_gemm/allreduce_gemm_impl_sm90.h
@@ -186,9 +186,6 @@ public:
             {
                 MPI_group_barrier(_ranks);
             }
-
-            TLLM_CUDA_CHECK(cudaStreamCreate(&_memcpy_stream));
-            TLLM_CUDA_CHECK(cudaEventCreate(&_fork_join_event));
         }
 
         int free() override
@@ -232,8 +229,6 @@ public:
         DeviceAllocationNvls<BarrierT> _tile_barriers;
         DeviceAllocationNvls<BarrierT> _completion_barriers;
         DeviceAllocationNvls<ElementD> _stage_buf;
-        cudaStream_t _memcpy_stream;
-        cudaEvent_t _fork_join_event;
     };
 
     GemmAllReduceImplTwoshot_Sm90()

--- a/cpp/tensorrt_llm/plugins/gemmAllReducePlugin/gemmAllReducePlugin.h
+++ b/cpp/tensorrt_llm/plugins/gemmAllReducePlugin/gemmAllReducePlugin.h
@@ -154,7 +154,7 @@ private:
     int mNbOutputs = 0;
 
     std::map<KeyType, ValueType> mTypedInstantiators;
-    char const* mWorkspaceKey = "gemm_allreduce_workspace";
+    std::string mWorkspaceKey;
     std::shared_ptr<cutlass_kernels::GemmAllReduceImplInterface> mGemm;
     // Params that are initialized during configurePlugin()
     GemmAllReducePersistentWorkspace* mWorkspace = nullptr;

--- a/cpp/tensorrt_llm/plugins/gemmAllReducePlugin/gemmAllReducePluginProfiler.cpp
+++ b/cpp/tensorrt_llm/plugins/gemmAllReducePlugin/gemmAllReducePluginProfiler.cpp
@@ -60,8 +60,12 @@ void GemmAllReducePluginProfiler::deserializeFromOwnFile(GemmIdCore gemmId, Gemm
 
 bool GemmAllReducePluginProfiler::useProfiler()
 {
-    char const* envDir = getenv("GEMM_AR_PLUGIN_PROFILE_DIR");
-    return envDir != nullptr;
+    // char const* envDir = getenv("GEMM_AR_PLUGIN_PROFILE_DIR");
+    // return envDir != nullptr;
+    // TODO(xsimmons): currently the profiler does not add any perf gain
+    // due to static heuristics being sufficient. We can re-enable this
+    // when we need more configurations.
+    return false;
 }
 
 std::string GemmAllReducePluginProfiler::getCacheFileName(GemmIdCore gemmId)

--- a/cpp/tensorrt_llm/runtime/ipcNvlsMemory.cu
+++ b/cpp/tensorrt_llm/runtime/ipcNvlsMemory.cu
@@ -295,6 +295,7 @@ public:
         // Clean up
         MPI_Group_free(&new_group);
         MPI_Group_free(&world_group);
+        MPI_Comm_free(&new_comm);
 
         return nvls_handle;
     }
@@ -401,14 +402,14 @@ void MPI_group_barrier(std::set<int> group)
     MPI_Comm new_comm;
 
     // Get the group of the world communicator
-    MPI_Comm_group(MPI_COMM_WORLD, &world_group);
+    MPI_Comm_group(COMM_SESSION, &world_group);
 
     // Create a new group containing only the ranks we want
     std::vector<int> ranks(group.begin(), group.end());
     MPI_Group_incl(world_group, ranks.size(), ranks.data(), &new_group);
 
     // Create a new communicator from the group
-    MPI_Comm_create_group(MPI_COMM_WORLD, new_group, 0, &new_comm);
+    MPI_Comm_create_group(COMM_SESSION, new_group, 0, &new_comm);
 
     // Use the new communicator for the barrier
     MPI_Barrier(new_comm);
@@ -509,6 +510,8 @@ IpcNvlsHandle* ipcNvlsAllocate(size_t size, std::set<int> group)
     MPI_Group_free(&world_group);
 
     MPI_Barrier(new_comm);
+
+    MPI_Comm_free(&new_comm);
 
     return handle;
 #else


### PR DESCRIPTION
## Description

Fix TMA error with GEMM+AR on TP=2 caused by incorrect workspace allocation. 

Additionally, disable gemmAllReducePluginProfiler to reduce complications during testing. This is not needed at the moment because static heuristics select optimal configurations.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit cleanup of MPI communicators after use to improve resource management.
  * Introduced a runtime check to ensure the M dimension does not exceed the configured maximum during plugin execution.

* **Refactor**
  * Updated internal handling of workspace keys for more consistent resource management.
  * Changed workspace key type in the plugin to use a string for improved flexibility.

* **Chores**
  * Disabled the plugin profiler by default, as static heuristics are currently sufficient.
  * Removed unused CUDA stream and event management from internal workspace classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->