### PR TITLE
[Draft] Inter-request kv cache manager support for HSTU

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -917,6 +917,8 @@ public:
     virtual void offloadSequence(
         LlmRequest::RequestIdType requestId, std::optional<SizeType32> numTokens = std::nullopt) = 0;
 
+    virtual void evictAllSequences(void) = 0;
+
     virtual SizeType32 getNumTokensCached(LlmRequest::RequestIdType requestId) const = 0;
     virtual SizeType32 getCacheStartPos(LlmRequest::RequestIdType requestId) const = 0;
     // ===== hstu modification end =====
@@ -1183,6 +1185,8 @@ public:
 
     void offloadSequence(
         LlmRequest::RequestIdType requestId, std::optional<SizeType32> numTokens = std::nullopt) override;
+
+    void evictAllSequences(void) override;
 
     SizeType32 getNumTokensCached(LlmRequest::RequestIdType requestId) const override;
     SizeType32 getCacheStartPos(LlmRequest::RequestIdType requestId) const override;

--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -694,7 +694,7 @@ public:
 
     // ===== hstu modification start =====
     LlmRequest::RequestIdType getRequestIdToEvict(
-        OptionalRef<std::unordered_set<SizeType32>> freezedIdGroup = std::nullopt) const;
+        std::unordered_set<int> freezedIdGroup) const;
     // ===== hstu modification end =====
 
     //! \brief Perform per-request bookkeeping
@@ -909,8 +909,9 @@ public:
 
     // ===== hstu modification start =====
     virtual void addSequenceWithEviction(LlmRequest::RequestIdType requestId, SizeType32 start_pos, SizeType32 inputLength,
-        SizeType32 beamWidth, OptionalRef<std::unordered_set<SizeType32>> freezedIdGroup = std::nullopt,
-        OptionalRef<LlmRequest> llmRequest = std::nullopt)
+        SizeType32 beamWidth,
+        OptionalRef<LlmRequest> llmRequest = std::nullopt,
+        std::unordered_set<int> freezedIdGroup = std::unordered_set<int>())
         = 0;
 
     virtual void offloadSequence(
@@ -1180,8 +1181,9 @@ public:
     
     // ===== hstu modification start =====
     void addSequenceWithEviction(LlmRequest::RequestIdType requestId, SizeType32 start_pos, SizeType32 length,
-        SizeType32 beamWidth, OptionalRef<std::unordered_set<SizeType32>> freezedIdGroup = std::nullopt,
-        OptionalRef<LlmRequest> llmRequest = std::nullopt);
+        SizeType32 beamWidth,
+        OptionalRef<LlmRequest> llmRequest = std::nullopt,
+        std::unordered_set<int> freezedIdGroup = std::unordered_set<int>());
 
     void offloadSequence(
         LlmRequest::RequestIdType requestId, std::optional<SizeType32> numTokens = std::nullopt) override;

--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -693,10 +693,8 @@ public:
     }
 
     // ===== hstu modification start =====
-    [[nodiscard]] LlmRequest::RequestIdType getRequestIdToEvict() const
-    {
-        return mSeqLRUList.back();
-    }
+    LlmRequest::RequestIdType getRequestIdToEvict(
+        OptionalRef<std::unordered_set<SizeType32>> freezedIdGroup = std::nullopt) const;
     // ===== hstu modification end =====
 
     //! \brief Perform per-request bookkeeping
@@ -911,7 +909,8 @@ public:
 
     // ===== hstu modification start =====
     virtual void addSequenceWithEviction(LlmRequest::RequestIdType requestId, SizeType32 start_pos, SizeType32 inputLength,
-        SizeType32 beamWidth, OptionalRef<LlmRequest> llmRequest = std::nullopt)
+        SizeType32 beamWidth, OptionalRef<std::unordered_set<SizeType32>> freezedIdGroup = std::nullopt,
+        OptionalRef<LlmRequest> llmRequest = std::nullopt)
         = 0;
 
     virtual void offloadSequence(
@@ -1181,7 +1180,8 @@ public:
     
     // ===== hstu modification start =====
     void addSequenceWithEviction(LlmRequest::RequestIdType requestId, SizeType32 start_pos, SizeType32 length,
-        SizeType32 beamWidth, OptionalRef<LlmRequest> llmRequest = std::nullopt);
+        SizeType32 beamWidth, OptionalRef<std::unordered_set<SizeType32>> freezedIdGroup = std::nullopt,
+        OptionalRef<LlmRequest> llmRequest = std::nullopt);
 
     void offloadSequence(
         LlmRequest::RequestIdType requestId, std::optional<SizeType32> numTokens = std::nullopt) override;

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -1914,6 +1914,15 @@ void KVCacheManager::offloadSequence(RequestIdType requestId, std::optional<Size
 {
 }
 
+void KVCacheManager::evictAllSequences(void)
+{
+    for (auto pair: mSequences) {
+        mSeqCacheStartPos.erase(pair.first);
+        mBlockManager.evictSequence(pair.second);
+    }
+    mSequences.clear();
+}
+
 SizeType32 KVCacheManager::getNumTokensCached(RequestIdType requestId) const
 {
     auto const seq_it = mSequences.find(requestId);

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -1812,6 +1812,7 @@ void KVCacheManager::addSequenceWithEviction(
 {
     TLLM_CHECK_WITH_INFO(length <= mMaxBlocksPerSeq * mTokensPerBlock, 
         "Do not accept delta length %d, %d x %d.", length, mMaxBlocksPerSeq, mTokensPerBlock);
+    mBlockManager.markSequenceRetained(requestId);
 
     auto const oldSeqIt = mSequences.find(requestId);
     if (mSequences.end() != oldSeqIt) {
@@ -1844,7 +1845,6 @@ void KVCacheManager::addSequenceWithEviction(
             curLength = 0;
         }
         else {
-            mBlockManager.markSequenceRetained(requestId);
             auto& sequence = mSequences.at(requestId);
             mBlockManager.evictBlocks(sequence, numBlocksSelfEvict);
             // cacheBlockOffsets(sequence);
@@ -1877,7 +1877,6 @@ void KVCacheManager::addSequenceWithEviction(
     SizeType32 numReusedBlocksPreRequest = mBlockManager.getNumReusedBlocks();
     SizeType32 numMissedBlocksPreRequest = mBlockManager.getNumMissedBlocks();
 
-    mBlockManager.markSequenceRetained(requestId);
     if (mSequences.end() == mSequences.find(requestId)) {
         auto kvCacheRetentionConfig = llmRequest
             ? llmRequest->getKvCacheRetentionConfig().value_or(executor::KvCacheRetentionConfig())

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -601,13 +601,13 @@ BlockPtr BlockManager::getFreeBlock(
 
 // ===== hstu modification start =====
 LlmRequest::RequestIdType BlockManager::getRequestIdToEvict(
-    OptionalRef<std::unordered_set<SizeType32>> freezedIdGroup) const
+    std::unordered_set<int> freezedIdGroup) const
 {
-    if (!freezedIdGroup.has_value())
+    if (freezedIdGroup.size() == 0)
         return mSeqLRUList.back();
     
     for (auto it = std::rbegin(mSeqLRUList); it != std::rend(mSeqLRUList); ++it) {
-        if (freezedIdGroup->find(*it) != freezedIdGroup->end())
+        if (freezedIdGroup.find((SizeType32)*it) != freezedIdGroup.end())
             continue;
         return *it;
     }
@@ -1824,8 +1824,7 @@ void KVCacheManager::schedulingRemoveSequence(RequestIdType requestId)
 // ===== hstu modification start =====
 void KVCacheManager::addSequenceWithEviction(
     RequestIdType requestId, SizeType32 start_pos, SizeType32 length, SizeType32 beamWidth, 
-    OptionalRef<std::unordered_set<SizeType32>> freezedIdGroup,
-    OptionalRef<LlmRequest> llmRequest)
+    OptionalRef<LlmRequest> llmRequest, std::unordered_set<int> freezedIdGroup)
 {
     TLLM_CHECK_WITH_INFO(length <= mMaxBlocksPerSeq * mTokensPerBlock, 
         "Do not accept delta length %d, %d x %d.", length, mMaxBlocksPerSeq, mTokensPerBlock);

--- a/cpp/tensorrt_llm/pybind/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/kvCacheManager.cpp
@@ -348,6 +348,7 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(py::module_& m)
         .def("offload_sequence", &BaseKVCacheManager::offloadSequence)
         .def("get_num_tokens_cached", &BaseKVCacheManager::getNumTokensCached)
         .def("get_cached_start_position", &BaseKVCacheManager::getCacheStartPos)
+        .def("evict_all_sequences", &BaseKVCacheManager::evictAllSequences)
         // ===== hstu modification end =====
         .def("get_block_pool_pointers",
             [](tbk::BaseKVCacheManager& self)

--- a/cpp/tensorrt_llm/pybind/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/kvCacheManager.cpp
@@ -343,6 +343,12 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(py::module_& m)
         .def("add_sequence", &BaseKVCacheManager::addSequence)
         .def("remove_sequence", &BaseKVCacheManager::removeSequence)
         .def("scheduling_remove_sequence", &BaseKVCacheManager::schedulingRemoveSequence)
+        // ===== hstu modification start =====
+        .def("add_sequence_with_eviction", &BaseKVCacheManager::addSequenceWithEviction)
+        .def("offload_sequence", &BaseKVCacheManager::offloadSequence)
+        .def("get_num_tokens_cached", &BaseKVCacheManager::getNumTokensCached)
+        .def("get_cached_start_position", &BaseKVCacheManager::getCacheStartPos)
+        // ===== hstu modification end =====
         .def("get_block_pool_pointers",
             [](tbk::BaseKVCacheManager& self)
             {
@@ -374,6 +380,14 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(py::module_& m)
                 auto pool_layer_idx = self.getPoolLayerIdx(layer_idx);
                 return pool.index({torch::indexing::Slice(), pool_layer_idx});
             })
+        // ===== hstu modification start =====
+        .def("get_primary_pool",
+            [](tbk::BaseKVCacheManager& self) -> at::Tensor
+            {
+                auto pool = tr::Torch::tensor(self.getPrimaryPool(0));
+                return pool;
+            })
+        // ===== hstu modification end =====
         .def("get_block_offsets_of_batch",
             [](tbk::BaseKVCacheManager& self, at::Tensor output, SizeType32 firstBatchSlotIdx, SizeType32 batchSize,
                 SizeType32 beamWidth)
@@ -433,7 +447,7 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(py::module_& m)
         .def(py::init<std::vector<SizeType32> const&, SizeType32, SizeType32, SizeType32, SizeType32, SizeType32,
                  SizeType32, std::vector<SizeType32> const&, SizeType32, SizeType32, bool, int64_t, bool, bool,
                  tbk::CacheType, std::optional<tensorrt_llm::executor::RetentionPriority>,
-                 std::shared_ptr<tbk::KVCacheEventManager>, bool, bool>(),
+                 std::shared_ptr<tbk::KVCacheEventManager>, bool, bool, SizeType32>(),
             py::arg("num_kv_heads_per_layer"), py::arg("size_per_head"), py::arg("tokens_per_block"),
             py::arg("blocks_in_primary_pool"), py::arg("blocks_in_secondary_pool"), py::arg("max_num_sequences"),
             py::arg("max_beam_width"), py::arg("max_attention_window_vec"), py::arg("temporary_attention_window"),
@@ -441,7 +455,8 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(py::module_& m)
             py::arg("enable_block_reuse") = false, py::arg("onboard_blocks") = true,
             py::arg_v("cache_type", tbk::CacheType::kSELF, "bindings.internal.batch_manager.CacheType.SELF"),
             py::arg("secondary_offload_min_priority") = std::nullopt, py::arg("event_manager") = nullptr,
-            py::arg("enable_partial_reuse") = true, py::arg("copy_on_partial_reuse") = true);
+            py::arg("enable_partial_reuse") = true, py::arg("copy_on_partial_reuse") = true,
+            py::arg("reserved_blocks_in_primary_pool") = 0);
 }
 
 void tb::BasePeftCacheManagerBindings::initBindings(py::module_& m)

--- a/cpp/tensorrt_llm/pybind/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/kvCacheManager.cpp
@@ -344,7 +344,9 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(py::module_& m)
         .def("remove_sequence", &BaseKVCacheManager::removeSequence)
         .def("scheduling_remove_sequence", &BaseKVCacheManager::schedulingRemoveSequence)
         // ===== hstu modification start =====
-        .def("add_sequence_with_eviction", &BaseKVCacheManager::addSequenceWithEviction)
+        .def("add_sequence_with_eviction", &BaseKVCacheManager::addSequenceWithEviction,
+            py::arg("requestId"), py::arg("start_pos"), py::arg("length"), py::arg("beamWidth"), py::arg("llmRequest"),
+            py::arg("freezedIdGroup") = std::unordered_set<int>())
         .def("offload_sequence", &BaseKVCacheManager::offloadSequence)
         .def("get_num_tokens_cached", &BaseKVCacheManager::getNumTokensCached)
         .def("get_cached_start_position", &BaseKVCacheManager::getCacheStartPos)


### PR DESCRIPTION
This is a draft PR serving as a discussion/design base on KV cache manager features for HSTU.
**This is NOT a PR for modification request.**

## Description

In HSTU model inference, we want to have a KV cache manager with the following features:
* KV data is managed per user. Each user has its own KV cache data labeled by its user id.
* KV cache data can increase and be reused cross different inference input batches (for the same user only).
* KV cache manager can offload data to host.

We'd like to use the KV cache manager in TRTLLM, and implement an extension with the features above. This PR shows such an example. Currently our implementation is based on v0.19.0.


