### PR TITLE
feat: Add support for benchmarking individual gemms in MOE benchmark

### DIFF
--- a/cpp/micro_benchmarks/README.md
+++ b/cpp/micro_benchmarks/README.md
@@ -11,6 +11,9 @@ To build add the `--micro_benchmark` flag to `build_wheel.py` or pass `-DBUILD_M
 
 ### Mixture Of Experts Backend Benchmark
 
+> [!CAUTION]
+> Disclaimer this benchmark is intended for developers to help evaluating the impact of new optimisations. This benchmark does not meet the same quality standards as other parts of TRT-LLM. Please use with caution
+
 Target `mixtureOfExpertsBackendBenchmark`
 
 This benchmark covers the backend used by the `MixtureOfExperts` plugin. It allows you to benchmark different MOE

--- a/cpp/micro_benchmarks/gen-moe-benchmark-file.py
+++ b/cpp/micro_benchmarks/gen-moe-benchmark-file.py
@@ -14,7 +14,8 @@ template = '''{{
   {dtype_string}
   {routing_string}
   {tactic_string}
-  "bias": 0
+  "bias": 0,
+  "gemm_to_profile": {gemm_to_profile}
 }}'''
 
 
@@ -54,39 +55,50 @@ def populate_benchmark_config(**kwargs):
 
 
 # Default Mixtral configurations
-num_experts = 256
-k = 8
+num_experts = 8
+k = 2
 hidden_size = 4096
-inter_size = 2048
-tp_size = 8
-ep_size = 1
+inter_size = 14336
+# tp_size = 8
+# ep_size = 1
 world_rank = 0
 act_fn = 3
-dtype_string = make_dtype_string(["fp4", "wfp4afp8"])  # All dtypes
-routing_string = make_routing_string(
-    name="uniform",
-    is_distribution=True)  # Use the default uniform random distribution
+dtype_string = make_dtype_string()  # All dtypes
 tactic_id1 = '"auto"'
 tactic_id2 = '"auto"'
+gemms_to_profile = [1, 2, 3]
 
 configs = []
-for num_tokens in [1, 8, 64, 2048, 65536]:
-    configs.append(
-        populate_benchmark_config(
-            num_experts=num_experts,
-            k=k,
-            hidden_size=hidden_size,
-            inter_size=inter_size,
-            tp_size=tp_size,
-            ep_size=ep_size,
-            world_rank=world_rank,
-            num_tokens=num_tokens,
-            act_fn=act_fn,
-            dtype_string=dtype_string,
-            routing_string=routing_string,
-            tactic_string=make_tactic_string(tactic_id1=tactic_id1,
-                                             tactic_id2=tactic_id2),
-        ))
+for ep_size in [1, num_experts]:
+    for num_tokens in [1, 8, 64, 2048, 16384]:
+        tp_size = 8 // ep_size
+        if inter_size % (tp_size * 128) != 0:
+            continue  # Insufficient alignment
+        if num_tokens <= num_experts:
+            routing_string = make_routing_string(
+                name="balanced",
+                is_distribution=False)  # Use the balanced distribution
+        else:
+            routing_string = make_routing_string(
+                name="uniform", is_distribution=True
+            )  # Use the default uniform random distribution
+        for gemm_to_profile in gemms_to_profile:
+            configs.append(
+                populate_benchmark_config(num_experts=num_experts,
+                                          k=k,
+                                          hidden_size=hidden_size,
+                                          inter_size=inter_size,
+                                          tp_size=tp_size,
+                                          ep_size=ep_size,
+                                          world_rank=world_rank,
+                                          num_tokens=num_tokens,
+                                          act_fn=act_fn,
+                                          dtype_string=dtype_string,
+                                          routing_string=routing_string,
+                                          tactic_string=make_tactic_string(
+                                              tactic_id1=tactic_id1,
+                                              tactic_id2=tactic_id2),
+                                          gemm_to_profile=gemm_to_profile))
 
 full_string = "[\n" + ",\n".join(configs) + "\n]"
 

--- a/cpp/micro_benchmarks/mixtureOfExpertsBackendBenchmarkFixture.h
+++ b/cpp/micro_benchmarks/mixtureOfExpertsBackendBenchmarkFixture.h
@@ -71,6 +71,13 @@ enum VERBOSE_LEVEL
 
 constexpr int LOG_LEVEL = ERROR;
 
+enum class GemmToProfile : int
+{
+    GEMM_1 = static_cast<int>(GemmProfilerBackend::GemmToProfile::GEMM_1),
+    GEMM_2 = static_cast<int>(GemmProfilerBackend::GemmToProfile::GEMM_2),
+    LAYER = static_cast<int>(3),
+};
+
 namespace
 {
 // Abstract class for routing config
@@ -358,6 +365,10 @@ public:
 
     constexpr static int64_t FP4_VECTOR_SIZE = NVFP4 ? TmaWarpSpecializedGroupedGemmInput::NVFP4BlockScaleVectorSize
                                                      : TmaWarpSpecializedGroupedGemmInput::MXFPXBlockScaleVectorSize;
+    constexpr static int64_t MinNDimAlignment = NVFP4 ? TmaWarpSpecializedGroupedGemmInput::MinNDimAlignmentNVFP4
+                                                      : TmaWarpSpecializedGroupedGemmInput::MinNDimAlignmentMXFPX;
+    constexpr static int64_t MinKDimAlignment = NVFP4 ? TmaWarpSpecializedGroupedGemmInput::MinKDimAlignmentNVFP4
+                                                      : TmaWarpSpecializedGroupedGemmInput::MinKDimAlignmentMXFPX;
 
     std::vector<BufferManager::IBufferPtr> managed_buffers;
     int* mSelectedExperts{};
@@ -365,6 +376,7 @@ public:
 
     int64_t mHiddenSize{};
     int64_t mNumExperts{};
+    int64_t mNumExpertsPerNode{};
     int64_t mK{};
 
     constexpr static nvinfer1::DataType toDTypeID()
@@ -497,6 +509,8 @@ public:
     }
 
     CutlassMoeFCRunner<DataType, WeightType, OutputType, InputType> mMoERunner{};
+    GemmProfilerBackend mGemmProfilerBackend{};
+    char* mGemmProfilerWorkspace{};
     char* mWorkspace{};
     float* mScaleProbs{};
     WeightStorage* mExpertWeight1{};
@@ -544,6 +558,7 @@ public:
     std::optional<tensorrt_llm::cutlass_extensions::CutlassGemmConfig> mSelectedConfig = std::nullopt;
 
     int64_t mBufferIndex = 0;
+    size_t mGemmProfilerWorkspaceSize = 0;
     size_t mWorkspaceSize = 0;
     size_t mExpertWeight1Size = 0;
     size_t mExpertWeight2Size = 0;
@@ -559,10 +574,15 @@ public:
     size_t mExpertIntScale1Size = 0;
     size_t mExpertIntScale2Size = 0;
 
+    size_t padSize(size_t size)
+    {
+        return ceilDiv(size, 128) * 128;
+    }
+
     template <class T>
     T* allocBuffer(size_t size)
     {
-        size_t size_padded = ceilDiv(size * sizeof(T), 128) * 128;
+        size_t size_padded = padSize(size) * sizeof(T);
         auto i_buffer = bufferManager->gpu(size_padded);
         check_cuda_error(cudaGetLastError());
         managed_buffers.emplace_back(std::move(i_buffer));
@@ -572,7 +592,7 @@ public:
     }
 
     void initBuffersPermute(int64_t num_tokens, int64_t hidden_size, int64_t inter_size, int64_t num_experts, int64_t k,
-        int64_t routing_config, MOEParallelismConfig parallelism_config)
+        int64_t routing_config, MOEParallelismConfig parallelism_config, GemmToProfile gemm_to_profile)
     {
         assert(hidden_size % BASE_HIDDEN_SIZE == 0);
 
@@ -582,104 +602,160 @@ public:
         mHiddenSize = hidden_size;
         mInterSize = inter_size / parallelism_config.tp_size;
         mNumExperts = num_experts;
+        mNumExpertsPerNode = num_experts / parallelism_config.ep_size;
         mK = k;
         mIsGated = isGatedActivation(mActType);
         mGatedMultiplier = mIsGated ? 2 : 1;
         auto const gated_inter = mInterSize * mGatedMultiplier;
+        size_t const expert_matrix_size = padSize(mNumExpertsPerNode * mHiddenSize * mInterSize);
 
-        mWorkspaceSize = mMoERunner.getWorkspaceSize(mTotalTokens, mHiddenSize, mInterSize, mNumExperts, mK, mActType,
-            {}, mUseLora, /*use_deepseek_fp8_block_scale=*/false, /*min_latency_mode=*/false, mUsePrequantScale);
+        bool need_weight_1 = gemm_to_profile == GemmToProfile::GEMM_1 || gemm_to_profile == GemmToProfile::LAYER;
+        bool need_weight_2 = gemm_to_profile == GemmToProfile::GEMM_2 || gemm_to_profile == GemmToProfile::LAYER;
+        mExpertWeight1Size = need_weight_1 ? expert_matrix_size * mGatedMultiplier / WEIGHT_ELEM_PER_BYTE : 0;
+        mExpertWeight2Size = need_weight_2 ? expert_matrix_size / WEIGHT_ELEM_PER_BYTE : 0;
+        mExpertWeight1 = need_weight_1 ? allocBuffer<WeightStorage>(mExpertWeight1Size * NUM_BUFFERS) : nullptr;
+        mExpertWeight2 = need_weight_2 ? allocBuffer<WeightStorage>(mExpertWeight2Size * NUM_BUFFERS) : nullptr;
 
-        mWorkspace = allocBuffer<char>(mWorkspaceSize * NUM_BUFFERS);
-        size_t const expert_matrix_size = mNumExperts * mHiddenSize * mInterSize;
-
-        mExpertWeight1Size = expert_matrix_size * mGatedMultiplier / WEIGHT_ELEM_PER_BYTE;
-        mExpertWeight2Size = expert_matrix_size / WEIGHT_ELEM_PER_BYTE;
-        mExpertWeight1 = allocBuffer<WeightStorage>(mExpertWeight1Size * NUM_BUFFERS);
-        mExpertWeight2 = allocBuffer<WeightStorage>(mExpertWeight2Size * NUM_BUFFERS);
-
-        mExpertBias1 = nullptr;
-        mExpertBias2 = nullptr;
-        if (mUseBias)
+        if (gemm_to_profile == GemmToProfile::LAYER)
         {
-            mExpertBias1Size = mNumExperts * gated_inter;
-            mExpertBias2Size = mNumExperts * mHiddenSize;
-            mExpertBias1 = allocBuffer<DataType>(mExpertBias1Size * NUM_BUFFERS);
-            mExpertBias2 = allocBuffer<DataType>(mExpertBias2Size * NUM_BUFFERS);
-        }
 
-        if constexpr (INT_QUANT)
-        {
-            mExpertIntScale1Size = mNumExperts * gated_inter;
-            mExpertIntScale2Size = mNumExperts * mHiddenSize;
-            mExpertIntScale1 = allocBuffer<DataType>(mExpertIntScale1Size * NUM_BUFFERS);
-            mExpertIntScale2 = allocBuffer<DataType>(mExpertIntScale2Size * NUM_BUFFERS);
+            mWorkspaceSize = mMoERunner.getWorkspaceSize(mTotalTokens, mHiddenSize, mInterSize, mNumExperts, mK,
+                mActType, parallelism_config, mUseLora, /*use_deepseek_fp8_block_scale=*/false,
+                /*min_latency_mode=*/false, mUsePrequantScale);
 
+            mWorkspace = allocBuffer<char>(mWorkspaceSize * NUM_BUFFERS);
+
+            mExpertBias1 = nullptr;
+            mExpertBias2 = nullptr;
+            if (mUseBias)
+            {
+                mExpertBias1Size = padSize(mNumExpertsPerNode * gated_inter);
+                mExpertBias2Size = padSize(mNumExpertsPerNode * mHiddenSize);
+                mExpertBias1 = allocBuffer<DataType>(mExpertBias1Size * NUM_BUFFERS);
+                mExpertBias2 = allocBuffer<DataType>(mExpertBias2Size * NUM_BUFFERS);
+            }
+
+            if constexpr (INT_QUANT)
+            {
+                mExpertIntScale1Size = padSize(mNumExpertsPerNode * gated_inter);
+                mExpertIntScale2Size = padSize(mNumExpertsPerNode * mHiddenSize);
+                mExpertIntScale1 = allocBuffer<DataType>(mExpertIntScale1Size * NUM_BUFFERS);
+                mExpertIntScale2 = allocBuffer<DataType>(mExpertIntScale2Size * NUM_BUFFERS);
+
+                for (int i = 0; i < NUM_BUFFERS; i++)
+                {
+                    mQuantParams[i] = QuantParams::Int(
+                        mExpertIntScale1 + mExpertIntScale1Size * i, mExpertIntScale2 + mExpertIntScale2Size * i);
+                }
+            }
+            else if constexpr (FP8)
+            {
+                mExpertFP8Scale1 = allocBuffer<float>(mNumExpertsPerNode);
+                mExpertFP8Scale2 = allocBuffer<float>(1);
+                mExpertFP8Scale3 = allocBuffer<float>(mNumExpertsPerNode);
+
+                for (int i = 0; i < NUM_BUFFERS; i++)
+                {
+                    mQuantParams[i] = QuantParams::FP8(mExpertFP8Scale1, mExpertFP8Scale2, mExpertFP8Scale3);
+                }
+            }
+            else if constexpr (ANY_FP4)
+            {
+                mExpertFP4ActScale1 = allocBuffer<float>(mNumExpertsPerNode);
+                mExpertFP4WeightSf1Size = mNumExpertsPerNode
+                    * TmaWarpSpecializedGroupedGemmInput::alignToSfDim(gated_inter, MinNDimAlignment)
+                    * TmaWarpSpecializedGroupedGemmInput::alignToSfDim(mHiddenSize, MinKDimAlignment) / FP4_VECTOR_SIZE;
+                mExpertFP4WeightSf1 = allocBuffer<ElementSF>(mExpertFP4WeightSf1Size * NUM_BUFFERS);
+                mExpertFP4GlobalScale1 = allocBuffer<float>(mNumExpertsPerNode);
+
+                mExpertFP4ActScale2 = allocBuffer<float>(mNumExpertsPerNode);
+                mExpertFP4WeightSf2Size = mNumExpertsPerNode
+                    * TmaWarpSpecializedGroupedGemmInput::alignToSfDim(mInterSize, MinNDimAlignment)
+                    * TmaWarpSpecializedGroupedGemmInput::alignToSfDim(mHiddenSize, MinKDimAlignment) / FP4_VECTOR_SIZE;
+                mExpertFP4WeightSf2 = allocBuffer<ElementSF>(mExpertFP4WeightSf2Size * NUM_BUFFERS);
+                mExpertFP4GlobalScale2 = allocBuffer<float>(mNumExpertsPerNode);
+
+                auto func = NVFP4 ? QuantParams::FP4 : QuantParams::FP8MXFP4;
+                for (int i = 0; i < NUM_BUFFERS; i++)
+                {
+                    mQuantParams[i] = func(mExpertFP4ActScale1, mExpertFP4WeightSf1 + mExpertFP4WeightSf1Size * i,
+                        mExpertFP4GlobalScale1, mExpertFP4ActScale2, mExpertFP4WeightSf2 + mExpertFP4WeightSf2Size * i,
+                        mExpertFP4GlobalScale2, false, false);
+                }
+            }
+
+            mSelectedExpertsSize = padSize(mTotalTokens * mK);
+            mSelectedExperts = allocBuffer<int>(mSelectedExpertsSize * NUM_BUFFERS);
+            mScaleProbsSize = padSize(mTotalTokens * mK);
+            mScaleProbs = allocBuffer<float>(mScaleProbsSize * NUM_BUFFERS);
+            mInputTensorSize = padSize(mTotalTokens * mHiddenSize);
+            mInputTensor = allocBuffer<DataType>(mInputTensorSize * NUM_BUFFERS);
+            mFinalOutputSize = padSize(mTotalTokens * mHiddenSize);
+            mFinalOutput = allocBuffer<OutputType>(mFinalOutputSize * NUM_BUFFERS);
+
+            mSourceToExpandedMapSize = padSize(mTotalTokens * mK);
+            mSourceToExpandedMap = allocBuffer<int>(mSourceToExpandedMapSize * NUM_BUFFERS);
+            mRoutingConfigIndex = routing_config;
+            auto tactic = routingConfigCache.at(routing_config);
+            tactic->start();
             for (int i = 0; i < NUM_BUFFERS; i++)
             {
-                mQuantParams[i] = QuantParams::Int(
-                    mExpertIntScale1 + mExpertIntScale1Size * i, mExpertIntScale2 + mExpertIntScale2Size * i);
-            }
-        }
-        else if constexpr (FP8)
-        {
-            mExpertFP8Scale1 = allocBuffer<float>(mNumExperts);
-            mExpertFP8Scale2 = allocBuffer<float>(1);
-            mExpertFP8Scale3 = allocBuffer<float>(mNumExperts);
-
-            for (int i = 0; i < NUM_BUFFERS; i++)
-            {
-                mQuantParams[i] = QuantParams::FP8(mExpertFP8Scale1, mExpertFP8Scale2, mExpertFP8Scale3);
-            }
-        }
-        else if constexpr (ANY_FP4)
-        {
-            mExpertFP4ActScale1 = allocBuffer<float>(1);
-            mExpertFP4WeightSf1Size = num_experts * gated_inter * mHiddenSize / FP4_VECTOR_SIZE;
-            mExpertFP4WeightSf1 = allocBuffer<ElementSF>(mExpertFP4WeightSf1Size * NUM_BUFFERS);
-            mExpertFP4GlobalScale1 = allocBuffer<float>(num_experts);
-
-            mExpertFP4ActScale2 = allocBuffer<float>(1);
-            mExpertFP4WeightSf2Size = num_experts * mInterSize * mHiddenSize / FP4_VECTOR_SIZE;
-            mExpertFP4WeightSf2 = allocBuffer<ElementSF>(mExpertFP4WeightSf2Size * NUM_BUFFERS);
-            mExpertFP4GlobalScale2 = allocBuffer<float>(num_experts);
-
-            auto func = NVFP4 ? QuantParams::FP4 : QuantParams::FP8MXFP4;
-            for (int i = 0; i < NUM_BUFFERS; i++)
-            {
-                mQuantParams[i] = func(mExpertFP4ActScale1, mExpertFP4WeightSf1 + mExpertFP4WeightSf1Size * i,
-                    mExpertFP4GlobalScale1, mExpertFP4ActScale2, mExpertFP4WeightSf2 + mExpertFP4WeightSf2Size * i,
-                    mExpertFP4GlobalScale2, false, false);
+                tactic->setRouting(mSelectedExperts + mSelectedExpertsSize * i, mNumExperts, mK, mTotalTokens);
             }
         }
 
-        mSelectedExpertsSize = mTotalTokens * mK;
-        mSelectedExperts = allocBuffer<int>(mSelectedExpertsSize * NUM_BUFFERS);
-        mScaleProbsSize = mTotalTokens * mK;
-        mScaleProbs = allocBuffer<float>(mScaleProbsSize * NUM_BUFFERS);
-        mInputTensorSize = mTotalTokens * mHiddenSize;
-        mInputTensor = allocBuffer<DataType>(mInputTensorSize * NUM_BUFFERS);
-        mFinalOutputSize = mTotalTokens * mHiddenSize;
-        mFinalOutput = allocBuffer<OutputType>(mFinalOutputSize * NUM_BUFFERS);
+#ifdef USING_OSS_CUTLASS_MOE_GEMM
+        mGemmProfilerBackend.init(mMoERunner, GemmProfilerBackend::GemmToProfile::Undefined, typeToDtypeID<DataType>(),
+            typeToDtypeID<WeightType>(), typeToDtypeID<OutputType>(), mNumExperts, mK, mHiddenSize, mInterSize,
+            mGroupSize, mActType, mUseBias, mUseLora, /*min_latency_mode=*/false,
+            /*need_weights=*/false, parallelism_config, /*enable_alltoall=*/false);
+#else
+        mGemmProfilerBackend.init(mMoERunner, GemmProfilerBackend::GemmToProfile::Undefined, typeToDtypeID<DataType>(),
+            typeToDtypeID<WeightType>(), typeToDtypeID<OutputType>(), mNumExperts, mK, mHiddenSize, mInterSize,
+            mGroupSize, mActType, mUseBias, mUseLora, /*min_latency_mode=*/false,
+            /*need_weights=*/false, parallelism_config);
+#endif
 
-        mSourceToExpandedMapSize = mTotalTokens * mK;
-        mSourceToExpandedMap = allocBuffer<int>(mSourceToExpandedMapSize * NUM_BUFFERS);
-
-        mRoutingConfigIndex = routing_config;
-        auto tactic = routingConfigCache.at(routing_config);
-        tactic->start();
-        for (int i = 0; i < NUM_BUFFERS; i++)
+        mGemmProfilerWorkspaceSize = 0;
+        if (gemm_to_profile == GemmToProfile::GEMM_1 || gemm_to_profile == GemmToProfile::LAYER)
         {
-            tactic->setRouting(mSelectedExperts + mSelectedExpertsSize * i, mNumExperts, mK, mTotalTokens);
+            mGemmProfilerBackend.mGemmToProfile = GemmProfilerBackend::GemmToProfile::GEMM_1;
+            mGemmProfilerWorkspaceSize
+                = std::max(mGemmProfilerWorkspaceSize, mGemmProfilerBackend.getWorkspaceSize(mTotalTokens));
         }
+
+        if (gemm_to_profile == GemmToProfile::GEMM_2 || gemm_to_profile == GemmToProfile::LAYER)
+        {
+            mGemmProfilerBackend.mGemmToProfile = GemmProfilerBackend::GemmToProfile::GEMM_2;
+            mGemmProfilerWorkspaceSize
+                = std::max(mGemmProfilerWorkspaceSize, mGemmProfilerBackend.getWorkspaceSize(mTotalTokens));
+        }
+
+        int64_t num_gemm_buffers = gemm_to_profile == GemmToProfile::LAYER ? 1 : NUM_BUFFERS;
+        mGemmProfilerWorkspaceSize = padSize(mGemmProfilerWorkspaceSize);
+        mGemmProfilerWorkspace = mGemmProfilerWorkspaceSize > 0
+            ? allocBuffer<char>(mGemmProfilerWorkspaceSize * num_gemm_buffers)
+            : nullptr;
 
         check_cuda_error(cudaStreamSynchronize(streamPtr->get()));
     }
 
+    void prepareGemmProfiler(GemmToProfile gemm_to_profile)
+    {
+        if (gemm_to_profile == GemmToProfile::LAYER)
+            return;
+        mGemmProfilerBackend.mGemmToProfile = static_cast<GemmProfilerBackend::GemmToProfile>(gemm_to_profile);
+        auto* expert_weights = gemm_to_profile == GemmToProfile::GEMM_1 ? mExpertWeight1 : mExpertWeight2;
+        auto expert_weights_size = gemm_to_profile == GemmToProfile::GEMM_1 ? mExpertWeight1Size : mExpertWeight2Size;
+        mGemmProfilerBackend.prepare(mTotalTokens, mGemmProfilerWorkspace + mGemmProfilerWorkspaceSize * mBufferIndex,
+            /*expert_weights=*/expert_weights + expert_weights_size * mBufferIndex, streamPtr->get());
+    }
+
     std::array<cudaGraph_t, NUM_BUFFERS> mGraph{};
+
     std::array<cudaGraphExec_t, NUM_BUFFERS> mGraphInstance{};
 
-    void createGraph(MOEParallelismConfig parallelism_config)
+    void createGraph(MOEParallelismConfig parallelism_config, GemmToProfile gemm_to_profile)
     {
         if (!useCudaGraph)
             return;
@@ -689,9 +765,11 @@ public:
         for (int i = 0; i < NUM_BUFFERS; i++)
         {
             mBufferIndex = i;
+            // Each buffer will have a different routing config for the gemm profiler
+            prepareGemmProfiler(gemm_to_profile);
             check_cuda_error(cudaGraphCreate(&mGraph[i], 0));
             check_cuda_error(cudaStreamBeginCapture(streamPtr->get(), cudaStreamCaptureModeThreadLocal));
-            runMoEPermute(parallelism_config);
+            runMoEPermute(parallelism_config, gemm_to_profile);
             check_cuda_error(cudaStreamEndCapture(streamPtr->get(), &mGraph[i]));
             check_cuda_error(cudaGraphInstantiate(&mGraphInstance[i], mGraph[i], nullptr, nullptr, 0));
         }
@@ -711,13 +789,23 @@ public:
         }
     }
 
-    float benchmarkLoop(MOEParallelismConfig parallelism_config)
+    float benchmarkLoop(MOEParallelismConfig parallelism_config, GemmToProfile gemm_to_profile)
     {
         mBufferIndex = (mBufferIndex + 1) % NUM_BUFFERS;
-        auto tactic = routingConfigCache.at(mRoutingConfigIndex);
-        if (!tactic->isDeterministic())
+
+        // Setup the profiler state for this iteration. CUDA Graphs will do this when it captures the graph.
+        if (gemm_to_profile != GemmToProfile::LAYER && !useCudaGraph)
         {
-            tactic->setRouting(mSelectedExperts + mSelectedExpertsSize * mBufferIndex, mNumExperts, mK, mTotalTokens);
+            prepareGemmProfiler(gemm_to_profile);
+        }
+        else if (gemm_to_profile == GemmToProfile::LAYER)
+        {
+            auto tactic = routingConfigCache.at(mRoutingConfigIndex);
+            if (!tactic->isDeterministic())
+            {
+                tactic->setRouting(
+                    mSelectedExperts + mSelectedExpertsSize * mBufferIndex, mNumExperts, mK, mTotalTokens);
+            }
         }
 
         {
@@ -729,7 +817,7 @@ public:
             }
             else
             {
-                runMoEPermute(parallelism_config);
+                runMoEPermute(parallelism_config, gemm_to_profile);
             }
             check_cuda_error(cudaEventRecord(mEndEvent, streamPtr->get()));
             check_cuda_error(cudaStreamSynchronize(streamPtr->get()));
@@ -742,27 +830,19 @@ public:
 
     // An imprecise benchmark pass for picking the best tactic.
     // Runs for 3 iterations or 1 second and picks the best option
-    int pickBestTactic(MOEParallelismConfig parallelism_config, GemmProfilerBackend::GemmToProfile gemm_to_profile)
+    int pickBestTactic(MOEParallelismConfig parallelism_config, GemmToProfile gemm_to_profile)
     {
         auto tactics = mMoERunner.getTactics();
         ::nvtx3::scoped_range nvtx(tensorrt_llm::common::nvtx::nextColor(),
             "Tactic Profiling GEMM " + std::to_string(static_cast<int>(gemm_to_profile)));
+        // We save space by reusing the same workspace buffer for all tactics when doing full layer profiling. So we
+        // need to hardcode the buffer index to 0.
+        auto old_buffer_index = mBufferIndex;
+        mBufferIndex = 0;
+        prepareGemmProfiler(gemm_to_profile);
+        mBufferIndex = old_buffer_index;
 
-        GemmProfilerBackend profiler;
-#ifdef USING_OSS_CUTLASS_MOE_GEMM
-        profiler.init(mMoERunner, gemm_to_profile, typeToDtypeID<DataType>(), typeToDtypeID<WeightType>(),
-            typeToDtypeID<OutputType>(), mNumExperts, mK, mHiddenSize, mInterSize, mGroupSize, mActType, mUseBias,
-            mUseLora, /*min_latency_mode=*/false, /*need_weights=*/true, parallelism_config, /*enable_alltoall=*/false);
-#else
-        profiler.init(mMoERunner, gemm_to_profile, typeToDtypeID<DataType>(), typeToDtypeID<WeightType>(),
-            typeToDtypeID<OutputType>(), mNumExperts, mK, mHiddenSize, mInterSize, mGroupSize, mActType, mUseBias,
-            mUseLora, /*min_latency_mode=*/false, /*need_weights=*/true, parallelism_config);
-#endif
-        auto workspace_size = profiler.getWorkspaceSize(mTotalTokens);
-        auto workspace = bufferManager->gpu(workspace_size);
-
-        profiler.prepare(
-            mTotalTokens, static_cast<char*>(workspace->data()), /*expert_weights=*/nullptr, streamPtr->get());
+        auto* mGemmProfilerExpertWeights = gemm_to_profile == GemmToProfile::GEMM_1 ? mExpertWeight1 : mExpertWeight2;
 
         float best_time = INFINITY;
         int best_idx = -1;
@@ -778,13 +858,13 @@ public:
                 {
                     ::nvtx3::scoped_range nvtx(tensorrt_llm::common::nvtx::nextColor(), "Tactic Profiling Warm-Up");
                     // Warm-Up run
-                    profiler.runProfiler(mTotalTokens, t, static_cast<char*>(workspace->data()),
-                        /*expert_weights=*/nullptr, streamPtr->get());
+                    mGemmProfilerBackend.runProfiler(mTotalTokens, t, mGemmProfilerWorkspace,
+                        /*expert_weights=*/mGemmProfilerExpertWeights, streamPtr->get());
                     check_cuda_error(cudaStreamSynchronize(streamPtr->get()));
                 }
 
                 // Profile all samples or for 1 sec
-                int const max_iters = profiler.NUM_ROUTING_SAMPLES;
+                int const max_iters = mGemmProfilerBackend.NUM_ROUTING_SAMPLES;
                 float const max_time_ms = 1000.f;
 
                 float time = 0.f;
@@ -796,8 +876,8 @@ public:
                             "Tactic Profiling Iteration " + std::to_string(iter));
 
                         check_cuda_error(cudaEventRecord(mStartEvent, streamPtr->get()));
-                        profiler.runProfiler(mTotalTokens, t, static_cast<char*>(workspace->data()),
-                            /*expert_weights=*/nullptr, streamPtr->get());
+                        mGemmProfilerBackend.runProfiler(mTotalTokens, t, mGemmProfilerWorkspace,
+                            /*expert_weights=*/mGemmProfilerExpertWeights, streamPtr->get());
                         check_cuda_error(cudaEventRecord(mEndEvent, streamPtr->get()));
                         check_cuda_error(cudaStreamSynchronize(streamPtr->get()));
                     }
@@ -838,17 +918,26 @@ public:
         return best_idx;
     }
 
-    std::pair<int, int> setTactic(int tactic_idx1, int tactic_idx2, MOEParallelismConfig parallelism_config)
+    int mBestTacticGemm1 = -1;
+    int mBestTacticGemm2 = -1;
+
+    std::pair<int, int> setTactic(
+        int tactic_idx1, int tactic_idx2, MOEParallelismConfig parallelism_config, GemmToProfile gemm_to_profile)
     {
         auto tactics = mMoERunner.getTactics();
-        for (auto& t_ptr : {&tactic_idx1, &tactic_idx2})
+        std::vector<std::pair<std::reference_wrapper<int>, GemmToProfile>> tactics_to_profile{
+            {tactic_idx1, GemmToProfile::GEMM_1}, {tactic_idx2, GemmToProfile::GEMM_2}};
+        for (auto& combo : tactics_to_profile)
         {
-            auto& t = *t_ptr;
+            auto& t = combo.first.get();
+            if (combo.second != gemm_to_profile && gemm_to_profile != GemmToProfile::LAYER)
+            {
+                t = 0; // Unneeded tactic, set to 0
+                continue;
+            }
             if (t == -1)
             {
-                t = pickBestTactic(parallelism_config,
-                    t_ptr == &tactic_idx1 ? GemmProfilerBackend::GemmToProfile::GEMM_1
-                                          : GemmProfilerBackend::GemmToProfile::GEMM_2);
+                t = pickBestTactic(parallelism_config, combo.second);
             }
 
             if (t < 0 || t >= tactics.size())
@@ -858,38 +947,66 @@ public:
         }
 
         mMoERunner.setTactic(tactics[tactic_idx1], tactics[tactic_idx2]);
+        mBestTacticGemm1 = tactic_idx1;
+        mBestTacticGemm2 = tactic_idx2;
         return {tactic_idx1, tactic_idx2};
     }
 
-    void runMoEPermute(MOEParallelismConfig parallelism_config)
+    void runMoEPermute(MOEParallelismConfig parallelism_config, GemmToProfile gemm_to_profile)
     {
-        auto stream = streamPtr->get();
-        MoeMinLatencyParams min_latency_params;
+        switch (gemm_to_profile)
+        {
+        case GemmToProfile::GEMM_1:
+        case GemmToProfile::GEMM_2:
+        {
+            auto tactic_idx = gemm_to_profile == GemmToProfile::GEMM_1 ? mBestTacticGemm1 : mBestTacticGemm2;
+            auto* expert_weights = gemm_to_profile == GemmToProfile::GEMM_1 ? mExpertWeight1 : mExpertWeight2;
+            auto expert_weights_size
+                = gemm_to_profile == GemmToProfile::GEMM_1 ? mExpertWeight1Size : mExpertWeight2Size;
+
+            auto tactics = mMoERunner.getTactics()[tactic_idx];
+            if (static_cast<int>(gemm_to_profile) != static_cast<int>(mGemmProfilerBackend.mGemmToProfile))
+            {
+                throw std::runtime_error("Configuration mismatch between mGemmProfilerBackend and runMoEPermute");
+            }
+            mGemmProfilerBackend.mSampleIndex = mBufferIndex % mGemmProfilerBackend.NUM_ROUTING_SAMPLES;
+            mGemmProfilerBackend.runProfiler(mTotalTokens, tactics,
+                mGemmProfilerWorkspace + mGemmProfilerWorkspaceSize * mBufferIndex,
+                /*expert_weights=*/expert_weights + expert_weights_size * mBufferIndex, streamPtr->get());
+            break;
+        }
+        case GemmToProfile::LAYER:
+        {
+            auto stream = streamPtr->get();
+            MoeMinLatencyParams min_latency_params;
 #ifdef USING_OSS_CUTLASS_MOE_GEMM
-        mMoERunner.runMoe(mInputTensor + mInputTensorSize * mBufferIndex, nullptr,
-            mSelectedExperts + mSelectedExpertsSize * mBufferIndex,
-            mUseFinalScale ? mScaleProbs + mScaleProbsSize * mBufferIndex : nullptr,
-            mExpertWeight1 + mExpertWeight1Size * mBufferIndex, mExpertBias1 + mExpertBias1Size * mBufferIndex,
-            mActType, mExpertWeight2 + mExpertWeight2Size * mBufferIndex,
-            mExpertBias2 + mExpertBias2Size * mBufferIndex, mQuantParams[mBufferIndex], mTotalTokens, mHiddenSize,
-            mInterSize, mNumExperts, mK, mWorkspace + mWorkspaceSize * mBufferIndex,
-            mFinalOutput + mFinalOutputSize * mBufferIndex,
-            mSourceToExpandedMap + mSourceToExpandedMapSize * mBufferIndex, parallelism_config,
-            /*enable_alltoall=*/false, mUseLora, mLoraParams[mBufferIndex],
-            /*use_fp8_block_scaling=*/false, /*min_latency_mode=*/false, min_latency_params, stream);
+            mMoERunner.runMoe(mInputTensor + mInputTensorSize * mBufferIndex, nullptr,
+                mSelectedExperts + mSelectedExpertsSize * mBufferIndex,
+                mUseFinalScale ? mScaleProbs + mScaleProbsSize * mBufferIndex : nullptr,
+                mExpertWeight1 + mExpertWeight1Size * mBufferIndex, mExpertBias1 + mExpertBias1Size * mBufferIndex,
+                mActType, mExpertWeight2 + mExpertWeight2Size * mBufferIndex,
+                mExpertBias2 + mExpertBias2Size * mBufferIndex, mQuantParams[mBufferIndex], mTotalTokens, mHiddenSize,
+                mInterSize, mNumExperts, mK, mWorkspace + mWorkspaceSize * mBufferIndex,
+                mFinalOutput + mFinalOutputSize * mBufferIndex,
+                mSourceToExpandedMap + mSourceToExpandedMapSize * mBufferIndex, parallelism_config,
+                /*enable_alltoall=*/false, mUseLora, mLoraParams[mBufferIndex],
+                /*use_fp8_block_scaling=*/false, /*min_latency_mode=*/false, min_latency_params, stream);
 #else
-        mMoERunner.runMoe(mInputTensor + mInputTensorSize * mBufferIndex, nullptr,
-            mSelectedExperts + mSelectedExpertsSize * mBufferIndex,
-            mUseFinalScale ? mScaleProbs + mScaleProbsSize * mBufferIndex : nullptr,
-            mExpertWeight1 + mExpertWeight1Size * mBufferIndex, mExpertBias1 + mExpertBias1Size * mBufferIndex,
-            mActType, mExpertWeight2 + mExpertWeight2Size * mBufferIndex,
-            mExpertBias2 + mExpertBias2Size * mBufferIndex, mQuantParams[mBufferIndex], mTotalTokens, mHiddenSize,
-            mInterSize, mNumExperts, mK, mWorkspace + mWorkspaceSize * mBufferIndex,
-            mFinalOutput + mFinalOutputSize * mBufferIndex,
-            mSourceToExpandedMap + mSourceToExpandedMapSize * mBufferIndex, parallelism_config, mUseLora,
-            mLoraParams[mBufferIndex],
-            /*use_fp8_block_scaling=*/false, /*min_latency_mode=*/false, min_latency_params, stream);
+            mMoERunner.runMoe(mInputTensor + mInputTensorSize * mBufferIndex, nullptr,
+                mSelectedExperts + mSelectedExpertsSize * mBufferIndex,
+                mUseFinalScale ? mScaleProbs + mScaleProbsSize * mBufferIndex : nullptr,
+                mExpertWeight1 + mExpertWeight1Size * mBufferIndex, mExpertBias1 + mExpertBias1Size * mBufferIndex,
+                mActType, mExpertWeight2 + mExpertWeight2Size * mBufferIndex,
+                mExpertBias2 + mExpertBias2Size * mBufferIndex, mQuantParams[mBufferIndex], mTotalTokens, mHiddenSize,
+                mInterSize, mNumExperts, mK, mWorkspace + mWorkspaceSize * mBufferIndex,
+                mFinalOutput + mFinalOutputSize * mBufferIndex,
+                mSourceToExpandedMap + mSourceToExpandedMapSize * mBufferIndex, parallelism_config, mUseLora,
+                mLoraParams[mBufferIndex],
+                /*use_fp8_block_scaling=*/false, /*min_latency_mode=*/false, min_latency_params, stream);
 #endif
+            break;
+        }
+        }
     }
 
     void runBenchmark(benchmark::State& state);
@@ -913,6 +1030,7 @@ void MixtureOfExpertsBenchmark<TypeTuple_>::runBenchmark(benchmark::State& state
     int tactic_idx1 = state.range(11);
     int tactic_idx2 = state.range(12);
     int const routing_config = state.range(13);
+    GemmToProfile const gemm_to_profile = static_cast<GemmToProfile>(state.range(14));
 
     state.counters["num_experts"] = num_experts;
     state.counters["top_k"] = top_k;
@@ -928,11 +1046,12 @@ void MixtureOfExpertsBenchmark<TypeTuple_>::runBenchmark(benchmark::State& state
     state.counters["routing_config"] = (int) routing_config;
     state.counters["dtype"] = (int) toDTypeID();
     state.counters["wtype"] = (int) toWTypeID();
+    state.counters["gemm_to_profile"] = (int) gemm_to_profile;
 
     std::stringstream ss;
-    ss << "Experts,K,Hidden,Inter,TP,EP,Rank,Tokens,Bias,Scale,Actfn,Tactic,Routing=";
+    ss << "Experts,K,Hidden,Inter,TP,EP,Rank,Tokens,Bias,Scale,Actfn,Tactic1,Tactic2,Gemm,Routing=";
     for (auto v : {num_experts, top_k, hidden_size, inter_size, tp_size, ep_size, world_rank, num_tokens,
-             (int) mUseBias, (int) mUseFinalScale, (int) mActType, tactic_idx1, tactic_idx2})
+             (int) mUseBias, (int) mUseFinalScale, (int) mActType, tactic_idx1, tactic_idx2, (int) gemm_to_profile})
     {
         ss << v << ",";
     }
@@ -942,10 +1061,11 @@ void MixtureOfExpertsBenchmark<TypeTuple_>::runBenchmark(benchmark::State& state
 
     // Always use EP size for moe config until we support TP+EP, we just divide the inter size for TP
     MOEParallelismConfig parallelism_config{tp_size, world_rank / ep_size, ep_size, world_rank % ep_size};
-    initBuffersPermute(num_tokens, hidden_size, inter_size, num_experts, top_k, routing_config, parallelism_config);
+    initBuffersPermute(
+        num_tokens, hidden_size, inter_size, num_experts, top_k, routing_config, parallelism_config, gemm_to_profile);
 
     // Parse the tactic, does checks for "auto" mode and out of range
-    std::tie(tactic_idx1, tactic_idx2) = setTactic(tactic_idx1, tactic_idx2, parallelism_config);
+    std::tie(tactic_idx1, tactic_idx2) = setTactic(tactic_idx1, tactic_idx2, parallelism_config, gemm_to_profile);
     if (tactic_idx1 < 0 || tactic_idx2 < 0)
     {
         state.SkipWithMessage("Out of range tactic");
@@ -962,13 +1082,13 @@ void MixtureOfExpertsBenchmark<TypeTuple_>::runBenchmark(benchmark::State& state
     state.counters["tactic_idx1"] = tactic_idx1;
     state.counters["tactic_idx2"] = tactic_idx2;
 
-    createGraph(parallelism_config);
+    createGraph(parallelism_config, gemm_to_profile);
 
     {
-        NVTX3_SCOPED_RANGE(BenchmarkRun);
+        ::nvtx3::scoped_range nvtx(tensorrt_llm::common::nvtx::nextColor(), "BenchmarkRun " + ss.str());
         for (auto _ : state)
         {
-            float ms = benchmarkLoop(parallelism_config);
+            float ms = benchmarkLoop(parallelism_config, gemm_to_profile);
             state.SetIterationTime(ms / 1000.f);
         }
     }

--- a/cpp/micro_benchmarks/mixtureOfExpertsBackendBenchmarkLauncher.cu
+++ b/cpp/micro_benchmarks/mixtureOfExpertsBackendBenchmarkLauncher.cu
@@ -389,11 +389,11 @@ void argGenLoadFile(benchmark::internal::Benchmark* benchmark)
             {
                 continue;
             }
-            else if (std::is_same_v<typename BenchClass::WeightType, float> && !hasDtype("float")
-                && !hasDtype("float32"))
-            {
-                continue;
-            }
+            // else if (std::is_same_v<typename BenchClass::WeightType, float> && !hasDtype("float")
+            //     && !hasDtype("float32"))
+            // {
+            //     continue;
+            // }
             else if (std::is_same_v<typename BenchClass::WeightType, half> && !hasDtype("float16") && !hasDtype("half"))
             {
                 continue;
@@ -452,7 +452,37 @@ void argGenLoadFile(benchmark::internal::Benchmark* benchmark)
         int world_rank = get_or("world_rank", 0);
         int bias = get_or("bias", 0);
         int do_final_scale = get_or("do_final_scale", 1); // Default to scales on
+        int gemm_to_profile = get_or("gemm_to_profile", (int) GemmToProfile::LAYER);
         TLLM_CHECK_WITH_INFO(world_rank < tp_size * ep_size, "Rank is out of bounds of tp*ep");
+
+        if (gemm_to_profile != (int) GemmToProfile::LAYER && routing_config != UNIFORM_ROUTING_CONFIG)
+        {
+            static bool info_printed = false;
+            if (!info_printed && LOG_LEVEL >= INFO)
+            {
+                std::cerr << "Warning: GEMM profiling is experimental, results may be inaccurate" << std::endl;
+                info_printed = true;
+            }
+
+            static bool printed = false;
+            if (LOG_LEVEL >= ERROR && !printed)
+            {
+                std::cerr << "Warning: Profiling a specific GEMM will always use uniform random token distribution"
+                          << std::endl;
+                printed = true;
+            }
+            routing_config = UNIFORM_ROUTING_CONFIG;
+            if (gemm_to_profile == (int) GemmToProfile::GEMM_1)
+            {
+                tactic_ids2 = {-1};
+            }
+            else if (gemm_to_profile == (int) GemmToProfile::GEMM_2)
+            {
+                if (!has_tactic_ids2)
+                    tactic_ids2 = std::move(tactic_ids1);
+                tactic_ids1 = {-1};
+            }
+        }
 
         auto get_range = [&](std::string name, int min = 1, int max = INT32_MAX)
         {
@@ -482,7 +512,7 @@ void argGenLoadFile(benchmark::internal::Benchmark* benchmark)
                     get_range("act_fn", 0, (int) ActivationType::Identity), //
                     t1,                                                     //
                     t2,                                                     //
-                    *routing_config});
+                    *routing_config, gemm_to_profile});
             }
         }
     }
@@ -518,7 +548,8 @@ void argGenHardcoded(benchmark::internal::Benchmark* benchmark)
                                         for (auto tactic2 : cutlass_tactic)
                                             for (auto routing : routing_config)
                                                 benchmark->Args({num_expert, k, size, inter_size, 1, 1, 0, tokens, bias,
-                                                    1, (int) act, tactic1, tactic2, routing});
+                                                    1, (int) act, tactic1, tactic2, routing,
+                                                    (int) GemmToProfile::LAYER});
                     }
 }
 
@@ -542,7 +573,7 @@ void argGen(benchmark::internal::Benchmark* benchmark)
     benchmark->UseManualTime();
     benchmark->ArgNames(
         {"Num Experts", "K", "Hidden Size", "Inter Size", "TP Size", "EP Size", "World Rank", "Num Tokens", "Use Bias",
-            "Use Final Scale", "Activation Function", "Tactic ID 1", "Tactic ID 2", "Routing ID"});
+            "Use Final Scale", "Activation Function", "Tactic ID 1", "Tactic ID 2", "Routing ID", "Gemm To Profile"});
 
     if (workloadFile)
         argGenLoadFile<BenchClass>(benchmark);
@@ -550,7 +581,8 @@ void argGen(benchmark::internal::Benchmark* benchmark)
         argGenHardcoded<BenchClass>(benchmark);
 }
 
-BENCHMARK_BASIC(float, float, float)
+// No one cares about float32
+// BENCHMARK_BASIC(float, float, float)
 BENCHMARK_BASIC(half, half, half)
 using uint8 = uint8_t;
 BENCHMARK_BASIC(half, uint8, half)
@@ -576,7 +608,7 @@ void delayedRegisterBenchmark()
     if (workloadFile)
     {
         // Extra ones we don't want for hardcoded runs
-        BENCHMARK_BASIC_DO_REGISTER(float, float, float);
+        // BENCHMARK_BASIC_DO_REGISTER(float, float, float);
         BENCHMARK_BASIC_DO_REGISTER(half, uint8, half);
         BENCHMARK_BASIC_DO_REGISTER(half, uint4b_t, half);
 #ifdef ENABLE_BF16
@@ -597,6 +629,9 @@ void doCleanup()
 
 void help()
 {
+    std::cout << "**Disclaimer: This benchmark is intended for developers to help evaluating the impact of new "
+                 "optimisations. This benchmark does not meet the same quality standards as other parts of TRT-LLM. "
+                 "Please use with caution**\n\n";
     std::cout << "Usage: mixtureOfExpertsBackendBenchmark [--disable_cuda_graphs] [--input_file <file>] [benchmark "
                  "options]\n";
     std::cout
@@ -624,6 +659,7 @@ void help()
            "    \"routing_name\": string, (optional)\n"
            "    \"selected_experts\": [int, ...], or string, (optional, length is a multiple of k)\n"
            "    \"expert_distribution\": [float, ...], or string, (optional, length is num_experts)\n"
+           "    \"gemm_to_profile\": int, (experimental, optional, 1 = gemm1, 2 = gemm2, 3 = layer)\n"
            "  },\n"
            "  ...\n"
            "]\n"
@@ -664,7 +700,7 @@ void help()
            "Useful for quick perf tests, prefer a full sweep and manually setting the tactic for more accurate "
            "results"
            "- dtypes - A list of dtypes to run this config through.\n"
-           "Allowed values are: fp8, fp4, wfp4afp8, int4, int8, float, half, bfloat16\n"
+           "Allowed values are: fp8, fp4, wfp4afp8, int4, int8, half, bfloat16\n"
            "If this argument is omitted all dtypes will be run. Note, not all tactics are supported for all "
            "dtypes,\n"
            "unsupported tactics will be skipped with a warning.\n"
@@ -681,6 +717,8 @@ void help()
            "- \"expert_distribution\" - instead of explicitly setting selected_experts, define a random distribution "
            "that experts will be randomly sampled from."
            "There is also pre-defined config \"uniform\", which is short-hand for a random uniform distribution\n"
+           "- \"gemm_to_profile\" - the gemm to profile, 1 = gemm1, 2 = gemm2, 3 = full layer. (default layer). If a "
+           "specific GEMM is profiled, it will always use uniform random token distribution\n"
            "\n";
 
     std::cout << "benchmark options:\n";

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/include/moe_kernels.h
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/include/moe_kernels.h
@@ -845,10 +845,10 @@ public:
         mWType = wtype;
         mOType = otype;
         mNumExperts = num_experts;
-        mNumExpertsPerNode = num_experts / (parallelism_config.ep_size * parallelism_config.tp_size);
+        mNumExpertsPerNode = num_experts / parallelism_config.ep_size;
         mK = k;
         mExpertHiddenSize = hidden_size;
-        mExpertInterSize = inter_size;
+        mExpertInterSize = inter_size; // Already divided by tp_size
         mGroupSize = group_size;
         mActivationType = activation_type;
         mBias = bias;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to profile individual GEMM operations or the full Mixture of Experts (MoE) layer in backend benchmarks.
  * Introduced a new benchmark parameter to select which GEMM to profile.
  * Enhanced benchmark configuration with dynamic parameter generation and additional profiling options.

* **Bug Fixes**
  * Corrected calculation for the number of experts per node in GEMM profiling.

* **Documentation**
  * Added cautionary disclaimers to benchmark documentation and help output, advising users about the intended use and quality standards of the benchmarks.

* **Chores**
  * Disabled float32 benchmarks and updated help text to reflect supported data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->