### PR TITLE
[TRTLLM-1302][feat] Topk logprobs for TRT backend and top1 logprob for PyT backend

### DIFF
--- a/tensorrt_llm/executor/postproc_worker.py
+++ b/tensorrt_llm/executor/postproc_worker.py
@@ -6,7 +6,6 @@ from typing import (TYPE_CHECKING, Any, Callable, Dict, List, NamedTuple,
                     Optional, Union)
 
 import zmq
-import zmq.asyncio
 
 from .._utils import nvtx_range_debug
 from ..bindings import executor as tllm

--- a/tensorrt_llm/executor/result.py
+++ b/tensorrt_llm/executor/result.py
@@ -245,13 +245,12 @@ class GenerationResultBase:
             output.cumulative_logprob = response_tensors.cum_log_probs[src_idx]
 
         if logprobs_result:
-            # update logprobs for TRT backend
+            # update logprobs from ResponseWrapper (TRT top logprobs WAR)
             output._last_logprobs_len = len(output.logprobs)
             output.prompt_logprobs = logprobs_result.prompt
             output.logprobs += logprobs_result.generation
-
-        if logprobs_result is None and response_tensors.log_probs is not None:
-            # update logprobs for both backends
+        elif response_tensors.log_probs is not None:
+            # handle logprobs directly from response tensors
             output._last_logprobs_len = len(output.logprobs)
             output.logprobs = response_tensors.log_probs[src_idx]
             # overcome some WAR in the cpp executor

--- a/tensorrt_llm/executor/result.py
+++ b/tensorrt_llm/executor/result.py
@@ -91,7 +91,7 @@ class CompletionOutput:
         text (str): The generated output text. Defaults to "".
         token_ids (List[int], optional): The token ids of the generated output text. Defaults to [].
         cumulative_logprob (float, optional): The cumulative log probability of the generated output text. Defaults to None.
-        logprobs (TokenLogprobs, optional): The log probabilities of the top probability words at each position if the logprobs are requested. Defaults to None.
+        logprobs (TokenLogprobs | List[float], optional): The log probabilities of the top probability words at each position if the logprobs are requested. Defaults to None.
         prompt_logprobs (TokenLogprobs, optional): The log probabilities per prompt token. Defaults to None.
         finish_reason (Literal['stop', 'length', 'timeout', 'cancelled'], optional): The reason why the sequence is finished. Defaults to None.
         stop_reason (int, str, optional): The stop string or token id that caused the completion to stop, None if the completion finished for some other reason. Defaults to None.
@@ -102,7 +102,7 @@ class CompletionOutput:
     Attributes:
         length (int): The number of generated tokens.
         token_ids_diff (List[int]): Newly generated token ids.
-        logprobs_diff (List[float]): Logprobs of newly generated tokens.
+        logprobs_diff (TokenLogprobs | List[float]): Logprobs of newly generated tokens.
         text_diff (str): Newly generated tokens.
     """
     index: int
@@ -111,8 +111,7 @@ class CompletionOutput:
     cumulative_logprob: Optional[float] = None
     logprobs: Optional[TokenLogprobs
                        | List[float]] = field(default_factory=list)
-    prompt_logprobs: Optional[TokenLogprobs
-                              | List[float]] = field(default_factory=list)
+    prompt_logprobs: Optional[TokenLogprobs] = field(default_factory=list)
     finish_reason: Optional[Literal['stop', 'length', 'timeout',
                                     'cancelled']] = None
     stop_reason: Optional[Union[int, str]] = None
@@ -143,7 +142,7 @@ class CompletionOutput:
         return self.token_ids[self._last_token_ids_len:]
 
     @property
-    def logprobs_diff(self) -> List[float]:
+    def logprobs_diff(self) -> TokenLogprobs | List[float]:
         return self.logprobs[self._last_logprobs_len:]
 
 

--- a/tensorrt_llm/executor/result.py
+++ b/tensorrt_llm/executor/result.py
@@ -110,9 +110,9 @@ class CompletionOutput:
     token_ids: Optional[List[int]] = field(default_factory=list)
     cumulative_logprob: Optional[float] = None
     logprobs: Optional[TokenLogprobs
-                       | list[float]] = field(default_factory=list)
+                       | List[float]] = field(default_factory=list)
     prompt_logprobs: Optional[TokenLogprobs
-                              | list[float]] = field(default_factory=list)
+                              | List[float]] = field(default_factory=list)
     finish_reason: Optional[Literal['stop', 'length', 'timeout',
                                     'cancelled']] = None
     stop_reason: Optional[Union[int, str]] = None

--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -644,7 +644,6 @@ class ChatCompletionRequest(OpenAIBaseModel):
         )
         if self.logprobs:
             logprobs = 1 if not self.top_logprobs else self.top_logprobs
-            print(f"Using logprobs: {logprobs}")
             if backend == "pytorch":
                 sampling_params.logprobs = logprobs
             else:

--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -210,7 +210,7 @@ class CompletionRequest(OpenAIBaseModel):
     echo: Optional[bool] = False
     frequency_penalty: Optional[float] = 0.0
     logit_bias: Optional[Dict[str, float]] = None
-    logprobs: Optional[bool] = None
+    logprobs: Optional[int] = None
     max_tokens: Optional[int] = None
     n: int = 1
     presence_penalty: Optional[float] = 0.0
@@ -649,6 +649,10 @@ class ChatCompletionRequest(OpenAIBaseModel):
             else:
                 if gather_generation_logits:
                     sampling_params.logprobs = logprobs
+                elif self.top_logprobs:
+                    raise ValueError(
+                        "`gather_generation_logits` must be `True` to use `top_logprobs`"
+                    )
                 else:
                     sampling_params._return_log_probs = True
         return sampling_params

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -426,6 +426,7 @@ class OpenAIServer:
             sampling_params = request.to_sampling_params(
                 vocab_size=self.tokenizer.tokenizer.vocab_size)
             # TODO: better way to enable metrics
+            sampling_params = request.to_sampling_params(self.llm.args.gather_generation_logits, self.llm.args.backend)
             if len(os.getenv("TRTLLM_KVCACHE_TIME_OUTPUT_PATH", "")) > 0:
                 sampling_params.return_perf_metrics = True
             postproc_args = ChatPostprocArgs.from_request(request)

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -424,9 +424,10 @@ class OpenAIServer:
             # Pass the tokenizer vocabulary size so ``logit_bias`` can be
             # expanded into an embedding bias tensor in the sampler.
             sampling_params = request.to_sampling_params(
-                vocab_size=self.tokenizer.tokenizer.vocab_size)
+                vocab_size=self.tokenizer.tokenizer.vocab_size,
+                gather_generation_logits=self.llm.args.gather_generation_logits,
+                backend=self.llm.args.backend)
             # TODO: better way to enable metrics
-            sampling_params = request.to_sampling_params(self.llm.args.gather_generation_logits, self.llm.args.backend)
             if len(os.getenv("TRTLLM_KVCACHE_TIME_OUTPUT_PATH", "")) > 0:
                 sampling_params.return_perf_metrics = True
             postproc_args = ChatPostprocArgs.from_request(request)

--- a/tensorrt_llm/serve/postprocess_handlers.py
+++ b/tensorrt_llm/serve/postprocess_handlers.py
@@ -63,8 +63,7 @@ class ChatPostprocArgs(PostprocArgs):
         )
 
 
-def create_logprobs(token_ids: List[int],
-                    tokenizer: TransformersTokenizer,
+def create_logprobs(token_ids: List[int], tokenizer: TransformersTokenizer,
                     logprobs: List[float] | TokenLogprobs,
                     top_logprobs: bool) -> ChatCompletionLogProbs:
     assert len(token_ids) == len(logprobs), \
@@ -195,7 +194,8 @@ def chat_stream_post_processor(rsp: GenerationResultBase,
         if args.return_logprobs:
             logprobs = output.logprobs_diff
             token_ids = output.token_ids_diff
-            choice.logprobs = create_logprobs(token_ids, args.tokenizer, logprobs, args.top_logprobs)
+            choice.logprobs = create_logprobs(token_ids, args.tokenizer,
+                                              logprobs, args.top_logprobs)
         if output.finish_reason is not None:
             choice.finish_reason = output.finish_reason
             choice.stop_reason = output.stop_reason
@@ -263,7 +263,9 @@ def chat_response_post_processor(
         )
 
         if args.return_logprobs:
-            choice.logprobs = create_logprobs(output.token_ids, args.tokenizer, output.logprobs, args.top_logprobs)
+            choice.logprobs = create_logprobs(output.token_ids, args.tokenizer,
+                                              output.logprobs,
+                                              args.top_logprobs)
         choices.append(choice)
 
     if args.echo and args.last_message_content:

--- a/tensorrt_llm/serve/postprocess_handlers.py
+++ b/tensorrt_llm/serve/postprocess_handlers.py
@@ -5,6 +5,7 @@ from .._utils import nvtx_range_debug
 from ..executor import (DetokenizedGenerationResultBase, GenerationResult,
                         GenerationResultBase)
 from ..executor.postproc_worker import PostprocArgs
+from ..executor.result import Logprob, TokenLogprobs
 from ..llmapi.reasoning_parser import (BaseReasoningParser,
                                        ReasoningParserFactory)
 from ..llmapi.tokenizer import TransformersTokenizer
@@ -39,6 +40,7 @@ class ChatPostprocArgs(PostprocArgs):
     tool_choice: Optional[Union[Literal["none"],
                                 ChatCompletionNamedToolChoiceParam]] = "none"
     return_logprobs: bool = False
+    top_logprobs: bool = False
     stream_options: Optional[StreamOptions] = None
     last_message_content: Optional[str] = None
     reasoning_parser: Optional[str] = None
@@ -56,23 +58,39 @@ class ChatPostprocArgs(PostprocArgs):
             tools=request.tools,
             tool_choice=request.tool_choice,
             stream_options=request.stream_options,
-            return_logprobs=request.logprobs,
+            return_logprobs=bool(request.logprobs),
+            top_logprobs=bool(request.top_logprobs),
         )
 
 
-def create_logprobs(token_ids: List[int], tokenizer: TransformersTokenizer,
-                    logprobs: List[float]) -> ChatCompletionLogProbs:
+def create_logprobs(token_ids: List[int],
+                    tokenizer: TransformersTokenizer,
+                    logprobs: List[float] | TokenLogprobs,
+                    top_logprobs: bool) -> ChatCompletionLogProbs:
     assert len(token_ids) == len(logprobs), \
             "token_ids and logprobs have different lengths"
     content: List[ChatCompletionLogProbsContent] = []
     for token_id, logprob in zip(token_ids, logprobs):
+        logprob: float | dict[int, Logprob]
         token = tokenizer.decode(token_id)
-        # returning multiple logprobs is not supported
-        first_logprob = ChatCompletionLogProbsContent(
+        chat_logprob = ChatCompletionLogProbsContent(
             token=token,
-            logprob=max(logprob, -9999.0),
-            bytes=list(token.encode("utf-8", errors="replace")))
-        content.append(first_logprob)
+            bytes=list(token.encode("utf-8", errors="replace")),
+        )
+        if isinstance(logprob, dict):
+            if token_id in logprob:
+                chat_logprob.logprob = max(logprob[token_id].logprob, -9999.0)
+                if top_logprobs:
+                    chat_logprob.top_logprobs = [
+                        ChatCompletionLogProbsContent(
+                            token=(tk := tokenizer.decode(tid)),
+                            logprob=max(logprob.logprob, -9999.0),
+                            bytes=list(tk.encode("utf-8", errors="replace")))
+                        for tid, logprob in logprob.items()
+                    ]
+        else:
+            chat_logprob.logprob = max(logprob, -9999.0)
+        content.append(chat_logprob)
     chat_logprobs = ChatCompletionLogProbs(content=content)
     return chat_logprobs
 
@@ -177,8 +195,7 @@ def chat_stream_post_processor(rsp: GenerationResultBase,
         if args.return_logprobs:
             logprobs = output.logprobs_diff
             token_ids = output.token_ids_diff
-            choice.logprobs = create_logprobs(token_ids, args.tokenizer,
-                                              logprobs)
+            choice.logprobs = create_logprobs(token_ids, args.tokenizer, logprobs, args.top_logprobs)
         if output.finish_reason is not None:
             choice.finish_reason = output.finish_reason
             choice.stop_reason = output.stop_reason
@@ -246,8 +263,7 @@ def chat_response_post_processor(
         )
 
         if args.return_logprobs:
-            choice.logprobs = create_logprobs(output.token_ids, args.tokenizer,
-                                              output.logprobs)
+            choice.logprobs = create_logprobs(output.token_ids, args.tokenizer, output.logprobs, args.top_logprobs)
         choices.append(choice)
 
     if args.echo and args.last_message_content:

--- a/tests/integration/defs/test_e2e.py
+++ b/tests/integration/defs/test_e2e.py
@@ -1548,16 +1548,18 @@ def test_trtllm_serve_lora_example(llm_root, llm_venv):
          str(test_root / "_test_trtllm_serve_lora.py")])
 
 
-def test_trtllm_serve_top_logprobs(llm_root, llm_venv):
+@pytest.mark.parametrize("backend", ["pytorch", "trt"])
+def test_trtllm_serve_top_logprobs(llm_root, llm_venv, backend: str):
     example_root = Path(os.path.join(llm_root, "examples", "serve"))
     test_root = unittest_path() / "llmapi" / "apps"
     llm_venv.run_cmd([
         "-m", "pip", "install", "-r",
         os.path.join(example_root, "requirements.txt")
     ])
-    llm_venv.run_cmd(
-        ["-m", "pytest",
-         str(test_root / "_test_trtllm_serve_top_logprobs.py")])
+    llm_venv.run_cmd([
+        "-m", "pytest",
+        str(test_root / "_test_trtllm_serve_top_logprobs.py"), "-k", backend
+    ])
 
 
 @pytest.mark.parametrize("backend", ["pytorch", "trt"])

--- a/tests/integration/defs/test_e2e.py
+++ b/tests/integration/defs/test_e2e.py
@@ -1548,6 +1548,18 @@ def test_trtllm_serve_lora_example(llm_root, llm_venv):
          str(test_root / "_test_trtllm_serve_lora.py")])
 
 
+def test_trtllm_serve_top_logprobs(llm_root, llm_venv):
+    example_root = Path(os.path.join(llm_root, "examples", "serve"))
+    test_root = unittest_path() / "llmapi" / "apps"
+    llm_venv.run_cmd([
+        "-m", "pip", "install", "-r",
+        os.path.join(example_root, "requirements.txt")
+    ])
+    llm_venv.run_cmd(
+        ["-m", "pytest",
+         str(test_root / "_test_trtllm_serve_top_logprobs.py")])
+
+
 @pytest.mark.parametrize("backend", ["pytorch", "trt"])
 def test_openai_misc_example(llm_root, llm_venv, backend: str):
     test_root = unittest_path() / "llmapi" / "apps"

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -33,6 +33,7 @@ l0_a10:
   - test_e2e.py::test_openai_lora
   - test_e2e.py::test_trtllm_serve_multimodal_example
   - test_e2e.py::test_trtllm_serve_lora_example
+  - test_e2e.py::test_trtllm_serve_top_logprobs[pytorch]
   - test_e2e.py::test_openai_misc_example[pytorch]
   - test_e2e.py::test_openai_reasoning[pytorch]
   - test_e2e.py::test_openai_completions_example[pytorch]
@@ -106,6 +107,7 @@ l0_a10:
   - llmapi/test_llm_examples.py::test_llmapi_server_example
   - llmapi/test_llm_examples.py::test_llmapi_kv_cache_connector[Qwen2-0.5B]
   - test_e2e.py::test_trtllm_serve_example
+  - test_e2e.py::test_trtllm_serve_top_logprobs[trt]
   - test_e2e.py::test_openai_misc_example[trt]
   - test_e2e.py::test_openai_completions_example[trt]
   - test_e2e.py::test_openai_chat_example[trt]

--- a/tests/unittest/api_stability/references/completion_output.yaml
+++ b/tests/unittest/api_stability/references/completion_output.yaml
@@ -16,7 +16,7 @@ properties:
     annotation: int
     default: inspect._empty
   logprobs_diff:
-    annotation: List[float]
+    annotation: list[dict[int, tensorrt_llm.executor.result.Logprob]] | List[float]
     default: inspect._empty
   text_diff:
     annotation: str

--- a/tests/unittest/api_stability/references_committed/completion_output.yaml
+++ b/tests/unittest/api_stability/references_committed/completion_output.yaml
@@ -20,7 +20,7 @@ methods:
         annotation: Optional[torch.Tensor]
         default: null
       logprobs:
-        annotation: Optional[list[dict[int, tensorrt_llm.executor.result.Logprob]]]
+        annotation: Optional[list[dict[int, tensorrt_llm.executor.result.Logprob]] | List[float]]
         default: null
       prompt_logprobs:
         annotation: Optional[list[dict[int, tensorrt_llm.executor.result.Logprob]]]

--- a/tests/unittest/llmapi/apps/_test_openai_chat.py
+++ b/tests/unittest/llmapi/apps/_test_openai_chat.py
@@ -141,42 +141,14 @@ def test_single_chat_session(client: openai.OpenAI, model_name: str):
     message = chat_completion.choices[0].message
     assert message.content is not None
     assert message.role == "assistant"
-
-
-def test_single_chat_session_with_logprobs(client: openai.OpenAI,
-                                           model_name: str, backend: str):
-    if backend == "pytorch":
-        pytest.skip("Logprobs are not supported in PyTorch backend yet")
-
-    messages = [{
-        "role": "system",
-        "content": "you are a helpful assistant"
-    }, {
-        "role": "user",
-        "content": "what is 1+1?"
-    }]
-
+    # test logprobs
     chat_completion = client.chat.completions.create(
         model=model_name,
         messages=messages,
         max_completion_tokens=10,
         logprobs=True,
     )
-    assert chat_completion.id is not None
-    assert len(chat_completion.choices) == 1
-    message = chat_completion.choices[0].message
-    assert message.content is not None
-    assert message.role == "assistant"
-    # test logprobs
     logprobs = chat_completion.choices[0].logprobs.content
-    finish_reason = chat_completion.choices[0].finish_reason
-    if finish_reason == "length":
-        assert len(logprobs) == 10
-    elif finish_reason == "stop":
-        assert len(logprobs) <= 10
-    else:
-        raise RuntimeError(
-            f"finish_reason {finish_reason} not in [length, stop]")
     for logprob in logprobs:
         assert logprob.token is not None
         assert logprob.logprob is not None
@@ -204,10 +176,11 @@ def test_multi_turn_dialogue(client: openai.OpenAI, model_name: str):
     assert message.content is not None and len(message.content) >= 0
 
 
-def test_multiple_response(client: openai.OpenAI, model_name: str,
-                           backend: str):
+def test_multiple_responses(client: openai.OpenAI, model_name: str,
+                            backend: str):
     if backend == "pytorch":
-        pytest.skip("Beam search is not supported in PyTorch backend yet")
+        pytest.skip(
+            "Multiple responses are not supported in PyTorch backend yet")
 
     messages = [{
         "role": "system",
@@ -244,70 +217,6 @@ def test_multiple_response(client: openai.OpenAI, model_name: str,
 @pytest.mark.asyncio(loop_scope="module")
 async def test_chat_streaming(async_client: openai.AsyncOpenAI,
                               model_name: str):
-    messages = [{
-        "role": "system",
-        "content": "you are a helpful assistant"
-    }, {
-        "role": "user",
-        "content": "what is 1+1?"
-    }]
-
-    chat_completion = await async_client.chat.completions.create(
-        model=model_name,
-        messages=messages,
-        max_completion_tokens=10,
-        temperature=0.0,
-        logprobs=False,
-    )
-    output = chat_completion.choices[0].message.content
-    _finish_reason = chat_completion.choices[0].finish_reason
-
-    # test streaming
-    stream = await async_client.chat.completions.create(
-        model=model_name,
-        messages=messages,
-        max_completion_tokens=10,
-        temperature=0.0,
-        logprobs=False,
-        stream=True,
-    )
-    str_chunks: List[str] = []
-
-    finish_reason_counter = 0
-    finish_reason: str = None
-    async for chunk in stream:
-        choice = chunk.choices[0]
-        delta = choice.delta
-        if choice.finish_reason is not None:
-            finish_reason_counter += 1
-            finish_reason = choice.finish_reason
-        if delta.role:
-            assert delta.role == "assistant"
-        if delta.content:
-            str_chunks.append(delta.content)
-    # test finish_reason
-    if delta.content == "":
-        assert finish_reason == "stop"
-    assert finish_reason_counter == 1
-    assert finish_reason == _finish_reason
-    num_tokens = len(str_chunks)
-    if finish_reason == "length":
-        assert num_tokens == 10
-    elif finish_reason == "stop":
-        assert num_tokens <= 10
-    else:
-        raise RuntimeError(
-            f"finish_reason {finish_reason} not in [length, stop]")
-    # test generated tokens
-    assert "".join(str_chunks) == output
-
-
-@pytest.mark.asyncio(loop_scope="module")
-async def test_chat_streaming_with_logprobs(async_client: openai.AsyncOpenAI,
-                                            model_name: str, backend: str):
-    if backend == "pytorch":
-        pytest.skip("Logprobs are not supported in PyTorch backend yet")
-
     messages = [{
         "role": "system",
         "content": "you are a helpful assistant"

--- a/tests/unittest/llmapi/apps/_test_trtllm_serve_top_logprobs.py
+++ b/tests/unittest/llmapi/apps/_test_trtllm_serve_top_logprobs.py
@@ -1,0 +1,135 @@
+import os
+import tempfile
+
+import openai
+import pytest
+import yaml
+
+from ..test_llm import get_model_path
+from .openai_server import RemoteOpenAIServer
+
+pytestmark = pytest.mark.threadleak(enabled=False)
+
+
+@pytest.fixture(scope="module", ids=["TinyLlama-1.1B-Chat"])
+def model_name():
+    return "llama-models-v2/TinyLlama-1.1B-Chat-v1.0"
+
+
+@pytest.fixture(scope="module", params=["trt", "pytorch"])
+def backend(request):
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def temp_extra_llm_api_options_file():
+    temp_dir = tempfile.gettempdir()
+    temp_file_path = os.path.join(temp_dir, "extra_llm_api_options.yaml")
+    try:
+        extra_llm_api_options_dict = {
+            "enable_chunked_prefill": False,
+            "gather_generation_logits": True,
+            "kv_cache_config": {
+                "enable_block_reuse": False,
+            }
+        }
+
+        with open(temp_file_path, 'w') as f:
+            yaml.dump(extra_llm_api_options_dict, f)
+
+        yield temp_file_path
+    finally:
+        if os.path.exists(temp_file_path):
+            os.remove(temp_file_path)
+
+
+@pytest.fixture(scope="module")
+def server(model_name: str, backend: str, temp_extra_llm_api_options_file: str):
+    model_path = get_model_path(model_name)
+    args = [
+        "--backend", f"{backend}", "--extra_llm_api_options",
+        temp_extra_llm_api_options_file
+    ]
+    with RemoteOpenAIServer(model_path, args) as remote_server:
+        yield remote_server
+
+
+@pytest.fixture(scope="module")
+def async_client(server: RemoteOpenAIServer):
+    return server.get_async_client()
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_chat_completion_top5_logprobs(async_client: openai.AsyncOpenAI,
+                                             model_name: str, backend: str):
+    # Skip if backend is PyTorch as it does not support topk logprobs when k > 1
+    if backend == "pytorch":
+        pytest.skip("Topk logprobs is not supported")
+
+    messages = [{
+        "role": "system",
+        "content": "You are a helpful assistant."
+    }, {
+        "role": "user",
+        "content": "What is the capital of France?"
+    }]
+
+    # Test top_logprobs
+    chat_completion = await async_client.chat.completions.create(
+        model=model_name,
+        messages=messages,
+        max_completion_tokens=10,
+        temperature=0.0,
+        logprobs=True,
+        top_logprobs=5,
+        extra_body={
+            "ignore_eos": True,
+        })
+    logprobs = chat_completion.choices[0].logprobs
+    assert logprobs is not None and logprobs.content is not None
+    assert len(logprobs.content) == 10
+    for logprob_content in logprobs.content:
+        assert logprob_content.token is not None
+        assert logprob_content.logprob is not None
+        assert logprob_content.bytes is not None
+        assert logprob_content.top_logprobs is not None
+        assert len(logprob_content.top_logprobs) == 5
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_chat_completion_top1_logprobs(async_client: openai.AsyncOpenAI,
+                                             model_name: str, backend: str):
+    # Skip if backend is TRT because it is tested in test_chat_completion_top5_logprobs
+    if backend == "trt":
+        pytest.skip(
+            "TRT top logprobs is already tested in test_chat_completion_top5_logprobs"
+        )
+
+    messages = [{
+        "role": "system",
+        "content": "You are a helpful assistant."
+    }, {
+        "role": "user",
+        "content": "What is the capital of France?"
+    }]
+    # Test top_logprobs=1
+    chat_completion = await async_client.chat.completions.create(
+        model=model_name,
+        messages=messages,
+        max_completion_tokens=10,
+        temperature=0.0,
+        logprobs=True,
+        top_logprobs=1,
+        extra_body={
+            "ignore_eos": True,
+        })
+    logprobs = chat_completion.choices[0].logprobs
+    assert logprobs is not None and logprobs.content is not None
+    assert len(logprobs.content) == 10
+    for logprob_content in logprobs.content:
+        assert logprob_content.token is not None
+        assert logprob_content.logprob is not None
+        assert logprob_content.bytes is not None
+        assert logprob_content.top_logprobs is not None
+        # Check that the top_logprobs contains only one entry
+        assert len(logprob_content.top_logprobs) == 1

--- a/tests/unittest/llmapi/apps/openai_server.py
+++ b/tests/unittest/llmapi/apps/openai_server.py
@@ -28,8 +28,7 @@ class RemoteOpenAIServer:
         args = ["--host", f"{self.host}", "--port", f"{self.port}"]
         if cli_args:
             args += cli_args
-        launch_cmd = ["python3"] + ["-m"] + ["tensorrt_llm.commands.serve"
-                                             ] + [model] + args
+        launch_cmd = ["trtllm-serve"] + [model] + args
         if llmapi_launch:
             # start server with llmapi-launch on multi nodes
             launch_cmd = ["trtllm-llmapi-launch"] + launch_cmd

--- a/tests/unittest/llmapi/apps/openai_server.py
+++ b/tests/unittest/llmapi/apps/openai_server.py
@@ -28,7 +28,8 @@ class RemoteOpenAIServer:
         args = ["--host", f"{self.host}", "--port", f"{self.port}"]
         if cli_args:
             args += cli_args
-        launch_cmd = ["trtllm-serve"] + [model] + args
+        launch_cmd = ["python3"] + ["-m"] + ["tensorrt_llm.commands.serve"
+                                             ] + [model] + args
         if llmapi_launch:
             # start server with llmapi-launch on multi nodes
             launch_cmd = ["trtllm-llmapi-launch"] + launch_cmd


### PR DESCRIPTION
## Description

1. TopK logprobs for TRT backend with gathering context & generation logits
2. Top1 logprobs for PyT backend
For now some length mismatch happens randomly, still need to investigate.
## Test Coverage

Will be added.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for returning top-k log probabilities per token in chat completions, enabling detailed token probability insights.
  * Enhanced API to optionally include top log probabilities in chat completion responses.
  * Extended request parameters to better control logprobs gathering and backend-specific behavior.

* **Bug Fixes**
  * Improved validation and handling of logprobs and top_logprobs parameters in chat completion requests.
  * Refined internal logprob state management for more accurate probability tracking.

* **Tests**
  * Added new integration and unit tests validating top-k logprobs functionality on PyTorch and TensorRT backends.
  * Consolidated and updated existing tests for logprobs and chat completions, removing redundant streaming tests.

* **Documentation**
  * Updated parameter validation logic and API behavior for logprobs and top_logprobs fields in chat completion requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->