### PR TITLE
test: update max_beam_width to 1 due to torchsampler changes.

### DIFF
--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -372,18 +372,18 @@ class TestTorchLlmArgs:
     def test_runtime_sizes(self):
         llm = TorchLLM(
             llama_model_path,
-            max_beam_width=4,
+            max_beam_width=1,
             max_num_tokens=256,
             max_seq_len=128,
             max_batch_size=8,
         )
 
-        assert llm.args.max_beam_width == 4
+        assert llm.args.max_beam_width == 1
         assert llm.args.max_num_tokens == 256
         assert llm.args.max_seq_len == 128
         assert llm.args.max_batch_size == 8
 
-        assert llm._executor_config.max_beam_width == 4
+        assert llm._executor_config.max_beam_width == 1
         assert llm._executor_config.max_num_tokens == 256
         assert llm._executor_config.max_seq_len == 128
         assert llm._executor_config.max_batch_size == 8


### PR DESCRIPTION
Update max_beam_width to 1 due to this [change](https://github.com/NVIDIA/TensorRT-LLM/pull/5513/files#diff-76ef6eceb82cb64d4ea6d49fca82d42ac6c942a45ad9fc8d3ff6a9b49e3b466bR223)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated a test to use a different configuration value, ensuring assertions reflect this change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->