### PR TITLE
[https://nvbugs/5387375] fix(scaffolding): fix scaffolding aime test in test_e2e

### DIFF
--- a/examples/scaffolding/run_best_of_n_with_reward.py
+++ b/examples/scaffolding/run_best_of_n_with_reward.py
@@ -60,7 +60,7 @@ def main():
     prompts = [query]
 
     results = llm.generate(prompts)
-    print(results[0].output.output_str)
+    print(results[0].outputs[0].text)
     llm.shutdown(shutdown_workers=True)
     print(f'main shut down done')
 

--- a/examples/scaffolding/run_majority_vote_aime24.py
+++ b/examples/scaffolding/run_majority_vote_aime24.py
@@ -101,9 +101,8 @@ def main():
         result = results[i]
         test_case = test_dataset[i]
         ref_answer = int(test_case["answer"])
-        result.result()
-        output = result.output
-        extracted_answer = extract_answer_from_boxed(output.output_str)
+        output = result.outputs[0]
+        extracted_answer = extract_answer_from_boxed(output.text)
         try:
             # print(f"[QUESTION]:\n{prompt}\n\n[OUTPUT]\n\n{output.output_str}\n\n")
             answer = int(extracted_answer)

--- a/tensorrt_llm/scaffolding/__init__.py
+++ b/tensorrt_llm/scaffolding/__init__.py
@@ -12,7 +12,6 @@ from .worker import OpenaiWorker, TRTLLMWorker, TRTOpenaiWorker, Worker
 
 __all__ = [
     "ScaffoldingLlm",
-    "ScaffoldingOutput",
     "ParallelProcess",
     "Controller",
     "NativeGenerationController",

--- a/tensorrt_llm/scaffolding/math_utils.py
+++ b/tensorrt_llm/scaffolding/math_utils.py
@@ -1,5 +1,4 @@
 import re
-from collections import Counter
 from typing import List
 
 
@@ -59,28 +58,31 @@ def get_majority_result(
     result_extractor=lambda x: x,
     result_validator=lambda x: True,
 ):
-    valid_answers_and_results = [(result, result_extractor(result))
-                                 for result in results
-                                 if result_validator(result) is True
-                                 and result_extractor(result) is not None]
-    if len(valid_answers_and_results) == 0:
+    extract_answers = [result_extractor(result) for result in results]
+    valid_answers = [
+        result for result in extract_answers
+        if result is not None and result_validator(result) is True
+    ]
+    if len(valid_answers) == 0:
         return None, None
 
-    majority_result = Counter(valid_answers_and_results).most_common(1)[0][0]
-    # return result and extracted result
-    return majority_result[0], majority_result[1]
+    answer_counts = {}
+    for answer in valid_answers:
+        answer_counts[answer] = answer_counts.get(answer, 0) + 1
+    majority_answer = max(answer_counts, key=answer_counts.get)
+    majority_index = next(
+        filter(lambda x: x[1] == majority_answer,
+               enumerate(extract_answers)))[0]
+    return majority_index, majority_answer
 
 
 def get_digit_majority_vote_result(results: List[str]) -> str:
 
     def is_digit(result: str):
-        extracted_answer = extract_answer_from_boxed(result)
-        if extracted_answer is None:
-            return False
-        return extracted_answer.isdigit()
+        return result.isdigit()
 
-    vote_result = get_majority_result(
+    index, extract_answer = get_majority_result(
         results,
         result_extractor=extract_answer_from_boxed,
-        result_validator=is_digit)[0]
-    return vote_result if vote_result else results[0]
+        result_validator=is_digit)
+    return (index, extract_answer) if extract_answer else (0, None)

--- a/tensorrt_llm/scaffolding/result.py
+++ b/tensorrt_llm/scaffolding/result.py
@@ -1,15 +1,7 @@
 import asyncio
-from dataclasses import dataclass
 from typing import Mapping, Optional
 
 from tensorrt_llm.executor.result import GenerationResult
-
-
-@dataclass(slots=True)
-class ScaffoldingOutput:
-
-    def __init__(self):
-        self.output_str = None
 
 
 class ScaffoldingResult:
@@ -17,7 +9,7 @@ class ScaffoldingResult:
     def __init__(self, streaming_event: Optional[asyncio.Event] = None):
         super().__init__()
         self.aqueue = asyncio.Queue()
-        self.cur_output = None
+        self.cur_output: GenerationResult = None
         self._done = False
         self.task_collections = None
         self.streaming_event = streaming_event

--- a/tensorrt_llm/scaffolding/scaffolding_llm.py
+++ b/tensorrt_llm/scaffolding/scaffolding_llm.py
@@ -82,7 +82,7 @@ class ScaffoldingLlm:
         ]
         await asyncio.gather(*async_tasks)
         for task in tasks:
-            if task.streaming:
+            if getattr(task, 'streaming', False):
                 await request.result.set_output_async(task.result)
                 self.streaming_event.clear()
                 await self.streaming_event.wait()

--- a/tensorrt_llm/scaffolding/task.py
+++ b/tensorrt_llm/scaffolding/task.py
@@ -62,8 +62,6 @@ class GenerationTask(Task):
     worker_tag: Union[str, "Controller.WorkerTag"] = None
 
     # result field
-    _outputs: Optional[List[dict]] = None
-
     # link to TRTLLM's GenerationResult, for async update in streaming mode
     _result: Optional[GenerationResult] = None
 
@@ -74,35 +72,36 @@ class GenerationTask(Task):
     @result.setter
     def result(self, result: GenerationResult) -> None:
         self._result = result
-        self._outputs = result.outputs
+
+    @property
+    def outputs(self) -> Optional[List[dict]]:
+        return self._result.outputs if self._result else None
 
     @property
     def output_tokens(self) -> List[int]:
-        return self._outputs[
-            0].token_ids if self.result and self._outputs else None
+        return self._result.outputs[0].token_ids if self._result else None
 
     @property
     def output_str(self) -> Optional[str]:
-        return self._outputs[0].text if self.result and self._outputs else None
+        return self._result.outputs[0].text if self._result else None
 
     @output_str.setter
     def output_str(self, output) -> Optional[str]:
-        assert self.result and self._outputs
-        self._outputs[0].text = output
+        assert self.result
+        self._result.outputs[0].text = output
 
     @property
     def cumulative_logprob(self) -> Optional[float]:
-        return self._outputs[
-            0].cumulative_logprob if self.result and self._outputs else None
+        return self._result.outputs[
+            0].cumulative_logprob if self._result else None
 
     @property
     def logprobs(self) -> Optional[List[float]]:
-        return self._outputs[
-            0].logprobs if self.result and self._outputs else None
+        return self._result.outputs[0].logprobs if self._result else None
 
     @property
     def context_logits(self) -> Optional[torch.Tensor]:
-        return self.result.context_logits if self.result else None
+        return self._result.context_logits if self._result else None
 
     @staticmethod
     def create_from_prompt(prompt: str) -> "GenerationTask":
@@ -113,7 +112,7 @@ class GenerationTask(Task):
         return task
 
     def create_scaffolding_output(self) -> GenerationResult:
-        return self.result
+        return self._result
 
 
 @dataclass

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -436,7 +436,6 @@ examples/test_multimodal.py::test_llm_multimodal_general[Qwen2-VL-7B-Instruct-pp
 examples/test_multimodal.py::test_llm_fp8_multimodal_general[fp8-fp8-cnn_dailymail-Qwen2-VL-7B-Instruct-pp:1-tp:1-bfloat16-bs:1-cpp_e2e:False] SKIP (https://nvbugs/5385987)
 examples/test_multimodal.py::test_llm_multimodal_general[Phi-4-multimodal-instruct-pp:1-tp:1-float16-bs:1-cpp_e2e:False-nb:1] SKIP (https://nvbugs/5385992)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_multi_gpus[throughput_tp8] SKIP (https://nvbugs/5377914)
-test_e2e.py::test_ptp_scaffolding[DeepSeek-R1-Distill-Qwen-7B-DeepSeek-R1/DeepSeek-R1-Distill-Qwen-7B] SKIP (https://nvbugs/5387375)
 examples/test_multimodal.py::test_llm_multimodal_general[kosmos-2-pp:1-tp:1-float16-bs:1-cpp_e2e:False-nb:1] SKIP (https://nvbugs/5387422)
 examples/test_multimodal.py::test_llm_multimodal_general[fuyu-8b-pp:1-tp:1-float16-bs:1-cpp_e2e:False-nb:1] SKIP (https://nvbugs/5387424)
 test_e2e.py::test_ptp_quickstart SKIP (https://nvbugs/5387762)

--- a/tests/unittest/scaffolding/test_bench.py
+++ b/tests/unittest/scaffolding/test_bench.py
@@ -13,7 +13,7 @@ OUTPUT_STR = "Yes."
 class DummyWorker(Worker):
 
     async def dummy_generation_handler(self, task: GenerationTask):
-        task.output_str = OUTPUT_STR
+        task.result = OUTPUT_STR
         return TaskStatus.SUCCESS
 
     task_handlers = {GenerationTask: dummy_generation_handler}
@@ -29,7 +29,7 @@ class DummyTaskCollection(TaskCollection):
         pass
 
     def after_yield(self, tasks: List[Task]):
-        self.output_len = len(tasks[0].output_str)
+        self.output_len = len(tasks[0].result)
 
 
 def test_scaffolding_benchmark():
@@ -56,6 +56,6 @@ def test_scaffolding_benchmark():
 
     assert len(results) == requests_num
     assert len(requests_execution_time) == requests_num
-    assert results[0].output.output_str == OUTPUT_STR
+    assert results[0].cur_output == OUTPUT_STR
     assert results[0].task_collections[
         "bench_dummy_collection"].output_len == len(OUTPUT_STR)

--- a/tests/unittest/scaffolding/test_parallel_process.py
+++ b/tests/unittest/scaffolding/test_parallel_process.py
@@ -4,8 +4,6 @@ import time
 from enum import Enum
 from typing import List
 
-import pytest
-
 from tensorrt_llm.scaffolding import (Controller, ParallelProcess,
                                       ScaffoldingLlm, Task, TaskStatus, Worker)
 
@@ -21,8 +19,6 @@ class DummyTask(Task):
         task = DummyTask(2)
         return task
 
-    # TODO: Fix when ScaffoldingOutput is replaced with GenerationResult
-    # def create_scaffolding_output(self) -> "ScaffoldingOutput":
     def create_scaffolding_output(self):
         self.verify()
         return None
@@ -34,8 +30,6 @@ class DummyTask(Task):
 
 class DummyControllerBase(Controller):
 
-    # TODO: Fix when ScaffoldingOutput is replaced with GenerationResult
-    # def generate(self, prompt: str, **kwargs) -> ScaffoldingOutput:
     def generate(self, prompt: str, **kwargs):
         task = DummyTask.create_from_prompt(prompt)
         yield from self.process([task], **kwargs)
@@ -125,7 +119,6 @@ def parallel_process_helper_run_and_verify(controllers):
     llm.shutdown()
 
 
-@pytest.skip(reason="ScaffoldingOutput removed in PR #5345, needs refactoring")
 def test_parallel_process_helper():
     NUM_CONTROLLERS = 3
     controllers = []
@@ -137,7 +130,6 @@ def test_parallel_process_helper():
     parallel_process_helper_run_and_verify(controllers)
 
 
-@pytest.skip(reason="ScaffoldingOutput removed in PR #5345, needs refactoring")
 def test_parallel_process_helper_with_two_level():
     NUM_CONTROLLERS_LEVEL_1 = 2
     NUM_CONTROLLERS_LEVEL_2 = 2

--- a/tests/unittest/scaffolding/test_task_collection.py
+++ b/tests/unittest/scaffolding/test_task_collection.py
@@ -2,8 +2,6 @@ import copy
 from enum import Enum
 from typing import List
 
-import pytest
-
 from tensorrt_llm.scaffolding import (Controller, ParallelProcess,
                                       ScaffoldingLlm, Task, TaskCollection,
                                       TaskStatus, Worker, with_task_collection)
@@ -20,8 +18,6 @@ class DummyTask(Task):
         task = DummyTask()
         return task
 
-    # TODO: Fix when ScaffoldingOutput is replaced with GenerationResult
-    # def create_scaffolding_output(self) -> "ScaffoldingOutput":
     def create_scaffolding_output(self):
         return None
 
@@ -55,8 +51,6 @@ class DummyControllerBase(Controller):
         super().__init__()
         self.expected_task_count = expected_task_count
 
-    # TODO: Fix when ScaffoldingOutput is replaced with GenerationResult
-    # def generate(self, prompt: str, **kwargs) -> ScaffoldingOutput:
     def generate(self, prompt: str, **kwargs):
         task = DummyTask.create_from_prompt(prompt)
         yield from self.process([task], **kwargs)
@@ -127,7 +121,6 @@ def run(controller, expected_task_count):
     llm.shutdown()
 
 
-@pytest.skip(reason="ScaffoldingOutput removed in PR #5345, needs refactoring")
 def test_dummy_task_collection():
     controller = DummyController(1)
     run(controller, 1)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when accessing generated text outputs and handling streaming tasks.
  * Fixed potential attribute errors and removed redundant code for output handling.

* **Refactor**
  * Simplified and unified how results and outputs are managed across scaffolding components.
  * Updated majority vote logic to return both index and answer, improving clarity and consistency.
  * Removed deprecated or unused classes and attributes.

* **Tests**
  * Updated tests to reflect new output handling.
  * Removed unnecessary skip decorators, enabling more tests to run by default.

* **Chores**
  * Cleaned up obsolete comments and imports.
  * Removed outdated test waivers for previously skipped tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

[JIRA ticket/NVBugs ID/GitHub issue][fix/feat/doc/infra/...] \<summary of this PR\>

For example, assume I have a PR to support a new feature about cache manager for JIRA ticket TRTLLM-1000, it would be like:

[TRTLLM-1000][feat] Support a new feature about cache manager

Or I have a PR to fix a Llama3 accuracy issue:

[https://nvbugs/1234567][fix] Fix Llama3 accuracy issue
-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
