### PR TITLE
doc: remove cuda_graph_config: {} from doc since cuda_graph enabled b…

### DIFF
--- a/docs/source/blogs/Best_perf_practice_on_DeepSeek-R1_in_TensorRT-LLM.md
+++ b/docs/source/blogs/Best_perf_practice_on_DeepSeek-R1_in_TensorRT-LLM.md
@@ -137,7 +137,6 @@ To do the benchmark, run the following command:
 YOUR_DATA_PATH=<your dataset file following the format>
 
 cat >./extra-llm-api-config.yml<<EOF
-cuda_graph_config: {}
 moe_config:
   backend: TRTLLM
 speculative_config:
@@ -318,7 +317,6 @@ To do the benchmark, run the following command:
 YOUR_DATA_PATH=<your dataset file following the format>
 
 cat >./extra-llm-api-config.yml<<EOF
-cuda_graph_config: {}
 speculative_config:
     decoding_type: MTP
     num_nextn_predict_layers: 3

--- a/docs/source/blogs/tech_blog/blog4_Scaling_Expert_Parallelism_in_TensorRT-LLM.md
+++ b/docs/source/blogs/tech_blog/blog4_Scaling_Expert_Parallelism_in_TensorRT-LLM.md
@@ -541,7 +541,6 @@ Run 32-way expert parallelism inference on the prepared dataset. Please refer to
 ```bash
 cat > ./extra_llm_api_options.yaml <<EOF
 enable_attention_dp: true
-cuda_graph_config: {}
 EOF
 
 trtllm-llmapi-launch \
@@ -622,7 +621,6 @@ Run 36-way expert parallelism inference with the EPLB configuration incorporated
 ```bash
 cat > ./extra_llm_api_options_eplb.yaml <<EOF
 enable_attention_dp: true
-cuda_graph_config: {}
 moe_config:
   load_balancer: ./moe_load_balancer.yaml
 EOF

--- a/examples/models/core/deepseek_v3/README.md
+++ b/examples/models/core/deepseek_v3/README.md
@@ -193,7 +193,6 @@ Evaluate the model accuracy using `trtllm-eval`.
 1. (Optional) Prepare an advanced configuration file:
 ```bash
 cat >./extra-llm-api-config.yml <<EOF
-cuda_graph_config: {}
 enable_attention_dp: true
 EOF
 ```


### PR DESCRIPTION
Clean doc by removing `cuda_graph_config: {}` since we enable cuda_graph by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified configuration examples in multiple documentation files by removing unused or empty entries for `cuda_graph_config`. This streamlines the YAML configuration snippets and improves clarity for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->