### PR TITLE
[feat] Enable TP and batching for PixtralVisionModel / Mistral3VLM

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_clip.py
+++ b/tensorrt_llm/_torch/models/modeling_clip.py
@@ -202,7 +202,7 @@ class CLIPVisionModel(nn.Module):
             request_ids=request_ids,
             prompt_lens=prompt_lens,
         )
-        attn_metadata.max_seq_len = seq_len * batch_size
+        attn_metadata.max_seq_len = seq_len
         attn_metadata.prepare()
         return attn_metadata
 

--- a/tensorrt_llm/_torch/models/modeling_mistral.py
+++ b/tensorrt_llm/_torch/models/modeling_mistral.py
@@ -3,6 +3,7 @@ import os
 from typing import Any, Dict, List, Optional, Tuple
 
 import torch
+import torchvision
 from torch import nn
 from transformers import (AutoProcessor, AutoTokenizer, Mistral3Config,
                           MistralConfig, PretrainedConfig, PreTrainedModel)
@@ -347,7 +348,6 @@ class Mistral3VLM(PreTrainedModel):
         attn_metadata: AttentionMetadata,
         input_ids: Optional[torch.LongTensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.Tensor] = None,
         return_context_logits: bool = False,
         **kwargs,
     ) -> torch.Tensor:
@@ -363,19 +363,25 @@ class Mistral3VLM(PreTrainedModel):
                 raise RuntimeError(
                     f"Number of multimodal tensors ({multimodal_params_len}) should be equal to number of "
                     f"context requests ({num_context_requests}) in the batch.")
-            # NOTES:
-            # 1. the pixel values in `multimodal_data["image"]` might vary in (height, width) between
-            #    images, making them unsafe to batch in general. The input processor also cannot produce
-            #    them in a batch, since it is always called with a single input - otherwise, we would
-            #    have been able to naturally leverage the padding / resizing capabilities of the underlying
-            #    `PixtralProcessor`.
-            # 2. After each `pixel_values` tensor has gone through the vision tower's `patch_conv` layer,
-            #    they are divided into patches that are then concatenated in order to treat them as a
-            #    single "sequence" in the vision tower's attention layers, so some form of batching still
-            #    happens in the vision tower.
-            image_features = [
-                self._get_image_features(**x.multimodal_data["image"])
+            pixel_values = [
+                x.multimodal_data["image"]["pixel_values"]
                 for x in multimodal_params
+            ]
+            image_sizes = [
+                x.multimodal_data["image"]["image_sizes"]
+                for x in multimodal_params
+            ]
+            if not (len(pixel_values) == len(image_sizes) ==
+                    multimodal_params_len):
+                raise ValueError(
+                    f"Expected as many `pixel_values` ({len(pixel_values)}) and "
+                    f"`image_sizes` ({len(image_sizes)}) as number of multimodal parameters "
+                    f"({multimodal_params_len}).")
+            batched_pixel_values, batched_image_sizes = self._batch_pixel_values(
+                pixel_values=pixel_values, image_sizes=image_sizes)
+            image_features = [
+                self._get_image_features(pixel_values=batched_pixel_values,
+                                         image_sizes=batched_image_sizes)
             ]
 
         input_ids, inputs_embeds = fuse_input_embeds(
@@ -428,6 +434,31 @@ class Mistral3VLM(PreTrainedModel):
         image_features = self._multi_modal_projector(image_outputs.squeeze(0),
                                                      image_sizes)
         return image_features
+
+    # Original HF implementation:
+    # https://github.com/huggingface/transformers/blob/v4.51.3/src/transformers/models/pixtral/
+    # image_processing_pixtral.py#L276
+    # We switch to using torchvision's padding functionality since it supports torch tensors
+    # (the transformers one expected numpy arrays).
+    @staticmethod
+    @torch.inference_mode()
+    def _batch_pixel_values(
+        pixel_values: List[torch.Tensor],
+        image_sizes: List[torch.Tensor],
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        batched_image_sizes = torch.cat(image_sizes)
+        max_shape = batched_image_sizes.max(dim=0).values
+        pixel_values = [
+            torchvision.transforms.v2.functional.pad(
+                image,
+                # Per torchvision docs, this should be in LTRB order if it's a sequence of 4 numbers.
+                padding=[0, 0, max_shape[1] - size[1], max_shape[0] - size[0]],
+                # Values extracted from HF implementation.
+                fill=0.0,
+                padding_mode="constant",
+            ) for image, size in zip(pixel_values, batched_image_sizes)
+        ]
+        return torch.cat(pixel_values), batched_image_sizes
 
 
 # Original implementation:

--- a/tests/unittest/_torch/modeling/test_modeling_pixtral.py
+++ b/tests/unittest/_torch/modeling/test_modeling_pixtral.py
@@ -1,11 +1,31 @@
+import gc
+import os
+import pathlib
+import pickle
+import sys
+
+import cloudpickle
+import mpi4py
 import pytest
 import torch
 import transformers
 from transformers.models.pixtral import modeling_pixtral as hf_modeling_pixtral
 
+import tensorrt_llm
 from tensorrt_llm import mapping as mapping_lib
 from tensorrt_llm._torch import model_config as model_config_lib
 from tensorrt_llm._torch.models import modeling_pixtral
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+cloudpickle.register_pickle_by_value(sys.modules[__name__])
+mpi4py.MPI.pickle.__init__(
+    cloudpickle.dumps,
+    cloudpickle.loads,
+    pickle.HIGHEST_PROTOCOL,
+)
+
+# needed since we reuse the mpi executor pool, first test running will leak a thread
+pytestmark = pytest.mark.threadleak(enabled=False)
 
 
 @pytest.fixture
@@ -49,21 +69,6 @@ def init_hf_model(cls, config, dtype, device):
     return model
 
 
-@pytest.mark.parametrize(
-    "mapping",
-    [
-        mapping_lib.Mapping(world_size=2, tp_size=2),
-        mapping_lib.Mapping(world_size=3, tp_size=3),
-        mapping_lib.Mapping(world_size=4, tp_size=2, pp_size=2),
-        mapping_lib.Mapping(world_size=8, tp_size=2, pp_size=2, cp_size=2),
-    ],
-)
-def test_pixtral_vision_model_rejects_tp_size_greater_than_one(pixtral_vision_config, mapping):
-    pixtral_vision_config.mapping = mapping
-    with pytest.raises(NotImplementedError, match="tp_size > 1"):
-        modeling_pixtral.PixtralVisionModel(model_config=pixtral_vision_config)
-
-
 @torch.no_grad()
 @pytest.mark.usefixtures("set_seed")
 def test_pixtral_vision_model_vs_hf(pixtral_vision_config):
@@ -83,10 +88,10 @@ def test_pixtral_vision_model_vs_hf(pixtral_vision_config):
     # Make sure both models have the same weights.
     pixtral_model.load_weights(hf_pixtral_model.state_dict())
 
-    batch_size = 1
+    batch_size = 2
     height, width, channels = 123, 456, 3
     pixel_values = torch.randn(batch_size, channels, height, width, device=device, dtype=dtype)
-    image_sizes = torch.tensor([[height, width]])
+    image_sizes = torch.tensor([[height, width], [height - 7, width - 11]])
     out = pixtral_model(
         pixel_values=pixel_values,
         image_sizes=image_sizes,
@@ -102,3 +107,112 @@ def test_pixtral_vision_model_vs_hf(pixtral_vision_config):
         )
 
     torch.testing.assert_close(out, hf_out, atol=0.2, rtol=0.2)
+
+
+@pytest.mark.parametrize("mpi_pool_executor", [2], indirect=True)
+@torch.no_grad()
+def test_tensor_parallelism(pixtral_vision_config, mpi_pool_executor, tmp_path):
+    mapping = mapping_lib.Mapping(world_size=2, tp_size=2)
+    if (num_available_devices := torch.cuda.device_count()) < mapping.world_size:
+        pytest.skip(f"{num_available_devices=} is less than the requested {mapping.world_size}.")
+
+    dtype = torch.bfloat16
+    device = torch.device("cuda")
+    pretrained_config = pixtral_vision_config.pretrained_config
+
+    hf_pixtral_model = init_hf_model(
+        cls=hf_modeling_pixtral.PixtralVisionModel,
+        config=pretrained_config,
+        dtype=dtype,
+        device=device,
+    )
+    # Save HF weights to disk so they can be used by worker processes.
+    state_dict = hf_pixtral_model.state_dict()
+    hf_weights_path = tmp_path / "hf_weights.pt"
+    torch.save(state_dict, hf_weights_path)
+
+    pixtral_model = (
+        modeling_pixtral.PixtralVisionModel(model_config=pixtral_vision_config).eval().to("cuda")
+    )
+    pixtral_model.load_weights(state_dict)
+    # Save the number of params to check that the model gets shared in the workers.
+    num_params = sum(p.numel() for p in pixtral_model.parameters())
+
+    batch_size = 2
+    height, width, channels = 123, 456, 3
+    pixel_values = torch.randn(batch_size, channels, height, width, device=device, dtype=dtype)
+    image_sizes = torch.tensor([[height, width], [height - 7, width - 11]])
+
+    ref_out = pixtral_model(pixel_values=pixel_values, image_sizes=image_sizes)
+
+    # Move to CPU before sending across process barrier.
+    ref_out = ref_out.to("cpu")
+    pixel_values = pixel_values.to("cpu")
+    image_sizes = image_sizes.to("cpu")
+
+    # Free up GPU memory on rank 0.
+    del state_dict
+    del hf_pixtral_model
+    del pixtral_model
+    gc.collect()
+    torch.cuda.empty_cache()
+
+    world_size = mapping.world_size
+    pixtral_vision_config.mapping = mapping
+    results = mpi_pool_executor.starmap(
+        _run_pixtral_and_compare_against_ref,
+        [
+            (
+                pixtral_vision_config,
+                hf_weights_path,
+                pixel_values,
+                image_sizes,
+                ref_out,
+                num_params,
+            )
+            for _ in range(world_size)
+        ],
+    )
+
+    for r in results:
+        assert r
+
+
+def _run_pixtral_and_compare_against_ref(
+    pixtral_vision_config: model_config_lib.ModelConfig[transformers.PixtralVisionConfig],
+    hf_weights_path: pathlib.Path,
+    pixel_values: torch.Tensor,
+    image_sizes: torch.Tensor,
+    expected_output: torch.Tensor,
+    total_num_params: int,
+) -> bool:
+    rank = tensorrt_llm.mpi_rank()
+    # Smoke check.
+    world_size = tensorrt_llm.mpi_world_size()
+    assert world_size > 1
+
+    torch.cuda.set_device(rank)
+
+    pixel_values = pixel_values.to("cuda")
+    image_sizes = image_sizes.to("cuda")
+    expected_output = expected_output.to("cuda")
+
+    pixtral_vision_config.mapping.rank = rank
+    pixtral_model = (
+        modeling_pixtral.PixtralVisionModel(model_config=pixtral_vision_config).eval().to("cuda")
+    )
+    state_dict = torch.load(hf_weights_path, map_location="cuda")
+    pixtral_model.load_weights(state_dict)
+
+    # Smoke check to see that we are indeed sharding the model.
+    rank_num_params = sum(p.numel() for p in pixtral_model.parameters())
+    params_fraction = rank_num_params / total_num_params
+    assert params_fraction < 1.0
+    assert params_fraction == pytest.approx(1.0 / world_size, rel=1e-2)
+
+    out = pixtral_model(
+        pixel_values=pixel_values,
+        image_sizes=image_sizes,
+    )
+    torch.testing.assert_close(out, expected_output, atol=0.2, rtol=0.2)
+    return True


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved support for batched and variable-sized image inputs in vision-language models, enabling more efficient processing.
  * Enhanced tensor parallelism support in vision transformer models, allowing for better scalability and performance.

* **Bug Fixes**
  * Corrected sequence length calculations in attention metadata for vision models to ensure accurate handling of batches.

* **Chores**
  * Added necessary dependencies to support image padding operations.
  * Introduced MPI-based parallel testing infrastructure for tensor parallelism validation in vision transformer models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# [5382078][5389014][feat] Enable TP and batching for PixtralVisionModel / Mistral3VLM

## Description

This commit implements tensor parallelism and batching support for the `PixtralVisionModel` (used by `Mistral3VLM`).

For TP, the gating issue was that there was no TP supported implementation of the `torch.nn.Conv2D` layer. Since there is just a single `Conv2D` layer at the very beginning of the vision encoder, this PR proposes to run that layer on all ranks, and slice its outputs instead, while the remainder of the vision tower (vision attention layers, etc.) all function with TP as they usually would.

For batching, the padding from HF's original implementation (which unfortunately only supports numpy) is functionally replicated using `torchvision`.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
