### PR TITLE
fix: Flush stale `PlanParams` with custom attention mask

### DIFF
--- a/tensorrt_llm/bench/benchmark/utils/asynchronous.py
+++ b/tensorrt_llm/bench/benchmark/utils/asynchronous.py
@@ -47,7 +47,9 @@ class LlmManager:
     def _task_done_callback(self, task: asyncio.Task) -> None:
         self._tasks.discard(task)
         if task.exception() is not None and not self._stop.is_set():
-            logger.error("Exception raised during inference - stopping")
+            logger.error(
+                f"Stopping benchmarking due to following exception raised during inference: {task.exception()}"
+            )
             self.stop()
 
     async def process_request(self, request: InferenceRequest,

--- a/tests/unittest/_torch/modeling/test_modeling_gemma3.py
+++ b/tests/unittest/_torch/modeling/test_modeling_gemma3.py
@@ -10,7 +10,8 @@ from transformers import Gemma3TextConfig
 from transformers.cache_utils import HybridCache
 
 import tensorrt_llm
-from tensorrt_llm._torch.attention_backend import FlashInferAttentionMetadata
+from tensorrt_llm._torch.attention_backend import (AttentionMetadata,
+                                                   FlashInferAttentionMetadata)
 from tensorrt_llm._torch.attention_backend.utils import get_attention_backend
 from tensorrt_llm._torch.metadata import KVCacheParams
 from tensorrt_llm._torch.model_config import ModelConfig
@@ -216,6 +217,20 @@ class TestGemma3(unittest.TestCase):
 
         kv_cache_manager.shutdown()
 
+    def _verify_params_flushed_upon_prepare(self,
+                                            attn_metadata: AttentionMetadata):
+        # This check is valid only for FlashInferAttentionMetadata. It checks that the PlanParams specific
+        # to forward call with custom mask exist right after the forward call and are flushed upon prepare.
+        if isinstance(attn_metadata, FlashInferAttentionMetadata):
+            # Right after forward call with custom mask, plan_params will have non-trivial attention_mask_data.
+            # One for global-prefill, other for local-prefill.
+            self.assertEqual(len(attn_metadata._plan_params_to_wrappers), 2)
+            for plan_params in attn_metadata._plan_params_to_wrappers.keys():
+                assert plan_params.attention_mask_data is not None
+            # Prepare should flush the params with non-trivial attention_mask_data.
+            attn_metadata.prepare()
+            self.assertEqual(len(attn_metadata._plan_params_to_wrappers), 0)
+
     @parameterized.expand([
         Scenario(backend="TRTLLM", config_name="1B"),
         Scenario(backend="VANILLA", config_name="1B"),
@@ -332,6 +347,7 @@ class TestGemma3(unittest.TestCase):
                                        ref.logits[:, -1].float(),
                                        atol=0.4,
                                        rtol=0.4)
+            self._verify_params_flushed_upon_prepare(attn_metadata)
 
         # Generation phase.
         gen_input_ids = torch.tensor([900], dtype=torch.int, device=device)


### PR DESCRIPTION
## Description
This is to address https://nvbugspro.nvidia.com/bug/5400160.

Background:
- We use FlashInfer backend for Gemma3 to support custom mask.
- FlashInfer backend maintains a [mapping](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/_torch/attention_backend/flashinfer.py#L69-L70) called `_plan_params_to_wrappers` from [PlanParams](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/_torch/attention_backend/flashinfer.py#L30) to a struct of prefill and decode wrappers. These are cached across batch iterations. These wrappers maybe planned a couple of times:
a) First, when a new batch of requests arrives, [prepare()](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/_torch/attention_backend/flashinfer.py#L190) is called and all existing wrappers are re-planned through `_plan_with_params`.
b) Second, as part of model forward pass, `metadata.plan()` is called which may further re-plan the wrappers through `_plan_with_params` if the model forward pass had a new set of params (like a custom attention mask).

**_Problem:_**
- `PlanParams` with custom attention mask goes stale as soon as corresponding forward pass is complete (because next forward pass would need a brand new custom mask).

- Currently, such stale `PlanParams` and their wrappers aren't getting duly discarded from `_plan_params_to_wrappers`. This not only bloats `_plan_params_to_wrappers` but also causes illegal memory accesses in FlashInfer because `qo_indptr` is updated to correspond to new batch of requests for next forward call.

_**Fix:**_
- Duly discard such stale params as part of `prepare()`.

**_Known limitations:_** (not specific to this change but for future reference)
- For Gemma3, at any point, the number of `PlanParams` could go up to 4: combinations of [prefill vs. decode] & [global vs. local]. The prefill wrappers are recreated every time there's a prefill request. Construction of this wrapper could be expensive.
- The size of prefill `PlanParams` could get really large (due to attention mask) making lookup of `_plan_params_to_wrappers` slower.

**_Potential improvements_** (not specific to this change but for future reference)
- Packing the mask could bring down memory footprint of mask significantly and make lookup of `_plan_params_to_wrappers` faster.
- Reusing the prefill wrappers across batch iterations is something we could explore. But, it's very risky without knowing the internal details of FlashInfer's state management.

Also, attaching logging from FlashInfer backend which could be useful for future reference. 
[benchout.txt](https://github.com/user-attachments/files/21307743/benchout.txt)

## Test Coverage
```
$ pytest tests/unittest/_torch/modeling/test_modeling_gemma3.py::TestGemma3::test_gemma3_allclose_to_hf[backend:flashinfer_config:27b] -s -v
$ pytest tests/unittest/_torch/modeling/test_modeling_gemma3.py::TestGemma3::test_gemma3_allclose_to_hf[backend:flashinfer_config:1b] -s -v
```

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--disable-fail-fast --skip-test --stage-list "A10-1, xxx" --gpu-type "A30, H100_PCIe" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-[Post-Merge]-1, xxx"]`

Launch build/test pipelines. All previously running jobs will be killed.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests. Will also run L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-[Post-Merge]-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-[Post-Merge]-1, xxx".

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of cached attention plans to selectively remove or replan based on attention mask data, enhancing inference reliability.
  * Enhanced error logging during benchmarking to provide detailed information when exceptions occur.

* **Tests**
  * Added validation to confirm internal attention plan parameters are properly flushed after preparation, increasing test coverage for attention handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->