### PR TITLE
[doc][chore][qwen] fix typo of qwen document

### DIFF
--- a/examples/models/core/qwen/README.md
+++ b/examples/models/core/qwen/README.md
@@ -70,7 +70,7 @@ In addition, there are two shared files in the parent folder [`examples`](../../
 | Qwen2.5-72B(-Instruct)|     Y   |   Y   |    -    |   Y   |   Y*  |   Y   |   Y   |   Y   |   Y   |   -   | Ampere+ |
 | QwQ-32B            |     Y      |   Y   |    -    |   Y   |   Y   |   Y   |   Y   |   Y   |   Y   |   -   | Ampere+ |
 | Qwen3-32B          |     Y      |   Y   |    Y    |   -   |   -   |   -   |   -   |   Y   |   -   |   Y   | Hopper+ |
-| Qwen3-235B-A3B     |     Y      |   Y   |    Y    |   -   |   -   |   -   |   -   |   Y   |   -   |   Y   | Hopper+ |
+| Qwen3-235B-A22B    |     Y      |   Y   |    Y    |   -   |   -   |   -   |   -   |   Y   |   -   |   Y   | Hopper+ |
 
 Please note that Y* sign means that the model does not support all the AWQ + TP combination.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the model name in the Qwen3 support matrix from "Qwen3-235B-A3B" to "Qwen3-235B-A22B".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->