### PR TITLE
enh: Lift expectation of single image per sample in Gemma3 VLM

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_gemma3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma3vl.py
@@ -45,18 +45,12 @@ class Gemma3InputProcessor(InputProcessor):
             raise KeyError("Expected image data in multimodal data for Gemma3.")
 
         images = mm_data.get("image")
-        if images and len(images) != 1:
-            raise ValueError(
-                f"Expected at most one image for processing, got {len(images)}."
-            )
-
-        image = images[0] if images else None
         do_rescale = self.processor.image_processor.do_rescale
-        if isinstance(image, torch.Tensor):
+        if images is not None and isinstance(images[0], torch.Tensor):
             do_rescale = False
         processor_output = self.processor(
             text=text_prompt,
-            images=image,
+            images=images,
             do_rescale=do_rescale,
             return_tensors="pt",
             device=self.device).to(dtype=torch.bfloat16)


### PR DESCRIPTION
## Description
Currently, there's a limitation placed on having a single image per sample in Gemma3 VLM. This MR lifts it.

Images tested come from here: http://vision.stanford.edu/aditya86/ImageNetDogs/menu_frame.html

```
$ python3 examples/llm-api/quickstart_multimodal.py --model_dir ../random/hf_models/gemma-3-4b-it/ --modality image --prompt "Compare the three images and explain differences." --media "http://vision.stanford.edu/aditya86/ImageNetDogs/images/n02091032-Italian_greyhound/n02091032_8855.jpg" "http://vision.stanford.edu/aditya86/ImageNetDogs/images/n02085620-Chihuahua/n02085620_10131.jpg" "http://vision.stanford.edu/aditya86/ImageNetDogs/images/n02109047-Great_Dane/n02109047_10414.jpg" --image_format pil --attention_backend FLASHINFER --disable_kv_cache_reuse --max_tokens 8192
```
Formatted output looks like this:
<img width="744" height="986" alt="image" src="https://github.com/user-attachments/assets/b1acfaca-9635-486d-afc0-06b783dd2c25" />

Also, attaching stdout from terminal for reference.
[multi_image_per_sample.txt](https://github.com/user-attachments/files/21323762/multi_image_per_sample.txt)


## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>