### PR TITLE
[https://nvbugs/5378031] [feat] Hopper W4A8 MoE supports ModelOpt ckpt for PyT backend

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -57,7 +57,8 @@ from ..models.modeling_utils import ModelConfig, QuantConfig
 from ..modules.attention import MLA
 from ..modules.decoder_layer import DecoderLayer
 from ..modules.embedding import Embedding
-from ..modules.fused_moe import (DeepSeekV3MoeRoutingMethod, TRTLLMGenFusedMoE,
+from ..modules.fused_moe import (DeepSeekV3MoeRoutingMethod,
+                                 MoEWeightLoadingMode, TRTLLMGenFusedMoE,
                                  create_moe,
                                  moe_load_balancer_set_repeated_for_next_layer)
 from ..modules.gated_mlp import GatedMLP
@@ -454,7 +455,13 @@ class Deepseekv3MoE(nn.Module):
             model_config=model_config,
             override_quant_config=override_quant_config,
             aux_stream_dict=aux_stream_dict,
-            layer_idx=layer_idx)
+            layer_idx=layer_idx,
+            # DS-R1 W4A8 is only supported through custom quantization script from
+            # examples/quantization/quantize_mixed_precision_moe.py
+            weight_loading_mode=(MoEWeightLoadingMode.W4A8_CUSTOM
+                                 if model_config.quant_config.quant_mode.
+                                 is_int4_weight_only_per_group() else
+                                 MoEWeightLoadingMode.VANILLA))
 
         self.mapping = model_config.mapping
 

--- a/tensorrt_llm/_torch/modules/fused_moe/interface.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/interface.py
@@ -11,8 +11,12 @@ from .routing import BaseMoeRoutingMethod
 
 
 class MoEWeightLoadingMode(Enum):
+    # Gate and up projection are not fused
     VANILLA = 0
+    # Gate and up projection are fused
     FUSED_GATE_UP_PROJ = 1
+    # Custom W4A8 weights from examples/quantization/quantize_mixed_precision_moe.py
+    W4A8_CUSTOM = 2
 
 
 class MoE(nn.Module):

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -1225,6 +1225,10 @@ class W4A8_AWQ_LinearMethod(LinearMethodBase):
         module.alpha = Parameter(torch.empty([1], dtype=torch.float32),
                                  requires_grad=False)
 
+        # WAR for CUDA graph. Mixed w4a8 gemm does not accept alpha in device buffer.
+        # Hence we prepare a separate plain float to be updated during the weight load.
+        module.alpha_value = 1.0
+
         if bias:
             module.bias = Parameter(torch.empty((out_features), dtype=dtype),
                                     requires_grad=False)
@@ -1261,7 +1265,7 @@ class W4A8_AWQ_LinearMethod(LinearMethodBase):
             has_zero_point=module.quant_config.has_zero_point,
             output_dtype=module.dtype
             or input.dtype,  # NOTE: output_dtype can only be bf16/fp16 for W4A8
-            alpha=module.alpha.item(),
+            alpha=module.alpha_value,
             bias=bias,
             zeros=None)
 
@@ -1343,6 +1347,8 @@ class W4A8_AWQ_LinearMethod(LinearMethodBase):
         copy_weight(module.input_scale, input_scale)
         copy_weight(module.alpha, alpha)
 
+        module.alpha_value = alpha.item()
+
         module.inv_input_scale.data = 1.0 / module.input_scale
 
     def load_weights_fused_qkv_linear(self, module: Linear,
@@ -1371,6 +1377,7 @@ class W4A8_AWQ_LinearMethod(LinearMethodBase):
         copy_weight(module.input_scale, input_scale)
         copy_weight(module.alpha, alpha)
 
+        module.alpha_value = alpha.item()
         # NOTE: pre_quant_scale is the same for q,k,v since modelopt checks which layer shared the same input and create an avg pre_quant_scale
         # Usually when modelopt exports the quantized model, pre_quant_Scale is fused in the layer norm (this case relevant if fused is disabled - modelopt internal)
         if "pre_quant_scale" in weights[0].keys():
@@ -1416,6 +1423,8 @@ class W4A8_AWQ_LinearMethod(LinearMethodBase):
         copy_weight(module.weight_scale, fused_scale)
         copy_weight(module.input_scale, input_scale)
         copy_weight(module.alpha, alpha)
+
+        module.alpha_value = alpha.item()
 
         if "pre_quant_scale" in weights[0].keys():
             # Use the same device as the weight tensor

--- a/tests/integration/test_lists/test-db/l0_dgx_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_h100.yml
@@ -72,6 +72,10 @@ l0_dgx_h100:
   - unittest/_torch/multi_gpu_modeling -k "deepseek"
   - unittest/_torch/modules/test_fused_moe.py::test_fused_moe_alltoall[DeepEP]
   - unittest/_torch/modules/test_fused_moe.py::test_fused_moe_alltoall[DeepEPLowLatency]
+  - unittest/_torch/modules/test_fused_moe.py::test_fused_moe_w4afp8[MoEWeightLoadingMode.VANILLA-dtype0]
+  - unittest/_torch/modules/test_fused_moe.py::test_fused_moe_w4afp8[MoEWeightLoadingMode.VANILLA-dtype1]
+  - unittest/_torch/modules/test_fused_moe.py::test_fused_moe_w4afp8[MoEWeightLoadingMode.W4A8_CUSTOM-dtype0]
+  - unittest/_torch/modules/test_fused_moe.py::test_fused_moe_w4afp8[MoEWeightLoadingMode.W4A8_CUSTOM-dtype1]
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_fp8_block_scales_4gpus[tp4-mtp_nextn=0-fp8kv=False-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=False]
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_fp8_block_scales_4gpus[tp4-mtp_nextn=0-fp8kv=True-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=False]
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_fp8_block_scales_4gpus[tp4-mtp_nextn=0-fp8kv=False-attention_dp=True-cuda_graph=False-overlap_scheduler=False-torch_compile=False]

--- a/tests/unittest/_torch/modules/test_fused_moe.py
+++ b/tests/unittest/_torch/modules/test_fused_moe.py
@@ -1109,7 +1109,7 @@ def test_fused_moe_w4afp8(dtype, weight_loading_mode):
             "weight",
             "weight_scale":
             ("weight_scale_inv" if weight_loading_mode
-            == MoEWeightLoadingMode.W4A8_CUSTOM else "weight_scale"),
+             == MoEWeightLoadingMode.W4A8_CUSTOM else "weight_scale"),
             "weight_scale_2":
             "weight_scale_2",
             "pre_quant_scale":
@@ -1133,16 +1133,23 @@ def test_fused_moe_w4afp8(dtype, weight_loading_mode):
                 w3_shape = (INTERMEDIATE_SIZE, HIDDEN_SIZE // 2)
 
             # The weights in int4 precision.
-            w1_weight = torch.randint(-128, 127, w1_shape, dtype=torch.int8).cuda()
-            w2_weight = torch.randint(-128, 127, w2_shape, dtype=torch.int8).cuda()
-            w3_weight = torch.randint(-128, 127, w3_shape, dtype=torch.int8).cuda()
+            w1_weight = torch.randint(-128, 127, w1_shape,
+                                      dtype=torch.int8).cuda()
+            w2_weight = torch.randint(-128, 127, w2_shape,
+                                      dtype=torch.int8).cuda()
+            w3_weight = torch.randint(-128, 127, w3_shape,
+                                      dtype=torch.int8).cuda()
 
             # The pre-quant scale to be multiplied with the input activation.
-            w1_pre_quant_scale = torch.ones(HIDDEN_SIZE, dtype=dtype, device="cuda")
+            w1_pre_quant_scale = torch.ones(HIDDEN_SIZE,
+                                            dtype=dtype,
+                                            device="cuda")
             w2_pre_quant_scale = torch.ones(INTERMEDIATE_SIZE,
                                             dtype=dtype,
                                             device="cuda")
-            w3_pre_quant_scale = torch.ones(HIDDEN_SIZE, dtype=dtype, device="cuda")
+            w3_pre_quant_scale = torch.ones(HIDDEN_SIZE,
+                                            dtype=dtype,
+                                            device="cuda")
 
             # The weight scale to dequantize int4 weights (by multiplication).
             w1_scale = torch.randn(
@@ -1160,12 +1167,14 @@ def test_fused_moe_w4afp8(dtype, weight_loading_mode):
 
             # The input scale to quantize the input activation (by division).
             w1_input_scale = torch.randn(1, dtype=torch.float32,
-                                        device="cuda") * 0.2
+                                         device="cuda") * 0.2
             w2_input_scale = w1_input_scale
             w3_input_scale = w1_input_scale
 
             # The weight scale 2 to quantize the dequantized weights (by division).
-            w1_weight_scale_2 = torch.ones([1], dtype=torch.float32, device="cuda")
+            w1_weight_scale_2 = torch.ones([1],
+                                           dtype=torch.float32,
+                                           device="cuda")
             w2_weight_scale_2 = w1_weight_scale_2
             w3_weight_scale_2 = w1_weight_scale_2
 
@@ -1179,12 +1188,18 @@ def test_fused_moe_w4afp8(dtype, weight_loading_mode):
             weights[f"{expert_id}.w1.{lut['weight_scale']}"] = w1_scale
             weights[f"{expert_id}.w2.{lut['weight_scale']}"] = w2_scale
             weights[f"{expert_id}.w3.{lut['weight_scale']}"] = w3_scale
-            weights[f"{expert_id}.w1.{lut['pre_quant_scale']}"] = w1_pre_quant_scale
-            weights[f"{expert_id}.w2.{lut['pre_quant_scale']}"] = w2_pre_quant_scale
-            weights[f"{expert_id}.w3.{lut['pre_quant_scale']}"] = w3_pre_quant_scale
-            weights[f"{expert_id}.w1.{lut['weight_scale_2']}"] = w1_weight_scale_2
-            weights[f"{expert_id}.w2.{lut['weight_scale_2']}"] = w2_weight_scale_2
-            weights[f"{expert_id}.w3.{lut['weight_scale_2']}"] = w3_weight_scale_2
+            weights[
+                f"{expert_id}.w1.{lut['pre_quant_scale']}"] = w1_pre_quant_scale
+            weights[
+                f"{expert_id}.w2.{lut['pre_quant_scale']}"] = w2_pre_quant_scale
+            weights[
+                f"{expert_id}.w3.{lut['pre_quant_scale']}"] = w3_pre_quant_scale
+            weights[
+                f"{expert_id}.w1.{lut['weight_scale_2']}"] = w1_weight_scale_2
+            weights[
+                f"{expert_id}.w2.{lut['weight_scale_2']}"] = w2_weight_scale_2
+            weights[
+                f"{expert_id}.w3.{lut['weight_scale_2']}"] = w3_weight_scale_2
 
         quant_config = QuantConfig(quant_algo=QuantAlgo.W4A8_AWQ)
         fused_moe = CutlassFusedMoE(
@@ -1209,7 +1224,7 @@ def test_fused_moe_w4afp8(dtype, weight_loading_mode):
                 if act.shape[0] == 0:
                     continue
                 final_scale = (final_scales *
-                            mask).sum(1)[activated_tokens].unsqueeze(1)
+                               mask).sum(1)[activated_tokens].unsqueeze(1)
 
                 # weights
                 def unpack_weights(weight: torch.Tensor) -> torch.Tensor:
@@ -1243,14 +1258,14 @@ def test_fused_moe_w4afp8(dtype, weight_loading_mode):
                 a1 = a2 = a3 = a1_a3 = None
                 if weight_loading_mode == MoEWeightLoadingMode.VANILLA:
                     a1 = weights[
-                        f"{e_idx}.w1.{lut['pre_quant_scale']}"].T.contiguous().cuda(
-                        )
+                        f"{e_idx}.w1.{lut['pre_quant_scale']}"].T.contiguous(
+                        ).cuda()
                     a2 = weights[
-                        f"{e_idx}.w2.{lut['pre_quant_scale']}"].T.contiguous().cuda(
-                        )
+                        f"{e_idx}.w2.{lut['pre_quant_scale']}"].T.contiguous(
+                        ).cuda()
                     a3 = weights[
-                        f"{e_idx}.w3.{lut['pre_quant_scale']}"].T.contiguous().cuda(
-                        )
+                        f"{e_idx}.w3.{lut['pre_quant_scale']}"].T.contiguous(
+                        ).cuda()
                     a1_a3 = torch.max(a1, a3)
 
                 # weight_scale_2
@@ -1273,7 +1288,7 @@ def test_fused_moe_w4afp8(dtype, weight_loading_mode):
                     if pre_quant_scale is not None:
                         act = act * pre_quant_scale
                     act = (torch.clamp((act / input_scale), -448.0,
-                                    448.0).to(torch.float8_e4m3fn).to(dtype))
+                                       448.0).to(torch.float8_e4m3fn).to(dtype))
                     weight = (weight.float() * weight_scale.repeat_interleave(
                         128, dim=0).float()).to(dtype)
                     if weight_scale_2 is not None:

--- a/tests/unittest/_torch/modules/test_fused_moe.py
+++ b/tests/unittest/_torch/modules/test_fused_moe.py
@@ -1080,7 +1080,10 @@ def test_fused_moe_nvfp4(dtype):
 
 @skip_neither_ada_nor_hopper_unittest
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-def test_fused_moe_w4afp8(dtype):
+@pytest.mark.parametrize(
+    "weight_loading_mode",
+    [MoEWeightLoadingMode.VANILLA, MoEWeightLoadingMode.W4A8_CUSTOM])
+def test_fused_moe_w4afp8(dtype, weight_loading_mode):
     mapping = Mapping()
     mapping.rank = mpi_rank()
 
@@ -1101,21 +1104,47 @@ def test_fused_moe_w4afp8(dtype):
 
         affine_coeff = 0.005
 
+        lut = {
+            "weight":
+            "weight",
+            "weight_scale":
+            ("weight_scale_inv" if weight_loading_mode
+            == MoEWeightLoadingMode.W4A8_CUSTOM else "weight_scale"),
+            "weight_scale_2":
+            "weight_scale_2",
+            "pre_quant_scale":
+            "pre_quant_scale",
+            "input_scale":
+            "input_scale",
+        }
+
         weights = {}
         for expert_id in range(NUM_EXPERTS):
-            w1_weight = torch.randint(-128,
-                                      127,
-                                      (INTERMEDIATE_SIZE, HIDDEN_SIZE // 2),
-                                      dtype=torch.int8).cuda()
-            w2_weight = torch.randint(-128,
-                                      127,
-                                      (HIDDEN_SIZE, INTERMEDIATE_SIZE // 2),
-                                      dtype=torch.int8).cuda()
-            w3_weight = torch.randint(-128,
-                                      127,
-                                      (INTERMEDIATE_SIZE, HIDDEN_SIZE // 2),
-                                      dtype=torch.int8).cuda()
+            # ModelOpt W4A8 packs pairs of 4b weights in the output dimension into one 8b element.
+            if weight_loading_mode == MoEWeightLoadingMode.VANILLA:
+                w1_shape = (INTERMEDIATE_SIZE // 2, HIDDEN_SIZE)
+                w2_shape = (HIDDEN_SIZE // 2, INTERMEDIATE_SIZE)
+                w3_shape = (INTERMEDIATE_SIZE // 2, HIDDEN_SIZE)
+            # The custom W4A8 quantization script examples/quantization/quantize_mixed_precision_moe.py
+            # packs pairs of 4b weight in the input dimension into one 8b element.
+            if weight_loading_mode == MoEWeightLoadingMode.W4A8_CUSTOM:
+                w1_shape = (INTERMEDIATE_SIZE, HIDDEN_SIZE // 2)
+                w2_shape = (HIDDEN_SIZE, INTERMEDIATE_SIZE // 2)
+                w3_shape = (INTERMEDIATE_SIZE, HIDDEN_SIZE // 2)
 
+            # The weights in int4 precision.
+            w1_weight = torch.randint(-128, 127, w1_shape, dtype=torch.int8).cuda()
+            w2_weight = torch.randint(-128, 127, w2_shape, dtype=torch.int8).cuda()
+            w3_weight = torch.randint(-128, 127, w3_shape, dtype=torch.int8).cuda()
+
+            # The pre-quant scale to be multiplied with the input activation.
+            w1_pre_quant_scale = torch.ones(HIDDEN_SIZE, dtype=dtype, device="cuda")
+            w2_pre_quant_scale = torch.ones(INTERMEDIATE_SIZE,
+                                            dtype=dtype,
+                                            device="cuda")
+            w3_pre_quant_scale = torch.ones(HIDDEN_SIZE, dtype=dtype, device="cuda")
+
+            # The weight scale to dequantize int4 weights (by multiplication).
             w1_scale = torch.randn(
                 (INTERMEDIATE_SIZE, HIDDEN_SIZE // SCALING_GROUP_SIZE),
                 dtype=dtype,
@@ -1129,19 +1158,33 @@ def test_fused_moe_w4afp8(dtype):
                 dtype=dtype,
                 device="cuda") * affine_coeff
 
-            w1_input = torch.randn(1, dtype=torch.float32, device="cuda") * 0.02
-            w2_input = w1_input
-            w3_input = w1_input
+            # The input scale to quantize the input activation (by division).
+            w1_input_scale = torch.randn(1, dtype=torch.float32,
+                                        device="cuda") * 0.2
+            w2_input_scale = w1_input_scale
+            w3_input_scale = w1_input_scale
 
-            weights[f"{expert_id}.w1.weight"] = w1_weight
-            weights[f"{expert_id}.w2.weight"] = w2_weight
-            weights[f"{expert_id}.w3.weight"] = w3_weight
-            weights[f"{expert_id}.w1.weight_scale_inv"] = w1_scale
-            weights[f"{expert_id}.w2.weight_scale_inv"] = w2_scale
-            weights[f"{expert_id}.w3.weight_scale_inv"] = w3_scale
-            weights[f"{expert_id}.w1.input_scale"] = w1_input
-            weights[f"{expert_id}.w2.input_scale"] = w2_input
-            weights[f"{expert_id}.w3.input_scale"] = w3_input
+            # The weight scale 2 to quantize the dequantized weights (by division).
+            w1_weight_scale_2 = torch.ones([1], dtype=torch.float32, device="cuda")
+            w2_weight_scale_2 = w1_weight_scale_2
+            w3_weight_scale_2 = w1_weight_scale_2
+
+            # Prepare weights.
+            weights[f"{expert_id}.w1.{lut['weight']}"] = w1_weight
+            weights[f"{expert_id}.w2.{lut['weight']}"] = w2_weight
+            weights[f"{expert_id}.w3.{lut['weight']}"] = w3_weight
+            weights[f"{expert_id}.w1.{lut['input_scale']}"] = w1_input_scale
+            weights[f"{expert_id}.w2.{lut['input_scale']}"] = w2_input_scale
+            weights[f"{expert_id}.w3.{lut['input_scale']}"] = w3_input_scale
+            weights[f"{expert_id}.w1.{lut['weight_scale']}"] = w1_scale
+            weights[f"{expert_id}.w2.{lut['weight_scale']}"] = w2_scale
+            weights[f"{expert_id}.w3.{lut['weight_scale']}"] = w3_scale
+            weights[f"{expert_id}.w1.{lut['pre_quant_scale']}"] = w1_pre_quant_scale
+            weights[f"{expert_id}.w2.{lut['pre_quant_scale']}"] = w2_pre_quant_scale
+            weights[f"{expert_id}.w3.{lut['pre_quant_scale']}"] = w3_pre_quant_scale
+            weights[f"{expert_id}.w1.{lut['weight_scale_2']}"] = w1_weight_scale_2
+            weights[f"{expert_id}.w2.{lut['weight_scale_2']}"] = w2_weight_scale_2
+            weights[f"{expert_id}.w3.{lut['weight_scale_2']}"] = w3_weight_scale_2
 
         quant_config = QuantConfig(quant_algo=QuantAlgo.W4A8_AWQ)
         fused_moe = CutlassFusedMoE(
@@ -1151,14 +1194,14 @@ def test_fused_moe_w4afp8(dtype):
             intermediate_size=INTERMEDIATE_SIZE,
             dtype=dtype,
             reduce_results=False,
-            model_config=ModelConfig(quant_config=quant_config))
+            model_config=ModelConfig(quant_config=quant_config),
+            weight_loading_mode=weight_loading_mode)
         fused_moe.load_weights([weights])
         fused_moe.cuda()
 
         def ref():
             results = torch.zeros_like(x)
             selected_experts, final_scales = routing_method.apply(router_logits)
-            unpacker = torch.ops.trtllm.unpack_int4_packed_tensor_to_int8
             for e_idx in range(NUM_EXPERTS):
                 mask = selected_experts == e_idx
                 activated_tokens = mask.sum(1).bool()
@@ -1166,45 +1209,100 @@ def test_fused_moe_w4afp8(dtype):
                 if act.shape[0] == 0:
                     continue
                 final_scale = (final_scales *
-                               mask).sum(1)[activated_tokens].unsqueeze(1)
+                            mask).sum(1)[activated_tokens].unsqueeze(1)
 
                 # weights
-                w1 = weights[f"{e_idx}.w1.weight"]
-                w1 = unpacker(w1.cpu()).T.contiguous().cuda()
-                w2 = weights[f"{e_idx}.w2.weight"]
-                w2 = unpacker(w2.cpu()).T.contiguous().cuda()
-                w3 = weights[f"{e_idx}.w3.weight"]
-                w3 = unpacker(w3.cpu()).T.contiguous().cuda()
+                def unpack_weights(weight: torch.Tensor) -> torch.Tensor:
+                    unpacker = torch.ops.trtllm.unpack_int4_packed_tensor_to_int8
+                    if weight_loading_mode == MoEWeightLoadingMode.VANILLA:
+                        return unpacker(weight.cpu().T.contiguous()).cuda()
+                    else:
+                        return unpacker(weight.cpu()).T.contiguous().cuda()
+
+                w1 = unpack_weights(weights[f"{e_idx}.w1.{lut['weight']}"])
+                w2 = unpack_weights(weights[f"{e_idx}.w2.{lut['weight']}"])
+                w3 = unpack_weights(weights[f"{e_idx}.w3.{lut['weight']}"])
                 w3_w1 = torch.cat([w3, w1], dim=-1)
 
-                # scales
-                s1 = weights[f"{e_idx}.w1.weight_scale_inv"].T.contiguous(
+                # weight_scale
+                s1 = weights[f"{e_idx}.w1.{lut['weight_scale']}"].T.contiguous(
                 ).cuda()
-                s2 = weights[f"{e_idx}.w2.weight_scale_inv"].T.contiguous(
+                s2 = weights[f"{e_idx}.w2.{lut['weight_scale']}"].T.contiguous(
                 ).cuda()
-                s3 = weights[f"{e_idx}.w3.weight_scale_inv"].T.contiguous(
+                s3 = weights[f"{e_idx}.w3.{lut['weight_scale']}"].T.contiguous(
                 ).cuda()
                 s3_s1 = torch.cat([s3, s1], dim=-1)
 
-                # prequant / alpha
-                p1 = weights[f"{e_idx}.w1.input_scale"].cuda()
-                p2 = weights[f"{e_idx}.w2.input_scale"].cuda()
-                p3 = weights[f"{e_idx}.w3.input_scale"].cuda()
-                p3_p1 = max(p1, p3)
+                # input_scale
+                p1 = weights[f"{e_idx}.w1.{lut['input_scale']}"].cuda()
+                p2 = weights[f"{e_idx}.w2.{lut['input_scale']}"].cuda()
+                p3 = weights[f"{e_idx}.w3.{lut['input_scale']}"].cuda()
+                p3_p1 = torch.max(p1, p3)
 
-                act = torch.clamp((act / p3_p1), -448.0,
-                                  448.0).to(torch.float8_e4m3fn).to(dtype)
-                w3_w1 = (w3_w1.float() *
-                         s3_s1.repeat_interleave(128, dim=0).float()).to(dtype)
-                fc1 = torch.matmul(act, w3_w1) * p3_p1
+                # pre_quant_scale
+                a1 = a2 = a3 = a1_a3 = None
+                if weight_loading_mode == MoEWeightLoadingMode.VANILLA:
+                    a1 = weights[
+                        f"{e_idx}.w1.{lut['pre_quant_scale']}"].T.contiguous().cuda(
+                        )
+                    a2 = weights[
+                        f"{e_idx}.w2.{lut['pre_quant_scale']}"].T.contiguous().cuda(
+                        )
+                    a3 = weights[
+                        f"{e_idx}.w3.{lut['pre_quant_scale']}"].T.contiguous().cuda(
+                        )
+                    a1_a3 = torch.max(a1, a3)
+
+                # weight_scale_2
+                q1 = q2 = q3 = q3_q1 = None
+                if weight_loading_mode == MoEWeightLoadingMode.VANILLA:
+                    q1 = weights[f"{e_idx}.w1.{lut['weight_scale_2']}"].cuda()
+                    q2 = weights[f"{e_idx}.w3.{lut['weight_scale_2']}"].cuda()
+                    q3 = weights[f"{e_idx}.w2.{lut['weight_scale_2']}"].cuda()
+                    q3_q1 = torch.max(q3, q1)
+
+                # forward pass
+                def process_layer(
+                    act,
+                    weight,
+                    weight_scale,
+                    input_scale,
+                    pre_quant_scale=None,
+                    weight_scale_2=None,
+                ):
+                    if pre_quant_scale is not None:
+                        act = act * pre_quant_scale
+                    act = (torch.clamp((act / input_scale), -448.0,
+                                    448.0).to(torch.float8_e4m3fn).to(dtype))
+                    weight = (weight.float() * weight_scale.repeat_interleave(
+                        128, dim=0).float()).to(dtype)
+                    if weight_scale_2 is not None:
+                        weight /= weight_scale_2
+                    output = torch.matmul(act, weight) * input_scale
+                    if weight_scale_2 is not None:
+                        output *= weight_scale_2
+                    return output
+
+                # fc13
+                fc1 = process_layer(
+                    act,
+                    w3_w1,
+                    s3_s1,
+                    p3_p1,
+                    pre_quant_scale=a1_a3,
+                    weight_scale_2=q3_q1,
+                )
                 fc1, gate = fc1.chunk(2, dim=-1)
                 fc1 = fc1 * torch.nn.functional.silu(gate)
 
-                act = torch.clamp((fc1 / p2), -448.0,
-                                  448.0).to(torch.float8_e4m3fn).to(dtype)
-                w2 = (w2.float() *
-                      s2.repeat_interleave(128, dim=0).float()).to(dtype)
-                fc2 = torch.matmul(act, w2) * p2
+                # fc2
+                fc2 = process_layer(fc1,
+                                    w2,
+                                    s2,
+                                    p2,
+                                    pre_quant_scale=a2,
+                                    weight_scale_2=q2)
+
                 results[activated_tokens, :] += (fc2 * final_scale).to(
                     results.dtype)
             return results
@@ -1218,8 +1316,13 @@ def test_fused_moe_w4afp8(dtype):
             output = fused_moe.forward(x, router_logits)
             ref_output = ref()
 
-        # compare
         torch.cuda.synchronize()
+        # assert that result does not contain NaN or is all 0s
+        assert not torch.isnan(ref_output).any(), "ref_output contains NaN"
+        assert not torch.isnan(output).any(), "output contains NaN"
+        assert torch.nonzero(output).numel() > 0, "output is empty"
+        assert torch.nonzero(ref_output).numel() > 0, "ref_output is empty"
+        # compare
         torch.testing.assert_close(output, ref_output, rtol=1e-2, atol=0.1)
 
 


### PR DESCRIPTION
## Description

Hopper W4A8 MoE supports ModelOpt ckpt for PyT backend

The existing SM90 W4A8 MoE supports bespoke checkpoint format exported by `examples/quantization/quantize_mixed_precision_moe.py`

The PR adds support taking checkpoints exported by ModelOpt.

This PR depends on #6005 to work on both W4A8 dense layer and W4A8 MoE layer.

## Test Coverage

```
pytest tests/unittest/_torch/modules/test_fused_moe.py -k w4afp8 -s
```

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a new weight loading mode ("CUSTOM_W4A8") for quantized models, enhancing flexibility in model deployment.
* **Bug Fixes**
  * Improved handling and validation of quantized weights and scales for different hardware and loading modes.
  * Ensured correct device placement for loaded tensors to support multi-GPU and distributed environments.
* **Tests**
  * Expanded and refined test coverage to ensure correct behavior for both "VANILLA" and "CUSTOM_W4A8" weight loading modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->