### PR TITLE
Revert "[TRTLLM-5530][BREAKING CHANGE] refactor: unify KvCacheConfig in LLM class for pytorch backend"

### DIFF
--- a/examples/llm-api/quickstart_advanced.py
+++ b/examples/llm-api/quickstart_advanced.py
@@ -149,7 +149,6 @@ def setup_llm(args, **kwargs):
     kv_cache_config = KvCacheConfig(
         enable_block_reuse=not args.disable_kv_cache_reuse,
         free_gpu_memory_fraction=args.kv_cache_fraction,
-        dtype=args.kv_cache_dtype,
     )
 
     spec_decode_algo = args.spec_decode_algo.upper(
@@ -195,6 +194,7 @@ def setup_llm(args, **kwargs):
         model=args.model_dir,
         backend='pytorch',
         disable_overlap_scheduler=args.disable_overlap_scheduler,
+        kv_cache_dtype=args.kv_cache_dtype,
         kv_cache_config=kv_cache_config,
         attn_backend=args.attention_backend,
         cuda_graph_config=cuda_graph_config,

--- a/tensorrt_llm/bench/benchmark/utils/general.py
+++ b/tensorrt_llm/bench/benchmark/utils/general.py
@@ -88,14 +88,12 @@ def get_settings(params: dict, dataset_metadata: DatasetMetadata, model: str,
     enable_chunked_prefill = params.get("enable_chunked_prefill", False)
 
     kv_cache_dtype = "auto"
-    kv_cache_config = {}
     if extra_llm_api_options:
         with open(extra_llm_api_options, 'r') as f:
             llm_args_dict = yaml.safe_load(f)
-            kv_cache_config = llm_args_dict.get("kv_cache_config", {
-                "dtype": "auto",
-            })
-            kv_cache_dtype = kv_cache_config.get("dtype", "auto")
+
+        if "kv_cache_dtype" in llm_args_dict:
+            kv_cache_dtype = llm_args_dict["kv_cache_dtype"]
 
         enable_chunked_prefill = llm_args_dict.get("enable_chunked_prefill",
                                                    enable_chunked_prefill)
@@ -160,11 +158,9 @@ def get_settings(params: dict, dataset_metadata: DatasetMetadata, model: str,
         "max_batch_size": max_batch_size
     }
 
-    kv_cache_config["dtype"] = kv_cache_dtype
-
     pyt_options = {
         "cuda_graph_config": cuda_graph_config,
-        "kv_cache_config": kv_cache_config,
+        "kv_cache_dtype": kv_cache_dtype,
     }
 
     backend = params.get("backend", "pytorch")

--- a/tensorrt_llm/bench/dataclasses/configuration.py
+++ b/tensorrt_llm/bench/dataclasses/configuration.py
@@ -114,6 +114,7 @@ class PerformanceOptions:
     def get_autodeploy_perf_config(self) -> Dict:
         AutoDeployPerfConfig = dict
         ad_config = AutoDeployPerfConfig()
+        ad_config["kv_cache_dtype"] = "auto"
         ad_config["attn_backend"] = "flashinfer"
         return ad_config
 

--- a/tensorrt_llm/bench/dataclasses/reporting.py
+++ b/tensorrt_llm/bench/dataclasses/reporting.py
@@ -11,7 +11,6 @@ from tensorrt_llm.bench.dataclasses.general import DatasetMetadata
 from tensorrt_llm.bench.dataclasses.statistics import (BenchmarkStatistics,
                                                        PercentileStats,
                                                        RequestRecord)
-from tensorrt_llm.llmapi import KvCacheConfig
 from tensorrt_llm.logger import Logger
 from tensorrt_llm.models.modeling_utils import SpeculativeDecodingMode
 
@@ -276,17 +275,8 @@ class ReportUtility:
             model = self.rt_cfg.model_path or self.rt_cfg.model
             model_config = ModelConfig.from_pretrained(model,
                                                        trust_remote_code=True)
-            kv_cache_config = self.kwargs.get("kv_cache_config",
-                                              KvCacheConfig())
-            if isinstance(kv_cache_config, KvCacheConfig):
-                kv_cache_dtype = kv_cache_config.dtype
-            elif isinstance(kv_cache_config, dict):
-                kv_cache_dtype = kv_cache_config.get("dtype", "auto")
-            else:
-                raise ValueError(
-                    f"Invalid kv_cache_config type: {type(kv_cache_config)}.")
-
-            validate_and_set_kv_cache_quant(model_config, kv_cache_dtype)
+            validate_and_set_kv_cache_quant(model_config,
+                                            self.kwargs["kv_cache_dtype"])
 
             stats_dict["engine"] |= {
                 "backend":

--- a/tensorrt_llm/llmapi/llm_utils.py
+++ b/tensorrt_llm/llmapi/llm_utils.py
@@ -405,9 +405,6 @@ class ModelLoader:
                 logger.info(f"Setting {key}={value} from HF quant config.")
                 setattr(quant_config, key, value)
 
-            # Update the quant_config in llm_args for pytorch
-            self.llm_args.quant_config = quant_config
-
             return True
 
         hf_config_path = f"{self._model_dir}/config.json"

--- a/tests/integration/defs/disaggregated/test_disaggregated_single_gpu.py
+++ b/tests/integration/defs/disaggregated/test_disaggregated_single_gpu.py
@@ -121,12 +121,14 @@ def verify_disaggregated(model, generation_overlap, enable_cuda_graph, prompt,
     worker_pytorch_configs.append(
         dict(
             disable_overlap_scheduler=True,
+            kv_cache_dtype="auto",
             cuda_graph_config=CudaGraphConfig() if enable_cuda_graph else None))
 
     # Generation worker
     worker_pytorch_configs.append(
         dict(
             disable_overlap_scheduler=not generation_overlap,
+            kv_cache_dtype="auto",
             cuda_graph_config=CudaGraphConfig() if enable_cuda_graph else None))
 
     kv_cache_configs = [KvCacheConfig(max_tokens=2048 * 8) for _ in range(2)]
@@ -245,16 +247,18 @@ def test_disaggregated_llama_context_capacity(model, enable_cuda_graph,
     worker_pytorch_configs.append(
         dict(
             disable_overlap_scheduler=True,
+            kv_cache_dtype="auto",
             cuda_graph_config=CudaGraphConfig() if enable_cuda_graph else None))
 
     # Generation worker
     worker_pytorch_configs.append(
         dict(
             disable_overlap_scheduler=not generation_overlap,
+            kv_cache_dtype="auto",
             cuda_graph_config=CudaGraphConfig() if enable_cuda_graph else None))
 
     kv_cache_configs = [
-        KvCacheConfig(max_tokens=128, enable_block_reuse=False, dtype="auto")
+        KvCacheConfig(max_tokens=128, enable_block_reuse=False)
         for _ in range(2)
     ]
     cache_transceiver_configs = [

--- a/tests/integration/defs/perf/pytorch_model_config.py
+++ b/tests/integration/defs/perf/pytorch_model_config.py
@@ -17,8 +17,6 @@
 Model pytorch yaml config for trtllm-bench perf tests
 """
 
-from tensorrt_llm.llmapi import KvCacheConfig
-
 
 def recursive_update(d, u):
     for k, v in u.items():
@@ -198,10 +196,5 @@ def get_model_yaml_config(model_label: str,
             }
             lora_config['lora_config']['max_lora_rank'] = 64
         base_config.update(lora_config)
-
-    kv_cache_config = base_config.get('kv_cache_config', KvCacheConfig())
-    if 'kv_cache_dtype' in base_config:
-        kv_cache_config.dtype = base_config.pop('kv_cache_dtype', 'auto')
-        base_config.update({'kv_cache_config': kv_cache_config})
 
     return base_config

--- a/tests/unittest/_torch/modeling/test_modeling_deepseek.py
+++ b/tests/unittest/_torch/modeling/test_modeling_deepseek.py
@@ -68,6 +68,7 @@ def test_deepseek_trtllmgen(model_name):
 
     pytorch_config = dict(
         disable_overlap_scheduler=True,
+        kv_cache_dtype="auto",
         attn_backend="TRTLLM",
         load_format="dummy",
         moe_config=MoeConfig(backend="TRTLLM"),
@@ -88,8 +89,7 @@ def test_deepseek_trtllmgen(model_name):
               moe_tensor_parallel_size=-1,
               enable_attention_dp=False,
               speculative_config=spec_config,
-              kv_cache_config=KvCacheConfig(dtype="auto",
-                                            enable_block_reuse=False,
+              kv_cache_config=KvCacheConfig(enable_block_reuse=False,
                                             free_gpu_memory_fraction=0.4))
 
     sampling_params = SamplingParams(max_tokens=20)

--- a/tests/unittest/_torch/multi_gpu_modeling/test_deepseek.py
+++ b/tests/unittest/_torch/multi_gpu_modeling/test_deepseek.py
@@ -63,6 +63,7 @@ def test_deepseek_streaming(model_name, backend, quant, tp_size):
 
     pytorch_config = dict(
         disable_overlap_scheduler=True,
+        kv_cache_dtype="auto",
         attn_backend=backend,
     )
     moe_config = MoeConfig(max_num_tokens=moe_max_num_tokens)

--- a/tests/unittest/api_stability/references_committed/llm.yaml
+++ b/tests/unittest/api_stability/references_committed/llm.yaml
@@ -57,6 +57,13 @@ methods:
       guided_decoding_backend:
         annotation: Optional[Literal["xgrammar", "llguidance"]]
         default: null
+      # Quantization and calibration
+      quant_config:
+        annotation: Optional[tensorrt_llm.models.modeling_utils.QuantConfig]
+        default: null
+      calib_config:
+        annotation: Optional[tensorrt_llm.llmapi.llm_utils.CalibConfig]
+        default: null
       # Speculative decoding
       speculative_config:
         annotation: Union[tensorrt_llm.llmapi.llm_args.DraftTargetDecodingConfig, tensorrt_llm.llmapi.llm_args.EagleDecodingConfig,tensorrt_llm.llmapi.llm_args.LookaheadDecodingConfig, tensorrt_llm.llmapi.llm_args.MedusaDecodingConfig, tensorrt_llm.llmapi.llm_args.MTPDecodingConfig, tensorrt_llm.llmapi.llm_args.NGramDecodingConfig, tensorrt_llm.llmapi.llm_args.UserProvidedDecodingConfig, NoneType]


### PR DESCRIPTION
Reverts NVIDIA/TensorRT-LLM#5752

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying the key-value cache data type (`kv_cache_dtype`) directly in configuration dictionaries and model initialization.
  * Introduced optional `quant_config` and `calib_config` parameters for model initialization.

* **Refactor**
  * Simplified and centralized quantization and cache data type configuration, removing redundant fields and streamlining configuration handling across the codebase and tests.

* **Tests**
  * Updated and enhanced tests to use the new quantization and cache data type configuration approach, improving clarity and coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->