### PR TITLE
[TRTLLM-5830][feat] Improve LoRA cache memory control

### DIFF
--- a/examples/llm-api/llm_multilora.py
+++ b/examples/llm-api/llm_multilora.py
@@ -23,7 +23,9 @@ def main():
     build_config.lora_config = LoraConfig(lora_dir=[lora_dir1])
     llm = LLM(model="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
               enable_lora=True,
-              max_lora_rank=64,
+              lora_config=LoraConfig(max_lora_rank=64,
+                                     max_loras=3,
+                                     max_cpu_loras=3),
               build_config=build_config)
 
     # Sample prompts

--- a/examples/llm-api/llm_multilora.py
+++ b/examples/llm-api/llm_multilora.py
@@ -5,7 +5,6 @@ from huggingface_hub import snapshot_download
 
 from tensorrt_llm import LLM
 from tensorrt_llm.executor import LoRARequest
-from tensorrt_llm.llmapi import BuildConfig
 from tensorrt_llm.lora_manager import LoraConfig
 
 
@@ -19,14 +18,12 @@ def main():
 
     # Currently, we need to pass at least one lora_dir to LLM constructor via build_config.lora_config.
     # This is necessary because it requires some configuration in the lora_dir to build the engine with LoRA support.
-    build_config = BuildConfig()
-    build_config.lora_config = LoraConfig(lora_dir=[lora_dir1],
-                                          max_lora_rank=64,
-                                          max_loras=3,
-                                          max_cpu_loras=3)
+    lora_config = LoraConfig(lora_dir=[lora_dir1],
+                             max_lora_rank=64,
+                             max_loras=3,
+                             max_cpu_loras=3)
     llm = LLM(model="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
-              enable_lora=True,
-              build_config=build_config)
+              lora_config=lora_config)
 
     # Sample prompts
     prompts = [

--- a/examples/llm-api/llm_multilora.py
+++ b/examples/llm-api/llm_multilora.py
@@ -20,12 +20,12 @@ def main():
     # Currently, we need to pass at least one lora_dir to LLM constructor via build_config.lora_config.
     # This is necessary because it requires some configuration in the lora_dir to build the engine with LoRA support.
     build_config = BuildConfig()
-    build_config.lora_config = LoraConfig(lora_dir=[lora_dir1])
+    build_config.lora_config = LoraConfig(lora_dir=[lora_dir1],
+                                          max_lora_rank=64,
+                                          max_loras=3,
+                                          max_cpu_loras=3)
     llm = LLM(model="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
               enable_lora=True,
-              lora_config=LoraConfig(max_lora_rank=64,
-                                     max_loras=3,
-                                     max_cpu_loras=3),
               build_config=build_config)
 
     # Sample prompts

--- a/examples/llm-api/quickstart_multimodal.py
+++ b/examples/llm-api/quickstart_multimodal.py
@@ -148,6 +148,9 @@ def main():
         models_module = importlib.import_module('tensorrt_llm._torch.models')
         model_class = getattr(models_module, args.auto_model_name)
         lora_config = model_class.lora_config(args.model_dir)
+        # For stability - explicitly set the LoRA GPU cache & CPU cache to have space for 2 adapters
+        lora_config.max_loras = 2
+        lora_config.max_cpu_loras = 2
 
     llm, sampling_params = setup_llm(args, lora_config=lora_config)
 

--- a/tensorrt_llm/_torch/models/modeling_phi4mm.py
+++ b/tensorrt_llm/_torch/models/modeling_phi4mm.py
@@ -271,16 +271,16 @@ class Phi4MMForCausalLM(transformers.PreTrainedModel):
         if modality == "image" or modality == "image_audio":
             lora_request = [
                 LoRARequest(
-                    lora_name=f"vision-lora-{i}",
-                    lora_int_id=i,
+                    lora_name="vision-lora",
+                    lora_int_id=0,
                     lora_path=f"{base_model_dir}/vision-lora",
                 ) for i in range(num_requests)
             ]
         elif modality == "audio":
             lora_request = [
                 LoRARequest(
-                    lora_name=f"speech-lora-{i}",
-                    lora_int_id=i,
+                    lora_name="speech-lora",
+                    lora_int_id=1,
                     lora_path=f"{base_model_dir}/speech-lora",
                 ) for i in range(num_requests)
             ]

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -482,7 +482,7 @@ def create_py_executor_instance(
         num_lora_modules = model_engine.model.model_config.pretrained_config.num_hidden_layers * \
             len(lora_config.lora_target_modules + lora_config.missing_qkv_modules)
 
-        peft_cache_config_model = PeftCacheConfig.create_from_pybind(
+        peft_cache_config_model = PeftCacheConfig.from_pybind(
             executor_config.peft_cache_config
         ) if executor_config.peft_cache_config is not None else PeftCacheConfig(
         )

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -823,7 +823,7 @@ class _TrtLLM(BaseLLM):
             num_lora_modules = engine_config.pretrained_config.num_hidden_layers * \
                 len(lora_config.lora_target_modules + lora_config.missing_qkv_modules)
 
-            peft_cache_config_model = PeftCacheConfig.create_from_pybind(
+            peft_cache_config_model = PeftCacheConfig.from_pybind(
                 self._executor_config.peft_cache_config
             ) if self._executor_config.peft_cache_config is not None else PeftCacheConfig(
             )

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -31,8 +31,8 @@ from ..inputs import (PromptInputs, create_input_processor,
 from ..logger import logger
 from ..sampling_params import SamplingParams
 from .llm_args import (TORCH_LLMARGS_EXPLICIT_DOCSTRING,
-                       TRT_LLMARGS_EXPLICIT_DOCSTRING, PybindMirror,
-                       TorchLlmArgs, TrtLlmArgs)
+                       TRT_LLMARGS_EXPLICIT_DOCSTRING, PeftCacheConfig,
+                       PybindMirror, TorchLlmArgs, TrtLlmArgs)
 from .llm_utils import (CachedModelLoader, KvCacheRetentionConfig,
                         LlmBuildStats, ModelLoader, _ModelRuntimeContext)
 from .mpi_session import MpiPoolSession, external_mpi_comm_available
@@ -807,19 +807,35 @@ class _TrtLLM(BaseLLM):
         if self.args.peft_cache_config is not None:
             self._executor_config.peft_cache_config = PybindMirror.maybe_to_pybind(
                 self.args.peft_cache_config)
-        elif self.args.build_config.plugin_config.lora_plugin:
+
+        lora_config = None
+        if self.args.build_config.plugin_config.lora_plugin:
             engine_config = EngineConfig.from_json_file(self._engine_dir /
                                                         "config.json")
             lora_config = engine_config.build_config.lora_config
+            if self.args.lora_config is not None:
+                logger.info(
+                    "Overriding lora_config from engine with lora_config from LLM args"
+                )
+                lora_config = self.args.lora_config
+
             max_lora_rank = lora_config.max_lora_rank
             num_lora_modules = engine_config.pretrained_config.num_hidden_layers * \
                 len(lora_config.lora_target_modules + lora_config.missing_qkv_modules)
-            self._executor_config.peft_cache_config = tllm.PeftCacheConfig(
-                num_device_module_layer=max_lora_rank * num_lora_modules *
-                self.args.max_loras,
-                num_host_module_layer=max_lora_rank * num_lora_modules *
-                self.args.max_cpu_loras,
+
+            peft_cache_config_model = PeftCacheConfig.create_from_pybind(
+                self._executor_config.peft_cache_config
+            ) if self._executor_config.peft_cache_config is not None else PeftCacheConfig(
             )
+            if lora_config.max_loras is not None:
+                peft_cache_config_model.num_device_module_layer = \
+                    max_lora_rank * num_lora_modules * lora_config.max_loras
+            if lora_config.max_cpu_loras is not None:
+                peft_cache_config_model.num_host_module_layer = \
+                    max_lora_rank * num_lora_modules * lora_config.max_cpu_loras
+            self._executor_config.peft_cache_config = peft_cache_config_model._to_pybind(
+            )
+
         if self.args.decoding_config is not None:
             self._executor_config.decoding_config = self.args.decoding_config
         if self.args.guided_decoding_backend == 'xgrammar':
@@ -860,7 +876,7 @@ class _TrtLLM(BaseLLM):
                 postprocess_tokenizer_dir=self.args.postprocess_tokenizer_dir,
             ),
             is_llm_executor=True,
-            lora_config=self.args.lora_config)
+            lora_config=lora_config)
 
 
 @append_docstring(TORCH_LLM_DOCSTRING)

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -735,8 +735,8 @@ class PeftCacheConfig(StrictBaseModel, PybindMirror):
     lora_prefetch_dir: Optional[str] = Field(
         default=None,
         description=
-        "folder to store the LoRA weights we hope to load during engine initialization"
-        ", not supported with pytorch backend")
+        "folder to store the LoRA weights we hope to load during engine initialization, currently not supported"
+    )
 
     def _to_pybind(self):
         return _PeftCacheConfig(
@@ -1628,10 +1628,8 @@ class BaseLlmArgs(StrictBaseModel):
 
     @model_validator(mode="after")
     def validate_peft_cache_config(self):
-        if self.backend == "pytorch" and self.peft_cache_config is not None:
-            if self.peft_cache_config.lora_prefetch_dir is not None:
-                logger.warning(
-                    "LoRA prefetch is not supported with pytorch backend")
+        if self.peft_cache_config is not None and self.peft_cache_config.lora_prefetch_dir is not None:
+            logger.warning("LoRA prefetch is not supported")
         return self
 
     def _update_plugin_config(self, key: str, value: Any):

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -605,7 +605,7 @@ class PybindMirror(ABC):
     def from_pybind(cls: Type[TypeBaseModel],
                     pybind_instance: "PybindMirror") -> TypeBaseModel:
         """Construct an instance of the given class from the fields in the given
-        pybind class.
+        pybind class instance.
 
         Args:
             cls: Type of the class to construct, must be a subclass of pydantic

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -727,11 +727,13 @@ class PeftCacheConfig(StrictBaseModel, PybindMirror):
     max_pages_per_block_device: int = Field(
         default=8,
         description="Number of cache pages per allocation block (device)")
-    device_cache_percent: Optional[float] = Field(
-        default=None,
-        description="percent of memory after engine load to use for cache")
-    host_cache_size: Optional[int] = Field(
-        default=None, description="size in bytes to use for host cache")
+    device_cache_percent: float = Field(
+        default=0.02,
+        description=
+        "Proportion of free device memory after engine load to use for cache, as a fraction from 0 to 1"
+    )
+    host_cache_size: int = Field(
+        default=1024**3, description="size in bytes to use for host cache")
     lora_prefetch_dir: Optional[str] = Field(
         default=None,
         description=

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -699,7 +699,7 @@ class PeftCacheConfig(StrictBaseModel, PybindMirror):
     num_device_module_layer: int = Field(
         default=0,
         description=
-        "number of max sized 1-layer 1-module sets of weights that can be stored in host cache"
+        "number of max sized 1-layer 1-module sets of weights that can be stored in device cache"
         ", affects device cache size and overrides value of device_cache_percent"
     )
     optimal_adapter_size: int = Field(

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1628,7 +1628,7 @@ class BaseLlmArgs(StrictBaseModel):
 
     @model_validator(mode="after")
     def validate_peft_cache_config(self):
-        if self.backend == "pytorch" and self.peft_cache_config.lora_prefetch_dir is not None:
+        if self.backend == "pytorch" and self.peft_cache_config is not None and self.peft_cache_config.lora_prefetch_dir is not None:
             logger.warning(
                 "LoRA prefetch is not supported with pytorch backend")
         return self

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -731,9 +731,10 @@ class PeftCacheConfig(StrictBaseModel, PybindMirror):
         default=0.02,
         description=
         "Proportion of free device memory after engine load to use for cache, as a fraction from 0 to 1"
-    )
+        ", defaults to 2%")
     host_cache_size: int = Field(
-        default=1024**3, description="size in bytes to use for host cache")
+        default=1024**3,
+        description="size in bytes to use for host cache, defaults to 1GiB")
     lora_prefetch_dir: Optional[str] = Field(
         default=None,
         description=

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -759,6 +759,15 @@ class PeftCacheConfig(StrictBaseModel, PybindMirror):
     @staticmethod
     def create_from_pybind(
             peft_cache_config: _PeftCacheConfig) -> "PeftCacheConfig":
+        # Some of the properties are optional in CPP but in python they have a default value and aren't optional,
+        # so copy their value only if they have a value in the CPP instance.
+        extra_kwargs = {}
+        if peft_cache_config.device_cache_percent is not None:
+            extra_kwargs[
+                "device_cache_percent"] = peft_cache_config.device_cache_percent
+        if peft_cache_config.host_cache_size is not None:
+            extra_kwargs["host_cache_size"] = peft_cache_config.host_cache_size
+
         return PeftCacheConfig(
             num_host_module_layer=peft_cache_config.num_host_module_layer,
             num_device_module_layer=peft_cache_config.num_device_module_layer,
@@ -770,9 +779,8 @@ class PeftCacheConfig(StrictBaseModel, PybindMirror):
             max_pages_per_block_host=peft_cache_config.max_pages_per_block_host,
             max_pages_per_block_device=peft_cache_config.
             max_pages_per_block_device,
-            device_cache_percent=peft_cache_config.device_cache_percent,
-            host_cache_size=peft_cache_config.host_cache_size,
-            lora_prefetch_dir=peft_cache_config.lora_prefetch_dir)
+            lora_prefetch_dir=peft_cache_config.lora_prefetch_dir,
+            **extra_kwargs)
 
 
 @PybindMirror.mirror_pybind_fields(_LookaheadDecodingConfig)

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -736,7 +736,7 @@ class PeftCacheConfig(StrictBaseModel, PybindMirror):
         default=None,
         description=
         "folder to store the LoRA weights we hope to load during engine initialization"
-    )
+        ", not supported with pytorch backend")
 
     def _to_pybind(self):
         return _PeftCacheConfig(
@@ -1624,6 +1624,13 @@ class BaseLlmArgs(StrictBaseModel):
                 )
                 self.lora_config.lora_target_modules = list(
                     default_trtllm_modules_to_hf_modules.keys())
+        return self
+
+    @model_validator(mode="after")
+    def validate_peft_cache_config(self):
+        if self.backend == "pytorch" and self.peft_cache_config.lora_prefetch_dir is not None:
+            logger.warning(
+                "LoRA prefetch is not supported with pytorch backend")
         return self
 
     def _update_plugin_config(self, key: str, value: Any):

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1628,9 +1628,10 @@ class BaseLlmArgs(StrictBaseModel):
 
     @model_validator(mode="after")
     def validate_peft_cache_config(self):
-        if self.backend == "pytorch" and self.peft_cache_config is not None and self.peft_cache_config.lora_prefetch_dir is not None:
-            logger.warning(
-                "LoRA prefetch is not supported with pytorch backend")
+        if self.backend == "pytorch" and self.peft_cache_config is not None:
+            if self.peft_cache_config.lora_prefetch_dir is not None:
+                logger.warning(
+                    "LoRA prefetch is not supported with pytorch backend")
         return self
 
     def _update_plugin_config(self, key: str, value: Any):

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1493,10 +1493,10 @@ class BaseLlmArgs(StrictBaseModel):
         if self.parallel_config._world_size == 1 and self.build_config:
             self.build_config.plugin_config.nccl_plugin = None
 
-        if self.enable_lora and self.lora_config is None and self.backend != 'pytorch':
+        if self.enable_lora and self.backend != 'pytorch':
             self.build_config.plugin_config.lora_plugin = 'auto'
-            if self.max_lora_rank is not None:
-                self.build_config.lora_config.max_lora_rank = self.max_lora_rank
+            if self.lora_config is not None:
+                self.build_config.lora_config.max_lora_rank = self.lora_config.max_lora_rank
 
         if hasattr(self,
                    'enable_prompt_adapter') and self.enable_prompt_adapter:

--- a/tensorrt_llm/lora_manager.py
+++ b/tensorrt_llm/lora_manager.py
@@ -203,8 +203,8 @@ class LoraConfig(DictConversion):
     max_lora_rank: int = 64
     lora_target_modules: List[str] = field(default_factory=list)
     trtllm_modules_to_hf_modules: Dict[str, str] = field(default_factory=dict)
-    max_loras: int = 4
-    max_cpu_loras: int = 4
+    max_loras: int | None = None
+    max_cpu_loras: int | None = None
 
     def __post_init__(self):
         assert self.lora_ckpt_source in ["hf", "nemo"], (

--- a/tests/unittest/llmapi/apps/_test_openai_lora.py
+++ b/tests/unittest/llmapi/apps/_test_openai_lora.py
@@ -36,7 +36,9 @@ def temp_extra_llm_api_options_file():
         extra_llm_api_options_dict = {
             "lora_config": {
                 "lora_target_modules": ['attn_q', 'attn_k', 'attn_v'],
-                "max_lora_rank": 8
+                "max_lora_rank": 8,
+                "max_loras": 4,
+                "max_cpu_loras": 4,
             }
         }
 

--- a/tests/unittest/llmapi/apps/_test_trtllm_serve_lora.py
+++ b/tests/unittest/llmapi/apps/_test_trtllm_serve_lora.py
@@ -25,7 +25,9 @@ def temp_extra_llm_api_options_file():
         extra_llm_api_options_dict = {
             "lora_config": {
                 "lora_target_modules": ['attn_q', 'attn_k', 'attn_v'],
-                "max_lora_rank": 8
+                "max_lora_rank": 8,
+                "max_loras": 4,
+                "max_cpu_loras": 4,
             }
         }
 

--- a/tests/unittest/llmapi/test_llm.py
+++ b/tests/unittest/llmapi/test_llm.py
@@ -1523,7 +1523,9 @@ def test_llama_7b_peft_cache_config_affects_peft_cache_size():
 
 
 def test_llama_7b_lora_config_overrides_peft_cache_config():
-    """Tests that cache size args in lora_config LLM arg override the cache size parameters in peft_cache_config LLM arg."""
+    """Tests that cache size args in lora_config LLM arg override the cache size
+    parameters in peft_cache_config LLM arg.
+    """    # noqa: D205
     build_config = BuildConfig(lora_config=LoraConfig(
         lora_target_modules=['attn_q', 'attn_k', 'attn_v'], max_lora_rank=8))
     check_llama_7b_multi_lora_from_request_test_harness(

--- a/tests/unittest/llmapi/test_llm.py
+++ b/tests/unittest/llmapi/test_llm.py
@@ -1490,10 +1490,9 @@ def test_llama_7b_multi_lora_evict_load_new_adapters(
 def test_llama_7b_peft_cache_config_affects_peft_cache_size():
     """Tests that LLM arg of peft_cache_config affects the peft cache sizes.
 
-    NOTE: The caller can't get the actual LoRA cache size without debug logs, so
-    to test whether it is affected by PeftCacheConfig LLM arg, a non-zero value
-    that's too small to contain a single adapter can be sent, which shall cause
-    a failure in init.
+    NOTE: The caller can't get the actual LoRA cache sizes, so we instead we
+    test that it fails when configured with a value too small to contain a
+    single adapter.
     """
     # For LoRA checkpoints without finetuned embedding and lm_head, we can either:
     # (1) specify lora_target_modules, or
@@ -1502,7 +1501,7 @@ def test_llama_7b_peft_cache_config_affects_peft_cache_size():
         lora_target_modules=['attn_q', 'attn_k', 'attn_v'], max_lora_rank=8)
     build_config = BuildConfig(lora_config=lora_config_no_cache_size_values)
 
-    # Test that init fails on PeftCacheConfig.host_cache_size too small
+    # Test that too small PeftCacheConfig.host_cache_size causes failure
     with pytest.raises(RuntimeError):
         check_llama_7b_multi_lora_from_request_test_harness(
             LLM,
@@ -1512,7 +1511,7 @@ def test_llama_7b_peft_cache_config_affects_peft_cache_size():
             lora_config=lora_config_no_cache_size_values,
             peft_cache_config=PeftCacheConfig(host_cache_size=1))
 
-    # Test that init fails on PeftCacheConfig.device_cache_percent too small
+    # Test that too small PeftCacheConfig.device_cache_percent causes failure
     with pytest.raises(RuntimeError):
         check_llama_7b_multi_lora_from_request_test_harness(
             LLM,

--- a/tests/unittest/llmapi/test_llm.py
+++ b/tests/unittest/llmapi/test_llm.py
@@ -1509,7 +1509,8 @@ def test_llama_7b_peft_cache_config_affects_peft_cache_size():
             build_config=build_config,
             fast_build=True,
             lora_config=lora_config_no_cache_size_values,
-            peft_cache_config=PeftCacheConfig(host_cache_size=1))
+            peft_cache_config=PeftCacheConfig(
+                host_cache_size=1))  # size in bytes
 
     # Test that too small PeftCacheConfig.device_cache_percent causes failure
     with pytest.raises(RuntimeError):
@@ -1519,7 +1520,7 @@ def test_llama_7b_peft_cache_config_affects_peft_cache_size():
             build_config=build_config,
             fast_build=True,
             lora_config=lora_config_no_cache_size_values,
-            peft_cache_config=PeftCacheConfig(device_cache_percent=0.000001))
+            peft_cache_config=PeftCacheConfig(device_cache_percent=0.0000001))
 
 
 def test_llama_7b_lora_config_overrides_peft_cache_config():
@@ -1538,8 +1539,9 @@ def test_llama_7b_lora_config_overrides_peft_cache_config():
             max_lora_rank=8,
             max_loras=2,
             max_cpu_loras=2),
-        peft_cache_config=PeftCacheConfig(host_cache_size=1,
-                                          device_cache_percent=0.000001))
+        peft_cache_config=PeftCacheConfig(
+            host_cache_size=1,  # size in bytes
+            device_cache_percent=0.0000001))
 
 
 @skip_gpu_memory_less_than_40gb

--- a/tests/unittest/llmapi/test_llm.py
+++ b/tests/unittest/llmapi/test_llm.py
@@ -1427,11 +1427,11 @@ def llama_v2_13b_lora_from_dir_test_harness(**llm_kwargs):
     hf_lora_dir = get_model_path("llama-models-v2/chinese-llama-2-lora-13b")
 
     # For LoRA checkpoints with finetuned embedding and lm_head, lora_dir must be provided at build time.
-    build_config = BuildConfig(lora_config=LoraConfig(lora_dir=[hf_lora_dir]))
+    build_config = BuildConfig(lora_config=LoraConfig(
+        lora_dir=[hf_lora_dir], max_lora_rank=64, max_loras=2, max_cpu_loras=2))
     llm = LLM(hf_model_dir,
               tokenizer=hf_lora_dir,
               enable_lora=True,
-              max_lora_rank=64,
               build_config=build_config,
               fast_build=True,
               **llm_kwargs)

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -223,10 +223,6 @@ def test_SchedulerConfig_declaration():
                                       config.dynamic_batch_config._to_pybind())
 
 
-def test_PeftCacheConfig_default_values():
-    check_defaults(PeftCacheConfig, tle.PeftCacheConfig)
-
-
 def test_PeftCacheConfig_declaration():
     config = PeftCacheConfig(num_host_module_layer=1,
                              num_device_module_layer=1,
@@ -254,6 +250,67 @@ def test_PeftCacheConfig_declaration():
     assert pybind_config.device_cache_percent == 0.5
     assert pybind_config.host_cache_size == 1024
     assert pybind_config.lora_prefetch_dir == "."
+
+
+def test_PeftCacheConfig_from_pybind():
+    pybind_config = tle.PeftCacheConfig(num_host_module_layer=1,
+                                        num_device_module_layer=1,
+                                        optimal_adapter_size=64,
+                                        max_adapter_size=128,
+                                        num_put_workers=1,
+                                        num_ensure_workers=1,
+                                        num_copy_streams=1,
+                                        max_pages_per_block_host=24,
+                                        max_pages_per_block_device=8,
+                                        device_cache_percent=0.5,
+                                        host_cache_size=1024,
+                                        lora_prefetch_dir=".")
+
+    config = PeftCacheConfig.from_pybind(pybind_config)
+    assert config.num_host_module_layer == 1
+    assert config.num_device_module_layer == 1
+    assert config.optimal_adapter_size == 64
+    assert config.max_adapter_size == 128
+    assert config.num_put_workers == 1
+    assert config.num_ensure_workers == 1
+    assert config.num_copy_streams == 1
+    assert config.max_pages_per_block_host == 24
+    assert config.max_pages_per_block_device == 8
+    assert config.device_cache_percent == 0.5
+    assert config.host_cache_size == 1024
+    assert config.lora_prefetch_dir == "."
+
+
+def test_PeftCacheConfig_from_pybind_gets_python_only_default_values_when_none(
+):
+    pybind_config = tle.PeftCacheConfig(num_host_module_layer=1,
+                                        num_device_module_layer=1,
+                                        optimal_adapter_size=64,
+                                        max_adapter_size=128,
+                                        num_put_workers=1,
+                                        num_ensure_workers=1,
+                                        num_copy_streams=1,
+                                        max_pages_per_block_host=24,
+                                        max_pages_per_block_device=8,
+                                        device_cache_percent=None,
+                                        host_cache_size=None,
+                                        lora_prefetch_dir=".")
+
+    config = PeftCacheConfig.from_pybind(pybind_config)
+    assert config.num_host_module_layer == 1
+    assert config.num_device_module_layer == 1
+    assert config.optimal_adapter_size == 64
+    assert config.max_adapter_size == 128
+    assert config.num_put_workers == 1
+    assert config.num_ensure_workers == 1
+    assert config.num_copy_streams == 1
+    assert config.max_pages_per_block_host == 24
+    assert config.max_pages_per_block_device == 8
+    assert config.device_cache_percent == PeftCacheConfig.model_fields[
+        "device_cache_percent"].default
+    assert config.host_cache_size == PeftCacheConfig.model_fields[
+        "host_cache_size"].default
+    assert config.lora_prefetch_dir == "."
 
 
 def test_update_llm_args_with_extra_dict_with_nested_dict():

--- a/tests/unittest/llmapi/test_llm_multi_gpu.py
+++ b/tests/unittest/llmapi/test_llm_multi_gpu.py
@@ -274,9 +274,6 @@ def test_llama_7b_multi_lora_tp2():
         enable_lora=True,
         build_config=BuildConfig(lora_config=lora_config),
         fast_build=True,
-        max_lora_rank=lora_config.max_lora_rank,
-        max_loras=lora_config.max_loras,
-        max_cpu_loras=lora_config.max_cpu_loras,
         kv_cache_config=global_kv_cache_config)
 
 

--- a/tests/unittest/llmapi/test_llm_pytorch.py
+++ b/tests/unittest/llmapi/test_llm_pytorch.py
@@ -140,7 +140,9 @@ def test_llm_with_postprocess_parallel_and_result_handler(streaming):
 def llama_7b_lora_from_dir_test_harness(**llm_kwargs) -> None:
     lora_config = LoraConfig(
         lora_dir=[f"{llm_models_root()}/llama-models/luotuo-lora-7b-0.1"],
-        max_lora_rank=8)
+        max_lora_rank=8,
+        max_loras=2,
+        max_cpu_loras=2)
     llm = LLM(model=f"{llm_models_root()}/llama-models/llama-7b-hf",
               lora_config=lora_config,
               **llm_kwargs)
@@ -174,7 +176,7 @@ def test_llama_7b_lora():
 
 @skip_gpu_memory_less_than_40gb
 def test_llama_7b_lora_default_modules() -> None:
-    lora_config = LoraConfig(max_lora_rank=64)
+    lora_config = LoraConfig(max_lora_rank=64, max_loras=2, max_cpu_loras=2)
 
     hf_model_dir = f"{llm_models_root()}/llama-models/llama-7b-hf"
 
@@ -418,7 +420,9 @@ def test_codellama_fp8_with_bf16_lora() -> None:
 
         lora_config = LoraConfig(lora_dir=lora_paths,
                                  lora_target_modules=target_modules,
-                                 max_lora_rank=8)
+                                 max_lora_rank=8,
+                                 max_loras=2,
+                                 max_cpu_loras=2)
 
         llm = LLM(model_dir, quant_config=quant_config, lora_config=lora_config)
 
@@ -468,7 +472,9 @@ def test_bielik_11b_v2_2_instruct_multi_lora() -> None:
 
         trtllm_lora_config = LoraConfig(lora_dir=lora_paths,
                                         lora_target_modules=target_modules,
-                                        max_lora_rank=8)
+                                        max_lora_rank=8,
+                                        max_loras=2,
+                                        max_cpu_loras=2)
         llm = LLM(model_dir, lora_config=trtllm_lora_config)
 
         prompts = [

--- a/tests/unittest/llmapi/test_llm_pytorch.py
+++ b/tests/unittest/llmapi/test_llm_pytorch.py
@@ -310,7 +310,8 @@ def test_llama_7b_peft_cache_config_affects_peft_cache_size():
         check_llama_7b_multi_lora_from_request_test_harness(
             LLM,
             lora_config=lora_config_no_cache_size_values,
-            peft_cache_config=PeftCacheConfig(host_cache_size=1),
+            peft_cache_config=PeftCacheConfig(
+                host_cache_size=1),  # size in bytes
             # Disable CUDA graph
             # TODO: remove this once we have a proper fix for CUDA graph in LoRA
             cuda_graph_config=None)
@@ -320,7 +321,7 @@ def test_llama_7b_peft_cache_config_affects_peft_cache_size():
         check_llama_7b_multi_lora_from_request_test_harness(
             LLM,
             lora_config=lora_config_no_cache_size_values,
-            peft_cache_config=PeftCacheConfig(device_cache_percent=0.000001),
+            peft_cache_config=PeftCacheConfig(device_cache_percent=0.0000001),
             # Disable CUDA graph
             # TODO: remove this once we have a proper fix for CUDA graph in LoRA
             cuda_graph_config=None)
@@ -337,8 +338,9 @@ def test_llama_7b_lora_config_overrides_peft_cache_config():
             max_lora_rank=8,
             max_loras=2,
             max_cpu_loras=2),
-        peft_cache_config=PeftCacheConfig(host_cache_size=1,
-                                          device_cache_percent=0.000001),
+        peft_cache_config=PeftCacheConfig(
+            host_cache_size=1,  # size in bytes
+            device_cache_percent=0.0000001),
         # Disable CUDA graph
         # TODO: remove this once we have a proper fix for CUDA graph in LoRA
         cuda_graph_config=None)

--- a/tests/unittest/llmapi/test_llm_pytorch.py
+++ b/tests/unittest/llmapi/test_llm_pytorch.py
@@ -327,7 +327,9 @@ def test_llama_7b_peft_cache_config_affects_peft_cache_size():
 
 
 def test_llama_7b_lora_config_overrides_peft_cache_config():
-    """Tests that cache size args in lora_config LLM arg override the cache size parameters in peft_cache_config LLM arg."""
+    """Tests that cache size args in lora_config LLM arg override the cache size
+    parameters in peft_cache_config LLM arg.
+    """    # noqa: D205
     check_llama_7b_multi_lora_from_request_test_harness(
         LLM,
         lora_config=LoraConfig(

--- a/tests/unittest/llmapi/test_llm_pytorch.py
+++ b/tests/unittest/llmapi/test_llm_pytorch.py
@@ -295,10 +295,9 @@ def test_llama_7b_multi_lora_load_previously_cpu_cache_evicted_adapter_fails(
 def test_llama_7b_peft_cache_config_affects_peft_cache_size():
     """Tests that LLM arg of peft_cache_config affects the peft cache sizes.
 
-    NOTE: The caller can't get the actual LoRA cache size without debug logs, so
-    to test whether it is affected by PeftCacheConfig LLM arg, a non-zero value
-    that's too small to contain a single adapter can be sent, which shall cause
-    a failure in init.
+    NOTE: The caller can't get the actual LoRA cache sizes, so we instead we
+    test that it fails when configured with a value too small to contain a
+    single adapter.
     """
     # For LoRA checkpoints without finetuned embedding and lm_head, we can either:
     # (1) specify lora_target_modules, or
@@ -306,7 +305,7 @@ def test_llama_7b_peft_cache_config_affects_peft_cache_size():
     lora_config_no_cache_size_values = LoraConfig(
         lora_target_modules=['attn_q', 'attn_k', 'attn_v'], max_lora_rank=8)
 
-    # Test that init fails on PeftCacheConfig.host_cache_size too small
+    # Test that too small PeftCacheConfig.host_cache_size causes failure
     with pytest.raises(RuntimeError):
         check_llama_7b_multi_lora_from_request_test_harness(
             LLM,
@@ -316,7 +315,7 @@ def test_llama_7b_peft_cache_config_affects_peft_cache_size():
             # TODO: remove this once we have a proper fix for CUDA graph in LoRA
             cuda_graph_config=None)
 
-    # Test that init fails on PeftCacheConfig.device_cache_percent too small
+    # Test that too small PeftCacheConfig.device_cache_percent causes failure
     with pytest.raises(RuntimeError):
         check_llama_7b_multi_lora_from_request_test_harness(
             LLM,


### PR DESCRIPTION
## Description

1. Added support for configuring LoRA cache sizes on pytorch flow.
2. Changed `LoraConfig.max_loras` and `LoraConfig.max_cpu_loras` to be optional. When they're not set, the cache size would be determined by the `PeftCacheConfig`.
3. Implemented a "merge" logic of fields in `peft_cache_config` and `lora_config` - when cache size fields in `lora_config` have a value, they would take precedence over the relevant fields in `peft_cache_config`
4. Removed deprecated LoRA LLM args, as they're already specified inside `lora_config: LoraConfig` LLM arg: `max_lora_rank`, `max_loras`, `max_cpu_loras`.
5. For user clarity - defined default values in python `PeftCacheConfig` class for `device_cache_percent` to 2% and `host_cache_size` to 1GiB, the same default values that the CPP code uses when these fields have no value.
6. In TRT-python flow, `lora_config` in LLM args would take precedence over `lora_config` from the engine build config.
7. Raise an exception when `peft_cache_config.lora_prefetch_dir` has a value, as currently it's not supported.
8. Added tests that verify the LoRA cache size LLM args take effect in the expect order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of LoRA and PEFT cache configurations, allowing cache size parameters in LoRA configs to override those in PEFT cache configs.
  * Enhanced flexibility for specifying LoRA adapter cache sizes by supporting optional values.
  * Added validation to prevent unsupported LoRA prefetch directory usage in PEFT cache configuration.
  * Refactored LoRA config integration to merge existing PEFT cache settings and support explicit overrides.
  * Simplified LoRA adapter naming in multimodal models for consistent identification.

* **Tests**
  * Added tests verifying correct behavior when LoRA and PEFT cache configurations interact, including error handling for insufficient cache sizes and precedence of LoRA config values.
  * Updated existing tests and fixtures to include new LoRA cache size parameters for comprehensive coverage.

* **Examples**
  * Updated example usage to pass LoRA configuration directly with explicit cache size parameters, removing deprecated fields.

* **Documentation & Validation**
  * Clarified PEFT cache configuration field descriptions and tightened default values.
  * Removed deprecated LoRA-related fields and warnings from configuration validation.
  * Added model validators to ensure compatibility of PEFT cache settings with backend capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Test Coverage

* `tests/unittest/llmapi/test_llm.py::test_llama_7b_peft_cache_config_affects_peft_cache_size`
* `tests/unittest/llmapi/test_llm.py::test_llama_7b_lora_config_overrides_peft_cache_config`
* `tests/unittest/llmapi/test_llm_pytorch.py::test_llama_7b_peft_cache_config_affects_peft_cache_size`
* `tests/unittest/llmapi/test_llm_pytorch.py::test_llama_7b_lora_config_overrides_peft_cache_config`

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
