### PR TITLE
fix: bindings unit tests for nanobind

### DIFF
--- a/cpp/tensorrt_llm/nanobind/batch_manager/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/bindings.cpp
@@ -79,7 +79,7 @@ void initBindings(nb::module_& m)
             }
         });
 
-    PybindUtils::bindSet<tb::ReqIdsSet>(m, "ReqIdsSet");
+    NanobindUtils::bindSet<tb::ReqIdsSet>(m, "ReqIdsSet");
 
     nb::enum_<tb::LlmRequestType>(m, "LlmRequestType")
         .value("LLMREQUEST_TYPE_CONTEXT_AND_GENERATION", tb::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION)

--- a/cpp/tensorrt_llm/nanobind/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/bindings.cpp
@@ -359,9 +359,12 @@ NB_MODULE(TRTLLM_NB_MODULE, m)
             config.earlyStopping, config.noRepeatNgramSize, config.numReturnSequences, config.minP,
             config.beamWidthArray);
     };
-    auto SamplingConfigSetState = [](tr::SamplingConfig& self, nb::tuple t) -> tr::SamplingConfig
+    auto SamplingConfigSetState = [](tr::SamplingConfig& self, nb::tuple t)
     {
-        assert(t.size() == 19);
+        if (t.size() != 19)
+        {
+            throw std::runtime_error("Invalid SamplingConfig state!");
+        }
 
         tr::SamplingConfig config;
         config.beamWidth = nb::cast<SizeType32>(t[0]);
@@ -384,7 +387,7 @@ NB_MODULE(TRTLLM_NB_MODULE, m)
         config.minP = nb::cast<OptVec<float>>(t[17]);
         config.beamWidthArray = nb::cast<OptVec<std::vector<SizeType32>>>(t[18]);
 
-        return config;
+        new (&self) tr::SamplingConfig(config);
     };
 
     nb::class_<tr::SamplingConfig>(m, "SamplingConfig")

--- a/cpp/tensorrt_llm/nanobind/common/bindTypes.h
+++ b/cpp/tensorrt_llm/nanobind/common/bindTypes.h
@@ -21,43 +21,10 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/string.h>
 
-namespace PybindUtils
+namespace NanobindUtils
 {
 
 namespace nb = nanobind;
-
-template <typename T>
-void bindList(nb::module_& m, std::string const& name)
-{
-    nb::class_<T>(m, name.c_str())
-        .def(nb::init<>())
-        .def("push_back", [](T& lst, const typename T::value_type& value) { lst.push_back(value); })
-        .def("pop_back", [](T& lst) { lst.pop_back(); })
-        .def("push_front", [](T& lst, const typename T::value_type& value) { lst.push_front(value); })
-        .def("pop_front", [](T& lst) { lst.pop_front(); })
-        .def("__len__", [](T const& lst) { return lst.size(); })
-        .def(
-            "__iter__", [](T& lst) { return nb::make_iterator(nb::type<T>(), "iterator", lst.begin(), lst.end()); },
-            nb::keep_alive<0, 1>())
-        .def("__getitem__",
-            [](T const& lst, size_t index)
-            {
-                if (index >= lst.size())
-                    throw nb::index_error();
-                auto it = lst.begin();
-                std::advance(it, index);
-                return *it;
-            })
-        .def("__setitem__",
-            [](T& lst, size_t index, const typename T::value_type& value)
-            {
-                if (index >= lst.size())
-                    throw nb::index_error();
-                auto it = lst.begin();
-                std::advance(it, index);
-                *it = value;
-            });
-}
 
 template <typename T>
 void bindSet(nb::module_& m, std::string const& name)
@@ -93,8 +60,8 @@ void bindSet(nb::module_& m, std::string const& name)
                 {
                     s.insert(item);
                 }
-                return s;
+                new (&v) T(s);
             });
 }
 
-} // namespace PybindUtils
+} // namespace NanobindUtils

--- a/cpp/tensorrt_llm/nanobind/executor/request.cpp
+++ b/cpp/tensorrt_llm/nanobind/executor/request.cpp
@@ -445,13 +445,18 @@ void initRequestBindings(nb::module_& m)
                 std::vector<char>(opaque_state_str_view.begin(), opaque_state_str_view.end()),
                 nb::cast<std::optional<VecTokens>>(state[3]));
         }
-        new (&contextPhaseParams) tle::ContextPhaseParams(nb::cast<VecTokens>(state[0]),
-            nb::cast<tle::ContextPhaseParams::RequestIdType>(state[1]), nb::cast<std::optional<VecTokens>>(state[3]));
+        else
+        {
+            new (&contextPhaseParams) tle::ContextPhaseParams(nb::cast<VecTokens>(state[0]),
+                nb::cast<tle::ContextPhaseParams::RequestIdType>(state[1]),
+                nb::cast<std::optional<VecTokens>>(state[3]));
+        }
     };
 
     nb::class_<tle::ContextPhaseParams>(m, "ContextPhaseParams")
-        .def("__init__",
-            [](tle::ContextPhaseParams const& self, VecTokens const& first_gen_tokens,
+        .def(
+            "__init__",
+            [](tle::ContextPhaseParams& self, VecTokens const& first_gen_tokens,
                 tle::ContextPhaseParams::RequestIdType req_id, std::optional<nb::bytes> const& opaque_state,
                 std::optional<VecTokens> const& draft_tokens)
             {
@@ -459,11 +464,16 @@ void initRequestBindings(nb::module_& m)
                 {
                     auto opaque_state_str_view
                         = std::string_view(opaque_state.value().c_str(), opaque_state.value().size());
-                    return std::make_unique<tle::ContextPhaseParams>(first_gen_tokens, req_id,
+                    new (&self) tle::ContextPhaseParams(first_gen_tokens, req_id,
                         std::vector<char>(opaque_state_str_view.begin(), opaque_state_str_view.end()), draft_tokens);
                 }
-                return std::make_unique<tle::ContextPhaseParams>(first_gen_tokens, req_id, draft_tokens);
-            })
+                else
+                {
+                    new (&self) tle::ContextPhaseParams(first_gen_tokens, req_id, draft_tokens);
+                }
+            },
+            nb::arg("first_gen_tokens"), nb::arg("req_id"), nb::arg("opaque_state").none(),
+            nb::arg("draft_tokens").none())
         .def_prop_ro("first_gen_tokens", [](tle::ContextPhaseParams const& self) { return self.getFirstGenTokens(); })
         .def_prop_ro("draft_tokens", [](tle::ContextPhaseParams const& self) { return self.getDraftTokens(); })
         .def_prop_ro("req_id", &tle::ContextPhaseParams::getReqId)
@@ -486,14 +496,14 @@ void initRequestBindings(nb::module_& m)
         return nb::make_tuple(self.getEagleChoices(), self.isGreedySampling(), self.getPosteriorThreshold(),
             self.useDynamicTree(), self.getDynamicTreeMaxTopK());
     };
-    auto EagleDecodingConfigSetstate = [](tle::EagleConfig& eagleConfig, nb::tuple const& state)
+    auto EagleDecodingConfigSetstate = [](tle::EagleConfig& self, nb::tuple const& state)
     {
         if (state.size() != 5)
         {
             throw std::runtime_error("Invalid EagleConfig state!");
         }
-        new (&eagleConfig) tle::EagleConfig(nb::cast<std::optional<tle::EagleChoices>>(state[0]),
-            nb::cast<bool>(state[1]), nb::cast<std::optional<float>>(state[2]), nb::cast<bool>(state[3]),
+        new (&self) tle::EagleConfig(nb::cast<std::optional<tle::EagleChoices>>(state[0]), nb::cast<bool>(state[1]),
+            nb::cast<std::optional<float>>(state[2]), nb::cast<bool>(state[3]),
             nb::cast<std::optional<SizeType32>>(state[4]));
     };
     nb::class_<tle::EagleConfig>(m, "EagleConfig")
@@ -522,13 +532,13 @@ void initRequestBindings(nb::module_& m)
     auto guidedDecodingParamsGetstate
         = [](tle::GuidedDecodingParams const& self) { return nb::make_tuple(self.getGuideType(), self.getGuide()); };
 
-    auto guidedDecodingParamsSetstate = [](tle::GuidedDecodingParams& guidedDecodingParams, nb::tuple const& state)
+    auto guidedDecodingParamsSetstate = [](tle::GuidedDecodingParams& self, nb::tuple const& state)
     {
         if (state.size() != 2)
         {
             throw std::runtime_error("Invalid GuidedDecodingParams state!");
         }
-        new (&guidedDecodingParams) tle::GuidedDecodingParams(
+        new (&self) tle::GuidedDecodingParams(
             nb::cast<tle::GuidedDecodingParams::GuideType>(state[0]), nb::cast<std::optional<std::string>>(state[1]));
     };
 
@@ -553,13 +563,13 @@ void initRequestBindings(nb::module_& m)
             self.getCrossAttentionMask(), self.getEagleConfig(), self.getSkipCrossAttnBlocks(),
             self.getGuidedDecodingParams());
     };
-    auto requestSetstate = [](tle::Request& request, nb::tuple const& state)
+    auto requestSetstate = [](tle::Request& self, nb::tuple const& state)
     {
         if (state.size() != 33)
         {
             throw std::runtime_error("Invalid Request state!");
         }
-        new (&request) tle::Request(nb::cast<VecTokens>(state[0]), nb::cast<SizeType32>(state[1]),
+        new (&self) tle::Request(nb::cast<VecTokens>(state[0]), nb::cast<SizeType32>(state[1]),
             nb::cast<bool>(state[2]), nb::cast<tle::SamplingConfig>(state[3]), nb::cast<tle::OutputConfig>(state[4]),
             nb::cast<std::optional<SizeType32>>(state[5]), nb::cast<std::optional<SizeType32>>(state[6]),
             nb::cast<std::optional<std::vector<SizeType32>>>(state[7]),
@@ -797,13 +807,13 @@ void initRequestBindings(nb::module_& m)
         return nb::make_tuple(self.timingMetrics, self.kvCacheMetrics, self.speculativeDecoding, self.firstIter,
             self.lastIter, self.iter);
     };
-    auto requestPerfMetricsSetstate = [](tle::RequestPerfMetrics& requestPerfMetrics, nb::tuple const& state)
+    auto requestPerfMetricsSetstate = [](tle::RequestPerfMetrics& self, nb::tuple const& state)
     {
         if (state.size() != 6)
         {
             throw std::runtime_error("Invalid RequestPerfMetrics state!");
         }
-        new (&requestPerfMetrics) tle::RequestPerfMetrics{nb::cast<tle::RequestPerfMetrics::TimingMetrics>(state[0]),
+        new (&self) tle::RequestPerfMetrics{nb::cast<tle::RequestPerfMetrics::TimingMetrics>(state[0]),
             nb::cast<tle::RequestPerfMetrics::KvCacheMetrics>(state[1]),
             nb::cast<tle::RequestPerfMetrics::SpeculativeDecodingMetrics>(state[2]),
             nb::cast<std::optional<tle::IterationType>>(state[3]),
@@ -824,19 +834,17 @@ void initRequestBindings(nb::module_& m)
         .def("__setstate__", requestPerfMetricsSetstate);
 
     nb::class_<tle::AdditionalOutput>(m, "AdditionalOutput")
-        .def("__init__ ",
-            [](tle::AdditionalOutput const& self, std::string const& name, tle::Tensor const& output)
-            { return std::make_unique<tle::AdditionalOutput>(name, output); })
+        .def(nb::init<std::string, tle::Tensor>(), nb::arg("name"), nb::arg("output"))
         .def_rw("name", &tle::AdditionalOutput::name)
         .def_rw("output", &tle::AdditionalOutput::output);
 
-    auto resultSetstate = [](tle::Result& result, nb::tuple const& state)
+    auto resultSetstate = [](tle::Result& self, nb::tuple const& state)
     {
         if (state.size() != 13)
         {
             throw std::runtime_error("Invalid Request state!");
         }
-        new (&result) tle::Result();
+        tle::Result result;
         result.isFinal = nb::cast<bool>(state[0]);
         result.outputTokenIds = nb::cast<std::vector<VecTokens>>(state[1]);
         result.cumLogProbs = nb::cast<std::optional<std::vector<float>>>(state[2]);
@@ -850,6 +858,7 @@ void initRequestBindings(nb::module_& m)
         result.decodingIter = nb::cast<SizeType32>(state[10]);
         result.contextPhaseParams = nb::cast<std::optional<tle::ContextPhaseParams>>(state[11]);
         result.requestPerfMetrics = nb::cast<std::optional<tle::RequestPerfMetrics>>(state[12]);
+        new (&self) tle::Result(result);
     };
 
     auto resultGetstate = [](tle::Result const& self)

--- a/cpp/tensorrt_llm/pybind/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/bindings.cpp
@@ -355,7 +355,10 @@ PYBIND11_MODULE(TRTLLM_PYBIND_MODULE, m)
     };
     auto SamplingConfigSetState = [](py::tuple t) -> tr::SamplingConfig
     {
-        assert(t.size() == 19);
+        if (t.size() != 19)
+        {
+            throw std::runtime_error("Invalid SamplingConfig state!");
+        }
 
         tr::SamplingConfig config;
         config.beamWidth = t[0].cast<SizeType32>();

--- a/tests/unittest/bindings/test_bindings_ut.py
+++ b/tests/unittest/bindings/test_bindings_ut.py
@@ -5,7 +5,6 @@ import time
 from pathlib import Path
 
 import numpy as np
-import pytest
 import torch
 from utils.runtime_defaults import assert_runtime_defaults_are_parsed_correctly
 
@@ -310,8 +309,6 @@ def test_gpt_json_config():
                                                  strict_keys=strict_keys)
 
 
-@pytest.mark.skipif(_tb.binding_type == "nanobind",
-                    reason="Test not supported for nanobind yet")
 def test_llm_request():
     beam_width = 2
     sampling_config = _tb.SamplingConfig(beam_width)
@@ -421,8 +418,6 @@ def test_Mpicomm():
     assert size2 == session_size
 
 
-@pytest.mark.skipif(_tb.binding_type == "nanobind",
-                    reason="Test not supported for nanobind yet")
 def test_SamplingConfig_pickle():
     config = _tb.SamplingConfig()
     config.beam_width = 5
@@ -447,7 +442,6 @@ def test_SamplingConfig_pickle():
     config.beam_width_array = [[2, 3, 4, 5]]
 
     config1 = pickle.loads(pickle.dumps(config))
-
     assert config1 == config
 
 
@@ -502,8 +496,6 @@ def test_KvCache_events_binding():
     torch.cuda.empty_cache()
 
 
-@pytest.mark.skipif(_tb.binding_type == "nanobind",
-                    reason="Test not supported for nanobind yet")
 def test_ReqIdsSet_pickle():
     ids = _tb.internal.batch_manager.ReqIdsSet()
     ids1 = pickle.loads(pickle.dumps(ids))


### PR DESCRIPTION
# Fix of failing bindings unit tests for nanobind

This change fixes errors in the nanobind bindings which caused unit tests in `tests/unittest/bindings` to fail. These tests were previously skipped with `@pytest.mark.skipif(_tb.binding_type == "nanobind")` and all of them are enabled in this PR.

Executing `pytest tests/unittest/bindings` 
|before|now|
|--|--|
|95 passed, 28 skipped|  123 passed, 1 skipped|
| | (1 added, 1 skipped for both pybind and nanobind) |


## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for constructing executors with managed weights using a variety of data types, including FP8 and BF16.
  * Enabled pickling (serialization) for additional nested types and improved support for custom objects in Python bindings.

* **Bug Fixes**
  * Improved error handling for deserialization in configuration objects, providing clearer runtime exceptions.

* **Refactor**
  * Updated Python bindings to use more robust object construction and state restoration patterns.
  * Enhanced dtype and shape extraction for tensor conversion, enabling broader compatibility.

* **Tests**
  * Introduced new tests covering executor creation with managed weights and improved pickle tests for custom objects.
  * Enabled previously skipped tests, increasing overall test coverage.

* **Chores**
  * Removed unused decorators and imports from test files.
  * Cleaned up and simplified internal utility code for binding and type casting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->