### PR TITLE
[fix][nvbugs/5399355] Fix Lamport buffer clear issue for MNNVL TwoShot Allreduce and add FP16 support.

### DIFF
--- a/cpp/tensorrt_llm/kernels/communicationKernels/mnnvlTwoShotAllreduceKernels.cu
+++ b/cpp/tensorrt_llm/kernels/communicationKernels/mnnvlTwoShotAllreduceKernels.cu
@@ -74,13 +74,6 @@ __device__ __inline__ float2 loadfloat2(void const* ptr)
     return *(float2*) return_value;
 }
 
-template <typename T>
-inline __device__ T max3(T in_a, T in_b, T in_c)
-{
-    T max_ab = in_a > in_b ? in_a : in_b;
-    return max_ab > in_c ? max_ab : in_c;
-}
-
 template <int WORLD_SIZE, typename T>
 __global__ void twoshot_allreduce_kernel(T* output_ptr, T* shard_ptr, T** input_ptrs, T* mcast_ptr, int num_tokens,
     int buffer_M, int token_dim, int rank, uint32_t* buffer_flags, bool wait_for_results)

--- a/cpp/tensorrt_llm/kernels/communicationKernels/mnnvlTwoShotAllreduceKernels.cu
+++ b/cpp/tensorrt_llm/kernels/communicationKernels/mnnvlTwoShotAllreduceKernels.cu
@@ -27,6 +27,10 @@
 
 namespace tensorrt_llm::kernels::mnnvl
 {
+
+// Guard for internal helper functions
+namespace
+{
 __device__ bool isNegZero(float v)
 {
     return v == 0.f && signbit(v);
@@ -49,6 +53,12 @@ inline __device__ float toFloat<__nv_bfloat16>(__nv_bfloat16 val)
     return __bfloat162float(val);
 }
 
+template <>
+inline __device__ float toFloat<__nv_half>(__nv_half val)
+{
+    return __half2float(val);
+}
+
 template <typename T>
 inline __device__ T fromFloat(float val)
 {
@@ -61,18 +71,76 @@ inline __device__ __nv_bfloat16 fromFloat<__nv_bfloat16>(float val)
     return __float2bfloat16(val);
 }
 
-__device__ __inline__ float2 loadfloat2(void const* ptr)
+template <>
+inline __device__ __nv_half fromFloat<__nv_half>(float val)
 {
-
-    float return_value[2];
-
-    asm volatile("ld.volatile.global.v2.f32 {%0, %1}, [%2];\n"
-                 : "=f"(return_value[0]), "=f"(return_value[1])
-                 : "l"(ptr)
-                 : "memory");
-
-    return *(float2*) return_value;
+    return __float2half(val);
 }
+
+inline __device__ float2 loadfloat2(void const* ptr)
+{
+    float2 return_value;
+    asm volatile("ld.volatile.global.v2.f32 {%0, %1}, [%2];\n" : "=f"(return_value.x), "=f"(return_value.y) : "l"(ptr));
+    return return_value;
+}
+
+template <typename T>
+inline __device__ T divUp(T val, T divisor)
+{
+    return (val + divisor - 1) / divisor;
+}
+
+__device__ struct __attribute__((aligned(32))) LamportFlags
+{
+    uint32_t buffer_size;
+    uint32_t input_offset;
+    uint32_t clear_offset;
+    uint32_t num_tokens_prev;
+    uint32_t* offset_access_ptr;
+    uint32_t* buffer_flags;
+
+    __device__ explicit LamportFlags(uint32_t* buffer_flags)
+        : offset_access_ptr(&buffer_flags[4])
+        , buffer_flags(buffer_flags)
+    {
+        uint4 flag = reinterpret_cast<uint4*>(buffer_flags)[0];
+        buffer_size = flag.z;
+        input_offset = flag.x * (buffer_size << 1U);
+        clear_offset = flag.y * (buffer_size << 1U);
+        num_tokens_prev = flag.w;
+    }
+
+    __device__ void cta_arrive()
+    {
+        __syncthreads();
+        if (threadIdx.x == 0)
+        {
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000))
+            asm volatile("red.async.release.global.gpu.add.u32 [%0], %1;" ::"l"(offset_access_ptr), "r"(1) : "memory");
+#elif (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+            asm volatile("red.global.gpu.add.u32 [%0], %1;" ::"l"(offset_access_ptr), "r"(1) : "memory");
+#else
+            atomicAdd(offset_access_ptr, 1);
+#endif
+        }
+    }
+
+    __device__ void wait_and_update(uint32_t num_tokens)
+    {
+        if (threadIdx.x == 0 && blockIdx.x == gridDim.x - 1 && blockIdx.y == 0)
+        {
+            while (*reinterpret_cast<uint32_t volatile*>(offset_access_ptr) < gridDim.x * gridDim.y)
+            {
+            }
+            uint4 flag = reinterpret_cast<uint4*>(buffer_flags)[0];
+            buffer_flags[0] = (flag.x + 1) % 3;
+            buffer_flags[1] = (flag.y + 1) % 3;
+            buffer_flags[3] = num_tokens;
+            *(offset_access_ptr) = 0;
+        }
+    }
+};
+} // namespace
 
 template <int WORLD_SIZE, typename T>
 __global__ void twoshot_allreduce_kernel(T* output_ptr, T* shard_ptr, T** input_ptrs, T* mcast_ptr, int num_tokens,
@@ -87,19 +155,14 @@ __global__ void twoshot_allreduce_kernel(T* output_ptr, T* shard_ptr, T** input_
     cudaGridDependencySynchronize();
 #endif
 
-    // [input_ptr, clear_ptr, buffer_size, access_counter]
-    uint4 flag = reinterpret_cast<uint4*>(buffer_flags)[0];
-    // Each buffer is M * N and we have 2 buffers in each group, one for reduce-scatter and one for allgather
-    uint32_t buffer_group_size = flag.z << 1;
-    uint32_t input_offset = flag.x * buffer_group_size;
-    uint32_t clear_offset = flag.y * buffer_group_size;
-    // Capture the number of tokens from the last call so that we can properly clear the buffer
-    // The scatter stage will use the buffer in WORLD_SIZE granularity, thus we need to round up
-    uint32_t num_tokens_to_clear = flag.w > num_tokens ? flag.w : num_tokens;
-    num_tokens_to_clear = (num_tokens_to_clear + WORLD_SIZE - 1) / WORLD_SIZE * WORLD_SIZE;
-    uint32_t* offset_access_ptr = &buffer_flags[4];
+    LamportFlags flags(buffer_flags);
 
-    uint32_t clear_tokens_per_cta = (num_tokens_to_clear + gridDim.x - 1) / gridDim.x;
+    // Capture the number of tokens in previous iteration so that we can properly clear the buffer
+    // The scatter stage will use the buffer in WORLD_SIZE granularity, thus we need to round up
+    uint32_t clr_toks_cta
+        = divUp<uint32_t>(flags.num_tokens_prev > num_tokens ? flags.num_tokens_prev : num_tokens, WORLD_SIZE)
+        * WORLD_SIZE;
+    clr_toks_cta = divUp<uint32_t>(clr_toks_cta, gridDim.x);
 
     if (elt < token_dim)
     {
@@ -109,16 +172,17 @@ __global__ void twoshot_allreduce_kernel(T* output_ptr, T* shard_ptr, T** input_
         T val = shard_ptr[token * token_dim + elt];
         if (isNegZero(val))
             val = fromFloat<T>(0.f);
-        input_ptrs[dest_rank][input_offset + dest_token_offset * token_dim * WORLD_SIZE + rank * token_dim + elt] = val;
+        input_ptrs[dest_rank][flags.input_offset + dest_token_offset * token_dim * WORLD_SIZE + rank * token_dim + elt]
+            = val;
 
         // Clear the buffer used by the previous call. Note the number of tokens to clear could be larger than the
         // number of tokens in the current call.
-        for (int clr_tok = 0; clr_tok < clear_tokens_per_cta; clr_tok++)
+        for (int clr_tok = 0; clr_tok < clr_toks_cta; clr_tok++)
         {
             uint32_t clr_token_idx = token + clr_tok * gridDim.x;
             if (clr_token_idx < buffer_M)
             {
-                input_ptrs[rank][clear_offset + clr_token_idx * token_dim + elt] = fromFloat<T>(-0.f);
+                input_ptrs[rank][flags.clear_offset + clr_token_idx * token_dim + elt] = fromFloat<T>(-0.f);
             }
         }
 
@@ -134,7 +198,7 @@ __global__ void twoshot_allreduce_kernel(T* output_ptr, T* shard_ptr, T** input_
                 bool valid = true;
                 for (int r = 0; r < WORLD_SIZE; r++)
                 {
-                    T volatile* lamport_ptr = (T volatile*) &input_ptrs[rank][input_offset
+                    T volatile* lamport_ptr = (T volatile*) &input_ptrs[rank][flags.input_offset
                         + local_token * token_dim * WORLD_SIZE + r * token_dim + elt];
                     values[r] = *lamport_ptr;
                     valid &= !isNegZero(values[r]);
@@ -146,7 +210,7 @@ __global__ void twoshot_allreduce_kernel(T* output_ptr, T* shard_ptr, T** input_
             {
                 accum += toFloat<T>(values[r]);
             }
-            mcast_ptr[input_offset + buffer_M * token_dim + token * token_dim + elt] = fromFloat<T>(accum);
+            mcast_ptr[flags.input_offset + buffer_M * token_dim + token * token_dim + elt] = fromFloat<T>(accum);
         }
     }
 
@@ -155,12 +219,12 @@ __global__ void twoshot_allreduce_kernel(T* output_ptr, T* shard_ptr, T** input_
 #endif
 
     // Similarly clear broadcast buffer here
-    for (int clr_tok = 0; clr_tok < clear_tokens_per_cta; clr_tok++)
+    for (int clr_tok = 0; clr_tok < clr_toks_cta; clr_tok++)
     {
         uint32_t clr_token_idx = token + clr_tok * gridDim.x;
         if (clr_token_idx < buffer_M)
         {
-            input_ptrs[rank][clear_offset + buffer_M * token_dim + clr_token_idx * token_dim + elt]
+            input_ptrs[rank][flags.clear_offset + buffer_M * token_dim + clr_token_idx * token_dim + elt]
                 = fromFloat<T>(-0.f);
         }
     }
@@ -169,18 +233,8 @@ __global__ void twoshot_allreduce_kernel(T* output_ptr, T* shard_ptr, T** input_
     if (wait_for_results)
     {
         // Update the atomic counter to indicate the block has read the offsets
-        __syncthreads();
+        flags.cta_arrive();
 
-        if (threadIdx.x == 0)
-        {
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000))
-            asm volatile("red.async.release.global.gpu.add.u32 [%0], %1;" ::"l"(offset_access_ptr), "r"(1) : "memory");
-#elif (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-            asm volatile("red.global.gpu.add.u32 [%0], %1;" ::"l"(offset_access_ptr), "r"(1) : "memory");
-#else
-            atomicAdd(offset_access_ptr, 1);
-#endif
-        }
         // Only use a set of CTAs for lamport sync, reargange the grid
         constexpr int ELTS_PER_LOAD = sizeof(float2) / sizeof(T);
         // blockDim.x / ELTS_PER_LOAD should be at least the size of a warp (32)
@@ -188,7 +242,7 @@ __global__ void twoshot_allreduce_kernel(T* output_ptr, T* shard_ptr, T** input_
         {
             uint64_t current_pos = blockIdx.x * token_dim + blockIdx.y * blockDim.x + threadIdx.x * ELTS_PER_LOAD;
 
-            void* lamport_ptr = (void*) &input_ptrs[rank][input_offset + buffer_M * token_dim + current_pos];
+            void* lamport_ptr = (void*) &input_ptrs[rank][flags.input_offset + buffer_M * token_dim + current_pos];
             // We have 2 assumptions here:
             // 1. The write is atomic in 8B granularity -> Each buffer in the buffer group should be aligned to 8B
             // 2. The num_token * token_dim is divisible by ELTS_PER_LOAD (4 for BF16 and 2 for FP32)
@@ -204,18 +258,7 @@ __global__ void twoshot_allreduce_kernel(T* output_ptr, T* shard_ptr, T** input_
         }
 
         // Update the buffer flags
-        if (threadIdx.x == 0 && blockIdx.x == gridDim.x - 1 && blockIdx.y == 0)
-        {
-            // Make sure all blocks have finished reading the offsets, 2-D grid
-            while (*reinterpret_cast<uint32_t volatile*>(offset_access_ptr) < gridDim.x * gridDim.y)
-            {
-            }
-            buffer_flags[0] = (flag.x + 1) % 3;
-            buffer_flags[1] = (flag.y + 1) % 3;
-            // Update the flags with the number of tokens in the current call
-            buffer_flags[3] = num_tokens;
-            *(offset_access_ptr) = 0;
-        }
+        flags.wait_and_update(num_tokens);
     }
 }
 
@@ -281,12 +324,28 @@ void twoshot_allreduce_op(AllReduceParams const& params)
         default: TLLM_CHECK_WITH_INFO(false, "TwoShot AllReduce]: unsupported world_size.");
         }
     }
+    else if (dtype == nvinfer1::DataType::kHALF)
+    {
+        switch (world_size)
+        {
+        case 2: LAUNCH_ALL_REDUCE_KERNEL(2, __nv_half); break;
+        case 4: LAUNCH_ALL_REDUCE_KERNEL(4, __nv_half); break;
+        case 8: LAUNCH_ALL_REDUCE_KERNEL(8, __nv_half); break;
+        case 16: LAUNCH_ALL_REDUCE_KERNEL(16, __nv_half); break;
+        case 32: LAUNCH_ALL_REDUCE_KERNEL(32, __nv_half); break;
+        case 64: LAUNCH_ALL_REDUCE_KERNEL(64, __nv_half); break;
+        default: TLLM_CHECK_WITH_INFO(false, "TwoShot AllReduce]: unsupported world_size.");
+        }
+    }
     else
     {
         TLLM_CHECK_WITH_INFO(false, "TwoShot AllReduce]: unsupported dtype.");
     }
 }
 
+// Guard for internal helper functions
+namespace
+{
 template <typename T_IN>
 __device__ void copy_f4(T_IN* dst, T_IN const* src)
 {
@@ -338,14 +397,15 @@ inline __device__ float block_reduce_sum(float val)
 __device__ float4 loadfloat4(void const* ptr)
 {
 
-    float return_value[4];
+    float4 return_value;
 
     asm volatile("ld.volatile.global.v4.f32 {%0, %1, %2, %3}, [%4];\n"
-                 : "=f"(return_value[0]), "=f"(return_value[1]), "=f"(return_value[2]), "=f"(return_value[3])
+                 : "=f"(return_value.x), "=f"(return_value.y), "=f"(return_value.z), "=f"(return_value.w)
                  : "l"(ptr));
 
-    return *(float4*) return_value;
+    return return_value;
 }
+} // namespace
 
 template <int DIM, int NUM_THREADS, int NUM_INPUTS, typename T_OUT, typename T_IN>
 __global__ void __launch_bounds__(128, 1)
@@ -373,12 +433,8 @@ __global__ void __launch_bounds__(128, 1)
 
     int offsets[NUM_INPUTS][DIM / (1 * ELTS_PER_THREAD * NUM_THREADS)];
 
-    uint32_t* offset_access_ptr = &buffer_flags[4];
-    uint4 flag = reinterpret_cast<uint4*>(buffer_flags)[0];
-    // Buffer size is M * N, and we need two buffers for reduce-scatter and allgather
-    uint32_t buffer_size = flag.z;
-    uint32_t buffer_offset = flag.x * (buffer_size << 1);
-    T_IN const* input = &buffer_input[buffer_offset + buffer_size];
+    LamportFlags flags(buffer_flags);
+    T_IN const* input = &buffer_input[flags.input_offset + flags.buffer_size];
 
     cudaTriggerProgrammaticLaunchCompletion();
 
@@ -408,17 +464,7 @@ __global__ void __launch_bounds__(128, 1)
     }
 
     __pipeline_commit();
-    __syncthreads();
-    if (threadIdx.x == 0)
-    {
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000))
-        asm volatile("red.async.release.global.gpu.add.u32 [%0], %1;" ::"l"(offset_access_ptr), "r"(1) : "memory");
-#elif (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-        asm volatile("red.global.gpu.add.u32 [%0], %1;" ::"l"(offset_access_ptr), "r"(1) : "memory");
-#else
-        atomicAdd(offset_access_ptr, 1);
-#endif
-    }
+    flags.cta_arrive();
     // Load all inputs
     bool valid = false;
 
@@ -548,17 +594,7 @@ __global__ void __launch_bounds__(128, 1)
             = out4;
     }
     // Update the buffer pointers
-    if (threadIdx.x == 0 && blockIdx.x == 0 && blockIdx.y == 0)
-    {
-        // Make sure all blocks have finished accessing the buffer
-        while (*reinterpret_cast<uint32_t volatile*>(offset_access_ptr) < gridDim.x * gridDim.y)
-        {
-        }
-        buffer_flags[0] = (flag.x + 1) % 3;
-        buffer_flags[1] = (flag.y + 1) % 3;
-        buffer_flags[3] = batch_size;
-        *(offset_access_ptr) = 0;
-    }
+    flags.wait_and_update(batch_size);
 #endif
 }
 
@@ -569,8 +605,6 @@ void twoshot_rmsnorm(T* prenorm_output, T* normed_output, T const* input, T cons
 
     // input to rmsnorm is the buffer in the twoshot ar
     // We should use prenorm output to determine the actual used size
-    // int batch = normed_output.sizes()[0];
-    // int dim = normed_output.sizes()[1];
     float _epsilon{static_cast<float>(epsilon)};
 
     static constexpr int NUM_THREADS = 128;
@@ -630,6 +664,20 @@ void twoshot_rmsnorm_op(RMSNormParams const& params)
         // DeepSeek Hidden Dimension
         case 7168: LAUNCH_RMSNORM_KERNEL(__nv_bfloat16, 7168); break;
         case 8192: LAUNCH_RMSNORM_KERNEL(__nv_bfloat16, 8192); break;
+        default: TLLM_CHECK_WITH_INFO(false, "[MNNVL TwoShot RMSNorm]: unsupported hidden_dim.");
+        }
+    }
+    else if (dtype == nvinfer1::DataType::kHALF)
+    {
+        switch (params.hidden_dim)
+        {
+        case 2048: LAUNCH_RMSNORM_KERNEL(__nv_half, 2048); break;
+        case 4096: LAUNCH_RMSNORM_KERNEL(__nv_half, 4096); break;
+        // Llama-4 Hidden Dimension
+        case 5120: LAUNCH_RMSNORM_KERNEL(__nv_half, 5120); break;
+        // DeepSeek Hidden Dimension
+        case 7168: LAUNCH_RMSNORM_KERNEL(__nv_half, 7168); break;
+        case 8192: LAUNCH_RMSNORM_KERNEL(__nv_half, 8192); break;
         default: TLLM_CHECK_WITH_INFO(false, "[MNNVL TwoShot RMSNorm]: unsupported hidden_dim.");
         }
     }

--- a/tensorrt_llm/_torch/distributed/ops.py
+++ b/tensorrt_llm/_torch/distributed/ops.py
@@ -305,7 +305,7 @@ class MNNVLAllReduce(nn.Module):
 
     @staticmethod
     def get_supported_dtypes():
-        return (torch.bfloat16, torch.float32)
+        return (torch.float16, torch.bfloat16, torch.float32)
 
     def forward(
         self,

--- a/tensorrt_llm/_torch/distributed/ops.py
+++ b/tensorrt_llm/_torch/distributed/ops.py
@@ -88,8 +88,8 @@ def get_allreduce_mnnvl_workspace(
 
         # This is a buffer to maintain the state of this allreduce Op
         # Should have the same lifetime with self._buffer
-        # [Buffer_ptr, Clear_ptr, Buffer_size, atomic access counter]
-        buffer_flags = torch.tensor([0, 2, max_num_elements, 0],
+        # [Buffer_ptr, Clear_ptr, Buffer_size, num_tokens_to_clear,atomic access counter]
+        buffer_flags = torch.tensor([0, 2, max_num_elements, 0, 0],
                                     dtype=torch.uint32,
                                     device=torch.device("cuda",
                                                         mapping.local_rank))
@@ -458,6 +458,7 @@ class AllReduce(nn.Module):
                                          == False):
             return input
 
+        allreduce_strategy = self.strategy
         if all_reduce_params is None:
             all_reduce_params = AllReduceParams()
 
@@ -469,6 +470,9 @@ class AllReduce(nn.Module):
                 return mnnvl_output
 
         # Fall back to regular AllReduce if MNNVL is not available or not applicable
+        # Make sure the strategy is AUTO since allreduceOp does not have the branch for MNNVL
+        if allreduce_strategy == AllReduceStrategy.MNNVL:
+            allreduce_strategy = AllReduceStrategy.AUTO
         output = torch.ops.trtllm.allreduce(
             input=input,
             residual=all_reduce_params.residual,
@@ -477,7 +481,7 @@ class AllReduce(nn.Module):
             bias=all_reduce_params.bias,
             workspace=self.workspace,
             group=self.mapping.tp_group,
-            strategy=self.strategy,
+            strategy=allreduce_strategy,
             op=all_reduce_params.fusion_op,
             eps=all_reduce_params.eps,
             trigger_completion_at_end=all_reduce_params.

--- a/tests/unittest/_torch/multi_gpu/test_mnnvl_allreduce.py
+++ b/tests/unittest/_torch/multi_gpu/test_mnnvl_allreduce.py
@@ -158,21 +158,11 @@ def row_linear_residual_norm_fusion_forward(
 @pytest.mark.parametrize(
     "seq_len",
     [
-        [
-            1,
-        ],
-        [
-            4,
-        ],
-        [
-            15,
-        ],
-        [
-            32,
-        ],
-        [
-            128,
-        ],
+        [1],
+        [4],
+        [15],
+        [32],
+        [128],
         [31, 11, 27, 4],
     ],
     ids=lambda x: f"seqlen:{x}",

--- a/tests/unittest/_torch/multi_gpu/test_mnnvl_allreduce.py
+++ b/tests/unittest/_torch/multi_gpu/test_mnnvl_allreduce.py
@@ -47,21 +47,21 @@ def rms_norm(x: torch.Tensor, weight: torch.Tensor = None, eps: float = 1e-6):
 def run_single_rank(
     tensor_parallel_size,
     single_rank_forward_func,
-    input,
-    residual,
+    input_list,
+    residual_list,
     norm_weight,
     eps,
     hidden_size,
     dtype,
     fused_add_norm,
-    reference_output,
+    reference_output_list,
 ):
     rank = tensorrt_llm.mpi_rank()
     torch.cuda.set_device(rank)
     try:
         single_rank_forward_func(
-            input,
-            residual,
+            input_list,
+            residual_list,
             norm_weight,
             eps,
             hidden_size,
@@ -69,7 +69,7 @@ def run_single_rank(
             tensor_parallel_size,
             rank,
             fused_add_norm,
-            reference_output,
+            reference_output_list,
         )
     except Exception:
         traceback.print_exc()
@@ -79,8 +79,8 @@ def run_single_rank(
 
 @torch.inference_mode()
 def row_linear_residual_norm_fusion_forward(
-    x: torch.Tensor,
-    residual: torch.Tensor,
+    x_list: list[torch.Tensor],
+    residual_list: list[torch.Tensor],
     norm_weight: torch.Tensor,
     eps: float,
     hidden_size: int,
@@ -88,16 +88,21 @@ def row_linear_residual_norm_fusion_forward(
     tensor_parallel_size: int,
     tensor_parallel_rank: int,
     fusion: bool,
-    reference_output: tuple[torch.Tensor, ...],
+    reference_output_list: list[tuple[torch.Tensor, ...]],
 ):
 
-    x = x.cuda()
-    residual = residual.cuda()
+    # Move all tensors to GPU
+    x_list = [x.cuda() for x in x_list]
+    residual_list = [residual.cuda() for residual in residual_list]
     norm_weight = norm_weight.cuda()
-    reference_output = tuple(t.cuda() for t in reference_output)
+    reference_output_list = [
+        tuple(t.cuda() for t in ref_output)
+        for ref_output in reference_output_list
+    ]
 
     MPI.COMM_WORLD.barrier()
 
+    # Create a single AllReduce instance to be reused for all sequence lengths
     allreduce = AllReduce(
         mapping=Mapping(
             world_size=tensor_parallel_size,
@@ -119,72 +124,116 @@ def row_linear_residual_norm_fusion_forward(
                     residual=residual,
                     norm_weight=norm_weight,
                     eps=eps,
-                ))
+                ),
+            )
             return (output, residual)
         else:
             output = allreduce(input)
             return (output, )
 
-    output = func(x.clone(), residual.clone(), norm_weight, eps, fusion)
+    # Process each sequence length using the same AllReduce instance
+    for i, (x, residual, reference_output) in enumerate(
+            zip(x_list, residual_list, reference_output_list)):
+        output = func(x.clone(), residual.clone(), norm_weight, eps, fusion)
 
-    torch.testing.assert_close(
-        output[0],
-        reference_output[0],
-        rtol=0.05,
-        atol=0.15,
-    )
-
-    if fusion:
         torch.testing.assert_close(
-            output[1],
-            reference_output[1],
+            output[0],
+            reference_output[0],
             rtol=0.05,
             atol=0.15,
         )
+
+        if fusion:
+            torch.testing.assert_close(
+                output[1],
+                reference_output[1],
+                rtol=0.05,
+                atol=0.15,
+            )
 
 
 @skip_pre_blackwell
 @pytest.mark.skipif(torch.cuda.device_count() < 2,
                     reason="needs 2 GPUs to run this test")
-@pytest.mark.parametrize("seq_len", [1, 4, 32, 128],
-                         ids=lambda x: f"seqlen:{x}")
+@pytest.mark.parametrize(
+    "seq_len",
+    [
+        [
+            1,
+        ],
+        [
+            4,
+        ],
+        [
+            15,
+        ],
+        [
+            32,
+        ],
+        [
+            128,
+        ],
+        [31, 11, 27, 4],
+    ],
+    ids=lambda x: f"seqlen:{x}",
+)
 @pytest.mark.parametrize("hidden_size", [7168], ids=lambda x: f"hidden:{x}")
+@pytest.mark.parametrize("dtype",
+                         [torch.float16, torch.bfloat16, torch.float32],
+                         ids=lambda x: f"dtype:{torch.finfo(x).dtype}")
 @pytest.mark.parametrize(
     "fusion",
     [True, False],
     ids=["fusion", "no_fusion"],
 )
-def test_row_linear_residual_norm_fusion(seq_len, hidden_size, fusion):
+def test_row_linear_residual_norm_fusion(seq_len, hidden_size, dtype, fusion):
 
     torch.manual_seed(42)
-    dtype = torch.bfloat16
     tensor_parallel_size = 2
 
-    x = torch.randn((tensor_parallel_size, seq_len, hidden_size), dtype=dtype)
-    residual = torch.randn((seq_len, hidden_size), dtype=dtype)
+    # Create norm_weight once (same for all sequence lengths)
     norm_weight = torch.randn((hidden_size, ), dtype=dtype)
     eps = 1e-5
-    reference_output = (torch.sum(x, dim=0), )
-    if fusion:
-        residual_out = reference_output[0] + residual
-        reference_output = (rms_norm(residual_out.to(torch.float32),
-                                     norm_weight, eps).to(dtype), residual_out)
+
+    # Create lists of tensors for each sequence length
+    x_list = []
+    residual_list = []
+    reference_output_list = []
+
+    for seq_len_val in seq_len:
+        x = torch.randn((tensor_parallel_size, seq_len_val, hidden_size),
+                        dtype=dtype)
+        residual = torch.randn((seq_len_val, hidden_size), dtype=dtype)
+        reference_output = (torch.sum(x, dim=0), )
+        if fusion:
+            residual_out = reference_output[0] + residual
+            reference_output = (rms_norm(residual_out.to(torch.float32),
+                                         norm_weight,
+                                         eps).to(dtype), residual_out)
+
+        x_list.append(x)
+        residual_list.append(residual)
+        reference_output_list.append(reference_output)
 
     with MPIPoolExecutor(max_workers=tensor_parallel_size) as executor:
         results = executor.map(
             run_single_rank,
-            *zip(*[(
-                tensor_parallel_size,
-                row_linear_residual_norm_fusion_forward,
-                x[i, :, :],
-                residual,
-                norm_weight,
-                eps,
-                hidden_size,
-                dtype,
-                fusion,
-                reference_output,
-            ) for i in range(tensor_parallel_size)]),
+            *zip(*[
+                (
+                    tensor_parallel_size,
+                    row_linear_residual_norm_fusion_forward,
+                    [
+                        x[i, :, :] for x in x_list
+                    ],  # Extract the i-th rank's data from each sequence length
+                    residual_list,
+                    norm_weight,
+                    eps,
+                    hidden_size,
+                    dtype,
+                    fusion,
+                    reference_output_list,
+                ) for i in range(tensor_parallel_size)
+            ]),
         )
         for r in results:
             assert r is True


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for half-precision (float16) data type in distributed allreduce operations.
  * Extended tests and functionality to handle multiple sequence lengths simultaneously.

* **Bug Fixes**
  * Improved buffer clearing and flag management in distributed allreduce operations to prevent stale data from previous runs.
  * Enhanced synchronization and buffer management for more reliable distributed computation.

* **Chores**
  * Updated internal buffer state tracking to ensure accurate handling of varying token counts during distributed operations.
  * Expanded supported data types for distributed allreduce to include float16.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

tl;dr:

- Fix accuracy issue caused by lamport buffer clearing strategy.
- Fix fallback path issue when MNNVL is not applicable.
- Add FP16 support for MNNVL two-shot kernel.
- Enhance the coverage of the unittest for MNNVL twoshot kernel.

The MNNVL twoshot kernel employs three buffers for Lamport synchronization in a circular manner. For each kernel call, it clears the preceding buffer and utilizes the current buffer for communication. In practical scenarios, it is possible that the preceding call had a lower number of tokens compared to the current call, resulting in some elements remaining ambiguous and potentially leading to race conditions for subsequent calls.

This PR  addresses this issue by introducing an additional variable in the buffer flags, capturing the number of tokens in the preceding call. Consequently, the kernel will clear the buffer based on this variable rather than the current kernel grid.

Furthermore, this PR resolves an issue that arises when `allreduce_strategy` is set to `MNNVL` but the allreduce operation necessitates a fallback. The fallback path fails to acknowledge `MNNVL` as a valid strategy. Therefore, it is imperative to modify the strategy as well at the fallback level.


## Test Coverage

`pytest tests/unittest/_torch/multi_gpu/test_mnnvl_allreduce.py`

```
11.73s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[no_fusion-dtype:float32-hidden:7168-seqlen:[128]]
11.57s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[fusion-dtype:float32-hidden:7168-seqlen:[128]]
10.12s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[fusion-dtype:float16-hidden:7168-seqlen:[128]]
10.12s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[no_fusion-dtype:float16-hidden:7168-seqlen:[32]]
10.10s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[fusion-dtype:bfloat16-hidden:7168-seqlen:[31, 11, 27, 4]]
10.09s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[no_fusion-dtype:bfloat16-hidden:7168-seqlen:[31, 11, 27, 4]]
10.07s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[no_fusion-dtype:float16-hidden:7168-seqlen:[31, 11, 27, 4]]
10.06s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[no_fusion-dtype:bfloat16-hidden:7168-seqlen:[4]]
10.05s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[no_fusion-dtype:float16-hidden:7168-seqlen:[128]]
10.03s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[no_fusion-dtype:bfloat16-hidden:7168-seqlen:[128]]
10.02s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[no_fusion-dtype:float32-hidden:7168-seqlen:[32]]
10.02s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[fusion-dtype:float16-hidden:7168-seqlen:[15]]
10.02s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[fusion-dtype:float32-hidden:7168-seqlen:[1]]
10.01s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[fusion-dtype:float32-hidden:7168-seqlen:[4]]
10.01s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[fusion-dtype:bfloat16-hidden:7168-seqlen:[128]]
10.01s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[fusion-dtype:float16-hidden:7168-seqlen:[32]]
10.01s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[no_fusion-dtype:bfloat16-hidden:7168-seqlen:[1]]
10.01s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[fusion-dtype:float32-hidden:7168-seqlen:[15]]
10.00s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[fusion-dtype:bfloat16-hidden:7168-seqlen:[15]]
10.00s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[no_fusion-dtype:bfloat16-hidden:7168-seqlen:[15]]
10.00s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[no_fusion-dtype:float32-hidden:7168-seqlen:[15]]
10.00s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[no_fusion-dtype:float16-hidden:7168-seqlen:[1]]
9.98s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[fusion-dtype:bfloat16-hidden:7168-seqlen:[4]]
9.98s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[no_fusion-dtype:float32-hidden:7168-seqlen:[4]]
9.98s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[fusion-dtype:float32-hidden:7168-seqlen:[32]]
9.97s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[fusion-dtype:float16-hidden:7168-seqlen:[4]]
9.97s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[no_fusion-dtype:float16-hidden:7168-seqlen:[15]]
9.96s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[no_fusion-dtype:float32-hidden:7168-seqlen:[1]]
9.95s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[fusion-dtype:float16-hidden:7168-seqlen:[31, 11, 27, 4]]
9.93s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[no_fusion-dtype:bfloat16-hidden:7168-seqlen:[32]]
9.93s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[fusion-dtype:bfloat16-hidden:7168-seqlen:[32]]
9.90s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[fusion-dtype:bfloat16-hidden:7168-seqlen:[1]]
9.89s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[no_fusion-dtype:float16-hidden:7168-seqlen:[4]]
9.36s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[fusion-dtype:float32-hidden:7168-seqlen:[31, 11, 27, 4]]
9.29s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[no_fusion-dtype:float32-hidden:7168-seqlen:[31, 11, 27, 4]]
9.26s call     _torch/multi_gpu/test_mnnvl_allreduce.py::test_row_linear_residual_norm_fusion[fusion-dtype:float16-hidden:7168-seqlen:[1]]
```

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
