### PR TITLE
[PERF] Don't use hmac encryption for loopback interfaces

### DIFF
--- a/tensorrt_llm/executor/ipc.py
+++ b/tensorrt_llm/executor/ipc.py
@@ -17,7 +17,7 @@ from ..llmapi.utils import (ManagedThread, enable_llm_debug, print_colored,
                             print_colored_debug)
 
 
-def is_address_is_loopback(address: str) -> bool:
+def is_address_loopback(address: str) -> bool:
     """Check if the address represents a local/loopback connection."""
     # IPC and inproc are always local
     if address.startswith(("ipc://", "inproc://")):
@@ -66,7 +66,7 @@ class ZeroMqQueue:
         self.socket_type = socket_type
         self.address_endpoint = address[
             0] if address is not None else "tcp://127.0.0.1:*"
-        if is_address_is_loopback(self.address_endpoint):
+        if is_address_loopback(self.address_endpoint):
             use_hmac_encryption = False
         self.is_server = is_server
         self.context = zmq.Context() if not is_async else zmq.asyncio.Context()


### PR DESCRIPTION
## Description

In `class ZeroMqQueue` disable encryption for loopback interfaces. 

**The Reason**
For Qwen-2.5-3B-VL main process (that get requests, pre-process images, send request to worker) is bottleneck. Images preprocessing and sending takes more time than inference. 

`send` is around 35% from all time 
<img width="821" height="96" alt="image" src="https://github.com/user-attachments/assets/1413cf58-24f1-4861-974c-de0dd3229ca4" />

inside send we spend around half to sign image with `hmac`. 

I think we can avoid encryption for loopback interfaces

 
## Performance 
Tested Qwen-2.5-3B-VL model. H100. Images 512x512
Before image processing took **23ms** per image. 
After **17ms**
  
<img width="413" height="90" alt="image" src="https://github.com/user-attachments/assets/399ce310-3389-4cd5-9f41-beb45e5d57ea" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically disables encryption for local or loopback IPC connections to improve performance.
* **Bug Fixes**
  * Ensures correct detection of local addresses to apply appropriate security settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->