### PR TITLE
[https://nvbugs/5387771] fix deadlocks due to insufficient numSemaphores

### DIFF
--- a/cpp/tensorrt_llm/common/attentionOp.h
+++ b/cpp/tensorrt_llm/common/attentionOp.h
@@ -341,6 +341,11 @@ public:
 
     void debugCheckSemaphores(cudaStream_t stream);
 
+    [[nodiscard]] int getMultiProcessorCount() const
+    {
+        return mMultiProcessorCount;
+    }
+
     [[nodiscard]] std::string toString() const;
 
     int mLayerIdx = -1;

--- a/cpp/tensorrt_llm/thop/attentionOp.cpp
+++ b/cpp/tensorrt_llm/thop/attentionOp.cpp
@@ -101,7 +101,9 @@ public:
 
         // Always reserve SemaphoreArray (for multi-block mode) as MMHA may enable multi-block mode when shared memory
         // is not enough.
-        op.reserveSemaphoreArray(op.mNumHeads * max_num_requests);
+        // The attention kernel might split the heads into multiple blocks, so we might need to reserve more semaphores.
+        // Use mMultiProcessorCount as the lower-bound to make sure we reserve enough semaphores.
+        op.reserveSemaphoreArray(std::max(op.mNumHeads * max_num_requests, op.getMultiProcessorCount()));
     }
 
     int64_t getWorkspaceSize(AttentionOp const& op, int const num_tokens, int const max_attention_window_size,


### PR DESCRIPTION
this MR fixes the deadlocks due to insufficient numSemaphores (for the multi-block mode in attention kernels). The trtllm-gen kernels might split the head into multiple CTAs, so more semaphores are needed actually. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a way to retrieve the number of multiprocessors available for attention operations.

* **Bug Fixes**
  * Improved resource allocation for attention operations to better handle cases where computation is split across multiple processing units, enhancing stability and efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->