### PR TITLE
[feat] Add support to load fp8 Meta Llama4 weights

### DIFF
--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -269,6 +269,21 @@ class ModelConfig(Generic[TConfig]):
                     128,
                     128), "FP8_BLOCK_SCALES only supports block_size=(128,128)"
                 quant_config.group_size = block_size[0]
+            elif hf_quant_config.get(
+                    "quant_method"
+            ) == "compressed-tensors" and hf_quant_config.get(
+                    "format") == "float-quantized":
+                # Llama4 FP8 ckpt
+                quant_config.quant_algo = QuantAlgo.FP8_PER_CHANNEL_PER_TOKEN
+                exclude_modules = hf_quant_config.get("ignore", None)
+                exclude_modules = [
+                    s.removeprefix("language_model.") for s in exclude_modules
+                ]
+                exclude_modules = [
+                    s.replace("q_proj", "qkv_proj") for s in exclude_modules
+                ]
+                quant_config.exclude_modules = exclude_modules
+                quant_config.use_meta_recipe = True
 
         model_config = cls(pretrained_config=pretrained_config,
                            quant_config=quant_config,

--- a/tensorrt_llm/_torch/models/modeling_llama.py
+++ b/tensorrt_llm/_torch/models/modeling_llama.py
@@ -273,6 +273,7 @@ class Llama4MoE(nn.Module):
             overridden_tp_size=1 if self.enable_attention_dp else None,
             reduce_output=False)
 
+        weight_loading_mode = MoEWeightLoadingMode.META_FP8_RECIPE if model_config.quant_config.use_meta_recipe else MoEWeightLoadingMode.FUSED_GATE_UP_PROJ
         self.experts = create_moe(
             routing_method=Llama4RenormalizeMoeRoutingMethod(top_k),
             num_experts=num_experts,
@@ -281,7 +282,7 @@ class Llama4MoE(nn.Module):
             dtype=dtype,
             reduce_results=
             False,  # In both low latency and max-throughput scenarios, FusedMoE needs not to do allreduce inside op.
-            weight_loading_mode=MoEWeightLoadingMode.FUSED_GATE_UP_PROJ,
+            weight_loading_mode=weight_loading_mode,
             model_config=model_config,
             apply_router_weight_on_input=True,
             layer_idx=layer_idx)

--- a/tensorrt_llm/_torch/modules/fused_moe/interface.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/interface.py
@@ -12,6 +12,7 @@ from .routing import BaseMoeRoutingMethod
 class MoEWeightLoadingMode(Enum):
     VANILLA = 0
     FUSED_GATE_UP_PROJ = 1
+    META_FP8_RECIPE = 2
 
 
 class MoE(nn.Module):
@@ -109,6 +110,12 @@ class MoE(nn.Module):
     def has_fp8_qdq(self):
         assert self._weights_created
         return self.quant_config is not None and self.quant_config.layer_quant_mode.has_fp8_qdq(
+        )
+
+    @property
+    def has_fp8_rowwise(self):
+        assert self._weights_created
+        return self.quant_config is not None and self.quant_config.layer_quant_mode.has_fp8_rowwise(
         )
 
     @property

--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -100,6 +100,10 @@ class FusedMoEMethodBase(ABC):
                 w1_weight = weights[f"{expert_id}.w1.weight"]
                 w3_weight = weights[f"{expert_id}.w3.weight"]
                 w2_weight = weights[f"{expert_id}.w2.weight"]
+            elif weight_loading_mode == MoEWeightLoadingMode.META_FP8_RECIPE:
+                w1_weight = weights[f"{expert_id}.gate_proj.weight"]
+                w3_weight = weights[f"{expert_id}.up_proj.weight"]
+                w2_weight = weights[f"{expert_id}.down_proj.weight"]
             elif weight_loading_mode == MoEWeightLoadingMode.FUSED_GATE_UP_PROJ:
                 w1_w3_weight = weights["gate_up_proj"][expert_id].transpose(
                     0, 1)
@@ -364,6 +368,11 @@ class FP8QDQFusedMoEMethod(FusedMoEMethodBase):
                 w1_input_scale = weights[f"{expert_id}.w1.input_scale"]
                 w3_input_scale = weights[f"{expert_id}.w3.input_scale"]
                 w2_input_scale = weights[f"{expert_id}.w2.input_scale"]
+            elif module.weight_loading_mode == MoEWeightLoadingMode.META_FP8_RECIPE:
+                # HACK: dynamic quantization so no input scale - create empty tensors for testing
+                w1_input_scale = torch.tensor(1.0, dtype=torch.float32)
+                w3_input_scale = torch.tensor(1.0, dtype=torch.float32)
+                w2_input_scale = torch.tensor(1.0, dtype=torch.float32)
             elif module.weight_loading_mode == MoEWeightLoadingMode.FUSED_GATE_UP_PROJ:
                 w1_input_scale = weights[f"gate_up_proj_input_scale"]
                 w3_input_scale = weights[f"gate_up_proj_input_scale"]
@@ -397,6 +406,11 @@ class FP8QDQFusedMoEMethod(FusedMoEMethodBase):
                 w1_weight_scale = weights[f"{expert_id}.w1.weight_scale"]
                 w3_weight_scale = weights[f"{expert_id}.w3.weight_scale"]
                 w2_weight_scale = weights[f"{expert_id}.w2.weight_scale"]
+            elif module.weight_loading_mode == MoEWeightLoadingMode.META_FP8_RECIPE:
+                # HACK: weight scale is not the right shape in blockwise recipe - create empty tensors for testing
+                w1_weight_scale = torch.tensor(1.0, dtype=torch.float32)
+                w3_weight_scale = torch.tensor(1.0, dtype=torch.float32)
+                w2_weight_scale = torch.tensor(1.0, dtype=torch.float32)
             elif module.weight_loading_mode == MoEWeightLoadingMode.FUSED_GATE_UP_PROJ:
                 w1_weight_scale = weights[f"gate_up_proj_weight_scale"]
                 w3_weight_scale = weights[f"gate_up_proj_weight_scale"]

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -498,7 +498,8 @@ class FP8RowwiseLinearMethod(LinearMethodBase):
 
         scale_name = self._get_scale_name(weights)
         weight_scale = load_weight_shard(weights[0][scale_name], module.tp_size,
-                                         module.tp_rank, module.tp_mode)
+                                         module.tp_rank,
+                                         module.tp_mode).squeeze()
         copy_weight(module.weight_scale, weight_scale)
         if "input_scale" in weights[0]:
             copy_weight(module.input_scale, weights[0]["input_scale"])
@@ -533,7 +534,7 @@ class FP8RowwiseLinearMethod(LinearMethodBase):
                                        module.tp_rank, module.tp_mode)
         right_scale = load_weight_shard(weights[1][scale_name], module.tp_size,
                                         module.tp_rank, module.tp_mode)
-        fused_scale = torch.cat((left_scale, right_scale))
+        fused_scale = torch.cat((left_scale, right_scale)).squeeze()
         copy_weight(module.weight_scale, fused_scale)
 
 

--- a/tensorrt_llm/llmapi/llm_utils.py
+++ b/tensorrt_llm/llmapi/llm_utils.py
@@ -426,6 +426,12 @@ class ModelLoader:
                             "weight_block_size"):
                     quant_config.quant_algo = QuantAlgo.FP8_BLOCK_SCALES
                     quant_config.exclude_modules = ["*eh_proj"]
+                elif hf_quant_config.get(
+                        "quant_method"
+                ) == "compressed-tensors" and hf_quant_config.get(
+                        "format") == "float-quantized":
+                    # Llama4 FP8 ckpt
+                    quant_config.quant_algo = QuantAlgo.FP8_PER_CHANNEL_PER_TOKEN
                 else:
                     raise NotImplementedError(
                         f"Unsupported quantization_config: {hf_quant_config}.")


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a new quantization mode ("compressed-tensors" with "float-quantized" format) for model loading and configuration.
  * Introduced a new weight loading mode for expert weights in MoE models, enhancing compatibility with FP8 quantization recipes.
  * Enabled recognition and handling of FP8 row-wise quantization in relevant modules.

* **Bug Fixes**
  * Improved tensor shape handling when loading weight scales to ensure correct dimensions.

* **Refactor**
  * Updated logic to accommodate new quantization modes and weight loading behaviors without altering user-facing APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[feat] Add support to load fp8 Meta Llama4 weights

## Description

TODO

## Test Coverage

TODO

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
