### PR TITLE
Update allreduce benchmark for torch

### DIFF
--- a/tests/microbenchmarks/all_reduce.py
+++ b/tests/microbenchmarks/all_reduce.py
@@ -18,21 +18,21 @@ from argparse import ArgumentParser
 # isort: off
 import torch
 # isort: on
-from cuda import cuda, cudart
+from cuda import cudart
 
 import tensorrt_llm as tllm
-from tensorrt_llm import Mapping, Tensor
+from tensorrt_llm import Mapping
+from tensorrt_llm._torch.distributed import AllReduce, AllReduceFusionOp
+from tensorrt_llm._torch.modules.rms_norm import RMSNorm
 from tensorrt_llm._utils import local_mpi_rank, local_mpi_size
-from tensorrt_llm.functional import (AllReduceParams, AllReduceStrategy,
-                                     allreduce)
-from tensorrt_llm.plugin.plugin import (current_all_reduce_helper,
-                                        init_all_reduce_helper)
-from tensorrt_llm.runtime import Session
+from tensorrt_llm.bindings.internal.runtime import delay_kernel
+from tensorrt_llm.functional import AllReduceParams, AllReduceStrategy
 
 
 def allreduce_benchmark(dtype: str,
-                        test_range: str = "10,10000000,10",
-                        no_header: bool = False):
+                        test_range: str = "1,10000000,10",
+                        no_header: bool = False,
+                        enable_cudagraph: bool = False):
     tllm.logger.set_level('error')
     world_size = tllm.mpi_world_size()
     rank = tllm.mpi_rank()
@@ -49,80 +49,120 @@ def allreduce_benchmark(dtype: str,
 
     torch_dtype = tllm._utils.str_dtype_to_torch(dtype)
     min_size, max_size, ratio = [int(i) for i in test_range.split(",")]
-    inner_loop = 1000
+    inner_loop = 1200
+    outer_loop = 10
 
     size = min_size
-    dtype_size = torch.finfo(torch_dtype).bits // 8
+    hidden_size = size
+    bs = 1
     if mapping.rank == 0 and not no_header:
         print(
-            f"{'world_size':<15}, {'dtype':<10}, {'message size':<15}, {'strategy':<15}, {'duration (ms)':<10}"
+            f"{'world_size':<15}, {'dtype':<10}, {'message size':<15}, {'strategy':<10}, {'fusion':<20}, {'version':<10}, {'duration (ms)':<10}"
         )
     while size < max_size:
-        input = torch.ones(size, dtype=torch_dtype, device="cuda")
+        input = torch.ones((bs, hidden_size), dtype=torch_dtype, device="cuda")
 
-        for strategy in [
-                AllReduceStrategy.AUTO,
-                AllReduceStrategy.NCCL,
-                AllReduceStrategy.ONESHOT,
-                AllReduceStrategy.TWOSHOT,
-        ]:
-            builder = tllm.Builder()
-            net = builder.create_network()
-            net.plugin_config.set_nccl_plugin(dtype)
-            init_all_reduce_helper()
-            _buffers, workspace = current_all_reduce_helper(
-            ).allocate_workspace(mapping, size * dtype_size)
+        for version in ["v1"]:
+            for fusion in [
+                    AllReduceFusionOp.RESIDUAL_RMS_NORM, AllReduceFusionOp.NONE
+            ]:
+                for strategy in [
+                        AllReduceStrategy.NCCL,
+                        AllReduceStrategy.ONESHOT,
+                        AllReduceStrategy.TWOSHOT,
+                ]:
+                    if size >= 25600000 and fusion != AllReduceFusionOp.NONE:
+                        continue
+                    allreduce = AllReduce(mapping=mapping, strategy=strategy)
+                    if fusion == AllReduceFusionOp.RESIDUAL_RMS_NORM:
+                        norm_weight = torch.randn((hidden_size, ),
+                                                  dtype=torch_dtype,
+                                                  device="cuda")
+                        norm = RMSNorm(hidden_size=hidden_size,
+                                       dtype=torch_dtype,
+                                       eps=1e-5).cuda()
+                        norm.weight.data.copy_(norm_weight)
+                        if version == "v1":
+                            params = {
+                                "all_reduce_params":
+                                AllReduceParams(fusion_op=fusion,
+                                                residual=input,
+                                                norm_weight=norm.weight,
+                                                eps=norm.variance_epsilon)
+                            }
+                        else:
+                            params = {
+                                "reduce_fusion_inputs": [input, norm.weight],
+                                "eps": norm.variance_epsilon,
+                                "fusion_op": fusion
+                            }
+                    else:
+                        if version == "v1":
+                            params = {
+                                "all_reduce_params":
+                                AllReduceParams(fusion_op=fusion)
+                            }
+                        else:
+                            continue
 
-            with tllm.net_guard(net):
-                tllm.default_trtnet()
+                    def func(input):
+                        for _ in range(inner_loop):
+                            input = allreduce(input, **params)
+                            if fusion == AllReduceFusionOp.RESIDUAL_RMS_NORM:
+                                input = input[0]
+                        return input
 
-                x = Tensor(name='x',
-                           shape=input.shape,
-                           dtype=tllm.str_dtype_to_trt(dtype))
+                    start = [
+                        torch.cuda.Event(enable_timing=True)
+                        for _ in range(outer_loop)
+                    ]
+                    stop = [
+                        torch.cuda.Event(enable_timing=True)
+                        for _ in range(outer_loop)
+                    ]
+                    graph = torch.cuda.CUDAGraph()
 
-                current_all_reduce_helper().set_workspace_tensor(mapping)
+                    stream = torch.cuda.Stream()
+                    with torch.cuda.stream(stream):
+                        if enable_cudagraph:
+                            for _ in range(2):
+                                func(input)
+                            with torch.cuda.graph(graph, stream=stream):
+                                output = func(input)
+                        tllm.mpi_barrier()
+                        delay_kernel(2000000, stream)
+                        torch.cuda.profiler.start()
+                        for i in range(outer_loop):
+                            start[i].record(stream)
+                            if enable_cudagraph:
+                                graph.replay()
+                            else:
+                                output = func(input)
+                            stop[i].record(stream)
 
-                current = x
-                for _ in range(inner_loop):
-                    current = allreduce(
-                        current,
-                        mapping.tp_group,
-                        all_reduce_params=AllReduceParams(strategy=strategy))
-                current.mark_output('output', dtype)
-            feed_dict = {'x': input, 'all_reduce_workspace': workspace}
-            builder_config = builder.create_builder_config(precision=dtype)
-            engine = builder.build_engine(net, builder_config)
-            assert engine is not None, "Failed to build engine"
-            session = Session.from_serialized_engine(engine)
+                    torch.cuda.synchronize()
+                    torch.cuda.profiler.stop()
+                    runtimes = [
+                        start[i].elapsed_time(stop[i])
+                        for i in range(outer_loop)
+                    ]
+                    median_ms = sorted(runtimes)[len(runtimes) // 2]
 
-            _, start = cuda.cuEventCreate(0)
-            _, stop = cuda.cuEventCreate(0)
-            runtimes = []
+                    if fusion == AllReduceFusionOp.NONE:
+                        allreduce_ref = (input * world_size)**inner_loop
+                        torch.testing.assert_close(output, allreduce_ref)
 
-            tllm.mpi_barrier()
-            output = torch.empty(input.shape, dtype=torch_dtype, device='cuda')
-            stream = torch.cuda.current_stream()
-            for _ in range(10):
-                cuda.cuEventRecord(start, stream.cuda_stream)
-                session.run(inputs=feed_dict,
-                            outputs={"output": output},
-                            stream=stream.cuda_stream)
-                cuda.cuEventRecord(stop, stream.cuda_stream)
-                torch.cuda.synchronize()
-                _, ms = cuda.cuEventElapsedTime(start, stop)
-                runtimes.append(ms)
-
-            median_ms = sorted(runtimes)[len(runtimes) // 2]
-
-            allreduce_ref = (input * world_size)**inner_loop
-            assert torch.allclose(output, allreduce_ref)
-
-            if mapping.rank == 0:
-                print(
-                    f"{mapping.world_size:<15}, {dtype:<10}, {size:<15}, {strategy.name:<15}, {median_ms:<10.2f}"
-                )
+                    if mapping.rank == 0:
+                        print(
+                            f"{mapping.world_size:<15}, {dtype:<10}, {size:<15}, {strategy.name:<10}, {fusion.name:<20}, {version:<10}, {median_ms:<10.2f}"
+                        )
 
         size *= ratio
+        if hidden_size * ratio > 4096:
+            bs *= ratio
+        else:
+            hidden_size *= ratio
+        assert size == bs * hidden_size
 
 
 if __name__ == "__main__":
@@ -134,6 +174,8 @@ if __name__ == "__main__":
         default="256,256000000,10",  # 256 to 256M
         help="min_size,max_size,multiplicative_ratio")
     parser.add_argument("--no-header", action="store_true")
+    parser.add_argument("--enable-cudagraph", action="store_true")
     args = parser.parse_args()
 
-    allreduce_benchmark(args.dtype, args.range, args.no_header)
+    allreduce_benchmark(args.dtype, args.range, args.no_header,
+                        args.enable_cudagraph)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined and restructured the all-reduce benchmark script for improved clarity and flexibility.
  * Updated input tensor handling to support dynamic batch and hidden sizes.
  * Enhanced timing accuracy with CUDA events, optional CUDA graph support, and profiler integration.
  * Output now includes detailed columns for fusion mode and version.

* **New Features**
  * Added benchmarking for fused all-reduce with residual RMS normalization.
  * Introduced command-line option to enable or disable CUDA graph usage.

* **Bug Fixes**
  * Improved validation of output correctness for non-fused cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

[JIRA ticket/NVBugs ID/GitHub issue][fix/feat/doc/infra/...] \<summary of this PR\>

For example, assume I have a PR to support a new feature about cache manager for JIRA ticket TRTLLM-1000, it would be like:

[TRTLLM-1000][feat] Support a new feature about cache manager

Or I have a PR to fix a Llama3 accuracy issue:

[https://nvbugs/1234567][fix] Fix Llama3 accuracy issue
-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
