### PR TITLE
[None][chore] upgrade mpi4py to 4.0.0

### DIFF
--- a/docker/common/install_mpi4py.sh
+++ b/docker/common/install_mpi4py.sh
@@ -7,7 +7,7 @@ if [ -n "${GITHUB_MIRROR}" ]; then
     GITHUB_URL=${GITHUB_MIRROR}
 fi
 
-MPI4PY_VERSION="3.1.5"
+MPI4PY_VERSION="4.0.0"
 RELEASE_URL="${GITHUB_URL}/mpi4py/mpi4py/archive/refs/tags/${MPI4PY_VERSION}.tar.gz"
 
 # Create and use a temporary directory
@@ -18,55 +18,56 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 curl -L ${RELEASE_URL} | tar -zx -C "$TMP_DIR"
 
 # Bypassing compatibility issues with higher versions (>= 69) of setuptools.
-sed -i 's/>= 40\.9\.0/>= 40.9.0, < 69/g' "$TMP_DIR/mpi4py-${MPI4PY_VERSION}/pyproject.toml"
+# sed -i 's/>= 40\.9\.0/>= 40.9.0, < 69/g' "$TMP_DIR/mpi4py-${MPI4PY_VERSION}/pyproject.toml"
 
 # Apply the patch
 cd "$TMP_DIR/mpi4py-${MPI4PY_VERSION}"
 git apply <<EOF
-diff --git a/src/mpi4py/futures/_lib.py b/src/mpi4py/futures/_lib.py
-index f14934d1..eebfb8fc 100644
---- a/src/mpi4py/futures/_lib.py
-+++ b/src/mpi4py/futures/_lib.py
-@@ -278,6 +278,40 @@ def _manager_comm(pool, options, comm, full=True):
-
-
- def _manager_split(pool, options, comm, root):
-+    if(os.getenv("TRTLLM_USE_MPI_KVCACHE")=="1"):
-+        from cuda import cudart
-+        has_slurm_rank=False
-+        has_ompi_rank=False
-+        slurm_rank=0
-+        ompi_rank=0
-+        if(os.getenv("SLURM_PROCID")):
-+            slurm_rank = int(os.environ["SLURM_PROCID"])
-+            has_slurm_rank=True
-+        elif(os.getenv("OMPI_COMM_WORLD_RANK")):
-+            ompi_rank = int(os.environ["OMPI_COMM_WORLD_RANK"])
-+            has_ompi_rank=True
-+        else:
-+            raise RuntimeError("No SLURM_PROCID or OMPI_COMM_WORLD_RANK environment variable found When TRTLLM_USE_MPI_KVCACHE is set to 1")
-+        if(has_slurm_rank and has_ompi_rank):
-+            if(slurm_rank>0 and ompi_rank>0):
-+                raise RuntimeError("Only one of SLURM_PROCID or OMPI_COMM_WORLD_RANK should >0 when TRTLLM_USE_MPI_KVCACHE is set to 1")
-+            else:
-+                rank=slurm_rank if slurm_rank>0 else ompi_rank
-+        else:
-+            rank = ompi_rank if has_ompi_rank else slurm_rank
+diff --git a/src/mpi4py/futures/_core.py b/src/mpi4py/futures/_core.py
+index 0e536948..191a65ec 100644
+--- a/src/mpi4py/futures/_core.py
++++ b/src/mpi4py/futures/_core.py
+@@ -534,6 +534,41 @@ def _comm_executor_helper(executor, comm, root):
+             set_comm_server(MPI.COMM_SELF)
+             _manager_thread(pool, options)
+             return
++        if(os.getenv("TRTLLM_USE_MPI_KVCACHE")=="1"):
++            from cuda import cudart
++            has_slurm_rank=False
++            has_ompi_rank=False
++            slurm_rank=0
++            ompi_rank=0
++           if(os.getenv("SLURM_PROCID")):
++               slurm_rank = int(os.environ["SLURM_PROCID"])
++               has_slurm_rank=True
++           elif(os.getenv("OMPI_COMM_WORLD_RANK")):
++               ompi_rank = int(os.environ["OMPI_COMM_WORLD_RANK"])
++               has_ompi_rank=True
++           else:
++               raise RuntimeError("No SLURM_PROCID or OMPI_COMM_WORLD_RANK environment variable found When TRTLLM_USE_MPI_KVCACHE is set to 1")
++           if(has_slurm_rank and has_ompi_rank):
++               if(slurm_rank>0 and ompi_rank>0):
++                   raise RuntimeError("Only one of SLURM_PROCID or OMPI_COMM_WORLD_RANK should >0 when TRTLLM_USE_MPI_KVCACHE is set to 1")
++               else:
++                   rank=slurm_rank if slurm_rank>0 else ompi_rank
++           else:
++               rank = ompi_rank if has_ompi_rank else slurm_rank
 +
-+        def CUASSERT(cuda_ret):
-+            err = cuda_ret[0]
-+            if err != cudart.cudaError_t.cudaSuccess:
-+                raise RuntimeError(
-+                    f"CUDA ERROR: {err}, error code reference: https://nvidia.github.io/cuda-python/module/cudart.html#cuda.cudart.cudaError_t"
-+                )
-+            if len(cuda_ret) > 1:
-+                return cuda_ret[1:]
-+            return None
-+        device_count = CUASSERT(cudart.cudaGetDeviceCount())[0]
-+        CUASSERT(cudart.cudaSetDevice(rank%device_count))
-+        print(f"rank: {rank},set  device: {CUASSERT(cudart.cudaGetDevice())[0]} in mpi4py _manager_split")
-     comm = serialized(comm_split)(comm, root)
-     _manager_comm(pool, options, comm, full=False)
++           def CUASSERT(cuda_ret):
++               err = cuda_ret[0]
++               if err != cudart.cudaError_t.cudaSuccess:
++                   raise RuntimeError(
++                       f"CUDA ERROR: {err}, error code reference: https://nvidia.github.io/cuda-python/module/cudart.html#cuda.cudart.cudaError_t"
++                   )
++               if len(cuda_ret) > 1:
++                   return cuda_ret[1:]
++               return None
++           device_count = CUASSERT(cudart.cudaGetDeviceCount())[0]
++           CUASSERT(cudart.cudaSetDevice(rank%device_count))
++           print(f"rank: {rank},set  device: {CUASSERT(cudart.cudaGetDevice())[0]} in mpi4py _manager_split")
++
+         comm, _ = serialized(comm_split)(comm, root)
+         _manager_comm(pool, options, comm, sync=False)
 
 EOF
 

--- a/docker/common/install_mpi4py.sh
+++ b/docker/common/install_mpi4py.sh
@@ -34,34 +34,34 @@ index 0e536948..191a65ec 100644
 +            has_ompi_rank=False
 +            slurm_rank=0
 +            ompi_rank=0
-+           if(os.getenv("SLURM_PROCID")):
-+               slurm_rank = int(os.environ["SLURM_PROCID"])
-+               has_slurm_rank=True
-+           elif(os.getenv("OMPI_COMM_WORLD_RANK")):
-+               ompi_rank = int(os.environ["OMPI_COMM_WORLD_RANK"])
-+               has_ompi_rank=True
-+           else:
-+               raise RuntimeError("No SLURM_PROCID or OMPI_COMM_WORLD_RANK environment variable found When TRTLLM_USE_MPI_KVCACHE is set to 1")
-+           if(has_slurm_rank and has_ompi_rank):
-+               if(slurm_rank>0 and ompi_rank>0):
-+                   raise RuntimeError("Only one of SLURM_PROCID or OMPI_COMM_WORLD_RANK should >0 when TRTLLM_USE_MPI_KVCACHE is set to 1")
-+               else:
-+                   rank=slurm_rank if slurm_rank>0 else ompi_rank
-+           else:
-+               rank = ompi_rank if has_ompi_rank else slurm_rank
++            if(os.getenv("SLURM_PROCID")):
++                slurm_rank = int(os.environ["SLURM_PROCID"])
++                has_slurm_rank=True
++            elif(os.getenv("OMPI_COMM_WORLD_RANK")):
++                ompi_rank = int(os.environ["OMPI_COMM_WORLD_RANK"])
++                has_ompi_rank=True
++            else:
++                raise RuntimeError("No SLURM_PROCID or OMPI_COMM_WORLD_RANK environment variable found When TRTLLM_USE_MPI_KVCACHE is set to 1")
++            if(has_slurm_rank and has_ompi_rank):
++                if(slurm_rank>0 and ompi_rank>0):
++                    raise RuntimeError("Only one of SLURM_PROCID or OMPI_COMM_WORLD_RANK should >0 when TRTLLM_USE_MPI_KVCACHE is set to 1")
++                else:
++                    rank=slurm_rank if slurm_rank>0 else ompi_rank
++            else:
++                rank = ompi_rank if has_ompi_rank else slurm_rank
 +
-+           def CUASSERT(cuda_ret):
-+               err = cuda_ret[0]
-+               if err != cudart.cudaError_t.cudaSuccess:
-+                   raise RuntimeError(
-+                       f"CUDA ERROR: {err}, error code reference: https://nvidia.github.io/cuda-python/module/cudart.html#cuda.cudart.cudaError_t"
-+                   )
-+               if len(cuda_ret) > 1:
-+                   return cuda_ret[1:]
-+               return None
-+           device_count = CUASSERT(cudart.cudaGetDeviceCount())[0]
-+           CUASSERT(cudart.cudaSetDevice(rank%device_count))
-+           print(f"rank: {rank},set  device: {CUASSERT(cudart.cudaGetDevice())[0]} in mpi4py _manager_split")
++            def CUASSERT(cuda_ret):
++                err = cuda_ret[0]
++                if err != cudart.cudaError_t.cudaSuccess:
++                    raise RuntimeError(
++                        f"CUDA ERROR: {err}, error code reference: https://nvidia.github.io/cuda-python/module/cudart.html#cuda.cudart.cudaError_t"
++                    )
++                if len(cuda_ret) > 1:
++                    return cuda_ret[1:]
++                return None
++            device_count = CUASSERT(cudart.cudaGetDeviceCount())[0]
++            CUASSERT(cudart.cudaSetDevice(rank%device_count))
++            print(f"rank: {rank},set  device: {CUASSERT(cudart.cudaGetDevice())[0]} in mpi4py _manager_split")
 +
          comm, _ = serialized(comm_split)(comm, root)
          _manager_comm(pool, options, comm, sync=False)

--- a/docker/common/install_mpi4py.sh
+++ b/docker/common/install_mpi4py.sh
@@ -17,9 +17,6 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 # Download and extract in one step
 curl -L ${RELEASE_URL} | tar -zx -C "$TMP_DIR"
 
-# Bypassing compatibility issues with higher versions (>= 69) of setuptools.
-# sed -i 's/>= 40\.9\.0/>= 40.9.0, < 69/g' "$TMP_DIR/mpi4py-${MPI4PY_VERSION}/pyproject.toml"
-
 # Apply the patch
 cd "$TMP_DIR/mpi4py-${MPI4PY_VERSION}"
 git apply <<EOF

--- a/jenkins/current_image_tags.properties
+++ b/jenkins/current_image_tags.properties
@@ -11,7 +11,7 @@
 #
 # NB: Typically, the suffix indicates the PR whose CI pipeline generated the images. In case that
 #     images are adopted from PostMerge pipelines, the abbreviated commit hash is used instead.
-LLM_DOCKER_IMAGE=urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:pytorch-25.06-py3-x86_64-ubuntu24.04-trt10.11.0.33-skip-tritondevel-202507251001-5678
-LLM_SBSA_DOCKER_IMAGE=urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:pytorch-25.06-py3-aarch64-ubuntu24.04-trt10.11.0.33-skip-tritondevel-202507251001-5678
-LLM_ROCKYLINUX8_PY310_DOCKER_IMAGE=urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:cuda-12.9.1-devel-rocky8-x86_64-rocky8-py310-trt10.11.0.33-skip-tritondevel-202507251001-5678
-LLM_ROCKYLINUX8_PY312_DOCKER_IMAGE=urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:cuda-12.9.1-devel-rocky8-x86_64-rocky8-py312-trt10.11.0.33-skip-tritondevel-202507251001-5678
+LLM_DOCKER_IMAGE=urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm-staging/tritondevel:x86_64-tritondevel-torch_skip-ac59174-github-pr-6305-592
+LLM_SBSA_DOCKER_IMAGE= urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm-staging/tritondevel:sbsa-tritondevel-torch_skip-ac59174-github-pr-6305-592
+LLM_ROCKYLINUX8_PY310_DOCKER_IMAGE=urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm-staging/tritondevel:x86_64-rockylinux8-torch_skip-py310-ac59174-github-pr-6305-592
+LLM_ROCKYLINUX8_PY312_DOCKER_IMAGE=urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm-staging/tritondevel:x86_64-rockylinux8-torch_skip-py312-ac59174-github-pr-6305-592

--- a/jenkins/current_image_tags.properties
+++ b/jenkins/current_image_tags.properties
@@ -12,6 +12,6 @@
 # NB: Typically, the suffix indicates the PR whose CI pipeline generated the images. In case that
 #     images are adopted from PostMerge pipelines, the abbreviated commit hash is used instead.
 LLM_DOCKER_IMAGE=urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm-staging/tritondevel:x86_64-tritondevel-torch_skip-ac59174-github-pr-6305-592
-LLM_SBSA_DOCKER_IMAGE= urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm-staging/tritondevel:sbsa-tritondevel-torch_skip-ac59174-github-pr-6305-592
+LLM_SBSA_DOCKER_IMAGE=urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm-staging/tritondevel:sbsa-tritondevel-torch_skip-ac59174-github-pr-6305-592
 LLM_ROCKYLINUX8_PY310_DOCKER_IMAGE=urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm-staging/tritondevel:x86_64-rockylinux8-torch_skip-py310-ac59174-github-pr-6305-592
 LLM_ROCKYLINUX8_PY312_DOCKER_IMAGE=urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm-staging/tritondevel:x86_64-rockylinux8-torch_skip-py312-ac59174-github-pr-6305-592

--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -100,6 +100,4 @@ def mpi_pool_executor(request):
     """
     num_workers = request.param
     with MPIPoolExecutor(num_workers) as executor:
-        # make the number of workers visible to tests
-        setattr(executor, "num_workers", num_workers)
         yield executor


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated mpi4py to version 4.0.0 for improved compatibility.
  * Enhanced CUDA device selection logic for MPI environments when a specific environment variable is set.
  * Improved error handling and debugging output for CUDA device assignment in distributed setups.
  * Updated Docker image tags for LLM-related builds with a new repository path and simplified tag format.
* **Tests**
  * Simplified test setup by removing an unused attribute from the MPI pool executor fixture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

chore: upgrade mpi4py to 4.0.0

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
