### PR TITLE
doc: fix invalid links related with llm api example

### DIFF
--- a/docs/source/torch.md
+++ b/docs/source/torch.md
@@ -13,7 +13,7 @@ The PyTorch backend of TensorRT-LLM is available in version 0.17 and later. You 
 
 Here is a simple example to show how to use `tensorrt_llm.LLM` API with Llama model.
 
-```{literalinclude} ../../examples/pytorch/quickstart.py
+```{literalinclude} ../../examples/llm-api/quickstart_example.py
     :language: python
     :linenos:
 ```

--- a/examples/models/core/deepseek_v3/README.md
+++ b/examples/models/core/deepseek_v3/README.md
@@ -77,7 +77,7 @@ git clone https://huggingface.co/deepseek-ai/DeepSeek-V3 <YOUR_MODEL_DIR>
 ## Quick Start
 
 ### Run a single inference
-To quickly run DeepSeek-V3, [examples/llm-api/quickstart_advanced.py](../pytorch/quickstart_advanced.py):
+To quickly run DeepSeek-V3, [examples/llm-api/quickstart_advanced.py](../llm-api/quickstart_advanced.py):
 
 ```bash
 cd examples/llm-api
@@ -94,7 +94,7 @@ Prompt: 'The future of AI is', Generated text: ' a topic of great interest and s
 ```
 
 ### Multi-Token Prediction (MTP)
-To run with MTP, use [examples/llm-api/quickstart_advanced.py](../pytorch/quickstart_advanced.py) with additional options, see
+To run with MTP, use [examples/llm-api/quickstart_advanced.py](../../../llm-api/quickstart_advanced.py) with additional options, see
 ```bash
 cd examples/llm-api
 python quickstart_advanced.py --model_dir <YOUR_MODEL_DIR> --spec_decode_algo MTP --spec_decode_max_draft_len N

--- a/examples/models/core/qwen/README.md
+++ b/examples/models/core/qwen/README.md
@@ -624,7 +624,7 @@ git clone https://huggingface.co/Qwen/Qwen3-30B-A3B <YOUR_MODEL_DIR>
 
 #### Run a single inference
 
-To quickly run Qwen3, [examples/llm-api/quickstart_advanced.py](../../../pytorch/quickstart_advanced.py):
+To quickly run Qwen3, [examples/llm-api/quickstart_advanced.py](../../../llm-api/quickstart_advanced.py):
 
 ```bash
 python3 examples/llm-api/quickstart_advanced.py --model_dir Qwen3-30B-A3B/ --kv_cache_fraction 0.6


### PR DESCRIPTION
Fix the [issue](https://nvidia.github.io/TensorRT-LLM/torch.html) that our doc doesn't show code snippets which raised by #5736 

<img width="1171" height="231" alt="image" src="https://github.com/user-attachments/assets/1c86a802-c9be-4fee-b91d-06e65ad7fbda" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated example file paths in multiple documentation files to ensure links to quickstart scripts are correct and functional.
  * Fixed references in DeepSeek-V3 and Qwen3 README files, as well as the PyTorch backend section, to point to the appropriate example scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->