### PR TITLE
[None][chore] unify the backend strings and warn the default backend change

### DIFF
--- a/tensorrt_llm/bench/benchmark/low_latency.py
+++ b/tensorrt_llm/bench/benchmark/low_latency.py
@@ -179,6 +179,13 @@ def latency_command(
     """Run a latency test on a TRT-LLM engine."""
 
     logger.info("Preparing to run latency benchmark...")
+
+    backend_repr = "PyTorch" if params.get(
+        "backend") == "pytorch" else "TensorRT"
+    logger.warning(
+        f"Starting latency benchmark with {backend_repr} backend, use `--backend` to switch to the other backend."
+    )
+
     # Parameters from CLI
     # Model, experiment, and engine params
     dataset_path: Path = params.get("dataset")

--- a/tensorrt_llm/bench/benchmark/low_latency.py
+++ b/tensorrt_llm/bench/benchmark/low_latency.py
@@ -21,11 +21,11 @@ from tensorrt_llm.bench.build.build import get_model_config
 from tensorrt_llm.bench.dataclasses.configuration import RuntimeConfig
 from tensorrt_llm.bench.dataclasses.general import BenchmarkEnvironment
 from tensorrt_llm.bench.dataclasses.reporting import ReportUtility
-from tensorrt_llm.llmapi import CapacitySchedulerPolicy
+from tensorrt_llm.llmapi import BackendType, CapacitySchedulerPolicy
 from tensorrt_llm.models.modeling_utils import SpeculativeDecodingMode
 
 # isort: off
-from tensorrt_llm.bench.benchmark.utils.general import get_settings_from_engine, get_settings, ALL_SUPPORTED_BACKENDS
+from tensorrt_llm.bench.benchmark.utils.general import get_settings_from_engine, get_settings
 # isort: on
 from tensorrt_llm.bench.utils.data import (create_dataset_from_stream,
                                            initialize_tokenizer,
@@ -46,10 +46,11 @@ from tensorrt_llm.sampling_params import SamplingParams
     default=None,
     help="Path to a serialized TRT-LLM engine.",
 )
-@optgroup.option("--backend",
-                 type=click.Choice(ALL_SUPPORTED_BACKENDS),
-                 default="pytorch",
-                 help="The backend to use when running benchmarking.")
+@optgroup.option(
+    "--backend",
+    type=click.Choice(BackendType.canonical_values()),
+    default=None,
+    help="The backend to use when running benchmarking. Default is 'pytorch'.")
 @optgroup.option(
     "--kv_cache_free_gpu_mem_fraction",
     type=float,
@@ -180,11 +181,9 @@ def latency_command(
 
     logger.info("Preparing to run latency benchmark...")
 
-    backend_repr = "PyTorch" if params.get(
-        "backend") == "pytorch" else "TensorRT"
-    logger.warning(
-        f"Starting latency benchmark with {backend_repr} backend, use `--backend` to switch to the other backend."
-    )
+    params["backend"] = BackendType.get_default_backend_with_warning(
+        params.get("backend"))
+    BackendType.print_backend_info(params.get("backend"))
 
     # Parameters from CLI
     # Model, experiment, and engine params
@@ -199,7 +198,7 @@ def latency_command(
     modality: str = params.get("modality")
     max_input_len: int = params.get("max_input_len")
     max_seq_len: int = params.get("max_seq_len")
-    backend: str = params.get("backend")
+    backend: BackendType = BackendType(params.get("backend"))
     model_type = get_model_config(model, checkpoint_path).model_type
 
     # Runtime Options
@@ -235,8 +234,7 @@ def latency_command(
 
     # Engine configuration parsing for PyTorch backend
     kwargs = {}
-    if backend and backend.lower() in ALL_SUPPORTED_BACKENDS and backend.lower(
-    ) != "tensorrt":
+    if backend != BackendType.TENSORRT:
         if bench_env.checkpoint_path is None:
             snapshot_download(model)
 
@@ -245,7 +243,7 @@ def latency_command(
         kwargs_max_sql = max_seq_len or metadata.max_sequence_length
         logger.info(f"Setting PyTorch max sequence length to {kwargs_max_sql}")
         kwargs["max_seq_len"] = kwargs_max_sql
-    elif backend.lower() == "tensorrt":
+    else:  # TensorRT backend
         assert max_seq_len is None, (
             "max_seq_len is not a runtime parameter for C++ backend")
         exec_settings, build_cfg = get_settings_from_engine(engine_dir)
@@ -257,10 +255,6 @@ def latency_command(
                 "dataset contains a maximum sequence of "
                 f"{metadata.max_sequence_length}. Please rebuild a new engine to"
                 "support this dataset.")
-    else:
-        raise RuntimeError(
-            f"Invalid backend: {backend}, please use one of the following: "
-            f"{ALL_SUPPORTED_BACKENDS}")
 
     exec_settings["model"] = model
     engine_tokens = exec_settings["settings_config"]["max_num_tokens"]
@@ -297,7 +291,7 @@ def latency_command(
 
     llm = None
     kwargs = kwargs | runtime_config.get_llm_args()
-    kwargs['backend'] = backend
+    kwargs['backend'] = backend.canonical_value
 
     try:
         logger.info("Setting up latency benchmark.")

--- a/tensorrt_llm/bench/benchmark/throughput.py
+++ b/tensorrt_llm/bench/benchmark/throughput.py
@@ -371,6 +371,10 @@ def throughput_command(
     exec_settings["extra_llm_api_options"] = params.pop("extra_llm_api_options")
     exec_settings["iteration_log"] = iteration_log
 
+    if exec_backend := exec_settings.get("backend", None):
+        if isinstance(exec_backend, BackendType):
+            exec_settings["backend"] = exec_backend.canonical_value
+
     # Construct the runtime configuration dataclass.
     runtime_config = RuntimeConfig(**exec_settings)
     llm = None

--- a/tensorrt_llm/bench/benchmark/throughput.py
+++ b/tensorrt_llm/bench/benchmark/throughput.py
@@ -29,6 +29,7 @@ from tensorrt_llm.bench.utils.data import (create_dataset_from_stream,
                                            initialize_tokenizer,
                                            update_metadata_for_multimodal)
 from tensorrt_llm.llmapi import CapacitySchedulerPolicy
+from tensorrt_llm.llmapi.utils import get_backend_repr
 from tensorrt_llm.logger import logger
 from tensorrt_llm.sampling_params import SamplingParams
 
@@ -254,6 +255,12 @@ def throughput_command(
     """Run a throughput test on a TRT-LLM engine."""
 
     logger.info("Preparing to run throughput benchmark...")
+
+    backend_repr = get_backend_repr(params.get("backend"))
+    logger.warning(
+        f"Starting throughput benchmark with {backend_repr} backend, use `--backend` to switch to the other backend."
+    )
+
     # Parameters from CLI
     # Model, experiment, and engine params
     dataset_path: Path = params.get("dataset")

--- a/tensorrt_llm/bench/benchmark/utils/general.py
+++ b/tensorrt_llm/bench/benchmark/utils/general.py
@@ -22,8 +22,6 @@ _KV_CACHE_MAP = {
     QuantAlgo.NVFP4.value: "fp8",
 }
 
-ALL_SUPPORTED_BACKENDS = ["pytorch", "_autodeploy", "tensorrt"]
-
 
 def get_settings_from_engine(
     engine_path: Path

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -25,6 +25,7 @@ from tensorrt_llm.llmapi.disagg_utils import (CtxGenServerConfig,
 from tensorrt_llm.llmapi.llm_utils import update_llm_args_with_extra_dict
 from tensorrt_llm.llmapi.mpi_session import find_free_port
 from tensorrt_llm.llmapi.reasoning_parser import ReasoningParserFactory
+from tensorrt_llm.llmapi.utils import get_backend_repr
 from tensorrt_llm.logger import logger, severity_map
 from tensorrt_llm.serve import OpenAIDisaggServer, OpenAIServer
 
@@ -292,6 +293,11 @@ def serve(
     MODEL: model name | HF checkpoint path | TensorRT engine path
     """
     logger.set_level(log_level)
+
+    backend_repr = get_backend_repr(backend)
+    logger.warning(
+        f"Starting serve with {backend_repr} backend, use `--backend` to switch to the other backend."
+    )
 
     llm_args, _ = get_llm_args(
         model=model,

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -158,7 +158,12 @@ def launch_server(host: str,
                   metadata_server_cfg: Optional[MetadataServerConfig] = None,
                   server_role: Optional[ServerRole] = None):
 
-    backend = llm_args["backend"]
+    if backend := llm_args.get("backend", None):
+        if isinstance(backend, BackendType):
+            llm_args["backend"] = backend.canonical_value
+    else:
+        backend = BackendType.get_default_backend_with_warning(backend)
+
     model = llm_args["model"]
 
     if backend == BackendType.PYTORCH:

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -25,7 +25,7 @@ from tensorrt_llm.llmapi.disagg_utils import (CtxGenServerConfig,
 from tensorrt_llm.llmapi.llm_utils import update_llm_args_with_extra_dict
 from tensorrt_llm.llmapi.mpi_session import find_free_port
 from tensorrt_llm.llmapi.reasoning_parser import ReasoningParserFactory
-from tensorrt_llm.llmapi.utils import get_backend_repr
+from tensorrt_llm.llmapi.utils import BackendType
 from tensorrt_llm.logger import logger, severity_map
 from tensorrt_llm.serve import OpenAIDisaggServer, OpenAIServer
 
@@ -72,7 +72,7 @@ def _signal_handler_cleanup_child(signum, frame):
 
 def get_llm_args(model: str,
                  tokenizer: Optional[str] = None,
-                 backend: str = "pytorch",
+                 backend: BackendType = BackendType.PYTORCH,
                  max_beam_width: int = BuildConfig.max_beam_width,
                  max_batch_size: int = BuildConfig.max_batch_size,
                  max_num_tokens: int = BuildConfig.max_num_tokens,
@@ -138,7 +138,7 @@ def get_llm_args(model: str,
         "kv_cache_config":
         kv_cache_config,
         "backend":
-        backend if backend == "pytorch" else None,
+        backend if backend == BackendType.PYTORCH else None,
         "num_postprocess_workers":
         num_postprocess_workers,
         "postprocess_tokenizer_dir":
@@ -161,7 +161,7 @@ def launch_server(host: str,
     backend = llm_args["backend"]
     model = llm_args["model"]
 
-    if backend == 'pytorch':
+    if backend == BackendType.PYTORCH:
         llm = PyTorchLLM(**llm_args)
     else:
         llm = LLM(**llm_args)
@@ -186,10 +186,12 @@ def launch_server(host: str,
               default="localhost",
               help="Hostname of the server.")
 @click.option("--port", type=int, default=8000, help="Port of the server.")
-@click.option("--backend",
-              type=click.Choice(["pytorch", "trt"]),
-              default="pytorch",
-              help="Set to 'pytorch' for pytorch path. Default is cpp path.")
+@click.option(
+    "--backend",
+    type=click.Choice(BackendType.canonical_values()),
+    default=None,
+    help=
+    "Set to 'tensorrt' for TensorRT engine path. Default is the pytorch path.")
 @click.option('--log_level',
               type=click.Choice(severity_map.keys()),
               default='info',
@@ -278,26 +280,25 @@ def launch_server(host: str,
     help=
     "Exit with runtime error when attention window is too large to fit even a single sequence in the KV cache."
 )
-def serve(
-        model: str, tokenizer: Optional[str], host: str, port: int,
-        log_level: str, backend: str, max_beam_width: int, max_batch_size: int,
-        max_num_tokens: int, max_seq_len: int, tp_size: int, pp_size: int,
-        ep_size: Optional[int], cluster_size: Optional[int],
-        gpus_per_node: Optional[int], kv_cache_free_gpu_memory_fraction: float,
-        num_postprocess_workers: int, trust_remote_code: bool,
-        extra_llm_api_options: Optional[str], reasoning_parser: Optional[str],
-        metadata_server_config_file: Optional[str], server_role: Optional[str],
-        fail_fast_on_attention_window_too_large: bool):
+def serve(model: str, tokenizer: Optional[str], host: str, port: int,
+          log_level: str, backend: Optional[str], max_beam_width: int,
+          max_batch_size: int, max_num_tokens: int, max_seq_len: int,
+          tp_size: int, pp_size: int, ep_size: Optional[int],
+          cluster_size: Optional[int], gpus_per_node: Optional[int],
+          kv_cache_free_gpu_memory_fraction: float,
+          num_postprocess_workers: int, trust_remote_code: bool,
+          extra_llm_api_options: Optional[str], reasoning_parser: Optional[str],
+          metadata_server_config_file: Optional[str],
+          server_role: Optional[str],
+          fail_fast_on_attention_window_too_large: bool):
     """Running an OpenAI API compatible server
 
     MODEL: model name | HF checkpoint path | TensorRT engine path
     """
     logger.set_level(log_level)
 
-    backend_repr = get_backend_repr(backend)
-    logger.warning(
-        f"Starting serve with {backend_repr} backend, use `--backend` to switch to the other backend."
-    )
+    backend: BackendType = BackendType.get_default_backend_with_warning(backend)
+    BackendType.print_backend_info(backend)
 
     llm_args, _ = get_llm_args(
         model=model,

--- a/tensorrt_llm/llmapi/__init__.py
+++ b/tensorrt_llm/llmapi/__init__.py
@@ -17,6 +17,7 @@ from .llm_args import (AttentionDpConfig, AutoDecodingConfig, BatchingType,
 from .llm_utils import (BuildConfig, KvCacheRetentionConfig, QuantAlgo,
                         QuantConfig)
 from .mpi_session import MpiCommSession
+from .utils import BackendType
 
 __all__ = [
     'LLM',
@@ -56,4 +57,5 @@ __all__ = [
     'TrtLlmArgs',
     'AutoDecodingConfig',
     'AttentionDpConfig',
+    'BackendType',
 ]

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -124,7 +124,7 @@ class BaseLLM:
 
         try:
             backend = kwargs.get('backend', None)
-            if backend == 'pytorch':
+            if backend in ('pytorch', None):
                 llm_args_cls = TorchLlmArgs
             elif backend == '_autodeploy':
                 from .._torch.auto_deploy.llm_args import \

--- a/tensorrt_llm/llmapi/utils.py
+++ b/tensorrt_llm/llmapi/utils.py
@@ -634,3 +634,12 @@ class ApiStatusRegistry:
 
 set_api_status = ApiStatusRegistry().set_api_status
 get_api_status = ApiStatusRegistry().get_api_status
+
+
+def get_backend_repr(backend):
+    _reprs = {
+        "pytorch": "PyTorch",
+        "tensorrt": "TensorRT",
+        "_autodeploy": "AutoDeploy",
+    }
+    return _reprs.get(backend, backend)

--- a/tensorrt_llm/llmapi/utils.py
+++ b/tensorrt_llm/llmapi/utils.py
@@ -20,6 +20,7 @@ import filelock
 import huggingface_hub
 import psutil
 import torch
+from aenum import MultiValueEnum
 from huggingface_hub import snapshot_download
 from pydantic import BaseModel
 from tqdm.auto import tqdm
@@ -636,10 +637,52 @@ set_api_status = ApiStatusRegistry().set_api_status
 get_api_status = ApiStatusRegistry().get_api_status
 
 
-def get_backend_repr(backend):
-    _reprs = {
-        "pytorch": "PyTorch",
-        "tensorrt": "TensorRT",
-        "_autodeploy": "AutoDeploy",
-    }
-    return _reprs.get(backend, backend)
+class BackendType(MultiValueEnum):
+    """ The backend type. """
+    # display_name, canonical_value, other aliases ...
+    PYTORCH = "PyTorch", "pytorch", "PyT"
+    TENSORRT = "TensorRT", "tensorrt", "trt"
+    _AUTODEPLOY = "AutoDeploy", "_autodeploy"
+
+    def __str__(self):
+        return self.values[0]
+
+    @property
+    def canonical_value(self):
+        return self.values[1]
+
+    @staticmethod
+    def default_value() -> str:
+        """ Default value for the backend. """
+        return BackendType.PYTORCH.canonical_value
+
+    @staticmethod
+    def canonical_values() -> list[str]:
+        """ Canonical values for the backend. """
+        return [v.canonical_value for v in BackendType]
+
+    # Several utils for unified behavior across trtllm-serve and trtllm-bench
+    @staticmethod
+    def print_backend_info(backend: "BackendType"):
+        """ Print the backend info. """
+        logger.info(f"Running with {backend} backend.")
+
+    # TODO[Superjom]: Remove this method after v1.0.0 is released.
+    @staticmethod
+    def get_default_backend_with_warning(
+            backend: Optional[str]) -> "BackendType":
+        """ Warn the user if the backend is not set, as we changed the default
+        backend to from tensorrt topytorch from v1.0 """
+        if backend is None:
+            logger.warning(
+                f"The default backend becomes 'pytorch' from v1.0, for TensorRT "
+                "engine, please use `--backend tensorrt` instead.")
+            backend = BackendType.default_value()
+
+        # check the backend should be in the canonical values
+        if backend not in BackendType.canonical_values():
+            raise ValueError(
+                f"Invalid backend: {backend}. Please use one of the following: "
+                f"{BackendType.canonical_values()}")
+
+        return BackendType(backend)

--- a/tests/integration/defs/stress_test/stress_test.py
+++ b/tests/integration/defs/stress_test/stress_test.py
@@ -322,7 +322,7 @@ def check_server_health(server_url: str,
 
 @pytest.mark.parametrize("test_mode", ["stress-test", "stress-stage-alone"],
                          ids=lambda x: x)
-@pytest.mark.parametrize("backend", ["trt", "pytorch"], ids=lambda x: x)
+@pytest.mark.parametrize("backend", ["tensorrt", "pytorch"], ids=lambda x: x)
 @pytest.mark.parametrize("capacity_scheduler_policy",
                          ["GUARANTEED_NO_EVICT", "MAX_UTILIZATION"],
                          ids=lambda x: x)
@@ -358,12 +358,12 @@ def test_run_stress_test(config, stress_time_timeout, backend,
     Args:
         config: Model configuration for the test (injected by pytest.mark.parametrize)
         stress_time_timeout: Tuple of (stress_time, stress_timeout) in seconds
-        backend: Backend to use ("trt" or "pytorch")
+        backend: Backend to use ("tensorrt" or "pytorch")
         capacity_scheduler_policy: Scheduler policy ("GUARANTEED_NO_EVICT", "MAX_UTILIZATION")
         test_mode: Test mode ("stress-test" or "stress-stage-alone")
     """
     # Create a new ModelConfig with the backend parameter
-    # Convert 'trt' to None as expected by the ModelConfig
+    # Convert 'tensorrt' to None as expected by the ModelConfig
 
     new_config = ModelConfig(model_dir=config.model_dir,
                              tp_size=config.tp_size,

--- a/tests/integration/defs/test_e2e.py
+++ b/tests/integration/defs/test_e2e.py
@@ -1441,7 +1441,7 @@ def test_trtllm_serve_lora_example(llm_root, llm_venv):
          str(test_root / "_test_trtllm_serve_lora.py")])
 
 
-@pytest.mark.parametrize("backend", ["pytorch", "trt"])
+@pytest.mark.parametrize("backend", ["pytorch", "tensorrt"])
 def test_openai_misc_example(llm_root, llm_venv, backend: str):
     test_root = unittest_path() / "llmapi" / "apps"
     llm_venv.run_cmd([
@@ -1450,7 +1450,7 @@ def test_openai_misc_example(llm_root, llm_venv, backend: str):
     ])
 
 
-@pytest.mark.parametrize("backend", ["pytorch", "trt"])
+@pytest.mark.parametrize("backend", ["pytorch", "tensorrt"])
 def test_openai_completions_example(llm_root, llm_venv, backend: str):
     test_root = unittest_path() / "llmapi" / "apps"
     filter_expr = f"{backend} and not sampler"
@@ -1460,7 +1460,7 @@ def test_openai_completions_example(llm_root, llm_venv, backend: str):
     ])
 
 
-@pytest.mark.parametrize("backend", ["pytorch", "trt"])
+@pytest.mark.parametrize("backend", ["pytorch", "tensorrt"])
 def test_openai_chat_example(llm_root, llm_venv, backend: str):
     test_root = unittest_path() / "llmapi" / "apps"
     filter_expr = f"{backend} and not sampler"
@@ -1470,7 +1470,7 @@ def test_openai_chat_example(llm_root, llm_venv, backend: str):
     ])
 
 
-@pytest.mark.parametrize("backend", ["pytorch", "trt"])
+@pytest.mark.parametrize("backend", ["pytorch", "tensorrt"])
 def test_openai_reasoning(llm_root, llm_venv, backend: str):
     test_root = unittest_path() / "llmapi" / "apps"
     llm_venv.run_cmd([

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -83,10 +83,10 @@ l0_a10:
   - llmapi/test_llm_e2e.py::test_llmapi_exit
   - llmapi/test_llm_examples.py::test_llmapi_server_example
   - test_e2e.py::test_trtllm_serve_example
-  - test_e2e.py::test_openai_misc_example[trt]
-  - test_e2e.py::test_openai_completions_example[trt]
-  - test_e2e.py::test_openai_chat_example[trt]
-  - test_e2e.py::test_openai_reasoning[trt]
+  - test_e2e.py::test_openai_misc_example[tensorrt]
+  - test_e2e.py::test_openai_completions_example[tensorrt]
+  - test_e2e.py::test_openai_chat_example[tensorrt]
+  - test_e2e.py::test_openai_reasoning[tensorrt]
   - test_e2e.py::test_trtllm_bench_sanity[--non-streaming-FP16-meta-llama/Llama-3.1-8B-llama-3.1-model/Meta-Llama-3.1-8B]
   - test_e2e.py::test_trtllm_bench_latency_sanity[FP16-meta-llama/Llama-3.1-8B-llama-3.1-model/Meta-Llama-3.1-8B]
   - unittest/trt/quantization
@@ -176,8 +176,8 @@ l0_a10:
   - accuracy/test_cli_flow.py::TestVicuna7B::test_eagle[cuda_graph=True-chunked_context=False-typical_acceptance=True] # 5 mins
   - accuracy/test_llm_api.py::TestEagleVicuna_7B_v1_3::test_auto_dtype
   - accuracy/test_llm_api.py::TestEagle2Vicuna_7B_v1_3::test_auto_dtype
-  - stress_test/stress_test.py::test_run_stress_test[llama-v3-8b-instruct-hf_tp1-stress_time_300s_timeout_450s-MAX_UTILIZATION-trt-stress-test]
-  - stress_test/stress_test.py::test_run_stress_test[llama-v3-8b-instruct-hf_tp1-stress_time_300s_timeout_450s-GUARANTEED_NO_EVICT-trt-stress-test]
+  - stress_test/stress_test.py::test_run_stress_test[llama-v3-8b-instruct-hf_tp1-stress_time_300s_timeout_450s-MAX_UTILIZATION-tensorrt-stress-test]
+  - stress_test/stress_test.py::test_run_stress_test[llama-v3-8b-instruct-hf_tp1-stress_time_300s_timeout_450s-GUARANTEED_NO_EVICT-tensorrt-stress-test]
 - condition:
     ranges:
       system_gpu_count:

--- a/tests/unittest/llmapi/apps/_test_openai_chat.py
+++ b/tests/unittest/llmapi/apps/_test_openai_chat.py
@@ -22,7 +22,7 @@ def model_name():
     return "llama-models-v2/TinyLlama-1.1B-Chat-v1.0"
 
 
-@pytest.fixture(scope="module", params=["trt", "pytorch"])
+@pytest.fixture(scope="module", params=["tensorrt", "pytorch"])
 def backend(request):
     return request.param
 
@@ -68,7 +68,7 @@ def server(model_name: str, backend: str, extra_llm_api_options: bool,
            temp_extra_llm_api_options_file: str, num_postprocess_workers: int):
     model_path = get_model_path(model_name)
     args = ["--backend", f"{backend}"]
-    if backend == "trt":
+    if backend == "tensorrt":
         args.extend(["--max_beam_width", "4"])
     if extra_llm_api_options:
         args.extend(

--- a/tests/unittest/llmapi/apps/_test_openai_completions.py
+++ b/tests/unittest/llmapi/apps/_test_openai_completions.py
@@ -17,7 +17,7 @@ def model_name():
     return "llama-models-v2/TinyLlama-1.1B-Chat-v1.0"
 
 
-@pytest.fixture(scope="module", params=["trt", "pytorch"])
+@pytest.fixture(scope="module", params=["tensorrt", "pytorch"])
 def backend(request):
     return request.param
 
@@ -33,7 +33,7 @@ def num_postprocess_workers(request):
 def server(model_name: str, backend: str, num_postprocess_workers: int):
     model_path = get_model_path(model_name)
     args = ["--backend", f"{backend}"]
-    if backend == "trt":
+    if backend == "tensorrt":
         args.extend(["--max_beam_width", "4"])
     args.extend(["--num_postprocess_workers", f"{num_postprocess_workers}"])
     with RemoteOpenAIServer(model_path, args) as remote_server:

--- a/tests/unittest/llmapi/apps/_test_openai_misc.py
+++ b/tests/unittest/llmapi/apps/_test_openai_misc.py
@@ -15,7 +15,7 @@ def model_name():
     return "llama-models-v2/TinyLlama-1.1B-Chat-v1.0"
 
 
-@pytest.fixture(scope="module", params=["trt", "pytorch"])
+@pytest.fixture(scope="module", params=["tensorrt", "pytorch"])
 def backend(request):
     return request.param
 

--- a/tests/unittest/llmapi/apps/_test_openai_multi_gpu.py
+++ b/tests/unittest/llmapi/apps/_test_openai_multi_gpu.py
@@ -15,7 +15,7 @@ def model_name():
     return "llama-models-v3/llama-v3-8b-instruct-hf"
 
 
-@pytest.fixture(scope="module", params=["trt", "pytorch"])
+@pytest.fixture(scope="module", params=["tensorrt", "pytorch"])
 def backend(request):
     return request.param
 

--- a/tests/unittest/llmapi/apps/_test_openai_reasoning.py
+++ b/tests/unittest/llmapi/apps/_test_openai_reasoning.py
@@ -14,7 +14,7 @@ def model_name() -> str:
     return "DeepSeek-R1-Distill-Qwen-1.5B"
 
 
-@pytest.fixture(scope="module", params=["trt", "pytorch"])
+@pytest.fixture(scope="module", params=["tensorrt", "pytorch"])
 def backend(request):
     return request.param
 

--- a/tests/unittest/llmapi/test_utils.py
+++ b/tests/unittest/llmapi/test_utils.py
@@ -1,4 +1,4 @@
-from tensorrt_llm.llmapi.utils import ApiStatusRegistry
+from tensorrt_llm.llmapi.utils import ApiStatusRegistry, BackendType
 
 
 def test_api_status_registry():
@@ -22,3 +22,22 @@ def test_api_status_registry():
             pass
 
     assert ApiStatusRegistry.get_api_status(App._my_method) == "beta"
+
+
+class TestBackendType:
+
+    def test_display_name(self):
+        assert str(BackendType.PYTORCH) == "PyTorch"
+        assert str(BackendType.TENSORRT) == "TensorRT"
+        assert str(BackendType._AUTODEPLOY) == "AutoDeploy"
+
+    def test_value(self):
+        assert BackendType.PYTORCH.canonical_value == "pytorch"
+        assert BackendType.TENSORRT.canonical_value == "tensorrt"
+        assert BackendType._AUTODEPLOY.canonical_value == "_autodeploy"
+
+    def test_canonical_values(self):
+        assert "pytorch" in BackendType.canonical_values()
+        assert "tensorrt" in BackendType.canonical_values()
+        assert "_autodeploy" in BackendType.canonical_values()
+        # for other values ...


### PR DESCRIPTION
## Description
1. Add warning in trtllm-serve and trtllm-bench if the `--backend` is not specified, this will guide the existing TRT users to specify `--backend tensorrt` to keep the existing behavior
2. Unify the backend candidates between trtllm-serve and trtllm-bench, like changing the trtllm-serve `--backend trt` to `--backend tensorrt`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Updated backend selection in CLI commands to use a structured backend enumeration with deferred defaulting to "PyTorch" and user warnings.
  * Improved backend name display and validation across benchmarks and serving commands for clearer backend management.

* **Tests**
  * Added unit tests to verify backend enum display names and canonical values.
  * Updated test parameterization and fixtures to use full backend names ("tensorrt" instead of "trt") for clarity.

* **Chores**
  * Replaced hardcoded backend strings with a unified backend enumeration for consistent handling.
  * Removed deprecated global backend alias list to streamline backend options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

[JIRA ticket/NVBugs ID/GitHub issue][fix/feat/doc/infra/...] \<summary of this PR\>

For example, assume I have a PR to support a new feature about cache manager for JIRA ticket TRTLLM-1000, it would be like:

[TRTLLM-1000][feat] Support a new feature about cache manager

Or I have a PR to fix a Llama3 accuracy issue:

[https://nvbugs/1234567][fix] Fix Llama3 accuracy issue
-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
