### PR TITLE
chore: disallow arbitrary arguments in llm_args.xxxConfigs

### DIFF
--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -61,7 +61,6 @@ speculative_config:
     decoding_type: Lookahead
     max_window_size: 4
     max_ngram_size: 3
-    verification_set_size: 4
     """
         dict_content = self._yaml_to_dict(yaml_content)
 
@@ -473,3 +472,229 @@ class TestTrtLlmArgs:
 
         assert args.max_num_tokens == 16
         assert args.max_batch_size == 4
+
+
+class TestStrictBaseModelArbitraryArgs:
+    """Test that StrictBaseModel prevents arbitrary arguments from being accepted."""
+
+    def test_cuda_graph_config_arbitrary_args(self):
+        """Test that CudaGraphConfig rejects arbitrary arguments."""
+        # Valid arguments should work
+        config = CudaGraphConfig(batch_sizes=[1, 2, 4], max_batch_size=8)
+        assert config.batch_sizes == [1, 2, 4]
+        assert config.max_batch_size == 8
+
+        # Arbitrary arguments should be rejected
+        with pytest.raises(
+                pydantic_core._pydantic_core.ValidationError) as exc_info:
+            CudaGraphConfig(batch_sizes=[1, 2, 4], invalid_arg="should_fail")
+        assert "invalid_arg" in str(exc_info.value)
+
+    def test_moe_config_arbitrary_args(self):
+        """Test that MoeConfig rejects arbitrary arguments."""
+        # Valid arguments should work
+        config = MoeConfig(backend="CUTLASS", max_num_tokens=1024)
+        assert config.backend == "CUTLASS"
+        assert config.max_num_tokens == 1024
+
+        # Arbitrary arguments should be rejected
+        with pytest.raises(
+                pydantic_core._pydantic_core.ValidationError) as exc_info:
+            MoeConfig(backend="CUTLASS", unknown_field="should_fail")
+        assert "unknown_field" in str(exc_info.value)
+
+    def test_calib_config_arbitrary_args(self):
+        """Test that CalibConfig rejects arbitrary arguments."""
+        # Valid arguments should work
+        config = CalibConfig(device="cuda", calib_batches=512)
+        assert config.device == "cuda"
+        assert config.calib_batches == 512
+
+        # Arbitrary arguments should be rejected
+        with pytest.raises(
+                pydantic_core._pydantic_core.ValidationError) as exc_info:
+            CalibConfig(device="cuda", extra_field="should_fail")
+        assert "extra_field" in str(exc_info.value)
+
+    def test_decoding_base_config_arbitrary_args(self):
+        """Test that DecodingBaseConfig rejects arbitrary arguments."""
+        # Valid arguments should work
+        config = DecodingBaseConfig(max_draft_len=10)
+        assert config.max_draft_len == 10
+
+        # Arbitrary arguments should be rejected
+        with pytest.raises(
+                pydantic_core._pydantic_core.ValidationError) as exc_info:
+            DecodingBaseConfig(max_draft_len=10, random_field="should_fail")
+        assert "random_field" in str(exc_info.value)
+
+    def test_dynamic_batch_config_arbitrary_args(self):
+        """Test that DynamicBatchConfig rejects arbitrary arguments."""
+        # Valid arguments should work
+        config = DynamicBatchConfig(enable_batch_size_tuning=True,
+                                    enable_max_num_tokens_tuning=True,
+                                    dynamic_batch_moving_average_window=8)
+        assert config.enable_batch_size_tuning == True
+
+        # Arbitrary arguments should be rejected
+        with pytest.raises(
+                pydantic_core._pydantic_core.ValidationError) as exc_info:
+            DynamicBatchConfig(enable_batch_size_tuning=True,
+                               enable_max_num_tokens_tuning=True,
+                               dynamic_batch_moving_average_window=8,
+                               fake_param="should_fail")
+        assert "fake_param" in str(exc_info.value)
+
+    def test_scheduler_config_arbitrary_args(self):
+        """Test that SchedulerConfig rejects arbitrary arguments."""
+        # Valid arguments should work
+        config = SchedulerConfig(
+            capacity_scheduler_policy=CapacitySchedulerPolicy.MAX_UTILIZATION)
+        assert config.capacity_scheduler_policy == CapacitySchedulerPolicy.MAX_UTILIZATION
+
+        # Arbitrary arguments should be rejected
+        with pytest.raises(
+                pydantic_core._pydantic_core.ValidationError) as exc_info:
+            SchedulerConfig(capacity_scheduler_policy=CapacitySchedulerPolicy.
+                            MAX_UTILIZATION,
+                            invalid_option="should_fail")
+        assert "invalid_option" in str(exc_info.value)
+
+    def test_peft_cache_config_arbitrary_args(self):
+        """Test that PeftCacheConfig rejects arbitrary arguments."""
+        # Valid arguments should work
+        config = PeftCacheConfig(num_host_module_layer=1,
+                                 num_device_module_layer=1)
+        assert config.num_host_module_layer == 1
+        assert config.num_device_module_layer == 1
+
+        # Arbitrary arguments should be rejected
+        with pytest.raises(
+                pydantic_core._pydantic_core.ValidationError) as exc_info:
+            PeftCacheConfig(num_host_module_layer=1,
+                            unexpected_field="should_fail")
+        assert "unexpected_field" in str(exc_info.value)
+
+    def test_kv_cache_config_arbitrary_args(self):
+        """Test that KvCacheConfig rejects arbitrary arguments."""
+        # Valid arguments should work
+        config = KvCacheConfig(enable_block_reuse=True, max_tokens=1024)
+        assert config.enable_block_reuse == True
+        assert config.max_tokens == 1024
+
+        # Arbitrary arguments should be rejected
+        with pytest.raises(
+                pydantic_core._pydantic_core.ValidationError) as exc_info:
+            KvCacheConfig(enable_block_reuse=True,
+                          non_existent_field="should_fail")
+        assert "non_existent_field" in str(exc_info.value)
+
+    def test_extended_runtime_perf_knob_config_arbitrary_args(self):
+        """Test that ExtendedRuntimePerfKnobConfig rejects arbitrary arguments."""
+        # Valid arguments should work
+        config = ExtendedRuntimePerfKnobConfig(multi_block_mode=True,
+                                               cuda_graph_mode=False)
+        assert config.multi_block_mode == True
+        assert config.cuda_graph_mode == False
+
+        # Arbitrary arguments should be rejected
+        with pytest.raises(
+                pydantic_core._pydantic_core.ValidationError) as exc_info:
+            ExtendedRuntimePerfKnobConfig(multi_block_mode=True,
+                                          bogus_setting="should_fail")
+        assert "bogus_setting" in str(exc_info.value)
+
+    def test_cache_transceiver_config_arbitrary_args(self):
+        """Test that CacheTransceiverConfig rejects arbitrary arguments."""
+        # Valid arguments should work
+        config = CacheTransceiverConfig(backend="ucx",
+                                        max_tokens_in_buffer=1024)
+        assert config.backend == "ucx"
+        assert config.max_tokens_in_buffer == 1024
+
+        # Arbitrary arguments should be rejected
+        with pytest.raises(
+                pydantic_core._pydantic_core.ValidationError) as exc_info:
+            CacheTransceiverConfig(backend="ucx", invalid_config="should_fail")
+        assert "invalid_config" in str(exc_info.value)
+
+    def test_torch_compile_config_arbitrary_args(self):
+        """Test that TorchCompileConfig rejects arbitrary arguments."""
+        # Valid arguments should work
+        config = TorchCompileConfig(enable_fullgraph=True,
+                                    enable_inductor=False)
+        assert config.enable_fullgraph == True
+        assert config.enable_inductor == False
+
+        # Arbitrary arguments should be rejected
+        with pytest.raises(
+                pydantic_core._pydantic_core.ValidationError) as exc_info:
+            TorchCompileConfig(enable_fullgraph=True,
+                               invalid_flag="should_fail")
+        assert "invalid_flag" in str(exc_info.value)
+
+    def test_trt_llm_args_arbitrary_args(self):
+        """Test that TrtLlmArgs rejects arbitrary arguments."""
+        # Valid arguments should work
+        args = TrtLlmArgs(model=llama_model_path, max_batch_size=8)
+        assert args.model == llama_model_path
+        assert args.max_batch_size == 8
+
+        # Arbitrary arguments should be rejected
+        with pytest.raises(
+                pydantic_core._pydantic_core.ValidationError) as exc_info:
+            TrtLlmArgs(model=llama_model_path, invalid_setting="should_fail")
+        assert "invalid_setting" in str(exc_info.value)
+
+    def test_torch_llm_args_arbitrary_args(self):
+        """Test that TorchLlmArgs rejects arbitrary arguments."""
+        # Valid arguments should work
+        args = TorchLlmArgs(model=llama_model_path, max_batch_size=8)
+        assert args.model == llama_model_path
+        assert args.max_batch_size == 8
+
+        # Arbitrary arguments should be rejected
+        with pytest.raises(
+                pydantic_core._pydantic_core.ValidationError) as exc_info:
+            TorchLlmArgs(model=llama_model_path,
+                         unsupported_option="should_fail")
+        assert "unsupported_option" in str(exc_info.value)
+
+    def test_nested_config_arbitrary_args(self):
+        """Test that nested configurations also reject arbitrary arguments."""
+        # Test with nested KvCacheConfig
+        with pytest.raises(
+                pydantic_core._pydantic_core.ValidationError) as exc_info:
+            KvCacheConfig(enable_block_reuse=True,
+                          max_tokens=1024,
+                          invalid_nested_field="should_fail")
+        assert "invalid_nested_field" in str(exc_info.value)
+
+        # Test with nested SchedulerConfig
+        with pytest.raises(
+                pydantic_core._pydantic_core.ValidationError) as exc_info:
+            SchedulerConfig(capacity_scheduler_policy=CapacitySchedulerPolicy.
+                            MAX_UTILIZATION,
+                            nested_invalid_field="should_fail")
+        assert "nested_invalid_field" in str(exc_info.value)
+
+    def test_strict_base_model_inheritance(self):
+        """Test that StrictBaseModel properly forbids extra fields."""
+        # Verify that StrictBaseModel is properly configured
+        assert StrictBaseModel.model_config.get("extra") == "forbid"
+
+        # Test that a simple StrictBaseModel instance rejects arbitrary fields
+        class TestConfig(StrictBaseModel):
+            field1: str = "default"
+            field2: int = 42
+
+        # Valid configuration should work
+        config = TestConfig(field1="test", field2=100)
+        assert config.field1 == "test"
+        assert config.field2 == 100
+
+        # Arbitrary field should be rejected
+        with pytest.raises(
+                pydantic_core._pydantic_core.ValidationError) as exc_info:
+            TestConfig(field1="test", field2=100, extra_field="should_fail")
+        assert "extra_field" in str(exc_info.value)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced stricter validation for configuration options, ensuring that only recognized fields are accepted and any extra or unknown fields are rejected.

* **Tests**
  * Added comprehensive tests to verify that all configuration classes strictly reject unexpected or arbitrary arguments during setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

[JIRA ticket/NVBugs ID/GitHub issue][fix/feat/doc/infra/...] \<summary of this PR\>

For example, assume I have a PR to support a new feature about cache manager for JIRA ticket TRTLLM-1000, it would be like:

[TRTLLM-1000][feat] Support a new feature about cache manager

Or I have a PR to fix a Llama3 accuracy issue:

[https://nvbugs/1234567][fix] Fix Llama3 accuracy issue
-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
