### PR TITLE
chore: add trtllm-serve json schema example into doc.

### DIFF
--- a/examples/serve/openai_completion_client_json_schema.py
+++ b/examples/serve/openai_completion_client_json_schema.py
@@ -1,0 +1,42 @@
+### :title OpenAI Completion Client with JSON Schema
+
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8000/v1",
+    api_key="tensorrt_llm",
+)
+
+response = client.chat.completions.create(
+    model="TinyLlama-1.1B-Chat-v1.0",
+    messages=[{
+        "role": "system",
+        "content": "you are a helpful assistant"
+    }, {
+        "role":
+        "user",
+        "content":
+        f"Give me the information of the biggest city of China in the JSON format.",
+    }],
+    max_tokens=100,
+    temperature=0,
+    response_format={
+        "type": "json",
+        "schema": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "population": {
+                    "type": "integer"
+                },
+            },
+            "required": ["name", "population"],
+            "chat_template_kwargs": {
+                "enable_thinking": False
+            }
+        }
+    },
+)
+print(response.choices[0].message.content)

--- a/tests/unittest/llmapi/apps/_test_openai_chat_json.py
+++ b/tests/unittest/llmapi/apps/_test_openai_chat_json.py
@@ -58,11 +58,6 @@ def client(server: RemoteOpenAIServer):
 
 
 @pytest.fixture(scope="module")
-def async_client(server: RemoteOpenAIServer):
-    return server.get_async_client()
-
-
-@pytest.fixture(scope="module")
 def user_profile_schema():
     """Provides a sample JSON schema for a user profile."""
     return {

--- a/tests/unittest/llmapi/apps/_test_trtllm_serve_example.py
+++ b/tests/unittest/llmapi/apps/_test_trtllm_serve_example.py
@@ -29,12 +29,13 @@ def example_root():
     return os.path.join(llm_root, "examples", "serve")
 
 
-@pytest.mark.parametrize("exe, script",
-                         [("python3", "openai_chat_client.py"),
-                          ("python3", "openai_completion_client.py"),
-                          ("bash", "curl_chat_client.sh"),
-                          ("bash", "curl_completion_client.sh"),
-                          ("bash", "genai_perf_client.sh")])
+@pytest.mark.parametrize(
+    "exe, script", [("python3", "openai_chat_client.py"),
+                    ("python3", "openai_completion_client.py"),
+                    ("python3", "openai_completion_client_json_schema.py"),
+                    ("bash", "curl_chat_client.sh"),
+                    ("bash", "curl_completion_client.sh"),
+                    ("bash", "genai_perf_client.sh")])
 def test_trtllm_serve_examples(exe: str, script: str,
                                server: RemoteOpenAIServer, example_root: str):
     client_script = os.path.join(example_root, script)


### PR DESCRIPTION
It's a supplement PR of #6321.

- Add a example as part of online serving example,
- Remove the useless code of test case for json schema feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new example script demonstrating chat completions with JSON schema response format using the OpenAI Python client.

* **Tests**
  * Removed an unused asynchronous client fixture from the test suite.
  * Expanded test coverage by adding the new example script to existing test cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->