### PR TITLE
chore: update trtllm-serve usage doc by removing backend parameter when it use torch as backend.

### DIFF
--- a/docs/source/blogs/tech_blog/blog5_Disaggregated_Serving_in_TensorRT-LLM.md
+++ b/docs/source/blogs/tech_blog/blog5_Disaggregated_Serving_in_TensorRT-LLM.md
@@ -76,12 +76,12 @@ In the example below, two context servers are launched on ports 8001 and 8002, a
 
 ```shell
 # Launching context servers
-trtllm-serve TinyLlama/TinyLlama-1.1B-Chat-v1.0 --host localhost --port 8001 --kv_cache_free_gpu_memory_fraction 0.15 --backend pytorch &> output_ctx0 &
-trtllm-serve TinyLlama/TinyLlama-1.1B-Chat-v1.0 --host localhost --port 8002 --kv_cache_free_gpu_memory_fraction 0.15 --backend pytorch &> output_ctx1 &
+trtllm-serve TinyLlama/TinyLlama-1.1B-Chat-v1.0 --host localhost --port 8001 --kv_cache_free_gpu_memory_fraction 0.15 &> output_ctx0 &
+trtllm-serve TinyLlama/TinyLlama-1.1B-Chat-v1.0 --host localhost --port 8002 --kv_cache_free_gpu_memory_fraction 0.15 &> output_ctx1 &
 
 # Launching generation servers
-trtllm-serve TinyLlama/TinyLlama-1.1B-Chat-v1.0 --host localhost --port 8003 --kv_cache_free_gpu_memory_fraction 0.15 --backend pytorch &> output_gen0 &
-trtllm-serve TinyLlama/TinyLlama-1.1B-Chat-v1.0 --host localhost --port 8004 --kv_cache_free_gpu_memory_fraction 0.15 --backend pytorch &> output_gen1 &
+trtllm-serve TinyLlama/TinyLlama-1.1B-Chat-v1.0 --host localhost --port 8003 --kv_cache_free_gpu_memory_fraction 0.15 &> output_gen0 &
+trtllm-serve TinyLlama/TinyLlama-1.1B-Chat-v1.0 --host localhost --port 8004 --kv_cache_free_gpu_memory_fraction 0.15 &> output_gen1 &
 
 # Launching disaggregated server
 trtllm-serve disaggregated -c disagg_config.yaml

--- a/docs/source/blogs/tech_blog/blog6_Llama4_maverick_eagle_guide.md
+++ b/docs/source/blogs/tech_blog/blog6_Llama4_maverick_eagle_guide.md
@@ -72,7 +72,7 @@ docker run -d --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 \
         TRT_LLM_DISABLE_LOAD_WEIGHTS_IN_PARALLEL=True \
         trtllm-serve /config/models/maverick \
             --host 0.0.0.0 --port 8000 \
-            --backend pytorch --tp_size 8 --ep_size 1 \
+            --tp_size 8 --ep_size 1 \
             --trust_remote_code --extra_llm_api_options c.yaml \
             --kv_cache_free_gpu_memory_fraction 0.75"
 ```

--- a/docs/source/commands/trtllm-serve.rst
+++ b/docs/source/commands/trtllm-serve.rst
@@ -27,7 +27,7 @@ The following abbreviated command syntax shows the commonly used arguments to st
 
 .. code-block:: bash
 
-   trtllm-serve <model> [--backend pytorch --tp_size <tp> --pp_size <pp> --ep_size <ep> --host <host> --port <port>]
+   trtllm-serve <model> [--tp_size <tp> --pp_size <pp> --ep_size <ep> --host <host> --port <port>]
 
 For the full syntax and argument descriptions, refer to :ref:`syntax`.
 
@@ -90,8 +90,7 @@ Then, start the server with the configuration file:
 .. code-block:: bash
 
    trtllm-serve Qwen/Qwen2-VL-7B-Instruct \
-       --extra_llm_api_options ./extra-llm-api-config.yml \
-       --backend pytorch
+       --extra_llm_api_options ./extra-llm-api-config.yml
 
 Multimodal Chat API
 ~~~~~~~~~~~~~~~~~~~
@@ -213,7 +212,7 @@ You can deploy `DeepSeek-V3 <https://huggingface.co/deepseek-ai/DeepSeek-V3>`_ m
         --container-image=<CONTAINER_IMG> \
         --container-mounts=/workspace:/workspace \
         --container-workdir /workspace \
-        bash -c "trtllm-llmapi-launch trtllm-serve deepseek-ai/DeepSeek-V3 --backend pytorch --max_batch_size 161 --max_num_tokens 1160 --tp_size 16 --ep_size 4 --kv_cache_free_gpu_memory_fraction 0.95 --extra_llm_api_options ./extra-llm-api-config.yml"
+        bash -c "trtllm-llmapi-launch trtllm-serve deepseek-ai/DeepSeek-V3 --max_batch_size 161 --max_num_tokens 1160 --tp_size 16 --ep_size 4 --kv_cache_free_gpu_memory_fraction 0.95 --extra_llm_api_options ./extra-llm-api-config.yml"
 
 See `the source code <https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/llmapi/trtllm-llmapi-launch>`_ of ``trtllm-llmapi-launch`` for more details.
 
@@ -232,7 +231,7 @@ Metrics Endpoint
 
 The ``/metrics`` endpoint provides runtime-iteration statistics such as GPU memory use and inflight-batching details.
 For the TensorRT backend, these statistics are enabled by default.
-However, for the PyTorch backend, specified with the ``--backend pytorch`` argument, you must explicitly enable iteration statistics logging by setting the `enable_iter_perf_stats` field in a YAML configuration file as shown in the following example:
+However, for the PyTorch backend, you must explicitly enable iteration statistics logging by setting the `enable_iter_perf_stats` field in a YAML configuration file as shown in the following example:
 
 .. code-block:: yaml
 
@@ -246,7 +245,7 @@ Then start the server and specify the ``--extra_llm_api_options`` argument with 
 
    trtllm-serve <model> \
      --extra_llm_api_options <path-to-extra-llm-api-config.yml> \
-     [--backend pytorch --tp_size <tp> --pp_size <pp> --ep_size <ep> --host <host> --port <port>]
+     [--tp_size <tp> --pp_size <pp> --ep_size <ep> --host <host> --port <port>]
 
 After at least one inference request is sent to the server, you can fetch the runtime-iteration statistics by polling the `/metrics` endpoint:
 

--- a/examples/disaggregated/README.md
+++ b/examples/disaggregated/README.md
@@ -25,14 +25,14 @@ for disaggregated serving. For example, you could launch two context servers and
 echo -e "disable_overlap_scheduler: True\ncache_transceiver_config:\n  backend: UCX\n  max_tokens_in_buffer: 2048" > context_extra-llm-api-config.yml
 
 # Start context servers
-CUDA_VISIBLE_DEVICES=0 trtllm-serve TinyLlama/TinyLlama-1.1B-Chat-v1.0 --host localhost --port 8001 --backend pytorch --extra_llm_api_options ./context_extra-llm-api-config.yml &> log_ctx_0 &
-CUDA_VISIBLE_DEVICES=1 trtllm-serve TinyLlama/TinyLlama-1.1B-Chat-v1.0 --host localhost --port 8002 --backend pytorch --extra_llm_api_options ./context_extra-llm-api-config.yml &> log_ctx_1 &
+CUDA_VISIBLE_DEVICES=0 trtllm-serve TinyLlama/TinyLlama-1.1B-Chat-v1.0 --host localhost --port 8001  --extra_llm_api_options ./context_extra-llm-api-config.yml &> log_ctx_0 &
+CUDA_VISIBLE_DEVICES=1 trtllm-serve TinyLlama/TinyLlama-1.1B-Chat-v1.0 --host localhost --port 8002  --extra_llm_api_options ./context_extra-llm-api-config.yml &> log_ctx_1 &
 
 # Generate gen_extra-llm-api-config.yml
 echo -e "cache_transceiver_config:\n  backend: UCX\n  max_tokens_in_buffer: 2048" > gen_extra-llm-api-config.yml
 
 # Start generation servers
-CUDA_VISIBLE_DEVICES=2 trtllm-serve TinyLlama/TinyLlama-1.1B-Chat-v1.0 --host localhost --port 8003 --backend pytorch --extra_llm_api_options ./gen_extra-llm-api-config.yml &> log_gen_0 &
+CUDA_VISIBLE_DEVICES=2 trtllm-serve TinyLlama/TinyLlama-1.1B-Chat-v1.0 --host localhost --port 8003  --extra_llm_api_options ./gen_extra-llm-api-config.yml &> log_gen_0 &
 ```
 
 Once the context and generation servers are launched, you can launch the disaggregated
@@ -95,11 +95,11 @@ After this, you can enable the dynamic scaling feature for the use case above as
 export TRTLLM_USE_UCX_KVCACHE=1
 
 # Context servers
-CUDA_VISIBLE_DEVICES=0 trtllm-serve TinyLlama/TinyLlama-1.1B-Chat-v1.0 --host localhost --port 8001 --backend pytorch --server_role CONTEXT --extra_llm_api_options ./context_extra-llm-api-config.yml --metadata_server_config_file ./metadata_config.yml &> log_ctx_0 &
-CUDA_VISIBLE_DEVICES=1 trtllm-serve TinyLlama/TinyLlama-1.1B-Chat-v1.0 --host localhost --port 8002 --backend pytorch --server_role CONTEXT --extra_llm_api_options ./context_extra-llm-api-config.yml --metadata_server_config_file ./metadata_config.yml &> log_ctx_1 &
+CUDA_VISIBLE_DEVICES=0 trtllm-serve TinyLlama/TinyLlama-1.1B-Chat-v1.0 --host localhost --port 8001  --server_role CONTEXT --extra_llm_api_options ./context_extra-llm-api-config.yml --metadata_server_config_file ./metadata_config.yml &> log_ctx_0 &
+CUDA_VISIBLE_DEVICES=1 trtllm-serve TinyLlama/TinyLlama-1.1B-Chat-v1.0 --host localhost --port 8002  --server_role CONTEXT --extra_llm_api_options ./context_extra-llm-api-config.yml --metadata_server_config_file ./metadata_config.yml &> log_ctx_1 &
 
 # Generation servers
-CUDA_VISIBLE_DEVICES=2 trtllm-serve TinyLlama/TinyLlama-1.1B-Chat-v1.0 --host localhost --port 8003 --backend pytorch --server_role GENERATION --extra_llm_api_options ./gen_extra-llm-api-config.yml --metadata_server_config_file ./metadata_config.yml &> log_gen_0 &
+CUDA_VISIBLE_DEVICES=2 trtllm-serve TinyLlama/TinyLlama-1.1B-Chat-v1.0 --host localhost --port 8003  --server_role GENERATION --extra_llm_api_options ./gen_extra-llm-api-config.yml --metadata_server_config_file ./metadata_config.yml &> log_gen_0 &
 ```
 
 As for the disaggregated server, you should also specify the --metadata_server_config_file like the following
@@ -123,7 +123,7 @@ Users can add servers by directly launching them with trtllm-serve. For example,
 ```bash
 CUDA_VISIBLE_DEVICES=3 trtllm-serve TinyLlama/TinyLlama-1.1B-Chat-v1.0 \
     --host localhost --port 8004 \
-    --backend pytorch --server_role GENERATION \
+     --server_role GENERATION \
     --extra_llm_api_options ./gen_extra-llm-api-config.yml \
     --metadata_server_config_file ./metadata_config.yml &> log_gen_0 &
 ```

--- a/examples/llm-api/llm_mgmn_trtllm_serve.sh
+++ b/examples/llm-api/llm_mgmn_trtllm_serve.sh
@@ -51,7 +51,6 @@ srun -l \
         trtllm-llmapi-launch \
          trtllm-serve $LOCAL_MODEL \
             --tp_size 16 \
-            --backend pytorch \
             --host 0.0.0.0 \
             ${ADDITIONAL_OPTIONS}
     "

--- a/examples/models/core/gemma/README.md
+++ b/examples/models/core/gemma/README.md
@@ -699,7 +699,6 @@ trtllm-serve \
   google/gemma-3-1b-it \
   --host localhost \
   --port 8001 \
-  --backend pytorch \
   --max_batch_size 8 \
   --tp_size 2 \
   --ep_size 2 \
@@ -723,7 +722,6 @@ trtllm-serve \
   google/gemma-3-1b-it \
   --host localhost \
   --port 8002 \
-  --backend pytorch \
   --max_batch_size 8 \
   --tp_size 2 \
   --ep_size 2 \

--- a/examples/models/core/llama/README.md
+++ b/examples/models/core/llama/README.md
@@ -1571,7 +1571,6 @@ Explanation:
 TensorRT-LLM supports nvidia TensorRT Model Optimizer quantized FP8 checkpoint
 ``` bash
 trtllm-serve nvidia/Llama-3.3-70B-Instruct-FP8 \
-    --backend pytorch \
     --tp_size 8 \
     --max_batch_size 1024 \
     --trust_remote_code \

--- a/examples/models/core/llama4/README.md
+++ b/examples/models/core/llama4/README.md
@@ -44,7 +44,6 @@ Explanation:
 TensorRT-LLM supports nvidia TensorRT Model Optimizer quantized FP8 checkpoint
 ``` bash
 trtllm-serve nvidia/Llama-4-Maverick-17B-128E-Instruct-FP8 \
-    --backend pytorch \
     --max_batch_size 512 \
     --tp_size 8 \
     --ep_size 8 \
@@ -99,7 +98,6 @@ Currently parallel weight loading conflicts with min_latency, disable the parall
 ``` bash
 TRT_LLM_DISABLE_LOAD_WEIGHTS_IN_PARALLEL=True \
 trtllm-serve nvidia/Llama-4-Maverick-17B-128E-Instruct-FP8 \
-    --backend pytorch \
     --max_batch_size 8 \
     --tp_size 8 \
     --ep_size 1 \

--- a/examples/models/core/qwen/README.md
+++ b/examples/models/core/qwen/README.md
@@ -765,7 +765,6 @@ trtllm-serve \
   Qwen3-30B-A3B/ \
   --host localhost \
   --port 8000 \
-  --backend pytorch \
   --max_batch_size 161 \
   --max_num_tokens 1160 \
   --tp_size 1 \
@@ -804,7 +803,6 @@ trtllm-serve \
   Qwen3-30B-A3B/ \
   --host localhost \
   --port 8001 \
-  --backend pytorch \
   --max_batch_size 161 \
   --max_num_tokens 1160 \
   --tp_size 1 \
@@ -842,7 +840,6 @@ trtllm-serve \
   Qwen3-30B-A3B/ \
   --host localhost \
   --port ${port} \
-  --backend pytorch \
   --max_batch_size 161 \
   --max_num_tokens 1160 \
   --tp_size 1 \

--- a/examples/serve/deepseek_r1_reasoning_parser.sh
+++ b/examples/serve/deepseek_r1_reasoning_parser.sh
@@ -3,7 +3,6 @@
 trtllm-serve \
     deepseek-ai/DeepSeek-R1 \
     --host localhost --port 8000 \
-    --backend pytorch \
     --max_batch_size 161 --max_num_tokens 1160 \
     --tp_size 8 --ep_size 8 --pp_size 1 \
     --kv_cache_free_gpu_memory_fraction 0.95 \

--- a/tests/integration/defs/disaggregated/test_disaggregated_etcd.py
+++ b/tests/integration/defs/disaggregated/test_disaggregated_etcd.py
@@ -61,9 +61,9 @@ def start_context_server(config,
     """Start a context server on specified GPU and port."""
     cmd = [
         "trtllm-serve", config['model_path'], "--host", "localhost", "--port",
-        str(port), "--backend", "pytorch", "--extra_llm_api_options",
-        f"./{CONTEXT_CONFIG_FILE}", "--metadata_server_config_file",
-        ETCD_CONFIG_FILE, "--server_role", "CONTEXT"
+        str(port), "--extra_llm_api_options", f"./{CONTEXT_CONFIG_FILE}",
+        "--metadata_server_config_file", ETCD_CONFIG_FILE, "--server_role",
+        "CONTEXT"
     ]
 
     server_env = env.copy() if env else os.environ.copy()
@@ -87,9 +87,9 @@ def start_generation_server(config,
     """Start a generation server on specified GPU and port."""
     cmd = [
         "trtllm-serve", config['model_path'], "--host", "localhost", "--port",
-        str(port), "--backend", "pytorch", "--extra_llm_api_options",
-        f"./{GENERATION_CONFIG_FILE}", "--metadata_server_config_file",
-        ETCD_CONFIG_FILE, "--server_role", "GENERATION"
+        str(port), "--extra_llm_api_options", f"./{GENERATION_CONFIG_FILE}",
+        "--metadata_server_config_file", ETCD_CONFIG_FILE, "--server_role",
+        "GENERATION"
     ]
 
     server_env = env.copy() if env else os.environ.copy()

--- a/tests/unittest/llmapi/apps/_test_openai_chat_json.py
+++ b/tests/unittest/llmapi/apps/_test_openai_chat_json.py
@@ -44,10 +44,7 @@ def temp_extra_llm_api_options_file(request):
 @pytest.fixture(scope="module")
 def server(model_name: str, temp_extra_llm_api_options_file: str):
     model_path = get_model_path(model_name)
-    args = [
-        "--backend", "pytorch", "--extra_llm_api_options",
-        temp_extra_llm_api_options_file
-    ]
+    args = ["--extra_llm_api_options", temp_extra_llm_api_options_file]
     with RemoteOpenAIServer(model_path, args) as remote_server:
         yield remote_server
 

--- a/tests/unittest/llmapi/apps/_test_openai_chat_multimodal.py
+++ b/tests/unittest/llmapi/apps/_test_openai_chat_multimodal.py
@@ -46,10 +46,7 @@ def temp_extra_llm_api_options_file(request):
 @pytest.fixture(scope="module")
 def server(model_name: str, temp_extra_llm_api_options_file: str):
     model_path = get_model_path(model_name)
-    args = [
-        "--backend", "pytorch", "--extra_llm_api_options",
-        temp_extra_llm_api_options_file
-    ]
+    args = ["--extra_llm_api_options", temp_extra_llm_api_options_file]
     with RemoteOpenAIServer(model_path, args) as remote_server:
         yield remote_server
 

--- a/tests/unittest/llmapi/apps/_test_openai_chat_structural_tag.py
+++ b/tests/unittest/llmapi/apps/_test_openai_chat_structural_tag.py
@@ -37,10 +37,7 @@ def temp_extra_llm_api_options_file(request):
 @pytest.fixture(scope="module")
 def server(model_name: str, temp_extra_llm_api_options_file: str):
     model_path = get_model_path(model_name)
-    args = [
-        "--backend", "pytorch", "--extra_llm_api_options",
-        temp_extra_llm_api_options_file
-    ]
+    args = ["--extra_llm_api_options", temp_extra_llm_api_options_file]
     with RemoteOpenAIServer(model_path, args) as remote_server:
         yield remote_server
 

--- a/tests/unittest/llmapi/apps/_test_trtllm_serve_duplicated_args.py
+++ b/tests/unittest/llmapi/apps/_test_trtllm_serve_duplicated_args.py
@@ -46,7 +46,7 @@ def example_root():
 def server(model_name: str, temp_extra_llm_api_options_file: str):
     model_path = get_model_path(model_name)
     args = [
-        "--backend", "pytorch", "--tp_size", "99", "--extra_llm_api_options",
+        "--tp_size", "99", "--extra_llm_api_options",
         temp_extra_llm_api_options_file
     ]
     with RemoteOpenAIServer(model_path, port=8000,


### PR DESCRIPTION
Remove the explicit `--backend pytorch` for trtllm-serve doc and example since we've set the PyTorch as the default backend with #5717 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed the explicit `--backend pytorch` option from all `trtllm-serve` command examples and related documentation, simplifying usage instructions across blogs, READMEs, and guides.

* **Tests**
  * Updated test fixtures and scripts to omit the `--backend pytorch` argument when launching servers, aligning tests with the streamlined command usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->