### PR TITLE
imp(TorchSampler):support torchsampler stop

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -27,6 +27,7 @@ from .config_utils import is_mla
 from .model_engine import PyTorchModelEngine
 from .py_executor import PyExecutor
 
+from transformers import PreTrainedTokenizerBase
 
 class _ExecutorCreationStage(enum.Enum):
     SAMPLER = "Sampler"
@@ -199,7 +200,8 @@ def create_py_executor(
         executor_config: ExecutorConfig,
         checkpoint_dir: str = None,
         lora_config: Optional[LoraConfig] = None,
-        garbage_collection_gen0_threshold: Optional[int] = None) -> PyExecutor:
+        garbage_collection_gen0_threshold: Optional[int] = None,
+        tokenizer:PreTrainedTokenizerBase=None) -> PyExecutor:
     _mangle_executor_config(executor_config)
     pytorch_backend_config = executor_config.pytorch_backend_config
 
@@ -340,7 +342,7 @@ def create_py_executor(
 
     with mem_monitor.observe_creation_stage(_ExecutorCreationStage.SAMPLER):
         sampler = instantiate_sampler(model_engine, executor_config,
-                                      pytorch_backend_config, mapping)
+                                      pytorch_backend_config, mapping,tokenizer)
 
     resources = {}
     estimating_kv_cache = False

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -26,6 +26,7 @@ from .finish_reason import FinishedState
 from .llm_request import LlmRequest, LlmRequestState
 from .scheduler import ScheduledRequests
 
+from transformers import PreTrainedTokenizerBase
 
 @dataclass(kw_only=True)
 class SampleStateTensors:
@@ -246,12 +247,13 @@ class TorchSampler(Sampler):
         max_beam_width: int
         enable_mixed_sampler: bool
 
-    def __init__(self, args: Args):
+    def __init__(self, args: Args,tokenizer):
         self.max_seq_len = args.max_seq_len
         self.enable_mixed_sampler = args.enable_mixed_sampler
         self.max_tokens = args.max_draft_len + 1
         assert args.max_beam_width == self.MAX_BEAM_WIDTH, "TorchSampler only supports beam_width = 1"
         self.num_seq_slots = args.max_num_sequences
+        self.tokenizer = tokenizer
 
         self.NEW_TOKENS_SHAPE = (self.max_tokens, self.num_seq_slots,
                                  self.MAX_BEAM_WIDTH)
@@ -268,22 +270,28 @@ class TorchSampler(Sampler):
                                                   >= self.max_seq_len)
 
     @staticmethod
-    def _meet_stop_token_criteria(request: LlmRequest):
+    def _meet_stop_token_criteria(request: LlmRequest,tokenizer,new_token):
         if request.py_stop_words_list:
             assert isinstance(
                 request.py_stop_words_list,
                 list), "request.py_stop_words_list should be a list"
+
             stop_words_list, prefix_sum = request.py_stop_words_list
             tokens = request.get_tokens(0)
+            new_words = tokenizer.decode(new_token,skip_special_tokens=False,clean_up_tokenization_spaces=False)
             offset = 0
             for i, offset_end in enumerate(prefix_sum):
                 if i > 0:
                     offset = prefix_sum[i - 1]
                 stop_word = stop_words_list[offset:offset_end]
+                stop_text = tokenizer.decode(stop_word,skip_special_tokens=False,clean_up_tokenization_spaces=False)
                 if len(stop_word) > len(tokens):
                     continue
                 if tokens[-len(stop_word):] == stop_word:
                     return True
+                if stop_text in new_words:
+                    return True
+
         return False
 
     def _handle_stop_criteria(self, request: LlmRequest,
@@ -298,7 +306,7 @@ class TorchSampler(Sampler):
             request.finish_by(FinishReason.LENGTH, self.BEAM)
             return True
 
-        if self._meet_stop_token_criteria(request):
+        if self._meet_stop_token_criteria(request,self.tokenizer,new_token):
             request.finish_by(FinishReason.STOP_WORDS, self.BEAM)
             return True
 
@@ -386,6 +394,7 @@ class TorchSampler(Sampler):
 
     def sample_async(self, scheduled_requests: ScheduledRequests,
                      model_outputs: dict[str, torch.Tensor]) -> SampleState:
+
         requests = scheduled_requests.all_requests()
         new_tokens = self.store.new_tokens
         vocab_size = model_outputs["logits"].shape[-1]
@@ -505,7 +514,9 @@ class TRTLLMSampler(Sampler):
         mapping: Mapping,
         decoding_mode: DecodingMode,
         disable_overlap_scheduler: bool,
+        tokenizer: PreTrainedTokenizerBase
     ):
+        self.tokenizer = tokenizer
 
         vocab_size = model.config.vocab_size
         num_hidden_layers = model.config.num_hidden_layers
@@ -532,6 +543,8 @@ class TRTLLMSampler(Sampler):
         self.model_config = ModelConfig(vocab_size, num_hidden_layers,
                                         num_hidden_layers, 0, num_heads,
                                         hidden_size, self.model_datatype)
+
+        self.tokenizer = tokenizer
 
         self._initialize_store()
         self._instantiate_algorithms()
@@ -639,7 +652,6 @@ class TRTLLMSampler(Sampler):
     @nvtx_range("sample_async")
     def sample_async(self, scheduled_requests: ScheduledRequests,
                      model_outputs) -> SampleStateTRTLLM:
-
         batch_size = scheduled_requests.batch_size
         beam_width = self.beam_width(scheduled_requests.all_requests())
         if (batch_size > 1 and beam_width > 1

--- a/tensorrt_llm/executor/executor.py
+++ b/tensorrt_llm/executor/executor.py
@@ -35,6 +35,9 @@ from .request import GenerationRequest, LoRARequest, PromptAdapterRequest
 from .result import GenerationResult, IterationResult
 from .utils import IntraProcessQueue, ProcessPoolExecutorSession, RequestError
 
+from transformers import PreTrainedTokenizerBase
+from ..llmapi.tokenizer import TokenizerBase
+
 if TYPE_CHECKING:
     from .proxy import GenerationExecutorProxy
     from .worker import GenerationExecutorWorker
@@ -352,6 +355,7 @@ class GenerationExecutor(ABC):
         is_llm_executor: Optional[bool] = None,
         lora_config: Optional[LoraConfig] = None,
         garbage_collection_gen0_threshold: Optional[int] = None,
+        tokenizer:PreTrainedTokenizerBase = None
     ) -> Union["GenerationExecutorProxy", "GenerationExecutorWorker"]:
         # local imports to avoid cyclic importing
         from .proxy import GenerationExecutorProxy
@@ -397,7 +401,8 @@ class GenerationExecutor(ABC):
                 postproc_worker_config=postproc_worker_config,
                 is_llm_executor=is_llm_executor,
                 garbage_collection_gen0_threshold=
-                garbage_collection_gen0_threshold)
+                garbage_collection_gen0_threshold,
+                tokenizer=tokenizer)
 
         # WAR: For the performance of gathering logits, we use single process worker
         # for TP1 to avoid the large overhead of IPC.
@@ -410,7 +415,8 @@ class GenerationExecutor(ABC):
             return GenerationExecutorWorker(**worker_kwargs,
                                             is_llm_executor=is_llm_executor,
                                             garbage_collection_gen0_threshold=
-                                            garbage_collection_gen0_threshold)
+                                            garbage_collection_gen0_threshold,
+                                            tokenizer=tokenizer)
 
         # For single-gpu case:
         # Partition the workload to multiple process for streaming performance.
@@ -424,7 +430,8 @@ class GenerationExecutor(ABC):
                 postproc_worker_config=postproc_worker_config,
                 is_llm_executor=is_llm_executor,
                 garbage_collection_gen0_threshold=
-                garbage_collection_gen0_threshold)
+                garbage_collection_gen0_threshold,
+                tokenizer=tokenizer)
         else:
             ctx = multiprocessing.get_context("spawn")
             # The ProcessPoolExecutorSession is used to support Windows, as mpi4py cannot.
@@ -437,7 +444,8 @@ class GenerationExecutor(ABC):
                 postproc_worker_config=postproc_worker_config,
                 is_llm_executor=is_llm_executor,
                 garbage_collection_gen0_threshold=
-                garbage_collection_gen0_threshold)
+                garbage_collection_gen0_threshold,
+                tokenizer=tokenizer)
 
     def wait_first_completed(
         self, futures: List[GenerationResult]

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -28,6 +28,8 @@ from .utils import (ErrorResponse, IntraProcessQueue, WorkerCommIpcAddrs,
                     is_llm_response, print_alive_threads)
 from .worker import GenerationExecutorWorker, worker_main
 
+from transformers import PreTrainedTokenizerBase
+
 __all__ = [
     "GenerationExecutorProxy",
 ]
@@ -46,6 +48,7 @@ class GenerationExecutorProxy(GenerationExecutor):
         postproc_worker_config: Optional[PostprocWorkerConfig] = None,
         is_llm_executor: Optional[bool] = None,
         garbage_collection_gen0_threshold: Optional[int] = None,
+        tokenizer:PreTrainedTokenizerBase = None,
     ) -> None:
         postproc_worker_config = postproc_worker_config or PostprocWorkerConfig(
         )
@@ -94,7 +97,8 @@ class GenerationExecutorProxy(GenerationExecutor):
                              postproc_worker_config=postproc_worker_config,
                              is_llm_executor=False,
                              garbage_collection_gen0_threshold=self.
-                             garbage_collection_gen0_threshold)
+                             garbage_collection_gen0_threshold,
+                             tokenizer=tokenizer)
 
         if "log_level" not in worker_kwargs:
             worker_kwargs["log_level"] = logger.level

--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -40,6 +40,8 @@ from .result import (GenerationResult, IterationResult, LogProbsResult,
 from .utils import (ErrorResponse, IntraProcessQueue, RequestError,
                     WorkerCommIpcAddrs, has_event_loop, is_llm_response)
 
+from transformers import PreTrainedTokenizerBase
+
 __all__ = [
     "GenerationExecutorWorker",
 ]
@@ -59,6 +61,7 @@ class GenerationExecutorWorker(GenerationExecutor):
         is_llm_executor: Optional[bool] = None,
         lora_config: Optional[LoraConfig] = None,
         garbage_collection_gen0_threshold: Optional[int] = None,
+        tokenizer:PreTrainedTokenizerBase = None
     ) -> None:
         postproc_config = postproc_worker_config or PostprocWorkerConfig()
         super().__init__(
@@ -81,6 +84,8 @@ class GenerationExecutorWorker(GenerationExecutor):
         self._executor_config = executor_config
         self._is_pytorch_backend = getattr(self._executor_config, "backend",
                                            None) == "pytorch"
+
+        self.tokenizer = tokenizer
 
         if global_mpi_size() > 1:
             logger.set_rank(self.global_rank)
@@ -134,7 +139,7 @@ class GenerationExecutorWorker(GenerationExecutor):
             else:
                 raise ValueError(
                     f"Unsupported backend config: {executor_config.backend}")
-            return create_executor(**args)
+            return create_executor(**args,tokenizer=self.tokenizer)
 
         self.engine = _create_engine()
 
@@ -610,6 +615,7 @@ def worker_main(
         bool] = True,  # whether it's the main executor instance
     lora_config: Optional[LoraConfig] = None,
     garbage_collection_gen0_threshold: Optional[int] = None,
+    tokenizer:PreTrainedTokenizerBase = None
 ) -> None:
     mpi_comm().barrier()
     print_colored_debug(f"Worker {mpi_rank()} entering worker_main...\n",
@@ -736,7 +742,8 @@ def worker_main(
             postproc_worker_config=postproc_worker_config,
             is_llm_executor=is_llm_executor,
             lora_config=lora_config,
-            garbage_collection_gen0_threshold=garbage_collection_gen0_threshold)
+            garbage_collection_gen0_threshold=garbage_collection_gen0_threshold,
+            tokenizer=tokenizer)
     except Exception as e:
         logger.error(f"Failed to initialize executor on rank {mpi_rank()}: {e}")
         logger.error(traceback.format_exc())

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -850,7 +850,8 @@ class _TrtLLM(BaseLLM):
                 postprocess_tokenizer_dir=self.args.postprocess_tokenizer_dir,
             ),
             is_llm_executor=True,
-            lora_config=self.args.lora_config)
+            lora_config=self.args.lora_config,
+            tokenizer = self._tokenizer)
 
 
 @append_docstring(TORCH_LLM_DOCSTRING)
@@ -984,7 +985,8 @@ class _TorchLLM(BaseLLM):
             is_llm_executor=True,
             lora_config=self.args.lora_config,
             garbage_collection_gen0_threshold=self.args.
-            garbage_collection_gen0_threshold)
+            garbage_collection_gen0_threshold,
+            tokenizer = self._tokenizer)
 
     def _validate_args_for_torch_backend(self, kwargs: dict) -> None:
         """Validate that users don't pass TrtLlmArgs-specific arguments when using PyTorch backend.

--- a/tensorrt_llm/sampling_params.py
+++ b/tensorrt_llm/sampling_params.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field, fields
 from typing import List, NamedTuple, Optional, Tuple, Union
 
+from transformers import PreTrainedTokenizerBase
 import torch
 from pydantic import BaseModel
 
@@ -273,6 +274,8 @@ class SamplingParams:
     # TODO: make this a per-request parameter.
     _stream_interval: Optional[int] = field(default=None, init=False, repr=False)
 
+    tokenizer:PreTrainedTokenizerBase = None
+
     def __post_init__(self):
         if self.pad_id is None:
             self.pad_id = self.end_id
@@ -334,6 +337,8 @@ class SamplingParams:
         return self.return_generation_logits and not self._generation_logits_auto_enabled
 
     def _setup(self, tokenizer, add_special_tokens: bool = False) -> "SamplingParams":
+        self.tokenizer = tokenizer
+
         if self.end_id is None:
             self.end_id = tokenizer.eos_token_id
             self.pad_id = tokenizer.pad_token_id


### PR DESCRIPTION
# imp(TorchSampler):support torchsampler stop in text Level
Currently, TorchSampler and TRTLLMSampler in TensorRT-LLM cannot implement stop word interception at the text level. Therefore, this PR implements stop word text level interception on TorchSampler.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for temperature-based sampling, allowing more control over text generation randomness.
  * Improved stop word detection by using tokenizer-based decoding for more accurate stopping criteria.
  * Enabled integration of tokenizer objects throughout the sampling and execution pipeline for enhanced text processing.

* **Bug Fixes**
  * Enhanced handling of string-based stop reasons to improve detection and output truncation.

* **Chores**
  * Updated internal interfaces to consistently accept and propagate tokenizer objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->