### PR TITLE
imp(torchsampler):support openai stop in text level

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -28,6 +28,7 @@ from .guided_decoder import GuidedDecoder
 from .model_engine import PyTorchModelEngine
 from .py_executor import PyExecutor
 
+from transformers import PreTrainedTokenizerBase
 
 class _ExecutorCreationStage(enum.Enum):
     SAMPLER = "Sampler"
@@ -185,7 +186,8 @@ def create_py_executor(
         executor_config: ExecutorConfig,
         checkpoint_dir: str = None,
         lora_config: Optional[LoraConfig] = None,
-        garbage_collection_gen0_threshold: Optional[int] = None) -> PyExecutor:
+        garbage_collection_gen0_threshold: Optional[int] = None,
+        tokenizer:PreTrainedTokenizerBase = None) -> PyExecutor:
     _mangle_executor_config(executor_config)
     pytorch_backend_config = executor_config.pytorch_backend_config
 
@@ -327,7 +329,7 @@ def create_py_executor(
 
     with mem_monitor.observe_creation_stage(_ExecutorCreationStage.SAMPLER):
         sampler = instantiate_sampler(model_engine, executor_config,
-                                      pytorch_backend_config, mapping)
+                                      pytorch_backend_config, mapping, tokenizer)
 
     guided_decoder: Optional[GuidedDecoder] = None
     if executor_config.guided_decoding_config is not None:

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -860,7 +860,8 @@ class _TrtLLM(BaseLLM):
                 postprocess_tokenizer_dir=self.args.postprocess_tokenizer_dir,
             ),
             is_llm_executor=True,
-            lora_config=self.args.lora_config)
+            lora_config=self.args.lora_config,
+            tokenizer = self._tokenizer)
 
 
 @append_docstring(TORCH_LLM_DOCSTRING)
@@ -998,7 +999,8 @@ class _TorchLLM(BaseLLM):
             is_llm_executor=True,
             lora_config=self.args.lora_config,
             garbage_collection_gen0_threshold=self.args.
-            garbage_collection_gen0_threshold)
+            garbage_collection_gen0_threshold,
+            tokenizer = self._tokenizer)
 
     def _validate_args_for_torch_backend(self, kwargs: dict) -> None:
         """Validate that users don't pass TrtLlmArgs-specific arguments when using PyTorch backend.


### PR DESCRIPTION
# imp(torchsampler):support openai stop in text level
Currently, TorchSampler and TRTLLMSampler in TensorRT-LLM cannot implement stop word interception at the text level. Therefore, this PR implements stop word text level interception on TorchSampler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for passing a tokenizer object throughout the model execution pipeline, enabling more accurate and flexible handling of stop criteria during text generation.
  * Improved stop condition detection by using tokenizer-based decoding of generated tokens.
* **Bug Fixes**
  * Enhanced stop word detection to work with decoded text, reducing errors in generation termination.
* **Chores**
  * Updated interfaces to accept and propagate an optional tokenizer parameter across relevant components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->