### PR TITLE
[None][feat] Add Qwen3 MoE support to TensorRT backend

### DIFF
--- a/tensorrt_llm/models/__init__.py
+++ b/tensorrt_llm/models/__init__.py
@@ -196,6 +196,7 @@ MODEL_MAP = {
     'Qwen2VLForConditionalGeneration': QWenForCausalLM,
     'Qwen2VLModel': QWenForCausalLM,
     'Qwen3ForCausalLM': QWenForCausalLM,
+    'Qwen3MoeForCausalLM': QWenForCausalLM,
     'WhisperEncoder': WhisperEncoder,
     'EncoderModel': EncoderModel,
     'DecoderModel': DecoderModel,

--- a/tensorrt_llm/models/qwen/config.py
+++ b/tensorrt_llm/models/qwen/config.py
@@ -150,11 +150,11 @@ class QWenConfig(PretrainedConfig):
         moe_shared_expert_intermediate_size = getattr(
             hf_config, "shared_expert_intermediate_size", 0)
         moe_normalization_mode = MoeConfig.ExpertScaleNormalizationMode.NONE
-        
+
         # Add support for mlp_only_layers and decoder_sparse_step (Qwen3 MoE)
         mlp_only_layers = getattr(hf_config, "mlp_only_layers", [])
         decoder_sparse_step = getattr(hf_config, "decoder_sparse_step", 1)
-        
+
         moe_config = MoeConfig(num_experts=moe_num_experts,
                                top_k=moe_top_k,
                                normalization_mode=moe_normalization_mode)

--- a/tensorrt_llm/models/qwen/config.py
+++ b/tensorrt_llm/models/qwen/config.py
@@ -32,6 +32,8 @@ class QWenConfig(PretrainedConfig):
                  use_logn_attn: bool = False,
                  moe: Optional[Union[MoeConfig, dict]] = None,
                  num_labels: int = 1,
+                 mlp_only_layers: Optional[list] = None,
+                 decoder_sparse_step: int = 1,
                  **kwargs):
         self.mlp_bias = mlp_bias
         self.attn_bias = attn_bias
@@ -40,6 +42,8 @@ class QWenConfig(PretrainedConfig):
         self.disable_weight_only_quant_plugin = disable_weight_only_quant_plugin
         self.num_labels = num_labels
         self.use_logn_attn = use_logn_attn
+        self.mlp_only_layers = mlp_only_layers or []
+        self.decoder_sparse_step = decoder_sparse_step
         if moe is None:
             # Legacy MOE config fields
             moe = MoeConfig(num_experts=kwargs.pop('moe_num_experts', 0),
@@ -64,6 +68,8 @@ class QWenConfig(PretrainedConfig):
         output[
             'disable_weight_only_quant_plugin'] = self.disable_weight_only_quant_plugin
         output['use_logn_attn'] = self.use_logn_attn
+        output['mlp_only_layers'] = self.mlp_only_layers
+        output['decoder_sparse_step'] = self.decoder_sparse_step
         output['moe'] = self.moe.to_dict()
         return output
 
@@ -144,6 +150,11 @@ class QWenConfig(PretrainedConfig):
         moe_shared_expert_intermediate_size = getattr(
             hf_config, "shared_expert_intermediate_size", 0)
         moe_normalization_mode = MoeConfig.ExpertScaleNormalizationMode.NONE
+        
+        # Add support for mlp_only_layers and decoder_sparse_step (Qwen3 MoE)
+        mlp_only_layers = getattr(hf_config, "mlp_only_layers", [])
+        decoder_sparse_step = getattr(hf_config, "decoder_sparse_step", 1)
+        
         moe_config = MoeConfig(num_experts=moe_num_experts,
                                top_k=moe_top_k,
                                normalization_mode=moe_normalization_mode)
@@ -189,9 +200,11 @@ class QWenConfig(PretrainedConfig):
             moe_intermediate_size=moe_intermediate_size,
             moe_shared_expert_intermediate_size=
             moe_shared_expert_intermediate_size,
+            mlp_only_layers=mlp_only_layers,
+            decoder_sparse_step=decoder_sparse_step,
             moe=moe_config,
             mapping=mapping,
-            quantization=quant_config,
+            quant_config=quant_config,
             num_labels=num_labels,
             tie_word_embeddings=tie_word_embeddings,
             **kwargs)

--- a/tensorrt_llm/models/qwen/config.py
+++ b/tensorrt_llm/models/qwen/config.py
@@ -114,7 +114,7 @@ class QWenConfig(PretrainedConfig):
             hf_config.hidden_size // hf_config.num_attention_heads)
         head_size = getattr(hf_config, "kv_channels", head_dim)
         hidden_act = getattr(hf_config, "hidden_act", "silu")
-        if qwen_type == "qwen2_moe":
+        if qwen_type in ("qwen2_moe", "qwen3_moe"):
             hidden_act = "swiglu"
 
         # Qwen3 models have no attention bias, while legacy models have bias

--- a/tensorrt_llm/models/qwen/config.py
+++ b/tensorrt_llm/models/qwen/config.py
@@ -204,7 +204,7 @@ class QWenConfig(PretrainedConfig):
             decoder_sparse_step=decoder_sparse_step,
             moe=moe_config,
             mapping=mapping,
-            quant_config=quant_config,
+            quantization=quant_config,
             num_labels=num_labels,
             tie_word_embeddings=tie_word_embeddings,
             **kwargs)

--- a/tensorrt_llm/models/qwen/convert.py
+++ b/tensorrt_llm/models/qwen/convert.py
@@ -812,7 +812,6 @@ def convert_hf_qwen(hf_model,
                     plugin_weight_only_quant_type,
                     dtype,
                     use_gemm_woq_plugin))
-                    
 
         else:
             mlp_gate_weight = get_weight(model_params, prefix + key_list[2],

--- a/tensorrt_llm/models/qwen/convert.py
+++ b/tensorrt_llm/models/qwen/convert.py
@@ -714,57 +714,57 @@ def convert_hf_qwen(hf_model,
                     dtype,
                     use_gemm_woq_plugin))
 
-        if qwen_type == "qwen2_moe" and moe_config and moe_config.has_moe():
-
-            # shared_expert for qwen2_moe
-            shared_expert_up_proj = model_params[
-                f'model.layers.{l}.mlp.shared_expert.up_proj.weight']
-            shared_expert_down_proj = model_params[
-                f'model.layers.{l}.mlp.shared_expert.down_proj.weight']
-            shared_expert_gate = model_params[
-                f'model.layers.{l}.mlp.shared_expert.gate_proj.weight']
-            shared_expert_up_proj = split(shared_expert_up_proj,
-                                          mapping.tp_size,
-                                          mapping.tp_rank,
-                                          dim=0)
-            shared_expert_down_proj = split(shared_expert_down_proj,
+        if moe_config and moe_config.has_moe():
+            if qwen_type == "qwen2_moe":
+                # shared_expert for qwen2_moe
+                shared_expert_up_proj = model_params[
+                    f'model.layers.{l}.mlp.shared_expert.up_proj.weight']
+                shared_expert_down_proj = model_params[
+                    f'model.layers.{l}.mlp.shared_expert.down_proj.weight']
+                shared_expert_gate = model_params[
+                    f'model.layers.{l}.mlp.shared_expert.gate_proj.weight']
+                shared_expert_up_proj = split(shared_expert_up_proj,
                                             mapping.tp_size,
                                             mapping.tp_rank,
-                                            dim=1)
-            shared_expert_gate = split(shared_expert_gate,
-                                       mapping.tp_size,
-                                       mapping.tp_rank,
-                                       dim=0)
-            shared_expert_gate_up_proj = torch.concat(
-                [shared_expert_up_proj, shared_expert_gate], dim=-2).to(dtype)
+                                            dim=0)
+                shared_expert_down_proj = split(shared_expert_down_proj,
+                                                mapping.tp_size,
+                                                mapping.tp_rank,
+                                                dim=1)
+                shared_expert_gate = split(shared_expert_gate,
+                                        mapping.tp_size,
+                                        mapping.tp_rank,
+                                        dim=0)
+                shared_expert_gate_up_proj = torch.concat(
+                    [shared_expert_up_proj, shared_expert_gate], dim=-2).to(dtype)
 
-            ## mlp.shared_expert.gate_up_proj.weight
-            weights.update(
-                get_tllm_linear_weight(shared_expert_gate_up_proj,
-                                       tllm_prex + 'mlp.shared_expert.fc.',
-                                       None, use_weight_only,
-                                       plugin_weight_only_quant_type, dtype,
-                                       use_gemm_woq_plugin))
+                ## mlp.shared_expert.gate_up_proj.weight
+                weights.update(
+                    get_tllm_linear_weight(shared_expert_gate_up_proj,
+                                        tllm_prex + 'mlp.shared_expert.fc.',
+                                        None, use_weight_only,
+                                        plugin_weight_only_quant_type, dtype,
+                                        use_gemm_woq_plugin))
 
-            ## mlp.shared_expert.down_proj.weight
-            weights.update(
-                get_tllm_linear_weight(shared_expert_down_proj.to(dtype),
-                                       tllm_prex + 'mlp.shared_expert.proj.',
-                                       None, use_weight_only,
-                                       plugin_weight_only_quant_type, dtype,
-                                       use_gemm_woq_plugin))
+                ## mlp.shared_expert.down_proj.weight
+                weights.update(
+                    get_tllm_linear_weight(shared_expert_down_proj.to(dtype),
+                                        tllm_prex + 'mlp.shared_expert.proj.',
+                                        None, use_weight_only,
+                                        plugin_weight_only_quant_type, dtype,
+                                        use_gemm_woq_plugin))
 
-            moe_shared_expert_gate_weights = get_weight(
-                model_params, prefix + 'mlp.shared_expert_gate', dtype)
-            weights.update(
-                get_tllm_linear_weight(
-                    moe_shared_expert_gate_weights,
-                    tllm_prex + 'mlp.shared_expert_gate.',
-                    None,
-                    False,  # Router should never be quantized
-                    plugin_weight_only_quant_type,
-                    dtype,
-                    use_gemm_woq_plugin))
+                moe_shared_expert_gate_weights = get_weight(
+                    model_params, prefix + 'mlp.shared_expert_gate', dtype)
+                weights.update(
+                    get_tllm_linear_weight(
+                        moe_shared_expert_gate_weights,
+                        tllm_prex + 'mlp.shared_expert_gate.',
+                        None,
+                        False,  # Router should never be quantized
+                        plugin_weight_only_quant_type,
+                        dtype,
+                        use_gemm_woq_plugin))
 
             ## fine-grained experts
             rank_experts = list(range(moe_config.num_experts))

--- a/tensorrt_llm/models/qwen/convert.py
+++ b/tensorrt_llm/models/qwen/convert.py
@@ -815,27 +815,18 @@ def convert_hf_qwen(hf_model,
                     
             # For Qwen3 MoE: Add standard MLP mappings for quantization compatibility
             if qwen_type == "qwen3_moe":
-                # Use the first expert from the already processed MoE weights 
-                # This ensures compatibility with the quantization system
-                first_expert_up = w3[0] if len(w3.shape) > 2 else w3  # up_proj
-                first_expert_gate = w1[0] if len(w1.shape) > 2 else w1  # gate_proj
-                first_expert_down = w2[0] if len(w2.shape) > 2 else w2  # down_proj
+                # Follow the same pattern as other MoE models (DeepSeek V2, LLaMA/Mixtral)
+                # Only create mlp.fc and mlp.proj for quantization compatibility
                 
                 # Create standard MLP weights for quantization compatibility
                 weights.update(
-                    get_tllm_linear_weight(first_expert_gate, tllm_prex + 'mlp.gate.',
+                    get_tllm_linear_weight(moe_experts_w3w1_weights, tllm_prex + 'mlp.fc.',
                                            None, use_weight_only,
                                            plugin_weight_only_quant_type, dtype,
                                            use_gemm_woq_plugin))
                                            
                 weights.update(
-                    get_tllm_linear_weight(first_expert_up, tllm_prex + 'mlp.fc.',
-                                           None, use_weight_only,
-                                           plugin_weight_only_quant_type, dtype,
-                                           use_gemm_woq_plugin))
-                                           
-                weights.update(
-                    get_tllm_linear_weight(first_expert_down, tllm_prex + 'mlp.proj.',
+                    get_tllm_linear_weight(w2.to(dtype), tllm_prex + 'mlp.proj.',
                                            None, use_weight_only,
                                            plugin_weight_only_quant_type, dtype,
                                            use_gemm_woq_plugin))

--- a/tensorrt_llm/models/qwen/convert.py
+++ b/tensorrt_llm/models/qwen/convert.py
@@ -813,23 +813,7 @@ def convert_hf_qwen(hf_model,
                     dtype,
                     use_gemm_woq_plugin))
                     
-            # For Qwen3 MoE: Add standard MLP mappings for quantization compatibility
-            if qwen_type == "qwen3_moe":
-                # Follow the same pattern as other MoE models (DeepSeek V2, LLaMA/Mixtral)
-                # Only create mlp.fc and mlp.proj for quantization compatibility
-                
-                # Create standard MLP weights for quantization compatibility
-                weights.update(
-                    get_tllm_linear_weight(moe_experts_w3w1_weights, tllm_prex + 'mlp.fc.',
-                                           None, use_weight_only,
-                                           plugin_weight_only_quant_type, dtype,
-                                           use_gemm_woq_plugin))
-                                           
-                weights.update(
-                    get_tllm_linear_weight(w2.to(dtype), tllm_prex + 'mlp.proj.',
-                                           None, use_weight_only,
-                                           plugin_weight_only_quant_type, dtype,
-                                           use_gemm_woq_plugin))
+
         else:
             mlp_gate_weight = get_weight(model_params, prefix + key_list[2],
                                          dtype)

--- a/tensorrt_llm/models/qwen/convert.py
+++ b/tensorrt_llm/models/qwen/convert.py
@@ -724,35 +724,36 @@ def convert_hf_qwen(hf_model,
                 shared_expert_gate = model_params[
                     f'model.layers.{l}.mlp.shared_expert.gate_proj.weight']
                 shared_expert_up_proj = split(shared_expert_up_proj,
-                                            mapping.tp_size,
-                                            mapping.tp_rank,
-                                            dim=0)
+                                              mapping.tp_size,
+                                              mapping.tp_rank,
+                                              dim=0)
                 shared_expert_down_proj = split(shared_expert_down_proj,
                                                 mapping.tp_size,
                                                 mapping.tp_rank,
                                                 dim=1)
                 shared_expert_gate = split(shared_expert_gate,
-                                        mapping.tp_size,
-                                        mapping.tp_rank,
-                                        dim=0)
+                                           mapping.tp_size,
+                                           mapping.tp_rank,
+                                           dim=0)
                 shared_expert_gate_up_proj = torch.concat(
-                    [shared_expert_up_proj, shared_expert_gate], dim=-2).to(dtype)
+                    [shared_expert_up_proj, shared_expert_gate],
+                    dim=-2).to(dtype)
 
                 ## mlp.shared_expert.gate_up_proj.weight
                 weights.update(
                     get_tllm_linear_weight(shared_expert_gate_up_proj,
-                                        tllm_prex + 'mlp.shared_expert.fc.',
-                                        None, use_weight_only,
-                                        plugin_weight_only_quant_type, dtype,
-                                        use_gemm_woq_plugin))
+                                           tllm_prex + 'mlp.shared_expert.fc.',
+                                           None, use_weight_only,
+                                           plugin_weight_only_quant_type, dtype,
+                                           use_gemm_woq_plugin))
 
                 ## mlp.shared_expert.down_proj.weight
                 weights.update(
-                    get_tllm_linear_weight(shared_expert_down_proj.to(dtype),
-                                        tllm_prex + 'mlp.shared_expert.proj.',
-                                        None, use_weight_only,
-                                        plugin_weight_only_quant_type, dtype,
-                                        use_gemm_woq_plugin))
+                    get_tllm_linear_weight(
+                        shared_expert_down_proj.to(dtype),
+                        tllm_prex + 'mlp.shared_expert.proj.', None,
+                        use_weight_only, plugin_weight_only_quant_type, dtype,
+                        use_gemm_woq_plugin))
 
                 moe_shared_expert_gate_weights = get_weight(
                     model_params, prefix + 'mlp.shared_expert_gate', dtype)

--- a/tensorrt_llm/models/qwen/model.py
+++ b/tensorrt_llm/models/qwen/model.py
@@ -90,11 +90,15 @@ class QWenDecoderLayer(Module):
         if config.moe.has_moe():
             mlp_kwargs = {'moe_config': config.moe, 'mapping': config.mapping}
             if config.qwen_type == 'qwen2_moe':
+                # Qwen2 MoE uses SharedMoE with shared expert
                 ClsMLP = SharedMoE
                 mlp_kwargs['use_shared_gate'] = True
                 mlp_kwargs['use_side_stream'] = True
                 mlp_kwargs['moe_config'].shared_expert_intermediate_size = \
                     config.moe_shared_expert_intermediate_size
+            elif config.qwen_type == 'qwen3_moe':
+                # Qwen3 MoE uses standard MOE without shared expert
+                ClsMLP = MOE
             else:
                 ClsMLP = MOE
         else:
@@ -104,7 +108,7 @@ class QWenDecoderLayer(Module):
         # Qwen's real inter_size depends on qwen_type
         if self.config.qwen_type == 'qwen':
             intermediate_size = config.intermediate_size // 2
-        elif self.config.qwen_type == 'qwen2_moe':
+        elif self.config.qwen_type in ('qwen2_moe', 'qwen3_moe'):
             intermediate_size = config.moe_intermediate_size
         else:
             intermediate_size = config.intermediate_size
@@ -264,25 +268,23 @@ class QWenForCausalLM(DecoderModelForCausalLM):
                 "mlp_4h_to_h": "mlp.c_proj",
                 "mlp_gate": "w1",
             }
-        elif config.qwen_type == 'qwen2_moe':
+        elif config.qwen_type in ('qwen2_moe', 'qwen3_moe'):
             self.trtllm_modules_to_hf_modules = copy.copy(
                 get_default_trtllm_modules_to_hf_modules())
+            # Common MoE expert mappings for both Qwen2 and Qwen3 MoE
             self.trtllm_modules_to_hf_modules.update({
-                "mlp_h_to_4h":
-                "mlp.shared_expert.gate_proj",
-                "mlp_4h_to_h":
-                "mlp.shared_expert.down_proj",
-                "mlp_gate":
-                "mlp.shared_expert.up_proj",
-                "mlp_router":
-                "mlp.shared_expert_gate",
-                "moe_h_to_4h":
-                "mlp.experts.gate_proj",
-                "moe_4h_to_h":
-                "mlp.experts.down_proj",
-                "moe_gate":
-                "mlp.experts.up_proj",
+                "moe_h_to_4h": "mlp.experts.gate_proj",
+                "moe_4h_to_h": "mlp.experts.down_proj",
+                "moe_gate": "mlp.experts.up_proj",
             })
+            # Qwen2 MoE additionally has shared expert
+            if config.qwen_type == 'qwen2_moe':
+                self.trtllm_modules_to_hf_modules.update({
+                    "mlp_h_to_4h": "mlp.shared_expert.gate_proj",
+                    "mlp_4h_to_h": "mlp.shared_expert.down_proj",
+                    "mlp_gate": "mlp.shared_expert.up_proj",
+                    "mlp_router": "mlp.shared_expert_gate",
+                })
         else:
             self.trtllm_modules_to_hf_modules = None
         super().__init__(config, transformer, lm_head)
@@ -343,6 +345,12 @@ class QWenForCausalLM(DecoderModelForCausalLM):
                     "mlp.shared_expert_gate": "mlp.shared_expert_gate",
                     "fc": ["up_proj", "gate_proj"],
                 }
+            elif config.qwen_type == "qwen3_moe":
+                custom_dict = {
+                    "fc": ["up_proj", "gate_proj"],  # MoE experts weight mapping
+                    "q_layernorm": "q_norm",         # Q normalization for Qwen3
+                    "k_layernorm": "k_norm",         # K normalization for Qwen3
+                }
             elif config.qwen_type in {"qwen2", "qwen2_vl"
                                       } and config.tie_word_embeddings:
                 custom_dict = {"lm_head": "model.embed_tokens"}
@@ -360,7 +368,7 @@ class QWenForCausalLM(DecoderModelForCausalLM):
                     "transformer": "language_model.model",
                     "lm_head": "language_model.lm_head",
                 }
-            elif config.qwen_type in ("qwen3", "qwen3_moe"):
+            elif config.qwen_type == "qwen3":
                 custom_dict = {
                     "q_layernorm": "q_norm",
                     "k_layernorm": "k_norm",
@@ -412,7 +420,7 @@ class QWenForCausalLM(DecoderModelForCausalLM):
                             loader.load(tllm_key,
                                         custom_postprocess_kwargs=arg_dict))
                 loader.fill(tllm_weights)
-            elif config.qwen_type == "qwen2_moe":
+            elif config.qwen_type in ("qwen2_moe", "qwen3_moe"):
                 for tllm_key, _ in model.named_parameters():
                     sub_module = model
                     for attr in tllm_key.split(".")[:-1]:

--- a/tensorrt_llm/models/qwen/model.py
+++ b/tensorrt_llm/models/qwen/model.py
@@ -273,17 +273,24 @@ class QWenForCausalLM(DecoderModelForCausalLM):
                 get_default_trtllm_modules_to_hf_modules())
             # Common MoE expert mappings for both Qwen2 and Qwen3 MoE
             self.trtllm_modules_to_hf_modules.update({
-                "moe_h_to_4h": "mlp.experts.gate_proj",
-                "moe_4h_to_h": "mlp.experts.down_proj",
-                "moe_gate": "mlp.experts.up_proj",
+                "moe_h_to_4h":
+                "mlp.experts.gate_proj",
+                "moe_4h_to_h":
+                "mlp.experts.down_proj",
+                "moe_gate":
+                "mlp.experts.up_proj",
             })
             # Qwen2 MoE additionally has shared expert
             if config.qwen_type == 'qwen2_moe':
                 self.trtllm_modules_to_hf_modules.update({
-                    "mlp_h_to_4h": "mlp.shared_expert.gate_proj",
-                    "mlp_4h_to_h": "mlp.shared_expert.down_proj",
-                    "mlp_gate": "mlp.shared_expert.up_proj",
-                    "mlp_router": "mlp.shared_expert_gate",
+                    "mlp_h_to_4h":
+                    "mlp.shared_expert.gate_proj",
+                    "mlp_4h_to_h":
+                    "mlp.shared_expert.down_proj",
+                    "mlp_gate":
+                    "mlp.shared_expert.up_proj",
+                    "mlp_router":
+                    "mlp.shared_expert_gate",
                 })
         else:
             self.trtllm_modules_to_hf_modules = None
@@ -347,9 +354,10 @@ class QWenForCausalLM(DecoderModelForCausalLM):
                 }
             elif config.qwen_type == "qwen3_moe":
                 custom_dict = {
-                    "fc": ["up_proj", "gate_proj"],  # MoE experts weight mapping
-                    "q_layernorm": "q_norm",         # Q normalization for Qwen3
-                    "k_layernorm": "k_norm",         # K normalization for Qwen3
+                    "fc": ["up_proj",
+                           "gate_proj"],  # MoE experts weight mapping
+                    "q_layernorm": "q_norm",  # Q normalization for Qwen3
+                    "k_layernorm": "k_norm",  # K normalization for Qwen3
                 }
             elif config.qwen_type in {"qwen2", "qwen2_vl"
                                       } and config.tie_word_embeddings:

--- a/tensorrt_llm/models/qwen/model.py
+++ b/tensorrt_llm/models/qwen/model.py
@@ -354,13 +354,7 @@ class QWenForCausalLM(DecoderModelForCausalLM):
                 }
             elif config.qwen_type == "qwen3_moe":
                 custom_dict = {
-                    # Map MoE experts to standard MLP layers for quantization compatibility
-                    # Follow the same pattern as other MoE models (only mlp.fc and mlp.proj)
-                    "mlp.fc": ["mlp.experts.up_proj", "mlp.experts.gate_proj"],
-                    "mlp.proj": "mlp.experts.down_proj",
-                    # Standard FC mapping for MoE experts
                     "fc": ["up_proj", "gate_proj"],
-                    # Qwen3 normalization layers
                     "q_layernorm": "q_norm",
                     "k_layernorm": "k_norm",
                 }

--- a/tensorrt_llm/models/qwen/model.py
+++ b/tensorrt_llm/models/qwen/model.py
@@ -357,7 +357,7 @@ class QWenForCausalLM(DecoderModelForCausalLM):
                     # Map MoE experts to standard MLP layers for quantization compatibility
                     # Follow the same pattern as other MoE models (only mlp.fc and mlp.proj)
                     "mlp.fc": ["mlp.experts.up_proj", "mlp.experts.gate_proj"],
-                    "mlp.proj": "mlp.experts.down_proj", 
+                    "mlp.proj": "mlp.experts.down_proj",
                     # Standard FC mapping for MoE experts
                     "fc": ["up_proj", "gate_proj"],
                     # Qwen3 normalization layers

--- a/tensorrt_llm/models/qwen/model.py
+++ b/tensorrt_llm/models/qwen/model.py
@@ -354,10 +354,15 @@ class QWenForCausalLM(DecoderModelForCausalLM):
                 }
             elif config.qwen_type == "qwen3_moe":
                 custom_dict = {
-                    "fc": ["up_proj",
-                           "gate_proj"],  # MoE experts weight mapping
-                    "q_layernorm": "q_norm",  # Q normalization for Qwen3
-                    "k_layernorm": "k_norm",  # K normalization for Qwen3
+                    # Map MoE experts to standard MLP layers for quantization compatibility
+                    "mlp.fc": ["mlp.experts.up_proj", "mlp.experts.gate_proj"],
+                    "mlp.proj": "mlp.experts.down_proj", 
+                    "mlp.router": "mlp.gate",
+                    # Standard FC mapping for MoE experts
+                    "fc": ["up_proj", "gate_proj"],
+                    # Qwen3 normalization layers
+                    "q_layernorm": "q_norm",
+                    "k_layernorm": "k_norm",
                 }
             elif config.qwen_type in {"qwen2", "qwen2_vl"
                                       } and config.tie_word_embeddings:

--- a/tensorrt_llm/models/qwen/model.py
+++ b/tensorrt_llm/models/qwen/model.py
@@ -355,9 +355,9 @@ class QWenForCausalLM(DecoderModelForCausalLM):
             elif config.qwen_type == "qwen3_moe":
                 custom_dict = {
                     # Map MoE experts to standard MLP layers for quantization compatibility
+                    # Follow the same pattern as other MoE models (only mlp.fc and mlp.proj)
                     "mlp.fc": ["mlp.experts.up_proj", "mlp.experts.gate_proj"],
                     "mlp.proj": "mlp.experts.down_proj", 
-                    "mlp.router": "mlp.gate",
                     # Standard FC mapping for MoE experts
                     "fc": ["up_proj", "gate_proj"],
                     # Qwen3 normalization layers


### PR DESCRIPTION
Implements TensorRT-LLM support for Qwen3 MoE models with architectural differences from Qwen2 MoE:

## Implement
- Add 'Qwen3MoeForCausalLM' to MODEL_MAP for automatic detection
- Add 'qwen3_moe' to valid model types in QWenConfig
- Use standard MOE implementation for Qwen3 MoE **without shared experts**
- Update weight conversion logic to handle Qwen3 MoE's expert structure
- Refactor trtllm_modules_to_hf_modules mapping to distinguish between Qwen2 MoE (with shared experts) and Qwen3 MoE (without shared experts)


## Testing
- Successfully creates Qwen3-30B-A3B MoE Engine (FP16, FP8)

ref)
vllm vs tensorrt-llm latency (Qwen3-30B-A3B MoE, H100 PCIe GPU, 2048 input_length, 3072 max_length, batch 16)

<html>
<head>

</head>
<body>

Precision | Framework | TTFT (ms) | TPS (tokens/s)
-- | -- | -- | --
FP16 | vLLM | 152.750 | 727.76
  | TRT (torch backend) | 127.477 | 785.82
  | TRT (trt backend) | 73.729 | 764.59
FP8 | vLLM | 175.951 | 993.81
  | TRT (torch backend) | 128.124 | 1164.08
  | TRT (trt backend) | 84.660 | 1206.60


</body>
</html>

Dear Maintainers,

I would like to kindly submit a pull request that adds support for building the Qwen3-MoE model as a TensorRT engine.
I would be truly grateful if you could take the time to review it at your convenience.

Thank you very much for your consideration.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for the "qwen3_moe" model variant, including activation functions, model mappings, and weight loading.
  * Introduced new configuration options for layer-specific MLP control and decoder sparsity steps.
* **Refactor**
  * Enhanced conditional logic for handling Mixture of Experts (MoE) models, improving clarity and extensibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->