### PR TITLE
[TRTLLM-6685][feat] Add speculative metrics for trt llm bench

### DIFF
--- a/tensorrt_llm/bench/dataclasses/reporting.py
+++ b/tensorrt_llm/bench/dataclasses/reporting.py
@@ -663,23 +663,7 @@ class ReportUtility:
         return self.statistics
 
     def get_max_draft_len(self) -> int:
-        """Get max_draft_len from rt_cfg or speculative_config."""
-        # Try to get from rt_cfg first
-        if (self.rt_cfg.decoding_config
-                and self.rt_cfg.decoding_config.decoding_mode
-                != SpeculativeDecodingMode.NONE):
-            # For C++ backend, max_draft_len is stored in the engine config
-            # We need to read it from the engine config file
-            if self.rt_cfg.engine_dir:
-                config_path = self.rt_cfg.engine_dir / "config.json"
-                try:
-                    with open(config_path, "r") as config:
-                        engine_config = json.load(config)
-                    build_cfg = engine_config["build_config"]
-                    return build_cfg.get("max_draft_len", 0)
-                except (FileNotFoundError, KeyError, json.JSONDecodeError):
-                    pass
-
+        """Get max_draft_len from speculative_config."""
         # Try to get from speculative_config
         if ("speculative_config" in self.kwargs
                 and self.kwargs["speculative_config"] is not None):

--- a/tensorrt_llm/bench/dataclasses/reporting.py
+++ b/tensorrt_llm/bench/dataclasses/reporting.py
@@ -119,9 +119,9 @@ class StatsKeeper:
             # For speculative decoding, we need to track the number of draft tokens per request and the number of accepted draft tokens per request
             if max_draft_tokens > 0:
                 num_draft_tokens.append(max_draft_tokens * (entry.decode_iteration + 1))
-                num_accepted_draft_tokens.append(entry.num_generated_tokens - entry.decode_iteration - 1)
+                num_accepted_draft_tokens.append(entry.num_total_output_tokens - entry.decode_iteration - 1)
                 draft_acceptance_rate.append(float(num_accepted_draft_tokens[-1]) / float(num_draft_tokens[-1]))
-                acceptance_length.append(entry.num_generated_tokens / (entry.decode_iteration +
+                acceptance_length.append(entry.num_total_output_tokens / (entry.decode_iteration +
                                                        1))
 
         global_acceptance_length = sum(output_tokens) / total_decoding_iterations

--- a/tensorrt_llm/bench/dataclasses/reporting.py
+++ b/tensorrt_llm/bench/dataclasses/reporting.py
@@ -118,15 +118,20 @@ class StatsKeeper:
 
             # For speculative decoding, we need to track the number of draft tokens per request and the number of accepted draft tokens per request
             if max_draft_tokens > 0:
-                num_draft_tokens.append(max_draft_tokens * (entry.decode_iteration + 1))
-                num_accepted_draft_tokens.append(entry.num_total_output_tokens - entry.decode_iteration - 1)
-                draft_acceptance_rate.append(float(num_accepted_draft_tokens[-1]) / float(num_draft_tokens[-1]))
-                acceptance_length.append(entry.num_total_output_tokens / (entry.decode_iteration +
-                                                       1))
+                num_draft_tokens.append(max_draft_tokens *
+                                        (entry.decode_iteration + 1))
+                num_accepted_draft_tokens.append(entry.num_total_output_tokens -
+                                                 entry.decode_iteration - 1)
+                draft_acceptance_rate.append(
+                    float(num_accepted_draft_tokens[-1]) /
+                    float(num_draft_tokens[-1]))
+                acceptance_length.append(entry.num_total_output_tokens /
+                                         (entry.decode_iteration + 1))
 
-        global_acceptance_length = sum(output_tokens) / total_decoding_iterations
+        global_acceptance_length = sum(
+            output_tokens) / total_decoding_iterations
         queue_time_total = last_queue_time - start_time
-        
+
         num_draft_tokens_percentiles = PercentileStats.from_iterable(
             num_draft_tokens) if num_draft_tokens else None
         num_accepted_draft_tokens_percentiles = PercentileStats.from_iterable(
@@ -156,7 +161,8 @@ class StatsKeeper:
             issue_rate_ns=queue_time_total / num_requests,
             acceptance_length=global_acceptance_length,
             num_draft_tokens_percentiles=num_draft_tokens_percentiles,
-            num_accepted_draft_tokens_percentiles=num_accepted_draft_tokens_percentiles,
+            num_accepted_draft_tokens_percentiles=
+            num_accepted_draft_tokens_percentiles,
             draft_acceptance_rate_percentiles=draft_acceptance_rate_percentiles,
             acceptance_length_percentiles=acceptance_length_percentiles,
         )
@@ -188,7 +194,8 @@ class ReportUtility:
         self.logger = logger
         self.kwargs = kwargs
         self.raw_statistics = statistics
-        self.statistics = statistics.generate_statistics_summary(self.get_max_draft_len())
+        self.statistics = statistics.generate_statistics_summary(
+            self.get_max_draft_len())
         self.streaming = streaming
 
     @staticmethod
@@ -436,16 +443,20 @@ class ReportUtility:
                 decoding_mode,
                 "num_draft_tokens_percentiles":
                 self.statistics.num_draft_tokens_percentiles.model_dump(
-                    exclude_none=True, by_alias=True, mode='json') if self.statistics.num_draft_tokens_percentiles else None,
+                    exclude_none=True, by_alias=True, mode='json')
+                if self.statistics.num_draft_tokens_percentiles else None,
                 "num_accepted_draft_tokens_percentiles":
-                self.statistics.num_accepted_draft_tokens_percentiles.model_dump(
-                    exclude_none=True, by_alias=True, mode='json') if self.statistics.num_accepted_draft_tokens_percentiles else None,
+                self.statistics.num_accepted_draft_tokens_percentiles.
+                model_dump(exclude_none=True, by_alias=True, mode='json') if
+                self.statistics.num_accepted_draft_tokens_percentiles else None,
                 "draft_acceptance_rate_percentiles":
                 self.statistics.draft_acceptance_rate_percentiles.model_dump(
-                    exclude_none=True, by_alias=True, mode='json') if self.statistics.draft_acceptance_rate_percentiles else None,
+                    exclude_none=True, by_alias=True, mode='json')
+                if self.statistics.draft_acceptance_rate_percentiles else None,
                 "acceptance_length_percentiles":
                 self.statistics.acceptance_length_percentiles.model_dump(
-                    exclude_none=True, by_alias=True, mode='json') if self.statistics.acceptance_length_percentiles else None
+                    exclude_none=True, by_alias=True, mode='json')
+                if self.statistics.acceptance_length_percentiles else None
             }
         # Dataset metadata
         stats_dict["dataset"] = self.dataset_metadata.model_dump(by_alias=True,
@@ -588,23 +599,37 @@ class ReportUtility:
             if self.get_max_draft_len() > 0:
                 num_draft_tokens = decoding["num_draft_tokens_percentiles"]
                 num_draft_tokens_stats = "\n".join(
-                    f"[DT] {key.upper():<7}: {num_draft_tokens[key]:.2f}" for key in
-                    ["minimum", "maximum", "average", "p50", "p90", "p95", "p99"])
+                    f"[DT] {key.upper():<7}: {num_draft_tokens[key]:.2f}"
+                    for key in [
+                        "minimum", "maximum", "average", "p50", "p90", "p95",
+                        "p99"
+                    ])
 
-                num_accepted_draft_tokens = decoding["num_accepted_draft_tokens_percentiles"]
+                num_accepted_draft_tokens = decoding[
+                    "num_accepted_draft_tokens_percentiles"]
                 num_accepted_draft_tokens_stats = "\n".join(
-                    f"[ADT] {key.upper():<7}: {num_accepted_draft_tokens[key]:.2f}" for key in
-                    ["minimum", "maximum", "average", "p50", "p90", "p95", "p99"])
+                    f"[ADT] {key.upper():<7}: {num_accepted_draft_tokens[key]:.2f}"
+                    for key in [
+                        "minimum", "maximum", "average", "p50", "p90", "p95",
+                        "p99"
+                    ])
 
-                draft_acceptance_rate = decoding["draft_acceptance_rate_percentiles"]
+                draft_acceptance_rate = decoding[
+                    "draft_acceptance_rate_percentiles"]
                 draft_acceptance_rate_stats = "\n".join(
-                    f"[DAR] {key.upper():<7}: {draft_acceptance_rate[key]:.2f}" for key in
-                    ["minimum", "maximum", "average", "p50", "p90", "p95", "p99"])
+                    f"[DAR] {key.upper():<7}: {draft_acceptance_rate[key]:.2f}"
+                    for key in [
+                        "minimum", "maximum", "average", "p50", "p90", "p95",
+                        "p99"
+                    ])
 
                 acceptance_length = decoding["acceptance_length_percentiles"]
                 acceptance_length_stats = "\n".join(
-                    f"[AL] {key.upper():<7}: {acceptance_length[key]:.2f}" for key in
-                    ["minimum", "maximum", "average", "p50", "p90", "p95", "p99"])
+                    f"[AL] {key.upper():<7}: {acceptance_length[key]:.2f}"
+                    for key in [
+                        "minimum", "maximum", "average", "p50", "p90", "p95",
+                        "p99"
+                    ])
 
                 decoding_stats = (
                     "===========================================================\n"
@@ -624,7 +649,8 @@ class ReportUtility:
                     "-- Acceptance Length Details --------------------------------\n\n"
                     f"{acceptance_length_stats}"
                     f"\n"
-                    "===========================================================\n")
+                    "===========================================================\n"
+                )
 
         logging_info = (f"{backend_info}"
                         f"{request_info}"
@@ -653,11 +679,10 @@ class ReportUtility:
                     return build_cfg.get("max_draft_len", 0)
                 except (FileNotFoundError, KeyError, json.JSONDecodeError):
                     pass
-        
+
         # Try to get from speculative_config
         if ("speculative_config" in self.kwargs
                 and self.kwargs["speculative_config"] is not None):
             return self.kwargs["speculative_config"].max_draft_len or 0
-        
-        return 0
 
+        return 0

--- a/tensorrt_llm/bench/dataclasses/reporting.py
+++ b/tensorrt_llm/bench/dataclasses/reporting.py
@@ -72,7 +72,7 @@ class StatsKeeper:
         if request_perf_item.response_is_final:
             self.num_complete = self.num_complete + 1
 
-    def generate_statistics_summary(self) -> None:
+    def generate_statistics_summary(self, max_draft_tokens: int) -> None:
         """Generate summary statistics from internally stored statistics.
 
         Returns:
@@ -90,42 +90,57 @@ class StatsKeeper:
 
         intertoken_avg_latencies = []
         output_tokens = []
-        request_acceptance = []
         total_decoding_iterations = 0
         ttft_times = []
         last_queue_time = 0.0
         queue_time_total = 0.0
 
+        num_draft_tokens = []
+        num_accepted_draft_tokens = []
+        draft_acceptance_rate = []
+        acceptance_length = []
+
         for entry in self.requests.values():
             start_time = min(entry.start_timestamp, start_time)
             end_time = max(entry.end_timestamp, end_time)
             last_queue_time = max(entry.start_timestamp, last_queue_time)
-            request_ar = entry.num_generated_tokens / (entry.decode_iteration +
-                                                       1)
 
             request_latencies.append(entry.end_to_end_latency)
             generation_latencies.append(entry.generation_time)
             generation_throughputs.append(entry.generation_token_throughput)
             ttft_times.append(entry.time_to_first_token)
             intertoken_avg_latencies.append(entry.intertoken_latency)
-            request_acceptance.append(request_ar)
             output_throughput_per_user.append(entry.output_token_throughput)
             total_decoding_iterations += entry.decode_iteration + 1
 
             output_tokens.append(entry.num_total_output_tokens)
             total_input_tokens += entry.num_input_tokens
 
-        global_acceptance_rate = sum(output_tokens) / total_decoding_iterations
+            # For speculative decoding, we need to track the number of draft tokens per request and the number of accepted draft tokens per request
+            if max_draft_tokens > 0:
+                num_draft_tokens.append(max_draft_tokens * (entry.decode_iteration + 1))
+                num_accepted_draft_tokens.append(entry.num_generated_tokens - entry.decode_iteration - 1)
+                draft_acceptance_rate.append(float(num_accepted_draft_tokens[-1]) / float(num_draft_tokens[-1]))
+                acceptance_length.append(entry.num_generated_tokens / (entry.decode_iteration +
+                                                       1))
+
+        global_acceptance_length = sum(output_tokens) / total_decoding_iterations
         queue_time_total = last_queue_time - start_time
-        percentile_request_accept = PercentileStats.from_iterable(
-            request_acceptance) if request_acceptance else None
+        
+        num_draft_tokens_percentiles = PercentileStats.from_iterable(
+            num_draft_tokens) if num_draft_tokens else None
+        num_accepted_draft_tokens_percentiles = PercentileStats.from_iterable(
+            num_accepted_draft_tokens) if num_accepted_draft_tokens else None
+        draft_acceptance_rate_percentiles = PercentileStats.from_iterable(
+            draft_acceptance_rate) if draft_acceptance_rate else None
+        acceptance_length_percentiles = PercentileStats.from_iterable(
+            acceptance_length) if acceptance_length else None
 
         stats = BenchmarkStatistics(
             num_requests=num_requests,
             total_latency_ns=end_time - start_time,
             total_output_tokens=sum(output_tokens),
             total_input_tokens=total_input_tokens,
-            acceptance_rate=global_acceptance_rate,
             request_latency_percentiles=PercentileStats.from_iterable(
                 request_latencies),
             tpot_percentiles=PercentileStats.from_iterable(
@@ -139,7 +154,11 @@ class StatsKeeper:
                 generation_latencies),
             token_percentiles=PercentileStats.from_iterable(output_tokens),
             issue_rate_ns=queue_time_total / num_requests,
-            acceptance_percentiles=percentile_request_accept,
+            acceptance_length=global_acceptance_length,
+            num_draft_tokens_percentiles=num_draft_tokens_percentiles,
+            num_accepted_draft_tokens_percentiles=num_accepted_draft_tokens_percentiles,
+            draft_acceptance_rate_percentiles=draft_acceptance_rate_percentiles,
+            acceptance_length_percentiles=acceptance_length_percentiles,
         )
 
         return stats
@@ -164,12 +183,12 @@ class ReportUtility:
             logger (Logger): A logger for logging.
             streaming (bool, optional): Streaming benchmark used. Defaults to False.
         """
-        self.raw_statistics = statistics
-        self.statistics = statistics.generate_statistics_summary()
         self.dataset_metadata = dataset_metadata
         self.rt_cfg = rt_cfg
         self.logger = logger
         self.kwargs = kwargs
+        self.raw_statistics = statistics
+        self.statistics = statistics.generate_statistics_summary(self.get_max_draft_len())
         self.streaming = streaming
 
     @staticmethod
@@ -415,9 +434,18 @@ class ReportUtility:
             stats_dict["decoding_stats"] = {
                 "mode":
                 decoding_mode,
-                "acceptance_percentiles":
-                self.statistics.acceptance_percentiles.model_dump(
-                    exclude_none=True, by_alias=True, mode='json')
+                "num_draft_tokens_percentiles":
+                self.statistics.num_draft_tokens_percentiles.model_dump(
+                    exclude_none=True, by_alias=True, mode='json') if self.statistics.num_draft_tokens_percentiles else None,
+                "num_accepted_draft_tokens_percentiles":
+                self.statistics.num_accepted_draft_tokens_percentiles.model_dump(
+                    exclude_none=True, by_alias=True, mode='json') if self.statistics.num_accepted_draft_tokens_percentiles else None,
+                "draft_acceptance_rate_percentiles":
+                self.statistics.draft_acceptance_rate_percentiles.model_dump(
+                    exclude_none=True, by_alias=True, mode='json') if self.statistics.draft_acceptance_rate_percentiles else None,
+                "acceptance_length_percentiles":
+                self.statistics.acceptance_length_percentiles.model_dump(
+                    exclude_none=True, by_alias=True, mode='json') if self.statistics.acceptance_length_percentiles else None
             }
         # Dataset metadata
         stats_dict["dataset"] = self.dataset_metadata.model_dump(by_alias=True,
@@ -557,21 +585,46 @@ class ReportUtility:
         decoding_stats = ""
         if decoding is not None:
             decoding = stats_dict["decoding_stats"]
-            acc = decoding["acceptance_percentiles"]
-            acc_stats = "\n".join(
-                f"[AR] {key.upper():<7}: {acc[key]:.2f}" for key in
-                ["minimum", "maximum", "average", "p50", "p90", "p95", "p99"])
+            if self.get_max_draft_len() > 0:
+                num_draft_tokens = decoding["num_draft_tokens_percentiles"]
+                num_draft_tokens_stats = "\n".join(
+                    f"[DT] {key.upper():<7}: {num_draft_tokens[key]:.2f}" for key in
+                    ["minimum", "maximum", "average", "p50", "p90", "p95", "p99"])
 
-            decoding_stats = (
-                "===========================================================\n"
-                f"= DECODING STATISTICS ({decoding['mode']})\n"
-                "===========================================================\n"
-                "\n"
-                "-- Acceptance Rate Details --------------------------------\n\n"
-                "\n"
-                f"{acc_stats}"
-                f"\n"
-                "===========================================================\n")
+                num_accepted_draft_tokens = decoding["num_accepted_draft_tokens_percentiles"]
+                num_accepted_draft_tokens_stats = "\n".join(
+                    f"[ADT] {key.upper():<7}: {num_accepted_draft_tokens[key]:.2f}" for key in
+                    ["minimum", "maximum", "average", "p50", "p90", "p95", "p99"])
+
+                draft_acceptance_rate = decoding["draft_acceptance_rate_percentiles"]
+                draft_acceptance_rate_stats = "\n".join(
+                    f"[DAR] {key.upper():<7}: {draft_acceptance_rate[key]:.2f}" for key in
+                    ["minimum", "maximum", "average", "p50", "p90", "p95", "p99"])
+
+                acceptance_length = decoding["acceptance_length_percentiles"]
+                acceptance_length_stats = "\n".join(
+                    f"[AL] {key.upper():<7}: {acceptance_length[key]:.2f}" for key in
+                    ["minimum", "maximum", "average", "p50", "p90", "p95", "p99"])
+
+                decoding_stats = (
+                    "===========================================================\n"
+                    f"= DECODING STATISTICS ({decoding['mode']})\n"
+                    "===========================================================\n"
+                    "\n"
+                    "-- Number of Draft Tokens Details --------------------------------\n\n"
+                    "\n"
+                    f"{num_draft_tokens_stats}"
+                    f"\n"
+                    "-- Number of Accepted Draft Tokens Details --------------------------------\n\n"
+                    f"{num_accepted_draft_tokens_stats}"
+                    f"\n"
+                    "-- Draft Acceptance Rate Details --------------------------------\n\n"
+                    f"{draft_acceptance_rate_stats}"
+                    f"\n"
+                    "-- Acceptance Length Details --------------------------------\n\n"
+                    f"{acceptance_length_stats}"
+                    f"\n"
+                    "===========================================================\n")
 
         logging_info = (f"{backend_info}"
                         f"{request_info}"
@@ -582,3 +635,29 @@ class ReportUtility:
                         f"{self.dataset_metadata.get_summary_for_print()}")
         self.logger.info(logging_info)
         return self.statistics
+
+    def get_max_draft_len(self) -> int:
+        """Get max_draft_len from rt_cfg or speculative_config."""
+        # Try to get from rt_cfg first
+        if (self.rt_cfg.decoding_config
+                and self.rt_cfg.decoding_config.decoding_mode
+                != SpeculativeDecodingMode.NONE):
+            # For C++ backend, max_draft_len is stored in the engine config
+            # We need to read it from the engine config file
+            if self.rt_cfg.engine_dir:
+                config_path = self.rt_cfg.engine_dir / "config.json"
+                try:
+                    with open(config_path, "r") as config:
+                        engine_config = json.load(config)
+                    build_cfg = engine_config["build_config"]
+                    return build_cfg.get("max_draft_len", 0)
+                except (FileNotFoundError, KeyError, json.JSONDecodeError):
+                    pass
+        
+        # Try to get from speculative_config
+        if ("speculative_config" in self.kwargs
+                and self.kwargs["speculative_config"] is not None):
+            return self.kwargs["speculative_config"].max_draft_len or 0
+        
+        return 0
+

--- a/tensorrt_llm/bench/dataclasses/statistics.py
+++ b/tensorrt_llm/bench/dataclasses/statistics.py
@@ -127,7 +127,7 @@ class BenchmarkStatistics(BaseModel):
     issue_rate_ns: float
 
     # Speculative Information
-    acceptance_rate: float
+    acceptance_length: float
 
     # Percentile-related Statistics
     request_latency_percentiles: Optional[PercentileStats] = None
@@ -137,7 +137,11 @@ class BenchmarkStatistics(BaseModel):
     ttft_percentiles: Optional[PercentileStats] = None
     generation_tp_percentiles: Optional[PercentileStats] = None
     generation_latency_percentiles: Optional[PercentileStats] = None
-    acceptance_percentiles: Optional[PercentileStats] = None
+    # Percentile-related Speculative Statistics
+    num_draft_tokens_percentiles: Optional[PercentileStats] = None
+    num_accepted_draft_tokens_percentiles: Optional[PercentileStats] = None
+    draft_acceptance_rate_percentiles: Optional[PercentileStats] = None
+    acceptance_length_percentiles: Optional[PercentileStats] = None
 
     @computed_field
     def sum_per_request_latencies_ns(self) -> float:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **New Features**
  * Added comprehensive tracking and reporting of speculative decoding draft token metrics, including draft tokens number, accepted draft tokens number, acceptance rates, and acceptance lengths.
  * Introduced detailed percentile statistics for these new metrics in benchmark reports.
  * Added the ability to retrieve the maximum draft length configuration for speculative decoding.

* **Improvements**
  * Enhanced benchmark statistics output with more granular and informative speculative decoding metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

[JIRA ticket/NVBugs ID/GitHub issue][fix/feat/doc/infra/...] \<summary of this PR\>

For example, assume I have a PR to support a new feature about cache manager for JIRA ticket TRTLLM-1000, it would be like:

[TRTLLM-1000][feat] Support a new feature about cache manager

Or I have a PR to fix a Llama3 accuracy issue:

[https://nvbugs/1234567][fix] Fix Llama3 accuracy issue
-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
