### PR TITLE
fix: correct scaling factor calculation in tests/unittest/trt/functional/test_fp4_gemm.py

### DIFF
--- a/tests/unittest/trt/functional/test_fp4_gemm.py
+++ b/tests/unittest/trt/functional/test_fp4_gemm.py
@@ -83,8 +83,8 @@ def random_fp4_tensor_and_sf_v2(shape, sf_vec_size):
     float_tensor = torch.randn(shape, dtype=torch.float32)
     half_tensor = float_tensor.to(torch.float16).cuda()
 
-    # global scale trick for int4 quantization.
-    alpha = 448.0 / (torch.max(float_tensor) / 6.0)
+    # global scale trick for fp4 quantization.
+    alpha = (448 * 6) / float_tensor.abs().max().float()
     sf_scale_tensor = torch.FloatTensor([alpha]).cuda()
     gemm_alpha_tensor = torch.FloatTensor([1.0 / alpha])
 
@@ -282,9 +282,8 @@ class TestFunctional(unittest.TestCase):
 
         input_fp16 = input_fp32.to(torch.float16).cuda()
 
-        # global scale trick for int4 quantization.
-        alpha = 448.0 / (torch.max(input_fp32) / 6.0)
-
+        # global scale trick for fp4 quantization.
+        alpha = (448 * 6) / input_fp32.abs().max().float()
         weights_fp32_transposed = torch.transpose(weights_fp32, 0, 1)
         sf_scale_tensor = torch.FloatTensor([alpha]).cuda()
         act_unscale_tensor = torch.FloatTensor([1.0 / alpha]).cuda()


### PR DESCRIPTION
[fix] Correct scaling factor calculation for symmetric quantization in fp4_gemm.py

## Description

In the old version, symmetric quantization was used, but the scaling factor was computed with `torch.max(float_tensor)`. This is incorrect for symmetric quantization, where the scaling factor should be the maximum absolute value of the tensor. This PR corrects the calculation by replacing `torch.max(float_tensor)` with `float_tensor.abs().max()`, ensuring the scaling factor is computed correctly for symmetric quantization.

## Test Coverage

- Passed all existing fp4 quantization-related unit tests.
- No new tests were added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the calculation method for the global scaling factor alpha in fp4 quantization tests to improve accuracy and clarity.
  * Revised comments to correctly reference "fp4 quantization" instead of "int4 quantization."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->