### PR TITLE
[None][feat] Add test for speculative rejection sampler (2-model)

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -320,6 +320,8 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
         self.py_draft_pages_allocated = 0
         self.py_rewind_len = 0
         self.py_draft_tokens = [] if self.draft_tokens is None else self.draft_tokens
+        self.py_draft_logits = None
+        self.py_target_probs = None
         self.py_last_context_chunk = (None, None)
         self.py_draft_logits = None
         self.py_target_probs = None

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -320,8 +320,6 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
         self.py_draft_pages_allocated = 0
         self.py_rewind_len = 0
         self.py_draft_tokens = [] if self.draft_tokens is None else self.draft_tokens
-        self.py_draft_logits = None
-        self.py_target_probs = None
         self.py_last_context_chunk = (None, None)
         self.py_draft_logits = None
         self.py_target_probs = None

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -277,24 +277,6 @@ class TorchSampler(Sampler):
         # So, we temporarily exit inference mode.
         with torch.inference_mode(False):
             self.store = self.create_store()
-            # Initialize seed for multi-GPU consistency
-        self._global_seed = 42
-        self._generator = None
-
-    def get_generator(self, device: torch.device) -> torch.Generator:
-        """Get a deterministic generator for the specified device.
-
-        Args:
-            device: The device to create the generator on
-
-        Returns:
-            A torch.Generator with the global seed set
-        """
-        if self._generator is None:
-            # Fallback to a default seed if not set
-            self._generator = torch.Generator(device=device)
-            self._generator.manual_seed(self._global_seed)
-        return self._generator
 
         # Initialize seed for multi-GPU consistency
         self._global_seed = 42

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, Optional
 
 import torch
 

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -420,7 +420,7 @@ class TorchSampler(Sampler):
                                      new_tokens: torch.Tensor) -> int:
         new_token = add_token(request, new_tokens, beam=self.BEAM)
         stop = self._handle_stop_criteria(request, new_token)
-        if stop or len(request.py_draft_tokens) == 0:
+        if stop or get_draft_token_length(request) == 0:
             return 0
         num_accepted = 0
 
@@ -452,7 +452,7 @@ class TorchSampler(Sampler):
         sample_last = True
         stop = False
         if rejected_indices.numel() == 0:
-            num_initially_accepted = len(request.py_draft_tokens)
+            num_initially_accepted = get_draft_token_length(request)
             sample_last = False
         else:
             num_initially_accepted = rejected_indices[0].item()

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -139,9 +139,6 @@ def top_p_sampling_batch(logits: torch.Tensor,
     # compute  cumulative probability distribution of each sample
     cumulative_probs = torch.cumsum(torch.softmax(sorted_logits, dim=-1),
                                     dim=-1)
-
-    if temperature != 0:
-        logits = logits / max(temperature, 1e-5)
     # get the location of top_p
     sorted_indices_to_remove = cumulative_probs > top_p
     sorted_indices_to_remove[:, 1:] = sorted_indices_to_remove[:, :-1].clone()

--- a/tests/unittest/_torch/speculative/test_torch_rejection_sampling.py
+++ b/tests/unittest/_torch/speculative/test_torch_rejection_sampling.py
@@ -1,0 +1,51 @@
+import numpy as np
+import torch
+from scipy.stats import entropy
+
+from tensorrt_llm._torch.pyexecutor.sampler import (get_rejected_indices,
+                                                    sample_rejected)
+
+
+def test_get_rejected_indices():
+    vocab_size = 500
+    num_iter = 50000
+    draft_probs = torch.rand(1, vocab_size)
+    drop_idx = torch.topk(draft_probs[0], k=400, largest=False)[1]
+    draft_probs[0, drop_idx] = 0.0
+    draft_probs = draft_probs / draft_probs.sum(dim=-1, keepdim=True)
+    target_probs = torch.rand(2, vocab_size)
+    drop_idx = torch.topk(target_probs[0], k=400, largest=False)[1]
+    target_probs[0, drop_idx] = 0.0
+    target_probs = target_probs / target_probs.sum(dim=-1, keepdim=True)
+    generator = torch.Generator()
+    sampled_tokens = []
+    sampled_regular = []
+    for _ in range(num_iter):
+        draft_tokens = [
+            torch.multinomial(draft_probs, num_samples=1,
+                              generator=generator).item()
+        ]
+        rejected_indices = get_rejected_indices(draft_probs, target_probs,
+                                                generator, draft_tokens)
+        if rejected_indices.shape[0] == 0:
+            sampled_tokens.append(draft_tokens[0])
+        else:
+            sampled_tokens.append(
+                sample_rejected(draft_probs, target_probs, generator, 0).item())
+        sampled_regular.append(
+            torch.multinomial(target_probs[0],
+                              num_samples=1,
+                              generator=generator).item())
+    bins = np.arange(vocab_size + 1) - 0.5  # Bins for histogram
+    sampled_tokens, _ = np.histogram(sampled_tokens, bins=bins, density=True)
+    sampled_regular, _ = np.histogram(sampled_regular, bins=bins, density=True)
+    expected_prob = target_probs[0].squeeze().numpy()
+
+    # KL Divergence check
+    kl_divergence = entropy(expected_prob, sampled_tokens)
+    kl_divergence_regular = entropy(expected_prob, sampled_regular)
+    assert abs(kl_divergence - kl_divergence_regular) < 0.01
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittest/_torch/speculative/test_torch_rejection_sampling.py
+++ b/tests/unittest/_torch/speculative/test_torch_rejection_sampling.py
@@ -1,3 +1,5 @@
+import unittest
+
 import numpy as np
 import torch
 from scipy.stats import entropy


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for deterministic sampling using seeded random generators, ensuring consistent results across multi-GPU setups.
  * Introduced temperature control for top-p sampling, allowing more flexible sampling strategies.
  * Implemented probabilistic acceptance of draft tokens based on model confidence, improving speculative decoding.

* **Improvements**
  * Enhanced handling of draft logits and probabilities for more accurate and controlled token generation.

* **Tests**
  * Added unit tests validating the rejection sampling mechanism to ensure accurate probabilistic token acceptance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up
-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
