### PR TITLE
[https://nvbugs/5410391][bug] Support to share device buffers in attention meta

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/flashinfer.py
+++ b/tensorrt_llm/_torch/attention_backend/flashinfer.py
@@ -167,12 +167,6 @@ class FlashInferAttentionMetadata(AttentionMetadata):
                                                  device='cuda',
                                                  dtype=torch.int)
 
-    def get_runtime_buffers(self):
-        return {}
-
-    def post_init_with_buffers(self, buffers) -> None:
-        self.__post_init__()
-
     def create_cuda_graph_metadata(self,
                                    max_batch_size: int,
                                    sub_cross_metadata: bool = False,

--- a/tensorrt_llm/_torch/attention_backend/flashinfer.py
+++ b/tensorrt_llm/_torch/attention_backend/flashinfer.py
@@ -167,10 +167,17 @@ class FlashInferAttentionMetadata(AttentionMetadata):
                                                  device='cuda',
                                                  dtype=torch.int)
 
+    def get_runtime_buffers(self):
+        return {}
+
+    def post_init_with_buffers(self, buffers) -> None:
+        self.__post_init__()
+
     def create_cuda_graph_metadata(self,
                                    max_batch_size: int,
                                    sub_cross_metadata: bool = False,
-                                   max_draft_tokens: int = 0) -> Self:
+                                   max_draft_tokens: int = 0,
+                                   buffers=None) -> Self:
         metadata = super().create_cuda_graph_metadata(max_batch_size,
                                                       sub_cross_metadata,
                                                       max_draft_tokens)

--- a/tensorrt_llm/_torch/attention_backend/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/interface.py
@@ -137,6 +137,7 @@ class AttentionMetadata:
 
     # This buffer is currently only used for TrtllmAttentionMetadata.
     cache_indirection: Optional[torch.Tensor] = None
+    cuda_graph_buffers: dict[str, list[torch.Tensor]] = None
 
     def __post_init__(self) -> None:
         if self.is_cross:
@@ -295,6 +296,7 @@ class AttentionMetadata:
 
         cuda_graph_metadata = copy.copy(self)
         cuda_graph_metadata.is_cuda_graph = True
+        cuda_graph_metadata.cuda_graph_buffers = buffers
         if self.has_cross_sub_metadata:
             cuda_graph_metadata.cross = cuda_graph_metadata.cross.create_cuda_graph_metadata(
                 max_batch_size, True)
@@ -319,7 +321,7 @@ class AttentionMetadata:
                 )
 
         cuda_graph_metadata.num_contexts = 0
-        cuda_graph_metadata.post_init_with_buffers(buffers)
+        cuda_graph_metadata.__post_init__()
         return cuda_graph_metadata
 
     def update_spec_dec_param(self, is_spec_decoding_enabled, is_spec_dec_tree,

--- a/tensorrt_llm/_torch/attention_backend/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/interface.py
@@ -282,7 +282,8 @@ class AttentionMetadata:
     def create_cuda_graph_metadata(self,
                                    max_batch_size: int,
                                    sub_cross_metadata: bool = False,
-                                   max_draft_tokens: int = 0) -> Self:
+                                   max_draft_tokens: int = 0,
+                                   buffers=None) -> Self:
         """
         Creates metadata for CUDA graph execution.
         CUDA graphs require to use pre-allocated buffers for all tensors in fields.
@@ -318,7 +319,7 @@ class AttentionMetadata:
                 )
 
         cuda_graph_metadata.num_contexts = 0
-        cuda_graph_metadata.__post_init__()
+        cuda_graph_metadata.post_init_with_buffers(buffers)
         return cuda_graph_metadata
 
     def update_spec_dec_param(self, is_spec_decoding_enabled, is_spec_dec_tree,

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -600,9 +600,9 @@ class TrtllmAttentionMetadata(AttentionMetadata):
 
     def __post_init__(self) -> None:
         super().__post_init__()
-        self.__post_init_with_buffers(self.cuda_graph_buffers)
+        self._post_init_with_buffers(self.cuda_graph_buffers)
 
-    def __post_init_with_buffers(self, buffers) -> None:
+    def _post_init_with_buffers(self, buffers) -> None:
 
         # Set a default value, as max_num_sequences is not always set.
         if self.max_num_sequences is None:
@@ -624,8 +624,6 @@ class TrtllmAttentionMetadata(AttentionMetadata):
             Args:
                 tensor_shape: The required shape.
                 dtype: The required dtype.
-                buffers: A dictionary mapping cache names to lists of buffer tensors.
-                        Can be `None` or empty.
                 cache_name: The key for the specific list of buffers to search in.
 
             Returns:
@@ -652,20 +650,26 @@ class TrtllmAttentionMetadata(AttentionMetadata):
 
         def get_empty_like(like_tensor: torch.Tensor,
                            cache_name: str) -> torch.Tensor:
-            return get_empty(like_tensor.shape,
-                             cache_name=cache_name,
-                             dtype=like_tensor.dtype)
+            return get_empty(
+                like_tensor.shape,
+                cache_name=cache_name,
+                dtype=like_tensor.dtype,
+            )
 
-        self.prompt_lens_cuda = get_empty((self.max_num_sequences, ),
-                                          cache_name="prompt_lens_cuda",
-                                          dtype=torch.int)
+        self.prompt_lens_cuda = get_empty(
+            (self.max_num_sequences, ),
+            cache_name="prompt_lens_cuda",
+            dtype=torch.int,
+        )
         self.prompt_lens_cpu = torch.empty_like(
             self.prompt_lens_cuda,
             device='cpu',
             pin_memory=True,
         )
-        self.kv_lens_cuda = get_empty_like(self.prompt_lens_cuda,
-                                           cache_name="kv_lens_cuda")
+        self.kv_lens_cuda = get_empty_like(
+            self.prompt_lens_cuda,
+            cache_name="kv_lens_cuda",
+        )
         self.kv_lens = torch.empty_like(self.kv_lens_cuda,
                                         device='cpu',
                                         pin_memory=True)
@@ -685,7 +689,8 @@ class TrtllmAttentionMetadata(AttentionMetadata):
                     self.kv_cache_manager.max_blocks_per_seq
                 ],
                 cache_name="kv_cache_block_offsets",
-                dtype=torch.int32)
+                dtype=torch.int32,
+            )
             self.host_kv_cache_block_offsets = torch.empty_like(
                 self.kv_cache_block_offsets,
                 device='cpu',
@@ -700,20 +705,23 @@ class TrtllmAttentionMetadata(AttentionMetadata):
                         self.kv_cache_manager.max_blocks_per_seq
                     ],
                     cache_name="block_ids_per_seq",
-                    dtype=torch.int32)
+                    dtype=torch.int32,
+                )
                 self.kv_block_ids_per_seq = get_empty(
                     [
                         self.kv_cache_manager.max_batch_size,
                         self.kv_cache_manager.max_blocks_per_seq
                     ],
                     cache_name="kv_block_ids_per_seq",
-                    dtype=torch.int32)
+                    dtype=torch.int32,
+                )
             if self.enable_paged_context_mla:
                 # for kv cache reuse/chunked context in MLA
                 self.ctx_cached_token_indptr = get_empty(
                     (self.max_num_requests + 1, ),
                     cache_name="ctx_cached_token_indptr",
-                    dtype=torch.int64)
+                    dtype=torch.int64,
+                )
                 self.host_ctx_cached_token_indptr = torch.zeros_like(
                     self.ctx_cached_token_indptr,
                     device='cpu',
@@ -722,16 +730,19 @@ class TrtllmAttentionMetadata(AttentionMetadata):
                 self.ctx_uncached_token_indptr = get_empty(
                     (self.max_num_requests + 1, ),
                     cache_name="ctx_uncached_token_indptr",
-                    dtype=torch.int64)
+                    dtype=torch.int64,
+                )
                 self.host_ctx_uncached_token_indptr = torch.zeros_like(
                     self.ctx_uncached_token_indptr,
                     device='cpu',
                     pin_memory=True,
                 )
                 # context full seqlens include cached tokens and uncached tokens
-                self.ctx_kv_indptr = get_empty((self.max_num_requests + 1, ),
-                                               cache_name="ctx_kv_indptr",
-                                               dtype=torch.int64)
+                self.ctx_kv_indptr = get_empty(
+                    (self.max_num_requests + 1, ),
+                    cache_name="ctx_kv_indptr",
+                    dtype=torch.int64,
+                )
                 self.host_ctx_kv_indptr = torch.zeros_like(
                     self.ctx_kv_indptr,
                     device='cpu',

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -844,8 +844,8 @@ class TrtllmAttentionMetadata(AttentionMetadata):
                 self.request_ids[self.num_contexts:], self.beam_width,
                 self.num_contexts)
             host_kv_shape = self.host_kv_cache_block_offsets.shape
-            self.kv_cache_block_offsets.view(host_kv_shape[0], -1,
-                                             host_kv_shape[2], host_kv_shape[3])
+            self.kv_cache_block_offsets = self.kv_cache_block_offsets.view(
+                host_kv_shape[0], -1, host_kv_shape[2], host_kv_shape[3])
             self.kv_cache_block_offsets[:, :self.num_seqs].copy_(
                 self.host_kv_cache_block_offsets[:, :self.num_seqs],
                 non_blocking=True)

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -669,14 +669,8 @@ class TrtllmAttentionMetadata(AttentionMetadata):
                     numel_buffer = buffer.numel()
 
                     # Condition for 1D tensors: buffer just needs to be large enough.
-                    if like_tensor.dim() == 1:
-                        if numel_buffer >= numel_like:
-                            return buffer  # Found a fit, return immediately.
-                    # Condition for N-D tensors: buffer size must be an exact multiple.
-                    else:
-                        # Ensure numel_like is not zero to prevent ZeroDivisionError.
-                        if numel_like > 0 and numel_buffer % numel_like == 0:
-                            return buffer  # Found a fit, return immediately.
+                    if numel_buffer >= numel_like:
+                        return buffer  # Found a fit, return immediately.
 
             # If we get here, no suitable buffer was found in the cache. Create a new one.
             return torch.empty_like(like_tensor, device='cuda')
@@ -843,9 +837,6 @@ class TrtllmAttentionMetadata(AttentionMetadata):
                 self.host_kv_cache_block_offsets,
                 self.request_ids[self.num_contexts:], self.beam_width,
                 self.num_contexts)
-            host_kv_shape = self.host_kv_cache_block_offsets.shape
-            self.kv_cache_block_offsets = self.kv_cache_block_offsets.view(
-                host_kv_shape[0], -1, host_kv_shape[2], host_kv_shape[3])
             self.kv_cache_block_offsets[:, :self.num_seqs].copy_(
                 self.host_kv_cache_block_offsets[:, :self.num_seqs],
                 non_blocking=True)

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -599,100 +599,183 @@ class TrtllmAttentionMetadata(AttentionMetadata):
         return self.kv_cache_manager.kv_cache_pool_mapping if self.kv_cache_manager is not None else None
 
     def __post_init__(self) -> None:
+        self.post_init_with_buffers({})
+
+    def get_runtime_buffers(self):
+        buffers = {
+            "prompt_lens_cuda": self.prompt_lens_cuda,
+            "kv_lens_cuda": self.kv_lens_cuda,
+            "kv_lens": self.kv_lens,
+            "workspace": self.workspace
+        }
+
+        if self.kv_cache_manager is not None:
+            buffers["kv_cache_block_offsets"] = self.kv_cache_block_offsets
+
+            if self.enable_flash_mla:
+                buffers["block_ids_per_seq"] = self.block_ids_per_seq
+                buffers["kv_block_ids_per_seq"] = self.kv_block_ids_per_seq
+
+            if self.enable_paged_context_mla:
+                buffers[
+                    "ctx_cached_token_indptr"] = self.ctx_cached_token_indptr
+                buffers[
+                    "ctx_uncached_token_indptr"] = self.ctx_uncached_token_indptr
+                buffers["ctx_kv_indptr"] = self.ctx_kv_indptr
+
+        return buffers
+
+    def post_init_with_buffers(self, buffers) -> None:
         super().__post_init__()
+
         # Set a default value, as max_num_sequences is not always set.
         if self.max_num_sequences is None:
             self.max_num_sequences = self.max_num_requests
 
-        self.prompt_lens_cuda = torch.empty(
+        def find_or_create_buffer(like_tensor: torch.Tensor,
+                                  buffers: Optional[dict[str,
+                                                         list[torch.Tensor]]],
+                                  cache_name: str) -> torch.Tensor:
+            """
+            Finds a compatible, reusable buffer from a cache or creates a new one.
+
+            This function searches for a pre-allocated tensor (buffer) that can be
+            reused for an operation involving a tensor with the shape of `like_tensor`.
+
+            The compatibility rules are:
+            - For 1D tensors: The buffer's total elements must be >= `like_tensor`'s.
+            - For N-D tensors (>1D): The buffer's total elements must be a perfect
+            multiple of `like_tensor`'s.
+
+            If a compatible buffer is found, it's returned immediately. Otherwise, a new
+            buffer is allocated on the 'cuda' device with the same properties as `like_tensor`.
+
+            Args:
+                like_tensor: The tensor defining the required shape and dtype.
+                buffers: A dictionary mapping cache names to lists of buffer tensors.
+                        Can be `None` or empty.
+                cache_name: The key for the specific list of buffers to search in.
+
+            Returns:
+                An existing compatible buffer or a newly created one.
+            """
+            # A "guard clause" to handle cases where buffers are not provided.
+            if buffers is not None:
+                # Safely get the list of candidates. Defaults to an empty list if key is missing.
+                candidate_buffers = buffers.get(cache_name, [])
+                numel_like = like_tensor.numel()
+
+                for buffer in candidate_buffers:
+                    numel_buffer = buffer.numel()
+
+                    # Condition for 1D tensors: buffer just needs to be large enough.
+                    if like_tensor.dim() == 1:
+                        if numel_buffer >= numel_like:
+                            return buffer  # Found a fit, return immediately.
+                    # Condition for N-D tensors: buffer size must be an exact multiple.
+                    else:
+                        # Ensure numel_like is not zero to prevent ZeroDivisionError.
+                        if numel_like > 0 and numel_buffer % numel_like == 0:
+                            return buffer  # Found a fit, return immediately.
+
+            # If we get here, no suitable buffer was found in the cache. Create a new one.
+            return torch.empty_like(like_tensor, device='cuda')
+
+        self.prompt_lens_cpu = torch.empty(
             (self.max_num_sequences, ),
-            device='cuda',
-            dtype=torch.int,
-        )
-        self.prompt_lens_cpu = torch.empty_like(
-            self.prompt_lens_cuda,
             device='cpu',
+            dtype=torch.int,
             pin_memory=True,
         )
-        self.kv_lens_cuda = torch.empty_like(self.prompt_lens_cuda)
-        self.kv_lens = torch.empty_like(self.kv_lens_cuda,
+
+        self.prompt_lens_cuda = find_or_create_buffer(self.prompt_lens_cpu,
+                                                      buffers,
+                                                      "prompt_lens_cuda")
+
+        self.kv_lens = torch.empty_like(self.prompt_lens_cuda,
                                         device='cpu',
                                         pin_memory=True)
+
+        self.kv_lens_cuda = find_or_create_buffer(self.kv_lens, buffers,
+                                                  "kv_lens_cuda")
+
         self.host_request_types = torch.empty_like(self.prompt_lens_cpu)
 
-        # For debugging, can use it to call the wrapper's plan function
         if self.workspace is None:
-            self.workspace = torch.empty(
-                (0, ),
-                device='cuda',
-                dtype=torch.int8,
-            )
+            if "workspace" in buffers:
+                self.workspace = buffers['workspace'][0]
+            else:
+                self.workspace = torch.empty(
+                    (0, ),
+                    device='cuda',
+                    dtype=torch.int8,
+                )
+
         if self.kv_cache_manager is not None:
-            self.kv_cache_block_offsets = torch.empty(
+            self.host_kv_cache_block_offsets = torch.empty(
                 [
                     self.kv_cache_manager.num_pools, self.max_num_sequences, 2,
                     self.kv_cache_manager.max_blocks_per_seq
                 ],
-                dtype=torch.int32,
-                device='cuda',
-            )
-            self.host_kv_cache_block_offsets = torch.empty_like(
-                self.kv_cache_block_offsets,
                 device='cpu',
+                dtype=torch.int32,
                 pin_memory=True,
             )
+
+            self.kv_cache_block_offsets = find_or_create_buffer(
+                self.host_kv_cache_block_offsets, buffers,
+                "kv_cache_block_offsets")
+
+            # They are referred in attention's forward no matter flash mla is enabled or not.
             self.block_ids_per_seq = None
             self.kv_block_ids_per_seq = None
             if self.enable_flash_mla:
-                self.block_ids_per_seq = torch.zeros(
-                    [
-                        self.kv_cache_manager.max_batch_size,
-                        self.kv_cache_manager.max_blocks_per_seq
-                    ],
-                    dtype=torch.int32,
-                    device='cuda',
-                )
-                self.kv_block_ids_per_seq = torch.zeros(
-                    [
-                        self.kv_cache_manager.max_batch_size,
-                        self.kv_cache_manager.max_blocks_per_seq
-                    ],
-                    dtype=torch.int32,
-                    device='cuda',
-                )
+                tmp_cpu_tensor = torch.empty([
+                    self.kv_cache_manager.max_batch_size,
+                    self.kv_cache_manager.max_blocks_per_seq
+                ],
+                                             device='cpu',
+                                             dtype=torch.int32)
+
+                self.block_ids_per_seq = find_or_create_buffer(
+                    tmp_cpu_tensor, buffers, "block_ids_per_seq")
+
+                self.kv_block_ids_per_seq = find_or_create_buffer(
+                    tmp_cpu_tensor, buffers, "kv_block_ids_per_seq")
+
             if self.enable_paged_context_mla:
                 # for kv cache reuse/chunked context in MLA
-                self.ctx_cached_token_indptr = torch.zeros(
+                self.host_ctx_cached_token_indptr = torch.zeros(
                     (self.max_num_requests + 1, ),
-                    device='cuda',
-                    dtype=torch.int64,
-                )
-                self.host_ctx_cached_token_indptr = torch.zeros_like(
-                    self.ctx_cached_token_indptr,
                     device='cpu',
+                    dtype=torch.int64,
                     pin_memory=True,
                 )
-                self.ctx_uncached_token_indptr = torch.zeros(
+
+                self.ctx_cached_token_indptr = find_or_create_buffer(
+                    self.host_ctx_cached_token_indptr, buffers,
+                    "ctx_cached_token_indptr")
+
+                self.host_ctx_uncached_token_indptr = torch.zeros(
                     (self.max_num_requests + 1, ),
-                    device='cuda',
-                    dtype=torch.int64,
-                )
-                self.host_ctx_uncached_token_indptr = torch.zeros_like(
-                    self.ctx_uncached_token_indptr,
                     device='cpu',
+                    dtype=torch.int64,
                     pin_memory=True,
                 )
-                # context full seqlens include cached tokens and uncached tokens
-                self.ctx_kv_indptr = torch.zeros(
+
+                self.ctx_uncached_token_indptr = find_or_create_buffer(
+                    self.host_ctx_uncached_token_indptr, buffers,
+                    "ctx_uncached_token_indptr")
+
+                self.host_ctx_kv_indptr = torch.zeros(
                     (self.max_num_requests + 1, ),
-                    device='cuda',
-                    dtype=torch.int64,
-                )
-                self.host_ctx_kv_indptr = torch.zeros_like(
-                    self.ctx_kv_indptr,
                     device='cpu',
+                    dtype=torch.int64,
                     pin_memory=True,
                 )
+
+                self.ctx_kv_indptr = find_or_create_buffer(
+                    self.host_ctx_kv_indptr, buffers, "ctx_kv_indptr")
 
     def prepare(self) -> None:
         extra_attrs = get_model_extra_attrs()
@@ -760,6 +843,9 @@ class TrtllmAttentionMetadata(AttentionMetadata):
                 self.host_kv_cache_block_offsets,
                 self.request_ids[self.num_contexts:], self.beam_width,
                 self.num_contexts)
+            host_kv_shape = self.host_kv_cache_block_offsets.shape
+            self.kv_cache_block_offsets.view(host_kv_shape[0], -1,
+                                             host_kv_shape[2], host_kv_shape[3])
             self.kv_cache_block_offsets[:, :self.num_seqs].copy_(
                 self.host_kv_cache_block_offsets[:, :self.num_seqs],
                 non_blocking=True)

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -237,11 +237,13 @@ class KvCacheCreator:
             torch_peak_memory = torch.cuda.memory_stats(
             )["allocated_bytes.all.peak"]
 
-            # Clear the caching allocator before measuring the current memory usage
+            # Clear the caching allocator after measuring the current memory usage
+            # This can help leave memory fragments buffer in pytorch
             torch.cuda.empty_cache()
             end, total_gpu_memory = torch.cuda.mem_get_info()
             torch_used_bytes = torch.cuda.memory_stats(
             )["allocated_bytes.all.current"]
+
         finally:
             py_executor.shutdown()
             py_executor.is_warmup = False

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -237,13 +237,11 @@ class KvCacheCreator:
             torch_peak_memory = torch.cuda.memory_stats(
             )["allocated_bytes.all.peak"]
 
-            # Clear the caching allocator after measuring the current memory usage
-            # This can help leave memory fragments buffer in pytorch
+            # Clear the caching allocator before measuring the current memory usage
             torch.cuda.empty_cache()
             end, total_gpu_memory = torch.cuda.mem_get_info()
             torch_used_bytes = torch.cuda.memory_stats(
             )["allocated_bytes.all.current"]
-
         finally:
             py_executor.shutdown()
             py_executor.is_warmup = False

--- a/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
+++ b/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
@@ -73,7 +73,8 @@ class DecodingCUDAGraphRunner:
         self.optional_extra_model_inputs = ["mrope_position_deltas"]
 
     def __del__(self):
-        self._graph.reset()
+        if self._graph is not None:
+            self._graph.reset()
 
     def capture(
         self,

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -425,6 +425,7 @@ class PyTorchModelEngine(ModelEngine):
         self.kv_cache_manager_key = ResourceManagerType.KV_CACHE_MANAGER
         self.lora_model_config: Optional[LoraModelConfig] = None
         self.cuda_graph_dummy_request = None
+        self.cuda_graph_meta_buffers: dict[str, list[torch.Tensor]] = {}
 
         # Setup the local cache indirection buffer only once and reuse it.
         # This way it can also be used for CUDA graphs.
@@ -931,6 +932,14 @@ class PyTorchModelEngine(ModelEngine):
         idx = bisect.bisect_left(self._cuda_graph_batch_sizes, batch_size)
         return self._cuda_graph_batch_sizes[idx]
 
+    def _update_attn_meta_buffers(self, meta_buffers):
+        if meta_buffers is None:
+            return
+        for key, value in meta_buffers.items():
+            if value is None:
+                continue
+            self.cuda_graph_meta_buffers.setdefault(key, []).append(value)
+
     def _maybe_get_cuda_graph(
         self,
         batch: ScheduledRequests,
@@ -970,15 +979,19 @@ class PyTorchModelEngine(ModelEngine):
 
         num_sequences_in_batch = batch_size * self.max_beam_width
         attn_metadata = self.attn_metadata.create_cuda_graph_metadata(
-            num_sequences_in_batch, False, draft_len)
+            num_sequences_in_batch, False, draft_len,
+            self.cuda_graph_meta_buffers)
+        new_attn_buffers = attn_metadata.get_runtime_buffers()
+
         assert attn_metadata.is_cuda_graph
 
+        spec_metadata = None
         if self.enable_spec_decode:
             spec_metadata = self.spec_metadata.create_cuda_graph_metadata(
                 num_sequences_in_batch)
             spec_metadata.draft_tokens = self.draft_tokens_cuda
-        else:
-            spec_metadata = None
+
+        self._update_attn_meta_buffers(new_attn_buffers)
 
         # Initialize nested dictionary if needed
         if batch_size not in self._cuda_graphs:
@@ -1143,9 +1156,10 @@ class PyTorchModelEngine(ModelEngine):
             for draft_len, graph in draft_graphs.items():
                 del graph
         self._cuda_graphs.clear()
-        torch.cuda.empty_cache()
         del self._cuda_graph_mem_pool
         self._cuda_graph_mem_pool = None
+        self.cuda_graph_meta_buffers.clear()
+        torch.cuda.empty_cache()
 
     def get_max_num_sequences(self) -> int:
         """

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -278,7 +278,6 @@ full:GB200/examples/test_qwen.py::test_llm_qwen_7b_multi_gpus_summary[qwen1.5_7b
 full:GB200/examples/test_qwen.py::test_llm_qwen_7b_multi_gpus_summary[qwen2_7b_instruct-enable_fmha_fp32_acc-enable_plugin-tp2pp2-nb:4] SKIP (https://nvbugs/5247837)
 full:GB200/examples/test_qwen.py::test_llm_qwen_7b_multi_gpus_summary[qwen2_vl_7b_instruct-enable_fmha_fp32_acc-enable_plugin-tp2pp2-nb:4] SKIP (https://nvbugs/5359696)
 full:GB200/examples/test_qwen.py::test_llm_qwen_7b_multi_gpus_summary[qwen2.5_7b_chat-enable_fmha_fp32_acc-enable_plugin-tp2pp2-nb:4] SKIP (https://nvbugs/5247837)
-accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16[mtp_nextn=0-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=False] SKIP (https://nvbugs/5410391)
 accuracy/test_llm_api.py::TestMistral_Nemo_12B_Base::test_fp8 SKIP (https://nvbugs/5413197)
 accuracy/test_cli_flow.py::TestLlama3_8BInstructGradient1048k::test_long_context_ppl SKIP (https://nvbugs/5413362)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_multi_gpus[throughput_tp8] SKIP (https://nvbugs/5455140)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime buffer APIs added to expose attention-related CPU/GPU buffers and accept supplied buffers during initialization.

* **Improvements**
  * Buffer-caching and reuse to reduce allocations and improve memory reuse/performance.
  * Initialization flow refactored to materialize and reuse provided buffers.
  * Memory-accounting comment clarified for token estimation.

* **Bug Fixes**
  * Safer finalization and clearing of stored metadata buffers to avoid stale-state errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up
-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
