### PR TITLE
[None][fix] xqa precision for fp16/bf16 kv cache

### DIFF
--- a/cpp/kernels/xqa/mha_sm90.cu
+++ b/cpp/kernels/xqa/mha_sm90.cu
@@ -2734,7 +2734,7 @@ __device__ inline void saveTransposedOutput(uint32_t threadRank, uint32_t warpRa
             reinterpret_cast<Vec<InputElem, 4>&>(f16Core)
                 = convert<InputElem>(reinterpret_cast<Vec<float, 4> const&>(core));
             auto const dst = idxMat < 2
-                ? &swizzleBuf.template at<true>(idxRow, 2 * (gmmaWarpsPerGrp * m + warpRank) + idxMat)
+                ? &swizzleBuf.template at<true>(8 * n + idxRow, 2 * (gmmaWarpsPerGrp * m + warpRank) + idxMat)
                 : nullptr;
             stmatrix<true, 2>(dst, f16Core);
 #elif CACHE_ELEM_ENUM == 2


### PR DESCRIPTION
## Description

- When the group size of the attention head in the xqa sm90 operator exceeds 8, errors will occur in the fp16/bf16 kv cache results.
- Modifying the logic of the stmatrix part can fix this bug.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal data handling for better memory organization, with no impact on user-facing features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->