### PR TITLE
[None][feat] Support CancelRequest for Disaggregated Serving

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/cacheTransceiver.h
+++ b/cpp/include/tensorrt_llm/batch_manager/cacheTransceiver.h
@@ -71,6 +71,8 @@ public:
     virtual void checkGenTransferStatus(std::optional<int> const& atLeastRequestNum = std::nullopt) = 0;
 
     [[nodiscard]] virtual bool checkGenTransferComplete() const = 0;
+
+    virtual bool cancelRequest(LlmRequest* llmRequest) = 0;
 };
 
 class CacheTransceiver : public BaseCacheTransceiver
@@ -110,6 +112,8 @@ public:
     void checkGenTransferStatus(std::optional<int> const& atLeastRequestNum = std::nullopt) override;
 
     [[nodiscard]] bool checkGenTransferComplete() const override;
+
+    virtual bool cancelRequest(LlmRequest* llmRequest) override;
 
 private:
     void initializeCommState();

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -567,4 +567,17 @@ bool CacheTransceiver::checkGenTransferComplete() const
     return mRequesterFutures.empty();
 }
 
+bool CacheTransceiver::cancelRequest(LlmRequest* llmRequest)
+{
+    if (llmRequest->isContextOnlyRequest())
+    {
+        return mCacheSender->cancelRequest(*llmRequest);
+    }
+    else if (llmRequest->isGenerationOnlyRequest())
+    {
+        return mCacheReceiver->cancelRequest(*llmRequest);
+    }
+    return false;
+}
+
 } // namespace tensorrt_llm::batch_manager

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
@@ -379,6 +379,48 @@ public:
         mFormatter->format(*session);
     }
 
+    bool cancelRequest(LlmRequest const& llmRequest)
+    {
+        bool isCancelled = false;
+        std::unique_lock lkResp(mSenderMutex);
+        auto it = mReadyResponses.find(llmRequest.mRequestId);
+        // If the request is not the current request and already in the ready queue, we can cancel it.
+        if (it != mReadyResponses.end() && (!isSending() || getCurrentRequestId() != llmRequest.mRequestId))
+        {
+            mCancelledRequests.insert(llmRequest.mRequestId);
+            isCancelled = true;
+        }
+        else
+        {
+            TLLM_LOG_WARNING("Cannot cancel request %zu", llmRequest.mRequestId);
+        }
+        return isCancelled;
+    }
+
+    void sendReadySignal(LlmRequest::RequestIdType requestId, bool isReady)
+    {
+        auto it = mRequestToSession.find(requestId);
+        TLLM_CHECK(it != mRequestToSession.end());
+        auto& session = it->second;
+        auto connections = session.getConnections();
+        for (size_t i = 0; i < connections.size(); i++)
+        {
+            auto* agentConnectionManager = dynamic_cast<executor::kv_cache::AgentConnectionManager*>(mManager);
+            if (agentConnectionManager != nullptr)
+            {
+                auto* agentConnection = dynamic_cast<executor::kv_cache::AgentConnection const*>(connections.at(i));
+                TLLM_CHECK(agentConnection != nullptr);
+                agentConnection->sendReadySignal(
+                    executor::kv_cache::DataContext{TransceiverTag::kREADY_SIGNAL_TAG}, isReady);
+            }
+            else
+            {
+                connections.at(i)->send(
+                    executor::kv_cache::DataContext{TransceiverTag::kREADY_SIGNAL_TAG}, &isReady, sizeof(isReady));
+            }
+        }
+    }
+
     ~Impl()
     {
         terminate();
@@ -463,8 +505,41 @@ private:
         {
             mRemainSendCount.erase(reqId);
 
-            asyncSendAndRemoveResponse(it->first, std::move(it->second));
-            removeResponse(it);
+            // Check if the request is cancelled
+            bool isReady = true;
+            {
+                std::unique_lock lk(mSenderMutex);
+                if (mCancelledRequests.find(reqId) != mCancelledRequests.end())
+                {
+                    isReady = false;
+                }
+            }
+            sendReadySignal(reqId, isReady);
+
+            if (isReady)
+            {
+                asyncSendAndRemoveResponse(it->first, std::move(it->second));
+                removeResponse(it);
+            }
+            else
+            {
+                // TODO: if the generation does not require the kv cache, the request will
+                // not be removed from mCancelledRequests. This should be handled by timeout.
+                auto it = mReadyResponses.find(mCurrentRequest.value());
+                {
+                    std::unique_lock lkResp(mSenderMutex);
+                    mReadyResponses.erase(it);
+                    mCancelledRequests.erase(mCurrentRequest.value());
+                    mRemainSendCount.erase(mCurrentRequest.value());
+                }
+                mCurrentRequest = std::nullopt;
+
+                if (mReadyResponses.empty())
+                {
+                    std::unique_lock lk(mCondMutex);
+                    mAnyReady = false;
+                }
+            }
         }
         mCurrentRequest = std::nullopt;
     }
@@ -491,7 +566,11 @@ private:
                     auto const& requestInfo = recvRequestInfo();
                     auto reqId = requestInfo.getRequestId();
 
-                    mCurrentRequest = reqId;
+                    {
+                        std::unique_lock lk(mSenderMutex);
+                        mCurrentRequest = reqId;
+                    }
+
                     if (mRemainSendCount.find(reqId) == mRemainSendCount.end())
                     {
                         mRemainSendCount[reqId] = getCounterpartsCount(reqId);
@@ -572,6 +651,7 @@ private:
 
 private:
     std::optional<RequestIdType> mCurrentRequest;
+    std::set<LlmRequest::RequestIdType> mCancelledRequests;
     std::map<RequestIdType, Response> mReadyResponses;
     std::mutex mSenderMutex, mCondMutex;
     std::atomic<bool> mAnyReady{false}, mTerminate{false};
@@ -777,6 +857,62 @@ public:
         connection->send(DataContext{TransceiverTag::kINFO_TAG}, serializedInfo.data(), infoSize);
     }
 
+    bool cancelRequest(LlmRequest const& llmRequest)
+    {
+
+        std::string processInfo = "default";
+        if (common::getEnvRequestKVCacheConcurrent())
+        {
+            processInfo = llmRequest.getDataTransceiverState().getCommState()->toString();
+        }
+
+        bool isCancelled = false;
+        auto& asyncResource = mInstanceToAsyncResource.at(processInfo);
+        {
+            std::unique_lock<std::mutex> lck(asyncResource->mMtxForQueue);
+            auto it = std::find_if(asyncResource->mRequestsQueue.begin(), asyncResource->mRequestsQueue.end(),
+                [&llmRequest](RequestAndPromise const& requestAndPromise)
+                { return requestAndPromise.mRequest->mRequestId == llmRequest.mRequestId; });
+            if (it != asyncResource->mRequestsQueue.end())
+            {
+                asyncResource->mRequestsQueue.erase(it);
+                isCancelled = true;
+            }
+            else
+            {
+                TLLM_LOG_WARNING("Cannot cancel request %zu", llmRequest.mRequestId);
+            }
+        }
+        return isCancelled;
+    }
+
+    bool receiveReadySignal(TransferSession& session)
+    {
+        bool isReadyFinal = true;
+        bool isReady = false;
+        auto connections = session.getConnections();
+
+        for (size_t i = 0; i < connections.size(); i++)
+        {
+            auto* agentConnectionManager = dynamic_cast<executor::kv_cache::AgentConnectionManager*>(mManager);
+            if (agentConnectionManager != nullptr)
+            {
+                auto* agentConnection = dynamic_cast<executor::kv_cache::AgentConnection const*>(connections.at(i));
+                TLLM_CHECK(agentConnection != nullptr);
+                isReady = agentConnection->recvReadySignal(
+                    executor::kv_cache::DataContext{TransceiverTag::kREADY_SIGNAL_TAG});
+            }
+            else
+            {
+                connections.at(i)->recv(
+                    executor::kv_cache::DataContext{TransceiverTag::kREADY_SIGNAL_TAG}, &isReady, sizeof(isReady));
+            }
+            isReadyFinal &= isReady;
+        }
+
+        return isReadyFinal;
+    }
+
     ~Impl()
     {
         for (auto&& [processInfo, asyncResource] : mInstanceToAsyncResource)
@@ -799,6 +935,14 @@ private:
         llmRequest.setKvCacheTransferStart(std::chrono::steady_clock::now());
         TLLM_CUDA_CHECK(cudaSetDevice(mDeviceId));
         auto session = sendRequestInfo(llmRequest);
+        bool isReady = receiveReadySignal(session);
+        if (!isReady)
+        {
+            // Reuse the error state for the cancelled request.
+            llmRequest.setState(LlmRequestState::kDISAGG_TRANS_ERROR);
+            llmRequest.setKvCacheTransferEnd(std::chrono::steady_clock::now());
+            return;
+        }
         receiveSync(session);
         llmRequest.setKvCacheTransferEnd(std::chrono::steady_clock::now());
 
@@ -970,6 +1114,16 @@ RequestInfo CacheSender::recvRequestInfo()
     return mImpl->recvRequestInfo();
 }
 
+bool CacheSender::cancelRequest(LlmRequest const& llmRequest)
+{
+    return mImpl->cancelRequest(llmRequest);
+}
+
+void CacheSender::sendReadySignal(LlmRequest::RequestIdType requestId, bool isReady)
+{
+    mImpl->sendReadySignal(requestId, isReady);
+}
+
 CacheReceiver::CacheReceiver(executor::kv_cache::ConnectionManager* manager,
     executor::kv_cache::CacheState selfCacheState, SizeType32 selfIndex, std::unique_ptr<BaseCacheFormatter> formatter)
     : mImpl{std::unique_ptr<Impl, ImplDeleter>(new Impl(manager, selfCacheState, selfIndex, std::move(formatter)))}
@@ -991,6 +1145,16 @@ TransferSession CacheReceiver::sendRequestInfo(LlmRequest const& llmRequest)
 void CacheReceiver::receiveSync(TransferSession& session)
 {
     mImpl->receiveSync(session);
+}
+
+bool CacheReceiver::cancelRequest(LlmRequest const& llmRequest)
+{
+    return mImpl->cancelRequest(llmRequest);
+}
+
+bool CacheReceiver::receiveReadySignal(TransferSession& session)
+{
+    return mImpl->receiveReadySignal(session);
 }
 
 } // namespace tensorrt_llm::batch_manager

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.h
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.h
@@ -144,6 +144,7 @@ struct TransceiverTag
     static constexpr int32_t kID_TAG{19};
     static constexpr int32_t kINFO_SIZE_TAG{22};
     static constexpr int32_t kINFO_TAG{32};
+    static constexpr int32_t kREADY_SIGNAL_TAG{42};
 };
 
 // Used to store the information that needs to be sent to the context executor to ensure the generation
@@ -240,6 +241,16 @@ public:
     /// @param llmRequest The request object to which the data belongs.
     virtual RequestInfo recvRequestInfo();
 
+    /// @brief Cancel the request.
+    /// @param requestId The ID used in the context phase of the current request.
+    /// @return Whether the request is cancelled.
+    virtual bool cancelRequest(LlmRequest const& llmRequest);
+
+    /// @brief Send ready signal.
+    /// @param requestId The ID used in the context phase of the current request.
+    /// @param isReady Whether the request is ready to be received.
+    virtual void sendReadySignal(LlmRequest::RequestIdType requestId, bool isReady);
+
     /// @brief Destructor.
     virtual ~CacheSender();
 
@@ -272,6 +283,17 @@ public:
     virtual TransferSession sendRequestInfo(LlmRequest const& llmRequest);
 
     virtual void receiveSync(TransferSession& session);
+
+    /// @brief Cancel the request.
+    /// @param llmRequest Request object.
+    /// @return Whether the request is cancelled.
+    virtual bool cancelRequest(LlmRequest const& llmRequest);
+
+    /// @brief Receive ready signal.
+    /// @param session The session object.
+    /// @return Whether the request is ready to be received.
+    virtual bool receiveReadySignal(TransferSession& session);
+
     /// @brief Destructor.
     virtual ~CacheReceiver();
 

--- a/cpp/tensorrt_llm/executor/cache_transmission/agent_utils/connection.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/agent_utils/connection.cpp
@@ -180,6 +180,22 @@ bool AgentConnection::hasLoadRemoteAgent() const
     return mHasLoadRemoteAgent;
 }
 
+void AgentConnection::sendReadySignal(DataContext const& ctx, bool isReady) const
+{
+    ReadySignalInfo readySignalInfo{mRemoteAgentName, ctx, isReady};
+    NotificationInfo notificationInfo{readySignalInfo};
+    std::stringstream ss;
+    NotificationInfo::serialize(notificationInfo, ss);
+    mAgentConnectionManager->getAgent()->notifySyncMessage(mRemoteAgentName, ss.str());
+}
+
+bool AgentConnection::recvReadySignal(DataContext const& ctx) const
+{
+    ReadySignalInfo readySignalInfo{mAgentName, ctx, false};
+    mAgentConnectionManager->waitForReadySignal(mRemoteAgentName, readySignalInfo);
+    return true;
+}
+
 AgentConnectionManager::AgentConnectionManager(
     batch_manager::kv_cache_manager::CacheTransBufferManager* cacheTransBufferManager, CacheState cacheState)
     : mCacheState(std::move(cacheState))
@@ -430,7 +446,8 @@ int AgentConnectionManager::getDeviceId() const
     return mDeviceId;
 }
 
-void AgentConnectionManager::waitForSyncInfo(std::string const& remoteAgentName, NotificationSyncInfo const& syncInfo)
+template <typename NotificationType>
+void AgentConnectionManager::waitForNotification(std::string const& remoteAgentName, NotificationType& expectedInfo)
 {
     while (true)
     {
@@ -452,12 +469,33 @@ void AgentConnectionManager::waitForSyncInfo(std::string const& remoteAgentName,
                 std::stringstream ss(*it2);
                 NotificationInfo notificationInfo = NotificationInfo::deserialize(ss);
                 bool erase = false;
-                if (std::holds_alternative<NotificationSyncInfo>(notificationInfo.mInfo))
+                if constexpr (std::is_same_v<NotificationType, NotificationSyncInfo>)
                 {
-                    auto notificationSyncInfo = std::get<NotificationSyncInfo>(notificationInfo.mInfo);
-                    if (notificationSyncInfo.mContext.getTag() == syncInfo.mContext.getTag()
-                        && notificationSyncInfo.mAgentName == syncInfo.mAgentName)
+                    if (std::holds_alternative<NotificationSyncInfo>(notificationInfo.mInfo))
                     {
+                        auto notificationData = std::get<NotificationSyncInfo>(notificationInfo.mInfo);
+                        if (notificationData.mContext.getTag() == expectedInfo.mContext.getTag()
+                            && notificationData.mAgentName == expectedInfo.mAgentName)
+                        {
+                            erase = true;
+                            it2 = notifs.erase(it2);
+                            if (notifs.empty())
+                            {
+                                it = mUnhandledNotifications.erase(it);
+                            }
+                            return;
+                        }
+                    }
+                }
+
+                if constexpr (std::is_same_v<NotificationType, ReadySignalInfo>)
+                {
+                    auto readySignalData = std::get<ReadySignalInfo>(notificationInfo.mInfo);
+                    if (readySignalData.mContext.getTag() == expectedInfo.mContext.getTag()
+                        && readySignalData.mAgentName == expectedInfo.mAgentName)
+                    {
+                        expectedInfo.mIsReady = readySignalData.mIsReady;
+
                         erase = true;
                         it2 = notifs.erase(it2);
                         if (notifs.empty())
@@ -467,6 +505,7 @@ void AgentConnectionManager::waitForSyncInfo(std::string const& remoteAgentName,
                         return;
                     }
                 }
+
                 if (!erase)
                 {
                     it2++;
@@ -482,6 +521,22 @@ void AgentConnectionManager::waitForSyncInfo(std::string const& remoteAgentName,
             }
         }
     }
+}
+
+// Explicit template instantiations
+template void AgentConnectionManager::waitForNotification<NotificationSyncInfo>(
+    std::string const& remoteAgentName, NotificationSyncInfo& expectedInfo);
+template void AgentConnectionManager::waitForNotification<ReadySignalInfo>(
+    std::string const& remoteAgentName, ReadySignalInfo& expectedInfo);
+
+void AgentConnectionManager::waitForSyncInfo(std::string const& remoteAgentName, NotificationSyncInfo& syncInfo)
+{
+    waitForNotification(remoteAgentName, syncInfo);
+}
+
+void AgentConnectionManager::waitForReadySignal(std::string const& remoteAgentName, ReadySignalInfo& readySignalInfo)
+{
+    waitForNotification(remoteAgentName, readySignalInfo);
 }
 
 std::string const& AgentConnectionManager::getAgentName() const

--- a/cpp/tensorrt_llm/executor/cache_transmission/agent_utils/connection.h
+++ b/cpp/tensorrt_llm/executor/cache_transmission/agent_utils/connection.h
@@ -71,6 +71,38 @@ struct RequestAndBufferInfo
     }
 };
 
+struct ReadySignalInfo
+{
+    std::string mAgentName;
+    DataContext mContext;
+    bool mIsReady;
+
+    static void serialize(ReadySignalInfo const& readySignalInfo, std::ostream& os)
+    {
+        namespace su = executor::serialize_utils;
+        su::serialize(readySignalInfo.mAgentName, os);
+        su::serialize(readySignalInfo.mContext.getTag(), os);
+        su::serialize(readySignalInfo.mIsReady, os);
+    }
+
+    static ReadySignalInfo deserialize(std::istream& is)
+    {
+        namespace su = executor::serialize_utils;
+        auto agentName = su::deserialize<decltype(mAgentName)>(is);
+        auto contextTag = su::deserialize<decltype(mContext.getTag())>(is);
+        DataContext context{contextTag};
+        auto isReady = su::deserialize<decltype(mIsReady)>(is);
+        return ReadySignalInfo{agentName, context, isReady};
+    }
+
+    static size_t serializedSize(ReadySignalInfo const& readySignalInfo)
+    {
+        namespace su = executor::serialize_utils;
+        return su::serializedSize(readySignalInfo.mAgentName) + su::serializedSize(readySignalInfo.mContext.getTag())
+            + su::serializedSize(readySignalInfo.mIsReady);
+    }
+};
+
 struct NotificationSyncInfo
 {
 
@@ -104,7 +136,7 @@ struct NotificationSyncInfo
 struct NotificationInfo
 {
 
-    std::variant<RequestAndBufferInfo, NotificationSyncInfo> mInfo;
+    std::variant<RequestAndBufferInfo, NotificationSyncInfo, ReadySignalInfo> mInfo;
 
     static void serialize(NotificationInfo const& notificationInfo, std::ostream& os)
     {
@@ -118,6 +150,10 @@ struct NotificationInfo
         {
             NotificationSyncInfo::serialize(std::get<NotificationSyncInfo>(notificationInfo.mInfo), os);
         }
+        else if (std::holds_alternative<ReadySignalInfo>(notificationInfo.mInfo))
+        {
+            ReadySignalInfo::serialize(std::get<ReadySignalInfo>(notificationInfo.mInfo), os);
+        }
         else
         {
             TLLM_THROW("Unknown variant type");
@@ -130,6 +166,7 @@ struct NotificationInfo
         auto variantIdx = su::deserialize<std::size_t>(is);
         constexpr std::size_t requestAndBufferInfoIdx{0};
         constexpr std::size_t notificationSyncInfoIdx{1};
+        constexpr std::size_t readySignalInfoIdx{2};
         if (variantIdx == requestAndBufferInfoIdx)
         {
             return NotificationInfo{RequestAndBufferInfo::deserialize(is)};
@@ -137,6 +174,10 @@ struct NotificationInfo
         else if (variantIdx == notificationSyncInfoIdx)
         {
             return NotificationInfo{NotificationSyncInfo::deserialize(is)};
+        }
+        else if (variantIdx == readySignalInfoIdx)
+        {
+            return NotificationInfo{ReadySignalInfo::deserialize(is)};
         }
         else
         {
@@ -156,6 +197,10 @@ struct NotificationInfo
         else if (std::holds_alternative<NotificationSyncInfo>(notificationInfo.mInfo))
         {
             totalSize += NotificationSyncInfo::serializedSize(std::get<NotificationSyncInfo>(notificationInfo.mInfo));
+        }
+        else if (std::holds_alternative<ReadySignalInfo>(notificationInfo.mInfo))
+        {
+            totalSize += ReadySignalInfo::serializedSize(std::get<ReadySignalInfo>(notificationInfo.mInfo));
         }
         else
         {
@@ -180,6 +225,8 @@ public:
     [[nodiscard]] std::optional<size_t> getCacheBufferId() const;
     void setHasLoadRemoteAgent(bool hasLoadRemoteAgent);
     [[nodiscard]] bool hasLoadRemoteAgent() const;
+    void sendReadySignal(DataContext const& ctx, bool isReady) const;
+    bool recvReadySignal(DataContext const& ctx) const;
 
 private:
     std::string mAgentName;
@@ -219,7 +266,11 @@ public:
         std::optional<std::string> metadata = std::nullopt, bool isSender = false);
     int getDeviceId() const;
     [[nodiscard]] std::string const& getAgentName() const;
-    void waitForSyncInfo(std::string const& remoteAgentName, NotificationSyncInfo const& syncInfo);
+
+    template <typename NotificationType>
+    void waitForNotification(std::string const& remoteAgentName, NotificationType& expectedInfo);
+    void waitForSyncInfo(std::string const& remoteAgentName, NotificationSyncInfo& syncInfo);
+    void waitForReadySignal(std::string const& remoteAgentName, ReadySignalInfo& readySignalInfo);
 
 private:
     std::map<std::string, std::shared_ptr<AgentConnection>> mConnections;

--- a/cpp/tensorrt_llm/nanobind/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/cacheTransceiver.cpp
@@ -72,6 +72,11 @@ public:
     {
         NB_OVERRIDE_PURE(checkGenTransferComplete);
     }
+
+    bool cancelRequest(tb::LlmRequest* llmRequest) override
+    {
+        NB_OVERRIDE_PURE(cancelRequest, llmRequest);
+    }
 };
 } // namespace
 
@@ -83,7 +88,8 @@ void tb::CacheTransceiverBindings::initBindings(nb::module_& m)
         .def("request_and_receive_async", &BaseCacheTransceiver::requestAndReceiveAsync)
         .def("check_context_transfer_status", &BaseCacheTransceiver::checkContextTransferStatus)
         .def("check_gen_transfer_status", &BaseCacheTransceiver::checkGenTransferStatus)
-        .def("check_gen_transfer_complete", &BaseCacheTransceiver::checkGenTransferComplete);
+        .def("check_gen_transfer_complete", &BaseCacheTransceiver::checkGenTransferComplete)
+        .def("cancel_request", &BaseCacheTransceiver::cancelRequest);
 
     nb::enum_<executor::kv_cache::CacheState::AttentionType>(m, "AttentionType")
         .value("DEFAULT", executor::kv_cache::CacheState::AttentionType::kDEFAULT)

--- a/cpp/tensorrt_llm/pybind/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/cacheTransceiver.cpp
@@ -68,6 +68,11 @@ public:
     {
         PYBIND11_OVERLOAD_PURE(bool, tb::BaseCacheTransceiver, checkGenTransferComplete);
     }
+
+    bool cancelRequest(tb::LlmRequest* llmRequest) override
+    {
+        PYBIND11_OVERLOAD_PURE(bool, tb::BaseCacheTransceiver, cancelRequest, llmRequest);
+    }
 };
 } // namespace
 
@@ -79,7 +84,8 @@ void tb::CacheTransceiverBindings::initBindings(py::module_& m)
         .def("request_and_receive_async", &BaseCacheTransceiver::requestAndReceiveAsync)
         .def("check_context_transfer_status", &BaseCacheTransceiver::checkContextTransferStatus)
         .def("check_gen_transfer_status", &BaseCacheTransceiver::checkGenTransferStatus)
-        .def("check_gen_transfer_complete", &BaseCacheTransceiver::checkGenTransferComplete);
+        .def("check_gen_transfer_complete", &BaseCacheTransceiver::checkGenTransferComplete)
+        .def("cancel_request", &BaseCacheTransceiver::cancelRequest);
 
     py::enum_<executor::kv_cache::CacheState::AttentionType>(m, "AttentionType")
         .value("DEFAULT", executor::kv_cache::CacheState::AttentionType::kDEFAULT)

--- a/cpp/tests/unit_tests/executor/serializeUtilsTest.cpp
+++ b/cpp/tests/unit_tests/executor/serializeUtilsTest.cpp
@@ -13,6 +13,7 @@
 #include "tensorrt_llm/executor/serializeUtils.h"
 #include "tensorrt_llm/batch_manager/kvCacheManager.h"
 #include "tensorrt_llm/common/logger.h"
+#include "tensorrt_llm/executor/cache_transmission/agent_utils/connection.h"
 #include "tensorrt_llm/executor/dataTransceiverState.h"
 #include "tensorrt_llm/executor/executor.h"
 #include "tensorrt_llm/executor/types.h"
@@ -1064,4 +1065,174 @@ TEST(SerializeUtilsTest, BlockKeyWithExtras)
     BlockKey key(true, loraTaskId, uniqueTokens, extraKeys);
 
     testSerializeDeserialize(key);
+}
+
+// Connection notification tests
+namespace kv_cache = tensorrt_llm::executor::kv_cache;
+
+template <typename T>
+T serializeDeserializeNotification(T const& val)
+{
+    auto size = T::serializedSize(val);
+    std::ostringstream oss;
+    T::serialize(val, oss);
+    EXPECT_EQ(oss.str().size(), size);
+
+    std::istringstream iss(oss.str());
+    return T::deserialize(iss);
+}
+
+TEST(SerializeUtilsTest, RequestAndBufferInfo)
+{
+    // Test with all fields populated
+    {
+        kv_cache::RequestAndBufferInfo original{"testAgent", "127.0.0.1:8080",
+            tensorrt_llm::batch_manager::RequestInfo{}, kv_cache::MemoryDesc{nullptr, 1024, 0},
+            std::make_optional<std::string>("metadata"), 1};
+
+        auto deserialized = serializeDeserializeNotification(original);
+
+        EXPECT_EQ(original.mAgentName, deserialized.mAgentName);
+        EXPECT_EQ(original.mAddress, deserialized.mAddress);
+        EXPECT_EQ(original.mRequestInfo.getRequestId(), deserialized.mRequestInfo.getRequestId());
+        EXPECT_EQ(original.mBufferDesc.getAddr(), deserialized.mBufferDesc.getAddr());
+        EXPECT_EQ(original.mBufferDesc.getLen(), deserialized.mBufferDesc.getLen());
+        EXPECT_EQ(original.mBufferDesc.getDeviceId(), deserialized.mBufferDesc.getDeviceId());
+        EXPECT_EQ(original.mMetadata, deserialized.mMetadata);
+        EXPECT_EQ(original.mValidConnectionIdx, deserialized.mValidConnectionIdx);
+    }
+
+    // Test with nullopt metadata
+    {
+        kv_cache::RequestAndBufferInfo original{"testAgent2", "192.168.1.1:9090",
+            tensorrt_llm::batch_manager::RequestInfo{}, kv_cache::MemoryDesc{nullptr, 512, 0}, std::nullopt, 2};
+
+        auto deserialized = serializeDeserializeNotification(original);
+
+        EXPECT_EQ(original.mAgentName, deserialized.mAgentName);
+        EXPECT_EQ(original.mAddress, deserialized.mAddress);
+        EXPECT_EQ(original.mRequestInfo.getRequestId(), deserialized.mRequestInfo.getRequestId());
+        EXPECT_EQ(original.mBufferDesc.getAddr(), deserialized.mBufferDesc.getAddr());
+        EXPECT_EQ(original.mBufferDesc.getLen(), deserialized.mBufferDesc.getLen());
+        EXPECT_EQ(original.mBufferDesc.getDeviceId(), deserialized.mBufferDesc.getDeviceId());
+        EXPECT_EQ(original.mMetadata, deserialized.mMetadata);
+        EXPECT_EQ(original.mValidConnectionIdx, deserialized.mValidConnectionIdx);
+    }
+}
+
+TEST(SerializeUtilsTest, ReadySignalInfo)
+{
+    // Test with isReady = true
+    {
+        kv_cache::ReadySignalInfo original{"agent1", kv_cache::DataContext{12345}, true};
+
+        auto deserialized = serializeDeserializeNotification(original);
+
+        EXPECT_EQ(original.mAgentName, deserialized.mAgentName);
+        EXPECT_EQ(original.mContext.getTag(), deserialized.mContext.getTag());
+        EXPECT_EQ(original.mIsReady, deserialized.mIsReady);
+    }
+
+    // Test with isReady = false
+    {
+        kv_cache::ReadySignalInfo original{"agent2", kv_cache::DataContext{67890}, false};
+
+        auto deserialized = serializeDeserializeNotification(original);
+
+        EXPECT_EQ(original.mAgentName, deserialized.mAgentName);
+        EXPECT_EQ(original.mContext.getTag(), deserialized.mContext.getTag());
+        EXPECT_EQ(original.mIsReady, deserialized.mIsReady);
+    }
+
+    // Test with different context tags
+    {
+        kv_cache::ReadySignalInfo original{"agent3", kv_cache::DataContext{0}, true};
+
+        auto deserialized = serializeDeserializeNotification(original);
+
+        EXPECT_EQ(original.mAgentName, deserialized.mAgentName);
+        EXPECT_EQ(original.mContext.getTag(), deserialized.mContext.getTag());
+        EXPECT_EQ(original.mIsReady, deserialized.mIsReady);
+    }
+}
+
+TEST(SerializeUtilsTest, NotificationSyncInfo)
+{
+    // Test basic functionality
+    {
+        kv_cache::NotificationSyncInfo original{"syncAgent", kv_cache::DataContext{54321}};
+
+        auto deserialized = serializeDeserializeNotification(original);
+
+        EXPECT_EQ(original.mAgentName, deserialized.mAgentName);
+        EXPECT_EQ(original.mContext.getTag(), deserialized.mContext.getTag());
+    }
+
+    // Test with different agent names and context tags
+    {
+        kv_cache::NotificationSyncInfo original{"anotherAgent", kv_cache::DataContext{98765}};
+
+        auto deserialized = serializeDeserializeNotification(original);
+
+        EXPECT_EQ(original.mAgentName, deserialized.mAgentName);
+        EXPECT_EQ(original.mContext.getTag(), deserialized.mContext.getTag());
+    }
+
+    // Test with empty agent name
+    {
+        kv_cache::NotificationSyncInfo original{"", kv_cache::DataContext{11111}};
+
+        auto deserialized = serializeDeserializeNotification(original);
+
+        EXPECT_EQ(original.mAgentName, deserialized.mAgentName);
+        EXPECT_EQ(original.mContext.getTag(), deserialized.mContext.getTag());
+    }
+}
+
+TEST(SerializeUtilsTest, NotificationInfo)
+{
+    // Test with RequestAndBufferInfo variant
+    {
+        kv_cache::RequestAndBufferInfo requestInfo{"testAgent", "127.0.0.1:8080",
+            tensorrt_llm::batch_manager::RequestInfo{}, kv_cache::MemoryDesc{nullptr, 1024, 0},
+            std::make_optional<std::string>("test_metadata"), 1};
+
+        kv_cache::NotificationInfo original{requestInfo};
+        auto deserialized = serializeDeserializeNotification(original);
+
+        EXPECT_TRUE(std::holds_alternative<kv_cache::RequestAndBufferInfo>(deserialized.mInfo));
+        auto deserializedRequestInfo = std::get<kv_cache::RequestAndBufferInfo>(deserialized.mInfo);
+        EXPECT_EQ(requestInfo.mAgentName, deserializedRequestInfo.mAgentName);
+        EXPECT_EQ(requestInfo.mAddress, deserializedRequestInfo.mAddress);
+        EXPECT_EQ(requestInfo.mRequestInfo.getRequestId(), deserializedRequestInfo.mRequestInfo.getRequestId());
+        EXPECT_EQ(requestInfo.mMetadata, deserializedRequestInfo.mMetadata);
+        EXPECT_EQ(requestInfo.mValidConnectionIdx, deserializedRequestInfo.mValidConnectionIdx);
+    }
+
+    // Test with NotificationSyncInfo variant
+    {
+        kv_cache::NotificationSyncInfo syncInfo{"syncAgent", kv_cache::DataContext{12345}};
+
+        kv_cache::NotificationInfo original{syncInfo};
+        auto deserialized = serializeDeserializeNotification(original);
+
+        EXPECT_TRUE(std::holds_alternative<kv_cache::NotificationSyncInfo>(deserialized.mInfo));
+        auto deserializedSyncInfo = std::get<kv_cache::NotificationSyncInfo>(deserialized.mInfo);
+        EXPECT_EQ(syncInfo.mAgentName, deserializedSyncInfo.mAgentName);
+        EXPECT_EQ(syncInfo.mContext.getTag(), deserializedSyncInfo.mContext.getTag());
+    }
+
+    // Test with ReadySignalInfo variant
+    {
+        kv_cache::ReadySignalInfo readyInfo{"readyAgent", kv_cache::DataContext{67890}, true};
+
+        kv_cache::NotificationInfo original{readyInfo};
+        auto deserialized = serializeDeserializeNotification(original);
+
+        EXPECT_TRUE(std::holds_alternative<kv_cache::ReadySignalInfo>(deserialized.mInfo));
+        auto deserializedReadyInfo = std::get<kv_cache::ReadySignalInfo>(deserialized.mInfo);
+        EXPECT_EQ(readyInfo.mAgentName, deserializedReadyInfo.mAgentName);
+        EXPECT_EQ(readyInfo.mContext.getTag(), deserializedReadyInfo.mContext.getTag());
+        EXPECT_EQ(readyInfo.mIsReady, deserializedReadyInfo.mIsReady);
+    }
 }

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
@@ -90,6 +90,10 @@ class KvCacheTransceiver(ABC):
     def check_gen_transfer_complete(self):
         raise NotImplementedError
 
+    @abstractmethod
+    def cancel_request(self, req: LlmRequest):
+        raise NotImplementedError
+
 
 class BindKvCacheTransceiver(KvCacheTransceiver):
 
@@ -129,6 +133,9 @@ class BindKvCacheTransceiver(KvCacheTransceiver):
 
     def check_gen_transfer_complete(self):
         return self.impl.check_gen_transfer_complete()
+
+    def cancel_request(self, req: LlmRequest):
+        return self.impl.cancel_request(req)
 
 
 class CacheTransBufferManager:

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1872,7 +1872,7 @@ class PyExecutor:
                 or request.state
                 == LlmRequestState.DISAGG_GENERATION_TRANS_IN_PROGRESS)
 
-    def _can_cancel_request(self, request) -> bool:
+    def _try_cancel_request(self, request) -> bool:
         """Check if a request can be canceled and attempt cancellation if needed.
 
         Returns:
@@ -1899,7 +1899,7 @@ class PyExecutor:
             if req_id not in self.executor_request_queue.get_canceled_req_ids():
                 continue
 
-            is_cancelled = self._can_cancel_request(request)
+            is_cancelled = self._try_cancel_request(request)
             if is_cancelled:
                 # Mark requests as finished, then, we reuse all existing code
                 # to clean up the KV cache resources.

--- a/tests/unittest/others/test_kv_cache_transceiver.py
+++ b/tests/unittest/others/test_kv_cache_transceiver.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 import torch
 
@@ -130,3 +132,74 @@ def test_kv_cache_transceiver_single_process(ctx_gen_kv_cache_dtype,
     assert torch.equal(
         kv_cache_manager_gen.get_buffers(0),
         kv_cache_manager_ctx.get_buffers(0)), "different kv-cache values"
+
+
+@pytest.mark.timeout(120)
+@pytest.mark.parametrize("attention_type",
+                         [AttentionTypeCpp.DEFAULT, AttentionTypeCpp.MLA],
+                         ids=["mha", "mla"])
+def test_cancel_request_in_transmission(attention_type):
+    # Init kv_cache manager and cache transceiver
+    mapping = Mapping(world_size=1, rank=0)
+    dist = MPIDist(mapping=mapping)
+    ctx_kv_cache_dtype, gen_kv_cache_dtype = DataType.HALF, DataType.HALF
+    kv_cache_manager_ctx = create_kv_cache_manager(mapping, ctx_kv_cache_dtype)
+    kv_cache_manager_gen = create_kv_cache_manager(mapping, gen_kv_cache_dtype)
+
+    cache_transceiver_config = trtllm.CacheTransceiverConfig(
+        backend=trtllm.CacheTransceiverBackendType.DEFAULT,
+        max_tokens_in_buffer=512)
+
+    kv_cache_transceiver_ctx = create_kv_cache_transceiver(
+        mapping, dist, kv_cache_manager_ctx, attention_type,
+        cache_transceiver_config)
+
+    kv_cache_transceiver_gen = create_kv_cache_transceiver(
+        mapping, dist, kv_cache_manager_gen, attention_type,
+        cache_transceiver_config)
+
+    fill_kv_cache_buffer(kv_cache_manager_ctx)
+
+    # init ctx request
+    sampling_params = SamplingParams()
+    ctx_request = LlmRequest(
+        request_id=0,
+        max_new_tokens=1,
+        input_tokens=list(range(256)),
+        sampling_config=tensorrt_llm.bindings.SamplingConfig(
+            sampling_params._get_sampling_config()),
+        is_streaming=False,
+        llm_request_type=LlmRequestType.LLMREQUEST_TYPE_CONTEXT_ONLY)
+
+    kv_cache_manager_ctx.impl.add_sequence(ctx_request.py_request_id,
+                                           ctx_request.prompt_len, 1,
+                                           ctx_request)
+    # send ctx request
+    kv_cache_transceiver_ctx.respond_and_send_async(ctx_request)
+
+    # wait for ctx request to be sent
+    time.sleep(2)
+
+    # cancel ctx request
+    is_cancelled = kv_cache_transceiver_ctx.cancel_request(ctx_request)
+    assert is_cancelled
+
+    # init gen request
+    gen_request = LlmRequest(
+        request_id=0,
+        max_new_tokens=1,
+        input_tokens=list(range(256)),
+        sampling_config=tensorrt_llm.bindings.SamplingConfig(
+            sampling_params._get_sampling_config()),
+        is_streaming=False,
+        llm_request_type=LlmRequestType.LLMREQUEST_TYPE_GENERATION_ONLY,
+        context_phase_params=ctx_request.context_phase_params)
+
+    kv_cache_manager_gen.impl.add_sequence(gen_request.py_request_id,
+                                           gen_request.prompt_len, 1,
+                                           gen_request)
+    # send gen request
+    kv_cache_transceiver_gen.request_and_receive_async(gen_request)
+
+    # Block the main thread due to the async operation
+    time.sleep(2)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added ability to cancel in-flight KV cache transfers through a new cancel_request API (available from C++ and Python).
  - Introduced readiness signaling between sender and receiver to coordinate cancellations and avoid unnecessary work.
  - Enhanced cancellation handling in the executor to defer termination until the transceiver confirms, improving stability in asynchronous workflows.

- Tests
  - Added tests for readiness signaling and canceling requests during transmission, including multi-GPU scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up
-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
