### PR TITLE
[https://nvbugs/5433581][fix] DeepGEMM installation on SBSA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ tensorrt_llm/bindings/**/*.pyi
 tensorrt_llm/deep_ep/
 tensorrt_llm/deep_ep_cpp_tllm.*.so
 tensorrt_llm/deep_ep_cpp_tllm.pyi
+tensorrt_llm/deep_gemm/
+tensorrt_llm/deep_gemm_cpp_tllm.*.so
+tensorrt_llm/deep_gemm_cpp_tllm.pyi
 *docs/cpp_docs*
 *docs/source/_cpp_gen*
 docs/source/**/*.rst

--- a/.gitmodules
+++ b/.gitmodules
@@ -26,6 +26,6 @@
 [submodule "3rdparty/cppzmq"]
 	path = 3rdparty/cppzmq
 	url = https://github.com/zeromq/cppzmq.git
-[submodule "3rdparty/deepgemm"]
-	path = 3rdparty/deepgemm
+[submodule "3rdparty/DeepGEMM"]
+	path = 3rdparty/DeepGEMM
 	url = https://github.com/zongfeijing/DeepGEMM.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -26,3 +26,6 @@
 [submodule "3rdparty/cppzmq"]
 	path = 3rdparty/cppzmq
 	url = https://github.com/zeromq/cppzmq.git
+[submodule "3rdparty/deepgemm"]
+	path = 3rdparty/deepgemm
+	url = https://github.com/zongfeijing/DeepGEMM.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -28,4 +28,4 @@
 	url = https://github.com/zeromq/cppzmq.git
 [submodule "3rdparty/DeepGEMM"]
 	path = 3rdparty/DeepGEMM
-	url = https://github.com/zongfeijing/DeepGEMM.git
+	url = https://github.com/deepseek-ai/DeepGEMM.git

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -31,7 +31,7 @@ option(BUILD_PYT "Build in PyTorch TorchScript class mode" ON)
 option(BUILD_TESTS "Build Google tests" ON)
 option(BUILD_BENCHMARKS "Build benchmarks" ON)
 option(BUILD_DEEP_EP "Build the Deep EP module" ON)
-option(BUILD_DEEPGEMM "Build the DeepGEMM module" ON)
+option(BUILD_DEEP_GEMM "Build the DeepGEMM module" ON)
 option(BUILD_MICRO_BENCHMARKS "Build C++ micro benchmarks" OFF)
 option(NVTX_DISABLE "Disable all NVTX features" ON)
 option(WARNING_IS_ERROR "Treat all warnings as errors" OFF)
@@ -202,7 +202,7 @@ get_filename_component(TRT_LLM_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR} PATH)
 set(3RDPARTY_DIR ${TRT_LLM_ROOT_DIR}/3rdparty)
 if(BINDING_TYPE STREQUAL "pybind"
    OR BUILD_DEEP_EP
-   OR BUILD_DEEPGEMM)
+   OR BUILD_DEEP_GEMM)
   add_subdirectory(${3RDPARTY_DIR}/pybind11
                    ${CMAKE_CURRENT_BINARY_DIR}/pybind11)
 endif()
@@ -223,7 +223,7 @@ include_directories(
   ${3RDPARTY_DIR}/json/include)
 if(BINDING_TYPE STREQUAL "pybind"
    OR BUILD_DEEP_EP
-   OR BUILD_DEEPGEMM)
+   OR BUILD_DEEP_GEMM)
   include_directories(${3RDPARTY_DIR}/pybind11/include)
 endif()
 if(BINDING_TYPE STREQUAL "nanobind")

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -31,6 +31,7 @@ option(BUILD_PYT "Build in PyTorch TorchScript class mode" ON)
 option(BUILD_TESTS "Build Google tests" ON)
 option(BUILD_BENCHMARKS "Build benchmarks" ON)
 option(BUILD_DEEP_EP "Build the Deep EP module" ON)
+option(BUILD_DEEPGEMM "Build the DeepGEMM module" ON)
 option(BUILD_MICRO_BENCHMARKS "Build C++ micro benchmarks" OFF)
 option(NVTX_DISABLE "Disable all NVTX features" ON)
 option(WARNING_IS_ERROR "Treat all warnings as errors" OFF)
@@ -199,7 +200,9 @@ set(TRT_LIB TensorRT::NvInfer)
 get_filename_component(TRT_LLM_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR} PATH)
 
 set(3RDPARTY_DIR ${TRT_LLM_ROOT_DIR}/3rdparty)
-if(BINDING_TYPE STREQUAL "pybind" OR BUILD_DEEP_EP)
+if(BINDING_TYPE STREQUAL "pybind"
+   OR BUILD_DEEP_EP
+   OR BUILD_DEEPGEMM)
   add_subdirectory(${3RDPARTY_DIR}/pybind11
                    ${CMAKE_CURRENT_BINARY_DIR}/pybind11)
 endif()
@@ -218,7 +221,9 @@ include_directories(
   ${3RDPARTY_DIR}/cutlass/tools/util/include
   ${3RDPARTY_DIR}/NVTX/include
   ${3RDPARTY_DIR}/json/include)
-if(BINDING_TYPE STREQUAL "pybind" OR BUILD_DEEP_EP)
+if(BINDING_TYPE STREQUAL "pybind"
+   OR BUILD_DEEP_EP
+   OR BUILD_DEEPGEMM)
   include_directories(${3RDPARTY_DIR}/pybind11/include)
 endif()
 if(BINDING_TYPE STREQUAL "nanobind")

--- a/cpp/tensorrt_llm/CMakeLists.txt
+++ b/cpp/tensorrt_llm/CMakeLists.txt
@@ -314,4 +314,8 @@ if(BUILD_DEEP_EP)
   add_subdirectory(deep_ep)
 endif()
 
+if(BUILD_DEEP_GEMM)
+  add_subdirectory(deep_gemm)
+endif()
+
 add_subdirectory(plugins)

--- a/cpp/tensorrt_llm/deep_gemm/CMakeLists.txt
+++ b/cpp/tensorrt_llm/deep_gemm/CMakeLists.txt
@@ -1,0 +1,162 @@
+add_custom_target(deep_gemm)
+
+# CUDA architectures
+# ==================
+
+# Filter CUDA arch >= 9.0 (deep_gemm requirements)
+set(DEEP_GEMM_CUDA_ARCHITECTURES "")
+foreach(CUDA_ARCH IN LISTS CMAKE_CUDA_ARCHITECTURES)
+  string(REGEX MATCHALL "^([1-9][0-9]*)([0-9])[af]?(-real|-virtual)?$" MATCHES
+               ${CUDA_ARCH})
+  if(NOT CMAKE_MATCH_0)
+    message(FATAL_ERROR "Invalid CUDA arch format: \"${CUDA_ARCH}\"")
+  endif()
+  set(CUDA_ARCH_MAJOR ${CMAKE_MATCH_1})
+  set(CUDA_ARCH_MINOR ${CMAKE_MATCH_2})
+  set(CUDA_ARCH_POSTFIX ${CMAKE_MATCH_3})
+  if(${CUDA_ARCH_MAJOR} GREATER_EQUAL 9)
+    list(APPEND DEEP_GEMM_CUDA_ARCHITECTURES
+         "${CUDA_ARCH_MAJOR}${CUDA_ARCH_MINOR}${CUDA_ARCH_POSTFIX}")
+  endif()
+endforeach()
+
+# Skip build if there is no suitable CUDA arch
+if(WIN32)
+  set(DEEP_GEMM_CUDA_ARCHITECTURES "")
+endif()
+message(
+  STATUS
+    "deep_gemm DEEP_GEMM_CUDA_ARCHITECTURES: ${DEEP_GEMM_CUDA_ARCHITECTURES}")
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cuda_architectures.txt
+     "${DEEP_GEMM_CUDA_ARCHITECTURES}")
+if(NOT DEEP_GEMM_CUDA_ARCHITECTURES)
+  return()
+endif()
+
+# Prepare files
+# =============
+
+# Use DeepGEMM submodule
+set(DEEP_GEMM_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../3rdparty/deepgemm)
+get_filename_component(DEEP_GEMM_SOURCE_DIR ${DEEP_GEMM_SOURCE_DIR} ABSOLUTE)
+
+if(NOT EXISTS ${DEEP_GEMM_SOURCE_DIR})
+  message(
+    FATAL_ERROR
+      "DeepGEMM submodule not found at ${DEEP_GEMM_SOURCE_DIR}. Please run: git submodule update --init --recursive"
+  )
+endif()
+
+# Check if submodules are initialized
+if(NOT EXISTS ${DEEP_GEMM_SOURCE_DIR}/third-party/cutlass/include)
+  message(
+    FATAL_ERROR
+      "DeepGEMM submodules not initialized. Please run: git submodule update --init --recursive"
+  )
+endif()
+
+# Copy and update python files
+set(DEEP_GEMM_PYTHON_DEST ${CMAKE_CURRENT_BINARY_DIR}/python/deep_gemm)
+file(REMOVE_RECURSE ${DEEP_GEMM_PYTHON_DEST})
+file(MAKE_DIRECTORY ${DEEP_GEMM_PYTHON_DEST})
+
+# Copy all files from deep_gemm directory
+file(GLOB_RECURSE DEEP_GEMM_ALL_FILES ${DEEP_GEMM_SOURCE_DIR}/deep_gemm/*)
+configure_file(${DEEP_GEMM_SOURCE_DIR}/LICENSE ${DEEP_GEMM_PYTHON_DEST}/LICENSE
+               COPYONLY)
+foreach(SOURCE_FILE ${DEEP_GEMM_ALL_FILES})
+  file(RELATIVE_PATH REL_PATH ${DEEP_GEMM_SOURCE_DIR}/deep_gemm ${SOURCE_FILE})
+  get_filename_component(REL_DIR ${REL_PATH} DIRECTORY)
+  file(MAKE_DIRECTORY ${DEEP_GEMM_PYTHON_DEST}/${REL_DIR})
+
+  # Check if it's a Python file that needs import renaming
+  get_filename_component(FILE_EXT ${SOURCE_FILE} EXT)
+  if(FILE_EXT STREQUAL ".py")
+    # Read file content and replace module imports for Python files
+    file(READ ${SOURCE_FILE} _content)
+    string(REPLACE "deep_gemm_cpp" "tensorrt_llm.deep_gemm_cpp_tllm" _content
+                   "${_content}")
+
+    # Add adaptation header
+    string(
+      PREPEND
+      _content
+      "# Adapted from https://github.com/zongfeijing/DeepGEMM/blob/war/deep_gemm/${REL_PATH}\n"
+    )
+
+    # Write modified content
+    set(_dst "${DEEP_GEMM_PYTHON_DEST}/${REL_PATH}")
+    file(WRITE ${_dst} "${_content}")
+  else()
+    # Copy non-Python files as-is
+    set(_dst "${DEEP_GEMM_PYTHON_DEST}/${REL_PATH}")
+    file(COPY ${SOURCE_FILE} DESTINATION ${DEEP_GEMM_PYTHON_DEST}/${REL_DIR})
+  endif()
+
+  # Add dependency tracking
+  set_property(
+    DIRECTORY
+    APPEND
+    PROPERTY CMAKE_CONFIGURE_DEPENDS ${SOURCE_FILE})
+endforeach()
+
+# Copy third-party includes (cutlass and fmt) to the include directory
+set(DEEP_GEMM_INCLUDE_DEST ${DEEP_GEMM_PYTHON_DEST}/include)
+file(MAKE_DIRECTORY ${DEEP_GEMM_INCLUDE_DEST})
+file(COPY ${DEEP_GEMM_SOURCE_DIR}/third-party/cutlass/include/cute
+     DESTINATION ${DEEP_GEMM_INCLUDE_DEST})
+file(COPY ${DEEP_GEMM_SOURCE_DIR}/third-party/cutlass/include/cutlass
+     DESTINATION ${DEEP_GEMM_INCLUDE_DEST})
+
+# Generate envs.py file similar to deep_gemm's setup.py
+set(ENVS_CONTENT
+    "# Pre-installed environment variables\npersistent_envs = dict()\n")
+file(WRITE ${DEEP_GEMM_PYTHON_DEST}/envs.py "${ENVS_CONTENT}")
+
+# Let CMake generate `fatbinData` for CUDA separable compilation
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION FALSE)
+
+# Find torch_python
+find_library(TORCH_PYTHON_LIB torch_python REQUIRED
+             HINTS ${TORCH_INSTALL_PREFIX}/lib)
+
+# Build deep_gemm_cpp_tllm extension (matching deep_gemm's setup.py)
+set(DEEP_GEMM_SOURCES ${DEEP_GEMM_SOURCE_DIR}/csrc/python_api.cpp)
+
+pybind11_add_module(deep_gemm_cpp_tllm ${DEEP_GEMM_SOURCES})
+set_target_properties(
+  deep_gemm_cpp_tllm
+  PROPERTIES CXX_STANDARD_REQUIRED ON
+             CXX_STANDARD 20
+             CUDA_SEPARABLE_COMPILATION OFF
+             CUDA_ARCHITECTURES "${DEEP_GEMM_CUDA_ARCHITECTURES}"
+             LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/deep_gemm_cpp_tllm.version
+             INSTALL_RPATH "${TORCH_INSTALL_PREFIX}/lib"
+             BUILD_WITH_INSTALL_RPATH TRUE)
+
+target_compile_options(deep_gemm_cpp_tllm PRIVATE ${TORCH_CXX_FLAGS} -std=c++20
+                                                  -O3 -fPIC -Wno-psabi)
+
+# Extension name definition
+target_compile_definitions(deep_gemm_cpp_tllm
+                           PRIVATE TORCH_EXTENSION_NAME=deep_gemm_cpp_tllm)
+
+# Include directories matching deep_gemm setup.py
+target_include_directories(
+  deep_gemm_cpp_tllm
+  PRIVATE ${CUDA_INCLUDE_DIRS} ${DEEP_GEMM_SOURCE_DIR}/deep_gemm/include
+          ${DEEP_GEMM_SOURCE_DIR}/third-party/cutlass/include
+          ${DEEP_GEMM_SOURCE_DIR}/third-party/fmt/include)
+
+# Link libraries (matching deep_gemm setup.py: cuda, cudart + torch)
+target_link_libraries(
+  deep_gemm_cpp_tllm PRIVATE ${TORCH_LIBRARIES} ${TORCH_PYTHON_LIB} cuda cudart)
+
+# Link directories
+target_link_directories(
+  deep_gemm_cpp_tllm PRIVATE ${CUDA_TOOLKIT_ROOT_DIR}/lib64
+  ${CUDA_TOOLKIT_ROOT_DIR}/lib64/stubs)
+
+# Set targets
+# ===========
+add_dependencies(deep_gemm deep_gemm_cpp_tllm)

--- a/cpp/tensorrt_llm/deep_gemm/CMakeLists.txt
+++ b/cpp/tensorrt_llm/deep_gemm/CMakeLists.txt
@@ -1,35 +1,6 @@
 add_custom_target(deep_gemm)
 
-# CUDA architectures
-# ==================
-
-# Filter CUDA arch >= 9.0 (deep_gemm requirements)
-set(DEEP_GEMM_CUDA_ARCHITECTURES "")
-foreach(CUDA_ARCH IN LISTS CMAKE_CUDA_ARCHITECTURES)
-  string(REGEX MATCHALL "^([1-9][0-9]*)([0-9])[af]?(-real|-virtual)?$" MATCHES
-               ${CUDA_ARCH})
-  if(NOT CMAKE_MATCH_0)
-    message(FATAL_ERROR "Invalid CUDA arch format: \"${CUDA_ARCH}\"")
-  endif()
-  set(CUDA_ARCH_MAJOR ${CMAKE_MATCH_1})
-  set(CUDA_ARCH_MINOR ${CMAKE_MATCH_2})
-  set(CUDA_ARCH_POSTFIX ${CMAKE_MATCH_3})
-  if(${CUDA_ARCH_MAJOR} GREATER_EQUAL 9)
-    list(APPEND DEEP_GEMM_CUDA_ARCHITECTURES
-         "${CUDA_ARCH_MAJOR}${CUDA_ARCH_MINOR}${CUDA_ARCH_POSTFIX}")
-  endif()
-endforeach()
-
-# Skip build if there is no suitable CUDA arch
 if(WIN32)
-  set(DEEP_GEMM_CUDA_ARCHITECTURES "")
-endif()
-message(
-  STATUS
-    "deep_gemm DEEP_GEMM_CUDA_ARCHITECTURES: ${DEEP_GEMM_CUDA_ARCHITECTURES}")
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cuda_architectures.txt
-     "${DEEP_GEMM_CUDA_ARCHITECTURES}")
-if(NOT DEEP_GEMM_CUDA_ARCHITECTURES)
   return()
 endif()
 
@@ -37,7 +8,7 @@ endif()
 # =============
 
 # Use DeepGEMM submodule
-set(DEEP_GEMM_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../3rdparty/deepgemm)
+set(DEEP_GEMM_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../3rdparty/DeepGEMM)
 get_filename_component(DEEP_GEMM_SOURCE_DIR ${DEEP_GEMM_SOURCE_DIR} ABSOLUTE)
 
 if(NOT EXISTS ${DEEP_GEMM_SOURCE_DIR})
@@ -107,11 +78,6 @@ file(COPY ${DEEP_GEMM_SOURCE_DIR}/third-party/cutlass/include/cute
      DESTINATION ${DEEP_GEMM_INCLUDE_DEST})
 file(COPY ${DEEP_GEMM_SOURCE_DIR}/third-party/cutlass/include/cutlass
      DESTINATION ${DEEP_GEMM_INCLUDE_DEST})
-file(COPY ${DEEP_GEMM_SOURCE_DIR}/third-party/fmt/include/fmt
-     DESTINATION ${DEEP_GEMM_INCLUDE_DEST})
-
-# Let CMake generate `fatbinData` for CUDA separable compilation
-set(CMAKE_INTERPROCEDURAL_OPTIMIZATION FALSE)
 
 # Find torch_python
 find_library(TORCH_PYTHON_LIB torch_python REQUIRED
@@ -126,8 +92,7 @@ set_target_properties(
   PROPERTIES CXX_STANDARD_REQUIRED ON
              CXX_STANDARD 20
              CXX_SCAN_FOR_MODULES OFF
-             CUDA_SEPARABLE_COMPILATION OFF
-             CUDA_ARCHITECTURES "${DEEP_GEMM_CUDA_ARCHITECTURES}"
+             CUDA_SEPARABLE_COMPILATION ON
              LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/deep_gemm_cpp_tllm.version
              INSTALL_RPATH "${TORCH_INSTALL_PREFIX}/lib"
              BUILD_WITH_INSTALL_RPATH TRUE)

--- a/cpp/tensorrt_llm/deep_gemm/CMakeLists.txt
+++ b/cpp/tensorrt_llm/deep_gemm/CMakeLists.txt
@@ -52,7 +52,7 @@ foreach(SOURCE_FILE ${DEEP_GEMM_ALL_FILES})
     string(
       PREPEND
       _content
-      "# Adapted from https://github.com/zongfeijing/DeepGEMM/blob/war/deep_gemm/${REL_PATH}\n"
+      "# Adapted from https://github.com/deepseek-ai/DeepGEMM/blob/main/deep_gemm/${REL_PATH}\n"
     )
 
     # Write modified content
@@ -90,14 +90,14 @@ pybind11_add_module(deep_gemm_cpp_tllm ${DEEP_GEMM_SOURCES})
 set_target_properties(
   deep_gemm_cpp_tllm
   PROPERTIES CXX_STANDARD_REQUIRED ON
-             CXX_STANDARD 20
+             CXX_STANDARD 17
              CXX_SCAN_FOR_MODULES OFF
              CUDA_SEPARABLE_COMPILATION ON
              LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/deep_gemm_cpp_tllm.version
              INSTALL_RPATH "${TORCH_INSTALL_PREFIX}/lib"
              BUILD_WITH_INSTALL_RPATH TRUE)
 
-target_compile_options(deep_gemm_cpp_tllm PRIVATE ${TORCH_CXX_FLAGS} -std=c++20
+target_compile_options(deep_gemm_cpp_tllm PRIVATE ${TORCH_CXX_FLAGS} -std=c++17
                                                   -O3 -fPIC -Wno-psabi)
 
 # Extension name definition
@@ -113,7 +113,8 @@ target_include_directories(
 
 # Link libraries (matching deep_gemm setup.py: cuda, cudart + torch)
 target_link_libraries(
-  deep_gemm_cpp_tllm PRIVATE ${TORCH_LIBRARIES} ${TORCH_PYTHON_LIB} cuda cudart)
+  deep_gemm_cpp_tllm PRIVATE ${TORCH_LIBRARIES} ${TORCH_PYTHON_LIB}
+                             CUDA::cuda_driver CUDA::cudart)
 
 # Link directories
 target_link_directories(

--- a/cpp/tensorrt_llm/deep_gemm/CMakeLists.txt
+++ b/cpp/tensorrt_llm/deep_gemm/CMakeLists.txt
@@ -107,11 +107,8 @@ file(COPY ${DEEP_GEMM_SOURCE_DIR}/third-party/cutlass/include/cute
      DESTINATION ${DEEP_GEMM_INCLUDE_DEST})
 file(COPY ${DEEP_GEMM_SOURCE_DIR}/third-party/cutlass/include/cutlass
      DESTINATION ${DEEP_GEMM_INCLUDE_DEST})
-
-# Generate envs.py file similar to deep_gemm's setup.py
-set(ENVS_CONTENT
-    "# Pre-installed environment variables\npersistent_envs = dict()\n")
-file(WRITE ${DEEP_GEMM_PYTHON_DEST}/envs.py "${ENVS_CONTENT}")
+file(COPY ${DEEP_GEMM_SOURCE_DIR}/third-party/fmt/include/fmt
+     DESTINATION ${DEEP_GEMM_INCLUDE_DEST})
 
 # Let CMake generate `fatbinData` for CUDA separable compilation
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION FALSE)
@@ -128,6 +125,7 @@ set_target_properties(
   deep_gemm_cpp_tllm
   PROPERTIES CXX_STANDARD_REQUIRED ON
              CXX_STANDARD 20
+             CXX_SCAN_FOR_MODULES OFF
              CUDA_SEPARABLE_COMPILATION OFF
              CUDA_ARCHITECTURES "${DEEP_GEMM_CUDA_ARCHITECTURES}"
              LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/deep_gemm_cpp_tllm.version

--- a/cpp/tensorrt_llm/deep_gemm/deep_gemm_cpp_tllm.version
+++ b/cpp/tensorrt_llm/deep_gemm/deep_gemm_cpp_tllm.version
@@ -1,0 +1,4 @@
+{
+  global: PyInit_deep_gemm_cpp_tllm;
+  local: *;
+};

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,5 +61,4 @@ etcd3
 blake3
 llguidance==0.7.29
 soundfile
-deep_gemm @ git+https://github.com/zongfeijing/DeepGEMM.git@a9d538ef4dff0326fe521c6ca0bfde115703b56a
 triton==3.3.1; platform_machine == "x86_64"

--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -695,17 +695,13 @@ def main(*,
                 "tensorrt_llm/deep_ep/nvshmem-build/src/lib/nvshmem_transport_ibgda.so.103",
                 lib_dir / "nvshmem")
 
-        deep_gemm_cuda_arch_file = build_dir / "tensorrt_llm" / "deep_gemm" / "cuda_architectures.txt"
-        if deep_gemm_cuda_arch_file.exists():
-            with deep_gemm_cuda_arch_file.open() as f:
-                deep_gemm_cuda_architectures = f.read().strip().strip(";")
-            if deep_gemm_cuda_architectures:
-                install_file(get_binding_lib("deep_gemm", "deep_gemm_cpp_tllm"),
-                             pkg_dir)
-                install_tree(build_dir / "tensorrt_llm" / "deep_gemm" /
-                             "python" / "deep_gemm",
-                             deep_gemm_dir,
-                             dirs_exist_ok=True)
+        install_file(get_binding_lib("deep_gemm", "deep_gemm_cpp_tllm"),
+                     pkg_dir)
+        install_tree(build_dir / "tensorrt_llm" / "deep_gemm" / "python" /
+                     "deep_gemm",
+                     deep_gemm_dir,
+                     dirs_exist_ok=True)
+
         if not skip_stubs:
             with working_directory(project_dir):
                 if binding_type == "nanobind":
@@ -779,10 +775,9 @@ def main(*,
                             build_run(
                                 f"\"{venv_python}\" -m pybind11_stubgen -o . deep_ep_cpp_tllm --exit-code",
                                 env=env_ld)
-                        if deep_gemm_cuda_architectures:
-                            build_run(
-                                f"\"{venv_python}\" -m pybind11_stubgen -o . deep_gemm_cpp_tllm --exit-code",
-                                env=env_ld)
+                        build_run(
+                            f"\"{venv_python}\" -m pybind11_stubgen -o . deep_gemm_cpp_tllm --exit-code",
+                            env=env_ld)
 
     if not skip_building_wheel:
         if dist_dir is None:

--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -448,10 +448,12 @@ def main(*,
     if cpp_only:
         build_pyt = "OFF"
         build_deep_ep = "OFF"
+        build_deep_gemm = "OFF"
     else:
-        targets.extend(["th_common", "bindings", "deep_ep"])
+        targets.extend(["th_common", "bindings", "deep_ep", "deep_gemm"])
         build_pyt = "ON"
         build_deep_ep = "ON"
+        build_deep_gemm = "ON"
 
     if benchmarks:
         targets.append("benchmarks")
@@ -490,7 +492,7 @@ def main(*,
                 )
             cmake_def_args = " ".join(cmake_def_args)
             cmake_configure_command = (
-                f'cmake -DCMAKE_BUILD_TYPE="{build_type}" -DBUILD_PYT="{build_pyt}" -DBINDING_TYPE="{binding_type}" -DBUILD_DEEP_EP="{build_deep_ep}"'
+                f'cmake -DCMAKE_BUILD_TYPE="{build_type}" -DBUILD_PYT="{build_pyt}" -DBINDING_TYPE="{binding_type}" -DBUILD_DEEP_EP="{build_deep_ep}" -DBUILD_DEEP_GEMM="{build_deep_gemm}"'
                 f' -DNVTX_DISABLE="{disable_nvtx}" -DBUILD_MICRO_BENCHMARKS={build_micro_benchmarks}'
                 f' -DBUILD_WHEEL_TARGETS="{";".join(targets)}"'
                 f' -DPython_EXECUTABLE={venv_python} -DPython3_EXECUTABLE={venv_python}'
@@ -637,6 +639,14 @@ def main(*,
         clear_folder(deep_ep_dir)
         deep_ep_dir.rmdir()
 
+    # Handle deep_gemm installation
+    deep_gemm_dir = pkg_dir / "deep_gemm"
+    if deep_gemm_dir.is_symlink():
+        deep_gemm_dir.unlink()
+    elif deep_gemm_dir.is_dir():
+        clear_folder(deep_gemm_dir)
+        deep_gemm_dir.rmdir()
+
     bin_dir = pkg_dir / "bin"
     if bin_dir.exists():
         clear_folder(bin_dir)
@@ -684,6 +694,18 @@ def main(*,
                 build_dir /
                 "tensorrt_llm/deep_ep/nvshmem-build/src/lib/nvshmem_transport_ibgda.so.103",
                 lib_dir / "nvshmem")
+
+        deep_gemm_cuda_arch_file = build_dir / "tensorrt_llm" / "deep_gemm" / "cuda_architectures.txt"
+        if deep_gemm_cuda_arch_file.exists():
+            with deep_gemm_cuda_arch_file.open() as f:
+                deep_gemm_cuda_architectures = f.read().strip().strip(";")
+            if deep_gemm_cuda_architectures:
+                install_file(get_binding_lib("deep_gemm", "deep_gemm_cpp_tllm"),
+                             pkg_dir)
+                install_tree(build_dir / "tensorrt_llm" / "deep_gemm" /
+                             "python" / "deep_gemm",
+                             deep_gemm_dir,
+                             dirs_exist_ok=True)
         if not skip_stubs:
             with working_directory(project_dir):
                 if binding_type == "nanobind":
@@ -756,6 +778,10 @@ def main(*,
                         if deep_ep_cuda_architectures:
                             build_run(
                                 f"\"{venv_python}\" -m pybind11_stubgen -o . deep_ep_cpp_tllm --exit-code",
+                                env=env_ld)
+                        if deep_gemm_cuda_architectures:
+                            build_run(
+                                f"\"{venv_python}\" -m pybind11_stubgen -o . deep_gemm_cpp_tllm --exit-code",
                                 env=env_ld)
 
     if not skip_building_wheel:

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,8 @@ else:
         'libs/libdecoder_attention_1.so', 'libs/nvshmem/License.txt',
         'libs/nvshmem/nvshmem_bootstrap_uid.so.3',
         'libs/nvshmem/nvshmem_transport_ibgda.so.103', 'bindings.*.so',
-        'deep_ep/LICENSE', 'deep_ep_cpp_tllm.*.so', "include/**/*"
+        'deep_ep/LICENSE', 'deep_ep_cpp_tllm.*.so', "include/**/*",
+        'deep_gemm/LICENSE', 'deep_gemm/include/**/*', 'deep_gemm_cpp_tllm.*.so'
     ]
 
 package_data += [

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_deepgemm.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_deepgemm.py
@@ -1,12 +1,12 @@
 from typing import List, Optional, Union
 
-import deep_gemm
 import torch
 import torch.nn.functional as F
 import triton
 import triton.language as tl
 
 import tensorrt_llm.quantization.utils.fp8_utils as fp8_utils
+from tensorrt_llm import deep_gemm
 from tensorrt_llm._utils import nvtx_range
 
 from ...distributed import allgather

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -573,7 +573,7 @@ class FP8BlockScalesLinearMethod(LinearMethodBase):
         assert input.dtype == torch.bfloat16
 
         if get_sm_version() == 100:
-            import deep_gemm
+            from tensorrt_llm import deep_gemm
             a, a_sf = fp8_utils.per_token_quant_and_transform(input)
             output = torch.empty((input.shape[0], module.weight.shape[0]),
                                  device=input.device,

--- a/tests/unittest/_torch/thop/test_fp8_block_scale_gemm.py
+++ b/tests/unittest/_torch/thop/test_fp8_block_scale_gemm.py
@@ -50,7 +50,7 @@ def test_fp8_block_scale_deep_gemm(dtype, m, k, n):
     act_b_fp8, act_b_sf = per_block_cast_to_fp8_e8m0(b)
 
     output_expected = a @ b.t()
-    import deep_gemm
+    from tensorrt_llm import deep_gemm
     output = torch.empty((act_a_fp8.shape[0], act_b_fp8.shape[0]),
                          device=act_a_fp8.device,
                          dtype=torch.bfloat16)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated DeepGEMM as a new optional module with build and packaging support, including CMake options and Python bindings.

* **Chores**
  * Updated dependency management and build scripts to support DeepGEMM integration.
  * Added DeepGEMM-related files and directories to ignore lists.
  * Included DeepGEMM license and related files in package data.

* **Refactor**
  * Updated import statements to use the new DeepGEMM module path throughout the codebase.

* **Tests**
  * Adjusted test imports to align with the new DeepGEMM integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up
-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
