### PR TITLE
Update CMakeLists.txt extend find_library names

### DIFF
--- a/cpp/tensorrt_llm/deep_ep/CMakeLists.txt
+++ b/cpp/tensorrt_llm/deep_ep/CMakeLists.txt
@@ -37,7 +37,7 @@ if(NOT DEEP_EP_CUDA_ARCHITECTURES)
 endif()
 
 # Ensure that dependent libraries are installed
-find_library(MLX5_lib NAMES mlx5 REQUIRED)
+find_library(MLX5_lib NAMES mlx5 libmlx5.so.1 REQUIRED)
 
 # Prepare files
 # =============


### PR DESCRIPTION
Update lookup names in CMake config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved detection of the MLX5 library during setup to ensure required components are found more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up
-->

## Description

Fix CMake configuration. 
CMake always rely on file ending `.so` in when searching for a libraries. 
Unfortunately installed files with package `ibverbs-providers` provide file `libmlx5.so.1` instead of `libxml5.so` .
```
$ docker run  -it --rm nvcr.io/nvidia/pytorch:25.05-py3 dpkg -L ibverbs-providers 

=============
== PyTorch ==
=============

NVIDIA Release 25.05 (build 170559088)
PyTorch Version 2.8.0a0+5228986
Container image Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
Copyright (c) 2014-2024 Facebook Inc.
Copyright (c) 2011-2014 Idiap Research Institute (Ronan Collobert)
Copyright (c) 2012-2014 Deepmind Technologies    (Koray Kavukcuoglu)
Copyright (c) 2011-2012 NEC Laboratories America (Koray Kavukcuoglu)
Copyright (c) 2011-2013 NYU                      (Clement Farabet)
Copyright (c) 2006-2010 NEC Laboratories America (Ronan Collobert, Leon Bottou, Iain Melvin, Jason Weston)
Copyright (c) 2006      Idiap Research Institute (Samy Bengio)
Copyright (c) 2001-2004 Idiap Research Institute (Ronan Collobert, Samy Bengio, Johnny Mariethoz)
Copyright (c) 2015      Google Inc.
Copyright (c) 2015      Yangqing Jia
Copyright (c) 2013-2016 The Caffe contributors
All rights reserved.

Various files include modifications (c) NVIDIA CORPORATION & AFFILIATES.  All rights reserved.

GOVERNING TERMS: The software and materials are governed by the NVIDIA Software License Agreement
(found at https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-software-license-agreement/)
and the Product-Specific Terms for NVIDIA AI Products
(found at https://www.nvidia.com/en-us/agreements/enterprise-software/product-specific-terms-for-ai-products/).

WARNING: The NVIDIA Driver was not detected.  GPU functionality will not be available.
   Use the NVIDIA Container Toolkit to start this container with GPU support; see
   https://docs.nvidia.com/datacenter/cloud-native/ .

NOTE: The SHMEM allocation limit is set to the default of 64MB.  This may be
   insufficient for PyTorch.  NVIDIA recommends the use of the following flags:
   docker run --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 ...

/.
/etc
/etc/libibverbs.d
/etc/libibverbs.d/bnxt_re.driver
/etc/libibverbs.d/cxgb4.driver
/etc/libibverbs.d/efa.driver
/etc/libibverbs.d/erdma.driver
/etc/libibverbs.d/hfi1verbs.driver
/etc/libibverbs.d/hns.driver
/etc/libibverbs.d/ipathverbs.driver
/etc/libibverbs.d/irdma.driver
/etc/libibverbs.d/mana.driver
/etc/libibverbs.d/mlx4.driver
/etc/libibverbs.d/mlx5.driver
/etc/libibverbs.d/mthca.driver
/etc/libibverbs.d/ocrdma.driver
/etc/libibverbs.d/qedr.driver
/etc/libibverbs.d/rxe.driver
/etc/libibverbs.d/siw.driver
/etc/libibverbs.d/vmw_pvrdma.driver
/usr
/usr/lib
/usr/lib/x86_64-linux-gnu
/usr/lib/x86_64-linux-gnu/libefa.so.1.3.50.0
/usr/lib/x86_64-linux-gnu/libibverbs
/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so
/usr/lib/x86_64-linux-gnu/libibverbs/libcxgb4-rdmav34.so
/usr/lib/x86_64-linux-gnu/libibverbs/liberdma-rdmav34.so
/usr/lib/x86_64-linux-gnu/libibverbs/libhfi1verbs-rdmav34.so
/usr/lib/x86_64-linux-gnu/libibverbs/libhns-rdmav34.so
/usr/lib/x86_64-linux-gnu/libibverbs/libipathverbs-rdmav34.so
/usr/lib/x86_64-linux-gnu/libibverbs/libirdma-rdmav34.so
/usr/lib/x86_64-linux-gnu/libibverbs/libmthca-rdmav34.so
/usr/lib/x86_64-linux-gnu/libibverbs/libocrdma-rdmav34.so
/usr/lib/x86_64-linux-gnu/libibverbs/libqedr-rdmav34.so
/usr/lib/x86_64-linux-gnu/libibverbs/librxe-rdmav34.so
/usr/lib/x86_64-linux-gnu/libibverbs/libsiw-rdmav34.so
/usr/lib/x86_64-linux-gnu/libibverbs/libvmw_pvrdma-rdmav34.so
/usr/lib/x86_64-linux-gnu/libmana.so.1.0.50.0
/usr/lib/x86_64-linux-gnu/libmlx4.so.1.0.50.0
/usr/lib/x86_64-linux-gnu/libmlx5.so.1.24.50.0
/usr/share
/usr/share/doc
/usr/share/doc/ibverbs-providers
/usr/share/doc/ibverbs-providers/copyright
/usr/share/lintian
/usr/share/lintian/overrides
/usr/share/lintian/overrides/ibverbs-providers
/usr/lib/x86_64-linux-gnu/libefa.so.1
/usr/lib/x86_64-linux-gnu/libibverbs/libefa-rdmav34.so
/usr/lib/x86_64-linux-gnu/libibverbs/libmana-rdmav34.so
/usr/lib/x86_64-linux-gnu/libibverbs/libmlx4-rdmav34.so
/usr/lib/x86_64-linux-gnu/libibverbs/libmlx5-rdmav34.so
/usr/lib/x86_64-linux-gnu/libmana.so.1
/usr/lib/x86_64-linux-gnu/libmlx4.so.1
/usr/lib/x86_64-linux-gnu/libmlx5.so.1
/usr/share/doc/ibverbs-providers/changelog.Debian.gz
``` 

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
