### PR TITLE
[TRTLLM-5863][feat] Support MoE INT8 Weight-Only-Quantization in PyTorch Workflow

### DIFF
--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
@@ -16,10 +16,10 @@ from .interface import MoE
 # isort: off
 from .quantization import (
     DeepSeekFP8BlockScalesFusedMoEMethod, FP8QDQFusedMoEMethod,
-    MoEWeightLoadingMode, NVFP4CutlassFusedMoEMethod, UnquantizedFusedMoEMethod, WeightOnlyFusedMoEMethod,
-                          
-    W4A8MXFP4FP8CutlassFusedMoEMethod, W4A8MXFP4MXFP8CutlassFusedMoEMethod,
-    WFP4A16FusedMoEMethod, WInt4AFP8FusedMoEMethod)
+    MoEWeightLoadingMode, NVFP4CutlassFusedMoEMethod, UnquantizedFusedMoEMethod,
+    INT8WoqPerChannelFusedMoEMethod, W4A8MXFP4FP8CutlassFusedMoEMethod,
+    W4A8MXFP4MXFP8CutlassFusedMoEMethod, WFP4A16FusedMoEMethod,
+    WInt4AFP8FusedMoEMethod)
 # isort: on
 from .routing import BaseMoeRoutingMethod
 
@@ -45,8 +45,6 @@ class CutlassFusedMoE(MoE):
                 FusedMoE Op: dynamic quant + scatter + gemm1 + swiglu + gemm2 + finalizeMoeRoute (return one tensor)
             p8 qdq, nvfp4:
                 FusedMoE Op: scatter + gemm1 + swiglu + gemm2 + finalizeMoeRoute (return one tensor)
-            weight only:
-                FusedMoE Op: ... to finish
 
     FusedMoE module:
         max-throughput mode:
@@ -185,14 +183,9 @@ class CutlassFusedMoE(MoE):
         )
 
     @property
-    def has_woq_per_channel(self):
-        return self.quant_config.layer_quant_mode.is_weight_only(
+    def has_int8_woq_per_channel(self):
+        return self.quant_config.layer_quant_mode.is_int8_weight_only(
         ) and not self.quant_config.layer_quant_mode.has_per_group_scaling()
-
-    @property
-    def has_woq_per_group_scaling(self):
-        return self.quant_config.layer_quant_mode.is_weight_only(
-        ) and self.quant_config.layer_quant_mode.has_per_group_scaling()
 
     @cached_property
     def enable_alltoall(self):
@@ -216,8 +209,8 @@ class CutlassFusedMoE(MoE):
             elif self.quant_config.layer_quant_mode.is_int4_weight_only_per_group(
             ):
                 return WInt4AFP8FusedMoEMethod()
-            elif self.has_woq_per_channel:
-                return WeightOnlyFusedMoEMethod()
+            elif self.has_int8_woq_per_channel:
+                return INT8WoqPerChannelFusedMoEMethod()
             elif self.quant_config.layer_quant_mode.has_w4a8_mxfp4_fp8():
                 return W4A8MXFP4FP8CutlassFusedMoEMethod()
             elif self.quant_config.layer_quant_mode.has_w4a16_mxfp4():
@@ -275,8 +268,7 @@ class CutlassFusedMoE(MoE):
         # quantize inputs
         use_deepseek_fp8_block_scale = False
         use_w4_group_scaling = False
-        use_woq_per_channel = False
-        use_woq_group_scaling = False
+        use_int8_woq_per_channel = False
         use_mxfp8_act_scaling = False
         weight_dtype = self.w3_w1_weight.dtype
         x_sf = None
@@ -290,19 +282,15 @@ class CutlassFusedMoE(MoE):
                 use_deepseek_fp8_block_scale = True
             elif self.has_w4afp8:
                 use_w4_group_scaling = True
-                use_woq_group_scaling = True
                 weight_dtype = torch.quint4x2
-            elif self.has_woq_per_channel:
-                use_woq_per_channel = True
-            elif self.has_woq_per_group_scaling:
-                use_woq_group_scaling = True
             elif self.has_w4a16_mxfp4:
                 pad_size = self.hidden_size - x.shape[1]
                 original_hidden_size = x.shape[1]
                 x = torch.nn.functional.pad(x, (0, pad_size))
-
                 use_w4_group_scaling = True
                 weight_dtype = torch.uint8
+            elif self.has_int8_woq_per_channel:
+                use_int8_woq_per_channel = True
             elif self.has_nvfp4:
                 if run_post_quant_allgather or self.enable_alltoall:
                     if isinstance(x, Fp4QuantizedTensor):
@@ -442,8 +430,7 @@ class CutlassFusedMoE(MoE):
             enable_alltoall=self.enable_alltoall,
             use_deepseek_fp8_block_scale=use_deepseek_fp8_block_scale,
             use_w4_group_scaling=use_w4_group_scaling,
-            use_woq_per_channel=use_woq_per_channel,
-            use_woq_group_scaling=use_woq_group_scaling,
+            use_int8_woq_per_channel=use_int8_woq_per_channel,
             use_mxfp8_act_scaling=use_mxfp8_act_scaling,
             min_latency_mode=False,
             use_fused_finalize=self.use_fused_finalize,

--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -8,6 +8,8 @@ from torch import nn
 
 import tensorrt_llm.logger as trtllm_logger
 from tensorrt_llm._utils import get_sm_version
+from tensorrt_llm.quantization.functional import \
+    preprocess_weights_for_mixed_gemm
 from tensorrt_llm.quantization.utils.fp4_utils import (
     float4_sf_dtype, get_reorder_rows_for_gated_act_gemm_row_indices,
     get_shuffle_matrix_a_row_indices, get_shuffle_matrix_sf_a_row_indices)
@@ -61,6 +63,11 @@ class FusedMoEQuantScalesW4A8(NamedTuple):
     zero_2: torch.Tensor
     alpha_1: torch.Tensor
     alpha_2: torch.Tensor
+
+
+class FusedMoEQuantScalesWeightOnly(NamedTuple):
+    fc31_weight_scale: torch.Tensor
+    fc2_weight_scale: torch.Tensor
 
 
 class FusedMoEQuantScalesW4A16MXFP4(NamedTuple):
@@ -774,6 +781,159 @@ class DeepSeekFP8BlockScalesFusedMoEMethodDeepGemm(
                                                            requires_grad=False)
             self.setup_quant_scales(module)
 
+class WeightOnlyFusedMoEMethod(FusedMoEMethodBase):
+    """
+    Base class for Weight Only Quantization fused MoE methods.
+    """
+
+    def create_weights(self, module: torch.nn.Module):
+        weight_dtype = torch.int8
+        # int4 weight are packed into int8
+        if module.quant_config.layer_quant_mode.is_int8_weight_only():
+            weight_id = 1
+        elif module.quant_config.layer_quant_mode.is_int4_weight_only():
+            weight_id = 2
+        else:
+            raise NotImplementedError(
+                f"Weight Only Quantization is unsupported on {module.quant_config.layer_quant_mode}."
+            )
+
+        w3_w1_weight_shape = (module.expert_size_per_partition,
+                              module.intermediate_size_per_partition * 2,
+                              module.hidden_size // weight_id)
+        w2_weight_shape = (module.expert_size_per_partition, module.hidden_size,
+                           module.intermediate_size_per_partition // weight_id)
+
+        fc31_weight_scale = nn.Parameter(torch.empty(
+            module.expert_size_per_partition,
+            module.intermediate_size_per_partition * 2,
+            dtype=module.dtype),
+                                         requires_grad=False)
+        module.register_parameter("fc31_weight_scale", fc31_weight_scale)
+
+        fc2_weight_scale = nn.Parameter(torch.empty(
+            module.expert_size_per_partition,
+            module.hidden_size,
+            dtype=module.dtype),
+                                        requires_grad=False)
+        module.register_parameter("fc2_weight_scale", fc2_weight_scale)
+
+        super().create_weights(module, weight_dtype, w3_w1_weight_shape,
+                               w2_weight_shape)
+        self.setup_quant_scales(module)
+
+    def setup_quant_scales(self, module: torch.nn.Module):
+        module.quant_scales = FusedMoEQuantScalesWeightOnly(
+            fc31_weight_scale=module.fc31_weight_scale,
+            fc2_weight_scale=module.fc2_weight_scale,
+        )
+
+    def get_quant_scales(self, module: torch.nn.Module, slot_start,
+                         slot_end) -> tuple[torch.Tensor, ...]:
+        assert module.smart_router
+        return FusedMoEQuantScalesWeightOnly(
+            fc31_weight_scale=module.fc31_weight_scale.narrow(
+                0, slot_start, slot_end - slot_start),
+            fc2_weight_scale=module.fc2_weight_scale.narrow(
+                0, slot_start, slot_end - slot_start),
+        )
+
+    def load_expert_w3_w1_weight(self, module: torch.nn.Module,
+                                 w1_weight: torch.Tensor,
+                                 w3_weight: torch.Tensor,
+                                 dst_w3_w1_weight: torch.Tensor):
+        """
+        Load w1 and w3 weights for each expert.
+        """
+        w1_weight_shard = load_weight_shard(w1_weight, module.tp_size,
+                                            module.tp_rank,
+                                            TensorParallelMode.COLUMN)
+        w3_weight_shard = load_weight_shard(w3_weight, module.tp_size,
+                                            module.tp_rank,
+                                            TensorParallelMode.COLUMN)
+        w31_weight_shard = torch.cat([w3_weight_shard, w1_weight_shard], dim=0)
+
+        # preprocess the weights for mixed gemm
+        preprocessor = preprocess_weights_for_mixed_gemm
+        if module.quant_config.layer_quant_mode.is_int8_weight_only():
+            weight_dtype = torch.int8
+        elif module.quant_config.layer_quant_mode.is_int4_weight_only():
+            weight_dtype = torch.quint4x2
+            packer = torch.ops.trtllm.pack_int8_tensor_to_packed_int4
+            unpacker = torch.ops.trtllm.unpack_int4_packed_tensor_to_int8
+            w31_weight_shard = packer(
+                unpacker(w31_weight_shard.cpu()).T.contiguous()).to(
+                    w31_weight_shard.device)
+
+        assert module.dtype in [torch.float16, torch.bfloat16], \
+            f"activation dtype should be float16 or bfloat16, got {module.dtype}"
+        w31_weight_shard = preprocessor(w31_weight_shard, weight_dtype,
+                                        module.dtype).view(
+                                            dst_w3_w1_weight.shape)
+        dst_w3_w1_weight.copy_(w31_weight_shard.view(dst_w3_w1_weight.dtype),
+                               non_blocking=True)
+
+    def load_expert_w2_weight(self, module: torch.nn.Module,
+                              w2_weight: torch.Tensor,
+                              dst_w2_weight: torch.Tensor):
+        """
+        Load w2 weight for each expert.
+        """
+        w2_weight_shard = load_weight_shard(w2_weight, module.tp_size,
+                                            module.tp_rank,
+                                            TensorParallelMode.ROW)
+
+        # preprocess the weights for mixed gemm
+        preprocessor = preprocess_weights_for_mixed_gemm
+        if module.quant_config.layer_quant_mode.is_int8_weight_only():
+            weight_dtype = torch.int8
+        elif module.quant_config.layer_quant_mode.is_int4_weight_only():
+            weight_dtype = torch.quint4x2
+            packer = torch.ops.trtllm.pack_int8_tensor_to_packed_int4
+            unpacker = torch.ops.trtllm.unpack_int4_packed_tensor_to_int8
+            w2_weight_shard = packer(
+                unpacker(w2_weight_shard.cpu()).T.contiguous()).to(
+                    w2_weight_shard.device)
+
+        assert module.dtype in [torch.float16, torch.bfloat16], \
+            f"activation dtype should be float16 or bfloat16, got {module.dtype}"
+        w2_weight_shard = preprocessor(w2_weight_shard, weight_dtype,
+                                       module.dtype).view(dst_w2_weight.shape)
+
+        dst_w2_weight.copy_(w2_weight_shard.view(dst_w2_weight.dtype),
+                            non_blocking=True)
+
+    def load_quant_scales(self, module: torch.nn.Module, weights: Dict):
+        # fc31 scales
+        all_w3_scales = [
+            load_weight_shard(weights[f"{expert_id}.w3.weight_scale_inv"],
+                              module.tp_size, module.tp_rank,
+                              TensorParallelMode.COLUMN)
+            for expert_id in module.initial_local_expert_ids
+        ]
+        all_w1_scales = [
+            load_weight_shard(weights[f"{expert_id}.w1.weight_scale_inv"],
+                              module.tp_size, module.tp_rank,
+                              TensorParallelMode.COLUMN)
+            for expert_id in module.initial_local_expert_ids
+        ]
+        w3_w1_scales = torch.cat(
+            [torch.stack(all_w3_scales),
+             torch.stack(all_w1_scales)], dim=-1)
+        w3_w1_scales = w3_w1_scales.to(torch.float16).view(module.dtype)
+        module.fc31_weight_scale.data.copy_(w3_w1_scales.contiguous())
+
+        # fc2 scales
+        all_w2_scales = [
+            load_weight_shard(weights[f"{expert_id}.w2.weight_scale_inv"],
+                              module.tp_size, module.tp_rank,
+                              TensorParallelMode.ROW)
+            for expert_id in module.initial_local_expert_ids
+        ]
+        w2_scales = torch.stack(all_w2_scales).to(torch.float16).view(
+            module.dtype)
+        module.fc2_weight_scale.data.copy_(w2_scales.contiguous())
+
 
 class WInt4AFP8FusedMoEMethod(FusedMoEMethodBase):
 
@@ -914,9 +1074,7 @@ class WInt4AFP8FusedMoEMethod(FusedMoEMethodBase):
         unpacker = torch.ops.trtllm.unpack_int4_packed_tensor_to_int8
         # SM89
         if module.sm_version == 89:
-            import tensorrt_llm.quantization.functional as trtllm_f
-
-            preprocessor = trtllm_f.preprocess_weights_for_mixed_gemm
+            preprocessor = preprocess_weights_for_mixed_gemm
 
             w31_weight_shard = packer(
                 unpacker(w31_weight_shard.cpu()).T.contiguous()).to(
@@ -963,9 +1121,7 @@ class WInt4AFP8FusedMoEMethod(FusedMoEMethodBase):
         packer = torch.ops.trtllm.pack_int8_tensor_to_packed_int4
         unpacker = torch.ops.trtllm.unpack_int4_packed_tensor_to_int8
         if module.sm_version == 89:
-            import tensorrt_llm.quantization.functional as trtllm_f
-
-            preprocessor = trtllm_f.preprocess_weights_for_mixed_gemm
+            preprocessor = preprocess_weights_for_mixed_gemm
 
             w2_weight_shard = packer(
                 unpacker(w2_weight_shard.cpu()).T.contiguous()).to(
@@ -1184,6 +1340,229 @@ class WInt4AFP8FusedMoEMethod(FusedMoEMethodBase):
             w2_s_shape[1] * module.interleave[1])
         module.fc2_weight_scale.data.copy_(w2_scales_interleaved.contiguous())
 
+
+class WeightOnlyFusedMoEMethod(FusedMoEMethodBase):
+
+    def create_weights(self, module: torch.nn.Module):
+        module.sm_version = get_sm_version()
+        module.sm_version = 80 if module.sm_version >= 90 else module.sm_version
+        module.preprocessor = preprocess_weights_for_mixed_gemm
+
+        weight_dtype = torch.int8
+        # int4 weight are packed into int8
+        if module.quant_config.layer_quant_mode.is_int8_weight_only():
+            pass
+        elif module.quant_config.layer_quant_mode.is_int4_weight_only():
+            pass
+        else:
+            raise NotImplementedError(
+                f"Weight Only Quantization is unsupported on {module.quant_config.layer_quant_mode}."
+            )
+
+        # notice the weight shape for weight-only is different from the original shape,
+        # since the quantized weights have their own layout
+        w3_w1_weight_shape = (module.expert_size_per_partition,
+                              module.hidden_size,
+                              module.intermediate_size_per_partition * 2)
+        w2_weight_shape = (module.expert_size_per_partition,
+                           module.intermediate_size_per_partition,
+                           module.hidden_size)
+
+        # col parallel
+        assert module.hidden_size % (self.group_size *
+                                     module.interleave[0]) == 0
+        scale_dtype = torch.uint8
+        fc31_weight_scale = nn.Parameter(torch.empty(
+            module.expert_size_per_partition,
+            module.hidden_size // (self.group_size * module.interleave[0]),
+            module.intermediate_size_per_partition * 2 * module.interleave[0],
+            dtype=scale_dtype),
+                                         requires_grad=False)
+        module.register_parameter("fc31_weight_scale", fc31_weight_scale)
+
+        # row parallel
+        assert module.intermediate_size_per_partition % (
+            self.group_size * module.interleave[1]) == 0
+        fc2_weight_scale = nn.Parameter(
+            torch.empty(module.expert_size_per_partition,
+                        module.intermediate_size_per_partition //
+                        (self.group_size * module.interleave[1]),
+                        module.hidden_size * module.interleave[1],
+                        dtype=scale_dtype),
+            requires_grad=False)
+        module.register_parameter("fc2_weight_scale", fc2_weight_scale)
+
+        super().create_weights(module, weight_dtype, w3_w1_weight_shape,
+                               w2_weight_shape)
+        self.setup_quant_scales(module)
+
+    def setup_quant_scales(self, module: torch.nn.Module):
+        module.quant_scales = FusedMoEQuantScalesW4A16MXFP4(
+            scale_1_interleaved=module.fc31_weight_scale,
+            scale_2_interleaved=module.fc2_weight_scale)
+
+    def get_quant_scales(self, module: torch.nn.Module, slot_start,
+                         slot_end) -> tuple[torch.Tensor, ...]:
+        assert module.smart_router
+        return FusedMoEQuantScalesW4A16MXFP4(
+            scale_1_interleaved=module.fc31_weight_scale.narrow(
+                0, slot_start, slot_end - slot_start),
+            scale_2_interleaved=module.fc2_weight_scale.narrow(
+                0, slot_start, slot_end - slot_start))
+
+    def load_expert_w3_w1_weight(self, module: torch.nn.Module,
+                                 w1_weight: torch.Tensor,
+                                 w3_weight: torch.Tensor,
+                                 dst_w3_w1_weight: torch.Tensor):
+        """
+        Load w1 and w3 weights for each expert.
+        Override this method if you need to preprocess the weights differently.
+        """
+        device = dst_w3_w1_weight.device
+        assert device.type == "cuda"
+        w1_weight_shard = load_weight_shard(w1_weight,
+                                            module.tp_size,
+                                            module.tp_rank,
+                                            TensorParallelMode.COLUMN,
+                                            device=device)
+        w3_weight_shard = load_weight_shard(w3_weight,
+                                            module.tp_size,
+                                            module.tp_rank,
+                                            TensorParallelMode.COLUMN)
+        w31_weight_shard = torch.cat([w3_weight_shard, w1_weight_shard], dim=0)
+
+        # preprocess the weights for mixed gemm
+        if module.quant_config.layer_quant_mode.is_int8_weight_only():
+            weight_dtype = torch.int8
+        # elif module.quant_config.layer_quant_mode.is_int4_weight_only():
+        #     weight_dtype = torch.quint4x2
+        #     packer = torch.ops.trtllm.pack_int8_tensor_to_packed_int4
+        #     unpacker = torch.ops.trtllm.unpack_int4_packed_tensor_to_int8
+        #     w31_weight_shard = packer(
+        #         unpacker(w31_weight_shard.cpu()).T.contiguous()).to(
+        #             w31_weight_shard.device)
+
+        assert module.dtype in [torch.float16, torch.bfloat16], \
+            f"activation dtype should be float16 or bfloat16, got {module.dtype}"
+
+        w31_weight_shard = module.preprocessor(w31_weight_shard.T.contiguous(),
+                                               weight_dtype, module.dtype,
+                                               module.sm_version).contiguous()
+        dst_w3_w1_weight.copy_(w31_weight_shard.view(dst_w3_w1_weight.dtype),
+                               non_blocking=True)
+
+    def load_expert_w2_weight(self, module: torch.nn.Module,
+                              w2_weight: torch.Tensor,
+                              dst_w2_weight: torch.Tensor):
+        """
+        Load w2 weight for each expert.
+        Override this method if you need to preprocess the weights differently.
+        """
+        device = dst_w2_weight.device
+        assert device.type == "cuda"
+        w2_weight_shard = load_weight_shard(w2_weight,
+                                            module.tp_size,
+                                            module.tp_rank,
+                                            TensorParallelMode.ROW)
+
+        # preprocess the weights for mixed gemm
+        if module.quant_config.layer_quant_mode.is_int8_weight_only():
+            weight_dtype = torch.int8
+        # elif module.quant_config.layer_quant_mode.is_int4_weight_only():
+        #     weight_dtype = torch.quint4x2
+        #     packer = torch.ops.trtllm.pack_int8_tensor_to_packed_int4
+        #     unpacker = torch.ops.trtllm.unpack_int4_packed_tensor_to_int8
+        #     w31_weight_shard = packer(
+        #         unpacker(w31_weight_shard.cpu()).T.contiguous()).to(
+        #             w31_weight_shard.device)
+
+        assert module.dtype in [torch.float16, torch.bfloat16], \
+            f"activation dtype should be float16 or bfloat16, got {module.dtype}"
+
+        w2_weight_shard = module.preprocessor(w2_weight_shard.T.contiguous(),
+                                              weight_dtype, module.dtype,
+                                              module.sm_version).contiguous()
+        dst_w2_weight.copy_(w2_weight_shard.view(dst_w2_weight.dtype),
+                            non_blocking=True)
+
+    def load_quant_scales(self, module: torch.nn.Module, weights: Dict):
+        device = module.fc31_weight_scale.data.device
+        assert device.type == "cuda"
+
+        # fc31 scales
+        assert (len(module.interleave) == 2)
+
+        all_w3_scales = []
+        all_w1_scales = []
+        for expert_id in module.initial_local_expert_ids:
+            w3_scale_shard = load_weight_shard(
+                weights[f"{expert_id}.w3.weight_scale_inv"],
+                module.tp_size,
+                module.tp_rank,
+                TensorParallelMode.COLUMN,
+                device=device)
+            w1_scale_shard = load_weight_shard(
+                weights[f"{expert_id}.w1.weight_scale_inv"],
+                module.tp_size,
+                module.tp_rank,
+                TensorParallelMode.COLUMN,
+                device=device)
+
+            pad_size_hidden = module.hidden_size // self.group_size - w3_scale_shard.shape[
+                1]
+            pad_size_inter = module.intermediate_size_per_partition - w3_scale_shard.shape[
+                0]
+            w3_scale_shard = torch.nn.functional.pad(
+                w3_scale_shard, (0, pad_size_hidden, 0, pad_size_inter))
+            w1_scale_shard = torch.nn.functional.pad(
+                w1_scale_shard, (0, pad_size_hidden, 0, pad_size_inter))
+
+            all_w3_scales.append(w3_scale_shard)
+            all_w1_scales.append(w1_scale_shard)
+
+        all_w3_w1_scales = torch.cat(
+            [torch.stack(all_w3_scales),
+             torch.stack(all_w1_scales)], dim=-2)
+
+        w3_w1_scales = all_w3_w1_scales.to(torch.bfloat16).view(module.dtype)
+        w3_w1_s_shape = w3_w1_scales.shape
+        w3_w1_scales_interleaved = w3_w1_scales.reshape(
+            w3_w1_s_shape[0], w3_w1_s_shape[1],
+            (w3_w1_s_shape[2] // module.interleave[0]), module.interleave[0])
+        w3_w1_scales_interleaved = w3_w1_scales_interleaved.permute(0, 2, 1, 3)
+        w3_w1_scales_interleaved = w3_w1_scales_interleaved.reshape(
+            w3_w1_s_shape[0], w3_w1_s_shape[2] // module.interleave[0],
+            w3_w1_s_shape[1] * module.interleave[0])
+        module.fc31_weight_scale.data.copy_(
+            w3_w1_scales_interleaved.contiguous())
+
+        # fc2 scales
+        all_w2_scales = []
+        for expert_id in module.initial_local_expert_ids:
+            w2_scales_shard = load_weight_shard(
+                weights[f"{expert_id}.w2.weight_scale_inv"],
+                module.tp_size,
+                module.tp_rank,
+                TensorParallelMode.ROW,
+                device=device)
+            pad_size_hidden = module.hidden_size - w2_scales_shard.shape[0]
+            pad_size_inter = module.intermediate_size_per_partition // self.group_size - w2_scales_shard.shape[
+                1]
+            w2_scales_shard = torch.nn.functional.pad(
+                w2_scales_shard, (0, pad_size_inter, 0, pad_size_hidden))
+            all_w2_scales.append(w2_scales_shard)
+
+        w2_scales = torch.stack(all_w2_scales).to(torch.bfloat16).view(
+            module.dtype)
+        w2_s_shape = w2_scales.shape
+        w2_scales_interleaved = w2_scales.reshape(
+            w2_s_shape[0], w2_s_shape[1],
+            (w2_s_shape[2] // module.interleave[1]), module.interleave[1])
+        w2_scales_interleaved = w2_scales_interleaved.permute(0, 2, 1, 3)
+        w2_scales_interleaved = w2_scales_interleaved.reshape(
+            w2_s_shape[0], w2_s_shape[2] // module.interleave[1],
+            w2_s_shape[1] * module.interleave[1])
+        module.fc2_weight_scale.data.copy_(w2_scales_interleaved.contiguous())
 
 class WFP4A16FusedMoEMethod(FusedMoEMethodBase):
 

--- a/tensorrt_llm/layers/moe.py
+++ b/tensorrt_llm/layers/moe.py
@@ -777,7 +777,7 @@ class MixtureOfExperts(Module):
         self.use_int8_weight = use_int8_weight
         self.group_size = group_size
 
-        if self.use_int8_weight:
+        if self.use_int8_weight and self.group_size > 0:
             raise NotImplementedError("INT8-GPTQ is not implemented for MoE.")
 
         self.static_routing = static_routing

--- a/tests/unittest/_torch/helpers.py
+++ b/tests/unittest/_torch/helpers.py
@@ -76,6 +76,7 @@ def calc_diff(x, y):
 
 
 def calc_woq_tolerence(x: torch.Tensor, weight_dtype: torch.dtype):
+    # align with woq_assert_near_eq function in tests/unittest/trt/quantization/_utils.py
     if weight_dtype == torch.int8:
         bits_in_type = 8
     elif weight_dtype == torch.quint4x2:

--- a/tests/unittest/_torch/helpers.py
+++ b/tests/unittest/_torch/helpers.py
@@ -75,6 +75,18 @@ def calc_diff(x, y):
     return 1 - sim
 
 
+def calc_woq_tolerence(x: torch.Tensor, weight_dtype: torch.dtype):
+    if weight_dtype == torch.int8:
+        bits_in_type = 8
+    elif weight_dtype == torch.quint4x2:
+        bits_in_type = 4
+    quant_range_scale = 1.0 / float(1 << (bits_in_type - 1))
+    max_val = torch.max(abs(x)).item()
+    atol = (max_val * quant_range_scale) * 1.5  # allow for rounding
+
+    return atol
+
+
 def reference_moe_torch(x: torch.Tensor, selected_experts: torch.Tensor,
                         final_scales: torch.Tensor, num_experts: int,
                         weights: Dict[str, torch.Tensor]) -> torch.Tensor:

--- a/tests/unittest/_torch/modules/test_fused_moe.py
+++ b/tests/unittest/_torch/modules/test_fused_moe.py
@@ -9,7 +9,8 @@ import cloudpickle
 import pytest
 import torch
 import torch.nn as nn
-from _torch.helpers import (per_block_cast_to_fp8, per_block_cast_to_fp8_e8m0,
+from _torch.helpers import (calc_woq_tolerence, per_block_cast_to_fp8,
+                            per_block_cast_to_fp8_e8m0,
                             per_token_cast_to_fp8_e8m0)
 from mpi4py import MPI
 from mpi4py.futures import MPIPoolExecutor
@@ -1901,6 +1902,113 @@ def test_fused_moe_triton_mxfp4(experts, hidden_size, intermediate_size,
         # There can be one off mismatch in the outputs due to different kernel implementations
         # Here we check certain percent of the outputs are within the tolerance
         check_accuracy(output, ref_output, rtol=0.6, atol=0.6, percent=0.945)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize("weight_dtype", [torch.int8])
+def test_fused_moe_weight_only(dtype, weight_dtype):
+
+    SEQ_LEN = 4
+    HIDDEN_SIZE = 768
+    INTERMEDIATE_SIZE = 640
+    NUM_EXPERTS = 3
+    TOP_K = 2
+    routing_method = RenormalizeMoeRoutingMethod(top_k=TOP_K)
+    torch.manual_seed(0)
+    torch.cuda.manual_seed(0)
+    x = torch.randn((SEQ_LEN, HIDDEN_SIZE), dtype=dtype, device="cuda")
+
+    router_logits = torch.randn((SEQ_LEN, NUM_EXPERTS),
+                                dtype=dtype,
+                                device="cuda")
+
+    weight_id = 1  # 1 for w8a16, 2 for w4a16
+    quant_config = QuantConfig(quant_algo=QuantAlgo.W8A16)
+    weights = {}
+    for expert_id in range(NUM_EXPERTS):
+        w1_weight = torch.randint(-128,
+                                  127,
+                                  (INTERMEDIATE_SIZE, HIDDEN_SIZE // weight_id),
+                                  dtype=torch.int8).cuda()
+        w2_weight = torch.randint(-128,
+                                  127,
+                                  (HIDDEN_SIZE, INTERMEDIATE_SIZE // weight_id),
+                                  dtype=torch.int8).cuda()
+        w3_weight = torch.randint(-128,
+                                  127,
+                                  (INTERMEDIATE_SIZE, HIDDEN_SIZE // weight_id),
+                                  dtype=torch.int8).cuda()
+
+        w1_scale = torch.randn(
+            (INTERMEDIATE_SIZE), dtype=dtype, device="cuda") / HIDDEN_SIZE
+        w2_scale = torch.randn(
+            (HIDDEN_SIZE), dtype=dtype, device="cuda") / INTERMEDIATE_SIZE
+        w3_scale = torch.randn(
+            (INTERMEDIATE_SIZE), dtype=dtype, device="cuda") / HIDDEN_SIZE
+
+        weights[f"{expert_id}.w1.weight"] = w1_weight
+        weights[f"{expert_id}.w2.weight"] = w2_weight
+        weights[f"{expert_id}.w3.weight"] = w3_weight
+        weights[f"{expert_id}.w1.weight_scale_inv"] = w1_scale
+        weights[f"{expert_id}.w2.weight_scale_inv"] = w2_scale
+        weights[f"{expert_id}.w3.weight_scale_inv"] = w3_scale
+
+    fused_moe = CutlassFusedMoE(
+        num_experts=NUM_EXPERTS,
+        routing_method=routing_method,
+        hidden_size=HIDDEN_SIZE,
+        intermediate_size=INTERMEDIATE_SIZE,
+        dtype=dtype,
+        reduce_results=False,
+        model_config=ModelConfig(quant_config=quant_config))
+    fused_moe.load_weights([weights])
+    fused_moe.cuda()
+
+    def ref():
+        results = torch.zeros_like(x)
+        selected_experts, final_scales = routing_method.apply(router_logits)
+        for e_idx in range(NUM_EXPERTS):
+            mask = selected_experts == e_idx
+            activated_tokens = mask.sum(1).bool()
+            act = x[activated_tokens, :]
+            if act.shape[0] == 0:
+                continue
+            final_scale = (final_scales *
+                           mask).sum(1)[activated_tokens].unsqueeze(1)
+            # weights
+            w1 = weights[f"{e_idx}.w1.weight"].T.contiguous().cuda()
+            w2 = weights[f"{e_idx}.w2.weight"].T.contiguous().cuda()
+            w3 = weights[f"{e_idx}.w3.weight"].T.contiguous().cuda()
+            w3_w1 = torch.cat([w3, w1], dim=-1)
+            # scales
+            s1 = weights[f"{e_idx}.w1.weight_scale_inv"].cuda()
+            s2 = weights[f"{e_idx}.w2.weight_scale_inv"].cuda()
+            s3 = weights[f"{e_idx}.w3.weight_scale_inv"].cuda()
+            s3_s1 = torch.cat([s3, s1], dim=-1)
+            # calculation
+            w3_w1 = (w3_w1.float() * s3_s1).to(dtype)
+            fc1 = torch.matmul(act, w3_w1)
+            fc1, gate = fc1.chunk(2, dim=-1)
+            act = fc1 * torch.nn.functional.silu(gate)
+            w2 = (w2.float() * s2).to(dtype)
+            fc2 = torch.matmul(act, w2)
+            results[activated_tokens, :] += (fc2 * final_scale).to(
+                results.dtype)
+        return results
+
+    AutoTuner.get().clear_cache()
+    with torch.inference_mode(), autotune():
+        fused_moe.forward(x, router_logits)
+
+    torch.cuda.synchronize()
+    with torch.inference_mode():
+        output = fused_moe.forward(x, router_logits)
+        ref_output = ref()
+
+    # compare
+    torch.cuda.synchronize()
+    atol = calc_woq_tolerence(ref_output, weight_dtype)
+    torch.testing.assert_close(output, ref_output, rtol=1e-27, atol=atol)
 
 
 class RefGatedMLPFusedMoE(nn.Module):

--- a/tests/unittest/trt/quantization/test_moe_weight_only_quant_matmul.py
+++ b/tests/unittest/trt/quantization/test_moe_weight_only_quant_matmul.py
@@ -14,32 +14,30 @@
 # limitations under the License.
 import unittest
 
-import pytest
-
 # isort: off
 import torch
 # isort: on
 
 from parameterized import parameterized
-from utils.util import (create_session, run_session,
-                        skip_neither_ada_nor_hopper_unittest,
+from utils.util import (create_session, run_session, skip_non_ada_unittest,
                         unittest_name_func)
 
 import tensorrt_llm
 import tensorrt_llm.quantization.functional
 from tensorrt_llm import Tensor
-from tensorrt_llm._utils import (get_sm_version, str_dtype_to_trt,
-                                 torch_to_numpy, trt_dtype_to_str)
+from tensorrt_llm._utils import (str_dtype_to_trt, torch_to_numpy,
+                                 trt_dtype_to_str)
 from tensorrt_llm.layers.moe import MoeConfig
 from tensorrt_llm.quantization import QuantMode
 
 from . import _utils
 
 
-class TestMoEWeightOnlyGroupWiseQuantMatmul(unittest.TestCase):
+class TestMoEWeightOnlyQuantMatmul(unittest.TestCase):
 
     def setUp(self):
         torch.manual_seed(0)
+        torch.cuda.manual_seed(0)
         tensorrt_llm.logger.set_level('error')
 
     def create_trt_session(
@@ -67,11 +65,11 @@ class TestMoEWeightOnlyGroupWiseQuantMatmul(unittest.TestCase):
         network = builder.create_network()
         dtype = str_dtype_to_trt(str_dtype)
         norm_mode = MoeConfig.ExpertScaleNormalizationMode.RENORMALIZE
-        quant_mode = QuantMode.use_weight_only(True, True)
         k = act.shape[1]
-        n = fc2_prequant_scale.shape[
-            -1]  # get the original n from prequant scale because either weight or scale could be interleaved
+        n = weight_scaling_factor_1.shape[-1] // 2
         num_experts = weight_scaling_factor_1.shape[0]
+
+        use_int8 = True if self.quant_mode.is_int8_weight_only() else False
 
         with tensorrt_llm.net_guard(network):
             trt_key = Tensor(name='input_hidden_states',
@@ -91,18 +89,25 @@ class TestMoEWeightOnlyGroupWiseQuantMatmul(unittest.TestCase):
                                           hidden_act="swiglu",
                                           bias=False,
                                           dtype=dtype,
-                                          quant_mode=quant_mode,
+                                          quant_mode=self.quant_mode,
                                           pre_quant_scale=has_pre_quant,
                                           zero=has_zero,
                                           use_w4a8_awq=has_alpha,
+                                          use_int8_weight=use_int8,
                                           group_size=group_size)
             moe.router.weight.value = torch_to_numpy(router.cpu())
             moe.fc.weight.value = torch_to_numpy(fc1_weights.cpu())
             moe.proj.weight.value = torch_to_numpy(fc2_weights.cpu())
-            moe.fc.weights_scaling_factor.value = torch_to_numpy(
-                weight_scaling_factor_1.cpu())
-            moe.proj.weights_scaling_factor.value = torch_to_numpy(
-                weight_scaling_factor_2.cpu())
+            if group_size != -1:
+                moe.fc.weights_scaling_factor.value = torch_to_numpy(
+                    weight_scaling_factor_1.cpu())
+                moe.proj.weights_scaling_factor.value = torch_to_numpy(
+                    weight_scaling_factor_2.cpu())
+            else:
+                moe.fc.per_channel_scale.value = torch_to_numpy(
+                    weight_scaling_factor_1.cpu())
+                moe.proj.per_channel_scale.value = torch_to_numpy(
+                    weight_scaling_factor_2.cpu())
             if has_pre_quant:
                 moe.fc.prequant_scaling_factor.value = torch_to_numpy(
                     fc1_prequant_scale.cpu())
@@ -121,8 +126,8 @@ class TestMoEWeightOnlyGroupWiseQuantMatmul(unittest.TestCase):
         session = create_session(builder,
                                  network,
                                  precision=trt_dtype_to_str(dtype),
-                                 int8=False,
-                                 quant_mode=quant_mode)
+                                 int8=use_int8,
+                                 quant_mode=self.quant_mode)
         return session
 
     def _woq_moe_groupwise_matmul(self,
@@ -206,49 +211,17 @@ class TestMoEWeightOnlyGroupWiseQuantMatmul(unittest.TestCase):
             ref_weight_1 += zero_1.repeat_interleave(group_size, dim=1)
             ref_weight_2 += zero_2.repeat_interleave(group_size, dim=1)
         activation_type = torch.float8_e4m3fn if has_alpha else activation_dtype
-        do_weight_interleave = get_sm_version(
-        ) != 90 or not has_alpha  # Hopper w4a8 does not interleave weight
         cuda_q_weight_1 = preprocessor(
-            unprocessed_weight_1.cpu(),
-            quantized_weight_dtype,
-            activation_type,
-            do_weight_interleave=do_weight_interleave).view(
-                activation_dtype).cpu()
+            unprocessed_weight_1.cpu(), quantized_weight_dtype,
+            activation_type).view(activation_dtype).cpu()
         cuda_q_weight_2 = preprocessor(
-            unprocessed_weight_2.cpu(),
-            quantized_weight_dtype,
-            activation_type,
-            do_weight_interleave=do_weight_interleave).view(
-                activation_dtype).cpu()
-        if get_sm_version() == 89 and has_alpha:
+            unprocessed_weight_2.cpu(), quantized_weight_dtype,
+            activation_type).view(activation_dtype).cpu()
+        if has_alpha and activation_dtype == torch.bfloat16:
             scale_1 = scale_1.to(torch.float16).view(activation_dtype)
             scale_2 = scale_2.to(torch.float16).view(activation_dtype)
             zero_1 = zero_1.to(torch.float16).view(activation_dtype)
             zero_2 = zero_2.to(torch.float16).view(activation_dtype)
-
-        if get_sm_version() == 90 and has_alpha:
-            if has_zero:
-                pytest.skip(
-                    "has_zero is not supported in Hopper with WINT4AFP8.")
-
-            def interleave_scales(scales: torch.Tensor, interleave_dim: int):
-                # [num_experts, num_groups, num_cols] --> [num_experts, num_groups // interleave, num_cols * interleave]
-                # Note: num_groups = num_rows // group_size
-                E, G, C = scales.shape
-                I = tensorrt_llm.quantization.functional.get_weight_scale_interleave_factor(
-                    interleave_dim, group_size)
-                assert G % I == 0, f"Group dimension ({G}) must be divisible by interleave factor ({I})."
-                scales_interleaved = scales.reshape(E, G // I, I, C)
-                scales_interleaved = scales_interleaved.permute(0, 1, 3, 2)
-                scales_interleaved = scales_interleaved.reshape(
-                    E, G // I, C * I)
-                return scales_interleaved.contiguous()
-
-            scale_1 = scale_1.to(torch.bfloat16).view(activation_dtype)
-            scale_2 = scale_2.to(torch.bfloat16).view(activation_dtype)
-            scale_1 = interleave_scales(scale_1, k)
-            scale_2 = interleave_scales(scale_2, n)
-            zero_1, zero_2 = None, None
 
         session = self.create_trt_session(
             activation_dtype_str, activation, router, pre_quant_scale_1,
@@ -298,6 +271,97 @@ class TestMoEWeightOnlyGroupWiseQuantMatmul(unittest.TestCase):
         ref = results.view(*inputs.shape)
         _utils.woq_assert_near_eq(ref, out, 2)
 
+    def _woq_moe_matmul_per_channel(self,
+                                    m,
+                                    n,
+                                    k,
+                                    num_experts,
+                                    activation_dtype_str,
+                                    quantized_weight_dtype,
+                                    top_k=2):
+
+        activation_dtype = tensorrt_llm._utils.str_dtype_to_torch(
+            activation_dtype_str)
+        activation = torch.randn(m, k, dtype=activation_dtype, device="cuda")
+        router = torch.randn((num_experts, k),
+                             dtype=torch.float32,
+                             device="cuda")
+
+        num_weights_in_32_bits = 4
+
+        assert n % num_weights_in_32_bits == 0, f"n must be a multiple of {num_weights_in_32_bits}"
+        unprocessed_int_weight_1 = torch.randint(
+            -2**31,
+            2**31, (num_experts, k, n * 2 // num_weights_in_32_bits),
+            dtype=torch.int32,
+            device="cuda")
+        unprocessed_int_weight_2 = torch.randint(
+            -2**31,
+            2**31, (num_experts, n, k // num_weights_in_32_bits),
+            dtype=torch.int32,
+            device="cuda")
+        unprocessed_weight_1 = unprocessed_int_weight_1.view(torch.int8)
+        unprocessed_weight_2 = unprocessed_int_weight_2.view(torch.int8)
+
+        scale_1 = torch.randn(
+            num_experts, 1, n * 2, dtype=activation_dtype, device="cuda") / k
+        scale_2 = torch.randn(
+            num_experts, 1, k, dtype=activation_dtype, device="cuda") / n
+
+        ref_weight_1 = unprocessed_weight_1 * scale_1
+        ref_weight_2 = unprocessed_weight_2 * scale_2
+        scale_1 = scale_1.squeeze(1)
+        scale_2 = scale_2.squeeze(1)
+
+        preprocessor = tensorrt_llm.quantization.functional.preprocess_weights_for_mixed_gemm
+
+        cuda_q_weight_1 = preprocessor(unprocessed_weight_1.cpu(),
+                                       quantized_weight_dtype,
+                                       activation_dtype).cpu()
+        cuda_q_weight_2 = preprocessor(unprocessed_weight_2.cpu(),
+                                       quantized_weight_dtype,
+                                       activation_dtype).cpu()
+
+        session = self.create_trt_session(activation_dtype_str, activation,
+                                          router, None, None, cuda_q_weight_1,
+                                          cuda_q_weight_2, scale_1, scale_2,
+                                          None, None, None, None, top_k, False,
+                                          False, False, -1)
+
+        inputs = {"input_hidden_states": activation}
+        outputs = run_session(session, inputs)
+        out = outputs['output'].float()
+
+        # ref
+        inputs = activation.cuda().float()
+        inputs_merged = inputs.view(-1, inputs.shape[-1])
+        routing = torch.matmul(inputs_merged, router.T.float())
+        router_probs = torch.softmax(routing, 1, dtype=inputs.dtype)
+        topk = torch.topk(router_probs, top_k)
+        results = torch.zeros_like(inputs_merged)
+        for i, (scales, experts) in enumerate(zip(topk.values, topk.indices)):
+            scales /= sum(scales)
+            input = inputs_merged[i, :]
+            for scale, expert in zip(scales, experts):
+                input = inputs_merged[i, :]
+                fc1_qd = ref_weight_1[expert].cuda().float()
+                fc1 = torch.matmul(input, fc1_qd)
+                fc1, gate = fc1.chunk(2, dim=-1)
+                fc1 = fc1 * torch.nn.functional.silu(gate)
+
+                fc2_qd = ref_weight_2[expert].cuda().float()
+                final = torch.matmul(fc1, fc2_qd)
+                results[i] += scale * final
+        ref = results.view(*inputs.shape)
+        _utils.woq_assert_near_eq(ref, out, 1)
+
+    @parameterized.expand([(1, 14336, 4096, 8, "float16"),
+                           (1, 14336, 4096, 8, "bfloat16")],
+                          name_func=unittest_name_func)
+    def test_moe_w8a16(self, m, n, k, experts, dtype):
+        self.quant_mode = QuantMode.use_weight_only(False, False)
+        self._woq_moe_matmul_per_channel(m, n, k, experts, dtype, torch.int8)
+
     @parameterized.expand([(1, 14336, 4096, 8, "float16", True, True),
                            (1, 14336, 4096, 8, "float16", True, False),
                            (1, 14336, 4096, 8, "float16", False, True),
@@ -305,7 +369,9 @@ class TestMoEWeightOnlyGroupWiseQuantMatmul(unittest.TestCase):
                            (1, 14336, 4096, 8, "bfloat16", True, False),
                            (1, 14336, 4096, 8, "bfloat16", False, True)],
                           name_func=unittest_name_func)
-    def test_moe_w4a16(self, m, n, k, experts, dtype, has_pre_quant, has_zero):
+    def test_moe_w4a16_groupwise(self, m, n, k, experts, dtype, has_pre_quant,
+                                 has_zero):
+        self.quant_mode = QuantMode.use_weight_only(True, True)
         self._woq_moe_groupwise_matmul(m, n, k, experts, dtype, torch.quint4x2,
                                        has_pre_quant, has_zero, False)
 
@@ -314,9 +380,10 @@ class TestMoEWeightOnlyGroupWiseQuantMatmul(unittest.TestCase):
                            (1, 14336, 4096, 8, "bfloat16", True, False),
                            (1, 14336, 4096, 8, "bfloat16", True, True)],
                           name_func=unittest_name_func)
-    @skip_neither_ada_nor_hopper_unittest
-    def test_moe_w4a8(self, m, n, k, experts, dtype, has_pre_quant, has_zero):
-
+    @skip_non_ada_unittest
+    def test_moe_w4a8_groupwise(self, m, n, k, experts, dtype, has_pre_quant,
+                                has_zero):
+        self.quant_mode = QuantMode.use_weight_only(True, True)
         self._woq_moe_groupwise_matmul(m, n, k, experts, dtype, torch.quint4x2,
                                        has_pre_quant, has_zero, True)
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for weight-only quantization modes, including per-channel and group scaling variants, for Mixture of Experts (MoE) layers.
  * Introduced new quantization method handling and configuration options in MoE modules and custom operators.
  * Enhanced test coverage with new tests for weight-only quantized MoE operations, including per-channel and groupwise modes.

* **Bug Fixes**
  * Refined error handling for INT8-GPTQ support to only trigger under specific conditions.

* **Tests**
  * Added and updated tests to validate correctness of weight-only quantized MoE implementations and tolerance calculations.
  * Improved test utilities for consistent quantization tolerance computation.

* **Refactor**
  * Updated and renamed test classes and methods for clarity and expanded quantization mode support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up
-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
