### PR TITLE
Draft: Split atten_metadata

### DIFF
--- a/run_deepseek_batch_split.sh
+++ b/run_deepseek_batch_split.sh
@@ -1,0 +1,398 @@
+#!/bin/bash
+
+model_card="deepseek-ai/DeepSeek-R1"
+model_path="/llm-models/DeepSeek-R1/DeepSeek-R1-FP4/"
+dataset_file="/tmp/aa_prompt_50000.txt"
+nsys_on="true"
+#nsys_on="false"
+
+# isl=8192
+# osl=1024
+
+multi_round=1
+disable_overlap_scheduler="false"
+
+# Default batch split configuration
+USE_BATCH_SPLIT_MODEL="true"
+BATCH_SPLIT_RATIO=0.5
+USE_SEPARATE_STREAMS="true"
+SYNC_AFTER_ATTENTION="true"
+ENABLE_LAYER_COMPLETION_EVENTS="false"
+ENABLE_INTRA_LAYER_BATCH_SPLITTING="true"
+NABLE_ATTENTION_METADATA_SPLITTING="true"
+ENABLE_SEPARATE_KV_CACHE_MANAGERS="true"
+
+# Function to print usage
+print_usage() {
+    echo "Usage: $0 <concurrency> <max_batch_size> <max_num_tokens> <tp> <ep> <gpu_fraction> <eplb_num_slots> <updates_per_iter> <log_dir> [mode]"
+    echo ""
+    echo "Required arguments:"
+    echo "  concurrency      - Number of concurrent requests"
+    echo "  max_batch_size   - Maximum batch size"
+    echo "  max_num_tokens   - Maximum number of tokens"
+    echo "  tp               - Tensor parallelism"
+    echo "  ep               - Expert parallelism"
+    echo "  gpu_fraction     - GPU memory fraction for KV cache"
+    echo "  eplb_num_slots   - EPLB number of slots (0 to disable)"
+    echo "  updates_per_iter - Updates per iteration"
+    echo "  log_dir          - Log directory"
+    echo ""
+    echo "Optional mode argument (default: 4):"
+    echo "  1 - No batch splitting and no inter-layer overlap"
+    echo "  2 - Only inter-layer overlap (pipeline parallelism)"
+    echo "  3 - Only batch splitting (no inter-layer overlap)"
+    echo "  4 - Both inter-layer and batch splitting (full overlap)"
+    echo ""
+    echo "Examples:"
+    echo "  $0 256 64 2400 4 4 0.5 0 1 /scratch/TensorRT-LLM/results_batch_split_20250716"
+    echo "  $0 256 64 2400 4 4 0.5 0 1 /scratch/TensorRT-LLM/results_batch_split_20250716 2"
+    echo "  $0 256 64 2400 4 4 0.5 0 1 /scratch/TensorRT-LLM/results_batch_split_20250716 1"
+}
+
+# Function to configure batch splitting based on mode
+configure_batch_splitting() {
+    local mode=$1
+    
+    case $mode in
+        1)
+            echo "Mode 1: No batch splitting and no inter-layer overlap"
+            USE_BATCH_SPLIT_MODEL="false"
+            USE_SEPARATE_STREAMS="false"
+            ENABLE_LAYER_COMPLETION_EVENTS="false"
+            ENABLE_INTRA_LAYER_BATCH_SPLITTING="false"
+            ENABLE_ATTENTION_METADATA_SPLITTING="false"
+            ENABLE_SEPARATE_KV_CACHE_MANAGERS="false"
+            SYNC_AFTER_ATTENTION="false"
+            ;;
+        2)
+            echo "Mode 2: Only inter-layer overlap (pipeline parallelism)"
+            USE_BATCH_SPLIT_MODEL="true"
+            USE_SEPARATE_STREAMS="true"
+            ENABLE_LAYER_COMPLETION_EVENTS="true"
+            ENABLE_INTRA_LAYER_BATCH_SPLITTING="false"
+            ENABLE_ATTENTION_METADATA_SPLITTING="false"
+            ENABLE_SEPARATE_KV_CACHE_MANAGERS="false"
+            SYNC_AFTER_ATTENTION="false"
+            ;;
+        3)
+            echo "Mode 3: Only batch splitting (no inter-layer overlap)"
+            USE_BATCH_SPLIT_MODEL="true"
+            USE_SPLIT_KV_CACHE="true"
+            USE_SEPARATE_STREAMS="true"
+            ENABLE_LAYER_COMPLETION_EVENTS="false"
+            ENABLE_INTRA_LAYER_BATCH_SPLITTING="true"
+            ENABLE_ATTENTION_METADATA_SPLITTING="true"
+            ENABLE_SEPARATE_KV_CACHE_MANAGERS="true"
+            SYNC_AFTER_ATTENTION="true"
+            ;;
+        4)
+            echo "Mode 4: Both inter-layer and batch splitting (full overlap)"
+            USE_BATCH_SPLIT_MODEL="true"
+            USE_SPLIT_KV_CACHE="true"
+            USE_SEPARATE_STREAMS="true"
+            ENABLE_LAYER_COMPLETION_EVENTS="true"
+            ENABLE_INTRA_LAYER_BATCH_SPLITTING="true"
+            ENABLE_ATTENTION_METADATA_SPLITTING="true"
+            ENABLE_SEPARATE_KV_CACHE_MANAGERS="true"
+            SYNC_AFTER_ATTENTION="true"
+            ;;
+        *)
+            echo "Error: Invalid mode '$mode'. Must be 1, 2, 3, or 4."
+            print_usage
+            exit 1
+            ;;
+    esac
+}
+
+# Parameter validation and default values
+if [ $# -lt 9 ]; then
+    echo "Error: Insufficient arguments provided."
+    print_usage
+    exit 1
+fi
+
+concurrency=${1:-256}
+max_batch_size=${2:-64}
+max_num_tokens=${3:-2400}
+tp=${4:-4}
+ep=${5:-4}
+gpu_fraction=${6:-0.5}
+eplb_num_slots=${7:-0}
+updates_per_iter=${8:-1}
+log_dir=${9:-"/scratch/TensorRT-LLM/results_batch_split_$(date +%Y%m%d)"}
+mode=${10:-2}  # Default to mode 2 (only inter-layer overlap)
+
+# Validate that eplb_num_slots is a number
+if ! [[ "${eplb_num_slots}" =~ ^[0-9]+$ ]]; then
+    echo "Error: eplb_num_slots must be a non-negative integer, got: '${eplb_num_slots}'"
+    exit 1
+fi
+
+# Validate that updates_per_iter is a number
+if ! [[ "${updates_per_iter}" =~ ^[0-9]+$ ]]; then
+    echo "Error: updates_per_iter must be a non-negative integer, got: '${updates_per_iter}'"
+    exit 1
+fi
+
+# Configure batch splitting based on mode
+configure_batch_splitting $mode
+
+echo "Parameters:"
+echo "  concurrency: ${concurrency}"
+echo "  max_batch_size: ${max_batch_size}"
+echo "  max_num_tokens: ${max_num_tokens}"
+echo "  tp: ${tp}"
+echo "  ep: ${ep}"
+echo "  gpu_fraction: ${gpu_fraction}"
+echo "  eplb_num_slots: ${eplb_num_slots}"
+echo "  updates_per_iter: ${updates_per_iter}"
+echo "  log_dir: ${log_dir}"
+echo "  mode: ${mode}"
+echo
+
+gen_aa_dataset() {
+    local isl=$1
+    local osl=$2
+    local num_prompts=$3
+    local dataset_file=$4
+
+    # run the loadgen
+    loadgen_config_file=/tmp/loadgen_config.json
+    # Generate the loadgen_config.json file
+    cat << EOF > ${loadgen_config_file}
+{
+    "dataset": {
+        "type": "aa",
+        "model_name": "${model_path}",
+        "seed": 42,
+        "max_count": ${num_prompts},
+        "approximate_input_tokens": ${isl},
+        "num_sentences_to_translate": 100,
+        "output_tokens": ${osl}
+    },
+    "inference_server": {
+        "type": "dump_dataset",
+        "output_file_name": "${dataset_file}"
+    },
+    "timing_strategy": {
+        "type": "fixed",
+        "desired_rps": -1
+    },
+    "post_processors": [],
+    "timeout": null
+}
+EOF
+    infserver_loadgen ${loadgen_config_file} --output_dir /tmp/ 
+    echo "Dataset generated to ${dataset_file}"
+}
+
+check_dataset_exists() {
+    local dataset_file=$1
+    local expected_lines=$2
+    
+    if [ -f "${dataset_file}" ]; then
+        local actual_lines=$(wc -l < "${dataset_file}")
+        if [ "${actual_lines}" -eq "${expected_lines}" ]; then
+            echo "Dataset ${dataset_file} already exists with ${actual_lines} lines. Skipping generation."
+            return 0
+        else
+            echo "Dataset ${dataset_file} exists but has ${actual_lines} lines (expected ${expected_lines}). Regenerating..."
+            return 1
+        fi
+    else
+        echo "Dataset ${dataset_file} does not exist. Generating..."
+        return 1
+    fi
+}
+
+gen_attn_dp_config() {
+    local cuda_graph_batch=$1
+    local eplb_num_slots=$2
+    local moe_max_num_tokens=$3
+    local updates_per_iter=$4
+    local sub_dir=$5
+    
+    extra_llm_api_file=${sub_dir}/extra-llm-api-config.yml
+    echo "extra_llm_api_file: ${extra_llm_api_file}"
+
+    cat << EOF > ${extra_llm_api_file}
+enable_attention_dp: true
+enable_layerwise_nvtx_marker: true
+print_iter_log: true
+enable_chunked_prefill: false
+moe_config:
+ max_num_tokens: ${moe_max_num_tokens}
+ backend: WIDEEP
+kv_cache_config:
+ dtype: fp8
+load_format: dummy
+cuda_graph_config : null
+EOF
+
+    if [ "${eplb_num_slots}" -gt 0 ]; then
+        eplb_config_file=${sub_dir}/moe_load_balancer.yaml
+        cat << EOF > ${eplb_config_file}
+num_slots: ${eplb_num_slots}
+layer_updates_per_iter: ${updates_per_iter}   
+EOF
+
+        cat << EOF >> ${extra_llm_api_file}
+moe_load_balancer: ${sub_dir}/moe_load_balancer.yaml
+EOF
+    fi
+}   
+
+run_dep_benchmark() {
+    local concurrency=$1
+    local max_batch_size=$2
+    local max_num_tokens=$3
+    local tp=$4
+    local ep=$5
+    local eplb_num_slots=$6
+    local updates_per_iter=$7
+    local sub_dir=$8
+
+    num_requests=$((concurrency * multi_round))
+    cuda_graph_batch=$((concurrency / tp))
+
+    extra_llm_api_file=${sub_dir}/extra-llm-api-config.yml
+
+    nsys_prefix=""
+    # check NSYS_MODE is not empty
+    if [ "${nsys_on}" == "true" ]; then
+        nsys_file=${sub_dir}/nsys_worker_proc_${SLURM_PROCID}
+        nsys_prefix="nsys profile -e \"NSYS_MPI_STORE_TEAMS_PER_RANK=1\" -o ${nsys_file} -f true -t cuda,nvtx,python-gil -c cudaProfilerApi --cuda-graph-trace node --capture-range-end=stop --gpu-metrics-devices=none"
+        export TLLM_PROFILE_START_STOP=700-750
+        export TLLM_PROFILE_RECORD_GC=1
+        export TLLM_NVTX_DEBUG=1
+    fi
+
+    trtllm-bench -m ${model_card} --model_path ${model_path} throughput \
+        --tp ${tp} \
+        --ep ${ep} \
+        --warmup 0 \
+        --dataset ${dataset_file} \
+        --backend pytorch \
+        --max_batch_size ${max_batch_size} \
+        --max_num_tokens ${max_num_tokens} \
+        --max_seq_len 2304 \
+	    --kv_cache_free_gpu_mem_fraction ${gpu_fraction} \
+        --extra_llm_api_options ${extra_llm_api_file} \
+        --num_requests ${num_requests} \
+        --concurrency ${concurrency} \
+        --report_json ${sub_dir}/trtllm_bench_report.json \
+        --iteration_log ${sub_dir}/iteration.log \
+        |& tee ${sub_dir}/trtllm_bench_run.log
+}
+
+sub_dir=${log_dir}/dep${ep}_concurrency${concurrency}_eplb${eplb_num_slots}_updates${updates_per_iter}_mode${mode}
+mkdir -p ${sub_dir}
+echo "sub_dir: ${sub_dir}"
+
+# Define moe_max_num_tokens in global scope
+moe_max_num_tokens=16384
+if [ "${concurrency}" -gt "${moe_max_num_tokens}" ]; then
+    moe_max_num_tokens=${concurrency}
+fi
+
+# Set batch split environment variables
+export USE_BATCH_SPLIT_MODEL=${USE_BATCH_SPLIT_MODEL}
+export USE_SPLIT_KV_CACHE=${USE_SPLIT_KV_CACHE}
+export BATCH_SPLIT_RATIO=${BATCH_SPLIT_RATIO}
+export USE_SEPARATE_STREAMS=${USE_SEPARATE_STREAMS}
+export SYNC_AFTER_ATTENTION=${SYNC_AFTER_ATTENTION}
+export ENABLE_LAYER_COMPLETION_EVENTS=${ENABLE_LAYER_COMPLETION_EVENTS}
+export ENABLE_INTRA_LAYER_BATCH_SPLITTING=${ENABLE_INTRA_LAYER_BATCH_SPLITTING}
+export ENABLE_ATTENTION_METADATA_SPLITTING=${ENABLE_ATTENTION_METADATA_SPLITTING}
+export ENABLE_SEPARATE_KV_CACHE_MANAGERS=${ENABLE_SEPARATE_KV_CACHE_MANAGERS}
+
+# Debug: Check environment variables and module import
+echo "=== DEBUG: Environment Variables ==="
+echo "USE_BATCH_SPLIT_MODEL: ${USE_BATCH_SPLIT_MODEL}"
+echo "USE_SPLIT_KV_CACHE: ${USE_SPLIT_KV_CACHE}"
+echo "ENABLE_SEPARATE_KV_CACHE_MANAGERS: ${ENABLE_SEPARATE_KV_CACHE_MANAGERS}"
+
+echo "=== DEBUG: Module Import Test ==="
+python -c "
+import os
+print('Environment variables in Python:')
+print('  USE_BATCH_SPLIT_MODEL:', os.environ.get('USE_BATCH_SPLIT_MODEL', 'not set'))
+print('  USE_SPLIT_KV_CACHE:', os.environ.get('USE_SPLIT_KV_CACHE', 'not set'))
+
+try:
+    import tensorrt_llm._torch.models.deepseek_v3_batch_split_moe
+    print('✓ Batch split module imported successfully')
+    
+    # Check if the registration happened
+    from tensorrt_llm._torch.models.modeling_auto import AutoModelForCausalLM
+    print('✓ AutoModelForCausalLM imported successfully')
+    
+except ImportError as e:
+    print('✗ Failed to import batch split module:', e)
+except Exception as e:
+    print('✗ Error during import:', e)
+"
+
+export TRTLLM_MOE_ENABLE_ALLTOALL_WITHOUT_ALLGATHER=1
+export TRTLLM_MNNVL_AR_ENABLED=1
+export FLASHINFER_WORKSPACE_BASE=/scratch/TensorRT-LLM/flashinfer/
+
+export TLLM_OVERRIDE_LAYER_NUM=5
+
+export EXPERT_STATISTIC_PATH=${sub_dir}/expert_statistic
+export EXPERT_STATISTIC_ITER_RANGE=600-650
+
+echo "Batch Split Configuration:"
+echo "  USE_BATCH_SPLIT_MODEL: ${USE_BATCH_SPLIT_MODEL}"
+echo "  BATCH_SPLIT_RATIO: ${BATCH_SPLIT_RATIO}"
+echo "  USE_SEPARATE_STREAMS: ${USE_SEPARATE_STREAMS}"
+echo "  SYNC_AFTER_ATTENTION: ${SYNC_AFTER_ATTENTION}"
+echo "  ENABLE_LAYER_COMPLETION_EVENTS: ${ENABLE_LAYER_COMPLETION_EVENTS}"
+echo "  ENABLE_INTRA_LAYER_BATCH_SPLITTING: ${ENABLE_INTRA_LAYER_BATCH_SPLITTING}"
+echo "  ENABLE_ATTENTION_METADATA_SPLITTING: ${ENABLE_ATTENTION_METADATA_SPLITTING}"
+echo "  ENABLE_SEPARATE_KV_CACHE_MANAGERS: ${ENABLE_SEPARATE_KV_CACHE_MANAGERS}"
+echo
+
+echo "run_dep_benchmark ${concurrency} ${max_batch_size} ${max_num_tokens} ${tp} ${ep} ${eplb_num_slots} ${updates_per_iter} ${sub_dir}"
+
+cuda_graph_batch=$((concurrency / tp))
+
+# Check if dataset exists before generating
+if ! check_dataset_exists "${dataset_file}" 50000; then
+    gen_aa_dataset 1024 1024 50000 /tmp/aa_prompt_50000.txt
+fi
+
+gen_attn_dp_config ${cuda_graph_batch} ${eplb_num_slots} ${moe_max_num_tokens} ${updates_per_iter} ${sub_dir}
+
+# Force import the batch split module to ensure registration happens
+echo "=== FORCING BATCH SPLIT MODULE IMPORT ==="
+python -c "
+import os
+print('Forcing import of batch split module...')
+try:
+    import tensorrt_llm._torch.models.deepseek_v3_batch_split_moe
+    print('✓ Batch split module imported and registered')
+except Exception as e:
+    print('✗ Error importing batch split module:', e)
+"
+
+run_dep_benchmark ${concurrency} ${max_batch_size} ${max_num_tokens} ${tp} ${ep} ${eplb_num_slots} ${updates_per_iter} ${sub_dir}
+#python /scratch/TensorRT-LLM/examples/wide_ep/ep_load_balancer/report_load_statistics.py --expert_statistic_path $EXPERT_STATISTIC_PATH
+
+# Usage Examples:
+# Mode 1: No batch splitting and no inter-layer overlap
+# ./run_deepseek_batch_split.sh 256 64 2400 4 4 0.5 0 1 /scratch/TensorRT-LLM/results_20250716 1
+#
+# Mode 2: Only inter-layer overlap (pipeline parallelism)
+# ./run_deepseek_batch_split.sh 256 64 2400 4 4 0.5 0 1 /scratch/TensorRT-LLM/results_20250716 2
+#
+# Mode 3: Only batch splitting (no inter-layer overlap)
+# ./run_deepseek_batch_split.sh 256 64 2400 4 4 0.5 0 1 /scratch/TensorRT-LLM/results_20250716 3
+#
+# Mode 4: Both inter-layer and batch splitting (full overlap) - DEFAULT
+# ./run_deepseek_batch_split.sh 256 64 2400 4 4 0.5 0 1 /scratch/TensorRT-LLM/results_20250716 4
+# ./run_deepseek_batch_split.sh 256 64 2400 4 4 0.5 0 1 /scratch/TensorRT-LLM/results_20250716  # Same as mode 4
+
+# Errors
+# ./run_deepseek_batch_split.sh 256 64 2400 4 4 0.5 256 4 /scratch/TensorRT-LLM/results_20250716
+# - load balancing fails due to gdr library missing on platform 

--- a/tensorrt_llm/_torch/attention_backend/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/interface.py
@@ -257,6 +257,7 @@ class AttentionMetadata:
         """
         Is this metadata for cross attention.
         """
+        print(f"[DEBUG] AttentionMetadata.is_cross - self.seq_lens: {self.seq_lens}, self.seq_lens_kv: {self.seq_lens_kv}")
         return self.seq_lens is not self.seq_lens_kv
 
     @property

--- a/tensorrt_llm/_torch/attention_backend/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/interface.py
@@ -257,7 +257,6 @@ class AttentionMetadata:
         """
         Is this metadata for cross attention.
         """
-        print(f"[DEBUG] AttentionMetadata.is_cross - self.seq_lens: {self.seq_lens}, self.seq_lens_kv: {self.seq_lens_kv}")
         return self.seq_lens is not self.seq_lens_kv
 
     @property

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -1157,6 +1157,22 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
                 use_paged_context_fmha=use_paged_context_fmha,
                 is_mla_enable=self.is_mla_enable,
             )
+        print(f"[DEBUG] TrtllmAttention.forward wrapper.plan layer_idx: {self.get_local_layer_idx(metadata)}\
+              tokens_per_block: {metadata.tokens_per_block}, max_num_requests: {metadata.max_num_requests},\
+              max_seq_len: {metadata.max_seq_len}, max_num_tokens: {metadata.max_num_tokens}\
+              attention_window_size: {attention_window_size}, sink_token_length: {0}, beam_width: {metadata.beam_width}\
+              sequence_length: {metadata.kv_lens_cuda_runtime.shape if metadata.kv_lens_cuda_runtime is not None else None}, host_past_key_value_lengths: {metadata.kv_lens_runtime.shape if metadata.kv_lens_runtime is not None else None}\
+              context_lengths: {metadata.prompt_lens_cuda_runtime.shape if metadata.prompt_lens_cuda_runtime is not None else None}, host_context_lengths: {metadata.prompt_lens_cpu_runtime.shape if metadata.prompt_lens_cpu_runtime is not None else None}\
+              host_request_types: {metadata.host_request_types_runtime.shape if metadata.host_request_types_runtime is not None else None}, kv_cache_block_offsets: {metadata.kv_cache_block_offsets.shape if metadata.kv_cache_block_offsets is not None else None}\
+              host_kv_cache_block_offsets: {metadata.host_kv_cache_block_offsets.shape if metadata.host_kv_cache_block_offsets is not None else None}, host_kv_cache_pool_pointers: {metadata.host_kv_cache_pool_pointers.shape if metadata.host_kv_cache_pool_pointers is not None else None}\
+              host_kv_cache_pool_mapping: {metadata.host_kv_cache_pool_mapping.shape if metadata.host_kv_cache_pool_mapping is not None else None}, block_ids_per_seq: {metadata.block_ids_per_seq.shape if metadata.block_ids_per_seq is not None else None}\
+              workspace: {metadata.workspace.shape if metadata.workspace is not None else None}, cache_indirection: {metadata.cache_indirection.shape if metadata.cache_indirection is not None else None}, kv_scale_orig_quant: {self.kv_scale_orig_quant}\
+              kv_scale_quant_orig: {self.kv_scale_quant_orig}, out_scale: {out_scale.shape if out_scale is not None else None}, out_scale_sf: {out_scale_sf.shape if out_scale_sf is not None else None}\
+              latent_cache: {latent_cache.shape if latent_cache is not None else None}, q_pe: {q_pe.shape if q_pe is not None else None}, mrope_config: {mrope_config}, mla_context_paged_kv: {mla_context_paged_kv.shape if mla_context_paged_kv is not None else None}\
+              mla_context_kv_cache_block_offsets: {mla_context_kv_cache_block_offsets.shape if mla_context_kv_cache_block_offsets is not None else None}, softmax_stats_tensor: {softmax_stats_tensor.shape if softmax_stats_tensor is not None else None}\
+              is_spec_decoding_enabled: {metadata.is_spec_decoding_enabled}, use_spec_decoding: {metadata.use_spec_decoding}\
+              spec_decoding_position_offsets: {metadata.spec_decoding_position_offsets.shape if metadata.spec_decoding_position_offsets is not None else None}, spec_decoding_packed_mask: {metadata.spec_decoding_packed_mask.shape if metadata.spec_decoding_packed_mask is not None else None}\
+              spec_decoding_generation_lengths: {metadata.spec_decoding_generation_lengths}")
         self.wrapper.plan(
             layer_idx=self.get_local_layer_idx(metadata),
             tokens_per_block=metadata.tokens_per_block,

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -1094,6 +1094,14 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
         output_sf: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> torch.Tensor:
+        print(f"[DEBUG] TrtllmAttention.forward - q shape: {q.shape}, dtype: {q.dtype}")
+        print(f"[DEBUG] TrtllmAttention.forward - k shape: {k.shape if k is not None else None}, dtype: {k.dtype if k is not None else None}")
+        print(f"[DEBUG] TrtllmAttention.forward - v shape: {v.shape if v is not None else None}, dtype: {v.dtype if v is not None else None}")
+        print(f"[DEBUG] TrtllmAttention.forward - attention_input_type: {attention_input_type}")
+        print(f"[DEBUG] TrtllmAttention.forward - latent_cache shape: {latent_cache.shape if latent_cache is not None else None}")
+        print(f"[DEBUG] TrtllmAttention.forward - q_pe shape: {q_pe.shape if q_pe is not None else None}")
+        print(f"[DEBUG] TrtllmAttention.forward - output shape: {output.shape if output is not None else None}")
+        
         assert isinstance(
             metadata,
             TrtllmAttentionMetadata,
@@ -1174,6 +1182,7 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
                 # TODO(qijun): revisit fp8_context_fmha logic
                 out_dtype = torch.float8_e4m3fn
 
+        print(f"[DEBUG] TrtllmAttention.forward - About to call CUDA kernel with out_dtype: {out_dtype}")
         output, output_sf = self.wrapper.run(
             q,
             k,
@@ -1187,7 +1196,11 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
 
         if out_dtype == torch.uint8:
             assert output_sf is not None
-            return Fp4QuantizedTensor(output, output_sf)
+            result = Fp4QuantizedTensor(output, output_sf)
+            print(f"[DEBUG] TrtllmAttention.forward - Returning Fp4QuantizedTensor with shape: {result.shape}")
+            return result
+        
+        print(f"[DEBUG] TrtllmAttention.forward - Final output shape: {output.shape}, dtype: {output.dtype}")
         return output
 
     @classmethod

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -406,15 +406,15 @@ class TrtllmAttentionWrapper:
             self.spec_decoding_position_offsets, self.spec_decoding_packed_mask
         ]
         
-        print(f"[DEBUG] TrtllmAttention.forward - q shape: {q.shape}, \
-            sequence_length shape: {self.sequence_length.shape}, \
-            host_past_key_value_lengths shape: {self.host_past_key_value_lengths.shape}, \
-            context_lengths shape: {self.context_lengths.shape}, \
-            host_context_lengths shape: {self.host_context_lengths.shape}, \
-            host_request_types shape: {self.host_request_types.shape}, \
-            kv_cache_block_offsets shape: {self.kv_cache_block_offsets.shape if self.kv_cache_block_offsets is not None else None}, \
-            k shape: {k.shape if k is not None else None}, v shape: {v.shape if v is not None else None}, output shape: {output.shape if output is not None else None}, output_sf shape: {output_sf.shape if output_sf is not None else None}, \
-            out_dtype: {out_dtype if out_dtype is not None else None}, is_fused_qkv: {is_fused_qkv}, update_kv_cache: {update_kv_cache}, attention_mask: {attention_mask}")
+        #print(f"[DEBUG] TrtllmAttention.forward - q shape: {q.shape}, \
+        #    sequence_length shape: {self.sequence_length.shape}, \
+        #    host_past_key_value_lengths shape: {self.host_past_key_value_lengths.shape}, \
+        #    context_lengths shape: {self.context_lengths.shape}, \
+        #    host_context_lengths shape: {self.host_context_lengths.shape}, \
+        #    host_request_types shape: {self.host_request_types.shape}, \
+        #    kv_cache_block_offsets shape: {self.kv_cache_block_offsets.shape if self.kv_cache_block_offsets is not None else None}, \
+        #    k shape: {k.shape if k is not None else None}, v shape: {v.shape if v is not None else None}, output shape: {output.shape if output is not None else None}, output_sf shape: {output_sf.shape if output_sf is not None else None}, \
+        #    out_dtype: {out_dtype if out_dtype is not None else None}, is_fused_qkv: {is_fused_qkv}, update_kv_cache: {update_kv_cache}, attention_mask: {attention_mask}")
 
         torch.ops.trtllm.attention_inplace(
             q,
@@ -696,12 +696,12 @@ class TrtllmAttentionMetadata(AttentionMetadata):
                 )
 
     def prepare(self, splitBatchOverlap: Optional[int] = None) -> None:
-        print(f"[DEBUG] TrtllmAttention.prepare")
+        print(f"[DEBUG] TrtllmAttention.prepare {splitBatchOverlap}")
         extra_attrs = get_model_extra_attrs()
         # If model extra attrs is set, attention_metadata is setup in executor.
         if extra_attrs is None:
             if splitBatchOverlap is not None:
-                print(f"[DEBUG] TrtllmAttention.prepare - splitBatchOverlap is not None")
+                #print(f"[DEBUG] TrtllmAttention.prepare - splitBatchOverlap is not None")
                 if splitBatchOverlap == 1:
                     print(f"[DEBUG] TrtllmAttention.prepare - splitBatchOverlap is 1")
                     get_global_attrs().attention_metadata_half1 = weakref.ref(self)
@@ -732,21 +732,21 @@ class TrtllmAttentionMetadata(AttentionMetadata):
             dtype=torch.int,
             device='cpu',
         )
-        print(f"[DEBUG] TrtllmAttention.prepare - num_seqs: {self.num_seqs}")
+        #print(f"[DEBUG] TrtllmAttention.prepare - num_seqs: {self.num_seqs}")
         self.prompt_lens_cpu[:self.num_seqs].copy_(prompt_lens)
         self.prompt_lens_cuda[:self.num_seqs].copy_(
             self.prompt_lens_cpu[:self.num_seqs], non_blocking=True)
 
         # number of tokens in the kv cache for each sequence in the batch
-        print(f"[DEBUG] TrtllmAttention.prepare - self.kv_cache_params.use_cache: {self.kv_cache_params.use_cache}")
-        print(f"[DEBUG] TrtllmAttention.prepare - self.kv_cache_params.num_cached_tokens_per_seq: {self.kv_cache_params.num_cached_tokens_per_seq}")
+        #print(f"[DEBUG] TrtllmAttention.prepare - self.kv_cache_params.use_cache: {self.kv_cache_params.use_cache}")
+        #print(f"[DEBUG] TrtllmAttention.prepare - self.kv_cache_params.num_cached_tokens_per_seq: {self.kv_cache_params.num_cached_tokens_per_seq}")
         cached_token_lens = torch.tensor(
             self.kv_cache_params.num_cached_tokens_per_seq,
             dtype=torch.int,
             device='cpu',
         ) if self.kv_cache_params.use_cache else None
-        print(f"[DEBUG] TrtllmAttention.prepare - cached_token_lens: {cached_token_lens}")
-        print(f"[DEBUG] TrtllmAttention.prepare - self.seq_lens_kv: {self.seq_lens_kv}")
+        #print(f"[DEBUG] TrtllmAttention.prepare - cached_token_lens: {cached_token_lens}")
+        #print(f"[DEBUG] TrtllmAttention.prepare - self.seq_lens_kv: {self.seq_lens_kv}")
         if self.enable_flash_mla:
             self.prepare_flash_mla()
         # number of tokens needed in the kv cache for each sequence after the next pass
@@ -779,8 +779,8 @@ class TrtllmAttentionMetadata(AttentionMetadata):
             self.kv_cache_block_offsets[:, :self.num_seqs].copy_(
                 self.host_kv_cache_block_offsets[:, :self.num_seqs],
                 non_blocking=True)
-            print(f"[DEBUG] TrtllmAttention.prepare {splitBatchOverlap} - self.kv_lens[:self.num_seqs]: {self.kv_lens[:self.num_seqs]}")
-            print(f"[DEBUG] TrtllmAttention.prepare {splitBatchOverlap} - self.kv_cache_manager.max_seq_len: {self.kv_cache_manager.max_seq_len}")
+            #print(f"[DEBUG] TrtllmAttention.prepare {splitBatchOverlap} - self.kv_lens[:self.num_seqs]: {self.kv_lens[:self.num_seqs]}")
+            #print(f"[DEBUG] TrtllmAttention.prepare {splitBatchOverlap} - self.kv_cache_manager.max_seq_len: {self.kv_cache_manager.max_seq_len}")
             assert self.kv_lens[:self.num_seqs].max(
             ) <= self.kv_cache_manager.max_seq_len, f"Please set max_seq_len to at least {self.kv_lens[:self.num_seqs].max()} for kv cache manager."
 
@@ -792,7 +792,7 @@ class TrtllmAttentionMetadata(AttentionMetadata):
                                                                   num_seqs]
 
     def prepare_flash_mla(self) -> None:
-        print(f"[DEBUG] TrtllmAttention.prepare_flash_mla - self.request_ids: {self.request_ids}")
+        #print(f"[DEBUG] TrtllmAttention.prepare_flash_mla - self.request_ids: {self.request_ids}")
         block_ids_per_seq = self.kv_cache_manager.get_block_ids_per_seq(
             self.request_ids).pin_memory()
         num_blocks = block_ids_per_seq.shape[1]
@@ -1122,14 +1122,14 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
         output_sf: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> torch.Tensor:
-        print(f"[DEBUG] TrtllmAttention.forward - q shape: {q.shape}, dtype: {q.dtype}")
-        print(f"[DEBUG] TrtllmAttention.forward - k shape: {k.shape if k is not None else None}, dtype: {k.dtype if k is not None else None}")
-        print(f"[DEBUG] TrtllmAttention.forward - v shape: {v.shape if v is not None else None}, dtype: {v.dtype if v is not None else None}")
-        print(f"[DEBUG] TrtllmAttention.forward - attention_input_type: {attention_input_type}")
-        print(f"[DEBUG] TrtllmAttention.forward - latent_cache shape: {latent_cache.shape if latent_cache is not None else None}")
-        print(f"[DEBUG] TrtllmAttention.forward - q_pe shape: {q_pe.shape if q_pe is not None else None}")
-        print(f"[DEBUG] TrtllmAttention.forward - output shape: {output.shape if output is not None else None}")
-        print(f"[DEBUG] TrtllmAttention.forward - attn_metadata: {metadata}")
+        #print(f"[DEBUG] TrtllmAttention.forward - q shape: {q.shape}, dtype: {q.dtype}")
+        #print(f"[DEBUG] TrtllmAttention.forward - k shape: {k.shape if k is not None else None}, dtype: {k.dtype if k is not None else None}")
+        #print(f"[DEBUG] TrtllmAttention.forward - v shape: {v.shape if v is not None else None}, dtype: {v.dtype if v is not None else None}")
+        #print(f"[DEBUG] TrtllmAttention.forward - attention_input_type: {attention_input_type}")
+        #print(f"[DEBUG] TrtllmAttention.forward - latent_cache shape: {latent_cache.shape if latent_cache is not None else None}")
+        #print(f"[DEBUG] TrtllmAttention.forward - q_pe shape: {q_pe.shape if q_pe is not None else None}")
+        #print(f"[DEBUG] TrtllmAttention.forward - output shape: {output.shape if output is not None else None}")
+        #print(f"[DEBUG] TrtllmAttention.forward - attn_metadata: {metadata}")
         
         assert isinstance(
             metadata,
@@ -1157,22 +1157,22 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
                 use_paged_context_fmha=use_paged_context_fmha,
                 is_mla_enable=self.is_mla_enable,
             )
-        print(f"[DEBUG] TrtllmAttention.forward wrapper.plan layer_idx: {self.get_local_layer_idx(metadata)}\
-              tokens_per_block: {metadata.tokens_per_block}, max_num_requests: {metadata.max_num_requests},\
-              max_seq_len: {metadata.max_seq_len}, max_num_tokens: {metadata.max_num_tokens}\
-              attention_window_size: {attention_window_size}, sink_token_length: {0}, beam_width: {metadata.beam_width}\
-              sequence_length: {metadata.kv_lens_cuda_runtime.shape if metadata.kv_lens_cuda_runtime is not None else None}, host_past_key_value_lengths: {metadata.kv_lens_runtime.shape if metadata.kv_lens_runtime is not None else None}\
-              context_lengths: {metadata.prompt_lens_cuda_runtime.shape if metadata.prompt_lens_cuda_runtime is not None else None}, host_context_lengths: {metadata.prompt_lens_cpu_runtime.shape if metadata.prompt_lens_cpu_runtime is not None else None}\
-              host_request_types: {metadata.host_request_types_runtime.shape if metadata.host_request_types_runtime is not None else None}, kv_cache_block_offsets: {metadata.kv_cache_block_offsets.shape if metadata.kv_cache_block_offsets is not None else None}\
-              host_kv_cache_block_offsets: {metadata.host_kv_cache_block_offsets.shape if metadata.host_kv_cache_block_offsets is not None else None}, host_kv_cache_pool_pointers: {metadata.host_kv_cache_pool_pointers.shape if metadata.host_kv_cache_pool_pointers is not None else None}\
-              host_kv_cache_pool_mapping: {metadata.host_kv_cache_pool_mapping.shape if metadata.host_kv_cache_pool_mapping is not None else None}, block_ids_per_seq: {metadata.block_ids_per_seq.shape if metadata.block_ids_per_seq is not None else None}\
-              workspace: {metadata.workspace.shape if metadata.workspace is not None else None}, cache_indirection: {metadata.cache_indirection.shape if metadata.cache_indirection is not None else None}, kv_scale_orig_quant: {self.kv_scale_orig_quant}\
-              kv_scale_quant_orig: {self.kv_scale_quant_orig}, out_scale: {out_scale.shape if out_scale is not None else None}, out_scale_sf: {out_scale_sf.shape if out_scale_sf is not None else None}\
-              latent_cache: {latent_cache.shape if latent_cache is not None else None}, q_pe: {q_pe.shape if q_pe is not None else None}, mrope_config: {mrope_config}, mla_context_paged_kv: {mla_context_paged_kv.shape if mla_context_paged_kv is not None else None}\
-              mla_context_kv_cache_block_offsets: {mla_context_kv_cache_block_offsets.shape if mla_context_kv_cache_block_offsets is not None else None}, softmax_stats_tensor: {softmax_stats_tensor.shape if softmax_stats_tensor is not None else None}\
-              is_spec_decoding_enabled: {metadata.is_spec_decoding_enabled}, use_spec_decoding: {metadata.use_spec_decoding}\
-              spec_decoding_position_offsets: {metadata.spec_decoding_position_offsets.shape if metadata.spec_decoding_position_offsets is not None else None}, spec_decoding_packed_mask: {metadata.spec_decoding_packed_mask.shape if metadata.spec_decoding_packed_mask is not None else None}\
-              spec_decoding_generation_lengths: {metadata.spec_decoding_generation_lengths}")
+        #print(f"[DEBUG] TrtllmAttention.forward wrapper.plan layer_idx: {self.get_local_layer_idx(metadata)}\
+        #      tokens_per_block: {metadata.tokens_per_block}, max_num_requests: {metadata.max_num_requests},\
+        #      max_seq_len: {metadata.max_seq_len}, max_num_tokens: {metadata.max_num_tokens}\
+        #      attention_window_size: {attention_window_size}, sink_token_length: {0}, beam_width: {metadata.beam_width}\
+        #      sequence_length: {metadata.kv_lens_cuda_runtime.shape if metadata.kv_lens_cuda_runtime is not None else None}, host_past_key_value_lengths: {metadata.kv_lens_runtime.shape if metadata.kv_lens_runtime is not None else None}\
+        #      context_lengths: {metadata.prompt_lens_cuda_runtime.shape if metadata.prompt_lens_cuda_runtime is not None else None}, host_context_lengths: {metadata.prompt_lens_cpu_runtime.shape if metadata.prompt_lens_cpu_runtime is not None else None}\
+        #      host_request_types: {metadata.host_request_types_runtime.shape if metadata.host_request_types_runtime is not None else None}, kv_cache_block_offsets: {metadata.kv_cache_block_offsets.shape if metadata.kv_cache_block_offsets is not None else None}\
+        #      host_kv_cache_block_offsets: {metadata.host_kv_cache_block_offsets.shape if metadata.host_kv_cache_block_offsets is not None else None}, host_kv_cache_pool_pointers: {metadata.host_kv_cache_pool_pointers.shape if metadata.host_kv_cache_pool_pointers is not None else None}\
+        #      host_kv_cache_pool_mapping: {metadata.host_kv_cache_pool_mapping.shape if metadata.host_kv_cache_pool_mapping is not None else None}, block_ids_per_seq: {metadata.block_ids_per_seq.shape if metadata.block_ids_per_seq is not None else None}\
+        #      workspace: {metadata.workspace.shape if metadata.workspace is not None else None}, cache_indirection: {metadata.cache_indirection.shape if metadata.cache_indirection is not None else None}, kv_scale_orig_quant: {self.kv_scale_orig_quant}\
+        #      kv_scale_quant_orig: {self.kv_scale_quant_orig}, out_scale: {out_scale.shape if out_scale is not None else None}, out_scale_sf: {out_scale_sf.shape if out_scale_sf is not None else None}\
+        #      latent_cache: {latent_cache.shape if latent_cache is not None else None}, q_pe: {q_pe.shape if q_pe is not None else None}, mrope_config: {mrope_config}, mla_context_paged_kv: {mla_context_paged_kv.shape if mla_context_paged_kv is not None else None}\
+        #      mla_context_kv_cache_block_offsets: {mla_context_kv_cache_block_offsets.shape if mla_context_kv_cache_block_offsets is not None else None}, softmax_stats_tensor: {softmax_stats_tensor.shape if softmax_stats_tensor is not None else None}\
+        #      is_spec_decoding_enabled: {metadata.is_spec_decoding_enabled}, use_spec_decoding: {metadata.use_spec_decoding}\
+        #      spec_decoding_position_offsets: {metadata.spec_decoding_position_offsets.shape if metadata.spec_decoding_position_offsets is not None else None}, spec_decoding_packed_mask: {metadata.spec_decoding_packed_mask.shape if metadata.spec_decoding_packed_mask is not None else None}\
+        #      spec_decoding_generation_lengths: {metadata.spec_decoding_generation_lengths}")
         self.wrapper.plan(
             layer_idx=self.get_local_layer_idx(metadata),
             tokens_per_block=metadata.tokens_per_block,
@@ -1227,7 +1227,7 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
                 # TODO(qijun): revisit fp8_context_fmha logic
                 out_dtype = torch.float8_e4m3fn
 
-        print(f"[DEBUG] TrtllmAttention.forward - About to call CUDA kernel with out_dtype: {out_dtype}")
+        #print(f"[DEBUG] TrtllmAttention.forward - About to call CUDA kernel with out_dtype: {out_dtype}")
         output, output_sf = self.wrapper.run(
             q,
             k,
@@ -1242,10 +1242,10 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
         if out_dtype == torch.uint8:
             assert output_sf is not None
             result = Fp4QuantizedTensor(output, output_sf)
-            print(f"[DEBUG] TrtllmAttention.forward - Returning Fp4QuantizedTensor with shape: {result.shape}")
+            #print(f"[DEBUG] TrtllmAttention.forward - Returning Fp4QuantizedTensor with shape: {result.shape}")
             return result
         
-        print(f"[DEBUG] TrtllmAttention.forward - Final output shape: {output.shape}, dtype: {output.dtype}")
+        #print(f"[DEBUG] TrtllmAttention.forward - Final output shape: {output.shape}, dtype: {output.dtype}")
         return output
 
     @classmethod

--- a/tensorrt_llm/_torch/distributed/ops.py
+++ b/tensorrt_llm/_torch/distributed/ops.py
@@ -183,7 +183,7 @@ def allgather(
                     print(f"[DEBUG] allgather - sizes[mapping.tp_rank]: {sizes[mapping.tp_rank]}")
             if os.environ.get("ENABLE_TRTLLM_SPLIT_BATCH_OVERLAP", "0") == "1":
                 assert all([
-                    val.shape[dim] == sizes[mapping.tp_rank] / 2 for val in input
+                    val.shape[dim] == sizes[mapping.tp_rank] / 2 or val.shape[dim] == sizes[mapping.tp_rank] for val in input
                     if val is not None
                 ])
             else:

--- a/tensorrt_llm/_torch/distributed/ops.py
+++ b/tensorrt_llm/_torch/distributed/ops.py
@@ -169,18 +169,19 @@ def allgather(
     if mapping.tp_size == 1:
         return input
 
-    print(f"[DEBUG] allgather - input shape: {mapping.tp_group}")
-    print(f"[DEBUG] allgather - input shape: {mapping}")
+    # print(f"[DEBUG] allgather - input shape: {mapping.tp_group}")
+    # print(f"[DEBUG] allgather - input shape: {mapping}")
+    # print(f"[DEBUG] allgather - sizes : {sizes}")
     if sizes is not None:
         assert len(sizes) == len(mapping.tp_group)
         if isinstance(input, torch.Tensor):
             assert input.shape[dim] == sizes[mapping.tp_rank]
         else:
-            for val in input:
-                if val is not None:
-                    print(f"[DEBUG] allgather - val shape: {val.shape}, dtype: {val.dtype}")
-                    print(f"[DEBUG] allgather - val shape: {val.shape[dim]}, dtype: {val.dtype}")
-                    print(f"[DEBUG] allgather - sizes[mapping.tp_rank]: {sizes[mapping.tp_rank]}")
+            #for val in input:
+            #    if val is not None:
+                    # print(f"[DEBUG] allgather - val shape: {val.shape}, dtype: {val.dtype}")
+                    # print(f"[DEBUG] allgather - val shape: {val.shape[dim]}, dtype: {val.dtype}")
+                    # print(f"[DEBUG] allgather - sizes[mapping.tp_rank]: {sizes[mapping.tp_rank]}")
             if os.environ.get("ENABLE_TRTLLM_SPLIT_BATCH_OVERLAP", "0") == "1":
                 assert all([
                     val.shape[dim] == sizes[mapping.tp_rank] / 2 or val.shape[dim] == sizes[mapping.tp_rank] for val in input
@@ -205,10 +206,10 @@ def allgather(
             val.contiguous().view(-1, val_info['numel_base'])
             for val, val_info in zip(input, output_info)
         ]
-    for val in input:
-        print(f"[DEBUG] allgather - input shape: {val.shape}")
-    for size in sizes:
-        print(f"[DEBUG] allgather - size: {size}")
+    #for val in input:
+    #    print(f"[DEBUG] allgather - input shape: {val.shape}")
+    #for size in sizes:
+    #    print(f"[DEBUG] allgather - size: {size}")
     output = torch_op(
         input,
         sizes,
@@ -562,7 +563,7 @@ class MoEAllReduce(nn.Module):
                 hidden_states: hidden_states of the model
                 residual: residual tensor
             """
-            print(f"[DEBUG] MoEAllReduce.forward - input shape: {input.shape}, dtype: {input.dtype}")
+            # print(f"[DEBUG] MoEAllReduce.forward - input shape: {input.shape}, dtype: {input.dtype}")
             return torch.ops.trtllm.moe_allreduce(
                 active_experts_token_input=input,
                 residual=all_reduce_params.residual,

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1278,7 +1278,7 @@ class MLA(nn.Module):
         else:
             raise NotImplementedError(
                 f"Missing bmm impl for dtype: {self.v_b_proj.dtype}.")
-
+        print(f"[DEBUG] MLA.forward_generation - output shape: {output.shape}, dtype: {output.dtype}")
         return output
 
     def forward(

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_wide_ep.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_wide_ep.py
@@ -709,7 +709,8 @@ class WideEPMoE(MoE):
         if self.layer_load_balancer and not self.layer_load_balancer.is_static_routing(
         ) and is_last_call:
             self.layer_load_balancer.maybe_cudagraph_done_set_cpu_stage()
-
+            
+        print(f"[DEBUG] FusedMoEWideEP.forward - final_hidden_states shape: {final_hidden_states.shape}, dtype: {final_hidden_states.dtype}")
         return final_hidden_states
 
     def forward(

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_wide_ep.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_wide_ep.py
@@ -365,6 +365,7 @@ class WideEPMoE(MoE):
             use_dp_padding: Optional[bool] = None,
             repeating_info: Tuple = (True, True),
     ) -> torch.Tensor:
+        print(f"[DEBUG] FusedMoEWideEP.forward_chunk - x shape: {x.shape}, dtype: {x.dtype}")
         if isinstance(x, Fp4QuantizedTensor):
             assert output_dtype is not None
             output_dtype = output_dtype
@@ -724,6 +725,7 @@ class WideEPMoE(MoE):
         assert all_rank_num_tokens is not None
         assert use_dp_padding is not None
 
+        print(f"[DEBUG] FusedMoEWideEP.forward - x shape: {x.shape}, dtype: {x.dtype}")
         # in case of num_rows is larger than max_chunk_size, we need to split the input into multiple chunks
         num_chunks = self.calculate_num_chunks(all_rank_num_tokens)
         use_all_to_all = self.can_use_alltoall(x, all_rank_num_tokens)

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_wide_ep.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_wide_ep.py
@@ -365,7 +365,7 @@ class WideEPMoE(MoE):
             use_dp_padding: Optional[bool] = None,
             repeating_info: Tuple = (True, True),
     ) -> torch.Tensor:
-        print(f"[DEBUG] FusedMoEWideEP.forward_chunk - x shape: {x.shape}, dtype: {x.dtype}")
+        # print(f"[DEBUG] FusedMoEWideEP.forward_chunk - x shape: {x.shape}, dtype: {x.dtype}")
         if isinstance(x, Fp4QuantizedTensor):
             assert output_dtype is not None
             output_dtype = output_dtype
@@ -710,7 +710,7 @@ class WideEPMoE(MoE):
         ) and is_last_call:
             self.layer_load_balancer.maybe_cudagraph_done_set_cpu_stage()
             
-        print(f"[DEBUG] FusedMoEWideEP.forward - final_hidden_states shape: {final_hidden_states.shape}, dtype: {final_hidden_states.dtype}")
+        # print(f"[DEBUG] FusedMoEWideEP.forward - final_hidden_states shape: {final_hidden_states.shape}, dtype: {final_hidden_states.dtype}")
         return final_hidden_states
 
     def forward(
@@ -726,7 +726,7 @@ class WideEPMoE(MoE):
         assert all_rank_num_tokens is not None
         assert use_dp_padding is not None
 
-        print(f"[DEBUG] FusedMoEWideEP.forward - x shape: {x.shape}, dtype: {x.dtype}")
+        # print(f"[DEBUG] FusedMoEWideEP.forward - x shape: {x.shape}, dtype: {x.dtype}")
         # in case of num_rows is larger than max_chunk_size, we need to split the input into multiple chunks
         num_chunks = self.calculate_num_chunks(all_rank_num_tokens)
         use_all_to_all = self.can_use_alltoall(x, all_rank_num_tokens)

--- a/tensorrt_llm/_torch/modules/multi_stream_utils.py
+++ b/tensorrt_llm/_torch/modules/multi_stream_utils.py
@@ -31,6 +31,7 @@ def maybe_execute_in_parallel(
     """
 
     do_multi_stream = is_graph_capturing() and aux_stream is not None
+    print(f"[DEBUG] maybe_execute_in_parallel - do_multi_stream: {do_multi_stream}")
 
     if do_multi_stream:
         event0.record()

--- a/tensorrt_llm/_torch/modules/multi_stream_utils.py
+++ b/tensorrt_llm/_torch/modules/multi_stream_utils.py
@@ -31,7 +31,7 @@ def maybe_execute_in_parallel(
     """
 
     do_multi_stream = is_graph_capturing() and aux_stream is not None
-    print(f"[DEBUG] maybe_execute_in_parallel - do_multi_stream: {do_multi_stream}")
+    # print(f"[DEBUG] maybe_execute_in_parallel - do_multi_stream: {do_multi_stream}")
 
     if do_multi_stream:
         event0.record()

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1444,14 +1444,13 @@ class PyTorchModelEngine(ModelEngine):
         
         attn_metadata_half1 = None
         attn_metadata_half2 = None
-        if attn_metadata.num_contexts == 0 and len(attn_metadata.request_ids) == 64:
+        if attn_metadata.num_contexts == 0 and len(attn_metadata.request_ids) == 64 and os.environ.get("ENABLE_TRTLLM_SPLIT_BATCH_OVERLAP") == "1":
+            print(f"[DEBUG] TrtllmAttention.prepare - {attn_metadata}")
             attn_metadata_half1 = copy.copy(attn_metadata)
             attn_metadata_half1.max_num_requests = 32
             attn_metadata_half1.max_num_sequences = 32
-            attn_metadata_half1.all_rank_num_tokens = [32, 32]
-            attn_metadata_half1.all_rank_max_num_tokens = 32
             attn_metadata_half1.kv_cache_manager = copy.copy(attn_metadata.kv_cache_manager)
-            attn_metadata_half1.kv_cache_manager.kv_cache_pool_pointers = attn_metadata.kv_cache_manager.kv_cache_pool_pointers[:32]
+            #attn_metadata_half1.kv_cache_manager.kv_cache_pool_pointers = attn_metadata.kv_cache_manager.kv_cache_pool_pointers[:32]
             attn_metadata_half1.kv_cache_manager.tokens_per_block = 32  
             attn_metadata_half1.kv_cache_block_offsets = attn_metadata.kv_cache_block_offsets[:,:32,:,:]
             attn_metadata_half1.host_kv_cache_block_offsets = attn_metadata.host_kv_cache_block_offsets[:,:32,:,:]
@@ -1469,10 +1468,8 @@ class PyTorchModelEngine(ModelEngine):
             attn_metadata_half2 = copy.copy(attn_metadata)
             attn_metadata_half2.max_num_requests = 32
             attn_metadata_half2.max_num_sequences = 32
-            attn_metadata_half2.all_rank_num_tokens = [32, 32]
-            attn_metadata_half2.all_rank_max_num_tokens = 32
             attn_metadata_half2.kv_cache_manager = copy.copy(attn_metadata.kv_cache_manager)
-            attn_metadata_half2.kv_cache_manager.kv_cache_pool_pointers = attn_metadata.kv_cache_manager.kv_cache_pool_pointers[32:]
+            #attn_metadata_half2.kv_cache_manager.kv_cache_pool_pointers = attn_metadata.kv_cache_manager.kv_cache_pool_pointers[32:]
             attn_metadata_half2.kv_cache_manager.tokens_per_block = 32
             attn_metadata_half2.kv_cache_block_offsets = attn_metadata.kv_cache_block_offsets[:,32:,:,:]
             attn_metadata_half2.host_kv_cache_block_offsets = attn_metadata.host_kv_cache_block_offsets[:,32:,:,:]

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -59,7 +59,16 @@ from .utils import generate_api_docs_as_docstring, get_type_repr
 
 # TODO[chunweiy]: move the following symbols back to utils scope, and remove the following import
 
-
+class SplitBatchAttnMoeOverlapConfig(BaseModel):
+    """
+    Configuration for split batch attention and MoE overlap.
+        Baseline batch_size = 2N |Attention|MOE||Attention|MOE| 
+        Split batch_size = N |Attention|MOE|           |Attention|MOE|
+                         = N           |Attention|MOE|           |Attention|MOE|
+    """
+    enable_split_batch_attn_moe_overlap: bool = Field(default=False, description="Enable split batch attention.")
+    split_batch_size: int = Field(default=0, description="Split batch size.")
+    
 class CudaGraphConfig(BaseModel):
     """
     Configuration for CUDA graphs.


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added optional split-batch attention/MoE overlap mode controlled by runtime flags to enable parallel processing of batch halves.
  * Introduced configuration options to toggle the feature and set split batch size.
  * Provided a new benchmarking script to generate datasets, configure runs, and profile multiple overlap modes.

* Chores
  * Added extensive runtime debug logging across attention, decoder, MoE, and execution paths to aid troubleshooting.
  * Relaxed an internal shape assertion under the new mode to support half-batch paths without affecting default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up
-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
