### PR TITLE
[None][fix] Fix 6522 mpi.pkl5.intracomm.Request has wait not Wait

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -794,7 +794,7 @@ class PyExecutor:
                     # Second last rank does not need to since last rank has original decoded tokens
                     if not self.dist.is_second_last_pp_rank:
                         if self.send_handles[prev_microbatch_id] is not None:
-                            self.send_handles[prev_microbatch_id].Wait()
+                            self.send_handles[prev_microbatch_id].wait()
                         needs_logits = (
                             self._need_return_logits(scheduled_batch)
                             or (self._need_return_log_probs(scheduled_batch)


### PR DESCRIPTION
Bug introduced: https://github.com/NVIDIA/TensorRT-LLM/pull/6522
Correct `wait`: https://mpi4py.readthedocs.io/en/stable/mpi4py.util.pkl5.html#mpi4py.util.pkl5.Request.wait
Previously correct `Wait`: https://mpi4py.readthedocs.io/en/stable/reference/mpi4py.MPI.Request.html#mpi4py.MPI.Request.Wait

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a synchronization call to ensure proper handling of CUDA send operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->