### PR TITLE
[https://nvbugs/5433581][fix] Revert deep_gemm installation workaround for SBSA

### DIFF
--- a/docs/source/installation/linux.md
+++ b/docs/source/installation/linux.md
@@ -16,11 +16,6 @@
    # Optional step: Only required for NVIDIA Blackwell GPUs and SBSA platform
    pip3 install torch==2.7.1 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128
 
-   # Optional step: Workaround for deep_gemm installation failure on SBSA platform
-   # The actual deep_gemm package and version should be obtained from the requirements.txt file.
-   pip3 install 'deep_gemm @ git+https://github.com/zongfeijing/DeepGEMM.git@a9d538ef4dff0326fe521c6ca0bfde115703b56a' \
-       --extra-index-url https://download.pytorch.org/whl/cu128
-
    sudo apt-get -y install libopenmpi-dev
    ```
 

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -2106,18 +2106,6 @@ def launchTestJobs(pipeline, testFilter, dockerNode=null)
                             trtllm_utils.llmExecStepWithRetry(pipeline, script: "pip3 install torch==2.7.1 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128")
                         }
 
-                        // Workaround for https://nvbugs/5433581 where deep_gemm installation fails on SBSA platform
-                        if (cpu_arch == AARCH64_TRIPLE) {
-                              echo "###### Workaround for https://nvbugs/5433581 Start ######"
-                              def deepGemmLine = readFile("${LLM_ROOT}/requirements.txt").readLines().find { it.trim().startsWith('deep_gemm') }
-                              if (deepGemmLine) {
-                                  trtllm_utils.llmExecStepWithRetry(pipeline, script: "pip3 install '${deepGemmLine.trim()}' --extra-index-url https://download.pytorch.org/whl/cu128")
-                              }
-                              else {
-                                echo "deep_gemm package not found in requirements.txt"
-                              }
-                        }
-
                         def libEnv = []
                         if (env.alternativeTRT) {
                             stage("Replace TensorRT") {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Linux installation instructions by removing the optional workaround step for installing the deep_gemm package on SBSA platforms.

* **Chores**
  * Removed the SBSA-specific workaround for deep_gemm installation from the testing pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->