### PR TITLE
[TRTLLM-5532][feat] store the block of context request into kv cache

### DIFF
--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -2127,24 +2127,24 @@ void KVCacheManager::addSequence(
 void KVCacheManager::storeContextBlocks(LlmRequest const& llmRequest)
 {
     auto const requestId = llmRequest.mRequestId;
-    auto& sequence = getSequence(requestId);
-    if (mEnableBlockReuse && !sequence.isCyclic() && !llmRequest.isDummyRequest())
+    if (mSequences.find(requestId) != mSequences.end())
     {
-        mBlockManager.storeContextBlocks(sequence, llmRequest);
+        auto& sequence = getSequence(requestId);
+        if (mEnableBlockReuse && !sequence.isCyclic() && !llmRequest.isDummyRequest())
+        {
+            mBlockManager.storeContextBlocks(sequence, llmRequest);
+        }
     }
 }
 
 void KVCacheManager::storeNewBlock(LlmRequest const& llmRequest)
 {
     auto const requestId = llmRequest.mRequestId;
-    if (mSequences.find(requestId) != mSequences.end())
+    auto& sequence = getSequence(requestId);
+    bool const storeBlocksForReuse = sequence.getBeamWidth() == 1 && !sequence.isCyclic();
+    if (mEnableBlockReuse && storeBlocksForReuse)
     {
-        auto& sequence = getSequence(requestId);
-        bool const storeBlocksForReuse = sequence.getBeamWidth() == 1 && !sequence.isCyclic();
-        if (mEnableBlockReuse && storeBlocksForReuse)
-        {
-            mBlockManager.storeNewBlock(sequence, llmRequest);
-        }
+        mBlockManager.storeNewBlock(sequence, llmRequest);
     }
 }
 

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -2137,11 +2137,14 @@ void KVCacheManager::storeContextBlocks(LlmRequest const& llmRequest)
 void KVCacheManager::storeNewBlock(LlmRequest const& llmRequest)
 {
     auto const requestId = llmRequest.mRequestId;
-    auto& sequence = getSequence(requestId);
-    bool const storeBlocksForReuse = sequence.getBeamWidth() == 1 && !sequence.isCyclic();
-    if (mEnableBlockReuse && storeBlocksForReuse)
+    if (mSequences.find(requestId) != mSequences.end())
     {
-        mBlockManager.storeNewBlock(sequence, llmRequest);
+        auto& sequence = getSequence(requestId);
+        bool const storeBlocksForReuse = sequence.getBeamWidth() == 1 && !sequence.isCyclic();
+        if (mEnableBlockReuse && storeBlocksForReuse)
+        {
+            mBlockManager.storeNewBlock(sequence, llmRequest);
+        }
     }
 }
 

--- a/cpp/tensorrt_llm/pybind/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/kvCacheManager.cpp
@@ -102,6 +102,12 @@ public:
             void, tbk::BaseKVCacheManager, addSequence, requestId, inputLength, beamWidth, llmRequest);
     }
 
+    void storeNewBlock(tb::LlmRequest const& llmRequest) override
+    {
+        TLLM_LOG_INFO("%s start", __PRETTY_FUNCTION__);
+        PYBIND11_OVERLOAD_PURE(void, tbk::BaseKVCacheManager, storeNewBlock, llmRequest);
+    }
+
     void removeSequence(tb::LlmRequest::RequestIdType requestId,
         tensorrt_llm::common::OptionalRef<tb::LlmRequest const> llmRequest = std::nullopt) override
     {
@@ -344,6 +350,7 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(py::module_& m)
         .def("add_token", &BaseKVCacheManager::addToken)
         .def("add_sequence", &BaseKVCacheManager::addSequence)
         .def("remove_sequence", &BaseKVCacheManager::removeSequence)
+        .def("store_new_block", &BaseKVCacheManager::storeNewBlock)
         .def("scheduling_remove_sequence", &BaseKVCacheManager::schedulingRemoveSequence)
         .def("get_block_pool_pointers",
             [](tbk::BaseKVCacheManager& self)

--- a/cpp/tensorrt_llm/pybind/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/kvCacheManager.cpp
@@ -102,12 +102,6 @@ public:
             void, tbk::BaseKVCacheManager, addSequence, requestId, inputLength, beamWidth, llmRequest);
     }
 
-    void storeNewBlock(tb::LlmRequest const& llmRequest) override
-    {
-        TLLM_LOG_INFO("%s start", __PRETTY_FUNCTION__);
-        PYBIND11_OVERLOAD_PURE(void, tbk::BaseKVCacheManager, storeNewBlock, llmRequest);
-    }
-
     void removeSequence(tb::LlmRequest::RequestIdType requestId,
         tensorrt_llm::common::OptionalRef<tb::LlmRequest const> llmRequest = std::nullopt) override
     {
@@ -350,7 +344,6 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(py::module_& m)
         .def("add_token", &BaseKVCacheManager::addToken)
         .def("add_sequence", &BaseKVCacheManager::addSequence)
         .def("remove_sequence", &BaseKVCacheManager::removeSequence)
-        .def("store_new_block", &BaseKVCacheManager::storeNewBlock)
         .def("scheduling_remove_sequence", &BaseKVCacheManager::schedulingRemoveSequence)
         .def("get_block_pool_pointers",
             [](tbk::BaseKVCacheManager& self)

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -463,7 +463,7 @@ class KVCacheManager(BaseResourceManager):
 
         # For context requests, we store the blocks for reuse.
         for request in scheduled_batch.context_requests:
-            self.impl.store_new_block(request)
+            self.impl.store_context_blocks(request)
 
     def free_resources(self, request: LlmRequest):
         self.impl.remove_sequence(request.py_request_id, request)

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -461,6 +461,10 @@ class KVCacheManager(BaseResourceManager):
                 if request.py_rewind_len > 0:
                     self.rewind_kv_cache(request, request.py_rewind_len)
 
+        # For context requests, we store the blocks for reuse.
+        for request in scheduled_batch.context_requests:
+            self.impl.store_new_block(request)
+
     def free_resources(self, request: LlmRequest):
         self.impl.remove_sequence(request.py_request_id, request)
 


### PR DESCRIPTION
When I run the forward with 5 same requests with input length 4096, output length 10, the original iteration logs are like 
```bash
[08/07/2025-02:28:51] [TRT-LLM] [I] iter = 5, global_rank = 0, rank = 0, currank_total_requests = 0/0, elapsed_time = 0.0823206901550293s, timestamp = 2025-08-07 02:28:51, num_scheduled_requests: 1, states = {'num_ctx_requests': 1, 'num_ctx_tokens': 4096, 'num_generation_tokens': 0}
[08/07/2025-02:28:52] [TRT-LLM] [I] iter = 6, global_rank = 0, rank = 0, currank_total_requests = 0/0, elapsed_time = 0.09875988960266113s, timestamp = 2025-08-07 02:28:52, num_scheduled_requests: 2, states = {'num_ctx_requests': 1, 'num_ctx_tokens': 4096, 'num_generation_tokens': 1}
[08/07/2025-02:28:52] [TRT-LLM] [I] iter = 7, global_rank = 0, rank = 0, currank_total_requests = 0/0, elapsed_time = 0.0669400691986084s, timestamp = 2025-08-07 02:28:52, num_scheduled_requests: 3, states = {'num_ctx_requests': 1, 'num_ctx_tokens': 4096, 'num_generation_tokens': 2}
[08/07/2025-02:28:52] [TRT-LLM] [I] iter = 8, global_rank = 0, rank = 0, currank_total_requests = 0/0, elapsed_time = 0.09499597549438477s, timestamp = 2025-08-07 02:28:52, num_scheduled_requests: 4, states = {'num_ctx_requests': 1, 'num_ctx_tokens': 4096, 'num_generation_tokens': 3}
[08/07/2025-02:28:52] [TRT-LLM] [I] iter = 9, global_rank = 0, rank = 0, currank_total_requests = 0/0, elapsed_time = 0.09572505950927734s, timestamp = 2025-08-07 02:28:52, num_scheduled_requests: 5, states = {'num_ctx_requests': 1, 'num_ctx_tokens': 4096, 'num_generation_tokens': 4}
```

I observe that the last four sentences cannot reuse the cache of the first sentence. So, I update the kv cache of context request after the forward and the new iteration logs become

```bash
[08/07/2025-02:42:29] [TRT-LLM] [I] iter = 4, global_rank = 0, rank = 0, currank_total_requests = 0/0, elapsed_time = 0.3997073173522949s, timestamp = 2025-08-07 02:42:29, num_scheduled_requests: 1, states = {'num_ctx_requests': 1, 'num_ctx_tokens': 4096, 'num_generation_tokens': 0}
[08/07/2025-02:42:29] [TRT-LLM] [I] iter = 5, global_rank = 0, rank = 0, currank_total_requests = 0/0, elapsed_time = 0.048545122146606445s, timestamp = 2025-08-07 02:42:29, num_scheduled_requests: 2, states = {'num_ctx_requests': 1, 'num_ctx_tokens': 1, 'num_generation_tokens': 1}
[08/07/2025-02:42:29] [TRT-LLM] [I] iter = 6, global_rank = 0, rank = 0, currank_total_requests = 0/0, elapsed_time = 0.0420839786529541s, timestamp = 2025-08-07 02:42:29, num_scheduled_requests: 3, states = {'num_ctx_requests': 1, 'num_ctx_tokens': 1, 'num_generation_tokens': 2}
[08/07/2025-02:42:29] [TRT-LLM] [I] iter = 7, global_rank = 0, rank = 0, currank_total_requests = 0/0, elapsed_time = 0.041689395904541016s, timestamp = 2025-08-07 02:42:29, num_scheduled_requests: 4, states = {'num_ctx_requests': 1, 'num_ctx_tokens': 1, 'num_generation_tokens': 3}
[08/07/2025-02:42:29] [TRT-LLM] [I] iter = 8, global_rank = 0, rank = 0, currank_total_requests = 0/0, elapsed_time = 0.04293417930603027s, timestamp = 2025-08-07 02:42:29, num_scheduled_requests: 5, states = {'num_ctx_requests': 1, 'num_ctx_tokens': 1, 'num_generation_tokens': 4}
```

which reuse the kv cache of first sentence as we expect. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling to prevent accessing non-existent sequences when storing context blocks, enhancing stability.

* **New Features**
  * Extended resource updates to process context requests, ensuring context blocks are stored for each relevant request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->