### PR TITLE
[https://nvbugs/5410687][fix] Hopper w4a8 groupwise MoE interleave

### DIFF
--- a/tensorrt_llm/quantization/functional.py
+++ b/tensorrt_llm/quantization/functional.py
@@ -1063,7 +1063,7 @@ def get_weight_scale_interleave_factor(interleaved_dim: int,
             factor = 1
         else:
             raise NotImplementedError(
-                f"Group dimension is required to be multiple of 128, received {interleaved_dim}."
+                f"Interleaved dimension must be a multiple of group_size ({group_size}), received {interleaved_dim}."
             )
     return factor
 

--- a/tests/unittest/trt/quantization/test_moe_weight_only_groupwise_quant_matmul.py
+++ b/tests/unittest/trt/quantization/test_moe_weight_only_groupwise_quant_matmul.py
@@ -14,19 +14,22 @@
 # limitations under the License.
 import unittest
 
+import pytest
+
 # isort: off
 import torch
 # isort: on
 
 from parameterized import parameterized
-from utils.util import (create_session, run_session, skip_non_ada_unittest,
+from utils.util import (create_session, run_session,
+                        skip_neither_ada_nor_hopper_unittest,
                         unittest_name_func)
 
 import tensorrt_llm
 import tensorrt_llm.quantization.functional
 from tensorrt_llm import Tensor
-from tensorrt_llm._utils import (str_dtype_to_trt, torch_to_numpy,
-                                 trt_dtype_to_str)
+from tensorrt_llm._utils import (get_sm_version, str_dtype_to_trt,
+                                 torch_to_numpy, trt_dtype_to_str)
 from tensorrt_llm.layers.moe import MoeConfig
 from tensorrt_llm.quantization import QuantMode
 
@@ -66,7 +69,8 @@ class TestMoEWeightOnlyGroupWiseQuantMatmul(unittest.TestCase):
         norm_mode = MoeConfig.ExpertScaleNormalizationMode.RENORMALIZE
         quant_mode = QuantMode.use_weight_only(True, True)
         k = act.shape[1]
-        n = weight_scaling_factor_1.shape[-1] // 2
+        n = fc2_prequant_scale.shape[
+            -1]  # get the original n from prequant scale because either weight or scale could be interleaved
         num_experts = weight_scaling_factor_1.shape[0]
 
         with tensorrt_llm.net_guard(network):
@@ -202,17 +206,49 @@ class TestMoEWeightOnlyGroupWiseQuantMatmul(unittest.TestCase):
             ref_weight_1 += zero_1.repeat_interleave(group_size, dim=1)
             ref_weight_2 += zero_2.repeat_interleave(group_size, dim=1)
         activation_type = torch.float8_e4m3fn if has_alpha else activation_dtype
+        do_weight_interleave = get_sm_version(
+        ) != 90 or not has_alpha  # Hopper w4a8 does not interleave weight
         cuda_q_weight_1 = preprocessor(
-            unprocessed_weight_1.cpu(), quantized_weight_dtype,
-            activation_type).view(activation_dtype).cpu()
+            unprocessed_weight_1.cpu(),
+            quantized_weight_dtype,
+            activation_type,
+            do_weight_interleave=do_weight_interleave).view(
+                activation_dtype).cpu()
         cuda_q_weight_2 = preprocessor(
-            unprocessed_weight_2.cpu(), quantized_weight_dtype,
-            activation_type).view(activation_dtype).cpu()
-        if has_alpha and activation_dtype == torch.bfloat16:
+            unprocessed_weight_2.cpu(),
+            quantized_weight_dtype,
+            activation_type,
+            do_weight_interleave=do_weight_interleave).view(
+                activation_dtype).cpu()
+        if get_sm_version() == 89 and has_alpha:
             scale_1 = scale_1.to(torch.float16).view(activation_dtype)
             scale_2 = scale_2.to(torch.float16).view(activation_dtype)
             zero_1 = zero_1.to(torch.float16).view(activation_dtype)
             zero_2 = zero_2.to(torch.float16).view(activation_dtype)
+
+        if get_sm_version() == 90 and has_alpha:
+            if has_zero:
+                pytest.skip(
+                    "has_zero is not supported in Hopper with WINT4AFP8.")
+
+            def interleave_scales(scales: torch.Tensor, interleave_dim: int):
+                # [num_experts, num_groups, num_cols] --> [num_experts, num_groups // interleave, num_cols * interleave]
+                # Note: num_groups = num_rows // group_size
+                E, G, C = scales.shape
+                I = tensorrt_llm.quantization.functional.get_weight_scale_interleave_factor(
+                    interleave_dim, group_size)
+                assert G % I == 0, f"Group dimension ({G}) must be divisible by interleave factor ({I})."
+                scales_interleaved = scales.reshape(E, G // I, I, C)
+                scales_interleaved = scales_interleaved.permute(0, 1, 3, 2)
+                scales_interleaved = scales_interleaved.reshape(
+                    E, G // I, C * I)
+                return scales_interleaved.contiguous()
+
+            scale_1 = scale_1.to(torch.bfloat16).view(activation_dtype)
+            scale_2 = scale_2.to(torch.bfloat16).view(activation_dtype)
+            scale_1 = interleave_scales(scale_1, k)
+            scale_2 = interleave_scales(scale_2, n)
+            zero_1, zero_2 = None, None
 
         session = self.create_trt_session(
             activation_dtype_str, activation, router, pre_quant_scale_1,
@@ -278,7 +314,7 @@ class TestMoEWeightOnlyGroupWiseQuantMatmul(unittest.TestCase):
                            (1, 14336, 4096, 8, "bfloat16", True, False),
                            (1, 14336, 4096, 8, "bfloat16", True, True)],
                           name_func=unittest_name_func)
-    @skip_non_ada_unittest
+    @skip_neither_ada_nor_hopper_unittest
     def test_moe_w4a8(self, m, n, k, experts, dtype, has_pre_quant, has_zero):
 
         self._woq_moe_groupwise_matmul(m, n, k, experts, dtype, torch.quint4x2,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced support for Hopper (SM 90) GPU architecture in quantization and MoE groupwise weight handling.
  * Added architecture-specific processing for weight scale interleaving in quantization workflows.

* **Bug Fixes**
  * Improved test logic to correctly handle and skip tests based on GPU architecture, ensuring accurate test coverage.

* **Tests**
  * Updated and expanded test cases to differentiate behavior between Ada and Hopper GPUs, including new logic for interleaved scale tensors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up
-->

## Description

MoE w4a8 (wINT4aFP8) groupwise quant status before this PR:
PyT path - support both Ada and Hopper
TRT path - kernels exist, but requires preprocessing on weights & scales. On Ada, it's supported; On Hopper, preprocessing is missing

After this PR:
TRT path supports w4a8 groupwise MoE quant on both Ada and Hopper. Hopper usage is demostrated with the provided unit test case. NOT added into E2E TRT run because PyT path is the recommended path for users.

Using PyT path to explain what preprocessing is needed:
On Ada: int4 weight preproc logic [here](https://github.com/NVIDIA/TensorRT-LLM/blob/69e9f6d48944b2ae0124ff57aa59340aa4dfae15/tensorrt_llm/_torch/modules/fused_moe/quantization.py#L674-L686) (interleave), scale preproc logic [here](https://github.com/NVIDIA/TensorRT-LLM/blob/69e9f6d48944b2ae0124ff57aa59340aa4dfae15/tensorrt_llm/_torch/modules/fused_moe/quantization.py#L754) (FP16 w/o interleave)
On Hopper: int4 weight preproc (None, no interleave), scale preproc logic (BF16 w/ interleave. calc interleave factor [here](https://github.com/NVIDIA/TensorRT-LLM/blob/69e9f6d48944b2ae0124ff57aa59340aa4dfae15/tensorrt_llm/_torch/modules/fused_moe/quantization.py#L555-L569) + dtype cast and do interleave [here](https://github.com/NVIDIA/TensorRT-LLM/blob/69e9f6d48944b2ae0124ff57aa59340aa4dfae15/tensorrt_llm/_torch/modules/fused_moe/quantization.py#L756-L767))

Solution: interleave weight_scale for Hopper path + disable weight interleave for Hopper path (but still need the subbyte transpose) + change in MoE layer definition to take the interleave factor into account. 

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
