### PR TITLE
[None][chore] always try-catch when clear build folder in build_wheel.py

### DIFF
--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -68,13 +68,13 @@ def get_build_dir(build_dir, build_type):
 def clear_folder(folder_path):
     for item in os.listdir(folder_path):
         item_path = os.path.join(folder_path, item)
-        if os.path.isdir(item_path) and not os.path.islink(item_path):
-            rmtree(item_path)
-        else:
-            try:
+        try:
+            if os.path.isdir(item_path) and not os.path.islink(item_path):
+                rmtree(item_path)
+            else:
                 os.remove(item_path)
-            except (OSError, IOError) as e:
-                print(f"Failed to remove {item_path}: {e}", file=sys.stderr)
+        except (OSError, IOError) as e:
+            print(f"Failed to remove {item_path}: {e}", file=sys.stderr)
 
 
 def sysconfig_scheme(override_vars=None):


### PR DESCRIPTION
Previously the build will stop if there is any mounted directory under `cpp/build/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when clearing folders to ensure both files and directories are safely removed, reducing the chance of unhandled errors during the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->