### PR TITLE
[TRTLLM-6633][feat] Padding for piecewise cudagraph

### DIFF
--- a/cpp/tensorrt_llm/thop/mlaPreprocessOp.cpp
+++ b/cpp/tensorrt_llm/thop/mlaPreprocessOp.cpp
@@ -565,7 +565,7 @@ TORCH_LIBRARY_FRAGMENT(trtllm, m)
 {
     m.def(
         "merge_chunked_attention_for_mla("
-        "Tensor merged_attn"
+        "Tensor(a!) merged_attn"
         ", Tensor temp_attn"
         ", Tensor merged_softmax_stats"
         ", Tensor temp_softmax_stats"

--- a/tensorrt_llm/_torch/attention_backend/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/interface.py
@@ -135,6 +135,9 @@ class AttentionMetadata:
     _num_ctx_tokens: int = field(init=False, default=0, repr=False)
     _num_tokens: int = field(init=False, default=0, repr=False)
 
+    # The number of tokens in the padded sequence.
+    padded_num_tokens: Optional[int] = None
+
     # This buffer is currently only used for TrtllmAttentionMetadata.
     cache_indirection: Optional[torch.Tensor] = None
 

--- a/tensorrt_llm/_torch/compilation/backend.py
+++ b/tensorrt_llm/_torch/compilation/backend.py
@@ -48,7 +48,7 @@ class Backend:
         self.custom_passes = Backend.get_custom_pass(enable_userbuffers)
         self.rank = tensorrt_llm.mpi_rank()
         self.enable_inductor = enable_inductor
-        self.capture_num_tokens = capture_num_tokens or []
+        self.capture_num_tokens = sorted(capture_num_tokens or [])
         self.piecewise_cuda_graph = enable_piecewise_cuda_graph
         self.no_optimization = False
         # We only need to create aux streams.

--- a/tensorrt_llm/_torch/compilation/piecewise_optimizer.py
+++ b/tensorrt_llm/_torch/compilation/piecewise_optimizer.py
@@ -11,8 +11,9 @@ from torch.fx.passes.split_module import split_module
 
 from tensorrt_llm.llmapi.utils import enable_llm_debug
 
-from ..utils import (get_model_extra_attrs, get_piecewise_cuda_graph_flag,
-                     make_weak_ref)
+from ..utils import (get_model_extra_attrs,
+                     get_per_request_piecewise_cuda_graph_flag,
+                     get_piecewise_cuda_graph_flag, make_weak_ref)
 from .multi_stream.auto_multi_stream import multi_stream_schedule
 from .utils import get_capture_piecewise_cuda_graph_flag, is_call_function
 
@@ -154,8 +155,10 @@ class PiecewiseRunner(object):
         elif isinstance(self.compile_time_num_tokens, int):
             runtime_num_of_token = self.compile_time_num_tokens
 
-        if runtime_num_of_token is None or runtime_num_of_token not in self.entries or not get_piecewise_cuda_graph_flag(
-        ):
+        if (runtime_num_of_token is None
+                or runtime_num_of_token not in self.entries
+                or not get_piecewise_cuda_graph_flag()
+                or not get_per_request_piecewise_cuda_graph_flag()):
             return self.default_callable(*args)
 
         entry = self.entries[runtime_num_of_token]

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -338,6 +338,19 @@ class Attention(nn.Module):
         attention_sinks: Optional[torch.Tensor] = None,
     ):
 
+        padded_num_tokens = attn_metadata.padded_num_tokens
+        num_tokens = attn_metadata.num_tokens
+
+        if padded_num_tokens is not None:
+            assert q.shape[0] == padded_num_tokens
+            q = q[:num_tokens, :]
+            if k is not None:
+                assert k.shape[0] == padded_num_tokens
+                k = k[:num_tokens, :]
+            if v is not None:
+                assert v.shape[0] == padded_num_tokens
+                v = v[:num_tokens, :]
+
         out_scale = None
         out_scale_sf = None
         has_quant_scale = (self.o_proj.has_fp8_qdq or self.o_proj.has_nvfp4
@@ -368,7 +381,7 @@ class Attention(nn.Module):
             attention_window_size=attention_window_size,
             attention_mask_data=attention_mask_data,
             enable_attn_nvfp4_output=enable_attn_nvfp4_output,
-            output=output,
+            output=output[:num_tokens, :] if output is not None else None,
             output_sf=output_sf,
             attention_sinks=attention_sinks)
         if isinstance(attn_output, tuple):
@@ -936,11 +949,10 @@ class MLA(nn.Module):
         return hidden_states.new_empty([num_tokens, hidden_size],
                                        dtype=hidden_states.dtype)
 
-    def forward_impl(self,
-                     position_ids: Optional[torch.Tensor],
+    def forward_impl(self, position_ids: Optional[torch.Tensor],
                      hidden_states: torch.Tensor,
                      attn_metadata: AttentionMetadata,
-                     output: Optional[torch.Tensor] = None) -> torch.Tensor:
+                     output: torch.Tensor) -> None:
         """
         Forward pass for the MLA module.
 
@@ -953,6 +965,18 @@ class MLA(nn.Module):
         Returns:
             torch.Tensor: The output tensor.
         """
+        # split q, k, v into context and gen batches
+        num_contexts = attn_metadata.num_contexts
+        num_generations = attn_metadata.num_generations
+        num_ctx_tokens = attn_metadata.num_ctx_tokens
+        num_tokens = attn_metadata.num_tokens
+        padded_num_tokens = attn_metadata.padded_num_tokens
+
+        if padded_num_tokens is not None:
+            hidden_states = hidden_states[:num_tokens, ...]
+            if position_ids is not None:
+                position_ids = position_ids[:num_tokens, ...]
+
         if self.is_lite:
             compressed_kv, k_pe = self.kv_a_proj_with_mqa(hidden_states).split(
                 [self.kv_lora_rank, self.qk_rope_head_dim], -1)
@@ -980,14 +1004,10 @@ class MLA(nn.Module):
             self.aux_stream,
         )
 
-        # split q, k, v into context and gen batches
-        num_contexts = attn_metadata.num_contexts
-        num_generations = attn_metadata.num_generations
-        num_ctx_tokens = attn_metadata.num_ctx_tokens
-        num_tokens = attn_metadata.num_tokens
-
         assert q.shape[
             0] == num_tokens, f"Expect q.shape[0] to be {num_tokens}, but got {q.shape[0]}"
+
+        assert output is not None, "output must be provided"
 
         if num_contexts > 0:
             q_ctx = q[:num_ctx_tokens, ...]
@@ -998,17 +1018,14 @@ class MLA(nn.Module):
                 assert position_ids is not None
                 k_pe_ctx = self.apply_rope(q_ctx, k_pe_ctx, position_ids)
 
-            attn_output_context = self.forward_context(
+            self.forward_context(
                 q_ctx,
                 compressed_kv_ctx,
                 k_pe_ctx,
                 attn_metadata,
+                output[:num_ctx_tokens, :],
                 latent_cache_ctx,
-                output=output if num_generations == 0 else None)
-            if num_generations == 0:
-                return attn_output_context
-        else:
-            attn_output_context = None
+            )
 
         if num_generations > 0:
             q_gen = q[num_ctx_tokens:, ...]
@@ -1019,48 +1036,24 @@ class MLA(nn.Module):
                 assert position_ids is not None
                 k_pe_gen = self.apply_rope(q_gen, k_pe_gen, position_ids)
 
-            attn_output_gen = self.forward_generation(
+            self.forward_generation(
                 q_gen,
                 compressed_kv_gen,
                 k_pe_gen,
                 attn_metadata,
+                output[num_ctx_tokens:num_tokens, :],
                 latent_cache_gen,
-                output=output if num_contexts == 0 else None)
-            if num_contexts == 0:
-                return attn_output_gen
-        else:
-            attn_output_gen = None
-
-        # release pytorch activation memory
-        q = None
-        compressed_kv = None
-        k_pe = None
-
-        assert attn_output_context is not None and attn_output_gen is not None
-        assert (
-            len(attn_output_context.shape) == 2
-        ), f"attn_output_context must be rank 2, not {len(attn_output_context.shape)}"
-        assert (
-            len(attn_output_gen.shape) == 2
-        ), f"attn_output_gen must be rank 2, not {len(attn_output_gen.shape)}"
-        output = output if output is not None else torch.empty(
-            (num_tokens, attn_output_context.shape[1]),
-            dtype=attn_output_context.dtype,
-            device=attn_output_context.device)
-        output[:attn_output_context.shape[0], :] = attn_output_context
-        output[attn_output_context.shape[0]:, :] = attn_output_gen
-        attn_output_context = None
-        attn_output_gen = None
-        return output
+            )
 
     def forward_context_default(
-            self,
-            q: torch.Tensor,
-            compressed_kv: torch.Tensor,
-            k_pe: torch.Tensor,
-            attn_metadata: AttentionMetadata,
-            latent_cache: Optional[torch.Tensor] = None,
-            output: Optional[torch.Tensor] = None) -> torch.Tensor:
+        self,
+        q: torch.Tensor,
+        compressed_kv: torch.Tensor,
+        k_pe: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        output: torch.Tensor,
+        latent_cache: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
         kv = self.kv_b_proj(compressed_kv)
         k_nope, v = kv.split(
             [
@@ -1099,7 +1092,7 @@ class MLA(nn.Module):
         q: torch.Tensor,
         latent_cache: torch.Tensor,
         attn_metadata: AttentionMetadata,
-        output: Optional[torch.Tensor] = None,
+        output: torch.Tensor,
     ) -> torch.Tensor:
         assert latent_cache is not None
         trtllm_attention = cast(TrtllmAttention, self.mha)
@@ -1168,7 +1161,7 @@ class MLA(nn.Module):
         latent_cache: torch.
         Tensor,  # compressed_kv + k_pe [context_tokens, 1, lora_size + rope_size]
         attn_metadata: TrtllmAttentionMetadata,
-        output: Optional[torch.Tensor] = None,
+        output: torch.Tensor,
     ) -> torch.Tensor:
         trtllm_attention = cast(TrtllmAttention, self.mha)
         # apply RoPE, append compressed_kv + k_pe to paged kv cache and assign q_pe to q
@@ -1190,11 +1183,8 @@ class MLA(nn.Module):
             dtype=torch.float,
             device='cuda',
         )
-        if output is None:
-            attn_output = q.new_empty(
-                (q.size(0), self.num_heads * self.v_head_dim), dtype=q.dtype)
-        else:
-            attn_output = output
+
+        attn_output = output
         temp_attn_output = q.new_empty(
             (q.size(0), self.num_heads * self.v_head_dim), dtype=q.dtype)
 
@@ -1332,8 +1322,8 @@ class MLA(nn.Module):
         compressed_kv: torch.Tensor,
         k_pe: torch.Tensor,
         attn_metadata: AttentionMetadata,
+        output: torch.Tensor,
         latent_cache: Optional[torch.Tensor] = None,
-        output: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         if isinstance(self.mha, TrtllmAttention):
             assert isinstance(attn_metadata, TrtllmAttentionMetadata)
@@ -1346,16 +1336,17 @@ class MLA(nn.Module):
                 return self.forward_context_with_cached_kv(
                     q, latent_cache, attn_metadata, output)
         return self.forward_context_default(q, compressed_kv, k_pe,
-                                            attn_metadata, latent_cache, output)
+                                            attn_metadata, output, latent_cache)
 
     def forward_generation(
-            self,
-            q: torch.Tensor,
-            compressed_kv: torch.Tensor,
-            k_pe: torch.Tensor,
-            attn_metadata: AttentionMetadata,
-            latent_cache: Optional[torch.Tensor] = None,
-            output: Optional[torch.Tensor] = None) -> torch.Tensor:
+        self,
+        q: torch.Tensor,
+        compressed_kv: torch.Tensor,
+        k_pe: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        output: torch.Tensor,
+        latent_cache: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
         num_tokens = q.shape[0]
         q_nope, q_pe = q.view([-1, self.num_heads, self.qk_head_dim]).split(
             [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
@@ -1426,12 +1417,6 @@ class MLA(nn.Module):
         # [seq, num_heads, kv_lora_rank]
         attn_out_latent = attn_out_latent.view(
             [-1, self.num_heads, self.kv_lora_rank])
-
-        # [seq, num_heads * v_head_dim]
-        output = output if output is not None else torch.empty(
-            [num_tokens, self.num_heads * self.v_head_dim],
-            dtype=attn_out_latent.dtype,
-            device=attn_out_latent.device)
 
         attn_output = output.view([num_tokens, self.num_heads, self.v_head_dim])
 

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1,3 +1,4 @@
+import bisect
 import contextlib
 import copy
 import functools

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -9,7 +9,7 @@ import traceback
 import weakref
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 import torch._dynamo.config
@@ -52,8 +52,9 @@ from ..models.modeling_utils import (DecoderModelForCausalLM, MetaInitMode,
 from ..modules.fused_moe.moe_load_balancer import (
     MoeLoadBalancer, MoeLoadBalancerIterContext, maybe_create_moe_load_balancer)
 from ..speculative import SpecMetadata, get_spec_metadata
-from ..utils import (get_model_extra_attrs, set_torch_compiling,
-                     with_model_extra_attrs)
+from ..utils import (get_model_extra_attrs,
+                     set_per_request_piecewise_cuda_graph_flag,
+                     set_torch_compiling, with_model_extra_attrs)
 from .config import LoadFormat, PyTorchConfig
 from .config_utils import is_mla
 from .cuda_graph_runner import CUDAGraphRunner
@@ -328,10 +329,9 @@ class PyTorchModelEngine(ModelEngine):
         self._init_model_capacity()
 
         self._torch_compile_backend = None
-        self._torch_compile_enabled = pytorch_backend_config.torch_compile_enabled
-        self._torch_compile_piecewise_cuda_graph = (
-            pytorch_backend_config.torch_compile_piecewise_cuda_graph
-            and not self.enable_attention_dp)
+        # Eagle3 draft model now does not support torch.compile
+        self._torch_compile_enabled = pytorch_backend_config.torch_compile_enabled and not is_draft_model
+        self._torch_compile_piecewise_cuda_graph = pytorch_backend_config.torch_compile_piecewise_cuda_graph
 
         piecewise_cuda_graph_num_tokens = (
             pytorch_backend_config.torch_compile_piecewise_cuda_graph_num_tokens
@@ -346,7 +346,7 @@ class PyTorchModelEngine(ModelEngine):
             use_ub_for_nccl = (
                 pytorch_backend_config.allreduce_strategy == "NCCL_SYMMETRIC"
                 and self._init_userbuffers(self.model.config.hidden_size))
-            if pytorch_backend_config.torch_compile_enabled:
+            if self._torch_compile_enabled:
                 set_torch_compiling(True)
                 use_ub = not use_ub_for_nccl and (
                     pytorch_backend_config.torch_compile_enable_userbuffers
@@ -604,91 +604,87 @@ class PyTorchModelEngine(ModelEngine):
                 result = None
             return result
 
-        def get_torch_compile_warmup_request(batch_size,
-                                             num_tokens_per_request):
+        def get_warmup_request(num_tokens: int, num_gen_tokens: int):
+            available_tokens = kv_cache_manager.get_num_available_tokens(
+                self.runtime_draft_len)
             available_blocks = kv_cache_manager.get_num_free_blocks()
-            if available_blocks >= batch_size * math.ceil(
-                    num_tokens_per_request / kv_cache_manager.tokens_per_block):
-                # Should only need (at most) one more page per request.
-                is_gen = num_tokens_per_request == 1
+            if num_tokens > self.max_num_tokens or num_tokens > available_tokens:
+                return None
 
-                requests = kv_cache_manager.add_dummy_requests(
-                    list(range(batch_size)), [num_tokens_per_request] *
-                    batch_size if not is_gen else None,
-                    is_gen=is_gen,
-                    max_num_draft_tokens=self.runtime_draft_len)
+            num_ctx_tokens = num_tokens - num_gen_tokens
+            num_ctx_requests = 0
+            ctx_requests = []
+            gen_requests = []
+
+            max_seq_len = self.max_seq_len - 1
+            num_full_seqs = 0
+            num_left_over_tokens = 0
+
+            if num_ctx_tokens > 0:
+                # We will try to assign as less context requests as possible to
+                # fill the num_ctx_tokens.
+
+                # Num full sequences:
+                num_full_seqs = num_ctx_tokens // max_seq_len
+                num_left_over_tokens = num_ctx_tokens - num_full_seqs * max_seq_len
+
+                num_ctx_requests = num_full_seqs + (1 if num_left_over_tokens
+                                                    > 0 else 0)
+
+            # We do not have enough batch to fill the request
+            if num_ctx_requests + num_gen_tokens > self.batch_size:
+                return None
+
+            blocks_to_use = num_full_seqs * math.ceil(
+                max_seq_len / kv_cache_manager.tokens_per_block) + math.ceil(
+                    num_left_over_tokens /
+                    kv_cache_manager.tokens_per_block) + num_gen_tokens
+
+            if blocks_to_use > available_blocks:
+                return None
+
+            if num_ctx_tokens > 0:
+                ctx_token_nums = [max_seq_len] * num_full_seqs
+                if num_left_over_tokens > 0:
+                    ctx_token_nums.append(num_left_over_tokens)
+
+                ctx_requests = kv_cache_manager.add_dummy_requests(
+                    list(range(num_ctx_requests)),
+                    token_nums=ctx_token_nums,
+                    is_gen=False,
+                    max_num_draft_tokens=self.runtime_draft_len,
+                )
 
                 if spec_resource_manager is not None:
                     spec_resource_manager.add_dummy_requests(
-                        request_ids=list(range(batch_size)))
+                        request_ids=list(range(num_ctx_requests)))
 
-                result = ScheduledRequests()
-                result.context_requests = []
-                result.generation_requests = []
-                if is_gen:
-                    result.generation_requests = requests
-                else:
-                    result.context_requests = requests
-            else:
-                result = None
-            return result
-
-        def get_autotune_warmup_request():
-            available_tokens = kv_cache_manager.get_num_available_tokens(
-                self.runtime_draft_len)
-            num_tokens_per_request = min(
-                min(available_tokens, self.max_seq_len - 1),
-                self.max_num_tokens)
-            # Number of tokens required per request must be rounded up to whole number of blocks
-            num_tokens_required_per_request = (
-                (num_tokens_per_request + kv_cache_manager.tokens_per_block - 1)
-                // kv_cache_manager.tokens_per_block
-            ) * kv_cache_manager.tokens_per_block
-
-            available_blocks = kv_cache_manager.get_num_free_blocks()
-
-            maximum_tunable_num_tokens = min(
-                self.batch_size * num_tokens_per_request, self.max_num_tokens,
-                available_blocks * kv_cache_manager.tokens_per_block)
-
-            # Calculate number of full-length requests and remaining tokens
-            # Each request has num_tokens_per_request tokens, except possibly the last one
-            # Calculations are also limited by how many KV cache blocks are available
-            full_len_request_num = min(
-                maximum_tunable_num_tokens // num_tokens_per_request,
-                max(1, available_tokens // num_tokens_required_per_request))
-            remaining_tokens = min(
-                maximum_tunable_num_tokens % num_tokens_per_request,
-                max(
-                    0, available_tokens -
-                    full_len_request_num * num_tokens_required_per_request))
-
-            request_num = full_len_request_num if remaining_tokens == 0 else full_len_request_num + 1
-
-            requests = kv_cache_manager.add_dummy_requests(
-                request_ids=list(range(full_len_request_num)),
-                token_nums=[num_tokens_per_request] * full_len_request_num,
-                is_gen=False,
-                max_num_draft_tokens=self.runtime_draft_len)
-
-            if remaining_tokens > 0:
-                final_request = kv_cache_manager.add_dummy_requests(
-                    request_ids=[full_len_request_num],
-                    token_nums=[remaining_tokens],
-                    is_gen=False,
-                    max_num_draft_tokens=self.runtime_draft_len)
-
-                requests += final_request
-
-            if spec_resource_manager is not None:
-                spec_resource_manager.add_dummy_requests(
-                    request_ids=list(range(request_num)))
+            if num_gen_tokens > 0:
+                gen_requests = kv_cache_manager.add_dummy_requests(
+                    list(
+                        range(num_ctx_requests,
+                              num_ctx_requests + num_gen_tokens)),
+                    token_nums=[1] * num_gen_tokens,
+                    is_gen=True,
+                    max_num_draft_tokens=self.max_draft_len,
+                )
+                if spec_resource_manager is not None:
+                    spec_resource_manager.add_dummy_requests(request_ids=list(
+                        range(num_ctx_requests, num_ctx_requests +
+                              num_gen_tokens)))
 
             result = ScheduledRequests()
-            result.context_requests = requests
-            result.generation_requests = []
+            result.context_requests = ctx_requests
+            result.generation_requests = gen_requests
 
             return result
+
+        curr_max_num_tokens = min(
+            kv_cache_manager.get_num_available_tokens(self.max_draft_len),
+            self.max_num_tokens, self.batch_size * (self.max_seq_len - 1))
+
+        def get_autotune_warmup_request():
+            return get_warmup_request(curr_max_num_tokens, 0)
 
         @contextlib.contextmanager
         def release_batch(result: ScheduledRequests | None):
@@ -708,32 +704,31 @@ class PyTorchModelEngine(ModelEngine):
 
         if self._torch_compile_enabled:
 
+            warmup_requests = set([
+                (1, 1),  # Specialize for 1 token.
+                (self.batch_size,
+                 self.batch_size),  # max_batch_size, pure generation
+                (2, 0),  # Non-one, pure context
+                (curr_max_num_tokens, 0),  # max_num_tokens, pure context
+            ])
+
             # Disable cuda graph capture here so that we can properly capture it later
             with self.no_cuda_graph():
-                available_tokens = kv_cache_manager.get_num_available_tokens(
-                    self.runtime_draft_len)
-                warmup_batch_size = [1, self.batch_size // 2]
-                if self.batch_size < 2:
-                    warmup_batch_size = [1]
-                for bs in warmup_batch_size:
-                    for num_tokens_per_request in [
-                            1,
-                            min(self.max_num_tokens // max(bs, 1),
-                                min(available_tokens, self.max_seq_len - 1))
-                    ]:
-                        with release_batch(
-                                get_torch_compile_warmup_request(
-                                    bs, num_tokens_per_request)) as batch:
-                            if batch is None:
-                                # No KV cache space!
-                                continue
-                            logger.info(
-                                f"Run warmup for batch size={bs}, pure {'context' if num_tokens_per_request > 1 else 'generation'} phase"
-                            )
-                            self.forward(batch,
-                                         new_tensors_device=None,
-                                         resource_manager=resource_manager)
-                            torch.cuda.synchronize()
+                for warmup_num_tokens, warmup_num_gen_tokens in warmup_requests:
+
+                    with release_batch(
+                            get_warmup_request(warmup_num_tokens,
+                                               warmup_num_gen_tokens)) as batch:
+                        if batch is None:
+                            # No KV cache space!
+                            continue
+                        logger.info(
+                            f"Run warmup with {warmup_num_tokens} tokens, include {warmup_num_gen_tokens} generation tokens"
+                        )
+                        self.forward(batch,
+                                     new_tensors_device=None,
+                                     resource_manager=resource_manager)
+                        torch.cuda.synchronize()
 
         if self.pytorch_backend_config.enable_autotuner:
             with self.no_cuda_graph(), autotune():
@@ -803,9 +798,8 @@ class PyTorchModelEngine(ModelEngine):
             with capture_piecewise_cuda_graph(True):
                 for num_tokens in piecewise_cuda_graph_num_tokens:
                     with self.no_cuda_graph():
-                        with release_batch(
-                                get_torch_compile_warmup_request(
-                                    1, num_tokens)) as batch:
+                        with release_batch(get_warmup_request(num_tokens,
+                                                              0)) as batch:
                             logger.info(
                                 f"Run piecewise CUDA graph warmup for num tokens={num_tokens}"
                             )
@@ -1129,6 +1123,70 @@ class PyTorchModelEngine(ModelEngine):
                     num_ctx_requests:num_seqs] += (
                         self.previous_kv_lens_offsets_cuda[:num_gen_requests])
         return inputs
+
+    def _get_all_rank_num_tokens(self, attn_metadata: AttentionMetadata):
+        if self.enable_attention_dp:
+            return list(self.dist.tp_allgather(attn_metadata.num_tokens))
+        return None
+
+    def _get_padding_params(
+        self, total_num_tokens: int, num_ctx_requests: int,
+        attn_all_rank_num_tokens: Optional[List[int]]
+    ) -> Tuple[int, bool, Optional[List[int]]]:
+        """
+        Get the padding parameters for tensor padding.
+        Return:
+            padded_num_tokens: the padded number of tokens
+            can_run_piecewise_cuda_graph: whether the piecewise cuda graph can be run
+            attn_all_rank_num_tokens: the number of tokens for each rank
+        """
+        padded_num_tokens = total_num_tokens
+
+        def get_padded_piecewise_tokens(tokens):
+            captured_num_tokens = self._torch_compile_backend.capture_num_tokens
+            return captured_num_tokens[bisect.bisect_left(
+                captured_num_tokens, tokens)]
+
+        if (self._torch_compile_backend is not None
+                and self._torch_compile_piecewise_cuda_graph
+                and self._torch_compile_backend.capture_num_tokens):
+            max_captured_num_tokens = self._torch_compile_backend.capture_num_tokens[
+                -1]
+            # Torch piecewise cuda graph is enabled.
+            if attn_all_rank_num_tokens is not None:
+                can_run_piecewise_cuda_graph = (num_ctx_requests != 0 and
+                                                max(attn_all_rank_num_tokens)
+                                                <= max_captured_num_tokens)
+                all_ranks_can_run_piecewise_cuda_graph = list(
+                    self.dist.tp_allgather(can_run_piecewise_cuda_graph))
+                if all(all_ranks_can_run_piecewise_cuda_graph):
+                    padded_num_tokens = get_padded_piecewise_tokens(
+                        max(attn_all_rank_num_tokens))
+                    logger.debug(
+                        f"Pad tensor with {total_num_tokens} tokens to {padded_num_tokens} tokens"
+                    )
+                    return padded_num_tokens, True, [
+                        padded_num_tokens
+                    ] * len(attn_all_rank_num_tokens)
+                else:
+                    logger.debug(
+                        f"Not all ranks can run piecewise cuda graph, disable piecewise cuda graph"
+                    )
+                    return total_num_tokens, False, attn_all_rank_num_tokens
+            elif num_ctx_requests != 0 and total_num_tokens <= max_captured_num_tokens:
+                padded_num_tokens = get_padded_piecewise_tokens(
+                    total_num_tokens)
+                logger.debug(
+                    f"Pad tensor with {total_num_tokens} tokens to {padded_num_tokens} tokens"
+                )
+                return padded_num_tokens, True, None
+            else:
+                logger.debug(
+                    f"Picewise cudagraph cannot be used with {total_num_tokens} tokens, {num_ctx_requests} context requests"
+                )
+                return total_num_tokens, False, None
+
+        return total_num_tokens, False, attn_all_rank_num_tokens
 
     def _prepare_tp_inputs(
             self,
@@ -1500,12 +1558,27 @@ class PyTorchModelEngine(ModelEngine):
         lora_params = self._get_lora_params_from_requests(
             scheduled_requests, attn_metadata)
 
+        attn_all_rank_num_tokens = self._get_all_rank_num_tokens(attn_metadata)
+        padded_num_tokens, can_run_piecewise_cuda_graph, attn_all_rank_num_tokens = self._get_padding_params(
+            total_num_tokens, num_ctx_requests, attn_all_rank_num_tokens)
+        set_per_request_piecewise_cuda_graph_flag(can_run_piecewise_cuda_graph)
+        attn_metadata.padded_num_tokens = padded_num_tokens if padded_num_tokens != total_num_tokens else None
+
+        virtual_num_tokens = total_num_tokens
+        if attn_metadata.padded_num_tokens is not None:
+            self.input_ids_cuda[total_num_tokens:padded_num_tokens].fill_(0)
+            self.position_ids_cuda[total_num_tokens:padded_num_tokens].fill_(0)
+            virtual_num_tokens = padded_num_tokens
+
+        if self.enable_attention_dp:
+            attn_metadata.all_rank_num_tokens = attn_all_rank_num_tokens
+
         # Prepare inputs
         inputs = {
             'attn_metadata': attn_metadata,
-            'input_ids': self.input_ids_cuda[:total_num_tokens],
+            'input_ids': self.input_ids_cuda[:virtual_num_tokens],
             'position_ids':
-            self.position_ids_cuda[:total_num_tokens].unsqueeze(0),
+            self.position_ids_cuda[:virtual_num_tokens].unsqueeze(0),
             'inputs_embeds': None,
             "multimodal_params": multimodal_params_list,
         }
@@ -1538,27 +1611,17 @@ class PyTorchModelEngine(ModelEngine):
             spec_metadata.prepare()
             inputs['spec_metadata'] = spec_metadata
 
-        # support attention dp
-        if self.enable_attention_dp:
-            if spec_metadata is not None:
-                all_rank_num_tokens = self.dist.tp_allgather([
-                    attn_metadata.num_tokens, spec_metadata.num_tokens,
-                    len(sequence_lengths)
-                ])
-                attn_all_rank_num_tokens = [
+            if self.enable_attention_dp:
+                all_rank_num_tokens = self.dist.tp_allgather(
+                    [spec_metadata.num_tokens,
+                     len(sequence_lengths)])
+
+                spec_all_rank_num_tokens = [
                     item[0] for item in all_rank_num_tokens
                 ]
-                spec_all_rank_num_tokens = [
-                    item[1] for item in all_rank_num_tokens
-                ]
-                all_rank_num_seqs = [item[2] for item in all_rank_num_tokens]
-                attn_metadata.all_rank_num_tokens = attn_all_rank_num_tokens
+                all_rank_num_seqs = [item[1] for item in all_rank_num_tokens]
                 spec_metadata.all_rank_num_tokens = spec_all_rank_num_tokens
                 spec_metadata.all_rank_num_seqs = all_rank_num_seqs
-            else:
-                all_rank_num_tokens = self.dist.tp_allgather(
-                    attn_metadata.num_tokens)
-                attn_metadata.all_rank_num_tokens = all_rank_num_tokens
 
         num_generation_tokens = len(generation_requests) + len(
             extend_requests) + sum(draft_lens)
@@ -1641,9 +1704,22 @@ class PyTorchModelEngine(ModelEngine):
             )
 
         attn_metadata.num_contexts = len(scheduled_requests.context_requests)
+
+        attn_all_rank_num_tokens = self._get_all_rank_num_tokens(attn_metadata)
+        padded_num_tokens, can_run_piecewise_cuda_graph, attn_all_rank_num_tokens = self._get_padding_params(
+            num_tokens, attn_metadata.num_contexts, attn_all_rank_num_tokens)
+        set_per_request_piecewise_cuda_graph_flag(can_run_piecewise_cuda_graph)
+        attn_metadata.padded_num_tokens = padded_num_tokens if padded_num_tokens != num_tokens else None
+
         if self.enable_attention_dp:
-            all_rank_num_tokens = self.dist.allgather(attn_metadata.num_tokens)
-            attn_metadata.all_rank_num_tokens = all_rank_num_tokens
+            attn_metadata.all_rank_num_tokens = attn_all_rank_num_tokens
+
+        virtual_num_tokens = num_tokens
+        if attn_metadata.padded_num_tokens is not None:
+            self.input_ids_cuda[num_tokens:padded_num_tokens].fill_(0)
+            self.position_ids_cuda[num_tokens:padded_num_tokens].fill_(0)
+            virtual_num_tokens = padded_num_tokens
+
         # this is for no cache attention, not for dummy attention
         if attn_metadata.kv_cache_manager is None:
             assert isinstance(
@@ -1659,8 +1735,9 @@ class PyTorchModelEngine(ModelEngine):
 
         inputs = {
             'attn_metadata': attn_metadata,
-            'input_ids': self.input_ids_cuda[:num_tokens],
-            'position_ids': self.position_ids_cuda[:num_tokens].unsqueeze(0),
+            'input_ids': self.input_ids_cuda[:virtual_num_tokens],
+            'position_ids':
+            self.position_ids_cuda[:virtual_num_tokens].unsqueeze(0),
             'inputs_embeds': None,
             "multimodal_params": multimodal_params_list
         }

--- a/tensorrt_llm/_torch/utils.py
+++ b/tensorrt_llm/_torch/utils.py
@@ -275,3 +275,11 @@ def piecewise_cuda_graph(enable: bool):
         yield
     finally:
         set_piecewise_cuda_graph_flag(prev_enable)
+
+
+def set_per_request_piecewise_cuda_graph_flag(enable: bool):
+    _global_attrs.per_request_piecewise_cuda_graph_flag = enable
+
+
+def get_per_request_piecewise_cuda_graph_flag() -> bool:
+    return getattr(_global_attrs, 'per_request_piecewise_cuda_graph_flag', True)

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -94,6 +94,7 @@ class TestLlama3_1_8BInstruct(LlmapiAccuracyTestHarness):
         torch_compile_config = TorchCompileConfig(
             enable_fullgraph=True,
             enable_piecewise_cuda_graph=True,
+            capture_num_tokens=[2048, 8192],
             max_num_streams=3) if torch_compile else None
         pytorch_config = dict(
             torch_compile_config=torch_compile_config,
@@ -120,6 +121,7 @@ class TestLlama3_1_8BInstruct(LlmapiAccuracyTestHarness):
         torch_compile_config = TorchCompileConfig(
             enable_fullgraph=True,
             enable_piecewise_cuda_graph=True,
+            capture_num_tokens=[2048, 8192],
             max_num_streams=3) if torch_compile else None
         pytorch_config = dict(
             torch_compile_config=torch_compile_config,
@@ -143,6 +145,7 @@ class TestLlama3_1_8BInstruct(LlmapiAccuracyTestHarness):
         torch_compile_config = TorchCompileConfig(
             enable_fullgraph=True,
             enable_piecewise_cuda_graph=True,
+            capture_num_tokens=[2048, 8192],
             max_num_streams=3) if torch_compile else None
         pytorch_config = dict(
             torch_compile_config=torch_compile_config,
@@ -176,6 +179,7 @@ class TestLlama3_1_8BInstruct(LlmapiAccuracyTestHarness):
         torch_compile_config = TorchCompileConfig(
             enable_fullgraph=True,
             enable_piecewise_cuda_graph=True,
+            capture_num_tokens=[2048, 8192],
             max_num_streams=3) if torch_compile else None
         pytorch_config = dict(
             torch_compile_config=torch_compile_config,
@@ -661,6 +665,7 @@ class TestLlama4MaverickInstruct(LlmapiAccuracyTestHarness):
         torch_compile_config = TorchCompileConfig(
             enable_fullgraph=True,
             enable_piecewise_cuda_graph=True,
+            capture_num_tokens=[2048, 8192],
             max_num_streams=3) if torch_compile else None
         pytorch_config = dict(
             cuda_graph_config=CudaGraphConfig(max_batch_size=8),
@@ -1036,6 +1041,7 @@ class TestDeepSeekV3Lite(LlmapiAccuracyTestHarness):
         torch_compile_config = TorchCompileConfig(
             enable_fullgraph=True,
             enable_piecewise_cuda_graph=cuda_graph,
+            capture_num_tokens=[2048, 8192],
             max_num_streams=3) if torch_compile else None
         pytorch_config = dict(
             disable_overlap_scheduler=not overlap_scheduler,
@@ -1074,7 +1080,8 @@ class TestDeepSeekV3Lite(LlmapiAccuracyTestHarness):
         kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.75)
         torch_compile_config = TorchCompileConfig(
             enable_fullgraph=True,
-            enable_piecewise_cuda_graph=cuda_graph and not attention_dp,
+            enable_piecewise_cuda_graph=cuda_graph,
+            capture_num_tokens=[2048, 8192],
             max_num_streams=3) if torch_compile else None
         pytorch_config = dict(
             disable_overlap_scheduler=not overlap_scheduler,
@@ -1113,6 +1120,7 @@ class TestDeepSeekV3Lite(LlmapiAccuracyTestHarness):
         torch_compile_config = TorchCompileConfig(
             enable_fullgraph=True,
             enable_piecewise_cuda_graph=cuda_graph,
+            capture_num_tokens=[2048, 8192],
             max_num_streams=3) if torch_compile else None
         pytorch_config = dict(
             disable_overlap_scheduler=not overlap_scheduler,
@@ -1164,6 +1172,7 @@ class TestDeepSeekV3Lite(LlmapiAccuracyTestHarness):
         torch_compile_config = (TorchCompileConfig(
             enable_fullgraph=True,
             enable_piecewise_cuda_graph=cuda_graph,
+            capture_num_tokens=[2048, 8192],
             max_num_streams=3) if torch_compile else None)
         pytorch_config = dict(
             disable_overlap_scheduler=not overlap_scheduler,
@@ -1262,7 +1271,8 @@ class TestDeepSeekV3Lite(LlmapiAccuracyTestHarness):
         kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.75)
         torch_compile_config = TorchCompileConfig(
             enable_fullgraph=True,
-            enable_piecewise_cuda_graph=cuda_graph and not attention_dp,
+            enable_piecewise_cuda_graph=cuda_graph,
+            capture_num_tokens=[2048, 8192],
             max_num_streams=3) if torch_compile else None
         pytorch_config = dict(
             disable_overlap_scheduler=not overlap_scheduler,
@@ -1322,6 +1332,7 @@ class TestDeepSeekV3Lite(LlmapiAccuracyTestHarness):
         torch_compile_config = (TorchCompileConfig(
             enable_fullgraph=True,
             enable_piecewise_cuda_graph=cuda_graph,
+            capture_num_tokens=[2048, 8192],
             max_num_streams=3) if torch_compile else None)
         pytorch_config = dict(
             disable_overlap_scheduler=not overlap_scheduler,
@@ -1448,7 +1459,8 @@ class TestDeepSeekV3Lite(LlmapiAccuracyTestHarness):
         torch_compile_config = TorchCompileConfig(
             enable_fullgraph=True,
             enable_piecewise_cuda_graph=cuda_graph,
-            max_num_streams=1) if torch_compile else None
+            capture_num_tokens=[2048, 8192],
+            max_num_streams=3) if torch_compile else None
         pytorch_config = dict(
             disable_overlap_scheduler=not overlap_scheduler,
             cuda_graph_config=CudaGraphConfig() if cuda_graph else None,
@@ -1497,7 +1509,8 @@ class TestDeepSeekV3Lite(LlmapiAccuracyTestHarness):
         # Picewise Cuda Graph cannot be enabled for nvfp4 attention dp.
         torch_compile_config = TorchCompileConfig(
             enable_fullgraph=True,
-            enable_piecewise_cuda_graph=cuda_graph and not attention_dp,
+            enable_piecewise_cuda_graph=cuda_graph,
+            capture_num_tokens=[2048, 8192],
             max_num_streams=3) if torch_compile else None
         pytorch_config = dict(
             disable_overlap_scheduler=not overlap_scheduler,
@@ -2250,7 +2263,8 @@ class TestQwen3_30B_A3B(LlmapiAccuracyTestHarness):
                               cuda_graph, overlap_scheduler, torch_compile):
         torch_compile_config = TorchCompileConfig(
             enable_fullgraph=True,
-            enable_piecewise_cuda_graph=cuda_graph and not attention_dp,
+            enable_piecewise_cuda_graph=cuda_graph,
+            capture_num_tokens=[2048, 8192],
             max_num_streams=3) if torch_compile else None
 
         pytorch_config = dict(
@@ -2277,7 +2291,8 @@ class TestQwen3_30B_A3B(LlmapiAccuracyTestHarness):
                  overlap_scheduler, torch_compile):
         torch_compile_config = TorchCompileConfig(
             enable_fullgraph=True,
-            enable_piecewise_cuda_graph=cuda_graph and not attention_dp,
+            enable_piecewise_cuda_graph=cuda_graph,
+            capture_num_tokens=[2048, 8192],
             max_num_streams=3) if torch_compile else None
 
         pytorch_config = dict(
@@ -2329,7 +2344,8 @@ class TestQwen3_30B_A3B(LlmapiAccuracyTestHarness):
 
         torch_compile_config = TorchCompileConfig(
             enable_fullgraph=True,
-            enable_piecewise_cuda_graph=cuda_graph and not attention_dp,
+            enable_piecewise_cuda_graph=cuda_graph,
+            capture_num_tokens=[2048, 8192],
             max_num_streams=3) if torch_compile else None
 
         pytorch_config = dict(

--- a/tests/unittest/_torch/thop/test_custom_ops.py
+++ b/tests/unittest/_torch/thop/test_custom_ops.py
@@ -80,7 +80,6 @@ def test_register_fake(custom_ops):
         "trtllm::fp4_batched_quantize",
         "trtllm::fp4_gemm_trtllmgen",
         "trtllm::fp4_bmm",
-        "trtllm::merge_chunked_attention_for_mla",
         "trtllm::cuda_scaled_mm",
         "trtllm::initialize_static_lowprecision_buffers",
         "trtllm::cutlass_scaled_mm",


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Padded-sequence support added across attention and MLA with explicit output-buffer handling and zeroing of padded tails.
  - Per-request piecewise CUDA graph control and expanded configurable piecewise batch sizes; warmup now builds granular requests.

- Performance
  - More consistent CUDA-graph captures and execution for padded/batched workloads, improving inference efficiency.

- Bug Fixes
  - Fixed shape/alignment issues in MTP/speculative paths when padding is present.

- Tests
  - Tests updated to enable piecewise CUDA graphs under attention DP and tighten custom-op coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up
-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
