### PR TITLE
[None][chore] Guided decoding benchmarking

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,6 +28,6 @@ jieba==0.42.1
 rouge==1.0.1
 pytest-rerunfailures
 ruff==0.9.4
-lm_eval[api]==0.4.8
+lm_eval[api]==0.4.9
 docstring_parser
 genai-perf==0.0.13

--- a/tensorrt_llm/_torch/pyexecutor/grammar_matcher.py
+++ b/tensorrt_llm/_torch/pyexecutor/grammar_matcher.py
@@ -194,7 +194,11 @@ class LLGuidanceMatcherFactory(GrammarMatcherFactory):
                 grammar = llguidance.LLMatcher.grammar_from_json_schema(
                     '{"type": "object"}')
             case GuidedDecodingParams.GuideType.JSON_SCHEMA:
-                grammar = llguidance.LLMatcher.grammar_from_json_schema(guide)
+                kwargs = {}
+                if os.environ.get("TRTLLM_XGUIDANCE_LENIENT") == "1":
+                    kwargs["overrides"] = {"lenient": True}
+                grammar = llguidance.LLMatcher.grammar_from_json_schema(
+                    guide, **kwargs)
             case GuidedDecodingParams.GuideType.REGEX:
                 grammar = llguidance.LLMatcher.grammar_from_regex(guide)
             case GuidedDecodingParams.GuideType.EBNF_GRAMMAR:

--- a/tensorrt_llm/_torch/speculative/model_drafter.py
+++ b/tensorrt_llm/_torch/speculative/model_drafter.py
@@ -29,15 +29,18 @@ if TYPE_CHECKING:
 
 # Place the tool function here to avoid circular import
 def get_draft_model_prompt(spec_dec_mode: SpeculativeDecodingMode,
-                           input_tokens: torch.Tensor) -> torch.Tensor:
+                           request: LlmRequest) -> List[int]:
     """
     Can be used to modify prompts for speculative algorithms that need to update tokens
     before drafting.
     """
+    draft_input_tokens = request.get_tokens(0)
     if spec_dec_mode.is_eagle3() or spec_dec_mode.is_mtp_eagle():
         # EAGLE3 always throws away the first token when processing draft inputs
-        return input_tokens[1:]
-    return input_tokens
+        draft_input_tokens = draft_input_tokens[1:]
+        if request.is_context_init_state:
+            draft_input_tokens.append(0)
+    return draft_input_tokens
 
 
 class ModelDrafter(Drafter):
@@ -167,7 +170,7 @@ class ModelDrafter(Drafter):
         num_draft_tokens, num_accepted_tokens = self._initialize_draft_tokens(
             request)
         input_tokens = get_draft_model_prompt(self.spec_config.spec_dec_mode,
-                                              request.get_tokens(0))
+                                              request)
 
         # First time seeing this request - context request
         if request.max_beam_num_tokens - 1 == request.py_prompt_len:
@@ -239,9 +242,8 @@ class ModelDrafter(Drafter):
                 # We hit this path if we're doing chunked prefill. The target model processed
                 # a prefill chunk on the last iteration. Now, we need to fill in the KV cache
                 # for the draft model too.
-                all_tokens = request.get_tokens(0)
                 input_tokens = get_draft_model_prompt(
-                    self.spec_config.spec_dec_mode, all_tokens)
+                    self.spec_config.spec_dec_mode, request)
 
                 new_request = self._create_context_request(
                     request, input_tokens)

--- a/tensorrt_llm/_torch/speculative/model_drafter.py
+++ b/tensorrt_llm/_torch/speculative/model_drafter.py
@@ -9,7 +9,8 @@ from tensorrt_llm._utils import nvtx_range
 from tensorrt_llm.logger import logger
 
 from ..attention_backend.trtllm import TrtllmAttention
-from ..pyexecutor.guided_decoder import GuidedDecoder
+from ..pyexecutor.guided_decoder import (TRTLLM_DISABLE_DRAFT_GUIDED_DECODING,
+                                         GuidedDecoder)
 from ..pyexecutor.handle_logits import HandleLogits
 from ..pyexecutor.llm_request import LlmRequest, LlmRequestState
 from ..pyexecutor.resource_manager import (BaseResourceManager, ResourceManager,
@@ -70,7 +71,10 @@ class ModelDrafter(Drafter):
         self.max_draft_tokens = max_draft_tokens
         # Sampling
         self.sampler = sampler
-        self.guided_decoder = guided_decoder
+        if TRTLLM_DISABLE_DRAFT_GUIDED_DECODING:
+            self.guided_decoder = None
+        else:
+            self.guided_decoder = guided_decoder
 
         self.use_static_draft_loop = draft_model_engine.model_is_wrapped
         if self.use_static_draft_loop:

--- a/tensorrt_llm/_torch/speculative/model_drafter.py
+++ b/tensorrt_llm/_torch/speculative/model_drafter.py
@@ -38,8 +38,10 @@ def get_draft_model_prompt(spec_dec_mode: SpeculativeDecodingMode,
     if spec_dec_mode.is_eagle3() or spec_dec_mode.is_mtp_eagle():
         # EAGLE3 always throws away the first token when processing draft inputs
         draft_input_tokens = draft_input_tokens[1:]
-        if request.is_context_init_state:
-            draft_input_tokens.append(0)
+    if request.is_context_init_state:
+        # A draft request's prompt is its target request's prompt adding the first golden token.
+        # Add a fake golden token here since the real one has not been generated.
+        draft_input_tokens.append(0)
     return draft_input_tokens
 
 

--- a/tensorrt_llm/bench/benchmark/utils/asynchronous.py
+++ b/tensorrt_llm/bench/benchmark/utils/asynchronous.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import time
 from contextlib import asynccontextmanager
 from itertools import chain
@@ -50,6 +51,7 @@ class LlmManager:
                               post_proc_params: PostprocParams):
         # Set up sampling params with inference request
         self.request_seen.set()
+        sampling_params = copy.deepcopy(sampling_params)
         sampling_params.max_tokens = request.output_tokens
         sampling_params.guided_decoding = request.guided_decoding_params
 

--- a/tensorrt_llm/bench/benchmark/utils/asynchronous.py
+++ b/tensorrt_llm/bench/benchmark/utils/asynchronous.py
@@ -51,6 +51,7 @@ class LlmManager:
         # Set up sampling params with inference request
         self.request_seen.set()
         sampling_params.max_tokens = request.output_tokens
+        sampling_params.guided_decoding = request.guided_decoding_params
 
         async with semaphore_guard(self._concurrency_semaphore):
             request_start_timestamp = time.perf_counter_ns()

--- a/tensorrt_llm/bench/dataclasses/general.py
+++ b/tensorrt_llm/bench/dataclasses/general.py
@@ -8,6 +8,7 @@ from pydantic import (AliasChoices, BaseModel, Field, computed_field,
 
 from tensorrt_llm.bench.dataclasses.statistics import PercentileStats
 from tensorrt_llm.executor.request import LoRARequest
+from tensorrt_llm.sampling_params import GuidedDecodingParams
 
 
 class BenchmarkEnvironment(BaseModel):
@@ -23,6 +24,7 @@ class InferenceRequest(BaseModel):
     input_ids: Optional[List[int]] = Field(
         alias=AliasChoices("input_ids", "logits"))
     lora_request: Optional[LoRARequest] = None
+    guided_decoding_params: Optional[GuidedDecodingParams] = None
 
     @model_validator(mode="after")
     def verify_prompt_and_logits(self) -> InferenceRequest:

--- a/tensorrt_llm/commands/eval.py
+++ b/tensorrt_llm/commands/eval.py
@@ -21,7 +21,8 @@ import tensorrt_llm.profiler as profiler
 from .. import LLM as PyTorchLLM
 from .._tensorrt_engine import LLM
 from ..evaluate import (GSM8K, MMLU, MMMU, CnnDailymail, GPQADiamond,
-                        GPQAExtended, GPQAMain, JsonModeEval)
+                        GPQAExtended, GPQAMain, HumanEval, JsonModeEval,
+                        JsonSchemaBenchEasy)
 from ..llmapi import BuildConfig, KvCacheConfig
 from ..llmapi.llm_utils import update_llm_args_with_extra_options
 from ..logger import logger, severity_map
@@ -159,6 +160,8 @@ main.add_command(GPQAMain.command)
 main.add_command(GPQAExtended.command)
 main.add_command(JsonModeEval.command)
 main.add_command(MMMU.command)
+main.add_command(HumanEval.command)
+main.add_command(JsonSchemaBenchEasy.command)
 
 if __name__ == "__main__":
     main()

--- a/tensorrt_llm/evaluate/__init__.py
+++ b/tensorrt_llm/evaluate/__init__.py
@@ -15,10 +15,11 @@
 
 from .cnn_dailymail import CnnDailymail
 from .json_mode_eval import JsonModeEval
-from .lm_eval import GSM8K, MMMU, GPQADiamond, GPQAExtended, GPQAMain
+from .lm_eval import (GSM8K, MMMU, GPQADiamond, GPQAExtended, GPQAMain,
+                      HumanEval, JsonSchemaBenchEasy)
 from .mmlu import MMLU
 
 __all__ = [
     "CnnDailymail", "MMLU", "GSM8K", "GPQADiamond", "GPQAMain", "GPQAExtended",
-    "JsonModeEval", "MMMU"
+    "JsonModeEval", "MMMU", "HumanEval", "JsonSchemaBenchEasy"
 ]

--- a/tensorrt_llm/evaluate/interface.py
+++ b/tensorrt_llm/evaluate/interface.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import copy
+import json
 import random
 from abc import ABC, abstractmethod
 from typing import Any, Iterable, List, Optional, Union
@@ -107,6 +108,25 @@ class Evaluator(ABC):
         profiler.reset("trtllm exec")
 
         score = self.compute_score(results, references, *zip(*auxiliaries))
+
+        from dataclasses import asdict
+        from itertools import repeat
+        num_repeats = 100
+        with open("bench_requests.jsonl", "w") as f:
+            for i, output in enumerate(repeat(outputs, num_repeats)):
+                bench_request = {
+                    "task_id": i,
+                    "prompt": output.prompt,
+                    "input_ids": output.prompt_token_ids,
+                    "output_tokens": output.sampling_params.max_tokens
+                }
+                guided_decoding_params = output.sampling_params.guided_decoding
+                if guided_decoding_params is not None:
+                    bench_request["guided_decoding_params"] = asdict(
+                        guided_decoding_params)
+                f.write(json.dumps(bench_request))
+                f.write("\n")
+
         return score
 
     @staticmethod

--- a/tensorrt_llm/evaluate/interface.py
+++ b/tensorrt_llm/evaluate/interface.py
@@ -110,10 +110,9 @@ class Evaluator(ABC):
         score = self.compute_score(results, references, *zip(*auxiliaries))
 
         from dataclasses import asdict
-        from itertools import repeat
         num_repeats = 100
         with open("bench_requests.jsonl", "w") as f:
-            for i, output in enumerate(repeat(outputs, num_repeats)):
+            for i, output in enumerate(outputs * num_repeats):
                 bench_request = {
                     "task_id": i,
                     "prompt": output.prompt,

--- a/tensorrt_llm/evaluate/lm_eval.py
+++ b/tensorrt_llm/evaluate/lm_eval.py
@@ -395,7 +395,8 @@ class LmEvalEvaluator(Evaluator):
             limit=self.num_samples,
             apply_chat_template=self.apply_chat_template,
             fewshot_as_multiturn=self.fewshot_as_multiturn,
-            system_instruction=self.system_prompt)
+            system_instruction=self.system_prompt,
+            confirm_run_unsafe_code=True)
         # Normalize scores to range 0~100
         scores = results["results"][self.task_name]
         for metric in scores.keys():
@@ -615,6 +616,100 @@ class GPQAExtended(LmEvalEvaluator):
     @staticmethod
     def command(ctx, **kwargs) -> None:
         GPQAExtended.command_harness(ctx, **kwargs)
+
+
+class HumanEval(LmEvalEvaluator):
+
+    def __init__(self, **kwargs):
+        super().__init__("humaneval", **kwargs)
+
+    @click.command("humaneval")
+    @click.option("--dataset_path",
+                  type=str,
+                  default=None,
+                  help="The path to HumanEval dataset. "
+                  "If unspecified, the dataset is downloaded from HF hub.")
+    @click.option(
+        "--num_samples",
+        type=int,
+        default=None,
+        help="Number of samples to run the evaluation; None means full dataset."
+    )
+    @click.option("--random_seed",
+                  type=int,
+                  default=0,
+                  help="Random seed for dataset processing.")
+    @click.option("--apply_chat_template",
+                  is_flag=True,
+                  default=False,
+                  help="Whether to apply chat template.")
+    @click.option("--fewshot_as_multiturn",
+                  is_flag=True,
+                  default=False,
+                  help="Apply fewshot as multiturn.")
+    @click.option("--system_prompt",
+                  type=str,
+                  default=None,
+                  help="System prompt.")
+    @click.option("--max_input_length",
+                  type=int,
+                  default=4096,
+                  help="Maximum prompt length.")
+    @click.option("--max_output_length",
+                  type=int,
+                  default=2048,
+                  help="Maximum generation length.")
+    @click.pass_context
+    @staticmethod
+    def command(ctx, **kwargs) -> None:
+        HumanEval.command_harness(ctx, **kwargs)
+
+
+class JsonSchemaBenchEasy(LmEvalEvaluator):
+
+    def __init__(self, **kwargs):
+        super().__init__("jsonschema_bench_easy", **kwargs)
+
+    @click.command("jsonschema_bench_easy")
+    @click.option("--dataset_path",
+                  type=str,
+                  default=None,
+                  help="The path to JsonSchemaBench dataset. "
+                  "If unspecified, the dataset is downloaded from HF hub.")
+    @click.option(
+        "--num_samples",
+        type=int,
+        default=None,
+        help="Number of samples to run the evaluation; None means full dataset."
+    )
+    @click.option("--random_seed",
+                  type=int,
+                  default=0,
+                  help="Random seed for dataset processing.")
+    @click.option("--apply_chat_template",
+                  is_flag=True,
+                  default=False,
+                  help="Whether to apply chat template.")
+    @click.option("--fewshot_as_multiturn",
+                  is_flag=True,
+                  default=False,
+                  help="Apply fewshot as multiturn.")
+    @click.option("--system_prompt",
+                  type=str,
+                  default=None,
+                  help="System prompt.")
+    @click.option("--max_input_length",
+                  type=int,
+                  default=4096,
+                  help="Maximum prompt length.")
+    @click.option("--max_output_length",
+                  type=int,
+                  default=2048,
+                  help="Maximum generation length.")
+    @click.pass_context
+    @staticmethod
+    def command(ctx, **kwargs) -> None:
+        JsonSchemaBenchEasy.command_harness(ctx, **kwargs)
 
 
 class MMMU(LmEvalEvaluator):


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added per-request guided decoding support across dataset ingestion and benchmarking, enabling requests to carry guided decoding parameters.
  * Evaluations now generate a bench_requests.jsonl file with repeated samples to facilitate benchmarking workflows.

* Chores
  * Ensured tokenizer initialization always runs during throughput benchmarking for more consistent runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up
-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
