### PR TITLE
[None][feat] Add single block version renormalized routing kernel

### DIFF
--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingRenormalize.cu
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingRenormalize.cu
@@ -27,6 +27,8 @@ static constexpr int MaxNumTopExperts = 8;
 static constexpr int MaxNumExperts = 128;
 static constexpr int MaxNumTokensSingleCluster = NumBlocksPerCluster * NumThreads;
 static constexpr int MaxNumTokensSingleClusterScores = NumBlocksPerCluster * NumWarps;
+static constexpr int NumThreadsSingleBlock = MaxNumExperts;
+static constexpr int BlockKernelMaxNumTokens = 4;
 
 template <typename DataType, typename InputType, int VecSize, bool DoSoftmaxBeforeTopK>
 __forceinline__ __device__ void routingTopKExperts(cg::thread_block_tile<WarpSize> const& warp,
@@ -71,6 +73,156 @@ __forceinline__ __device__ void routingTopKExperts(cg::thread_block_tile<WarpSiz
         if (laneIdx < topK)
         {
             warpTopKScore[laneIdx] = softmaxScore;
+        }
+    }
+}
+
+template <typename KernelParams, bool DoSoftmaxBeforeTopK = false>
+__global__ void __launch_bounds__(NumThreadsSingleBlock) routingIndicesBlockKernel(KernelParams params)
+{
+    // types used in this kernel
+    using OutputT = typename KernelParams::OutputT;
+    using InputT = typename KernelParams::InputT;
+    using BaseType = std::conditional_t<KernelParams::DoSoftmaxBeforeTopK, float, InputT>;
+    using TypePacked = PackedScoreIdx<BaseType>;
+
+    int32_t const warpIdx = __shfl_sync(0xffffffff, threadIdx.x / WarpSize, 0);
+    int32_t const laneIdx = cutlass::arch::LaneId();
+    int32_t const expert = threadIdx.x;
+    auto scoreOffset = warpIdx * params.mNumExperts;
+    bool validToken = warpIdx < params.mNumTokens;
+
+    static constexpr int VecSize = MaxNumExperts / WarpSize;
+    static constexpr int totalExpertCounts = BlockKernelMaxNumTokens * MaxNumExperts;
+    __shared__ int8_t __attribute((aligned(128))) smemOffset[totalExpertCounts];
+    __shared__ int8_t __attribute((aligned(128))) smemKIdx[totalExpertCounts];
+
+    using Scan = cub::BlockScan<int32_t, NumThreadsSingleBlock, cub::BLOCK_SCAN_WARP_SCANS>;
+    __shared__ typename Scan::TempStorage tempStorage;
+
+    auto block = cg::this_thread_block();
+    auto warp = cg::tiled_partition<WarpSize>(block);
+
+    for (int i = threadIdx.x; i < totalExpertCounts; i += blockDim.x)
+    {
+        smemOffset[i] = int8_t{-1};
+        smemKIdx[i] = int8_t{-1};
+    }
+    __syncthreads();
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    // then wait on primary grid
+    if constexpr (KernelParams::UsePdl)
+    {
+        cudaGridDependencySynchronize();
+    }
+#endif
+
+    if (params.mPtrScores != nullptr)
+    {
+        // in this case, each warp represents a token
+        BaseType score[VecSize];
+        int32_t idx[VecSize];
+
+        BaseType warpTopKScore[MaxNumTopExperts];
+        int32_t warpTopKExpertIdx[MaxNumTopExperts];
+
+        BaseType minScore = BaseType{-INFINITY};
+        if (validToken)
+        {
+            routingTopKExperts<BaseType, InputT, VecSize, KernelParams::DoSoftmaxBeforeTopK>(warp, score, idx,
+                warpTopKScore, warpTopKExpertIdx, laneIdx, params.mNumExperts, params.mTopK,
+                params.mPtrScores + scoreOffset, params.mNormTopkProb);
+
+            if (laneIdx < params.mTopK)
+            {
+                int offset = warpIdx * MaxNumExperts + warpTopKExpertIdx[laneIdx];
+                smemKIdx[offset] = static_cast<int8_t>(laneIdx);
+                if (params.mPtrExpertWeights != nullptr)
+                {
+                    params.mPtrExpertWeights[warpIdx * params.mTopK + laneIdx] = OutputT{warpTopKScore[laneIdx]};
+                }
+            }
+        } // end if (validToken)
+    }
+    __syncthreads();
+
+    // set local experts
+    auto localExpertIdx = expert - params.mLocalExpertsStartIdx;
+    auto isLocalExpert = localExpertIdx >= 0 && localExpertIdx < params.mNumLocalExperts
+        && (localExpertIdx & params.mLocalExpertsStrideLog2) == 0;
+    // Get the count of each expert and the offset for each token
+    int accExpertCount = 0;
+
+    if (isLocalExpert)
+    {
+        int offset = expert;
+        for (int j = 0; j < BlockKernelMaxNumTokens; j++)
+        {
+            if (smemKIdx[offset] >= 0)
+            {
+                smemOffset[offset] = static_cast<int8_t>(accExpertCount);
+                accExpertCount++;
+            }
+            offset += MaxNumExperts;
+        }
+    }
+    __syncthreads();
+    // Get the number of CTAs and the offset for each CTA
+    const int32_t numCta = divUpLog2<int32_t>(accExpertCount, params.mPaddingLog2);
+    int32_t ctaOffset = 0;
+    int32_t numNonExitingCtas;
+    Scan(tempStorage).ExclusiveSum(numCta, ctaOffset, numNonExitingCtas);
+
+    int32_t expertScanCounts = 0;
+    Scan(tempStorage).ExclusiveSum(divUpMulLog2(accExpertCount, params.mPaddingLog2), expertScanCounts);
+    __syncthreads();
+
+    if (isLocalExpert)
+    {
+        for (int cta = 0; cta < numCta; ++cta)
+        {
+            const int32_t localExpertIdx = (expert - params.mLocalExpertsStartIdx) >> params.mLocalExpertsStrideLog2;
+            params.mPtrCtaIdxXyToBatchIdx[ctaOffset + cta] = localExpertIdx;
+            params.mPtrCtaIdxXyToMnLimit[ctaOffset + cta]
+                = min(mulLog2<int32_t>(ctaOffset + cta + 1, params.mPaddingLog2),
+                    mulLog2<int32_t>(ctaOffset, params.mPaddingLog2) + accExpertCount);
+        }
+    }
+
+    // at this point, we can write out padded count
+    if (threadIdx.x == 0)
+    {
+        const int32_t permutedIdxSize = mulLog2<int32_t>(numNonExitingCtas, params.mPaddingLog2);
+        params.mPtrPermutedIdxSize[0] = permutedIdxSize;
+        params.mPtrNumNonExitingCtas[0] = numNonExitingCtas;
+    }
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+#if !defined(FDL_PROFILE) || FDL_PROFILE == 0
+    // we can trigger the next kernel at this point
+    if constexpr (KernelParams::UsePdl)
+    {
+        cudaTriggerProgrammaticLaunchCompletion();
+    }
+#endif
+#endif
+
+    for (int tokenIdx = 0; tokenIdx < params.mNumTokens; tokenIdx++)
+    {
+        int offset = tokenIdx * MaxNumExperts + threadIdx.x;
+        if (smemKIdx[offset] >= 0)
+        {
+            int const expandedIdx = tokenIdx * params.mTopK + smemKIdx[offset];
+            int const offsetWithinExpert = static_cast<int>(smemOffset[offset]);
+            int const offsetForExpert = expertScanCounts;
+            int const permutedIdx = isLocalExpert ? offsetForExpert + offsetWithinExpert : int32_t{-1};
+
+            params.mPtrExpandedIdxToPermutedIdx[expandedIdx] = permutedIdx;
+            if (isLocalExpert)
+            {
+                params.mPtrPermutedIdxToTokenIdx[permutedIdx] = tokenIdx;
+            }
         }
     }
 }
@@ -234,10 +386,11 @@ void run(Data const& data, void* stream)
         data.mNumExperts % 4 == 0, "Routing kernel expects #experts %d to be a multiple of 4.", data.mNumExperts);
     TLLM_CHECK_WITH_INFO(data.mPaddingLog2 < 8, "Routing kernel expects padding log2 < 8, got %d", data.mPaddingLog2);
 
+    bool const useSingleBlock = data.mNumTokens <= BlockKernelMaxNumTokens;
     bool const useSingleCluster
         = data.mNumTokens <= (data.mPtrScores != nullptr ? MaxNumTokensSingleClusterScores : MaxNumTokensSingleCluster);
 
-    if (!useSingleCluster)
+    if (!useSingleCluster && !useSingleBlock)
     {
         TLLM_CHECK_WITH_INFO(
             data.mPtrExpertIdx != nullptr, "When #tokens is large, `mPtrExpertIdx` is a required input.");
@@ -245,7 +398,15 @@ void run(Data const& data, void* stream)
             data.mPtrExpertCounts != nullptr, "When #tokens is large, `mPtrExpertCounts` is a required input.");
     }
 
-    if (useSingleCluster)
+    if (useSingleBlock)
+    {
+        //@TODO: For now we use the single block kernel for cases with token number no larger than 4.
+        // We will future tune this threshold based on the performance.
+        LAUNCH_ROUTING_WITH_EXTRA_FLAG(data, false, routingIndicesBlockKernel, 1, NumThreadsSingleBlock,
+            /*smemSize=*/0, // No dynamic smem
+            stream, data.mDoSoftmaxBeforeTopK, /*forceFloatInput=*/false);
+    }
+    else if (useSingleCluster)
     {
         LAUNCH_ROUTING_WITH_EXTRA_FLAG(data, false, routingIndicesClusterKernel, NumBlocksPerCluster, NumThreads,
             /*smemSize=*/0, // No dynamic smem

--- a/cpp/tests/unit_tests/kernels/routing/routingRenormalizeTest.cpp
+++ b/cpp/tests/unit_tests/kernels/routing/routingRenormalizeTest.cpp
@@ -178,6 +178,28 @@ private:
 
 TYPED_TEST_SUITE(RoutingRenormalizeKernelTest, FloatAndBf16Types);
 
+TYPED_TEST(RoutingRenormalizeKernelTest, BlockLevelParallelization)
+{
+    RoutingKernelTestParam param(RoutingMethodType::Renormalize, /*numTokens=*/4,
+        /*numExperts=*/128, /*topK=*/8,
+        /*expertParallelization=*/1, /*expertParallelizationId=*/0,
+        /*paddingLog2=*/3, /*localExpertsStrideLog2=*/0,
+        /*usePdl=*/true, /*getExpWeights=*/true,
+        /*nGroup*/ 0, /*topkGroup*/ 0, /*routedScalingFactor*/ 1.0f, /*requiredComputeCapability*/ 9);
+    this->runTest(param);
+};
+
+TYPED_TEST(RoutingRenormalizeKernelTest, BlockLevelParallelizationWithExpertParallelization)
+{
+    RoutingKernelTestParam param(RoutingMethodType::Renormalize, /*numTokens=*/14,
+        /*numExperts=*/128, /*topK=*/8,
+        /*expertParallelization=*/2, /*expertParallelizationId=*/1,
+        /*paddingLog2=*/3, /*localExpertsStrideLog2=*/0,
+        /*usePdl=*/true, /*getExpWeights=*/true,
+        /*nGroup*/ 0, /*topkGroup*/ 0, /*routedScalingFactor*/ 1.0f, /*requiredComputeCapability*/ 9);
+    this->runTest(param);
+};
+
 TYPED_TEST(RoutingRenormalizeKernelTest, ClusterLevelParallelization)
 {
     RoutingKernelTestParam param(RoutingMethodType::Renormalize, /*numTokens=*/10,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optimized routing path that accelerates very small token batches (up to 4 tokens), improving routing efficiency and latency for small requests.
* **Tests**
  * Added unit tests covering the new small-batch routing path, including scenarios with and without expert-parallel execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

This PR aims to optimize the performance of the renormalized routing kernel in the low-latency scenario (for Qwen3 and Orangina) in the MoE Trtllm Gen backend.

One simple example here shows the performance before and after optimization for token number 4 (for data type `float`  and `bfloat16`).
<img width="1248" height="208" alt="image" src="https://github.com/user-attachments/assets/c73f7922-6089-4fcc-9476-b5d0a087b9e5" />

<img width="1422" height="194" alt="image" src="https://github.com/user-attachments/assets/b9903ec9-da94-43d5-92d3-6bbfc940ae68" />

@MatthiasKohl Hi Matthias, please help review this kernel. This kernel uses one block to handle the 4 tokens. I used two int8 sparse arrays in shared memory to simplify the calculation.   
@rosenrodt  Hi Anthony, this is the same PR you helped review. Now we need to merge it into the GH main branch. 

## Test Coverage

`./tests/unit_tests/kernels/routingKernelsTest --gtest_filter=RoutingRenormalizeKernelTest/*`

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
