### PR TITLE
[None][chore] Find LLM_ROOT and LLM_BACKEND_ROOT dynamically

### DIFF
--- a/tests/integration/defs/triton_server/conftest.py
+++ b/tests/integration/defs/triton_server/conftest.py
@@ -77,7 +77,10 @@ def output_dir(request):
 @pytest.fixture(scope="session")
 def llm_backend_root():
     llm_root = os.environ.get("LLM_ROOT", find_repo_root())
-    return os.path.join(llm_root, "triton_backend")
+    backend_root = os.path.join(llm_root, "triton_backend")
+    assert os.path.isabs(backend_root), "LLM backend path must be absolute"
+    assert os.path.exists(backend_root), f"{backend_root} does not exist"
+    return backend_root
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/defs/triton_server/conftest.py
+++ b/tests/integration/defs/triton_server/conftest.py
@@ -13,6 +13,14 @@ from .trt_test_alternative import (SessionDataWriter, check_call, check_output,
                                    print_info)
 
 
+def find_repo_root():
+    """Find the repository root by going up 4 directories from the current file location."""
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    for _ in range(4):
+        current_dir = os.path.dirname(current_dir)
+    return current_dir
+
+
 def llm_models_root() -> str:
     '''return LLM_MODELS_ROOT path if it is set in env, assert when it's set but not a valid path
     '''
@@ -68,7 +76,8 @@ def output_dir(request):
 
 @pytest.fixture(scope="session")
 def llm_backend_root():
-    return os.path.join(os.environ["LLM_ROOT"], "triton_backend")
+    llm_root = os.environ.get("LLM_ROOT", find_repo_root())
+    return os.path.join(llm_root, "triton_backend")
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/defs/triton_server/test_triton_llm.py
+++ b/tests/integration/defs/triton_server/test_triton_llm.py
@@ -5,12 +5,13 @@ import pytest
 import torch
 import yaml
 
-sys.path.append(os.path.join(os.environ["LLM_ROOT"], "triton_backend"))
-
 from .build_engines import *
 from .common import *
-from .conftest import venv_check_call, venv_check_output
+from .conftest import find_repo_root, venv_check_call, venv_check_output
 from .trt_test_alternative import call, check_call, print_info
+
+LLM_ROOT = os.environ.get("LLM_ROOT", find_repo_root())
+sys.path.append(os.path.join(LLM_ROOT, "triton_backend"))
 
 
 @pytest.fixture(autouse=True)
@@ -91,7 +92,7 @@ def test_llama_v2_7b_ifb(
     if E2E_MODEL_NAME == "ensemble" and ACCUMULATE_TOKEN == "True":
         pytest.skip("Skipping.")
 
-    llm_backend_repo_root = os.environ["LLM_BACKEND_ROOT"]
+    llm_backend_repo_root = os.path.join(LLM_ROOT, "triton_backend")
     # Build engine
     ENGINE_PATH = prepare_llama_v2_7b_engine("ifb",
                                              tensorrt_llm_llama_example_root,
@@ -216,7 +217,7 @@ def test_mistral_v1_7b_ifb(
     if E2E_MODEL_NAME == "ensemble" and ACCUMULATE_TOKEN == "True":
         pytest.skip("Skipping.")
 
-    llm_backend_repo_root = os.environ["LLM_BACKEND_ROOT"]
+    llm_backend_repo_root = os.path.join(LLM_ROOT, "triton_backend")
     # Build Engine
     ENGINE_PATH = prepare_mistral_v1_7b_engine("ifb",
                                                tensorrt_llm_llama_example_root,
@@ -333,7 +334,7 @@ def test_mistral_v1_multi_models(
     if E2E_MODEL_NAME == "ensemble" and ACCUMULATE_TOKEN == "True":
         pytest.skip("Skipping.")
 
-    llm_backend_repo_root = os.environ["LLM_BACKEND_ROOT"]
+    llm_backend_repo_root = os.path.join(LLM_ROOT, "triton_backend")
     # Build Engine
     ENGINE_PATH = prepare_mistral_v1_7b_engine("ifb",
                                                tensorrt_llm_llama_example_root,
@@ -402,8 +403,7 @@ def test_mistral_v1_7b_python_backend(
     tensorrt_llm_llama_example_root,
     llm_backend_venv,
 ):
-    llm_backend_repo_root = os.path.join(os.environ["LLM_ROOT"],
-                                         "triton_backend")
+    llm_backend_repo_root = os.path.join(LLM_ROOT, "triton_backend")
     # Build Engine
     ENGINE_PATH = prepare_mistral_v1_7b_engine("python_backend",
                                                tensorrt_llm_llama_example_root,
@@ -520,7 +520,7 @@ def test_llama_v2_70b_ifb(
     if E2E_MODEL_NAME == "ensemble" and ACCUMULATE_TOKEN == "True":
         pytest.skip("Skipping.")
 
-    llm_backend_repo_root = os.environ["LLM_BACKEND_ROOT"]
+    llm_backend_repo_root = os.path.join(LLM_ROOT, "triton_backend")
     # Build Engine
     ENGINE_PATH = prepare_llama_v2_70b_engine("ifb",
                                               tensorrt_llm_llama_example_root,
@@ -640,7 +640,7 @@ def test_llama_v2_70b_ifb_lad(
     if BATCHING_STRATEGY == "V1" and BATCH_SCHEDULER_POLICY == "max_utilization":
         pytest.skip("Skipping. V1 doesn't support max_utilization.")
 
-    llm_backend_repo_root = os.environ["LLM_BACKEND_ROOT"]
+    llm_backend_repo_root = os.path.join(LLM_ROOT, "triton_backend")
 
     # Build Engine
     ENGINE_PATH = prepare_llama_v2_70b_engine("ifb",
@@ -765,7 +765,7 @@ def test_medusa_vicuna_7b_ifb(
     if E2E_MODEL_NAME == "ensemble" and ACCUMULATE_TOKEN == "True":
         pytest.skip("Skipping.")
 
-    llm_backend_repo_root = os.environ["LLM_BACKEND_ROOT"]
+    llm_backend_repo_root = os.path.join(LLM_ROOT, "triton_backend")
     # Build Engine
     ENGINE_PATH = prepare_medusa_vicuna_7b_engine(
         tensorrt_llm_medusa_example_root, vicuna_7b_model_root,
@@ -890,7 +890,7 @@ def test_eagle_vicuna_7b_ifb(
     if E2E_MODEL_NAME == "ensemble" and ACCUMULATE_TOKEN == "True":
         pytest.skip("Skipping.")
 
-    llm_backend_repo_root = os.environ["LLM_BACKEND_ROOT"]
+    llm_backend_repo_root = os.path.join(LLM_ROOT, "triton_backend")
     # Build Engine
     ENGINE_PATH = prepare_eagle_vicuna_7b_engine(
         tensorrt_llm_eagle_example_root, vicuna_7b_model_root,
@@ -967,7 +967,7 @@ def test_gpt_350m_python_backend(
     gpt_tokenizer_model_root,
     llm_backend_venv,
 ):
-    llm_backend_repo_root = os.environ["LLM_BACKEND_ROOT"]
+    llm_backend_repo_root = os.path.join(LLM_ROOT, "triton_backend")
     # Build engine
     ENGINE_PATH = prepare_gpt_350m_engine(
         "python_backend",
@@ -1096,7 +1096,7 @@ def test_gpt_350m_ifb(
     if E2E_MODEL_NAME == "ensemble" and ACCUMULATE_TOKEN == "True":
         pytest.skip("Skipping.")
 
-    llm_backend_repo_root = os.environ["LLM_BACKEND_ROOT"]
+    llm_backend_repo_root = os.path.join(LLM_ROOT, "triton_backend")
     # Build engine
     ENGINE_PATH = prepare_gpt_350m_engine(
         "ifb",
@@ -1232,7 +1232,7 @@ def test_t5_small_enc_dec_ifb(
     if E2E_MODEL_NAME == "ensemble" and ACCUMULATE_TOKEN == "True":
         pytest.skip("Skipping.")
 
-    llm_backend_repo_root = os.environ["LLM_BACKEND_ROOT"]
+    llm_backend_repo_root = os.path.join(LLM_ROOT, "triton_backend")
     # Build engine
     ENCODER_ENGINE_DIR, ENGINE_DIR = prepare_t5_small_engine(
         tensorrt_llm_enc_dec_example_root, t5_small_model_root)
@@ -1353,7 +1353,7 @@ def test_whisper_large_v3_ifb(
     if E2E_MODEL_NAME == "ensemble" and ACCUMULATE_TOKEN == "True":
         pytest.skip("Skipping.")
 
-    llm_backend_repo_root = os.environ["LLM_BACKEND_ROOT"]
+    llm_backend_repo_root = os.path.join(LLM_ROOT, "triton_backend")
     # Build engine
     ENCODER_ENGINE_DIR, ENGINE_DIR = prepare_whisper_large_engine(
         tensorrt_llm_whisper_example_root, whisper_large_model_root)
@@ -1489,7 +1489,7 @@ def test_gpt_gather_logits_ifb(
     if BATCHING_STRATEGY == "V1" and BATCH_SCHEDULER_POLICY == "max_utilization":
         pytest.skip("Skipping. V1 doesn't support max_utilization.")
 
-    llm_backend_repo_root = os.environ["LLM_BACKEND_ROOT"]
+    llm_backend_repo_root = os.path.join(LLM_ROOT, "triton_backend")
     # Build engine
     ENGINE_PATH = prepare_gpt_gather_logits_engine(
         "ifb",
@@ -1616,7 +1616,7 @@ def test_gpt_350m_speculative_decoding(
     if E2E_MODEL_NAME == "ensemble" and ACCUMULATE_TOKEN == "True":
         pytest.skip("Skipping.")
 
-    llm_backend_repo_root = os.environ["LLM_BACKEND_ROOT"]
+    llm_backend_repo_root = os.path.join(LLM_ROOT, "triton_backend")
     # Build engine
     CONTROL_ENGINE_DIR = prepare_gpt_350m_engine(
         "medium_control_ifb",
@@ -1806,7 +1806,7 @@ def test_gpt_350m_speculative_decoding_return_logits(
     if E2E_MODEL_NAME == "ensemble" and ACCUMULATE_TOKEN == "True":
         pytest.skip("Skipping.")
 
-    llm_backend_repo_root = os.environ["LLM_BACKEND_ROOT"]
+    llm_backend_repo_root = os.path.join(LLM_ROOT, "triton_backend")
     # Build engine
     CONTROL_ENGINE_DIR = prepare_gpt_350m_engine(
         "medium_control_ifb",
@@ -1999,7 +1999,7 @@ def test_gpt_speculative_decoding_bls(
     if E2E_MODEL_NAME == "ensemble" and ACCUMULATE_TOKEN == "True":
         pytest.skip("Skipping.")
 
-    llm_backend_repo_root = os.environ["LLM_BACKEND_ROOT"]
+    llm_backend_repo_root = os.path.join(LLM_ROOT, "triton_backend")
     # Build engine
     CONTROL_ENGINE_DIR = prepare_gpt_350m_engine(
         "medium_control_ifb",
@@ -2159,7 +2159,7 @@ def test_llama_v3_speculative_decoding_bls(
     if E2E_MODEL_NAME == "ensemble" and ACCUMULATE_TOKEN == "True":
         pytest.skip("Skipping.")
 
-    llm_backend_repo_root = os.environ["LLM_BACKEND_ROOT"]
+    llm_backend_repo_root = os.path.join(LLM_ROOT, "triton_backend")
     # Build engine
     DRAFT_ENGINE_DIR = prepare_llama_v3_8b_engine(
         tensorrt_llm_example_root,
@@ -2324,7 +2324,7 @@ def test_gpt_175b_dummyWeights_ifb(
     if E2E_MODEL_NAME == "ensemble" and ACCUMULATE_TOKEN == "True":
         pytest.skip("Skipping.")
 
-    llm_backend_repo_root = os.environ["LLM_BACKEND_ROOT"]
+    llm_backend_repo_root = os.path.join(LLM_ROOT, "triton_backend")
     # Build Engine
     ENGINE_PATH = prepare_gpt_175b_engine("ifb", tensorrt_llm_gpt_example_root,
                                           tensorrt_llm_example_root)
@@ -2440,7 +2440,7 @@ def test_llava(
     if E2E_MODEL_NAME == "ensemble" and ACCUMULATE_TOKEN == "True":
         pytest.skip("Skipping.")
 
-    llm_backend_repo_root = os.environ["LLM_BACKEND_ROOT"]
+    llm_backend_repo_root = os.path.join(LLM_ROOT, "triton_backend")
     # Build Engine
     ENGINE_PATH, MULTIMODAL_ENGINE_DIR = prepare_llava_engine(
         tensorrt_llm_multimodal_example_root, tensorrt_llm_llama_example_root,
@@ -2576,7 +2576,7 @@ def test_llava_onevision(
     if E2E_MODEL_NAME == "ensemble" and ACCUMULATE_TOKEN == "True":
         pytest.skip("Skipping.")
 
-    llm_backend_repo_root = os.environ["LLM_BACKEND_ROOT"]
+    llm_backend_repo_root = os.path.join(LLM_ROOT, "triton_backend")
     # Build Engine
     ENGINE_PATH, MULTIMODAL_ENGINE_DIR = prepare_llava_onevision_engine(
         tensorrt_llm_multimodal_example_root, tensorrt_llm_qwen_example_root,
@@ -2735,7 +2735,7 @@ def test_mllama(
     if E2E_MODEL_NAME == "ensemble" and ACCUMULATE_TOKEN == "True":
         pytest.skip("Skipping.")
 
-    llm_backend_repo_root = os.environ["LLM_BACKEND_ROOT"]
+    llm_backend_repo_root = os.path.join(LLM_ROOT, "triton_backend")
     # Build Engine
     ENGINE_PATH, MULTIMODAL_ENGINE_DIR = prepare_mllama_engine(
         tensorrt_llm_multimodal_example_root, tensorrt_llm_mllama_example_root,
@@ -2910,7 +2910,7 @@ def test_gpt_next_ptuning_ifb(
     if E2E_MODEL_NAME == "ensemble" and ACCUMULATE_TOKEN == "True":
         pytest.skip("Skipping.")
 
-    llm_backend_repo_root = os.environ["LLM_BACKEND_ROOT"]
+    llm_backend_repo_root = os.path.join(LLM_ROOT, "triton_backend")
     # Build engine
     ENGINE_PATH, output_model_dir = prepare_gpt_next_ptuning_engine(
         "ifb", tensorrt_llm_gpt_example_root, gpt_next_ptuning_model_root)
@@ -3088,7 +3088,7 @@ def test_gpt_2b_lora_ifb(
     if E2E_MODEL_NAME == "ensemble" and ACCUMULATE_TOKEN == "True":
         pytest.skip("Skipping.")
 
-    llm_backend_repo_root = os.environ["LLM_BACKEND_ROOT"]
+    llm_backend_repo_root = os.path.join(LLM_ROOT, "triton_backend")
     # Build engine
     weight_streaming = float(GPU_WEIGHTS_PERCENT) < 1.0
     ENGINE_PATH = prepare_gpt_2b_lora_engine("ifb",
@@ -3239,7 +3239,7 @@ def test_tiny_llama_1b_guided_decoding(
     if E2E_MODEL_NAME == "ensemble" and ACCUMULATE_TOKEN == "True":
         pytest.skip("Skipping.")
 
-    llm_backend_repo_root = os.environ["LLM_BACKEND_ROOT"]
+    llm_backend_repo_root = os.path.join(LLM_ROOT, "triton_backend")
 
     # Build engine
     ENGINE_PATH, XGRAMMAR_TOKENIZER_INFO_PATH = prepare_tiny_llama_1b_engine(
@@ -3388,7 +3388,7 @@ def test_gpt_disaggregated_serving_bls(
     if E2E_MODEL_NAME == "ensemble" and ACCUMULATE_TOKEN == "True":
         pytest.skip("Skipping.")
 
-    llm_backend_repo_root = os.environ["LLM_BACKEND_ROOT"]
+    llm_backend_repo_root = os.path.join(LLM_ROOT, "triton_backend")
     # Build engine
     ENGINE_PATH = prepare_gpt_350m_engine(
         "ifb",
@@ -3556,7 +3556,7 @@ def test_benchmark_core_model(
     llm_backend_venv,
 ):
 
-    llm_backend_repo_root = os.environ["LLM_BACKEND_ROOT"]
+    llm_backend_repo_root = os.path.join(LLM_ROOT, "triton_backend")
     # Build Engine
     ENGINE_PATH = model_setup["prepare_engine_fn"](
         "ifb", model_setup["example_root"], model_setup["tokenizer_path"])
@@ -3632,7 +3632,7 @@ def test_llmapi_backend(E2E_MODEL_NAME, DECOUPLED_MODE, TRITON_MAX_BATCH_SIZE,
                         TENSOR_PARALLEL_SIZE,
                         llm_backend_inflight_batcher_llm_root, llm_backend_venv,
                         llm_backend_dataset_root):
-    llm_backend_repo_root = os.environ["LLM_BACKEND_ROOT"]
+    llm_backend_repo_root = os.path.join(LLM_ROOT, "triton_backend")
 
     if torch.cuda.device_count() < int(TENSOR_PARALLEL_SIZE):
         pytest.skip("Skipping. Not enough GPUs.")
@@ -3789,7 +3789,7 @@ def test_tiny_llama_ifb_token_counts(
     if E2E_MODEL_NAME == "ensemble" and ACCUMULATE_TOKEN == "True":
         pytest.skip("Skipping.")
 
-    llm_backend_repo_root = os.environ["LLM_BACKEND_ROOT"]
+    llm_backend_repo_root = os.path.join(LLM_ROOT, "triton_backend")
     # Build engine
     ENGINE_PATH, _ = prepare_tiny_llama_1b_engine(
         type="ifb",


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tests now derive backend paths with a fallback repository-root discovery and validate computed paths to avoid fragile failures when env vars are missing.
  * Centralized backend root resolution across integration tests for consistency.

* **Tests**
  * Test harness extended to support config-driven, per-model test setups and multi-model benchmarking.
  * Added configurable latency thresholds per GPU/model to enforce performance limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

This removes the need to set the environment variables before running pytest

## Test Coverage

All Triton tests udpated

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
