### PR TITLE
[TRTLLM-6341][chore] Preliminary refactors on the kv cache manager before supporting swa kv cache reuse

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -1106,6 +1106,15 @@ public:
         return mWindowBlockManagers.at(windowSize).getPool(relativePoolIndex);
     }
 
+    //! \brief Update cache offsets for blocks initiated from sequence
+    void updateSequenceCacheBlockOffsets(GenerationRequest& seq, SizeType32 windowSize);
+
+    //! \brief Update cache offsets for last block
+    void updateLastCacheBlockOffsets(GenerationRequest& seq, SizeType32 windowSize);
+
+    //! \brief Update cache offsets for block at index
+    void updateCacheBlockOffsetsAtIdx(GenerationRequest& seq, SizeType32 windowSize, SizeType32 blockIdx);
+
 private:
     [[nodiscard]] WindowBlockManager const& windowManagerByLayer(SizeType32 layerIdx) const
     {
@@ -1636,12 +1645,6 @@ public:
     /// @return SizeType32 A maximum attention window in number of tokens.
     [[nodiscard]] static SizeType32 calculateMaxAttentionWindow(SizeType32 inputLength, SizeType32 outputLength,
         SizeType32 sinkTokenLength, SizeType32 blockCapacity, SizeType32 beamWidth, SizeType32 tokensPerBlock);
-
-private:
-    void cacheBlockOffsets(GenerationRequest& seq, SizeType32 windowSize);
-    void cacheNewBlockOffsets(GenerationRequest& seq, SizeType32 windowSize);
-    void updateNewBlockPointer(GenerationRequest& seq, SizeType32 windowSize, SizeType32 blockIdx);
-    void updateToken(GenerationRequest& sequence, bool addToken);
 
 private:
     // Maximum number of sequences

--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -551,7 +551,7 @@ public:
         GenerationRequest& sequence, SizeType32 inputLength, SizeType32 numContextBlocks, LlmRequest& llmRequest);
 
     //! \brief Assign blocks for new sequence. Does not try to reuse blocks.
-    void addSequence(GenerationRequest& sequence, SizeType32 numBlocks, SizeType32 unsharedBlockIdx);
+    void addSequence(GenerationRequest& sequence, SizeType32 numContextBlocks, bool isShareLastContextBlock);
 
     //! \brief Allocate new block for each beam of the sequence.
     //! \details Might free cached blocks if no free blocks are available.
@@ -869,8 +869,13 @@ public:
     void addSequence(GenerationRequest& sequence, SizeType32 inputLength, SizeType32 numContextBlocks,
         LlmRequest& llmRequest, SizeType32 windowSize);
 
+    //! \brief Assign blocks for a new sequence.
+    //! \param sequence  The GenerationRequest to process.
+    //! \param numContextBlocks  Number of context blocks to allocate.
+    //! \param windowSize  Attention window size
+    //! \param isShareLastContextBlock  If true, the last context block is shared among beams.
     void addSequence(
-        GenerationRequest& sequence, SizeType32 numBlocks, SizeType32 unsharedBlockIdx, SizeType32 windowSize);
+        GenerationRequest& sequence, SizeType32 numContextBlocks, SizeType32 windowSize, bool isShareLastContextBlock);
 
     void allocateBlock(GenerationRequest& sequence, SizeType32 windowSize);
 

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -1146,12 +1146,16 @@ void WindowBlockManager::refreshBlocks()
     mTransferManager->syncTransfers();
 }
 
+// There are two versions of BlockManager::addSequence function.
+// This is called when block reuse is enabled.
 void BlockManager::addSequence(GenerationRequest& sequence, SizeType32 inputLength, SizeType32 numContextBlocks,
     LlmRequest& llmRequest, SizeType32 windowSize)
 {
     mWindowBlockManagers.at(windowSize).addSequence(sequence, inputLength, numContextBlocks, llmRequest);
 }
 
+// There are two versions of WindowBlockManager::addSequence function.
+// This is called when block reuse is enabled.
 void WindowBlockManager::addSequence(
     GenerationRequest& sequence, SizeType32 inputLength, SizeType32 numContextBlocks, LlmRequest& llmRequest)
 {
@@ -1189,12 +1193,16 @@ void WindowBlockManager::addSequence(
         inputLength, prepopulatedPromptLen);
 }
 
+// There are two versions of BlockManager::addSequence function.
+// This is called when block reuse is disabled.
 void BlockManager::addSequence(
     GenerationRequest& sequence, SizeType32 numBlocks, SizeType32 unsharedBlockIdx, SizeType32 windowSize)
 {
     mWindowBlockManagers.at(windowSize).addSequence(sequence, numBlocks, unsharedBlockIdx);
 }
 
+// There are two versions of WindowBlockManager::addSequence function.
+// This is called when block reuse is disabled.
 void WindowBlockManager::addSequence(GenerationRequest& sequence, SizeType32 numBlocks, SizeType32 unsharedBlockIdx)
 {
     auto const requestId = sequence.getRequestId();

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -1639,6 +1639,8 @@ KVCacheManager::KVCacheManager(std::vector<SizeType32> const& numKvHeadsPerLayer
     // disable block reuse for sink bubble since chopVectorIntoBlocks does not match KV cache blocks in this case
     , mEnableBlockReuse{mSinkBubbleLength > 0 ? false : enableBlockReuse}
 {
+    TLLM_CHECK_WITH_INFO(mSinkBlockTokenLength == 0 && mSinkBubbleLength == 0,
+        "[kv cache manager] streamLLM is not supported at the moment");
     TLLM_CHECK_DEBUG(std::find(maxAttentionWindowVec.begin(), maxAttentionWindowVec.end(), mMaxAttentionWindow)
         != maxAttentionWindowVec.end());
     // The sink tokens are stored in blocks separate from other tokens.
@@ -1834,7 +1836,7 @@ SizeType32 KVCacheManager::getRemainingBlocksToCompletion(LlmRequest const& req,
     return (numTotalBlocksPerBeam - numAllocBlocksPerBeam) * req.mSamplingConfig.beamWidth;
 }
 
-void KVCacheManager::cacheBlockOffsets(GenerationRequest& sequence, SizeType32 windowSize)
+void BlockManager::updateSequenceCacheBlockOffsets(GenerationRequest& sequence, SizeType32 windowSize)
 {
     auto const& cacheBlocks = sequence.getCacheBlockIds(windowSize);
     auto& cacheBlocksTensor = sequence.getCacheBlockIndices(windowSize);
@@ -1849,12 +1851,12 @@ void KVCacheManager::cacheBlockOffsets(GenerationRequest& sequence, SizeType32 w
         for (SizeType32 blockIdx = 0; blockIdx < static_cast<SizeType32>(beamCacheBlock.size()); ++blockIdx)
         {
             auto const blockId = beamCacheBlock.at(blockIdx);
-            mBlockManager.setOffsets(offsetsPtr, offsetsShape, beamIdx, blockIdx, blockId, windowSize);
+            mWindowBlockManagers.at(windowSize).setOffsets(offsetsPtr, offsetsShape, beamIdx, blockIdx, blockId);
         }
     }
 }
 
-void KVCacheManager::cacheNewBlockOffsets(GenerationRequest& sequence, SizeType32 windowSize)
+void BlockManager::updateLastCacheBlockOffsets(GenerationRequest& sequence, SizeType32 windowSize)
 {
     auto const& cacheBlocks = sequence.getCacheBlockIds(windowSize);
     auto& cacheBlocksTensor = sequence.getCacheBlockIndices(windowSize);
@@ -1868,11 +1870,11 @@ void KVCacheManager::cacheNewBlockOffsets(GenerationRequest& sequence, SizeType3
         auto const& beamCacheBlock = cacheBlocks[beamIdx];
         auto const blockId = beamCacheBlock.back();
         auto const blockIdx = static_cast<SizeType32>(beamCacheBlock.size() - 1);
-        mBlockManager.setOffsets(offsetsPtr, offsetsShape, beamIdx, blockIdx, blockId, windowSize);
+        mWindowBlockManagers.at(windowSize).setOffsets(offsetsPtr, offsetsShape, beamIdx, blockIdx, blockId);
     }
 }
 
-void KVCacheManager::updateNewBlockPointer(GenerationRequest& sequence, SizeType32 windowSize, SizeType32 blockIdx)
+void BlockManager::updateCacheBlockOffsetsAtIdx(GenerationRequest& sequence, SizeType32 windowSize, SizeType32 blockIdx)
 {
     auto const& cacheBlocks = sequence.getCacheBlockIds(windowSize);
     auto& cacheBlocksTensor = sequence.getCacheBlockIndices(windowSize);
@@ -1885,74 +1887,35 @@ void KVCacheManager::updateNewBlockPointer(GenerationRequest& sequence, SizeType
     {
         auto const& beamCacheBlock = cacheBlocks[beamIdx];
         auto const blockId = beamCacheBlock.at(blockIdx);
-        mBlockManager.setOffsets(offsetsPtr, offsetsShape, beamIdx, blockIdx, blockId, windowSize);
-    }
-}
-
-void KVCacheManager::updateToken(GenerationRequest& sequence, bool addToken)
-{
-    auto currNumTokens = sequence.getNumTokens();
-
-    if (addToken)
-    {
-        sequence.addNewTokens(1);
-    }
-    else
-    {
-        sequence.removeTokens(1);
-    }
-
-    auto newNumTokens = sequence.getNumTokens();
-
-    if (!addToken)
-    {
-        std::swap(currNumTokens, newNumTokens);
-    }
-
-    for (auto const [windowSize, metadata] : mBlockManager.getWindowSizesMetadata())
-    {
-        auto const maxTokenNum = metadata.maxTokenNum;
-        SizeType32 const cyclicTokenNum = maxTokenNum - mSinkBlockTokenLength;
-        SizeType32 const nextTokenIdxInCycle = (currNumTokens - mSinkBlockTokenLength) % cyclicTokenNum;
-        SizeType32 const nextTokenIdxInCache = mSinkBlockTokenLength + nextTokenIdxInCycle;
-
-        // (nextTokenIdxInCache - mSinkBlockTokenLength) % cyclicTokenNum == 0)
-        // <=> nextTokenIdxInCycle == 0
-        // <=> nextTokenIdxInCache == mSinkBlockTokenLength
-        // => nextTokenIdxInCache % getTokensPerBlock() == 0
-
-        // Check if require a new block
-        if (nextTokenIdxInCache % getTokensPerBlock() == 0)
-        {
-            if (newNumTokens <= maxTokenNum)
-            {
-                if (addToken)
-                {
-                    mBlockManager.allocateBlock(sequence, windowSize);
-                    cacheNewBlockOffsets(sequence, windowSize);
-                }
-                else
-                {
-                    mBlockManager.releaseLastBlock(sequence, windowSize);
-                }
-            }
-            else if (sequence.getBeamWidth() > 1)
-            {
-                TLLM_CHECK_WITH_INFO(addToken, "Remove token is not supported with beam search");
-                // Get next block index
-                SizeType32 nextBlockIdx = nextTokenIdxInCache / getTokensPerBlock();
-                // Replace the shared block with the unshared ones
-                mBlockManager.replaceSharedBlock(sequence, windowSize, nextBlockIdx);
-                updateNewBlockPointer(sequence, windowSize, nextBlockIdx);
-            }
-        }
+        mWindowBlockManagers.at(windowSize).setOffsets(offsetsPtr, offsetsShape, beamIdx, blockIdx, blockId);
     }
 }
 
 void KVCacheManager::addToken(RequestIdType requestId)
 {
+    // TODO: add streamLLM support
     auto& sequence = getSequence(requestId);
-    updateToken(sequence, true);
+    sequence.addNewTokens(1);
+    for (auto const [windowSize, metadata] : mBlockManager.getWindowSizesMetadata())
+    {
+        if ((sequence.getNumTokens() - 1) % getTokensPerBlock() == 0)
+        {
+            if (sequence.getNumTokens() <= windowSize)
+            {
+                // Allocate new unshared blocks until the window can always
+                // accommodate "window size" number of tokens.
+                mBlockManager.allocateBlock(sequence, windowSize);
+                mBlockManager.updateLastCacheBlockOffsets(sequence, windowSize);
+            }
+            else if (sequence.getBeamWidth() > 1)
+            {
+                // For beam search, shared block is replaced with unshared ones
+                auto const nextBlockIdx = (sequence.getNumTokens() - 1) / getTokensPerBlock();
+                mBlockManager.replaceSharedBlock(sequence, windowSize, nextBlockIdx);
+                mBlockManager.updateCacheBlockOffsetsAtIdx(sequence, windowSize, nextBlockIdx);
+            }
+        }
+    }
 }
 
 std::optional<BlockKey> KVCacheManager::findNewContextBlock(
@@ -2026,7 +1989,7 @@ void KVCacheManager::addSequence(
             }
             mBlockManager.addSequence(sequence, numContextBlocks, unsharedBlockIdx, windowSize);
         }
-        cacheBlockOffsets(sequence, windowSize);
+        mBlockManager.updateSequenceCacheBlockOffsets(sequence, windowSize);
     }
 
     if (llmRequest)
@@ -2353,15 +2316,23 @@ BlocksPerWindow BaseKVCacheManager::calculateMaxNumBlocks(executor::KvCacheConfi
 
 void KVCacheManager::removeToken(RequestIdType requestId)
 {
+    // TODO: add streamLLM support
     auto& sequence = getSequence(requestId);
-    auto const beamWidth = sequence.getBeamWidth();
-
-    TLLM_CHECK_WITH_INFO(beamWidth == 1, "removeToken does not support beamWidth > 1");
     if (sequence.getNumTokens() == 0)
     {
         return;
     }
-    updateToken(sequence, false);
+    TLLM_CHECK_WITH_INFO(sequence.getBeamWidth() == 1, "[kv cache manager] removeToken does not support beamWidth > 1");
+    sequence.removeTokens(1);
+    for (auto const [windowSize, metadata] : mBlockManager.getWindowSizesMetadata())
+    {
+        SizeType32 const maxTokensInWindow = metadata.maxTokenNum;
+        SizeType32 const tokensInWindow = sequence.getNumTokens() % maxTokensInWindow;
+        if (tokensInWindow % getTokensPerBlock() == 0 && tokensInWindow <= maxTokensInWindow)
+        {
+            mBlockManager.releaseLastBlock(sequence, windowSize);
+        }
+    }
 }
 
 void KVCacheManager::rewindKVCache(RequestIdType requestId, SizeType32 rewindLengths)

--- a/cpp/tests/unit_tests/batch_manager/capacitySchedulerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/capacitySchedulerTest.cpp
@@ -408,10 +408,6 @@ int runTest(CapacityScheduler& capacityScheduler,
             else
             {
                 kvCacheManager->addToken(llmReq->mRequestId);
-                if (crossKvCacheManager)
-                {
-                    crossKvCacheManager->addToken(llmReq->mRequestId);
-                }
                 llmReq->addNewTokens({itCount});
             }
             if (llmReq->getNumTokens(0) == promptLen + llmReq->mMaxNewTokens)

--- a/cpp/tests/unit_tests/batch_manager/capacitySchedulerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/capacitySchedulerTest.cpp
@@ -453,7 +453,8 @@ TEST_F(CapacitySchedulerTest, SimpleShouldFit)
 
     auto capacitySchedulerPolicies = std::vector<CapacitySchedulerPolicy>{CapacitySchedulerPolicy::kGUARANTEED_NO_EVICT,
         CapacitySchedulerPolicy::kMAX_UTILIZATION, CapacitySchedulerPolicy::kSTATIC_BATCH};
-    auto sinkTokenLens = std::vector<SizeType32>{0, 4};
+    // TODO: Support and add coverage for sinkTokenLen > 0. (e.g. 4)
+    auto sinkTokenLens = std::vector<SizeType32>{0};
     for (auto capacitySchedulerPolicy : capacitySchedulerPolicies)
     {
         for (auto sinkTokenLen : sinkTokenLens)
@@ -506,7 +507,8 @@ TEST_F(CapacitySchedulerTest, SimpleShouldFitWithCrossBlocks)
 
     auto capacitySchedulerPolicies
         = std::vector<CapacitySchedulerPolicy>{CapacitySchedulerPolicy::kGUARANTEED_NO_EVICT};
-    auto sinkTokenLens = std::vector<SizeType32>{0, 4};
+    // TODO: Support and add coverage for sinkTokenLen > 0. (e.g. 4)
+    auto sinkTokenLens = std::vector<SizeType32>{0};
     for (auto capacitySchedulerPolicy : capacitySchedulerPolicies)
     {
         for (auto sinkTokenLen : sinkTokenLens)
@@ -550,7 +552,8 @@ TEST_F(CapacitySchedulerTest, SimpleLoraFitsDuplicateTask)
 
     auto capacitySchedulerPolicies = std::vector<CapacitySchedulerPolicy>{CapacitySchedulerPolicy::kGUARANTEED_NO_EVICT,
         CapacitySchedulerPolicy::kMAX_UTILIZATION, CapacitySchedulerPolicy::kSTATIC_BATCH};
-    auto sinkTokenLens = std::vector<SizeType32>{0, 4};
+    // TODO: Support and add coverage for sinkTokenLen > 0. (e.g. 4)
+    auto sinkTokenLens = std::vector<SizeType32>{0};
     for (auto capacitySchedulerPolicy : capacitySchedulerPolicies)
     {
         for (auto sinkTokenLen : sinkTokenLens)
@@ -594,7 +597,8 @@ TEST_F(CapacitySchedulerTest, SimpleLoraDoesntFitDuplicateTask)
 
     auto capacitySchedulerPolicies = std::vector<CapacitySchedulerPolicy>{CapacitySchedulerPolicy::kGUARANTEED_NO_EVICT,
         CapacitySchedulerPolicy::kMAX_UTILIZATION, CapacitySchedulerPolicy::kSTATIC_BATCH};
-    auto sinkTokenLens = std::vector<SizeType32>{0, 4};
+    // TODO: Support and add coverage for sinkTokenLen > 0. (e.g. 4)
+    auto sinkTokenLens = std::vector<SizeType32>{0};
 
     for (auto capacitySchedulerPolicy : capacitySchedulerPolicies)
     {
@@ -704,7 +708,8 @@ TEST_F(CapacitySchedulerTest, SimpleDoesntFitMaxUtilization)
     SizeType32 maxNumRequests = 2;
     SizeType32 maxInputLen = 1000;
 
-    auto sinkTokenLens = std::vector<SizeType32>{0, 4};
+    // TODO: Support and add coverage for sinkTokenLen > 0. (e.g. 4)
+    auto sinkTokenLens = std::vector<SizeType32>{0};
     for (auto sinkTokenLen : sinkTokenLens)
     {
         auto kvCacheManager = getKvCacheManager(
@@ -829,9 +834,13 @@ TEST_F(CapacitySchedulerTest, SimpleDoesntFitPriorities)
     SizeType32 maxNumRequests = 2;
     SizeType32 maxInputLen = 1000;
 
+    // TODO: Support and add coverage for sinkTokenLen > 0
+    // Removed configuration:
+    // {CapacitySchedulerPolicy::kMAX_UTILIZATION, 4, 125}
+    // {CapacitySchedulerPolicy::kGUARANTEED_NO_EVICT, 1, 160}
+    auto sinkTokenLens = std::vector<SizeType32>{0};
     auto configurations = std::vector<std::tuple<CapacitySchedulerPolicy, SizeType32, int>>{
-        {CapacitySchedulerPolicy::kMAX_UTILIZATION, 0, 119}, {CapacitySchedulerPolicy::kMAX_UTILIZATION, 4, 125},
-        {CapacitySchedulerPolicy::kGUARANTEED_NO_EVICT, 1, 160}};
+        {CapacitySchedulerPolicy::kMAX_UTILIZATION, 0, 119}};
 
     for (auto [capacitySchedulerPolicy, sinkTokenLen, expectedNumIters] : configurations)
     {
@@ -1027,7 +1036,8 @@ TEST_F(CapacitySchedulerTest, SimpleDoesntFitGuaranteedCompletion)
     SizeType32 maxNumRequests = 2;
     SizeType32 maxInputLen = 1000;
 
-    auto sinkTokenLens = std::vector<SizeType32>{0, 4};
+    // TODO: Support and add coverage for sinkTokenLen > 0. (e.g. 4)
+    auto sinkTokenLens = std::vector<SizeType32>{0};
     for (auto sinkTokenLen : sinkTokenLens)
     {
         auto kvCacheManager = getKvCacheManager(
@@ -1080,7 +1090,8 @@ TEST_F(CapacitySchedulerTest, SimpleDoesntFitWithCrossBlocks)
 
     auto capacitySchedulerPolicies
         = std::vector<CapacitySchedulerPolicy>{CapacitySchedulerPolicy::kGUARANTEED_NO_EVICT};
-    auto sinkTokenLens = std::vector<SizeType32>{0, 4};
+    // TODO: Support and add coverage for sinkTokenLen > 0
+    auto sinkTokenLens = std::vector<SizeType32>{0};
 
     for (auto capacitySchedulerPolicy : capacitySchedulerPolicies)
     {
@@ -1172,7 +1183,8 @@ TEST_F(CapacitySchedulerTest, SimpleDoesntFitAddingNewRequestsMaxUtilization)
     SizeType32 maxNumRequests = 4;
     SizeType32 maxInputLen = 1000;
 
-    auto sinkTokenLens = std::vector<SizeType32>{0, 4};
+    // TODO: Support and add coverage for sinkTokenLen > 0
+    auto sinkTokenLens = std::vector<SizeType32>{0};
     for (auto sinkTokenLen : sinkTokenLens)
     {
         auto kvCacheManager = getKvCacheManager(
@@ -1357,7 +1369,8 @@ TEST_F(CapacitySchedulerTest, SimpleDoesntFitAddingNewRequestsMaxUtilizationPrio
     SizeType32 maxNumRequests = 4;
     SizeType32 maxInputLen = 1000;
 
-    auto sinkTokenLens = std::vector<SizeType32>{0, 4};
+    // TODO: Support and add coverage for sinkTokenLen > 0
+    auto sinkTokenLens = std::vector<SizeType32>{0};
     for (auto sinkTokenLen : sinkTokenLens)
     {
         auto kvCacheManager = getKvCacheManager(
@@ -1504,7 +1517,8 @@ TEST_F(CapacitySchedulerTest, SimpleDoesntFitAddingNewRequestsGuaranteedCompleti
     SizeType32 maxNumRequests = 4;
     SizeType32 maxInputLen = 1000;
 
-    auto sinkTokenLens = std::vector<SizeType32>{0, 4};
+    // TODO: Support and add coverage for sinkTokenLen > 0
+    auto sinkTokenLens = std::vector<SizeType32>{0};
     for (auto sinkTokenLen : sinkTokenLens)
     {
         auto kvCacheManager = getKvCacheManager(
@@ -1555,7 +1569,8 @@ TEST_F(CapacitySchedulerTest, SimpleDoesntFitAddingNewRequestsGuaranteedCompleti
     SizeType32 maxNumRequests = 4;
     SizeType32 maxInputLen = 1000;
 
-    auto sinkTokenLens = std::vector<SizeType32>{0, 4};
+    // TODO: Support and add coverage for sinkTokenLen > 0
+    auto sinkTokenLens = std::vector<SizeType32>{0};
     for (auto sinkTokenLen : sinkTokenLens)
     {
         auto kvCacheManager = getKvCacheManager(
@@ -1835,7 +1850,8 @@ TEST_F(CapacitySchedulerTest, SimpleFitsStaticBatch)
     SizeType32 maxNumRequests = 2;
     SizeType32 maxInputLen = 1000;
 
-    auto sinkTokenLens = std::vector<SizeType32>{0, 4};
+    // TODO: Support and add coverage for sinkTokenLen > 0
+    auto sinkTokenLens = std::vector<SizeType32>{0};
     for (auto sinkTokenLen : sinkTokenLens)
     {
         auto kvCacheManager = getKvCacheManager(

--- a/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
@@ -2408,6 +2408,7 @@ TEST_P(KVCacheManagerTest, DISABLED_KVCacheManagerAllocationTest)
 
 TEST_P(KVCacheManagerTest, KVCacheManagerTest)
 {
+    // Full attention
     using DType = half;
     using SizeType32 = KVCacheManager::SizeType32;
 
@@ -2655,6 +2656,7 @@ TEST_P(KVCacheManagerTest, KVCacheManagerMaxAttentionWindowTest)
     auto constexpr tokensPerBlock = 64;
     auto constexpr blockLengthPerSeq = 10;
     auto constexpr maxNumSequences = 8;
+    // TODO: Support and add coverage for beamWidth > 1
     auto constexpr maxBeamWidth = 1;
     auto constexpr sinkTokenLength = 0;
     auto const stream = std::make_shared<tr::CudaStream>();
@@ -2664,10 +2666,10 @@ TEST_P(KVCacheManagerTest, KVCacheManagerMaxAttentionWindowTest)
 
     auto constexpr inputLength = maxNumTokens - tokensPerBlock - 1;
     // Enable cyclic kv cache for all new generated tokens.
-    auto constexpr maxAttentionWindow = inputLength;
-    auto constexpr numSharedBlocks = std::min(inputLength, maxAttentionWindow) / tokensPerBlock;
-    auto constexpr numBlocksPerSeq = numSharedBlocks + (blockLengthPerSeq - numSharedBlocks) * maxBeamWidth;
+    auto constexpr maxAttentionWindow = maxNumTokens;
+    auto constexpr numSharedBlocks = inputLength / tokensPerBlock;
     auto constexpr maxBlocksPerSeq = tc::ceilDiv(maxAttentionWindow, tokensPerBlock);
+    auto constexpr numBlocksPerSeq = numSharedBlocks + (maxBlocksPerSeq - numSharedBlocks) * maxBeamWidth;
 
     auto constexpr totalNumBlocks = maxNumSequences * numBlocksPerSeq;
     auto constexpr blocksInSecondaryPool = 0;
@@ -2757,9 +2759,9 @@ TEST_P(KVCacheManagerTest, KVCacheManagerMaxAttentionWindowTest)
     }
 
     EXPECT_NO_THROW(kvCacheManager.addToken(requestId));
-    EXPECT_EQ(blockManager.getNumFreeBlocks(), totalNumBlocks - numBlocksPerSeq + 1);
+    EXPECT_EQ(blockManager.getNumFreeBlocks(), totalNumBlocks - numSharedBlocks - maxBeamWidth);
     EXPECT_NO_THROW(kvCacheManager.addToken(requestId));
-    EXPECT_EQ(blockManager.getNumFreeBlocks(), totalNumBlocks - numBlocksPerSeq + 1);
+    EXPECT_EQ(blockManager.getNumFreeBlocks(), totalNumBlocks - numSharedBlocks - maxBeamWidth * 2);
     EXPECT_NO_THROW(kvCacheManager.removeSequence(requestId));
     EXPECT_EQ(blockManager.getNumFreeBlocks(), totalNumBlocks);
 
@@ -3488,8 +3490,10 @@ TEST_F(KVCacheManagerTest, KVCacheTransferManagerConcurrencyTest)
     }
 }
 
-TEST_P(KVCacheManagerTest, KVCacheManagerSinkTokenLengthTest)
+TEST_P(KVCacheManagerTest, DISABLED_KVCacheManagerSinkTokenLengthTest)
 {
+    // TODO: Support sink attention and add coverage
+    // TODO: Support and add coverage for beamWidth > 1
     using DType = half;
     using SizeType32 = KVCacheManager::SizeType32;
 
@@ -3633,6 +3637,7 @@ TEST_P(KVCacheManagerTest, KVCacheManagerSinkTokenLengthTest)
 
 TEST_P(KVCacheManagerTest, KVCacheManagerBatchTest)
 {
+    // Full attention
     using DType = half;
     using SizeType32 = KVCacheManager::SizeType32;
 
@@ -4124,6 +4129,8 @@ TEST_P(RemainingBlocksToCompletionTest, RemainingBlocksToCompletionCorrectlyEsti
     ASSERT_EQ(result, params.expectedRemainingBlocksToCompletion);
 }
 
+// TODO: Support and add coverage for beamWidth > 1
+// TODO: Support and add coverage for sink attention
 INSTANTIATE_TEST_SUITE_P(RemainingBlocksToCompletionCorrectlyEstimated, RemainingBlocksToCompletionTest,
     ::testing::Values(
         GetRemainingBlocksToCompletionOneRequestParameters{
@@ -4228,6 +4235,8 @@ TEST_P(FillKvCacheAndCompleteRequestsTest, FillKvCacheAndCompleteInParallel)
     }
 }
 
+// TODO: Support and add coverage for beamWidth > 1
+// TODO: Support and add coverage for sink attention
 auto const paramValues = ::testing::Values(
     FillKvCacheAndCompleteRequestsParameters{
         KvCacheManagerInstantiationParameters{

--- a/cpp/tests/unit_tests/batch_manager/kvCacheUtilsTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/kvCacheUtilsTest.cpp
@@ -84,6 +84,7 @@ TEST_F(BlockIteratorTest, CacheManagerTest)
     auto const stream = std::make_shared<tr::CudaStream>();
     auto constexpr onboardBlocks = true;
 
+    // TODO: Support and add coverage for beamWidth > 1
     auto constexpr beamWidth = 1;
     auto constexpr numBlocksPerBeam = blocksInPrimaryPool / beamWidth;
     auto constexpr maxSequenceLength = tokensPerBlock * numBlocksPerBeam;

--- a/cpp/tests/unit_tests/batch_manager/llmRequestTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/llmRequestTest.cpp
@@ -748,13 +748,13 @@ TEST_P(ParamTest, createResponse)
 
 INSTANTIATE_TEST_SUITE_P(LlmRequestTest, ParamTest,
     testing::Combine(
-        // streaming
-        testing::Values(false, true),
+        // TODO: Support and add coverage for streamLLM
+        testing::Values(false),
         // excludeInputFromOutput
         testing::Values(false, true),
         // returnAllGeneratedTokens
         testing::Values(false, true),
-        // beamWdith
+        // beamWidth
         testing::Values(1, 2),
         // tokensPerIteration
         testing::Values(1, 3),


### PR DESCRIPTION
## Description

<!--
Please explain the issue and the solution in short.
-->

This MR is a preliminary MR for implementing the SWA reuse mechanism for the kv cache manager. Please be aware that **no functional change is intended** in this merge request. The purpose of the clean-up is to decouple and remove existing functions for the up-coming SWA KV cache reuse change to be more natural and easier to review.

Right now, (1) streamLLM, and (2) beam search with SWA, are broken. We do not want to complicate the code base by stacking more features upon something that does not work. This MR prunes out the logic and add assertions so we can come back and re-support the broken feature and remove the assertion.

Since streamLLM (sink attention) is broken now, assertion is added under `KVCacheManager` ctor to guard for the value of `mSinkBlockTokenLength` and `mSinkBubbleLength`. Compute logics relate to it are pruned.

The beam search with SWA will still be broke when introducing the SWA KV cache reuse. We will revisit this problem in the future.

On top of this, we should make an effort to update the [supporting matrix](https://github.com/NVIDIA/TensorRT-LLM/blob/feat/1.0_doc_dev/docs/source/1.0/features/feature-combination-matrix.md) of the kv cache manager after merging the support of SWA KV cache reuse.

Changes are listed as following:
- Separate `KVCacheManager::updateToken` into `KVCacheManager::addToken` and `KVCacheManager::removeToken`. The functionality should be decoupled.
- Push utility `cacheSequenceBlockOffsets` and `cacheNewBlockOffset` from `KVCacheManager` down to `WindowBlockManager`. `KVCacheManager`-exposed functions should be real utilities that users of the structure can leverage. Implementation-detailed function calls should not exist at this level.
- Simplify "is shared last context block" logic under `KVCacheManager::addSequence`.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

Since no functional change is intended in this merge request, no test case is added. Several comments are added for future test coverage reminder.

For `LlmRequestTest.ParamTest`, `streaming=True` is commented out because we guard sink attention with assertion now.

In `capacitySchedulerTest`, `addToken` action to crossKVCacheManager is removed because in encoder-decoder model, generation tokens are added only to the decoder and not to the encoder.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-window KV-cache flows and a new explicit option to share the last context block; window-aware public APIs to update KV-cache offsets.

* **Refactor**
  * Centralized block allocation and offset-update responsibilities under window-aware block managers; per-window routing for sequence/token handling.

* **Behavior Changes**
  * Streaming generation disabled/guarded; legacy shared/unshared replacement paths removed; sequence/block APIs changed (window-aware, share-last flag).

* **Tests**
  * Unit tests simplified; sink-token >0 and multi-beam coverage deferred or disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->