### PR TITLE
[None] [feat] Enable run_post_quant_allgather for MoE TRTLLM backend

### DIFF
--- a/cpp/tensorrt_llm/kernels/customMoeRoutingKernels.cu
+++ b/cpp/tensorrt_llm/kernels/customMoeRoutingKernels.cu
@@ -38,17 +38,18 @@ static constexpr int WARPS_PER_BLOCK = BLOCK_SIZE / WARP_SIZE;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-template <typename T>
-__device__ T calcSoftmax(cg::thread_block_tile<WARP_SIZE> const& warp, T score, int32_t laneIdx, int32_t NumTopExperts)
+template <typename DataType>
+__device__ DataType calcSoftmax(
+    cg::thread_block_tile<WARP_SIZE> const& warp, DataType score, int32_t laneIdx, int32_t NumTopExperts)
 {
-    T maxScore = T{-INFINITY};
+    float maxScore = -INFINITY;
     if (laneIdx < NumTopExperts)
     {
-        maxScore = score >= maxScore ? score : maxScore;
+        maxScore = float(score) >= maxScore ? float(score) : maxScore;
     }
-    maxScore = cg::reduce(warp, maxScore, cg::greater<T>());
+    maxScore = cg::reduce(warp, maxScore, cg::greater<float>());
 
-    float sumScore{0.f};
+    float sumScore = 0.f;
     float newScore;
     // Get the summation of scores for each token
     if (laneIdx < NumTopExperts)
@@ -61,7 +62,7 @@ __device__ T calcSoftmax(cg::thread_block_tile<WARP_SIZE> const& warp, T score, 
 
     if (laneIdx < NumTopExperts)
     {
-        score = static_cast<T>(newScore / sumScore);
+        score = static_cast<DataType>(newScore / sumScore);
     }
 
     return score;
@@ -70,31 +71,35 @@ __device__ T calcSoftmax(cg::thread_block_tile<WARP_SIZE> const& warp, T score, 
 template <typename DataType, int VecSize>
 __device__ void calcSoftmax(cg::thread_block_tile<WARP_SIZE> const& warp, DataType (&scores)[VecSize])
 {
-    DataType maxScore = DataType{-INFINITY};
-    DataType sumScore = DataType{0.f};
-
+    // Compute in float to support half/bfloat16 inputs safely.
+    float maxScore = -INFINITY;
+    float sumScore = 0.f;
     // Get the max score for each token
 #pragma unroll
     for (int i = 0; i < VecSize; ++i)
     {
-        maxScore = scores[i] >= maxScore ? scores[i] : maxScore;
+        float si = static_cast<float>(scores[i]);
+        maxScore = si >= maxScore ? si : maxScore;
     }
-    maxScore = cg::reduce(warp, maxScore, cg::greater<DataType>());
+    maxScore = cg::reduce(warp, maxScore, cg::greater<float>());
 
     // Get the summation of scores for each token
 #pragma unroll
     for (int i = 0; i < VecSize; ++i)
     {
-        scores[i] = static_cast<DataType>(exp(scores[i] - maxScore));
-        sumScore += scores[i];
+        float si = static_cast<float>(scores[i]);
+        float e = expf(si - maxScore);
+        scores[i] = static_cast<DataType>(e);
+        sumScore += e;
     }
-    sumScore = cg::reduce(warp, sumScore, cg::plus<DataType>());
+    sumScore = cg::reduce(warp, sumScore, cg::plus<float>());
 
     // Normalize the scores
 #pragma unroll
     for (int i = 0; i < VecSize; ++i)
     {
-        scores[i] = static_cast<DataType>(scores[i] / sumScore);
+        float si = static_cast<float>(scores[i]) / sumScore;
+        scores[i] = static_cast<DataType>(si);
     }
 }
 
@@ -205,7 +210,7 @@ int nextPowerOfTwo(int num)
         break;
 
 template <typename InputT, typename OutputT, typename IdxT, bool DoSoftmaxBeforeTopK>
-void invokeRenormMoeRouting(InputT* routerLogits, OutputT* topkValues, IdxT* topkIndices, int64_t const numTokens,
+void invokeCustomMoeRouting(InputT* routerLogits, OutputT* topkValues, IdxT* topkIndices, int64_t const numTokens,
     int64_t const numExperts, int64_t const topK, cudaStream_t const stream)
 {
 
@@ -249,20 +254,25 @@ void invokeRenormMoeRouting(InputT* routerLogits, OutputT* topkValues, IdxT* top
 }
 
 #define INSTANTIATE_RENORM_MOE_ROUTING(InputT, OutputT, IdxT, DoSoftmaxBeforeTopK)                                     \
-    template void invokeRenormMoeRouting<InputT, OutputT, IdxT, DoSoftmaxBeforeTopK>(InputT * routerLogits,            \
+    template void invokeCustomMoeRouting<InputT, OutputT, IdxT, DoSoftmaxBeforeTopK>(InputT * routerLogits,            \
         OutputT * topkValues, IdxT * topkIndices, int64_t const numTokens, int64_t const numExperts,                   \
         int64_t const topK, cudaStream_t const stream);
 
 INSTANTIATE_RENORM_MOE_ROUTING(float, float, int32_t, false);
 INSTANTIATE_RENORM_MOE_ROUTING(half, float, int32_t, false);
-#ifdef ENABLE_BF16
-INSTANTIATE_RENORM_MOE_ROUTING(__nv_bfloat16, float, int32_t, false);
-#endif
-
 INSTANTIATE_RENORM_MOE_ROUTING(float, float, int32_t, true);
 INSTANTIATE_RENORM_MOE_ROUTING(half, float, int32_t, true);
+
 #ifdef ENABLE_BF16
+INSTANTIATE_RENORM_MOE_ROUTING(__nv_bfloat16, float, int32_t, false);
+INSTANTIATE_RENORM_MOE_ROUTING(float, __nv_bfloat16, int32_t, false);
+INSTANTIATE_RENORM_MOE_ROUTING(half, __nv_bfloat16, int32_t, false);
+INSTANTIATE_RENORM_MOE_ROUTING(__nv_bfloat16, __nv_bfloat16, int32_t, false);
+
 INSTANTIATE_RENORM_MOE_ROUTING(__nv_bfloat16, float, int32_t, true);
+INSTANTIATE_RENORM_MOE_ROUTING(float, __nv_bfloat16, int32_t, true);
+INSTANTIATE_RENORM_MOE_ROUTING(half, __nv_bfloat16, int32_t, true);
+INSTANTIATE_RENORM_MOE_ROUTING(__nv_bfloat16, __nv_bfloat16, int32_t, true);
 #endif
 
 } // namespace tensorrt_llm::kernels

--- a/cpp/tensorrt_llm/kernels/customMoeRoutingKernels.h
+++ b/cpp/tensorrt_llm/kernels/customMoeRoutingKernels.h
@@ -24,6 +24,6 @@
 namespace tensorrt_llm::kernels
 {
 template <typename InputT, typename OutputT, typename IdxT, bool DoSoftmaxBeforeTopK>
-void invokeRenormMoeRouting(InputT* routerLogits, OutputT* topkValues, IdxT* topkIndices, int64_t const numTokens,
+void invokeCustomMoeRouting(InputT* routerLogits, OutputT* topkValues, IdxT* topkIndices, int64_t const numTokens,
     int64_t const numExperts, int64_t const topK, cudaStream_t const stream);
 } // namespace tensorrt_llm::kernels

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingKernel.cuh
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingKernel.cuh
@@ -118,30 +118,35 @@ __device__ void initArr(int startIdx, int numElts, int stride, DataType* arr, Da
 template <typename DataType, int VecSize>
 __device__ void calcSoftmax(cg::thread_block_tile<WarpSize> const& warp, DataType (&scores)[VecSize])
 {
-    DataType maxScore = DataType{-INFINITY};
-    DataType sumScore = DataType{0.f};
-
+    // Compute in float to support half/bfloat16 inputs safely.
+    float maxScore = -INFINITY;
+    float sumScore = 0.f;
     // Get the max score for each token
+#pragma unroll
     for (int i = 0; i < VecSize; ++i)
     {
-        maxScore = scores[i] >= maxScore ? scores[i] : maxScore;
+        float si = static_cast<float>(scores[i]);
+        maxScore = si >= maxScore ? si : maxScore;
     }
-    maxScore = cg::reduce(warp, maxScore, cg::greater<DataType>());
+    maxScore = cg::reduce(warp, maxScore, cg::greater<float>());
 
     // Get the summation of scores for each token
 #pragma unroll
     for (int i = 0; i < VecSize; ++i)
     {
-        scores[i] = static_cast<DataType>(exp(scores[i] - maxScore));
-        sumScore += scores[i];
+        float si = static_cast<float>(scores[i]);
+        float e = expf(si - maxScore);
+        scores[i] = static_cast<DataType>(e);
+        sumScore += e;
     }
-    sumScore = cg::reduce(warp, sumScore, cg::plus<DataType>());
+    sumScore = cg::reduce(warp, sumScore, cg::plus<float>());
 
     // Normalize the scores
 #pragma unroll
     for (int i = 0; i < VecSize; ++i)
     {
-        scores[i] = static_cast<DataType>(scores[i] / sumScore);
+        float si = static_cast<float>(scores[i]) / sumScore;
+        scores[i] = static_cast<DataType>(si);
     }
 }
 
@@ -232,8 +237,16 @@ __device__ void routingPermutation(KernelParams params, PackedScoreIdx<BaseType>
         TypePacked scoreIdx;
         if constexpr (LoadExpertIdxFromGlobal)
         {
-            scoreIdx = TypePacked{static_cast<BaseType>(params.mPtrExpertIdx[expandedIdx].score),
-                static_cast<int16_t>(params.mPtrExpertIdx[expandedIdx].idx)};
+            if (params.mPtrTopKIds != nullptr)
+            {
+                scoreIdx = TypePacked{static_cast<BaseType>(params.mPtrTopKWeights[expandedIdx]),
+                    static_cast<int16_t>(params.mPtrTopKIds[expandedIdx])};
+            }
+            else
+            {
+                scoreIdx = TypePacked{static_cast<BaseType>(params.mPtrTopKPacked[expandedIdx].score),
+                    static_cast<int16_t>(params.mPtrTopKPacked[expandedIdx].idx)};
+            }
         }
         else
         {
@@ -248,9 +261,9 @@ __device__ void routingPermutation(KernelParams params, PackedScoreIdx<BaseType>
         auto isLocalExpert = localExpertIdx >= 0 && localExpertIdx < localExpertExtent
             && (localExpertIdx & params.mLocalExpertsStrideLog2) == 0;
         expertOffsets[ii] = isLocalExpert ? atomicAdd(smemExpertCount + scoreIdx.idx, 1) : 0;
-        if (params.mPtrExpertWeights != nullptr)
+        if (params.mPtrTopKWeights != nullptr && params.mPtrTopKIds == nullptr)
         {
-            params.mPtrExpertWeights[expandedIdx] = OutputT{scoreIdx.score};
+            params.mPtrTopKWeights[expandedIdx] = OutputT{scoreIdx.score};
         }
     };
 
@@ -459,19 +472,29 @@ __global__ void __launch_bounds__(NumThreadsHist) routingIndicesHistogramKernel(
     // Define a lambda to avoid code duplication in branches.
     auto loopBody = [&](int expandedIdx)
     {
-        PackedScoreIdx<OutputT> scoreIdx = params.mPtrExpertIdx[expandedIdx];
+        PackedScoreIdx<OutputT> scoreIdx;
+        int idx;
+        if (params.mPtrTopKIds != nullptr)
+        {
+            idx = params.mPtrTopKIds[expandedIdx];
+        }
+        else
+        {
+            // If params.mPtrTopKIds != nullptr, we don't need to store the weights
+            if (params.mPtrTopKWeights != nullptr)
+            {
+                scoreIdx = params.mPtrTopKPacked[expandedIdx];
+                idx = scoreIdx.idx;
+                params.mPtrTopKWeights[expandedIdx] = static_cast<OutputT>(scoreIdx.score);
+            }
+        }
         // check whether this expert is local to our GPU at all and ignore if not
-        auto localExpertIdx = scoreIdx.idx - params.mLocalExpertsStartIdx;
+        auto localExpertIdx = idx - params.mLocalExpertsStartIdx;
         auto isLocalExpert = localExpertIdx >= 0 && localExpertIdx < localExpertExtent
             && (localExpertIdx & params.mLocalExpertsStrideLog2) == 0;
         if (isLocalExpert)
         {
-            atomicAdd(&smemExpertCount[scoreIdx.idx], 1);
-        }
-
-        if (params.mPtrExpertWeights != nullptr)
-        {
-            params.mPtrExpertWeights[expandedIdx] = static_cast<OutputT>(scoreIdx.score);
+            atomicAdd(&smemExpertCount[idx], 1);
         }
     };
 
@@ -625,13 +648,13 @@ __global__ void __launch_bounds__(NumThreadsHist) routingIndicesOffsetsKernel(Ke
         // Define a lambda to avoid code duplication in branches.
         auto loopBody = [&](int ii, int expandedIdx)
         {
-            PackedScoreIdx<OutputT> scoreIdx = params.mPtrExpertIdx[expandedIdx];
-            expertIndexes[ii] = scoreIdx.idx;
+            expertIndexes[ii]
+                = params.mPtrTopKIds ? params.mPtrTopKIds[expandedIdx] : params.mPtrTopKPacked[expandedIdx].idx;
             // check whether this expert is local to our GPU at all and ignore if not
-            auto localExpertIdx = scoreIdx.idx - params.mLocalExpertsStartIdx;
+            auto localExpertIdx = expertIndexes[ii] - params.mLocalExpertsStartIdx;
             auto isLocalExpert = localExpertIdx >= 0 && localExpertIdx < localExpertExtent
                 && (localExpertIdx & params.mLocalExpertsStrideLog2) == 0;
-            expertOffsets[ii] = isLocalExpert ? atomicAdd(smemExpertCount + scoreIdx.idx, 1) : 0;
+            expertOffsets[ii] = isLocalExpert ? atomicAdd(smemExpertCount + expertIndexes[ii], 1) : 0;
         };
 
         // For all tiles but the last, all indices are in bounds.
@@ -767,5 +790,33 @@ __global__ void __launch_bounds__(NumThreadsHist) routingIndicesOffsetsKernel(Ke
 #endif // if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
 }
 
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <typename KernelParams>
+__global__ void __launch_bounds__(NumThreadsHist) routingInitExpertCounts(KernelParams params)
+{
+    // initialize the mPtrExpertCounts
+    int32_t expertCountsNum = 2 * params.mNumExperts;
+    int32_t globalThreadIdx = blockIdx.x * NumThreadsHist + threadIdx.x;
+    int32_t globalThreadStride = gridDim.x * NumThreadsHist;
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    // Wait on primary grid.
+    if constexpr (KernelParams::UsePdl)
+    {
+        cudaGridDependencySynchronize();
+    }
+#endif // if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+
+    initArr(globalThreadIdx, expertCountsNum, globalThreadStride, params.mPtrExpertCounts, 0);
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    // Wait on primary grid.
+    if constexpr (KernelParams::UsePdl)
+    {
+        cudaTriggerProgrammaticLaunchCompletion();
+    }
+#endif // if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+}
 } // namespace routing
 } // namespace moe::dev

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingKernel.h
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingKernel.h
@@ -58,17 +58,26 @@ struct DataBase
     // Note: this array (mPtrPermutedIdxToTokenIdx) is uninitialized
     // Any out-of-bounds values are undefined.
     int32_t* mPtrPermutedIdxToTokenIdx{nullptr};
+
     // optional: if `nullptr`, it is not filled
     // dim: [mNumTokens, mTopK]
-    void* mPtrExpertWeights{nullptr};
+    // When mPtrTopKIds is provided, mPtrTopKWeights must be also provided as inputs.
+    // Otherwise, mPtrTopKWeights is the output scores of the topK experts.
+    void* mPtrTopKWeights{nullptr};
+    // optional: if `nullptr`, it is not filled
+    // dim: [mNumTokens, mTopK]
+    // mPtrTopKIds[i] is the index of the expert for the i-th token in the top-k experts
+    // Together with mPtrTopKWeights, they form the top-k experts for each token
+    int32_t* mPtrTopKIds{nullptr};
+
     // optional: if `nullptr`, scores are used directly as input.
     // If it is given, it must represent a packed value s.t. the most significant
     // 16/32 bits represent the score without sigmoid activation and
     // the least significant 16 bits represent the index of the chosen expert (unsigned).
     // note: this is required if the number of tokens is large.
     // dim: [mNumTokens, mTopK]
-    void* mPtrExpertIdx{nullptr};
-    // optional: if `nullptr`, `mPtrExpertIdx` must be provided.
+    void* mPtrTopKPacked{nullptr};
+    // optional: if `nullptr`, `mPtrTopKPacked` must be provided.
     // If it is given, it represents the scores without sigmoid activation for
     // each token and expert.
     // note: if it is provided, we always re-compute the top1 scores
@@ -111,7 +120,8 @@ struct KernelParamsBase
     int32_t* mPtrCtaIdxXyToBatchIdx = nullptr;
     int32_t* mPtrCtaIdxXyToMnLimit = nullptr;
     int32_t* mPtrNumNonExitingCtas = nullptr;
-    OutputT* mPtrExpertWeights = nullptr;
+    OutputT* mPtrTopKWeights = nullptr;
+    int32_t* mPtrTopKIds = nullptr;
     InputT const* mPtrScores = nullptr;
 
     // Public scalar members
@@ -134,7 +144,8 @@ struct KernelParamsBase
         mPtrCtaIdxXyToBatchIdx = data.mPtrCtaIdxXyToBatchIdx;
         mPtrCtaIdxXyToMnLimit = data.mPtrCtaIdxXyToMnLimit;
         mPtrNumNonExitingCtas = data.mPtrNumNonExitingCtas;
-        mPtrExpertWeights = static_cast<OutputT*>(data.mPtrExpertWeights);
+        mPtrTopKWeights = static_cast<OutputT*>(data.mPtrTopKWeights);
+        mPtrTopKIds = static_cast<int32_t*>(data.mPtrTopKIds);
         mPtrScores = (InputT const*) data.mPtrScores;
 
         mNumTokens = data.mNumTokens;
@@ -176,10 +187,10 @@ struct KernelParams : public KernelParamsBase<InputT_, OutputT_, UsePdl_>
 
     static constexpr bool UseGroups = UseGroups_;
 
-    PackedScoreIdx<OutputT>* mPtrExpertIdx = nullptr;
+    PackedScoreIdx<OutputT>* mPtrTopKPacked = nullptr;
 
-    // OutputT* mPtrExpertWeightsFull = nullptr;
-    // Note: this variable(mPtrExpertWeightsFull) might need to be added back for the low-latency kernels for MoE in
+    // OutputT* mPtrTopKWeightsFull = nullptr;
+    // Note: this variable(mPtrTopKWeightsFull) might need to be added back for the low-latency kernels for MoE in
     // tllm-gen in the future
 
     OutputT const* mPtrRoutingBias = nullptr;
@@ -196,9 +207,9 @@ struct KernelParams : public KernelParamsBase<InputT_, OutputT_, UsePdl_>
         KernelParams params;
         params.setBaseParams(data);
 
-        params.mPtrExpertIdx = (PackedScoreIdx<OutputT>*) data.mPtrExpertIdx;
+        params.mPtrTopKPacked = (PackedScoreIdx<OutputT>*) data.mPtrTopKPacked;
 
-        // params.mPtrExpertWeightsFull = static_cast<OutputT*>(data.mPtrExpertWeightsFull);
+        // params.mPtrTopKWeightsFull = static_cast<OutputT*>(data.mPtrTopKWeightsFull);
         params.mPtrRoutingBias = static_cast<OutputT const*>(data.mPtrRoutingBias);
 
         params.mNumExpertGroups = data.mNumExpertGroups;
@@ -233,7 +244,7 @@ struct KernelParams : public KernelParamsBase<InputT_, OutputT_, UsePdl_>
     using InputT = InputT_;
     using OutputT = OutputT_;
 
-    PackedScoreIdx<OutputT>* mPtrExpertIdx = nullptr;
+    PackedScoreIdx<OutputT>* mPtrTopKPacked = nullptr;
 
     int32_t mTopK;
 
@@ -242,7 +253,7 @@ struct KernelParams : public KernelParamsBase<InputT_, OutputT_, UsePdl_>
         KernelParams params;
         params.setBaseParams(data);
 
-        params.mPtrExpertIdx = (PackedScoreIdx<OutputT>*) data.mPtrExpertIdx;
+        params.mPtrTopKPacked = (PackedScoreIdx<OutputT>*) data.mPtrTopKPacked;
         params.mTopK = data.mTopK;
         return params;
     }
@@ -276,7 +287,7 @@ struct KernelParams : public KernelParamsBase<InputT_, OutputT_, UsePdl_>
 
     static constexpr bool DoSoftmaxBeforeTopK = DoSoftmaxBeforeTopK_;
 
-    PackedScoreIdx<OutputT>* mPtrExpertIdx = nullptr;
+    PackedScoreIdx<OutputT>* mPtrTopKPacked = nullptr;
 
     int32_t mTopK = 0;
 
@@ -287,7 +298,7 @@ struct KernelParams : public KernelParamsBase<InputT_, OutputT_, UsePdl_>
         KernelParams params;
         params.setBaseParams(data);
 
-        params.mPtrExpertIdx = (PackedScoreIdx<OutputT>*) data.mPtrExpertIdx;
+        params.mPtrTopKPacked = (PackedScoreIdx<OutputT>*) data.mPtrTopKPacked;
         params.mNormTopkProb = data.mNormTopkProb;
         params.mTopK = data.mTopK;
         return params;

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingKernelTopK.cuh
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingKernelTopK.cuh
@@ -56,7 +56,7 @@ struct TopKRedType
     {
         auto valueBits
             = cub::Traits<TypeExpW>::TwiddleIn(reinterpret_cast<typename cub::Traits<TypeExpW>::UnsignedBits&>(val));
-        TypeCmp compactTmp = reinterpret_cast<TypeCmp&>(valueBits);
+        TypeCmp compactTmp = valueBits;
         compactTmp = (compactTmp << moveBits) | (0xFFFF & (maxIdx - idx));
         // Use 65535 minus idx to give higher priority to elements with smaller indices.
         return compactTmp;

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingLlama4.cu
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingLlama4.cu
@@ -44,7 +44,7 @@ __forceinline__ __device__ void routingTopKExperts(cg::thread_block_tile<WarpSiz
 {
     DataType minScore = DataType{-INFINITY};
     DataType maxScore = minScore;
-    int32_t maxExpertIdx{-1};
+    int32_t maxExpertIdx{0};
     using DataTypeVec = std::conditional_t<sizeof(DataType) == 2, float2, float4>;
 
     // Non-vectorized loading: directly access ptrScores with expertIdx
@@ -111,7 +111,7 @@ __global__ void __launch_bounds__(WarpSize) routingIndicesWarpKernel(KernelParam
     }
 #endif
 
-    if (params.mPtrScores != nullptr)
+    if (params.mPtrScores != nullptr && params.mPtrTopKIds == nullptr)
     {
         // if we use `mPtrScores` as input, we need to perform the top-1 reduction
         // for each token, we load the scores then use `reduceTopK` for this.
@@ -134,32 +134,48 @@ __global__ void __launch_bounds__(WarpSize) routingIndicesWarpKernel(KernelParam
                 smemExpertTokenCountFull[tokenIdx][warpMaxExpertIdx[0] / ExpertsPerThread] = expertTokenCount;
                 // we also compute the final score here and write it out if required
                 auto finalScore = OutputT{sigmoid_accurate(float{warpMaxScore[0]})};
-                if (params.mPtrExpertWeights != nullptr)
+                if (params.mPtrTopKWeights != nullptr)
                 {
-                    params.mPtrExpertWeights[tokenIdx] = finalScore;
+                    params.mPtrTopKWeights[tokenIdx] = finalScore;
                 }
             }
         }
     }
     else
     {
-        // if we do not have `mPtrScores` as input, we expect that `mPtrExpertWeights`
-        // contains the top-1 packed score and index already.
-        // Each thread represents a token here, and we extract the relevant score
-        // The assumption is that the #tokens is limited by warp-size
+        // if we do not have `mPtrScores` as input, we expect that `params.mPtrTopKPacked` or `params.mPtrTopKIds` and
+        // `params.mPtrTopKWeights` contains the top-1 packed score and index already. Each thread represents a token
+        // here, and we extract the relevant score The assumption is that the #tokens is limited by warp-size
         static_assert(WarpKernelMaxNumTokens <= WarpSize);
-        TypePacked scoreIdx = threadIdx.x < params.mNumTokens ? params.mPtrExpertIdx[threadIdx.x] : TypePacked{};
+        TypePacked scoreIdx = TypePacked{};
+        if (params.mPtrTopKIds != nullptr)
+        {
+            if (threadIdx.x < params.mNumTokens)
+            {
+                scoreIdx = TypePacked{static_cast<OutputT>(params.mPtrTopKWeights[threadIdx.x]),
+                    static_cast<int16_t>(params.mPtrTopKIds[threadIdx.x])};
+            }
+        }
+        else
+        {
+            if (threadIdx.x < params.mNumTokens)
+            {
+                scoreIdx = TypePacked{static_cast<OutputT>(params.mPtrTopKPacked[threadIdx.x].score),
+                    static_cast<int16_t>(params.mPtrTopKPacked[threadIdx.x].idx)};
+                if (params.mPtrTopKWeights != nullptr)
+                {
+                    // we also compute the final score here and write it out if required
+                    auto finalScore = OutputT{sigmoid_accurate(float{scoreIdx.score})};
+                    params.mPtrTopKWeights[threadIdx.x] = finalScore;
+                }
+            }
+        }
+
         int32_t expertTokenCount = 0;
         setBits</* IsZero= */ true>(expertTokenCount, 1, scoreIdx.idx % ExpertsPerThread);
         if (threadIdx.x < params.mNumTokens)
         {
             smemExpertTokenCountFull[threadIdx.x][scoreIdx.idx / ExpertsPerThread] = expertTokenCount;
-        }
-        // we also compute the final score here and write it out if required
-        auto finalScore = OutputT{sigmoid_accurate(float{scoreIdx.score})};
-        if (params.mPtrExpertWeights != nullptr && threadIdx.x < params.mNumTokens)
-        {
-            params.mPtrExpertWeights[threadIdx.x] = finalScore;
         }
     }
 
@@ -319,7 +335,16 @@ __global__ void __cluster_dims__(NumBlocksPerCluster, 1, 1) __launch_bounds__(Nu
         cudaGridDependencySynchronize();
     }
 
-    if (params.mPtrScores != nullptr)
+    if (params.mPtrTopKIds != nullptr)
+    {
+        if (validToken)
+        {
+            TypePacked packedScore{static_cast<OutputT>(params.mPtrTopKWeights[warpTokenIdx]),
+                static_cast<int16_t>(params.mPtrTopKIds[warpTokenIdx])};
+            smemPackedScoreIdx[warpIdx] = packedScore;
+        }
+    }
+    else if (params.mPtrScores != nullptr)
     {
         // in this case, each warp represents a token
         // we then exchange all token max scores, s.t. afterwards, each thread
@@ -338,13 +363,29 @@ __global__ void __cluster_dims__(NumBlocksPerCluster, 1, 1) __launch_bounds__(Nu
                 smemPackedScoreIdx[warpIdx] = packedScore;
             }
         }
-        // make packed scores available to all threads in cluster
-        __cluster_barrier_arrive();
-        __cluster_barrier_wait();
+    }
+    else
+    {
+        if (validToken)
+        {
+            smemPackedScoreIdx[warpIdx] = params.mPtrTopKPacked[warpTokenIdx];
+        }
     }
 
-    routingPermutation<KernelParams, OutputT, NumThreads, NumWarps, MaxNumTopExperts,
-        /*LoadExpertIdxFromGlobal=*/false>(params, smemPackedScoreIdx, warpIdx, clusterBlockRank);
+    // make packed scores available to all threads in cluster
+    __cluster_barrier_arrive();
+    __cluster_barrier_wait();
+
+    if (params.mPtrTopKIds != nullptr || params.mPtrScores != nullptr)
+    {
+        routingPermutation<KernelParams, OutputT, NumThreads, NumWarps, MaxNumTopExperts,
+            /*LoadExpertIdxFromGlobal=*/false>(params, smemPackedScoreIdx, warpIdx, clusterBlockRank);
+    }
+    else
+    {
+        routingPermutation<KernelParams, OutputT, NumThreads, NumWarps, MaxNumTopExperts,
+            /*LoadExpertIdxFromGlobal=*/true>(params, smemPackedScoreIdx, warpIdx, clusterBlockRank);
+    }
 }
 #else
 __global__ void routingIndicesClusterKernel(KernelParams params)
@@ -376,8 +417,8 @@ __global__ void __launch_bounds__(NumThreadsHist) routingIndicesHistogramScoresK
 
     // initialize the mPtrExpertCounts
     int32_t expertCountsNum = 2 * params.mNumExperts;
-    int32_t globalThreadIdx = blockIdx.x * NumThreads + threadIdx.x;
-    int32_t globalThreadStride = gridDim.x * NumThreads;
+    int32_t globalThreadIdx = blockIdx.x * NumThreadsHist + threadIdx.x;
+    int32_t globalThreadStride = gridDim.x * NumThreadsHist;
     initArr(globalThreadIdx, expertCountsNum, globalThreadStride, params.mPtrExpertCounts, 0);
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
@@ -397,14 +438,33 @@ __global__ void __launch_bounds__(NumThreadsHist) routingIndicesHistogramScoresK
         int32_t warpMaxExpertIdx[MaxNumTopExperts];
         InputT warpMaxScore[MaxNumTopExperts];
 
-        routingTopKExperts<InputT, MaxNumExperts / WarpSize>(
-            warp, warpMaxScore, warpMaxExpertIdx, laneIdx, params.mNumExperts, params.mPtrScores + scoreOffset);
+        if (params.mPtrTopKIds != nullptr)
+        {
+            if (laneIdx < MaxNumTopExperts)
+            {
+                warpMaxExpertIdx[laneIdx] = params.mPtrTopKIds[tokenIdx];
+                warpMaxScore[laneIdx] = static_cast<InputT>(params.mPtrTopKWeights[tokenIdx]);
+            }
+        }
+        else if (params.mPtrScores != nullptr)
+        {
+            routingTopKExperts<InputT, MaxNumExperts / WarpSize>(
+                warp, warpMaxScore, warpMaxExpertIdx, laneIdx, params.mNumExperts, params.mPtrScores + scoreOffset);
+        }
+        else
+        {
+            if (laneIdx < MaxNumTopExperts)
+            {
+                warpMaxExpertIdx[laneIdx] = params.mPtrTopKPacked[tokenIdx].idx;
+                warpMaxScore[laneIdx] = params.mPtrTopKPacked[tokenIdx].score;
+            }
+        }
 
         if (cute::elect_one_sync())
         {
             auto finalScore = OutputT{sigmoid_accurate(float{warpMaxScore[0]})};
             TypePacked packedScore{finalScore, static_cast<int16_t>(warpMaxExpertIdx[0])};
-            params.mPtrExpertIdx[tokenIdx] = packedScore;
+            params.mPtrTopKPacked[tokenIdx] = packedScore;
         }
     }
 }
@@ -413,15 +473,20 @@ __global__ void __launch_bounds__(NumThreadsHist) routingIndicesHistogramScoresK
 
 void run(Data const& data, void* stream)
 {
-    TLLM_CHECK_WITH_INFO(data.mPtrExpertIdx != nullptr || data.mPtrScores != nullptr,
+    TLLM_CHECK_WITH_INFO(data.mPtrTopKPacked != nullptr || data.mPtrScores != nullptr || data.mPtrTopKIds != nullptr,
         "Routing kernel requires at least one input parameter");
+    if (data.mPtrTopKIds != nullptr)
+    {
+        TLLM_CHECK_WITH_INFO(data.mPtrTopKWeights != nullptr,
+            "When mPtrTopKIds is provided, mPtrTopKWeights must also be provided for Llama4 routing.");
+    }
     TLLM_CHECK_WITH_INFO(data.mPtrPermutedIdxSize != nullptr && data.mPtrCtaIdxXyToBatchIdx != nullptr
             && data.mPtrCtaIdxXyToMnLimit != nullptr && data.mPtrNumNonExitingCtas != nullptr,
         "Llama4 routing kernel expects permuted idx and grouped Gemm launch config buffers");
     TLLM_CHECK_WITH_INFO(data.mTopK <= MaxNumTopExperts, "Routing kernel expects topK experts <= %d, got %d",
         MaxNumTopExperts, data.mTopK);
-    TLLM_CHECK_WITH_INFO(data.mNumExperts <= MaxNumExperts,
-        "Routing kernel expects #experts %d to be at most max #experts %d", data.mNumExperts, MaxNumExperts);
+    TLLM_CHECK_WITH_INFO(data.mNumExperts <= MaxNumExperts, "Routing kernel expects #experts %d to be no more than %d",
+        data.mNumExperts, MaxNumExperts);
     static_assert(MaxNumExperts <= NumThreads, "#experts must be bounded by #threads");
     static_assert(MaxNumExperts <= NumThreadsHist, "#experts must be bounded by #threads");
     TLLM_CHECK_WITH_INFO(
@@ -430,12 +495,13 @@ void run(Data const& data, void* stream)
 
     bool const useSingleWarp = (data.mPtrScores == nullptr && data.mNumTokens <= WarpKernelMaxNumTokens)
         || data.mNumTokens < WarpKernelMaxNumTokens;
-    bool const useSingleCluster
-        = data.mNumTokens <= (data.mPtrScores != nullptr ? MaxNumTokensSingleClusterScores : MaxNumTokensSingleCluster);
+    bool const useSingleCluster = data.mNumTokens <= ((data.mPtrScores != nullptr || data.mPtrTopKIds != nullptr)
+                                          ? MaxNumTokensSingleClusterScores
+                                          : MaxNumTokensSingleCluster);
     if (!useSingleCluster)
     {
-        TLLM_CHECK_WITH_INFO(
-            data.mPtrExpertIdx != nullptr, "When #tokens is large, `mPtrExpertIdx` is a required input.");
+        TLLM_CHECK_WITH_INFO((data.mPtrTopKPacked != nullptr || data.mPtrTopKIds != nullptr),
+            "When #tokens is large, `mPtrTopKPacked` or `mPtrTopKIds` is a required input.");
         TLLM_CHECK_WITH_INFO(
             data.mPtrExpertCounts != nullptr, "When #tokens is large, `mPtrExpertCounts` is a required input.");
     }
@@ -469,7 +535,7 @@ void run(Data const& data, void* stream)
         int const numBlocksOffsets
             = std::min((expandedIdxSize + offsetEltsPerBlock - 1) / offsetEltsPerBlock, maxNumBlocks);
 
-        if (data.mPtrScores != nullptr)
+        if (data.mPtrScores != nullptr && data.mPtrTopKIds == nullptr)
         {
             LAUNCH_ROUTING(data,
                 /*coopLaunch=*/false, routingIndicesHistogramScoresKernel, maxNumBlocks, NumThreadsHist,
@@ -479,8 +545,10 @@ void run(Data const& data, void* stream)
         else
         {
             // Reset the global histograms.
-            TLLM_CUDA_CHECK(cudaMemsetAsync(data.mPtrExpertCounts, 0,
-                static_cast<size_t>(2 * NumThreads) * sizeof(int32_t), (cudaStream_t) stream));
+            LAUNCH_ROUTING(data, false, routingInitExpertCounts, (2 * data.mNumExperts - 1) / NumThreadsHist + 1,
+                NumThreadsHist,
+                /*smemSize=*/0, // No dynamic smem
+                stream);
         }
         LAUNCH_ROUTING(data,
             /*coopLaunch=*/false, routingIndicesHistogramKernel, numBlocksHistogram, NumThreadsHist,

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingRenormalize.cu
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingRenormalize.cu
@@ -97,7 +97,7 @@ __global__ void __launch_bounds__(NumThreadsSingleBlock) routingIndicesBlockKern
     __shared__ int8_t __attribute((aligned(128))) smemOffset[totalExpertCounts];
     __shared__ int8_t __attribute((aligned(128))) smemKIdx[totalExpertCounts];
 
-    using Scan = cub::BlockScan<int32_t, NumThreadsSingleBlock, cub::BLOCK_SCAN_WARP_SCANS>;
+    using Scan = cub::BlockScan<int32_t, NumThreadsSingleBlock>;
     __shared__ typename Scan::TempStorage tempStorage;
 
     auto block = cg::this_thread_block();
@@ -118,7 +118,18 @@ __global__ void __launch_bounds__(NumThreadsSingleBlock) routingIndicesBlockKern
     }
 #endif
 
-    if (params.mPtrScores != nullptr)
+    if (params.mPtrTopKIds != nullptr)
+    {
+        if (validToken)
+        {
+            if (laneIdx < params.mTopK)
+            {
+                int offset = warpIdx * MaxNumExperts + params.mPtrTopKIds[warpIdx * params.mTopK + laneIdx];
+                smemKIdx[offset] = static_cast<int8_t>(laneIdx);
+            }
+        }
+    }
+    else if (params.mPtrScores != nullptr)
     {
         // in this case, each warp represents a token
         BaseType score[VecSize];
@@ -138,9 +149,9 @@ __global__ void __launch_bounds__(NumThreadsSingleBlock) routingIndicesBlockKern
             {
                 int offset = warpIdx * MaxNumExperts + warpTopKExpertIdx[laneIdx];
                 smemKIdx[offset] = static_cast<int8_t>(laneIdx);
-                if (params.mPtrExpertWeights != nullptr)
+                if (params.mPtrTopKWeights != nullptr)
                 {
-                    params.mPtrExpertWeights[warpIdx * params.mTopK + laneIdx] = OutputT{warpTopKScore[laneIdx]};
+                    params.mPtrTopKWeights[warpIdx * params.mTopK + laneIdx] = OutputT{warpTopKScore[laneIdx]};
                 }
             }
         } // end if (validToken)
@@ -283,14 +294,22 @@ __global__ void __cluster_dims__(NumBlocksPerCluster, 1, 1) __launch_bounds__(Nu
                     = TypePacked{warpTopKScore[laneIdx], static_cast<int16_t>(warpTopKExpertIdx[laneIdx])};
             }
         } // end if (validToken)
-
-        // make packed scores available to all threads in cluster
-        __cluster_barrier_arrive();
-        __cluster_barrier_wait();
     }
 
-    routingPermutation<KernelParams, BaseType, NumThreads, NumWarps, MaxNumTopExperts,
-        /*LoadExpertIdxFromGlobal=*/false>(params, smemPackedScoreIdx, warpIdx, clusterBlockRank);
+    // make packed scores available to all threads in cluster
+    __cluster_barrier_arrive();
+    __cluster_barrier_wait();
+
+    if (params.mPtrScores != nullptr)
+    {
+        routingPermutation<KernelParams, BaseType, NumThreads, NumWarps, MaxNumTopExperts,
+            /*LoadExpertIdxFromGlobal=*/false>(params, smemPackedScoreIdx, warpIdx, clusterBlockRank);
+    }
+    else
+    {
+        routingPermutation<KernelParams, BaseType, NumThreads, NumWarps, MaxNumTopExperts,
+            /*LoadExpertIdxFromGlobal=*/true>(params, smemPackedScoreIdx, warpIdx, clusterBlockRank);
+    }
 }
 #else
 __global__ void __launch_bounds__(NumThreads) routingIndicesClusterKernel(KernelParams /* params */)
@@ -330,8 +349,8 @@ __global__ void __launch_bounds__(NumThreadsHist) routingIndicesHistogramScoresK
 
     // initialize the mPtrExpertCounts
     int32_t expertCountsNum = 2 * params.mNumExperts;
-    int32_t globalThreadIdx = blockIdx.x * NumThreads + threadIdx.x;
-    int32_t globalThreadStride = gridDim.x * NumThreads;
+    int32_t globalThreadIdx = blockIdx.x * NumThreadsHist + threadIdx.x;
+    int32_t globalThreadStride = gridDim.x * NumThreadsHist;
     initArr(globalThreadIdx, expertCountsNum, globalThreadStride, params.mPtrExpertCounts, 0);
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
@@ -360,7 +379,7 @@ __global__ void __launch_bounds__(NumThreadsHist) routingIndicesHistogramScoresK
         {
             PackedScoreIdx<OutputT> packedScore{
                 static_cast<OutputT>(warpTopKScore[laneIdx]), static_cast<int16_t>(warpTopKExpertIdx[laneIdx])};
-            params.mPtrExpertIdx[tokenIdx * params.mTopK + laneIdx] = packedScore;
+            params.mPtrTopKPacked[tokenIdx * params.mTopK + laneIdx] = packedScore;
         }
     }
 }
@@ -369,15 +388,20 @@ __global__ void __launch_bounds__(NumThreadsHist) routingIndicesHistogramScoresK
 
 void run(Data const& data, void* stream)
 {
-    TLLM_CHECK_WITH_INFO(data.mPtrExpertIdx != nullptr || data.mPtrScores != nullptr,
+    TLLM_CHECK_WITH_INFO(data.mPtrTopKPacked != nullptr || data.mPtrScores != nullptr || data.mPtrTopKIds != nullptr,
         "Routing kernel requires at least one input parameter");
+    if (data.mPtrTopKIds != nullptr)
+    {
+        TLLM_CHECK_WITH_INFO(data.mPtrTopKWeights != nullptr,
+            "When mPtrTopKIds is provided, mPtrTopKWeights must also be provided for Renormalize routing.");
+    }
     TLLM_CHECK_WITH_INFO(data.mPtrPermutedIdxSize != nullptr && data.mPtrCtaIdxXyToBatchIdx != nullptr
             && data.mPtrCtaIdxXyToMnLimit != nullptr && data.mPtrNumNonExitingCtas != nullptr,
         "Llama4 routing kernel expects permuted idx and grouped Gemm launch config buffers");
     TLLM_CHECK_WITH_INFO(data.mTopK <= MaxNumTopExperts, "Routing kernel expects topK experts <= %d, got %d",
         MaxNumTopExperts, data.mTopK);
-    TLLM_CHECK_WITH_INFO(data.mNumExperts <= MaxNumExperts,
-        "Routing kernel expects #experts %d to be at most max #experts %d", data.mNumExperts, MaxNumExperts);
+    TLLM_CHECK_WITH_INFO(data.mNumExperts <= MaxNumExperts, "Routing kernel expects #experts %d to be no more than %d",
+        data.mNumExperts, MaxNumExperts);
     static_assert(MaxNumExperts <= NumThreads, "#experts must be bounded by #threads");
     static_assert(MaxNumExperts <= NumThreadsHist, "#experts must be bounded by #threads");
     TLLM_CHECK_WITH_INFO(
@@ -385,13 +409,15 @@ void run(Data const& data, void* stream)
     TLLM_CHECK_WITH_INFO(data.mPaddingLog2 < 8, "Routing kernel expects padding log2 < 8, got %d", data.mPaddingLog2);
 
     bool const useSingleBlock = data.mNumTokens <= BlockKernelMaxNumTokens;
-    bool const useSingleCluster
-        = data.mNumTokens <= (data.mPtrScores != nullptr ? MaxNumTokensSingleClusterScores : MaxNumTokensSingleCluster);
+
+    bool const useSingleCluster = data.mNumTokens <= ((data.mPtrScores != nullptr || data.mPtrTopKIds != nullptr)
+                                          ? MaxNumTokensSingleClusterScores
+                                          : MaxNumTokensSingleCluster);
 
     if (!useSingleCluster && !useSingleBlock)
     {
-        TLLM_CHECK_WITH_INFO(
-            data.mPtrExpertIdx != nullptr, "When #tokens is large, `mPtrExpertIdx` is a required input.");
+        TLLM_CHECK_WITH_INFO((data.mPtrTopKPacked != nullptr || data.mPtrTopKIds != nullptr),
+            "When #tokens is large, `mPtrTopKPacked` or `mPtrTopKIds` is a required input.");
         TLLM_CHECK_WITH_INFO(
             data.mPtrExpertCounts != nullptr, "When #tokens is large, `mPtrExpertCounts` is a required input.");
     }
@@ -425,7 +451,7 @@ void run(Data const& data, void* stream)
         int const numBlocksOffsets
             = std::min((expandedIdxSize + offsetEltsPerBlock - 1) / offsetEltsPerBlock, maxNumBlocks);
 
-        if (data.mPtrScores != nullptr)
+        if (data.mPtrScores != nullptr && data.mPtrTopKIds == nullptr)
         {
             LAUNCH_ROUTING_WITH_EXTRA_FLAG(data, false, routingIndicesHistogramScoresKernel, maxNumBlocks,
                 NumThreadsHist,
@@ -435,8 +461,10 @@ void run(Data const& data, void* stream)
         else
         {
             // Reset the global histograms.
-            TLLM_CUDA_CHECK(cudaMemsetAsync(data.mPtrExpertCounts, 0,
-                static_cast<size_t>(2 * NumThreads) * sizeof(int32_t), (cudaStream_t) stream));
+            LAUNCH_ROUTING_WITH_EXTRA_FLAG(data, false, routingInitExpertCounts,
+                (2 * data.mNumExperts - 1) / NumThreadsHist + 1, NumThreadsHist,
+                /*smemSize=*/0, // No dynamic smem
+                stream, data.mDoSoftmaxBeforeTopK, /*forceFloatInput=*/false);
         }
         LAUNCH_ROUTING_WITH_EXTRA_FLAG(data, false, routingIndicesHistogramKernel, numBlocksHistogram, NumThreadsHist,
             /*smemSize=*/0, // No dynamic smem

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/runner.cu
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/runner.cu
@@ -60,9 +60,9 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
     int32_t nGroup, int32_t topkGroup, int32_t localExpertOffset, int32_t localNumExperts, float routedScalingFactor,
     int32_t* routingExpertIndexes, int32_t* expertCountHistogram, int32_t* permutedIdxSize,
     int32_t* expandedIdxToPermutedIdx, int32_t* permutedIdxToExpandedIdx, int32_t* permutedIdxToTokenIdx,
-    void* expertWeights, int32_t* numTokensPerExpert, int32_t* ctaIdxXyToBatchIdx, int32_t* ctaIdxXyToMnLimit,
-    int32_t* numNonExitingCtas, btg::Dtype dtypeElt, bool useRoutingScalesOnInput, bool useDeepSeekFp8,
-    RoutingMethodType routingMethodType, cudaStream_t stream)
+    void* expertWeights, int32_t* expertIds, int32_t* numTokensPerExpert, int32_t* ctaIdxXyToBatchIdx,
+    int32_t* ctaIdxXyToMnLimit, int32_t* numNonExitingCtas, btg::Dtype dtypeElt, bool useRoutingScalesOnInput,
+    bool useDeepSeekFp8, RoutingMethodType routingMethodType, cudaStream_t stream)
 {
     if (routingMethodType == RoutingMethodType::DeepSeekV3)
     {
@@ -73,12 +73,12 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
         routingData.mUsePdl = true;
 
         // output:
-        routingData.mPtrExpertIdx = routingExpertIndexes;
+        routingData.mPtrTopKPacked = routingExpertIndexes;
         routingData.mPtrExpertCounts = expertCountHistogram;
         routingData.mPtrPermutedIdxSize = permutedIdxSize;
         routingData.mPtrExpandedIdxToPermutedIdx = expandedIdxToPermutedIdx;
         routingData.mPtrPermutedIdxToTokenIdx = permutedIdxToTokenIdx;
-        routingData.mPtrExpertWeights = expertWeights;
+        routingData.mPtrTopKWeights = expertWeights;
 
         routingData.mPtrCtaIdxXyToBatchIdx = ctaIdxXyToBatchIdx;
         routingData.mPtrCtaIdxXyToMnLimit = ctaIdxXyToMnLimit;
@@ -86,7 +86,9 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
 
         // input:
         routingData.mPtrRoutingBias = routingBias;
-        routingData.mPtrScores = reinterpret_cast<float*>(routingLogits);
+        // Pass-through raw pointer; kernels will cast to the proper InputT based on routing method
+        routingData.mPtrScores = expertIds == nullptr ? routingLogits : nullptr;
+        routingData.mPtrTopKIds = expertIds;
         routingData.mNumTokens = numTokens;
         routingData.mNumExperts = numExperts;
         routingData.mNumExpertGroups = nGroup;
@@ -112,12 +114,12 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
         routingData.mUsePdl = true;
 
         // output:
-        routingData.mPtrExpertIdx = routingExpertIndexes;
+        routingData.mPtrTopKPacked = routingExpertIndexes;
         routingData.mPtrExpertCounts = expertCountHistogram;
         routingData.mPtrPermutedIdxSize = permutedIdxSize;
         routingData.mPtrExpandedIdxToPermutedIdx = expandedIdxToPermutedIdx;
         routingData.mPtrPermutedIdxToTokenIdx = permutedIdxToTokenIdx;
-        routingData.mPtrExpertWeights = expertWeights;
+        routingData.mPtrTopKWeights = expertWeights;
 
         routingData.mPtrCtaIdxXyToBatchIdx = ctaIdxXyToBatchIdx;
         routingData.mPtrCtaIdxXyToMnLimit = ctaIdxXyToMnLimit;
@@ -127,7 +129,10 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
         // input:
         // routingData.mPtrRoutingWeights = args.mRoutingWeights;  // routing weights (don't need if not using gemm)
         // routingData.mPtrRoutingBias = routingBias;
-        routingData.mPtrScores = routingLogits;
+
+        // Pass-through raw pointer; kernels will cast to the proper InputT based on routing method
+        routingData.mPtrScores = expertIds == nullptr ? routingLogits : nullptr;
+        routingData.mPtrTopKIds = expertIds;
         // routingData.mPtrIn = args.mInputActs;
         routingData.mNumTokens = numTokens;
         // routingData.mHiddenDim = args.mHiddenDim;
@@ -158,18 +163,18 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
         routingData.mDoSoftmaxBeforeTopK = routingMethodType == RoutingMethodType::RenormalizeNaive;
         routingData.mNormTopkProb = routingMethodType == RoutingMethodType::RenormalizeNaive;
 
-        routingData.mPtrScores = routingLogits;
-
+        // Pass-through raw pointer; kernels will cast to the proper InputT based on routing method
+        routingData.mPtrScores = expertIds == nullptr ? routingLogits : nullptr;
         //
         // Outputs
         //
-        routingData.mPtrExpertIdx = routingExpertIndexes;
+        routingData.mPtrTopKPacked = routingExpertIndexes;
         routingData.mPtrExpertCounts = expertCountHistogram;
         routingData.mPtrPermutedIdxSize = permutedIdxSize;
         routingData.mPtrExpandedIdxToPermutedIdx = expandedIdxToPermutedIdx;
         routingData.mPtrPermutedIdxToTokenIdx = permutedIdxToTokenIdx;
-        routingData.mPtrExpertWeights = expertWeights;
-
+        routingData.mPtrTopKWeights = expertWeights;
+        routingData.mPtrTopKIds = expertIds;
         //
         // Grouped Gemm Launch Config Buffers
         //

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/runner.h
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/runner.h
@@ -106,9 +106,10 @@ public:
         int32_t nGroups, int32_t topkGroups, int32_t localExpertOffset, int32_t localNumExperts,
         float routedScalingFactor, int32_t* routingExpertIndexes, int32_t* expertCountHistogram,
         int32_t* permutedIdxSize, int32_t* expandedIdxToPermutedIdx, int32_t* permutedIdxToExpandedIdx,
-        int32_t* permutedIdxToTokenIdx, void* expertWeights, int32_t* numTokensPerExpert, int32_t* ctaIdxXyToBatchIdx,
-        int32_t* ctaIdxXyToMnLimit, int32_t* numNonExitingCtas, batchedGemm::trtllm::gen::Dtype dtypeElt,
-        bool useRoutingScalesOnInput, bool useDeepSeekFp8, RoutingMethodType routingMethodType, cudaStream_t stream);
+        int32_t* permutedIdxToTokenIdx, void* expertWeights, int32_t* expertIds, int32_t* numTokensPerExpert,
+        int32_t* ctaIdxXyToBatchIdx, int32_t* ctaIdxXyToMnLimit, int32_t* numNonExitingCtas,
+        batchedGemm::trtllm::gen::Dtype dtypeElt, bool useRoutingScalesOnInput, bool useDeepSeekFp8,
+        RoutingMethodType routingMethodType, cudaStream_t stream);
 
 private:
     int32_t mTileTokensDim;
@@ -197,6 +198,10 @@ struct MoERunnerArgs
     // [hidden_size/128, num_tokens] in float for e4m3 DS recipe
     // and [num_tokens, hidden_size/16] in float for e2m1
     void* hidden_states_scale = nullptr;
+
+    // Optional inputs:
+    void* topk_weights = nullptr; // [num_tokens, top_k]  with quantized weights
+    int32_t* topk_ids = nullptr;  // [num_tokens, top_k] with expert ids in int32_t
 
     // Gemm input:
     void* gemm1_weights = nullptr;

--- a/cpp/tensorrt_llm/thop/customMoeRoutingOp.cpp
+++ b/cpp/tensorrt_llm/thop/customMoeRoutingOp.cpp
@@ -24,9 +24,9 @@ namespace tk = tensorrt_llm::kernels;
 
 namespace torch_ext
 {
-
 template <bool DoSoftmaxBeforeTopK>
-std::tuple<at::Tensor, at::Tensor> custom_moe_routing_op(th::Tensor const& router_logits, int64_t topk)
+std::tuple<at::Tensor, at::Tensor> custom_moe_routing_op(
+    th::Tensor const& router_logits, int64_t topk, c10::optional<at::ScalarType> output_dtype)
 {
     auto data_type = router_logits.scalar_type();
     auto input_size = router_logits.sizes();
@@ -36,33 +36,69 @@ std::tuple<at::Tensor, at::Tensor> custom_moe_routing_op(th::Tensor const& route
     TORCH_CHECK(topk <= 8, "topk should be smaller than or equal to 8 for now"); //@todo: remove this restriction later
     TORCH_CHECK(num_experts <= 128, "expert number should be smaller than or equal to 128 for now");
 
-    th::Tensor topk_values = th::empty({num_tokens, topk}, th::dtype(torch::kFloat32).device(torch::kCUDA));
-    th::Tensor topk_indices = th::empty({num_tokens, topk}, th::dtype(torch::kInt32).device(torch::kCUDA));
+    // Determine output data type
+    at::ScalarType topk_values_dtype = output_dtype.value_or(torch::kFloat32);
+    TORCH_CHECK(topk_values_dtype == torch::kFloat32 || topk_values_dtype == torch::kBFloat16,
+        "output_dtype must be float32 or bfloat16");
+
+    auto opts = router_logits.options();
+    th::Tensor topk_values = th::empty({num_tokens, topk}, opts.dtype(topk_values_dtype));
+    th::Tensor topk_indices = th::empty({num_tokens, topk}, opts.dtype(torch::kInt32));
 
     auto stream = at::cuda::getCurrentCUDAStream(router_logits.get_device());
 
     switch (data_type)
     {
     case torch::kFloat32:
-        // Handle Float32
-        tk::invokeRenormMoeRouting<float, float, int32_t, DoSoftmaxBeforeTopK>(
-            reinterpret_cast<float*>(router_logits.mutable_data_ptr()),
-            reinterpret_cast<float*>(topk_values.mutable_data_ptr()),
-            reinterpret_cast<int32_t*>(topk_indices.mutable_data_ptr()), num_tokens, num_experts, topk, stream);
+        // Handle Float32 input
+        if (topk_values_dtype == torch::kFloat32)
+        {
+            tk::invokeCustomMoeRouting<float, float, int32_t, DoSoftmaxBeforeTopK>(
+                reinterpret_cast<float*>(router_logits.mutable_data_ptr()),
+                reinterpret_cast<float*>(topk_values.mutable_data_ptr()), topk_indices.data_ptr<int32_t>(), num_tokens,
+                num_experts, topk, stream);
+        }
+        else
+        { // bfloat16 output
+            tk::invokeCustomMoeRouting<float, __nv_bfloat16, int32_t, DoSoftmaxBeforeTopK>(
+                reinterpret_cast<float*>(router_logits.mutable_data_ptr()),
+                reinterpret_cast<__nv_bfloat16*>(topk_values.mutable_data_ptr()), topk_indices.data_ptr<int32_t>(),
+                num_tokens, num_experts, topk, stream);
+        }
         break;
     case torch::kBFloat16:
-        // Handle BFloat16
-        tk::invokeRenormMoeRouting<__nv_bfloat16, float, int32_t, DoSoftmaxBeforeTopK>(
-            reinterpret_cast<__nv_bfloat16*>(router_logits.mutable_data_ptr()),
-            reinterpret_cast<float*>(topk_values.mutable_data_ptr()),
-            reinterpret_cast<int32_t*>(topk_indices.mutable_data_ptr()), num_tokens, num_experts, topk, stream);
+        // Handle BFloat16 input
+        if (topk_values_dtype == torch::kFloat32)
+        {
+            tk::invokeCustomMoeRouting<__nv_bfloat16, float, int32_t, DoSoftmaxBeforeTopK>(
+                reinterpret_cast<__nv_bfloat16*>(router_logits.mutable_data_ptr()),
+                reinterpret_cast<float*>(topk_values.mutable_data_ptr()), topk_indices.data_ptr<int32_t>(), num_tokens,
+                num_experts, topk, stream);
+        }
+        else
+        { // bfloat16 output
+            tk::invokeCustomMoeRouting<__nv_bfloat16, __nv_bfloat16, int32_t, DoSoftmaxBeforeTopK>(
+                reinterpret_cast<__nv_bfloat16*>(router_logits.mutable_data_ptr()),
+                reinterpret_cast<__nv_bfloat16*>(topk_values.mutable_data_ptr()), topk_indices.data_ptr<int32_t>(),
+                num_tokens, num_experts, topk, stream);
+        }
         break;
     case torch::kHalf:
-        // Handle Half
-        tk::invokeRenormMoeRouting<half, float, int32_t, DoSoftmaxBeforeTopK>(
-            reinterpret_cast<half*>(router_logits.mutable_data_ptr()),
-            reinterpret_cast<float*>(topk_values.mutable_data_ptr()),
-            reinterpret_cast<int32_t*>(topk_indices.mutable_data_ptr()), num_tokens, num_experts, topk, stream);
+        // Handle Half input
+        if (topk_values_dtype == torch::kFloat32)
+        {
+            tk::invokeCustomMoeRouting<half, float, int32_t, DoSoftmaxBeforeTopK>(
+                reinterpret_cast<half*>(router_logits.mutable_data_ptr()),
+                reinterpret_cast<float*>(topk_values.mutable_data_ptr()), topk_indices.data_ptr<int32_t>(), num_tokens,
+                num_experts, topk, stream);
+        }
+        else
+        { // bfloat16 output
+            tk::invokeCustomMoeRouting<half, __nv_bfloat16, int32_t, DoSoftmaxBeforeTopK>(
+                reinterpret_cast<half*>(router_logits.mutable_data_ptr()),
+                reinterpret_cast<__nv_bfloat16*>(topk_values.mutable_data_ptr()), topk_indices.data_ptr<int32_t>(),
+                num_tokens, num_experts, topk, stream);
+        }
         break;
     default:
         // Handle other data types
@@ -72,21 +108,23 @@ std::tuple<at::Tensor, at::Tensor> custom_moe_routing_op(th::Tensor const& route
     return {topk_indices, topk_values};
 }
 
-std::tuple<at::Tensor, at::Tensor> renorm_moe_routing_op(th::Tensor const& router_logits, int64_t topk)
+std::tuple<at::Tensor, at::Tensor> renorm_moe_routing_op(
+    th::Tensor const& router_logits, int64_t topk, c10::optional<at::ScalarType> output_dtype)
 {
-    return custom_moe_routing_op<false>(router_logits, topk);
+    return custom_moe_routing_op<false>(router_logits, topk, output_dtype);
 }
 
-std::tuple<at::Tensor, at::Tensor> default_moe_routing_op(th::Tensor const& router_logits, int64_t topk)
+std::tuple<at::Tensor, at::Tensor> default_moe_routing_op(
+    th::Tensor const& router_logits, int64_t topk, c10::optional<at::ScalarType> output_dtype)
 {
-    return custom_moe_routing_op<true>(router_logits, topk);
+    return custom_moe_routing_op<true>(router_logits, topk, output_dtype);
 }
 } // namespace torch_ext
 
 TORCH_LIBRARY_FRAGMENT(trtllm, m)
 {
     m.def(
-        "renorm_moe_routing_op(Tensor router_logits, SymInt topk"
+        "renorm_moe_routing_op(Tensor router_logits, SymInt topk, ScalarType? output_dtype=None"
         ") -> (Tensor, Tensor)");
 }
 
@@ -98,7 +136,7 @@ TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
 TORCH_LIBRARY_FRAGMENT(trtllm, m)
 {
     m.def(
-        "default_moe_routing_op(Tensor router_logits, SymInt topk"
+        "default_moe_routing_op(Tensor router_logits, SymInt topk, ScalarType? output_dtype=None"
         ") -> (Tensor, Tensor)");
 }
 

--- a/cpp/tensorrt_llm/thop/fp4BlockScaleMoe.cpp
+++ b/cpp/tensorrt_llm/thop/fp4BlockScaleMoe.cpp
@@ -28,7 +28,7 @@ namespace btg = batchedGemm::trtllm::gen;
 using tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::Routing::RoutingMethodType;
 using MoeRunnerType = tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::MoE::Runner;
 
-std::vector<torch::Tensor> run_fp4_block_scale_moe_runner(torch::Tensor const& routing_logits,
+std::vector<torch::Tensor> run_fp4_block_scale_moe_runner(torch::optional<torch::Tensor> const& routing_logits,
     torch::optional<torch::Tensor> const& routing_bias, torch::Tensor const& hidden_states,
     torch::Tensor const& hidden_states_scale, torch::Tensor const& gemm1_weights,
     torch::Tensor const& gemm1_weights_scale, torch::Tensor const& gemm2_weights,
@@ -37,23 +37,62 @@ std::vector<torch::Tensor> run_fp4_block_scale_moe_runner(torch::Tensor const& r
     int64_t const num_experts, int64_t const top_k, std::optional<int64_t> const n_group,
     std::optional<int64_t> const topk_group, int64_t const intermediate_size, int64_t const local_expert_offset,
     int64_t const local_num_experts, std::optional<double> const routed_scaling_factor, int64_t const tile_tokens_dim,
-    int64_t const routing_method_type, bool const do_finalize, MoeRunnerType& moe_runner, int64_t const moeConfigIndex)
+    int64_t const routing_method_type, bool const do_finalize, MoeRunnerType& moe_runner, int64_t const moeConfigIndex,
+    torch::optional<torch::Tensor> const& topk_weights, torch::optional<torch::Tensor> const& topk_ids)
 {
     TORCH_CHECK(tensorrt_llm::common::isSM100Family(), "Only SM100f is supported by FP4 block scale MOE");
     TORCH_CHECK(tile_tokens_dim == 8 || tile_tokens_dim == 16 || tile_tokens_dim == 32 || tile_tokens_dim == 64,
         "tile_tokens_dim must be 8, 16, 32, 64");
-    if (static_cast<RoutingMethodType>(routing_method_type) == RoutingMethodType::DeepSeekV3)
+
+    if (topk_ids.has_value() && topk_weights.has_value())
     {
-        TORCH_CHECK(routing_logits.scalar_type() == at::ScalarType::Float, "routing_logits must be float");
+        TORCH_CHECK(topk_ids.value().scalar_type() == at::ScalarType::Int, "topk_ids must be int");
+        TORCH_CHECK(topk_weights.value().scalar_type() == at::ScalarType::BFloat16, "topk_weights must be bfloat16.");
+        TORCH_CHECK(topk_ids.value().dim() == 2, "topk_ids must be 2D.");
+        TORCH_CHECK(topk_ids.value().sizes()[0] == hidden_states.sizes()[0],
+            "topk_ids and hidden_states must have the same number of tokens.");
+        TORCH_CHECK(topk_ids.value().sizes()[1] == top_k, "topk_ids dim1 must match top_k.");
+        TORCH_CHECK(topk_weights.value().dim() == 2, "topk_weights must be 2D.");
+        TORCH_CHECK(topk_weights.value().sizes()[0] == hidden_states.sizes()[0],
+            "topk_weights and hidden_states must have the same number of tokens.");
+        TORCH_CHECK(topk_weights.value().sizes()[1] == top_k, "topk_weights dim1 must match top_k.");
+    }
+    else if (routing_logits.has_value())
+    {
+        if (static_cast<RoutingMethodType>(routing_method_type) == RoutingMethodType::DeepSeekV3)
+        {
+            TORCH_CHECK(routing_logits.value().scalar_type() == at::ScalarType::Float, "routing_logits must be float");
+        }
+        else
+        {
+            TORCH_CHECK(
+                routing_logits.value().scalar_type() == at::ScalarType::BFloat16, "routing_logits must be bfloat16");
+        }
+        TORCH_CHECK(routing_logits.value().dim() == 2, "routing_logits must be 2D.");
+        TORCH_CHECK(routing_logits.value().sizes()[1] == num_experts, "routing_logits has incorrect shape.");
     }
     else
     {
-        TORCH_CHECK(routing_logits.scalar_type() == at::ScalarType::BFloat16, "routing_logits must be bfloat16");
+        TORCH_CHECK(false, "routing_logits or (topk_ids and topk_weights) must be provided.");
     }
-    TORCH_CHECK(routing_logits.dim() == 2, "routing_logits must be 2D.");
-    TORCH_CHECK(routing_logits.sizes()[0] == hidden_states.sizes()[0],
-        "routing_logits and hidden_states must have the same number of tokens.");
-    TORCH_CHECK(routing_logits.sizes()[1] == num_experts, "routing_logits has incorrect shape.");
+
+    if (topk_ids.has_value() && topk_weights.has_value() && routing_logits.has_value())
+    {
+        TLLM_LOG_WARNING(
+            "When logits and (topk_ids and topk_weights) are both provided, we only use (topk_ids and topk_weights).");
+    }
+
+    if (topk_ids.has_value())
+    {
+        TORCH_CHECK(topk_ids.value().sizes()[0] == hidden_states.sizes()[0],
+            "topk_ids and hidden_states must have the same number of tokens.");
+    }
+    else
+    {
+        TORCH_CHECK(routing_logits.value().sizes()[0] == hidden_states.sizes()[0],
+            "routing_logits and hidden_states must have the same number of tokens.");
+    }
+
     if (routing_bias.has_value())
     {
         TORCH_CHECK(routing_bias.value().scalar_type() == at::ScalarType::BFloat16, "routing_bias must be bfloat16.");
@@ -90,6 +129,13 @@ std::vector<torch::Tensor> run_fp4_block_scale_moe_runner(torch::Tensor const& r
     TORCH_CHECK(num_experts > top_k, "num_experts must be greater than top_k");
     TORCH_CHECK(num_experts <= 256, "num_experts must be less than or equal to 256");
 
+    // If both routing inputs are provided, they must be on the same device
+    if (routing_logits.has_value() && topk_ids.has_value())
+    {
+        TORCH_CHECK(
+            routing_logits->device() == topk_ids->device(), "routing_logits and topk_ids must be on the same device");
+    }
+
     tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::MoE::MoERunnerArgs args;
     tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::MoE::MoEWorkspace workspace;
 
@@ -99,10 +145,14 @@ std::vector<torch::Tensor> run_fp4_block_scale_moe_runner(torch::Tensor const& r
         = routing_bias.has_value() ? routing_bias.value().scalar_type() : at::ScalarType::BFloat16;
     args.mDtypeElt = btg::Dtype::E2m1;
     args.mDtypeExpW = routing_bias_dtype == at::ScalarType::Float ? btg::Dtype::Fp32 : btg::Dtype::Bfloat16;
-    args.routing_logits = routing_logits.data_ptr();
+    args.routing_logits = routing_logits.has_value() ? routing_logits.value().data_ptr() : nullptr;
     args.routing_bias = routing_bias.has_value() ? routing_bias.value().data_ptr() : nullptr;
     args.hidden_states = hidden_states.data_ptr();
     args.hidden_states_scale = hidden_states_scale.data_ptr();
+
+    args.topk_weights = topk_weights.has_value() ? topk_weights.value().data_ptr() : nullptr;
+    args.topk_ids = topk_ids.has_value() ? static_cast<int32_t*>(topk_ids.value().data_ptr()) : nullptr;
+
     args.gemm1_weights = gemm1_weights.data_ptr();
     args.gemm1_weights_scale = gemm1_weights_scale.data_ptr();
     args.gemm2_weights = gemm2_weights.data_ptr();
@@ -120,61 +170,71 @@ std::vector<torch::Tensor> run_fp4_block_scale_moe_runner(torch::Tensor const& r
     args.intermediate_size = intermediate_size;
 
     // allocate workspace for routing kernel
+    if (routing_logits.has_value() && topk_ids.has_value())
+    {
+        TORCH_CHECK(routing_logits.value().device() == topk_ids.value().device(),
+            "routing_logits and topk_ids must be on the same device");
+    }
+    auto routing_device = routing_logits.has_value() ? routing_logits.value().device() : topk_ids.value().device();
     at::Tensor num_tokens_per_expert
-        = at::detail::empty_cuda({num_experts}, at::ScalarType::Int, routing_logits.device(), std::nullopt);
+        = at::detail::empty_cuda({num_experts}, at::ScalarType::Int, routing_device, std::nullopt);
     int32_t max_num_padded_tokens
         = tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::Routing::getMaxPermutedPaddedCount(
             args.num_tokens, top_k, num_experts, tile_tokens_dim);
     at::Tensor total_num_padded_tokens
-        = at::empty({}, at::TensorOptions().device(routing_logits.device()).dtype(at::ScalarType::Int));
-    at::Tensor expanded_idx_to_permuted_idx = at::detail::empty_cuda(
-        {args.num_tokens, args.top_k}, at::ScalarType::Int, routing_logits.device(), std::nullopt);
+        = at::empty({}, at::TensorOptions().device(routing_device).dtype(at::ScalarType::Int));
+    at::Tensor expanded_idx_to_permuted_idx
+        = at::detail::empty_cuda({args.num_tokens, args.top_k}, at::ScalarType::Int, routing_device, std::nullopt);
 
     at::Tensor permuted_idx_to_token_idx
-        = at::detail::empty_cuda({max_num_padded_tokens}, at::ScalarType::Int, routing_logits.device(), std::nullopt);
-    at::Tensor expert_weights = at::detail::empty_cuda(
-        {args.num_tokens, args.top_k}, routing_bias_dtype, routing_logits.device(), std::nullopt);
-    at::Tensor expert_indexes = at::detail::empty_cuda(
-        {args.num_tokens, args.top_k}, at::ScalarType::Int, routing_logits.device(), std::nullopt);
+        = at::detail::empty_cuda({max_num_padded_tokens}, at::ScalarType::Int, routing_device, std::nullopt);
+    at::Tensor expert_weights
+        = at::detail::empty_cuda({args.num_tokens, args.top_k}, routing_bias_dtype, routing_device, std::nullopt);
+    at::Tensor expert_indexes
+        = at::detail::empty_cuda({args.num_tokens, args.top_k}, at::ScalarType::Int, routing_device, std::nullopt);
     int64_t const size_of_expert_count_histogram = std::max(num_experts * 2, int64_t(256 * 2));
-    at::Tensor expert_count_histogram = at::detail::empty_cuda({size_of_expert_count_histogram},
-        at::ScalarType::Int, // 256 is the max number of threads per block and max number of experts
-        routing_logits.device(), std::nullopt);
+    at::Tensor expert_count_histogram
+        = at::detail::empty_cuda({size_of_expert_count_histogram}, at::ScalarType::Int, routing_device, std::nullopt);
 
     // allocate workspace for activation/gemm/finalize kernels
-    at::Tensor gemm1_output = at::detail::empty_cuda({max_num_padded_tokens, intermediate_size / 2},
-        at::ScalarType::Float8_e4m3fn, hidden_states.device(), std::nullopt);
+    at::Tensor gemm1_output = at::detail::empty_cuda(
+        {max_num_padded_tokens, intermediate_size / 2}, at::ScalarType::Float8_e4m3fn, routing_device, std::nullopt);
 
     int64_t sf_size = tensorrt_llm::computeSwizzledLayoutSFSize(max_num_padded_tokens, intermediate_size / 16);
     at::Tensor gemm1_output_scale
-        = at::detail::empty_cuda({sf_size}, at::ScalarType::Float8_e4m3fn, hidden_states.device(), std::nullopt);
+        = at::detail::empty_cuda({sf_size}, at::ScalarType::Float8_e4m3fn, routing_device, std::nullopt);
 
     at::Tensor gemm2_output = at::detail::empty_cuda(
-        {max_num_padded_tokens, args.hidden_size}, at::ScalarType::BFloat16, hidden_states.device(), std::nullopt);
+        {max_num_padded_tokens, args.hidden_size}, at::ScalarType::BFloat16, routing_device, std::nullopt);
 
     int32_t max_num_ctas = tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::Routing::getMaxNumCtasInBatchDim(
         args.num_tokens, args.top_k, args.num_experts, tile_tokens_dim);
     at::Tensor cta_idx_xy_to_batch_idx
-        = at::detail::empty_cuda({max_num_ctas}, at::ScalarType::Int, routing_logits.device(), std::nullopt);
+        = at::detail::empty_cuda({max_num_ctas}, at::ScalarType::Int, routing_device, std::nullopt);
     at::Tensor cta_idx_xy_to_mn_limit
-        = at::detail::empty_cuda({max_num_ctas}, at::ScalarType::Int, routing_logits.device(), std::nullopt);
+        = at::detail::empty_cuda({max_num_ctas}, at::ScalarType::Int, routing_device, std::nullopt);
     at::Tensor num_non_exiting_ctas
-        = at::empty({}, at::TensorOptions().device(routing_logits.device()).dtype(at::ScalarType::Int));
+        = at::empty({}, at::TensorOptions().device(routing_device).dtype(at::ScalarType::Int));
+
+    // Set the optional pointer to the expert weights and expert ids
+    void* expert_weights_ptr = args.topk_weights ? args.topk_weights : expert_weights.data_ptr();
 
     //
     // TopK routing
     //
 
     tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::Routing::Runner routing_runner(tile_tokens_dim);
-    auto const& stream = at::cuda::getCurrentCUDAStream(routing_logits.get_device());
+    auto const& stream = at::cuda::getCurrentCUDAStream(
+        routing_logits.has_value() ? routing_logits.value().get_device() : topk_ids.value().get_device());
     routing_runner.run(args.routing_logits, args.routing_bias, args.num_tokens, args.num_experts, args.top_k,
         args.n_group, args.topk_group, args.local_expert_offset, args.local_num_experts, args.routed_scaling_factor,
         expert_indexes.data_ptr<int>(), expert_count_histogram.data_ptr<int>(), total_num_padded_tokens.data_ptr<int>(),
         expanded_idx_to_permuted_idx.data_ptr<int>(), nullptr, /*permuted_idx_to_expanded_idx.data_ptr<int>(),*/
-        permuted_idx_to_token_idx.data_ptr<int>(), expert_weights.data_ptr(), num_tokens_per_expert.data_ptr<int>(),
-        cta_idx_xy_to_batch_idx.data_ptr<int>(), cta_idx_xy_to_mn_limit.data_ptr<int>(),
-        num_non_exiting_ctas.data_ptr<int>(), args.mDtypeElt, false /* use_routing_scales_on_input */,
-        false /* use_deep_seek_fp8 */, static_cast<RoutingMethodType>(routing_method_type), stream);
+        permuted_idx_to_token_idx.data_ptr<int>(), expert_weights_ptr, args.topk_ids,
+        num_tokens_per_expert.data_ptr<int>(), cta_idx_xy_to_batch_idx.data_ptr<int>(),
+        cta_idx_xy_to_mn_limit.data_ptr<int>(), num_non_exiting_ctas.data_ptr<int>(), args.mDtypeElt,
+        false /* use_routing_scales_on_input */, false /* use_deep_seek_fp8 */,
+        static_cast<RoutingMethodType>(routing_method_type), stream);
 
     //
     // FC13 (gemm1) + FC2 (gemm2)
@@ -247,7 +307,8 @@ std::vector<torch::Tensor> run_fp4_block_scale_moe_runner(torch::Tensor const& r
     workspace.expanded_idx_to_permuted_idx
         = expanded_idx_to_permuted_idx.data_ptr<int>(); // Needed by permute/finalize kernels
     workspace.permuted_idx_to_token_idx = permuted_idx_to_token_idx.data_ptr<int>(); // Needed by permuteGemm1 kernel
-    workspace.expert_weights = expert_weights.data_ptr();                            // Consumed by finalize kernel
+
+    workspace.expert_weights = expert_weights_ptr;                                   // Consumed by finalize kernel
 
     workspace.cta_idx_xy_to_batch_idx = cta_idx_xy_to_batch_idx.data_ptr<int>();
     workspace.cta_idx_xy_to_mn_limit = cta_idx_xy_to_mn_limit.data_ptr<int>();
@@ -297,7 +358,7 @@ public:
         mRunner = std::make_unique<RunnerType>(mDtypeElt, mUseDeepSeekFp8, mTileTokensDim);
     }
 
-    [[nodiscard]] std::vector<torch::Tensor> run(torch::Tensor const& routing_logits,
+    [[nodiscard]] std::vector<torch::Tensor> run(torch::optional<torch::Tensor> const& routing_logits,
         torch::optional<torch::Tensor> const& routing_bias, torch::Tensor const& hidden_states,
         torch::Tensor const& hidden_states_scale, torch::Tensor const& gemm1_weights,
         torch::Tensor const& gemm1_weights_scale, torch::Tensor const& gemm2_weights,
@@ -306,7 +367,8 @@ public:
         int64_t const num_experts, int64_t const top_k, std::optional<int64_t> const n_group,
         std::optional<int64_t> const topk_group, int64_t const intermediate_size, int64_t const local_expert_offset,
         int64_t const local_num_experts, std::optional<double> const routed_scaling_factor,
-        int64_t const routing_method_type, bool const do_finalize, int64_t moeConfigIndex)
+        int64_t const routing_method_type, bool const do_finalize, int64_t moeConfigIndex,
+        torch::optional<torch::Tensor> const& topk_weights, torch::optional<torch::Tensor> const& topk_ids)
     {
 
         // Autotuner has requested a default or 'fallback' config index
@@ -325,7 +387,7 @@ public:
             gemm1_weights, gemm1_weights_scale, gemm2_weights, gemm2_weights_scale, output1_scales_scalar,
             output1_scales_gate_scalar, output2_scales_scalar, num_experts, top_k, n_group, topk_group,
             intermediate_size, local_expert_offset, local_num_experts, routed_scaling_factor, mTileTokensDim,
-            routing_method_type, do_finalize, *mRunner, moeConfigIndex);
+            routing_method_type, do_finalize, *mRunner, moeConfigIndex, topk_weights, topk_ids);
     }
 
     [[nodiscard]] std::vector<int64_t> getValidConfigs(

--- a/cpp/tensorrt_llm/thop/fp8BlockScaleMoe.cpp
+++ b/cpp/tensorrt_llm/thop/fp8BlockScaleMoe.cpp
@@ -30,20 +30,66 @@ namespace btg = batchedGemm::trtllm::gen;
 using tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::Routing::RoutingMethodType;
 using MoeRunnerType = tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::MoE::Runner;
 
-at::Tensor run_fp8_block_scale_moe(at::Tensor const& routing_logits, std::optional<at::Tensor> const& routing_bias,
-    at::Tensor const& hidden_states, at::Tensor const& hidden_states_scale, at::Tensor const& gemm1_weights,
-    at::Tensor const& gemm1_weights_scale, at::Tensor const& gemm2_weights, at::Tensor const& gemm2_weights_scale,
-    int64_t const num_experts, int64_t const top_k, std::optional<int64_t> const n_group,
-    std::optional<int64_t> const topk_group, int64_t const intermediate_size, int64_t const local_expert_offset,
-    int64_t const local_num_experts, std::optional<double> const routed_scaling_factor, int64_t const tile_tokens_dim,
-    int64_t const routing_method_type, MoeRunnerType& moe_runner, int64_t moeConfigIndex)
+at::Tensor run_fp8_block_scale_moe(at::optional<at::Tensor> const& routing_logits,
+    std::optional<at::Tensor> const& routing_bias, at::Tensor const& hidden_states,
+    at::Tensor const& hidden_states_scale, at::Tensor const& gemm1_weights, at::Tensor const& gemm1_weights_scale,
+    at::Tensor const& gemm2_weights, at::Tensor const& gemm2_weights_scale, int64_t const num_experts,
+    int64_t const top_k, std::optional<int64_t> const n_group, std::optional<int64_t> const topk_group,
+    int64_t const intermediate_size, int64_t const local_expert_offset, int64_t const local_num_experts,
+    std::optional<double> const routed_scaling_factor, int64_t const tile_tokens_dim, int64_t const routing_method_type,
+    MoeRunnerType& moe_runner, int64_t moeConfigIndex, std::optional<at::Tensor> const& topk_weights,
+    std::optional<at::Tensor> const& topk_ids)
 {
     TORCH_CHECK(tensorrt_llm::common::isSM100Family(), "Only SM100f is supported by FP8 block scale MOE");
-    TORCH_CHECK(routing_logits.scalar_type() == at::ScalarType::Float, "routing_logits must be float.");
-    TORCH_CHECK(routing_logits.dim() == 2, "routing_logits must be 2D.");
-    TORCH_CHECK(routing_logits.sizes()[0] == hidden_states.sizes()[0],
-        "routing_logits and hidden_states must have the same number of tokens.");
-    TORCH_CHECK(routing_logits.sizes()[1] == num_experts, "routing_logits dim1 must match num_experts.");
+
+    if (topk_ids.has_value() && topk_weights.has_value())
+    {
+        TORCH_CHECK(topk_ids.value().scalar_type() == at::ScalarType::Int, "topk_ids must be int");
+        TORCH_CHECK(topk_weights.value().scalar_type() == at::ScalarType::BFloat16, "topk_weights must be bfloat16.");
+        TORCH_CHECK(topk_ids.value().dim() == 2, "topk_ids must be 2D.");
+        TORCH_CHECK(topk_ids.value().sizes()[0] == hidden_states.sizes()[0],
+            "topk_ids and hidden_states must have the same number of tokens.");
+        TORCH_CHECK(topk_ids.value().sizes()[1] == top_k, "topk_ids dim1 must match top_k.");
+        TORCH_CHECK(topk_weights.value().dim() == 2, "topk_weights must be 2D.");
+        TORCH_CHECK(topk_weights.value().sizes()[0] == hidden_states.sizes()[0],
+            "topk_weights and hidden_states must have the same number of tokens.");
+        TORCH_CHECK(topk_weights.value().sizes()[1] == top_k, "topk_weights dim1 must match top_k.");
+    }
+    else if (routing_logits.has_value())
+    {
+        if (static_cast<RoutingMethodType>(routing_method_type) == RoutingMethodType::DeepSeekV3)
+        {
+            TORCH_CHECK(routing_logits.value().scalar_type() == at::ScalarType::Float, "routing_logits must be float");
+        }
+        else
+        {
+            TORCH_CHECK(
+                routing_logits.value().scalar_type() == at::ScalarType::BFloat16, "routing_logits must be bfloat16");
+        }
+        TORCH_CHECK(routing_logits.value().dim() == 2, "routing_logits must be 2D.");
+        TORCH_CHECK(routing_logits.value().sizes()[1] == num_experts, "routing_logits dim1 must match num_experts.");
+    }
+    else
+    {
+        TORCH_CHECK(false, "routing_logits or (topk_ids and topk_weights) must be provided.");
+    }
+
+    if (topk_ids.has_value() && topk_weights.has_value() && routing_logits.has_value())
+    {
+        TLLM_LOG_WARNING(
+            "When logits and (topk_ids and topk_weights) are both provided, we only use (topk_ids and topk_weights).");
+    }
+
+    if (topk_ids.has_value())
+    {
+        TORCH_CHECK(topk_ids.value().sizes()[0] == hidden_states.sizes()[0],
+            "topk_ids and hidden_states must have the same number of tokens.");
+    }
+    else
+    {
+        TORCH_CHECK(routing_logits.value().sizes()[0] == hidden_states.sizes()[0],
+            "routing_logits and hidden_states must have the same number of tokens.");
+    }
 
     if (routing_bias.has_value())
     {
@@ -79,6 +125,13 @@ at::Tensor run_fp8_block_scale_moe(at::Tensor const& routing_logits, std::option
     TORCH_CHECK(num_experts % 4 == 0, "Routing kernel expects that num_experts must be divisible by 4");
     TORCH_CHECK(num_experts > top_k, "num_experts must be greater than top_k");
 
+    // If both routing inputs are provided, they must be on the same device
+    if (routing_logits.has_value() && topk_ids.has_value())
+    {
+        TORCH_CHECK(
+            routing_logits->device() == topk_ids->device(), "routing_logits and topk_ids must be on the same device");
+    }
+
     tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::MoE::MoERunnerArgs args;
     tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::MoE::MoEWorkspace workspace;
 
@@ -89,8 +142,12 @@ at::Tensor run_fp8_block_scale_moe(at::Tensor const& routing_logits, std::option
         = routing_bias.has_value() ? routing_bias.value().scalar_type() : at::ScalarType::BFloat16;
     args.mDtypeExpW = routing_bias_dtype == at::ScalarType::Float ? btg::Dtype::Fp32 : btg::Dtype::Bfloat16;
 
-    args.routing_logits = routing_logits.data_ptr<float>();
+    args.routing_logits = routing_logits.has_value() ? routing_logits.value().data_ptr() : nullptr;
     args.routing_bias = routing_bias.has_value() ? routing_bias.value().data_ptr() : nullptr;
+
+    args.topk_weights = topk_weights.has_value() ? topk_weights.value().data_ptr() : nullptr;
+    args.topk_ids = topk_ids.has_value() ? static_cast<int32_t*>(topk_ids.value().data_ptr()) : nullptr;
+
     args.hidden_states = hidden_states.data_ptr();
     args.hidden_states_scale = hidden_states_scale.data_ptr<float>();
     args.gemm1_weights = gemm1_weights.data_ptr();
@@ -110,55 +167,64 @@ at::Tensor run_fp8_block_scale_moe(at::Tensor const& routing_logits, std::option
     args.mUseDeepSeekFp8 = true;
 
     // allocate workspace for routing kernel
+    if (routing_logits.has_value() && topk_ids.has_value())
+    {
+        TORCH_CHECK(routing_logits.value().device() == topk_ids.value().device(),
+            "routing_logits and topk_ids must be on the same device");
+    }
+    auto routing_device = routing_logits.has_value() ? routing_logits.value().device() : topk_ids.value().device();
     at::Tensor num_tokens_per_expert
-        = at::detail::empty_cuda({num_experts}, at::ScalarType::Int, routing_logits.device(), std::nullopt);
+        = at::detail::empty_cuda({num_experts}, at::ScalarType::Int, routing_device, std::nullopt);
     int32_t max_num_padded_tokens
         = tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::Routing::getMaxPermutedPaddedCount(
             args.num_tokens, top_k, num_experts, tile_tokens_dim);
     at::Tensor total_num_padded_tokens
-        = at::empty({}, at::TensorOptions().device(routing_logits.device()).dtype(at::ScalarType::Int));
-    at::Tensor expanded_idx_to_permuted_idx = at::detail::empty_cuda(
-        {args.num_tokens * args.top_k}, at::ScalarType::Int, routing_logits.device(), std::nullopt);
+        = at::empty({}, at::TensorOptions().device(routing_device).dtype(at::ScalarType::Int));
+    at::Tensor expanded_idx_to_permuted_idx
+        = at::detail::empty_cuda({args.num_tokens * args.top_k}, at::ScalarType::Int, routing_device, std::nullopt);
     at::Tensor permuted_idx_to_token_idx
-        = at::detail::empty_cuda({max_num_padded_tokens}, at::ScalarType::Int, routing_logits.device(), std::nullopt);
-    at::Tensor expert_weights = at::detail::empty_cuda(
-        {args.num_tokens, args.top_k}, routing_bias_dtype, routing_logits.device(), std::nullopt);
-    at::Tensor expert_indexes = at::detail::empty_cuda(
-        {args.num_tokens, args.top_k}, at::ScalarType::Int, routing_logits.device(), std::nullopt);
+        = at::detail::empty_cuda({max_num_padded_tokens}, at::ScalarType::Int, routing_device, std::nullopt);
+    at::Tensor expert_weights
+        = at::detail::empty_cuda({args.num_tokens, args.top_k}, routing_bias_dtype, routing_device, std::nullopt);
+    at::Tensor expert_indexes
+        = at::detail::empty_cuda({args.num_tokens, args.top_k}, at::ScalarType::Int, routing_device, std::nullopt);
     int64_t const size_of_expert_count_histogram = std::max(num_experts * 2, int64_t(256 * 2));
-    at::Tensor expert_count_histogram = at::detail::empty_cuda({size_of_expert_count_histogram},
-        at::ScalarType::Int, // 256 is the max number of threads per block and max number of experts
-        routing_logits.device(), std::nullopt);
+    at::Tensor expert_count_histogram
+        = at::detail::empty_cuda({size_of_expert_count_histogram}, at::ScalarType::Int, routing_device, std::nullopt);
 
     // allocate workspace for activation/gemm/finalize kernels
-    at::Tensor gemm1_output = at::detail::empty_cuda({max_num_padded_tokens, 2 * intermediate_size},
-        at::ScalarType::Float8_e4m3fn, hidden_states.device(), std::nullopt);
-    at::Tensor gemm1_output_scale = at::detail::empty_cuda({2 * intermediate_size / 128, max_num_padded_tokens},
-        at::ScalarType::Float, hidden_states.device(), std::nullopt);
-    at::Tensor activation_output = at::detail::empty_cuda({max_num_padded_tokens, intermediate_size},
-        at::ScalarType::Float8_e4m3fn, hidden_states.device(), std::nullopt);
+    at::Tensor gemm1_output = at::detail::empty_cuda(
+        {max_num_padded_tokens, 2 * intermediate_size}, at::ScalarType::Float8_e4m3fn, routing_device, std::nullopt);
+    at::Tensor gemm1_output_scale = at::detail::empty_cuda(
+        {2 * intermediate_size / 128, max_num_padded_tokens}, at::ScalarType::Float, routing_device, std::nullopt);
+    at::Tensor activation_output = at::detail::empty_cuda(
+        {max_num_padded_tokens, intermediate_size}, at::ScalarType::Float8_e4m3fn, routing_device, std::nullopt);
     at::Tensor activation_output_scale = at::detail::empty_cuda(
-        {intermediate_size / 128, max_num_padded_tokens}, at::ScalarType::Float, hidden_states.device(), std::nullopt);
+        {intermediate_size / 128, max_num_padded_tokens}, at::ScalarType::Float, routing_device, std::nullopt);
     at::Tensor gemm2_output = at::detail::empty_cuda(
-        {max_num_padded_tokens, args.hidden_size}, at::ScalarType::BFloat16, hidden_states.device(), std::nullopt);
+        {max_num_padded_tokens, args.hidden_size}, at::ScalarType::BFloat16, routing_device, std::nullopt);
 
     int32_t max_num_ctas = tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::Routing::getMaxNumCtasInBatchDim(
         args.num_tokens, args.top_k, args.num_experts, tile_tokens_dim);
     at::Tensor cta_idx_xy_to_batch_idx
-        = at::detail::empty_cuda({max_num_ctas}, at::ScalarType::Int, routing_logits.device(), std::nullopt);
+        = at::detail::empty_cuda({max_num_ctas}, at::ScalarType::Int, routing_device, std::nullopt);
     at::Tensor cta_idx_xy_to_mn_limit
-        = at::detail::empty_cuda({max_num_ctas}, at::ScalarType::Int, routing_logits.device(), std::nullopt);
+        = at::detail::empty_cuda({max_num_ctas}, at::ScalarType::Int, routing_device, std::nullopt);
     at::Tensor num_non_exiting_ctas
-        = at::empty({}, at::TensorOptions().device(routing_logits.device()).dtype(at::ScalarType::Int));
+        = at::empty({}, at::TensorOptions().device(routing_device).dtype(at::ScalarType::Int));
+
+    // Set the optional pointer to the expert weights and expert ids
+    void* expert_weights_ptr = args.topk_weights ? args.topk_weights : expert_weights.data_ptr();
 
     tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::Routing::Runner routing_runner(tile_tokens_dim);
-    auto const& stream = at::cuda::getCurrentCUDAStream(routing_logits.get_device());
-    routing_runner.run(routing_logits.data_ptr<float>(), args.routing_bias, args.num_tokens, args.num_experts,
-        args.top_k, args.n_group, args.topk_group, args.local_expert_offset, args.local_num_experts,
-        args.routed_scaling_factor, expert_indexes.data_ptr<int>(), expert_count_histogram.data_ptr<int>(),
-        total_num_padded_tokens.data_ptr<int>(), expanded_idx_to_permuted_idx.data_ptr<int>(),
-        nullptr /*permuted_idx_to_expanded_idx.data_ptr<int>()*/, permuted_idx_to_token_idx.data_ptr<int>(),
-        expert_weights.data_ptr(), num_tokens_per_expert.data_ptr<int>(), cta_idx_xy_to_batch_idx.data_ptr<int>(),
+    auto const& stream = at::cuda::getCurrentCUDAStream(
+        routing_logits.has_value() ? routing_logits.value().get_device() : topk_ids.value().get_device());
+    routing_runner.run(args.routing_logits, args.routing_bias, args.num_tokens, args.num_experts, args.top_k,
+        args.n_group, args.topk_group, args.local_expert_offset, args.local_num_experts, args.routed_scaling_factor,
+        expert_indexes.data_ptr<int>(), expert_count_histogram.data_ptr<int>(), total_num_padded_tokens.data_ptr<int>(),
+        expanded_idx_to_permuted_idx.data_ptr<int>(), nullptr /*permuted_idx_to_expanded_idx.data_ptr<int>()*/,
+        permuted_idx_to_token_idx.data_ptr<int>(), expert_weights_ptr, args.topk_ids,
+        num_tokens_per_expert.data_ptr<int>(), cta_idx_xy_to_batch_idx.data_ptr<int>(),
         cta_idx_xy_to_mn_limit.data_ptr<int>(), num_non_exiting_ctas.data_ptr<int>(), args.mDtypeElt, false, true,
         static_cast<RoutingMethodType>(routing_method_type), stream);
 
@@ -206,7 +272,7 @@ at::Tensor run_fp8_block_scale_moe(at::Tensor const& routing_logits, std::option
     workspace.expanded_idx_to_permuted_idx
         = expanded_idx_to_permuted_idx.data_ptr<int>(); // Needed by activation/finalize kernels
     workspace.permuted_idx_to_token_idx = permuted_idx_to_token_idx.data_ptr<int>(); // Needed by permuteGemm1 kernel
-    workspace.expert_weights = expert_weights.data_ptr();                            // Consumed by finalize kernel
+    workspace.expert_weights = expert_weights_ptr;                                   // Consumed by finalize kernel
 
     workspace.cta_idx_xy_to_batch_idx = cta_idx_xy_to_batch_idx.data_ptr<int>();
     workspace.cta_idx_xy_to_mn_limit = cta_idx_xy_to_mn_limit.data_ptr<int>();
@@ -255,13 +321,14 @@ public:
         return mRunner->getValidConfigIndices(topK, hiddenSize, intermediateSize, numLocalExperts, numTokens);
     }
 
-    [[nodiscard]] at::Tensor run(at::Tensor const& routing_logits, std::optional<at::Tensor> const& routing_bias,
-        at::Tensor const& hidden_states, at::Tensor const& hidden_states_scale, at::Tensor const& gemm1_weights,
-        at::Tensor const& gemm1_weights_scale, at::Tensor const& gemm2_weights, at::Tensor const& gemm2_weights_scale,
-        int64_t num_experts, int64_t top_k, std::optional<int64_t> const n_group,
-        std::optional<int64_t> const topk_group, int64_t const intermediate_size, int64_t const local_expert_offset,
-        int64_t const local_num_experts, std::optional<double> const routed_scaling_factor, int64_t routing_method_type,
-        int64_t moeConfigIndex)
+    [[nodiscard]] at::Tensor run(at::optional<at::Tensor> const& routing_logits,
+        std::optional<at::Tensor> const& routing_bias, at::Tensor const& hidden_states,
+        at::Tensor const& hidden_states_scale, at::Tensor const& gemm1_weights, at::Tensor const& gemm1_weights_scale,
+        at::Tensor const& gemm2_weights, at::Tensor const& gemm2_weights_scale, int64_t num_experts, int64_t top_k,
+        std::optional<int64_t> const n_group, std::optional<int64_t> const topk_group, int64_t const intermediate_size,
+        int64_t const local_expert_offset, int64_t const local_num_experts,
+        std::optional<double> const routed_scaling_factor, int64_t routing_method_type, int64_t moeConfigIndex,
+        std::optional<at::Tensor> const& topk_weights, std::optional<at::Tensor> const& topk_ids)
     {
 
         // Autotuner has requested a default or 'fallback' config index
@@ -277,7 +344,7 @@ public:
         return run_fp8_block_scale_moe(routing_logits, routing_bias, hidden_states, hidden_states_scale, gemm1_weights,
             gemm1_weights_scale, gemm2_weights, gemm2_weights_scale, num_experts, top_k, n_group, topk_group,
             intermediate_size, local_expert_offset, local_num_experts, routed_scaling_factor, mTileTokensDim,
-            routing_method_type, *mRunner, moeConfigIndex);
+            routing_method_type, *mRunner, moeConfigIndex, topk_weights, topk_ids);
     }
 
 private:

--- a/cpp/tensorrt_llm/thop/fp8PerTensorScaleMoe.cpp
+++ b/cpp/tensorrt_llm/thop/fp8PerTensorScaleMoe.cpp
@@ -25,7 +25,7 @@ namespace torch_ext
 namespace btg = batchedGemm::trtllm::gen;
 using tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::Routing::RoutingMethodType;
 
-torch::Tensor fp8_per_tensor_scale_moe_runner(torch::Tensor const& routing_logits,
+torch::Tensor fp8_per_tensor_scale_moe_runner(torch::optional<torch::Tensor> const& routing_logits,
     torch::optional<torch::Tensor> const& routing_bias, torch::Tensor const& hidden_states,
     torch::Tensor const& gemm1_weights, torch::Tensor const& output1_scales_scalar,
     torch::Tensor const& output1_scales_gate_scalar, torch::Tensor const& gemm2_weights,
@@ -33,20 +33,67 @@ torch::Tensor fp8_per_tensor_scale_moe_runner(torch::Tensor const& routing_logit
     std::optional<int64_t> const n_group, std::optional<int64_t> const topk_group, int64_t const intermediate_size,
     int64_t const local_expert_offset, int64_t const local_num_experts,
     std::optional<double> const routed_scaling_factor, bool const use_routing_scales_on_input,
-    int64_t const tile_tokens_dim, int64_t const routing_method_type)
+    int64_t const tile_tokens_dim, int64_t const routing_method_type,
+    torch::optional<torch::Tensor> const& topk_weights, torch::optional<torch::Tensor> const& topk_ids)
 {
-
     TORCH_CHECK(tensorrt_llm::common::isSM100Family(), "Only SM100f is supported by FP8 block scale MOE");
-    if (use_routing_scales_on_input)
+    if (topk_ids.has_value() && topk_weights.has_value())
     {
-        TORCH_CHECK(routing_logits.scalar_type() == at::ScalarType::BFloat16, "routing_logits must be bfloat16.");
+        TORCH_CHECK(topk_ids.value().scalar_type() == at::ScalarType::Int, "topk_ids must be int");
+        TORCH_CHECK(topk_weights.value().scalar_type() == at::ScalarType::BFloat16, "topk_weights must be bfloat16.");
+        TORCH_CHECK(topk_ids.value().dim() == 2, "topk_ids must be 2D.");
+        TORCH_CHECK(topk_ids.value().sizes()[0] == hidden_states.sizes()[0],
+            "topk_ids and hidden_states must have the same number of tokens.");
+        TORCH_CHECK(topk_ids.value().sizes()[1] == top_k, "topk_ids dim1 must match top_k.");
+        TORCH_CHECK(topk_weights.value().dim() == 2, "topk_weights must be 2D.");
+        TORCH_CHECK(topk_weights.value().sizes()[0] == hidden_states.sizes()[0],
+            "topk_weights and hidden_states must have the same number of tokens.");
+        TORCH_CHECK(topk_weights.value().sizes()[1] == top_k, "topk_weights dim1 must match top_k.");
+    }
+    else if (routing_logits.has_value())
+    {
+        if (use_routing_scales_on_input)
+        {
+            TORCH_CHECK(
+                routing_logits.value().scalar_type() == at::ScalarType::BFloat16, "routing_logits must be bfloat16.");
+        }
+        else
+        {
+            if (static_cast<RoutingMethodType>(routing_method_type) == RoutingMethodType::DeepSeekV3)
+            {
+                TORCH_CHECK(
+                    routing_logits.value().scalar_type() == at::ScalarType::Float, "routing_logits must be float");
+            }
+            else
+            {
+                TORCH_CHECK(routing_logits.value().scalar_type() == at::ScalarType::BFloat16,
+                    "routing_logits must be bfloat16");
+            }
+        }
+        TORCH_CHECK(routing_logits.value().dim() == 2, "routing_logits must be 2D.");
+        TORCH_CHECK(routing_logits.value().sizes()[1] == num_experts, "routing_logits has incorrect shape.");
     }
     else
     {
-        TORCH_CHECK(routing_logits.scalar_type() == at::ScalarType::Float, "routing_logits must be float.");
+        TORCH_CHECK(false, "routing_logits or (topk_ids and topk_weights) must be provided.");
     }
-    TORCH_CHECK(routing_logits.dim() == 2, "routing_logits must be 2D.");
-    TORCH_CHECK(routing_logits.sizes()[1] == num_experts, "routing_logits has incorrect shape.");
+
+    if (topk_ids.has_value() && topk_weights.has_value() && routing_logits.has_value())
+    {
+        TLLM_LOG_WARNING(
+            "When logits and (topk_ids and topk_weights) are both provided, we only use (topk_ids and topk_weights).");
+    }
+
+    if (topk_ids.has_value())
+    {
+        TORCH_CHECK(topk_ids.value().sizes()[0] == hidden_states.sizes()[0],
+            "topk_ids and hidden_states must have the same number of tokens.");
+    }
+    else
+    {
+        TORCH_CHECK(routing_logits.value().sizes()[0] == hidden_states.sizes()[0],
+            "routing_logits and hidden_states must have the same number of tokens.");
+    }
 
     if (routing_bias.has_value())
     {
@@ -82,13 +129,23 @@ torch::Tensor fp8_per_tensor_scale_moe_runner(torch::Tensor const& routing_logit
     TORCH_CHECK(num_experts % 4 == 0, "Routing kernel expects that num_experts must be divisible by 4");
     TORCH_CHECK(num_experts > top_k, "num_experts must be greater than top_k");
 
+    // If both routing inputs are provided, they must be on the same device
+    if (routing_logits.has_value() && topk_ids.has_value())
+    {
+        TORCH_CHECK(
+            routing_logits->device() == topk_ids->device(), "routing_logits and topk_ids must be on the same device");
+    }
+
     tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::MoE::MoERunnerArgs args;
     tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::MoE::MoEWorkspace workspace;
 
     // setup args
     args.mDtypeElt = btg::Dtype::E4m3;
-    args.routing_logits = routing_logits.data_ptr();
+    args.routing_logits = routing_logits.has_value() ? routing_logits.value().data_ptr() : nullptr;
     args.routing_bias = routing_bias.has_value() ? routing_bias.value().data_ptr() : nullptr;
+
+    args.topk_weights = topk_weights.has_value() ? topk_weights.value().data_ptr() : nullptr;
+    args.topk_ids = topk_ids.has_value() ? static_cast<int32_t*>(topk_ids.value().data_ptr()) : nullptr;
     args.hidden_states = hidden_states.data_ptr();
     args.gemm1_weights = gemm1_weights.data_ptr();
     args.output1_scales_scalar = output1_scales_scalar.data_ptr<float>();
@@ -108,56 +165,68 @@ torch::Tensor fp8_per_tensor_scale_moe_runner(torch::Tensor const& routing_logit
     args.mUseRoutingScalesOnInput = use_routing_scales_on_input;
 
     // allocate workspace for routing kernel
+    if (routing_logits.has_value() && topk_ids.has_value())
+    {
+        TORCH_CHECK(routing_logits.value().device() == topk_ids.value().device(),
+            "routing_logits and topk_ids must be on the same device");
+    }
+    auto routing_device = routing_logits.has_value() ? routing_logits.value().device() : topk_ids.value().device();
     at::Tensor num_tokens_per_expert
-        = at::detail::empty_cuda({num_experts}, at::ScalarType::Int, routing_logits.device(), std::nullopt);
+        = at::detail::empty_cuda({num_experts}, at::ScalarType::Int, routing_device, std::nullopt);
     int32_t max_num_padded_tokens
         = tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::Routing::getMaxPermutedPaddedCount(
             args.num_tokens, top_k, num_experts, tile_tokens_dim);
     at::Tensor total_num_padded_tokens
-        = at::empty({}, at::TensorOptions().device(routing_logits.device()).dtype(at::ScalarType::Int));
-    at::Tensor expanded_idx_to_permuted_idx = at::detail::empty_cuda(
-        {args.num_tokens * args.top_k}, at::ScalarType::Int, routing_logits.device(), std::nullopt);
+        = at::empty({}, at::TensorOptions().device(routing_device).dtype(at::ScalarType::Int));
+    at::Tensor expanded_idx_to_permuted_idx
+        = at::detail::empty_cuda({args.num_tokens * args.top_k}, at::ScalarType::Int, routing_device, std::nullopt);
     at::Tensor permuted_idx_to_token_idx
-        = at::detail::empty_cuda({max_num_padded_tokens}, at::ScalarType::Int, routing_logits.device(), std::nullopt);
-    at::Tensor expert_weights = at::detail::empty_cuda(
-        {args.num_tokens, args.top_k}, at::ScalarType::BFloat16, routing_logits.device(), std::nullopt);
-    at::Tensor expert_indexes = at::detail::empty_cuda(
-        {args.num_tokens, args.top_k}, at::ScalarType::Int, routing_logits.device(), std::nullopt);
-    at::Tensor expert_count_histogram = at::detail::empty_cuda({2 * 256},
-        at::ScalarType::Int, // 256 is the max number of threads per block and max number of experts
-        routing_logits.device(), std::nullopt);
+        = at::detail::empty_cuda({max_num_padded_tokens}, at::ScalarType::Int, routing_device, std::nullopt);
+    at::Tensor expert_weights
+        = at::detail::empty_cuda({args.num_tokens, args.top_k}, at::ScalarType::BFloat16, routing_device, std::nullopt);
+    at::Tensor expert_indexes
+        = at::detail::empty_cuda({args.num_tokens, args.top_k}, at::ScalarType::Int, routing_device, std::nullopt);
+
+    int64_t const size_of_expert_count_histogram = std::max(num_experts * 2, int64_t(256 * 2));
+    at::Tensor expert_count_histogram
+        = at::detail::empty_cuda({size_of_expert_count_histogram}, at::ScalarType::Int, routing_device, std::nullopt);
 
     // allocate workspace for activation/gemm/finalize kernels
-    at::Tensor gemm1_output = at::detail::empty_cuda({max_num_padded_tokens, 2 * intermediate_size},
-        at::ScalarType::Float8_e4m3fn, hidden_states.device(), std::nullopt);
-    at::Tensor gemm1_output_scale = at::detail::empty_cuda({2 * intermediate_size / 128, max_num_padded_tokens},
-        at::ScalarType::Float, hidden_states.device(), std::nullopt);
-    at::Tensor activation_output = at::detail::empty_cuda({max_num_padded_tokens, intermediate_size},
-        at::ScalarType::Float8_e4m3fn, hidden_states.device(), std::nullopt);
+    at::Tensor gemm1_output = at::detail::empty_cuda(
+        {max_num_padded_tokens, 2 * intermediate_size}, at::ScalarType::Float8_e4m3fn, routing_device, std::nullopt);
+    at::Tensor gemm1_output_scale = at::detail::empty_cuda(
+        {2 * intermediate_size / 128, max_num_padded_tokens}, at::ScalarType::Float, routing_device, std::nullopt);
+    at::Tensor activation_output = at::detail::empty_cuda(
+        {max_num_padded_tokens, intermediate_size}, at::ScalarType::Float8_e4m3fn, routing_device, std::nullopt);
     at::Tensor activation_output_scale = at::detail::empty_cuda(
-        {intermediate_size / 128, max_num_padded_tokens}, at::ScalarType::Float, hidden_states.device(), std::nullopt);
+        {intermediate_size / 128, max_num_padded_tokens}, at::ScalarType::Float, routing_device, std::nullopt);
     at::Tensor gemm2_output = at::detail::empty_cuda(
-        {max_num_padded_tokens, args.hidden_size}, at::ScalarType::BFloat16, hidden_states.device(), std::nullopt);
+        {max_num_padded_tokens, args.hidden_size}, at::ScalarType::BFloat16, routing_device, std::nullopt);
 
     int32_t max_num_ctas = tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::Routing::getMaxNumCtasInBatchDim(
         args.num_tokens, args.top_k, args.num_experts, tile_tokens_dim);
     at::Tensor cta_idx_xy_to_batch_idx
-        = at::detail::empty_cuda({max_num_ctas}, at::ScalarType::Int, routing_logits.device(), std::nullopt);
+        = at::detail::empty_cuda({max_num_ctas}, at::ScalarType::Int, routing_device, std::nullopt);
     at::Tensor cta_idx_xy_to_mn_limit
-        = at::detail::empty_cuda({max_num_ctas}, at::ScalarType::Int, routing_logits.device(), std::nullopt);
+        = at::detail::empty_cuda({max_num_ctas}, at::ScalarType::Int, routing_device, std::nullopt);
     at::Tensor num_non_exiting_ctas
-        = at::empty({}, at::TensorOptions().device(routing_logits.device()).dtype(at::ScalarType::Int));
+        = at::empty({}, at::TensorOptions().device(routing_device).dtype(at::ScalarType::Int));
+
+    // Set the optional pointer to the expert weights and expert ids
+    void* expert_weights_ptr = args.topk_weights ? args.topk_weights : expert_weights.data_ptr();
 
     tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::Routing::Runner routing_runner(tile_tokens_dim);
-    auto const& stream = at::cuda::getCurrentCUDAStream(routing_logits.get_device());
-    routing_runner.run(routing_logits.data_ptr(), args.routing_bias, args.num_tokens, args.num_experts, args.top_k,
+    auto const& stream = at::cuda::getCurrentCUDAStream(
+        routing_logits.has_value() ? routing_logits.value().get_device() : topk_ids.value().get_device());
+    routing_runner.run(args.routing_logits, args.routing_bias, args.num_tokens, args.num_experts, args.top_k,
         args.n_group, args.topk_group, args.local_expert_offset, args.local_num_experts, args.routed_scaling_factor,
         expert_indexes.data_ptr<int>(), expert_count_histogram.data_ptr<int>(), total_num_padded_tokens.data_ptr<int>(),
         expanded_idx_to_permuted_idx.data_ptr<int>(), nullptr /*permuted_idx_to_expanded_idx.data_ptr<int>()*/,
-        permuted_idx_to_token_idx.data_ptr<int>(), expert_weights.data_ptr(), num_tokens_per_expert.data_ptr<int>(),
-        cta_idx_xy_to_batch_idx.data_ptr<int>(), cta_idx_xy_to_mn_limit.data_ptr<int>(),
-        num_non_exiting_ctas.data_ptr<int>(), args.mDtypeElt, use_routing_scales_on_input,
-        false /* use_deep_seek_fp8 */, static_cast<RoutingMethodType>(routing_method_type), stream);
+        permuted_idx_to_token_idx.data_ptr<int>(), expert_weights_ptr, args.topk_ids,
+        num_tokens_per_expert.data_ptr<int>(), cta_idx_xy_to_batch_idx.data_ptr<int>(),
+        cta_idx_xy_to_mn_limit.data_ptr<int>(), num_non_exiting_ctas.data_ptr<int>(), args.mDtypeElt,
+        use_routing_scales_on_input, false /* use_deep_seek_fp8 */, static_cast<RoutingMethodType>(routing_method_type),
+        stream);
 
     // MoE kernel except routing
     TORCH_CHECK(hidden_states.scalar_type() == at::ScalarType::Float8_e4m3fn, "hidden_states must be fp8.");
@@ -200,7 +269,7 @@ torch::Tensor fp8_per_tensor_scale_moe_runner(torch::Tensor const& routing_logit
     workspace.expanded_idx_to_permuted_idx
         = expanded_idx_to_permuted_idx.data_ptr<int>(); // Needed by activation/finalize kernels
     workspace.permuted_idx_to_token_idx = permuted_idx_to_token_idx.data_ptr<int>(); // Needed by permuteGemm1 kernel
-    workspace.expert_weights = expert_weights.data_ptr();                            // Consumed by finalize kernel
+    workspace.expert_weights = expert_weights_ptr;                                   // Consumed by finalize kernel
 
     workspace.cta_idx_xy_to_batch_idx = cta_idx_xy_to_batch_idx.data_ptr<int>();
     workspace.cta_idx_xy_to_mn_limit = cta_idx_xy_to_mn_limit.data_ptr<int>();
@@ -241,7 +310,7 @@ TORCH_LIBRARY_FRAGMENT(trtllm, m)
 {
     m.def(
         "fp8_per_tensor_scale_moe_runner("
-        "Tensor routing_logits,"
+        "Tensor? routing_logits,"
         "Tensor? routing_bias,"
         "Tensor hidden_states,"
         "Tensor gemm1_weights,"
@@ -259,7 +328,9 @@ TORCH_LIBRARY_FRAGMENT(trtllm, m)
         "float? routed_scaling_factor,"
         "bool use_routing_scales_on_input,"
         "int tile_tokens_dim,"
-        "int routing_method_type) -> Tensor");
+        "int routing_method_type,"
+        "Tensor? topk_weights,"
+        "Tensor? topk_ids) -> Tensor");
 }
 
 TORCH_LIBRARY_IMPL(trtllm, CUDA, m)

--- a/cpp/tensorrt_llm/thop/mxFp4BlockScaleMoe.cpp
+++ b/cpp/tensorrt_llm/thop/mxFp4BlockScaleMoe.cpp
@@ -31,7 +31,7 @@ namespace btg = batchedGemm::trtllm::gen;
 using tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::Routing::RoutingMethodType;
 using MoeRunnerType = tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::MoE::Runner;
 
-torch::Tensor dtype_mxe2m1_block_scale_moe_runner(torch::Tensor const& routing_logits,
+torch::Tensor dtype_mxe2m1_block_scale_moe_runner(torch::optional<torch::Tensor> const& routing_logits,
     torch::optional<torch::Tensor> const& routing_bias, torch::Tensor const& hidden_states,
     std::optional<torch::Tensor> const& hidden_states_scale, torch::Tensor const& gemm1_weights,
     torch::Tensor const& gemm1_weights_scale, std::optional<torch::Tensor> const& gemm1_bias,
@@ -44,18 +44,63 @@ torch::Tensor dtype_mxe2m1_block_scale_moe_runner(torch::Tensor const& routing_l
     std::optional<int64_t> const n_group, std::optional<int64_t> const topk_group, int64_t const intermediate_size,
     std::optional<int64_t> const hidden_size_output, int64_t const local_expert_offset, int64_t const local_num_experts,
     std::optional<double> const routed_scaling_factor, int64_t const tile_tokens_dim, int64_t const routing_method_type,
-    btg::Dtype const dtype, MoeRunnerType& moe_runner, int64_t moeConfigIndex)
+    btg::Dtype const dtype, MoeRunnerType& moe_runner, int64_t moeConfigIndex,
+    torch::optional<torch::Tensor> const& topk_weights, torch::optional<torch::Tensor> const& topk_ids)
 {
     TORCH_CHECK(tensorrt_llm::common::isSM100Family(), "Only SM100f is supported by MXFP4 block scale MOE");
     TORCH_CHECK(tile_tokens_dim == 8 || tile_tokens_dim == 16 || tile_tokens_dim == 32 || tile_tokens_dim == 64,
         "tile_tokens_dim must be 8, 16, 32, 64");
-    TORCH_CHECK(routing_logits.scalar_type() == at::ScalarType::Float
-            || routing_logits.scalar_type() == at::ScalarType::BFloat16,
-        "routing_logits must be float or bfloat16.");
-    TORCH_CHECK(routing_logits.dim() == 2, "routing_logits must be 2D.");
-    TORCH_CHECK(
-        routing_logits.sizes()[0] == hidden_states.sizes()[0], "routing_logits dim0 must match hidden_states dim0.");
-    TORCH_CHECK(routing_logits.sizes()[1] == num_experts, "routing_logits dim1 must match num_experts.");
+
+    if (topk_ids.has_value() && topk_weights.has_value())
+    {
+        TORCH_CHECK(topk_ids.value().scalar_type() == at::ScalarType::Int, "topk_ids must be int.");
+        TORCH_CHECK(topk_weights.value().scalar_type() == at::ScalarType::BFloat16, "topk_weights must be bfloat.");
+        TORCH_CHECK(topk_ids.value().dim() == 2, "topk_ids must be 2D.");
+        TORCH_CHECK(topk_weights.value().dim() == 2, "topk_weights must be 2D.");
+        TORCH_CHECK(
+            topk_ids.value().sizes()[0] == hidden_states.sizes()[0], "topk_ids dim0 must match hidden_states dim0.");
+        TORCH_CHECK(topk_ids.value().sizes()[1] == top_k, "topk_ids dim1 must match top_k.");
+        TORCH_CHECK(topk_weights.value().sizes()[0] == hidden_states.sizes()[0],
+            "topk_weights dim0 must match hidden_states dim0.");
+        TORCH_CHECK(topk_weights.value().sizes()[1] == top_k, "topk_weights dim1 must match top_k.");
+    }
+    else if (routing_logits.has_value())
+    {
+        if (static_cast<RoutingMethodType>(routing_method_type) == RoutingMethodType::DeepSeekV3)
+        {
+            TORCH_CHECK(routing_logits.value().scalar_type() == at::ScalarType::Float, "routing_logits must be float");
+        }
+        else
+        {
+            TORCH_CHECK(
+                routing_logits.value().scalar_type() == at::ScalarType::BFloat16, "routing_logits must be bfloat16");
+        }
+
+        TORCH_CHECK(routing_logits.value().dim() == 2, "routing_logits must be 2D.");
+        TORCH_CHECK(routing_logits.value().sizes()[1] == num_experts, "routing_logits dim1 must match num_experts.");
+    }
+    else
+    {
+        TORCH_CHECK(false, "routing_logits or (topk_ids and topk_weights) must be provided.");
+    }
+
+    if (topk_ids.has_value() && topk_weights.has_value() && routing_logits.has_value())
+    {
+        TLLM_LOG_WARNING(
+            "When logits and (topk_ids and topk_weights) are both provided, we only use (topk_ids and topk_weights).");
+    }
+
+    if (topk_ids.has_value())
+    {
+        TORCH_CHECK(topk_ids.value().sizes()[0] == hidden_states.sizes()[0],
+            "topk_ids and hidden_states must have the same number of tokens.");
+    }
+    else
+    {
+        TORCH_CHECK(routing_logits.value().sizes()[0] == hidden_states.sizes()[0],
+            "routing_logits and hidden_states must have the same number of tokens.");
+    }
+
     if (routing_bias.has_value())
     {
         TORCH_CHECK(routing_bias.value().scalar_type() == at::ScalarType::BFloat16, "routing_bias must be bfloat16.");
@@ -87,15 +132,26 @@ torch::Tensor dtype_mxe2m1_block_scale_moe_runner(torch::Tensor const& routing_l
     TORCH_CHECK(num_experts % 4 == 0, "Routing kernel expects that num_experts must be divisible by 4");
     TORCH_CHECK(num_experts > top_k, "num_experts must be greater than top_k");
 
+    // If both routing inputs are provided, they must be on the same device
+    if (routing_logits.has_value() && topk_ids.has_value())
+    {
+        TORCH_CHECK(
+            routing_logits->device() == topk_ids->device(), "routing_logits and topk_ids must be on the same device");
+    }
+
     tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::MoE::MoERunnerArgs args;
     tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::MoE::MoEWorkspace workspace;
 
     // setup args
     args.mDtypeElt = dtype;
-    args.routing_logits = routing_logits.data_ptr();
+    args.routing_logits = routing_logits.has_value() ? routing_logits.value().data_ptr() : nullptr;
     args.routing_bias = routing_bias.has_value() ? routing_bias.value().data_ptr() : nullptr;
     args.hidden_states = hidden_states.data_ptr();
     args.hidden_states_scale = hidden_states_scale.has_value() ? hidden_states_scale.value().data_ptr() : nullptr;
+
+    args.topk_weights = topk_weights.has_value() ? topk_weights.value().data_ptr() : nullptr;
+    args.topk_ids = topk_ids.has_value() ? static_cast<int32_t*>(topk_ids.value().data_ptr()) : nullptr;
+
     args.gemm1_weights = gemm1_weights.data_ptr();
     args.gemm1_weights_scale = gemm1_weights_scale.data_ptr();
     args.gemm2_weights = gemm2_weights.data_ptr();
@@ -124,52 +180,61 @@ torch::Tensor dtype_mxe2m1_block_scale_moe_runner(torch::Tensor const& routing_l
     args.intermediate_size = intermediate_size;
 
     // allocate workspace for routing kernel
+    if (routing_logits.has_value() && topk_ids.has_value())
+    {
+        TORCH_CHECK(routing_logits.value().device() == topk_ids.value().device(),
+            "routing_logits and topk_ids must be on the same device");
+    }
+    auto routing_device = routing_logits.has_value() ? routing_logits.value().device() : topk_ids.value().device();
     at::Tensor num_tokens_per_expert
-        = at::detail::empty_cuda({num_experts}, at::ScalarType::Int, routing_logits.device(), std::nullopt);
+        = at::detail::empty_cuda({num_experts}, at::ScalarType::Int, routing_device, std::nullopt);
     int32_t max_num_padded_tokens
         = tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::Routing::getMaxPermutedPaddedCount(
             args.num_tokens, top_k, num_experts, tile_tokens_dim);
     at::Tensor total_num_padded_tokens
-        = at::empty({}, at::TensorOptions().device(routing_logits.device()).dtype(at::ScalarType::Int));
-    at::Tensor expanded_idx_to_permuted_idx = at::detail::empty_cuda(
-        {args.num_tokens * args.top_k}, at::ScalarType::Int, routing_logits.device(), std::nullopt);
+        = at::empty({}, at::TensorOptions().device(routing_device).dtype(at::ScalarType::Int));
+    at::Tensor expanded_idx_to_permuted_idx
+        = at::detail::empty_cuda({args.num_tokens * args.top_k}, at::ScalarType::Int, routing_device, std::nullopt);
 
     at::Tensor permuted_idx_to_token_idx
-        = at::detail::empty_cuda({max_num_padded_tokens}, at::ScalarType::Int, routing_logits.device(), std::nullopt);
-    at::Tensor expert_weights = at::detail::empty_cuda(
-        {args.num_tokens, args.top_k}, at::ScalarType::BFloat16, routing_logits.device(), std::nullopt);
-    at::Tensor expert_indexes = at::detail::empty_cuda(
-        {args.num_tokens, args.top_k}, at::ScalarType::Int, routing_logits.device(), std::nullopt);
-    at::Tensor expert_count_histogram = at::detail::empty_cuda({2 * 256},
-        at::ScalarType::Int, // 256 is the max number of threads per block and max number of experts
-        routing_logits.device(), std::nullopt);
+        = at::detail::empty_cuda({max_num_padded_tokens}, at::ScalarType::Int, routing_device, std::nullopt);
+    at::Tensor expert_weights
+        = at::detail::empty_cuda({args.num_tokens, args.top_k}, at::ScalarType::BFloat16, routing_device, std::nullopt);
+    at::Tensor expert_indexes
+        = at::detail::empty_cuda({args.num_tokens, args.top_k}, at::ScalarType::Int, routing_device, std::nullopt);
+
+    int64_t const size_of_expert_count_histogram = std::max(num_experts * 2, int64_t(256 * 2));
+    at::Tensor expert_count_histogram
+        = at::detail::empty_cuda({size_of_expert_count_histogram}, at::ScalarType::Int, routing_device, std::nullopt);
+    // Set the optional pointer to the expert weights and expert ids
+    void* expert_weights_ptr = args.topk_weights ? args.topk_weights : expert_weights.data_ptr();
 
     int32_t const sf_block_size = 32;
     // allocate workspace for activation/gemm/finalize kernels
     auto const gemm1_output_type
         = dtype == btg::Dtype::Bfloat16 ? at::ScalarType::BFloat16 : at::ScalarType::Float8_e4m3fn;
     at::Tensor gemm1_output = at::detail::empty_cuda(
-        {max_num_padded_tokens, intermediate_size}, gemm1_output_type, hidden_states.device(), std::nullopt);
+        {max_num_padded_tokens, intermediate_size}, gemm1_output_type, routing_device, std::nullopt);
 
     std::optional<at::Tensor> gemm1_output_scale;
     if (dtype == btg::Dtype::MxE4m3)
     {
         int64_t sf_size
             = tensorrt_llm::computeSwizzledLayoutSFSize(max_num_padded_tokens, intermediate_size / sf_block_size);
-        gemm1_output_scale = at::detail::empty_cuda({sf_size}, SF_DTYPE, hidden_states.device(), std::nullopt);
+        gemm1_output_scale = at::detail::empty_cuda({sf_size}, SF_DTYPE, routing_device, std::nullopt);
     }
 
     at::Tensor gemm2_output = at::detail::empty_cuda(
-        {max_num_padded_tokens, args.hidden_size}, at::ScalarType::BFloat16, hidden_states.device(), std::nullopt);
+        {max_num_padded_tokens, args.hidden_size}, at::ScalarType::BFloat16, routing_device, std::nullopt);
 
     int32_t max_num_ctas = tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::Routing::getMaxNumCtasInBatchDim(
         args.num_tokens, args.top_k, args.num_experts, tile_tokens_dim);
     at::Tensor cta_idx_xy_to_batch_idx
-        = at::detail::empty_cuda({max_num_ctas}, at::ScalarType::Int, routing_logits.device(), std::nullopt);
+        = at::detail::empty_cuda({max_num_ctas}, at::ScalarType::Int, routing_device, std::nullopt);
     at::Tensor cta_idx_xy_to_mn_limit
-        = at::detail::empty_cuda({max_num_ctas}, at::ScalarType::Int, routing_logits.device(), std::nullopt);
+        = at::detail::empty_cuda({max_num_ctas}, at::ScalarType::Int, routing_device, std::nullopt);
     at::Tensor num_non_exiting_ctas
-        = at::empty({}, at::TensorOptions().device(routing_logits.device()).dtype(at::ScalarType::Int));
+        = at::empty({}, at::TensorOptions().device(routing_device).dtype(at::ScalarType::Int));
 
     // FIXME: check shape
     TORCH_CHECK(dtype == btg::Dtype::MxE4m3 || dtype == btg::Dtype::Bfloat16 || dtype == btg::Dtype::E4m3,
@@ -189,15 +254,17 @@ torch::Tensor dtype_mxe2m1_block_scale_moe_runner(torch::Tensor const& routing_l
     //
 
     tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::Routing::Runner routing_runner(tile_tokens_dim);
-    auto const& stream = at::cuda::getCurrentCUDAStream(routing_logits.get_device());
+    auto const& stream = at::cuda::getCurrentCUDAStream(
+        routing_logits.has_value() ? routing_logits.value().get_device() : topk_ids.value().get_device());
     routing_runner.run(args.routing_logits, args.routing_bias, args.num_tokens, args.num_experts, args.top_k,
         args.n_group, args.topk_group, args.local_expert_offset, args.local_num_experts, args.routed_scaling_factor,
         expert_indexes.data_ptr<int>(), expert_count_histogram.data_ptr<int>(), total_num_padded_tokens.data_ptr<int>(),
         expanded_idx_to_permuted_idx.data_ptr<int>(), nullptr, /*permuted_idx_to_expanded_idx.data_ptr<int>(),*/
-        permuted_idx_to_token_idx.data_ptr<int>(), expert_weights.data_ptr(), num_tokens_per_expert.data_ptr<int>(),
-        cta_idx_xy_to_batch_idx.data_ptr<int>(), cta_idx_xy_to_mn_limit.data_ptr<int>(),
-        num_non_exiting_ctas.data_ptr<int>(), args.mDtypeElt, false /* use_routing_scales_on_input */,
-        false /* use_deep_seek_fp8 */, static_cast<RoutingMethodType>(routing_method_type), stream);
+        permuted_idx_to_token_idx.data_ptr<int>(), expert_weights_ptr, args.topk_ids,
+        num_tokens_per_expert.data_ptr<int>(), cta_idx_xy_to_batch_idx.data_ptr<int>(),
+        cta_idx_xy_to_mn_limit.data_ptr<int>(), num_non_exiting_ctas.data_ptr<int>(), args.mDtypeElt,
+        false /* use_routing_scales_on_input */, false /* use_deep_seek_fp8 */,
+        static_cast<RoutingMethodType>(routing_method_type), stream);
 
     //
     // FC13 (gemm1) + FC2 (gemm2)
@@ -341,7 +408,7 @@ torch::Tensor dtype_mxe2m1_block_scale_moe_runner(torch::Tensor const& routing_l
     workspace.expanded_idx_to_permuted_idx
         = expanded_idx_to_permuted_idx.data_ptr<int>(); // Needed by permute/finalize kernels
     workspace.permuted_idx_to_token_idx = permuted_idx_to_token_idx.data_ptr<int>(); // Needed by permuteGemm1 kernel
-    workspace.expert_weights = expert_weights.data_ptr();                            // Consumed by finalize kernel
+    workspace.expert_weights = expert_weights_ptr;                                   // Consumed by finalize kernel
 
     workspace.cta_idx_xy_to_batch_idx = cta_idx_xy_to_batch_idx.data_ptr<int>();
     workspace.cta_idx_xy_to_mn_limit = cta_idx_xy_to_mn_limit.data_ptr<int>();
@@ -390,7 +457,7 @@ public:
     }
 
     // BF16 run does not use hidden_states_scale
-    [[nodiscard]] torch::Tensor run(torch::Tensor const& routing_logits,
+    [[nodiscard]] torch::Tensor run(torch::optional<torch::Tensor> const& routing_logits,
         std::optional<torch::Tensor> const& routing_bias, torch::Tensor const& hidden_states,
         torch::Tensor const& gemm1_weights, torch::Tensor const& gemm1_weights_scale,
         std::optional<torch::Tensor> const& gemm1_bias, std::optional<torch::Tensor> const& gemm1_alpha,
@@ -399,7 +466,9 @@ public:
         std::optional<torch::Tensor> const& gemm2_bias, int64_t num_experts, int64_t top_k,
         std::optional<int64_t> const n_group, std::optional<int64_t> const topk_group, int64_t intermediate_size,
         int64_t local_expert_offset, int64_t local_num_experts, std::optional<double> routed_scaling_factor,
-        int64_t routing_method_type, int64_t moeConfigIndex)
+        int64_t routing_method_type, int64_t moeConfigIndex, torch::optional<torch::Tensor> const& topk_weights,
+        torch::optional<torch::Tensor> const& topk_ids)
+
     {
         // Autotuner has requested a default or 'fallback' config index
         if (moeConfigIndex == -1)
@@ -415,7 +484,7 @@ public:
             gemm1_weights, gemm1_weights_scale, gemm1_bias, gemm1_alpha, gemm1_beta, gemm1_clamp_limit, gemm2_weights,
             gemm2_weights_scale, gemm2_bias, std::nullopt, std::nullopt, std::nullopt, num_experts, top_k, n_group,
             topk_group, intermediate_size, std::nullopt, local_expert_offset, local_num_experts, routed_scaling_factor,
-            mTileTokensDim, routing_method_type, mDtypeAct, *mRunner, moeConfigIndex);
+            mTileTokensDim, routing_method_type, mDtypeAct, *mRunner, moeConfigIndex, topk_weights, topk_ids);
     }
 
 private:
@@ -447,7 +516,7 @@ public:
         return mRunner->getValidConfigIndices(topK, hiddenSize, intermediateSize, numLocalExperts, numTokens);
     }
 
-    [[nodiscard]] torch::Tensor run(torch::Tensor const& routing_logits,
+    [[nodiscard]] torch::Tensor run(torch::optional<torch::Tensor> const& routing_logits,
         std::optional<torch::Tensor> const& routing_bias, torch::Tensor const& hidden_states,
         std::optional<torch::Tensor> const& hidden_states_scale, torch::Tensor const& gemm1_weights,
         torch::Tensor const& gemm1_weights_scale, std::optional<torch::Tensor> const& gemm1_bias,
@@ -459,7 +528,8 @@ public:
         std::optional<torch::Tensor> const& output2_scale_scalar, int64_t num_experts, int64_t top_k,
         std::optional<int64_t> const n_group, std::optional<int64_t> const topk_group, int64_t intermediate_size,
         std::optional<int64_t> const hidden_size_output, int64_t local_expert_offset, int64_t local_num_experts,
-        std::optional<double> routed_scaling_factor, int64_t routing_method_type, int64_t moeConfigIndex)
+        std::optional<double> routed_scaling_factor, int64_t routing_method_type, int64_t moeConfigIndex,
+        torch::optional<torch::Tensor> const& topk_weights, torch::optional<torch::Tensor> const& topk_ids)
     {
         // Autotuner has requested a default or 'fallback' config index
         if (moeConfigIndex == -1)
@@ -476,7 +546,7 @@ public:
             gemm2_weights_scale, gemm2_bias, output1_scale_scalar, output1_scale_gate_scalar, output2_scale_scalar,
             num_experts, top_k, n_group, topk_group, intermediate_size, hidden_size_output, local_expert_offset,
             local_num_experts, routed_scaling_factor, mTileTokensDim, routing_method_type, mDtypeAct, *mRunner,
-            moeConfigIndex);
+            moeConfigIndex, topk_weights, topk_ids);
     }
 
 private:

--- a/cpp/tests/unit_tests/kernels/routing/routingDeepSeekTest.cpp
+++ b/cpp/tests/unit_tests/kernels/routing/routingDeepSeekTest.cpp
@@ -73,40 +73,49 @@ private:
                 expWeightsIdx[ie] = si;
             }
 
-            // Calculate the group score
-            int32_t expertsPerGroup = param.numExperts / param.nGroup;
-            PackedFloat groupScoresCandidate[param.nGroup][2];
-            PackedFloat groupScores[param.nGroup];
-            for (int ig = 0; ig < param.nGroup; ++ig)
-            {
-                std::partial_sort_copy(expWeightsIdx + ig * expertsPerGroup, expWeightsIdx + (ig + 1) * expertsPerGroup,
-                    groupScoresCandidate[ig], groupScoresCandidate[ig] + 2, comp);
-                PackedFloat si{
-                    static_cast<float>(groupScoresCandidate[ig][0].score + groupScoresCandidate[ig][1].score),
-                    static_cast<int16_t>(ig)};
-                groupScores[ig] = si;
-            }
-
-            // Get the topkGroup group score
-            PackedFloat topGroupScores[param.topkGroup];
-            std::partial_sort_copy(
-                groupScores, groupScores + param.nGroup, topGroupScores, topGroupScores + param.topkGroup, comp);
-
-            // Prepare the data for the final topk experts selection
-            PackedFloat topkExpertsCandidate[param.topkGroup * expertsPerGroup];
             PackedFloat finalTopkExperts[param.topK];
-
-            for (int ig = 0; ig < param.topkGroup; ++ig)
+            if (param.nGroup != 0)
             {
-                for (int ie = 0; ie < expertsPerGroup; ++ie)
+                // Calculate the group score
+                int32_t expertsPerGroup = param.numExperts / param.nGroup;
+                PackedFloat groupScoresCandidate[param.nGroup][2];
+                PackedFloat groupScores[param.nGroup];
+                for (int ig = 0; ig < param.nGroup; ++ig)
                 {
-                    topkExpertsCandidate[ig * expertsPerGroup + ie]
-                        = expWeightsIdx[topGroupScores[ig].idx * expertsPerGroup + ie];
+                    std::partial_sort_copy(expWeightsIdx + ig * expertsPerGroup,
+                        expWeightsIdx + (ig + 1) * expertsPerGroup, groupScoresCandidate[ig],
+                        groupScoresCandidate[ig] + 2, comp);
+                    PackedFloat si{
+                        static_cast<float>(groupScoresCandidate[ig][0].score + groupScoresCandidate[ig][1].score),
+                        static_cast<int16_t>(ig)};
+                    groupScores[ig] = si;
                 }
-            }
 
-            std::partial_sort_copy(topkExpertsCandidate, topkExpertsCandidate + param.topkGroup * expertsPerGroup,
-                finalTopkExperts, finalTopkExperts + param.topK, comp);
+                // Get the topkGroup group score
+                PackedFloat topGroupScores[param.topkGroup];
+                std::partial_sort_copy(
+                    groupScores, groupScores + param.nGroup, topGroupScores, topGroupScores + param.topkGroup, comp);
+
+                // Prepare the data for the final topk experts selection
+                PackedFloat topkExpertsCandidate[param.topkGroup * expertsPerGroup];
+
+                for (int ig = 0; ig < param.topkGroup; ++ig)
+                {
+                    for (int ie = 0; ie < expertsPerGroup; ++ie)
+                    {
+                        topkExpertsCandidate[ig * expertsPerGroup + ie]
+                            = expWeightsIdx[topGroupScores[ig].idx * expertsPerGroup + ie];
+                    }
+                }
+
+                std::partial_sort_copy(topkExpertsCandidate, topkExpertsCandidate + param.topkGroup * expertsPerGroup,
+                    finalTopkExperts, finalTopkExperts + param.topK, comp);
+            }
+            else
+            {
+                std::partial_sort_copy(expWeightsIdx, expWeightsIdx + param.numExperts, finalTopkExperts,
+                    finalTopkExperts + param.topK, comp);
+            }
 
             // Normalize the score
             float sumScore = 0.0f;
@@ -120,16 +129,24 @@ private:
                 finalTopkExperts[ie].score = finalScore;
             }
 
-            // Convert back to io_dtype and store the topk expert results in hostData.mPtrExpertIdx
+            // Convert back to io_dtype and store the topk expert results in hostData.mPtrTopKPacked
             for (int ie = 0; ie < param.topK; ++ie)
             {
-                if (param.getExpWeights)
+                if (param.useTopKAsInput)
                 {
-                    bufferCast<T>(*this->mPtrExpertWeightsHost)[it * param.topK + ie]
+                    bufferCast<int32_t>(*this->mPtrTopKIdsHost)[it * param.topK + ie]
+                        = static_cast<int32_t>(finalTopkExperts[ie].idx);
+                    bufferCast<T>(*this->mPtrTopKWeightsHost)[it * param.topK + ie]
                         = static_cast<T>(finalTopkExperts[ie].score);
                 }
+                else if (param.getExpWeights)
+                {
+                    bufferCast<T>(*this->mPtrTopKWeightsHost)[it * param.topK + ie]
+                        = static_cast<T>(finalTopkExperts[ie].score);
+                }
+
                 PackedType si{static_cast<T>(finalTopkExperts[ie].score), finalTopkExperts[ie].idx};
-                reinterpret_cast<PackedType*>(bufferCast<int8_t>(*this->mPtrExpertIdxHost))[it * param.topK + ie] = si;
+                reinterpret_cast<PackedType*>(bufferCast<int8_t>(*this->mPtrTopKPackedHost))[it * param.topK + ie] = si;
             }
         }
     }
@@ -163,13 +180,24 @@ private:
     {
         RoutingKernelTest<T>::setCommonParams(param, routingData);
         routingData.mDtypeExpW = btg::Dtype::Bfloat16;
-        routingData.mPtrScores = bufferCast<float>(*this->mPtrScoresDevice);
+
         routingData.mPtrRoutingBias = bufferCast<T>(*this->mPtrRoutingBiasDevice);
 
         routingData.mNumExpertGroups = param.nGroup;
         routingData.mNumLimitedGroups = param.topkGroup;
         routingData.mRouteScale = param.routedScalingFactor;
         routingData.mUseRoutingSoftmax = false;
+
+        if (param.useTopKAsInput)
+        {
+            routingData.mPtrTopKIds = bufferCast<int32_t>(*this->mPtrTopKIdsDevice);
+            routingData.mPtrScores = nullptr;
+        }
+        else
+        {
+            routingData.mPtrTopKIds = nullptr;
+            routingData.mPtrScores = bufferCast<float>(*this->mPtrScoresDevice);
+        }
     }
 
     void callTestedFunction(
@@ -189,7 +217,18 @@ TYPED_TEST(RoutingDeepSeekKernelTest, ClusterLevelParallelization)
         /*numExperts=*/128, /*topK=*/8,
         /*expertParallelization=*/1, /*expertParallelizationId=*/0,
         /*paddingLog2=*/3, /*localExpertsStrideLog2=*/0,
-        /*usePdl=*/true, /*getExpWeights=*/true,
+        /*usePdl=*/true, /*getExpWeights=*/true, /*useTopKAsInput=*/false,
+        /*nGroup*/ 8, /*topkGroup*/ 4, /*routedScalingFactor*/ 1.0f, /*requiredComputeCapability*/ 9);
+    this->runTest(param);
+};
+
+TYPED_TEST(RoutingDeepSeekKernelTest, ClusterLevelParallelizationWithTopKAsInput)
+{
+    RoutingKernelTestParam param(RoutingMethodType::DeepSeekV3, /*numTokens=*/1024, // 10
+        /*numExperts=*/128, /*topK=*/8,
+        /*expertParallelization=*/1, /*expertParallelizationId=*/0,
+        /*paddingLog2=*/3, /*localExpertsStrideLog2=*/0,
+        /*usePdl=*/true, /*getExpWeights=*/true, /*useTopKAsInput=*/true,
         /*nGroup*/ 8, /*topkGroup*/ 4, /*routedScalingFactor*/ 1.0f, /*requiredComputeCapability*/ 9);
     this->runTest(param);
 };
@@ -200,7 +239,7 @@ TYPED_TEST(RoutingDeepSeekKernelTest, ClusterLevelParallelizationWithExpertParal
         /*numExperts=*/128, /*topK=*/8,
         /*expertParallelization=*/2, /*expertParallelizationId=*/1,
         /*paddingLog2=*/3, /*localExpertsStrideLog2=*/0,
-        /*usePdl=*/true, /*getExpWeights=*/true,
+        /*usePdl=*/true, /*getExpWeights=*/true, /*useTopKAsInput=*/false,
         /*nGroup*/ 8, /*topkGroup*/ 4, /*routedScalingFactor*/ 1.0f, /*requiredComputeCapability*/ 9);
     this->runTest(param);
 };
@@ -211,7 +250,7 @@ TYPED_TEST(RoutingDeepSeekKernelTest, CooperativeLevelParallelization)
         /*numExperts=*/128, /*topK=*/8,
         /*expertParallelization=*/1, /*expertParallelizationId=*/0,
         /*paddingLog2=*/3, /*localExpertsStrideLog2=*/0,
-        /*usePdl=*/true, /*getExpWeights=*/true,
+        /*usePdl=*/true, /*getExpWeights=*/true, /*useTopKAsInput=*/false,
         /*nGroup*/ 8, /*topkGroup*/ 4, /*routedScalingFactor*/ 1.0f, /*requiredComputeCapability*/ 10);
     this->runTest(param);
 };
@@ -222,7 +261,7 @@ TYPED_TEST(RoutingDeepSeekKernelTest, CooperativeLevelParallelization)
 //         /*numExperts=*/128, /*topK=*/8,
 //         /*expertParallelization=*/1, /*expertParallelizationId=*/0,
 //         /*paddingLog2=*/3, /*localExpertsStrideLog2=*/0,
-//         /*usePdl=*/true, /*getExpWeights=*/true,
+//         /*usePdl=*/true, /*getExpWeights=*/true, /*useTopKAsInput=*/false,
 //         /*nGroup*/ 8, /*topkGroup*/ 4, /*routedScalingFactor*/ 1.0f, /*requiredComputeCapability*/ 10);
 //     this->runTest(param);
 // };
@@ -233,7 +272,7 @@ TYPED_TEST(RoutingDeepSeekKernelTest, ClusterLevelParallelizationTop2)
         /*numExperts=*/128, /*topK=*/2,
         /*expertParallelization=*/1, /*expertParallelizationId=*/0,
         /*paddingLog2=*/3, /*localExpertsStrideLog2=*/0,
-        /*usePdl=*/true, /*getExpWeights=*/true,
+        /*usePdl=*/true, /*getExpWeights=*/true, /*useTopKAsInput=*/false,
         /*nGroup*/ 8, /*topkGroup*/ 4, /*routedScalingFactor*/ 1.0f, /*requiredComputeCapability*/ 9);
     this->runTest(param);
 };
@@ -244,7 +283,7 @@ TYPED_TEST(RoutingDeepSeekKernelTest, ClusterLevelParallelizationWithExpertParal
         /*numExperts=*/128, /*topK=*/2,
         /*expertParallelization=*/2, /*expertParallelizationId=*/1,
         /*paddingLog2=*/3, /*localExpertsStrideLog2=*/0,
-        /*usePdl=*/true, /*getExpWeights=*/true,
+        /*usePdl=*/true, /*getExpWeights=*/true, /*useTopKAsInput=*/false,
         /*nGroup*/ 8, /*topkGroup*/ 4, /*routedScalingFactor*/ 1.0f, /*requiredComputeCapability*/ 9);
     this->runTest(param);
 };
@@ -255,7 +294,7 @@ TYPED_TEST(RoutingDeepSeekKernelTest, CooperativeLevelParallelizationTop2)
         /*numExperts=*/128, /*topK=*/2,
         /*expertParallelization=*/1, /*expertParallelizationId=*/0,
         /*paddingLog2=*/3, /*localExpertsStrideLog2=*/0,
-        /*usePdl=*/true, /*getExpWeights=*/true,
+        /*usePdl=*/true, /*getExpWeights=*/true, /*useTopKExpertsAsInput=*/false,
         /*nGroup*/ 8, /*topkGroup*/ 4, /*routedScalingFactor*/ 1.0f, /*requiredComputeCapability*/ 10);
     this->runTest(param);
 };

--- a/cpp/tests/unit_tests/kernels/routing/routingTest.cpp
+++ b/cpp/tests/unit_tests/kernels/routing/routingTest.cpp
@@ -46,6 +46,7 @@ void RoutingKernelTest<T>::allocateBuffers(RoutingKernelTestParam const& param)
     auto const usePdl = param.usePdl;
     auto const doSoftmaxBeforeTopK = param.doSoftmaxBeforeTopK;
     auto const normTopkProb = param.normTopkProb;
+    auto const useTopKAsInput = param.useTopKAsInput;
 
     int64_t countsSize = 2 * numExperts;
     if (param.routingMethod == RoutingMethodType::DeepSeekV3)
@@ -72,8 +73,20 @@ void RoutingKernelTest<T>::allocateBuffers(RoutingKernelTestParam const& param)
         = mBufferManager->gpu(ITensor::makeShape({permIdxToTokenIdxSize}), nvinfer1::DataType::kINT32);
 
     int64_t expWeightsSize = numTokens * topK;
-    mPtrExpertWeightsHost = mBufferManager->pinned(ITensor::makeShape({expWeightsSize}), TRTDataType<T>::value);
-    mPtrExpertWeightsDevice = mBufferManager->gpu(ITensor::makeShape({expWeightsSize}), TRTDataType<T>::value);
+    mPtrTopKWeightsHost = mBufferManager->pinned(ITensor::makeShape({expWeightsSize}), TRTDataType<T>::value);
+    mPtrTopKWeightsDevice = mBufferManager->gpu(ITensor::makeShape({expWeightsSize}), TRTDataType<T>::value);
+
+    if (useTopKAsInput)
+    {
+        int64_t topKIdsSize = numTokens * topK;
+        mPtrTopKIdsHost = mBufferManager->pinned(ITensor::makeShape({topKIdsSize}), nvinfer1::DataType::kINT32);
+        mPtrTopKIdsDevice = mBufferManager->gpu(ITensor::makeShape({topKIdsSize}), nvinfer1::DataType::kINT32);
+    }
+    else
+    {
+        mPtrTopKIdsHost = nullptr;
+        mPtrTopKIdsDevice = nullptr;
+    }
 
     int64_t ctaIdxSize = numTokens * topK;
     mPtrCtaIdxXyToBatchIdxHost = mBufferManager->pinned(ITensor::makeShape({ctaIdxSize}), nvinfer1::DataType::kINT32);
@@ -89,8 +102,8 @@ void RoutingKernelTest<T>::allocateBuffers(RoutingKernelTestParam const& param)
         = mBufferManager->gpu(ITensor::makeShape({numNonExitingCtasSize}), nvinfer1::DataType::kINT32);
 
     int64_t idxSize = numTokens * topK * sizeof(PackedType);
-    mPtrExpertIdxHost = mBufferManager->pinned(ITensor::makeShape({idxSize}), nvinfer1::DataType::kINT8);
-    mPtrExpertIdxDevice = mBufferManager->gpu(ITensor::makeShape({idxSize}), nvinfer1::DataType::kINT8);
+    mPtrTopKPackedHost = mBufferManager->pinned(ITensor::makeShape({idxSize}), nvinfer1::DataType::kINT8);
+    mPtrTopKPackedDevice = mBufferManager->gpu(ITensor::makeShape({idxSize}), nvinfer1::DataType::kINT8);
     mCurandStatesDevice
         = mBufferManager->gpu(ITensor::makeShape({numTokens, sizeof(curandState_t)}), nvinfer1::DataType::kINT8);
 }
@@ -109,7 +122,7 @@ void RoutingKernelTest<T>::computePermutation(RoutingKernelTestParam const& para
 {
 
     int32_t* expertCountsHostPtr = bufferCast<int32_t>(*this->mPtrExpertCountsHost);
-    PackedType* expIdxHostPtr = reinterpret_cast<PackedType*>(bufferCast<int8_t>(*this->mPtrExpertIdxHost));
+    PackedType* expIdxHostPtr = reinterpret_cast<PackedType*>(bufferCast<int8_t>(*this->mPtrTopKPackedHost));
 
     auto tokenToExpertHost
         = mBufferManager->pinned(ITensor::makeShape({param.numTokens * param.topK}), nvinfer1::DataType::kINT32);
@@ -247,7 +260,7 @@ void RoutingKernelTest<T>::verifyExpertRoutingIndices(RoutingKernelTestParam con
     mStream->synchronize();
 
     int32_t* expIdxToPermHostptr = bufferCast<int32_t>(*mPtrExpandedIdxToPermutedIdxHost);
-    PackedType* expIdxHostPtr = reinterpret_cast<PackedType*>(bufferCast<int8_t>(*mPtrExpertIdxHost));
+    PackedType* expIdxHostPtr = reinterpret_cast<PackedType*>(bufferCast<int8_t>(*mPtrTopKPackedHost));
 
     for (int ie = 0; ie < param.numExperts; ++ie)
     {
@@ -283,7 +296,7 @@ void RoutingKernelTest<T>::verifyExpertRoutingIndices(RoutingKernelTestParam con
 template <typename T>
 void RoutingKernelTest<T>::verifyResult(RoutingKernelTestParam const& param)
 {
-    auto const expertWeightsHost = mBufferManager->copyFrom(*mPtrExpertWeightsDevice, MemoryType::kCPU);
+    auto const expertWeightsHost = mBufferManager->copyFrom(*mPtrTopKWeightsDevice, MemoryType::kCPU);
     auto const expertCountsHost = mBufferManager->copyFrom(*mPtrExpertCountsDevice, MemoryType::kCPU);
     auto const permutedIdxSizeHost = mBufferManager->copyFrom(*mPtrPermutedIdxSizeDevice, MemoryType::kCPU);
     auto const numNonExitingCtasHost = mBufferManager->copyFrom(*mPtrNumNonExitingCtasDevice, MemoryType::kCPU);
@@ -301,7 +314,7 @@ void RoutingKernelTest<T>::verifyResult(RoutingKernelTestParam const& param)
 
     if (param.getExpWeights)
     {
-        EXPECT_EQ(isClose(bufferCast<T>(*mPtrExpertWeightsHost), expertWeightsPtr, param.numTokens * param.topK,
+        EXPECT_EQ(isClose(bufferCast<T>(*mPtrTopKWeightsHost), expertWeightsPtr, param.numTokens * param.topK,
                       "expert weights"),
             true);
     }
@@ -344,6 +357,15 @@ void RoutingKernelTest<T>::runTest(RoutingKernelTestParam const& param)
     // Setup buffers
     setupBuffers(param);
 
+    // Call host function
+    callHostFunction(param);
+    if (param.useTopKAsInput)
+    {
+        // Set the topk_ids as input
+        mBufferManager->copy(*mPtrTopKIdsHost, *mPtrTopKIdsDevice);
+        mBufferManager->copy(*mPtrTopKWeightsHost, *mPtrTopKWeightsDevice);
+        mStream->synchronize();
+    }
     // Retrieve the workspace size of the routing kernel.
     auto const workspaceSize = getDeviceWorkspaceSize(param);
     TensorPtr workspaceDevice
@@ -351,10 +373,6 @@ void RoutingKernelTest<T>::runTest(RoutingKernelTestParam const& param)
 
     // Call tested function routing
     callTestedFunction(param, workspaceDevice);
-
-    // Call host function
-    callHostFunction(param);
-
     // Verify results
     verifyResult(param);
 }

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -488,17 +488,19 @@ def _register_fake():
         ]
 
     @torch.library.register_fake("trtllm::renorm_moe_routing_op")
-    def _(router_logits, topk):
+    def _(router_logits, topk, output_dtype: torch.dtype = None):
         num_tokens = router_logits.shape[0]
         sz = (num_tokens, topk)
+        output_dtype = output_dtype or torch.float32
         return router_logits.new_empty(
             sz, dtype=torch.int32), router_logits.new_empty(sz,
-                                                            dtype=torch.float32)
+                                                            dtype=output_dtype)
 
     @torch.library.register_fake("trtllm::default_moe_routing_op")
-    def _(router_logits, topk):
+    def _(router_logits, topk, output_dtype: torch.dtype = None):
         num_tokens = router_logits.shape[0]
         sz = (num_tokens, topk)
+        output_dtype = output_dtype or torch.float32
         return router_logits.new_empty(
             sz, dtype=torch.int32), router_logits.new_empty(sz,
-                                                            dtype=torch.float32)
+                                                            dtype=output_dtype)

--- a/tensorrt_llm/_torch/custom_ops/trtllm_gen_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/trtllm_gen_custom_ops.py
@@ -34,7 +34,7 @@ def calculate_tile_tokens_dim(
 @dataclass(frozen=True)
 class FP4BlockScaleMoEInputs:
 
-    routing_logits: torch.Tensor
+    routing_logits: Optional[torch.Tensor]
     routing_bias: Optional[torch.Tensor]
     hidden_states: torch.Tensor
     hidden_states_scale: torch.Tensor
@@ -45,6 +45,8 @@ class FP4BlockScaleMoEInputs:
     output1_scale_scalar: torch.Tensor
     output1_scale_gate_scalar: torch.Tensor
     output2_scale_scalar: torch.Tensor
+    topk_weights: Optional[torch.Tensor] = None
+    topk_ids: Optional[torch.Tensor] = None
 
 
 class FP4BlockScaleMoERunner(TunableRunner):
@@ -114,8 +116,9 @@ class FP4BlockScaleMoERunner(TunableRunner):
         tactic: int = -1,
     ) -> torch.Tensor:
 
-        kernel_runner = self.get_runner(inputs[0].shape[0])
         args = FP4BlockScaleMoEInputs(*inputs)
+
+        kernel_runner = self.get_runner(args.hidden_states.shape[0])
 
         return kernel_runner.run_moe(
             args.routing_logits, args.routing_bias, args.hidden_states,
@@ -126,7 +129,8 @@ class FP4BlockScaleMoERunner(TunableRunner):
             self.num_experts, self.top_k, self.n_group, self.topk_group,
             self.intermediate_size, self.local_expert_offset,
             self.local_num_experts, self.routed_scaling_factor,
-            self.routing_method_type, self.do_finalize, tactic)
+            self.routing_method_type, self.do_finalize, tactic,
+            args.topk_weights, args.topk_ids)
 
     def get_valid_tactics(self, inputs: List[torch.Tensor],
                           profile: OptimizationProfile, **kwargs) -> List[int]:
@@ -227,28 +231,29 @@ class FP4BlockScaleMoERunner(TunableRunner):
 
 @torch.library.custom_op("trtllm::fp4_block_scale_moe_runner", mutates_args=())
 def fp4_block_scale_moe_runner(
-    routing_logits: torch.Tensor,
-    routing_bias: Optional[torch.Tensor],
-    hidden_states: torch.Tensor,
-    hidden_states_scale: torch.Tensor,
-    gemm1_weights: torch.Tensor,
-    gemm1_weights_scale: torch.Tensor,
-    gemm2_weights: torch.Tensor,
-    gemm2_weights_scale: torch.Tensor,
-    output1_scale_scalar: torch.Tensor,
-    output1_scale_gate_scalar: torch.Tensor,
-    output2_scale_scalar: torch.Tensor,
-    num_experts: int,
-    top_k: int,
-    n_group: Optional[int],
-    topk_group: Optional[int],
-    intermediate_size: int,
-    local_expert_offset: int,
-    local_num_experts: int,
-    routed_scaling_factor: Optional[float],
-    routing_method_type: int,
-    do_finalize: bool,
-) -> List[torch.Tensor]:
+        routing_logits: Optional[torch.Tensor],
+        routing_bias: Optional[torch.Tensor],
+        hidden_states: torch.Tensor,
+        hidden_states_scale: torch.Tensor,
+        gemm1_weights: torch.Tensor,
+        gemm1_weights_scale: torch.Tensor,
+        gemm2_weights: torch.Tensor,
+        gemm2_weights_scale: torch.Tensor,
+        output1_scale_scalar: torch.Tensor,
+        output1_scale_gate_scalar: torch.Tensor,
+        output2_scale_scalar: torch.Tensor,
+        num_experts: int,
+        top_k: int,
+        n_group: Optional[int],
+        topk_group: Optional[int],
+        intermediate_size: int,
+        local_expert_offset: int,
+        local_num_experts: int,
+        routed_scaling_factor: Optional[float],
+        routing_method_type: int,
+        do_finalize: bool,
+        topk_weights: Optional[torch.Tensor] = None,
+        topk_ids: Optional[torch.Tensor] = None) -> List[torch.Tensor]:
 
     tuner = AutoTuner.get()
 
@@ -265,8 +270,17 @@ def fp4_block_scale_moe_runner(
         do_finalize,
     )
 
-    inputs = [
-        routing_logits,
+    # Use dummy routing logits for autotuner
+    if routing_logits is None:
+        routing_logits_for_tuner = torch.randn(hidden_states.shape[0],
+                                               num_experts,
+                                               dtype=torch.bfloat16,
+                                               device=hidden_states.device)
+    else:
+        routing_logits_for_tuner = routing_logits
+
+    input_tensors_for_tuner = [
+        routing_logits_for_tuner,
         routing_bias,
         hidden_states,
         hidden_states_scale,
@@ -283,10 +297,13 @@ def fp4_block_scale_moe_runner(
         "trtllm::fp4_block_scale_moe_runner",
         [kernel_runner],
         kernel_runner.tuning_config,
-        inputs,
+        input_tensors_for_tuner,
     )
 
-    return kernel_runner(inputs, tactic=best_tactic)
+    input_tensors = input_tensors_for_tuner + [topk_weights, topk_ids]
+    input_tensors[
+        0] = routing_logits  # replace dummy routing logits with actual routing logits
+    return kernel_runner(input_tensors, tactic=best_tactic)
 
 
 def fp4_block_scale_fake_output_without_finalize(
@@ -315,29 +332,29 @@ def fp4_block_scale_fake_output_without_finalize(
 
 
 @fp4_block_scale_moe_runner.register_fake
-def _(
-    routing_logits,
-    routing_bias,
-    hidden_states,
-    hidden_states_scale,
-    gemm1_weights,
-    gemm1_weights_scale,
-    gemm2_weights,
-    gemm2_weights_scale,
-    output1_scale_scalar,
-    output1_scale_gate_scalar,
-    output2_scale_scalar,
-    num_experts,
-    top_k,
-    n_group,
-    topk_group,
-    intermediate_size,
-    local_expert_offset,
-    local_num_experts,
-    routed_scaling_factor,
-    routing_method_type,
-    do_finalize,
-) -> List[torch.Tensor]:
+def _(routing_logits,
+      routing_bias,
+      hidden_states,
+      hidden_states_scale,
+      gemm1_weights,
+      gemm1_weights_scale,
+      gemm2_weights,
+      gemm2_weights_scale,
+      output1_scale_scalar,
+      output1_scale_gate_scalar,
+      output2_scale_scalar,
+      num_experts,
+      top_k,
+      n_group,
+      topk_group,
+      intermediate_size,
+      local_expert_offset,
+      local_num_experts,
+      routed_scaling_factor,
+      routing_method_type,
+      do_finalize,
+      topk_weights: Optional[torch.Tensor] = None,
+      topk_ids: Optional[torch.Tensor] = None) -> List[torch.Tensor]:
     if do_finalize:
         num_tokens = hidden_states.shape[0]
         hidden_size = hidden_states.shape[1] * 2
@@ -357,7 +374,7 @@ def _(
 @dataclass(frozen=True)
 class FP8BlockScaleMoEInputs:
 
-    routing_logits: torch.Tensor
+    routing_logits: Optional[torch.Tensor]
     routing_bias: torch.Tensor
     hidden_states: torch.Tensor
     hidden_states_scale: torch.Tensor
@@ -365,6 +382,8 @@ class FP8BlockScaleMoEInputs:
     gemm1_weights_scale: torch.Tensor
     gemm2_weights: torch.Tensor
     gemm2_weights_scale: torch.Tensor
+    topk_weights: Optional[torch.Tensor] = None
+    topk_ids: Optional[torch.Tensor] = None
 
 
 class FP8BlockScaleMoERunner(TunableRunner):
@@ -442,7 +461,7 @@ class FP8BlockScaleMoERunner(TunableRunner):
 
         args = FP8BlockScaleMoEInputs(*inputs)
 
-        kernel_runner = self.get_runner(inputs[0].shape[0])
+        kernel_runner = self.get_runner(args.hidden_states.shape[0])
 
         return kernel_runner.run_moe(
             args.routing_logits, args.routing_bias, args.hidden_states,
@@ -451,7 +470,8 @@ class FP8BlockScaleMoERunner(TunableRunner):
             args.gemm2_weights_scale, self.num_experts, self.top_k,
             self.n_group, self.topk_group, self.intermediate_size,
             self.local_expert_offset, self.local_num_experts,
-            self.routed_scaling_factor, self.routing_method_type, tactic)
+            self.routed_scaling_factor, self.routing_method_type, tactic,
+            args.topk_weights, args.topk_ids)
 
     def get_valid_tactics(self, inputs: List[torch.Tensor],
                           profile: OptimizationProfile, **kwargs) -> List[int]:
@@ -532,24 +552,25 @@ class FP8BlockScaleMoERunner(TunableRunner):
 
 @torch.library.custom_op("trtllm::fp8_block_scale_moe_runner", mutates_args=())
 def fp8_block_scale_moe_runner(
-    routing_logits: torch.Tensor,
-    routing_bias: torch.Tensor,
-    hidden_states: torch.Tensor,
-    hidden_states_scale: torch.Tensor,
-    gemm1_weights: torch.Tensor,
-    gemm1_weights_scale: torch.Tensor,
-    gemm2_weights: torch.Tensor,
-    gemm2_weights_scale: torch.Tensor,
-    num_experts: int,
-    top_k: int,
-    n_group: int,
-    topk_group: int,
-    intermediate_size: int,
-    local_expert_offset: int,
-    local_num_experts: int,
-    routed_scaling_factor: float,
-    routing_method_type: int,
-) -> torch.Tensor:
+        routing_logits: Optional[torch.Tensor],
+        routing_bias: torch.Tensor,
+        hidden_states: torch.Tensor,
+        hidden_states_scale: torch.Tensor,
+        gemm1_weights: torch.Tensor,
+        gemm1_weights_scale: torch.Tensor,
+        gemm2_weights: torch.Tensor,
+        gemm2_weights_scale: torch.Tensor,
+        num_experts: int,
+        top_k: int,
+        n_group: int,
+        topk_group: int,
+        intermediate_size: int,
+        local_expert_offset: int,
+        local_num_experts: int,
+        routed_scaling_factor: float,
+        routing_method_type: int,
+        topk_weights: Optional[torch.Tensor] = None,
+        topk_ids: Optional[torch.Tensor] = None) -> torch.Tensor:
 
     tuner = AutoTuner.get()
 
@@ -565,8 +586,17 @@ def fp8_block_scale_moe_runner(
         routing_method_type,
     )
 
-    inputs = [
-        routing_logits,
+    # Use dummy routing logits for autotuner
+    if routing_logits is None:
+        routing_logits_for_tuner = torch.randn(hidden_states.shape[0],
+                                               num_experts,
+                                               dtype=torch.bfloat16,
+                                               device=hidden_states.device)
+    else:
+        routing_logits_for_tuner = routing_logits
+
+    input_tensors_for_tuner = [
+        routing_logits_for_tuner,
         routing_bias,
         hidden_states,
         hidden_states_scale,
@@ -580,32 +610,35 @@ def fp8_block_scale_moe_runner(
         "trtllm::fp8_block_scale_moe_runner",
         [kernel_runner],
         kernel_runner.tuning_config,
-        inputs,
+        input_tensors_for_tuner,
     )
 
-    return kernel_runner(inputs, tactic=best_tactic)
+    input_tensors = input_tensors_for_tuner + [topk_weights, topk_ids]
+    input_tensors[
+        0] = routing_logits  # replace dummy routing logits with actual routing logits
+    return kernel_runner(input_tensors, tactic=best_tactic)
 
 
 @fp8_block_scale_moe_runner.register_fake
-def _(
-    routing_logits: torch.Tensor,
-    routing_bias: torch.Tensor,
-    hidden_states: torch.Tensor,
-    hidden_states_scale: torch.Tensor,
-    gemm1_weights: torch.Tensor,
-    gemm1_weights_scale: torch.Tensor,
-    gemm2_weights: torch.Tensor,
-    gemm2_weights_scale: torch.Tensor,
-    num_experts: int,
-    top_k: int,
-    n_group: int,
-    topk_group: int,
-    intermediate_size: int,
-    local_expert_offset: int,
-    local_num_experts: int,
-    routed_scaling_factor: float,
-    routing_method_type: int,
-) -> torch.Tensor:
+def _(routing_logits: torch.Tensor,
+      routing_bias: torch.Tensor,
+      hidden_states: torch.Tensor,
+      hidden_states_scale: torch.Tensor,
+      gemm1_weights: torch.Tensor,
+      gemm1_weights_scale: torch.Tensor,
+      gemm2_weights: torch.Tensor,
+      gemm2_weights_scale: torch.Tensor,
+      num_experts: int,
+      top_k: int,
+      n_group: int,
+      topk_group: int,
+      intermediate_size: int,
+      local_expert_offset: int,
+      local_num_experts: int,
+      routed_scaling_factor: float,
+      routing_method_type: int,
+      topk_weights: Optional[torch.Tensor] = None,
+      topk_ids: Optional[torch.Tensor] = None) -> torch.Tensor:
     num_tokens = hidden_states.shape[0]
     hidden_size = hidden_states.shape[1] * 2
 
@@ -615,7 +648,7 @@ def _(
 
 @dataclass(frozen=True)
 class MxE4m3MxE2m1BlockScaleMoEInputs:
-    routing_logits: torch.Tensor
+    routing_logits: Optional[torch.Tensor]
     routing_bias: Optional[torch.Tensor]
     hidden_states: torch.Tensor
     hidden_states_scale: torch.Tensor
@@ -628,6 +661,8 @@ class MxE4m3MxE2m1BlockScaleMoEInputs:
     gemm2_weights: torch.Tensor
     gemm2_weights_scale: torch.Tensor
     gemm2_bias: Optional[torch.Tensor]
+    topk_weights: Optional[torch.Tensor] = None
+    topk_ids: Optional[torch.Tensor] = None
 
 
 class MxE4m3MxE2m1BlockScaleMoERunner(TunableRunner):
@@ -708,8 +743,7 @@ class MxE4m3MxE2m1BlockScaleMoERunner(TunableRunner):
 
         args = MxE4m3MxE2m1BlockScaleMoEInputs(*inputs)
 
-        kernel_runner = self.get_runner(inputs[0].shape[0])
-
+        kernel_runner = self.get_runner(args.hidden_states.shape[0])
         return kernel_runner.run_moe(
             args.routing_logits, args.routing_bias, args.hidden_states,
             args.hidden_states_scale, args.gemm1_weights,
@@ -719,7 +753,8 @@ class MxE4m3MxE2m1BlockScaleMoERunner(TunableRunner):
             self.num_experts, self.top_k, self.n_group, self.topk_group,
             self.intermediate_size, self.hidden_size_output,
             self.local_expert_offset, self.local_num_experts,
-            self.routed_scaling_factor, self.routing_method_type, tactic)
+            self.routed_scaling_factor, self.routing_method_type, tactic,
+            args.topk_weights, args.topk_ids)
 
     def get_valid_tactics(self, inputs: List[torch.Tensor],
                           profile: OptimizationProfile, **kwargs) -> List[int]:
@@ -810,19 +845,33 @@ class MxE4m3MxE2m1BlockScaleMoERunner(TunableRunner):
 @torch.library.custom_op("trtllm::mxe4m3_mxe2m1_block_scale_moe_runner",
                          mutates_args=())
 def mxe4m3_mxe2m1_block_scale_moe_runner(
-        routing_logits: torch.Tensor, routing_bias: Optional[torch.Tensor],
-        hidden_states: torch.Tensor, hidden_states_scale: torch.Tensor,
-        gemm1_weights: torch.Tensor, gemm1_weights_scale: torch.Tensor,
-        gemm1_bias: Optional[torch.Tensor], gemm1_alpha: Optional[torch.Tensor],
+        routing_logits: Optional[torch.Tensor],
+        routing_bias: Optional[torch.Tensor],
+        hidden_states: torch.Tensor,
+        hidden_states_scale: torch.Tensor,
+        gemm1_weights: torch.Tensor,
+        gemm1_weights_scale: torch.Tensor,
+        gemm1_bias: Optional[torch.Tensor],
+        gemm1_alpha: Optional[torch.Tensor],
         gemm1_beta: Optional[torch.Tensor],
-        gemm1_clamp_limit: Optional[torch.Tensor], gemm2_weights: torch.Tensor,
-        gemm2_weights_scale: torch.Tensor, gemm2_bias: Optional[torch.Tensor],
-        num_experts: int, top_k: int, n_group: Optional[int],
-        topk_group: Optional[int], intermediate_size: int,
-        hidden_size_output: int, local_expert_offset: int,
-        local_num_experts: int, routed_scaling_factor: Optional[float],
-        routing_method_type: int, act_type: int,
-        imbalance_factor: float) -> torch.Tensor:
+        gemm1_clamp_limit: Optional[torch.Tensor],
+        gemm2_weights: torch.Tensor,
+        gemm2_weights_scale: torch.Tensor,
+        gemm2_bias: Optional[torch.Tensor],
+        num_experts: int,
+        top_k: int,
+        n_group: Optional[int],
+        topk_group: Optional[int],
+        intermediate_size: int,
+        hidden_size_output: int,
+        local_expert_offset: int,
+        local_num_experts: int,
+        routed_scaling_factor: Optional[float],
+        routing_method_type: int,
+        act_type: int,
+        imbalance_factor: float,
+        topk_weights: Optional[torch.Tensor] = None,
+        topk_ids: Optional[torch.Tensor] = None) -> torch.Tensor:
 
     tuner = AutoTuner.get()
 
@@ -831,8 +880,17 @@ def mxe4m3_mxe2m1_block_scale_moe_runner(
         hidden_size_output, local_expert_offset, local_num_experts,
         routed_scaling_factor, routing_method_type, act_type, imbalance_factor)
 
-    input_tensors = [
-        routing_logits,
+    # Use dummy routing logits for autotuner
+    if routing_logits is None:
+        routing_logits_for_tuner = torch.randn(hidden_states.shape[0],
+                                               num_experts,
+                                               dtype=torch.bfloat16,
+                                               device=hidden_states.device)
+    else:
+        routing_logits_for_tuner = routing_logits
+
+    input_tensors_for_tuner = [
+        routing_logits_for_tuner,
         routing_bias,
         hidden_states,
         hidden_states_scale,
@@ -851,15 +909,18 @@ def mxe4m3_mxe2m1_block_scale_moe_runner(
         "trtllm::mxe4m3_mxe2m1_block_scale_moe_runner",
         [kernel_runner],
         kernel_runner.tuning_config,
-        input_tensors,
+        input_tensors_for_tuner,
     )
 
+    input_tensors = input_tensors_for_tuner + [topk_weights, topk_ids]
+    input_tensors[
+        0] = routing_logits  # replace dummy routing logits with actual routing logits
     return kernel_runner(input_tensors, tactic=best_tactic)
 
 
 @dataclass(frozen=True)
 class E4m3MxE2m1BlockScaleMoEInputs:
-    routing_logits: torch.Tensor
+    routing_logits: Optional[torch.Tensor]
     routing_bias: Optional[torch.Tensor]
     hidden_states: torch.Tensor
     gemm1_weights: torch.Tensor
@@ -874,6 +935,8 @@ class E4m3MxE2m1BlockScaleMoEInputs:
     output1_scale_scalar: torch.Tensor
     output1_scale_gate_scalar: torch.Tensor
     output2_scale_scalar: torch.Tensor
+    topk_weights: Optional[torch.Tensor] = None
+    topk_ids: Optional[torch.Tensor] = None
 
 
 class E4m3MxE2m1BlockScaleMoERunner(TunableRunner):
@@ -949,8 +1012,8 @@ class E4m3MxE2m1BlockScaleMoERunner(TunableRunner):
     ) -> torch.Tensor:
 
         args = E4m3MxE2m1BlockScaleMoEInputs(*inputs)
-        kernel_runner = self.get_runner(inputs[0].shape[0])
 
+        kernel_runner = self.get_runner(args.hidden_states.shape[0])
         return kernel_runner.run_moe(
             args.routing_logits, args.routing_bias, args.hidden_states, None,
             args.gemm1_weights, args.gemm1_weights_scale, args.gemm1_bias,
@@ -960,7 +1023,8 @@ class E4m3MxE2m1BlockScaleMoERunner(TunableRunner):
             args.output2_scale_scalar, self.num_experts, self.top_k,
             self.n_group, self.topk_group, self.intermediate_size, None,
             self.local_expert_offset, self.local_num_experts,
-            self.routed_scaling_factor, self.routing_method_type, tactic)
+            self.routed_scaling_factor, self.routing_method_type, tactic,
+            args.topk_weights, args.topk_ids)
 
     def get_valid_tactics(self, inputs: List[torch.Tensor],
                           profile: OptimizationProfile, **kwargs) -> List[int]:
@@ -1031,20 +1095,34 @@ class E4m3MxE2m1BlockScaleMoERunner(TunableRunner):
 @torch.library.custom_op("trtllm::e4m3_mxe2m1_block_scale_moe_runner",
                          mutates_args=())
 def e4m3_mxe2m1_block_scale_moe_runner(
-        routing_logits: torch.Tensor, routing_bias: Optional[torch.Tensor],
-        hidden_states: torch.Tensor, gemm1_weights: torch.Tensor,
-        gemm1_weights_scale: torch.Tensor, gemm1_bias: Optional[torch.Tensor],
-        gemm1_alpha: Optional[torch.Tensor], gemm1_beta: Optional[torch.Tensor],
-        gemm1_clamp_limit: Optional[torch.Tensor], gemm2_weights: torch.Tensor,
-        gemm2_weights_scale: torch.Tensor, gemm2_bias: Optional[torch.Tensor],
+        routing_logits: Optional[torch.Tensor],
+        routing_bias: Optional[torch.Tensor],
+        hidden_states: torch.Tensor,
+        gemm1_weights: torch.Tensor,
+        gemm1_weights_scale: torch.Tensor,
+        gemm1_bias: Optional[torch.Tensor],
+        gemm1_alpha: Optional[torch.Tensor],
+        gemm1_beta: Optional[torch.Tensor],
+        gemm1_clamp_limit: Optional[torch.Tensor],
+        gemm2_weights: torch.Tensor,
+        gemm2_weights_scale: torch.Tensor,
+        gemm2_bias: Optional[torch.Tensor],
         output1_scale_scalar: torch.Tensor,
         output1_scale_gate_scalar: torch.Tensor,
-        output2_scale_scalar: torch.Tensor, num_experts: int, top_k: int,
-        n_group: Optional[int], topk_group: Optional[int],
-        intermediate_size: int, local_expert_offset: int,
-        local_num_experts: int, routed_scaling_factor: Optional[float],
-        routing_method_type: int, act_type: int,
-        imbalance_factor: float) -> torch.Tensor:
+        output2_scale_scalar: torch.Tensor,
+        num_experts: int,
+        top_k: int,
+        n_group: Optional[int],
+        topk_group: Optional[int],
+        intermediate_size: int,
+        local_expert_offset: int,
+        local_num_experts: int,
+        routed_scaling_factor: Optional[float],
+        routing_method_type: int,
+        act_type: int,
+        imbalance_factor: float,
+        topk_weights: Optional[torch.Tensor] = None,
+        topk_ids: Optional[torch.Tensor] = None) -> torch.Tensor:
 
     tuner = AutoTuner.get()
 
@@ -1062,8 +1140,17 @@ def e4m3_mxe2m1_block_scale_moe_runner(
         imbalance_factor,
     )
 
-    input_tensors = [
-        routing_logits,
+    # Use dummy routing logits for autotuner
+    if routing_logits is None:
+        routing_logits_for_tuner = torch.randn(hidden_states.shape[0],
+                                               num_experts,
+                                               dtype=torch.bfloat16,
+                                               device=hidden_states.device)
+    else:
+        routing_logits_for_tuner = routing_logits
+
+    input_tensors_for_tuner = [
+        routing_logits_for_tuner,
         routing_bias,
         hidden_states,
         gemm1_weights,
@@ -1084,15 +1171,19 @@ def e4m3_mxe2m1_block_scale_moe_runner(
         "trtllm::e4m3_mxe2m1_block_scale_moe_runner",
         [kernel_runner],
         kernel_runner.tuning_config,
-        input_tensors,
+        input_tensors_for_tuner,
     )
 
+    # Add topk tensors for final execution
+    input_tensors = input_tensors_for_tuner + [topk_weights, topk_ids]
+    input_tensors[
+        0] = routing_logits  # replace dummy routing logits with actual routing logits
     return kernel_runner(input_tensors, tactic=best_tactic)
 
 
 @dataclass(frozen=True)
 class Bf16MxE2m1BlockScaleMoEInputs:
-    routing_logits: torch.Tensor
+    routing_logits: Optional[torch.Tensor]
     routing_bias: Optional[torch.Tensor]
     hidden_states: torch.Tensor
     gemm1_weights: torch.Tensor
@@ -1104,6 +1195,8 @@ class Bf16MxE2m1BlockScaleMoEInputs:
     gemm2_weights: torch.Tensor
     gemm2_weights_scale: torch.Tensor
     gemm2_bias: Optional[torch.Tensor]
+    topk_weights: Optional[torch.Tensor] = None
+    topk_ids: Optional[torch.Tensor] = None
 
 
 class Bf16MxE2m1BlockScaleMoERunner(TunableRunner):
@@ -1179,8 +1272,8 @@ class Bf16MxE2m1BlockScaleMoERunner(TunableRunner):
     ) -> torch.Tensor:
 
         args = Bf16MxE2m1BlockScaleMoEInputs(*inputs)
-        kernel_runner = self.get_runner(inputs[0].shape[0])
 
+        kernel_runner = self.get_runner(args.hidden_states.shape[0])
         return kernel_runner.run_moe(
             args.routing_logits, args.routing_bias, args.hidden_states,
             args.gemm1_weights, args.gemm1_weights_scale, args.gemm1_bias,
@@ -1189,7 +1282,7 @@ class Bf16MxE2m1BlockScaleMoERunner(TunableRunner):
             self.num_experts, self.top_k, self.n_group, self.topk_group,
             self.intermediate_size, self.local_expert_offset,
             self.local_num_experts, self.routed_scaling_factor,
-            self.routing_method_type, tactic)
+            self.routing_method_type, tactic, args.topk_weights, args.topk_ids)
 
     def get_valid_tactics(self, inputs: List[torch.Tensor],
                           profile: OptimizationProfile, **kwargs) -> List[int]:
@@ -1260,17 +1353,31 @@ class Bf16MxE2m1BlockScaleMoERunner(TunableRunner):
 @torch.library.custom_op("trtllm::bf16_mxe2m1_block_scale_moe_runner",
                          mutates_args=())
 def bf16_mxe2m1_block_scale_moe_runner(
-        routing_logits: torch.Tensor, routing_bias: Optional[torch.Tensor],
-        hidden_states: torch.Tensor, gemm1_weights: torch.Tensor,
-        gemm1_weights_scale: torch.Tensor, gemm1_bias: Optional[torch.Tensor],
-        gemm1_alpha: Optional[torch.Tensor], gemm1_beta: Optional[torch.Tensor],
-        gemm1_clamp_limit: Optional[torch.Tensor], gemm2_weights: torch.Tensor,
-        gemm2_weights_scale: torch.Tensor, gemm2_bias: Optional[torch.Tensor],
-        num_experts: int, top_k: int, n_group: Optional[int],
-        topk_group: Optional[int], intermediate_size: int,
-        local_expert_offset: int, local_num_experts: int,
-        routed_scaling_factor: Optional[float], routing_method_type: int,
-        act_type: int, imbalance_factor: float) -> torch.Tensor:
+        routing_logits: Optional[torch.Tensor],
+        routing_bias: Optional[torch.Tensor],
+        hidden_states: torch.Tensor,
+        gemm1_weights: torch.Tensor,
+        gemm1_weights_scale: torch.Tensor,
+        gemm1_bias: Optional[torch.Tensor],
+        gemm1_alpha: Optional[torch.Tensor],
+        gemm1_beta: Optional[torch.Tensor],
+        gemm1_clamp_limit: Optional[torch.Tensor],
+        gemm2_weights: torch.Tensor,
+        gemm2_weights_scale: torch.Tensor,
+        gemm2_bias: Optional[torch.Tensor],
+        num_experts: int,
+        top_k: int,
+        n_group: Optional[int],
+        topk_group: Optional[int],
+        intermediate_size: int,
+        local_expert_offset: int,
+        local_num_experts: int,
+        routed_scaling_factor: Optional[float],
+        routing_method_type: int,
+        act_type: int,
+        imbalance_factor: float,
+        topk_weights: Optional[torch.Tensor] = None,
+        topk_ids: Optional[torch.Tensor] = None) -> torch.Tensor:
 
     tuner = AutoTuner.get()
 
@@ -1288,8 +1395,17 @@ def bf16_mxe2m1_block_scale_moe_runner(
         imbalance_factor,
     )
 
-    input_tensors = [
-        routing_logits,
+    # Use dummy routing logits for autotuner
+    if routing_logits is None:
+        routing_logits_for_tuner = torch.randn(hidden_states.shape[0],
+                                               num_experts,
+                                               dtype=torch.bfloat16,
+                                               device=hidden_states.device)
+    else:
+        routing_logits_for_tuner = routing_logits
+
+    input_tensors_for_tuner = [
+        routing_logits_for_tuner,
         routing_bias,
         hidden_states,
         gemm1_weights,
@@ -1303,11 +1419,16 @@ def bf16_mxe2m1_block_scale_moe_runner(
         gemm2_bias,
     ]
 
+    # Choose best tactic using autotuner
     _, best_tactic = tuner.choose_one(
         "trtllm::bf16_mxe2m1_block_scale_moe_runner",
         [kernel_runner],
         kernel_runner.tuning_config,
-        input_tensors,
+        input_tensors_for_tuner,
     )
 
+    # Add topk tensors for final execution
+    input_tensors = input_tensors_for_tuner + [topk_weights, topk_ids]
+    input_tensors[
+        0] = routing_logits  # replace dummy routing logits with actual routing logits
     return kernel_runner(input_tensors, tactic=best_tactic)

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -52,14 +52,13 @@ from tensorrt_llm.quantization.utils.fp8_utils import (
 from ..attention_backend import AttentionMetadata
 from ..attention_backend.interface import PositionalEmbeddingParams, RopeParams
 from ..distributed import (AllReduce, AllReduceFusionOp, AllReduceParams,
-                           MoEAllReduce, MoEAllReduceParams, allgather)
+                           MoEAllReduce, MoEAllReduceParams)
 from ..model_config import ModelConfig
 from ..modules.attention import MLA
 from ..modules.decoder_layer import DecoderLayer
 from ..modules.embedding import Embedding
 from ..modules.fused_moe import (DeepSeekV3MoeRoutingMethod,
-                                 MoEWeightLoadingMode, TRTLLMGenFusedMoE,
-                                 create_moe)
+                                 MoEWeightLoadingMode, create_moe)
 from ..modules.gated_mlp import GatedMLP
 from ..modules.linear import Linear, TensorParallelMode, WeightsLoadingConfig
 from ..modules.multi_stream_utils import maybe_execute_in_parallel
@@ -854,13 +853,6 @@ class Deepseekv3MoE(nn.Module):
                               all_rank_num_tokens, do_finalize):
         # max-throughput
         use_dp_padding = False
-        if self.use_dp and self.mapping.tp_size > 1:
-            if isinstance(self.experts, TRTLLMGenFusedMoE):
-                hidden_states = allgather(hidden_states,
-                                          self.mapping,
-                                          dim=0,
-                                          sizes=all_rank_num_tokens)
-
         router_logits = self.gate(hidden_states)
 
         routed_output = self.experts(

--- a/tensorrt_llm/_torch/models/modeling_gpt_oss.py
+++ b/tensorrt_llm/_torch/models/modeling_gpt_oss.py
@@ -23,7 +23,7 @@ from ..modules.embedding import Embedding
 # isort: off
 from ..modules.fused_moe import (MoE, MoEWeightLoadingMode,
                                  RenormalizeMoeRoutingMethod, TritonFusedMoE,
-                                 TRTLLMGenFusedMoE, create_moe)
+                                 create_moe)
 from ..modules.fused_moe.routing import (get_cached_perfect_router_logits,
                                          precompute_common_perfect_router_logits
                                          )
@@ -151,7 +151,10 @@ class MLPBlock(torch.nn.Module):
         )
 
         self.routing_method = RenormalizeMoeRoutingMethod(
-            top_k=pretrained_config.num_experts_per_tok)
+            top_k=pretrained_config.num_experts_per_tok,
+            output_dtype=torch.bfloat16
+            if config.moe_backend.upper() == "TRTLLM" else torch.float32)
+
         self.swiglu_alpha = torch.tensor(
             [1.702] * (self.num_experts // config.mapping.moe_ep_size),
             dtype=torch.float32).cuda()
@@ -260,7 +263,7 @@ class MLPBlock(torch.nn.Module):
         all_rank_num_tokens = attn_metadata.all_rank_num_tokens
 
         if self.mapping.tp_size > 1 and all_rank_num_tokens is not None:
-            if (isinstance(self.experts, (TRTLLMGenFusedMoE, TritonFusedMoE))):
+            if (isinstance(self.experts, (TritonFusedMoE))):
                 t = allgather(t, self.mapping, dim=0, sizes=all_rank_num_tokens)
 
         g = self.gate(t)
@@ -273,7 +276,7 @@ class MLPBlock(torch.nn.Module):
             g = self._create_ideal_expert_load_balanced_logits(
                 num_tokens=num_tokens, num_experts=num_experts, device=x.device)
 
-        # Let CutlassFusedMoE handle allgather internally
+        # Let CutlassFusedMoE and TRTLLMGenFusedMoE handle allgather internally
         # Pass the normalized tensor (t) as input to experts, not x
         expert_output = self.experts(x=t,
                                      router_logits=g,

--- a/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
@@ -10,15 +10,14 @@ from tensorrt_llm._torch.models.checkpoints.base_weight_mapper import \
 
 from ..attention_backend import AttentionMetadata
 from ..distributed import (AllReduce, AllReduceFusionOp, AllReduceParams,
-                           MoEAllReduce, MoEAllReduceParams, allgather)
+                           MoEAllReduce, MoEAllReduceParams)
 from ..model_config import ModelConfig
 from ..modules.decoder_layer import DecoderLayer
 from ..modules.embedding import Embedding
 from ..modules.fused_moe import (BaseMoeRoutingMethod,
                                  RenormalizeMoeRoutingMethod,
                                  RenormalizeNaiveMoeRoutingMethod,
-                                 RoutingMethodType, TRTLLMGenFusedMoE,
-                                 create_moe)
+                                 RoutingMethodType, create_moe)
 from ..modules.linear import TensorParallelMode
 from ..modules.rms_norm import RMSNorm
 from ..speculative import SpecMetadata
@@ -46,6 +45,7 @@ class Qwen3Gate(nn.Module):
                                                dtype=dtype),
                                    requires_grad=False)
         self.routing_method_type = routing_method_type
+        self.moe_backend = moe_backend
         # FIXME: out_dtype=float32 does not work
         # self.out_dtype = torch.float32 if moe_backend == "TRTLLM" else dtype
         self.out_dtype = dtype
@@ -65,9 +65,15 @@ class Qwen3Gate(nn.Module):
     @property
     def routing_method(self) -> BaseMoeRoutingMethod:
         if self.routing_method_type == RoutingMethodType.RenormalizeNaive:
-            return RenormalizeNaiveMoeRoutingMethod(top_k=self.top_k)
+            return RenormalizeNaiveMoeRoutingMethod(
+                top_k=self.top_k,
+                output_dtype=torch.bfloat16
+                if self.moe_backend.upper() == "TRTLLM" else torch.float32)
         elif self.routing_method_type == RoutingMethodType.Renormalize:
-            return RenormalizeMoeRoutingMethod(top_k=self.top_k)
+            return RenormalizeMoeRoutingMethod(
+                top_k=self.top_k,
+                output_dtype=torch.bfloat16
+                if self.moe_backend.upper() == "TRTLLM" else torch.float32)
         else:
             raise ValueError(
                 f"Unsupported routing method: {self.routing_method_type}")
@@ -130,13 +136,6 @@ class Qwen3MoE(nn.Module):
 
         if not do_finalize:
             assert not self.enable_attention_dp
-
-        if self.enable_attention_dp and self.mapping.tp_size > 1:
-            if isinstance(self.experts, TRTLLMGenFusedMoE):
-                hidden_states = allgather(hidden_states,
-                                          self.mapping,
-                                          dim=0,
-                                          sizes=all_rank_num_tokens)
 
         router_logits = self.gate(hidden_states)
         final_hidden_states = self.experts(

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py
@@ -7,8 +7,9 @@ from tensorrt_llm._utils import get_sm_version
 
 from ...custom_ops.trtllm_gen_custom_ops import \
     fp4_block_scale_fake_output_without_finalize
+from ...distributed import allgather
 from ...model_config import ModelConfig
-from ...utils import Fp4QuantizedTensor
+from ...utils import Fp4QuantizedTensor, ceil_div
 from .interface import MoE, MoEWeightLoadingMode
 from .quantization import (DeepSeekFP8BlockScalesFusedMoEMethod,
                            NVFP4TRTLLMGenFusedMoEMethod,
@@ -195,6 +196,66 @@ class TRTLLMGenFusedMoE(MoE):
             topk_group = None
             routed_scaling_factor = None
 
+        # Don't support post-quant allgather for fp8 block scale and has_w4a16_mxfp4 for now.
+        is_post_quant_allgather_supported = self.has_nvfp4 or self.has_w4a8_mxfp4_fp8 or self.has_w4a8_mxfp4_mxfp8
+        run_post_quant_allgather = self.use_dp and self.parallel_size > 1 and is_post_quant_allgather_supported
+
+        x_sf = None
+        token_selected_experts = None
+        token_final_scales = None
+        x_row = x.shape[0]
+        x_col = x.shape[1]
+        if run_post_quant_allgather:
+            # apply routing
+            token_selected_experts, token_final_scales = self.routing_method.apply(
+                router_logits)
+            token_final_scales = token_final_scales.to(torch.bfloat16)
+            assert token_final_scales.dtype == torch.bfloat16
+            assert token_selected_experts.dtype == torch.int32
+            # quantize inputs
+            if self.has_w4a8_mxfp4_fp8:
+                x, _ = torch.ops.tensorrt_llm.static_quantize_e4m3_per_tensor(
+                    x, self.fc31_input_dequant[0])
+                # Update x_row and x_col to the padded shape
+                x_row, x_col = x.shape[0], x.shape[1]
+            elif self.has_nvfp4:
+                if isinstance(x, Fp4QuantizedTensor):
+                    assert not x.is_sf_swizzled, "Fp4QuantizedTensor should not be swizzled before communication"
+                    x_row = x.shape[0]
+                    # note: we use uint8 to store 2 fp4 values
+                    x_col = x.shape[1] * 2
+                    x, x_sf = x.fp4_tensor, x.scaling_factor
+                else:
+                    x_row = x.shape[0]
+                    x_col = x.shape[1]
+                    x, x_sf = torch.ops.trtllm.fp4_quantize(
+                        x, self.fc31_input_scale, self.scaling_vector_size,
+                        False, False)
+            elif self.has_w4a8_mxfp4_mxfp8:
+                x, x_sf = torch.ops.trtllm.mxfp8_quantize(
+                    x, False, alignment=self.quant_method.weight_alignment)
+                # Update x_row and x_col to the padded shape
+                x_row, x_col = x.shape[0], x.shape[1]
+            else:
+                raise ValueError(
+                    f"unsupported quantization mode with run_post_quant_allgather: {self.quant_config.quant_mode}"
+                )
+
+            #allgather for attention DP
+            if x_sf is not None:
+                x_sf = x_sf.view(x_row, ceil_div(x_col,
+                                                 self.scaling_vector_size))
+                assert len(
+                    x_sf.shape
+                ) == 2, "The hidden states scaling factor should be 2D tensor before allgather"
+            x, x_sf, token_selected_experts, token_final_scales = allgather(
+                [x, x_sf, token_selected_experts, token_final_scales],
+                self.mapping,
+                dim=0,
+                sizes=None if use_dp_padding else all_rank_num_tokens)
+            if x_sf is not None:
+                x_sf = x_sf.flatten()
+
         # TODO: since routing kernel is integrated into moe_runner for fp8,
         #       here we just route the I/Os for moe_runner
         if self.has_deepseek_fp8_block_scales:
@@ -224,18 +285,22 @@ class TRTLLMGenFusedMoE(MoE):
         elif self.has_nvfp4:
             scale_factor_use_ue8m0 = False
             is_scale_factor_swizzled = False  # use linear layout here
-            hidden_states_fp4, hidden_states_scale_linear_fp4 = (
-                torch.ops.trtllm.fp4_quantize(
-                    x,
-                    self.fc31_input_scale,
-                    self.scaling_vector_size,
-                    scale_factor_use_ue8m0,
-                    is_scale_factor_swizzled,
-                ))
+
+            if not run_post_quant_allgather:
+                hidden_states_fp4, hidden_states_scale_linear_fp4 = (
+                    torch.ops.trtllm.fp4_quantize(
+                        x,
+                        self.fc31_input_scale,
+                        self.scaling_vector_size,
+                        scale_factor_use_ue8m0,
+                        is_scale_factor_swizzled,
+                    ))
+            else:
+                hidden_states_fp4, hidden_states_scale_linear_fp4 = x, x_sf
 
             outputs = torch.ops.trtllm.fp4_block_scale_moe_runner(
-                router_logits,
-                routing_bias,
+                router_logits if not run_post_quant_allgather else None,
+                routing_bias if not run_post_quant_allgather else None,
                 hidden_states_fp4,
                 hidden_states_scale_linear_fp4.view(torch.float8_e4m3fn),
                 self.w3_w1_weight,
@@ -256,6 +321,8 @@ class TRTLLMGenFusedMoE(MoE):
                 routed_scaling_factor,
                 self.routing_method.routing_method_type,
                 do_finalize=do_finalize,
+                topk_ids=token_selected_experts,
+                topk_weights=token_final_scales,
             )
 
             if not do_finalize:
@@ -295,20 +362,25 @@ class TRTLLMGenFusedMoE(MoE):
                 self.routing_method.routing_method_type,
                 0,  # act_type
                 1.3,  # imbalance_factor
+                token_final_scales,
+                token_selected_experts,
             )
             final_hidden_states = final_hidden_states[:, :self.
                                                       hidden_size].contiguous()
         elif self.has_w4a8_mxfp4_fp8:
             pad_size = self.w3_w1_weight.shape[-1] * 2 - x.shape[-1]
-            x = torch.nn.functional.pad(x, (0, pad_size))
-            x, _ = torch.ops.tensorrt_llm.static_quantize_e4m3_per_tensor(
-                x, self.fc31_input_gate_dequant[0])
+            if not run_post_quant_allgather:
+                x = torch.nn.functional.pad(x, (0, pad_size))
+                x, _ = torch.ops.tensorrt_llm.static_quantize_e4m3_per_tensor(
+                    x, self.fc31_input_gate_dequant[0])
+            else:
+                x = x
             intermediate_size_per_partition_padded = self.w3_w1_weight.shape[
                 -2] // 2
 
             final_hidden_states = torch.ops.trtllm.e4m3_mxe2m1_block_scale_moe_runner(
-                router_logits,
-                routing_bias,
+                router_logits if not run_post_quant_allgather else None,
+                routing_bias if not run_post_quant_allgather else None,
                 x,
                 self.w3_w1_weight,
                 self.w3_w1_weight_scale,
@@ -334,19 +406,25 @@ class TRTLLMGenFusedMoE(MoE):
                 self.routing_method.routing_method_type,
                 0,  # act_type
                 1.3,  # imbalance_factor
+                token_final_scales,
+                token_selected_experts,
             )
             final_hidden_states = final_hidden_states[:, :self.
                                                       hidden_size].contiguous()
         elif self.has_w4a8_mxfp4_mxfp8:
-            # TRTLLM-Gen uses linear SF layout for the mxfp8 input.
-            mxfp8_x, sf = torch.ops.trtllm.mxfp8_quantize(
-                x, False, alignment=self.quant_method.weight_alignment)
+            if not run_post_quant_allgather:
+                # TRTLLM-Gen uses linear SF layout for the mxfp8 input.
+                mxfp8_x, sf = torch.ops.trtllm.mxfp8_quantize(
+                    x, False, alignment=self.quant_method.weight_alignment)
+            else:
+                mxfp8_x, sf = x, x_sf
+
             intermediate_size_per_partition_padded = self.w3_w1_weight.shape[
                 -2] // 2
 
             final_hidden_states = torch.ops.trtllm.mxe4m3_mxe2m1_block_scale_moe_runner(
-                router_logits,
-                routing_bias,
+                router_logits if not run_post_quant_allgather else None,
+                routing_bias if not run_post_quant_allgather else None,
                 mxfp8_x,
                 sf,
                 self.w3_w1_weight,
@@ -371,10 +449,12 @@ class TRTLLMGenFusedMoE(MoE):
                 self.routing_method.routing_method_type,
                 0,  # act_type
                 1.3,  # imbalance_factor
+                token_final_scales,
+                token_selected_experts,
             )
         else:
             raise NotImplementedError(
-                "TRTLLMGenFusedMoE only supports fp8_block_scaling, nvfp4, w4a16_mxfp4 and w4a8_mxfp4_fp8 dtypes."
+                "TRTLLMGenFusedMoE only supports fp8_block_scaling, nvfp4, w4a16_mxfp4, w4a8_mxfp4_mxfp8 and w4a8_mxfp4_fp8 dtypes."
             )
 
         final_hidden_states = self.reducescatter_or_allreduce(


### PR DESCRIPTION
### Add topk_ids and topk_weight as inputs for moe trtllgen backend
Add the two inputs `topk_ids` and `topk_weights` first. 
Then, enable post-quantization allgather for the Moe TrtllmGen backend.

1. Routing kernels
I modified the kernels for DeepSeek and Llama 4 and renormalized routing methods in files `RoutingDeepSeek.cu`, `RoutingRenormalize.cu` and `RoutingLlama4.cu`

- Related C++ unit tests are also added in files like `routingTest.cpp`.
- Besides that, I updated the default value of `maxExpertIdx` in file `RoutingLlama4.cu`, so that it can handle `NaN` correctly.
- Added more detailed type checks like this:
```
        if (static_cast<RoutingMethodType>(routing_method_type) == RoutingMethodType::DeepSeekV3)
        {
            TORCH_CHECK(routing_logits.value().scalar_type() == at::ScalarType::Float, "routing_logits must be float");
        }
        else
        {
            TORCH_CHECK(
                routing_logits.value().scalar_type() == at::ScalarType::BFloat16, "routing_logits must be bfloat16");
        }
```
- Changed the names of several variables to add new inputs (for example, changed `mPtrExpertIdx` to `mPtrTopKPacked`).

Hi @MatthiasKohl and @nekorobov, could you please review this part?

2. Add two parameters (`topk_ids` and `topk_weights`) in all the MoE trtllm-gen Ops. For example:
https://gitlab-master.nvidia.com/ftp/tekit/-/merge_requests/9611/diffs?file=1e58f3c66b27c6a2f10bc87b0a3381f3d846762c#1e58f3c66b27c6a2f10bc87b0a3381f3d846762c_673_731

Related unit tests in file `tests/unittest/_torch/thop/test_moe.py` 


3. @DomBrown  Hi Dom, this is the same PR you helped review before.


4.  Hi Daniel, as we are going to reuse the routing part for the post-quant all-gather of MoE Trtllm Gen backend, I might need BF16 output for Trtllm Gen backend. I added a parameter in the routing method for CUTLASS. Maybe you can take a look?  (For example [routing.py](https://gitlab-master.nvidia.com/ftp/tekit/-/blob/user/christinaz/add_inputs_moe_trtllmgen/tensorrt_llm/_torch/modules/fused_moe/routing.py?ref_type=heads#L222))

5. @rosenrodt  Hi Anthony, I added the post-quant allgather logic. Please help review it [fused_moe_trtllm_gen.py](https://gitlab-master.nvidia.com/ftp/tekit/-/blob/user/christinaz/add_inputs_moe_trtllmgen/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py?ref_type=heads#L210)


## Test Coverage

```
cd cpp/build
make -j$(nproc) google-tests
./tests/unit_tests/kernels/routingKernelsTest

pytest -v -s tests/unittest/_torch/thop/test_moe.py

pytest -s -o log_cli=true "tests/integration/defs/accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_nvfp4_4gpus[moe_backend=TRTLLM-mtp_nextn=2-tp4-fp8kv=True-attention_dp=True-cuda_graph=True-overlap_scheduler=True-torch_compile=False]"
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Top‑K routing inputs (ids + weights) and dual Top‑K output formats; routing no longer requires per‑token logits.

* **Improvements**
  * Kernelized histogram init and unified Top‑K handling across FP4/FP8/BF16 with device-aware allocations and preserved legacy score path.
  * Routing output dtype now configurable (bf16 or fp32); autotuning/custom ops propagate Top‑K data.

* **Tests**
  * Expanded unit tests to exercise Top‑K‑as‑input flows across backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
