### PR TITLE
[https://nvbugs/5444095][infra] waive test_ptp_quickstart_multimodal llava test

### DIFF
--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -286,3 +286,4 @@ accuracy/test_llm_api_pytorch.py::TestQwen3_235B_A22B::test_nvfp4[latency_moe_tr
 accuracy/test_llm_api_pytorch.py::TestGemma3_27BInstruct::test_fp8_prequantized SKIP (https://nvbugs/5445774)
 accuracy/test_disaggregated_serving.py::TestQwen3_8B::test_nixl_backend SKIP (https://nvbugs/5448437)
 disaggregated/test_disaggregated.py::test_disaggregated_benchmark_on_diff_backends[DeepSeek-V3-Lite-fp8] SKIP (https://nvbugs/5448449)
+test_e2e.py::test_ptp_quickstart_multimodal[llava-v1.6-mistral-7b-llava-v1.6-mistral-7b-hf-image-False] SKIP (https://nvbugs/5444095)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test skip configuration to temporarily exclude a specific end-to-end multimodal quickstart scenario affected by a known issue, improving CI reliability, build stability, and reducing false failures during automated runs. This change is limited to test infrastructure and does not alter product functionality or user experience. No other tests were modified, and no user-facing behavior is impacted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->