### PR TITLE
[None][fix] Correct reporting of torch_dtype for ModelConfig class.

### DIFF
--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -144,6 +144,14 @@ class ModelConfig(Generic[TConfig]):
                 self.allreduce_strategy)
 
     @property
+    def torch_dtype(self) -> torch.dtype:
+        """Get the torch dtype of the model."""
+        # TODO: this is an assumption that a HF model is always in bfloat16
+        # We should figure out a better way to handle this if other models
+        # start to not report dtype.
+        return self.pretrained_config.torch_dtype or torch.bfloat16
+
+    @property
     def fuse_pos_embd(self):
         if self.attn_backend == 'TRTLLM':
             return True

--- a/tensorrt_llm/bench/benchmark/throughput.py
+++ b/tensorrt_llm/bench/benchmark/throughput.py
@@ -517,8 +517,9 @@ def throughput_command(
         logger.info("Keyboard interrupt, exiting benchmark...")
         sys.exit(130)
     except Exception as e:
-        logger.error(f"Error during benchmarking: {e}")
-        sys.exit(-1)
+        import traceback
+        logger.error(traceback.format_exc())
+        raise e
     finally:
         if llm is not None:
             llm.shutdown()

--- a/tensorrt_llm/bench/benchmark/throughput.py
+++ b/tensorrt_llm/bench/benchmark/throughput.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sys
 from pathlib import Path
 
 import click
@@ -514,6 +515,10 @@ def throughput_command(
         report_utility.report_statistics()
     except KeyboardInterrupt:
         logger.info("Keyboard interrupt, exiting benchmark...")
+    except Exception:
+        import traceback
+        logger.error(f"Error during benchmarking:\n{traceback.format_exc()}")
+        sys.exit(1)
     finally:
         if llm is not None:
             llm.shutdown()

--- a/tensorrt_llm/bench/benchmark/throughput.py
+++ b/tensorrt_llm/bench/benchmark/throughput.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import sys
 from pathlib import Path
 
 import click
@@ -515,11 +514,6 @@ def throughput_command(
         report_utility.report_statistics()
     except KeyboardInterrupt:
         logger.info("Keyboard interrupt, exiting benchmark...")
-        sys.exit(130)
-    except Exception as e:
-        import traceback
-        logger.error(traceback.format_exc())
-        raise e
     finally:
         if llm is not None:
             llm.shutdown()

--- a/tensorrt_llm/bench/dataclasses/reporting.py
+++ b/tensorrt_llm/bench/dataclasses/reporting.py
@@ -318,7 +318,7 @@ class ReportUtility:
                 "backend":
                 "Pytorch",
                 "dtype":
-                torch_dtype_to_str(model_config.pretrained_config.torch_dtype
+                torch_dtype_to_str(model_config.torch_dtype
                                    or model_config.pretrained_config.
                                    get_text_config().torch_dtype),
                 "kv_cache_dtype":

--- a/tests/integration/defs/test_e2e.py
+++ b/tests/integration/defs/test_e2e.py
@@ -619,7 +619,7 @@ def test_trtllm_bench_invalid_token_pytorch(llm_root, llm_venv, model_name,
                 f"throughput " \
                 f"--dataset {str(dataset_path)} --backend pytorch " \
                 f"--extra_llm_api_options {extra_options_path} " \
-                f"> {output_path}"
+                f"> {output_path} 2>&1"
         # Check clean shutdown (no hang)
         with pytest.raises(subprocess.CalledProcessError) as exc_info:
             check_call(benchmark_cmd, shell=True, env=llm_venv._new_env)

--- a/tests/integration/defs/test_e2e.py
+++ b/tests/integration/defs/test_e2e.py
@@ -629,7 +629,7 @@ def test_trtllm_bench_invalid_token_pytorch(llm_root, llm_venv, model_name,
             stdout = f.read()
 
     # Check that error is reported correctly
-    assert "Error during benchmarking: Requests failed: Token ID out of range (1 requests)" in stdout
+    assert "Requests failed: Token ID out of range (1 requests)" in stdout
 
 
 def trtllm_bench_prolog(


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Model configuration exposes a read-only torch dtype property; defaults to bfloat16 when unspecified.

- Improvements
  - Reporting now prefers the model-configured torch dtype when available, improving accuracy of benchmark statistics.

- Refactor
  - Throughput benchmarking no longer catches interrupts or general exceptions; it ensures shutdown but lets errors propagate to the caller.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

The primary contribution that this PR add is a property for the TRT-LLM `ModelConfig` class that returns the `torch_dtype`. Recently we encountered the case where the `torch_dtype` is not specified which causes reporting that relies on it to fail. This fix simple defaults to `torch.bfloat16` in the event that we do not find it in the HF config.

This PR also reverts some of the exception reporting to re-raise an exception when encountered in `trtllm-bench` as the current implementation leads to unclear/less informative information than required to debug.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
