### PR TITLE
[https://nvbugs/5429636][fix] fix KVC mem leakage by adding kv_transfer_timeout_ms

### DIFF
--- a/cpp/include/tensorrt_llm/executor/executor.h
+++ b/cpp/include/tensorrt_llm/executor/executor.h
@@ -1443,13 +1443,16 @@ public:
         UCX = 2,
         NIXL = 3
     };
-    explicit CacheTransceiverConfig(
-        std::optional<BackendType> backendType = std::nullopt, std::optional<size_t> maxNumTokens = std::nullopt);
+    explicit CacheTransceiverConfig(std::optional<BackendType> backendType = std::nullopt,
+        std::optional<size_t> maxNumTokens = std::nullopt,
+        std::optional<MillisecondsType> kvTransferTimeoutMs = std::nullopt);
 
     bool operator==(CacheTransceiverConfig const& other) const;
     void setBackendType(std::optional<BackendType> backendType);
     void setMaxTokensInBuffer(std::optional<size_t> maxTokensInBuffer);
+    void setKvTransferTimeoutMs(std::optional<MillisecondsType> kvTransferTimeoutMs);
 
+    [[nodiscard]] std::optional<std::chrono::milliseconds> getKvTransferTimeoutMs() const;
     [[nodiscard]] std::optional<size_t> getMaxTokensInBuffer() const;
     [[nodiscard]] std::optional<BackendType> getBackendType() const;
 
@@ -1459,6 +1462,7 @@ private:
     /// kvCache tokens to be transferred for a single request is greater than this value, the performance of the cache
     /// transfer may be degraded.
     std::optional<size_t> mMaxTokensInBuffer;
+    std::optional<std::chrono::milliseconds> mKvTransferTimeoutMs;
 };
 
 /// @brief Configuration class for the model executor

--- a/cpp/tensorrt_llm/executor/cacheTransceiverConfig.cpp
+++ b/cpp/tensorrt_llm/executor/cacheTransceiverConfig.cpp
@@ -21,16 +21,18 @@
 namespace tensorrt_llm::executor
 {
 
-CacheTransceiverConfig::CacheTransceiverConfig(
-    std::optional<BackendType> backendType, std::optional<size_t> maxNumTokens)
+CacheTransceiverConfig::CacheTransceiverConfig(std::optional<BackendType> backendType,
+    std::optional<size_t> maxNumTokens, std::optional<std::chrono::milliseconds> kvTransferTimeoutMs)
     : mBackendType(backendType)
     , mMaxTokensInBuffer(maxNumTokens)
+    , mKvTransferTimeoutMs(kvTransferTimeoutMs)
 {
 }
 
 bool CacheTransceiverConfig::operator==(CacheTransceiverConfig const& other) const
 {
-    return mMaxTokensInBuffer == other.mMaxTokensInBuffer && mBackendType == other.mBackendType;
+    return mMaxTokensInBuffer == other.mMaxTokensInBuffer && mBackendType == other.mBackendType
+        && mKvTransferTimeoutMs == other.mKvTransferTimeoutMs;
 }
 
 void CacheTransceiverConfig::setBackendType(std::optional<BackendType> backendType)
@@ -51,6 +53,16 @@ std::optional<CacheTransceiverConfig::BackendType> CacheTransceiverConfig::getBa
 std::optional<size_t> CacheTransceiverConfig::getMaxTokensInBuffer() const
 {
     return mMaxTokensInBuffer;
+}
+
+void CacheTransceiverConfig::setKvTransferTimeoutMs(std::optional<std::chrono::milliseconds> kvTransferTimeoutMs)
+{
+    mKvTransferTimeoutMs = kvTransferTimeoutMs;
+}
+
+std::optional<std::chrono::milliseconds> CacheTransceiverConfig::getKvTransferTimeoutMs() const
+{
+    return mKvTransferTimeoutMs;
 }
 
 } // namespace tensorrt_llm::executor

--- a/cpp/tensorrt_llm/nanobind/executor/executorConfig.cpp
+++ b/cpp/tensorrt_llm/nanobind/executor/executorConfig.cpp
@@ -429,25 +429,16 @@ void initConfigBindings(nb::module_& m)
         .def("__setstate__", guidedDecodingConfigSetstate);
 
     auto cacheTransceiverConfigGetstate = [](tle::CacheTransceiverConfig const& self)
-    {
-        auto timeout = self.getKvTransferTimeoutMs();
-        std::optional<int64_t> timeoutMs = timeout ? std::optional<int64_t>(timeout->count()) : std::nullopt;
-        return nb::make_tuple(self.getBackendType(), self.getMaxTokensInBuffer(), timeoutMs);
-    };
+    { return nb::make_tuple(self.getBackendType(), self.getMaxTokensInBuffer(), self.getKvTransferTimeoutMs()); };
     auto cacheTransceiverConfigSetstate = [](tle::CacheTransceiverConfig& self, nb::tuple const& state)
     {
         if (state.size() != 3)
         {
             throw std::runtime_error("Invalid CacheTransceiverConfig state!");
         }
-        new (&self)
-            tle::CacheTransceiverConfig(nb::cast<std::optional<tle::CacheTransceiverConfig::BackendType>>(state[0]),
-                nb::cast<std::optional<size_t>>(state[1]));
-        auto timeoutMs = nb::cast<std::optional<int64_t>>(state[2]);
-        if (timeoutMs)
-        {
-            self.setKvTransferTimeoutMs(std::chrono::milliseconds(*timeoutMs));
-        }
+        new (&self) tle::CacheTransceiverConfig(
+            nb::cast<std::optional<tle::CacheTransceiverConfig::BackendType>>(state[0]),
+            nb::cast<std::optional<size_t>>(state[1]), nb::cast<std::optional<std::chrono::milliseconds>>(state[2]));
     };
 
     nb::enum_<tle::CacheTransceiverConfig::BackendType>(m, "CacheTransceiverBackendType")
@@ -470,44 +461,16 @@ void initConfigBindings(nb::module_& m)
             });
 
     nb::class_<tle::CacheTransceiverConfig>(m, "CacheTransceiverConfig")
-        .def(nb::init(
-                 [](std::optional<tle::CacheTransceiverConfig::BackendType> backend, std::optional<size_t> maxTokens,
-                     std::optional<int64_t> timeoutMs)
-                 {
-                     std::optional<std::chrono::milliseconds> timeout = std::nullopt;
-                     if (timeoutMs)
-                     {
-                         timeout = std::chrono::milliseconds(*timeoutMs);
-                     }
-                     return tle::CacheTransceiverConfig(backend, maxTokens, timeout);
-                 }),
+        .def(nb::init<std::optional<tle::CacheTransceiverConfig::BackendType>, std::optional<size_t>,
+                 std::optional<std::chrono::milliseconds>>(),
             nb::arg("backend") = std::nullopt, nb::arg("max_tokens_in_buffer") = std::nullopt,
             nb::arg("kv_transfer_timeout_ms") = std::nullopt)
         .def_prop_rw(
             "backend", &tle::CacheTransceiverConfig::getBackendType, &tle::CacheTransceiverConfig::setBackendType)
         .def_prop_rw("max_tokens_in_buffer", &tle::CacheTransceiverConfig::getMaxTokensInBuffer,
             &tle::CacheTransceiverConfig::setMaxTokensInBuffer)
-        .def_prop_rw(
-            "kv_transfer_timeout_ms",
-            [](tle::CacheTransceiverConfig const& self) -> std::optional<int64_t>
-            {
-                auto timeout = self.getKvTransferTimeoutMs();
-                return timeout ? std::optional<int64_t>(timeout->count()) : std::nullopt;
-            },
-            [](tle::CacheTransceiverConfig& self, std::optional<int64_t> timeoutMs)
-            {
-                if (timeoutMs)
-                {
-                    self.setKvTransferTimeoutMs(std::chrono::milliseconds(*timeoutMs));
-                }
-                else
-                {
-                    self.setKvTransferTimeoutMs(std::nullopt);
-                }
-            })
-        .def("setKvTransferTimeoutMs",
-            [](tle::CacheTransceiverConfig& self, int64_t timeoutMs)
-            { self.setKvTransferTimeoutMs(std::chrono::milliseconds(timeoutMs)); })
+        .def_prop_rw("kv_transfer_timeout_ms", &tle::CacheTransceiverConfig::getKvTransferTimeoutMs,
+            &tle::CacheTransceiverConfig::setKvTransferTimeoutMs)
         .def("__getstate__", cacheTransceiverConfigGetstate)
         .def("__setstate__", cacheTransceiverConfigSetstate);
 

--- a/examples/disaggregated/README.md
+++ b/examples/disaggregated/README.md
@@ -16,6 +16,9 @@ cache_transceiver_config:
   backend: <str>
   # KV cache buffer size. Set it ≥ the maximum ISL (Input Sequence Length) for best performance.
   max_tokens_in_buffer: <int>
+  # KV cache transfer timeout in milliseconds.
+  # For requests, if they do not send/receive the KV cache in time they are removed and cleaned up.
+  kv_transfer_timeout_ms: <int>
 ```
 
 The following is an example, consisting of the `ctx_extra-llm-api-config.yaml` and `gen_extra-llm-api-config.yaml` files needed in the sections below.

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
@@ -101,6 +101,7 @@ class BindKvCacheTransceiver(KvCacheTransceiver):
         tokens_per_block = kv_cache_manager.tokens_per_block
         dtype = kv_cache_manager.dtype
 
+        self.kv_transfer_timeout_ms = cache_transceiver_config.kv_transfer_timeout_ms
         self.impl = CacheTransceiverCpp(kv_cache_manager.impl,
                                         total_num_kv_heads_per_layer, head_dim,
                                         tokens_per_block, world_config, dtype,

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -330,6 +330,7 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
         self.is_cuda_graph_dummy = False
         self.py_lora_task_layer_module_configs = None
         self.py_kv_transfer_start_time = None
+        self.py_to_cleanup = False
 
         self.py_return_log_probs = return_log_probs
         self.py_return_context_logits = return_context_logits

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -329,6 +329,7 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
         self.is_attention_dp_dummy = False
         self.is_cuda_graph_dummy = False
         self.py_lora_task_layer_module_configs = None
+        self.py_kv_transfer_start_time = None
 
         self.py_return_log_probs = return_log_probs
         self.py_return_context_logits = return_context_logits

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1270,7 +1270,7 @@ class PyExecutor:
 
     def _check_kv_transfer_timeout(self):
         current_time = time.time()
-        timeout_ms = self.kv_cache_transceiver.cache_transceiver_config.kv_transfer_timeout_ms
+        timeout_ms = self.kv_cache_transceiver.kv_transfer_timeout_ms
         if timeout_ms is None:
             return
 
@@ -1279,6 +1279,9 @@ class PyExecutor:
                 continue
             if (current_time -
                     req.py_kv_transfer_start_time) * 1000 > timeout_ms:
+                logger.debug(
+                    f"Terminating context request {req.py_request_id} due to KV cache transfer timeout"
+                )
                 self._terminate_request(req)
 
         for req in self.active_requests[:]:
@@ -1385,7 +1388,7 @@ class PyExecutor:
             for req in new_gen_reqs:
                 self.kv_cache_transceiver.request_and_receive_async(req)
 
-        if self.kv_cache_transceiver.cache_transceiver_config.kv_transfer_timeout_ms is not None:
+        if self.kv_cache_transceiver.kv_transfer_timeout_ms is not None:
             for req in new_gen_reqs:
                 if req.state == LlmRequestState.DISAGG_GENERATION_TRANS_IN_PROGRESS:
                     req.py_kv_transfer_start_time = time.time()
@@ -1423,7 +1426,7 @@ class PyExecutor:
             if req.state == LlmRequestState.DISAGG_CONTEXT_TRANS_IN_PROGRESS
         ]
 
-        if self.kv_cache_transceiver.cache_transceiver_config.kv_transfer_timeout_ms is not None:
+        if self.kv_cache_transceiver.kv_transfer_timeout_ms is not None:
             for req in ctx_transmission_reqs:
                 if req.state == LlmRequestState.DISAGG_CONTEXT_TRANS_IN_PROGRESS:
                     req.py_kv_transfer_start_time = time.time()

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -906,7 +906,6 @@ class PyExecutor:
             self.guided_decoder.execute(scheduled_batch, logits)
 
     def _executor_loop(self):
-        self._log_ctx_transmission_state("Starting _executor_loop")
         torch.cuda.set_device(self.device_id)
         # ensure the context is created, otherwise, some MPI calls will fail.
         CUASSERT(cudart.cudaSetDevice(self.device_id))
@@ -976,8 +975,8 @@ class PyExecutor:
                         self._add_kv_cache_events()
 
                 if self.kv_cache_transceiver and self.ctx_in_transmission_requests:
-                    self._terminate_ctx_finished_requests()
                     self._check_kv_transfer_timeout()
+                    self._terminate_ctx_finished_requests()
 
                 if self.enable_iter_perf_stats:
                     iter_stats.inflight_batching_stats.num_ctx_tokens = self.model_engine.iter_states[
@@ -988,23 +987,6 @@ class PyExecutor:
                             scheduled_requests=scheduled_batch),
                                    iter_stats=iter_stats,
                                    iter_start_time=iter_start_time))
-
-    def _log_ctx_transmission_state(self, context: str):
-        """Helper method to log the current state of ctx_in_transmission_requests"""
-        if not self.ctx_in_transmission_requests:
-            logger.debug(
-                f"[CTX_TRANSMISSION] {context}: ctx_in_transmission_requests is EMPTY"
-            )
-        else:
-            request_ids = [
-                req.py_request_id for req in self.ctx_in_transmission_requests
-            ]
-            client_ids = [
-                req.py_client_id for req in self.ctx_in_transmission_requests
-            ]
-            logger.debug(
-                f"[CTX_TRANSMISSION] {context}: ctx_in_transmission_requests has {len(self.ctx_in_transmission_requests)} requests - request_ids: {request_ids}, client_ids: {client_ids}"
-            )
 
     def _prepare_draft_requests(self):
         try:
@@ -1118,9 +1100,8 @@ class PyExecutor:
                         ctx_transmission_reqs=ctx_transmission_reqs)
 
                 if self.kv_cache_transceiver and self.ctx_in_transmission_requests:
+                    self._check_kv_transfer_timeout()
                     self._terminate_ctx_finished_requests()
-                    # Not sure about this one...
-                    # self._check_kv_transfer_timeout()
 
     def _process_previous_batch(self):
         if self.kv_cache_transceiver and self.previous_batch.ctx_transmission_reqs:
@@ -1657,7 +1638,6 @@ class PyExecutor:
 
     @nvtx_range("_handle_responses")
     def _handle_responses(self):
-        self._log_ctx_transmission_state("Start of _handle_responses")
         new_responses = []
         requests_to_terminate = []
         new_active_requests = []
@@ -1704,8 +1684,6 @@ class PyExecutor:
             if request_done:
                 if request.is_disagg_context_transmission_state:
                     self.ctx_in_transmission_requests.append(request)
-                    self._log_ctx_transmission_state(
-                        "After adding request in _handle_responses")
                 else:
                     requests_to_terminate.append(request)
             else:
@@ -1715,22 +1693,15 @@ class PyExecutor:
         self._enqueue_responses(new_responses)
         for request in requests_to_terminate:
             self._terminate_request(request)
-        self._log_ctx_transmission_state("End of _handle_responses")
         return requests_to_terminate
 
     @nvtx_range("_terminate_ctx_finished_requests")
     def _terminate_ctx_finished_requests(self):
-        self._log_ctx_transmission_state(
-            "Start of _terminate_ctx_finished_requests")
         for request in self.ctx_in_transmission_requests[:]:
             if request.is_disagg_context_complete_state or request.py_to_cleanup:
-                self._log_ctx_transmission_state(
-                    f"After removing request {request.py_request_id}")
                 request.py_kv_transfer_start_time = None
                 self._terminate_request(request)
                 self.ctx_in_transmission_requests.remove(request)
-        self._log_ctx_transmission_state(
-            "End of _terminate_ctx_finished_requests")
 
     def _await_any_response(self,
                             timeout: Optional[float] = None

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1271,6 +1271,8 @@ class PyExecutor:
     def _check_kv_transfer_timeout(self):
         current_time = time.time()
         timeout_ms = self.kv_cache_transceiver.cache_transceiver_config.kv_transfer_timeout_ms
+        if timeout_ms is None:
+            return
 
         for req in self.ctx_in_transmission_requests[:]:
             if req.py_kv_transfer_start_time is None:
@@ -1280,7 +1282,7 @@ class PyExecutor:
                 self._terminate_request(req)
 
         for req in self.active_requests[:]:
-            if req.is_disagg_generation_transmission_complete and req.py_kv_transfer_start_time is not None:
+            if req.is_disagg_generation_transmission_in_progress and req.py_kv_transfer_start_time is not None:
                 if (current_time -
                         req.py_kv_transfer_start_time) * 1000 > timeout_ms:
                     self._terminate_request(req)

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1275,7 +1275,7 @@ class PyExecutor:
             return
         current_time = time.time()
 
-        for req in self.ctx_in_transmission_requests[:]:
+        for req in self.ctx_in_transmission_requests:
             if req.py_kv_transfer_start_time is None:
                 continue
             elapsed_time = (current_time - req.py_kv_transfer_start_time) * 1000
@@ -1285,7 +1285,7 @@ class PyExecutor:
                 )
                 req.py_to_cleanup = True
 
-        for req in self.active_requests[:]:
+        for req in self.active_requests:
             if req.is_disagg_generation_transmission_in_progress and req.py_kv_transfer_start_time is not None:
                 elapsed_time = (current_time -
                                 req.py_kv_transfer_start_time) * 1000

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1070,10 +1070,16 @@ class CacheTransceiverConfig(StrictBaseModel, PybindMirror):
         default=None,
         description="The max number of tokens the transfer buffer can fit.")
 
+    kv_transfer_timeout_ms: Optional[int] = Field(
+        default=None,
+        description="Timeout in milliseconds for KV cache transfer operations. "
+        "Requests exceeding this timeout will be terminated.")
+
     def _to_pybind(self):
         return _CacheTransceiverConfig(
             backend=_CacheTransceiverBackendType.from_string(self.backend),
-            max_tokens_in_buffer=self.max_tokens_in_buffer)
+            max_tokens_in_buffer=self.max_tokens_in_buffer,
+            kv_transfer_timeout_ms=self.kv_transfer_timeout_ms)
 
 
 @dataclass


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Configurable per-transfer KV cache timeout (milliseconds); executor enforces timeouts for context and generation transfers and auto-cleans timed-out requests.

- **Improvements**
  - Python API exposes kv_transfer_timeout_ms property and setter; pickle/state handling persists the timeout.
  - Public model forwards kv_transfer_timeout_ms to bindings.
  - Backend enum adds DEFAULT and a from_string helper.

- **Documentation**
  - Example config updated to show kv_transfer_timeout_ms usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up
-->

## Description

Issue was raised on Github where the context server occasionally hangs due to requests that fail to transfer piling up and accumulating resources. This PR is adding the ability for users to configure `kv_transfer_timeout_ms` under `cache_transceiver_config` which will remove resources for requests that fail to successfully transfer their KV cache in time (can be configured separately for ctx and gen). Must be configured carefully, or you may get rid of perfectly good requests.

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

Tested locally by changing the proxy server to intentionally generate failures and then verifying that resources and requests were cleaned up after the timeout(s).
<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
