### PR TITLE
[None][fix] Fix free memory fraction calculation in resource manager

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -814,7 +814,14 @@ class KVCacheManager(BaseResourceManager):
         logger.debug(f"window_size_to_layers: {window_size_to_layers}")
 
         free_mem, total_mem = torch.cuda.mem_get_info()
-        primary_pool_memory_bytes = free_mem
+        free_mem_fraction = (kv_cache_config.free_gpu_memory_fraction
+                             if kv_cache_config.free_gpu_memory_fraction
+                             is not None else 0.9)
+        assert free_mem_fraction < 1.0, (
+            f"Invalid freeMemFraction: {free_mem_fraction} must be < 1.0")
+        logger.debug(f"free_mem_fraction: {free_mem_fraction}")
+
+        primary_pool_memory_bytes = int(free_mem * free_mem_fraction)
         secondary_pool_memory_bytes = 0
         logger.debug(
             f"primary_pool_memory_bytes is set to {primary_pool_memory_bytes/1024**3}GB, \n"


### PR DESCRIPTION
## Description

<!--
Please explain the issue and the solution in short.
-->

The calculation under `calculate_max_num_blocks_from_cpp` is incorrect. Looking closely it does not give regard of the memory fraction coefficient provided. This MR changes for it to respect fraction specified, or else we will disregard the memory taken for storing the model and get out-of-memory (OOM) for allocating too much blocks.

## Test Coverage

This bug is due to us having test coverage for the function only on the cpp side (kvCacheManagerTest.cpp). The function assumes to receive a free memory size and allocate blocks upon the given number.

The testing should be on python side, however I don't see any tests to the function under test_resource_manager.py.

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GPU memory budgeting now uses a configurable safe fraction of free GPU memory to reduce out-of-memory errors during large-model inference and serving.
  * Added debug logging to report the configured memory fraction for easier diagnostics.
  * No changes to public APIs; behavior is more predictable across varied GPU memory conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->