### PR TITLE
[#6186][feat] Introduce QKNormRoPEAttention module

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_qwen3.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3.py
@@ -129,13 +129,20 @@ class Qwen3DecoderLayer(DecoderLayer):
         self,
         model_config: ModelConfig[Qwen3Config],
         layer_idx: int,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ):
         super().__init__()
         self.layer_idx = layer_idx
         config = model_config.pretrained_config
         self.self_attn = QKNormRoPEAttention(
-            model_config,
+            hidden_size=config.hidden_size,
+            num_attention_heads=config.num_attention_heads,
+            num_key_value_heads=config.num_key_value_heads,
+            max_position_embeddings=config.max_position_embeddings,
+            bias=config.attention_bias,
             layer_idx=layer_idx,
+            dtype=config.torch_dtype,
+            dense_bias=config.attention_bias,
+            config=model_config,
         )
 
         self.mlp = GatedMLP(

--- a/tensorrt_llm/_torch/models/modeling_qwen3.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3.py
@@ -1,11 +1,13 @@
-import math
 from typing import Optional, Tuple
 
 import torch
 from torch import nn
-from transformers import PretrainedConfig, Qwen3Config
+from transformers import Qwen3Config
+
+from tensorrt_llm.functional import PositionEmbeddingType
 
 from ..attention_backend import AttentionMetadata
+from ..attention_backend.interface import PositionalEmbeddingParams, RopeParams
 from ..model_config import ModelConfig
 from ..modules.decoder_layer import DecoderLayer
 from ..modules.embedding import Embedding
@@ -18,109 +20,47 @@ from .modeling_speculative import SpecDecOneEngineForCausalLM
 from .modeling_utils import DecoderModel, register_auto_model
 
 
-# Move out from this class
-def compute_yarn_parameters(
-    config: PretrainedConfig, ) -> tuple[float, float, float, float]:
-    """
-    Refer to https://github.com/huggingface/transformers/blob/main/src/transformers/modeling_rope_utils.py#L197C1-L288C1
-    Computes the inverse frequencies with NTK scaling. Please refer to the
-    [original paper](https://huggingface.co/papers/2309.00071)
-    Args:
-        config ([`~transformers.PretrainedConfig`]):
-            The model configuration.
-    Returns:
-        factor: float, the scaling factor for the RoPE embeddings
-        low: float, the lower bound of the dimension range
-        high: float, the upper bound of the dimension range
-        attention_factor: float, the post-processing scaling factor applied to the computed cos/sin
-    """
+class Qwen3Attention(QKNormRoPEAttention):
 
-    # The config does not contain rope_scaling, which means the model is not using yarn
-    rope_scaling = getattr(config, "rope_scaling", None)
-    if rope_scaling is None:
-        return 1.0, 0, 0, 1.0
+    def __init__(
+        self,
+        model_config: ModelConfig[Qwen3Config],
+        layer_idx: Optional[int] = None,
+        fuse_qk_norm_rope: bool = True,
+    ):
+        config = model_config.pretrained_config
 
-    base = config.rope_theta
-    partial_rotary_factor = config.partial_rotary_factor if hasattr(
-        config, "partial_rotary_factor") else 1.0
-    head_dim = getattr(config, "head_dim",
-                       config.hidden_size // config.num_attention_heads)
-    dim = int(head_dim * partial_rotary_factor)
-    factor = getattr(rope_scaling, "factor", 1.0)
-    attention_factor = rope_scaling.get("attention_factor")
-    mscale = rope_scaling.get("mscale")
-    mscale_all_dim = rope_scaling.get("mscale_all_dim")
-
-    if "original_max_position_embeddings" in rope_scaling:
-        original_max_position_embeddings = rope_scaling[
-            "original_max_position_embeddings"]
-        factor = config.max_position_embeddings / original_max_position_embeddings
-    else:
-        original_max_position_embeddings = config.max_position_embeddings
-
-    def get_mscale(scale, mscale=1):
-        if scale <= 1:
-            return 1.0
-        return 0.1 * mscale * math.log(scale) + 1.0
-
-    # Sets the attention factor as suggested in the paper
-    if attention_factor is None:
-        if mscale and mscale_all_dim:
-            attention_factor = float(
-                get_mscale(factor, mscale) / get_mscale(factor, mscale_all_dim))
+        if getattr(config, "rope_scaling", None) is not None:
+            if "type" in config.rope_scaling:
+                pos_type = config.rope_scaling["type"]
+            elif "rope_type" in config.rope_scaling:
+                pos_type = config.rope_scaling["rope_type"]
+            else:
+                raise ValueError(
+                    "rope_scaling must have type or rope_type field")
+            pos_embd_params = PositionalEmbeddingParams(
+                type=PositionEmbeddingType.from_string(pos_type),
+                rope=RopeParams.from_config(config),
+            )
         else:
-            attention_factor = get_mscale(factor)
+            pos_embd_params = PositionalEmbeddingParams(
+                type=PositionEmbeddingType.rope_gpt_neox,
+                rope=RopeParams.from_config(config),
+            )
 
-    # Optional config options
-    # beta_fast/beta_slow: as suggested in the paper, default to 32/1 (correspondingly)
-    beta_fast = rope_scaling.get("beta_fast") or 32
-    beta_slow = rope_scaling.get("beta_slow") or 1
-
-    # Compute the inverse frequencies
-    def find_correction_dim(num_rotations, dim, base, max_position_embeddings):
-        """Inverse dimension formula to find the dimension based on the number of rotations"""
-        return (dim *
-                math.log(max_position_embeddings /
-                         (num_rotations * 2 * math.pi))) / (2 * math.log(base))
-
-    def find_correction_range(low_rot, high_rot, dim, base,
-                              max_position_embeddings, truncate):
-        """Find dimension range bounds based on rotations"""
-        low = find_correction_dim(low_rot, dim, base, max_position_embeddings)
-        high = find_correction_dim(high_rot, dim, base, max_position_embeddings)
-        if truncate:
-            low = math.floor(low)
-            high = math.ceil(high)
-        return max(low, 0), min(high, dim - 1)
-
-    truncate = rope_scaling.get("truncate", True)
-    low, high = find_correction_range(beta_fast, beta_slow, dim, base,
-                                      original_max_position_embeddings,
-                                      truncate)
-
-    # These parts are implemented in the fusedQKNormRopeKernel.cu
-    # # def linear_ramp_factor(min, max, dim):
-    # #     if min == max:
-    # #         max += 0.001  # Prevent singularity
-
-    # #     linear_func = (torch.arange(dim, dtype=torch.float32) - min) / (max - min)
-    # #     ramp_func = torch.clamp(linear_func, 0, 1)
-    # #     return ramp_func
-
-    # # Note on variable naming: "interpolation" comes from the original technique, where we interpolate the position IDs
-    # # to expand the possible context length. In other words, interpolation = apply scaling factor.
-    # # pos_freqs = base ** (torch.arange(0, dim, 2).to(device=device, dtype=torch.float) / dim)
-    # # inv_freq_extrapolation = 1.0 / pos_freqs
-    # # inv_freq_interpolation = 1.0 / (factor * pos_freqs)
-
-    # # # Get n-dimensional rotational scaling corrected for extrapolation
-    # # inv_freq_extrapolation_factor = 1 - linear_ramp_factor(low, high, dim // 2).to(device=device, dtype=torch.float)
-    # # inv_freq = (
-    # #     inv_freq_interpolation * (1 - inv_freq_extrapolation_factor)
-    # #     + inv_freq_extrapolation * inv_freq_extrapolation_factor
-    # # )
-    # # return inv_freq, attention_factor
-    return factor, low, high, attention_factor
+        super().__init__(
+            hidden_size=config.hidden_size,
+            num_attention_heads=config.num_attention_heads,
+            num_key_value_heads=config.num_key_value_heads,
+            max_position_embeddings=config.max_position_embeddings,
+            bias=config.attention_bias,
+            pos_embd_params=pos_embd_params,
+            fuse_qk_norm_rope=fuse_qk_norm_rope,
+            layer_idx=layer_idx,
+            dtype=config.torch_dtype,
+            dense_bias=config.attention_bias,
+            config=model_config,
+        )
 
 
 class Qwen3DecoderLayer(DecoderLayer):
@@ -133,16 +73,9 @@ class Qwen3DecoderLayer(DecoderLayer):
         super().__init__()
         self.layer_idx = layer_idx
         config = model_config.pretrained_config
-        self.self_attn = QKNormRoPEAttention(
-            hidden_size=config.hidden_size,
-            num_attention_heads=config.num_attention_heads,
-            num_key_value_heads=config.num_key_value_heads,
-            max_position_embeddings=config.max_position_embeddings,
-            bias=config.attention_bias,
+        self.self_attn = Qwen3Attention(
+            model_config,
             layer_idx=layer_idx,
-            dtype=config.torch_dtype,
-            dense_bias=config.attention_bias,
-            config=model_config,
         )
 
         self.mlp = GatedMLP(

--- a/tensorrt_llm/_torch/models/modeling_qwen3.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3.py
@@ -5,17 +5,13 @@ import torch
 from torch import nn
 from transformers import PretrainedConfig, Qwen3Config
 
-from tensorrt_llm.functional import PositionEmbeddingType
-
 from ..attention_backend import AttentionMetadata
-from ..attention_backend.interface import PositionalEmbeddingParams, RopeParams
 from ..model_config import ModelConfig
-from ..modules.attention import Attention
 from ..modules.decoder_layer import DecoderLayer
 from ..modules.embedding import Embedding
 from ..modules.gated_mlp import GatedMLP
 from ..modules.linear import TensorParallelMode
-from ..modules.multi_stream_utils import maybe_execute_in_parallel
+from ..modules.qk_norm_attention import QKNormRoPEAttention
 from ..modules.rms_norm import RMSNorm
 from ..speculative import SpecMetadata
 from .modeling_speculative import SpecDecOneEngineForCausalLM
@@ -127,108 +123,6 @@ def compute_yarn_parameters(
     return factor, low, high, attention_factor
 
 
-class Qwen3Attention(Attention):
-
-    def __init__(
-        self,
-        model_config: ModelConfig[Qwen3Config],
-        layer_idx: Optional[int] = None,
-        fuse_qk_norm_rope: bool = True,
-    ):
-        config = model_config.pretrained_config
-        self.pretrained_config = config
-
-        if getattr(config, "rope_scaling", None) is not None:
-            if "type" in config.rope_scaling:
-                pos_type = config.rope_scaling["type"]
-            elif "rope_type" in config.rope_scaling:
-                pos_type = config.rope_scaling["rope_type"]
-            else:
-                raise ValueError(
-                    "rope_scaling must have type or rope_type field")
-            pos_embd_params = PositionalEmbeddingParams(
-                type=PositionEmbeddingType.from_string(pos_type),
-                rope=RopeParams.from_config(config),
-            )
-        else:
-            pos_embd_params = PositionalEmbeddingParams(
-                type=PositionEmbeddingType.rope_gpt_neox,
-                rope=RopeParams.from_config(config),
-            )
-
-        self.fuse_qk_norm_rope = fuse_qk_norm_rope
-
-        super().__init__(
-            hidden_size=config.hidden_size,
-            num_attention_heads=config.num_attention_heads,
-            num_key_value_heads=config.num_key_value_heads,
-            max_position_embeddings=config.max_position_embeddings,
-            bias=config.attention_bias,
-            pos_embd_params=pos_embd_params,
-            rope_fusion=not self.
-            fuse_qk_norm_rope,  # If fuse_qk_norm_rope is true, do not apply fused RoPE in attention OP, and self.rotary_emb will be skipped in the overridden apply_rope.
-            layer_idx=layer_idx,
-            dtype=config.torch_dtype,
-            dense_bias=config.attention_bias,
-            config=model_config,
-        )
-
-        self.q_norm = RMSNorm(hidden_size=self.head_dim,
-                              eps=1e-6,
-                              dtype=config.torch_dtype,
-                              has_weights=True)
-        self.k_norm = RMSNorm(hidden_size=self.head_dim,
-                              eps=1e-6,
-                              dtype=config.torch_dtype,
-                              has_weights=True)
-        self.aux_stream = torch.cuda.Stream()
-        self.ln_events = [torch.cuda.Event(), torch.cuda.Event()]
-
-    def apply_qk_norm(self, q, k):
-
-        def q_l2norm():
-            return self.q_norm(q.reshape(-1, self.head_dim)).reshape(
-                -1, self.q_size)
-
-        def k_l2norm():
-            return self.k_norm(k.reshape(-1, self.head_dim)).reshape(
-                -1, self.kv_size)
-
-        q, k = maybe_execute_in_parallel(
-            q_l2norm,
-            k_l2norm,
-            self.ln_events[0],
-            self.ln_events[1],
-            self.aux_stream,
-        )
-
-        return q, k
-
-    def apply_qk_norm_rope(self, qkv, position_ids):
-        factor, low, high, attention_factor = compute_yarn_parameters(
-            self.pretrained_config)
-        torch.ops.trtllm.fused_qk_norm_rope(
-            qkv, self.num_heads, self.num_key_value_heads,
-            self.num_key_value_heads, self.head_dim,
-            self.q_norm.variance_epsilon, self.q_norm.weight,
-            self.k_norm.weight,
-            self.pos_embd_params.rope.theta, self.pos_embd_params.is_neox,
-            position_ids.view(-1), factor, low, high, attention_factor)
-        return qkv, None, None
-
-    def apply_rope(self, q: torch.Tensor, k: Optional[torch.Tensor],
-                   v: Optional[torch.Tensor], position_ids: torch.Tensor):
-        # Qwen3 applies QK norm before RoPE.
-        if not self.fuse_qk_norm_rope:
-            q, k, v = self.split_qkv(q, k, v)
-            q, k = self.apply_qk_norm(q, k)
-            return super().apply_rope(q, k, v, position_ids)
-
-        assert k is None and v is None, "The input should be a concatenated qkv tensor to apply_qk_norm_rope"
-        qkv = q
-        return self.apply_qk_norm_rope(qkv, position_ids)
-
-
 class Qwen3DecoderLayer(DecoderLayer):
 
     def __init__(
@@ -239,7 +133,7 @@ class Qwen3DecoderLayer(DecoderLayer):
         super().__init__()
         self.layer_idx = layer_idx
         config = model_config.pretrained_config
-        self.self_attn = Qwen3Attention(
+        self.self_attn = QKNormRoPEAttention(
             model_config,
             layer_idx=layer_idx,
         )

--- a/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
@@ -20,10 +20,10 @@ from ..modules.fused_moe import (BaseMoeRoutingMethod,
                                  RoutingMethodType, TRTLLMGenFusedMoE,
                                  create_moe)
 from ..modules.linear import TensorParallelMode
+from ..modules.qk_norm_attention import QKNormRoPEAttention
 from ..modules.rms_norm import RMSNorm
 from ..speculative import SpecMetadata
 from ..utils import AuxStreamType
-from .modeling_qwen3 import Qwen3Attention
 from .modeling_speculative import SpecDecOneEngineForCausalLM
 from .modeling_utils import DecoderModel, EagerFusionConfig, register_auto_model
 
@@ -166,7 +166,7 @@ class Qwen3MoEDecoderLayer(DecoderLayer):
         super().__init__()
         self.model_config = model_config
         config = model_config.pretrained_config
-        self.self_attn = Qwen3Attention(
+        self.self_attn = QKNormRoPEAttention(
             model_config,
             layer_idx=layer_idx,
         )

--- a/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
@@ -20,10 +20,10 @@ from ..modules.fused_moe import (BaseMoeRoutingMethod,
                                  RoutingMethodType, TRTLLMGenFusedMoE,
                                  create_moe)
 from ..modules.linear import TensorParallelMode
-from ..modules.qk_norm_attention import QKNormRoPEAttention
 from ..modules.rms_norm import RMSNorm
 from ..speculative import SpecMetadata
 from ..utils import AuxStreamType
+from .modeling_qwen3 import Qwen3Attention
 from .modeling_speculative import SpecDecOneEngineForCausalLM
 from .modeling_utils import DecoderModel, EagerFusionConfig, register_auto_model
 
@@ -166,16 +166,9 @@ class Qwen3MoEDecoderLayer(DecoderLayer):
         super().__init__()
         self.model_config = model_config
         config = model_config.pretrained_config
-        self.self_attn = QKNormRoPEAttention(
-            hidden_size=config.hidden_size,
-            num_attention_heads=config.num_attention_heads,
-            num_key_value_heads=config.num_key_value_heads,
-            max_position_embeddings=config.max_position_embeddings,
-            bias=config.attention_bias,
+        self.self_attn = Qwen3Attention(
+            model_config,
             layer_idx=layer_idx,
-            dtype=config.torch_dtype,
-            dense_bias=config.attention_bias,
-            config=model_config,
         )
         self.mapping = model_config.mapping
         self.enable_attention_dp = self.mapping.enable_attention_dp

--- a/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
@@ -167,8 +167,15 @@ class Qwen3MoEDecoderLayer(DecoderLayer):
         self.model_config = model_config
         config = model_config.pretrained_config
         self.self_attn = QKNormRoPEAttention(
-            model_config,
+            hidden_size=config.hidden_size,
+            num_attention_heads=config.num_attention_heads,
+            num_key_value_heads=config.num_key_value_heads,
+            max_position_embeddings=config.max_position_embeddings,
+            bias=config.attention_bias,
             layer_idx=layer_idx,
+            dtype=config.torch_dtype,
+            dense_bias=config.attention_bias,
+            config=model_config,
         )
         self.mapping = model_config.mapping
         self.enable_attention_dp = self.mapping.enable_attention_dp

--- a/tensorrt_llm/_torch/modules/qk_norm_attention.py
+++ b/tensorrt_llm/_torch/modules/qk_norm_attention.py
@@ -1,0 +1,111 @@
+from typing import Optional
+
+import torch
+
+from ..attention_backend.interface import (PositionalEmbeddingParams,
+                                           PositionEmbeddingType, RopeParams)
+from ..model_config import ModelConfig
+from ..modules.attention import Attention
+from ..modules.multi_stream_utils import maybe_execute_in_parallel
+from ..modules.rms_norm import RMSNorm
+
+
+class QKNormRoPEAttention(Attention):
+    """
+    QKNormRoPEAttention is a custom attention layer that applies QK norm and RoPE to the input tensor.
+    It is used in the Qwen3 model.
+    It is a subclass of Attention, and overrides the apply_rope method to apply QK norm and RoPE.
+    """
+
+    def __init__(
+        self,
+        model_config: ModelConfig,
+        layer_idx: Optional[int] = None,
+        fuse_qk_norm_rope: bool = True,
+    ):
+        config = model_config.pretrained_config
+
+        if getattr(config, "rope_scaling", None) is not None:
+            pos_embd_params = PositionalEmbeddingParams(
+                type=PositionEmbeddingType.from_string(
+                    config.rope_scaling["type"]),
+                rope=RopeParams.from_config(config),
+            )
+        else:
+            pos_embd_params = PositionalEmbeddingParams(
+                type=PositionEmbeddingType.rope_gpt_neox,
+                rope=RopeParams.from_config(config),
+            )
+
+        self.fuse_qk_norm_rope = fuse_qk_norm_rope
+
+        super().__init__(
+            hidden_size=config.hidden_size,
+            num_attention_heads=config.num_attention_heads,
+            num_key_value_heads=config.num_key_value_heads,
+            max_position_embeddings=config.max_position_embeddings,
+            bias=config.attention_bias,
+            pos_embd_params=pos_embd_params,
+            rope_fusion=not self.
+            fuse_qk_norm_rope,  # If fuse_qk_norm_rope is true, do not apply fused RoPE in attention OP, and self.rotary_emb will be skipped in the overridden apply_rope.
+            layer_idx=layer_idx,
+            dtype=config.torch_dtype,
+            dense_bias=config.attention_bias,
+            config=model_config,
+        )
+
+        self.q_norm = RMSNorm(hidden_size=self.head_dim,
+                              eps=1e-6,
+                              dtype=config.torch_dtype,
+                              has_weights=True)
+        self.k_norm = RMSNorm(hidden_size=self.head_dim,
+                              eps=1e-6,
+                              dtype=config.torch_dtype,
+                              has_weights=True)
+        self.aux_stream = torch.cuda.Stream()
+        self.ln_events = [torch.cuda.Event(), torch.cuda.Event()]
+
+    def apply_qk_norm(self, q, k):
+
+        def q_l2norm():
+            return self.q_norm(q.reshape(-1, self.head_dim)).reshape(
+                -1, self.q_size)
+
+        def k_l2norm():
+            return self.k_norm(k.reshape(-1, self.head_dim)).reshape(
+                -1, self.kv_size)
+
+        q, k = maybe_execute_in_parallel(
+            q_l2norm,
+            k_l2norm,
+            self.ln_events[0],
+            self.ln_events[1],
+            self.aux_stream,
+        )
+
+        return q, k
+
+    def apply_qk_norm_rope(self, qkv, position_ids):
+        torch.ops.trtllm.fused_qk_norm_rope(
+            qkv, self.num_heads, self.num_key_value_heads,
+            self.num_key_value_heads, self.head_dim,
+            self.q_norm.variance_epsilon, self.q_norm.weight,
+            self.k_norm.weight, self.pos_embd_params.rope.theta,
+            self.pos_embd_params.is_neox, position_ids.view(-1))
+        return qkv, None, None
+
+    def apply_rope(self, q: torch.Tensor, k: Optional[torch.Tensor],
+                   v: Optional[torch.Tensor], position_ids: torch.Tensor):
+        """
+        The apply_rope method is called in the forward method of the Attention class.
+        The apply_rope method is overridden in this class to apply QK norm and RoPE to the input tensor.
+        """
+        # Qwen3 applies QK norm before RoPE.
+        if not self.fuse_qk_norm_rope:
+            q, k, v = self.split_qkv(q, k, v)
+            q, k = self.apply_qk_norm(q, k)
+            return super().apply_rope(q, k, v, position_ids)
+
+        assert k is None and v is None, "The input should be a concatenated qkv tensor to apply_qk_norm_rope"
+        qkv = q
+        return self.apply_qk_norm_rope(qkv, position_ids)

--- a/tensorrt_llm/_torch/modules/qk_norm_attention.py
+++ b/tensorrt_llm/_torch/modules/qk_norm_attention.py
@@ -43,9 +43,10 @@ def compute_yarn_parameters(
         attention_factor: float, the post-processing scaling factor applied to the computed cos/sin
     """
 
-    # The config does not contain rope_scaling, which means the model is not using yarn
+    # If config does not contain rope_scaling or rope_type is not yarn, it means the model is not using yarn
     rope_scaling = getattr(config, "rope_scaling", None)
-    if rope_scaling is None:
+    if rope_scaling is None or getattr(rope_scaling, "rope_type",
+                                       None) != "yarn":
         return 1.0, 0, 0, 1.0
 
     base = config.rope_theta

--- a/tensorrt_llm/_torch/modules/qk_norm_attention.py
+++ b/tensorrt_llm/_torch/modules/qk_norm_attention.py
@@ -13,16 +13,122 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 from typing import Optional
 
 import torch
+from transformers import PretrainedConfig
 
-from ..attention_backend.interface import (PositionalEmbeddingParams,
-                                           PositionEmbeddingType, RopeParams)
+from ..attention_backend.interface import PositionalEmbeddingParams
 from ..model_config import ModelConfig
 from ..modules.attention import Attention
 from ..modules.multi_stream_utils import maybe_execute_in_parallel
 from ..modules.rms_norm import RMSNorm
+
+
+# Move out from this class
+def compute_yarn_parameters(
+    config: PretrainedConfig, ) -> tuple[float, float, float, float]:
+    """
+    Refer to https://github.com/huggingface/transformers/blob/main/src/transformers/modeling_rope_utils.py#L197C1-L288C1
+    Computes the inverse frequencies with NTK scaling. Please refer to the
+    [original paper](https://huggingface.co/papers/2309.00071)
+    Args:
+        config ([`~transformers.PretrainedConfig`]):
+            The model configuration.
+    Returns:
+        factor: float, the scaling factor for the RoPE embeddings
+        low: float, the lower bound of the dimension range
+        high: float, the upper bound of the dimension range
+        attention_factor: float, the post-processing scaling factor applied to the computed cos/sin
+    """
+
+    # The config does not contain rope_scaling, which means the model is not using yarn
+    rope_scaling = getattr(config, "rope_scaling", None)
+    if rope_scaling is None:
+        return 1.0, 0, 0, 1.0
+
+    base = config.rope_theta
+    partial_rotary_factor = config.partial_rotary_factor if hasattr(
+        config, "partial_rotary_factor") else 1.0
+    head_dim = getattr(config, "head_dim",
+                       config.hidden_size // config.num_attention_heads)
+    dim = int(head_dim * partial_rotary_factor)
+    factor = getattr(rope_scaling, "factor", 1.0)
+    attention_factor = rope_scaling.get("attention_factor")
+    mscale = rope_scaling.get("mscale")
+    mscale_all_dim = rope_scaling.get("mscale_all_dim")
+
+    if "original_max_position_embeddings" in rope_scaling:
+        original_max_position_embeddings = rope_scaling[
+            "original_max_position_embeddings"]
+        factor = config.max_position_embeddings / original_max_position_embeddings
+    else:
+        original_max_position_embeddings = config.max_position_embeddings
+
+    def get_mscale(scale, mscale=1):
+        if scale <= 1:
+            return 1.0
+        return 0.1 * mscale * math.log(scale) + 1.0
+
+    # Sets the attention factor as suggested in the paper
+    if attention_factor is None:
+        if mscale and mscale_all_dim:
+            attention_factor = float(
+                get_mscale(factor, mscale) / get_mscale(factor, mscale_all_dim))
+        else:
+            attention_factor = get_mscale(factor)
+
+    # Optional config options
+    # beta_fast/beta_slow: as suggested in the paper, default to 32/1 (correspondingly)
+    beta_fast = rope_scaling.get("beta_fast") or 32
+    beta_slow = rope_scaling.get("beta_slow") or 1
+
+    # Compute the inverse frequencies
+    def find_correction_dim(num_rotations, dim, base, max_position_embeddings):
+        """Inverse dimension formula to find the dimension based on the number of rotations"""
+        return (dim *
+                math.log(max_position_embeddings /
+                         (num_rotations * 2 * math.pi))) / (2 * math.log(base))
+
+    def find_correction_range(low_rot, high_rot, dim, base,
+                              max_position_embeddings, truncate):
+        """Find dimension range bounds based on rotations"""
+        low = find_correction_dim(low_rot, dim, base, max_position_embeddings)
+        high = find_correction_dim(high_rot, dim, base, max_position_embeddings)
+        if truncate:
+            low = math.floor(low)
+            high = math.ceil(high)
+        return max(low, 0), min(high, dim - 1)
+
+    truncate = rope_scaling.get("truncate", True)
+    low, high = find_correction_range(beta_fast, beta_slow, dim, base,
+                                      original_max_position_embeddings,
+                                      truncate)
+
+    # These parts are implemented in the fusedQKNormRopeKernel.cu
+    # # def linear_ramp_factor(min, max, dim):
+    # #     if min == max:
+    # #         max += 0.001  # Prevent singularity
+
+    # #     linear_func = (torch.arange(dim, dtype=torch.float32) - min) / (max - min)
+    # #     ramp_func = torch.clamp(linear_func, 0, 1)
+    # #     return ramp_func
+
+    # # Note on variable naming: "interpolation" comes from the original technique, where we interpolate the position IDs
+    # # to expand the possible context length. In other words, interpolation = apply scaling factor.
+    # # pos_freqs = base ** (torch.arange(0, dim, 2).to(device=device, dtype=torch.float) / dim)
+    # # inv_freq_extrapolation = 1.0 / pos_freqs
+    # # inv_freq_interpolation = 1.0 / (factor * pos_freqs)
+
+    # # # Get n-dimensional rotational scaling corrected for extrapolation
+    # # inv_freq_extrapolation_factor = 1 - linear_ramp_factor(low, high, dim // 2).to(device=device, dtype=torch.float)
+    # # inv_freq = (
+    # #     inv_freq_interpolation * (1 - inv_freq_extrapolation_factor)
+    # #     + inv_freq_extrapolation * inv_freq_extrapolation_factor
+    # # )
+    # # return inv_freq, attention_factor
+    return factor, low, high, attention_factor
 
 
 class QKNormRoPEAttention(Attention):
@@ -40,25 +146,14 @@ class QKNormRoPEAttention(Attention):
         num_key_value_heads: int,
         max_position_embeddings: int,
         bias: bool,
+        pos_embd_params: Optional[PositionalEmbeddingParams] = None,
         fuse_qk_norm_rope: bool = True,
         layer_idx: Optional[int] = None,
         dtype: torch.dtype = None,
         dense_bias: Optional[bool] = None,
         config: ModelConfig,
     ):
-        pretrained_config = config.pretrained_config
-
-        if getattr(pretrained_config, "rope_scaling", None) is not None:
-            pos_embd_params = PositionalEmbeddingParams(
-                type=PositionEmbeddingType.from_string(
-                    pretrained_config.rope_scaling["type"]),
-                rope=RopeParams.from_config(pretrained_config),
-            )
-        else:
-            pos_embd_params = PositionalEmbeddingParams(
-                type=PositionEmbeddingType.rope_gpt_neox,
-                rope=RopeParams.from_config(pretrained_config),
-            )
+        self.pretrained_config = config.pretrained_config
 
         self.fuse_qk_norm_rope = fuse_qk_norm_rope
 
@@ -78,13 +173,15 @@ class QKNormRoPEAttention(Attention):
             config=config,
         )
 
+        pretrained_dtype = self.pretrained_config.torch_dtype
+
         self.q_norm = RMSNorm(hidden_size=self.head_dim,
                               eps=1e-6,
-                              dtype=pretrained_config.torch_dtype,
+                              dtype=pretrained_dtype,
                               has_weights=True)
         self.k_norm = RMSNorm(hidden_size=self.head_dim,
                               eps=1e-6,
-                              dtype=pretrained_config.torch_dtype,
+                              dtype=pretrained_dtype,
                               has_weights=True)
         self.aux_stream = torch.cuda.Stream()
         self.ln_events = [torch.cuda.Event(), torch.cuda.Event()]
@@ -110,12 +207,15 @@ class QKNormRoPEAttention(Attention):
         return q, k
 
     def apply_qk_norm_rope(self, qkv, position_ids):
+        factor, low, high, attention_factor = compute_yarn_parameters(
+            self.pretrained_config)
         torch.ops.trtllm.fused_qk_norm_rope(
             qkv, self.num_heads, self.num_key_value_heads,
             self.num_key_value_heads, self.head_dim,
             self.q_norm.variance_epsilon, self.q_norm.weight,
-            self.k_norm.weight, self.pos_embd_params.rope.theta,
-            self.pos_embd_params.is_neox, position_ids.view(-1))
+            self.k_norm.weight,
+            self.pos_embd_params.rope.theta, self.pos_embd_params.is_neox,
+            position_ids.view(-1), factor, low, high, attention_factor)
         return qkv, None, None
 
     def apply_rope(self, q: torch.Tensor, k: Optional[torch.Tensor],
@@ -124,7 +224,7 @@ class QKNormRoPEAttention(Attention):
         The apply_rope method is called in the forward method of the Attention class.
         The apply_rope method is overridden in this class to apply QK norm and RoPE to the input tensor.
         """
-        # Qwen3 applies QK norm before RoPE.
+        # Apply QK norm before RoPE.
         if not self.fuse_qk_norm_rope:
             q, k, v = self.split_qkv(q, k, v)
             q, k = self.apply_qk_norm(q, k)

--- a/tensorrt_llm/_torch/modules/qk_norm_attention.py
+++ b/tensorrt_llm/_torch/modules/qk_norm_attention.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Optional
 
 import torch

--- a/tensorrt_llm/_torch/modules/qk_norm_attention.py
+++ b/tensorrt_llm/_torch/modules/qk_norm_attention.py
@@ -134,7 +134,7 @@ def compute_yarn_parameters(
 class QKNormRoPEAttention(Attention):
     """
     QKNormRoPEAttention is a custom attention layer that applies QK norm and RoPE to the input tensor.
-    It is used in the Qwen3 model.
+    It is used in the Gemma3 and Qwen3 models.
     It is a subclass of Attention, and overrides the apply_rope method to apply QK norm and RoPE.
     """
 
@@ -152,6 +152,7 @@ class QKNormRoPEAttention(Attention):
         dtype: torch.dtype = None,
         dense_bias: Optional[bool] = None,
         config: ModelConfig,
+        q_scaling: float = 1.0,
     ):
         self.pretrained_config = config.pretrained_config
 
@@ -171,17 +172,16 @@ class QKNormRoPEAttention(Attention):
             dtype=dtype,
             dense_bias=dense_bias,
             config=config,
+            q_scaling=q_scaling,
         )
 
-        pretrained_dtype = self.pretrained_config.torch_dtype
-
         self.q_norm = RMSNorm(hidden_size=self.head_dim,
-                              eps=1e-6,
-                              dtype=pretrained_dtype,
+                              eps=self.pretrained_config.rms_norm_eps,
+                              dtype=self.pretrained_config.torch_dtype,
                               has_weights=True)
         self.k_norm = RMSNorm(hidden_size=self.head_dim,
-                              eps=1e-6,
-                              dtype=pretrained_dtype,
+                              eps=self.pretrained_config.rms_norm_eps,
+                              dtype=self.pretrained_config.torch_dtype,
                               has_weights=True)
         self.aux_stream = torch.cuda.Stream()
         self.ln_events = [torch.cuda.Event(), torch.cuda.Event()]


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Qwen3 models now use a redesigned self-attention that integrates Q/K normalization with rotary positional embeddings for improved stability and output quality, including MoE variants.

* **Performance Improvements**
  * Faster inference via a fused attention execution path and parallelized normalization, reducing latency and compute overhead.

* **Compatibility**
  * No user-facing API changes; existing Qwen3 workflows remain supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up
-->

## Description

- Added QKNormRoPEAttention class to apply QK normalization and RoPE.
- Replaced Qwen3Attention with QKNormRoPEAttention in Qwen3DecoderLayer.
- Removed unused imports and code related to the previous attention implementation.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
