### PR TITLE
[None][feat] Refactor llama4 for multimodal encoder IFB

### DIFF
--- a/docs/source/reference/multimodal-feature-support-matrix.md
+++ b/docs/source/reference/multimodal-feature-support-matrix.md
@@ -6,7 +6,7 @@
 | HyperCLOVA         | Yes        | Yes                 | No             | No              |
 | VILA               | Yes        | No                  | No             | No              |
 | LLaVA-NeXT         | Yes        | Yes                 | No             | No              |
-| Llama 4            | Yes        | No                  | No             | No              |
+| Llama 4            | Yes        | Yes                 | No             | No              |
 | Mistral-Small-3.1  | Yes        | Yes                 | No             | No              |
 | Phi-4-multimodal   | Yes        | Yes                 | No             | No              |
 | Qwen2-VL           | Yes        | Yes                 | Yes            | No              |

--- a/tensorrt_llm/_torch/models/modeling_llama.py
+++ b/tensorrt_llm/_torch/models/modeling_llama.py
@@ -16,6 +16,7 @@ from tensorrt_llm._torch.models.checkpoints.base_weight_mapper import \
     BaseWeightMapper
 from tensorrt_llm._utils import get_sm_version
 from tensorrt_llm.functional import PositionEmbeddingType
+from tensorrt_llm.inputs.multimodal import MultimodalParams
 from tensorrt_llm.logger import logger
 from tensorrt_llm.lora_manager import HfLoraLoader
 from tensorrt_llm.models.convert_utils import split_matrix_tp
@@ -24,6 +25,7 @@ from ...inputs import (ExtraProcessedInputs, InputProcessor,
                        MultimodalPlaceholderMetadata,
                        MultimodalPlaceholderPlacement, TextPrompt,
                        register_input_processor)
+from ...llmapi.utils import download_hf_model
 from ...sampling_params import SamplingParams
 from ..attention_backend import AttentionMetadata
 from ..attention_backend.interface import (PositionalEmbeddingParams,
@@ -44,6 +46,8 @@ from .modeling_multimodal_utils import fuse_input_embeds
 from .modeling_speculative import SpecDecOneEngineForCausalLM
 from .modeling_utils import (DecoderModel, DecoderModelForCausalLM,
                              EagerFusionConfig, register_auto_model)
+
+DISAGG = os.getenv('TLLM_MULTIMODAL_DISAGGREGATED', '0') == '1'
 
 
 class Llama4Attention(Attention):
@@ -967,6 +971,46 @@ class LlamaForCausalLM(SpecDecOneEngineForCausalLM[LlamaModel, LlamaConfig]):
                 layer.next_attn = self.model.layers[idx + 1].self_attn
 
 
+class Llama4VisionEncoder(nn.Module):
+
+    def __init__(self, model_config: ModelConfig[Llama4Config], *args,
+                 **kwargs):
+        super().__init__()
+        self.pretrained_config = model_config.pretrained_config
+        self.device = f"cuda:{model_config.mapping.rank}"
+
+        model_path = self.pretrained_config._name_or_path
+        if os.path.isdir(model_path):
+            local_model_path = model_path
+        else:
+            local_model_path = download_hf_model(model_path)
+
+        self.dtype = self.pretrained_config.text_config.torch_dtype
+        module_dict = nn.ModuleDict({
+            "vision_model":
+            Llama4VisionModel(self.pretrained_config.vision_config),
+            "multi_modal_projector":
+            Llama4MultiModalProjector(self.pretrained_config),
+        })
+        load_sharded_checkpoint(module_dict, local_model_path, strict=False)
+
+        self.vision_model = module_dict["vision_model"].to(self.device)
+        self.mm_projector = module_dict["multi_modal_projector"].to(self.device)
+
+    @torch.inference_mode()
+    def forward(self, multimodal_params: List[MultimodalParams]):
+        pixel_values = [
+            multimodal_param.multimodal_data["image"]["pixel_values"]
+            for multimodal_param in multimodal_params
+        ]
+        pixel_values = torch.cat(pixel_values,
+                                 dim=0).to(self.device).to(torch.float32)
+        image_features = self.vision_model(
+            pixel_values).last_hidden_state.flatten(0, 1)
+        image_features = self.mm_projector(image_features)
+        return [image_features]
+
+
 class Llama4InputProcessor(InputProcessor):
 
     def __init__(self,
@@ -987,13 +1031,6 @@ class Llama4InputProcessor(InputProcessor):
         self.image_token = self.processor.img_patch_token
         self.image_token_start_index = self.model_config.boi_token_index
         self.image_token_end_index = self.model_config.eoi_token_index
-        self.encoder = nn.ModuleDict({
-            "vision_model":
-            Llama4VisionModel(model_config.vision_config),
-            "multi_modal_projector":
-            Llama4MultiModalProjector(model_config)
-        }).cuda()
-        load_sharded_checkpoint(self.encoder, model_path, strict=False)
 
     def attach_multimodal_embeddings(
         self, inputs: TextPrompt, multimodal_embedding: Dict[str,
@@ -1153,16 +1190,14 @@ class Llama4InputProcessor(InputProcessor):
             add_special_tokens=sampling_params.add_special_tokens,
             **truncate_kwargs)
         if images:
-            token_ids, pixel_values = processed["input_ids"].squeeze(
-            ), processed["pixel_values"]
-            mm_embeds = self.encoder.vision_model(
-                pixel_values.float().cuda()).last_hidden_state.flatten(0, 1)
-            mm_embeds = self.encoder.multi_modal_projector(mm_embeds)
+            token_ids = processed["input_ids"].squeeze()
             # for fuse_input_embeds
             token_ids[token_ids == self.image_token_index] = self.vocab_size + 1
 
             multimodal_data = {}
-            multimodal_data["multimodal_embedding"] = mm_embeds
+            multimodal_data["image"] = {
+                "pixel_values": processed["pixel_values"],
+            }
             return token_ids.tolist(), {"multimodal_data": multimodal_data}
         else:
             return processed["input_ids"].squeeze().tolist(), {}
@@ -1183,6 +1218,9 @@ class Llama4ForConditionalGeneration(SpecDecOneEngineForCausalLM[Llama4Model,
         self,
         model_config: ModelConfig[Llama4Config],
     ):
+        # Keep a reference to the full config (with vision) before switching to text-only
+        full_model_config = model_config
+
         # TODO: figure out a better way to handle multimodality.
         model_config = copy.copy(model_config)
         architectures = model_config.pretrained_config.architectures
@@ -1190,6 +1228,9 @@ class Llama4ForConditionalGeneration(SpecDecOneEngineForCausalLM[Llama4Model,
         model_config.pretrained_config.architectures = architectures
         super().__init__(Llama4Model(model_config), model_config)
         self.preload_weight_modules = self.model.preload_weight_modules
+
+        if not DISAGG:
+            self.mm_encoder = Llama4VisionEncoder(full_model_config)
 
     def forward(
         self,
@@ -1204,10 +1245,14 @@ class Llama4ForConditionalGeneration(SpecDecOneEngineForCausalLM[Llama4Model,
         multimodal_params = kwargs.get("multimodal_params", [])
         mm_embeds = []
         if len(multimodal_params) > 0:
-            mm_embeds = [
-                multimodal_param.multimodal_data["multimodal_embedding"]
-                for multimodal_param in multimodal_params
-            ]
+            if not DISAGG:
+                mm_embeds = self.mm_encoder.forward(multimodal_params)
+            else:
+                mm_embeds = [
+                    multimodal_param.multimodal_data["multimodal_embedding"]
+                    for multimodal_param in multimodal_params
+                ]
+
         input_ids, inputs_embeds = fuse_input_embeds(self.model.embed_tokens,
                                                      input_ids, mm_embeds)
         return super().forward(attn_metadata,
@@ -1228,7 +1273,16 @@ class Llama4ForConditionalGeneration(SpecDecOneEngineForCausalLM[Llama4Model,
         return super().infer_max_seq_len()
 
     def load_weights(self, weights: Dict, weight_mapper: BaseWeightMapper):
-        super().load_weights(weights, weight_mapper)
+        # Temporarily detach mm_encoder so the TRT-LLM loader doesn't try to load it
+        had_mm_encoder = hasattr(self, "mm_encoder")
+        saved_mm_encoder = getattr(self, "mm_encoder", None)
+        if had_mm_encoder:
+            delattr(self, "mm_encoder")
+        try:
+            super().load_weights(weights, weight_mapper)
+        finally:
+            if had_mm_encoder:
+                self.mm_encoder = saved_mm_encoder
 
         for idx, layer in enumerate(
                 self.model.layers[:self.config.num_hidden_layers]):

--- a/tensorrt_llm/_torch/models/modeling_llama.py
+++ b/tensorrt_llm/_torch/models/modeling_llama.py
@@ -979,6 +979,8 @@ class Llama4VisionEncoder(nn.Module):
         self.device = f"cuda:{model_config.mapping.rank}"
 
         self.dtype = self.pretrained_config.text_config.torch_dtype
+
+    def load_weights(self):
         module_dict = nn.ModuleDict({
             "vision_model":
             Llama4VisionModel(self.pretrained_config.vision_config),
@@ -1268,6 +1270,9 @@ class Llama4ForConditionalGeneration(SpecDecOneEngineForCausalLM[Llama4Model,
         return super().infer_max_seq_len()
 
     def load_weights(self, weights: Dict, weight_mapper: BaseWeightMapper):
+        if not DISAGG:
+            self.mm_encoder.load_weights()
+
         # Temporarily detach mm_encoder so the TRT-LLM loader doesn't try to load it
         had_mm_encoder = hasattr(self, "mm_encoder")
         saved_mm_encoder = getattr(self, "mm_encoder", None)


### PR DESCRIPTION
Following https://github.com/NVIDIA/TensorRT-LLM/pull/6478
Make vision model standalone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added an optional dedicated vision encoder path for multimodal image inputs, controllable via an environment flag.
  - Improved handling of image features and automatic fetching of required vision components when needed.

- Documentation
  - Updated the Multimodal Feature Support Matrix to reflect that Llama 4 now supports an image-feature encoder pathway.

- Refactor
  - Decoupled vision processing from the text pathway to enhance reliability, configurability, and future extensibility without changing APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up
-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
