### PR TITLE
[TRTLLM-7094][feat] Gpt-oss reasoning content parsing in trtllm-serve

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -67,3 +67,4 @@ soundfile
 triton==3.3.1; platform_machine == "x86_64"
 tiktoken
 blobfile
+openai_harmony

--- a/tensorrt_llm/inputs/utils.py
+++ b/tensorrt_llm/inputs/utils.py
@@ -361,7 +361,7 @@ def add_multimodal_placeholders(model_type: str, text_prompt: str,
 
 def resolve_hf_chat_template(
     tokenizer: TokenizerBase,
-    processor: ProcessorMixin,
+    processor: ProcessorMixin | None,
     chat_template: Optional[str],
     tools: Optional[list[dict[str, Any]]],
 ) -> Optional[str]:
@@ -401,7 +401,7 @@ def apply_chat_template(
     *,
     model_type: str,
     tokenizer: Union[TransformersTokenizer, TokenizerBase],
-    processor: ProcessorMixin,
+    processor: ProcessorMixin | None,
     conversation: list[ConversationMessage],
     add_generation_prompt: bool,
     mm_placeholder_counts: dict[str, int],

--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -478,7 +478,6 @@ class ChatCompletionRequest(OpenAIBaseModel):
                                 ChatCompletionNamedToolChoiceParam]] = "none"
     #FIXME: maybe remove this field because it could be added to chat_template_kwargs
     reasoning_effort: Optional[Literal["low", "medium", "high"]] = None
-    use_harmony: bool = False
     user: Optional[str] = None
 
     # doc: begin-chat-completion-sampling-params

--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -476,6 +476,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
     tools: Optional[List[ChatCompletionToolsParam]] = None
     tool_choice: Optional[Union[Literal["none"],
                                 ChatCompletionNamedToolChoiceParam]] = "none"
+    reasoning_effort: Optional[Literal["low", "medium", "high"]] = None
     user: Optional[str] = None
 
     # doc: begin-chat-completion-sampling-params

--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -476,7 +476,6 @@ class ChatCompletionRequest(OpenAIBaseModel):
     tools: Optional[List[ChatCompletionToolsParam]] = None
     tool_choice: Optional[Union[Literal["none"],
                                 ChatCompletionNamedToolChoiceParam]] = "none"
-    #FIXME: maybe remove this field because it could be added to chat_template_kwargs
     reasoning_effort: Optional[Literal["low", "medium", "high"]] = None
     user: Optional[str] = None
 

--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -476,7 +476,9 @@ class ChatCompletionRequest(OpenAIBaseModel):
     tools: Optional[List[ChatCompletionToolsParam]] = None
     tool_choice: Optional[Union[Literal["none"],
                                 ChatCompletionNamedToolChoiceParam]] = "none"
+    #FIXME: maybe remove this field because it could be added to chat_template_kwargs
     reasoning_effort: Optional[Literal["low", "medium", "high"]] = None
+    use_harmony: bool = False
     user: Optional[str] = None
 
     # doc: begin-chat-completion-sampling-params

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -308,6 +308,9 @@ class OpenAIServer:
             if request.prompt_token_ids is not None:
                 prompt = request.prompt_token_ids
             else:
+                chat_template_kwargs = request.chat_template_kwargs or {}
+                if request.reasoning_effort is not None:
+                    chat_template_kwargs["reasoning_effort"] = request.reasoning_effort
                 prompt: str = apply_chat_template(
                     model_type=self.model_config.model_type,
                     tokenizer=self.tokenizer,
@@ -318,7 +321,7 @@ class OpenAIServer:
                     tools=tool_dicts,
                     documents=request.documents,
                     chat_template=request.chat_template,
-                    chat_template_kwargs=request.chat_template_kwargs or {},
+                    chat_template_kwargs=chat_template_kwargs,
                 )
             prompt = prompt_inputs(prompt)
 

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -342,10 +342,10 @@ class OpenAIServer:
             if use_harmony:
                 encoding = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
                 harmony_stop_token_ids = encoding.stop_tokens_for_assistant_actions()
-                if stop_token_ids := sampling_params.stop_token_ids:
-                    stop_token_ids += harmony_stop_token_ids
+                if sampling_params.stop_token_ids:
+                    sampling_params.stop_token_ids += harmony_stop_token_ids
                 else:
-                    stop_token_ids = harmony_stop_token_ids
+                    sampling_params.stop_token_ids = harmony_stop_token_ids
 
             disaggregated_params = to_llm_disaggregated_params(request.disaggregated_params)
             promise = self.llm.generate_async(

--- a/tensorrt_llm/serve/postprocess_handlers.py
+++ b/tensorrt_llm/serve/postprocess_handlers.py
@@ -80,7 +80,7 @@ def create_logprobs(token_ids: List[int],
     return chat_logprobs
 
 
-def apply_reasoning_parser(args: ChatPostprocArgs, output_index: int, text: str, streaming: bool) -> Tuple[bool, str, str]:
+def apply_reasoning_parser(args: ChatPostprocArgs, output_index: int, text: str, streaming: bool) -> Tuple[bool, str | None, str | None]:
     reasoning_parser = None
     if args.reasoning_parser is not None:
         if output_index not in args.reasoning_parser_dict:
@@ -94,7 +94,7 @@ def apply_reasoning_parser(args: ChatPostprocArgs, output_index: int, text: str,
             result = reasoning_parser.parse(text)
         else:
             result = reasoning_parser.parse_delta(text)
-        in_reasoning, content, reasoning_text = result.in_reasoning, result.content, result.reasoning_text
+        in_reasoning, content, reasoning_text = result.in_reasoning, result.content, result.reasoning_content
     else:
         in_reasoning, content, reasoning_text = False, text, None
 

--- a/tensorrt_llm/serve/postprocess_handlers.py
+++ b/tensorrt_llm/serve/postprocess_handlers.py
@@ -59,7 +59,6 @@ class ChatPostprocArgs(PostprocArgs):
             tool_choice=request.tool_choice,
             stream_options=request.stream_options,
             return_logprobs=request.logprobs,
-            use_harmony=request.use_harmony,
         )
 
 

--- a/tests/integration/defs/test_e2e.py
+++ b/tests/integration/defs/test_e2e.py
@@ -1441,6 +1441,13 @@ def test_trtllm_serve_lora_example(llm_root, llm_venv):
          str(test_root / "_test_trtllm_serve_lora.py")])
 
 
+def test_openai_harmony(llm_root, llm_venv):
+    test_root = unittest_path() / "llmapi" / "apps"
+    llm_venv.run_cmd(
+        ["-m", "pytest",
+         str(test_root / "_test_openai_harmony.py")])
+
+
 @pytest.mark.parametrize("backend", ["pytorch", "trt"])
 def test_openai_misc_example(llm_root, llm_venv, backend: str):
     test_root = unittest_path() / "llmapi" / "apps"

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -90,6 +90,7 @@ l0_h100:
   - test_e2e.py::test_trtllm_bench_request_rate_and_concurrency[enable_concurrency-enable_request_rate] # negative test
   - test_e2e.py::test_trtllm_bench_help_sanity[meta-llama/Llama-3.1-8B]
   - test_e2e.py::test_ptp_quickstart_multimodal[gemma-3-27b-it-gemma/gemma-3-27b-it-image-True]
+  - test_e2e.py::test_openai_harmony
 - condition:
     ranges:
       system_gpu_count:

--- a/tests/unittest/llmapi/apps/_test_openai_harmony.py
+++ b/tests/unittest/llmapi/apps/_test_openai_harmony.py
@@ -1,0 +1,39 @@
+import openai
+import pytest
+
+from ..test_llm import get_model_path
+from .openai_server import RemoteOpenAIServer
+
+
+@pytest.fixture(scope="module", ids=["gpt-oss-20b"])
+def model_name():
+    return "gpt_oss/gpt-oss-20b"
+
+
+@pytest.fixture(scope="module")
+def server(model_name: str):
+    model_path = get_model_path(model_name)
+    with RemoteOpenAIServer(model_path) as remote_server:
+        yield remote_server
+
+
+@pytest.fixture(scope="module")
+def async_client(server: RemoteOpenAIServer):
+    return server.get_async_client()
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_chat_completion_gpt_oss(async_client: openai.AsyncOpenAI):
+    response = await async_client.chat.completions.create(
+        model="gpt_oss/gpt-oss-20b",
+        messages=[{
+            "role":
+            "system",
+            "content":
+            "You are ChatGPT, a large language model trained by OpenAI"
+        }, {
+            "role": "user",
+            "content": "Which one is larger, 9.11 or 9.9?"
+        }])
+    assert response.choices[0].message.content is not None
+    assert response.choices[0].message.reasoning_content is not None


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Harmony support for GPT-OSS: reasoning-aware streaming and enhanced stop-token handling.
  - Chat Completions API accepts optional reasoning_effort (“low”, “medium”, “high”).
  - More flexible chat templating: templates work when a processor is omitted.

- **Tests**
  - Added unit and integration tests validating Harmony-based GPT-OSS chat completions and reasoning output.

- **Chores**
  - Added openai_harmony dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up
-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
