### PR TITLE
Support W4A8 method of AngleSlim tool

### DIFF
--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -356,7 +356,7 @@ class ModelConfig(Generic[TConfig]):
         json_exclude_quantization = json_quant_configs.get(
             'exclude_quantization', None)
         if json_exclude_quantization:
-            quant_config.exclude_quant_config = {
+            quant_config.exclude_quantization = {
                 "quant_algo":
                 QuantAlgo(
                     json_exclude_quantization.get('quant_algo', None).upper())
@@ -456,11 +456,11 @@ class ModelConfig(Generic[TConfig]):
         else:
             quant_config.exclude_modules = hf_quant_config.get("ignored_layers")
 
-        # set exclude_quant_config
+        # set exclude_quantization
         hf_ignored_quantization_config = hf_quant_config.get(
             "ignored_quantization_config")
         if hf_ignored_quantization_config:
-            quant_config.exclude_quant_config = {
+            quant_config.exclude_quantization = {
                 "kv_cache_quant_algo":
                 QuantAlgo(
                     hf_ignored_quantization_config.get(

--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -350,19 +350,28 @@ class ModelConfig(Generic[TConfig]):
             json_quant_configs.get('activation_scheme', None).upper()
         ) if json_quant_configs.get("activation_scheme") else None
 
-        json_exclude_quant_configs = json_quant_configs.get('exclude_quantization', None)
-        if json_exclude_quant_configs:
+        json_exclude_quantization= json_quant_configs.get('exclude_quantization', None)
+        if json_exclude_quantization:
             quant_config.exclude_quant_config = {
                 "quant_algo": QuantAlgo(
-                    json_exclude_quant_configs.get('quant_algo', None).upper()
-                ) if json_exclude_quant_configs.get("quant_algo") else None,
+                    json_exclude_quantization.get('quant_algo', None).upper()
+                ) if json_exclude_quantization.get("quant_algo") else None,
                 "kv_cache_quant_algo": QuantAlgo(
-                    json_exclude_quant_configs.get("kv_cache_quant_algo").upper()
-                ) if json_exclude_quant_configs.get("kv_cache_quant_algo") else None,
+                    json_exclude_quantization.get("kv_cache_quant_algo").upper()
+                ) if json_exclude_quantization.get("kv_cache_quant_algo") else None,
                 "activation_scheme": ActivationScheme(
-                    json_exclude_quant_configs.get('activation_scheme', None).upper()
-                ) if json_exclude_quant_configs.get("activation_scheme") else None,
+                    json_exclude_quantization.get('activation_scheme', None).upper()
+                ) if json_exclude_quantization.get("activation_scheme") else None,
+                "group_size": json_exclude_quantization.get('group_size', None),
             }
+            if quant_config.exclude_quantization["quant_algo"] in [QuantAlgo.FP8_BLOCK_SCALES, QuantAlgo.W4A8_AWQ]:
+                if quant_config.exclude_quantization["group_size"] is None:
+                    quant_config.exclude_quantization["group_size"] = 128
+
+        if quant_config.quant_algo in [QuantAlgo.FP8_BLOCK_SCALES, QuantAlgo.W4A8_AWQ]:
+            if quant_config.group_size is None:
+                quant_config.group_size = 128
+
         return quant_config, layer_quant_config
 
     @staticmethod
@@ -409,8 +418,11 @@ class ModelConfig(Generic[TConfig]):
                 'block.*.attn.out', 'block.*.mlp.gate', 'block.*.attn.qkv',
                 'embedding', 'unembedding'
             ]
+        elif hf_quant_config.get("quant_method") == "fp8":
+            quant_config.quant_algo = QuantAlgo.FP8
         elif hf_quant_config.get("quant_method") == "w4a8_awq":
             quant_config.quant_algo = QuantAlgo.W4A8_AWQ
+            quant_config.group_size = hf_quant_config.get("weight_group_size", 128)
         else:
             raise NotImplementedError(f"Unsupported quantization_config: {hf_quant_config}.")
 
@@ -422,25 +434,40 @@ class ModelConfig(Generic[TConfig]):
             if hf_quant_config.get("activation_scheme") else None
         # set exclude_modules
         if quant_config.exclude_modules:
-            if hf_quant_config.get("ignored_modules"):
-                quant_config.exclude_modules += hf_quant_config.get("ignored_modules")
+            if hf_quant_config.get("ignored_layers"):
+                quant_config.exclude_modules += hf_quant_config.get("ignored_layers")
         else:
-            quant_config.exclude_modules = hf_quant_config.get("ignored_modules")
+            quant_config.exclude_modules = hf_quant_config.get("ignored_layers")
 
         # set exclude_quant_config
         hf_ignored_quantization_config = hf_quant_config.get("ignored_quantization_config")
         if hf_ignored_quantization_config:
             quant_config.exclude_quant_config = {
-                "quant_algo": QuantAlgo(
-                    hf_ignored_quantization_config.get("quant_method").upper()
-                ) if hf_ignored_quantization_config.get("quant_method") else None,
                 "kv_cache_quant_algo": QuantAlgo(
                     hf_ignored_quantization_config.get("kv_cache_quant_method").upper()
                 ) if hf_ignored_quantization_config.get("kv_cache_quant_method") else None,
                 "activation_scheme": ActivationScheme(
                     hf_ignored_quantization_config.get("activation_scheme").upper()
                 ) if hf_ignored_quantization_config.get("activation_scheme") else None,
+                "group_size": 128,
             }
+            if hf_ignored_quantization_config.get(
+                    "quant_method") == "fp8" and hf_ignored_quantization_config.get("weight_block_size", []):
+                quant_config.exclude_quantization["quant_algo"] = QuantAlgo.FP8_BLOCK_SCALES
+                block_size = hf_ignored_quantization_config.get("weight_block_size", [])
+                assert tuple(block_size) == (
+                    128,
+                    128), "FP8_BLOCK_SCALES only supports block_size=(128,128)"
+                quant_config.exclude_quantization["group_size"] = block_size[0]
+            elif hf_ignored_quantization_config.get("quant_method") == "fp8":
+                quant_config.exclude_quantization["quant_algo"] = QuantAlgo.FP8
+            elif hf_ignored_quantization_config.get("quant_method") == "w4a8_awq":
+                quant_config.exclude_quantization["quant_algo"] = QuantAlgo.W4A8_AWQ
+                quant_config.exclude_quantization["group_size"] = hf_ignored_quantization_config.get(
+                    "weight_group_size", 128)
+            else:
+                raise NotImplementedError(f"Unsupported quantization_config.ignored_quantization_config: "
+                                          f"{hf_ignored_quantization_config}.")
 
         logger.info(f"Load quantization config from pretrained config, quant_config: {quant_config}")
 

--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -325,7 +325,8 @@ class ModelConfig(Generic[TConfig]):
         return quant_config, layer_quant_config
 
     @staticmethod
-    def load_angelslim_quant_config(quant_config_file, checkpoint_dir, moe_backend):
+    def load_angelslim_quant_config(quant_config_file, checkpoint_dir,
+                                    moe_backend):
         quant_config = QuantConfig()
         layer_quant_config = None
 
@@ -621,7 +622,7 @@ class ModelConfig(Generic[TConfig]):
             quant_config, layer_quant_config = cls.load_modelopt_quant_config(
                 quant_config_file, checkpoint_dir, moe_backend)
         elif quant_config_file := cached_file(checkpoint_dir,
-                                            'angelslim_hf_quant_config.json'):
+                                              'angelslim_hf_quant_config.json'):
             quant_config, layer_quant_config = cls.load_angelslim_quant_config(
                 quant_config_file, checkpoint_dir, moe_backend)
         # quantized ckpt in other formats

--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -368,8 +368,10 @@ class ModelConfig(Generic[TConfig]):
                 'block.*.attn.out', 'block.*.mlp.gate', 'block.*.attn.qkv',
                 'embedding', 'unembedding'
             ]
+        # FP8 per-tensor checkpoints.
         elif hf_quant_config.get("quant_method") == "fp8":
             quant_config.quant_algo = QuantAlgo.FP8
+        # W4A8_AWQ checkpoints.
         elif hf_quant_config.get("quant_method") == "w4a8_awq":
             quant_config.quant_algo = QuantAlgo.W4A8_AWQ
             quant_config.group_size = hf_quant_config.get(

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -290,7 +290,8 @@ class DeepseekV3WeightLoader:
                 if names[-1] == "kv_b_proj":
                     # TODO: remove weight_dequant after enabling fp8_bmm
                     dequant_kv_b_proj = self.model_config.quant_config.is_module_excluded_from_quantization(
-                        names[-1]) and self.model_config.quant_config.exclude_quantization is None
+                        names[-1]
+                    ) and self.model_config.quant_config.exclude_quantization is None
                     if dequant_kv_b_proj:
                         kv_b_proj, k_b_proj_trans = load_kv_b_proj_and_k_b_proj_trans_dequant(
                             name)

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -290,7 +290,7 @@ class DeepseekV3WeightLoader:
                 if names[-1] == "kv_b_proj":
                     # TODO: remove weight_dequant after enabling fp8_bmm
                     dequant_kv_b_proj = self.model_config.quant_config.is_module_excluded_from_quantization(
-                        names[-1])
+                        names[-1]) and self.model_config.quant_config.exclude_quantization is None
                     if dequant_kv_b_proj:
                         kv_b_proj, k_b_proj_trans = load_kv_b_proj_and_k_b_proj_trans_dequant(
                             name)

--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -478,17 +478,17 @@ class DecoderModelForCausalLM(nn.Module,
         """
         quant_config = self.model_config.quant_config
         kv_cache_quant_algo = None
-        if quant_config:
-            kv_cache_quant_algo = quant_config.kv_cache_quant_algo
         quant_algo = None
         activation_scheme = None
         group_size = 128
-        exclude_quantization = quant_config.exclude_quantization
-        if exclude_quantization:
-            quant_algo = exclude_quantization.get("quant_algo", None)
-            activation_scheme = exclude_quantization.get(
-                "activation_scheme", None)
-            group_size = exclude_quantization.get("group_size", 128)
+        if quant_config:
+            kv_cache_quant_algo = quant_config.kv_cache_quant_algo
+            exclude_quantization = quant_config.exclude_quantization
+            if exclude_quantization:
+                quant_algo = exclude_quantization.get("quant_algo", None)
+                activation_scheme = exclude_quantization.get(
+                    "activation_scheme", None)
+                group_size = exclude_quantization.get("group_size", 128)
         new_config = QuantConfig(
             quant_algo=quant_algo,
             kv_cache_quant_algo=kv_cache_quant_algo,

--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -482,12 +482,18 @@ class DecoderModelForCausalLM(nn.Module,
             kv_cache_quant_algo = quant_config.kv_cache_quant_algo
         quant_algo = None
         activation_scheme = None
-        exclude_quant_config = quant_config.exclude_quant_config
-        if exclude_quant_config:
-            quant_algo = exclude_quant_config.get("quant_algo", None)
-            activation_scheme = exclude_quant_config.get("activation_scheme", None)
+        group_size = 128
+        exclude_quantization = quant_config.exclude_quantization
+        if exclude_quantization:
+            quant_algo = exclude_quantization.get("quant_algo", None)
+            activation_scheme = exclude_quantization.get("activation_scheme", None)
+            group_size = exclude_quantization.get("group_size", 128)
         new_config = QuantConfig(
-            quant_algo=quant_algo, kv_cache_quant_algo=kv_cache_quant_algo, activation_scheme=activation_scheme)
+            quant_algo=quant_algo,
+            kv_cache_quant_algo=kv_cache_quant_algo,
+            activation_scheme=activation_scheme,
+            group_size=group_size,
+        )
 
         if quant_config is not None:
             if quant_config.exclude_modules is not None:

--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -480,7 +480,14 @@ class DecoderModelForCausalLM(nn.Module,
         kv_cache_quant_algo = None
         if quant_config:
             kv_cache_quant_algo = quant_config.kv_cache_quant_algo
-        new_config = QuantConfig(kv_cache_quant_algo=kv_cache_quant_algo)
+        quant_algo = None
+        activation_scheme = None
+        exclude_quant_config = quant_config.exclude_quant_config
+        if exclude_quant_config:
+            quant_algo = exclude_quant_config.get("quant_algo", None)
+            activation_scheme = exclude_quant_config.get("activation_scheme", None)
+        new_config = QuantConfig(
+            quant_algo=quant_algo, kv_cache_quant_algo=kv_cache_quant_algo, activation_scheme=activation_scheme)
 
         if quant_config is not None:
             if quant_config.exclude_modules is not None:

--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -486,7 +486,8 @@ class DecoderModelForCausalLM(nn.Module,
         exclude_quantization = quant_config.exclude_quantization
         if exclude_quantization:
             quant_algo = exclude_quantization.get("quant_algo", None)
-            activation_scheme = exclude_quantization.get("activation_scheme", None)
+            activation_scheme = exclude_quantization.get(
+                "activation_scheme", None)
             group_size = exclude_quantization.get("group_size", 128)
         new_config = QuantConfig(
             quant_algo=quant_algo,

--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -1338,12 +1338,12 @@ class WInt4AFP8FusedMoEMethod(FusedMoEMethodBase):
         if w4a8_custom and has_fp8_weight_scale:
             all_w2_scales = torch.stack(
                 all_w2_scales) / all_w2_scales_fp8.unsqueeze(2)
-        if module.sm_version == 89:
-            w2_scales = torch.stack(all_w2_scales).to(torch.float16).view(
-                module.dtype)
         else:
-            w2_scales = torch.stack(all_w2_scales).to(torch.bfloat16).view(
-                module.dtype)
+            all_w2_scales = torch.stack(all_w2_scales)
+        if module.sm_version == 89:
+            w2_scales = all_w2_scales.to(torch.float16).view(module.dtype)
+        else:
+            w2_scales = all_w2_scales.to(torch.bfloat16).view(module.dtype)
 
         if module.weight_loading_mode == MoEWeightLoadingMode.VANILLA:
             w2_scales = w2_scales.permute(1, 2, 0)

--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -1127,17 +1127,21 @@ class WInt4AFP8FusedMoEMethod(FusedMoEMethodBase):
             if has_fp8_weight_scale:
                 all_w3_w1_scales_fp8_max = []
                 for expert_id in module.initial_local_expert_ids:
-                    w1_weight_scale_fp8 = load_weight_shard(weights[f"{expert_id}.w1.weight_scale"],
-                                                            device=self.device)
-                    w3_weight_scale_fp8 = load_weight_shard(weights[f"{expert_id}.w3.weight_scale"],
-                                                            device=self.device)
-                    all_w3_w1_scales_fp8_max.append(torch.max(w3_weight_scale_fp8, w1_weight_scale_fp8))
-                all_w3_w1_scales_fp8_max = torch.stack(all_w3_w1_scales_fp8_max).reshape(module.fc31_alpha.shape)
+                    w1_weight_scale_fp8 = load_weight_shard(
+                        weights[f"{expert_id}.w1.weight_scale"],
+                        device=self.device)
+                    w3_weight_scale_fp8 = load_weight_shard(
+                        weights[f"{expert_id}.w3.weight_scale"],
+                        device=self.device)
+                    all_w3_w1_scales_fp8_max.append(
+                        torch.max(w3_weight_scale_fp8, w1_weight_scale_fp8))
+                all_w3_w1_scales_fp8_max = torch.stack(
+                    all_w3_w1_scales_fp8_max).reshape(module.fc31_alpha.shape)
             else:
-                all_w3_w1_scales_fp8_max = torch.ones_like(module.fc31_alpha, device=self.device)
+                all_w3_w1_scales_fp8_max = torch.ones_like(module.fc31_alpha,
+                                                           device=self.device)
             module.fc31_alpha.data.copy_(
-                (all_w3_w1_scales_fp8_max *
-                 all_w3_w1_input_scales_max).float())
+                (all_w3_w1_scales_fp8_max * all_w3_w1_input_scales_max).float())
         else:
             # In vanilla ckpt (at least from ModelOpt), per-tensor input_scale and per-channel pre_quant_scale are separately stored
             all_w3_pre_quant_scales = [
@@ -1216,7 +1220,8 @@ class WInt4AFP8FusedMoEMethod(FusedMoEMethodBase):
             for expert_id in module.initial_local_expert_ids
         ]
         if w4a8_custom and has_fp8_weight_scale:
-            all_w3_scales = torch.stack(all_w3_scales) / all_w3_w1_scales_fp8_max.unsqueeze(2)
+            all_w3_scales = torch.stack(
+                all_w3_scales) / all_w3_w1_scales_fp8_max.unsqueeze(2)
         all_w1_scales = [
             load_weight_shard(weights[f"{expert_id}.w1.{weight_scale_name}"],
                               module.tp_size,
@@ -1226,14 +1231,14 @@ class WInt4AFP8FusedMoEMethod(FusedMoEMethodBase):
             for expert_id in module.initial_local_expert_ids
         ]
         if w4a8_custom and has_fp8_weight_scale:
-            all_w1_scales = torch.stack(all_w1_scales) / all_w3_w1_scales_fp8_max.unsqueeze(2)
-            all_w3_w1_scales = torch.cat(
-                [all_w3_scales,
-                 all_w1_scales], dim=-2)
+            all_w1_scales = torch.stack(
+                all_w1_scales) / all_w3_w1_scales_fp8_max.unsqueeze(2)
+            all_w3_w1_scales = torch.cat([all_w3_scales, all_w1_scales], dim=-2)
         else:
             all_w3_w1_scales = torch.cat(
                 [torch.stack(all_w3_scales),
-                 torch.stack(all_w1_scales)], dim=-2)
+                 torch.stack(all_w1_scales)],
+                dim=-2)
         if module.sm_version == 89:
             w3_w1_scales = all_w3_w1_scales.to(torch.float16).view(module.dtype)
         else:
@@ -1274,15 +1279,17 @@ class WInt4AFP8FusedMoEMethod(FusedMoEMethodBase):
             # In custom W4A8 ckpt, per-tensor weight_scale_2 is fused into alpha
             if has_fp8_weight_scale:
                 all_w2_scales_fp8 = [
-                    load_weight_shard(weights[f"{expert_id}.w2.weight_scale"], device=self.device)
+                    load_weight_shard(weights[f"{expert_id}.w2.weight_scale"],
+                                      device=self.device)
                     for expert_id in module.initial_local_expert_ids
                 ]
-                all_w2_scales_fp8 = torch.stack(all_w2_scales_fp8).reshape(module.fc2_alpha.shape)
+                all_w2_scales_fp8 = torch.stack(all_w2_scales_fp8).reshape(
+                    module.fc2_alpha.shape)
             else:
-                all_w2_scales_fp8 = torch.ones_like(module.fc2_alpha, device=self.device)
+                all_w2_scales_fp8 = torch.ones_like(module.fc2_alpha,
+                                                    device=self.device)
             module.fc2_alpha.data.copy_(
-                (all_w2_scales_fp8 *
-                 all_w2_input_scales_max).float())
+                (all_w2_scales_fp8 * all_w2_input_scales_max).float())
         else:
             # In vanilla ckpt (at least from ModelOpt), per-tensor input_scale and per-channel pre_quant_scale are separately stored
             all_w2_pre_quant_scales = [
@@ -1329,7 +1336,8 @@ class WInt4AFP8FusedMoEMethod(FusedMoEMethodBase):
             for expert_id in module.initial_local_expert_ids
         ]
         if w4a8_custom and has_fp8_weight_scale:
-            all_w2_scales = torch.stack(all_w2_scales) / all_w2_scales_fp8.unsqueeze(2)
+            all_w2_scales = torch.stack(
+                all_w2_scales) / all_w2_scales_fp8.unsqueeze(2)
         if module.sm_version == 89:
             w2_scales = torch.stack(all_w2_scales).to(torch.float16).view(
                 module.dtype)

--- a/tensorrt_llm/llmapi/llm_utils.py
+++ b/tensorrt_llm/llmapi/llm_utils.py
@@ -25,7 +25,8 @@ from ..llmapi.llm_args import TrtLlmArgs
 from ..logger import logger
 from ..mapping import Mapping
 from ..models.automodel import MODEL_MAP, AutoConfig, AutoModelForCausalLM
-from ..models.modeling_utils import PretrainedConfig, QuantAlgo, QuantConfig, ActivationScheme
+from ..models.modeling_utils import (ActivationScheme, PretrainedConfig,
+                                     QuantAlgo, QuantConfig)
 from ..module import Module
 from .build_cache import (BuildCache, BuildCacheConfig, CachedStage,
                           get_build_cache_config_from_env)
@@ -418,8 +419,8 @@ class ModelLoader:
                     quant_config.exclude_modules = ["*eh_proj"]
                     block_size = hf_quant_config.get("weight_block_size", [])
                     assert tuple(block_size) == (
-                        128,
-                        128), "FP8_BLOCK_SCALES only supports block_size=(128,128)"
+                        128, 128
+                    ), "FP8_BLOCK_SCALES only supports block_size=(128,128)"
                     quant_config.group_size = block_size[0]
                 elif hf_quant_config.get("quant_method") == "mxfp4":
                     from .._torch.model_config import ModelConfig
@@ -434,7 +435,8 @@ class ModelLoader:
                     quant_config.quant_algo = QuantAlgo.FP8
                 elif hf_quant_config.get("quant_method") == "w4a8_awq":
                     quant_config.quant_algo = QuantAlgo.W4A8_AWQ
-                    quant_config.group_size = hf_quant_config.get("weight_group_size", 128)
+                    quant_config.group_size = hf_quant_config.get(
+                        "weight_group_size", 128)
                 else:
                     raise NotImplementedError(
                         f"Unsupported quantization_config: {hf_quant_config}.")
@@ -450,26 +452,36 @@ class ModelLoader:
                 # set exclude_modules
                 if quant_config.exclude_modules:
                     if hf_quant_config.get("ignored_modules"):
-                        quant_config.exclude_modules += hf_quant_config.get("ignored_modules")
+                        quant_config.exclude_modules += hf_quant_config.get(
+                            "ignored_modules")
                 else:
-                    quant_config.exclude_modules = hf_quant_config.get("ignored_modules")
+                    quant_config.exclude_modules = hf_quant_config.get(
+                        "ignored_modules")
                 # set exclude_quant_config
-                hf_ignored_quantization_config = hf_quant_config.get("ignored_quantization_config")
+                hf_ignored_quantization_config = hf_quant_config.get(
+                    "ignored_quantization_config")
                 if hf_ignored_quantization_config:
                     quant_config.exclude_quant_config = {
-                        "quant_algo": QuantAlgo(
-                            hf_ignored_quantization_config.get("quant_method").upper()
-                        ) if hf_ignored_quantization_config.get("quant_method") else None,
-                        "kv_cache_quant_algo": QuantAlgo(
-                            hf_ignored_quantization_config.get("kv_cache_quant_method").upper()
-                        ) if hf_ignored_quantization_config.get("kv_cache_quant_method") else None,
-                        "activation_scheme": ActivationScheme(
-                            hf_ignored_quantization_config.get("activation_scheme").upper()
-                        ) if hf_ignored_quantization_config.get("activation_scheme") else None,
+                        "quant_algo":
+                        QuantAlgo(
+                            hf_ignored_quantization_config.get(
+                                "quant_method").upper())
+                        if hf_ignored_quantization_config.get("quant_method")
+                        else None,
+                        "kv_cache_quant_algo":
+                        QuantAlgo(
+                            hf_ignored_quantization_config.get(
+                                "kv_cache_quant_method").upper())
+                        if hf_ignored_quantization_config.get(
+                            "kv_cache_quant_method") else None,
+                        "activation_scheme":
+                        ActivationScheme(
+                            hf_ignored_quantization_config.get(
+                                "activation_scheme").upper()) if
+                        hf_ignored_quantization_config.get("activation_scheme")
+                        else None,
                     }
-                logger.info(
-                    f"Detected quantization_config: {quant_config}."
-                )
+                logger.info(f"Detected quantization_config: {quant_config}.")
                 return True
 
         return False

--- a/tensorrt_llm/llmapi/llm_utils.py
+++ b/tensorrt_llm/llmapi/llm_utils.py
@@ -457,11 +457,11 @@ class ModelLoader:
                 else:
                     quant_config.exclude_modules = hf_quant_config.get(
                         "ignored_modules")
-                # set exclude_quant_config
+                # set exclude_quantization
                 hf_ignored_quantization_config = hf_quant_config.get(
                     "ignored_quantization_config")
                 if hf_ignored_quantization_config:
-                    quant_config.exclude_quant_config = {
+                    quant_config.exclude_quantization = {
                         "quant_algo":
                         QuantAlgo(
                             hf_ignored_quantization_config.get(

--- a/tensorrt_llm/models/modeling_utils.py
+++ b/tensorrt_llm/models/modeling_utils.py
@@ -45,7 +45,7 @@ from ..quantization.layers import (FP8Linear, Fp8RowwiseFusedGatedMLP,
                                    WeightOnlyQuantLinear,
                                    WeightOnlyQuantRowLinear)
 from ..quantization.mode import (KV_CACHE_QUANT_ALGO_LIST, QUANT_ALGO_LIST,
-                                 W8A8_SQ_PLUGIN_LIST, QuantAlgo)
+                                 W8A8_SQ_PLUGIN_LIST, QuantAlgo, ActivationScheme)
 from ..quantization.utils import fp4_utils
 from ..top_model_mixin import TopModelMixin
 from .convert_utils import weight_only_quantize_dict
@@ -143,6 +143,8 @@ class QuantConfig:
         pre_quant_scale (bool): Whether to use pre-quant scale for quantization. Defaults to False.
         exclude_modules (List[str], optional): The module name patterns that are skipped in quantization. Defaults to None.
         mamba_ssm_cache_dtype (str, optional): The data type for mamba SSM cache. Defaults to None.
+        exclude_quant_config  (Dict, optional): The model of exclude_modules will use exclude_quant_config.
+        activation_scheme (tensorrt_llm.quantization.mode.ActivationScheme, optional): The input of activation quantize scheme.
     """
     quant_algo: Optional[QuantAlgo] = None
     kv_cache_quant_algo: Optional[QuantAlgo] = None
@@ -154,6 +156,8 @@ class QuantConfig:
     pre_quant_scale: bool = False
     exclude_modules: Optional[List[str]] = None
     mamba_ssm_cache_dtype: Optional[str] = None
+    exclude_quant_config: Optional[Dict] = None
+    activation_scheme: Optional[ActivationScheme] = None
 
     @cached_property
     def quant_mode(self) -> QuantModeWrapper:

--- a/tensorrt_llm/models/modeling_utils.py
+++ b/tensorrt_llm/models/modeling_utils.py
@@ -45,7 +45,8 @@ from ..quantization.layers import (FP8Linear, Fp8RowwiseFusedGatedMLP,
                                    WeightOnlyQuantLinear,
                                    WeightOnlyQuantRowLinear)
 from ..quantization.mode import (KV_CACHE_QUANT_ALGO_LIST, QUANT_ALGO_LIST,
-                                 W8A8_SQ_PLUGIN_LIST, QuantAlgo, ActivationScheme)
+                                 W8A8_SQ_PLUGIN_LIST, ActivationScheme,
+                                 QuantAlgo)
 from ..quantization.utils import fp4_utils
 from ..top_model_mixin import TopModelMixin
 from .convert_utils import weight_only_quantize_dict

--- a/tensorrt_llm/models/modeling_utils.py
+++ b/tensorrt_llm/models/modeling_utils.py
@@ -143,7 +143,7 @@ class QuantConfig:
         pre_quant_scale (bool): Whether to use pre-quant scale for quantization. Defaults to False.
         exclude_modules (List[str], optional): The module name patterns that are skipped in quantization. Defaults to None.
         mamba_ssm_cache_dtype (str, optional): The data type for mamba SSM cache. Defaults to None.
-        exclude_quant_config  (Dict, optional): The model of exclude_modules will use exclude_quant_config.
+        exclude_quantization  (Dict, optional): The model of exclude_modules will use exclude_quantization.
         activation_scheme (tensorrt_llm.quantization.mode.ActivationScheme, optional): The input of activation quantize scheme.
     """
     quant_algo: Optional[QuantAlgo] = None
@@ -156,7 +156,7 @@ class QuantConfig:
     pre_quant_scale: bool = False
     exclude_modules: Optional[List[str]] = None
     mamba_ssm_cache_dtype: Optional[str] = None
-    exclude_quant_config: Optional[Dict] = None
+    exclude_quantization: Optional[Dict] = None
     activation_scheme: Optional[ActivationScheme] = None
 
     @cached_property

--- a/tensorrt_llm/quantization/mode.py
+++ b/tensorrt_llm/quantization/mode.py
@@ -473,3 +473,8 @@ class GroupwiseQuantAlgo:
     PRE_QUANT_SCALE = 4
     W4A8_ALPHA = 8
     INT8_WEIGHT = 16
+
+
+class ActivationScheme(StrEnum, metaclass=BaseEnumMeta):
+    STATIC = auto()
+    DYNAMIC = auto()

--- a/tests/unittest/api_stability/references/quant_config.yaml
+++ b/tests/unittest/api_stability/references/quant_config.yaml
@@ -31,6 +31,12 @@ methods:
       use_meta_recipe:
         annotation: bool
         default: false
+      exclude_quantization:
+        annotation: Optional[dict]
+        default: null
+      activation_scheme:
+        annotation: Optional[tensorrt_llm.quantization.mode.ActivationScheme]
+        default: null
     return_annotation: None
   from_dict:
     parameters:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added support for Angelslim quantization configs when loading pretrained models.
  - Expanded HF quantization config support: w4a8_awq and fp8 methods, kv-cache quantization, activation schemes (STATIC/DYNAMIC), module exclusions, and per-module override configs.
  - Configurable weight name in MoE backends (supports qweight/weight paths) and enriched per-expert FP8/FP4 scale handling, plus SM100-specific resmoothing.
  - Added logging of detected quantization settings.
- Bug Fixes
  - Corrected dequantization handling for certain DeepSeek V3 weights to respect exclusion settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up
-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
