### PR TITLE
[TRTLLM-7155][feat] Unify sampler handle logits implementation.

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/executor_request_queue.py
+++ b/tensorrt_llm/_torch/pyexecutor/executor_request_queue.py
@@ -704,8 +704,9 @@ class ExecutorRequestQueue:
             position_blocks.append(position_block.tolist()[0])
         return ctx_blocks, position_blocks, padding
 
-    def set_exclude_last_generation_logits(
-            self, disable_overlap_scheduler: bool) -> None:
+    def set_exclude_last_generation_logits(self,
+                                           disable_overlap_scheduler: bool,
+                                           pp_size: int) -> None:
         # When overlap scheduler is enabled then when starting to handle a new prompt,
         # sample_async is called twice before the first call to update_requests:
         # - 1st time as a context request that handles on the 1st generated token
@@ -717,7 +718,7 @@ class ExecutorRequestQueue:
         # logits storage contains the logits of both the token update_requests should work
         # on, and also its next token. Thus, excluding the last generation logits from any
         # getter is required.
-        self.should_exclude_last_generation_logits = not disable_overlap_scheduler
+        self.should_exclude_last_generation_logits = not disable_overlap_scheduler and pp_size == 1
 
     def _should_exclude_last_generation_logits(self) -> bool:
         return self.should_exclude_last_generation_logits

--- a/tensorrt_llm/_torch/pyexecutor/executor_request_queue.py
+++ b/tensorrt_llm/_torch/pyexecutor/executor_request_queue.py
@@ -16,7 +16,6 @@ from tensorrt_llm.mapping import CpType
 from ..distributed import Distributed
 from .llm_request import (ExecutorRequest, LlmRequest,
                           executor_request_to_llm_request)
-from .sampler import Sampler
 
 SHUTDOWN_REQUEST_ID = -1
 
@@ -705,9 +704,8 @@ class ExecutorRequestQueue:
             position_blocks.append(position_block.tolist()[0])
         return ctx_blocks, position_blocks, padding
 
-    def set_exclude_last_generation_logits(self,
-                                           disable_overlap_scheduler: bool,
-                                           sampler: Sampler) -> None:
+    def set_exclude_last_generation_logits(
+            self, disable_overlap_scheduler: bool) -> None:
         # When overlap scheduler is enabled then when starting to handle a new prompt,
         # sample_async is called twice before the first call to update_requests:
         # - 1st time as a context request that handles on the 1st generated token

--- a/tensorrt_llm/_torch/pyexecutor/executor_request_queue.py
+++ b/tensorrt_llm/_torch/pyexecutor/executor_request_queue.py
@@ -16,7 +16,7 @@ from tensorrt_llm.mapping import CpType
 from ..distributed import Distributed
 from .llm_request import (ExecutorRequest, LlmRequest,
                           executor_request_to_llm_request)
-from .sampler import Sampler, TorchSampler
+from .sampler import Sampler
 
 SHUTDOWN_REQUEST_ID = -1
 
@@ -714,14 +714,12 @@ class ExecutorRequestQueue:
         # - 2nd time as a generation request that handles on the 2nd generated token.
         # and only after these two calls the sampler's update_request method is called.
         # So in a sampler that works by the expected flow of handling the logits in
-        # sample_async (TorchSampler is an anomaly that instead does that on
-        # update_requests), every update_request doesn't handle the newest token, but one
+        # sample_async, every update_request doesn't handle the newest token, but one
         # before it. Since all these calls work on the same request object, then its
         # logits storage contains the logits of both the token update_requests should work
         # on, and also its next token. Thus, excluding the last generation logits from any
-        # getter is required, when not using TorchSampler.
-        self.should_exclude_last_generation_logits = not disable_overlap_scheduler and not isinstance(
-            sampler, TorchSampler)
+        # getter is required.
+        self.should_exclude_last_generation_logits = not disable_overlap_scheduler
 
     def _should_exclude_last_generation_logits(self) -> bool:
         return self.should_exclude_last_generation_logits

--- a/tensorrt_llm/_torch/pyexecutor/handle_logits.py
+++ b/tensorrt_llm/_torch/pyexecutor/handle_logits.py
@@ -1,3 +1,4 @@
+from itertools import chain
 from typing import List
 
 import torch
@@ -25,10 +26,8 @@ class HandleLogits:
             num_context_logits_prefix_sum: Prefix sum of the logits
             is_generation_model: Bool containing whether the model is generation or not
         """
-        if not any(r.py_return_context_logits
-                   for r in context_requests) and not any(
-                       r.py_return_generation_logits
-                       for r in generation_requests):
+        if not any(r.py_return_context_logits or r.py_return_generation_logits
+                   for r in chain(context_requests, generation_requests)):
             return
 
         if not is_generation_model:

--- a/tensorrt_llm/_torch/pyexecutor/handle_logits.py
+++ b/tensorrt_llm/_torch/pyexecutor/handle_logits.py
@@ -25,6 +25,12 @@ class HandleLogits:
             num_context_logits_prefix_sum: Prefix sum of the logits
             is_generation_model: Bool containing whether the model is generation or not
         """
+        if not any(r.py_return_context_logits
+                   for r in context_requests) and not any(
+                       r.py_return_generation_logits
+                       for r in generation_requests):
+            return
+
         if not is_generation_model:
             for batch_index, llm_req in enumerate(context_requests):
                 logits_temp = logits[batch_index]

--- a/tensorrt_llm/_torch/pyexecutor/handle_logits.py
+++ b/tensorrt_llm/_torch/pyexecutor/handle_logits.py
@@ -11,13 +11,9 @@ class HandleLogits:
 
     @torch.inference_mode()
     @nvtx_range("handle_logits")
-    def __call__(
-        self,
-        context_requests: List[LlmRequest],
-        generation_requests: List[LlmRequest],
-        logits: torch.Tensor,
-        beam_width: int,
-    ):
+    def __call__(self, context_requests: List[LlmRequest],
+                 generation_requests: List[LlmRequest], logits: torch.Tensor,
+                 beam_width: int, num_context_logits_prefix_sum: list[int]):
         """Handles context and generation logits for a batch of requests.
 
         Args:
@@ -25,13 +21,8 @@ class HandleLogits:
             generation_requests: List of generation requests to process
             logits: Input logits tensor
             beam_width: Beam width for the generation requests
+            num_context_logits_prefix_sum: Prefix sum of the logits
         """
-        num_context_logits_prefix_sum = [0]
-        prefix_sum = 0
-        for request in context_requests:
-            prefix_sum += request.context_chunk_size if request.py_return_context_logits else 1
-            num_context_logits_prefix_sum.append(prefix_sum)
-
         # Copy logits into decoderBuffers.logits
         for batch_index, llm_req in enumerate(context_requests):
             logits_begin = num_context_logits_prefix_sum[batch_index]

--- a/tensorrt_llm/_torch/pyexecutor/handle_logits.py
+++ b/tensorrt_llm/_torch/pyexecutor/handle_logits.py
@@ -31,8 +31,7 @@ class HandleLogits:
             return
 
         if not is_generation_model:
-            for batch_index, llm_req in enumerate(context_requests):
-                logits_temp = logits[batch_index]
+            for llm_req, logits_temp in zip(context_requests, logits):
                 if logits_temp.ndim == 1:
                     # For BERT: Add axis to be compatible with LogitsStorage
                     # (LogitsStorage will interpret this dim as the prompt_len which

--- a/tensorrt_llm/_torch/pyexecutor/handle_logits.py
+++ b/tensorrt_llm/_torch/pyexecutor/handle_logits.py
@@ -12,10 +12,15 @@ class HandleLogits:
 
     @torch.inference_mode()
     @nvtx_range("handle_logits")
-    def __call__(self, context_requests: List[LlmRequest],
-                 generation_requests: List[LlmRequest], logits: torch.Tensor,
-                 beam_width: int, num_context_logits_prefix_sum: list[int],
-                 is_generation_model: bool):
+    def __call__(
+        self,
+        context_requests: List[LlmRequest],
+        generation_requests: List[LlmRequest],
+        logits: torch.Tensor,
+        beam_width: int,
+        num_context_logits_prefix_sum: list[int],
+        is_generation_model: bool,
+    ):
         """Handles context and generation logits for a batch of requests.
 
         Args:

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1528,10 +1528,9 @@ class PyExecutor:
                     prefix_sum += request.context_chunk_size if request.py_return_context_logits else 1
                     num_context_logits_prefix_sum.append(prefix_sum)
 
-                self._handle_logits(
-                    scheduled_batch, batch_outputs,
-                    num_context_logits_prefix_sum,
-                    self.model_engine.model.model_config.is_generation)
+                self._handle_logits(scheduled_batch, batch_outputs,
+                                    num_context_logits_prefix_sum,
+                                    self.sampler.is_generation_model())
                 return self.sampler.sample_async(scheduled_batch, batch_outputs,
                                                  num_context_logits_prefix_sum)
         except Exception as e:

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -245,7 +245,7 @@ class PyExecutor:
             is_disaggregated=kv_cache_transceiver is not None,
         )
         self.executor_request_queue.set_exclude_last_generation_logits(
-            self.disable_overlap_scheduler)
+            self.disable_overlap_scheduler, self.dist.pp_size)
 
         self.stats_lock = threading.Lock()
         self.stats = []

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -850,28 +850,34 @@ class PyExecutor:
                         # logits of the requests that have finished.
                         # NOTE: If the rank processing the logits ever becomes the same as
                         # the rank sending the responses, this code can be removed.
-                        finished_requests_results = [
-                            r.py_result
-                            for r in scheduled_batch.all_requests() if
-                            r.state == LlmRequestState.GENERATION_COMPLETE
-                            and (r.py_return_context_logits or r.py_return_generation_logits)
+                        finished_reqs = [
+                            r for r in previous_batch.sample_state.
+                            scheduled_requests.all_requests()
+                            if r.state == LlmRequestState.GENERATION_COMPLETE
+                            and (r.py_return_context_logits
+                                 or r.py_return_generation_logits)
                         ]
-                        if self.dist.is_first_pp_rank and len(
-                                finished_requests_results):
-                            (finished_requests_results,
-                                ) = self.dist.recv_object(
-                                    src=self.dist.last_pp_rank,
-                                    tag=prev_microbatch_id,
-                                )
-                        elif self.dist.is_last_pp_rank and len(
-                                finished_requests_results):
+                        if self.dist.is_first_pp_rank and len(finished_reqs):
+                            finished_reqs_py_results = [
+                                r.py_result for r in finished_reqs
+                            ]
+                            (finished_reqs_py_results,
+                             ) = self.dist.recv_object(
+                                 src=self.dist.prev_pp_rank,
+                                 tag=prev_microbatch_id,
+                             )
+                            for req, py_result in zip(finished_reqs,
+                                                      finished_reqs_py_results):
+                                req.py_result = py_result
+
+                        elif self.dist.is_last_pp_rank and len(finished_reqs):
                             if self.send_handles[
                                     prev_microbatch_id] is not None:
                                 self.send_handles[prev_microbatch_id].wait()
                             self.send_handles[
                                 prev_microbatch_id] = self.dist.isend_object(
-                                    (finished_requests_results, ),
-                                    dest=self.dist.first_pp_rank,
+                                    ([r.py_result for r in finished_reqs], ),
+                                    dest=self.dist.next_pp_rank,
                                     tag=prev_microbatch_id)
 
                         finished_requests = self._handle_responses()

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1534,8 +1534,10 @@ class PyExecutor:
                     prefix_sum += request.context_chunk_size if request.py_return_context_logits else 1
                     num_context_logits_prefix_sum.append(prefix_sum)
 
-                self._handle_logits(scheduled_batch, batch_outputs,
-                                    num_context_logits_prefix_sum)
+                self._handle_logits(
+                    scheduled_batch, batch_outputs,
+                    num_context_logits_prefix_sum,
+                    self.model_engine.model.model_config.is_generation)
                 return self.sampler.sample_async(scheduled_batch, batch_outputs,
                                                  num_context_logits_prefix_sum)
         except Exception as e:
@@ -1546,14 +1548,14 @@ class PyExecutor:
 
     @nvtx_range("_handle_logits")
     def _handle_logits(self, scheduled_batch, batch_outputs,
-                       num_context_logits_prefix_sum):
+                       num_context_logits_prefix_sum, is_generation_model):
         if any(r.py_return_context_logits or r.py_return_generation_logits
                for r in scheduled_batch.all_requests()):
             HandleLogits()(
                 scheduled_batch.context_requests,
                 scheduled_batch.generation_requests, batch_outputs["logits"],
                 self.sampler.beam_width(scheduled_batch.all_requests()),
-                num_context_logits_prefix_sum)
+                num_context_logits_prefix_sum, is_generation_model)
 
     @nvtx_range("_setup_sampler_step")
     def _setup_sampler_step(self, requests: ScheduledRequests):

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -845,6 +845,37 @@ class PyExecutor:
                                 previous_batch.scheduled_ctx_reqs)
 
                         self._handle_canceled_requests()
+
+                        # If logits were requested last PP rank has to send to first PP rank (who sends responses) the
+                        # logits of the requests that have finished.
+                        # NOTE: If the rank processing the logits ever becomes the same as
+                        # the rank sending the responses, this code can be removed.
+                        if any(r.py_return_context_logits
+                               or r.py_return_generation_logits
+                               for r in scheduled_batch.all_requests()):
+                            finished_requests_results = [
+                                r.py_result
+                                for r in scheduled_batch.all_requests() if
+                                r.state == LlmRequestState.GENERATION_COMPLETE
+                            ]
+                            if self.dist.is_first_pp_rank and len(
+                                    finished_requests_results):
+                                (finished_requests_results,
+                                 ) = self.dist.recv_object(
+                                     src=self.dist.last_pp_rank,
+                                     tag=prev_microbatch_id,
+                                 )
+                            elif self.dist.is_last_pp_rank and len(
+                                    finished_requests_results):
+                                if self.send_handles[
+                                        prev_microbatch_id] is not None:
+                                    self.send_handles[prev_microbatch_id].wait()
+                                self.send_handles[
+                                    prev_microbatch_id] = self.dist.isend_object(
+                                        (finished_requests_results, ),
+                                        dest=self.dist.first_pp_rank,
+                                        tag=prev_microbatch_id)
+
                         finished_requests = self._handle_responses()
                         previous_scheduled_batch = previous_batch.sample_state.scheduled_requests
                         self.resource_manager.update_resources(

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -175,7 +175,6 @@ class PyExecutor:
         self.guided_decoder = guided_decoder
         self.dist = dist
         self.disable_overlap_scheduler = disable_overlap_scheduler
-        self.max_num_sequences = max_num_sequences
 
         # enqueue and _fetch_new_requests used data
         self.active = True
@@ -1541,16 +1540,9 @@ class PyExecutor:
     def _handle_logits(self, scheduled_batch, batch_outputs):
         if any(r.py_return_context_logits or r.py_return_generation_logits
                for r in scheduled_batch.all_requests()):
-            num_context_logits_prefix_sum = [0]
-            prefix_sum = 0
-            for request in scheduled_batch.context_requests:
-                prefix_sum += request.context_chunk_size if request.py_return_context_logits else 1
-                num_context_logits_prefix_sum.append(prefix_sum)
-
             HandleLogits()(
                 scheduled_batch.context_requests,
                 scheduled_batch.generation_requests, batch_outputs["logits"],
-                num_context_logits_prefix_sum, self.max_num_sequences,
                 self.sampler.beam_width(scheduled_batch.all_requests()))
 
     @nvtx_range("_setup_sampler_step")

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -673,8 +673,7 @@ class TorchSampler(Sampler):
             for i in range(len(scheduled_requests.context_requests)):
                 gen_logits_indices.append(num_context_logits_prefix_sum[i + 1] -
                                           1)
-            for i in range(len(scheduled_requests.generation_requests)):
-                gen_logits_indices.append(total_context_logits + i)
+            gen_logits_indices.extend(range(total_context_logits, total_context_logits + len(scheduled_requests.generation_requests)))
             raw_logits = model_outputs["logits"][gen_logits_indices]
         else:
             raw_logits = model_outputs["logits"]

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -673,7 +673,10 @@ class TorchSampler(Sampler):
             for i in range(len(scheduled_requests.context_requests)):
                 gen_logits_indices.append(num_context_logits_prefix_sum[i + 1] -
                                           1)
-            gen_logits_indices.extend(range(total_context_logits, total_context_logits + len(scheduled_requests.generation_requests)))
+            gen_logits_indices.extend(
+                range(
+                    total_context_logits, total_context_logits +
+                    len(scheduled_requests.generation_requests)))
             raw_logits = model_outputs["logits"][gen_logits_indices]
         else:
             raw_logits = model_outputs["logits"]

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -112,8 +112,10 @@ class EarlyStopWithMMResult(Sampler):
     Use for skipping decoding step for non generation model, and return the batch_output (such as mm_embeddings)
     """
 
-    def sample_async(self, scheduled_requests: ScheduledRequests,
-                     model_outputs) -> SampleStateWithMMResult:
+    def sample_async(
+            self, scheduled_requests: ScheduledRequests, model_outputs,
+            num_context_logits_prefix_sum: list[int]
+    ) -> SampleStateWithMMResult:
         # from model_outputs to MultimodalResult
         data = MultimodalResult(mm_embeddings=model_outputs['mm_embeddings'])
         return SampleStateWithMMResult(scheduled_requests=scheduled_requests,

--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -268,8 +268,10 @@ class MTPSampler(TorchSampler):
             req.py_rewind_len = self.draft_len - (num_new_tokens - 1)
             self._request_common_handling(req, next_draft_tokens_list)
 
-    def sample_async(self, scheduled_requests: ScheduledRequests,
-                     outputs: dict[str, torch.Tensor]) -> SampleStateMTP:
+    def sample_async(
+            self, scheduled_requests: ScheduledRequests,
+            outputs: dict[str, torch.Tensor],
+            num_context_logits_prefix_sum: list[int]) -> SampleStateMTP:
         # new_tokens_device: accepted tokens, device tensor, shape: batch_size, nextn + 1
         # new_tokens_lens_device: accepted lengths, device tensor, shape: batch_size
         # next_draft_tokens_device: predicted draft tokens, device tensor, shape: batch_size, nextn

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -15,6 +15,7 @@
 import os
 
 import pytest
+import torch
 from defs.conftest import get_sm_version
 
 from tensorrt_llm import LLM
@@ -397,6 +398,40 @@ class TestLlama3_2_1B(LlmapiAccuracyTestHarness):
             assert llm.args.quant_config.quant_algo == QuantAlgo.FP8
             task = CnnDailymail(self.MODEL_NAME)
             task.evaluate(llm)
+
+    @skip_pre_hopper
+    @pytest.mark.skip_less_device(4)
+    @pytest.mark.parametrize("disable_overlap_scheduler", [True, False])
+    @pytest.mark.parametrize("pp_size", [2, 4], ids=["pp2", "pp4"])
+    def test_return_logits_pp(self, pp_size, disable_overlap_scheduler):
+        prompts = ["A B C"]
+
+        llm = LLM(model=self.MODEL_PATH,
+                  pipeline_parallel_size=pp_size,
+                  disable_overlap_scheduler=disable_overlap_scheduler)
+
+        sampling_params = SamplingParams(max_tokens=8,
+                                         return_context_logits=True,
+                                         return_generation_logits=True,
+                                         logprobs=True)
+
+        with llm:
+            for output in llm.generate(prompts,
+                                       sampling_params=sampling_params):
+                assert output.context_logits is not None
+                # NOTE: prompt_token_ids of "A B C" becomes [1, 319, 350, 315]
+                expected_len = len(prompts[0].split()) + 1
+                assert expected_len == output.context_logits.shape[0]
+
+                gen_logits = output.outputs[0].generation_logits
+                assert gen_logits is not None
+                assert gen_logits.ndim == 2
+                assert gen_logits.shape[0] == sampling_params.max_tokens
+                assert torch.argmax(
+                    gen_logits, dim=1).tolist() == output.outputs[0].token_ids
+
+                assert len(
+                    output.outputs[0].logprobs) == sampling_params.max_tokens
 
 
 class TestLlama3_2_3B(LlmapiAccuracyTestHarness):

--- a/tests/unittest/_torch/sampler/test_return_logits.py
+++ b/tests/unittest/_torch/sampler/test_return_logits.py
@@ -12,7 +12,7 @@ prompts = ["A B C"]
 global_kvcache_config = KvCacheConfig(max_tokens=10000)
 
 
-@force_ampere  # Save H100 resource
+# @force_ampere  # Save H100 resource
 @pytest.mark.parametrize("return_log_probs", [False, True])
 @pytest.mark.parametrize("gather_generation_logits", [False, True])
 @pytest.mark.parametrize("gather_context_logits", [False, True])

--- a/tests/unittest/_torch/sampler/test_return_logits.py
+++ b/tests/unittest/_torch/sampler/test_return_logits.py
@@ -27,9 +27,6 @@ def test_generate_with_return_logits(disable_overlap_scheduler: bool,
             or return_log_probs):  # prune space
         pytest.skip("Nothing to test")
 
-    if sampler_type == "TorchSampler" and gather_context_logits:
-        pytest.skip("TorchSampler does not support gather_context_logits")
-
     build_config = BuildConfig()
     build_config.gather_context_logits = gather_context_logits
 
@@ -93,9 +90,6 @@ def test_generate_async_with_return_logits(disable_overlap_scheduler: bool,
     if not (gather_context_logits or gather_generation_logits
             or return_log_probs):  # prune space
         pytest.skip("Nothing to test")
-
-    if sampler_type == "TorchSampler" and gather_context_logits:
-        pytest.skip("TorchSampler does not support gather_context_logits")
 
     build_config = BuildConfig()
     build_config.gather_context_logits = gather_context_logits

--- a/tests/unittest/_torch/sampler/test_return_logits.py
+++ b/tests/unittest/_torch/sampler/test_return_logits.py
@@ -12,7 +12,7 @@ prompts = ["A B C"]
 global_kvcache_config = KvCacheConfig(max_tokens=10000)
 
 
-# @force_ampere  # Save H100 resource
+@force_ampere  # Save H100 resource
 @pytest.mark.parametrize("return_log_probs", [False, True])
 @pytest.mark.parametrize("gather_generation_logits", [False, True])
 @pytest.mark.parametrize("gather_context_logits", [False, True])


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Refactor
  * Unified beam width handling for consistent sampling across requests.
  * Streamlined logits processing; computed only when requested to reduce overhead.
  * Generation logits are no longer returned; outputs focus on token log-probabilities.
  * Removed host-side logits storage to lower memory usage and improve efficiency.
  * More consistent behavior when overlap scheduling is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up
-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
