### PR TITLE
[#6798][fix] fix compilation error in ub_allocator in single device build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 *.npy
 .VSCodeCounter
 cpp/build*
+cpp/Release
 build
 !tensorrt_llm/bench/build
 !builders/

--- a/cpp/tensorrt_llm/kernels/userbuffers/ub_allocator.h
+++ b/cpp/tensorrt_llm/kernels/userbuffers/ub_allocator.h
@@ -14,16 +14,18 @@
  * limitations under the License.
  */
 #pragma once
-#include "nccl.h"
 #include "tensorrt_llm/runtime/worldConfig.h"
 #include <memory>
 #if ENABLE_MULTI_DEVICE
+#include "nccl.h"
 #include "userbuffers.h"
 #ifdef _WIN32
 #include <windows.h>
 #else
 #include <dlfcn.h>
 #endif
+#else
+using ncclWindow_t = void*;
 #endif
 
 namespace tensorrt_llm::runtime::ub
@@ -50,6 +52,7 @@ struct UBBuffer
         return (addr == nullptr) || (handle == -1) || (size == 0);
     }
 };
+
 #if ENABLE_MULTI_DEVICE
 class UserBufferAllocator
 {


### PR DESCRIPTION
Fix compilation error in ub_allocator in single device build.

## Description

Issue: compilation error when ENABLE_MULTI_DEVICE=0 
Solution: if ENABLE_MULTI_DEVICE=0, dont include nccl.h, dont use nccl_window 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build/run reliability on single-GPU systems by removing an unnecessary multi-device dependency, preventing failures where certain GPU libraries aren't present.

* **Chores**
  * Updated repository ignore rules to exclude release build artifacts, reducing accidental commits and keeping the repo cleaner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->