### PR TITLE
[None][chore] update disagg readme and scripts for pipeline parallelism

### DIFF
--- a/examples/disaggregated/slurm/benchmark/README.md
+++ b/examples/disaggregated/slurm/benchmark/README.md
@@ -34,17 +34,29 @@ It takes the following arguments in order:
 
 1.  `num_ctx_servers`: Number of context servers.
 2.  `ctx_tp_size`: Tensor parallel size for context servers.
-3.  `ctx_batch_size`: Max batch size for context servers.
-4.  `ctx_max_num_tokens`: Max number of tokens for context servers.
-5.  `ctx_enable_attention_dp`: `true` or `false` to enable attention DP for context servers.
-6.  `num_gen_servers`: Number of generation servers.
-7.  `gen_tp_size`: Tensor parallel size for generation servers.
-8.  `gen_batch_size`: Max batch size for generation servers.
-9.  `gen_max_num_tokens`: Max number of tokens for generation servers.
-10. `gen_enable_attention_dp`: `true` or `false` to enable attention DP for generation servers.
-11. `gen_gpu_memory_fraction`: GPU memory fraction for generation servers.
-12. `concurrency_list`: A space-separated list of concurrencies to test (e.g., "1 2 4 8").
-13. `sub_file`: A subdirectory name for logs.
+3.  `ctx_pp_size`: Pipeline parallel size for context servers.
+4.  `ctx_batch_size`: Max batch size for context servers.
+5.  `ctx_max_num_tokens`: Max number of tokens for context servers.
+6.  `ctx_enable_attention_dp`: `true` or `false` to enable attention DP for context servers.
+7.  `num_gen_servers`: Number of generation servers.
+8.  `gen_tp_size`: Tensor parallel size for generation servers.
+9.  `gen_pp_size`: Pipeline parallel size for generation servers.
+10. `gen_batch_size`: Max batch size for generation servers.
+11. `gen_max_num_tokens`: Max number of tokens for generation servers.
+12. `gen_enable_attention_dp`: `true` or `false` to enable attention DP for generation servers.
+13. `gen_gpu_memory_fraction`: GPU memory fraction for generation servers.
+14. `eplb_num_slots`: Number of slots for eplb.
+15. `mtp_size`: Number of nextn layers for MTP.
+16. `concurrency`: Concurrency level for benchmarking.
+17. `isl`: Input sequence length.
+18. `osl`: Output sequence length.
+19. `multi_round`: Number of rounds for the benchmark.
+20. `streaming`: `true` or `false` for streaming mode.
+21. `container_image`: Container image to use.
+22. `mounts`: Container mounts.
+23. `workdir`: Working directory.
+24. `model_dir`: Model directory path.
+25. `trtllm_repo`: TensorRT-LLM repository path.
 
 ### `gen_yaml.py`
 
@@ -90,5 +102,5 @@ This script orchestrates the execution of the benchmark client. It waits for the
 7.  `disaggr_torch.slurm` starts the main `trtllm-serve` process.
 8.  `disaggr_torch.slurm` runs `run_benchmark.sh` which waits for the server to be ready.
 9.  `run_benchmark.sh` executes the benchmark for each concurrency level specified.
-10.  After the benchmark, `run_benchmark.sh` and `disaggr_torch.slurm` attempt to kill the server and worker processes.
+10. After the benchmark, `run_benchmark.sh` and `disaggr_torch.slurm` attempt to kill the server and worker processes.
 11. Logs for each run are stored in a subdirectory specified by the `sub_file` parameter.

--- a/examples/disaggregated/slurm/benchmark/disaggr_torch.slurm
+++ b/examples/disaggregated/slurm/benchmark/disaggr_torch.slurm
@@ -41,7 +41,8 @@ container_image=${22}
 mounts=${23}
 workdir=${24}
 model_dir=${25}
-trtllm_repo=${26}
+benchmark_mode=${26}
+trtllm_repo=${27}
 
 echo "================= parameters ================="
 echo "num_ctx_servers: ${num_ctx_servers}"

--- a/examples/disaggregated/slurm/benchmark/disaggr_torch.slurm
+++ b/examples/disaggregated/slurm/benchmark/disaggr_torch.slurm
@@ -10,47 +10,50 @@
 # Context servers arguments
 num_ctx_servers=${1}
 ctx_tp_size=${2}
-ctx_batch_size=${3}
-ctx_max_num_tokens=${4}
-ctx_enable_attention_dp=${5}
-ctx_gpu_memory_fraction=${6}
+ctx_pp_size=${3}
+ctx_batch_size=${4}
+ctx_max_num_tokens=${5}
+ctx_enable_attention_dp=${6}
+ctx_gpu_memory_fraction=${7}
 
 # Generation servers arguments
-num_gen_servers=${7}
-gen_tp_size=${8}
-gen_batch_size=${9}
-gen_max_num_tokens=${10}
-gen_enable_attention_dp=${11}
-gen_gpu_memory_fraction=${12}
+num_gen_servers=${8}
+gen_tp_size=${9}
+gen_pp_size=${10}
+gen_batch_size=${11}
+gen_max_num_tokens=${12}
+gen_enable_attention_dp=${13}
+gen_gpu_memory_fraction=${14}
 
 # Other arguments
-eplb_num_slots=${13}
-mtp_size=${14}
+eplb_num_slots=${15}
+mtp_size=${16}
 
 # Benchmarking arguments
-concurrency=${15}
-isl=${16}
-osl=${17}
-multi_round=${18}
-streaming=${19}
+concurrency=${17}
+isl=${18}
+osl=${19}
+multi_round=${20}
+streaming=${21}
 
 # User specific arguments
-container_image=${20}
-mounts=${21}
-workdir=${22}
-model_dir=${23}
-benchmark_mode=${24}
-trtllm_repo=${25}
+container_image=${22}
+mounts=${23}
+workdir=${24}
+model_dir=${25}
+trtllm_repo=${26}
 
 echo "================= parameters ================="
 echo "num_ctx_servers: ${num_ctx_servers}"
 echo "ctx_tp_size: ${ctx_tp_size}"
+echo "ctx_pp_size: ${ctx_pp_size}"
 echo "ctx_batch_size: ${ctx_batch_size}"
 echo "ctx_max_num_tokens: ${ctx_max_num_tokens}"
 echo "ctx_enable_attention_dp: ${ctx_enable_attention_dp}"
 echo "ctx_gpu_memory_fraction: ${ctx_gpu_memory_fraction}"
 echo "num_gen_servers: ${num_gen_servers}"
 echo "gen_tp_size: ${gen_tp_size}"
+echo "gen_pp_size: ${gen_pp_size}"
 echo "gen_batch_size: ${gen_batch_size}"
 echo "gen_max_num_tokens: ${gen_max_num_tokens}"
 echo "gen_enable_attention_dp: ${gen_enable_attention_dp}"
@@ -83,8 +86,8 @@ full_logdir=${logdir}/ctx${num_ctx_servers}_gen${num_gen_servers}_dep${gen_tp_si
 
 echo "concurrency: ${concurrency}"
 
-ctx_gpus=$((num_ctx_servers * ctx_tp_size))
-gen_gpus=$((num_gen_servers * gen_tp_size))
+ctx_gpus=$((num_ctx_servers * ctx_tp_size * ctx_pp_size))
+gen_gpus=$((num_gen_servers * gen_tp_size * gen_pp_size))
 
 echo "enable_attention_dp: ${ctx_enable_attention_dp}, ${gen_enable_attention_dp}, gpu_memory_fraction: ${gen_gpu_memory_fraction}"
 
@@ -132,6 +135,7 @@ srun -l --container-name=${container_name} \
             --model ${model_dir} \
             --num_ctx_servers ${num_ctx_servers} \
             --ctx_tp_size ${ctx_tp_size} \
+            --ctx_pp_size ${ctx_pp_size} \
             --ctx_batch_size ${ctx_batch_size} \
             --ctx_max_num_tokens ${ctx_max_num_tokens} \
             --ctx_max_seq_len ${ctx_max_seq_len} \
@@ -139,6 +143,7 @@ srun -l --container-name=${container_name} \
             --cache_transceiver_max_num_tokens ${cache_transceiver_max_num_tokens} \
             --num_gen_servers ${num_gen_servers} \
             --gen_tp_size ${gen_tp_size} \
+            --gen_pp_size ${gen_pp_size} \
             --gen_batch_size ${gen_batch_size} \
             --gen_max_num_tokens ${gen_max_num_tokens} \
             --gen_max_seq_len ${gen_max_seq_len} \

--- a/examples/disaggregated/slurm/benchmark/gen_yaml.py
+++ b/examples/disaggregated/slurm/benchmark/gen_yaml.py
@@ -247,9 +247,9 @@ def gen_config_file(config_path: str,
     if num_ctx_servers > 0:
         config['context_servers']['urls'] = ctx_urls
 
-    gen_urls, _ = generate_urls("gen", num_gen_servers, gen_tp_size, gen_pp_size,
-                                max_tasks_per_node, nodes, task_nodes,
-                                node_ports, task_nodes_offset)
+    gen_urls, _ = generate_urls("gen", num_gen_servers, gen_tp_size,
+                                gen_pp_size, max_tasks_per_node, nodes,
+                                task_nodes, node_ports, task_nodes_offset)
     config['generation_servers']['urls'] = gen_urls
 
     # set the hostname to the first node

--- a/examples/disaggregated/slurm/benchmark/gen_yaml.py
+++ b/examples/disaggregated/slurm/benchmark/gen_yaml.py
@@ -123,6 +123,7 @@ def gen_config_file(config_path: str,
                     model_path: str,
                     num_ctx_servers: int,
                     ctx_tp_size: int,
+                    ctx_pp_size: int,
                     ctx_batch_size: int,
                     ctx_max_num_tokens: int,
                     ctx_max_seq_len: int,
@@ -130,6 +131,7 @@ def gen_config_file(config_path: str,
                     ctx_enable_attention_dp: bool,
                     num_gen_servers: int,
                     gen_tp_size: int,
+                    gen_pp_size: int,
                     gen_batch_size: int,
                     gen_max_num_tokens: int,
                     gen_max_seq_len: int,
@@ -148,6 +150,7 @@ def gen_config_file(config_path: str,
         model_path: Path to the model
         num_ctx_servers: Number of context servers
         ctx_tp_size: Tensor parallel size for context servers
+        ctx_pp_size: Pipeline parallel size for context servers
         ctx_batch_size: Batch size for context servers
         ctx_max_num_tokens: Max number of tokens for context servers
         ctx_max_seq_len: Max sequence length for context servers
@@ -155,6 +158,7 @@ def gen_config_file(config_path: str,
         ctx_enable_attention_dp: Enable attention DP for context servers
         num_gen_servers: Number of generation servers
         gen_tp_size: Tensor parallel size for generation servers
+        gen_pp_size: Pipeline parallel size for generation servers
         gen_batch_size: Batch size for generation servers
         gen_max_num_tokens: Max number of tokens for generation servers
         gen_enable_attention_dp: Enable attention DP for generation servers
@@ -187,7 +191,7 @@ def gen_config_file(config_path: str,
             'tensor_parallel_size': ctx_tp_size,
             'moe_expert_parallel_size': ctx_tp_size,
             'enable_attention_dp': ctx_enable_attention_dp,
-            'pipeline_parallel_size': 1,
+            'pipeline_parallel_size': ctx_pp_size,
             'print_iter_log': True,
             'disable_overlap_scheduler': True,
             'kv_cache_config': {
@@ -205,7 +209,7 @@ def gen_config_file(config_path: str,
             'tensor_parallel_size': gen_tp_size,
             'moe_expert_parallel_size': gen_tp_size,
             'enable_attention_dp': gen_enable_attention_dp,
-            'pipeline_parallel_size': 1,
+            'pipeline_parallel_size': gen_pp_size,
             'max_batch_size': gen_batch_size,
             'max_num_tokens': gen_max_num_tokens,
             'max_seq_len': gen_max_seq_len,
@@ -237,13 +241,13 @@ def gen_config_file(config_path: str,
 
     # Generate URLs for context and generation servers
     ctx_urls, task_nodes_offset = generate_urls("ctx", num_ctx_servers,
-                                                ctx_tp_size, 1,
+                                                ctx_tp_size, ctx_pp_size,
                                                 max_tasks_per_node, nodes,
                                                 task_nodes, node_ports)
     if num_ctx_servers > 0:
         config['context_servers']['urls'] = ctx_urls
 
-    gen_urls, _ = generate_urls("gen", num_gen_servers, gen_tp_size, 1,
+    gen_urls, _ = generate_urls("gen", num_gen_servers, gen_tp_size, gen_pp_size,
                                 max_tasks_per_node, nodes, task_nodes,
                                 node_ports, task_nodes_offset)
     config['generation_servers']['urls'] = gen_urls
@@ -300,6 +304,10 @@ if __name__ == "__main__":
                         type=int,
                         required=True,
                         help="Tensor parallel size for context servers")
+    parser.add_argument("--ctx_pp_size",
+                        type=int,
+                        default=1,
+                        help="Pipeline parallel size for context servers")
     parser.add_argument("--ctx_batch_size",
                         type=int,
                         required=True,
@@ -328,6 +336,10 @@ if __name__ == "__main__":
                         type=int,
                         required=True,
                         help="Tensor parallel size for generation servers")
+    parser.add_argument("--gen_pp_size",
+                        type=int,
+                        default=1,
+                        help="Pipeline parallel size for generation servers")
     parser.add_argument("--gen_batch_size",
                         type=int,
                         required=True,
@@ -372,11 +384,11 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     gen_config_file(args.config, args.model, args.num_ctx_servers,
-                    args.ctx_tp_size, args.ctx_batch_size,
+                    args.ctx_tp_size, args.ctx_pp_size, args.ctx_batch_size,
                     args.ctx_max_num_tokens, args.ctx_max_seq_len,
                     args.ctx_free_gpu_memory_fraction,
                     args.ctx_enable_attention_dp, args.num_gen_servers,
-                    args.gen_tp_size, args.gen_batch_size,
+                    args.gen_tp_size, args.gen_pp_size, args.gen_batch_size,
                     args.gen_max_num_tokens, args.gen_max_seq_len,
                     args.gen_enable_attention_dp, args.gen_gpu_memory_fraction,
                     args.eplb_num_slots, args.mtp_size, args.worker_start_port,

--- a/examples/disaggregated/slurm/benchmark/submit.sh
+++ b/examples/disaggregated/slurm/benchmark/submit.sh
@@ -38,7 +38,7 @@ args=(
 )
 
 # This command starts a job with 8 nodes, 32 GPUs in total.
-# The server will include 4 context workers with DEP=4, and 1 generation worker with DEP=8.
+# The server will include 4 context workers with DEP4, and 1 generation worker with DEP8.
 # `--segment` makes sure that all nodes are in the same NVLink domain
 sbatch --nodes=${total_node_num} \
     --ntasks=${ntasks} \

--- a/examples/disaggregated/slurm/benchmark/submit.sh
+++ b/examples/disaggregated/slurm/benchmark/submit.sh
@@ -21,15 +21,15 @@ streaming=true
 benchmark_mode=e2e
 
 args=(
-    1 4 4 4480 true "0.75"          # Context servers arguments
-    1 8 1024 1024 true "0.8" # Generation servers arguments
-    0 0                      # Other arguments
-    $concurrency             # Benchmarking arguments
+    1 4 1 4 4480 true "0.75"   # Context servers arguments
+    1 8 1 1024 1024 true "0.8" # Generation servers arguments
+    0 0                        # Other arguments
+    $concurrency               # Benchmarking arguments
     $isl
     $osl
     $multi_round
     $streaming
-    $container_image         # User specific arguments
+    $container_image           # User specific arguments
     $mounts
     $workdir
     $model_dir
@@ -38,7 +38,7 @@ args=(
 )
 
 # This command starts a job with 8 nodes, 32 GPUs in total.
-# The server will include 4 context workers with DEP4, and 1 generation worker with DEP8.
+# The server will include 4 context workers with TP=4, PP=1, and 1 generation worker with TP=8, PP=1.
 # `--segment` makes sure that all nodes are in the same NVLink domain
 sbatch --nodes=${total_node_num} \
     --ntasks=${ntasks} \

--- a/examples/disaggregated/slurm/benchmark/submit.sh
+++ b/examples/disaggregated/slurm/benchmark/submit.sh
@@ -38,7 +38,7 @@ args=(
 )
 
 # This command starts a job with 8 nodes, 32 GPUs in total.
-# The server will include 4 context workers with TP=4, PP=1, and 1 generation worker with TP=8, PP=1.
+# The server will include 4 context workers with DEP=4, and 1 generation worker with DEP=8.
 # `--segment` makes sure that all nodes are in the same NVLink domain
 sbatch --nodes=${total_node_num} \
     --ntasks=${ntasks} \

--- a/examples/wide_ep/slurm_scripts/submit_e2e.sh
+++ b/examples/wide_ep/slurm_scripts/submit_e2e.sh
@@ -30,8 +30,8 @@ for b in 1 64 1024; do
         ntasks=$((total_node_num * ntasks_per_node))
 
         args=(
-            ${ctx_num} 4 4 4480 true "0.85"   # Context servers arguments
-            1 16 1024 1024 true "0.7"       # Generation servers arguments
+            ${ctx_num} 4 1 4 4480 true "0.85"   # Context servers arguments
+            1 16 1 1024 1024 true "0.7"       # Generation servers arguments
             $eplb_num_slots $mtp_size  # Other arguments
             $concurrency               # Benchmarking arguments
             $isl
@@ -68,8 +68,8 @@ for b in 512; do
     eplb_num_slots=288
 
     args=(
-        ${ctx_num} 4 4 4480 true "0.85"   # Context servers arguments
-        1 32 1024 1024 true "0.7"  # Generation servers arguments
+        ${ctx_num} 4 1 4 4480 true "0.85"   # Context servers arguments
+        1 32 1 1024 1024 true "0.7"  # Generation servers arguments
         $eplb_num_slots $mtp_size  # Other arguments
         $concurrency               # Benchmarking arguments
         $isl

--- a/examples/wide_ep/slurm_scripts/submit_gen_only.sh
+++ b/examples/wide_ep/slurm_scripts/submit_gen_only.sh
@@ -30,8 +30,8 @@ for b in 1 64 1024; do
         ntasks=$((total_node_num * ntasks_per_node))
 
         args=(
-            ${ctx_num} 4 4 4480 true "0.85"   # Context servers arguments
-            1 16 1024 1024 true "0.7"       # Generation servers arguments
+            ${ctx_num} 4 1 4 4480 true "0.85"   # Context servers arguments
+            1 16 1 1024 1024 true "0.7"       # Generation servers arguments
             $eplb_num_slots $mtp_size  # Other arguments
             $concurrency               # Benchmarking arguments
             $isl
@@ -68,8 +68,8 @@ for b in 512; do
     eplb_num_slots=288
 
     args=(
-        ${ctx_num} 4 4 4480 true "0.85"   # Context servers arguments
-        1 32 1024 1024 true "0.7"  # Generation servers arguments
+        ${ctx_num} 4 1 4 4480 true "0.85"   # Context servers arguments
+        1 32 1 1024 1024 true "0.7"  # Generation servers arguments
         $eplb_num_slots $mtp_size  # Other arguments
         $concurrency               # Benchmarking arguments
         $isl


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added pipeline-parallel options for context and generation (ctx_pp_size, gen_pp_size); resource calculation and generated configs now account for pipeline parallelism.

- Refactor
  - Public CLI/SLURM interface expanded and reordered: positional arguments increased and submission scripts updated to match; prints now include the new pipeline sizes.

- Documentation
  - Benchmark README updated with richer, pipeline-aware arguments; concurrency_list renamed to concurrency; many deployment/config options added and old log-subdirectory option removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up
-->

## Description

We landed pipeline parallelism with pyt backend a little bit ago but these changes didn't propagate to the disagg readme and benchmarking scripts, etc. Making that change now.

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

Will try running this locally to make sure it works as expected

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
