### PR TITLE
[#5861][feat] Implement Annotation-Based Quantization Transformation Pipeline

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -23,7 +23,6 @@ transforms:
     stage: post_export
     backend: real_quant
     requires_clean_graph: false
-  # old quantization transform - for backward
   quantize:
     stage: pattern_matcher
     enabled: false

--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -19,8 +19,14 @@ transforms:
     stage: post_export
   cleanup_input_constraints:
     stage: post_export
+  quantize_annotate:
+    stage: post_export
+    backend: real_quant
+    requires_clean_graph: false
+  # old quantization transform - for backward
   quantize:
     stage: pattern_matcher
+    enabled: false
   quantize_moe:
     stage: pattern_matcher
   match_repeat_kv:
@@ -31,3 +37,6 @@ transforms:
     stage: pattern_matcher
   match_attention_layout:
     stage: pattern_matcher
+  quantize_late_fusion:
+    stage: perf_optimization
+    requires_clean_graph: false

--- a/tensorrt_llm/quantization/quant_annotation.py
+++ b/tensorrt_llm/quantization/quant_annotation.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass
+from typing import Optional, Dict, Any
+
+@dataclass
+class QuantAnnotation:
+    """Annotation for quantization metadata.
+    
+    Attributes:
+        quant_scheme: Quantization scheme (e.g., 'int8', 'fp8')
+        backend: Quantization backend implementation
+        quant_group: Group ID for shard-aware quantization
+        metadata: Additional quantization parameters
+    """
+    quant_scheme: str
+    backend: str
+    quant_group: Optional[int] = None
+    metadata: Optional[Dict[str, Any]] = None
+
+def annotate_node(node, annotation: QuantAnnotation):
+    """Annotate a node with quantization metadata"""
+    if not hasattr(node, 'meta'):
+        node.meta = {}
+    node.meta['quant_annotation'] = annotation
+
+def get_quant_annotation(node) -> Optional[QuantAnnotation]:
+    """Retrieve quantization annotation from a node"""
+    return node.meta.get('quant_annotation', None)
+
+def has_quant_annotation(node) -> bool:
+    """Check if a node has quantization annotation"""
+    return get_quant_annotation(node) is not None
+
+def clear_quant_annotation(node):
+    """Remove quantization annotation from a node"""
+    if hasattr(node, 'meta') and 'quant_annotation' in node.meta:
+        del node.meta['quant_annotation']
+
+def copy_quant_annotation(source_node, target_node):
+    """Copy quantization annotation from source node to target node"""
+    annotation = get_quant_annotation(source_node)
+    if annotation:
+        annotate_node(target_node, annotation)
+
+def update_annotation_for_sharding(node, shard_info: Dict[str, Any]):
+    """Update quantization annotation to include sharding information"""
+    annotation = get_quant_annotation(node)
+    if annotation:
+        # Update metadata with sharding info
+        if annotation.metadata is None:
+            annotation.metadata = {}
+        annotation.metadata.update(shard_info)
+        # Update quant_group if sharding affects quantization grouping
+        if 'shard_rank' in shard_info:
+            annotation.quant_group = shard_info['shard_rank']

--- a/tensorrt_llm/quantization/quant_annotation.py
+++ b/tensorrt_llm/quantization/quant_annotation.py
@@ -3,13 +3,12 @@ from typing import Optional, Dict, Any
 
 @dataclass
 class QuantAnnotation:
-    """Annotation for quantization metadata.
-    
-    Attributes:
-        quant_scheme: Quantization scheme (e.g., 'int8', 'fp8')
-        backend: Quantization backend implementation
-        quant_group: Group ID for shard-aware quantization
-        metadata: Additional quantization parameters
+    """
+    metadata for annotation
+    quant_scheme: Quantization scheme (e.g., 'int8', 'fp8')
+    backend: Quantization backend implementation
+    quant_group: Group ID for shard-aware quantization
+    metadata: Additional quantization parameters
     """
     quant_scheme: str
     backend: str


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Introduces a two-stage quantization workflow (annotation and late fusion) enabling backend-aware quantization and performance optimizations.
- Chores
  - Quantization is now disabled by default; enable it via configuration when needed.
  - Added configuration entries to control the new quantization stages and their execution order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up
-->

## Description

<!--
Please explain the issue and the solution in short.
-->

This PR (addressing #5861) refactors the QAT pipeline to decouple quantization logic from other graph optimization passes by introducing annotations.

`quantize_annotate`: A pass runs early to annotate nodes with quantization metadata without actually modifying the graph structure.

`quantize_late_fusion`: Applies actual quantization transformations based on the preserved annotations

The intermediate passes only need to preserve the node metadata, ideally they need not be quantization-aware.
