### PR TITLE
[None][chore] fix markdown format for the deployment guide

### DIFF
--- a/docs/source/deployment-guide/quick-start-recipe-for-deepseek-r1-on-trtllm.md
+++ b/docs/source/deployment-guide/quick-start-recipe-for-deepseek-r1-on-trtllm.md
@@ -8,15 +8,15 @@ The guide is intended for developers and practitioners seeking high-throughput o
 
 ## Prerequisites
 
-GPU: NVIDIA Blackwell or Hopper Architecture  
-OS: Linux  
-Drivers: CUDA Driver 575 or Later  
-Docker with NVIDIA Container Toolkit installed  
-Python3 and python3-pip (Optional, for accuracy evaluation only)
+* GPU: NVIDIA Blackwell or Hopper Architecture
+* OS: Linux
+* Drivers: CUDA Driver 575 or Later
+* Docker with NVIDIA Container Toolkit installed
+* Python3 and python3-pip (Optional, for accuracy evaluation only)
 
 ## Models
 
-* FP8 model: [DeepSeek-R1-0528](https://huggingface.co/deepseek-ai/DeepSeek-R1-0528)  
+* FP8 model: [DeepSeek-R1-0528](https://huggingface.co/deepseek-ai/DeepSeek-R1-0528)
 * NVFP4 model: [DeepSeek-R1-0528-FP4](https://huggingface.co/nvidia/DeepSeek-R1-0528-FP4)
 
 
@@ -39,18 +39,18 @@ nvcr.io/nvidia/tensorrt-llm/release:1.0.0rc6 \
 /bin/bash
 ```
 
-Note: 
+Note:
 
-* You can mount additional directories and paths using the \-v \<local\_path\>:\<path\> flag if needed, such as mounting the downloaded weight paths.  
-* The command mounts your user .cache directory to save the downloaded model checkpoints which are saved to \~/.cache/huggingface/hub/ by default. This prevents having to redownload the weights each time you rerun the container. If the \~/.cache directory doesn’t exist please create it using  mkdir \~/.cache  
-* The command also maps port **8000** from the container to your host so you can access the LLM API endpoint from your host  
-* See the [https://catalog.ngc.nvidia.com/orgs/nvidia/teams/tensorrt-llm/containers/release/tags](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/tensorrt-llm/containers/release/tags) for all the available containers. The containers published in the main branch weekly have “rcN” suffix, while the monthly release with QA tests has no “rcN” suffix. Use the rc release to get the latest model and feature support.
+* The command mounts your user `.cache` directory to save the downloaded model checkpoints which are saved to `~/.cache/huggingface/hub/` by default. This prevents having to redownload the weights each time you rerun the container. If the `~/.cache` directory doesn’t exist please create it using `$ mkdir ~/.cache`.
+* You can mount additional directories and paths using the `-v <host_path>:<container_path>` flag if needed, such as mounting the downloaded weight paths.
+* The command also maps port `8000` from the container to your host so you can access the LLM API endpoint from your host
+* See the <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/tensorrt-llm/containers/release/tags> for all the available containers. The containers published in the main branch weekly have `rcN` suffix, while the monthly release with QA tests has no `rcN` suffix. Use the `rc` release to get the latest model and feature support.
 
-If you want to use latest main branch, you can choose to build from source to install TensorRT-LLM, the steps refer to [https://nvidia.github.io/TensorRT-LLM/latest/installation/build-from-source-linux.html](https://nvidia.github.io/TensorRT-LLM/latest/installation/build-from-source-linux.html) 
+If you want to use latest main branch, you can choose to build from source to install TensorRT-LLM, the steps refer to <https://nvidia.github.io/TensorRT-LLM/latest/installation/build-from-source-linux.html>.
 
 ### Creating the TRT-LLM Server config
 
-We create a YAML configuration file /tmp/config.yml for the TensorRT-LLM Server and populate it with the following recommended performance settings.
+We create a YAML configuration file `/tmp/config.yml` for the TensorRT-LLM Server and populate it with the following recommended performance settings.
 
 ```shell
 EXTRA_LLM_API_FILE=/tmp/config.yml
@@ -115,98 +115,96 @@ After the server is set up, the client can now send prompt requests to the serve
 ### Configs and Parameters
 
 These options are used directly on the command line when you start the `trtllm-serve` process.
+
 #### `--tp_size`
 
-&emsp;**Description:** Sets the **tensor-parallel size**. This should typically match the number of GPUs you intend to use for a single model instance.
+* **Description:** Sets the **tensor-parallel size**. This should typically match the number of GPUs you intend to use for a single model instance.
 
 #### `--ep_size`
 
-&emsp;**Description:** Sets the **expert-parallel size** for Mixture-of-Experts (MoE) models. Like `tp_size`, this should generally match the number of GPUs you're using. This setting has no effect on non-MoE models.
+* **Description:** Sets the **expert-parallel size** for Mixture-of-Experts (MoE) models. Like `tp_size`, this should generally match the number of GPUs you're using. This setting has no effect on non-MoE models.
 
 #### `--kv_cache_free_gpu_memory_fraction`
 
-&emsp;**Description:** A value between 0.0 and 1.0 that specifies the fraction of free GPU memory to reserve for the KV cache after the model is loaded. Since memory usage can fluctuate, this buffer helps prevent out-of-memory (OOM) errors.
-
-&emsp;**Recommendation:** If you experience OOM errors, try reducing this value to **0.7** or lower.
+* **Description:** A value between `0.0` and `1.0` that specifies the fraction of free GPU memory to reserve for the KV cache after the model is loaded. Since memory usage can fluctuate, this buffer helps prevent out-of-memory (OOM) errors.
+* **Recommendation:** If you experience OOM errors, try reducing this value to `0.7` or lower.
 
 #### `--backend pytorch`
 
-&emsp;**Description:** Tells TensorRT-LLM to use the **pytorch** backend.
+* **Description:** Tells TensorRT-LLM to use the **pytorch** backend.
 
 #### `--max_batch_size`
 
-&emsp;**Description:** The maximum number of user requests that can be grouped into a single batch for processing.
+* **Description:** The maximum number of user requests that can be grouped into a single batch for processing.
 
 #### `--max_num_tokens`
 
-&emsp;**Description:** The maximum total number of tokens (across all requests) allowed inside a single scheduled batch.
+* **Description:** The maximum total number of tokens (across all requests) allowed inside a single scheduled batch.
 
 #### `--max_seq_len`
 
-&emsp;**Description:** The maximum possible sequence length for a single request, including both input and generated output tokens.
+* **Description:** The maximum possible sequence length for a single request, including both input and generated output tokens.
 
 #### `--trust_remote_code`
 
-&emsp;**Description:** Allows TensorRT-LLM to download models and tokenizers from Hugging Face. This flag is passed directly to the Hugging Face API.
+* **Description:** Allows TensorRT-LLM to download models and tokenizers from Hugging Face. This flag is passed directly to the Hugging Face API.
 
 
 #### Extra LLM API Options (YAML Configuration)
 
-These options provide finer control over performance and are set within a YAML file passed to the trtllm-serve command via the \--extra\_llm\_api\_options argument.
+These options provide finer control over performance and are set within a YAML file passed to the `trtllm-serve` command via the `--extra_llm_api_options` argument.
 
 #### `kv_cache_config`
 
-&emsp;**Description**: A section for configuring the Key-Value (KV) cache.
+* **Description**: A section for configuring the Key-Value (KV) cache.
 
-&emsp;**Options**: 
+* **Options**:
 
-&emsp;&emsp;dtype: Sets the data type for the KV cache.
-
-&emsp;&emsp;**Default**: auto (uses the data type specified in the model checkpoint).
+  * `dtype`: Sets the data type for the KV cache.
+    **Default**: `"auto"` (uses the data type specified in the model checkpoint).
 
 #### `cuda_graph_config`
 
-&emsp;**Description**: A section for configuring CUDA graphs to optimize performance.
+* **Description**: A section for configuring CUDA graphs to optimize performance.
 
-&emsp;**Options**:
+* **Options**:
 
-&emsp;&emsp;enable\_padding: If true, input batches are padded to the nearest cuda\_graph\_batch\_size. This can significantly improve performance.
+  * `enable_padding`: If `"true"`, input batches are padded to the nearest `cuda_graph_batch_size`. This can significantly improve performance.
 
-&emsp;&emsp;**Default**: false
+    **Default**: `false`
 
-&emsp;&emsp;max\_batch\_size: Sets the maximum batch size for which a CUDA graph will be created.
+  * `max_batch_size`: Sets the maximum batch size for which a CUDA graph will be created.
 
-&emsp;&emsp;**Default**: 0
+    **Default**: `0`
 
-&emsp;&emsp;**Recommendation**: Set this to the same value as the \--max\_batch\_size command-line option.
+    **Recommendation**: Set this to the same value as the `--max_batch_size` command-line option.
 
-&emsp;&emsp;batch\_sizes: A specific list of batch sizes to create CUDA graphs for.
+  * `batch_sizes`: A specific list of batch sizes to create CUDA graphs for.
 
-&emsp;&emsp;**Default**: None
+     **Default**: `None`
 
 #### `moe_config`
 
-&emsp;**Description**: Configuration for Mixture-of-Experts (MoE) models.
+* **Description**: Configuration for Mixture-of-Experts (MoE) models.
 
-&emsp;**Options**:
+* **Options**:
 
-&emsp;&emsp;backend: The backend to use for MoE operations.
-
-&emsp;&emsp;**Default**: CUTLASS
+  * `backend`: The backend to use for MoE operations.
+    **Default**: `CUTLASS`
 
 #### `attention_backend`
 
-&emsp;**Description**: The backend to use for attention calculations.
+* **Description**: The backend to use for attention calculations.
 
-&emsp;**Default**: TRTLLM
+* **Default**: `TRTLLM`
 
-See the [TorchLlmArgs class](https://nvidia.github.io/TensorRT-LLM/llm-api/reference.html#tensorrt_llm.llmapi.TorchLlmArgs) for the full list of options which can be used in the extra\_llm\_api\_options`.`
+See the [`TorchLlmArgs` class](https://nvidia.github.io/TensorRT-LLM/llm-api/reference.html#tensorrt_llm.llmapi.TorchLlmArgs) for the full list of options which can be used in the `extra_llm_api_options`.
 
 ## Testing API Endpoint
 
 ### Basic Test
 
-Start a new terminal on the host to test the TensorRT-LLM server you just launched. 
+Start a new terminal on the host to test the TensorRT-LLM server you just launched.
 
 You can query the health/readiness of the server using:
 
@@ -216,7 +214,7 @@ curl -s -o /dev/null -w "Status: %{http_code}\n" "http://localhost:8000/health"
 
 When the `Status: 200` code is returned, the server is ready for queries. Note that the very first query may take longer due to initialization and compilation.
 
-After the TRT-LLM server is set up and shows Application startup complete, you can send requests to the server. 
+After the TRT-LLM server is set up and shows Application startup complete, you can send requests to the server.
 
 ```shell
 curl http://localhost:8000/v1/completions -H "Content-Type: application/json"  -d '{
@@ -240,11 +238,11 @@ Here is an example response, showing that the TRT-LLM server returns “New York
 * Ensure your model checkpoints are compatible with the expected format.
 * For performance issues, check GPU utilization with nvidia-smi while the server is running.
 * If the container fails to start, verify that the NVIDIA Container Toolkit is properly installed.
-* For connection issues, make sure port 8000 is not being used by another application.
+* For connection issues, make sure the server port (`8000` in this guide) is not being used by another application.
 
 ### Running Evaluations to Verify Accuracy (Optional)
 
-We use the lm-eval tool to test the model’s accuracy. For more information see [https://github.com/EleutherAI/lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness).
+We use the `lm-eval` tool to test the model’s accuracy. For more information see [https://github.com/EleutherAI/lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness).
 
 To run the evaluation harness exec into the running TensorRT-LLM container and install with this command:
 
@@ -256,9 +254,9 @@ pip install lm_eval
 
 FP8 command for GSM8K:
 
-* Note: The tokenizer will add BOS (beginning of sentence token) before input prompt by default which leads to accuracy regression on GSM8K task for DeepSeek R1 model. So, set add\_special\_tokens=False to avoid it.
+* Note: The tokenizer will add BOS (beginning of sentence token) before input prompt by default which leads to accuracy regression on GSM8K task for DeepSeek R1 model. So, set `add_special_tokens=False` to avoid it.
 
-```
+```shell
 MODEL_PATH=deepseek-ai/DeepSeek-R1-0528
 
 lm_eval --model local-completions  --tasks gsm8k --batch_size 256 --gen_kwargs temperature=0.0,add_special_tokens=False --num_fewshot 5 --model_args model=${MODEL_PATH},base_url=http://localhost:8000/v1/completions,num_concurrent=32,max_retries=20,tokenized_requests=False --log_samples --output_path trtllm.fp8.gsm8k
@@ -266,7 +264,7 @@ lm_eval --model local-completions  --tasks gsm8k --batch_size 256 --gen_kwargs t
 
 Sample result in Blackwell:
 
-```shell
+```
 |Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
 |-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
 |gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9538|±  |0.0058|
@@ -275,7 +273,7 @@ Sample result in Blackwell:
 
 FP4 command for GSM8K:
 
-* Note: The tokenizer will add BOS before input prompt by default, which leads to accuracy regression on GSM8K task for DeepSeek R1 model. So set add\_special\_tokens=False to avoid it.
+* Note: The tokenizer will add BOS before input prompt by default, which leads to accuracy regression on GSM8K task for DeepSeek R1 model. So set `add_special_tokens=False` to avoid it.
 
 ```shell
 MODEL_PATH=nvidia/DeepSeek-R1-0528-FP4
@@ -285,7 +283,7 @@ lm_eval --model local-completions  --tasks gsm8k --batch_size 256 --gen_kwargs t
 
 Sample result in Blackwell:
 
-```shell
+```
 |Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
 |-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
 |gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9462|±  |0.0062|
@@ -294,7 +292,7 @@ Sample result in Blackwell:
 
 ## Benchmarking Performance
 
-To benchmark the performance of your TensorRT-LLM server you can leverage the built-in “benchmark\_serving.py” script. To do this first creating a wrapper [bench.sh](http://bench.sh) script.
+To benchmark the performance of your TensorRT-LLM server you can leverage the built-in `benchmark_serving.py` script. To do this first creating a wrapper `bench.sh` script.
 
 ```shell
 cat <<EOF >  bench.sh
@@ -324,7 +322,7 @@ EOF
 chmod +x bench.sh
 ```
 
-To benchmark the FP4 model, replace \--model deepseek-ai/DeepSeek-R1-0528 with \--model nvidia/DeepSeek-R1-0528-FP4.
+To benchmark the FP4 model, replace `--model deepseek-ai/DeepSeek-R1-0528` with `--model nvidia/DeepSeek-R1-0528-FP4`.
 
 If you want to save the results to a file add the following options.
 
@@ -334,9 +332,9 @@ If you want to save the results to a file add the following options.
 --result-filename "concurrency_${concurrency}.json"
 ```
 
-For more benchmarking options see. [https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt\_llm/serve/scripts/benchmark\_serving.py](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/serve/scripts/benchmark_serving.py) 
+For more benchmarking options see <https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt\_llm/serve/scripts/benchmark\_serving.py>.
 
-Run bench.sh to begin a serving benchmark. This will take a long time if you run all the concurrencies mentioned in the above bench.sh script.
+Run `bench.sh` to begin a serving benchmark. This will take a long time if you run all the concurrencies mentioned in the above `bench.sh` script.
 
 ```shell
 ./bench.sh
@@ -375,13 +373,13 @@ P99 E2EL (ms):                            [result]
 
 ### Key Metrics
 
-* Median Time to First Token (TTFT)  
-  * The typical time elapsed from when a request is sent until the first output token is generated.  
-* Median Time Per Output Token (TPOT)  
-  * The typical time required to generate each token *after* the first one.   
-* Median Inter-Token Latency (ITL)  
-  * The typical time delay between the completion of one token and the completion of the next.  
-* Median End-to-End Latency (E2EL)  
-  * The typical total time from when a request is submitted until the final token of the response is received.   
-* Total Token Throughput  
-  * The combined rate at which the system processes both input (prompt) tokens and output (generated) tokens. 
+* Median Time to First Token (TTFT)
+  * The typical time elapsed from when a request is sent until the first output token is generated.
+* Median Time Per Output Token (TPOT)
+  * The typical time required to generate each token *after* the first one.
+* Median Inter-Token Latency (ITL)
+  * The typical time delay between the completion of one token and the completion of the next.
+* Median End-to-End Latency (E2EL)
+  * The typical total time from when a request is submitted until the final token of the response is received.
+* Total Token Throughput
+  * The combined rate at which the system processes both input (prompt) tokens and output (generated) tokens.

--- a/docs/source/deployment-guide/quick-start-recipe-for-llama3.3-70b-on-trtllm.md
+++ b/docs/source/deployment-guide/quick-start-recipe-for-llama3.3-70b-on-trtllm.md
@@ -12,15 +12,15 @@ To use Llama 3.3-70B, you must first agree to Meta’s Llama 3 Community License
 
 ## Prerequisites
 
-GPU: NVIDIA Blackwell or Hopper Architecture  
-OS: Linux  
-Drivers: CUDA Driver 575 or Later  
-Docker with NVIDIA Container Toolkit installed  
+GPU: NVIDIA Blackwell or Hopper Architecture
+OS: Linux
+Drivers: CUDA Driver 575 or Later
+Docker with NVIDIA Container Toolkit installed
 Python3 and python3-pip (Optional, for accuracy evaluation only)
 
 ## Models
 
-* FP8 model: [Llama-3.3-70B-Instruct-FP8](https://huggingface.co/nvidia/Llama-3.3-70B-Instruct-FP8)  
+* FP8 model: [Llama-3.3-70B-Instruct-FP8](https://huggingface.co/nvidia/Llama-3.3-70B-Instruct-FP8)
 * NVFP4 model: [Llama-3.3-70B-Instruct-FP4](https://huggingface.co/nvidia/Llama-3.3-70B-Instruct-FP4)
 
 
@@ -43,18 +43,18 @@ nvcr.io/nvidia/tensorrt-llm/release:1.0.0rc6 \
 /bin/bash
 ```
 
-Note: 
+Note:
 
-* You can mount additional directories and paths using the \-v \<local\_path\>:\<path\> flag if needed, such as mounting the downloaded weight paths.  
-* The command mounts your user .cache directory to save the downloaded model checkpoints which are saved to \~/.cache/huggingface/hub/ by default. This prevents having to redownload the weights each time you rerun the container. If the \~/.cache directory doesn’t exist please create it using  mkdir \~/.cache  
-* The command also maps port **8000** from the container to your host so you can access the LLM API endpoint from your host  
-* See the [https://catalog.ngc.nvidia.com/orgs/nvidia/teams/tensorrt-llm/containers/release/tags](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/tensorrt-llm/containers/release/tags) for all the available containers. The containers published in the main branch weekly have “rcN” suffix, while the monthly release with QA tests has no “rcN” suffix. Use the rc release to get the latest model and feature support.
+* The command mounts your user `.cache` directory to save the downloaded model checkpoints which are saved to `~/.cache/huggingface/hub/` by default. This prevents having to redownload the weights each time you rerun the container. If the `~/.cache` directory doesn’t exist please create it using `$ mkdir ~/.cache`.
+* You can mount additional directories and paths using the `-v <host_path>:<container_path>` flag if needed, such as mounting the downloaded weight paths.
+* The command also maps port `8000` from the container to your host so you can access the LLM API endpoint from your host
+* See the <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/tensorrt-llm/containers/release/tags> for all the available containers. The containers published in the main branch weekly have `rcN` suffix, while the monthly release with QA tests has no `rcN` suffix. Use the `rc` release to get the latest model and feature support.
 
-If you want to use latest main branch, you can choose to build from source to install TensorRT-LLM, the steps refer to [https://nvidia.github.io/TensorRT-LLM/latest/installation/build-from-source-linux.html](https://nvidia.github.io/TensorRT-LLM/latest/installation/build-from-source-linux.html) 
+If you want to use latest main branch, you can choose to build from source to install TensorRT-LLM, the steps refer to <https://nvidia.github.io/TensorRT-LLM/latest/installation/build-from-source-linux.html>.
 
 ### Creating the TRT-LLM Server config
 
-We create a YAML configuration file /tmp/config.yml for the TensorRT-LLM Server and populate it with the following recommended performance settings.
+We create a YAML configuration file `/tmp/config.yml` for the TensorRT-LLM Server and populate it with the following recommended performance settings.
 
 ```shell
 EXTRA_LLM_API_FILE=/tmp/config.yml
@@ -64,7 +64,7 @@ enable_attention_dp: false
 cuda_graph_config:
   enable_padding: true
   max_batch_size: 1024
-kv_cache_config:     
+kv_cache_config:
   dtype: fp8
 EOF
 ```
@@ -93,98 +93,96 @@ After the server is set up, the client can now send prompt requests to the serve
 ### Configs and Parameters
 
 These options are used directly on the command line when you start the `trtllm-serve` process.
+
 #### `--tp_size`
 
-&emsp;**Description:** Sets the **tensor-parallel size**. This should typically match the number of GPUs you intend to use for a single model instance.
+* **Description:** Sets the **tensor-parallel size**. This should typically match the number of GPUs you intend to use for a single model instance.
 
 #### `--ep_size`
 
-&emsp;**Description:** Sets the **expert-parallel size** for Mixture-of-Experts (MoE) models. Like `tp_size`, this should generally match the number of GPUs you're using. This setting has no effect on non-MoE models.
+* **Description:** Sets the **expert-parallel size** for Mixture-of-Experts (MoE) models. Like `tp_size`, this should generally match the number of GPUs you're using. This setting has no effect on non-MoE models.
 
 #### `--kv_cache_free_gpu_memory_fraction`
 
-&emsp;**Description:** A value between 0.0 and 1.0 that specifies the fraction of free GPU memory to reserve for the KV cache after the model is loaded. Since memory usage can fluctuate, this buffer helps prevent out-of-memory (OOM) errors.
-
-&emsp;**Recommendation:** If you experience OOM errors, try reducing this value to **0.8** or lower.
+* **Description:** A value between `0.0` and `1.0` that specifies the fraction of free GPU memory to reserve for the KV cache after the model is loaded. Since memory usage can fluctuate, this buffer helps prevent out-of-memory (OOM) errors.
+* **Recommendation:** If you experience OOM errors, try reducing this value to `0.8` or lower.
 
 #### `--backend pytorch`
 
-&emsp;**Description:** Tells TensorRT-LLM to use the **pytorch** backend.
+* **Description:** Tells TensorRT-LLM to use the **pytorch** backend.
 
 #### `--max_batch_size`
 
-&emsp;**Description:** The maximum number of user requests that can be grouped into a single batch for processing.
+* **Description:** The maximum number of user requests that can be grouped into a single batch for processing.
 
 #### `--max_num_tokens`
 
-&emsp;**Description:** The maximum total number of tokens (across all requests) allowed inside a single scheduled batch.
+* **Description:** The maximum total number of tokens (across all requests) allowed inside a single scheduled batch.
 
 #### `--max_seq_len`
 
-&emsp;**Description:** The maximum possible sequence length for a single request, including both input and generated output tokens.
+* **Description:** The maximum possible sequence length for a single request, including both input and generated output tokens.
 
 #### `--trust_remote_code`
 
-&emsp;**Description:** Allows TensorRT-LLM to download models and tokenizers from Hugging Face. This flag is passed directly to the Hugging Face API.
+* **Description:** Allows TensorRT-LLM to download models and tokenizers from Hugging Face. This flag is passed directly to the Hugging Face API.
 
 
 #### Extra LLM API Options (YAML Configuration)
 
-These options provide finer control over performance and are set within a YAML file passed to the trtllm-serve command via the \--extra\_llm\_api\_options argument.
+These options provide finer control over performance and are set within a YAML file passed to the `trtllm-serve` command via the `--extra_llm_api_options` argument.
 
 #### `kv_cache_config`
 
-&emsp;**Description**: A section for configuring the Key-Value (KV) cache.
+* **Description**: A section for configuring the Key-Value (KV) cache.
 
-&emsp;**Options**: 
+* **Options**:
 
-&emsp;&emsp;dtype: Sets the data type for the KV cache.
-
-&emsp;&emsp;**Default**: auto (uses the data type specified in the model checkpoint).
+  * `dtype`: Sets the data type for the KV cache.
+    **Default**: `"auto"` (uses the data type specified in the model checkpoint).
 
 #### `cuda_graph_config`
 
-&emsp;**Description**: A section for configuring CUDA graphs to optimize performance.
+* **Description**: A section for configuring CUDA graphs to optimize performance.
 
-&emsp;**Options**:
+* **Options**:
 
-&emsp;&emsp;enable\_padding: If true, input batches are padded to the nearest cuda\_graph\_batch\_size. This can significantly improve performance.
+  * `enable_padding`: If `"true"`, input batches are padded to the nearest `cuda_graph_batch_size`. This can significantly improve performance.
 
-&emsp;&emsp;**Default**: false
+    **Default**: `false`
 
-&emsp;&emsp;max\_batch\_size: Sets the maximum batch size for which a CUDA graph will be created.
+  * `max_batch_size`: Sets the maximum batch size for which a CUDA graph will be created.
 
-&emsp;&emsp;**Default**: 0
+    **Default**: `0`
 
-&emsp;&emsp;**Recommendation**: Set this to the same value as the \--max\_batch\_size command-line option.
+    **Recommendation**: Set this to the same value as the `--max_batch_size` command-line option.
 
-&emsp;&emsp;batch\_sizes: A specific list of batch sizes to create CUDA graphs for.
+  * `batch_sizes`: A specific list of batch sizes to create CUDA graphs for.
 
-&emsp;&emsp;**Default**: None
+     **Default**: `None`
 
 #### `moe_config`
 
-&emsp;**Description**: Configuration for Mixture-of-Experts (MoE) models.
+* **Description**: Configuration for Mixture-of-Experts (MoE) models.
 
-&emsp;**Options**:
+* **Options**:
 
-&emsp;&emsp;backend: The backend to use for MoE operations.
-
-&emsp;&emsp;**Default**: CUTLASS
+  * `backend`: The backend to use for MoE operations.
+    **Default**: `CUTLASS`
 
 #### `attention_backend`
 
-&emsp;**Description**: The backend to use for attention calculations.
+* **Description**: The backend to use for attention calculations.
 
-&emsp;**Default**: TRTLLM
+* **Default**: `TRTLLM`
 
-See the [TorchLlmArgs](https://nvidia.github.io/TensorRT-LLM/llm-api/reference.html#tensorrt_llm.llmapi.TorchLlmArgs) class for the full list of options which can be used in the `extra_llm_api_options`.
+See the [`TorchLlmArgs` class](https://nvidia.github.io/TensorRT-LLM/llm-api/reference.html#tensorrt_llm.llmapi.TorchLlmArgs) for the full list of options which can be used in the `extra_llm_api_options`.
 
 ## Testing API Endpoint
 
 ### Basic Test
 
-Start a new terminal on the host to test the TensorRT-LLM server you just launched. 
+Start a new terminal on the host to test the TensorRT-LLM server you just launched.
 
 You can query the health/readiness of the server using:
 
@@ -194,7 +192,7 @@ curl -s -o /dev/null -w "Status: %{http_code}\n" "http://localhost:8000/health"
 
 When the `Status: 200` code is returned, the server is ready for queries. Note that the very first query may take longer due to initialization and compilation.
 
-After the TRT-LLM server is set up and shows Application startup complete, you can send requests to the server. 
+After the TRT-LLM server is set up and shows Application startup complete, you can send requests to the server.
 
 ```shell
 curl http://localhost:8000/v1/completions -H "Content-Type: application/json"  -d '{
@@ -213,15 +211,15 @@ Here is an example response, showing that the TRT-LLM server returns “New York
 
 ### Troubleshooting Tips
 
-* If you encounter CUDA out-of-memory errors, try reducing max\_batch\_size or max\_seq\_len  
-* Ensure your model checkpoints are compatible with the expected format  
-* For performance issues, check GPU utilization with nvidia-smi while the server is running  
-* If the container fails to start, verify that the NVIDIA Container Toolkit is properly installed  
-* For connection issues, make sure port 8000 is not being used by another application
+* If you encounter CUDA out-of-memory errors, try reducing `max_batch_size` or `max_seq_len`.
+* Ensure your model checkpoints are compatible with the expected format.
+* For performance issues, check GPU utilization with nvidia-smi while the server is running.
+* If the container fails to start, verify that the NVIDIA Container Toolkit is properly installed.
+* For connection issues, make sure the server port (`8000` in this guide) is not being used by another application.
 
 ### Running Evaluations to Verify Accuracy (Optional)
 
-We use the lm-eval tool to test the model’s accuracy. For more information see [https://github.com/EleutherAI/lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness).
+We use the lm-eval tool to test the model’s accuracy. For more information see <https://github.com/EleutherAI/lm-evaluation-harness>.
 
 To run the evaluation harness exec into the running TensorRT-LLM container and install with this command:
 
@@ -233,15 +231,15 @@ pip install lm_eval
 
 FP8 command for GSM8K
 
-* Note: The tokenizer will add BOS (beginning of sentence token) before input prompt by default which leads to accuracy regression on GSM8K task for Llama 3.3 70B instruction model. So, set add\_special\_tokens=False to avoid it.
+* Note: The tokenizer will add BOS (beginning of sentence token) before input prompt by default which leads to accuracy regression on GSM8K task for Llama 3.3 70B instruction model. So, set `add_special_tokens=False` to avoid it.
 
-```
+```shell
 MODEL_PATH=nvidia/Llama-3.3-70B-Instruct-FP8
 
 lm_eval --model local-completions  --tasks gsm8k --batch_size 256 --gen_kwargs temperature=0.0,add_special_tokens=False --num_fewshot 5 --model_args model=${MODEL_PATH},base_url=http://localhost:8000/v1/completions,num_concurrent=32,max_retries=20,tokenized_requests=False --log_samples --output_path trtllm.fp8.gsm8k
 ```
 
-Sample result in Blackwell. 
+Sample result in Blackwell.
 
 ```
 |Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
@@ -252,7 +250,7 @@ Sample result in Blackwell.
 
 FP4 command for GSM8K
 
-* Note: The tokenizer will add BOS before input prompt by default, which leads to accuracy regression on GSM8K task for LLama 3.3 70B instruction model. So set add\_special\_tokens=False to avoid it.
+* Note: The tokenizer will add BOS before input prompt by default, which leads to accuracy regression on GSM8K task for LLama 3.3 70B instruction model. So set `add_special_tokens=False` to avoid it.
 
 ```shell
 MODEL_PATH=nvidia/Llama-3.3-70B-Instruct-FP4
@@ -262,7 +260,7 @@ lm_eval --model local-completions  --tasks gsm8k --batch_size 256 --gen_kwargs t
 
 Sample result in Blackwell
 
-```shell
+```
 |Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
 |-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
 |gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9356|±  |0.0068|
@@ -271,7 +269,7 @@ Sample result in Blackwell
 
 ## Benchmarking Performance
 
-To benchmark the performance of your TensorRT-LLM server you can leverage the built-in “benchmark\_serving.py” script. To do this first creating a wrapper [bench.sh](http://bench.sh) script.
+To benchmark the performance of your TensorRT-LLM server you can leverage the built-in `benchmark_serving.py` script. To do this first creating a wrapper `bench.sh` script.
 
 ```shell
 cat <<EOF >  bench.sh
@@ -301,7 +299,7 @@ EOF
 chmod +x bench.sh
 ```
 
-To benchmark the FP4 model, replace \--model nvidia/Llama-3.3-70B-Instruct-FP8 with \--model nvidia/Llama-3.3-70B-Instruct-FP4.
+To benchmark the FP4 model, replace `--model nvidia/Llama-3.3-70B-Instruct-FP8` with `--model nvidia/Llama-3.3-70B-Instruct-FP4`.
 
 If you want to save the results to a file add the following options.
 
@@ -311,9 +309,9 @@ If you want to save the results to a file add the following options.
 --result-filename "concurrency_${concurrency}.json"
 ```
 
-For more benchmarking options see. [https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt\_llm/serve/scripts/benchmark\_serving.py](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/serve/scripts/benchmark_serving.py) 
+For more benchmarking options see <https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt\_llm/serve/scripts/benchmark\_serving.py>.
 
-Run bench.sh to begin a serving benchmark. This will take a long time if you run all the concurrencies mentioned in the above bench.sh script.
+Run `bench.sh` to begin a serving benchmark. This will take a long time if you run all the concurrencies mentioned in the above `bench.sh` script.
 
 ```shell
 ./bench.sh
@@ -352,13 +350,13 @@ P99 E2EL (ms):                            [result]
 
 ### Key Metrics
 
-* Median Time to First Token (TTFT)  
-  * The typical time elapsed from when a request is sent until the first output token is generated.  
-* Median Time Per Output Token (TPOT)  
-  * The typical time required to generate each token *after* the first one.   
-* Median Inter-Token Latency (ITL)  
-  * The typical time delay between the completion of one token and the completion of the next.  
-* Median End-to-End Latency (E2EL)  
-  * The typical total time from when a request is submitted until the final token of the response is received.   
-* Total Token Throughput  
-  * The combined rate at which the system processes both input (prompt) tokens and output (generated) tokens. 
+* Median Time to First Token (TTFT)
+  * The typical time elapsed from when a request is sent until the first output token is generated.
+* Median Time Per Output Token (TPOT)
+  * The typical time required to generate each token *after* the first one.
+* Median Inter-Token Latency (ITL)
+  * The typical time delay between the completion of one token and the completion of the next.
+* Median End-to-End Latency (E2EL)
+  * The typical total time from when a request is submitted until the final token of the response is received.
+* Total Token Throughput
+  * The combined rate at which the system processes both input (prompt) tokens and output (generated) tokens.

--- a/docs/source/deployment-guide/quick-start-recipe-for-llama4-scout-on-trtllm.md
+++ b/docs/source/deployment-guide/quick-start-recipe-for-llama4-scout-on-trtllm.md
@@ -8,15 +8,15 @@ The guide is intended for developers and practitioners seeking high-throughput o
 
 ## Access & Licensing
 
-To use Llama4 Scout 17B, you must first agree to Meta’s Llama 4 Community License ([https://github.com/meta-llama/llama-models/blob/main/models/llama4/LICENSE](https://github.com/meta-llama/llama-models/blob/main/models/llama4/LICENSE)). NVIDIA’s quantized versions (FP8 and NVFP4) are built on top of the base model and are available for research and commercial use under the same license.
+To use Llama4 Scout 17B, you must first agree to Meta’s [Llama 4 Community License](https://github.com/meta-llama/llama-models/blob/main/models/llama4/LICENSE). NVIDIA’s quantized versions (FP8 and NVFP4) are built on top of the base model and are available for research and commercial use under the same license.
 
 ## Prerequisites
 
-GPU: NVIDIA Blackwell or Hopper Architecture  
-OS: Linux  
-Drivers: CUDA Driver 575 or Later  
-Docker with NVIDIA Container Toolkit installed  
-Python3 and python3-pip (Optional, for accuracy evaluation only)
+* GPU: NVIDIA Blackwell or Hopper Architecture
+* OS: Linux
+* Drivers: CUDA Driver 575 or Later
+* Docker with NVIDIA Container Toolkit installed
+* Python3 and python3-pip (Optional, for accuracy evaluation only)
 
 ## Models
 
@@ -44,16 +44,16 @@ nvcr.io/nvidia/tensorrt-llm/release:1.0.0rc6 \
 
 Note:
 
-* You can mount additional directories and paths using the `-v <local_path>:<path>` flag if needed, such as mounting the downloaded weight paths.
-* The command mounts your user .cache directory to save the downloaded model checkpoints which are saved to `~/.cache/huggingface/hub/` by default. This prevents having to redownload the weights each time you rerun the container. If the `~/.cache` directory doesn’t exist please create it using  mkdir `~/.cache`.
-* The command also maps port 8000 from the container to your host so you can access the LLM API endpoint from your host
-* See the [https://catalog.ngc.nvidia.com/orgs/nvidia/teams/tensorrt-llm/containers/release/tags](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/tensorrt-llm/containers/release/tags) for all the available containers. The containers published in the main branch weekly have “rcN” suffix, while the monthly release with QA tests has no “rcN” suffix. Use the rc release to get the latest model and feature support.
+* The command mounts your user `.cache` directory to save the downloaded model checkpoints which are saved to `~/.cache/huggingface/hub/` by default. This prevents having to redownload the weights each time you rerun the container. If the `~/.cache` directory doesn’t exist please create it using `$ mkdir ~/.cache`.
+* You can mount additional directories and paths using the `-v <host_path>:<container_path>` flag if needed, such as mounting the downloaded weight paths.
+* The command also maps port `8000` from the container to your host so you can access the LLM API endpoint from your host
+* See the <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/tensorrt-llm/containers/release/tags> for all the available containers. The containers published in the main branch weekly have `rcN` suffix, while the monthly release with QA tests has no `rcN` suffix. Use the `rc` release to get the latest model and feature support.
 
-If you want to use latest main branch, you can choose to build from source to install TensorRT-LLM, the steps refer to [https://nvidia.github.io/TensorRT-LLM/latest/installation/build-from-source-linux.html](https://nvidia.github.io/TensorRT-LLM/latest/installation/build-from-source-linux.html)
+If you want to use latest main branch, you can choose to build from source to install TensorRT-LLM, the steps refer to <https://nvidia.github.io/TensorRT-LLM/latest/installation/build-from-source-linux.html>.
 
 ### Creating the TRT-LLM Server config
 
-We create a YAML configuration file /tmp/config.yml for the TensorRT-LLM Server and populate it with the following recommended performance settings.
+We create a YAML configuration file `/tmp/config.yml` for the TensorRT-LLM Server and populate it with the following recommended performance settings.
 
 ```shell
 EXTRA_LLM_API_FILE=/tmp/config.yml
@@ -92,92 +92,90 @@ After the server is set up, the client can now send prompt requests to the serve
 ### Configs and Parameters
 
 These options are used directly on the command line when you start the `trtllm-serve` process.
+
 #### `--tp_size`
 
-&emsp;**Description:** Sets the **tensor-parallel size**. This should typically match the number of GPUs you intend to use for a single model instance.
+* **Description:** Sets the **tensor-parallel size**. This should typically match the number of GPUs you intend to use for a single model instance.
 
 #### `--ep_size`
 
-&emsp;**Description:** Sets the **expert-parallel size** for Mixture-of-Experts (MoE) models. Like `tp_size`, this should generally match the number of GPUs you're using. This setting has no effect on non-MoE models.
+* **Description:** Sets the **expert-parallel size** for Mixture-of-Experts (MoE) models. Like `tp_size`, this should generally match the number of GPUs you're using. This setting has no effect on non-MoE models.
 
 #### `--kv_cache_free_gpu_memory_fraction`
 
-&emsp;**Description:** A value between 0.0 and 1.0 that specifies the fraction of free GPU memory to reserve for the KV cache after the model is loaded. Since memory usage can fluctuate, this buffer helps prevent out-of-memory (OOM) errors.
-
-&emsp;**Recommendation:** If you experience OOM errors, try reducing this value to **0.8** or lower.
+* **Description:** A value between `0.0` and `1.0` that specifies the fraction of free GPU memory to reserve for the KV cache after the model is loaded. Since memory usage can fluctuate, this buffer helps prevent out-of-memory (OOM) errors.
+* **Recommendation:** If you experience OOM errors, try reducing this value to `0.7` or lower.
 
 #### `--backend pytorch`
 
-&emsp;**Description:** Tells TensorRT-LLM to use the **pytorch** backend.
+* **Description:** Tells TensorRT-LLM to use the **pytorch** backend.
 
 #### `--max_batch_size`
 
-&emsp;**Description:** The maximum number of user requests that can be grouped into a single batch for processing.
+* **Description:** The maximum number of user requests that can be grouped into a single batch for processing.
 
 #### `--max_num_tokens`
 
-&emsp;**Description:** The maximum total number of tokens (across all requests) allowed inside a single scheduled batch.
+* **Description:** The maximum total number of tokens (across all requests) allowed inside a single scheduled batch.
 
 #### `--max_seq_len`
 
-&emsp;**Description:** The maximum possible sequence length for a single request, including both input and generated output tokens.
+* **Description:** The maximum possible sequence length for a single request, including both input and generated output tokens.
 
 #### `--trust_remote_code`
 
-&emsp;**Description:** Allows TensorRT-LLM to download models and tokenizers from Hugging Face. This flag is passed directly to the Hugging Face API.
+* **Description:** Allows TensorRT-LLM to download models and tokenizers from Hugging Face. This flag is passed directly to the Hugging Face API.
 
 
 #### Extra LLM API Options (YAML Configuration)
 
-These options provide finer control over performance and are set within a YAML file passed to the trtllm-serve command via the `--extra_llm_api_options` argument.
+These options provide finer control over performance and are set within a YAML file passed to the `trtllm-serve` command via the `--extra_llm_api_options` argument.
 
 #### `kv_cache_config`
 
-&emsp;**Description**: A section for configuring the Key-Value (KV) cache.
+* **Description**: A section for configuring the Key-Value (KV) cache.
 
-&emsp;**Options**:
+* **Options**:
 
-&emsp;&emsp;`dtype`: Sets the data type for the KV cache.
-
-&emsp;&emsp;**Default**: auto (uses the data type specified in the model checkpoint).
+  * `dtype`: Sets the data type for the KV cache.
+    **Default**: `"auto"` (uses the data type specified in the model checkpoint).
 
 #### `cuda_graph_config`
 
-&emsp;**Description**: A section for configuring CUDA graphs to optimize performance.
+* **Description**: A section for configuring CUDA graphs to optimize performance.
 
-&emsp;**Options**:
+* **Options**:
 
-&emsp;&emsp;`enable_padding`: If true, input batches are padded to the nearest `cuda_graph_batch_size`. This can significantly improve performance.
+  * `enable_padding`: If `"true"`, input batches are padded to the nearest `cuda_graph_batch_size`. This can significantly improve performance.
 
-&emsp;&emsp;**Default**: false
+    **Default**: `false`
 
-&emsp;&emsp;`max_batch_size`: Sets the maximum batch size for which a CUDA graph will be created.
+  * `max_batch_size`: Sets the maximum batch size for which a CUDA graph will be created.
 
-&emsp;&emsp;**Default**: 0
+    **Default**: `0`
 
-&emsp;&emsp;**Recommendation**: Set this to the same value as the `--max_batch_size` command-line option.
+    **Recommendation**: Set this to the same value as the `--max_batch_size` command-line option.
 
-&emsp;&emsp;`batch_sizes`: A specific list of batch sizes to create CUDA graphs for.
+  * `batch_sizes`: A specific list of batch sizes to create CUDA graphs for.
 
-&emsp;&emsp;**Default**: None
+     **Default**: `None`
 
 #### `moe_config`
 
-&emsp;**Description**: Configuration for Mixture-of-Experts (MoE) models.
+* **Description**: Configuration for Mixture-of-Experts (MoE) models.
 
-&emsp;**Options**:
+* **Options**:
 
-&emsp;&emsp;`backend`: The backend to use for MoE operations.
-
-&emsp;&emsp;**Default**: CUTLASS
+  * `backend`: The backend to use for MoE operations.
+    **Default**: `CUTLASS`
 
 #### `attention_backend`
 
-&emsp;**Description**: The backend to use for attention calculations.
+* **Description**: The backend to use for attention calculations.
 
-&emsp;**Default**: TRTLLM
+* **Default**: `TRTLLM`
 
-See the [TorchLlmArgs](https://nvidia.github.io/TensorRT-LLM/llm-api/reference.html#tensorrt_llm.llmapi.TorchLlmArgs) class for the full list of options which can be used in the `extra_llm_api_options`.
+See the [`TorchLlmArgs` class](https://nvidia.github.io/TensorRT-LLM/llm-api/reference.html#tensorrt_llm.llmapi.TorchLlmArgs) for the full list of options which can be used in the `extra_llm_api_options`.
 
 ## Testing API Endpoint
 
@@ -216,11 +214,11 @@ Here is an example response, showing that the TRT-LLM server returns “New York
 * Ensure your model checkpoints are compatible with the expected format.
 * For performance issues, check GPU utilization with nvidia-smi while the server is running.
 * If the container fails to start, verify that the NVIDIA Container Toolkit is properly installed.
-* For connection issues, make sure port 8000 is not being used by another application.
+* For connection issues, make sure the server port (`8000` in this guide) is not being used by another application.
 
 ### Running Evaluations to Verify Accuracy (Optional)
 
-We use the lm-eval tool to test the model’s accuracy. For more information see [https://github.com/EleutherAI/lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness).
+We use the lm-eval tool to test the model’s accuracy. For more information see <https://github.com/EleutherAI/lm-evaluation-harness>.
 
 To run the evaluation harness exec into the running TensorRT-LLM container and install with this command:
 
@@ -240,7 +238,7 @@ lm_eval --model local-completions  --tasks gsm8k --batch_size 256 --gen_kwargs t
 
 Sample result in Blackwell.
 
-```shell
+```
 |Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
 |-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
 |gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9189|±  |0.0075|
@@ -257,7 +255,7 @@ lm_eval --model local-completions  --tasks gsm8k --batch_size 256 --gen_kwargs t
 
 Sample result in Blackwell
 
-```shell
+```
 |Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
 |-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
 |gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9075|±  |0.0080|
@@ -266,7 +264,7 @@ Sample result in Blackwell
 
 ## Benchmarking Performance
 
-To benchmark the performance of your TensorRT-LLM server you can leverage the built-in `benchmark_serving.py` script. To do this first creating a wrapper [bench.sh](http://bench.sh) script.
+To benchmark the performance of your TensorRT-LLM server you can leverage the built-in `benchmark_serving.py` script. To do this first creating a wrapper `bench.sh` script.
 
 ```shell
 cat <<EOF >  bench.sh
@@ -306,7 +304,7 @@ If you want to save the results to a file add the following options.
 --result-filename "concurrency_${concurrency}.json"
 ```
 
-For more benchmarking options see. [https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt\_llm/serve/scripts/benchmark\_serving.py](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/serve/scripts/benchmark_serving.py)
+For more benchmarking options see <https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt\_llm/serve/scripts/benchmark\_serving.py>.
 
 Run bench.sh to begin a serving benchmark. This will take a long time if you run all the concurrencies mentioned in the above bench.sh script.
 


### PR DESCRIPTION
This is to address Kaiyu's offline suggestion to
https://github.com/NVIDIA/TensorRT-LLM/pull/6853 .

Keep this separate from the original PR for clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Polished deployment guides for DeepSeek R1, Llama3.3‑70B, and Llama4 Scout.
  * Standardized formatting of commands, URLs, ports, paths, and options (inline code, code blocks, angle-bracket links).
  * Converted prerequisites and parameters to clear bullet lists with consistent defaults and value styling.
  * Expanded and clarified YAML/CLI examples and configuration sections (cache, CUDA/attention/MoE).
  * Improved troubleshooting, benchmarking, and sample-output presentation; no behavior or command changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->