### PR TITLE
[https://nvbugs/5445466][fix] Bypass MLP TP split for MNNVL in DeepSeek V3 to avoid hanging.

### DIFF
--- a/tensorrt_llm/_torch/distributed/ops.py
+++ b/tensorrt_llm/_torch/distributed/ops.py
@@ -420,7 +420,9 @@ class AllReduce(nn.Module):
             # Initialize MNNVL AllReduce if needed
             if self.strategy in (AllReduceStrategy.AUTO, AllReduceStrategy.MNNVL):
                 if self.mapping.tp_size != self.mapping.world_size:
-                    logger.debug(f"MNNVLAllReduce is disabled due to tp_size != world_size")
+                    logger.debug(
+                        f"MNNVLAllReduce is disabled due to tp_size:{self.mapping.tp_size} != world_size:{self.mapping.world_size}"
+                    )
                     self.mnnvl_allreduce = None
                 elif MNNVLAllReduce.is_mnnvl(self.mapping, dtype):
                     try:

--- a/tensorrt_llm/_torch/distributed/ops.py
+++ b/tensorrt_llm/_torch/distributed/ops.py
@@ -21,11 +21,11 @@ logger = logging.getLogger(__name__)
 
 
 def get_allreduce_workspace(mapping: Mapping) -> torch.LongTensor:
-    if not hasattr(_thread_local, f"allreduce_workspaces_{mapping.pp_rank}"):
-        setattr(_thread_local, f"allreduce_workspaces_{mapping.pp_rank}", {})
+    if not hasattr(_thread_local, f'allreduce_workspaces_{mapping.pp_rank}'):
+        setattr(_thread_local, f'allreduce_workspaces_{mapping.pp_rank}', {})
 
     allreduce_workspaces = getattr(_thread_local,
-                                   f"allreduce_workspaces_{mapping.pp_rank}")
+                                   f'allreduce_workspaces_{mapping.pp_rank}')
     if mapping not in allreduce_workspaces:
         ipc_buffers, workspace = CustomAllReduceHelper.allocate_allreduce_fusion_workspace(
             mapping,
@@ -37,7 +37,7 @@ def get_allreduce_workspace(mapping: Mapping) -> torch.LongTensor:
 
 
 def allocate_low_presicion_allreduce_workspace(mapping: Mapping) -> None:
-    if not hasattr(_thread_local, "lowprecision_allreduce_workspaces"):
+    if not hasattr(_thread_local, 'lowprecision_allreduce_workspaces'):
         _thread_local.lowprecision_allreduce_workspaces = {}
     lowprecision_allreduce_workspaces = _thread_local.lowprecision_allreduce_workspaces
     if mapping not in lowprecision_allreduce_workspaces:
@@ -56,14 +56,14 @@ def get_allreduce_mnnvl_workspace(
     mapping: Mapping, dtype: torch.dtype
 ) -> Tuple[McastGPUBuffer, torch.Tensor, torch.Tensor, int]:
     if not hasattr(_thread_local,
-                   f"allreduce_mnnvl_workspaces_{mapping.pp_rank}"):
-        setattr(_thread_local, f"allreduce_mnnvl_workspaces_{mapping.pp_rank}",
+                   f'allreduce_mnnvl_workspaces_{mapping.pp_rank}'):
+        setattr(_thread_local, f'allreduce_mnnvl_workspaces_{mapping.pp_rank}',
                 {})
 
     force_mn = os.environ.get("TRTLLM_FORCE_MNNVL_AR", "0") == "1"
 
     allreduce_mnnvl_workspaces = getattr(
-        _thread_local, f"allreduce_mnnvl_workspaces_{mapping.pp_rank}")
+        _thread_local, f'allreduce_mnnvl_workspaces_{mapping.pp_rank}')
     if mapping not in allreduce_mnnvl_workspaces:
         # buffer shape: [3, 2, buffer_tokens, hidden_dim]
         stride = 3 * 2 * dtype.itemsize
@@ -116,7 +116,7 @@ def get_output_info(input: torch.Tensor, dim: int) -> List[int]:
         val if idx != dim else -1 for idx, val in enumerate(input.shape)
     ]
     numel_base = -math.prod(output_shape)
-    return {"output_shape": output_shape, "numel_base": numel_base}
+    return {'output_shape': output_shape, 'numel_base': numel_base}
 
 
 def filter_valid_input(
@@ -144,7 +144,7 @@ def allgather(
     dim: int = -1,
     sizes: Optional[List[int]] = None,
 ) -> Union[torch.Tensor, List[torch.Tensor]]:
-    """
+    '''
     Add an operation that performs a collective all-gather.
 
     If 'sizes' is 'None', the input tensors in the different ranks must have the same shape.
@@ -168,7 +168,7 @@ def allgather(
         sizes(Optional[List[int]]): An optional list indicating 'input.shape[dim]' in all ranks. By default None.
     Returns:
         The gathered tensor or tensor list.
-    """
+    '''
     if mapping.tp_size == 1:
         return input
 
@@ -186,13 +186,13 @@ def allgather(
     if isinstance(input, torch.Tensor):
         torch_op = torch.ops.trtllm.allgather
         output_info = get_output_info(input, dim)
-        input = input.contiguous().view(-1, output_info["numel_base"])
+        input = input.contiguous().view(-1, output_info['numel_base'])
     else:
         input, valid = filter_valid_input(input)
         torch_op = torch.ops.trtllm.allgather_list
         output_info = [get_output_info(val, dim) for val in input]
         input = [
-            val.contiguous().view(-1, val_info["numel_base"])
+            val.contiguous().view(-1, val_info['numel_base'])
             for val, val_info in zip(input, output_info)
         ]
 
@@ -204,13 +204,13 @@ def allgather(
 
     def convert_output(x, x_info):
         if dim == 0:
-            x = x.view(x_info["output_shape"])
+            x = x.view(x_info['output_shape'])
         else:
             if sizes is None:
                 x_list = x.chunk(mapping.tp_size)
             else:
                 x_list = x.split(sizes)
-            x = torch.cat([x.reshape(x_info["output_shape"]) for x in x_list],
+            x = torch.cat([x.reshape(x_info['output_shape']) for x in x_list],
                           dim=dim)
         return x
 
@@ -248,13 +248,13 @@ def reducescatter(
     def convert_input(x, x_info):
         # Inputs are reshaped in this way to pass necessary shape information to the reducescatter op
         if dim == 0:
-            x = x.contiguous().view(-1, x_info["numel_base"])
+            x = x.contiguous().view(-1, x_info['numel_base'])
         else:
             if sizes is None:
                 x_list = x.chunk(mapping.tp_size, dim=dim)
             else:
                 x_list = x.split(sizes, dim=dim)
-            x = torch.cat([x.reshape(-1, x_info["numel_base"]) for x in x_list])
+            x = torch.cat([x.reshape(-1, x_info['numel_base']) for x in x_list])
         return x
 
     if isinstance(input, torch.Tensor):
@@ -277,10 +277,10 @@ def reducescatter(
     )
 
     if isinstance(input, torch.Tensor):
-        output = output.view(output_info["output_shape"])
+        output = output.view(output_info['output_shape'])
     else:
         output = [
-            val.view(val_info["output_shape"])
+            val.view(val_info['output_shape'])
             for val, val_info in zip(output, output_info)
         ]
         output = restore_full_output(output, valid)
@@ -300,12 +300,13 @@ class MNNVLAllReduce(nn.Module):
         super().__init__()
         self.mapping = mapping
         self.dtype = dtype
-        assert dtype in MNNVLAllReduce.get_supported_dtypes() and (
-            not mapping.has_cp()
+        assert (
+            dtype in MNNVLAllReduce.get_supported_dtypes()
+            and (not mapping.has_cp())
         ), "MNNVL all reduce only supports dtype {MNNVLAllReduce.get_supported_dtypes()} and without cp."
 
-        self.mcast_buffer_mnnvl, self.buffer_mnnvl, self.buffer_flags_mnnvl, self.max_num_elements_mnnvl = (
-            get_allreduce_mnnvl_workspace(self.mapping, dtype))
+        self.mcast_buffer_mnnvl, self.buffer_mnnvl, self.buffer_flags_mnnvl, self.max_num_elements_mnnvl = get_allreduce_mnnvl_workspace(
+            self.mapping, dtype)
 
     @staticmethod
     def get_supported_dtypes():
@@ -397,14 +398,12 @@ class MNNVLAllReduce(nn.Module):
 
 class AllReduce(nn.Module):
 
-    def __init__(
-        self,
-        mapping: Mapping,
-        strategy: AllReduceStrategy = AllReduceStrategy.AUTO,
-        dtype: Optional[torch.dtype] = None,
-    ):
+    def __init__(self,
+                 mapping: Mapping,
+                 strategy: AllReduceStrategy = AllReduceStrategy.AUTO,
+                 dtype: Optional[torch.dtype] = None):
         super().__init__()
-        """
+        '''
         AllReduce is a module that performs an all-reduce operation on a tensor.
 
         Args:
@@ -441,7 +440,7 @@ class AllReduce(nn.Module):
             https://github.com/NVIDIA/TensorRT-LLM/blob/main/tests/unittest/_torch/multi_gpu/test_allreduce.py
 
             The LOWPRECISION strategy can be selected either by directly specifying it in the constructor.
-        """
+        '''
 
         self.mapping = mapping
         self.workspace = None
@@ -623,8 +622,8 @@ class MoEAllReduce(nn.Module):
                 eps=all_reduce_params.eps,
             )
         else:
-            assert (all_reduce_params.residual.shape[0] <= self.max_token
-                    ), "Num tokens must be less than or equal to max_token"
+            assert all_reduce_params.residual.shape[
+                0] <= self.max_token, "Num tokens must be less than or equal to max_token"
 
             return torch.ops.trtllm.moe_finalize_allreduce(
                 input=input,

--- a/tensorrt_llm/_torch/distributed/ops.py
+++ b/tensorrt_llm/_torch/distributed/ops.py
@@ -403,7 +403,7 @@ class AllReduce(nn.Module):
                  strategy: AllReduceStrategy = AllReduceStrategy.AUTO,
                  dtype: Optional[torch.dtype] = None):
         super().__init__()
-        '''
+        """
         AllReduce is a module that performs an all-reduce operation on a tensor.
 
         Args:
@@ -440,7 +440,7 @@ class AllReduce(nn.Module):
             https://github.com/NVIDIA/TensorRT-LLM/blob/main/tests/unittest/_torch/multi_gpu/test_allreduce.py
 
             The LOWPRECISION strategy can be selected either by directly specifying it in the constructor.
-        '''
+        """
 
         self.mapping = mapping
         self.workspace = None
@@ -486,7 +486,7 @@ class AllReduce(nn.Module):
         *,
         all_reduce_params: Optional[AllReduceParams] = None,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, ...]]:
-        """
+        '''
         The input tensors in the different ranks must have the same shape.
         The output tensor will have that same shape with the input tensor.
         The output tensor will be replicated among the TP group.
@@ -508,7 +508,7 @@ class AllReduce(nn.Module):
             RESIDUAL_RMS_NORM_OUT_QUANT_FP8: [norm, norm_quant, residual]
             RESIDUAL_RMS_NORM_QUANT_NVFP4: [norm_quant_fp4, scale_factor, residual]
             RESIDUAL_RMS_NORM_OUT_QUANT_NVFP4: [norm, norm_quant_fp4, scale_factor, residual]
-        """
+        '''
         if self.mapping.tp_size == 1 or (all_reduce_params is not None
                                          and all_reduce_params.enable_allreduce
                                          == False):

--- a/tensorrt_llm/_torch/distributed/ops.py
+++ b/tensorrt_llm/_torch/distributed/ops.py
@@ -312,6 +312,7 @@ class MNNVLAllReduce(nn.Module):
     def get_supported_dtypes():
         return (torch.float16, torch.bfloat16, torch.float32)
 
+    # Check if MNNVL is supported
     @staticmethod
     def is_mnnvl(mapping: Mapping, dtype: torch.dtype) -> bool:
         from tensorrt_llm._mnnvl_utils import MnnvlMemory
@@ -321,6 +322,14 @@ class MNNVLAllReduce(nn.Module):
         return (dtype in MNNVLAllReduce.get_supported_dtypes()
                 and not mapping.has_cp() and mapping.is_multi_node()
                 and MnnvlMemory.supports_mnnvl() and is_on_aarch64)
+
+    # Check if MNNVL strategy is used
+    @staticmethod
+    def should_use_mnnvl(strategy: AllReduceStrategy, mapping: Mapping,
+                         dtype: torch.dtype) -> bool:
+        if strategy in (AllReduceStrategy.AUTO, AllReduceStrategy.MNNVL):
+            return MNNVLAllReduce.is_mnnvl(mapping, dtype)
+        return False
 
     def forward(
         self,

--- a/tensorrt_llm/_torch/distributed/ops.py
+++ b/tensorrt_llm/_torch/distributed/ops.py
@@ -422,7 +422,7 @@ class AllReduce(nn.Module):
                 if self.mapping.tp_size != self.mapping.world_size:
                     logger.debug(f"MNNVLAllReduce is disabled due to tp_size != world_size")
                     self.mnnvl_allreduce = None
-                if MNNVLAllReduce.is_mnnvl(self.mapping, dtype):
+                elif MNNVLAllReduce.is_mnnvl(self.mapping, dtype):
                     try:
                         self.mnnvl_allreduce = MNNVLAllReduce(self.mapping, dtype) if dtype else None
                         if self.mnnvl_allreduce:

--- a/tensorrt_llm/_torch/distributed/ops.py
+++ b/tensorrt_llm/_torch/distributed/ops.py
@@ -421,8 +421,8 @@ class AllReduce(nn.Module):
             if self.strategy in (AllReduceStrategy.AUTO, AllReduceStrategy.MNNVL):
                 if self.mapping.tp_size != self.mapping.world_size:
                     logger.debug(
-                        f"MNNVLAllReduce is disabled due to tp_size:{self.mapping.tp_size} != world_size:{self.mapping.world_size}"
-                    )
+                        f"MNNVLAllReduce is disabled due to tp_size:{self.mapping.tp_size} "
+                        f"!= world_size:{self.mapping.world_size}")
                     self.mnnvl_allreduce = None
                 elif MNNVLAllReduce.is_mnnvl(self.mapping, dtype):
                     try:

--- a/tensorrt_llm/_torch/distributed/ops.py
+++ b/tensorrt_llm/_torch/distributed/ops.py
@@ -323,14 +323,6 @@ class MNNVLAllReduce(nn.Module):
                 and not mapping.has_cp() and mapping.is_multi_node()
                 and MnnvlMemory.supports_mnnvl() and is_on_aarch64)
 
-    # Check if MNNVL strategy is used
-    @staticmethod
-    def should_use_mnnvl(strategy: AllReduceStrategy, mapping: Mapping,
-                         dtype: torch.dtype) -> bool:
-        if strategy in (AllReduceStrategy.AUTO, AllReduceStrategy.MNNVL):
-            return MNNVLAllReduce.is_mnnvl(mapping, dtype)
-        return False
-
     def forward(
         self,
         input: torch.Tensor,
@@ -488,6 +480,9 @@ class AllReduce(nn.Module):
                         f"MNNVLAllReduce can't be enabled due to failing the is_mnnvl check."
                     )
                     self.mnnvl_allreduce = None
+
+    def is_mnnvl(self) -> bool:
+        return self.mnnvl_allreduce is not None
 
     def forward(
         self,

--- a/tensorrt_llm/_torch/distributed/ops.py
+++ b/tensorrt_llm/_torch/distributed/ops.py
@@ -10,7 +10,8 @@ from torch import nn
 
 from tensorrt_llm._utils import mpi_barrier
 from tensorrt_llm.bindings.internal.runtime import McastGPUBuffer
-from tensorrt_llm.functional import AllReduceFusionOp, AllReduceParams, AllReduceStrategy, MoEAllReduceParams
+from tensorrt_llm.functional import (AllReduceFusionOp, AllReduceParams,
+                                     AllReduceStrategy, MoEAllReduceParams)
 from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.plugin.plugin import CustomAllReduceHelper
@@ -23,11 +24,13 @@ def get_allreduce_workspace(mapping: Mapping) -> torch.LongTensor:
     if not hasattr(_thread_local, f"allreduce_workspaces_{mapping.pp_rank}"):
         setattr(_thread_local, f"allreduce_workspaces_{mapping.pp_rank}", {})
 
-    allreduce_workspaces = getattr(_thread_local, f"allreduce_workspaces_{mapping.pp_rank}")
+    allreduce_workspaces = getattr(_thread_local,
+                                   f"allreduce_workspaces_{mapping.pp_rank}")
     if mapping not in allreduce_workspaces:
         ipc_buffers, workspace = CustomAllReduceHelper.allocate_allreduce_fusion_workspace(
             mapping,
-            CustomAllReduceHelper.max_workspace_size_auto(mapping.tp_size, support_deterministic=False),
+            CustomAllReduceHelper.max_workspace_size_auto(
+                mapping.tp_size, support_deterministic=False),
         )
         allreduce_workspaces[mapping] = (ipc_buffers, workspace)
     return allreduce_workspaces[mapping][1]
@@ -40,28 +43,34 @@ def allocate_low_presicion_allreduce_workspace(mapping: Mapping) -> None:
     if mapping not in lowprecision_allreduce_workspaces:
         ipc_buffers, workspace = CustomAllReduceHelper.allocate_lowprecision_workspace(
             mapping,
-            CustomAllReduceHelper.max_workspace_size_lowprecision(mapping.tp_size),
+            CustomAllReduceHelper.max_workspace_size_lowprecision(
+                mapping.tp_size),
         )
         lowprecision_allreduce_workspaces[mapping] = (ipc_buffers, workspace)
-        CustomAllReduceHelper.initialize_lowprecision_buffers(workspace, mapping.tp_size)
+        CustomAllReduceHelper.initialize_lowprecision_buffers(
+            workspace, mapping.tp_size)
     return
 
 
 def get_allreduce_mnnvl_workspace(
     mapping: Mapping, dtype: torch.dtype
 ) -> Tuple[McastGPUBuffer, torch.Tensor, torch.Tensor, int]:
-    if not hasattr(_thread_local, f"allreduce_mnnvl_workspaces_{mapping.pp_rank}"):
-        setattr(_thread_local, f"allreduce_mnnvl_workspaces_{mapping.pp_rank}", {})
+    if not hasattr(_thread_local,
+                   f"allreduce_mnnvl_workspaces_{mapping.pp_rank}"):
+        setattr(_thread_local, f"allreduce_mnnvl_workspaces_{mapping.pp_rank}",
+                {})
 
     force_mn = os.environ.get("TRTLLM_FORCE_MNNVL_AR", "0") == "1"
 
-    allreduce_mnnvl_workspaces = getattr(_thread_local, f"allreduce_mnnvl_workspaces_{mapping.pp_rank}")
+    allreduce_mnnvl_workspaces = getattr(
+        _thread_local, f"allreduce_mnnvl_workspaces_{mapping.pp_rank}")
     if mapping not in allreduce_mnnvl_workspaces:
         # buffer shape: [3, 2, buffer_tokens, hidden_dim]
         stride = 3 * 2 * dtype.itemsize
         # Max hidden_size_to_support
         max_hidden_dim = 16384
-        buffer_size_in_bytes = math.ceil(12_000_000 / (max_hidden_dim * stride)) * (max_hidden_dim * stride)
+        buffer_size_in_bytes = math.ceil(
+            12_000_000 / (max_hidden_dim * stride)) * (max_hidden_dim * stride)
         max_num_elements = buffer_size_in_bytes // stride
 
         mcast_buffer = McastGPUBuffer(
@@ -72,7 +81,8 @@ def get_allreduce_mnnvl_workspace(
             True,  # mnNvlink
         )
 
-        buffer = mcast_buffer.get_uc_buffer(mapping.tp_rank, (3, 2, max_num_elements), dtype, 0)
+        buffer = mcast_buffer.get_uc_buffer(mapping.tp_rank,
+                                            (3, 2, max_num_elements), dtype, 0)
         # Only initialize the buffer when we need to resize it
         buffer.fill_(-0.0)
         # CPU barrier since we assume this should not be called in cuda graph
@@ -82,32 +92,44 @@ def get_allreduce_mnnvl_workspace(
         # This is a buffer to maintain the state of this allreduce Op
         # Should have the same lifetime with self._buffer
         # [Buffer_ptr, Clear_ptr, num_tokens_to_clear,atomic access counter]
-        buffer_flags = torch.tensor([0, 2, 0, 0], dtype=torch.uint32, device=torch.device("cuda", mapping.local_rank))
+        buffer_flags = torch.tensor([0, 2, 0, 0],
+                                    dtype=torch.uint32,
+                                    device=torch.device("cuda",
+                                                        mapping.local_rank))
 
-        allreduce_mnnvl_workspaces[mapping] = (mcast_buffer, buffer, buffer_flags, max_num_elements)
+        allreduce_mnnvl_workspaces[mapping] = (mcast_buffer, buffer,
+                                               buffer_flags, max_num_elements)
     return allreduce_mnnvl_workspaces[mapping]
 
 
-def userbuffers_allreduce_finalize(input: torch.Tensor, force_applying_finalize: bool = False) -> torch.Tensor:
-    output = torch.ops.trtllm.userbuffers_allreduce_finalize(input, force_applying_finalize)
+def userbuffers_allreduce_finalize(
+        input: torch.Tensor,
+        force_applying_finalize: bool = False) -> torch.Tensor:
+    output = torch.ops.trtllm.userbuffers_allreduce_finalize(
+        input, force_applying_finalize)
     return output
 
 
 def get_output_info(input: torch.Tensor, dim: int) -> List[int]:
     dim = dim % input.ndim
-    output_shape = [val if idx != dim else -1 for idx, val in enumerate(input.shape)]
+    output_shape = [
+        val if idx != dim else -1 for idx, val in enumerate(input.shape)
+    ]
     numel_base = -math.prod(output_shape)
     return {"output_shape": output_shape, "numel_base": numel_base}
 
 
-def filter_valid_input(input_list: List[torch.Tensor]) -> Tuple[List[torch.Tensor], List[bool]]:
+def filter_valid_input(
+        input_list: List[torch.Tensor]
+) -> Tuple[List[torch.Tensor], List[bool]]:
     func_valid = lambda x: x is not None
     valid_list = list(map(func_valid, input_list))
     input_list = list(filter(func_valid, input_list))
     return input_list, valid_list
 
 
-def restore_full_output(valid_outputs: List[torch.Tensor], valid_list: List[bool]) -> List[torch.Tensor]:
+def restore_full_output(valid_outputs: List[torch.Tensor],
+                        valid_list: List[bool]) -> List[torch.Tensor]:
     idx = 0
     full_outputs = []
     for v in valid_list:
@@ -155,7 +177,10 @@ def allgather(
         if isinstance(input, torch.Tensor):
             assert input.shape[dim] == sizes[mapping.tp_rank]
         else:
-            assert all([val.shape[dim] == sizes[mapping.tp_rank] for val in input if val is not None])
+            assert all([
+                val.shape[dim] == sizes[mapping.tp_rank] for val in input
+                if val is not None
+            ])
 
     # Inputs are reshaped in this way to pass necessary shape information to the allgather op
     if isinstance(input, torch.Tensor):
@@ -166,7 +191,10 @@ def allgather(
         input, valid = filter_valid_input(input)
         torch_op = torch.ops.trtllm.allgather_list
         output_info = [get_output_info(val, dim) for val in input]
-        input = [val.contiguous().view(-1, val_info["numel_base"]) for val, val_info in zip(input, output_info)]
+        input = [
+            val.contiguous().view(-1, val_info["numel_base"])
+            for val, val_info in zip(input, output_info)
+        ]
 
     output = torch_op(
         input,
@@ -182,13 +210,17 @@ def allgather(
                 x_list = x.chunk(mapping.tp_size)
             else:
                 x_list = x.split(sizes)
-            x = torch.cat([x.reshape(x_info["output_shape"]) for x in x_list], dim=dim)
+            x = torch.cat([x.reshape(x_info["output_shape"]) for x in x_list],
+                          dim=dim)
         return x
 
     if isinstance(input, torch.Tensor):
         output = convert_output(output, output_info)
     else:
-        output = [convert_output(val, val_info) for val, val_info in zip(output, output_info)]
+        output = [
+            convert_output(val, val_info)
+            for val, val_info in zip(output, output_info)
+        ]
         output = restore_full_output(output, valid)
     return output
 
@@ -208,7 +240,10 @@ def reducescatter(
         if isinstance(input, torch.Tensor):
             assert input.shape[dim] == sum_split_size
         else:
-            assert all([val.shape[dim] == sum_split_size for val in input if val is not None])
+            assert all([
+                val.shape[dim] == sum_split_size for val in input
+                if val is not None
+            ])
 
     def convert_input(x, x_info):
         # Inputs are reshaped in this way to pass necessary shape information to the reducescatter op
@@ -230,7 +265,10 @@ def reducescatter(
         input, valid = filter_valid_input(input)
         torch_op = torch.ops.trtllm.reducescatter_list
         output_info = [get_output_info(val, dim) for val in input]
-        input = [convert_input(val, val_info) for val, val_info in zip(input, output_info)]
+        input = [
+            convert_input(val, val_info)
+            for val, val_info in zip(input, output_info)
+        ]
 
     output = torch_op(
         input,
@@ -241,7 +279,10 @@ def reducescatter(
     if isinstance(input, torch.Tensor):
         output = output.view(output_info["output_shape"])
     else:
-        output = [val.view(val_info["output_shape"]) for val, val_info in zip(output, output_info)]
+        output = [
+            val.view(val_info["output_shape"])
+            for val, val_info in zip(output, output_info)
+        ]
         output = restore_full_output(output, valid)
     return output
 
@@ -264,8 +305,7 @@ class MNNVLAllReduce(nn.Module):
         ), "MNNVL all reduce only supports dtype {MNNVLAllReduce.get_supported_dtypes()} and without cp."
 
         self.mcast_buffer_mnnvl, self.buffer_mnnvl, self.buffer_flags_mnnvl, self.max_num_elements_mnnvl = (
-            get_allreduce_mnnvl_workspace(self.mapping, dtype)
-        )
+            get_allreduce_mnnvl_workspace(self.mapping, dtype))
 
     @staticmethod
     def get_supported_dtypes():
@@ -277,13 +317,9 @@ class MNNVLAllReduce(nn.Module):
 
         arch = platform.machine().lower()
         is_on_aarch64 = "aarch64" in arch
-        return (
-            dtype in MNNVLAllReduce.get_supported_dtypes()
-            and not mapping.has_cp()
-            and mapping.is_multi_node()
-            and MnnvlMemory.supports_mnnvl()
-            and is_on_aarch64
-        )
+        return (dtype in MNNVLAllReduce.get_supported_dtypes()
+                and not mapping.has_cp() and mapping.is_multi_node()
+                and MnnvlMemory.supports_mnnvl() and is_on_aarch64)
 
     def forward(
         self,
@@ -309,7 +345,9 @@ class MNNVLAllReduce(nn.Module):
         max_num_tokens = self.max_num_elements_mnnvl // hidden_dim
         num_elements_in_use = max_num_tokens * hidden_dim
         if num_tokens > max_num_tokens:
-            logger.debug(f"MNNVL AllReduce can't be enabled due to {num_tokens=} larger than {max_num_tokens=}.")
+            logger.debug(
+                f"MNNVL AllReduce can't be enabled due to {num_tokens=} larger than {max_num_tokens=}."
+            )
             return None
 
         # This should not happen but leave this check for future code changes
@@ -320,7 +358,9 @@ class MNNVLAllReduce(nn.Module):
             return None
 
         output = torch.empty_like(input)
-        buffer_mnnvl = self.buffer_mnnvl.view(-1)[: (3 * 2 * num_elements_in_use)].view(3, 2, -1, hidden_dim)
+        buffer_mnnvl = self.buffer_mnnvl.view(-1)[:(3 * 2 *
+                                                    num_elements_in_use)].view(
+                                                        3, 2, -1, hidden_dim)
 
         if fusion_op == AllReduceFusionOp.NONE:
             output = torch.ops.trtllm.mnnvl_twoshot_allreduce(
@@ -332,10 +372,8 @@ class MNNVLAllReduce(nn.Module):
             )
             return output.view(shape)
         # Fallback to use other allreduce if hidden_size is not supported
-        elif (
-            fusion_op == AllReduceFusionOp.RESIDUAL_RMS_NORM
-            and hidden_dim in MNNVLAllReduce.SUPPORTED_FUSION_HIDDEN_DIMS
-        ):
+        elif (fusion_op == AllReduceFusionOp.RESIDUAL_RMS_NORM
+              and hidden_dim in MNNVLAllReduce.SUPPORTED_FUSION_HIDDEN_DIMS):
             torch.ops.trtllm.mnnvl_twoshot_allreduce(
                 input,
                 buffer_mnnvl,
@@ -418,7 +456,8 @@ class AllReduce(nn.Module):
                 self.workspace = get_allreduce_workspace(self.mapping)
 
             # Initialize MNNVL AllReduce if needed
-            if self.strategy in (AllReduceStrategy.AUTO, AllReduceStrategy.MNNVL):
+            if self.strategy in (AllReduceStrategy.AUTO,
+                                 AllReduceStrategy.MNNVL):
                 if self.mapping.tp_size != self.mapping.world_size:
                     logger.debug(
                         f"MNNVLAllReduce is disabled due to tp_size:{self.mapping.tp_size} "
@@ -426,16 +465,20 @@ class AllReduce(nn.Module):
                     self.mnnvl_allreduce = None
                 elif MNNVLAllReduce.is_mnnvl(self.mapping, dtype):
                     try:
-                        self.mnnvl_allreduce = MNNVLAllReduce(self.mapping, dtype) if dtype else None
+                        self.mnnvl_allreduce = MNNVLAllReduce(
+                            self.mapping, dtype) if dtype else None
                         if self.mnnvl_allreduce:
                             logger.debug(f"MNNVLAllReduce is enabled")
                         else:
                             logger.debug(f"MNNVLAllReduce is disabled")
                     except Exception as e:
-                        logger.debug(f"MNNVL AllReduce can't be enabled due to {e}.")
+                        logger.debug(
+                            f"MNNVL AllReduce can't be enabled due to {e}.")
                         self.mnnvl_allreduce = None
                 else:
-                    logger.debug(f"MNNVLAllReduce can't be enabled due to failing the is_mnnvl check.")
+                    logger.debug(
+                        f"MNNVLAllReduce can't be enabled due to failing the is_mnnvl check."
+                    )
                     self.mnnvl_allreduce = None
 
     def forward(
@@ -467,7 +510,9 @@ class AllReduce(nn.Module):
             RESIDUAL_RMS_NORM_QUANT_NVFP4: [norm_quant_fp4, scale_factor, residual]
             RESIDUAL_RMS_NORM_OUT_QUANT_NVFP4: [norm, norm_quant_fp4, scale_factor, residual]
         """
-        if self.mapping.tp_size == 1 or (all_reduce_params is not None and all_reduce_params.enable_allreduce == False):
+        if self.mapping.tp_size == 1 or (all_reduce_params is not None
+                                         and all_reduce_params.enable_allreduce
+                                         == False):
             return input
 
         input = input.contiguous()  # Underlying op requires contiguous input
@@ -478,7 +523,8 @@ class AllReduce(nn.Module):
 
         # Try MNNVL AllReduce first if available
         if self.mnnvl_allreduce:
-            mnnvl_output = self.mnnvl_allreduce(input, all_reduce_params=all_reduce_params)
+            mnnvl_output = self.mnnvl_allreduce(
+                input, all_reduce_params=all_reduce_params)
             if mnnvl_output is not None:
                 return mnnvl_output
 
@@ -497,7 +543,8 @@ class AllReduce(nn.Module):
             strategy=allreduce_strategy,
             op=all_reduce_params.fusion_op,
             eps=all_reduce_params.eps,
-            trigger_completion_at_end=all_reduce_params.trigger_completion_at_end,
+            trigger_completion_at_end=all_reduce_params.
+            trigger_completion_at_end,
         )
 
         return output if len(output) > 1 else output[0]
@@ -576,15 +623,15 @@ class MoEAllReduce(nn.Module):
                 eps=all_reduce_params.eps,
             )
         else:
-            assert (
-                all_reduce_params.residual.shape[0] <= self.max_token
-            ), "Num tokens must be less than or equal to max_token"
+            assert (all_reduce_params.residual.shape[0] <= self.max_token
+                    ), "Num tokens must be less than or equal to max_token"
 
             return torch.ops.trtllm.moe_finalize_allreduce(
                 input=input,
                 residual=all_reduce_params.residual,
                 norm_weight=all_reduce_params.norm_weight,
-                expanded_idx_to_permuted_idx=all_reduce_params.expanded_idx_to_permuted_idx,
+                expanded_idx_to_permuted_idx=all_reduce_params.
+                expanded_idx_to_permuted_idx,
                 shared_expert_output=all_reduce_params.shared_expert_output,
                 expert_scale_factor=all_reduce_params.expert_scale_factor,
                 workspace=self.workspace,

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -52,7 +52,6 @@ from ..attention_backend import AttentionMetadata
 from ..attention_backend.interface import PositionalEmbeddingParams, RopeParams
 from ..distributed import (AllReduce, AllReduceFusionOp, AllReduceParams,
                            MoEAllReduce, MoEAllReduceParams, allgather)
-from ..distributed.ops import MNNVLAllReduce
 from ..model_config import ModelConfig
 from ..modules.attention import MLA
 from ..modules.decoder_layer import DecoderLayer
@@ -746,9 +745,8 @@ class DeepseekV3DecoderLayer(DecoderLayer):
                 self.mapping.tp_size,
             )
 
-            if tp > self.mapping.gpus_per_node and not MNNVLAllReduce.should_use_mnnvl(
-                    self.model_config.allreduce_strategy, self.mapping,
-                    self.config.torch_dtype):
+            if tp > self.mapping.gpus_per_node and not self.allreduce.is_mnnvl(
+            ):
                 mlp_tp_size = math.gcd(
                     tp,
                     self.mapping.gpus_per_node,

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -51,8 +51,8 @@ from tensorrt_llm.quantization.utils.fp8_utils import (
 from ..attention_backend import AttentionMetadata
 from ..attention_backend.interface import PositionalEmbeddingParams, RopeParams
 from ..distributed import (AllReduce, AllReduceFusionOp, AllReduceParams,
-                           MNNVLAllReduce, MoEAllReduce, MoEAllReduceParams,
-                           allgather)
+                           MoEAllReduce, MoEAllReduceParams, allgather)
+from ..distributed.ops import MNNVLAllReduce
 from ..model_config import ModelConfig
 from ..modules.attention import MLA
 from ..modules.decoder_layer import DecoderLayer

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -622,6 +622,10 @@ class DeepseekV3DecoderLayer(DecoderLayer):
 
         self.mapping = model_config.mapping
         mapping = self.mapping
+        self.allreduce = AllReduce(mapping=model_config.mapping,
+                                   strategy=model_config.allreduce_strategy,
+                                   dtype=config.torch_dtype)
+        self.moe_allreduce = MoEAllReduce(self.mapping)
 
         self.self_attn = DeepseekV3Attention(
             model_config,
@@ -695,10 +699,6 @@ class DeepseekV3DecoderLayer(DecoderLayer):
                                                 eps=config.rms_norm_eps,
                                                 dtype=config.torch_dtype)
         self.layer_idx = layer_idx
-        self.allreduce = AllReduce(mapping=model_config.mapping,
-                                   strategy=model_config.allreduce_strategy,
-                                   dtype=config.torch_dtype)
-        self.moe_allreduce = MoEAllReduce(self.mapping)
         self.next_layer_layernorm: RMSNorm = None
 
     def _get_decoder_layer_quant_config(

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -622,10 +622,6 @@ class DeepseekV3DecoderLayer(DecoderLayer):
 
         self.mapping = model_config.mapping
         mapping = self.mapping
-        self.allreduce = AllReduce(mapping=model_config.mapping,
-                                   strategy=model_config.allreduce_strategy,
-                                   dtype=config.torch_dtype)
-        self.moe_allreduce = MoEAllReduce(self.mapping)
 
         self.self_attn = DeepseekV3Attention(
             model_config,
@@ -647,6 +643,10 @@ class DeepseekV3DecoderLayer(DecoderLayer):
         self.is_nvfp4 = quant_config.layer_quant_mode.has_nvfp4()
 
         has_tp = mapping.has_tp()
+        self.allreduce = AllReduce(mapping=model_config.mapping,
+                                   strategy=model_config.allreduce_strategy,
+                                   dtype=config.torch_dtype)
+        self.moe_allreduce = MoEAllReduce(self.mapping)
 
         if (config.n_routed_experts is not None
                 and layer_idx >= config.first_k_dense_replace

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -746,10 +746,12 @@ class DeepseekV3DecoderLayer(DecoderLayer):
             )
 
             if tp > self.mapping.gpus_per_node and (
-                    self.allreduce.strategy not in (
+                    self.model_config.allreduce_strategy not in (
                         AllReduceStrategy.AUTO,
                         AllReduceStrategy.MNNVL,
-                    ) or not MNNVLAllReduce.is_mnnvl()):
+                    ) or not MNNVLAllReduce.is_mnnvl(
+                        self.mapping,
+                        self.model_config.pretrained_config.torch_dtype)):
                 mlp_tp_size = math.gcd(
                     tp,
                     self.mapping.gpus_per_node,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smarter MLP tensor-parallel sizing that adapts to cluster topology and chosen all-reduce strategy, reducing inter-node communication and improving scalability.
  * Runtime-aware selection of optimized all-reduce with safer fallbacks when the optimized path isn't applicable.

* **Bug Fixes**
  * Prevents enabling an optimized all-reduce mode when tensor-parallel and cluster/world sizes mismatch, with added diagnostic logging.

* **Chores**
  * All-reduce forward calls now require passing all_reduce_params as a keyword argument to clarify usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
This PR fixes the hanging issue when MNNVL is used for Deepseek V3. 
1. In the context of a multinode scenario, where the `is_mnnvl` function in MNNVLAllreduce indicates the availability of MNNVLink, we do not need to impose the restriction on the TP size within a single node for MLP.
2. Implement a fallback path when `tp_size != world_size` to prevent functional errors arising from unexpected parallel mapping. Subsequent work will attempt to eliminate this limitation by acquiring the correction mapping information within the multicast buffer initialization.

Relevant PR: [6860](https://github.com/NVIDIA/TensorRT-LLM/pull/6860), which should be reverted once we find this fix is satisfying.

Known Issue:

- The fallback path in MNNVLAllreduce is dynamically selected based on the number of tokens in each iteration. Consequently, when fallback occurs and a non-MNNVL strategy is employed, the MLP will incur the additional cost of inter-node communication.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
