### PR TITLE
[https://nvbugs/5448579][fix] EXAONE-4.0 accuracy test bugfix

### DIFF
--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -2372,10 +2372,8 @@ class TestPhi4MM(LlmapiAccuracyTestHarness):
 
 class TestEXAONE4(LlmapiAccuracyTestHarness):
     MODEL_NAME = "LGAI-EXAONE/EXAONE-4.0-32B"
-    kv_cache_config = KvCacheConfig(
-        enable_block_reuse=False,
-        enable_partial_reuse=False,
-        max_attention_window=[4096, 4096, 4096, 131072])
+    kv_cache_config = KvCacheConfig(enable_block_reuse=False,
+                                    enable_partial_reuse=False)
 
     def test_auto_dtype(self):
         model_path = f"{llm_models_root()}/EXAONE-4.0-32B"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified cache configuration in integration tests for the PyTorch LLM API by removing an unnecessary parameter and using clearer defaults, without altering test behavior or coverage.
* **Chores**
  * Internal test maintenance to improve readability and consistency. No user-facing changes or functionality impacted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->