### PR TITLE
[None][chore] add a EditorConfig config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# Auto basic formatting when saving file with EditorConfig https://editorconfig.org/
+
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# make
+[Makefile*]
+indent_style = tab
+indent_size = 4
+
+# c++
+[*.{cpp,cu,h}]
+indent_style = space
+indent_size = 4
+
+# python
+[*.py]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
Basic formatting such as "no trailing whitespace" will happen when saving the file with [EditorConfig](https://editorconfig.org/) extension.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added EditorConfig to enforce consistent formatting across editors (LF line endings, trim trailing whitespace, ensure final newline).
* **Style**
  * Standardized indentation: tabs with size 4 for Makefiles; spaces with size 4 for C/C++; spaces with size 4 for Python.
* **Notes**
  * No functional changes to the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->