### PR TITLE
[TRTLLM-4501][feat] Add input tensor pre-hook function API for the tuning process.

### DIFF
--- a/tensorrt_llm/_torch/autotuner.py
+++ b/tensorrt_llm/_torch/autotuner.py
@@ -92,10 +92,13 @@ class TuningConfig:
             any value is provided to the choose_one function, the input tensor will be saturated
             with the provided value.
             If not provided, the autotuner will not consider the max num tokens.
+        inputs_pre_hook (Callable): A function that takes a list of input tensors, returns a list of modified input tensors.
+            It is called before the input tensors are prepared for the tuning process to match the real data distribution.
     """
     dynamic_tensor_specs: Tuple[DynamicTensorSpec, ...] = ()
     constraint_specs: Tuple[ConstraintSpec, ...] = ()
     tune_max_num_tokens: int = None
+    inputs_pre_hook: Callable = None
 
 
 @dataclass(unsafe_hash=True)
@@ -660,6 +663,9 @@ class AutoTuner:
         min_time = float('inf')
         has_tuning_failure_occured = False
         best_runner_id, best_tactic = None, None
+        # If the inputs_pre_hook is provided, it will be called before profiling.
+        if tuning_config.inputs_pre_hook is not None:
+            input_tensors = tuning_config.inputs_pre_hook(input_tensors)
         for runner_id, runner in enumerate(runners):
             # TODO: use FakeTensor here.
             runner_arg_names = {

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -29,8 +29,8 @@ class MoERunner(TunableRunner):
     runner_dict = dict()
     tuning_config = TuningConfig(
         dynamic_tensor_specs=(DynamicTensorSpec(
-            0, 0, get_last_power_of_2_num_tokens_buckets(8192),
-            lambda x: min(last_positive_power_of_2(x), 8192)), ),
+            0, 0, get_last_power_of_2_num_tokens_buckets,
+            last_positive_power_of_2), ),
         tune_max_num_tokens=8192,
     )
 


### PR DESCRIPTION
Some tunable ops require a more realistic data distribution, for instance, a shape-associated tensor. Thus, a customizable pre-hook function can be declared in the tuning config to modify the input tensor before the tuning process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional input pre-processing hook to modify inputs before autotuning.
  * Added a configurable token cap to limit tokens used during tuning.
  * Expanded tactic selection to accept richer tactic configuration objects for profiling.

* **Tests**
  * Updated tests to cover input pre-processing, token caps, and the enhanced tactic configuration and profiling flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->