### PR TITLE
[TRTLLM-6835][fix] Fix potential hang caused by python multiprocessing when prefetching weights

### DIFF
--- a/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
@@ -1,6 +1,7 @@
 import glob
 import multiprocessing
 import os
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, List
 
 import psutil
@@ -120,7 +121,7 @@ class HfWeightLoader(BaseWeightLoader):
         if len(local_file_names) == 0:
             return
 
-        max_processes = min(multiprocessing.cpu_count() * 2, 16,
-                            len(local_file_names))
-        with multiprocessing.Pool(processes=max_processes) as pool:
-            pool.map(self._prefetch_one_file, local_file_names)
+        max_workers = min(multiprocessing.cpu_count() * 2, 16,
+                          len(local_file_names))
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            list(executor.map(self._prefetch_one_file, local_file_names))


### PR DESCRIPTION
This PR replaces multiprocessing with multithreading when prefetching weights, since the workload is I/O-bound. Python’s default fork start method for multiprocessing carries a risk of hangs (see https://github.com/python/cpython/issues/84559), and when used together with MPI it can deadlock. In theory, multithreading is the safer choice; we have verified on an 8-GPU node that loading DeepSeek-R1 takes no longer than before. See the following pics:
<img width="357" height="119" alt="截屏2025-08-15 10 39 46" src="https://github.com/user-attachments/assets/27061415-fb68-4424-bb3a-aee73ae70c17" />
<img width="659" height="391" alt="截屏2025-08-15 10 41 23" src="https://github.com/user-attachments/assets/843e67e7-ee04-4d72-a42a-89ade9f961bf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved prefetching performance by switching to thread-based parallelism for I/O tasks, enhancing reliability across environments.
  * Ensures all prefetch operations complete before continuing, resulting in smoother and potentially faster model initialization.
  * No configuration changes required; worker limits remain automatically tuned to system resources, helping reduce startup overhead on multi-core systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->