### PR TITLE
[TRTLLM-6549][feat] add perf metrics endpoint to openai server and openai disagg server

### DIFF
--- a/tensorrt_llm/llmapi/disagg_utils.py
+++ b/tensorrt_llm/llmapi/disagg_utils.py
@@ -52,6 +52,7 @@ class DisaggServerConfig():
     gen_router_config: Optional[RouterConfig] = None
     conditional_disagg_config: Optional[ConditionalDisaggConfig] = None
     max_retries: int = 3
+    perf_metrics_max_requests: int = 0
 
 
 @dataclass
@@ -61,6 +62,20 @@ class MetadataServerConfig():
     port: int = 2379
     health_check_timeout: float = 5.0
     refresh_interval: float = 10.0
+
+
+def get_ctx_gen_server_urls(
+        server_configs: list[CtxGenServerConfig]
+) -> tuple[list[str], list[str]]:
+    ctx_server_urls = []
+    gen_server_urls = []
+    for cfg in server_configs:
+        if cfg.type == "ctx":
+            ctx_server_urls.append(f"http://{cfg.hostname}:{cfg.port}")
+        else:
+            gen_server_urls.append(f"http://{cfg.hostname}:{cfg.port}")
+
+    return ctx_server_urls, gen_server_urls
 
 
 def parse_disagg_config_file(yaml_config_file: str):
@@ -77,6 +92,7 @@ def parse_disagg_config_file(yaml_config_file: str):
 def extract_disagg_cfg(hostname: str = 'localhost',
                        port: int = 8000,
                        max_retries: int = 3,
+                       perf_metrics_max_requests: int = 0,
                        context_servers: Optional[dict] = None,
                        generation_servers: Optional[dict] = None,
                        conditional_disagg_config: Optional[dict] = None,
@@ -115,7 +131,8 @@ def extract_disagg_cfg(hostname: str = 'localhost',
 
     config = DisaggServerConfig(server_configs, hostname, port,
                                 ctx_router_config, gen_router_config,
-                                conditional_disagg_config, max_retries)
+                                conditional_disagg_config, max_retries,
+                                perf_metrics_max_requests)
 
     return config
 

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -2115,6 +2115,12 @@ class TorchLlmArgs(BaseLlmArgs):
                                  description="Print iteration logs.",
                                  status="beta")
 
+    perf_metrics_max_requests: int = Field(
+        default=0,
+        description=
+        "The maximum number of requests for perf metrics. Must also set request_perf_metrics to true to get perf metrics.",
+        status="prototype")
+
     batch_wait_timeout_ms: float = Field(
         default=0,
         description=

--- a/tensorrt_llm/serve/openai_disagg_server.py
+++ b/tensorrt_llm/serve/openai_disagg_server.py
@@ -151,16 +151,15 @@ class OpenAIDisaggServer:
                     self.server_perf_metrics[server][ctx_request_id] = request_perf_metrics
             remain_keys = []
             for ctx_server, gen_server, ctx_request_id in self.perf_metrics_keys:
-                ctx_perf_metrics = self.server_perf_metrics[ctx_server].pop(ctx_request_id, None)
                 gen_perf_metrics = self.server_perf_metrics[gen_server].pop(ctx_request_id, None)
                 if gen_perf_metrics is None:
                     # generation not finished
                     remain_keys.append((ctx_server, gen_server, ctx_request_id))
                     continue
+                ctx_perf_metrics = self.server_perf_metrics[ctx_server].pop(ctx_request_id, None)
                 return_metrics.append({
                     "ctx_server": ctx_server,
                     "gen_server": gen_server,
-                    # "ctx_request_id": ctx_request_id,
                     "ctx_perf_metrics": ctx_perf_metrics,
                     "gen_perf_metrics": gen_perf_metrics})
             self.perf_metrics_keys = remain_keys

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -84,6 +84,8 @@ class OpenAIServer:
         else:
             self.model = model
         self.metrics_collector = None
+        self.perf_metrics = []
+        self.perf_metrics_lock = asyncio.Lock()
         if self.llm.args.return_perf_metrics:
             set_prometheus_multiproc_dir()
             self.metrics_collector = MetricsCollector({
@@ -159,6 +161,7 @@ class OpenAIServer:
         self.app.add_api_route("/v1/models", self.get_model, methods=["GET"])
         # TODO: the metrics endpoint only reports iteration stats, not the runtime stats for now
         self.app.add_api_route("/metrics", self.get_iteration_stats, methods=["GET"])
+        self.app.add_api_route("/perf_metrics", self.get_perf_metrics, methods=["GET"])
         # TODO: workaround before ETCD support
         self.app.add_api_route("/kv_cache_events", self.get_kv_cache_events, methods=["POST"])
         self.app.add_api_route("/v1/completions",
@@ -255,6 +258,31 @@ class OpenAIServer:
             stats.append(stat)
         return JSONResponse(content=stats)
 
+    async def get_perf_metrics(self) -> JSONResponse:
+        async with self.perf_metrics_lock:
+            perf_metrics = self.perf_metrics
+            self.perf_metrics = []
+        for metrics_dict in perf_metrics:
+            metrics = metrics_dict["perf_metrics"]
+            timing_metrics = metrics.timing_metrics
+            # TODO: other metrics
+            metrics_json = {
+                "first_iter": metrics.first_iter,
+                "last_iter": metrics.last_iter,
+                "arrival_time": timing_metrics.arrival_time.total_seconds(),
+                "first_scheduled_time": timing_metrics.first_scheduled_time.total_seconds(),
+                "first_token_time": timing_metrics.first_token_time.total_seconds(),
+                "last_token_time": timing_metrics.last_token_time.total_seconds(),
+            }
+            if timing_metrics.kv_cache_size > 0:
+                metrics_json.update({
+                    "kv_cache_size": timing_metrics.kv_cache_size,
+                    "kv_cache_transfer_start": timing_metrics.kv_cache_transfer_start.total_seconds(),
+                    "kv_cache_transfer_end": timing_metrics.kv_cache_transfer_end.total_seconds(),
+                })
+            metrics_dict["perf_metrics"] = metrics_json
+        return JSONResponse(content=perf_metrics)
+
     async def get_kv_cache_events(self) -> JSONResponse:
         events = []
         try:
@@ -264,6 +292,22 @@ class OpenAIServer:
             # queue is empty, no more events
             pass
         return JSONResponse(content=events)
+
+    async def _extract_metrics(self, res: RequestOutput):
+        if not res.finished:
+            return
+        if self.metrics_collector:
+            self.metrics_collector.log_metrics_dict(res.metrics_dict)
+        if self.llm.args.return_perf_metrics:
+            output = res.outputs[0]
+            item = {
+                "request_id": res.request_id,
+                "perf_metrics": res.outputs[0].request_perf_metrics
+            }
+            if output.disaggregated_params:
+                item["ctx_request_id"] = output.disaggregated_params.ctx_request_id
+            async with self.perf_metrics_lock:
+                self.perf_metrics.append(item)
 
     async def openai_chat(self, request: ChatCompletionRequest, raw_request: Request) -> Response:
 
@@ -280,8 +324,7 @@ class OpenAIServer:
                 post_processor, args = postproc_params.post_processor, postproc_params.postproc_args
             async for res in promise:
                 pp_results = res.outputs[0]._postprocess_result if self.postproc_worker_enabled else post_processor(res, args)
-                if res.finished and self.metrics_collector:
-                    self.metrics_collector.log_metrics_dict(res.metrics_dict)
+                await self._extract_metrics(res)
                 for pp_res in pp_results:
                     yield pp_res
             yield "data: [DONE]\n\n"
@@ -299,8 +342,7 @@ class OpenAIServer:
             # Add prompt_tokens_ids to the response
             if disaggregated_params and disaggregated_params.request_type and disaggregated_params.request_type == "context_only":
                 chat_response.prompt_token_ids = promise.prompt_token_ids
-            if promise.finished and self.metrics_collector:
-                self.metrics_collector.log_metrics_dict(promise.metrics_dict)
+            await self._extract_metrics(promise)
             return chat_response
 
         try:
@@ -469,8 +511,7 @@ class OpenAIServer:
             if disaggregated_params and disaggregated_params.request_type and disaggregated_params.request_type == "context_only":
                 # Include prompt token ids for context-only requests
                 pp_result.prompt_token_ids = response.prompt_token_ids
-            if response.finished and self.metrics_collector:
-                self.metrics_collector.log_metrics_dict(response.metrics_dict)
+            await self._extract_metrics(response)
             return pp_result
 
         def merge_completion_responses(responses: List[CompletionResponse]) -> CompletionResponse:
@@ -506,8 +547,7 @@ class OpenAIServer:
                     pp_result = post_processor(output, args)
                 else:
                     pp_result = output.outputs[0]._postprocess_result
-                if output.finished and self.metrics_collector:
-                    self.metrics_collector.log_metrics_dict(output.metrics_dict)
+                await self._extract_metrics(output)
                 for pp_res in pp_result:
                     yield pp_res
 

--- a/tests/integration/defs/disaggregated/test_configs/disagg_config_metrics.yaml
+++ b/tests/integration/defs/disaggregated/test_configs/disagg_config_metrics.yaml
@@ -5,11 +5,13 @@ free_gpu_memory_fraction: 0.25
 backend: "pytorch"
 cuda_graph_config: null
 disable_overlap_scheduler: True
+perf_metrics_max_requests: 1000
 context_servers:
   num_instances: 1
   tensor_parallel_size: 1
   pipeline_parallel_size: 1
   return_perf_metrics: True
+  perf_metrics_max_requests: 1000
   cache_transceiver_config:
     backend: DEFAULT
   urls:
@@ -19,6 +21,7 @@ generation_servers:
   tensor_parallel_size: 1
   pipeline_parallel_size: 1
   return_perf_metrics: True
+  perf_metrics_max_requests: 1000
   cache_transceiver_config:
     backend: DEFAULT
   urls:

--- a/tests/integration/defs/disaggregated/test_configs/disagg_config_metrics.yaml
+++ b/tests/integration/defs/disaggregated/test_configs/disagg_config_metrics.yaml
@@ -1,0 +1,25 @@
+hostname: localhost
+port: 8000
+model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
+free_gpu_memory_fraction: 0.25
+backend: "pytorch"
+cuda_graph_config: null
+disable_overlap_scheduler: True
+context_servers:
+  num_instances: 1
+  tensor_parallel_size: 1
+  pipeline_parallel_size: 1
+  return_perf_metrics: True
+  cache_transceiver_config:
+    backend: DEFAULT
+  urls:
+      - "localhost:8001"
+generation_servers:
+  num_instances: 1
+  tensor_parallel_size: 1
+  pipeline_parallel_size: 1
+  return_perf_metrics: True
+  cache_transceiver_config:
+    backend: DEFAULT
+  urls:
+      - "localhost:8002"

--- a/tests/integration/defs/disaggregated/test_disaggregated.py
+++ b/tests/integration/defs/disaggregated/test_disaggregated.py
@@ -547,7 +547,7 @@ def test_disaggregated_perf_metrics(disaggregated_test_root, llm_venv,
         with urllib.request.urlopen(f"{server_url}/perf_metrics",
                                     timeout=10) as resp:
             assert resp.status == 200
-            perf_metrics = json.loads(resp.read())
+            perf_metrics = json.load(resp)
         assert len(perf_metrics) > 0
         item = perf_metrics[0]
         assert "ctx_server" in item
@@ -556,8 +556,8 @@ def test_disaggregated_perf_metrics(disaggregated_test_root, llm_venv,
         assert "gen_perf_metrics" in item
         assert item["ctx_perf_metrics"]["ctx_request_id"] == item[
             "gen_perf_metrics"]["ctx_request_id"]
-        ctx_metrics = item["ctx_perf_metrics"]["perf_metrics"]
-        gen_metrics = item["gen_perf_metrics"]["perf_metrics"]
+        ctx_metrics = item["ctx_perf_metrics"]["perf_metrics"]["timing_metrics"]
+        gen_metrics = item["gen_perf_metrics"]["perf_metrics"]["timing_metrics"]
         # only one token is generated in ctx
         assert ctx_metrics["first_token_time"] == ctx_metrics["last_token_time"]
         assert ctx_metrics["last_token_time"] < gen_metrics["arrival_time"]

--- a/tests/integration/defs/disaggregated/test_disaggregated.py
+++ b/tests/integration/defs/disaggregated/test_disaggregated.py
@@ -17,6 +17,7 @@ import os
 import re
 import subprocess
 import tempfile
+from typing import Callable
 
 import pytest
 import yaml
@@ -33,6 +34,14 @@ def cleanup_output_files():
             os.remove(file)
         except FileNotFoundError:
             pass
+
+
+def get_disagg_server_url_from_cfg(config_file: str):
+    with open(config_file, 'r') as file:
+        config = yaml.safe_load(file)
+    server_host = config.get('hostname', 'localhost')
+    server_port = config.get('port', 8000)
+    return f"http://{server_host}:{server_port}"
 
 
 def get_test_config(test_desc, example_dir, test_root):
@@ -57,6 +66,7 @@ def get_test_config(test_desc, example_dir, test_root):
         (2, f"{test_configs_root}/disagg_config_cuda_graph_padding.yaml"),
         "mixed": (2, f"{test_configs_root}/disagg_config_mixed.yaml"),
         "overlap": (2, f"{test_configs_root}/disagg_config_overlap.yaml"),
+        "perf_metrics": (2, f"{test_configs_root}/disagg_config_metrics.yaml"),
         "trtllm_sampler":
         (2, f"{test_configs_root}/disagg_config_trtllm_sampler.yaml"),
         "load_balance":
@@ -152,7 +162,8 @@ def run_disaggregated_test(example_dir,
                            num_iters=5,
                            env=None,
                            cwd=None,
-                           prompt_file="prompts.json"):
+                           prompt_file="prompts.json",
+                           extra_endpoints_test: Callable[[str], None] = None):
     """Run disaggregated test with given configuration."""
     cleanup_output_files()
     run_env = env.copy()
@@ -231,6 +242,10 @@ def run_disaggregated_test(example_dir,
                 # Skip output verification for long prompts test
                 if prompt_file == "long_prompts.json":
                     continue
+
+                if extra_endpoints_test is not None:
+                    extra_endpoints_test(
+                        get_disagg_server_url_from_cfg(config_file))
 
                 # Verify outputs
                 not_expected_strings = ["Berlin Berlin"]
@@ -509,6 +524,59 @@ def test_disaggregated_overlap(disaggregated_test_root, llm_venv,
                            "overlap",
                            env=llm_venv._new_env,
                            cwd=llm_venv.get_working_directory())
+
+
+@pytest.mark.parametrize("llama_model_root", ['TinyLlama-1.1B-Chat-v1.0'],
+                         indirect=True)
+def test_disaggregated_perf_metrics(disaggregated_test_root, llm_venv,
+                                    disaggregated_example_root,
+                                    llama_model_root):
+    src_dst_dict = {
+        llama_model_root:
+        f"{llm_venv.get_working_directory()}/TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+    }
+    for src, dst in src_dst_dict.items():
+        if not os.path.islink(dst):
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            os.symlink(src, dst, target_is_directory=True)
+
+    def extra_endpoints_test(server_url: str):
+        import json
+
+        import urllib3
+        resp = urllib3.request("GET", f"{server_url}/perf_metrics")
+        assert resp.status == 200
+        perf_metrics = json.loads(resp.data)
+        assert len(perf_metrics) > 0
+        item = perf_metrics[0]
+        assert "ctx_server" in item
+        assert "gen_server" in item
+        assert "ctx_perf_metrics" in item
+        assert "gen_perf_metrics" in item
+        assert item["ctx_perf_metrics"]["ctx_request_id"] == item[
+            "gen_perf_metrics"]["ctx_request_id"]
+        ctx_metrics = item["ctx_perf_metrics"]["perf_metrics"]
+        gen_metrics = item["gen_perf_metrics"]["perf_metrics"]
+        for metrics in ctx_metrics, gen_metrics:
+            assert metrics["arrival_time"] < metrics["first_scheduled_time"]
+            assert metrics["first_scheduled_time"] < metrics["first_token_time"]
+        assert ctx_metrics["first_token_time"] == ctx_metrics["last_token_time"]
+        assert ctx_metrics["last_token_time"] < gen_metrics["arrival_time"]
+        assert gen_metrics["kv_cache_size"] > 0
+        assert gen_metrics["arrival_time"] < gen_metrics[
+            "kv_cache_transfer_start"]
+        assert gen_metrics["kv_cache_transfer_start"] < gen_metrics[
+            "kv_cache_transfer_end"]
+        assert gen_metrics["kv_cache_transfer_end"] < gen_metrics[
+            "first_scheduled_time"]
+
+    run_disaggregated_test(
+        disaggregated_example_root,
+        "perf_metrics",
+        env=llm_venv._new_env,
+        cwd=llm_venv.get_working_directory(),
+        #    extra_endpoints_test=extra_endpoints_test
+    )
 
 
 @pytest.mark.parametrize("llama_model_root", ['TinyLlama-1.1B-Chat-v1.0'],

--- a/tests/integration/defs/test_e2e.py
+++ b/tests/integration/defs/test_e2e.py
@@ -1499,6 +1499,13 @@ def test_openai_chat_with_logit_bias(llm_root, llm_venv, sampler: str):
     ])
 
 
+def test_openai_perf_metrics(llm_root, llm_venv):
+    test_root = unittest_path() / "llmapi" / "apps"
+    llm_venv.run_cmd(
+        ["-m", "pytest",
+         str(test_root / "_test_openai_perf_metrics.py")])
+
+
 def test_openai_prometheus(llm_root, llm_venv):
     test_root = unittest_path() / "llmapi" / "apps"
     llm_venv.run_cmd(

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -25,6 +25,7 @@ l0_a10:
   - test_e2e.py::test_openai_chat_structural_tag_example
   - test_e2e.py::test_openai_chat_json_example
   - test_e2e.py::test_openai_chat_multimodal_example
+  - test_e2e.py::test_openai_perf_metrics
   - test_e2e.py::test_openai_prometheus
   - test_e2e.py::test_openai_lora
   - test_e2e.py::test_trtllm_serve_multimodal_example

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -73,6 +73,7 @@ l0_h100:
   - disaggregated/test_disaggregated.py::test_disaggregated_cuda_graph[TinyLlama-1.1B-Chat-v1.0]
   - disaggregated/test_disaggregated.py::test_disaggregated_mixed[TinyLlama-1.1B-Chat-v1.0]
   - disaggregated/test_disaggregated.py::test_disaggregated_overlap[TinyLlama-1.1B-Chat-v1.0]
+  - disaggregated/test_disaggregated.py::test_disaggregated_perf_metrics[TinyLlama-1.1B-Chat-v1.0]
   - disaggregated/test_disaggregated_single_gpu.py::test_disaggregated_simple_llama[False-False-TinyLlama-1.1B-Chat-v1.0]
   - disaggregated/test_disaggregated_single_gpu.py::test_disaggregated_simple_llama[False-True-TinyLlama-1.1B-Chat-v1.0]
   - disaggregated/test_disaggregated_single_gpu.py::test_disaggregated_simple_llama[True-False-TinyLlama-1.1B-Chat-v1.0]

--- a/tests/unittest/api_stability/references/llm.yaml
+++ b/tests/unittest/api_stability/references/llm.yaml
@@ -131,6 +131,10 @@ methods:
         annotation: bool
         default: False
         status: beta
+      perf_metrics_max_requests:
+        annotation: int
+        default: 0
+        status: prototype
       torch_compile_config:
         annotation: Optional[tensorrt_llm.llmapi.llm_args.TorchCompileConfig]
         default: null

--- a/tests/unittest/llmapi/apps/_test_openai_perf_metrics.py
+++ b/tests/unittest/llmapi/apps/_test_openai_perf_metrics.py
@@ -73,6 +73,16 @@ def test_metrics_endpoint(server: RemoteOpenAIServer):
     assert "first_scheduled_time" in data
     assert "first_token_time" in data
     assert "last_token_time" in data
+    assert "num_total_allocated_blocks" in data
+    assert "num_new_allocated_blocks" in data
+    assert "num_reused_blocks" in data
+    assert "num_missed_blocks" in data
+    assert data["first_iter"] <= data["last_iter"]
+    assert data["arrival_time"] < data["first_scheduled_time"]
+    assert data["first_scheduled_time"] < data["first_token_time"]
+    assert data["first_token_time"] <= data["last_token_time"]
+    assert data["num_new_allocated_blocks"] <= data[
+        "num_total_allocated_blocks"]
 
     # exclude disagg specific metrics
     assert "ctx_request_id" not in data_list[0]

--- a/tests/unittest/llmapi/apps/_test_openai_perf_metrics.py
+++ b/tests/unittest/llmapi/apps/_test_openai_perf_metrics.py
@@ -1,0 +1,81 @@
+import json
+import logging
+import os
+import tempfile
+from urllib.request import urlopen
+
+import pytest
+import yaml
+
+from ..test_llm import get_model_path
+from .openai_server import RemoteOpenAIServer
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module", ids=["TinyLlama-1.1B-Chat"])
+def model_name():
+    return "llama-models-v2/TinyLlama-1.1B-Chat-v1.0"
+
+
+@pytest.fixture(scope="module")
+def temp_extra_llm_api_options_file(request):
+    temp_dir = tempfile.gettempdir()
+    temp_file_path = os.path.join(temp_dir, "extra_llm_api_options.yaml")
+    try:
+        extra_llm_api_options_dict = {"return_perf_metrics": True}
+
+        with open(temp_file_path, 'w') as f:
+            yaml.dump(extra_llm_api_options_dict, f)
+
+        yield temp_file_path
+    finally:
+        if os.path.exists(temp_file_path):
+            os.remove(temp_file_path)
+
+
+@pytest.fixture(scope="module")
+def server(model_name: str,
+           temp_extra_llm_api_options_file: str) -> RemoteOpenAIServer:
+    model_path = get_model_path(model_name)
+    args = ["--backend", "pytorch", "--tp_size", "1"]
+    args.extend(["--extra_llm_api_options", temp_extra_llm_api_options_file])
+    logger.info(f"Starting server, model: {model_name}, args: {args}")
+    with RemoteOpenAIServer(model_path, args) as remote_server:
+        yield remote_server
+        logger.info("Tests completed, shutting down server")
+
+
+def test_metrics_endpoint(server: RemoteOpenAIServer):
+
+    client = server.get_client()
+    client.completions.create(
+        model="Server",
+        prompt="Hello, my name is",
+        max_tokens=25,
+        stream=False,
+    )
+
+    response = urlopen(f'{server.url_root}/perf_metrics')
+    assert response.status is 200
+
+    data_list = json.loads(response.read())
+    assert len(data_list) == 1
+    assert "perf_metrics" in data_list[0]
+    assert "request_id" in data_list[0]
+
+    data = data_list[0]["perf_metrics"]
+    assert "first_iter" in data
+    assert "last_iter" in data
+    assert "arrival_time" in data
+    assert "first_scheduled_time" in data
+    assert "first_token_time" in data
+    assert "last_token_time" in data
+
+    # exclude disagg specific metrics
+    assert "ctx_request_id" not in data_list[0]
+    assert "kv_cache_size" not in data
+    assert "kv_cache_transfer_start" not in data
+    assert "kv_cache_transfer_end" not in data


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a /perf_metrics endpoint exposing per-request performance metrics for chat, completions, and streaming.
  * Cross-server correlation and aggregation of perf metrics for disaggregated deployments with bounded history and configurable max entries.
  * Server startup now accepts a single config object with new perf-metrics flags.

* **Tests**
  * Added unit and integration tests and a disaggregated test config validating /perf_metrics payloads and correlations.

* **Chores**
  * Updated startup/config handling to use the new config-driven server construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up
-->

## Description

Add a `/perf_metrics` endpoint to openai server. When `return_perf_metrics` is set to `true`, and `perf_metrics_max_requests` is larger than 0, the endpoint will return a list of per-request metrics of finished requests. Previously it is only available via LLMAPI. This is similar to the existing `/metrics` endpoint which returns per-iteration statistics. The server will keep at most `perf_metrics_max_requests` entries to avoid OOM and returns all of them when requested. Each metrics item is returned at most once.

For disaggregated serving, the endpoint will collect perf metrics from all servers, match corresponding context and generation requests and form a new perf metrics list. This requires `return_perf_metrics` and `perf_metrics_max_requests` is set on both context and generation servers, and `perf_metrics_max_requests` on the disagg server.

IFB output:
```
[{
  "request_id": 2,
  "perf_metrics": {
    "first_iter": 7,
    "last_iter": 16,
    "timing_metrics": {
      "arrival_time": 19786.758976,
      "first_scheduled_time": 19786.75926,
      "first_token_time": 19786.809404,
      "last_token_time": 19786.864166
    },
    "kv_cache_metrics": {
      "num_total_allocated_blocks": 65,
      "num_new_allocated_blocks": 65,
      "num_reused_blocks": 0,
      "num_missed_blocks": 0
    }
  }
}, ...]
```
Disaggregated serving output:
```
[{
  "ctx_server": "http://localhost:8001",
  "gen_server": "http://localhost:8003",
  "ctx_perf_metrics": {
    "request_id": 2,
    "perf_metrics": {
      "first_iter": 7,
      "last_iter": 7,
      "timing_metrics": {
        "arrival_time": 22561.15635,
        "first_scheduled_time": 22561.156587,
        "first_token_time": 22561.204958,
        "last_token_time": 22561.204958
      },
      "kv_cache_metrics": {
        "num_total_allocated_blocks": 65,
        "num_new_allocated_blocks": 65,
        "num_reused_blocks": 0,
        "num_missed_blocks": 0
      }
    },
    "ctx_request_id": 1
  },
  "gen_perf_metrics": {
    "request_id": 2,
    "perf_metrics": {
      "first_iter": 75,
      "last_iter": 83,
      "timing_metrics": {
        "arrival_time": 22561.231106,
        "first_scheduled_time": 22561.490031,
        "first_token_time": 22561.497665,
        "last_token_time": 22561.539704,
        "kv_cache_size": 59637760,
        "kv_cache_transfer_start": 22561.231877,
        "kv_cache_transfer_end": 22561.48959
      },
      "kv_cache_metrics": {
        "num_total_allocated_blocks": 65,
        "num_new_allocated_blocks": 65,
        "num_reused_blocks": 0,
        "num_missed_blocks": 0
      }
    },
    "ctx_request_id": 1
  }
}, ...]
```


## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

- `tests/unittest/llmapi/apps/_test_openai_perf_metrics.py`
- `tests/integration/defs/disaggregated/test_disaggregated.py::test_disaggregated_perf_metrics`

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
