### PR TITLE
[TRTLLM-6746][feat] Enable two-model spec dec for MTP Eagle

### DIFF
--- a/examples/llm-api/quickstart_advanced.py
+++ b/examples/llm-api/quickstart_advanced.py
@@ -170,16 +170,15 @@ def setup_llm(args, **kwargs):
 
     if spec_decode_algo == 'MTP':
         if not args.use_one_model:
-            print(
-                "MTP only supports one model style spec decode; ignoring default use_one_model=False"
-            )
-
+            print("Running MTP eagle with two model style.")
         spec_config = MTPDecodingConfig(
             num_nextn_predict_layers=args.spec_decode_max_draft_len,
             use_relaxed_acceptance_for_thinking=args.
             use_relaxed_acceptance_for_thinking,
             relaxed_topk=args.relaxed_topk,
-            relaxed_delta=args.relaxed_delta)
+            relaxed_delta=args.relaxed_delta,
+            mtp_eagle_one_model=args.use_one_model,
+            speculative_model_dir=args.model_dir)
     elif spec_decode_algo == "EAGLE3":
         spec_config = EagleDecodingConfig(
             max_draft_len=args.spec_decode_max_draft_len,

--- a/tensorrt_llm/_torch/models/modeling_auto.py
+++ b/tensorrt_llm/_torch/models/modeling_auto.py
@@ -31,6 +31,8 @@ class AutoModelForCausalLM(Generic[TModel, TConfig]):
                                         "")  # Strip the appended EAGLE3
         if hasattr(config.pretrained_config, "draft_vocab_size"):
             model_arch = "EAGLE3" + model_arch
+        if model_arch == "DeepseekV3ForCausalLM" and config.spec_config is not None and config.spec_config.max_draft_len == 0:
+            model_arch = "MTPDraftModelForCausalLM"
 
         cls = MODEL_CLASS_MAPPING.get(model_arch)
         if cls is None:

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -136,6 +136,288 @@ def moe_reduce_add_shared_output(routed_output, shared_output):
     return shared_output + routed_output
 
 
+class DeepseekV3WeightLoader:
+
+    def __init__(self, model, is_draft_model: bool = False):
+        self.model = model
+        self.config = model.config
+        self.model_config = model.model_config
+        self.is_draft_model = is_draft_model
+
+    def load_weights(self, weights: Dict):
+
+        def rename_moe_weight(weights: Dict, rename_rules: Dict):
+            result = {}
+            for key, value in weights.items():
+                new_key = key
+                for old, new in rename_rules.items():
+                    new_key = new_key.replace(old, new)
+                result[new_key] = value
+            return result
+
+        ## Prepare weights for TP
+        def split(v, tp_size, idx, dim=0):
+            if tp_size == 1:
+                return v
+            if len(v.shape) == 1:
+                return torch.chunk(v, tp_size)[idx].contiguous()
+            return torch.chunk(v, tp_size, dim=dim)[idx].contiguous()
+
+        def split_matrix_tp(v, tensor_parallel, rank, dim):
+            return split(v, tensor_parallel, rank, dim=dim)
+
+        def load_kv_b_proj_and_k_b_proj_trans(module_name: str,
+                                              is_scale: bool) -> torch.Tensor:
+            weight_name = "weight" if not is_scale else "weight_scale_inv"
+            local_qk_nope_head_dim = qk_nope_head_dim if not is_scale else qk_nope_head_dim // 128
+            local_v_head_dim = v_head_dim if not is_scale else v_head_dim // 128
+            local_kv_lora_rank = kv_lora_rank if not is_scale else kv_lora_rank // 128
+
+            kv_b_proj = weights[f"{module_name}.{weight_name}"][:].unflatten(
+                0,
+                [
+                    num_heads,
+                    local_qk_nope_head_dim + local_v_head_dim,
+                ],
+            )
+
+            if not self.model_config.mapping.enable_attention_dp:
+                kv_b_proj = split_matrix_tp(kv_b_proj, tp_size, tp_rank, 0)
+            k_nope_weight, v_weight = kv_b_proj.split(
+                [local_qk_nope_head_dim, local_v_head_dim],
+                dim=1,
+            )
+            weight_divisor = 1 if self.model_config.mapping.enable_attention_dp else tp_size
+            local_num_heads = num_heads // weight_divisor
+
+            k_nope_weight_trans = k_nope_weight.transpose(2, 1).contiguous()
+
+            kv_b_proj = torch.concat([
+                k_nope_weight.reshape(local_num_heads * local_qk_nope_head_dim,
+                                      local_kv_lora_rank),
+                v_weight.reshape(local_num_heads * local_v_head_dim,
+                                 local_kv_lora_rank)
+            ],
+                                     dim=0)
+
+            return kv_b_proj, k_nope_weight_trans
+
+        def load_kv_b_proj_and_k_b_proj_trans_dequant(
+                module_name: str) -> torch.Tensor:
+            weight_name = "weight"
+            local_qk_nope_head_dim = qk_nope_head_dim
+            local_v_head_dim = v_head_dim
+            local_kv_lora_rank = kv_lora_rank
+
+            kv_b_proj = weights[f"{module_name}.{weight_name}"][:].cuda()
+
+            weight_name = "weight_scale_inv"
+            kv_b_proj_scale = weights[f"{module_name}.{weight_name}"][:].cuda()
+
+            kv_b_proj = weight_dequant(kv_b_proj, kv_b_proj_scale)
+            kv_b_proj = kv_b_proj.unflatten(
+                0,
+                [
+                    num_heads,
+                    local_qk_nope_head_dim + local_v_head_dim,
+                ],
+            )
+            if not self.model_config.mapping.enable_attention_dp:
+                kv_b_proj = split_matrix_tp(kv_b_proj, tp_size, tp_rank, 0)
+            k_nope_weight, v_weight = kv_b_proj.split(
+                [local_qk_nope_head_dim, local_v_head_dim],
+                dim=1,
+            )
+            weight_divisor = 1 if self.model_config.mapping.enable_attention_dp else tp_size
+            local_num_heads = num_heads // weight_divisor
+
+            k_nope_weight_trans = k_nope_weight.transpose(2, 1).contiguous()
+
+            kv_b_proj = torch.concat([
+                k_nope_weight.reshape(local_num_heads * local_qk_nope_head_dim,
+                                      local_kv_lora_rank),
+                v_weight.reshape(local_num_heads * local_v_head_dim,
+                                 local_kv_lora_rank)
+            ],
+                                     dim=0)
+
+            return kv_b_proj, k_nope_weight_trans
+
+        def split_kv_b_proj(kv_b_proj: torch.Tensor,
+                            is_scale: bool) -> torch.Tensor:
+            local_qk_nope_head_dim = qk_nope_head_dim if not is_scale else qk_nope_head_dim // 128
+            local_v_head_dim = v_head_dim if not is_scale else v_head_dim // 128
+
+            weight_divisor = 1 if self.model_config.mapping.enable_attention_dp else tp_size
+            local_num_heads = num_heads // weight_divisor
+
+            k_b_proj, v_b_proj = kv_b_proj.split([
+                local_num_heads * local_qk_nope_head_dim,
+                local_num_heads * local_v_head_dim
+            ],
+                                                 dim=0)
+            k_b_proj = k_b_proj.view(
+                [local_num_heads, local_qk_nope_head_dim, -1])
+            v_b_proj = v_b_proj.view([local_num_heads, local_v_head_dim, -1])
+
+            return k_b_proj, v_b_proj
+
+        is_lite = self.config.q_lora_rank is None
+        num_heads = self.config.num_attention_heads
+        qk_nope_head_dim = self.config.qk_nope_head_dim
+        v_head_dim = self.config.v_head_dim
+        kv_lora_rank = self.config.kv_lora_rank
+
+        tp_rank = self.model_config.mapping.tp_rank
+        tp_size = self.model_config.mapping.tp_size
+
+        params_map = {'gate_up_proj': ['gate_proj', 'up_proj']}
+        all_named_modules = dict(self.model.named_modules())
+
+        for name, module in tqdm(all_named_modules.items(),
+                                 desc="Loading weights"):
+            if len(module._parameters) <= 0 or name.startswith("draft_model"):
+                continue
+            else:
+                names = name.split('.')
+                parent_module_name = '.'.join(names[:-1])
+                if "model.layers" in name and int(
+                        names[2]) >= self.config.num_hidden_layers:
+                    mtp_layer_idx = int(
+                        names[2]) - self.config.num_hidden_layers
+                    names[2] = str(mtp_layer_idx %
+                                   self.config.num_nextn_predict_layers +
+                                   self.config.num_hidden_layers)
+                    name = '.'.join(names)
+                if names[-1] == "kv_b_proj":
+                    # TODO: remove weight_dequant after enabling fp8_bmm
+                    dequant_kv_b_proj = self.model_config.quant_config.is_module_excluded_from_quantization(
+                        names[-1])
+                    if dequant_kv_b_proj:
+                        kv_b_proj, k_b_proj_trans = load_kv_b_proj_and_k_b_proj_trans_dequant(
+                            name)
+                    else:
+                        kv_b_proj, k_b_proj_trans = load_kv_b_proj_and_k_b_proj_trans(
+                            name, is_scale=False)
+                    module.weight.data.copy_(
+                        kv_b_proj.reshape(module.weight.shape))
+
+                    attn_module = all_named_modules[parent_module_name]
+                    _, v_b_proj = split_kv_b_proj(module.weight.data,
+                                                  is_scale=False)
+                    attn_module.v_b_proj = nn.Parameter(v_b_proj,
+                                                        requires_grad=False)
+
+                    attn_module.k_b_proj_trans.data.copy_(
+                        k_b_proj_trans.reshape(
+                            attn_module.k_b_proj_trans.shape))
+
+                    if getattr(module, "weight_scale",
+                               None) is not None and not dequant_kv_b_proj:
+                        kv_b_proj_scale, k_b_proj_trans_scale = load_kv_b_proj_and_k_b_proj_trans(
+                            name, is_scale=True)
+                        module.weight_scale.copy_(
+                            kv_b_proj_scale.reshape(module.weight_scale.shape))
+                        attn_module.k_b_proj_trans_scale.copy_(
+                            k_b_proj_trans_scale.reshape(
+                                attn_module.k_b_proj_trans_scale.shape))
+
+                        _, v_b_proj_scale = split_kv_b_proj(
+                            module.weight_scale.data, is_scale=True)
+                        attn_module.v_b_proj_scale = nn.Parameter(
+                            v_b_proj_scale, requires_grad=False)
+
+                        if attn_module.k_b_proj_trans_dequant is not None:
+                            attn_module.k_b_proj_trans_dequant.data.copy_(
+                                weight_dequant(
+                                    k_b_proj_trans.view(
+                                        -1, k_b_proj_trans.shape[-1]).cuda(),
+                                    k_b_proj_trans_scale.view(
+                                        -1,
+                                        k_b_proj_trans_scale.shape[-1]).cuda(),
+                                ).view(
+                                    *attn_module.k_b_proj_trans_dequant.shape).
+                                to(attn_module.k_b_proj_trans_dequant.dtype))
+                        if attn_module.v_b_proj_dequant is not None:
+                            attn_module.v_b_proj_dequant.data.copy_(
+                                weight_dequant(
+                                    v_b_proj.view(-1,
+                                                  v_b_proj.shape[-1]).cuda(),
+                                    v_b_proj_scale.view(
+                                        -1, v_b_proj_scale.shape[-1]).cuda(),
+                                ).view(*attn_module.v_b_proj_dequant.shape).to(
+                                    attn_module.v_b_proj_dequant.dtype))
+                elif names[-1] == "kv_a_proj_with_mqa":
+                    fused_a = weights[
+                        f"{'.'.join(names[:-1])}.kv_a_proj_with_mqa.weight"][:]
+                    if not is_lite:
+                        q_a_proj = weights[
+                            f"{'.'.join(names[:-1])}.q_a_proj.weight"][:]
+                        fused_a = torch.cat([q_a_proj, fused_a], dim=0)
+
+                    if f"{'.'.join(names[:-1])}.kv_a_proj_with_mqa.weight_scale_inv" in weights:
+                        fused_a_scale = weights[
+                            f"{'.'.join(names[:-1])}.kv_a_proj_with_mqa.weight_scale_inv"]
+                        if not is_lite:
+                            q_a_proj_scale = weights[
+                                f"{'.'.join(names[:-1])}.q_a_proj.weight_scale_inv"][:]
+                            fused_a_scale = torch.cat(
+                                [q_a_proj_scale, fused_a_scale], dim=0)
+
+                        module.weight_scale.data.copy_(fused_a_scale)
+
+                    module.weight.data.copy_(fused_a)
+                elif names[-1] in params_map:
+                    module_weights = []
+                    for new_name in params_map[names[-1]]:
+                        module_weights.append(
+                            filter_weights('.'.join(names[:-1] + [new_name]),
+                                           weights))
+                    module.load_weights(weights=module_weights)
+                elif names[-1] == "experts":
+                    module_weights = filter_weights(name, weights)
+                    module_weights = rename_moe_weight(module_weights, {
+                        "down_proj": "w2",
+                        "up_proj": "w3",
+                        "gate_proj": "w1",
+                    })
+                    module.load_weights(weights=[module_weights])
+                elif names[-1] == "self_attn":
+                    continue
+                elif names[-1] == "next_layer_layernorm":
+                    continue
+                else:
+                    module_weights = filter_weights(name, weights)
+                    if hasattr(module, 'load_weights'):
+                        module.load_weights(weights=[module_weights])
+                    else:
+                        for n, p in module.named_parameters():
+                            p.data.copy_(module_weights[n][:])
+
+                if self.model_config.quant_config.layer_quant_mode.has_fp8_block_scales(
+                ) and is_sm_100f() and hasattr(
+                        module, "weight_scale"):
+                    weight, weight_scale = resmooth_to_fp8_e8m0(
+                        module.weight, module.weight_scale)
+                    transfromed_scale = transform_sf_into_required_layout(
+                        weight_scale,
+                        mn=weight.shape[0],
+                        k=weight.shape[1],
+                        recipe=(1, 128, 128),
+                        is_sfa=False)
+                    module.weight = nn.Parameter(weight, requires_grad=False)
+                    module.weight_scale = nn.Parameter(transfromed_scale,
+                                                       requires_grad=False)
+        if not self.is_draft_model:
+            for idx, layer in enumerate(
+                    self.model.model.layers[:self.config.num_hidden_layers]):
+                if idx == self.config.num_hidden_layers - 1:
+                    layer.next_layer_layernorm = self.model.model.norm
+                else:
+                    layer.next_layer_layernorm = self.model.model.layers[
+                        idx + 1].input_layernorm
+
+
 class DeepseekV3MTPHead(nn.Module):
 
     def __init__(self, model_config: ModelConfig[PretrainedConfig]):
@@ -304,16 +586,17 @@ class Deepseekv3RoutingImpl():
         self.routed_scaling_factor = routed_scaling_factor
         self.is_fused = is_fused
 
+    @staticmethod
     @torch.compile(options={"max-autotune": True})
-    def get_scores(self, logits, e_score_correction_bias):
+    def get_scores(logits, e_score_correction_bias):
         scores = F.sigmoid(logits)
         scores_with_bias = scores + e_score_correction_bias
         return scores, scores_with_bias
 
     def noaux_tc(self, logits, e_score_correction_bias):
         n_group = self.n_group
-        scores, scores_with_bias = self.get_scores(logits,
-                                                   e_score_correction_bias)
+        scores, scores_with_bias = Deepseekv3RoutingImpl.get_scores(
+            logits, e_score_correction_bias)
         scores_shape = list(scores_with_bias.shape)
 
         if enable_llm_debug():
@@ -647,9 +930,11 @@ class Deepseekv3MoE(nn.Module):
 
 class DeepseekV3DecoderLayer(DecoderLayer):
 
-    def __init__(self, model_config: ModelConfig[PretrainedConfig],
-                 layer_idx: int, aux_stream_dict: Dict[AuxStreamType,
-                                                       torch.cuda.Stream]):
+    def __init__(self,
+                 model_config: ModelConfig[PretrainedConfig],
+                 layer_idx: int,
+                 aux_stream_dict: Dict[AuxStreamType, torch.cuda.Stream],
+                 is_separate_draft_engine: bool = False):
         super().__init__()
         self.model_config = model_config
         self.config = model_config.pretrained_config
@@ -663,10 +948,14 @@ class DeepseekV3DecoderLayer(DecoderLayer):
 
         self.mapping = model_config.mapping
         mapping = self.mapping
+        layer_idx_for_attention = layer_idx
+        if is_separate_draft_engine:
+            #KVCacheManager only support 1 layer for separate draft engine
+            layer_idx_for_attention = layer_idx - model_config.pretrained_config.num_hidden_layers
 
         self.self_attn = DeepseekV3Attention(
             model_config,
-            layer_idx=layer_idx,
+            layer_idx=layer_idx_for_attention,
             aux_stream=aux_stream_dict[AuxStreamType.Attention])
         self.enable_attention_dp = mapping.enable_attention_dp
 
@@ -984,10 +1273,13 @@ class DeepseekV3DecoderLayer(DecoderLayer):
 
 class DeepseekV3MTP(DeepseekV3DecoderLayer):
 
-    def __init__(self, model_config: ModelConfig[PretrainedConfig],
-                 layer_idx: int, aux_stream_dict: Dict[AuxStreamType,
-                                                       torch.cuda.Stream]):
-        super().__init__(model_config, layer_idx, aux_stream_dict)
+    def __init__(self,
+                 model_config: ModelConfig[PretrainedConfig],
+                 layer_idx: int,
+                 aux_stream_dict: Dict[AuxStreamType, torch.cuda.Stream],
+                 is_separate_draft_engine: bool = False):
+        super().__init__(model_config, layer_idx, aux_stream_dict,
+                         is_separate_draft_engine)
         config = model_config.pretrained_config
         self.hidden_dim = config.hidden_size
         self.moe_intermediate_size = config.moe_intermediate_size
@@ -1203,7 +1495,7 @@ class DeepseekV3ForCausalLM(SpecDecOneEngineForCausalLM[DeepseekV3Model,
                          model_config=model_config)
 
         self.model_nextn = 0
-        if model_config.spec_config is not None and model_config.spec_config.spec_dec_mode.is_mtp(
+        if model_config.spec_config is not None and model_config.spec_config.spec_dec_mode.is_mtp_one_model(
         ):
             model_nextn = model_config.spec_config.num_nextn_predict_layers
             ckpt_nextn = self.config.num_nextn_predict_layers
@@ -1252,274 +1544,5 @@ class DeepseekV3ForCausalLM(SpecDecOneEngineForCausalLM[DeepseekV3Model,
                                **kwargs)
 
     def load_weights(self, weights: Dict):
-
-        def rename_moe_weight(weights: Dict, rename_rules: Dict):
-            result = {}
-            for key, value in weights.items():
-                new_key = key
-                for old, new in rename_rules.items():
-                    new_key = new_key.replace(old, new)
-                result[new_key] = value
-            return result
-
-        ## Prepare weights for TP
-        def split(v, tp_size, idx, dim=0):
-            if tp_size == 1:
-                return v
-            if len(v.shape) == 1:
-                return torch.chunk(v, tp_size)[idx].contiguous()
-            else:
-                return torch.chunk(v, tp_size, dim=dim)[idx].contiguous()
-
-        def split_matrix_tp(v, tensor_parallel, rank, dim):
-            return split(v, tensor_parallel, rank, dim=dim)
-
-        def load_kv_b_proj_and_k_b_proj_trans(module_name: str,
-                                              is_scale: bool) -> torch.Tensor:
-            weight_name = "weight" if not is_scale else "weight_scale_inv"
-            local_qk_nope_head_dim = qk_nope_head_dim if not is_scale else qk_nope_head_dim // 128
-            local_v_head_dim = v_head_dim if not is_scale else v_head_dim // 128
-            local_kv_lora_rank = kv_lora_rank if not is_scale else kv_lora_rank // 128
-
-            kv_b_proj = weights[f"{module_name}.{weight_name}"][:].unflatten(
-                0,
-                [
-                    num_heads,
-                    local_qk_nope_head_dim + local_v_head_dim,
-                ],
-            )
-
-            if not self.model_config.mapping.enable_attention_dp:
-                kv_b_proj = split_matrix_tp(kv_b_proj, tp_size, tp_rank, 0)
-            k_nope_weight, v_weight = kv_b_proj.split(
-                [local_qk_nope_head_dim, local_v_head_dim],
-                dim=1,
-            )
-            weight_divisor = 1 if self.model_config.mapping.enable_attention_dp else tp_size
-            local_num_heads = num_heads // weight_divisor
-
-            k_nope_weight_trans = k_nope_weight.transpose(2, 1).contiguous()
-
-            kv_b_proj = torch.concat([
-                k_nope_weight.reshape(local_num_heads * local_qk_nope_head_dim,
-                                      local_kv_lora_rank),
-                v_weight.reshape(local_num_heads * local_v_head_dim,
-                                 local_kv_lora_rank)
-            ],
-                                     dim=0)
-
-            return kv_b_proj, k_nope_weight_trans
-
-        def load_kv_b_proj_and_k_b_proj_trans_dequant(
-                module_name: str) -> torch.Tensor:
-            weight_name = "weight"
-            local_qk_nope_head_dim = qk_nope_head_dim
-            local_v_head_dim = v_head_dim
-            local_kv_lora_rank = kv_lora_rank
-
-            kv_b_proj = weights[f"{module_name}.{weight_name}"][:].cuda()
-
-            weight_name = "weight_scale_inv"
-            kv_b_proj_scale = weights[f"{module_name}.{weight_name}"][:].cuda()
-
-            kv_b_proj = weight_dequant(kv_b_proj, kv_b_proj_scale)
-            kv_b_proj = kv_b_proj.unflatten(
-                0,
-                [
-                    num_heads,
-                    local_qk_nope_head_dim + local_v_head_dim,
-                ],
-            )
-            if not self.model_config.mapping.enable_attention_dp:
-                kv_b_proj = split_matrix_tp(kv_b_proj, tp_size, tp_rank, 0)
-            k_nope_weight, v_weight = kv_b_proj.split(
-                [local_qk_nope_head_dim, local_v_head_dim],
-                dim=1,
-            )
-            weight_divisor = 1 if self.model_config.mapping.enable_attention_dp else tp_size
-            local_num_heads = num_heads // weight_divisor
-
-            k_nope_weight_trans = k_nope_weight.transpose(2, 1).contiguous()
-
-            kv_b_proj = torch.concat([
-                k_nope_weight.reshape(local_num_heads * local_qk_nope_head_dim,
-                                      local_kv_lora_rank),
-                v_weight.reshape(local_num_heads * local_v_head_dim,
-                                 local_kv_lora_rank)
-            ],
-                                     dim=0)
-
-            return kv_b_proj, k_nope_weight_trans
-
-        def split_kv_b_proj(kv_b_proj: torch.Tensor,
-                            is_scale: bool) -> torch.Tensor:
-            local_qk_nope_head_dim = qk_nope_head_dim if not is_scale else qk_nope_head_dim // 128
-            local_v_head_dim = v_head_dim if not is_scale else v_head_dim // 128
-
-            weight_divisor = 1 if self.model_config.mapping.enable_attention_dp else tp_size
-            local_num_heads = num_heads // weight_divisor
-
-            k_b_proj, v_b_proj = kv_b_proj.split([
-                local_num_heads * local_qk_nope_head_dim,
-                local_num_heads * local_v_head_dim
-            ],
-                                                 dim=0)
-            k_b_proj = k_b_proj.view(
-                [local_num_heads, local_qk_nope_head_dim, -1])
-            v_b_proj = v_b_proj.view([local_num_heads, local_v_head_dim, -1])
-
-            return k_b_proj, v_b_proj
-
-        is_lite = self.config.q_lora_rank is None
-        num_heads = self.config.num_attention_heads
-        qk_nope_head_dim = self.config.qk_nope_head_dim
-        v_head_dim = self.config.v_head_dim
-        kv_lora_rank = self.config.kv_lora_rank
-
-        tp_rank = self.model_config.mapping.tp_rank
-        tp_size = self.model_config.mapping.tp_size
-
-        params_map = {'gate_up_proj': ['gate_proj', 'up_proj']}
-        all_named_modules = dict(self.named_modules())
-
-        for name, module in tqdm(all_named_modules.items(),
-                                 desc="Loading weights"):
-            if len(module._parameters) <= 0 or name.startswith("draft_model"):
-                continue
-            else:
-                names = name.split('.')
-                parent_module_name = '.'.join(names[:-1])
-                if "model.layers" in name and int(
-                        names[2]) >= self.config.num_hidden_layers:
-                    mtp_layer_idx = int(
-                        names[2]) - self.config.num_hidden_layers
-                    names[2] = str(mtp_layer_idx %
-                                   self.config.num_nextn_predict_layers +
-                                   self.config.num_hidden_layers)
-                    name = '.'.join(names)
-                if names[-1] == "kv_b_proj":
-                    # TODO: remove weight_dequant after enabling fp8_bmm
-                    dequant_kv_b_proj = self.model_config.quant_config.is_module_excluded_from_quantization(
-                        names[-1])
-                    if dequant_kv_b_proj:
-                        kv_b_proj, k_b_proj_trans = load_kv_b_proj_and_k_b_proj_trans_dequant(
-                            name)
-                    else:
-                        kv_b_proj, k_b_proj_trans = load_kv_b_proj_and_k_b_proj_trans(
-                            name, is_scale=False)
-                    module.weight.data.copy_(
-                        kv_b_proj.reshape(module.weight.shape))
-
-                    attn_module = all_named_modules[parent_module_name]
-                    _, v_b_proj = split_kv_b_proj(module.weight.data,
-                                                  is_scale=False)
-                    attn_module.v_b_proj = nn.Parameter(v_b_proj,
-                                                        requires_grad=False)
-
-                    attn_module.k_b_proj_trans.data.copy_(
-                        k_b_proj_trans.reshape(
-                            attn_module.k_b_proj_trans.shape))
-
-                    if getattr(module, "weight_scale",
-                               None) is not None and not dequant_kv_b_proj:
-                        kv_b_proj_scale, k_b_proj_trans_scale = load_kv_b_proj_and_k_b_proj_trans(
-                            name, is_scale=True)
-                        module.weight_scale.copy_(
-                            kv_b_proj_scale.reshape(module.weight_scale.shape))
-                        attn_module.k_b_proj_trans_scale.copy_(
-                            k_b_proj_trans_scale.reshape(
-                                attn_module.k_b_proj_trans_scale.shape))
-
-                        _, v_b_proj_scale = split_kv_b_proj(
-                            module.weight_scale.data, is_scale=True)
-                        attn_module.v_b_proj_scale = nn.Parameter(
-                            v_b_proj_scale, requires_grad=False)
-
-                        if attn_module.k_b_proj_trans_dequant is not None:
-                            attn_module.k_b_proj_trans_dequant.data.copy_(
-                                weight_dequant(
-                                    k_b_proj_trans.view(
-                                        -1, k_b_proj_trans.shape[-1]).cuda(),
-                                    k_b_proj_trans_scale.view(
-                                        -1,
-                                        k_b_proj_trans_scale.shape[-1]).cuda(),
-                                ).view(
-                                    *attn_module.k_b_proj_trans_dequant.shape).
-                                to(attn_module.k_b_proj_trans_dequant.dtype))
-                        if attn_module.v_b_proj_dequant is not None:
-                            attn_module.v_b_proj_dequant.data.copy_(
-                                weight_dequant(
-                                    v_b_proj.view(-1,
-                                                  v_b_proj.shape[-1]).cuda(),
-                                    v_b_proj_scale.view(
-                                        -1, v_b_proj_scale.shape[-1]).cuda(),
-                                ).view(*attn_module.v_b_proj_dequant.shape).to(
-                                    attn_module.v_b_proj_dequant.dtype))
-                elif names[-1] == "kv_a_proj_with_mqa":
-                    fused_a = weights[
-                        f"{'.'.join(names[:-1])}.kv_a_proj_with_mqa.weight"][:]
-                    if not is_lite:
-                        q_a_proj = weights[
-                            f"{'.'.join(names[:-1])}.q_a_proj.weight"][:]
-                        fused_a = torch.cat([q_a_proj, fused_a], dim=0)
-
-                    if f"{'.'.join(names[:-1])}.kv_a_proj_with_mqa.weight_scale_inv" in weights:
-                        fused_a_scale = weights[
-                            f"{'.'.join(names[:-1])}.kv_a_proj_with_mqa.weight_scale_inv"]
-                        if not is_lite:
-                            q_a_proj_scale = weights[
-                                f"{'.'.join(names[:-1])}.q_a_proj.weight_scale_inv"][:]
-                            fused_a_scale = torch.cat(
-                                [q_a_proj_scale, fused_a_scale], dim=0)
-
-                        module.weight_scale.data.copy_(fused_a_scale)
-
-                    module.weight.data.copy_(fused_a)
-                elif names[-1] in params_map:
-                    module_weights = []
-                    for new_name in params_map[names[-1]]:
-                        module_weights.append(
-                            filter_weights('.'.join(names[:-1] + [new_name]),
-                                           weights))
-                    module.load_weights(weights=module_weights)
-                elif names[-1] == "experts":
-                    module_weights = filter_weights(name, weights)
-                    module_weights = rename_moe_weight(module_weights, {
-                        "down_proj": "w2",
-                        "up_proj": "w3",
-                        "gate_proj": "w1",
-                    })
-                    module.load_weights(weights=[module_weights])
-                elif names[-1] == "self_attn":
-                    continue
-                elif names[-1] == "next_layer_layernorm":
-                    continue
-                else:
-                    module_weights = filter_weights(name, weights)
-                    if hasattr(module, 'load_weights'):
-                        module.load_weights(weights=[module_weights])
-                    else:
-                        for n, p in module.named_parameters():
-                            p.data.copy_(module_weights[n][:])
-
-                if self.model_config.quant_config.layer_quant_mode.has_fp8_block_scales(
-                ) and is_sm_100f() and hasattr(module, "weight_scale"):
-                    weight, weight_scale = resmooth_to_fp8_e8m0(
-                        module.weight, module.weight_scale)
-                    transfromed_scale = transform_sf_into_required_layout(
-                        weight_scale,
-                        mn=weight.shape[0],
-                        k=weight.shape[1],
-                        recipe=(1, 128, 128),
-                        is_sfa=False)
-                    module.weight = nn.Parameter(weight, requires_grad=False)
-                    module.weight_scale = nn.Parameter(transfromed_scale,
-                                                       requires_grad=False)
-
-        for idx, layer in enumerate(
-                self.model.layers[:self.config.num_hidden_layers]):
-            if idx == self.config.num_hidden_layers - 1:
-                layer.next_layer_layernorm = self.model.norm
-            else:
-                layer.next_layer_layernorm = self.model.layers[
-                    idx + 1].input_layernorm
+        weight_loader = DeepseekV3WeightLoader(self)
+        weight_loader.load_weights(weights)

--- a/tensorrt_llm/_torch/models/modeling_speculative.py
+++ b/tensorrt_llm/_torch/models/modeling_speculative.py
@@ -393,7 +393,6 @@ class MTPDraftModel(nn.Module):
         hidden_states: torch.Tensor,
         attn_metadata: AttentionMetadata,
         all_rank_num_tokens: Optional[List[int]] = None,
-        all_rank_max_num_tokens: Optional[int] = None,
         **kwargs,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         hidden_states = self.layers(
@@ -403,7 +402,6 @@ class MTPDraftModel(nn.Module):
             embed_tokens=self.embed_tokens,
             attn_metadata=attn_metadata,
             all_rank_num_tokens=all_rank_num_tokens,
-            all_rank_max_num_tokens=all_rank_max_num_tokens,
         )
 
         return hidden_states
@@ -458,7 +456,6 @@ class MTPDraftModelForCausalLM(DecoderModelForCausalLM[MTPDraftModel,
             hidden_states=hidden_states,
             attn_metadata=attn_metadata,
             all_rank_num_tokens=attn_metadata.all_rank_num_tokens,
-            all_rank_max_num_tokens=attn_metadata.all_rank_max_num_tokens,
             **kwargs)
         return self.logits_processor.forward(
             output,

--- a/tensorrt_llm/_torch/models/modeling_speculative.py
+++ b/tensorrt_llm/_torch/models/modeling_speculative.py
@@ -1,4 +1,4 @@
-from typing import Dict, Generic, Optional, Tuple
+from typing import Dict, Generic, List, Optional, Tuple
 
 import torch
 from torch import nn
@@ -18,6 +18,7 @@ from ..modules.linear import (Linear, TensorParallelMode, WeightMode,
 from ..modules.rms_norm import RMSNorm
 from ..pyexecutor.guided_decoder import CapturableGuidedDecoder
 from ..speculative import SpecMetadata, get_spec_worker
+from ..utils import AuxStreamType
 from .checkpoints.base_weight_mapper import BaseWeightMapper
 from .modeling_utils import (DecoderModel, DecoderModelForCausalLM, TModel,
                              register_auto_model)
@@ -342,8 +343,8 @@ class MTPForCausalLM(nn.Module):
         from .modeling_deepseekv3 import DeepseekV3MTP
 
         spec_dec_mode = model_config.spec_config.spec_dec_mode
-        assert spec_dec_mode.is_mtp()
-        mtp_num_layers = 1 if spec_dec_mode.is_mtp_eagle(
+        assert spec_dec_mode.is_mtp_one_model()
+        mtp_num_layers = 1 if spec_dec_mode.is_mtp_eagle_one_model(
         ) else model_config.spec_config.num_nextn_predict_layers
 
         moe_load_balancer_set_repeated_for_next_layer(
@@ -358,16 +359,127 @@ class MTPForCausalLM(nn.Module):
         self.embed_tokens = model.embed_tokens
 
 
+class MTPDraftModel(nn.Module):
+
+    def __init__(self, model_config: ModelConfig[PretrainedConfig],
+                 layer_idx: int, aux_stream_dict: Dict[AuxStreamType,
+                                                       torch.cuda.Stream]):
+        super().__init__()
+        # Import here to avoid circular import
+        from .modeling_deepseekv3 import DeepseekV3MTP
+
+        mtp_layer = DeepseekV3MTP(model_config,
+                                  layer_idx,
+                                  aux_stream_dict,
+                                  is_separate_draft_engine=True)
+        setattr(self, f"layers.{layer_idx}", mtp_layer)
+        self.layers = mtp_layer
+        self.layer_idx = layer_idx
+        self.config = model_config.pretrained_config
+        self.embed_tokens = Embedding(
+            self.config.vocab_size,
+            self.config.hidden_size,
+            dtype=self.config.torch_dtype,
+        )
+
+    def __repr__(self):
+        """Custom string representation to display layer index"""
+        return f"(layers): ({self.layer_idx}): {repr(self.layers)}"
+
+    def forward(
+        self,
+        input_ids: torch.IntTensor,
+        position_ids: torch.IntTensor,
+        hidden_states: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        all_rank_num_tokens: Optional[List[int]] = None,
+        all_rank_max_num_tokens: Optional[int] = None,
+        **kwargs,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        hidden_states = self.layers(
+            input_ids,
+            position_ids,
+            hidden_states,
+            embed_tokens=self.embed_tokens,
+            attn_metadata=attn_metadata,
+            all_rank_num_tokens=all_rank_num_tokens,
+            all_rank_max_num_tokens=all_rank_max_num_tokens,
+        )
+
+        return hidden_states
+
+
+@register_auto_model("MTPDraftModelForCausalLM")
+class MTPDraftModelForCausalLM(DecoderModelForCausalLM[MTPDraftModel,
+                                                       PretrainedConfig]):
+
+    def __init__(self, model_config: ModelConfig[PretrainedConfig]):
+        self.model_config = model_config
+        aux_stream_list = [torch.cuda.Stream() for _ in range(2)]
+        self.aux_stream_dict = {
+            AuxStreamType.Attention: aux_stream_list[0],
+            AuxStreamType.MoeShared: aux_stream_list[0],
+            AuxStreamType.MoeChunkingOverlap: aux_stream_list[1],
+        }
+        super().__init__(
+            MTPDraftModel(self.model_config,
+                          self.model_config.pretrained_config.num_hidden_layers,
+                          self.aux_stream_dict),
+            config=self.model_config,
+            hidden_size=self.model_config.pretrained_config.hidden_size,
+            vocab_size=self.model_config.pretrained_config.vocab_size)
+
+    def load_weights(self, weights: Dict):
+        # Import here to avoid circular import
+        from .modeling_deepseekv3 import DeepseekV3WeightLoader
+        weight_loader = DeepseekV3WeightLoader(self, is_draft_model=True)
+        weight_loader.load_weights(weights)
+
+    def load_weights_from_target_model(self,
+                                       target_model: torch.nn.Module) -> None:
+        if self.model.embed_tokens is None:
+            self.model.embed_tokens = target_model.model.embed_tokens
+        self.lm_head = target_model.lm_head
+
+    def forward(self,
+                attn_metadata: AttentionMetadata,
+                input_ids: torch.IntTensor = None,
+                position_ids: torch.IntTensor = None,
+                inputs_embeds: Optional[torch.FloatTensor] = None,
+                return_context_logits: bool = False,
+                spec_metadata: Optional[SpecMetadata] = None,
+                hidden_states: torch.Tensor = None,
+                **kwargs) -> torch.Tensor:
+
+        hidden_states = spec_metadata.get_hidden_states()
+        output = self.model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            hidden_states=hidden_states,
+            attn_metadata=attn_metadata,
+            all_rank_num_tokens=attn_metadata.all_rank_num_tokens,
+            all_rank_max_num_tokens=attn_metadata.all_rank_max_num_tokens,
+            **kwargs)
+        return self.logits_processor.forward(
+            output,
+            self.lm_head,
+            attn_metadata,
+            return_context_logits,
+        )
+
+
 def get_draft_model(model_config, draft_config, lm_head, model):
     assert getattr(model_config, 'spec_config', None) != None
     spec_dec_mode = model_config.spec_config.spec_dec_mode
     if spec_dec_mode.is_eagle3_one_model():
         return Eagle3ForCausalLM(
             draft_config, model_config.pretrained_config.num_hidden_layers)
-    elif spec_dec_mode.is_mtp():
+    elif spec_dec_mode.is_mtp_one_model():
         return MTPForCausalLM(model_config,
                               model_config.pretrained_config.num_hidden_layers,
                               lm_head, model)
+    elif spec_dec_mode.is_mtp_eagle():
+        return MTPDraftModelForCausalLM(model_config)
     else:
         raise NotImplementedError(
             f"get_draft_model does not support speculative decoding mode {spec_dec_mode}."

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -330,6 +330,9 @@ def create_py_executor(
                 is_draft_model=True,
                 drafting_loop_wrapper=drafting_loop_wrapper,
             )
+            # For DeepseekV3 MTP, we need to set the num_hidden_layers to 1 for the draft model
+            if spec_config.spec_dec_mode.is_mtp_eagle():
+                draft_model_engine.model.model_config.pretrained_config.num_hidden_layers = 1
             draft_model_engine.kv_cache_manager_key = ResourceManagerType.DRAFT_KV_CACHE_MANAGER
             draft_model_engine.load_weights_from_target_model(
                 model_engine.model)

--- a/tensorrt_llm/_torch/speculative/eagle3.py
+++ b/tensorrt_llm/_torch/speculative/eagle3.py
@@ -92,18 +92,18 @@ class Eagle3SpecMetadata(SpecMetadata):
     is_draft_model: bool = False
     is_first_draft: bool = False
     eagle3_resource_manager: Optional[Eagle3ResourceManager] = None
+    is_mtp_eagle: bool = False
 
     def __post_init__(self):
         if self.is_draft_model:
             self.layers_to_capture = (self.num_layers - 1, )
         elif self.layers_to_capture is None:
-            if self.num_layers == 1:
+            if self.num_layers == 1 or self.is_mtp_eagle:
                 self.layers_to_capture = (self.num_layers - 1, )
             else:
                 if self.num_layers <= 5:
                     raise ValueError(
                         "Not enough hidden layers for default EAGLE3 capture")
-
                 self.layers_to_capture = (1, self.num_layers // 2 - 1,
                                           self.num_layers - 4)
         else:

--- a/tensorrt_llm/_torch/speculative/model_drafter.py
+++ b/tensorrt_llm/_torch/speculative/model_drafter.py
@@ -31,7 +31,7 @@ def get_draft_model_prompt(spec_dec_mode: SpeculativeDecodingMode,
     Can be used to modify prompts for speculative algorithms that need to update tokens
     before drafting.
     """
-    if spec_dec_mode.is_eagle3():
+    if spec_dec_mode.is_eagle3() or spec_dec_mode.is_mtp_eagle():
         # EAGLE3 always throws away the first token when processing draft inputs
         return input_tokens[1:]
     return input_tokens

--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -155,7 +155,7 @@ class MTPSpecMetadata(SpecMetadata):
     @all_rank_num_seqs.setter
     def all_rank_num_seqs(self, value: List[int]):
         self._all_rank_num_seqs = value
-        if self.spec_dec_mode.is_mtp_eagle():
+        if self.spec_dec_mode.is_mtp_eagle_one_model():
             self.subseq_all_rank_num_tokens = value
 
     def prepare(self):
@@ -172,7 +172,7 @@ class MTPSpecMetadata(SpecMetadata):
         # while MTP Eagle worker uses (max_draft_len + 1) input tokens in the 1st draft
         # forward and only one input token in the following draft forward.
         # This num_tokens is used to set the all_rank_num_tokens for attention dp.
-        if not self.spec_dec_mode.is_mtp_eagle():
+        if not self.spec_dec_mode.is_mtp_eagle_one_model():
             self.num_tokens -= self.num_generations
 
         if self.mtp_hidden_states_manager is not None:  # MTP vanilla or use relaxed acceptance
@@ -183,7 +183,7 @@ class MTPSpecMetadata(SpecMetadata):
                 mtp_slot_ids.append(slot_id)
 
             # MTP Vanilla: Update mtp hidden states and past tokens
-            if self.spec_dec_mode.is_mtp():
+            if self.spec_dec_mode.is_mtp_one_model():
                 mtp_hidden_states_ptrs = []
                 mtp_past_tokens_ptrs = []
                 for slot_id in mtp_slot_ids:

--- a/tensorrt_llm/_torch/speculative/utils.py
+++ b/tensorrt_llm/_torch/speculative/utils.py
@@ -19,7 +19,7 @@ def get_spec_metadata(spec_config,
                       max_num_tokens,
                       spec_resource_manager=None,
                       is_draft_model=False):
-    if spec_config.spec_dec_mode.is_mtp():
+    if spec_config.spec_dec_mode.is_mtp_one_model():
         return MTPSpecMetadata(
             max_draft_len=spec_config.max_draft_len,
             spec_dec_mode=spec_config.spec_dec_mode,
@@ -39,6 +39,21 @@ def get_spec_metadata(spec_config,
             is_draft_model=is_draft_model,
             eagle3_resource_manager=spec_resource_manager,
             layers_to_capture=spec_config.eagle3_layers_to_capture,
+            is_mtp_eagle=False,
+        )
+    if spec_config.spec_dec_mode.is_mtp_eagle():
+        return Eagle3SpecMetadata(
+            max_draft_len=spec_config.max_draft_len,
+            spec_dec_mode=spec_config.spec_dec_mode,
+            max_num_requests=max_num_requests,
+            num_layers=model_config.num_hidden_layers,
+            hidden_size=model_config.hidden_size,
+            max_num_tokens=max_num_tokens,
+            dtype=model_config.torch_dtype,
+            is_draft_model=is_draft_model,
+            eagle3_resource_manager=spec_resource_manager,
+            layers_to_capture=None,
+            is_mtp_eagle=True,
         )
     if spec_config.spec_dec_mode.is_eagle3_one_model():
         return Eagle3OneModelSpecMetadata(
@@ -70,7 +85,7 @@ def get_spec_resource_manager(model_engine, draft_model_engine=None):
     max_seq_len = model_engine.max_seq_len
     max_num_tokens = model_engine.max_num_tokens
     spec_dec_mode = spec_config.spec_dec_mode
-    if spec_dec_mode.is_mtp_eagle():
+    if spec_dec_mode.is_mtp_eagle_one_model():
         if spec_config.use_relaxed_acceptance_for_thinking:
             return MTPHiddenStatesManager(
                 spec_config,
@@ -80,15 +95,15 @@ def get_spec_resource_manager(model_engine, draft_model_engine=None):
             )
         else:
             return None
-    if spec_dec_mode.is_mtp():
+    if spec_dec_mode.is_mtp_one_model():
         return MTPHiddenStatesManager(
             spec_config,
             model_config.torch_dtype,
             model_config.hidden_size,
             max_num_requests,
         )
-    if spec_dec_mode.is_eagle3():
-        assert draft_model_engine is not None, "Draft model engine is required for Eagle3 two model flow."
+    if spec_dec_mode.is_eagle3() or spec_dec_mode.is_mtp_eagle():
+        assert draft_model_engine is not None, "Draft model engine is required for Eagle3 and MTP Eagle two model flow."
         return Eagle3ResourceManager(
             spec_config,
             draft_model_engine.model.config.torch_dtype,
@@ -106,10 +121,11 @@ def get_spec_resource_manager(model_engine, draft_model_engine=None):
 
 def get_spec_decoder(sampler_args: TorchSampler.Args,
                      spec_config: "DecodingBaseConfig"):
-    if spec_config.spec_dec_mode.is_mtp():
+    if spec_config.spec_dec_mode.is_mtp_one_model():
         return MTPSampler(sampler_args,
                           nextn=spec_config.num_nextn_predict_layers)
-    if spec_config.spec_dec_mode.is_eagle3():
+    if spec_config.spec_dec_mode.is_eagle3(
+    ) or spec_config.spec_dec_mode.is_mtp_eagle():
         # TorchSampler handles Eagle3 gracefully, by integrating d2t into the sampling process
         return TorchSampler(sampler_args)
     if spec_config.spec_dec_mode.is_eagle3_one_model():
@@ -132,7 +148,8 @@ def get_spec_drafter(model_engine,
 
     max_num_requests = model_engine.batch_size
     if spec_config.spec_dec_mode.is_draft_target(
-    ) or spec_config.spec_dec_mode.is_eagle3():
+    ) or spec_config.spec_dec_mode.is_eagle3(
+    ) or spec_config.spec_dec_mode.is_mtp_eagle():
         return ModelDrafter(spec_config,
                             draft_model_engine,
                             spec_config.max_draft_len,
@@ -148,7 +165,7 @@ def get_spec_drafter(model_engine,
 
 
 def get_num_spec_layers(spec_config):
-    if spec_config.spec_dec_mode.is_mtp():
+    if spec_config.spec_dec_mode.is_mtp_one_model():
         return spec_config.num_nextn_predict_layers
     if spec_config.spec_dec_mode.is_eagle3_one_model():
         num_eagle_layers = spec_config.num_eagle_layers
@@ -160,7 +177,7 @@ def get_spec_worker(spec_config, model_config, mapping):
     spec_dec_mode = spec_config.spec_dec_mode
     if spec_dec_mode.is_mtp_vanilla():
         return MTPWorker(spec_config, model_config)
-    if spec_dec_mode.is_mtp_eagle():
+    if spec_dec_mode.is_mtp_eagle_one_model():
         return MTPEagleWorker(spec_config, model_config)
     if spec_dec_mode.is_eagle3_one_model():
         return Eagle3OneModelWorker(spec_config, mapping)
@@ -174,14 +191,13 @@ def get_num_extra_kv_tokens(spec_config):
     """
     if spec_config is None:
         return 0
-    if spec_config.spec_dec_mode.is_eagle3_one_model(
-    ) or spec_config.spec_dec_mode.is_mtp_eagle():
+    if spec_config.spec_dec_mode.is_eagle3_one_model():
         return spec_config.max_draft_len - 1
     return 0
 
 
 def update_spec_config_from_model_config(spec_config, model_config):
-    if spec_config.spec_dec_mode.is_mtp():
+    if spec_config.spec_dec_mode.is_mtp_one_model():
         # Use `max_draft_len` for several low-level APIs. TODO: Remove this after distinguishing them.
         spec_config.max_draft_len = spec_config.num_nextn_predict_layers
         # Use `num_nextn_predict_layers_from_model_config` to decide decoding mode MTP / MTP_EAGLE.

--- a/tests/integration/defs/test_e2e.py
+++ b/tests/integration/defs/test_e2e.py
@@ -1913,9 +1913,38 @@ def test_ptp_quickstart_advanced_mtp(llm_root, llm_venv, model_name,
                 "MTP",
                 "--model_dir",
                 f"{llm_models_root()}/{model_path}",
+                "--use_one_model",
             ],
             stdout=running_log)
         _check_mem_usage(running_log, [54.60, 0, 0, 0])
+
+
+@pytest.mark.parametrize("model_name,model_path", [
+    ("DeepSeek-V3-Lite-BF16", "DeepSeek-V3-Lite/bf16"),
+])
+def test_ptp_quickstart_advanced_mtp_eagle(llm_root, llm_venv, model_name,
+                                           model_path):
+    print(f"Testing {model_name}.")
+    example_root = Path(os.path.join(llm_root, "examples", "llm-api"))
+    with tempfile.NamedTemporaryFile(mode='w+t',
+                                     suffix=f".{model_name}.log",
+                                     dir="./",
+                                     delete=True,
+                                     delete_on_close=True) as running_log:
+        llm_venv.run_cmd(
+            [
+                str(example_root / "quickstart_advanced.py"),
+                "--use_cuda_graph",
+                "--spec_decode_max_draft_len",
+                "1",  # test 1 MTP module
+                "--spec_decode_algo",
+                "MTP",
+                "--model_dir",
+                f"{llm_models_root()}/{model_path}",
+            ],
+            stdout=running_log)
+        # 74.60 is the memory usage for DeepSeek-V3-Lite-BF16 with MTP Eagle 2 two model style as one extra kv cache is needed for draft model.
+        _check_mem_usage(running_log, [74.60, 0, 0, 0])
 
 
 @pytest.mark.skip_less_device(4)
@@ -2169,6 +2198,7 @@ def test_relaxed_acceptance_quickstart_advanced_deepseek_r1_8gpus(
             "--relaxed_topk=10",
             "--relaxed_delta=0.5",
             "--enable_attention_dp",
+            "--use_one_model",
         ],
                          stdout=running_log)
         _check_mem_usage(running_log, [85.6, 0, 0, 0], 8)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - MTP Eagle decoding now supports both one-model and two-model modes.
  - Configurable Eagle capture layers and relaxed acceptance controls (top-k, delta).
  - MTP draft decoding enabled with automatic routing; draft prompts drop first token in Eagle/MTP Eagle modes.
- Refactor
  - Weight-loading modularized for more reliable loading, dequantization, and tensor-parallel support.
  - Dynamic capture-layer handling to reduce memory and scale with configuration.
- Chores
  - Updated decoding-mode and config wiring to enable new variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up
-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
