### PR TITLE
[https://nvbugs/5444937][chore] Fixing KV events tests

### DIFF
--- a/tests/unittest/llmapi/test_llm_kv_cache_events.py
+++ b/tests/unittest/llmapi/test_llm_kv_cache_events.py
@@ -232,7 +232,6 @@ def check_events(llm,
     assert not llm.get_kv_cache_events(5)
 
 
-@pytest.mark.skip(reason="https://nvbugs/5445001")
 def test_llm_kv_events_api():
     llm = create_llm()
     sampling_params = SamplingParams(max_tokens=6,

--- a/tests/unittest/llmapi/test_llm_kv_cache_events.py
+++ b/tests/unittest/llmapi/test_llm_kv_cache_events.py
@@ -175,8 +175,10 @@ def check_events(llm,
     else:
         while events:
             event = events.pop(0)
+            if not event:
+                continue
             assert "attention_dp_rank" in event
-            if event and event["attention_dp_rank"] == attention_dp_rank:
+            if event["attention_dp_rank"] == attention_dp_rank:
                 assert event["data"]["type"] in ["created", "stored"]
                 if event["data"]["type"] == "created":
                     assert event["event_id"] == 0

--- a/tests/unittest/llmapi/test_llm_kv_cache_events.py
+++ b/tests/unittest/llmapi/test_llm_kv_cache_events.py
@@ -160,8 +160,8 @@ def check_events(llm,
                      scheduling_params=scheduling_params)
     time.sleep(1)
     events = llm.get_kv_cache_events(5)
-
     # Created or stored event
+    total_stored_blocks = 0
     if attention_dp_rank is None:
         event = events.pop(0)  # created event
         assert event["event_id"] == 0
@@ -169,21 +169,22 @@ def check_events(llm,
         while events:
             event = events.pop(0)
             if event:
-                assert event["event_id"] == 1
                 assert event["data"]["type"] == "stored"
-                assert len(event["data"]["blocks"]) == 5
+                assert event["event_id"] > 0
+                total_stored_blocks += len(event["data"]["blocks"])
     else:
         while events:
             event = events.pop(0)
             assert "attention_dp_rank" in event
             if event and event["attention_dp_rank"] == attention_dp_rank:
-                assert event["event_id"] in [0, 1]
                 assert event["data"]["type"] in ["created", "stored"]
                 if event["data"]["type"] == "created":
                     assert event["event_id"] == 0
                 if event["data"]["type"] == "stored":
-                    assert event["event_id"] == 1
-                    assert len(event["data"]["blocks"]) == 5
+                    assert event["event_id"] > 0
+                    total_stored_blocks += len(event["data"]["blocks"])
+
+    assert total_stored_blocks == 5  # Should have 5 blocks in total
 
     _ = llm.generate(requests[1],
                      sampling_params=sampling_params,
@@ -191,22 +192,21 @@ def check_events(llm,
     time.sleep(1)
     events2 = llm.get_kv_cache_events(5)
 
+    total_stored_blocks = 0
+    has_removed_event = False
     while events2:
         event = events2.pop(0)
         if event and (attention_dp_rank is None
                       or event.get("attention_dp_rank") == attention_dp_rank):
-            if event["event_id"] == 2:
-                # 2 removed events needed
-                # should be a removed event to make space for context block
-                assert event["data"]["type"] == "removed"
+            if event["data"]["type"] == "removed":
+                has_removed_event = True
                 assert event["data"]["block_hashes"]
-            elif event["event_id"] == 3:
-                assert event["data"]["type"] == "removed"
-                assert event["data"]["block_hashes"]
-            # stored event for 2nd request
-            elif event["event_id"] == 4:
-                assert event["data"]["type"] == "stored"
-                assert len(event["data"]["blocks"]) == 5
+            # stored events
+            elif event["data"]["type"] == "stored":
+                total_stored_blocks += len(event["data"]["blocks"])
+
+    assert total_stored_blocks == 5  # Should have 5 blocks in total
+    assert has_removed_event
 
     _ = llm.generate(requests[2],
                      sampling_params=sampling_params,
@@ -214,19 +214,21 @@ def check_events(llm,
     time.sleep(1)
     events3 = llm.get_kv_cache_events(5)
 
+    total_stored_blocks = 0
+    has_removed_event = False
     while events3:
         event = events3.pop(0)
         if event and (attention_dp_rank is None
                       or event.get("attention_dp_rank") == attention_dp_rank):
-            if event["event_id"] == 5:
-                assert event["data"]["type"] == "removed"
+
+            if event["data"]["type"] == "removed":
+                has_removed_event = True
                 assert event["data"]["block_hashes"]
-            elif event["event_id"] == 6:
-                assert event["data"]["type"] == "removed"
-                assert event["data"]["block_hashes"]
-            elif event["event_id"] == 7:
-                assert event["data"]["type"] == "stored"
-                assert len(event["data"]["blocks"]) == 5
+            elif event["data"]["type"] == "stored":
+                total_stored_blocks += len(event["data"]["blocks"])
+
+    assert total_stored_blocks == 5  # Should have 5 blocks in total
+    assert has_removed_event
 
     # no more events after request is finished
     assert not llm.get_kv_cache_events(5)
@@ -246,7 +248,6 @@ def test_llm_kv_events_api():
     check_events(llm, requests, sampling_params)
 
 
-@pytest.mark.skip(reason="https://nvbugs/5451407")
 @skip_single_gpu
 @pytest.mark.threadleak(enabled=False)
 def test_llm_api_attention_dp_kv_events():


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Re-enabled KV-cache event tests that were previously skipped to improve coverage.
  * Updated validations to avoid fixed event_id assumptions; now validate created vs stored semantics and ensure stored events have positive IDs.
  * Accumulate and assert per-batch stored block counts (5 blocks after each batch) and verify removal events between batches.
  * Confirm final absence of events; no public API/signature changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up
-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
