### PR TITLE
[TRTLLM-7346][fix] Improve performance of PyTorchModelEngine._get_lora_params_from_requests

### DIFF
--- a/tensorrt_llm/_torch/peft/lora/layer.py
+++ b/tensorrt_llm/_torch/peft/lora/layer.py
@@ -107,8 +107,6 @@ class LoraLayer(torch.nn.Module):
                 module_idx = int(module_idx)
                 if module_idx in lora_params[layer_idx]:
                     active_lora_module_ids.append(module_idx)
-                    # TODO (dafrimi): needs to pass this is_dora arg
-                    lora_params[layer_idx][module_idx]['is_dora']
                     lora_ranks.append(
                         lora_params[layer_idx][module_idx]['adapter_size'])
                     lora_weight_pointers.append(

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -339,7 +339,9 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
         self.py_decoding_iter = 0
         self.is_attention_dp_dummy = False
         self.is_cuda_graph_dummy = False
-        self.py_lora_task_layer_module_configs = None
+        self.py_lora_task_layer_module_configs: list[
+            tensorrt_llm.bindings.internal.runtime.
+            TaskLayerModuleConfig] | None = None
 
         self.py_return_log_probs = return_log_probs
         self.py_return_context_logits = return_context_logits

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -2108,88 +2108,69 @@ class PyTorchModelEngine(ModelEngine):
             for module in request.py_lora_task_layer_module_configs:
                 module_id = module.module_id
                 layer_id = module.layer_id
-                adapter_size = module.adapter_size
-                is_dora = module.scaling_vec_pointer == 0
-                weights_in_pointer = module.weights_in_pointer
-                weights_out_pointer = module.weights_out_pointer
-                scaling_vec_pointer = module.scaling_vec_pointer
-                if weights_in_pointer is None:
-                    weights_in_pointer = 0
-                if weights_out_pointer is None:
-                    weights_out_pointer = 0
-                if scaling_vec_pointer is None:
-                    scaling_vec_pointer = 0
 
                 if layer_id not in lora_params:
                     lora_params[layer_id] = {}
                 if module_id not in lora_params[layer_id]:
-                    lora_params[layer_id][module_id] = {}
+                    lora_params[layer_id][module_id] = {
+                        'adapter_size': [],
+                        'is_dora': [],
+                        'weight_pointers': [],
+                    }
 
-                if 'adapter_size' not in lora_params[layer_id][module_id]:
-                    lora_params[layer_id][module_id]['adapter_size'] = []
-                if 'is_dora' not in lora_params[layer_id][module_id]:
-                    lora_params[layer_id][module_id]['is_dora'] = []
-                if 'weight_pointers' not in lora_params[layer_id][module_id]:
-                    lora_params[layer_id][module_id]['weight_pointers'] = []
-
-                tmp_lora_params[
-                    f'{request.py_request_id}_{layer_id}_{module_id}_adapter_size'] = [
-                        adapter_size
-                    ]
-                tmp_lora_params[
-                    f'{request.py_request_id}_{layer_id}_{module_id}_is_dora'] = [
-                        is_dora
-                    ]
-                tmp_lora_params[
-                    f'{request.py_request_id}_{layer_id}_{module_id}_weights_pointer'] = [
-                        weights_in_pointer, weights_out_pointer,
-                        scaling_vec_pointer
-                    ]
+                scaling_vec_pointer = module.scaling_vec_pointer
+                if scaling_vec_pointer is None:
+                    scaling_vec_pointer = 0
+                tmp_lora_params[(request.py_request_id, layer_id,
+                                 module_id)] = {
+                                     'adapter_size': [module.adapter_size],
+                                     'is_dora': [scaling_vec_pointer == 0],
+                                     'weights_pointer': [
+                                         module.weights_in_pointer,
+                                         module.weights_out_pointer,
+                                         scaling_vec_pointer
+                                     ],
+                                 }
 
         for request in request_list:
             # Need to set default values for this case
             if request.py_lora_task_layer_module_configs is None:
                 for layer_id in lora_params:
                     for module_id in lora_params[layer_id]:
-                        lora_params[layer_id][module_id]['adapter_size'].append(
-                            0)
-                        lora_params[layer_id][module_id]['is_dora'].append(
-                            False)
-                        lora_params[layer_id][module_id]['weight_pointers'] += [
-                            0, 0, 0
-                        ]
+                        current_lora_params = lora_params[layer_id][module_id]
+                        current_lora_params['adapter_size'].append(0)
+                        current_lora_params['is_dora'].append(False)
+                        current_lora_params['weight_pointers'] += [0, 0, 0]
 
             else:
                 for layer_id in lora_params:
                     for module_id in lora_params[layer_id]:
-                        if f'{request.py_request_id}_{layer_id}_{module_id}_adapter_size' not in tmp_lora_params:
-                            lora_params[layer_id][module_id][
-                                'adapter_size'].append(0)
-                            lora_params[layer_id][module_id]['is_dora'].append(
-                                False)
-                            lora_params[layer_id][module_id][
-                                'weight_pointers'] += [0, 0, 0]
+                        current_tmp_lora_params = tmp_lora_params.get(
+                            (request.py_request_id, layer_id, module_id), None)
+                        current_lora_params = lora_params[layer_id][module_id]
+                        if current_tmp_lora_params is None:
+                            current_lora_params['adapter_size'].append(0)
+                            current_lora_params['is_dora'].append(False)
+                            current_lora_params['weight_pointers'] += [0, 0, 0]
                         else:
-                            lora_params[layer_id][module_id][
-                                'adapter_size'] += tmp_lora_params[
-                                    f'{request.py_request_id}_{layer_id}_{module_id}_adapter_size']
-                            lora_params[layer_id][module_id][
-                                'is_dora'] += tmp_lora_params[
-                                    f'{request.py_request_id}_{layer_id}_{module_id}_is_dora']
-                            lora_params[layer_id][module_id][
-                                'weight_pointers'] += tmp_lora_params[
-                                    f'{request.py_request_id}_{layer_id}_{module_id}_weights_pointer']
+                            current_lora_params[
+                                'adapter_size'] += current_tmp_lora_params[
+                                    'adapter_size']
+                            current_lora_params[
+                                'is_dora'] += current_tmp_lora_params['is_dora']
+                            current_lora_params[
+                                'weight_pointers'] += current_tmp_lora_params[
+                                    'weights_pointer']
 
         for layer_id in lora_params:
             for module_id in lora_params[layer_id]:
-                lora_params[layer_id][module_id][
-                    'adapter_size'] = torch.IntTensor(
-                        lora_params[layer_id][module_id]['adapter_size'])
-                lora_params[layer_id][module_id][
-                    'weight_pointers'] = torch.LongTensor(
-                        lora_params[layer_id][module_id]['weight_pointers'])
+                current_lora_params = lora_params[layer_id][module_id]
+                current_lora_params['adapter_size'] = torch.IntTensor(
+                    current_lora_params['adapter_size'])
+                current_lora_params['weight_pointers'] = torch.LongTensor(
+                    current_lora_params['weight_pointers'])
 
-        if bool(lora_params):
+        if lora_params:
             lora_params['host_request_types'] = attn_metadata.host_request_types
             lora_params['prompt_lens_cpu'] = attn_metadata.prompt_lens_cpu
             lora_params['num_seqs'] = attn_metadata.num_seqs

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -2125,7 +2125,7 @@ class PyTorchModelEngine(ModelEngine):
                                  module_id)] = {
                                      'adapter_size': [module.adapter_size],
                                      'is_dora': [scaling_vec_pointer == 0],
-                                     'weights_pointer': [
+                                     'weight_pointers': [
                                          module.weights_in_pointer,
                                          module.weights_out_pointer,
                                          scaling_vec_pointer
@@ -2160,11 +2160,13 @@ class PyTorchModelEngine(ModelEngine):
                                 'is_dora'] += current_tmp_lora_params['is_dora']
                             current_lora_params[
                                 'weight_pointers'] += current_tmp_lora_params[
-                                    'weights_pointer']
+                                    'weight_pointers']
 
         for layer_id in lora_params:
             for module_id in lora_params[layer_id]:
                 current_lora_params = lora_params[layer_id][module_id]
+                # TODO: When lora_grouped_gemm supports DoRA: convert 'is_dora' to a bool tensor.
+                #       Until it's supported, that would just slow down this function, so better not to do it.
                 current_lora_params['adapter_size'] = torch.IntTensor(
                     current_lora_params['adapter_size'])
                 current_lora_params['weight_pointers'] = torch.LongTensor(

--- a/tests/unittest/_torch/modules/tests_lora_modules/test_lora_attention_pytorch_flow_vs_trt.py
+++ b/tests/unittest/_torch/modules/tests_lora_modules/test_lora_attention_pytorch_flow_vs_trt.py
@@ -419,31 +419,23 @@ class TestLoraAttentionPytorchFlowVsTRT(unittest.TestCase):
                     lora_params['lora_ranks'],
                     'weight_pointers':
                     lora_params['lora_weights_pointers'],
-                    'is_dora':
-                    False,
                 },
                 LoraModuleType.ATTENTION_K: {
                     'adapter_size':
                     lora_params['lora_ranks'],
                     'weight_pointers': lora_params['lora_weights_pointers'],
-                    'is_dora':
-                    False,
                 },
                 LoraModuleType.ATTENTION_V: {
                     'adapter_size':
                     lora_params['lora_ranks'],
                     'weight_pointers':
                      lora_params['lora_weights_pointers'],
-                    'is_dora':
-                    False,
                 },
                 LoraModuleType.ATTENTION_DENSE: {
                     'adapter_size':
                     lora_params['lora_ranks'],
                     'weight_pointers':
                     lora_params['lora_weights_pointers'],
-                    'is_dora':
-                    False,
                 }
             }
         }


### PR DESCRIPTION
## Description

Improve the runtime performance of `PyTorchModelEngine._get_lora_params_from_requests` by:
1. Changing the dict key from a formatted string containing request_id, layer_id and module_id to a tuple.
2. Avoiding repeated dict lookups.

Performance improvement of these changes when benchmarked on `Llama-3.1-8B-Instruct-FP8`, TP=1, BS=16:
* `PyTorchModelEngine._get_lora_params_from_requests` run time reduced by ~33%.
* forward step run time reduced by ~10%.

In addition, some DoRA related code was removed as it's not supported in pytorch flow.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal LoRA parameter aggregation so per-layer/module data is merged consistently and converted to tensors; removed an obsolete internal per-module flag from the runtime/forward path.

* **Chores**
  * Added an explicit type annotation to an internal attribute; no behavioral or public API changes.

* **Tests**
  * Updated unit test LoRA configurations to match the new internal representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->