### PR TITLE
[TRTLLM-7458][infra] Retry test stage

### DIFF
--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -1,4 +1,4 @@
-@Library(['bloom-jenkins-shared-lib@main', 'trtllm-jenkins-shared-lib@main']) _
+@Library(['bloom-jenkins-shared-lib@main', 'trtllm-jenkins-shared-lib@user/yiqingy/retry_stage']) _
 
 import java.lang.InterruptedException
 import groovy.transform.Field
@@ -498,7 +498,7 @@ def uploadResults(def pipeline, SlurmCluster cluster, String clusterName, String
                 sh "ls -al ${stageName}/"
                 echo "Upload test results."
                 sh "tar -czvf results-${stageName}${postTag}.tar.gz ${stageName}/"
-                ensureStageResultNotUploaded("${stageName}${postTag}")
+                ensureStageResultNotUploaded("${stageName}${postTag}" + "-Attempt" + GlobalState.stageAttemptTimes[stageName])
                 trtllm_utils.uploadArtifacts(
                     "results-${stageName}${postTag}.tar.gz",
                     "${UPLOAD_PATH}/test-results/"
@@ -506,10 +506,6 @@ def uploadResults(def pipeline, SlurmCluster cluster, String clusterName, String
             } else {
                 println("No results xml to submit")
             }
-        }
-
-        if (hasTimeoutTest || downloadResultSucceed) {
-            junit(allowEmptyResults: true, testResults: "${stageName}/results*.xml")
         }
     }
 }
@@ -1860,6 +1856,7 @@ def globalVars = [
 
 class GlobalState {
     static def uploadResultStageNames = []
+    static def stageAttemptTimes = [:]
 
     // HOST_NODE_NAME to starting port section map
     // This map maintains the next available starting port for each host node
@@ -1933,7 +1930,7 @@ def cacheErrorAndUploadResult(stageName, taskRunner, finallyRunner, noResultIfSu
         caughtError = e
         throw e
     } finally {
-        ensureStageResultNotUploaded(stageName + postTag)
+        ensureStageResultNotUploaded(stageName + postTag + "-Attempt" + GlobalState.stageAttemptTimes[stageName])
         if (stageIsInterrupted) {
             echo "Stage is interrupted, skip to upload test result."
         } else {
@@ -2027,6 +2024,24 @@ def createKubernetesPodConfig(image, type, arch = "amd64", gpuCount = 1, perfMod
         containerConfig = """
                   - name: alpine
                     image: urm.nvidia.com/docker/alpine:latest
+                    command: ['cat']
+                    tty: true
+                    resources:
+                      requests:
+                        cpu: '2'
+                        memory: 10Gi
+                        ephemeral-storage: 25Gi
+                      limits:
+                        cpu: '2'
+                        memory: 10Gi
+                        ephemeral-storage: 25Gi
+                    imagePullPolicy: Always"""
+        nodeLabelPrefix = "cpu"
+        break
+    case "package":
+        containerConfig = """
+                  - name: trt-llm
+                    image: ${image}
                     command: ['cat']
                     tty: true
                     resources:
@@ -2671,7 +2686,7 @@ def rerunFailedTests(stageName, llmSrc, testCmdLine, resultFileName="results.xml
         generate_rerun_tests_list \
         --output-dir=${rerunDir}/ \
         --input-file=${WORKSPACE}/${stageName}/${resultFileName} \
-        --fail-signatures='${failSignaturesList}'
+        --fail-signatures="${failSignaturesList}"
     """
 
     // If there are some failed tests that cannot be rerun (e.g. test duration > 10 min and no known failure signatures),
@@ -4404,15 +4419,31 @@ def launchTestJobs(pipeline, testFilter)
     pipeline.echo "Now we will run stages: [\n${keysStr}\n]"
 
     parallelJobsFiltered = parallelJobsFiltered.collectEntries { key, values -> [key, {
-        stage(key) {
-            if (key in testFilter[REUSE_STAGE_LIST]) {
+        def stageName = key
+        stage(stageName) {
+            if (stageName in testFilter[REUSE_STAGE_LIST]) {
                 stage("Skip - Reused") {
                     echo "Skip - Passed in the previous pipelines."
                 }
             } else if (values instanceof List) {
-                runKubernetesPodWithInfraRetry(pipeline, values[0], "trt-llm", key, { attemptTag, isFinalAttempt ->
+                def stageIsInterrupted = false
+                try {
+                    trtllm_utils.llmStageWithRetry(pipeline, stageName, {
+                        GlobalState.stageAttemptTimes[stageName] = GlobalState.stageAttemptTimes.getOrDefault(stageName, 0) + 1
+                        echo "GlobalState.stageAttemptTimes[${stageName}]: ${GlobalState.stageAttemptTimes[stageName]}"
+                        runKubernetesPodWithInfraRetry(pipeline, values[0], "trt-llm", key, { attemptTag, isFinalAttempt ->
                     values[1](attemptTag, isFinalAttempt)
                 })
+                    })
+                } catch (InterruptedException e) {
+                    stageIsInterrupted = true
+                    throw e
+                } finally {
+                    def image = "urm.nvidia.com/docker/golang:1.22"
+                    trtllm_utils.launchKubernetesPod(pipeline, createKubernetesPodConfig(image, "package"), "trt-llm", {
+                        publishJunitTestResults(pipeline, stageName, stageIsInterrupted)
+                    })
+                }
             } else {
                 values()
             }
@@ -4422,6 +4453,39 @@ def launchTestJobs(pipeline, testFilter)
     return parallelJobsFiltered
 }
 
+
+def publishJunitTestResults(pipeline, stageName, stageIsInterrupted) {
+    stage("Publish the junit test results") {
+        if (stageIsInterrupted) {
+            echo "Stage is interrupted, skip to upload test result."
+        } else {
+            def resultsTar = "results-${stageName}.tar.gz"
+            def remoteResultsPath = "https://urm.nvidia.com/artifactory/${UPLOAD_PATH}/test-results/${resultsTar}"
+            sh "echo 'Attempting to download: ${remoteResultsPath}'"
+            trtllm_utils.llmExecStepWithRetry(pipeline, script: "apt-get update")
+            trtllm_utils.llmExecStepWithRetry(pipeline, script: "apt-get -y install wget")
+            try {
+                trtllm_utils.llmExecStepWithRetry(pipeline, script: "wget -nv ${remoteResultsPath}")
+            } catch (Exception e) {
+                // wget returns exit code 8 for server errors (404, 500, etc.)
+                if (e.message.contains("exit code 8") || e.message.contains("404")) {
+                    echo "Test result not found (HTTP error), skip to upload test result."
+                    return
+                }
+                throw e
+            }
+            sh "tar -xzvf ${resultsTar}"
+            sh "cd ${stageName} && ls -alh"
+            junit(allowEmptyResults: true, testResults: "${stageName}/results*.xml")
+            // Clean up the workspace
+            sh """
+                env | sort
+                pwd && ls -alh
+                rm -rf ./*
+            """
+        }
+    }
+}
 
 
 def launchTestJobsForImagesSanityCheck(pipeline, globalVars) {

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -2681,13 +2681,15 @@ def rerunFailedTests(stageName, llmSrc, testCmdLine, resultFileName="results.xml
 
     // Generate rerun test lists
     def failSignaturesList = trtllm_utils.getFailSignaturesList().join(",")
-    sh """
+    sh(script: """
+        set +x  # Disable debug mode
         python3 ${llmSrc}/jenkins/scripts/test_rerun.py \
         generate_rerun_tests_list \
         --output-dir=${rerunDir}/ \
         --input-file=${WORKSPACE}/${stageName}/${resultFileName} \
         --fail-signatures="${failSignaturesList}"
-    """
+        set -x  # Enable debug mode
+    """)
 
     // If there are some failed tests that cannot be rerun (e.g. test duration > 10 min and no known failure signatures),
     // fail the stage immediately without attempting any reruns
@@ -4430,10 +4432,10 @@ def launchTestJobs(pipeline, testFilter)
                 try {
                     trtllm_utils.llmStageWithRetry(pipeline, stageName, {
                         GlobalState.stageAttemptTimes[stageName] = GlobalState.stageAttemptTimes.getOrDefault(stageName, 0) + 1
-                        echo "GlobalState.stageAttemptTimes[${stageName}]: ${GlobalState.stageAttemptTimes[stageName]}"
+                        echo "${stageName} attempt times: ${GlobalState.stageAttemptTimes[stageName]}"
                         runKubernetesPodWithInfraRetry(pipeline, values[0], "trt-llm", key, { attemptTag, isFinalAttempt ->
-                    values[1](attemptTag, isFinalAttempt)
-                })
+                            values[1](attemptTag, isFinalAttempt)
+                        })
                     })
                 } catch (InterruptedException e) {
                     stageIsInterrupted = true
@@ -4469,7 +4471,7 @@ def publishJunitTestResults(pipeline, stageName, stageIsInterrupted) {
             } catch (Exception e) {
                 // wget returns exit code 8 for server errors (404, 500, etc.)
                 if (e.message.contains("exit code 8") || e.message.contains("404")) {
-                    echo "Test result not found (HTTP error), skip to upload test result."
+                    echo "Test result not found, skip to upload test result."
                     return
                 }
                 throw e

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -4447,7 +4447,22 @@ def launchTestJobs(pipeline, testFilter)
                     })
                 }
             } else {
-                values()
+                def stageIsInterrupted = false
+                try {
+                    trtllm_utils.llmStageWithRetry(pipeline, stageName, {
+                        GlobalState.stageAttemptTimes[stageName] = GlobalState.stageAttemptTimes.getOrDefault(stageName, 0) + 1
+                        echo "${stageName} attempt times: ${GlobalState.stageAttemptTimes[stageName]}"
+                        values()
+                    })
+                } catch (InterruptedException e) {
+                    stageIsInterrupted = true
+                    throw e
+                } finally {
+                    def image = "urm.nvidia.com/docker/golang:1.22"
+                    trtllm_utils.launchKubernetesPod(pipeline, createKubernetesPodConfig(image, "package"), "trt-llm", {
+                        publishJunitTestResults(pipeline, stageName, stageIsInterrupted, "-SubJob-RunTest")
+                    })
+                }
             }
         }
     }]}
@@ -4456,13 +4471,12 @@ def launchTestJobs(pipeline, testFilter)
 }
 
 
-def publishJunitTestResults(pipeline, stageName, stageIsInterrupted) {
+def publishJunitTestResults(pipeline, stageName, stageIsInterrupted, postTag="") {
     stage("Publish the junit test results") {
         if (stageIsInterrupted) {
             echo "Stage is interrupted, skip to upload test result."
         } else {
-            def resultsTar = "results-${stageName}.tar.gz"
-            def remoteResultsPath = "https://urm.nvidia.com/artifactory/${UPLOAD_PATH}/test-results/${resultsTar}"
+            def remoteResultsPath = "https://urm.nvidia.com/artifactory/${UPLOAD_PATH}/test-results/results-${stageName}${postTag}.tar.gz"
             sh "echo 'Attempting to download: ${remoteResultsPath}'"
             trtllm_utils.llmExecStepWithRetry(pipeline, script: "apt-get update")
             trtllm_utils.llmExecStepWithRetry(pipeline, script: "apt-get -y install wget")
@@ -4476,7 +4490,7 @@ def publishJunitTestResults(pipeline, stageName, stageIsInterrupted) {
                 }
                 throw e
             }
-            sh "tar -xzvf ${resultsTar}"
+            sh "tar -xzvf results-${stageName}.tar.gz"
             sh "cd ${stageName} && ls -alh"
             junit(allowEmptyResults: true, testResults: "${stageName}/results*.xml")
             // Clean up the workspace

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -4490,7 +4490,7 @@ def publishJunitTestResults(pipeline, stageName, stageIsInterrupted, postTag="")
                 }
                 throw e
             }
-            sh "tar -xzvf results-${stageName}.tar.gz"
+            sh "tar -xzvf results-${stageName}${postTag}.tar.gz"
             sh "cd ${stageName} && ls -alh"
             junit(allowEmptyResults: true, testResults: "${stageName}/results*.xml")
             // Clean up the workspace

--- a/jenkins/scripts/test_rerun.py
+++ b/jenkins/scripts/test_rerun.py
@@ -24,7 +24,6 @@ def generate_rerun_tests_list(outdir, xml_filename, failSignaturesList):
     #    - If test duration > 5 min and <= 10 min: add to rerun_1.txt (will rerun 1 time)
     #    - If test duration > 10 min but contains fail signatures in error message: add to rerun_1.txt
     #    - If test duration > 10 min and no known failure signatures: add to rerun_0.txt (will not rerun)
-    print(failSignaturesList)
 
     rerun_0_filename = os.path.join(outdir, 'rerun_0.txt')
     rerun_1_filename = os.path.join(outdir, 'rerun_1.txt')

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch_multimodal.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch_multimodal.py
@@ -152,6 +152,7 @@ class TestVILA1_5_3B(LlmapiAccuracyTestHarness):
     )
 
     def test_auto_dtype(self):
+        pytest.fail("ImagePullBackOff")
         with LLM(
             self.MODEL_PATH,
             max_num_tokens=self.MAX_NUM_TOKENS,

--- a/tests/integration/defs/llmapi/test_llm_api_connector.py
+++ b/tests/integration/defs/llmapi/test_llm_api_connector.py
@@ -156,6 +156,7 @@ def test_connector_simple(enforce_single_worker, model_with_connector,
 @pytest.mark.parametrize("use_overlap_scheduler", [True, False])
 def test_connector_async_onboard(enforce_single_worker, model_with_connector,
                                  use_overlap_scheduler):
+    pytest.fail("Connection failed")
     NUM_TOKENS = 8
 
     model_fn, scheduler, worker = model_with_connector

--- a/tests/integration/defs/test_e2e.py
+++ b/tests/integration/defs/test_e2e.py
@@ -1095,6 +1095,7 @@ def test_openai_tool_call(llm_root, llm_venv):
 
 @pytest.mark.parametrize("sampler", ["torch_sampler", "trtllm_sampler"])
 def test_openai_completions_with_logit_bias(llm_root, llm_venv, sampler: str):
+    pytest.fail("No CUDA GPUs are available")
     test_root = unittest_path() / "llmapi" / "apps"
     llm_venv.run_cmd([
         "-m", "pytest",


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now uses an updated per-stage retry library reference; per-stage retry wrapper accepts a configurable sleep/delay.

* **Tests**
  * Test matrix reduced—many PyTorch and end-to-end entries disabled/commented to shrink run scope.
  * Per-stage automatic retry wrapping applied across test stages for consistency.

* **Improvements**
  * Rerun failure messages surface underlying error details for clearer diagnostics.

* **Bug Fixes**
  * Infrastructure/machine errors now propagate immediately and skip automated reruns when detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
