### PR TITLE
[#6901][fix] Breaking Change: disable nvtx annotation by default.

### DIFF
--- a/docs/source/performance/perf-analysis.md
+++ b/docs/source/performance/perf-analysis.md
@@ -76,7 +76,7 @@ TLLM_PROFILE_START_STOP=100-150 nsys profile \
   -o trace -f true \
   -t 'cuda,nvtx,python-gil' -c cudaProfilerApi \
   --cuda-graph-trace node \
-  -e TLLM_PROFILE_RECORD_GC=1,TLLM_LLMAPI_ENABLE_NVTX=1,TLLM_TORCH_PROFILE_TRACE=trace.json \
+  -e TLLM_PROFILE_RECORD_GC=1,TLLM_NVTX_DEBUG=1,TLLM_TORCH_PROFILE_TRACE=trace.json \
   --trace-fork-before-exec=true \
   trtllm-bench \ # or trtllm-serve command
     --model deepseek-ai/DeepSeek-V3 \

--- a/tensorrt_llm/_utils.py
+++ b/tensorrt_llm/_utils.py
@@ -866,7 +866,10 @@ def nvtx_range(msg: str,
     Returns:
         contextmanager: A context manager that marks the NVTX range.
     """
-    return nvtx.annotate(msg, color=color, domain=domain, category=category)
+    if os.getenv("TLLM_NVTX_DEBUG", "0") == "1":
+        return nvtx.annotate(msg, color=color, domain=domain, category=category)
+    else:
+        return _null_context_manager()
 
 
 def nvtx_range_debug(msg: str,
@@ -889,8 +892,7 @@ def nvtx_range_debug(msg: str,
         contextmanager: A context manager that either marks the NVTX range if enabled,
                         or a null context manager that does nothing if disabled.
     """
-    if os.getenv("TLLM_LLMAPI_ENABLE_NVTX", "0") == "1" or \
-            os.getenv("TLLM_NVTX_DEBUG", "0") == "1":
+    if os.getenv("TLLM_NVTX_DEBUG", "0") == "1":
         return nvtx_range(msg, color=color, domain=domain, category=category)
     else:
         return _null_context_manager()
@@ -912,7 +914,8 @@ def nvtx_mark(msg: str,
         domain (str, optional): The domain name for the marker. Defaults to "TensorRT-LLM".
         category (str, optional): The category for the marker. Defaults to None.
     """
-    nvtx.mark(msg, color=color, category=category, domain=domain)
+    if os.getenv("TLLM_NVTX_DEBUG", "0") == "1":
+        nvtx.mark(msg, color=color, category=category, domain=domain)
 
 
 def volume(d: Sequence[int]):


### PR DESCRIPTION
Disable NVTX annotation by default unless we set ENV `TLLM_ENABLE_NVTX=1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NVTX instrumentation can be toggled at runtime via TLLM_ENABLE_NVTX=1; when disabled (default) NVTX calls are no-ops.
  * Instrumentation control extended to additional public helpers; debug-only gating remains available via existing environment variables.
  * Public APIs/signatures unchanged; only runtime instrumentation behavior and control flow modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->