### PR TITLE
[None][feat] Apply AutoTuner to fp8_block_scale_deep_gemm to trigger JIT ahead of time.

### DIFF
--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -4,6 +4,8 @@ from typing import List, Optional, Tuple
 import torch
 
 import tensorrt_llm.quantization.utils.fp4_utils as fp4_utils
+import tensorrt_llm.quantization.utils.fp8_utils as fp8_utils
+from tensorrt_llm import deep_gemm
 from tensorrt_llm._utils import get_sm_version
 
 from ..autotuner import (AutoTuner, ConstraintSpec, DynamicTensorSpec,
@@ -888,6 +890,94 @@ def _(
     # Assuming weight is packed and the output dimension can be inferred from weight.size(1)
     N = weight.size(1) if weight.dim() > 1 else weight.size(0)
     return input.new_empty((M, N), dtype=output_dtype)
+
+
+def fp8_swap_ab_gen_tuning_buckets(x: int):
+    buckets = tuple(range(8, 128, 8))
+    if x >= 128:
+        buckets += tuple(range(128, x, 128))
+    return buckets
+
+
+class fp8SwapABGemmRunner(TunableRunner):
+    tuning_config = TuningConfig(
+        dynamic_tensor_specs=(DynamicTensorSpec(
+            0, 0, fp8_swap_ab_gen_tuning_buckets), ),
+        tune_max_num_tokens=4096,
+    )
+
+    def __init__(self, output_dtype: torch.dtype, disable_ue8m0_cast: bool):
+        self.output_dtype = output_dtype
+        self.disable_ue8m0_cast = disable_ue8m0_cast
+
+    def get_valid_tactics(
+        self,
+        inputs: List[torch.Tensor],
+        profile: OptimizationProfile,
+    ) -> List[int]:
+        # Encode swap_ab as False (0) and True (1). Currently only add one tactic here.
+        return [0]
+
+    def forward(
+        self,
+        inputs: List[torch.Tensor],
+        tactic: int = -1,
+    ) -> torch.Tensor:
+        input, weight, weight_scale = inputs
+        a, a_sf = fp8_utils.per_token_quant_and_transform(input)
+        output = torch.empty(
+            (input.size(0), weight.size(0)),
+            device=input.device,
+            dtype=self.output_dtype,
+        )
+        # TODO: add swap_ab=tactic == 0 to detemrmine the swap_ab value
+        # Treat the default tactic=-1 as swap_ab=False
+        deep_gemm.fp8_gemm_nt(
+            (a, a_sf),
+            (weight, weight_scale),
+            output,
+            disable_ue8m0_cast=self.disable_ue8m0_cast,
+        )
+        return output
+
+
+@torch.library.custom_op("trtllm::fp8_swap_ab_gemm", mutates_args=())
+def fp8_swap_ab_gemm(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    output_dtype: torch.dtype = torch.bfloat16,
+    disable_ue8m0_cast: bool = False,
+    tune_max_num_tokens: int = 4096,
+) -> torch.Tensor:
+    tuner = AutoTuner.get()
+    fp8_swap_ab_gemm_runner = fp8SwapABGemmRunner(
+        output_dtype,
+        disable_ue8m0_cast,
+    )
+    fp8SwapABGemmRunner.tuning_config.tune_max_num_tokens = tune_max_num_tokens
+    _, best_tactic = tuner.choose_one(
+        "trtllm::fp8_swap_ab_gemm",
+        [fp8_swap_ab_gemm_runner],
+        fp8SwapABGemmRunner.tuning_config,
+        [input, weight, weight_scale],
+    )
+    return fp8_swap_ab_gemm_runner(
+        inputs=[input, weight, weight_scale],
+        tactic=best_tactic,
+    )
+
+
+@fp8_swap_ab_gemm.register_fake
+def _(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    output_dtype: torch.dtype = torch.bfloat16,
+    disable_ue8m0_cast: bool = False,
+    tune_max_num_tokens: int = 4096,
+) -> torch.Tensor:
+    return input.new_empty((input.size(0), weight.size(0)), dtype=output_dtype)
 
 
 def get_event(event_idx: int):


### PR DESCRIPTION
Because deep_gemm.gp8_gemm_nt will trigger many JIT processes during the inference phase, we need to sweep these shapes ahead of time. Apply the AutoTuner framework to achieve this and retain the potential capability to tune the swap_ab flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a fused FP8 GEMM operation exposed as a Torch custom op with autotuning, dynamic-shape support, and configurable casting; returns outputs in the requested dtype.

- Performance
  - Streamlines FP8 linear execution by removing intermediate buffers and fusing quantization + GEMM, reducing memory and improving efficiency.

- Refactor
  - Replaced multi-step FP8 path in linear layers with the new fused operation.

- Tests
  - Updated unit tests to validate the fused FP8 path under autotune.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->