### PR TITLE
[None][perf] Accelerate global scale calculations for deepEP fp4 combine

### DIFF
--- a/cpp/tensorrt_llm/kernels/quantization.h
+++ b/cpp/tensorrt_llm/kernels/quantization.h
@@ -88,5 +88,9 @@ void invokeBlockScaleInterleave(int b, int m, int m_padded, int n, int n_padded,
 void invokeBlockScaleInterleaveReverse(
     int b, int m, int n, uint8_t const* SFIn, uint8_t* SFOutput, int multiProcessorCount, cudaStream_t stream = 0);
 
+template <typename T>
+void computePerTokenGlobalScaleForFP4Quantization(int b, int m, int n, T const* input, int const* tokensPerBatch,
+    float* globalScale, int multiProcessorCount, cudaStream_t stream = 0);
+
 } // namespace kernels
 } // namespace tensorrt_llm

--- a/cpp/tensorrt_llm/thop/fp4Quantize.h
+++ b/cpp/tensorrt_llm/thop/fp4Quantize.h
@@ -26,4 +26,6 @@ namespace torch_ext
 {
 std::tuple<at::Tensor, at::Tensor> fp4_quantize(at::Tensor const& self, std::optional<at::Tensor> const& globalScale,
     int64_t sfVecSize, bool sfUseUE8M0, bool isSfSwizzledLayout);
-}
+
+at::Tensor calculate_nvfp4_global_scale(at::Tensor const& input, std::optional<at::Tensor> const& tokensPerBatch);
+} // namespace torch_ext

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -179,6 +179,10 @@ def _register_fake():
         return (input.new_empty(output_shape, dtype=torch.uint8),
                 global_scale.new_empty(scale_shape, dtype=torch.uint8))
 
+    @torch.library.register_fake("trtllm::calculate_nvfp4_global_scale")
+    def _(input: torch.Tensor, tokens_per_batch: Optional[torch.Tensor]):
+        return input.new_empty((input.shape[:-1], 1), dtype=torch.float32)
+
     @torch.library.register_fake("trtllm::moe_comm")
     def _(
         inputs: List[torch.Tensor],

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_wide_ep.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_wide_ep.py
@@ -691,8 +691,8 @@ class WideEPMoE(MoE):
                     self.expert_size_per_partition,
                     num_tokens_per_expert_for_fused_moe, self.hidden_size)
                 if self.use_low_precision_combine:
-                    global_scales = (448 * 6) / final_hidden_states.abs().max(
-                        dim=-1, keepdim=True).values.to(torch.float32)
+                    global_scales = torch.ops.trtllm.calculate_nvfp4_global_scale(
+                        final_hidden_states, recv_expert_count)
                     final_hidden_states = self.deep_ep_buffer.low_latency_combine_fp4(
                         final_hidden_states, global_scales, deep_ep_topk_idx,
                         deep_ep_topk_weights, deep_ep_handle)

--- a/tests/unittest/_torch/thop/test_fp4_calculate_global_scale.py
+++ b/tests/unittest/_torch/thop/test_fp4_calculate_global_scale.py
@@ -1,0 +1,223 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import torch
+from parameterized import parameterized
+from utils.util import skip_pre_blackwell_unittest, unittest_name_func
+
+import tensorrt_llm
+
+
+def reference_calculate_global_scale(input_tensor):
+    max_abs_values = input_tensor.abs().max(dim=-1, keepdim=True).values.to(
+        torch.float32)
+    global_scales = (448 * 6) / max_abs_values
+    return global_scales
+
+
+class TestFP4CalculateGlobalScale(unittest.TestCase):
+
+    def setUp(self):
+        tensorrt_llm.logger.set_level("warning")
+        torch.manual_seed(42)
+        torch.cuda.manual_seed(42)
+
+    @parameterized.expand([
+        [1, 64, 7168, torch.bfloat16, False],
+        [1, 64, 7168, torch.float16, False],
+        [1, 64, 7168, torch.bfloat16, True],
+        [1, 64, 4096, torch.bfloat16, True],
+        [8, 8 * 64, 7168, torch.bfloat16, False],
+        [8, 8 * 64, 7168, torch.bfloat16, True],
+        [16, 16 * 64, 7168, torch.bfloat16, True],
+        [32, 32 * 64, 7168, torch.bfloat16, True],
+    ],
+                          name_func=unittest_name_func)
+    @skip_pre_blackwell_unittest
+    def test_calculate_nvfp4_global_scale_accuracy(self, batch_size,
+                                                   max_token_num, hidden_size,
+                                                   dtype, use_tokens_per_batch):
+        if batch_size == 1:
+            input_shape = (max_token_num, hidden_size)
+        else:
+            input_shape = (batch_size, max_token_num, hidden_size)
+        input_tensor = torch.randn(input_shape, dtype=dtype, device='cuda')
+
+        assert hidden_size % 16 == 0, f"Hidden size {hidden_size} must be divisible by 16"
+
+        tokens_per_batch = None
+        if use_tokens_per_batch:
+            # Create tokensPerBatch tensor with shape (batch_size)
+            # Each value represents the actual number of meaningful tokens in that batch
+            tokens_per_batch = torch.randint(0,
+                                             max_token_num + 1, (batch_size, ),
+                                             device='cuda',
+                                             dtype=torch.int32)
+
+        reference_result = reference_calculate_global_scale(input_tensor)
+        custom_result = torch.ops.trtllm.calculate_nvfp4_global_scale(
+            input_tensor, tokens_per_batch)
+        torch.cuda.synchronize()
+
+        self.assertEqual(custom_result.shape, reference_result.shape)
+
+        if use_tokens_per_batch:
+            # Create mask for meaningful tokens based on tokens_per_batch
+            # Only compare results for tokens that are within the meaningful range
+            meaningful_mask = torch.zeros(custom_result.shape,
+                                          dtype=torch.bool,
+                                          device='cuda')
+            if batch_size == 1:
+                meaningful_mask[:tokens_per_batch[0]] = True
+            else:
+                for i in range(batch_size):
+                    meaningful_mask[i, :tokens_per_batch[i]] = True
+
+            custom_result = custom_result * meaningful_mask
+            reference_result = reference_result * meaningful_mask
+
+        torch.testing.assert_close(
+            custom_result,
+            reference_result,
+            atol=1e-3,
+            rtol=1e-3,
+            msg=
+            f"Shape: {input_shape}, dtype: {dtype}, custom_result: {custom_result}, reference_result: {reference_result}"
+        )
+
+    @parameterized.expand(
+        [
+            # [local_experts_num, ranks_num * max_token_num_per_rank, max_token_num_per_rank, hidden_size]
+            [32, 8 * 64, 64, 7168, torch.bfloat16, False],
+            [32, 8 * 64, 64, 7168, torch.bfloat16, True],
+            [16, 16 * 64, 64, 7168, torch.bfloat16, False],
+            [16, 16 * 64, 64, 7168, torch.bfloat16, True],
+            [8, 32 * 64, 64, 7168, torch.bfloat16, False],
+            [8, 32 * 64, 64, 7168, torch.bfloat16, True],
+        ],
+        name_func=unittest_name_func)
+    @skip_pre_blackwell_unittest
+    def test_calculate_nvfp4_global_scale_performance(self, batch_size,
+                                                      max_token_num,
+                                                      real_token_num,
+                                                      hidden_size, dtype,
+                                                      use_tokens_per_batch):
+        if batch_size == 1:
+            input_shape = (max_token_num, hidden_size)
+        else:
+            input_shape = (batch_size, max_token_num, hidden_size)
+        input_tensor = torch.randn(input_shape, dtype=dtype, device='cuda')
+
+        tokens_per_batch = None
+        if use_tokens_per_batch:
+            tokens_per_batch = torch.zeros((batch_size, ),
+                                           device='cuda',
+                                           dtype=torch.int32)
+            tokens_per_batch[:] = real_token_num
+
+        for _ in range(10):
+            _ = torch.ops.trtllm.calculate_nvfp4_global_scale(
+                input_tensor, tokens_per_batch)
+            _ = reference_calculate_global_scale(input_tensor)
+
+        torch.cuda.synchronize()
+
+        num_iterations = 100
+
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+
+        start_event.record()
+        for _ in range(num_iterations):
+            _ = torch.ops.trtllm.calculate_nvfp4_global_scale(
+                input_tensor, tokens_per_batch)
+        end_event.record()
+        torch.cuda.synchronize()
+        custom_time = start_event.elapsed_time(end_event)
+
+        start_event.record()
+        for _ in range(num_iterations):
+            _ = reference_calculate_global_scale(input_tensor)
+        end_event.record()
+        torch.cuda.synchronize()
+        reference_time = start_event.elapsed_time(end_event)
+
+        custom_avg_time = custom_time / num_iterations
+        reference_avg_time = reference_time / num_iterations
+        speedup = reference_avg_time / custom_avg_time
+
+        tokens_info = "with tokensPerBatch" if use_tokens_per_batch else "without tokensPerBatch"
+        print(
+            f"\nPerformance Test Results for {input_shape}, {real_token_num}, {dtype}, {tokens_info}:"
+        )
+        print(f"Custom op average time: {custom_avg_time*1000:.3f} us")
+        print(f"Reference average time: {reference_avg_time*1000:.3f} us")
+        print(f"Speedup: {speedup:.2f}x")
+
+    @skip_pre_blackwell_unittest
+    def test_calculate_nvfp4_global_scale_invalid_inputs(self):
+        # Test with 1D tensor (should fail)
+        input_tensor = torch.randn(4096, dtype=torch.float16, device='cuda')
+        with self.assertRaises(Exception):
+            torch.ops.trtllm.calculate_nvfp4_global_scale(input_tensor)
+
+        # Test with hidden_size not divisible by 16 (should fail)
+        input_tensor = torch.randn((4, 32, 4095),
+                                   dtype=torch.float16,
+                                   device='cuda')
+        with self.assertRaises(Exception):
+            torch.ops.trtllm.calculate_nvfp4_global_scale(input_tensor)
+
+        # Test with mismatched tokensPerBatch shape (wrong batch size)
+        input_tensor = torch.randn((4, 32, 4096),
+                                   dtype=torch.float16,
+                                   device='cuda')
+        tokens_per_batch = torch.randint(1,
+                                         33, (5, ),
+                                         device='cuda',
+                                         dtype=torch.int32)  # Wrong batch size
+        with self.assertRaises(Exception):
+            torch.ops.trtllm.calculate_nvfp4_global_scale(
+                input_tensor, tokens_per_batch)
+
+        # Test with tokensPerBatch having wrong number of dimensions (should be 1D)
+        input_tensor = torch.randn((4, 32, 4096),
+                                   dtype=torch.float16,
+                                   device='cuda')
+        tokens_per_batch = torch.randint(1,
+                                         33, (4, 32),
+                                         device='cuda',
+                                         dtype=torch.int32)  # 2D instead of 1D
+        with self.assertRaises(Exception):
+            torch.ops.trtllm.calculate_nvfp4_global_scale(
+                input_tensor, tokens_per_batch)
+
+        # Test with tokensPerBatch having wrong first dimension size
+        input_tensor = torch.randn((4, 32, 4096),
+                                   dtype=torch.float16,
+                                   device='cuda')
+        tokens_per_batch = torch.randint(1,
+                                         33, (3, ),
+                                         device='cuda',
+                                         dtype=torch.int32)  # Wrong batch size
+        with self.assertRaises(Exception):
+            torch.ops.trtllm.calculate_nvfp4_global_scale(
+                input_tensor, tokens_per_batch)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - GPU-accelerated per-token FP4 global-scale calculation added; supports FP16 and BF16 inputs, optional tokens-per-batch masking, and a PyTorch operator used in low-precision MoE combine flow.
- **Performance**
  - Native operator replaces Python-side reduction, improving throughput for FP4 quantization and enabling vectorized reductions for larger hidden sizes.
- **Tests**
  - New unit tests for correctness across shapes/dtypes, masked tokens, performance timing, and input validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
