### PR TITLE
[TRTLLM-6741] [feat] enable LM tp for MTP, under attention dp case

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -352,7 +352,7 @@ class DecoderModelForCausalLM(nn.Module,
         self.pp_size = config.mapping.pp_size
         self.has_custom_lm_head = False
 
-        if config.mapping.enable_attention_dp:
+        if config.mapping.enable_attention_dp and not getattr(config.mapping, 'enable_lm_tp_in_adp', False):
             self.lm_head = LMHead(
                 vocab_size,
                 hidden_size,

--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -18,6 +18,8 @@ from .interface import SpecMetadata
 if TYPE_CHECKING:
     from tensorrt_llm.llmapi.llm_args import MTPDecodingConfig
 
+import os
+from tensorrt_llm.mapping import Mapping
 
 @dataclass(kw_only=True)
 class SampleStateTensorsMTP(SampleStateTensors):
@@ -1118,8 +1120,6 @@ class MTPWorker(nn.Module):
                       self.model_config.mapping, 'enable_lm_tp_in_adp', False)):
             # For ADP + LM TP mode, we need to find the global argmax across all TP ranks
             # First, get local argmax and max values
-            import os
-            from tensorrt_llm.mapping import Mapping
             lm_tp_size = int(os.getenv('LM_TP_SIZE', 2))
             assert self.model_config.mapping.tp_size % lm_tp_size == 0
             lm_pp_size = self.model_config.mapping.pp_size * self.model_config.mapping.tp_size // lm_tp_size

--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, Optional
 
 import torch
+import torch.nn.functional as F
 from torch import nn
 
 from ..attention_backend import AttentionMetadata
@@ -473,9 +474,23 @@ class MTPWorker(nn.Module):
         for _, mtp_layer in enumerate(draft_model.mtp_layers):
             hidden_states = mtp_layer(embed_tokens=draft_model.embed_tokens,
                                       **draft_inputs)
-            logits = mtp_layer.shared_head(hidden_states, draft_model.lm_head,
+            token_count = hidden_states.view(-1,
+                                             hidden_states.shape[-1]).shape[0]
+            all_rank_max_num_tokens = attn_metadata.all_rank_max_num_tokens
+            pad_len = all_rank_max_num_tokens - token_count
+            if pad_len > 0:
+                padded_hidden_states = F.pad(hidden_states.view(
+                    -1, hidden_states.shape[-1]), (0, 0, 0, pad_len),
+                                             mode="constant",
+                                             value=0)
+            else:
+                padded_hidden_states = hidden_states.view(
+                    -1, hidden_states.shape[-1])
+            logits = mtp_layer.shared_head(padded_hidden_states,
+                                           draft_model.lm_head,
                                            attn_metadata).float()
             new_draft_token = self.draft_sampler(logits)
+            new_draft_token = new_draft_token[:token_count]
             next_draft_tokens.append(new_draft_token)
             # shift input_ids and hidden_states
             input_ids = draft_inputs["input_ids"]
@@ -1041,12 +1056,13 @@ class MTPWorker(nn.Module):
         }
 
     @torch.compile(options={"max-autotune": True})
-    def get_local_max_and_combined(self, logits):
+    def get_local_max_and_combined(self, logits, mapping_lm_tp=None):
         local_max_values, local_argmax = torch.max(logits, dim=-1, keepdim=True)
         # Adjust indices based on TP rank and size
         vocab_per_rank = logits.shape[-1]
+        mapping_lm_tp = mapping_lm_tp if mapping_lm_tp is not None else self.model_config.mapping
         max_index_per_rank = local_argmax.type(
-            torch.int32) + (self.model_config.mapping.tp_rank * vocab_per_rank)
+            torch.int32) + (mapping_lm_tp.tp_rank * vocab_per_rank)
         # Use torch.stack and flatten instead of view+cat to avoid torch.compile issues
         # Convert both to float32 to ensure consistent dtype
         max_index_per_rank_float = max_index_per_rank.float()
@@ -1095,6 +1111,34 @@ class MTPWorker(nn.Module):
             combined = self.get_local_max_and_combined(logits)
             gathered = allgather(combined, self.model_config.mapping, dim=-1)
             draft_tokens = self.get_draft_tokens_from_gathered(gathered)
+        elif (self.model_config is not None
+              and hasattr(self.model_config, 'mapping')
+              and self.model_config.mapping.tp_size > 1) and (
+                  self.model_config.mapping.enable_attention_dp and getattr(
+                      self.model_config.mapping, 'enable_lm_tp_in_adp', False)):
+            # For ADP + LM TP mode, we need to find the global argmax across all TP ranks
+            # First, get local argmax and max values
+            import os
+            from tensorrt_llm.mapping import Mapping
+            lm_tp_size = int(os.getenv('LM_TP_SIZE', 2))
+            assert self.model_config.mapping.tp_size % lm_tp_size == 0
+            lm_pp_size = self.model_config.mapping.pp_size * self.model_config.mapping.tp_size // lm_tp_size
+            mapping_lm_tp = Mapping(
+                world_size=lm_tp_size * lm_pp_size,
+                rank=self.model_config.mapping.rank,
+                gpus_per_node=self.model_config.mapping.gpus_per_node,
+                tp_size=lm_tp_size,
+                pp_size=lm_pp_size,
+                enable_attention_dp=self.model_config.mapping.enable_attention_dp,
+                enable_lm_tp_in_adp=self.model_config.mapping.enable_lm_tp_in_adp,
+            )
+            combined = self.get_local_max_and_combined(logits, mapping_lm_tp)
+            gathered = allgather(combined, mapping_lm_tp, dim=-1)
+            batch_size = logits.shape[0]
+            local_batch_size = batch_size // mapping_lm_tp.tp_size
+            gathered = gathered.view(mapping_lm_tp.tp_size, local_batch_size, -1)
+            sliced_gathered = gathered[mapping_lm_tp.tp_rank]
+            draft_tokens = self.get_draft_tokens_from_gathered(sliced_gathered)
         else:
             # Simple argmax if no TP or no model config
             draft_tokens = torch.argmax(logits, dim=-1).type(torch.int32)
@@ -1194,10 +1238,26 @@ class MTPEagleWorker(MTPWorker):
                     **inputs)
                 # All of the seq_len are 1, use batch_indices_cuda as gather_ids
                 gather_ids = spec_metadata.batch_indices_cuda[:batch_size]
+            hidden_states_gathered = hidden_states[gather_ids]
+            token_count = hidden_states_gathered.view(-1,
+                                             hidden_states_gathered.shape[-1]).shape[0]
+            max_num_requests = spec_metadata.max_num_requests
+            pad_len = max_num_requests - token_count
+            if pad_len > 0:
+                padded_hidden_states = F.pad(hidden_states_gathered.view(
+                    -1, hidden_states_gathered.shape[-1]), (0, 0, 0, pad_len),
+                                             mode="constant",
+                                             value=0)
+            elif pad_len == 0:
+                padded_hidden_states = hidden_states_gathered.view(
+                    -1, hidden_states_gathered.shape[-1])
+            else:
+                raise ValueError(f"In MTPEagleWorker.forward(), token_count < max_num_requests, which is not supported")
             logits = draft_model.mtp_layers[0].shared_head(
-                hidden_states[gather_ids], draft_model.lm_head, attn_metadata,
+                padded_hidden_states, draft_model.lm_head, attn_metadata,
                 True)
             new_draft_token = self.draft_sampler(logits)
+            new_draft_token = new_draft_token[:token_count]
 
             hidden_states, position_ids = self.update_draft_tokens(
                 next_draft_tokens, new_draft_token, hidden_states, gather_ids,

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -225,6 +225,7 @@ class _ParallelConfig:
     moe_ep_size: int = 1
     cp_config: dict = field(default_factory=dict)
     enable_attention_dp: bool = False
+    enable_lm_tp_in_adp: bool = False
     auto_parallel: bool = False
 
     _world_size: int = field(default=1, init=False)
@@ -288,6 +289,7 @@ class _ParallelConfig:
                        cp_size=self.cp_size,
                        cp_config=self.cp_config,
                        enable_attention_dp=self.enable_attention_dp,
+                       enable_lm_tp_in_adp=self.enable_lm_tp_in_adp,
                        moe_cluster_size=self.moe_cluster_size,
                        moe_tp_size=self.moe_tp_size,
                        moe_ep_size=self.moe_ep_size,
@@ -1261,6 +1263,11 @@ class BaseLlmArgs(StrictBaseModel):
         description="Enable attention data parallel.",
         status="beta")
 
+    enable_lm_tp_in_adp: bool = Field(
+        default=False,
+        description="Enable lm tp in attention dp.",
+        status="beta")
+
     cp_config: Optional[dict] = Field(default_factory=dict,
                                       description="Context parallel config.",
                                       status="prototype")
@@ -1508,6 +1515,7 @@ class BaseLlmArgs(StrictBaseModel):
             moe_tp_size=self.moe_tensor_parallel_size,
             moe_ep_size=self.moe_expert_parallel_size,
             enable_attention_dp=self.enable_attention_dp,
+            enable_lm_tp_in_adp=self.enable_lm_tp_in_adp,
             cp_config=self.cp_config)
         return self
 

--- a/tensorrt_llm/mapping.py
+++ b/tensorrt_llm/mapping.py
@@ -141,7 +141,8 @@ class Mapping(object):
             attn_tp_size=-1,
             attn_cp_size=-1,
             auto_parallel=False,
-            enable_attention_dp=False):
+            enable_attention_dp=False,
+            enable_lm_tp_in_adp=False):
         # set default values for non-moe cases
         # or where only one MOE parallelism size is specified
         if moe_cluster_size == -1:
@@ -224,6 +225,7 @@ class Mapping(object):
         self.auto_parallel = auto_parallel
         self.world_size = world_size
         self.enable_attention_dp = enable_attention_dp
+        self.enable_lm_tp_in_adp = enable_lm_tp_in_adp
         self.rank = rank
         self.gpus_per_node = gpus_per_node
         self.pp_groups = []
@@ -510,4 +512,6 @@ class Mapping(object):
             'attn_cp_size': self.attn_cp_size,
             'cp_config': self.cp_config,
             'auto_parallel': self.auto_parallel,
+            'enable_attention_dp': self.enable_attention_dp,
+            'enable_lm_tp_in_adp': self.enable_lm_tp_in_adp,
         }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional beta setting to enable LM tensor parallelism when using Attention Data Parallelism. Configurable via args/CLI and off by default.
* **Performance**
  * Improved throughput and scalability for ADP + TP setups, including optimized cross-rank sampling in speculative decoding (MTP/Eagle).
* **Stability**
  * More robust speculative decoding via automatic padding/cropping of variable-length batches to prevent shape mismatches.
* **Compatibility**
  * No breaking changes; existing behaviors remain unchanged unless the new option is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
