### PR TITLE
[TRTLLM-6876][feat] Add low precision all2all for mnnvl

### DIFF
--- a/cpp/tensorrt_llm/kernels/fusedMoeCommKernels.cu
+++ b/cpp/tensorrt_llm/kernels/fusedMoeCommKernels.cu
@@ -332,13 +332,6 @@ __device__ __forceinline__ void dequantize_nvfp4_sharedmem(uint8_t* compact_ptr,
                 v2.x = tensorrt_llm::common::cuda_cast<DType>(tmp[t].x * dequantScale);
                 v2.y = tensorrt_llm::common::cuda_cast<DType>(tmp[t].y * dequantScale);
                 reinterpret_cast<DType2*>(out + idx0)[0] = v2;
-
-                // This is a workaround to avoid the issue of nan or inf.
-                // TODO: remove this after the issue is fixed.
-                // if (dequantScale > 1e10)
-                // {
-                //     printf("This is a workaround to avoid the issue of nan or inf. \n");
-                // }
             }
         }
         __syncwarp();

--- a/cpp/tests/unit_tests/kernels/fusedMoeCommKernelTest.cpp
+++ b/cpp/tests/unit_tests/kernels/fusedMoeCommKernelTest.cpp
@@ -65,6 +65,19 @@ protected:
         }
     }
 
+    cudaDataType_t getCudaDataType(int elementSize)
+    {
+        switch (elementSize)
+        {
+        case 1: return CUDA_R_8U;
+        case 2: return CUDA_R_16F;
+        case 4: return CUDA_R_32F;
+        case 8: return CUDA_R_64F;
+        case 16: return CUDA_C_64F;
+        default: TLLM_THROW("Unsupported element size: %d", elementSize);
+        };
+    }
+
     bool skipped = false;
     cudaStream_t stream = nullptr;
 
@@ -238,7 +251,8 @@ protected:
             deviceFieldPtrs[i] = deviceField;
 
             // Use the new fillFieldInfo helper function
-            sendFieldInfo.fieldsInfo[i].fillFieldInfo(deviceField, elementSize, vectorSize, vectorSize);
+            sendFieldInfo.fieldsInfo[i].fillFieldInfo(
+                deviceField, elementSize, vectorSize, vectorSize, getCudaDataType(elementSize));
         }
 
         // Fill field placement info
@@ -385,7 +399,8 @@ protected:
             deviceFieldPtrs[i] = deviceField;
 
             // Use the new fillFieldInfo helper function
-            recvFieldInfo.fieldsInfo[i].fillFieldInfo(deviceField, elementSize, vectorSize, vectorSize);
+            recvFieldInfo.fieldsInfo[i].fillFieldInfo(
+                deviceField, elementSize, vectorSize, vectorSize, getCudaDataType(elementSize));
         }
 
         // Fill field placement info
@@ -612,8 +627,10 @@ protected:
             deviceRecvFieldPtrs[i] = deviceRecvField;
 
             // Fill field info for both send and recv
-            sendFieldInfo.fieldsInfo[i].fillFieldInfo(deviceSendField, elementSize, vectorSize, vectorSize);
-            recvFieldInfo.fieldsInfo[i].fillFieldInfo(deviceRecvField, elementSize, vectorSize, vectorSize);
+            sendFieldInfo.fieldsInfo[i].fillFieldInfo(
+                deviceSendField, elementSize, vectorSize, vectorSize, getCudaDataType(elementSize));
+            recvFieldInfo.fieldsInfo[i].fillFieldInfo(
+                deviceRecvField, elementSize, vectorSize, vectorSize, getCudaDataType(elementSize));
         }
 
         // Fill field placement info
@@ -1067,8 +1084,10 @@ protected:
             deviceRecvFieldPtrs[i] = deviceRecvField;
 
             // Fill field info
-            sendFieldInfo.fieldsInfo[i].fillFieldInfo(deviceSendField, elementSize, vectorSize, vectorSize);
-            recvFieldInfo.fieldsInfo[i].fillFieldInfo(deviceRecvField, elementSize, vectorSize, vectorSize);
+            sendFieldInfo.fieldsInfo[i].fillFieldInfo(
+                deviceSendField, elementSize, vectorSize, vectorSize, getCudaDataType(elementSize));
+            recvFieldInfo.fieldsInfo[i].fillFieldInfo(
+                deviceRecvField, elementSize, vectorSize, vectorSize, getCudaDataType(elementSize));
         }
 
         // Fill field placement info

--- a/tensorrt_llm/_mnnvl_utils.py
+++ b/tensorrt_llm/_mnnvl_utils.py
@@ -598,6 +598,7 @@ class MnnvlMoe:
         ep_size: int,
         top_k: int,
         token_count: int,
+        use_low_precision_combine: bool = False,
     ):
         assert x.dim() == 2, "2D tensor supported, please reshape."
         output_tensors = torch.ops.trtllm.moe_comm(
@@ -611,6 +612,7 @@ class MnnvlMoe:
             ep_rank,
             ep_size,
             [True],
+            use_low_precision_combine,
         )
         output_tensor = output_tensors[0]
         return torch.sum(

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_wide_ep.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_wide_ep.py
@@ -905,7 +905,8 @@ class WideEPMoE(MoE):
             ep_rank=self.ep_rank,
             ep_size=self.ep_size,
             top_k=top_k,
-            token_count=token_count)
+            token_count=token_count,
+            use_low_precision_combine=self.use_low_precision_combine)
 
         return final_hidden_states
 

--- a/tests/unittest/_torch/thop/test_moe_alltoall.py
+++ b/tests/unittest/_torch/thop/test_moe_alltoall.py
@@ -164,6 +164,9 @@ class TestMoeAlltoAllSingleGPU(unittest.TestCase):
                 128,
             ], torch.float16, True
         ),  # large input count with small vector dim that requires more indices per fifo
+        (8, 256, [
+            7168,
+        ], torch.bfloat16, True),
     ])
     def test_moe_alltoall_multi_rank_single_gpu(self,
                                                 world_size,

--- a/tests/unittest/_torch/thop/test_moe_alltoall.py
+++ b/tests/unittest/_torch/thop/test_moe_alltoall.py
@@ -17,6 +17,7 @@ import unittest
 import pytest
 import torch
 from parameterized import parameterized
+from utils.util import getSMVersion
 
 import tensorrt_llm as tllm
 
@@ -174,6 +175,10 @@ class TestMoeAlltoAllSingleGPU(unittest.TestCase):
                                                 vector_dims,
                                                 dtype,
                                                 use_low_precision=False):
+
+        if use_low_precision and getSMVersion() < 100:
+            pytest.skip("low precision is not supported on pre-blackwell")
+
         torch.cuda.set_device(0)
         max_world_size = 8
         assert world_size <= max_world_size, f"should run with world_size at most {max_world_size}"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Optional opt-in low-precision MoE all-to-all path (per-16-element NVFP4/FP8 quantization with 128B-aligned blocks) exposed via runtime and Python/Torch flag.
  - Exposed workspace helpers and a runtime control to tune usable GPU SMs for performance.

- **Bug Fixes**
  - Added CUDA synchronization after workspace initialization to improve stability.

- **Tests**
  - Tests extended to cover low-precision flows and relax tolerances where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
