### PR TITLE
[https://nvbugs/5455140][chore] Add some CUDA graph memory logs to help locate an occasional OOM issue.

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
+++ b/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
@@ -3,6 +3,9 @@ from typing import Any, Callable, Dict, Optional, Tuple
 
 import torch
 
+from tensorrt_llm.logger import logger
+from tensorrt_llm.profiler import device_memory_info
+
 from ..attention_backend.interface import AttentionMetadata
 from ..speculative.interface import SpecMetadata
 from ..utils import make_weak_ref, set_piecewise_cuda_graph_flag
@@ -80,6 +83,31 @@ class DecodingCUDAGraphRunner:
         forward_fn: Callable[[Dict[str, Any]], torch.Tensor],
         pool: Optional[Tuple[int, int]] = None,
     ) -> Tuple[int, int]:
+        # Memory statistics at capture start
+        mem_used_start, mem_free_start, mem_total = device_memory_info()
+        mem_used_inside_torch_start = torch.cuda.memory_stats(
+        )["allocated_bytes.all.current"]
+
+        # Method 1: device_memory_info
+        mem_used_outside_torch_method1_start = (
+            mem_used_start - mem_used_inside_torch_start
+        ) if mem_used_start > mem_used_inside_torch_start else 0
+
+        # Method 2: torch.cuda.mem_get_info
+        mem_free_cuda_start, total_gpu_memory_start = torch.cuda.mem_get_info()
+        total_used_bytes_start = total_gpu_memory_start - mem_free_cuda_start
+        mem_used_outside_torch_method2_start = (
+            total_used_bytes_start - mem_used_inside_torch_start
+        ) if total_used_bytes_start > mem_used_inside_torch_start else 0
+
+        logger.info(
+            f"CUDA graph capture START (batch_size={self.batch_size}): "
+            f"inside torch: {mem_used_inside_torch_start / 1024**3:.2f} GB, "
+            f"outside torch (method1): {mem_used_outside_torch_method1_start / 1024**3:.2f} GB, "
+            f"outside torch (method2): {mem_used_outside_torch_method2_start / 1024**3:.2f} GB, "
+            f"total: {mem_used_start / 1024**3:.2f} GB, free: {mem_free_start / 1024**3:.2f} GB"
+        )
+
         self._graph = torch.cuda.CUDAGraph()
         inputs = {
             "attn_metadata": self.attn_metadata,
@@ -90,6 +118,11 @@ class DecodingCUDAGraphRunner:
             "mrope_position_deltas": self.mrope_position_deltas,
         }
 
+        # Memory statistics before warmup
+        mem_used_before_warmup, _, _ = device_memory_info()
+        mem_used_inside_torch_before_warmup = torch.cuda.memory_stats(
+        )["allocated_bytes.all.current"]
+
         # We have to do warm up runs to initialize PyTorch's
         # internal states according to the docs:
         # https://pytorch.org/docs/stable/notes/cuda.html#cuda-graph-semantics
@@ -98,12 +131,114 @@ class DecodingCUDAGraphRunner:
         set_piecewise_cuda_graph_flag(False)
         for _ in range(2):
             forward_fn(inputs)
+
+        # Memory statistics after warmup
+        mem_used_after_warmup, mem_free_after_warmup, _ = device_memory_info()
+        mem_used_inside_torch_after_warmup = torch.cuda.memory_stats(
+        )["allocated_bytes.all.current"]
+
+        # Method 1: device_memory_info
+        mem_used_outside_torch_method1_after_warmup = (
+            mem_used_after_warmup - mem_used_inside_torch_after_warmup
+        ) if mem_used_after_warmup > mem_used_inside_torch_after_warmup else 0
+
+        # Method 2: torch.cuda.mem_get_info
+        mem_free_cuda_after_warmup, total_gpu_memory_after_warmup = torch.cuda.mem_get_info(
+        )
+        total_used_bytes_after_warmup = total_gpu_memory_after_warmup - mem_free_cuda_after_warmup
+        mem_used_outside_torch_method2_after_warmup = (
+            total_used_bytes_after_warmup - mem_used_inside_torch_after_warmup
+        ) if total_used_bytes_after_warmup > mem_used_inside_torch_after_warmup else 0
+
+        warmup_mem_change = mem_used_after_warmup - mem_used_before_warmup
+        warmup_inside_torch_change = mem_used_inside_torch_after_warmup - mem_used_inside_torch_before_warmup
+
+        logger.info(
+            f"CUDA graph warmup completed: "
+            f"CURRENT - inside torch: {mem_used_inside_torch_after_warmup / 1024**3:.2f} GB, "
+            f"outside torch (method1): {mem_used_outside_torch_method1_after_warmup / 1024**3:.2f} GB, "
+            f"outside torch (method2): {mem_used_outside_torch_method2_after_warmup / 1024**3:.2f} GB, "
+            f"total: {mem_used_after_warmup / 1024**3:.2f} GB, free: {mem_free_after_warmup / 1024**3:.2f} GB | "
+            f"CHANGES - total: {warmup_mem_change / 1024**3:.2f} GB, "
+            f"inside torch: {warmup_inside_torch_change / 1024**3:.2f} GB")
+
+        # Memory statistics before graph capture
+        mem_used_before_capture, _, _ = device_memory_info()
+        mem_used_inside_torch_before_capture = torch.cuda.memory_stats(
+        )["allocated_bytes.all.current"]
+
         with torch.cuda.graph(self._graph, pool=pool):
             output = forward_fn(inputs)
+
+        # Memory statistics after graph capture
+        mem_used_after_capture, mem_free_after_capture, _ = device_memory_info()
+        mem_used_inside_torch_after_capture = torch.cuda.memory_stats(
+        )["allocated_bytes.all.current"]
+
+        # Method 1: device_memory_info
+        mem_used_outside_torch_method1_after_capture = (
+            mem_used_after_capture - mem_used_inside_torch_after_capture
+        ) if mem_used_after_capture > mem_used_inside_torch_after_capture else 0
+
+        # Method 2: torch.cuda.mem_get_info
+        mem_free_cuda_after_capture, total_gpu_memory_after_capture = torch.cuda.mem_get_info(
+        )
+        total_used_bytes_after_capture = total_gpu_memory_after_capture - mem_free_cuda_after_capture
+        mem_used_outside_torch_method2_after_capture = (
+            total_used_bytes_after_capture - mem_used_inside_torch_after_capture
+        ) if total_used_bytes_after_capture > mem_used_inside_torch_after_capture else 0
+
+        capture_mem_change = mem_used_after_capture - mem_used_before_capture
+        capture_inside_torch_change = mem_used_inside_torch_after_capture - mem_used_inside_torch_before_capture
+
+        logger.info(
+            f"CUDA graph capture completed: "
+            f"CURRENT - inside torch: {mem_used_inside_torch_after_capture / 1024**3:.2f} GB, "
+            f"outside torch (method1): {mem_used_outside_torch_method1_after_capture / 1024**3:.2f} GB, "
+            f"outside torch (method2): {mem_used_outside_torch_method2_after_capture / 1024**3:.2f} GB, "
+            f"total: {mem_used_after_capture / 1024**3:.2f} GB, free: {mem_free_after_capture / 1024**3:.2f} GB | "
+            f"CHANGES - total: {capture_mem_change / 1024**3:.2f} GB, "
+            f"inside torch: {capture_inside_torch_change / 1024**3:.2f} GB")
+
         set_graph_capturing(False)
         set_piecewise_cuda_graph_flag(True)
         # Mark weak ref here. The output tensor should be freed properly.
         self._output = make_weak_ref(output)
+
+        # Memory statistics at capture end
+        mem_used_end, mem_free_end, mem_total = device_memory_info()
+        mem_used_inside_torch_end = torch.cuda.memory_stats(
+        )["allocated_bytes.all.current"]
+
+        # Method 1: device_memory_info
+        mem_used_outside_torch_method1_end = (
+            mem_used_end - mem_used_inside_torch_end
+        ) if mem_used_end > mem_used_inside_torch_end else 0
+
+        # Method 2: torch.cuda.mem_get_info
+        mem_free_cuda_end, total_gpu_memory_end = torch.cuda.mem_get_info()
+        total_used_bytes_end = total_gpu_memory_end - mem_free_cuda_end
+        mem_used_outside_torch_method2_end = (
+            total_used_bytes_end - mem_used_inside_torch_end
+        ) if total_used_bytes_end > mem_used_inside_torch_end else 0
+
+        # Calculate total changes
+        total_mem_change = mem_used_end - mem_used_start
+        total_inside_torch_change = mem_used_inside_torch_end - mem_used_inside_torch_start
+        total_outside_torch_change_method1 = mem_used_outside_torch_method1_end - mem_used_outside_torch_method1_start
+        total_outside_torch_change_method2 = mem_used_outside_torch_method2_end - mem_used_outside_torch_method2_start
+
+        logger.info(
+            f"CUDA graph capture COMPLETE (batch_size={self.batch_size}): "
+            f"FINAL CURRENT - inside torch: {mem_used_inside_torch_end / 1024**3:.2f} GB, "
+            f"outside torch (method1): {mem_used_outside_torch_method1_end / 1024**3:.2f} GB, "
+            f"outside torch (method2): {mem_used_outside_torch_method2_end / 1024**3:.2f} GB, "
+            f"total: {mem_used_end / 1024**3:.2f} GB, free: {mem_free_end / 1024**3:.2f} GB | "
+            f"TOTAL CHANGES - inside torch: {total_inside_torch_change / 1024**3:.2f} GB, "
+            f"outside torch (method1): {total_outside_torch_change_method1 / 1024**3:.2f} GB, "
+            f"outside torch (method2): {total_outside_torch_change_method2 / 1024**3:.2f} GB, "
+            f"total memory: {total_mem_change / 1024**3:.2f} GB")
+
         return self._graph.pool()
 
     def needs_capture(self) -> bool:

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -356,6 +356,8 @@ class PyTorchModelEngine(ModelEngine):
         )
 
         attn_backend = pytorch_backend_config.attn_backend
+        log_memory_stats("Before model loading start - Memory usage",
+                         get_memory_stats())
         self.model = self._load_model(
             model_path,
             mapping=self.mapping,

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -29,6 +29,7 @@ from tensorrt_llm.logger import logger
 from tensorrt_llm.lora_manager import LoraConfig, LoraModelConfig
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.models.modeling_utils import QuantAlgo
+from tensorrt_llm.profiler import device_memory_info
 from tensorrt_llm.quantization.utils.fp4_utils import float4_e2m1x2
 
 from ..attention_backend.interface import (AttentionMetadata,
@@ -749,11 +750,80 @@ class PyTorchModelEngine(ModelEngine):
                         logger.info(
                             f"Run generation only CUDA graph warmup for batch size={bs}, draft_len={draft_len}"
                         )
+
+                        # Memory statistics before CUDA graph capture
+                        mem_used_before, mem_free_before, mem_total = device_memory_info(
+                        )
+                        mem_used_inside_torch_before = torch.cuda.memory_stats(
+                        )["allocated_bytes.all.current"]
+
+                        # Method 1: device_memory_info
+                        mem_used_outside_torch_method1_before = (
+                            mem_used_before - mem_used_inside_torch_before
+                        ) if mem_used_before > mem_used_inside_torch_before else 0
+
+                        # Method 2: torch.cuda.mem_get_info
+                        mem_free_cuda_before, total_gpu_memory_before = torch.cuda.mem_get_info(
+                        )
+                        total_used_bytes_before = total_gpu_memory_before - mem_free_cuda_before
+                        mem_used_outside_torch_method2_before = (
+                            total_used_bytes_before -
+                            mem_used_inside_torch_before
+                        ) if total_used_bytes_before > mem_used_inside_torch_before else 0
+
+                        logger.info(
+                            f"Memory stats BEFORE graph capture forward (batch_size={bs}, draft_len={draft_len}): "
+                            f"memory used inside torch: {mem_used_inside_torch_before / 1024**3:.2f} GB, "
+                            f"memory used outside torch (method1 - device_memory_info): {mem_used_outside_torch_method1_before / 1024**3:.2f} GB, "
+                            f"memory used outside torch (method2 - mem_get_info): {mem_used_outside_torch_method2_before / 1024**3:.2f} GB, "
+                            f"total memory used: {mem_used_before / 1024**3:.2f} GB, "
+                            f"free memory: {mem_free_before / 1024**3:.2f} GB")
+
                         self.enable_spec_decode = draft_len > 0 or self.is_draft_model
                         self.forward(batch,
                                      new_tensors_device=None,
                                      resource_manager=resource_manager)
                         torch.cuda.synchronize()
+
+                        # Memory statistics after CUDA graph capture
+                        mem_used_after, mem_free_after, mem_total = device_memory_info(
+                        )
+                        mem_used_inside_torch_after = torch.cuda.memory_stats(
+                        )["allocated_bytes.all.current"]
+
+                        # Method 1: device_memory_info
+                        mem_used_outside_torch_method1_after = (
+                            mem_used_after - mem_used_inside_torch_after
+                        ) if mem_used_after > mem_used_inside_torch_after else 0
+
+                        # Method 2: torch.cuda.mem_get_info
+                        mem_free_cuda_after, total_gpu_memory_after = torch.cuda.mem_get_info(
+                        )
+                        total_used_bytes_after = total_gpu_memory_after - mem_free_cuda_after
+                        mem_used_outside_torch_method2_after = (
+                            total_used_bytes_after - mem_used_inside_torch_after
+                        ) if total_used_bytes_after > mem_used_inside_torch_after else 0
+
+                        mem_change = mem_used_after - mem_used_before
+                        inside_torch_change = mem_used_inside_torch_after - mem_used_inside_torch_before
+                        outside_torch_change_method1 = mem_used_outside_torch_method1_after - mem_used_outside_torch_method1_before
+                        outside_torch_change_method2 = mem_used_outside_torch_method2_after - mem_used_outside_torch_method2_before
+
+                        logger.info(
+                            f"Memory stats AFTER graph capture forward (batch_size={bs}, draft_len={draft_len}): "
+                            f"memory used inside torch: {mem_used_inside_torch_after / 1024**3:.2f} GB, "
+                            f"memory used outside torch (method1 - device_memory_info): {mem_used_outside_torch_method1_after / 1024**3:.2f} GB, "
+                            f"memory used outside torch (method2 - mem_get_info): {mem_used_outside_torch_method2_after / 1024**3:.2f} GB, "
+                            f"total memory used: {mem_used_after / 1024**3:.2f} GB, "
+                            f"free memory: {mem_free_after / 1024**3:.2f} GB")
+
+                        logger.info(
+                            f"Memory CHANGES during forward (batch_size={bs}, draft_len={draft_len}): "
+                            f"inside torch change: {inside_torch_change / 1024**3:.2f} GB, "
+                            f"outside torch change (method1): {outside_torch_change_method1 / 1024**3:.2f} GB, "
+                            f"outside torch change (method2): {outside_torch_change_method2 / 1024**3:.2f} GB, "
+                            f"total memory change: {mem_change / 1024**3:.2f} GB"
+                        )
 
             if self._torch_compile_piecewise_cuda_graph and self._torch_compile_enabled:
                 for seq_lens in cuda_graph_batch_sizes:
@@ -2104,6 +2174,24 @@ class PyTorchModelEngine(ModelEngine):
         gather_context_logits: bool = False,
         cache_indirection_buffer: Optional[torch.Tensor] = None,
     ):
+        # Memory statistics before forward
+        mem_used_before, mem_free_before, mem_total = device_memory_info()
+        mem_used_inside_torch_before = torch.cuda.memory_stats(
+        )["allocated_bytes.all.current"]
+
+        # Method 1: device_memory_info
+        mem_used_outside_torch_method1_before = (
+            mem_used_before - mem_used_inside_torch_before
+        ) if mem_used_before > mem_used_inside_torch_before else 0
+
+        # Method 2: torch.cuda.mem_get_info
+        mem_free_cuda_before, total_gpu_memory_before = torch.cuda.mem_get_info(
+        )
+        total_used_bytes_before = total_gpu_memory_before - mem_free_cuda_before
+        mem_used_outside_torch_method2_before = (
+            total_used_bytes_before - mem_used_inside_torch_before
+        ) if total_used_bytes_before > mem_used_inside_torch_before else 0
+
         kv_cache_manager = resource_manager.get_resource_manager(
             self.kv_cache_manager_key)
 
@@ -2138,8 +2226,48 @@ class PyTorchModelEngine(ModelEngine):
                 scheduled_requests, attn_metadata, spec_metadata)
 
             with MoeLoadBalancerIterContext(moe_load_balancer):
-                return self._forward_step(inputs, gather_ids,
-                                          gather_context_logits)
+                outputs = self._forward_step(inputs, gather_ids,
+                                             gather_context_logits)
+
+            # Memory statistics after forward (no cache path)
+            mem_used_after, mem_free_after, mem_total = device_memory_info()
+            mem_used_inside_torch_after = torch.cuda.memory_stats(
+            )["allocated_bytes.all.current"]
+
+            # Method 1: device_memory_info
+            mem_used_outside_torch_method1_after = (
+                mem_used_after - mem_used_inside_torch_after
+            ) if mem_used_after > mem_used_inside_torch_after else 0
+
+            # Method 2: torch.cuda.mem_get_info
+            mem_free_cuda_after, total_gpu_memory_after = torch.cuda.mem_get_info(
+            )
+            total_used_bytes_after = total_gpu_memory_after - mem_free_cuda_after
+            mem_used_outside_torch_method2_after = (
+                total_used_bytes_after - mem_used_inside_torch_after
+            ) if total_used_bytes_after > mem_used_inside_torch_after else 0
+
+            # Calculate memory changes
+            mem_change = mem_used_after - mem_used_before
+            inside_torch_change = mem_used_inside_torch_after - mem_used_inside_torch_before
+            outside_torch_change_method1 = mem_used_outside_torch_method1_after - mem_used_outside_torch_method1_before
+            outside_torch_change_method2 = mem_used_outside_torch_method2_after - mem_used_outside_torch_method2_before
+
+            batch_size = len(scheduled_requests.all_requests())
+
+            logger.info(
+                f"Forward memory stats [no_cache] (batch_size={batch_size}): "
+                f"CURRENT - inside torch: {mem_used_inside_torch_after / 1024**3:.2f} GB, "
+                f"outside torch (method1): {mem_used_outside_torch_method1_after / 1024**3:.2f} GB, "
+                f"outside torch (method2): {mem_used_outside_torch_method2_after / 1024**3:.2f} GB, "
+                f"total: {mem_used_after / 1024**3:.2f} GB, "
+                f"free: {mem_free_after / 1024**3:.2f} GB | "
+                f"CHANGES - inside torch: {inside_torch_change / 1024**3:.2f} GB, "
+                f"outside torch (method1): {outside_torch_change_method1 / 1024**3:.2f} GB, "
+                f"outside torch (method2): {outside_torch_change_method2 / 1024**3:.2f} GB, "
+                f"total: {mem_change / 1024**3:.2f} GB")
+
+            return outputs
         with self._maybe_pad_batch(scheduled_requests, kv_cache_manager,
                                    spec_resource_manager) as scheduled_requests:
             maybe_graph = self._maybe_get_cuda_graph(scheduled_requests)
@@ -2187,6 +2315,46 @@ class PyTorchModelEngine(ModelEngine):
                         outputs = maybe_graph.run(inputs)
 
             self._execute_logit_post_processors(scheduled_requests, outputs)
+
+            # Memory statistics after forward
+            mem_used_after, mem_free_after, mem_total = device_memory_info()
+            mem_used_inside_torch_after = torch.cuda.memory_stats(
+            )["allocated_bytes.all.current"]
+
+            # Method 1: device_memory_info
+            mem_used_outside_torch_method1_after = (
+                mem_used_after - mem_used_inside_torch_after
+            ) if mem_used_after > mem_used_inside_torch_after else 0
+
+            # Method 2: torch.cuda.mem_get_info
+            mem_free_cuda_after, total_gpu_memory_after = torch.cuda.mem_get_info(
+            )
+            total_used_bytes_after = total_gpu_memory_after - mem_free_cuda_after
+            mem_used_outside_torch_method2_after = (
+                total_used_bytes_after - mem_used_inside_torch_after
+            ) if total_used_bytes_after > mem_used_inside_torch_after else 0
+
+            # Calculate memory changes
+            mem_change = mem_used_after - mem_used_before
+            inside_torch_change = mem_used_inside_torch_after - mem_used_inside_torch_before
+            outside_torch_change_method1 = mem_used_outside_torch_method1_after - mem_used_outside_torch_method1_before
+            outside_torch_change_method2 = mem_used_outside_torch_method2_after - mem_used_outside_torch_method2_before
+
+            # Determine execution path
+            execution_path = "cuda_graph" if maybe_graph is not None else "regular"
+            batch_size = len(scheduled_requests.all_requests())
+
+            logger.info(
+                f"Forward memory stats [{execution_path}] (batch_size={batch_size}): "
+                f"CURRENT - inside torch: {mem_used_inside_torch_after / 1024**3:.2f} GB, "
+                f"outside torch (method1): {mem_used_outside_torch_method1_after / 1024**3:.2f} GB, "
+                f"outside torch (method2): {mem_used_outside_torch_method2_after / 1024**3:.2f} GB, "
+                f"total: {mem_used_after / 1024**3:.2f} GB, "
+                f"free: {mem_free_after / 1024**3:.2f} GB | "
+                f"CHANGES - inside torch: {inside_torch_change / 1024**3:.2f} GB, "
+                f"outside torch (method1): {outside_torch_change_method1 / 1024**3:.2f} GB, "
+                f"outside torch (method2): {outside_torch_change_method2 / 1024**3:.2f} GB, "
+                f"total: {mem_change / 1024**3:.2f} GB")
 
             return outputs
 

--- a/tensorrt_llm/executor/executor.py
+++ b/tensorrt_llm/executor/executor.py
@@ -386,6 +386,13 @@ class GenerationExecutor(ABC):
         if lora_config:
             worker_kwargs["lora_config"] = lora_config
 
+        from tensorrt_llm._torch.pyexecutor.model_engine import (
+            get_memory_stats, log_memory_stats)
+        stats_before_worker_init = get_memory_stats()
+        log_memory_stats(
+            "Memory stats BEFORE GenerationExecution initialization",
+            stats_before_worker_init)
+
         # The case where the Python main process is launched by mpirun
         mpirun_launch = external_mpi_comm_available(model_world_size)
         # The case where the Python main process utilizes mpi4py to spawn MPI workers

--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -60,6 +60,13 @@ class GenerationExecutorWorker(GenerationExecutor):
         lora_config: Optional[LoraConfig] = None,
         garbage_collection_gen0_threshold: Optional[int] = None,
     ) -> None:
+        # Memory tracking before worker initialization
+        from tensorrt_llm._torch.pyexecutor.model_engine import (
+            get_memory_stats, log_memory_stats)
+        stats_before_worker_init = get_memory_stats()
+        log_memory_stats("Memory stats BEFORE worker initialization",
+                         stats_before_worker_init)
+
         postproc_config = postproc_worker_config or PostprocWorkerConfig()
         super().__init__(
             num_postprocess_workers=postproc_config.num_postprocess_workers,

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -281,5 +281,4 @@ full:GB200/examples/test_qwen.py::test_llm_qwen_7b_multi_gpus_summary[qwen2.5_7b
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16[mtp_nextn=0-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=False] SKIP (https://nvbugs/5410391)
 accuracy/test_llm_api.py::TestMistral_Nemo_12B_Base::test_fp8 SKIP (https://nvbugs/5413197)
 accuracy/test_cli_flow.py::TestLlama3_8BInstructGradient1048k::test_long_context_ppl SKIP (https://nvbugs/5413362)
-accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_multi_gpus[throughput_tp8] SKIP (https://nvbugs/5455140)
 disaggregated/test_disaggregated.py::test_disaggregated_diff_max_tokens[TinyLlama-1.1B-Chat-v1.0] SKIP (https://nvbugs/5451272)


### PR DESCRIPTION
Since we can’t reproduce the issue on the local cluster but it appears in the post-merge CI, we’ll add some logging first. When the OOM recurs in post-merge CI, we’ll have more information; once the problem is located, we’ll revert these logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds comprehensive GPU memory profiling and human-readable logging across CUDA graph capture, model load/compile, warmup, and execution; reports totals, free, inside-PyTorch vs outside-PyTorch, and per-stage deltas with contextual metadata (batch size, execution path, layer).
  * Instruments memory logging inside model internals and executor worker initialization for finer-grained diagnostics; new memory-tracking helpers are exposed.

* **Tests**
  * Removed a test-waive entry from integration test lists (adjusts skip configuration).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->