### PR TITLE
[TRTLLM-6393][feat] add static tree sampling and verification

### DIFF
--- a/examples/llm-api/llm_speculative_decoding.py
+++ b/examples/llm-api/llm_speculative_decoding.py
@@ -6,8 +6,8 @@ from typing import Optional
 import click
 
 from tensorrt_llm import LLM, SamplingParams
-from tensorrt_llm.llmapi import (EagleDecodingConfig, MTPDecodingConfig,
-                                 NGramDecodingConfig)
+from tensorrt_llm.llmapi import (EagleDecodingConfig, KvCacheConfig,
+                                 MTPDecodingConfig, NGramDecodingConfig)
 
 prompts = [
     "What is the capital of France?",
@@ -38,9 +38,12 @@ def run_Eagle3():
         speculative_model_dir="yuhuili/EAGLE3-LLaMA3.1-Instruct-8B",
         eagle3_one_model=True)
 
+    kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.8)
+
     llm = LLM(
         model="meta-llama/Llama-3.1-8B-Instruct",
         speculative_config=spec_config,
+        kv_cache_config=kv_cache_config,
     )
 
     for prompt in prompts:

--- a/examples/llm-api/quickstart_advanced.py
+++ b/examples/llm-api/quickstart_advanced.py
@@ -128,6 +128,11 @@ def add_llm_args(parser):
     parser.add_argument('--draft_model_dir', type=str, default=None)
     parser.add_argument('--max_matching_ngram_size', type=int, default=5)
     parser.add_argument('--use_one_model', default=False, action='store_true')
+    parser.add_argument('--eagle_choices', type=str, default=None)
+    parser.add_argument('--use_dynamic_tree',
+                        default=False,
+                        action='store_true')
+    parser.add_argument('--dynamic_tree_max_topK', type=int, default=None)
 
     # Relaxed acceptance
     parser.add_argument('--use_relaxed_acceptance_for_thinking',
@@ -183,7 +188,10 @@ def setup_llm(args, **kwargs):
         spec_config = EagleDecodingConfig(
             max_draft_len=args.spec_decode_max_draft_len,
             speculative_model_dir=args.draft_model_dir,
-            eagle3_one_model=args.use_one_model)
+            eagle3_one_model=args.use_one_model,
+            eagle_choices=args.eagle_choices,
+            use_dynamic_tree=args.use_dynamic_tree,
+            dynamic_tree_max_topK=args.dynamic_tree_max_topK)
     elif spec_decode_algo == "DRAFT_TARGET":
         spec_config = DraftTargetDecodingConfig(
             max_draft_len=args.spec_decode_max_draft_len,

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -309,6 +309,13 @@ def create_autodeploy_executor(ad_config: LlmArgs):
     max_draft_len = (
         0 if ad_config.speculative_config is None else ad_config.speculative_config.max_draft_len
     )
+    max_total_draft_tokens = 0
+    if ad_config.speculative_config is None:
+        max_total_draft_tokens = 0
+    elif hasattr(ad_config.speculative_config, "max_total_draft_tokens"):
+        max_total_draft_tokens = ad_config.speculative_config.max_total_draft_tokens
+    else:
+        max_total_draft_tokens = max_draft_len
 
     # initialize model engine
     engine = ADEngine.build_from_config(ad_config=ad_config)
@@ -343,6 +350,7 @@ def create_autodeploy_executor(ad_config: LlmArgs):
     sampler_args = TorchSampler.Args(
         max_seq_len=ad_config.max_seq_len,
         max_draft_len=max_draft_len,
+        max_total_draft_tokens=max_total_draft_tokens,
         max_num_sequences=max_num_sequences,
         max_beam_width=ad_config.max_beam_width,
     )

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -708,9 +708,18 @@ def create_torch_sampler_args(mapping: Mapping, *, max_seq_len: int,
     max_num_sequences = max_batch_size * mapping.pp_size
     max_draft_len = (0 if speculative_config is None else
                      speculative_config.max_draft_len)
+    max_total_draft_tokens = 0
+    if speculative_config is None:
+        max_total_draft_tokens = 0
+    elif hasattr(speculative_config, 'max_total_draft_tokens'):
+        max_total_draft_tokens = speculative_config.max_total_draft_tokens
+    else:
+        max_total_draft_tokens = max_draft_len
+
     return TorchSampler.Args(
         max_seq_len=max_seq_len,
         max_draft_len=max_draft_len,
+        max_total_draft_tokens=max_total_draft_tokens,
         max_num_sequences=max_num_sequences,
         max_beam_width=max_beam_width,
     )

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -26,8 +26,10 @@ from tensorrt_llm.bindings.internal.runtime import (BufferManager, CudaEvent,
 from tensorrt_llm.executor.result import Logprob
 from tensorrt_llm.mapping import Mapping
 
+from ..speculative.spec_tree_manager import SpecTreeManager
 from .finish_reason import FinishedState
 from .llm_request import LlmRequest, LlmRequestState, get_draft_token_length
+from .resource_manager import ResourceManager, ResourceManagerType
 from .scheduler import ScheduledRequests
 
 if sys.version_info[:2] >= (3, 12):
@@ -66,12 +68,19 @@ class Sampler(ABC):
         return None
 
     @abstractmethod
-    def sample_async(self, scheduled_requests: ScheduledRequests, model_outputs,
-                     num_context_logits_prefix_sum: list[int]) -> SampleState:
+    def sample_async(
+            self,
+            scheduled_requests: ScheduledRequests,
+            model_outputs,
+            num_context_logits_prefix_sum: list[int],
+            resource_manager: Optional[ResourceManager] = None) -> SampleState:
         raise NotImplementedError
 
     @abstractmethod
-    def update_requests(self, state: SampleState) -> None:
+    def update_requests(
+            self,
+            state: SampleState,
+            resource_manager: Optional[ResourceManager] = None) -> None:
         raise NotImplementedError
 
     @staticmethod
@@ -96,13 +105,20 @@ class EarlyStopSampler(Sampler):
     """
 
     @override
-    def sample_async(self, scheduled_requests: ScheduledRequests, model_outputs,
-                     num_context_logits_prefix_sum: list[int]) -> SampleState:
+    def sample_async(
+            self,
+            scheduled_requests: ScheduledRequests,
+            model_outputs,
+            num_context_logits_prefix_sum: list[int],
+            resource_manager: Optional[ResourceManager] = None) -> SampleState:
         host = SampleStateTensors(new_tokens=torch.empty(0))
         return SampleState(scheduled_requests=scheduled_requests, host=host)
 
     @override
-    def update_requests(self, state: SampleState) -> None:
+    def update_requests(
+            self,
+            state: SampleState,
+            resource_manager: Optional[ResourceManager] = None) -> None:
         assert isinstance(state, SampleState)
         scheduled_requests = state.scheduled_requests
         assert (not scheduled_requests.generation_requests)
@@ -138,8 +154,11 @@ class EarlyStopWithMMResult(Sampler):
 
     @override
     def sample_async(
-            self, scheduled_requests: ScheduledRequests, model_outputs,
-            num_context_logits_prefix_sum: list[int]
+        self,
+        scheduled_requests: ScheduledRequests,
+        model_outputs,
+        num_context_logits_prefix_sum: list[int],
+        resource_manager: Optional[ResourceManager] = None
     ) -> SampleStateWithMMResult:
         # from model_outputs to MultimodalResult
         data = MultimodalResult(mm_embeddings=model_outputs['mm_embeddings'])
@@ -147,7 +166,11 @@ class EarlyStopWithMMResult(Sampler):
                                        data=data)
 
     @override
-    def update_requests(self, state: SampleStateWithMMResult) -> None:
+    def update_requests(
+            self,
+            state: SampleStateWithMMResult,
+            resource_manager: Optional[ResourceManager] = None) -> None:
+        # resource_manager will not be used in this function, just for interface consistency.
         assert isinstance(state, SampleStateWithMMResult)
         scheduled_requests = state.scheduled_requests
         assert (not scheduled_requests.generation_requests)
@@ -389,7 +412,7 @@ def sample(
     logits: torch.Tensor,
     generator: Optional[torch.Generator] = None,
     *,
-    softmax_indices: Optional[torch.IntTensor] = None
+    softmax_indices: Optional[torch.IntTensor] = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     filter_softmax = True
     match strategy:
@@ -772,6 +795,7 @@ class TorchSampler(Sampler):
         max_draft_len: int
         max_num_sequences: int
         max_beam_width: int
+        max_total_draft_tokens: int
 
     def __init__(self, args: Args):
         self.max_seq_len = args.max_seq_len
@@ -806,6 +830,18 @@ class TorchSampler(Sampler):
             self._generator.manual_seed(self._global_seed)
         assert self._generator.device == device
         return self._generator
+
+    def get_spec_tree_manager(
+            self,
+            resource_manager: ResourceManager) -> Optional[SpecTreeManager]:
+        if resource_manager is None:
+            return None
+        spec_resource_manager = resource_manager.get_resource_manager(
+            ResourceManagerType.SPEC_RESOURCE_MANAGER)
+        if spec_resource_manager is None or not hasattr(spec_resource_manager,
+                                                        "spec_tree_manager"):
+            return None
+        return spec_resource_manager.spec_tree_manager
 
     def _meet_max_token_stop_criteria(self, request: LlmRequest):
         num_tokens = request.get_num_tokens(self.BEAM)
@@ -886,6 +922,146 @@ class TorchSampler(Sampler):
                 break
         return num_accepted
 
+    def _process_draft_tokens_tree(self, request: LlmRequest,
+                                   new_tokens: torch.Tensor,
+                                   spec_tree_manager: SpecTreeManager) -> int:
+        """Tree verification for draft token tree based speculative decoding. This function will only be called for the target model.
+        Verification logic:
+            Find the longest prefix match. Since each node in the tree has a related path,
+            we can find the longest match by comparing all the paths.
+        Args:
+            request: LlmRequest. The request with draft tokens.
+            new_tokens: torch.Tensor. [max_draft_len + 1, max_num_sequences, MAX_BEAM_WIDTH], host buffer. The tokens generated by the target model
+                        The relationship between [max_draft_len + 1] and the draft token tree:
+                        If the current node is accepted, what is the NEXT token_id that the target model will generate?
+                        For example, new_tokens[0, req_idx, 1] indicates the NEXT token_id sampled from the root node in the draft token tree if it is accepted.
+                        We know that the root node in the draft token tree is always accepted. Therefore, new_tokens[0, req_idx, 1] indicates the token_id following the root node,
+                        corresponding to the first layer in the draft token tree (the root node is the 0th layer).
+                        Similarly, new_tokens[1, req_idx, 1] represents the NEXT token_id if the first token in the first layer of the draft tokens tree is accepted.
+            spec_tree_manager: SpecTreeManager. which contains the tree structure and other meta information of the tree.
+        """
+        # handle the drafter model request
+        # For the drafter model, we do not execute the tree verification logic,
+        # but only add the draft tokens of the previous layer.
+        if get_draft_token_length(request) == 0:
+            cur_draft_layer_idx = spec_tree_manager.cur_draft_layer_idx
+
+            # TODO: For the last layer of the dynamic tree, we need to resampling all the draft tokens.
+            cur_layer_num_nodes = sum(
+                spec_tree_manager.get_top_k_list(cur_draft_layer_idx))
+            for i in range(cur_layer_num_nodes):
+                new_token = add_token(request, new_tokens, beam=0, step=i)
+            return 0
+        else:
+            # handle the target model request
+            # For the target model, we will do the tree verification logic.
+            seq_slot = request.py_seq_slot
+            assert seq_slot is not None
+            eagle_paths = spec_tree_manager.get_eagle_paths(seq_slot)
+
+            all_draft_tokens = request.py_draft_tokens  # [max_total_draft_tokens]
+            all_target_tokens = new_tokens[:, seq_slot, :].squeeze(
+                -1)  # [max_total_draft_tokens]
+            assert all_target_tokens.shape[
+                0] == spec_tree_manager.max_total_draft_tokens + 1
+
+            longest_accepted_len = 0
+            longest_match_path_idx = -1
+
+            for path_idx, path in enumerate(eagle_paths):
+                path_exclude_root = path[
+                    1:] - 1  # [max_draft_len], '[1:]' since the new_tokens does not contain the root node.
+                # '-1' is the index shift after exclude the root node.
+                draft_tokens_indices = path_exclude_root[path_exclude_root >=
+                                                         0]  # [max_draft_len]
+                target_tokens_indices = path[path >= 0]  # [max_draft_len + 1]
+
+                assert len(
+                    draft_tokens_indices) == len(target_tokens_indices) - 1
+
+                cur_draft_tokens = all_draft_tokens[draft_tokens_indices]
+                cur_target_tokens = all_target_tokens[target_tokens_indices]
+
+                cur_accepted_len = torch.cumprod(
+                    (cur_draft_tokens == cur_target_tokens[:-1]).int(),
+                    dim=-1).sum()
+
+                # Accepted one more token from the target model.
+                cur_accepted_len += 1
+
+                if cur_accepted_len > longest_accepted_len:
+                    longest_accepted_len = cur_accepted_len
+                    longest_match_path_idx = path_idx
+
+            if longest_accepted_len == 0:
+                # No draft tokens are accepted.
+                # Take the top-1 token of the first layer as the next new token.
+                new_token = add_token(request, new_tokens, beam=0, step=0)
+                return 0
+            else:
+                # Take the longest accepted path as the next new token.
+                num_accepted_draft_tokens = 0
+                for idx in eagle_paths[
+                        longest_match_path_idx][:longest_accepted_len]:
+                    new_token = add_token(request, new_tokens, beam=0, step=idx)
+                    num_accepted_draft_tokens += 1
+                    if self._handle_stop_criteria(request, new_token):
+                        break
+
+                return num_accepted_draft_tokens - 1
+
+    def _tree_sampling_batch(self, requests: list[LlmRequest],
+                             max_num_sequences: int, seq_slots: torch.Tensor,
+                             model_outputs: dict[str, torch.Tensor],
+                             spec_tree_manager: SpecTreeManager):
+
+        if spec_tree_manager.use_dynamic_tree and draft_layer_id == spec_tree_manager.max_draft_len - 1:
+            # TODO: Re-sample the draft tokens for the last layer.
+            raise NotImplementedError(
+                "Dynamic tree is not fully supported yet.")
+
+        raw_logits = model_outputs["logits"]
+        num_requests = len(requests)
+        assert raw_logits.shape[0] % num_requests == 0
+        num_logits_per_request = raw_logits.shape[0] // num_requests
+        request_index = torch.arange(num_requests)
+
+        draft_layer_id = spec_tree_manager.cur_draft_layer_idx
+        # 1) Get the topK list for the specific draft layer.
+        top_k_list = spec_tree_manager.get_top_k_list(draft_layer_id)
+        assert len(top_k_list) == num_logits_per_request
+
+        # Considering that the beam_width of spec-dec can only be 1, we ignore this dimension here.
+        new_draft_tokens_cuda = torch.empty(
+            (max_num_sequences, spec_tree_manager.max_total_draft_tokens + 1),
+            dtype=torch.int64,
+            device=raw_logits.device)
+
+        top_k_list_cumsum = torch.cumsum(top_k_list, dim=0)
+        # Different nodes have different topK value.
+        for i, top_k_list_i in enumerate(top_k_list):
+            # 2) Extract the logits needed for this layer.
+            logits = raw_logits[request_index * num_logits_per_request + i, :]
+            assert logits.shape[0] == len(requests)
+            # 3) Sample the logits according to the topK value.
+            indices = torch.topk(logits, k=top_k_list_i, dim=-1).indices
+            # 4) Write to the temporary output tensor.
+            new_draft_tokens_cuda[
+                seq_slots, top_k_list_cumsum[i] -
+                top_k_list_i:top_k_list_cumsum[i]] = indices[request_index]
+
+        # 5) Append eagle3 d2t.
+        self._apply_d2t(new_draft_tokens_cuda, model_outputs)
+
+        # 6) Copy back to the output tensor.
+        int_new_draft_tokens = new_draft_tokens_cuda.transpose(0, 1).to(
+            torch.int, non_blocking=True).unsqueeze(dim=-1)
+
+        new_draft_tokens_host = int_new_draft_tokens.to("cpu",
+                                                        non_blocking=True)
+
+        return new_draft_tokens_host
+
     def _process_draft_tokens_rejection_sampling(
             self, request: LlmRequest, new_tokens: torch.Tensor) -> int:
         sampling_strategy = _request_strategy(request)
@@ -926,17 +1102,31 @@ class TorchSampler(Sampler):
 
         return num_accepted
 
-    def process_draft_tokens(self, request: LlmRequest,
-                             new_tokens: torch.Tensor) -> int:
+    def process_draft_tokens(
+            self,
+            request: LlmRequest,
+            new_tokens: torch.Tensor,
+            resource_manager: Optional[ResourceManager] = None) -> int:
         if request.py_draft_logits is None:
-            return self._process_draft_tokens_greedy(request, new_tokens)
+            spec_tree_manager = self.get_spec_tree_manager(resource_manager)
+            if spec_tree_manager is not None:
+                num_accepted = self._process_draft_tokens_tree(
+                    request,
+                    new_tokens=new_tokens,
+                    spec_tree_manager=spec_tree_manager)
+            else:
+                num_accepted = self._process_draft_tokens_greedy(
+                    request, new_tokens=new_tokens)
+            return num_accepted
         else:
             return self._process_draft_tokens_rejection_sampling(
                 request, new_tokens)
 
     @override
-    @torch.inference_mode()
-    def update_requests(self, state: SampleState) -> None:
+    def update_requests(
+            self,
+            state: SampleState,
+            resource_manager: Optional[ResourceManager] = None) -> None:
         assert isinstance(state, SampleState)
         if state.sampler_event:
             state.sampler_event.synchronize()
@@ -955,7 +1145,8 @@ class TorchSampler(Sampler):
             if req.state == LlmRequestState.GENERATION_COMPLETE:
                 continue
             processed = 1
-            num_accepted = self.process_draft_tokens(req, new_tokens)
+            num_accepted = self.process_draft_tokens(req, new_tokens,
+                                                     resource_manager)
             if get_draft_token_length(req) > 0:
                 req.py_num_accepted_draft_tokens = num_accepted
                 req.py_rewind_len = req.py_draft_pages_allocated - num_accepted
@@ -980,9 +1171,12 @@ class TorchSampler(Sampler):
 
     @override
     @torch.inference_mode()
-    def sample_async(self, scheduled_requests: ScheduledRequests,
-                     model_outputs: dict[str, torch.Tensor],
-                     num_context_logits_prefix_sum: list[int]) -> SampleState:
+    def sample_async(
+            self,
+            scheduled_requests: ScheduledRequests,
+            model_outputs: dict[str, torch.Tensor],
+            num_context_logits_prefix_sum: list[int],
+            resource_manager: Optional[ResourceManager] = None) -> SampleState:
         requests = scheduled_requests.all_requests()
         new_tokens = self.store.new_tokens
         log_probs_host = self.log_probs_host(scheduled_requests)
@@ -990,12 +1184,14 @@ class TorchSampler(Sampler):
             [r.py_seq_slot for r in requests],
             dtype=torch.int64,  # for index_fill_
             pin_memory=True)
-        new_tokens_host = self._process_requests(scheduled_requests,
-                                                 model_outputs,
-                                                 new_tokens,
-                                                 num_context_logits_prefix_sum,
-                                                 seq_slots=seq_slots_host,
-                                                 log_probs_host=log_probs_host)
+        new_tokens_host = self._process_requests(
+            scheduled_requests,
+            model_outputs,
+            new_tokens,
+            num_context_logits_prefix_sum,
+            seq_slots=seq_slots_host,
+            log_probs_host=log_probs_host,
+            resource_manager=resource_manager)
 
         sampler_event = torch.cuda.Event()
         sampler_event.record()
@@ -1444,8 +1640,10 @@ class TorchSampler(Sampler):
             num_context_logits_prefix_sum: list[int],
             *,
             seq_slots: torch.Tensor,
-            log_probs_host: torch.Tensor | None = None) -> torch.Tensor:
+            log_probs_host: torch.Tensor | None = None,
+            resource_manager: Optional[ResourceManager] = None) -> torch.Tensor:
         seq_slots = seq_slots.to(dtype=torch.int32)  # int32 suffices here
+        spec_tree_manager = self.get_spec_tree_manager(resource_manager)
 
         raw_logits_cuda = model_outputs["logits"]
 
@@ -1481,6 +1679,18 @@ class TorchSampler(Sampler):
 
         logits_cuda = self._apply_min_length_penalty(logits_cuda, requests,
                                                      req_num_steps_list)
+
+        # Fast path for drafter model's tree sampling.
+        if spec_tree_manager is not None and logits_cuda.size(0) == len(
+                scheduled_requests.all_requests()):
+            new_tokens_host = self._tree_sampling_batch(
+                requests,
+                self.max_num_sequences,
+                seq_slots,
+                model_outputs,
+                spec_tree_manager,
+            )
+            return new_tokens_host
 
         # Perform sampling in batches
         batched_sampling_result = self._sample_batched_by_strategy(
@@ -1698,8 +1908,12 @@ class TRTLLMSampler(Sampler):
     @nvtx_range("sample_async")
     @override
     def sample_async(
-            self, scheduled_requests: ScheduledRequests, model_outputs,
-            num_context_logits_prefix_sum: list[int]) -> SampleStateTRTLLM:
+        self,
+        scheduled_requests: ScheduledRequests,
+        model_outputs,
+        num_context_logits_prefix_sum: list[int],
+        resource_manager: Optional[ResourceManager] = None
+    ) -> SampleStateTRTLLM:
 
         batch_size = scheduled_requests.batch_size
         beam_width = self.beam_width(scheduled_requests.all_requests())
@@ -1789,7 +2003,10 @@ class TRTLLMSampler(Sampler):
 
     @torch.inference_mode()
     @override
-    def update_requests(self, state: SampleStateTRTLLM):
+    def update_requests(self,
+                        state: SampleStateTRTLLM,
+                        resource_manager: Optional[ResourceManager] = None):
+        # resource_manager will not be used in this function, just for interface consistency.
         assert isinstance(state, SampleStateTRTLLM)
         if state.scheduled_requests.batch_size == 0:
             return

--- a/tensorrt_llm/_torch/speculative/__init__.py
+++ b/tensorrt_llm/_torch/speculative/__init__.py
@@ -3,6 +3,7 @@ from .eagle3 import Eagle3SpecMetadata
 from .interface import SpecMetadata
 from .mtp import MTPEagleWorker, MTPSpecMetadata, MTPWorker
 from .ngram import NGramDrafter, NGramPoolManager
+from .spec_tree_manager import SpecTreeManager
 from .utils import (get_num_extra_kv_tokens, get_num_spec_layers,
                     get_spec_decoder, get_spec_drafter, get_spec_metadata,
                     get_spec_resource_manager, get_spec_worker,
@@ -25,4 +26,5 @@ __all__ = [
     "get_spec_worker",
     "update_spec_config_from_model_config",
     "suggest_spec_config",
+    "SpecTreeManager",
 ]

--- a/tensorrt_llm/_torch/speculative/model_drafter.py
+++ b/tensorrt_llm/_torch/speculative/model_drafter.py
@@ -11,7 +11,8 @@ from tensorrt_llm.logger import logger
 from ..pyexecutor.guided_decoder import GuidedDecoder
 from ..pyexecutor.handle_logits import HandleLogits
 from ..pyexecutor.llm_request import LlmRequest, LlmRequestState
-from ..pyexecutor.resource_manager import BaseResourceManager, ResourceManager
+from ..pyexecutor.resource_manager import (BaseResourceManager, ResourceManager,
+                                           ResourceManagerType)
 from ..pyexecutor.sampler import Sampler, SampleState, SampleStateTensors
 from ..pyexecutor.scheduler import ScheduledRequests
 from ..pyexecutor.seq_slot_manager import SeqSlotManager
@@ -173,7 +174,7 @@ class ModelDrafter(Drafter):
         # Copy additional properties
         draft_request.py_stop_words_list = original_request.py_stop_words_list
 
-        # Add to appropriate batch based on request type
+        # Add to appropriate batch based on request typetensorrt_llm/_torch/speculative/model_drafter.py
         if draft_request.state == LlmRequestState.GENERATION_IN_PROGRESS:
             draft_batch.generation_requests.append(draft_request)
         else:
@@ -283,8 +284,12 @@ class ModelDrafter(Drafter):
 
         return outputs
 
-    def sample_async(self, draft_batch: ScheduledRequests,
-                     outputs: Dict[str, Any]) -> Optional[SampleState]:
+    def sample_async(
+        self,
+        draft_batch: ScheduledRequests,
+        outputs: Dict[str, Any],
+        resource_manager: Optional[ResourceManager] = None
+    ) -> Optional[SampleState]:
         """Sample tokens from draft model outputs."""
         try:
             num_context_logits_prefix_sum = [0]
@@ -300,7 +305,8 @@ class ModelDrafter(Drafter):
                            self.sampler.is_generation_model())
 
             return self.sampler.sample_async(draft_batch, outputs,
-                                             num_context_logits_prefix_sum)
+                                             num_context_logits_prefix_sum,
+                                             resource_manager)
         except Exception as e:
             logger.error(f"Error in sampling: {str(e)}")
             return None
@@ -314,9 +320,25 @@ class ModelDrafter(Drafter):
             if request.context_remaining_length == 0:
                 request.state = LlmRequestState.GENERATION_IN_PROGRESS
 
-    def update_requests(self, sample_state: SampleState) -> None:
+    def update_cur_draft_layer_idx(
+            self,
+            cur_draft_layer_idx: int,
+            resource_manager: Optional[ResourceManager] = None):
+        spec_resource_manager = resource_manager.get_resource_manager(
+            ResourceManagerType.SPEC_RESOURCE_MANAGER)
+        if spec_resource_manager is None:
+            return None
+
+        spec_tree_manager = spec_resource_manager.spec_tree_manager
+        if spec_tree_manager is not None:
+            spec_tree_manager.cur_draft_layer_idx = cur_draft_layer_idx
+
+    def update_requests(
+            self,
+            sample_state: SampleState,
+            resource_manager: Optional[ResourceManager] = None) -> None:
         """Update requests with sample state."""
-        self.sampler.update_requests(sample_state)
+        self.sampler.update_requests(sample_state, resource_manager)
 
     def process_decoded_tokens(
             self, draft_batch: ScheduledRequests,
@@ -505,19 +527,25 @@ class ModelDrafter(Drafter):
             self.draft_seq_slot_manager.free_resources(req)
 
     def process_dynamic_draft_outputs(
-            self, outputs: Any,
-            req_id_to_old_request: Dict[int, LlmRequest]) -> None:
+            self,
+            outputs: Any,
+            req_id_to_old_request: Dict[int, LlmRequest],
+            resource_manager: Optional[ResourceManager] = None) -> None:
         """
         Process outputs from dynamic draft loop, update target requests, and clean up resources.
         """
-        self.update_requests(outputs)
+        self.update_requests(outputs, resource_manager)
         self.process_decoded_tokens(outputs.scheduled_requests,
                                     req_id_to_old_request)
 
     def _execute_draft_iteration(
-        self, draft_batch: ScheduledRequests, resource_manager: ResourceManager,
-        previous_draft_state: Optional[SampleState]
-    ) -> Tuple[Any, Optional[SampleState]]:
+            self, draft_batch: ScheduledRequests,
+            resource_manager: ResourceManager,
+            previous_draft_state: Optional[SampleState],
+            cur_draft_layer_idx: int) -> Tuple[Any, Optional[SampleState]]:
+        self.update_cur_draft_layer_idx(
+            cur_draft_layer_idx, resource_manager
+        )  # Update the current draft layer index in the resource manager.
         """Forward pass through the draft model."""
         outputs = self.forward_draft_model(
             draft_batch,
@@ -527,14 +555,14 @@ class ModelDrafter(Drafter):
             if previous_draft_state else None)
 
         if previous_draft_state is not None:
-            self.update_requests(previous_draft_state)
+            self.update_requests(previous_draft_state, resource_manager)
 
         if self.guided_decoder is not None:
             self.guided_decoder.add_batch(draft_batch)
             self.guided_decoder.execute(outputs['logits'],
                                         d2t=outputs.get('d2t'))
 
-        sample_state = self.sample_async(draft_batch, outputs)
+        sample_state = self.sample_async(draft_batch, outputs, resource_manager)
         self.update_request_states(draft_batch)
 
         return outputs, sample_state
@@ -574,7 +602,7 @@ class ModelDrafter(Drafter):
                 break
 
             _, sample_state = self._execute_draft_iteration(
-                draft_batch, resource_manager, previous_draft_state)
+                draft_batch, resource_manager, previous_draft_state, i + 1)
 
             # Update target inputs if provided (for overlap mode)
             if target_inputs is not None and num_draft_reqs is not None:
@@ -630,6 +658,9 @@ class ModelDrafter(Drafter):
             return None, None, None
 
         # Initial forward pass
+        self.update_cur_draft_layer_idx(
+            0, resource_manager
+        )  # Update the current draft layer index in the resource manager.
         outputs = self.forward_draft_model(draft_batch,
                                            resource_manager,
                                            is_first_draft_token=True,
@@ -652,7 +683,8 @@ class ModelDrafter(Drafter):
             self.guided_decoder.add_batch(draft_batch)
             self.guided_decoder.execute(outputs['logits'],
                                         d2t=outputs.get('d2t'))
-        draft_sample_state = self.sample_async(draft_batch, outputs)
+        draft_sample_state = self.sample_async(draft_batch, outputs,
+                                               resource_manager)
 
         # Update target inputs with first iteration results
         draft_tensors = draft_sample_state and draft_sample_state.device and draft_sample_state.device.new_tokens
@@ -698,6 +730,9 @@ class ModelDrafter(Drafter):
             if draft_batch is None:
                 return
 
+            self.update_cur_draft_layer_idx(
+                0, resource_manager
+            )  # Update the current draft layer index in the resource manager.
             # Initial forward pass. May do the complete drafting loop
             # if use_static_draft_loop is set.
             outputs = self.forward_draft_model(draft_batch,
@@ -713,7 +748,8 @@ class ModelDrafter(Drafter):
                 self.guided_decoder.add_batch(draft_batch)
                 self.guided_decoder.execute(outputs['logits'],
                                             d2t=outputs.get('d2t'))
-            sample_state = self.sample_async(draft_batch, outputs)
+            sample_state = self.sample_async(draft_batch, outputs,
+                                             resource_manager)
             self.update_request_states(draft_batch)
 
             # Execute the iterative draft loop

--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -226,6 +226,7 @@ class MTPSampler(TorchSampler):
         next_new_tokens: torch.Tensor
         next_draft_tokens: torch.Tensor
         new_tokens_lens: torch.Tensor
+        max_total_draft_tokens: torch.Tensor
 
     def create_store(self) -> Store:
         num_tokens, seq_slots, _ = self.NEW_TOKENS_SHAPE
@@ -236,6 +237,7 @@ class MTPSampler(TorchSampler):
             next_new_tokens=int_tensor(self.NEW_TOKENS_SHAPE),
             next_draft_tokens=int_tensor((seq_slots, draft_len)),
             new_tokens_lens=int_tensor((seq_slots, )),
+            max_total_draft_tokens=int_tensor((seq_slots, draft_len)),
         )
 
     def _request_common_handling(self, request: LlmRequest,
@@ -246,7 +248,11 @@ class MTPSampler(TorchSampler):
         request.py_draft_tokens = next_draft_tokens[request.py_seq_slot]
         request.py_decoding_iter += 1
 
-    def update_requests(self, state: SampleStateMTP) -> None:
+    def update_requests(
+            self,
+            state: SampleStateMTP,
+            resource_manager: Optional[BaseResourceManager] = None) -> None:
+        # resource_manager will be not be used in this function
         assert isinstance(state, SampleStateMTP)
 
         state.sampler_event.synchronize()

--- a/tensorrt_llm/_torch/speculative/spec_tree_manager.py
+++ b/tensorrt_llm/_torch/speculative/spec_tree_manager.py
@@ -1,0 +1,166 @@
+from typing import List, Optional
+
+import torch
+
+
+class SpecTreeManager:
+    use_dynamic_tree: bool  # Whether using dynamic tree
+    max_total_draft_tokens: int  # The number of all nodes in the tree (except the root)
+    dynamic_tree_max_topK: int  # If using dynamic tree, the number of nodes to expand each time.
+    max_draft_len: int  # The number of drafter layer. When using linear-tree, the max_draft_len is the same as max_total_draft_tokens.
+    cur_draft_layer_idx: int  # The current index of the drafter layer
+
+    # Auxiliary buffers
+    # The user input eagle choices, only available when using static tree.
+    eagle_choices: Optional[List[List[int]]] = None
+    # If dynamice tree, each request has their own tree. If static tree, all requests share the same tree.
+    num_trees: Optional[int] = None
+
+    # Convert the choice to a path. Each path is an array of indices from the root to other nodes in the tree.
+    # shape: [num_trees, max_total_draft_tokens + 1, max_draft_len + 1]
+    eagle_paths: Optional[torch.Tensor] = None
+
+    # The spec decoding mask.
+    # shape: [num_trees, max_total_draft_tokens + 1, max_total_draft_tokens + 1], include the root node.
+    spec_dec_mask_matrix: Optional[torch.Tensor] = None
+    # shape: [num_trees, max_total_draft_tokens + 1], pad the 0-1 matrix to int32 vector.
+    spec_dec_pack_mask: Optional[torch.Tensor] = None
+
+    def __init__(self, max_num_requests: int, use_dynamic_tree: bool,
+                 max_total_draft_tokens: int, max_draft_len: int,
+                 eagle_choices: [List[List[int]]], dynamic_tree_max_topK: int):
+
+        self.use_dynamic_tree = use_dynamic_tree
+        self.max_total_draft_tokens = max_total_draft_tokens
+        self.max_draft_len = max_draft_len
+        self.eagle_choices = eagle_choices
+        self.num_trees = max_num_requests if use_dynamic_tree else 1
+        self.dynamic_tree_max_topK = dynamic_tree_max_topK
+        self.cur_draft_layer_idx = -1
+
+        # Initialize the buffers
+        self.eagle_paths = torch.ones(
+            (self.num_trees, self.max_total_draft_tokens + 1,
+             self.max_draft_len + 1),
+            dtype=torch.int32,
+            device='cpu',
+            pin_memory=True,
+        ) * -1
+        self.spec_dec_mask_matrix = torch.eye(
+            self.max_total_draft_tokens + 1,
+            dtype=torch.bool,
+            device='cpu',
+            pin_memory=True,
+        ).unsqueeze(0).repeat(self.num_trees, 1, 1)
+        self.spec_dec_pack_mask = torch.zeros(
+            (self.num_trees + 1, self.max_total_draft_tokens + 1),
+            dtype=torch.int32,
+            device='cpu',
+            pin_memory=True,
+        )
+        self.top_k_list = []
+
+        if self.use_dynamic_tree:
+            self.init_tree_info_for_dynamic_tree()
+        else:
+            self.init_tree_info_for_static_tree()
+
+    def init_tree_info_for_dynamic_tree(self):
+        # For the dynamic tree
+        # To the internal layer, the number of nodes is the same as the dynamic_tree_max_topK.
+        self.top_k_list = [
+            torch.ones(self.dynamic_tree_max_topK,
+                       dtype=torch.int32,
+                       device='cpu',
+                       pin_memory=True) * self.dynamic_tree_max_topK
+        ]
+
+    # For the static tree
+    def init_tree_info_for_static_tree(self):
+        index_mapping_set = {}
+        nodes_list_per_layer = [[] for _ in range(self.max_draft_len + 1)]
+        child_nodes_list = [[] for _ in range(self.max_total_draft_tokens + 1)]
+
+        # 1) Map the index
+        for i, choice in enumerate(self.eagle_choices):
+            index_mapping_set[str(choice)] = i + 1
+
+        # 2) Reconstruct the eagle_paths
+        self.eagle_paths.fill_(-1)
+        self.eagle_paths[0][0][0] = 0  # root node
+        for i, choice in enumerate(self.eagle_choices):
+            self.eagle_paths[0][i + 1][0] = 0
+            for j in range(len(choice)):
+                self.eagle_paths[0][i + 1][j + 1] = index_mapping_set[str(
+                    choice[:j + 1])]
+
+        # 3) Compute node_list_per_layer
+        nodes_list_per_layer[0].append(0)  # root node
+        for choice in self.eagle_choices:
+            cur_layer = len(choice)
+            nodes_list_per_layer[cur_layer].append(
+                index_mapping_set[str(choice)])
+
+        # 4) Compute child_nodes_list
+        for choice in self.eagle_choices:
+            if len(choice) == 1:  # root node's children
+                child_nodes_list[0].append(index_mapping_set[str(choice)])
+            else:
+                child_nodes_list[index_mapping_set[str(choice[:-1])]].append(
+                    index_mapping_set[str(choice)])
+
+        # 5) Compute top_k_list
+        for i in range(self.max_draft_len):
+            cur_layer_nodes = nodes_list_per_layer[i]
+            tmp_top_k_list = [
+                len(child_nodes_list[node]) for node in cur_layer_nodes
+                if len(child_nodes_list[node]) > 0
+            ]
+            assert sum(tmp_top_k_list) == len(nodes_list_per_layer[i + 1])
+            self.top_k_list.append(
+                torch.tensor(tmp_top_k_list,
+                             dtype=torch.int32,
+                             device='cpu',
+                             pin_memory=True))
+
+        # 6) Compute the spec decoding according to the eagle_paths
+        for i, path in enumerate(self.eagle_paths[0]):
+            indices = path[path > -1]
+            self.spec_dec_mask_matrix[0][i, indices] = 1
+        self.spec_dec_pack_mask = self.compute_spec_dec_pack_mask(
+            self.spec_dec_mask_matrix)
+
+    # Get the eagle_paths
+    def get_eagle_paths(self, tree_idx=0):
+        if self.use_dynamic_tree:
+            self.eagle_paths[tree_idx].fill_(-1)
+            # If dynamic tree, return the eagle_paths according to the mask.
+            for i in range(self.max_total_draft_tokens + 1):
+                self.eagle_paths[tree_idx][:, i, :] = self.spec_dec_mask_matrix[
+                    tree_idx][i, :].nonzero()
+            return self.eagle_paths[tree_idx]
+        else:
+            # If static tree, return the prepared eagle_paths. These paths are immutable.
+            return self.eagle_paths[0]
+
+    # Get the topK list for the specific draft layer
+    def get_top_k_list(self, draft_layer_id):
+        assert draft_layer_id >= 0
+        return self.top_k_list[draft_layer_id]
+
+    # Compute the packed mask according to the mask matrix
+    def compute_spec_dec_pack_mask(self, mask_matrix):
+        # mask_matrix: shape: [num_trees, max_total_draft_tokens + 1, max_total_draft_tokens + 1]
+        int_tensor = mask_matrix.to(torch.int32)
+        weights = torch.pow(
+            2, torch.arange(mask_matrix.shape[-1], device=mask_matrix.device))
+        packed_mask = torch.sum(int_tensor * weights, dim=-1)
+        return packed_mask
+
+    # Print the tree info
+    def dump_tree_info(self):
+        if not self.use_dynamic_tree:
+            print(f"Static tree: {self.eagle_paths}")
+        print(f"TopK list: {self.top_k_list}")
+        print(f"Spec dec mask matrix: {self.spec_dec_mask_matrix.int()}")
+        print(f"Spec dec pack mask: {self.spec_dec_pack_mask}")

--- a/tensorrt_llm/_torch/speculative/utils.py
+++ b/tensorrt_llm/_torch/speculative/utils.py
@@ -40,20 +40,10 @@ def get_spec_metadata(spec_config,
             eagle3_resource_manager=spec_resource_manager,
             layers_to_capture=spec_config.eagle3_layers_to_capture,
             is_mtp_eagle=False,
-        )
-    if spec_config.spec_dec_mode.is_mtp_eagle():
-        return Eagle3SpecMetadata(
-            max_draft_len=spec_config.max_draft_len,
-            spec_dec_mode=spec_config.spec_dec_mode,
-            max_num_requests=max_num_requests,
-            num_layers=model_config.num_hidden_layers,
-            hidden_size=model_config.hidden_size,
-            max_num_tokens=max_num_tokens,
-            dtype=model_config.torch_dtype,
-            is_draft_model=is_draft_model,
-            eagle3_resource_manager=spec_resource_manager,
-            layers_to_capture=None,
-            is_mtp_eagle=True,
+            max_total_draft_tokens=spec_config.max_total_draft_tokens,
+            eagle_choices=spec_config.eagle_choices,
+            is_spec_dec_tree=spec_config.eagle_choices is not None,
+            is_spec_dec_dynamic_tree=spec_config.use_dynamic_tree,
         )
     if spec_config.spec_dec_mode.is_eagle3_one_model():
         return Eagle3OneModelSpecMetadata(

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1,3 +1,4 @@
+import ast
 import copy
 import functools
 import json
@@ -443,12 +444,68 @@ class EagleDecodingConfig(DecodingBaseConfig):
     eagle_choices: Optional[List[List[int]]] = None
     greedy_sampling: Optional[bool] = True
     posterior_threshold: Optional[float] = None
+    # Whether to use dynamic tree.
     use_dynamic_tree: Optional[bool] = False
+    # The topK value for each layer when enable dynamic tree.
     dynamic_tree_max_topK: Optional[int] = None
+    # The number of draft tokens in the draft tokens tree.
+    max_total_draft_tokens: Optional[int] = None
+    # The number of eagle layer. will not be used in pytorch flow, just for compatibility with TRT flow
     num_eagle_layers: Optional[int] = None
+    # The number of non-leaves in each layer.
     max_non_leaves_per_layer: Optional[int] = None
     eagle3_one_model: Optional[bool] = True
     eagle3_layers_to_capture: Optional[Set[int]] = None
+
+    def __init__(self, **kwargs):
+        super().__init__()
+        for attr_name, attr_value in kwargs.items():
+            if attr_name == 'max_draft_len':
+                self.num_eagle_layers = attr_value
+                self.max_total_draft_tokens = attr_value  # If using linear-tree, the max_total_draft_tokens is the same as max_draft_len
+            # Convert the data type of Eagle choice from str to List[List[int]]
+            if attr_name == 'eagle_choices' and attr_value is not None:
+                logger.warning(
+                    "NOTE: The Draft token tree is still under development, PLEASE DO NOT USE IT !!!"
+                )
+                if not isinstance(attr_value, list):
+                    if isinstance(attr_value, str):
+                        attr_value = ast.literal_eval(
+                            attr_value.replace(" ", ""))
+                    else:
+                        raise ValueError(
+                            "Wrong eagle choices type. Eagle choices should be a List[List[int]] or a string like [[0], [1], [2], [0, 0], [0, 1]]."
+                        )
+            setattr(self, attr_name, attr_value)
+
+        assert self.max_draft_len is not None, "max_draft_len is required for Eagle"
+
+        # Static tree logic
+        # Checks whether the input eagle choices is valid
+        # and reset the max_draft_len and num_eagle_layers if necessary
+        if self.eagle_choices is not None:
+            # If eagle_choices is provided, use_dynamic_tree will not be used
+            assert not self.use_dynamic_tree, "If eagle_choices is provided, use_dynamic_tree need to be False"
+
+            # Get num_eagle_layers from eagle_choices
+            num_eagle_layers_from_choices = self.check_eagle_choices()
+            if num_eagle_layers_from_choices != self.num_eagle_layers:
+                logger.warning(
+                    f"Base on the input choices, reset the num_eagle_layers(max_draft_len) from {self.num_eagle_layers} to {num_eagle_layers_from_choices}"
+                )
+                self.num_eagle_layers = num_eagle_layers_from_choices
+                self.max_draft_len = num_eagle_layers_from_choices
+
+            # Each draft node has a path(choice) from the root to it.
+            # So the number of choices also represents the number of max draft nodes.
+            self.max_total_draft_tokens = len(self.eagle_choices)
+
+        # Dynamic tree logic
+        if self.use_dynamic_tree:
+            assert self.eagle_choices is None, "If use_dynamic_tree is True, eagle_choices should be None"
+            assert self.max_draft_len is not None and self.max_draft_len > 0, "max_draft_len should be provided, which indicates the number of drafter layers"
+            assert self.dynamic_tree_max_topK is not None and self.dynamic_tree_max_topK > 0, "dynamic_tree_max_topK should be provided, which indicates the number of nodes to expand each time"
+            assert self.max_total_draft_tokens is not None and self.max_total_draft_tokens > 0, "max_total_draft_tokens should be provided, which indicates the total nodes of the final draft tree. (exclude the root node)"
 
     @classmethod
     def from_dict(cls, data: dict):
@@ -459,6 +516,25 @@ class EagleDecodingConfig(DecodingBaseConfig):
     def validate(self) -> None:
         if self.speculative_model_dir is None:
             raise ValueError("Draft model must be provided for EAGLE")
+
+    def check_eagle_choices(self):
+        # 1) Check connectivity
+        unique_choices = set(
+            tuple(sub_choice)
+            for sub_choice in self.eagle_choices)  # remove repeated choices
+        self.eagle_choices = sorted([list(t) for t in unique_choices],
+                                    key=lambda x: (len(x), x))  # sort choices
+        for choice in self.eagle_choices:
+            if len(choice) > 1:
+                assert choice[
+                    0:
+                    -1] in self.eagle_choices, f"Error: choice {choice} is not connected"
+
+        # 2) Get num_eagle_layers_from_choices
+        num_eagle_layers_from_choices = max(
+            len(choice) for choice in self.eagle_choices)
+
+        return num_eagle_layers_from_choices
 
     @functools.cached_property
     def spec_dec_mode(self):

--- a/tests/unittest/_torch/speculative/test_draft_token_tree_sampling.py
+++ b/tests/unittest/_torch/speculative/test_draft_token_tree_sampling.py
@@ -1,0 +1,438 @@
+import os
+import sys
+import unittest
+
+import torch
+from utils.llm_data import llm_models_root
+
+from tensorrt_llm import SamplingParams
+from tensorrt_llm._torch.pyexecutor.llm_request import (LlmRequest,
+                                                        SamplingConfig)
+from tensorrt_llm._torch.pyexecutor.sampler import TorchSampler
+from tensorrt_llm._torch.speculative.spec_tree_manager import SpecTreeManager
+from tensorrt_llm.llmapi import EagleDecodingConfig
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+
+def test_draft_token_static_tree_sampling():
+    # Fix parameters
+    models_path = llm_models_root()
+    eagle_model_dir = f"{models_path}/EAGLE3-LLaMA3.1-Instruct-8B"  # It will not actually be used.
+    beam_width = 1
+    use_dynamic_tree = False
+    max_new_tokens = 128
+
+    # Create related object and run test
+    def run_test(max_batch_size, draft_layer_id, max_total_draft_tokens,
+                 max_draft_len, eagle_choices, logits, ref_new_tokens,
+                 num_new_draft_tokens):
+        spec_config = EagleDecodingConfig(
+            max_draft_len=max_draft_len,
+            max_total_draft_tokens=max_total_draft_tokens,
+            speculative_model_dir=eagle_model_dir,
+            eagle3_one_model=False,
+            eagle_choices=eagle_choices,
+            use_dynamic_tree=use_dynamic_tree,
+        )
+        spec_tree_manager = SpecTreeManager(
+            max_num_requests=max_batch_size,
+            use_dynamic_tree=spec_config.use_dynamic_tree,
+            max_draft_len=spec_config.max_draft_len,
+            max_total_draft_tokens=spec_config.max_total_draft_tokens,
+            eagle_choices=spec_config.eagle_choices,
+            dynamic_tree_max_topK=spec_config.dynamic_tree_max_topK,
+        )
+        spec_tree_manager.cur_draft_layer_idx = draft_layer_id
+        torch_sampler = TorchSampler(
+            TorchSampler.Args(
+                max_draft_len=spec_config.max_draft_len,
+                max_seq_len=1024,
+                max_total_draft_tokens=spec_config.max_total_draft_tokens,
+                max_num_sequences=max_batch_size,
+                max_beam_width=beam_width))
+
+        # Prepare tree sampling inputs
+        scheduled_requests = []
+        for req_id in range(max_batch_size):
+            req = LlmRequest(
+                request_id=req_id,
+                max_new_tokens=max_new_tokens,
+                input_tokens=range(req_id * 10, (req_id + 1) * 10),
+                sampling_config=SamplingConfig(
+                    SamplingParams()._get_sampling_config()),
+                is_streaming=False,
+            )
+            scheduled_requests.append(req)
+        seq_slots = torch.tensor(range(max_batch_size),
+                                 dtype=torch.int64,
+                                 device='cuda')
+        new_tokens = torch.zeros((spec_config.max_total_draft_tokens + 1,
+                                  max_batch_size, beam_width),
+                                 dtype=torch.int,
+                                 device='cuda')
+
+        model_outputs = {
+            "logits": logits,
+        }
+
+        new_tokens_host = torch_sampler._tree_sampling_batch(
+            requests=scheduled_requests,
+            max_num_sequences=max_batch_size,
+            seq_slots=seq_slots,
+            model_outputs=model_outputs,
+            spec_tree_manager=spec_tree_manager)
+        new_tokens_host = new_tokens_host.squeeze(dim=-1).transpose(
+            0, 1)  # shape: [max_batch_size, max_total_draft_tokens + 1]
+
+        print(
+            f"new_tokens_host.shape: {new_tokens_host.shape}, new_tokens_host: {new_tokens_host}"
+        )
+        print(
+            f"ref_new_tokens.shape: {ref_new_tokens.shape}, ref_new_tokens: {ref_new_tokens}"
+        )
+
+        assert torch.all(new_tokens_host[:, :num_new_draft_tokens] ==
+                         ref_new_tokens[:, :num_new_draft_tokens])
+
+    ################## CASE 1 static tree, batch size = 1, draft_layer_id = 0 ##########################
+    max_batch_size = 1
+    draft_layer_id = 0
+    max_total_draft_tokens = 12
+    max_draft_len = 3
+    eagle_choices = [[0], [1], [2], [0, 0], [0, 1], [0, 2], [1, 0], [1, 1],
+                     [2, 0], [0, 0, 0], [0, 1, 1], [1, 0, 0]]
+
+    logits = torch.tensor(
+        [
+            [0.1, 1.1, 0.3, 0.4, 1.2, 0.6, 0.7, 0.8, 0.9, 1.0
+             ],  # top3 indices = [4, 1, 9]
+        ],
+        device='cuda')
+    ref_new_tokens = torch.tensor(
+        [
+            [4, 1, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        ], device='cpu')  # shape: [max_batch_size, max_total_draft_tokens + 1]
+    num_new_draft_tokens = 3
+    run_test(max_batch_size, draft_layer_id, max_total_draft_tokens,
+             max_draft_len, eagle_choices, logits, ref_new_tokens,
+             num_new_draft_tokens)
+
+    ################## CASE 2 static tree, batch size = 1, draft_layer_id = 1 ##########################
+    max_batch_size = 1
+    draft_layer_id = 1
+    max_total_draft_tokens = 12
+    max_draft_len = 3
+    eagle_choices = [[0], [1], [2], [0, 0], [0, 1], [0, 2], [1, 0], [1, 1],
+                     [2, 0], [0, 0, 0], [0, 1, 1], [1, 0, 0]]
+
+    logits = torch.tensor(
+        [
+            [0.1, 1.1, 0.3, 0.4, 1.2, 0.6, 0.7, 0.8, 0.9, 1.0
+             ],  # top3 indices = [4, 1, 9]
+            [0.1, 1.1, 0.3, 0.4, 0.6, 0.7, 0.8, 1.2, 0.9, 1.0
+             ],  # top2 indices = [7, 1]
+            [0.1, 1.1, 0.3, 0.4, 0.6, 0.7, 0.8, 0.9, 1.0, 1.2
+             ],  # top1 indices = [9]
+        ],
+        device='cuda')
+    ref_new_tokens = torch.tensor(
+        [
+            [4, 1, 9, 7, 1, 9, 0, 0, 0, 0, 0, 0, 0],
+        ], device='cpu')  # shape: [max_batch_size, max_total_draft_tokens + 1]
+    num_new_draft_tokens = 6
+    run_test(max_batch_size, draft_layer_id, max_total_draft_tokens,
+             max_draft_len, eagle_choices, logits, ref_new_tokens,
+             num_new_draft_tokens)
+
+    ################## CASE 3 static tree, batch size = 1, draft_layer_id = 2 ##########################
+    max_batch_size = 1
+    draft_layer_id = 2
+    max_total_draft_tokens = 12
+    max_draft_len = 3
+    eagle_choices = [[0], [1], [2], [0, 0], [0, 1], [0, 2], [1, 0], [1, 1],
+                     [2, 0], [0, 0, 0], [0, 1, 1], [1, 0, 0]]
+    logits = torch.tensor(
+        [
+            [0.1, 1.1, 0.3, 0.4, 1.2, 0.6, 0.7, 0.8, 0.9, 1.0
+             ],  # top1 indices = [4]
+            [0.1, 1.1, 0.3, 0.4, 0.6, 0.7, 0.8, 1.2, 0.9, 1.0
+             ],  # top1 indices = [7]
+            [0.1, 1.1, 0.3, 0.4, 0.6, 0.7, 0.8, 0.9, 1.0, 1.2
+             ],  # top1 indices = [9]
+        ],
+        device='cuda')
+    ref_new_tokens = torch.tensor(
+        [
+            [4, 7, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        ], device='cpu')  # shape: [max_batch_size, max_total_draft_tokens + 1]
+    num_new_draft_tokens = 3
+    run_test(max_batch_size, draft_layer_id, max_total_draft_tokens,
+             max_draft_len, eagle_choices, logits, ref_new_tokens,
+             num_new_draft_tokens)
+
+    ################## CASE 4 static tree, batch size = 2, draft_layer_id = 0 ##########################
+    max_batch_size = 2
+    draft_layer_id = 0
+    max_total_draft_tokens = 12
+    max_draft_len = 3
+    eagle_choices = [[0], [1], [2], [0, 0], [0, 1], [0, 2], [1, 0], [1, 1],
+                     [2, 0], [0, 0, 0], [0, 1, 1], [1, 0, 0]]
+    logits = torch.tensor(
+        [
+            [0.1, 1.1, 0.3, 0.4, 1.2, 0.6, 0.7, 0.8, 0.9, 1.0
+             ],  # top3 indices = [4, 1, 9]
+            [0.1, 0.3, 1.1, 0.4, 1.2, 0.6, 0.7, 0.8, 0.9, 1.0
+             ],  # top3 indices = [4, 2, 9]
+        ],
+        device='cuda')
+    ref_new_tokens = torch.tensor(
+        [
+            [4, 1, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [4, 2, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        ],
+        device='cpu')  # shape: [max_batch_size, max_total_draft_tokens + 1]
+    num_new_draft_tokens = 3
+    run_test(max_batch_size, draft_layer_id, max_total_draft_tokens,
+             max_draft_len, eagle_choices, logits, ref_new_tokens,
+             num_new_draft_tokens)
+
+    ################## CASE 5 static tree, batch size = 2, draft_layer_id = 1 ##########################
+    max_batch_size = 2
+    draft_layer_id = 1
+    max_total_draft_tokens = 12
+    max_draft_len = 3
+    eagle_choices = [[0], [1], [2], [0, 0], [0, 1], [0, 2], [1, 0], [1, 1],
+                     [2, 0], [0, 0, 0], [0, 1, 1], [1, 0, 0]]
+    logits = torch.tensor(
+        [
+            [0.1, 1.1, 0.3, 0.4, 1.2, 0.6, 0.7, 0.8, 0.9, 1.0
+             ],  # top3 indices = [4, 1, 9]
+            [0.1, 1.1, 0.3, 0.4, 0.6, 0.7, 0.8, 1.2, 0.9, 1.0
+             ],  # top2 indices = [7, 1]
+            [0.1, 1.1, 0.3, 0.4, 0.6, 0.7, 0.8, 0.9, 1.0, 1.2
+             ],  # top1 indices = [9]
+            [0.1, 1.1, 0.3, 0.4, 0.6, 1.2, 0.7, 0.8, 1.0, 0.9
+             ],  # top3 indices = [5, 1, 8]
+            [0.1, 1.1, 0.3, 0.4, 0.6, 0.7, 1.2, 0.8, 0.9, 1.0
+             ],  # top2 indices = [6, 1]
+            [0.1, 1.1, 0.3, 0.4, 0.6, 0.7, 0.8, 0.9, 1.2, 1.0
+             ],  # top1 indices = [8]
+        ],
+        device='cuda')
+    ref_new_tokens = torch.tensor(
+        [
+            [4, 1, 9, 7, 1, 9, 0, 0, 0, 0, 0, 0, 0],
+            [5, 1, 8, 6, 1, 8, 0, 0, 0, 0, 0, 0, 0],
+        ],
+        device='cpu')  # shape: [max_batch_size, max_total_draft_tokens + 1]
+    num_new_draft_tokens = 6
+    run_test(max_batch_size, draft_layer_id, max_total_draft_tokens,
+             max_draft_len, eagle_choices, logits, ref_new_tokens,
+             num_new_draft_tokens)
+
+    ################## CASE 6 static tree, batch size = 2, draft_layer_id = 2 ##########################
+    max_batch_size = 2
+    draft_layer_id = 2
+    max_total_draft_tokens = 12
+    max_draft_len = 3
+    eagle_choices = [[0], [1], [2], [0, 0], [0, 1], [0, 2], [1, 0], [1, 1],
+                     [2, 0], [0, 0, 0], [0, 1, 1], [1, 0, 0]]
+    logits = torch.tensor(
+        [
+            [0.1, 1.1, 0.3, 0.4, 1.2, 0.6, 0.7, 0.8, 0.9, 1.0
+             ],  # top1 indices = [4]
+            [0.1, 1.1, 0.3, 0.4, 0.6, 0.7, 0.8, 1.2, 0.9, 1.0
+             ],  # top1 indices = [7]
+            [0.1, 1.1, 0.3, 0.4, 0.6, 0.7, 0.8, 0.9, 1.0, 1.2
+             ],  # top1 indices = [9]
+            [0.1, 1.1, 0.3, 0.4, 0.6, 1.2, 0.7, 0.8, 0.9, 1.0
+             ],  # top1 indices = [5]
+            [0.1, 1.1, 0.3, 0.4, 0.6, 0.7, 0.8, 0.9, 1.2, 1.0
+             ],  # top1 indices = [8]
+            [1.2, 0.1, 1.1, 0.3, 0.4, 0.6, 0.7, 0.8, 0.9, 1.0
+             ],  # top1 indices = [0]
+        ],
+        device='cuda')
+    ref_new_tokens = torch.tensor(
+        [
+            [4, 7, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [5, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        ],
+        device='cpu')  # shape: [max_batch_size, max_total_draft_tokens + 1]
+    num_new_draft_tokens = 3
+    run_test(max_batch_size, draft_layer_id, max_total_draft_tokens,
+             max_draft_len, eagle_choices, logits, ref_new_tokens,
+             num_new_draft_tokens)
+
+    ################## CASE 7 static tree, batch size = 1, draft_layer_id = 0, bigger tree ##########################
+    max_batch_size = 1
+    draft_layer_id = 0
+    max_total_draft_tokens = 63
+    max_draft_len = 4
+    eagle_choices = [[0], [0, 0], [1], [0, 1], [2], [0, 0, 0], [1, 0], [0, 2],
+                     [3], [0, 3], [4], [0, 4], [2, 0], [0, 5], [0, 0, 1], [5],
+                     [0, 6], [6], [0, 7], [0, 1, 0], [1, 1], [7], [0, 8],
+                     [0, 0, 2], [3, 0], [0, 9], [8], [9], [1, 0, 0], [0, 2, 0],
+                     [1, 2], [0, 0, 3], [4, 0], [2, 1], [0, 0, 4], [0, 0, 5],
+                     [0, 0, 0, 0], [0, 1, 1], [0, 0, 6], [0, 3, 0], [5, 0],
+                     [1, 3], [0, 0, 7], [0, 0, 8], [0, 0, 9], [6, 0], [0, 4, 0],
+                     [1, 4], [7, 0], [0, 1, 2], [2, 0, 0], [3, 1], [2, 2],
+                     [8, 0], [0, 5, 0], [1, 5], [1, 0, 1], [0, 2, 1], [9, 0],
+                     [0, 6, 0], [0, 0, 0, 1], [1, 6], [0, 7, 0]]  # mc_sim_7b_63
+
+    logits = torch.tensor([[
+        1.1, 1.9, 0.7, 0.3, 4.4, 4.3, 4.9, 1.2, 3.9, 4.7, 1.4, 2.5, 3.2, 0.8,
+        2.0, 3.0, 1.8, 2.3, 4.2, 1.3
+    ]],
+                          device='cuda')
+    ref_new_tokens = torch.tensor(
+        [
+            [
+                6, 9, 4, 5, 18, 8, 12, 15, 11, 17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0
+            ],
+        ],
+        device='cpu')  # shape: [max_batch_size, max_total_draft_tokens + 1]
+    num_new_draft_tokens = 10
+    run_test(max_batch_size, draft_layer_id, max_total_draft_tokens,
+             max_draft_len, eagle_choices, logits, ref_new_tokens,
+             num_new_draft_tokens)
+
+    ################## CASE 8 static tree, batch size = 1, draft_layer_id = 0, bigger tree ##########################
+    max_batch_size = 1
+    draft_layer_id = 1
+    max_total_draft_tokens = 63
+    max_draft_len = 4
+    eagle_choices = [[0], [0, 0], [1], [0, 1], [2], [0, 0, 0], [1, 0], [0, 2],
+                     [3], [0, 3], [4], [0, 4], [2, 0], [0, 5], [0, 0, 1], [5],
+                     [0, 6], [6], [0, 7], [0, 1, 0], [1, 1], [7], [0, 8],
+                     [0, 0, 2], [3, 0], [0, 9], [8], [9], [1, 0, 0], [0, 2, 0],
+                     [1, 2], [0, 0, 3], [4, 0], [2, 1], [0, 0, 4], [0, 0, 5],
+                     [0, 0, 0, 0], [0, 1, 1], [0, 0, 6], [0, 3, 0], [5, 0],
+                     [1, 3], [0, 0, 7], [0, 0, 8], [0, 0, 9], [6, 0], [0, 4, 0],
+                     [1, 4], [7, 0], [0, 1, 2], [2, 0, 0], [3, 1], [2, 2],
+                     [8, 0], [0, 5, 0], [1, 5], [1, 0, 1], [0, 2, 1], [9, 0],
+                     [0, 6, 0], [0, 0, 0, 1], [1, 6], [0, 7, 0]]  # mc_sim_7b_63
+
+    logits = torch.tensor([
+        [
+            3.8, 2.5, 1.9, 0.2, 4.5, 0.9, 0.5, 3.9, 4.0, 2.9, 2.7, 0.7, 2.8,
+            2.1, 1.2, 1.4, 3.3, 3.7, 2.4, 5.4
+        ],
+        [
+            3.2, 5.4, 0.1, 4.6, 1.9, 4.8, 3.8, 0.9, 5.3, 3.7, 4.4, 0.4, 4.3,
+            1.3, 0.3, 3.6, 2.5, 6.0, 3.1, 3.9
+        ],
+        [
+            4.1, 2.8, 3.9, 4.2, 5.1, 5.8, 3.7, 1.5, 0.8, 1.4, 2.2, 0.0, 1.9,
+            2.5, 3.2, 0.4, 3.5, 5.0, 2.9, 4.3
+        ],
+        [
+            0.7, 1.4, 0.6, 2.0, 3.0, 0.9, 1.7, 0.0, 3.4, 2.8, 4.7, 3.6, 5.6,
+            4.2, 1.1, 4.5, 1.2, 1.3, 3.9, 3.2
+        ],
+        [
+            3.6, 5.5, 4.0, 6.0, 4.7, 2.3, 5.8, 0.8, 3.2, 0.3, 4.8, 2.1, 0.0,
+            3.1, 0.1, 2.5, 2.2, 5.0, 3.4, 3.9
+        ],
+        [
+            3.3, 3.8, 2.5, 2.4, 6.0, 5.5, 3.6, 0.6, 1.8, 2.6, 4.7, 1.2, 3.9,
+            4.0, 4.8, 5.0, 1.1, 1.9, 0.4, 0.3
+        ],
+        [
+            3.1, 1.7, 0.0, 4.6, 3.7, 3.2, 2.8, 4.7, 2.7, 3.8, 6.0, 4.2, 1.1,
+            3.4, 5.5, 2.1, 2.6, 1.8, 0.1, 1.3
+        ],
+        [
+            3.6, 5.1, 2.3, 5.3, 3.5, 1.8, 2.7, 2.4, 3.2, 3.0, 4.8, 5.9, 2.9,
+            1.4, 5.7, 0.9, 1.0, 1.3, 2.0, 3.9
+        ],
+        [
+            3.9, 0.2, 4.5, 1.5, 1.4, 0.1, 4.3, 0.3, 3.2, 3.4, 0.4, 3.8, 4.8,
+            3.5, 5.6, 1.9, 2.8, 4.1, 1.0, 5.0
+        ],
+        [
+            5.9, 1.8, 3.5, 0.3, 1.7, 2.5, 3.0, 3.3, 2.1, 4.3, 6.0, 0.1, 0.5,
+            0.9, 4.0, 5.4, 1.1, 2.7, 5.3, 3.4
+        ],
+    ],
+                          device='cuda')
+    ref_new_tokens = torch.tensor(
+        [[
+            19,
+            4,
+            8,
+            7,
+            0,
+            17,
+            16,
+            9,
+            12,
+            10,  # top-10
+            17,
+            1,
+            8,
+            5,
+            3,
+            10,
+            12,  # top-7
+            5,
+            4,
+            17,  # top-3
+            12,
+            10,  # top-2
+            3,  # top-1
+            4,  # top-1
+            10,  # top-1
+            11,  # top-1
+            14,  # top-1
+            10,  # top-1
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]],
+        device='cpu')  # shape: [max_batch_size, max_total_draft_tokens + 1]
+    num_new_draft_tokens = 28
+    run_test(max_batch_size, draft_layer_id, max_total_draft_tokens,
+             max_draft_len, eagle_choices, logits, ref_new_tokens,
+             num_new_draft_tokens)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittest/_torch/speculative/test_draft_token_tree_verification.py
+++ b/tests/unittest/_torch/speculative/test_draft_token_tree_verification.py
@@ -1,0 +1,354 @@
+import os
+import sys
+import unittest
+
+import torch
+from utils.llm_data import llm_models_root
+
+from tensorrt_llm import SamplingParams
+from tensorrt_llm._torch.pyexecutor.llm_request import (LlmRequest,
+                                                        SamplingConfig)
+from tensorrt_llm._torch.pyexecutor.sampler import TorchSampler
+from tensorrt_llm._torch.speculative.spec_tree_manager import SpecTreeManager
+from tensorrt_llm.llmapi import EagleDecodingConfig
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+
+def run_test(eagle_model_dir, max_seq_len, beam_width, use_dynamic_tree,
+             max_new_tokens, max_batch_size, input_request, input_new_tokens,
+             draft_layer_id, max_total_draft_tokens, max_draft_len,
+             eagle_choices, ref_num_accepted_draft_tokens, ref_mtokens):
+    spec_config = EagleDecodingConfig(
+        max_draft_len=max_draft_len,
+        max_total_draft_tokens=max_total_draft_tokens,
+        speculative_model_dir=eagle_model_dir,
+        eagle3_one_model=False,
+        eagle_choices=eagle_choices,
+        use_dynamic_tree=use_dynamic_tree,
+    )
+    spec_tree_manager = SpecTreeManager(
+        max_num_requests=max_batch_size,
+        use_dynamic_tree=spec_config.use_dynamic_tree,
+        max_draft_len=spec_config.max_draft_len,
+        max_total_draft_tokens=spec_config.max_total_draft_tokens,
+        eagle_choices=spec_config.eagle_choices,
+        dynamic_tree_max_topK=spec_config.dynamic_tree_max_topK,
+    )
+    spec_tree_manager.cur_draft_layer_idx = draft_layer_id
+    torch_sampler = TorchSampler(
+        TorchSampler.Args(
+            max_seq_len=max_seq_len,
+            max_draft_len=spec_config.max_draft_len,
+            max_total_draft_tokens=spec_config.max_total_draft_tokens,
+            max_num_sequences=max_batch_size,
+            max_beam_width=beam_width,
+        ))
+
+    num_accepted_draft_tokens = torch_sampler._process_draft_tokens_tree(
+        request=input_request,
+        new_tokens=input_new_tokens,
+        spec_tree_manager=spec_tree_manager)
+
+    print(f"num_accepted_draft_tokens: {num_accepted_draft_tokens}")
+    print(f"ref_num_accepted_draft_tokens: {ref_num_accepted_draft_tokens}")
+    print(f"input_request.get_tokens(0): {input_request.get_tokens(0)}")
+    print(f"ref_mtokens: {ref_mtokens}")
+
+    # For draft model, no tokens will be accepted.
+    assert num_accepted_draft_tokens == ref_num_accepted_draft_tokens
+
+    # Check mtokens by calling get_tokens()
+    assert input_request.get_tokens(0) == ref_mtokens
+
+
+# For the draft model, we will not do the tree verification logic, but only add the draft tokens of the previous layer.
+def test_static_tree_verification_for_draft_model():
+    # Fix parameters
+    models_path = llm_models_root()
+    eagle_model_dir = f"{models_path}/EAGLE3-LLaMA3.1-Instruct-8B"  # It will not actually be used.
+    max_seq_len = 1024
+    beam_width = 1
+    use_dynamic_tree = False
+    max_new_tokens = 128
+    max_batch_size = 1  # Each request will call tree_verification separately, so batch_size is always 1.
+
+    # We dn not need to test the case of draft_layer_id = 0, because _update_requests() is one step delay.
+    # And we do not need to extract the root node of in the draft_layer_id = 0.
+
+    ################## CASE 1 static tree, draft model's request, draft_layer_id = 1 ##########################
+    draft_layer_id = 0
+    max_total_draft_tokens = 12
+    max_draft_len = 3
+    eagle_choices = [[0], [1], [2], [0, 0], [0, 1], [0, 2], [1, 0], [1, 1],
+                     [2, 0], [0, 0, 0], [0, 1, 1], [1, 0, 0]]
+
+    input_request = LlmRequest(
+        request_id=0,
+        seq_slot=0,
+        max_new_tokens=max_new_tokens,
+        input_tokens=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        sampling_config=SamplingConfig(SamplingParams()._get_sampling_config()),
+        is_streaming=False,
+    )
+    # shape: [max_total_draft_tokens + 1, max_batch_size, beam_width]
+    input_new_tokens = torch.zeros(max_total_draft_tokens + 1,
+                                   max_batch_size,
+                                   beam_width,
+                                   dtype=torch.int,
+                                   device='cpu')
+    input_new_tokens[:3, 0,
+                     0] = torch.tensor([20, 21, 22
+                                        ])  # The draft tokens of the 1st layer.
+
+    ref_mtokens = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 20, 21, 22]
+
+    run_test(eagle_model_dir=eagle_model_dir,
+             max_seq_len=max_seq_len,
+             beam_width=beam_width,
+             use_dynamic_tree=use_dynamic_tree,
+             max_new_tokens=max_new_tokens,
+             max_batch_size=max_batch_size,
+             input_request=input_request,
+             input_new_tokens=input_new_tokens,
+             draft_layer_id=draft_layer_id,
+             max_draft_len=max_draft_len,
+             max_total_draft_tokens=max_total_draft_tokens,
+             eagle_choices=eagle_choices,
+             ref_num_accepted_draft_tokens=0,
+             ref_mtokens=ref_mtokens)
+
+    ################## CASE 2 static tree, draft model's request, draft_layer_id = 2 ##########################
+    draft_layer_id = 1
+    max_total_draft_tokens = 12
+    max_draft_len = 3
+    eagle_choices = [[0], [1], [2], [0, 0], [0, 1], [0, 2], [1, 0], [1, 1],
+                     [2, 0], [0, 0, 0], [0, 1, 1], [1, 0, 0]]
+
+    input_request = LlmRequest(
+        request_id=0,
+        seq_slot=0,
+        max_new_tokens=max_new_tokens,
+        input_tokens=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        sampling_config=SamplingConfig(SamplingParams()._get_sampling_config()),
+        is_streaming=False,
+    )
+    # shape: [max_total_draft_tokens + 1, max_batch_size, beam_width]
+    input_new_tokens = torch.zeros(max_total_draft_tokens + 1,
+                                   max_batch_size,
+                                   beam_width,
+                                   dtype=torch.int,
+                                   device='cpu')
+    input_new_tokens[:6, 0,
+                     0] = torch.tensor([20, 21, 22, 23, 24, 25
+                                        ])  # The draft tokens of the 2nd layer.
+
+    ref_mtokens = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 20, 21, 22, 23, 24, 25]
+
+    run_test(eagle_model_dir=eagle_model_dir,
+             max_seq_len=max_seq_len,
+             beam_width=beam_width,
+             use_dynamic_tree=use_dynamic_tree,
+             max_new_tokens=max_new_tokens,
+             max_batch_size=max_batch_size,
+             input_request=input_request,
+             input_new_tokens=input_new_tokens,
+             draft_layer_id=draft_layer_id,
+             max_draft_len=max_draft_len,
+             max_total_draft_tokens=max_total_draft_tokens,
+             eagle_choices=eagle_choices,
+             ref_num_accepted_draft_tokens=0,
+             ref_mtokens=ref_mtokens)
+
+    ################## CASE 3 static tree, draft model's request, draft_layer_id = 3 ##########################
+    draft_layer_id = 2
+    max_total_draft_tokens = 12
+    max_draft_len = 3
+    eagle_choices = [[0], [1], [2], [0, 0], [0, 1], [0, 2], [1, 0], [1, 1],
+                     [2, 0], [0, 0, 0], [0, 1, 1], [1, 0, 0]]
+
+    input_request = LlmRequest(
+        request_id=0,
+        seq_slot=0,
+        max_new_tokens=max_new_tokens,
+        input_tokens=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        sampling_config=SamplingConfig(SamplingParams()._get_sampling_config()),
+        is_streaming=False,
+    )
+    # shape: [max_total_draft_tokens + 1, max_batch_size, beam_width]
+    input_new_tokens = torch.zeros(max_total_draft_tokens + 1,
+                                   max_batch_size,
+                                   beam_width,
+                                   dtype=torch.int,
+                                   device='cpu')
+    input_new_tokens[:3, 0,
+                     0] = torch.tensor([26, 27, 28
+                                        ])  # The draft tokens of the 3rd layer.
+
+    ref_mtokens = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 26, 27, 28]
+
+    run_test(eagle_model_dir=eagle_model_dir,
+             max_seq_len=max_seq_len,
+             beam_width=beam_width,
+             use_dynamic_tree=use_dynamic_tree,
+             max_new_tokens=max_new_tokens,
+             max_batch_size=max_batch_size,
+             input_request=input_request,
+             input_new_tokens=input_new_tokens,
+             draft_layer_id=draft_layer_id,
+             max_draft_len=max_draft_len,
+             max_total_draft_tokens=max_total_draft_tokens,
+             eagle_choices=eagle_choices,
+             ref_num_accepted_draft_tokens=0,
+             ref_mtokens=ref_mtokens)
+
+
+# For the target model, we will do the tree verification logic.
+def test_static_tree_verification_for_target_model():
+    # Fix parameters
+    models_path = llm_models_root()
+    eagle_model_dir = f"{models_path}/EAGLE3-LLaMA3.1-Instruct-8B"  # It will not actually be used.
+    max_seq_len = 1024
+    beam_width = 1
+    use_dynamic_tree = False
+    max_new_tokens = 128
+    max_batch_size = 1  # Each request will call tree_verification separately, so batch_size is always 1.
+
+    ################## CASE 1 static tree, target model's request, no draft tokens are accepted ##########################
+    draft_layer_id = 1  # Not be used.
+    max_total_draft_tokens = 12
+    max_draft_len = 3
+    eagle_choices = [[0], [1], [2], [0, 0], [0, 1], [0, 2], [1, 0], [1, 1],
+                     [2, 0], [0, 0, 0], [0, 1, 1], [1, 0, 0]]
+
+    input_request = LlmRequest(
+        request_id=0,
+        seq_slot=0,
+        max_new_tokens=max_new_tokens,
+        input_tokens=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        sampling_config=SamplingConfig(SamplingParams()._get_sampling_config()),
+        is_streaming=False,
+    )
+    input_request.py_draft_tokens = torch.tensor(
+        [11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22],
+        dtype=torch.int,
+        device='cpu')  # all draft tokens
+    # shape: [max_total_draft_tokens + 1, max_batch_size, beam_width]
+    input_new_tokens = torch.tensor(
+        [31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 0],
+        dtype=torch.int,
+        device='cpu').reshape(
+            (max_total_draft_tokens + 1, max_batch_size, beam_width))
+
+    ref_mtokens = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                   31]  # Only accept the top-1 of the first draft layer.
+    ref_num_accepted_draft_tokens = 0
+
+    run_test(eagle_model_dir=eagle_model_dir,
+             max_seq_len=max_seq_len,
+             beam_width=beam_width,
+             use_dynamic_tree=use_dynamic_tree,
+             max_new_tokens=max_new_tokens,
+             max_batch_size=max_batch_size,
+             input_request=input_request,
+             input_new_tokens=input_new_tokens,
+             draft_layer_id=draft_layer_id,
+             max_draft_len=max_draft_len,
+             max_total_draft_tokens=max_total_draft_tokens,
+             eagle_choices=eagle_choices,
+             ref_num_accepted_draft_tokens=ref_num_accepted_draft_tokens,
+             ref_mtokens=ref_mtokens)
+
+    ################## CASE 2 static tree, target model's request, only one path is accepted, not the longest one ##########################
+    draft_layer_id = 1  # Not be used.
+    max_total_draft_tokens = 12
+    max_draft_len = 3
+    eagle_choices = [[0], [1], [2], [0, 0], [0, 1], [0, 2], [1, 0], [1, 1],
+                     [2, 0], [0, 0, 0], [0, 1, 1], [1, 0, 0]]
+
+    input_request = LlmRequest(
+        request_id=0,
+        seq_slot=0,
+        max_new_tokens=max_new_tokens,
+        input_tokens=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        sampling_config=SamplingConfig(SamplingParams()._get_sampling_config()),
+        is_streaming=False,
+    )
+    input_request.py_draft_tokens = torch.tensor(
+        [11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22],
+        dtype=torch.int,
+        device='cpu')  # all draft tokens, [max_total_draft_tokens]
+    # shape: [max_total_draft_tokens + 1, max_batch_size, beam_width]
+    input_new_tokens = torch.tensor(
+        [11, 15, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112
+         ],  # [max_total_draft_tokens + 1]
+        dtype=torch.int,
+        device='cpu').reshape(
+            (max_total_draft_tokens + 1, max_batch_size, beam_width))
+
+    ref_mtokens = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 15, 105]
+    ref_num_accepted_draft_tokens = 2
+
+    run_test(eagle_model_dir=eagle_model_dir,
+             max_seq_len=max_seq_len,
+             beam_width=beam_width,
+             use_dynamic_tree=use_dynamic_tree,
+             max_new_tokens=max_new_tokens,
+             max_batch_size=max_batch_size,
+             input_request=input_request,
+             input_new_tokens=input_new_tokens,
+             draft_layer_id=draft_layer_id,
+             max_draft_len=max_draft_len,
+             max_total_draft_tokens=max_total_draft_tokens,
+             eagle_choices=eagle_choices,
+             ref_num_accepted_draft_tokens=ref_num_accepted_draft_tokens,
+             ref_mtokens=ref_mtokens)
+
+    ################## CASE 3 static tree, target model's request, only one path is accepted, which is also the longest one ##########################
+    draft_layer_id = 1  # Not be used.
+    max_total_draft_tokens = 12
+    max_draft_len = 3
+    eagle_choices = [[0], [1], [2], [0, 0], [0, 1], [0, 2], [1, 0], [1, 1],
+                     [2, 0], [0, 0, 0], [0, 1, 1], [1, 0, 0]]
+
+    input_request = LlmRequest(
+        request_id=0,
+        seq_slot=0,
+        max_new_tokens=max_new_tokens,
+        input_tokens=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        sampling_config=SamplingConfig(SamplingParams()._get_sampling_config()),
+        is_streaming=False,
+    )
+    input_request.py_draft_tokens = torch.tensor(
+        [11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22],
+        dtype=torch.int,
+        device='cpu')  # all draft tokens, [max_total_draft_tokens]
+    # shape: [max_total_draft_tokens + 1, max_batch_size, beam_width]
+    input_new_tokens = torch.tensor(
+        [11, 14, 102, 103, 20, 105, 106, 107, 108, 109, 110, 111, 112
+         ],  # [max_total_draft_tokens + 1]
+        dtype=torch.int,
+        device='cpu').reshape(
+            (max_total_draft_tokens + 1, max_batch_size, beam_width))
+
+    ref_mtokens = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 14, 20, 110]
+    ref_num_accepted_draft_tokens = 3
+
+    run_test(eagle_model_dir=eagle_model_dir,
+             max_seq_len=max_seq_len,
+             beam_width=beam_width,
+             use_dynamic_tree=use_dynamic_tree,
+             max_new_tokens=max_new_tokens,
+             max_batch_size=max_batch_size,
+             input_request=input_request,
+             input_new_tokens=input_new_tokens,
+             draft_layer_id=draft_layer_id,
+             max_draft_len=max_draft_len,
+             max_total_draft_tokens=max_total_draft_tokens,
+             eagle_choices=eagle_choices,
+             ref_num_accepted_draft_tokens=ref_num_accepted_draft_tokens,
+             ref_mtokens=ref_mtokens)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional static-tree speculative decoding for EAGLE3 via a new --eagle_choices CLI option or config; runtime parsing/validation and automatic adjustments to decoding settings and total draft-token limits.
  * Resource-manager-driven SpecTree integration enabling a tree-based drafting path; sampling and drafting flows now accept and propagate a resource manager when available.

* **Tests**
  * New unit tests for static-tree sampling and draft-token verification across layers, batches and large trees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

This RP implements sampling and verification of the draft token static tree.


## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
