### PR TITLE
[TRTLLM-6055][infra] Slurm Test refactor

### DIFF
--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -1,4 +1,4 @@
-@Library(['bloom-jenkins-shared-lib@main', 'trtllm-jenkins-shared-lib@main']) _
+@Library(['bloom-jenkins-shared-lib@dev-yuanjingx-slurm_refactor', 'trtllm-jenkins-shared-lib@main']) _
 
 import java.lang.InterruptedException
 import groovy.transform.Field
@@ -930,8 +930,10 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
                     export resourcePathNode=$resourcePathNode
                     export pytestCommand="$pytestCommand"
                     export NVIDIA_IMEX_CHANNELS=0
+                    export NVIDIA_IMEX_CHANNELS=0
+                    export NVIDIA_VISIBLE_DEVICES=\$(seq -s, 0 \$((\$(nvidia-smi --query-gpu=count -i 0 --format=noheader)-1)))
                     chmod +x $scriptRunNode
-                    srun ${srunArgs.join(" ")} ${scriptRunNode}
+                    srun --kill-on-bad-exit=1 ${srunArgs.join(" ")} ${scriptRunNode}
                 """.replaceAll("(?m)^\\s*", "")
                 pipeline.writeFile(file: scriptLaunchPathLocal, text: scriptContent)
                 Utils.copyFileToRemoteHost(
@@ -2679,7 +2681,7 @@ def launchTestJobs(pipeline, testFilter)
     multiNodesSBSAConfigs = [:]
     def numMultiNodeTests = 9
     multiNodesSBSAConfigs += (1..numMultiNodeTests).collectEntries { i ->
-        ["GB200-8_GPUs-2_Nodes-PyTorch-Post-Merge-${i}".toString(), ["gb200-multi-node", "l0_gb200_multi_nodes", i, numMultiNodeTests, 8, 2]]
+        ["GB200-8_GPUs-2_Nodes-PyTorch-Post-Merge-${i}".toString(), ["gb200-trtllm", "l0_gb200_multi_nodes", i, numMultiNodeTests, 8, 2]]
     }
     fullSet += multiNodesSBSAConfigs.keySet()
 

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -768,7 +768,6 @@ def getPytestBaseCommandLine(
     }
     if (stageName.contains("-Ray-")) {
         testCmdLine += ["--run-ray"]
-        trtllm_utils.llmExecStepWithRetry(pipeline, script: "pip3 install ray[default]")
     }
     if (extraArgs) {
         testCmdLine += extraArgs
@@ -2052,6 +2051,9 @@ def runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config=VANILLA_CO
             trtllm_utils.llmExecStepWithRetry(pipeline, script: "cd ${llmSrc} && sed -i '/^# .*<For CUDA 12\\.9>\$/ {s/^# //; n; s/^/# /}' requirements.txt && cat requirements.txt")
         }
         trtllm_utils.llmExecStepWithRetry(pipeline, script: "cd ${llmSrc} && pip3 install --retries 1 -r requirements-dev.txt")
+        if (stageName.contains("-Ray-")) {
+            trtllm_utils.llmExecStepWithRetry(pipeline, script: "pip3 install ray[default]")
+        }
         if (!skipInstallWheel) {
             trtllm_utils.llmExecStepWithRetry(pipeline, script: "cd ${llmPath} && pip3 install --force-reinstall --no-deps TensorRT-LLM/tensorrt_llm-*.whl")
         }

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -663,7 +663,7 @@ def runLLMTestlistWithAgent(pipeline, platform, testList, config=VANILLA_CONFIG,
             // Workaround to handle the interruption during clean up SLURM resources
             retry(3) {
                 try {
-                    //cleanUpNodeResources(pipeline, cluster, nodeName, slurmJobID)
+                    cleanUpNodeResources(pipeline, cluster, nodeName, slurmJobID)
                 } catch (Exception e) {
                     error "Error during clean up SLURM resources: ${e.getMessage()} and retrying."
                 }
@@ -994,7 +994,7 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
             // Workaround to handle the interruption during clean up SLURM resources
             retry(3) {
                 try {
-                    //cleanUpSlurmResources(pipeline, cluster, jobUID)
+                    cleanUpSlurmResources(pipeline, cluster, jobUID)
                 } catch (Exception e) {
                     error "Error during clean up SLURM resources: ${e.getMessage()} and retrying."
                 }

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -2691,7 +2691,7 @@ def launchTestJobs(pipeline, testFilter)
 
     // multiNodesSBSAConfigs = [
         // Each stage test 1 testcase with 8 GPUs and 2 nodes.
-        // Disable GB200 multi-node testing in L0 pre-merge until the configuration issue is resolved (https://nvbugs/5455140)
+        // Disable GB200 multi-node testing in L0 pre-merge until related issues is resolved (https://nvbugs/5485182, https://nvbugs/5437384)
         // "GB200-8_GPUs-2_Nodes-PyTorch-1": ["gb200-trtllm", "l0_gb200_multi_nodes", 1, 5, 8, 2],
         // "GB200-8_GPUs-2_Nodes-PyTorch-2": ["gb200-trtllm", "l0_gb200_multi_nodes", 2, 5, 8, 2],
         // "GB200-8_GPUs-2_Nodes-PyTorch-3": ["gb200-trtllm", "l0_gb200_multi_nodes", 3, 5, 8, 2],

--- a/jenkins/scripts/slurm_run.sh
+++ b/jenkins/scripts/slurm_run.sh
@@ -7,17 +7,30 @@ trap 'rc=$?; echo "Error in file ${BASH_SOURCE[0]} on line $LINENO: $BASH_COMMAN
 cd $resourcePathNode
 llmSrcNode=$resourcePathNode/TensorRT-LLM/src
 
-# generate .coveragerc in workspace
-coverageConfigFile="$jobWorkspace/.coveragerc"
-cat << EOF > "$coverageConfigFile"
-[run]
-branch = True
-data_file = $jobWorkspace/.coverage.$stageName
-[paths]
-source =
-    $llmSrcNode/tensorrt_llm/
-    ---wheel_path---/tensorrt_llm/
-EOF
+set_value_in_command() {
+    # Parameters
+    local key="$1"
+    local value="$2"
+    local command="$3"
+
+    # Transform the key
+    local placeholder="__PLACEHOLDER_${key}__"
+
+    # Check if placeholder exists
+    if [[ "$command" != *"$placeholder"* ]]; then
+        echo "Error: placeholder '$placeholder' not found in the command" >&2
+        return 1
+    fi
+
+    # Replace all occurrences
+    local result="${command//${placeholder}/${value}}"
+
+    # Return the result
+    echo "$result"
+}
+
+# save job ID in $jobWorkspace/id.txt for later job to retrieve
+echo $SLURM_JOB_ID > $jobWorkspace/slurm_job_id.txt
 
 resultsPath=$jobWorkspace/results
 mkdir -p $resultsPath
@@ -28,6 +41,9 @@ if [ $SLURM_LOCALID -eq 0 ]; then
     python3 --version
     apt-get install -y libffi-dev
     nvidia-smi && nvidia-smi -q && nvidia-smi topo -m
+    if [[ $pytestCommand == *--run-ray* ]]; then
+        pip3 install ray[default]
+    fi
     cd $llmSrcNode && pip3 install --retries 1 -r requirements-dev.txt
     cd $resourcePathNode &&  pip3 install --force-reinstall --no-deps TensorRT-LLM/tensorrt_llm-*.whl
     git config --global --add safe.directory "*"
@@ -40,49 +56,30 @@ else
         sleep 5
     done
 fi
-export CPP_TEST_TIMEOUT_OVERRIDDEN=$pytestTestTimeout
-export LLM_ROOT=$llmSrcNode
-export LLM_MODELS_ROOT=$MODEL_CACHE_DIR
-export UCX_TLS=^gdr_copy
+
 
 llmapiLaunchScript="$llmSrcNode/tensorrt_llm/llmapi/trtllm-llmapi-launch"
 chmod +x $llmapiLaunchScript
 cd $llmSrcNode/tests/integration/defs
-testCmdLines=(
-    "$llmapiLaunchScript"
-    "pytest"
-    "-v"
-    "--timeout-method=thread"
-    "--timeout=$pytestTestTimeout"
-    "--test-list=$testListPathNode"
-    "--waives-file=$waivesListPathNode"
-    "--rootdir $llmSrcNode/tests/integration/defs"
-    "--test-prefix=$stageName"
-    "--splits $splits"
-    "--group $splitId"
-    "--output-dir=$jobWorkspace/"
-    "--csv=$resultsPath/report.csv"
-    "--junit-xml $resultsPath/results.xml"
-    "-o junit_logging=out-err"
-)
-if [ "$perfMode" = "true" ]; then
-    testCmdLines+=(
-        "--perf"
-        "--perf-log-formats csv"
-        "--perf-log-formats yaml"
-    )
-fi
+
+# get trtllm wheel path and add to pytest command
 trtllmWhlPath=$(pip3 show tensorrt_llm | grep Location | cut -d ' ' -f 2)
 trtllmWhlPath=$(echo "$trtllmWhlPath" | sed 's/[[:space:]]+/_/g')
 echo "TRTLLM WHEEL PATH: $trtllmWhlPath"
-sed -i "s|---wheel_path---|$trtllmWhlPath|g" "$coverageConfigFile"
-testCmdLines+=(
-    "--cov=$llmSrcNode/examples/"
-    "--cov=$llmSrcNode/tensorrt_llm/"
-    "--cov=$trtllmWhlPath/tensorrt_llm/"
-    "--cov-report="
-    "--cov-config=$coverageConfigFile"
-)
+pytestCommand=$(set_value_in_command "TRTLLM_WHL_PATH" "$trtllmWhlPath" "$pytestCommand")
+
+# generate .coveragerc in workspace and add file path to pytest command
+cat << EOF > $jobWorkspace/.coveragerc
+[run]
+branch = True
+data_file = $jobWorkspace/.coverage.$stageName
+[paths]
+source =
+    $llmSrcNode/tensorrt_llm/
+    $trtllmWhlPath/tensorrt_llm/
+EOF
+pytestCommand=$(set_value_in_command "coverageConfigFile" "$jobWorkspace/.coveragerc" "$pytestCommand")
+
 containerPipLLMLibPath=$(pip3 show tensorrt_llm | grep "Location" | awk -F ":" '{ gsub(/ /, "", $2); print $2"/tensorrt_llm/libs"}')
 containerPipLLMLibPath=$(echo "$containerPipLLMLibPath" | sed 's/[[:space:]]+/_/g')
 containerLDLibPath=$LD_LIBRARY_PATH
@@ -95,14 +92,40 @@ export LD_LIBRARY_PATH=$containerLDLibPath
 echo "Library Path:"
 echo "$LD_LIBRARY_PATH"
 env | sort
-fullCmd="${testCmdLines[*]}"
-echo "Full Command: $fullCmd"
+
+# echo "Running: $testCase"
+echo "Full Command: $pytestCommand"
+
+# For single node testing
+# Unset Env variables that set by Slurm srun
+# This will disable MPI when run pytest
+# (Disabled since we plan to use sbatch for trtllm slurm jobs)
+ if [ "${SLURM_JOB_NUM_NODES:-1}" -eq 1 ]; then
+     for v in ${!PMI@} ${!PMIX@} ${!MPI@} ${!OMPI@} ${!SLURM@}; do
+         unset "$v"
+     done
+ fi
 
 # Turn off "exit on error" so the following lines always run
 set +e
 trap - ERR
 
-eval $fullCmd
-exitCode=$?
-echo "Rank${SLURM_LOCALID} Pytest exit code: $exitCode"
-exit $exitCode
+eval $pytestCommand
+
+if [ "$perfMode" = "true" ]; then
+    if [[ "$stageName" == *PyTorch* ]]; then
+        basePerfFilename="base_perf_pytorch.csv"
+    else
+        basePerfFilename="base_perf.csv"
+    fi
+    basePerfPath="$llmSrcNode/tests/integration/defs/perf/$basePerfFilename"
+    echo "Check perf result"
+    python3 $llmSrcNode/tests/integration/defs/perf/sanity_perf_check.py \
+        $stageName/perf_script_test_results.csv \
+        $basePerfPath
+    echo "Check perf report"
+    python3 $llmSrcNode/tests/integration/defs/perf/create_perf_comparison_report.py \
+        --output_path $stageName/report.pdf \
+        --files $stageName/perf_script_test_results.csv \
+        $basePerfPath
+fi


### PR DESCRIPTION

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

1. previously multi node testing on slurm is using srun directly, and single node are installing jenkins agent on the node and launch docker container on the node to run the tests. With this PR, both single node and multi node tests are running directly with srun / sbatch
2. Have a shared method to generate pytest command for both slurm job and blossom job.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Unified single- and multi-node test runs with a single launch flow.
  - Automatic coverage config generation and injection into test runs.
  - Enhanced performance reporting with post-run sanity checks and comparison reports.
- Refactor
  - Centralized test command construction and remote launcher execution.
  - Clearer stage names in the pipeline.
  - Default node count changed to 1 for test runs.
- Chores
  - Improved environment setup (library paths, UCX settings) and host reporting.
  - Simplified resource cleanup and orchestration logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->