### PR TITLE
[None][fix] Switch llm api quickstart example location per workflow.

### DIFF
--- a/examples/llm-api/_tensorrt_engine/quickstart_example.py
+++ b/examples/llm-api/_tensorrt_engine/quickstart_example.py
@@ -1,11 +1,17 @@
-from tensorrt_llm import LLM, SamplingParams
+from tensorrt_llm import BuildConfig, SamplingParams
+from tensorrt_llm._tensorrt_engine import LLM  # NOTE the change
 
 
 def main():
 
+    build_config = BuildConfig()
+    build_config.max_batch_size = 256
+    build_config.max_num_tokens = 1024
+
     # Model could accept HF model name, a path to local HF model,
     # or TensorRT Model Optimizer's quantized checkpoints like nvidia/Llama-3.1-8B-Instruct-FP8 on HF.
-    llm = LLM(model="TinyLlama/TinyLlama-1.1B-Chat-v1.0")
+    llm = LLM(model="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+              build_config=build_config)
 
     # Sample prompts.
     prompts = [

--- a/examples/llm-api/quickstart_example.py
+++ b/examples/llm-api/quickstart_example.py
@@ -1,17 +1,11 @@
-from tensorrt_llm import BuildConfig, SamplingParams
-from tensorrt_llm._tensorrt_engine import LLM  # NOTE the change
+from tensorrt_llm import LLM, SamplingParams
 
 
 def main():
 
-    build_config = BuildConfig()
-    build_config.max_batch_size = 256
-    build_config.max_num_tokens = 1024
-
     # Model could accept HF model name, a path to local HF model,
     # or TensorRT Model Optimizer's quantized checkpoints like nvidia/Llama-3.1-8B-Instruct-FP8 on HF.
-    llm = LLM(model="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
-              build_config=build_config)
+    llm = LLM(model="TinyLlama/TinyLlama-1.1B-Chat-v1.0")
 
     # Sample prompts.
     prompts = [


### PR DESCRIPTION
We need to put the quickstart_example.py which use trt flow under _tensorrt_engine folder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Optional build-time configuration exposed for advanced users (BuildConfig) while default initialization remains simplified.
  - Sampling settings can now be provided at generation time via SamplingParams.

- **Refactor**
  - Unified top-level imports for LLM and SamplingParams to streamline usage.

- **Documentation**
  - Quickstart examples updated to show both simplified init and optional build-config workflows and generate(prompts, sampling_params) usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->