### PR TITLE
[None][feat] Add GptOssParser for GPT-OSS model reasoning

### DIFF
--- a/tensorrt_llm/llmapi/reasoning_parser.py
+++ b/tensorrt_llm/llmapi/reasoning_parser.py
@@ -85,17 +85,12 @@ class DeepSeekR1Parser(BaseReasoningParser):
 class GptOssParser(BaseReasoningParser):
     """
     Reasoning parser for GPT-OSS model using Harmony response format.
-    The GPT-OSS model uses channels: 'analysis' for reasoning and 'final' for the response.
-    The pattern appears to be: analysis content followed by 'assistantfinal' then the actual response.
     """
 
     def __init__(self):
-        # Based on the actual response format observed
         self.reasoning_end = "assistantfinal"
         self.in_reasoning = True
-        # State for handling multi-token transitions in streaming
         self.transition_buffer = ""
-        self.looking_for_final = False
 
     def _create_reasoning_end_result(self, content: str,
                                      reasoning_content: str):
@@ -111,9 +106,7 @@ class GptOssParser(BaseReasoningParser):
         return reasoning_parser_result
 
     def parse(self, text: str) -> ReasoningParserResult:
-        # Look for the pattern where analysis ends and final begins
         if self.reasoning_end not in text:
-            # If we find "analysis" at the start, treat as reasoning
             if text.startswith("analysis"):
                 return ReasoningParserResult(True, reasoning_content=text)
             return ReasoningParserResult(True, reasoning_content=text)
@@ -122,39 +115,43 @@ class GptOssParser(BaseReasoningParser):
         reasoning_content = splits[0]
         content = splits[1] if len(splits) > 1 else ""
 
-        # Clean up reasoning content - remove "analysis" prefix if present
         if reasoning_content.startswith("analysis"):
-            reasoning_content = reasoning_content[8:]  # Remove "analysis"
+            reasoning_content = reasoning_content[8:]
 
         reasoning_parser_result = self._create_reasoning_end_result(
             content, reasoning_content)
         return reasoning_parser_result
 
     def parse_delta(self, delta_text: str) -> ReasoningParserResult:
-        # Add to transition buffer for multi-token transition handling
         self.transition_buffer += delta_text
 
-        # Simple approach: if we see "final" token and we're in reasoning mode,
-        # switch to content mode for the next tokens
-        if self.in_reasoning and delta_text == "final":
+        if self.in_reasoning and self.transition_buffer.endswith(
+                "assistantfinal"):
             self.in_reasoning = False
-            # Return empty to signal transition
-            return ReasoningParserResult(False, content="")
+            remaining_content = self.transition_buffer[:-len("assistantfinal")]
+            self.transition_buffer = ""
 
-        # If we just saw "assistant" token, don't output it
-        if self.in_reasoning and delta_text == "assistant":
-            self.looking_for_final = True
-            return ReasoningParserResult(True, reasoning_content="")
+            if remaining_content:
+                clean_remaining = remaining_content
+                if clean_remaining.startswith("analysis"):
+                    clean_remaining = clean_remaining[8:]
+                return ReasoningParserResult(True,
+                                             reasoning_content=clean_remaining)
+            else:
+                return ReasoningParserResult(False, content="")
 
         if self.in_reasoning:
-            # Normal reasoning content
-            clean_delta = delta_text
+            if "assistant" in self.transition_buffer and not self.transition_buffer.endswith(
+                    "assistantfinal"):
+                return ReasoningParserResult(True, reasoning_content="")
+
+            clean_delta = self.transition_buffer
             if clean_delta.startswith("analysis"):
                 clean_delta = clean_delta[8:]
 
+            self.transition_buffer = ""
             return ReasoningParserResult(True, reasoning_content=clean_delta)
 
-        # not self.in_reasoning - we're in final content mode
         return ReasoningParserResult(False, content=delta_text)
 
 

--- a/tensorrt_llm/llmapi/reasoning_parser.py
+++ b/tensorrt_llm/llmapi/reasoning_parser.py
@@ -81,9 +81,86 @@ class DeepSeekR1Parser(BaseReasoningParser):
         return ReasoningParserResult(self.in_reasoning, content=delta_text)
 
 
+class GptOssParser(BaseReasoningParser):
+    """
+    Reasoning parser for GPT-OSS model using Harmony response format.
+    The GPT-OSS model uses channels: 'analysis' for reasoning and 'final' for the response.
+    The pattern appears to be: analysis content followed by 'assistantfinal' then the actual response.
+    """
+
+    def __init__(self):
+        # Based on the actual response format observed
+        self.reasoning_end = "assistantfinal"
+        self.in_reasoning = True
+        # State for handling multi-token transitions in streaming
+        self.transition_buffer = ""
+        self.looking_for_final = False
+
+    def _create_reasoning_end_result(self, content: str,
+                                     reasoning_content: str):
+        if len(content) == 0:
+            reasoning_parser_result = ReasoningParserResult(
+                True, reasoning_content=reasoning_content)
+        elif len(reasoning_content) == 0:
+            reasoning_parser_result = ReasoningParserResult(False,
+                                                            content=content)
+        else:
+            reasoning_parser_result = ReasoningParserResult(
+                False, content=content, reasoning_content=reasoning_content)
+        return reasoning_parser_result
+
+    def parse(self, text: str) -> ReasoningParserResult:
+        # Look for the pattern where analysis ends and final begins
+        if self.reasoning_end not in text:
+            # If we find "analysis" at the start, treat as reasoning
+            if text.startswith("analysis"):
+                return ReasoningParserResult(True, reasoning_content=text)
+            return ReasoningParserResult(True, reasoning_content=text)
+
+        splits = text.split(self.reasoning_end, 1)
+        reasoning_content = splits[0]
+        content = splits[1] if len(splits) > 1 else ""
+
+        # Clean up reasoning content - remove "analysis" prefix if present
+        if reasoning_content.startswith("analysis"):
+            reasoning_content = reasoning_content[8:]  # Remove "analysis"
+
+        reasoning_parser_result = self._create_reasoning_end_result(
+            content, reasoning_content)
+        return reasoning_parser_result
+
+    def parse_delta(self, delta_text: str) -> ReasoningParserResult:
+        # Add to transition buffer for multi-token transition handling
+        self.transition_buffer += delta_text
+
+        # Simple approach: if we see "final" token and we're in reasoning mode,
+        # switch to content mode for the next tokens
+        if self.in_reasoning and delta_text == "final":
+            self.in_reasoning = False
+            # Return empty to signal transition
+            return ReasoningParserResult(False, content="")
+
+        # If we just saw "assistant" token, don't output it
+        if self.in_reasoning and delta_text == "assistant":
+            self.looking_for_final = True
+            return ReasoningParserResult(True, reasoning_content="")
+
+        if self.in_reasoning:
+            # Normal reasoning content
+            clean_delta = delta_text
+            if clean_delta.startswith("analysis"):
+                clean_delta = clean_delta[8:]
+
+            return ReasoningParserResult(True, reasoning_content=clean_delta)
+
+        # not self.in_reasoning - we're in final content mode
+        return ReasoningParserResult(False, content=delta_text)
+
+
 class ReasoningParserFactory:
     parsers: Dict[str, BaseReasoningParser] = {
         "deepseek-r1": DeepSeekR1Parser,
+        "gpt-oss": GptOssParser,
     }
 
     @staticmethod

--- a/tensorrt_llm/llmapi/reasoning_parser.py
+++ b/tensorrt_llm/llmapi/reasoning_parser.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Dict, Optional


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added support for GPT-OSS/Harmony-style reasoning streams, enabling compatibility with additional models.
  - Improved streaming behavior with smooth transitions from reasoning to final answers.
  - Cleaner display by trimming leading “analysis” prefixes from reasoning output.
  - Clear separation of reasoning content and final responses, including edge cases with empty segments.
  - Automatic selection via the “gpt-oss” model alias for seamless integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>