### PR TITLE
[TRTLLM-6794][feat] enable rejection sampler for ngram

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -353,6 +353,7 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
         # If the request is a draft request, target_seq_slot is the sequence slot ID of its target request.
         self.py_target_seq_slot = target_seq_slot
         self.use_draft_model = is_draft
+        self.py_has_ngram_spec_tokens = False
 
         # TODO: remove this when use DynamicDecodeOp in pytorch flow.
         # currently, keep py_stop_words_list as python list, rather than tensor.

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -397,6 +397,53 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
         self.state = LlmRequestState.GENERATION_COMPLETE
         self.set_finished_reason(reason, beam)
 
+    def clone(self):
+        return LlmRequest(
+            request_id=self.py_request_id,
+            max_num_tokens=self.max_num_tokens,
+            input_tokens=self.input_tokens,
+            sampling_config=self.sampling_config,
+            is_streaming=self.is_streaming,
+            end_id=self.end_id,
+            pad_id=self.pad_id,
+            embedding_bias=self.embedding_bias,
+            bad_words_list=self.bad_words_list,
+            stop_words_list=self.stop_words_list,
+            prompt_embedding_table=self.prompt_embedding_table,
+            prompt_vocab_size=self.prompt_vocab_size,
+            multimodal_hashes=self.multimodal_hashes,
+            multimodal_positions=self.multimodal_positions,
+            multimodal_lengths=self.multimodal_lengths,
+            multimodal_embedding=self.multimodal_embedding,
+            lora_task_id=self.lora_task_id,
+            lora_weights=self.lora_weights,
+            lora_config=self.lora_config,
+            py_lora_path=self.py_lora_path,
+            mrope_rotary_cos_sin=self.mrope_rotary_cos_sin,
+            mrope_position_deltas=self.mrope_position_deltas,
+            lookahead_config=self.lookahead_config,
+            return_log_probs=self.return_log_probs,
+            return_context_logits=self.return_context_logits,
+            return_generation_logits=self.return_generation_logits,
+            return_perf_metrics=self.return_perf_metrics,
+            exclude_last_generation_logits=self.exclude_last_generation_logits,
+            draft_tokens=self.draft_tokens,
+            draft_logits=self.draft_logits,
+            exclude_input_from_output=self.exclude_input_from_output,
+            logits_post_processor=self.logits_post_processor,
+            apply_logits_post_processor_batched=self.
+            apply_logits_post_processor_batched,
+            guided_decoding_params=self.guided_decoding_params,
+            py_logits_post_processors=self.py_logits_post_processors,
+            encoder_input_tokens=self.encoder_input_tokens,
+            return_encoder_output=self.return_encoder_output,
+            client_id=self.client_id,
+            priority=self.priority,
+            llm_request_type=self.llm_request_type,
+            context_phase_params=self.context_phase_params,
+            py_multimodal_data=self.py_multimodal_data,
+            seq_slot=self.py_seq_slot)
+
     def create_child_request(self, child_id):
         child = super().create_child_request(child_id)
         py_request = LlmRequest(llm_request=child)

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -397,53 +397,6 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
         self.state = LlmRequestState.GENERATION_COMPLETE
         self.set_finished_reason(reason, beam)
 
-    def clone(self):
-        return LlmRequest(
-            request_id=self.py_request_id,
-            max_num_tokens=self.max_num_tokens,
-            input_tokens=self.input_tokens,
-            sampling_config=self.sampling_config,
-            is_streaming=self.is_streaming,
-            end_id=self.end_id,
-            pad_id=self.pad_id,
-            embedding_bias=self.embedding_bias,
-            bad_words_list=self.bad_words_list,
-            stop_words_list=self.stop_words_list,
-            prompt_embedding_table=self.prompt_embedding_table,
-            prompt_vocab_size=self.prompt_vocab_size,
-            multimodal_hashes=self.multimodal_hashes,
-            multimodal_positions=self.multimodal_positions,
-            multimodal_lengths=self.multimodal_lengths,
-            multimodal_embedding=self.multimodal_embedding,
-            lora_task_id=self.lora_task_id,
-            lora_weights=self.lora_weights,
-            lora_config=self.lora_config,
-            py_lora_path=self.py_lora_path,
-            mrope_rotary_cos_sin=self.mrope_rotary_cos_sin,
-            mrope_position_deltas=self.mrope_position_deltas,
-            lookahead_config=self.lookahead_config,
-            return_log_probs=self.return_log_probs,
-            return_context_logits=self.return_context_logits,
-            return_generation_logits=self.return_generation_logits,
-            return_perf_metrics=self.return_perf_metrics,
-            exclude_last_generation_logits=self.exclude_last_generation_logits,
-            draft_tokens=self.draft_tokens,
-            draft_logits=self.draft_logits,
-            exclude_input_from_output=self.exclude_input_from_output,
-            logits_post_processor=self.logits_post_processor,
-            apply_logits_post_processor_batched=self.
-            apply_logits_post_processor_batched,
-            guided_decoding_params=self.guided_decoding_params,
-            py_logits_post_processors=self.py_logits_post_processors,
-            encoder_input_tokens=self.encoder_input_tokens,
-            return_encoder_output=self.return_encoder_output,
-            client_id=self.client_id,
-            priority=self.priority,
-            llm_request_type=self.llm_request_type,
-            context_phase_params=self.context_phase_params,
-            py_multimodal_data=self.py_multimodal_data,
-            seq_slot=self.py_seq_slot)
-
     def create_child_request(self, child_id):
         child = super().create_child_request(child_id)
         py_request = LlmRequest(llm_request=child)

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -975,7 +975,13 @@ class PyExecutor:
                                 for req in scheduled_batch.generation_requests:
                                     if req.py_request_id not in generation_request_mapping:
                                         generation_request_mapping[
-                                            req.py_request_id] = req.clone()
+                                            req.py_request_id] = LlmRequest(
+                                                llm_request=req,
+                                                stop_words_list=req.
+                                                py_stop_words_list,
+                                                seq_slot=req.py_seq_slot,
+                                                target_seq_slot=req.
+                                                py_target_seq_slot)
                                         generation_request_mapping[
                                             req.
                                             py_request_id].sampling_config = SamplingConfig(
@@ -986,7 +992,13 @@ class PyExecutor:
                                 for req in scheduled_batch.context_requests:
                                     if req.py_request_id not in context_request_mapping:
                                         context_request_mapping[
-                                            req.py_request_id] = req.clone()
+                                            req.py_request_id] = LlmRequest(
+                                                llm_request=req,
+                                                stop_words_list=req.
+                                                py_stop_words_list,
+                                                seq_slot=req.py_seq_slot,
+                                                target_seq_slot=req.
+                                                py_target_seq_slot)
                                         context_request_mapping[
                                             req.
                                             py_request_id].sampling_config = SamplingConfig(

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -493,7 +493,7 @@ class TorchSampler(Sampler):
 
     def _process_draft_tokens_rejection_sampling(
             self, request: LlmRequest, new_tokens: torch.Tensor) -> int:
-        if request.py_draft_logits:
+        if request.py_draft_logits is None:
             draft_probs = torch.zeros(len(request.py_draft_tokens),
                                       request.py_target_probs.shape[-1],
                                       device=request.py_target_probs.device)
@@ -545,8 +545,8 @@ class TorchSampler(Sampler):
     def process_draft_tokens(self, request: LlmRequest,
                              new_tokens: torch.Tensor) -> int:
         # If the request has ngram spec tokens and the strategy is not greedy, use rejection sampling to get higher draft acceptance rate.
-        if request.py_has_ngram_spec_tokens and request_strategy(
-                request) != Strategy.GREEDY:
+        if request.py_has_ngram_spec_tokens and request_strategy(request) != (
+                "greedy", None):
             return self._process_draft_tokens_rejection_sampling(
                 request, new_tokens)
         if request.py_draft_logits is None:

--- a/tensorrt_llm/_torch/speculative/drafter.py
+++ b/tensorrt_llm/_torch/speculative/drafter.py
@@ -16,6 +16,7 @@ class Drafter(ABC):
     def prepare_draft_tokens(
         self,
         scheduled_requests: ScheduledRequests,
+        request_mapping: Optional[dict[int, LlmRequest]] = None,
         resource_manager: Optional[ResourceManager] = None,
     ) -> None:
         """

--- a/tensorrt_llm/_torch/speculative/model_drafter.py
+++ b/tensorrt_llm/_torch/speculative/model_drafter.py
@@ -347,7 +347,7 @@ class ModelDrafter(Drafter):
     def prepare_draft_tokens(
         self,
         scheduled_requests: ScheduledRequests,
-        request_mapping: dict[int, LlmRequest],
+        request_mapping: Optional[dict[int, LlmRequest]] = None,
         resource_manager: Optional[ResourceManager] = None,
     ) -> None:
         """

--- a/tensorrt_llm/_torch/speculative/model_drafter.py
+++ b/tensorrt_llm/_torch/speculative/model_drafter.py
@@ -347,6 +347,7 @@ class ModelDrafter(Drafter):
     def prepare_draft_tokens(
         self,
         scheduled_requests: ScheduledRequests,
+        request_mapping: dict[int, LlmRequest],
         resource_manager: Optional[ResourceManager] = None,
     ) -> None:
         """

--- a/tensorrt_llm/_torch/speculative/ngram.py
+++ b/tensorrt_llm/_torch/speculative/ngram.py
@@ -177,6 +177,7 @@ class NGramDrafter(Drafter):
     def prepare_draft_tokens(
         self,
         scheduled_requests: ScheduledRequests,
+        request_mapping: dict[int, LlmRequest],
         resource_manager: Optional[ResourceManager] = None,
     ) -> None:
         # Sort by request_id when py_batch_idx is None as a fallback.
@@ -188,7 +189,7 @@ class NGramDrafter(Drafter):
             (r.py_batch_idx is None, r.py_batch_idx or r.request_id),
         ):
             # Add new token to a copy of the generated tokens to find new draft tokens
-            prefix = list(request.get_tokens(0))  # Get a copy
+            prefix = list(request_mapping[request.py_request_id].get_tokens(0))
 
             # Generate draft tokens
             draft_tokens = self.spec_resource_manager.get_draft_tokens(
@@ -203,3 +204,5 @@ class NGramDrafter(Drafter):
                 pad_length = self.max_draft_len - len(draft_tokens)
                 draft_tokens.extend([0] * pad_length)
             request.py_draft_tokens = draft_tokens
+            request_mapping[
+                request.py_request_id].py_draft_tokens = draft_tokens


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Adds an optional n-gram–based speculative decoding mode with a follow-up greedy sampling pass for enhanced draft generation.
  - Enables draft token preparation across both standard and pipelined execution paths when the mode is active.

- Bug Fixes
  - Enforces a single sampling strategy when mixed sampling is disabled, preventing inconsistent results.
  - Uses an isolated temporary buffer for new tokens during sampling to avoid cross-request interference and improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
