### PR TITLE
[None][fix] fix get_iteration_stats IndexError

### DIFF
--- a/tensorrt_llm/llmapi/utils.py
+++ b/tensorrt_llm/llmapi/utils.py
@@ -355,11 +355,33 @@ class AsyncQueue:
         if self._tainted:
             raise AsyncQueue.MixedSyncAsyncAPIError()
 
-        if timeout is None or timeout > 0:
-            # This may raise asyncio.TimeoutError
-            await asyncio.wait_for(self._event.wait(), timeout=timeout)
-        elif not self._q:
-            raise asyncio.QueueEmpty()
+        # Non-blocking path: timeout <= 0.
+        if timeout is not None and timeout <= 0:
+            if not self._q:
+                raise asyncio.QueueEmpty()
+            res = self._q.popleft()
+            if not self._q:
+                self._event.clear()
+            return res
+
+        # Blocking path: timeout is None (wait indefinitely) or > 0 (timed wait, retry with remaining time).
+        if timeout is None:
+            # Wait indefinitely until the queue is non-empty.
+            # It is necessary to check if the queue is empty after awakened.
+            # Because multiple waiting coroutines may be awakened simultaneously when a new item entries empty queue.
+            # These coroutines will all pop this item from queue, and then raise IndexError.
+            while not self._q:
+                await self._event.wait()
+        else:
+            # Compute the deadline; if the queue is still empty after waking, continue waiting for the remaining time.
+            loop = asyncio.get_running_loop()
+            deadline = loop.time() + timeout
+            while not self._q:
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    raise asyncio.TimeoutError()
+                # This may raise asyncio.TimeoutError.
+                await asyncio.wait_for(self._event.wait(), timeout=remaining)
 
         res = self._q.popleft()
         if not self._q:

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -300,8 +300,12 @@ class OpenAIServer:
 
     async def get_iteration_stats(self) -> JSONResponse:
         stats = []
-        async for stat in self.llm.get_stats_async(2):
-            stats.append(stat)
+        try:
+            async for stat in self.llm.get_stats_async(2):
+                stats.append(stat)
+        except IndexError:
+            # queue is empty, no more events
+            pass
         return JSONResponse(content=stats)
 
     async def get_perf_metrics(self) -> JSONResponse:

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -300,12 +300,8 @@ class OpenAIServer:
 
     async def get_iteration_stats(self) -> JSONResponse:
         stats = []
-        try:
-            async for stat in self.llm.get_stats_async(2):
-                stats.append(stat)
-        except IndexError:
-            # queue is empty, no more stats
-            pass
+        async for stat in self.llm.get_stats_async(2):
+            stats.append(stat)
         return JSONResponse(content=stats)
 
     async def get_perf_metrics(self) -> JSONResponse:

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -304,7 +304,7 @@ class OpenAIServer:
             async for stat in self.llm.get_stats_async(2):
                 stats.append(stat)
         except IndexError:
-            # queue is empty, no more events
+            # queue is empty, no more stats
             pass
         return JSONResponse(content=stats)
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - More reliable timeout behavior when waiting for results, reducing sporadic timeouts or hangs.
  - Non-blocking fetches now consistently return immediately when no data is available.
  - Readiness signals are correctly reset when queues become empty, improving stability.

- Refactor
  - Clarifies retrieval into explicit non-blocking, indefinite-wait, and timed-wait modes for more predictable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
