### PR TITLE
[None][feat] Add logging for OAI disagg server

### DIFF
--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -457,10 +457,14 @@ def serve_encoder(model: str, host: str, port: int, log_level: str,
               type=click.Choice(severity_map.keys()),
               default='info',
               help="The logging level.")
+@click.option("--metrics-log-interval",
+              type=int,
+              default=30,
+              help="The interval of logging metrics in seconds")
 def disaggregated(config_file: Optional[str],
                   metadata_server_config_file: Optional[str],
                   server_start_timeout: int, request_timeout: int,
-                  log_level: str):
+                  log_level: str, metrics_log_interval: int):
     """Running server in disaggregated mode"""
 
     logger.set_level(log_level)
@@ -473,7 +477,8 @@ def disaggregated(config_file: Optional[str],
     server = OpenAIDisaggServer(config=disagg_cfg,
                                 req_timeout_secs=request_timeout,
                                 server_start_timeout_secs=server_start_timeout,
-                                metadata_server_cfg=metadata_server_cfg)
+                                metadata_server_cfg=metadata_server_cfg,
+                                metrics_interval_secs=metrics_log_interval)
 
     asyncio.run(server(disagg_cfg.hostname, disagg_cfg.port))
 

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -457,10 +457,13 @@ def serve_encoder(model: str, host: str, port: int, log_level: str,
               type=click.Choice(severity_map.keys()),
               default='info',
               help="The logging level.")
-@click.option("--metrics-log-interval",
-              type=int,
-              default=30,
-              help="The interval of logging metrics in seconds")
+@click.option(
+    "--metrics-log-interval",
+    type=int,
+    default=0,
+    help=
+    "The interval of logging metrics in seconds. Set to 0 to disable metrics logging."
+)
 def disaggregated(config_file: Optional[str],
                   metadata_server_config_file: Optional[str],
                   server_start_timeout: int, request_timeout: int,

--- a/tensorrt_llm/llmapi/disagg_utils.py
+++ b/tensorrt_llm/llmapi/disagg_utils.py
@@ -51,7 +51,7 @@ class DisaggServerConfig():
     ctx_router_config: Optional[RouterConfig] = None
     gen_router_config: Optional[RouterConfig] = None
     conditional_disagg_config: Optional[ConditionalDisaggConfig] = None
-    max_retries: int = 3
+    max_retries: int = 1
     perf_metrics_max_requests: int = 0
 
 
@@ -91,7 +91,7 @@ def parse_disagg_config_file(yaml_config_file: str):
 
 def extract_disagg_cfg(hostname: str = 'localhost',
                        port: int = 8000,
-                       max_retries: int = 3,
+                       max_retries: int = 1,
                        perf_metrics_max_requests: int = 0,
                        context_servers: Optional[dict] = None,
                        generation_servers: Optional[dict] = None,

--- a/tensorrt_llm/serve/openai_disagg_server.py
+++ b/tensorrt_llm/serve/openai_disagg_server.py
@@ -111,7 +111,8 @@ class OpenAIDisaggServer:
                 await self.gen_router.start_server_monitoring(metadata_server_cfg.refresh_interval)
 
             # Start periodic metrics logging
-            self._metrics_task = asyncio.create_task(self._log_metrics_periodically(self.metrics_interval_secs))
+            if self.metrics_interval_secs > 0:
+                self._metrics_task = asyncio.create_task(self._log_metrics_periodically(self.metrics_interval_secs))
 
             yield
 
@@ -139,8 +140,9 @@ class OpenAIDisaggServer:
         self.register_routes()
 
     async def _increment_metric(self, key: str, amount: int = 1):
-        async with self._metrics_lock:
-            self._metrics[key] += amount
+        if self.metrics_interval_secs > 0:
+            async with self._metrics_lock:
+                self._metrics[key] += amount
 
     async def _get_metrics_snapshot(self):
         async with self._metrics_lock:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable metrics logging for disaggregated serving via a new --metrics-log-interval option (seconds; 0 disables), with periodic metrics output.
* **Bug Fixes**
  * Requests now return HTTP 500 on retry exhaustion instead of 429.
  * Streaming responses emit a correct [DONE] sentinel.
* **Chores**
  * Reduced default retry attempts from 3 to 1 for faster failure feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
