### PR TITLE
[TRTLLM-7385][feat] Optimize Qwen2/2.5-VL performance

### DIFF
--- a/examples/llm-api/quickstart_multimodal.py
+++ b/examples/llm-api/quickstart_multimodal.py
@@ -300,6 +300,14 @@ def main():
         prompt = args.prompt[i]
         generated_text = output.outputs[0].text
         print(f"[{i}] Prompt: {prompt!r}, Generated text: {generated_text!r}")
+        if args.return_context_logits:
+            print(f"[{i}] Context logits: {output.context_logits}")
+        if args.return_generation_logits:
+            print(
+                f"[{i}] Generation logits: {output.outputs[0].generation_logits}"
+            )
+        if args.logprobs:
+            print(f"[{i}] Logprobs: {output.outputs[0].logprobs}")
 
 
 if __name__ == "__main__":

--- a/tensorrt_llm/_torch/attention_backend/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/interface.py
@@ -511,6 +511,9 @@ class PositionalEmbeddingParams:
     rope: Optional[RopeParams] = None
     is_neox: bool = True
 
+    # mRoPE params (currently, Qwen2/2.5-VL uses it)
+    mrope_section: Optional[List[int]] = None
+
     def __post_init__(self) -> None:
         if self.type.is_deferred():
             assert self.embedder is not None, f"{self.type} requires a not-none external embedder"

--- a/tensorrt_llm/_torch/models/checkpoints/__init__.py
+++ b/tensorrt_llm/_torch/models/checkpoints/__init__.py
@@ -6,6 +6,7 @@ from .hf.llama4_weight_mapper import Llama4HfWeightMapper
 from .hf.mixtral_weight_mapper import MixtralHfWeightMapper
 from .hf.nemotron_h_weight_mapper import NemotronHHfWeightMapper
 from .hf.qwen2_moe_weight_mapper import Qwen2MoeHfWeightMapper
+from .hf.qwen2vl_weight_mapper import Qwen2VLHfWeightMapper
 from .hf.qwen3_moe_weight_mapper import Qwen3MoeHfWeightMapper
 from .hf.weight_loader import HfWeightLoader
 from .hf.weight_mapper import HfWeightMapper
@@ -14,5 +15,5 @@ __all__ = [
     "HfConfigLoader", "HfWeightLoader", "HfWeightMapper",
     "BaseCheckpointLoader", "HfCheckpointLoader", "NemotronHHfWeightMapper",
     "Gemma3HfWeightMapper", "MixtralHfWeightMapper", "Llama4HfWeightMapper",
-    "Qwen2MoeHfWeightMapper", "Qwen3MoeHfWeightMapper"
+    "Qwen2MoeHfWeightMapper", "Qwen3MoeHfWeightMapper", "Qwen2VLHfWeightMapper"
 ]

--- a/tensorrt_llm/_torch/models/checkpoints/hf/qwen2vl_weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/qwen2vl_weight_mapper.py
@@ -12,9 +12,10 @@ class Qwen2VLHfWeightMapper(HfWeightMapper):
 
     def filter_weights(self, prefix: str, weights: dict) -> dict:
         transformed_weights = {}
+        language_model_prefix = "model.language_model."
         for key, value in weights.items():
-            if key.startswith("model.language_model."):
-                new_key = "model." + key[len("model.language_model."):]
+            if key.startswith(language_model_prefix):
+                new_key = "model." + key[len(language_model_prefix):]
                 transformed_weights[new_key] = value
             else:
                 transformed_weights[key] = value

--- a/tensorrt_llm/_torch/models/checkpoints/hf/qwen2vl_weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/qwen2vl_weight_mapper.py
@@ -1,0 +1,21 @@
+from tensorrt_llm._torch.models.checkpoints.hf.weight_mapper import \
+    HfWeightMapper
+from tensorrt_llm._torch.models.modeling_utils import register_mapper
+
+
+@register_mapper("HF", "Qwen2VLForConditionalGeneration")
+class Qwen2VLHfWeightMapper(HfWeightMapper):
+    """
+    Weight mapper for Qwen2VLForConditionalGeneration that handles the
+    'language_model.' prefix removal from weight keys.
+    """
+
+    def filter_weights(self, prefix: str, weights: dict) -> dict:
+        transformed_weights = {}
+        for key, value in weights.items():
+            if key.startswith("model.language_model."):
+                new_key = "model." + key[len("model.language_model."):]
+                transformed_weights[new_key] = value
+            else:
+                transformed_weights[key] = value
+        return super().filter_weights(prefix, transformed_weights)

--- a/tensorrt_llm/_torch/models/modeling_gpt_oss.py
+++ b/tensorrt_llm/_torch/models/modeling_gpt_oss.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional
 
 import torch
 from torch import nn
@@ -498,7 +498,6 @@ class Transformer(DecoderModel):
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         spec_metadata: Optional[SpecMetadata] = None,
-        mrope_config: Optional[Tuple[torch.Tensor, int]] = None,
         **kwargs,
     ) -> torch.Tensor:
         if (input_ids is None) ^ (inputs_embeds is not None):
@@ -515,7 +514,6 @@ class Transformer(DecoderModel):
                 hidden_states=hidden_states,
                 attn_metadata=attn_metadata,
                 residual=residual,
-                mrope_config=mrope_config,
                 spec_metadata=spec_metadata,
             )
 

--- a/tensorrt_llm/_torch/models/modeling_hunyuan_moe.py
+++ b/tensorrt_llm/_torch/models/modeling_hunyuan_moe.py
@@ -174,7 +174,6 @@ class HunYuanAttention(Attention):
         attn_metadata: AttentionMetadata,
         attention_mask: PredefinedAttentionMask = PredefinedAttentionMask.
         CAUSAL,
-        mrope_config: Optional[dict] = None,
         all_reduce_params: Optional[AllReduceParams] = None,
         lora_params: Optional[dict] = None,
         **kwargs,
@@ -185,7 +184,6 @@ class HunYuanAttention(Attention):
             hidden_states=hidden_states,
             attn_metadata=attn_metadata,
             attention_mask=attention_mask,
-            mrope_config=mrope_config,
             all_reduce_params=all_reduce_params,
             lora_params=lora_params,
             **kwargs,

--- a/tensorrt_llm/_torch/models/modeling_llama.py
+++ b/tensorrt_llm/_torch/models/modeling_llama.py
@@ -175,14 +175,14 @@ class Llama4Attention(Attention):
             q = self._attention_scaling(q, position_ids)
 
         q, k, v = self.convert_qkv(q, k, v)
-        attn_output = self.forward_impl(q,
-                                        k,
-                                        v,
-                                        attn_metadata,
-                                        attention_mask,
-                                        None,
-                                        None,
-                                        None,
+        attn_output = self.forward_impl(q=q,
+                                        k=k,
+                                        v=v,
+                                        attn_metadata=attn_metadata,
+                                        attention_mask=attention_mask,
+                                        attention_window_size=None,
+                                        attention_mask_data=None,
+                                        mrope_config=None,
                                         attention_sinks=None)
 
         if isinstance(attn_output, tuple):

--- a/tensorrt_llm/_torch/models/modeling_llama.py
+++ b/tensorrt_llm/_torch/models/modeling_llama.py
@@ -163,7 +163,6 @@ class Llama4Attention(Attention):
         attn_metadata: AttentionMetadata,
         attention_mask: PredefinedAttentionMask = PredefinedAttentionMask.
         CAUSAL,
-        mrope_config: Optional[dict] = None,
         all_reduce_params: Optional[AllReduceParams] = None,
         skip_attn_scaling: bool = False,
     ):
@@ -183,7 +182,7 @@ class Llama4Attention(Attention):
                                         attention_mask,
                                         None,
                                         None,
-                                        mrope_config,
+                                        None,
                                         attention_sinks=None)
 
         if isinstance(attn_output, tuple):
@@ -201,7 +200,6 @@ class Llama4Attention(Attention):
         attn_metadata: AttentionMetadata,
         attention_mask: PredefinedAttentionMask = PredefinedAttentionMask.
         CAUSAL,
-        mrope_config: Optional[dict] = None,
         all_reduce_params: Optional[AllReduceParams] = None,
         lora_params: Optional[dict] = None,
         **kwargs,
@@ -213,7 +211,6 @@ class Llama4Attention(Attention):
                 hidden_states=hidden_states,
                 attn_metadata=attn_metadata,
                 attention_mask=attention_mask,
-                mrope_config=mrope_config,
                 all_reduce_params=all_reduce_params,
                 lora_params=lora_params,
                 **kwargs,
@@ -223,7 +220,6 @@ class Llama4Attention(Attention):
                                       hidden_states=hidden_states,
                                       attn_metadata=attn_metadata,
                                       attention_mask=attention_mask,
-                                      mrope_config=mrope_config,
                                       all_reduce_params=all_reduce_params)
 
 

--- a/tensorrt_llm/_torch/models/modeling_llama_min_latency.py
+++ b/tensorrt_llm/_torch/models/modeling_llama_min_latency.py
@@ -417,7 +417,6 @@ class Llama4MinLatencyAttention(Llama4Attention):
         attn_metadata: AttentionMetadata,
         attention_mask: PredefinedAttentionMask = PredefinedAttentionMask.
         CAUSAL,
-        mrope_config: Optional[dict] = None,
         all_reduce_params: Optional[AllReduceParams] = None,
     ):
         # If we are going to use min-latency gemm+attn_scaling kernel, pass position_ids to QKV gemm and set
@@ -431,8 +430,8 @@ class Llama4MinLatencyAttention(Llama4Attention):
             skip_attn_scaling = True
 
         return super()._forward_nope(position_ids, hidden_states, attn_metadata,
-                                     attention_mask, mrope_config,
-                                     all_reduce_params, skip_attn_scaling)
+                                     attention_mask, all_reduce_params,
+                                     skip_attn_scaling)
 
 
 class Llama4MinLatencyFusedMoE(CutlassFusedMoE):

--- a/tensorrt_llm/_torch/models/modeling_qwen.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen.py
@@ -32,7 +32,7 @@ class QwenAttention(Attention):
                 type=PositionEmbeddingType.from_string(
                     config.rope_scaling["type"]),
                 rope=RopeParams.from_config(config),
-            )
+                mrope_section=config.rope_scaling.get('mrope_section', None))
         else:
             pos_embd_params = PositionalEmbeddingParams(
                 type=PositionEmbeddingType.rope_gpt_neox,
@@ -46,6 +46,7 @@ class QwenAttention(Attention):
             bias=True,
             pos_embd_params=pos_embd_params,
             layer_idx=layer_idx,
+            rope_fusion=not getattr(config, 'disable_fuse_rope', False),
             dtype=config.torch_dtype,
             dense_bias=False,
             config=model_config,

--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -38,7 +38,8 @@ from ..modules.rotary_embedding import MRotaryEmbedding
 from .modeling_auto import AutoModelForCausalLM
 from .modeling_multimodal_utils import (find_input_mm_embeds, fuse_input_embeds,
                                         get_multimodal_embeddings)
-from .modeling_utils import register_auto_model, register_vision_encoder
+from .modeling_utils import (ModelConfig, register_auto_model,
+                             register_vision_encoder)
 
 DISAGG = os.getenv('TLLM_MULTIMODAL_DISAGGREGATED', '0') == '1'
 PAD_INDEX = -100  # NOTE: refer to https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen2_5_vl/modular_qwen2_5_vl.py#L269

--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -12,7 +12,6 @@ from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import (
     Qwen2_5_VisionPatchEmbed, Qwen2_5_VisionRotaryEmbedding,
     Qwen2_5_VisionTransformerPretrainedModel, Qwen2_5_VLMLP,
     Qwen2_5_VLVisionBlock, apply_rotary_pos_emb_vision)
-from transformers.models.qwen2_vl.image_processing_qwen2_vl import smart_resize
 from transformers.models.qwen2_vl.modeling_qwen2_vl import \
     Qwen2VisionTransformerPretrainedModel
 
@@ -27,7 +26,6 @@ from tensorrt_llm.functional import PositionEmbeddingType
 from tensorrt_llm.inputs.multimodal import MultimodalParams
 
 from ..._utils import nvtx_range, nvtx_range_debug
-from ...functional import RopeEmbeddingUtils, RotaryScalingType
 from ...inputs import (BaseMultimodalInputProcessor, ExtraProcessedInputs,
                        InputProcessor, MultimodalPlaceholderMetadata,
                        MultimodalPlaceholderPlacement, TextPrompt,

--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -375,6 +375,7 @@ class Qwen2VisionModelBase(nn.Module):
         super().__init__()
         config = model_config.pretrained_config.vision_config
         config.torch_dtype = model_config.pretrained_config.torch_dtype
+        self.model_config = model_config
         self.model_dtype = config.torch_dtype
 
         if model_class in [
@@ -385,7 +386,8 @@ class Qwen2VisionModelBase(nn.Module):
             config._attn_implementation = 'flash_attention_2'
             self.visual = model_class(config).to(self.model_dtype).eval()
         elif model_class == Qwen2_5_VisionModel:
-            self.visual = model_class(model_config).to(self.model_dtype).eval()
+            self.visual = model_class(self.model_config).to(
+                self.model_dtype).eval()
         else:
             raise NotImplementedError(
                 f"Model class {model_class} not implemented")

--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -981,7 +981,7 @@ class Qwen2VLModel(Qwen2VLModelBase):
 
     def load_weights(self, weights, weight_mapper: BaseWeightMapper):
         if not DISAGG:
-            vision_encoder_weights = process_weights("visual", weights)
+            vision_encoder_weights = process_weights(weights, "visual")
             self.mm_encoder.load_state_dict(vision_encoder_weights, strict=True)
 
         self.llm.load_weights(weights, weight_mapper)

--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -41,7 +41,7 @@ from .modeling_multimodal_utils import (find_input_mm_embeds, fuse_input_embeds,
 from .modeling_utils import register_auto_model, register_vision_encoder
 
 DISAGG = os.getenv('TLLM_MULTIMODAL_DISAGGREGATED', '0') == '1'
-PAD_INDEX = -100  # https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen2_5_vl/modular_qwen2_5_vl.py#L269
+PAD_INDEX = -100  # NOTE: refer to https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen2_5_vl/modular_qwen2_5_vl.py#L269
 
 
 def process_weights(weights: Dict,

--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -392,6 +392,11 @@ class Qwen2VisionModelBase(nn.Module):
             raise NotImplementedError(
                 f"Model class {model_class} not implemented")
 
+        self.post_config()
+
+    def post_config(self):
+        self.config = self.model_config.pretrained_config.vision_config
+
     def _parse_and_batch_multimodal_data(
         self, multimodal_params: List[MultimodalParams]
     ) -> Tuple[Dict[str, Any], Dict[str, List[Any]]]:

--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -998,6 +998,7 @@ def getSMVersion():
 
 get_sm_version = getSMVersion()
 if get_sm_version >= 100:
+    # NOTE: Qwen2.5-VL with SM 100 and above uses HF's implementation due to lacking of TRT-LLM's Attention kernel.
     QWEN2_5_VL_VISION_MODEL_CLASS = Qwen2_5_VisionTransformerPretrainedModel
 else:
     QWEN2_5_VL_VISION_MODEL_CLASS = Qwen2_5_VisionModel

--- a/tensorrt_llm/_torch/models/modeling_qwen3.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3.py
@@ -115,7 +115,6 @@ class Qwen3DecoderLayer(DecoderLayer):
         hidden_states: torch.Tensor,
         attn_metadata: AttentionMetadata,
         residual: Optional[torch.Tensor],
-        mrope_config: Optional[Tuple[torch.Tensor, int]] = None,
         spec_metadata: Optional[SpecMetadata] = None,
         **kwargs,
     ) -> torch.Tensor:
@@ -131,7 +130,6 @@ class Qwen3DecoderLayer(DecoderLayer):
             position_ids=position_ids,
             hidden_states=hidden_states,
             attn_metadata=attn_metadata,
-            mrope_config=mrope_config,
             all_reduce_params=AllReduceParams(
                 enable_allreduce=not self.disable_allreduce),
             **kwargs,
@@ -187,7 +185,6 @@ class Qwen3Model(DecoderModel):
         input_ids: Optional[torch.IntTensor] = None,
         position_ids: Optional[torch.IntTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
-        mrope_config: Optional[Tuple[torch.Tensor, int]] = None,
         spec_metadata: Optional[SpecMetadata] = None,
         **kwargs,
     ) -> torch.Tensor:
@@ -208,7 +205,6 @@ class Qwen3Model(DecoderModel):
                 hidden_states=hidden_states,
                 attn_metadata=attn_metadata,
                 residual=residual,
-                mrope_config=mrope_config,
                 spec_metadata=spec_metadata,
             )
 

--- a/tensorrt_llm/_torch/models/modeling_qwen3.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import Optional
 
 import torch
 from torch import nn

--- a/tensorrt_llm/_torch/modules/rotary_embedding.py
+++ b/tensorrt_llm/_torch/modules/rotary_embedding.py
@@ -172,7 +172,7 @@ class MRotaryEmbedding(RotaryEmbedding):
         q_or_k = targets[0]
         remove_input_padding = (len(q_or_k.size()) == 2)
 
-        # TODO: Re-visit this to achieve cos_sin caching
+        # TODO(yechank-nvidia): Re-visit this to achieve cos_sin caching
         cos, sin = self.get_cos_sin(position_ids)
         cos, sin = cos.to(dtype=q_or_k.dtype), sin.to(dtype=q_or_k.dtype)
         if remove_input_padding:

--- a/tensorrt_llm/_torch/modules/rotary_embedding.py
+++ b/tensorrt_llm/_torch/modules/rotary_embedding.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 import torch
 from torch import nn
@@ -140,7 +140,9 @@ class MRotaryEmbedding(RotaryEmbedding):
         super().__init__(rope_params, head_dim=head_dim, is_neox=is_neox)
         self.mrope_section = mrope_section
 
-    def get_cos_sin(self, position_ids: torch.Tensor):
+    def get_cos_sin(
+            self,
+            position_ids: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
         if position_ids.ndim == 3:
             cos_sin = self.rotary_cos_sin[position_ids.view(3, -1)]
             cos, sin = cos_sin[:, :, 0, :], cos_sin[:, :, 1, :]

--- a/tensorrt_llm/_torch/modules/rotary_embedding.py
+++ b/tensorrt_llm/_torch/modules/rotary_embedding.py
@@ -125,3 +125,69 @@ class RotaryEmbedding(nn.Module):
         else:
             embed = torch.stack((o1, o2), dim=-1).flatten(-2)
             return torch.cat((embed, q_or_k_pass), dim=-1)
+
+
+class MRotaryEmbedding(RotaryEmbedding):
+
+    def __init__(
+        self,
+        rope_params: RopeParams,
+        *,
+        head_dim: int,
+        is_neox: bool = True,
+        # NOTE: default mrope_section is [16, 24, 24] for Qwen2/2.5-VL
+        mrope_section: List[int] = [16, 24, 24],
+    ):
+        super().__init__(rope_params, head_dim=head_dim, is_neox=is_neox)
+        self.mrope_section = mrope_section
+
+    def forward(
+        self,
+        position_ids: torch.Tensor,
+        targets: List[torch.Tensor],
+    ) -> List[torch.Tensor]:
+        # it is assumed all targets are of the same rank
+        q_or_k = targets[0]
+        remove_input_padding = (len(q_or_k.size()) == 2)
+
+        if position_ids.ndim == 3:
+            cos_sin = self.rotary_cos_sin[position_ids.view(3, -1)]
+            cos, sin = cos_sin[:, :, 0, :], cos_sin[:, :, 1, :]
+            cos = torch.cat([
+                m[i]
+                for i, m in enumerate(cos.split(self.mrope_section, dim=-1))
+            ],
+                            dim=-1)
+            sin = torch.cat([
+                m[i]
+                for i, m in enumerate(sin.split(self.mrope_section, dim=-1))
+            ],
+                            dim=-1)
+        else:
+            # Fallback to the original RoPE where position_ids is 2D for dummy requests
+            cos_sin = self.rotary_cos_sin[position_ids.view(-1)]
+            cos, sin = cos_sin[:, 0, :], cos_sin[:, 1, :]
+
+        cos = cos.to(dtype=q_or_k.dtype).unsqueeze(0)
+        sin = sin.to(dtype=q_or_k.dtype).unsqueeze(0)
+        if remove_input_padding:
+            bsz = 1
+            seq_len, _ = q_or_k.size()
+        else:
+            bsz, seq_len, _ = q_or_k.size()
+
+        def rope_target(target):
+            target = target.view(bsz, seq_len, -1,
+                                 self.head_dim).transpose(1, 2)
+            target = RotaryEmbedding.apply_rotary_pos_emb(target,
+                                                          cos,
+                                                          sin,
+                                                          is_neox=self.is_neox)
+            target = target.transpose(1, 2).contiguous()
+            if remove_input_padding:
+                target = target.view(seq_len, -1)
+            else:
+                target = target.view(bsz, seq_len, -1)
+            return target
+
+        return [rope_target(target) for target in targets]

--- a/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
+++ b/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
@@ -247,7 +247,6 @@ class CUDAGraphRunner:
         static_tensors["input_ids"][:seqlen].copy_(input_ids)
 
         position_ids = current_inputs["position_ids"]
-        print(f"[TRT-LLM DEBUG] position_ids.shape: {position_ids.shape}")
         if engine.use_mrope and current_inputs.get(
                 'multimodal_params') is not None:
             static_tensors["position_ids"][:, :, :seqlen].copy_(position_ids)

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1396,12 +1396,13 @@ class PyTorchModelEngine(ModelEngine):
                     mrope_position_ids.append(ctx_mrope_position_ids)
 
                 # TODO: Visit later to decide the appropriate position of sending multimodal data & selectively sending multimodal data
-                multimodal_params.to_device(
-                    "multimodal_data",
-                    "cuda",
-                    pin_memory=True,
-                    keyword=getattr(self.model, "multimodal_data_device_paths",
-                                    None))
+                multimodal_params.to_device("multimodal_data",
+                                            "cuda",
+                                            pin_memory=True,
+                                            filter_keywords=getattr(
+                                                self.model,
+                                                "multimodal_data_device_paths",
+                                                None))
 
                 #re-assign the multimodal_data to the request after to_device for generation requests
                 request.py_multimodal_data = multimodal_params.multimodal_data
@@ -1563,7 +1564,9 @@ class PyTorchModelEngine(ModelEngine):
                             "multimodal_data",
                             "cuda",
                             pin_memory=True,
-                            keyword=["mrope_config.mrope_position_deltas"])
+                            filter_keywords=[
+                                "mrope_config.mrope_position_deltas"
+                            ])
                         multimodal_params_list.append(multimodal_params)
 
             request.py_batch_idx = request.py_seq_slot

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -449,6 +449,9 @@ class PyTorchModelEngine(ModelEngine):
         self.position_ids_cuda = torch.empty((self.max_num_tokens, ),
                                              dtype=torch.int,
                                              device='cuda')
+        if self.use_mrope:
+            self.mrope_position_ids_cuda = torch.empty(
+                (3, 1, self.max_num_tokens), dtype=torch.int, device='cuda')
         self.iter_counter = 0
 
         # We look up this key in resource_manager during forward to find the
@@ -571,7 +574,6 @@ class PyTorchModelEngine(ModelEngine):
         if kv_cache_manager is None:
             logger.info("Skipping warm up as no KV Cache manager allocated.")
             return
-        use_mrope = self.use_mrope
 
         # The lifetime of model engine and kv cache manager can be different.
         # Reset the global cuda graph dummy request to None in warmup.
@@ -601,7 +603,7 @@ class PyTorchModelEngine(ModelEngine):
                     list(range(batch_size - 1)),
                     is_gen=True,
                     max_num_draft_tokens=draft_len,
-                    use_mrope=use_mrope,
+                    use_mrope=self.use_mrope,
                     max_beam_width=self.max_beam_width,
                     num_extra_decoding_steps=num_extra_decoding_steps)
                 # Divide by max_beam_width to get an approximation of the number of tokens that can be added to the final request.
@@ -630,7 +632,7 @@ class PyTorchModelEngine(ModelEngine):
                     token_nums=[token_num],
                     is_gen=True,
                     max_num_draft_tokens=draft_len,
-                    use_mrope=use_mrope,
+                    use_mrope=self.use_mrope,
                     max_beam_width=self.max_beam_width,
                     num_extra_decoding_steps=num_extra_decoding_steps)[0]
                 # Add the longest request before all other seq_len=1 request to simulate the padding CUDA graph case.
@@ -703,7 +705,9 @@ class PyTorchModelEngine(ModelEngine):
                     token_nums=ctx_token_nums,
                     is_gen=False,
                     max_num_draft_tokens=self.runtime_draft_len,
-                )
+                    use_mrope=self.use_mrope)
+
+                requests += final_request
 
                 if spec_resource_manager is not None:
                     spec_resource_manager.add_dummy_requests(
@@ -1351,8 +1355,9 @@ class PyTorchModelEngine(ModelEngine):
         num_cached_tokens_per_seq = []  # per sequence
         draft_tokens = []
         draft_lens = []
-        multimodal_params_list = []
         gen_request_seq_slots = []  # per generation request
+        multimodal_params_list = []
+        mrope_position_ids = []
 
         for request in scheduled_requests.context_requests:
             request_ids.append(request.py_request_id)
@@ -1383,11 +1388,23 @@ class PyTorchModelEngine(ModelEngine):
             multimodal_params = MultimodalParams(
                 multimodal_data=request.py_multimodal_data,
                 multimodal_runtime=py_multimodal_runtime)
-
             if multimodal_params.has_content():
-                multimodal_params.to_device("multimodal_data",
-                                            "cuda",
-                                            pin_memory=True)
+                if self.use_mrope:
+                    ctx_mrope_position_ids = multimodal_params.multimodal_data[
+                        'mrope_config'][
+                            'mrope_position_ids'][:, :,
+                                                  begin_compute:begin_compute +
+                                                  len(prompt_tokens)]
+                    mrope_position_ids.append(ctx_mrope_position_ids)
+
+                # TODO: Visit later to decide the appropriate position of sending multimodal data & selectively sending multimodal data
+                multimodal_params.to_device(
+                    "multimodal_data",
+                    "cuda",
+                    pin_memory=True,
+                    keyword=getattr(self.model, "multimodal_data_device_paths",
+                                    None))
+
                 #re-assign the multimodal_data to the request after to_device for generation requests
                 request.py_multimodal_data = multimodal_params.multimodal_data
                 multimodal_params_list.append(multimodal_params)
@@ -1416,17 +1433,6 @@ class PyTorchModelEngine(ModelEngine):
                     extend_requests.append(request)
             else:
                 generation_requests.append(request)
-            # Multimodal
-            multimodal_params = MultimodalParams(
-                multimodal_data=request.py_multimodal_data)
-            multimodal_params.strip_for_generation()
-            if multimodal_params.has_content():
-                multimodal_params.to_device("multimodal_data",
-                                            "cuda",
-                                            pin_memory=True)
-                # re-assign the multimodal_data to the request after strip_for_generation for another generation request,
-                request.py_multimodal_data = multimodal_params.multimodal_data
-                multimodal_params_list.append(multimodal_params)
         extend_requests += extend_dummy_requests
 
         spec_config = self.spec_config if self.enable_spec_decode else None
@@ -1542,6 +1548,32 @@ class PyTorchModelEngine(ModelEngine):
                 sequence_lengths.append(1)
                 gather_ids.append(len(position_ids) - 1)
 
+                # Multimodal
+                multimodal_params = MultimodalParams(
+                    multimodal_data=request.py_multimodal_data)
+                multimodal_params.strip_for_generation()
+                if multimodal_params.has_content():
+                    if self.use_mrope:
+                        mrope_position_deltas = multimodal_params.multimodal_data[
+                            'mrope_config']['mrope_position_deltas']
+                        # NOTE: Expanding position_ids to 3D tensor who is using mrope
+                        gen_mrope_position_ids = (past_seen_token_num +
+                                                  mrope_position_deltas).expand(
+                                                      3, 1, 1)
+                        mrope_position_ids.append(gen_mrope_position_ids)
+                        multimodal_params.to_device(
+                            "multimodal_data",
+                            "cuda",
+                            pin_memory=True,
+                            keyword=["mrope_config.mrope_position_deltas"])
+                        multimodal_params_list.append(multimodal_params)
+                        # multimodal_params.to_device("multimodal_data",
+                        #                             "cuda",
+                        #                             pin_memory=True)
+                        # # re-assign the multimodal_data to the request after strip_for_generation for another generation request,
+                        # request.py_multimodal_data = multimodal_params.multimodal_data
+                        # multimodal_params_list.append(multimodal_params)
+
             request.py_batch_idx = request.py_seq_slot
             # Do not add a gen_request_seq_slot for CUDA graph dummy requests
             # to prevent access errors due to None values
@@ -1656,11 +1688,26 @@ class PyTorchModelEngine(ModelEngine):
             self.previous_pos_id_offsets_cuda *= 0
             self.previous_kv_lens_offsets_cuda *= 0
 
-        position_ids = torch.tensor(position_ids,
-                                    dtype=torch.int,
-                                    pin_memory=True)
-        self.position_ids_cuda[:total_num_tokens].copy_(position_ids,
-                                                        non_blocking=True)
+        if self.use_mrope and mrope_position_ids:
+            # NOTE: self.use_mrope is enough for differentiating whether to use mrope_position_ids but
+            # `_create_dummy_context_requests` from `kv_cache_creater` makes an exception that I can not add multimodal_data to the dummy_request
+            # so that we only replace position_ids with mrope_position_ids when it is not a dummy request and for models who is using mrope.
+            mrope_position_ids = torch.cat(mrope_position_ids,
+                                           dim=-1).pin_memory()
+            self.mrope_position_ids_cuda[:, :, :total_num_tokens].copy_(
+                mrope_position_ids[:, :, :total_num_tokens], non_blocking=True)
+            final_position_ids = self.mrope_position_ids_cuda[:, :, :
+                                                              total_num_tokens]
+        else:
+            position_ids = torch.tensor(position_ids,
+                                        dtype=torch.int,
+                                        pin_memory=True)
+            self.position_ids_cuda[:total_num_tokens].copy_(position_ids,
+                                                            non_blocking=True)
+            final_position_ids = self.position_ids_cuda[:
+                                                        total_num_tokens].unsqueeze(
+                                                            0)
+
         if self.enable_spec_decode:
             self.gather_ids_cuda[:len(gather_ids)].copy_(torch.tensor(
                 gather_ids, dtype=torch.int, pin_memory=True),
@@ -1735,18 +1782,6 @@ class PyTorchModelEngine(ModelEngine):
             'inputs_embeds': None,
             "multimodal_params": multimodal_params_list,
         }
-
-        # Directly input mrope_position_deltas as a Tensor for cuda graph, because dictionary could not be captured.
-        if attn_metadata.is_cuda_graph and len(multimodal_params_list) > 0:
-            if 'mrope_position_deltas' in multimodal_params_list[
-                    0].multimodal_data.get('mrope_config', {}):
-                mrope_position_deltas_list = [
-                    multimodal_params.multimodal_data['mrope_config']
-                    ['mrope_position_deltas']
-                    for multimodal_params in multimodal_params_list
-                ]
-                inputs['mrope_position_deltas'] = torch.cat(
-                    mrope_position_deltas_list, dim=0)
 
         if bool(lora_params):
             inputs['lora_params'] = lora_params

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1399,7 +1399,7 @@ class PyTorchModelEngine(ModelEngine):
                 multimodal_params.to_device("multimodal_data",
                                             "cuda",
                                             pin_memory=True,
-                                            filter_keywords=getattr(
+                                            target_keywords=getattr(
                                                 self.model,
                                                 "multimodal_data_device_paths",
                                                 None))
@@ -1564,7 +1564,7 @@ class PyTorchModelEngine(ModelEngine):
                             "multimodal_data",
                             "cuda",
                             pin_memory=True,
-                            filter_keywords=[
+                            target_keywords=[
                                 "mrope_config.mrope_position_deltas"
                             ])
                         multimodal_params_list.append(multimodal_params)

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -517,7 +517,7 @@ class KVCacheManager(BaseResourceManager):
                     for _ in range(max_num_draft_tokens):
                         self.impl.add_token(req_id)
 
-            # NOTE: Planning to get dummy_data from each model. Before that, we need to add dummy mrop_config to the request here.
+            # TODO: Planning to get dummy_data from each model. Before that, we need to add dummy mrop_config to the request here.
             if use_mrope:
                 dummy_mrope_position_ids = torch.arange(
                     0, token_num, dtype=torch.int32).expand(3, 1, -1).clone()

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -491,15 +491,12 @@ class KVCacheManager(BaseResourceManager):
                 1
             ] * token_num if self.impl.cross_kv else None
             # Using 1 instead of 0 prevents NaN during warmup in e.g. Deepseek
-            mrope_position_deltas = torch.zeros(
-                1, device="cuda", dtype=torch.int32) if use_mrope else None
             req = LlmRequest(request_id=req_id,
                              max_new_tokens=1,
                              input_tokens=[1] * token_num,
                              sampling_config=SamplingConfig(
                                  sampling_params._get_sampling_config()),
                              is_streaming=False,
-                             mrope_position_deltas=mrope_position_deltas,
                              encoder_input_tokens=encoder_input_tokens)
             req.is_dummy_request = True
             req.paged_kv_block_ids = []
@@ -520,6 +517,20 @@ class KVCacheManager(BaseResourceManager):
                     for _ in range(max_num_draft_tokens):
                         self.impl.add_token(req_id)
 
+            # NOTE: Planning to get dummy_data from each model. Before that, we need to add dummy mrop_config to the request here.
+            if use_mrope:
+                dummy_mrope_position_ids = torch.arange(
+                    0, token_num, dtype=torch.int32).expand(3, 1, -1).clone()
+                req.py_multimodal_data = {
+                    "mrope_config": {
+                        "mrope_position_ids": dummy_mrope_position_ids
+                    }
+                }
+                if is_gen:
+                    dummy_mrope_position_deltas = torch.zeros(
+                        1, dtype=torch.int32).unsqueeze(0)
+                    req.py_multimodal_data["mrope_config"][
+                        "mrope_position_deltas"] = dummy_mrope_position_deltas
             requests.append(req)
         return requests
 

--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -405,14 +405,14 @@ class MultimodalParams:
                   element: str,
                   device: str,
                   pin_memory: bool = False,
-                  keyword: Optional[List[str]] = None) -> None:
+                  filter_keywords: Optional[List[str]] = None) -> None:
         """Move specified multimodal data element to target device.
 
         Args:
             element: Element to move (only "multimodal_data" is supported)
             device: Target device (e.g., "cuda", "cpu")
             pin_memory: Whether to pin memory for asynchronous transfers
-            keyword: Optional list of keyword paths to filter which data to move.
+            filter_keywords: Optional list of keyword paths to filter which data to move.
                     Each string can be a simple key or dot-separated path
                     (e.g., ["image.pixel_values", "mrope_config"])
                     If provided, only data matching these paths will be moved to device.
@@ -431,7 +431,7 @@ class MultimodalParams:
             return  # Nothing to move
 
         # If keyword is specified, only move data for those keyword paths
-        if keyword is not None:
+        if filter_keywords is not None:
             if not isinstance(data, dict):
                 raise ValueError(
                     f"multimodal_data must be a dictionary when keyword is specified, "
@@ -439,7 +439,7 @@ class MultimodalParams:
 
             # Process multiple keyword paths
             transformed_data = self._move_multiple_paths_to_device(
-                data, keyword, device, pin_memory)
+                data, filter_keywords, device, pin_memory)
         else:
             # Move all data as before
             transformed_data = self._apply_tensor_operation(
@@ -448,13 +448,13 @@ class MultimodalParams:
         setattr(self, element, transformed_data)
 
     def _move_multiple_paths_to_device(self, data: Dict[str, Any],
-                                       keyword_list: List[str], device: str,
+                                       filter_keywords: List[str], device: str,
                                        pin_memory: bool) -> Dict[str, Any]:
         """Move multiple nested data paths to device.
 
         Args:
             data: The multimodal data dictionary
-            keyword_list: List of keyword paths (can be dot-separated)
+            filter_keywords: List of keyword paths (can be dot-separated)
             device: Target device
             pin_memory: Whether to pin memory
 
@@ -462,7 +462,7 @@ class MultimodalParams:
             Updated data dictionary with specified paths moved to device
         """
         result = data
-        for keyword_path in keyword_list:
+        for keyword_path in filter_keywords:
             # Parse each keyword path
             if '.' in keyword_path:
                 key_path = keyword_path.split('.')

--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -404,13 +404,18 @@ class MultimodalParams:
     def to_device(self,
                   element: str,
                   device: str,
-                  pin_memory: bool = False) -> None:
+                  pin_memory: bool = False,
+                  keyword: Optional[List[str]] = None) -> None:
         """Move specified multimodal data element to target device.
 
         Args:
             element: Element to move (only "multimodal_data" is supported)
             device: Target device (e.g., "cuda", "cpu")
-            pin_memory: Whether to pin memory for faster transfers
+            pin_memory: Whether to pin memory for asynchronous transfers
+            keyword: Optional list of keyword paths to filter which data to move.
+                    Each string can be a simple key or dot-separated path
+                    (e.g., ["image.pixel_values", "mrope_config"])
+                    If provided, only data matching these paths will be moved to device.
 
         Raises:
             ValueError: If element is not "multimodal_data" or device is invalid
@@ -425,30 +430,90 @@ class MultimodalParams:
         if data is None:
             return  # Nothing to move
 
-        transformed_data = self._apply_tensor_operation(data,
-                                                        "to_device",
-                                                        device=device,
-                                                        pin_memory=pin_memory)
+        # If keyword is specified, only move data for those keyword paths
+        if keyword is not None:
+            if not isinstance(data, dict):
+                raise ValueError(
+                    f"multimodal_data must be a dictionary when keyword is specified, "
+                    f"got {type(data)}")
+
+            # Process multiple keyword paths
+            transformed_data = self._move_multiple_paths_to_device(
+                data, keyword, device, pin_memory)
+        else:
+            # Move all data as before
+            transformed_data = self._apply_tensor_operation(
+                data, "to_device", device=device, pin_memory=pin_memory)
+
         setattr(self, element, transformed_data)
+
+    def _move_multiple_paths_to_device(self, data: Dict[str, Any],
+                                       keyword_list: List[str], device: str,
+                                       pin_memory: bool) -> Dict[str, Any]:
+        """Move multiple nested data paths to device.
+
+        Args:
+            data: The multimodal data dictionary
+            keyword_list: List of keyword paths (can be dot-separated)
+            device: Target device
+            pin_memory: Whether to pin memory
+
+        Returns:
+            Updated data dictionary with specified paths moved to device
+        """
+        result = data
+        for keyword_path in keyword_list:
+            # Parse each keyword path
+            if '.' in keyword_path:
+                key_path = keyword_path.split('.')
+            else:
+                key_path = [keyword_path]
+
+            # Navigate to the target location and move data
+            current = result
+            parent_path = key_path[:-1]
+            target_key = key_path[-1]
+
+            # Navigate to the parent dictionary
+            for key in parent_path:
+                if not isinstance(current, dict) or key not in current:
+                    # Path doesn't exist, skip this keyword path
+                    break
+                current = current[key]
+            else:
+                # Check if the target key exists and move it to device
+                if isinstance(current, dict) and target_key in current:
+                    current[target_key] = self._apply_tensor_operation(
+                        current[target_key],
+                        "to_device",
+                        device=device,
+                        pin_memory=pin_memory)
+
+        return result
 
     def strip_for_generation(self) -> None:
         """Strip multimodal data for generation processing.
 
-        Keeps only mrope_config and removes all other multimodal data
+        Keeps only mrope_position_deltas and removes all other multimodal data
         (embeddings, images, etc.) as they're not needed during generation.
         """
         if not self.multimodal_data:
             return
 
-        # Extract mrope_config before clearing
-        mrope_config = None
+        # Extract mrope_position_deltas before clearing
+        mrope_position_deltas = None
         if 'mrope_config' in self.multimodal_data:
             mrope_config = self.multimodal_data['mrope_config']
+            if isinstance(mrope_config,
+                          dict) and 'mrope_position_deltas' in mrope_config:
+                mrope_position_deltas = mrope_config['mrope_position_deltas']
 
-        # Clear all data and restore only mrope_config if it exists
+        # Clear all data and restore only position deltas if they exist
         self.multimodal_data = {}
-        if mrope_config is not None:
-            self.multimodal_data['mrope_config'] = mrope_config
+        if mrope_position_deltas is not None:
+            self.multimodal_data['mrope_config'] = {
+                'mrope_position_deltas': mrope_position_deltas
+            }
 
     def has_content(self) -> bool:
         """Check if this object contains any multimodal data."""

--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -405,14 +405,14 @@ class MultimodalParams:
                   element: str,
                   device: str,
                   pin_memory: bool = False,
-                  filter_keywords: Optional[List[str]] = None) -> None:
+                  target_keywords: Optional[List[str]] = None) -> None:
         """Move specified multimodal data element to target device.
 
         Args:
             element: Element to move (only "multimodal_data" is supported)
             device: Target device (e.g., "cuda", "cpu")
             pin_memory: Whether to pin memory for asynchronous transfers
-            filter_keywords: Optional list of keyword paths to filter which data to move.
+            target_keywords: Optional list of keyword paths to filter which data to move.
                     Each string can be a simple key or dot-separated path
                     (e.g., ["image.pixel_values", "mrope_config"])
                     If provided, only data matching these paths will be moved to device.
@@ -431,7 +431,7 @@ class MultimodalParams:
             return  # Nothing to move
 
         # If keyword is specified, only move data for those keyword paths
-        if filter_keywords is not None:
+        if target_keywords is not None:
             if not isinstance(data, dict):
                 raise ValueError(
                     f"multimodal_data must be a dictionary when keyword is specified, "
@@ -439,7 +439,7 @@ class MultimodalParams:
 
             # Process multiple keyword paths
             transformed_data = self._move_multiple_paths_to_device(
-                data, filter_keywords, device, pin_memory)
+                data, target_keywords, device, pin_memory)
         else:
             # Move all data as before
             transformed_data = self._apply_tensor_operation(
@@ -448,13 +448,13 @@ class MultimodalParams:
         setattr(self, element, transformed_data)
 
     def _move_multiple_paths_to_device(self, data: Dict[str, Any],
-                                       filter_keywords: List[str], device: str,
+                                       target_keywords: List[str], device: str,
                                        pin_memory: bool) -> Dict[str, Any]:
         """Move multiple nested data paths to device.
 
         Args:
             data: The multimodal data dictionary
-            filter_keywords: List of keyword paths (can be dot-separated)
+            target_keywords: List of keyword paths (can be dot-separated)
             device: Target device
             pin_memory: Whether to pin memory
 
@@ -462,7 +462,7 @@ class MultimodalParams:
             Updated data dictionary with specified paths moved to device
         """
         result = data
-        for keyword_path in filter_keywords:
+        for keyword_path in target_keywords:
             # Parse each keyword path
             if '.' in keyword_path:
                 key_path = keyword_path.split('.')

--- a/tensorrt_llm/serve/scripts/benchmark_dataset.py
+++ b/tensorrt_llm/serve/scripts/benchmark_dataset.py
@@ -1119,8 +1119,6 @@ class VisionArenaDataset(HuggingFaceDataset):
         enable_multimodal_chat: bool = False,
         **kwargs,
     ) -> list:
-        if enable_multimodal_chat:
-            raise NotImplementedError
 
         output_len = (output_len
                       if output_len is not None else self.DEFAULT_OUTPUT_LEN)
@@ -1130,7 +1128,6 @@ class VisionArenaDataset(HuggingFaceDataset):
         parser_fn = self.SUPPORTED_DATASET_PATHS.get(self.dataset_path)
         if parser_fn is None:
             raise ValueError(f"Unsupported dataset path: {self.dataset_path}")
-
         sampled_requests = []
         for item in self.data:
             if len(prompts) >= num_requests:

--- a/tests/integration/test_lists/test-db/l0_a30.yml
+++ b/tests/integration/test_lists/test-db/l0_a30.yml
@@ -14,6 +14,7 @@ l0_a30:
       backend: pytorch
   tests:
   # ------------- PyTorch tests ---------------
+  - unittest/_torch/modules/test_rotary_embedding.py
   - unittest/_torch/modeling -k "modeling_nemotron_nas"
   - unittest/_torch/modeling -k "modeling_phi3"
   - unittest/_torch/modeling -k "modeling_qwen"

--- a/tests/integration/test_lists/test-db/l0_a30.yml
+++ b/tests/integration/test_lists/test-db/l0_a30.yml
@@ -14,7 +14,6 @@ l0_a30:
       backend: pytorch
   tests:
   # ------------- PyTorch tests ---------------
-  - unittest/_torch/modules/test_rotary_embedding.py
   - unittest/_torch/modeling -k "modeling_nemotron_nas"
   - unittest/_torch/modeling -k "modeling_phi3"
   - unittest/_torch/modeling -k "modeling_qwen"

--- a/tests/integration/test_lists/test-db/l0_l40s.yml
+++ b/tests/integration/test_lists/test-db/l0_l40s.yml
@@ -17,16 +17,13 @@ l0_l40s:
   - unittest/_torch/modeling -k "modeling_mllama"
   - unittest/_torch/modeling -k "modeling_vila"
   - unittest/_torch/modeling -k "modeling_siglip"
+  - unittest/_torch/modeling -k "modeling_qwen2_5vl"
   - test_e2e.py::test_ptp_scaffolding[DeepSeek-R1-Distill-Qwen-7B-DeepSeek-R1/DeepSeek-R1-Distill-Qwen-7B]
   - test_e2e.py::test_ptp_quickstart_multimodal[NVILA-8B-FP16-vila/NVILA-8B-image-False]
   - test_e2e.py::test_ptp_quickstart_multimodal[NVILA-8B-FP16-vila/NVILA-8B-video-False]
   - test_e2e.py::test_ptp_quickstart_multimodal[llava-v1.6-mistral-7b-llava-v1.6-mistral-7b-hf-image-False]
   - test_e2e.py::test_ptp_quickstart_multimodal[qwen2-vl-7b-instruct-Qwen2-VL-7B-Instruct-image-False]
   - test_e2e.py::test_ptp_quickstart_multimodal[qwen2-vl-7b-instruct-Qwen2-VL-7B-Instruct-video-False]
-  - test_e2e.py::test_ptp_quickstart_multimodal[qwen2.5-vl-7b-instruct-Qwen2.5-VL-7B-Instruct-image-False]
-  - test_e2e.py::test_ptp_quickstart_multimodal[qwen2.5-vl-7b-instruct-Qwen2.5-VL-7B-Instruct-image-True]
-  - test_e2e.py::test_ptp_quickstart_multimodal[qwen2.5-vl-7b-instruct-Qwen2.5-VL-7B-Instruct-video-False]
-  - test_e2e.py::test_ptp_quickstart_multimodal[qwen2.5-vl-7b-instruct-Qwen2.5-VL-7B-Instruct-video-True]
   - test_e2e.py::test_ptp_quickstart_multimodal_phi4mm[audio]
   - test_e2e.py::test_ptp_quickstart_multimodal_phi4mm[image]
   - test_e2e.py::test_ptp_quickstart_multimodal_phi4mm[image_audio]

--- a/tests/integration/test_lists/test-db/l0_l40s.yml
+++ b/tests/integration/test_lists/test-db/l0_l40s.yml
@@ -22,8 +22,6 @@ l0_l40s:
   - test_e2e.py::test_ptp_quickstart_multimodal[NVILA-8B-FP16-vila/NVILA-8B-image-False]
   - test_e2e.py::test_ptp_quickstart_multimodal[NVILA-8B-FP16-vila/NVILA-8B-video-False]
   - test_e2e.py::test_ptp_quickstart_multimodal[llava-v1.6-mistral-7b-llava-v1.6-mistral-7b-hf-image-False]
-  - test_e2e.py::test_ptp_quickstart_multimodal[qwen2-vl-7b-instruct-Qwen2-VL-7B-Instruct-image-False]
-  - test_e2e.py::test_ptp_quickstart_multimodal[qwen2-vl-7b-instruct-Qwen2-VL-7B-Instruct-video-False]
   - test_e2e.py::test_ptp_quickstart_multimodal_phi4mm[audio]
   - test_e2e.py::test_ptp_quickstart_multimodal_phi4mm[image]
   - test_e2e.py::test_ptp_quickstart_multimodal_phi4mm[image_audio]

--- a/tests/unittest/_torch/modeling/test_modeling_qwen2_5vl.py
+++ b/tests/unittest/_torch/modeling/test_modeling_qwen2_5vl.py
@@ -187,7 +187,7 @@ class TestQwen2_5_VL(unittest.TestCase):
                 "multimodal_data",
                 device,
                 pin_memory=True,
-                filter_keywords=getattr(model, "multimodal_data_device_paths",
+                target_keywords=getattr(model, "multimodal_data_device_paths",
                                         None))
             multimodal_params_list.append(multimodal_params)
         input_ids = torch.tensor(input_ids, dtype=torch.int32, device=device)
@@ -474,7 +474,7 @@ class TestQwen2_5_VL(unittest.TestCase):
                 "multimodal_data",
                 device,
                 pin_memory=True,
-                filter_keywords=["mrope_config.mrope_position_deltas"])
+                target_keywords=["mrope_config.mrope_position_deltas"])
             gen_multimodal_params_list.append(multimodal_param)
 
         graph_runner = None

--- a/tests/unittest/_torch/modeling/test_modeling_qwen2_5vl.py
+++ b/tests/unittest/_torch/modeling/test_modeling_qwen2_5vl.py
@@ -187,7 +187,8 @@ class TestQwen2_5_VL(unittest.TestCase):
                 "multimodal_data",
                 device,
                 pin_memory=True,
-                keyword=getattr(model, "multimodal_data_device_paths", None))
+                filter_keywords=getattr(model, "multimodal_data_device_paths",
+                                        None))
             multimodal_params_list.append(multimodal_params)
         input_ids = torch.tensor(input_ids, dtype=torch.int32, device=device)
         return input_ids, context_sequence_lengths, multimodal_params_list
@@ -259,8 +260,8 @@ class TestQwen2_5_VL(unittest.TestCase):
             MultimodalParams(
                 multimodal_data={
                     "mrope_config": {
-                        "mrope_position_deltas": torch.zeros(1,
-                                                             dtype=torch.int32)
+                        "mrope_position_deltas":
+                        torch.zeros(1, dtype=torch.int32, device='cuda')
                     }
                 })
         ] * 2)
@@ -473,7 +474,7 @@ class TestQwen2_5_VL(unittest.TestCase):
                 "multimodal_data",
                 device,
                 pin_memory=True,
-                keyword=["mrope_config.mrope_position_deltas"])
+                filter_keywords=["mrope_config.mrope_position_deltas"])
             gen_multimodal_params_list.append(multimodal_param)
 
         graph_runner = None

--- a/tests/unittest/_torch/modeling/test_modeling_qwen2_5vl.py
+++ b/tests/unittest/_torch/modeling/test_modeling_qwen2_5vl.py
@@ -1,0 +1,491 @@
+import os
+import unittest
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import List
+
+import torch
+from parameterized import parameterized
+from transformers import AutoProcessor, AutoTokenizer, Qwen2_5_VLConfig
+from transformers import \
+    Qwen2_5_VLForConditionalGeneration as HFQwen2_5_VLForConditionalLM
+
+import tensorrt_llm
+from tensorrt_llm._torch.attention_backend.utils import get_attention_backend
+from tensorrt_llm._torch.metadata import KVCacheParams
+from tensorrt_llm._torch.model_config import ModelConfig
+from tensorrt_llm._torch.models.checkpoints.hf.qwen2vl_weight_mapper import \
+    Qwen2VLHfWeightMapper
+from tensorrt_llm._torch.models.modeling_qwen2vl import Qwen2_5_VLModel
+from tensorrt_llm._torch.pyexecutor.cuda_graph_runner import \
+    DecodingCUDAGraphRunner
+from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
+from tensorrt_llm.bindings.executor import KvCacheConfig
+from tensorrt_llm.inputs import (create_input_processor,
+                                 default_multimodal_input_loader, prompt_inputs)
+from tensorrt_llm.inputs.multimodal import MultimodalParams
+from tensorrt_llm.mapping import Mapping
+
+
+def llm_models_root() -> str:
+    '''return LLM_MODELS_ROOT path if it is set in env, assert when it's set but not a valid path
+    '''
+    DEFAULT_LLM_MODEL_ROOT = os.path.join("/scratch.trt_llm_data", "llm-models")
+    LLM_MODELS_ROOT = os.environ.get("LLM_MODELS_ROOT", DEFAULT_LLM_MODEL_ROOT)
+
+    return LLM_MODELS_ROOT
+
+
+QWEN2_5_VL_7B_CONFIG = {
+    "architectures": ["Qwen2_5_VLForConditionalGeneration"],
+    "attention_dropout": 0.0,
+    "bos_token_id": 151643,
+    "eos_token_id": 151645,
+    "vision_start_token_id": 151652,
+    "vision_end_token_id": 151653,
+    "vision_token_id": 151654,
+    "image_token_id": 151655,
+    "video_token_id": 151656,
+    "hidden_act": "silu",
+    "hidden_size": 3584,
+    "initializer_range": 0.02,
+    "intermediate_size": 18944,
+    "max_position_embeddings": 128000,
+    "max_window_layers": 28,
+    "model_type": "qwen2_5_vl",
+    "num_attention_heads": 28,
+    "num_hidden_layers":
+    2,  # NOTE: Only 1 layer for testing, 28 layers for full model
+    "num_key_value_heads": 4,
+    "rms_norm_eps": 1e-06,
+    "rope_theta": 1000000.0,
+    "sliding_window": 32768,
+    "tie_word_embeddings": False,
+    "torch_dtype": "bfloat16",
+    "transformers_version": "4.41.2",
+    "use_cache": True,
+    "use_sliding_window": False,
+    "vision_config": {
+        "depth": 2,  # NOTE: Only 1 layer for testing, 32 layers for full model
+        "hidden_act": "silu",
+        "hidden_size": 1280,
+        "intermediate_size": 3420,
+        "num_heads": 16,
+        "in_chans": 3,
+        "out_hidden_size": 3584,
+        "patch_size": 14,
+        "spatial_merge_size": 2,
+        "spatial_patch_size": 14,
+        "window_size": 112,
+        "fullatt_block_indexes": [7, 15, 23, 31],
+        "tokens_per_second": 2,
+        "temporal_patch_size": 2
+    },
+    "rope_scaling": {
+        "type": "mrope",
+        "mrope_section": [16, 24, 24]
+    },
+    "vocab_size": 152064,
+    "attn_implementation": "flash_attention_2",
+    "_name_or_path":
+    str(os.path.join(llm_models_root(), "Qwen2.5-VL-7B-Instruct"))
+}
+
+
+@dataclass(repr=False)
+class Scenario:
+    modality: str = "image"
+    use_cuda_graph: bool = False
+    disable_fuse_rope: bool = False
+
+    def __repr__(self) -> str:
+        return f"modality:{self.modality.lower()}-use_cuda_graph:{self.use_cuda_graph}-disable_fuse_rope:{self.disable_fuse_rope}"
+
+
+class TestQwen2_5_VL(unittest.TestCase):
+
+    def get_kv_cache_manager(self, dtype: torch.dtype, config: Qwen2_5_VLConfig,
+                             tokens_per_block: int, max_seq_len: int,
+                             batch_size: int, num_blocks: int):
+        if dtype == torch.half:
+            kv_cache_dtype = tensorrt_llm.bindings.DataType.HALF
+        elif dtype == torch.bfloat16:
+            kv_cache_dtype = tensorrt_llm.bindings.DataType.BF16
+        else:
+            raise ValueError("Invalid dtype")
+
+        mapping = Mapping(world_size=1, tp_size=1, rank=0)
+        kv_cache_config = KvCacheConfig(max_tokens=num_blocks *
+                                        tokens_per_block)
+        kv_cache_manager = KVCacheManager(
+            kv_cache_config,
+            tensorrt_llm.bindings.internal.batch_manager.CacheType.SELF,
+            num_layers=config.num_hidden_layers,
+            num_kv_heads=config.num_key_value_heads,
+            head_dim=config.hidden_size // config.num_attention_heads,
+            tokens_per_block=tokens_per_block,
+            max_seq_len=max_seq_len,
+            max_batch_size=batch_size,
+            mapping=mapping,
+            dtype=kv_cache_dtype,
+        )
+        return kv_cache_manager
+
+    def get_inputprocessor(self, model_path):
+        tokenizer = AutoTokenizer.from_pretrained(model_path)
+        return create_input_processor(model_path, tokenizer=tokenizer)
+
+    def get_trtllm_inputs(self, model, scenario: Scenario, device: torch.device,
+                          prompt: List[str], media: List[str]):
+        processor = self.get_inputprocessor(
+            model.model_config.pretrained_config._name_or_path)
+        inputs = default_multimodal_input_loader(
+            tokenizer=processor.tokenizer,
+            model_dir=model.model_config.pretrained_config._name_or_path,
+            model_type="qwen2_5_vl",
+            modality=scenario.modality,
+            prompts=prompt,
+            media=media,
+            image_data_format="pt",
+            num_frames=8,
+            device="cpu")
+        inputs = [prompt_inputs(i) for i in inputs]
+
+        input_ids = []
+        context_sequence_lengths = []
+        multimodal_params_list = []
+        for input in inputs:
+            prompt_token_ids, extra_processed_inputs = processor(
+                input, sampling_params=None)
+            input_ids.extend(prompt_token_ids)
+            context_sequence_lengths.append(len(prompt_token_ids))
+            multimodal_params = MultimodalParams(
+                multimodal_data=extra_processed_inputs.get('multimodal_data'))
+            multimodal_params.to_device(
+                "multimodal_data",
+                device,
+                pin_memory=True,
+                keyword=getattr(model, "multimodal_data_device_paths", None))
+            multimodal_params_list.append(multimodal_params)
+        input_ids = torch.tensor(input_ids, dtype=torch.int32, device=device)
+        return input_ids, context_sequence_lengths, multimodal_params_list
+
+    def get_hf_inputs(self, model, scenario: Scenario, device: torch.device,
+                      prompt: List[str], media: List[str]):
+        processor = AutoProcessor.from_pretrained(
+            model.model_config.pretrained_config._name_or_path)
+        inputs = default_multimodal_input_loader(
+            tokenizer=processor.tokenizer,
+            model_dir=model.model_config.pretrained_config._name_or_path,
+            model_type="qwen2_5_vl",
+            modality=scenario.modality,
+            prompts=prompt,
+            media=media,
+            image_data_format="pt",
+            num_frames=8,
+            device="cpu")
+        inputs = [prompt_inputs(i) for i in inputs]
+
+        processor_inputs = processor(
+            text=[input['prompt'] for input in inputs],
+            images=[input['multi_modal_data']['image'] for input in inputs],
+            padding=True,
+            return_tensors="pt",
+            do_rescale=False,
+        ).to(device)
+        return processor_inputs
+
+    def test_qwen2_5_vl_sanity(self):
+
+        config_dict = deepcopy(QWEN2_5_VL_7B_CONFIG)
+        qwen2_5_vl_config = Qwen2_5_VLConfig.from_dict(config_dict)
+        dtype = qwen2_5_vl_config.torch_dtype
+        device = torch.device('cuda')
+
+        model_config = ModelConfig(pretrained_config=qwen2_5_vl_config)
+        qwen2_5_vl = Qwen2_5_VLModel(model_config,
+                                     disable_fuse_rope=True).to(device)
+
+        prompt = [
+            "Describe the natural environment in the image.",
+            "Describe the object and the weather condition in the image."
+        ]
+        media = [
+            "https://huggingface.co/datasets/YiYiXu/testing-images/resolve/main/seashore.png",
+            "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/inpaint.png"
+        ]
+        input_ids, context_sequence_lengths, multimodal_params_list = self.get_trtllm_inputs(
+            qwen2_5_vl, Scenario(modality="image"), device, prompt, media)
+
+        # Add generation input_ids
+        input_ids = torch.cat([
+            input_ids,
+            torch.tensor([900, 1000], dtype=torch.int32, device=device)
+        ],
+                              dim=0)
+        multimodal_params_list.extend([
+            MultimodalParams(
+                multimodal_data={
+                    "mrope_config": {
+                        "mrope_position_deltas": torch.zeros(1,
+                                                             dtype=torch.int32)
+                    }
+                })
+        ] * 2)
+
+        generation_sequence_lengths = [1, 1]
+        sequence_lengths = context_sequence_lengths + generation_sequence_lengths
+        past_seen_tokens = [0, 0, 62, 75]
+        request_ids = list(range(len(sequence_lengths)))
+        token_nums = (torch.tensor(past_seen_tokens) +
+                      torch.tensor(sequence_lengths)).tolist()
+        prompt_lens = token_nums[:2] + past_seen_tokens[2:]
+
+        num_blocks = 100
+        tokens_per_block = 128
+        max_seq_len = num_blocks * tokens_per_block
+        batch_size = len(context_sequence_lengths) + 2
+        kv_cache_manager = self.get_kv_cache_manager(
+            dtype=dtype,
+            config=qwen2_5_vl_config,
+            tokens_per_block=tokens_per_block,
+            max_seq_len=max_seq_len,
+            batch_size=batch_size,
+            num_blocks=num_blocks)
+        kv_cache_manager.add_dummy_requests(request_ids,
+                                            token_nums,
+                                            use_mrope=True)
+
+        metadata_cls = get_attention_backend(model_config.attn_backend).Metadata
+        attn_metadata = metadata_cls(
+            seq_lens=torch.tensor(sequence_lengths, dtype=torch.int),
+            num_contexts=len(context_sequence_lengths),
+            kv_cache_params=KVCacheParams(
+                use_cache=True,
+                num_cached_tokens_per_seq=past_seen_tokens,
+            ),
+            kv_cache_manager=kv_cache_manager,
+            request_ids=request_ids,
+            prompt_lens=prompt_lens,
+            max_num_requests=len(context_sequence_lengths) + 2,
+            max_num_tokens=8192,
+        )
+
+        position_ids = []
+        for i, tokens in enumerate(past_seen_tokens):
+            seq_len = context_sequence_lengths[i] if i < len(
+                context_sequence_lengths) else 1
+            position_id = torch.arange(tokens,
+                                       tokens + seq_len,
+                                       device=input_ids.device)
+            position_ids.append(position_id)
+
+        position_ids = torch.cat(position_ids).unsqueeze(0)
+
+        with torch.inference_mode():
+            attn_metadata.prepare()
+            logits = qwen2_5_vl.forward(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                attn_metadata=attn_metadata,
+                multimodal_params=multimodal_params_list)
+
+        self.assertEqual(len(past_seen_tokens), logits.shape[0])
+
+        with torch.inference_mode():
+            attn_metadata.prepare()
+            logits = qwen2_5_vl.forward(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                attn_metadata=attn_metadata,
+                return_context_logits=True,
+                multimodal_params=multimodal_params_list)
+        self.assertEqual(input_ids.shape, logits.shape[:-1])
+
+        kv_cache_manager.shutdown()
+
+    @parameterized.expand([
+        Scenario(modality="image",
+                 use_cuda_graph=False,
+                 disable_fuse_rope=False),
+        Scenario(modality="image", use_cuda_graph=False,
+                 disable_fuse_rope=True),
+        Scenario(modality="image", use_cuda_graph=True,
+                 disable_fuse_rope=False),
+        Scenario(modality="image", use_cuda_graph=True, disable_fuse_rope=True),
+    ])
+    @torch.no_grad()
+    def test_qwen2_5_vl_allclose_to_hf(self, scenario: Scenario) -> None:
+        """
+        Compare output to HF.
+        """
+        torch.random.manual_seed(0)
+        config_dict = deepcopy(QWEN2_5_VL_7B_CONFIG)
+        qwen2_5_vl_config = Qwen2_5_VLConfig.from_dict(config_dict)
+
+        dtype = qwen2_5_vl_config.torch_dtype
+        device = torch.device('cuda')
+
+        model_config = ModelConfig(pretrained_config=qwen2_5_vl_config)
+        qwen2_5_vl = Qwen2_5_VLModel(
+            model_config,
+            disable_fuse_rope=scenario.disable_fuse_rope).to(device)
+
+        num_blocks = 5
+        tokens_per_block = 128
+        max_seq_len = num_blocks * tokens_per_block
+        batch_size = 1
+
+        hf_qwen2_5_vl = HFQwen2_5_VLForConditionalLM(qwen2_5_vl_config).to(
+            dtype).to(device).eval()
+
+        weight_mapper = Qwen2VLHfWeightMapper()
+        weight_mapper.init_model_and_config(qwen2_5_vl, model_config)
+        qwen2_5_vl.load_weights(hf_qwen2_5_vl.state_dict(), weight_mapper)
+
+        kv_cache_manager = self.get_kv_cache_manager(
+            dtype=dtype,
+            config=qwen2_5_vl_config,
+            tokens_per_block=tokens_per_block,
+            max_seq_len=max_seq_len,
+            batch_size=batch_size,
+            num_blocks=num_blocks)
+
+        # Context phase.
+        prompt = [
+            "Describe the natural environment in the image.",
+        ]
+        media = [
+            "https://huggingface.co/datasets/YiYiXu/testing-images/resolve/main/seashore.png",
+        ]
+        input_ids, context_sequence_lengths, multimodal_params_list = self.get_trtllm_inputs(
+            qwen2_5_vl, Scenario(modality="image"), device, prompt, media)
+        num_cached_tokens_per_seq = [0]
+        request_ids = [1]
+        token_nums = [input_ids.size(-1)]
+        prompt_lens = [input_ids.size(-1)]
+        kv_cache_manager.add_dummy_requests(request_ids,
+                                            token_nums,
+                                            use_mrope=True)
+
+        metadata_cls = get_attention_backend(model_config.attn_backend).Metadata
+        attn_metadata = metadata_cls(
+            seq_lens=torch.tensor([input_ids.size(-1)], dtype=torch.int),
+            num_contexts=1,
+            kv_cache_params=KVCacheParams(
+                use_cache=True,
+                num_cached_tokens_per_seq=num_cached_tokens_per_seq,
+            ),
+            max_num_requests=1,
+            max_num_tokens=8192,
+            kv_cache_manager=kv_cache_manager,
+            request_ids=request_ids,
+            prompt_lens=prompt_lens,
+        )
+
+        # Mrope position ids
+        position_ids = multimodal_params_list[0].multimodal_data[
+            "mrope_config"]["mrope_position_ids"]
+        position_ids = position_ids.cuda()
+
+        hf_inputs = self.get_hf_inputs(qwen2_5_vl, Scenario(modality="image"),
+                                       device, prompt, media)
+        with torch.inference_mode():
+            attn_metadata.prepare()
+            logits = qwen2_5_vl.forward(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                attn_metadata=attn_metadata,
+                multimodal_params=multimodal_params_list)
+            # NOTE: HF creates its own position_ids inside forward() call
+            ref = hf_qwen2_5_vl.forward(
+                input_ids=hf_inputs["input_ids"],
+                pixel_values=hf_inputs["pixel_values"],
+                image_grid_thw=hf_inputs["image_grid_thw"],
+                use_cache=True)
+            torch.testing.assert_close(logits,
+                                       ref.logits[:, -1].float(),
+                                       atol=0.4,
+                                       rtol=0.4)
+
+        # Generation phase.
+        gen_input_ids = torch.tensor([900], dtype=torch.int, device=device)
+        num_cached_tokens_per_seq = [input_ids.size(-1)]
+        attn_metadata = metadata_cls(
+            seq_lens=torch.tensor([gen_input_ids.size(-1)], dtype=torch.int),
+            num_contexts=0,
+            kv_cache_params=KVCacheParams(
+                use_cache=True,
+                num_cached_tokens_per_seq=num_cached_tokens_per_seq,
+            ),
+            kv_cache_manager=kv_cache_manager,
+            request_ids=request_ids,
+            prompt_lens=prompt_lens,
+            max_num_requests=1,
+            max_num_tokens=8192,
+        )
+        mrope_gen_position_ids = multimodal_params_list[0].multimodal_data[
+            "mrope_config"]["mrope_position_deltas"]
+        gen_position_ids = [
+            torch.arange(input_ids.size(-1),
+                         input_ids.size(-1) + gen_input_ids.size(-1),
+                         dtype=torch.int32)
+        ]
+        gen_position_ids = torch.cat(gen_position_ids)
+        gen_position_ids = (gen_position_ids + mrope_gen_position_ids).expand(
+            3, 1, 1).cuda()
+        gen_multimodal_params_list = []
+        for multimodal_param in multimodal_params_list:
+            multimodal_param.to_device(
+                "multimodal_data",
+                device,
+                pin_memory=True,
+                keyword=["mrope_config.mrope_position_deltas"])
+            gen_multimodal_params_list.append(multimodal_param)
+
+        def run_forward(input_ids, position_ids, attn_metadata,
+                        multimodal_params):
+            attn_metadata.prepare()
+            if not scenario.use_cuda_graph:
+                return qwen2_5_vl.forward(input_ids=input_ids,
+                                          position_ids=position_ids,
+                                          attn_metadata=attn_metadata,
+                                          multimodal_params=multimodal_params)
+            else:
+                graph_runner = DecodingCUDAGraphRunner(
+                    attn_metadata.max_num_requests, "cuda", attn_metadata)
+                graph_runner.capture(
+                    lambda inputs: qwen2_5_vl.forward(**inputs))
+
+                for _ in range(2):
+                    # Run it twice. This helps us catch problems if buffers are accidentally reallocated
+                    # in prepare().
+                    attn_metadata.prepare()
+                    logits = graph_runner.run({
+                        "input_ids":
+                        input_ids,
+                        "position_ids":
+                        position_ids,
+                        "attn_metadata":
+                        attn_metadata,
+                        "multimodal_params":
+                        multimodal_params,
+                    })
+                return logits
+
+        with torch.inference_mode():
+            attn_metadata.prepare()
+            logits = run_forward(input_ids=gen_input_ids,
+                                 position_ids=gen_position_ids,
+                                 attn_metadata=attn_metadata,
+                                 multimodal_params=gen_multimodal_params_list)
+            ref = hf_qwen2_5_vl.forward(input_ids=gen_input_ids.unsqueeze(0),
+                                        position_ids=gen_position_ids,
+                                        past_key_values=ref.past_key_values,
+                                        use_cache=True)
+            torch.testing.assert_close(logits,
+                                       ref.logits[:, -1].float(),
+                                       atol=0.4,
+                                       rtol=0.4)
+
+        kv_cache_manager.shutdown()

--- a/tests/unittest/_torch/modules/test_rotary_embedding.py
+++ b/tests/unittest/_torch/modules/test_rotary_embedding.py
@@ -1,0 +1,160 @@
+import pytest
+import torch
+
+from tensorrt_llm._torch.attention_backend.interface import (RopeParams,
+                                                             RotaryScalingType)
+from tensorrt_llm._torch.modules.rotary_embedding import (MRotaryEmbedding,
+                                                          RotaryEmbedding)
+
+
+class TestRotaryEmbedding:
+    """Test suite for RotaryEmbedding module."""
+
+    @pytest.fixture
+    def basic_rope_params(self):
+        """Create basic RopeParams for testing."""
+        return RopeParams(
+            dim=128,
+            theta=1000000.0,
+            alpha=1.0,
+            scale_type=RotaryScalingType.none,
+            scale=1.0,
+            max_positions=32768,
+            original_max_positions=1024,
+            beta_fast=32,
+            beta_slow=1,
+            mscale=1.0,
+            mscale_all_dim=0.0,
+            short_factor=None,
+            long_factor=None,
+            max_seq_len=None,
+            duplicate_data=True,
+        )
+
+    def test_rotary_embedding_sanity(self, basic_rope_params):
+        """Test RotaryEmbedding with sanity test."""
+        assert torch.cuda.is_available(), "This test requires CUDA"
+        device = "cuda"
+
+        head_dim = 128
+        seq_len = 1000
+        num_heads = 8
+
+        rope = RotaryEmbedding(rope_params=basic_rope_params,
+                               head_dim=head_dim,
+                               is_neox=True)
+
+        # Move rotary_cos_sin to the correct device
+        rope.rotary_cos_sin = rope.rotary_cos_sin.to(device)
+
+        # Create test inputs in remove_input_padding format
+        q = torch.randn(seq_len,
+                        num_heads * head_dim,
+                        dtype=torch.float16,
+                        device=device)
+        k = torch.randn(seq_len,
+                        num_heads * head_dim,
+                        dtype=torch.float16,
+                        device=device)
+        position_ids = torch.arange(seq_len, device=device)
+
+        # Forward pass
+        result = rope.forward(position_ids, [q, k])
+        assert len(result) == 2
+        assert result[0].shape == q.shape
+        assert result[1].shape == k.shape
+
+
+class TestMRotaryEmbedding:
+    """Test suite for MRotaryEmbedding module."""
+
+    @pytest.fixture
+    def basic_rope_params(self):
+        """Create basic RopeParams for testing."""
+        return RopeParams(
+            dim=128,
+            theta=1000000.0,
+            alpha=1.0,
+            scale_type=RotaryScalingType.none,
+            scale=1.0,
+            max_positions=32768,
+            original_max_positions=1024,
+            beta_fast=32,
+            beta_slow=1,
+            mscale=1.0,
+            mscale_all_dim=0.0,
+            short_factor=None,
+            long_factor=None,
+            max_seq_len=None,
+            duplicate_data=True,
+        )
+
+    def test_mrotary_embedding_sanity_3d_position_ids(self, basic_rope_params):
+        """Test MRotaryEmbedding forward pass with 3D position_ids."""
+        assert torch.cuda.is_available(), "This test requires CUDA"
+        device = "cuda"
+        head_dim = 128
+        seq_len = 1000
+        num_heads = 8
+        mrope_section = [16, 24, 24]
+
+        mrope = MRotaryEmbedding(rope_params=basic_rope_params,
+                                 head_dim=head_dim,
+                                 mrope_section=mrope_section,
+                                 is_neox=True)
+
+        # Create test inputs with 3D position_ids (for mrope)
+        q = torch.randn(seq_len,
+                        num_heads * head_dim,
+                        dtype=torch.float16,
+                        device=device)
+        k = torch.randn(seq_len,
+                        num_heads * head_dim,
+                        dtype=torch.float16,
+                        device=device)
+        position_ids = torch.stack([
+            torch.arange(seq_len).unsqueeze(0),
+            torch.arange(seq_len).unsqueeze(0),
+            torch.arange(seq_len).unsqueeze(0)
+        ],
+                                   dim=0)  # Shape: [3, batch_size, seq_len]
+
+        # Forward pass
+        result = mrope.forward(position_ids, [q, k])
+
+        assert len(result) == 2
+        assert result[0].shape == q.shape
+        assert result[1].shape == k.shape
+
+    def test_mrotary_embedding_sanity_1d_position_ids(self, basic_rope_params):
+        """Test MRotaryEmbedding forward pass with 1D position_ids (fallback to regular RoPE)."""
+        assert torch.cuda.is_available(), "This test requires CUDA"
+        device = "cuda"
+
+        head_dim = 128
+        seq_len = 1000
+        num_heads = 8
+        mrope_section = [16, 24, 24]
+
+        mrope = MRotaryEmbedding(rope_params=basic_rope_params,
+                                 head_dim=head_dim,
+                                 mrope_section=mrope_section,
+                                 is_neox=True)
+
+        # Create test inputs with 1D position_ids (fallback case)
+        q = torch.randn(seq_len,
+                        num_heads * head_dim,
+                        dtype=torch.float32,
+                        device=device)
+        k = torch.randn(seq_len,
+                        num_heads * head_dim,
+                        dtype=torch.float32,
+                        device=device)
+        position_ids = torch.arange(seq_len, device=device)
+
+        # Forward pass
+        result = mrope.forward(position_ids, [q, k])
+
+        assert len(result) == 2
+        assert result[0].shape == q.shape
+        assert result[1].shape == k.shape

--- a/tests/unittest/_torch/multimodal/test_find_num_image_tokens.py
+++ b/tests/unittest/_torch/multimodal/test_find_num_image_tokens.py
@@ -4,7 +4,6 @@ import pytest
 import requests
 from PIL import Image
 from transformers import AutoConfig, AutoTokenizer
-from utils.util import getSMVersion
 
 from tensorrt_llm import MultimodalEncoder
 from tensorrt_llm._torch.models.modeling_llava_next import \
@@ -53,12 +52,7 @@ def multimodal_model_configs():
 
 @pytest.mark.parametrize("model_key", [
     "llava-v1.6-mistral-7b-hf",
-    pytest.param(
-        "qwen2.5-vl",
-        marks=pytest.mark.skipif(
-            getSMVersion() >= 100,
-            reason="qwen2.5-vl head_dim=80 is not supported on SM 100 and above"
-        )),
+    "qwen2.5-vl",
 ])
 def test_get_num_tokens_per_image(model_key, multimodal_model_configs):
     """Test that get_num_tokens_per_image predicts the correct number of tokens.
@@ -165,12 +159,7 @@ def test_get_num_tokens_per_image(model_key, multimodal_model_configs):
 
 
 @pytest.mark.parametrize("model_key", [
-    pytest.param(
-        "qwen2.5-vl",
-        marks=pytest.mark.skipif(
-            getSMVersion() >= 100,
-            reason="qwen2.5-vl head_dim=80 is not supported on SM 100 and above"
-        )),
+    "qwen2.5-vl",
 ])
 def test_get_num_tokens_per_video(model_key, multimodal_model_configs):
     """Test that get_num_tokens_per_video predicts the correct number of tokens.

--- a/tests/unittest/_torch/multimodal/test_find_num_image_tokens.py
+++ b/tests/unittest/_torch/multimodal/test_find_num_image_tokens.py
@@ -4,6 +4,7 @@ import pytest
 import requests
 from PIL import Image
 from transformers import AutoConfig, AutoTokenizer
+from utils.util import getSMVersion
 
 from tensorrt_llm import MultimodalEncoder
 from tensorrt_llm._torch.models.modeling_llava_next import \
@@ -52,7 +53,12 @@ def multimodal_model_configs():
 
 @pytest.mark.parametrize("model_key", [
     "llava-v1.6-mistral-7b-hf",
-    "qwen2.5-vl",
+    pytest.param(
+        "qwen2.5-vl",
+        marks=pytest.mark.skipif(
+            getSMVersion() >= 100,
+            reason="qwen2.5-vl head_dim=80 is not supported on SM 100 and above"
+        )),
 ])
 def test_get_num_tokens_per_image(model_key, multimodal_model_configs):
     """Test that get_num_tokens_per_image predicts the correct number of tokens.
@@ -159,7 +165,12 @@ def test_get_num_tokens_per_image(model_key, multimodal_model_configs):
 
 
 @pytest.mark.parametrize("model_key", [
-    "qwen2.5-vl",
+    pytest.param(
+        "qwen2.5-vl",
+        marks=pytest.mark.skipif(
+            getSMVersion() >= 100,
+            reason="qwen2.5-vl head_dim=80 is not supported on SM 100 and above"
+        )),
 ])
 def test_get_num_tokens_per_video(model_key, multimodal_model_configs):
     """Test that get_num_tokens_per_video predicts the correct number of tokens.

--- a/tests/unittest/_torch/multimodal/test_share_multiparams.py
+++ b/tests/unittest/_torch/multimodal/test_share_multiparams.py
@@ -146,7 +146,7 @@ class TestMultimodalParamsDeviceTransfer(unittest.TestCase):
         result = params.multimodal_data["image"]["pixel_values"]
         self.assertEqual(result.device, torch.device("cuda:0"))
 
-    def test_to_device_with_keyword(self):
+    def test_to_device_with_filter_keywords(self):
         """Test converting data to device with keyword."""
         params = MultimodalParams()
         params.multimodal_data = self.sample_multimodal_data.copy()
@@ -154,7 +154,7 @@ class TestMultimodalParamsDeviceTransfer(unittest.TestCase):
         params.to_device("multimodal_data",
                          device="cuda:0",
                          pin_memory=True,
-                         keyword=["image.pixel_values"])
+                         filter_keywords=["image.pixel_values"])
 
         result = params.multimodal_data["image"]["pixel_values"]
         self.assertEqual(result.device, torch.device("cuda:0"))

--- a/tests/unittest/_torch/multimodal/test_share_multiparams.py
+++ b/tests/unittest/_torch/multimodal/test_share_multiparams.py
@@ -146,7 +146,7 @@ class TestMultimodalParamsDeviceTransfer(unittest.TestCase):
         result = params.multimodal_data["image"]["pixel_values"]
         self.assertEqual(result.device, torch.device("cuda:0"))
 
-    def test_to_device_with_filter_keywords(self):
+    def test_to_device_with_target_keywords(self):
         """Test converting data to device with keyword."""
         params = MultimodalParams()
         params.multimodal_data = self.sample_multimodal_data.copy()
@@ -154,7 +154,7 @@ class TestMultimodalParamsDeviceTransfer(unittest.TestCase):
         params.to_device("multimodal_data",
                          device="cuda:0",
                          pin_memory=True,
-                         filter_keywords=["image.pixel_values"])
+                         target_keywords=["image.pixel_values"])
 
         result = params.multimodal_data["image"]["pixel_values"]
         self.assertEqual(result.device, torch.device("cuda:0"))

--- a/tests/unittest/_torch/multimodal/test_share_multiparams.py
+++ b/tests/unittest/_torch/multimodal/test_share_multiparams.py
@@ -146,6 +146,25 @@ class TestMultimodalParamsDeviceTransfer(unittest.TestCase):
         result = params.multimodal_data["image"]["pixel_values"]
         self.assertEqual(result.device, torch.device("cuda:0"))
 
+    def test_to_device_with_keyword(self):
+        """Test converting data to device with keyword."""
+        params = MultimodalParams()
+        params.multimodal_data = self.sample_multimodal_data.copy()
+
+        params.to_device("multimodal_data",
+                         device="cuda:0",
+                         pin_memory=True,
+                         keyword=["image.pixel_values"])
+
+        result = params.multimodal_data["image"]["pixel_values"]
+        self.assertEqual(result.device, torch.device("cuda:0"))
+
+        result = params.multimodal_data["mrope_config"]["mrope_rotary_cos_sin"]
+        self.assertEqual(result.device, torch.device("cpu"))
+
+        result = params.multimodal_data["mrope_config"]["mrope_position_deltas"]
+        self.assertEqual(result.device, torch.device("cpu"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added multimodal mRoPE support across models, enabling Qwen2/Qwen2.5-VL with configurable rope fusion.
  - Enabled importing HuggingFace Qwen2-VL weights through a new mapping flow.
  - Added selective device transfer for multimodal inputs via path filtering.

- Performance
  - CUDA Graphs path now supports mRoPE with per-batch parameters and non-blocking transfers.

- Improvements
  - Refined vision encoder integration and positional handling.
  - Quickstart example can optionally print context/generation logits and logprobs via flags.

- Tests
  - Added comprehensive Qwen2.5-VL integration tests and a unit test for selective device transfer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->