### PR TITLE
[None][chore] Replace --eos_id with --ignore_eos in trtllm-bench

### DIFF
--- a/docs/source/blogs/tech_blog/blog4_Scaling_Expert_Parallelism_in_TensorRT-LLM.md
+++ b/docs/source/blogs/tech_blog/blog4_Scaling_Expert_Parallelism_in_TensorRT-LLM.md
@@ -556,7 +556,7 @@ trtllm-bench --model ${MODEL_NAME} \
     --backend pytorch \
     --dataset ./dataset.json \
     --warmup 0 \
-    --eos_id -1
+    --ignore_eos=True
 ```
 
 After inference, review the dumped statistic files in `$EXPERT_STATISTIC_PATH`. Run the `examples/ep_load_balancer/report_load_statistics.py` script to show the standard deviation and imbalance ratio metrics:
@@ -638,7 +638,7 @@ trtllm-bench --model ${MODEL_NAME} \
     --backend pytorch \
     --dataset ./dataset.json \
     --warmup 0 \
-    --eos_id -1
+    --ignore_eos=True
 ```
 
 Run the `examples/ep_load_balancer/report_load_statistics.py` script again:

--- a/examples/wide_ep/ep_load_balancer/README.md
+++ b/examples/wide_ep/ep_load_balancer/README.md
@@ -43,7 +43,7 @@ trtllm-bench --model ${MODEL_NAME} \
     --kv_cache_free_gpu_mem_fraction 0.75 \
     --dataset ./dataset.json \
     --warmup 0 \
-    --eos_id -1
+    --ignore_eos=True
 ```
 
 After inference, review the dumped statistic files in `$EXPERT_STATISTIC_PATH`. For each layer and iteration, the load imbalance can be measured using simple metrics such as the standard deviation or the imbalance ratio. Given the routed token counts for all ranks, the imbalance ratio is defined as $(max - mean) / mean$, which represents the excessive workload received by the hottest rank. A perfectly balanced load would have an imbalance ratio of 0. Run the [`report_load_statistics.py`](./report_load_statistics.py) script:
@@ -134,7 +134,7 @@ trtllm-bench --model ${MODEL_NAME} \
     --kv_cache_free_gpu_mem_fraction 0.75 \
     --dataset ./dataset.json \
     --warmup 0 \
-    --eos_id -1
+    --ignore_eos=True
 ```
 
 Run the [`report_load_statistics.py`](./report_load_statistics.py) script again:
@@ -200,7 +200,7 @@ trtllm-bench --model ${MODEL_NAME} \
     --kv_cache_free_gpu_mem_fraction 0.75 \
     --dataset ./dataset.json \
     --warmup 0 \
-    --eos_id -1
+    --ignore_eos=True
 ```
 
 > **Note:** Similar to offline EP Load Balancer, you can enable expert ID counting to verify the effectiveness of EPLB, but remember to disable it when running inference for benchmarking or production purposes.

--- a/tensorrt_llm/bench/benchmark/low_latency.py
+++ b/tensorrt_llm/bench/benchmark/low_latency.py
@@ -296,6 +296,8 @@ def latency_command(
         ignore_eos = True if runtime_config.decoding_config.decoding_mode == SpeculativeDecodingMode.NONE else False
         eos_id = tokenizer.eos_token_id if not ignore_eos else -1
         pad_id = tokenizer.pad_token_id if not ignore_eos else -1
+        if pad_id is None:  # LLAMA2 does not have a pad token
+            pad_id = eos_id
 
         sampler_args = {
             "end_id": eos_id,

--- a/tensorrt_llm/bench/benchmark/throughput.py
+++ b/tensorrt_llm/bench/benchmark/throughput.py
@@ -126,12 +126,12 @@ from tensorrt_llm.sampling_params import SamplingParams
     help="Do not skip tokenizer initialization when loading the model.",
 )
 @optgroup.option(
-    "--eos_id",
-    type=int,
-    default=-1,
+    "--ignore_eos",
+    type=bool,
+    default=True,
     required=False,
     help=
-    "Set the end-of-sequence token for the benchmark. Set to -1 to disable EOS.",
+    "Ignore EOS token in the dataset by setting the eos_id to -1. Set to False to use the EOS token in the dataset.",
 )
 @optgroup.option(
     "--modality",
@@ -411,9 +411,14 @@ def throughput_command(
 
         llm = get_llm(runtime_config, kwargs)
 
+        eos_id = tokenizer.eos_token_id if not options.ignore_eos else -1
+        pad_id = tokenizer.pad_token_id if not options.ignore_eos else -1
+        if pad_id is None:  # LLAMA2 does not have a pad token
+            pad_id = eos_id
+
         sampler_args = {
-            "end_id": options.eos_id,
-            "pad_id": options.eos_id,
+            "end_id": eos_id,
+            "pad_id": pad_id,
             "n": options.beam_width,
             "use_beam_search": options.beam_width > 1
         }

--- a/tests/integration/defs/perf/test_perf.py
+++ b/tests/integration/defs/perf/test_perf.py
@@ -1336,7 +1336,12 @@ class MultiMetricPerfTest(AbstractPerfScriptTestClass):
             benchmark_cmd += [
                 f"--lora_num_device_mod_layers={32 * num_layers * num_lora_mods * max_lora_rank}"
             ]
-            benchmark_cmd += [f"--eos_id={eos_id}"]
+            # If using trtllm-bench, use --ignore_eos instead of --eos_id.
+            # If using cpp benchmarking scripts like bertBenchmark, gptManagerBenchmark, use --eos_id.
+            benchmark_cmd += [f"--eos_id={eos_id}"
+                              ] if "trtllm-bench" not in benchmark_cmd else [
+                                  f"--ignore_eos=False"
+                              ]
             benchmark_cmd += [f"--lora_dir={lora_dir}"]
         else:
             dataset_path = os.path.join(engine_dir, "synthetic_data.json")


### PR DESCRIPTION
## Description

Previously, trtllm-bench used an --eos_id argument (default -1) for sampling. With eos_id = -1, the EOS token was ignored and output was generated to the maximum sequence length. To properly enable EOS termination, users had to manually set tokenizer.eos_token_id, which is model-dependent and error-prone.

This PR replaces --eos_id with a boolean flag --ignore_eos (default: True), making EOS handling simpler and more intuitive.

Note: --eos_id is still used by the C++ benchmarking scripts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added --ignore_eos flag for throughput benchmarking, replacing numeric --eos_id; default ignores EOS tokens and auto-derives EOS/pad handling.

- Bug Fixes
  - Improved padding fallback: when no pad token exists, padding falls back to EOS to enhance compatibility with models that lack a pad token.

- Documentation
  - Updated blog and README examples to use --ignore_eos=True.

- Tests
  - Updated integration benchmarks to conditionally use --ignore_eos for relevant scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->


## Test Coverage
Existing test in `tests/integration/defs/perf/test_perf.py`

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
