### PR TITLE
[TRTLLM-7440][fix] Split `fused_input_embed` to separate out host sync

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_gemma3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma3vl.py
@@ -263,7 +263,9 @@ class Gemma3VLM(PreTrainedModel):
             embedding_layer=self.llm.model.embed_tokens,
             input_ids=input_ids,
             mm_embeds=mm_embeds,
-            mm_token_ids=self.image_token_ids)
+            mm_token_ids=self.image_token_ids,
+            **kwargs,
+        )
         logits = self.llm.forward(
             attn_metadata=attn_metadata,
             input_ids=input_ids,

--- a/tensorrt_llm/_torch/models/modeling_gemma3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma3vl.py
@@ -286,3 +286,7 @@ class Gemma3VLM(PreTrainedModel):
                                                attn_metadata=attn_metadata)[-1]
             image_features = self.mm_projector(image_features)
         return image_features
+
+    @property
+    def mm_token_ids(self):
+        return self.image_token_ids

--- a/tensorrt_llm/_torch/models/modeling_hyperclovax.py
+++ b/tensorrt_llm/_torch/models/modeling_hyperclovax.py
@@ -1052,7 +1052,8 @@ class HCXVisionForCausalLM(PreTrainedModel):
                 ]
 
         input_ids, input_embeds = fuse_input_embeds(self.llm.model.embed_tokens,
-                                                    input_ids, mm_embeds)
+                                                    input_ids, mm_embeds,
+                                                    **kwargs)
         output_prob = self.llm.forward(
             attn_metadata=attn_metadata,
             input_ids=input_ids,

--- a/tensorrt_llm/_torch/models/modeling_llama.py
+++ b/tensorrt_llm/_torch/models/modeling_llama.py
@@ -1280,7 +1280,8 @@ class Llama4ForConditionalGeneration(SpecDecOneEngineForCausalLM[Llama4Model,
                 ]
 
         input_ids, inputs_embeds = fuse_input_embeds(self.model.embed_tokens,
-                                                     input_ids, mm_embeds)
+                                                     input_ids, mm_embeds,
+                                                     **kwargs)
         return super().forward(attn_metadata,
                                input_ids,
                                position_ids,

--- a/tensorrt_llm/_torch/models/modeling_llava_next.py
+++ b/tensorrt_llm/_torch/models/modeling_llava_next.py
@@ -485,7 +485,7 @@ class LlavaNextModel(PreTrainedModel):
                     for multimodal_param in multimodal_params
                 ]
         input_ids, inputs_embeds = fuse_input_embeds(
-            self.llm.model.embed_tokens, input_ids, mm_embeds)
+            self.llm.model.embed_tokens, input_ids, mm_embeds, **kwargs)
 
         logits = self.llm.forward(attn_metadata, input_ids, position_ids,
                                   inputs_embeds, return_context_logits)

--- a/tensorrt_llm/_torch/models/modeling_mistral.py
+++ b/tensorrt_llm/_torch/models/modeling_mistral.py
@@ -502,6 +502,10 @@ class Mistral3VLM(PreTrainedModel):
         ]
         return torch.cat(pixel_values), batched_image_sizes
 
+    @property
+    def mm_token_ids(self):
+        return self._image_token_ids
+
 
 # Original implementation:
 # https://github.com/huggingface/transformers/blob/v4.51.3/src/transformers/models/mistral3/modeling_mistral3.py#L66

--- a/tensorrt_llm/_torch/models/modeling_mistral.py
+++ b/tensorrt_llm/_torch/models/modeling_mistral.py
@@ -15,7 +15,7 @@ from tensorrt_llm._torch.attention_backend.interface import (
 from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.models import modeling_pixtral
 from tensorrt_llm._torch.models.modeling_multimodal_utils import \
-    fuse_input_embeds, fuse_input_embeds_cuda
+    fuse_input_embeds
 from tensorrt_llm._torch.models.modeling_utils import (DecoderModel,
                                                        DecoderModelForCausalLM,
                                                        _load_weights_impl,
@@ -401,27 +401,15 @@ class Mistral3VLM(PreTrainedModel):
                 self._get_image_features(pixel_values=batched_pixel_values,
                                          image_sizes=batched_image_sizes)
             ]
-
+        
         with nvtx_range("[mistral] Fuse input embeds"):
-            text_token_indices = kwargs.get("text_token_indices", None)
-            mm_token_indices = kwargs.get("mm_token_indices", None)
-            if text_token_indices is not None and mm_token_indices is not None:
-                input_ids, inputs_embeds = fuse_input_embeds_cuda(
-                    embedding_layer=self.llm.model.embed_tokens,
-                    input_ids=input_ids,
-                    text_token_indices=text_token_indices,
-                    mm_token_indices=mm_token_indices,
-                    mm_embeds=mm_embeds,
-                )
-            else:
-                # fallback to the implementation w/ host sync (from torch.where)
-                # TODO: remove this fallback after all models are supported
-                input_ids, inputs_embeds = fuse_input_embeds(
-                    embedding_layer=self.llm.model.embed_tokens,
-                    input_ids=input_ids,
-                    mm_embeds=mm_embeds,
-                    mm_token_ids=self._image_token_ids,
-                )
+            input_ids, inputs_embeds = fuse_input_embeds(
+                embedding_layer=self.llm.model.embed_tokens,
+                input_ids=input_ids,
+                mm_embeds=mm_embeds,
+                mm_token_ids=self._image_token_ids,
+                **kwargs,
+            )
 
         return self.llm.forward(
             attn_metadata=attn_metadata,

--- a/tensorrt_llm/_torch/models/modeling_mistral.py
+++ b/tensorrt_llm/_torch/models/modeling_mistral.py
@@ -401,7 +401,7 @@ class Mistral3VLM(PreTrainedModel):
                 self._get_image_features(pixel_values=batched_pixel_values,
                                          image_sizes=batched_image_sizes)
             ]
-        
+
         with nvtx_range("[mistral] Fuse input embeds"):
             input_ids, inputs_embeds = fuse_input_embeds(
                 embedding_layer=self.llm.model.embed_tokens,

--- a/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
@@ -105,6 +105,77 @@ def find_uncached_mm_embeds(
     return sliced_mm_embeds
 
 
+def filter_mm_token_from_input_ids(
+    input_ids: torch.IntTensor,
+    vocab_size: int,
+    mm_token_ids: Optional[torch.IntTensor] = None,
+) -> Tuple[torch.IntTensor, torch.IntTensor]:
+    if mm_token_ids is None:
+        # NOTE:
+        # If mm_token_ids is None, it is assumed that the multimodal
+        # tokens are out-of-vocab tokens i.e. the `input_ids` contains
+        # tokens >= vocab_size that represent the multimodal tokens.
+        # Since mm_token_ids is be unbounded in this case,
+        # using torch.isin() may not be performant.
+        # This provides a more performant alternative while keeping
+        # the flexibility of still specifying all possible mm_token_ids,
+        # if the user wants to.
+        mm_token_mask = input_ids >= vocab_size
+        text_token_mask = input_ids < vocab_size
+    else:
+        mm_token_ids = mm_token_ids.to(input_ids.device)
+        mm_token_mask = torch.isin(input_ids, mm_token_ids)
+        text_token_mask = ~mm_token_mask
+    text_token_indices = torch.where(text_token_mask)[0]
+    mm_token_indices = torch.where(mm_token_mask)[0]
+    return text_token_indices, mm_token_indices
+
+
+def fuse_input_embeds_cuda(
+    embedding_layer: Embedding,
+    input_ids: torch.IntTensor,
+    text_token_indices: torch.IntTensor,
+    mm_token_indices: torch.IntTensor,
+    mm_embeds: List[torch.Tensor],
+) -> Tuple[Optional[torch.FloatTensor], Optional[torch.FloatTensor]]:
+    """
+    Fuse text and multimodal embeddings. input_ids is [text_total_length + mm_total_length] and mm_embed is [mm_total_length, hidden_dim]. We just need to fuse them into [text_total_length + mm_total_length, hidden_dim] by slice-and-assign to the corresponding entries.
+
+    Args:
+        input_ids: shape [text_total_length + mm_total_length], flattened from List[(text_length1 + mm_total_length1), ..., (text_lengthi + mm_total_lengthi)]. For LLM model, the requests are inflight batched together, but the input_ids are flattened with padding removed. By the slice condition < vocab_size, we can easily separate text / multimodal tokens and naturally batched the LLM embedding lookup
+        text_token_indices: indices of text tokens in the input_ids
+        mm_token_indices: indices of multimodal tokens in the input_ids
+        mm_embeds: List[(mm_total_length1, hidden_dim), ..., (mm_total_lengthi, hidden_dim)].
+    Returns:
+        - If (1) JIT test run, (2) non-multimodal run, i.e. all text-only requests, either context or generation phase (3) multimodal run, all requests in generation phase --> there is no multimodal data, return only the input_ids
+        - If (4) multimodal run, mixed batch of context and generation requests, each context request has a multimodal feature --> return only the fused input_embeds of shape [total length, hidden_dim]. For text tokens, LLM embedding layer has already run.
+    """
+    if len(mm_embeds) == 0:
+        return input_ids, None
+
+    mm_embed = torch.cat(mm_embeds, dim=0)
+
+    if mm_token_indices.shape[0] != mm_embed.shape[0]:
+        raise ValueError(
+            f"Multimodal token count mismatch: found {len(mm_token_indices)} image tokens in input_ids "
+            f"but received {mm_embed.shape[0]} image embeddings. "
+            "This is likely due to KV cache reuse, chunk prefill, or other optimizations that "
+            "cause token count mismatches within the inference batch.")
+
+    text_embed = embedding_layer(input_ids[text_token_indices])
+    input_embeds = torch.empty(input_ids.shape[0],
+                               mm_embed.shape[-1],
+                               device=text_embed.device,
+                               dtype=text_embed.dtype)
+
+    input_embeds[text_token_indices, :] = text_embed.to(
+        dtype=input_embeds.dtype, device=input_embeds.device)
+    input_embeds[mm_token_indices, :] = mm_embed.to(dtype=input_embeds.dtype,
+                                                    device=input_embeds.device)
+
+    return None, input_embeds
+
+
 def fuse_input_embeds(
     embedding_layer: Embedding,
     input_ids: torch.IntTensor,

--- a/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
@@ -110,12 +110,25 @@ def filter_mm_token_from_input_ids(
     vocab_size: int,
     mm_token_ids: Optional[torch.IntTensor] = None,
 ) -> Tuple[torch.IntTensor, torch.IntTensor]:
+    """
+    Filter multimodal tokens from input_ids.
+    Args:
+        input_ids: shape [text_total_length + mm_total_length].
+        vocab_size: size of the model's vocabulary
+        mm_token_ids: possible token ids for multimodal tokens, if known. If not known and set to None, it is assumed that the multimodal tokens are out-of-vocabulary tokens i.e. the `input_ids` contains tokens >= vocab_size that represent the multimodal tokens.
+    Note:
+        This function involves host device sync due to the use of torch.where() (= torch.nonzero) which requires allocation on host.
+        The output indices reside on the same device as input_ids.
+    Returns:
+        text_token_indices: indices of text tokens in the input_ids
+        mm_token_indices: indices of multimodal tokens in the input_ids
+    """
     if mm_token_ids is None:
         # NOTE:
         # If mm_token_ids is None, it is assumed that the multimodal
         # tokens are out-of-vocab tokens i.e. the `input_ids` contains
         # tokens >= vocab_size that represent the multimodal tokens.
-        # Since mm_token_ids is be unbounded in this case,
+        # Since mm_token_ids can be unbounded in this case,
         # using torch.isin() may not be performant.
         # This provides a more performant alternative while keeping
         # the flexibility of still specifying all possible mm_token_ids,
@@ -168,8 +181,7 @@ def fuse_input_embeds_cuda(
                                device=text_embed.device,
                                dtype=text_embed.dtype)
 
-    input_embeds[text_token_indices, :] = text_embed.to(
-        dtype=input_embeds.dtype, device=input_embeds.device)
+    input_embeds[text_token_indices, :] = text_embed
     input_embeds[mm_token_indices, :] = mm_embed.to(dtype=input_embeds.dtype,
                                                     device=input_embeds.device)
 
@@ -183,59 +195,26 @@ def fuse_input_embeds(
     mm_token_ids: Optional[torch.IntTensor] = None,
 ) -> Tuple[Optional[torch.FloatTensor], Optional[torch.FloatTensor]]:
     """
-    Fuse text and multimodal embeddings. input_ids is [text_total_length + mm_total_length] and mm_embed is [mm_total_length, hidden_dim]. We just need to fuse them into [text_total_length + mm_total_length, hidden_dim] by slice-and-assign to the corresponding entries.
-
+    Filter multimodal tokens from input_ids and fuse text and multimodal embeddings.
     Args:
-        input_ids: shape [text_total_length + mm_total_length], flattened from List[(text_length1 + mm_total_length1), ..., (text_lengthi + mm_total_lengthi)]. For LLM model, the requests are inflight batched together, but the input_ids are flattened with padding removed. By the slice condition < vocab_size, we can easily separate text / multimodal tokens and naturally batched the LLM embedding lookup
-        mm_embed: List[(mm_total_length1, hidden_dim), ..., (mm_total_lengthi, hidden_dim)].
-        mm_token_ids: possible token ids for multimodal tokens, if known. If not known and set to None, it is assumed that the multimodal tokens are out-of-vocabulary tokens i.e. the `input_ids` contains tokens >= vocab_size that represent the multimodal tokens.
+        embedding_layer: embedding layer of the model.
+        input_ids: shape [text_total_length + mm_total_length].
+        mm_embeds: list of multimodal embeddings.
+        mm_token_ids: possible token ids for multimodal tokens, if known. If not known and set to None, it is assumed that the multimodal tokens are out-of-vocabulary tokens.
     Returns:
         - If (1) JIT test run, (2) non-multimodal run, i.e. all text-only requests, either context or generation phase (3) multimodal run, all requests in generation phase --> there is no multimodal data, return only the input_ids
         - If (4) multimodal run, mixed batch of context and generation requests, each context request has a multimodal feature --> return only the fused input_embeds of shape [total length, hidden_dim]. For text tokens, LLM embedding layer has already run.
+    Note:
+        This function involves host device sync due to the use of torch.where() from filter_mm_token_from_input_ids.
     """
-    if len(mm_embeds) == 0:
-        return input_ids, None
-
-    mm_embed = torch.cat(mm_embeds, dim=0)
-
-    if mm_token_ids is None:
-        # NOTE:
-        # If mm_token_ids is None, it is assumed that the multimodal
-        # tokens are out-of-vocab tokens i.e. the `input_ids` contains
-        # tokens >= vocab_size that represent the multimodal tokens.
-        # Since mm_token_ids is be unbounded in this case,
-        # using torch.isin() may not be performant.
-        # This provides a more performant alternative while keeping
-        # the flexibility of still specifying all possible mm_token_ids,
-        # if the user wants to.
-        vocab_size = embedding_layer.num_embeddings
-        mm_token_mask = input_ids >= vocab_size
-        text_token_mask = input_ids < vocab_size
-    else:
-        mm_token_ids = mm_token_ids.to(input_ids.device)
-        mm_token_mask = torch.isin(input_ids, mm_token_ids)
-        text_token_mask = ~mm_token_mask
-    text_token_indices = torch.where(text_token_mask)[0]
-    mm_token_indices = torch.where(mm_token_mask)[0]
-    if len(mm_token_indices) != mm_embed.shape[0]:
-        raise ValueError(
-            f"Multimodal token count mismatch: found {len(mm_token_indices)} image tokens in input_ids "
-            f"but received {mm_embed.shape[0]} image embeddings. "
-            "This is likely due to KV cache reuse, chunk prefill, or other optimizations that "
-            "cause token count mismatches within the inference batch.")
-
-    text_embed = embedding_layer(input_ids[text_token_indices])
-    input_embeds = torch.empty(input_ids.shape[0],
-                               mm_embed.shape[-1],
-                               device=text_embed.device,
-                               dtype=text_embed.dtype)
-
-    input_embeds[text_token_indices, :] = text_embed.to(
-        dtype=input_embeds.dtype, device=input_embeds.device)
-    input_embeds[mm_token_indices, :] = mm_embed.to(dtype=input_embeds.dtype,
-                                                    device=input_embeds.device)
-
-    return None, input_embeds
+    text_token_indices, mm_token_indices = filter_mm_token_from_input_ids(
+        input_ids,
+        vocab_size=embedding_layer.num_embeddings,
+        mm_token_ids=mm_token_ids)
+    # text_token_indices, mm_token_indices resides on the same device as input_ids
+    return fuse_input_embeds_cuda(embedding_layer, input_ids,
+                                  text_token_indices, mm_token_indices,
+                                  mm_embeds)
 
 
 #region VILA utils

--- a/tensorrt_llm/_torch/models/modeling_phi4mm.py
+++ b/tensorrt_llm/_torch/models/modeling_phi4mm.py
@@ -653,7 +653,3 @@ class Phi4MMForCausalLM(transformers.PreTrainedModel):
             ]
 
         return lora_request
-
-    @property
-    def mm_token_ids(self):
-        return self.MM_TOKEN_IDS

--- a/tensorrt_llm/_torch/models/modeling_phi4mm.py
+++ b/tensorrt_llm/_torch/models/modeling_phi4mm.py
@@ -594,6 +594,7 @@ class Phi4MMForCausalLM(transformers.PreTrainedModel):
             input_ids,
             mm_embedding,
             mm_token_ids=self.mm_token_ids,
+            **kwargs,
         )
 
         output_prob = self.llm.forward(
@@ -652,3 +653,7 @@ class Phi4MMForCausalLM(transformers.PreTrainedModel):
             ]
 
         return lora_request
+
+    @property
+    def mm_token_ids(self):
+        return self.MM_TOKEN_IDS

--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -642,7 +642,8 @@ class Qwen2VLModelBase(PreTrainedModel):
                 'mrope_position_deltas']
 
         input_ids, input_embeds = fuse_input_embeds(self.llm.model.embed_tokens,
-                                                    input_ids, mm_embeds)
+                                                    input_ids, mm_embeds,
+                                                    **kwargs)
         output_prob = self.llm.forward(
             attn_metadata=attn_metadata,
             input_ids=input_ids,

--- a/tensorrt_llm/_torch/models/modeling_vila.py
+++ b/tensorrt_llm/_torch/models/modeling_vila.py
@@ -1186,7 +1186,7 @@ class VilaModel(PreTrainedModel):
             ]
 
         input_ids, inputs_embeds = fuse_input_embeds(
-            self.llm.model.embed_tokens, input_ids, mm_embeds)
+            self.llm.model.embed_tokens, input_ids, mm_embeds, **kwargs)
         logits = self.llm.forward(attn_metadata=attn_metadata,
                                   input_ids=input_ids,
                                   position_ids=position_ids,

--- a/tensorrt_llm/_torch/modules/embedding.py
+++ b/tensorrt_llm/_torch/modules/embedding.py
@@ -138,25 +138,23 @@ def pre_comm_embedding_ops(
     padding_size: int,
 ):
     # Generate the mask for the input if needed.
-    if tp_size > 1:
-        if tp_mode == TensorParallelMode.COLUMN:
-            input_, input_mask = get_masked_input_and_mask(
-                input_,
-                vocab_start_index,
-                vocab_end_index,
-            )
+    if tp_mode == TensorParallelMode.COLUMN:
+        input_, input_mask = get_masked_input_and_mask(
+            input_,
+            vocab_start_index,
+            vocab_end_index,
+        )
 
     # Get the embeddings.
     output = F.embedding(input_, weight)
 
     # Mask or pad the output if needed.
-    if tp_size > 1:
-        if tp_mode == TensorParallelMode.COLUMN:
-            output.masked_fill_(input_mask, 0)
-        elif tp_mode == TensorParallelMode.ROW:
-            if gather_output:
-                if tp_rank == tp_size - 1 and padding_size > 0:
-                    output = F.pad(output, (0, padding_size))
+    if tp_mode == TensorParallelMode.COLUMN:
+        output.masked_fill_(input_mask, 0)
+    elif tp_mode == TensorParallelMode.ROW:
+        if gather_output:
+            if tp_rank == tp_size - 1 and padding_size > 0:
+                output = F.pad(output, (0, padding_size))
 
     return output
 
@@ -205,9 +203,9 @@ class Embedding(LMHead):
             self.vocab_end_index = num_embeddings
 
     def forward(self, input):
-        # Run the ops before all_reduce/all_gather.
-        # We use torch.compile() to fuse the tiny pointwise ops before all_reduce/all_gather for Embedding module.
         if self.tp_size > 1:
+            # Run the ops before all_reduce/all_gather.
+            # We use torch.compile() to fuse the tiny pointwise ops before all_reduce/all_gather for Embedding module.
             embedding_ops_func = torch.compile(
                 pre_comm_embedding_ops,
                 options={"max-autotune": True},

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -43,6 +43,7 @@ from ..metadata import KVCacheParams
 from ..model_config import ModelConfig, MoeLoadBalancerConfig
 from ..models import AutoModelForCausalLM
 from ..models.checkpoints.base_checkpoint_loader import BaseCheckpointLoader
+from ..models.modeling_multimodal_utils import filter_mm_token_from_input_ids
 from ..models.modeling_utils import (DecoderModelForCausalLM, MetaInitMode,
                                      timing)
 from ..modules.fused_moe.moe_load_balancer import (
@@ -1260,6 +1261,18 @@ class PyTorchModelEngine(ModelEngine):
 
         return total_num_tokens, False, attn_all_rank_num_tokens
 
+    def _prepare_multimodal_indices(self, input_ids: list[int]):
+        input_ids = torch.tensor(input_ids, dtype=torch.int, device="cpu")
+        vocab_size = self.model.config.vocab_size
+        if hasattr(self.model, '_image_token_ids'):
+            mm_token_ids = self.model._image_token_ids
+        else:
+            mm_token_ids = None
+
+        text_token_indices, mm_token_indices = filter_mm_token_from_input_ids(
+            input_ids, vocab_size=vocab_size, mm_token_ids=mm_token_ids)
+        return text_token_indices, mm_token_indices
+
     def _prepare_tp_inputs(
             self,
             scheduled_requests: ScheduledRequests,
@@ -1336,6 +1349,10 @@ class PyTorchModelEngine(ModelEngine):
 
             request.py_batch_idx = request.py_seq_slot
 
+        if len(multimodal_params_list) > 0:
+            _, mm_token_indices = self._prepare_multimodal_indices(input_ids)
+        else:
+            mm_token_indices = None
         num_ctx_requests = len(scheduled_requests.context_requests)
         num_ctx_tokens = len(input_ids)
 
@@ -1699,11 +1716,20 @@ class PyTorchModelEngine(ModelEngine):
                 spec_metadata.all_rank_num_tokens = spec_all_rank_num_tokens
                 spec_metadata.all_rank_num_seqs = all_rank_num_seqs
 
+        if mm_token_indices is not None:
+            mask = torch.ones(total_num_tokens, dtype=torch.bool)
+            mask[mm_token_indices] = False
+            inputs['mm_token_indices'] = mm_token_indices.pin_memory().to(
+                "cuda", non_blocking=True)
+            inputs['text_token_indices'] = torch.where(mask)[0].pin_memory().to(
+                "cuda", non_blocking=True)
+
         num_generation_tokens = len(generation_requests) + len(
             extend_requests) + sum(draft_lens)
         self.iter_states['num_ctx_requests'] = num_ctx_requests
         self.iter_states['num_ctx_tokens'] = num_ctx_tokens
         self.iter_states['num_generation_tokens'] = num_generation_tokens
+
         return inputs, self.gather_ids_cuda[:len(
             gather_ids)] if self.enable_spec_decode else None
 

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1264,10 +1264,8 @@ class PyTorchModelEngine(ModelEngine):
     def _prepare_multimodal_indices(self, input_ids: list[int]):
         input_ids = torch.tensor(input_ids, dtype=torch.int, device="cpu")
         vocab_size = self.model.config.vocab_size
-        if hasattr(self.model, '_image_token_ids'):
-            mm_token_ids = self.model._image_token_ids
-        else:
-            mm_token_ids = None
+        # TODO: unify naming of mm_token_ids across models
+        mm_token_ids = getattr(self.model, "_image_token_ids", None)
 
         text_token_indices, mm_token_indices = filter_mm_token_from_input_ids(
             input_ids, vocab_size=vocab_size, mm_token_ids=mm_token_ids)

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1348,6 +1348,7 @@ class PyTorchModelEngine(ModelEngine):
             request.py_batch_idx = request.py_seq_slot
 
         if len(multimodal_params_list) > 0:
+            # discard the text token indices as it only includes context tokens at this moment
             _, mm_token_indices = self._prepare_multimodal_indices(input_ids)
         else:
             mm_token_indices = None
@@ -1727,7 +1728,6 @@ class PyTorchModelEngine(ModelEngine):
         self.iter_states['num_ctx_requests'] = num_ctx_requests
         self.iter_states['num_ctx_tokens'] = num_ctx_tokens
         self.iter_states['num_generation_tokens'] = num_generation_tokens
-
         return inputs, self.gather_ids_cuda[:len(
             gather_ids)] if self.enable_spec_decode else None
 

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1265,7 +1265,7 @@ class PyTorchModelEngine(ModelEngine):
         input_ids = torch.tensor(input_ids, dtype=torch.int, device="cpu")
         vocab_size = self.model.config.vocab_size
         # TODO: unify naming of mm_token_ids across models
-        mm_token_ids = getattr(self.model, "_image_token_ids", None)
+        mm_token_ids = getattr(self.model, "mm_token_ids", None)
 
         text_token_indices, mm_token_indices = filter_mm_token_from_input_ids(
             input_ids, vocab_size=vocab_size, mm_token_ids=mm_token_ids)
@@ -1349,6 +1349,9 @@ class PyTorchModelEngine(ModelEngine):
 
         if len(multimodal_params_list) > 0:
             # discard the text token indices as it only includes context tokens at this moment
+            print(
+                f"len multimodal_params_list: {len(multimodal_params_list)} from model_engine"
+            )
             _, mm_token_indices = self._prepare_multimodal_indices(input_ids)
         else:
             mm_token_indices = None

--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -188,6 +188,8 @@ class MultimodalParams:
     multimodal_input: Optional[MultimodalInput] = None
     multimodal_data: Optional[Dict[str, Any]] = field(default_factory=dict)
     multimodal_runtime: Optional[MultimodalRuntimeData] = None
+    text_token_indices: Optional[torch.Tensor] = None
+    mm_token_indices: Optional[torch.Tensor] = None
 
     def __post_init__(self):
         """Ensure default values are properly set."""

--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -188,8 +188,6 @@ class MultimodalParams:
     multimodal_input: Optional[MultimodalInput] = None
     multimodal_data: Optional[Dict[str, Any]] = field(default_factory=dict)
     multimodal_runtime: Optional[MultimodalRuntimeData] = None
-    text_token_indices: Optional[torch.Tensor] = None
-    mm_token_indices: Optional[torch.Tensor] = None
 
     def __post_init__(self):
         """Ensure default values are properly set."""

--- a/tests/unittest/_torch/multimodal/test_fuse_input_embeds.py
+++ b/tests/unittest/_torch/multimodal/test_fuse_input_embeds.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 
 from tensorrt_llm._torch.models.modeling_multimodal_utils import (
-    filter_mm_token_from_input_ids, fuse_input_embeds, fuse_input_embeds_cuda)
+    filter_mm_token_from_input_ids, fuse_input_embeds)
 from tensorrt_llm._torch.modules.embedding import Embedding
 
 
@@ -49,6 +49,16 @@ def test_filter_mm_token_from_input_ids_explicit_ids(device):
     torch.testing.assert_close(mm_idx.cpu(),
                                torch.tensor([2, 4, 6], dtype=torch.long))
 
+    # Even with some ids > vocab, mm indices should still only match the given mm_token_ids
+    input_ids = torch.tensor([1, 2, 55, 3, 77, 9, 88, 101, 102, 103],
+                             dtype=torch.long,
+                             device=device)
+    _, mm_idx = filter_mm_token_from_input_ids(input_ids,
+                                               vocab_size=vocab_size,
+                                               mm_token_ids=mm_token_ids)
+    torch.testing.assert_close(mm_idx.cpu(),
+                               torch.tensor([2, 4, 6], dtype=torch.long))
+
 
 @pytest.mark.parametrize("device", ["cpu"] +
                          (["cuda"] if torch.cuda.is_available() else []))
@@ -86,7 +96,11 @@ def test_fuse_input_embeds_mismatch_raises(device):
     wrong_mm = torch.randn(true_mm_count - 1, hidden, device=device)
 
     with pytest.raises(ValueError, match="Multimodal token count mismatch"):
-        fuse_input_embeds_cuda(emb, input_ids, text_idx, mm_idx, [wrong_mm])
+        fuse_input_embeds(emb,
+                          input_ids, [wrong_mm],
+                          mm_token_ids=None,
+                          text_token_indices=text_idx,
+                          mm_token_indices=mm_idx)
 
 
 @pytest.mark.parametrize("device", ["cpu"] +
@@ -101,15 +115,22 @@ def test_fuse_input_embeds_success_oov_path(device):
                              device=device)
 
     # Build mm embeddings to match number of OOV positions
-    _, mm_idx = filter_mm_token_from_input_ids(input_ids,
-                                               vocab_size=emb.num_embeddings)
+    text_idx, mm_idx = filter_mm_token_from_input_ids(
+        input_ids, vocab_size=emb.num_embeddings)
     mm_emb = torch.randn(mm_idx.shape[0], hidden, device=device)
 
-    # High-level API should produce fused embeddings only (ids is None)
+    # kwargs path to produce fused embeddings
     out_ids, out_embeds = fuse_input_embeds(emb,
                                             input_ids,
                                             mm_embeds=[mm_emb],
-                                            mm_token_ids=None)
+                                            mm_token_ids=None,
+                                            text_token_indices=text_idx,
+                                            mm_token_indices=mm_idx)
+    # integrated filtering path to produce fused embeddings (not kwargs path)
+    out_ids_v2, out_embeds_v2 = fuse_input_embeds(emb,
+                                                  input_ids,
+                                                  mm_embeds=[mm_emb],
+                                                  mm_token_ids=None)
 
     assert out_ids is None
     assert out_embeds is not None
@@ -125,3 +146,58 @@ def test_fuse_input_embeds_success_oov_path(device):
     torch.testing.assert_close(
         out_embeds[mm_idx],
         mm_emb.to(dtype=out_embeds.dtype, device=out_embeds.device))
+    torch.testing.assert_close(out_embeds_v2, out_embeds)
+    torch.testing.assert_close(out_ids_v2, out_ids)
+
+
+@pytest.mark.parametrize("device", ["cpu"] +
+                         (["cuda"] if torch.cuda.is_available() else []))
+def test_fuse_input_embeds_kwargs_precedence_over_sentinel_and_ids(device):
+    """
+    Ensure that when kwargs provide precomputed indices, they take precedence
+    over both OOV-sentinel filtering and explicit mm_token_ids.
+    """
+    hidden = 8
+    vocab_size = 40
+    emb = make_embedding(num_embeddings=vocab_size,
+                         hidden_size=hidden,
+                         device=device)
+
+    # Use vocab_size+1 as OOV sentinel
+    oov_sentinel = vocab_size + 1
+    input_ids = torch.tensor([0, oov_sentinel, 1, oov_sentinel, 2],
+                             dtype=torch.long,
+                             device=device)
+
+    # Precompute correct indices (kwargs path)
+    text_idx, mm_idx = filter_mm_token_from_input_ids(input_ids,
+                                                      vocab_size=vocab_size,
+                                                      mm_token_ids=None)
+    mm_emb = torch.randn(mm_idx.shape[0], hidden, device=device)
+
+    # Provide a deliberately incorrect mm_token_ids to ensure it is ignored
+    bad_mm_token_ids = torch.tensor(
+        [0], dtype=torch.long,
+        device=device)  # would misclassify index 0 as mm if used
+
+    out_ids, out_embeds = fuse_input_embeds(
+        emb,
+        input_ids,
+        mm_embeds=[mm_emb],
+        mm_token_ids=
+        bad_mm_token_ids,  # should be ignored because indices are provided
+        text_token_indices=text_idx,
+        mm_token_indices=mm_idx,
+    )
+
+    # Validate outputs
+    assert out_ids is None
+    assert out_embeds is not None
+    assert out_embeds.shape == (input_ids.numel(), hidden)
+
+    ref_text = emb(input_ids[text_idx])
+    torch.testing.assert_close(out_embeds[text_idx], ref_text)
+    torch.testing.assert_close(
+        out_embeds[mm_idx],
+        mm_emb.to(dtype=out_embeds.dtype, device=out_embeds.device),
+    )

--- a/tests/unittest/_torch/multimodal/test_fuse_input_embeds.py
+++ b/tests/unittest/_torch/multimodal/test_fuse_input_embeds.py
@@ -9,7 +9,9 @@ from tensorrt_llm._torch.modules.embedding import Embedding
 def make_embedding(num_embeddings: int = 100,
                    hidden_size: int = 16,
                    device: str = "cpu") -> Embedding:
+    torch.manual_seed(0)
     emb = Embedding(num_embeddings=num_embeddings, embedding_dim=hidden_size)
+    emb.weight.data.normal_(mean=0.0, std=0.02)
     return emb.to(device)
 
 

--- a/tests/unittest/_torch/multimodal/test_fuse_input_embeds.py
+++ b/tests/unittest/_torch/multimodal/test_fuse_input_embeds.py
@@ -1,0 +1,127 @@
+import pytest
+import torch
+
+from tensorrt_llm._torch.models.modeling_multimodal_utils import (
+    filter_mm_token_from_input_ids, fuse_input_embeds, fuse_input_embeds_cuda)
+from tensorrt_llm._torch.modules.embedding import Embedding
+
+
+def make_embedding(num_embeddings: int = 100,
+                   hidden_size: int = 16,
+                   device: str = "cpu") -> Embedding:
+    emb = Embedding(num_embeddings=num_embeddings, embedding_dim=hidden_size)
+    return emb.to(device)
+
+
+@pytest.mark.parametrize("device", ["cpu"] +
+                         (["cuda"] if torch.cuda.is_available() else []))
+def test_filter_mm_token_from_input_ids_oov(device):
+    vocab_size = 10
+    # input_ids contains text (< vocab) and OOV mm tokens (>= vocab)
+    input_ids = torch.tensor([1, 2, 11, 3, 12, 9, 15],
+                             dtype=torch.long,
+                             device=device)
+    text_idx, mm_idx = filter_mm_token_from_input_ids(input_ids,
+                                                      vocab_size=vocab_size,
+                                                      mm_token_ids=None)
+
+    torch.testing.assert_close(text_idx.cpu(),
+                               torch.tensor([0, 1, 3, 5], dtype=torch.long))
+    torch.testing.assert_close(mm_idx.cpu(),
+                               torch.tensor([2, 4, 6], dtype=torch.long))
+
+
+@pytest.mark.parametrize("device", ["cpu"] +
+                         (["cuda"] if torch.cuda.is_available() else []))
+def test_filter_mm_token_from_input_ids_explicit_ids(device):
+    vocab_size = 100
+    # All ids are < vocab; mm tokens are explicitly specified
+    input_ids = torch.tensor([1, 2, 55, 3, 77, 9, 88],
+                             dtype=torch.long,
+                             device=device)
+    mm_token_ids = torch.tensor([55, 77, 88], dtype=torch.long)
+    text_idx, mm_idx = filter_mm_token_from_input_ids(input_ids,
+                                                      vocab_size=vocab_size,
+                                                      mm_token_ids=mm_token_ids)
+
+    torch.testing.assert_close(text_idx.cpu(),
+                               torch.tensor([0, 1, 3, 5], dtype=torch.long))
+    torch.testing.assert_close(mm_idx.cpu(),
+                               torch.tensor([2, 4, 6], dtype=torch.long))
+
+
+@pytest.mark.parametrize("device", ["cpu"] +
+                         (["cuda"] if torch.cuda.is_available() else []))
+def test_fuse_input_embeds_empty_mm_returns_ids(device):
+    emb = make_embedding(num_embeddings=20, hidden_size=8, device=device)
+    input_ids = torch.tensor([1, 2, 3, 4], dtype=torch.long, device=device)
+
+    out_ids, out_embeds = fuse_input_embeds(emb,
+                                            input_ids,
+                                            mm_embeds=[],
+                                            mm_token_ids=None)
+
+    # No mm embeddings => passthrough ids, no embeds fused
+    assert out_embeds is None
+    torch.testing.assert_close(out_ids, input_ids)
+
+
+@pytest.mark.parametrize("device", ["cpu"] +
+                         (["cuda"] if torch.cuda.is_available() else []))
+def test_fuse_input_embeds_mismatch_raises(device):
+    emb = make_embedding(num_embeddings=50, hidden_size=8, device=device)
+
+    # Mix text (< vocab) and mm (>= vocab) tokens. Here vocab_size == 50
+    input_ids = torch.tensor([1, 51, 2, 52, 3, 53],
+                             dtype=torch.long,
+                             device=device)
+
+    # Identify indices first to drive the lower-level CUDA fuse directly for mismatch
+    text_idx, mm_idx = filter_mm_token_from_input_ids(
+        input_ids, vocab_size=emb.num_embeddings)
+
+    # Provide the wrong number of mm embeddings (e.g., one short)
+    hidden = 8
+    true_mm_count = mm_idx.shape[0]
+    wrong_mm = torch.randn(true_mm_count - 1, hidden, device=device)
+
+    with pytest.raises(ValueError, match="Multimodal token count mismatch"):
+        fuse_input_embeds_cuda(emb, input_ids, text_idx, mm_idx, [wrong_mm])
+
+
+@pytest.mark.parametrize("device", ["cpu"] +
+                         (["cuda"] if torch.cuda.is_available() else []))
+def test_fuse_input_embeds_success_oov_path(device):
+    hidden = 8
+    emb = make_embedding(num_embeddings=40, hidden_size=hidden, device=device)
+
+    # input ids: mix of text (<40) and mm (>=40)
+    input_ids = torch.tensor([0, 1, 41, 2, 42, 3, 43, 4],
+                             dtype=torch.long,
+                             device=device)
+
+    # Build mm embeddings to match number of OOV positions
+    _, mm_idx = filter_mm_token_from_input_ids(input_ids,
+                                               vocab_size=emb.num_embeddings)
+    mm_emb = torch.randn(mm_idx.shape[0], hidden, device=device)
+
+    # High-level API should produce fused embeddings only (ids is None)
+    out_ids, out_embeds = fuse_input_embeds(emb,
+                                            input_ids,
+                                            mm_embeds=[mm_emb],
+                                            mm_token_ids=None)
+
+    assert out_ids is None
+    assert out_embeds is not None
+    assert out_embeds.shape == (input_ids.numel(), hidden)
+
+    # Validate that text positions equal embedding lookup, and mm positions equal provided mm_emb
+    text_idx, mm_idx2 = filter_mm_token_from_input_ids(
+        input_ids, vocab_size=emb.num_embeddings)
+    torch.testing.assert_close(mm_idx2, mm_idx)
+
+    ref_text = emb(input_ids[text_idx])
+    torch.testing.assert_close(out_embeds[text_idx], ref_text)
+    torch.testing.assert_close(
+        out_embeds[mm_idx],
+        mm_emb.to(dtype=out_embeds.dtype, device=out_embeds.device))


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Token filtering for multimodal inputs and an orchestrated embedding-fusion step.
  - Models now forward extra kwargs to the fusion step; callers can supply precomputed indices.

- Tests
  - Added CPU/CUDA unit tests covering token filtering, fusion success/failure, and kwargs precedence.

- Documentation
  - Clarified text/mm token indices usage and host-device synchronization considerations.

- Refactor
  - Skip compilation overhead for embedding path on single-GPU runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
