### PR TITLE
[TRTLLM-5670][feat] Support top log probabilities

### DIFF
--- a/cpp/include/tensorrt_llm/executor/executor.h
+++ b/cpp/include/tensorrt_llm/executor/executor.h
@@ -216,7 +216,7 @@ public:
         bool returnGenerationLogits = false, bool excludeInputFromOutput = false, bool returnEncoderOutput = false,
         bool returnPerfMetrics = false,
         std::optional<std::vector<AdditionalModelOutput>> additionalModelOutputs = std::nullopt,
-        SizeType32 topLogProbs = 0);
+        std::optional<SizeType32> topLogProbs = std::nullopt);
 
     /// @brief Controls if Result should contain log probabilities. Default is false.
     bool returnLogProbs;

--- a/cpp/include/tensorrt_llm/executor/executor.h
+++ b/cpp/include/tensorrt_llm/executor/executor.h
@@ -215,7 +215,8 @@ public:
     explicit OutputConfig(bool returnLogProbs = false, bool returnContextLogits = false,
         bool returnGenerationLogits = false, bool excludeInputFromOutput = false, bool returnEncoderOutput = false,
         bool returnPerfMetrics = false,
-        std::optional<std::vector<AdditionalModelOutput>> additionalModelOutputs = std::nullopt);
+        std::optional<std::vector<AdditionalModelOutput>> additionalModelOutputs = std::nullopt,
+        SizeType32 topLogProbs = 0);
 
     /// @brief Controls if Result should contain log probabilities. Default is false.
     bool returnLogProbs;
@@ -233,6 +234,8 @@ public:
 
     /// @brief The additional outputs to gather from the model.
     std::optional<std::vector<AdditionalModelOutput>> additionalModelOutputs;
+    /// @brief The number of logprobs to return. Default is 0.
+    std::optional<SizeType32> topLogProbs;
 };
 
 /// @brief Configuration for speculative decoding with external draft tokens.

--- a/cpp/tensorrt_llm/executor/outputConfig.cpp
+++ b/cpp/tensorrt_llm/executor/outputConfig.cpp
@@ -22,7 +22,7 @@ namespace tensorrt_llm::executor
 
 OutputConfig::OutputConfig(bool inReturnLogProbs, bool inReturnContextLogits, bool inReturnGenerationLogits,
     bool inExcludeInputFromOutput, bool inReturnEncoderOutput, bool inReturnPerfMetrics,
-    std::optional<std::vector<AdditionalModelOutput>> additionalModelOutputs)
+    std::optional<std::vector<AdditionalModelOutput>> additionalModelOutputs, SizeType32 topLogProbs)
     : returnLogProbs(inReturnLogProbs)
     , returnContextLogits(inReturnContextLogits)
     , returnGenerationLogits(inReturnGenerationLogits)
@@ -30,6 +30,7 @@ OutputConfig::OutputConfig(bool inReturnLogProbs, bool inReturnContextLogits, bo
     , returnEncoderOutput(inReturnEncoderOutput)
     , returnPerfMetrics(inReturnPerfMetrics)
     , additionalModelOutputs(std::move(additionalModelOutputs))
+    , topLogProbs(topLogProbs)
 {
 }
 

--- a/cpp/tensorrt_llm/executor/outputConfig.cpp
+++ b/cpp/tensorrt_llm/executor/outputConfig.cpp
@@ -22,7 +22,7 @@ namespace tensorrt_llm::executor
 
 OutputConfig::OutputConfig(bool inReturnLogProbs, bool inReturnContextLogits, bool inReturnGenerationLogits,
     bool inExcludeInputFromOutput, bool inReturnEncoderOutput, bool inReturnPerfMetrics,
-    std::optional<std::vector<AdditionalModelOutput>> additionalModelOutputs, SizeType32 topLogProbs)
+    std::optional<std::vector<AdditionalModelOutput>> additionalModelOutputs, std::optional<SizeType32> topLogProbs)
     : returnLogProbs(inReturnLogProbs)
     , returnContextLogits(inReturnContextLogits)
     , returnGenerationLogits(inReturnGenerationLogits)

--- a/cpp/tensorrt_llm/nanobind/executor/request.cpp
+++ b/cpp/tensorrt_llm/nanobind/executor/request.cpp
@@ -198,17 +198,19 @@ void initRequestBindings(nb::module_& m)
     auto outputConfigGetstate = [](tle::OutputConfig const& self)
     {
         return nb::make_tuple(self.returnLogProbs, self.returnContextLogits, self.returnGenerationLogits,
-            self.excludeInputFromOutput, self.returnEncoderOutput, self.returnPerfMetrics, self.additionalModelOutputs);
+            self.excludeInputFromOutput, self.returnEncoderOutput, self.returnPerfMetrics, self.additionalModelOutputs,
+            self.topLogProbs);
     };
     auto outputConfigSetstate = [](tle::OutputConfig& outputConfig, nb::tuple const& state)
     {
-        if (state.size() != 7)
+        if (state.size() != 8)
         {
             throw std::runtime_error("Invalid OutputConfig state!");
         }
         new (&outputConfig) tle::OutputConfig(nb::cast<bool>(state[0]), nb::cast<bool>(state[1]),
             nb::cast<bool>(state[2]), nb::cast<bool>(state[3]), nb::cast<bool>(state[4]), nb::cast<bool>(state[5]),
-            nb::cast<std::optional<std::vector<tle::AdditionalModelOutput>>>(state[6]));
+            nb::cast<std::optional<std::vector<tle::AdditionalModelOutput>>>(state[6]),
+            nb::cast<std::optional<SizeType32>>(state[7]));
     };
     nb::class_<tle::OutputConfig>(m, "OutputConfig")
         .def(
@@ -222,7 +224,7 @@ void initRequestBindings(nb::module_& m)
                 new (&self) tle::OutputConfig(return_log_probs.value_or(false), return_context_logits.value_or(false),
                     return_generation_logits.value_or(false), exclude_input_from_output.value_or(false),
                     return_encoder_output.value_or(false), return_perf_metrics.value_or(false),
-                    additional_model_outputs, top_logprobs.value_or(0));
+                    additional_model_outputs, top_logprobs);
             },
             nb::arg("return_log_probs") = nb::none(), nb::arg("return_context_logits") = nb::none(),
             nb::arg("return_generation_logits") = nb::none(), nb::arg("exclude_input_from_output") = nb::none(),

--- a/cpp/tensorrt_llm/nanobind/executor/request.cpp
+++ b/cpp/tensorrt_llm/nanobind/executor/request.cpp
@@ -216,17 +216,18 @@ void initRequestBindings(nb::module_& m)
             [](tle::OutputConfig& self, std::optional<bool> return_log_probs, std::optional<bool> return_context_logits,
                 std::optional<bool> return_generation_logits, std::optional<bool> exclude_input_from_output,
                 std::optional<bool> return_encoder_output, std::optional<bool> return_perf_metrics,
-                std::optional<std::vector<tle::AdditionalModelOutput>> additional_model_outputs)
+                std::optional<std::vector<tle::AdditionalModelOutput>> additional_model_outputs,
+                std::optional<SizeType32> top_logprobs)
             {
                 new (&self) tle::OutputConfig(return_log_probs.value_or(false), return_context_logits.value_or(false),
                     return_generation_logits.value_or(false), exclude_input_from_output.value_or(false),
                     return_encoder_output.value_or(false), return_perf_metrics.value_or(false),
-                    additional_model_outputs);
+                    additional_model_outputs, top_logprobs.value_or(0));
             },
             nb::arg("return_log_probs") = nb::none(), nb::arg("return_context_logits") = nb::none(),
             nb::arg("return_generation_logits") = nb::none(), nb::arg("exclude_input_from_output") = nb::none(),
             nb::arg("return_encoder_output") = nb::none(), nb::arg("return_perf_metrics") = nb::none(),
-            nb::arg("additional_model_outputs") = nb::none())
+            nb::arg("additional_model_outputs") = nb::none(), nb::arg("top_logprobs") = nb::none())
         .def_rw("return_log_probs", &tle::OutputConfig::returnLogProbs)
         .def_rw("return_context_logits", &tle::OutputConfig::returnContextLogits)
         .def_rw("return_generation_logits", &tle::OutputConfig::returnGenerationLogits)
@@ -234,6 +235,7 @@ void initRequestBindings(nb::module_& m)
         .def_rw("return_encoder_output", &tle::OutputConfig::returnEncoderOutput)
         .def_rw("return_perf_metrics", &tle::OutputConfig::returnPerfMetrics)
         .def_rw("additional_model_outputs", &tle::OutputConfig::additionalModelOutputs)
+        .def_rw("top_logprobs", &tle::OutputConfig::topLogProbs)
         .def("__getstate__", outputConfigGetstate)
         .def("__setstate__", outputConfigSetstate);
 

--- a/cpp/tensorrt_llm/pybind/executor/request.cpp
+++ b/cpp/tensorrt_llm/pybind/executor/request.cpp
@@ -207,7 +207,7 @@ void initRequestBindings(pybind11::module_& m)
     };
     py::class_<tle::OutputConfig>(m, "OutputConfig")
         .def(py::init<bool, bool, bool, bool, bool, bool, std::optional<std::vector<tle::AdditionalModelOutput>>,
-                 SizeType32>(),
+                 std::optional<SizeType32>>(),
             py::arg("return_log_probs") = false, py::arg("return_context_logits") = false,
             py::arg("return_generation_logits") = false, py::arg("exclude_input_from_output") = false,
             py::arg("return_encoder_output") = false, py::arg("return_perf_metrics") = false,

--- a/cpp/tensorrt_llm/pybind/executor/request.cpp
+++ b/cpp/tensorrt_llm/pybind/executor/request.cpp
@@ -204,11 +204,12 @@ void initRequestBindings(pybind11::module_& m)
             state[6].cast<std::optional<std::vector<tle::AdditionalModelOutput>>>());
     };
     py::class_<tle::OutputConfig>(m, "OutputConfig")
-        .def(py::init<bool, bool, bool, bool, bool, bool, std::optional<std::vector<tle::AdditionalModelOutput>>>(),
+        .def(py::init<bool, bool, bool, bool, bool, bool, std::optional<std::vector<tle::AdditionalModelOutput>>,
+                 SizeType32>(),
             py::arg("return_log_probs") = false, py::arg("return_context_logits") = false,
             py::arg("return_generation_logits") = false, py::arg("exclude_input_from_output") = false,
             py::arg("return_encoder_output") = false, py::arg("return_perf_metrics") = false,
-            py::arg("additional_model_outputs") = py::none())
+            py::arg("additional_model_outputs") = py::none(), py::arg("top_logprobs") = 0)
         .def_readwrite("return_log_probs", &tle::OutputConfig::returnLogProbs)
         .def_readwrite("return_context_logits", &tle::OutputConfig::returnContextLogits)
         .def_readwrite("return_generation_logits", &tle::OutputConfig::returnGenerationLogits)
@@ -216,6 +217,7 @@ void initRequestBindings(pybind11::module_& m)
         .def_readwrite("return_encoder_output", &tle::OutputConfig::returnEncoderOutput)
         .def_readwrite("return_perf_metrics", &tle::OutputConfig::returnPerfMetrics)
         .def_readwrite("additional_model_outputs", &tle::OutputConfig::additionalModelOutputs)
+        .def_readwrite("top_logprobs", &tle::OutputConfig::topLogProbs)
         .def(py::pickle(outputConfigGetstate, outputConfigSetstate));
 
     auto externalDraftTokensConfigGetstate = [](tle::ExternalDraftTokensConfig const& self)

--- a/cpp/tensorrt_llm/pybind/executor/request.cpp
+++ b/cpp/tensorrt_llm/pybind/executor/request.cpp
@@ -191,17 +191,19 @@ void initRequestBindings(pybind11::module_& m)
     auto outputConfigGetstate = [](tle::OutputConfig const& self)
     {
         return py::make_tuple(self.returnLogProbs, self.returnContextLogits, self.returnGenerationLogits,
-            self.excludeInputFromOutput, self.returnEncoderOutput, self.returnPerfMetrics, self.additionalModelOutputs);
+            self.excludeInputFromOutput, self.returnEncoderOutput, self.returnPerfMetrics, self.additionalModelOutputs,
+            self.topLogProbs);
     };
     auto outputConfigSetstate = [](py::tuple const& state)
     {
-        if (state.size() != 7)
+        if (state.size() != 8)
         {
             throw std::runtime_error("Invalid OutputConfig state!");
         }
         return tle::OutputConfig(state[0].cast<bool>(), state[1].cast<bool>(), state[2].cast<bool>(),
             state[3].cast<bool>(), state[4].cast<bool>(), state[5].cast<bool>(),
-            state[6].cast<std::optional<std::vector<tle::AdditionalModelOutput>>>());
+            state[6].cast<std::optional<std::vector<tle::AdditionalModelOutput>>>(),
+            state[7].cast<std::optional<SizeType32>>());
     };
     py::class_<tle::OutputConfig>(m, "OutputConfig")
         .def(py::init<bool, bool, bool, bool, bool, bool, std::optional<std::vector<tle::AdditionalModelOutput>>,
@@ -209,7 +211,7 @@ void initRequestBindings(pybind11::module_& m)
             py::arg("return_log_probs") = false, py::arg("return_context_logits") = false,
             py::arg("return_generation_logits") = false, py::arg("exclude_input_from_output") = false,
             py::arg("return_encoder_output") = false, py::arg("return_perf_metrics") = false,
-            py::arg("additional_model_outputs") = py::none(), py::arg("top_logprobs") = 0)
+            py::arg("additional_model_outputs") = py::none(), py::arg("top_logprobs") = py::none())
         .def_readwrite("return_log_probs", &tle::OutputConfig::returnLogProbs)
         .def_readwrite("return_context_logits", &tle::OutputConfig::returnContextLogits)
         .def_readwrite("return_generation_logits", &tle::OutputConfig::returnGenerationLogits)

--- a/examples/llm-api/quickstart_advanced.py
+++ b/examples/llm-api/quickstart_advanced.py
@@ -220,7 +220,7 @@ def setup_llm(args, **kwargs):
         args.max_top_logprobs = args.top_logprobs
     # Remove this once torch sampler stops using enable_mixed_sampler
     is_greedy = (not args.max_beam_width > 1) and (
-        args.top_k is None or args.top_k == 0) and (args.top_p is None
+        args.top_k is None or args.top_k == 1) and (args.top_p is None
                                                     or args.top_p == 0.0)
 
 

--- a/examples/llm-api/quickstart_advanced.py
+++ b/examples/llm-api/quickstart_advanced.py
@@ -147,7 +147,7 @@ def add_llm_args(parser):
                         default=False,
                         action='store_true')
     parser.add_argument('--logprobs', default=False, action='store_true')
-    parser.add_argument('--top_logprobs', type=int, default=0)
+    parser.add_argument('--top_logprobs', type=int, default=None)
     parser.add_argument('--max_top_logprobs', type=int, default=0)
     return parser
 
@@ -216,7 +216,7 @@ def setup_llm(args, **kwargs):
     )
 
     # if only top_logprobs is set, set max_top_logprobs to top_logprobs
-    if args.max_top_logprobs < args.top_logprobs:
+    if args.top_logprobs is not None and args.max_top_logprobs < args.top_logprobs:
         args.max_top_logprobs = args.top_logprobs
     # Remove this once torch sampler stops using enable_mixed_sampler
     is_greedy = (not args.max_beam_width > 1) and (

--- a/examples/llm-api/quickstart_advanced.py
+++ b/examples/llm-api/quickstart_advanced.py
@@ -223,7 +223,6 @@ def setup_llm(args, **kwargs):
         args.top_k is None or args.top_k == 1) and (args.top_p is None
                                                     or args.top_p == 0.0)
 
-
     llm = LLM(
         model=args.model_dir,
         backend='pytorch',
@@ -270,6 +269,11 @@ def setup_llm(args, **kwargs):
 
     assert best_of >= args.n, f"In sampling mode best_of value: {best_of} should be less or equal to n: {args.n}"
 
+    num_logprobs = args.logprobs
+    if args.logprobs is not None:
+        if args.top_logprobs is not None:
+            num_logprobs = args.top_logprobs
+
     sampling_params = SamplingParams(
         max_tokens=args.max_tokens,
         temperature=args.temperature,
@@ -277,8 +281,7 @@ def setup_llm(args, **kwargs):
         top_p=args.top_p,
         return_context_logits=args.return_context_logits,
         return_generation_logits=args.return_generation_logits,
-        logprobs=args.logprobs,
-        top_logprobs=args.top_logprobs,
+        logprobs=num_logprobs,
         n=args.n,
         best_of=best_of,
         use_beam_search=use_beam_search)
@@ -320,10 +323,6 @@ def main():
                 )
             if args.logprobs:
                 print(f"[{i}]{sequence_id_text} Logprobs: {sequence.logprobs}")
-            if args.top_logprobs:
-                print(
-                    f"[{i}]{sequence_id_text} Top logprobs: {sequence.top_logprobs}"
-                )
 
 
 if __name__ == '__main__':

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -345,6 +345,7 @@ def create_autodeploy_executor(ad_config: LlmArgs):
         max_seq_len=ad_config.max_seq_len,
         max_draft_len=max_draft_len,
         max_num_sequences=max_num_sequences,
+        max_top_logprobs=ad_config.max_top_logprobs,
         max_beam_width=ad_config.max_beam_width,
         enable_mixed_sampler=ad_config.enable_mixed_sampler,
     )

--- a/tensorrt_llm/_torch/auto_deploy/shim/demollm.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/demollm.py
@@ -234,9 +234,9 @@ class DemoEngine(ADEngine):
         logits_shape = logits.shape
         logits = logits.view(-1, logits_shape[-1])  # sampling_batch expects 2D logits
         if isinstance(sampling_params.top_k, int):
-            idx_next, probs = top_k_sampling_batch(logits, sampling_params.top_k)
+            idx_next, probs, _ = top_k_sampling_batch(logits, sampling_params.top_k)
         else:
-            idx_next, probs = greedy_search_sampling_batch(logits)
+            idx_next, probs, _ = greedy_search_sampling_batch(logits)
         idx_next = idx_next.view(logits_shape[:-1])
         return idx_next, probs
 

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -686,8 +686,8 @@ def create_py_executor_instance(
 
 
 def create_torch_sampler_args(mapping: Mapping, *, max_seq_len: int,
-                              enable_mixed_sampler: bool,
-                              max_top_logprobs: int, max_batch_size: int,
+                              enable_mixed_sampler: bool, max_top_logprobs: int,
+                              max_batch_size: int,
                               speculative_config: SpeculativeConfig,
                               max_beam_width: int):
     max_num_sequences = max_batch_size * mapping.pp_size
@@ -715,7 +715,6 @@ def instantiate_sampler(engine: PyTorchModelEngine,
         max_seq_len=engine.max_seq_len,
         enable_mixed_sampler=pytorch_backend_config.enable_mixed_sampler,
         max_top_logprobs=pytorch_backend_config.max_top_logprobs,
-    ,
         max_batch_size=max_batch_size,
         speculative_config=speculative_config,
         max_beam_width=max_beam_width)

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -686,7 +686,8 @@ def create_py_executor_instance(
 
 
 def create_torch_sampler_args(mapping: Mapping, *, max_seq_len: int,
-                              enable_mixed_sampler: bool, max_batch_size: int,
+                              enable_mixed_sampler: bool,
+                              max_top_logprobs: int, max_batch_size: int,
                               speculative_config: SpeculativeConfig,
                               max_beam_width: int):
     max_num_sequences = max_batch_size * mapping.pp_size
@@ -697,6 +698,7 @@ def create_torch_sampler_args(mapping: Mapping, *, max_seq_len: int,
         max_draft_len=max_draft_len,
         max_num_sequences=max_num_sequences,
         max_beam_width=max_beam_width,
+        max_top_logprobs=max_top_logprobs,
         enable_mixed_sampler=enable_mixed_sampler,
     )
 
@@ -712,6 +714,8 @@ def instantiate_sampler(engine: PyTorchModelEngine,
         mapping,
         max_seq_len=engine.max_seq_len,
         enable_mixed_sampler=pytorch_backend_config.enable_mixed_sampler,
+        max_top_logprobs=pytorch_backend_config.max_top_logprobs,
+    ,
         max_batch_size=max_batch_size,
         speculative_config=speculative_config,
         max_beam_width=max_beam_width)

--- a/tensorrt_llm/_torch/pyexecutor/config.py
+++ b/tensorrt_llm/_torch/pyexecutor/config.py
@@ -113,6 +113,9 @@ class PyTorchConfig:
     # If false, set the PyTorch CUDA memory fraction to 1.0.
     _limit_torch_cuda_mem_fraction: bool = True
 
+    # The max number of logprobs to return per token
+    max_top_logprobs: int = 0
+
 
 EXETENDED_EXECUTOR_CONFIG_FIELDS = [
     'backend',

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -422,7 +422,7 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
 
     @property
     def calculate_top_logprobs(self):
-        return self.py_top_logprobs is not None
+        return self.py_top_logprobs is not None and self.py_top_logprobs > 0
 
     def finish_by(self, reason: FinishReason, beam: int) -> None:
         """CPP finish by reason does not support beam_width > 1"""

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -315,7 +315,6 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
             # Detour handling of some parameters
             client_id: int = None,
             return_log_probs: bool = False,
-            top_logprobs: int = 0,
             return_context_logits: bool = False,
             return_generation_logits: bool = False,
             return_logits_device_memory: bool = True,
@@ -327,6 +326,7 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
             is_draft: bool = False,
             seq_slot: Optional[int] = None,
             target_seq_slot: Optional[int] = None,
+            top_logprobs: Optional[int] = None,
             **kwargs):
 
         self.py_logits_post_processors = kwargs.pop("py_logits_post_processors",
@@ -419,6 +419,10 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
     @property
     def is_dummy(self):
         return self.is_attention_dp_dummy or self.is_cuda_graph_dummy or self.is_dummy_request
+
+    @property
+    def calculate_top_logprobs(self):
+        return self.py_top_logprobs is not None
 
     def finish_by(self, reason: FinishReason, beam: int) -> None:
         """CPP finish by reason does not support beam_width > 1"""

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -292,7 +292,7 @@ def greedy_search_sampling_batch(logits):
     """
     next_tokens = torch.argmax(logits, dim=-1)
     softmax = torch.softmax(logits, dim=-1)
-    return next_tokens, softmax, None
+    return next_tokens, softmax, next_tokens.unsqueeze(-1)
 
 
 def get_rejected_indices(draft_probs: torch.Tensor, target_probs: torch.Tensor,

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -240,7 +240,7 @@ def top_k_top_p_sampling_batch(logits: torch.Tensor,
     Returns:
         next_tokens: [batch_size, 1] (sampled tokens)
         softmax: [batch_size, vocab_size] (probability distribution)
-        indices: [batch_size, top_k] (indices of top_k logits)
+        indices: [batch_size, top_k] (indices after applying top-k then top-p mask)
     """
     logits_dim = logits.dim()
     if logits_dim == 1:

--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -215,10 +215,11 @@ class MTPSpecMetadata(SpecMetadata):
 class MTPStore(TorchStore):
 
     def __init__(self, *, max_draft_len: int, max_num_sequences: int,
-                 max_beam_width: int):
+                 max_beam_width: int, max_top_logprobs: int):
         super().__init__(max_draft_len=max_draft_len,
                          max_num_sequences=max_num_sequences,
-                         max_beam_width=max_beam_width)
+                         max_beam_width=max_beam_width,
+                         max_top_logprobs=max_top_logprobs)
         self.next_new_tokens = int_tensor(
             (self.max_tokens, self.max_num_sequences, SINGLE_BEAM_WIDTH))
         self.next_draft_tokens = int_tensor(
@@ -241,7 +242,8 @@ class MTPSampler(Sampler):
         self.draft_len = nextn
         self.store = MTPStore(max_draft_len=nextn,
                               max_num_sequences=args.max_num_sequences,
-                              max_beam_width=args.max_beam_width)
+                              max_beam_width=args.max_beam_width,
+                              max_top_logprobs=args.max_top_logprobs)
         self.max_seq_len = args.max_seq_len
 
     def _request_common_handling(self, request: LlmRequest,

--- a/tensorrt_llm/executor/result.py
+++ b/tensorrt_llm/executor/result.py
@@ -93,6 +93,7 @@ class CompletionOutput:
         cumulative_logprob (float, optional): The cumulative log probability of the generated output text. Defaults to None.
         logprobs (TokenLogprobs | List[float], optional): The log probabilities of the top probability words at each position if the logprobs are requested. Defaults to None.
         prompt_logprobs (TokenLogprobs, optional): The log probabilities per prompt token. Defaults to None.
+        top_logprobs (TokenLogprobs, optional): The log probabilities of the top probability words at each position if the top_logprobs are requested. Defaults to None.
         finish_reason (Literal['stop', 'length', 'timeout', 'cancelled'], optional): The reason why the sequence is finished. Defaults to None.
         stop_reason (int, str, optional): The stop string or token id that caused the completion to stop, None if the completion finished for some other reason. Defaults to None.
         generation_logits (torch.Tensor, optional): The logits on the generated output token ids. Defaults to None.

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -580,10 +580,6 @@ class BaseLLM:
                 raise ValueError(
                     f"`prompt_logprobs` in sampling_params is not supported in the PyTorch backend yet. Received `prompt_logprobs={sampling_params.prompt_logprobs}`. Please unset this field."
                 )
-            if sampling_params.logprobs and sampling_params.logprobs > 1:
-                raise ValueError(
-                    f"PyTorch backend currently only supports `logprobs=1`. Received `logprobs={sampling_params.logprobs}` (Top{sampling_params.logprobs} logprobs). Please set `logprobs=1` in `sampling_params` instead."
-                )
             # Check prompt length and query length against max_num_tokens to filter illegal requests.
             # Skip check for gen-only requests
             if self.args.backend == "pytorch" and not self.args.enable_chunked_prefill and not is_gen_only:

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1352,6 +1352,9 @@ class BaseLlmArgs(StrictBaseModel):
     max_beam_width: Optional[int] = Field(default=None,
                                           description="The maximum beam width.")
 
+    max_top_logprobs: int = Field(
+        default=0, description="The maximum number of top logprobs.")
+
     max_num_tokens: Optional[int] = Field(
         default=None, description="The maximum number of tokens.")
 
@@ -2617,7 +2620,9 @@ class TorchLlmArgs(BaseLlmArgs):
             attention_dp_batching_wait_iters=self.attention_dp_config.
             batching_wait_iters if self.attention_dp_config is not None else
             AttentionDpConfig.model_fields['batching_wait_iters'].default,
-            batch_wait_timeout_ms=self.batch_wait_timeout_ms)
+            batch_wait_timeout_ms=self.batch_wait_timeout_ms,
+            max_top_logprobs=self.max_top_logprobs,
+        )
 
 
 def update_llm_args_with_extra_dict(

--- a/tensorrt_llm/sampling_params.py
+++ b/tensorrt_llm/sampling_params.py
@@ -173,7 +173,7 @@ class SamplingParams:
 
         logprobs (int, optional): Number of log probabilities to return per output token. Defaults to None.
         prompt_logprobs (int, optional): Number of log probabilities to return per prompt token. Defaults to None.
-        top_logprobs (int, optional): Number of top log probabilities to return per output token. Defaults to 0.
+        top_logprobs (int, optional): Number of top log probabilities to return per output token. Defaults to None.
         return_context_logits (bool): Controls if Result should contain the context logits. Defaults to False.
         return_generation_logits (bool): Controls if Result should contain the generation logits. Defaults to False.
         exclude_input_from_output (bool): Controls if output tokens in Result should include the input tokens. Defaults to True.

--- a/tensorrt_llm/sampling_params.py
+++ b/tensorrt_llm/sampling_params.py
@@ -324,12 +324,9 @@ class SamplingParams:
         self.prompt_logprobs = self.prompt_logprobs and int(self.prompt_logprobs)
 
         if self.logprobs is not None:
-            if self._greedy_decoding and self.logprobs > 0:
+            if self._greedy_decoding and self.logprobs > 1:
                 # check for greedy sampling
-                raise ValueError(
-                    "logprobs > 0 must not be specified for greedy sampling, "
-                    "as it provides the same output as logprobs = 0 in this case."
-                )
+                raise ValueError(f"logprobs {self.logprobs} must not exceed 1 for greedy sampling")
             elif self.top_k is not None and self.top_k < self.logprobs:
                 # check for top-k sampling
                 raise ValueError(f"logprobs {self.logprobs} must not exceed top_k {self.top_k}")

--- a/tests/integration/test_lists/test-db/l0_a30.yml
+++ b/tests/integration/test_lists/test-db/l0_a30.yml
@@ -21,6 +21,7 @@ l0_a30:
   - unittest/_torch/modeling -k "modeling_out_of_tree"
   - unittest/_torch/auto_deploy/unit/singlegpu -k "not test_trtllm_bench_backend_comparison"
   - unittest/_torch/sampler/test_beam_search.py
+  - unittest/_torch/sampler/test_return_top_k_logprobs.py
   - test_e2e.py::test_openai_completions_with_logit_bias[torch_sampler]
   - test_e2e.py::test_openai_chat_with_logit_bias[torch_sampler]
   - test_e2e.py::test_openai_completions_with_logit_bias[trtllm_sampler]

--- a/tests/unittest/_torch/sampler/test_return_top_k_logprobs.py
+++ b/tests/unittest/_torch/sampler/test_return_top_k_logprobs.py
@@ -64,6 +64,15 @@ def test_generate_with_top_logprobs(top_logprobs: int, top_k: int, top_p: float,
                 assert len(output.outputs[0].top_logprobs) == max_tokens
                 assert len(output.outputs[0].logprobs[0]) == 1
                 assert len(output.outputs[0].top_logprobs[0]) == top_logprobs
+                sampled_token = list(output.outputs[0].logprobs[0].keys())[0]
+                sampled_token_logprob = output.outputs[0].logprobs[0][
+                    sampled_token].logprob
+                if sampled_token in output.outputs[0].top_logprobs[0]:
+                    assert sampled_token_logprob == output.outputs[
+                        0].top_logprobs[0][sampled_token].logprob
+                else:
+                    assert sampled_token_logprob <= list(
+                        output.outputs[0].top_logprobs[0].values())[-1].logprob
     else:
         # expected to fail testcases
         with pytest.raises(ValueError, match="top_logprobs.*"):
@@ -77,7 +86,7 @@ def test_generate_with_top_logprobs(top_logprobs: int, top_k: int, top_p: float,
 
 @force_ampere  # Save H100 resource
 @pytest.mark.threadleak(enabled=False)
-def test_generate_with_top_logprobs_and_disabler_logprobs(
+def test_generate_with_top_logprobs_and_disabled_logprobs(
         llm_torch, input_prompts):
     max_tokens = 8
     top_logprobs = 2

--- a/tests/unittest/_torch/sampler/test_return_top_k_logprobs.py
+++ b/tests/unittest/_torch/sampler/test_return_top_k_logprobs.py
@@ -1,0 +1,72 @@
+import os
+
+import pytest
+from utils.llm_data import llm_models_root
+from utils.util import force_ampere
+
+from tensorrt_llm import LLM, SamplingParams
+from tensorrt_llm.llmapi import CudaGraphConfig, KvCacheConfig
+
+
+@pytest.fixture(scope="module")
+def input_prompts():
+    return [
+        "Born in north-east France, Soyer trained as a",
+        "The future of AI is",
+    ]
+
+
+@pytest.fixture(scope="module")
+def llm_torch(input_prompts):
+    return LLM(
+        model=os.path.join(llm_models_root(), "llama-models-v2",
+                           "TinyLlama-1.1B-Chat-v1.0"),
+        kv_cache_config=KvCacheConfig(max_tokens=10000),
+        max_batch_size=len(
+            input_prompts
+        ),  # use small batch size to prevent large buffers from possibly hiding wrong data accesses.
+        max_seq_len=32,
+        disable_overlap_scheduler=False,
+        sampler_type="TorchSampler",
+        cuda_graph_config=CudaGraphConfig(batch_sizes=[1, 2, 4, 8],
+                                          enable_padding=True),
+        enable_mixed_sampler=True,
+        max_top_logprobs=4,
+    )
+
+
+@force_ampere  # Save H100 resource
+@pytest.mark.parametrize("top_logprobs", [0, 1, 2, 4])
+@pytest.mark.parametrize("top_k", [None, 2])
+@pytest.mark.parametrize("top_p", [None, 0.5])
+@pytest.mark.threadleak(enabled=False)
+def test_generate_with_top_logprobs(top_logprobs: int, top_k: int, top_p: float,
+                                    llm_torch, input_prompts):
+    max_tokens = 8
+    is_topk = top_k is not None and top_k > 1
+    is_topp = top_p is not None and top_p > 0.0 and not is_topk
+    is_valid_setup = is_topk and top_logprobs <= top_k or is_topp or top_logprobs == 0
+    if is_valid_setup:
+        # passing testcases
+        sampling_params = SamplingParams(max_tokens=max_tokens,
+                                         logprobs=True,
+                                         top_k=top_k,
+                                         top_p=top_p,
+                                         temperature=1.0,
+                                         top_logprobs=top_logprobs)
+        for output in llm_torch.generate(input_prompts,
+                                         sampling_params=sampling_params):
+            if top_logprobs > 0:
+                assert len(output.outputs[0].logprobs) == max_tokens
+                assert len(output.outputs[0].top_logprobs) == max_tokens
+                assert len(output.outputs[0].logprobs[0]) == 1
+                assert len(output.outputs[0].top_logprobs[0]) == top_logprobs
+    else:
+        # expected to fail testcases
+        with pytest.raises(ValueError, match="top_logprobs.*cannot exceed.*"):
+            sampling_params = SamplingParams(max_tokens=max_tokens,
+                                             logprobs=True,
+                                             top_k=top_k,
+                                             top_p=top_p,
+                                             temperature=1.0,
+                                             top_logprobs=top_logprobs)

--- a/tests/unittest/_torch/sampler/test_return_top_k_logprobs.py
+++ b/tests/unittest/_torch/sampler/test_return_top_k_logprobs.py
@@ -36,7 +36,7 @@ def llm_torch(input_prompts):
 
 
 @force_ampere  # Save H100 resource
-@pytest.mark.parametrize("top_logprobs", [None, 0, 2, 4])
+@pytest.mark.parametrize("top_logprobs", [0, 2, 4])
 @pytest.mark.parametrize("top_k", [None, 2])
 @pytest.mark.parametrize("top_p", [None, 0.5])
 @pytest.mark.threadleak(enabled=False)
@@ -45,61 +45,29 @@ def test_generate_with_top_logprobs(top_logprobs: int, top_k: int, top_p: float,
     max_tokens = 8
     is_topk = top_k is not None and top_k > 1
     is_topp = top_p is not None and top_p > 0.0 and not is_topk
-    uses_top_logprobs = top_logprobs is not None
-    is_valid_top_logprobs = top_logprobs > 0 if uses_top_logprobs else True
-    is_valid_setup = not uses_top_logprobs or (is_valid_top_logprobs and (
-        (is_topk and top_logprobs <= top_k) or is_topp))
+    is_valid_setup = (is_topk
+                      and top_logprobs <= top_k) or is_topp or top_logprobs == 0
     if is_valid_setup:
         # passing testcases
         sampling_params = SamplingParams(max_tokens=max_tokens,
-                                         logprobs=True,
+                                         logprobs=top_logprobs,
                                          top_k=top_k,
                                          top_p=top_p,
-                                         temperature=1.0,
-                                         top_logprobs=top_logprobs)
+                                         temperature=1.0)
         for output in llm_torch.generate(input_prompts,
                                          sampling_params=sampling_params):
-            if top_logprobs is not None and top_logprobs > 0:
+            if top_logprobs > 0:
                 assert len(output.outputs[0].logprobs) == max_tokens
-                assert len(output.outputs[0].top_logprobs) == max_tokens
-                assert len(output.outputs[0].logprobs[0]) == 1
-                assert len(output.outputs[0].top_logprobs[0]) == top_logprobs
-                sampled_token = list(output.outputs[0].logprobs[0].keys())[0]
-                sampled_token_logprob = output.outputs[0].logprobs[0][
-                    sampled_token].logprob
-                if sampled_token in output.outputs[0].top_logprobs[0]:
-                    assert sampled_token_logprob == output.outputs[
-                        0].top_logprobs[0][sampled_token].logprob
-                else:
-                    assert sampled_token_logprob <= list(
-                        output.outputs[0].top_logprobs[0].values())[-1].logprob
+                assert len(
+                    output.outputs[0].logprobs[0]) == top_logprobs or len(
+                        output.outputs[0].logprobs[0]) == top_logprobs + 1
     else:
         # expected to fail testcases
-        with pytest.raises(ValueError, match="top_logprobs.*"):
-            sampling_params = SamplingParams(max_tokens=max_tokens,
-                                             logprobs=True,
-                                             top_k=top_k,
-                                             top_p=top_p,
-                                             temperature=1.0,
-                                             top_logprobs=top_logprobs)
-
-
-@force_ampere  # Save H100 resource
-@pytest.mark.threadleak(enabled=False)
-def test_generate_with_top_logprobs_and_disabled_logprobs(
-        llm_torch, input_prompts):
-    max_tokens = 8
-    top_logprobs = 2
-    top_k = 2
-    top_p = None
-
-    # expected to fail testcases
-    with pytest.raises(
-            ValueError,
-            match=".*You need to set logprobs to True to use top_logprobs.*"):
-        sampling_params = SamplingParams(max_tokens=max_tokens,
-                                         logprobs=False,
-                                         top_k=top_k,
-                                         top_p=top_p,
-                                         temperature=1.0,
-                                         top_logprobs=top_logprobs)
+        with pytest.raises(ValueError, match="logprobs.*"):
+            sampling_params = SamplingParams(
+                max_tokens=max_tokens,
+                logprobs=top_logprobs,
+                top_k=top_k,
+                top_p=top_p,
+                temperature=1.0,
+            )

--- a/tests/unittest/_torch/sampler/test_return_top_k_logprobs.py
+++ b/tests/unittest/_torch/sampler/test_return_top_k_logprobs.py
@@ -36,7 +36,7 @@ def llm_torch(input_prompts):
 
 
 @force_ampere  # Save H100 resource
-@pytest.mark.parametrize("top_logprobs", [0, 2, 4])
+@pytest.mark.parametrize("top_logprobs", [0, 1, 4])
 @pytest.mark.parametrize("top_k", [None, 2])
 @pytest.mark.parametrize("top_p", [None, 0.5])
 @pytest.mark.threadleak(enabled=False)
@@ -45,8 +45,10 @@ def test_generate_with_top_logprobs(top_logprobs: int, top_k: int, top_p: float,
     max_tokens = 8
     is_topk = top_k is not None and top_k > 1
     is_topp = top_p is not None and top_p > 0.0 and not is_topk
-    is_valid_setup = (is_topk
-                      and top_logprobs <= top_k) or is_topp or top_logprobs == 0
+    is_greedy = not (is_topk or is_topp)
+    is_valid_setup = (is_topk and top_logprobs
+                      <= top_k) or is_topp or top_logprobs == 0 or (
+                          is_greedy and top_logprobs == 1)
     if is_valid_setup:
         # passing testcases
         sampling_params = SamplingParams(max_tokens=max_tokens,

--- a/tests/unittest/_torch/sampler/test_return_top_k_logprobs.py
+++ b/tests/unittest/_torch/sampler/test_return_top_k_logprobs.py
@@ -36,7 +36,7 @@ def llm_torch(input_prompts):
 
 
 @force_ampere  # Save H100 resource
-@pytest.mark.parametrize("top_logprobs", [0, 1, 2, 4])
+@pytest.mark.parametrize("top_logprobs", [None, 0, 2, 4])
 @pytest.mark.parametrize("top_k", [None, 2])
 @pytest.mark.parametrize("top_p", [None, 0.5])
 @pytest.mark.threadleak(enabled=False)
@@ -45,7 +45,10 @@ def test_generate_with_top_logprobs(top_logprobs: int, top_k: int, top_p: float,
     max_tokens = 8
     is_topk = top_k is not None and top_k > 1
     is_topp = top_p is not None and top_p > 0.0 and not is_topk
-    is_valid_setup = is_topk and top_logprobs <= top_k or is_topp or top_logprobs == 0
+    uses_top_logprobs = top_logprobs is not None
+    is_valid_top_logprobs = top_logprobs > 0 if uses_top_logprobs else True
+    is_valid_setup = not uses_top_logprobs or (is_valid_top_logprobs and (
+        (is_topk and top_logprobs <= top_k) or is_topp))
     if is_valid_setup:
         # passing testcases
         sampling_params = SamplingParams(max_tokens=max_tokens,
@@ -56,17 +59,38 @@ def test_generate_with_top_logprobs(top_logprobs: int, top_k: int, top_p: float,
                                          top_logprobs=top_logprobs)
         for output in llm_torch.generate(input_prompts,
                                          sampling_params=sampling_params):
-            if top_logprobs > 0:
+            if top_logprobs is not None and top_logprobs > 0:
                 assert len(output.outputs[0].logprobs) == max_tokens
                 assert len(output.outputs[0].top_logprobs) == max_tokens
                 assert len(output.outputs[0].logprobs[0]) == 1
                 assert len(output.outputs[0].top_logprobs[0]) == top_logprobs
     else:
         # expected to fail testcases
-        with pytest.raises(ValueError, match="top_logprobs.*cannot exceed.*"):
+        with pytest.raises(ValueError, match="top_logprobs.*"):
             sampling_params = SamplingParams(max_tokens=max_tokens,
                                              logprobs=True,
                                              top_k=top_k,
                                              top_p=top_p,
                                              temperature=1.0,
                                              top_logprobs=top_logprobs)
+
+
+@force_ampere  # Save H100 resource
+@pytest.mark.threadleak(enabled=False)
+def test_generate_with_top_logprobs_and_disabler_logprobs(
+        llm_torch, input_prompts):
+    max_tokens = 8
+    top_logprobs = 2
+    top_k = 2
+    top_p = None
+
+    # expected to fail testcases
+    with pytest.raises(
+            ValueError,
+            match=".*You need to set logprobs to True to use top_logprobs.*"):
+        sampling_params = SamplingParams(max_tokens=max_tokens,
+                                         logprobs=False,
+                                         top_k=top_k,
+                                         top_p=top_p,
+                                         temperature=1.0,
+                                         top_logprobs=top_logprobs)

--- a/tests/unittest/api_stability/references/completion_output.yaml
+++ b/tests/unittest/api_stability/references/completion_output.yaml
@@ -10,9 +10,6 @@ methods:
       request_perf_metrics:
         annotation: Optional[tensorrt_llm.bindings.executor.RequestPerfMetrics]
         default: null
-      top_logprobs:
-        annotation: Optional[list[dict[int, tensorrt_llm.executor.result.Logprob]]]
-        default: null
     return_annotation: None
 properties:
   length:

--- a/tests/unittest/api_stability/references/completion_output.yaml
+++ b/tests/unittest/api_stability/references/completion_output.yaml
@@ -10,6 +10,9 @@ methods:
       request_perf_metrics:
         annotation: Optional[tensorrt_llm.bindings.executor.RequestPerfMetrics]
         default: null
+      top_logprobs:
+        annotation: Optional[list[dict[int, tensorrt_llm.executor.result.Logprob]]]
+        default: null
     return_annotation: None
 properties:
   length:

--- a/tests/unittest/api_stability/references/llm.yaml
+++ b/tests/unittest/api_stability/references/llm.yaml
@@ -175,6 +175,10 @@ methods:
         annotation: bool
         default: False
         status: prototype
+      max_top_logprobs:
+        annotation: int
+        default: 0
+        status: prototype
     return_annotation: None
   generate:
     parameters:

--- a/tests/unittest/api_stability/references/sampling_params.yaml
+++ b/tests/unittest/api_stability/references/sampling_params.yaml
@@ -11,8 +11,5 @@ methods:
       beam_width_array:
         annotation: Optional[List[int]]
         default: null
-      top_logprobs:
-        annotation: Optional[int]
-        default: null
     return_annotation: None
 properties: {}

--- a/tests/unittest/api_stability/references/sampling_params.yaml
+++ b/tests/unittest/api_stability/references/sampling_params.yaml
@@ -11,5 +11,8 @@ methods:
       beam_width_array:
         annotation: Optional[List[int]]
         default: null
+      top_logprobs:
+        annotation: Optional[int]
+        default: null
     return_annotation: None
 properties: {}

--- a/tests/unittest/api_stability/test_llm_api.py
+++ b/tests/unittest/api_stability/test_llm_api.py
@@ -56,7 +56,7 @@ class TestSamplingParams(ApiStabilityTestHarness):
             "return_log_probs", "return_context_logits",
             "return_generation_logits", "exclude_input_from_output",
             "return_encoder_output", "return_perf_metrics",
-            "additional_model_outputs"
+            "additional_model_outputs", "top_logprobs"
         }
         found_fields = {
             f

--- a/tests/unittest/bindings/test_executor_bindings.py
+++ b/tests/unittest/bindings/test_executor_bindings.py
@@ -889,10 +889,11 @@ def test_output_config():
     assert config.return_encoder_output == False
     assert config.return_perf_metrics == False
     assert config.additional_model_outputs is None
+    assert config.top_logprobs is None
 
     config = trtllm.OutputConfig(
         True, False, True, False, True, False,
-        list([trtllm.AdditionalModelOutput("topKLogits", True)]))
+        list([trtllm.AdditionalModelOutput("topKLogits", True)]), 10)
     assert config.return_log_probs == True
     assert config.return_context_logits == False
     assert config.return_generation_logits == True
@@ -903,12 +904,13 @@ def test_output_config():
     additional_model_output = config.additional_model_outputs[0]
     assert additional_model_output.name == "topKLogits"
     assert additional_model_output.gather_context == True
+    assert config.top_logprobs == 10
 
 
 def test_output_config_pickle():
     config = trtllm.OutputConfig(
         True, False, True, False, True, False,
-        list([trtllm.AdditionalModelOutput("topKLogits", True)]))
+        list([trtllm.AdditionalModelOutput("topKLogits", True)]), 10)
     config_copy = pickle.loads(pickle.dumps(config))
     assert config_copy.return_log_probs == True
     assert config_copy.return_context_logits == False
@@ -920,6 +922,7 @@ def test_output_config_pickle():
     additional_model_output = config_copy.additional_model_outputs[0]
     assert additional_model_output.name == "topKLogits"
     assert additional_model_output.gather_context == True
+    assert config_copy.top_logprobs == 10
 
 
 def test_external_draft_tokens_config():

--- a/tests/unittest/llmapi/apps/_test_trtllm_serve_top_logprobs.py
+++ b/tests/unittest/llmapi/apps/_test_trtllm_serve_top_logprobs.py
@@ -31,7 +31,8 @@ def temp_extra_llm_api_options_file():
             "gather_generation_logits": True,
             "kv_cache_config": {
                 "enable_block_reuse": False,
-            }
+            },
+            "max_top_logprobs": 1
         }
 
         with open(temp_file_path, 'w') as f:

--- a/tests/unittest/llmapi/test_llm_pytorch.py
+++ b/tests/unittest/llmapi/test_llm_pytorch.py
@@ -244,6 +244,7 @@ def test_embedding_bias_with_torch_sampler_strategies(enable_mixed_sampler,
     vocab_size_padded = 32000
     embedding_bias = torch.zeros(vocab_size_padded)
     embedding_bias[biased_word_id] = torch.finfo(torch.float32).max
+    max_top_logprobs = 0
 
     sampling_kwargs = {
         "max_tokens": 6,
@@ -252,6 +253,7 @@ def test_embedding_bias_with_torch_sampler_strategies(enable_mixed_sampler,
 
     if enable_logprobs:
         sampling_kwargs["logprobs"] = 1
+        max_top_logprobs = 1
     # All test cases use greedy sampling for simplicity
 
     sampling_params = SamplingParams(**sampling_kwargs)
@@ -260,7 +262,8 @@ def test_embedding_bias_with_torch_sampler_strategies(enable_mixed_sampler,
                      prompts, ["Z Z Z Z Z Z"],
                      sampling_params=sampling_params,
                      backend="pytorch",
-                     enable_mixed_sampler=enable_mixed_sampler)
+                     enable_mixed_sampler=enable_mixed_sampler,
+                     max_top_logprobs=max_top_logprobs)
 
 
 def llama_7b_lora_from_dir_test_harness(**llm_kwargs) -> None:


### PR DESCRIPTION
# [TRTLLM-5670][feat] Support top log probabilities

- Added a new parameter `topLogProbs` to the `OutputConfig` class, allowing users to specify the number of top log probabilities to return.
- Updated related methods and bindings in the executor and API layers to accommodate this feature.
- updated code in Torch sampler to provide the functionality
- added a new Dict to LogProbStorage containing the top logprobs
- included validation checks for top log probabilities in the sampling parameters
- added tests to ensure correct functionality.

**Change:** Changed API to conform better with current API.
 - removed top_logprobs parameter and used logprobs instead
 - concatenated top_logprobs and logprobs in output instead of adding top_logprobs field
 - Note: Need to update Performance tests for this new change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Return top token log-probabilities with each generated token.
  - New controls: SamplingParams.top_logprobs and LLM max_top_logprobs.
  - Python API/bindings accept, serialize, and expose top_logprobs across requests and results.

- Documentation
  - quickstart_advanced adds --top_logprobs and --max_top_logprobs flags, prints top log-probs, and auto-enables mixed sampling when applicable.

- Tests
  - Added unit and integration tests covering top_logprobs validation, serialization, and runtime behavior (including torch sampler paths).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Allow the user to specify with the top_logprobs parameter if he wants to have the logprobs of the top <top_logprobs> tokens at each step in addition to the logprobs of the sampled tokens. 

Currently only functionality was tested. 

## Performance Tests
I ran performance checks of main and this branch for greedy and top-k sampling with logprobs=false/true to see how the changes impact workflows, where top-logprobs are not enabled.

Number of requests:             100
Number of concurrent requests:  55.9995
Average Input Length (tokens):  40.0000
Average Output Length (tokens): 2009.0000
TP Size:                1
PP Size:                1
EP Size:                None
Max Runtime Batch Size: 64
Max Runtime Tokens:     131072
Scheduling Policy:      GUARANTEED_NO_EVICT
KV Memory Percentage:   90.00%
Issue Rate (req/sec):   3.9227E+17


### This branch (Need update since latest changes)

Test Configuration | Request Throughput (req/sec) | Total Output Throughput (tokens/sec) | Total Token Throughput (tokens/sec) | Total Latency (ms) | Average Request Latency (ms)
--- | --- | --- | --- | --- | ---
Greedy Sampling (w/ logprobs) | 1.8135 | 3643.3317 | 3715.8719 | 55141.8369 | 30763.6410
Greedy Sampling (w/o logprobs) | 3.1688 | 6366.1379 | 6492.8903 | 31557.5947 | 18070.6263
Top-k Only Sampling (w/logprobs) | 1.7962 | 3608.5418 | 3680.3893 | 55673.4576 | 31001.0933
Top-k Only Sampling (w/o logprobs) | 2.7684 | 5561.8000 | 5672.5377 | 36121.3996 | 20532.6132

### main branch

Test Configuration | Request Throughput (req/sec) | Total Output Throughput (tokens/sec) | Total Token Throughput (tokens/sec) | Total Latency (ms) | Average Request Latency (ms)
--- | --- | --- | --- | --- | ---
Greedy Sampling (w/ logprobs) | 1.8263 | 3669.0145 | 3742.0661 | 54755.8476 | 30663.0136
Greedy Sampling (w/o logprobs | 3.1843 | 6397.2784 | 6524.6508 | 31403.9797 | 17990.4672
Top-k Only Sampling (w/ logprobs) | 1.7546 | 3524.9074 | 3595.0897 | 56994.4056 | 31702.4851
Top-k Only Sampling (w/o logprobs) | 2.7831 | 5591.2461 | 5702.5701 | 35931.1673 | 20441.4355



## Test Coverage

new test: test_return_top_k_logprobs.py 
tests if the shape of the results is correct. Additionally ensures that some failure cases throw the correct error

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
