### PR TITLE
[TRTLLM-6639][test] Add lora adapter test cases with llmapi

### DIFF
--- a/tests/integration/defs/test_e2e.py
+++ b/tests/integration/defs/test_e2e.py
@@ -31,9 +31,10 @@ from defs.trt_test_alternative import (check_call, check_call_negative_test,
 from .common import (PluginOptions, convert_weights, get_mmlu_accuracy,
                      prune_checkpoint, quantize_data, refit_model,
                      venv_check_call)
-from .conftest import (llm_models_root, skip_no_sm120, skip_nvlink_inactive,
-                       skip_post_blackwell, skip_pre_blackwell, skip_pre_hopper,
-                       tests_path, unittest_path)
+from .conftest import (get_device_count, llm_models_root, skip_no_sm120,
+                       skip_nvlink_inactive, skip_post_blackwell,
+                       skip_pre_blackwell, skip_pre_hopper, tests_path,
+                       unittest_path)
 
 sys.path.append(os.path.join(str(tests_path()), '/../examples/apps'))
 
@@ -2976,3 +2977,103 @@ def test_multi_nodes_eval(llm_venv, model_path, tp_size, pp_size, ep_size,
     if os.environ.get("SLURM_PROCID", '0') == '0':
         mmlu_accuracy = get_mmlu_accuracy(output)
         assert mmlu_accuracy > mmlu_threshold, f"MMLU accuracy {mmlu_accuracy} is less than threshold {mmlu_threshold}"
+
+
+@pytest.mark.parametrize("workflow", ["trt", "torch"])
+@pytest.mark.parametrize("tp_size", [1, 8], ids=["tp1", "tp8"])
+@pytest.mark.parametrize(
+    ["model_path", "lora_path"],
+    [("llama-3.1-model/Llama-3.1-8B-Instruct",
+      "lora/evian2-8b-instruct_vhf-lora-v1_jetart"),
+     ("llama-3.3-models/Llama-3.3-70B-Instruct",
+      "lora/llama3-70b-instruct-lora_vhf-squad-v1"),
+     ("nemotron-nas/Llama-3_3-Nemotron-Super-49B-v1",
+      "nemotron-nas/Llama-3_3-Nemotron-Super-49B-v1-lora-adapter_r64")(
+          "Mixtral-8x7B-v0.1", "lora/mixtral-8x7b-instruct-v0-1_vhf-lora-v1"),
+     ("Mistral-7B-Instruct-v0.3",
+      "lora/mistral-7b-instruct-v0-3_vhf_lora_squad"),
+     ("starcoder2-7b", "lora/starcoder2-7b_vhf-lora-squad-030325211133")])
+def test_llmapi_lora(workflow, model_path, lora_path, tp_size):
+    device_count = get_device_count()
+    if device_count < tp_size:
+        pytest.skip(f"Need at least {tp_size} GPUs to run this test")
+
+    if workflow == "trt":
+        from tensorrt_llm._tensorrt_engine import LLM
+    else:
+        from tensorrt_llm import LLM
+    from tensorrt_llm.executor.request import LoRARequest
+    from tensorrt_llm.lora_helper import LoraConfig
+    from tensorrt_llm.sampling_params import SamplingParams
+
+    # Configure LoRA
+    lora_config = LoraConfig(lora_dir=[f"/code/tensorrt_llm/{lora_path}"],
+                             max_lora_rank=8,
+                             max_loras=1,
+                             max_cpu_loras=1)
+
+    # Initialize LLM with LoRA support
+    llm = LLM(f"{llm_models_root()}/{model_path}",
+              lora_config=lora_config,
+              tensor_parallel_size=tp_size)
+
+    # Create LoRA request
+    lora_request = LoRARequest("my-lora-task", 0,
+                               f"/code/tensorrt_llm/{lora_path}")
+
+    # Test multiple prompts
+    prompts = [
+        "Hello, how are you?",
+        "What is the capital of France?",
+        "Explain the concept of machine learning.",
+    ]
+
+    sampling_params = SamplingParams(max_tokens=50)
+
+    # Generate with LoRA
+    print("=== Generating with LoRA adapter ===")
+    lora_outputs = llm.generate(prompts,
+                                sampling_params,
+                                lora_request=[lora_request] * len(prompts))
+
+    # Generate without LoRA (baseline)
+    print("=== Generating without LoRA adapter (baseline) ===")
+    baseline_outputs = llm.generate(prompts,
+                                    sampling_params,
+                                    lora_request=[None] * len(prompts))
+
+    # Compare outputs using token_ids for more accurate overlap calculation
+    print("\n=== Token-based Overlap Analysis ===")
+    total_overlap_ratio = 0
+
+    for i, (prompt, lora_out, baseline_out) in enumerate(
+            zip(prompts, lora_outputs, baseline_outputs)):
+        lora_tokens = lora_out.outputs[0].token_ids
+        baseline_tokens = baseline_out.outputs[0].token_ids
+
+        # Calculate overlap between token sequences
+        min_len = min(len(lora_tokens), len(baseline_tokens))
+        if min_len == 0:
+            overlap_ratio = 0.0
+        else:
+            # Count matching tokens at each position
+            matching_tokens = sum(1 for j in range(min_len)
+                                  if lora_tokens[j] in baseline_tokens)
+            overlap_ratio = matching_tokens / min_len
+
+        total_overlap_ratio += overlap_ratio
+
+        print(f"\nPrompt {i+1}: {prompt}")
+        print(f"LoRA tokens:    {lora_tokens[:10]}...")  # Show first 10 tokens
+        print(f"Baseline tokens: {baseline_tokens[:10]}...")
+        print(f"Token overlap:   {overlap_ratio:.2%}")
+        print(f"LoRA text:       {lora_out.outputs[0].text.strip()}")
+        print(f"Baseline text:   {baseline_out.outputs[0].text.strip()}")
+        print("-" * 80)
+
+    # Calculate average overlap across all prompts
+    avg_overlap = total_overlap_ratio / len(prompts)
+    print(f"\n=== Final Results ===")
+    print(f"Average token overlap: {avg_overlap:.2%}")
+
+    assert avg_overlap >= 0.6, f"Average token overlap {avg_overlap:.2%} is below 60%"

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -346,3 +346,8 @@ stress_test/stress_test.py::test_run_stress_test[llama-v3-8b-instruct-hf_tp1-str
 test_e2e.py::test_trtllm_bench_iteration_log[TRT-streaming-meta-llama/Llama-3.1-8B-llama-3.1-model/Meta-Llama-3.1-8B] SKIP (https://nvbugs/5448523)
 cpp/test_unit_tests.py::test_unit_tests[kernels-80] SKIP (https://nvbugs/5504078)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_fp8_block_scales[mtp=vanilla-fp8kv=False-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=False] SKIP (https://nvbugs/5504086)
+test_e2e.py::test_llmapi_lora[llama-3.1-model/Llama-3.1-8B-Instruct-lora/evian2-8b-instruct_vhf-lora-v1_jetart-tp1-torch] SKIP (https://nvbugs/5484088)
+test_e2e.py::test_llmapi_lora[llama-3.3-models/Llama-3.3-70B-Instruct-lora/llama-3.3-70b-instruct_vhf-squad-lora-031925331-v2-tp8-torch] SKIP (https://nvbugs/5484088)
+test_e2e.py::test_llmapi_lora[Mixtral-8x7B-v0.1-lora/mixtral-8x7b-instruct-v0-1_vhf-lora-v1-tp8-torch] SKIP (https://nvbugs/5484088)
+test_e2e.py::test_llmapi_lora[Mistral-7B-Instruct-v0.3-lora/mistral-7b-instruct-v0-3_vhf_lora_squad-tp1-torch] SKIP (https://nvbugs/5484088)
+test_e2e.py::test_llmapi_lora[starcoder2-7b-lora/starcoder2-7b_vhf-lora-squad-030325211133-tp1-torch] SKIP (https://nvbugs/5484088)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
local verification: [report](https://prod.blsm.nvidia.com/swqa-tensorrt-qa-test/job/LLM_FUNCTION_MULTI_STAGE/50/testReport/)
## Summary by CodeRabbit

* **Tests**
  * Added parameterized end-to-end LoRA tests validating LoRA-enabled generation against non‑LoRA baselines across multiple models, workflows (TensorRT/PyTorch), tensor‑parallel sizes, and sampling prompts; also added related accuracy test entries.
* **Waives**
  * Added five platform-specific skips to waive select LoRA end-to-end tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
