### PR TITLE
[#7222][autodeploy] Separate run_shape_prop as another graph utility

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/transform/interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/interface.py
@@ -13,7 +13,7 @@ from torch.fx import GraphModule
 
 from ..models.factory import ModelFactory
 from ..shim.interface import CachedSequenceInterface
-from ..transformations._graph import canonicalize_graph, lift_to_meta
+from ..transformations._graph import canonicalize_graph, lift_to_meta, run_shape_prop
 from ..utils.logger import ad_logger
 from ..utils.sharding_utils import ShardingConfig
 
@@ -328,7 +328,7 @@ class BaseTransform(ABC):
         if self.config.requires_shape_prop and not has_valid_shapes:
             canonicalize_graph(gm)
             with lift_to_meta(gm):
-                canonicalize_graph(gm, shape_prop=True)
+                run_shape_prop(gm)
             is_clean = True
             has_valid_shapes = True
         elif self.config.requires_clean_graph and not is_clean:
@@ -354,7 +354,7 @@ class BaseTransform(ABC):
         if self.config.run_shape_prop and not (info.is_clean and info.has_valid_shapes):
             canonicalize_graph(gm)
             with lift_to_meta(gm):
-                canonicalize_graph(gm, shape_prop=True)
+                run_shape_prop(gm)
         elif self.config.run_graph_cleanup and not info.is_clean:
             canonicalize_graph(gm)
 

--- a/tensorrt_llm/_torch/auto_deploy/transformations/_graph.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/_graph.py
@@ -129,7 +129,7 @@ def _move_single_gm_to_device(gm: GraphModule, device: torch.device) -> None:
         gm.recompile()
 
 
-def move_to_device(gm: fx.GraphModule, device: DeviceLikeType) -> fx.GraphModule:
+def move_to_device(gm: fx.GraphModule, device: DeviceLikeType) -> None:
     """Move the entire graph module and all sub-GraphModules to the specified device."""
     # get device
     device = torch.device(device)
@@ -154,7 +154,7 @@ def _is_impure_node(node: Node) -> bool:
             node.target._nondeterministic_seeded = True
 
 
-def _canonicalize_single_gm(gm: GraphModule) -> GraphModule:
+def _canonicalize_single_gm(gm: GraphModule) -> None:
     # clean up graph (needs to be done repeatedly until no more dead code)
     gm.graph.eliminate_dead_code(is_impure_node=_is_impure_node)
 
@@ -187,7 +187,7 @@ def canonicalize_graph(gm: GraphModule) -> None:
 def _run_shape_prop_single_gm(
     gm: GraphModule,
     args_static: Optional[Tuple[Any, ...]] = None,
-) -> bool:
+) -> None:
     fake_mode: Optional[FakeTensorMode] = _detect_fake_mode_from_gm(gm)
 
     # get fake tensors from placeholder nodes

--- a/tensorrt_llm/_torch/auto_deploy/transformations/_graph.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/_graph.py
@@ -154,9 +154,7 @@ def _is_impure_node(node: Node) -> bool:
             node.target._nondeterministic_seeded = True
 
 
-def _canonicalize_single_gm(
-    gm: GraphModule, shape_prop: bool = False, args_static: Optional[Tuple[Any, ...]] = None
-) -> GraphModule:
+def _canonicalize_single_gm(gm: GraphModule) -> GraphModule:
     # clean up graph (needs to be done repeatedly until no more dead code)
     gm.graph.eliminate_dead_code(is_impure_node=_is_impure_node)
 
@@ -166,57 +164,79 @@ def _canonicalize_single_gm(
     # clean up graph module
     gm.delete_all_unused_submodules()
 
-    # NOTE: shape_prop can be a littly finicky & slow, so we only run it optionally...
-    if shape_prop:
-        fake_mode: Optional[FakeTensorMode] = _detect_fake_mode_from_gm(gm)
-
-        # get fake tensors from placeholder nodes
-        inps = [node.meta.get("val") for node in gm.graph.nodes if node.op == "placeholder"]
-
-        # check if we need to use args to create fake tensors
-        if any(inp is None for inp in inps):
-            if args_static is not None and fake_mode is not None and len(args_static) == len(inps):
-                inps = [
-                    fake_t if fake_t is not None else fake_mode.from_tensor(arg, static_shapes=True)
-                    for fake_t, arg in zip(inps, args_static)
-                ]
-
-        # run shape propagation if we have all the fake tensors
-        if all(inp is not None for inp in inps):
-            FakeTensorProp(gm, fake_mode).propagate(*inps)
-        else:
-            ad_logger.warning("No fake tensors and no args available for shape propagation")
-
     # lint the graph
     gm.graph.lint()
 
 
-def canonicalize_graph(
-    gm: GraphModule, shape_prop: bool = False, args_static: Optional[Tuple[Any, ...]] = None
-) -> None:
+def canonicalize_graph(gm: GraphModule) -> None:
     """Canonicalize the graph of the given GraphModule.
 
     Args:
         gm: The GraphModule to canonicalize.
-        shape_prop: Whether to run shape propagation. Shape propagation tends to be finicky and
-            slow, so we only run it optionally.
-        args_static: A tuple of static arguments to use for shape propagation. Shape propagation
-            requires all inputs to the graph ("placeholder" nodes) to have metadata with an
-            appropriate FakeTensor argument (``node.meta["val"]``). ``args_static`` can be used to
-            infer static FakeTensor information if some placeholder nodes do not have metadata.
-            When ``meta["val"]`` is available, it will take precedence over ``args_static``.
-
     Returns:
         The canonicalized (cleaned-up) GraphModule.
     """
     ad_logger.debug(f"Before canonicalizing: {gm}")
 
     for _, subgm in reversed(list(named_graphmodules(gm))):
-        _canonicalize_single_gm(
-            subgm, shape_prop=shape_prop, args_static=args_static if subgm is gm else None
-        )
+        _canonicalize_single_gm(subgm)
 
     ad_logger.debug(f"After canonicalizing: {gm}")
+
+
+def _run_shape_prop_single_gm(
+    gm: GraphModule,
+    args_static: Optional[Tuple[Any, ...]] = None,
+) -> bool:
+    fake_mode: Optional[FakeTensorMode] = _detect_fake_mode_from_gm(gm)
+
+    # get fake tensors from placeholder nodes
+    inps = [node.meta.get("val") for node in gm.graph.nodes if node.op == "placeholder"]
+
+    # check if we need to use args to create fake tensors
+    if any(inp is None for inp in inps):
+        if args_static is not None and fake_mode is not None and len(args_static) == len(inps):
+            inps = [
+                fake_t if fake_t is not None else fake_mode.from_tensor(arg, static_shapes=True)
+                for fake_t, arg in zip(inps, args_static)
+            ]
+
+    # run shape propagation if we have all the fake tensors
+    if all(inp is not None for inp in inps):
+        FakeTensorProp(gm, fake_mode).propagate(*inps)
+    else:
+        ad_logger.warning("No fake tensors and no args available for shape propagation")
+
+    # lint the graph
+    gm.graph.lint()
+
+
+def run_shape_prop(
+    gm: GraphModule,
+    args_static: Optional[Tuple[Any, ...]] = None,
+) -> None:
+    """Run FakeTensor-based shape propagation on the given GraphModule and its submodules.
+
+    This pass attempts to populate shape/type metadata for all nodes by propagating
+    FakeTensor inputs through the graph. If a placeholder node already has a
+    ``node.meta["val"]`` entry, that FakeTensor will be used. Otherwise, if
+    ``args_static`` is provided and a FakeTensorMode is detected, new FakeTensors
+    are synthesized from the static arguments.
+
+    Args:
+        gm: The top-level GraphModule on which to run shape propagation. All nested
+            GraphModules are processed in reverse topological order.
+        args_static: Optional tuple of concrete tensors used to create FakeTensors
+            when placeholder metadata is missing. Only applied to the top-level
+            GraphModule; submodules reuse their existing placeholder metadata.
+
+    """
+    ad_logger.debug(f"Before running shape propagation: {gm}")
+
+    for _, subgm in reversed(list(named_graphmodules(gm))):
+        _run_shape_prop_single_gm(subgm, args_static=args_static if subgm is gm else None)
+
+    ad_logger.debug(f"After running shape propagation: {gm}")
 
 
 def add_graph_input(


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated, callable shape-propagation step that can be run separately to improve handling of dynamic inputs.

* **Refactor**
  * Decoupled canonicalization from shape propagation for clearer, more reliable graph processing and better diagnostics.

* **Developer Impact**
  * Public APIs and return behavior changed: shape propagation is now a separate invocation; integration points may require minor updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
