### PR TITLE
[TRTLLM-7208][feat] Implement basic functionalities for Responses API

### DIFF
--- a/examples/models/core/gpt_oss/openai_chat_client_function_calling.py
+++ b/examples/models/core/gpt_oss/openai_chat_client_function_calling.py
@@ -110,6 +110,7 @@ def main():
     print(f"[RESPONSE 1] [COT] {reasoning}")
     print(f"[RESPONSE 1] [FUNCTION CALL] {tool.__name__}(**{kwargs})")
     answer = tool(**kwargs)
+    print(answer)
 
     messages.extend([{
         "role": "assistant",

--- a/examples/models/core/gpt_oss/openai_chat_client_function_calling.py
+++ b/examples/models/core/gpt_oss/openai_chat_client_function_calling.py
@@ -110,7 +110,6 @@ def main():
     print(f"[RESPONSE 1] [COT] {reasoning}")
     print(f"[RESPONSE 1] [FUNCTION CALL] {tool.__name__}(**{kwargs})")
     answer = tool(**kwargs)
-    print(answer)
 
     messages.extend([{
         "role": "assistant",

--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -751,7 +751,7 @@ class ResponsesRequest(OpenAIBaseModel):
         if self.text is not None and self.text.format is not None:
             response_format = self.text.format
             if response_format.type == "json_schema":
-                guided_decoding = GuidedDecodingParams.from_optional(
+                guided_decoding = GuidedDecodingParams(
                     json=response_format.schema_)
             elif response_format.type == "json_object":
                 raise NotImplementedError("json_object is not supported")
@@ -766,6 +766,7 @@ class ResponsesRequest(OpenAIBaseModel):
         )
 
     @model_validator(mode="before")
+    @classmethod
     def validate_background(cls, data):
         if not data.get("background"):
             return data
@@ -774,6 +775,7 @@ class ResponsesRequest(OpenAIBaseModel):
         return data
 
     @model_validator(mode="before")
+    @classmethod
     def validate_prompt(cls, data):
         if data.get("prompt") is not None:
             raise ValueError("prompt template is not supported")

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -41,7 +41,7 @@ from tensorrt_llm.serve.openai_protocol import (ChatCompletionRequest,
                                                 CompletionResponseChoice,
                                                 ErrorResponse, ModelCard,
                                                 ModelList, ResponsesRequest,
-                                                ResponsesResponse, UsageInfo,
+                                                UsageInfo,
                                                 to_llm_disaggregated_params)
 from tensorrt_llm.serve.postprocess_handlers import (
     ChatPostprocArgs, CompletionPostprocArgs, chat_response_post_processor,
@@ -771,13 +771,13 @@ class OpenAIServer:
             return self.create_error_response(message=str(e), err_type="internal_error")
 
     async def openai_responses(self, request: ResponsesRequest, raw_request: Request) -> Response:
-        async def create_stream_response(generator, request: ResponsesRequest, sampling_params) -> ResponsesResponse:
+        async def create_stream_response(generator, request: ResponsesRequest, sampling_params) -> AsyncGenerator[str, None]:
             async for event_data in responses_api_process_streaming_events(
                 request=request,
                 sampling_params=sampling_params,
                 generator=generator,
                 harmony_adapter=self.harmony_adapter,
-                model_name=self.model_config.model_type,
+                model_name=self.model,
                 conversation_store=self.conversation_store,
                 enable_store=self.enable_store
             ):
@@ -829,7 +829,7 @@ class OpenAIServer:
                     generator=promise,
                     request=request,
                     sampling_params=sampling_params,
-                    model_name=self.model_config.model_type,
+                    model_name=self.model,
                     conversation_store=self.conversation_store,
                     generation_result=None,
                     enable_store=self.enable_store)

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -40,12 +40,20 @@ from tensorrt_llm.serve.openai_protocol import (ChatCompletionRequest,
                                                 CompletionResponse,
                                                 CompletionResponseChoice,
                                                 ErrorResponse, ModelCard,
-                                                ModelList, UsageInfo,
+                                                ModelList, ResponsesRequest,
+                                                ResponsesResponse, UsageInfo,
                                                 to_llm_disaggregated_params)
 from tensorrt_llm.serve.postprocess_handlers import (
     ChatPostprocArgs, CompletionPostprocArgs, chat_response_post_processor,
     chat_stream_post_processor, completion_response_post_processor,
     completion_stream_post_processor)
+from tensorrt_llm.serve.responses_utils import ConversationHistoryStore
+from tensorrt_llm.serve.responses_utils import \
+    create_response as responses_api_create_response
+from tensorrt_llm.serve.responses_utils import \
+    process_streaming_events as responses_api_process_streaming_events
+from tensorrt_llm.serve.responses_utils import \
+    request_preprocess as responses_api_request_preprocess
 from tensorrt_llm.version import __version__ as VERSION
 
 from .._utils import nvtx_mark, set_prometheus_multiproc_dir
@@ -81,6 +89,12 @@ class OpenAIServer:
         except Exception:
             logger.debug("Failed to load AutoConfig for %s", hf_tokenizer_path)
             self.model_config = None
+
+        # Enable response storage for Responses API
+        self.enable_store = True
+        if len(os.getenv("TRTLLM_RESPONSES_API_DISABLE_STORE", "")) > 0:
+            self.enable_store = False
+        self.conversation_store = ConversationHistoryStore()
 
         model_dir = Path(model)
         if model_dir.exists() and model_dir.is_dir():
@@ -165,6 +179,20 @@ class OpenAIServer:
         return JSONResponse(content=error_response.model_dump(),
                             status_code=error_response.code)
 
+    def _create_invalid_response_id_error(self, response_id: str) -> Response:
+        return self.create_error_response(
+            err_type="InvalidRequestError",
+            message=(f"Invalid 'response_id': '{response_id}'. "
+                     "Expected an ID that begins with 'resp'."),
+        )
+
+    def _create_response_id_not_found_error(self, response_id: str) -> Response:
+        return self.create_error_response(
+            err_type="InvalidRequestError",
+            message=f"Response with id '{response_id}' not found.",
+            status_code=HTTPStatus.NOT_FOUND,
+        )
+
     def register_routes(self):
         self.app.add_api_route("/health", self.health, methods=["GET"])
         self.app.add_api_route("/health_generate", self.health_generate, methods=["GET"])
@@ -180,6 +208,9 @@ class OpenAIServer:
                                methods=["POST"])
         self.app.add_api_route("/v1/chat/completions",
                                self.openai_chat if not self.use_harmony else self.chat_harmony,
+                               methods=["POST"])
+        self.app.add_api_route("/v1/responses",
+                               self.openai_responses,
                                methods=["POST"])
         if self.llm.args.return_perf_metrics:
             # register /prometheus/metrics
@@ -738,6 +769,80 @@ class OpenAIServer:
             logger.error("Error in harmony chat completion: %s", e)
             logger.debug("Error details: %s", traceback.format_exc())
             return self.create_error_response(message=str(e), err_type="internal_error")
+
+    async def openai_responses(self, request: ResponsesRequest, raw_request: Request) -> Response:
+        async def create_stream_response(generator, request: ResponsesRequest, sampling_params) -> ResponsesResponse:
+            async for event_data in responses_api_process_streaming_events(
+                request=request,
+                sampling_params=sampling_params,
+                generator=generator,
+                harmony_adapter=self.harmony_adapter,
+                model_name=self.model_config.model_type,
+                conversation_store=self.conversation_store,
+                enable_store=self.enable_store
+            ):
+                yield event_data
+
+        try:
+            if not self.use_harmony:
+                raise NotImplementedError("Responses API only supports harmony format for now")
+
+            # Initialize HarmonyAdapter
+            # NOTE: WAR for Disagg failure, may affect perf if no warmup
+            if not self.harmony_adapter:
+                self.harmony_adapter = HarmonyAdapter()
+
+            if request.background:
+                logger.warning("Request.background is not supported yet, will fallback to foreground processing.")
+
+            # Get prev response
+            prev_response = None
+            if self.enable_store:
+                prev_response_id = request.previous_response_id
+                if prev_response_id is not None:
+                    if not prev_response_id.startswith("resp_"):
+                        return self._create_invalid_response_id_error(prev_response_id)
+
+                    prev_response = await self.conversation_store.load_response(prev_response_id)
+                    if prev_response is None:
+                        logger.debug(f"response_id {prev_response_id} not found")
+                        return self._create_response_id_not_found_error(prev_response_id)
+
+            input_tokens, sampling_params = await responses_api_request_preprocess(
+                request, prev_response, self.harmony_adapter, self.conversation_store, self.enable_store)
+
+            promise = self.llm.generate_async(
+                inputs=input_tokens,
+                sampling_params=sampling_params,
+                streaming=request.stream,
+            )
+
+            asyncio.create_task(self.await_disconnected(raw_request, promise))
+
+            if request.stream:
+                return StreamingResponse(
+                    create_stream_response(promise, request, sampling_params),
+                    media_type="text/event-stream"
+                )
+            else:
+                return await responses_api_create_response(
+                    generator=promise,
+                    request=request,
+                    sampling_params=sampling_params,
+                    model_name=self.model_config.model_type,
+                    conversation_store=self.conversation_store,
+                    generation_result=None,
+                    enable_store=self.enable_store)
+        except CppExecutorError:
+            logger.error(traceback.format_exc())
+            # If internal executor error is raised, shutdown the server
+            signal.raise_signal(signal.SIGINT)
+        except Exception as e:
+            logger.error(traceback.format_exc())
+            return self.create_error_response(str(e))
+
+        return JSONResponse(content={"detail": "None"})
+
 
     async def __call__(self, host, port):
         # Store the binding address for server registration

--- a/tensorrt_llm/serve/responses_utils.py
+++ b/tensorrt_llm/serve/responses_utils.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 import asyncio
 import json
 import os

--- a/tensorrt_llm/serve/responses_utils.py
+++ b/tensorrt_llm/serve/responses_utils.py
@@ -1,0 +1,844 @@
+import asyncio
+import json
+import os
+import time
+import uuid
+from collections.abc import AsyncGenerator
+from copy import copy
+from typing import Literal, Optional, OrderedDict, Union
+
+# yapf: disable
+from openai.types.responses import (ResponseCompletedEvent,
+                                    ResponseContentPartAddedEvent,
+                                    ResponseContentPartDoneEvent,
+                                    ResponseCreatedEvent,
+                                    ResponseFunctionToolCall,
+                                    ResponseInProgressEvent, ResponseOutputItem,
+                                    ResponseOutputItemAddedEvent,
+                                    ResponseOutputItemDoneEvent,
+                                    ResponseOutputMessage, ResponseOutputText,
+                                    ResponseReasoningItem,
+                                    ResponseReasoningTextDeltaEvent,
+                                    ResponseReasoningTextDoneEvent,
+                                    ResponseTextDeltaEvent,
+                                    ResponseTextDoneEvent)
+# yapf: enable
+from openai.types.responses.response_function_web_search import (
+    ActionFind, ActionOpenPage, ActionSearch, ResponseFunctionWebSearch)
+from openai.types.responses.response_reasoning_item import Content
+from openai.types.responses.tool import Tool
+from openai_harmony import (Author, Conversation, DeveloperContent,
+                            HarmonyEncodingName, Message, ReasoningEffort, Role,
+                            StreamState, SystemContent, TextContent,
+                            ToolDescription, load_harmony_encoding)
+
+from tensorrt_llm.llmapi import SamplingParams
+from tensorrt_llm.llmapi.llm import RequestOutput
+from tensorrt_llm.logger import logger
+from tensorrt_llm.serve.openai_protocol import (OpenAIBaseModel,
+                                                ResponseInputOutputItem,
+                                                ResponsesRequest,
+                                                ResponsesResponse)
+
+from .harmony_adapter import HarmonyAdapter
+
+REASONING_EFFORT = {
+    "high": ReasoningEffort.HIGH,
+    "medium": ReasoningEffort.MEDIUM,
+    "low": ReasoningEffort.LOW,
+}
+
+ENABLE_RESPONSES_DEBUG_MSG = False
+
+
+def responses_debug_log(msg):
+    if ENABLE_RESPONSES_DEBUG_MSG:
+        logger.debug(msg)
+
+
+_harmony_encoding = None
+
+
+def random_uuid():
+    return str(uuid.uuid4().hex)
+
+
+def get_encoding():
+    global _harmony_encoding
+    if _harmony_encoding is None:
+        _harmony_encoding = load_harmony_encoding(
+            HarmonyEncodingName.HARMONY_GPT_OSS)
+    return _harmony_encoding
+
+
+def decode_tokens(tokens):
+    return get_encoding().decode(tokens)
+
+
+def parse_response_input(
+    input_msg: ResponseInputOutputItem,
+    prev_responses: list[Union[ResponseOutputItem, ResponseReasoningItem]]
+) -> Message:
+    if not isinstance(input_msg, dict):
+        input_msg = input_msg.model_dump()
+
+    responses_debug_log(f"------- Parsing input -----------")
+    responses_debug_log(input_msg)
+    responses_debug_log("")
+
+    if "type" not in input_msg or input_msg["type"] == "message":
+        role = input_msg["role"]
+        content = input_msg["content"]
+        if role == "system":
+            # User is trying to set a system message. Change it to:
+            # <|start|>developer<|message|># Instructions
+            # {instructions}<|end|>
+            role = "developer"
+            text_prefix = "Instructions:\n"
+        else:
+            text_prefix = ""
+        if isinstance(content, str):
+            msg = Message.from_role_and_content(role, text_prefix + content)
+        elif isinstance(content, list):
+            contents = [
+                TextContent(text=text_prefix + c["text"]) for c in content
+            ]
+            msg = Message.from_role_and_contents(role, contents)
+        else:
+            logger.warning("Responses API: Invalid input message type")
+            msg = None
+    elif input_msg["type"] == "function_call_output":
+        call_id = input_msg["call_id"]
+        call_response: Optional[ResponseFunctionToolCall] = None
+        for prev_response in reversed(prev_responses):
+            if isinstance(prev_response, ResponseFunctionToolCall
+                          ) and prev_response.call_id == call_id:
+                call_response = prev_response
+                break
+        if call_response is None:
+            raise ValueError(f"No call message found for {call_id}")
+        msg = Message.from_author_and_content(
+            Author.new(Role.TOOL, f"functions.{call_response.name}"),
+            input_msg["output"])
+    elif input_msg["type"] == "reasoning":
+        content = input_msg["content"]
+        assert len(content) == 1
+        msg = Message.from_role_and_content(Role.ASSISTANT, content[0]["text"])
+    elif input_msg["type"] == "function_call":
+        msg = Message.from_role_and_content(Role.ASSISTANT,
+                                            input_msg["arguments"])
+        msg = msg.with_channel("commentary")
+        msg = msg.with_recipient(f"functions.{input_msg['name']}")
+        msg = msg.with_content_type("json")
+    else:
+        raise ValueError(f"Unknown input type: {input_msg['type']}")
+    return msg
+
+
+class ConversationHistoryStore:
+
+    def __init__(self, resp_capacity: int = 16, max_conversations=32):
+        self.response_capacity = resp_capacity
+        self.conversation_capacity = resp_capacity * 4
+        self.max_conversations = max_conversations
+
+        self.responses_lock = asyncio.Lock()
+        self.responses: OrderedDict[str, ResponsesResponse] = OrderedDict()
+
+        self.conversations_lock = asyncio.Lock()
+        self.conversations: OrderedDict[str, list[Message]] = OrderedDict()
+        self.response_to_conversation: dict[str, str] = {}
+        self.conversation_to_response: dict[str, str] = {}
+
+    async def load_response(self, resp_id: str) -> ResponsesResponse:
+        responses_debug_log(f"ConversationHistoryStore loading resp: {resp_id}")
+        async with self.responses_lock:
+            return self.responses.get(resp_id)
+
+    async def store_response(self,
+                             resp: ResponsesResponse,
+                             resp_msgs: Optional[list[Message]] = [],
+                             prev_resp_id: Optional[str] = None) -> None:
+        resp_id = resp.id
+        responses_debug_log(f"ConversationHistoryStore storing resp: {resp_id}")
+        async with self.responses_lock:
+            self.responses[resp_id] = resp
+            if len(self.responses) > self.response_capacity:
+                self._pop_response()
+
+        async with self.conversations_lock:
+            conversation_id: str
+            if resp_id in self.response_to_conversation:
+                conversation_id = self.response_to_conversation[resp_id]
+                self.conversations[conversation_id].extend(resp_msgs)
+            elif prev_resp_id is not None:
+                conversation_id = self.response_to_conversation[prev_resp_id]
+                self.conversations[conversation_id].extend(resp_msgs)
+                while len(self.conversations[conversation_id]
+                          ) > self.conversation_capacity:
+                    self._pop_conversation()
+            else:
+                conversation_id = random_uuid()
+                self.conversations[conversation_id] = resp_msgs
+
+            responses_debug_log(
+                f" * storing at conversation id: {conversation_id}")
+
+            self.response_to_conversation[resp_id] = conversation_id
+            self.conversation_to_response[conversation_id] = resp_id
+            self._update_visited_conversation(conversation_id)
+
+    async def store_messages(self, resp_id: str, msgs: list[Message],
+                             prev_resp_id: Optional[str]):
+        responses_debug_log(f"ConversationHistoryStore storing msg:")
+        for msg in msgs:
+            responses_debug_log(f" -> {msg.to_json()}")
+
+        async with self.conversations_lock:
+            conversation_id: str
+            if prev_resp_id is not None:
+                conversation_id = self.response_to_conversation[prev_resp_id]
+            else:
+                conversation_id = random_uuid()
+
+            responses_debug_log(
+                f" * storing at conversation: {conversation_id}")
+            self.conversations[conversation_id] = msgs
+            if len(self.conversations[conversation_id]
+                   ) > self.conversation_capacity:
+                self._pop_conversation()
+
+            self.response_to_conversation[resp_id] = conversation_id
+            self.conversation_to_response[conversation_id] = resp_id
+            self._update_visited_conversation(conversation_id)
+
+    async def append_messages(self, resp_id: str, msgs: list[Message]):
+        responses_debug_log(f"ConversationHistoryStore appending msgs:")
+        for msg in msgs:
+            responses_debug_log(f" -> {msg.to_json()}")
+
+        async with self.conversations_lock:
+            assert resp_id in self.response_to_conversation
+            conversation_id = self.response_to_conversation[resp_id]
+
+            responses_debug_log(
+                f" * appending at conversation: {conversation_id}")
+            self.conversations[conversation_id].extend(msgs)
+            if len(self.conversations[conversation_id]
+                   ) > self.conversation_capacity:
+                self._pop_conversation()
+            self._update_visited_conversation(conversation_id)
+
+    async def get_conversation_history(self, resp_id: str) -> list[Message]:
+        responses_debug_log(f"ConversationHistoryStore getting prev_msgs:")
+        responses_debug_log(f" -> prev_resp_id: {resp_id}")
+        async with self.conversations_lock:
+            if resp_id in self.response_to_conversation:
+                conversation_id = self.response_to_conversation[resp_id]
+                self._update_visited_conversation(conversation_id)
+                return self.conversations.get(conversation_id, [])
+
+            return []
+
+    def _update_visited_conversation(self, conversation_id) -> None:
+        if conversation_id not in self.conversations:
+            return
+
+        self.conversations.move_to_end(conversation_id)
+        if len(self.conversations) > self.max_conversations:
+            removed_id, _ = self.conversations.popitem(last=False)
+            responses_debug_log(
+                f"ConversationHistoryStore Removing conversation {removed_id}")
+            removed_resp_id = self.conversation_to_response[removed_id]
+            # The responses may have been removed due to response capacity
+            if removed_resp_id in self.response_to_conversation:
+                self.response_to_conversation.pop(removed_resp_id)
+            self.conversation_to_response.pop(removed_id)
+
+    def _pop_conversation(self, resp_id) -> None:
+        conversation_id = self.response_to_conversation[resp_id]
+        conversation = self.conversations[conversation_id]
+        first_conversation_range = []
+        for i, msg in enumerate(conversation):
+            if msg.author.role == Role.USER:
+                first_conversation_range.append(i)
+            elif msg.channel == "final":
+                first_conversation_range.append(i)
+                break
+        del conversation[
+            first_conversation_range[0]:first_conversation_range[1] + 1]
+
+    def _pop_response(self) -> None:
+        responses_debug_log(f"responses type: {type(self.responses)}")
+        resp_id, _ = self.responses.popitem(last=False)
+        if resp_id in self.response_to_conversation:
+            self.response_to_conversation.pop(resp_id)
+
+
+def get_system_message(
+    model_identity: Optional[str] = None,
+    reasoning_effort: Optional[Literal["high", "medium", "low"]] = None,
+    start_date: Optional[str] = None,
+    browser_description: Optional[str] = None,
+    python_description: Optional[str] = None,
+) -> Message:
+    sys_msg_content = SystemContent.new()
+    if model_identity is not None:
+        sys_msg_content = sys_msg_content.with_model_identity(model_identity)
+    if reasoning_effort is not None:
+        sys_msg_content = sys_msg_content.with_reasoning_effort(
+            REASONING_EFFORT[reasoning_effort])
+    if start_date:
+        sys_msg_content = sys_msg_content.with_conversation_start_date(
+            start_date)
+    if browser_description is not None:
+        sys_msg_content = sys_msg_content.with_tools(browser_description)
+    if python_description is not None:
+        sys_msg_content = sys_msg_content.with_tools(python_description)
+    sys_msg = Message.from_role_and_content(Role.SYSTEM, sys_msg_content)
+    return sys_msg
+
+
+def get_developer_message(instructions: Optional[str] = None,
+                          tools: Optional[list[Tool]] = None) -> Message:
+    dev_msg_content = DeveloperContent.new()
+    if instructions is not None:
+        dev_msg_content = dev_msg_content.with_instructions(instructions)
+    if tools is not None:
+        function_tools = []
+        for tool in tools:
+            if tool.type in ("web_search_preview", "code_interpreter"):
+                # These are built-in tools that are added to the system message.
+                pass
+            elif tool.type == "function":
+                function_tools.append(tool)
+            else:
+                raise ValueError(f"tool type {tool.type} not supported")
+        if function_tools:
+            function_tool_descriptions = [
+                ToolDescription.new(
+                    name=tool.name,
+                    description=tool.description,
+                    parameters=tool.parameters,
+                ) for tool in function_tools
+            ]
+            dev_msg_content = dev_msg_content.with_function_tools(
+                function_tool_descriptions)
+    dev_msg = Message.from_role_and_content(Role.DEVELOPER, dev_msg_content)
+    return dev_msg
+
+
+def get_user_message(content: str) -> Message:
+    return Message.from_role_and_content(Role.USER, content)
+
+
+def construct_harmony_messages(
+    request: ResponsesRequest,
+    prev_response: Optional[ResponsesResponse],
+    prev_msgs: list[Message] = [],
+) -> list[Message]:
+    """
+        Construct messages from request input, includes conversation history messages if exists.
+        """
+    messages: list[Message] = []
+    if prev_response is None:
+        # New conversation.
+        reasoning_effort = (request.reasoning.effort
+                            if request.reasoning else None)
+        sys_msg = get_system_message(reasoning_effort=reasoning_effort, )
+        messages.append(sys_msg)
+        dev_msg = get_developer_message(request.instructions, request.tools)
+        messages.append(dev_msg)
+    else:
+        messages.extend(prev_msgs)
+    # Append the new input.
+    # Responses API supports simple text inputs without chat format.
+    if isinstance(request.input, str):
+        messages.append(get_user_message(request.input))
+    else:
+        if prev_response is not None:
+            prev_outputs = copy(prev_response.output)
+        else:
+            prev_outputs = []
+        for input_msg in request.input:
+            msg = parse_response_input(input_msg, prev_outputs)
+            if msg is not None:
+                messages.append(msg)
+            # User passes in a a tool call request and its output. We need
+            # to add the tool call request to prev_outputs so that the
+            # parse_response_input can find the tool call request when
+            # parsing the tool call output.
+            if isinstance(input_msg, ResponseFunctionToolCall):
+                prev_outputs.append(input_msg)
+    return messages
+
+
+def render_for_completion(messages: list[Message]) -> list[int]:
+    conversation = Conversation.from_messages(messages)
+    responses_debug_log("Rendering conversation:")
+    responses_debug_log(conversation.to_json())
+    token_ids = get_encoding().render_conversation_for_completion(
+        conversation, Role.ASSISTANT)
+    return token_ids
+
+
+def parse_output_tokens(tokens: list[int]) -> list[Message]:
+    return get_encoding().parse_messages_from_completion_tokens(
+        tokens, role=Role.ASSISTANT)
+
+
+def parse_output_message(message: Message) -> list[ResponseOutputItem]:
+    """
+    Parse a Harmony message into a list of output response items.
+    """
+    if message.author.role != "assistant":
+        # This is a message from a tool to the assistant (e.g., search result).
+        # Don't include it in the final output for now. This aligns with
+        # OpenAI's behavior on models like o4-mini.
+        return []
+
+    output_items: list[ResponseOutputItem] = []
+    recipient = message.recipient
+    if recipient is not None and recipient.startswith("browser."):
+        if len(message.content) != 1:
+            raise ValueError("Invalid number of contents in browser message")
+        content = message.content[0]
+        browser_call = json.loads(content.text)
+        # TODO: translate to url properly!
+        if recipient == "browser.search":
+            action = ActionSearch(
+                query=f"cursor:{browser_call.get('query', '')}", type="search")
+        elif recipient == "browser.open":
+            action = ActionOpenPage(url=f"cursor:{browser_call.get('url', '')}",
+                                    type="open_page")
+        elif recipient == "browser.find":
+            action = ActionFind(pattern=browser_call["pattern"],
+                                url=f"cursor:{browser_call.get('url', '')}",
+                                type="find")
+        else:
+            raise ValueError(f"Unknown browser action: {recipient}")
+        web_search_item = ResponseFunctionWebSearch(
+            id=f"ws_{random_uuid()}",
+            action=action,
+            status="completed",
+            type="web_search_call",
+        )
+        output_items.append(web_search_item)
+    elif message.channel == "analysis":
+        for content in message.content:
+            reasoning_item = ResponseReasoningItem(
+                id=f"rs_{random_uuid()}",
+                summary=[],
+                type="reasoning",
+                content=[Content(text=content.text, type="reasoning_text")],
+                status=None,
+            )
+            output_items.append(reasoning_item)
+    elif message.channel == "commentary":
+        if message.recipient is None:
+            pass
+        elif message.recipient.startswith("functions."):
+            function_name = message.recipient.split(".")[-1]
+            for content in message.content:
+                random_id = random_uuid()
+                response_item = ResponseFunctionToolCall(
+                    arguments=content.text,
+                    call_id=f"call_{random_id}",
+                    type="function_call",
+                    name=function_name,
+                    id=f"fc_{random_id}",
+                )
+                output_items.append(response_item)
+        elif message.recipient.startswith(
+                "python") or message.recipient.startswith("browser"):
+            for content in message.content:
+                reasoning_item = ResponseReasoningItem(
+                    id=f"rs_{random_uuid()}",
+                    summary=[],
+                    type="reasoning",
+                    content=[Content(text=content.text, type="reasoning_text")],
+                    status=None,
+                )
+                output_items.append(reasoning_item)
+        else:
+            raise ValueError(f"Unknown recipient: {message.recipient}")
+    elif message.channel == "final":
+        contents = []
+        for content in message.content:
+            output_text = ResponseOutputText(
+                text=content.text,
+                annotations=[],  # TODO
+                type="output_text",
+                logprobs=None,  # TODO
+            )
+            contents.append(output_text)
+        text_item = ResponseOutputMessage(
+            id=f"msg_{random_uuid()}",
+            content=contents,
+            role=message.author.role,
+            status="completed",
+            type="message",
+        )
+        output_items.append(text_item)
+    else:
+        raise ValueError(f"Unknown channel: {message.channel}")
+    return output_items
+
+
+def finish_reason_mapping(finish_reason: str) -> str:
+    match finish_reason:
+        case 'stop':
+            return 'completed'
+        case 'length':
+            return 'incomplete'
+        case 'timeout':
+            return 'failed'
+        case 'cancelled':
+            return 'cancelled'
+
+    raise RuntimeError("Should never reach here!")
+
+
+async def request_preprocess(request: ResponsesRequest,
+                             prev_response: Optional[ResponsesResponse],
+                             harmony_adapter: HarmonyAdapter,
+                             conversation_store: ConversationHistoryStore,
+                             enable_store=False):
+    # TODO: fix default_max_tokens
+    sampling_params = request.to_sampling_params(
+        default_max_tokens=int(16384),
+        default_sampling_params={
+            "stop_token_ids": harmony_adapter.get_stop_tokens()
+        })
+
+    prev_response_id = request.previous_response_id
+
+    # TODO: better way to enable metrics
+    if len(os.getenv("TRTLLM_KVCACHE_TIME_OUTPUT_PATH", "")) > 0:
+        sampling_params.return_perf_metrics = True
+
+    prev_msgs = []
+    if enable_store:
+        prev_msgs = await conversation_store.get_conversation_history(
+            prev_response_id)
+
+        responses_debug_log(f"Prev msgs:")
+        for msg in prev_msgs:
+            responses_debug_log(f" -> {msg.to_json()}")
+
+    messages = construct_harmony_messages(request,
+                                          prev_response,
+                                          prev_msgs=prev_msgs)
+
+    if enable_store and request.store:
+        # Remove reasoning messages to save token usage during multi-turn conversation
+        msgs_to_store = [msg for msg in messages if msg.channel != "analysis"]
+        await conversation_store.store_messages(request.request_id,
+                                                msgs_to_store, prev_response_id)
+
+    input_tokens = render_for_completion(messages)
+
+    responses_debug_log("======= Complete Inputs to model =======")
+    responses_debug_log(decode_tokens(input_tokens))
+    responses_debug_log("========================================")
+    return input_tokens, sampling_params
+
+
+async def create_response(
+    generator,
+    request: ResponsesRequest,
+    sampling_params,
+    model_name: str,
+    conversation_store: ConversationHistoryStore,
+    generation_result: RequestOutput = None,
+    enable_store=False,
+    create_time: int = None,
+) -> ResponsesResponse:
+
+    final_res: Optional[RequestOutput] = None
+    response_creation_time = create_time if create_time is not None else int(
+        time.time())
+    prev_response_id = request.previous_response_id
+
+    if generation_result is not None:
+        final_res = generation_result
+    else:
+        final_res = await generator
+
+    if final_res is None:
+        raise RuntimeError("No output generated or provided")
+
+    responses_debug_log("================================================")
+    responses_debug_log("RAW MODEL OUTPUT:")
+    responses_debug_log(final_res.outputs)
+    responses_debug_log("================================================")
+
+    output_messages = parse_output_tokens(final_res.outputs[0].token_ids)
+
+    responses_debug_log(f"output messages: {len(output_messages)}")
+    for msg in output_messages:
+        responses_debug_log(f" -> {msg.to_json()}")
+
+    # prepare responses output
+    output_content = []
+    for msg in output_messages:
+        output_content.extend(parse_output_message(msg))
+
+    response = ResponsesResponse.from_request(
+        request=request,
+        sampling_params=sampling_params,
+        model_name=model_name,
+        created_time=response_creation_time,
+        output=output_content,
+        status=finish_reason_mapping(final_res.outputs[0].finish_reason),
+    )
+
+    if enable_store and request.store:
+        await conversation_store.store_response(resp=response,
+                                                resp_msgs=output_messages,
+                                                prev_resp_id=prev_response_id)
+
+    responses_debug_log("========== Response ===========")
+    responses_debug_log(response)
+    responses_debug_log("===============================")
+    return response
+
+
+async def process_streaming_events(
+        request: ResponsesRequest,
+        sampling_params: SamplingParams,
+        generator,
+        harmony_adapter: HarmonyAdapter,
+        model_name: str,
+        conversation_store: ConversationHistoryStore,
+        create_time: int = None,
+        enable_store=False) -> AsyncGenerator[str, None]:
+    sequence_number = 0
+    response_creation_time = create_time if create_time is not None else int(
+        time.time())
+    final_res: Optional[RequestOutput] = None
+
+    def _send_event(event: OpenAIBaseModel):
+        nonlocal sequence_number
+        # Set sequence_number if the event has this attribute
+        if hasattr(event, 'sequence_number'):
+            event.sequence_number = sequence_number
+        sequence_number += 1
+        # Get event type from the event's type field if it exists
+        event_type = getattr(event, 'type', 'unknown')
+        return (f"event: {event_type}\n"
+                f"data: {event.model_dump_json(indent=None)}\n\n")
+
+    current_content_index = 0  # FIXME: this number is never changed
+    current_output_index = 0
+    current_item_id = ""  # FIXME: this number is never changed
+    sent_output_item_added = False
+
+    initial_response = ResponsesResponse.from_request(
+        request,
+        sampling_params,
+        model_name=model_name,
+        created_time=response_creation_time,
+        output=[],
+        status="in_progress",
+        usage=None,
+    ).model_dump()
+    yield _send_event(
+        ResponseCreatedEvent(
+            type="response.created",
+            sequence_number=-1,
+            response=initial_response,
+        ))
+    yield _send_event(
+        ResponseInProgressEvent(
+            type="response.in_progress",
+            sequence_number=-1,
+            response=initial_response,
+        ))
+
+    tools = [tool.model_dump() for tool in request.tools]
+    stream_request_id = f"reponses-api-{request.request_id}"
+    async for res in generator:
+        final_res = res
+        output = res.outputs[0]
+
+        messages = harmony_adapter.stateful_stream_harmony_tokens_to_openai_messages(
+            stream_request_id, output.token_ids_diff, tools,
+            request.tool_choice)
+        stream_state = harmony_adapter.get_stream_state(stream_request_id)
+        assert stream_state is not None
+        parser = stream_state.get_parser()
+
+        if parser.state == StreamState.EXPECT_START:
+            current_output_index += 1
+            sent_output_item_added = False
+
+            if len(messages) > 0:
+                previous_item = messages[-1]
+                if previous_item.recipient is not None:
+                    # Deal with tool call here
+                    pass
+                elif previous_item.channel == "analysis":
+                    reasoning_item = ResponseReasoningItem(
+                        type="reasoning",
+                        content=[
+                            Content(
+                                text=previous_item.content[0].text,
+                                type="reasoning_text",
+                            ),
+                        ],
+                        status="completed",
+                        id=current_item_id,
+                        summary=[],
+                    )
+                    yield _send_event(
+                        ResponseReasoningTextDoneEvent(
+                            type="response.reasoning_text.done",
+                            item_id=current_item_id,
+                            sequence_number=-1,
+                            output_index=current_output_index,
+                            content_index=current_content_index,
+                            text=previous_item.content[0].text,
+                        ))
+                    yield _send_event(
+                        ResponseOutputItemDoneEvent(
+                            type="response.output_item.done",
+                            sequence_number=-1,
+                            output_index=current_output_index,
+                            item=reasoning_item,
+                        ))
+                elif previous_item.channel == "final":
+                    text_content = ResponseOutputText(
+                        type="output_text",
+                        text=previous_item.content[0].text,
+                        annotations=[],
+                    )
+                    yield _send_event(
+                        ResponseTextDoneEvent(
+                            type="response.output_text.done",
+                            sequence_number=-1,
+                            output_index=current_output_index,
+                            content_index=current_content_index,
+                            text=previous_item.content[0].text,
+                            logprobs=[],
+                            item_id=current_item_id,
+                        ))
+                    yield _send_event(
+                        ResponseContentPartDoneEvent(
+                            type="response.content_part.done",
+                            sequence_number=-1,
+                            item_id=current_item_id,
+                            output_index=current_output_index,
+                            content_index=current_content_index,
+                            part=text_content,
+                        ))
+                    yield _send_event(
+                        ResponseOutputItemDoneEvent(
+                            type="response.output_item.done",
+                            sequence_number=-1,
+                            output_index=current_output_index,
+                            item=ResponseOutputMessage(
+                                id=current_item_id,
+                                type="message",
+                                role="assistant",
+                                content=[text_content],
+                                status="completed",
+                            ),
+                        ))
+
+        if parser.last_content_delta:
+            if (parser.current_channel == "final"
+                    and parser.current_recipient is None):
+                if not sent_output_item_added:
+                    sent_output_item_added = True
+                    yield _send_event(
+                        ResponseOutputItemAddedEvent(
+                            type="response.output_item.added",
+                            sequence_number=-1,
+                            output_index=current_output_index,
+                            item=ResponseOutputMessage(
+                                id=current_item_id,
+                                type="message",
+                                role="assistant",
+                                content=[],
+                                status="in_progress",
+                            ),
+                        ))
+                    yield _send_event(
+                        ResponseContentPartAddedEvent(
+                            type="response.content_part.added",
+                            sequence_number=-1,
+                            output_index=current_output_index,
+                            item_id=current_item_id,
+                            content_index=current_content_index,
+                            part=ResponseOutputText(
+                                type="output_text",
+                                text="",
+                                annotations=[],
+                                logprobs=[],
+                            ),
+                        ))
+                yield _send_event(
+                    ResponseTextDeltaEvent(
+                        type="response.output_text.delta",
+                        sequence_number=-1,
+                        content_index=current_content_index,
+                        output_index=current_output_index,
+                        item_id=current_item_id,
+                        delta=parser.last_content_delta,
+                        # TODO, use logprobs from ctx.last_request_output
+                        logprobs=[],
+                    ))
+            elif (parser.current_channel == "analysis"
+                  and parser.current_recipient is None):
+                if not sent_output_item_added:
+                    sent_output_item_added = True
+                    yield _send_event(
+                        ResponseOutputItemAddedEvent(
+                            type="response.output_item.added",
+                            sequence_number=-1,
+                            output_index=current_output_index,
+                            item=ResponseReasoningItem(
+                                type="reasoning",
+                                id=current_item_id,
+                                summary=[],
+                                status="in_progress",
+                            ),
+                        ))
+                    yield _send_event(
+                        ResponseContentPartAddedEvent(
+                            type="response.content_part.added",
+                            sequence_number=-1,
+                            output_index=current_output_index,
+                            item_id=current_item_id,
+                            content_index=current_content_index,
+                            part=ResponseOutputText(
+                                type="output_text",
+                                text="",
+                                annotations=[],
+                                logprobs=[],
+                            ),
+                        ))
+                yield _send_event(
+                    ResponseReasoningTextDeltaEvent(
+                        type="response.reasoning_text.delta",
+                        item_id=current_item_id,
+                        output_index=current_output_index,
+                        content_index=current_content_index,
+                        delta=parser.last_content_delta,
+                        sequence_number=-1,
+                    ))
+
+        # TODO(JunyiXu-nv): support built-in tools(python/browser/code interpreter)
+
+    final_response = await create_response(generator, request, sampling_params,
+                                           model_name, conversation_store,
+                                           final_res, enable_store,
+                                           response_creation_time)
+
+    yield _send_event(
+        ResponseCompletedEvent(
+            type="response.completed",
+            sequence_number=-1,
+            response=final_response.model_dump(),
+        ))

--- a/tests/integration/defs/test_e2e.py
+++ b/tests/integration/defs/test_e2e.py
@@ -1618,6 +1618,13 @@ def test_openai_chat_harmony(llm_root, llm_venv):
          str(test_root / "_test_openai_chat_harmony.py")])
 
 
+def test_openai_responses(llm_root, llm_venv):
+    test_root = unittest_path() / "llmapi" / "apps"
+    llm_venv.run_cmd(
+        ["-m", "pytest",
+         str(test_root / "_test_openai_responses.py")])
+
+
 def test_openai_prometheus(llm_root, llm_venv):
     test_root = unittest_path() / "llmapi" / "apps"
     llm_venv.run_cmd(

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -104,6 +104,7 @@ l0_h100:
   - test_e2e.py::test_trtllm_bench_request_rate_and_concurrency[enable_concurrency-enable_request_rate] # negative test
   - test_e2e.py::test_trtllm_bench_help_sanity[meta-llama/Llama-3.1-8B]
   - test_e2e.py::test_openai_chat_harmony
+  - test_e2e.py::test_openai_responses
   - test_e2e.py::test_ptp_quickstart_multimodal[gemma-3-27b-it-gemma/gemma-3-27b-it-image-True]
   # ------------- AutoDeploy tests ---------------
   - accuracy/test_llm_api_autodeploy.py::TestLlama3_1_8B::test_auto_dtype

--- a/tests/unittest/llmapi/apps/_test_openai_responses.py
+++ b/tests/unittest/llmapi/apps/_test_openai_responses.py
@@ -1,0 +1,241 @@
+import json
+
+import openai
+import pytest
+from openai.types.responses import (ResponseCompletedEvent,
+                                    ResponseReasoningTextDeltaEvent,
+                                    ResponseTextDeltaEvent)
+
+from ..test_llm import get_model_path
+from .openai_server import RemoteOpenAIServer
+
+pytestmark = pytest.mark.threadleak(enabled=False)
+
+
+@pytest.fixture(scope="module", ids=["GPT-OSS-20B"])
+def model():
+    return "gpt_oss/gpt-oss-20b/"
+
+
+@pytest.fixture(scope="module")
+def server(model: str):
+    model_path = get_model_path(model)
+    with RemoteOpenAIServer(model_path) as remote_server:
+        yield remote_server
+
+
+@pytest.fixture(scope="module")
+def client(server: RemoteOpenAIServer):
+    return server.get_async_client()
+
+
+def check_reponse(response, prefix=""):
+    reasoning_exist, message_exist = False, False
+    for output in response.output:
+        if output.type == "reasoning":
+            reasoning_exist = True
+        elif output.type == "message":
+            message_exist = True
+
+    assert reasoning_exist, f"{prefix}Reasoning content not exists!"
+    assert message_exist, f"{prefix}Message content not exists!"
+
+
+def check_tool_calling(response, first_resp=True, prefix=""):
+    reasoning_exist, tool_call_exist, message_exist = False, False, False
+    function_call = None
+    for output in response.output:
+        if output.type == "reasoning":
+            reasoning_exist = True
+        elif output.type == "function_call":
+            tool_call_exist = True
+            function_call = output
+        elif output.type == "message":
+            message_exist = True
+
+    if first_resp:
+        assert reasoning_exist and tool_call_exist, f"{prefix}Invalid tool calling 1st response"
+        assert not message_exist, f"{prefix}Invalid tool calling 1st response"
+
+        return function_call
+    else:
+        assert reasoning_exist and message_exist, f"{prefix}Invalid tool calling 2nd response"
+        assert not tool_call_exist, f"{prefix}Invalid tool calling 2nd response"
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_reasoning(client: openai.AsyncOpenAI, model: str):
+    response = await client.responses.create(
+        model=model, input="Which one is larger as numeric, 9.9 or 9.11?")
+
+    check_reponse(response, "test_reasoning: ")
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_reasoning_effort(client: openai.AsyncOpenAI, model: str):
+    for effort in ["low", "medium", "high"]:
+        response = await client.responses.create(
+            model=model,
+            instructions="Use less than 1024 tokens for reasoning",
+            input="Which one is larger as numeric, 9.9 or 9.11?",
+            reasoning={"effort": effort})
+        check_reponse(response, f"test_reasoning_effort_{effort}: ")
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_chat(client: openai.AsyncOpenAI, model: str):
+    response = await client.responses.create(model=model,
+                                             input=[{
+                                                 "role":
+                                                 "developer",
+                                                 "content":
+                                                 "Respond in Chinese."
+                                             }, {
+                                                 "role": "user",
+                                                 "content": "Hello!"
+                                             }, {
+                                                 "role":
+                                                 "assistant",
+                                                 "content":
+                                                 "Hello! How can I help you?"
+                                             }, {
+                                                 "role": "user",
+                                                 "content": "Tell me a joke."
+                                             }])
+    check_reponse(response, "test_chat: ")
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_multi_turn_chat(client: openai.AsyncOpenAI, model: str):
+    response = await client.responses.create(model=model,
+                                             input="What is the answer of 1+1?")
+    check_reponse(response, "test_multi_turn_chat_1: ")
+
+    response_2 = await client.responses.create(
+        model=model,
+        input="What is the answer of previous question?",
+        previous_response_id=response.id)
+    check_reponse(response_2, "test_multi_turn_chat_2: ")
+
+
+def get_current_weather(location: str, format: str = "celsius") -> dict:
+    return {"sunny": True, "temperature": 20 if format == "celsius" else 68}
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_tool_calls(client: openai.AsyncOpenAI, model: str):
+    tool_get_current_weather = {
+        "type": "function",
+        "name": "get_current_weather",
+        "description": "Gets the current weather in the provided location.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "description": "The city and state, e.g. San Francisco, CA",
+                },
+                "format": {
+                    "type": "string",
+                    "description": "default: celsius",
+                    "enum": ["celsius", "fahrenheit"],
+                },
+            },
+            "required": ["location"],
+        }
+    }
+    messages = [{"role": "user", "content": "What is the weather like in SF?"}]
+    response = await client.responses.create(
+        model=model,
+        input=messages,
+        tools=[tool_get_current_weather],
+    )
+    messages.extend(response.output)
+    function_call = check_tool_calling(response, True, "test_tool_calls: ")
+
+    assert function_call.name == "get_current_weather"
+
+    args = json.loads(function_call.arguments)
+    answer = get_current_weather(**args)
+    messages.append({
+        "type": "function_call_output",
+        "call_id": function_call.call_id,
+        "output": json.dumps(answer),
+    })
+
+    response = await client.responses.create(model=model,
+                                             input=messages,
+                                             tools=[tool_get_current_weather])
+
+    check_tool_calling(response, False, "test_tool_calls: ")
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_streaming(client: openai.AsyncOpenAI, model: str):
+    stream = await client.responses.create(
+        model=model,
+        input="Explain the theory of relativity in brief.",
+        stream=True,
+    )
+
+    reasoning_deltas, message_deltas = list(), list()
+    async for event in stream:
+        if isinstance(event, ResponseTextDeltaEvent):
+            message_deltas.append(event.delta)
+        elif isinstance(event, ResponseReasoningTextDeltaEvent):
+            reasoning_deltas.append(event.delta)
+
+    full_response = "".join(message_deltas)
+    full_reasoning_response = "".join(reasoning_deltas)
+    assert full_response
+    assert full_reasoning_response
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_streaming_tool_call(client: openai.AsyncOpenAI, model: str):
+    tool_get_current_weather = {
+        "type": "function",
+        "name": "get_current_weather",
+        "description": "Gets the current weather in the provided location.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "description": "The city and state, e.g. San Francisco, CA",
+                },
+                "format": {
+                    "type": "string",
+                    "description": "default: celsius",
+                    "enum": ["celsius", "fahrenheit"],
+                },
+            },
+            "required": ["location"],
+        }
+    }
+    messages = [{"role": "user", "content": "What is the weather like in SF?"}]
+    stream = await client.responses.create(
+        model=model,
+        input=messages,
+        tools=[tool_get_current_weather],
+        stream=True,
+    )
+
+    function_call = None
+    reasoning_deltas = list()
+    async for event in stream:
+        if isinstance(event, ResponseCompletedEvent):
+            for output in event.response.output:
+                if output.type == "function_call":
+                    function_call = output
+        elif isinstance(event, ResponseReasoningTextDeltaEvent):
+            reasoning_deltas.append(event.delta)
+
+    reasoning = "".join(reasoning_deltas)
+    tool_args = json.loads(function_call.arguments)
+
+    assert function_call.name == "get_current_weather", "wrong function calling name"
+    assert tool_args, "tool args not exists!"
+    assert reasoning, "reasoning not exists!"
+
+    get_current_weather(**tool_args)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - OpenAI-compatible Responses API at /v1/responses with streaming (SSE) and non‑streaming modes.
  - Stateful per-request streaming that emits complete OpenAI-style messages across calls and handles channel/tool transitions.
  - Enhanced tool handling: nested tool names supported and "none" option to disable tools.
  - Optional persistent conversation storage with retrieval by response ID; expanded request/response models and per-token usage details.

- **Tests**
  - New unit and integration tests covering reasoning, multi‑turn chat, tool-calling, and streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

New Features
- Add basic Responses API implementations, including stateful multi-turn chat, function calling, reasoning effort setting, streaming reasoning and message response.

Tests
- Added unit and e2e tests covering chat, multi-turn chat, reasoning, streaming, and tool calls.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
