### PR TITLE
draft: enable LM tp for MTP, under attention dp case

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_speculative.py
+++ b/tensorrt_llm/_torch/models/modeling_speculative.py
@@ -433,6 +433,11 @@ class SpecDecOneEngineForCausalLM(DecoderModelForCausalLM[TModel, TConfig],
                 attn_metadata,
                 True,
             )
+            # print(f"lm_head.weight.data_ptr: {self.lm_head.weight.data_ptr()}")
+            # print(f"lm_head.weight.shape: {self.lm_head.weight.shape}")
+            print(f"In SpecDecOneEngineForCausalLM, before spec_worker, logits.shape: {logits.shape}")
+            # print(f"draft_model.lm_head.weight.data_ptr: {self.draft_model.lm_head.weight.data_ptr()}")
+            # print(f"draft_model.lm_head.weight.shape: {self.draft_model.lm_head.weight.shape}")
             # get accepted tokens and next draft tokens
             return self.spec_worker(input_ids=input_ids,
                                     position_ids=position_ids,

--- a/tensorrt_llm/_torch/modules/embedding.py
+++ b/tensorrt_llm/_torch/modules/embedding.py
@@ -37,8 +37,8 @@ class LMHead(Linear):
         mapping = mapping or Mapping()
         tp_size = mapping.tp_size
 
-        # Attention DP doesn't work with embedding parallelization.
-        if mapping.enable_attention_dp:
+        # Attention DP doesn't work with embedding parallelization, unless enable_lm_tp_in_adp is set.
+        if mapping.enable_attention_dp and not getattr(mapping, 'enable_lm_tp_in_adp', False):
             tensor_parallel_mode = None
 
         if tensor_parallel_mode == TensorParallelMode.ROW:
@@ -69,6 +69,9 @@ class LMHead(Linear):
         self.embedding_dim = embedding_dim
 
         weight_shape = (self.out_features, self.in_features)
+        print('*' * 50)
+        print(f"enable_attention_dp: {mapping.enable_attention_dp}, enable_lm_tp_in_adp: {getattr(mapping, 'enable_lm_tp_in_adp', False)}")
+        print(f"In LMHead, weight_shape: {weight_shape}")
         self.weight = Parameter(torch.empty(weight_shape, dtype=dtype))
         self.register_parameter("bias", None)
 

--- a/tensorrt_llm/_torch/modules/logits_processor.py
+++ b/tensorrt_llm/_torch/modules/logits_processor.py
@@ -1,8 +1,9 @@
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 
-from ..model_config import ModelConfig
 from ..attention_backend import AttentionMetadata
+from ..model_config import ModelConfig
 from .linear import Linear
 
 
@@ -29,20 +30,36 @@ class LogitsProcessor(nn.Module):
             else:
                 hidden_states = hidden_states[-1]
 
+        token_count = hidden_states.view(-1, hidden_states.shape[-1]).shape[0]
+
         # Add pre-lm gather logic
-        if (self.model_config.mapping.enable_attention_dp and 
-            getattr(self.model_config.mapping, 'enable_lm_tp_in_adp', False)):
+        if (self.model_config.mapping.enable_attention_dp and getattr(
+                self.model_config.mapping, 'enable_lm_tp_in_adp', False)):
             # ADP + LM TP mode: perform All-Gather before LM_head
             from ..distributed import allgather
-            hidden_states = allgather(hidden_states, self.model_config.mapping, dim=0)
+            all_rank_max_num_tokens = attn_metadata.all_rank_max_num_tokens
+            pad_len = all_rank_max_num_tokens - token_count
+            if pad_len > 0:
+                padded_hidden_states = F.pad(hidden_states.view(
+                    -1, hidden_states.shape[-1]), (0, 0, 0, pad_len),
+                                             mode="constant",
+                                             value=0)
+            else:
+                padded_hidden_states = hidden_states.view(
+                    -1, hidden_states.shape[-1])
+            hidden_states = allgather(padded_hidden_states,
+                                      self.model_config.mapping,
+                                      dim=0)
 
         # Temporarily disable gather_output when not in ADP mode or (in ADP mode and LM TP is enabled)
-        if (not self.model_config.mapping.enable_attention_dp) or (self.model_config.mapping.enable_attention_dp and
-                getattr(self.model_config.mapping, 'enable_lm_tp_in_adp', False)):
+        if (not self.model_config.mapping.enable_attention_dp) or (
+                self.model_config.mapping.enable_attention_dp and getattr(
+                    self.model_config.mapping, 'enable_lm_tp_in_adp', False)):
             lm_head.gather_output = False
         logits = lm_head(hidden_states)
-        if (not self.model_config.mapping.enable_attention_dp) or (self.model_config.mapping.enable_attention_dp and
-                getattr(self.model_config.mapping, 'enable_lm_tp_in_adp', False)):
+        if (not self.model_config.mapping.enable_attention_dp) or (
+                self.model_config.mapping.enable_attention_dp and getattr(
+                    self.model_config.mapping, 'enable_lm_tp_in_adp', False)):
             lm_head.gather_output = True
         # print(f"In LogitsProcessor, lm_head.weight.data_ptr: {lm_head.weight.data_ptr()}")
         # print(f"In LogitsProcessor, lm_head.weight.shape: {lm_head.weight.shape}")
@@ -50,8 +67,9 @@ class LogitsProcessor(nn.Module):
         logits = allgather(logits, self.model_config.mapping, dim=-1)
         batch_size = logits.shape[0]
         local_batch_size = batch_size // self.model_config.mapping.tp_size
-        logits = logits.view(self.model_config.mapping.tp_size, local_batch_size, -1)
-        logits = logits[self.model_config.mapping.tp_rank]
+        logits = logits.view(self.model_config.mapping.tp_size,
+                             local_batch_size, -1)
+        logits = logits[self.model_config.mapping.tp_rank][:token_count]
         print(f"In LogitsProcessor, final logits.shape: {logits.shape}")
         logits = logits.float()
         return logits

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -225,6 +225,7 @@ class _ParallelConfig:
     moe_ep_size: int = 1
     cp_config: dict = field(default_factory=dict)
     enable_attention_dp: bool = False
+    enable_lm_tp_in_adp: bool = False
     auto_parallel: bool = False
 
     _world_size: int = field(default=1, init=False)
@@ -288,6 +289,7 @@ class _ParallelConfig:
                        cp_size=self.cp_size,
                        cp_config=self.cp_config,
                        enable_attention_dp=self.enable_attention_dp,
+                       enable_lm_tp_in_adp=self.enable_lm_tp_in_adp,
                        moe_cluster_size=self.moe_cluster_size,
                        moe_tp_size=self.moe_tp_size,
                        moe_ep_size=self.moe_ep_size,
@@ -1246,6 +1248,11 @@ class BaseLlmArgs(StrictBaseModel):
         description="Enable attention data parallel.",
         status="beta")
 
+    enable_lm_tp_in_adp: bool = Field(
+        default=False,
+        description="Enable lm tp in attention dp.",
+        status="beta")
+
     cp_config: Optional[dict] = Field(default_factory=dict,
                                       description="Context parallel config.",
                                       status="prototype")
@@ -1493,6 +1500,7 @@ class BaseLlmArgs(StrictBaseModel):
             moe_tp_size=self.moe_tensor_parallel_size,
             moe_ep_size=self.moe_expert_parallel_size,
             enable_attention_dp=self.enable_attention_dp,
+            enable_lm_tp_in_adp=self.enable_lm_tp_in_adp,
             cp_config=self.cp_config)
         return self
 

--- a/tensorrt_llm/mapping.py
+++ b/tensorrt_llm/mapping.py
@@ -141,7 +141,8 @@ class Mapping(object):
             attn_tp_size=-1,
             attn_cp_size=-1,
             auto_parallel=False,
-            enable_attention_dp=False):
+            enable_attention_dp=False,
+            enable_lm_tp_in_adp=False):
         # set default values for non-moe cases
         # or where only one MOE parallelism size is specified
         if moe_cluster_size == -1:
@@ -224,6 +225,7 @@ class Mapping(object):
         self.auto_parallel = auto_parallel
         self.world_size = world_size
         self.enable_attention_dp = enable_attention_dp
+        self.enable_lm_tp_in_adp = enable_lm_tp_in_adp
         self.rank = rank
         self.gpus_per_node = gpus_per_node
         self.pp_groups = []


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added optional setting to enable LM tensor-parallelism within Attention Data Parallel, improving scalability on multi-GPU setups.
  - Enhanced distributed generation: pre-LM gather and cross-rank logits handling for more consistent outputs under ADP + LM TP.
  - Speculative decoding updated to support ADP + LM TP paths for draft token selection.

- Chores
  - Introduced additional runtime logs (shapes, ranks, paths) to aid debugging.

- Public API
  - New user-facing argument to toggle LM TP in ADP is available in configuration and mapped through engine setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
