### PR TITLE
[None][feat] Support DeepGEMM swap-AB on sm100

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,4 +28,5 @@
 	url = https://github.com/zeromq/cppzmq.git
 [submodule "3rdparty/DeepGEMM"]
 	path = 3rdparty/DeepGEMM
-	url = https://github.com/deepseek-ai/DeepGEMM.git
+	url = https://github.com/ruoqianguo/DeepGEMM.git
+	branch = dev/ruoqiang/swapab_sm100


### PR DESCRIPTION
This PR enables swap AB as an optional tactic for sm100 FP8 blockwise GEMM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enabled an additional tactic for FP8 GEMM that can automatically swap A/B operands when beneficial, expanding kernel choices for potential performance gains on supported GPUs. No API changes required.

- Chores
  - Updated the DeepGEMM submodule to a new repository and branch to align with recent optimizations and ensure compatibility with the expanded FP8 GEMM tactics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->