### PR TITLE
[TRTLLM-7410][feat] Support hashing and KV cache reuse for videos

### DIFF
--- a/examples/llm-api/quickstart_multimodal.py
+++ b/examples/llm-api/quickstart_multimodal.py
@@ -154,7 +154,7 @@ def parse_arguments():
     parser = add_lora_args(parser)
     args = parser.parse_args()
 
-    args.disable_kv_cache_reuse = True  # kv cache reuse does not work for multimodal, force overwrite
+    args.disable_kv_cache_reuse = False  # kv cache reuse does not work for multimodal, force overwrite
     if args.kv_cache_fraction is None:
         args.kv_cache_fraction = 0.6  # lower the default kv cache fraction for multimodal
 
@@ -185,6 +185,19 @@ def main():
         lora_config.max_cpu_loras = 2
 
     llm, sampling_params = setup_llm(args, lora_config=lora_config)
+
+#    from tensorrt_llm import MultimodalEncoder, SamplingParams
+#    sampling_params = SamplingParams(max_tokens=args.max_tokens)
+#    llm = MultimodalEncoder(
+#        model=args.model_dir,
+#        backend='pytorch',
+#        disable_overlap_scheduler=args.disable_overlap_scheduler,
+#        max_seq_len=args.max_seq_len,
+#        max_batch_size=args.max_batch_size,
+#        max_num_tokens=args.max_num_tokens,
+#        trust_remote_code=args.trust_remote_code,
+#        )
+
 
     image_format = args.image_format
     if args.model_type is not None:
@@ -280,8 +293,8 @@ def main():
                                              model_dir=str(llm._hf_model_dir),
                                              model_type=model_type,
                                              modality=args.modality,
-                                             prompts=args.prompt,
-                                             media=args.media,
+                                             prompts=[args.prompt[0], args.prompt[0]],
+                                             media=[args.media[0], args.media[0]],
                                              image_data_format=image_format,
                                              num_frames=args.num_frames,
                                              device=args.device)
@@ -294,7 +307,6 @@ def main():
     outputs = llm.generate(
         inputs,
         sampling_params,
-        lora_request=lora_request,
     )
 
     for i, output in enumerate(outputs):

--- a/examples/llm-api/quickstart_multimodal.py
+++ b/examples/llm-api/quickstart_multimodal.py
@@ -154,7 +154,7 @@ def parse_arguments():
     parser = add_lora_args(parser)
     args = parser.parse_args()
 
-    args.disable_kv_cache_reuse = False  # kv cache reuse does not work for multimodal, force overwrite
+    args.disable_kv_cache_reuse = True  # kv cache reuse does not work for multimodal, force overwrite
     if args.kv_cache_fraction is None:
         args.kv_cache_fraction = 0.6  # lower the default kv cache fraction for multimodal
 
@@ -185,19 +185,6 @@ def main():
         lora_config.max_cpu_loras = 2
 
     llm, sampling_params = setup_llm(args, lora_config=lora_config)
-
-#    from tensorrt_llm import MultimodalEncoder, SamplingParams
-#    sampling_params = SamplingParams(max_tokens=args.max_tokens)
-#    llm = MultimodalEncoder(
-#        model=args.model_dir,
-#        backend='pytorch',
-#        disable_overlap_scheduler=args.disable_overlap_scheduler,
-#        max_seq_len=args.max_seq_len,
-#        max_batch_size=args.max_batch_size,
-#        max_num_tokens=args.max_num_tokens,
-#        trust_remote_code=args.trust_remote_code,
-#        )
-
 
     image_format = args.image_format
     if args.model_type is not None:
@@ -293,8 +280,8 @@ def main():
                                              model_dir=str(llm._hf_model_dir),
                                              model_type=model_type,
                                              modality=args.modality,
-                                             prompts=[args.prompt[0], args.prompt[0]],
-                                             media=[args.media[0], args.media[0]],
+                                             prompts=args.prompt,
+                                             media=args.media,
                                              image_data_format=image_format,
                                              num_frames=args.num_frames,
                                              device=args.device)
@@ -307,6 +294,7 @@ def main():
     outputs = llm.generate(
         inputs,
         sampling_params,
+        lora_request=lora_request,
     )
 
     for i, output in enumerate(outputs):

--- a/tensorrt_llm/_torch/models/modeling_llava_next.py
+++ b/tensorrt_llm/_torch/models/modeling_llava_next.py
@@ -14,8 +14,8 @@ from transformers.models.llava_next.modeling_llava_next import (
 
 from tensorrt_llm.inputs.multimodal import MultimodalParams
 
-from ...inputs import (ExtraProcessedInputs, InputProcessor,
-                       MultimodalPlaceholderMetadata,
+from ...inputs import (BaseMultimodalInputProcessor, ExtraProcessedInputs,
+                       InputProcessor, MultimodalPlaceholderMetadata,
                        MultimodalPlaceholderPlacement, TextPrompt,
                        register_input_processor)
 from ...llmapi.utils import download_hf_model
@@ -32,7 +32,7 @@ from .modeling_utils import (filter_weights, register_auto_model,
 DISAGG = os.getenv('TLLM_MULTIMODAL_DISAGGREGATED', '0') == '1'
 
 
-class LlavaNextInputProcessor(InputProcessor):
+class LlavaNextInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
 
     def __init__(self,
                  model_path: str,
@@ -55,17 +55,6 @@ class LlavaNextInputProcessor(InputProcessor):
         self.image_token_index = model_config.image_token_index
         self.vocab_size = model_config.vocab_size
         self.config = model_config.vision_config
-
-    def get_num_tokens_per_image(
-        self,
-        *,
-        image_width: int,
-        image_height: int,
-    ) -> int:
-        image_size = (image_height, image_width)
-        num_image_tokens = self.processor._get_num_multimodal_tokens(
-            [image_size])["num_image_tokens"][0]
-        return num_image_tokens
 
     def _postprocess(
         self, input_ids: torch.Tensor, mm_features: Union[torch.Tensor,

--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -44,6 +44,7 @@ class Qwen2VLInputProcessorBase(BaseMultimodalInputProcessor, InputProcessor):
             trust_remote_code=trust_remote_code)
 
         self.tllm_multimodal_token_id = self.model_config.vocab_size + 1
+        # temporal patch size for video frames
         self.temporal_patch_size = getattr(model_config.vision_config,
                                            'temporal_patch_size', 1)
 

--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -7,14 +7,13 @@ import torch.nn as nn
 from transformers import (AutoProcessor, AutoTokenizer, PretrainedConfig,
                           PreTrainedModel, Qwen2_5_VLForConditionalGeneration,
                           Qwen2VLForConditionalGeneration)
-from transformers.models.qwen2_vl.image_processing_qwen2_vl import smart_resize
 
 from tensorrt_llm.inputs.multimodal import MultimodalParams
 
 from ..._utils import nvtx_range_debug
 from ...functional import RopeEmbeddingUtils, RotaryScalingType
-from ...inputs import (ExtraProcessedInputs, InputProcessor,
-                       MultimodalPlaceholderMetadata,
+from ...inputs import (BaseMultimodalInputProcessor, ExtraProcessedInputs,
+                       InputProcessor, MultimodalPlaceholderMetadata,
                        MultimodalPlaceholderPlacement, TextPrompt,
                        register_input_processor)
 from ...logger import logger
@@ -29,7 +28,7 @@ from .modeling_utils import register_auto_model, register_vision_encoder
 DISAGG = os.getenv('TLLM_MULTIMODAL_DISAGGREGATED', '0') == '1'
 
 
-class Qwen2VLInputProcessorBase(InputProcessor):
+class Qwen2VLInputProcessorBase(BaseMultimodalInputProcessor, InputProcessor):
 
     def __init__(self,
                  model_path: str,
@@ -45,6 +44,8 @@ class Qwen2VLInputProcessorBase(InputProcessor):
             trust_remote_code=trust_remote_code)
 
         self.tllm_multimodal_token_id = self.model_config.vocab_size + 1
+        self.temporal_patch_size = getattr(model_config.vision_config,
+                                           'temporal_patch_size', 1)
 
     @classmethod
     def get_rope_index(
@@ -219,38 +220,6 @@ class Qwen2VLInputProcessorBase(InputProcessor):
         mrope_position_deltas = torch.tensor(
             mrope_position_deltas, device=input_ids.device).unsqueeze(1)
         return position_ids, mrope_position_deltas
-
-    def get_num_tokens_per_image(
-        self,
-        *,
-        image_width: int,
-        image_height: int,
-        num_frames: int = 1,
-        do_resize: bool = True,
-    ):
-        patch_size = self.model_config.vision_config.patch_size
-        merge_size = self.model_config.vision_config.spatial_merge_size
-        temporal_patch_size = self.model_config.vision_config.temporal_patch_size
-        if do_resize:
-            resized_height, resized_width = smart_resize(
-                height=image_height,
-                width=image_width,
-                factor=patch_size * merge_size,
-                min_pixels=self.processor.image_processor.min_pixels,
-                max_pixels=self.processor.image_processor.max_pixels,
-            )
-            image_width, image_height = resized_width, resized_height
-
-        padded_num_frames = num_frames + num_frames % temporal_patch_size
-
-        grid_t = max(padded_num_frames // temporal_patch_size, 1)
-        grid_h = image_height // patch_size
-        grid_w = image_width // patch_size
-
-        num_patches = grid_t * grid_h * grid_w
-        num_vision_tokens = num_patches // (merge_size**2)
-
-        return num_vision_tokens
 
     def _preprocess(self, text: dict[str, any], mm_data: dict[str, any],
                     mm_processor_kwargs: Dict[str, Any]):

--- a/tensorrt_llm/inputs/__init__.py
+++ b/tensorrt_llm/inputs/__init__.py
@@ -1,7 +1,7 @@
 from .data import PromptInputs, TextPrompt, TokensPrompt, prompt_inputs
 from .multimodal import MultimodalInput
-from .registry import (ExtraProcessedInputs, InputProcessor,
-                       MultimodalPlaceholderMetadata,
+from .registry import (BaseMultimodalInputProcessor, ExtraProcessedInputs,
+                       InputProcessor, MultimodalPlaceholderMetadata,
                        MultimodalPlaceholderPlacement, create_input_processor,
                        create_input_processor_with_hash,
                        register_input_processor)
@@ -27,6 +27,7 @@ __all__ = [
     "create_input_processor_with_hash",
     "register_input_processor",
     "ExtraProcessedInputs",
+    "BaseMultimodalInputProcessor",
     "MultimodalPlaceholderMetadata",
     "MultimodalPlaceholderPlacement",
     "ConversationMessage",

--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -9,6 +9,8 @@ import torch
 from blake3 import blake3
 from torchvision.transforms import ToPILImage
 
+from tensorrt_llm.logger import logger
+
 # Default hasher
 default_hasher = blake3
 
@@ -551,6 +553,10 @@ def find_mm_token_positions(
     if mm_token_ids is None and vocab_size is None:
         raise ValueError(
             "Provide either mm_token_ids or vocab_size to find multimodal token positions"
+        )
+    if mm_token_ids is not None and vocab_size is not None:
+        logger.warning(
+            "Both mm_token_ids and vocab_size are provided, using mm_token_ids and ignoring vocab_size"
         )
 
     # Convert input_ids to tensor if needed

--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -517,6 +517,9 @@ def find_mm_token_lengths(mm_data: Dict[str, Any],
                     num_frames=len(item),
                 )
                 modality_token_lengths.append(num_tokens)
+            else:
+                # TODO: add audio support if needed
+                raise ValueError(f"Unsupported modality: {modality}")
 
         num_mm_tokens[modality] = modality_token_lengths
 
@@ -540,7 +543,7 @@ def find_mm_token_positions(
         input_ids: Token sequence (tensor, list, or numpy array)
         num_mm_tokens: List of lengths for each multimodal token chunk
         vocab_size: Size of the model's vocabulary
-        mm_token_ids: possible token ids for multimodal tokens
+        mm_token_ids: Possible token ids for multimodal tokens
 
     Returns:
         List of starting positions for each multimodal token chunk
@@ -561,8 +564,6 @@ def find_mm_token_positions(
     if mm_token_ids is None:
         mm_mask = input_ids >= vocab_size
     else:
-        if not isinstance(mm_token_ids, torch.Tensor):
-            mm_token_ids = torch.tensor(mm_token_ids)
         if mm_token_ids.ndim != 1:
             raise ValueError("mm_token_ids must be a 1D tensor")
         mm_token_ids = torch.unique(mm_token_ids)

--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -445,6 +445,8 @@ def apply_mm_hashes(mm_data: Dict[str, Any],
             # Hash each frame with a separator to avoid collisions between [A,B] and [AB]
             for frame in image:
                 hasher.update(b"<frame>")
+                if isinstance(frame, torch.Tensor):
+                    frame = frame.detach().cpu().contiguous()
                 hasher.update(serialize_item(frame))
         else:
             hasher.update(serialize_item(image))

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -41,6 +41,110 @@ class InputProcessor(Protocol):
         ...
 
 
+class BaseMultimodalInputProcessor:
+    """
+    Base class for multimodal input processors with default implementations
+    of get_num_tokens_per_image and get_num_tokens_per_video methods.
+
+    This class provides default implementations that work with most AutoProcessor-based
+    models. Specific processors can override these methods if they need custom logic.
+    """
+
+    def get_num_tokens_per_image(
+        self,
+        *,
+        image_width: int,
+        image_height: int,
+        **kwargs,
+    ):
+        """
+        Calculate the number of tokens generated for an image.
+
+        Default implementation assumes the processor has either:
+        1. A 'processor' attribute with _get_num_multimodal_tokens method
+        2. A '_processor' attribute with _get_num_multimodal_tokens method
+
+        Override this method for custom implementations.
+        """
+        if hasattr(self, 'processor') and hasattr(self.processor,
+                                                  '_get_num_multimodal_tokens'):
+            image_size = (image_height, image_width)
+            num_image_tokens = self.processor._get_num_multimodal_tokens(
+                [image_size], **kwargs)["num_image_tokens"][0]
+            return num_image_tokens
+        # Check for _processor attribute (e.g., Mistral3)
+        elif hasattr(self, '_processor') and hasattr(
+                self._processor, '_get_num_multimodal_tokens'):
+            image_size = (image_height, image_width)
+            num_image_tokens = self._processor._get_num_multimodal_tokens(
+                [image_size], **kwargs)["num_image_tokens"][0]
+            return num_image_tokens
+        else:
+            raise NotImplementedError(
+                f"get_num_tokens_per_image not implemented for {self.__class__.__name__}. "
+                "Please override this method or ensure the processor has _get_num_multimodal_tokens method."
+            )
+
+    def get_num_tokens_per_video(
+        self,
+        *,
+        video_width: int,
+        video_height: int,
+        num_frames: int,
+        **kwargs,
+    ):
+        """
+        Calculate the number of tokens generated for a video.
+
+        Default implementation assumes the processor has either:
+        1. A 'processor' attribute with _get_num_multimodal_tokens method
+        2. A '_processor' attribute with _get_num_multimodal_tokens method
+
+        Override this method for custom implementations.
+        """
+        if hasattr(self, 'processor') and hasattr(self.processor,
+                                                  '_get_num_multimodal_tokens'):
+            video_size = (num_frames, video_height, video_width)
+            # Try to get video tokens directly
+            try:
+                num_video_tokens = self.processor._get_num_multimodal_tokens(
+                    video_sizes=[video_size], **kwargs)["num_video_tokens"][0]
+                return num_video_tokens
+            except Exception:
+                # Fallback: treat video as sequence of frames
+                num_tokens_per_frame = self.get_num_tokens_per_image(
+                    image_width=video_width,
+                    image_height=video_height,
+                    **kwargs)
+                temporal_patch_size = self.temporal_patch_size if hasattr(
+                    self, 'temporal_patch_size') else 1
+                return num_tokens_per_frame * num_frames // temporal_patch_size
+        # Check for _processor attribute (e.g., Mistral3)
+        # TODO: unify the naming convention for the processor attribute
+        elif hasattr(self, '_processor') and hasattr(
+                self._processor, '_get_num_multimodal_tokens'):
+            video_size = (num_frames, video_height, video_width)
+            # Try to get video tokens directly
+            try:
+                num_video_tokens = self._processor._get_num_multimodal_tokens(
+                    video_sizes=[video_size], **kwargs)["num_video_tokens"][0]
+                return num_video_tokens
+            except Exception:
+                # Fallback: treat video as sequence of frames
+                num_tokens_per_frame = self.get_num_tokens_per_image(
+                    image_width=video_width,
+                    image_height=video_height,
+                    **kwargs)
+                temporal_patch_size = self.temporal_patch_size if hasattr(
+                    self, 'temporal_patch_size') else 1
+                return num_tokens_per_frame * num_frames // temporal_patch_size
+        else:
+            raise NotImplementedError(
+                f"get_num_tokens_per_video not implemented for {self.__class__.__name__}. "
+                "Please override this method or ensure the processor has _get_num_multimodal_tokens method."
+            )
+
+
 class DefaultInputProcessor(InputProcessor):
     """Preprocess the inputs to the model."""
 
@@ -327,6 +431,8 @@ def create_input_processor_with_hash(
         assert 'multi_modal_data' in inputs, "multi_modal_data must be provided for hashing support."
         mm_data = inputs['multi_modal_data']
         num_mm_tokens = find_mm_token_lengths(mm_data, input_processor)
+        # TODO: here we assume there is only one modality for now
+        num_mm_tokens = next(iter(num_mm_tokens.values()))
         if len(num_mm_tokens) > 0:
             mm_hashes = apply_mm_hashes(mm_data, hash_lib)
             prompt_token_ids, extra_processed_inputs = input_processor(
@@ -358,8 +464,8 @@ def create_input_processor_with_hash(
         modalities = list(set(inputs['multi_modal_data'].keys())
                           ) if 'multi_modal_data' in inputs else []
         if len(modalities) > 0:
-            # NOTE: tensorrt_llm/inputs/multimodal.py:find_mm_token_lengths only supports image data for now
-            if len(modalities) == 1 and modalities[0] == "image":
+            # TODO: support multiple modalities for multimodal hashing (for kv cache reuse, chunked prefill, etc.)
+            if len(modalities) == 1:
                 # only try multimodal hashing if the inputs only contain image data
                 if input_processor.multimodal_hashing_supported is not None:
                     use_multimodal_hashing = input_processor.multimodal_hashing_supported

--- a/tests/unittest/_torch/multimodal/test_find_num_image_tokens.py
+++ b/tests/unittest/_torch/multimodal/test_find_num_image_tokens.py
@@ -8,15 +8,22 @@ from transformers import AutoConfig, AutoTokenizer
 from tensorrt_llm import MultimodalEncoder
 from tensorrt_llm._torch.models.modeling_llava_next import \
     LlavaNextInputProcessor
+from tensorrt_llm._torch.models.modeling_mistral import Mistral3InputProcessor
 from tensorrt_llm._torch.models.modeling_qwen2vl import \
     Qwen2VLInputProcessorBase
 from tensorrt_llm._torch.shared_tensor import SharedTensorContainer
 from tensorrt_llm.inputs import default_multimodal_input_loader
+from tensorrt_llm.inputs.utils import load_video
 
 example_images = [
     "https://huggingface.co/datasets/YiYiXu/testing-images/resolve/main/seashore.png",
     "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/inpaint.png",
     "https://huggingface.co/datasets/Sayali9141/traffic_signal_images/resolve/main/61.jpg",
+]
+
+example_videos = [
+    "https://huggingface.co/datasets/Efficient-Large-Model/VILA-inference-demos/resolve/main/OAI-sora-tokyo-walk.mp4",
+    "https://huggingface.co/datasets/Efficient-Large-Model/VILA-inference-demos/resolve/main/world.mp4",
 ]
 
 
@@ -39,7 +46,12 @@ def multimodal_model_configs():
         'qwen2.5-vl': {
             'hf_model_dir': 'Qwen/Qwen2.5-VL-3B-Instruct',
             'model_type': 'qwen2_5_vl',
-        }
+        },
+        'mistral-small-3.1': {
+            'hf_model_dir':
+            '/home/scratch.trt_llm_data/llm-models/Mistral-Small-3.1-24B-Instruct-2503',
+            'model_type': 'mistral3',
+        },
     }
     return model_configs
 
@@ -137,6 +149,11 @@ def test_get_num_tokens_per_image(model_key, multimodal_model_configs):
                     image_height=image_height,
                     num_frames=1,
                     do_resize=True)
+            elif model_type == 'mistral':
+                predicted_num_tokens = input_processor.get_num_tokens_per_image(
+                    image_width=image_width, image_height=image_height)
+            else:
+                raise ValueError(f"Unsupported model type: {model_type}")
 
             # The key assertion: predicted should match actual
             assert predicted_num_tokens == actual_num_tokens, \
@@ -145,6 +162,123 @@ def test_get_num_tokens_per_image(model_key, multimodal_model_configs):
 
             # Additional validation: ensure we got reasonable token counts
             assert actual_num_tokens > 0, f"Got zero image tokens for {model_key} image {image_idx}"
+            assert actual_embedding.ndim >= 2, f"Expected at least 2D embedding, got {actual_embedding.ndim}D"
+
+    finally:
+        # Cleanup resources
+        if encoder is not None:
+            del encoder
+
+
+@pytest.mark.parametrize("model_key", [
+    "qwen2.5-vl",
+])
+def test_get_num_tokens_per_video(model_key, multimodal_model_configs):
+    """Test that get_num_tokens_per_video predicts the correct number of tokens.
+
+    This test verifies that the get_num_tokens_per_video method correctly predicts
+    the number of video tokens by comparing against actual encoder output shapes.
+    Tests all example videos in a single test run.
+    """
+    # Get model configuration
+    if model_key not in multimodal_model_configs:
+        pytest.skip(f"Skipping test for {model_key} - model not available")
+
+    model_config = multimodal_model_configs[model_key]
+    encoder_model_dir = model_config['hf_model_dir']
+    model_type = model_config['model_type']
+
+    # Test configuration
+    max_batch_size = len(example_videos)  # Batch size to handle all test videos
+
+    encoder = None
+
+    try:
+        encoder = MultimodalEncoder(model=encoder_model_dir,
+                                    max_batch_size=max_batch_size)
+
+        # Load model configuration and create input processor once
+        model_config_dict = AutoConfig.from_pretrained(encoder_model_dir,
+                                                       trust_remote_code=True)
+        tokenizer = AutoTokenizer.from_pretrained(encoder_model_dir,
+                                                  trust_remote_code=True)
+
+        # Create input processor once
+        if model_type == 'llava_next':
+            input_processor = LlavaNextInputProcessor(
+                model_path=encoder_model_dir,
+                model_config=model_config_dict,
+                tokenizer=tokenizer,
+                trust_remote_code=True)
+        elif model_type == 'qwen2_5_vl':
+            input_processor = Qwen2VLInputProcessorBase(
+                model_path=encoder_model_dir,
+                model_config=model_config_dict,
+                tokenizer=tokenizer,
+                trust_remote_code=True)
+        elif model_type == 'mistral':
+            input_processor = Mistral3InputProcessor(
+                model_path=encoder_model_dir,
+                model_config=model_config_dict,
+                tokenizer=tokenizer,
+                trust_remote_code=True)
+        else:
+            pytest.fail(f"Unsupported model type: {model_type}")
+
+        # Prepare batch inputs with all 3 images
+        prompts = ["dummy"] * len(example_videos)  # One prompt per video
+        media = example_videos  # All video URLs
+
+        # Prepare inputs and get actual embeddings for all images
+        inputs = default_multimodal_input_loader(tokenizer=tokenizer,
+                                                 model_dir=encoder_model_dir,
+                                                 model_type=model_type,
+                                                 modality="video",
+                                                 prompts=prompts,
+                                                 media=media,
+                                                 image_data_format="pt")
+
+        # Get actual embeddings from encoder (batch processing)
+        encoder_outputs = encoder.generate(inputs)
+        assert len(encoder_outputs) == len(
+            example_videos
+        ), f"Expected {len(example_videos)} encoder outputs, got {len(encoder_outputs)}"
+
+        for video_idx, test_video_url in enumerate(example_videos):
+
+            # Get test video dimensions
+            test_video = load_video(test_video_url, num_frames=8, format="pil")
+            # load_video returns a list of frames, we only have one video
+            video_width, video_height = test_video[0].size
+            num_frames = len(test_video)
+
+            # Get actual embedding tensor for this image
+            actual_embedding = SharedTensorContainer.from_dict(
+                encoder_outputs[video_idx].mm_embedding_handle).get_local_view(
+                )
+
+            # The first dimension should be the number of image tokens
+            actual_num_tokens = actual_embedding.shape[0]
+
+            # Get predicted number of tokens using get_num_tokens_per_image
+            if model_type == 'llava_next':
+                predicted_num_tokens = input_processor.get_num_tokens_per_video(
+                    video_width=video_width,
+                    video_height=video_height,
+                    num_frames=num_frames)
+            elif model_type == 'qwen2_5_vl':
+                predicted_num_tokens = input_processor.get_num_tokens_per_video(
+                    video_width=video_width,
+                    video_height=video_height,
+                    num_frames=num_frames)
+
+            # The key assertion: predicted should match actual
+            assert predicted_num_tokens == actual_num_tokens, \
+                f"Token count mismatch for {model_key} with video {video_idx} ({video_width}x{video_height}): " \
+                f"predicted={predicted_num_tokens}, actual={actual_num_tokens}"
+
+            # Additional validation: ensure we got reasonable token counts
+            assert actual_num_tokens > 0, f"Got zero video tokens for {model_key} video {video_idx}"
             assert actual_embedding.ndim >= 2, f"Expected at least 2D embedding, got {actual_embedding.ndim}D"
 
     finally:

--- a/tests/unittest/_torch/multimodal/test_find_num_image_tokens.py
+++ b/tests/unittest/_torch/multimodal/test_find_num_image_tokens.py
@@ -8,7 +8,6 @@ from transformers import AutoConfig, AutoTokenizer
 from tensorrt_llm import MultimodalEncoder
 from tensorrt_llm._torch.models.modeling_llava_next import \
     LlavaNextInputProcessor
-from tensorrt_llm._torch.models.modeling_mistral import Mistral3InputProcessor
 from tensorrt_llm._torch.models.modeling_qwen2vl import \
     Qwen2VLInputProcessorBase
 from tensorrt_llm._torch.shared_tensor import SharedTensorContainer
@@ -46,11 +45,6 @@ def multimodal_model_configs():
         'qwen2.5-vl': {
             'hf_model_dir': 'Qwen/Qwen2.5-VL-3B-Instruct',
             'model_type': 'qwen2_5_vl',
-        },
-        'mistral-small-3.1': {
-            'hf_model_dir':
-            '/home/scratch.trt_llm_data/llm-models/Mistral-Small-3.1-24B-Instruct-2503',
-            'model_type': 'mistral3',
         },
     }
     return model_configs
@@ -149,9 +143,6 @@ def test_get_num_tokens_per_image(model_key, multimodal_model_configs):
                     image_height=image_height,
                     num_frames=1,
                     do_resize=True)
-            elif model_type == 'mistral':
-                predicted_num_tokens = input_processor.get_num_tokens_per_image(
-                    image_width=image_width, image_height=image_height)
             else:
                 raise ValueError(f"Unsupported model type: {model_type}")
 
@@ -212,12 +203,6 @@ def test_get_num_tokens_per_video(model_key, multimodal_model_configs):
                 trust_remote_code=True)
         elif model_type == 'qwen2_5_vl':
             input_processor = Qwen2VLInputProcessorBase(
-                model_path=encoder_model_dir,
-                model_config=model_config_dict,
-                tokenizer=tokenizer,
-                trust_remote_code=True)
-        elif model_type == 'mistral':
-            input_processor = Mistral3InputProcessor(
                 model_path=encoder_model_dir,
                 model_config=model_config_dict,
                 tokenizer=tokenizer,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Introduced a unified multimodal input processor base, now exported for public use.
  - Expanded multimodal support to include video token-length computation alongside images.
  - Enhanced hashing to handle tensors and frame sequences for reliable multimodal caching.

- Refactor
  - Updated LLaVA-Next and Qwen2VL input processors to adopt the new multimodal base and streamlined initialization, removing legacy image token-count paths.

- Tests
  - Added video token-count validation and extended coverage to Mistral models, including new configurations and fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
