### PR TITLE
[TRTLLM-7330][feat] Eagle3 cuda graph support for the first draft model inference

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
+++ b/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
@@ -8,8 +8,10 @@ import torch
 from ...inputs.multimodal import MultimodalParams
 from ..expert_statistic import ExpertStatistic
 from ..modules.multi_stream_utils import with_multi_stream
+from ..speculative.eagle3 import Eagle3ResourceManager
 from ..utils import make_weak_ref, piecewise_cuda_graph
-from .resource_manager import ResourceManager, ResourceManagerType
+from .resource_manager import (BaseResourceManager, ResourceManager,
+                               ResourceManagerType)
 from .scheduler import ScheduledRequests
 
 if TYPE_CHECKING:
@@ -25,7 +27,7 @@ class CUDAGraphRunner:
 
     This unified class handles high-level orchestration (padding, eligibility)
     and low-level execution (capturing, resource management, replaying) for
-    multiple graphs, keyed by (batch size, draft_len).
+    multiple graphs, keyed by (batch size, draft_len, is_first_draft).
     """
     WARMUP_STEPS = 2
 
@@ -40,11 +42,14 @@ class CUDAGraphRunner:
         self.max_supported_batch_size = engine._max_cuda_graph_batch_size
         self.max_beam_width = engine.max_beam_width
         self.spec_config = engine.spec_config
+        engine = self._get_engine()
+        self.max_possible_draft_len = (engine.original_max_draft_len
+                                       if self.enable_spec_decode else 0)
 
-        self.graphs: Dict[Tuple[int, int], torch.cuda.CUDAGraph] = {}
-        self.graph_outputs: Dict[Tuple[int, int],
+        self.graphs: Dict[Tuple[int, int, int], torch.cuda.CUDAGraph] = {}
+        self.graph_outputs: Dict[Tuple[int, int, int],
                                  Callable[[], Optional[torch.Tensor]]] = {}
-        self.graph_metadata: Dict[Tuple[int, int], Dict[str, Any]] = {}
+        self.graph_metadata: Dict[Tuple[int, int, int], Dict[str, Any]] = {}
         self.memory_pool = engine._cuda_graph_mem_pool
         self.padding_dummy_request: Optional["Request"] = None
 
@@ -56,7 +61,7 @@ class CUDAGraphRunner:
         """Allocates static tensors sized for the largest possible batch."""
         engine = self._get_engine()
 
-        token_per_request = self.draft_len + 1
+        token_per_request = self.max_possible_draft_len + 1
         max_total_tokens = (self.max_supported_batch_size *
                             self.max_beam_width * token_per_request)
         max_total_tokens = min(max_total_tokens, engine.max_num_tokens)
@@ -86,9 +91,19 @@ class CUDAGraphRunner:
     def enable_spec_decode(self):
         return self._get_engine().enable_spec_decode
 
-    @property
-    def draft_len(self):
-        return self.spec_config.max_draft_len if self.enable_spec_decode else 0
+    def get_graph_key(
+            self,
+            batch_size,
+            spec_resource_manager: Optional[BaseResourceManager] = None):
+        engine = self._get_engine()
+        if engine.is_draft_model and spec_resource_manager is not None and isinstance(
+                spec_resource_manager, Eagle3ResourceManager):
+            draft_len = engine.original_max_draft_len if spec_resource_manager.is_first_draft else 0
+            key = (batch_size, draft_len, spec_resource_manager.is_first_draft)
+        else:
+            draft_len = self.spec_config.max_draft_len if self.enable_spec_decode else 0
+            key = (batch_size, draft_len, False)
+        return key
 
     @property
     def spec_metadata(self):
@@ -113,7 +128,10 @@ class CUDAGraphRunner:
                 "The parent PyTorchModelEngine has been garbage collected.")
         return engine
 
-    def maybe_get_cuda_graph(self, batch: ScheduledRequests):
+    def maybe_get_cuda_graph(
+            self,
+            batch: ScheduledRequests,
+            spec_resource_manager: Optional[BaseResourceManager] = None):
         """
         Determines if the current batch can be run with a CUDA graph.
 
@@ -121,13 +139,14 @@ class CUDAGraphRunner:
         - A boolean indicating if a graph can be used.
         - The attn_metadata for the graph, if applicable.
         - The spec_metadata for the graph, if applicable.
+        - The key for the graph.
         """
         engine = self._get_engine()
 
         # disable when doing statistic
         if hasattr(engine, 'iter_counter') and ExpertStatistic.set_iter(
                 engine.iter_counter):
-            return False, None, None
+            return False, None, None, None
 
         can_run_cuda_graph = batch.can_run_cuda_graph
         batch_size = batch.batch_size
@@ -141,22 +160,22 @@ class CUDAGraphRunner:
                 for all_gen_only in all_can_graph_batch)
 
             if not is_all_gen_only or not all_batch_size_equal:
-                return False, None, None
+                return False, None, None, None
 
         if not self.enabled or not can_run_cuda_graph:
-            return False, None, None
+            return False, None, None, None
+        key = self.get_graph_key(batch_size, spec_resource_manager)
 
-        key = (batch_size, self.draft_len)
         if key in self.graphs:
             return True, self.graph_metadata[key][
-                "attn_metadata"], self.graph_metadata[key]["spec_metadata"]
+                "attn_metadata"], self.graph_metadata[key]["spec_metadata"], key
 
         if batch_size not in self.supported_batch_sizes:
-            return False, None, None
+            return False, None, None, None
 
         num_sequences_in_batch = batch_size * self.max_beam_width
         attn_metadata = self.attn_metadata.create_cuda_graph_metadata(
-            num_sequences_in_batch, False, self.draft_len)
+            num_sequences_in_batch, False, key[1])
         assert attn_metadata.is_cuda_graph
 
         if self.enable_spec_decode:
@@ -165,23 +184,29 @@ class CUDAGraphRunner:
             spec_metadata.draft_tokens = self.draft_tokens_cuda
         else:
             spec_metadata = None
-        return True, attn_metadata, spec_metadata
+        return True, attn_metadata, spec_metadata, key
 
-    def needs_capture(self, batch_size: int):
-        return (batch_size, self.draft_len) not in self.graph_outputs
+    def needs_capture(self, key: Tuple[int, int, int]):
+
+        return key not in self.graph_outputs
 
     def capture(self,
-                batch_size: int,
+                key: Tuple[int, int, int],
                 forward_fn: Callable,
                 initial_inputs: Dict[str, Any],
                 postprocess_fn: Optional[Callable] = None):
         """Captures the forward pass for a given batch size."""
+<<<<<<< HEAD
         engine = self._get_engine()
         key = (batch_size, self.draft_len)
+=======
+        batch_size = key[0]
+>>>>>>> 61ef183ad (eagle3 cuda graph for the 1st draft model infer)
         # [CUDA graph spec decode padding]
         # We pad input IDs/position IDs to the maximum draft length (token per request).
         # We're forced to do this because we cannot reallocate inputs over many graph runs.
-        token_per_request = self.draft_len + 1
+        max_draft_len = key[1]
+        token_per_request = max_draft_len + 1
         num_tokens_for_capture = (batch_size * self.max_beam_width *
                                   token_per_request)
 
@@ -207,6 +232,17 @@ class CUDAGraphRunner:
             "spec_metadata": initial_inputs.get("spec_metadata", None),
         }
 
+        def wrap_forward_fn(key: Tuple[int, int, int], forward_fn: Callable,
+                            capture_inputs: Dict[str, Any]):
+            engine = self._get_engine()
+            # for the first inference of draft model, we need to set the use_spec_decoding to True when capture the graph for multiple runs.
+            is_first_draft = key[2]
+            needs_kv_cache_recompute = True if engine.enable_spec_decode and engine.spec_config.spec_dec_mode.needs_kv_cache_recompute(
+            ) else False
+            if is_first_draft and engine.is_draft_model and needs_kv_cache_recompute:
+                capture_inputs['attn_metadata'].use_spec_decoding = True
+            return forward_fn(capture_inputs)
+
         # We have to do warm up runs to initialize PyTorch's
         # internal states according to the docs:
         # https://pytorch.org/docs/stable/notes/cuda.html#cuda-graph-semantics
@@ -214,11 +250,11 @@ class CUDAGraphRunner:
         graph = torch.cuda.CUDAGraph()
         with with_multi_stream(True), piecewise_cuda_graph(False):
             for _ in range(self.WARMUP_STEPS):
-                forward_fn(capture_inputs)
+                wrap_forward_fn(key, forward_fn, capture_inputs)
                 if postprocess_fn is not None:
                     postprocess_fn(capture_inputs)
             with torch.cuda.graph(graph, pool=self.memory_pool):
-                output = forward_fn(capture_inputs)
+                output = wrap_forward_fn(key, forward_fn, capture_inputs)
             if postprocess_fn is not None:
                 postprocess_fn(capture_inputs)
 
@@ -226,11 +262,10 @@ class CUDAGraphRunner:
         self.graph_outputs[key] = make_weak_ref(output)
         self.memory_pool = graph.pool()
 
-    def replay(self, batch_size: int,
+    def replay(self, key: Tuple[int, int, int],
                current_inputs: Dict[str, Any]) -> Optional[torch.Tensor]:
         """Replays a previously captured graph."""
         engine = self._get_engine()
-        key = (batch_size, self.draft_len)
         stored_meta = self.graph_metadata[key]
         assert current_inputs["attn_metadata"] is stored_meta["attn_metadata"]
         if stored_meta["spec_metadata"] is not None:

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -311,6 +311,7 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
             is_draft: bool = False,
             seq_slot: Optional[int] = None,
             target_seq_slot: Optional[int] = None,
+            is_first_draft: bool = False,
             **kwargs):
 
         self.py_logits_post_processors = kwargs.pop("py_logits_post_processors",
@@ -365,6 +366,8 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
         # If the request is a draft request, target_seq_slot is the sequence slot ID of its target request.
         self.py_target_seq_slot = target_seq_slot
         self.use_draft_model = is_draft
+        # Whether the request is for the first forward of the draft model.
+        self.py_is_first_draft = is_first_draft
 
         # TODO: remove this when use DynamicDecodeOp in pytorch flow.
         # currently, keep py_stop_words_list as python list, rather than tensor.

--- a/tensorrt_llm/_torch/speculative/drafting_loops.py
+++ b/tensorrt_llm/_torch/speculative/drafting_loops.py
@@ -63,10 +63,9 @@ def prepare_for_generation(attn_metadata: AttentionMetadata,
                            spec_metadata: SpecMetadata,
                            position_ids: torch.Tensor) -> torch.Tensor:
     batch_size = attn_metadata.num_seqs
-    # Using attn_metadata.seq_lens_cuda[:batch_size] to get the max_draft_len + 1
     num_accepted_draft_tokens = spec_metadata.num_accepted_draft_tokens[:
                                                                         batch_size]
-    #Get sequence lengths                                                                 batch_size]
+    # Using attn_metadata.seq_lens_cuda[:batch_size] to get the max_draft_len + 1
     seq_lens = attn_metadata.seq_lens_cuda[:batch_size]
     attn_metadata.kv_lens_cuda[:
                                batch_size] -= seq_lens - num_accepted_draft_tokens - 1
@@ -84,7 +83,7 @@ def prepare_for_generation(attn_metadata: AttentionMetadata,
 
     attn_metadata.host_request_types[:attn_metadata.num_contexts].fill_(1)
     attn_metadata.num_contexts = 0
-    # the next inference of draft model will not use spec decoding and the number of input tokens is 1.
+    # The next inference of draft model will not use spec decoding and the number of input tokens is 1
     attn_metadata.use_spec_decoding = False
 
     spec_metadata.num_tokens = batch_size

--- a/tensorrt_llm/_torch/speculative/drafting_loops.py
+++ b/tensorrt_llm/_torch/speculative/drafting_loops.py
@@ -43,7 +43,7 @@ def save_metadata_state(attn_metadata: AttentionMetadata,
     finally:
         attn_metadata.restore_from_spec_dec()
         attn_metadata.kv_lens_cuda[:batch_size].copy_(kv_lens)
-
+        attn_metadata.on_update()
         if attn_metadata.is_cuda_graph:
             spec_metadata.num_tokens = num_tokens
             if isinstance(spec_metadata, Eagle3SpecMetadata):
@@ -61,8 +61,22 @@ def save_metadata_state(attn_metadata: AttentionMetadata,
 
 def prepare_for_generation(attn_metadata: AttentionMetadata,
                            spec_metadata: SpecMetadata,
-                           last_tokens_idx: torch.Tensor) -> None:
+                           position_ids: torch.Tensor) -> torch.Tensor:
     batch_size = attn_metadata.num_seqs
+    # Using attn_metadata.seq_lens_cuda[:batch_size] to get the max_draft_len + 1
+    num_accepted_draft_tokens = spec_metadata.num_accepted_draft_tokens[:
+                                                                        batch_size]
+    #Get sequence lengths                                                                 batch_size]
+    seq_lens = attn_metadata.seq_lens_cuda[:batch_size]
+    attn_metadata.kv_lens_cuda[:
+                               batch_size] -= seq_lens - num_accepted_draft_tokens - 1
+
+    # Calculate last accepted token indices
+    last_tokens_idx = torch.cumsum(
+        seq_lens, dim=0,
+        dtype=torch.long) - seq_lens + num_accepted_draft_tokens
+    new_position_ids = position_ids[0, last_tokens_idx] + 1
+
     attn_metadata._seq_lens[:batch_size].fill_(1)
     attn_metadata._seq_lens_cuda[:batch_size].fill_(1)
     attn_metadata.on_update()
@@ -70,6 +84,8 @@ def prepare_for_generation(attn_metadata: AttentionMetadata,
 
     attn_metadata.host_request_types[:attn_metadata.num_contexts].fill_(1)
     attn_metadata.num_contexts = 0
+    # the next inference of draft model will not use spec decoding and the number of input tokens is 1.
+    attn_metadata.use_spec_decoding = False
 
     spec_metadata.num_tokens = batch_size
 
@@ -87,6 +103,8 @@ def prepare_for_generation(attn_metadata: AttentionMetadata,
                 dtype=spec_metadata.hidden_states_write_indices.dtype,
                 device=spec_metadata.hidden_states_write_indices.device))
 
+    return new_position_ids
+
 
 class ChainDrafter(torch.nn.Module):
 
@@ -98,25 +116,23 @@ class ChainDrafter(torch.nn.Module):
         self.max_draft_len = max_draft_len
 
     def forward(self, input_ids: torch.Tensor, position_ids: torch.Tensor,
-                attn_metadata: AttentionMetadata,
-                spec_metadata: AttentionMetadata, **kwargs) -> None:
+                attn_metadata: AttentionMetadata, spec_metadata: SpecMetadata,
+                **kwargs) -> torch.Tensor:
 
         logits = self.draft_model.forward(input_ids=input_ids,
                                           position_ids=position_ids,
                                           attn_metadata=attn_metadata,
-                                          spec_metadata=spec_metadata)
+                                          spec_metadata=spec_metadata,
+                                          return_context_logits=True)
+        logits = logits[spec_metadata.gather_ids]
 
         new_draft_tokens = [self.sample(logits)]
-
         with save_metadata_state(attn_metadata, spec_metadata):
             batch_size = attn_metadata.num_seqs
-            last_tokens_idx = torch.cumsum(
-                attn_metadata.seq_lens_cuda, dim=0, dtype=torch.long) - 1
-            new_position_ids = position_ids[0, last_tokens_idx] + 1
 
-            prepare_for_generation(attn_metadata, spec_metadata,
-                                   last_tokens_idx)
-
+            new_position_ids = prepare_for_generation(attn_metadata,
+                                                      spec_metadata,
+                                                      position_ids)
             for i in range(self.max_draft_len - 1):
                 logits = self.draft_model.forward(
                     input_ids=new_draft_tokens[-1],

--- a/tensorrt_llm/_torch/speculative/interface.py
+++ b/tensorrt_llm/_torch/speculative/interface.py
@@ -116,7 +116,7 @@ class SpeculativeDecodingMode(IntEnum):
         spec_resource_manager: BaseResourceManager,
         is_draft_model: bool,
         attention_backend: Type[AttentionBackend],
-        allow_chain_drafter: bool,
+        use_chain_drafter: bool,
     ):
         """
         If true, the attention backend kernel needs to run in spec-dec mode (multi-token query mode).
@@ -124,7 +124,7 @@ class SpeculativeDecodingMode(IntEnum):
         is_trtllm_attention = issubclass(attention_backend, TrtllmAttention)
         return self.is_eagle3_one_model() or (
             self.is_eagle3() and spec_resource_manager.is_first_draft
-            and is_trtllm_attention and allow_chain_drafter and is_draft_model)
+            and is_trtllm_attention and use_chain_drafter and is_draft_model)
 
     @staticmethod
     def from_string(name: Optional[str]) -> "SpeculativeDecodingMode":

--- a/tensorrt_llm/_torch/speculative/model_drafter.py
+++ b/tensorrt_llm/_torch/speculative/model_drafter.py
@@ -8,6 +8,7 @@ import torch
 from tensorrt_llm._utils import nvtx_range
 from tensorrt_llm.logger import logger
 
+from ..attention_backend.trtllm import TrtllmAttention
 from ..pyexecutor.guided_decoder import GuidedDecoder
 from ..pyexecutor.handle_logits import HandleLogits
 from ..pyexecutor.llm_request import LlmRequest, LlmRequestState
@@ -16,6 +17,7 @@ from ..pyexecutor.sampler import Sampler, SampleState, SampleStateTensors
 from ..pyexecutor.scheduler import ScheduledRequests
 from ..pyexecutor.seq_slot_manager import SeqSlotManager
 from ..speculative.mtp import SampleStateTensorsMTP
+from ..utils import _get_allow_chain_drafter
 from .drafter import Drafter
 
 if TYPE_CHECKING:
@@ -139,6 +141,22 @@ class ModelDrafter(Drafter):
             input_tokens) - num_accepted_tokens - 1
         return new_request
 
+    def _create_accepted_tokens_request_for_trtllm_attn(
+            self, request: LlmRequest, input_tokens: Any,
+            num_accepted_tokens: int) -> LlmRequest:
+        """
+        Create a chunked context request for accepted tokens.
+        Only applicable if the draft model needs to recompute KV cache for accepted tokens (e.g. eagle 3)
+        """
+        # Pad input_tokens to max_draft_tokens
+        input_tokens.extend(
+            0 for _ in range(self.max_draft_tokens - num_accepted_tokens))
+        new_request = self._create_draft_request(request, input_tokens)
+        new_request.state = LlmRequestState.GENERATION_IN_PROGRESS
+        new_request.py_num_accepted_draft_tokens = request.py_num_accepted_draft_tokens
+        new_request.py_is_first_draft = True
+        return new_request
+
     def _create_draft_request_for_request(
             self, request: LlmRequest) -> Optional[LlmRequest]:
         """Create a draft request based on the original request state."""
@@ -146,7 +164,6 @@ class ModelDrafter(Drafter):
             request)
         input_tokens = get_draft_model_prompt(self.spec_config.spec_dec_mode,
                                               request.get_tokens(0))
-
         # First time seeing this request - context request
         if request.max_beam_num_tokens - 1 == request.py_prompt_len:
             # This is the first time the draft model is seeing this request.
@@ -154,6 +171,12 @@ class ModelDrafter(Drafter):
             # the newly decoded one - this is the convention for EAGLE 2 and 3.
             assert num_draft_tokens == 0
             return self._create_context_request(request, input_tokens)
+
+        # For TRTLLM attention backend, we need to create a generation request for both no tokens accepted and tokens accepted
+        elif issubclass(self.draft_model_engine.attn_backend,
+                        TrtllmAttention) and _get_allow_chain_drafter():
+            return self._create_accepted_tokens_request_for_trtllm_attn(
+                request, input_tokens, num_accepted_tokens)
 
         # No tokens accepted - generation request. This only applies to speculation algorithms
         # that need to recompute KV cache for accepted tokens like eagle3.
@@ -563,6 +586,8 @@ class ModelDrafter(Drafter):
             The final sample state
         """
         # Convert context requests to generation requests
+        for req in draft_batch.generation_requests:
+            req.py_is_first_draft = False
         draft_batch.generation_requests = draft_batch.context_requests + draft_batch.generation_requests
         draft_batch.context_requests = []
 

--- a/tensorrt_llm/_torch/utils.py
+++ b/tensorrt_llm/_torch/utils.py
@@ -302,3 +302,8 @@ def create_lm_head_tp_mapping(mapping: Mapping) -> Mapping:
         enable_attention_dp=mapping.enable_attention_dp,
         enable_lm_head_tp_in_adp=mapping.enable_lm_head_tp_in_adp,
     )
+
+
+# Development function to control chain drafter feature
+def _get_allow_chain_drafter() -> bool:
+    return True

--- a/tensorrt_llm/_torch/utils.py
+++ b/tensorrt_llm/_torch/utils.py
@@ -304,6 +304,7 @@ def create_lm_head_tp_mapping(mapping: Mapping) -> Mapping:
     )
 
 
-# Development function to control chain drafter feature
+# Development function to control chain drafter feature.
+# It's here so that unit tests can mock it and turn it off.
 def _get_allow_chain_drafter() -> bool:
     return True

--- a/tests/unittest/_torch/helpers.py
+++ b/tests/unittest/_torch/helpers.py
@@ -180,6 +180,15 @@ class MockEngine:
 
 def create_mock_engine(batch_size: int):
 
+    class MockSpecConfig:
+
+        class SpecDecMode:
+
+            def needs_kv_cache_recompute(self):
+                return False
+
+        spec_dec_mode = SpecDecMode()
+
     return MockEngine(
         pytorch_backend_config=MockPytorchBackendConfig(
             use_cuda_graph=True, cuda_graph_padding_enabled=False),
@@ -189,7 +198,8 @@ def create_mock_engine(batch_size: int):
         max_num_tokens=8192,
         is_spec_decode=False,
         enable_spec_decode=False,
-        spec_config=None,
+        spec_config=MockSpecConfig(),
+        is_draft_model=False,
         _cuda_graph_mem_pool=None,
         use_mrope=False,
     )

--- a/tests/unittest/_torch/modeling/test_modeling_exaone4.py
+++ b/tests/unittest/_torch/modeling/test_modeling_exaone4.py
@@ -355,7 +355,8 @@ class TestEXAONE4(unittest.TestCase):
                     "position_ids": position_ids,
                     "attn_metadata": attn_metadata,
                 }
-                graph_runner.capture(1,
+                key = (1, 0, False)
+                graph_runner.capture(key,
                                      lambda inputs: exaone4.forward(**inputs),
                                      inputs)
 
@@ -363,7 +364,7 @@ class TestEXAONE4(unittest.TestCase):
                     # Run it twice. This helps us catch problems if buffers are accidentally reallocated
                     # in prepare().
                     attn_metadata.prepare()
-                    logits = graph_runner.replay(1, inputs)
+                    logits = graph_runner.replay(key, inputs)
                 return logits
 
         if scenario.use_cuda_graph:

--- a/tests/unittest/_torch/modeling/test_modeling_llama.py
+++ b/tests/unittest/_torch/modeling/test_modeling_llama.py
@@ -343,13 +343,15 @@ class TestLlama(unittest.TestCase):
                     "position_ids": position_ids,
                     "attn_metadata": attn_metadata,
                 }
-                graph_runner.capture(1, lambda inputs: llama.forward(**inputs),
+                key = (1, 0, False)
+                graph_runner.capture(key,
+                                     lambda inputs: llama.forward(**inputs),
                                      inputs)
                 for _ in range(2):
                     # Run it twice. This helps us catch problems if buffers are accidentally reallocated
                     # in prepare().
                     attn_metadata.prepare()
-                    logits = graph_runner.replay(1, inputs)
+                    logits = graph_runner.replay(key, inputs)
                 return logits
 
         if scenario.use_cuda_graph:

--- a/tests/unittest/_torch/modeling/test_modeling_llama_min_latency.py
+++ b/tests/unittest/_torch/modeling/test_modeling_llama_min_latency.py
@@ -420,14 +420,16 @@ class TestLlama4MinLatency(unittest.TestCase):
                     "position_ids": position_ids,
                     "attn_metadata": attn_metadata,
                 }
-                graph_runner.capture(1, lambda inputs: llama.forward(**inputs),
+                key = (1, 0, False)
+                graph_runner.capture(key,
+                                     lambda inputs: llama.forward(**inputs),
                                      inputs)
 
                 for _ in range(2):
                     # Run it twice. This helps us catch problems if buffers are accidentally reallocated
                     # in prepare().
                     attn_metadata.prepare()
-                    logits = graph_runner.replay(1, inputs)
+                    logits = graph_runner.replay(key, inputs)
                 return logits
 
         if scenario.use_cuda_graph:

--- a/tests/unittest/_torch/modeling/test_modeling_mistral.py
+++ b/tests/unittest/_torch/modeling/test_modeling_mistral.py
@@ -421,13 +421,14 @@ def test_mistral_3_vlm_allclose_to_hf(mistral_small_3_1_24b_config, backend, use
                     "position_ids": position_ids,
                     "attn_metadata": attn_metadata,
                 }
-                graph_runner.capture(1, lambda inputs: mistral.forward(**inputs), inputs)
+                key = (1, 0, False)
+                graph_runner.capture(key, lambda inputs: mistral.forward(**inputs), inputs)
 
                 for _ in range(2):
                     # Run it twice. This helps us catch problems if buffers are accidentally reallocated
                     # in prepare().
                     attn_metadata.prepare()
-                    logits = graph_runner.replay(1, inputs)
+                    logits = graph_runner.replay(key, inputs)
                 return logits
 
         if use_cuda_graph:

--- a/tests/unittest/_torch/modeling/test_modeling_mixtral.py
+++ b/tests/unittest/_torch/modeling/test_modeling_mixtral.py
@@ -327,7 +327,8 @@ class TestMixtral(unittest.TestCase):
                     "position_ids": position_ids,
                     "attn_metadata": attn_metadata,
                 }
-                graph_runner.capture(1,
+                key = (1, 0, False)
+                graph_runner.capture(key,
                                      lambda inputs: mixtral.forward(**inputs),
                                      inputs)
 
@@ -335,7 +336,7 @@ class TestMixtral(unittest.TestCase):
                     # Run it twice. This helps us catch problems if buffers are accidentally reallocated
                     # in prepare().
                     attn_metadata.prepare()
-                    logits = graph_runner.replay(1, inputs)
+                    logits = graph_runner.replay(key, inputs)
                 return logits
 
         if scenario.use_cuda_graph:

--- a/tests/unittest/_torch/modeling/test_modeling_mllama.py
+++ b/tests/unittest/_torch/modeling/test_modeling_mllama.py
@@ -437,14 +437,16 @@ class TestMLlama(unittest.TestCase):
                     "position_ids": position_ids,
                     "attn_metadata": attn_metadata,
                 }
-                graph_runner.capture(1, lambda inputs: mllama.forward(**inputs),
+                key = (1, 0, False)
+                graph_runner.capture(key,
+                                     lambda inputs: mllama.forward(**inputs),
                                      inputs)
 
                 for _ in range(2):
                     # Run it twice. This helps us catch problems if buffers are accidentally reallocated
                     # in prepare().
                     attn_metadata.prepare()
-                    logits = graph_runner.replay(1, inputs)
+                    logits = graph_runner.replay(key, inputs)
                 return logits
 
         if scenario.use_cuda_graph:

--- a/tests/unittest/_torch/modeling/test_modeling_nemotron.py
+++ b/tests/unittest/_torch/modeling/test_modeling_nemotron.py
@@ -335,7 +335,8 @@ class TestNemotron(unittest.TestCase):
                     "position_ids": position_ids,
                     "attn_metadata": attn_metadata,
                 }
-                graph_runner.capture(1,
+                key = (1, 0, False)
+                graph_runner.capture(key,
                                      lambda inputs: nemotron.forward(**inputs),
                                      inputs)
 
@@ -343,7 +344,7 @@ class TestNemotron(unittest.TestCase):
                     # Run it twice. This helps us catch problems if buffers are accidentally reallocated
                     # in prepare().
                     attn_metadata.prepare()
-                    logits = graph_runner.replay(1, inputs)
+                    logits = graph_runner.replay(key, inputs)
                 return logits
 
         if scenario.use_cuda_graph:

--- a/tests/unittest/_torch/modeling/test_modeling_phi3.py
+++ b/tests/unittest/_torch/modeling/test_modeling_phi3.py
@@ -327,14 +327,15 @@ class TestPhi3(unittest.TestCase):
                     "position_ids": position_ids,
                     "attn_metadata": attn_metadata,
                 }
-                graph_runner.capture(1, lambda inputs: phi3.forward(**inputs),
+                key = (1, 0, False)
+                graph_runner.capture(key, lambda inputs: phi3.forward(**inputs),
                                      inputs)
 
                 for _ in range(2):
                     # Run it twice. This helps us catch problems if buffers are accidentally reallocated
                     # in prepare().
                     attn_metadata.prepare()
-                    logits = graph_runner.replay(1, inputs)
+                    logits = graph_runner.replay(key, inputs)
                 return logits
 
         if scenario.use_cuda_graph:

--- a/tests/unittest/_torch/modeling/test_modeling_qwen.py
+++ b/tests/unittest/_torch/modeling/test_modeling_qwen.py
@@ -282,14 +282,15 @@ class TestQwen(unittest.TestCase):
                     "position_ids": position_ids,
                     "attn_metadata": attn_metadata,
                 }
-                graph_runner.capture(1, lambda inputs: qwen.forward(**inputs),
+                key = (1, 0, False)
+                graph_runner.capture(key, lambda inputs: qwen.forward(**inputs),
                                      inputs)
 
                 for _ in range(2):
                     # Run it twice. This helps us catch problems if buffers are accidentally reallocated
                     # in prepare().
                     attn_metadata.prepare()
-                    logits = graph_runner.replay(1, inputs)
+                    logits = graph_runner.replay(key, inputs)
                 return logits
 
         if scenario.use_cuda_graph:

--- a/tests/unittest/_torch/modeling/test_modeling_qwen2_5vl.py
+++ b/tests/unittest/_torch/modeling/test_modeling_qwen2_5vl.py
@@ -498,8 +498,9 @@ class TestQwen2_5_VL(unittest.TestCase):
                     "attn_metadata": attn_metadata,
                     "multimodal_params": multimodal_params,
                 }
+                key = (1, 0, False)
                 graph_runner.capture(
-                    batch_size=1,
+                    key=key,
                     forward_fn=lambda inputs: qwen2_5_vl.forward(**inputs),
                     initial_inputs=inputs)
 
@@ -507,8 +508,7 @@ class TestQwen2_5_VL(unittest.TestCase):
                     # Run it twice. This helps us catch problems if buffers are accidentally reallocated
                     # in prepare().
                     attn_metadata.prepare()
-                    logits = graph_runner.replay(batch_size=1,
-                                                 current_inputs=inputs)
+                    logits = graph_runner.replay(key=key, current_inputs=inputs)
                 return logits
 
         if scenario.use_cuda_graph:

--- a/tests/unittest/_torch/modeling/test_modeling_qwen_moe.py
+++ b/tests/unittest/_torch/modeling/test_modeling_qwen_moe.py
@@ -332,7 +332,8 @@ class TestQwenMoe(unittest.TestCase):
                     "position_ids": position_ids,
                     "attn_metadata": attn_metadata,
                 }
-                graph_runner.capture(1,
+                key = (1, 0, False)
+                graph_runner.capture(key,
                                      lambda inputs: qwen_moe.forward(**inputs),
                                      inputs)
 
@@ -340,7 +341,7 @@ class TestQwenMoe(unittest.TestCase):
                     # Run it twice. This helps us catch problems if buffers are accidentally reallocated
                     # in prepare().
                     attn_metadata.prepare()
-                    logits = graph_runner.replay(1, inputs)
+                    logits = graph_runner.replay(key, inputs)
                 return logits
 
         if scenario.use_cuda_graph:

--- a/tests/unittest/_torch/speculative/test_eagle3.py
+++ b/tests/unittest/_torch/speculative/test_eagle3.py
@@ -26,6 +26,7 @@ def enforce_single_worker(monkeypatch):
 @pytest.mark.parametrize(
     "use_cuda_graph,attn_backend,disable_overlap_scheduler,enable_block_reuse,use_one_model,enable_chunked_prefill,use_chain_drafter,multi_batch",
     [
+<<<<<<< HEAD
         [True, "TRTLLM", True, False, False, False, True, False],
         [True, "TRTLLM", True, False, False, False, False, False],
         [False, "TRTLLM", True, False, False, False, True, False],
@@ -50,6 +51,29 @@ def enforce_single_worker(monkeypatch):
         [True, "TRTLLM", False, False, False, True, False, False],
         [True, "FLASHINFER", False, False, False, False, True, False],
         [False, "FLASHINFER", False, False, False, False, True, False],
+=======
+        [True, "TRTLLM", True, False, False, False, True],
+        # TODO: skip use_chain_drafter = False unitest and enable it when https://nvbugs/5517404 is fixed
+        # [True, "TRTLLM", True, False, False, False, False],
+        [False, "TRTLLM", True, False, False, False, True],
+        # [False, "TRTLLM", True, False, False, False, False],
+        [True, "FLASHINFER", True, False, False, False, True],
+        [False, "FLASHINFER", True, False, False, False, True],
+        [False, "TRTLLM", False, True, True, False, True],
+        [True, "TRTLLM", False, True, True, False, True],
+        [True, "TRTLLM", True, False, True, True, True],
+        [True, "TRTLLM", True, False, True, False, True],
+        # TODO: nvbugs/5461761
+        # [True, "TRTLLM", True, False, False, True, True],
+        [True, "TRTLLM", False, False, False, False, True],
+        [False, "TRTLLM", False, False, False, False, True],
+        # [True, "TRTLLM", False, False, False, False, False],
+        # [False, "TRTLLM", False, False, False, False, False],
+        [True, "TRTLLM", False, False, False, True, True],
+        # [True, "TRTLLM", False, False, False, True, False],
+        [True, "FLASHINFER", False, False, False, False, True],
+        [False, "FLASHINFER", False, False, False, False, True],
+>>>>>>> 702c2d53a (eagle3 cuda graph for the 1st draft model infer)
     ])
 @pytest.mark.high_cuda_memory
 def test_llama_eagle3(use_cuda_graph: bool, attn_backend: str,
@@ -70,6 +94,7 @@ def test_llama_eagle3(use_cuda_graph: bool, attn_backend: str,
     eagle_model_dir = f"{models_path}/EAGLE3-LLaMA3.1-Instruct-8B"
     target_model_dir = f"{models_path}/llama-3.1-model/Llama-3.1-8B-Instruct"
 
+<<<<<<< HEAD
     # Mock _get_allow_chain_drafter to return False when use_chain_drafter is False
     if not use_chain_drafter:
         patch_context = patch(
@@ -79,6 +104,16 @@ def test_llama_eagle3(use_cuda_graph: bool, attn_backend: str,
         patch_context = patch(
             'tensorrt_llm._torch.pyexecutor.py_executor_creator._get_allow_chain_drafter',
             return_value=True)
+=======
+    # bs > 1 gives non-deterministic when doing IFB. There are slight chances
+    # that ref and spec does not match 100%
+    max_batch_size = 2
+    max_draft_len = 4
+    kv_cache_config = KvCacheConfig(enable_block_reuse=enable_block_reuse,
+                                    max_tokens=8192)
+    cuda_graph_config = CudaGraphConfig(
+        batch_sizes=[1]) if use_cuda_graph else None
+>>>>>>> 702c2d53a (eagle3 cuda graph for the 1st draft model infer)
 
     with patch_context:
         # bs > 1 gives non-deterministic when doing IFB. There are slight chances
@@ -124,28 +159,32 @@ def test_llama_eagle3(use_cuda_graph: bool, attn_backend: str,
             prompts = [
                 "The capital of France is a city of romance, art, fashion, and cuisine. Paris is a must-visit destination for anyone who loves history, architecture, and culture. From the iconic Eiffel Tower to the world-famous Louvre Museum, Paris has something to offer for every interest and age.\nThe city is divided into 20 arrondissements, each with its own unique character and charm. The Latin Quarter is a popular area for students and young travelers, while the Champs-Élysées is a hub for shopping and dining. The Montmartre neighborhood is famous for its bohemian vibe and stunning views of the city.\nParis is also known for its beautiful parks and gardens, such as the Luxembourg Gardens and the Tuileries Garden. The city has a rich history, with landmarks like the Notre-Dame Cathedral and the Arc de Triomphe. Visitors can also explore the city's many museums, including the Musée d'Orsay and the Musée Rodin.\nIn addition to its cultural and historical attractions, Paris is also a great destination for foodies. The city is famous for its cuisine, including croissants, baguettes, and cheese. Visitors can sample the city's famous dishes at one of the many restaurants, cafes, and "
             ]
-            tok_ids = llm_spec.tokenizer.encode(prompts[0])
+            tok_ids = [llm_spec.tokenizer.encode(prompts[0])]
         else:
             prompts = [
                 "The capital of France is",
                 "The president of the United States is",
             ]
-            tok_ids = llm_spec.tokenizer.encode("The future of AI is")
+            tok_ids = [
+                llm_spec.tokenizer.encode("The future of AI is"),
+                llm_spec.tokenizer.encode(prompts)
+            ]
 
-        num_tokens = 0
-        num_drafted = 0
-        num_accepted = 0
         sampling_params = SamplingParams(max_tokens=128, temperature=0)
-        for output in llm_spec.generate_async(tok_ids,
-                                              sampling_params,
-                                              streaming=True):
-            new_tokens = output.outputs[0].token_ids
-            num_drafted += max_draft_len
-            num_accepted += len(new_tokens) - num_tokens - 1
-            num_tokens = len(new_tokens)
+        for i in range(len(tok_ids)):
+            num_tokens = 0
+            num_drafted = 0
+            num_accepted = 0
+            for output in llm_spec.generate_async(tok_ids[i],
+                                                  sampling_params,
+                                                  streaming=True):
+                new_tokens = output.outputs[0].token_ids
+                num_drafted += max_draft_len
+                num_accepted += len(new_tokens) - num_tokens - 1
+                num_tokens = len(new_tokens)
 
-        accept_rate = num_accepted / num_drafted
-        assert accept_rate > 0.15
+            accept_rate = num_accepted / num_drafted
+            assert accept_rate > 0.15
 
         # Output tests
         sampling_params = SamplingParams(max_tokens=10, temperature=0)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - First-draft support in speculative decoding with resource-manager awareness (Eagle3-compatible).
  - Requests can be marked as first-draft to affect drafting behavior and token handling.
  - CUDA graph flow now returns and uses a richer graph key to distinguish batch/draft scenarios.

- **Refactor**
  - Preserves original draft lengths for correct token budgeting and warmup coverage.
  - Unified draft generation path and simplified forward flow (no special gating for CUDA graphs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
