### PR TITLE
[None][feat] wide_ep support block-wise FP8 on blackwell

### DIFF
--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_wide_ep.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_wide_ep.py
@@ -5,8 +5,9 @@ from typing import Dict, List, Optional, Tuple, Union
 import torch
 
 from tensorrt_llm._mnnvl_utils import MnnvlMemory, MnnvlMoe, MoEAlltoallInfo
-from tensorrt_llm._utils import logger
+from tensorrt_llm._utils import get_sm_version
 from tensorrt_llm.functional import AllReduceStrategy
+from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 
 from ...distributed import AllReduce, allgather, reducescatter
@@ -15,8 +16,10 @@ from ...model_config import ModelConfig
 from ...utils import AuxStreamType, EventType, Fp4QuantizedTensor
 from .deep_ep_utils import buffer_pool, deep_ep_installed
 from .interface import MoE
+from .moe_backend import MoEBackend, MoEBackendSelection
 from .moe_load_balancer import get_moe_load_balancer
 from .quantization import (DeepSeekFP8BlockScalesFusedMoEMethod,
+                           DeepSeekFP8BlockScalesFusedMoEMethodDeepGemm,
                            FP8QDQFusedMoEMethod, MoEWeightLoadingMode,
                            NVFP4CutlassFusedMoEMethod,
                            UnquantizedFusedMoEMethod, WInt4AFP8FusedMoEMethod)
@@ -89,6 +92,9 @@ class WideEPMoE(MoE):
         # If True, the router weight will be multiplied on the input rather than at the end of FC2
         self.apply_router_weight_on_input = apply_router_weight_on_input
         self.layer_idx = layer_idx
+
+        # Store original hidden size before any potential padding
+        self.unpadded_hidden_size = self.hidden_size
 
         moe_load_balancer = get_moe_load_balancer()
         self.layer_load_balancer = None
@@ -227,6 +233,9 @@ class WideEPMoE(MoE):
         self.enable_dummy_allreduce = os.environ.get(
             "TRTLLM_ENABLE_DUMMY_ALLREDUCE", "0") == "1"
 
+        # MoE backend will be lazily initialized when first accessed (see moe_backend property)
+        self._moe_backend_impl = None
+
     def _check_configs(self):
         assert self._weights_created
 
@@ -316,7 +325,10 @@ class WideEPMoE(MoE):
             if self.quant_config.layer_quant_mode.has_fp8_qdq():
                 return FP8QDQFusedMoEMethod()
             elif self.quant_config.layer_quant_mode.has_fp8_block_scales():
-                return DeepSeekFP8BlockScalesFusedMoEMethod()
+                if get_sm_version() == 100:
+                    return DeepSeekFP8BlockScalesFusedMoEMethodDeepGemm()
+                else:
+                    return DeepSeekFP8BlockScalesFusedMoEMethod()
             elif self.quant_config.layer_quant_mode.has_nvfp4():
                 return NVFP4CutlassFusedMoEMethod()
             elif self.quant_config.layer_quant_mode.is_int4_weight_only_per_group(
@@ -338,6 +350,19 @@ class WideEPMoE(MoE):
 
         self._weights_created = True
         self._check_configs()
+
+    @property
+    def moe_backend_impl(self) -> MoEBackend:
+        """
+        Lazily initialize and return the MoE backend.
+
+        The backend is selected based on hardware capabilities and quantization
+        configuration, which are only available after weights are created.
+        """
+        if self._moe_backend_impl is None:
+            assert self._weights_created, "Weights must be created before accessing moe_backend"
+            self._moe_backend_impl = MoEBackendSelection.select_backend(self)
+        return self._moe_backend_impl
 
     def dummy_allreduce(self):
         """
@@ -389,8 +414,6 @@ class WideEPMoE(MoE):
         if self.layer_load_balancer and is_first_call:
             self.layer_load_balancer.start_wait_gpu_stage()
 
-        use_deepseek_fp8_block_scale = False
-        use_w4_group_scaling = False
         weight_dtype = self.w3_w1_weight.dtype
 
         token_selected_experts, token_final_scales = self.routing_method.apply(
@@ -544,9 +567,8 @@ class WideEPMoE(MoE):
                     x_sf = x_sf.view((x_row, -1))
 
             elif self.has_deepseek_fp8_block_scales:
-                use_deepseek_fp8_block_scale = True
+                pass
             elif self.has_w4afp8:
-                use_w4_group_scaling = True
                 weight_dtype = torch.quint4x2
             else:
                 raise ValueError(
@@ -569,12 +591,8 @@ class WideEPMoE(MoE):
                 sizes=None if use_dp_padding else all_rank_num_tokens)
             x_row = x.shape[0]
 
-        ep_size = self.ep_size
-        ep_rank = self.ep_rank
         w3_w1_weight = self.w3_w1_weight
         w2_weight = self.w2_weight
-        cluster_size = self.cluster_size
-        cluster_rank = self.cluster_rank
         quant_scales = self.quant_scales
 
         if self.alltoall_method_type == AlltoallMethodType.MNNVL:
@@ -640,7 +658,8 @@ class WideEPMoE(MoE):
                     f"Not available alltoall method type: {self.alltoall_method_type!r}"
                 )
 
-        final_hidden_states = torch.ops.trtllm.fused_moe(
+        final_hidden_states = self.moe_backend_impl.run_moe(
+            self,
             x,
             token_selected_slots,
             token_final_scales,
@@ -652,17 +671,8 @@ class WideEPMoE(MoE):
             quant_scales=quant_scales,
             input_sf=x_sf,
             swizzled_input_sf=False,
-            tp_size=self.tp_size,
-            tp_rank=self.tp_rank,
-            ep_size=ep_size,
-            ep_rank=ep_rank,
-            cluster_size=cluster_size,
-            cluster_rank=cluster_rank,
-            enable_alltoall=use_all_to_all,
-            use_deepseek_fp8_block_scale=use_deepseek_fp8_block_scale,
-            use_w4_group_scaling=use_w4_group_scaling,
             min_latency_mode=False,
-            tune_max_num_tokens=self.tune_max_num_tokens,
+            use_fused_finalize=True,
             tuner_num_tokens=tuner_num_tokens,
             tuner_top_k=tuner_top_k,
         )

--- a/tensorrt_llm/_torch/modules/fused_moe/moe_backend.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/moe_backend.py
@@ -1,0 +1,791 @@
+"""
+MoE Backend abstraction for supporting different MoE computation implementations.
+This module provides a unified interface for different MoE backends (Cutlass, DeepGemm, etc.)
+"""
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Dict, List, Optional
+
+import torch
+
+from tensorrt_llm._utils import get_sm_version
+
+if TYPE_CHECKING:
+    from .interface import MoE
+
+
+class MoEBackend(ABC):
+    """Abstract base class for MoE computation backends.
+
+    This class provides a strategy pattern for different MoE computation implementations.
+    It is used by MoE modules (like WideEPMoE) to delegate the actual computation.
+
+    Note: MoEBackend is NOT a MoE module itself, but a computation strategy.
+    The actual MoE module (e.g., WideEPMoE) inherits from MoE and uses MoEBackend
+    for the computation implementation.
+    """
+
+    # Backend-specific abstract methods
+    @abstractmethod
+    def finalize_tactic(
+        self,
+        module: 'MoE',
+        tuner_input: torch.Tensor,
+        output_dtype: torch.dtype,
+        min_latency_mode: bool = False,
+        use_fused_finalize: bool = True,
+        tuner_top_k: Optional[int] = None,
+    ) -> None:
+        """
+        Finalize tactics for the MoE computation.
+        For Cutlass backend, this includes profiling and tactic selection.
+        For DeepGemm backend, this can be a no-op.
+
+        Args:
+            module: The MoE module containing MoE configurations
+            tuner_input: Real input used for tuning (same shape/layout as non-alltoall)
+            output_dtype: Output dtype for tuner run
+            min_latency_mode: Whether to profile for min-latency path
+            use_fused_finalize: Whether to use fused finalize
+            tuner_top_k: Top-k value for tuning (Cutlass specific)
+        """
+
+    @abstractmethod
+    def compute_moe(
+            self,
+            module: 'MoE',
+            # Input tensors
+            x: torch.Tensor,
+            token_selected_slots: torch.Tensor,
+            token_final_scales: Optional[torch.Tensor],
+            # Weight tensors
+            w3_w1_weight: torch.Tensor,
+            w3_w1_bias: Optional[torch.Tensor],
+            w2_weight: torch.Tensor,
+            w2_bias: Optional[torch.Tensor],
+            # Output configuration
+            output_dtype: torch.dtype,
+            # Quantization parameters
+            quant_scales: List[torch.Tensor],
+            input_sf: Optional[torch.Tensor] = None,
+            swizzled_input_sf: bool = True,
+            # Performance tuning (only runtime-variable parameters)
+            min_latency_mode: bool = False,
+            use_fused_finalize: bool = True,
+            tuner_num_tokens: Optional[int] = None,
+            tuner_top_k: Optional[int] = None,
+            **kwargs) -> torch.Tensor:
+        """
+        Perform the actual MoE computation.
+
+        Configuration parameters (tp_size, ep_size, swiglu params, etc.) are
+        automatically extracted from the module parameter.
+
+        Args:
+            module: MoE module containing configuration and parameters.
+                   The following will be extracted:
+                   - tp_size, tp_rank, ep_size, ep_rank, cluster_size, cluster_rank
+                   - enable_alltoall, tune_max_num_tokens
+                   - swiglu_alpha, swiglu_beta, swiglu_limit
+                   - Quantization flags based on module properties
+            x: Input tensor
+            token_selected_slots: Selected expert slots
+            token_final_scales: Scaling factors
+            w3_w1_weight: Fused gate and up projection weights
+            w3_w1_bias: Optional bias
+            w2_weight: Down projection weights
+            w2_bias: Optional bias
+            output_dtype: Output data type
+            quant_scales: Quantization scales
+            input_sf: Input scaling factor
+            swizzled_input_sf: Whether input_sf is swizzled
+            min_latency_mode: Use minimum latency optimizations
+            use_fused_finalize: Use fused finalization
+            tuner_num_tokens: Number of tokens for tuning
+            tuner_top_k: Top-k value for tuning
+
+        Returns:
+            Computed MoE output tensor
+        """
+
+    def run_moe(
+            self,
+            module: 'MoE',
+            # Input tensors
+            input: torch.Tensor,
+            token_selected_slots: torch.Tensor,
+            token_final_scales: torch.Tensor,
+            w3_w1_weight: torch.Tensor,
+            w3_w1_bias: Optional[torch.Tensor],
+            w2_weight: torch.Tensor,
+            w2_bias: Optional[torch.Tensor],
+            output_dtype: torch.dtype,
+            # Quantization parameters
+            quant_scales: List[torch.Tensor],
+            input_sf: Optional[torch.Tensor] = None,
+            swizzled_input_sf: bool = True,
+            # Performance tuning (only runtime-variable parameters)
+            min_latency_mode: bool = False,
+            use_fused_finalize: bool = True,
+            tuner_num_tokens: Optional[int] = None,
+            tuner_top_k: Optional[int] = None,
+            **kwargs) -> torch.Tensor:
+        """
+        Run the complete MoE computation pipeline.
+
+        Configuration parameters are automatically extracted from the module.
+
+        Args:
+            module: MoE module containing configuration
+            input: Input tensor to the MoE layer
+            token_selected_slots: Selected expert slots for each token
+            token_final_scales: Final scaling factors for each token
+            w3_w1_weight: Concatenated weights for w3 and w1 projections
+            w3_w1_bias: Optional bias for w3/w1 projections
+            w2_weight: Weight for w2 projection
+            w2_bias: Optional bias for w2 projection
+            output_dtype: Desired output data type
+            quant_scales: Quantization scales for weights
+            input_sf: Optional input scale factors for quantization
+            swizzled_input_sf: Whether input scale factors are swizzled
+            min_latency_mode: Use minimum latency optimizations
+            use_fused_finalize: Use fused finalization
+            tuner_num_tokens: Number of tokens for tuner input
+            tuner_top_k: Top-k value for tuning
+
+        Returns:
+            Computed MoE output tensor
+        """
+        self.finalize_tactic(module, input, output_dtype, min_latency_mode,
+                             use_fused_finalize, tuner_top_k)
+
+        # Call compute_moe with module
+        return self.compute_moe(module=module,
+                                x=input,
+                                token_selected_slots=token_selected_slots,
+                                token_final_scales=token_final_scales,
+                                w3_w1_weight=w3_w1_weight,
+                                w3_w1_bias=w3_w1_bias,
+                                w2_weight=w2_weight,
+                                w2_bias=w2_bias,
+                                output_dtype=output_dtype,
+                                quant_scales=quant_scales,
+                                input_sf=input_sf,
+                                swizzled_input_sf=swizzled_input_sf,
+                                min_latency_mode=min_latency_mode,
+                                use_fused_finalize=use_fused_finalize,
+                                tuner_num_tokens=tuner_num_tokens,
+                                tuner_top_k=tuner_top_k,
+                                **kwargs)
+
+
+class MoECutlassBackend(MoEBackend):
+    """Cutlass-based MoE backend using torch.ops.trtllm.fused_moe."""
+
+    def __init__(self):
+        """Initialize the Cutlass backend."""
+        super().__init__()
+        self.moe_runner = None
+        self.gemm_tactics = None
+
+    def finalize_tactic(
+        self,
+        module: 'MoE',
+        tuner_input: torch.Tensor,
+        output_dtype: torch.dtype,
+        min_latency_mode: bool = False,
+        use_fused_finalize: bool = True,
+        tuner_top_k: Optional[int] = None,
+    ) -> None:
+        """
+        Finalize tactics for Cutlass MoE by profiling and selecting optimal GEMM tactics.
+        """
+
+        # Import necessary modules for profiling
+        from ...custom_ops.torch_custom_ops import AutoTuner, MoERunner
+
+        # Use real tuner_input rather than dummy input
+        assert tuner_input is not None, "tuner_input must be provided to finalize_tactic"
+        if tuner_top_k is None:
+            tuner_top_k = getattr(module.routing_method, 'experts_per_token', 1)
+
+        # Determine view dtype for weights to match runtime quantization layout
+        weight_view_dtype = module.w3_w1_weight.dtype
+        if getattr(module, 'has_w4afp8', False):
+            weight_view_dtype = torch.quint4x2
+        elif getattr(module, 'has_w4a16_mxfp4', False):
+            weight_view_dtype = torch.uint8
+
+        # Create MoERunner for profiling
+        if self.moe_runner is None:
+            self.moe_runner = MoERunner(
+                x_dtype=tuner_input.dtype,
+                weight_dtype=module.w3_w1_weight.dtype,
+                output_dtype=output_dtype,
+                top_k=tuner_top_k,
+                tp_size=module.tp_size,
+                tp_rank=module.tp_rank,
+                ep_size=module.ep_size,
+                ep_rank=module.ep_rank,
+                cluster_size=module.cluster_size,
+                cluster_rank=module.cluster_rank,
+                use_deepseek_fp8_block_scale=getattr(
+                    module, 'has_deepseek_fp8_block_scales', False),
+                use_w4_group_scaling=getattr(module, 'has_w4afp8', False),
+                use_int8_woq_per_channel=getattr(module,
+                                                 'has_int8_woq_per_channel',
+                                                 False),
+                use_mxfp8_act_scaling=getattr(module, 'has_mxfp8_act_scaling',
+                                              False),
+                min_latency_mode=min_latency_mode,
+                use_fused_finalize=use_fused_finalize,
+            )
+
+        # Set tuning configuration
+        MoERunner.tuning_config.tune_max_num_tokens = getattr(
+            module, 'tune_max_num_tokens', 8192)
+
+        # Get AutoTuner for tactic selection
+        tuner = AutoTuner.get()
+
+        # Profile and select tactics (GEMM1)
+        _, gemm_tactic_1 = tuner.choose_one(
+            "trtllm::fused_moe::gemm1",
+            [self.moe_runner],
+            MoERunner.tuning_config,
+            [
+                tuner_input,
+                module.w3_w1_weight.view(weight_view_dtype),
+                getattr(module, 'w3_w1_bias', None),
+                module.w2_weight.view(weight_view_dtype),
+                getattr(module, 'w2_bias', None),
+            ],
+            gemm_idx=1,
+        )
+
+        # Profile and select tactics (GEMM2)
+        _, gemm_tactic_2 = tuner.choose_one(
+            "trtllm::fused_moe::gemm2",
+            [self.moe_runner],
+            MoERunner.tuning_config,
+            [
+                tuner_input,
+                module.w3_w1_weight.view(weight_view_dtype),
+                getattr(module, 'w3_w1_bias', None),
+                module.w2_weight.view(weight_view_dtype),
+                getattr(module, 'w2_bias', None),
+            ],
+            gemm_idx=2,
+        )
+
+        # Store selected tactics
+        self.gemm_tactics = [gemm_tactic_1, gemm_tactic_2]
+
+    def compute_moe(
+            self,
+            module: 'MoE',  # Now required as first parameter
+            # Input tensors
+        x: torch.Tensor,
+            token_selected_slots: torch.Tensor,
+            token_final_scales: Optional[torch.Tensor],
+            # Weight tensors
+            w3_w1_weight: torch.Tensor,
+            w3_w1_bias: Optional[torch.Tensor],
+            w2_weight: torch.Tensor,
+            w2_bias: Optional[torch.Tensor],
+            # Output configuration
+            output_dtype: torch.dtype,
+            # Quantization parameters
+            quant_scales: List[torch.Tensor],
+            input_sf: Optional[torch.Tensor] = None,
+            swizzled_input_sf: bool = True,
+            # Performance tuning (only runtime-variable parameters)
+            min_latency_mode: bool = False,
+            use_fused_finalize: bool = True,
+            tuner_num_tokens: Optional[int] = None,
+            tuner_top_k: Optional[int] = None,
+            **kwargs) -> torch.Tensor:
+        """
+        Compute MoE using Cutlass backend with MoERunner.
+        """
+        # Extract parameters from module
+        tp_size = module.tp_size
+        tp_rank = module.tp_rank
+        ep_size = module.ep_size
+        ep_rank = module.ep_rank
+        cluster_size = module.cluster_size
+        cluster_rank = module.cluster_rank
+        enable_alltoall = module.enable_alltoall
+        getattr(module, 'tune_max_num_tokens', 8192)
+        swiglu_alpha = module.swiglu_alpha
+        swiglu_beta = module.swiglu_beta
+        swiglu_limit = module.swiglu_limit
+        use_w4_group_scaling = getattr(module, 'has_w4afp8', False)
+
+        # Determine weight dtype for view operation if needed
+        weight_dtype = w3_w1_weight.dtype
+        if use_w4_group_scaling and weight_dtype != torch.quint4x2:
+            weight_dtype = torch.quint4x2
+
+        # Validate that tactics have been finalized
+        if self.gemm_tactics is None or len(self.gemm_tactics) == 0:
+            raise RuntimeError(
+                "GEMM tactics have not been finalized. "
+                "Call finalize_tactic() before compute_moe() or use run_moe() instead."
+            )
+
+        if self.moe_runner is None:
+            raise RuntimeError(
+                "MoERunner has not been initialized. "
+                "Call finalize_tactic() before compute_moe() or use run_moe() instead."
+            )
+
+        # Select the appropriate run method based on latency mode
+        run_moe = self.moe_runner.fused_moe_runner.run_moe_min_latency if min_latency_mode else self.moe_runner.fused_moe_runner.run_moe
+
+        # Run the actual MoE computation
+        output = run_moe(
+            x,
+            token_selected_slots,
+            token_final_scales,
+            w3_w1_weight.view(weight_dtype),
+            w3_w1_bias,
+            w2_weight.view(weight_dtype),
+            w2_bias,
+            quant_scales,
+            input_sf,
+            swizzled_input_sf,
+            swiglu_alpha,
+            swiglu_beta,
+            swiglu_limit,
+            tp_size,
+            tp_rank,
+            ep_size,
+            ep_rank,
+            cluster_size,
+            cluster_rank,
+            enable_alltoall,
+            min_latency_mode,
+            self.gemm_tactics,
+        )
+
+        # Return output based on latency mode
+        return output if min_latency_mode else [output]
+
+    def run_moe(
+            self,
+            module: 'MoE',
+            # Input tensors
+            input: torch.Tensor,
+            token_selected_slots: torch.Tensor,
+            token_final_scales: torch.Tensor,
+            w3_w1_weight: torch.Tensor,
+            w3_w1_bias: Optional[torch.Tensor],
+            w2_weight: torch.Tensor,
+            w2_bias: Optional[torch.Tensor],
+            output_dtype: torch.dtype,
+            # Quantization parameters
+            quant_scales: List[torch.Tensor],
+            input_sf: Optional[torch.Tensor] = None,
+            swizzled_input_sf: bool = True,
+            # Performance tuning (only runtime-variable parameters)
+            min_latency_mode: bool = False,
+            use_fused_finalize: bool = True,
+            tuner_num_tokens: Optional[int] = None,
+            tuner_top_k: Optional[int] = None,
+            **kwargs) -> torch.Tensor:
+        """
+        Run the complete MoE computation pipeline for Cutlass backend.
+
+        This override handles the specific tuner_input logic needed for Cutlass.
+
+        Args:
+            module: MoE module containing configuration
+            input: Input tensor to the MoE layer
+            token_selected_slots: Selected expert slots for each token
+            token_final_scales: Final scaling factors for each token
+            w3_w1_weight: Concatenated weights for w3 and w1 projections
+            w3_w1_bias: Optional bias for w3/w1 projections
+            w2_weight: Weight for w2 projection
+            w2_bias: Optional bias for w2 projection
+            output_dtype: Desired output data type
+            quant_scales: Quantization scales for weights
+            input_sf: Optional input scale factors for quantization
+            swizzled_input_sf: Whether input scale factors are swizzled
+            min_latency_mode: Use minimum latency optimizations
+            use_fused_finalize: Use fused finalization
+            tuner_num_tokens: Number of tokens for tuner input
+            tuner_top_k: Top-k value for tuning
+
+        Returns:
+            Computed MoE output tensor
+        """
+        # Extract enable_alltoall from module to determine tuner_input logic
+        enable_alltoall = module.enable_alltoall
+
+        # Compute tuner_input per fused_moe logic
+        if enable_alltoall:
+            assert tuner_num_tokens is not None
+            assert tuner_top_k is not None
+            tuner_input = input[:tuner_num_tokens]
+        else:
+            assert tuner_num_tokens is None
+            assert tuner_top_k is None
+            tuner_input = input
+            tuner_top_k = token_selected_slots.size(1)
+
+        self.finalize_tactic(module, tuner_input, output_dtype,
+                             min_latency_mode, use_fused_finalize, tuner_top_k)
+
+        # Call compute_moe with module
+        return self.compute_moe(module=module,
+                                x=input,
+                                token_selected_slots=token_selected_slots,
+                                token_final_scales=token_final_scales,
+                                w3_w1_weight=w3_w1_weight,
+                                w3_w1_bias=w3_w1_bias,
+                                w2_weight=w2_weight,
+                                w2_bias=w2_bias,
+                                output_dtype=output_dtype,
+                                quant_scales=quant_scales,
+                                input_sf=input_sf,
+                                swizzled_input_sf=swizzled_input_sf,
+                                min_latency_mode=min_latency_mode,
+                                use_fused_finalize=use_fused_finalize,
+                                tuner_num_tokens=tuner_num_tokens,
+                                tuner_top_k=tuner_top_k,
+                                **kwargs)
+
+
+class MoEDeepGemmBackend(MoEBackend):
+    """DeepGemm-based MoE backend for GB200 block FP8."""
+
+    def __init__(self):
+        """Initialize DeepGemm backend."""
+        super().__init__()
+        import tensorrt_llm.quantization.utils.fp8_utils as fp8_utils
+        self.fp8_utils = fp8_utils
+
+        from .fused_moe_deepgemm import deepgemm_fp8_group_blockwise_gemm
+        self.deepgemm_fp8_group_blockwise_gemm = deepgemm_fp8_group_blockwise_gemm
+
+    def finalize_tactic(
+        self,
+        module: 'MoE',
+        tuner_input: torch.Tensor,
+        output_dtype: torch.dtype,
+        min_latency_mode: bool = False,
+        use_fused_finalize: bool = True,
+        tuner_top_k: Optional[int] = None,
+    ) -> None:
+        """
+        No-op for DeepGemm backend as it doesn't require tactic profiling.
+
+        Args:
+            module: The MoE module
+            tuner_input: Input tensor for tuning
+            output_dtype: Output dtype
+            min_latency_mode: Whether to use min-latency mode
+            use_fused_finalize: Whether to use fused finalize
+            tuner_top_k: Top-k value for tuning
+        """
+
+    def _get_deepgemm_workspace(self, module: 'MoE', m_max: int,
+                                group_size: int) -> Dict[str, torch.Tensor]:
+        """
+        Get workspace for DeepGemm backend operations.
+
+        Args:
+            module: The MoE module containing configuration
+            m_max: Maximum number of tokens (aligned)
+            group_size: Group size for quantization
+
+        Returns:
+            Dictionary containing workspace tensors
+        """
+        import tensorrt_llm.quantization.utils.fp8_utils as fp8_utils
+
+        # Get dimensions from module
+        hidden_size = module.hidden_size
+        intermediate_size = module.intermediate_size
+        expert_size_per_partition = module.expert_size_per_partition
+
+        # Calculate aligned dimensions
+        m_padded = fp8_utils.align(m_max, 4)
+        fp8_dim = max(hidden_size, intermediate_size)
+        scale_k = fp8_utils.ceil_div(fp8_dim, group_size)
+        scale_k_padded = fp8_utils.align(scale_k, 4)
+
+        # Allocate workspace tensors
+        workspace = {}
+
+        # Workspace for FP8 activations
+        workspace["workspace_0"] = torch.empty(
+            (expert_size_per_partition * m_max * fp8_dim),
+            dtype=torch.float8_e4m3fn,
+            device='cuda')
+
+        # Workspace for intermediate results
+        workspace["workspace_1"] = torch.empty(
+            (expert_size_per_partition * m_max *
+             max(intermediate_size * 2, hidden_size)),
+            dtype=torch.bfloat16,
+            device='cuda')
+
+        # Workspace for scaling factors
+        workspace["workspace_sf"] = torch.empty(
+            expert_size_per_partition * (scale_k_padded // 4) * m_padded,
+            dtype=torch.int32,
+            device='cuda')
+
+        return workspace
+
+    def compute_moe(
+            self,
+            module: 'MoE',
+            # Input tensors
+            x: torch.Tensor,
+            token_selected_slots: torch.Tensor,
+            token_final_scales: Optional[torch.Tensor],
+            # Weight tensors
+            w3_w1_weight: torch.Tensor,
+            w3_w1_bias: Optional[torch.Tensor],
+            w2_weight: torch.Tensor,
+            w2_bias: Optional[torch.Tensor],
+            # Output configuration
+            output_dtype: torch.dtype,
+            # Quantization parameters
+            quant_scales: List[torch.Tensor],
+            input_sf: Optional[torch.Tensor] = None,
+            swizzled_input_sf: bool = True,
+            # Performance tuning (only runtime-variable parameters)
+            min_latency_mode: bool = False,
+            use_fused_finalize: bool = True,
+            tuner_num_tokens: Optional[int] = None,
+            tuner_top_k: Optional[int] = None,
+            **kwargs) -> torch.Tensor:
+        """
+        Compute MoE using DeepGemm backend with block FP8 quantization.
+
+        Note: This assumes the data has already been gathered/alltoall'd
+        by the WideEP forward_chunk method.
+        """
+
+        # Import necessary functions for DeepGemm
+        from .fused_moe_deepgemm import (masked_index_copy_group_quant_fp8,
+                                         preprocess_after_permute, set_strides,
+                                         triton_masked_index_gather)
+
+        # Extract parameters from module
+        tp_size = module.tp_size
+        tp_rank = module.tp_rank
+        ep_size = module.ep_size
+        ep_rank = module.ep_rank
+        cluster_size = module.cluster_size
+        cluster_rank = module.cluster_rank
+        enable_alltoall = module.enable_alltoall
+        getattr(module, 'tune_max_num_tokens', 8192)
+        module.swiglu_alpha
+        module.swiglu_beta
+        module.swiglu_limit
+
+        # Not supported: min_latency_mode. Raise error if enabled.
+        if min_latency_mode:
+            raise NotImplementedError(
+                "DeepGemm backend does not support min_latency_mode=True")
+
+        # Get expert configuration from module
+        expert_size_per_partition = module.expert_size_per_partition
+        intermediate_size = module.intermediate_size
+        hidden_size = x.shape[1]
+
+        # Permute the data for expert-parallel processing
+        (
+            permuted_row_to_unpermuted_row_tensor,
+            permuted_token_selected_experts_tensor,
+            permuted_data_tensor,
+            expert_first_token_offset_tensor,
+            permuted_token_final_scales_tensor,
+            unpermuted_row_to_permuted_row_tensor,
+        ) = torch.ops.trtllm.moe_permute_op(
+            x,
+            token_selected_slots,
+            token_final_scales,
+            None,  # w3_w1_weight
+            None,  # w2_weight
+            None,  # quant_scales
+            input_sf=input_sf,
+            num_experts_on_rank=expert_size_per_partition,
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            ep_size=ep_size,
+            ep_rank=ep_rank,
+            cluster_size=cluster_size,
+            cluster_rank=cluster_rank,
+            min_latency_mode=min_latency_mode,
+            use_fp8_block_scaling=True,  # Always use block scaling for DeepGemm
+        )
+
+        if permuted_data_tensor.numel() == 0:
+            return torch.zeros_like(x)
+
+        # Preprocess for masked operations
+        masked_m, token_to_expert_map = preprocess_after_permute(
+            expert_first_token_offset_tensor, permuted_data_tensor)
+
+        expected_m = (token_selected_slots.numel() + expert_size_per_partition -
+                      1) // expert_size_per_partition
+
+        # Get workspace for DeepGemm operations
+        m_max = self.fp8_utils.align(x.shape[0], 128)
+        workspace = self._get_deepgemm_workspace(module, m_max, 128)
+
+        # Padding and quantization for first GEMM input
+        m_padded = self.fp8_utils.align(m_max, 4)
+        scale_k = self.fp8_utils.ceil_div(hidden_size, 128)
+        scale_k_padded = self.fp8_utils.align(scale_k, 4)
+
+        act_input_fp8 = set_strides(workspace["workspace_0"],
+                                    expert_size_per_partition, m_max,
+                                    hidden_size)
+        act_input_sf = set_strides(workspace["workspace_sf"],
+                                   expert_size_per_partition,
+                                   scale_k_padded // 4, m_padded)
+
+        # Quantize and copy input with masking
+        act_input_sf = masked_index_copy_group_quant_fp8(
+            act_input_fp8,
+            act_input_sf,
+            permuted_data_tensor,
+            expert_first_token_offset_tensor,
+            token_to_expert_map,
+            group_size=128)
+
+        # First grouped GEMM (w3 and w1)
+        h1 = set_strides(workspace["workspace_1"], expert_size_per_partition,
+                         m_max, intermediate_size * 2)
+
+        self.deepgemm_fp8_group_blockwise_gemm(
+            d=h1,
+            a=act_input_fp8,
+            b=w3_w1_weight,
+            sfa=act_input_sf,
+            sfb=quant_scales[0] if quant_scales else None,
+            masked_m=masked_m,
+            expected_m=expected_m,
+        )
+
+        # SiLU activation and quantization for second GEMM
+        act_input_fp8 = set_strides(workspace["workspace_0"],
+                                    expert_size_per_partition, m_max,
+                                    intermediate_size)
+
+        scale_k = self.fp8_utils.ceil_div(intermediate_size, 128)
+        scale_k_padded = self.fp8_utils.align(scale_k, 4)
+        act_input_sf = set_strides(workspace["workspace_sf"],
+                                   expert_size_per_partition,
+                                   scale_k_padded // 4, m_padded)
+
+        act_input_sf = self.fp8_utils.silu_and_mul_masked_post_quant_fwd(
+            output=act_input_fp8,
+            output_scale=act_input_sf,
+            input=h1,
+            quant_group_size=128,
+            masked_m=masked_m,
+            scale_ue8m0=True)
+
+        # Second grouped GEMM (w2)
+        h3 = set_strides(workspace["workspace_1"], expert_size_per_partition,
+                         m_max, hidden_size)
+
+        self.deepgemm_fp8_group_blockwise_gemm(
+            d=h3,
+            a=act_input_fp8,
+            b=w2_weight,
+            sfa=act_input_sf,
+            sfb=quant_scales[1] if quant_scales else None,
+            masked_m=masked_m,
+            expected_m=expected_m,
+        )
+
+        # Gather results back to original token order
+        triton_masked_index_gather(permuted_data_tensor, h3,
+                                   expert_first_token_offset_tensor,
+                                   token_to_expert_map)
+
+        # Finalize and scale the output
+        # Get unpadded_hidden_size from module if available, otherwise use hidden_size
+        # For now it is the user's responsibility to set unpadded_hidden_size.
+        # DeepGemmFusedMoE and WideEPMoE both have unpadded_hidden_size.
+        unpadded_hidden_size = getattr(module, 'unpadded_hidden_size',
+                                       x.shape[1])
+
+        final_hidden_states = torch.ops.trtllm.moe_finalize_scale_op(
+            permuted_data_tensor,
+            None,  # biases (w2_bias could be added here if needed)
+            token_final_scales,
+            unpermuted_row_to_permuted_row_tensor,
+            permuted_row_to_unpermuted_row_tensor,
+            token_selected_slots,
+            expert_first_token_offset_tensor,
+            enable_alltoall,
+            x.shape[0],  # num_rows
+            x.shape[1],  # hidden_size
+            unpadded_hidden_size,  # unpadded_hidden_size (may be different from hidden_size if padding was applied)
+            module.routing_method.top_k if module else 1,  # experts_per_token
+            expert_size_per_partition,  # num_experts_per_node
+            tp_size,
+            tp_rank,
+            ep_size,
+            ep_rank,
+        )
+
+        return final_hidden_states if min_latency_mode else [
+            final_hidden_states
+        ]
+
+
+class MoEBackendSelection:
+    """
+    Utility class for selecting the appropriate MoE backend based on
+    hardware capabilities and quantization configuration.
+
+    This class implements the strategy pattern for backend selection,
+    choosing between Cutlass and DeepGemm implementations based on:
+    - Hardware capabilities (SM version)
+    - Quantization configuration (block FP8 support)
+    """
+
+    @staticmethod
+    def select_backend(module: 'MoE') -> MoEBackend:
+        """
+        Select the appropriate MoE backend based on module configuration.
+
+        Selection criteria:
+        - Blackwell (SM100) with block FP8 quantization -> DeepGemm backend
+        - All other configurations -> Cutlass backend
+
+        Args:
+            module: The MoE module containing configuration information
+                   Expected attributes:
+                   - has_deepseek_fp8_block_scales: Whether block FP8 is enabled
+
+        Returns:
+            MoEBackend: Selected backend instance (MoECutlassBackend or MoEDeepGemmBackend)
+
+        Example:
+            >>> backend = MoEBackendSelection.select_backend(moe_module)
+            >>> output = backend.run_moe(input, ...)
+        """
+        # Check if we should use DeepGemm backend
+        # Blackwell has SM version 100
+        is_blackwell = get_sm_version() == 100
+        has_block_fp8 = (hasattr(module, 'has_deepseek_fp8_block_scales')
+                         and module.has_deepseek_fp8_block_scales)
+
+        if is_blackwell and has_block_fp8:
+            # Use DeepGemm backend for Blackwell with block FP8
+            return MoEDeepGemmBackend()
+        else:
+            # Use Cutlass backend for all other cases
+            return MoECutlassBackend()


### PR DESCRIPTION
Signed-off-by: xxi <xxi@nvidia.com>

	modified:   tensorrt_llm/_torch/modules/fused_moe/fused_moe_wide_ep.py
	new file:   tensorrt_llm/_torch/modules/fused_moe/moe_backend.py
	modified:   tests/unittest/_torch/modules/test_fused_moe.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Introduces a pluggable MoE backend with automatic, hardware-aware selection.
  - Adds lazy backend initialization and preserves original (unpadded) hidden size per layer.
  - Exposes a public accessor to retrieve the selected backend.

- Performance
  - Optimizes FP8 blockwise quantization on next‑gen GPUs, with backend-dispatched execution and improved tuning controls.
  - Simplifies runtime flags while maintaining behavior across all-to-all modes.

- Tests
  - Adds an end-to-end test validating FP8 blockwise MoE outputs across different all-to-all configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
[None][feat] wide_ep support block-wise FP8 on blackwell

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Before this PR, the wide_ep could not support block-wise FP8 on Blackwell.
In this PR, the wide_ep will use MoEBackendSelection to choose the proper MoEBackend according to the heuristic.
For now:
If the model has block-wise FP8 quantization and run on Blackwell, it will choose MoEDeepGemmBackend,
Otherwise, choose the MoECutlassBackend.
-->

## Test Coverage

<!--
test_fused_moe_fp8_blockwise_wide_ep
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
