### PR TITLE
[#5860][autodeploy] GPT-OSS MXFP4 support V2: patch before export

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/__init__.py
@@ -6,6 +6,7 @@ from .flashinfer_attention import *
 from .flashinfer_rope import *
 from .linear import *
 from .mla import *
+from .mxfp4 import *
 from .quant import *
 from .rms_norm import *
 from .torch_attention import *

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mxfp4.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mxfp4.py
@@ -1,0 +1,158 @@
+import torch
+
+_triton_kernels_hub = None
+
+
+def _hub():
+    global _triton_kernels_hub
+    if _triton_kernels_hub is None:
+        from kernels import get_kernel
+
+        _triton_kernels_hub = get_kernel("kernels-community/triton_kernels")
+    return _triton_kernels_hub
+
+
+# copied from transformers.integrations.mxfp4::swizzle_mxfp4
+def _swizzle_mxfp4(w, w_scale):
+    triton_kernels_hub = _hub()
+
+    FP4, convert_layout, wrap_torch_tensor = (
+        triton_kernels_hub.tensor.FP4,
+        triton_kernels_hub.tensor.convert_layout,
+        triton_kernels_hub.tensor.wrap_torch_tensor,
+    )
+    layout = triton_kernels_hub.tensor_details.layout
+    StridedLayout = triton_kernels_hub.tensor_details.layout.StridedLayout
+
+    value_layout, value_layout_opts = layout.make_default_matmul_mxfp4_w_layout(mx_axis=1)
+    w = convert_layout(wrap_torch_tensor(w, dtype=FP4), value_layout, **value_layout_opts)
+    # TODO : add that when we are actually sure that it works on B200
+    # if torch.cuda.get_device_capability()[0] == 10:
+    #     constraints = {
+    #         "is_persistent": True,
+    #         "epilogue_subtile": 1,
+    #     }
+    #     opt_flags.update_opt_flags_constraints(constraints)
+    # # transpose the tensor so that the quantization axis is on dim1
+
+    # TODO: there is still an issue with the scales on hopper
+    # scale_layout, scale_layout_opts = layout.make_default_matmul_mxfp4_w_scale_layout(mx_axis=1, num_warps=8)
+    # w_scale = convert_layout(wrap_torch_tensor(w_scale), scale_layout, **scale_layout_opts)
+    w_scale = convert_layout(wrap_torch_tensor(w_scale), StridedLayout)
+    return w, w_scale
+
+
+@torch.library.custom_op("auto_deploy::mxfp4_mlp", mutates_args=())
+def mxfp4_mlp(
+    hidden_states: torch.Tensor,  # [B, S, H] or [T, H]
+    # router
+    router_weight: torch.Tensor,  # [E, H]
+    router_bias: torch.Tensor,  # [E]
+    top_k: int,
+    # gate_up path
+    gate_up_blocks: torch.Tensor,  # usually [E, 2I, H] or [E, H, 2I]
+    gate_up_bias: torch.Tensor,  # [E, 2I]
+    gate_up_scales: torch.Tensor,  # any broadcastable scale shape (raw)
+    alpha: float,
+    limit: float,
+    # down path
+    down_blocks: torch.Tensor,  # usually [E, I, H] or [E, H, I]
+    down_bias: torch.Tensor,  # [E, H]
+    down_scales: torch.Tensor,  # any broadcastable scale shape (raw)
+) -> torch.Tensor:
+    """
+    Wrapper that forwards to your Python reference implementation.
+    Return:
+      routed_out:   same leading shape as hidden_states, last dim = H
+      router_logits: [T, E] (T = number of tokens = prod(hidden_states.shape[:-1]))
+    """
+
+    hub = _hub()
+    routing = hub.routing.routing
+
+    batch_size = hidden_states.shape[0]
+    intermediate_size = gate_up_blocks.shape[1] // 2
+    hidden_size = hidden_states.shape[-1]
+    hidden_states = hidden_states.reshape(-1, hidden_size)
+    router_logits = torch.nn.functional.linear(hidden_states, router_weight, router_bias)
+
+    with torch.cuda.device(router_logits.device):
+        routing_data, gather_idx, scatter_idx = routing(router_logits, top_k)
+
+    FnSpecs, FusedActivation, matmul_ogs = (
+        hub.matmul_ogs.FnSpecs,
+        hub.matmul_ogs.FusedActivation,
+        hub.matmul_ogs.matmul_ogs,
+    )
+    FlexCtx, InFlexData, PrecisionConfig = (
+        hub.matmul_ogs.FlexCtx,
+        hub.matmul_ogs.InFlexData,
+        hub.matmul_ogs.PrecisionConfig,
+    )
+    swiglu_fn = hub.swiglu.swiglu_fn
+
+    local_experts = gate_up_blocks.size(0)
+    gate_up_blocks = gate_up_blocks.view(local_experts, intermediate_size * 2, -1)
+    triton_gate_up_w, gate_up_w_scale_raw = _swizzle_mxfp4(
+        gate_up_blocks.transpose(-2, -1), gate_up_scales.transpose(-2, -1)
+    )
+    triton_gate_up_w.shape = torch.Size([local_experts, hidden_size, intermediate_size * 2])
+    down_blocks = down_blocks.view(local_experts, -1, intermediate_size // 2)
+    triton_down_w, down_w_scale_raw = _swizzle_mxfp4(
+        down_blocks.transpose(-2, -1), down_scales.transpose(-2, -1)
+    )
+    triton_down_w.shape = torch.Size([local_experts, intermediate_size, hidden_size])
+
+    gate_pc = PrecisionConfig(
+        weight_scale=gate_up_w_scale_raw, flex_ctx=FlexCtx(rhs_data=InFlexData())
+    )
+
+    down_pc = PrecisionConfig(
+        weight_scale=down_w_scale_raw, flex_ctx=FlexCtx(rhs_data=InFlexData())
+    )
+
+    act = FusedActivation(
+        FnSpecs("swiglu", swiglu_fn, ("alpha", "limit")), (float(alpha), float(limit)), 2
+    )
+
+    intermediate_cache1 = matmul_ogs(
+        hidden_states,
+        triton_gate_up_w,
+        gate_up_bias.to(torch.float32),
+        routing_data,
+        gather_indx=gather_idx,
+        precision_config=gate_pc,
+        gammas=None,
+        fused_activation=act,
+    )
+
+    routed_out = matmul_ogs(
+        intermediate_cache1,
+        triton_down_w,
+        down_bias.to(torch.float32),
+        routing_data,
+        scatter_indx=scatter_idx,
+        precision_config=down_pc,
+        gammas=routing_data.gate_scal,
+    )
+
+    routed_out = routed_out.reshape(batch_size, -1, hidden_size)
+    return routed_out
+
+
+@mxfp4_mlp.register_fake
+def _mxfp4_mlp_fake(
+    hidden_states: torch.Tensor,
+    router_weight: torch.Tensor,
+    router_bias: torch.Tensor,
+    top_k: int,
+    gate_up_blocks: torch.Tensor,
+    gate_up_bias: torch.Tensor,
+    gate_up_scales: torch.Tensor,
+    alpha: float,
+    limit: float,
+    down_blocks: torch.Tensor,
+    down_bias: torch.Tensor,
+    down_scales: torch.Tensor,
+):
+    return torch.empty_like(hidden_states)

--- a/tensorrt_llm/_torch/auto_deploy/models/hf.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/hf.py
@@ -172,6 +172,26 @@ class AutoModelForCausalLMFactory(ModelFactory):
 
         model.eval()
 
+        # TODO(fridah): this should be handled by QuantConfigReader
+        from transformers.quantizers import AutoHfQuantizer
+
+        hf_quantizer = AutoHfQuantizer.from_config(
+            model_config.quantization_config,
+            pre_quantized=True,
+        )
+
+        dtype = hf_quantizer.update_dtype(model_config.dtype)
+        model.to(dtype)
+
+        hf_quantizer.preprocess_model(
+            model=model,
+            device_map=None,
+            keep_in_fp32_modules=model._keep_in_fp32_modules,
+            config=model.config,
+            use_kernels=False,
+        )
+        print("Model after pre-processing: ", model)
+
         return model
 
     def _set_sharding_config(self, model_config: PretrainedConfig):


### PR DESCRIPTION
This PR does the following:
1. patch MLP forward layer to custom kernel (MXFP4 routing+expert triton kernel)
2. update model with MXFP4 modules in build_model
3. export the model

env requirements for huggingface to load MXFP4 model
```
pip install triton==3.4.0
pip install kernels

and the latest transformers
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an MXFP4-based routed MLP operator with fused activation for faster inference; now available under the custom_ops namespace.
  * Enabled automatic quantization pre-processing during model build, adjusting dtype and preparing weights for quantized execution to improve performance and memory efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
