### PR TITLE
[TRTLLM-6742][feat] L2 Prefetch

### DIFF
--- a/cpp/tensorrt_llm/kernels/prefetch.cu
+++ b/cpp/tensorrt_llm/kernels/prefetch.cu
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "prefetch.h"
+
+#include <cute/tensor.hpp>
+
+namespace tensorrt_llm
+{
+namespace kernels
+{
+
+// assume load a [M, K] row major weight matrix
+// how to sync with DMA warp is tricky
+template <typename T, int CTA_M, int CTA_K, class TmaLoad, class GmemTensor>
+__global__ void cute_tma_prefetch_kernel(
+    __grid_constant__ TmaLoad const tma_load, GmemTensor gmem_tensor, int K, int throttle_time)
+{
+    using namespace cute;
+
+    // if the kernel allocates tmem (min 32 columns), the compiler will mark the binary
+    // as using tmem, then the kernel launch will acquire all vrc so that we have 1 cta/SM
+    // then we relinquish which clears the vrc, and we deallocate the tmem
+    // so that the next kernel can launch
+    __shared__ uint32_t tmem_base_ptr;
+    // Tmem allocator
+    cute::TMEM::Allocator1Sm tmem_allocator{};
+    tmem_allocator.allocate(32, &tmem_base_ptr);
+    tmem_allocator.release_allocation_lock(); // relinquish
+    tmem_allocator.free(tmem_base_ptr, 32);
+
+    if (threadIdx.x == 0)
+    {
+        auto gmem_tensor_coord = tma_load.get_tma_tensor(shape(gmem_tensor));
+        auto tma_load_per_cta = tma_load.get_slice(0);
+
+        for (int k = 0; k < K / CTA_K; k++)
+        {
+            auto gmem_tensor_coord_cta
+                = local_tile(gmem_tensor_coord, Tile<Int<CTA_M>, Int<CTA_K>>{}, make_coord(blockIdx.x, k));
+
+            prefetch(tma_load, tma_load_per_cta.partition_S(gmem_tensor_coord_cta));
+
+            auto start = clock64();
+            while (clock64() - start < throttle_time)
+                ;
+        }
+    }
+}
+
+template <typename T, int CTA_M, int CTA_K>
+void cute_host_prefetch(T const* data, int M, int K, int strideM, int throttle_time, cudaStream_t stream)
+{
+    using namespace cute;
+
+    // create the GMEM tensor, row major
+    auto gmem_layout = make_layout(make_shape(M, K), make_stride(strideM, 1));
+    auto gmem_tensor = make_tensor(make_gmem_ptr(data), gmem_layout);
+
+    // create the SMEM layout, row major
+    // smem_layout need to use static integer
+    // use dynamic integer will cause compilation error
+    auto smem_layout = make_layout(make_shape(Int<CTA_M>{}, Int<CTA_K>{}), make_stride(Int<CTA_K>{}, _1{}));
+
+    // create the TMA object
+    auto tma_load = make_tma_copy(SM90_TMA_LOAD{}, gmem_tensor, smem_layout);
+
+    // invoke the kernel
+    // each CTA responsible for a range of M, and all kblock associated with it
+    cudaLaunchConfig_t config{};
+    config.gridDim = dim3{(uint32_t) (M / CTA_M), 1, 1};
+    config.blockDim = 32;
+    config.stream = stream;
+
+    auto* kernel_instance = &cute_tma_prefetch_kernel<T, CTA_M, CTA_K, decltype(tma_load), decltype(gmem_tensor)>;
+    // default carveout is 32KB, which mismatches with gemm, so will trigger smem reconfiguration, which requires
+    // draining SM, i.e. no overlapping
+    cudaFuncSetAttribute(kernel_instance, cudaFuncAttributePreferredSharedMemoryCarveout, 100);
+
+    cudaLaunchKernelEx(&config, kernel_instance, tma_load, gmem_tensor, K, throttle_time);
+}
+
+#define INSTANTIATE_CUTE_HOST_PREFETCH(T, CTA_M, CTA_K)                                                                \
+    template void cute_host_prefetch<T, CTA_M, CTA_K>(T const*, int, int, int, int, cudaStream_t);
+
+// In the same order as in 3rdparty/cutlass/include/cute/arch/copy_sm90_desc.hpp
+INSTANTIATE_CUTE_HOST_PREFETCH(uint8_t, 64, 128);
+INSTANTIATE_CUTE_HOST_PREFETCH(cute::float_e4m3_t, 64, 128);
+INSTANTIATE_CUTE_HOST_PREFETCH(cute::float_e5m2_t, 64, 128);
+INSTANTIATE_CUTE_HOST_PREFETCH(cute::half_t, 64, 128);
+INSTANTIATE_CUTE_HOST_PREFETCH(float, 64, 128);
+INSTANTIATE_CUTE_HOST_PREFETCH(cute::bfloat16_t, 64, 128);
+
+} // namespace kernels
+} // namespace tensorrt_llm

--- a/cpp/tensorrt_llm/kernels/prefetch.cu
+++ b/cpp/tensorrt_llm/kernels/prefetch.cu
@@ -130,16 +130,18 @@ void cute_host_prefetch(T const* data, int M, int K, int strideM, int delay_star
         &config, kernel_instance, tma_load, gmem_tensor, M, K, delay_start, throttle_time, throttle_mode));
 }
 
-#define INSTANTIATE_CUTE_HOST_PREFETCH(T, CTA_M, CTA_K)                                                                \
-    template void cute_host_prefetch<T, CTA_M, CTA_K>(T const*, int, int, int, int, int, int, bool, cudaStream_t);
+#define INSTANTIATE_CUTE_HOST_PREFETCH(T, CTA_M, CTA_K_BYTES)                                                          \
+    template void cute_host_prefetch<T, CTA_M, CTA_K_BYTES / sizeof(T)>(                                               \
+        T const*, int, int, int, int, int, int, bool, cudaStream_t);
 
 // In the same order as in 3rdparty/cutlass/include/cute/arch/copy_sm90_desc.hpp
-INSTANTIATE_CUTE_HOST_PREFETCH(uint8_t, 64, 128);
-INSTANTIATE_CUTE_HOST_PREFETCH(cute::float_e4m3_t, 64, 128);
-INSTANTIATE_CUTE_HOST_PREFETCH(cute::float_e5m2_t, 64, 128);
-INSTANTIATE_CUTE_HOST_PREFETCH(cute::half_t, 64, 128);
-INSTANTIATE_CUTE_HOST_PREFETCH(float, 64, 128);
-INSTANTIATE_CUTE_HOST_PREFETCH(cute::bfloat16_t, 64, 128);
+INSTANTIATE_CUTE_HOST_PREFETCH(uint8_t, 64, 256);
+INSTANTIATE_CUTE_HOST_PREFETCH(cute::float_e4m3_t, 64, 256);
+INSTANTIATE_CUTE_HOST_PREFETCH(cute::float_e5m2_t, 64, 256);
+INSTANTIATE_CUTE_HOST_PREFETCH(int64_t, 64, 256);
+INSTANTIATE_CUTE_HOST_PREFETCH(cute::half_t, 64, 256);
+INSTANTIATE_CUTE_HOST_PREFETCH(float, 64, 256);
+INSTANTIATE_CUTE_HOST_PREFETCH(cute::bfloat16_t, 64, 256);
 
 } // namespace kernels
 } // namespace tensorrt_llm

--- a/cpp/tensorrt_llm/kernels/prefetch.h
+++ b/cpp/tensorrt_llm/kernels/prefetch.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cuda_runtime.h>
+
+namespace tensorrt_llm
+{
+namespace kernels
+{
+
+template <typename T, int CTA_M, int CTA_K>
+void cute_host_prefetch(T const* data, int M, int K, int strideM, int throttle_time, cudaStream_t stream);
+
+} // namespace kernels
+} // namespace tensorrt_llm

--- a/cpp/tensorrt_llm/kernels/prefetch.h
+++ b/cpp/tensorrt_llm/kernels/prefetch.h
@@ -24,7 +24,8 @@ namespace kernels
 {
 
 template <typename T, int CTA_M, int CTA_K>
-void cute_host_prefetch(T const* data, int M, int K, int strideM, int throttle_time, bool pdl, cudaStream_t stream);
+void cute_host_prefetch(T const* data, int M, int K, int strideM, int delay_start, int throttle_time, int throttle_mode,
+    bool pdl, cudaStream_t stream);
 
 } // namespace kernels
 } // namespace tensorrt_llm

--- a/cpp/tensorrt_llm/kernels/prefetch.h
+++ b/cpp/tensorrt_llm/kernels/prefetch.h
@@ -24,7 +24,7 @@ namespace kernels
 {
 
 template <typename T, int CTA_M, int CTA_K>
-void cute_host_prefetch(T const* data, int M, int K, int strideM, int throttle_time, cudaStream_t stream);
+void cute_host_prefetch(T const* data, int M, int K, int strideM, int throttle_time, bool pdl, cudaStream_t stream);
 
 } // namespace kernels
 } // namespace tensorrt_llm

--- a/cpp/tensorrt_llm/thop/CMakeLists.txt
+++ b/cpp/tensorrt_llm/thop/CMakeLists.txt
@@ -79,6 +79,7 @@ add_library(
   noAuxTcOp.cpp
   ncclCommunicatorOp.cpp
   parallelDecodeKVCacheUpdateOp.cpp
+  prefetchOp.cpp
   redrafterCurandOp.cpp
   reducescatterOp.cpp
   relativeAttentionBiasOp.cpp

--- a/cpp/tensorrt_llm/thop/prefetchOp.cpp
+++ b/cpp/tensorrt_llm/thop/prefetchOp.cpp
@@ -68,6 +68,10 @@ void cute_host_prefetch_pytorch(
     {
         DISPATCH_PREFETCH(cutlass::bfloat16_t, at::BFloat16);
     }
+    else if (tensor.dtype() == torch::kUInt8)
+    {
+        DISPATCH_PREFETCH(uint8_t, uint8_t);
+    }
     else if (tensor.dtype() == torch::kFloat8_e4m3fn)
     {
         DISPATCH_PREFETCH(cutlass::float_e4m3_t, at::Float8_e4m3fn);
@@ -83,8 +87,8 @@ void cute_host_prefetch_pytorch(
     else
     {
         TORCH_CHECK(false,
-            "Unsupported tensor data type. Supported types: float32, float16, bfloat16, float8_e4m3fn, float8_e5m2, "
-            "int64");
+            "Unsupported tensor data type. Supported types: float32, float16, bfloat16, uint8, float8_e4m3fn, "
+            "float8_e5m2, int64");
     }
 }
 

--- a/cpp/tensorrt_llm/thop/prefetchOp.cpp
+++ b/cpp/tensorrt_llm/thop/prefetchOp.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tensorrt_llm/kernels/prefetch.h"
+#include <ATen/cuda/CUDAContext.h>
+#include <cute/tensor.hpp>
+#include <torch/extension.h>
+
+namespace torch_ext
+{
+
+static constexpr int PF_TILE_M = 64;
+static constexpr int PF_TILE_K
+    = 128; // TODO: determine whether we need this, or can just use a single UTMAPF for all of K
+
+// PyTorch wrapper with automatic M,K detection from tensor shape
+void cute_host_prefetch_pytorch(torch::Tensor tensor, int64_t throttle_time)
+{
+    // Ensure tensor is 2D and on CUDA
+    TORCH_CHECK(tensor.dim() == 2, "Input tensor must be 2D (M, K)");
+    TORCH_CHECK(tensor.is_cuda(), "Input tensor must be on CUDA");
+
+    int M = tensor.size(0);
+    int K = tensor.size(1);
+    int strideM = tensor.stride(0);
+    int strideK = tensor.stride(1);
+
+    // Check that M and K are divisible by tile sizes
+    TORCH_CHECK(M % PF_TILE_M == 0, "M dimension must be divisible by PF_TILE_M (", PF_TILE_M, ")");
+    TORCH_CHECK(K % PF_TILE_K == 0, "K dimension must be divisible by PF_TILE_K (", PF_TILE_K, ")");
+    TORCH_CHECK(strideM % PF_TILE_M == 0, "M dimension stride must be divisible by PF_TILE_M (", PF_TILE_M, ")");
+    TORCH_CHECK(strideK == 1, "K dimension stride must be 1");
+
+    // Get CUDA stream
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+    // Dispatch based on tensor data type
+    if (tensor.dtype() == torch::kFloat32)
+    {
+        tensorrt_llm::kernels::cute_host_prefetch<float, PF_TILE_M, PF_TILE_K>(
+            tensor.data_ptr<float>(), M, K, strideM, (int) throttle_time, stream);
+    }
+    else if (tensor.dtype() == torch::kFloat16)
+    {
+        tensorrt_llm::kernels::cute_host_prefetch<cutlass::half_t, PF_TILE_M, PF_TILE_K>(
+            reinterpret_cast<cutlass::half_t*>(tensor.data_ptr<at::Half>()), M, K, strideM, (int) throttle_time,
+            stream);
+    }
+    else if (tensor.dtype() == torch::kBFloat16)
+    {
+        tensorrt_llm::kernels::cute_host_prefetch<cutlass::bfloat16_t, PF_TILE_M, PF_TILE_K>(
+            reinterpret_cast<cutlass::bfloat16_t*>(tensor.data_ptr<at::BFloat16>()), M, K, strideM, (int) throttle_time,
+            stream);
+    }
+    else if (tensor.dtype() == torch::kFloat8_e4m3fn)
+    {
+        tensorrt_llm::kernels::cute_host_prefetch<cutlass::float_e4m3_t, PF_TILE_M, PF_TILE_K>(
+            reinterpret_cast<cutlass::float_e4m3_t*>(tensor.data_ptr<at::Float8_e4m3fn>()), M, K, strideM,
+            (int) throttle_time, stream);
+    }
+    else if (tensor.dtype() == torch::kFloat8_e5m2)
+    {
+        tensorrt_llm::kernels::cute_host_prefetch<cutlass::float_e5m2_t, PF_TILE_M, PF_TILE_K>(
+            reinterpret_cast<cutlass::float_e5m2_t*>(tensor.data_ptr<at::Float8_e5m2>()), M, K, strideM,
+            (int) throttle_time, stream);
+    }
+    else
+    {
+        TORCH_CHECK(false,
+            "Unsupported tensor data type. Supported types: float32, float16, bfloat16, float8_e4m3fn, float8_e5m2");
+    }
+}
+
+} // namespace torch_ext
+
+TORCH_LIBRARY_FRAGMENT(trtllm, m)
+{
+    m.def("cute_host_prefetch(Tensor tensor, int throttle_time) -> ()");
+}
+
+TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
+{
+    m.impl("cute_host_prefetch", &torch_ext::cute_host_prefetch_pytorch);
+}

--- a/tensorrt_llm/_torch/utils.py
+++ b/tensorrt_llm/_torch/utils.py
@@ -17,6 +17,7 @@ aux_stream_name_list = [
     'MoeShared',
     'MoeChunkingOverlap',
     'MoeBalancer',
+    'Prefetch',
 ]
 AuxStreamType = Enum(
     'AuxStreamType',


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
