### PR TITLE
[TRTLLM-7027][feat] Fuse d2t to logitsBitmaskKernel and fix a race condition in one-model spec

### DIFF
--- a/cpp/tensorrt_llm/kernels/logitsBitmask.cu
+++ b/cpp/tensorrt_llm/kernels/logitsBitmask.cu
@@ -60,6 +60,7 @@ __device__ PackedT packedNegativeInfinity()
     }
     return *reinterpret_cast<PackedT*>(packed);
 }
+} // namespace
 
 template <typename T, typename PackedT, int32_t kBitsPerThread>
 __global__ void __launch_bounds__(kThreadsPerBlock) logitsBitmaskKernel(
@@ -145,7 +146,6 @@ void logitsBitmaskDispatchToBitsPerThread(
         logitsBitmaskKernel<T, PackedT, 32><<<grid, block, 0, stream>>>(logits, bitmask, vocabSizePadded, bitmaskSize);
     }
 }
-} // namespace
 
 template <typename T>
 void invokeLogitsBitmask(
@@ -179,5 +179,153 @@ template void invokeLogitsBitmask<half>(
 template void invokeLogitsBitmask<__nv_bfloat16>(
     __nv_bfloat16** logits, uint32_t const** bitmask, int32_t batchSize, int32_t vocabSizePadded, cudaStream_t stream);
 #endif
+
+template <typename T, typename PackedT, int32_t kBitsPerThread>
+__global__ void __launch_bounds__(kThreadsPerBlock) contiguousLogitsBitmaskKernel(T* __restrict__ logits,
+    uint32_t const* __restrict__ bitmask, int32_t const* __restrict__ tokenMask, int32_t const* __restrict__ d2t,
+    int32_t vocabSizePadded, int32_t bitmaskSize)
+{
+    int constexpr kAlignment = sizeof(PackedT) / sizeof(T);
+    uint32_t constexpr kPackedMask = (1 << kAlignment) - 1;
+
+    int const batchIdx = blockIdx.y;
+    if (tokenMask != nullptr && !tokenMask[batchIdx])
+    {
+        return;
+    }
+
+    int const blockOffset = blockIdx.x * kThreadsPerBlock * kBitsPerThread;
+    T* logitsGmemPtr = logits + batchIdx * vocabSizePadded + blockOffset;
+
+    uint32_t const* bitmaskGmemPtr = bitmask + batchIdx * bitmaskSize + blockOffset / kBitsPerMaskElement;
+    int const bitmaskInnerIdx = threadIdx.x % (kBitsPerMaskElement / kAlignment);
+    T logitsReg[kAlignment];
+
+#pragma unroll
+    for (int offset = threadIdx.x * kAlignment; offset < kThreadsPerBlock * kBitsPerThread;
+         offset += kThreadsPerBlock * kAlignment)
+    {
+        if (blockOffset + offset >= vocabSizePadded)
+        {
+            break;
+        }
+
+        uint32_t bitmaskVal = 0;
+        if (d2t == nullptr)
+        {
+            bitmaskVal
+                = (~bitmaskGmemPtr[offset / kBitsPerMaskElement] >> (bitmaskInnerIdx * kAlignment)) & kPackedMask;
+        }
+        else
+        {
+#pragma unroll
+            for (int i = 0; i < kAlignment; i++)
+            {
+                int const d2tOffset = blockOffset + offset + i + d2t[blockOffset + offset + i];
+                bitmaskVal |= ((~bitmask[batchIdx * bitmaskSize + d2tOffset / kBitsPerMaskElement]
+                                   >> (d2tOffset % kBitsPerMaskElement))
+                                  & 1)
+                    << i;
+            }
+        }
+
+        if (bitmaskVal == 0)
+        {
+            continue;
+        }
+
+        if (bitmaskVal == kPackedMask)
+        {
+            *reinterpret_cast<PackedT*>(logitsGmemPtr + offset) = packedNegativeInfinity<T, PackedT>();
+            continue;
+        }
+
+        *reinterpret_cast<PackedT*>(logitsReg) = *reinterpret_cast<PackedT*>(logitsGmemPtr + offset);
+#pragma unroll
+        for (int i = 0; i < kAlignment; i++)
+        {
+            if (((bitmaskVal >> i) & 1))
+            {
+                logitsReg[i] = negativeInfinity<T>();
+            }
+        }
+        *reinterpret_cast<PackedT*>(logitsGmemPtr + offset) = *reinterpret_cast<PackedT*>(logitsReg);
+    }
+}
+
+template <typename T, typename PackedT>
+void contiguousLogitsBitmaskDispatchToBitsPerThread(T* logits, uint32_t const* bitmask, int32_t const* tokenMask,
+    int32_t const* d2t, int32_t batchSize, int32_t vocabSizePadded, int32_t bitmaskSize, cudaStream_t stream)
+{
+    int constexpr kAlignment = sizeof(PackedT) / sizeof(T);
+    int32_t const numBlocksPerRow = ceilDiv(2048 / kThreadsPerBlock * 128, batchSize);
+    int32_t const numBitsPerThread = ceilDiv(vocabSizePadded, kThreadsPerBlock * numBlocksPerRow);
+
+    dim3 const block(kThreadsPerBlock);
+
+    if (numBitsPerThread <= 4 && kAlignment <= 4)
+    {
+        dim3 const grid(ceilDiv(vocabSizePadded, kThreadsPerBlock * 4), batchSize);
+        contiguousLogitsBitmaskKernel<T, PackedT, 4>
+            <<<grid, block, 0, stream>>>(logits, bitmask, tokenMask, d2t, vocabSizePadded, bitmaskSize);
+    }
+    else if (numBitsPerThread <= 8 && kAlignment <= 8)
+    {
+        dim3 const grid(ceilDiv(vocabSizePadded, kThreadsPerBlock * 8), batchSize);
+        contiguousLogitsBitmaskKernel<T, PackedT, 8>
+            <<<grid, block, 0, stream>>>(logits, bitmask, tokenMask, d2t, vocabSizePadded, bitmaskSize);
+    }
+    else if (numBitsPerThread <= 16 && kAlignment <= 16)
+    {
+        dim3 const grid(ceilDiv(vocabSizePadded, kThreadsPerBlock * 16), batchSize);
+        contiguousLogitsBitmaskKernel<T, PackedT, 16>
+            <<<grid, block, 0, stream>>>(logits, bitmask, tokenMask, d2t, vocabSizePadded, bitmaskSize);
+    }
+    else
+    {
+        dim3 const grid(ceilDiv(vocabSizePadded, kThreadsPerBlock * 32), batchSize);
+        contiguousLogitsBitmaskKernel<T, PackedT, 32>
+            <<<grid, block, 0, stream>>>(logits, bitmask, tokenMask, d2t, vocabSizePadded, bitmaskSize);
+    }
+}
+
+template <typename T>
+void invokeContiguousLogitsBitmask(T* logits, uint32_t const* bitmask, int32_t const* tokenMask, int32_t const* d2t,
+    int32_t batchSize, int32_t vocabSizePadded, int32_t bitmaskSize, cudaStream_t stream)
+{
+    // Dispatch to PackedT
+    if (vocabSizePadded % (sizeof(float4) / sizeof(T)) == 0)
+    {
+        contiguousLogitsBitmaskDispatchToBitsPerThread<T, float4>(
+            logits, bitmask, tokenMask, d2t, batchSize, vocabSizePadded, bitmaskSize, stream);
+    }
+    else if (vocabSizePadded % (sizeof(float2) / sizeof(T)) == 0)
+    {
+        contiguousLogitsBitmaskDispatchToBitsPerThread<T, float2>(
+            logits, bitmask, tokenMask, d2t, batchSize, vocabSizePadded, bitmaskSize, stream);
+    }
+    else if (vocabSizePadded % (sizeof(float) / sizeof(T)) == 0)
+    {
+        contiguousLogitsBitmaskDispatchToBitsPerThread<T, float>(
+            logits, bitmask, tokenMask, d2t, batchSize, vocabSizePadded, bitmaskSize, stream);
+    }
+    else
+    {
+        contiguousLogitsBitmaskDispatchToBitsPerThread<T, T>(
+            logits, bitmask, tokenMask, d2t, batchSize, vocabSizePadded, bitmaskSize, stream);
+    }
+}
+
+template void invokeContiguousLogitsBitmask<float>(float* logits, uint32_t const* bitmask, int32_t const* tokenMask,
+    int32_t const* d2t, int32_t batchSize, int32_t vocabSizePadded, int32_t bitmaskSize, cudaStream_t stream);
+template void invokeContiguousLogitsBitmask<half>(half* logits, uint32_t const* bitmask, int32_t const* tokenMask,
+    int32_t const* d2t, int32_t batchSize, int32_t vocabSizePadded, int32_t bitmaskSize, cudaStream_t stream);
+
+#ifdef ENABLE_BF16
+template void invokeContiguousLogitsBitmask<__nv_bfloat16>(__nv_bfloat16* logits, uint32_t const* bitmask,
+    int32_t const* tokenMask, int32_t const* d2t, int32_t batchSize, int32_t vocabSizePadded, int32_t bitmaskSize,
+    cudaStream_t stream);
+#endif
+
 } // namespace kernels
 } // namespace tensorrt_llm

--- a/cpp/tensorrt_llm/kernels/logitsBitmask.cu
+++ b/cpp/tensorrt_llm/kernels/logitsBitmask.cu
@@ -119,7 +119,8 @@ void logitsBitmaskDispatchToBitsPerThread(
     T** logits, uint32_t const** bitmask, int32_t batchSize, int32_t vocabSizePadded, cudaStream_t stream)
 {
     int constexpr kAlignment = sizeof(PackedT) / sizeof(T);
-    int32_t const numBlocksPerRow = ceilDiv(2048 / kThreadsPerBlock * 128, batchSize);
+    static int const smCount = tensorrt_llm::common::getMultiProcessorCount();
+    int32_t const numBlocksPerRow = ceilDiv(2048 / kThreadsPerBlock * smCount, batchSize);
     int32_t const numBitsPerThread = ceilDiv(vocabSizePadded, kThreadsPerBlock * numBlocksPerRow);
     int32_t bitmaskSize = ceilDiv(vocabSizePadded, kBitsPerMaskElement);
 
@@ -258,7 +259,8 @@ void contiguousLogitsBitmaskDispatchToBitsPerThread(T* logits, uint32_t const* b
     int32_t const* d2t, int32_t batchSize, int32_t vocabSizePadded, int32_t bitmaskSize, cudaStream_t stream)
 {
     int constexpr kAlignment = sizeof(PackedT) / sizeof(T);
-    int32_t const numBlocksPerRow = ceilDiv(2048 / kThreadsPerBlock * 128, batchSize);
+    static int const smCount = tensorrt_llm::common::getMultiProcessorCount();
+    int32_t const numBlocksPerRow = ceilDiv(2048 / kThreadsPerBlock * smCount, batchSize);
     int32_t const numBitsPerThread = ceilDiv(vocabSizePadded, kThreadsPerBlock * numBlocksPerRow);
 
     dim3 const block(kThreadsPerBlock);

--- a/cpp/tensorrt_llm/kernels/logitsBitmask.h
+++ b/cpp/tensorrt_llm/kernels/logitsBitmask.h
@@ -29,5 +29,9 @@ template <typename T>
 void invokeLogitsBitmask(
     T** logits, uint32_t const** bitmask, int32_t batchSize, int32_t vocabSizePadded, cudaStream_t stream);
 
+template <typename T>
+void invokeContiguousLogitsBitmask(T* logits, uint32_t const* bitmask, int32_t const* tokenMask, int32_t const* d2t,
+    int32_t batchSize, int32_t vocabSizePadded, int32_t bitmaskSize, cudaStream_t stream);
+
 } // namespace kernels
 } // namespace tensorrt_llm

--- a/cpp/tensorrt_llm/thop/logitsBitmaskOp.cpp
+++ b/cpp/tensorrt_llm/thop/logitsBitmaskOp.cpp
@@ -21,8 +21,6 @@
 namespace torch_ext
 {
 
-int32_t constexpr kBitsPerMaskElement = 32;
-
 void logitsBitmask(torch::Tensor const& logits, torch::Tensor const& bitmask,
     at::optional<torch::Tensor> const& tokenMask = at::nullopt, at::optional<torch::Tensor> const& d2t = at::nullopt)
 {

--- a/cpp/tensorrt_llm/thop/logitsBitmaskOp.cpp
+++ b/cpp/tensorrt_llm/thop/logitsBitmaskOp.cpp
@@ -97,7 +97,7 @@ void logitsBitmask(torch::Tensor const& logits, torch::Tensor const& bitmask,
 
 TORCH_LIBRARY_FRAGMENT(trtllm, m)
 {
-    m.def("logits_bitmask(Tensor logits, Tensor bitmask, Tensor? token_mask=None, Tensor? d2t=None) -> ()");
+    m.def("logits_bitmask(Tensor(a!) logits, Tensor bitmask, Tensor? token_mask=None, Tensor? d2t=None) -> ()");
 }
 
 TORCH_LIBRARY_IMPL(trtllm, CUDA, m)

--- a/cpp/tensorrt_llm/thop/logitsBitmaskOp.cpp
+++ b/cpp/tensorrt_llm/thop/logitsBitmaskOp.cpp
@@ -23,61 +23,72 @@ namespace torch_ext
 
 int32_t constexpr kBitsPerMaskElement = 32;
 
-void logitsBitmask(std::vector<torch::Tensor> const& logits, std::vector<torch::Tensor> const& bitmask)
+void logitsBitmask(torch::Tensor const& logits, torch::Tensor const& bitmask,
+    at::optional<torch::Tensor> const& tokenMask = at::nullopt, at::optional<torch::Tensor> const& d2t = at::nullopt)
 {
-    TORCH_CHECK(bitmask.size() == logits.size(), "The lengths of logits and bitmask do not match.");
-    int32_t batchSize = logits.size();
+    int32_t const batchSize = logits.size(0);
     if (batchSize == 0)
     {
         return;
     }
-    int32_t vocabSizePadded = logits[0].size(0);
-    int32_t bitmaskSize = tensorrt_llm::common::ceilDiv(vocabSizePadded, kBitsPerMaskElement);
+    TORCH_CHECK(bitmask.size(0) == batchSize, "bitmask must have the same batch size as logits.");
 
-    auto options = torch::TensorOptions().dtype(torch::kUInt64).device(torch::kCPU).pinned_memory(true);
-    auto logitsPtrsHost = torch::empty({batchSize}, options);
-    auto bitmaskPtrsHost = torch::empty({batchSize}, options);
-    for (int i = 0; i < batchSize; i++)
+    int32_t vocabSizePadded = logits.size(1);
+    int32_t bitmaskSize = bitmask.size(1);
+    TORCH_CHECK(logits.is_cuda(), "logits must be a CUDA tensor.");
+    TORCH_CHECK(logits.is_contiguous(), "logits must be contiguous.");
+    TORCH_CHECK(logits.dim() == 2, "logits must be a 2D tensor.");
+    TORCH_CHECK(bitmask.is_cuda(), "bitmask must be a CUDA tensor.");
+    TORCH_CHECK(bitmask.is_contiguous(), "bitmask must be contiguous.");
+    TORCH_CHECK(bitmask.dim() == 2, "bitmask must be a 2D tensor.");
+    TORCH_CHECK(bitmask.scalar_type() == torch::kUInt32 || bitmask.scalar_type() == torch::kInt32,
+        "bitmask must have element type uint32 or int32.");
+
+    int32_t const* tokenMaskPtr = nullptr;
+    if (tokenMask.has_value())
     {
-        TORCH_CHECK(logits[i].is_cuda(), "logits must be a CUDA tensor.");
-        TORCH_CHECK(logits[i].is_contiguous(), "logits must be contiguous.");
-        TORCH_CHECK(logits[i].dim() == 1, "logits must be a 1D tensor.");
-        TORCH_CHECK(logits[i].size(0) == vocabSizePadded, "logits must have the same vocab size.");
-        TORCH_CHECK(bitmask[i].is_cuda(), "bitmask must be a CUDA tensor.");
-        TORCH_CHECK(bitmask[i].is_contiguous(), "bitmask must be contiguous.");
-        TORCH_CHECK(bitmask[i].dim() == 1, "bitmask must be a 1D tensor.");
-        TORCH_CHECK(bitmask[i].size(0) == bitmaskSize, "bitmask must have size equal to ceilDiv(vocab_size, 32).");
-        TORCH_CHECK(bitmask[i].scalar_type() == torch::kUInt32 || bitmask[i].scalar_type() == torch::kInt32,
-            "bitmask must have element type uint32 or int32.");
-
-        logitsPtrsHost[i] = reinterpret_cast<uint64_t>(logits[i].data_ptr());
-        bitmaskPtrsHost[i] = reinterpret_cast<uint64_t>(bitmask[i].data_ptr());
+        TORCH_CHECK(tokenMask->is_cuda(), "tokenMask must be a CUDA tensor.");
+        TORCH_CHECK(tokenMask->is_contiguous(), "tokenMask must be contiguous.");
+        TORCH_CHECK(tokenMask->dim() == 1, "tokenMask must be a 1D tensor.");
+        TORCH_CHECK(tokenMask->size(0) == batchSize, "tokenMask must have the same batch size as logits.");
+        TORCH_CHECK(tokenMask->scalar_type() == torch::kInt32, "tokenMask must have element type int32.");
+        tokenMaskPtr = reinterpret_cast<int32_t const*>(tokenMask->data_ptr());
     }
 
-    auto logitsPtrs = logitsPtrsHost.to(torch::kCUDA, /*non_blocking=*/true);
-    auto bitmaskPtrs = bitmaskPtrsHost.to(torch::kCUDA, /*non_blocking=*/true);
+    int32_t const* d2tPtr = nullptr;
+    if (d2t.has_value())
+    {
+        TORCH_CHECK(d2t->is_cuda(), "d2t must be a CUDA tensor.");
+        TORCH_CHECK(d2t->is_contiguous(), "d2t must be contiguous.");
+        TORCH_CHECK(d2t->dim() == 1, "d2t must be a 1D tensor.");
+        TORCH_CHECK(d2t->size(0) == vocabSizePadded, "d2t must have the same vocab size as logits.");
+        TORCH_CHECK(d2t->scalar_type() == torch::kInt32, "d2t must have element type int32.");
+        d2tPtr = reinterpret_cast<int32_t const*>(d2t->data_ptr());
+    }
 
-    auto stream = at::cuda::getCurrentCUDAStream(logits[0].get_device()).stream();
+    auto stream = at::cuda::getCurrentCUDAStream(logits.get_device()).stream();
 
-    switch (logits[0].scalar_type())
+    switch (logits.scalar_type())
     {
     case torch::kFloat32:
     {
-        tensorrt_llm::kernels::invokeLogitsBitmask<float>(reinterpret_cast<float**>(logitsPtrs.data_ptr()),
-            reinterpret_cast<uint32_t const**>(bitmaskPtrs.data_ptr()), batchSize, vocabSizePadded, stream);
+        tensorrt_llm::kernels::invokeContiguousLogitsBitmask<float>(reinterpret_cast<float*>(logits.data_ptr()),
+            reinterpret_cast<uint32_t const*>(bitmask.data_ptr()), tokenMaskPtr, d2tPtr, batchSize, vocabSizePadded,
+            bitmaskSize, stream);
         break;
     }
     case torch::kFloat16:
     {
-        tensorrt_llm::kernels::invokeLogitsBitmask<__half>(reinterpret_cast<__half**>(logitsPtrs.data_ptr()),
-            reinterpret_cast<uint32_t const**>(bitmaskPtrs.data_ptr()), batchSize, vocabSizePadded, stream);
+        tensorrt_llm::kernels::invokeContiguousLogitsBitmask<__half>(reinterpret_cast<__half*>(logits.data_ptr()),
+            reinterpret_cast<uint32_t const*>(bitmask.data_ptr()), tokenMaskPtr, d2tPtr, batchSize, vocabSizePadded,
+            bitmaskSize, stream);
         break;
     }
     case torch::kBFloat16:
     {
-        tensorrt_llm::kernels::invokeLogitsBitmask<__nv_bfloat16>(
-            reinterpret_cast<__nv_bfloat16**>(logitsPtrs.data_ptr()),
-            reinterpret_cast<uint32_t const**>(bitmaskPtrs.data_ptr()), batchSize, vocabSizePadded, stream);
+        tensorrt_llm::kernels::invokeContiguousLogitsBitmask<__nv_bfloat16>(
+            reinterpret_cast<__nv_bfloat16*>(logits.data_ptr()), reinterpret_cast<uint32_t const*>(bitmask.data_ptr()),
+            tokenMaskPtr, d2tPtr, batchSize, vocabSizePadded, bitmaskSize, stream);
         break;
     }
     default: TORCH_CHECK(false, "logits dtype must be float, half or bfloat16."); break;
@@ -88,7 +99,7 @@ void logitsBitmask(std::vector<torch::Tensor> const& logits, std::vector<torch::
 
 TORCH_LIBRARY_FRAGMENT(trtllm, m)
 {
-    m.def("logits_bitmask(Tensor[] logits, Tensor[] bitmask) -> ()");
+    m.def("logits_bitmask(Tensor logits, Tensor bitmask, Tensor? token_mask=None, Tensor? d2t=None) -> ()");
 }
 
 TORCH_LIBRARY_IMPL(trtllm, CUDA, m)

--- a/tensorrt_llm/_torch/compilation/utils.py
+++ b/tensorrt_llm/_torch/compilation/utils.py
@@ -72,7 +72,10 @@ def inplace_info():
         torch.ops.trtllm.flashinfer_apply_rope_with_cos_sin_cache_inplace.default:
         {
             1: "query",
-            2: "key",
+            2: "key"
+        },
+        torch.ops.trtllm.logits_bitmask.default: {
+            1: "logits"
         }
     }
     return inplace_map

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -162,7 +162,10 @@ def _register_fake():
         return torch.empty_like(input).to(torch.float8_e4m3fn), scale
 
     @torch.library.register_fake("trtllm::logits_bitmask")
-    def _(logits: List[torch.Tensor], bitmask: List[torch.Tensor]):
+    def _(logits: torch.Tensor,
+          bitmask: torch.Tensor,
+          token_mask: Optional[torch.Tensor] = None,
+          d2t: Optional[torch.Tensor] = None):
         pass
 
     @torch.library.register_fake("trtllm::fp4_quantize")

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -161,13 +161,6 @@ def _register_fake():
     def _(input: torch.Tensor, scale: torch.Tensor):
         return torch.empty_like(input).to(torch.float8_e4m3fn), scale
 
-    @torch.library.register_fake("trtllm::logits_bitmask")
-    def _(logits: torch.Tensor,
-          bitmask: torch.Tensor,
-          token_mask: Optional[torch.Tensor] = None,
-          d2t: Optional[torch.Tensor] = None):
-        pass
-
     @torch.library.register_fake("trtllm::fp4_quantize")
     def _(
         input: torch.Tensor,

--- a/tensorrt_llm/_torch/models/modeling_speculative.py
+++ b/tensorrt_llm/_torch/models/modeling_speculative.py
@@ -170,7 +170,7 @@ class Eagle3DraftModel(DecoderModel):
 
         if config.draft_vocab_size is not None and config.vocab_size != config.draft_vocab_size:
             self.d2t = nn.Parameter(torch.empty((config.draft_vocab_size, ),
-                                                dtype=torch.int64),
+                                                dtype=torch.int32),
                                     requires_grad=False)
 
         if self.hidden_size_in != config.hidden_size:

--- a/tests/unittest/_torch/thop/parallel/test_logits_bitmask_op.py
+++ b/tests/unittest/_torch/thop/parallel/test_logits_bitmask_op.py
@@ -60,7 +60,7 @@ def test_logits_bitmask_with_d2t(batch_size: int, vocab_size: int, stride: int,
                                   device="cuda") % stride == 0
         token_mask = token_mask.to(torch.int32)
     d2t = torch.randint(0, 3, size=(vocab_size // 4, ),
-                        device="cuda").cumsum(dim=0).to(dtype=torch.int32)
+                        device="cuda").cumsum(dim=0, dtype=torch.int32)
 
     # Compute reference logits
     logits_reference = logits.clone()

--- a/tests/unittest/_torch/thop/parallel/test_logits_bitmask_op.py
+++ b/tests/unittest/_torch/thop/parallel/test_logits_bitmask_op.py
@@ -9,8 +9,8 @@ import tensorrt_llm  # noqa
 @pytest.mark.parametrize("vocab_size", [128000, 128001])
 @pytest.mark.parametrize("stride", [1, 4])
 @pytest.mark.parametrize("logits_dtype", ["float32", "float16", "bfloat16"])
-def test_logits_bitmask_op(batch_size: int, vocab_size: int, stride: int,
-                           logits_dtype: str):
+def test_logits_bitmask(batch_size: int, vocab_size: int, stride: int,
+                        logits_dtype: str):
     logits_dtype = getattr(torch, logits_dtype)
     logits = torch.randn(batch_size,
                          vocab_size,
@@ -21,13 +21,62 @@ def test_logits_bitmask_op(batch_size: int, vocab_size: int, stride: int,
                               size=(batch_size, vocab_size),
                               dtype=torch.bool,
                               device="cuda")
+    bitmask = xgrammar.testing._bool_mask_to_bitmask(bool_mask)
+    token_mask = None
+    if stride > 1:
+        token_mask = torch.arange(batch_size, dtype=torch.int32,
+                                  device="cuda") % stride == 0
+        token_mask = token_mask.to(torch.int32)
 
+    # Compute reference logits
     logits_reference = logits.clone()
     logits_reference[::stride].masked_fill_(~bool_mask[::stride], -float('inf'))
 
-    bitmask = xgrammar.testing._bool_mask_to_bitmask(bool_mask)
-    torch.ops.trtllm.logits_bitmask(
-        [logits[i] for i in range(0, batch_size, stride)],
-        [bitmask[i] for i in range(0, batch_size, stride)])
+    # Call logits bitmask op and evaluate
+    torch.ops.trtllm.logits_bitmask(logits, bitmask, token_mask=token_mask)
+    torch.testing.assert_close(logits, logits_reference)
 
+
+@pytest.mark.parametrize("batch_size", [1, 64])
+@pytest.mark.parametrize("vocab_size", [128000, 128001])
+@pytest.mark.parametrize("stride", [1, 4])
+@pytest.mark.parametrize("logits_dtype", ["float32", "float16", "bfloat16"])
+def test_logits_bitmask_with_d2t(batch_size: int, vocab_size: int, stride: int,
+                                 logits_dtype: str):
+    logits_dtype = getattr(torch, logits_dtype)
+    logits = torch.randn(batch_size,
+                         vocab_size // 4,
+                         dtype=logits_dtype,
+                         device="cuda")
+    bool_mask = torch.randint(0,
+                              2,
+                              size=(batch_size, vocab_size),
+                              dtype=torch.bool,
+                              device="cuda")
+    bitmask = xgrammar.testing._bool_mask_to_bitmask(bool_mask)
+    token_mask = None
+    if stride > 1:
+        token_mask = torch.arange(batch_size, dtype=torch.int32,
+                                  device="cuda") % stride == 0
+        token_mask = token_mask.to(torch.int32)
+    d2t = torch.randint(0, 3, size=(vocab_size // 4, ),
+                        device="cuda").cumsum(dim=0).to(dtype=torch.int32)
+
+    # Compute reference logits
+    logits_reference = logits.clone()
+    draft_logits = logits_reference
+    d2t_mapping = d2t + torch.arange(d2t.size(0), device=d2t.device)
+    target_logits = torch.empty(draft_logits.size(0),
+                                vocab_size,
+                                dtype=draft_logits.dtype,
+                                device=draft_logits.device)
+    target_logits.index_copy_(-1, d2t_mapping, draft_logits)
+    target_logits[::stride].masked_fill_(~bool_mask[::stride], -float('inf'))
+    torch.index_select(target_logits, -1, d2t_mapping, out=draft_logits)
+
+    # Call logits bitmask op and evaluate
+    torch.ops.trtllm.logits_bitmask(logits,
+                                    bitmask,
+                                    token_mask=token_mask,
+                                    d2t=d2t)
     torch.testing.assert_close(logits, logits_reference)


### PR DESCRIPTION
# [TRTLLM-7027][feat] Fuse d2t to logitsBitmaskKernel and fix a race condition in one-model spec

## Description

This PR introduces a new `contiguousLogitsBitmaskKernel`, which is more suitable for the current PyTorch `GuidedDecoder`:
* Fuses d2t for EAGLE3
* Supports token-level mask for CUDA graph

-----

In addition, this PR fixes a race condition in one-model speculative decoding (MTP, MTP-Eagle, Eagle3):
* In PyTorchModelEngine prepare_inputs, `attn_metadata` performs an async H2D copy for `seq_lens` -> `seq_lens_cuda`
* In MTP worker, `attn_metadata.seq_lens` is in-place modified.

If the host code runs fast, the second operation could be earlier than the first operation. If so, the data in `seq_lens_cuda` is corrupted.


## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
