### PR TITLE
[None][feat] add model seed-oss

### DIFF
--- a/tensorrt_llm/_torch/models/__init__.py
+++ b/tensorrt_llm/_torch/models/__init__.py
@@ -30,6 +30,7 @@ from .modeling_qwen_moe import Qwen2MoeForCausalLM
 from .modeling_siglip import SiglipVisionModel
 from .modeling_utils import get_model_architecture
 from .modeling_vila import VilaModel
+from .modeling_seedoss import SeedOssForCausalLM
 
 # Note: for better readiblity, this should have same order as imports above
 __all__ = [
@@ -66,6 +67,7 @@ __all__ = [
     "Qwen3ForCausalLM",
     "Qwen3MoeForCausalLM",
     "GptOssForCausalLM",
+    "SeedOssForCausalLM",
 ]
 
 if transformers.__version__ >= "4.45.1":

--- a/tensorrt_llm/_torch/models/__init__.py
+++ b/tensorrt_llm/_torch/models/__init__.py
@@ -71,7 +71,6 @@ __all__ = [
     "Qwen3ForCausalLM",
     "Qwen3MoeForCausalLM",
     "GptOssForCausalLM",
-    "SeedOssForCausalLM",
 ]
 
 if transformers.__version__ >= "4.45.1":

--- a/tensorrt_llm/_torch/models/__init__.py
+++ b/tensorrt_llm/_torch/models/__init__.py
@@ -30,8 +30,10 @@ from .modeling_qwen_moe import Qwen2MoeForCausalLM
 from .modeling_siglip import SiglipVisionModel
 from .modeling_utils import get_model_architecture
 from .modeling_vila import VilaModel
+
 try:
-    from .modeling_seedoss import SeedOssForCausalLM  # requires transformers with SeedOssConfig
+    from .modeling_seedoss import \
+        SeedOssForCausalLM  # requires transformers with SeedOssConfig
     _HAS_SEEDOSS = True
 except Exception:
     _HAS_SEEDOSS = False

--- a/tensorrt_llm/_torch/models/__init__.py
+++ b/tensorrt_llm/_torch/models/__init__.py
@@ -27,16 +27,10 @@ from .modeling_qwen2vl import Qwen2_5_VLModel, Qwen2VLModel
 from .modeling_qwen3 import Qwen3ForCausalLM
 from .modeling_qwen3_moe import Qwen3MoeForCausalLM
 from .modeling_qwen_moe import Qwen2MoeForCausalLM
+from .modeling_seedoss import SeedOssForCausalLM
 from .modeling_siglip import SiglipVisionModel
 from .modeling_utils import get_model_architecture
 from .modeling_vila import VilaModel
-
-try:
-    from .modeling_seedoss import \
-        SeedOssForCausalLM  # requires transformers with SeedOssConfig
-    _HAS_SEEDOSS = True
-except Exception:
-    _HAS_SEEDOSS = False
 
 # Note: for better readiblity, this should have same order as imports above
 __all__ = [
@@ -73,6 +67,7 @@ __all__ = [
     "Qwen3ForCausalLM",
     "Qwen3MoeForCausalLM",
     "GptOssForCausalLM",
+    "SeedOssForCausalLM",
 ]
 
 if transformers.__version__ >= "4.45.1":
@@ -83,6 +78,3 @@ else:
     print(
         f"Failed to import MllamaForConditionalGeneration as transformers.__version__ {transformers.__version__} < 4.45.1"
     )
-
-if _HAS_SEEDOSS:
-    __all__.append("SeedOssForCausalLM")

--- a/tensorrt_llm/_torch/models/__init__.py
+++ b/tensorrt_llm/_torch/models/__init__.py
@@ -30,7 +30,11 @@ from .modeling_qwen_moe import Qwen2MoeForCausalLM
 from .modeling_siglip import SiglipVisionModel
 from .modeling_utils import get_model_architecture
 from .modeling_vila import VilaModel
-from .modeling_seedoss import SeedOssForCausalLM
+try:
+    from .modeling_seedoss import SeedOssForCausalLM  # requires transformers with SeedOssConfig
+    _HAS_SEEDOSS = True
+except Exception:
+    _HAS_SEEDOSS = False
 
 # Note: for better readiblity, this should have same order as imports above
 __all__ = [
@@ -78,3 +82,6 @@ else:
     print(
         f"Failed to import MllamaForConditionalGeneration as transformers.__version__ {transformers.__version__} < 4.45.1"
     )
+
+if _HAS_SEEDOSS:
+    __all__.append("SeedOssForCausalLM")

--- a/tensorrt_llm/_torch/models/modeling_seedoss.py
+++ b/tensorrt_llm/_torch/models/modeling_seedoss.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from typing import Optional, Tuple
 
 import torch
@@ -27,7 +28,8 @@ class SeedOssAttention(Attention):
         layer_idx: Optional[int] = None,
     ):
         config = model_config.pretrained_config
-        if config.rope_scaling["rope_type"] == "default":
+        rope_scaling = getattr(config, "rope_scaling", None)
+        if isinstance(rope_scaling, dict) and rope_scaling.get("rope_type") == "default":
             # map transformers 'default' type to trtllm 'none' type
             config.rope_scaling["rope_type"] = "none"
         super().__init__(
@@ -68,6 +70,7 @@ class SeedOssDecoderLayer(DecoderLayer):
             bias=config.mlp_bias if hasattr(config, "mlp_bias") else False,
             dtype=config.torch_dtype,
             config=model_config,
+            layer_idx=layer_idx,
         )
         self.input_layernorm = RMSNorm(hidden_size=config.hidden_size,
                                        eps=config.rms_norm_eps,

--- a/tensorrt_llm/_torch/models/modeling_seedoss.py
+++ b/tensorrt_llm/_torch/models/modeling_seedoss.py
@@ -1,0 +1,188 @@
+from typing import Optional, Tuple
+
+import torch
+from torch import nn
+from transformers import SeedOssConfig
+
+from tensorrt_llm.functional import PositionEmbeddingType
+
+from ..attention_backend import AttentionMetadata
+from ..attention_backend.interface import PositionalEmbeddingParams, RopeParams
+from ..model_config import ModelConfig
+from ..modules.attention import Attention
+from ..modules.decoder_layer import DecoderLayer
+from ..modules.embedding import Embedding
+from ..modules.gated_mlp import GatedMLP
+from ..modules.linear import TensorParallelMode
+from ..modules.rms_norm import RMSNorm
+from ..speculative import SpecMetadata
+from .modeling_speculative import SpecDecOneEngineForCausalLM
+from .modeling_utils import DecoderModel, register_auto_model
+
+
+class SeedOssAttention(Attention):
+    def __init__(
+        self,
+        model_config: ModelConfig[SeedOssConfig],
+        layer_idx: Optional[int] = None,
+    ):
+        config = model_config.pretrained_config
+        if config.rope_scaling["rope_type"] == "default":
+            # map transformers 'default' type to trtllm 'none' type
+            config.rope_scaling["rope_type"] = "none"
+        super().__init__(
+            hidden_size=config.hidden_size,
+            num_attention_heads=config.num_attention_heads,
+            num_key_value_heads=config.num_key_value_heads,
+            max_position_embeddings=config.max_position_embeddings,
+            bias=config.attention_bias,
+            pos_embd_params=PositionalEmbeddingParams(
+                type=PositionEmbeddingType.rope_gpt_neox,
+                rope=RopeParams.from_config(config),
+            ),
+            layer_idx=layer_idx,
+            dtype=config.torch_dtype,
+            config=model_config,
+            dense_bias=config.attention_out_bias,
+        )
+
+
+class SeedOssDecoderLayer(DecoderLayer):
+
+    def __init__(
+        self,
+        model_config: ModelConfig[SeedOssConfig],
+        layer_idx: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        super().__init__()
+        self.layer_idx = layer_idx
+        config = model_config.pretrained_config
+        self.self_attn = SeedOssAttention(
+            model_config,
+            layer_idx=layer_idx,
+        )
+
+        self.mlp = GatedMLP(
+            hidden_size=config.hidden_size,
+            intermediate_size=config.intermediate_size,
+            bias=config.mlp_bias if hasattr(config, "mlp_bias") else False,
+            dtype=config.torch_dtype,
+            config=model_config,
+        )
+        self.input_layernorm = RMSNorm(hidden_size=config.hidden_size,
+                                       eps=config.rms_norm_eps,
+                                       dtype=config.torch_dtype)
+        self.post_attention_layernorm = RMSNorm(hidden_size=config.hidden_size,
+                                                eps=config.rms_norm_eps,
+                                                dtype=config.torch_dtype)
+
+    def forward(
+        self,
+        position_ids: torch.IntTensor,
+        hidden_states: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        residual: Optional[torch.Tensor],
+        mrope_config: Optional[Tuple[torch.Tensor, int]] = None,
+        spec_metadata: Optional[SpecMetadata] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        if residual is None:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states, residual = self.input_layernorm(
+                hidden_states, residual)
+
+        # Self Attention
+        hidden_states = self.self_attn(
+            position_ids=position_ids,
+            hidden_states=hidden_states,
+            attn_metadata=attn_metadata,
+            mrope_config=mrope_config,
+            **kwargs,
+        )
+
+        # Fully Connected
+        hidden_states, residual = self.post_attention_layernorm(
+            hidden_states, residual)
+        hidden_states = self.mlp(hidden_states)
+
+        if spec_metadata is not None:
+            spec_metadata.maybe_capture_hidden_states(self.layer_idx,
+                                                      hidden_states, residual)
+
+        return hidden_states, residual
+
+
+class SeedOssModel(DecoderModel):
+
+    def __init__(self, model_config: ModelConfig[SeedOssConfig]):
+        super().__init__(model_config)
+        config = self.model_config
+
+        self.embed_tokens = Embedding(
+            config.pretrained_config.vocab_size,
+            config.pretrained_config.hidden_size,
+            dtype=config.pretrained_config.torch_dtype,
+            mapping=config.mapping,
+            tensor_parallel_mode=TensorParallelMode.COLUMN,
+            gather_output=True,
+        )
+        self.layers = nn.ModuleList([
+            SeedOssDecoderLayer(
+                model_config,
+                layer_idx,
+            ) for layer_idx in range(config.pretrained_config.num_hidden_layers)
+        ])
+        self.norm = RMSNorm(
+            hidden_size=config.pretrained_config.hidden_size,
+            eps=config.pretrained_config.rms_norm_eps,
+            dtype=config.pretrained_config.torch_dtype,
+        )
+
+    def forward(
+        self,
+        attn_metadata: AttentionMetadata,
+        input_ids: Optional[torch.IntTensor] = None,
+        position_ids: Optional[torch.IntTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        mrope_config: Optional[Tuple[torch.Tensor, int]] = None,
+        spec_metadata: Optional[SpecMetadata] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError(
+                "You cannot specify both input_ids and inputs_embeds at the same time, and must specify either one"
+            )
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        hidden_states = inputs_embeds
+
+        residual = None
+        for decoder_layer in self.layers:
+            hidden_states, residual = decoder_layer(
+                position_ids=position_ids,
+                hidden_states=hidden_states,
+                attn_metadata=attn_metadata,
+                residual=residual,
+                mrope_config=mrope_config,
+                spec_metadata=spec_metadata,
+            )
+
+        hidden_states, _ = self.norm(hidden_states, residual)
+        return hidden_states
+
+
+@register_auto_model("SeedOssForCausalLM")
+class SeedOssForCausalLM(SpecDecOneEngineForCausalLM[SeedOssModel, SeedOssConfig]):
+
+    def __init__(
+        self,
+        model_config: ModelConfig[SeedOssConfig],
+    ):
+        super().__init__(
+            SeedOssModel(model_config),
+            model_config,
+        )

--- a/tensorrt_llm/_torch/models/modeling_seedoss.py
+++ b/tensorrt_llm/_torch/models/modeling_seedoss.py
@@ -22,6 +22,7 @@ from .modeling_utils import DecoderModel, register_auto_model
 
 
 class SeedOssAttention(Attention):
+
     def __init__(
         self,
         model_config: ModelConfig[SeedOssConfig],
@@ -29,7 +30,8 @@ class SeedOssAttention(Attention):
     ):
         config = model_config.pretrained_config
         rope_scaling = getattr(config, "rope_scaling", None)
-        if isinstance(rope_scaling, dict) and rope_scaling.get("rope_type") == "default":
+        if isinstance(rope_scaling,
+                      dict) and rope_scaling.get("rope_type") == "default":
             # map transformers 'default' type to trtllm 'none' type
             config.rope_scaling["rope_type"] = "none"
         super().__init__(
@@ -179,7 +181,8 @@ class SeedOssModel(DecoderModel):
 
 
 @register_auto_model("SeedOssForCausalLM")
-class SeedOssForCausalLM(SpecDecOneEngineForCausalLM[SeedOssModel, SeedOssConfig]):
+class SeedOssForCausalLM(SpecDecOneEngineForCausalLM[SeedOssModel,
+                                                     SeedOssConfig]):
 
     def __init__(
         self,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the SeedOss causal language model, now available for use in generation workflows.
  * Enables loading and running SeedOss via the standard auto-model interface.
  * Includes optimized attention, normalization, and MLP blocks for improved model behavior.
  * Supports configurable positional embeddings and tensor-parallel token embeddings.
  * Public API updated to expose SeedOssForCausalLM for easier integration in applications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

This PR adds support for the seed-oss model inference in TensorRT-LLM pytorch backend.
<!--**Important Note: This PR is currently blocked and should not be merged until its dependency is resolved.**-->

## Dependency

- `transformers >= 4.56.0`
- This PR depends on #7523
<!-- - This implementation depends on a forthcoming [change](https://github.com/huggingface/transformers/pull/40272) to the HuggingFace transformers library. -->
<!-- - **Please do not merge this PR until the referenced Transformers PR has been merged and the changes are available in a released version of the transformers library.** -->

## Related Issues
#7196 

## Test Coverage

<!-- - `tests/unittest/_torch/modeling/test_modeling_seedoss.py` -->

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
