### PR TITLE
[https://nvbugs/5496960][fix] Fix Gemma model forward.

### DIFF
--- a/tensorrt_llm/models/gemma/model.py
+++ b/tensorrt_llm/models/gemma/model.py
@@ -157,10 +157,13 @@ class GemmaDecoderLayer(Module):
                 if default_net().plugin_config.reduce_fusion else
                 AllReduceFusionOp.NONE,
                 residual=residual,
-                norm_weight=self.pre_feedforward_layernorm.weight.value,
-                norm_pre_residual_weight=self.post_layernorm.weight.value
+                norm_weight=self.pre_feedforward_layernorm.weight.value
                 if self.config.inter_layernorms else None,
-                eps=self.pre_feedforward_layernorm.eps))
+                norm_pre_residual_weight=self.post_layernorm.weight.value,
+                eps=self.pre_feedforward_layernorm.eps
+                if self.config.inter_layernorms else 1e-06,
+            ),
+        )
 
         if use_cache:
             attention_output, presents = attention_output


### PR DESCRIPTION
Fix the missing condition for the Gemma V1 model path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrects application of normalization only when inter-layer norms are enabled, preventing misconfigured behavior.
  * Aligns epsilon values with the selected configuration for more stable and predictable outputs.
  * Improves numerical consistency across model configurations, reducing variance between runs.
  * Enhances reliability of residual and post-residual normalization, leading to smoother training/inference in supported setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->