### PR TITLE
[None][chore] Upgrade transformers to 4.56.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ nvidia-modelopt[torch]~=0.33.0
 nvidia-nccl-cu12
 # nvidia-cuda-nvrtc-cu12  # <For CUDA 12.9>
 nvidia-cuda-nvrtc
-transformers==4.55.0
+transformers==4.56.0
 prometheus_client
 prometheus_fastapi_instrumentator
 pydantic>=2.9.1

--- a/tensorrt_llm/_torch/auto_deploy/export/library/tensor_meta_device.py
+++ b/tensorrt_llm/_torch/auto_deploy/export/library/tensor_meta_device.py
@@ -7,10 +7,11 @@ from ..interface import BaseExportPatch, ExportPatchRegistry
 
 @ExportPatchRegistry.register("tensor_meta_device")
 class TensorMetaDevicePatch(BaseExportPatch):
-    """Patch torch.tensor to handle 0.0 on meta device.
+    """Patch torch.tensor to handle 0.0 or empty data on meta device.
 
     This patch addresses an issue where torch.tensor(0.0, device="meta")
-    doesn't work and needs to be replaced with torch.zeros((), device="meta").
+    and torch.tensor([], device="meta") doesn't work and needs to be replaced with
+    torch.zeros operator.
     """
 
     def _apply_patch(self):
@@ -21,8 +22,11 @@ class TensorMetaDevicePatch(BaseExportPatch):
         # Create patched function
         def _torch_tensor_patch(data, **kwargs):
             device = kwargs.get("device", None)
-            if data == 0.0 and device is not None and torch.device(device) == torch.device("meta"):
-                return torch.zeros((), **kwargs)
+            if device is not None and torch.device(device) == torch.device("meta"):
+                if data == 0.0:
+                    return torch.zeros((), **kwargs)
+                if data == [] or data == ():
+                    return torch.zeros((0,), **kwargs)
             return self.original_values["torch.tensor"](data, **kwargs)
 
         # Apply patch

--- a/tests/unittest/_torch/modeling/test_modeling_nemotron_nas.py
+++ b/tests/unittest/_torch/modeling/test_modeling_nemotron_nas.py
@@ -4,10 +4,10 @@ from dataclasses import dataclass
 from typing import Any
 
 import torch
+import transformers
 from parameterized import parameterized
 from transformers import AutoConfig
 from transformers.dynamic_module_utils import get_class_from_dynamic_module
-from transformers.generation.utils import NEED_SETUP_CACHE_CLASSES_MAPPING
 from utils.llm_data import llm_models_root
 
 import tensorrt_llm
@@ -19,6 +19,9 @@ from tensorrt_llm._torch.models.modeling_nemotron_nas import \
 from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
 from tensorrt_llm.bindings.executor import KvCacheConfig
 from tensorrt_llm.mapping import Mapping
+
+# Setup NEED_SETUP_CACHE_CLASSES_MAPPING to an empty dict for modeling_nemotron_nas.py
+transformers.generation.utils.NEED_SETUP_CACHE_CLASSES_MAPPING = dict()
 
 NEMOTRON_NAS_MINI_CONFIG = {
     "architectures": ["DeciLMForCausalLM"],
@@ -392,7 +395,8 @@ class TestNemotronNAS(unittest.TestCase):
         # This line populates the "variable" field in the NEED_SETUP_CACHE_CLASSES_MAPPING dict
         hf_nemotron_nas._prepare_generation_config(None)
         # And this line is the only way to access the only concrete Cache class DeciLMForCausalLM accepts
-        VariableCache = NEED_SETUP_CACHE_CLASSES_MAPPING["variable"]
+        VariableCache = transformers.generation.utils.NEED_SETUP_CACHE_CLASSES_MAPPING[
+            "variable"]
 
         model_config = ModelConfig(pretrained_config=nemotron_nas_config,
                                    attn_backend=backend)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Bug Fixes
  * Improved robustness when creating tensors on the meta device, correctly handling empty inputs and preventing errors in edge cases.

* Chores
  * Upgraded Transformers dependency to 4.56.0 for improved compatibility and maintenance.

* Tests
  * Updated tests to align with the latest Transformers generation utilities, ensuring consistent behavior and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
