### PR TITLE
[https://nvbugs/5474409][fix] Potential fix for oom

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -731,6 +731,7 @@ def run_concurrently(func,
         }
 
         # Process completed tasks as they finish
+
         for result in futures.as_completed(future_to_result):
             arg = future_to_result[result]
             try:
@@ -744,6 +745,9 @@ def run_concurrently(func,
                     f"Error executing {func.__name__} with args {arg}: {str(e)}"
                 )
                 raise
+    # cleanup the cache so that any subsequent tasks can use the free memory (specifically the sequential tasks)
+    torch.cuda.empty_cache()
+    pbar.close()
 
 
 def _load_weights_impl(model: Union[nn.Module, DecoderModelForCausalLM],
@@ -775,60 +779,76 @@ def _load_weights_impl(model: Union[nn.Module, DecoderModelForCausalLM],
         'qkv_proj': ['q_proj', 'k_proj', 'v_proj'],
         'gate_up_proj': ['gate_proj', 'up_proj']
     }
+    # serial_load_modules is the list of modules that are loaded serially before running concurrently
+    serial_load_modules = []
+    # serial_retry_oomed_modules is the list of modules that are loaded serially after running concurrently due to OOM error
+    serial_retry_oomed_modules = []
 
     def load_single_module(name, module):
-        if len(module._parameters) > 0:
-            # skip load weights if module is in skip_modules
-            if any(skip_module in name for skip_module in skip_modules):
-                return
+        try:
+            if len(module._parameters) > 0:
+                # skip load weights if module is in skip_modules
+                if any(skip_module in name for skip_module in skip_modules):
+                    return
 
-            # skip load weights if tie word embeddings is enabled and layer is lm_head
-            if model.config.tie_word_embeddings and name.startswith("lm_head"):
-                return
+                # skip load weights if tie word embeddings is enabled and layer is lm_head
+                if model.config.tie_word_embeddings and name.startswith(
+                        "lm_head"):
+                    return
 
-            # Skip loading weights for embedding and lm_head if LoRA is enabled and has custom values
-            if hasattr(model, "model") and hasattr(
-                    model.model, 'has_custom_embed_tokens'
-            ) and model.model.has_custom_embed_tokens and name == "model.embed_tokens":
-                return
-            if hasattr(model, 'has_custom_lm_head'
-                       ) and model.has_custom_lm_head and name == "lm_head":
-                return
+                # Skip loading weights for embedding and lm_head if LoRA is enabled and has custom values
+                if hasattr(model, "model") and hasattr(
+                        model.model, 'has_custom_embed_tokens'
+                ) and model.model.has_custom_embed_tokens and name == "model.embed_tokens":
+                    return
+                if hasattr(model, 'has_custom_lm_head'
+                           ) and model.has_custom_lm_head and name == "lm_head":
+                    return
 
-            names = name.split('.')
-            # WAR: better solution is that llama has its own load_weights function.
-            if names[-1] == 'next_layer_layernorm':
-                return
-            if names[-1] in params_map:
-                module_weights = []
-                for new_name in params_map[names[-1]]:
-                    fw = filter_weights('.'.join(names[:-1] + [new_name]),
-                                        weights)
-                    if new_name in ['k_proj', 'v_proj']:
-                        num_kv_heads_list = [num_kv_heads
-                                             ] * len(fw) if isinstance(
-                                                 num_kv_heads,
-                                                 int) else num_kv_heads
-                        fw = {
-                            k:
-                            duplicate_kv_weight(
-                                weight=v[:],
-                                num_kv_heads=num_kv_heads_list[i],
-                                tensor_parallel_size=tp_size)
-                            if k in ["weight", "bias"] else v
-                            for i, (k, v) in enumerate(fw.items())
-                        }
+                names = name.split('.')
+                # WAR: better solution is that llama has its own load_weights function.
+                if names[-1] == 'next_layer_layernorm':
+                    return
+                if names[-1] in params_map:
+                    module_weights = []
+                    for new_name in params_map[names[-1]]:
+                        fw = filter_weights('.'.join(names[:-1] + [new_name]),
+                                            weights)
+                        if new_name in ['k_proj', 'v_proj']:
+                            num_kv_heads_list = [num_kv_heads
+                                                 ] * len(fw) if isinstance(
+                                                     num_kv_heads,
+                                                     int) else num_kv_heads
+                            fw = {
+                                k:
+                                duplicate_kv_weight(
+                                    weight=v[:],
+                                    num_kv_heads=num_kv_heads_list[i],
+                                    tensor_parallel_size=tp_size)
+                                if k in ["weight", "bias"] else v
+                                for i, (k, v) in enumerate(fw.items())
+                            }
 
-                    module_weights.append(fw)
-                module.load_weights(weights=module_weights)
-            else:
-                module_weights = filter_weights(name, weights)
-                if hasattr(module, 'load_weights'):
-                    module.load_weights(weights=[module_weights])
+                        module_weights.append(fw)
+                    module.load_weights(weights=module_weights)
                 else:
-                    for n, p in module._parameters.items():
-                        if p is not None:
-                            p.data.copy_(module_weights[n][:])
+                    module_weights = filter_weights(name, weights)
+                    if hasattr(module, 'load_weights'):
+                        module.load_weights(weights=[module_weights])
+                    else:
+                        for n, p in module._parameters.items():
+                            if p is not None:
+                                p.data.copy_(module_weights[n][:])
+        except torch.OutOfMemoryError as e:
+            logger.warning(
+                f"Out of memory error in {load_single_module.__name__} with args {name, module}: {str(e)}"
+            )
+            serial_retry_oomed_modules.append((name, module))
+        except Exception as e:
+            logger.warning(
+                f"Error executing {load_single_module.__name__} with args {name, module}: {str(e)}"
+            )
+            raise
 
     if os.environ.get("TRT_LLM_DISABLE_LOAD_WEIGHTS_IN_PARALLEL",
                       False) in ["True", "true", "1", "yes", "y"]:
@@ -857,6 +877,15 @@ def _load_weights_impl(model: Union[nn.Module, DecoderModelForCausalLM],
         args_list = [(name, module) for name, module in model.named_modules()
                      if name not in serial_load_modules]
         run_concurrently(load_single_module, args_list, pbar=pbar)
+
+        # Now retry the modules that failed due to OOM error
+        if serial_retry_oomed_modules:
+            pbar = tqdm(serial_retry_oomed_modules,
+                        desc="Loading weights serially")
+            for name, module in serial_retry_oomed_modules:
+                load_single_module(name, module)
+                pbar.update(1)
+            pbar.close()
 
 
 def _load_weights_impl_v2(model: Union[nn.Module, DecoderModelForCausalLM],


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added serial pre-load and serial retry passes so selected critical modules load before and after concurrent loading.
  - New progress indication for serial retry phase and warning-level reporting for load issues.

- **Bug Fixes**
  - Concurrent weight loading now handles GPU OOMs by queueing affected parts for serial retry instead of failing.
  - GPU memory is freed between phases to reduce follow-up OOMs and improve stability for very large models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
