### PR TITLE
[#7308][feat] AutoDeploy: basic transformers mode with model build + cached attention + multi-gpu support

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/config/transformers.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/transformers.yaml
@@ -2,7 +2,7 @@
 #In transformers mode are playing with gm.factory_module, which is a dead module.
 #Need to always ensure not cleaning graph.
 transforms:
-  build_model:
+  build_and_load_factory_model:
     stage: factory
     device: meta
     run_graph_cleanup: false
@@ -13,7 +13,7 @@ transforms:
     run_graph_cleanup: false
     requires_clean_graph: false
 
-  load_factory_model_weights:
+  move_cm_to_device:
     stage: weight_load
     run_graph_cleanup: false
     requires_clean_graph: false

--- a/tensorrt_llm/_torch/auto_deploy/config/transformers.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/transformers.yaml
@@ -1,0 +1,27 @@
+# Additional default args for AutoDeployConfig/LlmArgs in _torch/auto_deploy/llm_args.py
+#In transformers mode are playing with gm.factory_module, which is a dead module.
+#Need to always ensure not cleaning graph.
+transforms:
+  build_model:
+    stage: factory
+    device: meta
+    run_graph_cleanup: false
+    requires_clean_graph: false
+
+  transformers_replace_cached_attn:
+    stage: factory
+    run_graph_cleanup: false
+    requires_clean_graph: false
+
+  load_weights:
+    stage: weight_load
+    run_graph_cleanup: false
+    requires_clean_graph: false
+    #We need this argument to load weights for the factory model.
+    load_factoy_model: true
+
+  initialize_cache:
+    stage: cache_init
+
+  resize_kv_cache:
+    stage: cache_init

--- a/tensorrt_llm/_torch/auto_deploy/config/transformers.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/transformers.yaml
@@ -13,12 +13,10 @@ transforms:
     run_graph_cleanup: false
     requires_clean_graph: false
 
-  load_weights:
+  load_factory_model_weights:
     stage: weight_load
     run_graph_cleanup: false
     requires_clean_graph: false
-    #We need this argument to load weights for the factory model.
-    load_factoy_model: true
 
   initialize_cache:
     stage: cache_init

--- a/tensorrt_llm/_torch/auto_deploy/config/transformers.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/transformers.yaml
@@ -12,6 +12,7 @@ transforms:
     stage: factory
     run_graph_cleanup: false
     requires_clean_graph: false
+    attn_backend: flashinfer
 
   move_cm_to_device:
     stage: weight_load

--- a/tensorrt_llm/_torch/auto_deploy/distributed/common.py
+++ b/tensorrt_llm/_torch/auto_deploy/distributed/common.py
@@ -136,6 +136,7 @@ def initialize(rank: int = 0, world_size: int = 1, port: Optional[int] = None) -
     os.environ["WORLD_SIZE"] = str(world_size)
     os.environ["MASTER_ADDR"] = "127.0.0.1"
     os.environ["MASTER_PORT"] = str(port)
+    os.environ["LOCAL_RANK"] = str(local_rank)
 
     # Necessary to assign a device to each rank.
     torch.cuda.set_device(local_rank)

--- a/tensorrt_llm/_torch/auto_deploy/llm_args.py
+++ b/tensorrt_llm/_torch/auto_deploy/llm_args.py
@@ -18,10 +18,14 @@ PathLike = Union[str, Path]
 
 
 def _get_config_dict() -> SettingsConfigDict:
+    # yaml_file = "default.yaml"
+    yaml_file = "transformers.yaml"
+    print(f"Using config file: {yaml_file}")
+
     return SettingsConfigDict(
         arbitrary_types_allowed=True,
         extra="forbid",
-        yaml_file=str(files("tensorrt_llm._torch.auto_deploy.config") / "default.yaml"),
+        yaml_file=str(files("tensorrt_llm._torch.auto_deploy.config") / yaml_file),
         nested_model_default_partial_update=True,
     )
 

--- a/tensorrt_llm/_torch/auto_deploy/models/factory.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/factory.py
@@ -152,7 +152,9 @@ class ModelFactory(ABC):
         """
         return model_name_or_path
 
-    def load_or_random_init(self, model: nn.Module, device: DeviceLikeType):
+    def load_or_random_init(
+        self, model: nn.Module, device: DeviceLikeType, load_factoy_model: bool = False
+    ):
         """Load the checkpoint into the model or randomly initialize the model.
 
         Args:
@@ -160,6 +162,8 @@ class ModelFactory(ABC):
                 the same model that is built above but it needs to have a state dict compatible with
                 the model built above.
             device: The device to load the model on.
+            load_factoy_model: If True, will load weights for the factory model in addition to main
+                gm. This is useful for the transformers model.
 
         NOTE: we always call ``self._to_maybe_random(model, device)`` as a preprocessing step
         to ensure the model parameters already exist on the right device and have the desired dtype
@@ -190,7 +194,7 @@ class ModelFactory(ABC):
         self._to_maybe_random(model, device)
         if not self.skip_loading_weights:
             self.prefetch_checkpoint(force=True)
-            self._load_checkpoint(model, device)
+            self._load_checkpoint(model, device, load_factoy_model=load_factoy_model)
 
     @staticmethod
     def _to_maybe_random(model: nn.Module, device: DeviceLikeType):

--- a/tensorrt_llm/_torch/auto_deploy/models/factory.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/factory.py
@@ -152,9 +152,7 @@ class ModelFactory(ABC):
         """
         return model_name_or_path
 
-    def load_or_random_init(
-        self, model: nn.Module, device: DeviceLikeType, load_factoy_model: bool = False
-    ):
+    def load_or_random_init(self, model: nn.Module, device: DeviceLikeType):
         """Load the checkpoint into the model or randomly initialize the model.
 
         Args:
@@ -194,7 +192,7 @@ class ModelFactory(ABC):
         self._to_maybe_random(model, device)
         if not self.skip_loading_weights:
             self.prefetch_checkpoint(force=True)
-            self._load_checkpoint(model, device, load_factoy_model=load_factoy_model)
+            self._load_checkpoint(model, device)
 
     @staticmethod
     def _to_maybe_random(model: nn.Module, device: DeviceLikeType):

--- a/tensorrt_llm/_torch/auto_deploy/models/hf.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/hf.py
@@ -328,7 +328,9 @@ class AutoModelForCausalLMFactory(ModelFactory):
 
         return fetched_dir
 
-    def _load_checkpoint(self, model: nn.Module, device: DeviceLikeType):
+    def _load_checkpoint(
+        self, model: nn.Module, device: DeviceLikeType, load_factoy_model: bool = False
+    ):
         """Load the checkpoint into the model."""
         # identify the most relevant checkpoint file
         ckpt_file = self._get_checkpoint_file(self.model)
@@ -341,6 +343,11 @@ class AutoModelForCausalLMFactory(ModelFactory):
             # This sync step can interfere with load_hooks by mixing raw checkpoint weights and
             # model-transformed weights,leading to unexpected key mismatches or format issues.
             load_checkpoint_in_model(model, checkpoint=ckpt_file, full_state_dict=False)
+            # In eager mode, we also load weights for the factory model.
+            if load_factoy_model:
+                load_checkpoint_in_model(
+                    model.factory_model, checkpoint=ckpt_file, full_state_dict=False
+                )
 
     def _load_quantization_config(self, fetched_dir: str):
         """Load the quantization config from the model directory if not done already."""

--- a/tensorrt_llm/_torch/auto_deploy/models/hf.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/hf.py
@@ -118,6 +118,13 @@ class AutoModelForCausalLMFactory(ModelFactory):
         """
         return type(model).forward(model, input_ids=input_ids, position_ids=position_ids)
 
+    @staticmethod
+    def _simple_forward_with_kwargs(
+        model: nn.Module, input_ids: torch.Tensor, position_ids: torch.Tensor, **kwargs
+    ):
+        """A simple forward pass with kwargs."""
+        return type(model).forward(model, input_ids=input_ids, position_ids=position_ids, **kwargs)
+
     def _recursive_update_config(self, config: PretrainedConfig, update_dict: Dict[str, Any]):
         """
         Deep-merge a PretrainedConfig object with values from update_dict.
@@ -169,6 +176,7 @@ class AutoModelForCausalLMFactory(ModelFactory):
 
         # patch forward method
         model.forward = types.MethodType(self._simple_forward, model)
+        model.forward_with_kwargs = types.MethodType(self._simple_forward_with_kwargs, model)
 
         model.eval()
 

--- a/tensorrt_llm/_torch/auto_deploy/models/hf.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/hf.py
@@ -118,13 +118,6 @@ class AutoModelForCausalLMFactory(ModelFactory):
         """
         return type(model).forward(model, input_ids=input_ids, position_ids=position_ids)
 
-    @staticmethod
-    def _simple_forward_with_kwargs(
-        model: nn.Module, input_ids: torch.Tensor, position_ids: torch.Tensor, **kwargs
-    ):
-        """A simple forward pass with kwargs."""
-        return type(model).forward(model, input_ids=input_ids, position_ids=position_ids, **kwargs)
-
     def _recursive_update_config(self, config: PretrainedConfig, update_dict: Dict[str, Any]):
         """
         Deep-merge a PretrainedConfig object with values from update_dict.
@@ -175,8 +168,8 @@ class AutoModelForCausalLMFactory(ModelFactory):
         self._set_sharding_config(model.config)
 
         # patch forward method
+        model.original_forward = model.forward
         model.forward = types.MethodType(self._simple_forward, model)
-        model.forward_with_kwargs = types.MethodType(self._simple_forward_with_kwargs, model)
 
         model.eval()
 

--- a/tensorrt_llm/_torch/auto_deploy/models/hf.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/hf.py
@@ -328,9 +328,7 @@ class AutoModelForCausalLMFactory(ModelFactory):
 
         return fetched_dir
 
-    def _load_checkpoint(
-        self, model: nn.Module, device: DeviceLikeType, load_factoy_model: bool = False
-    ):
+    def _load_checkpoint(self, model: nn.Module, device: DeviceLikeType):
         """Load the checkpoint into the model."""
         # identify the most relevant checkpoint file
         ckpt_file = self._get_checkpoint_file(self.model)
@@ -343,11 +341,6 @@ class AutoModelForCausalLMFactory(ModelFactory):
             # This sync step can interfere with load_hooks by mixing raw checkpoint weights and
             # model-transformed weights,leading to unexpected key mismatches or format issues.
             load_checkpoint_in_model(model, checkpoint=ckpt_file, full_state_dict=False)
-            # In eager mode, we also load weights for the factory model.
-            if load_factoy_model:
-                load_checkpoint_in_model(
-                    model.factory_model, checkpoint=ckpt_file, full_state_dict=False
-                )
 
     def _load_quantization_config(self, fetched_dir: str):
         """Load the quantization config from the model directory if not done already."""

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/build_model.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/build_model.py
@@ -1,9 +1,11 @@
 """A simple wrapper transform to build a model via the model factory."""
 
+import types
 from typing import Tuple, Type
 
 from pydantic import Field
 from torch.fx import GraphModule
+from transformers import AutoModelForCausalLM
 
 from ...models.factory import ModelFactory
 from ...shim.interface import CachedSequenceInterface
@@ -41,6 +43,39 @@ class BuildModel(BaseTransform):
     ) -> Tuple[GraphModule, TransformInfo]:
         # build the model
         model = factory.build_model(self.config.device)
+
+        # as wrapper to satisfy the interface we will register the model as a submodule
+        gm.add_module("factory_model", model)
+
+        # by convention, we say this fake graph module is always clean
+        info = TransformInfo(skipped=False, num_matches=1, is_clean=True, has_valid_shapes=True)
+
+        return gm, info
+
+
+@TransformRegistry.register("build_and_load_factory_model")
+class BuildAndLoadFactoryModel(BaseTransform):
+    """A simple wrapper transform to build a model via the model factory."""
+
+    def _apply(
+        self,
+        gm: GraphModule,
+        cm: CachedSequenceInterface,
+        factory: ModelFactory,
+        shared_config: SharedConfig,
+    ) -> Tuple[GraphModule, TransformInfo]:
+        # load model with auto sharding
+        model = AutoModelForCausalLM.from_pretrained(
+            factory.model,
+            trust_remote_code=True,
+            tp_plan="auto",
+            torch_dtype="auto",
+        )
+
+        # patch forward method
+        model.original_forward = model.forward
+        model.forward = types.MethodType(factory._simple_forward, model)
+        model.eval()
 
         # as wrapper to satisfy the interface we will register the model as a submodule
         gm.add_module("factory_model", model)

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/load_weights.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/load_weights.py
@@ -24,6 +24,9 @@ class LoadWeightsToDeviceConfig(TransformConfig):
     adconfig_checkpoint_device: Optional[str] = Field(
         default=None, description="Optional checkpoint device argument from adconfig."
     )
+    load_factoy_model: bool = Field(
+        default=False, description="Whether to load the factory model in addition to main gm."
+    )
 
 
 @TransformRegistry.register("load_weights")
@@ -43,8 +46,11 @@ class LoadWeightsToDevice(BaseTransform):
         factory: ModelFactory,
         shared_config: SharedConfig,
     ) -> Tuple[GraphModule, TransformInfo]:
+        # breakpoint()
         factory.load_or_random_init(
-            gm, device=self.config.adconfig_checkpoint_device or self.config.device
+            gm,
+            device=self.config.adconfig_checkpoint_device or self.config.device,
+            load_factoy_model=self.config.load_factoy_model,
         )
         move_to_device(gm, self.config.device)
         cm.to(self.config.device)

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/load_weights.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/load_weights.py
@@ -46,7 +46,6 @@ class LoadWeightsToDevice(BaseTransform):
         factory: ModelFactory,
         shared_config: SharedConfig,
     ) -> Tuple[GraphModule, TransformInfo]:
-        # breakpoint()
         factory.load_or_random_init(
             gm,
             device=self.config.adconfig_checkpoint_device or self.config.device,

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/load_weights.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/load_weights.py
@@ -55,7 +55,7 @@ class LoadWeightsToDevice(BaseTransform):
         return gm, info
 
 
-@TransformRegistry.register("load_factory_model_weights")
+@TransformRegistry.register("move_cm_to_device")
 class LoadFactoryModelWeights(LoadWeightsToDevice):
     """Load weights for the factory model in the transformers mode."""
 
@@ -66,11 +66,6 @@ class LoadFactoryModelWeights(LoadWeightsToDevice):
         factory: ModelFactory,
         shared_config: SharedConfig,
     ) -> Tuple[GraphModule, TransformInfo]:
-        factory.load_or_random_init(
-            gm.factory_model,
-            device=self.config.adconfig_checkpoint_device or self.config.device,
-        )
-        move_to_device(gm.factory_model, self.config.device)
         cm.to(self.config.device)
 
         info = TransformInfo(skipped=False, num_matches=0, is_clean=True, has_valid_shapes=True)

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/transformers_attn.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/transformers_attn.py
@@ -49,9 +49,8 @@ def cached_mha_for_hf(
     key = torch.einsum("bhld->blhd", key)
     value = torch.einsum("bhld->blhd", value)
 
-    # cm pass cache of all layers. we need to get the current layer's kv cache.
-    layer_idx = module._layer_idx
-    layer_kv_cache = (all_layers_kv_cache[layer_idx * 2], all_layers_kv_cache[layer_idx * 2 + 1])
+    # Get the current layer's kv cache.
+    layer_kv_cache = all_layers_kv_cache[module._layer_idx]
 
     attn_output = torch.ops.auto_deploy.flashinfer_attention_mha_with_cache(
         # QKV
@@ -75,39 +74,29 @@ def cached_mha_for_hf(
     return attn_output, attn_weights
 
 
-def forward_cached(module: torch.nn.Module, *cm_args, **cm_kwargs):
+def forward_cached(module: torch.nn.Module, *cm_args):
     """
     Run transformers module with cm inputs and cached attn.
     Used to patch the original HFCausalLM.forward method.
     """
-    expected_num_args = (
-        2 + module.num_cached_attn_args + module.num_kvcache_args + module.num_buffer_args
-    )
-    assert len(cm_args) == expected_num_args, (
-        f"Number of cm input args ({len(cm_args)}) mismatch. Expected {expected_num_args}."
-    )
-
-    input_ids, position_ids = cm_args[:2]
+    args_map = module.cm_args_index_map
+    input_ids, position_ids = cm_args[args_map["ids_and_position_ids"]]
 
     # cached_attn_args: seq_len, input_pos, cache_loc, pages_per_seq
-    cached_attn_args = cm_args[2 : 2 + module.num_cached_attn_args]
+    cached_attn_args = cm_args[args_map["cached_attn_args"]]
     metadata = module.get_attn_metadata(input_ids, position_ids, *cached_attn_args)
-    assert len(metadata) == module.num_metadata, (
-        f"Number of metadata ({len(metadata)}) mismatch. Expected {module.num_metadata}."
-    )
 
-    # kv_cache_args: k_cache_0, v_cache_0, k_cache_1, v_cache_1, ...
-    kv_cache_args = cm_args[
-        2 + module.num_cached_attn_args : 2 + module.num_cached_attn_args + module.num_kvcache_args
-    ]
+    # organize kv cache into one list per layer,
+    # e.g. [[k_cache_0, v_cache_0], [k_cache_1, v_cache_1], ...]
+    all_layers_kv_cache = [cm_args[slice] for slice in args_map["kvcache_args"]]
 
     # buffers: (workspace_buffer,)
-    buffers = cm_args[2 + module.num_cached_attn_args + module.num_kvcache_args :]
+    buffers = cm_args[args_map["buffer_args"]]
 
     # pass additional inputs with kwargs
     hf_input_kwargs = {
         "metadata": metadata,
-        "all_layers_kv_cache": kv_cache_args,
+        "all_layers_kv_cache": all_layers_kv_cache,
         "buffers": buffers,
     }
 
@@ -134,14 +123,23 @@ class HFReplaceCachedAttn(BaseTransform):
         ALL_ATTENTION_FUNCTIONS.register("ad_cached_mha", cached_mha_for_hf)
         gm.factory_model.config._attn_implementation = "ad_cached_mha"
 
-        # switch cm to cached attn inputs
-        num_cached_attn_args = len(cm.info.switch_to_cached_attn_inputs())
-
         # Each attn module save their layer idx to find their cache from cm input args later.
         for layer_idx in range(hf_config.num_hidden_layers):
             gm.factory_model.model.layers[layer_idx].self_attn._layer_idx = layer_idx
 
-        # Add cache
+        cm_args_index_map = {}
+        # cm have 2 inputs by default, input_ids and position_ids.
+        num_cm_args = len(cm.args)
+        cm_args_index_map["ids_and_position_ids"] = slice(0, num_cm_args)
+
+        # Add cached attn args and update index map
+        num_cached_attn_args = len(cm.info.switch_to_cached_attn_inputs())
+        cm_args_index_map["cached_attn_args"] = slice(
+            num_cm_args, num_cm_args + num_cached_attn_args
+        )
+        num_cm_args += num_cached_attn_args
+
+        # Add cache and update map
         # equivalent to attn_descriptor.get_cache_initializers()
         def _get_cache(si: SequenceInfo):
             return torch.empty(
@@ -157,18 +155,18 @@ class HFReplaceCachedAttn(BaseTransform):
             "k_cache": _get_cache,
             "v_cache": _get_cache,
         }
-
-        num_kvcache_args = 0
+        per_layer_kvcache_slice = []
         for layer_idx in range(hf_config.num_hidden_layers):
             for k_or_v, get_cache in cache_initializers.items():
-                k_indexed = f"{k_or_v}_{layer_idx}"
-                cm.add_cache(k_indexed, get_cache)
-                num_kvcache_args += 1
+                cm.add_cache(f"{k_or_v}_{layer_idx}", get_cache)
+            per_layer_kvcache_slice.append(
+                slice(num_cm_args, num_cm_args + len(cache_initializers))
+            )
+            num_cm_args += len(cache_initializers)
+        cm_args_index_map["kvcache_args"] = per_layer_kvcache_slice
 
-        # Add buffer
+        # Add buffer and update map
         # equivalent to attn_descriptor.get_global_buffer_initializers
-        num_buffer_args = 0
-
         def _init_workspace(si: SequenceInfo) -> torch.Tensor:
             # NOTE (lucaslie): avoid OOM for many cudagraphs,
             # see https://github.com/NVIDIA/TensorRT-LLM/pull/3686
@@ -177,23 +175,17 @@ class HFReplaceCachedAttn(BaseTransform):
             return buffer
 
         cm.add_cache("workspace_buffer", _init_workspace)
-        num_buffer_args += 1
+        cm_args_index_map["buffer_args"] = slice(num_cm_args, num_cm_args + 1)
 
         # prepare get_metadata function
-        get_metadata, num_metadata = attn_descriptor.get_prepare_metadata_op()
-
-        # Save attributes for the module to use during forward
-        # TODO: consider make an attribute class
+        get_metadata, _ = attn_descriptor.get_prepare_metadata_op()
         gm.factory_model.get_attn_metadata = partial(get_metadata, page_size=cm.info.page_size)
-        gm.factory_model.num_cached_attn_args = num_cached_attn_args
-        gm.factory_model.num_kvcache_args = num_kvcache_args
-        gm.factory_model.num_buffer_args = num_buffer_args
-        gm.factory_model.num_metadata = num_metadata
+
+        # Save index map for the module to fetch args from cm input
+        gm.factory_model.cm_args_index_map = cm_args_index_map
 
         # Finally, we patch the forward method of facotry_model and the whole gm.
-        gm.factory_model.forward = types.MethodType(
-            partial(forward_cached, get_metadata=get_metadata), gm.factory_model
-        )
+        gm.factory_model.forward = types.MethodType(forward_cached, gm.factory_model)
         gm.forward = gm.factory_model.forward
 
         # by convention, we say this fake graph module is always clean

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/transformers_attn.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/transformers_attn.py
@@ -1,0 +1,203 @@
+"""A simple wrapper transform to build a model via the model factory."""
+
+import types
+from functools import partial
+from typing import Optional, Tuple
+
+import torch
+from torch.fx import GraphModule
+from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+from ...custom_ops.attention_interface import AttentionRegistry
+from ...models.factory import ModelFactory
+from ...shim.interface import CachedSequenceInterface, SequenceInfo
+from ..interface import BaseTransform, SharedConfig, TransformInfo, TransformRegistry
+
+
+def cached_mha_for_hf(
+    module: torch.nn.Module,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: Optional[torch.Tensor],
+    dropout: float = 0.0,
+    scaling: Optional[float] = None,
+    **kwargs,
+):
+    """
+    A wrapper that accept HF attn inputs and outputs but calls flashinfer operator.
+    Used to patch attn_interface in transformers.
+    Args:
+        *args: same as HF attention_interface.
+        **kwargs: need to contain metadata, all_layers_kv_cache, and buffers from cm.
+    Returns:
+        attn_output: same as HF attention_interface.
+        attn_weights: set to None.
+    """
+
+    # First we extract cached attn inputs from kwargs
+    try:
+        metadata = kwargs["metadata"]
+        all_layers_kv_cache = kwargs["all_layers_kv_cache"]
+        buffers = kwargs["buffers"]
+    except KeyError as e:
+        raise KeyError(f"Missing required kwarg: {e.args[0]}")
+
+    # reshape to flashinfer input format
+    # TODO:(hg) might want to optimize this later.
+    query = torch.einsum("bhld->blhd", query)
+    key = torch.einsum("bhld->blhd", key)
+    value = torch.einsum("bhld->blhd", value)
+
+    # cm pass cache of all layers. we need to get the current layer's kv cache.
+    layer_idx = module._layer_idx
+    layer_kv_cache = (all_layers_kv_cache[layer_idx * 2], all_layers_kv_cache[layer_idx * 2 + 1])
+
+    attn_output = torch.ops.auto_deploy.flashinfer_attention_mha_with_cache(
+        # QKV
+        query,
+        key,
+        value,
+        # metadata
+        *metadata,
+        # caches
+        *layer_kv_cache,
+        # buffers
+        *buffers,
+        # constants, harded coded for flashinfer.
+        scaling,
+        k_scale=1,
+        v_scale=1,
+    )
+
+    attn_weights = None
+
+    return attn_output, attn_weights
+
+
+def forward_cached(module: torch.nn.Module, *cm_args, **cm_kwargs):
+    """
+    Run transformers module with cm inputs and cached attn.
+    Used to patch the original HFCausalLM.forward method.
+    """
+    expected_num_args = (
+        2 + module.num_cached_attn_args + module.num_kvcache_args + module.num_buffer_args
+    )
+    assert len(cm_args) == expected_num_args, (
+        f"Number of cm input args ({len(cm_args)}) mismatch. Expected {expected_num_args}."
+    )
+
+    input_ids, position_ids = cm_args[:2]
+
+    # cached_attn_args: seq_len, input_pos, cache_loc, pages_per_seq
+    cached_attn_args = cm_args[2 : 2 + module.num_cached_attn_args]
+    metadata = module.get_attn_metadata(input_ids, position_ids, *cached_attn_args)
+    assert len(metadata) == module.num_metadata, (
+        f"Number of metadata ({len(metadata)}) mismatch. Expected {module.num_metadata}."
+    )
+
+    # kv_cache_args: k_cache_0, v_cache_0, k_cache_1, v_cache_1, ...
+    kv_cache_args = cm_args[
+        2 + module.num_cached_attn_args : 2 + module.num_cached_attn_args + module.num_kvcache_args
+    ]
+
+    # buffers: (workspace_buffer,)
+    buffers = cm_args[2 + module.num_cached_attn_args + module.num_kvcache_args :]
+
+    # pass additional inputs with kwargs
+    hf_input_kwargs = {
+        "metadata": metadata,
+        "all_layers_kv_cache": kv_cache_args,
+        "buffers": buffers,
+    }
+
+    return module.forward_with_kwargs(input_ids, position_ids, **hf_input_kwargs)
+
+
+@TransformRegistry.register("transformers_replace_cached_attn")
+class HFReplaceCachedAttn(BaseTransform):
+    """Replace cached attention for the factory model, update inputs and outputs, and patch the gm forward."""
+
+    def _apply(
+        self,
+        gm: GraphModule,
+        cm: CachedSequenceInterface,
+        factory: ModelFactory,
+        shared_config: SharedConfig,
+    ) -> Tuple[GraphModule, TransformInfo]:
+        cache_config = factory.get_cache_config()
+        hf_config = gm.factory_model.config
+        # TODO:(hg) Hard-coded attn_backend=flashinfer now.
+        attn_descriptor = AttentionRegistry.get("flashinfer")
+
+        # Register cached attn in HF.
+        ALL_ATTENTION_FUNCTIONS.register("ad_cached_mha", cached_mha_for_hf)
+        gm.factory_model.config._attn_implementation = "ad_cached_mha"
+
+        # switch cm to cached attn inputs
+        num_cached_attn_args = len(cm.info.switch_to_cached_attn_inputs())
+
+        # Each attn module save their layer idx to find their cache from cm input args later.
+        for layer_idx in range(hf_config.num_hidden_layers):
+            gm.factory_model.model.layers[layer_idx].self_attn._layer_idx = layer_idx
+
+        # Add cache
+        # equivalent to attn_descriptor.get_cache_initializers()
+        def _get_cache(si: SequenceInfo):
+            # use torch.empty
+            return torch.zeros(
+                si.num_pages,
+                si.page_size,
+                hf_config.num_key_value_heads,
+                hf_config.head_dim,
+                device=si.device,
+                dtype=cache_config.dtype or hf_config.torch_dtype,
+            )
+
+        cache_initializers = {
+            "k_cache": _get_cache,
+            "v_cache": _get_cache,
+        }
+
+        num_kvcache_args = 0
+        for layer_idx in range(hf_config.num_hidden_layers):
+            for k_or_v, get_cache in cache_initializers.items():
+                k_indexed = f"{k_or_v}_{layer_idx}"
+                cm.add_cache(k_indexed, get_cache)
+                num_kvcache_args += 1
+
+        # Add buffer
+        # equivalent to attn_descriptor.get_global_buffer_initializers
+        num_buffer_args = 0
+
+        def _init_workspace(si: SequenceInfo) -> torch.Tensor:
+            # NOTE (lucaslie): avoid OOM for many cudagraphs,
+            # see https://github.com/NVIDIA/TensorRT-LLM/pull/3686
+            buffer = torch.empty(320 * 1024 * 1024, dtype=torch.uint8, device=si.device)
+            attn_descriptor._get_planner().init_workspace(buffer)
+            return buffer
+
+        cm.add_cache("workspace_buffer", _init_workspace)
+        num_buffer_args += 1
+
+        # prepare get_metadata function
+        get_metadata, num_metadata = attn_descriptor.get_prepare_metadata_op()
+
+        # Save attributes for the module to use during forward
+        # TODO: consider make an attribute class
+        gm.factory_model.get_attn_metadata = partial(get_metadata, page_size=cm.info.page_size)
+        gm.factory_model.num_cached_attn_args = num_cached_attn_args
+        gm.factory_model.num_kvcache_args = num_kvcache_args
+        gm.factory_model.num_buffer_args = num_buffer_args
+        gm.factory_model.num_metadata = num_metadata
+
+        # Finally, we patch the forward method of facotry_model and the whole gm.
+        gm.factory_model.forward = types.MethodType(
+            partial(forward_cached, get_metadata=get_metadata), gm.factory_model
+        )
+        gm.forward = gm.factory_model.forward
+
+        # by convention, we say this fake graph module is always clean
+        info = TransformInfo(skipped=False, num_matches=1, is_clean=True, has_valid_shapes=True)
+
+        return gm, info

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/transformers_attn.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/transformers_attn.py
@@ -144,8 +144,7 @@ class HFReplaceCachedAttn(BaseTransform):
         # Add cache
         # equivalent to attn_descriptor.get_cache_initializers()
         def _get_cache(si: SequenceInfo):
-            # use torch.empty
-            return torch.zeros(
+            return torch.empty(
                 si.num_pages,
                 si.page_size,
                 hf_config.num_key_value_heads,

--- a/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
@@ -51,6 +51,12 @@ class InferenceOptimizer:
             ].checkpoint_device = self.ad_config.checkpoint_device
             self.ad_config.transforms["load_weights"].device = cm.device
 
+        if "load_factory_model_weights" in self.ad_config.transforms:
+            self.ad_config.transforms[
+                "load_factory_model_weights"
+            ].checkpoint_device = self.ad_config.checkpoint_device
+            self.ad_config.transforms["load_factory_model_weights"].device = cm.device
+
         if "resize_kv_cache" in self.ad_config.transforms:
             self.ad_config.transforms[
                 "resize_kv_cache"

--- a/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
+++ b/tensorrt_llm/_torch/auto_deploy/transformations/transform.py
@@ -51,11 +51,11 @@ class InferenceOptimizer:
             ].checkpoint_device = self.ad_config.checkpoint_device
             self.ad_config.transforms["load_weights"].device = cm.device
 
-        if "load_factory_model_weights" in self.ad_config.transforms:
+        if "move_cm_to_device" in self.ad_config.transforms:
             self.ad_config.transforms[
-                "load_factory_model_weights"
+                "move_cm_to_device"
             ].checkpoint_device = self.ad_config.checkpoint_device
-            self.ad_config.transforms["load_factory_model_weights"].device = cm.device
+            self.ad_config.transforms["move_cm_to_device"].device = cm.device
 
         if "resize_kv_cache" in self.ad_config.transforms:
             self.ad_config.transforms[


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description
Support eager inference with transformers code.
<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
