### PR TITLE
[https://nvbugs/5501557][fix] Fix out-of-bounds vector access for model with multiple layer types

### DIFF
--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
@@ -148,6 +148,19 @@ public:
 
     ~TrtGptModelInflightBatching() override;
 
+    /// @brief Calculate the cache size per token for the disaggregated serving.
+    /// @param modelConfig Model configuration.
+    /// @param worldConfig World configuration.
+    /// @param maxAttentionWindowVec Maximum attention window vector. (may have fewer elements than numLayers, in which
+    /// case it cycles)
+    /// @param isCrossAttention Whether the attention is cross attention.
+    /// @param kvFactor KV factor.
+    /// @return Cache size per token for the disaggregated layers. Note that window size is not included in the result
+    /// here.
+    [[nodiscard]] static std::map<SizeType32, SizeType32> calculateCacheSizePerTokenForDisagg(
+        runtime::ModelConfig const& modelConfig, runtime::WorldConfig const& worldConfig,
+        std::vector<SizeType32> const& maxAttentionWindowVec, bool isCrossAttention, SizeType32 kvFactor);
+
     void terminateRequest(LlmRequestPtr const& llmRequest, bool pause = false) override;
 
     /// @brief Terminate request in the next forwardSync call that includes the request.


### PR DESCRIPTION
## Description
This MR fixes https://nvbugspro.nvidia.com/bug/5501557.

**_Background:_**
- Nemotron Super has 80 layers out of which 49 are attention layers and 31 are no-op.
- [calculateCacheSizePerToken](https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp#L268) is used to compute the memory allocation for disagg serving's `CacheTransBufferManager`. While it works fine for models with only attention layers, it's failing for Nemotron Super because of the multiple layer types.

**_Root cause:_**
- [calculateCacheSizePerTokenForSingleWindowSize](https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp#L280) looks up numKVHeads for all 80 layers [here](https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h#L1345).
- Given that there are only 49 attn layers, this caused out-of-bounds vector access [here](https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/include/tensorrt_llm/runtime/modelConfig.h#L809-L810).

**_Other issues:_**
- `groupLayersByWindowSize` doesn't account for PP. [[example](https://github.com/NVIDIA/TensorRT-LLM/pull/7644/files#r2333958086)]
- `calculateCacheSizePerTokenForSingleWindowSize` expects layer ids passed to be global (and not local as in PP ranks). [[explained](https://github.com/NVIDIA/TensorRT-LLM/pull/7644/files#r2334043773)]

**_Fix:_**
- We look-up numKVHeads specifically for attention layers.
- We also use global layer ids by accounting for Pipeline Parallelism.

## Test Coverage
Unit test:
```
./cpp/build/tests/unit_tests/executor/executorTestSmall
```

Running mmlu_pro eval on gemma-2-9b:
```
// Create extra llmapi options for trtllm-serve.
$ cat gemma2_extra_llmapi_config.yml 
kv_cache_config:
  max_attention_window: [4096, 8192]
  enable_block_reuse: false

// Launch the model server.
$ trtllm-serve /home/scratch.trt_llm_data/llm-models/gemma/gemma-2-9b-it/ --backend trt --tp_size 1 --port 8000 --max_batch_size 8  --extra_llm_api_options gemma2_extra_llmapi_config.yml

// Launch eval client.
$ docker run --rm -it --ipc host --network host -u root -p 8000:8000 nvcr.io/nvidia/eval-factory/simple-evals:25.07.3

// Run eval command within eval client.
# core_evals_simple_evals run_eval --eval_type mmlu_pro --model_id gemma/gemma-2-9b-it --model_url http://127.0.0.1:8000/v1/chat/completions --model_type chat --output_dir /workspace/results_new/
```

Testing the originally failing model:
```
// Convert checkpoint to TRTLLM format.
$ python examples/models/core/nemotron_nas/convert_checkpoint.py --model_dir ../random/hf_models/Llama-3_3-Nemotron-Super-49B-v1_5/ --output_dir nemotron_super_bf16_tp2_ckpt/ --dtype bfloat16 --tp_size 2 --trust_remote_code

// Build the engines in advance.
$ trtllm-build --checkpoint_dir nemotron_super_bf16_tp2_ckpt/ --output_dir nemotron_super_bf16_tp2_eng/ --gemm_plugin auto --kv_cache_type paged

// Run model inference.
$ mpirun -n 2 python examples/run.py --engine_dir nemotron_super_bf16_tp2_eng/ --tokenizer_dir ../random/hf_models/Llama-3_3-Nemotron-Super-49B-v1_5/ --max_output_len 512
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Per-token KV-cache sizing now correctly accounts for global layer indices across pipeline ranks, avoiding under- or over-allocation while preserving wrap-around when attention-window config is shorter than total layers.

* **Refactor**
  * Centralized the layer-to-window grouping using a global-layer view so cache planning is consistent across ranks with no change to external behavior.

* **New Features**
  * Added a public helper to compute per-token cache sizes for disaggregated layers.

* **Tests**
  * Added unit tests validating cache-size distributions across window and layer configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->