### PR TITLE
[#2859][feat] Support for Qwen2.5-VL models for TRT flow

### DIFF
--- a/examples/models/core/multimodal/README.md
+++ b/examples/models/core/multimodal/README.md
@@ -1084,7 +1084,7 @@ Navigate to the folder `TensorRT-LLM/examples/models/core/multimodal`
         --image_path=https://storage.googleapis.com/sfr-vision-language-research/LAVIS/assets/merlion.png
         --audio_path=${HF_DIR}/examples/what_is_shown_in_this_image.wav
     ```
-## Qwen2-VL
+## Qwen2-VL/Qwen2.5-VL
 [Qwen2-VL Family](https://github.com/QwenLM/Qwen2-VL): is the latest version of the vision language models in the Qwen model families. Here we show how to deploy Qwen2-VL 2B and 7B in TensorRT-LLM.
 
 Firstly, please install transformers and qwen-vl-utils

--- a/examples/models/core/multimodal/README.md
+++ b/examples/models/core/multimodal/README.md
@@ -22,7 +22,7 @@ We first describe three runtime modes for running multimodal models and how to r
 - [Nougat](#nougat)
 - [Phi-3-vision](#phi-3-vision)
 - [Phi-4-multimodal](#phi-4-multimodal)
-- [Qwen2-VL](#qwen2-vl)
+- [Qwen2-VL/Qwen2.5-VL](#qwen2-vl)
 - [Video NeVA](#video-neva)
 - [Dataset Evaluation](#dataset-evaluation)
 - [Enabling Tensor Parallelism for multi-GPU](#enabling-tensor-parallelism-for-multi-gpu)

--- a/tensorrt_llm/builder.py
+++ b/tensorrt_llm/builder.py
@@ -1372,7 +1372,8 @@ def build(model: PretrainedModel, build_config: BuildConfig) -> Engine:
         if build_config.speculative_decoding_mode == SpeculativeDecodingMode.LOOKAHEAD_DECODING:
             prepare_input_args[
                 "spec_decoding_is_generation_length_variable"] = True
-        if model.config.architecture == "Qwen2VLForConditionalGeneration" or model.config.architecture == "Qwen2VLModel":
+        if model.config.architecture == "Qwen2VLForConditionalGeneration" or model.config.architecture == "Qwen2VLModel" or \
+                model.config.architecture == "Qwen2_5_VLForConditionalGeneration" or model.config.architecture == "Qwen2_5_VLModel":
             prepare_input_args[
                 'mrope_rotary_cos_sin_size'] = model.config.max_position_embeddings * model.config.rotary_embedding_dim
         if build_config.speculative_decoding_mode == SpeculativeDecodingMode.EAGLE and not build_config.plugin_config.use_paged_context_fmha:

--- a/tensorrt_llm/commands/build.py
+++ b/tensorrt_llm/commands/build.py
@@ -630,8 +630,8 @@ def main():
                 'monitor_memory':
                 args.monitor_memory,
                 'use_mrope':
-                (True if model_config.qwen_type == "qwen2_vl" else False)
-                if hasattr(model_config, "qwen_type") else False
+                (True if model_config.qwen_type in ["qwen2_vl", "qwen2_5_vl"]
+                 else False) if hasattr(model_config, "qwen_type") else False
             },
             plugin_config=plugin_config)
 

--- a/tensorrt_llm/models/__init__.py
+++ b/tensorrt_llm/models/__init__.py
@@ -195,6 +195,8 @@ MODEL_MAP = {
     'Qwen2ForSequenceClassification': QWenForCausalLM,
     'Qwen2VLForConditionalGeneration': QWenForCausalLM,
     'Qwen2VLModel': QWenForCausalLM,
+    'Qwen2_5_VLForConditionalGeneration': QWenForCausalLM,
+    'Qwen2_5_VLModel': QWenForCausalLM,
     'Qwen3ForCausalLM': QWenForCausalLM,
     'Qwen3MoeForCausalLM': QWenForCausalLM,
     'WhisperEncoder': WhisperEncoder,

--- a/tensorrt_llm/models/qwen/config.py
+++ b/tensorrt_llm/models/qwen/config.py
@@ -111,7 +111,8 @@ class QWenConfig(PretrainedConfig):
             hf_config.architectures = ['Qwen2ForCausalLM']
 
         valid_types = ('qwen', 'qwen2', 'qwen2_moe', 'qwen2_llava_onevision',
-                       'qwen2_vl', 'qwen2_audio', 'qwen3', 'qwen3_moe')
+                       'qwen2_vl', 'qwen2_5_vl', 'qwen2_audio', 'qwen3',
+                       'qwen3_moe')
         assert qwen_type in valid_types, f"Unsupported Qwen type: {qwen_type}, only {valid_types} are acceptable."
         num_key_value_heads = getattr(hf_config, "num_key_value_heads",
                                       hf_config.num_attention_heads)
@@ -163,7 +164,7 @@ class QWenConfig(PretrainedConfig):
         dtype = infer_dtype(dtype, getattr(hf_config, 'torch_dtype', None))
         tie_word_embeddings = getattr(hf_config, 'tie_word_embeddings', False)
 
-        if qwen_type == 'qwen2_vl':
+        if qwen_type == 'qwen2_vl' or qwen_type == 'qwen2_5_vl':
             pe_type = 'mrope'
             rotary_embedding_percentage = getattr(hf_config, 'rotary_pct', 1.0)
             rotary_embedding_dim = getattr(

--- a/tensorrt_llm/models/qwen/convert.py
+++ b/tensorrt_llm/models/qwen/convert.py
@@ -103,10 +103,13 @@ def smooth_qwen2_model(model, scales, alpha, qwen_qkv_para, qwen_smoother):
     # Smooth the activation and weights with smoother = $\diag{s}$
     for name, module in model.named_modules():
         from transformers.models.qwen2.modeling_qwen2 import Qwen2DecoderLayer
+        from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import \
+            Qwen2_5_VLDecoderLayer
         from transformers.models.qwen2_vl.modeling_qwen2_vl import \
             Qwen2VLDecoderLayer
         if not isinstance(module, Qwen2DecoderLayer) and not isinstance(
-                module, Qwen2VLDecoderLayer):
+                module, Qwen2VLDecoderLayer) and not isinstance(
+                    module, Qwen2_5_VLDecoderLayer):
             continue
         # qkv_proj
         layer_name_q = name + ".self_attn.q_proj"
@@ -1100,7 +1103,8 @@ def load_weights_from_hf_gptq_model(hf_model, config: QWenConfig):
 
     model_params = {k: v for k, v in hf_model.state_dict().items()}
     torch.cuda.empty_cache()
-    valid_types = ('qwen', 'qwen2', 'qwen2_vl', 'qwen3', 'qwen3_moe')
+    valid_types = ('qwen', 'qwen2', 'qwen2_vl', 'qwen2_5_vl', 'qwen3',
+                   'qwen3_moe')
     assert qwen_type in valid_types, f"Unsupported Qwen type: {qwen_type}, only {valid_types} are supported for GPTQ."
     layer_prefix = "transformer.h." if qwen_type == 'qwen' else "model.layers."
     key_list = get_qwen_key_list(qwen_type)

--- a/tensorrt_llm/models/qwen/model.py
+++ b/tensorrt_llm/models/qwen/model.py
@@ -358,7 +358,7 @@ class QWenForCausalLM(DecoderModelForCausalLM):
                     "q_layernorm": "q_norm",
                     "k_layernorm": "k_norm",
                 }
-            elif config.qwen_type in {"qwen2", "qwen2_vl"
+            elif config.qwen_type in {"qwen2", "qwen2_vl", "qwen2_5_vl"
                                       } and config.tie_word_embeddings:
                 custom_dict = {"lm_head": "model.embed_tokens"}
             elif config.architecture == "Qwen2ForSequenceClassification":

--- a/tensorrt_llm/runtime/multimodal_model_runner.py
+++ b/tensorrt_llm/runtime/multimodal_model_runner.py
@@ -401,7 +401,7 @@ class MultimodalModelRunner:
                 self.args.hf_model_dir).text_config._name_or_path
         if 'internlm' in self.model_type:
             self.args.lora_task_uids = ['0'] * args.batch_size
-        if self.model_type == "qwen2_vl":
+        if self.model_type == "qwen2_vl" or self.model_type == "qwen2_5_vl":
             hf_config = AutoConfig.from_pretrained(self.args.hf_model_dir)
             self.vision_start_token_id = hf_config.vision_start_token_id
             self.vision_end_token_id = hf_config.vision_end_token_id
@@ -480,6 +480,13 @@ class MultimodalModelRunner:
                 if self.args.session != "cpp_llm_only":
                     logger.warning(
                         "Qwen2-vl only support C++ session for now, fallback to C++ session."
+                    )
+                    self.args.session = "cpp_llm_only"
+
+            if self.model_type == 'qwen2_5_vl':
+                if self.args.session != "cpp_llm_only":
+                    logger.warning(
+                        "Qwen2.5-vl only support C++ session for now, fallback to C++ session."
                     )
                     self.args.session = "cpp_llm_only"
 
@@ -624,7 +631,7 @@ class MultimodalModelRunner:
         elif self.model_type in [
                 'phi-3-vision', 'pix2struct', 'llava_next', 'llava', 'fuyu',
                 'kosmos-2', 'mllama', 'llava_onevision', 'qwen2_vl',
-                'phi-4-multimodal'
+                'qwen2_5_vl', 'phi-4-multimodal'
         ]:
             self.processor = AutoProcessor.from_pretrained(
                 self.args.hf_model_dir, trust_remote_code=True, num_crops=16)
@@ -951,7 +958,7 @@ class MultimodalModelRunner:
             image = input['pixel_values']
             image = image[0]
             image_size = input['image_sizes'][0].cpu()
-        elif self.model_type == "qwen2_vl":
+        elif self.model_type == "qwen2_vl" or self.model_type == "qwen2_5_vl":
             input = image
             image = input['image']
             input_ids = input['input_ids']
@@ -1060,7 +1067,14 @@ class MultimodalModelRunner:
                 visual_features, input_ids, image_grid_thw, attention_mask,
                 input_lengths)
             return input_ids, input_lengths, ptuning_args, visual_features, mrope_args
-
+        elif self.model_type == 'qwen2_5_vl':
+            length = input_ids.shape[1]
+            input_lengths = torch.IntTensor([length] * self.args.batch_size).to(
+                torch.int32)
+            input_ids, ptuning_args, mrope_args = self.setup_fake_prompts_qwen2_5_vl(
+                visual_features, input_ids, image_grid_thw, attention_mask,
+                input_lengths)
+            return input_ids, input_lengths, ptuning_args, visual_features, mrope_args
         elif self.model_type == 'kosmos-2':
             visual_features = visual_features.squeeze(
             ) if visual_features is not None else None
@@ -1397,6 +1411,14 @@ class MultimodalModelRunner:
                 mrope_rotary_cos_sin=mrope_args[0],
                 mrope_position_deltas=mrope_args[1],
             )
+        elif 'qwen2_5_vl' in self.model_type:
+            input_ids, input_lengths, ptuning_args, visual_features, mrope_args = self.preprocess(
+                pre_prompt, post_prompt, image, other_vision_inputs,
+                other_audio_inputs)
+            mrope_params = MropeParams(
+                mrope_rotary_cos_sin=mrope_args[0],
+                mrope_position_deltas=mrope_args[1],
+            )
         else:
             input_ids, input_lengths, ptuning_args, visual_features, model_runner_input = self.preprocess(
                 pre_prompt, post_prompt, image, other_vision_inputs,
@@ -1436,7 +1458,7 @@ class MultimodalModelRunner:
                 input_position_ids=input_position_ids
                 if self.model_type == 'cogvlm' else None,
                 mrope_params=mrope_params
-                if self.model_type == 'qwen2_vl' else None,
+                if self.model_type in ['qwen2_vl', 'qwen2_5_vl'] else None,
                 encoder_input_features=model_runner_input
                 if self.cpp_e2e else None,
                 sampling_config=None,
@@ -1615,7 +1637,7 @@ class MultimodalModelRunner:
             self.vision_input_names[0]:
             image.to(str_dtype_to_torch(self.vision_precision)),
         }
-        if self.model_type == "qwen2_vl":
+        if self.model_type == "qwen2_vl" or self.model_type == "qwen2_5_vl":
             other_vision_inputs['attention_mask'] = other_vision_inputs[
                 'attention_mask'].to(str_dtype_to_torch(self.vision_precision))
         for key, tensor in other_vision_inputs.items():
@@ -2037,6 +2059,76 @@ class MultimodalModelRunner:
         mrope_args = [concat_cos_sin, mrope_position_deltas]
         return input_ids, ptuning_args, mrope_args
 
+    def setup_fake_prompts_qwen2_5_vl(self, visual_features, input_ids,
+                                      vision_grid_thws, attention_mask,
+                                      input_lengths):
+
+        visual_features = torch.unsqueeze(visual_features, 0)
+
+        # Get the rope index
+        # From HF's preprocess code
+        mrope_position_ids, mrope_position_deltas = self.get_rope_index(
+            input_ids,
+            image_grid_thw=vision_grid_thws,
+            video_grid_thw=None,
+            attention_mask=attention_mask,
+        )
+
+        # This is where we convert input_ids of image features into fake_prompt_ids mapping for TRT-LLM engine.
+        masks = (input_ids == self.image_token_id) | (
+            input_ids == self.vision_token_id) | (input_ids
+                                                  == self.video_token_id)
+        cumulative_counts = masks.cumsum(dim=1)
+        values = (self.model_config.vocab_size - 1) + cumulative_counts
+        input_ids[masks] = values[masks]
+
+        if self.decoder_llm or self.runtime_mapping.is_first_pp_rank():
+            ptuning_args = self.ptuning_setup(visual_features, input_ids,
+                                              input_lengths)
+        else:
+            ptuning_args = [None, None, None]
+
+        # This does not have dependency on input.
+        # Switch to attributes to use across iterations.
+        if not hasattr(self, 'rotary_cos_sin'):
+            inv_freq, rotary_cos_sin = RopeEmbeddingUtils.create_sinusoidal_positions_for_attention_plugin(
+                num_pos=self.max_position_embeddings,
+                dim=int(self.hidden_size / self.num_attention_heads),
+                theta=float(self.rope_theta),
+                scale_type=RotaryScalingType.mrope)
+            self.rotary_cos_sin = torch.from_numpy(rotary_cos_sin).to(
+                visual_features.device)
+            self.rotary_cos_sin = self.rotary_cos_sin.reshape(
+                self.max_position_embeddings,
+                int(self.hidden_size / self.num_attention_heads / 2), 2)
+            self.cos_ori = self.rotary_cos_sin[:, :, 0]
+            self.sin_ori = self.rotary_cos_sin[:, :, 1]
+
+        mrope_position_ids = mrope_position_ids.transpose(1, 0)
+        mrope_position_ids_padding = torch.zeros(
+            mrope_position_ids.shape[:-1] + (self.max_position_embeddings, ),
+            dtype=torch.int32,
+            device=visual_features.device)
+        mrope_position_ids_padding[:, :, :mrope_position_ids.
+                                   shape[-1]] = mrope_position_ids
+        cos = self.cos_ori[mrope_position_ids_padding]
+        sin = self.sin_ori[mrope_position_ids_padding]
+
+        mrope_section = [16, 24, 24]
+        cos = torch.cat([
+            m[:, i % 3] for i, m in enumerate(cos.split(mrope_section, dim=-1))
+        ],
+                        dim=-1).unsqueeze(-1)
+        sin = torch.cat([
+            m[:, i % 3] for i, m in enumerate(sin.split(mrope_section, dim=-1))
+        ],
+                        dim=-1).unsqueeze(-1)
+        concat_cos_sin = torch.concatenate((cos, sin), axis=-1)
+        concat_cos_sin = concat_cos_sin.reshape(concat_cos_sin.shape[0], -1)
+
+        mrope_args = [concat_cos_sin, mrope_position_deltas]
+        return input_ids, ptuning_args, mrope_args
+
     def ptuning_setup_fuyu(self, input_ids, image_patches_indices):
         res_input_ids = []
         for cur_input_ids, cur_image_patches_indices in zip(
@@ -2265,7 +2357,7 @@ class MultimodalModelRunner:
                                  timeout=5).raw).convert('RGB')
             else:
                 images = Image.open(image_path).convert('RGB')
-        elif "qwen2_vl" in self.model_type:
+        elif "qwen2_vl" in self.model_type or "qwen2_5_vl" in self.model_type:
             images = []
             if self.args.image_path is None:
                 img_url = 'https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen-VL/assets/demo.jpeg'
@@ -2332,11 +2424,12 @@ class MultimodalModelRunner:
         return audio
 
     def setup_inputs(self, input_text, raw_image, raw_audio=None):
-        from ..tools.multimodal_builder import compute_rotary_pos_emb
+        from ..tools.multimodal_builder import (
+            compute_rotary_pos_emb, compute_rotary_pos_emb_qwen2_5_vl)
         other_vision_inputs = {}
         other_audio_inputs = {}
         other_decoder_inputs = {}
-        if self.model_type not in ['qwen2_vl', 'vila', 'llava']:
+        if self.model_type not in ['qwen2_vl', 'qwen2_5_vl', 'vila', 'llava']:
             input_text = input_text[0] if isinstance(input_text,
                                                      list) else input_text
 
@@ -2432,6 +2525,84 @@ class MultimodalModelRunner:
             }
             rotary_pos_emb = compute_rotary_pos_emb(
                 image_grid_thw, hf_config, VisionRotaryEmbedding).to("cuda")
+            other_vision_inputs['attention_mask_llm'] = attention_mask
+            other_vision_inputs['image_grid_thw'] = image_grid_thw
+            other_vision_inputs['attention_mask'] = attention_mask_vit
+            other_vision_inputs['rotary_pos_emb'] = rotary_pos_emb
+            return input_text, pre_prompt, post_prompt, images_qwenvl, decoder_input_ids, other_vision_inputs, other_audio_inputs, other_decoder_inputs
+        elif 'qwen2_5_vl' in self.model_type:
+            from qwen_vl_utils import process_vision_info
+            from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import \
+                Qwen2_5_VisionRotaryEmbedding
+            hf_config = AutoConfig.from_pretrained(self.args.hf_model_dir)
+            if input_text is None:
+                input_text = ["Question: Describe this image. Answer:"
+                              ] * self.args.batch_size
+            messages = [[{
+                "role":
+                "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "image": raw_image[idx],
+                    },
+                    {
+                        "type": "text",
+                        "text": input_text[idx],
+                    },
+                ],
+            }] for idx in range(self.args.batch_size)]
+
+            texts = [
+                self.processor.apply_chat_template(msg,
+                                                   tokenize=False,
+                                                   add_generation_prompt=True)
+                for msg in messages
+            ]
+            image_inputs, video_inputs = process_vision_info(messages)
+            inputs = self.processor(
+                text=texts,
+                images=image_inputs,
+                videos=video_inputs,
+                padding=True,
+                return_tensors="pt",
+            )
+            inputs = inputs.to(self.device)
+            image = inputs['pixel_values']
+            image_grid_thw = inputs['image_grid_thw']
+            input_ids = inputs['input_ids']
+            attention_mask = inputs['attention_mask']
+            cu_seqlens = torch.repeat_interleave(
+                image_grid_thw[:, 1] * image_grid_thw[:, 2],
+                image_grid_thw[:, 0]).cumsum(dim=0, dtype=torch.int32)
+            cu_seqlens = F.pad(cu_seqlens, (1, 0), value=0)
+
+            seq_length = image.shape[0]
+            # Create block indices using bucketing
+            block_indices = torch.bucketize(torch.arange(seq_length,
+                                                         device=image.device),
+                                            cu_seqlens,
+                                            right=True) - 1
+
+            # Generate block diagonal mask using matrix expansion
+            attention_mask_vit = torch.where(
+                block_indices.view(-1, 1) == block_indices.view(1, -1),
+                torch.zeros((), device=image.device, dtype=image.dtype),
+                torch.full((),
+                           torch.finfo(torch.float16).min,
+                           device=image.device,
+                           dtype=image.dtype)).unsqueeze(0)
+
+            decoder_input_ids = None
+            post_prompt = None
+            pre_prompt = None
+            images_qwenvl = {
+                "image": image,
+                "input_ids": input_ids,
+            }
+            rotary_pos_emb = compute_rotary_pos_emb_qwen2_5_vl(
+                image_grid_thw, hf_config,
+                Qwen2_5_VisionRotaryEmbedding).to("cuda")
             other_vision_inputs['attention_mask_llm'] = attention_mask
             other_vision_inputs['image_grid_thw'] = image_grid_thw
             other_vision_inputs['attention_mask'] = attention_mask_vit

--- a/tensorrt_llm/tools/multimodal_builder.py
+++ b/tensorrt_llm/tools/multimodal_builder.py
@@ -1801,12 +1801,7 @@ def build_qwen2_5_vl_engine(args):
                 input_names=['input', 'rotary_pos_emb', 'attention_mask'],
                 output_names=['encoder_output'],
                 dynamic_axes=dynamic_axes)
-    print("VISION CONFIG")
-    print(vars(hf_config.vision_config))
     rotary_pos_emb_dim = hf_config.vision_config.hidden_size // hf_config.vision_config.num_heads // 2
-    print(rotary_pos_emb_dim)
-    print("VL DIM")
-    print(qwen2_5_vl_dim)
     build_trt_engine(args.model_type, [rotary_pos_emb_dim],
                      f'{args.output_dir}/onnx',
                      args.output_dir,

--- a/tensorrt_llm/tools/multimodal_builder.py
+++ b/tensorrt_llm/tools/multimodal_builder.py
@@ -1403,7 +1403,6 @@ def compute_rotary_pos_emb_qwen2_5_vl(grid_thw, hf_config,
         return rotary_pos_emb
 
     rotary_pos_emb = rot_pos_emb(grid_thw, rotary_pos_emb_func)
-    print(f"Rotary pos emb shape: {rotary_pos_emb.shape}")
     return rotary_pos_emb
 
 
@@ -1627,7 +1626,6 @@ def build_qwen2_5_vl_engine(args):
         device_map="cpu",
         attn_implementation="eager")
     hf_config = AutoConfig.from_pretrained(args.model_path)
-    print(vars(hf_config))
     qwen2_5_vl_dim = hf_config.vision_config.in_chans * hf_config.vision_config.patch_size * hf_config.vision_config.patch_size * hf_config.vision_config.temporal_patch_size
     processor = AutoProcessor.from_pretrained(args.model_path)
     messages = [{

--- a/tensorrt_llm/tools/multimodal_builder.py
+++ b/tensorrt_llm/tools/multimodal_builder.py
@@ -40,7 +40,7 @@ def add_multimodal_arguments(parser):
             'blip2', 'llava', 'llava_next', 'llava_onevision',
             'llava_onevision_lmms', 'vila', 'nougat', 'cogvlm', 'fuyu',
             'pix2struct', 'neva', 'kosmos-2', 'video-neva', 'phi-3-vision',
-            'phi-4-multimodal', 'mllama', 'internvl', 'qwen2_vl',
+            'phi-4-multimodal', 'mllama', 'internvl', 'qwen2_vl', 'qwen2_5_vl',
             'internlm-xcomposer2', 'qwen2_audio', 'pixtral', 'eclair'
         ],
         help="Model type")
@@ -140,6 +140,8 @@ class MultimodalEngineBuilder:
             build_internvl_engine(args)
         elif args.model_type == 'qwen2_vl':
             build_qwen2_vl_engine(args)
+        elif args.model_type == 'qwen2_5_vl':
+            build_qwen2_5_vl_engine(args)
         elif args.model_type == 'qwen2_audio':
             build_qwen2_audio_engine(args)
         elif args.model_type == "pixtral":
@@ -262,6 +264,37 @@ def build_trt_engine(model_type,
         profile.set_shape(input_images.name, [multi_size_min, qwen2_vl_dim],
                           [multi_size_opt, qwen2_vl_dim],
                           [multi_size_max, qwen2_vl_dim])
+
+        attenstion_mask.shape = [1, -1, -1]
+        profile.set_shape(attenstion_mask.name,
+                          [1, multi_size_min, multi_size_min],
+                          [1, multi_size_opt, multi_size_opt],
+                          [1, multi_size_max, multi_size_max])
+    elif model_type == "qwen2_5_vl":
+        input_images = network.get_input(0)
+        inputT = network.get_input(1)
+        attenstion_mask = network.get_input(2)
+
+        qwen2_5_vl_dim = model_params.get('qwen2_5_vl_dim', 0)
+        min_hw_dims = model_params.get('min_hw_dims', 0)
+        max_hw_dims = model_params.get('max_hw_dims', 0)
+
+        assert min_hw_dims > 0, "min_hw_dims must be positive for qwen2_5_vl"
+        assert max_hw_dims > 0, "max_hw_dims must be positive for qwen2_5_vl"
+
+        multi_size_min = min_hw_dims
+        multi_size_max = max_hw_dims * max_batch_size
+        multi_size_opt = max(multi_size_min, int(multi_size_max / 2))
+
+        inputT.shape = [-1, *input_sizes]
+        profile.set_shape(inputT.name, [multi_size_min, *input_sizes],
+                          [multi_size_opt, *input_sizes],
+                          [multi_size_max, *input_sizes])
+
+        input_images.shape = [-1, qwen2_5_vl_dim]
+        profile.set_shape(input_images.name, [multi_size_min, qwen2_5_vl_dim],
+                          [multi_size_opt, qwen2_5_vl_dim],
+                          [multi_size_max, qwen2_5_vl_dim])
 
         attenstion_mask.shape = [1, -1, -1]
         profile.set_shape(attenstion_mask.name,
@@ -1333,6 +1366,47 @@ def compute_rotary_pos_emb(grid_thw, hf_config, VisionRotaryEmbedding):
     return rotary_pos_emb
 
 
+def compute_rotary_pos_emb_qwen2_5_vl(grid_thw, hf_config,
+                                      Qwen2_5_VisionRotaryEmbedding):
+    head_dim = hf_config.vision_config.hidden_size // hf_config.vision_config.num_heads
+    rotary_pos_emb_func = Qwen2_5_VisionRotaryEmbedding(head_dim // 2)
+    hf_config.vision_config.spatial_merge_size
+
+    def rot_pos_emb(grid_thw, rotary_pos_emb_func):
+        pos_ids = []
+        for t, h, w in grid_thw:
+            hpos_ids = torch.arange(h).unsqueeze(1).expand(-1, w)
+            hpos_ids = hpos_ids.reshape(
+                h // hf_config.vision_config.spatial_merge_size,
+                hf_config.vision_config.spatial_merge_size,
+                w // hf_config.vision_config.spatial_merge_size,
+                hf_config.vision_config.spatial_merge_size,
+            )
+            hpos_ids = hpos_ids.permute(0, 2, 1, 3)
+            hpos_ids = hpos_ids.flatten()
+
+            wpos_ids = torch.arange(w).unsqueeze(0).expand(h, -1)
+            wpos_ids = wpos_ids.reshape(
+                h // hf_config.vision_config.spatial_merge_size,
+                hf_config.vision_config.spatial_merge_size,
+                w // hf_config.vision_config.spatial_merge_size,
+                hf_config.vision_config.spatial_merge_size,
+            )
+            wpos_ids = wpos_ids.permute(0, 2, 1, 3)
+            wpos_ids = wpos_ids.flatten()
+            pos_ids.append(
+                torch.stack([hpos_ids, wpos_ids], dim=-1).repeat(t, 1))
+        pos_ids = torch.cat(pos_ids, dim=0)
+        max_grid_size = grid_thw[:, 1:].max()
+        rotary_pos_emb_full = rotary_pos_emb_func(max_grid_size)
+        rotary_pos_emb = rotary_pos_emb_full[pos_ids].flatten(1)
+        return rotary_pos_emb
+
+    rotary_pos_emb = rot_pos_emb(grid_thw, rotary_pos_emb_func)
+    print(f"Rotary pos emb shape: {rotary_pos_emb.shape}")
+    return rotary_pos_emb
+
+
 def build_qwen2_vl_engine(args):
     import transformers
     from qwen_vl_utils import process_vision_info
@@ -1535,6 +1609,210 @@ def build_qwen2_vl_engine(args):
                      args.max_batch_size,
                      model_params={
                          'qwen2_vl_dim': qwen2_vl_dim,
+                         'min_hw_dims': args.min_hw_dims,
+                         'max_hw_dims': args.max_hw_dims
+                     })
+
+
+def build_qwen2_5_vl_engine(args):
+    from qwen_vl_utils import process_vision_info
+    from transformers import AutoProcessor, Qwen2_5_VLForConditionalGeneration
+    from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import (
+        Qwen2_5_VisionRotaryEmbedding, Qwen2_5_VisionTransformerPretrainedModel,
+        Qwen2_5_VLVisionAttention, Qwen2_5_VLVisionBlock)
+
+    model = Qwen2_5_VLForConditionalGeneration.from_pretrained(
+        args.model_path,
+        torch_dtype=torch.float32,
+        device_map="cpu",
+        attn_implementation="eager")
+    hf_config = AutoConfig.from_pretrained(args.model_path)
+    print(vars(hf_config))
+    qwen2_5_vl_dim = hf_config.vision_config.in_chans * hf_config.vision_config.patch_size * hf_config.vision_config.patch_size * hf_config.vision_config.temporal_patch_size
+    processor = AutoProcessor.from_pretrained(args.model_path)
+    messages = [{
+        "role":
+        "user",
+        "content": [
+            {
+                "type":
+                "image",
+                "image":
+                "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen-VL/assets/demo.jpeg",
+            },
+            {
+                "type": "text",
+                "text": "Describe this picture?"
+            },
+        ],
+    }]
+    text = processor.apply_chat_template(messages,
+                                         tokenize=False,
+                                         add_generation_prompt=True)
+    image_inputs, video_inputs = process_vision_info(messages)
+    for i in range(len(image_inputs)):
+        image_inputs[i] = image_inputs[i].resize(
+            (image_inputs[i].size[0] // 2, image_inputs[i].size[1] // 2))
+    inputs = processor(
+        text=[text],
+        images=image_inputs,
+        videos=video_inputs,
+        padding=True,
+        return_tensors="pt",
+    )
+    inputs = inputs
+    image = inputs['pixel_values'].to(torch.float16)
+    image_grid_thw = inputs['image_grid_thw']
+    cu_seqlens = torch.repeat_interleave(
+        image_grid_thw[:, 1] * image_grid_thw[:, 2],
+        image_grid_thw[:, 0]).cumsum(dim=0, dtype=torch.int32)
+    cu_seqlens = F.pad(cu_seqlens, (1, 0), value=0)
+    seq_length = image.shape[0]
+    attention_mask = torch.full([1, seq_length, seq_length],
+                                torch.finfo(image.dtype).min,
+                                device=image.device,
+                                dtype=image.dtype)
+    for i in range(1, len(cu_seqlens)):
+        attention_mask[..., cu_seqlens[i - 1]:cu_seqlens[i],
+                       cu_seqlens[i - 1]:cu_seqlens[i]] = 0
+    rotary_pos_emb = compute_rotary_pos_emb_qwen2_5_vl(
+        image_grid_thw, hf_config, Qwen2_5_VisionRotaryEmbedding)
+
+    class VisionAttentionOpt(Qwen2_5_VLVisionAttention):
+
+        def __init__(self, dim: int, num_heads: int = 16):
+            super().__init__(dim, num_heads)
+            self.head_dim = dim / num_heads
+
+        def forward(self,
+                    hidden_states: torch.Tensor,
+                    attention_mask: torch.Tensor,
+                    rotary_pos_emb: torch.Tensor = None) -> torch.Tensor:
+            seq_length = hidden_states.shape[0]
+            q, k, v = self.qkv(hidden_states).reshape(seq_length, 3,
+                                                      self.num_heads,
+                                                      -1).permute(1, 0, 2,
+                                                                  3).unbind(0)
+
+            # Copied from transformers.models.llama.modeling_qwen2_vl in v4.48
+            def rotate_half(x):
+                x1 = x[..., :x.shape[-1] // 2]
+                x2 = x[..., x.shape[-1] // 2:]
+                return torch.cat((-x2, x1), dim=-1)
+
+            def apply_rotary_pos_emb_vision(
+                    tensor: torch.Tensor, freqs: torch.Tensor) -> torch.Tensor:
+                orig_dtype = tensor.dtype
+                tensor = tensor.float()
+                cos = freqs.cos()
+                sin = freqs.sin()
+                cos = cos.unsqueeze(1).repeat(1, 1, 2).unsqueeze(0).float()
+                sin = sin.unsqueeze(1).repeat(1, 1, 2).unsqueeze(0).float()
+                output = (tensor * cos) + (rotate_half(tensor) * sin)
+                output = output.to(orig_dtype)
+                return output
+
+            q = apply_rotary_pos_emb_vision(q.unsqueeze(0),
+                                            rotary_pos_emb).squeeze(0)
+            k = apply_rotary_pos_emb_vision(k.unsqueeze(0),
+                                            rotary_pos_emb).squeeze(0)
+            q = q.transpose(0, 1)
+            k = k.transpose(0, 1)
+            v = v.transpose(0, 1)
+            attn_weights = torch.matmul(q, k.transpose(1, 2)) / math.sqrt(
+                self.head_dim)
+            attn_weights = attn_weights + attention_mask
+            attn_weights = nn.functional.softmax(attn_weights,
+                                                 dim=-1,
+                                                 dtype=torch.float32).to(
+                                                     q.dtype)
+            attn_output = torch.matmul(attn_weights, v)
+            attn_output = attn_output.transpose(0, 1)
+            attn_output = attn_output.reshape(seq_length, -1)
+            attn_output = self.proj(attn_output)
+            return attn_output
+
+    class Qwen2_5_VLVisionBlockOpt(Qwen2_5_VLVisionBlock):
+
+        def __init__(self, config, attn_implementation: str = "eager") -> None:
+            super().__init__(config)
+            self.attn = VisionAttentionOpt(config.hidden_size,
+                                           num_heads=config.num_heads)
+
+        def forward(self, hidden_states, attention_mask,
+                    rotary_pos_emb) -> torch.Tensor:
+            hidden_states = hidden_states + self.attn(
+                self.norm1(hidden_states),
+                attention_mask=attention_mask,
+                rotary_pos_emb=rotary_pos_emb)
+            hidden_states = hidden_states + self.mlp(self.norm2(hidden_states))
+            return hidden_states
+
+    class Qwen2VisionTransformerPretrainedModelOpt(
+            Qwen2_5_VisionTransformerPretrainedModel):
+
+        def __init__(self, config) -> None:
+            super().__init__(config)
+            self.blocks = nn.ModuleList([
+                Qwen2_5_VLVisionBlockOpt(config, config._attn_implementation)
+                for _ in range(config.depth)
+            ])
+
+        def forward(self, hidden_states: torch.Tensor,
+                    rotary_pos_emb: torch.Tensor,
+                    attention_mask: torch.Tensor) -> torch.Tensor:
+            hidden_states = self.patch_embed(hidden_states)
+            for blk in self.blocks:
+                hidden_states = blk(hidden_states,
+                                    attention_mask=attention_mask,
+                                    rotary_pos_emb=rotary_pos_emb)
+            res = self.merger(hidden_states)
+            return res
+
+    class VisionEncoderWrapper(torch.nn.Module):
+
+        def __init__(self, model):
+            super().__init__()
+            self.visual = Qwen2VisionTransformerPretrainedModelOpt._from_config(
+                model.config.vision_config,
+                torch_dtype=torch.float32,
+            )
+            self.visual.load_state_dict(model.visual.state_dict())
+
+        def forward(self, images, rotary_pos_emb, attention_mask):
+            img_features = self.visual(images, rotary_pos_emb, attention_mask)
+            return img_features
+
+    wrapper = VisionEncoderWrapper(model)
+    dynamic_axes = {
+        'input': {
+            0: 'hw'
+        },
+        'rotary_pos_emb': {
+            0: 'hw'
+        },
+        'attention_mask': {
+            1: 'hw',
+            2: 'hw'
+        }
+    }
+    export_onnx(wrapper, (image, rotary_pos_emb, attention_mask),
+                f'{args.output_dir}/onnx',
+                input_names=['input', 'rotary_pos_emb', 'attention_mask'],
+                output_names=['encoder_output'],
+                dynamic_axes=dynamic_axes)
+    print("VISION CONFIG")
+    print(vars(hf_config.vision_config))
+    rotary_pos_emb_dim = hf_config.vision_config.hidden_size // hf_config.vision_config.num_heads // 2
+    print(rotary_pos_emb_dim)
+    print("VL DIM")
+    print(qwen2_5_vl_dim)
+    build_trt_engine(args.model_type, [rotary_pos_emb_dim],
+                     f'{args.output_dir}/onnx',
+                     args.output_dir,
+                     args.max_batch_size,
+                     model_params={
+                         'qwen2_5_vl_dim': qwen2_5_vl_dim,
                          'min_hw_dims': args.min_hw_dims,
                          'max_hw_dims': args.max_hw_dims
                      })

--- a/triton_backend/all_models/inflight_batcher_llm/preprocessing/1/model.py
+++ b/triton_backend/all_models/inflight_batcher_llm/preprocessing/1/model.py
@@ -137,7 +137,7 @@ class TritonPythonModel:
 
             assert self.model_type in [
                 'llava', 'blip2-opt', 'pixtral', 'vila', 'mllama',
-                'llava_onevision', 'qwen2_vl'
+                'llava_onevision', 'qwen2_vl', 'qwen2_5_vl'
             ], f"[TensorRT-LLM][ERROR] Currently supported multi-modal models are llava, blip2-opt, pixtral, vila, mllama, llava_onevision and qwen2_vl. Got {self.model_type}."
 
             assert self.model_type != 'llava_onevison' or self.max_num_images is None or self.max_num_images <= 1, f"LLaVA-OneVsion is not support multi image inference currently."
@@ -152,7 +152,8 @@ class TritonPythonModel:
             self._setup_ptable_shape(llm_model_config)
 
             if self.model_type in [
-                    'mllama', 'llava_onevision', 'qwen2_vl', 'pixtral'
+                    'mllama', 'llava_onevision', 'qwen2_vl', 'qwen2_5_vl',
+                    'pixtral'
             ]:
                 full_processor = AutoProcessor.from_pretrained(
                     tokenizer_dir, trust_remote_code=True)
@@ -316,7 +317,7 @@ class TritonPythonModel:
                             queries=query.astype(str).tolist(),
                             video_bytes=video_bytes,
                         )
-                elif self.model_type == 'qwen2_vl':
+                elif self.model_type == 'qwen2_vl' or self.model_type == 'qwen2_5_vl':
                     processed_tensors = self.vision_preprocessor.qwen2_vl_process_image(
                         queries=query.astype(str).tolist(),
                         img_urls=img_urls,
@@ -371,7 +372,9 @@ class TritonPythonModel:
                 embedding_bias_words, embedding_bias_weights,
                 self.embedding_bias_weights_dtype, batch_size)
 
-            if prompt_table_extra_id is not None and self.model_type != 'qwen2_vl':
+            if prompt_table_extra_id is not None and self.model_type not in [
+                    'qwen2_vl', 'qwen2_5_vl'
+            ]:
                 prompt_table_extra_ids = np.zeros_like(input_id)
                 for i in range(batch_size):
                     prompt_table_extra_ids[i] = np.where(
@@ -381,7 +384,7 @@ class TritonPythonModel:
             # Create output tensors. You need pb_utils.Tensor
             # objects to create pb_utils.InferenceResponse.
             # Qwen2-VL model has special logic to process input ids
-            if self.model_type == 'qwen2_vl':
+            if self.model_type == 'qwen2_vl' or self.model_type == 'qwen2_5_vl':
                 input_id_tensor = pb_utils.Tensor.from_dlpack(
                     'INPUT_ID', qwen2vl_input_id_tensor)
                 request_input_len_tensor = pb_utils.Tensor.from_dlpack(
@@ -576,6 +579,8 @@ class TritonPythonModel:
         else:
             # Qwen2-VL input id is calculated when processing image
             if 'qwen2_vl' == self.model_type:
+                return None, None
+            if 'qwen2_5_vl' == self.model_type:
                 return None, None
             if self.is_multimodal and self.max_num_images and self.max_num_images > 1:
                 start_ids = self._process_multi_image_inputs(query)

--- a/triton_backend/tools/multimodal/client.py
+++ b/triton_backend/tools/multimodal/client.py
@@ -268,7 +268,8 @@ if __name__ == "__main__":
                         required=True,
                         choices=[
                             'blip2', 'llava', 'vila', 'mllama',
-                            'llava_onevision', 'qwen2_vl', 'pixtral'
+                            'llava_onevision', 'qwen2_vl', 'qwen2_5_vl',
+                            'pixtral'
                         ],
                         help="Model type")
     parser.add_argument("--hf_model_dir",
@@ -350,6 +351,10 @@ if __name__ == "__main__":
             image_data = np.array([[raw_image]])
             image_input_name = "image_bytes_input"
     elif FLAGS.model_type == 'qwen2_vl':
+        raw_image = raw_image.resize((504, 504))
+        image_data = np.array([[raw_image]])
+        image_input_name = "image_bytes_input"
+    elif FLAGS.model_type == 'qwen2_5_vl':
         raw_image = raw_image.resize((504, 504))
         image_data = np.array([[raw_image]])
         image_input_name = "image_bytes_input"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added end-to-end support for Qwen2.5-VL multimodal models, including configuration, tokenization, weight loading, quantization/export, engine building, runtime generation, and vision preprocessing/encoding.
  - Expanded builders and runtime to handle rotary embeddings and vision inputs for Qwen2.5-VL.
  - Updated CLI/client to accept model_type=qwen2_5_vl with appropriate image handling.
- Documentation
  - Updated examples navigation label to “Qwen2-VL/Qwen2.5-VL.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Added support for Qwen2.5-VL models including quantization and triton serving.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
