### PR TITLE
[TRTLLM-6668][feat] Enable overlap scheduler for two-model spec decoding

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1183,13 +1183,29 @@ class PyTorchModelEngine(ModelEngine):
                 num_ctx_requests = inputs['attn_metadata'].num_contexts
                 num_gen_requests = inputs['attn_metadata'].num_generations
                 num_ctx_tokens = inputs['attn_metadata'].num_ctx_tokens
+                num_extended_ctx_requests = inputs[
+                    'attn_metadata'].num_extended_ctx_requests
                 previous_batch_tokens = inputs['input_ids'].shape[
                     0] - num_ctx_tokens
                 inputs['position_ids'][0, num_ctx_tokens:] += (
                     self.previous_pos_id_offsets_cuda[:previous_batch_tokens])
-                inputs['attn_metadata'].kv_lens_cuda[
-                    num_ctx_requests:num_seqs] += (
-                        self.previous_kv_lens_offsets_cuda[:num_gen_requests])
+                # Only TrtllmAttentionMetadata has kv_lens_cuda.
+                if isinstance(inputs['attn_metadata'], TrtllmAttentionMetadata):
+                    if num_extended_ctx_requests > 0:
+                        # The generation requests with draft_tokens are treated as chunked context requests when extend_ctx returns True.
+                        inputs['attn_metadata'].kv_lens_cuda[
+                            num_ctx_requests -
+                            num_extended_ctx_requests:num_ctx_requests] += (
+                                self.
+                                previous_kv_lens_offsets_cuda[:
+                                                              num_extended_ctx_requests]
+                            )
+                    else:
+                        inputs['attn_metadata'].kv_lens_cuda[
+                            num_ctx_requests:num_seqs] += (
+                                self.
+                                previous_kv_lens_offsets_cuda[:num_gen_requests]
+                            )
 
         if self.guided_decoder is not None:
             self.guided_decoder.token_event.record()
@@ -1285,8 +1301,9 @@ class PyTorchModelEngine(ModelEngine):
         if new_tensors_device is not None:
             # speculative decoding cases: [batch, 1 + draft_len], others: [batch]
             new_tokens_device = new_tensors_device.new_tokens
-            if self.without_logits:
-                assert isinstance(new_tensors_device, SampleStateTensorsMTP)
+            # When using overlap scheduler with speculative decoding, the target model's inputs would be SampleStateTensorsMTP.
+            if isinstance(new_tensors_device, SampleStateTensorsMTP):
+                assert self.enable_spec_decode and not self.is_draft_model
                 new_tokens_lens_device = new_tensors_device.new_tokens_lens  # [batch]
                 next_draft_tokens_device = new_tensors_device.next_draft_tokens  # [batch, draft_len]
 
@@ -1453,9 +1470,19 @@ class PyTorchModelEngine(ModelEngine):
                 previous_batch_indices.append(previous_batch_idx)
                 previous_pos_indices.extend([previous_batch_idx] *
                                             (1 + self.runtime_draft_len))
-                num_cached_tokens_per_seq.append(past_seen_token_num +
-                                                 self.runtime_draft_len + 1)
-                prompt_lengths.append(request.py_prompt_len)
+                if self.spec_config.spec_dec_mode.has_draft_model():
+                    # In the overlap scheduler workflow, if having draft model, we already updated the previous batch before launching the target model,
+                    # so we only need to add the runtime_draft_len to the past_seen_token_num.
+                    num_cached_tokens_per_seq.append(past_seen_token_num +
+                                                     self.runtime_draft_len)
+                else:
+                    num_cached_tokens_per_seq.append(past_seen_token_num +
+                                                     self.runtime_draft_len + 1)
+                if self.enable_spec_decode and spec_config.spec_dec_mode.extend_ctx(
+                        self.attn_backend):
+                    prompt_lengths.append(1 + self.runtime_draft_len)
+                else:
+                    prompt_lengths.append(request.py_prompt_len)
 
         for request in generation_requests:
             request_ids.append(request.py_request_id)
@@ -1637,9 +1664,13 @@ class PyTorchModelEngine(ModelEngine):
         attn_metadata.request_ids = request_ids
         attn_metadata.prompt_lens = prompt_lengths
         attn_metadata.num_contexts = len(scheduled_requests.context_requests)
+        # Use num_extended_ctx_requests to record the number of extend context requests,
+        # so that we can update the kv_lens_cuda correctly in _preprocess_inputs.
+        attn_metadata.num_extended_ctx_requests = 0
         if self.enable_spec_decode and spec_config.spec_dec_mode.extend_ctx(
                 self.attn_backend):
             attn_metadata.num_contexts += len(extend_requests)
+            attn_metadata.num_extended_ctx_requests = len(extend_requests)
 
         attn_metadata.kv_cache_params = KVCacheParams(
             use_cache=True,

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1983,8 +1983,7 @@ class PyExecutor:
 
                 target_inputs, draft_outputs, draft_batch = self.drafter.generate_draft_tokens_with_overlap(
                     scheduled_batch, self.resource_manager,
-                    previous_tensors.device if previous_tensors else None,
-                    self.guided_decoder)
+                    previous_tensors.device if previous_tensors else None)
 
                 self.has_previous_draft_tokens = target_inputs is not None and target_inputs.next_draft_tokens is not None
             else:

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -278,11 +278,10 @@ class PyExecutor:
             self.event_loop = trace_func(self.event_loop)
 
         if self.drafter is not None:
-            if self.event_loop.__name__ != self._executor_loop.__name__:
+            if self.event_loop.__name__ == self._executor_loop_pp.__name__:
                 raise NotImplementedError(
                     "Drafting is not supported for selected executor loop. "
-                    "Please disable disagg/pipeline parallelism/overlap scheduler."
-                )
+                    "Please disable disagg/pipeline parallelism scheduler.")
             self.draft_seq_slot_manager = SeqSlotManager(max_num_sequences)
         self.garbage_collection_gen0_threshold = garbage_collection_gen0_threshold
         self.max_seq_len = max_seq_len

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -1,6 +1,7 @@
 import copy
 import enum
 import importlib
+import os
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -35,6 +36,13 @@ from .guided_decoder import CapturableGuidedDecoder, GuidedDecoder
 from .kv_cache_connector import KvCacheConnectorManager
 from .model_engine import PyTorchModelEngine
 from .py_executor import PyExecutor
+
+
+# Development flag to control chain drafter feature
+def _get_allow_chain_drafter() -> bool:
+    """Get the chain drafter flag from environment variable."""
+    # Use environment variable for cross-process compatibility
+    return os.getenv("TRTLLM_ALLOW_CHAIN_DRAFTER", "0") == "1"
 
 
 class _ExecutorCreationStage(enum.Enum):
@@ -282,11 +290,15 @@ def create_py_executor(
             # generation requests when we invoke it autoregressively
             draft_spec_config.max_draft_len = 0
 
-            use_chain_drafter = (
-                executor_config.guided_decoding_config is None
-                and not pytorch_backend_config.enable_mixed_sampler
-                and pytorch_backend_config.attn_backend == "TRTLLM")
+            if _get_allow_chain_drafter():
+                use_chain_drafter = (
+                    executor_config.guided_decoding_config is None
+                    and not pytorch_backend_config.enable_mixed_sampler
+                    and pytorch_backend_config.attn_backend == "TRTLLM")
+            else:
+                use_chain_drafter = False
 
+            logger.debug(f"USE CHAIN DRAFTER: {use_chain_drafter}")
             if use_chain_drafter:
 
                 def drafting_loop_wrapper(model):

--- a/tensorrt_llm/_torch/speculative/interface.py
+++ b/tensorrt_llm/_torch/speculative/interface.py
@@ -57,7 +57,8 @@ class SpeculativeDecodingMode(IntEnum):
         return self.is_mtp() or self.is_eagle3_one_model() or self.is_ngram()
 
     def support_overlap_scheduler(self):
-        return self.is_mtp() or self.is_eagle3_one_model()
+        return self.is_mtp() or self.is_eagle3_one_model(
+        ) or self.has_draft_model()
 
     def support_guided_decoder(self):
         return self.is_none() or self.has_spec_drafter()

--- a/tensorrt_llm/_torch/speculative/model_drafter.py
+++ b/tensorrt_llm/_torch/speculative/model_drafter.py
@@ -216,6 +216,10 @@ class ModelDrafter(Drafter):
                 self._add_to_draft_batch(draft_batch, new_request, request)
 
             for request in scheduled_requests.generation_requests:
+                if request.state == LlmRequestState.GENERATION_COMPLETE:
+                    # Skip generation complete requests. This could happen when enabling overlap scheduler.
+                    continue
+
                 if request.py_draft_pages_allocated == 0:
                     # No space for draft tokens
                     continue
@@ -358,6 +362,9 @@ class ModelDrafter(Drafter):
             return True
 
         for request in scheduled_batch.generation_requests:
+            if request.state == LlmRequestState.GENERATION_COMPLETE:
+                continue
+
             if request.max_beam_num_tokens - 1 >= self.draft_model_engine.max_seq_len:
                 continue
             return True

--- a/tensorrt_llm/_torch/speculative/model_drafter.py
+++ b/tensorrt_llm/_torch/speculative/model_drafter.py
@@ -10,8 +10,7 @@ from tensorrt_llm.logger import logger
 
 from ..pyexecutor.guided_decoder import GuidedDecoder
 from ..pyexecutor.handle_logits import HandleLogits
-from ..pyexecutor.llm_request import (LlmRequest, LlmRequestState,
-                                      get_draft_token_length)
+from ..pyexecutor.llm_request import LlmRequest, LlmRequestState
 from ..pyexecutor.resource_manager import BaseResourceManager, ResourceManager
 from ..pyexecutor.sampler import (Sampler, SampleState, SampleStateTensors,
                                   TorchSampler)
@@ -600,20 +599,6 @@ class ModelDrafter(Drafter):
             previous_draft_state = sample_state
 
         return previous_draft_state
-
-    def pad_draft_tokens_for_cuda_graph(
-            self, scheduled_requests: ScheduledRequests) -> None:
-        """
-        Pad draft tokens to the max draft length for CUDA graph compatibility.
-
-        Args:
-            scheduled_requests: The scheduled requests to pad
-        """
-        for req in scheduled_requests.generation_requests:
-            max_draft_tokens = self.max_draft_tokens
-            num_draft_tokens = get_draft_token_length(req)
-            req.py_draft_tokens.extend(
-                0 for _ in range(max_draft_tokens - num_draft_tokens))
 
     def generate_draft_tokens_with_overlap(
         self, scheduled_batch: ScheduledRequests,

--- a/tensorrt_llm/_torch/speculative/model_drafter.py
+++ b/tensorrt_llm/_torch/speculative/model_drafter.py
@@ -10,11 +10,14 @@ from tensorrt_llm.logger import logger
 
 from ..pyexecutor.guided_decoder import GuidedDecoder
 from ..pyexecutor.handle_logits import HandleLogits
-from ..pyexecutor.llm_request import LlmRequest, LlmRequestState
+from ..pyexecutor.llm_request import (LlmRequest, LlmRequestState,
+                                      get_draft_token_length)
 from ..pyexecutor.resource_manager import BaseResourceManager, ResourceManager
-from ..pyexecutor.sampler import Sampler, SampleState, TorchSampler
+from ..pyexecutor.sampler import (Sampler, SampleState, SampleStateTensors,
+                                  TorchSampler)
 from ..pyexecutor.scheduler import ScheduledRequests
 from ..pyexecutor.seq_slot_manager import SeqSlotManager
+from ..speculative.mtp import SampleStateTensorsMTP
 from .drafter import Drafter
 
 if TYPE_CHECKING:
@@ -175,8 +178,8 @@ class ModelDrafter(Drafter):
         else:
             draft_batch.context_requests.append(draft_request)
 
-    @nvtx_range("_prepare_draft_batch")
-    def _prepare_draft_batch(
+    @nvtx_range("prepare_draft_batch")
+    def prepare_draft_batch(
             self, scheduled_requests: ScheduledRequests) -> ScheduledRequests:
         """
         Prepares a batch for the draft model engine. Draft tokens are only produced
@@ -235,35 +238,37 @@ class ModelDrafter(Drafter):
             return draft_batch
 
         except Exception as e:
-            logger.error(f"Error in _prepare_draft_batch: {str(e)}")
+            logger.error(f"Error in prepare_draft_batch: {str(e)}")
             traceback.print_exc()
             raise e
 
-    def _should_disable_cuda_graph(
-            self, previous_batch: Optional[SampleState]) -> bool:
+    def _should_disable_cuda_graph(self, is_first_draft_token: bool) -> bool:
         """Check if CUDA graph should be disabled for the current forward pass."""
-        if previous_batch is not None:
+        if not is_first_draft_token:
             return False
         if self.use_static_draft_loop:
             return False
         return self.spec_config.spec_dec_mode.needs_kv_cache_recompute()
 
-    def _forward_draft_model(
-            self,
-            draft_batch: ScheduledRequests,
-            resource_manager: ResourceManager,
-            previous_batch: Optional[SampleState] = None) -> Dict[str, Any]:
+    def forward_draft_model(
+        self,
+        draft_batch: ScheduledRequests,
+        resource_manager: ResourceManager,
+        is_first_draft_token: bool,
+        previous_tensors: Optional[SampleStateTensors] = None
+    ) -> Dict[str, Any]:
         """Forward pass through the draft model."""
-        if self._should_disable_cuda_graph(previous_batch):
+        if self._should_disable_cuda_graph(is_first_draft_token):
             with self.draft_model_engine.no_cuda_graph():
                 outputs = self.draft_model_engine.forward(
-                    draft_batch, resource_manager)
+                    draft_batch,
+                    resource_manager,
+                    new_tensors_device=previous_tensors)
         else:
-            new_tensors_device = previous_batch.device if previous_batch else None
             outputs = self.draft_model_engine.forward(
                 draft_batch,
                 resource_manager,
-                new_tensors_device=new_tensors_device)
+                new_tensors_device=previous_tensors)
 
         # Handle d2t data if available. Static drafting loops should incorporate d2t
         # in their implementations.
@@ -273,8 +278,8 @@ class ModelDrafter(Drafter):
 
         return outputs
 
-    def _sample_async(self, draft_batch: ScheduledRequests,
-                      outputs: Dict[str, Any]) -> Optional[SampleState]:
+    def sample_async(self, draft_batch: ScheduledRequests,
+                     outputs: Dict[str, Any]) -> Optional[SampleState]:
         """Sample tokens from draft model outputs."""
         try:
             if self.sampler is not None:
@@ -298,8 +303,8 @@ class ModelDrafter(Drafter):
             logger.error(f"Error in sampling: {str(e)}")
             return None
 
-    def _update_request_states(self,
-                               scheduled_requests: ScheduledRequests) -> None:
+    def update_request_states(self,
+                              scheduled_requests: ScheduledRequests) -> None:
         """Update request states after processing."""
         for request in scheduled_requests.context_requests:
             if request.state != LlmRequestState.GENERATION_COMPLETE:
@@ -307,12 +312,12 @@ class ModelDrafter(Drafter):
             if request.context_remaining_length == 0:
                 request.state = LlmRequestState.GENERATION_IN_PROGRESS
 
-    def _update_requests(self, sample_state: SampleState) -> None:
+    def update_requests(self, sample_state: SampleState) -> None:
         """Update requests with sample state."""
         if self.sampler is not None:
             self.sampler.update_requests(sample_state)
 
-    def _process_decoded_tokens(
+    def process_decoded_tokens(
             self, draft_batch: ScheduledRequests,
             req_id_to_old_request: Dict[int, LlmRequest]) -> List[LlmRequest]:
         """Process decoded tokens and determine which requests to continue processing."""
@@ -337,6 +342,354 @@ class ModelDrafter(Drafter):
 
         return new_requests
 
+    def should_forward_draft_model(self,
+                                   scheduled_batch: ScheduledRequests) -> bool:
+        """
+        Determine if the draft model should be forwarded for the given batch.
+
+        Args:
+            scheduled_batch: The scheduled requests to check
+
+        Returns:
+            bool: True if draft model should be forwarded, False otherwise
+        """
+        for request in scheduled_batch.context_requests:
+            if request.is_first_context_chunk:
+                continue
+            return True
+
+        for request in scheduled_batch.generation_requests:
+            if request.max_beam_num_tokens - 1 >= self.draft_model_engine.max_seq_len:
+                continue
+            return True
+
+        return False
+
+    def _convert_draft_tensors(
+        self,
+        scheduled_batch: ScheduledRequests,
+        new_tensors_device: Optional[SampleStateTensors] = None
+    ) -> Optional[SampleStateTensorsMTP]:
+        """
+        Convert tensors for draft model processing.
+
+        Args:
+            scheduled_batch: The scheduled requests
+            new_tensors_device: The device tensors to convert
+
+        Returns:
+            SampleStateTensorsMTP: Converted tensors or None
+        """
+        if new_tensors_device is None:
+            return None
+        # Get device from the new_tokens tensor
+        device = new_tensors_device.new_tokens.device
+
+        # Use the same shape as new_tensors_device.new_tokens
+        new_tokens = torch.zeros_like(new_tensors_device.new_tokens)
+        new_tokens_lens = None
+        next_draft_tokens = None
+        # Iterate through generation requests and copy tokens based on accepted draft tokens
+        for idx, request in enumerate(scheduled_batch.all_requests()):
+            if request.state != LlmRequestState.GENERATION_IN_PROGRESS:
+                num_accepted_tokens = request.py_num_accepted_draft_tokens
+                new_tokens[0, idx] = new_tensors_device.new_tokens[
+                    num_accepted_tokens, idx]
+            else:
+                # Create new tensors with the correct device
+                # We already updated the target state, so the new_tokens_lens should be all ones.
+                new_tokens_lens = torch.ones(scheduled_batch.batch_size,
+                                             device=device)
+                next_draft_tokens = torch.zeros(scheduled_batch.batch_size,
+                                                self.max_draft_tokens,
+                                                device=device)
+                num_accepted_tokens = request.py_num_accepted_draft_tokens
+                new_tokens[0, idx] = new_tensors_device.new_tokens[
+                    num_accepted_tokens, idx]
+
+        # Create a new SampleStateTensorsMTP object with the additional fields
+        updated_tensors = SampleStateTensorsMTP(
+            new_tokens=new_tokens,
+            log_probs=new_tensors_device.log_probs,
+            new_tokens_lens=new_tokens_lens,
+            next_draft_tokens=next_draft_tokens)
+
+        if hasattr(new_tensors_device, 'logits'):
+            updated_tensors.logits = new_tensors_device.logits
+
+        return updated_tensors
+
+    def _update_target_inputs_with_draft_tokens(
+            self, target_inputs: SampleStateTensorsMTP,
+            draft_tensors: Optional[torch.Tensor], draft_position: int,
+            draft_length: int, num_draft_reqs: int) -> None:
+        """
+        Update target inputs with new draft tokens from sample state.
+
+        Args:
+            target_inputs: The target input tensors to update
+            draft_sample_state: The draft sample state containing new tokens
+            iteration: The current iteration index
+        """
+        if draft_tensors is not None:
+            for idx in range(num_draft_reqs):
+                # Skip prefill requests
+                if target_inputs.next_draft_tokens is None:
+                    continue
+                target_inputs.new_tokens[draft_position + 1:draft_position +
+                                         draft_length + 1, idx,
+                                         0] = draft_tensors[0:draft_length, idx]
+                target_inputs.next_draft_tokens[
+                    idx, draft_position:draft_position +
+                    draft_length] = draft_tensors[0:draft_length, idx]
+
+    def _setup_draft_batch_and_resources(
+        self,
+        scheduled_batch: ScheduledRequests,
+        guided_decoder: Optional[GuidedDecoder] = None
+    ) -> Tuple[Optional[ScheduledRequests], Optional[Dict[int, LlmRequest]]]:
+        """
+        Setup draft batch and prepare resources.
+
+        Args:
+            scheduled_batch: The scheduled requests
+            guided_decoder: The guided decoder
+
+        Returns:
+            Tuple of (draft_batch, req_id_to_old_request) or (None, None) if no batch
+        """
+        if guided_decoder is not None:
+            guided_decoder.rollback_rejected_tokens(scheduled_batch)
+
+        draft_batch = self.prepare_draft_batch(scheduled_batch)
+        if draft_batch.batch_size == 0:
+            return None, None
+
+        req_id_to_old_request = {
+            req.py_request_id: req
+            for req in scheduled_batch.all_requests()
+        }
+
+        self.draft_seq_slot_manager.prepare_resources(draft_batch)
+        return draft_batch, req_id_to_old_request
+
+    def process_static_draft_outputs(
+            self, outputs: Any, draft_batch: ScheduledRequests,
+            req_id_to_old_request: Dict[int, LlmRequest]) -> None:
+        """
+        Process outputs from static draft loop, update target requests, and clean up resources.
+
+        Args:
+            outputs: The outputs from the draft model
+            draft_batch: The draft batch that was processed
+            req_id_to_old_request: Mapping from request ID to original request
+        """
+        outputs_host = outputs.cpu()
+        for token_idx in range(self.max_draft_tokens):
+            for req_idx, req in enumerate(draft_batch.all_requests()):
+                target_model_req = req_id_to_old_request[req.py_request_id]
+                if target_model_req.state != LlmRequestState.GENERATION_IN_PROGRESS:
+                    # Chunked prefill request in progress; no need to append draft tokens
+                    continue
+
+                target_req = req_id_to_old_request[req.py_request_id]
+                target_req.py_draft_tokens.append(
+                    outputs_host[token_idx][req_idx])
+
+        # Clean up draft resources
+        for req in draft_batch.all_requests():
+            self.draft_seq_slot_manager.free_resources(req)
+
+    def _execute_draft_iteration(
+        self,
+        draft_batch: ScheduledRequests,
+        resource_manager: ResourceManager,
+        previous_draft_state: Optional[SampleState],
+        guided_decoder: Optional[GuidedDecoder] = None
+    ) -> Tuple[Any, Optional[SampleState]]:
+        """
+        Execute a single draft iteration.
+
+        Args:
+            draft_batch: The draft batch to process
+            resource_manager: The resource manager
+            previous_draft_state: The previous draft state
+            guided_decoder: The guided decoder
+
+        Returns:
+            Tuple of (outputs, new_sample_state)
+        """
+        outputs = self.forward_draft_model(
+            draft_batch,
+            resource_manager,
+            is_first_draft_token=False,
+            previous_tensors=previous_draft_state.device
+            if previous_draft_state else None)
+
+        if previous_draft_state is not None:
+            self.update_requests(previous_draft_state)
+
+        if guided_decoder is not None:
+            guided_decoder.add_batch(draft_batch)
+            guided_decoder.execute(outputs['logits'],
+                                   outputs['logits'],
+                                   d2t=outputs.get('d2t'))
+
+        sample_state = self.sample_async(draft_batch, outputs)
+        self.update_request_states(draft_batch)
+
+        return outputs, sample_state
+
+    def _execute_draft_loop(
+        self,
+        draft_batch: ScheduledRequests,
+        resource_manager: ResourceManager,
+        req_id_to_old_request: Dict[int, LlmRequest],
+        guided_decoder: Optional[GuidedDecoder] = None,
+        target_inputs: Optional[SampleStateTensorsMTP] = None,
+        num_draft_reqs: Optional[int] = None,
+        initial_draft_state: Optional[SampleState] = None
+    ) -> Optional[SampleState]:
+        """
+        Execute the iterative draft loop.
+
+        Args:
+            draft_batch: The draft batch to process
+            resource_manager: The resource manager
+            req_id_to_old_request: Mapping from request ID to original request
+            guided_decoder: The guided decoder
+            target_inputs: Optional target inputs to update (for overlap mode)
+            num_draft_reqs: Number of draft requests (for overlap mode)
+            initial_draft_state: The initial draft state from the first forward pass
+
+        Returns:
+            The final sample state
+        """
+        # Convert context requests to generation requests
+        draft_batch.generation_requests = draft_batch.context_requests + draft_batch.generation_requests
+        draft_batch.context_requests = []
+
+        previous_draft_state = initial_draft_state
+
+        # Generate remaining draft tokens iteratively
+        for i in range(self.max_draft_tokens - 1):
+            if len(draft_batch.generation_requests) == 0:
+                break
+
+            _, sample_state = self._execute_draft_iteration(
+                draft_batch, resource_manager, previous_draft_state,
+                guided_decoder)
+
+            # Update target inputs if provided (for overlap mode)
+            if target_inputs is not None and num_draft_reqs is not None:
+                draft_tensors = sample_state and sample_state.device and sample_state.device.new_tokens
+                self._update_target_inputs_with_draft_tokens(
+                    target_inputs,
+                    draft_tensors,
+                    i + 1,
+                    draft_length=1,
+                    num_draft_reqs=num_draft_reqs)
+
+            if sample_state is not None and previous_draft_state is not None:
+                new_requests = self.process_decoded_tokens(
+                    previous_draft_state.scheduled_requests,
+                    req_id_to_old_request)
+            else:
+                new_requests = []
+
+            draft_batch.generation_requests = new_requests
+            previous_draft_state = sample_state
+
+        return previous_draft_state
+
+    def pad_draft_tokens_for_cuda_graph(
+            self, scheduled_requests: ScheduledRequests) -> None:
+        """
+        Pad draft tokens to the max draft length for CUDA graph compatibility.
+
+        Args:
+            scheduled_requests: The scheduled requests to pad
+        """
+        for req in scheduled_requests.generation_requests:
+            max_draft_tokens = self.max_draft_tokens
+            num_draft_tokens = get_draft_token_length(req)
+            req.py_draft_tokens.extend(
+                0 for _ in range(max_draft_tokens - num_draft_tokens))
+
+    def generate_draft_tokens_with_overlap(
+        self, scheduled_batch: ScheduledRequests,
+        resource_manager: ResourceManager,
+        previous_tensors: Optional[SampleStateTensors],
+        guided_decoder: Optional[GuidedDecoder]
+    ) -> Tuple[Optional[SampleStateTensorsMTP], Optional[Any],
+               Optional[ScheduledRequests]]:
+        """
+        Generate draft tokens with overlap scheduling support.
+
+        Args:
+            scheduled_batch: The scheduled requests
+            resource_manager: The resource manager
+            previous_tensors: Previous iteration tensors
+            guided_decoder: The guided decoder
+
+        Returns:
+            Tuple[Optional[SampleStateTensorsMTP], Optional[SampleState]]:
+                - Updated target inputs or None
+                - Draft sample state or None
+        """
+        draft_batch, req_id_to_old_request = self._setup_draft_batch_and_resources(
+            scheduled_batch, guided_decoder)
+        if draft_batch is None:
+            return None, None, None
+
+        target_inputs = self._convert_draft_tensors(scheduled_batch,
+                                                    previous_tensors)
+        if target_inputs is None:
+            return None, None, None
+
+        # Initial forward pass
+        outputs = self.forward_draft_model(draft_batch,
+                                           resource_manager,
+                                           is_first_draft_token=True,
+                                           previous_tensors=previous_tensors)
+
+        num_draft_reqs = len(draft_batch.all_requests())
+        if self.use_static_draft_loop:
+            # Only update target inputs, cleanup will be done in executor loop
+            self._update_target_inputs_with_draft_tokens(
+                target_inputs,
+                outputs,
+                0,
+                draft_length=self.max_draft_tokens,
+                num_draft_reqs=num_draft_reqs)
+            return target_inputs, outputs, draft_batch
+
+        # Handle guided decoder and sampling for non-static loop
+        if self.guided_decoder is not None:
+            self.guided_decoder.add_batch(draft_batch)
+            self.guided_decoder.execute(outputs['logits'],
+                                        outputs['logits'],
+                                        d2t=outputs.get('d2t'))
+        draft_sample_state = self.sample_async(draft_batch, outputs)
+
+        # Update target inputs with first iteration results
+        draft_tensors = draft_sample_state and draft_sample_state.device and draft_sample_state.device.new_tokens
+        self._update_target_inputs_with_draft_tokens(
+            target_inputs,
+            draft_tensors,
+            0,
+            draft_length=1,
+            num_draft_reqs=num_draft_reqs)
+
+        self.update_request_states(draft_batch)
+
+        # Execute the iterative draft loop
+        previous_draft_state = self._execute_draft_loop(
+            draft_batch, resource_manager, req_id_to_old_request,
+            guided_decoder, target_inputs, num_draft_reqs, draft_sample_state)
+
+        return target_inputs, previous_draft_state, draft_batch
+
     @nvtx_range("prepare_draft_tokens")
     def prepare_draft_tokens(
         self,
@@ -357,84 +710,41 @@ class ModelDrafter(Drafter):
             raise ValueError("Resource manager is required")
 
         try:
-            draft_batch = self._prepare_draft_batch(scheduled_requests)
-
-            if draft_batch.batch_size == 0:
+            draft_batch, req_id_to_old_request = self._setup_draft_batch_and_resources(
+                scheduled_requests)
+            if draft_batch is None:
                 return
-
-            self.draft_seq_slot_manager.prepare_resources(draft_batch)
-
-            req_id_to_old_request = {
-                req.py_request_id: req
-                for req in scheduled_requests.all_requests()
-            }
 
             # Initial forward pass. May do the complete drafting loop
             # if use_static_draft_loop is set.
-            outputs = self._forward_draft_model(draft_batch, resource_manager)
+            outputs = self.forward_draft_model(draft_batch,
+                                               resource_manager,
+                                               is_first_draft_token=True)
 
             if self.use_static_draft_loop:
-                outputs_host = outputs.cpu()
-                for token_idx in range(self.max_draft_tokens):
-                    for req_idx, req in enumerate(draft_batch.all_requests()):
-                        target_model_req = req_id_to_old_request[
-                            req.py_request_id]
-                        if target_model_req.state != LlmRequestState.GENERATION_IN_PROGRESS:
-                            # Chunked prefill request in progress; no need to append draft tokens
-                            continue
-
-                        target_req = req_id_to_old_request[req.py_request_id]
-                        target_req.py_draft_tokens.append(
-                            outputs_host[token_idx][req_idx])
-
-                for req in draft_batch.all_requests():
-                    self.draft_seq_slot_manager.free_resources(req)
-
+                self.process_static_draft_outputs(outputs, draft_batch,
+                                                  req_id_to_old_request)
                 return
 
+            # Handle guided decoder and sampling for non-static loop
             if self.guided_decoder is not None:
                 self.guided_decoder.add_batch(draft_batch)
                 self.guided_decoder.execute(outputs['logits'],
                                             d2t=outputs.get('d2t'))
-            sample_state = self._sample_async(draft_batch, outputs)
-            previous_batch = sample_state
+            sample_state = self.sample_async(draft_batch, outputs)
+            self.update_request_states(draft_batch)
 
-            self._update_request_states(draft_batch)
-
-            # Convert context requests to generation requests
-            draft_batch.generation_requests = draft_batch.context_requests + draft_batch.generation_requests
-            draft_batch.context_requests = []
-
-            # Generate remaining draft tokens iteratively
-            for i in range(self.max_draft_tokens - 1):
-                if len(draft_batch.generation_requests) == 0:
-                    break
-
-                outputs = self._forward_draft_model(draft_batch,
-                                                    resource_manager,
-                                                    previous_batch)
-                if previous_batch is not None:
-                    self._update_requests(previous_batch)
-                if self.guided_decoder is not None:
-                    self.guided_decoder.add_batch(draft_batch)
-                    self.guided_decoder.execute(outputs['logits'],
-                                                d2t=outputs.get('d2t'))
-                sample_state = self._sample_async(draft_batch, outputs)
-                self._update_request_states(draft_batch)
-                if previous_batch is not None:
-                    new_requests = self._process_decoded_tokens(
-                        previous_batch.scheduled_requests,
-                        req_id_to_old_request)
-                else:
-                    new_requests = []
-                draft_batch.generation_requests = new_requests
-                previous_batch = sample_state
+            # Execute the iterative draft loop
+            previous_draft_state = self._execute_draft_loop(
+                draft_batch, resource_manager, req_id_to_old_request,
+                self.guided_decoder, None, None, sample_state)
 
             # Final cleanup
-            if previous_batch is not None:
-                self._update_requests(previous_batch)
-                self._process_decoded_tokens(previous_batch.scheduled_requests,
-                                             req_id_to_old_request)
+            if previous_draft_state is not None:
+                self.update_requests(previous_draft_state)
+                self.process_decoded_tokens(
+                    previous_draft_state.scheduled_requests,
+                    req_id_to_old_request)
 
         except Exception as e:
             traceback.print_exc()

--- a/tensorrt_llm/_torch/speculative/ngram.py
+++ b/tensorrt_llm/_torch/speculative/ngram.py
@@ -25,7 +25,7 @@ class NGramPoolManager(BaseResourceManager):
     `matches` is a list of candidate draft token ids attaching to a pattern.
 
     Arguments:
-        max_draft_len: int
+        max_draft_tokens: int
             The length maximum of draft tokens (can be understood as length maximum of output draft tokens).
 
         max_matching_ngram_size: int
@@ -51,7 +51,7 @@ class NGramPoolManager(BaseResourceManager):
 
     def __init__(self, spec_config: "NGramDecodingConfig",
                  max_num_requests: int):
-        self.max_draft_len = spec_config.max_draft_len
+        self.max_draft_tokens = spec_config.max_draft_len
         self.max_matching_ngram_size = spec_config.max_matching_ngram_size
         self.is_keep_all = spec_config.is_keep_all
         self.is_use_oldest = spec_config.is_use_oldest  # TODO: remove this if updating strategy is supported
@@ -107,7 +107,7 @@ class NGramPoolManager(BaseResourceManager):
                           -1):
             # Find each possible pattern-match combination, and use tuple for hash
             for l in range(len(sequence) - size):
-                r = min(l + size + self.max_draft_len, len(sequence))
+                r = min(l + size + self.max_draft_tokens, len(sequence))
                 pattern = tuple(sequence[l:l + size])
                 new_match = tuple(sequence[l + size:r])
                 if pattern not in pool or \
@@ -138,7 +138,7 @@ class NGramPoolManager(BaseResourceManager):
         # Update start_index
         self.start_index[request_id] = max(
             0, prefix_len -
-            (self.max_draft_len + self.max_matching_ngram_size - 1))
+            (self.max_draft_tokens + self.max_matching_ngram_size - 1))
 
         return draft_tokens
 
@@ -170,7 +170,7 @@ class NGramDrafter(Drafter):
         super().__init__(spec_config.max_concurrency)
         assert ngram_pool_manager is not None, "NGram needs a resource manager to maintain the pool."
         self.spec_config = spec_config
-        self.max_draft_len = spec_config.max_draft_len
+        self.max_draft_tokens = spec_config.max_draft_len
         self.spec_resource_manager = ngram_pool_manager
 
     def prepare_draft_tokens(

--- a/tests/unittest/_torch/speculative/test_dynamic_spec_decode.py
+++ b/tests/unittest/_torch/speculative/test_dynamic_spec_decode.py
@@ -14,8 +14,9 @@ from tensorrt_llm.llmapi import (CudaGraphConfig, EagleDecodingConfig,
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 
+@pytest.mark.parametrize("disable_overlap_scheduler", [True, False])
 @pytest.mark.high_cuda_memory
-def test_dynamic_spec_decode():
+def test_dynamic_spec_decode(disable_overlap_scheduler: bool):
     total_mem_gb = torch.cuda.get_device_properties(0).total_memory / 1e9
     if total_mem_gb < 35:
         pytest.skip("Not enough memory to load target + draft model")
@@ -32,7 +33,7 @@ def test_dynamic_spec_decode():
     llm_common_config = dict(
         model=target_model_dir,
         attn_backend="TRTLLM",
-        disable_overlap_scheduler=True,
+        disable_overlap_scheduler=disable_overlap_scheduler,
         cuda_graph_config=cuda_graph_config,
         max_batch_size=max_batch_size,
         kv_cache_config=kv_cache_config,
@@ -51,8 +52,8 @@ def test_dynamic_spec_decode():
     )
 
     # Mock should_use_spec_decode to return True for first two calls, then False
-    def mock_should_use_spec_decode(self, requests, max_batch_size,
-                                    max_num_tokens, max_draft_len):
+    def mock_should_use_spec_decode(requests, max_batch_size, max_num_tokens,
+                                    max_draft_len):
         if not hasattr(mock_should_use_spec_decode, 'call_count'):
             mock_should_use_spec_decode.call_count = 0
         mock_should_use_spec_decode.call_count += 1

--- a/tests/unittest/_torch/speculative/test_eagle3.py
+++ b/tests/unittest/_torch/speculative/test_eagle3.py
@@ -28,6 +28,8 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
         [True, "TRTLLM", True, False, True, True],
         # TODO: nvbugs/5461761
         # [True, "TRTLLM", True, False, False, True],
+        [True, "TRTLLM", True, False, False, True],
+        [True, "TRTLLM", False, False, False, False],
     ])
 @pytest.mark.high_cuda_memory
 def test_llama_eagle3(use_cuda_graph: bool, attn_backend: str,

--- a/tests/unittest/_torch/speculative/test_eagle3.py
+++ b/tests/unittest/_torch/speculative/test_eagle3.py
@@ -26,10 +26,16 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
         [False, "TRTLLM", False, True, True, False],
         [True, "TRTLLM", False, True, True, False],
         [True, "TRTLLM", True, False, True, True],
+        [True, "TRTLLM", True, False, True, False],
         # TODO: nvbugs/5461761
         # [True, "TRTLLM", True, False, False, True],
         [True, "TRTLLM", True, False, False, True],
+        [False, "TRTLLM", True, False, False, True],
         [True, "TRTLLM", False, False, False, False],
+        [False, "TRTLLM", False, False, False, False],
+        [True, "TRTLLM", False, False, False, True],
+        [True, "FLASHINFER", False, False, False, False],
+        [False, "FLASHINFER", False, False, False, False],
     ])
 @pytest.mark.high_cuda_memory
 def test_llama_eagle3(use_cuda_graph: bool, attn_backend: str,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Enables overlap scheduling for speculative decoding with draft models (including Eagle3 and draft-target scenarios).
  - Adds extended-context decoding support with correct handling during generation.
  - Improves CUDA graph compatibility via automatic draft token padding.

- Bug Fixes
  - Corrects token-length accounting and KV cache updates in extended-context and speculative decoding, improving stability and accuracy.

- Tests
  - Expands Eagle3 test coverage across multiple backends, CUDA graph settings, chunked prefill, and one-model configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

To support overlap scheduler with two-model spec decoding, the PR initializes the same input as one-model spec with overlap scheduler (SampleStateTensorsMTP).

With the changes, the workflow of the overlap scheduler without speculative decoding is as below.
<img width="1207" height="561" alt="overlap_without_spec_dec" src="https://github.com/user-attachments/assets/24227e5e-9586-48a4-b738-5d19b9e66dfe" />


The expected workflow when enabling speculative decoding is that "forward draft model" can be done before "sync target sample state". However, the current [prepare_draft_batch](https://github.com/ziyixiong-nv/TensorRT-LLM/blob/dev-fxiong-trtllm-6668/tensorrt_llm/_torch/speculative/model_drafter.py#L173) has a dependency on the input tokens, so it must happen after "sync target sample state". Then the workflow for overlap scheduler with speculative decoding is as below, so we only have overlap for draft-draft and draft-target, but no overlap for target-draft.
<img width="1203" height="573" alt="overlap_with_spec_dec" src="https://github.com/user-attachments/assets/f785d472-e767-4d27-b3bc-c6e4a8c140ae" />


## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
