### PR TITLE
[None][feat] Add a standalone buffer cache class and reuse buffers between cduagraph and no-graph flow

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -621,7 +621,7 @@ class TrtllmAttentionMetadata(AttentionMetadata):
         capture_graph = torch.cuda.is_current_stream_capturing()
 
         def get_empty(tensor_shape: list[int], dtype: torch.dtype,
-                      cache_name: str, pin_memory: bool) -> torch.Tensor:
+                      cache_name: str) -> torch.Tensor:
             """
             Finds a compatible, reusable buffer from a cache or creates a new one.
 
@@ -637,7 +637,6 @@ class TrtllmAttentionMetadata(AttentionMetadata):
                 tensor_shape: The required shape.
                 dtype: The required dtype.
                 cache_name: The key for the specific list of buffers to search in.
-                pin_memory: This buffer block shall be kept in buffer pool if provided
             Returns:
                 An existing compatible buffer or a newly created one.
             """
@@ -645,27 +644,26 @@ class TrtllmAttentionMetadata(AttentionMetadata):
                 return torch.zeros(tensor_shape, device='cuda', dtype=dtype)
 
             return buffers.get_buffer(tensor_shape, dtype, cache_name,
-                                      pin_memory)
+                                      capture_graph)
 
-        def get_empty_like(like_tensor: torch.Tensor, cache_name: str,
-                           pin_memory: bool) -> torch.Tensor:
+        def get_empty_like(like_tensor: torch.Tensor,
+                           cache_name: str) -> torch.Tensor:
             return get_empty(like_tensor.shape,
                              cache_name=cache_name,
-                             dtype=like_tensor.dtype,
-                             pin_memory=pin_memory)
+                             dtype=like_tensor.dtype)
 
-        self.prompt_lens_cuda = get_empty((self.max_num_sequences, ),
-                                          cache_name="prompt_lens_cuda",
-                                          dtype=torch.int,
-                                          pin_memory=capture_graph)
+        self.prompt_lens_cuda = get_empty(
+            (self.max_num_sequences, ),
+            cache_name="prompt_lens_cuda",
+            dtype=torch.int,
+        )
         self.prompt_lens_cpu = torch.empty_like(
             self.prompt_lens_cuda,
             device='cpu',
             pin_memory=True,
         )
         self.kv_lens_cuda = get_empty_like(self.prompt_lens_cuda,
-                                           cache_name="kv_lens_cuda",
-                                           pin_memory=capture_graph)
+                                           cache_name="kv_lens_cuda")
         self.kv_lens = torch.empty_like(self.kv_lens_cuda,
                                         device='cpu',
                                         pin_memory=True)
@@ -687,7 +685,7 @@ class TrtllmAttentionMetadata(AttentionMetadata):
                 ],
                 cache_name="kv_cache_block_offsets",
                 dtype=torch.int32,
-                pin_memory=capture_graph)
+            )
             self.host_kv_cache_block_offsets = torch.empty_like(
                 self.kv_cache_block_offsets,
                 device='cpu',
@@ -703,7 +701,7 @@ class TrtllmAttentionMetadata(AttentionMetadata):
                     ],
                     cache_name="block_ids_per_seq",
                     dtype=torch.int32,
-                    pin_memory=capture_graph)
+                )
                 self.kv_block_ids_per_seq = get_empty(
                     [
                         self.kv_cache_manager.max_batch_size,
@@ -711,14 +709,14 @@ class TrtllmAttentionMetadata(AttentionMetadata):
                     ],
                     cache_name="kv_block_ids_per_seq",
                     dtype=torch.int32,
-                    pin_memory=capture_graph)
+                )
             if self.enable_context_mla_with_cached_kv:
                 # for kv cache reuse/chunked context in MLA
                 self.ctx_cached_token_indptr = get_empty(
                     (self.max_num_requests + 1, ),
                     cache_name="ctx_cached_token_indptr",
                     dtype=torch.int64,
-                    pin_memory=capture_graph)
+                )
                 self.host_ctx_cached_token_indptr = torch.zeros_like(
                     self.ctx_cached_token_indptr,
                     device='cpu',
@@ -728,17 +726,18 @@ class TrtllmAttentionMetadata(AttentionMetadata):
                     (self.max_num_requests + 1, ),
                     cache_name="ctx_uncached_token_indptr",
                     dtype=torch.int64,
-                    pin_memory=capture_graph)
+                )
                 self.host_ctx_uncached_token_indptr = torch.zeros_like(
                     self.ctx_uncached_token_indptr,
                     device='cpu',
                     pin_memory=True,
                 )
                 # context full seqlens include cached tokens and uncached tokens
-                self.ctx_kv_indptr = get_empty((self.max_num_requests + 1, ),
-                                               cache_name="ctx_kv_indptr",
-                                               dtype=torch.int64,
-                                               pin_memory=capture_graph)
+                self.ctx_kv_indptr = get_empty(
+                    (self.max_num_requests + 1, ),
+                    cache_name="ctx_kv_indptr",
+                    dtype=torch.int64,
+                )
                 self.host_ctx_kv_indptr = torch.zeros_like(
                     self.ctx_kv_indptr,
                     device='cpu',

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -621,7 +621,7 @@ class TrtllmAttentionMetadata(AttentionMetadata):
         capture_graph = torch.cuda.is_current_stream_capturing()
 
         def get_empty(tensor_shape: list[int], dtype: torch.dtype,
-                      cache_name: str, pin_memory: boolean) -> torch.Tensor:
+                      cache_name: str, pin_memory: bool) -> torch.Tensor:
             """
             Finds a compatible, reusable buffer from a cache or creates a new one.
 
@@ -644,11 +644,11 @@ class TrtllmAttentionMetadata(AttentionMetadata):
             if buffers is None:
                 return torch.zeros(tensor_shape, device='cuda', dtype=dtype)
 
-            return buffers.get_buffer(self, tensor_shape, dtype, cache_name,
+            return buffers.get_buffer(tensor_shape, dtype, cache_name,
                                       pin_memory)
 
         def get_empty_like(like_tensor: torch.Tensor, cache_name: str,
-                           pin_memory: boolean) -> torch.Tensor:
+                           pin_memory: bool) -> torch.Tensor:
             return get_empty(like_tensor.shape,
                              cache_name=cache_name,
                              dtype=like_tensor.dtype,

--- a/tensorrt_llm/_torch/memory_buffer_utils.py
+++ b/tensorrt_llm/_torch/memory_buffer_utils.py
@@ -7,109 +7,93 @@ import torch
 
 @dataclass
 class BufferBlock:
+    """A container for a buffer tensor and its state."""
     buffer: torch.Tensor = None
-    pin_memory: bool = False
+    is_reserved: bool = False
 
 
-# Intention to have this buffer is to reuse buffer tensors across graph and non-graph
-# situation (across layer/round).
-# When forward is under graph capturing, one stream is created and all tensors' memory
-# is associated with this stream and be kept in a graph pool. Then, all buffer memory
-# allocated during graph capture won't be released back to allocator/system.
-# Then, in non-graph mode, additional buffers are allocated which give bigger pressure
-# on memory consumption at runtime.
-# Timeline example:
-#   [t0] start cudagraph capture
-#   [t1] A = torch.zeros(....) -> allocate buffer A and put into graph pool
-#   [t2] end cudagraph capture
-#   [t3] in non-graph forward
-#   [t4] A = torch.zeros(....) -> allocate buffer A in allocator but not use memory in cudagraph pool
-#        OOM may happen
-# TODO:
-# The final resolution to this problem shall be supported in pytorch that to allocate memory
-#    from a give pool, it's the graph pool here.
-# It will be like
-#    try:
-#        with torch.cuda.use_mem_pool(graphpool):
-#            allocate_memory_here
-#    except exception as ex:
-#        allocate_memory_outside of graphpool
-# Need some archeteture change:
-#    1. a. set a thread local graphpool context object when cudagraphRunner start a fn
-#       b. check and get the thread local graphpool
-#       b. allocate memory
-#    2. aggregate workspaces in the same OP to be a big one in graph pool
-#       allocate memory for the big workspace and slice them into small ones.
-#       However, in non-graph mode, allocate workspace one by one
 class Buffers:
+    """
+    Manages and reuses CUDA memory buffers to reduce allocation overhead,
+    especially when interacting with CUDA graphs.
+
+    This class maintains a pool of named buffers. When a buffer is requested,
+    it tries to find an existing, available buffer that is large enough.
+    If none is found, a new one is allocated and added to the pool. This helps
+    avoid repeated allocations, which can be slow and cause memory fragmentation,
+    particularly when the same operations are run inside and outside of a
+    CUDA graph context.
+    """
 
     def __init__(self):
         self.buffers: dict[str, list[BufferBlock]] = {}
 
+    @staticmethod
+    def _view_as(buffer: torch.Tensor, target_shape: list[int],
+                 target_dtype: torch.dtype) -> torch.Tensor:
+        """Safely creates a view of a raw byte buffer with the desired shape and dtype."""
+        # The buffer is stored as uint8, so its numel is its size in bytes.
+        required_size_in_bytes = math.prod(target_shape) * target_dtype.itemsize
+        if buffer.numel() < required_size_in_bytes:
+            raise ValueError(
+                "Buffer is too small for the requested shape and dtype.")
+
+        # Slice the buffer to the exact required size, then view it with the correct type and shape.
+        return buffer[:required_size_in_bytes].view(target_dtype).view(
+            target_shape)
+
     def get_buffer(self, tensor_shape: list[int], dtype: torch.dtype,
-                   buffer_name: str, pin_memory: bool):
-
-        def select_buffer_with_more_elements(
-            pinned_buffer: Optional[torch.Tensor],
-            runtime_buffer: Optional[torch.Tensor]
-        ) -> tuple[Optional[torch.Tensor]]:
-            if pinned_buffer is None:
-                return runtime_buffer
-            if runtime_buffer is None:
-                return pinned_buffer
-
-            return runtime_buffer if runtime_buffer.buffer.numel(
-            ) > pinned_buffer.buffer.numel() else pinned_buffer
-
-        def view_to(buffer: torch.Tensor, dtype: torch.dtype,
-                    tensor_shape: list[int]) -> torch.Tensor:
-            return buffer[0:math.prod(tensor_shape) *
-                          dtype.itemsize].view(dtype).view(tensor_shape)
+                   buffer_name: str, reserve_buffer: bool):
 
         # all buffers are allocated with 1 byte element size
-        element_size = dtype.itemsize
-        required_memory_size = math.prod(tensor_shape) * element_size
-        candidate_buffers = self.buffers.get(buffer_name, [])
-        pinned_buffer = None
-        free_buffer = None
-        for buffer in candidate_buffers:
-            buffer_size = buffer.buffer.numel()
-            if buffer_size >= required_memory_size:
-                if buffer.pin_memory:
-                    pinned_buffer = buffer
-                else:
-                    free_buffer = buffer
+        required_memory_size = math.prod(tensor_shape) * dtype.itemsize
+        candidate_blocks = self.buffers.get(buffer_name, [])
 
-            if free_buffer is not None and pinned_buffer is not None:
-                break
+        # Find the best-fit available buffer.
+        best_fit_block: Optional[BufferBlock] = None
+        smallest_sufficient_size = float('inf')
+        for block in candidate_blocks:
+            # Skip buffers that are too small.
+            if block.buffer.numel() < required_memory_size:
+                continue
 
-        if pin_memory:
-            if pinned_buffer is not None:
-                return view_to(pinned_buffer.buffer, dtype, tensor_shape)
-            elif free_buffer is not None:
-                free_buffer.pin_memory = True
-                return view_to(free_buffer.buffer, dtype, tensor_shape)
+            # Find the smallest buffer that is still large enough (best-fit).
+            if block.buffer.numel() < smallest_sufficient_size:
+                # Use reserved block if find one.
+                if best_fit_block is not None and best_fit_block.is_reserved and not block.is_reserved:
+                    continue
 
-        if buffer_name in self.buffers:
-            candidate_buffers = self.buffers.get(buffer_name, [])
-            for buffer in list(candidate_buffers):
-                if not buffer.pin_memory:
-                    # Need to call del BufferBlock.buffer, otherwise memory isn't
-                    # released and OOM may happen.
-                    del buffer.buffer
-                    candidate_buffers.remove(buffer)
+                best_fit_block = block
+                smallest_sufficient_size = block.buffer.numel()
 
-        new_buffer = torch.zeros((required_memory_size, ),
-                                 device='cuda',
-                                 dtype=torch.uint8)
-        self.buffers.setdefault(buffer_name, []).append(
-            BufferBlock(buffer=new_buffer, pin_memory=pin_memory))
-        return view_to(new_buffer, dtype, tensor_shape)
+        if reserve_buffer and best_fit_block is not None:
+            # A suitable buffer was found, so reuse it.
+            best_fit_block.is_reserved = True
+            return self._view_as(best_fit_block.buffer, tensor_shape, dtype)
+
+        for block in list(candidate_blocks):
+            if not block.is_reserved:
+                # Need to call del BufferBlock.buffer, otherwise memory isn't
+                # released and OOM may happen.
+                del block.buffer
+                candidate_blocks.remove(block)
+
+        # No suitable buffer was found, so allocate a new one.
+        # The new buffer is created with uint8 to represent raw bytes.
+        new_buffer_tensor = torch.zeros((required_memory_size, ),
+                                        device='cuda',
+                                        dtype=torch.uint8)
+        new_block = BufferBlock(buffer=new_buffer_tensor,
+                                is_reserved=reserve_buffer)
+
+        # Add the new buffer to the pool for this name.
+        self.buffers.setdefault(buffer_name, []).append(new_block)
+        return self._view_as(new_block.buffer, tensor_shape, dtype)
 
 
 _buffer = Buffers()
 
 
-def get_memory_buffer():
+def get_memory_buffers():
     global _buffer
     return _buffer

--- a/tensorrt_llm/_torch/memory_buffer_utils.py
+++ b/tensorrt_llm/_torch/memory_buffer_utils.py
@@ -92,16 +92,12 @@ class Buffers:
 
         if buffer_name in self.buffers:
             candidate_buffers = self.buffers.get(buffer_name, [])
-            remove_idx = []
-            for idx, buffer in enumerate(candidate_buffers):
+            for buffer in list(candidate_buffers):
                 if not buffer.pin_memory:
-                    remove_idx.append(idx)
-
-            for idx in remove_idx[::-1]:
-                removed = candidate_buffers.pop(idx)
-                # Need to call del BufferBlock.buffer, otherwise memory isn't
-                # released and OOM may happen.
-                del removed.buffer
+                    # Need to call del BufferBlock.buffer, otherwise memory isn't
+                    # released and OOM may happen.
+                    del buffer.buffer
+                    candidate_buffers.remove(buffer)
 
         new_buffer = torch.zeros((required_memory_size, ),
                                  device='cuda',

--- a/tensorrt_llm/_torch/memory_buffer_utils.py
+++ b/tensorrt_llm/_torch/memory_buffer_utils.py
@@ -86,18 +86,15 @@ class Buffers:
         if pin_memory:
             if pinned_buffer is not None:
                 return view_to(pinned_buffer.buffer, dtype, tensor_shape)
-            else:
-                buffer = select_buffer_with_more_elements(
-                    pinned_buffer, free_buffer)
-                if buffer is not None:
-                    buffer.pin_memory = True
-                    return view_to(buffer.buffer, dtype, tensor_shape)
+            elif free_buffer is not None:
+                free_buffer.pin_memory = True
+                return view_to(free_buffer.buffer, dtype, tensor_shape)
 
         if buffer_name in self.buffers:
             candidate_buffers = self.buffers.get(buffer_name, [])
             remove_idx = []
             for idx, buffer in enumerate(candidate_buffers):
-                if buffer.pin_memory == False:
+                if not buffer.pin_memory:
                     remove_idx.append(idx)
 
             for idx in remove_idx[::-1]:

--- a/tensorrt_llm/_torch/memory_buffer_utils.py
+++ b/tensorrt_llm/_torch/memory_buffer_utils.py
@@ -1,0 +1,122 @@
+import math
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+
+
+@dataclass
+class BufferBlock:
+    buffer: torch.Tensor = None
+    pin_memory: bool = False
+
+
+# Intention to have this buffer is to reuse buffer tensors across graph and non-graph
+# situation (across layer/round).
+# When forward is under graph capturing, one stream is created and all tensors' memory
+# is associated with this stream and be kept in a graph pool. Then, all buffer memory
+# allocated during graph capture won't be released back to allocator/system.
+# Then, in non-graph mode, additional buffers are allocated which give bigger pressure
+# on memory consumption at runtime.
+# Timeline example:
+#   [t0] start cudagraph capture
+#   [t1] A = torch.zeros(....) -> allocate buffer A and put into graph pool
+#   [t2] end cudagraph capture
+#   [t3] in non-graph forward
+#   [t4] A = torch.zeros(....) -> allocate buffer A in allocator but not use memory in cudagraph pool
+#        OOM may happen
+# TODO:
+# The final resolution to this problem shall be supported in pytorch that to allocate memory
+#    from a give pool, it's the graph pool here.
+# It will be like
+#    try:
+#        with torch.cuda.use_mem_pool(graphpool):
+#            allocate_memory_here
+#    except exception as ex:
+#        allocate_memory_outside of graphpool
+# Need some archeteture change:
+#    1. a. set a thread local graphpool context object when cudagraphRunner start a fn
+#       b. check and get the thread local graphpool
+#       b. allocate memory
+#    2. aggregate workspaces in the same OP to be a big one in graph pool
+#       allocate memory for the big workspace and slice them into small ones.
+#       However, in non-graph mode, allocate workspace one by one
+class Buffers:
+
+    def __init__(self):
+        self.buffers: dict[str, list[BufferBlock]] = {}
+
+    def get_buffer(self, tensor_shape: list[int], dtype: torch.dtype,
+                   buffer_name: str, pin_memory: bool):
+
+        def select_buffer_with_more_elements(
+            pinned_buffer: Optional[torch.Tensor],
+            runtime_buffer: Optional[torch.Tensor]
+        ) -> tuple[Optional[torch.Tensor]]:
+            if pinned_buffer is None:
+                return runtime_buffer
+            if runtime_buffer is None:
+                return pinned_buffer
+
+            return runtime_buffer if runtime_buffer.buffer.numel(
+            ) > pinned_buffer.buffer.numel() else pinned_buffer
+
+        def view_to(buffer: torch.Tensor, dtype: torch.dtype,
+                    tensor_shape: list[int]) -> torch.Tensor:
+            return buffer[0:math.prod(tensor_shape) *
+                          dtype.itemsize].view(dtype).view(tensor_shape)
+
+        # all buffers are allocated with 1 byte element size
+        element_size = dtype.itemsize
+        required_memory_size = math.prod(tensor_shape) * element_size
+        candidate_buffers = self.buffers.get(buffer_name, [])
+        pinned_buffer = None
+        free_buffer = None
+        for buffer in candidate_buffers:
+            buffer_size = buffer.buffer.numel()
+            if buffer_size >= required_memory_size:
+                if buffer.pin_memory:
+                    pinned_buffer = buffer
+                else:
+                    free_buffer = buffer
+
+            if free_buffer is not None and pinned_buffer is not None:
+                break
+
+        if pin_memory:
+            if pinned_buffer is not None:
+                return view_to(pinned_buffer.buffer, dtype, tensor_shape)
+            else:
+                buffer = select_buffer_with_more_elements(
+                    pinned_buffer, free_buffer)
+                if buffer is not None:
+                    buffer.pin_memory = True
+                    return view_to(buffer.buffer, dtype, tensor_shape)
+
+        if buffer_name in self.buffers:
+            candidate_buffers = self.buffers.get(buffer_name, [])
+            remove_idx = []
+            for idx, buffer in enumerate(candidate_buffers):
+                if buffer.pin_memory == False:
+                    remove_idx.append(idx)
+
+            for idx in remove_idx[::-1]:
+                removed = candidate_buffers.pop(idx)
+                # Need to call del BufferBlock.buffer, otherwise memory isn't
+                # released and OOM may happen.
+                del removed.buffer
+
+        new_buffer = torch.zeros((required_memory_size, ),
+                                 device='cuda',
+                                 dtype=torch.uint8)
+        self.buffers.setdefault(buffer_name, []).append(
+            BufferBlock(buffer=new_buffer, pin_memory=pin_memory))
+        return view_to(new_buffer, dtype, tensor_shape)
+
+
+_buffer = Buffers()
+
+
+def get_memory_buffer():
+    global _buffer
+    return _buffer

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_deepgemm.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_deepgemm.py
@@ -367,7 +367,7 @@ class DeepGemmFusedMoE(CutlassFusedMoE):
     """
 
     # To reuse pytorch memory segments allocated during graph capture.
-    buffer = get_memory_buffer()
+    buffers = get_memory_buffer()
 
     def __init__(
         self,
@@ -421,12 +421,12 @@ class DeepGemmFusedMoE(CutlassFusedMoE):
 
         # create workspace
         fp8_dim = max(hidden_size, intermediate_size)
-        workspace_0 = DeepGemmFusedMoE.buffer.get_buffer(
+        workspace_0 = DeepGemmFusedMoE.buffers.get_buffer(
             (num_experts * m_max * fp8_dim, ),
             dtype=torch.float8_e4m3fn,
             buffer_name='workspace_0',
             pin_memory=capture_graph)
-        workspace_1 = DeepGemmFusedMoE.buffer.get_buffer(
+        workspace_1 = DeepGemmFusedMoE.buffers.get_buffer(
             (num_experts * m_max * max(intermediate_size * 2, hidden_size), ),
             dtype=torch.bfloat16,
             buffer_name='workspace_1',
@@ -437,7 +437,7 @@ class DeepGemmFusedMoE(CutlassFusedMoE):
         scale_k = fp8_utils.ceil_div(fp8_dim, group_size)
         scale_k_padded = fp8_utils.align(scale_k, 4)
 
-        workspace_sf = DeepGemmFusedMoE.buffer.get_buffer(
+        workspace_sf = DeepGemmFusedMoE.buffers.get_buffer(
             (num_experts * (scale_k_padded // 4) * m_padded, ),
             dtype=torch.int32,
             buffer_name='workspace_sf',

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_deepgemm.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_deepgemm.py
@@ -1,4 +1,3 @@
-import math
 from typing import Dict, List, Optional, Union
 
 import torch
@@ -10,6 +9,7 @@ from tensorrt_llm import deep_gemm
 from tensorrt_llm._utils import nvtx_range
 
 from ...distributed import allgather
+from ...memory_buffer_utils import get_memory_buffer
 from ...model_config import ModelConfig
 from ...utils import AuxStreamType, EventType, Fp4QuantizedTensor
 from .fused_moe_cutlass import CutlassFusedMoE
@@ -367,8 +367,7 @@ class DeepGemmFusedMoE(CutlassFusedMoE):
     """
 
     # To reuse pytorch memory segments allocated during graph capture.
-    allocated_buffer_in_graph_pool: dict[str, list[torch.Tensor]] = {}
-    allocated_buffer_in_runtime: dict[str, torch.Tensor] = {}
+    buffer = get_memory_buffer()
 
     def __init__(
         self,
@@ -415,102 +414,37 @@ class DeepGemmFusedMoE(CutlassFusedMoE):
         )
 
     def get_workspace(self, m_max: int, group_size: int):
-
-        def select_buffer_with_more_elements(
-                graph_buffer: Optional[torch.Tensor],
-                runtime_buffer: Optional[torch.Tensor],
-                is_capturing: bool = False
-        ) -> tuple[Optional[torch.Tensor], bool]:
-            if is_capturing and graph_buffer is not None:
-                return graph_buffer, True
-
-            if is_capturing == False and runtime_buffer is not None:
-                return runtime_buffer, False
-
-            if graph_buffer is None:
-                return runtime_buffer, False
-
-            if runtime_buffer is None:
-                return graph_buffer, True
-
-        def get_empty(tensor_shape: list[int], dtype: torch.dtype,
-                      cache_name: str) -> torch.Tensor:
-            capture_graph = torch.cuda.is_current_stream_capturing()
-            if DeepGemmFusedMoE.allocated_buffer_in_graph_pool is not None:
-                numel_like = math.prod(tensor_shape)
-                runtime_buffer = None
-                if cache_name in DeepGemmFusedMoE.allocated_buffer_in_runtime:
-                    buffer = DeepGemmFusedMoE.allocated_buffer_in_runtime[
-                        cache_name]
-                    numel_buffer = buffer.numel()
-                    runtime_buffer = buffer if numel_buffer >= numel_like else None
-
-                graph_buffer = None
-                # Safely get the list of candidates. Defaults to an empty list if key is missing.
-                candidate_buffers = DeepGemmFusedMoE.allocated_buffer_in_graph_pool.get(
-                    cache_name, [])
-                for buffer in candidate_buffers:
-                    numel_buffer = buffer.numel()
-                    # buffer just needs to be large enough.
-                    if numel_buffer >= numel_like:
-                        graph_buffer = buffer
-                        break
-
-                if capture_graph and graph_buffer is not None:
-                    return graph_buffer[0:numel_like].view(tensor_shape)
-                else:
-                    buffer, use_graph = select_buffer_with_more_elements(
-                        graph_buffer,
-                        runtime_buffer,
-                        is_capturing=capture_graph)
-                    if buffer is not None:
-                        if not use_graph and capture_graph:
-                            # move the buffer into graph buffers since it's running in graph capturing mode.
-                            DeepGemmFusedMoE.allocated_buffer_in_runtime.pop(
-                                cache_name, None)
-                            DeepGemmFusedMoE.allocated_buffer_in_graph_pool.setdefault(
-                                cache_name, []).append(buffer)
-
-                            return buffer[0:numel_like].view(tensor_shape)
-
-            # Reach here, no buffer is found. Then, we will use a new buffer to replace the small one. Release the memory first.
-            if cache_name in DeepGemmFusedMoE.allocated_buffer_in_runtime:
-                del DeepGemmFusedMoE.allocated_buffer_in_runtime[cache_name]
-
-            # If we get here, no suitable buffer was found in the cache. Create a new one.
-            new_buffer = torch.zeros(tensor_shape, device='cuda', dtype=dtype)
-            if DeepGemmFusedMoE.allocated_buffer_in_graph_pool is not None:
-                if capture_graph:
-                    DeepGemmFusedMoE.allocated_buffer_in_graph_pool.setdefault(
-                        cache_name, []).append(new_buffer)
-                else:
-                    DeepGemmFusedMoE.allocated_buffer_in_runtime[
-                        cache_name] = new_buffer
-            return new_buffer
-
+        capture_graph = torch.cuda.is_current_stream_capturing()
         hidden_size = self.hidden_size
         intermediate_size = self.intermediate_size_per_partition
         num_experts = self.expert_size_per_partition
 
         # create workspace
         fp8_dim = max(hidden_size, intermediate_size)
-        workspace_0 = get_empty((num_experts * m_max * fp8_dim, ),
-                                dtype=torch.float8_e4m3fn,
-                                cache_name='workspace_0')
-        workspace_1 = get_empty(
+        workspace_0 = DeepGemmFusedMoE.buffer.get_buffer(
+            (num_experts * m_max * fp8_dim, ),
+            dtype=torch.float8_e4m3fn,
+            buffer_name='workspace_0',
+            create_if_miss=True,
+            pin_memory=capture_graph)
+        workspace_1 = DeepGemmFusedMoE.buffer.get_buffer(
             (num_experts * m_max * max(intermediate_size * 2, hidden_size), ),
             dtype=torch.bfloat16,
-            cache_name='workspace_1')
+            buffer_name='workspace_1',
+            create_if_miss=True,
+            pin_memory=capture_graph)
 
         # create workspace for scaling factors
         m_padded = fp8_utils.align(m_max, 4)
         scale_k = fp8_utils.ceil_div(fp8_dim, group_size)
         scale_k_padded = fp8_utils.align(scale_k, 4)
 
-        workspace_sf = get_empty(
+        workspace_sf = DeepGemmFusedMoE.buffer.get_buffer(
             (num_experts * (scale_k_padded // 4) * m_padded, ),
             dtype=torch.int32,
-            cache_name='workspace_sf')
+            buffer_name='workspace_sf',
+            create_if_miss=True,
+            pin_memory=capture_graph)
 
         workspace = {
             "workspace_0": workspace_0,

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_deepgemm.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_deepgemm.py
@@ -425,13 +425,11 @@ class DeepGemmFusedMoE(CutlassFusedMoE):
             (num_experts * m_max * fp8_dim, ),
             dtype=torch.float8_e4m3fn,
             buffer_name='workspace_0',
-            create_if_miss=True,
             pin_memory=capture_graph)
         workspace_1 = DeepGemmFusedMoE.buffer.get_buffer(
             (num_experts * m_max * max(intermediate_size * 2, hidden_size), ),
             dtype=torch.bfloat16,
             buffer_name='workspace_1',
-            create_if_miss=True,
             pin_memory=capture_graph)
 
         # create workspace for scaling factors
@@ -443,7 +441,6 @@ class DeepGemmFusedMoE(CutlassFusedMoE):
             (num_experts * (scale_k_padded // 4) * m_padded, ),
             dtype=torch.int32,
             buffer_name='workspace_sf',
-            create_if_miss=True,
             pin_memory=capture_graph)
 
         workspace = {

--- a/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
+++ b/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
@@ -7,7 +7,7 @@ import torch
 
 from ...inputs.multimodal import MultimodalParams
 from ..expert_statistic import ExpertStatistic
-from ..memory_buffer_utils import get_memory_buffer
+from ..memory_buffer_utils import get_memory_buffers
 from ..modules.multi_stream_utils import with_multi_stream
 from ..speculative.eagle3 import Eagle3ResourceManager
 from ..utils import make_weak_ref, piecewise_cuda_graph
@@ -54,7 +54,7 @@ class CUDAGraphRunner:
         self.shared_static_tensors: Dict[str, torch.Tensor] = {}
         if self.enabled:
             self._create_shared_static_tensors()
-        self.cuda_graph_meta_buffers = get_memory_buffer()
+        self.cuda_graph_meta_buffers = get_memory_buffers()
 
     def _create_shared_static_tensors(self):
         """Allocates static tensors sized for the largest possible batch."""

--- a/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
+++ b/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
@@ -7,6 +7,7 @@ import torch
 
 from ...inputs.multimodal import MultimodalParams
 from ..expert_statistic import ExpertStatistic
+from ..memory_buffer_utils import get_memory_buffer
 from ..modules.multi_stream_utils import with_multi_stream
 from ..speculative.eagle3 import Eagle3ResourceManager
 from ..utils import make_weak_ref, piecewise_cuda_graph
@@ -53,6 +54,7 @@ class CUDAGraphRunner:
         self.shared_static_tensors: Dict[str, torch.Tensor] = {}
         if self.enabled:
             self._create_shared_static_tensors()
+        self.cuda_graph_meta_buffers = get_memory_buffer()
 
     def _create_shared_static_tensors(self):
         """Allocates static tensors sized for the largest possible batch."""
@@ -177,7 +179,7 @@ class CUDAGraphRunner:
 
         num_sequences_in_batch = batch_size * self.max_beam_width
         attn_metadata = self.attn_metadata.create_cuda_graph_metadata(
-            num_sequences_in_batch, False, key[1])
+            num_sequences_in_batch, False, key[1], self.cuda_graph_meta_buffers)
         assert attn_metadata.is_cuda_graph
 
         if self.enable_spec_decode:


### PR DESCRIPTION
and no-graph flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Centralized GPU memory buffer reuse for fused MoE improves throughput and reduces allocation overhead, especially with CUDA graphs.
* **Reliability**
  * More robust workspace handling during CUDA graph capture minimizes sporadic failures and allocation errors.
* **Resource Usage**
  * Reduced GPU memory fragmentation via buffer reuse across runs, enabling smoother long-running sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
