### PR TITLE
[None][fix] Enable kv cache reuse for VLMs with special tokens

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
@@ -30,6 +30,37 @@ from tensorrt_llm.inputs.multimodal import MultimodalParams
 from tensorrt_llm.logger import logger
 
 
+def _map_to_mm_embed_bound(start_pos, end_pos, special_token_offsets):
+    """
+    Map positions in the token sequence (which includes special tokens) to positions
+    in the mm_embeds (which excludes special tokens).
+
+    Args:
+        start_pos: Start position in the token sequence
+        end_pos: End position in the token sequence
+        special_token_offsets: torch.Tensor of special token positions
+
+    Returns:
+        Tuple of (adjusted_start_pos, adjusted_end_pos) in mm_embeds coordinates
+    """
+    # Count special tokens before start_pos
+    special_tokens_before_start = sum(1 for offset in special_token_offsets
+                                      if offset < start_pos)
+
+    # Count special tokens within the range [start_pos, end_pos)
+    special_tokens_within_range = sum(1 for offset in special_token_offsets
+                                      if start_pos <= offset < end_pos)
+
+    # Calculate the original chunk size
+    chunk_size = end_pos - start_pos
+
+    # Adjust positions by removing special token counts
+    adjusted_start_pos = start_pos - special_tokens_before_start
+    adjusted_end_pos = adjusted_start_pos + chunk_size - special_tokens_within_range
+
+    return adjusted_start_pos, adjusted_end_pos
+
+
 def find_uncached_mm_embeds(
         mm_embeds: List[torch.Tensor],
         multimodal_params: List[MultimodalParams]) -> torch.Tensor:
@@ -80,13 +111,25 @@ def find_uncached_mm_embeds(
     # Partial caching, return the sliced mm_embeds
     current_pos = 0
     slices = []
+
     for param in multimodal_params:
         runtime = param.multimodal_runtime
-        slices.append((current_pos + runtime.num_cached_mm_tokens,
-                       current_pos + runtime.total_mm_tokens))
+        local_start_pos = runtime.num_cached_mm_tokens
+        local_end_pos = runtime.total_mm_tokens
+        if 'special_token_offsets' in param.multimodal_data:
+            local_start_pos, local_end_pos = _map_to_mm_embed_bound(
+                local_start_pos, local_end_pos,
+                param.multimodal_data['special_token_offsets'])
+
+        start_pos = current_pos + local_start_pos
+        end_pos = current_pos + local_end_pos
+        slices.append((start_pos, end_pos))
         if len(mm_embeds
                ) == 1:  # pre-concatenated mm_embeds, need global offset
             current_pos += runtime.total_mm_tokens
+            if 'special_token_offsets' in param.multimodal_data:
+                current_pos -= len(
+                    param.multimodal_data['special_token_offsets'])
 
     sliced_mm_embeds = []
     if len(mm_embeds) == 1:

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1329,8 +1329,10 @@ class PyTorchModelEngine(ModelEngine):
             py_multimodal_runtime = MultimodalRuntimeData(
                 mm_token_lengths=request.multimodal_lengths,
                 mm_token_positions=request.multimodal_positions,
-                num_cached_tokens=past_seen_token_num
-            ) if request.multimodal_hashes is not None else None
+                num_cached_tokens=past_seen_token_num,
+                special_token_offsets=request.py_multimodal_data.get(
+                    'special_token_offsets',
+                    [])) if request.multimodal_hashes is not None else None
 
             multimodal_params = MultimodalParams(
                 multimodal_data=request.py_multimodal_data,

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -99,6 +99,19 @@ class BaseMultimodalInputProcessor:
         )
         return None
 
+    def get_mm_special_token_ids(self) -> Optional[Tensor]:
+        """
+        Return multimodal special token IDs if available; otherwise None.
+
+        Special tokens refer to multimodal-related tokens (e.g. <image_end>, <image_break>) that are not part
+        of the ViT output but come from text embeddings. Some VLMs
+        (e.g., Mistral3, LLaMA4) mix special tokens with multimodal tokens,
+        so they need to be returned separately.
+        """
+        processor = self.get_processor()
+        return getattr(processor, "mm_special_token_ids",
+                       None) if processor else None
+
     @property
     def get_num_multimodal_tokens(self):
         """
@@ -459,17 +472,24 @@ def create_input_processor_with_hash(
                 inputs, sampling_params)
             vocab_size = input_processor.get_vocab_size()
             mm_ids = input_processor.get_mm_token_ids()
+            mm_special_token_ids = input_processor.get_mm_special_token_ids()
             if vocab_size is None and mm_ids is None:
                 raise ValueError(
                     "Cannot locate vocab_size or mm_token_ids for multimodal token preprocessing"
                 )
-            start_positions = find_mm_token_positions(
+            start_positions, start_special_token_positions = find_mm_token_positions(
                 input_ids=prompt_token_ids,  # token sequence
                 num_mm_tokens=
                 num_mm_tokens,  # list of lengths of each chunk of visual tokens
                 vocab_size=vocab_size,
                 mm_token_ids=mm_ids,
+                mm_special_token_ids=mm_special_token_ids,
             )
+            # Store special token offsets if available
+            if len(start_special_token_positions
+                   ) > 0 and mm_special_token_ids is not None:
+                extra_processed_inputs["multimodal_data"][
+                    "special_token_offsets"] = start_special_token_positions
             # flatten the hashes from dict to a single list
             mm_hashes = [h for hashes in mm_hashes.values() for h in hashes]
             validate_mm_inputs(prompt_token_ids, mm_hashes, start_positions,


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
