### PR TITLE
[None][doc] Fix the link in the doc

### DIFF
--- a/docs/source/features/disagg-serving.md
+++ b/docs/source/features/disagg-serving.md
@@ -169,7 +169,7 @@ curl http://localhost:8000/v1/completions \
 
 #### Launching disaggregated servers on SLURM clusters
 
-Please refer to [Disaggregated Inference Benchmark Scripts](../../../../examples/disaggregated/slurm).
+Please refer to [Disaggregated Inference Benchmark Scripts](../../../examples/disaggregated/slurm).
 
 ### Dynamo
 

--- a/docs/source/features/disagg-serving.md
+++ b/docs/source/features/disagg-serving.md
@@ -169,7 +169,7 @@ curl http://localhost:8000/v1/completions \
 
 #### Launching disaggregated servers on SLURM clusters
 
-Please refer to [Disaggregated Inference Benchmark Scripts](../../scripts/disaggregated).
+Please refer to [Disaggregated Inference Benchmark Scripts](../../../../examples/disaggregated/slurm).
 
 ### Dynamo
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the hyperlink under “Launching disaggregated servers on SLURM clusters” to point to the correct examples location.
  * Ensures readers are directed to the appropriate disaggregated SLURM example when following the docs.
  * No other content changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->