### PR TITLE
[https://nvbugs/5517404][fix] Use the correct cuda graph for dynamic spec dec

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1511,7 +1511,6 @@ class PyTorchModelEngine(ModelEngine):
                     prompt_lengths.append(1 + self.runtime_draft_len)
                 else:
                     prompt_lengths.append(request.py_prompt_len)
-
         for request in generation_requests:
             request_ids.append(request.py_request_id)
             beam_width = request.sampling_config.beam_width
@@ -1534,7 +1533,6 @@ class PyTorchModelEngine(ModelEngine):
                     if beam == first_beam:
                         previous_batch_indices.append(request.py_batch_idx)
                     past_seen_token_num = request.max_beam_num_tokens
-
                 position_ids.append(past_seen_token_num)
                 num_cached_tokens_per_seq.append(past_seen_token_num)
                 prompt_lengths.append(request.py_prompt_len)

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -45,7 +45,7 @@ from .py_executor import PyExecutor
 def _get_allow_chain_drafter() -> bool:
     """Get the chain drafter flag from environment variable."""
     # Use environment variable for cross-process compatibility
-    return os.getenv("TRTLLM_ALLOW_CHAIN_DRAFTER", "0") == "1"
+    return os.getenv("TRTLLM_ALLOW_CHAIN_DRAFTER", "1") != "0"
 
 
 class _ExecutorCreationStage(enum.Enum):

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -41,7 +41,8 @@ from .model_engine import PyTorchModelEngine
 from .py_executor import PyExecutor
 
 
-# Development function to control chain drafter feature
+# Development function to control chain drafter feature.
+# It's here so that unit tests can mock it and turn it off.
 def _get_allow_chain_drafter() -> bool:
     return True
 

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -41,11 +41,9 @@ from .model_engine import PyTorchModelEngine
 from .py_executor import PyExecutor
 
 
-# Development flag to control chain drafter feature
+# Development function to control chain drafter feature
 def _get_allow_chain_drafter() -> bool:
-    """Get the chain drafter flag from environment variable."""
-    # Use environment variable for cross-process compatibility
-    return os.getenv("TRTLLM_ALLOW_CHAIN_DRAFTER", "1") != "0"
+    return True
 
 
 class _ExecutorCreationStage(enum.Enum):

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -563,6 +563,9 @@ class TorchSampler(Sampler):
             if get_draft_token_length(req) > 0:
                 req.py_num_accepted_draft_tokens = num_accepted
                 req.py_rewind_len = req.py_draft_pages_allocated - num_accepted
+            else:
+                req.py_num_accepted_draft_tokens = 0
+                req.py_rewind_len = 0
             processed += num_accepted
             self.handle_logprobs(req, state, beam=self.BEAM, count=processed)
             req.py_decoding_iter += 1

--- a/tensorrt_llm/_torch/speculative/model_drafter.py
+++ b/tensorrt_llm/_torch/speculative/model_drafter.py
@@ -444,9 +444,9 @@ class ModelDrafter(Drafter):
                     continue
 
                 # Get the index of the draft/target tokens in the device tensor
-                draft_idx = req_idx if self.use_static_draft_loop else request.py_seq_slot
+                draft_idx = req_idx if self.use_static_draft_loop else request.py_batch_idx
                 target_idx = req_id_to_old_request[
-                    request.py_request_id].py_seq_slot
+                    request.py_request_id].py_batch_idx
                 target_inputs.new_tokens[draft_position + 1:draft_position +
                                          draft_length + 1, target_idx,
                                          0] = draft_tensors[0:draft_length,

--- a/tensorrt_llm/_torch/speculative/model_drafter.py
+++ b/tensorrt_llm/_torch/speculative/model_drafter.py
@@ -396,6 +396,7 @@ class ModelDrafter(Drafter):
         new_tokens_lens = None
         next_draft_tokens = None
         has_draft_tokens = False
+        batch_size = new_tokens.shape[1]
         # Iterate through generation requests and copy tokens based on accepted draft tokens
         for request in scheduled_batch.all_requests():
             idx = request.py_seq_slot
@@ -411,9 +412,8 @@ class ModelDrafter(Drafter):
 
         if has_draft_tokens:
             # We already updated the target state, so the new_tokens_lens should be all ones.
-            new_tokens_lens = torch.ones(scheduled_batch.batch_size,
-                                         device=device)
-            next_draft_tokens = torch.zeros(scheduled_batch.batch_size,
+            new_tokens_lens = torch.ones(batch_size, device=device)
+            next_draft_tokens = torch.zeros(batch_size,
                                             self.max_draft_tokens,
                                             device=device)
 
@@ -438,13 +438,13 @@ class ModelDrafter(Drafter):
         Update target inputs with new draft tokens from sample state.
         """
         if draft_tensors is not None:
-            for request in draft_batch.all_requests():
+            for req_idx, request in enumerate(draft_batch.all_requests()):
                 # Skip prefill requests
                 if target_inputs.next_draft_tokens is None:
                     continue
 
                 # Get the index of the draft/target tokens in the device tensor
-                draft_idx = request.py_seq_slot
+                draft_idx = req_idx if self.use_static_draft_loop else request.py_seq_slot
                 target_idx = req_id_to_old_request[
                     request.py_request_id].py_seq_slot
                 target_inputs.new_tokens[draft_position + 1:draft_position +

--- a/tests/unittest/_torch/helpers.py
+++ b/tests/unittest/_torch/helpers.py
@@ -188,6 +188,7 @@ def create_mock_engine(batch_size: int):
         max_beam_width=1,
         max_num_tokens=8192,
         is_spec_decode=False,
+        enable_spec_decode=False,
         spec_config=None,
         _cuda_graph_mem_pool=None,
         use_mrope=False,

--- a/tests/unittest/_torch/speculative/test_dynamic_spec_decode.py
+++ b/tests/unittest/_torch/speculative/test_dynamic_spec_decode.py
@@ -8,6 +8,8 @@ import torch
 from utils.llm_data import llm_models_root
 
 from tensorrt_llm import LLM, SamplingParams
+from tensorrt_llm._torch.pyexecutor.llm_request import (LlmRequestState,
+                                                        get_draft_token_length)
 from tensorrt_llm.llmapi import (CudaGraphConfig, EagleDecodingConfig,
                                  KvCacheConfig)
 
@@ -17,75 +19,91 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 @pytest.mark.parametrize("disable_overlap_scheduler", [True, False])
 @pytest.mark.high_cuda_memory
 def test_dynamic_spec_decode(disable_overlap_scheduler: bool):
-    total_mem_gb = torch.cuda.get_device_properties(0).total_memory / 1e9
-    if total_mem_gb < 35:
-        pytest.skip("Not enough memory to load target + draft model")
+    # Store original value and set environment variable
+    original_value = os.environ.get("TLLM_WORKER_USE_SINGLE_PROCESS")
+    # mock_should_use_spec_decode doesn't work with multiple processes,
+    # so we set the environment variable to 1 in this test.
+    os.environ["TLLM_WORKER_USE_SINGLE_PROCESS"] = "1"
 
-    models_path = llm_models_root()
-    eagle_model_dir = f"{models_path}/EAGLE3-LLaMA3.1-Instruct-8B"
-    target_model_dir = f"{models_path}/llama-3.1-model/Llama-3.1-8B-Instruct"
+    try:
+        total_mem_gb = torch.cuda.get_device_properties(0).total_memory / 1e9
+        if total_mem_gb < 35:
+            pytest.skip("Not enough memory to load target + draft model")
 
-    max_batch_size = 1
-    max_draft_len = 4
-    kv_cache_config = KvCacheConfig(enable_block_reuse=True, max_tokens=8192)
-    cuda_graph_config = CudaGraphConfig(batch_sizes=[1])
+        models_path = llm_models_root()
+        eagle_model_dir = f"{models_path}/EAGLE3-LLaMA3.1-Instruct-8B"
+        target_model_dir = f"{models_path}/llama-3.1-model/Llama-3.1-8B-Instruct"
 
-    llm_common_config = dict(
-        model=target_model_dir,
-        attn_backend="TRTLLM",
-        disable_overlap_scheduler=disable_overlap_scheduler,
-        cuda_graph_config=cuda_graph_config,
-        max_batch_size=max_batch_size,
-        kv_cache_config=kv_cache_config,
-        # This max_seq_len is larger than the one specified
-        # in the llama 3 8B eagle's config. We want to make sure
-        # that the draft model won't go above its max in warmup
-        # in this test.
-        max_seq_len=8192,
-    )
+        max_batch_size = 1
+        max_draft_len = 4
+        kv_cache_config = KvCacheConfig(enable_block_reuse=True,
+                                        max_tokens=8192)
+        cuda_graph_config = CudaGraphConfig(batch_sizes=[1])
 
-    spec_config = EagleDecodingConfig(
-        max_draft_len=max_draft_len,
-        speculative_model_dir=eagle_model_dir,
-        # Llama 3 does not support one model eagle.
-        eagle3_one_model=False,
-    )
+        llm_common_config = dict(
+            model=target_model_dir,
+            attn_backend="TRTLLM",
+            disable_overlap_scheduler=disable_overlap_scheduler,
+            cuda_graph_config=cuda_graph_config,
+            max_batch_size=max_batch_size,
+            kv_cache_config=kv_cache_config,
+            # This max_seq_len is larger than the one specified
+            # in the llama 3 8B eagle's config. We want to make sure
+            # that the draft model won't go above its max in warmup
+            # in this test.
+            max_seq_len=8192,
+        )
 
-    # Mock should_use_spec_decode to return True for first two calls, then False
-    def mock_should_use_spec_decode(requests, max_batch_size, max_num_tokens,
-                                    max_draft_len):
-        if not hasattr(mock_should_use_spec_decode, 'call_count'):
-            mock_should_use_spec_decode.call_count = 0
-        mock_should_use_spec_decode.call_count += 1
-        return mock_should_use_spec_decode.call_count <= 2
+        spec_config = EagleDecodingConfig(
+            max_draft_len=max_draft_len,
+            speculative_model_dir=eagle_model_dir,
+            # Llama 3 does not support one model eagle.
+            eagle3_one_model=False,
+        )
 
-    with patch(
-            'tensorrt_llm._torch.speculative.model_drafter.ModelDrafter.should_use_spec_decode',
-            side_effect=mock_should_use_spec_decode):
-        llm_spec = LLM(**llm_common_config, speculative_config=spec_config)
-        sampling_params = SamplingParams(max_tokens=128, temperature=0)
+        # Mock should_use_spec_decode to return True and False alternately.
+        def mock_should_use_spec_decode(requests, max_batch_size,
+                                        max_num_tokens, max_draft_len):
+            for req in requests:
+                if req.state != LlmRequestState.GENERATION_IN_PROGRESS:
+                    continue
+                if get_draft_token_length(req) > 0:
+                    return False
+            return True
 
-        # Output tests
-        prompts = [
-            "The capital of France is",
-            "The president of the United States is",
-        ]
-        sampling_params = SamplingParams(max_tokens=10, temperature=0)
+        with patch(
+                'tensorrt_llm._torch.speculative.model_drafter.ModelDrafter.should_use_spec_decode',
+                side_effect=mock_should_use_spec_decode):
+            llm_spec = LLM(**llm_common_config, speculative_config=spec_config)
+            sampling_params = SamplingParams(max_tokens=128, temperature=0)
 
-        results_spec = llm_spec.generate(prompts, sampling_params)
-        generated_text_spec = [
-            result.outputs[0].text for result in results_spec
-        ]
-        llm_spec.shutdown()
+            # Output tests
+            prompts = [
+                "The capital of France is",
+                "The president of the United States is",
+            ]
+            sampling_params = SamplingParams(max_tokens=10, temperature=0)
 
-    llm_ref = LLM(**llm_common_config)
-    results_ref = llm_ref.generate(prompts, sampling_params)
-    generated_text_ref = [result.outputs[0].text for result in results_ref]
-    llm_ref.shutdown()
+            results_spec = llm_spec.generate(prompts, sampling_params)
+            generated_text_spec = [
+                result.outputs[0].text for result in results_spec
+            ]
+            llm_spec.shutdown()
 
-    for text_spec, text_ref in zip(generated_text_spec, generated_text_ref):
-        # The spec decode algorithm currently guarantees identical results
-        assert text_spec == text_ref
+        llm_ref = LLM(**llm_common_config)
+        results_ref = llm_ref.generate(prompts, sampling_params)
+        generated_text_ref = [result.outputs[0].text for result in results_ref]
+        llm_ref.shutdown()
+
+        for text_spec, text_ref in zip(generated_text_spec, generated_text_ref):
+            # The spec decode algorithm currently guarantees identical results
+            assert text_spec == text_ref
+    finally:
+        # Restore original environment variable value
+        if original_value is None:
+            os.environ.pop("TLLM_WORKER_USE_SINGLE_PROCESS", None)
+        else:
+            os.environ["TLLM_WORKER_USE_SINGLE_PROCESS"] = original_value
 
 
 def test_should_use_spec_decode():

--- a/tests/unittest/_torch/speculative/test_eagle3.py
+++ b/tests/unittest/_torch/speculative/test_eagle3.py
@@ -4,6 +4,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -16,35 +17,50 @@ from tensorrt_llm.llmapi import (CudaGraphConfig, EagleDecodingConfig,
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 
+@pytest.fixture(scope="function")
+def enforce_single_worker(monkeypatch):
+    monkeypatch.setenv("TLLM_WORKER_USE_SINGLE_PROCESS", "1")
+    yield
+
+
 @pytest.mark.parametrize(
-    "use_cuda_graph,attn_backend,disable_overlap_scheduler,enable_block_reuse,use_one_model,enable_chunked_prefill,use_chain_drafter",
+    "use_cuda_graph,attn_backend,disable_overlap_scheduler,enable_block_reuse,use_one_model,enable_chunked_prefill,use_chain_drafter,multi_batch",
     [
-        [True, "TRTLLM", True, False, False, False, True],
-        [True, "TRTLLM", True, False, False, False, False],
-        [False, "TRTLLM", True, False, False, False, True],
-        [False, "TRTLLM", True, False, False, False, False],
-        [True, "FLASHINFER", True, False, False, False, True],
-        [False, "FLASHINFER", True, False, False, False, True],
-        [False, "TRTLLM", False, True, True, False, True],
-        [True, "TRTLLM", False, True, True, False, True],
-        [True, "TRTLLM", True, False, True, True, True],
-        [True, "TRTLLM", True, False, True, False, True],
+        [True, "TRTLLM", True, False, False, False, True, False],
+        [True, "TRTLLM", True, False, False, False, False, False],
+        [False, "TRTLLM", True, False, False, False, True, False],
+        [False, "TRTLLM", True, False, False, False, False, False],
+        [True, "FLASHINFER", True, False, False, False, True, False],
+        [False, "FLASHINFER", True, False, False, False, True, False],
+        [False, "TRTLLM", False, True, True, False, True, False],
+        [True, "TRTLLM", False, True, True, False, True, False],
+        [True, "TRTLLM", True, False, True, True, True, False],
+        [True, "TRTLLM", True, False, True, False, True, False],
         # TODO: nvbugs/5461761
-        # [True, "TRTLLM", True, False, False, True, True],
-        [True, "TRTLLM", False, False, False, False, True],
-        [False, "TRTLLM", False, False, False, False, True],
-        [True, "TRTLLM", False, False, False, False, False],
-        [False, "TRTLLM", False, False, False, False, False],
-        [True, "TRTLLM", False, False, False, True, True],
-        [True, "TRTLLM", False, False, False, True, False],
-        [True, "FLASHINFER", False, False, False, False, True],
-        [False, "FLASHINFER", False, False, False, False, True],
+        # [True, "TRTLLM", True, False, False, True, True, False],
+        [True, "TRTLLM", False, False, False, False, True, False],
+        [False, "TRTLLM", False, False, False, False, True, False],
+        [True, "TRTLLM", False, False, False, False, False, True],
+        [False, "TRTLLM", False, False, False, False, False, True],
+        [True, "TRTLLM", False, False, False, False, True, True],
+        [False, "TRTLLM", False, False, False, False, True, True],
+        [True, "TRTLLM", False, False, False, False, False, False],
+        [False, "TRTLLM", False, False, False, False, False, False],
+        [True, "TRTLLM", False, False, False, True, True, False],
+        [True, "TRTLLM", False, False, False, True, False, False],
+        [True, "FLASHINFER", False, False, False, False, True, False],
+        [False, "FLASHINFER", False, False, False, False, True, False],
     ])
 @pytest.mark.high_cuda_memory
 def test_llama_eagle3(use_cuda_graph: bool, attn_backend: str,
                       disable_overlap_scheduler: bool, enable_block_reuse: bool,
                       use_one_model: bool, enable_chunked_prefill: bool,
-                      use_chain_drafter: bool):
+                      use_chain_drafter: bool, multi_batch: bool, request):
+    # Use enforce_single_worker fixture only when use_chain_drafter is False.
+    # Otherwise, we can't modify the returned value of _get_allow_chain_drafter in multiprocessing.
+    if not use_chain_drafter:
+        request.getfixturevalue('enforce_single_worker')
+
     # Eagle3 one model works with overlap scheduler and block reuse.
     total_mem_gb = torch.cuda.get_device_properties(0).total_memory / 1e9
     if total_mem_gb < 35:
@@ -54,46 +70,52 @@ def test_llama_eagle3(use_cuda_graph: bool, attn_backend: str,
     eagle_model_dir = f"{models_path}/EAGLE3-LLaMA3.1-Instruct-8B"
     target_model_dir = f"{models_path}/llama-3.1-model/Llama-3.1-8B-Instruct"
 
-    # bs > 1 gives non-deterministic when doing IFB. There are slight chances
-    # that ref and spec does not match 100%
-    max_batch_size = 1
-    max_draft_len = 4
-    kv_cache_config = KvCacheConfig(enable_block_reuse=enable_block_reuse,
-                                    max_tokens=8192)
-    cuda_graph_config = CudaGraphConfig(
-        batch_sizes=[1]) if use_cuda_graph else None
+    # Mock _get_allow_chain_drafter to return False when use_chain_drafter is False
+    if not use_chain_drafter:
+        patch_context = patch(
+            'tensorrt_llm._torch.pyexecutor.py_executor_creator._get_allow_chain_drafter',
+            return_value=False)
+    else:
+        patch_context = patch(
+            'tensorrt_llm._torch.pyexecutor.py_executor_creator._get_allow_chain_drafter',
+            return_value=True)
 
-    llm_common_config = dict(
-        model=target_model_dir,
-        attn_backend=attn_backend,
-        disable_overlap_scheduler=disable_overlap_scheduler,
-        cuda_graph_config=cuda_graph_config,
-        max_batch_size=max_batch_size,
-        kv_cache_config=kv_cache_config,
-        # This max_seq_len is larger than the one specified
-        # in the llama 3 8B eagle's config. We want to make sure
-        # that the draft model won't go above its max in warmup
-        # in this test.
-        max_seq_len=8192,
-        enable_chunked_prefill=enable_chunked_prefill,
-    )
-    if enable_chunked_prefill:
-        # Use a small max_num_tokens so that the chunked prefill path gets exercised.
-        llm_common_config['max_num_tokens'] = 64
+    with patch_context:
+        # bs > 1 gives non-deterministic when doing IFB. There are slight chances
+        # that ref and spec does not match 100%
+        max_batch_size = 4 if multi_batch else 1
+        max_draft_len = 4
+        kv_cache_config = KvCacheConfig(enable_block_reuse=enable_block_reuse,
+                                        max_tokens=8192)
+        cuda_graph_config = CudaGraphConfig(
+            batch_sizes=[1]) if use_cuda_graph else None
 
-    spec_config = EagleDecodingConfig(
-        max_draft_len=max_draft_len,
-        speculative_model_dir=eagle_model_dir,
-        # Llama 3 does not support one model eagle.
-        eagle3_one_model=use_one_model,
-    )
+        llm_common_config = dict(
+            model=target_model_dir,
+            attn_backend=attn_backend,
+            disable_overlap_scheduler=disable_overlap_scheduler,
+            cuda_graph_config=cuda_graph_config,
+            max_batch_size=max_batch_size,
+            kv_cache_config=kv_cache_config,
+            # This max_seq_len is larger than the one specified
+            # in the llama 3 8B eagle's config. We want to make sure
+            # that the draft model won't go above its max in warmup
+            # in this test.
+            max_seq_len=8192,
+            enable_chunked_prefill=enable_chunked_prefill,
+        )
+        if enable_chunked_prefill:
+            # Use a small max_num_tokens so that the chunked prefill path gets exercised.
+            llm_common_config['max_num_tokens'] = 64
 
-    # Set the development flag to control use_chain_drafter behavior
-    original_env_value = os.environ.get("TRTLLM_ALLOW_CHAIN_DRAFTER", "1")
-    try:
-        os.environ[
-            "TRTLLM_ALLOW_CHAIN_DRAFTER"] = "1" if use_chain_drafter else "0"
-        # Create the LLM instance with the mocked flag controlling use_chain_drafter
+        spec_config = EagleDecodingConfig(
+            max_draft_len=max_draft_len,
+            speculative_model_dir=eagle_model_dir,
+            # Llama 3 does not support one model eagle.
+            eagle3_one_model=use_one_model,
+        )
+
+        # Create the LLM instance
         llm_spec = LLM(**llm_common_config, speculative_config=spec_config)
 
         # Acceptance rate tests
@@ -142,9 +164,6 @@ def test_llama_eagle3(use_cuda_graph: bool, attn_backend: str,
         for text_spec, text_ref in zip(generated_text_spec, generated_text_ref):
             # The spec decode algorithm currently guarantees identical results
             assert text_spec == text_ref
-    finally:
-        # Restore the original environment variable value
-        os.environ["TRTLLM_ALLOW_CHAIN_DRAFTER"] = original_env_value
 
 
 def test_deepseek_eagle3():

--- a/tests/unittest/_torch/speculative/test_eagle3.py
+++ b/tests/unittest/_torch/speculative/test_eagle3.py
@@ -89,7 +89,7 @@ def test_llama_eagle3(use_cuda_graph: bool, attn_backend: str,
     )
 
     # Set the development flag to control use_chain_drafter behavior
-    original_env_value = os.environ.get("TRTLLM_ALLOW_CHAIN_DRAFTER", "0")
+    original_env_value = os.environ.get("TRTLLM_ALLOW_CHAIN_DRAFTER", "1")
     try:
         os.environ[
             "TRTLLM_ALLOW_CHAIN_DRAFTER"] = "1" if use_chain_drafter else "0"


### PR DESCRIPTION
…spec dec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Correctly handles requests with zero draft tokens to prevent undefined values.
  - Aligns token sizing and padding with the active draft length, improving speculative decoding stability.

- Refactor
  - Aligns speculative decoding control with the latest engine API for better compatibility.
  - Uses dynamic draft length calculation to reduce state mismatches.

- Tests
  - Stabilizes dynamic speculative decoding tests by running in a single-process mode with deterministic mocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

The spec dec could be turned on/off dynamically, so we need to check engine's `enable_spec_decode` for the value.
With this value, we can figure out the cuda graph that should be used.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
