### PR TITLE
[https://nvbugs/5503529][fix] Change test_llmapi_example_multilora to get adapters path from cmd line to avoid downloading from HF

### DIFF
--- a/examples/llm-api/llm_multilora.py
+++ b/examples/llm-api/llm_multilora.py
@@ -1,6 +1,8 @@
 ### :section Customization
 ### :title Generate text with multiple LoRA adapters
 ### :order 5
+from typing import Optional
+
 import click
 from huggingface_hub import snapshot_download
 
@@ -22,8 +24,8 @@ from tensorrt_llm.lora_helper import LoraConfig
               type=str,
               default=None,
               help="Path to the tarot LoRA directory")
-def main(chatbot_lora_dir: str | None, mental_health_lora_dir: str | None,
-         tarot_lora_dir: str | None):
+def main(chatbot_lora_dir: Optional[str], mental_health_lora_dir: Optional[str],
+         tarot_lora_dir: Optional[str]):
 
     # Download the LoRA adapters from huggingface hub.
     if chatbot_lora_dir is None:

--- a/examples/llm-api/llm_multilora.py
+++ b/examples/llm-api/llm_multilora.py
@@ -1,9 +1,10 @@
 ### :section Customization
 ### :title Generate text with multiple LoRA adapters
 ### :order 5
+
+import argparse
 from typing import Optional
 
-import click
 from huggingface_hub import snapshot_download
 
 from tensorrt_llm import LLM
@@ -11,23 +12,10 @@ from tensorrt_llm.executor import LoRARequest
 from tensorrt_llm.lora_helper import LoraConfig
 
 
-@click.command()
-@click.option("--chatbot_lora_dir",
-              type=str,
-              default=None,
-              help="Path to the chatbot LoRA directory")
-@click.option("--mental_health_lora_dir",
-              type=str,
-              default=None,
-              help="Path to the mental health LoRA directory")
-@click.option("--tarot_lora_dir",
-              type=str,
-              default=None,
-              help="Path to the tarot LoRA directory")
 def main(chatbot_lora_dir: Optional[str], mental_health_lora_dir: Optional[str],
          tarot_lora_dir: Optional[str]):
 
-    # Download the LoRA adapters from huggingface hub.
+    # Download the LoRA adapters from huggingface hub, if not provided via command line args.
     if chatbot_lora_dir is None:
         chatbot_lora_dir = snapshot_download(
             repo_id="snshrivas10/sft-tiny-chatbot")
@@ -82,4 +70,20 @@ def main(chatbot_lora_dir: Optional[str], mental_health_lora_dir: Optional[str],
 
 
 if __name__ == '__main__':
-    main()
+    parser = argparse.ArgumentParser(
+        description="Generate text with multiple LoRA adapters")
+    parser.add_argument('--chatbot_lora_dir',
+                        type=str,
+                        default=None,
+                        help='Path to the chatbot LoRA directory')
+    parser.add_argument('--mental_health_lora_dir',
+                        type=str,
+                        default=None,
+                        help='Path to the mental health LoRA directory')
+    parser.add_argument('--tarot_lora_dir',
+                        type=str,
+                        default=None,
+                        help='Path to the tarot LoRA directory')
+    args = parser.parse_args()
+    main(args.chatbot_lora_dir, args.mental_health_lora_dir,
+         args.tarot_lora_dir)

--- a/examples/llm-api/llm_multilora.py
+++ b/examples/llm-api/llm_multilora.py
@@ -1,6 +1,7 @@
 ### :section Customization
 ### :title Generate text with multiple LoRA adapters
 ### :order 5
+import click
 from huggingface_hub import snapshot_download
 
 from tensorrt_llm import LLM
@@ -8,17 +9,37 @@ from tensorrt_llm.executor import LoRARequest
 from tensorrt_llm.lora_helper import LoraConfig
 
 
-def main():
+@click.command()
+@click.option("--chatbot_lora_dir",
+              type=str,
+              default=None,
+              help="Path to the chatbot LoRA directory")
+@click.option("--mental_health_lora_dir",
+              type=str,
+              default=None,
+              help="Path to the mental health LoRA directory")
+@click.option("--tarot_lora_dir",
+              type=str,
+              default=None,
+              help="Path to the tarot LoRA directory")
+def main(chatbot_lora_dir: str | None, mental_health_lora_dir: str | None,
+         tarot_lora_dir: str | None):
 
     # Download the LoRA adapters from huggingface hub.
-    lora_dir1 = snapshot_download(repo_id="snshrivas10/sft-tiny-chatbot")
-    lora_dir2 = snapshot_download(
-        repo_id="givyboy/TinyLlama-1.1B-Chat-v1.0-mental-health-conversational")
-    lora_dir3 = snapshot_download(repo_id="barissglc/tinyllama-tarot-v1")
+    if chatbot_lora_dir is None:
+        chatbot_lora_dir = snapshot_download(
+            repo_id="snshrivas10/sft-tiny-chatbot")
+    if mental_health_lora_dir is None:
+        mental_health_lora_dir = snapshot_download(
+            repo_id=
+            "givyboy/TinyLlama-1.1B-Chat-v1.0-mental-health-conversational")
+    if tarot_lora_dir is None:
+        tarot_lora_dir = snapshot_download(
+            repo_id="barissglc/tinyllama-tarot-v1")
 
     # Currently, we need to pass at least one lora_dir to LLM constructor via build_config.lora_config.
     # This is necessary because it requires some configuration in the lora_dir to build the engine with LoRA support.
-    lora_config = LoraConfig(lora_dir=[lora_dir1],
+    lora_config = LoraConfig(lora_dir=[chatbot_lora_dir],
                              max_lora_rank=64,
                              max_loras=3,
                              max_cpu_loras=3)
@@ -39,10 +60,11 @@ def main():
     for output in llm.generate(prompts,
                                lora_request=[
                                    None,
-                                   LoRARequest("chatbot", 1, lora_dir1), None,
-                                   LoRARequest("mental-health", 2, lora_dir2),
+                                   LoRARequest("chatbot", 1, chatbot_lora_dir),
                                    None,
-                                   LoRARequest("tarot", 3, lora_dir3)
+                                   LoRARequest("mental-health", 2,
+                                               mental_health_lora_dir), None,
+                                   LoRARequest("tarot", 3, tarot_lora_dir)
                                ]):
         prompt = output.prompt
         generated_text = output.outputs[0].text

--- a/tests/integration/defs/llmapi/test_llm_examples.py
+++ b/tests/integration/defs/llmapi/test_llm_examples.py
@@ -110,7 +110,16 @@ def test_llmapi_example_inference_async_streaming(llm_root, engine_dir,
 
 
 def test_llmapi_example_multilora(llm_root, engine_dir, llm_venv):
-    _run_llmapi_example(llm_root, engine_dir, llm_venv, "llm_multilora.py")
+    cmd_line_args = [
+        "--chatbot_lora_dir",
+        f"{llm_models_root()}/llama-models-v2/sft-tiny-chatbot",
+        "--mental_health_lora_dir",
+        f"{llm_models_root()}/llama-models-v2/TinyLlama-1.1B-Chat-v1.0-mental-health-conversational",
+        "--tarot_lora_dir",
+        f"{llm_models_root()}/llama-models-v2/tinyllama-tarot-v1"
+    ]
+    _run_llmapi_example(llm_root, engine_dir, llm_venv, "llm_multilora.py",
+                        *cmd_line_args)
 
 
 def test_llmapi_example_guided_decoding(llm_root, engine_dir, llm_venv):


### PR DESCRIPTION
## Description

The test downloaded LoRA adapters from HF, which sometimes failed with `TimeoutError: _ssl.c:983: The handshake operation timed out`.
This PR changes the test to receive the LoRA adapter dir path as command line arguments, to avoid this issue.

## Test Coverage

- `tests/integration/defs/llmapi/test_llm_examples.py::test_llmapi_example_multilora`

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>