### PR TITLE
[None][doc] Fix the link in the doc

### DIFF
--- a/docs/source/features/disagg-serving.md
+++ b/docs/source/features/disagg-serving.md
@@ -169,7 +169,7 @@ curl http://localhost:8000/v1/completions \
 
 #### Launching disaggregated servers on SLURM clusters
 
-Please refer to [Disaggregated Inference Benchmark Scripts](../../scripts/disaggregated).
+Please refer to [Disaggregated Inference Benchmark Scripts](../../../examples/disaggregated/slurm).
 
 ### Dynamo
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Corrected the link in “Launching disaggregated servers on SLURM clusters” to the proper examples location for SLURM-based disaggregated serving. This fixes an outdated path and makes setup steps easier to follow. Users can now access the working example without broken navigation. The anchor text remains the same.
  - No behavior, code, or API changes; this update strictly improves documentation accuracy and discoverability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->