### PR TITLE
[TRTLLM-8637][feat] Optimize the routing kernel for DeepseekV3 (MoE CUTLASS backend); Add support for 384 experts (MoE TRTLLM backend)

### DIFF
--- a/cpp/tensorrt_llm/kernels/noAuxTcKernels.cu
+++ b/cpp/tensorrt_llm/kernels/noAuxTcKernels.cu
@@ -15,706 +15,322 @@
  * limitations under the License.
  */
 
+#include "moeTopKFuncs.cuh"
 #include "tensorrt_llm/common/cudaTypeUtils.cuh"
 #include "tensorrt_llm/common/envUtils.h"
 #include "tensorrt_llm/kernels/noAuxTcKernels.h"
 #include <cooperative_groups.h>
 #include <cooperative_groups/reduce.h>
+
 namespace cg = cooperative_groups;
 using namespace tensorrt_llm::common;
 
 namespace tensorrt_llm::kernels
 {
-constexpr unsigned FULL_WARP_MASK = 0xffffffff;
-constexpr int32_t WARP_SIZE = 32;
-constexpr int32_t BLOCK_SIZE = 512;
-constexpr int32_t NUM_WARPS_PER_BLOCK = BLOCK_SIZE / WARP_SIZE;
+static constexpr int WARP_SIZE = 32;
+static constexpr int NumKimiK2Experts = 384;
+static constexpr int NumDeepseekExperts = 256;
+static constexpr int MaxNumExpertsUnit = 128;
+static constexpr int NumTopGroupScores = 2;
+static constexpr int MaxNumTopExperts = 8;
+static constexpr int MaxNumTopGroups = 4;
 
-namespace warp_topk
+static __device__ inline float sigmoid_accurate(float x)
 {
-
-template <int size, typename T>
-__host__ __device__ constexpr T round_up_to_multiple_of(T len)
-{
-    if (len == 0)
-    {
-        return 0;
-    }
-    return ((len - 1) / size + 1) * size;
+    return 0.5f * tanhf(0.5f * x) + 0.5f;
 }
 
-template <typename T>
-constexpr __host__ __device__ bool isPowerOf2(T v)
+template <typename InputT, typename BiasT, typename OutputT, typename IdxT, int MaxNumExperts, bool UseGroups>
+__global__ void deepseek_v3_topk_kernel(InputT* scores, OutputT* topkValues, IdxT* topkIndices, BiasT* routingBias,
+    int64_t const numTokens, int64_t const numGroup, int64_t const topkGroup, int64_t const topk,
+    int64_t const numExperts, int64_t const numExpertsPerGroup, double const routedScalingFactor)
 {
-    return (v && !(v & (v - 1)));
-}
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    asm volatile("griddepcontrol.wait;");
+#endif
 
-template <bool greater, typename T>
-__forceinline__ __device__ bool is_better_than(T val, T baseline)
-{
-    return (val > baseline && greater) || (val < baseline && !greater);
-}
+    // declare shared memory structure
+    // number of experts is bounded by number of threads
+    __shared__ float __attribute((aligned(128))) smemScoreSigmoid[MaxNumExperts];
+    __shared__ float __attribute((aligned(128))) smemScoreBias[MaxNumExperts];
+    // number of expert groups is bounded by number of warps
+    int constexpr NumWarps = MaxNumExperts / WARP_SIZE;
+    __shared__ float __attribute((aligned(128))) smemGroupScores[NumWarps];
 
-template <bool greater, typename T, typename idxT>
-__forceinline__ __device__ bool is_better_than(T val, T baseline, idxT index, idxT baseline_index)
-{
-    bool res = (val > baseline && greater) || (val < baseline && !greater);
-    if (val == baseline)
+    // needed for warp reduce
+    auto block = cg::this_thread_block();
+    auto warp = cg::tiled_partition<WARP_SIZE>(block);
+
+    // for the final reduction of weight norm, only some lanes need to participate
+    int32_t laneIdx = threadIdx.x % WARP_SIZE;
+    int32_t warpIdx = __shfl_sync(0xffffffff, threadIdx.x / WARP_SIZE, 0);
+
+    if constexpr (UseGroups)
     {
-        res = (index < baseline_index && greater) || (index < baseline_index && !greater);
-    }
-    return res;
-}
-
-template <typename T, typename idxT>
-int calc_smem_size_for_block_wide(int num_of_warp, int64_t k)
-{
-    int64_t cache_topk = (sizeof(T) + sizeof(idxT)) * num_of_warp * k;
-    int64_t n = std::max<int>(num_of_warp / 2 * k, num_of_warp * WARP_SIZE);
-    return max(cache_topk, round_up_to_multiple_of<256>(n * sizeof(T)) + n * sizeof(idxT));
-}
-
-template <int size, bool ascending, bool reverse, typename T, typename idxT, bool is_stable>
-struct BitonicMerge
-{
-    // input should be a bitonic sequence, and sort it to be a monotonic sequence
-    __device__ static void merge(T* __restrict__ val_arr, idxT* __restrict__ idx_arr)
-    {
-        static_assert(isPowerOf2(size));
-        static_assert(size >= 2 * WARP_SIZE);
-        constexpr int arr_len = size / WARP_SIZE;
-
-        constexpr int stride = arr_len / 2;
-        for (int i = 0; i < stride; ++i)
-        {
-            int const other_i = i + stride;
-            T& val = val_arr[i];
-            T& other_val = val_arr[other_i];
-            bool is_better;
-            if constexpr (is_stable)
-            {
-                is_better = is_better_than<ascending>(val, other_val, idx_arr[i], idx_arr[other_i]);
-            }
-            else
-            {
-                is_better = is_better_than<ascending>(val, other_val);
-            }
-
-            if (is_better)
-            {
-                T tmp = val;
-                val = other_val;
-                other_val = tmp;
-
-                idxT tmp2 = idx_arr[i];
-                idx_arr[i] = idx_arr[other_i];
-                idx_arr[other_i] = tmp2;
-            }
-        }
-
-        BitonicMerge<size / 2, ascending, reverse, T, idxT, is_stable>::merge(val_arr, idx_arr);
-        BitonicMerge<size / 2, ascending, reverse, T, idxT, is_stable>::merge(
-            val_arr + arr_len / 2, idx_arr + arr_len / 2);
-    }
-};
-
-template <int size, bool ascending, typename T, typename idxT, bool is_stable>
-struct BitonicSort
-{
-    __device__ static void sort(T* __restrict__ val_arr, idxT* __restrict__ idx_arr)
-    {
-        static_assert(isPowerOf2(size));
-        static_assert(size >= 2 * WARP_SIZE);
-        constexpr int arr_len = size / WARP_SIZE;
-
-        BitonicSort<size / 2, true, T, idxT, is_stable>::sort(val_arr, idx_arr);
-        BitonicSort<size / 2, false, T, idxT, is_stable>::sort(val_arr + arr_len / 2, idx_arr + arr_len / 2);
-        BitonicMerge<size, ascending, ascending, T, idxT, is_stable>::merge(val_arr, idx_arr);
-    }
-};
-
-template <bool ascending, typename T, typename idxT, bool is_stable>
-struct BitonicSort<32, ascending, T, idxT, is_stable>
-{
-    __device__ static void sort(T* __restrict__ val_arr, idxT* __restrict__ idx_arr)
-    {
-        int const lane = threadIdx.x % WARP_SIZE;
-
-        // ascending doesn't matter before merging since all we need is a bitonic sequence
-        for (int stage = 0; stage < 4; ++stage)
-        {
-            for (int stride = (1 << stage); stride > 0; stride /= 2)
-            {
-                bool reverse = (lane >> stage) & 2;
-                bool is_second = lane & stride;
-
-                T other = __shfl_xor_sync(FULL_WARP_MASK, *val_arr, stride);
-                idxT other_idx = __shfl_xor_sync(FULL_WARP_MASK, *idx_arr, stride);
-
-                bool is_better;
-                if constexpr (is_stable)
-                {
-                    if constexpr (ascending)
-                    {
-                        is_better = ((*val_arr > other) || ((*val_arr == other) && (*idx_arr < other_idx)))
-                            != (reverse != is_second);
-                    }
-                    else
-                    {
-                        is_better = ((*val_arr > other) || ((*val_arr == other) && (*idx_arr > other_idx)))
-                            != (reverse != is_second);
-                    }
-                }
-                else
-                {
-                    // is_better = (*val_arr != other) && is_better_than(*val_arr, other, (reverse == is_second));
-                    is_better = (*val_arr != other && (*val_arr > other) != (reverse != is_second));
-                }
-                if (is_better)
-                {
-                    *val_arr = other;
-                    *idx_arr = other_idx;
-                }
-            }
-        }
-
-        BitonicMerge<32, ascending, ascending, T, idxT, is_stable>::merge(val_arr, idx_arr);
-    }
-};
-
-template <bool ascending, bool reverse, typename T, typename idxT, bool is_stable>
-struct BitonicMerge<32, ascending, reverse, T, idxT, is_stable>
-{
-    __device__ static void merge(T* __restrict__ val_arr, idxT* __restrict__ idx_arr)
-    {
-        int const lane = threadIdx.x % WARP_SIZE;
-        for (int stride = WARP_SIZE / 2; stride > 0; stride /= 2)
-        {
-            bool is_second = lane & stride;
-            T& val = *val_arr;
-            T other = __shfl_xor_sync(FULL_WARP_MASK, val, stride);
-            idxT& idx = *idx_arr;
-            idxT other_idx = __shfl_xor_sync(FULL_WARP_MASK, idx, stride);
-
-            bool is_better;
-            if constexpr (is_stable)
-            {
-                if constexpr (ascending)
-                {
-                    is_better = ((*val_arr > other) || ((*val_arr == other) && (*idx_arr < other_idx)))
-                        == (reverse != is_second); // for min
-                }
-                else
-                {
-                    is_better = ((*val_arr > other) || ((*val_arr == other) && (*idx_arr > other_idx)))
-                        == (reverse != is_second); // for max
-                }
-            }
-            else
-            {
-                // is_better = (val != other) && (is_better_than(val, other, (reverse != is_second)));
-                is_better = (val != other && ((val > other) == (ascending != is_second)));
-            }
-
-            if (is_better)
-            {
-                val = other;
-                idx = other_idx;
-            }
-        }
-    }
-};
-
-template <int capacity, bool greater, typename T, typename idxT, bool is_stable>
-class WarpSort
-{
-public:
-    __device__ WarpSort(idxT k, T dummy)
-        : lane_(threadIdx.x % WARP_SIZE)
-        , k_(k)
-        , dummy_(dummy)
-    {
-        static_assert(capacity >= WARP_SIZE && isPowerOf2(capacity));
-
-        for (int i = 0; i < max_arr_len_; ++i)
-        {
-            val_arr_[i] = dummy_;
-            idx_arr_[i] = 0;
-        }
-    }
-
-    // load and merge k sorted values
-    __device__ void load_sorted(T const* __restrict__ in, idxT const* __restrict__ in_idx, idxT start)
-    {
-        idxT idx = start + WARP_SIZE - 1 - lane_;
-        for (int i = max_arr_len_ - 1; i >= 0; --i, idx += WARP_SIZE)
-        {
-            if (idx < start + k_)
-            {
-                T t = in[idx];
-                bool is_better;
-                if constexpr (is_stable)
-                {
-                    is_better = is_better_than<greater>(t, val_arr_[i], in_idx[idx], idx_arr_[i]);
-                }
-                else
-                {
-                    is_better = is_better_than<greater>(t, val_arr_[i]);
-                }
-                if (is_better)
-                {
-                    val_arr_[i] = t;
-                    idx_arr_[i] = in_idx[idx];
-                }
-            }
-        }
-
-        BitonicMerge<capacity, greater, !greater, T, idxT, is_stable>::merge(val_arr_, idx_arr_);
-    }
-
-    __device__ void dump(T* __restrict__ out, idxT* __restrict__ out_idx) const
-    {
-        for (int i = 0; i < max_arr_len_; ++i)
-        {
-            idxT out_i = i * WARP_SIZE + lane_;
-            if (out_i < k_)
-            {
-                out[out_i] = val_arr_[i];
-                out_idx[out_i] = idx_arr_[i];
-            }
-        }
-    }
-
-    __device__ void dumpIdx(idxT* __restrict__ out_idx) const
-    {
-        for (int i = 0; i < max_arr_len_; ++i)
-        {
-            idxT out_i = i * WARP_SIZE + lane_;
-            if (out_i < k_)
-            {
-                out_idx[out_i] = idx_arr_[i];
-            }
-        }
-    }
-
-protected:
-    static constexpr int max_arr_len_ = capacity / WARP_SIZE;
-
-    T val_arr_[max_arr_len_];
-    idxT idx_arr_[max_arr_len_];
-
-    int const lane_;
-    idxT const k_;
-    T const dummy_;
-
-}; // end class WarpSort
-
-template <int capacity, bool greater, typename T, typename idxT, bool is_stable>
-class WarpSelect : public WarpSort<capacity, greater, T, idxT, is_stable>
-{
-public:
-    __device__ WarpSelect(idxT k, T dummy)
-        : WarpSort<capacity, greater, T, idxT, is_stable>(k, dummy)
-        , k_th_(dummy)
-        , k_th_lane_((k - 1) % WARP_SIZE)
-    {
-
-        extern __shared__ char smem_buf[]; // extern __shared__ T smem_buf[];
-
-        int const num_of_warp = blockDim.x / WARP_SIZE;
-        int const warp_id = threadIdx.x / WARP_SIZE;
-        val_smem_ = reinterpret_cast<T*>(smem_buf);
-        val_smem_ += warp_id * WARP_SIZE;
-        idx_smem_
-            = reinterpret_cast<idxT*>(smem_buf + round_up_to_multiple_of<256>(num_of_warp * sizeof(T) * WARP_SIZE));
-        idx_smem_ += warp_id * WARP_SIZE;
-    }
-
-    __device__ void add(T const* in, idxT start, idxT end)
-    {
-        idxT const end_for_fullwarp = round_up_to_multiple_of<WARP_SIZE>(end - start) + start;
-        for (idxT i = start + lane_; i < end_for_fullwarp; i += WARP_SIZE)
-        {
-            T val = (i < end) ? in[i] : dummy_;
-            add(val, i);
-        }
-    }
-
-    __device__ void add(T val, idxT idx)
-    {
-        bool do_add;
-        if constexpr (is_stable)
-        {
-            do_add = is_better_than<greater>(val, k_th_, idx, k_th_idx_);
-        }
-        else
-        {
-            do_add = is_better_than<greater>(val, k_th_);
-        }
-
-        uint32_t mask = __ballot_sync(FULL_WARP_MASK, do_add);
-        if (mask == 0)
+        if (warpIdx >= numGroup)
         {
             return;
         }
-
-        int pos = smem_buf_len_ + __popc(mask & ((0x1u << lane_) - 1));
-        if (do_add && pos < WARP_SIZE)
-        {
-            val_smem_[pos] = val;
-            idx_smem_[pos] = idx;
-            do_add = false;
-        }
-        smem_buf_len_ += __popc(mask);
-        if (smem_buf_len_ >= WARP_SIZE)
-        {
-            __syncwarp();
-            merge_buf_(val_smem_[lane_], idx_smem_[lane_]);
-            smem_buf_len_ -= WARP_SIZE;
-        }
-        if (do_add)
-        {
-            pos -= WARP_SIZE;
-            val_smem_[pos] = val;
-            idx_smem_[pos] = idx;
-        }
-        __syncwarp();
     }
 
-    __device__ void done()
-    {
-        if (smem_buf_len_)
-        {
-            T val = (lane_ < smem_buf_len_) ? val_smem_[lane_] : dummy_;
-            idxT idx = (lane_ < smem_buf_len_) ? idx_smem_[lane_] : 0;
-            merge_buf_(val, idx);
-        }
+    // note that for invalid scores, we simply use a negative value:
+    // they work well even with the compacted format used in topK, and
+    // sigmoid / bias activated scores cannot be negative
+    static constexpr float invalidScoreFloat = -1.F;
+    const OutputT invalidScore = OutputT{invalidScoreFloat};
 
-        // after done(), smem is used for merging results among warps
+    // load bias already; each warp represents one expert group
+    auto threadExpert = threadIdx.x;
+    bool expertSelected = threadExpert < numExperts;
+    if constexpr (UseGroups)
+    {
+        threadExpert = warpIdx * numExpertsPerGroup + laneIdx;
+        expertSelected = laneIdx < numExpertsPerGroup;
+    }
+
+    auto scoreIdx = int64_t{blockIdx.x} * int64_t{numExperts} + threadExpert;
+    auto biasVal = expertSelected ? static_cast<float>(routingBias[threadExpert]) : invalidScoreFloat;
+    topkValues += blockIdx.x * topk;
+    topkIndices += blockIdx.x * topk;
+
+    // get our assigned thread score; each warp represents one expert group
+    float score = expertSelected ? static_cast<float>(scores[scoreIdx]) : invalidScoreFloat;
+    auto scoreSigmoid = sigmoid_accurate(score);
+    // write the sigmoid score to shared for later use
+    if (expertSelected)
+    {
+        smemScoreSigmoid[threadExpert] = scoreSigmoid;
+    }
+
+    // get the score with bias
+    // note that with invalid values, because sigmoid is < 1 and bias is -1,
+    // we must get a negative value, which is smaller than any valid value
+    auto scoreBias = float{scoreSigmoid + float{biasVal}};
+
+    if (expertSelected)
+    {
+        smemScoreBias[threadExpert] = scoreBias;
+    }
+
+    // registers for top group score reduction
+    float topExpGroupScores[NumTopGroupScores];
+    [[maybe_unused]] int32_t topExpGroupIdx[NumTopGroupScores];
+    float topGroups[MaxNumTopGroups]; // bound of numGroup
+    int32_t topGroupIdx[MaxNumTopGroups];
+    float expertScoreGroup[MaxNumTopGroups];
+    int32_t expertIdxGroup[MaxNumTopGroups];
+    float topScores[MaxNumTopExperts]; // bound of topk
+    int32_t topExperts[MaxNumTopExperts];
+
+    if constexpr (UseGroups)
+    {
+        reduce_topk::reduceTopK(warp, topExpGroupScores, topExpGroupIdx, scoreBias, threadExpert,
+            /* minValue */ invalidScoreFloat);
+
+        // get the final group score and write it to shared
+        if (laneIdx == 0)
+        {
+            auto groupScore = topExpGroupScores[0] + topExpGroupScores[1];
+            smemGroupScores[warpIdx] = groupScore;
+        }
+    }
+
+    // make group scores available to all warps
+    __syncthreads();
+
+    if constexpr (UseGroups)
+    {
+        if (warpIdx == 0)
+        {
+            // a single warp performs the selection of top groups, and goes on to select the final experts
+            float groupScore = laneIdx < numGroup ? smemGroupScores[laneIdx] : invalidScoreFloat;
+
+            reduce_topk::reduceTopK(warp, topGroups, topGroupIdx, groupScore, laneIdx,
+                /* minValue */ invalidScoreFloat);
+
+            // final expert selection: get relevant indexes and scores from shared
+
+#pragma unroll
+            for (int ii = 0; ii < MaxNumTopGroups; ++ii)
+            { // bound of numGroup
+                auto groupIdx = topGroupIdx[ii];
+                expertIdxGroup[ii] = groupIdx * numExpertsPerGroup + laneIdx;
+
+                expertScoreGroup[ii]
+                    = groupIdx < numGroup && expertSelected ? smemScoreBias[expertIdxGroup[ii]] : invalidScoreFloat;
+            }
+
+            tensorrt_llm::kernels::reduce_topk::reduceTopK(warp, topScores, topExperts, expertScoreGroup,
+                expertIdxGroup,
+                /* minValue */ invalidScoreFloat, topk);
+        }
+    }
+    else if constexpr (MaxNumExperts > MaxNumExpertsUnit)
+    {
+        // without groups, and the expert number is larger than MaxNumExpertsUnit,
+        // we need to use multiple warps to calculate the intermediate topk results
+
+        int constexpr NumExpertWarps = (MaxNumExperts - 1) / MaxNumExpertsUnit + 1;
+        int constexpr NumInterTopK = NumExpertWarps * MaxNumTopExperts;
+        __shared__ float __attribute((aligned(128))) smemInterTopScores[NumInterTopK];
+        __shared__ int32_t __attribute((aligned(128))) smemInterTopExperts[NumInterTopK];
+        if (warpIdx < NumExpertWarps)
+        {
+            int offset = warpIdx * WARP_SIZE * MaxNumTopGroups;
+#pragma unroll
+            for (int ii = 0; ii < MaxNumTopGroups; ++ii)
+            {
+                auto expertIdx = ii * WARP_SIZE + laneIdx;
+                expertIdxGroup[ii] = offset + expertIdx;
+                expertScoreGroup[ii]
+                    = offset + expertIdx < numExperts ? smemScoreBias[offset + expertIdx] : invalidScoreFloat;
+            }
+            reduce_topk::reduceTopK(warp, topScores, topExperts, expertScoreGroup, expertIdxGroup,
+                /* minValue */ invalidScoreFloat, topk);
+
+            if (laneIdx < topk)
+            {
+                smemInterTopScores[warpIdx * MaxNumTopExperts + laneIdx] = topScores[laneIdx];
+                smemInterTopExperts[warpIdx * MaxNumTopExperts + laneIdx] = topExperts[laneIdx];
+            }
+        }
         __syncthreads();
-    }
-
-private:
-    __device__ void set_k_th_()
-    {
-        k_th_ = __shfl_sync(FULL_WARP_MASK, val_arr_[max_arr_len_ - 1], k_th_lane_);
-        if constexpr (is_stable)
+        if (warpIdx == 0)
         {
-            k_th_idx_ = __shfl_sync(FULL_WARP_MASK, idx_arr_[max_arr_len_ - 1], k_th_lane_);
-        }
-    }
-
-    __device__ void merge_buf_(T val, idxT idx)
-    {
-        BitonicSort<WARP_SIZE, greater, T, idxT, is_stable>::sort(&val, &idx);
-
-        T& old = val_arr_[max_arr_len_ - 1];
-
-        bool is_better;
-        if constexpr (is_stable)
-        {
-            is_better = is_better_than<greater>(val, old, idx, idx_arr_[max_arr_len_ - 1]);
-        }
-        else
-        {
-            is_better = is_better_than<greater>(val, old);
-        }
-
-        if (is_better)
-        {
-            old = val;
-            idx_arr_[max_arr_len_ - 1] = idx;
-        }
-
-        BitonicMerge<capacity, greater, !greater, T, idxT, is_stable>::merge(val_arr_, idx_arr_);
-
-        set_k_th_();
-    }
-
-    using WarpSort<capacity, greater, T, idxT, is_stable>::max_arr_len_;
-    using WarpSort<capacity, greater, T, idxT, is_stable>::val_arr_;
-    using WarpSort<capacity, greater, T, idxT, is_stable>::idx_arr_;
-    using WarpSort<capacity, greater, T, idxT, is_stable>::lane_;
-    using WarpSort<capacity, greater, T, idxT, is_stable>::k_;
-    using WarpSort<capacity, greater, T, idxT, is_stable>::dummy_;
-
-    T* val_smem_;
-    idxT* idx_smem_;
-    int smem_buf_len_ = 0;
-
-    T k_th_;
-    idxT k_th_idx_;
-    int const k_th_lane_;
-}; // end class WarpSelect
-} // namespace warp_topk
-
-template <typename T>
-__device__ void topk_with_k2(T* output, T const* input, cg::thread_block_tile<32> const& tile, int32_t const lane_id,
-    int const num_experts_per_group)
-{
-    // Get the top2 per thread
-    T largest = -INFINITY;
-    T second_largest = -INFINITY;
-
-    if (num_experts_per_group > WARP_SIZE)
-    {
-        for (int i = lane_id; i < num_experts_per_group; i += WARP_SIZE)
-        {
-            T value = input[i];
-            if (value > largest)
+            int constexpr NumInterTopKPerThread = (NumInterTopK * NumExpertWarps - 1) / WARP_SIZE + 1;
+            float intermidiateScore[NumInterTopKPerThread];
+            int32_t intermidiateExpert[NumInterTopKPerThread];
+            for (int i = laneIdx; i < NumInterTopKPerThread * WARP_SIZE; i += WARP_SIZE)
             {
-                second_largest = largest;
-                largest = value;
+                int ii = i / WARP_SIZE;
+                if (i < NumInterTopK)
+                {
+                    intermidiateScore[ii] = smemInterTopScores[i];
+                    intermidiateExpert[ii] = smemInterTopExperts[i];
+                }
+                else
+                {
+                    intermidiateScore[ii] = invalidScoreFloat;
+                    intermidiateExpert[ii] = MaxNumExperts - 1;
+                }
             }
-            else if (value > second_largest)
-            {
-                second_largest = value;
-            }
+            reduce_topk::reduceTopK(warp, topScores, topExperts, intermidiateScore, intermidiateExpert,
+                /* minValue */ invalidScoreFloat, topk);
         }
     }
     else
     {
-        for (int i = lane_id; i < num_experts_per_group; i += WARP_SIZE)
+        // without groups, and the expert number is smaller than MaxNumExpertsUnit
+        // each thread just takes `MaxNumTopGroups` experts
+        if (warpIdx == 0)
         {
-            largest = input[i];
+#pragma unroll
+            for (int ii = 0; ii < MaxNumTopGroups; ++ii)
+            {
+                auto expertIdx = ii * WARP_SIZE + laneIdx;
+                expertIdxGroup[ii] = expertIdx;
+                expertScoreGroup[ii] = expertIdx < numExperts ? smemScoreBias[expertIdx] : invalidScoreFloat;
+            }
+            reduce_topk::reduceTopK(warp, topScores, topExperts, expertScoreGroup, expertIdxGroup,
+                /* minValue */ invalidScoreFloat, topk);
         }
     }
 
-    __syncwarp(); // Ensure all threads have valid data before reduction
-    // Get the top2 warpwise
-    T max1 = cg::reduce(tile, largest, cg::greater<T>());
-
-    T max2 = max1;
-    bool equal_to_max1 = (max1 == largest);
-
-    int count_max1 = __popc(__ballot_sync(FULL_WARP_MASK, equal_to_max1));
-
-    if (count_max1 == 1)
+    if (warpIdx == 0)
     {
-        largest = (largest == max1) ? second_largest : largest;
-        max2 = cg::reduce(tile, largest, cg::greater<T>());
+        // determine our lane's expert index and write to output
+        int32_t expertIdx = laneIdx < topk ? topExperts[laneIdx] : MaxNumExperts - 1;
+        // norm the value
+        float scoreNorm = laneIdx < topk ? smemScoreSigmoid[expertIdx] : 0.F;
+        auto redNorm = cg::reduce(warp, scoreNorm, cg::plus<float>{});
+        auto finalScore = static_cast<OutputT>(scoreNorm * routedScalingFactor / (redNorm + 1e-20));
+        // store the topk scores and experts to output
+        if (laneIdx < topk)
+        {
+            topkValues[laneIdx] = static_cast<OutputT>(finalScore);
+            topkIndices[laneIdx] = expertIdx;
+        }
     }
 
-    if (lane_id == 0)
-    {
-        *output = max1 + max2;
-    }
-}
-
-template <typename T>
-__global__ void topk_with_k2_kernel(T* output, T* input, int64_t const num_tokens, int64_t const num_cases,
-    int64_t const n_group, int64_t const num_experts_per_group)
-{
-
-    int32_t warp_id = threadIdx.x / WARP_SIZE;
-    int32_t lane_id = threadIdx.x % WARP_SIZE;
-
-    int32_t case_id = blockIdx.x * NUM_WARPS_PER_BLOCK + warp_id;
-    if (case_id < num_cases)
-    {
-        input += case_id * num_experts_per_group;
-        output += case_id;
-
-        cg::thread_block block = cg::this_thread_block();
-        cg::thread_block_tile<32> tile = cg::tiled_partition<32>(block);
-
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-        asm volatile("griddepcontrol.wait;");
-#endif
-        topk_with_k2(output, input, tile, lane_id, num_experts_per_group);
-    }
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
     asm volatile("griddepcontrol.launch_dependents;");
 #endif
 }
 
-template <typename T, typename IdxT>
-__global__ void group_idx_and_topk_idx_kernel(T* scores, T const* group_scores, T* topk_values, IdxT* topk_indices,
-    T* scores_with_bias, int64_t const num_tokens, int64_t const n_group, int64_t const topk_group, int64_t const topk,
-    int64_t const num_experts, int64_t const num_experts_per_group, double routed_scaling_factor)
+template <typename InputT, typename BiasT, typename OutputT, typename IdxT>
+void invokeNoAuxTc(InputT* scores, BiasT* bias, OutputT* topk_values, IdxT* topk_indices, int64_t const num_tokens,
+    int64_t const num_experts, int64_t const n_group, int64_t const topk_group, int64_t const topk,
+    double const routed_scaling_factor, cudaStream_t const stream)
 {
-    int32_t warp_id = threadIdx.x / WARP_SIZE;
-    int32_t lane_id = threadIdx.x % WARP_SIZE;
-    int32_t case_id = blockIdx.x * NUM_WARPS_PER_BLOCK + warp_id; // one per token
-    scores_with_bias += case_id * num_experts;
-    scores += case_id * num_experts;
-    group_scores += case_id * n_group;
-    topk_values += case_id * topk;
-    topk_indices += case_id * topk;
 
-    int32_t align_num_experts_per_group = warp_topk::round_up_to_multiple_of<WARP_SIZE>(num_experts_per_group);
+    // Check if we can use the optimized deepseek_v3_topk_kernel
+    bool const is_single_group = (n_group == 1) && (num_experts <= NumKimiK2Experts);
 
-    cg::thread_block block = cg::this_thread_block();
-    cg::thread_block_tile<32> tile = cg::tiled_partition<32>(block);
+    int64_t const experts_per_group = num_experts / n_group;
+    bool const is_multi_group = (n_group != 1) && (num_experts <= NumDeepseekExperts)
+        && (experts_per_group <= WARP_SIZE) && (experts_per_group * topk_group <= MaxNumExpertsUnit);
 
-    extern __shared__ char smem_buf[]; // NOTE: reuse the shared memory here to store the target topk idx
-    int32_t* s_topk_idx = reinterpret_cast<int32_t*>(smem_buf);
-    T* s_topk_value = reinterpret_cast<T*>(s_topk_idx + NUM_WARPS_PER_BLOCK * topk) + warp_id * topk;
-    s_topk_idx += warp_id * topk;
-
-    T value = cuda::std::numeric_limits<T>::min();
-    T topk_group_value = cuda::std::numeric_limits<T>::min();
-    int32_t num_equalto_topkth_group;
-
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-    asm volatile("griddepcontrol.wait;"); // I think all prolog can be put before acqbulk because it's ptr arithmetic
-#endif
-
-    if (case_id < num_tokens)
+    if (is_single_group || is_multi_group)
     {
-        // calculate group_idx
-        int32_t target_num_min = WARP_SIZE - n_group + topk_group;
-        if (lane_id < n_group
-            && (isfinite(cuda_cast<float, T>(group_scores[lane_id])))) // The check is necessary to avoid abnormal input
+        cudaLaunchConfig_t config;
+        auto* kernel_instance = &deepseek_v3_topk_kernel<InputT, BiasT, OutputT, IdxT, NumDeepseekExperts, true>;
+        int num_threads = NumDeepseekExperts;
+        if (is_single_group)
         {
-            value = group_scores[lane_id];
-        }
-
-        int count_equal_to_top_value = WARP_SIZE - n_group;
-        int pre_count_equal_to_top_value = 0;
-        // Use loop to find the largset top_group
-        while (count_equal_to_top_value < target_num_min)
-        {
-            __syncwarp(); // Ensure all threads have valid data before reduction
-            topk_group_value = cg::reduce(tile, value, cg::greater<T>());
-            if (value == topk_group_value)
+            if (num_experts > MaxNumExpertsUnit)
             {
-                value = cuda::std::numeric_limits<T>::min();
+                kernel_instance = &deepseek_v3_topk_kernel<InputT, BiasT, OutputT, IdxT, NumKimiK2Experts, false>;
+                num_threads = NumKimiK2Experts;
             }
-            pre_count_equal_to_top_value = count_equal_to_top_value;
-            count_equal_to_top_value
-                = __popc(__ballot_sync(FULL_WARP_MASK, (value == cuda::std::numeric_limits<T>::min())));
+            else
+            {
+                kernel_instance = &deepseek_v3_topk_kernel<InputT, BiasT, OutputT, IdxT, MaxNumExpertsUnit, false>;
+                num_threads = MaxNumExpertsUnit;
+            }
         }
-        num_equalto_topkth_group = target_num_min - pre_count_equal_to_top_value;
+
+        config.gridDim = num_tokens;
+        config.blockDim = num_threads;
+        config.dynamicSmemBytes = 0;
+        config.stream = stream;
+        cudaLaunchAttribute attrs[1];
+        attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+        attrs[0].val.programmaticStreamSerializationAllowed = tensorrt_llm::common::getEnvEnablePDL();
+        config.numAttrs = 1;
+        config.attrs = attrs;
+
+        cudaLaunchKernelEx(&config, kernel_instance, scores, topk_values, topk_indices, bias, num_tokens, n_group,
+            topk_group, topk, num_experts, num_experts / n_group, routed_scaling_factor);
+        sync_check_cuda_error(stream);
     }
-    __syncthreads();
-
-    warp_topk::WarpSelect</*capability*/ WARP_SIZE, /*greater*/ true, T, int32_t, /* is_stable */ true> queue(
-        (int32_t) topk, -INFINITY);
-
-    int count_equalto_topkth_group = 0;
-    bool if_proceed_next_topk = (topk_group_value != cuda::std::numeric_limits<T>::min());
-    if (case_id < num_tokens && if_proceed_next_topk)
+    else
     {
-        for (int i_group = 0; i_group < n_group; i_group++)
-        {
-            if ((group_scores[i_group] > topk_group_value)
-                || ((group_scores[i_group] == topk_group_value)
-                    && (count_equalto_topkth_group < num_equalto_topkth_group)))
-            {
-                int32_t offset = i_group * num_experts_per_group;
-                for (int32_t i = lane_id; i < align_num_experts_per_group; i += WARP_SIZE)
-                {
-                    T candidates
-                        = (i < num_experts_per_group) && isfinite(cuda_cast<float, T>(scores_with_bias[offset + i]))
-                        ? scores_with_bias[offset + i]
-                        : cuda::std::numeric_limits<T>::min();
-                    queue.add(candidates, offset + i);
-                }
-                if (group_scores[i_group] == topk_group_value)
-                {
-                    count_equalto_topkth_group++;
-                }
-            }
-        }
-        queue.done();
-        __syncwarp();
-        // Get the topk_idx
-        queue.dumpIdx(s_topk_idx);
-        __syncwarp();
+        // TODO: call the generic path (previous implementation) or signal unsupported config.
+        TLLM_CHECK_WITH_INFO(false,
+            "invokeNoAuxTc: unsupported configuration (n_group=%ld, num_experts=%ld, topk_group=%ld). Please use "
+            "original pytorch implementation.",
+            n_group, num_experts, topk_group);
     }
-
-    // Load the valid score value
-    // Calculate the summation
-    float topk_sum = 1e-20;
-    if (case_id < num_tokens && if_proceed_next_topk)
-    {
-        for (int i = lane_id; i < warp_topk::round_up_to_multiple_of<WARP_SIZE>(topk); i += WARP_SIZE)
-        {
-            T value = i < topk ? scores[s_topk_idx[i]] : cuda_cast<T, float>(0.0f); // Load the valid value of expert
-            if (i < topk)
-            {
-                s_topk_value[i] = value;
-            }
-            topk_sum += reduce(tile, cuda_cast<float, T>(value), cg::plus<float>());
-        }
-    }
-
-    __syncthreads();
-
-    if (case_id < num_tokens)
-    {
-        if (if_proceed_next_topk)
-        {
-            for (int i = lane_id; i < topk; i += WARP_SIZE)
-            {
-                float value = cuda_cast<float, T>(s_topk_value[i]) / topk_sum * routed_scaling_factor;
-                topk_indices[i] = s_topk_idx[i];
-                topk_values[i] = cuda_cast<T, float>(value);
-            }
-        }
-        else
-        {
-            for (int i = lane_id; i < topk; i += WARP_SIZE)
-            {
-                topk_indices[i] = i;
-                topk_values[i] = cuda_cast<T, float>(1.0f / topk);
-            }
-        }
-        // Note: when if_proceed_next_topk==false, choose the first 8 experts as the default result.
-        //@TODO: check if this default strategy is acceptable. Might need to leave it as nan array.
-    }
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-    asm volatile("griddepcontrol.launch_dependents;");
-#endif
 }
 
-template <typename T, typename IdxT>
-void invokeNoAuxTc(T* scores, T* group_scores, T* topk_values, IdxT* topk_indices, T* scores_with_bias,
-    int64_t const num_tokens, int64_t const num_experts, int64_t const n_group, int64_t const topk_group,
-    int64_t const topk, double const routed_scaling_factor, cudaStream_t const stream)
-{
-    int64_t num_cases = num_tokens * n_group;
-    int64_t topk_with_k2_num_blocks = (num_cases - 1) / NUM_WARPS_PER_BLOCK + 1;
-    auto* kernel_instance1 = &topk_with_k2_kernel<T>;
-    cudaLaunchConfig_t config;
-    config.gridDim = topk_with_k2_num_blocks;
-    config.blockDim = BLOCK_SIZE;
-    config.dynamicSmemBytes = 0;
-    config.stream = stream;
-    cudaLaunchAttribute attrs[1];
-    attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
-    attrs[0].val.programmaticStreamSerializationAllowed = tensorrt_llm::common::getEnvEnablePDL();
-    config.numAttrs = 1;
-    config.attrs = attrs;
-    cudaLaunchKernelEx(&config, kernel_instance1, group_scores, scores_with_bias, num_tokens, num_cases, n_group,
-        num_experts / n_group);
-    sync_check_cuda_error(stream);
-
-    int64_t topk_with_k_group_num_blocks = (num_tokens - 1) / NUM_WARPS_PER_BLOCK + 1;
-    size_t dynamic_smem_in_bytes = warp_topk::calc_smem_size_for_block_wide<T, int32_t>(NUM_WARPS_PER_BLOCK, topk);
-    auto* kernel_instance2 = &group_idx_and_topk_idx_kernel<T, IdxT>;
-    config.gridDim = topk_with_k_group_num_blocks;
-    config.blockDim = BLOCK_SIZE;
-    config.dynamicSmemBytes = dynamic_smem_in_bytes;
-    config.stream = stream;
-    attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
-    attrs[0].val.programmaticStreamSerializationAllowed = tensorrt_llm::common::getEnvEnablePDL();
-    config.numAttrs = 1;
-    config.attrs = attrs;
-    cudaLaunchKernelEx(&config, kernel_instance2, scores, group_scores, topk_values, topk_indices, scores_with_bias,
-        num_tokens, n_group, topk_group, topk, num_experts, num_experts / n_group, routed_scaling_factor);
-    sync_check_cuda_error(stream);
-}
-
-#define INSTANTIATE_NOAUX_TC(T, IdxT)                                                                                  \
-    template void invokeNoAuxTc<T, IdxT>(T * scores, T * group_scores, T * topk_values, IdxT * topk_indices,           \
-        T * scores_with_bias, int64_t const num_tokens, int64_t const num_experts, int64_t const n_group,              \
+#define INSTANTIATE_NOAUX_TC(InputT, BiasT, OutputT, IdxT)                                                             \
+    template void invokeNoAuxTc<InputT, BiasT, OutputT, IdxT>(InputT * scores, BiasT * bias, OutputT * topk_values,    \
+        IdxT * topk_indices, int64_t const num_tokens, int64_t const num_experts, int64_t const n_group,               \
         int64_t const topk_group, int64_t const topk, double const routed_scaling_factor, cudaStream_t const stream);
 
-INSTANTIATE_NOAUX_TC(float, int32_t);
-INSTANTIATE_NOAUX_TC(half, int32_t);
+INSTANTIATE_NOAUX_TC(float, float, float, int32_t);
+INSTANTIATE_NOAUX_TC(float, half, float, int32_t);
+
+INSTANTIATE_NOAUX_TC(half, float, half, int32_t);
+INSTANTIATE_NOAUX_TC(half, half, half, int32_t);
+
 #ifdef ENABLE_BF16
-INSTANTIATE_NOAUX_TC(__nv_bfloat16, int32_t);
+INSTANTIATE_NOAUX_TC(float, __nv_bfloat16, float, int32_t);
+INSTANTIATE_NOAUX_TC(half, __nv_bfloat16, half, int32_t);
+
+INSTANTIATE_NOAUX_TC(__nv_bfloat16, __nv_bfloat16, __nv_bfloat16, int32_t);
+INSTANTIATE_NOAUX_TC(__nv_bfloat16, float, __nv_bfloat16, int32_t);
+INSTANTIATE_NOAUX_TC(__nv_bfloat16, half, __nv_bfloat16, int32_t);
 #endif
+
 } // namespace tensorrt_llm::kernels

--- a/cpp/tensorrt_llm/kernels/noAuxTcKernels.h
+++ b/cpp/tensorrt_llm/kernels/noAuxTcKernels.h
@@ -25,9 +25,9 @@
 namespace tensorrt_llm::kernels
 {
 
-template <typename T, typename IdxT>
-void invokeNoAuxTc(T* scores, T* group_scores, T* topk_values, IdxT* topk_indices, T* scores_with_bias,
-    int64_t const num_tokens, int64_t const num_experts, int64_t const n_group, int64_t const topk_group,
-    int64_t const topk, double const routed_scaling_factor, cudaStream_t const stream = 0);
+template <typename InputT, typename BiasT, typename OutputT, typename IdxT>
+void invokeNoAuxTc(InputT* scores, BiasT* bias, OutputT* topk_values, IdxT* topk_indices, int64_t const num_tokens,
+    int64_t const num_experts, int64_t const n_group, int64_t const topk_group, int64_t const topk,
+    double const routed_scaling_factor, cudaStream_t const stream = 0);
 
 } // namespace tensorrt_llm::kernels

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/DevKernel.h
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/DevKernel.h
@@ -127,52 +127,53 @@ namespace moe::dev
         LAUNCH_PDL(data, coopLaunch, LAUNCH_ESC(types, false), kernel, numBlocks, numThreads, smemSize, stream);       \
     }
 
-#define LAUNCH_ROUTING(data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream)                              \
+#define LAUNCH_ROUTING_LLAMA4(data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream)                       \
     if (data.mDtypeExpW == tg::Dtype::Fp32)                                                                            \
     {                                                                                                                  \
-        LAUNCH_TILEN(data, coopLaunch, LAUNCH_ESC(float, float), kernel, numBlocks, numThreads, smemSize, stream);     \
+        LAUNCH_TILEN(data, coopLaunch, LAUNCH_ESC(float, float, 128 /* Always 128 for llama4*/), kernel, numBlocks,    \
+            numThreads, smemSize, stream);                                                                             \
     }                                                                                                                  \
     else if (data.mDtypeExpW == tg::Dtype::Bfloat16)                                                                   \
     {                                                                                                                  \
-        LAUNCH_TILEN(data, coopLaunch, LAUNCH_ESC(__nv_bfloat16, __nv_bfloat16), kernel, numBlocks, numThreads,        \
-            smemSize, stream);                                                                                         \
+        LAUNCH_TILEN(data, coopLaunch, LAUNCH_ESC(__nv_bfloat16, __nv_bfloat16, 128 /* Always 128 for llama4*/),       \
+            kernel, numBlocks, numThreads, smemSize, stream);                                                          \
     }                                                                                                                  \
     else                                                                                                               \
     {                                                                                                                  \
         TLLM_LOG_ERROR("Unsupported dtypeExpW");                                                                       \
     }
 
-#define LAUNCH_ROUTING_WITH_EXTRA_FLAG(                                                                                \
-    data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream, extraFlag, forceFloatInput)                     \
+#define LAUNCH_ROUTING_WITH_NUM_EXPERTS_FORCE_FLOAT_INPUT(                                                             \
+    data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream, extraFlag, forceFloatInput, numExperts)         \
     if (data.mDtypeExpW == tg::Dtype::Fp32 && extraFlag)                                                               \
     {                                                                                                                  \
-        LAUNCH_TILEN(                                                                                                  \
-            data, coopLaunch, LAUNCH_ESC(float, float, true), kernel, numBlocks, numThreads, smemSize, stream);        \
+        LAUNCH_TILEN(data, coopLaunch, LAUNCH_ESC(float, float, numExperts, true), kernel, numBlocks, numThreads,      \
+            smemSize, stream);                                                                                         \
     }                                                                                                                  \
     else if (data.mDtypeExpW == tg::Dtype::Fp32)                                                                       \
     {                                                                                                                  \
-        LAUNCH_TILEN(                                                                                                  \
-            data, coopLaunch, LAUNCH_ESC(float, float, false), kernel, numBlocks, numThreads, smemSize, stream);       \
+        LAUNCH_TILEN(data, coopLaunch, LAUNCH_ESC(float, float, numExperts, false), kernel, numBlocks, numThreads,     \
+            smemSize, stream);                                                                                         \
     }                                                                                                                  \
     else if (data.mDtypeExpW == tg::Dtype::Bfloat16 && extraFlag && forceFloatInput)                                   \
     {                                                                                                                  \
-        LAUNCH_TILEN(data, coopLaunch, LAUNCH_ESC(float, __nv_bfloat16, true), kernel, numBlocks, numThreads,          \
-            smemSize, stream);                                                                                         \
+        LAUNCH_TILEN(data, coopLaunch, LAUNCH_ESC(float, __nv_bfloat16, numExperts, true), kernel, numBlocks,          \
+            numThreads, smemSize, stream);                                                                             \
     }                                                                                                                  \
     else if (data.mDtypeExpW == tg::Dtype::Bfloat16 && extraFlag)                                                      \
     {                                                                                                                  \
-        LAUNCH_TILEN(data, coopLaunch, LAUNCH_ESC(__nv_bfloat16, __nv_bfloat16, true), kernel, numBlocks, numThreads,  \
-            smemSize, stream);                                                                                         \
+        LAUNCH_TILEN(data, coopLaunch, LAUNCH_ESC(__nv_bfloat16, __nv_bfloat16, numExperts, true), kernel, numBlocks,  \
+            numThreads, smemSize, stream);                                                                             \
     }                                                                                                                  \
     else if (data.mDtypeExpW == tg::Dtype::Bfloat16 && forceFloatInput)                                                \
     {                                                                                                                  \
-        LAUNCH_TILEN(data, coopLaunch, LAUNCH_ESC(float, __nv_bfloat16, false), kernel, numBlocks, numThreads,         \
-            smemSize, stream);                                                                                         \
+        LAUNCH_TILEN(data, coopLaunch, LAUNCH_ESC(float, __nv_bfloat16, numExperts, false), kernel, numBlocks,         \
+            numThreads, smemSize, stream);                                                                             \
     }                                                                                                                  \
     else if (data.mDtypeExpW == tg::Dtype::Bfloat16)                                                                   \
     {                                                                                                                  \
-        LAUNCH_TILEN(data, coopLaunch, LAUNCH_ESC(__nv_bfloat16, __nv_bfloat16, false), kernel, numBlocks, numThreads, \
-            smemSize, stream);                                                                                         \
+        LAUNCH_TILEN(data, coopLaunch, LAUNCH_ESC(__nv_bfloat16, __nv_bfloat16, numExperts, false), kernel, numBlocks, \
+            numThreads, smemSize, stream);                                                                             \
     }                                                                                                                  \
     else                                                                                                               \
     {                                                                                                                  \
@@ -181,6 +182,34 @@ namespace moe::dev
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+#define LAUNCH_ROUTING_WITH_NUM_EXPERTS(                                                                               \
+    data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream, extraFlag1, numExperts)                         \
+    if (data.mDtypeExpW == tg::Dtype::Fp32 && extraFlag1)                                                              \
+    {                                                                                                                  \
+        LAUNCH_TILEN(data, coopLaunch, LAUNCH_ESC(float, float, numExperts, true), kernel, numBlocks, numThreads,      \
+            smemSize, stream);                                                                                         \
+    }                                                                                                                  \
+    else if (data.mDtypeExpW == tg::Dtype::Fp32)                                                                       \
+    {                                                                                                                  \
+        LAUNCH_TILEN(data, coopLaunch, LAUNCH_ESC(float, float, numExperts, false), kernel, numBlocks, numThreads,     \
+            smemSize, stream);                                                                                         \
+    }                                                                                                                  \
+    else if (data.mDtypeExpW == tg::Dtype::Bfloat16 && extraFlag1)                                                     \
+    {                                                                                                                  \
+        LAUNCH_TILEN(data, coopLaunch, LAUNCH_ESC(__nv_bfloat16, __nv_bfloat16, numExperts, true), kernel, numBlocks,  \
+            numThreads, smemSize, stream);                                                                             \
+    }                                                                                                                  \
+    else if (data.mDtypeExpW == tg::Dtype::Bfloat16)                                                                   \
+    {                                                                                                                  \
+        LAUNCH_TILEN(data, coopLaunch, LAUNCH_ESC(__nv_bfloat16, __nv_bfloat16, numExperts, false), kernel, numBlocks, \
+            numThreads, smemSize, stream);                                                                             \
+    }                                                                                                                  \
+    else                                                                                                               \
+    {                                                                                                                  \
+        TLLM_LOG_ERROR("Unsupported dtypeExpW");                                                                       \
+    }
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
 namespace activation
 {
 

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingDeepSeek.cu
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingDeepSeek.cu
@@ -24,11 +24,12 @@ namespace routingDeepSeek
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-static constexpr int NumThreads = 256;
-static constexpr int NumWarps = NumThreads / WarpSize;
+static constexpr int NumKimiK2Experts = 384;
+static constexpr int NumDeepseekExperts = 256;
 static constexpr int NumTopGroupScores = 2;
 static constexpr int MaxNumTopExperts = 8;
 static constexpr int MaxNumTopGroups = 4;
+static constexpr int MaxNumGroups = 8;
 
 template <typename KernelParams>
 __global__ void routingMainKernel(KernelParams params)
@@ -39,10 +40,10 @@ __global__ void routingMainKernel(KernelParams params)
 
     // declare shared memory structure
     // number of experts is bounded by number of threads
-    __shared__ float __attribute((aligned(128))) smemScoreSigmoid[NumThreads];
-    __shared__ float __attribute((aligned(128))) smemScoreBias[NumThreads];
+    __shared__ float __attribute((aligned(128))) smemScoreSigmoid[KernelParams::MaxNumExperts];
+    __shared__ float __attribute((aligned(128))) smemScoreBias[KernelParams::MaxNumExperts];
     // number of expert groups is bounded by number of warps
-    __shared__ float __attribute((aligned(128))) smemGroupScores[NumWarps];
+    __shared__ float __attribute((aligned(128))) smemGroupScores[MaxNumGroups];
 
     // needed for warp reduce
     auto block = cg::this_thread_block();
@@ -79,8 +80,8 @@ __global__ void routingMainKernel(KernelParams params)
     // initialize the mPtrExpertCounts
     if (params.mPtrExpertCounts)
     {
-        int32_t globalThreadIdx = blockIdx.x * NumThreads + threadIdx.x;
-        int32_t globalThreadStride = gridDim.x * NumThreads;
+        int32_t globalThreadIdx = blockIdx.x * blockDim.x + threadIdx.x;
+        int32_t globalThreadStride = gridDim.x * blockDim.x;
         int32_t expertCountsNum = 2 * params.mNumExperts;
         initArr(globalThreadIdx, expertCountsNum, globalThreadStride, params.mPtrExpertCounts, 0);
     }
@@ -131,7 +132,6 @@ __global__ void routingMainKernel(KernelParams params)
         {
             topk::reduceTopK(warp, topExpGroupScores, topExpGroupIdx, scoreBias, threadExpert,
                 /* minValue */ invalidScoreFloat);
-
             // get the final group score and write it to shared
             if (cute::elect_one_sync())
             {
@@ -144,16 +144,13 @@ __global__ void routingMainKernel(KernelParams params)
         __syncthreads();
 
         auto localExpertExtent = params.mNumLocalExperts << params.mLocalExpertsStrideLog2;
-        if (warpIdx == 0)
-        {
-            // a single warp performs the selection of top groups, and goes on to select the final experts
-            if constexpr (KernelParams::UseGroups)
+        if constexpr (KernelParams::UseGroups)
+        { // a single warp performs the selection of top groups, and goes on to select the final experts
+            if (warpIdx == 0)
             {
                 float groupScore = laneIdx < params.mNumExpertGroups ? smemGroupScores[laneIdx] : invalidScoreFloat;
-
                 topk::reduceTopK(warp, topGroups, topGroupIdx, groupScore, laneIdx,
                     /* minValue */ invalidScoreFloat);
-
                 // final expert selection: get relevant indexes and scores from shared
 
 #pragma unroll
@@ -171,11 +168,67 @@ __global__ void routingMainKernel(KernelParams params)
                         ? smemScoreBias[expertIdxGroup[ii]]
                         : invalidScoreFloat;
                 }
+
+                topk::reduceTopK(warp, topScores, topExperts, expertScoreGroup, expertIdxGroup,
+                    /* minValue */ invalidScoreFloat, params.mTopK);
             }
-            else
+        }
+        else if constexpr (KernelParams::MaxNumExperts > topk::MaxNumExpertsUnit)
+        {
+            // without groups, each thread just takes `MaxNumTopGroups` experts
+            int constexpr NumExpertWarps = (KernelParams::MaxNumExperts - 1) / topk::MaxNumExpertsUnit + 1;
+            int constexpr NumInterTopK = NumExpertWarps * MaxNumTopExperts;
+            __shared__ float __attribute((aligned(128))) smemInterTopScores[NumInterTopK];
+            __shared__ int32_t __attribute((aligned(128))) smemInterTopExperts[NumInterTopK];
+            if (warpIdx < NumExpertWarps)
+            {
+                int offset = warpIdx * WarpSize * MaxNumTopGroups;
+#pragma unroll
+                for (int ii = 0; ii < MaxNumTopGroups; ++ii)
+                {
+                    auto expertIdx = ii * WarpSize + laneIdx;
+                    expertIdxGroup[ii] = offset + expertIdx;
+                    expertScoreGroup[ii] = offset + expertIdx < params.mNumExperts ? smemScoreBias[offset + expertIdx]
+                                                                                   : invalidScoreFloat;
+                }
+                topk::reduceTopK(warp, topScores, topExperts, expertScoreGroup, expertIdxGroup,
+                    /* minValue */ invalidScoreFloat, params.mTopK);
+
+                if (laneIdx < params.mTopK)
+                {
+                    smemInterTopScores[warpIdx * MaxNumTopExperts + laneIdx] = topScores[laneIdx];
+                    smemInterTopExperts[warpIdx * MaxNumTopExperts + laneIdx] = topExperts[laneIdx];
+                }
+            }
+            __syncthreads();
+            if (warpIdx == 0)
+            {
+                int constexpr NumInterTopKPerThread = (NumInterTopK * NumExpertWarps - 1) / WarpSize + 1;
+                float intermidiateScore[NumInterTopKPerThread];
+                int32_t intermidiateExpert[NumInterTopKPerThread];
+                for (int i = laneIdx; i < NumInterTopKPerThread * WarpSize; i += WarpSize)
+                {
+                    int ii = i / WarpSize;
+                    if (i < NumInterTopK)
+                    {
+                        intermidiateScore[ii] = smemInterTopScores[i];
+                        intermidiateExpert[ii] = smemInterTopExperts[i];
+                    }
+                    else
+                    {
+                        intermidiateScore[ii] = invalidScoreFloat;
+                        intermidiateExpert[ii] = KernelParams::MaxNumExperts - 1;
+                    }
+                }
+                topk::reduceTopK(warp, topScores, topExperts, intermidiateScore, intermidiateExpert,
+                    /* minValue */ invalidScoreFloat, params.mTopK);
+            }
+        }
+        else
+        {
+            if (warpIdx == 0)
             {
                 // without groups, each thread just takes `MaxNumTopGroups` experts
-
 #pragma unroll
                 for (int ii = 0; ii < MaxNumTopGroups; ++ii)
                 {
@@ -184,11 +237,13 @@ __global__ void routingMainKernel(KernelParams params)
                     expertScoreGroup[ii]
                         = expertIdx < params.mNumExperts ? smemScoreBias[expertIdx] : invalidScoreFloat;
                 }
+                topk::reduceTopK(warp, topScores, topExperts, expertScoreGroup, expertIdxGroup,
+                    /* minValue */ invalidScoreFloat, params.mTopK);
             }
+        }
 
-            topk::reduceTopK(warp, topScores, topExperts, expertScoreGroup, expertIdxGroup,
-                /* minValue */ invalidScoreFloat, params.mTopK);
-
+        if (warpIdx == 0)
+        {
             // determine our lane's expert index and write to output
             int32_t expertIdx = 0;
 #pragma unroll
@@ -225,7 +280,7 @@ __global__ void routingMainKernel(KernelParams params)
 
 template <typename KernelParams>
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-__global__ void __cluster_dims__(NumBlocksPerCluster, 1, 1) __launch_bounds__(NumThreads)
+__global__ void __cluster_dims__(NumBlocksPerCluster, 1, 1) __launch_bounds__(KernelParams::MaxNumExperts)
     routingIndicesClusterKernel(KernelParams params)
 {
     using OutputT = typename KernelParams::OutputT;
@@ -239,9 +294,8 @@ __global__ void __cluster_dims__(NumBlocksPerCluster, 1, 1) __launch_bounds__(Nu
     {
         cudaGridDependencySynchronize();
     }
-
-    routingPermutation<KernelParams, OutputT, NumThreads, NumWarps, MaxNumTopExperts, /*LoadExpertIdxFromGlobal=*/true>(
-        params, nullptr, warpIdx, clusterBlockRank);
+    routingPermutation<KernelParams, OutputT, KernelParams::MaxNumExperts, KernelParams::MaxNumExperts / WarpSize,
+        MaxNumTopExperts, /*LoadExpertIdxFromGlobal=*/true>(params, nullptr, warpIdx, clusterBlockRank);
 }
 #else
 __global__ void routingIndicesClusterKernel(KernelParams params)
@@ -254,9 +308,10 @@ __global__ void routingIndicesClusterKernel(KernelParams params)
 
 template <typename KernelParams>
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-__global__ void __launch_bounds__(NumThreads) routingIndicesCoopKernel(KernelParams params)
+__global__ void __launch_bounds__(KernelParams::MaxNumExperts) routingIndicesCoopKernel(KernelParams params)
 {
     // number of experts is bounded by number of threads
+    int constexpr NumThreads = KernelParams::MaxNumExperts;
     __shared__ int32_t __attribute((aligned(128))) smemExpertCount[NumThreads];
     __shared__ int32_t __attribute((aligned(128))) smemExpertOffset[NumThreads];
     // needed for the exclusive sum of token offsets
@@ -429,7 +484,7 @@ __global__ void __launch_bounds__(NumThreads) routingIndicesCoopKernel(KernelPar
     }
 
     // write out padded count
-    if (gridBlockIdx == 0 && warpIdx == NumWarps - 1 && cute::elect_one_sync())
+    if (gridBlockIdx == 0 && warpIdx == NumThreads / WarpSize - 1 && cute::elect_one_sync())
     {
         params.mPtrPermutedIdxSize[0] = permutedIdxSize;
         params.mPtrNumNonExitingCtas[0] = numNonExitingCtas;
@@ -485,7 +540,49 @@ __global__ void routingIndicesCoopKernel(KernelParams params)
 }
 #endif
 
+int constexpr getMaxNumExperts(int32_t numExperts)
+{
+    if (numExperts <= topk::MaxNumExpertsUnit)
+    {
+        return topk::MaxNumExpertsUnit;
+    }
+    else if (numExperts <= NumDeepseekExperts)
+    {
+        return NumDeepseekExperts;
+    }
+    else if (numExperts <= NumKimiK2Experts)
+    {
+        return NumKimiK2Experts;
+    }
+    else
+    {
+        TLLM_LOG_ERROR("Unsupported numExperts");
+        return 0;
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+#define LAUNCH_ROUTING_DEEPSEEK(                                                                                       \
+    data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream, extraFlag1, forceFloatInput)                    \
+    if (data.mNumExperts <= topk::MaxNumExpertsUnit)                                                                   \
+    {                                                                                                                  \
+        LAUNCH_ROUTING_WITH_NUM_EXPERTS_FORCE_FLOAT_INPUT(data, coopLaunch, kernel, numBlocks, numThreads, smemSize,   \
+            stream, extraFlag1, forceFloatInput, topk::MaxNumExpertsUnit);                                             \
+    }                                                                                                                  \
+    else if (data.mNumExperts <= NumDeepseekExperts)                                                                   \
+    {                                                                                                                  \
+        LAUNCH_ROUTING_WITH_NUM_EXPERTS_FORCE_FLOAT_INPUT(data, coopLaunch, kernel, numBlocks, numThreads, smemSize,   \
+            stream, extraFlag1, forceFloatInput, NumDeepseekExperts);                                                  \
+    }                                                                                                                  \
+    else if (data.mNumExperts <= NumKimiK2Experts)                                                                     \
+    {                                                                                                                  \
+        LAUNCH_ROUTING_WITH_NUM_EXPERTS_FORCE_FLOAT_INPUT(data, coopLaunch, kernel, numBlocks, numThreads, smemSize,   \
+            stream, extraFlag1, forceFloatInput, NumKimiK2Experts);                                                    \
+    }                                                                                                                  \
+    else                                                                                                               \
+    {                                                                                                                  \
+        TLLM_LOG_ERROR("Unsupported numExperts");                                                                      \
+    }
 
 void run(Data& data, void* stream)
 {
@@ -511,32 +608,31 @@ void run(Data& data, void* stream)
         data.mNumLimitedGroups);
     TLLM_CHECK_WITH_INFO(data.mNumExperts >= MaxNumTopExperts, "Routing kernel expects %d to be at most #experts %d",
         MaxNumTopExperts, data.mNumExperts);
-    TLLM_CHECK_WITH_INFO(data.mNumExperts <= NumThreads, "Routing kernel expects #experts %d  <= #threads %d",
-        data.mNumExperts, NumThreads);
+    TLLM_CHECK_WITH_INFO(data.mNumExperts <= NumKimiK2Experts, "Routing kernel expects #experts %d  <= #threads %d",
+        data.mNumExperts, NumKimiK2Experts);
     TLLM_CHECK_WITH_INFO(data.mNumExpertGroups >= data.mNumLimitedGroups,
         "Routing kernel expects top groups %d to be limited by #expert groups %d", data.mNumLimitedGroups,
         data.mNumExpertGroups);
     if (data.mNumExpertGroups > 1)
     {
-        TLLM_CHECK_WITH_INFO(data.mNumExpertGroups <= NumWarps,
-            "Routing kernel expects #experts groups %d to be <= #warps %d", data.mNumExpertGroups, NumWarps);
+        TLLM_CHECK_WITH_INFO(data.mNumExpertGroups <= MaxNumGroups,
+            "Routing kernel expects #experts groups %d to be <= #warps %d", data.mNumExpertGroups, MaxNumGroups);
         TLLM_CHECK_WITH_INFO(data.mNumExperts % data.mNumExpertGroups == 0,
             "Routing kernel expects #experts %d to be a multiple of #expert groups %d", data.mNumExperts,
             data.mNumExpertGroups);
         TLLM_CHECK_WITH_INFO(data.mNumExperts / data.mNumExpertGroups <= WarpSize,
-            "Routing kernel expects #experts per group <= warp size, got %d", data.mNumExperts / data.mNumExpertGroups);
+            "Routing kernel expects #experts per group <= warp size, got %d, data.mNumExpertGroups %d",
+            data.mNumExperts / data.mNumExpertGroups, data.mNumExpertGroups);
     }
     else
     {
-        TLLM_CHECK_WITH_INFO(data.mNumExperts <= WarpSize * MaxNumTopGroups,
-            "Routing kernel expects #experts %d <= WarpSize * MaxNumTopGroups %d", data.mNumExperts,
-            WarpSize * MaxNumTopGroups);
-        TLLM_CHECK_WITH_INFO(
-            data.mTopK <= NumWarps, "Routing kernel expects top K %d to be <= #warps %d", data.mTopK, NumWarps);
+        TLLM_CHECK_WITH_INFO(data.mTopK <= topk::MaxNumTopK, "Routing kernel expects top K %d to be <= #warps %d",
+            data.mTopK, topk::MaxNumTopK);
     }
     TLLM_CHECK_WITH_INFO(
         data.mNumExperts % 4 == 0, "Routing kernel expects #experts %d to be a multiple of 4.", data.mNumExperts);
     int const numBlocks = data.mNumTokens;
+    int const numThreadsHist = getMaxNumExperts(data.mNumExperts);
 
     bool const useSingleCluster = data.mNumTokens <= 1024;
     if (!useSingleCluster)
@@ -564,20 +660,20 @@ void run(Data& data, void* stream)
     int const numBlocksCoop = 128;
 
     // Maximum number of tokens supported by the kernel using a cooperative launch.
-    int const maxTokensCoop = (numBlocksCoop * NumThreads * 64) / data.mTopK;
-
+    int const maxTokensCoop = (numBlocksCoop * numThreadsHist * 64) / data.mTopK;
     if (data.mPtrTopKIds == nullptr)
     {
-        LAUNCH_ROUTING_WITH_EXTRA_FLAG(data,
-            /*coopLaunch=*/false, routingMainKernel, numBlocks, NumThreads,
+        int const numThreadsMain = data.mNumExperts < NumDeepseekExperts ? NumDeepseekExperts : NumKimiK2Experts;
+        LAUNCH_ROUTING_DEEPSEEK(data,
+            /*coopLaunch=*/false, routingMainKernel, numBlocks, numThreadsMain,
             /*smemSize=*/0, // No dynamic smem
             stream, data.mNumExpertGroups > 1, /*forceFloatInput=*/true);
     }
     else
     {
         // Reset the global histograms.
-        LAUNCH_ROUTING_WITH_EXTRA_FLAG(data, false, routingInitExpertCounts,
-            (2 * data.mNumExperts - 1) / NumThreadsHist + 1, NumThreadsHist,
+        LAUNCH_ROUTING_DEEPSEEK(data, false, routingInitExpertCounts, (2 * data.mNumExperts - 1) / numThreadsHist + 1,
+            numThreadsHist,
             /*smemSize=*/0, // No dynamic smem
             stream, data.mNumExpertGroups > 1, /*forceFloatInput=*/false);
     }
@@ -586,24 +682,23 @@ void run(Data& data, void* stream)
     {
         if (useSingleCluster)
         {
-            LAUNCH_ROUTING_WITH_EXTRA_FLAG(data,
-                /*coopLaunch=*/false, routingIndicesClusterKernel, NumBlocksPerCluster, NumThreads,
+            LAUNCH_ROUTING_DEEPSEEK(data,
+                /*coopLaunch=*/false, routingIndicesClusterKernel, NumBlocksPerCluster, numThreadsHist,
                 /*smemSize=*/0, // No dynamic smem
                 stream, data.mNumExpertGroups > 1, /*forceFloatInput=*/true);
         }
         else if (data.mNumTokens <= maxTokensCoop)
         {
-            LAUNCH_ROUTING_WITH_EXTRA_FLAG(data,
-                /*coopLaunch=*/true, routingIndicesCoopKernel, numBlocksCoop, NumThreads,
+            LAUNCH_ROUTING_DEEPSEEK(data,
+                /*coopLaunch=*/true, routingIndicesCoopKernel, numBlocksCoop, numThreadsHist,
                 /*smemSize=*/0, // No dynamic smem
                 stream, data.mNumExpertGroups > 1, /*forceFloatInput=*/true);
         }
         else
         {
             const int32_t expandedIdxSize = data.mNumTokens * data.mTopK;
-
-            const int32_t histogramEltsPerBlock = 8 * NumThreads;
-            const int32_t offsetEltsPerBlock = NumEltsPerOffsetTilePerThread * NumThreads;
+            const int32_t histogramEltsPerBlock = 8 * numThreadsHist;
+            const int32_t offsetEltsPerBlock = NumEltsPerOffsetTilePerThread * numThreadsHist;
 
             // Limit grid size (both kernels use a grid-stride loop).
             const int32_t maxNumBlocks = 1024;
@@ -613,12 +708,12 @@ void run(Data& data, void* stream)
             int const numBlocksOffsets
                 = std::min((expandedIdxSize + offsetEltsPerBlock - 1) / offsetEltsPerBlock, maxNumBlocks);
 
-            LAUNCH_ROUTING_WITH_EXTRA_FLAG(data,
-                /*coopLaunch=*/false, routingIndicesHistogramKernel, numBlocksHistogram, NumThreads,
+            LAUNCH_ROUTING_DEEPSEEK(data,
+                /*coopLaunch=*/false, routingIndicesHistogramKernel, numBlocksHistogram, numThreadsHist,
                 /*smemSize=*/0, // No dynamic smem
                 stream, data.mNumExpertGroups > 1, /*forceFloatInput=*/true);
-            LAUNCH_ROUTING_WITH_EXTRA_FLAG(data,
-                /*coopLaunch=*/false, routingIndicesOffsetsKernel, numBlocksOffsets, NumThreads,
+            LAUNCH_ROUTING_DEEPSEEK(data,
+                /*coopLaunch=*/false, routingIndicesOffsetsKernel, numBlocksOffsets, numThreadsHist,
                 /*smemSize=*/0, // No dynamic smem
                 stream, data.mNumExpertGroups > 1, /*forceFloatInput=*/true);
         }

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingKernelTopK.cuh
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingKernelTopK.cuh
@@ -34,6 +34,8 @@ namespace cg = cooperative_groups;
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 static constexpr int WarpSize = 32;
+static constexpr int MaxNumExpertsUnit = 128;
+static constexpr int MaxNumTopK = 10;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -178,7 +180,7 @@ __forceinline__ __device__ void reduceTopK(cg::thread_block_tile<WarpSize> const
 };
 
 template <int K, typename Type, int N>
-__forceinline__ __device__ void reduceTopK(cg::thread_block_tile<WarpSize> const& warp, Type (&out)[K],
+__forceinline__ __device__ void reduceTopKFunc(cg::thread_block_tile<WarpSize> const& warp, Type (&out)[K],
     int32_t (&outIdx)[K], Type (&value)[N], int32_t (&idx)[N], Type const minValue, int actualK = K)
 {
     static_assert(K > 0, "Top K must have K > 0");
@@ -208,6 +210,67 @@ __forceinline__ __device__ void reduceTopK(cg::thread_block_tile<WarpSize> const
         // get the next largest value
         packedMax = topK[0].reduce(warp);
         RedType::unpack(out[kk], outIdx[kk], packedMax);
+    }
+};
+
+template <int K, typename Type, int N>
+__forceinline__ __device__ void reduceTopK(cg::thread_block_tile<WarpSize> const& warp, Type (&out)[K],
+    int32_t (&outIdx)[K], Type (&value)[N], int32_t (&idx)[N], Type const minValue, int actualK = K)
+{
+    static_assert(K > 0, "Top K must have K > 0");
+    static_assert(K < WarpSize, "Top K must have K < WarpSize");
+    static_assert(N > 0, "Top K must have N > 0");
+    static_assert(N <= 16, "Only support candidates number less than or equal to 16*32=512");
+    static_assert(
+        N <= 4 || N % 4 == 0, "Only support candidates number is a multiple of 4*32=128 or less than or equal to 4");
+    using RedType = TopKRedType<Type>;
+
+    if constexpr (N <= 4)
+    {
+        reduceTopKFunc<K, Type, N>(warp, out, outIdx, value, idx, minValue, actualK);
+    }
+    else
+    {
+
+        constexpr int numLoops = (N - 1) / 4 + 1;
+        constexpr int numResults = (numLoops * K - 1) / WarpSize + 1;
+
+        Type topKBufferValue[numResults];
+        int32_t topKBufferIdx[numResults];
+        int32_t laneIdx = threadIdx.x % WarpSize;
+
+        for (int ii = 0; ii < numResults; ++ii)
+        {
+            topKBufferValue[ii] = minValue;
+            topKBufferIdx[ii] = ii * WarpSize - 1; //@todo: check if this is correct
+        }
+        for (int loop = 0; loop < numLoops; ++loop)
+        {
+            int start = loop * 4;
+            Type topKValue[K];
+            int32_t topKIdx[K];
+            Type inValue[4];
+            int32_t inIdx[4];
+            for (int i = 0; i < 4; ++i)
+            {
+                inValue[i] = value[start + i];
+                inIdx[i] = idx[start + i];
+            }
+            reduceTopKFunc<K, Type, 4>(warp, topKValue, topKIdx, inValue, inIdx, minValue, actualK);
+            int inOffset = laneIdx % K;
+            if (laneIdx >= loop * K && laneIdx < (loop + 1) * K)
+            {
+                topKBufferValue[0] = topKValue[inOffset];
+                topKBufferIdx[0] = topKIdx[inOffset];
+            }
+            if (loop == numLoops - 1 && (laneIdx < (numLoops * K - WarpSize)))
+            {
+                topKBufferValue[1] = topKValue[inOffset];
+                topKBufferIdx[1] = topKIdx[inOffset];
+            }
+        }
+
+        reduceTopKFunc<K, Type, numResults>(warp, out, outIdx, topKBufferValue, topKBufferIdx, minValue, actualK);
     }
 };
 

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingLlama4.cu
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/RoutingLlama4.cu
@@ -26,7 +26,8 @@ namespace routingLlama4
 static constexpr int NumThreads = 1024;
 static constexpr int NumWarps = NumThreads / WarpSize;
 static constexpr int MaxNumTopExperts = 1;
-static constexpr int MaxNumExperts = 128;
+// static constexpr int MaxNumExperts = 128;
+static constexpr int NumExpertsLimit = 128;
 static constexpr int MaxNumTokensSingleCluster = NumBlocksPerCluster * NumThreads;
 static constexpr int MaxNumTokensSingleClusterScores = NumBlocksPerCluster * NumWarps;
 static constexpr int WarpKernelSmemStride = 33;
@@ -88,7 +89,7 @@ __global__ void __launch_bounds__(WarpSize) routingIndicesWarpKernel(KernelParam
     __shared__ int32_t __attribute((aligned(128)))
     smemExpertTokenCountFull[WarpKernelMaxNumTokens][WarpKernelSmemStride];
     static_assert(WarpKernelSmemStride == WarpSize + 1);
-    static_assert(MaxNumExperts / sizeof(int32_t) <= WarpSize);
+    static_assert(KernelParams::MaxNumExperts / sizeof(int32_t) <= WarpSize);
 
     // values needed for the top-1 reduction, if required
     InputT minScore = InputT{-INFINITY};
@@ -405,7 +406,7 @@ __global__ void __cluster_dims__(NumBlocksPerCluster, 1, 1) __launch_bounds__(Nu
 
         if (validToken)
         {
-            routingTopKExperts<InputT, MaxNumExperts / WarpSize>(
+            routingTopKExperts<InputT, KernelParams::MaxNumExperts / WarpSize>(
                 warp, warpMaxScore, warpMaxExpertIdx, laneIdx, params.mNumExperts, params.mPtrScores + scoreOffset);
             if (cute::elect_one_sync())
             {
@@ -449,27 +450,27 @@ __global__ void routingIndicesClusterKernel(KernelParams params)
 
 // this kernel is needed in case we have scores as input for the histogram kernel
 template <typename KernelParams>
-__global__ void __launch_bounds__(NumThreadsHist) routingIndicesHistogramScoresKernel(KernelParams params)
+__global__ void __launch_bounds__(KernelParams::MaxNumExperts) routingIndicesHistogramScoresKernel(KernelParams params)
 {
     using OutputT = typename KernelParams::OutputT;
     using InputT = typename KernelParams::InputT;
     using TypePacked = PackedScoreIdx<OutputT>;
-    static constexpr int VecSize = MaxNumExperts / WarpSize;
+    static constexpr int VecSize = KernelParams::MaxNumExperts / WarpSize;
     //  we assume that #experts is a multiple of 4, so VecSize must be 4.
     static_assert(VecSize == 4);
 
     int32_t const laneIdx = cutlass::arch::LaneId();
     int32_t const warpIdx = threadIdx.x / WarpSize;
-    int32_t const globalWarpIdx = blockIdx.x * NumWarpsHist + warpIdx;
-    int32_t const globalWarpStride = gridDim.x * NumWarpsHist;
+    int32_t const globalWarpIdx = blockIdx.x * KernelParams::MaxNumExperts / WarpSize + warpIdx;
+    int32_t const globalWarpStride = gridDim.x * KernelParams::MaxNumExperts / WarpSize;
     InputT minScore = InputT{-INFINITY};
     auto block = cg::this_thread_block();
     auto warp = cg::tiled_partition<WarpSize>(block);
 
     // initialize the mPtrExpertCounts
     int32_t expertCountsNum = 2 * params.mNumExperts;
-    int32_t globalThreadIdx = blockIdx.x * NumThreadsHist + threadIdx.x;
-    int32_t globalThreadStride = gridDim.x * NumThreadsHist;
+    int32_t globalThreadIdx = blockIdx.x * KernelParams::MaxNumExperts + threadIdx.x;
+    int32_t globalThreadStride = gridDim.x * KernelParams::MaxNumExperts;
     initArr(globalThreadIdx, expertCountsNum, globalThreadStride, params.mPtrExpertCounts, 0);
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
@@ -499,7 +500,7 @@ __global__ void __launch_bounds__(NumThreadsHist) routingIndicesHistogramScoresK
         }
         else if (params.mPtrScores != nullptr)
         {
-            routingTopKExperts<InputT, MaxNumExperts / WarpSize>(
+            routingTopKExperts<InputT, KernelParams::MaxNumExperts / WarpSize>(
                 warp, warpMaxScore, warpMaxExpertIdx, laneIdx, params.mNumExperts, params.mPtrScores + scoreOffset);
         }
         else
@@ -521,6 +522,20 @@ __global__ void __launch_bounds__(NumThreadsHist) routingIndicesHistogramScoresK
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+int constexpr getMaxNumExperts(int32_t numExperts)
+{
+    if (numExperts <= topk::MaxNumExpertsUnit)
+    {
+        return topk::MaxNumExpertsUnit;
+    }
+    else
+    {
+        TLLM_LOG_ERROR("Unsupported numExperts");
+        return 0;
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void run(Data const& data, void* stream)
 {
@@ -536,10 +551,10 @@ void run(Data const& data, void* stream)
         "Llama4 routing kernel expects permuted idx and grouped Gemm launch config buffers");
     TLLM_CHECK_WITH_INFO(data.mTopK <= MaxNumTopExperts, "Routing kernel expects topK experts <= %d, got %d",
         MaxNumTopExperts, data.mTopK);
-    TLLM_CHECK_WITH_INFO(data.mNumExperts <= MaxNumExperts, "Routing kernel expects #experts %d to be no more than %d",
-        data.mNumExperts, MaxNumExperts);
-    static_assert(MaxNumExperts <= NumThreads, "#experts must be bounded by #threads");
-    static_assert(MaxNumExperts <= NumThreadsHist, "#experts must be bounded by #threads");
+    TLLM_CHECK_WITH_INFO(data.mNumExperts <= NumExpertsLimit,
+        "Routing kernel expects #experts %d to be no more than %d", data.mNumExperts, NumExpertsLimit);
+    // static_assert(MaxNumExperts <= NumThreads, "#experts must be bounded by #threads");
+    // static_assert(MaxNumExperts <= numThreadsHist, "#experts must be bounded by #threads");
     TLLM_CHECK_WITH_INFO(
         data.mNumExperts % 4 == 0, "Routing kernel expects #experts %d to be a multiple of 4.", data.mNumExperts);
 
@@ -556,16 +571,17 @@ void run(Data const& data, void* stream)
             data.mPtrExpertCounts != nullptr, "When #tokens is large, `mPtrExpertCounts` is a required input.");
     }
 
+    int const numThreadsHist = getMaxNumExperts(data.mNumExperts);
     if (useSingleWarp)
     {
-        LAUNCH_ROUTING(data,
+        LAUNCH_ROUTING_LLAMA4(data,
             /*coopLaunch=*/false, routingIndicesWarpKernel, 1, WarpSize,
             /*smemSize=*/0, // No dynamic smem
             stream);
     }
     else if (useSingleCluster)
     {
-        LAUNCH_ROUTING(data,
+        LAUNCH_ROUTING_LLAMA4(data,
             /*coopLaunch=*/false, routingIndicesClusterKernel, NumBlocksPerCluster, NumThreads,
             /*smemSize=*/0, // No dynamic smem
             stream);
@@ -574,8 +590,8 @@ void run(Data const& data, void* stream)
     {
         const uint32_t expandedIdxSize = data.mNumTokens * data.mTopK;
 
-        const uint32_t histogramEltsPerBlock = 8 * NumThreadsHist;
-        const uint32_t offsetEltsPerBlock = NumEltsPerOffsetTilePerThread * NumThreadsHist;
+        const uint32_t histogramEltsPerBlock = 8 * numThreadsHist;
+        const uint32_t offsetEltsPerBlock = NumEltsPerOffsetTilePerThread * numThreadsHist;
 
         // Limit grid size (all kernels use a grid-stride loop).
         const uint32_t maxNumBlocks = 1024;
@@ -587,25 +603,25 @@ void run(Data const& data, void* stream)
 
         if (data.mPtrScores != nullptr && data.mPtrTopKIds == nullptr)
         {
-            LAUNCH_ROUTING(data,
-                /*coopLaunch=*/false, routingIndicesHistogramScoresKernel, maxNumBlocks, NumThreadsHist,
+            LAUNCH_ROUTING_LLAMA4(data,
+                /*coopLaunch=*/false, routingIndicesHistogramScoresKernel, maxNumBlocks, numThreadsHist,
                 /*smemSize=*/0, // No dynamic smem
                 stream);
         }
         else
         {
             // Reset the global histograms.
-            LAUNCH_ROUTING(data, false, routingInitExpertCounts, (2 * data.mNumExperts - 1) / NumThreadsHist + 1,
-                NumThreadsHist,
+            LAUNCH_ROUTING_LLAMA4(data, false, routingInitExpertCounts, (2 * data.mNumExperts - 1) / numThreadsHist + 1,
+                numThreadsHist,
                 /*smemSize=*/0, // No dynamic smem
                 stream);
         }
-        LAUNCH_ROUTING(data,
-            /*coopLaunch=*/false, routingIndicesHistogramKernel, numBlocksHistogram, NumThreadsHist,
+        LAUNCH_ROUTING_LLAMA4(data,
+            /*coopLaunch=*/false, routingIndicesHistogramKernel, numBlocksHistogram, numThreadsHist,
             /*smemSize=*/0, // No dynamic smem
             stream);
-        LAUNCH_ROUTING(data,
-            /*coopLaunch=*/false, routingIndicesOffsetsKernel, numBlocksOffsets, NumThreadsHist,
+        LAUNCH_ROUTING_LLAMA4(data,
+            /*coopLaunch=*/false, routingIndicesOffsetsKernel, numBlocksOffsets, numThreadsHist,
             /*smemSize=*/0, // No dynamic smem
             stream);
     }

--- a/cpp/tensorrt_llm/thop/fp4BlockScaleMoe.cpp
+++ b/cpp/tensorrt_llm/thop/fp4BlockScaleMoe.cpp
@@ -120,8 +120,8 @@ std::vector<torch::Tensor> run_fp4_block_scale_moe_runner(torch::optional<torch:
     else if (static_cast<RoutingMethodType>(routing_method_type) == RoutingMethodType::Renormalize
         || static_cast<RoutingMethodType>(routing_method_type) == RoutingMethodType::RenormalizeNaive)
     {
-        TORCH_CHECK(top_k <= 8 && top_k > 0,
-            "Current routing kernel (no groups, renormalize) only supports top_k<=8 && top_k>0.");
+        TORCH_CHECK(top_k <= 10 && top_k > 0,
+            "Current routing kernel (no groups, renormalize) only supports top_k<=10 && top_k>0.");
     }
     else if (static_cast<RoutingMethodType>(routing_method_type) == RoutingMethodType::Llama4)
     {
@@ -130,7 +130,7 @@ std::vector<torch::Tensor> run_fp4_block_scale_moe_runner(torch::optional<torch:
 
     TORCH_CHECK(num_experts % 4 == 0, "Routing kernel expects that num_experts must be divisible by 4");
     TORCH_CHECK(num_experts > top_k, "num_experts must be greater than top_k");
-    TORCH_CHECK(num_experts <= 256, "num_experts must be less than or equal to 256");
+    TORCH_CHECK(num_experts <= 512, "num_experts must be less than or equal to 512");
 
     // If both routing inputs are provided, they must be on the same device
     if (routing_logits.has_value() && topk_ids.has_value())

--- a/cpp/tensorrt_llm/thop/fp8BlockScaleMoe.cpp
+++ b/cpp/tensorrt_llm/thop/fp8BlockScaleMoe.cpp
@@ -115,7 +115,7 @@ at::Tensor run_fp8_block_scale_moe(at::optional<at::Tensor> const& routing_logit
     else if (static_cast<RoutingMethodType>(routing_method_type) == RoutingMethodType::Renormalize
         || static_cast<RoutingMethodType>(routing_method_type) == RoutingMethodType::RenormalizeNaive)
     {
-        TORCH_CHECK(top_k <= 8 && top_k > 0,
+        TORCH_CHECK(top_k <= 10 && top_k > 0,
             "Current routing kernel (no groups, renormalize) only supports top_k<=8 && top_k>0.");
     }
     else if (static_cast<RoutingMethodType>(routing_method_type) == RoutingMethodType::Llama4)

--- a/cpp/tensorrt_llm/thop/mxFp4BlockScaleMoe.cpp
+++ b/cpp/tensorrt_llm/thop/mxFp4BlockScaleMoe.cpp
@@ -126,8 +126,8 @@ torch::Tensor dtype_mxe2m1_block_scale_moe_runner(torch::optional<torch::Tensor>
     else if (static_cast<RoutingMethodType>(routing_method_type) == RoutingMethodType::Renormalize
         || static_cast<RoutingMethodType>(routing_method_type) == RoutingMethodType::RenormalizeNaive)
     {
-        TORCH_CHECK(top_k <= 8 && top_k > 0,
-            "Current routing kernel (no groups, renormalize) only supports top_k<=8 && top_k>0.");
+        TORCH_CHECK(top_k <= 10 && top_k > 0,
+            "Current routing kernel (no groups, renormalize) only supports top_k<=10 && top_k>0.");
     }
 
     TORCH_CHECK(num_experts % 4 == 0, "Routing kernel expects that num_experts must be divisible by 4");

--- a/cpp/tensorrt_llm/thop/noAuxTcOp.cpp
+++ b/cpp/tensorrt_llm/thop/noAuxTcOp.cpp
@@ -34,55 +34,118 @@ namespace tk = tensorrt_llm::kernels;
 
 namespace torch_ext
 {
-std::tuple<at::Tensor, at::Tensor> noaux_tc_op(th::Tensor const& scores, th::Tensor const& scores_with_bias,
-    int64_t n_group, int64_t topk_group, int64_t topk, double routed_scaling_factor)
+std::tuple<at::Tensor, at::Tensor> noaux_tc_op(th::Tensor const& scores, th::Tensor const& bias, int64_t n_group,
+    int64_t topk_group, int64_t topk, double routed_scaling_factor)
 {
-    auto data_type = scores_with_bias.scalar_type();
-    auto input_size = scores_with_bias.sizes();
+    auto data_type = scores.scalar_type();
+    auto bias_type = bias.scalar_type();
+
+    auto input_size = scores.sizes();
     int64_t num_tokens = input_size[0];
     int64_t num_experts = input_size[1];
-    TORCH_CHECK(input_size.size() == 2, "scores_with_bias must be a 2D Tensor");
+    TORCH_CHECK(input_size.size() == 2, "scores must be a 2D Tensor");
+    TORCH_CHECK(scores.is_cuda() && bias.is_cuda(), "scores and bias must be CUDA tensors");
+    TORCH_CHECK(scores.get_device() == bias.get_device(), "scores and bias must be on the same device");
+    TORCH_CHECK(bias.dim() == 1 && bias.numel() == num_experts,
+        "bias must be 1D with length == number of experts (%ld)", num_experts);
     TORCH_CHECK(num_experts % n_group == 0, "num_experts should be divisible by n_group");
     TORCH_CHECK(
         n_group <= 32, "n_group should be smaller than or equal to 32 for now"); //@todo: remove this restriction later
     TORCH_CHECK(
         topk <= 32, "topk should be smaller than or equal to 32 for now");       //@todo: remove this restriction later
 
-    th::Tensor group_scores = th::empty({num_tokens, n_group}, th::dtype(data_type).device(torch::kCUDA));
     th::Tensor topk_values = th::empty({num_tokens, topk}, th::dtype(data_type).device(torch::kCUDA));
     th::Tensor topk_indices = th::empty({num_tokens, topk}, th::dtype(torch::kInt32).device(torch::kCUDA));
     //@TODO check the data type of indices
 
-    auto stream = at::cuda::getCurrentCUDAStream(scores_with_bias.get_device());
+    auto stream = at::cuda::getCurrentCUDAStream(scores.get_device());
 
     switch (data_type)
     {
     case torch::kFloat16:
         // Handle Float16
-        tk::invokeNoAuxTc<half, int32_t>(reinterpret_cast<half*>(scores.mutable_data_ptr()),
-            reinterpret_cast<half*>(group_scores.mutable_data_ptr()),
-            reinterpret_cast<half*>(topk_values.mutable_data_ptr()),
-            reinterpret_cast<int32_t*>(topk_indices.mutable_data_ptr()),
-            reinterpret_cast<half*>(scores_with_bias.data_ptr()), num_tokens, num_experts, n_group, topk_group, topk,
-            routed_scaling_factor, stream);
+        switch (bias_type)
+        {
+        case torch::kFloat16:
+            tk::invokeNoAuxTc<half, half, half, int32_t>(reinterpret_cast<half*>(scores.mutable_data_ptr()),
+                reinterpret_cast<half*>(bias.mutable_data_ptr()),
+                reinterpret_cast<half*>(topk_values.mutable_data_ptr()),
+                reinterpret_cast<int32_t*>(topk_indices.mutable_data_ptr()), num_tokens, num_experts, n_group,
+                topk_group, topk, routed_scaling_factor, stream);
+            break;
+        case torch::kFloat32:
+            tk::invokeNoAuxTc<half, float, half, int32_t>(reinterpret_cast<half*>(scores.mutable_data_ptr()),
+                reinterpret_cast<float*>(bias.mutable_data_ptr()),
+                reinterpret_cast<half*>(topk_values.mutable_data_ptr()),
+                reinterpret_cast<int32_t*>(topk_indices.mutable_data_ptr()), num_tokens, num_experts, n_group,
+                topk_group, topk, routed_scaling_factor, stream);
+            break;
+        case torch::kBFloat16:
+            tk::invokeNoAuxTc<half, __nv_bfloat16, half, int32_t>(reinterpret_cast<half*>(scores.mutable_data_ptr()),
+                reinterpret_cast<__nv_bfloat16*>(bias.mutable_data_ptr()),
+                reinterpret_cast<half*>(topk_values.mutable_data_ptr()),
+                reinterpret_cast<int32_t*>(topk_indices.mutable_data_ptr()), num_tokens, num_experts, n_group,
+                topk_group, topk, routed_scaling_factor, stream);
+        default: throw std::invalid_argument("Invalid bias dtype, only supports float16, float32, and bfloat16"); break;
+        }
         break;
     case torch::kFloat32:
-        // Handle Float32
-        tk::invokeNoAuxTc<float, int32_t>(reinterpret_cast<float*>(scores.mutable_data_ptr()),
-            reinterpret_cast<float*>(group_scores.mutable_data_ptr()),
-            reinterpret_cast<float*>(topk_values.mutable_data_ptr()),
-            reinterpret_cast<int32_t*>(topk_indices.mutable_data_ptr()),
-            reinterpret_cast<float*>(scores_with_bias.data_ptr()), num_tokens, num_experts, n_group, topk_group, topk,
-            routed_scaling_factor, stream);
+        switch (bias_type)
+        {
+        case torch::kFloat32:
+            tk::invokeNoAuxTc<float, float, float, int32_t>(reinterpret_cast<float*>(scores.mutable_data_ptr()),
+                reinterpret_cast<float*>(bias.mutable_data_ptr()),
+                reinterpret_cast<float*>(topk_values.mutable_data_ptr()),
+                reinterpret_cast<int32_t*>(topk_indices.mutable_data_ptr()), num_tokens, num_experts, n_group,
+                topk_group, topk, routed_scaling_factor, stream);
+            break;
+        case torch::kFloat16:
+            tk::invokeNoAuxTc<float, half, float, int32_t>(reinterpret_cast<float*>(scores.mutable_data_ptr()),
+                reinterpret_cast<half*>(bias.mutable_data_ptr()),
+                reinterpret_cast<float*>(topk_values.mutable_data_ptr()),
+                reinterpret_cast<int32_t*>(topk_indices.mutable_data_ptr()), num_tokens, num_experts, n_group,
+                topk_group, topk, routed_scaling_factor, stream);
+            break;
+        case torch::kBFloat16:
+            tk::invokeNoAuxTc<float, __nv_bfloat16, float, int32_t>(reinterpret_cast<float*>(scores.mutable_data_ptr()),
+                reinterpret_cast<__nv_bfloat16*>(bias.mutable_data_ptr()),
+                reinterpret_cast<float*>(topk_values.mutable_data_ptr()),
+                reinterpret_cast<int32_t*>(topk_indices.mutable_data_ptr()), num_tokens, num_experts, n_group,
+                topk_group, topk, routed_scaling_factor, stream);
+            break;
+        default: throw std::invalid_argument("Invalid bias dtype, only supports float16, float32, and bfloat16"); break;
+        }
         break;
     case torch::kBFloat16:
         // Handle BFloat16
-        tk::invokeNoAuxTc<__nv_bfloat16, int32_t>(reinterpret_cast<__nv_bfloat16*>(scores.mutable_data_ptr()),
-            reinterpret_cast<__nv_bfloat16*>(group_scores.mutable_data_ptr()),
-            reinterpret_cast<__nv_bfloat16*>(topk_values.mutable_data_ptr()),
-            reinterpret_cast<int32_t*>(topk_indices.mutable_data_ptr()),
-            reinterpret_cast<__nv_bfloat16*>(scores_with_bias.data_ptr()), num_tokens, num_experts, n_group, topk_group,
-            topk, routed_scaling_factor, stream);
+        switch (bias_type)
+        {
+        case torch::kBFloat16:
+            tk::invokeNoAuxTc<__nv_bfloat16, __nv_bfloat16, __nv_bfloat16, int32_t>(
+                reinterpret_cast<__nv_bfloat16*>(scores.mutable_data_ptr()),
+                reinterpret_cast<__nv_bfloat16*>(bias.mutable_data_ptr()),
+                reinterpret_cast<__nv_bfloat16*>(topk_values.mutable_data_ptr()),
+                reinterpret_cast<int32_t*>(topk_indices.mutable_data_ptr()), num_tokens, num_experts, n_group,
+                topk_group, topk, routed_scaling_factor, stream);
+            break;
+        case torch::kFloat16:
+            tk::invokeNoAuxTc<__nv_bfloat16, half, __nv_bfloat16, int32_t>(
+                reinterpret_cast<__nv_bfloat16*>(scores.mutable_data_ptr()),
+                reinterpret_cast<half*>(bias.mutable_data_ptr()),
+                reinterpret_cast<__nv_bfloat16*>(topk_values.mutable_data_ptr()),
+                reinterpret_cast<int32_t*>(topk_indices.mutable_data_ptr()), num_tokens, num_experts, n_group,
+                topk_group, topk, routed_scaling_factor, stream);
+            break;
+        case torch::kFloat32:
+            tk::invokeNoAuxTc<__nv_bfloat16, float, __nv_bfloat16, int32_t>(
+                reinterpret_cast<__nv_bfloat16*>(scores.mutable_data_ptr()),
+                reinterpret_cast<float*>(bias.mutable_data_ptr()),
+                reinterpret_cast<__nv_bfloat16*>(topk_values.mutable_data_ptr()),
+                reinterpret_cast<int32_t*>(topk_indices.mutable_data_ptr()), num_tokens, num_experts, n_group,
+                topk_group, topk, routed_scaling_factor, stream);
+            break;
+        default: throw std::invalid_argument("Invalid bias dtype, only supports bfloat16, float16, and float32"); break;
+        }
         break;
     default:
         // Handle other data types
@@ -97,7 +160,7 @@ std::tuple<at::Tensor, at::Tensor> noaux_tc_op(th::Tensor const& scores, th::Ten
 TORCH_LIBRARY_FRAGMENT(trtllm, m)
 {
     m.def(
-        "noaux_tc_op(Tensor scores, Tensor scores_with_bias, int n_group, int topk_group, int topk, float "
+        "noaux_tc_op(Tensor scores, Tensor bias, int n_group, int topk_group, int topk, float "
         "routed_scaling_factor) -> (Tensor, Tensor)");
 }
 

--- a/cpp/tests/unit_tests/kernels/routing/routingDeepSeekTest.cpp
+++ b/cpp/tests/unit_tests/kernels/routing/routingDeepSeekTest.cpp
@@ -211,10 +211,43 @@ private:
 
 TYPED_TEST_SUITE(RoutingDeepSeekKernelTest, Bf16Types);
 
+TYPED_TEST(RoutingDeepSeekKernelTest, ClusterLevelParallelization32)
+{
+    RoutingKernelTestParam param(RoutingMethodType::DeepSeekV3, /*numTokens=*/4, // 1024
+        /*numExperts=*/32, /*topK=*/8,
+        /*expertParallelization=*/1, /*expertParallelizationId=*/0, /*tileTokensDim=*/256,
+        /*paddingLog2=*/3, /*localExpertsStrideLog2=*/0,
+        /*usePdl=*/true, /*getExpWeights=*/true, /*useTopKAsInput=*/false,
+        /*nGroup*/ 8, /*topkGroup*/ 4, /*routedScalingFactor*/ 1.0f, /*requiredComputeCapability*/ 9);
+    this->runTest(param);
+};
+
+TYPED_TEST(RoutingDeepSeekKernelTest, ClusterLevelParallelization72)
+{
+    RoutingKernelTestParam param(RoutingMethodType::DeepSeekV3, /*numTokens=*/4, // 1024
+        /*numExperts=*/72, /*topK=*/6,
+        /*expertParallelization=*/1, /*expertParallelizationId=*/0, /*tileTokensDim=*/256,
+        /*paddingLog2=*/3, /*localExpertsStrideLog2=*/0,
+        /*usePdl=*/true, /*getExpWeights=*/true, /*useTopKAsInput=*/false,
+        /*nGroup*/ 1, /*topkGroup*/ 1, /*routedScalingFactor*/ 1.0f, /*requiredComputeCapability*/ 9);
+    this->runTest(param);
+};
+
+TYPED_TEST(RoutingDeepSeekKernelTest, ClusterLevelParallelization384)
+{
+    RoutingKernelTestParam param(RoutingMethodType::DeepSeekV3, /*numTokens=*/4, // 1024
+        /*numExperts=*/384, /*topK=*/8,
+        /*expertParallelization=*/1, /*expertParallelizationId=*/0, /*tileTokensDim=*/256,
+        /*paddingLog2=*/3, /*localExpertsStrideLog2=*/0,
+        /*usePdl=*/true, /*getExpWeights=*/true, /*useTopKAsInput=*/false,
+        /*nGroup*/ 1, /*topkGroup*/ 1, /*routedScalingFactor*/ 1.0f, /*requiredComputeCapability*/ 9);
+    this->runTest(param);
+};
+
 TYPED_TEST(RoutingDeepSeekKernelTest, ClusterLevelParallelization)
 {
     RoutingKernelTestParam param(RoutingMethodType::DeepSeekV3, /*numTokens=*/1024, // 10
-        /*numExperts=*/128, /*topK=*/8,
+        /*numExperts=*/256, /*topK=*/8,
         /*expertParallelization=*/1, /*expertParallelizationId=*/0, /*tileTokensDim=*/256,
         /*paddingLog2=*/3, /*localExpertsStrideLog2=*/0,
         /*usePdl=*/true, /*getExpWeights=*/true, /*useTopKAsInput=*/false,
@@ -225,7 +258,7 @@ TYPED_TEST(RoutingDeepSeekKernelTest, ClusterLevelParallelization)
 TYPED_TEST(RoutingDeepSeekKernelTest, ClusterLevelParallelizationWithTopKAsInput)
 {
     RoutingKernelTestParam param(RoutingMethodType::DeepSeekV3, /*numTokens=*/1024, // 10
-        /*numExperts=*/128, /*topK=*/8,
+        /*numExperts=*/256, /*topK=*/8,
         /*expertParallelization=*/1, /*expertParallelizationId=*/0, /*tileTokensDim=*/192,
         /*paddingLog2=*/3, /*localExpertsStrideLog2=*/0,
         /*usePdl=*/true, /*getExpWeights=*/true, /*useTopKAsInput=*/true,
@@ -233,10 +266,21 @@ TYPED_TEST(RoutingDeepSeekKernelTest, ClusterLevelParallelizationWithTopKAsInput
     this->runTest(param);
 };
 
+TYPED_TEST(RoutingDeepSeekKernelTest, ClusterLevelParallelizationWithTopKAsInput384)
+{
+    RoutingKernelTestParam param(RoutingMethodType::DeepSeekV3, /*numTokens=*/1024, // 10
+        /*numExperts=*/384, /*topK=*/8,
+        /*expertParallelization=*/1, /*expertParallelizationId=*/0, /*tileTokensDim=*/256,
+        /*paddingLog2=*/3, /*localExpertsStrideLog2=*/0,
+        /*usePdl=*/true, /*getExpWeights=*/true, /*useTopKAsInput=*/true,
+        /*nGroup*/ 1, /*topkGroup*/ 1, /*routedScalingFactor*/ 1.0f, /*requiredComputeCapability*/ 9);
+    this->runTest(param);
+};
+
 TYPED_TEST(RoutingDeepSeekKernelTest, ClusterLevelParallelizationWithExpertParallelization)
 {
     RoutingKernelTestParam param(RoutingMethodType::DeepSeekV3, /*numTokens=*/100,
-        /*numExperts=*/128, /*topK=*/8,
+        /*numExperts=*/256, /*topK=*/8,
         /*expertParallelization=*/2, /*expertParallelizationId=*/1, /*tileTokensDim=*/192,
         /*paddingLog2=*/3, /*localExpertsStrideLog2=*/0,
         /*usePdl=*/true, /*getExpWeights=*/true, /*useTopKAsInput=*/false,
@@ -247,7 +291,7 @@ TYPED_TEST(RoutingDeepSeekKernelTest, ClusterLevelParallelizationWithExpertParal
 TYPED_TEST(RoutingDeepSeekKernelTest, CooperativeLevelParallelization)
 {
     RoutingKernelTestParam param(RoutingMethodType::DeepSeekV3, /*numTokens=*/1030,
-        /*numExperts=*/128, /*topK=*/8,
+        /*numExperts=*/256, /*topK=*/8,
         /*expertParallelization=*/1, /*expertParallelizationId=*/0, /*tileTokensDim=*/256,
         /*paddingLog2=*/3, /*localExpertsStrideLog2=*/0,
         /*usePdl=*/true, /*getExpWeights=*/true, /*useTopKAsInput=*/false,
@@ -255,21 +299,43 @@ TYPED_TEST(RoutingDeepSeekKernelTest, CooperativeLevelParallelization)
     this->runTest(param);
 };
 
+TYPED_TEST(RoutingDeepSeekKernelTest, CooperativeLevelParallelization384)
+{
+    RoutingKernelTestParam param(RoutingMethodType::DeepSeekV3, /*numTokens=*/1030,
+        /*numExperts=*/384, /*topK=*/8,
+        /*expertParallelization=*/1, /*expertParallelizationId=*/0, /*tileTokensDim=*/256,
+        /*paddingLog2=*/3, /*localExpertsStrideLog2=*/0,
+        /*usePdl=*/true, /*getExpWeights=*/true, /*useTopKAsInput=*/false,
+        /*nGroup*/ 1, /*topkGroup*/ 1, /*routedScalingFactor*/ 1.0f, /*requiredComputeCapability*/ 10);
+    this->runTest(param);
+};
+
 TYPED_TEST(RoutingDeepSeekKernelTest, DeviceLevelParallelization)
 {
     RoutingKernelTestParam param(RoutingMethodType::DeepSeekV3, /*numTokens=*/20300,
-        /*numExperts=*/128, /*topK=*/8,
-        /*expertParallelization=*/1, /*expertParallelizationId=*/0, /*tileTokensDim=*/192,
+        /*numExperts=*/256, /*topK=*/8,
+        /*expertParallelization=*/1, /*expertParallelizationId=*/0, /*tileTokensDim=*/256,
         /*paddingLog2=*/3, /*localExpertsStrideLog2=*/0,
         /*usePdl=*/true, /*getExpWeights=*/true, /*useTopKAsInput=*/false,
         /*nGroup*/ 8, /*topkGroup*/ 4, /*routedScalingFactor*/ 1.0f, /*requiredComputeCapability*/ 10);
     this->runTest(param);
 };
 
+TYPED_TEST(RoutingDeepSeekKernelTest, DeviceLevelParallelization384)
+{
+    RoutingKernelTestParam param(RoutingMethodType::DeepSeekV3, /*numTokens=*/20300,
+        /*numExperts=*/384, /*topK=*/8,
+        /*expertParallelization=*/1, /*expertParallelizationId=*/0, /*tileTokensDim=*/256,
+        /*paddingLog2=*/3, /*localExpertsStrideLog2=*/0,
+        /*usePdl=*/true, /*getExpWeights=*/true, /*useTopKAsInput=*/false,
+        /*nGroup*/ 1, /*topkGroup*/ 1, /*routedScalingFactor*/ 1.0f, /*requiredComputeCapability*/ 10);
+    this->runTest(param);
+};
+
 TYPED_TEST(RoutingDeepSeekKernelTest, ClusterLevelParallelizationTop2)
 {
     RoutingKernelTestParam param(RoutingMethodType::DeepSeekV3, /*numTokens=*/10,
-        /*numExperts=*/128, /*topK=*/2,
+        /*numExperts=*/256, /*topK=*/2,
         /*expertParallelization=*/1, /*expertParallelizationId=*/0, /*tileTokensDim=*/256,
         /*paddingLog2=*/3, /*localExpertsStrideLog2=*/0,
         /*usePdl=*/true, /*getExpWeights=*/true, /*useTopKAsInput=*/false,
@@ -280,7 +346,7 @@ TYPED_TEST(RoutingDeepSeekKernelTest, ClusterLevelParallelizationTop2)
 TYPED_TEST(RoutingDeepSeekKernelTest, ClusterLevelParallelizationWithExpertParallelizationTop2)
 {
     RoutingKernelTestParam param(RoutingMethodType::DeepSeekV3, /*numTokens=*/100,
-        /*numExperts=*/128, /*topK=*/2,
+        /*numExperts=*/256, /*topK=*/2,
         /*expertParallelization=*/2, /*expertParallelizationId=*/1, /*tileTokensDim=*/192,
         /*paddingLog2=*/3, /*localExpertsStrideLog2=*/0,
         /*usePdl=*/true, /*getExpWeights=*/true, /*useTopKAsInput=*/false,
@@ -291,12 +357,22 @@ TYPED_TEST(RoutingDeepSeekKernelTest, ClusterLevelParallelizationWithExpertParal
 TYPED_TEST(RoutingDeepSeekKernelTest, CooperativeLevelParallelizationTop2)
 {
     RoutingKernelTestParam param(RoutingMethodType::DeepSeekV3, /*numTokens=*/1030,
-        /*numExperts=*/128, /*topK=*/2,
+        /*numExperts=*/256, /*topK=*/2,
         /*expertParallelization=*/1, /*expertParallelizationId=*/0, /*tileTokensDim=*/256,
         /*paddingLog2=*/3, /*localExpertsStrideLog2=*/0,
-        /*usePdl=*/true, /*getExpWeights=*/true, /*useTopKExpertsAsInput=*/false,
+        /*usePdl=*/true, /*getExpWeights=*/true, /*useTopKAsInput=*/false,
         /*nGroup*/ 8, /*topkGroup*/ 4, /*routedScalingFactor*/ 1.0f, /*requiredComputeCapability*/ 10);
     this->runTest(param);
 };
 
+TYPED_TEST(RoutingDeepSeekKernelTest, CooperativeLevelParallelizationTop8)
+{
+    RoutingKernelTestParam param(RoutingMethodType::DeepSeekV3, /*numTokens=*/1030,
+        /*numExperts=*/32, /*topK=*/8,
+        /*expertParallelization=*/1, /*expertParallelizationId=*/0, /*tileTokensDim=*/256,
+        /*paddingLog2=*/3, /*localExpertsStrideLog2=*/0,
+        /*usePdl=*/true, /*getExpWeights=*/true, /*useTopKAsInput=*/false,
+        /*nGroup*/ 8, /*topkGroup*/ 4, /*routedScalingFactor*/ 1.0f, /*requiredComputeCapability*/ 10);
+    this->runTest(param);
+};
 } // namespace

--- a/cpp/tests/unit_tests/kernels/routing/routingRenormalizeTest.cpp
+++ b/cpp/tests/unit_tests/kernels/routing/routingRenormalizeTest.cpp
@@ -240,7 +240,7 @@ TYPED_TEST(RoutingRenormalizeKernelTest, ClusterLevelParallelizationWithRenormal
 {
     RoutingKernelTestParam param(RoutingMethodType::RenormalizeNaive, /*numTokens=*/10,
         /*numExperts=*/128, /*topK=*/8,
-        /*expertParallelization=*/1, /*expertParallelizationId=*/0, /*tileTokensDim=*/8,
+        /*expertParallelization=*/1, /*expertParallelizationId=*/0, /*tileTokensDim=*/256,
         /*paddingLog2=*/3, /*localExpertsStrideLog2=*/0,
         /*usePdl=*/true, /*getExpWeights=*/true, /*useTopKAsInput=*/false,
         /*nGroup*/ 0, /*topkGroup*/ 0, /*routedScalingFactor*/ 1.0f, /*requiredComputeCapability*/ 9);
@@ -295,9 +295,42 @@ TYPED_TEST(RoutingRenormalizeKernelTest, DeviceLevelParallelizationTop4)
 {
     RoutingKernelTestParam param(RoutingMethodType::Renormalize, /*numTokens=*/1000,
         /*numExperts=*/128, /*topK=*/4,
-        /*expertParallelization=*/1, /*expertParallelizationId=*/0, /*tileTokensDim=*/8,
+        /*expertParallelization=*/1, /*expertParallelizationId=*/0, /*tileTokensDim=*/256,
         /*paddingLog2=*/3, /*localExpertsStrideLog2=*/0,
         /*usePdl=*/true, /*getExpWeights=*/true, /*useTopKAsInput=*/true,
+        /*nGroup*/ 0, /*topkGroup*/ 0, /*routedScalingFactor*/ 1.0f, /*requiredComputeCapability*/ 8);
+    this->runTest(param);
+};
+
+TYPED_TEST(RoutingRenormalizeKernelTest, BlockLevelParallelizationLargeN)
+{
+    RoutingKernelTestParam param(RoutingMethodType::Renormalize, /*numTokens=*/4,
+        /*numExperts=*/512, /*topK=*/10,
+        /*expertParallelization=*/1, /*expertParallelizationId=*/0, /*tileTokensDim=*/256,
+        /*paddingLog2=*/3, /*localExpertsStrideLog2=*/0,
+        /*usePdl=*/true, /*getExpWeights=*/true, /*useTopKAsInput=*/false,
+        /*nGroup*/ 0, /*topkGroup*/ 0, /*routedScalingFactor*/ 1.0f, /*requiredComputeCapability*/ 9);
+    this->runTest(param);
+};
+
+TYPED_TEST(RoutingRenormalizeKernelTest, ClusterLevelParallelizationLargeN)
+{
+    RoutingKernelTestParam param(RoutingMethodType::Renormalize, /*numTokens=*/100,
+        /*numExperts=*/512, /*topK=*/10,
+        /*expertParallelization=*/1, /*expertParallelizationId=*/0, /*tileTokensDim=*/256,
+        /*paddingLog2=*/3, /*localExpertsStrideLog2=*/0,
+        /*usePdl=*/true, /*getExpWeights=*/true, /*useTopKAsInput=*/false,
+        /*nGroup*/ 0, /*topkGroup*/ 0, /*routedScalingFactor*/ 1.0f, /*requiredComputeCapability*/ 9);
+    this->runTest(param);
+};
+
+TYPED_TEST(RoutingRenormalizeKernelTest, DeviceLevelParallelizationLargeN)
+{
+    RoutingKernelTestParam param(RoutingMethodType::Renormalize, /*numTokens=*/1000,
+        /*numExperts=*/512, /*topK=*/10,
+        /*expertParallelization=*/1, /*expertParallelizationId=*/0, /*tileTokensDim=*/256,
+        /*paddingLog2=*/3, /*localExpertsStrideLog2=*/0,
+        /*usePdl=*/true, /*getExpWeights=*/true, /*useTopKAsInput=*/false,
         /*nGroup*/ 0, /*topkGroup*/ 0, /*routedScalingFactor*/ 1.0f, /*requiredComputeCapability*/ 8);
     this->runTest(param);
 };

--- a/tests/unittest/_torch/thop/parallel/test_noaux_tc.py
+++ b/tests/unittest/_torch/thop/parallel/test_noaux_tc.py
@@ -8,8 +8,7 @@ from tensorrt_llm._torch.models.modeling_deepseekv3 import DeepseekV3Gate
 @pytest.mark.parametrize("num_experts, n_group, topk_group, top_k", [
     (256, 8, 4, 8),
     (72, 1, 1, 6),
-    (128, 16, 7, 9),
-    (1024, 32, 10, 23),
+    (384, 1, 1, 8),
 ])
 @pytest.mark.parametrize("dtype",
                          [torch.float16, torch.bfloat16, torch.float32])


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Expanded MoE routing to support top-k up to 10 and up to 512 experts.
  - Configurable per-kernel maximum experts with improved group-aware top-k selection.
  - Enhanced routing variants for DeepSeek V3 and Llama 4 scenarios.
- Performance
  - Reworked kernels and reductions for faster, more scalable top-k routing and normalization.
  - Conditional fuse gating in DeepSeek V3 to optimize routing based on runtime shapes.
- Refactor
  - Updated routing API to use bias instead of prior auxiliary inputs; streamlined launch paths.
- Tests
  - Added extensive unit tests covering larger expert counts, top-k=10, and new routing paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Optimize the routing kernel for DeepseekV3 (MoE CUTLASS backend); Add support for KIMI K2 and Qwen-next (MoE TRTLLM backend)

We fused the PyTorch OPs for the routing part of Deepseel V3, and now we optimize its performance like what we have done for the MoE TRTLLM backend. 

Also add support for KIMI K2 and Qwen-next (MoE TRTLLM backend)

## Test Coverage

> pytest -s tests/unittest/_torch/thop/parallel/test_noaux_tc.py
> pytest -v -s tests/unittest/_torch/thop/parallel/test_moe.py

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
