### PR TITLE
[None][AutoDeploy] Add the triton ref for Bamba custom ops

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -274,6 +274,7 @@ class SequenceInfo:
             if self.max_batch_size > 1:
                 bs_seq_len_shape[0] = Dim("batch_size", max=self.max_batch_size)
             bs_seq_len_shape[1] = Dim("seq_len", max=self.max_seq_len)
+            # bs_seq_len_shape[1] = Dim.AUTO
             self._dynamic_shapes = {k: bs_seq_len_shape for k in self._uncached_arg_names}
             # cached args are static
             self._dynamic_shapes.update({k: {} for k in self._cached_arg_names})

--- a/tensorrt_llm/_torch/auto_deploy/models/hf.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/hf.py
@@ -115,14 +115,18 @@ class AutoModelForCausalLMFactory(ModelFactory):
         return AutoModelForCausalLM.from_config
 
     @staticmethod
-    def _simple_forward(model: nn.Module, input_ids: torch.Tensor, position_ids: torch.Tensor):
+    def _simple_forward(
+        model: nn.Module, input_ids: torch.Tensor, position_ids: torch.Tensor, *args, **kwargs
+    ):
         """A simple forward pass for the model to functionalize the args.
 
         This follows the standard function signature as expected by factory.py. We do _not_ use the
         model.forward method directly to create the patch. Instead we use the type of the model to
         get the forward method to keep the patch composable with other forward patches.
         """
-        return type(model).forward(model, input_ids=input_ids, position_ids=position_ids)
+        return type(model).forward(
+            model, input_ids=input_ids, position_ids=position_ids, *args, **kwargs
+        )
 
     def _recursive_update_config(self, config: PretrainedConfig, update_dict: Dict[str, Any]):
         """

--- a/tensorrt_llm/_torch/auto_deploy/models/patches/bamba.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/patches/bamba.py
@@ -1,0 +1,429 @@
+"""A patch for the Bamba model to make it compatible with torch.export."""
+
+from typing import List, Optional, Tuple
+
+import torch
+from torch import nn
+from transformers.models.bamba.modeling_bamba import (
+    BambaMixer,
+    BambaModel,
+    HybridMambaAttentionDynamicCache,
+    apply_mask_to_padding_states,
+    pad_tensor_by_size,
+    reshape_into_chunks,
+    segment_sum,
+)
+
+from ...export.interface import BaseExportPatch, ExportPatchRegistry
+
+
+# Original implementation:
+# https://github.com/huggingface/transformers/blob/06f8004e5cd9d06cfbffc3f47afb6c2b43bcb3d2/
+# src/transformers/models/bamba/modeling_bamba.py#L719
+# NOTE: we remove the cache-related code paths.
+def _bamba_mixer_torch_forward(
+    self,
+    input_states,
+    cache_params: Optional[HybridMambaAttentionDynamicCache] = None,
+    cache_position: Optional[torch.LongTensor] = None,
+    attention_mask: Optional[torch.Tensor] = None,
+):
+    # `input_states` is of shape `[B, T, hidden_dim]`, and during generate, each successive call
+    # will have T = T + 1.
+    batch_size, seq_len, _ = input_states.shape
+    dtype = input_states.dtype
+
+    # 1. Gated MLP's linear projection
+    input_states = apply_mask_to_padding_states(input_states, attention_mask)
+    projected_states = self.in_proj(input_states)
+    gate, hidden_states_B_C, dt = projected_states.split(
+        [self.intermediate_size, self.conv_dim, self.num_heads], dim=-1
+    )
+
+    use_precomputed_states = (
+        cache_params is not None
+        and cache_params.has_previous_state
+        and seq_len == 1
+        and cache_params.conv_states[self.layer_idx].shape[0]
+        == cache_params.ssm_states[self.layer_idx].shape[0]
+        == batch_size
+        and cache_position is not None
+        and cache_position[0] > 0
+    )
+
+    # 2. Convolution sequence transformation
+    if use_precomputed_states:
+        cache_params.conv_states[self.layer_idx] = cache_params.conv_states[self.layer_idx].roll(
+            shifts=-1, dims=-1
+        )
+        cache_params.conv_states[self.layer_idx][:, :, -1] = hidden_states_B_C[:, 0, :].to(
+            cache_params.conv_states[self.layer_idx].device
+        )
+
+        # We need to guarantee that anything regarding the cache is on the same device
+        conv_states = cache_params.conv_states[self.layer_idx].to(device=self.conv1d.weight.device)
+
+        hidden_states_B_C = torch.sum(conv_states * self.conv1d.weight.squeeze(1), dim=-1)
+        if self.use_conv_bias:
+            hidden_states_B_C = hidden_states_B_C + self.conv1d.bias
+        hidden_states_B_C = self.act(hidden_states_B_C)
+    else:
+        # Init cache
+        if cache_params is not None:
+            hidden_states_B_C_transposed = hidden_states_B_C.transpose(1, 2)
+            conv_states = nn.functional.pad(
+                hidden_states_B_C_transposed,
+                (self.conv_kernel_size - hidden_states_B_C_transposed.shape[-1], 0),
+            )
+            cache_params.conv_states[self.layer_idx].copy_(conv_states)
+
+        hidden_states_B_C = self.act(
+            self.conv1d(hidden_states_B_C.transpose(1, 2))[..., :seq_len].transpose(1, 2)
+        )
+
+    hidden_states_B_C = apply_mask_to_padding_states(hidden_states_B_C, attention_mask)
+    hidden_states, B, C = torch.split(
+        hidden_states_B_C,
+        [
+            self.intermediate_size,
+            self.n_groups * self.ssm_state_size,
+            self.n_groups * self.ssm_state_size,
+        ],
+        dim=-1,
+    )
+
+    # 3. SSM transformation
+    A = -torch.exp(self.A_log.float())  # [num_heads]
+    if use_precomputed_states:
+        y, ssm_state = torch.ops.auto_deploy.ssm_transform_cached(
+            hidden_states=hidden_states,
+            A=A,
+            B=B,
+            C=C,
+            D=self.D,
+            dt=dt,
+            dt_bias=self.dt_bias,
+            ssm_state_size=self.ssm_state_size,
+            time_step_limit=list(self.time_step_limit),
+            batch_size=batch_size,
+            seq_len=seq_len,
+            head_dim=self.head_dim,
+            num_heads=self.num_heads,
+            n_groups=self.n_groups,
+            chunk_size=self.chunk_size,
+            cached_ssm_state=cache_params.ssm_states[self.layer_idx],
+        )
+    else:
+        y, ssm_state = torch.ops.auto_deploy.ssm_transform(
+            hidden_states=hidden_states,
+            A=A,
+            B=B,
+            C=C,
+            D=self.D,
+            dt=dt,
+            dt_bias=self.dt_bias,
+            ssm_state_size=self.ssm_state_size,
+            time_step_limit=list(self.time_step_limit),
+            batch_size=batch_size,
+            seq_len=seq_len,
+            head_dim=self.head_dim,
+            num_heads=self.num_heads,
+            n_groups=self.n_groups,
+            chunk_size=self.chunk_size,
+        )
+
+    # Init cache
+    if ssm_state is not None and cache_params is not None:
+        cache_params.ssm_states[self.layer_idx].copy_(ssm_state)
+
+    scan_output = self.norm(y, gate)
+
+    # end ssd naive
+    # !! This is the end of the uncached code path.
+
+    # 4. Final linear projection
+    contextualized_states = self.out_proj(scan_output.to(dtype))  # [batch, seq_len, hidden_size]
+    return contextualized_states
+
+
+# The original implementation looks at `cache_position[0]` to decide what to do which does not
+# play well with export. Plus, we do not want it to be updated anyway.
+def _bamba_model_update_mamba_mask(self, attention_mask, cache_position):
+    return None
+
+
+@torch.library.custom_op("auto_deploy::ssm_transform", mutates_args={})
+def _ssm_transform(
+    hidden_states: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    D: torch.Tensor,
+    dt: torch.Tensor,
+    dt_bias: torch.Tensor,
+    ssm_state_size: int,
+    # NOTE: `torch` custom ops do not like `Tuple` inputs. Using `List` is the suggested WAR.
+    time_step_limit: List[float],
+    batch_size: int,
+    seq_len: int,
+    head_dim: int,
+    num_heads: int,
+    n_groups: int,
+    chunk_size: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    # !! This is the uncached code path from the original implementation.
+    # begin ssd naive implementation without einsums
+    dt = nn.functional.softplus(dt + dt_bias)
+    dt = torch.clamp(dt, time_step_limit[0], time_step_limit[1])
+    hidden_states = hidden_states.reshape(batch_size, seq_len, -1, head_dim).float()
+    B = B.reshape(batch_size, seq_len, -1, ssm_state_size).float()
+    C = C.reshape(batch_size, seq_len, -1, ssm_state_size).float()
+    B = B.repeat_interleave(num_heads // n_groups, dim=2, output_size=num_heads)
+    C = C.repeat_interleave(num_heads // n_groups, dim=2, output_size=num_heads)
+    pad_size = (chunk_size - seq_len % chunk_size) % chunk_size
+
+    D_residual = D[..., None] * pad_tensor_by_size(hidden_states, pad_size)
+
+    # Discretize x and A
+    hidden_states = hidden_states * dt[..., None]
+    A = A.to(hidden_states.dtype) * dt
+
+    # Rearrange into blocks/chunks
+    hidden_states, A, B, C = [
+        reshape_into_chunks(t, pad_size, chunk_size) for t in (hidden_states, A, B, C)
+    ]
+
+    # [bsz, -1, chunk_size, num_heads] -> [bsz, num_heads, -1, chunk_size]
+    A = A.permute(0, 3, 1, 2)
+    A_cumsum = torch.cumsum(A, dim=-1)
+
+    # 1. Compute the output for each intra-chunk (diagonal blocks)
+    # This is the analog of a causal mask
+    L = torch.exp(segment_sum(A))
+
+    # Contraction of C and B to get G (attention-weights like)
+    G_intermediate = C[:, :, :, None, :, :] * B[:, :, None, :, :, :]  # shape: (b, c, l, s, h, n)
+    G = G_intermediate.sum(dim=-1)  # shape: (b, c, l, s, h)
+
+    # Compute M, equivalent to applying attention mask to weights
+    M_intermediate = G[..., None] * L.permute(0, 2, 3, 4, 1)[..., None]
+    M = M_intermediate.sum(dim=-1)
+
+    # Compute Y_diag (apply to values)
+    Y_diag = (M[..., None] * hidden_states[:, :, None]).sum(dim=3)
+
+    # 2. Compute the state for each intra-chunk
+    # (right term of low-rank factorization of off-diagonal blocks; B terms)
+    decay_states = torch.exp(A_cumsum[:, :, :, -1:] - A_cumsum)
+    B_decay = B * decay_states.permute(0, -2, -1, 1)[..., None]
+    states = (B_decay[..., None, :] * hidden_states[..., None]).sum(dim=2)
+
+    # 3. Compute the inter-chunk SSM recurrence; produces correct SSM states at chunk boundaries
+    # (middle term of factorization of off-diag blocks; A terms)
+    previous_states = torch.zeros_like(states[:, :1])
+    states = torch.cat([previous_states, states], dim=1)
+    decay_chunk = torch.exp(segment_sum(nn.functional.pad(A_cumsum[:, :, :, -1], (1, 0))))
+    decay_chunk = decay_chunk.transpose(1, 3)
+    new_states = (decay_chunk[..., None, None] * states[:, :, None, ...]).sum(dim=1)
+    states, ssm_state = new_states[:, :-1], new_states[:, -1]
+    # states = new_states[:, :-1]
+
+    # 4. Compute state -> output conversion per chunk
+    # (left term of low-rank factorization of off-diagonal blocks; C terms)
+    state_decay_out = torch.exp(A_cumsum)
+    C_times_states = C[..., None, :] * states[:, :, None, ...]
+    state_decay_out_permuted = state_decay_out.permute(0, 2, 3, 1)
+    Y_off = C_times_states.sum(-1) * state_decay_out_permuted[..., None]
+
+    # Add output of intra-chunk and inter-chunk terms (diagonal and off-diagonal blocks)
+    y = Y_diag + Y_off
+    # [bsz, -1, self.chunk_size, num_heads, head_dim] -> [bsz, (padded) seq_len, num_heads, head_dim]
+    y = y.reshape(batch_size, -1, num_heads, head_dim)
+
+    y = y + D_residual
+    # Cutting off padded chunks
+    if pad_size > 0:
+        y = y[:, :seq_len, :, :]
+    y = y.reshape(batch_size, seq_len, -1)
+
+    return y, ssm_state
+
+
+@_ssm_transform.register_fake
+def _ssm_transform_meta(
+    hidden_states: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    D: torch.Tensor,
+    dt: torch.Tensor,
+    dt_bias: torch.Tensor,
+    ssm_state_size: int,
+    # NOTE: `torch` custom ops do not like `Tuple` inputs. Using `List` is the suggested WAR.
+    time_step_limit: List[float],
+    batch_size: int,
+    seq_len: int,
+    head_dim: int,
+    num_heads: int,
+    n_groups: int,
+    chunk_size: int,
+):
+    return (
+        torch.empty_like(hidden_states),
+        torch.empty(batch_size, num_heads, head_dim, ssm_state_size, dtype=hidden_states.dtype),
+    )
+
+
+@torch.library.custom_op("auto_deploy::ssm_transform_cached", mutates_args={})
+def _ssm_transform_cached(
+    hidden_states: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    D: torch.Tensor,
+    dt: torch.Tensor,
+    dt_bias: torch.Tensor,
+    ssm_state_size: int,
+    # NOTE: `torch` custom ops do not like `Tuple` inputs. Using `List` is the suggested WAR.
+    time_step_limit: List[float],
+    batch_size: int,
+    seq_len: int,
+    head_dim: int,
+    num_heads: int,
+    n_groups: int,
+    chunk_size: int,
+    cached_ssm_state: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    # We need to guarantee that anything regarding the cache is on the same device
+    cache_device = cached_ssm_state.device
+
+    # Note: there is no need to pad parameter matrices here, as there is just one new token
+    # for batched generation
+    dt = dt[:, 0, :][:, None, ...]
+    dt = dt.transpose(1, 2).expand(batch_size, dt.shape[-1], head_dim)
+    # [num_heads] -> [num_heads, head_dim]
+    dt_bias = dt_bias[..., None].expand(dt_bias.shape[0], head_dim)
+
+    dt = torch.nn.functional.softplus(dt + dt_bias.to(dt.dtype))
+    dt = torch.clamp(dt, time_step_limit[0], time_step_limit[1])
+    A = A[..., None, None].expand(num_heads, head_dim, ssm_state_size).to(dtype=torch.float32)
+    # [bsz, num_heads, head_dim, state_size]
+    dA = (torch.exp(dt[..., None] * A)).to(device=cache_device)
+
+    # Discretize B
+    # [bsz, n_groups * state_size] -> [bsz, n_groups, 1, state_size] ->
+    # -> [bsz, n_groups, group to head repetition factor, state_size] -> [bsz, num_heads, state_size]
+    B = B.reshape(batch_size, n_groups, -1)[..., None, :]
+    B = B.expand(batch_size, n_groups, num_heads // n_groups, B.shape[-1]).contiguous()
+    B = B.reshape(batch_size, -1, B.shape[-1])
+    # [bsz, num_heads, head_dim, state_size]
+    dB = dt[..., None] * B[..., None, :]
+
+    # Discretize x into dB
+    # [bsz, intermediate_size] -> [bsz, num_heads, head_dim]
+    hidden_states = hidden_states.reshape(batch_size, -1, head_dim)
+    dBx = (dB * hidden_states[..., None]).to(device=cache_device)
+
+    # State calculation
+    # cached_ssm_state.copy_(cached_ssm_state * dA + dBx)
+    cached_ssm_state = cached_ssm_state * dA + dBx
+
+    # Subsequent output
+    # [bsz, n_groups * state_size] -> [bsz, num_heads, state_size]
+    C = C.reshape(batch_size, n_groups, -1)[..., None, :]
+    C = C.expand(batch_size, n_groups, num_heads // n_groups, C.shape[-1]).contiguous()
+    C = C.reshape(batch_size, -1, C.shape[-1])
+    # [bsz, num_heads, head_dim]
+
+    ssm_states = cached_ssm_state.to(device=C.device, dtype=C.dtype)  # Shape: [b, h, d, n]
+    # Reshape ssm_states to merge the first two dimensions
+    ssm_states_reshaped = ssm_states.view(
+        batch_size * num_heads, head_dim, ssm_state_size
+    )  # Shape: [b*h, d, n]
+    C_reshaped = C.view(batch_size * num_heads, ssm_state_size, 1)  # Shape: [b*h, n, 1]
+    y = torch.bmm(ssm_states_reshaped, C_reshaped)
+    y = y.view(batch_size, num_heads, head_dim)
+
+    # D skip connection
+    # [num_heads] -> [num_heads, head_dim]
+    D = D[..., None].expand(D.shape[0], head_dim)
+    y = (y + hidden_states * D).to(y.dtype)
+
+    # [bsz, num_heads, head_dim] -> [bsz, 1, intermediate_size]
+    y = y.reshape(batch_size, -1)[:, None, ...]
+    return y, cached_ssm_state
+
+
+@_ssm_transform_cached.register_fake
+def _ssm_transform_meta(
+    hidden_states: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    D: torch.Tensor,
+    dt: torch.Tensor,
+    dt_bias: torch.Tensor,
+    ssm_state_size: int,
+    # NOTE: `torch` custom ops do not like `Tuple` inputs. Using `List` is the suggested WAR.
+    time_step_limit: List[float],
+    batch_size: int,
+    seq_len: int,
+    head_dim: int,
+    num_heads: int,
+    n_groups: int,
+    chunk_size: int,
+    cached_ssm_state: torch.Tensor,
+):
+    return (
+        torch.empty_like(hidden_states),
+        torch.empty(batch_size, num_heads, head_dim, ssm_state_size, dtype=hidden_states.dtype),
+    )
+
+
+# NOTE: this would need to be applied earlier than other patches, since the `_init_weights` (which
+# is called by `post_init`) is called before we run `forward`.
+def _bamba_pretrained_model_init_weights(self, module):
+    # ARGH python does not like this.
+    super()._init_weights(module)
+    if isinstance(module, BambaMixer):
+        module.dt_bias.data.fill_(1.0)
+        # ? Why is this even necessary? `BambaMixer.__init__` already sets
+        # A = torch.arange(1, self.num_heads + 1)
+        # self.A_log = nn.Parameter(torch.log(A))
+        # module.A_log.data = torch.log(torch.arange(1, module.num_heads + 1))
+        module.D.data.fill_(1.0)
+
+
+def _cache_bool(self) -> bool:
+    # This is a workaround for the bug on this line:
+    # https://github.com/huggingface/transformers/blob/v4.55.0/src/transformers/models/bamba/modeling_bamba.py#L1211
+    # The base `Cache` class from which `HybridMambaAttentionDynamicCache` inherits has a `__len__`
+    # special method implement that returns `False` when the instance is initialized, but stores no
+    # cache.
+    # The original line should really be checking for `if past_key_values is not None` but adding
+    # a patch for `BambaModel.forward` just for that reason seems overly intrusive.
+    return True
+
+
+@ExportPatchRegistry.register("bamba")
+class BambaModelPatch(BaseExportPatch):
+    """Patch for `BambaMixer`."""
+
+    def _apply_patch(self):
+        self.original_values["BambaMixer.torch_forward"] = BambaMixer.torch_forward
+        self.original_values["BambaModel._update_mamba_mask"] = BambaModel._update_mamba_mask
+        # NOTE: there is `HybridMambaAttentionDynamicCache.__bool__` to save.
+        # self.original_values["BambaPreTrainedModel._init_weights"] = BambaPreTrainedModel._init_weights
+
+        BambaMixer.torch_forward = _bamba_mixer_torch_forward
+        BambaModel._update_mamba_mask = _bamba_model_update_mamba_mask
+        HybridMambaAttentionDynamicCache.__bool__ = _cache_bool
+        # BambaPreTrainedModel._init_weights = _bamba_pretrained_model_init_weights
+
+    def _revert_patch(self):
+        BambaMixer.torch_forward = self.original_values["BambaMixer.torch_forward"]
+        BambaModel._update_mamba_mask = self.original_values["BambaModel._update_mamba_mask"]
+        del HybridMambaAttentionDynamicCache.__bool__
+        # BambaPreTrainedModel._init_weights = self.original_values[
+        #     "BambaPreTrainedModel._init_weights"
+        # ]

--- a/tensorrt_llm/_torch/custom_ops/auto_deploy_bamba_triton_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/auto_deploy_bamba_triton_ops.py
@@ -1,0 +1,189 @@
+"""Triton-backed custom ops for Bamba SSM transforms.
+
+These ops mirror the signatures of the original torch reference ops defined in
+`tensorrt_llm._torch.auto_deploy.models.patches.bamba` but dispatch to fast Triton
+implementations from the Mamba Triton modules (`ssd_combined` and `selective_state_update`).
+"""
+
+from typing import List, Tuple
+
+import torch
+
+from tensorrt_llm._torch.modules.mamba.selective_state_update import \
+    selective_state_update
+from tensorrt_llm._torch.modules.mamba.ssd_combined import \
+    mamba_chunk_scan_combined
+
+
+@torch.library.custom_op("auto_deploy::ssm_transform_triton", mutates_args={})
+def ssm_transform_triton(
+    hidden_states: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    D: torch.Tensor,
+    dt: torch.Tensor,
+    dt_bias: torch.Tensor,
+    ssm_state_size: int,
+    # NOTE: `torch` custom ops do not like `Tuple` inputs. Using `List` is the suggested WAR.
+    time_step_limit: List[float],
+    batch_size: int,
+    seq_len: int,
+    head_dim: int,
+    num_heads: int,
+    n_groups: int,
+    chunk_size: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Triton implementation of uncached SSM transform.
+
+    Shapes:
+      - hidden_states: [batch_size, seq_len, num_heads * head_dim]
+      - dt: [batch_size, seq_len, num_heads]
+      - A: [num_heads]
+      - B, C: [batch_size, seq_len, n_groups * ssm_state_size]
+      - D: [num_heads]
+    Returns:
+      - y: [batch_size, seq_len, num_heads * head_dim]
+      - final_states: [batch_size, num_heads, head_dim, ssm_state_size]
+    """
+    # Prepare tensors
+    x = hidden_states.reshape(batch_size, seq_len, num_heads, head_dim)
+    B4 = B.reshape(batch_size, seq_len, n_groups, ssm_state_size)
+    C4 = C.reshape(batch_size, seq_len, n_groups, ssm_state_size)
+
+    # Call combined Triton kernel
+    out, final_states = mamba_chunk_scan_combined(
+        x,
+        dt,
+        A,
+        B4,
+        C4,
+        chunk_size=chunk_size,
+        D=D,  # accepts [num_heads] or [num_heads, head_dim]
+        z=None,
+        dt_bias=dt_bias,
+        seq_idx=None,
+        dt_softplus=True,
+        dt_limit=(time_step_limit[0], time_step_limit[1]),
+        return_final_states=True,
+    )
+
+    y = out.reshape(batch_size, seq_len, num_heads * head_dim)
+    # Ensure dtype matches reference op expectations
+    y = y.to(hidden_states.dtype)
+    final_states = final_states.to(hidden_states.dtype)
+    return y, final_states
+
+
+@ssm_transform_triton.register_fake
+def _(
+    hidden_states: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    D: torch.Tensor,
+    dt: torch.Tensor,
+    dt_bias: torch.Tensor,
+    ssm_state_size: int,
+    time_step_limit: List[float],
+    batch_size: int,
+    seq_len: int,
+    head_dim: int,
+    num_heads: int,
+    n_groups: int,
+    chunk_size: int,
+):
+    y_shape = (batch_size, seq_len, num_heads * head_dim)
+    state_shape = (batch_size, num_heads, head_dim, ssm_state_size)
+    return hidden_states.new_empty(y_shape), hidden_states.new_empty(
+        state_shape)
+
+
+@torch.library.custom_op("auto_deploy::ssm_transform_cached_triton",
+                         mutates_args={})
+def ssm_transform_cached_triton(
+    hidden_states: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    D: torch.Tensor,
+    dt: torch.Tensor,
+    dt_bias: torch.Tensor,
+    ssm_state_size: int,
+    # NOTE: `torch` custom ops do not like `Tuple` inputs. Using `List` is the suggested WAR.
+    time_step_limit: List[float],
+    batch_size: int,
+    seq_len: int,
+    head_dim: int,
+    num_heads: int,
+    n_groups: int,
+    chunk_size: int,
+    cached_ssm_state: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Triton implementation of cached SSM transform (single-token update).
+
+    Shapes:
+      - hidden_states: [batch_size, num_heads * head_dim]
+      - dt: [batch_size, 1, num_heads]
+      - A: [num_heads]
+      - B, C: [batch_size, n_groups * ssm_state_size]
+      - D: [num_heads]
+      - cached_ssm_state: [batch_size, num_heads, head_dim, ssm_state_size]
+    Returns:
+      - y: [batch_size, 1, num_heads * head_dim]
+      - new_state: [batch_size, num_heads, head_dim, ssm_state_size]
+    """
+    # Expand per-head per-dim parameters
+    dt_hp = dt[:, 0, :][:, :, None].expand(batch_size, num_heads, head_dim)
+    dt_bias_hp = dt_bias[..., None].expand(num_heads, head_dim)
+    A_full = A[..., None, None].expand(num_heads, head_dim, ssm_state_size)
+    D_full = D[..., None].expand(num_heads, head_dim)
+
+    B_grouped = B.reshape(batch_size, n_groups, ssm_state_size)
+    C_grouped = C.reshape(batch_size, n_groups, ssm_state_size)
+
+    x = hidden_states.reshape(batch_size, num_heads, head_dim)
+    # compute new state; avoid mutating input cache
+    new_state = cached_ssm_state.clone()
+    y_hp = selective_state_update(
+        new_state,
+        x,
+        dt_hp,
+        A_full,
+        B_grouped,
+        C_grouped,
+        D=D_full,
+        z=None,
+        dt_bias=dt_bias_hp,
+        dt_softplus=True,
+    )
+    y = y_hp.reshape(batch_size, -1)[:, None, ...]
+    # Ensure dtype matches reference op expectations
+    y = y.to(hidden_states.dtype)
+    new_state = new_state.to(hidden_states.dtype)
+    return y, new_state
+
+
+@ssm_transform_cached_triton.register_fake
+def _(
+    hidden_states: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    D: torch.Tensor,
+    dt: torch.Tensor,
+    dt_bias: torch.Tensor,
+    ssm_state_size: int,
+    time_step_limit: List[float],
+    batch_size: int,
+    seq_len: int,
+    head_dim: int,
+    num_heads: int,
+    n_groups: int,
+    chunk_size: int,
+    cached_ssm_state: torch.Tensor,
+):
+    y_shape = (batch_size, 1, num_heads * head_dim)
+    state_shape = (batch_size, num_heads, head_dim, ssm_state_size)
+    return hidden_states.new_empty(y_shape), hidden_states.new_empty(
+        state_shape)

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_bamba_triton_ops.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_bamba_triton_ops.py
@@ -1,0 +1,108 @@
+import pytest
+import torch
+
+# Import the reference torch custom ops from the existing patch module
+from tensorrt_llm._torch.auto_deploy.models.patches.bamba import _ssm_transform as ssm_transform_ref
+from tensorrt_llm._torch.auto_deploy.models.patches.bamba import (
+    _ssm_transform_cached as ssm_transform_cached_ref,
+)
+
+# Ensure Triton-backed ops are registered
+from tensorrt_llm._torch.custom_ops import auto_deploy_bamba_triton_ops  # noqa: F401
+
+
+def make_inputs(device, dtype, *, B=2, T=8, H=8, P=64, G=1, N=128, chunk=4):
+    inter = H * P
+    hs = torch.randn(B, T, inter, device=device, dtype=dtype)
+    dt = torch.randn(B, T, H, device=device, dtype=dtype)
+    A = -torch.rand(H, device=device, dtype=torch.float32) - 1.0
+    Bmat = torch.randn(B, T, G * N, device=device, dtype=dtype)
+    Cmat = torch.randn(B, T, G * N, device=device, dtype=dtype)
+    D = torch.randn(H, device=device, dtype=torch.float32)
+    dt_bias = torch.rand(H, device=device, dtype=torch.float32) - 4.0
+    return hs, A, Bmat, Cmat, D, dt, dt_bias, N, [0.0, float("inf")], B, T, P, H, G, chunk
+
+
+@pytest.mark.parametrize("dtype", [torch.float32])
+def test_ssm_transform_triton_vs_ref(dtype):
+    device = "cuda"
+    hs, A, Bmat, Cmat, D, dt, dt_bias, N, tlim, B, T, P, H, G, chunk = make_inputs(device, dtype)
+
+    # reference torch custom op
+    y_ref, state_ref = ssm_transform_ref(
+        hs, A, Bmat, Cmat, D, dt, dt_bias, N, tlim, B, T, P, H, G, chunk
+    )
+
+    # triton custom op
+    y_tri, state_tri = torch.ops.auto_deploy.ssm_transform_triton(
+        hs, A, Bmat, Cmat, D, dt, dt_bias, N, tlim, B, T, P, H, G, chunk
+    )
+
+    # Combined Triton kernel vs naive reference can differ slightly; use looser tol
+    rtol = {torch.float16: 1e-2, torch.float32: 1e-2, torch.bfloat16: 1e-1}[dtype]
+    atol = {torch.float16: 2e-2, torch.float32: 3e-2, torch.bfloat16: 1e-1}[dtype]
+    torch.testing.assert_close(y_tri, y_ref, rtol=rtol, atol=atol)
+    # state_ref in ref path is final state at chunk boundaries (shape [B,H,P,N])
+    torch.testing.assert_close(state_tri, state_ref, rtol=1e-4, atol=atol)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32])
+def test_ssm_transform_cached_triton_vs_ref(dtype):
+    device = "cuda"
+    B, H, P, N = 2, 8, 64, 128
+    G = 1
+    inter = H * P
+    hs = torch.randn(B, inter, device=device, dtype=dtype)
+    dt = torch.randn(B, 1, H, device=device, dtype=dtype)
+    A = -torch.rand(H, device=device, dtype=torch.float32) - 1.0
+    Bmat = torch.randn(B, G * N, device=device, dtype=dtype)
+    Cmat = torch.randn(B, G * N, device=device, dtype=dtype)
+    D = torch.randn(H, device=device, dtype=torch.float32)
+    dt_bias = torch.rand(H, device=device, dtype=torch.float32) - 4.0
+    state0 = torch.randn(B, H, P, N, device=device, dtype=dtype)
+    tlim = [0.0, float("inf")]
+
+    # reference op
+    y_ref, state_ref = ssm_transform_cached_ref(
+        hs,
+        A,
+        Bmat,
+        Cmat,
+        D,
+        dt,
+        dt_bias,
+        N,
+        tlim,
+        B,
+        1,
+        P,
+        H,
+        G,
+        1,
+        state0.clone(),
+    )
+
+    # triton op
+    y_tri, state_tri = torch.ops.auto_deploy.ssm_transform_cached_triton(
+        hs,
+        A,
+        Bmat,
+        Cmat,
+        D,
+        dt,
+        dt_bias,
+        N,
+        tlim,
+        B,
+        1,
+        P,
+        H,
+        G,
+        1,
+        state0.clone(),
+    )
+
+    rtol = {torch.float16: 1e-2, torch.float32: 1e-2, torch.bfloat16: 1e-1}[dtype]
+    atol = {torch.float16: 2e-2, torch.float32: 3e-2, torch.bfloat16: 1e-1}[dtype]
+    torch.testing.assert_close(y_tri, y_ref, rtol=rtol, atol=atol)
+    torch.testing.assert_close(state_tri, state_ref, rtol=rtol, atol=atol)

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_bamba.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_bamba.py
@@ -1,0 +1,124 @@
+import torch  # noqa
+from torch.export import Dim  # noqa
+from transformers import AutoTokenizer
+
+from tensorrt_llm._torch.auto_deploy.export import apply_export_patches, torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.llm_args import AutoDeployConfig
+from tensorrt_llm._torch.auto_deploy.transformations._graph import move_to_device  # noqa
+
+MODEL_DIR = (
+    "/home/scratch.williamz_gpu/code/trtc/builder/hf_cache/hub/models--ibm-ai-platform--Bamba-9B-v2/"
+    "snapshots/b42852dc9eb96c8ae3359dc8df0e4c3f5c37eb21"
+)
+EXAMPLE_INPUT = "Mamba is a snake with the following properties:"
+
+
+def test_bamba_patches():
+    llm_args = AutoDeployConfig(
+        **{
+            "model": MODEL_DIR,
+            "world_size": 0,
+            "runtime": "demollm",
+            "compile_backend": "torch-simple",
+            "attn_backend": "flashinfer",
+            "model_factory": "AutoModelForCausalLM",
+            "model_kwargs": {
+                "use_cache": True,
+            },
+            "max_seq_len": 512,
+        },
+    )
+
+    factory = llm_args.create_factory()
+    model = factory.build_model("meta")
+    factory.load_or_random_init(model, device="cuda")
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_DIR)
+
+    _verify_generation(factory, model, tokenizer)
+
+    # 1. Export wants min batch size of 2 (to avoid specialization during export).
+    # 2. Can't get `padding` / `truncation` to work without other steps so just use the same prompt
+    #    twice in order for the tokenizer not to complain when creating the tensor.
+    message = [EXAMPLE_INPUT] * 2
+    inputs = tokenizer(message, return_tensors="pt", return_token_type_ids=False).to(model.device)
+
+    input_ids = inputs["input_ids"]
+    position_ids = torch.arange(input_ids.shape[1], device=input_ids.device).repeat(
+        input_ids.shape[0], 1
+    )
+
+    outputs_for_comparison = {}
+    with torch.inference_mode():
+        out_original = model(input_ids=input_ids, position_ids=position_ids)
+        with apply_export_patches(patch_list=["bamba"]):
+            outputs_for_comparison["patched"] = model(
+                input_ids=input_ids, position_ids=position_ids
+            )
+
+    dynamic_shapes = (
+        {0: Dim("batch_size", min=0, max=8), 1: Dim("seq_len", min=0, max=512)},
+        {
+            0: Dim("batch_size", min=0, max=8),
+            1: Dim("seq_len", min=0, max=512),
+        },
+    )
+    print("====== EXPORTING GRAPH MODULE ======")
+    gm = torch_export_to_gm(
+        model,
+        args=(input_ids, position_ids),
+        dynamic_shapes=dynamic_shapes,
+        patch_list=[
+            "bamba",
+            # For "unsupported scalarType".
+            "autocast_noop",
+        ],
+    )
+    move_to_device(gm, model.device)
+
+    with torch.inference_mode():
+        outputs_for_comparison["gm"] = gm(input_ids, position_ids)
+
+    atol, rtol = 1e-3, 1e-3
+    for comp, outs in outputs_for_comparison.items():
+        print(f"====== COMPARISON ({comp}) ======")
+        try:
+            torch.testing.assert_close(
+                outs,
+                out_original,
+                rtol=rtol,
+                atol=atol,
+            )
+            print("Passed!")
+        except AssertionError as e:
+            print(e)
+            diff = torch.abs(outs.logits - out_original.logits)
+            print(f"abs diff: {diff}")
+            print(f"average diff: {diff.mean()}")
+
+
+# NOTE: remember to augment `_simple_forward` to pass `*args, **kwargs`.
+def _verify_generation(factory, model, tokenizer):
+    # print("====== WITHOUT PATCH ======")
+    # _generate(tokenizer, model)
+    with apply_export_patches(patch_list=["bamba"]):
+        print("====== WITH PATCH ======")
+        _generate(tokenizer, model)
+
+
+def _generate(tokenizer, model):
+    message = [EXAMPLE_INPUT]
+    inputs = tokenizer(message, return_tensors="pt", return_token_type_ids=False).to(model.device)
+    response = model.generate(**inputs, max_new_tokens=64)
+    print(tokenizer.batch_decode(response, skip_special_tokens=True)[0])
+
+
+# def _get_example_inputs(llm_args, factory, device):
+#     batch_size = min(2, llm_args.max_batch_size)
+#     seq_len = min(4, llm_args.max_seq_len)
+#     inputs = {"input_ids": torch.ones(batch_size, seq_len, dtype=torch.int)}
+#     for key, value in inputs.items():
+#         if isinstance(value, torch.Tensor):
+#             dtype = torch.bfloat16 if isinstance(value, torch.FloatTensor) else None
+#             inputs[key] = value.to(device=device, dtype=dtype)
+#
+#     return inputs


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added export support for Bamba models, including dynamic-shape graph export and patched generation.
  - Introduced high-performance Triton-backed SSM ops (cached and uncached) for faster inference.
  - Increased model compatibility by allowing extra arguments to be forwarded in simple forward calls.

- Tests
  - Added parity tests validating Triton SSM ops against reference implementations.
  - Added end-to-end test covering Bamba patching, export to graph module, and output consistency.

- Chores
  - Minor non-functional comment update in attention dynamic shape handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->