### PR TITLE
[None][fix] Revert "Revert "[None][feat] support attention dp for qwen3 dense model""

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_qwen3.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3.py
@@ -143,7 +143,6 @@ class Qwen3DecoderLayer(DecoderLayer):
         hidden_states = self.mlp(
             hidden_states,
             all_rank_num_tokens=attn_metadata.all_rank_num_tokens,
-            all_rank_max_num_tokens=attn_metadata.all_rank_max_num_tokens,
             final_all_reduce_params=AllReduceParams(
                 enable_allreduce=not self.disable_allreduce),
             cutlass_min_latency_mode=False,


### PR DESCRIPTION
Reverts NVIDIA/TensorRT-LLM#7765

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Configurable per-layer all-reduce in attention and MLP for improved data-parallel support.
  - Smarter gating automatically enables/disables all-reduce based on distributed settings.
  - Propagation of token-distribution metadata into MLP for more efficient distributed execution.
  - Embedding behavior aligned with distributed mapping for consistent outputs.

- Refactor
  - Added optional constructor parameters to MLP and Embedding to support distributed setups; defaults preserve existing behavior.
  - Internal wiring updated to pass distributed mapping and all-reduce options through the model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->