### PR TITLE
[None][feat] Support kv_cahce_reuse for HyperCLOVAX-Vision model

### DIFF
--- a/docs/source/models/supported-models.md
+++ b/docs/source/models/supported-models.md
@@ -10,6 +10,7 @@ The following is a table of supported models for the PyTorch backend:
 | `DeepseekV3ForCausalLM`              | DeepSeek-V3                        | `deepseek-ai/DeepSeek-V3`                    |
 | `Exaone4ForCausalLM`                 | EXAONE 4.0                         | `LGAI-EXAONE/EXAONE-4.0-32B`                 |
 | `Gemma3ForCausalLM`                  | Gemma 3                            | `google/gemma-3-1b-it`                       |
+| `GptOssForCausalLM`                  | GPT-OSS                            | `openai/gpt-oss-120b`                        |
 | `LlamaForCausalLM`                   | Llama 3.1, Llama 3, Llama 2, LLaMA | `meta-llama/Meta-Llama-3.1-70B`              |
 | `Llama4ForConditionalGeneration`     | Llama 4                            | `meta-llama/Llama-4-Scout-17B-16E-Instruct`  |
 | `MistralForCausalLM`                 | Mistral                            | `mistralai/Mistral-7B-v0.1`                  |
@@ -17,8 +18,8 @@ The following is a table of supported models for the PyTorch backend:
 | `MllamaForConditionalGeneration`     | Llama 3.2                          | `meta-llama/Llama-3.2-11B-Vision`            |
 | `NemotronForCausalLM`                | Nemotron-3, Nemotron-4, Minitron   | `nvidia/Minitron-8B-Base`                    |
 | `NemotronNASForCausalLM`             | NemotronNAS                        | `nvidia/Llama-3_3-Nemotron-Super-49B-v1`     |
-| `Qwen2ForCausalLM`                   | QwQ, Qwen2                         | `Qwen/Qwen2-7B-Instruct`                     |
 | `Phi3ForCausalLM`                    | Phi-4                              | `microsoft/Phi-4`                            |
+| `Qwen2ForCausalLM`                   | QwQ, Qwen2                         | `Qwen/Qwen2-7B-Instruct`                     |
 | `Qwen2ForProcessRewardModel`         | Qwen2-based                        | `Qwen/Qwen2.5-Math-PRM-7B`                   |
 | `Qwen2ForRewardModel`                | Qwen2-based                        | `Qwen/Qwen2.5-Math-RM-72B`                   |
 | `Qwen3ForCausalLM`                   | Qwen3                              | `Qwen/Qwen3-8B`                              |
@@ -32,11 +33,11 @@ Note: Support for other models may vary. Features marked "N/A" are not applicabl
 
 | Model Architecture/Feature     | Overlap Scheduler | CUDA Graph | Attention Data Parallelism | Disaggregated Serving | Chunked Prefill | MTP | EAGLE-3(One Model Engine) | EAGLE-3(Two Model Engine) | Torch Sampler | TLLM C++ Sampler | KV Cache Reuse | Sliding Window Attention | Logits Post Processor | Guided Decoding |
 | ------------------------------ | ----------------- | ---------- | -------------------------- | --------------------- | --------------- | --- | ------------------------- | ------------------------- | ------------- | ---------------- | -------------- | ------------------------ | --------------------- | --------------- |
-| DeepseekV3ForCausalLM          | Yes               | Yes        | Yes                        | Yes                   | Yes [^1]        | Yes | No                        | No                        | Yes           | Yes              | Yes [^2]       | N/A                      | Yes                   | Yes             |
-| Qwen3MoeForCausalLM            | Yes               | Yes        | Yes                        | Yes                   | Yes             | No  | Yes                       | Yes                       | Yes           | Yes              | Yes            | N/A                      | Yes                   | Yes             |
-| Qwen3NextForCausalLM           | Yes                | Yes        | No                         | Untested                    | Yes              | No  | No                        | No                        | Yes            | Yes               | No             | No                       | Untested                    | Untested              |
-| Llama4ForConditionalGeneration | Yes               | Yes        | Yes                        | Yes                   | Yes             | No  | Yes                       | Yes                       | Yes           | Yes              | Untested       | N/A                      | Yes                   | Yes             |
-| GPT-OSS                        | Yes               | Yes        | Yes                        | Yes                   | No              | No  | Yes                       | No                        | Yes           | Yes              | No             | N/A                      | Yes                   | Yes             |
+| `DeepseekV3ForCausalLM`          | Yes               | Yes        | Yes                        | Yes                   | Yes [^1]        | Yes | No                        | No                        | Yes           | Yes              | Yes [^2]       | N/A                      | Yes                   | Yes             |
+| `Qwen3MoeForCausalLM`            | Yes               | Yes        | Yes                        | Yes                   | Yes             | No  | Yes                       | Yes                       | Yes           | Yes              | Yes            | N/A                      | Yes                   | Yes             |
+| `Qwen3NextForCausalLM`           | Yes                | Yes        | No                         | Untested                    | Yes              | No  | No                        | No                        | Yes            | Yes               | No             | No                       | Untested                    | Untested              |
+| `Llama4ForConditionalGeneration` | Yes               | Yes        | Yes                        | Yes                   | Yes             | No  | Yes                       | Yes                       | Yes           | Yes              | Untested       | N/A                      | Yes                   | Yes             |
+| `GptOssForCausalLM`            | Yes              | Yes         | Yes                        | Yes                   | No             | No   | Yes                       | No                        | Yes           | Yes              | No             | N/A                      | Yes                    | Yes             |
 
 [^1]: Chunked Prefill for MLA can only be enabled on SM100.
 [^2]: KV cache reuse for MLA can only be enabled on SM90/SM100 and in BF16/FP8 KV cache dtype.
@@ -44,18 +45,18 @@ Note: Support for other models may vary. Features marked "N/A" are not applicabl
 
 # Multimodal Feature Support Matrix (PyTorch Backend)
 
-| Model Architecture/Feature         | Overlap Scheduler | CUDA Graph | Chunked Prefill | Torch Sampler | TLLM C++ Sampler | KV Cache Reuse | Logits Post Processor | EPD Disaggregated Serving | Modality |
-| ---------------------------------- | ----------------- | ---------- | --------------- | ------------- | ---------------- | -------------- | --------------------- | ------------------------- | -------- |
-| Gemma3ForConditionalGeneration     | Yes               | Yes        | N/A             | Yes           | Yes              | N/A            | Yes                   | No                        | L + I    |
-| HCXVisionForCausalLM               | Yes               | Yes        | No              | Yes           | Yes              | No             | Yes                   | No                        | L + I    |
-| LlavaLlamaModel (VILA)             | Yes               | Yes        | No              | Yes           | Yes              | No             | Yes                   | No                        | L + I + V |
-| LlavaNextForConditionalGeneration  | Yes               | Yes        | No              | Yes           | Yes              | No             | Yes                   | No                        | L + I    |
-| Llama4ForConditionalGeneration     | Yes               | Yes        | No              | Yes           | Yes              | No             | Yes                   | No                        | L + I    |
-| Mistral3ForConditionalGeneration   | Yes               | Yes        | Yes             | Yes           | Yes              | Yes            | Yes                   | No                        | L + I    |
-| NemotronH_Nano_VL_V2               | Yes               | Yes        | Yes             | Yes           | Yes              | No             | Yes                   | No                        | L + I + V |
-| Phi4MMForCausalLM                  | Yes               | Yes        | Yes             | Yes           | Yes              | Yes            | Yes                   | No                        | L + I + A |
-| Qwen2VLForConditionalGeneration    | Yes               | Yes        | No              | Yes           | Yes              | Yes            | Yes                   | No                        | L + I + V |
-| Qwen2_5_VLForConditionalGeneration | Yes               | Yes        | No              | Yes           | Yes              | Yes            | Yes                   | No                        | L + I + V |
+| Model Architecture/Feature           | Overlap Scheduler | CUDA Graph | Chunked Prefill | Torch Sampler | TLLM C++ Sampler | KV Cache Reuse | Logits Post Processor | EPD Disaggregated Serving | Modality  |
+| ------------------------------------ | ----------------- | ---------- | --------------- | ------------- | ---------------- | -------------- | --------------------- | ------------------------- | --------- |
+| `Gemma3ForConditionalGeneration`     | Yes               | Yes        | N/A             | Yes           | Yes              | N/A            | Yes                   | No                        | L + I     |
+| `HCXVisionForCausalLM`               | Yes               | Yes        | No              | Yes           | Yes              | Yes            | Yes                   | No                        | L + I     |
+| `LlavaLlamaModel (VILA)`             | Yes               | Yes        | No              | Yes           | Yes              | No             | Yes                   | No                        | L + I + V |
+| `LlavaNextForConditionalGeneration`  | Yes               | Yes        | No              | Yes           | Yes              | No             | Yes                   | No                        | L + I     |
+| `Llama4ForConditionalGeneration`     | Yes               | Yes        | No              | Yes           | Yes              | No             | Yes                   | No                        | L + I     |
+| `Mistral3ForConditionalGeneration`   | Yes               | Yes        | Yes             | Yes           | Yes              | Yes            | Yes                   | No                        | L + I     |
+| `NemotronH_Nano_VL_V2`               | Yes               | Yes        | Yes             | Yes           | Yes              | No             | Yes                   | No                        | L + I + V |
+| `Phi4MMForCausalLM`                  | Yes               | Yes        | Yes             | Yes           | Yes              | Yes            | Yes                   | No                        | L + I + A |
+| `Qwen2VLForConditionalGeneration`    | Yes               | Yes        | No              | Yes           | Yes              | Yes            | Yes                   | No                        | L + I + V |
+| `Qwen2_5_VLForConditionalGeneration` | Yes               | Yes        | No              | Yes           | Yes              | Yes            | Yes                   | No                        | L + I + V |
 
 Note:
 - L: Language

--- a/tensorrt_llm/_torch/models/modeling_clip.py
+++ b/tensorrt_llm/_torch/models/modeling_clip.py
@@ -184,6 +184,13 @@ class CLIPVisionModel(nn.Module):
         self.vision_model = CLIPVisionTransformer(self.model_config)
         self.metadata_cls = get_attention_backend(
             model_config.attn_backend).Metadata
+        self.attn_metadata = self.metadata_cls(
+            max_num_requests=
+            8192,  #TODO(yechank-nvidia): Make this along with the LLM's max_num_requests
+            max_num_tokens=
+            8192,  #TODO(yechank-nvidia): Make this along with the LLM's max_num_tokens
+            kv_cache_manager=None,
+        )
 
     def prepare_attn_metadata(self, batch_size):
         """
@@ -193,18 +200,17 @@ class CLIPVisionModel(nn.Module):
         seq_len = (self.config.image_size // self.config.patch_size)**2 + 1
         request_ids = list(range(1, batch_size + 1))
         prompt_lens = [seq_len] * batch_size
-        attn_metadata = self.metadata_cls(
-            seq_lens=torch.tensor([seq_len] * batch_size, dtype=torch.int),
-            num_contexts=batch_size,
-            max_num_requests=batch_size,
-            max_num_tokens=seq_len * batch_size,
-            kv_cache_manager=None,
-            request_ids=request_ids,
-            prompt_lens=prompt_lens,
-        )
-        attn_metadata.max_seq_len = seq_len
-        attn_metadata.prepare()
-        return attn_metadata
+        seq_lens = torch.tensor([seq_len] * batch_size,
+                                dtype=torch.int,
+                                pin_memory=True)
+
+        self.attn_metadata.num_contexts = batch_size
+        self.attn_metadata.request_ids = request_ids
+        self.attn_metadata.prompt_lens = prompt_lens
+        self.attn_metadata.seq_lens = seq_lens
+        self.attn_metadata.max_seq_len = seq_len
+        self.attn_metadata.prepare()
+        return self.attn_metadata
 
     @property
     def dtype(self):

--- a/tensorrt_llm/_torch/models/modeling_hyperclovax.py
+++ b/tensorrt_llm/_torch/models/modeling_hyperclovax.py
@@ -9,9 +9,8 @@ import torch
 import torch.nn as nn
 from einops import rearrange
 from PIL import Image
-from transformers import (AutoConfig, AutoModel, AutoProcessor, AutoTokenizer,
-                          PretrainedConfig, PreTrainedModel)
-from transformers.modeling_utils import load_sharded_checkpoint
+from transformers import (AutoProcessor, AutoTokenizer, PretrainedConfig,
+                          PreTrainedModel)
 from transformers.models.auto import CONFIG_MAPPING
 
 from tensorrt_llm.inputs.multimodal import MultimodalParams
@@ -588,6 +587,7 @@ class HCXVisionInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
         self.tllm_multimodal_token_id = self.pretrained_config.language_config[
             "vocab_size"] + 1
         self.vision_query_lengths = None
+        self._vision_query_generator = None
 
     def get_vocab_size(self):
         return self.pretrained_config.language_config["vocab_size"]
@@ -597,10 +597,55 @@ class HCXVisionInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
         image: Image.Image,
         **kwargs,
     ):
-        return self.vision_query_lengths[0].pop(0)
+        """
+        Get the number of tokens per image.
+
+        This method must be called after __call__ is executed.
+        Uses a generator pattern to safely iterate through vision_query_lengths.
+
+        Args:
+            image: PIL Image to get token count for
+            **kwargs: Additional arguments for processor (unused)
+
+        Returns:
+            int: Number of tokens for the image
+
+        Raises:
+            RuntimeError: If called before __call__ is executed
+            IndexError: If called more times than there are images
+        """
+        if self.vision_query_lengths is None:
+            raise RuntimeError(
+                "get_num_tokens_per_image() must be called after __call__() is executed. "
+                "vision_query_lengths is not available.")
+
+        # Initialize generator if not already done
+        if self._vision_query_generator is None:
+            self._vision_query_generator = self._create_vision_query_generator()
+
+        try:
+            return next(self._vision_query_generator)
+        except StopIteration:
+            raise IndexError(
+                "get_num_tokens_per_image() called more times than the number of images processed. "
+                "No more vision query lengths available.")
 
     def get_mm_token_ids(self):
         return torch.tensor([self.tllm_multimodal_token_id])
+
+    def _create_vision_query_generator(self):
+        """Create a generator that yields vision query lengths for each image."""
+        if self.vision_query_lengths is None:
+            return
+
+        # Flatten all vision query lengths from all batches
+        for batch_vision_queries in self.vision_query_lengths:
+            for query_length in batch_vision_queries:
+                yield query_length
+
+    def _reset_vision_query_generator(self):
+        """Reset the vision query generator."""
+        self._vision_query_generator = None
 
     def _post_process(self,
                       input_ids: torch.Tensor,
@@ -677,6 +722,8 @@ class HCXVisionInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
             )
             self.vision_query_lengths = preprocessed_image.get(
                 "vision_query_lengths", None)
+            # Reset generator when new vision_query_lengths are available
+            self._reset_vision_query_generator()
 
         input_ids = self.tokenizer.encode(text_prompt,
                                           add_special_tokens=False,
@@ -726,97 +773,70 @@ class HCXVisionInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
         }
 
 
-class HCXVisionModel:
+@register_auto_model("HCXVisionModel")
+class HCXVisionModel(nn.Module):
 
     def __init__(self, model_config: ModelConfig[PretrainedConfig]):
-
+        super().__init__()
+        self.model_config = model_config
         self.pretrained_config = model_config.pretrained_config
-        self.vision_config = self.pretrained_config.vision_config
-
-        model_path = self.pretrained_config._name_or_path
-        # TODO: use config.mapping.get_local_rank() instead
-        self.device = f"cuda:{torch.cuda.current_device()}"
-
-        hf_model_config = AutoConfig.from_pretrained(model_path,
-                                                     trust_remote_code=True)
-        vision_model_type = hf_model_config.vision_config["model_type"]
-        vision_config = CONFIG_MAPPING[vision_model_type](
-            **hf_model_config.vision_config)
-        self.dtype = vision_config.torch_dtype
-        module_dict = nn.ModuleDict({
-            "vision_model":
-            AutoModel.from_config(vision_config, trust_remote_code=True),
-            "mm_projector":
-            HCXVisionCAbstractor(
-                num_queries=hf_model_config.num_queries_vis_abstractor,
-                num_input_tokens=(vision_config.image_size //
-                                  vision_config.patch_size)**2,
-                encoder_hidden_size=vision_config.hidden_size,
-                hidden_size=vision_config.hidden_size,
-                output_hidden_size=hf_model_config.
-                language_config["hidden_size"],
-                pos_emb=hf_model_config.proj_pos_emb,
-                prenorm=hf_model_config.proj_prenorm,
-            ),
-        })
-
-        module_dict.register_parameter(
-            "image_newline",
-            nn.Parameter(
-                torch.empty(hf_model_config.language_config["hidden_size"])))
-
-        missing_keys, _ = load_sharded_checkpoint(module_dict,
-                                                  model_path,
-                                                  strict=False)
-        assert len(missing_keys) == 0, f"Missing keys: {missing_keys}"
-        hf_vision_model = module_dict["vision_model"].to(self.dtype)
-        hf_mm_projector = module_dict["mm_projector"].to(self.dtype).to(
-            self.device)
-        hf_image_newline = module_dict.image_newline.to(self.dtype).to(
-            self.device)
-
-        vision_model_config = ModelConfig(pretrained_config=vision_config,
-                                          attn_backend="TRTLLM")
-
-        # Model related lines
-        self.vision_model = SiglipVisionModel(vision_model_config).to(
-            self.device).to(self.dtype)
-        self.vision_model.load_weights(hf_vision_model.state_dict())
-        self.mm_projector = hf_mm_projector.eval()
-        self.image_newline = hf_image_newline
+        siglip_model_config = copy.deepcopy(self.model_config)
+        siglip_model_config.pretrained_config = self.model_config.pretrained_config.vision_config
+        self.visual_token_idx = 0 if "siglip" in self.model_config.pretrained_config.vision_config.model_type else 1
+        self.dtype = self.model_config.pretrained_config.vision_config.torch_dtype
+        self.vision_model = SiglipVisionModel(siglip_model_config).to(
+            self.dtype)
+        self.mm_projector = HCXVisionCAbstractor(
+            num_queries=self.pretrained_config.num_queries_vis_abstractor,
+            num_input_tokens=(
+                self.pretrained_config.vision_config.image_size //
+                self.pretrained_config.vision_config.patch_size)**2,
+            encoder_hidden_size=self.pretrained_config.vision_config.
+            hidden_size,
+            hidden_size=self.pretrained_config.vision_config.hidden_size,
+            output_hidden_size=self.pretrained_config.hidden_size,
+            pos_emb=self.pretrained_config.proj_pos_emb,
+            prenorm=self.pretrained_config.proj_prenorm,
+        ).to(self.dtype)
+        self.image_newline = nn.Parameter(torch.empty(
+            self.pretrained_config.hidden_size, ),
+                                          requires_grad=False).to(self.dtype)
 
         self.unpad = self.pretrained_config.unpad
         self.use_nth_layer = self.pretrained_config.use_nth_layer
         self.anyres = self.pretrained_config.anyres
-        self.possible_resolutions = self._init_possible_resolutions(
-            self.pretrained_config)
+        self.possible_resolutions = self._init_possible_resolutions()
+        self.post_config()
 
-    def _init_possible_resolutions(self, config: PretrainedConfig):
+    def post_config(self):
+        self.config = self.vision_model.config
+        self.model_config.pretrained_config = self.vision_model.config
+
+    def _init_possible_resolutions(self):
         possible_resolutions = []
-        if config.anyres:
-            assert config.max_num_grids > 0
-            for i in range(1, config.max_num_grids + 1):
-                for j in range(1, config.max_num_grids + 1):
-                    if i == 1 and j == 1 and not config.use_1x1_grid:
+        if self.pretrained_config.anyres:
+            assert self.pretrained_config.max_num_grids > 0
+            for i in range(1, self.pretrained_config.max_num_grids + 1):
+                for j in range(1, self.pretrained_config.max_num_grids + 1):
+                    if i == 1 and j == 1 and not self.pretrained_config.use_1x1_grid:
                         continue
-                    if i * j <= config.max_num_grids:
+                    if i * j <= self.pretrained_config.max_num_grids:
                         possible_resolutions.append([i, j])
 
             possible_resolutions = [[
-                ys * config.vision_config["image_size"],
-                xs * config.vision_config["image_size"]
+                ys * self.pretrained_config.vision_config.image_size,
+                xs * self.pretrained_config.vision_config.image_size
             ] for ys, xs in possible_resolutions]
         return possible_resolutions
 
-    def _to_device(
-        self, input_tensor: Union[torch.Tensor, List, None]
-    ) -> Union[torch.Tensor, List, None]:
-        if input_tensor is None:
-            return None
-        elif isinstance(input_tensor, list):
-            return [self._to_device(item) for item in input_tensor]
-        elif isinstance(input_tensor, torch.Tensor):
-            return input_tensor.to(self.device)
+    def load_weights(self, weights):
+        vision_weights = _filter_weights(weights, "vision_model.")
+        self.vision_model.load_weights(vision_weights)
+
+        mm_projector_weights = _filter_weights(weights, "mm_projector.")
+        self.mm_projector.load_state_dict(mm_projector_weights, strict=True)
+
+        self.image_newline.data.copy_(weights["image_newline"])
 
     def _parse_and_batch_multimodal_data(
         self, multimodal_params: List[MultimodalParams]
@@ -842,8 +862,6 @@ class HCXVisionModel:
 
         pixel_values, mm_extra_data = self._parse_and_batch_multimodal_data(
             multimodal_params)
-        pixel_values = self._to_device(
-            pixel_values)  # TODO: remove this once we have the shared tensor
         image_sizes = mm_extra_data.get("image_sizes", None)
         is_videos = mm_extra_data.get("is_videos", None)
         num_queries_vis_abstractors = mm_extra_data.get(
@@ -856,8 +874,6 @@ class HCXVisionModel:
         len_pixel_values = [len(pixel_value) for pixel_value in pixel_values]
         concat_pixel_values = torch.cat(list(chain(*pixel_values)),
                                         dim=0)  # list of list of 4D Tensor
-        visual_token_idx = 0 if "siglip" in self.vision_config[
-            "model_type"] else 1
 
         n_chunks = 1
         total_len = concat_pixel_values.size(0)
@@ -867,7 +883,7 @@ class HCXVisionModel:
         for i in range(n_chunks):
             start = i * chunk_size
             end = (i + 1) * chunk_size
-            chunk = concat_pixel_values[start:end].to(self.vision_model.dtype)
+            chunk = concat_pixel_values[start:end]
             if chunk.size(0) < chunk_size:
                 pad_size = chunk_size - chunk.size(0)
                 dummy_shape = (pad_size, ) + tuple(
@@ -883,10 +899,10 @@ class HCXVisionModel:
             if self.use_nth_layer == -1:
                 self.vision_model.vision_model.post_layernorm = nn.Identity()
                 outs = self.vision_model(chunk, attn_metadata=attn_metadata)
-                outs = outs[:, visual_token_idx:]
+                outs = outs[:, self.visual_token_idx:]
             else:
                 outs = self.vision_model(chunk, attn_metadata=attn_metadata)
-                outs = outs[self.use_nth_layer][:, visual_token_idx:]
+                outs = outs[self.use_nth_layer][:, self.visual_token_idx:]
             image_forward_outs_chunks.append(outs)
 
         image_forward_outs = torch.cat(image_forward_outs_chunks, dim=0).to(
@@ -999,30 +1015,41 @@ class HCXVisionForCausalLM(PreTrainedModel):
         if hasattr(self, "llm"):
             return
         if not DISAGG:
-            self.mm_encoder = HCXVisionModel(model_config)
+            vision_model_config = copy.deepcopy(model_config)
+            vision_model_type = self.model_config.pretrained_config.vision_config[
+                "model_type"]
+            vision_config_obj = CONFIG_MAPPING[vision_model_type](
+                **self.model_config.pretrained_config.vision_config)
+            vision_model_config.pretrained_config.vision_config = vision_config_obj
+            vision_model_config.pretrained_config.architectures = [
+                "HCXVisionModel"
+            ]
+            self.mm_encoder = AutoModelForCausalLM.from_config(
+                vision_model_config)
+
         llm_model_config = copy.deepcopy(model_config)
         llm_model_config.pretrained_config = PretrainedConfig.from_dict(
             llm_model_config.pretrained_config.language_config)
         self.llm = AutoModelForCausalLM.from_config(llm_model_config)
-
-        self.model_dtype = getattr(config, "torch_dtype", torch.bfloat16)
-        logger.info(f"{self.dtype=} {self.model_dtype=}")
+        self.model_dtype = getattr(config.language_config, "torch_dtype",
+                                   torch.bfloat16)
         self.post_config()
         self.is_loaded = True
 
     def load_weights(self, weights):
 
-        def filter_weights(prefix, weights: Dict):
-            result = {}
-            for k, v in weights.items():
-                if k.startswith(prefix):
-                    new_k = k[len(prefix) + 1:]
-                    result[new_k] = v.to(self.dtype)
-                    assert result[new_k] is not None
-            return result
+        def _filter_weights(weights: Dict[str, torch.Tensor],
+                            prefix: str) -> Dict[str, torch.Tensor]:
+            return {
+                name[len(prefix):]: weight
+                for name, weight in weights.items() if name.startswith(prefix)
+            }
 
-        weights = filter_weights("language_model", weights)
-        self.llm.load_weights(weights)
+        language_weights = _filter_weights(weights, "language_model.")
+        self.llm.load_weights(language_weights)
+
+        if not DISAGG:
+            self.mm_encoder.load_weights(weights)
 
     def infer_max_seq_len(self) -> int:
         return self.llm.infer_max_seq_len()

--- a/tensorrt_llm/_torch/models/modeling_hyperclovax.py
+++ b/tensorrt_llm/_torch/models/modeling_hyperclovax.py
@@ -1037,14 +1037,6 @@ class HCXVisionForCausalLM(PreTrainedModel):
         self.is_loaded = True
 
     def load_weights(self, weights):
-
-        def _filter_weights(weights: Dict[str, torch.Tensor],
-                            prefix: str) -> Dict[str, torch.Tensor]:
-            return {
-                name[len(prefix):]: weight
-                for name, weight in weights.items() if name.startswith(prefix)
-            }
-
         language_weights = _filter_weights(weights, "language_model.")
         self.llm.load_weights(language_weights)
 
@@ -1103,3 +1095,11 @@ class HCXVisionForCausalLM(PreTrainedModel):
 
         logger.debug(f'output shape: {output_prob.shape}')
         return output_prob
+
+
+def _filter_weights(weights: Dict[str, torch.Tensor],
+                    prefix: str) -> Dict[str, torch.Tensor]:
+    return {
+        name[len(prefix):]: weight
+        for name, weight in weights.items() if name.startswith(prefix)
+    }

--- a/tensorrt_llm/_torch/models/modeling_llava_next.py
+++ b/tensorrt_llm/_torch/models/modeling_llava_next.py
@@ -354,7 +354,6 @@ class LlavaNextVisionModel(nn.Module):
     def post_config(self):
         self.config = self.pretrained_config.vision_config
 
-    # Copied from https://github.com/huggingface/transformers/blob/main/src/transformers/models/llava_next/modeling_llava_next.py#L284
     def pack_image_features(self,
                             image_features,
                             image_sizes,
@@ -417,6 +416,50 @@ class LlavaNextVisionModel(nn.Module):
                                     device=image_features[0].device)
         return new_image_features, feature_lens
 
+    def _pad_for_batching(
+        self,
+        pixel_values: list[torch.Tensor],
+    ):
+        """
+        Pads images on the `num_of_patches` dimension with zeros to form a batch of same number of patches.
+        Optimized for CUDA tensors using torch.nn.functional.pad.
+
+        Args:
+            pixel_values (`list[torch.Tensor]`):
+                A list of pixel value tensors, each of shape (`batch`, `num_patches`, `height`, `width`, `channels`)
+
+        Returns:
+            list[`torch.Tensor`]: The padded image tensors.
+        """
+        if not pixel_values:
+            return pixel_values
+
+        # Find max patches across all images
+        max_patches = max(tensor.shape[1] for tensor in pixel_values)
+
+        # Pad each tensor efficiently using torch.nn.functional.pad
+        padded_values = []
+
+        for pixel_value in pixel_values:
+            current_patches = pixel_value.shape[1]
+            if current_patches < max_patches:
+                # Pad the second dimension (num_patches at index 1)
+                # torch.nn.functional.pad expects padding in reverse order of dimensions
+                # For shape (batch, num_patches, height, width, channels), we pad the second dim:
+                # padding format: (channels_before, channels_after, width_before, width_after, height_before, height_after, patches_before, patches_after, batch_before, batch_after)
+                padding = (0, 0, 0, 0, 0, 0, 0, max_patches - current_patches,
+                           0, 0)
+                padded_pixel_value = F.pad(pixel_value,
+                                           padding,
+                                           mode='constant',
+                                           value=0.0)
+            else:
+                padded_pixel_value = pixel_value
+
+            padded_values.append(padded_pixel_value)
+
+        return padded_values
+
     @torch.inference_mode()
     def forward(self, multimodal_params: List[MultimodalParams]):
         pixel_values = [
@@ -427,6 +470,8 @@ class LlavaNextVisionModel(nn.Module):
             multimodal_param.multimodal_data["image"]["image_sizes"]
             for multimodal_param in multimodal_params
         ]
+        pixel_values = self._pad_for_batching(pixel_values)
+
         pixel_values = torch.cat(pixel_values, dim=0)
         image_sizes = torch.cat(image_sizes, dim=0)
 

--- a/tensorrt_llm/_torch/models/modeling_siglip.py
+++ b/tensorrt_llm/_torch/models/modeling_siglip.py
@@ -77,6 +77,13 @@ class SiglipVisionModel(nn.Module):
         self.model_config = model_config
         self.metadata_cls = get_attention_backend(
             model_config.attn_backend).Metadata
+        self.attn_metadata = self.metadata_cls(
+            max_num_requests=
+            8192,  #TODO(yechank-nvidia): Make this along with the LLM's max_num_requests
+            max_num_tokens=
+            8192,  #TODO(yechank-nvidia): Make this along with the LLM's max_num_tokens
+            kv_cache_manager=None,
+        )
 
     def prepare_attn_metadata(self, batch_size):
         """
@@ -86,18 +93,17 @@ class SiglipVisionModel(nn.Module):
         seq_len = (self.config.image_size // self.config.patch_size)**2
         request_ids = list(range(1, batch_size + 1))
         prompt_lens = [seq_len] * batch_size
-        attn_metadata = self.metadata_cls(
-            seq_lens=torch.tensor([seq_len] * batch_size, dtype=torch.int),
-            num_contexts=batch_size,
-            max_num_requests=batch_size,
-            max_num_tokens=seq_len * batch_size,
-            kv_cache_manager=None,
-            request_ids=request_ids,
-            prompt_lens=prompt_lens,
-        )
-        attn_metadata.max_seq_len = seq_len * batch_size
-        attn_metadata.prepare()
-        return attn_metadata
+        seq_lens = torch.tensor([seq_len] * batch_size,
+                                dtype=torch.int,
+                                pin_memory=True)
+
+        self.attn_metadata.num_contexts = batch_size
+        self.attn_metadata.request_ids = request_ids
+        self.attn_metadata.prompt_lens = prompt_lens
+        self.attn_metadata.seq_lens = seq_lens
+        self.attn_metadata.max_seq_len = seq_len
+        self.attn_metadata.prepare()
+        return self.attn_metadata
 
     @property
     def dtype(self):

--- a/tensorrt_llm/_torch/models/modeling_siglip.py
+++ b/tensorrt_llm/_torch/models/modeling_siglip.py
@@ -75,13 +75,17 @@ class SiglipVisionModel(nn.Module):
         self.vision_model = SiglipVisionTransformer(
             model_config, use_post_layernorm=use_post_layernorm)
         self.model_config = model_config
+
+        # Needed for prepare_attn_metadata
+        self.image_size = self.config.image_size
+        self.patch_size = self.config.patch_size
+
         self.metadata_cls = get_attention_backend(
             model_config.attn_backend).Metadata
         self.attn_metadata = self.metadata_cls(
             max_num_requests=
             8192,  #TODO(yechank-nvidia): Make this along with the LLM's max_num_requests
-            max_num_tokens=
-            8192,  #TODO(yechank-nvidia): Make this along with the LLM's max_num_tokens
+            max_num_tokens=model_config.max_num_tokens,
             kv_cache_manager=None,
         )
 
@@ -90,7 +94,7 @@ class SiglipVisionModel(nn.Module):
         To simplify the usage of the model, this function aims to fill the metadata for Attention
         Call this function before forward pass
         """
-        seq_len = (self.config.image_size // self.config.patch_size)**2
+        seq_len = (self.image_size // self.patch_size)**2
         request_ids = list(range(1, batch_size + 1))
         prompt_lens = [seq_len] * batch_size
         seq_lens = torch.tensor([seq_len] * batch_size,

--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -668,7 +668,7 @@ def find_mm_token_positions(
             "Provide either mm_token_ids or vocab_size to find multimodal token positions"
         )
     if mm_token_ids is not None and vocab_size is not None:
-        logger.warning(
+        logger.debug(
             "Both mm_token_ids and vocab_size are provided, using mm_token_ids and ignoring vocab_size"
         )
 

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -88,7 +88,7 @@ class BaseMultimodalInputProcessor:
                                                   None) is not None:
             return int(self.tokenizer.vocab_size)
 
-        logger.warning(
+        logger.debug(
             f"Cannot determine vocab_size from {self.__class__.__name__}. "
             "Please override this method to provide the vocabulary size. ")
         return None
@@ -103,7 +103,7 @@ class BaseMultimodalInputProcessor:
                                              None) is not None:
             return processor.mm_token_ids
 
-        logger.warning(
+        logger.debug(
             f"Cannot determine mm_token_ids from {self.__class__.__name__}. "
             "If needed, please override this method to return multimodal token ids. "
         )

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -503,45 +503,47 @@ def create_input_processor_with_hash(
         """
         assert 'multi_modal_data' in inputs, "multi_modal_data must be provided for hashing support."
         mm_data = inputs['multi_modal_data']
+        mm_hashes = apply_mm_hashes(mm_data, hash_lib)
+        prompt_token_ids, extra_processed_inputs = input_processor(
+            inputs, sampling_params)
+
         num_mm_tokens = find_mm_token_lengths(mm_data, input_processor)
         # TODO: here we assume there is only one modality for now
         num_mm_tokens = next(iter(num_mm_tokens.values()))
-        if len(num_mm_tokens) > 0:
-            mm_hashes = apply_mm_hashes(mm_data, hash_lib)
-            prompt_token_ids, extra_processed_inputs = input_processor(
-                inputs, sampling_params)
-            vocab_size = input_processor.get_vocab_size()
-            mm_ids = input_processor.get_mm_token_ids()
-            mm_special_token_ids = input_processor.get_mm_special_token_ids()
-            if vocab_size is None and mm_ids is None:
-                raise ValueError(
-                    "Cannot locate vocab_size or mm_token_ids for multimodal token preprocessing"
-                )
-            start_positions, start_special_token_positions = find_mm_token_positions(
-                input_ids=prompt_token_ids,  # token sequence
-                num_mm_tokens=
-                num_mm_tokens,  # list of lengths of each chunk of visual tokens
-                vocab_size=vocab_size,
-                mm_token_ids=mm_ids,
-                mm_special_token_ids=mm_special_token_ids,
-            )
-            # Store special token offsets if available
-            if len(start_special_token_positions
-                   ) > 0 and mm_special_token_ids is not None:
-                extra_processed_inputs["multimodal_data"][
-                    "special_token_offsets"] = start_special_token_positions
-            # flatten the hashes from dict to a single list
-            mm_hashes = [h for hashes in mm_hashes.values() for h in hashes]
-            validate_mm_inputs(prompt_token_ids, mm_hashes, start_positions,
-                               num_mm_tokens)
-            mm_hashes_int32 = [hexdigest_to_int32(h) for h in mm_hashes
-                               ]  # nested list w/ multiple int32 per hash
+        if len(num_mm_tokens) <= 0:
+            return [], None
 
-            extra_processed_inputs[
-                "multimodal_input"] = MultimodalInput.from_components(
-                    mm_hashes_int32, start_positions, num_mm_tokens)
-            return prompt_token_ids, extra_processed_inputs
-        return [], None
+        vocab_size = input_processor.get_vocab_size()
+        mm_ids = input_processor.get_mm_token_ids()
+        mm_special_token_ids = input_processor.get_mm_special_token_ids()
+        if vocab_size is None and mm_ids is None:
+            raise ValueError(
+                "Cannot locate vocab_size or mm_token_ids for multimodal token preprocessing"
+            )
+        start_positions, start_special_token_positions = find_mm_token_positions(
+            input_ids=prompt_token_ids,  # token sequence
+            num_mm_tokens=
+            num_mm_tokens,  # list of lengths of each chunk of visual tokens
+            vocab_size=vocab_size,
+            mm_token_ids=mm_ids,
+            mm_special_token_ids=mm_special_token_ids,
+        )
+        # Store special token offsets if available
+        if len(start_special_token_positions
+               ) > 0 and mm_special_token_ids is not None:
+            extra_processed_inputs["multimodal_data"][
+                "special_token_offsets"] = start_special_token_positions
+        # flatten the hashes from dict to a single list
+        mm_hashes = [h for hashes in mm_hashes.values() for h in hashes]
+        validate_mm_inputs(prompt_token_ids, mm_hashes, start_positions,
+                           num_mm_tokens)
+        mm_hashes_int32 = [hexdigest_to_int32(h) for h in mm_hashes
+                           ]  # nested list w/ multiple int32 per hash
+
+        extra_processed_inputs[
+            "multimodal_input"] = MultimodalInput.from_components(
+                mm_hashes_int32, start_positions, num_mm_tokens)
+        return prompt_token_ids, extra_processed_inputs
 
     def input_processor_wrapper(
         inputs: TextPrompt, sampling_params: SamplingParams


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced multimodal processing for HCXVision, including image token counting and unified embedding utilities.

- Bug Fixes
  - LLaVA-Next now pads variable-patch images for stable batching and shape consistency.

- Documentation
  - Updated supported models with GPT-OSS (PyTorch backend).
  - Restructured feature matrices for clearer model/feature coverage.

- Refactor
  - Vision backends (CLIP, SigLIP) reuse pre-initialized attention metadata for efficiency.
  - Streamlined multimodal hashing and position detection; early exits when no multimodal tokens.
  - Disaggregated multimodal embeddings temporarily disabled with a clear error.

- Chores
  - Reduced noisy multimodal logging (warning → debug).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->