### PR TITLE
[TRTLLM-6541][test] WIP: Do not merge - Add multi node supporting for perf

### DIFF
--- a/tests/integration/defs/perf/test_perf.py
+++ b/tests/integration/defs/perf/test_perf.py
@@ -2006,7 +2006,7 @@ class MultiMetricPerfTest(AbstractPerfScriptTestClass):
             f'{self._working_dir}/server_config.yaml', '-p',
             f'{client_dir}/prompts.json', '--ignore-eos',
             '--server-start-timeout',
-            str(1800)
+            str(3600)
         ]
         return client_cmd
 

--- a/tests/integration/defs/perf/test_perf.py
+++ b/tests/integration/defs/perf/test_perf.py
@@ -1166,7 +1166,6 @@ class MultiMetricPerfTest(AbstractPerfScriptTestClass):
             build_cmd.append(f"--output_timing_cache={timing_cache}")
         return build_cmd
 
-    @multi_node_llm_command_wrapper
     def get_prepare_data_command(self, engine_dir, input_len,
                                  output_len) -> list:
         data_cmd = []
@@ -2018,7 +2017,6 @@ class MultiMetricPerfTest(AbstractPerfScriptTestClass):
         gen_cmd = f'CUDA_VISIBLE_DEVICES={gen_gpu_list} {llm_api_cmd} trtllm-serve {model_dir} --host localhost --port 8002 --extra_llm_api_options {gen_config_path}'
         return ctx_cmd, gen_cmd
 
-    @multi_node_disagg_server_command_wrapper
     def _get_disagg_server_deploy_command(self):
         server_config = self._gen_disagg_server_config()
         server_config_path = os.path.join(self._working_dir,
@@ -2027,7 +2025,6 @@ class MultiMetricPerfTest(AbstractPerfScriptTestClass):
             yaml.dump(server_config, f)
         return f'trtllm-serve disaggregated -c {server_config_path} -t 3600 -r 3600'
 
-    @multi_node_disagg_server_command_wrapper
     def _get_disagg_client_command(self):
         client_dir = os.path.join(self._llm_root,
                                   "examples/disaggregated/clients")
@@ -2040,7 +2037,6 @@ class MultiMetricPerfTest(AbstractPerfScriptTestClass):
         ]
         return client_cmd
 
-    @multi_node_disagg_server_command_wrapper
     def _get_disagg_benchmark_command(self):
         benchmark_script = os.path.join(self._llm_root, "tensorrt_llm", "serve",
                                         "scripts", "benchmark_serving.py")

--- a/tests/integration/defs/perf/test_perf.py
+++ b/tests/integration/defs/perf/test_perf.py
@@ -2097,9 +2097,7 @@ def run_perf_test(perf_case_name, trt_performance_cache_fpath,
             should_run = True
         elif test_runner._config.runtime == "disagg_server":
             # multi-node + disagg_server：run on both node0,process0 and node1,process0
-            should_run = MultiNodeProbe.is_first_process() and (
-                MultiNodeProbe.is_first_node()
-                or MultiNodeProbe.is_second_node())
+            should_run = MultiNodeProbe.is_first_process()
         else:
             # multi-node + other runtime：only run onnode0,process0
             should_run = MultiNodeProbe.is_first_node(

--- a/tests/integration/defs/perf/test_perf.py
+++ b/tests/integration/defs/perf/test_perf.py
@@ -2089,20 +2089,21 @@ def run_perf_test(perf_case_name, trt_performance_cache_fpath,
     The actual test definition for TensorRT LLM perf test.
     """
     working_dir = llm_venv.get_working_directory()
-    
+
     if MultiNodeProbe.is_multi_node():
         # Add process ID to avoid conflicts in multi-process environment
         process_id = os.getpid()
-        mpi_rank = os.environ.get("SLURM_PROCID", "0") 
-        process_working_dir = os.path.join(working_dir, f"rank{mpi_rank}-pid{process_id}")
+        mpi_rank = os.environ.get("SLURM_PROCID", "0")
+        process_working_dir = os.path.join(working_dir,
+                                           f"rank{mpi_rank}-pid{process_id}")
         os.makedirs(process_working_dir, exist_ok=True)
         working_dir = process_working_dir
-    
+
     test_runner = MultiMetricPerfTest(perf_case_name)
     test_runner.set_runtime_configs(llm_root, working_dir,
                                     trt_performance_cache_fpath)
     test_runner.run_metrics(llm_venv, trt_gpu_clock_lock,
-                                    llm_session_data_writer, output_dir)
+                            llm_session_data_writer, output_dir)
 
 
 def generate_perf_tests(session, config, items):

--- a/tests/integration/defs/perf/utils.py
+++ b/tests/integration/defs/perf/utils.py
@@ -97,7 +97,7 @@ class MultiNodeProbe(object):
         nodelist_str = os.environ.get("SLURM_NODELIST", "")
         if not nodelist_str:
             return []
-        
+
         # Matched format: prefix-[num1,num2,...]
         match = re.match(r'(.*?)\[([^\]]+)\]', nodelist_str)
         if match:
@@ -505,7 +505,7 @@ class PerfDisaggScriptTestCmds(NamedTuple):
         server_proc = None
 
         try:
-            if MultiNodeProbe.is_first_node() :
+            if MultiNodeProbe.is_first_node():
                 # Start ctx workers
                 output_ctx = open('output_ctx.log', 'w')
                 ctx_workers_proc = popen(self.ctx_cmd,
@@ -523,7 +523,8 @@ class PerfDisaggScriptTestCmds(NamedTuple):
                                          env=venv._new_env,
                                          shell=True)
 
-            if MultiNodeProbe.is_first_node() and MultiNodeProbe.is_first_process():
+            if MultiNodeProbe.is_first_node(
+            ) and MultiNodeProbe.is_first_process():
                 # Start server
                 output_server = open('output_server.log', 'w')
                 server_proc = popen(self.server_cmd,

--- a/tests/integration/defs/perf/utils.py
+++ b/tests/integration/defs/perf/utils.py
@@ -19,11 +19,13 @@ import io
 import os
 import re
 import subprocess
+import time
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
 from typing import Dict, List, NamedTuple, Optional
 
+import requests
 from _pytest.nodes import Item
 from _pytest.python import Function
 from defs.trt_test_alternative import (check_output, popen, print_error,
@@ -316,6 +318,17 @@ class PerfDisaggScriptTestCmds(NamedTuple):
     client_cmd: List[str]
     benchmark_cmd: List[str]
 
+    def wait_for_endpoint_ready(self, url: str, timeout: int = 600):
+        start = time.monotonic()
+        while time.monotonic() - start < timeout:
+            try:
+                time.sleep(1)
+                if requests.get(url).status_code == 200:
+                    print(f"endpoint {url} is ready")
+                    return
+            except Exception as err:
+                print(f"endpoint {url} is not ready, with exception: {err}")
+
     def run_cmd(self, cmd_idx: int, venv) -> str:
         output = ""
         try:
@@ -340,6 +353,7 @@ class PerfDisaggScriptTestCmds(NamedTuple):
                           stderr=subprocess.STDOUT,
                           env=venv._new_env,
                           shell=True) as server_proc):
+                self.wait_for_endpoint_ready(f"http://localhost:8000/health")
                 check_output(self.client_cmd, env=venv._new_env)
                 output += check_output(self.benchmark_cmd, env=venv._new_env)
         finally:

--- a/tests/integration/defs/perf/utils.py
+++ b/tests/integration/defs/perf/utils.py
@@ -328,6 +328,8 @@ class PerfDisaggScriptTestCmds(NamedTuple):
                     return
             except Exception as err:
                 print(f"endpoint {url} is not ready, with exception: {err}")
+        print_error(
+            f"Endpoint {url} did not become ready within {timeout} seconds")
 
     def run_cmd(self, cmd_idx: int, venv) -> str:
         output = ""
@@ -353,7 +355,9 @@ class PerfDisaggScriptTestCmds(NamedTuple):
                           stderr=subprocess.STDOUT,
                           env=venv._new_env,
                           shell=True) as server_proc):
-                self.wait_for_endpoint_ready(f"http://localhost:8000/health")
+                self.wait_for_endpoint_ready(
+                    f"http://localhost:8000/health",
+                    timeout=3600)  # 60 minutes for large models
                 check_output(self.client_cmd, env=venv._new_env)
                 output += check_output(self.benchmark_cmd, env=venv._new_env)
         finally:

--- a/tests/integration/defs/perf/utils.py
+++ b/tests/integration/defs/perf/utils.py
@@ -357,7 +357,7 @@ class PerfDisaggScriptTestCmds(NamedTuple):
                           shell=True) as server_proc):
                 self.wait_for_endpoint_ready(
                     f"http://localhost:8000/health",
-                    timeout=3600)  # 60 minutes for large models
+                    timeout=1800)  # 30 minutes for large models
                 check_output(self.client_cmd, env=venv._new_env)
                 output += check_output(self.benchmark_cmd, env=venv._new_env)
         finally:

--- a/tests/integration/defs/perf/utils.py
+++ b/tests/integration/defs/perf/utils.py
@@ -505,8 +505,7 @@ class PerfDisaggScriptTestCmds(NamedTuple):
         server_proc = None
 
         try:
-            if MultiNodeProbe.is_first_node(
-            ) and MultiNodeProbe.is_first_process():
+            if MultiNodeProbe.is_first_node() :
                 # Start ctx workers
                 output_ctx = open('output_ctx.log', 'w')
                 ctx_workers_proc = popen(self.ctx_cmd,
@@ -515,8 +514,7 @@ class PerfDisaggScriptTestCmds(NamedTuple):
                                          env=venv._new_env,
                                          shell=True)
 
-            if MultiNodeProbe.is_second_node(
-            ) and MultiNodeProbe.is_first_process():
+            if MultiNodeProbe.is_second_node():
                 # Start gen workers
                 output_gen = open('output_gen.log', 'w')
                 gen_workers_proc = popen(self.gen_cmd,
@@ -525,8 +523,7 @@ class PerfDisaggScriptTestCmds(NamedTuple):
                                          env=venv._new_env,
                                          shell=True)
 
-            if MultiNodeProbe.is_first_node(
-            ) and MultiNodeProbe.is_first_process():
+            if MultiNodeProbe.is_first_node() and MultiNodeProbe.is_first_process():
                 # Start server
                 output_server = open('output_server.log', 'w')
                 server_proc = popen(self.server_cmd,

--- a/tests/integration/defs/perf/utils.py
+++ b/tests/integration/defs/perf/utils.py
@@ -84,6 +84,17 @@ def collect_and_clean_myelin_time(log: str):
     return log
 
 
+class MultiNodeProbe(object):
+    '''
+        class to probe if the test is running on multi-node,
+        or if the test is running on the 1st node/2nd node, etc.
+    '''
+
+    @staticmethod
+    def is_multi_node():
+        pass
+
+
 class PerfMetricType(str, Enum):
     """
     An string-enum type to define what kind of perf metric it is. It is used by QA to

--- a/tests/integration/test_lists/qa/llm_perf_sanity.yml
+++ b/tests/integration/test_lists/qa/llm_perf_sanity.yml
@@ -221,4 +221,4 @@ llm_perf_sanity:
   - perf/test_perf.py::test_perf[llama_v4_scout_17b_16e_instruct_fp8-bench-pytorch-float8-maxbs:1024-maxnt:20000-kv_frac:0.85-input_output_len:20000,2000-reqs:1000-ep:8-tp:8-gpus:8] TIMEOUT(100)
   - perf/test_perf.py::test_perf[qwen3_235b_a22b_fp8-bench-pytorch-float8-input_output_len:1000,2000-con:256-ep:8-gpus:8] TIMEOUT(60)
   - perf/test_perf.py::test_perf[deepseek_v3_lite_fp8-disagg_server-ctx_dp:4-gen_tp:4]
-  - perf/test_perf.py::test_perf[llama_v3.1_70b-disagg_server-ctx_dp:4-gen_tp:4]
+  - perf/test_perf.py::test_perf[llama_v3.1_8b-disagg_server-ctx_dp:4-gen_tp:4]

--- a/tests/integration/test_lists/qa/llm_perf_sanity.yml
+++ b/tests/integration/test_lists/qa/llm_perf_sanity.yml
@@ -220,5 +220,5 @@ llm_perf_sanity:
   - perf/test_perf.py::test_perf[llama_v4_maverick_17b_128e_instruct_fp8-bench-pytorch-float8-maxbs:1024-maxnt:20000-kv_frac:0.6-input_output_len:20000,2000-reqs:1000-ep:8-tp:8-gpus:8]
   - perf/test_perf.py::test_perf[llama_v4_scout_17b_16e_instruct_fp8-bench-pytorch-float8-maxbs:1024-maxnt:20000-kv_frac:0.85-input_output_len:20000,2000-reqs:1000-ep:8-tp:8-gpus:8] TIMEOUT(100)
   - perf/test_perf.py::test_perf[qwen3_235b_a22b_fp8-bench-pytorch-float8-input_output_len:1000,2000-con:256-ep:8-gpus:8] TIMEOUT(60)
-  - perf/test_perf.py::test_perf[deepseek_v3_lite-disagg_server-ctx_dp:4-gen_tp:4]
+  - perf/test_perf.py::test_perf[deepseek_v3_lite_fp8-disagg_server-ctx_dp:4-gen_tp:4]
   - perf/test_perf.py::test_perf[llama_v3.1_70b-disagg_server-ctx_dp:4-gen_tp:4]


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Multi-node orchestration for performance tests, including SLURM-aware node detection and role assignment.
  - Automatic command wrapping for multi-node LLM and disaggregated server runs.
  - Built-in health checks and synchronized startup across nodes.
  - Smart result gating to prevent duplicate outputs in multi-node executions.

- Tests
  - QA perf sanity list updated: switched two entries to FP8 variants while retaining gen_tp=4:
    - deepseek_v3_lite → deepseek_v3_lite_fp8
    - llama_v3.1_70b → llama_v3.1_8b
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Please do not merge this one. Not fully tested yet.

1. Add multi-node support for normal perf test cases.
2. Add multi-node support for disaggrated serve cases.
