### PR TITLE
[https://nvbugs/5523080][fix] Correct the batch index in device tensors

### DIFF
--- a/tensorrt_llm/_torch/speculative/model_drafter.py
+++ b/tensorrt_llm/_torch/speculative/model_drafter.py
@@ -395,23 +395,27 @@ class ModelDrafter(Drafter):
         new_tokens = torch.zeros_like(new_tensors_device.new_tokens)
         new_tokens_lens = None
         next_draft_tokens = None
+        has_draft_tokens = False
         # Iterate through generation requests and copy tokens based on accepted draft tokens
-        for idx, request in enumerate(scheduled_batch.all_requests()):
+        for request in scheduled_batch.all_requests():
+            idx = request.py_seq_slot
             if request.state != LlmRequestState.GENERATION_IN_PROGRESS:
                 num_accepted_tokens = request.py_num_accepted_draft_tokens
                 new_tokens[0, idx] = new_tensors_device.new_tokens[
                     num_accepted_tokens, idx]
             else:
-                # Create new tensors with the correct device
-                # We already updated the target state, so the new_tokens_lens should be all ones.
-                new_tokens_lens = torch.ones(scheduled_batch.batch_size,
-                                             device=device)
-                next_draft_tokens = torch.zeros(scheduled_batch.batch_size,
-                                                self.max_draft_tokens,
-                                                device=device)
+                has_draft_tokens = True
                 num_accepted_tokens = request.py_num_accepted_draft_tokens
                 new_tokens[0, idx] = new_tensors_device.new_tokens[
                     num_accepted_tokens, idx]
+
+        if has_draft_tokens:
+            # We already updated the target state, so the new_tokens_lens should be all ones.
+            new_tokens_lens = torch.ones(scheduled_batch.batch_size,
+                                         device=device)
+            next_draft_tokens = torch.zeros(scheduled_batch.batch_size,
+                                            self.max_draft_tokens,
+                                            device=device)
 
         # Create a new SampleStateTensorsMTP object with the additional fields
         updated_tensors = SampleStateTensorsMTP(
@@ -428,26 +432,28 @@ class ModelDrafter(Drafter):
     def _update_target_inputs_with_draft_tokens(
             self, target_inputs: SampleStateTensorsMTP,
             draft_tensors: Optional[torch.Tensor], draft_position: int,
-            draft_length: int, num_draft_reqs: int) -> None:
+            draft_length: int, draft_batch: ScheduledRequests,
+            req_id_to_old_request: Dict[int, LlmRequest]) -> None:
         """
         Update target inputs with new draft tokens from sample state.
-
-        Args:
-            target_inputs: The target input tensors to update
-            draft_sample_state: The draft sample state containing new tokens
-            iteration: The current iteration index
         """
         if draft_tensors is not None:
-            for idx in range(num_draft_reqs):
+            for request in draft_batch.all_requests():
                 # Skip prefill requests
                 if target_inputs.next_draft_tokens is None:
                     continue
+
+                # Get the index of the draft/target tokens in the device tensor
+                draft_idx = request.py_seq_slot
+                target_idx = req_id_to_old_request[
+                    request.py_request_id].py_seq_slot
                 target_inputs.new_tokens[draft_position + 1:draft_position +
-                                         draft_length + 1, idx,
-                                         0] = draft_tensors[0:draft_length, idx]
+                                         draft_length + 1, target_idx,
+                                         0] = draft_tensors[0:draft_length,
+                                                            draft_idx]
                 target_inputs.next_draft_tokens[
-                    idx, draft_position:draft_position +
-                    draft_length] = draft_tensors[0:draft_length, idx]
+                    target_idx, draft_position:draft_position +
+                    draft_length] = draft_tensors[0:draft_length, draft_idx]
 
     def _setup_draft_batch_and_resources(
         self, scheduled_batch: ScheduledRequests
@@ -581,7 +587,8 @@ class ModelDrafter(Drafter):
                     draft_tensors,
                     draft_position=i + 1,
                     draft_length=1,
-                    num_draft_reqs=num_draft_reqs)
+                    draft_batch=draft_batch,
+                    req_id_to_old_request=req_id_to_old_request)
 
             if sample_state is not None and previous_draft_state is not None:
                 new_requests = self.process_decoded_tokens(
@@ -639,7 +646,8 @@ class ModelDrafter(Drafter):
                 outputs,
                 draft_position=0,
                 draft_length=self.max_draft_tokens,
-                num_draft_reqs=num_draft_reqs)
+                draft_batch=draft_batch,
+                req_id_to_old_request=req_id_to_old_request)
             return target_inputs, outputs, draft_batch
 
         # Handle guided decoder and sampling for non-static loop
@@ -656,7 +664,8 @@ class ModelDrafter(Drafter):
             draft_tensors,
             draft_position=0,
             draft_length=1,
-            num_draft_reqs=num_draft_reqs)
+            draft_batch=draft_batch,
+            req_id_to_old_request=req_id_to_old_request)
 
         self.update_request_states(draft_batch)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Corrected token alignment during speculative decoding, reducing errors in overlap and mixed in-progress scenarios.
  - Improved stability of KV-cache handling when drafts map back to original requests.

- Refactor
  - Streamlined draft token transfer and mapping to original requests for more reliable drafting flows.
  - Deferred allocation of draft-related tensors to reduce unnecessary work and edge-case issues.

- Documentation
  - Updated docstrings to reflect revised drafting interfaces and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->
The batch index of draft and target requests should be used for updating the device tensors.


## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
