### PR TITLE
[https://nvbugs/5498478][fix] Fix eagle3 fp8 kv target model + bf16 draft model + chunked prefill

### DIFF
--- a/cpp/tensorrt_llm/common/attentionOp.cpp
+++ b/cpp/tensorrt_llm/common/attentionOp.cpp
@@ -2674,16 +2674,6 @@ int AttentionOp::initialize() noexcept
             fmhaParams.dataTypeKv = DATA_TYPE_E4M3;
             fmhaParams.dataTypeOut = DATA_TYPE_BF16;
         }
-        if (mFP8FmhaForEagle3)
-        {
-            // use FP8 FMHA for Eagle3 with FP8 target model and BF16/FP16 draft model
-            FmhaDispatcher tempFmhaDispatcher(fmhaParams);
-            // use FP8 output for non-TllmGen, because FP8 TllmGen supports BF16/FP16 output
-            if (!tempFmhaDispatcher.useTllmGen())
-            {
-                fmhaParams.dataTypeOut = DATA_TYPE_E4M3;
-            }
-        }
         // TODO: remove forceFp32Acc from MHARunnerFixedParams after adding host_runtime_perf_knobs to
         // bertAttentionPlugin input tensors, so that we can change mLaunchParams.force_fp32_acc value in runtime.
         fmhaParams.forceFp32Acc = false;
@@ -2733,6 +2723,16 @@ int AttentionOp::initialize() noexcept
         fmhaParams.attnLogitSoftcappingScale = mAttnLogitSoftcappingScale;
         fmhaParams.hasAlibi = isALiBi();
         fmhaParams.scaleAlibi = isAliBiWithScale();
+        if (mFP8FmhaForEagle3)
+        {
+            // use FP8 FMHA for Eagle3 with FP8 target model and BF16/FP16 draft model
+            FmhaDispatcher tempFmhaDispatcher(fmhaParams);
+            // use FP8 output for non-TllmGen, because FP8 TllmGen supports BF16/FP16 output
+            if (!tempFmhaDispatcher.useTllmGen())
+            {
+                fmhaParams.dataTypeOut = DATA_TYPE_E4M3;
+            }
+        }
 
         // Load kernels from the pre-compiled cubins.
         mFmhaDispatcher.reset(new FmhaDispatcher(fmhaParams));

--- a/cpp/tensorrt_llm/common/attentionOp.h
+++ b/cpp/tensorrt_llm/common/attentionOp.h
@@ -137,6 +137,9 @@ public:
         T const* k_ptr = nullptr;
         T const* v_ptr = nullptr;
 
+        // optional for mFP8FmhaForEagle3
+        int64_t output_tensor_numel = 0;
+
         std::string enqueueContextParamsToString() const
         {
             // variables from the params coming from the runtime
@@ -190,6 +193,7 @@ public:
             ss << "softmaxStatsPtr: " << this->softmax_stats << std::endl;
             ss << "k_ptr: " << this->k_ptr << std::endl;
             ss << "v_ptr: " << this->v_ptr << std::endl;
+            ss << "output_tensor_numel: " << this->output_tensor_numel << std::endl;
             return ss.str();
         }
     };
@@ -422,6 +426,7 @@ public:
     bool mIsSpecDecodingEnabled = false;
     bool mUseSpecDecoding = false;
     bool mIsSpecDecTree = true;
+    bool mFP8FmhaForEagle3 = false;
     bool mSpecDecodingIsGenerationLengthVariable = false;
     int32_t mSpecDecodingMaxGenerationLength = 1;
     bool mIsMLAEnabled = false;

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/decoderXQAImplJIT.cpp
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/decoderXQAImplJIT.cpp
@@ -124,6 +124,14 @@ bool DecoderXQAImplJIT::shouldUse(XQAParams const& umbrellaXQAParams, bool forCo
         bool hasPerfGain = mayHavePerfGain(xqaParams);
         if (!hasPerfGain)
         {
+            if (xqaParams.kv_cache_data_type == DATA_TYPE_E4M3
+                && (xqaParams.data_type == DATA_TYPE_BF16 || xqaParams.data_type == DATA_TYPE_FP16))
+            {
+                TLLM_LOG_DEBUG(
+                    "JIT XQA is selected in the generation phase for fp16/bf16 input and e4m3 kv cache because MMHA "
+                    "does not support this combination.");
+                return true;
+            }
             TLLM_LOG_DEBUG("JIT XQA is not used: maybe no performance gain");
             return false;
         }

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/decoderXQAImplJIT.cpp
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/decoderXQAImplJIT.cpp
@@ -124,7 +124,7 @@ bool DecoderXQAImplJIT::shouldUse(XQAParams const& umbrellaXQAParams, bool forCo
         bool hasPerfGain = mayHavePerfGain(xqaParams);
         if (!hasPerfGain)
         {
-            if (xqaParams.kv_cache_data_type == DATA_TYPE_E4M3
+            if (!xqaParams.is_fp8_output && xqaParams.kv_cache_data_type == DATA_TYPE_E4M3
                 && (xqaParams.data_type == DATA_TYPE_BF16 || xqaParams.data_type == DATA_TYPE_FP16))
             {
                 TLLM_LOG_DEBUG(

--- a/cpp/tensorrt_llm/kernels/fmhaDispatcher.h
+++ b/cpp/tensorrt_llm/kernels/fmhaDispatcher.h
@@ -40,6 +40,12 @@ public:
     // Check if any fmha kernel meets the requirements.
     bool isSupported();
 
+    // Whether to use trtllm-gen kernels.
+    bool useTllmGen() const
+    {
+        return mUseTllmGen;
+    }
+
     // Does FMHA need a separate Q and Kv input ?
     bool isSeparateQAndKvInput() const
     {

--- a/cpp/tensorrt_llm/kernels/xqaDispatcher.cpp
+++ b/cpp/tensorrt_llm/kernels/xqaDispatcher.cpp
@@ -244,15 +244,6 @@ bool XqaDispatcher::shouldUse(XQAParams const& params)
         return true;
     }
 
-    if (params.kv_cache_data_type == DATA_TYPE_E4M3
-        && (params.data_type == DATA_TYPE_BF16 || params.data_type == DATA_TYPE_FP16))
-    {
-        TLLM_LOG_DEBUG(
-            "XQA kernels are selected in the generation phase for fp16/bf16 input and e4m3 kv cache because MMHA does "
-            "not support this combination.");
-        return true;
-    }
-
     return mDecoderXqaRunner->shouldUse(params, /*forConfigurePlugin=*/false);
 }
 

--- a/cpp/tensorrt_llm/kernels/xqaDispatcher.cpp
+++ b/cpp/tensorrt_llm/kernels/xqaDispatcher.cpp
@@ -243,7 +243,6 @@ bool XqaDispatcher::shouldUse(XQAParams const& params)
 
         return true;
     }
-
     return mDecoderXqaRunner->shouldUse(params, /*forConfigurePlugin=*/false);
 }
 

--- a/cpp/tensorrt_llm/kernels/xqaDispatcher.cpp
+++ b/cpp/tensorrt_llm/kernels/xqaDispatcher.cpp
@@ -243,6 +243,16 @@ bool XqaDispatcher::shouldUse(XQAParams const& params)
 
         return true;
     }
+
+    if (params.kv_cache_data_type == DATA_TYPE_E4M3
+        && (params.data_type == DATA_TYPE_BF16 || params.data_type == DATA_TYPE_FP16))
+    {
+        TLLM_LOG_DEBUG(
+            "XQA kernels are selected in the generation phase for fp16/bf16 input and e4m3 kv cache because MMHA does "
+            "not support this combination.");
+        return true;
+    }
+
     return mDecoderXqaRunner->shouldUse(params, /*forConfigurePlugin=*/false);
 }
 

--- a/tensorrt_llm/_torch/models/modeling_speculative.py
+++ b/tensorrt_llm/_torch/models/modeling_speculative.py
@@ -65,6 +65,7 @@ class Eagle3Attention(Attention):
             skip_create_weights_in_init=model_config.
             skip_create_weights_in_init,
         )
+        self.is_eagle3 = True
 
 
 class Eagle3DecoderLayer(DecoderLayer):

--- a/tests/unittest/_torch/speculative/test_eagle3.py
+++ b/tests/unittest/_torch/speculative/test_eagle3.py
@@ -28,9 +28,18 @@ def enforce_single_worker(monkeypatch):
         [True, "TRTLLM", True, False, False, False, True, False, False, False],
         [True, "TRTLLM", True, False, False, False, False, False, False, False],
         [False, "TRTLLM", True, False, False, False, True, False, False, False],
-        [False, "TRTLLM", True, False, False, False, False, False, False, False],
-        [True, "FLASHINFER", True, False, False, False, True, False, False, False],
-        [False, "FLASHINFER", True, False, False, False, True, False, False, False],
+        [
+            False, "TRTLLM", True, False, False, False, False, False, False,
+            False
+        ],
+        [
+            True, "FLASHINFER", True, False, False, False, True, False, False,
+            False
+        ],
+        [
+            False, "FLASHINFER", True, False, False, False, True, False, False,
+            False
+        ],
         [False, "TRTLLM", False, True, True, False, True, False, False, False],
         [True, "TRTLLM", False, True, True, False, True, False, False, False],
         [True, "TRTLLM", True, False, True, True, True, False, False, False],
@@ -38,10 +47,37 @@ def enforce_single_worker(monkeypatch):
         # TODO: nvbugs/5461761
         # [True, "TRTLLM", True, False, False, True, True, False, False, False],
         [True, "TRTLLM", False, False, False, False, True, False, False, False],
-        [False, "TRTLLM", False, False, False, False, True, False, False, False],
+        [
+            False, "TRTLLM", False, False, False, False, True, False, False,
+            False
+        ],
         [True, "TRTLLM", False, False, False, False, False, True, False, False],
         [True, "TRTLLM", False, False, False, False, False, True, True, False],
-        [True, "TRTLLM", False, True, True, True, True, True, True, True],
+        [
+            False, "TRTLLM", False, False, False, False, False, True, False,
+            False
+        ],
+        [True, "TRTLLM", False, False, False, False, True, True, False, False],
+        [False, "TRTLLM", False, False, False, False, True, True, False, False],
+        [
+            True, "TRTLLM", False, False, False, False, False, False, False,
+            False
+        ],
+        [
+            False, "TRTLLM", False, False, False, False, False, False, False,
+            False
+        ],
+        [True, "TRTLLM", False, False, False, True, True, False, False, False],
+        [True, "TRTLLM", False, False, False, True, False, False, False, False],
+        [
+            True, "FLASHINFER", False, False, False, False, True, False, False,
+            False
+        ],
+        [
+            False, "FLASHINFER", False, False, False, False, True, False, False,
+            False
+        ],
+        [True, "TRTLLM", False, True, True, True, True, True, True, True, True],
     ])
 @pytest.mark.high_cuda_memory
 def test_llama_eagle3(use_cuda_graph: bool, attn_backend: str,

--- a/tests/unittest/_torch/speculative/test_eagle3.py
+++ b/tests/unittest/_torch/speculative/test_eagle3.py
@@ -77,7 +77,7 @@ def enforce_single_worker(monkeypatch):
             False, "FLASHINFER", False, False, False, False, True, False, False,
             False
         ],
-        [True, "TRTLLM", False, True, True, True, True, True, True, True, True],
+        [True, "TRTLLM", False, True, True, True, True, True, True, True],
     ])
 @pytest.mark.high_cuda_memory
 def test_llama_eagle3(use_cuda_graph: bool, attn_backend: str,

--- a/tests/unittest/_torch/speculative/test_eagle3.py
+++ b/tests/unittest/_torch/speculative/test_eagle3.py
@@ -2,6 +2,7 @@ import json
 import os
 import sys
 import tempfile
+import unittest
 from pathlib import Path
 
 import pytest
@@ -355,7 +356,6 @@ def test_multi_eagle3(use_one_model: bool):
             pass
 
 
-<<<<<<< HEAD
 @pytest.mark.parametrize("disable_overlap_scheduler", [True, False])
 def test_eagle3_cuda_graph_padding(disable_overlap_scheduler: bool):
     """Test CUDA graph padding with 3 requests and max_batch_size=4.


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->
Fix eagle3 fp8 kv target model + bf16 draft model + chunked prefill by mandating the use of FP8 FMHA in draft layers, because the attention of the 2nd chunk context phase needs to load FP8 KV cache.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->
A test of eagle3 + FP8 KV target model + bf16 draft model + chunked prefill is added:
tests/unittest/_torch/speculative/test_eagle3.py::test_llama_eagle3[True-TRTLLM-False-True-True-True-True-True-True]


## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
