### PR TITLE
[https://nvbugs/5519544][fix] fix invalid expression for disabling pa…

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -895,7 +895,7 @@ def _load_weights_impl(model: Union[nn.Module, DecoderModelForCausalLM],
                             p.data.copy_(module_weights[n][:])
 
     if os.environ.get("TRT_LLM_DISABLE_LOAD_WEIGHTS_IN_PARALLEL",
-                      False) in ["True", "true", "1", "yes", "y"]:
+                      "True") in ["True", "true", "1", "yes", "y"]:
         for name, module in tqdm(list(model.named_modules()),
                                  desc="Loading weights"):
             load_single_module(name, module)


### PR DESCRIPTION
…rallel loading

It's a cherry-pick PR of #7762


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Default behavior now loads model weights sequentially rather than in parallel, improving stability and compatibility across diverse environments (especially constrained or multi-process setups).
  - You may notice slightly longer initial load times; inference performance is unaffected.
  - Advanced users can opt back into parallel loading via environment configuration if needed.
  - No public APIs were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->