### PR TITLE
[#4674][bugfix] AutoDeploy Fix memory leak in fuse_moe

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -107,7 +107,7 @@ transforms:
     backend: trtllm
   fuse_moe:
     stage: post_load_fusion
-    enabled: false # TODO: https://github.com/NVIDIA/TensorRT-LLM/issues/4674 this is causing OOMs
+    enabled: true
   fuse_allreduce_residual_rmsnorm:
     stage: post_load_fusion
   fuse_collectives:

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
@@ -113,124 +113,73 @@ def _insert_fused_moe_ops(gm: GraphModule) -> int:
         node.replace_all_uses_with(new_node)
         graph.erase_node(node)
 
-        mem_after = _cuda_mem_allocated()
-        delta = (
-            (mem_after - mem_before) if (mem_before is not None and mem_after is not None) else None
+        _cleanup_unstacked_weights(
+            gm,
+            node,
+            mem_before,
+            created_bytes,
+            this_fusion_param_names,
+            total_cuda_delta,
+            total_freed_param_bytes,
         )
-        if delta is not None:
-            total_cuda_delta += max(delta, 0)
-        ad_logger.info(
-            f"[fuse_moe] Fused MoE params for node={getattr(node, 'name', 'unknown')} | "
-            f"CUDA Δ={_fmt_bytes(delta if delta is not None else 0)} | "
-            f"created params={_fmt_bytes(created_bytes)} | "
-            f"CUDA after={_fmt_bytes(mem_after)}"
-        )
-
-        # Per-fusion cleanup: DCE then unregister any now-unreferenced original params for this fusion.
-        try:
-            gm.graph.eliminate_dead_code()
-        except Exception:
-            pass
-
-        used_attr_names_iter = set()
-        for n in gm.graph.nodes:
-            if getattr(n, "op", None) == "get_attr":
-                used_attr_names_iter.add(getattr(n, "target", None))
-
-        names_to_unregister_iter = [
-            name for name in this_fusion_param_names if name not in used_attr_names_iter
-        ]
-
-        freed_param_bytes_iter = 0
-        for name in names_to_unregister_iter:
-            param_obj = None
-            try:
-                # Use GraphModule API to robustly fetch parameter by dotted path
-                param_obj = gm.get_parameter(name)
-            except Exception:
-                param_obj = None
-            if isinstance(param_obj, torch.nn.Parameter):
-                try:
-                    freed_param_bytes_iter += param_obj.element_size() * param_obj.numel()
-                except Exception:
-                    pass
-            # Remove from owning submodule
-            try:
-                owner_mod, leaf = _resolve_owner_module_and_leaf_attr(gm, name)
-                if hasattr(owner_mod, "_parameters") and leaf in owner_mod._parameters:
-                    owner_mod._parameters.pop(leaf, None)
-                if hasattr(owner_mod, leaf):
-                    delattr(owner_mod, leaf)
-            except Exception:
-                pass
-            # Drop local ref
-            del param_obj
-
-        if names_to_unregister_iter:
-            total_freed_param_bytes += freed_param_bytes_iter
-            ad_logger.info(
-                (
-                    f"[fuse_moe] Per-fusion unregistered {len(names_to_unregister_iter)} params | "
-                    f"approx freed={_fmt_bytes(freed_param_bytes_iter)}"
-                )
-            )
-            try:
-                if torch.cuda.is_available():
-                    torch.cuda.empty_cache()
-            except Exception:
-                pass
-
-    # Eliminate dead nodes first, then unregister any original params no longer referenced.
-    try:
-        gm.graph.eliminate_dead_code()
-    except Exception:
-        pass
-
-    used_attr_names = set()
-    for n in gm.graph.nodes:
-        if getattr(n, "op", None) == "get_attr":
-            used_attr_names.add(getattr(n, "target", None))
-
-    names_to_unregister = [name for name in original_param_names if name not in used_attr_names]
-
-    freed_param_bytes = 0
-    for name in names_to_unregister:
-        param_obj = None
-        try:
-            param_obj = gm.get_parameter(name)
-        except Exception:
-            param_obj = None
-        if isinstance(param_obj, torch.nn.Parameter):
-            try:
-                freed_param_bytes += param_obj.element_size() * param_obj.numel()
-            except Exception:
-                pass
-        try:
-            owner_mod, leaf = _resolve_owner_module_and_leaf_attr(gm, name)
-            if hasattr(owner_mod, "_parameters") and leaf in owner_mod._parameters:
-                owner_mod._parameters.pop(leaf, None)
-            if hasattr(owner_mod, leaf):
-                delattr(owner_mod, leaf)
-        except Exception:
-            pass
-        del param_obj
-
-    ad_logger.info(
-        (
-            f"[fuse_moe] Unregistered {len(names_to_unregister)} original parameters | "
-            f"approx freed={_fmt_bytes(freed_param_bytes)} | "
-            f"per-fusion freed total={_fmt_bytes(total_freed_param_bytes)}"
-        )
-    )
-
-    summary_msg = (
-        f"[fuse_moe] Summary: fused={fused_key_counter} | "
-        f"total created params={_fmt_bytes(total_created_param_bytes)} | "
-        f"net CUDA increase (observed)={_fmt_bytes(total_cuda_delta)}"
-    )
-    ad_logger.info(summary_msg)
 
     return fused_key_counter
+
+
+def _cleanup_unstacked_weights(
+    gm,
+    node,
+    mem_before,
+    created_bytes,
+    this_fusion_param_names,
+    total_cuda_delta,
+    total_freed_param_bytes,
+):
+    """DCE then unregister any now-unreferenced original params for this fusion"""
+    mem_after = _cuda_mem_allocated()
+    delta = (mem_after - mem_before) if (mem_before is not None and mem_after is not None) else None
+    if delta is not None:
+        total_cuda_delta += max(delta, 0)
+    ad_logger.info(
+        f"[fuse_moe] Fused MoE params for node={getattr(node, 'name', 'unknown')} | "
+        f"CUDA Δ={_fmt_bytes(delta if delta is not None else 0)} | "
+        f"created params={_fmt_bytes(created_bytes)} | "
+        f"CUDA after={_fmt_bytes(mem_after)}"
+    )
+
+    gm.graph.eliminate_dead_code()
+
+    used_attr_names_iter = set()
+    for n in gm.graph.nodes:
+        if getattr(n, "op", None) == "get_attr":
+            used_attr_names_iter.add(getattr(n, "target", None))
+
+    names_to_unregister_iter = [
+        name for name in this_fusion_param_names if name not in used_attr_names_iter
+    ]
+
+    freed_param_bytes_iter = 0
+    for name in names_to_unregister_iter:
+        param_obj = gm.get_parameter(name)
+        if isinstance(param_obj, torch.nn.Parameter):
+            freed_param_bytes_iter += param_obj.element_size() * param_obj.numel()
+        owner_mod, leaf = _resolve_owner_module_and_leaf_attr(gm, name)
+        if hasattr(owner_mod, "_parameters") and leaf in owner_mod._parameters:
+            owner_mod._parameters.pop(leaf, None)
+        if hasattr(owner_mod, leaf):
+            delattr(owner_mod, leaf)
+        del param_obj
+
+    if names_to_unregister_iter:
+        total_freed_param_bytes += freed_param_bytes_iter
+        ad_logger.info(
+            (
+                f"[fuse_moe] Per-fusion unregistered {len(names_to_unregister_iter)} params | "
+                f"approx freed={_fmt_bytes(freed_param_bytes_iter)}"
+            )
+        )
+        # Flush CUDA cache since we freed large chunks of memory
+        torch.cuda.empty_cache()
 
 
 def _find_lowest_common_ancessor(nodes: list[Node]) -> Optional[Node]:
@@ -560,7 +509,6 @@ class MatchMoePattern(BaseTransform):
         shared_config: SharedConfig,
     ) -> Tuple[GraphModule, TransformInfo]:
         graph = gm.graph
-        total_cuda_delta = 0
 
         # Preprocessing: Identify boundary nodes (e.g. residual connections) in the graph.
         boundary_nodes = identify_regions_between_residuals(gm)
@@ -620,7 +568,6 @@ class MatchMoePattern(BaseTransform):
                 continue
 
             # Step 5: Insert the MoE op into the graph.
-            mem_before = _cuda_mem_allocated()
             with graph.inserting_before(final_hidden_state_node):
                 w1_list = expert_weights["w1"]
                 w2_list = expert_weights["w2"]
@@ -650,34 +597,10 @@ class MatchMoePattern(BaseTransform):
             final_hidden_state_node.replace_all_uses_with(fused_moe_node)
             graph.erase_node(final_hidden_state_node)
 
-            mem_after = _cuda_mem_allocated()
-            delta = (
-                mem_after - mem_before
-                if (mem_before is not None and mem_after is not None)
-                else None
-            )
-            if delta is not None:
-                total_cuda_delta += max(delta, 0)
-            ad_logger.info(
-                (
-                    f"[match_moe_pattern] Inserted at node="
-                    f"{getattr(final_hidden_state_node, 'name', 'unknown')} | "
-                    f"CUDA Δ={_fmt_bytes(delta if delta is not None else 0)} | "
-                    f"CUDA after={_fmt_bytes(mem_after)}"
-                )
-            )
-
             while _remove_dead_inplace_nodes_in_region(gm.graph, start_boundary, end_boundary):
                 gm.graph.eliminate_dead_code()
 
             num_moe_patterns += 1
-
-        ad_logger.info(
-            (
-                f"[match_moe_pattern] Summary: inserted={num_moe_patterns} | "
-                f"net CUDA increase (observed)={_fmt_bytes(total_cuda_delta)}"
-            )
-        )
 
         info = TransformInfo(
             skipped=False, num_matches=num_moe_patterns, is_clean=False, has_valid_shapes=False

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
@@ -100,10 +100,7 @@ def _cleanup_unstacked_weights(
     for name in names_to_unregister_iter:
         param_obj = gm.get_parameter(name)
         owner_mod, leaf = _resolve_owner_module_and_leaf_attr(gm, name)
-        if hasattr(owner_mod, "_parameters") and leaf in owner_mod._parameters:
-            owner_mod._parameters.pop(leaf, None)
-        if hasattr(owner_mod, leaf):
-            delattr(owner_mod, leaf)
+        delattr(owner_mod, leaf)
         del param_obj
 
     # Flush CUDA cache since we freed large chunks of memory

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
@@ -40,13 +40,10 @@ def _insert_fused_moe_ops(gm: GraphModule) -> int:
 
         # Track original parameter names for later safe unregistration.
         this_fusion_param_names = set()
-        try:
-            this_fusion_param_names.update([n.target for n in w1_list])
-            this_fusion_param_names.update([n.target for n in w2_list])
-            this_fusion_param_names.update([n.target for n in w3_list])
-            original_param_names.update(this_fusion_param_names)
-        except Exception:
-            pass
+        this_fusion_param_names.update([n.target for n in w1_list])
+        this_fusion_param_names.update([n.target for n in w2_list])
+        this_fusion_param_names.update([n.target for n in w3_list])
+        original_param_names.update(this_fusion_param_names)
 
         fused_w3_w1_experts = torch.stack(
             [
@@ -108,11 +105,8 @@ def _cleanup_unstacked_weights(
         name for name in this_fusion_param_names if name not in used_attr_names_iter
     ]
 
-    freed_param_bytes_iter = 0
     for name in names_to_unregister_iter:
         param_obj = gm.get_parameter(name)
-        if isinstance(param_obj, torch.nn.Parameter):
-            freed_param_bytes_iter += param_obj.element_size() * param_obj.numel()
         owner_mod, leaf = _resolve_owner_module_and_leaf_attr(gm, name)
         if hasattr(owner_mod, "_parameters") and leaf in owner_mod._parameters:
             owner_mod._parameters.pop(leaf, None)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  - Enabled Mixture-of-Experts (MoE) fusion during post-load fusion, improving out-of-the-box optimization for supported models.
* Performance
  - Reduced peak GPU memory usage during MoE fusion by immediately removing dead subgraphs and unused components after fusion.
* Tests
  - Added unit tests to verify parameter reduction and stable CUDA memory after MoE fusion cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description
AutoDeploy's fuse_moe transformation was previously disabled due to excessive memory usage. The transformation is stacking the expert weights, but fails to remove the unstacked weights that are no longer in use, causing a x2 memory bloating. This PR locates the unused parameters and removes them from the graph, allowing for memory deallocation.

## Test Coverage
- AutoDeploy dashboard doesn't crash with OOM.
- _torch/auto_deploy/unit/singlegpu/transformations/library/test_moe_fusion.py::test_fuse_moe_cleanup

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
