### PR TITLE
[TRTLLM-8129][feat] Allreduce tuning and benchmark script revising

### DIFF
--- a/cpp/tensorrt_llm/common/customAllReduceUtils.h
+++ b/cpp/tensorrt_llm/common/customAllReduceUtils.h
@@ -16,8 +16,14 @@
 
 #pragma once
 
+#include "tensorrt_llm/common/cudaUtils.h"
 #include "tensorrt_llm/common/envUtils.h"
+#include "tensorrt_llm/kernels/customAllReduceKernels.h"
 #include <cstddef>
+#include <unordered_map>
+
+using tensorrt_llm::kernels::AllReduceFusionOp;
+using tensorrt_llm::kernels::AllReduceStrategyType;
 
 namespace tensorrt_llm::utils::customAllReduceUtils
 {
@@ -38,4 +44,253 @@ inline size_t getMaxRequiredWorkspaceSize(int worldSize) noexcept
     return 8 * 1000 * 1000;
 }
 
+// (SM major_version, TP_size) -> (NCCL_num_token_threshold, TWO_SHOT_numel_threshold)
+inline std::unordered_map<int, std::unordered_map<int, std::pair<size_t, size_t>>> HeuristicThresholdLP{
+    {90,
+        {
+            {2, {4096, 4096 * 4096}},
+            {4, {4096, 1024 * 1024}},
+            {8, {2048, 512 * 512}},
+        }},
+    {100,
+        {
+            {2, {4096, 4096 * 4096}},
+            {4, {4096, 1024 * 2048}},
+            {8, {4096, 1024 * 1024}},
+        }},
+};
+
+inline AllReduceStrategyType SelectStrategyLP(size_t seq_len, size_t hidden_size, int world_size, AllReduceFusionOp op)
+{
+    // The heuristic is based on the following assumptions:
+    //  __________________________________
+    // |              \ TWO-SHOT zone |
+    // | ONE-SHOT zone    \           | NCCL zone
+    // |_______________________\______|___
+    // sm_major is 90 or 100
+
+    auto const sm_major = std::min(100, std::max(90, tensorrt_llm::common::getSMVersion()));
+
+    auto const [nccl_num_token_threshold, two_shot_numel_threshold] = HeuristicThresholdLP[sm_major][world_size];
+    auto const message_size = seq_len * hidden_size;
+    if (message_size >= two_shot_numel_threshold)
+    {
+        return AllReduceStrategyType::TWOSHOT;
+    }
+    else
+    {
+        return AllReduceStrategyType::ONESHOT;
+    }
+    return AllReduceStrategyType::NCCL;
+}
+
+// use 1D vector to store the best strategy instead of a map for each sm version
+// store int value instead of enum class
+// The following layout, flattened to 1D vector
+// (SM, TP, fusionOp, hidden_size, num_tokens) -> strategy
+// table size estimate:
+// SM: (<=90, 100)
+// TP: (2, 4, 8)
+// hidden_size: (128, 256, 512, 1024, 2048, 4096, 8192)
+// fusionOp: (NONE, RESIDUAL_RMS_NORM, RESIDUAL_RMS_NORM_QUANT_FP8, RESIDUAL_RMS_NORM_QUANT_NVFP4)
+// num_tokens: (1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384)
+// total size: 2 * 3 * 4 * 7 * 14 = 2352
+
+constexpr int kTpSizeChoice = 3;
+constexpr int kFusionOpChoice = 4;
+constexpr int kHiddenSizeChoice = 7;
+constexpr int kNumTokensChoice = 14;
+
+inline std::unordered_map<AllReduceFusionOp, int> mapFusionOpToIndex = {
+    {AllReduceFusionOp::NONE, 0},
+    {AllReduceFusionOp::RESIDUAL_RMS_NORM, 1},
+    {AllReduceFusionOp::RESIDUAL_RMS_NORM_QUANT_FP8, 2},
+    {AllReduceFusionOp::RESIDUAL_RMS_NORM_QUANT_NVFP4, 3},
+    // norm out quant fusion ops share the same index with norm quant fusion ops
+    {AllReduceFusionOp::RESIDUAL_RMS_NORM_OUT_QUANT_FP8, 2},
+    {AllReduceFusionOp::RESIDUAL_RMS_NORM_OUT_QUANT_NVFP4, 3},
+};
+
+// AllReduce lookup: [tp][fusion][hidden][tokens] = strategy
+// TP:[2, 4, 8]
+// Fusion:['NONE', 'RESIDUAL_RMS_NORM']
+// Hidden:[128, 256, 512, 1024, 2048, 4096, 8192]
+// Tokens:[1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384]
+
+using AllReduceBestStrategyTableType = std::vector<std::vector<std::vector<std::vector<int>>>>;
+
+// Forward declarations for strategy tables
+extern const std::unordered_map<int, AllReduceBestStrategyTableType> AllReduceBestStrategyTable;
+
+inline AllReduceStrategyType selectStrategyLookUpTable(
+    size_t num_tokens, size_t hidden_size, AllReduceFusionOp fusionOp, int tp_size)
+{
+    auto sm_version = tensorrt_llm::common::getSMVersion();
+    auto tp_index = static_cast<size_t>(std::log2(tp_size) - 1);
+    auto fusion_op_index = static_cast<size_t>(mapFusionOpToIndex.find(fusionOp)->second);
+    auto num_token_index = static_cast<size_t>(std::log2(num_tokens));
+    auto hidden_size_index = static_cast<size_t>(std::log2(hidden_size) - 7);
+
+    // Map all pre-Blackwell sm versions to 90 for now
+    if (sm_version < 100)
+    {
+        sm_version = 90;
+    }
+
+    // Map all post-Blackwell sm versions to 100 for now
+    if (sm_version >= 100)
+    {
+        sm_version = 100;
+    }
+
+    // Check if the entry is out of bounds, otherwise return NCCL as fallback
+    if (AllReduceBestStrategyTable.find(sm_version) == AllReduceBestStrategyTable.end()
+        || tp_index >= AllReduceBestStrategyTable.at(sm_version).size()
+        || fusion_op_index >= AllReduceBestStrategyTable.at(sm_version).at(tp_index).size()
+        || hidden_size_index >= AllReduceBestStrategyTable.at(sm_version).at(tp_index).at(fusion_op_index).size()
+        || num_token_index
+            >= AllReduceBestStrategyTable.at(sm_version).at(tp_index).at(fusion_op_index).at(hidden_size_index).size())
+    {
+        return AllReduceStrategyType::NCCL;
+    }
+
+    return static_cast<AllReduceStrategyType>(
+        AllReduceBestStrategyTable.at(sm_version)[tp_index][fusion_op_index][hidden_size_index][num_token_index]);
+}
+
+// Strategy table definitions
+inline AllReduceBestStrategyTableType AllReduceBestStrategyTableSM90
+    = {{    // TP=2
+           {// Fusion=NONE
+               {4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 4, 4, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 5, 4, 4, 4, 4, 4, 4, 0, 0},
+               {4, 4, 5, 4, 4, 5, 5, 5, 4, 5, 4, 4, 4, 0, 0}, {4, 4, 4, 4, 5, 4, 5, 4, 4, 4, 4, 4, 0, 0, 0},
+               {4, 4, 4, 4, 4, 5, 5, 5, 5, 4, 4, 5, 0, 0, 0}, {4, 5, 4, 5, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0},
+               {4, 4, 5, 5, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0, 0}},
+           {// Fusion=RESIDUAL_RMS_NORM
+               {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0},
+               {4, 4, 4, 4, 5, 5, 5, 5, 4, 4, 4, 4, 0, 0, 0}, {4, 4, 4, 4, 4, 5, 5, 4, 5, 4, 4, 4, 0, 0, 0},
+               {4, 4, 4, 5, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0}, {4, 4, 4, 4, 5, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0},
+               {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0, 0}},
+           {// Fusion=RESIDUAL_RMS_NORM_QUANT_FP8
+               {4, 4, 4, 4, 4, 5, 5, 5, 4, 4, 4, 4, 0, 0, 0}, {4, 4, 4, 5, 4, 4, 5, 4, 4, 5, 4, 4, 4, 0, 0},
+               {4, 4, 4, 4, 5, 5, 5, 5, 5, 4, 4, 4, 4, 0, 0}, {4, 4, 4, 5, 5, 5, 5, 4, 5, 4, 4, 4, 4, 0, 0},
+               {4, 4, 4, 5, 5, 4, 4, 4, 5, 4, 4, 4, 0, 0, 0}, {4, 4, 5, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0},
+               {4, 4, 5, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0, 0}},
+           {// Fusion=RESIDUAL_RMS_NORM_QUANT_NVFP4
+               {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+               {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+               {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+               {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}},
+        {    // TP=4
+            {// Fusion=NONE
+                {4, 4, 4, 4, 5, 4, 4, 5, 4, 5, 4, 4, 0, 0, 0}, {4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 4, 0, 0, 0, 0},
+                {4, 4, 4, 4, 5, 4, 5, 5, 5, 4, 4, 5, 0, 0, 0}, {4, 4, 4, 4, 4, 5, 5, 4, 5, 4, 5, 5, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 5, 4, 5, 5, 0, 0, 0, 0}, {4, 4, 4, 5, 5, 5, 5, 4, 5, 5, 0, 0, 0, 0, 0},
+                {4, 4, 4, 4, 4, 5, 4, 5, 5, 0, 0, 0, 0, 0, 0}},
+            {// Fusion=RESIDUAL_RMS_NORM
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 5, 4, 4, 4, 4, 5, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 0, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 0, 0, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 5, 0, 0, 0, 0, 0, 0}},
+            {// Fusion=RESIDUAL_RMS_NORM_QUANT_FP8
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0}, {4, 4, 4, 4, 4, 5, 5, 4, 5, 4, 4, 4, 0, 0, 0},
+                {4, 4, 4, 4, 4, 5, 4, 5, 5, 4, 4, 5, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 0, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 0, 0, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 5, 0, 0, 0, 0, 0, 0}},
+            {// Fusion=RESIDUAL_RMS_NORM_QUANT_NVFP4
+                {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+                {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+                {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+                {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}},
+        {    // TP=8
+            {// Fusion=NONE
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 0, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 0, 0, 0, 0, 0},
+                {4, 4, 4, 4, 4, 5, 5, 5, 5, 0, 0, 0, 0, 0, 0}},
+            {// Fusion=RESIDUAL_RMS_NORM
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 0, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 0, 5, 5, 0, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
+            {// Fusion=RESIDUAL_RMS_NORM_QUANT_FP8
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 0, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 0, 5, 5, 0, 0, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 0, 0, 5, 0, 0, 0, 0, 0, 0}},
+            {// Fusion=RESIDUAL_RMS_NORM_QUANT_NVFP4
+                {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+                {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+                {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+                {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}}};
+
+inline AllReduceBestStrategyTableType AllReduceBestStrategyTableSM100
+    = {{    // TP=2
+           {// Fusion=NONE
+               {4, 4, 4, 4, 4, 4, 4, 4, 5, 4, 4, 4, 0, 0, 0}, {4, 4, 4, 4, 5, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0},
+               {4, 4, 4, 5, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0}, {4, 4, 4, 5, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0},
+               {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0},
+               {4, 4, 5, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0, 0}},
+           {// Fusion=RESIDUAL_RMS_NORM
+               {4, 4, 4, 4, 5, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0},
+               {4, 4, 4, 4, 5, 4, 4, 4, 5, 4, 4, 4, 4, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0},
+               {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0},
+               {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0, 0}},
+           {// Fusion=RESIDUAL_RMS_NORM_QUANT_FP8
+               {4, 4, 4, 4, 5, 4, 5, 5, 4, 4, 4, 4, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 5, 4, 4, 4, 4, 4, 0, 0, 0},
+               {4, 4, 4, 4, 5, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0}, {4, 4, 4, 4, 4, 5, 5, 4, 4, 4, 4, 4, 4, 0, 0},
+               {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0},
+               {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0, 0}},
+           {// Fusion=RESIDUAL_RMS_NORM_QUANT_NVFP4
+               {4, 4, 4, 5, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0},
+               {4, 4, 4, 4, 5, 5, 4, 4, 4, 4, 4, 4, 4, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0},
+               {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0},
+               {4, 4, 5, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0, 0}}},
+        {    // TP=4
+            {// Fusion=NONE
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 0, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 0, 0, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 5, 0, 0, 0, 0, 0, 0}},
+            {// Fusion=RESIDUAL_RMS_NORM
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 0, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 0, 0, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0, 0, 0}},
+            {// Fusion=RESIDUAL_RMS_NORM_QUANT_FP8
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 0, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 0, 0, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0, 0, 0}},
+            {// Fusion=RESIDUAL_RMS_NORM_QUANT_NVFP4
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 0, 0, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0, 0, 0}}},
+        {    // TP=8
+            {// Fusion=NONE
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 0, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 0, 0, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 5, 5, 0, 0, 0, 0, 0, 0}},
+            {// Fusion=RESIDUAL_RMS_NORM
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 0, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 0, 0, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 5, 0, 0, 0, 0, 0, 0}},
+            {// Fusion=RESIDUAL_RMS_NORM_QUANT_FP8
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 0, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 0, 0, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 5, 0, 0, 0, 0, 0, 0}},
+            {// Fusion=RESIDUAL_RMS_NORM_QUANT_NVFP4
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 0, 0, 0, 0}, {4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 0, 0, 0, 0, 0},
+                {4, 4, 4, 4, 4, 4, 4, 4, 5, 0, 0, 0, 0, 0, 0}}}};
+
+inline const std::unordered_map<int, AllReduceBestStrategyTableType> AllReduceBestStrategyTable = {
+    {90, AllReduceBestStrategyTableSM90},
+    {100, AllReduceBestStrategyTableSM100},
+};
 } // namespace tensorrt_llm::utils::customAllReduceUtils

--- a/cpp/tensorrt_llm/kernels/communicationKernels/allReduceFusionKernels.cu
+++ b/cpp/tensorrt_llm/kernels/communicationKernels/allReduceFusionKernels.cu
@@ -134,8 +134,12 @@ public:
             // corresponding CTA has not been launched.
             for (int flag_idx = blockIdx.x; flag_idx < kBarrierFlagCount; flag_idx += gridDim.x)
             {
-                st_flag(m_target_flag + flag_idx * NRanks, m_flag_value);
+                asm volatile(
+                    "st.global.relaxed.sys.b32 [%1], %0;" ::"r"(m_flag_value), "l"(m_target_flag + flag_idx * NRanks));
             }
+            // Single release fence
+            asm volatile("fence.release.sys;");
+
             while (ld_flag(m_current_flag) == prev_flag(m_flag_value))
             {
             }

--- a/cpp/tensorrt_llm/kernels/customAllReduceKernels.h
+++ b/cpp/tensorrt_llm/kernels/customAllReduceKernels.h
@@ -106,6 +106,30 @@ inline std::string toString(AllReduceFusionOp op)
     return oss.str();
 }
 
+inline std::ostream& operator<<(std::ostream& os, AllReduceStrategyType op)
+{
+    switch (op)
+    {
+    case AllReduceStrategyType::NCCL: os << "NCCL"; break;
+    case AllReduceStrategyType::MIN_LATENCY: os << "MIN_LATENCY"; break;
+    case AllReduceStrategyType::UB: os << "UB"; break;
+    case AllReduceStrategyType::AUTO: os << "AUTO"; break;
+    case AllReduceStrategyType::ONESHOT: os << "ONESHOT"; break;
+    case AllReduceStrategyType::TWOSHOT: os << "TWOSHOT"; break;
+    case AllReduceStrategyType::LOWPRECISION: os << "LOWPRECISION"; break;
+    case AllReduceStrategyType::MNNVL: os << "MNNVL"; break;
+    case AllReduceStrategyType::NCCL_SYMMETRIC: os << "NCCL_SYMMETRIC"; break;
+    }
+    return os;
+}
+
+inline std::string toString(AllReduceStrategyType op)
+{
+    std::ostringstream oss;
+    oss << op;
+    return oss.str();
+}
+
 struct AllReduceFusionParams
 {
     AllReduceFusionParams()

--- a/tests/scripts/allreduce_perf/README.md
+++ b/tests/scripts/allreduce_perf/README.md
@@ -1,0 +1,193 @@
+# AllReduce Performance Offline Autotuning and Visualization Tools
+
+This directory contains tools for benchmarking, analyzing, and visualizing AllReduce performance in TensorRT-LLM. The toolkit consists of two main components:
+
+1. **`allreduce_heuristic_code_gen.py`** - Generates optimized C++ lookup tables for AllReduce strategy selection
+2. **`allreduce_perf_viz.py`** - Creates comprehensive visualizations of AllReduce performance data
+
+## Overview
+
+The AllReduce performance analysis workflow involves:
+1. **Benchmarking**: Run performance tests across different configurations
+2. **Analysis**: Generate optimal strategy lookup tables
+3. **Visualization**: Create heatmaps and performance comparison charts
+
+## Prerequisites
+
+- TensorRT-LLM environment with MPI support
+- Python packages: `pandas`, `numpy`, `matplotlib`, `seaborn`, `scipy`
+- CUDA-capable GPU(s) for benchmarking
+
+## Tool 1: allreduce_heuristic_code_gen.py
+
+### Purpose
+Generates C++ lookup tables that contain the optimal AllReduce strategy for different parameter combinations (tensor parallel size, fusion operations, hidden sizes, and token counts).
+
+### Usage
+
+#### Basic Usage (Auto-benchmark and generate)
+```bash
+python allreduce_heuristic_code_gen.py
+```
+
+#### Advanced Usage
+```bash
+python allreduce_heuristic_code_gen.py \
+    --data_dir /path/to/benchmark/data \
+    --sm_version 89 \
+    --save_csv_dir /path/to/save/csv \
+    --enable_auto
+```
+
+### Parameters
+
+- `--data_dir`: Directory containing existing benchmark CSV files (optional)
+- `--sm_version`: CUDA SM version (auto-detected if not specified)
+- `--save_csv_dir`: Directory to save benchmark CSV files
+- `--enable_auto`: Enable AUTO strategy in benchmarking
+
+### Workflow
+
+1. **Benchmark Generation** (if `--data_dir` not provided):
+   - Automatically runs `all_reduce.py` microbenchmark using MPI
+   - Tests multiple tensor parallel sizes (currently TP=2)
+   - Generates CSV files: `benchmark.tp{size}.sm{version}.csv`
+
+2. **Strategy Analysis**:
+   - Loads benchmark data from CSV files
+   - Filters data based on predefined thresholds
+   - Finds optimal strategy for each parameter combination
+   - Creates 4D lookup table: `[tp_size][fusion][hidden_size][num_tokens]`
+
+3. **Code Generation**:
+   - Converts lookup table to C++ array format
+   - Outputs to `gen_heuristic_code/generated_lookup_table.cpp`
+   - Ready for integration into TensorRT-LLM codebase
+
+### Output Example
+```cpp
+// AllReduce lookup: [tp][fusion][hidden][tokens] = strategy
+// TP:[2, 4, 8] Fusion:['NONE', 'RESIDUAL_RMS_NORM', ...]
+inline AllReduceBestStrategyTableType AllReduceBestStrategyTableSM89 = {
+    {
+        // TP=2
+        { // Fusion=NONE
+            {0,0,4,4,5,5,5,5,5,5,5,5,5,5,5}, // hidden_size=128
+            {0,4,4,4,5,5,5,5,5,5,5,5,5,5,5}, // hidden_size=256
+            // ... more rows
+        },
+        // ... more fusion types
+    },
+    // ... more TP sizes
+};
+```
+
+## Tool 2: allreduce_perf_viz.py
+
+### Purpose
+Creates comprehensive visualizations of AllReduce performance data including performance heatmaps, strategy comparison charts, and difference analysis.
+
+### Usage
+
+#### Basic Usage
+```bash
+python allreduce_perf_viz.py --data_dir /path/to/benchmark/data
+```
+
+### Parameters
+
+- `--data_dir`: Directory containing benchmark CSV files (default: 'data')
+
+### Generated Visualizations
+
+The tool generates three types of visualizations for each configuration:
+
+#### 1. Performance Heatmaps (`*_heatmap.png`)
+- **Purpose**: Show raw performance times for each strategy
+- **Layout**: Side-by-side heatmaps for each AllReduce strategy
+- **Axes**: X=num_tokens, Y=hidden_size
+- **Colors**: Performance time in microseconds (μs)
+- **Features**: Shared colorbar, logarithmic scaling for better visualization
+
+#### 2. Best Strategy Maps (`*_best_strategy.png`)
+- **Purpose**: Show optimal strategy for each parameter combination
+- **Layout**: Single heatmap with categorical colors
+- **Axes**: X=num_tokens, Y=hidden_size
+- **Colors**: Different strategies (NCCL, ONESHOT, TWOSHOT, etc.)
+- **Features**: Custom colorbar with strategy labels, distribution statistics
+
+#### 3. Strategy Difference Heatmaps (`*_strategy_difference_heatmap.png`)
+- **Purpose**: Show performance difference from optimal strategy
+- **Layout**: Side-by-side heatmaps for each strategy
+- **Axes**: X=num_tokens, Y=hidden_size
+- **Colors**: Percentage difference from best strategy (white=optimal, red=slower)
+- **Features**: Annotated cells with exact difference values
+
+### Visualization Functions
+
+The script provides three main visualization functions that can be used programmatically:
+
+```python
+# 1. Performance heatmaps
+visualize_2d_heatmap(df, fusion_op='NONE', save_path='heatmap.png')
+
+# 2. Best strategy visualization
+visualize_2d_best_strategy(df, fusion_op='NONE', save_path='best_strategy.png')
+
+# 3. Strategy difference analysis
+visualize_strategy_difference_heatmaps(df, fusion_op='NONE', save_path='diff.png')
+```
+
+### Output Structure
+```
+data/
+├── viz/
+│   ├── NONE/
+│   │   ├── benchmark.tp2.sm89_heatmap.png
+│   │   ├── benchmark.tp2.sm89_best_strategy.png
+│   │   └── benchmark.tp2.sm89_strategy_difference_heatmap.png
+│   ├── RESIDUAL_RMS_NORM/
+│   │   └── ... (similar files)
+│   └── ... (other fusion operations)
+└── benchmark.tp2.sm89.csv
+```
+
+## Configuration Details
+
+### Supported Strategies
+- **NCCL** (0): Standard NCCL AllReduce
+- **ONESHOT** (4): Custom single-phase AllReduce
+- **TWOSHOT** (5): Custom two-phase AllReduce
+
+### Supported Fusion Operations
+- `NONE`: No fusion
+- `RESIDUAL_RMS_NORM`: Residual + RMS normalization
+- `RESIDUAL_RMS_NORM_QUANT_FP8`: RESIDUAL_RMS_NORM + FP8 quantization
+- `RESIDUAL_RMS_NORM_QUANT_NVFP4`: RESIDUAL_RMS_NORM + NVFP4 quantization
+
+### Parameter Ranges
+- **Tensor Parallel Sizes**: 2, 4, 8
+- **Hidden Sizes**: 128 to 8192 (powers of 2)
+- **Token Counts**: 1 to 16384 (powers of 2)
+
+## Performance Tips
+
+- Run benchmarks on target hardware for accurate results
+- Use multiple runs and average results for stability
+- Consider different fusion operations based on your use case
+- Monitor GPU memory usage during benchmarking
+
+## Integration with TensorRT-LLM
+
+The generated lookup tables can be integrated into TensorRT-LLM's AllReduce implementation to automatically select optimal strategies based on runtime parameters. The C++ arrays follow the format expected by the TensorRT-LLM AllReduce subsystem.
+
+## Contributing
+
+When adding new strategies or fusion operations:
+
+1. **Update Configuration**: Modify the `Constants` class in `allreduce_heuristic_code_gen.py`
+2. **Add Strategy Mapping**: Update `strategy_name_to_enum` dictionary with new strategy entries
+3. **Generate New Lookup Tables**: Run `allreduce_heuristic_code_gen.py` to create updated lookup tables for optimal AllReduce strategies
+4. **Integrate into Codebase**: Copy the generated C++ array into the appropriate lookup table in `cpp/tensorrt_llm/common/customAllReduceUtils.h`
+5. **Update Visualizations**: Modify color schemes in `allreduce_perf_viz.py` if needed for new strategies
+6. **Validate**: Test with representative workloads to ensure performance improvements

--- a/tests/scripts/allreduce_perf/allreduce_heuristic_code_gen.py
+++ b/tests/scripts/allreduce_perf/allreduce_heuristic_code_gen.py
@@ -1,0 +1,255 @@
+import os
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from tensorrt_llm._utils import get_sm_version
+
+
+@dataclass
+class Constants:
+    # 16384
+    num_tokens_bits = 15
+    hidden_size_bits = 14
+    max_num_tokens_considered = 2**num_tokens_bits
+    max_hidden_size_considered = 2**hidden_size_bits
+    oneshot_num_tokens_threshold: int = 1
+    oneshot_hidden_size_threshold = 128
+    num_tokens_list = [2**i for i in range(num_tokens_bits)]
+    hidden_size_list = [2**i for i in range(7, hidden_size_bits)]
+    fusion_op_list = [
+        'NONE', 'RESIDUAL_RMS_NORM', 'RESIDUAL_RMS_NORM_QUANT_FP8',
+        'RESIDUAL_RMS_NORM_QUANT_NVFP4'
+    ]
+    tp_size_list = [2, 4, 8]
+    strategy_name_to_enum = {
+        'NCCL': 0,
+        'ONESHOT': 4,
+        'TWOSHOT': 5,
+    }
+
+
+def find_best_strategy(df: pd.DataFrame):
+    """Find the best strategy for each combination of parameters."""
+    return df.groupby([
+        'world_size', 'fusion', 'hidden_size', 'num_tokens'
+    ]).apply(lambda group: group.loc[group['time (us)'].idxmin(), 'strategy'])
+
+
+def filter_df(df: pd.DataFrame):
+    df = df[(df['num_tokens'] >= Constants.oneshot_num_tokens_threshold)
+            & (df['num_tokens'] <= Constants.max_num_tokens_considered) &
+            (df['hidden_size'] >= Constants.oneshot_hidden_size_threshold) &
+            (df['hidden_size'] <= Constants.max_hidden_size_considered)]
+    return df
+
+
+def generate_heuristic_look_up_table(df: pd.DataFrame) -> str:
+    """
+    Generate a heuristic lookup table from benchmark data and output as C++ array.
+
+    Args:
+        df: DataFrame with columns: world_size, dtype, size, num_tokens, hidden_size,
+            strategy, fusion, time (us)
+
+    Returns:
+        String containing C++ array definition for the lookup table
+    """
+    if df is None or df.empty:
+        print("DataFrame is empty or None")
+        return ""
+
+    print(f"Input DataFrame shape: {df.shape}")
+    print(f"Available strategies: {df['strategy'].unique()}")
+    print(f"Available fusions: {df['fusion'].unique()}")
+    print(f"Available tp_sizes: {sorted(df['world_size'].unique())}")
+
+    # Filter out AUTO strategy as it's not a concrete implementation
+    df_filtered = df[df['strategy'] != 'AUTO'].copy()
+    print(f"After filtering AUTO strategy: {df_filtered.shape}")
+
+    # Apply range filters
+    df_filtered = filter_df(df_filtered)
+
+    # Find best strategy for each combination
+    best_strategies = find_best_strategy(df_filtered)
+
+    # Create lookup table dimensions
+    tp_size_count = len(Constants.tp_size_list)
+    fusion_count = len(Constants.fusion_op_list)
+    hidden_size_count = len(Constants.hidden_size_list)
+    num_tokens_count = len(Constants.num_tokens_list)
+
+    # Initialize lookup table with default values (NCCL = 0)
+    strategy_table = np.full(
+        (tp_size_count, fusion_count, hidden_size_count, num_tokens_count),
+        Constants.strategy_name_to_enum['NCCL'],
+        dtype=int)
+
+    # Fill the lookup table with best strategies
+    filled_entries = 0
+    for (tp_size, fusion, hidden_size,
+         num_tokens), best_strategy in best_strategies.items():
+        try:
+            tp_idx = Constants.tp_size_list.index(tp_size)
+            fusion_idx = Constants.fusion_op_list.index(fusion)
+            hidden_size_idx = Constants.hidden_size_list.index(hidden_size)
+            num_tokens_idx = Constants.num_tokens_list.index(num_tokens)
+
+            if best_strategy in Constants.strategy_name_to_enum:
+                strategy_value = Constants.strategy_name_to_enum[best_strategy]
+                strategy_table[tp_idx, fusion_idx, hidden_size_idx,
+                               num_tokens_idx] = strategy_value
+                filled_entries += 1
+        except ValueError:
+            # Skip entries that don't match our defined lists
+            continue
+
+    print(f"Filled {filled_entries} entries in the lookup table")
+
+    return strategy_table
+
+
+def generate_cpp_strategy_lut_code(
+    strategy_table: np.ndarray,
+    sm_version: int,
+) -> str:
+    """Generate formatted C++ array code from numpy lookup table."""
+    tp_size_count, fusion_count, hidden_size_count, num_tokens_count = strategy_table.shape
+
+    # Header with compact comments
+    cpp_code = f"// AllReduce lookup: [tp][fusion][hidden][tokens] = strategy\n"
+    cpp_code += f"// TP:{Constants.tp_size_list}\n"
+    cpp_code += f"// Fusion:{Constants.fusion_op_list}\n"
+    cpp_code += f"// Hidden:{Constants.hidden_size_list}\n"
+    cpp_code += f"// Tokens:{Constants.num_tokens_list}\n"
+    cpp_code += f"inline AllReduceBestStrategyTableType AllReduceBestStrategyTableSM{sm_version} = {{\n"
+
+    # Generate formatted array notation
+    for tp_idx in range(tp_size_count):
+        cpp_code += "    {\n"
+        cpp_code += f"        // TP={Constants.tp_size_list[tp_idx]}\n"
+
+        for fusion_idx in range(fusion_count):
+            cpp_code += f"        {{ // Fusion={Constants.fusion_op_list[fusion_idx]}\n"
+
+            for hidden_idx in range(hidden_size_count):
+                cpp_code += "            {"
+                # Put all token values on one line
+                token_values = []
+                for token_idx in range(num_tokens_count):
+                    value = strategy_table[tp_idx, fusion_idx, hidden_idx,
+                                           token_idx]
+                    token_values.append(str(value))
+                cpp_code += ",".join(token_values)
+                cpp_code += "}"
+                if hidden_idx < hidden_size_count - 1:
+                    cpp_code += ","
+                cpp_code += "\n"
+
+            cpp_code += "        }"
+            if fusion_idx < fusion_count - 1:
+                cpp_code += ","
+            cpp_code += "\n"
+
+        cpp_code += "    }"
+        if tp_idx < tp_size_count - 1:
+            cpp_code += ","
+        cpp_code += "\n"
+
+    cpp_code += "};\n"
+    return cpp_code
+
+
+def main():
+    # add args
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--data_dir", type=str, default=None)
+    parser.add_argument("--sm_version", type=int, default=None)
+    parser.add_argument("--save_csv_dir", type=str, default=None)
+    parser.add_argument("--enable_auto", action="store_true", default=False)
+
+    args = parser.parse_args()
+    tp_size_list = [2]
+
+    # Process the benchmark data
+    # combine all the data into one dataframe
+    data_dir = args.data_dir
+    sm_version = args.sm_version
+
+    if sm_version is None:
+        sm_version = get_sm_version()
+        print(f"Using SM version: {sm_version}")
+
+    df = pd.DataFrame()
+
+    if data_dir is None:
+        if args.save_csv_dir is not None:
+            data_dir = args.save_csv_dir
+            os.makedirs(data_dir, exist_ok=True)
+        else:
+            tmpdir = tempfile.TemporaryDirectory()
+            data_dir = tmpdir.name
+        for tp_size in tp_size_list:
+            # use mpi to run all_reduce.py to benchmark the performance if data_dir is not provided
+            script_path = os.path.join(
+                os.path.dirname(os.path.abspath(__file__)),
+                "../../microbenchmarks/all_reduce.py")
+            save_csv = f"{data_dir}/benchmark.tp{tp_size}.sm{sm_version}.csv"
+
+            print("enable_auto", args.enable_auto)
+            cmd = [
+                "mpirun",
+                "-n",
+                str(tp_size),
+                "python",
+                script_path,
+                "--explore_2d",
+                "--save_csv",
+                save_csv,
+            ]
+            if args.enable_auto:
+                cmd.append("--enable_auto")
+            subprocess.run(
+                cmd,
+                env=os.environ,
+            )
+
+    for tp_size in tp_size_list:
+        data_file = f"{data_dir}/benchmark.tp{tp_size}.sm{sm_version}.csv"
+        if not (Path(data_file)).exists():
+            print(f"File {data_file} does not exist")
+            return
+
+        df_tp = pd.read_csv(Path(data_file))
+        df = pd.concat([df, df_tp])
+
+    assert df.empty == False, "Benchmark data is empty"
+
+    if not os.path.exists(f"{data_dir}/gen_heuristic_code"):
+        os.makedirs(f"{data_dir}/gen_heuristic_code")
+
+    if df is not None:
+        # Generate the C++ lookup table code
+        strategy_table = generate_heuristic_look_up_table(df)
+        cpp_code = generate_cpp_strategy_lut_code(strategy_table, sm_version)
+
+        # Write the generated code to a file
+        output_file = f"{data_dir}/gen_heuristic_code/generated_lookup_table.cpp"
+        with open(output_file, 'w') as f:
+            f.write(cpp_code)
+
+        print(f"\nGenerated C++ lookup table, written to: {output_file}")
+        print("\nFirst 20 lines of generated code:")
+        print(cpp_code)
+    else:
+        print("Failed to load benchmark data")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/scripts/allreduce_perf/allreduce_perf_viz.py
+++ b/tests/scripts/allreduce_perf/allreduce_perf_viz.py
@@ -1,0 +1,609 @@
+import os
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
+from matplotlib.colors import ListedColormap
+
+from tensorrt_llm._utils import get_sm_version
+
+
+def visualize_2d_heatmap(df, fusion_op='NONE', save_path=None):
+    """Visualize the allreduce dataframe as a 2D heatmap using seaborn.
+
+        Args:
+        df: DataFrame with columns: world_size, dtype, size, strategy, fusion, version, time (us)
+        save_path: Optional path to save the plot. If None, displays the plot.
+
+    Creates a 2D heatmap where:
+    - x-axis: num_tokens
+    - y-axis: hidden_size
+    - colors: time (us) values using seaborn heatmap
+    """
+    if df is None or df.empty:
+        print("DataFrame is empty or None")
+        return
+
+    fusion_col = 'fusion' if 'fusion' in df.columns else 'fusion_op'
+    df_filtered = df[df[fusion_col] == fusion_op].copy()
+
+    if df_filtered.empty:
+        print(f"No data found for fusion == '{fusion_op}'")
+        return
+
+    # Determine column names (adapt to different data formats)
+    num_tokens_col = 'num_tokens'
+    time_col = 'time (us)' if 'time (us)' in df_filtered.columns else 'time_ms'
+
+    # Get unique strategies
+    strategies = df_filtered['strategy'].unique()
+
+    # Set seaborn style for better aesthetics
+    sns.set_style("whitegrid")
+    plt.style.use('default')  # Reset to default style
+
+    # Create subplots for each strategy
+    n_strategies = len(strategies)
+    fig, axes = plt.subplots(1, n_strategies, figsize=(8 * n_strategies, 6))
+
+    # Handle single strategy case
+    if n_strategies == 1:
+        axes = [axes]
+
+    fig.suptitle(f'AllReduce Performance Heatmaps (Fusion: {fusion_op})',
+                 fontsize=16,
+                 fontweight='bold',
+                 y=1.02)
+
+    # Calculate global min and max for consistent colorbar across all strategies
+    global_time_min = df_filtered[time_col].min()
+    global_time_max = df_filtered[time_col].max()
+
+    for i, strategy in enumerate(strategies):
+        ax = axes[i]
+        strategy_data = df_filtered[df_filtered['strategy'] == strategy]
+
+        if strategy_data.empty:
+            ax.set_title(f'{strategy} - No Data')
+            continue
+
+        # Create pivot table for heatmap
+        # Use num_tokens as index (y-axis) and hidden_size as columns (x-axis)
+        pivot_data = strategy_data.pivot_table(
+            index='hidden_size',
+            columns='num_tokens',
+            values=time_col,
+            aggfunc='mean'  # Use mean if there are duplicate entries
+        )
+
+        # Sort indices and columns for better visualization
+        pivot_data = pivot_data.sort_index(
+            ascending=False)  # Larger hidden_size at top
+        pivot_data = pivot_data.reindex(sorted(pivot_data.columns),
+                                        axis=1)  # Sort columns
+
+        # Create seaborn heatmap with linear scaling
+        sns.heatmap(
+            pivot_data,
+            ax=ax,
+            cmap='Spectral_r',
+            cbar=False,  # We'll add a shared colorbar later
+            fmt='.1f',
+            square=True,  # Make cells square instead of rectangular
+            linewidths=0.5,
+            linecolor='white',
+            vmin=global_time_min,
+            vmax=global_time_max)
+
+        # Customize labels and title
+        ax.set_xlabel(f'{num_tokens_col.title()}',
+                      fontweight='bold',
+                      fontsize=12)
+        ax.set_ylabel('Hidden Size', fontweight='bold', fontsize=12)
+        ax.set_title(f'{strategy}', fontweight='bold', fontsize=14)
+
+        # Rotate x-axis labels for better readability
+        ax.tick_params(axis='x', rotation=45)
+        ax.tick_params(axis='y', rotation=0)
+
+        # Format tick labels to remove decimal points for integers
+        x_labels = [
+            f'{int(float(label.get_text()))}' for label in ax.get_xticklabels()
+        ]
+        y_labels = [
+            f'{int(float(label.get_text()))}' for label in ax.get_yticklabels()
+        ]
+        ax.set_xticklabels(x_labels)
+        ax.set_yticklabels(y_labels)
+
+    # Add a single shared colorbar for all subplots
+    fig.subplots_adjust(right=0.87)  # Make room for colorbar
+
+    # Create a dummy plot for colorbar with linear scaling
+    sm = plt.cm.ScalarMappable(cmap='Spectral_r',
+                               norm=plt.Normalize(vmin=global_time_min,
+                                                  vmax=global_time_max))
+    sm.set_array([])
+
+    cbar_ax = fig.add_axes([0.89, 0.15, 0.01,
+                            0.7])  # [left, bottom, width, height]
+    cbar = fig.colorbar(sm, cax=cbar_ax)
+    cbar.set_label('Time (μs)', fontweight='bold', fontsize=12)
+
+    plt.tight_layout()
+    plt.subplots_adjust(right=0.87)  # Ensure colorbar space is maintained
+
+    # Save or show the plot
+    if save_path:
+        # Create directory if it doesn't exist
+        Path(save_path).parent.mkdir(parents=True, exist_ok=True)
+        plt.savefig(save_path, dpi=300, bbox_inches='tight')
+        print(f"2D heatmap saved to: {save_path}")
+        plt.close()  # Close the figure to free memory
+    else:
+        plt.show()
+
+    # Print some statistics
+    print(f"\n2D Heatmap Statistics:")
+    print(f"Strategies: {list(strategies)}")
+    print(
+        f"{num_tokens_col.title()} values: {sorted(df_filtered['num_tokens'].unique())}"
+    )
+    print(f"Hidden sizes: {sorted(df_filtered['hidden_size'].unique())}")
+    print(
+        f"Global time range (colorbar): {global_time_min:.4f} - {global_time_max:.4f} μs"
+    )
+    print(f"Total data points: {len(df_filtered)}")
+
+
+def visualize_2d_best_strategy(df, fusion_op='NONE', save_path=None):
+    """Visualize the best strategy for each mesh grid position as a 2D heatmap.
+
+        Args:
+        df: DataFrame with columns: world_size, dtype, size, strategy, fusion, version, time (us)
+        save_path: Optional path to save the plot. If None, displays the plot.
+
+    Creates a heat map where:
+    - x-axis: num_tokens
+    - y-axis: hidden_size
+    - colors: best strategy for each (num_tokens, hidden_size) combination
+    """
+    if df is None or df.empty:
+        print("DataFrame is empty or None")
+        return
+
+    fusion_col = 'fusion' if 'fusion' in df.columns else 'fusion_op'
+    df_filtered = df[df[fusion_col] == fusion_op].copy()
+
+    # Filter out AUTO strategy
+    df_filtered = df_filtered[df_filtered['strategy'] != 'AUTO'].copy()
+
+    if df_filtered.empty:
+        print(
+            f"No data found for fusion == '{fusion_op}' after filtering out AUTO strategy"
+        )
+        return
+
+    # Determine column names (adapt to different data formats)
+    num_tokens_col = 'num_tokens'
+    time_col = 'time (us)' if 'time (us)' in df_filtered.columns else 'time_ms'
+
+    # Find the best strategy for each (num_tokens, hidden_size) combination
+    best_strategy_data = []
+
+    for (num_tokens, hidden_size), group in df_filtered.groupby(
+        ['num_tokens', 'hidden_size']):
+        # Find the strategy with minimum time for this combination
+        best_row = group.loc[group[time_col].idxmin()]
+        best_strategy_data.append({
+            'num_tokens': num_tokens,
+            'hidden_size': hidden_size,
+            'best_strategy': best_row['strategy'],
+            'best_time': best_row[time_col]
+        })
+
+    best_df = pd.DataFrame(best_strategy_data)
+
+    # Get unique strategies and create a color mapping
+    strategies = sorted(df_filtered['strategy'].unique())
+
+    # Create a categorical color map with distinct colors
+    strategy_colors = plt.cm.Set3(np.linspace(0, 1, len(strategies)))
+    strategy_to_num = {strategy: i for i, strategy in enumerate(strategies)}
+
+    # Create pivot table for heatmap with strategy numbers
+    pivot_data = best_df.pivot_table(
+        index='hidden_size',
+        columns='num_tokens',
+        values='best_strategy',
+        aggfunc='first'  # Should be unique anyway
+    )
+
+    # Convert strategy names to numbers for heatmap
+    pivot_numeric = pivot_data.applymap(lambda x: strategy_to_num[x]
+                                        if pd.notna(x) else np.nan)
+
+    # Sort indices and columns for better visualization
+    pivot_numeric = pivot_numeric.sort_index(
+        ascending=False)  # Larger hidden_size at top
+    pivot_numeric = pivot_numeric.reindex(sorted(pivot_numeric.columns),
+                                          axis=1)  # Sort columns
+
+    # Set seaborn style for better aesthetics
+    sns.set_style("whitegrid")
+    plt.style.use('default')  # Reset to default style
+
+    # Create the figure
+    fig, ax = plt.subplots(figsize=(12, 8))
+
+    # Create custom colormap
+    cmap = ListedColormap(strategy_colors)
+
+    # Create seaborn heatmap with categorical data
+    sns.heatmap(
+        pivot_numeric,
+        ax=ax,
+        cmap=cmap,
+        cbar=False,  # We'll create a custom colorbar
+        fmt='',
+        square=True,  # Make cells square instead of rectangular
+        linewidths=1,
+        linecolor='white',
+        vmin=-0.5,
+        vmax=len(strategies) - 0.5)
+
+    # Create custom colorbar with strategy labels
+    cbar = plt.colorbar(plt.cm.ScalarMappable(cmap=cmap,
+                                              norm=plt.Normalize(
+                                                  vmin=-0.5,
+                                                  vmax=len(strategies) - 0.5)),
+                        ax=ax,
+                        ticks=range(len(strategies)))
+    cbar.ax.set_yticklabels(strategies)
+    cbar.set_label('Best Strategy', fontweight='bold', fontsize=12)
+
+    # Customize labels and title
+    ax.set_xlabel(f'{num_tokens_col.title()}', fontweight='bold', fontsize=14)
+    ax.set_ylabel('Hidden Size', fontweight='bold', fontsize=14)
+    ax.set_title(
+        f'Best AllReduce Strategy for Each Mesh Grid Position\n(Fusion: {fusion_op})',
+        fontweight='bold',
+        fontsize=16,
+        pad=20)
+
+    # Rotate x-axis labels for better readability
+    ax.tick_params(axis='x', rotation=45)
+    ax.tick_params(axis='y', rotation=0)
+
+    # Format tick labels to remove decimal points for integers
+    x_labels = [
+        f'{int(float(label.get_text()))}' for label in ax.get_xticklabels()
+    ]
+    y_labels = [
+        f'{int(float(label.get_text()))}' for label in ax.get_yticklabels()
+    ]
+    ax.set_xticklabels(x_labels)
+    ax.set_yticklabels(y_labels)
+
+    plt.tight_layout()
+
+    # Save or show the plot
+    if save_path:
+        # Create directory if it doesn't exist
+        Path(save_path).parent.mkdir(parents=True, exist_ok=True)
+        plt.savefig(save_path, dpi=300, bbox_inches='tight')
+        print(f"Best strategy heatmap saved to: {save_path}")
+        plt.close()  # Close the figure to free memory
+    else:
+        plt.show()
+
+    # Print some statistics
+    print(f"\nBest Strategy Heatmap Statistics:")
+    print(f"Strategies found: {strategies}")
+    print(
+        f"{num_tokens_col.title()} values: {sorted(best_df['num_tokens'].unique())}"
+    )
+    print(f"Hidden sizes: {sorted(best_df['hidden_size'].unique())}")
+    print(f"Total grid positions: {len(best_df)}")
+
+    # Show strategy distribution
+    strategy_counts = best_df['best_strategy'].value_counts()
+    print(f"\nStrategy distribution:")
+    for strategy, count in strategy_counts.items():
+        percentage = (count / len(best_df)) * 100
+        print(f"  {strategy}: {count} positions ({percentage:.1f}%)")
+
+    return best_df
+
+
+def visualize_strategy_difference_heatmaps(df,
+                                           fusion_op='NONE',
+                                           save_path=None):
+    """Generate 2D heatmaps showing the difference between each strategy and the best strategy.
+
+        Args:
+        df: DataFrame with columns: world_size, dtype, size, strategy, fusion, version, time (us)
+        save_path: Optional file path to save the plot. If None, displays the plots.
+
+    Creates difference heatmaps where:
+    - x-axis: num_tokens
+    - y-axis: hidden_size
+    - colors: time difference (current_strategy_time - best_time) in μs
+    - Generates one heatmap per strategy
+    """
+    if df is None or df.empty:
+        print("DataFrame is empty or None")
+        return
+
+    fusion_col = 'fusion' if 'fusion' in df.columns else 'fusion_op'
+    df_filtered = df[df[fusion_col] == fusion_op].copy()
+
+    if df_filtered.empty:
+        print(f"No data found for fusion == '{fusion_op}'")
+        return
+
+    # Determine column names
+    num_tokens_col = 'num_tokens'
+    time_col = 'time (us)' if 'time (us)' in df_filtered.columns else 'time_ms'
+
+    # Find the best strategy and time for each (num_tokens, hidden_size) combination
+    best_times = {}
+    for (num_tokens, hidden_size), group in df_filtered.groupby(
+        ['num_tokens', 'hidden_size']):
+        best_row = group.loc[group[time_col].idxmin()]
+        best_times[(num_tokens, hidden_size)] = best_row[time_col]
+
+    # Get unique strategies
+    strategies = sorted(df_filtered['strategy'].unique())
+
+    # Set seaborn style for better aesthetics
+    sns.set_style("whitegrid")
+    plt.style.use('default')
+
+    # Calculate difference data for all strategies
+    all_diff_data = []
+    max_diff = 0
+    min_diff = 0
+
+    for strategy in strategies:
+        strategy_data = df_filtered[df_filtered['strategy'] == strategy]
+
+        if strategy_data.empty:
+            continue
+
+        # Calculate differences for this strategy
+        diff_data = []
+        for _, row in strategy_data.iterrows():
+            num_tokens = row['num_tokens']
+            hidden_size = row['hidden_size']
+            current_time = row[time_col]
+
+            best_time = best_times.get((num_tokens, hidden_size))
+            if best_time is not None:
+                diff = (current_time - best_time) / best_time * 100
+                diff_data.append({
+                    'num_tokens': num_tokens,
+                    'hidden_size': hidden_size,
+                    'diff (%)': diff,
+                    'strategy': strategy
+                })
+                max_diff = max(max_diff, diff)
+                min_diff = min(min_diff, diff)
+
+        all_diff_data.extend(diff_data)
+
+    # Ensure we have data to visualize
+    if not all_diff_data:
+        print("No valid data found for difference calculation")
+        return
+
+    # Check if we have multiple strategies for meaningful comparison
+    if len(strategies) == 1:
+        print(
+            f"Warning: Only one strategy ({strategies[0]}) found. All differences will be zero."
+        )
+
+    print(
+        f"Generating difference heatmaps for {len(strategies)} strategies with {len(all_diff_data)} data points..."
+    )
+
+    # Create subplots for each strategy
+    n_strategies = len(strategies)
+    fig, axes = plt.subplots(1, n_strategies, figsize=(8 * n_strategies, 6))
+
+    # Handle single strategy case
+    if n_strategies == 1:
+        axes = [axes]
+
+    fig.suptitle(
+        f'Strategy Performance Difference from Best Strategy (Fusion: {fusion_op})',
+        fontsize=16,
+        fontweight='bold',
+        y=1.02)
+
+    # Use a colormap where 0 (best strategy) appears white
+    cmap = 'Reds'  # White at 0 -> Red for worse performance
+
+    for i, strategy in enumerate(strategies):
+        ax = axes[i]
+
+        # Filter data for this strategy
+        strategy_diff_data = [
+            d for d in all_diff_data if d['strategy'] == strategy
+        ]
+
+        if not strategy_diff_data:
+            ax.set_title(f'{strategy} - No Data')
+            continue
+
+        # Convert to DataFrame and create pivot table
+        strategy_df = pd.DataFrame(strategy_diff_data)
+        pivot_data = strategy_df.pivot_table(index='hidden_size',
+                                             columns='num_tokens',
+                                             values='diff (%)',
+                                             aggfunc='mean')
+
+        # Sort indices and columns for better visualization
+        pivot_data = pivot_data.sort_index(
+            ascending=False)  # Larger hidden_size at top
+        pivot_data = pivot_data.reindex(sorted(pivot_data.columns),
+                                        axis=1)  # Sort columns
+
+        # Determine annotation font size based on grid size
+        total_cells = pivot_data.shape[0] * pivot_data.shape[1]
+        annot_fontsize = 8 if total_cells <= 25 else 6 if total_cells <= 64 else 4
+
+        # Create seaborn heatmap with 0 values as white
+        sns.heatmap(
+            pivot_data,
+            ax=ax,
+            cmap=cmap,
+            cbar=False,  # We'll add a shared colorbar later
+            fmt='.1f',
+            square=True,
+            linewidths=0.5,
+            linecolor='white',
+            vmin=0,  # Force 0 (best strategy) to map to white
+            vmax=max(
+                max_diff,
+                0.1),  # Ensure we have at least some range for visualization
+            annot=True,  # Show values in cells
+            annot_kws={
+                'fontsize': annot_fontsize,
+                'weight': 'bold'
+            })
+
+        # Customize labels and title
+        ax.set_xlabel(f'{num_tokens_col.title()}',
+                      fontweight='bold',
+                      fontsize=12)
+        ax.set_ylabel('Hidden Size', fontweight='bold', fontsize=12)
+        ax.set_title(f'{strategy}\n(Difference from Best %)',
+                     fontweight='bold',
+                     fontsize=12)
+
+        # Rotate x-axis labels for better readability
+        ax.tick_params(axis='x', rotation=45)
+        ax.tick_params(axis='y', rotation=0)
+
+        # Format tick labels to remove decimal points for integers
+        x_labels = [
+            f'{int(float(label.get_text()))}' for label in ax.get_xticklabels()
+        ]
+        y_labels = [
+            f'{int(float(label.get_text()))}' for label in ax.get_yticklabels()
+        ]
+        ax.set_xticklabels(x_labels)
+        ax.set_yticklabels(y_labels)
+
+    # Add a single shared colorbar for all subplots
+    fig.subplots_adjust(right=0.87)  # Make room for colorbar
+
+    # Create a dummy plot for colorbar with 0 values as white
+    sm = plt.cm.ScalarMappable(
+        cmap=cmap,
+        norm=plt.Normalize(vmin=0, vmax=max(max_diff,
+                                            0.1))  # Force 0 to map to white
+    )
+    sm.set_array([])
+
+    cbar_ax = fig.add_axes([0.89, 0.15, 0.01,
+                            0.7])  # [left, bottom, width, height]
+    cbar = fig.colorbar(sm, cax=cbar_ax)
+    cbar.set_label('Time Difference (%)\n', fontweight='bold', fontsize=12)
+
+    plt.tight_layout()
+    plt.subplots_adjust(right=0.87)  # Ensure colorbar space is maintained
+
+    # Save or show the plot
+    if save_path:
+        # Create parent directory if it doesn't exist
+        save_file_path = Path(save_path)
+        if not save_file_path.suffix:
+            # If no extension provided, add .png
+            save_file_path = save_file_path.with_suffix('.png')
+        save_file_path.parent.mkdir(parents=True, exist_ok=True)
+        plt.savefig(save_file_path, dpi=300, bbox_inches='tight')
+        print(f"Strategy difference heatmaps saved to: {save_file_path}")
+        plt.close()  # Close the figure to free memory
+    else:
+        plt.show()
+
+    # Print statistics
+    print(f"\nStrategy Difference Heatmap Statistics:")
+    print(f"Strategies analyzed: {strategies}")
+    print(f"Difference range: {min_diff:.2f} to {max_diff:.2f} μs")
+    print(f"Note: Positive values indicate slower than best strategy")
+
+    # Show per-strategy statistics
+    for strategy in strategies:
+        strategy_diffs = [
+            d['diff (%)'] for d in all_diff_data if d['strategy'] == strategy
+        ]
+        if strategy_diffs:
+            avg_diff = np.mean(strategy_diffs)
+            max_diff_strategy = max(strategy_diffs)
+            print(
+                f"  {strategy}: avg diff = {avg_diff:.2f} μs, max diff = {max_diff_strategy:.2f} μs"
+            )
+
+
+def main():
+    # add args
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--data_dir", type=str, default=None)
+    args = parser.parse_args()
+    fusion_op_list = [
+        "NONE",
+        "RESIDUAL_RMS_NORM",
+        "RESIDUAL_RMS_NORM_QUANT_FP8",
+        "RESIDUAL_RMS_NORM_QUANT_NVFP4",
+    ]
+    tp_size_list = [2, 4, 8]
+
+    if args.data_dir is None:
+        print("Please provide a data directory")
+        return
+
+    if not os.path.exists(os.path.join(args.data_dir, "viz")):
+        os.makedirs(os.path.join(args.data_dir, "viz"))
+        os.makedirs(os.path.join(args.data_dir, "viz", fusion_op))
+
+    for tp_size in tp_size_list:
+        case_name = f"benchmark.tp{tp_size}.sm{get_sm_version()}"
+        fname = os.path.join(args.data_dir, case_name + ".csv")
+        if not (Path(fname)).exists():
+            print(f"File {fname} does not exist")
+            continue
+
+        df = pd.read_csv(Path(fname))
+        for fusion_op in fusion_op_list:
+            os.makedirs(os.path.join(args.data_dir, "viz", fusion_op))
+
+            if df is not None:
+                print(f"\n=== TP Size: {tp_size} ===")
+                print(df.head())
+                print(f"Data shape: {df.shape}")
+
+                # Create 2D heatmap visualization and save to data/viz directory
+                viz_path_heatmap = f"{args.data_dir}/viz/{fusion_op}/{case_name}_heatmap.png"
+                visualize_2d_heatmap(df, fusion_op, save_path=viz_path_heatmap)
+
+                # Create best strategy heatmap visualization and save to data/viz directory
+                viz_path_best_strategy = f"{args.data_dir}/viz/{fusion_op}/{case_name}_best_strategy.png"
+                visualize_2d_best_strategy(df,
+                                           fusion_op,
+                                           save_path=viz_path_best_strategy)
+
+                # Create strategy difference heatmaps and save to data/viz directory
+                viz_path_diff = f"{os.path.dirname(__file__)}/{args.data_dir}/viz/{fusion_op}/{case_name}_strategy_difference_heatmap.png"
+                visualize_strategy_difference_heatmaps(df,
+                                                       fusion_op,
+                                                       save_path=viz_path_diff)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unittest/_torch/multi_gpu/test_allreduce.py
+++ b/tests/unittest/_torch/multi_gpu/test_allreduce.py
@@ -25,8 +25,8 @@ from utils.util import skip_pre_blackwell
 
 import tensorrt_llm
 from tensorrt_llm._torch.distributed import (AllReduce, AllReduceFusionOp,
-                                             AllReduceParams, MoEAllReduce,
-                                             MoEAllReduceParams)
+                                             AllReduceParams, AllReduceStrategy,
+                                             MoEAllReduce, MoEAllReduceParams)
 from tensorrt_llm._torch.modules.linear import Linear, TensorParallelMode
 from tensorrt_llm._torch.modules.rms_norm import RMSNorm
 from tensorrt_llm.mapping import Mapping
@@ -123,10 +123,10 @@ def run_allreduce_op(x: torch.Tensor, residual: torch.Tensor, hidden_size: int,
         dtype=dtype,
         mapping=mapping,
         tensor_parallel_mode=TensorParallelMode.ROW,
+        allreduce_strategy=AllReduceStrategy.NCCL,
     ).cuda()
+    allreduce = AllReduce(mapping=mapping)
     norm = RMSNorm(hidden_size=hidden_size, eps=eps, dtype=dtype).cuda()
-
-    allreduce = AllReduce(mapping=mapping).cuda()
 
     scale = torch.tensor(1.0, dtype=torch.float32).cuda()
     linear.load_weights([dict(weight=weights[0])])


### PR DESCRIPTION
Because we have encountered some perf regression due to using a one-shot kernel instead of NCCL on A100/H100, it will be beneficial if we can have a solid benchmarking of allreduce Op and analyze the data collected from it.
 
Implemented new AllreduceOp heuristic:
* Added Linear programming-based heuristic implementation.
* Added LUT-based heuristic implementation and corresponding code generation script.

AllreduceOp minor fixing:
* Fixed a minor issue in AllreduceOp, that the strategy can not be overridden when ONESHOT or TWOSHOT is set.
* Fixed a minor TWOSHOT kernel perf issue.
* Cleaned up Dispatching code in AllReduceOp.

This PR will fix the perf gaps reported in:
* https://nvbugspro.nvidia.com/bug/5517023

For Deepseek-R1 perf, it shows 3-4% perf gain in concurrencies of 256 and 512.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - All-reduce microbenchmark now uses shape-driven sweeps across versions/fusion/strategies and can export results to CSV via a new CLI flag.
  - Enhanced profiling: labeled regions, optional CUDA graphs, warmups, and median-based timing.

- Refactor
  - Strategy selection for all-reduce now strictly honors the configured strategy (no remapping).

- Tests
  - Updated benchmark validations to use direct comparisons with tolerance for improved correctness checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
