### PR TITLE
[None][fix] Fix dummy load format for DeepSeek.

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -1548,11 +1548,10 @@ class DeepseekV3ForCausalLM(SpecDecOneEngineForCausalLM[DeepseekV3Model,
                     module.weight_scale = nn.Parameter(transfromed_scale,
                                                        requires_grad=False)
 
-        if not self.is_draft_model:
-            for idx, layer in enumerate(
-                    self.model.model.layers[:self.config.num_hidden_layers]):
-                if idx == self.config.num_hidden_layers - 1:
-                    layer.next_layer_layernorm = self.model.model.norm
-                else:
-                    layer.next_layer_layernorm = self.model.model.layers[
-                        idx + 1].input_layernorm
+        for idx, layer in enumerate(
+                self.model.layers[:self.config.num_hidden_layers]):
+            if idx == self.config.num_hidden_layers - 1:
+                layer.next_layer_layernorm = self.model.norm
+            else:
+                layer.next_layer_layernorm = self.model.layers[
+                    idx + 1].input_layernorm

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -1530,7 +1530,7 @@ class DeepseekV3ForCausalLM(SpecDecOneEngineForCausalLM[DeepseekV3Model,
     def post_load_weights(self):
         all_named_modules = dict(self.model.named_modules())
         for name, module in tqdm(all_named_modules.items(),
-                                 desc="Loading weights"):
+                                 desc="Post loading weights"):
             if len(module._parameters) <= 0 or name.startswith("draft_model"):
                 continue
             else:

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -394,28 +394,6 @@ class DeepseekV3WeightLoader:
                         for n, p in module.named_parameters():
                             p.data.copy_(module_weights[n][:])
 
-                if self.model_config.quant_config.layer_quant_mode.has_fp8_block_scales(
-                ) and is_sm_100f() and hasattr(module, "weight_scale"):
-                    weight, weight_scale = resmooth_to_fp8_e8m0(
-                        module.weight, module.weight_scale)
-                    transfromed_scale = transform_sf_into_required_layout(
-                        weight_scale,
-                        mn=weight.shape[0],
-                        k=weight.shape[1],
-                        recipe=(1, 128, 128),
-                        is_sfa=False)
-                    module.weight = nn.Parameter(weight, requires_grad=False)
-                    module.weight_scale = nn.Parameter(transfromed_scale,
-                                                       requires_grad=False)
-        if not self.is_draft_model:
-            for idx, layer in enumerate(
-                    self.model.model.layers[:self.config.num_hidden_layers]):
-                if idx == self.config.num_hidden_layers - 1:
-                    layer.next_layer_layernorm = self.model.model.norm
-                else:
-                    layer.next_layer_layernorm = self.model.model.layers[
-                        idx + 1].input_layernorm
-
 
 class DeepseekV3MTPHead(nn.Module):
 
@@ -1548,3 +1526,33 @@ class DeepseekV3ForCausalLM(SpecDecOneEngineForCausalLM[DeepseekV3Model,
     def load_weights(self, weights: Dict):
         weight_loader = DeepseekV3WeightLoader(self)
         weight_loader.load_weights(weights)
+
+    def post_load_weights(self):
+        all_named_modules = dict(self.model.named_modules())
+        for name, module in tqdm(all_named_modules.items(),
+                                 desc="Loading weights"):
+            if len(module._parameters) <= 0 or name.startswith("draft_model"):
+                continue
+            else:
+                if self.model_config.quant_config.layer_quant_mode.has_fp8_block_scales(
+                ) and is_sm_100f() and hasattr(module, "weight_scale"):
+                    weight, weight_scale = resmooth_to_fp8_e8m0(
+                        module.weight, module.weight_scale)
+                    transfromed_scale = transform_sf_into_required_layout(
+                        weight_scale,
+                        mn=weight.shape[0],
+                        k=weight.shape[1],
+                        recipe=(1, 128, 128),
+                        is_sfa=False)
+                    module.weight = nn.Parameter(weight, requires_grad=False)
+                    module.weight_scale = nn.Parameter(transfromed_scale,
+                                                       requires_grad=False)
+
+        if not self.is_draft_model:
+            for idx, layer in enumerate(
+                    self.model.model.layers[:self.config.num_hidden_layers]):
+                if idx == self.config.num_hidden_layers - 1:
+                    layer.next_layer_layernorm = self.model.model.norm
+                else:
+                    layer.next_layer_layernorm = self.model.model.layers[
+                        idx + 1].input_layernorm

--- a/tensorrt_llm/_torch/models/modeling_llama_min_latency.py
+++ b/tensorrt_llm/_torch/models/modeling_llama_min_latency.py
@@ -1,5 +1,4 @@
 from collections.abc import Callable
-from functools import partial
 from typing import Dict, List, Optional, Tuple, Union
 
 import torch
@@ -66,7 +65,6 @@ class Llama4MinLatencyLinear(Linear):
         enable_fused_gemm_swiglu: bool = False,
         enable_fused_gemm_attn_scaling: bool = False,
         enable_trtllm_gen: bool = False,
-        post_load_weights_hook: Optional[Callable] = None,
     ):
         # First, initialize the base class.
         super().__init__(
@@ -88,7 +86,6 @@ class Llama4MinLatencyLinear(Linear):
         self.enable_fused_gemm_swiglu = enable_fused_gemm_swiglu
         self.enable_fused_gemm_attn_scaling = enable_fused_gemm_attn_scaling
         self.enable_trtllm_gen = enable_trtllm_gen
-        self.post_load_weights_hook = post_load_weights_hook
         self.position_ids = None
 
     def load_weights(self, weights: List[Dict]):
@@ -122,9 +119,6 @@ class Llama4MinLatencyLinear(Linear):
                 self.trtllm_gen_weight = shuffle_matrix_a(
                     self.weight.view(torch.uint8),
                     128).view(torch.float8_e4m3fn)
-
-        if self.post_load_weights_hook is not None:
-            self.post_load_weights_hook(self)
 
     # Override apply_linear instead of forward so that we can reuse the AllReduce/AllGather logic in the parent class.
     def apply_linear(
@@ -298,17 +292,6 @@ class Llama4MinLatencyGatedMLP(GatedMLP):
                 enable_trtllm_gen=True,
             )
 
-            # After loading both gate_up_proj and down_proj, we need to set the scales needed by the special kernels and by
-            # the trtllm-gen gemm+swiglu kernel.
-            def post_load_weights_hook(gate_up_proj, down_proj):
-                if gate_up_proj.has_fp8_qdq:
-                    # For the special gemm+swiglu kernel, we need to set the inverse of the output scale, which is the inverse
-                    # of down_proj's combined input scale.
-                    gate_up_proj.inv_output_scale = 1.0 / down_proj.input_scale
-                    # For the trtllm-gen gemm+swiglu kernel, we need to set the global scale, which is gate_up_proj's
-                    # combined input scale times inv_output_scale.
-                    gate_up_proj.trtllm_gen_global_scale = gate_up_proj.combined_scale * gate_up_proj.inv_output_scale
-
             self.down_proj = Llama4MinLatencyLinear(
                 self.intermediate_size,
                 self.hidden_size,
@@ -320,9 +303,18 @@ class Llama4MinLatencyGatedMLP(GatedMLP):
                 reduce_output=reduce_output,
                 skip_create_weights_in_init=config.skip_create_weights_in_init,
                 enable_trtllm_gen=True,
-                post_load_weights_hook=partial(post_load_weights_hook,
-                                               self.gate_up_proj),
             )
+
+    # After loading both gate_up_proj and down_proj, we need to set the scales needed by the special kernels and by
+    # the trtllm-gen gemm+swiglu kernel.
+    def post_load_weights(self):
+        if self.gate_up_proj.has_fp8_qdq:
+            # For the special gemm+swiglu kernel, we need to set the inverse of the output scale, which is the inverse
+            # of down_proj's combined input scale.
+            self.gate_up_proj.inv_output_scale = 1.0 / self.down_proj.input_scale
+            # For the trtllm-gen gemm+swiglu kernel, we need to set the global scale, which is gate_up_proj's
+            # combined input scale times inv_output_scale.
+            self.gate_up_proj.trtllm_gen_global_scale = self.gate_up_proj.combined_scale * self.gate_up_proj.inv_output_scale
 
     def forward(
         self,
@@ -451,7 +443,6 @@ class Llama4MinLatencyFusedMoE(CutlassFusedMoE):
         weight_loading_mode: MoEWeightLoadingMode = MoEWeightLoadingMode.
         VANILLA,
         apply_router_weight_on_input: bool = False,
-        post_load_weights_hook: Optional[Callable] = None,
     ):
 
         super().__init__(
@@ -467,8 +458,6 @@ class Llama4MinLatencyFusedMoE(CutlassFusedMoE):
             apply_router_weight_on_input=apply_router_weight_on_input,
         )
 
-        self.post_load_weights_hook = post_load_weights_hook
-
         # Enable min-latency mode for Llama4 Maverick TP8 EP1.
         self.enable_min_latency_fused_moe = False
         if num_experts == 128 \
@@ -481,12 +470,6 @@ class Llama4MinLatencyFusedMoE(CutlassFusedMoE):
             and routing_method.top_k == 1 \
             and apply_router_weight_on_input:
             self.enable_min_latency_fused_moe = True
-
-    def load_weights(self, weights: List[Dict]):
-        super().load_weights(weights)
-
-        if self.post_load_weights_hook:
-            self.post_load_weights_hook(self)
 
     def forward(
         self,
@@ -561,22 +544,6 @@ class Llama4MinLatencyMoE(Llama4MoE):
             overridden_tp_size=1 if self.enable_attention_dp else None,
             reduce_output=False)
 
-        def post_load_weights_hook(shared_expert, experts):
-            # Set min-latency quant scales for routed experts if we plan to use min-latency MoE kernels.
-            # This is because the routed experts' input scale is after the score multiplication, so we must use the
-            # pre-score scaling input scale, which happens to be shared expert's input scale.
-            if experts.enable_min_latency_fused_moe and hasattr(
-                    shared_expert.gate_up_proj, "input_scale"):
-                pre_score_scaling_input_scale = shared_expert.gate_up_proj.input_scale
-                experts.min_latency_quant_scales = FusedMoEQuantScalesFP8(
-                    fc1_dequant=experts.fc31_dequant.data /
-                    experts.fc31_input_dequant.data *
-                    pre_score_scaling_input_scale,
-                    fc2_quant=experts.fc2_quant,
-                    fc2_dequant=experts.fc2_dequant,
-                    fc1_input_dequant=pre_score_scaling_input_scale,
-                )
-
         self.experts = Llama4MinLatencyFusedMoE(
             routing_method=Llama4RenormalizeMoeRoutingMethod(top_k),
             num_experts=num_experts,
@@ -588,8 +555,7 @@ class Llama4MinLatencyMoE(Llama4MoE):
             weight_loading_mode=MoEWeightLoadingMode.FUSED_GATE_UP_PROJ,
             model_config=model_config,
             apply_router_weight_on_input=True,
-            post_load_weights_hook=partial(post_load_weights_hook,
-                                           self.shared_expert))
+        )
 
         self.router = Llama4MinLatencyLinear(
             hidden_size,
@@ -597,6 +563,22 @@ class Llama4MinLatencyMoE(Llama4MoE):
             bias=False,
             dtype=model_config.pretrained_config.torch_dtype,
             quant_config=None)
+
+    def post_load_weights(self):
+        # Set min-latency quant scales for routed experts if we plan to use min-latency MoE kernels.
+        # This is because the routed experts' input scale is after the score multiplication, so we must use the
+        # pre-score scaling input scale, which happens to be shared expert's input scale.
+        if self.experts.enable_min_latency_fused_moe and hasattr(
+                self.shared_expert.gate_up_proj, "input_scale"):
+            pre_score_scaling_input_scale = self.shared_expert.gate_up_proj.input_scale
+            self.experts.min_latency_quant_scales = FusedMoEQuantScalesFP8(
+                fc1_dequant=self.experts.fc31_dequant.data /
+                self.experts.fc31_input_dequant.data *
+                pre_score_scaling_input_scale,
+                fc2_quant=self.experts.fc2_quant,
+                fc2_dequant=self.experts.fc2_dequant,
+                fc1_input_dequant=pre_score_scaling_input_scale,
+            )
 
     def compute_routed_output(
             self,

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
@@ -567,3 +567,6 @@ class CutlassFusedMoE(MoE):
         weights = weights[0]
 
         self.quant_method.load_weights(self, weights, self.weight_loading_mode)
+
+    def post_load_weights(self):
+        self.quant_method.post_load_weights(self)

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_triton.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_triton.py
@@ -1385,3 +1385,6 @@ class TritonFusedMoE(MoE):
         weights = weights[0]
 
         self.quant_method.load_weights(self, weights, self.weight_loading_mode)
+
+    def post_load_weights(self):
+        self.quant_method.post_load_weights(self)

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py
@@ -168,6 +168,9 @@ class TRTLLMGenFusedMoE(MoE):
 
         self.quant_method.load_weights(self, weights, self.weight_loading_mode)
 
+    def post_load_weights(self):
+        self.quant_method.post_load_weights(self)
+
     def forward_impl(
         self,
         x: Union[torch.Tensor, Fp4QuantizedTensor],

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_wide_ep.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_wide_ep.py
@@ -1004,3 +1004,6 @@ class WideEPMoE(MoE):
         weights = weights[0]
 
         self.quant_method.load_weights(self, weights, self.weight_loading_mode)
+
+    def post_load_weights(self):
+        self.quant_method.post_load_weights(self)

--- a/tensorrt_llm/_torch/modules/fused_moe/interface.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/interface.py
@@ -195,6 +195,9 @@ class MoE(nn.Module):
     def load_weights(self, weights: List[Dict]):
         raise NotImplementedError
 
+    def post_load_weights(self):
+        pass
+
     @abstractmethod
     def forward_impl(
         self,

--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -322,6 +322,9 @@ class FusedMoEMethodBase(ABC):
             module.layer_load_balancer.set_initial_weight_assignments(
                 module.initial_global_assignments)
 
+    def post_load_weights(self, module: torch.nn.Module):
+        pass
+
     def load_quant_scales(self, module: torch.nn.Module, weights: List[Dict]):
         pass
 
@@ -726,6 +729,7 @@ class DeepSeekFP8BlockScalesFusedMoEMethodDeepGemm(
                         weight, scale)
         super().load_weights(module, weights, weight_loading_mode)
 
+    def post_load_weights(self, module: torch.nn.Module):
         if is_sm_100f():
             transfromed_w3_w1_scale = transform_sf_into_required_layout(
                 module.quant_scales[0],

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -241,6 +241,9 @@ class LinearMethodBase(ABC):
         else:
             raise ValueError(f'unsupported weight mode: {weight_mode}')
 
+    def post_load_weights(self, module: Linear):
+        pass
+
     def load_weight_scales(self, weights: List[Dict], *args, **kwargs):
         """
         Load quantized weight scales from the checkpoint.
@@ -2001,3 +2004,6 @@ class Linear(nn.Module):
 
         weight_mode = self.weights_loading_config.weight_mode
         self.quant_method.load_weights(self, weights, weight_mode)
+
+    def post_load_weights(self):
+        self.quant_method.post_load_weights(self)

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1046,6 +1046,10 @@ class PyTorchModelEngine(ModelEngine):
                 raise NotImplementedError(
                     f"No load support for load format: {load_format}")
 
+            for module in model.modules():
+                if hasattr(module, 'post_load_weights'):
+                    module.post_load_weights()
+
             if isinstance(moe_load_balancer, MoeLoadBalancer):
                 setattr(self, "moe_load_balancer", moe_load_balancer)
                 moe_load_balancer.register_weight_slots_after_to_cuda()

--- a/tests/unittest/_torch/modules/test_fused_moe.py
+++ b/tests/unittest/_torch/modules/test_fused_moe.py
@@ -729,6 +729,7 @@ def test_fused_moe_fp8_blockwise_deepgemm(dtype,
     )
     fused_moe.cuda()
     fused_moe.load_weights([weights])
+    fused_moe.post_load_weights()
 
     def swiglu_fused_moe(x):
         x, gate = x.chunk(2, dim=-1)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatic post-load weight processing across models, enabling FP8 scaling and MoE quant scale setup after loading.
  - Engine now auto-detects and runs post-load steps where supported for smoother model initialization.
- Refactor
  - Replaced hook-based closures with explicit post-load methods on relevant modules and models.
  - Centralized invocation of post-load steps in the model loading flow.
  - Removed a constructor parameter related to post-load hooks in min-latency components; post-load behavior is now implicit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
