### PR TITLE
[TRTLLM-8209][feat] Support new structural tag API (upgrade XGrammar to 0.1.25)

### DIFF
--- a/cpp/tensorrt_llm/batch_manager/guidedDecoder.cpp
+++ b/cpp/tensorrt_llm/batch_manager/guidedDecoder.cpp
@@ -109,34 +109,20 @@ void GuidedDecoder::build(ScheduledRequests const& scheduledRequests)
                     }
                     case executor::GuidedDecodingParams::GuideType::kREGEX:
                     {
-                        auto const& grammar = xgrammar::Grammar::FromRegex(guide.value());
-                        mXGrammarMatchers.at(seqSlot)
-                            = std::make_shared<xgrammar::GrammarMatcher>(mXGrammarCompiler->CompileGrammar(grammar));
+                        mXGrammarMatchers.at(seqSlot) = std::make_shared<xgrammar::GrammarMatcher>(
+                            mXGrammarCompiler->CompileRegex(guide.value()));
                         break;
                     }
                     case executor::GuidedDecodingParams::GuideType::kEBNF_GRAMMAR:
                     {
-                        auto const& grammar = xgrammar::Grammar::FromEBNF(guide.value());
-                        mXGrammarMatchers.at(seqSlot)
-                            = std::make_shared<xgrammar::GrammarMatcher>(mXGrammarCompiler->CompileGrammar(grammar));
+                        mXGrammarMatchers.at(seqSlot) = std::make_shared<xgrammar::GrammarMatcher>(
+                            mXGrammarCompiler->CompileGrammar(guide.value()));
                         break;
                     }
                     case executor::GuidedDecodingParams::GuideType::kSTRUCTURAL_TAG:
                     {
-                        auto const& structuralTagParametersJson = nlohmann::json::parse(guide.value());
-                        auto const& structuralTagItemsJson
-                            = structuralTagParametersJson.at("structures").template get<std::vector<nlohmann::json>>();
-                        std::vector<xgrammar::StructuralTagItem> structuralTagItems;
-                        for (auto const& s : structuralTagItemsJson)
-                        {
-                            structuralTagItems.emplace_back(
-                                xgrammar::StructuralTagItem{s.at("begin").template get<std::string>(),
-                                    s.at("schema").dump(), s.at("end").template get<std::string>()});
-                        }
-                        auto const& triggers
-                            = structuralTagParametersJson.at("triggers").template get<std::vector<std::string>>();
                         mXGrammarMatchers.at(seqSlot) = std::make_shared<xgrammar::GrammarMatcher>(
-                            mXGrammarCompiler->CompileStructuralTag(structuralTagItems, triggers));
+                            mXGrammarCompiler->CompileStructuralTag(guide.value()));
                         break;
                     }
                     default:

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,7 +59,7 @@ peft
 einops
 flashinfer-python>=0.3.0
 opencv-python-headless
-xgrammar==0.1.21
+xgrammar==0.1.25
 llguidance==0.7.29
 jsonschema
 backoff

--- a/tensorrt_llm/__init__.py
+++ b/tensorrt_llm/__init__.py
@@ -29,10 +29,6 @@ _add_trt_llm_dll_directory()
 
 import sys
 
-# Need to import xgrammar before tensorrt_llm library,
-# otherwise `MemoryError: std::bad_alloc` pattern error will be raised.
-import xgrammar  # noqa
-
 import tensorrt_llm._torch.models as torch_models
 import tensorrt_llm.functional as functional
 import tensorrt_llm.math_utils as math_utils

--- a/tensorrt_llm/__init__.py
+++ b/tensorrt_llm/__init__.py
@@ -29,6 +29,10 @@ _add_trt_llm_dll_directory()
 
 import sys
 
+# Need to import xgrammar before tensorrt_llm library,
+# otherwise `MemoryError: std::bad_alloc` pattern error will be raised.
+import xgrammar  # noqa
+
 import tensorrt_llm._torch.models as torch_models
 import tensorrt_llm.functional as functional
 import tensorrt_llm.math_utils as math_utils

--- a/tensorrt_llm/_torch/pyexecutor/grammar_matcher.py
+++ b/tensorrt_llm/_torch/pyexecutor/grammar_matcher.py
@@ -1,4 +1,3 @@
-import json
 import os
 from abc import ABC, abstractmethod
 
@@ -102,24 +101,13 @@ class XGrammarMatcherFactory(GrammarMatcherFactory):
                 compiled_grammar = self._xgrammar_compiler.compile_json_schema(
                     guide)
             case GuidedDecodingParams.GuideType.REGEX:
-                grammar = xgrammar.Grammar.from_regex(guide)
-                compiled_grammar = self._xgrammar_compiler.compile_grammar(
-                    grammar)
+                compiled_grammar = self._xgrammar_compiler.compile_regex(guide)
             case GuidedDecodingParams.GuideType.EBNF_GRAMMAR:
-                grammar = xgrammar.Grammar.from_ebnf(guide)
                 compiled_grammar = self._xgrammar_compiler.compile_grammar(
-                    grammar)
+                    guide)
             case GuidedDecodingParams.GuideType.STRUCTURAL_TAG:
-                structural_tag_parameters = json.loads(guide)
-                structures = structural_tag_parameters["structures"]
-                structures = [
-                    xgrammar.StructuralTagItem(begin=s["begin"],
-                                               schema=json.dumps(s["schema"]),
-                                               end=s["end"]) for s in structures
-                ]
-                triggers = structural_tag_parameters["triggers"]
                 compiled_grammar = self._xgrammar_compiler.compile_structural_tag(
-                    structures, triggers)
+                    guide)
             case _:
                 raise ValueError(f"Unsupported guide type: {guide_type}.")
 

--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -6,6 +6,7 @@ import uuid
 from typing import Any, Dict, List, Literal, Optional, Union
 
 import torch
+import xgrammar
 from openai.types.chat import ChatCompletionAssistantMessageParam
 from openai.types.chat import \
     ChatCompletionContentPartParam as OpenAIChatCompletionContentPartParam
@@ -85,18 +86,11 @@ class ModelList(OpenAIBaseModel):
     data: List[ModelCard] = Field(default_factory=list)
 
 
-class StructuralTag(OpenAIBaseModel):
-    begin: str
-    schema_: Optional[dict[str, Any]] = Field(alias="schema")
-    end: str
-
-
 class ResponseFormat(OpenAIBaseModel):
     # type must be one of "text", "json", "json_object", or "structural_tag"
     type: Literal["text", "json", "json_object", "structural_tag"]
     schema: Optional[dict] = None
-    structures: Optional[List[StructuralTag]] = None
-    triggers: Optional[List[str]] = None
+    format: Optional[xgrammar.structural_tag.Format] = None
 
 
 class DisaggregatedParams(OpenAIBaseModel):

--- a/tests/unittest/_torch/thop/parallel/test_logits_bitmask_op.py
+++ b/tests/unittest/_torch/thop/parallel/test_logits_bitmask_op.py
@@ -21,7 +21,7 @@ def test_logits_bitmask(batch_size: int, vocab_size: int, stride: int,
                               size=(batch_size, vocab_size),
                               dtype=torch.bool,
                               device="cuda")
-    bitmask = xgrammar.testing._bool_mask_to_bitmask(bool_mask)
+    bitmask = xgrammar.testing.bool_mask_to_bitmask(bool_mask)
     token_mask = None
     if stride > 1:
         token_mask = torch.arange(batch_size, dtype=torch.int32,
@@ -53,7 +53,7 @@ def test_logits_bitmask_with_d2t(batch_size: int, vocab_size: int, stride: int,
                               size=(batch_size, vocab_size),
                               dtype=torch.bool,
                               device="cuda")
-    bitmask = xgrammar.testing._bool_mask_to_bitmask(bool_mask)
+    bitmask = xgrammar.testing.bool_mask_to_bitmask(bool_mask)
     token_mask = None
     if stride > 1:
         token_mask = torch.arange(batch_size, dtype=torch.int32,

--- a/tests/unittest/llmapi/apps/_test_openai_chat_structural_tag.py
+++ b/tests/unittest/llmapi/apps/_test_openai_chat_structural_tag.py
@@ -162,22 +162,34 @@ You are a helpful assistant."""
         messages=messages,
         max_completion_tokens=256,
         response_format={
-            "type":
-            "structural_tag",
-            "structures": [
-                {
-                    "begin": "<function=get_current_weather>",
-                    "schema":
-                    tool_get_current_weather["function"]["parameters"],
-                    "end": "</function>",
-                },
-                {
-                    "begin": "<function=get_current_date>",
-                    "schema": tool_get_current_date["function"]["parameters"],
-                    "end": "</function>",
-                },
-            ],
-            "triggers": ["<function="],
+            "type": "structural_tag",
+            "format": {
+                "type":
+                "triggered_tags",
+                "triggers": ["<function="],
+                "tags": [
+                    {
+                        "begin": "<function=get_current_weather>",
+                        "content": {
+                            "type":
+                            "json_schema",
+                            "json_schema":
+                            tool_get_current_weather["function"]["parameters"]
+                        },
+                        "end": "</function>",
+                    },
+                    {
+                        "begin": "<function=get_current_date>",
+                        "content": {
+                            "type":
+                            "json_schema",
+                            "json_schema":
+                            tool_get_current_date["function"]["parameters"]
+                        },
+                        "end": "</function>",
+                    },
+                ],
+            },
         },
     )
 


### PR DESCRIPTION
# [TRTLLM-8209][feat] Support new structural tag API (upgrade XGrammar to 0.1.25)

## Description

This PR supports the new structural tag API of xgrammar. Quoting xgrammar's [doc](https://xgrammar.mlc.ai/docs/tutorials/structural_tag.html):

> The structural tag API aims to provide a JSON-config-based way to precisely describe the output format of an LLM. It is more flexible and dynamic than the OpenAI API:
> * Flexible: supports various structures, including tool calling, reasoning (<think>…</think>), etc.
> * Dynamic: allows a mixture of free-form text and structures such as tool calls, entering constrained generation when a pre-set trigger is met.

> It can also be used in the LLM engine to implement the OpenAI Tool Calling API with strict format constraints, with these benefits:
> * Support the advanced tool calling features, such as forced tool calling, parallel tool calling, etc.
> * Support the tool calling format of most of the LLMs available in the market with minimal effort.

Thanks the XGrammar team @Ubospica for this new feature!

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Updated structural_tag response_format to use a nested format field (triggered tags with per-tag JSON schema), replacing structures/triggers.
- Refactor
  - Simplified grammar compilation paths for regex, EBNF grammar, and structural tags for more direct compilation.
- Chores
  - Upgraded xgrammar dependency to 0.1.25 and updated third-party reference.
- Tests
  - Adjusted chat structural_tag tests to the new format payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->