### PR TITLE
[#7654][feat] CMake option to link statically with TRT

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -48,6 +48,8 @@ option(NVRTC_DYNAMIC_LINKING "Link against the dynamic NVRTC libraries" OFF)
 option(CUBLAS_DYNAMIC_LINKING
        "Link against the dynamic cublas/cublasLt libraries" ON)
 option(CURAND_DYNAMIC_LINKING "Link against the dynamic curand library" ON)
+option(TRT_DYNAMIC_LINKING
+       "Link against the dynamic TensorRT libraries (nvInfer,...)" ON)
 
 option(ENABLE_NVSHMEM "Enable building with NVSHMEM support" OFF)
 option(USING_OSS_CUTLASS_LOW_LATENCY_GEMM


### PR DESCRIPTION
Add new CMake option TRT_DYNAMIC_LINKING, default ON.

## Description

Default build links dynamically with TensorRT multiplying the number of dyn libs needed to deploy/publish/reveal to the end customers.
Solution: add an option to statically link with TRT.

## Test Coverage

CI to build both dynamically (cublas, curand, trt, ...) and statically (cublas, curand, trt).

## PR Checklist

- [X] Please check this after reviewing the above items as appropriate for this PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added build option to dynamically link TensorRT libraries (default ON), with automatic handling of library name variants and postfixes.
  - Static linking now supported; automatically links nvJitLink when needed. On Windows, dynamic linking is enforced (errors on static selection).

- Chores
  - Improved build diagnostics with clearer logs for include directories and resolved libraries, aiding troubleshooting of TensorRT components (e.g., OnnxParser, Plugin).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->