### PR TITLE
[https://nvbugs/5451740][fix] Add DP padding back on SM120

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -58,7 +58,7 @@ from ..modules.attention import MLA
 from ..modules.decoder_layer import DecoderLayer
 from ..modules.embedding import Embedding
 from ..modules.fused_moe import (CutlassFusedMoE, DeepSeekV3MoeRoutingMethod,
-                                 WideEPMoE, create_moe)
+                                 MoEWeightLoadingMode, WideEPMoE, create_moe)
 from ..modules.gated_mlp import GatedMLP
 from ..modules.linear import Linear, TensorParallelMode, WeightsLoadingConfig
 from ..modules.multi_stream_utils import maybe_execute_in_parallel

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -57,8 +57,8 @@ from ..model_config import ModelConfig
 from ..modules.attention import MLA
 from ..modules.decoder_layer import DecoderLayer
 from ..modules.embedding import Embedding
-from ..modules.fused_moe import (DeepSeekV3MoeRoutingMethod,
-                                 MoEWeightLoadingMode, create_moe)
+from ..modules.fused_moe import (CutlassFusedMoE, DeepSeekV3MoeRoutingMethod,
+                                 WideEPMoE, create_moe)
 from ..modules.gated_mlp import GatedMLP
 from ..modules.linear import Linear, TensorParallelMode, WeightsLoadingConfig
 from ..modules.multi_stream_utils import maybe_execute_in_parallel
@@ -831,6 +831,17 @@ class Deepseekv3MoE(nn.Module):
                               all_rank_num_tokens, do_finalize):
         # max-throughput
         use_dp_padding = False
+        # Add attention DP padding on SM120 for context comm performance
+        enable_dp_padding = (
+            get_sm_version() == 120
+            and (not isinstance(self.experts, (CutlassFusedMoE, WideEPMoE)) or
+                 (not self.experts.has_fp8_qdq and self.experts.has_nvfp4)))
+        if self.use_dp and self.mapping.tp_size > 1 and enable_dp_padding:
+            use_dp_padding = True
+            hidden_states = torch.nn.functional.pad(
+                hidden_states,
+                (0, 0, 0, max(all_rank_num_tokens) - hidden_states.shape[0]))
+
         router_logits = self.gate(hidden_states)
 
         routed_output = self.experts(

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -832,6 +832,7 @@ class Deepseekv3MoE(nn.Module):
         # max-throughput
         use_dp_padding = False
         # Add DP padding on SM120 for context comm performance
+        # TODO: Move this model-agonostic part to MoE
         if self.use_dp and self.mapping.tp_size > 1 and get_sm_version() == 120:
             use_dp_padding = True
             hidden_states = torch.nn.functional.pad(

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -831,7 +831,7 @@ class Deepseekv3MoE(nn.Module):
                               all_rank_num_tokens, do_finalize):
         # max-throughput
         use_dp_padding = False
-        # Add attention DP padding on SM120 for context comm performance
+        # Add DP padding on SM120 for context comm performance
         enable_dp_padding = (
             get_sm_version() == 120
             and (not isinstance(self.experts, (CutlassFusedMoE, WideEPMoE)) or


### PR DESCRIPTION
## Description

1. Add DP padding back on the devices that have limited communication bw, current just enabled for SM120. Without DP padding, NCCL reduce_scatter + all_gather would fallback to reduce + broadcast, which can cause 30% context phase comm perf regression. 
2. Another non arch-specific issue caused by dp_padding missing is that when num_chunks>1 for chunked MoE in IFB scenario (e.g. input_seqlen=4k, moe_max_num_tokens=3k, num_chunks=2), input tokens for 8 ranks are [4096, 1, 1, 1, 1, 1, 1, 1], all ranks needs to be split into 2 chunks, which makes rank1-7 have input tensor with zero dim, which leads to NCCL kernel failure. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added automatic DP padding for attention on SM120 in specific MoE + tensor-parallel setups to ensure consistent routing and outputs.
  - Exposed additional MoE backends for use in configurations, enabling broader deployment options.

- Bug Fixes
  - Resolved potential shape/routing inconsistencies in MoE pipelines when using tensor parallelism on SM120 by applying conditional padding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->