### PR TITLE
[TRTLLM-7733][feat] Executor changes to support helix parallelism

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/executor_request_queue.py
+++ b/tensorrt_llm/_torch/pyexecutor/executor_request_queue.py
@@ -596,6 +596,72 @@ class ExecutorRequestQueue:
                     self.new_active_requests_queue_latency_ms += now - self.start_times.pop(
                         child_id)
 
+    # Note: Helix parallelism is a decode-only feature run with disaggregated serving. This function gets called on gen server
+    # during initialization of a new request.
+    def _merge_helix_requests(self, new_requests: list[RequestQueueItem],
+                              tokens_per_block: int):
+        req_with_children = []
+        num_cp_ranks = self.dist.cp_size
+        curr_cp_rank = self.dist.cp_rank
+
+        # For each request, partition the input_token_ids into blocks and then partition blocks across CP ranks.
+        # Currently, the partitioning is such that contiguous blocks are assigned to the same CP rank (as opposed
+        # to round-robin).
+        for req_item in new_requests:
+            all_input_ids = torch.tensor(req_item.request.input_token_ids,
+                                         dtype=torch.int64).unsqueeze(0)
+            input_len = all_input_ids.shape[-1]
+
+            num_total_blocks = (input_len + tokens_per_block -
+                                1) // tokens_per_block
+            if num_total_blocks < num_cp_ranks:
+                raise ValueError(
+                    f"There aren't enough tokens to get at least one block per CP rank. num_total_blocks {num_total_blocks} < num_cp_ranks {num_cp_ranks}. Please use smaller tokens_per_block for KV cache or reduce the number of CP ranks."
+                )
+
+            # Padding to ensure torch.stack used with torch.tensor_split works properly.
+            padding_len = 0
+            if input_len % tokens_per_block != 0:
+                padding_len = tokens_per_block - (input_len % tokens_per_block)
+                padding_ids = torch.zeros([1, padding_len], dtype=torch.int64)
+                all_input_ids = torch.cat((all_input_ids, padding_ids), dim=-1)
+            all_position_ids = torch.arange(0,
+                                            input_len + padding_len,
+                                            dtype=torch.int64).unsqueeze(0)
+
+            input_id_blocks_per_rank = torch.tensor_split(
+                torch.stack(all_input_ids.split(tokens_per_block, dim=-1)),
+                num_cp_ranks)
+            position_id_blocks_per_rank = torch.tensor_split(
+                torch.stack(all_position_ids.split(tokens_per_block, dim=-1)),
+                num_cp_ranks)
+
+            # Get the input_ids and position_ids for this rank.
+            input_ids_this_rank = input_id_blocks_per_rank[
+                curr_cp_rank].flatten().tolist()
+            position_ids_this_rank = position_id_blocks_per_rank[
+                curr_cp_rank].flatten().tolist()
+
+            # Undo the padding. Only last rank's last block will be padded right now
+            # given contiguous block assignment.
+            if curr_cp_rank == num_cp_ranks - 1 and padding_len > 0:
+                input_ids_this_rank = input_ids_this_rank[:-padding_len]
+                position_ids_this_rank = position_ids_this_rank[:-padding_len]
+
+            req = executor_request_to_llm_request(
+                req_id=req_item.id,
+                executor_request=req_item.request,
+                child_req_ids=req_item.child_req_ids,
+                exclude_last_generation_logits=self.
+                _should_exclude_last_generation_logits(),
+                input_token_ids=input_ids_this_rank,
+                position_ids=position_ids_this_rank,
+            )
+            req_with_children.append(req)
+            if req.child_requests:
+                req_with_children.extend(req.child_requests)
+        return req_with_children
+
     @nvtx_range("_merge_requests")
     def _merge_requests(
             self, new_requests: list[RequestQueueItem]) -> List[LlmRequest]:
@@ -604,20 +670,24 @@ class ExecutorRequestQueue:
             cp_type = cp_config['cp_type']
             if cp_type == CpType.STAR:
                 return self._merge_star_attention_requests(new_requests)
-            elif cp_type == CpType.RING:
-                raise NotImplementedError("ring attention not implemented yet")
+            elif cp_type == CpType.HELIX:
+                # Take the usual route below.
+                return self._merge_helix_requests(
+                    new_requests,
+                    tokens_per_block=cp_config['tokens_per_block'])
             else:
-                raise NotImplementedError(f'unsupport cp type {cp_type}')
-        else:
-            req_with_children = []
-            for req_item in new_requests:
-                req = executor_request_to_llm_request(
-                    req_item.id, req_item.request, req_item.child_req_ids,
-                    self._should_exclude_last_generation_logits())
-                req_with_children.append(req)
-                if req.child_requests:
-                    req_with_children.extend(req.child_requests)
-            return req_with_children
+                raise NotImplementedError(
+                    f'Unsupported cp type {cp_type.name}.')
+
+        req_with_children = []
+        for req_item in new_requests:
+            req = executor_request_to_llm_request(
+                req_item.id, req_item.request, req_item.child_req_ids,
+                self._should_exclude_last_generation_logits())
+            req_with_children.append(req)
+            if req.child_requests:
+                req_with_children.extend(req.child_requests)
+        return req_with_children
 
     def _merge_star_attention_requests(
             self, new_requests: list[RequestQueueItem]) -> List[LlmRequest]:

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -605,7 +605,8 @@ def executor_request_to_llm_request(
         executor_request: ExecutorRequest,
         child_req_ids: List[int],
         exclude_last_generation_logits: bool,
-        input_token_ids: Optional[List] = None) -> LlmRequest:
+        input_token_ids: Optional[List] = None,
+        position_ids: Optional[List] = None) -> LlmRequest:
     executor_sampling_config = executor_request.sampling_config
     sampling_config = SamplingConfig(executor_sampling_config)
 
@@ -644,6 +645,7 @@ def executor_request_to_llm_request(
             convert_wordlist(executor_request.bad_words), dtype=torch.int32)
         if executor_request.bad_words else None,
         stop_words_list=stop_words_list,
+        position_ids=position_ids,
         prompt_embedding_table=None if executor_request.prompt_tuning_config
         is None else executor_request.prompt_tuning_config.embedding_table,
         prompt_vocab_size=None if executor_request.prompt_tuning_config is None

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -629,9 +629,11 @@ class PyTorchModelEngine(ModelEngine):
                         if spec_resource_manager is not None:
                             spec_resource_manager.free_resources(req)
 
-        # TODO: current warmup_request is not suitable for star attention
+        # TODO: current warmup_request is not suitable for context parallelism.
         cp_type = self.mapping.cp_config.get('cp_type', None)
-        if cp_type == CpType.STAR:
+        if cp_type is not None:
+            logger.info("[ModelEngine::warmup] Skipping warmup for cp_type: ",
+                        cp_type.name)
             return
 
         if self._torch_compile_enabled:
@@ -1334,7 +1336,13 @@ class PyTorchModelEngine(ModelEngine):
                     if beam == first_beam:
                         previous_batch_indices.append(request.py_batch_idx)
                     past_seen_token_num = request.max_beam_num_tokens
-                position_ids.append(past_seen_token_num)
+                position_id = past_seen_token_num
+                if self.mapping.has_cp_helix():
+                    # Do an allgather among CP ranks to get the complete sequence length seen by all CP ranks.
+                    past_seen_token_nums = self.dist.cp_allgather(
+                        past_seen_token_num)
+                    position_id = sum(past_seen_token_nums)
+                position_ids.append(position_id)
                 num_cached_tokens_per_seq.append(past_seen_token_num)
                 prompt_lengths.append(request.py_prompt_len)
                 draft_lens.append(0)
@@ -2111,13 +2119,17 @@ class PyTorchModelEngine(ModelEngine):
             if CpType.STAR == cp_type:
                 return self._prepare_star_attention_inputs(
                     scheduled_requests, kv_cache_manager, attn_metadata)
+            elif CpType.HELIX == cp_type:
+                # Take the usual route of _prepare_tp_inputs.
+                pass
             else:
-                assert False, f'Unsupport cp_type {cp_type}'
-        else:
-            return self._prepare_tp_inputs(scheduled_requests, kv_cache_manager,
-                                           attn_metadata, spec_metadata,
-                                           new_tensors_device,
-                                           cache_indirection_buffer)
+                raise NotImplementedError(
+                    f"Unsupported cp_type {getattr(cp_type, 'name', cp_type)}.")
+
+        return self._prepare_tp_inputs(scheduled_requests, kv_cache_manager,
+                                       attn_metadata, spec_metadata,
+                                       new_tensors_device,
+                                       cache_indirection_buffer)
 
     @torch.inference_mode()
     @with_model_extra_attrs(lambda self: self.model.extra_attrs)

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1764,10 +1764,13 @@ class PyExecutor:
             cp_type = cp_config['cp_type']
             if cp_type == CpType.STAR:
                 self._update_request_states_star_attention(scheduled_requests)
+            elif cp_type == CpType.HELIX:
+                # Take the usual route with _update_request_states_tp().
+                pass
             else:
-                assert False, f'Unsupport cp_type {cp_type}'
-        else:
-            self._update_request_states_tp(scheduled_requests)
+                raise NotImplementedError(
+                    f'Unsupported cp type {cp_type.name}.')
+        self._update_request_states_tp(scheduled_requests)
 
     @nvtx_range("_sample_async")
     def _sample_async(self, scheduled_batch,

--- a/tests/unittest/_torch/executor/test_executor_request_queue.py
+++ b/tests/unittest/_torch/executor/test_executor_request_queue.py
@@ -9,6 +9,8 @@ import pytest
 
 from tensorrt_llm._torch.pyexecutor.executor_request_queue import (
     SHUTDOWN_REQUEST_ID, ExecutorRequestQueue, RequestQueueItem)
+from tensorrt_llm.bindings import executor as trtllm
+from tensorrt_llm.mapping import CpType
 
 
 @pytest.fixture
@@ -89,6 +91,160 @@ def test_enqueue_requests(executor_queue):
     for req_id in req_ids:
         assert req_id in executor_queue.start_times
         assert executor_queue.start_times[req_id] == 1234.5
+
+
+def test_merge_helix_requests_with_padding(mock_dist):
+    """Test _merge_helix_requests with basic valid input."""
+
+    tokens_per_block = 2
+
+    # Create request item with 13 tokens to get exactly 7 blocks for 4 CP ranks.
+    input_tokens = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
+    executor_request = trtllm.Request(input_token_ids=input_tokens,
+                                      max_tokens=5,
+                                      streaming=False,
+                                      sampling_config=trtllm.SamplingConfig(),
+                                      output_config=trtllm.OutputConfig())
+    request_item = RequestQueueItem(
+        id=1,
+        request=executor_request,
+    )
+
+    for rank in [0, 1, 2, 3]:
+        # Create executor queue for helix with 4 CP ranks.
+        mock_dist.cp_size = 4
+        mock_dist.cp_rank = rank
+        mock_dist.cp_config = {
+            'cp_type': CpType.HELIX,
+            'tokens_per_block': tokens_per_block,
+        }
+        executor_queue = ExecutorRequestQueue(dist=mock_dist,
+                                              enable_attention_dp=False,
+                                              max_batch_size=8,
+                                              max_beam_width=1,
+                                              max_num_active_requests=16,
+                                              enable_iter_perf_stats=True,
+                                              batch_wait_timeout_ms=0.0,
+                                              is_disaggregated=True)
+
+        # Mock _should_exclude_last_generation_logits.
+        with patch.object(executor_queue,
+                          '_should_exclude_last_generation_logits',
+                          return_value=False):
+            result = executor_queue._merge_helix_requests([request_item],
+                                                          tokens_per_block)
+
+        # Verify the result.
+        assert len(result) == 1
+        llm_request = result[0]
+        from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest
+        assert isinstance(llm_request, LlmRequest)
+        assert llm_request.request_id == 1
+        if rank == 0:
+            assert llm_request.get_tokens(0) == [1, 2, 3, 4]
+        elif rank == 1:
+            assert llm_request.get_tokens(0) == [5, 6, 7, 8]
+        elif rank == 2:
+            assert llm_request.get_tokens(0) == [9, 10, 11, 12]
+        else:
+            assert llm_request.get_tokens(0) == [13]
+
+
+def test_merge_helix_requests_without_padding(mock_dist):
+    """Test _merge_helix_requests with evenly divisible tokens (no padding)."""
+
+    tokens_per_block = 4
+
+    # Create request item with 12 tokens to get exactly 3 blocks for 2 CP ranks.
+    input_tokens = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+    executor_request = trtllm.Request(input_token_ids=input_tokens,
+                                      max_tokens=5,
+                                      streaming=False,
+                                      sampling_config=trtllm.SamplingConfig(),
+                                      output_config=trtllm.OutputConfig())
+    request_item = RequestQueueItem(
+        id=1,
+        request=executor_request,
+    )
+
+    for rank in [0, 1]:
+        # Create executor queue for helix with 2 CP ranks.
+        mock_dist.cp_size = 2
+        mock_dist.cp_rank = rank
+        mock_dist.cp_config = {
+            'cp_type': CpType.HELIX,
+            'tokens_per_block': tokens_per_block,
+        }
+        executor_queue = ExecutorRequestQueue(dist=mock_dist,
+                                              enable_attention_dp=False,
+                                              max_batch_size=8,
+                                              max_beam_width=1,
+                                              max_num_active_requests=16,
+                                              enable_iter_perf_stats=True,
+                                              batch_wait_timeout_ms=0.0,
+                                              is_disaggregated=True)
+
+        # Mock _should_exclude_last_generation_logits.
+        with patch.object(executor_queue,
+                          '_should_exclude_last_generation_logits',
+                          return_value=False):
+            result = executor_queue._merge_helix_requests([request_item],
+                                                          tokens_per_block)
+
+        # Verify the result.
+        assert len(result) == 1
+        llm_request = result[0]
+        from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest
+        assert isinstance(llm_request, LlmRequest)
+        assert llm_request.request_id == 1
+        if rank == 0:
+            assert llm_request.get_tokens(0) == [1, 2, 3, 4, 5, 6, 7, 8]
+        else:
+            assert llm_request.get_tokens(0) == [9, 10, 11, 12]
+
+
+def test_merge_helix_requests_insufficient_blocks_error(mock_dist):
+    """Test _merge_helix_requests raises error when insufficient blocks."""
+    mock_dist.cp_size = 4
+
+    tokens_per_block = 4
+    mock_dist.cp_config = {
+        'cp_type': CpType.HELIX,
+        'tokens_per_block': tokens_per_block,
+    }
+
+    # Create input with only 12 tokens. This creates 3 blocks which is fewer than 4 CP ranks.
+    executor_request = trtllm.Request(
+        input_token_ids=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+        max_tokens=12,
+        streaming=False,
+        sampling_config=trtllm.SamplingConfig(),
+        output_config=trtllm.OutputConfig())
+    request_item = RequestQueueItem(
+        id=1,
+        request=executor_request,
+    )
+
+    # Loop over ranks 0, 1, 2, 3 and verify that all ranks throw assertion.
+    for rank in range(4):
+        mock_dist.cp_rank = rank
+
+        executor_queue = ExecutorRequestQueue(dist=mock_dist,
+                                              enable_attention_dp=False,
+                                              max_batch_size=8,
+                                              max_beam_width=1,
+                                              max_num_active_requests=16,
+                                              enable_iter_perf_stats=True,
+                                              batch_wait_timeout_ms=0.0,
+                                              is_disaggregated=True)
+
+        with pytest.raises(
+                ValueError,
+                match=
+                "There aren't enough tokens to get at least one block per CP rank"
+        ):
+            executor_queue._merge_helix_requests([request_item],
+                                                 tokens_per_block)
 
 
 def test_enqueue_request_single(executor_queue):

--- a/tests/unittest/_torch/executor/test_pytorch_model_engine.py
+++ b/tests/unittest/_torch/executor/test_pytorch_model_engine.py
@@ -1,5 +1,6 @@
 import unittest
 from dataclasses import dataclass
+from unittest.mock import MagicMock
 
 import torch
 
@@ -15,10 +16,11 @@ from tensorrt_llm._torch.pyexecutor.resource_manager import (KVCacheManager,
                                                              ResourceManagerType
                                                              )
 # isort: on
+from tensorrt_llm._torch.attention_backend.interface import AttentionMetadata
 from tensorrt_llm._torch.pyexecutor.scheduler import ScheduledRequests
 from tensorrt_llm.bindings.executor import KvCacheConfig
 from tensorrt_llm.llmapi import CudaGraphConfig, LlmArgs, SamplingParams
-from tensorrt_llm.mapping import Mapping
+from tensorrt_llm.mapping import CpType, Mapping
 
 
 @dataclass
@@ -319,6 +321,127 @@ class PyTorchModelEngineTestCase(unittest.TestCase):
                          "Custom max_batch_size should be respected")
         self.assertTrue(pytorch_config_custom.cuda_graph_padding_enabled,
                         "Custom enable_padding should be respected")
+
+    def test_prepare_tp_inputs_with_helix_parallelism(self) -> None:
+        """Test _prepare_tp_inputs function with helix parallelism."""
+
+        # Create model engine with helix parallelism.
+        config = PyTorchConfig(use_cuda_graph=False)
+        model_engine = DummyModelEngine(config, batch_size=4, dtype=torch.half)
+
+        # Provide mapping for model engine.
+        cp_size = 2
+        cp_rank = 0
+        cp_config = {"cp_type": CpType.HELIX, "tokens_per_block": 4}
+        mapping = Mapping(world_size=cp_size,
+                          tp_size=1,
+                          pp_size=1,
+                          cp_size=cp_size,
+                          cp_config=cp_config,
+                          rank=cp_rank)
+        model_engine.mapping = mapping
+
+        # Mock model_engine's dist and its cp_allgather to return different values per CP rank.
+        mock_dist = MagicMock()
+
+        def mock_cp_allgather(obj):
+            # Simulate allgather across CP ranks: [past_seen_token_num_rank0, past_seen_token_num_rank1]
+            if cp_rank == 0:
+                return [obj, obj + 10]  # Rank 0 sees tokens [obj, obj+10]
+            else:
+                return [obj - 10, obj]  # Rank 1 sees tokens [obj-10, obj]
+
+        mock_dist.cp_allgather.side_effect = mock_cp_allgather
+        model_engine.dist = mock_dist
+
+        # Create scheduled requests with two generation requests.
+        scheduled_requests = ScheduledRequests()
+        scheduled_requests.context_requests = []
+        prompt_lens = [20, 15]
+        gen_requests = []
+        for idx in range(len(prompt_lens)):
+            req = _create_request(num_tokens=prompt_lens[idx], req_id=idx + 1)
+            req.py_prompt_len = prompt_lens[idx]
+            req.py_batch_idx = None
+            req.is_dummy_request = False
+            req.py_seq_slot = idx
+            req.sampling_config.beam_width = 1
+            req.py_multimodal_data = {}
+            gen_requests.append(req)
+        scheduled_requests.generation_requests = gen_requests
+
+        # Create KV cache manager for attention metadata.
+        kv_cache_config = KvCacheConfig(max_tokens=512)
+        kv_cache_manager = KVCacheManager(
+            kv_cache_config,
+            tensorrt_llm.bindings.internal.batch_manager.CacheType.SELF,
+            num_layers=1,
+            num_kv_heads=16,
+            head_dim=16,
+            tokens_per_block=1,
+            max_seq_len=512,
+            max_batch_size=4,
+            mapping=mapping,
+            dtype=tensorrt_llm.bindings.DataType.HALF,
+        )
+        attn_metadata = AttentionMetadata(max_num_requests=4,
+                                          max_num_tokens=512,
+                                          kv_cache_manager=kv_cache_manager)
+        attn_metadata.is_cuda_graph = False
+
+        # Initialize model engine buffers.
+        max_num_tokens = 512
+        model_engine.max_num_tokens = max_num_tokens
+        model_engine.input_ids_cuda = torch.zeros(max_num_tokens,
+                                                  dtype=torch.int32,
+                                                  device='cuda')
+        model_engine.position_ids_cuda = torch.zeros(max_num_tokens,
+                                                     dtype=torch.int32,
+                                                     device='cuda')
+        model_engine.previous_batch_indices_cuda = torch.zeros(
+            max_num_tokens, dtype=torch.int32, device='cuda')
+
+        result, _ = model_engine._prepare_tp_inputs(
+            scheduled_requests=scheduled_requests,
+            kv_cache_manager=kv_cache_manager,
+            attn_metadata=attn_metadata)
+
+        # Verify expected keys are present.
+        self.assertIsNotNone(result)
+        self.assertIn('input_ids', result)
+        self.assertIn('position_ids', result)
+        self.assertIn('attn_metadata', result)
+
+        # Check that cp_allgather was called for position calculation.
+        # Also, verify that position_ids are properly calculated.
+        self.assertTrue(mock_dist.cp_allgather.called)
+        position_ids = result['position_ids']
+        self.assertIsInstance(position_ids, torch.Tensor)
+        # For cp_rank=0, the expected position_ids should be:
+        # req1: past_seen_token_num=19 (prompt_len0-1), allgather=[19, 29], sum=48.
+        # req2: past_seen_token_num=14 (prompt_len1-1), allgather=[14, 24], sum=38.
+        expected_positions = [48, 38]
+        actual_positions = position_ids.squeeze(0).cpu().tolist()[:2]
+        self.assertEqual(
+            actual_positions, expected_positions,
+            f"Position IDs should reflect CP allgather results. Expected: {expected_positions}, Got: {actual_positions}"
+        )
+
+        # Verify attention metadata is properly configured.
+        self.assertEqual(attn_metadata.request_ids, [1, 2])
+        self.assertEqual(attn_metadata.prompt_lens, [20, 15])
+        self.assertEqual(attn_metadata.num_contexts, 0)
+
+        # Verify KV cache parameters
+        self.assertIsNotNone(attn_metadata.kv_cache_params)
+        self.assertTrue(attn_metadata.kv_cache_params.use_cache)
+
+        # Verify sequence lengths are correct.
+        expected_seq_lens = [1, 1]
+        if hasattr(attn_metadata,
+                   'seq_lens') and attn_metadata.seq_lens is not None:
+            actual_seq_lens = attn_metadata.seq_lens.cpu().tolist()
+            self.assertEqual(actual_seq_lens, expected_seq_lens)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
This MR makes initial executor changes to support helix parallelism which is a form of context parallelism.

Main things to note:
- Helix parallelism is a decode-only feature run with disaggregated serving on gen server.
- We partition the sequence length into blocks and then partition blocks those across CP ranks. Currently, we assign contiguous blocks to the same CP rank. Alternatively, we could assign blocks in a round-robin fashion.
- In `prepare_inputs`, we do an allgather among CP ranks to find the full prompt length for the sequence to determine the query token's `position_id`. This is important to get the right rope embeddings for the query token.
- Feature is not exposed through trtllm-serve, quickstart_advanced etc. This will be done when all other follow-up changes are merged.

Open items to be addressed in future MR:
- For a given query token at decode, only one of the CP ranks should write the token's KV to its KV cache.

## Test Coverage
Unit tests:
```
$ pytest tests/unittest/_torch/executor/test_pytorch_model_engine.py::PyTorchModelEngineTestCase::test_prepare_tp_inputs_with_helix_parallelism -s -v
$ pytest tests/unittest/_torch/executor/test_executor_request_queue.py::test_merge_helix_requests_insufficient_blocks_error -s -v
$ pytest tests/unittest/_torch/executor/test_executor_request_queue.py::test_merge_helix_requests_without_padding -s -v
$ pytest tests/unittest/_torch/executor/test_executor_request_queue.py::test_merge_helix_requests_with_padding -s -v
```

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
