### PR TITLE
[None][test] Update get_sysinfo.py to avoid UnboundLocalError

### DIFF
--- a/tests/integration/defs/sysinfo/get_sysinfo.py
+++ b/tests/integration/defs/sysinfo/get_sysinfo.py
@@ -181,7 +181,7 @@ def construct_gpu_properties(mako_opts, device_index=0):
                 entity = str(pci_device_id).lower()
                 if entity in chip_name_mapping:
                     chip = str(chip_name_mapping[entity])
-                    full_name = "{} Bring-up Board".format(chip.upper())
+                    full_name = "{} BRING-UP BOARD".format(chip.upper())
                 else:
                     err_msg = r"Could not find a chip name associated with this device id - {}. Chip name won't be reported".format(
                         entity)

--- a/tests/integration/defs/sysinfo/get_sysinfo.py
+++ b/tests/integration/defs/sysinfo/get_sysinfo.py
@@ -187,7 +187,7 @@ def construct_gpu_properties(mako_opts, device_index=0):
                         entity)
                     logger.warning(err_msg)
 
-        gpu_name = full_name.replace("NVIDIA", "").strip()
+        gpu_name = full_name.replace("NVIDIA", "").strip().upper()
         assert gpu_name != "", "device_product_name is empty after removing substring 'NVIDIA' and leading/trailing whitespaces."
 
         compute_capability = get_compute_capability(device_index)

--- a/tests/integration/defs/sysinfo/get_sysinfo.py
+++ b/tests/integration/defs/sysinfo/get_sysinfo.py
@@ -186,7 +186,7 @@ def construct_gpu_properties(mako_opts, device_index=0):
                     err_msg = r"Could not find a chip name associated with this device id - {}. Chip name won't be reported".format(
                         entity)
                     logger.warning(err_msg)
-            
+
         gpu_name = full_name.replace("NVIDIA", "").strip()
         assert gpu_name != "", "device_product_name is empty after removing substring 'NVIDIA' and leading/trailing whitespaces."
 

--- a/tests/integration/defs/sysinfo/get_sysinfo.py
+++ b/tests/integration/defs/sysinfo/get_sysinfo.py
@@ -180,14 +180,14 @@ def construct_gpu_properties(mako_opts, device_index=0):
             if pci_device_id is not None and chip_name_mapping:
                 entity = str(pci_device_id).lower()
                 if entity in chip_name_mapping:
-                    chip = str(chip_name_mapping[entity]).lower()
+                    chip = str(chip_name_mapping[entity])
+                    full_name = "{} Bring-up Board".format(chip.upper())
                 else:
                     err_msg = r"Could not find a chip name associated with this device id - {}. Chip name won't be reported".format(
                         entity)
                     logger.warning(err_msg)
-            full_name = "{} Bring-up Board".format(chip.upper())
-
-        gpu_name = full_name.replace("NVIDIA", "").strip().upper()
+            
+        gpu_name = full_name.replace("NVIDIA", "").strip()
         assert gpu_name != "", "device_product_name is empty after removing substring 'NVIDIA' and leading/trailing whitespaces."
 
         compute_capability = get_compute_capability(device_index)


### PR DESCRIPTION
## Description
Move the usage of chip to avoid unboundLocalError
Also, remove unused lower() and upper()
<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - System Info now displays consistent hardware names. When a PCI device maps to a chip, the board name shows as "<CHIP> Bring-up Board" with the chip in uppercase.
  - GPU names preserve their original case and drop the "NVIDIA" prefix for cleaner, more readable labels, avoiding unintended all-caps outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->