### PR TITLE
[TRTLLM-8293][infra] Support creating images with CUDA 12.9

### DIFF
--- a/docker/Dockerfile.multi
+++ b/docker/Dockerfile.multi
@@ -77,6 +77,8 @@ RUN bash ./install.sh --opencv && bash ./install.sh --protobuf && rm install.sh
 # Rename pytorch_triton package to triton
 RUN if [ -f /etc/redhat-release ]; then \
         echo "Rocky8 detected, skipping symlink and ldconfig steps"; \
+    elif [ ! -d /usr/local/lib/python3.12/dist-packages/pytorch_triton-3.3.1+gitc8757738.dist-info ]; then \
+        echo "pytorch_triton directory not found, skipping rename operation"; \
     else \
         cd /usr/local/lib/python3.12/dist-packages/ && \
         ls -la | grep pytorch_triton && \

--- a/docker/Dockerfile.multi
+++ b/docker/Dockerfile.multi
@@ -3,6 +3,7 @@ ARG BASE_IMAGE=nvcr.io/nvidia/pytorch
 ARG TRITON_IMAGE=nvcr.io/nvidia/tritonserver
 ARG BASE_TAG=25.08-py3
 ARG TRITON_BASE_TAG=25.08-py3
+ARG TRITON_BASE_TAG_12_9=25.06-py3
 ARG DEVEL_IMAGE=devel
 
 FROM ${BASE_IMAGE}:${BASE_TAG} AS base

--- a/docker/Dockerfile.multi
+++ b/docker/Dockerfile.multi
@@ -3,6 +3,7 @@ ARG BASE_IMAGE=nvcr.io/nvidia/pytorch
 ARG TRITON_IMAGE=nvcr.io/nvidia/tritonserver
 ARG BASE_TAG=25.08-py3
 ARG TRITON_BASE_TAG=25.08-py3
+ARG BASE_TAG_12_9=25.06-py3
 ARG TRITON_BASE_TAG_12_9=25.06-py3
 ARG DEVEL_IMAGE=devel
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -201,10 +201,10 @@ rockylinux8_%: BASE_TAG = 13.0.0-devel-rockylinux8
 rockylinux8_12_9_%: STAGE = tritondevel
 rockylinux8_12_9_%: BASE_IMAGE = nvcr.io/nvidia/cuda
 rockylinux8_12_9_%: BASE_TAG = 12.9.1-devel-rockylinux8
-rockylinux8_12_9_%: TRITON_BASE_TAG=25.06-py3
+rockylinux8_12_9_%: TRITON_BASE_TAG=$(shell grep '^ARG TRITON_BASE_TAG_12_9=' Dockerfile.multi | grep -o '=.*' | tr -d '="')
 
-tritondevel_12_9_%: BASE_TAG=25.06-py3
-tritondevel_12_9_%: TRITON_BASE_TAG=25.06-py3
+tritondevel_12_9_%: BASE_TAG=$(shell grep '^ARG BASE_TAG_12_9=' Dockerfile.multi | grep -o '=.*' | tr -d '="')
+tritondevel_12_9_%: TRITON_BASE_TAG=$(shell grep '^ARG TRITON_BASE_TAG_12_9=' Dockerfile.multi | grep -o '=.*' | tr -d '="')
 
 # For x86_64 and aarch64
 ubuntu22_%: STAGE = tritondevel

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -198,6 +198,10 @@ rockylinux8_%: STAGE = tritondevel
 rockylinux8_%: BASE_IMAGE = nvcr.io/nvidia/cuda
 rockylinux8_%: BASE_TAG = 13.0.0-devel-rockylinux8
 
+rockylinux8_12_9_%: STAGE = tritondevel
+rockylinux8_12_9_%: BASE_IMAGE = nvcr.io/nvidia/cuda
+rockylinux8_12_9_%: BASE_TAG = 12.9.1-devel-rockylinux8
+
 # For x86_64 and aarch64
 ubuntu22_%: STAGE = tritondevel
 ubuntu22_%: BASE_IMAGE = nvcr.io/nvidia/cuda

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -201,6 +201,10 @@ rockylinux8_%: BASE_TAG = 13.0.0-devel-rockylinux8
 rockylinux8_12_9_%: STAGE = tritondevel
 rockylinux8_12_9_%: BASE_IMAGE = nvcr.io/nvidia/cuda
 rockylinux8_12_9_%: BASE_TAG = 12.9.1-devel-rockylinux8
+rockylinux8_12_9_%: TRITON_BASE_TAG=25.06-py3
+
+tritondevel_12_9_%: BASE_TAG=25.06-py3
+tritondevel_12_9_%: TRITON_BASE_TAG=25.06-py3
 
 # For x86_64 and aarch64
 ubuntu22_%: STAGE = tritondevel

--- a/docker/common/install_cuda_toolkit.sh
+++ b/docker/common/install_cuda_toolkit.sh
@@ -10,7 +10,7 @@ CUDA_VER="13.0.0_580.65.06"
 # For CUDA 12.9
 CUDA_VER_12_9="12.9.1_575.57.08"
 NVCC_VERSION_OUTPUT=$(nvcc --version)
-if [[ $(echo $NVCC_VERSION_OUTPUT | grep -oP "\d+\.\d+" | head -n 1) == ${CUDA_VER_12_9%%.*_*} ]]; then
+if [[ $(echo $NVCC_VERSION_OUTPUT | grep -oP "\d+\.\d+" | head -n 1) == ${CUDA_VER_12_9%.*_*} ]]; then
     CUDA_VER="${CUDA_VER_12_9}"
 fi
 

--- a/docker/common/install_cuda_toolkit.sh
+++ b/docker/common/install_cuda_toolkit.sh
@@ -6,9 +6,16 @@ set -ex
 # CUDA version is usually aligned with the latest NGC CUDA image tag.
 # Only use when public CUDA image is not ready.
 CUDA_VER="13.0.0_580.65.06"
+
+# For CUDA 12.9
+CUDA_VER_12_9="12.9.1_575.57.08"
+NVCC_VERSION_OUTPUT=$(nvcc --version)
+if [[ $(echo $NVCC_VERSION_OUTPUT | grep -oP "\d+\.\d+" | head -n 1) == ${CUDA_VER_12_9%%.*_*} ]]; then
+    CUDA_VER="${CUDA_VER_12_9}"
+fi
+
 CUDA_VER_SHORT="${CUDA_VER%_*}"
 
-NVCC_VERSION_OUTPUT=$(nvcc --version)
 OLD_CUDA_VER=$(echo $NVCC_VERSION_OUTPUT | grep -oP "\d+\.\d+" | head -n 1)
 echo "The version of pre-installed CUDA is ${OLD_CUDA_VER}."
 

--- a/docker/common/install_tensorrt.sh
+++ b/docker/common/install_tensorrt.sh
@@ -20,6 +20,15 @@ NVRTC_VER="13.0.48-1"
 CUDA_RUNTIME="13.0.48-1"
 CUDA_DRIVER_VERSION="580.65.06-1.el8"
 
+# For CUDA 12.9
+CUDA_VER_12_9="12.9"
+CUDNN_VER_12_9="9.10.2.21-1"
+NCCL_VER_12_9="2.27.5-1+cuda12.9"
+CUBLAS_VER_12_9="12.9.1.4-1"
+NVRTC_VER_12_9="12.9.86-1"
+CUDA_RUNTIME_12_9="12.9.79-1"
+CUDA_DRIVER_VERSION_12_9="575.57.08-1.el8"
+
 for i in "$@"; do
     case $i in
         --TRT_VER=?*) TRT_VER="${i#*=}";;
@@ -33,6 +42,18 @@ for i in "$@"; do
 done
 
 NVCC_VERSION_OUTPUT=$(nvcc --version)
+
+if [[ $(echo $NVCC_VERSION_OUTPUT | grep -oP "\d+\.\d+" | head -n 1) == ${CUDA_VER_12_9} ]]; then
+    CUDA_VER="${CUDA_VER_12_9}"
+    CUDNN_VER="${CUDNN_VER_12_9}"
+    NCCL_VER="${NCCL_VER_12_9}"
+    CUBLAS_VER="${CUBLAS_VER_12_9}"
+    NVRTC_VER="${NVRTC_VER_12_9}"
+    CUDA_RUNTIME="${CUDA_RUNTIME_12_9}"
+    CUDA_DRIVER_VERSION="${CUDA_DRIVER_VERSION_12_9}"
+fi
+CUDA_MAJOR_VER="${CUDA_VER%%.*}"
+
 if [[ $(echo $NVCC_VERSION_OUTPUT | grep -oP "\d+\.\d+" | head -n 1) != ${CUDA_VER} ]]; then
   echo "The version of pre-installed CUDA is not equal to ${CUDA_VER}."
 fi
@@ -65,9 +86,9 @@ install_ubuntu_requirements() {
     NVRTC_CUDA_VERSION=$(echo $CUDA_VER | sed 's/\./-/g')
 
     apt-get install -y --no-install-recommends \
-        libcudnn9-cuda-13=${CUDNN_VER} \
-        libcudnn9-dev-cuda-13=${CUDNN_VER} \
-        libcudnn9-headers-cuda-13=${CUDNN_VER} \
+        libcudnn9-cuda-${CUDA_MAJOR_VER}=${CUDNN_VER} \
+        libcudnn9-dev-cuda-${CUDA_MAJOR_VER}=${CUDNN_VER} \
+        libcudnn9-headers-cuda-${CUDA_MAJOR_VER}=${CUDNN_VER} \
         libnccl2=${NCCL_VER} \
         libnccl-dev=${NCCL_VER} \
         libcublas-${CUBLAS_CUDA_VERSION}=${CUBLAS_VER} \
@@ -91,7 +112,7 @@ install_rockylinux_requirements() {
         "libnccl-devel-${NCCL_VER}.${ARCH1}" \
         "cuda-compat-${CUBLAS_CUDA_VERSION}-${CUDA_DRIVER_VERSION}.${ARCH1}" \
         "cuda-toolkit-${CUBLAS_CUDA_VERSION}-config-common-${CUDA_RUNTIME}.noarch" \
-        "cuda-toolkit-13-config-common-${CUDA_RUNTIME}.noarch" \
+        "cuda-toolkit-${CUDA_MAJOR_VER}-config-common-${CUDA_RUNTIME}.noarch" \
         "cuda-toolkit-config-common-${CUDA_RUNTIME}.noarch" \
         "libcublas-${CUBLAS_CUDA_VERSION}-${CUBLAS_VER}.${ARCH1}" \
         "libcublas-devel-${CUBLAS_CUDA_VERSION}-${CUBLAS_VER}.${ARCH1}"; do
@@ -107,7 +128,7 @@ install_rockylinux_requirements() {
         libnccl-devel-${NCCL_VER}.${ARCH1}.rpm \
         cuda-compat-${CUBLAS_CUDA_VERSION}-${CUDA_DRIVER_VERSION}.${ARCH1}.rpm \
         cuda-toolkit-${CUBLAS_CUDA_VERSION}-config-common-${CUDA_RUNTIME}.noarch.rpm \
-        cuda-toolkit-13-config-common-${CUDA_RUNTIME}.noarch.rpm \
+        cuda-toolkit-${CUDA_MAJOR_VER}-config-common-${CUDA_RUNTIME}.noarch.rpm \
         cuda-toolkit-config-common-${CUDA_RUNTIME}.noarch.rpm \
         libcublas-${CUBLAS_CUDA_VERSION}-${CUBLAS_VER}.${ARCH1}.rpm \
         libcublas-devel-${CUBLAS_CUDA_VERSION}-${CUBLAS_VER}.${ARCH1}.rpm

--- a/docker/common/install_tensorrt.sh
+++ b/docker/common/install_tensorrt.sh
@@ -21,6 +21,7 @@ CUDA_RUNTIME="13.0.48-1"
 CUDA_DRIVER_VERSION="580.65.06-1.el8"
 
 # For CUDA 12.9
+TRT_VER_12_9="10.11.0.33"
 CUDA_VER_12_9="12.9"
 CUDNN_VER_12_9="9.10.2.21-1"
 NCCL_VER_12_9="2.27.5-1+cuda12.9"
@@ -44,6 +45,7 @@ done
 NVCC_VERSION_OUTPUT=$(nvcc --version)
 
 if [[ $(echo $NVCC_VERSION_OUTPUT | grep -oP "\d+\.\d+" | head -n 1) == ${CUDA_VER_12_9} ]]; then
+    TRT_VER="${TRT_VER_12_9}"
     CUDA_VER="${CUDA_VER_12_9}"
     CUDNN_VER="${CUDNN_VER_12_9}"
     NCCL_VER="${NCCL_VER_12_9}"

--- a/docker/common/install_triton.sh
+++ b/docker/common/install_triton.sh
@@ -14,6 +14,13 @@ install_boost() {
 }
 
 install_triton_deps() {
+  DATACENTER_GPU_MANAGER_VER="-4-cuda${CUDA_VER}"
+  # For CUDA 12.9
+  NVCC_VERSION_OUTPUT=$(nvcc --version)
+  if [[ $(echo $NVCC_VERSION_OUTPUT | grep -oP "\d+\.\d+" | head -n 1) == "12.9" ]]; then
+    DATACENTER_GPU_MANAGER_VER="=1:3.3.6"
+  fi
+
   apt-get update \
     && apt-get install -y --no-install-recommends \
       pigz \
@@ -23,7 +30,7 @@ install_triton_deps() {
       python3-build \
       libb64-dev \
       libarchive-dev \
-      datacenter-gpu-manager-4-cuda${CUDA_VER} \
+      datacenter-gpu-manager${DATACENTER_GPU_MANAGER_VER} \
     && install_boost \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/jenkins/BuildDockerImage.groovy
+++ b/jenkins/BuildDockerImage.groovy
@@ -305,9 +305,9 @@ def buildImage(config, imageKeyToTag)
         def TRITON_IMAGE = sh(script: "cd ${LLM_ROOT} && grep '^ARG TRITON_IMAGE=' docker/Dockerfile.multi | grep -o '=.*' | tr -d '=\"'", returnStdout: true).trim()
         def TRITON_BASE_TAG = sh(script: "cd ${LLM_ROOT} && grep '^ARG TRITON_BASE_TAG=' docker/Dockerfile.multi | grep -o '=.*' | tr -d '=\"'", returnStdout: true).trim()
 
-        if (target == "rockylinux8" || target == "rockylinux8_12_9") {
-            BASE_IMAGE = sh(script: "cd ${LLM_ROOT} && grep '^jenkins-rockylinux8_%: BASE_IMAGE =' docker/Makefile | grep -o '=.*' | tr -d '=\"'", returnStdout: true).trim()
-        }
+        // if (target == "rockylinux8" || target == "rockylinux8_12_9") {
+        //     BASE_IMAGE = sh(script: "cd ${LLM_ROOT} && grep '^jenkins-rockylinux8_%: BASE_IMAGE =' docker/Makefile | grep -o '=.*' | tr -d '=\"'", returnStdout: true).trim()
+        // }
         if (target == "rockylinux8_12_9") {
             TRITON_BASE_TAG = sh(script: "cd ${LLM_ROOT} && grep '^ARG TRITON_BASE_TAG_12_9=' docker/Dockerfile.multi | grep -o '=.*' | tr -d '=\"'", returnStdout: true).trim()
         }
@@ -408,21 +408,21 @@ def launchBuildJobs(pipeline, globalVars, imageKeyToTag) {
 
     def release_action = params.action
     def buildConfigs = [
-        "Build trtllm release (x86_64)": [
-            target: "trtllm",
-            action: release_action,
-            customTag: LLM_BRANCH_TAG + "-x86_64",
-            build_wheel: true,
-            dockerfileStage: "release",
-        ],
-        "Build trtllm release (SBSA)": [
-            target: "trtllm",
-            action: release_action,
-            customTag: LLM_BRANCH_TAG + "-sbsa",
-            build_wheel: true,
-            arch: "arm64",
-            dockerfileStage: "release",
-        ],
+        // "Build trtllm release (x86_64)": [
+        //     target: "trtllm",
+        //     action: release_action,
+        //     customTag: LLM_BRANCH_TAG + "-x86_64",
+        //     build_wheel: true,
+        //     dockerfileStage: "release",
+        // ],
+        // "Build trtllm release (SBSA)": [
+        //     target: "trtllm",
+        //     action: release_action,
+        //     customTag: LLM_BRANCH_TAG + "-sbsa",
+        //     build_wheel: true,
+        //     arch: "arm64",
+        //     dockerfileStage: "release",
+        // ],
         "Build CI image (x86_64 tritondevel)": [:],
         "Build CI image (SBSA tritondevel)": [
             arch: "arm64",
@@ -437,10 +437,10 @@ def launchBuildJobs(pipeline, globalVars, imageKeyToTag) {
             args: "PYTHON_VERSION=3.12.3",
             postTag: "-py312",
         ],
-        "Build CI image for CUDA12.9 (x86_64 tritondevel)": [:],
-        "Build CI image for CUDA12.9 (SBSA tritondevel)": [
-            arch: "arm64",
-        ],
+        // "Build CI image for CUDA12.9 (x86_64 tritondevel)": [:],
+        // "Build CI image for CUDA12.9 (SBSA tritondevel)": [
+        //     arch: "arm64",
+        // ],
         "Build CI image for CUDA12.9 (RockyLinux8 Python310)": [
             target: "rockylinux8_12_9",
             args: "PYTHON_VERSION=3.10.12",
@@ -451,29 +451,29 @@ def launchBuildJobs(pipeline, globalVars, imageKeyToTag) {
             args: "PYTHON_VERSION=3.12.3",
             postTag: "-py312",
         ],
-        "Build NGC devel and release (x86_64)": [
-            target: "ngc-release",
-            action: release_action,
-            args: "DOCKER_BUILD_OPTS='--load --platform linux/amd64'",
-            build_wheel: true,
-            dependent: [
-                target: "ngc-devel",
-                dockerfileStage: "devel",
-            ],
-            dockerfileStage: "release",
-        ],
-        "Build NGC devel and release (SBSA)": [
-            target: "ngc-release",
-            action: release_action,
-            args: "DOCKER_BUILD_OPTS='--load --platform linux/arm64'",
-            arch: "arm64",
-            build_wheel: true,
-            dependent: [
-                target: "ngc-devel",
-                dockerfileStage: "devel",
-            ],
-            dockerfileStage: "release",
-        ],
+        // "Build NGC devel and release (x86_64)": [
+        //     target: "ngc-release",
+        //     action: release_action,
+        //     args: "DOCKER_BUILD_OPTS='--load --platform linux/amd64'",
+        //     build_wheel: true,
+        //     dependent: [
+        //         target: "ngc-devel",
+        //         dockerfileStage: "devel",
+        //     ],
+        //     dockerfileStage: "release",
+        // ],
+        // "Build NGC devel and release (SBSA)": [
+        //     target: "ngc-release",
+        //     action: release_action,
+        //     args: "DOCKER_BUILD_OPTS='--load --platform linux/arm64'",
+        //     arch: "arm64",
+        //     build_wheel: true,
+        //     dependent: [
+        //         target: "ngc-devel",
+        //         dockerfileStage: "devel",
+        //     ],
+        //     dockerfileStage: "release",
+        // ],
     ]
     // Override all fields in build config with default values
     buildConfigs.each { key, config ->

--- a/jenkins/BuildDockerImage.groovy
+++ b/jenkins/BuildDockerImage.groovy
@@ -440,13 +440,13 @@ def launchBuildJobs(pipeline, globalVars, imageKeyToTag) {
             args: "PYTHON_VERSION=3.12.3",
             postTag: "-py312",
         ],
-        // "Build CI image for CUDA12.9 (x86_64 tritondevel)": [
-        //     target: "tritondevel_12_9",
-        // ],
-        // "Build CI image for CUDA12.9 (SBSA tritondevel)": [
-        //     target: "tritondevel_12_9",
-        //     arch: "arm64",
-        // ],
+        "Build CI image for CUDA12.9 (x86_64 tritondevel)": [
+            target: "tritondevel_12_9",
+        ],
+        "Build CI image for CUDA12.9 (SBSA tritondevel)": [
+            target: "tritondevel_12_9",
+            arch: "arm64",
+        ],
         "Build CI image for CUDA12.9 (RockyLinux8 Python310)": [
             target: "rockylinux8_12_9",
             args: "PYTHON_VERSION=3.10.12",

--- a/jenkins/BuildDockerImage.groovy
+++ b/jenkins/BuildDockerImage.groovy
@@ -308,12 +308,6 @@ def buildImage(config, imageKeyToTag)
         if (target == "rockylinux8" || target == "rockylinux8_12_9") {
             BASE_IMAGE = sh(script: "cd ${LLM_ROOT} && grep '^jenkins-rockylinux8_%: BASE_IMAGE =' docker/Makefile | grep -o '=.*' | tr -d '=\"'", returnStdout: true).trim()
         }
-        if (target == "tritondevel_12_9") {
-            BASE_TAG = sh(script: "cd ${LLM_ROOT} && grep '^ARG BASE_TAG_12_9=' docker/Dockerfile.multi | grep -o '=.*' | tr -d '=\"'", returnStdout: true).trim()
-        }
-        if (target == "tritondevel_12_9" || target == "rockylinux8_12_9") {
-            TRITON_BASE_TAG = sh(script: "cd ${LLM_ROOT} && grep '^ARG TRITON_BASE_TAG_12_9=' docker/Dockerfile.multi | grep -o '=.*' | tr -d '=\"'", returnStdout: true).trim()
-        }
 
         // Replace the base image and triton image with the internal mirror
         BASE_IMAGE = BASE_IMAGE.replace("nvcr.io/", "urm.nvidia.com/docker/")

--- a/jenkins/BuildDockerImage.groovy
+++ b/jenkins/BuildDockerImage.groovy
@@ -308,7 +308,10 @@ def buildImage(config, imageKeyToTag)
         if (target == "rockylinux8" || target == "rockylinux8_12_9") {
             BASE_IMAGE = sh(script: "cd ${LLM_ROOT} && grep '^jenkins-rockylinux8_%: BASE_IMAGE =' docker/Makefile | grep -o '=.*' | tr -d '=\"'", returnStdout: true).trim()
         }
-        if (target == "rockylinux8_12_9") {
+        if (target == "tritondevel_12_9") {
+            BASE_TAG = sh(script: "cd ${LLM_ROOT} && grep '^ARG BASE_TAG_12_9=' docker/Dockerfile.multi | grep -o '=.*' | tr -d '=\"'", returnStdout: true).trim()
+        }
+        if (target == "tritondevel_12_9" || target == "rockylinux8_12_9") {
             TRITON_BASE_TAG = sh(script: "cd ${LLM_ROOT} && grep '^ARG TRITON_BASE_TAG_12_9=' docker/Dockerfile.multi | grep -o '=.*' | tr -d '=\"'", returnStdout: true).trim()
         }
 
@@ -437,10 +440,13 @@ def launchBuildJobs(pipeline, globalVars, imageKeyToTag) {
             args: "PYTHON_VERSION=3.12.3",
             postTag: "-py312",
         ],
-        // "Build CI image for CUDA12.9 (x86_64 tritondevel)": [:],
-        // "Build CI image for CUDA12.9 (SBSA tritondevel)": [
-        //     arch: "arm64",
-        // ],
+        "Build CI image for CUDA12.9 (x86_64 tritondevel)": [
+            target: "tritondevel_12_9",
+        ],
+        "Build CI image for CUDA12.9 (SBSA tritondevel)": [
+            target: "tritondevel_12_9",
+            arch: "arm64",
+        ],
         "Build CI image for CUDA12.9 (RockyLinux8 Python310)": [
             target: "rockylinux8_12_9",
             args: "PYTHON_VERSION=3.10.12",

--- a/jenkins/BuildDockerImage.groovy
+++ b/jenkins/BuildDockerImage.groovy
@@ -305,9 +305,9 @@ def buildImage(config, imageKeyToTag)
         def TRITON_IMAGE = sh(script: "cd ${LLM_ROOT} && grep '^ARG TRITON_IMAGE=' docker/Dockerfile.multi | grep -o '=.*' | tr -d '=\"'", returnStdout: true).trim()
         def TRITON_BASE_TAG = sh(script: "cd ${LLM_ROOT} && grep '^ARG TRITON_BASE_TAG=' docker/Dockerfile.multi | grep -o '=.*' | tr -d '=\"'", returnStdout: true).trim()
 
-        // if (target == "rockylinux8" || target == "rockylinux8_12_9") {
-        //     BASE_IMAGE = sh(script: "cd ${LLM_ROOT} && grep '^jenkins-rockylinux8_%: BASE_IMAGE =' docker/Makefile | grep -o '=.*' | tr -d '=\"'", returnStdout: true).trim()
-        // }
+        if (target == "rockylinux8" || target == "rockylinux8_12_9") {
+            BASE_IMAGE = sh(script: "cd ${LLM_ROOT} && grep '^jenkins-rockylinux8_%: BASE_IMAGE =' docker/Makefile | grep -o '=.*' | tr -d '=\"'", returnStdout: true).trim()
+        }
         if (target == "rockylinux8_12_9") {
             TRITON_BASE_TAG = sh(script: "cd ${LLM_ROOT} && grep '^ARG TRITON_BASE_TAG_12_9=' docker/Dockerfile.multi | grep -o '=.*' | tr -d '=\"'", returnStdout: true).trim()
         }

--- a/jenkins/BuildDockerImage.groovy
+++ b/jenkins/BuildDockerImage.groovy
@@ -305,8 +305,11 @@ def buildImage(config, imageKeyToTag)
         def TRITON_IMAGE = sh(script: "cd ${LLM_ROOT} && grep '^ARG TRITON_IMAGE=' docker/Dockerfile.multi | grep -o '=.*' | tr -d '=\"'", returnStdout: true).trim()
         def TRITON_BASE_TAG = sh(script: "cd ${LLM_ROOT} && grep '^ARG TRITON_BASE_TAG=' docker/Dockerfile.multi | grep -o '=.*' | tr -d '=\"'", returnStdout: true).trim()
 
-        if (target == "rockylinux8") {
+        if (target == "rockylinux8" || target == "rockylinux8_12_9") {
             BASE_IMAGE = sh(script: "cd ${LLM_ROOT} && grep '^jenkins-rockylinux8_%: BASE_IMAGE =' docker/Makefile | grep -o '=.*' | tr -d '=\"'", returnStdout: true).trim()
+        }
+        if (target == "rockylinux8_12_9") {
+            TRITON_BASE_TAG = sh(script: "cd ${LLM_ROOT} && grep '^ARG TRITON_BASE_TAG_12_9=' docker/Dockerfile.multi | grep -o '=.*' | tr -d '=\"'", returnStdout: true).trim()
         }
 
         // Replace the base image and triton image with the internal mirror
@@ -431,6 +434,20 @@ def launchBuildJobs(pipeline, globalVars, imageKeyToTag) {
         ],
         "Build CI image (RockyLinux8 Python312)": [
             target: "rockylinux8",
+            args: "PYTHON_VERSION=3.12.3",
+            postTag: "-py312",
+        ],
+        "Build CI image for CUDA12.9 (x86_64 tritondevel)": [:],
+        "Build CI image for CUDA12.9 (SBSA tritondevel)": [
+            arch: "arm64",
+        ],
+        "Build CI image for CUDA12.9 (RockyLinux8 Python310)": [
+            target: "rockylinux8_12_9",
+            args: "PYTHON_VERSION=3.10.12",
+            postTag: "-py310",
+        ],
+        "Build CI image for CUDA12.9 (RockyLinux8 Python312)": [
+            target: "rockylinux8_12_9",
             args: "PYTHON_VERSION=3.12.3",
             postTag: "-py312",
         ],

--- a/jenkins/BuildDockerImage.groovy
+++ b/jenkins/BuildDockerImage.groovy
@@ -440,13 +440,13 @@ def launchBuildJobs(pipeline, globalVars, imageKeyToTag) {
             args: "PYTHON_VERSION=3.12.3",
             postTag: "-py312",
         ],
-        "Build CI image for CUDA12.9 (x86_64 tritondevel)": [
-            target: "tritondevel_12_9",
-        ],
-        "Build CI image for CUDA12.9 (SBSA tritondevel)": [
-            target: "tritondevel_12_9",
-            arch: "arm64",
-        ],
+        // "Build CI image for CUDA12.9 (x86_64 tritondevel)": [
+        //     target: "tritondevel_12_9",
+        // ],
+        // "Build CI image for CUDA12.9 (SBSA tritondevel)": [
+        //     target: "tritondevel_12_9",
+        //     arch: "arm64",
+        // ],
         "Build CI image for CUDA12.9 (RockyLinux8 Python310)": [
             target: "rockylinux8_12_9",
             args: "PYTHON_VERSION=3.10.12",

--- a/jenkins/BuildDockerImage.groovy
+++ b/jenkins/BuildDockerImage.groovy
@@ -408,21 +408,21 @@ def launchBuildJobs(pipeline, globalVars, imageKeyToTag) {
 
     def release_action = params.action
     def buildConfigs = [
-        // "Build trtllm release (x86_64)": [
-        //     target: "trtllm",
-        //     action: release_action,
-        //     customTag: LLM_BRANCH_TAG + "-x86_64",
-        //     build_wheel: true,
-        //     dockerfileStage: "release",
-        // ],
-        // "Build trtllm release (SBSA)": [
-        //     target: "trtllm",
-        //     action: release_action,
-        //     customTag: LLM_BRANCH_TAG + "-sbsa",
-        //     build_wheel: true,
-        //     arch: "arm64",
-        //     dockerfileStage: "release",
-        // ],
+        "Build trtllm release (x86_64)": [
+            target: "trtllm",
+            action: release_action,
+            customTag: LLM_BRANCH_TAG + "-x86_64",
+            build_wheel: true,
+            dockerfileStage: "release",
+        ],
+        "Build trtllm release (SBSA)": [
+            target: "trtllm",
+            action: release_action,
+            customTag: LLM_BRANCH_TAG + "-sbsa",
+            build_wheel: true,
+            arch: "arm64",
+            dockerfileStage: "release",
+        ],
         "Build CI image (x86_64 tritondevel)": [:],
         "Build CI image (SBSA tritondevel)": [
             arch: "arm64",
@@ -454,29 +454,29 @@ def launchBuildJobs(pipeline, globalVars, imageKeyToTag) {
             args: "PYTHON_VERSION=3.12.3",
             postTag: "-py312",
         ],
-        // "Build NGC devel and release (x86_64)": [
-        //     target: "ngc-release",
-        //     action: release_action,
-        //     args: "DOCKER_BUILD_OPTS='--load --platform linux/amd64'",
-        //     build_wheel: true,
-        //     dependent: [
-        //         target: "ngc-devel",
-        //         dockerfileStage: "devel",
-        //     ],
-        //     dockerfileStage: "release",
-        // ],
-        // "Build NGC devel and release (SBSA)": [
-        //     target: "ngc-release",
-        //     action: release_action,
-        //     args: "DOCKER_BUILD_OPTS='--load --platform linux/arm64'",
-        //     arch: "arm64",
-        //     build_wheel: true,
-        //     dependent: [
-        //         target: "ngc-devel",
-        //         dockerfileStage: "devel",
-        //     ],
-        //     dockerfileStage: "release",
-        // ],
+        "Build NGC devel and release (x86_64)": [
+            target: "ngc-release",
+            action: release_action,
+            args: "DOCKER_BUILD_OPTS='--load --platform linux/amd64'",
+            build_wheel: true,
+            dependent: [
+                target: "ngc-devel",
+                dockerfileStage: "devel",
+            ],
+            dockerfileStage: "release",
+        ],
+        "Build NGC devel and release (SBSA)": [
+            target: "ngc-release",
+            action: release_action,
+            args: "DOCKER_BUILD_OPTS='--load --platform linux/arm64'",
+            arch: "arm64",
+            build_wheel: true,
+            dependent: [
+                target: "ngc-devel",
+                dockerfileStage: "devel",
+            ],
+            dockerfileStage: "release",
+        ],
     ]
     // Override all fields in build config with default values
     buildConfigs.each { key, config ->

--- a/jenkins/BuildDockerImage.groovy
+++ b/jenkins/BuildDockerImage.groovy
@@ -308,6 +308,9 @@ def buildImage(config, imageKeyToTag)
         if (target == "rockylinux8" || target == "rockylinux8_12_9") {
             BASE_IMAGE = sh(script: "cd ${LLM_ROOT} && grep '^jenkins-rockylinux8_%: BASE_IMAGE =' docker/Makefile | grep -o '=.*' | tr -d '=\"'", returnStdout: true).trim()
         }
+        if (target == "tritondevel_12_9" || target == "rockylinux8_12_9") {
+            TRITON_BASE_TAG = sh(script: "cd ${LLM_ROOT} && grep '^ARG TRITON_BASE_TAG_12_9=' docker/Dockerfile.multi | grep -o '=.*' | tr -d '=\"'", returnStdout: true).trim()
+        }
 
         // Replace the base image and triton image with the internal mirror
         BASE_IMAGE = BASE_IMAGE.replace("nvcr.io/", "urm.nvidia.com/docker/")


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added Docker image variants with CUDA 12.9 for Rocky Linux 8 and Triton devel (x86_64 and ARM64).
  - Enhanced installers to automatically select CUDA/TensorRT/CuDNN/NCCL packages for CUDA 12.9.
  - Improved package selection logic using detected CUDA major version for broader OS compatibility.

- Bug Fixes
  - Made package rename step conditional to avoid failures when the target directory is absent.

- Chores
  - Expanded CI build matrix to include CUDA 12.9 images and Python version combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
