### PR TITLE
[None][feat] Support Qwen3 reasoning parser

### DIFF
--- a/tensorrt_llm/llmapi/reasoning_parser.py
+++ b/tensorrt_llm/llmapi/reasoning_parser.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from typing import Type
 
 
 @dataclass
@@ -104,17 +105,21 @@ class DeepSeekR1Parser(BaseReasoningParser):
 
 
 class ReasoningParserFactory:
-    parsers: dict[str, BaseReasoningParser] = {
+    parsers: dict[str, Type[BaseReasoningParser]] = {
         "deepseek-r1": DeepSeekR1Parser,
         "qwen3": DeepSeekR1Parser,
     }
 
     @staticmethod
     def create_reasoning_parser(reasoning_parser: str) -> BaseReasoningParser:
-        if reasoning_parser not in ReasoningParserFactory.parsers:
-            raise ValueError(f"Invalid reasoning_parser: {reasoning_parser}")
-        reasoning_parser_class = ReasoningParserFactory.parsers.get(
-            reasoning_parser.lower())
-        if reasoning_parser == "deepseek-r1":
-            return reasoning_parser_class(reasoning_at_start=True)
-        return reasoning_parser_class()
+        try:
+            reasoning_parser_class = ReasoningParserFactory.parsers[
+                reasoning_parser.lower()]
+            if reasoning_parser == "deepseek-r1":
+                return reasoning_parser_class(reasoning_at_start=True)
+            return reasoning_parser_class()
+        except Exception as e:
+            raise ValueError(
+                f"Invalid reasoning parser: {reasoning_parser}\n"
+                f"Supported parsers: {list(ReasoningParserFactory.parsers.keys())}"
+            ) from e

--- a/tensorrt_llm/llmapi/reasoning_parser.py
+++ b/tensorrt_llm/llmapi/reasoning_parser.py
@@ -101,7 +101,8 @@ class DeepSeekR1Parser(BaseReasoningParser):
             self._buffer = ""
             return ReasoningParserResult(content=content,
                                          reasoning_content=reasoning_content)
-        raise RuntimeError("Unreachable code reached.")
+        raise RuntimeError(
+            "Unreachable code reached in `DeepSeekR1Parser.parse_delta`")
 
 
 class ReasoningParserFactory:
@@ -118,7 +119,7 @@ class ReasoningParserFactory:
             if reasoning_parser == "deepseek-r1":
                 return reasoning_parser_class(reasoning_at_start=True)
             return reasoning_parser_class()
-        except Exception as e:
+        except KeyError as e:
             raise ValueError(
                 f"Invalid reasoning parser: {reasoning_parser}\n"
                 f"Supported parsers: {list(ReasoningParserFactory.parsers.keys())}"

--- a/tensorrt_llm/llmapi/reasoning_parser.py
+++ b/tensorrt_llm/llmapi/reasoning_parser.py
@@ -1,18 +1,12 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Dict, Optional
 
 
 @dataclass
 class ReasoningParserResult:
-
-    def __init__(self,
-                 in_reasoning: bool,
-                 content: Optional[str] = None,
-                 reasoning_content: Optional[str] = None):
-        self.in_reasoning = in_reasoning
-        self.content = content
-        self.reasoning_content = reasoning_content
+    in_reasoning: bool
+    content: str = ""
+    reasoning_content: str = ""
 
 
 class BaseReasoningParser(ABC):
@@ -34,9 +28,12 @@ class DeepSeekR1Parser(BaseReasoningParser):
     treat all the text before the </think> tag as `reasoning_content` and the text after as `content`.
     """
 
-    def __init__(self):
+    def __init__(self, reasoning_at_start: bool = False) -> None:
+        self.reasoning_start = "<think>"
         self.reasoning_end = "</think>"
-        self.in_reasoning = True
+        self.reasoning_at_start = reasoning_at_start
+        self.in_reasoning = self.reasoning_at_start
+        self._buffer = ""
 
     def _create_reasoning_end_result(self, content: str,
                                      reasoning_content: str):
@@ -52,38 +49,66 @@ class DeepSeekR1Parser(BaseReasoningParser):
         return reasoning_parser_result
 
     def parse(self, text: str) -> ReasoningParserResult:
-        if self.reasoning_end not in text:
-            return ReasoningParserResult(True, reasoning_content=text)
-
-        splits = text.split(self.reasoning_end, maxsplit=1)
-        reasoning_content = splits[0]
-        content = splits[1]
-
-        reasoning_parser_result = self._create_reasoning_end_result(
-            content, reasoning_content)
-        return reasoning_parser_result
+        if not self.reasoning_at_start:
+            splits = text.partition(self.reasoning_start)
+            if splits[1] == "":
+                # no reasoning start tag found
+                return ReasoningParserResult(False, content=text)
+            # reasoning start tag found
+            # text before reasoning start tag is dropped
+            text = splits[2]
+        splits = text.partition(self.reasoning_end)
+        reasoning_content, content = splits[0], splits[2]
+        return ReasoningParserResult(not bool(content), content,
+                                     reasoning_content)
 
     def parse_delta(self, delta_text: str) -> ReasoningParserResult:
-        if self.in_reasoning and self.reasoning_end in delta_text:
-            end_idx = delta_text.find(self.reasoning_end)
-            reasoning_content = delta_text[:end_idx]
-            content = delta_text[end_idx + len(self.reasoning_end):]
-            reasoning_parser_result = self._create_reasoning_end_result(
-                content, reasoning_content)
-            self.in_reasoning = False
-            return reasoning_parser_result
+        self._buffer += delta_text
+        delta_text = self._buffer
+        reasoning_content = None
+        content = None
+        if (self.reasoning_start.startswith(delta_text)
+                or self.reasoning_end.startswith(delta_text)):
+            # waiting for more text to determine if it's a reasoning start or end tag
+            return ReasoningParserResult(self.in_reasoning)
+
+        if not self.in_reasoning:
+            begin_idx = delta_text.find(self.reasoning_start)
+            if begin_idx == -1:
+                self._buffer = ""
+                return ReasoningParserResult(False, content=delta_text)
+            self.in_reasoning = True
+            # set reasoning_content, will be processed by the next block
+            reasoning_content = delta_text[begin_idx +
+                                           len(self.reasoning_start):]
 
         if self.in_reasoning:
-            return ReasoningParserResult(self.in_reasoning,
-                                         reasoning_content=delta_text)
-
-        # not self.in_reasoning:
-        return ReasoningParserResult(self.in_reasoning, content=delta_text)
+            delta_text = reasoning_content if reasoning_content is not None else delta_text
+            end_idx = delta_text.find(self.reasoning_end)
+            if end_idx == -1:
+                last_idx = delta_text.rfind(self.reasoning_end[0])
+                if last_idx != -1 and self.reasoning_end.startswith(
+                        delta_text[last_idx:]):
+                    self._buffer = delta_text[last_idx:]
+                    reasoning_content = delta_text[:last_idx]
+                else:
+                    self._buffer = ""
+                    reasoning_content = delta_text
+                return ReasoningParserResult(
+                    True, reasoning_content=reasoning_content)
+            reasoning_content = delta_text[:end_idx]
+            content = delta_text[end_idx + len(self.reasoning_end):]
+            self.in_reasoning = False
+            self._buffer = ""
+            return ReasoningParserResult(self.in_reasoning, content,
+                                         reasoning_content)
+        raise RuntimeError("Unreachable code reached.")
 
 
 class ReasoningParserFactory:
-    parsers: Dict[str, BaseReasoningParser] = {
+    parsers: dict[str, BaseReasoningParser] = {
         "deepseek-r1": DeepSeekR1Parser,
+        "qwen3": DeepSeekR1Parser,
     }
 
     @staticmethod
@@ -92,4 +117,6 @@ class ReasoningParserFactory:
             raise ValueError(f"Invalid reasoning_parser: {reasoning_parser}")
         reasoning_parser_class = ReasoningParserFactory.parsers.get(
             reasoning_parser.lower())
+        if reasoning_parser == "deepseek-r1":
+            return reasoning_parser_class(reasoning_at_start=True)
         return reasoning_parser_class()

--- a/tensorrt_llm/serve/postprocess_handlers.py
+++ b/tensorrt_llm/serve/postprocess_handlers.py
@@ -95,7 +95,7 @@ def create_logprobs(token_ids: List[int], tokenizer: TransformersTokenizer,
 
 
 def apply_reasoning_parser(args: ChatPostprocArgs, output_index: int, text: str,
-                           streaming: bool) -> Tuple[bool, str, str]:
+                           streaming: bool) -> Tuple[str, str]:
     reasoning_parser = None
     if args.reasoning_parser is not None:
         if output_index not in args.reasoning_parser_dict:
@@ -104,17 +104,16 @@ def apply_reasoning_parser(args: ChatPostprocArgs, output_index: int, text: str,
                     args.reasoning_parser)
         reasoning_parser = args.reasoning_parser_dict[output_index]
 
-    in_reasoning = False
     if reasoning_parser is not None:
         if not streaming:
             result = reasoning_parser.parse(text)
         else:
             result = reasoning_parser.parse_delta(text)
-        in_reasoning, content, reasoning_content = result.in_reasoning, result.content, result.reasoning_content
+        content, reasoning_content = result.content, result.reasoning_content
     else:
-        in_reasoning, content, reasoning_content = False, text, None
+        content, reasoning_content = text, ""
 
-    return in_reasoning, content, reasoning_content
+    return content, reasoning_content
 
 
 @nvtx_range_debug("chat_stream_post_processor")
@@ -123,8 +122,8 @@ def chat_stream_post_processor(rsp: GenerationResultBase,
 
     def yield_first_chat(num_tokens: int,
                          idx: int,
-                         role: str = None,
-                         content: str = None):
+                         role: str | None = None,
+                         content: str | None = None):
         choice_data = ChatCompletionResponseStreamChoice(index=idx,
                                                          delta=DeltaMessage(
                                                              role=role,
@@ -167,7 +166,7 @@ def chat_stream_post_processor(rsp: GenerationResultBase,
 
         delta_text = output.text_diff
 
-        in_reasoning, delta_text, reasoning_delta_text = apply_reasoning_parser(
+        delta_text, reasoning_delta_text = apply_reasoning_parser(
             args, i, delta_text, True)
 
         if args.tool_choice and type(
@@ -177,12 +176,8 @@ def chat_stream_post_processor(rsp: GenerationResultBase,
                     name=args.tool_choice.function.name, arguments=delta_text))
             ])
         else:
-            if in_reasoning:
-                delta_message = DeltaMessage(
-                    reasoning_content=reasoning_delta_text)
-            else:
-                delta_message = DeltaMessage(
-                    content=delta_text, reasoning_content=reasoning_delta_text)
+            delta_message = DeltaMessage(content=delta_text,
+                                         reasoning_content=reasoning_delta_text)
 
         choice = ChatCompletionResponseStreamChoice(
             index=i,
@@ -231,8 +226,8 @@ def chat_response_post_processor(
     choices: List[ChatCompletionResponseChoice] = []
     role = args.role
     for output in rsp.outputs:
-        _, text, reasoning_text = apply_reasoning_parser(
-            args, output.index, output.text, False)
+        text, reasoning_text = apply_reasoning_parser(args, output.index,
+                                                      output.text, False)
 
         if args.tool_choice and isinstance(args.tool_choice,
                                            ChatCompletionNamedToolChoiceParam):
@@ -244,8 +239,6 @@ def chat_response_post_processor(
                         name=args.tool_choice.function.name, arguments=text))
                 ])
         else:
-            if text is None:
-                text = ""
             message = ChatMessage(role=role,
                                   content=text,
                                   reasoning_content=reasoning_text)

--- a/tests/unittest/llmapi/apps/_test_openai_reasoning.py
+++ b/tests/unittest/llmapi/apps/_test_openai_reasoning.py
@@ -9,9 +9,13 @@ from .openai_server import RemoteOpenAIServer
 pytestmark = pytest.mark.threadleak(enabled=False)
 
 
-@pytest.fixture(scope="module", ids=["DeepSeek-R1-Distill-Qwen-1.5B"])
-def model_name() -> str:
-    return "DeepSeek-R1-Distill-Qwen-1.5B"
+# yapf: disable
+@pytest.fixture(scope="module",
+                params=["DeepSeek-R1-Distill-Qwen-1.5B",
+                        "Qwen3/Qwen3-0.6B"])
+def model_name(request) -> str:
+    return request.param
+# yapf: enable
 
 
 @pytest.fixture(scope="module", params=["trt", "pytorch"])
@@ -21,12 +25,19 @@ def backend(request):
 
 @pytest.fixture(scope="module")
 def server(model_name: str, backend: str):
+    # Skip specific model/backend combinations
+    if model_name == "Qwen3/Qwen3-0.6B" and backend == "trt":
+        pytest.skip("Qwen3 model not supported with trt backend")
+
     model_path = get_model_path(model_name)
     args = ["--backend", f"{backend}"]
     max_beam_width = 1 if backend == "pytorch" else 2
     args.extend(["--max_beam_width", str(max_beam_width)])
     args.extend(["--max_batch_size", "2", "--max_seq_len", "1024"])
-    args.extend(["--reasoning_parser", "deepseek-r1"])
+    if model_name.startswith("Qwen3"):
+        args.extend(["--reasoning_parser", "qwen3"])
+    else:
+        args.extend(["--reasoning_parser", "deepseek-r1"])
     with RemoteOpenAIServer(model_path, args) as remote_server:
         yield remote_server
 
@@ -51,16 +62,10 @@ def test_reasoning_parser(client: openai.OpenAI, model_name: str, backend: str):
         extra_body=extra_body,
     )
 
-    if backend == "pytorch":
-        assert len(resp.choices) == n
-        for resp_choice in resp.choices:
-            assert len(resp_choice.message.content) > 0
-            assert len(resp_choice.message.reasoning_content) > 0
-    else:
-        assert len(resp.choices) == n
-        for resp_choice in resp.choices:
-            assert len(resp_choice.message.content) > 0
-            assert len(resp_choice.message.reasoning_content) > 0
+    assert len(resp.choices) == n
+    for resp_choice in resp.choices:
+        assert len(resp_choice.message.content) > 0
+        assert len(resp_choice.message.reasoning_content) > 0
 
 
 @pytest.fixture(scope="module")
@@ -78,9 +83,9 @@ async def process_stream(
         delta = choice.delta.dict()
         content = delta.get("content", None)
         reasoning_content = delta.get("reasoning_content", None)
-        if content is not None:
+        if content:
             content_chunks.append(content)
-        if reasoning_content is not None:
+        if reasoning_content:
             reasoning_content_chunks.append(reasoning_content)
     return (content_chunks, reasoning_content_chunks)
 
@@ -105,7 +110,7 @@ async def test_reasoning_parser_streaming(async_client: openai.AsyncOpenAI,
     stream = await async_client.chat.completions.create(
         model=model_name,
         messages=messages,
-        max_completion_tokens=1,
+        max_completion_tokens=2,
         temperature=0.0,
         stream=True,
     )
@@ -113,4 +118,9 @@ async def test_reasoning_parser_streaming(async_client: openai.AsyncOpenAI,
     content_chunks, reasoning_content_chunks = await process_stream(
         stream=stream)
     assert len(content_chunks) == 0
-    assert len(reasoning_content_chunks) == 1
+    if model_name.startswith("Qwen3"):
+        # First token would be <think>
+        assert len(reasoning_content_chunks) == 1
+    else:
+        # <think> is in chat template
+        assert len(reasoning_content_chunks) == 2

--- a/tests/unittest/llmapi/test_reasoning_parser.py
+++ b/tests/unittest/llmapi/test_reasoning_parser.py
@@ -7,10 +7,10 @@ R1_START, R1_END = "<think>", "</think>"
 
 @pytest.mark.parametrize(
     ("text", "in_reasoning", "content", "reasoning_context"), [
-        ("a b", True, None, "a b"),
-        (f"{R1_END} a b", False, " a b", None),
+        ("a b", True, "", "a b"),
+        (f"{R1_END} a b", False, " a b", ""),
         (f"a {R1_END} b", False, " b", "a "),
-        (f"a b {R1_END}", True, None, "a b "),
+        (f"a b {R1_END}", True, "", "a b "),
         (f"{R1_START} a {R1_END} b", False, " b", f"{R1_START} a "),
     ])
 def test_deepseek_r1_reasoning_parser(text: str, in_reasoning: bool,
@@ -25,27 +25,59 @@ def test_deepseek_r1_reasoning_parser(text: str, in_reasoning: bool,
 
 @pytest.mark.parametrize(
     ("delta_texts", "in_reasoning", "content", "reasoning_context"), [
-        (["a", "b"], [True, True], [None, None], ["a", "b"]),
-        ([R1_END, "a", "b"], [True, False, False], [None, "a", "b"
-                                                    ], ["", None, None]),
-        (["a", R1_END, "b"], [True, True, False], [None, None, "b"
-                                                   ], ["a", "", None]),
-        (["a", "b", R1_END], [True, True, True], [None, None, None
-                                                  ], ["a", "b", ""]),
-        (["a", f"l{R1_END}", "b"], [True, True, False], [None, None, "b"
-                                                         ], ["a", "l", None]),
-        (["a", f"l{R1_END}r", "b"], [True, False, False], [None, "r", "b"
-                                                           ], ["a", "l", None]),
-        (["a", f"{R1_END}r", "b"], [True, False, False], [None, "r", "b"
-                                                          ], ["a", None, None]),
-        ([R1_START, "a", f"l{R1_END}r", "b"], [True, True, False, False],
-         [None, None, "r", "b"], [R1_START, "a", "l", None]),
+        (["a", "b"], [True, True], ["", ""], ["a", "b"]),
+        ([R1_END, "a", "b"], [True, False, False], ["", "a", "b"], ["", "", ""
+                                                                    ]),
+        (["a", R1_END, "b"], [True, True, False], ["", "", "b"], ["a", "", ""]),
+        (["a", "b", R1_END], [True, True, True], ["", "", ""], ["a", "b", ""]),
+        (["a", f"l{R1_END}", "b"], [True, False, False], ["", "", "b"
+                                                          ], ["a", "l", ""]),
+        (["a", f"l{R1_END}r", "b"], [True, False, False], ["", "r", "b"
+                                                           ], ["a", "l", ""]),
+        (["a", f"{R1_END}r", "b"], [True, False, False], ["", "r", "b"
+                                                          ], ["a", "", ""]),
     ])
 def test_deepseek_r1_reasoning_parser_stream(delta_texts: list,
                                              in_reasoning: list, content: list,
                                              reasoning_context: list):
     reasoning_parser = ReasoningParserFactory.create_reasoning_parser(
         "deepseek-r1")
+    for i, delta_text in enumerate(delta_texts):
+        result = reasoning_parser.parse_delta(delta_text)
+        assert result.in_reasoning == in_reasoning[i]
+        assert result.content == content[i]
+        assert result.reasoning_content == reasoning_context[i]
+
+
+@pytest.mark.parametrize(
+    ("text", "in_reasoning", "content", "reasoning_context"), [
+        ("a<think>b</think>c", False, "c", "b"),
+        ("<think>a</think>b", False, "b", "a"),
+        ("<think>a", True, "", "a"),
+        ("a", False, "a", ""),
+        ("<think>", True, "", ""),
+    ])
+def test_qwen3_reasoning_parser(text: str, in_reasoning: bool, content: str,
+                                reasoning_context: str):
+    reasoning_parser = ReasoningParserFactory.create_reasoning_parser("qwen3")
+    result = reasoning_parser.parse(text)
+    assert result.in_reasoning == in_reasoning
+    assert result.content == content
+    assert result.reasoning_content == reasoning_context
+
+
+@pytest.mark.parametrize(
+    ("delta_texts", "in_reasoning", "content", "reasoning_context"), [
+        (["<think>a", "l</think>r", "b"], [True, False, False
+                                           ], ["", "r", "b"], ["a", "l", ""]),
+        (["<th", "ink>a</think>b"], [False, False], ["", "b"], ["", "a"]),
+        (["<think>a</th", "ink>b"], [True, False], ["", "b"], ["a", ""]),
+        (["<think>", "a</think>b"], [False, False], ["", "b"], ["", "a"]),
+        (["<think>a</think>", "b"], [False, False], ["", "b"], ["a", ""]),
+    ])
+def test_qwen3_reasoning_parser_stream(delta_texts: list, in_reasoning: list,
+                                       content: list, reasoning_context: list):
+    reasoning_parser = ReasoningParserFactory.create_reasoning_parser("qwen3")
     for i, delta_text in enumerate(delta_texts):
         result = reasoning_parser.parse_delta(delta_text)
         assert result.in_reasoning == in_reasoning[i]

--- a/tests/unittest/llmapi/test_reasoning_parser.py
+++ b/tests/unittest/llmapi/test_reasoning_parser.py
@@ -5,81 +5,67 @@ from tensorrt_llm.llmapi.reasoning_parser import ReasoningParserFactory
 R1_START, R1_END = "<think>", "</think>"
 
 
-@pytest.mark.parametrize(
-    ("text", "in_reasoning", "content", "reasoning_context"), [
-        ("a b", True, "", "a b"),
-        (f"{R1_END} a b", False, " a b", ""),
-        (f"a {R1_END} b", False, " b", "a "),
-        (f"a b {R1_END}", True, "", "a b "),
-        (f"{R1_START} a {R1_END} b", False, " b", f"{R1_START} a "),
-    ])
-def test_deepseek_r1_reasoning_parser(text: str, in_reasoning: bool,
-                                      content: str, reasoning_context: str):
+@pytest.mark.parametrize(("text", "content", "reasoning_context"), [
+    ("a b", "", "a b"),
+    (f"{R1_END} a b", " a b", ""),
+    (f"a {R1_END} b", " b", "a "),
+    (f"a b {R1_END}", "", "a b "),
+    (f"{R1_START} a {R1_END} b", " b", f"{R1_START} a "),
+])
+def test_deepseek_r1_reasoning_parser(text: str, content: str,
+                                      reasoning_context: str):
     reasoning_parser = ReasoningParserFactory.create_reasoning_parser(
         "deepseek-r1")
     result = reasoning_parser.parse(text)
-    assert result.in_reasoning == in_reasoning
     assert result.content == content
     assert result.reasoning_content == reasoning_context
 
 
-@pytest.mark.parametrize(
-    ("delta_texts", "in_reasoning", "content", "reasoning_context"), [
-        (["a", "b"], [True, True], ["", ""], ["a", "b"]),
-        ([R1_END, "a", "b"], [True, False, False], ["", "a", "b"], ["", "", ""
-                                                                    ]),
-        (["a", R1_END, "b"], [True, True, False], ["", "", "b"], ["a", "", ""]),
-        (["a", "b", R1_END], [True, True, True], ["", "", ""], ["a", "b", ""]),
-        (["a", f"l{R1_END}", "b"], [True, False, False], ["", "", "b"
-                                                          ], ["a", "l", ""]),
-        (["a", f"l{R1_END}r", "b"], [True, False, False], ["", "r", "b"
-                                                           ], ["a", "l", ""]),
-        (["a", f"{R1_END}r", "b"], [True, False, False], ["", "r", "b"
-                                                          ], ["a", "", ""]),
-    ])
-def test_deepseek_r1_reasoning_parser_stream(delta_texts: list,
-                                             in_reasoning: list, content: list,
+@pytest.mark.parametrize(("delta_texts", "content", "reasoning_context"), [
+    (["a", "b"], ["", ""], ["a", "b"]),
+    ([R1_END, "a", "b"], ["", "a", "b"], ["", "", ""]),
+    (["a", R1_END, "b"], ["", "", "b"], ["a", "", ""]),
+    (["a", "b", R1_END], ["", "", ""], ["a", "b", ""]),
+    (["a", f"l{R1_END}", "b"], ["", "", "b"], ["a", "l", ""]),
+    (["a", f"l{R1_END}r", "b"], ["", "r", "b"], ["a", "l", ""]),
+    (["a", f"{R1_END}r", "b"], ["", "r", "b"], ["a", "", ""]),
+])
+def test_deepseek_r1_reasoning_parser_stream(delta_texts: list, content: list,
                                              reasoning_context: list):
     reasoning_parser = ReasoningParserFactory.create_reasoning_parser(
         "deepseek-r1")
     for i, delta_text in enumerate(delta_texts):
         result = reasoning_parser.parse_delta(delta_text)
-        assert result.in_reasoning == in_reasoning[i]
         assert result.content == content[i]
         assert result.reasoning_content == reasoning_context[i]
 
 
-@pytest.mark.parametrize(
-    ("text", "in_reasoning", "content", "reasoning_context"), [
-        ("a<think>b</think>c", False, "c", "b"),
-        ("<think>a</think>b", False, "b", "a"),
-        ("<think>a", True, "", "a"),
-        ("a", False, "a", ""),
-        ("<think>", True, "", ""),
-    ])
-def test_qwen3_reasoning_parser(text: str, in_reasoning: bool, content: str,
+@pytest.mark.parametrize(("text", "content", "reasoning_context"), [
+    ("a<think>b</think>c", "c", "b"),
+    ("<think>a</think>b", "b", "a"),
+    ("<think>a", "", "a"),
+    ("a", "a", ""),
+    ("<think>", "", ""),
+])
+def test_qwen3_reasoning_parser(text: str, content: str,
                                 reasoning_context: str):
     reasoning_parser = ReasoningParserFactory.create_reasoning_parser("qwen3")
     result = reasoning_parser.parse(text)
-    assert result.in_reasoning == in_reasoning
     assert result.content == content
     assert result.reasoning_content == reasoning_context
 
 
-@pytest.mark.parametrize(
-    ("delta_texts", "in_reasoning", "content", "reasoning_context"), [
-        (["<think>a", "l</think>r", "b"], [True, False, False
-                                           ], ["", "r", "b"], ["a", "l", ""]),
-        (["<th", "ink>a</think>b"], [False, False], ["", "b"], ["", "a"]),
-        (["<think>a</th", "ink>b"], [True, False], ["", "b"], ["a", ""]),
-        (["<think>", "a</think>b"], [False, False], ["", "b"], ["", "a"]),
-        (["<think>a</think>", "b"], [False, False], ["", "b"], ["a", ""]),
-    ])
-def test_qwen3_reasoning_parser_stream(delta_texts: list, in_reasoning: list,
-                                       content: list, reasoning_context: list):
+@pytest.mark.parametrize(("delta_texts", "content", "reasoning_context"), [
+    (["<think>a", "l</think>r", "b"], ["", "r", "b"], ["a", "l", ""]),
+    (["<th", "ink>a</think>b"], ["", "b"], ["", "a"]),
+    (["<think>a</th", "ink>b"], ["", "b"], ["a", ""]),
+    (["<think>", "a</think>b"], ["", "b"], ["", "a"]),
+    (["<think>a</think>", "b"], ["", "b"], ["a", ""]),
+])
+def test_qwen3_reasoning_parser_stream(delta_texts: list, content: list,
+                                       reasoning_context: list):
     reasoning_parser = ReasoningParserFactory.create_reasoning_parser("qwen3")
     for i, delta_text in enumerate(delta_texts):
         result = reasoning_parser.parse_delta(delta_text)
-        assert result.in_reasoning == in_reasoning[i]
         assert result.content == content[i]
         assert result.reasoning_content == reasoning_context[i]

--- a/tests/unittest/llmapi/test_reasoning_parser.py
+++ b/tests/unittest/llmapi/test_reasoning_parser.py
@@ -61,6 +61,8 @@ def test_qwen3_reasoning_parser(text: str, content: str,
     (["<think>a</th", "ink>b"], ["", "b"], ["a", ""]),
     (["<think>", "a</think>b"], ["", "b"], ["", "a"]),
     (["<think>a</think>", "b"], ["", "b"], ["a", ""]),
+    (["<think>a</th", "ank></th", "ink>b"], ["", "", "b"
+                                             ], ["a", "</thank>", ""]),
 ])
 def test_qwen3_reasoning_parser_stream(delta_texts: list, content: list,
                                        reasoning_context: list):


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added Qwen3 reasoning support and alias selection; optional "reasoning starts at response start" behavior.
  - Improved streaming parsing with incremental buffering for more accurate content vs. reasoning splits.

- Refactor
  - Unified parser output: functions now return content and reasoning_content only (removed in_reasoning flag).

- Tests
  - Expanded tests for DeepSeek-R1 and Qwen3 parsing in both batch and streaming modes.

- Documentation
  - Updated usage notes to reflect new response shape and Qwen3 support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
