### PR TITLE
[https://nvbugs/5527956][fix] AutoDeploy: fix IMA due to outdated metadata

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -89,9 +89,6 @@ class ADEngine(ModelEngine):
         attn_page_size = ad_config.attn_page_size
         max_num_tokens = ad_config.max_num_tokens
         max_beam_width = ad_config.max_beam_width
-        ad_logger.info(
-            f"{max_seq_len=}, {max_batch_size=}, {attn_page_size=}, {max_num_tokens=}, {max_beam_width=}"
-        )
 
         # update device to contain the current default device if it's in cuda
         device = torch.device(ad_config.device)

--- a/tensorrt_llm/_torch/auto_deploy/shim/interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/interface.py
@@ -73,7 +73,9 @@ class CachedSequenceInterface:
         self.info.num_pages = new_num_pages
         for name, cache in self._caches.items():
             # We assume cache is a tensor of shape (max_batch_size, page_size, n_heads, head_dim)
-            if "cache" in name:
+            # TODO: cache resize should ideally be handled via a callback to the AttentionDescriptor
+            # to avoid hard-coding any assumptions about the cache shape or its "pagedness"
+            if "k_cache" in name or "v_cache" in name:
                 current_shape = cache.shape
                 new_shape = (new_num_pages, *current_shape[1:])
                 cache.resize_(new_shape)

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/cleanup_input_constraints.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/cleanup_input_constraints.py
@@ -43,7 +43,11 @@ class CleanupInputConstraints(BaseTransform):
                 raise TypeError(f"Unexpected type {type(s)} in symbolic shape.")
 
         # update the max constraint for each vr
-        max_total = math.prod(vr.upper for vr in vrs)
+        # NOTE: this is more a heuristic anyway than a strict constraint. We just want to make sure
+        # that this never gets triggered. So we multiply by 1000 to be safe. Not that it has to
+        # be a symint (not an int) --> so that's why we use a heuristic based on the existing
+        # symint values instead of just using e.g. max_num_tokens...
+        max_total = math.prod(vr.upper for vr in vrs) * 1000
         for vr in vrs:
             object.__setattr__(vr, "upper", max_total)
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
@@ -12,7 +12,6 @@ from ...distributed.common import all_gather_object, get_world_size
 from ...models.factory import ModelFactory
 from ...shim.interface import CachedSequenceInterface
 from ...transformations._graph import add_graph_input
-from ...utils.logger import ad_logger
 from ...utils.node_utils import get_all_input_output_nodes, is_op
 from ..interface import (
     BaseTransform,
@@ -280,34 +279,32 @@ class ResizeKVCache(BaseTransform):
                 skipped=True, num_matches=0, is_clean=True, has_valid_shapes=True
             )
 
-        try:
-            # Let's run a forward pass to get the memory usage
-            cm.info.set_max_num_tokens_sample()
-            free_mem_pre, _ = _get_mem_info_in_mb()
-            self._log_info(f"Free memory before forward pass (MB): {free_mem_pre}")
+        # TODO: the manual PyTorch workflow respects max_num_tokens if set and does _NOT_ resize
+        # the cache in this case. Should we do the same here?
 
-            self._run_forward(gm, cm)
+        # Let's run a forward pass to get the memory usage
+        cm.info.set_max_num_tokens_sample()
+        free_mem_pre, _ = _get_mem_info_in_mb()
+        self._log_info(f"Free memory before forward pass (MB): {free_mem_pre}")
 
-            free_mem_post, _ = _get_mem_info_in_mb()
-            self._log_info(f"Free memory after forward pass (MB): {free_mem_post}")
+        self._run_forward(gm, cm)
 
-            memory_for_forward_pass = free_mem_pre - free_mem_post
-            self._log_info(f"Memory for forward pass (MB): {memory_for_forward_pass}")
+        free_mem_post, _ = _get_mem_info_in_mb()
+        self._log_info(f"Free memory after forward pass (MB): {free_mem_post}")
 
-            new_cache_size = free_mem_post * 1024 * 1024 * free_mem_ratio + current_cache_size
-            new_num_pages = int(new_cache_size // (current_cache_size // current_num_pages))
+        memory_for_forward_pass = free_mem_pre - free_mem_post
+        self._log_info(f"Memory for forward pass (MB): {memory_for_forward_pass}")
 
-            # Need to sync all the GPUs
-            gathered_num_pages = [None] * get_world_size()
-            all_gather_object(gathered_num_pages, new_num_pages)
-            new_num_pages = min(gathered_num_pages)
-            self._log_info(f"After all_gather - new_num_pages: {new_num_pages}")
+        new_cache_size = free_mem_post * 1024 * 1024 * free_mem_ratio + current_cache_size
+        new_num_pages = int(new_cache_size // (current_cache_size // current_num_pages))
 
-            cm.resize_cache(new_num_pages)
-        except Exception as e:
-            ad_logger.warning(
-                f"Error encountered while resizing kv cache: {e}.\nSkipping cache resize."
-            )
+        # Need to sync all the GPUs
+        gathered_num_pages = [None] * get_world_size()
+        all_gather_object(gathered_num_pages, new_num_pages)
+        new_num_pages = min(gathered_num_pages)
+        self._log_info(f"After all_gather - new_num_pages: {new_num_pages}")
+
+        cm.resize_cache(new_num_pages)
 
         # Free memory
         torch.cuda.empty_cache()

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -327,7 +327,6 @@ test_e2e.py::test_trtllm_multimodal_benchmark_serving SKIP (https://nvbugs/55233
 accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_ctx_pp_gen_tp_asymmetric[MMLU-gen_tp=2-ctx_pp=4] SKIP (https://nvbugs/5434320)
 examples/test_llama.py::test_llm_llama_1gpu_fp8_kv_cache[llama-v2-7b-hf-bfloat16] SKIP (https://nvbugs/5527940)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16_4gpus[tp4-mtp_nextn=2-attention_dp=True-cuda_graph=True-overlap_scheduler=True-torch_compile=True] SKIP (https://nvbugs/5528070)
-accuracy/test_llm_api_autodeploy.py::TestLlama3_1_8B::test_auto_dtype SKIP (https://nvbugs/5527956)
 test_e2e.py::test_ptp_quickstart_multimodal[mistral-small-3.1-24b-instruct-Mistral-Small-3.1-24B-Instruct-2503-mixture_text_image-True] SKIP (https://nvbugs/5509024)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_fp8_blockscale[throughput] SKIP (https://nvbugs/5481198)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_fp8_blockscale_chunked_prefill[latency] SKIP (https://nvbugs/5481198)


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime validation and automatic resizing to prevent size-mismatch errors during deployment.
  * Ensured cache and page assignment data are fully reset before writing new values, reducing potential state carryover issues.

* **Tests**
  * Re-enabled a previously skipped accuracy test, reflecting improved dtype handling and increased test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

### Benchmarking
```
trtllm-bench --model meta-llama/Meta-Llama-3.1-70B-Instruct  throughput --dataset /tmp/synthetic_128_128.txt --backend _autodeploy --extra_llm_api_options examples/auto_deploy/bench.yaml --tp 4 --max_batch_size=512
```

`AutoDeploy` post-changes

```
===========================================================
= PERFORMANCE OVERVIEW 
===========================================================
Request Throughput (req/sec):                     46.4220
Total Output Throughput (tokens/sec):             5942.0141
Total Token Throughput (tokens/sec):              11884.0283
Total Latency (ms):                               21541.5173
Average request latency (ms):                     16875.9192
Per User Output Throughput [w/ ctx] (tps/user):   8.1624
Per GPU Output Throughput (tps/gpu):              1485.5035
```

`AutoDeploy` pre-changes
```
===========================================================
= PERFORMANCE OVERVIEW 
===========================================================
Request Throughput (req/sec):                     46.2991
Total Output Throughput (tokens/sec):             5926.2847
Total Token Throughput (tokens/sec):              11852.5694
Total Latency (ms):                               21598.6923
Average request latency (ms):                     16917.2744
Per User Output Throughput [w/ ctx] (tps/user):   8.1431
Per GPU Output Throughput (tps/gpu):              1481.5712
```

`PyTorch`

```
===========================================================
= PERFORMANCE OVERVIEW 
===========================================================
Request Throughput (req/sec):                     48.7223
Total Output Throughput (tokens/sec):             6236.4594
Total Token Throughput (tokens/sec):              12472.9189
Total Latency (ms):                               20524.4660
Average request latency (ms):                     16033.7262
Per User Output Throughput [w/ ctx] (tps/user):   8.6087
Per GPU Output Throughput (tps/gpu):              1559.1149
```

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
