### PR TITLE
[None][feat] Support task aware schedule in GuaranteedNoEvictScheduler

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
+++ b/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
@@ -84,6 +84,7 @@ class GenericLlmRequest
 
 public:
     using SizeType32 = runtime::SizeType32;
+    using SizeType64 = runtime::SizeType64;
     using TokenIdType = runtime::TokenIdType;
     using RequestIdType = std::uint64_t;
     using LoraTaskIdType = runtime::LoraTaskIdType;
@@ -139,7 +140,8 @@ public:
         std::optional<SizeType32> languageAdapterUid = std::nullopt,
         std::optional<MillisecondsType> allottedTimeMs = std::nullopt,
         std::optional<executor::ContextPhaseParams> const& contextPhaseParams = std::nullopt,
-        std::optional<CacheSaltIDType> cacheSaltID = std::nullopt, std::optional<TimePoint> arrivalTime = std::nullopt)
+        std::optional<CacheSaltIDType> cacheSaltID = std::nullopt, std::optional<TimePoint> arrivalTime = std::nullopt,
+        std::optional<SizeType64> taskId = std::nullopt)
         : mRequestId(requestId)
         , mPromptLen(inputTokens->size())
         , mMaxNewTokens(maxNewTokens)
@@ -197,6 +199,7 @@ public:
         , mLanguageAdapterUid(languageAdapterUid)
         , mAllottedTimeMs(allottedTimeMs)
         , mCacheSaltID(cacheSaltID)
+        , mTaskId(taskId.value_or(0))
     {
         if (mEncoderTokens.has_value() || encoderInputFeatures.has_value())
         {
@@ -1873,6 +1876,11 @@ public:
         return mUseDraftModel;
     }
 
+    [[nodiscard]] SizeType64 getTaskId() const
+    {
+        return mTaskId;
+    }
+
     RequestIdType mRequestId;
     SizeType32 mPromptLen;
     SizeType32 mMaxNewTokens;
@@ -2053,6 +2061,8 @@ protected:
 
     // Cache salt id for each request.
     std::optional<CacheSaltIDType> mCacheSaltID{std::nullopt};
+
+    SizeType64 mTaskId;
 
 private:
     void initialize(
@@ -2236,7 +2246,8 @@ public:
         std::optional<SizeType32> languageAdapterUid = std::nullopt,
         std::optional<MillisecondsType> allottedTimeMs = std::nullopt,
         std::optional<executor::ContextPhaseParams> const& contextPhaseParams = std::nullopt,
-        std::optional<CacheSaltIDType> cacheSaltID = std::nullopt, std::optional<TimePoint> arrivalTime = std::nullopt)
+        std::optional<CacheSaltIDType> cacheSaltID = std::nullopt, std::optional<TimePoint> arrivalTime = std::nullopt,
+        std::optional<SizeType64> taskId = std::nullopt)
         : Base(requestId, maxNewTokens, std::make_shared<std::vector<TokenIdType>>(std::move(inputTokens)),
             samplingConfig, isStreaming, endId, padId, std::move(embeddingBias), std::move(badWordsList),
             std::move(stopWordsList),
@@ -2267,7 +2278,7 @@ public:
                                : std::optional<std::shared_ptr<VecTokenExtraIds>>(std::nullopt),
             numReturnSequences, std::move(eagleConfig), skipCrossAttnBlocks, returnPerfMetrics,
             std::move(guidedDecodingParams), languageAdapterUid, allottedTimeMs, contextPhaseParams, cacheSaltID,
-            arrivalTime)
+            arrivalTime, taskId)
     {
     }
 

--- a/cpp/tensorrt_llm/batch_manager/capacityScheduler.cpp
+++ b/cpp/tensorrt_llm/batch_manager/capacityScheduler.cpp
@@ -271,6 +271,21 @@ std::tuple<RequestVector, RequestVector> GuaranteedNoEvictScheduler::impl(
         }
     }
 
+    std::stable_sort(pendingRequests.begin(), pendingRequests.end(),
+        [](std::shared_ptr<LlmRequest> const& a, std::shared_ptr<LlmRequest> const& b)
+        { return a->getTaskId() < b->getTaskId(); });
+    std::stable_sort(pendingDisGenInitRequests.begin(), pendingDisGenInitRequests.end(),
+        [](std::shared_ptr<LlmRequest> const& a, std::shared_ptr<LlmRequest> const& b)
+        { return a->getTaskId() < b->getTaskId(); });
+    if (!pendingRequests.empty())
+    {
+        std::cout << "pendingRequests task_id: ";
+        for (auto const& req : pendingRequests)
+        {
+            std::cout << req->getTaskId() << " ";
+        }
+        std::cout << std::endl;
+    }
     // If StaticBatchScheduling == true check if we can add pending requests only when no requests are active.
     // Otherwise, add just check that we can add pending requests.
     if (!StaticBatchScheduling || scheduledRequests.size() == 0)

--- a/cpp/tensorrt_llm/nanobind/batch_manager/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/bindings.cpp
@@ -252,137 +252,143 @@ void initBindings(nb::module_& m)
         .def_prop_rw("is_dummy_request", &GenLlmReq::isDummyRequest, &GenLlmReq::setIsDummyRequest)
         .def_prop_ro("return_perf_metrics", &GenLlmReq::getReturnPerfMetrics)
         .def_prop_rw("use_draft_model", &GenLlmReq::useDraftModel, &GenLlmReq::setUseDraftModel);
+    .def_rw("task_id", &GenLlmReq::mTaskId)
 
-    nb::class_<tb::LlmRequest, GenLlmReq>(m, "LlmRequest", nb::dynamic_attr())
-        .def(
-            "__init__",
-            [](tb::LlmRequest* self, tb::LlmRequest::RequestIdType request_id,
-                tb::LlmRequest::SizeType32 max_new_tokens, std::vector<tb::LlmRequest::TokenIdType> input_tokens,
-                runtime::SamplingConfig sampling_config, bool is_streaming,
-                std::optional<tb::LlmRequest::SizeType32> end_id, std::optional<tb::LlmRequest::SizeType32> pad_id,
-                std::optional<at::Tensor> embedding_bias, std::optional<at::Tensor> bad_words_list,
-                std::optional<at::Tensor> stop_words_list,
-                std::optional<std::vector<tb::LlmRequest::SizeType32>> position_ids,
-                std::optional<at::Tensor> prompt_embedding_table,
-                std::optional<tb::LlmRequest::SizeType32> prompt_vocab_size,
-                std::optional<std::vector<std::vector<tb::LlmRequest::SizeType32>>> multimodal_hashes,
-                std::optional<std::vector<tb::LlmRequest::SizeType32>> multimodal_positions,
-                std::optional<std::vector<tb::LlmRequest::SizeType32>> multimodal_lengths,
-                std::optional<at::Tensor> multimodal_embedding, std::optional<at::Tensor> mrope_rotary_cos_sin,
-                std::optional<tb::LlmRequest::SizeType32> mrope_position_deltas,
-                std::optional<LoraTaskIdType> lora_task_id, std::optional<at::Tensor> lora_weights,
-                std::optional<at::Tensor> lora_config,
-                std::optional<executor::LookaheadDecodingConfig> lookahead_config,
-                std::optional<executor::KvCacheRetentionConfig> kv_cache_retention_config, bool return_log_probs,
-                bool return_context_logits, bool return_generation_logits,
-                std::optional<tb::LlmRequest::VecTokens> draft_tokens, std::optional<at::Tensor> draft_logits,
-                bool exclude_input_from_output,
-                std::optional<tb::LlmRequest::LogitsPostProcessor> logits_post_processor,
-                bool apply_logits_post_processor_batched, std::optional<tb::LlmRequest::VecTokens> encoder_input_tokens,
-                bool return_encoder_output, std::optional<tb::LlmRequest::RequestIdType> client_id,
-                executor::PriorityType priority, std::optional<at::Tensor> encoder_input_features,
-                std::optional<tb::LlmRequest::SizeType32> encoder_output_length,
-                std::optional<at::Tensor> cross_attention_mask, tb::LlmRequestType llm_request_type,
-                std::optional<tb::LlmRequest::VecTokenExtraIds> input_token_extra_ids,
-                tb::LlmRequest::SizeType32 num_return_sequences, std::optional<executor::EagleConfig> eagle_config,
-                std::optional<at::Tensor> skip_cross_attn_blocks, bool return_perf_metrics,
-                std::optional<executor::GuidedDecodingParams> guided_decoding_params,
-                std::optional<tb::LlmRequest::SizeType32> language_adapter_uid,
-                std::optional<tb::LlmRequest::MillisecondsType> allotted_time_ms,
-                std::optional<executor::ContextPhaseParams> context_phase_params,
-                std::optional<tb::LlmRequest::CacheSaltIDType> cache_salt_id,
-                std::optional<tb::LlmRequest::TimePoint> arrival_time)
-            {
-                auto makeOptionalTensor = [](std::optional<at::Tensor> const& atTensor, bool unsqueeze = false)
+        nb::class_<tb::LlmRequest, GenLlmReq>(m, "LlmRequest", nb::dynamic_attr())
+            .def(
+                "__init__",
+                [](tb::LlmRequest* self, tb::LlmRequest::RequestIdType request_id,
+                    tb::LlmRequest::SizeType32 max_new_tokens, std::vector<tb::LlmRequest::TokenIdType> input_tokens,
+                    runtime::SamplingConfig sampling_config, bool is_streaming,
+                    std::optional<tb::LlmRequest::SizeType32> end_id, std::optional<tb::LlmRequest::SizeType32> pad_id,
+                    std::optional<at::Tensor> embedding_bias, std::optional<at::Tensor> bad_words_list,
+                    std::optional<at::Tensor> stop_words_list,
+                    std::optional<std::vector<tb::LlmRequest::SizeType32>> position_ids,
+                    std::optional<at::Tensor> prompt_embedding_table,
+                    std::optional<tb::LlmRequest::SizeType32> prompt_vocab_size,
+                    std::optional<std::vector<std::vector<tb::LlmRequest::SizeType32>>> multimodal_hashes,
+                    std::optional<std::vector<tb::LlmRequest::SizeType32>> multimodal_positions,
+                    std::optional<std::vector<tb::LlmRequest::SizeType32>> multimodal_lengths,
+                    std::optional<at::Tensor> multimodal_embedding, std::optional<at::Tensor> mrope_rotary_cos_sin,
+                    std::optional<tb::LlmRequest::SizeType32> mrope_position_deltas,
+                    std::optional<LoraTaskIdType> lora_task_id, std::optional<at::Tensor> lora_weights,
+                    std::optional<at::Tensor> lora_config,
+                    std::optional<executor::LookaheadDecodingConfig> lookahead_config,
+                    std::optional<executor::KvCacheRetentionConfig> kv_cache_retention_config, bool return_log_probs,
+                    bool return_context_logits, bool return_generation_logits,
+                    std::optional<tb::LlmRequest::VecTokens> draft_tokens, std::optional<at::Tensor> draft_logits,
+                    bool exclude_input_from_output,
+                    std::optional<tb::LlmRequest::LogitsPostProcessor> logits_post_processor,
+                    bool apply_logits_post_processor_batched,
+                    std::optional<tb::LlmRequest::VecTokens> encoder_input_tokens, bool return_encoder_output,
+                    std::optional<tb::LlmRequest::RequestIdType> client_id, executor::PriorityType priority,
+                    std::optional<at::Tensor> encoder_input_features,
+                    std::optional<tb::LlmRequest::SizeType32> encoder_output_length,
+                    std::optional<at::Tensor> cross_attention_mask, tb::LlmRequestType llm_request_type,
+                    std::optional<tb::LlmRequest::VecTokenExtraIds> input_token_extra_ids,
+                    tb::LlmRequest::SizeType32 num_return_sequences, std::optional<executor::EagleConfig> eagle_config,
+                    std::optional<at::Tensor> skip_cross_attn_blocks, bool return_perf_metrics,
+                    std::optional<executor::GuidedDecodingParams> guided_decoding_params,
+                    std::optional<tb::LlmRequest::SizeType32> language_adapter_uid,
+                    std::optional<tb::LlmRequest::MillisecondsType> allotted_time_ms,
+                    std::optional<executor::ContextPhaseParams> context_phase_params,
+                    std::optional<tb::LlmRequest::CacheSaltIDType> cache_salt_id,
+                    std::optional<tb::LlmRequest::TimePoint> arrival_time,
+                    std::optional<tb::LlmRequest::SizeType64> task_id)
                 {
-                    std::optional<tb::LlmRequest::TensorPtr> tensorPtr = std::nullopt;
-                    if (atTensor)
+                    auto makeOptionalTensor = [](std::optional<at::Tensor> const& atTensor, bool unsqueeze = false)
                     {
-                        tensorPtr = tr::TorchView::of(atTensor.value());
-                        if (unsqueeze)
+                        std::optional<tb::LlmRequest::TensorPtr> tensorPtr = std::nullopt;
+                        if (atTensor)
                         {
-                            (*tensorPtr)->unsqueeze(0);
+                            tensorPtr = tr::TorchView::of(atTensor.value());
+                            if (unsqueeze)
+                            {
+                                (*tensorPtr)->unsqueeze(0);
+                            }
                         }
-                    }
-                    return tensorPtr;
-                };
+                        return tensorPtr;
+                    };
 
-                auto embedding_bias_tensor_ptr = makeOptionalTensor(embedding_bias, true);
-                auto bad_words_list_tensor_ptr = makeOptionalTensor(bad_words_list, true);
-                auto stop_words_list_tensor_ptr = makeOptionalTensor(stop_words_list, true);
-                auto prompt_embedding_table_tensor_ptr = makeOptionalTensor(prompt_embedding_table);
-                auto multimodal_embedding_tensor_ptr = makeOptionalTensor(multimodal_embedding);
-                auto lora_weights_tensor_ptr = makeOptionalTensor(lora_weights);
-                auto mrope_rotary_cos_sin_tensor_ptr = makeOptionalTensor(mrope_rotary_cos_sin);
-                auto lora_config_tensor_ptr = makeOptionalTensor(lora_config);
-                auto draft_logits_tensor_ptr = makeOptionalTensor(draft_logits);
-                auto encoder_input_features_tensor_ptr = makeOptionalTensor(encoder_input_features);
-                auto cross_attention_mask_tensor_ptr = makeOptionalTensor(cross_attention_mask);
-                auto skip_cross_attn_blocks_tensor_ptr = makeOptionalTensor(skip_cross_attn_blocks);
+                    auto embedding_bias_tensor_ptr = makeOptionalTensor(embedding_bias, true);
+                    auto bad_words_list_tensor_ptr = makeOptionalTensor(bad_words_list, true);
+                    auto stop_words_list_tensor_ptr = makeOptionalTensor(stop_words_list, true);
+                    auto prompt_embedding_table_tensor_ptr = makeOptionalTensor(prompt_embedding_table);
+                    auto multimodal_embedding_tensor_ptr = makeOptionalTensor(multimodal_embedding);
+                    auto lora_weights_tensor_ptr = makeOptionalTensor(lora_weights);
+                    auto mrope_rotary_cos_sin_tensor_ptr = makeOptionalTensor(mrope_rotary_cos_sin);
+                    auto lora_config_tensor_ptr = makeOptionalTensor(lora_config);
+                    auto draft_logits_tensor_ptr = makeOptionalTensor(draft_logits);
+                    auto encoder_input_features_tensor_ptr = makeOptionalTensor(encoder_input_features);
+                    auto cross_attention_mask_tensor_ptr = makeOptionalTensor(cross_attention_mask);
+                    auto skip_cross_attn_blocks_tensor_ptr = makeOptionalTensor(skip_cross_attn_blocks);
 
-                new (self) tb::LlmRequest{request_id, max_new_tokens, input_tokens, sampling_config, is_streaming,
-                    end_id, pad_id, embedding_bias_tensor_ptr, bad_words_list_tensor_ptr, stop_words_list_tensor_ptr,
-                    position_ids, prompt_embedding_table_tensor_ptr, prompt_vocab_size, multimodal_hashes,
-                    multimodal_positions, multimodal_lengths, multimodal_embedding_tensor_ptr,
-                    mrope_rotary_cos_sin_tensor_ptr, mrope_position_deltas, lora_task_id, lora_weights_tensor_ptr,
-                    lora_config_tensor_ptr, lookahead_config, kv_cache_retention_config, return_log_probs,
-                    return_context_logits, return_generation_logits, draft_tokens, draft_logits_tensor_ptr,
-                    exclude_input_from_output, logits_post_processor, apply_logits_post_processor_batched,
-                    encoder_input_tokens, return_encoder_output, client_id, priority, encoder_input_features_tensor_ptr,
-                    encoder_output_length, cross_attention_mask_tensor_ptr, llm_request_type, input_token_extra_ids,
-                    num_return_sequences, eagle_config, skip_cross_attn_blocks_tensor_ptr, return_perf_metrics,
-                    guided_decoding_params, language_adapter_uid, allotted_time_ms, context_phase_params, cache_salt_id,
-                    arrival_time};
-            },
-            nb::arg("request_id"), nb::arg("max_new_tokens"), nb::arg("input_tokens"), nb::arg("sampling_config"),
-            nb::arg("is_streaming"), nb::arg("end_id") = std::nullopt, nb::arg("pad_id") = std::nullopt,
-            nb::arg("embedding_bias") = std::nullopt, nb::arg("bad_words_list") = std::nullopt,
-            nb::arg("stop_words_list") = std::nullopt, nb::arg("position_ids") = std::nullopt,
-            nb::arg("prompt_embedding_table") = std::nullopt, nb::arg("prompt_vocab_size") = std::nullopt,
-            nb::arg("multimodal_hashes") = std::nullopt, nb::arg("multimodal_positions") = std::nullopt,
-            nb::arg("multimodal_lengths") = std::nullopt, nb::arg("multimodal_embedding") = std::nullopt,
-            nb::arg("mrope_rotary_cos_sin") = std::nullopt, nb::arg("mrope_position_deltas") = std::nullopt,
-            nb::arg("lora_task_id") = std::nullopt, nb::arg("lora_weights") = std::nullopt,
-            nb::arg("lora_config") = std::nullopt, nb::arg("lookahead_config") = std::nullopt,
-            nb::arg("kv_cache_retention_config") = std::nullopt, nb::arg("return_log_probs") = false,
-            nb::arg("return_context_logits") = false, nb::arg("return_generation_logits") = false,
-            nb::arg("draft_tokens") = std::nullopt, nb::arg("draft_logits") = std::nullopt,
-            nb::arg("exclude_input_from_output") = false, nb::arg("logits_post_processor") = std::nullopt,
-            nb::arg("apply_logits_post_processor_batched") = false, nb::arg("encoder_input_tokens") = std::nullopt,
-            nb::arg("return_encoder_output") = false, nb::arg("client_id") = std::nullopt,
-            nb::arg("priority") = executor::Request::kDefaultPriority, nb::arg("encoder_input_features") = std::nullopt,
-            nb::arg("encoder_output_len") = std::nullopt, nb::arg("cross_attention_mask") = std::nullopt,
-            nb::arg("llm_request_type") = tb::LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION,
-            nb::arg("input_token_extra_ids") = std::nullopt, nb::arg("num_return_sequences") = 1,
-            nb::arg("eagle_config") = std::nullopt, nb::arg("skip_cross_attn_blocks") = std::nullopt,
-            nb::arg("return_perf_metrics") = false, nb::arg("guided_decoding_params") = std::nullopt,
-            nb::arg("language_adapter_uid") = std::nullopt, nb::arg("allotted_time_ms") = std::nullopt,
-            nb::arg("context_phase_params") = std::nullopt, nb::arg("cache_salt_id") = std::nullopt,
-            nb::arg("arrival_time") = std::nullopt)
-        .def("check_token_id_range", &tb::LlmRequest::checkTokenIdRange, nb::arg("vocab_size"))
-        .def(nb::init<tb::LlmRequest const&>())
-        .def("validate", &tb::LlmRequest::validate, nb::arg("max_input_len"), nb::arg("max_seq_len"),
-            nb::arg("max_draft_len"), nb::arg("vocab_size_padded"), nb::arg("max_endocer_input_len") = std::nullopt,
-            nb::arg("enable_kv_cache_reuse") = false)
-        .def("create_response", &tb::LlmRequest::createResponse, nb::arg("use_fast_logits") = false,
-            nb::arg("mpi_world_rank") = 0)
-        .def("create_child_request", &tb::LlmRequest::createChildRequest, nb::arg("child_id"))
-        .def("create_result", &tb::LlmRequest::createResult, nb::arg("use_fast_logits") = false,
-            nb::arg("mpi_world_rank") = 0)
-        .def("create_serialized_result",
-            [](tb::LlmRequest& self, bool use_fast_logits = false, int mpi_world_rank = 0)
-            {
-                std::vector<char> serialized_result;
-                bool is_final = false;
-                self.createSerializedResult(serialized_result, is_final, use_fast_logits, mpi_world_rank);
-                return std::make_tuple(nb::bytes(serialized_result.data(), serialized_result.size()), is_final);
-            })
-        .def("move_prompt_embedding_table_to_gpu", &tb::LlmRequest::movePromptEmbeddingTableToGpu, nb::arg("manager"))
-        .def("move_lora_weights_to_gpu", &tb::LlmRequest::moveLoraWeightsToGpu, nb::arg("manager"))
-        .def("finish_by_reason", &tb::LlmRequest::finishByReason, nb::arg("finish_reason"))
-        .def("set_first_scheduled_time", &tb::LlmRequest::setFirstScheduledTime)
-        .def("update_perf_metrics", &tb::LlmRequest::updatePerfMetrics, nb::arg("iter_counter"))
-        .def("remove_lora_tensors", &tb::LlmRequest::removeLoraTensors);
+                    new (self) tb::LlmRequest{request_id, max_new_tokens, input_tokens, sampling_config, is_streaming,
+                        end_id, pad_id, embedding_bias_tensor_ptr, bad_words_list_tensor_ptr,
+                        stop_words_list_tensor_ptr, position_ids, prompt_embedding_table_tensor_ptr, prompt_vocab_size,
+                        multimodal_hashes, multimodal_positions, multimodal_lengths, multimodal_embedding_tensor_ptr,
+                        mrope_rotary_cos_sin_tensor_ptr, mrope_position_deltas, lora_task_id, lora_weights_tensor_ptr,
+                        lora_config_tensor_ptr, lookahead_config, kv_cache_retention_config, return_log_probs,
+                        return_context_logits, return_generation_logits, draft_tokens, draft_logits_tensor_ptr,
+                        exclude_input_from_output, logits_post_processor, apply_logits_post_processor_batched,
+                        encoder_input_tokens, return_encoder_output, client_id, priority,
+                        encoder_input_features_tensor_ptr, encoder_output_length, cross_attention_mask_tensor_ptr,
+                        llm_request_type, input_token_extra_ids, num_return_sequences, eagle_config,
+                        skip_cross_attn_blocks_tensor_ptr, return_perf_metrics, guided_decoding_params,
+                        language_adapter_uid, allotted_time_ms, context_phase_params, cache_salt_id, arrival_time,
+                        task_id};
+                },
+                nb::arg("request_id"), nb::arg("max_new_tokens"), nb::arg("input_tokens"), nb::arg("sampling_config"),
+                nb::arg("is_streaming"), nb::arg("end_id") = std::nullopt, nb::arg("pad_id") = std::nullopt,
+                nb::arg("embedding_bias") = std::nullopt, nb::arg("bad_words_list") = std::nullopt,
+                nb::arg("stop_words_list") = std::nullopt, nb::arg("position_ids") = std::nullopt,
+                nb::arg("prompt_embedding_table") = std::nullopt, nb::arg("prompt_vocab_size") = std::nullopt,
+                nb::arg("multimodal_hashes") = std::nullopt, nb::arg("multimodal_positions") = std::nullopt,
+                nb::arg("multimodal_lengths") = std::nullopt, nb::arg("multimodal_embedding") = std::nullopt,
+                nb::arg("mrope_rotary_cos_sin") = std::nullopt, nb::arg("mrope_position_deltas") = std::nullopt,
+                nb::arg("lora_task_id") = std::nullopt, nb::arg("lora_weights") = std::nullopt,
+                nb::arg("lora_config") = std::nullopt, nb::arg("lookahead_config") = std::nullopt,
+                nb::arg("kv_cache_retention_config") = std::nullopt, nb::arg("return_log_probs") = false,
+                nb::arg("return_context_logits") = false, nb::arg("return_generation_logits") = false,
+                nb::arg("draft_tokens") = std::nullopt, nb::arg("draft_logits") = std::nullopt,
+                nb::arg("exclude_input_from_output") = false, nb::arg("logits_post_processor") = std::nullopt,
+                nb::arg("apply_logits_post_processor_batched") = false, nb::arg("encoder_input_tokens") = std::nullopt,
+                nb::arg("return_encoder_output") = false, nb::arg("client_id") = std::nullopt,
+                nb::arg("priority") = executor::Request::kDefaultPriority,
+                nb::arg("encoder_input_features") = std::nullopt, nb::arg("encoder_output_len") = std::nullopt,
+                nb::arg("cross_attention_mask") = std::nullopt,
+                nb::arg("llm_request_type") = tb::LlmRequestType::LLMREQUEST_TYPE_CONTEXT_AND_GENERATION,
+                nb::arg("input_token_extra_ids") = std::nullopt, nb::arg("num_return_sequences") = 1,
+                nb::arg("eagle_config") = std::nullopt, nb::arg("skip_cross_attn_blocks") = std::nullopt,
+                nb::arg("return_perf_metrics") = false, nb::arg("guided_decoding_params") = std::nullopt,
+                nb::arg("language_adapter_uid") = std::nullopt, nb::arg("allotted_time_ms") = std::nullopt,
+                nb::arg("context_phase_params") = std::nullopt, nb::arg("cache_salt_id") = std::nullopt,
+                nb::arg("arrival_time") = std::nullopt, nb::arg("task_id") = std::nullopt)
+            .def("check_token_id_range", &tb::LlmRequest::checkTokenIdRange, nb::arg("vocab_size"))
+            .def(nb::init<tb::LlmRequest const&>())
+            .def("validate", &tb::LlmRequest::validate, nb::arg("max_input_len"), nb::arg("max_seq_len"),
+                nb::arg("max_draft_len"), nb::arg("vocab_size_padded"), nb::arg("max_endocer_input_len") = std::nullopt,
+                nb::arg("enable_kv_cache_reuse") = false)
+            .def("create_response", &tb::LlmRequest::createResponse, nb::arg("use_fast_logits") = false,
+                nb::arg("mpi_world_rank") = 0)
+            .def("create_child_request", &tb::LlmRequest::createChildRequest, nb::arg("child_id"))
+            .def("create_result", &tb::LlmRequest::createResult, nb::arg("use_fast_logits") = false,
+                nb::arg("mpi_world_rank") = 0)
+            .def("create_serialized_result",
+                [](tb::LlmRequest& self, bool use_fast_logits = false, int mpi_world_rank = 0)
+                {
+                    std::vector<char> serialized_result;
+                    bool is_final = false;
+                    self.createSerializedResult(serialized_result, is_final, use_fast_logits, mpi_world_rank);
+                    return std::make_tuple(nb::bytes(serialized_result.data(), serialized_result.size()), is_final);
+                })
+            .def("move_prompt_embedding_table_to_gpu", &tb::LlmRequest::movePromptEmbeddingTableToGpu,
+                nb::arg("manager"))
+            .def("move_lora_weights_to_gpu", &tb::LlmRequest::moveLoraWeightsToGpu, nb::arg("manager"))
+            .def("finish_by_reason", &tb::LlmRequest::finishByReason, nb::arg("finish_reason"))
+            .def("set_first_scheduled_time", &tb::LlmRequest::setFirstScheduledTime)
+            .def("update_perf_metrics", &tb::LlmRequest::updatePerfMetrics, nb::arg("iter_counter"))
+            .def("remove_lora_tensors", &tb::LlmRequest::removeLoraTensors);
 
     nb::class_<tb::SequenceSlotManager>(m, "SequenceSlotManager")
         .def(nb::init<tb::SequenceSlotManager::SlotIdType, uint64_t>(), nb::arg("max_num_slots"),

--- a/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/batch_manager/bindings.cpp
@@ -296,7 +296,8 @@ void initBindings(pybind11::module_& m)
                      std::optional<tb::LlmRequest::MillisecondsType> allotted_time_ms,
                      std::optional<executor::ContextPhaseParams> context_phase_params,
                      std::optional<tb::LlmRequest::CacheSaltIDType> cache_salt_id,
-                     std::optional<tb::LlmRequest::TimePoint> arrival_time)
+                     std::optional<tb::LlmRequest::TimePoint> arrival_time,
+                     std::optional<tb::LlmRequest::SizeType64> task_id)
                  {
                      auto makeOptionalTensor = [](std::optional<at::Tensor> const& atTensor, bool unsqueeze = false)
                      {
@@ -337,7 +338,8 @@ void initBindings(pybind11::module_& m)
                          encoder_input_features_tensor_ptr, encoder_output_length, cross_attention_mask_tensor_ptr,
                          llm_request_type, input_token_extra_ids, num_return_sequences, eagle_config,
                          skip_cross_attn_blocks_tensor_ptr, return_perf_metrics, guided_decoding_params,
-                         language_adapter_uid, allotted_time_ms, context_phase_params, cache_salt_id, arrival_time};
+                         language_adapter_uid, allotted_time_ms, context_phase_params, cache_salt_id, arrival_time,
+                         task_id};
                  }),
             py::arg("request_id"), py::arg("max_new_tokens"), py::arg("input_tokens"), py::arg("sampling_config"),
             py::arg("is_streaming"), py::arg("end_id") = std::nullopt, py::arg("pad_id") = std::nullopt,
@@ -364,7 +366,7 @@ void initBindings(pybind11::module_& m)
             py::arg("return_perf_metrics") = false, py::arg("guided_decoding_params") = std::nullopt,
             py::arg("language_adapter_uid") = std::nullopt, py::arg("allotted_time_ms") = std::nullopt,
             py::arg("context_phase_params") = std::nullopt, py::arg("cache_salt_id") = std::nullopt,
-            py::arg("arrival_time") = std::nullopt)
+            py::arg("arrival_time") = std::nullopt, py::arg("task_id") = std::nullopt)
         .def("check_token_id_range", &tb::LlmRequest::checkTokenIdRange, py::arg("vocab_size"))
         .def(py::init<tb::LlmRequest const&>())
         .def("validate", &tb::LlmRequest::validate, py::arg("max_input_len"), py::arg("max_seq_len"),

--- a/examples/scaffolding/benchmark_task_aware_scheduler.py
+++ b/examples/scaffolding/benchmark_task_aware_scheduler.py
@@ -1,0 +1,120 @@
+import argparse
+import asyncio
+import statistics
+import time
+
+from tensorrt_llm.scaffolding.controller import (BestOfNController,
+                                                 NativeGenerationController,
+                                                 PRMController)
+from tensorrt_llm.scaffolding.scaffolding_llm import ScaffoldingLlm
+from tensorrt_llm.scaffolding.worker import TRTLLMWorker
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--generation_model',
+        type=str,
+        default="DeepSeek-R1-Distill-Qwen-7B",
+    )
+    parser.add_argument(
+        '--reward_model',
+        type=str,
+        default="Qwen2.5-Math-PRM-7B",
+    )
+    parser.add_argument('--sample_num', type=int, default=5)
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = parse_arguments()
+    workers = {}
+    gen_worker = TRTLLMWorker.init_with_new_llm(
+        args.generation_model,
+        backend="pytorch",
+        max_batch_size=args.sample_num,
+        max_num_tokens=8192,
+        kv_cache_free_gpu_memory_fraction=0.1)
+    reward_worker = TRTLLMWorker.init_with_new_llm(
+        args.reward_model,
+        backend="pytorch",
+        max_batch_size=args.sample_num,
+        max_num_tokens=8192,
+        kv_cache_free_gpu_memory_fraction=0.2,
+        disable_overlap_scheduler=True)
+    workers[NativeGenerationController.WorkerTag.GENERATION] = gen_worker
+    workers[PRMController.WorkerTag.REWARD] = reward_worker
+
+    gen_controller = NativeGenerationController(sampling_params={
+        "max_tokens": 2048,
+        "temperature": 0.6,
+    },
+                                                # streaming=True,
+                                                )
+    reward_controller = PRMController(tokenizer=reward_worker.tokenizer)
+    controller = BestOfNController(
+        generation_controller=gen_controller,
+        reward_controller=reward_controller,
+        default_sample_num=args.sample_num,
+    )
+    llm = ScaffoldingLlm(controller, workers=workers)
+
+    # query = "Solve for x: 4x + 5 = 6x - 7"
+    query_num = 1
+    base_query = "Sue lives in a fun neighborhood.  One weekend, the neighbors decided to play a prank on Sue.  On Friday morning, the neighbors placed 18 pink plastic flamingos out on Sue's front yard.  On Saturday morning, the neighbors took back one third of the flamingos, painted them white, and put these newly painted white flamingos back out on Sue's front yard.  Then, on Sunday morning, they added another 18 pink plastic flamingos to the collection. At noon on Sunday, how many more pink plastic flamingos were out than white plastic flamingos?"
+    prompts = []
+    for i in range(query_num):
+        modified_query = base_query.replace("Sue", f"{i+1}")
+        prompts.append(modified_query)
+
+    durations = asyncio.run(benchmark_concurrent_prompts(prompts, llm))
+    print(f"average duration: {statistics.mean(durations)}")
+    print(f"median duration: {statistics.median(durations)}")
+    print(f"max duration: {max(durations)}")
+    print(f"min duration: {min(durations)}")
+
+    llm.shutdown(shutdown_workers=True)
+    print(f'main shut down done')
+
+
+async def benchmark_single_prompt(prompt, llm: ScaffoldingLlm):
+    time_start = time.time()
+    i = 0
+    async for result in llm.generate_async(prompt):
+        i += 1
+        print(">>>", i, result)
+        async for output in result.cur_output:
+            print(">>>", i, len(output.outputs[0].token_ids), "\n",
+                  output.outputs[0].text)
+    time_duration = time.time() - time_start
+    return time_duration
+
+
+# async def benchmark_single_prompt(prompt, llm: ScaffoldingLlm):
+#     time_start = time.time()
+
+#     # ✅ 使用 aresult() 而不是异步迭代器
+#     result = llm.generate_async(prompt)
+#     await result.aresult()
+
+#     # 处理最终结果
+#     if result.cur_output:
+#         print("Final result:", result.cur_output.outputs[0].text)
+
+#     time_duration = time.time() - time_start
+#     return time_duration
+
+
+async def benchmark_concurrent_prompts(prompts, llm: ScaffoldingLlm):
+    print(f"concurrently execute {len(prompts)} prompts")
+
+    tasks = [benchmark_single_prompt(prompt, llm) for prompt in prompts]
+
+    durations = await asyncio.gather(*tasks)
+
+    return durations
+
+
+if __name__ == '__main__':
+    main()

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -532,6 +532,10 @@ def executor_request_to_llm_request(
         mrope_rotary_cos_sin = executor_request.mrope_config.mrope_rotary_cos_sin
         mrope_position_deltas = executor_request.mrope_config.mrope_position_deltas
 
+    task_id = None
+    if hasattr(executor_request, "py_scheduling_params"):
+        task_id = executor_request.py_scheduling_params.task_id
+
     llm_request = LlmRequest(
         request_id=req_id,
         max_new_tokens=executor_request.max_tokens,
@@ -591,7 +595,8 @@ def executor_request_to_llm_request(
         cache_salt_id=executor_request.cache_salt_id,
         arrival_time=getattr(executor_request, "py_arrival_time", None),
         py_multimodal_data=getattr(executor_request, "py_multimodal_data",
-                                   None))
+                                   None),
+        task_id=task_id)
     if child_req_ids:
         for child_id in child_req_ids:
             llm_request.create_child_request(child_id)

--- a/tensorrt_llm/scaffolding/task.py
+++ b/tensorrt_llm/scaffolding/task.py
@@ -57,6 +57,9 @@ class GenerationTask(Task):
     top_k: Optional[int] = None
     return_context_logits: Optional[bool] = False
 
+    # scheduling params
+    task_id: Optional[int] = None
+
     # suggest to use Controller.WorkerTag
     # anyway, users need to ensure that the value of the worker_tag can be found in the scaffoldingLlm's workers map
     worker_tag: Union[str, "Controller.WorkerTag"] = None
@@ -104,11 +107,12 @@ class GenerationTask(Task):
         return self._result.context_logits if self._result else None
 
     @staticmethod
-    def create_from_prompt(prompt: str) -> "GenerationTask":
+    def create_from_prompt(prompt: str, task_id: int) -> "GenerationTask":
         task = GenerationTask()
         task.input_str = prompt
         task.skip_tokenizer = False
         task.skip_detokenizer = False
+        task.task_id = task_id
         return task
 
     def create_scaffolding_output(self) -> GenerationResult:

--- a/tensorrt_llm/scheduling_params.py
+++ b/tensorrt_llm/scheduling_params.py
@@ -13,3 +13,4 @@ class SchedulingParams:
 
     attention_dp_rank: Optional[int] = None
     attention_dp_relax: Optional[bool] = None
+    task_id: Optional[int] = None


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
