### PR TITLE
[TRTLLM-8238][feat] Add EVS support for nano-v2-vlm

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_nanov2vlm.py
+++ b/tensorrt_llm/_torch/models/modeling_nanov2vlm.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 import copy
 import os
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
@@ -14,7 +14,8 @@ from tensorrt_llm.inputs.multimodal import MultimodalParams
 from ...inputs import (BaseMultimodalInputProcessor, ExtraProcessedInputs,
                        InputProcessor, MultimodalPlaceholderMetadata,
                        MultimodalPlaceholderPlacement, TextPrompt,
-                       compute_retention_mask, register_input_processor)
+                       compute_retained_tokens_count, compute_retention_mask,
+                       register_input_processor)
 from ...logger import logger
 from ...sampling_params import SamplingParams
 from ..attention_backend import AttentionMetadata
@@ -26,6 +27,8 @@ from .modeling_radio import RADIOVisionModel
 from .modeling_utils import register_auto_model
 
 VIDEO_PRUNING_RATIO = float(os.getenv("TLLM_VIDEO_PRUNING_RATIO", "0"))
+# Set max_num_tiles to 1 for video modality, to match the training behavior.
+VIDEO_MAX_NUM_TILES = 1
 
 
 # Make this a runtime lookup rather than a module-wide constant for easier unit testing.
@@ -53,6 +56,7 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
         self.downsample_ratio = config.downsample_ratio
         self.spatial_merge_size = int(self.patch_size / self.downsample_ratio)
         self.ps_version = config.ps_version  # Pixel shuffle version.
+        self.video_pruning_ratio = VIDEO_PRUNING_RATIO
 
         # Construct the vision projection.
         self.vit_hidden_size = config.vit_hidden_size
@@ -111,70 +115,126 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
         return x
 
     def extract_feature(self, pixel_values):
-        vit_embeds = self.vision_model(pixel_values)
-        # Down-sampling and projection.
-        h = w = int(vit_embeds.shape[1]**0.5)
-        vit_embeds = vit_embeds.reshape(vit_embeds.shape[0], h, w, -1)
-        vit_embeds = self.pixel_shuffle(vit_embeds,
-                                        scale_factor=self.downsample_ratio)
-        vit_embeds = vit_embeds.reshape(vit_embeds.shape[0], -1,
-                                        vit_embeds.shape[-1])
-        vit_embeds = self.mlp1(vit_embeds)
+        # Use micro-batch to avoid OOM, especially for long video inputs.
+        micro_batch_size = 128
+        n = pixel_values.shape[0]
+        vit_embeds_lst = []
+        for i in range(0, n, micro_batch_size):
+            micro_batch_pixel_values = pixel_values[i:i + micro_batch_size]
+            vit_embeds = self.vision_model(micro_batch_pixel_values)
+            # Down-sampling and projection.
+            h = w = int(vit_embeds.shape[1]**0.5)
+            vit_embeds = vit_embeds.reshape(vit_embeds.shape[0], h, w, -1)
+            vit_embeds = self.pixel_shuffle(vit_embeds,
+                                            scale_factor=self.downsample_ratio)
+            vit_embeds = vit_embeds.reshape(vit_embeds.shape[0], -1,
+                                            vit_embeds.shape[-1])
+            vit_embeds = self.mlp1(vit_embeds)
+            vit_embeds_lst.append(vit_embeds)
+        vit_embeds = torch.cat(vit_embeds_lst, dim=0)
         return vit_embeds
 
+    def apply_evs_per_video(
+            self, mm_embed: torch.Tensor,
+            video_sizes: List[Tuple]) -> Tuple[torch.Tensor, List[int]]:
+        """Apply EVS to the multimodal embedding for a single video."""
+        start_idx, mm_embed_list, num_tokens_per_video = 0, [], []
+        for video_size in video_sizes:
+            # Fetch mm_embed correctly for the flattened temporal/patches dimension.
+            t, p, ih, iw = video_size
+            partial_mm_embed = mm_embed[start_idx:start_idx + t * p]
+            # -> [num_frames * num_patches_per_frame, h*w, hidden_size]
+
+            # Need to expose temporal dimension for EVS.
+            _, wh, hidden_size = partial_mm_embed.shape
+            reshaped_partial_mm_embed = partial_mm_embed.reshape(
+                t, p, wh, hidden_size).reshape(t, p * wh, hidden_size)
+            # -> [num_frames, num_patches_per_frame*h*w, hidden_size]
+
+            original_retention_mask = compute_retention_mask(
+                video_embeds=reshaped_partial_mm_embed,
+                video_size=(t, p * ih, iw),
+                spatial_merge_size=self.spatial_merge_size,
+                pruning_ratio=self.video_pruning_ratio,
+                flatten_output=False,
+            ).flatten(start_dim=1)
+            # -> [num_frames, num_patches_per_frame*h*w]
+            num_tokens_per_frame = original_retention_mask.sum(dim=1)
+            retention_mask = original_retention_mask.reshape(t, p, wh).reshape(
+                t * p, wh)
+            # -> [num_frames * num_patches_per_frame, h*w]
+
+            # Skip by temporal/patch dimension.
+            start_idx += t * p
+
+            partial_mm_embed = partial_mm_embed[retention_mask]
+            mm_embed_list.append(partial_mm_embed)
+            num_tokens_per_video.append(num_tokens_per_frame)
+        mm_embed = torch.cat(mm_embed_list, dim=0)
+        num_tokens_in_video = torch.cat(num_tokens_per_video, dim=0)
+        return mm_embed, num_tokens_in_video
+
     def apply_evs(
-            self, mm_embedding: List[torch.Tensor],
-            multimodal_params: List[MultimodalParams]) -> List[torch.Tensor]:
+        self, mm_embedding: List[torch.Tensor],
+        multimodal_data_lst: List[Dict[str, Any]]
+    ) -> Tuple[List[torch.Tensor], Optional[List[List[int] | None]]]:
         """Apply EVS to the multimodal embedding."""
-        if VIDEO_PRUNING_RATIO <= 0:
-            return mm_embedding
+        # Skip EVS if pruning ratio is 0.
+        if self.video_pruning_ratio <= 0:
+            return mm_embedding, None
 
         modality_types = [
-            multimodal_param.multimodal_data['modality_type']
-            for multimodal_param in multimodal_params
+            multimodal_data['modality_type']
+            for multimodal_data in multimodal_data_lst
         ]
+        # Skip EVS if there is no video modality.
+        if "video" not in modality_types:
+            return mm_embedding, None
+
         video_size_list = [
-            multimodal_param.multimodal_data['video_size']
-            for multimodal_param in multimodal_params
+            multimodal_data[modality_type]["video_size"] for modality_type,
+            multimodal_data in zip(modality_types, multimodal_data_lst)
         ]
         mm_embedding_evs = []
+        num_tokens_in_videos = []
         # Iterate over batch.
         for modality_type, mm_embed, video_sizes in zip(modality_types,
                                                         mm_embedding,
                                                         video_size_list):
-            if modality_type == "video":
-                # Iterate over each video in the batch.
-                start_idx, mm_embed_list = 0, []
-                for video_size in video_sizes:
-                    partial_mm_embed = mm_embed[start_idx:start_idx +
-                                                video_size[0]]
-                    retention_mask = compute_retention_mask(
-                        video_embeds=partial_mm_embed,
-                        video_size=video_size,
-                        spatial_merge_size=self.spatial_merge_size,
-                        q=VIDEO_PRUNING_RATIO,
-                        flatten_output=False,
-                    ).flatten(start_dim=1)
-                    start_idx += video_size[0]
-                    partial_mm_embed = partial_mm_embed[retention_mask]
-                    mm_embed_list.append(partial_mm_embed)
-                mm_embedding_evs.append(torch.cat(mm_embed_list, dim=0))
-            else:
+            # Skip EVS if modality type is not video.
+            if modality_type != "video":
                 mm_embedding_evs.append(mm_embed)
-        return mm_embedding_evs
+                num_tokens_in_videos.append(None)
+            else:
+                # Iterate over each video in the batch.
+                mm_embed, num_tokens_per_frames = self.apply_evs_per_video(
+                    mm_embed, video_sizes)
+                mm_embedding_evs.append(mm_embed)
+                num_tokens_in_videos.append(num_tokens_per_frames)
+        return mm_embedding_evs, num_tokens_in_videos
 
-    def forward(self, multimodal_params: List[MultimodalParams]):
+    def forward(
+        self, multimodal_params: List[MultimodalParams]
+    ) -> Tuple[List[torch.Tensor], List[List[int] | None]]:
         mm_embedding = []
+        multimodal_data_lst = [
+            multimodal_param.multimodal_data
+            for multimodal_param in multimodal_params
+        ]
+        modality_types = [
+            multimodal_data['modality_type']
+            for multimodal_data in multimodal_data_lst
+        ]
         # Batch data.
         pixel_values = [
-            multimodal_param.multimodal_data["pixel_values"]
-            for multimodal_param in multimodal_params
+            multimodal_data[modality_type]["pixel_values"] for modality_type,
+            multimodal_data in zip(modality_types, multimodal_data_lst)
         ]
         batched_pixel_values = torch.cat(pixel_values, dim=0)
         # -> [num_patches, channel, height, width]
         patch_list = [
-            multimodal_param.multimodal_data["num_patches"]
-            for multimodal_param in multimodal_params
+            multimodal_data[modality_type]["num_patches"] for modality_type,
+            multimodal_data in zip(modality_types, multimodal_data_lst)
         ]
         batched_num_patches = torch.cat(patch_list, dim=0).tolist()
         # -> list of[num_patches1, num_patches2, ...]
@@ -184,13 +244,14 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
                                    batched_num_patches,
                                    dim=0)
 
-        mm_embedding = self.apply_evs(mm_embedding, multimodal_params)
+        mm_embedding, num_tokens_in_videos = self.apply_evs(
+            mm_embedding, multimodal_data_lst)
 
         mm_embedding = [
             m.reshape(-1, self.llm_hidden_size) for m in mm_embedding
         ]
         # -> list of [num_patches*num_image_token, hidden_size]
-        return mm_embedding
+        return mm_embedding, num_tokens_in_videos
 
 
 class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
@@ -207,9 +268,11 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
         self.image_size = model_config.force_image_size
         self.patch_size = model_config.patch_size
         self.downsample_ratio = model_config.downsample_ratio
+        self.spatial_merge_size = int(self.patch_size / self.downsample_ratio)
         self.img_context_token_id = model_config.img_context_token_id
         self.num_image_token = int((self.image_size // self.patch_size)**2 *
                                    (self.downsample_ratio**2))
+        self.video_pruning_ratio = VIDEO_PRUNING_RATIO
 
         self.device = 'cpu'
 
@@ -227,14 +290,18 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
         self.img_start_token = model_config.img_start_token
         self.img_end_token = model_config.img_end_token
         self.dtype = model_config.torch_dtype
+        self.image_start_token_id = self.tokenizer.encode(
+            self.img_start_token, add_special_tokens=False)[0]
+        self.image_end_token_id = self.tokenizer.encode(
+            self.img_end_token, add_special_tokens=False)[0]
 
     def get_vocab_size(self):
         return self.model_config.llm_config.vocab_size
 
     def get_mm_special_token_ids(self) -> torch.Tensor:
         " Return multimodal special token ids for NanoV2VL. "
-        # TODO: Hardcoded for now, need extract from model config later.
-        return torch.tensor([131073, 131074])
+        return torch.tensor(
+            [self.image_start_token_id, self.image_end_token_id])
 
     def get_mm_token_ids(self):
         return torch.tensor([self.img_context_token_id], dtype=torch.int32)
@@ -298,13 +365,18 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
 
         image_height = image.height
         image_width = image.width
-        target_ratios = _get_internvl_target_ratios(
-            1, self.processor.max_num_tiles)
+        if 'max_num_tiles' in kwargs:
+            max_num_tiles = kwargs['max_num_tiles']
+        else:
+            max_num_tiles = self.processor.max_num_tiles
+        target_ratios = _get_internvl_target_ratios(1, max_num_tiles)
         blocks = _calculate_targets(image_width, image_height, target_ratios,
                                     self.image_size)
         if self.processor.use_thumbnail and blocks != 1:
             blocks += 1
         num_image_tokens = self.num_image_token * blocks
+        # Add special tokens.
+        num_image_tokens += len(self.get_mm_special_token_ids())
         return num_image_tokens
 
     def get_num_tokens_per_video(
@@ -316,45 +388,206 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
     ):
         # Use VIDEO_PRUNING_RATIO if not explicitly provided
         if video_pruning_ratio is None:
-            video_pruning_ratio = VIDEO_PRUNING_RATIO
+            video_pruning_ratio = self.video_pruning_ratio
 
         num_frames = len(video)
-
         if video_pruning_ratio > 0:
-            num_tokens_per_frame = self.get_num_tokens_per_image(image=video[0],
-                                                                 **kwargs)
-            num_tokens_per_frame_list = [num_tokens_per_frame] * num_frames
-
-            # Total patches across all frames
-            total_num_tokens_base = sum(num_tokens_per_frame_list)
-
-            # Calculate total desired tokens after pruning
-            desired_num_tokens = int(total_num_tokens_base *
-                                     (1.0 - video_pruning_ratio))
-
-            # Calculate tokens for each frame except the last
-            existing_num_tokens = 0
-            for i in range(num_frames - 1):
-                feature_size = num_tokens_per_frame_list[i]
-                feature_size = int(feature_size * (1.0 - video_pruning_ratio))
-                existing_num_tokens += feature_size
-
-            # Last frame gets the remaining tokens
-            last_frame_tokens = desired_num_tokens - existing_num_tokens
-            num_total_tokens = existing_num_tokens + last_frame_tokens
-
-            # Add start and end tokens for each frame
-            num_total_tokens += num_frames * 2
+            num_tokens_per_frame = self.get_num_tokens_per_image(
+                image=video[0],
+                max_num_tiles=VIDEO_MAX_NUM_TILES,
+                **kwargs,
+            )
+            num_image_tokens_per_frame = num_tokens_per_frame - len(
+                self.get_mm_special_token_ids())
+            blocks = num_image_tokens_per_frame // self.num_image_token
+            video_size = (num_frames, blocks * self.image_size, self.image_size)
+            num_total_tokens = compute_retained_tokens_count(
+                video_size=video_size,
+                spatial_merge_size=self.spatial_merge_size,
+                pruning_ratio=video_pruning_ratio,
+            )
+            # Add special tokens for each frame.
+            num_total_tokens += num_frames * len(
+                self.get_mm_special_token_ids())
         else:
             # No pruning - sum tokens for all frames
             num_total_tokens = sum(
                 self.get_num_tokens_per_image(
-                    image=frame, video_pruning_ratio=None, **kwargs)
-                for frame in video)
-            # Add start and end tokens for each frame
-            num_total_tokens += num_frames * 2
-
+                    image=frame,
+                    video_pruning_ratio=None,
+                    max_num_tiles=VIDEO_MAX_NUM_TILES,
+                    **kwargs,
+                ) for frame in video)
         return num_total_tokens
+
+    def _process_images(
+            self, images: List[Image.Image | torch.Tensor],
+            text_prompt: str) -> Tuple[Dict[str, Any], torch.Tensor]:
+        # Multiple images can be processed in one call.
+        processed_images = self.processor(images=images,
+                                          return_tensors='pt').to(self.device)
+
+        # Prepare text prompt for image modality.
+        parts = text_prompt.split(self.img_context_token)
+        if len(parts) - 1 != len(processed_images['num_patches']):
+            raise ValueError(
+                f"Number of {self.img_context_token} tokens ({len(parts) - 1}) doesn't match num_patches_list length ({len(processed_images['num_patches'])})"
+            )
+        processed_query = parts[0]
+        for num_patches, part in zip(processed_images['num_patches'],
+                                     parts[1:]):
+            feature_size = num_patches * self.num_image_token
+            image_repl = self.img_start_token + self.img_context_token * feature_size + self.img_end_token
+            processed_query += image_repl + part
+
+        input_ids = self.tokenizer.encode(processed_query,
+                                          add_special_tokens=False,
+                                          return_tensors="pt")
+        return processed_images, input_ids
+
+    def _process_videos_frames(
+            self,
+            videos: List[List[Image.Image | torch.Tensor]]) -> Dict[str, Any]:
+        num_patches_list = []
+        pixel_values_list = []
+        video_size_list = []
+        for video in videos:
+            num_frames = len(video)
+
+            # Use VIDEO_MAX_NUM_TILES for video modality to match the training behaviors.
+            orig_max_num_tiles = self.processor.max_num_tiles
+            self.processor.max_num_tiles = VIDEO_MAX_NUM_TILES
+            processed_images = self.processor(
+                images=video, return_tensors='pt').to(self.device)
+            self.processor.max_num_tiles = orig_max_num_tiles
+
+            t, _, h, w = processed_images['pixel_values'].shape
+            num_patches_list.append(processed_images['num_patches'])
+            pixel_values_list.append(processed_images['pixel_values'])
+            video_size_list.append([num_frames, t // num_frames, h, w])
+
+        processed_images['num_patches'] = torch.tensor(
+            [sum(num_patches) for num_patches in num_patches_list])
+        processed_images['pixel_values'] = torch.cat(pixel_values_list, dim=0)
+        processed_images['video_size'] = video_size_list
+        return processed_images
+
+    def _get_frame_separators(
+            self, video_size_lst: List[Tuple],
+            video_metadatas: List[Dict[str, Any] | None]) -> List[List[str]]:
+
+        # Process videos one by one to get correct processed_query.
+        frame_separators_lst = []
+        for metadata, video_size in zip(video_metadatas, video_size_lst):
+            num_frames = video_size[0]
+
+            # Get frame separators.
+            if metadata is not None:
+                metedata_fps = metadata["fps"]
+                frame_duration_ms = int(1000.0 / metedata_fps)
+                frames_indices = metadata["frames_indices"]
+                timestamps = [
+                    int(frame_index) * frame_duration_ms / 1000.0
+                    for frame_index in frames_indices
+                ]
+                frame_separators = [
+                    f"Frame {i + 1} sampled at {timestamp:.2f} seconds: "
+                    for i, timestamp in enumerate(timestamps)
+                ]
+            else:
+                frame_separators = [
+                    f"Frame {i + 1}: " for i in range(num_frames)
+                ]
+            frame_separators_lst.append(frame_separators)
+
+        return frame_separators_lst
+
+    def _process_video_prompts(
+        self, split_text_prompt: List[str],
+        num_tokens_per_frame_lst: List[List[int] | None],
+        frame_separators_lst: List[List[str]]
+    ) -> Tuple[torch.Tensor, Optional[List[torch.Tensor]]]:
+        # Process videos one by one to get correct processed_query.
+        processed_query = []
+        evs_query = []
+        for video_index, (num_tokens_per_frame, frame_separators) in enumerate(
+                zip(num_tokens_per_frame_lst, frame_separators_lst)):
+
+            # Prepare video and EVS query.
+            processed_query.append(split_text_prompt[video_index])
+            processed_query.append("This is a video:\n")
+            for frame_sep, num_tokens in zip(frame_separators,
+                                             num_tokens_per_frame):
+                frame_prompts = [
+                    frame_sep, self.img_start_token,
+                    self.img_context_token * num_tokens, self.img_end_token,
+                    "\n"
+                ]
+                processed_query.extend(frame_prompts)
+            # Video_context_token as placeholder, and it will be combined with the real image_tokens_per_frames during model forward.
+            if self.video_pruning_ratio > 0:
+                evs_query.append(split_text_prompt[video_index])
+                evs_query.append("This is a video:\n")
+                for frame_sep in frame_separators:
+                    frame_prompts = [
+                        frame_sep, self.img_start_token,
+                        self.video_context_token, self.img_end_token, "\n"
+                    ]
+                    evs_query.extend(frame_prompts)
+        # Append the last part of the text prompt.
+        processed_query.append(split_text_prompt[-1])
+
+        # Tokenize processed query.
+        input_ids_lst = [
+            self.tokenizer.encode(
+                query,
+                add_special_tokens=False,
+                return_tensors="pt",
+            ) for query in processed_query
+        ]
+        input_ids = torch.cat(input_ids_lst, dim=1)
+
+        if self.video_pruning_ratio > 0:
+            evs_query.append(split_text_prompt[-1])
+            evs_ids = [
+                self.tokenizer.encode(
+                    query,
+                    add_special_tokens=False,
+                    return_tensors="pt",
+                )[0] for query in evs_query
+            ]
+        else:
+            evs_ids = None
+
+        return input_ids, evs_ids
+
+    def _compute_token_numbers_per_video(
+            self, video_size_lst: List[Tuple]) -> List[List[int]]:
+        num_tokens_per_frame_lst = []
+        for video_size in video_size_lst:
+            num_frames = video_size[0]
+            num_patches_per_frame = video_size[1]
+            img_height = video_size[2]
+            img_width = video_size[3]
+
+            if self.video_pruning_ratio > 0:
+                desired_num_tokens = compute_retained_tokens_count(
+                    video_size=(num_frames, num_patches_per_frame * img_height,
+                                img_width),
+                    spatial_merge_size=self.spatial_merge_size,
+                    pruning_ratio=self.video_pruning_ratio,
+                )
+                # It is dummy tokens and will be adjusted in VisionEncoder after applied EVS.
+                # We need to know the length of the full input ids ahead, to make Mamba-mixer and inflight-batching work.
+                num_tokens_per_frame = [desired_num_tokens
+                                        ] + [0] * (num_frames - 1)
+            else:
+                num_tokens_per_frame = [
+                    num_patches_per_frame * self.num_image_token
+                ] * num_frames
+
+            num_tokens_per_frame_lst.append(num_tokens_per_frame)
+        return num_tokens_per_frame_lst
 
     @torch.inference_mode()
     def __call__(
@@ -364,10 +597,6 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
             "multi_modal_data", {})
         images = mm_data.get("image", None)
         videos = mm_data.get("video", None)
-        if videos is not None:
-            videos, video_metadata = [
-                video_data.frames for video_data in videos
-            ], [video_data.metadata for video_data in videos]
         if images is not None and videos is not None:
             raise ValueError(
                 "NanoV2VL does not support both images and videos in the same prompt yet."
@@ -380,86 +609,56 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
             return input_ids[0].to(torch.int32).tolist(), {}
 
         modality_type = None
+        modality_data = dict()
+        input_ids = None
         if images is not None:
             modality_type = "image"
-            # Processing for multimodal data.
-            processed_images = self.processor(images=images,
-                                              return_tensors='pt').to(
-                                                  self.device)
-            # Insert enough special tokens for image embedding.
-            parts = text_prompt.split(self.img_context_token)
-            if len(parts) - 1 != len(processed_images['num_patches']):
-                raise ValueError(
-                    f"Number of {self.img_context_token} tokens ({len(parts) - 1}) doesn't match num_patches_list length ({len(processed_images['num_patches'])})"
-                )
-            processed_query = parts[0]
-            for num_patches, part in zip(processed_images['num_patches'],
-                                         parts[1:]):
-                feature_size = num_patches * self.num_image_token
-                image_repl = self.img_start_token + self.img_context_token * feature_size + self.img_end_token
-                processed_query += image_repl + part
+            processed_images, input_ids = self._process_images(
+                images, text_prompt)
+            evs_ids = None
+            modality_data["pixel_values"] = processed_images["pixel_values"].to(
+                self.dtype)
+            modality_data["num_patches"] = processed_images["num_patches"].sum(
+                dim=0, keepdim=True)
+            modality_data["video_size"] = None
+            # During model inference, the image/video modality data can be mixed during inflight-batching.
+            # Store input_ids for image modality here when EVS is enabled, which will be used in merge_evs_mm_embeds later.
+            modality_data["evs_ids"] = input_ids[0].to(
+                torch.int32) if self.video_pruning_ratio > 0 else None
         elif videos is not None:
             modality_type = "video"
-            num_videos = len(videos)
-            num_patches_list = []
-            pixel_values_list = []
-            video_size_list = []
-            parts = text_prompt.split(self.video_context_token)
-            if len(parts) - 1 != num_videos:
+            video_frames, video_metadatas = [
+                video_data.frames for video_data in videos
+            ], [video_data.metadata for video_data in videos]
+            num_videos = len(video_frames)
+            processed_images = self._process_videos_frames(video_frames)
+
+            # Num_tokens_per_frame_lst is a dummy one when EVS is enabled.
+            num_tokens_per_frame_lst = self._compute_token_numbers_per_video(
+                processed_images['video_size'])
+            # Special video tokens will be added to match training behaviors.
+            frame_separators_lst = self._get_frame_separators(
+                processed_images['video_size'], video_metadatas)
+
+            split_text_prompt = text_prompt.split(self.video_context_token)
+            if len(split_text_prompt) - 1 != num_videos:
                 raise ValueError(
-                    f"Number of {self.video_context_token} tokens ({len(parts) - 1}) doesn't match number of videos ({num_videos})"
+                    f"Number of {self.video_context_token} tokens ({len(split_text_prompt) - 1}) doesn't match number of videos ({num_videos})"
                 )
-            # Process videos one by one to get correct processed_query.
-            processed_query = ""
-            for video_index, video in enumerate(videos):
-                # Processing for multimodal data.
-                processed_images = self.processor(images=video,
-                                                  return_tensors='pt').to(
-                                                      self.device)
-                t, _, h, w = processed_images['pixel_values'].shape
-                num_patches_list.append(processed_images['num_patches'])
-                pixel_values_list.append(processed_images['pixel_values'])
-                video_size_list.append([t, h, w])
-
-                # Processing the text prompt.
-                processed_query += parts[video_index]
-                total_num_patches = sum(processed_images['num_patches'])
-                desired_num_tokens = int(self.num_image_token *
-                                         total_num_patches *
-                                         (1.0 - VIDEO_PRUNING_RATIO))
-                existing_num_tokens = 0
-                for num_patches in processed_images['num_patches'][:-1]:
-                    feature_size = num_patches * self.num_image_token
-                    feature_size = int(feature_size *
-                                       (1.0 - VIDEO_PRUNING_RATIO))
-                    existing_num_tokens += feature_size
-                    image_repl = self.img_start_token + self.img_context_token * feature_size + self.img_end_token
-                    processed_query += image_repl
-                # Special handling for the last patch of image tokens.
-                image_repl = self.img_start_token + self.img_context_token * (
-                    desired_num_tokens -
-                    existing_num_tokens) + self.img_end_token
-                processed_query += image_repl
-            processed_query += parts[num_videos]
-            processed_images['num_patches'] = torch.tensor(
-                [sum(num_patches) for num_patches in num_patches_list])
-            processed_images['pixel_values'] = torch.cat(pixel_values_list,
-                                                         dim=0)
-            processed_images['video_size'] = video_size_list
-
-        input_ids = self.tokenizer.encode(processed_query,
-                                          add_special_tokens=False,
-                                          return_tensors="pt")
+            input_ids, evs_ids = self._process_video_prompts(
+                split_text_prompt, num_tokens_per_frame_lst,
+                frame_separators_lst)
+            modality_data["pixel_values"] = processed_images["pixel_values"].to(
+                self.dtype)
+            modality_data["num_patches"] = processed_images["num_patches"].sum(
+                dim=0, keepdim=True)
+            modality_data["video_size"] = processed_images["video_size"]
+            modality_data["evs_ids"] = evs_ids
 
         # Will package inputs for language model forward in AGGREGATE mode.
         multimodal_data = {}
-        multimodal_data['pixel_values'] = processed_images['pixel_values'].to(
-            self.dtype)
-        multimodal_data['num_patches'] = processed_images['num_patches'].sum(
-            dim=0, keepdim=True)
         multimodal_data['modality_type'] = modality_type
-        multimodal_data['video_size'] = processed_images[
-            'video_size'] if modality_type == "video" else None
+        multimodal_data[modality_type] = modality_data
         return input_ids[0].to(torch.int32).tolist(), {
             "multimodal_data": multimodal_data,
         }
@@ -503,8 +702,10 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         self.vocab_size = llm_model_config.pretrained_config.vocab_size
         self.model_dtype = getattr(config, "torch_dtype", torch.bfloat16)
         self.img_context_token_id = config.img_context_token_id
+        self.video_context_token_id = config.video_context_token_id
         self.post_config()
         self.is_loaded = True
+        self.video_pruning_ratio = VIDEO_PRUNING_RATIO
 
     def load_weights(self, weights):
         # Load vision encoder weights.
@@ -526,6 +727,70 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         # use llm.config as config for pytorch model engine
         self.config = self.llm.config
         self.model_config.pretrained_config = self.llm.config
+
+    def merge_evs_mm_embeds(self, num_tokens_in_videos: List[int],
+                            multimodal_params: List[MultimodalParams],
+                            input_ids: torch.Tensor) -> torch.Tensor:
+        """Merge EVS and MM embeds into input_ids.
+
+        Args:
+            num_tokens_in_videos: List of number of tokens in videos.
+            multimodal_params: List of multimodal parameters. The shape is [num_context_requests, ].
+            input_ids: Original dummy input ids. Note: it contains the generation ids when enabling inflight-batching.
+                The shape is [num_tokens_context + num_tokens_generation, ].
+
+        Returns:
+            Input ids with EVS and MM embeds merged.
+        """
+        multimodal_data_lst = [
+            multimodal_param.multimodal_data
+            for multimodal_param in multimodal_params
+        ]
+        modalities = [
+            multimodal_data['modality_type']
+            for multimodal_data in multimodal_data_lst
+        ]
+        # Skip EVS if there is no video modality.
+        if "video" not in modalities:
+            return input_ids
+
+        evs_ids_lst = [
+            multimodal_data[modality]['evs_ids'] for modality, multimodal_data
+            in zip(modalities, multimodal_data_lst)
+        ]
+        # Iterate over batch.
+        context_ids = []
+        for evs_ids, modality, num_tokens_in_video in zip(
+                evs_ids_lst, modalities, num_tokens_in_videos):
+            # Special handling for image modality when mixing image and video modalities during inflight-batching.
+            if modality == "image":
+                context_ids.append(evs_ids)
+                continue
+
+            image_idx = 0
+            for evs_id in evs_ids:
+                if len(evs_id
+                       ) == 1 and evs_id[0] == self.video_context_token_id:
+                    image_mm = torch.full(
+                        (num_tokens_in_video[image_idx], ),
+                        fill_value=self.img_context_token_id,
+                        dtype=evs_id.dtype,
+                        device=evs_id.device,
+                    )
+                    context_ids.append(image_mm)
+                    image_idx += 1
+                else:
+                    context_ids.append(evs_id)
+
+        context_ids = torch.cat(context_ids, dim=0)
+        # -> [num_tokens, ]
+
+        # Special handling for inflight-batching.
+        # Assume input ids format is [context_ids, generation_ids].
+        input_ids[:context_ids.shape[0]] = context_ids
+        del context_ids
+
+        return input_ids
 
     @torch.inference_mode()
     def forward(
@@ -549,7 +814,7 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         mm_embedding = []
         if len(multimodal_params) > 0:
             if not _is_disagg():
-                mm_embedding = get_multimodal_embeddings(
+                mm_embedding, num_tokens_in_videos = get_multimodal_embeddings(
                     encoder_forward_fn=self.vision_encoder.forward,
                     multimodal_params=multimodal_params[:num_context_requests])
             else:
@@ -557,6 +822,14 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
                     "Nano-V2-VLM does not support disaggregated inference yet. Please unset "
                     f"the TLLM_MULTIMODAL_DISAGGREGATED environment variable, or set it to '0'."
                 )
+            # Adjust input_ids in videos if EVS is applied.
+            if self.video_pruning_ratio > 0:
+                input_ids = self.merge_evs_mm_embeds(
+                    num_tokens_in_videos,
+                    multimodal_params=multimodal_params[:num_context_requests],
+                    input_ids=input_ids,
+                )
+
             mm_embedding = find_input_mm_embeds(
                 mm_embedding, multimodal_params[:num_context_requests])
         input_ids, input_embeds = fuse_input_embeds(

--- a/tensorrt_llm/_torch/models/modeling_nanov2vlm.py
+++ b/tensorrt_llm/_torch/models/modeling_nanov2vlm.py
@@ -14,7 +14,7 @@ from tensorrt_llm.inputs.multimodal import MultimodalParams
 from ...inputs import (BaseMultimodalInputProcessor, ExtraProcessedInputs,
                        InputProcessor, MultimodalPlaceholderMetadata,
                        MultimodalPlaceholderPlacement, TextPrompt,
-                       register_input_processor)
+                       compute_retention_mask, register_input_processor)
 from ...logger import logger
 from ...sampling_params import SamplingParams
 from ..attention_backend import AttentionMetadata
@@ -23,6 +23,8 @@ from .modeling_auto import AutoModelForCausalLM
 from .modeling_multimodal_utils import find_input_mm_embeds, fuse_input_embeds
 from .modeling_radio import RADIOVisionModel
 from .modeling_utils import register_auto_model
+
+VIDEO_PRUNING_RATIO = float(os.getenv("TLLM_VIDEO_PRUNING_RATIO", "0"))
 
 
 # Make this a runtime lookup rather than a module-wide constant for easier unit testing.
@@ -48,6 +50,7 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
         self.num_image_token = int((self.image_size // self.patch_size)**2 *
                                    (config.downsample_ratio**2))
         self.downsample_ratio = config.downsample_ratio
+        self.spatial_merge_size = int(self.patch_size / self.downsample_ratio)
         self.ps_version = config.ps_version  # Pixel shuffle version.
 
         # Construct the vision projection.
@@ -118,6 +121,47 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
         vit_embeds = self.mlp1(vit_embeds)
         return vit_embeds
 
+    def apply_evs(
+            self, mm_embedding: List[torch.Tensor],
+            multimodal_params: List[MultimodalParams]) -> List[torch.Tensor]:
+        """Apply EVS to the multimodal embedding."""
+        if VIDEO_PRUNING_RATIO <= 0:
+            return mm_embedding
+
+        modality_types = [
+            multimodal_param.multimodal_data['modality_type']
+            for multimodal_param in multimodal_params
+        ]
+        video_size_list = [
+            multimodal_param.multimodal_data['video_size']
+            for multimodal_param in multimodal_params
+        ]
+        mm_embedding_evs = []
+        # Iterate over batch.
+        for modality_type, mm_embed, video_sizes in zip(modality_types,
+                                                        mm_embedding,
+                                                        video_size_list):
+            if modality_type == "video":
+                # Iterate over each video in the batch.
+                start_idx, mm_embed_list = 0, []
+                for video_size in video_sizes:
+                    partial_mm_embed = mm_embed[start_idx:start_idx +
+                                                video_size[0]]
+                    retention_mask = compute_retention_mask(
+                        video_embeds=partial_mm_embed,
+                        video_size=video_size,
+                        spatial_merge_size=self.spatial_merge_size,
+                        q=VIDEO_PRUNING_RATIO,
+                        flatten_output=False,
+                    ).flatten(start_dim=1)
+                    start_idx += video_size[0]
+                    partial_mm_embed = partial_mm_embed[retention_mask]
+                    mm_embed_list.append(partial_mm_embed)
+                mm_embedding_evs.append(torch.cat(mm_embed_list, dim=0))
+            else:
+                mm_embedding_evs.append(mm_embed)
+        return mm_embedding_evs
+
     def forward(self, multimodal_params: List[MultimodalParams]):
         mm_embedding = []
         # Batch data.
@@ -138,6 +182,9 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
         mm_embedding = torch.split(batched_image_embeds,
                                    batched_num_patches,
                                    dim=0)
+
+        mm_embedding = self.apply_evs(mm_embedding, multimodal_params)
+
         mm_embedding = [
             m.reshape(-1, self.llm_hidden_size) for m in mm_embedding
         ]
@@ -277,7 +324,9 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
                                               return_tensors="pt")
             return input_ids[0].to(torch.int32).tolist(), {}
 
+        modality_type = None
         if images is not None:
+            modality_type = "image"
             # Processing for multimodal data.
             processed_images = self.processor(images=images,
                                               return_tensors='pt').to(
@@ -295,9 +344,11 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
                 image_repl = self.img_start_token + self.img_context_token * feature_size + self.img_end_token
                 processed_query += image_repl + part
         elif videos is not None:
+            modality_type = "video"
             num_videos = len(videos)
             num_patches_list = []
             pixel_values_list = []
+            video_size_list = []
             parts = text_prompt.split(self.video_context_token)
             if len(parts) - 1 != num_videos:
                 raise ValueError(
@@ -310,20 +361,36 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
                 processed_images = self.processor(images=video,
                                                   return_tensors='pt').to(
                                                       self.device)
+                t, _, h, w = processed_images['pixel_values'].shape
                 num_patches_list.append(processed_images['num_patches'])
                 pixel_values_list.append(processed_images['pixel_values'])
+                video_size_list.append([t, h, w])
 
                 # Processing the text prompt.
                 processed_query += parts[video_index]
-                for num_patches in processed_images['num_patches']:
+                total_num_patches = sum(processed_images['num_patches'])
+                desired_num_tokens = int(self.num_image_token *
+                                         total_num_patches *
+                                         (1.0 - VIDEO_PRUNING_RATIO))
+                existing_num_tokens = 0
+                for num_patches in processed_images['num_patches'][:-1]:
                     feature_size = num_patches * self.num_image_token
+                    feature_size = int(feature_size *
+                                       (1.0 - VIDEO_PRUNING_RATIO))
+                    existing_num_tokens += feature_size
                     image_repl = self.img_start_token + self.img_context_token * feature_size + self.img_end_token
                     processed_query += image_repl
+                # Special handling for the last patch of image tokens.
+                image_repl = self.img_start_token + self.img_context_token * (
+                    desired_num_tokens -
+                    existing_num_tokens) + self.img_end_token
+                processed_query += image_repl
             processed_query += parts[num_videos]
             processed_images['num_patches'] = torch.tensor(
                 [sum(num_patches) for num_patches in num_patches_list])
             processed_images['pixel_values'] = torch.cat(pixel_values_list,
                                                          dim=0)
+            processed_images['video_size'] = video_size_list
 
         input_ids = self.tokenizer.encode(processed_query,
                                           add_special_tokens=False,
@@ -335,6 +402,9 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
             self.dtype)
         multimodal_data['num_patches'] = processed_images['num_patches'].sum(
             dim=0, keepdim=True)
+        multimodal_data['modality_type'] = modality_type
+        multimodal_data['video_size'] = processed_images[
+            'video_size'] if modality_type == "video" else None
         return input_ids[0].to(torch.int32).tolist(), {
             "multimodal_data": multimodal_data,
         }

--- a/tensorrt_llm/_torch/models/modeling_nanov2vlm.py
+++ b/tensorrt_llm/_torch/models/modeling_nanov2vlm.py
@@ -20,7 +20,8 @@ from ...sampling_params import SamplingParams
 from ..attention_backend import AttentionMetadata
 from ..model_config import ModelConfig
 from .modeling_auto import AutoModelForCausalLM
-from .modeling_multimodal_utils import find_input_mm_embeds, fuse_input_embeds
+from .modeling_multimodal_utils import (find_input_mm_embeds, fuse_input_embeds,
+                                        get_multimodal_embeddings)
 from .modeling_radio import RADIOVisionModel
 from .modeling_utils import register_auto_model
 
@@ -230,6 +231,11 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
     def get_vocab_size(self):
         return self.model_config.llm_config.vocab_size
 
+    def get_mm_special_token_ids(self) -> torch.Tensor:
+        " Return multimodal special token ids for NanoV2VL. "
+        # TODO: Hardcoded for now, need extract from model config later.
+        return torch.tensor([131073, 131074])
+
     def get_mm_token_ids(self):
         return torch.tensor([self.img_context_token_id], dtype=torch.int32)
 
@@ -300,6 +306,55 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
             blocks += 1
         num_image_tokens = self.num_image_token * blocks
         return num_image_tokens
+
+    def get_num_tokens_per_video(
+        self,
+        *,
+        video: List[Image.Image],
+        video_pruning_ratio: Optional[float] = None,
+        **kwargs,
+    ):
+        # Use VIDEO_PRUNING_RATIO if not explicitly provided
+        if video_pruning_ratio is None:
+            video_pruning_ratio = VIDEO_PRUNING_RATIO
+
+        num_frames = len(video)
+
+        if video_pruning_ratio > 0:
+            num_tokens_per_frame = self.get_num_tokens_per_image(image=video[0],
+                                                                 **kwargs)
+            num_tokens_per_frame_list = [num_tokens_per_frame] * num_frames
+
+            # Total patches across all frames
+            total_num_tokens_base = sum(num_tokens_per_frame_list)
+
+            # Calculate total desired tokens after pruning
+            desired_num_tokens = int(total_num_tokens_base *
+                                     (1.0 - video_pruning_ratio))
+
+            # Calculate tokens for each frame except the last
+            existing_num_tokens = 0
+            for i in range(num_frames - 1):
+                feature_size = num_tokens_per_frame_list[i]
+                feature_size = int(feature_size * (1.0 - video_pruning_ratio))
+                existing_num_tokens += feature_size
+
+            # Last frame gets the remaining tokens
+            last_frame_tokens = desired_num_tokens - existing_num_tokens
+            num_total_tokens = existing_num_tokens + last_frame_tokens
+
+            # Add start and end tokens for each frame
+            num_total_tokens += num_frames * 2
+        else:
+            # No pruning - sum tokens for all frames
+            num_total_tokens = sum(
+                self.get_num_tokens_per_image(
+                    image=frame, video_pruning_ratio=None, **kwargs)
+                for frame in video)
+            # Add start and end tokens for each frame
+            num_total_tokens += num_frames * 2
+
+        return num_total_tokens
 
     @torch.inference_mode()
     def __call__(
@@ -494,7 +549,9 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         mm_embedding = []
         if len(multimodal_params) > 0:
             if not _is_disagg():
-                mm_embedding = self.vision_encoder(multimodal_params)
+                mm_embedding = get_multimodal_embeddings(
+                    encoder_forward_fn=self.vision_encoder.forward,
+                    multimodal_params=multimodal_params[:num_context_requests])
             else:
                 raise NotImplementedError(
                     "Nano-V2-VLM does not support disaggregated inference yet. Please unset "

--- a/tensorrt_llm/inputs/__init__.py
+++ b/tensorrt_llm/inputs/__init__.py
@@ -1,4 +1,5 @@
 from .data import PromptInputs, TextPrompt, TokensPrompt, prompt_inputs
+from .evs import compute_retained_tokens_count, compute_retention_mask
 from .multimodal import MultimodalInput
 from .registry import (BaseDummyInputsBuilder, BaseMultimodalInputProcessor,
                        ExtraProcessedInputs, InputProcessor,
@@ -54,4 +55,6 @@ __all__ = [
     "load_image",
     "load_video",
     "get_cache_salt_id",
+    "compute_retained_tokens_count",
+    "compute_retention_mask",
 ]

--- a/tensorrt_llm/inputs/evs.py
+++ b/tensorrt_llm/inputs/evs.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+
+import torch
+
+
+def compute_retained_tokens_count(video_size: torch.LongTensor,
+                                  spatial_merge_size: int, q: float) -> int:
+    """
+    Compute the number of retained tokens for a given video.
+    Method ensures that we retain all the tokens from the first frame
+    regardless of the pruning rate.
+
+    Args:
+        video_size: The size of the video in the format of (T, H, W).
+        spatial_merge_size: The size of the spatial merge.
+        q: The pruning rate.
+
+    Returns:
+        The number of retained tokens.
+    """
+    T, H, W = map(int, video_size)
+    min_num_tokens = (H // spatial_merge_size) * (W // spatial_merge_size)
+    evs_num_tokens = int(T * min_num_tokens * (1 - q))
+    return max(min_num_tokens, evs_num_tokens)
+
+
+def compute_retention_mask(
+    video_embeds: torch.Tensor,
+    video_size: torch.LongTensor,
+    spatial_merge_size: int,
+    q: float,
+    flatten_output: bool = True,
+) -> torch.Tensor:
+    """
+    Computes the retention mask for input video embeddings.
+
+    Args:
+        video_embeds (`torch.Tensor`): The input video embeddings
+            of shape `(T * H * W // spatial_merge_size ^ 2, hidden_size)`
+            or shape `(T, H * W // spatial_merge_size ^ 2, hidden_size)`.
+        video_size (`torch.LongTensor` of shape `(3)`):
+            The temporal, height and width of video.
+        spatial_merge_size: Size reduction for rows & cols dimensions.
+        q: (`float`): Pruning rate factor [0,1)
+        flatten_output: (`bool`): Whether to flatten the output mask.
+
+    Returns:
+        `torch.Tensor`: The retention mask for the video embeddings of
+            `(T * H * W // spatial_merge_size ^ 2)` shape.
+    """
+    T, H, W = video_size
+
+    # Use reshape instead of einops to avoid graph breaks
+    video_embeds = video_embeds.reshape(
+        T,
+        H // spatial_merge_size,
+        W // spatial_merge_size,
+        video_embeds.size(-1),
+    )
+
+    # Core EVS
+    similarity = torch.nn.functional.cosine_similarity(video_embeds[1:, ...],
+                                                       video_embeds[:-1, ...],
+                                                       dim=-1)
+    dissimilarity = 1 - similarity
+
+    # Always ensure we include all tokens from the first frame
+    dissimilarity = torch.cat(
+        [255 * torch.ones_like(video_embeds[:1, :, :, 0]), dissimilarity],
+        dim=0)
+
+    dissimilarity_flat = dissimilarity.view(-1)
+    order = torch.argsort(dissimilarity_flat,
+                          dim=-1,
+                          descending=True,
+                          stable=True)
+    retain_num_tokens = compute_retained_tokens_count(video_size,
+                                                      spatial_merge_size, q)
+    topk_indices = order[:retain_num_tokens]
+
+    retention_mask = torch.zeros_like(dissimilarity_flat, dtype=torch.bool)
+    retention_mask[topk_indices] = True
+    retention_mask = retention_mask.reshape(dissimilarity.size())
+
+    mask = retention_mask.view(-1) if flatten_output else retention_mask
+    return mask


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added optional video token pruning for multimodal inputs, controlled by an environment variable ratio (default off).
  - Multimodal outputs now include modality type and video size metadata for videos.
  - Introduced public utilities to compute retained token counts and retention masks for video embeddings.
- Behavior
  - When pruning is disabled, image and video processing remains unchanged.
- Tests/Chores/Docs
  - No user-facing changes reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
