### PR TITLE
[None][chroe] Update cron schedule for closing inactive issues

### DIFF
--- a/.github/workflows/auto-close-inactive-issues.yml
+++ b/.github/workflows/auto-close-inactive-issues.yml
@@ -3,10 +3,11 @@ name: Close inactive issues
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 3 * * *"
 
 jobs:
   stale:
+    if: ${{ github.repository == 'Nvidia/TensorRT-LLM' }}
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/auto-close-inactive-issues.yml
+++ b/.github/workflows/auto-close-inactive-issues.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   stale:
-    if: ${{ github.repository == 'Nvidia/TensorRT-LLM' }}
+    if: github.repository == 'NVIDIA/TensorRT-LLM'
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
* Change cron schedule to run at 3 AM daily instead of hourly.
* Only run in the official repo.

Example about the GitHub action (the recent 2 are skipped): https://github.com/zhenhuaw-me/TensorRT-LLM/actions/workflows/auto-close-inactive-issues.yml


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the inactive-issue automation to run once daily at 03:00 UTC instead of hourly, providing more predictable and less frequent notifications.
  * Limited the automation to the Nvidia/TensorRT-LLM repository to avoid unintended runs elsewhere.
  * Kept all existing steps, permissions, and messages unchanged—only timing and repository scope are affected.
  * Users will see stale/close actions processed in a single daily batch without changes to criteria or messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->