### PR TITLE
[None][fix] : Fix OOM issue when dp padding is enabled

### DIFF
--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
@@ -469,8 +469,13 @@ class CutlassFusedMoE(MoE):
             num_rows = x.shape[0]
 
         # in case of num_rows is larger than max_chunk_size, we need to split the input into multiple chunks
-        num_chunks = (num_rows + self.moe_max_num_tokens -
-                      1) // self.moe_max_num_tokens
+        if self.use_dp and self.parallel_size > 1 and use_dp_padding:
+            num_chunks = (max(all_rank_num_tokens) * len(all_rank_num_tokens) +
+                          self.moe_max_num_tokens -
+                          1) // self.moe_max_num_tokens
+        else:
+            num_chunks = (num_rows + self.moe_max_num_tokens -
+                          1) // self.moe_max_num_tokens
 
         if use_dp_padding:
             all_rank_num_tokens_padded = [max(all_rank_num_tokens)

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
@@ -468,20 +468,16 @@ class CutlassFusedMoE(MoE):
         else:
             num_rows = x.shape[0]
 
-        # in case of num_rows is larger than max_chunk_size, we need to split the input into multiple chunks
-        if self.use_dp and self.parallel_size > 1 and use_dp_padding:
-            num_chunks = (max(all_rank_num_tokens) * len(all_rank_num_tokens) +
-                          self.moe_max_num_tokens -
-                          1) // self.moe_max_num_tokens
-        else:
-            num_chunks = (num_rows + self.moe_max_num_tokens -
-                          1) // self.moe_max_num_tokens
-
         if use_dp_padding:
             all_rank_num_tokens_padded = [max(all_rank_num_tokens)
                                           ] * len(all_rank_num_tokens)
+            num_rows = sum(all_rank_num_tokens_padded)
         else:
             all_rank_num_tokens_padded = all_rank_num_tokens
+
+        # in case of num_rows is larger than max_chunk_size, we need to split the input into multiple chunks
+        num_chunks = (num_rows + self.moe_max_num_tokens -
+                      1) // self.moe_max_num_tokens
 
         if num_chunks == 1:
             outputs = self.forward_chunk(

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_wide_ep.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_wide_ep.py
@@ -757,16 +757,16 @@ class WideEPMoE(MoE):
 
         all_rank_max_num_tokens = max(all_rank_num_tokens)
 
-        # in case of num_rows is larger than max_chunk_size, we need to split the input into multiple chunks
-        num_chunks = self.calculate_num_chunks(all_rank_num_tokens)
-        use_all_to_all = self.can_use_alltoall(all_rank_num_tokens,
-                                               all_rank_max_num_tokens)
-
         if use_dp_padding:
             all_rank_num_tokens_padded = [all_rank_max_num_tokens
                                           ] * len(all_rank_num_tokens)
         else:
             all_rank_num_tokens_padded = all_rank_num_tokens
+
+        # in case of num_rows is larger than max_chunk_size, we need to split the input into multiple chunks
+        num_chunks = self.calculate_num_chunks(all_rank_num_tokens_padded)
+        use_all_to_all = self.can_use_alltoall(all_rank_num_tokens_padded,
+                                               all_rank_max_num_tokens)
         if num_chunks == 1:
             is_first_call = self.repeat_idx == 0
             is_last_call = self.repeat_idx == self.repeat_count - 1


### PR DESCRIPTION
@coderabbitai summary

## Description
When dp padding is enabled, the number of chunks should be re-calculated using padded tokens not the original all_rank_num_tokens. The OOM issue is found on SM120 due to dp padding is only enabled on the platform, see https://github.com/NVIDIA/TensorRT-LLM/pull/7965/files
