### PR TITLE
[None][feat] Load some default SampingParams values from generation_config

### DIFF
--- a/tensorrt_llm/sampling_params.py
+++ b/tensorrt_llm/sampling_params.py
@@ -358,6 +358,13 @@ class SamplingParams:
             if self.pad_id is None:
                 self.pad_id = self.end_id
 
+        if generation_config is not None:
+            self.max_tokens = self.max_tokens if self.max_tokens is not None else getattr(generation_config, "max_tokens", None)
+            self.min_tokens = self.min_tokens if self.min_tokens is not None else getattr(generation_config, "min_tokens", None)
+            self.temperature = self.temperature if self.temperature is not None else getattr(generation_config, "temperature", None)
+            self.top_k = self.top_k if self.top_k is not None else getattr(generation_config, "top_k", None)
+            self.top_p = self.top_p if self.top_p is not None else getattr(generation_config, "top_p", None)
+
         def _encode(tokenizer, text, add_special_tokens):
             try:
                 return tokenizer.encode(text, add_special_tokens=add_special_tokens)

--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -236,7 +236,7 @@ class CompletionRequest(OpenAIBaseModel):
     stop_token_ids: Optional[List[int]] = Field(default_factory=list)
     include_stop_str_in_output: bool = False
     ignore_eos: bool = False
-    min_tokens: int = 0
+    min_tokens: Optional[int] = None
     skip_special_tokens: bool = True
     spaces_between_special_tokens: bool = True
     truncate_prompt_tokens: Optional[Annotated[int, Field(ge=1)]] = None
@@ -537,7 +537,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
     stop_token_ids: Optional[List[int]] = Field(default_factory=list)
     include_stop_str_in_output: bool = False
     ignore_eos: bool = False
-    min_tokens: int = 0
+    min_tokens: Optional[int] = None
     skip_special_tokens: bool = True
     spaces_between_special_tokens: bool = True
     truncate_prompt_tokens: Optional[Annotated[int, Field(ge=1)]] = None


### PR DESCRIPTION
This feature is incomplete, because some default sampling params  for `/v1/chat/completions` and `/v1/competions` are hidden in `ChatCompletionRequest` & `CompletionRequest` and they won't be overwritten from generation_config in my current implementation. Moving them to `SampingParams._setup` doesn't seem like a good idea, I need some advice

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Sampling parameters now inherit unspecified values from the generation configuration (max tokens, min tokens, temperature, top-k, top-p), reducing manual setup and aligning defaults.
  - In OpenAI-compatible serving, min_tokens is now optional in completion and chat-completion requests; omitting it applies no explicit minimum while preserving existing validation.
  - No other behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->