### PR TITLE
[https://nvbugs/5510879][fix] Fix pytorch & TRT-python flows fused LoRA adapter modules weight split with TP>1

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -1179,8 +1179,7 @@ class PeftCacheManager(BaseResourceManager):
         )
         self._lora_manager = LoraManager(
             mapping=mapping,
-            model_config=ModelConfigPython.from_model_config_cpp(
-                model_config, mapping),
+            model_config=ModelConfigPython.from_model_config_cpp(model_config),
             cpp_peft_cache_manager=self.impl)
 
     def get_lora_manager(self) -> LoraManager:

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -1180,7 +1180,8 @@ class PeftCacheManager(BaseResourceManager):
         self._lora_manager = LoraManager(
             mapping=mapping,
             model_config=ModelConfigPython.from_model_config_cpp(
-                model_config, mapping))
+                model_config, mapping),
+            cpp_peft_cache_manager=self.impl)
 
     def get_lora_manager(self) -> LoraManager:
         return self._lora_manager

--- a/tensorrt_llm/_utils.py
+++ b/tensorrt_llm/_utils.py
@@ -42,7 +42,7 @@ import torch
 import tensorrt as trt
 # isort: on
 
-from tensorrt_llm.bindings import DataType, GptJsonConfig
+from tensorrt_llm.bindings import DataType, GptJsonConfig, LayerType
 from tensorrt_llm.bindings.BuildInfo import ENABLE_MULTI_DEVICE
 from tensorrt_llm.logger import logger
 
@@ -196,6 +196,10 @@ _binding_dtype_bits = {
     DataType.UINT8: 8,
     DataType.NVFP4: 4,
 }
+
+
+def binding_layer_type_to_str(layer_type: LayerType) -> str:
+    return layer_type.name.lower()
 
 
 def binding_to_str_dtype(binding_dtype) -> str:

--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -205,10 +205,8 @@ class BaseWorker(GenerationExecutor):
                 # point in the TRT flow is currently not supported (it's at the CPP
                 # Executor->ExecutorImpl->TrtGptModel->mPeftCacheManager) therefore for now this LoRA
                 # optimization is not available in TRT-python flow.
-                mapping = engine_config.pretrained_config.mapping if self.llm_args is None else self.llm_args.parallel_config.to_mapping(
-                )
                 self._lora_manager = LoraManager(
-                    mapping=mapping,
+                    mapping=engine_config.pretrained_config.mapping,
                     model_config=self._runtime_model_config,
                     cpp_peft_cache_manager=None)
             if engine_config.build_config.max_prompt_embedding_table_size > 0:

--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -10,7 +10,6 @@ from typing import Dict, List, Optional, Tuple, Union
 import torch
 
 from tensorrt_llm.logger import logger
-from tensorrt_llm.mapping import Mapping
 
 from .._torch.pyexecutor.llm_request import LlmResponse
 from .._utils import (global_mpi_rank, global_mpi_size, mpi_comm, mpi_rank,
@@ -206,11 +205,7 @@ class BaseWorker(GenerationExecutor):
                 # point in the TRT flow is currently not supported (it's at the CPP
                 # Executor->ExecutorImpl->TrtGptModel->mPeftCacheManager) therefore for now this LoRA
                 # optimization is not available in TRT-python flow.
-
-                # NOTE: In TRT-python flow, llm_args is not set, so we create Mapping() with default values here.
-                #       this would cause incorrect weight split on TP>1 for fused LoRA modules.
-                mapping = Mapping(
-                ) if self.llm_args is None else self.llm_args.parallel_config.to_mapping(
+                mapping = engine_config.pretrained_config.mapping if self.llm_args is None else self.llm_args.parallel_config.to_mapping(
                 )
                 self._lora_manager = LoraManager(
                     mapping=mapping,

--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -311,7 +311,6 @@ class BaseWorker(GenerationExecutor):
             [lora_request.path],
             model_config=self._runtime_model_config if
             self._runtime_model_config is not None else self._lora_model_config,
-            runtime_mapping=None,
             uids=[adapter_id],
             ckpt_source=lora_request.ckpt_source)
         return adapter_id in newly_loaded_uids

--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -10,6 +10,7 @@ from typing import Callable, List, Optional, Union
 import zmq
 
 from tensorrt_llm.logger import logger
+from tensorrt_llm.mapping import Mapping
 
 from .._utils import mpi_comm, mpi_rank
 from ..bindings import executor as tllm

--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -10,7 +10,6 @@ from typing import Callable, List, Optional, Union
 import zmq
 
 from tensorrt_llm.logger import logger
-from tensorrt_llm.mapping import Mapping
 
 from .._utils import mpi_comm, mpi_rank
 from ..bindings import executor as tllm

--- a/tensorrt_llm/lora_helper.py
+++ b/tensorrt_llm/lora_helper.py
@@ -46,6 +46,7 @@ def get_default_trtllm_modules_to_hf_modules():
         "attn_q": "q_proj",
         "attn_k": "k_proj",
         "attn_v": "v_proj",
+        "attn_qkv": "qkv_proj",
         "attn_dense": "o_proj",
         "mlp_h_to_4h": "gate_proj",
         "mlp_4h_to_h": "down_proj",

--- a/tensorrt_llm/lora_manager.py
+++ b/tensorrt_llm/lora_manager.py
@@ -1092,6 +1092,8 @@ class LoraManager(object):
                         half_size = t_out.shape[rank_dim] // 2
                         part_sizes = [half_size, half_size]
                     elif lora_module == "attn_qkv":
+                        # The sizes are multiplied by tp_size because num_heads and num_kv_heads here were already
+                        # divided by tp_size
                         q_size = (
                             self._model_config.head_size * self._model_config.num_heads * tp_size
                         )

--- a/tensorrt_llm/lora_manager.py
+++ b/tensorrt_llm/lora_manager.py
@@ -974,8 +974,8 @@ class LoraManager(object):
             return lora_model
 
         def interleave_fused_lora_weights_for_tp(
-            weight: torch.Tensor, rank_dim: int, tp_size: int, part_sizes: list[int]
-        ) -> list[torch.Tensor]:
+            weight: torch.Tensor, rank_dim: int, tp_size: int, part_sizes: List[int]
+        ) -> List[torch.Tensor]:
             assert weight.shape[rank_dim] == sum(part_sizes)
 
             # Split the weights into their respective parts. e.g. weight -> [Wq, Wk, Wv] for attn_qkv.

--- a/tensorrt_llm/lora_manager.py
+++ b/tensorrt_llm/lora_manager.py
@@ -1020,7 +1020,7 @@ class LoraManager(object):
                 part_sizes = [half_size, half_size]
             elif lora_module == "attn_qkv":
                 # The sizes are multiplied by tp_size because num_heads and num_kv_heads here were already
-                # divided by tp_size
+                # divided by tp_size in tensorrt_llm/_torch/model_config.py::ModelConfig.get_bindings_model_config
                 q_size = self._model_config.head_size * self._model_config.num_heads * tp_size
                 kv_size = self._model_config.head_size * self._model_config.num_kv_heads * tp_size
                 part_sizes = [q_size, kv_size, kv_size]

--- a/tensorrt_llm/lora_manager.py
+++ b/tensorrt_llm/lora_manager.py
@@ -1084,7 +1084,7 @@ class LoraManager(object):
                     # e.g. Convert [q, k, v] to [q_rank0, k_rank0, v_rank0, ..., q_rankN, k_rankN, v_rankN] where
                     # N=TP size
                     tp_size = self._mapping.tp_size
-                    interleaved_parts = []
+                    part_sizes = []
                     if lora_module == "mlp_gate_up":
                         assert t_out.shape[rank_dim] % 2 == 0
                         half_size = t_out.shape[rank_dim] // 2

--- a/tensorrt_llm/runtime/enc_dec_model_runner.py
+++ b/tensorrt_llm/runtime/enc_dec_model_runner.py
@@ -175,7 +175,9 @@ class EncDecModelRunner:
             # encoder lora manager setup
             if self.encoder_model_config.lora_plugin:
                 self.encoder_lora_manager = LoraManager(
-                    mapping=self.encoder_runtime_mapping)
+                    mapping=self.encoder_runtime_mapping,
+                    model_config=self.encoder_model_config,
+                )
                 # TODO: this is only for bart
                 self.encoder_lora_manager.load_from_hf(
                     model_dirs=lora_dir,
@@ -198,7 +200,9 @@ class EncDecModelRunner:
         # decoder lora manager setup
         if self.decoder_model_config.lora_plugin:
             self.decoder_lora_manager = LoraManager(
-                mapping=self.decoder_runtime_mapping)
+                mapping=self.decoder_runtime_mapping,
+                model_config=self.decoder_model_config,
+            )
             # TODO: this is only for bart
             self.decoder_lora_manager.load_from_hf(
                 model_dirs=lora_dir,

--- a/tensorrt_llm/runtime/enc_dec_model_runner.py
+++ b/tensorrt_llm/runtime/enc_dec_model_runner.py
@@ -174,12 +174,12 @@ class EncDecModelRunner:
 
             # encoder lora manager setup
             if self.encoder_model_config.lora_plugin:
-                self.encoder_lora_manager = LoraManager()
+                self.encoder_lora_manager = LoraManager(
+                    mapping=self.encoder_runtime_mapping)
                 # TODO: this is only for bart
                 self.encoder_lora_manager.load_from_hf(
                     model_dirs=lora_dir,
                     model_config=self.encoder_model_config,
-                    runtime_mapping=self.encoder_runtime_mapping,
                     component='encoder',
                 )
             else:
@@ -197,12 +197,12 @@ class EncDecModelRunner:
 
         # decoder lora manager setup
         if self.decoder_model_config.lora_plugin:
-            self.decoder_lora_manager = LoraManager()
+            self.decoder_lora_manager = LoraManager(
+                mapping=self.decoder_runtime_mapping)
             # TODO: this is only for bart
             self.decoder_lora_manager.load_from_hf(
                 model_dirs=lora_dir,
                 model_config=self.decoder_model_config,
-                runtime_mapping=self.decoder_runtime_mapping,
                 component='decoder',
             )
         else:

--- a/tensorrt_llm/runtime/generation.py
+++ b/tensorrt_llm/runtime/generation.py
@@ -40,8 +40,9 @@ from tensorrt_llm.runtime.memory_pools.pools_kv_cache_manager import \
     PoolsKVCacheManager
 from tensorrt_llm.runtime.redrafter_utils import *
 
-from .._utils import (binding_to_str_dtype, pad_vocab_size, str_dtype_to_torch,
-                      torch_to_numpy, trt_dtype_to_torch)
+from .._utils import (binding_layer_type_to_str, binding_to_str_dtype,
+                      pad_vocab_size, str_dtype_to_torch, torch_to_numpy,
+                      trt_dtype_to_torch)
 from ..bindings import KVCacheType, ipc_nvls_allocate, ipc_nvls_free
 from ..layers import LanguageAdapterConfig
 from ..logger import logger
@@ -672,16 +673,24 @@ class ModelConfig:
             num_heads=model_config_cpp.num_heads,
             num_kv_heads=model_config_cpp.num_kv_heads(0),
             hidden_size=model_config_cpp.hidden_size,
+            remove_input_padding=model_config_cpp.use_packed_input,
             kv_cache_type=model_config_cpp.kv_cache_type,
             cross_attention=model_config_cpp.use_cross_attention,
             head_size=model_config_cpp.head_size,
             max_prompt_embedding_table_size=model_config_cpp.
             max_prompt_embedding_table_size,
+            quant_mode=QuantMode(model_config_cpp.quant_mode.value),
+            gather_context_logits=model_config_cpp.compute_context_logits,
+            gather_generation_logits=model_config_cpp.compute_generation_logits,
             gpt_attention_plugin=model_config_cpp.use_gpt_attention_plugin,
             dtype=binding_to_str_dtype(model_config_cpp.data_type),
             num_kv_heads_per_layer=model_config_cpp.num_kv_heads_per_layer,
             tokens_per_block=model_config_cpp.tokens_per_block,
             lora_plugin=model_config_cpp.use_lora_plugin,
+            layer_types=[
+                binding_layer_type_to_str(lt)
+                for lt in model_config_cpp.layer_types
+            ],
         )
 
 

--- a/tensorrt_llm/runtime/generation.py
+++ b/tensorrt_llm/runtime/generation.py
@@ -657,7 +657,7 @@ class ModelConfig:
     @classmethod
     def from_model_config_cpp(cls, model_config_cpp,
                               mapping: Mapping) -> 'ModelConfig':
-        """Create a partially initialized ModelConfigPython from a given ModelConfigCpp.
+        """Create a partially initialized ModelConfig instance from a given ModelConfig CPP binding instance.
 
         Note that each of these classes have fields that don't exist in the other, so the created ModelConfigPython
         won't have all of its fields initialized.

--- a/tensorrt_llm/runtime/generation.py
+++ b/tensorrt_llm/runtime/generation.py
@@ -655,8 +655,7 @@ class ModelConfig:
     language_adapter_config: Optional[LanguageAdapterConfig] = None
 
     @classmethod
-    def from_model_config_cpp(cls, model_config_cpp,
-                              mapping: Mapping) -> 'ModelConfig':
+    def from_model_config_cpp(cls, model_config_cpp) -> 'ModelConfig':
         """Create a partially initialized ModelConfig instance from a given ModelConfig CPP binding instance.
 
         Note that each of these classes have fields that don't exist in the other, so the created ModelConfigPython
@@ -666,10 +665,7 @@ class ModelConfig:
             max_batch_size=model_config_cpp.max_batch_size,
             max_beam_width=model_config_cpp.max_beam_width,
             vocab_size=model_config_cpp.vocab_size,
-            num_layers=model_config_cpp.num_layers(
-                pipeline_parallelism=mapping.pp_size,
-                pipeline_parallelism_rank=mapping.pp_rank,
-            ),
+            num_layers=model_config_cpp.num_layers(),
             num_heads=model_config_cpp.num_heads,
             num_kv_heads=model_config_cpp.num_kv_heads(0),
             hidden_size=model_config_cpp.hidden_size,

--- a/tensorrt_llm/runtime/model_runner.py
+++ b/tensorrt_llm/runtime/model_runner.py
@@ -611,11 +611,10 @@ class ModelRunner(ModelRunnerMixin):
             session.runtime._set_weight_streaming(gpu_weights_percent)
 
         if session.use_lora_plugin:
-            lora_manager = LoraManager()
+            lora_manager = LoraManager(mapping=runtime_mapping)
             if lora_dir is not None:
                 lora_manager.load_from_ckpt(lora_dir,
                                             model_config=model_config,
-                                            runtime_mapping=runtime_mapping,
                                             ckpt_source=lora_ckpt_source)
         else:
             lora_manager = None
@@ -720,11 +719,10 @@ class ModelRunner(ModelRunnerMixin):
                                   debug_mode=debug_mode,
                                   stream=stream)
             if session.use_lora_plugin:
-                lora_manager = LoraManager()
+                lora_manager = LoraManager(mapping=runtime_mapping)
                 if lora_dir is not None:
                     lora_manager.load_from_ckpt(lora_dir,
                                                 model_config=model_config,
-                                                runtime_mapping=runtime_mapping,
                                                 ckpt_source=lora_ckpt_source)
             else:
                 lora_manager = None

--- a/tensorrt_llm/runtime/model_runner.py
+++ b/tensorrt_llm/runtime/model_runner.py
@@ -611,7 +611,8 @@ class ModelRunner(ModelRunnerMixin):
             session.runtime._set_weight_streaming(gpu_weights_percent)
 
         if session.use_lora_plugin:
-            lora_manager = LoraManager(mapping=runtime_mapping)
+            lora_manager = LoraManager(mapping=runtime_mapping,
+                                       model_config=model_config)
             if lora_dir is not None:
                 lora_manager.load_from_ckpt(lora_dir,
                                             model_config=model_config,
@@ -719,7 +720,8 @@ class ModelRunner(ModelRunnerMixin):
                                   debug_mode=debug_mode,
                                   stream=stream)
             if session.use_lora_plugin:
-                lora_manager = LoraManager(mapping=runtime_mapping)
+                lora_manager = LoraManager(mapping=runtime_mapping,
+                                           model_config=model_config)
                 if lora_dir is not None:
                     lora_manager.load_from_ckpt(lora_dir,
                                                 model_config=model_config,

--- a/tensorrt_llm/runtime/model_runner_cpp.py
+++ b/tensorrt_llm/runtime/model_runner_cpp.py
@@ -277,7 +277,8 @@ class ModelRunnerCpp(ModelRunnerMixin):
 
         engine_config = EngineConfig.from_json_file(f"{engine_dir}/config.json")
         if model_config.use_lora_plugin and rank == 0:
-            lora_manager = LoraManager()
+            lora_manager = LoraManager(
+                mapping=_world_config_to_mapping(world_config))
             if lora_dir is None:
                 config_lora_dir = engine_config.build_config.lora_config.lora_dir
                 if len(config_lora_dir) > 0:
@@ -292,7 +293,6 @@ class ModelRunnerCpp(ModelRunnerMixin):
                 # For Executor, only rank 0 can enqueue requests, and should hold all lora weights
                 lora_manager.load_from_ckpt(lora_dir,
                                             model_config=runtime_model_config,
-                                            runtime_mapping=None,
                                             ckpt_source=lora_ckpt_source)
             else:
                 raise RuntimeError(

--- a/tensorrt_llm/runtime/model_runner_cpp.py
+++ b/tensorrt_llm/runtime/model_runner_cpp.py
@@ -32,8 +32,9 @@ from ..builder import EngineConfig
 from ..layers import MropeParams
 from ..logger import logger
 from ..mapping import Mapping
-from .generation import (LogitsProcessor, LoraManager, SamplingConfig,
-                         StoppingCriteria)
+from .generation import LogitsProcessor, LoraManager
+from .generation import ModelConfig as ModelConfigPython
+from .generation import SamplingConfig, StoppingCriteria
 from .model_runner import ModelRunnerMixin, _engine_config_to_model_config
 
 _bindings_dtype_to_torch_dtype_dict = {
@@ -277,8 +278,11 @@ class ModelRunnerCpp(ModelRunnerMixin):
 
         engine_config = EngineConfig.from_json_file(f"{engine_dir}/config.json")
         if model_config.use_lora_plugin and rank == 0:
+            mapping = _world_config_to_mapping(world_config)
             lora_manager = LoraManager(
-                mapping=_world_config_to_mapping(world_config))
+                mapping=mapping,
+                model_config=ModelConfigPython.from_model_config_cpp(
+                    model_config, mapping))
             if lora_dir is None:
                 config_lora_dir = engine_config.build_config.lora_config.lora_dir
                 if len(config_lora_dir) > 0:

--- a/tensorrt_llm/runtime/model_runner_cpp.py
+++ b/tensorrt_llm/runtime/model_runner_cpp.py
@@ -282,7 +282,7 @@ class ModelRunnerCpp(ModelRunnerMixin):
             lora_manager = LoraManager(
                 mapping=mapping,
                 model_config=ModelConfigPython.from_model_config_cpp(
-                    model_config, mapping))
+                    model_config))
             if lora_dir is None:
                 config_lora_dir = engine_config.build_config.lora_config.lora_dir
                 if len(config_lora_dir) > 0:

--- a/tests/unittest/llmapi/lora_test_utils.py
+++ b/tests/unittest/llmapi/lora_test_utils.py
@@ -2,7 +2,7 @@ import json
 import tarfile
 import tempfile
 from pathlib import Path
-from typing import OrderedDict, Type
+from typing import List, OrderedDict, Type
 
 import torch
 from utils.llm_data import llm_models_root
@@ -21,8 +21,8 @@ _RU_LORA_ADAPTER_PROMPTS = [
 
 
 def _generate_llm_response_lora_fused_modules(llm_class: Type[BaseLLM],
-                                              prompts: list[str],
-                                              **extra_llm_kwargs) -> list[str]:
+                                              prompts: List[str],
+                                              **extra_llm_kwargs) -> List[str]:
     """Generates responses with LoRA requests with the Phi-3-mini-4k-instruct-ru-lora adapter.
     The used LoRA adapter has fused attention QKV and fused MLP gate up proj modules.
     Returns the generated texts.
@@ -66,7 +66,7 @@ def check_lora_fused_modules_output_tp2_identical_to_tp1(
 
 
 def check_llama_7b_multi_unique_lora_adapters_from_request(
-        lora_adapter_count_per_call: list[int], repeat_calls: int,
+        lora_adapter_count_per_call: List[int], repeat_calls: int,
         repeats_per_call: int, llm_class: Type[BaseLLM], **llm_kwargs):
     """Calls llm.generate s.t. for each C in lora_adapter_count_per_call, llm.generate is called with C requests
     repeated 'repeats_per_call' times, where each request is configured with a unique LoRA adapter ID.

--- a/tests/unittest/llmapi/lora_test_utils.py
+++ b/tests/unittest/llmapi/lora_test_utils.py
@@ -11,6 +11,58 @@ from utils.util import duplicate_list_to_length, flatten_list, similar
 from tensorrt_llm import SamplingParams
 from tensorrt_llm.executor.request import LoRARequest
 from tensorrt_llm.llmapi.llm import BaseLLM
+from tensorrt_llm.lora_helper import LoraConfig
+
+_RU_LORA_ADAPTER_PROMPTS = [
+    "Назови главную площадь в центре Москвы.",
+    "Напиши полное предложение, описывающее, что в музее не хватает женских скульптур. Используй фразу \"не хватает\".",
+    "Что означает выражение \"водить за нос\"? Объясни в двух словах.",
+]
+
+
+def _generate_llm_response_lora_fused_modules(llm_class: Type[BaseLLM],
+                                              prompts: list[str],
+                                              **extra_llm_kwargs) -> list[str]:
+    """Generates responses with LoRA requests with the Phi-3-mini-4k-instruct-ru-lora adapter.
+    The used LoRA adapter has fused attention QKV and fused MLP gate up proj modules.
+    Returns the generated texts.
+    """  # noqa: D205
+    hf_model_dir = f"{llm_models_root()}/Phi-3/Phi-3-mini-4k-instruct"
+    hf_lora_dir = f"{llm_models_root()}/lora/phi/Phi-3-mini-4k-instruct-ru-lora"
+
+    lora_req = LoRARequest("ru-lora", 0, hf_lora_dir)
+    sampling_params = SamplingParams(max_tokens=20)
+
+    lora_config = LoraConfig(lora_dir=[hf_lora_dir],
+                             max_lora_rank=16,
+                             max_loras=2,
+                             max_cpu_loras=2)
+
+    lora_requests = [lora_req] * len(prompts)
+    with llm_class(hf_model_dir, lora_config=lora_config,
+                   **extra_llm_kwargs) as llm:
+        outputs = llm.generate(prompts,
+                               sampling_params,
+                               lora_request=lora_requests)
+
+    return [output.outputs[0].text for output in outputs]
+
+
+def check_lora_fused_modules_output_tp2_identical_to_tp1(
+        llm_class: Type[BaseLLM], **extra_llm_kwargs) -> None:
+    """Tests the output with LoRA requests with the Phi-3-mini-4k-instruct-ru-lora adapter with TP=2 is identical to
+    the output with TP=1.
+    That LoRA adapter has fused attention QKV and fused MLP gate up proj modules.
+    """  # noqa: D205
+    extra_llm_kwargs["tensor_parallel_size"] = 1
+    outputs_tp1 = _generate_llm_response_lora_fused_modules(
+        llm_class, _RU_LORA_ADAPTER_PROMPTS, **extra_llm_kwargs)
+
+    extra_llm_kwargs["tensor_parallel_size"] = 2
+    outputs_tp2 = _generate_llm_response_lora_fused_modules(
+        llm_class, _RU_LORA_ADAPTER_PROMPTS, **extra_llm_kwargs)
+
+    assert outputs_tp1 == outputs_tp2
 
 
 def check_llama_7b_multi_unique_lora_adapters_from_request(

--- a/tests/unittest/llmapi/lora_test_utils.py
+++ b/tests/unittest/llmapi/lora_test_utils.py
@@ -20,9 +20,9 @@ _RU_LORA_ADAPTER_PROMPTS = [
 ]
 
 
-def _generate_llm_response_lora_fused_modules(llm_class: Type[BaseLLM],
-                                              prompts: List[str],
-                                              **extra_llm_kwargs) -> List[str]:
+def _generate_phi3_response_lora_fused_modules(llm_class: Type[BaseLLM],
+                                               prompts: List[str],
+                                               **extra_llm_kwargs) -> List[str]:
     """Generates responses with LoRA requests with the Phi-3-mini-4k-instruct-ru-lora adapter.
     The used LoRA adapter has fused attention QKV and fused MLP gate up proj modules.
     Returns the generated texts.
@@ -48,18 +48,18 @@ def _generate_llm_response_lora_fused_modules(llm_class: Type[BaseLLM],
     return [output.outputs[0].text for output in outputs]
 
 
-def check_lora_fused_modules_output_tp2_identical_to_tp1(
+def check_phi3_lora_fused_modules_output_tp2_identical_to_tp1(
         llm_class: Type[BaseLLM], **extra_llm_kwargs) -> None:
     """Tests the output with LoRA requests with the Phi-3-mini-4k-instruct-ru-lora adapter with TP=2 is identical to
     the output with TP=1.
     That LoRA adapter has fused attention QKV and fused MLP gate up proj modules.
     """  # noqa: D205
     extra_llm_kwargs["tensor_parallel_size"] = 1
-    outputs_tp1 = _generate_llm_response_lora_fused_modules(
+    outputs_tp1 = _generate_phi3_response_lora_fused_modules(
         llm_class, _RU_LORA_ADAPTER_PROMPTS, **extra_llm_kwargs)
 
     extra_llm_kwargs["tensor_parallel_size"] = 2
-    outputs_tp2 = _generate_llm_response_lora_fused_modules(
+    outputs_tp2 = _generate_phi3_response_lora_fused_modules(
         llm_class, _RU_LORA_ADAPTER_PROMPTS, **extra_llm_kwargs)
 
     assert outputs_tp1 == outputs_tp2

--- a/tests/unittest/llmapi/test_llm_multi_gpu_pytorch.py
+++ b/tests/unittest/llmapi/test_llm_multi_gpu_pytorch.py
@@ -62,6 +62,7 @@ def test_llama_7b_multi_lora_tp2():
         cuda_graph_config=None)
 
 
+@pytest.mark.gpu2
 def test_phi3_lora_fused_modules_output_on_tp2_identical_to_tp1() -> None:
     check_phi3_lora_fused_modules_output_tp2_identical_to_tp1(
         LLM,

--- a/tests/unittest/llmapi/test_llm_multi_gpu_pytorch.py
+++ b/tests/unittest/llmapi/test_llm_multi_gpu_pytorch.py
@@ -5,7 +5,7 @@ from .test_llm import tinyllama_logits_processor_test_harness, llama_model_path
 from tensorrt_llm import LLM
 from tensorrt_llm.llmapi import KvCacheConfig
 from tensorrt_llm.lora_helper import LoraConfig
-from .lora_test_utils import check_llama_7b_multi_lora_from_request_test_harness, check_lora_fused_modules_output_tp2_identical_to_tp1
+from .lora_test_utils import check_llama_7b_multi_lora_from_request_test_harness, check_phi3_lora_fused_modules_output_tp2_identical_to_tp1
 from .test_llm_pytorch import llama_7b_lora_from_dir_test_harness
 from .test_llm import _test_llm_capture_request_error
 from utils.util import skip_ray
@@ -62,8 +62,8 @@ def test_llama_7b_multi_lora_tp2():
         cuda_graph_config=None)
 
 
-def test_lora_fused_modules_output_on_tp2_identical_to_tp1() -> None:
-    check_lora_fused_modules_output_tp2_identical_to_tp1(
+def test_phi3_lora_fused_modules_output_on_tp2_identical_to_tp1() -> None:
+    check_phi3_lora_fused_modules_output_tp2_identical_to_tp1(
         LLM,
         # Disable CUDA graph
         # TODO: remove this once we have a proper fix for CUDA graph in LoRA

--- a/tests/unittest/llmapi/test_llm_multi_gpu_pytorch.py
+++ b/tests/unittest/llmapi/test_llm_multi_gpu_pytorch.py
@@ -5,7 +5,7 @@ from .test_llm import tinyllama_logits_processor_test_harness, llama_model_path
 from tensorrt_llm import LLM
 from tensorrt_llm.llmapi import KvCacheConfig
 from tensorrt_llm.lora_helper import LoraConfig
-from .lora_test_utils import check_llama_7b_multi_lora_from_request_test_harness
+from .lora_test_utils import check_llama_7b_multi_lora_from_request_test_harness, check_lora_fused_modules_output_tp2_identical_to_tp1
 from .test_llm_pytorch import llama_7b_lora_from_dir_test_harness
 from .test_llm import _test_llm_capture_request_error
 from utils.util import skip_ray
@@ -57,6 +57,14 @@ def test_llama_7b_multi_lora_tp2():
         lora_config=lora_config,
         tensor_parallel_size=2,
         kv_cache_config=global_kv_cache_config,
+        # Disable CUDA graph
+        # TODO: remove this once we have a proper fix for CUDA graph in LoRA
+        cuda_graph_config=None)
+
+
+def test_lora_fused_modules_output_on_tp2_identical_to_tp1() -> None:
+    check_lora_fused_modules_output_tp2_identical_to_tp1(
+        LLM,
         # Disable CUDA graph
         # TODO: remove this once we have a proper fix for CUDA graph in LoRA
         cuda_graph_config=None)


### PR DESCRIPTION
## Description

The bug: Generated output of LoRA adapters with fused modules (such as "attn_qkv" or "mlp_gate_up") with TP>1 was bad. 

The cause: The TP split logic of fused LoRA adapter modules was wrong - instead of splitting each "sub-module" weight (e.g. in "attn_qkv" split `Wq` by TP size, and do the same for `Wk` and `Wv`) between the different ranks, the concatenation of the "sub-modules" was split (`WqWkWv` was split by TP size).

The fix: First split the concatenation to the "sub-modules", then split each one by the TP rank, and then concatenate the interleaved parts. e.g. for "attn_qkv" - convert `W=torch.cat([Wq, Wk, Wv])` to `W=torch.chat([Wq_rank0, Wk_rank0, Wv_rank0, ..., Wq_rankN, Wk_rankN, Wv_rankN])` where N=TP size.

Notes:
- This bug and this fix also apply for TRT-python flow.
- There's no TRT-python test of this fix because the test uses Phi-3 model and Phi-3-mini-4k-instruct-ru-lora adapter, as that's the only public LoRA adapter I found that uses fused attention QKV and fused MLP gate up, and Phi-3 doesn't work well on TRT-python with TP>1 as reported in https://nvbugspro.nvidia.com/bug/5393849

## Test Coverage

- `tests/unittest/llmapi/test_llm_multi_gpu_pytorch.py::test_phi3_lora_fused_modules_output_on_tp2_identical_to_tp1`

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved LoRA support with explicit runtime mapping and model configuration, enabling better multi-GPU and pipeline/tensor parallel integration.
  * Added handling for fused QKV and MLP up-projection modules in LoRA adapters for broader model compatibility.
* **Bug Fixes**
  * Ensures LoRA fused-module outputs are consistent across tensor parallel sizes (e.g., TP1 vs TP2).
* **Tests**
  * Added end-to-end tests validating identical outputs for LoRA fused modules across TP settings and expanded utilities for LoRA adapter loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->