### PR TITLE
[#4593][feat] AutoDeploy: Linear Attention Support (SSM + causal_conv + Bamba + Nemotron-H)

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -129,10 +129,10 @@ transforms:
     attn_backend: MultiHeadLatentAttention
   insert_cached_ssm_attention:
     stage: cache_init
-    attn_backend: torch_ssm
+    attn_backend: triton_ssm
   insert_cached_causal_conv:
     stage: cache_init
-    attn_backend: torch_causal_conv
+    attn_backend: cuda_causal_conv
   initialize_cache:
     stage: cache_init
   resize_kv_cache:

--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -127,6 +127,12 @@ transforms:
   insert_cached_mla_attention:
     stage: cache_init
     attn_backend: MultiHeadLatentAttention
+  insert_cached_ssm_attention:
+    stage: cache_init
+    attn_backend: torch_ssm
+  insert_cached_causal_conv:
+    stage: cache_init
+    attn_backend: torch_causal_conv
   initialize_cache:
     stage: cache_init
   resize_kv_cache:

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/__init__.py
@@ -1,20 +1,10 @@
 """Custom ops and make sure they are all registered."""
 
-from ._triton_attention_internal import *
-from .dist import *
-from .flashinfer_attention import *
-from .flashinfer_rope import *
-from .linear import *
-from .mla import *
-from .mxfp4_moe import *
-from .quant import *
-from .rms_norm import *
-from .torch_attention import *
-from .torch_backend_attention import *
-from .torch_moe import *
-from .torch_quant import *
-from .torch_rope import *
-from .torch_router import *
-from .triton_attention import *
-from .triton_rope import *
-from .trtllm_moe import *
+import importlib
+import pkgutil
+
+__all__ = []
+
+for _, module_name, is_pkg in pkgutil.iter_modules(__path__):
+    __all__.append(module_name)
+    importlib.import_module(f"{__name__}.{module_name}")

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -311,6 +311,7 @@ class SequenceInfo:
             if self.max_batch_size > 1:
                 bs_seq_len_shape[0] = Dim("batch_size", max=self.max_batch_size)
             bs_seq_len_shape[1] = Dim("seq_len", max=self.max_seq_len)
+            # bs_seq_len_shape[1] = Dim.AUTO
             self._dynamic_shapes = {k: bs_seq_len_shape for k in self._uncached_arg_names}
             # cached args are static
             self._dynamic_shapes.update({k: {} for k in self._cached_arg_names})

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -136,7 +136,8 @@ class SequenceInfo:
         self._num_pages = max(
             self.max_batch_size,
             (self.max_num_tokens) // self.page_size  # floored number of pages
-            + (self.max_num_tokens % self.page_size > 0) * self.max_batch_size,  # +1 per sequence
+            + (self.max_num_tokens / self.max_batch_size % self.page_size > 0)  # check for overflow
+            * self.max_batch_size,  # +1 page per sequence if overflow is required
         )
         # sanity check
         assert self.num_pages >= self.max_batch_size, "num_pages can't be less than max_batch_size"

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -72,6 +72,8 @@ class SequenceInfo:
     - pages_per_seq: [ps_0, ps_1, ..., ps_{b-1}] where ps_i is the number of pages allocated for
       sequence i. Note that, for example, cache_loc[p_0:p_1] will correspond to the pages associated
       with sequence 1 in the batch.
+    - slot_idx: [s_0, s_1, ..., s_{b-1}]
+      Corresponds to the slot index of each sequence in the batch.
 
     ################################################################################################
 
@@ -164,6 +166,7 @@ class SequenceInfo:
             "input_pos": torch.empty(self.max_batch_size, dtype=torch.int),
             "cache_loc": torch.empty(self.num_pages, dtype=torch.int),
             "pages_per_seq": torch.empty(self.max_batch_size, dtype=torch.int),
+            "slot_idx": torch.empty(self.max_batch_size, dtype=torch.int),
             # OTHER FIELDS WHERE WE NEED EFFICIENT HOST<>DEVICE TRANSFER
             "_gather_idx": torch.empty(self.max_num_tokens, dtype=torch.int),
         }
@@ -172,7 +175,8 @@ class SequenceInfo:
         }
         # NOTE: order of keys is relevant here!
         self._uncached_arg_names = ("input_ids", "position_ids")
-        self._cached_arg_names = ("seq_len", "input_pos", "cache_loc", "pages_per_seq")
+        self._cached_arg_names = ("seq_len", "input_pos", "cache_loc", "pages_per_seq", "slot_idx")
+        self._cached_constants = ("page_size",)
         ############################################################################################
 
         # EXTRA TENSOR FIELDS ######################################################################
@@ -296,7 +300,7 @@ class SequenceInfo:
         ``insert_cached_attention`` to extract the constant arguments and add them to the
         ``prepare_metadata`` node/op.
         """
-        return (self.page_size,)
+        return tuple(getattr(self, k) for k in self._cached_constants)
 
     @property
     def named_dynamic_shapes(self) -> Dict[str, Dict[str, Dim]]:
@@ -523,11 +527,15 @@ class SequenceInfo:
         cache_loc = list(range(sum(pages_per_seq)))
         page_assignments = self._get_page_assignments(cache_loc, pages_per_seq)
 
+        # vanilla slot indices
+        slot_idx = list(range(len(input_ids)))
+
         self.nest_sequences(
             input_ids,
             position_ids,  # will be auto-inferred if None
             input_pos=0,  # no cache history
             page_assignments=page_assignments,  # vanilla page assignments
+            slot_idx=slot_idx,  # vanilla slot indices
             **extra_args,
         )
 
@@ -614,6 +622,7 @@ class SequenceInfo:
         position_ids: Optional[Sequence[Sequence[int]]] = None,
         input_pos: Optional[Union[Sequence[int], int]] = None,
         page_assignments: Optional[Sequence[Sequence[int]]] = None,
+        slot_idx: Optional[Sequence[int]] = None,
         **extra_args: Dict[str, Union[torch.Tensor, Sequence[torch.Tensor]]],
     ) -> None:
         """Create and store sequence information for the next forward pass.
@@ -623,6 +632,7 @@ class SequenceInfo:
             position_ids: List of sequences of position_ids for each token.
             input_pos: Absolute starting position in the cache for each sequence.
             page_assignments: List of sequences of page assignments for each sequence.
+            slot_idx: List of slot indices for each sequence.
             extra_args: Extra arguments to be stored in the interface.
 
         This i/f will ensure that all sequence info args are updated accordingly.
@@ -648,6 +658,10 @@ class SequenceInfo:
             )
             self._store_arg("cache_loc", cache_loc, reset=True)
             self._store_arg("pages_per_seq", pages_per_seq, reset=True)
+
+        # check for updated slot_idx
+        if slot_idx is not None:
+            self._store_arg("slot_idx", slot_idx)
 
         ### UPDATE MAIN INPUTS #####################################################################
         # set new input_ids and make sure to flatten it
@@ -750,6 +764,7 @@ class PrepareMetadataCallable(Protocol):
         input_pos: torch.Tensor,
         cache_loc: torch.Tensor,
         pages_per_seq: torch.Tensor,
+        slot_idx: torch.Tensor,
         page_size: int,
     ) -> List[torch.Tensor]: ...
 
@@ -835,6 +850,9 @@ class AttentionDescriptor(ABC):
             seq_len: torch.Tensor,
             input_pos: torch.Tensor,
             cache_loc: torch.Tensor,
+            pages_per_seq: torch.Tensor,
+            slot_idx: torch.Tensor,
+            page_size: int,
         ) -> List[torch.Tensor]: ...
         ```
         The metadata should contain all necessary global information required for the underlying

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/cuda_backend_causal_conv.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/cuda_backend_causal_conv.py
@@ -1,0 +1,365 @@
+"""CUDA-backed cached causal conv1d custom ops and attention descriptor.
+
+This mirrors `torch_backend_causal_conv.py` but reuses existing TRT-LLM CUDA
+operators for performance:
+- Prefill uses `torch.ops.trtllm.causal_conv1d_fwd`
+- Decode uses `torch.ops.trtllm.causal_conv1d_update`
+
+The flattened cached op integrates with the auto_deploy attention interface
+and updates a slot-indexed convolution state cache internally.
+"""
+
+from typing import List, Optional, Tuple
+
+import torch
+from torch._ops import OpOverloadPacket
+from torch.fx import Node
+
+from tensorrt_llm._torch.modules.mamba import PAD_SLOT_ID
+
+from ..utils.node_utils import extract_op_args
+from .attention_interface import (
+    AttentionDescriptor,
+    AttentionLayout,
+    AttentionRegistry,
+    BufferInitializerDict,
+    CacheConfig,
+    CacheInitializerDict,
+    Constant,
+    MHACallable,
+    PrepareMetadataCallable,
+    SequenceInfo,
+)
+
+
+def _build_conv_state_from_sequence(input_bt_c: torch.Tensor, kernel_size: int) -> torch.Tensor:
+    """Builds a convolution state of fixed window `kernel_size` from a sequence.
+
+    input_bt_c: [B, T, C]
+    Returns: [B, C, K]
+    """
+    # [B, T, C] -> [B, C, T]
+    input_b_c_t = input_bt_c.transpose(1, 2)
+    seq_len = input_b_c_t.shape[-1]
+    if seq_len >= kernel_size:
+        return input_b_c_t[..., -kernel_size:]
+    pad_amount = kernel_size - seq_len
+    # F.pad last dim (time) with (pad_left, pad_right)
+    return torch.nn.functional.pad(input_b_c_t, (pad_amount, 0))
+
+
+def _cuda_causal_conv1d_prefill(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    stride: int,
+    padding: int,
+    dilation: int,
+    groups: int,
+    padding_mode: str,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Prefill path using TRT-LLM forward kernel; returns (y, conv_state[K-1])."""
+    assert padding_mode == "zeros", "padding_mode must be zeros"
+    # Shapes: convert input to [B, C, T]
+    x_b_c_t = input.transpose(1, 2).contiguous()
+    k = weight.shape[-1]
+    # Weight to [C, K]
+    w2d = weight.squeeze(1) if weight.ndim == 3 else weight
+    w2d = w2d.contiguous()
+    # Initialize state [B, C, K-1] to zeros
+    conv_state = torch.zeros(
+        x_b_c_t.shape[0], x_b_c_t.shape[1], k - 1, device=x_b_c_t.device, dtype=x_b_c_t.dtype
+    )
+    # Run TRT forward (in-place on x_b_c_t and conv_state)
+    torch.ops.trtllm.causal_conv1d_fwd(
+        x_b_c_t, w2d, bias, conv_state, None, None, None, False, PAD_SLOT_ID
+    )
+    y = x_b_c_t.transpose(1, 2)
+    return y, conv_state
+
+
+def _cuda_causal_conv1d_decode(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    stride: int,
+    padding: int,
+    dilation: int,
+    groups: int,
+    padding_mode: str,
+    conv_state_cache: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Decode path using TRT-LLM update kernel for last-step output and cache update.
+
+    Returns (y, updated_conv_state) where y: [B, 1, C_out] and updated state: [B, C_in, K].
+    """
+    assert padding_mode == "zeros", "padding_mode must be zeros"
+    # For cached decode we currently support stride=1 and dilation=1 (standard causal conv)
+    assert stride == 1, "cached causal conv1d currently supports stride == 1 only"
+    assert dilation == 1, "cached causal conv1d currently supports dilation == 1 only"
+
+    batch_size, seq_len, _ = input.shape
+    assert seq_len == 1, "decode path expects seq_len == 1"
+
+    kernel_size = weight.shape[-1]
+    # TRT update expects state len >= K-1
+    assert conv_state_cache.shape[-1] >= kernel_size - 1, (
+        "conv_state_cache's last dim must be >= kernel_size - 1"
+    )
+
+    # TRT-LLM update kernel expects depthwise form: weight [dim, width], groups == dim
+    in_channels = input.shape[-1]
+    assert groups == in_channels, (
+        "cuda cached causal conv decode currently supports depthwise conv with groups == in_channels"
+    )
+    # Convert weight to [dim, width]
+    if weight.ndim == 3:
+        # Expect [C_out, C_in/groups, K] with C_in/groups == 1
+        assert weight.shape[-2] == 1 and weight.shape[0] == in_channels, (
+            "expected depthwise weight with shape [C, 1, K] matching input channels"
+        )
+        weight_2d = weight.squeeze(-2)
+    elif weight.ndim == 2:
+        weight_2d = weight
+        assert weight_2d.shape[0] == in_channels, (
+            "weight rows must match input channels for depthwise conv"
+        )
+    else:
+        raise AssertionError("unsupported weight rank for causal conv update; expected 2D or 3D")
+
+    # Prepare buffers for TRT-LLM update kernel call.
+    # TRT-LLM update kernel signature (Python):
+    # torch.ops.trtllm.causal_conv1d_update(x, conv_state, weight, bias,
+    #                                       activation_val, cache_seqlens,
+    #                                       conv_state_indices, pad_slot_id)
+    # We set activation to None and other optional args to None to get a plain linear conv.
+    # Convert input to [B, C, T]
+    x_b_c_t = input.transpose(1, 2).contiguous()
+    updated_cache = conv_state_cache.clone()
+    torch.ops.trtllm.causal_conv1d_update(
+        x_b_c_t, updated_cache, weight_2d, bias, False, None, None, PAD_SLOT_ID
+    )
+    y = x_b_c_t.transpose(1, 2)
+    return y, updated_cache
+
+
+# ---------------------------------------------------------------
+# Metadata + flattened cached op that integrates with the AD i/f
+# ---------------------------------------------------------------
+
+
+@torch.library.custom_op("auto_deploy::cuda_causal_conv_prepare_metadata", mutates_args=())
+def cuda_causal_conv_prepare_metadata(
+    input_ids: torch.Tensor,
+    position_ids: torch.Tensor,
+    seq_len: torch.Tensor,
+    input_pos: torch.Tensor,
+    cache_loc: torch.Tensor,
+    pages_per_seq: torch.Tensor,
+    slot_idx: torch.Tensor,
+    page_size: int,
+) -> List[torch.Tensor]:
+    """Prepare metadata for cached causal conv (CUDA backend).
+
+    Returns a tuple of (seq_len_sanitized, seq_start, slot_idx_sanitized).
+    """
+    seq_len_sanitized = SequenceInfo._get_sanitized_seq_len(input_ids, seq_len)
+    num_seq = len(seq_len_sanitized)
+
+    seq_start = torch.zeros_like(seq_len_sanitized)
+    if num_seq > 1:
+        seq_start[1:] = torch.cumsum(seq_len_sanitized[:-1], 0)
+
+    slot_idx_sanitized = slot_idx[:num_seq].clone().to(torch.long)
+
+    return (seq_len_sanitized, seq_start, slot_idx_sanitized)
+
+
+@cuda_causal_conv_prepare_metadata.register_fake
+def cuda_causal_conv_prepare_metadata_fake(
+    input_ids, position_ids, seq_len, input_pos, cache_loc, pages_per_seq, slot_idx, page_size
+):
+    seq_len_sanitized = SequenceInfo._get_sanitized_seq_len(input_ids, seq_len)
+    num_seq = len(seq_len_sanitized)
+    return (
+        torch.empty_like(seq_len_sanitized),
+        torch.empty_like(seq_len_sanitized),
+        torch.empty(num_seq, dtype=torch.long, device=slot_idx.device),
+    )
+
+
+@torch.library.custom_op("auto_deploy::cuda_cached_causal_conv1d", mutates_args={})
+def _cuda_cached_causal_conv1d(
+    # INPUTS (dense but may be flattened across sequences)
+    input: torch.Tensor,  # [b, s, c_in]
+    weight: torch.Tensor,  # [c_out, c_in/groups, k] but we expect depthwise use: [c_in, k]
+    bias: Optional[torch.Tensor],
+    # METADATA
+    seq_len: torch.Tensor,  # [num_seq]
+    seq_start: torch.Tensor,  # [num_seq]
+    slot_idx: torch.Tensor,  # [num_seq]
+    # CACHES
+    conv_state_cache: torch.Tensor,  # [max_batch_size, c_in, k-1]
+    # CONSTANTS
+    stride: int,
+    padding: int,
+    dilation: int,
+    groups: int,
+    padding_mode: str,
+) -> torch.Tensor:
+    """Flattened cached causal conv that respects slot-indexed state caches (CUDA backend).
+
+    Supports two layouts from the attention interface:
+    - Generate-only: input is [b, 1, c_in]. We'll gather caches using slot_idx[:b].
+    - Flattened context/mixed: input is [1, total_s, c_in] and seq_len/seq_start
+      describe per-sequence segments. We'll process each segment and scatter final states to caches.
+    """
+    b, s = input.shape[:2]
+    num_seq = seq_len.shape[0]
+
+    if s == 1:
+        # Generate-only batch
+        slot_idx_long = slot_idx.to(torch.long)
+        cache_batch = conv_state_cache.index_select(0, slot_idx_long)
+
+        y, updated_state = _cuda_causal_conv1d_decode(
+            input,
+            weight,
+            bias,
+            stride,
+            padding,
+            dilation,
+            groups,
+            padding_mode,
+            cache_batch,
+        )
+
+        conv_state_cache.index_copy_(0, slot_idx_long, updated_state.to(conv_state_cache.dtype))
+        # Custom op must not return an alias of any input; return a fresh tensor
+        return y.to(input.dtype).contiguous().clone()
+
+    # Context/mixed phase (flattened sequences)
+    bs = b * s
+    flat_idx = torch.arange(bs, device=input.device, dtype=torch.long)
+
+    inp_flat = input.reshape(bs, *input.shape[2:])
+    y = torch.empty(b, s, weight.shape[0], device=input.device, dtype=input.dtype)
+    y_flat = y.view(bs, *y.shape[2:])
+
+    for i in range(num_seq):
+        length_i = seq_len[i]
+        if length_i.eq(0):
+            continue
+        start_i = seq_start[i]
+        end_i = start_i + length_i
+
+        mask_i = (flat_idx >= start_i.to(torch.long)) & (flat_idx < end_i.to(torch.long))
+        idx_i = torch.nonzero(mask_i, as_tuple=False).squeeze(-1)
+
+        inp_seq = inp_flat.index_select(0, idx_i).unsqueeze(0)
+
+        y_seq, conv_state_i = _cuda_causal_conv1d_prefill(
+            inp_seq,
+            weight,
+            bias,
+            stride,
+            padding,
+            dilation,
+            groups,
+            padding_mode,
+        )
+
+        y_flat.index_copy_(0, idx_i, y_seq[0].to(y_flat.dtype))
+
+        slot_i = slot_idx[i].to(torch.long).unsqueeze(0)
+        conv_state_cache.index_copy_(0, slot_i, conv_state_i.to(conv_state_cache.dtype))
+
+    # Custom op must not return an alias of any input; return a fresh tensor
+    return y.contiguous().clone()
+
+
+@_cuda_cached_causal_conv1d.register_fake
+def _cuda_cached_causal_conv1d_fake(
+    # INPUTS
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    # METADATA
+    seq_len: torch.Tensor,
+    seq_start: torch.Tensor,
+    slot_idx: torch.Tensor,
+    # CACHES
+    conv_state_cache: torch.Tensor,
+    # CONSTANTS
+    stride: int,
+    padding: int,
+    dilation: int,
+    groups: int,
+    padding_mode: str,
+):
+    return torch.empty(
+        input.shape[0], input.shape[1], weight.shape[0], device=input.device, dtype=input.dtype
+    )
+
+
+@AttentionRegistry.register("cuda_causal_conv")
+class CudaBackendCausalConv(AttentionDescriptor):
+    @classmethod
+    def is_paged(cls) -> bool:
+        return True
+
+    @classmethod
+    def get_attention_layout(cls) -> AttentionLayout:
+        # Hidden states follow [b, s, c]
+        return "bsnd"
+
+    @classmethod
+    def get_num_qkv_args(cls) -> int:
+        # torch_causal_conv1d signature has 3 relevant tensor arguments
+        # TODO: bias can be optional!! How to handle None bias here?
+        return 3
+
+    @classmethod
+    def get_source_attention_op(cls) -> OpOverloadPacket:
+        return torch.ops.auto_deploy.torch_causal_conv1d
+
+    @classmethod
+    def get_cached_attention_op(cls) -> MHACallable:
+        return torch.ops.auto_deploy.cuda_cached_causal_conv1d
+
+    @classmethod
+    def get_prepare_metadata_op(cls) -> Tuple[PrepareMetadataCallable, int]:
+        # Returns (seq_len, seq_start, slot_idx)
+        return torch.ops.auto_deploy.cuda_causal_conv_prepare_metadata, 3
+
+    @classmethod
+    def get_cache_initializers(
+        cls, source_attn_node: Node, cache_config: CacheConfig
+    ) -> CacheInitializerDict:
+        inp_fake: torch.Tensor = source_attn_node.args[0].meta["val"]
+        w_fake: torch.Tensor = source_attn_node.args[1].meta["val"]
+
+        in_channels = inp_fake.shape[-1]
+        kernel_size = w_fake.shape[-1]
+
+        def _get_conv_cache(si: SequenceInfo):
+            return torch.empty(
+                si.max_batch_size,
+                in_channels,
+                max(1, kernel_size - 1),
+                device=si.device,
+                dtype=cache_config.dtype or inp_fake.dtype,
+            )
+
+        return {"conv_state_cache": _get_conv_cache}
+
+    @classmethod
+    def get_global_buffer_initializers(cls, source_attn_node: Node) -> BufferInitializerDict:
+        return {}
+
+    @classmethod
+    def get_constants(cls, source_attn_node: Node) -> List[Constant]:
+        stride, padding, dilation, groups, padding_mode = extract_op_args(
+            source_attn_node, "stride", "padding", "dilation", "groups", "padding_mode"
+        )
+        return [stride, padding, dilation, groups, padding_mode]

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/cuda_backend_causal_conv.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/cuda_backend_causal_conv.py
@@ -16,6 +16,7 @@ from torch._ops import OpOverloadPacket
 from torch.fx import Node
 
 from tensorrt_llm._torch.modules.mamba import PAD_SLOT_ID
+from tensorrt_llm._torch.modules.mamba.causal_conv1d import causal_conv1d_fn, causal_conv1d_update
 
 from ..utils.node_utils import extract_op_args
 from .attention_interface import (
@@ -48,106 +49,9 @@ def _build_conv_state_from_sequence(input_bt_c: torch.Tensor, kernel_size: int) 
     return torch.nn.functional.pad(input_b_c_t, (pad_amount, 0))
 
 
-def _cuda_causal_conv1d_prefill(
-    input: torch.Tensor,
-    weight: torch.Tensor,
-    bias: Optional[torch.Tensor],
-    stride: int,
-    padding: int,
-    dilation: int,
-    groups: int,
-    padding_mode: str,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Prefill path using TRT-LLM forward kernel; returns (y, conv_state[K-1])."""
-    assert padding_mode == "zeros", "padding_mode must be zeros"
-    # Shapes: convert input to [B, C, T]
-    x_b_c_t = input.transpose(1, 2).contiguous()
-    k = weight.shape[-1]
-    # Weight to [C, K]
-    w2d = weight.squeeze(1) if weight.ndim == 3 else weight
-    w2d = w2d.contiguous()
-    # Initialize state [B, C, K-1] to zeros
-    conv_state = torch.zeros(
-        x_b_c_t.shape[0], x_b_c_t.shape[1], k - 1, device=x_b_c_t.device, dtype=x_b_c_t.dtype
-    )
-    # Run TRT forward (in-place on x_b_c_t and conv_state)
-    torch.ops.trtllm.causal_conv1d_fwd(
-        x_b_c_t, w2d, bias, conv_state, None, None, None, False, PAD_SLOT_ID
-    )
-    y = x_b_c_t.transpose(1, 2)
-    return y, conv_state
-
-
-def _cuda_causal_conv1d_decode(
-    input: torch.Tensor,
-    weight: torch.Tensor,
-    bias: Optional[torch.Tensor],
-    stride: int,
-    padding: int,
-    dilation: int,
-    groups: int,
-    padding_mode: str,
-    conv_state_cache: torch.Tensor,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Decode path using TRT-LLM update kernel for last-step output and cache update.
-
-    Returns (y, updated_conv_state) where y: [B, 1, C_out] and updated state: [B, C_in, K].
-    """
-    assert padding_mode == "zeros", "padding_mode must be zeros"
-    # For cached decode we currently support stride=1 and dilation=1 (standard causal conv)
-    assert stride == 1, "cached causal conv1d currently supports stride == 1 only"
-    assert dilation == 1, "cached causal conv1d currently supports dilation == 1 only"
-
-    batch_size, seq_len, _ = input.shape
-    assert seq_len == 1, "decode path expects seq_len == 1"
-
-    kernel_size = weight.shape[-1]
-    # TRT update expects state len >= K-1
-    assert conv_state_cache.shape[-1] >= kernel_size - 1, (
-        "conv_state_cache's last dim must be >= kernel_size - 1"
-    )
-
-    # TRT-LLM update kernel expects depthwise form: weight [dim, width], groups == dim
-    in_channels = input.shape[-1]
-    assert groups == in_channels, (
-        "cuda cached causal conv decode currently supports depthwise conv with groups == in_channels"
-    )
-    # Convert weight to [dim, width]
-    if weight.ndim == 3:
-        # Expect [C_out, C_in/groups, K] with C_in/groups == 1
-        assert weight.shape[-2] == 1 and weight.shape[0] == in_channels, (
-            "expected depthwise weight with shape [C, 1, K] matching input channels"
-        )
-        weight_2d = weight.squeeze(-2)
-    elif weight.ndim == 2:
-        weight_2d = weight
-        assert weight_2d.shape[0] == in_channels, (
-            "weight rows must match input channels for depthwise conv"
-        )
-    else:
-        raise AssertionError("unsupported weight rank for causal conv update; expected 2D or 3D")
-
-    # Prepare buffers for TRT-LLM update kernel call.
-    # TRT-LLM update kernel signature (Python):
-    # torch.ops.trtllm.causal_conv1d_update(x, conv_state, weight, bias,
-    #                                       activation_val, cache_seqlens,
-    #                                       conv_state_indices, pad_slot_id)
-    # We set activation to None and other optional args to None to get a plain linear conv.
-    # Convert input to [B, C, T]
-    x_b_c_t = input.transpose(1, 2).contiguous()
-    updated_cache = conv_state_cache.clone()
-    torch.ops.trtllm.causal_conv1d_update(
-        x_b_c_t, updated_cache, weight_2d, bias, False, None, None, PAD_SLOT_ID
-    )
-    y = x_b_c_t.transpose(1, 2)
-    return y, updated_cache
-
-
 # ---------------------------------------------------------------
 # Metadata + flattened cached op that integrates with the AD i/f
 # ---------------------------------------------------------------
-
-
 @torch.library.custom_op("auto_deploy::cuda_causal_conv_prepare_metadata", mutates_args=())
 def cuda_causal_conv_prepare_metadata(
     input_ids: torch.Tensor,
@@ -217,62 +121,86 @@ def _cuda_cached_causal_conv1d(
     b, s = input.shape[:2]
     num_seq = seq_len.shape[0]
 
+    # Split by lengths: assume prefills first, decodes after
     if s == 1:
-        # Generate-only batch
-        slot_idx_long = slot_idx.to(torch.long)
-        cache_batch = conv_state_cache.index_select(0, slot_idx_long)
+        num_prefill = 0
+        num_decode = num_seq
+    else:
+        prefill_mask = seq_len > 1
+        num_prefill = int(prefill_mask.sum().item())
+        num_decode = num_seq - num_prefill
 
-        y, updated_state = _cuda_causal_conv1d_decode(
-            input,
-            weight,
-            bias,
-            stride,
-            padding,
-            dilation,
-            groups,
-            padding_mode,
-            cache_batch,
-        )
-
-        conv_state_cache.index_copy_(0, slot_idx_long, updated_state.to(conv_state_cache.dtype))
-        # Custom op must not return an alias of any input; return a fresh tensor
-        return y.to(input.dtype).contiguous().clone()
-
-    # Context/mixed phase (flattened sequences)
+    # Flatten tokens
     bs = b * s
-    flat_idx = torch.arange(bs, device=input.device, dtype=torch.long)
-
-    inp_flat = input.reshape(bs, *input.shape[2:])
+    inp_flat = input.reshape(bs, *input.shape[2:])  # [total_s, C_in]
     y = torch.empty(b, s, weight.shape[0], device=input.device, dtype=input.dtype)
     y_flat = y.view(bs, *y.shape[2:])
 
-    for i in range(num_seq):
-        length_i = seq_len[i]
-        if length_i.eq(0):
-            continue
-        start_i = seq_start[i]
-        end_i = start_i + length_i
+    # Prepare weight as [dim, width] (depthwise)
+    if weight.ndim == 3:
+        assert weight.shape[-2] == 1
+        w2d = weight.squeeze(-2)
+    else:
+        w2d = weight
 
-        mask_i = (flat_idx >= start_i.to(torch.long)) & (flat_idx < end_i.to(torch.long))
-        idx_i = torch.nonzero(mask_i, as_tuple=False).squeeze(-1)
+    total_prefill_tokens = 0
 
-        inp_seq = inp_flat.index_select(0, idx_i).unsqueeze(0)
+    # PREFILL: concatenate all prefill tokens and run one varlen forward
+    if num_prefill > 0:
+        seq_len_prefill = seq_len[:num_prefill].to(torch.int32)
+        total_prefill_tokens = int(seq_len_prefill.sum().item())
 
-        y_seq, conv_state_i = _cuda_causal_conv1d_prefill(
-            inp_seq,
-            weight,
+        # x_varlen: (dim, cu_seq_len)
+        x_varlen = inp_flat[:total_prefill_tokens].transpose(0, 1).contiguous()
+
+        # Metadata
+        cu_seqlens = torch.cat(
+            [
+                torch.zeros(1, dtype=torch.int32, device=input.device),
+                torch.cumsum(seq_len_prefill, dim=0, dtype=torch.int32),
+            ],
+            dim=0,
+        ).contiguous()
+        cache_indices = slot_idx[:num_prefill].to(torch.int32).contiguous()
+        has_initial_state = torch.zeros(num_prefill, dtype=torch.bool, device=input.device)
+
+        # Run varlen conv; updates conv_state_cache in-place per cache_indices
+        y_varlen = causal_conv1d_fn(
+            x_varlen,
+            w2d,
             bias,
-            stride,
-            padding,
-            dilation,
-            groups,
-            padding_mode,
+            query_start_loc=cu_seqlens,
+            cache_indices=cache_indices,
+            has_initial_state=has_initial_state,
+            conv_states=conv_state_cache,
+            activation=None,
+            pad_slot_id=PAD_SLOT_ID,
+        )  # (dim, total_prefill_tokens)
+
+        # Scatter outputs back to y
+        y_prefill = y_varlen.transpose(0, 1)  # [total_prefill_tokens, C_out]
+        y_flat[:total_prefill_tokens].copy_(y_prefill.to(y_flat.dtype))
+
+    # DECODE: batch update for single-token sequences
+    if num_decode > 0:
+        # Use true start offsets for decode tokens (tail after prefills)
+        decode_idx = seq_start[num_prefill:].to(torch.long)
+        x_decode = inp_flat.index_select(0, decode_idx)  # [num_decode, C_in]
+
+        y_dec = causal_conv1d_update(
+            x_decode,  # [batch, dim]
+            conv_state_cache,
+            w2d,
+            bias,
+            activation=None,
+            cache_seqlens=None,
+            conv_state_indices=slot_idx[num_prefill:].to(torch.int32),
+            pad_slot_id=PAD_SLOT_ID,
         )
 
-        y_flat.index_copy_(0, idx_i, y_seq[0].to(y_flat.dtype))
-
-        slot_i = slot_idx[i].to(torch.long).unsqueeze(0)
-        conv_state_cache.index_copy_(0, slot_i, conv_state_i.to(conv_state_cache.dtype))
+        if y_dec.dim() == 3:
+            y_dec = y_dec.squeeze(-1)
+        y_flat.index_copy_(0, decode_idx, y_dec.to(y_flat.dtype))
 
     # Custom op must not return an alias of any input; return a fresh tensor
     return y.contiguous().clone()

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/flashinfer_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/flashinfer_attention.py
@@ -161,6 +161,7 @@ def prepare_flashinfer_metadata(
     input_pos: torch.Tensor,
     cache_loc: torch.Tensor,
     pages_per_seq: torch.Tensor,
+    slot_idx: torch.Tensor,
     page_size: int,
 ) -> List[torch.Tensor]:
     """Prepare metadata for flashinfer attention.
@@ -213,7 +214,7 @@ def prepare_flashinfer_metadata(
 # As SequenceInfo._get_sanitized_num_sequences could break in fake mode
 @prepare_flashinfer_metadata.register_fake
 def prepare_flashinfer_metadata_fake(
-    input_ids, position_ids, seq_len, input_pos, cache_loc, pages_per_seq, page_size
+    input_ids, position_ids, seq_len, input_pos, cache_loc, pages_per_seq, slot_idx, page_size
 ):
     seq_len = SequenceInfo._get_sanitized_seq_len(input_ids, seq_len)
     qo_indptr = torch.empty(len(seq_len) + 1, dtype=seq_len.dtype, device=seq_len.device)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/flashinfer_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/flashinfer_attention.py
@@ -415,8 +415,8 @@ class FlashInferAttention(AttentionDescriptor):
         else:
             scale = source_attn_node.kwargs.get("scale", None)
 
-        if not isinstance(scale, float):
-            ad_logger.warning("Provided scale is not a float. Using default scale instead.")
+        if not (isinstance(scale, float) or scale is None):
+            ad_logger.warning(f"Provided {scale=}, is not a float. Using default scale instead.")
             scale = None
 
         return [

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mla.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mla.py
@@ -181,6 +181,7 @@ def prepare_fused_mla_metadata(
     input_pos: torch.Tensor,
     cache_loc: torch.Tensor,
     pages_per_seq: torch.Tensor,
+    slot_idx: torch.Tensor,
     page_size: int,
 ) -> List[torch.Tensor]:
     num_seq = SequenceInfo._get_sanitized_num_sequences(input_ids, seq_len)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_backend_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_backend_attention.py
@@ -477,8 +477,8 @@ class TorchBackendAttention(AttentionDescriptor):
             scale = source_attn_node.kwargs.get("scale", None)
 
         # Validate scale
-        if not isinstance(scale, float):
-            ad_logger.warning("Provided scale is not a float. Using default scale instead.")
+        if not (isinstance(scale, float) or scale is None):
+            ad_logger.warning(f"Provided {scale=}, is not a float. Using default scale instead.")
             scale = None
 
         # Get sinks, sliding_window, and logit_cap from args or kwargs

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_backend_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_backend_attention.py
@@ -362,6 +362,7 @@ def torch_backend_prepare_metadata(
     input_pos: torch.Tensor,
     cache_loc: torch.Tensor,
     pages_per_seq: torch.Tensor,
+    slot_idx: torch.Tensor,
     page_size: int,
 ) -> List[torch.Tensor]:
     """Prepare metadata for torch backend attention (similar to triton backend)."""
@@ -378,7 +379,7 @@ def torch_backend_prepare_metadata(
 
 @torch_backend_prepare_metadata.register_fake
 def torch_backend_prepare_metadata_fake(
-    input_ids, position_ids, seq_len, input_pos, cache_loc, pages_per_seq, page_size
+    input_ids, position_ids, seq_len, input_pos, cache_loc, pages_per_seq, slot_idx, page_size
 ):
     num_seq = SequenceInfo._get_sanitized_num_sequences(input_ids, seq_len)
     return (

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_backend_causal_conv.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_backend_causal_conv.py
@@ -1,0 +1,354 @@
+"""Custom op collection for cached causal conv1d in pure PyTorch.
+
+This mirrors the structure used by the cached Mamba/SSM ops:
+- clean functional interface identical to the uncached op plus cache argument at the end
+- prefill vs decode handled internally
+- cache read/write handled internally
+
+In addition, this file provides an AttentionDescriptor-compatible flattened cached op
+and a metadata op to integrate with the auto_deploy attention interface.
+"""
+
+from typing import List, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch._ops import OpOverloadPacket
+from torch.fx import Node
+
+from ..utils.node_utils import extract_op_args
+from .attention_interface import (
+    AttentionDescriptor,
+    AttentionLayout,
+    AttentionRegistry,
+    BufferInitializerDict,
+    CacheConfig,
+    CacheInitializerDict,
+    Constant,
+    MHACallable,
+    PrepareMetadataCallable,
+    SequenceInfo,
+)
+
+
+def _build_conv_state_from_sequence(input_bt_c: torch.Tensor, kernel_size: int) -> torch.Tensor:
+    """Builds a convolution state of fixed window `kernel_size` from a sequence.
+
+    input_bt_c: [B, T, C]
+    Returns: [B, C, K]
+    """
+    # [B, T, C] -> [B, C, T]
+    input_b_c_t = input_bt_c.transpose(1, 2)
+    seq_len = input_b_c_t.shape[-1]
+    if seq_len >= kernel_size:
+        return input_b_c_t[..., -kernel_size:]
+    pad_amount = kernel_size - seq_len
+    return F.pad(input_b_c_t, (pad_amount, 0))
+
+
+def _torch_causal_conv1d_prefill(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    stride: int,
+    padding: int,
+    dilation: int,
+    groups: int,
+    padding_mode: str,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Prefill path: compute full conv and produce initial cache state.
+
+    Returns (y, conv_state) where y: [B, T, C_out] and conv_state: [B, C_in, K].
+    """
+    assert padding_mode == "zeros", "padding_mode must be zeros"
+
+    batch_size, seq_len, _ = input.shape
+    # Reuse the uncached op for the actual convolution
+    y = torch.ops.auto_deploy.torch_causal_conv1d(
+        input,
+        weight,
+        bias,
+        stride,
+        padding,
+        dilation,
+        groups,
+        padding_mode,
+    )
+
+    kernel_size = weight.shape[-1]
+    conv_state = _build_conv_state_from_sequence(input, kernel_size)
+    return y, conv_state
+
+
+def _torch_causal_conv1d_decode(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    stride: int,
+    padding: int,
+    dilation: int,
+    groups: int,
+    padding_mode: str,
+    conv_state_cache: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Decode path: update cache with the latest token and compute the last output.
+
+    Returns (y, updated_conv_state) where y: [B, 1, C_out] and updated state: [B, C_in, K].
+    """
+    assert padding_mode == "zeros", "padding_mode must be zeros"
+    # For cached decode we currently support stride=1 and dilation=1 (standard causal conv)
+    # This mirrors the original decode implementation assumptions for Bamba.
+    assert stride == 1, "cached causal conv1d currently supports stride == 1 only"
+    assert dilation == 1, "cached causal conv1d currently supports dilation == 1 only"
+
+    batch_size, seq_len, _ = input.shape
+    assert seq_len == 1, "decode path expects seq_len == 1"
+
+    kernel_size = weight.shape[-1]
+    assert conv_state_cache.shape[-1] == kernel_size, (
+        "conv_state_cache's last dim must equal kernel_size"
+    )
+
+    # Update cache in-place: roll left and place the new element at the end
+    updated_cache = conv_state_cache.roll(shifts=-1, dims=-1)
+    # [B, T=1, C] -> [B, C]
+    new_sample_bc = input.transpose(1, 2)[..., 0]
+    updated_cache[:, :, -1] = new_sample_bc.to(updated_cache.dtype).to(updated_cache.device)
+
+    # Compute output for the current step using the cache window.
+    # Convert cache window [B, C_in, K] -> short sequence [B, K, C_in]
+    window_seq = updated_cache.transpose(1, 2).to(device=weight.device, dtype=weight.dtype)
+    # Reuse the uncached op with padding=0, stride=1, dilation=1 so output length == 1
+    y = torch.ops.auto_deploy.torch_causal_conv1d(
+        window_seq,
+        weight,
+        bias,
+        1,  # stride
+        0,  # padding
+        1,  # dilation
+        groups,
+        padding_mode,
+    )
+
+    return y, updated_cache
+
+
+# ---------------------------------------------------------------
+# Metadata + flattened cached op that integrates with the AD i/f
+# ---------------------------------------------------------------
+
+
+@torch.library.custom_op("auto_deploy::torch_causal_conv_prepare_metadata", mutates_args=())
+def torch_causal_conv_prepare_metadata(
+    input_ids: torch.Tensor,
+    position_ids: torch.Tensor,
+    seq_len: torch.Tensor,
+    input_pos: torch.Tensor,
+    cache_loc: torch.Tensor,
+    pages_per_seq: torch.Tensor,
+    slot_idx: torch.Tensor,
+    page_size: int,
+) -> List[torch.Tensor]:
+    """Prepare metadata for cached causal conv.
+
+    Returns a tuple of (seq_len_sanitized, seq_start, slot_idx_sanitized).
+    """
+    seq_len_sanitized = SequenceInfo._get_sanitized_seq_len(input_ids, seq_len)
+    num_seq = len(seq_len_sanitized)
+
+    seq_start = torch.zeros_like(seq_len_sanitized)
+    if num_seq > 1:
+        seq_start[1:] = torch.cumsum(seq_len_sanitized[:-1], 0)
+
+    slot_idx_sanitized = slot_idx[:num_seq].clone().to(torch.long)
+
+    return (seq_len_sanitized, seq_start, slot_idx_sanitized)
+
+
+@torch_causal_conv_prepare_metadata.register_fake
+def torch_causal_conv_prepare_metadata_fake(
+    input_ids, position_ids, seq_len, input_pos, cache_loc, pages_per_seq, slot_idx, page_size
+):
+    seq_len_sanitized = SequenceInfo._get_sanitized_seq_len(input_ids, seq_len)
+    num_seq = len(seq_len_sanitized)
+    return (
+        torch.empty_like(seq_len_sanitized),
+        torch.empty_like(seq_len_sanitized),
+        torch.empty(num_seq, dtype=torch.long, device=slot_idx.device),
+    )
+
+
+@torch.library.custom_op("auto_deploy::torch_cached_causal_conv1d", mutates_args={})
+def _torch_cached_causal_conv1d(
+    # INPUTS (dense but may be flattened across sequences)
+    input: torch.Tensor,  # [b, s, c_in]
+    weight: torch.Tensor,  # [c_out, c_in/groups, k]
+    bias: Optional[torch.Tensor],
+    # METADATA
+    seq_len: torch.Tensor,  # [num_seq]
+    seq_start: torch.Tensor,  # [num_seq]
+    slot_idx: torch.Tensor,  # [num_seq]
+    # CACHES
+    conv_state_cache: torch.Tensor,  # [max_batch_size, c_in, k]
+    # CONSTANTS
+    stride: int,
+    padding: int,
+    dilation: int,
+    groups: int,
+    padding_mode: str,
+) -> torch.Tensor:
+    """Flattened cached causal conv that respects slot-indexed state caches.
+
+    Supports two layouts from the attention interface:
+    - Generate-only: input is [b, 1, c_in]. We'll gather caches using slot_idx[:b].
+    - Flattened context/mixed: input is [1, total_s, c_in] and seq_len/seq_start
+      describe per-sequence segments. We'll process each segment and scatter final states to caches.
+    """
+    b, s = input.shape[:2]
+    num_seq = seq_len.shape[0]
+
+    if s == 1:
+        # Generate-only batch
+        slot_idx_long = slot_idx.to(torch.long)
+        cache_batch = conv_state_cache.index_select(0, slot_idx_long)
+
+        y, updated_state = _torch_causal_conv1d_decode(
+            input,
+            weight,
+            bias,
+            stride,
+            padding,
+            dilation,
+            groups,
+            padding_mode,
+            cache_batch,
+        )
+
+        conv_state_cache.index_copy_(0, slot_idx_long, updated_state.to(conv_state_cache.dtype))
+        return y.to(input.dtype)
+
+    # Context/mixed phase (flattened sequences)
+    bs = b * s
+    flat_idx = torch.arange(bs, device=input.device, dtype=torch.long)
+
+    inp_flat = input.reshape(bs, *input.shape[2:])
+    y = torch.empty(b, s, weight.shape[0], device=input.device, dtype=input.dtype)
+    y_flat = y.view(bs, *y.shape[2:])
+
+    for i in range(num_seq):
+        length_i = seq_len[i]
+        if length_i.eq(0):
+            continue
+        start_i = seq_start[i]
+        end_i = start_i + length_i
+
+        mask_i = (flat_idx >= start_i.to(torch.long)) & (flat_idx < end_i.to(torch.long))
+        idx_i = torch.nonzero(mask_i, as_tuple=False).squeeze(-1)
+
+        inp_seq = inp_flat.index_select(0, idx_i).unsqueeze(0)
+
+        y_seq, conv_state_i = _torch_causal_conv1d_prefill(
+            inp_seq,
+            weight,
+            bias,
+            stride,
+            padding,
+            dilation,
+            groups,
+            padding_mode,
+        )
+
+        y_flat.index_copy_(0, idx_i, y_seq[0].to(y_flat.dtype))
+
+        slot_i = slot_idx[i].to(torch.long).unsqueeze(0)
+        conv_state_cache.index_copy_(0, slot_i, conv_state_i.to(conv_state_cache.dtype))
+
+    return y
+
+
+@_torch_cached_causal_conv1d.register_fake
+def _torch_cached_causal_conv1d_fake(
+    # INPUTS
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    # METADATA
+    seq_len: torch.Tensor,
+    seq_start: torch.Tensor,
+    slot_idx: torch.Tensor,
+    # CACHES
+    conv_state_cache: torch.Tensor,
+    # CONSTANTS
+    stride: int,
+    padding: int,
+    dilation: int,
+    groups: int,
+    padding_mode: str,
+):
+    return torch.empty(
+        input.shape[0], input.shape[1], weight.shape[0], device=input.device, dtype=input.dtype
+    )
+
+
+@AttentionRegistry.register("torch_causal_conv")
+class TorchBackendCausalConv(AttentionDescriptor):
+    @classmethod
+    def is_paged(cls) -> bool:
+        # TODO: we should refine our notion of "is_paged" --> seems counterintuitive for ssm nows
+        return True
+
+    @classmethod
+    def get_attention_layout(cls) -> AttentionLayout:
+        # Hidden states follow [b, s, c]
+        return "bsnd"
+
+    @classmethod
+    def get_num_qkv_args(cls) -> int:
+        # torch_causal_conv1d signature has 3 relevant tensor arguments
+        # TODO: bias can be optional!! How to handle None bias here?
+        return 3
+
+    @classmethod
+    def get_source_attention_op(cls) -> OpOverloadPacket:
+        return torch.ops.auto_deploy.torch_causal_conv1d
+
+    @classmethod
+    def get_cached_attention_op(cls) -> MHACallable:
+        return torch.ops.auto_deploy.torch_cached_causal_conv1d
+
+    @classmethod
+    def get_prepare_metadata_op(cls) -> Tuple[PrepareMetadataCallable, int]:
+        # Returns (seq_len, seq_start, slot_idx)
+        return torch.ops.auto_deploy.torch_causal_conv_prepare_metadata, 3
+
+    @classmethod
+    def get_cache_initializers(
+        cls, source_attn_node: Node, cache_config: CacheConfig
+    ) -> CacheInitializerDict:
+        inp_fake: torch.Tensor = source_attn_node.args[0].meta["val"]
+        w_fake: torch.Tensor = source_attn_node.args[1].meta["val"]
+
+        in_channels = inp_fake.shape[-1]
+        kernel_size = w_fake.shape[-1]
+
+        def _get_conv_cache(si: SequenceInfo):
+            return torch.empty(
+                si.max_batch_size,
+                in_channels,
+                kernel_size,
+                device=si.device,
+                dtype=cache_config.dtype or inp_fake.dtype,
+            )
+
+        return {"conv_state_cache": _get_conv_cache}
+
+    @classmethod
+    def get_global_buffer_initializers(cls, source_attn_node: Node) -> BufferInitializerDict:
+        return {}
+
+    @classmethod
+    def get_constants(cls, source_attn_node: Node) -> List[Constant]:
+        stride, padding, dilation, groups, padding_mode = extract_op_args(
+            source_attn_node, "stride", "padding", "dilation", "groups", "padding_mode"
+        )
+        return [stride, padding, dilation, groups, padding_mode]

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_backend_mamba.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_backend_mamba.py
@@ -282,6 +282,7 @@ def _torch_cached_ssm_transform_fake(
     return torch.empty_like(
         hidden_states,
         memory_format=torch.contiguous_format,
+        dtype=torch.float32,
     )
 
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_backend_mamba.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_backend_mamba.py
@@ -1,0 +1,359 @@
+"""Custom op collection for cached mamba2 ssm transform (linear attention) in pure PyTorch.
+
+This file contains two kinds of functionality:
+1) Low-level cached SSM ops (decode + prefill) that operate on dense [batch, seq_len] inputs.
+2) AttentionDescriptor-compatible metadata/op wrappers that handle flattened sequences and slot
+   indexed SSM state caches per the auto_deploy attention interface.
+"""
+
+from typing import List, Tuple
+
+import torch
+from torch._ops import OpOverloadPacket
+from torch.fx import Node
+
+from ..utils.node_utils import extract_op_args
+from .attention_interface import (
+    AttentionDescriptor,
+    AttentionLayout,
+    AttentionRegistry,
+    BufferInitializerDict,
+    CacheConfig,
+    CacheInitializerDict,
+    Constant,
+    MHACallable,
+    PrepareMetadataCallable,
+    SequenceInfo,
+)
+from .torch_mamba import _torch_ssm_transform_prefill
+
+
+def _torch_cached_ssm_transform_decode(
+    hidden_states: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    D: torch.Tensor,
+    dt: torch.Tensor,
+    dt_bias: torch.Tensor,
+    # NOTE: `torch` custom ops do not like `Tuple` inputs. Using `List` is the suggested WAR.
+    time_step_limit: List[float],
+    chunk_size: int,
+    ssm_state_cache: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    # ) -> Tuple[torch.Tensor, torch.Tensor]:
+    # retrieve some shape information
+    batch_size, seq_len, num_heads, head_dim = hidden_states.shape
+    n_groups, ssm_state_size = B.shape[2:]
+
+    # Note: there is no need to pad parameter matrices here, as there is just one new token
+    # for batched generation
+    dt = dt[:, 0, :][:, None, ...]
+    dt = dt.transpose(1, 2).expand(batch_size, dt.shape[-1], head_dim)
+    # [num_heads] -> [num_heads, head_dim]
+    dt_bias = dt_bias[..., None].expand(dt_bias.shape[0], head_dim)
+
+    dt = torch.nn.functional.softplus(dt + dt_bias.to(dt.dtype))
+    dt = torch.clamp(dt, time_step_limit[0], time_step_limit[1])
+    A = A[..., None, None].expand(num_heads, head_dim, ssm_state_size).to(dtype=torch.float32)
+    # [bsz, num_heads, head_dim, state_size]
+    dA = torch.exp(dt[..., None] * A)
+
+    # Discretize B
+    # [bsz, n_groups * state_size] -> [bsz, n_groups, 1, state_size] ->
+    # -> [bsz, n_groups, group to head repetition factor, state_size] -> [bsz, num_heads, state_size]
+    B = B.reshape(batch_size, n_groups, -1)[..., None, :]
+    B = B.expand(batch_size, n_groups, num_heads // n_groups, B.shape[-1]).contiguous()
+    B = B.reshape(batch_size, -1, B.shape[-1])
+    # [bsz, num_heads, head_dim, state_size]
+    dB = dt[..., None] * B[..., None, :]
+
+    # Discretize x into dB
+    # [bsz, intermediate_size] -> [bsz, num_heads, head_dim]
+    hidden_states = hidden_states.reshape(batch_size, -1, head_dim)
+    dBx = dB * hidden_states[..., None]
+
+    # State calculation
+    updated_ssm_state = ssm_state_cache * dA + dBx
+
+    # Subsequent output
+    # [bsz, n_groups * state_size] -> [bsz, num_heads, state_size]
+    C = C.reshape(batch_size, n_groups, -1)[..., None, :]
+    C = C.expand(batch_size, n_groups, num_heads // n_groups, C.shape[-1]).contiguous()
+    C = C.reshape(batch_size, -1, C.shape[-1])
+    # [bsz, num_heads, head_dim]
+
+    ssm_states = updated_ssm_state.to(dtype=C.dtype)  # Shape: [b, h, d, n]
+    # Reshape ssm_states to merge the first two dimensions
+    ssm_states_reshaped = ssm_states.view(
+        batch_size * num_heads, head_dim, ssm_state_size
+    )  # Shape: [b*h, d, n]
+    C_reshaped = C.view(batch_size * num_heads, ssm_state_size, 1)  # Shape: [b*h, n, 1]
+    y = torch.bmm(ssm_states_reshaped, C_reshaped)
+    y = y.view(batch_size, num_heads, head_dim)
+
+    # D skip connection
+    # [num_heads] -> [num_heads, head_dim]
+    D = D[..., None].expand(D.shape[0], head_dim)
+    y = (y + hidden_states * D).to(y.dtype)
+
+    # [bsz, num_heads, head_dim] -> [bsz, 1, num_heads, head_dim]
+    y = y.reshape(batch_size, 1, num_heads, head_dim)
+    return y, updated_ssm_state
+
+
+def _update_ssm_state_cache(ssm_cache: torch.Tensor, ssm_state: torch.Tensor) -> None:
+    ssm_cache.copy_(ssm_state)
+
+
+# ---------------------------------------------------------------
+# Metadata + flattened cached op that integrates with the AD i/f
+# ---------------------------------------------------------------
+
+
+@torch.library.custom_op("auto_deploy::torch_ssm_prepare_metadata", mutates_args=())
+def _torch_ssm_prepare_metadata(
+    input_ids: torch.Tensor,
+    position_ids: torch.Tensor,
+    seq_len: torch.Tensor,
+    input_pos: torch.Tensor,
+    cache_loc: torch.Tensor,
+    pages_per_seq: torch.Tensor,
+    slot_idx: torch.Tensor,
+    page_size: int,
+) -> List[torch.Tensor]:
+    """Prepare metadata for cached SSM transform.
+
+    Returns a tuple of (seq_len_sanitized, seq_start, slot_idx_sanitized).
+    """
+    # Determine number of active sequences and compute seq_start boundaries
+    seq_len_sanitized = SequenceInfo._get_sanitized_seq_len(input_ids, seq_len)
+    num_seq = len(seq_len_sanitized)
+
+    seq_start = torch.zeros_like(seq_len_sanitized)
+    if num_seq > 1:
+        seq_start[1:] = torch.cumsum(seq_len_sanitized[:-1], 0)
+
+    # Truncate slot indices to match active sequences
+    slot_idx_sanitized = slot_idx[:num_seq].clone().to(torch.long)
+
+    return (seq_len_sanitized, seq_start, slot_idx_sanitized)
+
+
+@_torch_ssm_prepare_metadata.register_fake
+def _torch_ssm_prepare_metadata_fake(
+    input_ids, position_ids, seq_len, input_pos, cache_loc, pages_per_seq, slot_idx, page_size
+):
+    # Use the same sanitization logic to determine sizes in fake mode
+    seq_len_sanitized = SequenceInfo._get_sanitized_seq_len(input_ids, seq_len)
+    num_seq = len(seq_len_sanitized)
+    return (
+        torch.empty_like(seq_len_sanitized),
+        torch.empty_like(seq_len_sanitized),
+        torch.empty(num_seq, dtype=torch.long, device=slot_idx.device),
+    )
+
+
+@torch.library.custom_op("auto_deploy::torch_cached_ssm_transform", mutates_args={})
+def _torch_cached_ssm_transform(
+    # INPUTS (dense but may be flattened across sequences)
+    hidden_states: torch.Tensor,  # [b, s, num_heads, head_dim]
+    A: torch.Tensor,  # [num_heads]
+    B: torch.Tensor,  # [b, s, n_groups, ssm_state_size]
+    C: torch.Tensor,  # [b, s, n_groups, ssm_state_size]
+    D: torch.Tensor,  # [num_heads]
+    dt: torch.Tensor,  # [b, s, num_heads]
+    dt_bias: torch.Tensor,  # [num_heads]
+    # METADATA
+    seq_len: torch.Tensor,  # [num_seq]
+    seq_start: torch.Tensor,  # [num_seq]
+    slot_idx: torch.Tensor,  # [num_seq]
+    # CACHES
+    ssm_state_cache: torch.Tensor,  # [max_batch_size, num_heads, head_dim, ssm_state_size]
+    # CONSTANTS
+    time_step_limit: List[float],
+    chunk_size: int,
+) -> torch.Tensor:
+    """Flattened cached SSM transform op that respects slot-indexed state caches.
+
+    This op supports two layouts from the attention interface:
+    - Generate-only: hidden_states is [b, 1, H, D]. We'll gather caches using slot_idx[:b].
+    - Flattened context/mixed: hidden_states is [1, total_s, H, D] and seq_len/seq_start
+      describe per-sequence segments. We'll process each segment and scatter final states to caches.
+    """
+    b, s = hidden_states.shape[:2]
+    num_seq = seq_len.shape[0]
+
+    if s == 1:
+        # Generate-only batch: gather cache slices for slots (already sanitized by metadata)
+        slot_idx_long = slot_idx.to(torch.long)
+        ssm_batch = ssm_state_cache.index_select(dim=0, index=slot_idx_long)
+
+        y, updated_state = _torch_cached_ssm_transform_decode(
+            hidden_states,
+            A,
+            B,
+            C,
+            D,
+            dt,
+            dt_bias,
+            time_step_limit,
+            chunk_size,
+            ssm_batch,
+        )
+
+        # Scatter updated states back to global cache
+        ssm_state_cache.index_copy_(0, slot_idx_long, updated_state.to(ssm_state_cache.dtype))
+
+        # return in the same dtype as the input
+        return y.to(hidden_states.dtype)
+
+    # Context/mixed phase (flattened sequences). Expect b == 1, but handle general b robustly.
+    # We'll iterate over sequences defined by (seq_len, seq_start) and update state per slot.
+    # Process across the flattened second dimension.
+    # Precompute a device index for flattened positions
+    bs = b * s
+    flat_idx = torch.arange(bs, device=hidden_states.device, dtype=torch.long)
+
+    # NOTE: use reshape to force contiguous format after reshape, needed to process it sequentially
+    hs_flat = hidden_states.reshape(bs, *hidden_states.shape[2:])
+    B_flat = B.reshape(bs, *B.shape[2:])
+    C_flat = C.reshape(bs, *C.shape[2:])
+    dt_flat = dt.reshape(bs, *dt.shape[2:])
+
+    # NOTE: need contiguous format to process it sequentially
+    y = torch.empty_like(hidden_states, memory_format=torch.contiguous_format)
+    y_flat = y.view(bs, *y.shape[2:])
+
+    for i in range(num_seq):
+        length_i = seq_len[i]
+        # Skip empty sequences without synchronizing to host
+        if length_i.eq(0):
+            continue
+
+        start_i = seq_start[i]
+        end_i = start_i + length_i
+
+        # Build device indices for this sequence's token range
+        mask_i = (flat_idx >= start_i.to(torch.long)) & (flat_idx < end_i.to(torch.long))
+        idx_i = torch.nonzero(mask_i, as_tuple=False).squeeze(-1)
+
+        # Gather per-sequence views
+        hs_seq = hs_flat.index_select(0, idx_i).unsqueeze(0)
+        B_seq = B_flat.index_select(0, idx_i).unsqueeze(0)
+        C_seq = C_flat.index_select(0, idx_i).unsqueeze(0)
+        dt_seq = dt_flat.index_select(0, idx_i).unsqueeze(0)
+
+        # Run prefill and obtain final SSM state for this sequence
+        y_seq, ssm_state_i = _torch_ssm_transform_prefill(
+            hs_seq, A, B_seq, C_seq, D, dt_seq, dt_bias, time_step_limit, chunk_size
+        )
+
+        # Write outputs back using device indices
+        y_flat.index_copy_(0, idx_i, y_seq[0].to(y_flat.dtype))
+
+        # Scatter the final state to the slot-indexed cache using device index
+        slot_i = slot_idx[i].to(torch.long).unsqueeze(0)
+        ssm_state_cache.index_copy_(0, slot_i, ssm_state_i.to(ssm_state_cache.dtype))
+
+    return y
+
+
+@_torch_cached_ssm_transform.register_fake
+def _torch_cached_ssm_transform_fake(
+    # INPUTS
+    hidden_states: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    D: torch.Tensor,
+    dt: torch.Tensor,
+    dt_bias: torch.Tensor,
+    # METADATA
+    seq_len: torch.Tensor,
+    seq_start: torch.Tensor,
+    slot_idx: torch.Tensor,
+    # CACHES
+    ssm_state_cache: torch.Tensor,
+    # CONSTANTS
+    time_step_limit: List[float],
+    chunk_size: int,
+):
+    return torch.empty_like(
+        hidden_states,
+        memory_format=torch.contiguous_format,
+    )
+
+
+@AttentionRegistry.register("torch_ssm")
+class TorchBackendSSM(AttentionDescriptor):
+    @classmethod
+    def is_paged(cls) -> bool:
+        # TODO: we should refine our notion of "is_paged" --> seems counterintuitive for ssm now
+        return True
+
+    @classmethod
+    def get_attention_layout(cls) -> AttentionLayout:
+        # Hidden states follow [b, s, n, d]
+        return "bsnd"
+
+    @classmethod
+    def get_num_qkv_args(cls) -> int:
+        # torch_ssm_transform signature has 7 node/state arguments
+        return 7
+
+    @classmethod
+    def get_source_attention_op(cls) -> OpOverloadPacket:
+        return torch.ops.auto_deploy.torch_ssm_transform
+
+    @classmethod
+    def get_cached_attention_op(cls) -> MHACallable:
+        return torch.ops.auto_deploy.torch_cached_ssm_transform
+
+    @classmethod
+    def get_prepare_metadata_op(cls) -> Tuple[PrepareMetadataCallable, int]:
+        # Returns (seq_len, seq_start, slot_idx)
+        return torch.ops.auto_deploy.torch_ssm_prepare_metadata, 3
+
+    @classmethod
+    def get_cache_initializers(
+        cls, source_attn_node: Node, cache_config: CacheConfig
+    ) -> CacheInitializerDict:
+        # Shapes from fake tensors
+        hs_fake: torch.Tensor = source_attn_node.args[0].meta["val"]
+        B_fake: torch.Tensor = source_attn_node.args[2].meta["val"]
+
+        num_heads = hs_fake.shape[-2]
+        head_dim = hs_fake.shape[-1]
+
+        # Infer state size by assuming B has shape [b, s, n_groups * ssm_state_size]
+        # During runtime we pass [b, s, n_groups, ssm_state_size]; both give the same last dim product.
+        if B_fake.ndim >= 4:
+            ssm_state_size = B_fake.shape[-1]
+        else:
+            # Fallback: assume last dim is n_groups * state_size and choose a minimal positive size
+            ssm_state_size = max(1, B_fake.shape[-1])
+
+        def _get_ssm_cache(si: SequenceInfo):
+            return torch.empty(
+                si.max_batch_size,
+                num_heads,
+                head_dim,
+                ssm_state_size,
+                device=si.device,
+                dtype=cache_config.dtype or hs_fake.dtype,
+            )
+
+        return {"ssm_state_cache": _get_ssm_cache}
+
+    @classmethod
+    def get_global_buffer_initializers(cls, source_attn_node: Node) -> BufferInitializerDict:
+        return {}
+
+    @classmethod
+    def get_constants(cls, source_attn_node: Node) -> List[Constant]:
+        # time_step_limit, chunk_size should be extracted and passed in as constants
+        time_step_limit, chunk_size = extract_op_args(
+            source_attn_node, "time_step_limit", "chunk_size"
+        )
+        return [time_step_limit, chunk_size]

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_causal_conv.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_causal_conv.py
@@ -1,0 +1,46 @@
+"""Custom op collection for uncached causal conv (sliding window with 1d)."""
+
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+
+
+@torch.library.custom_op("auto_deploy::torch_causal_conv1d", mutates_args={})
+def _torch_causal_conv1d(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+    stride: int = 1,
+    padding: int = 0,
+    dilation: int = 1,
+    groups: int = 1,
+    padding_mode: str = "zeros",
+) -> torch.Tensor:
+    assert padding_mode == "zeros", "padding_mode must be zeros"
+
+    batch_size, seq_len, _ = input.shape
+
+    return F.conv1d(
+        input.transpose(1, 2),
+        weight,
+        bias,
+        stride,
+        padding,
+        dilation,
+        groups,
+    )[..., :seq_len].transpose(1, 2)
+
+
+@_torch_causal_conv1d.register_fake
+def _torch_causal_conv1d_meta(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+    stride: int = 1,
+    padding: int = 0,
+    dilation: int = 1,
+    groups: int = 1,
+    padding_mode: str = "zeros",
+) -> torch.Tensor:
+    return torch.empty_like(input)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_mamba.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_mamba.py
@@ -194,4 +194,4 @@ def _torch_ssm_transform_meta(
     time_step_limit: List[float],
     chunk_size: int,
 ) -> torch.Tensor:
-    return torch.empty_like(hidden_states)
+    return torch.empty_like(hidden_states, dtype=torch.float32)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_mamba.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_mamba.py
@@ -1,0 +1,197 @@
+"""Custom op collection for uncached mamba mixer (linear attention)."""
+
+from typing import List, Tuple
+
+import torch
+from torch import nn
+
+
+def _pad_tensor_by_size(input_tensor: torch.Tensor, pad_size: int):
+    """
+    Padding x tensor with `pad_size` on the seq_len dim (dim=1)
+
+    Assumes that we only have tensors of either size 4 or 3
+    """
+    pad_shape = (
+        (0, 0, 0, 0, 0, pad_size, 0, 0)
+        if len(input_tensor.shape) == 4
+        else (0, 0, 0, pad_size, 0, 0)
+    )
+
+    return torch.nn.functional.pad(input_tensor, pad_shape, mode="constant", value=0)
+
+
+def _reshape_into_chunks(input_tensor, pad_size, chunk_size):
+    """
+    Padding input_tensor with `pad_size` on the seq_len dim (dim=1) and
+    simultaneously splitting it into chunk sequences.
+
+    Assumes that we only have tensors of either size 4 or 3
+    """
+    # [bsz, seq_len, ...] -> [bsz, seq_len multiple of chunk_size, ...]
+    input_tensor = _pad_tensor_by_size(input_tensor, pad_size)
+
+    if len(input_tensor.shape) == 3:
+        # [bsz, seq_len multiple of chunk_size, num_heads] -> [bsz, -1, chunk_size, num_heads]
+        return input_tensor.reshape(input_tensor.shape[0], -1, chunk_size, input_tensor.shape[2])
+    else:
+        # [bsz, seq_len multiple of chunk_size, num_heads, head_dim or state_size] ->
+        # [bsz, -1, chunk_size, num_heads, head_dim or state_size]
+        return input_tensor.reshape(
+            input_tensor.shape[0], -1, chunk_size, input_tensor.shape[2], input_tensor.shape[3]
+        )
+
+
+def _segment_sum(input_tensor):
+    """
+    More stable segment sum calculation. Uses cumulative sums and masking instead of direct subtractions.
+    """
+    chunk_size = input_tensor.size(-1)
+    # 1. expand input tensor to have an additional dimension and repeat along that dimension
+    # [..., chunk_size] -> [..., chunk_size, chunk_size]
+    input_tensor = input_tensor[..., None].expand(*input_tensor.size(), chunk_size)
+    # 2. create a lower triangular mask with the diagonal set to 0 to 0 out elements above diag
+    mask = torch.tril(
+        torch.ones(chunk_size, chunk_size, device=input_tensor.device, dtype=torch.bool),
+        diagonal=-1,
+    )
+    input_tensor = input_tensor.masked_fill(~mask, 0)
+    # 3. compute actual cumsum
+    tensor_segsum = torch.cumsum(input_tensor, dim=-2)
+
+    # 4. apply mask to keep only the lower triangular part of the cumulative sum result (incl diagonal this time)
+    mask = torch.tril(
+        torch.ones(chunk_size, chunk_size, device=input_tensor.device, dtype=torch.bool), diagonal=0
+    )
+    tensor_segsum = tensor_segsum.masked_fill(~mask, -torch.inf)
+    return tensor_segsum
+
+
+def _torch_ssm_transform_prefill(
+    hidden_states: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    D: torch.Tensor,
+    dt: torch.Tensor,
+    dt_bias: torch.Tensor,
+    time_step_limit: List[
+        float
+    ],  # NOTE: `torch` custom ops do not like `Tuple` inputs. Using `List` is the suggested WAR.
+    chunk_size: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    # retrieve some shape information
+    batch_size, seq_len, num_heads, head_dim = hidden_states.shape
+    n_groups, ssm_state_size = B.shape[2:]
+
+    # !! This is the uncached code path from the original implementation.
+    # begin ssd naive implementation without einsums
+    dt = nn.functional.softplus(dt + dt_bias)
+    dt = torch.clamp(dt, time_step_limit[0], time_step_limit[1])
+    hidden_states = hidden_states.reshape(batch_size, seq_len, num_heads, head_dim).float()
+    B = B.reshape(batch_size, seq_len, n_groups, ssm_state_size).float()
+    C = C.reshape(batch_size, seq_len, n_groups, ssm_state_size).float()
+    B = B.repeat_interleave(num_heads // n_groups, dim=2, output_size=num_heads)
+    C = C.repeat_interleave(num_heads // n_groups, dim=2, output_size=num_heads)
+    pad_size = (chunk_size - seq_len % chunk_size) % chunk_size
+
+    D_residual = D[..., None] * _pad_tensor_by_size(hidden_states, pad_size)
+
+    # Discretize x and A
+    hidden_states = hidden_states * dt[..., None]
+    A = A.to(hidden_states.dtype) * dt
+
+    # Rearrange into blocks/chunks
+    hidden_states, A, B, C = [
+        _reshape_into_chunks(t, pad_size, chunk_size) for t in (hidden_states, A, B, C)
+    ]
+
+    # [bsz, -1, chunk_size, num_heads] -> [bsz, num_heads, -1, chunk_size]
+    A = A.permute(0, 3, 1, 2)
+    A_cumsum = torch.cumsum(A, dim=-1)
+
+    # 1. Compute the output for each intra-chunk (diagonal blocks)
+    # This is the analog of a causal mask
+    L = torch.exp(_segment_sum(A))
+
+    # Contraction of C and B to get G (attention-weights like)
+    G_intermediate = C[:, :, :, None, :, :] * B[:, :, None, :, :, :]  # shape: (b, c, l, s, h, n)
+    G = G_intermediate.sum(dim=-1)  # shape: (b, c, l, s, h)
+
+    # Compute M, equivalent to applying attention mask to weights
+    M_intermediate = G[..., None] * L.permute(0, 2, 3, 4, 1)[..., None]
+    M = M_intermediate.sum(dim=-1)
+
+    # Compute Y_diag (apply to values)
+    Y_diag = (M[..., None] * hidden_states[:, :, None]).sum(dim=3)
+
+    # 2. Compute the state for each intra-chunk
+    # (right term of low-rank factorization of off-diagonal blocks; B terms)
+    decay_states = torch.exp(A_cumsum[:, :, :, -1:] - A_cumsum)
+    B_decay = B * decay_states.permute(0, -2, -1, 1)[..., None]
+    states = (B_decay[..., None, :] * hidden_states[..., None]).sum(dim=2)
+
+    # 3. Compute the inter-chunk SSM recurrence; produces correct SSM states at chunk boundaries
+    # (middle term of factorization of off-diag blocks; A terms)
+    previous_states = torch.zeros_like(states[:, :1])
+    states = torch.cat([previous_states, states], dim=1)
+    decay_chunk = torch.exp(_segment_sum(nn.functional.pad(A_cumsum[:, :, :, -1], (1, 0))))
+    decay_chunk = decay_chunk.transpose(1, 3)
+    new_states = (decay_chunk[..., None, None] * states[:, :, None, ...]).sum(dim=1)
+    states, ssm_state = new_states[:, :-1], new_states[:, -1]
+    # states = new_states[:, :-1]
+
+    # 4. Compute state -> output conversion per chunk
+    # (left term of low-rank factorization of off-diagonal blocks; C terms)
+    state_decay_out = torch.exp(A_cumsum)
+    C_times_states = C[..., None, :] * states[:, :, None, ...]
+    state_decay_out_permuted = state_decay_out.permute(0, 2, 3, 1)
+    Y_off = C_times_states.sum(-1) * state_decay_out_permuted[..., None]
+
+    # Add output of intra-chunk and inter-chunk terms (diagonal and off-diagonal blocks)
+    y = Y_diag + Y_off
+    # [bsz, -1, self.chunk_size, num_heads, head_dim] -> [bsz, (padded) seq_len, num_heads, head_dim]
+    y = y.reshape(batch_size, -1, num_heads, head_dim)
+
+    y = y + D_residual
+    # Cutting off padded chunks
+    if pad_size > 0:
+        y = y[:, :seq_len, :, :]
+    y = y.reshape(batch_size, seq_len, num_heads, head_dim)
+
+    return y, ssm_state
+
+
+@torch.library.custom_op("auto_deploy::torch_ssm_transform", mutates_args={})
+def _torch_ssm_transform(
+    hidden_states: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    D: torch.Tensor,
+    dt: torch.Tensor,
+    dt_bias: torch.Tensor,
+    time_step_limit: List[
+        float
+    ],  # NOTE: `torch` custom ops do not like `Tuple` inputs. Using `List` is the suggested WAR.
+    chunk_size: int,
+) -> torch.Tensor:
+    y, _ = _torch_ssm_transform_prefill(
+        hidden_states, A, B, C, D, dt, dt_bias, time_step_limit, chunk_size
+    )
+    return y
+
+
+@_torch_ssm_transform.register_fake
+def _torch_ssm_transform_meta(
+    hidden_states: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    D: torch.Tensor,
+    dt: torch.Tensor,
+    dt_bias: torch.Tensor,
+    time_step_limit: List[float],
+    chunk_size: int,
+) -> torch.Tensor:
+    return torch.empty_like(hidden_states)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_attention.py
@@ -408,8 +408,8 @@ class TritonAttention(AttentionDescriptor):
 
         # do a sanity check on the scale if it is not None, we only support the default scale
         # of 1/sqrt(head_dim) and so we should do an approximate check for that one
-        if not isinstance(scale, float):
-            ad_logger.warning("Provided scale is not a float, Using default scale instead.")
+        if not (isinstance(scale, float) or scale is None):
+            ad_logger.warning(f"Provided {scale=} is not a float. Using default scale instead.")
             scale = None
         # Get sinks and sliding_window from args or kwargs
         sinks = extract_op_args(source_attn_node, "sinks")[0]

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_attention.py
@@ -290,8 +290,10 @@ def prepare_fused_mha_metadata(
     input_pos: torch.Tensor,
     cache_loc: torch.Tensor,
     pages_per_seq: torch.Tensor,
+    slot_idx: torch.Tensor,
     page_size: int,
 ) -> List[torch.Tensor]:
+    # TODO: maybe use slot_idx instead of pages_per_seq??
     num_seq = SequenceInfo._get_sanitized_num_sequences(input_ids, seq_len)
     seq_start = torch.zeros_like(seq_len[:num_seq])
     seq_start[1:] = torch.cumsum(seq_len[: num_seq - 1], 0)
@@ -307,7 +309,7 @@ def prepare_fused_mha_metadata(
 # SequenceInfo._get_sanitized_num_sequences could break in fake mode
 @prepare_fused_mha_metadata.register_fake
 def prepare_fused_mha_metadata_fake(
-    input_ids, position_ids, seq_len, input_pos, cache_loc, pages_per_seq, page_size
+    input_ids, position_ids, seq_len, input_pos, cache_loc, pages_per_seq, slot_idx, page_size
 ):
     num_seq = SequenceInfo._get_sanitized_num_sequences(input_ids, seq_len)
     return (

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_backend_mamba.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_backend_mamba.py
@@ -1,0 +1,253 @@
+from typing import List, Tuple
+
+import torch
+from torch._ops import OpOverloadPacket
+from torch.fx import Node
+
+# Triton kernels
+from tensorrt_llm._torch.modules.mamba.selective_state_update import selective_state_update
+from tensorrt_llm._torch.modules.mamba.ssd_combined import mamba_chunk_scan_combined
+
+from ..utils.node_utils import extract_op_args
+from .attention_interface import (
+    AttentionDescriptor,
+    AttentionLayout,
+    AttentionRegistry,
+    BufferInitializerDict,
+    CacheConfig,
+    CacheInitializerDict,
+    Constant,
+    MHACallable,
+    PrepareMetadataCallable,
+    SequenceInfo,
+)
+
+
+@torch.library.custom_op("auto_deploy::triton_cached_ssm_transform", mutates_args={})
+def _triton_cached_ssm_transform(
+    # INPUTS (dense but may be flattened across sequences)
+    hidden_states: torch.Tensor,  # [b, s, num_heads, head_dim]
+    A: torch.Tensor,  # [num_heads]
+    B: torch.Tensor,  # [b, s, n_groups, ssm_state_size]
+    C: torch.Tensor,  # [b, s, n_groups, ssm_state_size]
+    D: torch.Tensor,  # [num_heads]
+    dt: torch.Tensor,  # [b, s, num_heads]
+    dt_bias: torch.Tensor,  # [num_heads]
+    # METADATA
+    seq_len: torch.Tensor,  # [num_seq]
+    seq_start: torch.Tensor,  # [num_seq]
+    slot_idx: torch.Tensor,  # [num_seq]
+    # CACHES
+    ssm_state_cache: torch.Tensor,  # [max_batch_size, num_heads, head_dim, ssm_state_size]
+    # CONSTANTS
+    time_step_limit: List[float],
+    chunk_size: int,
+) -> torch.Tensor:
+    """Flattened cached SSM transform op that respects slot-indexed state caches.
+
+    Implements generate-only (s==1) via selective_state_update and prefill/mixed (s>1) via
+    mamba_chunk_scan_combined, updating the slot-indexed cache in-op. Returns y only.
+    """
+    b, s = hidden_states.shape[:2]
+    num_seq = seq_len.shape[0]
+
+    if s == 1:
+        # Generate-only batch: gather cache slices for slots (already sanitized by metadata)
+        slot_idx_long = slot_idx.to(torch.long)
+        ssm_batch = ssm_state_cache.index_select(dim=0, index=slot_idx_long)
+
+        # Shapes
+        batch_size = b
+        num_heads = hidden_states.shape[2]
+        head_dim = hidden_states.shape[3]
+        n_groups = B.shape[2]
+        ssm_state_size = B.shape[3]
+
+        # Prepare per-head, per-dim tensors
+        dt_hp = dt[:, 0, :][:, :, None].expand(batch_size, num_heads, head_dim)
+        dt_bias_hp = dt_bias[..., None].expand(num_heads, head_dim)
+        dt_pre = torch.nn.functional.softplus(dt_hp + dt_bias_hp.to(dtype=dt_hp.dtype))
+        dt_pre = torch.clamp(dt_pre, time_step_limit[0], time_step_limit[1])
+        A_full = A[..., None, None].expand(num_heads, head_dim, ssm_state_size)
+        D_full = D[..., None].expand(num_heads, head_dim)
+        B_grouped = B.reshape(batch_size, n_groups, ssm_state_size)
+        C_grouped = C.reshape(batch_size, n_groups, ssm_state_size)
+        x = hidden_states.reshape(batch_size, num_heads, head_dim)
+
+        # compute new state; avoid mutating input cache slice
+        updated_state = ssm_batch.clone()
+        # Provide a zero dt_bias tensor to satisfy kernel arg expansion; we've already
+        # applied dt_bias and softplus/clamp into dt_pre above.
+        dt_bias_zero = torch.zeros_like(dt_bias_hp)
+        y_hp = selective_state_update(
+            updated_state,
+            x,
+            dt_pre,
+            A_full,
+            B_grouped,
+            C_grouped,
+            D=D_full,
+            z=None,
+            dt_bias=dt_bias_zero,
+            dt_softplus=False,
+        )
+        y = y_hp.reshape(batch_size, 1, num_heads, head_dim)
+
+        # Scatter updated states back to global cache
+        ssm_state_cache.index_copy_(0, slot_idx_long, updated_state.to(ssm_state_cache.dtype))
+
+        return y.to(hidden_states.dtype)
+
+    # Context/mixed phase (flattened sequences). Expect b == 1, but handle general b robustly.
+    bs = b * s
+    flat_idx = torch.arange(bs, device=hidden_states.device, dtype=torch.long)
+
+    # NOTE: use reshape to force contiguous format after reshape
+    hs_flat = hidden_states.reshape(bs, *hidden_states.shape[2:])
+    B_flat = B.reshape(bs, *B.shape[2:])
+    C_flat = C.reshape(bs, *C.shape[2:])
+    dt_flat = dt.reshape(bs, *dt.shape[2:])
+
+    # NOTE: need contiguous format to process it sequentially
+    y = torch.empty_like(hidden_states, memory_format=torch.contiguous_format)
+    y_flat = y.view(bs, *y.shape[2:])
+
+    for i in range(num_seq):
+        length_i = seq_len[i]
+        if length_i.eq(0):
+            continue
+
+        start_i = seq_start[i]
+        end_i = start_i + length_i
+
+        mask_i = (flat_idx >= start_i.to(torch.long)) & (flat_idx < end_i.to(torch.long))
+        idx_i = torch.nonzero(mask_i, as_tuple=False).squeeze(-1)
+
+        hs_seq = hs_flat.index_select(0, idx_i).unsqueeze(0)
+        B_seq = B_flat.index_select(0, idx_i).unsqueeze(0)
+        C_seq = C_flat.index_select(0, idx_i).unsqueeze(0)
+        dt_seq = dt_flat.index_select(0, idx_i).unsqueeze(0)
+
+        y_seq, ssm_state_i = mamba_chunk_scan_combined(
+            hs_seq,
+            dt_seq,
+            A,
+            B_seq,
+            C_seq,
+            chunk_size=chunk_size,
+            D=D,
+            z=None,
+            dt_bias=dt_bias,
+            seq_idx=None,
+            dt_softplus=True,
+            dt_limit=(time_step_limit[0], time_step_limit[1]),
+            return_final_states=True,
+        )
+
+        y_flat.index_copy_(0, idx_i, y_seq[0].to(y_flat.dtype))
+
+        slot_i = slot_idx[i].to(torch.long).unsqueeze(0)
+        ssm_state_cache.index_copy_(0, slot_i, ssm_state_i.to(ssm_state_cache.dtype))
+
+    return y
+
+
+@_triton_cached_ssm_transform.register_fake
+def _triton_cached_ssm_transform_fake(
+    # INPUTS (dense but may be flattened across sequences)
+    hidden_states: torch.Tensor,  # [b, s, num_heads, head_dim]
+    A: torch.Tensor,  # [num_heads]
+    B: torch.Tensor,  # [b, s, n_groups, ssm_state_size]
+    C: torch.Tensor,  # [b, s, n_groups, ssm_state_size]
+    D: torch.Tensor,  # [num_heads]
+    dt: torch.Tensor,  # [b, s, num_heads]
+    dt_bias: torch.Tensor,  # [num_heads]
+    # METADATA
+    seq_len: torch.Tensor,  # [num_seq]
+    seq_start: torch.Tensor,  # [num_seq]
+    slot_idx: torch.Tensor,  # [num_seq]
+    # CACHES
+    ssm_state_cache: torch.Tensor,  # [max_batch_size, num_heads, head_dim, ssm_state_size]
+    # CONSTANTS
+    time_step_limit: List[float],
+    chunk_size: int,
+):
+    # Return a correctly-shaped tensor for tracing with fake tensors
+    return torch.empty_like(
+        hidden_states,
+        memory_format=torch.contiguous_format,
+        dtype=hidden_states.dtype,
+    )
+
+
+## Note: we reuse the existing metadata custom op and its registered fake from torch backend.
+
+
+@AttentionRegistry.register("triton_ssm")
+class TritonBackendSSM(AttentionDescriptor):
+    @classmethod
+    def is_paged(cls) -> bool:
+        return True
+
+    @classmethod
+    def get_attention_layout(cls) -> AttentionLayout:
+        # Hidden states follow [b, s, n, d]
+        return "bsnd"
+
+    @classmethod
+    def get_num_qkv_args(cls) -> int:
+        # torch_ssm_transform signature has 7 node/state arguments
+        return 7
+
+    @classmethod
+    def get_source_attention_op(cls) -> OpOverloadPacket:
+        # Keep source op unchanged (used for uncached pre-export)
+        return torch.ops.auto_deploy.torch_ssm_transform
+
+    @classmethod
+    def get_cached_attention_op(cls) -> MHACallable:
+        return torch.ops.auto_deploy.triton_cached_ssm_transform
+
+    @classmethod
+    def get_prepare_metadata_op(cls) -> Tuple[PrepareMetadataCallable, int]:
+        # Returns (seq_len, seq_start, slot_idx)
+        return torch.ops.auto_deploy.torch_ssm_prepare_metadata, 3
+
+    @classmethod
+    def get_cache_initializers(
+        cls, source_attn_node: Node, cache_config: CacheConfig
+    ) -> CacheInitializerDict:
+        # Shapes from fake tensors
+        hs_fake: torch.Tensor = source_attn_node.args[0].meta["val"]
+        B_fake: torch.Tensor = source_attn_node.args[2].meta["val"]
+
+        num_heads = hs_fake.shape[-2]
+        head_dim = hs_fake.shape[-1]
+
+        if B_fake.ndim >= 4:
+            ssm_state_size = B_fake.shape[-1]
+        else:
+            ssm_state_size = max(1, B_fake.shape[-1])
+
+        def _get_ssm_cache(si: SequenceInfo):
+            return torch.empty(
+                si.max_batch_size,
+                num_heads,
+                head_dim,
+                ssm_state_size,
+                device=si.device,
+                dtype=cache_config.dtype or hs_fake.dtype,
+            )
+
+        return {"ssm_state_cache": _get_ssm_cache}
+
+    @classmethod
+    def get_global_buffer_initializers(cls, source_attn_node: Node) -> BufferInitializerDict:
+        return {}
+
+    @classmethod
+    def get_constants(cls, source_attn_node: Node) -> List[Constant]:
+        time_step_limit, chunk_size = extract_op_args(
+            source_attn_node, "time_step_limit", "chunk_size"
+        )
+        return [time_step_limit, chunk_size]

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_backend_mamba.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_backend_mamba.py
@@ -45,109 +45,116 @@ def _triton_cached_ssm_transform(
 ) -> torch.Tensor:
     """Flattened cached SSM transform op that respects slot-indexed state caches.
 
-    Implements generate-only (s==1) via selective_state_update and prefill/mixed (s>1) via
-    mamba_chunk_scan_combined, updating the slot-indexed cache in-op. Returns y only.
+    Split mixed batches into prefill (seq_len>1) and decode (seq_len==1):
+    - Prefill: run one varlen combined scan over concatenated prefill tokens and update final states per slot.
+    - Decode: batch single-token updates with selective_state_update and update states per slot.
     """
     b, s = hidden_states.shape[:2]
     num_seq = seq_len.shape[0]
 
+    # Flatten tokens for indexing/scatter
+    bs = b * s
+    device = hidden_states.device
+    hs_flat = hidden_states.reshape(bs, *hidden_states.shape[2:])  # [bs, H, D]
+    B_flat = B.reshape(bs, *B.shape[2:])  # [bs, G, N]
+    C_flat = C.reshape(bs, *C.shape[2:])  # [bs, G, N]
+    dt_flat = dt.reshape(bs, dt.shape[2])  # [bs, H]
+
+    y = torch.empty_like(hidden_states, memory_format=torch.contiguous_format)
+    y_flat = y.view(bs, *y.shape[2:])
+
+    num_heads = hidden_states.shape[2]
+    head_dim = hidden_states.shape[3]
+    ssm_state_size = B.shape[3]
+
     if s == 1:
-        # Generate-only batch: gather cache slices for slots (already sanitized by metadata)
-        slot_idx_long = slot_idx.to(torch.long)
-        ssm_batch = ssm_state_cache.index_select(dim=0, index=slot_idx_long)
+        num_prefill = 0
+        num_decode = num_seq
+    else:
+        prefill_mask = seq_len > 1
+        num_prefill = int(prefill_mask.sum().item())
+        num_decode = num_seq - num_prefill
 
-        # Shapes
-        batch_size = b
-        num_heads = hidden_states.shape[2]
-        head_dim = hidden_states.shape[3]
-        n_groups = B.shape[2]
-        ssm_state_size = B.shape[3]
+    # Prefill: concatenate tokens at the front and run combined scan
+    if num_prefill > 0:
+        seq_len_prefill = seq_len[:num_prefill].to(torch.int32)
+        total_prefill_tokens = int(seq_len_prefill.sum().item())
+        prefill_idx = torch.arange(total_prefill_tokens, device=device, dtype=torch.long)
 
-        # Prepare per-head, per-dim tensors
-        dt_hp = dt[:, 0, :][:, :, None].expand(batch_size, num_heads, head_dim)
+        hs_prefill = hs_flat.index_select(0, prefill_idx).unsqueeze(0)  # [1, S_p, H, D]
+        B_prefill = B_flat.index_select(0, prefill_idx).unsqueeze(0)  # [1, S_p, G, N]
+        C_prefill = C_flat.index_select(0, prefill_idx).unsqueeze(0)  # [1, S_p, G, N]
+        dt_prefill = dt_flat.index_select(0, prefill_idx).unsqueeze(0)  # [1, S_p, H]
+
+        cu_seqlens = torch.cat(
+            [
+                torch.zeros(1, dtype=torch.int32, device=device),
+                torch.cumsum(seq_len_prefill, dim=0),
+            ],
+            dim=0,
+        )
+        seq_ids = torch.arange(num_prefill, device=device, dtype=torch.int32)
+        seq_idx_prefill = torch.repeat_interleave(seq_ids, seq_len_prefill).view(1, -1)
+
+        y_prefill, varlen_states = mamba_chunk_scan_combined(
+            hs_prefill,
+            dt_prefill,
+            A,
+            B_prefill,
+            C_prefill,
+            chunk_size=chunk_size,
+            D=D,
+            z=None,
+            dt_bias=dt_bias,
+            initial_states=None,
+            seq_idx=seq_idx_prefill,
+            chunk_indices=None,
+            chunk_offsets=None,
+            cu_seqlens=cu_seqlens,
+            dt_softplus=True,
+            dt_limit=(time_step_limit[0], time_step_limit[1]),
+            return_final_states=False,
+            return_varlen_states=True,
+        )
+
+        y_flat.index_copy_(0, prefill_idx, y_prefill[0].to(y_flat.dtype))
+        ssm_state_cache.index_copy_(
+            0, slot_idx[:num_prefill].to(torch.long), varlen_states.to(ssm_state_cache.dtype)
+        )
+
+    # Decode: batch single-token updates via selective_state_update
+    if num_decode > 0:
+        decode_idx = seq_start[num_prefill:].to(torch.long)
+        slot_idx_decode = slot_idx[num_prefill:].to(torch.long)
+
+        x_decode = hs_flat.index_select(0, decode_idx)  # [nd, H, D]
+        B_decode = B_flat.index_select(0, decode_idx)  # [nd, G, N]
+        C_decode = C_flat.index_select(0, decode_idx)  # [nd, G, N]
+        dt_decode = dt_flat.index_select(0, decode_idx)  # [nd, H]
+
+        dt_hp = dt_decode[:, :, None].expand(-1, num_heads, head_dim)
         dt_bias_hp = dt_bias[..., None].expand(num_heads, head_dim)
         dt_pre = torch.nn.functional.softplus(dt_hp + dt_bias_hp.to(dtype=dt_hp.dtype))
         dt_pre = torch.clamp(dt_pre, time_step_limit[0], time_step_limit[1])
         A_full = A[..., None, None].expand(num_heads, head_dim, ssm_state_size)
         D_full = D[..., None].expand(num_heads, head_dim)
-        B_grouped = B.reshape(batch_size, n_groups, ssm_state_size)
-        C_grouped = C.reshape(batch_size, n_groups, ssm_state_size)
-        x = hidden_states.reshape(batch_size, num_heads, head_dim)
 
-        # compute new state; avoid mutating input cache slice
-        updated_state = ssm_batch.clone()
-        # Provide a zero dt_bias tensor to satisfy kernel arg expansion; we've already
-        # applied dt_bias and softplus/clamp into dt_pre above.
         dt_bias_zero = torch.zeros_like(dt_bias_hp)
-        y_hp = selective_state_update(
-            updated_state,
-            x,
+        y_dec = selective_state_update(
+            ssm_state_cache,
+            x_decode,
             dt_pre,
             A_full,
-            B_grouped,
-            C_grouped,
+            B_decode,
+            C_decode,
             D=D_full,
             z=None,
             dt_bias=dt_bias_zero,
             dt_softplus=False,
-        )
-        y = y_hp.reshape(batch_size, 1, num_heads, head_dim)
+            state_batch_indices=slot_idx_decode,
+        )  # [nd, H, D]
 
-        # Scatter updated states back to global cache
-        ssm_state_cache.index_copy_(0, slot_idx_long, updated_state.to(ssm_state_cache.dtype))
-
-        return y.to(hidden_states.dtype)
-
-    # Context/mixed phase (flattened sequences). Expect b == 1, but handle general b robustly.
-    bs = b * s
-    flat_idx = torch.arange(bs, device=hidden_states.device, dtype=torch.long)
-
-    # NOTE: use reshape to force contiguous format after reshape
-    hs_flat = hidden_states.reshape(bs, *hidden_states.shape[2:])
-    B_flat = B.reshape(bs, *B.shape[2:])
-    C_flat = C.reshape(bs, *C.shape[2:])
-    dt_flat = dt.reshape(bs, *dt.shape[2:])
-
-    # NOTE: need contiguous format to process it sequentially
-    y = torch.empty_like(hidden_states, memory_format=torch.contiguous_format)
-    y_flat = y.view(bs, *y.shape[2:])
-
-    for i in range(num_seq):
-        length_i = seq_len[i]
-        if length_i.eq(0):
-            continue
-
-        start_i = seq_start[i]
-        end_i = start_i + length_i
-
-        mask_i = (flat_idx >= start_i.to(torch.long)) & (flat_idx < end_i.to(torch.long))
-        idx_i = torch.nonzero(mask_i, as_tuple=False).squeeze(-1)
-
-        hs_seq = hs_flat.index_select(0, idx_i).unsqueeze(0)
-        B_seq = B_flat.index_select(0, idx_i).unsqueeze(0)
-        C_seq = C_flat.index_select(0, idx_i).unsqueeze(0)
-        dt_seq = dt_flat.index_select(0, idx_i).unsqueeze(0)
-
-        y_seq, ssm_state_i = mamba_chunk_scan_combined(
-            hs_seq,
-            dt_seq,
-            A,
-            B_seq,
-            C_seq,
-            chunk_size=chunk_size,
-            D=D,
-            z=None,
-            dt_bias=dt_bias,
-            seq_idx=None,
-            dt_softplus=True,
-            dt_limit=(time_step_limit[0], time_step_limit[1]),
-            return_final_states=True,
-        )
-
-        y_flat.index_copy_(0, idx_i, y_seq[0].to(y_flat.dtype))
-
-        slot_i = slot_idx[i].to(torch.long).unsqueeze(0)
-        ssm_state_cache.index_copy_(0, slot_i, ssm_state_i.to(ssm_state_cache.dtype))
+        y_flat.index_copy_(0, decode_idx, y_dec.to(y_flat.dtype))
 
     return y
 

--- a/tensorrt_llm/_torch/auto_deploy/llm.py
+++ b/tensorrt_llm/_torch/auto_deploy/llm.py
@@ -1,6 +1,8 @@
 import types
 from typing import Any, Dict, List, Optional, Tuple
 
+import torch
+
 from ...executor.result import CompletionOutput
 from ...inputs.registry import DefaultInputProcessor, ExtraProcessedInputs
 from ...llmapi.llm import RequestOutput, _TorchLLM
@@ -41,6 +43,9 @@ class ADInputProcessor(DefaultInputProcessor):
             }
         # check for messages field and if yes, use the apply_chat_template method
         if "messages" in inputs:
+            # multi_modal_data should not be present in the messages field
+            assert "multi_modal_data" not in inputs, f"unexpected multi_modal_data key in {inputs=}"
+
             # TODO: we don't really need this but it makes for a good sanity check. Consider
             # removing this in the future if we need to speed things up.
             prompt = self.processor.apply_chat_template(
@@ -60,6 +65,25 @@ class ADInputProcessor(DefaultInputProcessor):
                 return_attention_mask=False,
                 **kwargs,
             )
+        # check if multi_modal_data has already been pre-processed/added to the inputs
+        # for example, this might be the case when invoking AD via trtllm-serve
+        elif "multi_modal_data" in inputs:
+            images = inputs["multi_modal_data"]["image"]
+            if images is not None and isinstance(images[0], torch.Tensor):
+                # The default multimodal input loader will normalize images to [0, 1] when the requested
+                # format is "pt" (pytorch tensors), but not for "pil" (PIL images).
+                do_rescale = False
+            all_args = self.processor(
+                text=inputs["prompt"],
+                images=images,
+                return_dict=True,
+                return_tensors="pt",
+                do_rescale=do_rescale,
+            )
+        else:
+            all_args = None
+
+        if all_args is not None:
             # TODO: is there a more reliable way to avoid the attention_mask here?
             all_args.pop("attention_mask", None)
 

--- a/tensorrt_llm/_torch/auto_deploy/llm_args.py
+++ b/tensorrt_llm/_torch/auto_deploy/llm_args.py
@@ -207,6 +207,7 @@ class AutoDeployConfig(DynamicYamlMixInForSettings, BaseSettings):
     # TODO: discuss what to do with this once we fully transition to the new inference optimizer
     def update_attn_page_size(self):
         # NOTE force attn_page_size to equal max_seq_len for triton backend
+        # TODO: maybe don't do this and rely on slot_idx instead??
         if self.attn_backend == "triton" or self.attn_backend == "torch":
             self.attn_page_size = self.max_seq_len
         return self

--- a/tensorrt_llm/_torch/auto_deploy/models/patches/bamba.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/patches/bamba.py
@@ -1,0 +1,434 @@
+"""A patch for the Bamba model to make it compatible with torch.export."""
+
+from typing import List, Optional, Tuple
+
+import torch
+from torch import nn
+from transformers.models.bamba.modeling_bamba import (
+    BambaMixer,
+    BambaModel,
+    BambaPreTrainedModel,
+    HybridMambaAttentionDynamicCache,
+    apply_mask_to_padding_states,
+    pad_tensor_by_size,
+    reshape_into_chunks,
+    segment_sum,
+)
+
+from ...export.interface import BaseExportPatch, ExportPatchRegistry
+
+
+# Original implementation:
+# https://github.com/huggingface/transformers/blob/06f8004e5cd9d06cfbffc3f47afb6c2b43bcb3d2/
+# src/transformers/models/bamba/modeling_bamba.py#L719
+# NOTE: we remove the cache-related code paths.
+def _bamba_mixer_torch_forward(
+    self,
+    input_states,
+    cache_params: Optional[HybridMambaAttentionDynamicCache] = None,
+    cache_position: Optional[torch.LongTensor] = None,
+    attention_mask: Optional[torch.Tensor] = None,
+):
+    # `input_states` is of shape `[B, T, hidden_dim]`, and during generate, each successive call
+    # will have T = T + 1.
+    batch_size, seq_len, _ = input_states.shape
+    dtype = input_states.dtype
+
+    # 1. Gated MLP's linear projection
+    input_states = apply_mask_to_padding_states(input_states, attention_mask)
+    projected_states = self.in_proj(input_states)
+    gate, hidden_states_B_C, dt = projected_states.split(
+        [self.intermediate_size, self.conv_dim, self.num_heads], dim=-1
+    )
+
+    use_precomputed_states = (
+        cache_params is not None
+        and cache_params.has_previous_state
+        and seq_len == 1
+        and cache_params.conv_states[self.layer_idx].shape[0]
+        == cache_params.ssm_states[self.layer_idx].shape[0]
+        == batch_size
+        and cache_position is not None
+        and cache_position[0] > 0
+    )
+
+    # 2. Convolution sequence transformation
+    if use_precomputed_states:
+        cache_params.conv_states[self.layer_idx] = cache_params.conv_states[self.layer_idx].roll(
+            shifts=-1, dims=-1
+        )
+        cache_params.conv_states[self.layer_idx][:, :, -1] = hidden_states_B_C[:, 0, :].to(
+            cache_params.conv_states[self.layer_idx].device
+        )
+
+        # We need to guarantee that anything regarding the cache is on the same device
+        conv_states = cache_params.conv_states[self.layer_idx].to(device=self.conv1d.weight.device)
+
+        hidden_states_B_C = torch.sum(conv_states * self.conv1d.weight.squeeze(1), dim=-1)
+        if self.use_conv_bias:
+            hidden_states_B_C = hidden_states_B_C + self.conv1d.bias
+        hidden_states_B_C = self.act(hidden_states_B_C)
+    else:
+        # Init cache
+        if cache_params is not None:
+            hidden_states_B_C_transposed = hidden_states_B_C.transpose(1, 2)
+            conv_states = nn.functional.pad(
+                hidden_states_B_C_transposed,
+                (self.conv_kernel_size - hidden_states_B_C_transposed.shape[-1], 0),
+            )
+            cache_params.conv_states[self.layer_idx].copy_(conv_states)
+
+        hidden_states_B_C = self.act(
+            self.conv1d(hidden_states_B_C.transpose(1, 2))[..., :seq_len].transpose(1, 2)
+        )
+
+    hidden_states_B_C = apply_mask_to_padding_states(hidden_states_B_C, attention_mask)
+    hidden_states, B, C = torch.split(
+        hidden_states_B_C,
+        [
+            self.intermediate_size,
+            self.n_groups * self.ssm_state_size,
+            self.n_groups * self.ssm_state_size,
+        ],
+        dim=-1,
+    )
+
+    # 3. SSM transformation
+    A = -torch.exp(self.A_log.float())  # [num_heads]
+    if use_precomputed_states:
+        y, ssm_state = torch.ops.auto_deploy.ssm_transform_cached(
+            hidden_states=hidden_states,
+            A=A,
+            B=B,
+            C=C,
+            D=self.D,
+            dt=dt,
+            dt_bias=self.dt_bias,
+            ssm_state_size=self.ssm_state_size,
+            time_step_limit=list(self.time_step_limit),
+            batch_size=batch_size,
+            seq_len=seq_len,
+            head_dim=self.head_dim,
+            num_heads=self.num_heads,
+            n_groups=self.n_groups,
+            chunk_size=self.chunk_size,
+            cached_ssm_state=cache_params.ssm_states[self.layer_idx],
+        )
+    else:
+        y, ssm_state = torch.ops.auto_deploy.ssm_transform(
+            hidden_states=hidden_states,
+            A=A,
+            B=B,
+            C=C,
+            D=self.D,
+            dt=dt,
+            dt_bias=self.dt_bias,
+            ssm_state_size=self.ssm_state_size,
+            time_step_limit=list(self.time_step_limit),
+            batch_size=batch_size,
+            seq_len=seq_len,
+            head_dim=self.head_dim,
+            num_heads=self.num_heads,
+            n_groups=self.n_groups,
+            chunk_size=self.chunk_size,
+        )
+
+    # Init cache
+    if ssm_state is not None and cache_params is not None:
+        cache_params.ssm_states[self.layer_idx].copy_(ssm_state)
+
+    scan_output = self.norm(y, gate)
+
+    # end ssd naive
+    # !! This is the end of the uncached code path.
+
+    # 4. Final linear projection
+    contextualized_states = self.out_proj(scan_output.to(dtype))  # [batch, seq_len, hidden_size]
+    return contextualized_states
+
+
+# The original implementation looks at `cache_position[0]` to decide what to do which does not
+# play well with export. Plus, we do not want it to be updated anyway.
+def _bamba_model_update_mamba_mask(self, attention_mask, cache_position):
+    return None
+
+
+@torch.library.custom_op("auto_deploy::ssm_transform", mutates_args={})
+def _ssm_transform(
+    hidden_states: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    D: torch.Tensor,
+    dt: torch.Tensor,
+    dt_bias: torch.Tensor,
+    ssm_state_size: int,
+    # NOTE: `torch` custom ops do not like `Tuple` inputs. Using `List` is the suggested WAR.
+    time_step_limit: List[float],
+    batch_size: int,
+    seq_len: int,
+    head_dim: int,
+    num_heads: int,
+    n_groups: int,
+    chunk_size: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    # !! This is the uncached code path from the original implementation.
+    # begin ssd naive implementation without einsums
+    dt = nn.functional.softplus(dt + dt_bias)
+    dt = torch.clamp(dt, time_step_limit[0], time_step_limit[1])
+    hidden_states = hidden_states.reshape(batch_size, seq_len, -1, head_dim).float()
+    B = B.reshape(batch_size, seq_len, -1, ssm_state_size).float()
+    C = C.reshape(batch_size, seq_len, -1, ssm_state_size).float()
+    B = B.repeat_interleave(num_heads // n_groups, dim=2, output_size=num_heads)
+    C = C.repeat_interleave(num_heads // n_groups, dim=2, output_size=num_heads)
+    pad_size = (chunk_size - seq_len % chunk_size) % chunk_size
+
+    D_residual = D[..., None] * pad_tensor_by_size(hidden_states, pad_size)
+
+    # Discretize x and A
+    hidden_states = hidden_states * dt[..., None]
+    A = A.to(hidden_states.dtype) * dt
+
+    # Rearrange into blocks/chunks
+    hidden_states, A, B, C = [
+        reshape_into_chunks(t, pad_size, chunk_size) for t in (hidden_states, A, B, C)
+    ]
+
+    # [bsz, -1, chunk_size, num_heads] -> [bsz, num_heads, -1, chunk_size]
+    A = A.permute(0, 3, 1, 2)
+    A_cumsum = torch.cumsum(A, dim=-1)
+
+    # 1. Compute the output for each intra-chunk (diagonal blocks)
+    # This is the analog of a causal mask
+    L = torch.exp(segment_sum(A))
+
+    # Contraction of C and B to get G (attention-weights like)
+    G_intermediate = C[:, :, :, None, :, :] * B[:, :, None, :, :, :]  # shape: (b, c, l, s, h, n)
+    G = G_intermediate.sum(dim=-1)  # shape: (b, c, l, s, h)
+
+    # Compute M, equivalent to applying attention mask to weights
+    M_intermediate = G[..., None] * L.permute(0, 2, 3, 4, 1)[..., None]
+    M = M_intermediate.sum(dim=-1)
+
+    # Compute Y_diag (apply to values)
+    Y_diag = (M[..., None] * hidden_states[:, :, None]).sum(dim=3)
+
+    # 2. Compute the state for each intra-chunk
+    # (right term of low-rank factorization of off-diagonal blocks; B terms)
+    decay_states = torch.exp(A_cumsum[:, :, :, -1:] - A_cumsum)
+    B_decay = B * decay_states.permute(0, -2, -1, 1)[..., None]
+    states = (B_decay[..., None, :] * hidden_states[..., None]).sum(dim=2)
+
+    # 3. Compute the inter-chunk SSM recurrence; produces correct SSM states at chunk boundaries
+    # (middle term of factorization of off-diag blocks; A terms)
+    previous_states = torch.zeros_like(states[:, :1])
+    states = torch.cat([previous_states, states], dim=1)
+    decay_chunk = torch.exp(segment_sum(nn.functional.pad(A_cumsum[:, :, :, -1], (1, 0))))
+    decay_chunk = decay_chunk.transpose(1, 3)
+    new_states = (decay_chunk[..., None, None] * states[:, :, None, ...]).sum(dim=1)
+    states, ssm_state = new_states[:, :-1], new_states[:, -1]
+    # states = new_states[:, :-1]
+
+    # 4. Compute state -> output conversion per chunk
+    # (left term of low-rank factorization of off-diagonal blocks; C terms)
+    state_decay_out = torch.exp(A_cumsum)
+    C_times_states = C[..., None, :] * states[:, :, None, ...]
+    state_decay_out_permuted = state_decay_out.permute(0, 2, 3, 1)
+    Y_off = C_times_states.sum(-1) * state_decay_out_permuted[..., None]
+
+    # Add output of intra-chunk and inter-chunk terms (diagonal and off-diagonal blocks)
+    y = Y_diag + Y_off
+    # [bsz, -1, self.chunk_size, num_heads, head_dim] -> [bsz, (padded) seq_len, num_heads, head_dim]
+    y = y.reshape(batch_size, -1, num_heads, head_dim)
+
+    y = y + D_residual
+    # Cutting off padded chunks
+    if pad_size > 0:
+        y = y[:, :seq_len, :, :]
+    y = y.reshape(batch_size, seq_len, -1)
+
+    return y, ssm_state
+
+
+@_ssm_transform.register_fake
+def _ssm_transform_meta(
+    hidden_states: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    D: torch.Tensor,
+    dt: torch.Tensor,
+    dt_bias: torch.Tensor,
+    ssm_state_size: int,
+    # NOTE: `torch` custom ops do not like `Tuple` inputs. Using `List` is the suggested WAR.
+    time_step_limit: List[float],
+    batch_size: int,
+    seq_len: int,
+    head_dim: int,
+    num_heads: int,
+    n_groups: int,
+    chunk_size: int,
+):
+    return (
+        torch.empty_like(hidden_states),
+        torch.empty(batch_size, num_heads, head_dim, ssm_state_size, dtype=hidden_states.dtype),
+    )
+
+
+@torch.library.custom_op("auto_deploy::ssm_transform_cached", mutates_args={})
+def _ssm_transform_cached(
+    hidden_states: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    D: torch.Tensor,
+    dt: torch.Tensor,
+    dt_bias: torch.Tensor,
+    ssm_state_size: int,
+    # NOTE: `torch` custom ops do not like `Tuple` inputs. Using `List` is the suggested WAR.
+    time_step_limit: List[float],
+    batch_size: int,
+    seq_len: int,
+    head_dim: int,
+    num_heads: int,
+    n_groups: int,
+    chunk_size: int,
+    cached_ssm_state: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    # We need to guarantee that anything regarding the cache is on the same device
+    cache_device = cached_ssm_state.device
+
+    # Note: there is no need to pad parameter matrices here, as there is just one new token
+    # for batched generation
+    dt = dt[:, 0, :][:, None, ...]
+    dt = dt.transpose(1, 2).expand(batch_size, dt.shape[-1], head_dim)
+    # [num_heads] -> [num_heads, head_dim]
+    dt_bias = dt_bias[..., None].expand(dt_bias.shape[0], head_dim)
+
+    dt = torch.nn.functional.softplus(dt + dt_bias.to(dt.dtype))
+    dt = torch.clamp(dt, time_step_limit[0], time_step_limit[1])
+    A = A[..., None, None].expand(num_heads, head_dim, ssm_state_size).to(dtype=torch.float32)
+    # [bsz, num_heads, head_dim, state_size]
+    dA = (torch.exp(dt[..., None] * A)).to(device=cache_device)
+
+    # Discretize B
+    # [bsz, n_groups * state_size] -> [bsz, n_groups, 1, state_size] ->
+    # -> [bsz, n_groups, group to head repetition factor, state_size] -> [bsz, num_heads, state_size]
+    B = B.reshape(batch_size, n_groups, -1)[..., None, :]
+    B = B.expand(batch_size, n_groups, num_heads // n_groups, B.shape[-1]).contiguous()
+    B = B.reshape(batch_size, -1, B.shape[-1])
+    # [bsz, num_heads, head_dim, state_size]
+    dB = dt[..., None] * B[..., None, :]
+
+    # Discretize x into dB
+    # [bsz, intermediate_size] -> [bsz, num_heads, head_dim]
+    hidden_states = hidden_states.reshape(batch_size, -1, head_dim)
+    dBx = (dB * hidden_states[..., None]).to(device=cache_device)
+
+    # State calculation
+    # cached_ssm_state.copy_(cached_ssm_state * dA + dBx)
+    cached_ssm_state = cached_ssm_state * dA + dBx
+
+    # Subsequent output
+    # [bsz, n_groups * state_size] -> [bsz, num_heads, state_size]
+    C = C.reshape(batch_size, n_groups, -1)[..., None, :]
+    C = C.expand(batch_size, n_groups, num_heads // n_groups, C.shape[-1]).contiguous()
+    C = C.reshape(batch_size, -1, C.shape[-1])
+    # [bsz, num_heads, head_dim]
+
+    ssm_states = cached_ssm_state.to(device=C.device, dtype=C.dtype)  # Shape: [b, h, d, n]
+    # Reshape ssm_states to merge the first two dimensions
+    ssm_states_reshaped = ssm_states.view(
+        batch_size * num_heads, head_dim, ssm_state_size
+    )  # Shape: [b*h, d, n]
+    C_reshaped = C.view(batch_size * num_heads, ssm_state_size, 1)  # Shape: [b*h, n, 1]
+    y = torch.bmm(ssm_states_reshaped, C_reshaped)
+    y = y.view(batch_size, num_heads, head_dim)
+
+    # D skip connection
+    # [num_heads] -> [num_heads, head_dim]
+    D = D[..., None].expand(D.shape[0], head_dim)
+    y = (y + hidden_states * D).to(y.dtype)
+
+    # [bsz, num_heads, head_dim] -> [bsz, 1, intermediate_size]
+    y = y.reshape(batch_size, -1)[:, None, ...]
+    return y, cached_ssm_state
+
+
+@_ssm_transform_cached.register_fake
+def _ssm_transform_meta(
+    hidden_states: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    D: torch.Tensor,
+    dt: torch.Tensor,
+    dt_bias: torch.Tensor,
+    ssm_state_size: int,
+    # NOTE: `torch` custom ops do not like `Tuple` inputs. Using `List` is the suggested WAR.
+    time_step_limit: List[float],
+    batch_size: int,
+    seq_len: int,
+    head_dim: int,
+    num_heads: int,
+    n_groups: int,
+    chunk_size: int,
+    cached_ssm_state: torch.Tensor,
+):
+    return (
+        torch.empty_like(hidden_states),
+        torch.empty(batch_size, num_heads, head_dim, ssm_state_size, dtype=hidden_states.dtype),
+    )
+
+
+# NOTE: this would need to be applied earlier than other patches, since the `_init_weights` (which
+# is called by `post_init`) is called before we run `forward`.
+def _bamba_pretrained_model_init_weights(self, module):
+    # ARGH python does not like this.
+    super(BambaPreTrainedModel, self)._init_weights(module)
+    if isinstance(module, BambaMixer):
+        module.dt_bias.data.fill_(1.0)
+        # ? Why is this even necessary? `BambaMixer.__init__` already sets
+        A = torch.arange(1, module.num_heads + 1)
+        self.A_log = nn.Parameter(torch.log(A))
+        # module.A_log.data = torch.log(torch.arange(1, module.num_heads + 1))
+        module.D.data.fill_(1.0)
+
+
+def _cache_bool(self) -> bool:
+    # This is a workaround for the bug on this line:
+    # https://github.com/huggingface/transformers/blob/v4.55.0/src/transformers/models/bamba/modeling_bamba.py#L1211
+    # The base `Cache` class from which `HybridMambaAttentionDynamicCache` inherits has a `__len__`
+    # special method implement that returns `False` when the instance is initialized, but stores no
+    # cache.
+    # The original line should really be checking for `if past_key_values is not None` but adding
+    # a patch for `BambaModel.forward` just for that reason seems overly intrusive.
+    return True
+
+
+@ExportPatchRegistry.register("bamba")
+class BambaModelPatch(BaseExportPatch):
+    """Patch for `BambaMixer`."""
+
+    def _apply_patch(self):
+        self.original_values["BambaMixer.torch_forward"] = BambaMixer.torch_forward
+        self.original_values["BambaModel._update_mamba_mask"] = BambaModel._update_mamba_mask
+        # NOTE: there is `HybridMambaAttentionDynamicCache.__bool__` to save.
+        # self.original_values["BambaPreTrainedModel._init_weights"] = BambaPreTrainedModel._init_weights
+
+        BambaMixer.torch_forward = _bamba_mixer_torch_forward
+        BambaModel._update_mamba_mask = _bamba_model_update_mamba_mask
+        HybridMambaAttentionDynamicCache.__bool__ = _cache_bool
+        # BambaPreTrainedModel._init_weights = _bamba_pretrained_model_init_weights
+
+    def _revert_patch(self):
+        BambaMixer.torch_forward = self.original_values["BambaMixer.torch_forward"]
+        BambaModel._update_mamba_mask = self.original_values["BambaModel._update_mamba_mask"]
+        del HybridMambaAttentionDynamicCache.__bool__
+        # BambaPreTrainedModel._init_weights = self.original_values[
+        #     "BambaPreTrainedModel._init_weights"
+        # ]
+
+
+# NOTE: patch that is used during build model time
+BambaPreTrainedModel._init_weights = _bamba_pretrained_model_init_weights

--- a/tensorrt_llm/_torch/auto_deploy/models/patches/bamba.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/patches/bamba.py
@@ -1,6 +1,6 @@
 """A patch for the Bamba model to make it compatible with torch.export."""
 
-from typing import List, Optional, Tuple
+from typing import Optional
 
 import torch
 from torch import nn
@@ -10,9 +10,6 @@ from transformers.models.bamba.modeling_bamba import (
     BambaPreTrainedModel,
     HybridMambaAttentionDynamicCache,
     apply_mask_to_padding_states,
-    pad_tensor_by_size,
-    reshape_into_chunks,
-    segment_sum,
 )
 
 from ...export.interface import BaseExportPatch, ExportPatchRegistry
@@ -41,45 +38,50 @@ def _bamba_mixer_torch_forward(
         [self.intermediate_size, self.conv_dim, self.num_heads], dim=-1
     )
 
-    use_precomputed_states = (
-        cache_params is not None
-        and cache_params.has_previous_state
-        and seq_len == 1
-        and cache_params.conv_states[self.layer_idx].shape[0]
-        == cache_params.ssm_states[self.layer_idx].shape[0]
-        == batch_size
-        and cache_position is not None
-        and cache_position[0] > 0
-    )
+    use_caching = cache_params is not None
 
-    # 2. Convolution sequence transformation
-    if use_precomputed_states:
-        cache_params.conv_states[self.layer_idx] = cache_params.conv_states[self.layer_idx].roll(
-            shifts=-1, dims=-1
+    # 2. Convolution sequence transformation (cached/uncached handled inside the op)
+    if use_caching:
+        # Prepare dense metadata for cached flattened op
+        seq_len_t = torch.full((batch_size,), seq_len, device=input_states.device, dtype=torch.int)
+        seq_start_t = torch.arange(
+            0, batch_size * seq_len, seq_len, device=input_states.device, dtype=torch.int
         )
-        cache_params.conv_states[self.layer_idx][:, :, -1] = hidden_states_B_C[:, 0, :].to(
-            cache_params.conv_states[self.layer_idx].device
-        )
+        slot_idx_t = torch.arange(batch_size, device=input_states.device, dtype=torch.long)
 
-        # We need to guarantee that anything regarding the cache is on the same device
-        conv_states = cache_params.conv_states[self.layer_idx].to(device=self.conv1d.weight.device)
-
-        hidden_states_B_C = torch.sum(conv_states * self.conv1d.weight.squeeze(1), dim=-1)
-        if self.use_conv_bias:
-            hidden_states_B_C = hidden_states_B_C + self.conv1d.bias
-        hidden_states_B_C = self.act(hidden_states_B_C)
-    else:
-        # Init cache
-        if cache_params is not None:
-            hidden_states_B_C_transposed = hidden_states_B_C.transpose(1, 2)
-            conv_states = nn.functional.pad(
-                hidden_states_B_C_transposed,
-                (self.conv_kernel_size - hidden_states_B_C_transposed.shape[-1], 0),
-            )
-            cache_params.conv_states[self.layer_idx].copy_(conv_states)
-
+    if use_caching:
         hidden_states_B_C = self.act(
-            self.conv1d(hidden_states_B_C.transpose(1, 2))[..., :seq_len].transpose(1, 2)
+            torch.ops.auto_deploy.torch_cached_causal_conv1d(
+                # INPUTS
+                hidden_states_B_C,
+                self.conv1d.weight,
+                self.conv1d.bias,
+                # METADATA
+                seq_len_t,
+                seq_start_t,
+                slot_idx_t,
+                # CACHES
+                cache_params.conv_states[self.layer_idx],
+                # CONSTANTS
+                self.conv1d.stride[0],
+                self.conv1d.padding[0],
+                self.conv1d.dilation[0],
+                self.conv1d.groups,
+                self.conv1d.padding_mode,
+            )
+        )
+    else:
+        hidden_states_B_C = self.act(
+            torch.ops.auto_deploy.torch_causal_conv1d(
+                hidden_states_B_C,
+                self.conv1d.weight,
+                self.conv1d.bias,
+                self.conv1d.stride[0],
+                self.conv1d.padding[0],
+                self.conv1d.dilation[0],
+                self.conv1d.groups,
+                self.conv1d.padding_mode,
+            )
         )
 
     hidden_states_B_C = apply_mask_to_padding_states(hidden_states_B_C, attention_mask)
@@ -95,47 +97,42 @@ def _bamba_mixer_torch_forward(
 
     # 3. SSM transformation
     A = -torch.exp(self.A_log.float())  # [num_heads]
-    if use_precomputed_states:
-        y, ssm_state = torch.ops.auto_deploy.ssm_transform_cached(
-            hidden_states=hidden_states,
+
+    if use_caching:
+        # Use new flattened cached op for both cache updates and outputs
+        y = torch.ops.auto_deploy.torch_cached_ssm_transform(
+            # INPUTS
+            hidden_states=hidden_states.view(batch_size, seq_len, -1, self.head_dim),
             A=A,
-            B=B,
-            C=C,
+            B=B.view(batch_size, seq_len, -1, self.ssm_state_size),
+            C=C.view(batch_size, seq_len, -1, self.ssm_state_size),
             D=self.D,
             dt=dt,
             dt_bias=self.dt_bias,
-            ssm_state_size=self.ssm_state_size,
+            # METADATA
+            seq_len=seq_len_t,
+            seq_start=seq_start_t,
+            slot_idx=slot_idx_t,
+            # CACHES
+            ssm_state_cache=cache_params.ssm_states[self.layer_idx],
+            # CONSTANTS
             time_step_limit=list(self.time_step_limit),
-            batch_size=batch_size,
-            seq_len=seq_len,
-            head_dim=self.head_dim,
-            num_heads=self.num_heads,
-            n_groups=self.n_groups,
             chunk_size=self.chunk_size,
-            cached_ssm_state=cache_params.ssm_states[self.layer_idx],
         )
     else:
-        y, ssm_state = torch.ops.auto_deploy.ssm_transform(
-            hidden_states=hidden_states,
+        y = torch.ops.auto_deploy.torch_ssm_transform(
+            hidden_states=hidden_states.view(batch_size, seq_len, -1, self.head_dim),
             A=A,
-            B=B,
-            C=C,
+            B=B.view(batch_size, seq_len, -1, self.ssm_state_size),
+            C=C.view(batch_size, seq_len, -1, self.ssm_state_size),
             D=self.D,
             dt=dt,
             dt_bias=self.dt_bias,
-            ssm_state_size=self.ssm_state_size,
             time_step_limit=list(self.time_step_limit),
-            batch_size=batch_size,
-            seq_len=seq_len,
-            head_dim=self.head_dim,
-            num_heads=self.num_heads,
-            n_groups=self.n_groups,
             chunk_size=self.chunk_size,
         )
 
-    # Init cache
-    if ssm_state is not None and cache_params is not None:
-        cache_params.ssm_states[self.layer_idx].copy_(ssm_state)
+    y = y.view(batch_size, seq_len, -1)
 
     scan_output = self.norm(y, gate)
 
@@ -151,234 +148,6 @@ def _bamba_mixer_torch_forward(
 # play well with export. Plus, we do not want it to be updated anyway.
 def _bamba_model_update_mamba_mask(self, attention_mask, cache_position):
     return None
-
-
-@torch.library.custom_op("auto_deploy::ssm_transform", mutates_args={})
-def _ssm_transform(
-    hidden_states: torch.Tensor,
-    A: torch.Tensor,
-    B: torch.Tensor,
-    C: torch.Tensor,
-    D: torch.Tensor,
-    dt: torch.Tensor,
-    dt_bias: torch.Tensor,
-    ssm_state_size: int,
-    # NOTE: `torch` custom ops do not like `Tuple` inputs. Using `List` is the suggested WAR.
-    time_step_limit: List[float],
-    batch_size: int,
-    seq_len: int,
-    head_dim: int,
-    num_heads: int,
-    n_groups: int,
-    chunk_size: int,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    # !! This is the uncached code path from the original implementation.
-    # begin ssd naive implementation without einsums
-    dt = nn.functional.softplus(dt + dt_bias)
-    dt = torch.clamp(dt, time_step_limit[0], time_step_limit[1])
-    hidden_states = hidden_states.reshape(batch_size, seq_len, -1, head_dim).float()
-    B = B.reshape(batch_size, seq_len, -1, ssm_state_size).float()
-    C = C.reshape(batch_size, seq_len, -1, ssm_state_size).float()
-    B = B.repeat_interleave(num_heads // n_groups, dim=2, output_size=num_heads)
-    C = C.repeat_interleave(num_heads // n_groups, dim=2, output_size=num_heads)
-    pad_size = (chunk_size - seq_len % chunk_size) % chunk_size
-
-    D_residual = D[..., None] * pad_tensor_by_size(hidden_states, pad_size)
-
-    # Discretize x and A
-    hidden_states = hidden_states * dt[..., None]
-    A = A.to(hidden_states.dtype) * dt
-
-    # Rearrange into blocks/chunks
-    hidden_states, A, B, C = [
-        reshape_into_chunks(t, pad_size, chunk_size) for t in (hidden_states, A, B, C)
-    ]
-
-    # [bsz, -1, chunk_size, num_heads] -> [bsz, num_heads, -1, chunk_size]
-    A = A.permute(0, 3, 1, 2)
-    A_cumsum = torch.cumsum(A, dim=-1)
-
-    # 1. Compute the output for each intra-chunk (diagonal blocks)
-    # This is the analog of a causal mask
-    L = torch.exp(segment_sum(A))
-
-    # Contraction of C and B to get G (attention-weights like)
-    G_intermediate = C[:, :, :, None, :, :] * B[:, :, None, :, :, :]  # shape: (b, c, l, s, h, n)
-    G = G_intermediate.sum(dim=-1)  # shape: (b, c, l, s, h)
-
-    # Compute M, equivalent to applying attention mask to weights
-    M_intermediate = G[..., None] * L.permute(0, 2, 3, 4, 1)[..., None]
-    M = M_intermediate.sum(dim=-1)
-
-    # Compute Y_diag (apply to values)
-    Y_diag = (M[..., None] * hidden_states[:, :, None]).sum(dim=3)
-
-    # 2. Compute the state for each intra-chunk
-    # (right term of low-rank factorization of off-diagonal blocks; B terms)
-    decay_states = torch.exp(A_cumsum[:, :, :, -1:] - A_cumsum)
-    B_decay = B * decay_states.permute(0, -2, -1, 1)[..., None]
-    states = (B_decay[..., None, :] * hidden_states[..., None]).sum(dim=2)
-
-    # 3. Compute the inter-chunk SSM recurrence; produces correct SSM states at chunk boundaries
-    # (middle term of factorization of off-diag blocks; A terms)
-    previous_states = torch.zeros_like(states[:, :1])
-    states = torch.cat([previous_states, states], dim=1)
-    decay_chunk = torch.exp(segment_sum(nn.functional.pad(A_cumsum[:, :, :, -1], (1, 0))))
-    decay_chunk = decay_chunk.transpose(1, 3)
-    new_states = (decay_chunk[..., None, None] * states[:, :, None, ...]).sum(dim=1)
-    states, ssm_state = new_states[:, :-1], new_states[:, -1]
-    # states = new_states[:, :-1]
-
-    # 4. Compute state -> output conversion per chunk
-    # (left term of low-rank factorization of off-diagonal blocks; C terms)
-    state_decay_out = torch.exp(A_cumsum)
-    C_times_states = C[..., None, :] * states[:, :, None, ...]
-    state_decay_out_permuted = state_decay_out.permute(0, 2, 3, 1)
-    Y_off = C_times_states.sum(-1) * state_decay_out_permuted[..., None]
-
-    # Add output of intra-chunk and inter-chunk terms (diagonal and off-diagonal blocks)
-    y = Y_diag + Y_off
-    # [bsz, -1, self.chunk_size, num_heads, head_dim] -> [bsz, (padded) seq_len, num_heads, head_dim]
-    y = y.reshape(batch_size, -1, num_heads, head_dim)
-
-    y = y + D_residual
-    # Cutting off padded chunks
-    if pad_size > 0:
-        y = y[:, :seq_len, :, :]
-    y = y.reshape(batch_size, seq_len, -1)
-
-    return y, ssm_state
-
-
-@_ssm_transform.register_fake
-def _ssm_transform_meta(
-    hidden_states: torch.Tensor,
-    A: torch.Tensor,
-    B: torch.Tensor,
-    C: torch.Tensor,
-    D: torch.Tensor,
-    dt: torch.Tensor,
-    dt_bias: torch.Tensor,
-    ssm_state_size: int,
-    # NOTE: `torch` custom ops do not like `Tuple` inputs. Using `List` is the suggested WAR.
-    time_step_limit: List[float],
-    batch_size: int,
-    seq_len: int,
-    head_dim: int,
-    num_heads: int,
-    n_groups: int,
-    chunk_size: int,
-):
-    return (
-        torch.empty_like(hidden_states),
-        torch.empty(batch_size, num_heads, head_dim, ssm_state_size, dtype=hidden_states.dtype),
-    )
-
-
-@torch.library.custom_op("auto_deploy::ssm_transform_cached", mutates_args={})
-def _ssm_transform_cached(
-    hidden_states: torch.Tensor,
-    A: torch.Tensor,
-    B: torch.Tensor,
-    C: torch.Tensor,
-    D: torch.Tensor,
-    dt: torch.Tensor,
-    dt_bias: torch.Tensor,
-    ssm_state_size: int,
-    # NOTE: `torch` custom ops do not like `Tuple` inputs. Using `List` is the suggested WAR.
-    time_step_limit: List[float],
-    batch_size: int,
-    seq_len: int,
-    head_dim: int,
-    num_heads: int,
-    n_groups: int,
-    chunk_size: int,
-    cached_ssm_state: torch.Tensor,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    # We need to guarantee that anything regarding the cache is on the same device
-    cache_device = cached_ssm_state.device
-
-    # Note: there is no need to pad parameter matrices here, as there is just one new token
-    # for batched generation
-    dt = dt[:, 0, :][:, None, ...]
-    dt = dt.transpose(1, 2).expand(batch_size, dt.shape[-1], head_dim)
-    # [num_heads] -> [num_heads, head_dim]
-    dt_bias = dt_bias[..., None].expand(dt_bias.shape[0], head_dim)
-
-    dt = torch.nn.functional.softplus(dt + dt_bias.to(dt.dtype))
-    dt = torch.clamp(dt, time_step_limit[0], time_step_limit[1])
-    A = A[..., None, None].expand(num_heads, head_dim, ssm_state_size).to(dtype=torch.float32)
-    # [bsz, num_heads, head_dim, state_size]
-    dA = (torch.exp(dt[..., None] * A)).to(device=cache_device)
-
-    # Discretize B
-    # [bsz, n_groups * state_size] -> [bsz, n_groups, 1, state_size] ->
-    # -> [bsz, n_groups, group to head repetition factor, state_size] -> [bsz, num_heads, state_size]
-    B = B.reshape(batch_size, n_groups, -1)[..., None, :]
-    B = B.expand(batch_size, n_groups, num_heads // n_groups, B.shape[-1]).contiguous()
-    B = B.reshape(batch_size, -1, B.shape[-1])
-    # [bsz, num_heads, head_dim, state_size]
-    dB = dt[..., None] * B[..., None, :]
-
-    # Discretize x into dB
-    # [bsz, intermediate_size] -> [bsz, num_heads, head_dim]
-    hidden_states = hidden_states.reshape(batch_size, -1, head_dim)
-    dBx = (dB * hidden_states[..., None]).to(device=cache_device)
-
-    # State calculation
-    # cached_ssm_state.copy_(cached_ssm_state * dA + dBx)
-    cached_ssm_state = cached_ssm_state * dA + dBx
-
-    # Subsequent output
-    # [bsz, n_groups * state_size] -> [bsz, num_heads, state_size]
-    C = C.reshape(batch_size, n_groups, -1)[..., None, :]
-    C = C.expand(batch_size, n_groups, num_heads // n_groups, C.shape[-1]).contiguous()
-    C = C.reshape(batch_size, -1, C.shape[-1])
-    # [bsz, num_heads, head_dim]
-
-    ssm_states = cached_ssm_state.to(device=C.device, dtype=C.dtype)  # Shape: [b, h, d, n]
-    # Reshape ssm_states to merge the first two dimensions
-    ssm_states_reshaped = ssm_states.view(
-        batch_size * num_heads, head_dim, ssm_state_size
-    )  # Shape: [b*h, d, n]
-    C_reshaped = C.view(batch_size * num_heads, ssm_state_size, 1)  # Shape: [b*h, n, 1]
-    y = torch.bmm(ssm_states_reshaped, C_reshaped)
-    y = y.view(batch_size, num_heads, head_dim)
-
-    # D skip connection
-    # [num_heads] -> [num_heads, head_dim]
-    D = D[..., None].expand(D.shape[0], head_dim)
-    y = (y + hidden_states * D).to(y.dtype)
-
-    # [bsz, num_heads, head_dim] -> [bsz, 1, intermediate_size]
-    y = y.reshape(batch_size, -1)[:, None, ...]
-    return y, cached_ssm_state
-
-
-@_ssm_transform_cached.register_fake
-def _ssm_transform_meta(
-    hidden_states: torch.Tensor,
-    A: torch.Tensor,
-    B: torch.Tensor,
-    C: torch.Tensor,
-    D: torch.Tensor,
-    dt: torch.Tensor,
-    dt_bias: torch.Tensor,
-    ssm_state_size: int,
-    # NOTE: `torch` custom ops do not like `Tuple` inputs. Using `List` is the suggested WAR.
-    time_step_limit: List[float],
-    batch_size: int,
-    seq_len: int,
-    head_dim: int,
-    num_heads: int,
-    n_groups: int,
-    chunk_size: int,
-    cached_ssm_state: torch.Tensor,
-):
-    return (
-        torch.empty_like(hidden_states),
-        torch.empty(batch_size, num_heads, head_dim, ssm_state_size, dtype=hidden_states.dtype),
-    )
 
 
 # NOTE: this would need to be applied earlier than other patches, since the `_init_weights` (which

--- a/tensorrt_llm/_torch/auto_deploy/models/patches/nemotron_h.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/patches/nemotron_h.py
@@ -1,0 +1,125 @@
+import contextlib
+import importlib.util
+import sys
+import types
+from typing import Callable, Dict, List, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from einops import rearrange
+from transformers import AutoModelForCausalLM
+
+from tensorrt_llm._torch.auto_deploy.models.patches.bamba import _bamba_mixer_torch_forward
+
+
+# Forked from:
+# https://github.com/state-spaces/mamba/blob/6b32be06d026e170b3fdaf3ae6282c5a6ff57b06/mamba_ssm/ops/triton/layernorm_gated.py
+# NOTES:
+# 1. At time of writing (09/25/2025), the nano nemotron v2 modeling code expects `mamba_ssm`
+#    to be installed so as to be able to make use of its grouped gated RMS norm operation.
+#    We therefore replace it with one that uses einops + pytorch.
+def _rms_norm_ref(
+    x, weight, bias, z=None, eps=1e-6, group_size=None, norm_before_gate=True, upcast=True
+):
+    dtype = x.dtype
+    # N = x.shape[-1]
+    weight = weight.float()
+    bias = bias.float() if bias is not None else None
+    if upcast:
+        x = x.float()
+        z = z.float() if z is not None else z
+    if z is not None and not norm_before_gate:
+        x = x * F.silu(z)
+    if group_size is None:
+        rstd = 1 / torch.sqrt((x.square()).mean(dim=-1, keepdim=True) + eps)
+        out = (x * rstd * weight) + bias if bias is not None else (x * rstd * weight)
+    else:
+        x_group = rearrange(x, "... (g d) -> ... g d", d=group_size)
+        rstd = 1 / torch.sqrt((x_group.square()).mean(dim=-1, keepdim=True) + eps)
+        out = rearrange(x_group * rstd, "... g d -> ... (g d)") * weight
+        if bias is not None:
+            out = out + bias
+    if z is not None and norm_before_gate:
+        out *= F.silu(z)
+    return out.to(dtype)
+
+
+# The original implementation looks at `cache_position[0]` to decide what to do which does not
+# play well with export. Plus, we do not want it to be updated anyway.
+def _nemotron_h_model_update_mamba_mask(self, attention_mask, cache_position):
+    return None
+
+
+def _nemotron_h_model_update_causal_mask(self, attention_mask, input_tensor, cache_position):
+    # Force attention to use causal mode without explicit masks
+    return None
+
+
+def _nemotron_h_block_forward(
+    self,
+    hidden_states,
+    cache_params=None,
+    cache_position: Optional[torch.LongTensor] = None,
+    attention_mask: Optional[torch.Tensor] = None,
+):
+    device = hidden_states.device
+    with contextlib.ExitStack() as stack:
+        if device.type == "cuda":
+            stack.enter_context(torch.cuda.stream(torch.cuda.default_stream(device)))
+        # * Use torch.cuda.stream() to avoid NaN issues when using multiple GPUs
+        residual = hidden_states
+        hidden_states = self.norm(hidden_states.to(dtype=self.norm.weight.dtype))
+        if self.residual_in_fp32:
+            residual = residual.to(torch.float32)
+
+        if self.block_type == "mamba":
+            hidden_states = self.mixer(
+                hidden_states, cache_params=cache_params, cache_position=cache_position
+            )
+        elif self.block_type == "attention":
+            hidden_states = self.mixer(hidden_states, cache_position=cache_position)
+            hidden_states = hidden_states[0]
+        elif self.block_type == "mlp":
+            hidden_states = self.mixer(hidden_states)
+        else:
+            raise ValueError(f"Invalid block_type: {self.block_type}")
+
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+_from_config_original = AutoModelForCausalLM.from_config
+
+CUSTOM_MODULE_PATCHES: Dict[str, List[Tuple[str, Callable]]] = {
+    "NemotronHMamba2Mixer": [("forward", _bamba_mixer_torch_forward)],
+    "NemotronHModel": [
+        ("_update_causal_mask", _nemotron_h_model_update_causal_mask),
+        ("_update_mamba_mask", _nemotron_h_model_update_mamba_mask),
+    ],
+    "NemotronHBlock": [("forward", _nemotron_h_block_forward)],
+}
+
+
+def get_model_from_config_patched(config, **kwargs):
+    model = _from_config_original(config, **kwargs)
+    # Patch modules
+    for _, module in model.named_modules():
+        if (module_name := type(module).__name__) in CUSTOM_MODULE_PATCHES.keys():
+            patches = CUSTOM_MODULE_PATCHES[module_name]
+            for method_name, method_patch in patches:
+                setattr(module, method_name, types.MethodType(method_patch, module))
+
+    return model
+
+
+# TODO: figure out how this can be incorporated into the export patch system
+AutoModelForCausalLM.from_config = get_model_from_config_patched
+
+# TODO: figure out how this can be incorporated into the export patch system
+# Only patch if the module isn't available
+_mamba_ssm_module = "mamba_ssm"
+_mamba_ssm_submodule = f"{_mamba_ssm_module}.ops.triton.layernorm_gated"
+if importlib.util.find_spec(_mamba_ssm_module) is None:
+    stub_mod = types.ModuleType(_mamba_ssm_submodule)
+    stub_mod.rmsnorm_fn = _rms_norm_ref
+    sys.modules[_mamba_ssm_submodule] = stub_mod

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -182,6 +182,7 @@ class ADEngine(ModelEngine):
         input_pos: List[int] = []
         last_logit_only: List[bool] = []
         page_assignments: List[List[int]] = []
+        slot_idx: List[int] = []
         flat_gather_idx: List[int] = []
         extra_args: Dict[str, List[torch.Tensor]] = defaultdict(list)
 
@@ -199,6 +200,9 @@ class ADEngine(ModelEngine):
             # get cache indices
             cache_indices = kv_cache_manager.get_cache_indices(request)
             page_assignments.append(cache_indices)
+
+            # store seq slot idx
+            slot_idx.append(request.seq_slot)
 
             # store extra arguments
             if request.py_multimodal_data is not None:
@@ -219,6 +223,10 @@ class ADEngine(ModelEngine):
 
             request.py_batch_idx = request.seq_slot
 
+            # store seq slot idx
+            # TODO: double-check if this is correct for the overlap scheduler
+            slot_idx.append(request.seq_slot)
+
             # return all logits
             last_logit_only.append(False)
 
@@ -231,6 +239,7 @@ class ADEngine(ModelEngine):
             input_ids,
             input_pos=input_pos,
             page_assignments=page_assignments,
+            slot_idx=slot_idx,
             **extra_args,
         )
         # scatter the new tokens into the input_ids tensor if provided

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -158,7 +158,7 @@ class ADEngine(ModelEngine):
         self.model = get_inference_model(self.cache_seq_interface)
 
         # start fresh with fixed seed
-        torch.manual_seed(1234)
+        torch.manual_seed(42)
 
     @nvtx_range("ad_prepare_inputs")
     def _prepare_inputs(

--- a/tensorrt_llm/_torch/auto_deploy/shim/demollm.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/demollm.py
@@ -114,6 +114,7 @@ class DemoEngine(ADEngine):
             input_ids=input_ids,
             input_pos=0,
             page_assignments=self._assign_pages(total_lens),
+            slot_idx=list(range(len(input_ids))),
             **extra_args,
         )
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/attention.py
@@ -410,6 +410,30 @@ def _grouped_attn_replacement_9(q, k, v, dropout_p, scale):
     )
 
 
+def _grouped_attn_pattern_10(q, k, v, n_rep, dropout_p):
+    k = torch.ops.auto_deploy.torch_attention_repeat_kv(k, n_rep)
+    v = torch.ops.auto_deploy.torch_attention_repeat_kv(v, n_rep)
+    return torch.ops.auto_deploy.torch_attention_sdpa.default(
+        q,
+        k,
+        v,
+        attn_mask=None,
+        dropout_p=dropout_p,
+        is_causal=True,
+    )
+
+
+def _grouped_attn_replacement_10(q, k, v, n_rep, dropout_p):
+    return torch.ops.auto_deploy.torch_attention_grouped_sdpa.default(
+        q,
+        k,
+        v,
+        attn_mask=None,
+        dropout_p=dropout_p,
+        is_causal=True,
+    )
+
+
 @TransformRegistry.register("match_repeat_kv")
 class MatchRepeatKV(BaseTransform):
     """
@@ -511,6 +535,7 @@ class MatchGroupedAttention(BaseTransform):
             dummy_args_2 = [q, k1, v1, attn_mask, dropout, scale]
             dummy_args_3 = [q, k1, v1, n_rep, attn_mask]
             dummy_args_4 = [q, k1, v1, dropout, scale]
+            dummy_args_5 = [q, k1, v1, n_rep, dropout]
 
             register_ad_pattern(
                 search_fn=_grouped_attn_pattern_1,
@@ -581,6 +606,13 @@ class MatchGroupedAttention(BaseTransform):
                 patterns=patterns,
                 dummy_args=dummy_args_4,
                 scalar_workaround={"scale": scale, "dropout_p": dropout},
+            )
+            register_ad_pattern(
+                search_fn=_grouped_attn_pattern_10,
+                replace_fn=_grouped_attn_replacement_10,
+                patterns=patterns,
+                dummy_args=dummy_args_5,
+                scalar_workaround={"dropout_p": dropout, "n_rep": n_rep},
             )
 
         num_grouped_patterns = _apply_pattern(gm, "Grouped Attention", register_grouped_attention)

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
@@ -12,7 +12,6 @@ from ...distributed.common import all_gather_object, get_world_size
 from ...models.factory import ModelFactory
 from ...shim.interface import CachedSequenceInterface
 from ...transformations._graph import add_graph_input
-from ...utils.logger import ad_logger
 from ...utils.node_utils import get_all_input_output_nodes, is_op
 from ..interface import (
     BaseTransform,
@@ -306,10 +305,11 @@ class ResizeKVCache(BaseTransform):
         self._log_info(f"After all_gather - new_num_pages: {new_num_pages}")
 
         cm.resize_cache(new_num_pages)
+
         # Log the final cache size for performance measurement, do not remove this log.
         final_cache_size_bytes = cm.current_cache_size_bytes()
         final_cache_size_gb = final_cache_size_bytes / (1024**3)  # Convert to GiB
-        ad_logger.info(
+        self._log_info(
             f"Final KV cache size after resize: {final_cache_size_gb:.2f} GiB ({new_num_pages} pages)"
         )
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/mxfp4_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/mxfp4_moe.py
@@ -9,7 +9,7 @@ from tensorrt_llm._torch.auto_deploy.utils.pattern_matcher import (
     register_ad_pattern,
 )
 
-from ...custom_ops import IS_TRITON_KERNELS_AVAILABLE
+from ...custom_ops.mxfp4_moe import IS_TRITON_KERNELS_AVAILABLE
 from ...utils.module import get_submodule_of_param
 from ...utils.node_utils import is_op
 from ..interface import BaseTransform, TransformInfo, TransformRegistry

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/ssm_cache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/ssm_cache.py
@@ -1,0 +1,15 @@
+"""A set of transforms to handle SSM cache transforms."""
+
+from ..interface import TransformRegistry
+from .kvcache import InsertCachedAttention
+
+
+# TODO: think about separating valid attention backends per transform better in the future
+@TransformRegistry.register("insert_cached_ssm_attention")
+class SSMCacheTransform(InsertCachedAttention):
+    """A transform to handle SSM cache operations."""
+
+
+@TransformRegistry.register("insert_cached_causal_conv")
+class InitializeCausalConvCache(InsertCachedAttention):
+    """A transform to handle causal conv cache operations."""

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -167,7 +167,13 @@ def launch_server(host: str,
         llm_args.pop("build_config", None)
         # TODO(https://github.com/NVIDIA/TensorRT-LLM/issues/7142):
         # AutoDeploy does not support cache reuse yet.
-        llm_args["kv_cache_config"].enable_block_reuse = False
+        kv_cache_config = llm_args["kv_cache_config"]
+        # If the LLM API options YAML contained a portion for `kv_cache_config`, then this will be
+        # a dict. Otherwise, it will be an instance of the `KvCacheConfig` class, hence the below.
+        if isinstance(kv_cache_config, dict):
+            llm_args["kv_cache_config"]["enable_block_reuse"] = False
+        else:
+            llm_args["kv_cache_config"].enable_block_reuse = False
         llm = AutoDeployLLM(**llm_args)
     elif backend == 'tensorrt' or backend == 'trt':
         llm_args.pop("backend")

--- a/tests/unittest/_torch/auto_deploy/_utils_test/_model_test_utils.py
+++ b/tests/unittest/_torch/auto_deploy/_utils_test/_model_test_utils.py
@@ -447,7 +447,7 @@ _SMALL_MODEL_CONFIGS = {
         },
     },
     "ibm-ai-platform/Bamba-9B-v2": {
-        "llm_models_subdir": "NO_SUBDIR",  # no synced to llm_models_root at the moment
+        "llm_models_subdir": "Bamba-9B-v2",
         "model_kwargs": {
             "torch_dtype": "bfloat16",
             "hidden_size": 64,
@@ -463,6 +463,21 @@ _SMALL_MODEL_CONFIGS = {
             "num_hidden_layers": 10,
             "num_attention_heads": 4,
             "num_key_value_heads": 2,
+        },
+    },
+    "nvidia/NVIDIA-Nemotron-Nano-12B-v2": {
+        "llm_models_subdir": "NVIDIA-Nemotron-Nano-12B-v2",
+        "model_kwargs": {
+            "torch_dtype": "bfloat16",
+            "hidden_size": 32,
+            "intermediate_size": 64,
+            "mamba_head_dim": 40,
+            "mamba_num_heads": 4,
+            "n_groups": 2,
+            "num_attention_heads": 4,
+            "num_hidden_layers": 9,
+            "num_key_value_heads": 2,
+            "ssm_state_size": 32,
         },
     },
 }

--- a/tests/unittest/_torch/auto_deploy/_utils_test/_model_test_utils.py
+++ b/tests/unittest/_torch/auto_deploy/_utils_test/_model_test_utils.py
@@ -446,6 +446,25 @@ _SMALL_MODEL_CONFIGS = {
             "vision_config": {"num_hidden_layers": 2},
         },
     },
+    "ibm-ai-platform/Bamba-9B-v2": {
+        "llm_models_subdir": "NO_SUBDIR",  # no synced to llm_models_root at the moment
+        "model_kwargs": {
+            "torch_dtype": "bfloat16",
+            "hidden_size": 64,
+            "intermediate_size": 128,
+            "mamba_chunk_size": 64,
+            "mamba_d_conv": 2,
+            "mamba_d_head": 16,
+            "mamba_d_state": 64,
+            "mamba_expand": 1,
+            "mamba_n_groups": 1,
+            "mamba_n_heads": 4,
+            "model_type": "bamba",
+            "num_hidden_layers": 10,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+        },
+    },
 }
 
 

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_cuda_causal_conv_cached_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_cuda_causal_conv_cached_op.py
@@ -1,0 +1,200 @@
+"""Unit tests for CUDA-backed cached causal conv1d custom ops.
+
+Covers:
+- Generate-only path with slot-indexed cache mapping
+- Context (flattened) path and state write-back per slot
+- Metadata preparation
+"""
+
+import pytest
+import torch
+
+import tensorrt_llm._torch.auto_deploy  # noqa: F401
+
+
+def _random_params_depthwise(device, dtype, batch, seq, channels, k):
+    x = torch.randn(batch, seq, channels, device=device, dtype=dtype)
+    # Depthwise: out_channels == in_channels, groups == channels, weight [C, 1, K]
+    weight = torch.randn(channels, 1, k, device=device, dtype=dtype)
+    bias = torch.randn(channels, device=device, dtype=dtype)
+    stride = 1
+    padding = k - 1
+    dilation = 1
+    groups = channels
+    padding_mode = "zeros"
+    return x, weight, bias, stride, padding, dilation, groups, padding_mode
+
+
+@pytest.fixture
+def conv_env():
+    device = "cuda"
+    dtype = torch.float16
+    atol = 5e-2
+    rtol = 5e-2
+    torch.manual_seed(123)
+    torch.cuda.empty_cache()
+    return {"device": device, "dtype": dtype, "atol": atol, "rtol": rtol}
+
+
+def test_generate_only_with_slot_mapping_cuda(conv_env):
+    device = conv_env["device"]
+    dtype = conv_env["dtype"]
+
+    batch, seq = 1, 1
+    c, k = 2, 3
+    x, w, b, s, p, d, g, pm = _random_params_depthwise(device, dtype, batch, seq, c, k)
+
+    # Slot mapping with arbitrary order within max_batch_size
+    max_batch_size = 2
+    slot_idx = torch.tensor([0], device=device, dtype=torch.int32)
+    # Cache holds K-1 entries (TRT update kernel contract)
+    conv_state_cache = torch.randn(
+        max_batch_size,
+        c,
+        k - 1,
+        device=device,
+        dtype=dtype,
+    )
+
+    # Metadata (not used in generate-only op entry, but required by the interface)
+    seq_len = torch.ones(batch, device=device, dtype=torch.int32)
+    seq_start = torch.zeros(batch, device=device, dtype=torch.int32)
+
+    # Snapshot caches for reference before running op (op mutates caches)
+    gathered_before = conv_state_cache.clone().index_select(0, slot_idx)
+    x_ref = x.clone()
+    # Run CUDA cached op
+    y = torch.ops.auto_deploy.cuda_cached_causal_conv1d(
+        # INPUTS
+        x,
+        w,
+        b,
+        # METADATA
+        seq_len,
+        seq_start,
+        slot_idx,
+        # CACHES
+        conv_state_cache,
+        # CONSTANTS
+        s,
+        p,
+        d,
+        g,
+        pm,
+    )
+
+    assert y.shape == (batch, seq, c)
+    assert torch.isfinite(y).all()
+
+    # Reference via torch uncached conv on window [state(K-1) | x]
+    window_bt_c = torch.cat([gathered_before.transpose(1, 2), x_ref], dim=-2)
+    y_ref = torch.ops.auto_deploy.torch_causal_conv1d(window_bt_c, w, b, 1, 0, 1, g, pm)
+    assert torch.allclose(y, y_ref, atol=conv_env["atol"], rtol=conv_env["rtol"])
+    after = conv_state_cache.index_select(0, slot_idx)
+    expected_after = torch.cat([gathered_before[..., 1:], x_ref.transpose(1, 2)[..., :1]], dim=-1)
+    assert torch.allclose(
+        after, expected_after.to(after.dtype), atol=conv_env["atol"], rtol=conv_env["rtol"]
+    )
+
+
+def test_context_flattened_and_state_writeback_cuda(conv_env):
+    device = conv_env["device"]
+    dtype = conv_env["dtype"]
+
+    # Two short sequences with lengths 2 and 1, flattened to [1,3]
+    lens = [2, 1]
+    total = sum(lens)
+    batch, seq = 1, total
+    c, k = 2, 3
+    x, w, b, s, p, d, g, pm = _random_params_depthwise(device, dtype, batch, seq, c, k)
+
+    max_batch_size = 2
+    slot_idx = torch.tensor([1, 0], device=device, dtype=torch.int32)
+    conv_state_cache = torch.randn(
+        max_batch_size,
+        c,
+        k - 1,
+        device=device,
+        dtype=dtype,
+    )
+
+    seq_len = torch.tensor(lens, device=device, dtype=torch.int32)
+    seq_start = torch.tensor([0, lens[0]], device=device, dtype=torch.int32)
+
+    y = torch.ops.auto_deploy.cuda_cached_causal_conv1d(
+        # INPUTS
+        x,
+        w,
+        b,
+        # METADATA
+        seq_len,
+        seq_start,
+        slot_idx,
+        # CACHES
+        conv_state_cache,
+        # CONSTANTS
+        s,
+        p,
+        d,
+        g,
+        pm,
+    )
+
+    assert y.shape == (batch, seq, c)
+    assert torch.isfinite(y).all()
+
+    # Reference by per-sequence prefill output and expected conv state (K-1 window)
+    y_ref = torch.empty_like(y)
+    for i, ln in enumerate(lens):
+        st = 0 if i == 0 else lens[0]
+        x_i = x[:, st : st + ln]
+        y_i, _ = (
+            tensorrt_llm._torch.auto_deploy.custom_ops.torch_backend_causal_conv._torch_causal_conv1d_prefill(  # type: ignore  # noqa: E501
+                x_i, w, b, s, p, d, g, pm
+            )
+        )
+        y_ref[:, st : st + ln].copy_(y_i)
+        # Cache should hold K-1 latest inputs
+        x_b_c_t = x_i.transpose(1, 2)
+        if ln >= (k - 1):
+            expected_state = x_b_c_t[..., -(k - 1) :]
+        else:
+            pad = (k - 1) - ln
+            expected_state = torch.nn.functional.pad(x_b_c_t, (pad, 0))
+        assert torch.allclose(
+            conv_state_cache[slot_idx[i]].to(expected_state.dtype),
+            expected_state,
+            atol=conv_env["atol"],
+            rtol=conv_env["rtol"],
+        )
+
+    assert torch.allclose(y, y_ref.to(y.dtype), atol=conv_env["atol"], rtol=conv_env["rtol"])
+
+
+def test_prepare_metadata_cuda(conv_env):
+    device = conv_env["device"]
+
+    b, s = 4, 6
+    input_ids = torch.randint(0, 1000, (b, s), device=device)
+    position_ids = torch.arange(s, device=device).expand(b, -1)
+    seq_len = torch.tensor([2, 1, 0, 0], device=device, dtype=torch.int32)
+    input_pos = torch.tensor([0, 3, 0, 0], device=device, dtype=torch.int32)
+    cache_loc = torch.arange(b, device=device, dtype=torch.int32)
+    pages_per_seq = torch.ones(b, device=device, dtype=torch.int32)
+    slot_idx = torch.tensor([2, 0, 1, 3], device=device, dtype=torch.int32)
+    page_size = 128
+
+    out = torch.ops.auto_deploy.cuda_causal_conv_prepare_metadata(
+        input_ids,
+        position_ids,
+        seq_len,
+        input_pos,
+        cache_loc,
+        pages_per_seq,
+        slot_idx,
+        page_size,
+    )
+    assert len(out) == 3
+    seq_len_s, seq_start, slot_s = out
+    assert seq_len_s.numel() == 2 and slot_s.numel() == 2
+    assert torch.all(seq_start == torch.tensor([0, 2], device=device, dtype=seq_start.dtype))

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_cuda_causal_conv_cached_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_cuda_causal_conv_cached_op.py
@@ -97,6 +97,7 @@ def test_generate_only_with_slot_mapping_cuda(conv_env):
     )
 
 
+@pytest.mark.skip(reason="https://nvbugspro.nvidia.com/bug/5548861")
 def test_context_flattened_and_state_writeback_cuda(conv_env):
     device = conv_env["device"]
     dtype = conv_env["dtype"]

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_torch_attention_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_torch_attention_op.py
@@ -475,10 +475,11 @@ class TestTorchBackendAttention:
         input_pos = torch.zeros(batch_size, device=device, dtype=torch.int32)
         cache_loc = torch.arange(batch_size, device=device, dtype=torch.int32)
         pages_per_seq = torch.ones(batch_size, device=device, dtype=torch.int32)
+        slot_idx = torch.arange(batch_size, device=device, dtype=torch.int32)
 
         # Test metadata preparation
         result = torch.ops.auto_deploy.torch_cached_attention_prepare_metadata(
-            input_ids, position_ids, seq_len, input_pos, cache_loc, pages_per_seq, 128
+            input_ids, position_ids, seq_len, input_pos, cache_loc, pages_per_seq, slot_idx, 128
         )
 
         # Verify result structure

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_torch_causal_conv_cached_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_torch_causal_conv_cached_op.py
@@ -1,0 +1,193 @@
+"""Unit tests for cached causal conv1d custom ops.
+
+Covers:
+- Generate-only path with slot-indexed cache mapping
+- Context (flattened) path and state write-back per slot
+- Metadata preparation
+"""
+
+import pytest
+import torch
+
+import tensorrt_llm._torch.auto_deploy  # noqa: F401
+
+
+def _random_params(device, dtype, batch, seq, c_in, c_out, k, groups=1):
+    x = torch.randn(batch, seq, c_in, device=device, dtype=dtype)
+    weight = torch.randn(c_out, c_in // groups, k, device=device, dtype=dtype)
+    bias = torch.randn(c_out, device=device, dtype=dtype)
+    stride = 1
+    padding = k - 1
+    dilation = 1
+    padding_mode = "zeros"
+    return x, weight, bias, stride, padding, dilation, groups, padding_mode
+
+
+@pytest.fixture
+def conv_env():
+    device = "cuda"
+    dtype = torch.float16
+    atol = 5e-2
+    rtol = 5e-2
+    torch.manual_seed(123)
+    torch.cuda.empty_cache()
+    return {"device": device, "dtype": dtype, "atol": atol, "rtol": rtol}
+
+
+def test_generate_only_with_slot_mapping(conv_env):
+    device = conv_env["device"]
+    dtype = conv_env["dtype"]
+
+    batch, seq = 3, 1
+    c_in, c_out, k = 8, 6, 3
+    x, w, b, s, p, d, g, pm = _random_params(device, dtype, batch, seq, c_in, c_out, k)
+
+    # Slot mapping with arbitrary order within max_batch_size
+    max_batch_size = 6
+    slot_idx = torch.tensor([4, 1, 3], device=device, dtype=torch.int32)
+    conv_state_cache = torch.randn(
+        max_batch_size,
+        c_in,
+        k,
+        device=device,
+        dtype=dtype,
+    )
+
+    # Metadata (not used in generate-only op entry, but required by the interface)
+    seq_len = torch.ones(batch, device=device, dtype=torch.int32)
+    seq_start = torch.zeros(batch, device=device, dtype=torch.int32)
+
+    # Snapshot caches for reference before running op (op mutates caches)
+    gathered_before = conv_state_cache.clone().index_select(0, slot_idx)
+
+    # Run cached op
+    y = torch.ops.auto_deploy.torch_cached_causal_conv1d(
+        # INPUTS
+        x,
+        w,
+        b,
+        # METADATA
+        seq_len,
+        seq_start,
+        slot_idx,
+        # CACHES
+        conv_state_cache,
+        # CONSTANTS
+        s,
+        p,
+        d,
+        g,
+        pm,
+    )
+
+    assert y.shape == (batch, seq, c_out)
+    assert torch.isfinite(y).all()
+
+    # Reference: use pre-op gathered states, run decode helper directly, compare
+    y_ref, updated = (
+        tensorrt_llm._torch.auto_deploy.custom_ops.torch_backend_causal_conv._torch_causal_conv1d_decode(  # type: ignore  # noqa: E501
+            x, w, b, s, p, d, g, pm, gathered_before
+        )
+    )
+    assert torch.allclose(y, y_ref, atol=conv_env["atol"], rtol=conv_env["rtol"])
+    after = conv_state_cache.index_select(0, slot_idx)
+    assert torch.allclose(
+        after, updated.to(after.dtype), atol=conv_env["atol"], rtol=conv_env["rtol"]
+    )
+
+
+def test_context_flattened_and_state_writeback(conv_env):
+    device = conv_env["device"]
+    dtype = conv_env["dtype"]
+
+    # Two sequences with lengths 3 and 2, flattened to [1,5]
+    lens = [3, 2]
+    total = sum(lens)
+    batch, seq = 1, total
+    c_in, c_out, k = 8, 6, 3
+    x, w, b, s, p, d, g, pm = _random_params(device, dtype, batch, seq, c_in, c_out, k)
+
+    max_batch_size = 4
+    slot_idx = torch.tensor([2, 0], device=device, dtype=torch.int32)
+    conv_state_cache = torch.randn(
+        max_batch_size,
+        c_in,
+        k,
+        device=device,
+        dtype=dtype,
+    )
+
+    seq_len = torch.tensor(lens, device=device, dtype=torch.int32)
+    seq_start = torch.tensor([0, lens[0]], device=device, dtype=torch.int32)
+
+    y = torch.ops.auto_deploy.torch_cached_causal_conv1d(
+        # INPUTS
+        x,
+        w,
+        b,
+        # METADATA
+        seq_len,
+        seq_start,
+        slot_idx,
+        # CACHES
+        conv_state_cache,
+        # CONSTANTS
+        s,
+        p,
+        d,
+        g,
+        pm,
+    )
+
+    assert y.shape == (batch, seq, c_out)
+    assert torch.isfinite(y).all()
+
+    # Reference by per-sequence prefill
+    y_ref = torch.empty_like(y)
+    for i, ln in enumerate(lens):
+        st = 0 if i == 0 else lens[0]
+        x_i = x[:, st : st + ln]
+        y_i, s_i = (
+            tensorrt_llm._torch.auto_deploy.custom_ops.torch_backend_causal_conv._torch_causal_conv1d_prefill(  # type: ignore  # noqa: E501
+                x_i, w, b, s, p, d, g, pm
+            )
+        )
+        y_ref[:, st : st + ln].copy_(y_i)
+        # Cache should hold final state at slot
+        assert torch.allclose(
+            conv_state_cache[slot_idx[i]].to(s_i.dtype),
+            s_i,
+            atol=conv_env["atol"],
+            rtol=conv_env["rtol"],
+        )
+
+    assert torch.allclose(y, y_ref.to(y.dtype), atol=conv_env["atol"], rtol=conv_env["rtol"])
+
+
+def test_prepare_metadata(conv_env):
+    device = conv_env["device"]
+
+    b, s = 4, 6
+    input_ids = torch.randint(0, 1000, (b, s), device=device)
+    position_ids = torch.arange(s, device=device).expand(b, -1)
+    seq_len = torch.tensor([2, 1, 0, 0], device=device, dtype=torch.int32)
+    input_pos = torch.tensor([0, 3, 0, 0], device=device, dtype=torch.int32)
+    cache_loc = torch.arange(b, device=device, dtype=torch.int32)
+    pages_per_seq = torch.ones(b, device=device, dtype=torch.int32)
+    slot_idx = torch.tensor([2, 0, 1, 3], device=device, dtype=torch.int32)
+    page_size = 128
+
+    out = torch.ops.auto_deploy.torch_causal_conv_prepare_metadata(
+        input_ids,
+        position_ids,
+        seq_len,
+        input_pos,
+        cache_loc,
+        pages_per_seq,
+        slot_idx,
+        page_size,
+    )
+    assert len(out) == 3
+    seq_len_s, seq_start, slot_s = out
+    assert seq_len_s.numel() == 2 and slot_s.numel() == 2
+    assert torch.all(seq_start == torch.tensor([0, 2], device=device, dtype=seq_start.dtype))

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_torch_mamba_cached_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_torch_mamba_cached_op.py
@@ -1,0 +1,209 @@
+"""Unit tests for cached Mamba (SSM) custom ops.
+
+Covers:
+- Generate-only path with slot-indexed cache mapping
+- Context (flattened) path and state write-back per slot
+- Metadata preparation
+"""
+
+import pytest
+import torch
+
+import tensorrt_llm._torch.auto_deploy  # noqa: F401
+
+
+def _random_params(device, dtype, batch, seq, num_heads, head_dim, n_groups, ssm_state_size):
+    hidden_states = torch.randn(batch, seq, num_heads, head_dim, device=device, dtype=dtype)
+    A = torch.randn(num_heads, device=device, dtype=torch.float32)
+    # B, C live in fp16 typically, but decode/prefill handle casting
+    B = torch.randn(batch, seq, n_groups, ssm_state_size, device=device, dtype=dtype)
+    C = torch.randn(batch, seq, n_groups, ssm_state_size, device=device, dtype=dtype)
+    D = torch.randn(num_heads, device=device, dtype=dtype)
+    dt = torch.randn(batch, seq, num_heads, device=device, dtype=dtype)
+    dt_bias = torch.randn(num_heads, device=device, dtype=dtype)
+    time_step_limit = [1e-6, 1.0]
+    chunk_size = 4
+    return hidden_states, A, B, C, D, dt, dt_bias, time_step_limit, chunk_size
+
+
+@pytest.fixture
+def mamba_env():
+    device = "cuda"
+    dtype = torch.float16
+    atol = 5e-2
+    rtol = 5e-2
+    torch.manual_seed(123)
+    torch.cuda.empty_cache()
+    return {"device": device, "dtype": dtype, "atol": atol, "rtol": rtol}
+
+
+def test_generate_only_with_slot_mapping(mamba_env):
+    device = mamba_env["device"]
+    dtype = mamba_env["dtype"]
+    atol = mamba_env["atol"]
+    rtol = mamba_env["rtol"]
+
+    batch, seq = 3, 1
+    num_heads, head_dim = 4, 8
+    n_groups, ssm_state_size = 2, 4
+    (hidden_states, A, B, C, D, dt, dt_bias, time_step_limit, chunk_size) = _random_params(
+        device, dtype, batch, seq, num_heads, head_dim, n_groups, ssm_state_size
+    )
+
+    # Slot mapping with arbitrary order within max_batch_size
+    max_batch_size = 6
+    slot_idx = torch.tensor([4, 1, 3], device=device, dtype=torch.int32)
+    ssm_state_cache = torch.randn(
+        max_batch_size,
+        num_heads,
+        head_dim,
+        ssm_state_size,
+        device=device,
+        dtype=dtype,
+    )
+
+    # Metadata
+    seq_len = torch.ones(batch, device=device, dtype=torch.int32)
+    seq_start = torch.zeros(batch, device=device, dtype=torch.int32)
+
+    # Snapshot caches for reference before running op (op mutates caches)
+    gathered_before = ssm_state_cache.clone().index_select(0, slot_idx)
+
+    # Run cached op
+    y = torch.ops.auto_deploy.torch_cached_ssm_transform(
+        # INPUTS
+        hidden_states,
+        A,
+        B,
+        C,
+        D,
+        dt,
+        dt_bias,
+        # METADATA
+        seq_len,
+        seq_start,
+        slot_idx,
+        # CACHES
+        ssm_state_cache,
+        # CONSTANTS
+        time_step_limit,
+        chunk_size,
+    )
+
+    assert y.shape == hidden_states.shape
+    assert torch.isfinite(y).all()
+
+    # Reference: use pre-op gathered states, run decode helper directly, compare
+    y_ref, updated = (
+        tensorrt_llm._torch.auto_deploy.custom_ops.torch_backend_mamba._torch_cached_ssm_transform_decode(  # type: ignore  # noqa: E501
+            hidden_states, A, B, C, D, dt, dt_bias, time_step_limit, chunk_size, gathered_before
+        )
+    )
+    # y close to y_ref
+    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol)
+    # Updated states scattered correctly
+    after = ssm_state_cache.index_select(0, slot_idx)
+    assert torch.allclose(after, updated.to(after.dtype), atol=atol, rtol=rtol)
+
+
+def test_context_flattened_and_state_writeback(mamba_env):
+    device = mamba_env["device"]
+    dtype = mamba_env["dtype"]
+    atol = mamba_env["atol"]
+    rtol = mamba_env["rtol"]
+
+    # Two sequences with lengths 3 and 2, flattened to [1,5]
+    lens = [3, 2]
+    total = sum(lens)
+    batch, seq = 1, total
+    num_heads, head_dim = 4, 8
+    n_groups, ssm_state_size = 2, 4
+    (hidden_states, A, B, C, D, dt, dt_bias, time_step_limit, chunk_size) = _random_params(
+        device, dtype, batch, seq, num_heads, head_dim, n_groups, ssm_state_size
+    )
+
+    max_batch_size = 4
+    slot_idx = torch.tensor([2, 0], device=device, dtype=torch.int32)
+    ssm_state_cache = torch.randn(
+        max_batch_size,
+        num_heads,
+        head_dim,
+        ssm_state_size,
+        device=device,
+        dtype=dtype,
+    )
+
+    seq_len = torch.tensor(lens, device=device, dtype=torch.int32)
+    seq_start = torch.tensor([0, lens[0]], device=device, dtype=torch.int32)
+
+    y = torch.ops.auto_deploy.torch_cached_ssm_transform(
+        # INPUTS
+        hidden_states,
+        A,
+        B,
+        C,
+        D,
+        dt,
+        dt_bias,
+        # METADATA
+        seq_len,
+        seq_start,
+        slot_idx,
+        # CACHES
+        ssm_state_cache,
+        # CONSTANTS
+        time_step_limit,
+        chunk_size,
+    )
+
+    assert y.shape == hidden_states.shape
+    assert torch.isfinite(y).all()
+
+    # Reference by per-sequence prefill
+    y_ref = torch.empty_like(hidden_states)
+    for i, ln in enumerate(lens):
+        st = 0 if i == 0 else lens[0]
+        hs = hidden_states[:, st : st + ln]
+        Bb = B[:, st : st + ln]
+        Cb = C[:, st : st + ln]
+        dtb = dt[:, st : st + ln]
+        y_i, s_i = (
+            tensorrt_llm._torch.auto_deploy.custom_ops.torch_mamba._torch_ssm_transform_prefill(  # type: ignore  # noqa: E501
+                hs, A, Bb, Cb, D, dtb, dt_bias, time_step_limit, chunk_size
+            )
+        )
+        y_ref[:, st : st + ln].copy_(y_i)
+        # Cache should hold final state at slot
+        assert torch.allclose(ssm_state_cache[slot_idx[i]].to(s_i.dtype), s_i, atol=atol, rtol=rtol)
+
+    assert torch.allclose(y, y_ref.to(y.dtype), atol=atol, rtol=rtol)
+
+
+def test_prepare_metadata(mamba_env):
+    device = mamba_env["device"]
+
+    b, s = 4, 6
+    input_ids = torch.randint(0, 1000, (b, s), device=device)
+    position_ids = torch.arange(s, device=device).expand(b, -1)
+    seq_len = torch.tensor([2, 1, 0, 0], device=device, dtype=torch.int32)
+    input_pos = torch.tensor([0, 3, 0, 0], device=device, dtype=torch.int32)
+    cache_loc = torch.arange(b, device=device, dtype=torch.int32)
+    pages_per_seq = torch.ones(b, device=device, dtype=torch.int32)
+    slot_idx = torch.tensor([2, 0, 1, 3], device=device, dtype=torch.int32)
+    page_size = 128
+
+    out = torch.ops.auto_deploy.torch_ssm_prepare_metadata(
+        input_ids,
+        position_ids,
+        seq_len,
+        input_pos,
+        cache_loc,
+        pages_per_seq,
+        slot_idx,
+        page_size,
+    )
+    # Returns a list of tensors from custom op API
+    assert len(out) == 3
+    seq_len_s, seq_start, slot_s = out
+    assert seq_len_s.numel() == 2 and slot_s.numel() == 2
+    assert torch.all(seq_start == torch.tensor([0, 2], device=device, dtype=seq_start.dtype))

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_triton_mamba_cached_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_triton_mamba_cached_op.py
@@ -28,6 +28,7 @@ def mamba_env():
     return {"device": device, "dtype": dtype, "atol": atol, "rtol": rtol}
 
 
+@pytest.mark.skip(reason="https://nvbugspro.nvidia.com/bug/5548861")
 def test_triton_generate_only_with_slot_mapping(mamba_env):
     device = mamba_env["device"]
     dtype = mamba_env["dtype"]

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_triton_mamba_cached_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_triton_mamba_cached_op.py
@@ -1,0 +1,169 @@
+import pytest
+import torch
+
+import tensorrt_llm._torch.auto_deploy  # noqa: F401
+
+
+def _random_params(device, dtype, batch, seq, num_heads, head_dim, n_groups, ssm_state_size):
+    hidden_states = torch.randn(batch, seq, num_heads, head_dim, device=device, dtype=dtype)
+    A = torch.randn(num_heads, device=device, dtype=torch.float32)
+    B = torch.randn(batch, seq, n_groups, ssm_state_size, device=device, dtype=dtype)
+    C = torch.randn(batch, seq, n_groups, ssm_state_size, device=device, dtype=dtype)
+    D = torch.randn(num_heads, device=device, dtype=dtype)
+    dt = torch.randn(batch, seq, num_heads, device=device, dtype=dtype)
+    dt_bias = torch.randn(num_heads, device=device, dtype=dtype)
+    time_step_limit = [1e-6, 1.0]
+    chunk_size = 4
+    return hidden_states, A, B, C, D, dt, dt_bias, time_step_limit, chunk_size
+
+
+@pytest.fixture
+def mamba_env():
+    device = "cuda"
+    dtype = torch.float16
+    atol = 5e-2
+    rtol = 5e-2
+    torch.manual_seed(123)
+    torch.cuda.empty_cache()
+    return {"device": device, "dtype": dtype, "atol": atol, "rtol": rtol}
+
+
+def test_triton_generate_only_with_slot_mapping(mamba_env):
+    device = mamba_env["device"]
+    dtype = mamba_env["dtype"]
+    atol = mamba_env["atol"]
+    rtol = mamba_env["rtol"]
+
+    batch, seq = 3, 1
+    num_heads, head_dim = 4, 8
+    n_groups, ssm_state_size = 2, 4
+    (hidden_states, A, B, C, D, dt, dt_bias, time_step_limit, chunk_size) = _random_params(
+        device, dtype, batch, seq, num_heads, head_dim, n_groups, ssm_state_size
+    )
+
+    max_batch_size = 6
+    slot_idx = torch.tensor([4, 1, 3], device=device, dtype=torch.int32)
+    ssm_state_cache_torch = torch.randn(
+        max_batch_size, num_heads, head_dim, ssm_state_size, device=device, dtype=dtype
+    )
+    ssm_state_cache_triton = ssm_state_cache_torch.clone()
+
+    seq_len = torch.ones(batch, device=device, dtype=torch.int32)
+    seq_start = torch.zeros(batch, device=device, dtype=torch.int32)
+
+    # Torch reference
+    y_torch = torch.ops.auto_deploy.torch_cached_ssm_transform(
+        hidden_states,
+        A,
+        B,
+        C,
+        D,
+        dt,
+        dt_bias,
+        seq_len,
+        seq_start,
+        slot_idx,
+        ssm_state_cache_torch,
+        time_step_limit,
+        chunk_size,
+    )
+
+    # Triton under test
+    y_triton = torch.ops.auto_deploy.triton_cached_ssm_transform(
+        hidden_states,
+        A,
+        B,
+        C,
+        D,
+        dt,
+        dt_bias,
+        seq_len,
+        seq_start,
+        slot_idx,
+        ssm_state_cache_triton,
+        time_step_limit,
+        chunk_size,
+    )
+
+    assert y_triton.shape == hidden_states.shape
+    assert torch.isfinite(y_triton).all()
+
+    # Compare outputs
+    assert torch.allclose(y_triton, y_torch.to(y_triton.dtype), atol=atol, rtol=rtol)
+
+    # Compare cache updates at slots
+    after_torch = ssm_state_cache_torch.index_select(0, slot_idx)
+    after_triton = ssm_state_cache_triton.index_select(0, slot_idx)
+    assert torch.allclose(after_triton.to(after_torch.dtype), after_torch, atol=atol, rtol=rtol)
+
+
+def test_triton_context_flattened_and_state_writeback(mamba_env):
+    device = mamba_env["device"]
+    dtype = mamba_env["dtype"]
+    atol = mamba_env["atol"]
+    rtol = mamba_env["rtol"]
+
+    lens = [2]
+    total = sum(lens)
+    batch, seq = 1, total
+    num_heads, head_dim = 1, 4
+    n_groups, ssm_state_size = 1, 1
+    (hidden_states, A, B, C, D, dt, dt_bias, time_step_limit, chunk_size) = _random_params(
+        device, dtype, batch, seq, num_heads, head_dim, n_groups, ssm_state_size
+    )
+
+    max_batch_size = 2
+    slot_idx = torch.tensor([1], device=device, dtype=torch.int32)
+    ssm_state_cache_torch = torch.randn(
+        max_batch_size, num_heads, head_dim, ssm_state_size, device=device, dtype=dtype
+    )
+    ssm_state_cache_triton = ssm_state_cache_torch.clone()
+
+    seq_len = torch.tensor(lens, device=device, dtype=torch.int32)
+    seq_start = torch.tensor([0, lens[0]], device=device, dtype=torch.int32)
+
+    # Torch reference
+    y_torch = torch.ops.auto_deploy.torch_cached_ssm_transform(
+        hidden_states,
+        A,
+        B,
+        C,
+        D,
+        dt,
+        dt_bias,
+        seq_len,
+        seq_start,
+        slot_idx,
+        ssm_state_cache_torch,
+        time_step_limit,
+        chunk_size,
+    )
+
+    # Triton under test
+    y_triton = torch.ops.auto_deploy.triton_cached_ssm_transform(
+        hidden_states,
+        A,
+        B,
+        C,
+        D,
+        dt,
+        dt_bias,
+        seq_len,
+        seq_start,
+        slot_idx,
+        ssm_state_cache_triton,
+        time_step_limit,
+        chunk_size,
+    )
+
+    assert y_triton.shape == hidden_states.shape
+    assert torch.isfinite(y_triton).all()
+    # Compare outputs
+    assert torch.allclose(y_triton, y_torch.to(y_triton.dtype), atol=1e-1, rtol=1e-1)
+
+    # Cache should hold final state at slots
+    for i, ln in enumerate(lens):
+        slot = slot_idx[i]
+        state_torch = ssm_state_cache_torch[slot]
+        state_triton = ssm_state_cache_triton[slot]
+        assert torch.allclose(state_triton.to(state_torch.dtype), state_torch, atol=atol, rtol=rtol)

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_bamba.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_bamba.py
@@ -1,0 +1,172 @@
+import torch  # noqa
+import torch.export as te
+from torch.export import Dim  # noqa
+import pytest
+from tensorrt_llm._torch.auto_deploy.export import apply_export_patches, torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.llm_args import AutoDeployConfig
+from tensorrt_llm._torch.auto_deploy.transformations._graph import move_to_device  # noqa
+
+MODEL_DIR = "ibm-ai-platform/Bamba-9B-v2"
+EXAMPLE_INPUT = "Mamba is a snake with the following properties:"
+
+
+@pytest.mark.parametrize(
+    "model_on_meta_during_export",
+    [
+        True,
+        # False,
+    ],
+)
+@pytest.mark.parametrize(
+    "export_func",
+    [
+        "torch_export_to_gm",
+        # "torch_export",
+    ],
+)
+def test_bamba_patches(model_on_meta_during_export: bool, export_func: str):
+    llm_args = AutoDeployConfig(
+        **{
+            "model": MODEL_DIR,
+            "world_size": 0,
+            "runtime": "demollm",
+            "compile_backend": "torch-simple",
+            "attn_backend": "flashinfer",
+            "model_factory": "AutoModelForCausalLM",
+            "model_kwargs": {
+                "use_cache": False,
+                "torch_dtype": "bfloat16",
+                "num_hidden_layers": 10,
+            },
+            "max_seq_len": 512,
+            "skip_loading_weights": False,
+        },
+    )
+
+    factory = llm_args.create_factory()
+    model = factory.build_model("meta")
+    tokenizer = factory.init_tokenizer()
+
+    # 1. Export wants min batch size of 2 (to avoid specialization during export).
+    # 2. Can't get `padding` / `truncation` to work without other steps so just use the same prompt
+    #    twice in order for the tokenizer not to complain when creating the tensor.
+    message = [EXAMPLE_INPUT] * 2
+    inputs = tokenizer(message, return_tensors="pt", return_token_type_ids=False).to("cuda")
+
+    input_ids = inputs["input_ids"]
+    position_ids = torch.arange(input_ids.shape[1], device=input_ids.device).repeat(
+        input_ids.shape[0], 1
+    )
+    dynamic_shapes = (
+        {0: Dim("batch_size", min=0, max=8), 1: Dim("seq_len", min=0, max=512)},
+        {
+            0: Dim("batch_size", min=0, max=8),
+            1: Dim("seq_len", min=0, max=512),
+        },
+    )
+
+    def _run_torch_export_to_gm():
+        return torch_export_to_gm(
+            model,
+            args=(input_ids, position_ids),
+            dynamic_shapes=dynamic_shapes,
+            patch_list=[
+                "bamba",
+                # For "unsupported scalarType".
+                "autocast_noop",
+            ],
+        )
+
+    def _run_torch_export():
+        with apply_export_patches(patch_list=["bamba", "autocast_noop"]):
+            with torch.inference_mode():
+                ep = te.export(
+                    model,
+                    args=(input_ids, position_ids),
+                    dynamic_shapes=dynamic_shapes,
+                    strict=False,
+                )
+            egm = ep.module()
+        return egm
+
+    def _run_export():
+        if export_func == "torch_export_to_gm":
+            return _run_torch_export_to_gm()
+        else:
+            return _run_torch_export()
+
+    if model_on_meta_during_export:
+        gm = _run_export()
+        factory.load_or_random_init(gm, device="cuda")
+        move_to_device(gm, "cuda")
+
+    factory.load_or_random_init(model, device="cuda")
+
+    print("====== EXPORTING GRAPH MODULE ======")
+    if not model_on_meta_during_export:
+        gm = _run_export()
+        move_to_device(gm, "cuda")
+
+    gm.model.A_log = model.model.A_log
+
+    # let's do a comparison of every state dict item between the model and the gm
+    torch.testing.assert_close(model.state_dict(), gm.state_dict(), rtol=0.0, atol=0.0)
+
+    _verify_generation(factory, model, tokenizer)
+
+    outputs_for_comparison = {}
+    with torch.inference_mode():
+        out_original = model(input_ids=input_ids, position_ids=position_ids)
+        with apply_export_patches(patch_list=["bamba"]):
+            outputs_for_comparison["patched"] = model(
+                input_ids=input_ids, position_ids=position_ids
+            )
+
+    with torch.inference_mode():
+        outputs_for_comparison["gm"] = gm(input_ids, position_ids)
+
+    atol, rtol = 1e-3, 1e-3
+    for comp, outs in outputs_for_comparison.items():
+        print(f"====== COMPARISON ({comp}) ======")
+        try:
+            torch.testing.assert_close(
+                outs,
+                out_original,
+                rtol=rtol,
+                atol=atol,
+            )
+            print("Passed!")
+        except AssertionError as e:
+            print(e)
+            diff = torch.abs(outs.logits - out_original.logits)
+            print(f"abs diff: {diff}")
+            print(f"average diff: {diff.mean()}")
+            print(f"{comp=}")
+
+
+# NOTE: remember to augment `_simple_forward` to pass `*args, **kwargs`.
+def _verify_generation(factory, model, tokenizer):
+    # print("====== WITHOUT PATCH ======")
+    # _generate(tokenizer, model)
+    with apply_export_patches(patch_list=["bamba"]):
+        print("====== WITH PATCH ======")
+        _generate(tokenizer, model)
+
+
+def _generate(tokenizer, model):
+    message = [EXAMPLE_INPUT]
+    inputs = tokenizer(message, return_tensors="pt", return_token_type_ids=False).to(model.device)
+    response = model.generate(**inputs, max_new_tokens=64)
+    print(tokenizer.batch_decode(response, skip_special_tokens=True)[0])
+
+
+# def _get_example_inputs(llm_args, factory, device):
+#     batch_size = min(2, llm_args.max_batch_size)
+#     seq_len = min(4, llm_args.max_seq_len)
+#     inputs = {"input_ids": torch.ones(batch_size, seq_len, dtype=torch.int)}
+#     for key, value in inputs.items():
+#         if isinstance(value, torch.Tensor):
+#             dtype = torch.bfloat16 if isinstance(value, torch.FloatTensor) else None
+#             inputs[key] = value.to(device=device, dtype=dtype)
+#
+#     return inputs

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_bamba.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_bamba.py
@@ -52,6 +52,10 @@ def test_bamba_patches(
         },
     )
 
+    torch.manual_seed(0)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(0)
+
     factory = llm_args.create_factory()
     model = factory.build_model("meta")
     tokenizer = factory.init_tokenizer()

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/shim/test_engine.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/shim/test_engine.py
@@ -52,7 +52,7 @@ def get_inference_model(cache_seq_interface):
 def test_engine(engine_cls: Type[ADEngine], attn_backend: str, attn_page_size: int):
     """Test the SimpleEngine functionality."""
 
-    seed = 1234  # Set random seed for model param init
+    seed = 42  # Set random seed for model param init
     torch.manual_seed(seed)
     if torch.cuda.is_available():
         torch.cuda.manual_seed_all(seed)

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
@@ -49,6 +49,7 @@ def _check_ad_config(experiment_config: ExperimentConfig, llm_args: LlmArgs):
             "meta-llama/Meta-Llama-3.1-8B-Instruct",
             attn_backend="flashinfer",
             compile_backend="torch-opt",
+            free_mem_ratio=0.0001,
         ),
         get_small_model_config_pytest_param(
             "mistralai/Mixtral-8x7B-Instruct-v0.1",

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
@@ -95,12 +95,18 @@ def _check_ad_config(experiment_config: ExperimentConfig, llm_args: LlmArgs):
             attn_backend="flashinfer",
             compile_backend="torch-simple",
         ),
+        get_small_model_config_pytest_param(
+            "nvidia/NVIDIA-Nemotron-Nano-12B-v2",
+            attn_backend="flashinfer",
+            compile_backend="torch-simple",
+        ),
     ],
 )
 def test_build_ad(experiment_config: Dict, mode: str):
     if (
         "DeepSeek-V3" in experiment_config["args"]["model"]
         or "Phi-3-mini-4k-instruct" in experiment_config["args"]["model"]
+        or "NVIDIA-Nemotron-Nano-12B-v2" in experiment_config["args"]["model"]
         and mode == "transformers"
     ):
         pytest.skip(f"{experiment_config['args']['model']} is not supported in transformers mode")

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_attention_matcher.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_attention_matcher.py
@@ -1157,7 +1157,6 @@ class BsndAttentionModel(AttentionLayoutModel):
 @pytest.mark.parametrize(
     "model_config",
     [
-        {"type": "standard", "use_grouped_sdpa": False, "name": "SDPA"},
         {"type": "standard", "use_grouped_sdpa": True, "name": "GroupedSDPA"},
         {"type": "already_bsnd", "name": "DirectBSND"},
     ],


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  - Slot-indexed KV/state caching across attention and SSM paths.
  - Cached causal convolution backend (Torch and CUDA) plus uncached op.
  - Cached SSM/Mamba backends (Torch and Triton) and uncached transform.
  - Expanded grouped-attention patterns with scale/dropout support.
  - Multimodal (image+text) input handling in auto-deploy.
  - Export-time patches for Bamba and Nemotron H models.
  - Added presets for Bamba-9B-v2 and Nemotron-Nano-12B-v2.

* Bug Fixes
  - More robust KV-cache config parsing in server.
  - Scale validation accepts None.

* Refactor/Chores
  - Dynamic custom-ops discovery; logging route update; seed set to 42.

* Tests
  - New unit tests for causal conv, SSM backends (Torch/Triton), attention metadata, and hybrid export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
