### PR TITLE
[TRTLLM-8269][fix] Revert "do not explicitly pass temperature=0 to select greedy sampling"

### DIFF
--- a/tensorrt_llm/evaluate/json_mode_eval.py
+++ b/tensorrt_llm/evaluate/json_mode_eval.py
@@ -64,7 +64,8 @@ class JsonModeEval(Evaluator):
                 schema["x-guidance"] = {"lenient": True}
                 schema = json.dumps(schema)
             sampling_args = {
-                "guided_decoding": GuidedDecodingParams(json=schema)
+                "guided_decoding": GuidedDecodingParams(json=schema),
+                "temperature": 0,
             }
             yield sample["prompt"], sampling_args, sample["completion"], sample[
                 "schema"]

--- a/tensorrt_llm/evaluate/mmlu.py
+++ b/tensorrt_llm/evaluate/mmlu.py
@@ -219,7 +219,7 @@ class MMLU(Evaluator):
                                                  include_answer=False)
                 prompt = train_prompt + prompt_end
                 label = test_df.iloc[i, test_df.shape[1] - 1]
-                yield prompt, None, label, subject
+                yield prompt, {"temperature": 0}, label, subject
 
     def compute_score(self, outputs: List[RequestOutput], references: List[str],
                       subjects: List[str]) -> float:

--- a/tests/unittest/llmapi/apps/_test_openai_misc.py
+++ b/tests/unittest/llmapi/apps/_test_openai_misc.py
@@ -94,9 +94,12 @@ async def test_request_cancellation(server: RemoteOpenAIServer,
     # Request about 2 million tokens
     for _ in range(200):
         task = asyncio.create_task(
+            # FIXME: Some requests complete quickly without temperature=0,
+            #        despite min_tokens being specified, cf. https://nvbugs/5513423
             client.chat.completions.create(messages=chat_input,
                                            model=model_name,
                                            max_tokens=10000,
+                                           temperature=0,
                                            extra_body={"min_tokens": 10000}))
         tasks.append(task)
 


### PR DESCRIPTION
Reverts NVIDIA/TensorRT-LLM#7909

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced deterministic generation in evaluation flows by setting temperature to 0, improving consistency of JSON-mode and MMLU results.

* **Tests**
  * Updated chat completion tests to include temperature=0 for more reliable and predictable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->