### PR TITLE
[None][feat] AutoDeploy: compiler backends based on nn.Module

### DIFF
--- a/examples/auto_deploy/build_and_run_flux.py
+++ b/examples/auto_deploy/build_and_run_flux.py
@@ -5,7 +5,7 @@ import modelopt.torch.opt as mto
 import torch
 from diffusers import DiffusionPipeline
 
-from tensorrt_llm._torch.auto_deploy.compile import compile_and_capture
+from tensorrt_llm._torch.auto_deploy.compile import CompileBackendRegistry
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.transformations.library.fusion import fuse_gemms
 from tensorrt_llm._torch.auto_deploy.transformations.library.quantization import quantize
@@ -143,7 +143,8 @@ def main():
 
     fuse_gemms(gm)
 
-    gm = compile_and_capture(gm, backend="torch-opt", args=(), kwargs=flux_kwargs)
+    compiler_cls = CompileBackendRegistry.get("torch-opt")
+    gm = compiler_cls(gm, args=(), kwargs=flux_kwargs).compile()
 
     del model
     fx_model = gm

--- a/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_compile.py
+++ b/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_compile.py
@@ -5,15 +5,15 @@ import torch.nn as nn
 
 from tensorrt_llm._torch.auto_deploy.utils.logger import ad_logger
 
-from ..compiler import BackendCompiler, BackendRegistry
+from ..compiler import CompileBackendRegistry, CompilerBackend
 
 
-@BackendRegistry.register("torch-compile")
-class TorchCompileCompiler(BackendCompiler):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+@CompileBackendRegistry.register("torch-compile")
+class TorchCompileCompiler(CompilerBackend):
+    def __init__(self, *args_for_init, **kwargs_for_init):
+        super().__init__(*args_for_init, **kwargs_for_init)
         ad_logger.info(f"Torch Dynamo cache size limit {torch._dynamo.config.cache_size_limit=}")
 
     def compile(self) -> nn.Module:
         """Compile the model using torch.compile."""
-        return torch.compile(self.gm, dynamic=True)
+        return torch.compile(self.model, dynamic=True)

--- a/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_cudagraph.py
+++ b/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_cudagraph.py
@@ -5,30 +5,39 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple
 import torch
 import torch.nn as nn
 from torch.cuda import CUDAGraph
-from torch.utils._pytree import TreeSpec, tree_flatten
+from torch.fx._pytree import tree_flatten_spec
+from torch.utils._pytree import PyTree, TreeSpec, tree_flatten
 
 from ...utils.cuda_graph import CudaGraphWarmUpPhase
 from ...utils.logger import ad_logger
-from ..compiler import BackendCompiler, BackendRegistry, _flatten_args
+from ..compiler import CompileBackendRegistry, CompilerBackend
+
+
+def _args_kwargs_flatten_spec(in_spec: TreeSpec, *args, **kwargs) -> List[Any]:
+    """Flatten inputs according to provided in_spec."""
+    all_args: PyTree = (args, kwargs)
+    return tree_flatten_spec(all_args, in_spec)
+
+
+def _args_kwargs_flatten(*args, **kwargs) -> Tuple[List[Any], TreeSpec]:
+    """Flatten inputs and return flattened inputs together with the TreeSpec."""
+    all_args: PyTree = (args, kwargs)
+    return tree_flatten(all_args)
 
 
 class CapturedGraph(nn.Module):
     def __init__(
         self,
         model: nn.Module,
-        in_spec: TreeSpec,
-        out_spec: TreeSpec,
         cuda_graph_batch_sizes: List[int],
-        num_batched_inputs: Optional[int] = 1,  # number of batched, dynamic inputs...
+        num_batched_inputs: int,  # number of batched, dynamic inputs...
     ):
         super().__init__()
-        self._in_spec = in_spec
-        self._out_spec = out_spec
         self.model = model
         self.cuda_graph_max_batch_size = max(cuda_graph_batch_sizes)
         ad_logger.info(f"Setting {self.cuda_graph_max_batch_size=}")
         self.num_batched_inputs = num_batched_inputs if num_batched_inputs is not None else 1
-        self.graphs: Dict[Tuple[int, ...], CUDAGraph] = {}
+        self.cudagraphs: Dict[Tuple[int, ...], CUDAGraph] = {}
         self._input_buffers: List[torch.Tensor] = [
             torch.empty(0, 1) for _ in range(self.num_batched_inputs)
         ]
@@ -36,6 +45,10 @@ class CapturedGraph(nn.Module):
         self._args_hash: Optional[Tuple[int, ...]] = None
         self.cuda_graph_batch_sizes = sorted(cuda_graph_batch_sizes, reverse=True)
         self._cuda_graph_mem_pool = None
+
+        # store the in_spec and out_spec during graph capture
+        self._in_spec = None
+        self._out_spec = None
 
     def _get_hash(self, flat_args: List[Any]) -> Tuple[int, ...]:
         return tuple(hash(a) for a in flat_args)
@@ -65,8 +78,7 @@ class CapturedGraph(nn.Module):
             # compute output
             out = self.model(*args, **kwargs)
             # write out into output buffer up to out batch size
-            out_flat, out_spec = tree_flatten(out)
-            assert out_spec == self._out_spec, "Output spec mismatch."
+            out_flat = tree_flatten_spec(out, self._out_spec)
             for o_buffer, o in zip(self._out_buffer_flat, out_flat):
                 o_buffer[: o.shape[0]] = o
         torch.cuda.synchronize()
@@ -75,8 +87,11 @@ class CapturedGraph(nn.Module):
 
     def capture_graph(self, *args, **kwargs):
         """Capture and pre-fetch the graph for variable batch size."""
-        # flatten args, kwargs
-        all_args_flat = _flatten_args(self._in_spec, *args, **kwargs)
+        # check this is the first time we capture the graph
+        assert not self.cudagraphs, "Graphs already captured."
+
+        # flatten args, kwargs for the first time and record in_spec
+        all_args_flat, self._in_spec = _args_kwargs_flatten(*args, **kwargs)
 
         # extract the batched input tensors
         args_batched = all_args_flat[: self.num_batched_inputs]
@@ -94,10 +109,8 @@ class CapturedGraph(nn.Module):
             f"than the max_batch_size? It will fall back to non-CUDA graph forward pass for "
             f"batch sizes exceeding the max_batch_size."
         )
-        msg_ndim = "Expecting at least a 2D for batched input tensors."
         if any(self.cuda_graph_max_batch_size < input.shape[0] for input in args_batched):
             ad_logger.info(msg_bs)
-        assert all(input.ndim > 1 for input in args_batched), msg_ndim
 
         # repeat the batched input tensors to the cuda_graph_max_batch_size
         self._input_buffers = [
@@ -109,11 +122,11 @@ class CapturedGraph(nn.Module):
         args, kwargs = self._in_spec.unflatten(self._input_buffers + args_static)
 
         # capture output once with cuda_graph_max_batch_size to capture output buffers
+        # store the out_spec at this point
         with CudaGraphWarmUpPhase():
             ad_logger.info(f"Warm up with {self.cuda_graph_max_batch_size=} before graph capture")
             out = self.model(*args, **kwargs)
-        self._out_buffer_flat, out_spec = tree_flatten(out)
-        assert out_spec == self._out_spec, "Output spec mismatch."
+        self._out_buffer_flat, self._out_spec = tree_flatten(out)
 
         # capture graph now for a range of batch sizes
         for bs in self.cuda_graph_batch_sizes:
@@ -125,12 +138,12 @@ class CapturedGraph(nn.Module):
 
             # capture graph for truncated inputs
             combined_shape = sum((input.shape for input in inputs_truncated), start=())
-            self.graphs[combined_shape] = self._capture_one_graph(*args, **kwargs)
+            self.cudagraphs[combined_shape] = self._capture_one_graph(*args, **kwargs)
 
     def forward(self, *args, **kwargs) -> Any:
         """Run the compiled graph."""
         # flatten args, kwargs
-        all_args_flat = _flatten_args(self._in_spec, *args, **kwargs)
+        all_args_flat = _args_kwargs_flatten_spec(self._in_spec, *args, **kwargs)
 
         # extract the batched input tensors
         args_batched = all_args_flat[: self.num_batched_inputs]
@@ -148,7 +161,7 @@ class CapturedGraph(nn.Module):
         combined_shape = sum(rounded_shapes, start=())
 
         # regular forward for non-matching shapes
-        if combined_shape not in self.graphs:
+        if combined_shape not in self.cudagraphs:
             return self.model(*args, **kwargs)
 
         # copy inputs to input buffers
@@ -156,7 +169,7 @@ class CapturedGraph(nn.Module):
             self._input_buffers[i][: input_tensor.shape[0]].copy_(input_tensor, non_blocking=True)
 
         # run forward pass via graph
-        self.graphs[combined_shape].replay()
+        self.cudagraphs[combined_shape].replay()
 
         # retrieve output from buffer, cut to batch size, and unflatten
         bs = args_batched[0].shape[0]
@@ -164,14 +177,28 @@ class CapturedGraph(nn.Module):
         return self._out_spec.unflatten(out_flat)
 
 
-@BackendRegistry.register("torch-cudagraph")
-class TorchCudagraphCompiler(BackendCompiler):
+@CompileBackendRegistry.register("torch-cudagraph")
+class TorchCudagraphCompiler(CompilerBackend):
     """Compiler that uses only CUDA graphs."""
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        requested = self.compiler_kwargs.get("cuda_graph_batch_sizes")
-        if not requested:
+    def __init__(
+        self,
+        *args_for_init,
+        cuda_graph_batch_sizes: Optional[List[int]] = None,
+        num_batched_inputs: int = 1,
+        max_batch_size: Optional[int] = None,
+        **kwargs_for_init,
+    ):
+        super().__init__(*args_for_init, **kwargs_for_init)
+
+        # heuristic to identify max batch size
+        assert max_batch_size or cuda_graph_batch_sizes, (
+            "At least one of max_batch_size or cuda_graph_batch_sizes must be provided."
+        )
+        self.max_batch_size = max_batch_size or max(cuda_graph_batch_sizes)
+
+        self.num_batched_inputs = num_batched_inputs
+        if not cuda_graph_batch_sizes:
             # Use heuristic which includes commonly-used sizes like 1 and max_bs
             self.cuda_graph_batch_sizes = self._get_graph_batch_sizes(self.max_batch_size)
             ad_logger.info(f"Using heuristic cuda_graph_batch_sizes: {self.cuda_graph_batch_sizes}")
@@ -180,13 +207,15 @@ class TorchCudagraphCompiler(BackendCompiler):
             # No point capturing CUDA graphs for batch sizes larger than max_batch_size
             effective = {
                 min(max(1, int(b)), int(self.max_batch_size))
-                for b in requested
+                for b in cuda_graph_batch_sizes
                 if isinstance(b, (int, float)) and b > 0
             }
             self.cuda_graph_batch_sizes = sorted(effective, reverse=True)
 
             # Log if we clamped any values
-            original_values = [int(b) for b in requested if isinstance(b, (int, float)) and b > 0]
+            original_values = [
+                int(b) for b in cuda_graph_batch_sizes if isinstance(b, (int, float)) and b > 0
+            ]
             clamped_values = [v for v in original_values if v > self.max_batch_size]
             if clamped_values:
                 ad_logger.info(
@@ -194,25 +223,18 @@ class TorchCudagraphCompiler(BackendCompiler):
                 )
 
             ad_logger.info(
-                f"Using explicit cuda_graph_batch_sizes: requested={requested}"
+                f"Using explicit cuda_graph_batch_sizes: requested={cuda_graph_batch_sizes}"
                 f" -> effective={self.cuda_graph_batch_sizes}"
                 f" (clamped to [1, {self.max_batch_size}])"
             )
 
-    def _init_captured_graph(
-        self, gm: nn.Module, in_spec: TreeSpec, out_spec: TreeSpec
-    ) -> CapturedGraph:
-        return CapturedGraph(
-            gm,
-            in_spec=in_spec,
-            out_spec=out_spec,
-            cuda_graph_batch_sizes=self.cuda_graph_batch_sizes,
-            num_batched_inputs=self.compiler_kwargs.get("num_batched_inputs"),
-        )
-
     @torch.inference_mode()
     def compile(self) -> CapturedGraph:
-        captured_model = self._init_captured_graph(self.gm, self.gm._in_spec, self.gm._out_spec)
+        captured_model = CapturedGraph(
+            self.model,
+            cuda_graph_batch_sizes=self.cuda_graph_batch_sizes,
+            num_batched_inputs=self.num_batched_inputs,
+        )
 
         # try capturing cudagraph
         if self.args is not None or self.kwargs is not None:

--- a/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_opt.py
+++ b/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_opt.py
@@ -1,19 +1,20 @@
 """Mixed backend with torch.compile + Cudagraph."""
 
 import torch
+import torch.nn as nn
 
 from tensorrt_llm._torch.auto_deploy.utils.logger import ad_logger
 
-from ..compiler import BackendRegistry
-from .torch_cudagraph import CapturedGraph, TorchCudagraphCompiler
+from ..compiler import CompileBackendRegistry
+from .torch_cudagraph import TorchCudagraphCompiler
 
 
-@BackendRegistry.register("torch-opt")
+@CompileBackendRegistry.register("torch-opt")
 class TorchOptCompiler(TorchCudagraphCompiler):
     """Compiler that uses both torch.compile and CUDA graphs."""
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, *args_for_init, **kwargs_for_init):
+        super().__init__(*args_for_init, **kwargs_for_init)
         torch._dynamo.config.recompile_limit = max(
             len(self.cuda_graph_batch_sizes), torch._dynamo.config.recompile_limit
         )
@@ -22,6 +23,6 @@ class TorchOptCompiler(TorchCudagraphCompiler):
             f"{torch._dynamo.config.cache_size_limit=}"
         )
 
-    def _init_captured_graph(self, gm, in_spec, out_spec) -> CapturedGraph:
-        gm = torch.compile(gm, dynamic=True)
-        return super()._init_captured_graph(gm, in_spec, out_spec)
+    def compile(self) -> nn.Module:
+        self.model = torch.compile(self.model, dynamic=True)
+        return super().compile()

--- a/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_simple.py
+++ b/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_simple.py
@@ -2,10 +2,10 @@
 
 import torch.nn as nn
 
-from ..compiler import BackendCompiler, BackendRegistry
+from ..compiler import CompileBackendRegistry, CompilerBackend
 
 
-@BackendRegistry.register("torch-simple")
-class TorchCompiler(BackendCompiler):
+@CompileBackendRegistry.register("torch-simple")
+class TorchCompiler(CompilerBackend):
     def compile(self) -> nn.Module:
-        return self.gm
+        return self.model

--- a/tensorrt_llm/_torch/auto_deploy/compile/compiler.py
+++ b/tensorrt_llm/_torch/auto_deploy/compile/compiler.py
@@ -3,30 +3,18 @@
 This is useful as final optimization step for in-framework deployment of our inference models.
 """
 
-import time
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import Any, Dict, Optional, Tuple, Type
 
 import torch.nn as nn
-from torch.fx import GraphModule
-from torch.fx._pytree import tree_flatten_spec
-from torch.utils._pytree import PyTree
-
-from ..utils.logger import ad_logger
 
 
-def _flatten_args(in_spec, *args, **kwargs) -> List[Any]:
-    """Flatten inputs from in_spec where we assume the first input is the main input tensor."""
-    all_args: PyTree = (args, kwargs)
-    return tree_flatten_spec(all_args, in_spec)
-
-
-class BackendRegistry:
-    _backend_registry: Dict[str, Type["BackendCompiler"]] = {}
+class CompileBackendRegistry:
+    _backend_registry: Dict[str, Type["CompilerBackend"]] = {}
 
     @classmethod
-    def register(cls, backend: str) -> Type["BackendCompiler"]:
-        def decorator(compiler_cls: Type["BackendCompiler"]):
+    def register(cls, backend: str) -> Type["CompilerBackend"]:
+        def decorator(compiler_cls: Type["CompilerBackend"]):
             assert backend not in cls._backend_registry, f"Backend {backend} already registered."
             cls._backend_registry[backend] = compiler_cls
             return compiler_cls
@@ -34,7 +22,7 @@ class BackendRegistry:
         return decorator
 
     @classmethod
-    def get(cls, backend: str) -> Type["BackendCompiler"]:
+    def get(cls, backend: str) -> Type["CompilerBackend"]:
         assert cls.has(backend), f"Backend {backend} not registered."
         return cls._backend_registry[backend]
 
@@ -43,58 +31,18 @@ class BackendRegistry:
         return backend in cls._backend_registry
 
 
-class BackendCompiler(ABC):
-    max_batch_size: int
-
+class CompilerBackend(ABC):
     def __init__(
         self,
-        gm: GraphModule,
+        model: nn.Module,
         args: Tuple[Any, ...],
         kwargs: Optional[Dict[str, Any]] = None,
-        dynamic_shapes=None,
-        compiler_kwargs: Optional[Dict[str, Any]] = None,
+        **compiler_kwargs,
     ):
-        self.gm = gm
+        self.model = model
         self.args = args
         self.kwargs = kwargs or {}
-        self.dynamic_shapes = dynamic_shapes
-        self.compiler_kwargs = compiler_kwargs or {}
-        # identify max_batch_size
-        if self.dynamic_shapes is not None and 0 in self.dynamic_shapes[0]:
-            self.max_batch_size = self.dynamic_shapes[0][0].max
-        else:
-            # NOTE: we assume the first input is the main input tensor with batch dimension
-            batched_input, *_ = _flatten_args(self.gm._in_spec, *self.args, **self.kwargs)
-            self.max_batch_size = batched_input.shape[0]
 
     @abstractmethod
     def compile(self) -> nn.Module:
         raise NotImplementedError
-
-
-def compile_and_capture(
-    gm: GraphModule,
-    backend: str,
-    args: Tuple[Any, ...],
-    kwargs: Optional[Dict[str, Any]] = None,
-    dynamic_shapes=None,
-    compiler_kwargs: Optional[Dict[str, Any]] = None,
-) -> nn.Module:
-    """Compile or capture graph for single-token generation."""
-    elapsed_time = -time.time()
-    ad_logger.info("Fusion before compiling...")
-
-    # Try to get the requested backend, fall back to torch-simple if not found
-    if not BackendRegistry.has(backend):
-        ad_logger.warning(f"Backend '{backend}' not found. Falling back to 'torch-simple' backend.")
-        backend = "torch-simple"
-
-    ad_logger.info(f"Compiling for {backend} backend...")
-
-    compiler_cls = BackendRegistry.get(backend)
-    compiled_module = compiler_cls(gm, args, kwargs, dynamic_shapes, compiler_kwargs).compile()
-
-    elapsed_time += time.time()
-    ad_logger.info(f"Compile time with backend {backend}: {elapsed_time:.6f} seconds")
-
-    return compiled_module

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -304,7 +304,7 @@ class SequenceInfo:
         return tuple(getattr(self, k) for k in self._cached_constants)
 
     @property
-    def named_dynamic_shapes(self) -> Dict[str, Dict[str, Dim]]:
+    def named_dynamic_shapes(self) -> Dict[str, DynamicShape]:
         """Return dynamic shapes of sequence info tensors.
 
         NOTE: will be lazily initialized since the Dim object is not picklable for multi-processing.

--- a/tensorrt_llm/_torch/auto_deploy/transform/interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/interface.py
@@ -3,17 +3,24 @@
 This module defines the base classes and interfaces for all transforms.
 """
 
+import time
 from abc import ABC, abstractmethod
 from enum import Enum
-from functools import total_ordering
+from functools import total_ordering, wraps
 from typing import Any, Callable, Dict, Mapping, Tuple, Type, Union, final
 
+import torch.nn as nn
 from pydantic import BaseModel, Field
 from torch.fx import GraphModule
 
 from ..models.factory import ModelFactory
 from ..shim.interface import CachedSequenceInterface
-from ..transformations._graph import canonicalize_graph, lift_to_meta, run_shape_prop
+from ..transformations._graph import (
+    canonicalize_graph,
+    lift_to_meta,
+    named_graphmodules,
+    run_shape_prop,
+)
 from ..utils.logger import ad_logger
 from ..utils.sharding_utils import ShardingConfig
 
@@ -71,6 +78,10 @@ class TransformConfig(BaseModel):
     )
 
     ### OPTIONAL CONFIG ###########################################################################
+    run_per_gm: bool = Field(
+        description="Whether to run the transform per graph (sub)module or on whole module.",
+        default=False,
+    )
     enabled: bool = Field(
         default=True,
         description="Whether to enable this transform.",
@@ -136,6 +147,39 @@ class TransformInfo(BaseModel):
 TransformHistory = Dict[str, TransformInfo]
 
 
+def with_transform_logging(call_fn: Callable) -> Callable:
+    """Decorator to prepend transform-specific prefix to all ad_logger logs during __call__.
+
+    Temporarily patches `ad_logger.log` so that any logs emitted within the call automatically
+    include the `[stage=..., transform=...]` prefix that `_log_info` would otherwise add manually.
+    The original logger behavior is restored after the call, even if an exception occurs.
+    """
+
+    @wraps(call_fn)
+    def _wrapper(
+        self,
+        gm: nn.Module,
+        cm: CachedSequenceInterface,
+        factory: ModelFactory,
+        shared_config: SharedConfig,
+    ) -> nn.Module:
+        prefix = f"[stage={self.config.stage.value}, transform={self.get_transform_key()}]"
+        original_log = ad_logger.log
+
+        def _patched_log(severity, *msg):
+            if msg and isinstance(msg[0], str) and msg[0].startswith(prefix):
+                return original_log(severity, *msg)
+            return original_log(severity, prefix, *msg)
+
+        ad_logger.log = _patched_log  # type: ignore[assignment]
+        try:
+            return call_fn(self, gm, cm, factory, shared_config)
+        finally:
+            ad_logger.log = original_log  # type: ignore[assignment]
+
+    return _wrapper
+
+
 class BaseTransform(ABC):
     """A base class for all transforms."""
 
@@ -198,14 +242,15 @@ class BaseTransform(ABC):
         config = cls.get_config_class()(**kwargs)
         return cls(config=config)
 
+    @with_transform_logging
     @final
     def __call__(
         self,
-        gm: GraphModule,
+        gm: nn.Module,
         cm: CachedSequenceInterface,
         factory: ModelFactory,
         shared_config: SharedConfig,
-    ) -> GraphModule:
+    ) -> nn.Module:
         """Apply the transform to the graph.
 
         Args:
@@ -239,22 +284,32 @@ class BaseTransform(ABC):
         # show debug info for debug config
         ad_logger.debug(f"{t_name} config: {self.config}")
 
+        # store some timing information
+        elapsed_time_total = -time.time()
+        elapsed_time_pre_cleanup = 0.0
+        elapsed_time_apply = 0.0
+        elapsed_time_post_cleanup = 0.0
+
         # run or skip the transform
         if self.config.enabled:
             # run graph pre-cleanup
+            elapsed_time_pre_cleanup = -time.time()
             is_clean_pre, has_valid_shapes_pre = self._run_pre_cleanup(gm, info_last)
+            elapsed_time_pre_cleanup += time.time()
 
             # run the transform in a error-handling wrapper if desired
+            elapsed_time_apply = -time.time()
             if self.config.skip_on_error:
                 try:
-                    gm, info = self._apply(gm, cm, factory, shared_config)
+                    gm, info = self._apply_per_gm(gm, cm, factory, shared_config)
                 except Exception as e:
                     error_msg = f"Transform {t_name} failed"
                     ad_logger.warning(f"{error_msg}: {e}")
                     info = TransformInfo(skipped=True, num_matches=0)
             else:
                 # handle this here normally to improve debugging and error message
-                gm, info = self._apply(gm, cm, factory, shared_config)
+                gm, info = self._apply_per_gm(gm, cm, factory, shared_config)
+            elapsed_time_apply += time.time()
 
             # we cannot say it's clean if the previous wasn't clean even if this one is
             # create new info object with updated cleanup status
@@ -264,13 +319,17 @@ class BaseTransform(ABC):
             info = TransformInfo(**info_dict)
 
             # run graph post-cleanup
+            elapsed_time_post_cleanup = -time.time()
             info = self._run_post_cleanup(gm, info)
+            elapsed_time_post_cleanup += time.time()
         else:
             # skip the transform and set info object using the last transform info
             info_dict = info_last.model_dump()
             info_dict["skipped"] = True
             info_dict["num_matches"] = 0
             info = TransformInfo(**info_dict)
+
+        elapsed_time_total += time.time()
 
         # log the result of the transform
         log_msgs = [
@@ -280,6 +339,13 @@ class BaseTransform(ABC):
             f"has_valid_shapes={info.has_valid_shapes}",
         ]
         self._log_info(", ".join(log_msgs))
+        log_msgs_timing = [
+            f"elapsed time: total={elapsed_time_total:.3f}s",
+            f"pre_cleanup={elapsed_time_pre_cleanup:.3f}s",
+            f"apply={elapsed_time_apply:.3f}s",
+            f"post_cleanup={elapsed_time_post_cleanup:.3f}s",
+        ]
+        self._log_info(", ".join(log_msgs_timing))
         ad_logger.debug(f"Graph after {t_name}: {gm}")
 
         # update + store new meta data
@@ -291,14 +357,36 @@ class BaseTransform(ABC):
         return gm
 
     @final
+    def _apply_per_gm(
+        self,
+        gm: nn.Module,
+        cm: CachedSequenceInterface,
+        factory: ModelFactory,
+        shared_config: SharedConfig,
+    ) -> Tuple[GraphModule, TransformInfo]:
+        if not self.config.run_per_gm:
+            return self._apply(gm, cm, factory, shared_config)
+
+        # just run it on first graph module we are encountering for now...
+        for k, graph_sub in named_graphmodules(gm):
+            graph_sub, info = self._apply(graph_sub, cm, factory, shared_config)
+            if k == "":
+                gm = graph_sub
+            else:
+                gm.set_submodule(k, graph_sub)
+            break
+        return gm, info
+
+    @final
     def _log_info(self, *args: any):
         """Log a message with the transform key."""
-        prefix = f"[stage={self.config.stage.value}, transform={self.get_transform_key()}]"
-        ad_logger.info(f"{prefix} " + " ".join(map(str, args)))
+        ad_logger.info(*args)
 
     @final
     def _get_autodeploy_meta(self, gm: GraphModule) -> AutodeployMeta:
         """Get the autodeploy metadata from the graphmodule."""
+        if not hasattr(gm, "meta"):
+            gm.meta = {}
         return gm.meta.get(self._autodeploy_meta_key, {})
 
     @final

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/cleanup_input_constraints.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/cleanup_input_constraints.py
@@ -29,7 +29,7 @@ class CleanupInputConstraints(BaseTransform):
         shared_config: SharedConfig,
     ) -> Tuple[GraphModule, TransformInfo]:
         graph: Graph = gm.graph
-        input_node = graph.find_nodes(op="placeholder")[0]
+        input_node = graph.find_nodes(op="placeholder")[1]
         sym_shape: torch.Size = input_node.meta["val"].shape
 
         # get expressions in the symbolic shape

--- a/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
@@ -321,9 +321,10 @@ def identify_regions_between_residuals(gm: GraphModule) -> List[Node]:
     for node in gm.graph.nodes:
         if input_id_node is None and node.op == "placeholder":
             input_id_node = node
-        output_node = node
+        if node.op == "output":
+            output_node = node
     assert input_id_node, "Could not find input node"
-    assert output_node.op == "output", "Could not find output node"
+    assert output_node, "Could not find output node"
 
     # start list of boundary nodes
     boundary_nodes = [input_id_node]

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/compile/test_captured_graph.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/compile/test_captured_graph.py
@@ -6,8 +6,10 @@ from _model_test_utils import (
     generate_dynamic_shapes,
 )
 
-from tensorrt_llm._torch.auto_deploy.compile.backends.torch_cudagraph import CapturedGraph
-from tensorrt_llm._torch.auto_deploy.compile.compiler import _flatten_args
+from tensorrt_llm._torch.auto_deploy.compile.backends.torch_cudagraph import (
+    CapturedGraph,
+    _args_kwargs_flatten_spec,
+)
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 
 
@@ -91,8 +93,6 @@ def test_cudagraph_capture_replay(
     print(dynamic_shapes)
 
     graph_module = torch_export_to_gm(model, args=args, dynamic_shapes=dynamic_shapes)
-    in_spec = graph_module._in_spec
-    out_spec = graph_module._out_spec
 
     # Apply torch.compile if needed
     if use_torch_compile:
@@ -100,8 +100,6 @@ def test_cudagraph_capture_replay(
 
     compiled_model = CapturedGraph(
         graph_module,
-        in_spec,
-        out_spec,
         cuda_graph_batch_sizes=[batch_size],
         num_batched_inputs=num_inputs,
     )
@@ -111,7 +109,7 @@ def test_cudagraph_capture_replay(
         compiled_model.capture_graph(*args)
 
         # Ensure the graph is stored for the combined shape of all inputs
-        assert combined_shape in compiled_model.graphs, (
+        assert combined_shape in compiled_model.cudagraphs, (
             f"Graph for combined shape {combined_shape} was not captured."
         )
 
@@ -125,7 +123,7 @@ def test_cudagraph_capture_replay(
         replay_args = tuple(replay_input_data)
 
         # Get flat inputs for manual replay
-        all_args_flat = _flatten_args(compiled_model._in_spec, *replay_args)
+        all_args_flat = _args_kwargs_flatten_spec(compiled_model._in_spec, *replay_args)
         input_args_flat = all_args_flat[:num_inputs]  # Extract just the batched inputs
 
         # Update input buffers for replay
@@ -133,7 +131,7 @@ def test_cudagraph_capture_replay(
             compiled_model._input_buffers[i][: input_tensor.shape[0]] = input_tensor
 
         # Get the appropriate graph and replay
-        graph = compiled_model.graphs[combined_shape]
+        graph = compiled_model.cudagraphs[combined_shape]
         graph.replay()
 
         # Get output from manual replay

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/compile/test_cuda_graph_batch_sizes.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/compile/test_cuda_graph_batch_sizes.py
@@ -71,10 +71,10 @@ class TestCudaGraphBatchSizes:
         requested_batch_sizes = [1, 4, 8, 16, 32, 64]  # 32 and 64 should be clamped to 16
 
         compiler = TorchCudagraphCompiler(
-            gm=data["gm"],
+            model=data["gm"],
             args=(data["input_tensor"],),
-            dynamic_shapes=data["dynamic_shapes"],
-            compiler_kwargs={"cuda_graph_batch_sizes": requested_batch_sizes},
+            max_batch_size=max_batch_size,
+            cuda_graph_batch_sizes=requested_batch_sizes,
         )
 
         # Check that batch sizes are clamped to max_batch_size
@@ -94,10 +94,9 @@ class TestCudaGraphBatchSizes:
         requested_batch_sizes = [1, 4, 8, 12]
 
         compiler = TorchCudagraphCompiler(
-            gm=data["gm"],
+            model=data["gm"],
             args=(data["input_tensor"],),
-            dynamic_shapes=data["dynamic_shapes"],
-            compiler_kwargs={"cuda_graph_batch_sizes": requested_batch_sizes},
+            cuda_graph_batch_sizes=requested_batch_sizes,
         )
 
         # Check that batch sizes are preserved
@@ -113,10 +112,9 @@ class TestCudaGraphBatchSizes:
         max_batch_size = data["batch_size"]  # 16
 
         compiler = TorchCudagraphCompiler(
-            gm=data["gm"],
+            model=data["gm"],
             args=(data["input_tensor"],),
-            dynamic_shapes=data["dynamic_shapes"],
-            compiler_kwargs={},  # No cuda_graph_batch_sizes provided
+            max_batch_size=max_batch_size,  # No cuda_graph_batch_sizes provided
         )
 
         # Check that heuristic batch sizes were generated
@@ -133,9 +131,8 @@ class TestCudaGraphBatchSizes:
 
         captured_graph = CapturedGraph(
             model=data["model"],
-            in_spec=data["gm"]._in_spec,
-            out_spec=data["gm"]._out_spec,
             cuda_graph_batch_sizes=cuda_graph_batch_sizes,
+            num_batched_inputs=1,
         )
 
         assert captured_graph.cuda_graph_max_batch_size == max(cuda_graph_batch_sizes)
@@ -149,9 +146,8 @@ class TestCudaGraphBatchSizes:
         cuda_graph_batch_sizes = [1, 2, 4]
         captured_graph = CapturedGraph(
             model=data["model"],
-            in_spec=data["gm"]._in_spec,
-            out_spec=data["gm"]._out_spec,
             cuda_graph_batch_sizes=cuda_graph_batch_sizes,
+            num_batched_inputs=1,
         )
 
         # Capture with small input
@@ -184,9 +180,8 @@ class TestCudaGraphBatchSizes:
         cuda_graph_batch_sizes = [1, 2, 4, 8]
         captured_graph = CapturedGraph(
             model=data["model"],
-            in_spec=data["gm"]._in_spec,
-            out_spec=data["gm"]._out_spec,
             cuda_graph_batch_sizes=cuda_graph_batch_sizes,
+            num_batched_inputs=1,
         )
 
         # Capture with full-size input
@@ -231,10 +226,10 @@ class TestCudaGraphBatchSizes:
             expected_max = max_batch_size
 
         compiler = TorchCudagraphCompiler(
-            gm=data["gm"],
+            model=data["gm"],
             args=(data["input_tensor"],),
-            dynamic_shapes=data["dynamic_shapes"],
-            compiler_kwargs=compiler_kwargs,
+            max_batch_size=max_batch_size,
+            **compiler_kwargs,
         )
 
         # Check that max batch size is as expected


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Pluggable compile backends with an explicit compile step.
  - Option to run transforms per sub-module.
  - Named dynamic shapes accessor, alongside tuple-based shapes.

- Improvements
  - Enhanced logging with compile/transform timing and clearer messages.
  - More robust CUDA Graph capture with smarter batch-size heuristics.
  - Streamlined input flattening and shape handling.

- Bug Fixes
  - Correct output-node detection in graph utilities.
  - Input-constraint cleanup now targets the intended input tensor.

- Refactor
  - Unified compiler/registry interfaces and simplified compile workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
