### PR TITLE
[TRTLLM-8414][chore] BREAKING CHANGE: refine sampling strategy selection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ extend_skip_glob = [
     "tests/unittest/_torch/modeling/test_modeling_mistral.py",
     "tests/unittest/_torch/modeling/test_modeling_pixtral.py",
     "tests/unittest/_torch/models/checkpoints/hf/test_weight_loader.py",
+    "tests/unittest/_torch/sampler/test_torch_sampler.py",
 ]
 
 [tool.yapf]
@@ -65,6 +66,7 @@ ignore_patterns = [
     "tests/unittest/_torch/modeling/test_modeling_mistral.py",
     "tests/unittest/_torch/modeling/test_modeling_pixtral.py",
     "tests/unittest/_torch/models/checkpoints/hf/test_weight_loader.py",
+    "tests/unittest/_torch/sampler/test_torch_sampler.py",
 ]
 
 [tool.codespell]
@@ -144,6 +146,7 @@ include = [
     "tests/unittest/_torch/modeling/test_modeling_mistral.py",
     "tests/unittest/_torch/modeling/test_modeling_pixtral.py",
     "tests/unittest/_torch/models/checkpoints/hf/test_weight_loader.py",
+    "tests/unittest/_torch/sampler/test_torch_sampler.py",
 ]
 exclude = [
     "**3rdparty/**",

--- a/tensorrt_llm/_torch/auto_deploy/shim/demollm.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/demollm.py
@@ -234,8 +234,10 @@ class DemoEngine(ADEngine):
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         logits_shape = logits.shape
         logits = logits.view(-1, logits_shape[-1])  # sampling_batch expects 2D logits
-        if isinstance(sampling_params.top_k, int):
-            idx_next, probs = top_k_sampling_batch(logits, sampling_params.top_k)
+        if isinstance(sampling_params.top_k, int) and sampling_params.top_k > 1:
+            idx_next, probs = top_k_sampling_batch(
+                logits, top_k=sampling_params.top_k, temperature=1.0
+            )
         else:
             idx_next, probs = greedy_search_sampling_batch(logits)
         idx_next = idx_next.view(logits_shape[:-1])

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass
 from itertools import repeat
-from typing import Any, List, Literal, Optional, cast
+from typing import Any, List, Literal, Optional, TypeVar, cast
 
 import torch
 import torch.nn.functional as F
@@ -26,6 +26,7 @@ from tensorrt_llm.bindings.internal.runtime import (BufferManager, CudaEvent,
                                                     GptDecoderBatched)
 from tensorrt_llm.executor.result import Logprob
 from tensorrt_llm.mapping import Mapping
+from tensorrt_llm.sampling_params import SamplingParams
 
 from ..speculative.spec_tree_manager import SpecTreeManager
 from .finish_reason import FinishedState
@@ -195,84 +196,75 @@ class EarlyStopWithMMResult(Sampler):
 
 def top_k_sampling_batch(
     logits,
-    top_k=50,
-    generator: Optional[torch.Generator] = None
+    *,
+    top_k: int,
+    temperature: float,
+    generator: Optional[torch.Generator] = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    logits_dim = logits.dim()
-    if logits_dim == 1:
-        logits = logits.unsqueeze(0)
-    # logits should be 2D ：[batch_size, vocab_size]
-    batch_size, vocab_size = logits.size()
-
-    # get first top_k logits of each sample and their indices
-    if top_k > 0:
-        values, indices = torch.topk(logits, top_k, dim=-1)
-        min_values = values[:, -1].unsqueeze(-1).expand(batch_size, vocab_size)
-
-        # set the logits who is less than first top_k logits to -inf
-        logits = torch.where(logits < min_values,
-                             torch.full_like(logits, float('-inf')), logits)
-
-    # compute probability distribution
-    softmax = torch.softmax(logits, dim=-1)
-
-    # sample from the distribution and generate result of [batch_size, 1]
-    next_tokens = torch.multinomial(softmax, num_samples=1,
-                                    generator=generator).squeeze(-1)
-    return next_tokens, softmax
+    # NB: To be replaced by a more efficient implementation.
+    return top_k_top_p_sampling_batch(
+        logits,
+        top_k=top_k,
+        temperature=temperature,
+        generator=generator,
+        top_p=1,
+    )
 
 
 def top_p_sampling_batch(
     logits: torch.Tensor,
     *,
-    top_p: float = 0.9,
-    temperature: float = 1.0,
+    top_p: float,
+    temperature: float,
+    generator: Optional[torch.Generator] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    # NB: To be replaced by a more efficient implementation.
+    return top_k_top_p_sampling_batch(
+        logits,
+        top_p=top_p,
+        top_k=logits.size(1),
+        temperature=temperature,
+        generator=generator,
+    )
+
+
+def temperature_sampling_batch(
+    logits: torch.Tensor,
+    *,
+    temperature: float,
+    generator: Optional[torch.Generator] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    # NB: To be replaced by a more efficient implementation.
+    return top_k_top_p_sampling_batch(
+        logits,
+        top_p=1,
+        top_k=logits.size(1),
+        temperature=temperature,
+        generator=generator,
+    )
+
+
+def top_k_top_p_sampling_batch(
+    logits: torch.Tensor,
+    *,
+    top_k: int,
+    top_p: float,
+    temperature: float,
     generator: Optional[torch.Generator] = None
 ) -> tuple[torch.Tensor, torch.Tensor]:
     logits_dim = logits.dim()
     assert logits_dim == 2, "logits should be 2D: [batch_size, vocab_size]"
-
-    if temperature != 0:
-        logits = logits / max(temperature, 1e-5)
-
-    # sort the logits of each sample in descending order
-    sorted_logits, sorted_indices = torch.sort(logits, descending=True, dim=-1)
-
-    # compute  cumulative probability distribution of each sample
-    cumulative_probs = torch.cumsum(torch.softmax(sorted_logits, dim=-1),
-                                    dim=-1)
-    # get the location of top_p
-    sorted_indices_to_remove = cumulative_probs > top_p
-    sorted_indices_to_remove[:, 1:] = sorted_indices_to_remove[:, :-1].clone()
-    sorted_indices_to_remove[:, 0] = 0
-
-    # set the logits to -inf whose is outside top_p
-    indices_to_remove = sorted_indices_to_remove.scatter(
-        1, sorted_indices, sorted_indices_to_remove)
-    logits = logits.masked_fill(indices_to_remove, float('-inf'))
-
-    # compute probability distribution
-    softmax = torch.softmax(logits, dim=-1)
-
-    # sample from the distribution and generate result of [batch_size, 1]
-    next_tokens = torch.multinomial(softmax, num_samples=1,
-                                    generator=generator).squeeze(-1)
-    return next_tokens, softmax
-
-
-def top_k_top_p_sampling_batch(logits: torch.Tensor,
-                               *,
-                               top_k: int,
-                               top_p: float,
-                               temperature: float = 1.0,
-                               generator: Optional[torch.Generator] = None):
-    logits_dim = logits.dim()
-    assert logits_dim == 2, "logits should be 2D: [batch_size, vocab_size]"
-    if temperature != 0:
-        logits = logits / max(temperature, 1e-5)
+    assert temperature > 0, "non-greedy sampling requires valid temperature"
+    logits = logits / max(temperature, 1e-5)
     batch_size, vocab_size = logits.size()
-    # get first top_k logits of each sample and their indices
-    if top_k > 0:
+
+    assert top_k > 1, "non-greedy sampling requires valid top_k"
+    need_top_k = top_k < vocab_size
+    assert top_p > 0, "non-greedy sampling requires valid top_p"
+    need_top_p = top_p < 1
+
+    # top-K: mask out logits not belonging to the top-K for each sample
+    if need_top_k:
         values, _ = torch.topk(logits, top_k, dim=-1)
         min_values = values[:, -1].unsqueeze(-1).expand(batch_size, vocab_size)
 
@@ -280,21 +272,28 @@ def top_k_top_p_sampling_batch(logits: torch.Tensor,
         logits = torch.where(logits < min_values,
                              torch.full_like(logits, float('-inf')), logits)
 
-    sorted_logits, sorted_indices = torch.sort(logits, descending=True, dim=-1)
+    # top-p: mask out logits outside the nucleus
+    if need_top_p:
+        sorted_logits, sorted_indices = torch.sort(logits,
+                                                   descending=True,
+                                                   dim=-1)
 
-    # compute  cumulative probability distribution of each sample
-    cumulative_probs = torch.cumsum(torch.softmax(sorted_logits, dim=-1),
-                                    dim=-1)
+        # compute cumulative probability distribution of each sample
+        cumulative_probs = torch.cumsum(torch.softmax(sorted_logits, dim=-1),
+                                        dim=-1)
 
-    # get the location of top_p
-    sorted_indices_to_remove = cumulative_probs > top_p
-    sorted_indices_to_remove[:, 1:] = sorted_indices_to_remove[:, :-1].clone()
-    sorted_indices_to_remove[:, 0] = 0
+        # get the location of top_p
+        # NB: Currently selecting the smallest index with cumulative_probs > top_p.
+        #     Thus, top_p -> 0 resembles greedy; agreement requires torch.sort(..., stable=True).
+        sorted_indices_to_remove = cumulative_probs > top_p
+        sorted_indices_to_remove[:,
+                                 1:] = sorted_indices_to_remove[:, :-1].clone()
+        sorted_indices_to_remove[:, 0] = 0
 
-    # set the logits to -inf whose is outside top_p
-    indices_to_remove = sorted_indices_to_remove.scatter(
-        1, sorted_indices, sorted_indices_to_remove)
-    logits = logits.masked_fill(indices_to_remove, float('-inf'))
+        # set the logits to -inf for token indices outside top_p
+        indices_to_remove = sorted_indices_to_remove.scatter(
+            1, sorted_indices, sorted_indices_to_remove)
+        logits = logits.masked_fill(indices_to_remove, float('-inf'))
 
     # compute probability distribution
     softmax = torch.softmax(logits, dim=-1)
@@ -359,48 +358,100 @@ def sample_rejected(draft_probs: torch.Tensor, target_probs: torch.Tensor,
     return new_token
 
 
-TopK = tuple[Literal["top_k"], int]
+TemperatureOnly = tuple[Literal["temperature"], float]
+TopK = tuple[Literal["top_k"], int, float]
 TopP = tuple[Literal["top_p"], float, float]
 TopKTopP = tuple[Literal["top_k_top_p"], int, float, float]
 Greedy = tuple[Literal["greedy"], None]
 GREEDY: Greedy = ("greedy", None)
-Strategy = TopK | TopP | Greedy | TopKTopP
+Strategy = TopK | TopP | Greedy | TopKTopP | TemperatureOnly
+
+T = TypeVar('T')
 
 
-def _request_strategy(request: LlmRequest) -> Strategy:
-    # top_p and top_K with temperature=0.0 reduces to greedy
-    # sampling
-    temperature = request.sampling_config.temperature
-    if temperature is not None:
-        temperature = temperature[0]
-        if temperature == 0.0:
-            return GREEDY
+# Due to tensorrt_llm::runtime::SamplingConfig using vectors, params
+# in LlmRequest.sampling_params are either None or single-element lists.
+# This helper method simplifies code using such params.
+def _unwrap_singleton(p: Optional[List[T]]) -> Optional[T]:
+    if p is None:
+        return None
+    t, = p
+    return t
 
-    if request.sampling_config.top_k is not None and len(
-            request.sampling_config.top_k
-    ) > 0 and request.sampling_config.top_p is not None and len(
-            request.sampling_config.top_p) > 0:
-        return ("top_k_top_p", request.sampling_config.top_k[0],
-                request.sampling_config.top_p[0], temperature)
-    elif request.sampling_config.top_p is not None and len(
-            request.sampling_config.top_p) > 0:
-        top_p = request.sampling_config.top_p[0]
-        return ("top_p", top_p, temperature)
-    elif request.sampling_config.top_k is not None and len(
-            request.sampling_config.top_k) > 0:
-        return ("top_k", request.sampling_config.top_k[0])
-    else:
+
+@dataclass(frozen=True, kw_only=True)
+class TorchSamplerSamplingParams:
+    """Subset of tensorrt_llm::runtime::SamplingConfig handled by TorchSampler."""
+    temperature: Optional[float]
+    top_p: Optional[float]
+    top_k: Optional[int]
+
+
+def _request_get_sampling_params(
+        request: LlmRequest) -> TorchSamplerSamplingParams:
+    sampling_config = request.sampling_config
+    temperature = _unwrap_singleton(
+        cast(Optional[List[float]], sampling_config.temperature))
+    top_p = _unwrap_singleton(cast(Optional[List[float]],
+                                   sampling_config.top_p))
+    top_k = _unwrap_singleton(cast(Optional[List[int]], sampling_config.top_k))
+
+    return TorchSamplerSamplingParams(
+        temperature=temperature,
+        top_p=top_p,
+        top_k=top_k,
+    )
+
+
+def _request_strategy(request: LlmRequest, *, vocab_size: int) -> Strategy:
+    # The semantics are specified in the doc-string of SamplingParams
+
+    params = _request_get_sampling_params(request)
+    temperature = params.temperature
+    top_p = params.top_p
+    top_k = params.top_k
+
+    if SamplingParams.params_imply_greedy_decoding(
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+    ):
         return GREEDY
+
+    # --- resolving default values
+    # NB: not greedy, hence temperature != 0 if specified
+    temperature = temperature or 1.0
+
+    # NB: not greedy, hence top_p != 0 if specified
+    top_p = top_p or 1.0
+    # NB: not greedy, hence top_k != 1 if specified
+    #     (0 and vocab_size are equivalent)
+    top_k = top_k or vocab_size
+
+    assert top_k > 1, "non-greedy sampling requires valid top_k"
+    need_top_k = top_k < vocab_size
+    assert top_p > 0, "non-greedy sampling requires valid top_p"
+    need_top_p = top_p < 1
+
+    if need_top_p:
+        if need_top_k:
+            return ("top_k_top_p", top_k, top_p, temperature)
+        return ("top_p", top_p, temperature)
+    if need_top_k:
+        return ("top_k", top_k, temperature)
+    return ("temperature", temperature)
 
 
 def _group_requests_by_sampling_strategy(
         requests: Iterable[LlmRequest],
         *,
-        pin_memory: bool = False) -> dict[Strategy, torch.Tensor]:
+        pin_memory: bool = False,
+        vocab_size: int) -> dict[Strategy, torch.Tensor]:
     # NB: Client code relies on request indices in returned torch.Tensor being sorted.
     strategy_dict: dict[Strategy, list[int]] = defaultdict(list)
     for req_index, req in enumerate(requests):
-        strategy_dict[_request_strategy(req)].append(req_index)
+        strategy_dict[_request_strategy(
+            req, vocab_size=vocab_size)].append(req_index)
     return {
         strategy: torch.tensor(indices,
                                pin_memory=pin_memory,
@@ -418,23 +469,32 @@ def sample(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     filter_softmax = True
     match strategy:
-        case ("top_k", top_k):
-            tokens, softmax = top_k_sampling_batch(logits, top_k, generator)
+        case ("top_k", top_k, temperature):
+            tokens, softmax = top_k_sampling_batch(logits,
+                                                   top_k=top_k,
+                                                   temperature=temperature,
+                                                   generator=generator)
         case ("top_p", top_p, temperature):
             tokens, softmax = top_p_sampling_batch(
                 logits,
                 top_p=top_p,
                 generator=generator,
-                **(dict(temperature=temperature)
-                   if temperature is not None else dict()))
+                temperature=temperature,
+            )
         case ("top_k_top_p", top_k, top_p, temperature):
             tokens, softmax = top_k_top_p_sampling_batch(
                 logits,
                 top_k=top_k,
                 top_p=top_p,
+                temperature=temperature,
                 generator=generator,
-                **(dict(temperature=temperature)
-                   if temperature is not None else dict()))
+            )
+        case ("temperature", temperature):
+            tokens, softmax = temperature_sampling_batch(
+                logits,
+                temperature=temperature,
+                generator=generator,
+            )
         case ("greedy", None):
             tokens, softmax = greedy_search_sampling_batch(
                 logits, softmax_indices=softmax_indices)
@@ -1070,7 +1130,11 @@ class TorchSampler(Sampler):
     def _process_draft_tokens_rejection_sampling(
             self, request: LlmRequest, new_tokens: list[list[list[int]]],
             new_tokens_tensor: torch.Tensor) -> int:
-        sampling_strategy = _request_strategy(request)
+        # FIXME: Passing a dummy vocab_size could result in unnecessary
+        #        filtering of vocab_size logits, out of vocab_size in
+        #        total. The 'sample' below should generally be avoided
+        #        by retaining the draft_probs during drafting (TRTLLM-7772).
+        sampling_strategy = _request_strategy(request, vocab_size=2**31)
         generator = self.get_generator(request.py_draft_logits.device)
         _, draft_probs = sample(sampling_strategy,
                                 request.py_draft_logits,
@@ -1329,7 +1393,7 @@ class TorchSampler(Sampler):
                                                  dim=-1)
 
         requests_by_strategy = _group_requests_by_sampling_strategy(
-            requests, pin_memory=True)
+            requests, pin_memory=True, vocab_size=logits_cuda.size(1))
         generator_cuda = self.get_generator(cuda_device)
 
         # FIXME: This check should/could be performed in ModelDrafter.prepare_draft_tokens
@@ -1706,8 +1770,17 @@ class TorchSampler(Sampler):
 
     @override
     def should_provide_draft_probs(self, request: LlmRequest) -> bool:
+        params = _request_get_sampling_params(request)
+        temperature = params.temperature
+        top_p = params.top_p
+        top_k = params.top_k
+
         # Do not request draft probs when sampling is greedy.
-        return _request_strategy(request) is not GREEDY
+        return not SamplingParams.params_imply_greedy_decoding(
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+        )
 
 
 class Algorithms:

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -14,6 +14,7 @@ l0_a10:
       backend: pytorch
   tests:
   # ------------- PyTorch tests ---------------
+  - unittest/_torch/sampler/test_torch_sampler.py
   - unittest/_torch/modeling/test_modeling_mistral.py
   - unittest/_torch/modeling/test_modeling_pixtral.py
   # NOTE: this is a CPU-only test, but we do not have a dedicated job for this (and therefore no

--- a/tests/unittest/_torch/sampler/test_torch_sampler.py
+++ b/tests/unittest/_torch/sampler/test_torch_sampler.py
@@ -1,0 +1,303 @@
+from itertools import product
+from typing import Optional, cast
+
+import pytest
+from utils.util import force_ampere
+
+from tensorrt_llm._torch.pyexecutor.sampler import (
+    GREEDY,
+    LlmRequest,
+    TorchSampler,
+    _request_strategy,
+)
+from tensorrt_llm.bindings import SamplingConfig
+from tensorrt_llm.sampling_params import SamplingParams
+
+
+@force_ampere
+class TestStrategySelection:
+    VOCAB_SIZE = 1000
+    TOP_K_VALS = [None, 0, 1, 42, 1000]
+    TOP_P_VALS = [None, 0, 0.42, 1]
+    TEMPERATURE_VALS = [None, 0, 1.42]
+
+    # For non-greedy sampling, the following choices have no effect.
+    TOP_P_NEUTRAL_VALS = [None, 1]
+    TOP_K_NEUTRAL_VALS = [None, 0, VOCAB_SIZE]
+    TEMPERATURE_NEUTRAL_VALS = [None, 1]
+
+    TEMPERATURE_NOT_GREEDY = [0.42] + [t for t in TEMPERATURE_NEUTRAL_VALS if t is not None]
+
+    class MockLlmRequest:
+        sampling_config: SamplingConfig
+
+    def _check_params(self, params: SamplingParams):
+        # cf. description of 'top_p' in doc-string of SamplingParams and
+        # test_top_p_0_disallowed below.
+        if params.top_p == 0:
+            pytest.skip("top_p = 0 disallowed by tensorrt_llm::executor::SamplingConfig")
+
+    def test_top_p_0_disallowed(self):
+        # If this xpasses, update _check_params and doc-string of SamplingParams.
+        params = SamplingParams(top_p=0)
+        pytest.xfail("top_p = 0 disallowed by tensorrt_llm::executor::SamplingConfig")
+        params._get_sampling_config()
+
+    def _build_mock_llm_request(self, params: SamplingParams) -> LlmRequest:
+        request = self.MockLlmRequest()
+        request.sampling_config = SamplingConfig(params._get_sampling_config())
+        return cast(LlmRequest, request)
+
+    def test_defaults(self):
+        # NB: The code in _request_strategy relies on the default values below.
+        default_params = SamplingParams()
+        assert default_params.top_k is None
+        assert default_params.top_p is None
+        assert default_params.temperature is None
+
+    def test_defaults_config(self):
+        # NB: The code in _request_strategy relies on the default values below.
+        default_config = SamplingParams()._get_sampling_config()
+        assert default_config.top_k is None
+        assert default_config.top_p is None
+        assert default_config.temperature is None
+
+    def test_defaults_request(self):
+        # NB: The code in _request_strategy relies on the default values below.
+        request = self._build_mock_llm_request(SamplingParams())
+        default_config = request.sampling_config
+        assert default_config.top_k is None
+        assert default_config.top_p is None
+        assert default_config.temperature is None
+
+    def test_default_is_greedy(self):
+        request = self._build_mock_llm_request(SamplingParams())
+        assert _request_strategy(request, vocab_size=self.VOCAB_SIZE) is GREEDY
+
+    @pytest.mark.parametrize(
+        "top_p, top_k",
+        [
+            pytest.param(top_p, top_k)
+            # https://stackoverflow.com/a/75421799, does not work with nested loops
+            for (top_k, top_p) in product(TOP_K_VALS, TOP_P_VALS)
+        ],
+    )
+    def test_temperature_0_is_greedy(self, top_p: Optional[float], top_k: Optional[int]):
+        params = SamplingParams(temperature=0, top_p=top_p, top_k=top_k)
+        self._check_params(params)
+        request = self._build_mock_llm_request(params)
+        assert _request_strategy(request, vocab_size=self.VOCAB_SIZE) is GREEDY
+
+    @pytest.mark.parametrize(
+        "temperature, top_k",
+        [
+            pytest.param(temperature, top_k)
+            # https://stackoverflow.com/a/75421799, does not work with nested loops
+            for (temperature, top_k) in product(TEMPERATURE_VALS, TOP_K_VALS)
+        ],
+    )
+    def test_top_p_0_is_greedy(self, temperature: Optional[float], top_k: Optional[int]):
+        params = SamplingParams(top_p=0, temperature=temperature, top_k=top_k)
+        self._check_params(params)
+        request = self._build_mock_llm_request(params)
+        assert _request_strategy(request, vocab_size=self.VOCAB_SIZE) is GREEDY
+
+    @pytest.mark.parametrize(
+        "temperature, top_p",
+        [
+            pytest.param(temperature, top_p)
+            # https://stackoverflow.com/a/75421799, does not work with nested loops
+            for (temperature, top_p) in product(TEMPERATURE_VALS, TOP_P_VALS)
+        ],
+    )
+    def test_top_k_1_is_greedy(self, temperature: Optional[float], top_p: Optional[float]):
+        params = SamplingParams(top_p=top_p, temperature=temperature, top_k=1)
+        self._check_params(params)
+        request = self._build_mock_llm_request(params)
+        assert _request_strategy(request, vocab_size=self.VOCAB_SIZE) is GREEDY
+
+    @pytest.mark.parametrize(
+        "temperature, trivial_top_p, trivial_top_k",
+        [
+            pytest.param(temperature, top_p, top_k)
+            # https://stackoverflow.com/a/75421799, does not work with nested loops
+            for (temperature, top_k, top_p) in product(
+                TEMPERATURE_NOT_GREEDY, TOP_K_NEUTRAL_VALS, TOP_P_NEUTRAL_VALS
+            )
+        ],
+    )
+    def test_temperature_only(
+        self, temperature: float, trivial_top_p: Optional[float], trivial_top_k: Optional[int]
+    ):
+        params = SamplingParams(temperature=temperature, top_p=trivial_top_p, top_k=trivial_top_k)
+        self._check_params(params)
+        request = self._build_mock_llm_request(params)
+        strat = _request_strategy(request, vocab_size=self.VOCAB_SIZE)
+        assert len(strat) == 2
+        assert strat[0] == "temperature"
+        assert strat[1] == pytest.approx(temperature)
+
+    @pytest.mark.parametrize(
+        "trivial_temperature, trivial_top_k",
+        [
+            pytest.param(temperature, top_k)
+            # https://stackoverflow.com/a/75421799, does not work with nested loops
+            for (temperature, top_k) in product(TEMPERATURE_NEUTRAL_VALS, TOP_K_NEUTRAL_VALS)
+        ],
+    )
+    def test_top_p_only(self, trivial_temperature: Optional[float], trivial_top_k: Optional[int]):
+        params = SamplingParams(top_p=0.42, temperature=trivial_temperature, top_k=trivial_top_k)
+        self._check_params(params)
+        request = self._build_mock_llm_request(params)
+        strat = _request_strategy(request, vocab_size=self.VOCAB_SIZE)
+        assert len(strat) == 3
+        assert strat[0] == "top_p"
+        assert strat[1] == pytest.approx(0.42)
+        assert strat[2] == pytest.approx(1.0)
+
+    @pytest.mark.parametrize(
+        "trivial_top_k",
+        [
+            pytest.param(top_k)
+            for top_k in TOP_K_NEUTRAL_VALS  # https://stackoverflow.com/a/75421799
+        ],
+    )
+    def test_top_p_with_temperature(self, trivial_top_k: Optional[int]):
+        params = SamplingParams(top_p=0.42, temperature=0.9, top_k=trivial_top_k)
+        self._check_params(params)
+        request = self._build_mock_llm_request(params)
+        strat = _request_strategy(request, vocab_size=self.VOCAB_SIZE)
+        assert len(strat) == 3
+        assert strat[0] == "top_p"
+        assert strat[1] == pytest.approx(0.42)
+        assert strat[2] == pytest.approx(0.9)
+
+    @pytest.mark.parametrize(
+        "trivial_temperature, trivial_top_p",
+        [
+            pytest.param(temperature, top_p)
+            # https://stackoverflow.com/a/75421799, does not work with nested loops
+            for (temperature, top_p) in product(TEMPERATURE_NEUTRAL_VALS, TOP_P_NEUTRAL_VALS)
+        ],
+    )
+    def test_top_k_only(self, trivial_temperature: Optional[float], trivial_top_p: Optional[float]):
+        params = SamplingParams(top_k=42, temperature=trivial_temperature, top_p=trivial_top_p)
+        self._check_params(params)
+        request = self._build_mock_llm_request(params)
+        strat = _request_strategy(request, vocab_size=self.VOCAB_SIZE)
+        assert len(strat) == 3
+        assert strat[0] == "top_k"
+        assert strat[1] == 42
+        assert strat[2] == pytest.approx(1.0)
+
+    @pytest.mark.parametrize(
+        "trivial_top_p",
+        [
+            pytest.param(top_p)
+            for top_p in TOP_P_NEUTRAL_VALS  # https://stackoverflow.com/a/75421799
+        ],
+    )
+    def test_top_k_with_temperature(self, trivial_top_p: Optional[float]):
+        params = SamplingParams(top_k=42, temperature=0.9, top_p=trivial_top_p)
+        self._check_params(params)
+        request = self._build_mock_llm_request(params)
+        strat = _request_strategy(request, vocab_size=self.VOCAB_SIZE)
+        assert len(strat) == 3
+        assert strat[0] == "top_k"
+        assert strat[1] == 42
+        assert strat[2] == pytest.approx(0.9)
+
+    @pytest.mark.parametrize(
+        "trivial_temperature",
+        [
+            pytest.param(temperature)
+            for temperature in TEMPERATURE_NEUTRAL_VALS  # https://stackoverflow.com/a/75421799
+        ],
+    )
+    def test_top_k_top_p(self, trivial_temperature: Optional[float]):
+        params = SamplingParams(top_k=42, top_p=0.7, temperature=trivial_temperature)
+        self._check_params(params)
+        request = self._build_mock_llm_request(params)
+        strat = _request_strategy(request, vocab_size=self.VOCAB_SIZE)
+        assert len(strat) == 4
+        assert strat[0] == "top_k_top_p"
+        assert strat[1] == 42
+        assert strat[2] == pytest.approx(0.7)
+        assert strat[3] == pytest.approx(1.0)
+
+    def test_top_k_top_p_with_temperature(self):
+        params = SamplingParams(top_k=42, top_p=0.7, temperature=0.9)
+        self._check_params(params)
+        request = self._build_mock_llm_request(params)
+        strat = _request_strategy(request, vocab_size=self.VOCAB_SIZE)
+        assert len(strat) == 4
+        assert strat[0] == "top_k_top_p"
+        assert strat[1] == 42
+        assert strat[2] == pytest.approx(0.7)
+        assert strat[3] == pytest.approx(0.9)
+
+    def test_param_validation(self):
+        with pytest.raises(ValueError, match="require temperature >= 0, got temperature=-1"):
+            SamplingParams(temperature=-1)
+
+        with pytest.raises(ValueError, match="require 0 <= top_p <= 1, got top_p=-1"):
+            SamplingParams(top_p=-1)
+
+        with pytest.raises(ValueError, match="require 0 <= top_p <= 1, got top_p=2"):
+            SamplingParams(top_p=2)
+
+        with pytest.raises(ValueError, match="require top_k >= 0, got top_k=-1"):
+            SamplingParams(top_k=-1)
+
+    @pytest.mark.parametrize(
+        "top_k, top_p",
+        [
+            pytest.param(top_k, top_p)
+            # https://stackoverflow.com/a/75421799, does not work with nested loops
+            for (top_k, top_p) in product(TOP_K_NEUTRAL_VALS, TOP_P_NEUTRAL_VALS)
+            if (top_k, top_p) != (None, None)
+        ],
+    )
+    def test_trivial_top_k_top_p_not_greedy(self, top_k: Optional[int], top_p: Optional[float]):
+        params = SamplingParams(top_k=top_k, top_p=top_p)
+        self._check_params(params)
+        request = self._build_mock_llm_request(params)
+        strat = _request_strategy(request, vocab_size=self.VOCAB_SIZE)
+        assert len(strat) == 2
+        assert strat[0] == "temperature"
+        assert strat[1] == pytest.approx(1.0)
+
+    @pytest.fixture
+    def torch_sampler(self) -> TorchSampler:
+        return TorchSampler(
+            TorchSampler.Args(
+                max_seq_len=123,
+                max_draft_len=3,
+                max_num_sequences=12,
+                max_beam_width=1,
+                max_total_draft_tokens=3,
+            )
+        )
+
+    @pytest.mark.parametrize(
+        "temperature, top_p, top_k",
+        [
+            pytest.param(temperature, top_p, top_k)
+            # https://stackoverflow.com/a/75421799, does not work with nested loops
+            for (temperature, top_p, top_k) in product(TEMPERATURE_VALS, TOP_P_VALS, TOP_K_VALS)
+        ],
+    )
+    def test_should_provide_draft_probs_consistency(
+        self,
+        temperature: Optional[float],
+        top_p: Optional[float],
+        top_k: Optional[int],
+        torch_sampler: TorchSampler,
+    ):
+        params = SamplingParams(top_k=top_k, top_p=top_p, temperature=temperature)
+        self._check_params(params)
+        request = self._build_mock_llm_request(params)
+        strat = _request_strategy(request, vocab_size=self.VOCAB_SIZE)
+        is_greedy = strat is GREEDY
+
+        assert torch_sampler.should_provide_draft_probs(request) == (not is_greedy)

--- a/tests/unittest/_torch/sampler/test_trtllm_sampler.py
+++ b/tests/unittest/_torch/sampler/test_trtllm_sampler.py
@@ -23,6 +23,7 @@ def create_llm(model_dir):
         enable_chunked_prefill=True,
         cuda_graph_config=CudaGraphConfig(),
         kv_cache_config=trt_kv_cache_config,
+        sampler_type="TRTLLMSampler",
         max_num_tokens=
         128  # Only one request longer than max_num_tokens is required to test chunked prefill
     )

--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -18,6 +18,7 @@ import sys
 import traceback
 from typing import Any
 
+import _pytest.outcomes
 import pytest
 import torch
 import tqdm
@@ -65,8 +66,9 @@ def pytest_pyfunc_call(pyfuncitem) -> Any:
         return (yield)
     # NB: _pytest.outcomes.OutcomeException subclasses BaseException
     except BaseException as e:
-        print(f"TEST RAISED ERROR: {e}")
-        traceback.print_exception(e)
+        if not isinstance(e, _pytest.outcomes.Skipped):
+            print(f"TEST RAISED ERROR: {e}")
+            traceback.print_exception(e)
         raise
 
 


### PR DESCRIPTION
## Description

**NOTE:** These changes specify the sampling behavior in some previously undefined cases. While the new behavior should be in line with the examples in the documentation, it does differ from the base-branch behavior in certain cases.

Roughly, the new semantics are (see TRTLLM-8414 for complete background):
* If `top_k = top_p = temperature = None`  (the default if the respective parameters are not specified), sampling is greedy (`torch.argmax`).
* If a non-trivial `top_k`, `top_p`, and/or `temperature` is provided, sampling proceeds accordingly. In this case, unspecified parameters default to `top_k = 0`,  `top_p = 1`, `temperature = 1.0`.
* If either `temperature = 0`, `top_p = 0`,  and/or `top_k = 1`, is specified, sampling is greedy, irrespective of the values of the remaining parameters.

## Test Coverage

Unit tests for the sampling strategy selection are implemented as part of this PR.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Unified sampling strategies with support for top-k, top-p (nucleus), temperature, and their combinations, with clearer greedy behavior when parameters imply determinism.
- Bug Fixes
  - Improved handling of edge cases and defaults in sampling (e.g., validation of temperature/top-p/top-k ranges and greedy fallbacks).
- Tests
  - Added comprehensive unit tests covering strategy selection, parameter validation, and draft-probability decisions.
  - Enabled selection of a specific sampler type in tests.
  - Suppressed noisy traces for skipped tests.
- Chores
  - Adjusted tooling configuration to exclude a specific test file from formatting and spell-checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->