### PR TITLE
[None][feat] Implement support for Falcon-H1 models

### DIFF
--- a/tensorrt_llm/_torch/models/__init__.py
+++ b/tensorrt_llm/_torch/models/__init__.py
@@ -5,6 +5,7 @@ from .modeling_bert import BertForSequenceClassification
 from .modeling_clip import CLIPVisionModel
 from .modeling_deepseekv3 import DeepseekV3ForCausalLM
 from .modeling_exaone4 import Exaone4ForCausalLM
+from .modeling_falcon_h1 import FalconH1ForCausalLM
 from .modeling_gemma3 import Gemma3ForCausalLM
 from .modeling_gemma3vl import Gemma3VLM
 from .modeling_gpt_oss import GptOssForCausalLM
@@ -62,6 +63,7 @@ __all__ = [
     "Qwen3ForCausalLM",
     "Qwen3MoeForCausalLM",
     "GptOssForCausalLM",
+    "FalconH1ForCausalLM",
 ]
 
 if transformers.__version__ >= "4.45.1":

--- a/tensorrt_llm/_torch/models/modeling_falcon_h1.py
+++ b/tensorrt_llm/_torch/models/modeling_falcon_h1.py
@@ -119,6 +119,8 @@ class FalconH1SSMDecoderLayer(nn.Module):
                                  head_dim=config.mamba_d_head,
                                  chunk_size=config.mamba_chunk_size,
                                  layer_idx=layer_idx,
+                                 bias=config.mamba_proj_bias,
+                                 conv_bias=config.mamba_conv_bias,
                                  rms_norm_eps=config.rms_norm_eps,
                                  dtype=config.torch_dtype,
                                  config=model_config)

--- a/tensorrt_llm/_torch/models/modeling_falcon_h1.py
+++ b/tensorrt_llm/_torch/models/modeling_falcon_h1.py
@@ -371,6 +371,8 @@ class FalconH1ForCausalLM(DecoderModelForCausalLM[FalconH1Model, FalconH1Config]
                 # Flatten conv1d weights [out, 1, k] -> [out, k]
                 if nk.endswith('.mamba.conv1d.weight') and v.ndim == 3 and v.shape[1] == 1:
                     v = v.squeeze(1).contiguous()
+                if '.mamba.A' in nk:
+                    v = -torch.exp(v.to(torch.float32))
                 norm[nk] = v
             return norm
 

--- a/tensorrt_llm/_torch/models/modeling_falcon_h1.py
+++ b/tensorrt_llm/_torch/models/modeling_falcon_h1.py
@@ -1,0 +1,219 @@
+import re
+import time
+from typing import Optional
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+from transformers import FalconH1Config
+
+from tensorrt_llm._torch.models.checkpoints.base_weight_mapper import \
+    BaseWeightMapper
+from tensorrt_llm._torch.modules.mamba.mamba2_metadata import Mamba2Metadata
+
+from tensorrt_llm._torch.attention_backend import AttentionMetadata
+from tensorrt_llm._torch.model_config import ModelConfig
+from tensorrt_llm._torch.modules.attention import Attention
+from tensorrt_llm._torch.modules.decoder_layer import DecoderLayer
+from tensorrt_llm._torch.modules.embedding import Embedding
+from tensorrt_llm._torch.modules.mamba.mamba2_mixer import Mamba2Mixer
+from tensorrt_llm._torch.modules.mlp import MLP
+from tensorrt_llm._torch.modules.rms_norm import RMSNorm
+from tensorrt_llm._torch.models.modeling_utils import (DecoderModel,
+                                                      DecoderModelForCausalLM,
+                                                      register_auto_model)
+
+
+class FalconH1ParallelHybridLayer(DecoderLayer):
+
+    def __init__(self, model_config: ModelConfig[FalconH1Config], layer_idx: int):
+        super().__init__()
+        config = model_config.pretrained_config
+
+        self.layer_idx = layer_idx
+
+        # Branch modules
+        self.self_attn = Attention(hidden_size=config.hidden_size,
+                                   num_attention_heads=config.num_attention_heads,
+                                   num_key_value_heads=config.num_key_value_heads,
+                                   max_position_embeddings=getattr(config, "max_position_embeddings", 8192),
+                                   bias=False,
+                                   pos_embd_params=None,
+                                   layer_idx=layer_idx,
+                                   dtype=config.torch_dtype,
+                                   config=model_config)
+
+        self.mamba = Mamba2Mixer(d_model=config.hidden_size,
+                                 d_state=config.mamba_d_state,
+                                 d_conv=config.mamba_d_conv,
+                                 nheads=config.mamba_n_heads,
+                                 n_groups=config.mamba_n_groups,
+                                 head_dim=config.mamba_d_head,
+                                 chunk_size=getattr(config, "mamba_chunk_size", getattr(config, "chunk_size", 128)),
+                                 layer_idx=layer_idx,
+                                 rms_norm_eps=config.rms_norm_eps,
+                                 dtype=config.torch_dtype,
+                                 config=model_config)
+
+        # FFN uses fused gate_up and down with SiLU gating
+        intermediate_size = (config.intermediate_size[0]
+                             if isinstance(config.intermediate_size, list)
+                             else config.intermediate_size)
+        self.feed_forward = MLP(hidden_size=config.hidden_size,
+                                intermediate_size=intermediate_size,
+                                bias=False,
+                                activation=F.silu,
+                                dtype=config.torch_dtype,
+                                config=model_config)
+
+        # Norms
+        self.input_layernorm = RMSNorm(hidden_size=config.hidden_size,
+                                       eps=config.rms_norm_eps,
+                                       dtype=config.torch_dtype)
+        self.pre_ff_layernorm = RMSNorm(hidden_size=config.hidden_size,
+                                        eps=config.rms_norm_eps,
+                                        dtype=config.torch_dtype)
+
+        # Multipliers (default to 1.0 if missing)
+        self.register_buffer("_ssm_in_mul", torch.tensor(getattr(config, "ssm_in_multiplier", 1.0), dtype=torch.float32), persistent=False)
+        self.register_buffer("_ssm_out_mul", torch.tensor(getattr(config, "ssm_out_multiplier", 1.0), dtype=torch.float32), persistent=False)
+        self.register_buffer("_attn_in_mul", torch.tensor(getattr(config, "attention_in_multiplier", 1.0), dtype=torch.float32), persistent=False)
+        self.register_buffer("_attn_out_mul", torch.tensor(getattr(config, "attention_out_multiplier", 1.0), dtype=torch.float32), persistent=False)
+
+    def forward(self,
+                position_ids: torch.IntTensor,
+                hidden_states: torch.Tensor,
+                attn_metadata: AttentionMetadata,
+                **kwargs) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+
+        # Attention branch
+        attn_input = hidden_states * self._attn_in_mul
+        attn_hidden = self.self_attn(position_ids=None,
+                                     hidden_states=attn_input,
+                                     attn_metadata=attn_metadata)
+
+        # Mamba branch
+        ssm_input = hidden_states * self._ssm_in_mul
+        mamba_hidden = self.mamba(ssm_input, attn_metadata, **kwargs)
+
+        hidden_states = attn_hidden * self._attn_out_mul + mamba_hidden * self._ssm_out_mul
+        hidden_states = hidden_states + residual
+
+        # FFN
+        residual = hidden_states
+        hidden_states = self.pre_ff_layernorm(hidden_states)
+        hidden_states = self.feed_forward(hidden_states)
+        hidden_states = hidden_states + residual
+        return hidden_states
+
+
+class FalconH1Model(DecoderModel):
+
+    def __init__(self, model_config: ModelConfig[FalconH1Config]):
+        super().__init__(model_config)
+        config = self.model_config.pretrained_config
+
+        # embeddings
+        self.embed_tokens = Embedding(
+            config.vocab_size,
+            config.hidden_size,
+            dtype=config.torch_dtype,
+        )
+
+        # layers
+        layers = []
+        for layer_idx in range(config.num_hidden_layers):
+            layers.append(FalconH1ParallelHybridLayer(model_config, layer_idx))
+        self.layers = nn.ModuleList(layers)
+
+        # final norm
+        self.final_layernorm = RMSNorm(hidden_size=config.hidden_size,
+                              eps=config.rms_norm_eps,
+                              dtype=config.torch_dtype)
+
+        self.mamba_metadata: Optional[Mamba2Metadata] = None
+
+        embed_mul = getattr(config, "embedding_multiplier", 1.0)
+        self.register_buffer("_embed_mul", torch.tensor(embed_mul, dtype=torch.float32), persistent=False)
+
+    def forward(self,
+                attn_metadata: AttentionMetadata,
+                input_ids: Optional[torch.IntTensor] = None,
+                position_ids: Optional[torch.IntTensor] = None,
+                inputs_embeds: Optional[torch.FloatTensor] = None,
+                **kwargs) -> torch.Tensor:
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError(
+                "You cannot specify both input_ids and inputs_embeds at the same time, and must specify either one"
+            )
+
+        if self.mamba_metadata is None or self.mamba_metadata.max_batch_size != attn_metadata.max_num_requests:
+            chunk_size = getattr(self.model_config.pretrained_config, "mamba_chunk_size", getattr(self.model_config.pretrained_config, "chunk_size", 128))
+            self.mamba_metadata = Mamba2Metadata(attn_metadata.max_num_requests, chunk_size=chunk_size)
+        self.mamba_metadata.prepare(attn_metadata)
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        hidden_states = inputs_embeds * self._embed_mul
+
+        for layer in self.layers:
+            hidden_states = layer(position_ids,
+                                  hidden_states,
+                                  attn_metadata,
+                                  mamba_metadata=self.mamba_metadata)
+
+        hidden_states = self.final_layernorm(hidden_states)
+        return hidden_states
+
+
+@register_auto_model("FalconH1ForCausalLM")
+class FalconH1ForCausalLM(DecoderModelForCausalLM[FalconH1Model, FalconH1Config]):
+
+    def __init__(self, model_config: ModelConfig[FalconH1Config]):
+        # import debugpy
+        # debugpy.listen(5678)
+        # debugpy.wait_for_client()
+
+        if not model_config.mapping.tp_size in [1, 2, 4, 8]:
+            raise ValueError("TP has to be either 1, 2, 4 or 8")
+
+        if model_config.quant_config.exclude_modules is not None:
+            model_config.quant_config.exclude_modules = [
+                re.sub(r'(model\.layers\.)?backbone', 'model', k)
+                for k in model_config.quant_config.exclude_modules
+            ]
+
+        super().__init__(FalconH1Model(model_config),
+                         config=model_config,
+                         hidden_size=model_config.pretrained_config.hidden_size,
+                         vocab_size=model_config.pretrained_config.vocab_size)
+
+    def load_weights(self, weights: dict, weight_mapper: BaseWeightMapper):
+        # Normalize checkpoint keys for Mamba2Mixer compatibility
+        def _normalize_keys(w: dict) -> dict:
+            norm = {}
+            for k, v in w.items():
+                nk = k
+                if '.mamba.A_log' in nk:
+                    nk = nk.replace('.mamba.A_log', '.mamba.A')
+                if '.dt_proj.bias' in nk:
+                    nk = nk.replace('.dt_proj.bias', '.dt_bias')
+                # Flatten conv1d weights [out, 1, k] -> [out, k]
+                if nk.endswith('.mamba.conv1d.weight') and v.ndim == 3 and v.shape[1] == 1:
+                    v = v.squeeze(1).contiguous()
+                norm[nk] = v
+            return norm
+
+        weights = _normalize_keys(weights)
+
+        new_weights = weight_mapper.preprocess_weights(weights)
+        if new_weights is None:
+            new_weights = weights
+        else:
+            new_weights = _normalize_keys(new_weights)
+        super().load_weights(new_weights, weight_mapper)
+
+

--- a/tensorrt_llm/_torch/models/modeling_falcon_h1.py
+++ b/tensorrt_llm/_torch/models/modeling_falcon_h1.py
@@ -1,3 +1,6 @@
+# Portions of this code were derived from the vLLM project:
+# https://github.com/vllm-project/vllm/blob/a903669e10cc98507fa5c2ae099b7161f7140cf7/vllm/model_executor/models/falcon_h1.py
+
 import re
 from typing import Optional
 

--- a/tensorrt_llm/_torch/models/modeling_falcon_h1.py
+++ b/tensorrt_llm/_torch/models/modeling_falcon_h1.py
@@ -300,9 +300,7 @@ class FalconH1Model(DecoderModel):
 
         self.mamba_metadata: Optional[Mamba2Metadata] = None
 
-        # TODO: simplify?
-        embed_mul = getattr(config, "embedding_multiplier", 1.0)
-        self.register_buffer("_embed_mul", torch.tensor(embed_mul, dtype=torch.float32), persistent=False)
+        self.embedding_multiplier = getattr(config, "embedding_multiplier", 1.0)
 
     def forward(self,
                 attn_metadata: AttentionMetadata,
@@ -324,7 +322,7 @@ class FalconH1Model(DecoderModel):
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
 
-        hidden_states = inputs_embeds * self._embed_mul
+        hidden_states = inputs_embeds * self.embedding_multiplier
 
         for layer in self.layers:
             hidden_states = layer(position_ids,

--- a/tensorrt_llm/_torch/models/modeling_falcon_h1.py
+++ b/tensorrt_llm/_torch/models/modeling_falcon_h1.py
@@ -39,6 +39,10 @@ class FalconH1MLP(nn.Module):
         super().__init__()
         config = model_config.pretrained_config
 
+        if config.hidden_act != "silu":
+            raise ValueError(f"Unsupported activation: {config.hidden_act}. "
+                             "Only silu is supported for now.")
+
         # Handle list intermediate_size
         self.intermediate_size = (intermediate_size[0] if isinstance(
             intermediate_size, list) else intermediate_size)
@@ -113,9 +117,7 @@ class FalconH1SSMDecoderLayer(nn.Module):
                                  nheads=config.mamba_n_heads,
                                  n_groups=config.mamba_n_groups,
                                  head_dim=config.mamba_d_head,
-                                 chunk_size=getattr(
-                                     config, "mamba_chunk_size",
-                                     getattr(config, "chunk_size", 128)),
+                                 chunk_size=config.mamba_chunk_size,
                                  layer_idx=layer_idx,
                                  rms_norm_eps=config.rms_norm_eps,
                                  dtype=config.torch_dtype,
@@ -397,3 +399,6 @@ class FalconH1ForCausalLM(DecoderModelForCausalLM[FalconH1Model,
         else:
             new_weights = _normalize_keys(new_weights)
         super().load_weights(new_weights, weight_mapper)
+
+
+# TODO: Take lm_head_multiplier into account

--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -402,7 +402,8 @@ class DecoderModelForCausalLM(nn.Module,
             if config.mapping.is_last_pp_rank():
                 self.model.keep_embed_tokens = True
 
-        self.logits_processor = LogitsProcessor()
+        self.logits_processor = LogitsProcessor(
+            scale=getattr(config.pretrained_config, 'lm_head_multiplier', 1.0))
 
         self.prologue = []
         self.epilogue = [self.lm_head]

--- a/tensorrt_llm/_torch/modules/logits_processor.py
+++ b/tensorrt_llm/_torch/modules/logits_processor.py
@@ -7,8 +7,9 @@ from .linear import Linear
 
 class LogitsProcessor(nn.Module):
 
-    def __init__(self):
+    def __init__(self, scale: float = 1.0):
         super().__init__()
+        self.scale = scale
 
     def forward(self,
                 hidden_states: torch.Tensor,
@@ -29,4 +30,6 @@ class LogitsProcessor(nn.Module):
 
         logits = lm_head(hidden_states)
         logits = logits.float()
+        if self.scale != 1.0:
+            logits = logits * self.scale
         return logits

--- a/tensorrt_llm/_torch/modules/mamba/mamba2_mixer.py
+++ b/tensorrt_llm/_torch/modules/mamba/mamba2_mixer.py
@@ -131,7 +131,8 @@ class Mamba2Mixer(nn.Module):
                         requires_grad=False))
 
         # norm (only create if mamba_rms_norm is True)
-        mamba_rms_norm = getattr(config.pretrained_config, 'mamba_rms_norm', True)
+        mamba_rms_norm = getattr(config.pretrained_config, 'mamba_rms_norm',
+                                 True)
         if mamba_rms_norm:
             self.norm = RMSNormGated(
                 self.tp_d_inner,

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -21,7 +21,7 @@ from tensorrt_llm.mapping import CpType, Mapping
 from ..model_config import ModelConfig
 from ..speculative import get_num_extra_kv_tokens, get_spec_decoder
 from .config import PyTorchConfig
-from .config_utils import is_mla, is_nemotron_hybrid, is_falcon_h1
+from .config_utils import is_falcon_h1, is_mla, is_nemotron_hybrid
 from .guided_decoder import GuidedDecoder
 from .kv_cache_connector import KvCacheConnectorManager
 from .kv_cache_transceiver import AttentionTypeCpp, create_kv_cache_transceiver

--- a/tensorrt_llm/_torch/pyexecutor/config_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/config_utils.py
@@ -5,6 +5,8 @@ def is_nemotron_hybrid(config):
         return True
     return False
 
+def is_falcon_h1(config):
+    return "FalconH1ForCausalLM" in getattr(config, "architectures", [])
 
 def is_mla(config):
     if getattr(config, "kv_lora_rank", None) and getattr(

--- a/tensorrt_llm/_torch/pyexecutor/config_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/config_utils.py
@@ -5,8 +5,10 @@ def is_nemotron_hybrid(config):
         return True
     return False
 
+
 def is_falcon_h1(config):
     return "FalconH1ForCausalLM" in getattr(config, "architectures", [])
+
 
 def is_mla(config):
     if getattr(config, "kv_lora_rank", None) and getattr(


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[None][feat] Implement support for Falcon-H1 models**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Implemented support for [Falcon-H1 models](https://huggingface.co/collections/tiiuae/falcon-h1-6819f2795bc406da60fab8df). Besides creating and registering `FalconH1ForCausalLM`, the following changes were made:
- `tensorrt_llm/_torch/modules/mamba/mamba2_mixer.py`: Added optional `mup_vector`, made `RMSNorm` optional
- `tensorrt_llm/_torch/pyexecutor/_util.py`: Configured `MambaHybridCacheManager` for Falcon-H1

## Test Coverage

Manually benchmarked with `trtllm-bench`/`genai-perf` and tested with `trtllm-eval`. Tests to be added to this PR.

## PR Checklist

- [ ] Rebase to main (currently based on `1.1.0rc5`)
- [ ] Add tests
- [ ] Add documentation
- [ ] Double-check correctness of attention (`q_scaling = 1.0 / key_multiplier`) and SSM (use of gating in `mamba2_mixer.py`)

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
