### PR TITLE
[https://nvbugs/5556475] [fix] Fix the `tensorrt_llm_bls` model to correctly return the outputs for `num_input_tokens` and `num_output_tokens`

### DIFF
--- a/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm_bls/1/lib/decode.py
+++ b/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm_bls/1/lib/decode.py
@@ -98,6 +98,8 @@ class Request:
     lora_config: Optional[np.ndarray] = None
     exclude_input_in_output: Optional[np.ndarray] = None
     return_perf_metrics: Optional[np.ndarray] = None
+    return_num_input_tokens: Optional[np.ndarray] = None
+    return_num_output_tokens: Optional[np.ndarray] = None
     guided_decoding_guide_type: Optional[np.ndarray] = None
     guided_decoding_guide: Optional[np.ndarray] = None
     request_id: Optional[str] = None
@@ -194,6 +196,8 @@ class GenerationResponse:
     acceptance_rate: Optional[np.ndarray] = None
     total_accepted_draft_tokens: Optional[np.ndarray] = None
     total_draft_tokens: Optional[np.ndarray] = None
+    num_input_tokens: Optional[np.ndarray] = None
+    num_output_tokens: Optional[np.ndarray] = None
 
 
 @dataclass
@@ -215,6 +219,8 @@ class Response:
     acceptance_rate: Optional[np.ndarray] = None
     total_accepted_draft_tokens: Optional[np.ndarray] = None
     total_draft_tokens: Optional[np.ndarray] = None
+    num_input_tokens: Optional[np.ndarray] = None
+    num_output_tokens: Optional[np.ndarray] = None
 
     def __eq__(self, o) -> bool:
         """Just for testing"""

--- a/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm_bls/1/lib/triton_decoder.py
+++ b/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm_bls/1/lib/triton_decoder.py
@@ -104,8 +104,9 @@ class TritonDecoder(Decoder):
             "return_context_logits", "return_generation_logits", "beam_width",
             "stream", "prompt_vocab_size", "num_draft_tokens",
             "use_draft_logits", "exclude_input_in_output",
-            "return_perf_metrics", "lora_weights", "lora_config", "lora_task_id",
-            "return_num_input_tokens", "return_num_output_tokens"
+            "return_perf_metrics", "lora_weights", "lora_config",
+            "lora_task_id", "return_num_input_tokens",
+            "return_num_output_tokens"
         }
 
     def _exec_triton_request(self, request):

--- a/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm_bls/1/lib/triton_decoder.py
+++ b/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm_bls/1/lib/triton_decoder.py
@@ -72,7 +72,8 @@ class TritonDecoder(Decoder):
             "kv_cache_reused_blocks", "kv_cache_alloc_total_blocks",
             "arrival_time_ns", "first_scheduled_time_ns", "first_token_time_ns",
             "last_token_time_ns", "acceptance_rate",
-            "total_accepted_draft_tokens", "total_draft_tokens"
+            "total_accepted_draft_tokens", "total_draft_tokens",
+            "num_input_tokens", "num_output_tokens"
         ]
 
         self._postproc_outputs = [
@@ -92,7 +93,8 @@ class TritonDecoder(Decoder):
             "embedding_bias_weights", "num_draft_tokens", "use_draft_logits",
             "lora_task_id", "lora_weights", "lora_config",
             "exclude_input_in_output", "return_perf_metrics",
-            "guided_decoding_guide_type", "guided_decoding_guide"
+            "guided_decoding_guide_type", "guided_decoding_guide",
+            "return_num_input_tokens", "return_num_output_tokens"
         ]
 
         self.__undo_reshape_whitelist = {
@@ -102,7 +104,8 @@ class TritonDecoder(Decoder):
             "return_context_logits", "return_generation_logits", "beam_width",
             "stream", "prompt_vocab_size", "num_draft_tokens",
             "use_draft_logits", "exclude_input_in_output",
-            "return_perf_metrics", "lora_weights", "lora_config", "lora_task_id"
+            "return_perf_metrics", "lora_weights", "lora_config", "lora_task_id",
+            "return_num_input_tokens", "return_num_output_tokens"
         }
 
     def _exec_triton_request(self, request):
@@ -136,7 +139,9 @@ class TritonDecoder(Decoder):
             "last_token_time_ns": "last_token_time_ns",
             "acceptance_rate": "acceptance_rate",
             "total_accepted_draft_tokens": "total_accepted_draft_tokens",
-            "total_draft_tokens": "total_draft_tokens"
+            "total_draft_tokens": "total_draft_tokens",
+            "num_input_tokens": "num_input_tokens",
+            "num_output_tokens": "num_output_tokens"
         }
         tensors = self.create_triton_tensors(response, name_map)
         return pb_utils.InferenceResponse(output_tensors=tensors)
@@ -459,7 +464,9 @@ class TritonDecoder(Decoder):
             "exclude_input_in_output": "exclude_input_in_output",
             "return_perf_metrics": "return_perf_metrics",
             "guided_decoding_guide_type": "guided_decoding_guide_type",
-            "guided_decoding_guide": "guided_decoding_guide"
+            "guided_decoding_guide": "guided_decoding_guide",
+            "return_num_input_tokens": "return_num_input_tokens",
+            "return_num_output_tokens": "return_num_output_tokens"
         }
         batch_size = request.text_input.shape[0]
         tensors = self.create_triton_tensors(request, name_map)
@@ -546,7 +553,9 @@ class TritonDecoder(Decoder):
             "last_token_time_ns": "last_token_time_ns",
             "acceptance_rate": "acceptance_rate",
             "total_accepted_draft_tokens": "total_accepted_draft_tokens",
-            "total_draft_tokens": "total_draft_tokens"
+            "total_draft_tokens": "total_draft_tokens",
+            "num_input_tokens": "num_input_tokens",
+            "num_output_tokens": "num_output_tokens"
         }
         return self.convert_triton_response(triton_output, GenerationResponse,
                                             name_map)
@@ -599,5 +608,7 @@ class TritonDecoder(Decoder):
             last_token_time_ns=gen_res.last_token_time_ns,
             acceptance_rate=gen_res.acceptance_rate,
             total_accepted_draft_tokens=gen_res.total_accepted_draft_tokens,
-            total_draft_tokens=gen_res.total_draft_tokens)
+            total_draft_tokens=gen_res.total_draft_tokens,
+            num_input_tokens=gen_res.num_input_tokens,
+            num_output_tokens=gen_res.num_output_tokens)
         return response


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token usage metrics are now available in LLM responses. The system supports optional fields to return and track detailed information about the number of input tokens and output tokens processed during each generation request. This enables users to monitor resource consumption and gain better insights into token usage patterns for performance optimization and cost management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

The `tensorrt_llm_bls` model in the Triton backend was not returning `num_input_tokens` and `num_output_tokens`, despite passing the `inputs return_num_input_tokens` and `return_num_output_tokens` in the request.

This PR addresses the issue by the following changes:
- The `tensorrt_llm_bls` model was updated to pass the `return_num_input_tokens` and `return_num_output_tokens` parameters correctly for the inference, ensuring token counts are included in the final response.

## Test Coverage

TBD

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
