### PR TITLE
[None][feat] AutoDeploy: per graph or whole module transform infrastructure

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -6,6 +6,7 @@ transforms:
   ############################################################################################
   build_model:
     stage: factory
+    run_per_gm: false
     device: meta
     # nothing to clean up
     run_graph_cleanup: false
@@ -14,8 +15,8 @@ transforms:
     stage: export
     clone_state_dict: false
     strict: false
-    # nothing to clean up
-    run_graph_cleanup: false
+    run_per_gm: false
+    run_graph_cleanup: true
     requires_clean_graph: false
   cleanup_noop_slice:
     stage: post_export
@@ -35,6 +36,7 @@ transforms:
     run_shape_prop: true
   match_eager_attention:
     stage: pattern_matcher
+    requires_shape_prop: true
   match_grouped_attention:
     stage: pattern_matcher
   match_attention_layout:
@@ -87,8 +89,10 @@ transforms:
   ############################################################################################
   load_weights:
     stage: weight_load
+    run_per_gm: false
   move_inputs_to_device:
     stage: weight_load
+    run_per_gm: false
   ############################################################################################
   # RUN POST-LOAD FUSION AND OPTIMIZATIONS
   ############################################################################################
@@ -138,10 +142,13 @@ transforms:
     attn_backend: cuda_causal_conv
   initialize_cache:
     stage: cache_init
+    run_per_gm: false
   resize_kv_cache:
     stage: cache_init
+    run_per_gm: false
   ############################################################################################
   # COMPILE MODEL
   ############################################################################################
   compile_model:
     stage: compile
+    run_per_gm: false

--- a/tensorrt_llm/_torch/auto_deploy/config/transformers.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/transformers.yaml
@@ -6,23 +6,29 @@ transforms:
   ############################################################################################
   build_and_load_factory_model:
     stage: factory
+    run_per_gm: false
   ############################################################################################
   # MOVE ARGUMENTS TO DEVICE
   ############################################################################################
   move_inputs_to_device:
     stage: weight_load
+    run_per_gm: false
   ############################################################################################
   # SWITCH TO CACHED+FLATTENED ATTENTION + INITIALIZE CACHES
   ############################################################################################
   detect_hf_attn_layers:
     stage: cache_init
+    run_per_gm: false
   transformers_replace_cached_attn:
     stage: cache_init
     attn_backend: flashinfer
+    run_per_gm: false
   initialize_cache:
     stage: cache_init
+    run_per_gm: false
   resize_kv_cache:
     stage: cache_init
+    run_per_gm: false
   ############################################################################################
   # COMPILE MODEL
   ############################################################################################

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/cuda_backend_causal_conv.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/cuda_backend_causal_conv.py
@@ -54,7 +54,6 @@ def _build_conv_state_from_sequence(input_bt_c: torch.Tensor, kernel_size: int) 
 # ---------------------------------------------------------------
 @torch.library.custom_op("auto_deploy::cuda_causal_conv_prepare_metadata", mutates_args=())
 def cuda_causal_conv_prepare_metadata(
-    input_ids: torch.Tensor,
     position_ids: torch.Tensor,
     seq_len: torch.Tensor,
     input_pos: torch.Tensor,
@@ -67,7 +66,7 @@ def cuda_causal_conv_prepare_metadata(
 
     Returns a tuple of (seq_len_sanitized, seq_start, slot_idx_sanitized).
     """
-    seq_len_sanitized = SequenceInfo._get_sanitized_seq_len(input_ids, seq_len)
+    seq_len_sanitized = SequenceInfo._get_sanitized_seq_len(position_ids, seq_len)
     num_seq = len(seq_len_sanitized)
 
     seq_start = torch.zeros_like(seq_len_sanitized)
@@ -81,9 +80,9 @@ def cuda_causal_conv_prepare_metadata(
 
 @cuda_causal_conv_prepare_metadata.register_fake
 def cuda_causal_conv_prepare_metadata_fake(
-    input_ids, position_ids, seq_len, input_pos, cache_loc, pages_per_seq, slot_idx, page_size
+    position_ids, seq_len, input_pos, cache_loc, pages_per_seq, slot_idx, page_size
 ):
-    seq_len_sanitized = SequenceInfo._get_sanitized_seq_len(input_ids, seq_len)
+    seq_len_sanitized = SequenceInfo._get_sanitized_seq_len(position_ids, seq_len)
     num_seq = len(seq_len_sanitized)
     return (
         torch.empty_like(seq_len_sanitized),

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/flashinfer_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/flashinfer_attention.py
@@ -155,7 +155,6 @@ _GlobalFlashInferPlanner = _FlashInferPlanner()
 
 @torch.library.custom_op("auto_deploy::flashinfer_attention_prepare_metadata", mutates_args=())
 def prepare_flashinfer_metadata(
-    input_ids: torch.Tensor,
     position_ids: torch.Tensor,
     seq_len: torch.Tensor,
     input_pos: torch.Tensor,
@@ -174,7 +173,7 @@ def prepare_flashinfer_metadata(
     _GlobalFlashInferPlanner.reset()
 
     # retrieve sanitzed metadata
-    seq_len = SequenceInfo._get_sanitized_seq_len(input_ids, seq_len)
+    seq_len = SequenceInfo._get_sanitized_seq_len(position_ids, seq_len)
     num_seq = len(seq_len)
 
     # prepare flashinfer-style metadata
@@ -214,9 +213,9 @@ def prepare_flashinfer_metadata(
 # As SequenceInfo._get_sanitized_num_sequences could break in fake mode
 @prepare_flashinfer_metadata.register_fake
 def prepare_flashinfer_metadata_fake(
-    input_ids, position_ids, seq_len, input_pos, cache_loc, pages_per_seq, slot_idx, page_size
+    position_ids, seq_len, input_pos, cache_loc, pages_per_seq, slot_idx, page_size
 ):
-    seq_len = SequenceInfo._get_sanitized_seq_len(input_ids, seq_len)
+    seq_len = SequenceInfo._get_sanitized_seq_len(position_ids, seq_len)
     qo_indptr = torch.empty(len(seq_len) + 1, dtype=seq_len.dtype, device=seq_len.device)
     return (
         qo_indptr,  # qo_indptr

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mla.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mla.py
@@ -175,7 +175,6 @@ def fused_flattened_mla_with_cache_fake(
     "auto_deploy::triton_attention_prepare_fused_mla_metadata", mutates_args=()
 )
 def prepare_fused_mla_metadata(
-    input_ids: torch.Tensor,
     position_ids: torch.Tensor,
     seq_len: torch.Tensor,
     input_pos: torch.Tensor,
@@ -184,7 +183,7 @@ def prepare_fused_mla_metadata(
     slot_idx: torch.Tensor,
     page_size: int,
 ) -> List[torch.Tensor]:
-    num_seq = SequenceInfo._get_sanitized_num_sequences(input_ids, seq_len)
+    num_seq = SequenceInfo._get_sanitized_num_sequences(position_ids, seq_len)
     seq_start = torch.zeros_like(seq_len[:num_seq])
     seq_start[1:] = torch.cumsum(seq_len[: num_seq - 1], 0)
     return (
@@ -197,7 +196,7 @@ def prepare_fused_mla_metadata(
 
 @prepare_fused_mla_metadata.register_fake
 def prepare_fused_mla_metadata_fake(
-    input_ids, position_ids, seq_len, input_pos, cache_loc, pages_per_seq, page_size
+    position_ids, seq_len, input_pos, cache_loc, pages_per_seq, slot_idx, page_size
 ):
     return (
         torch.empty_like(seq_len),

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_backend_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_backend_attention.py
@@ -356,7 +356,6 @@ def torch_backend_mha_with_cache_fake(
 
 @torch.library.custom_op("auto_deploy::torch_cached_attention_prepare_metadata", mutates_args=())
 def torch_backend_prepare_metadata(
-    input_ids: torch.Tensor,
     position_ids: torch.Tensor,
     seq_len: torch.Tensor,
     input_pos: torch.Tensor,
@@ -366,7 +365,7 @@ def torch_backend_prepare_metadata(
     page_size: int,
 ) -> List[torch.Tensor]:
     """Prepare metadata for torch backend attention (similar to triton backend)."""
-    num_seq = SequenceInfo._get_sanitized_num_sequences(input_ids, seq_len)
+    num_seq = SequenceInfo._get_sanitized_num_sequences(position_ids, seq_len)
     seq_start = torch.zeros_like(seq_len[:num_seq])
     seq_start[1:] = torch.cumsum(seq_len[: num_seq - 1], 0)
     return (
@@ -379,9 +378,9 @@ def torch_backend_prepare_metadata(
 
 @torch_backend_prepare_metadata.register_fake
 def torch_backend_prepare_metadata_fake(
-    input_ids, position_ids, seq_len, input_pos, cache_loc, pages_per_seq, slot_idx, page_size
+    position_ids, seq_len, input_pos, cache_loc, pages_per_seq, slot_idx, page_size
 ):
-    num_seq = SequenceInfo._get_sanitized_num_sequences(input_ids, seq_len)
+    num_seq = SequenceInfo._get_sanitized_num_sequences(position_ids, seq_len)
     return (
         torch.empty_like(seq_len[:num_seq]),
         torch.empty_like(input_pos[:num_seq]),

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_backend_causal_conv.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_backend_causal_conv.py
@@ -140,7 +140,6 @@ def _torch_causal_conv1d_decode(
 
 @torch.library.custom_op("auto_deploy::torch_causal_conv_prepare_metadata", mutates_args=())
 def torch_causal_conv_prepare_metadata(
-    input_ids: torch.Tensor,
     position_ids: torch.Tensor,
     seq_len: torch.Tensor,
     input_pos: torch.Tensor,
@@ -153,7 +152,7 @@ def torch_causal_conv_prepare_metadata(
 
     Returns a tuple of (seq_len_sanitized, seq_start, slot_idx_sanitized).
     """
-    seq_len_sanitized = SequenceInfo._get_sanitized_seq_len(input_ids, seq_len)
+    seq_len_sanitized = SequenceInfo._get_sanitized_seq_len(position_ids, seq_len)
     num_seq = len(seq_len_sanitized)
 
     seq_start = torch.zeros_like(seq_len_sanitized)
@@ -167,9 +166,9 @@ def torch_causal_conv_prepare_metadata(
 
 @torch_causal_conv_prepare_metadata.register_fake
 def torch_causal_conv_prepare_metadata_fake(
-    input_ids, position_ids, seq_len, input_pos, cache_loc, pages_per_seq, slot_idx, page_size
+    position_ids, seq_len, input_pos, cache_loc, pages_per_seq, slot_idx, page_size
 ):
-    seq_len_sanitized = SequenceInfo._get_sanitized_seq_len(input_ids, seq_len)
+    seq_len_sanitized = SequenceInfo._get_sanitized_seq_len(position_ids, seq_len)
     num_seq = len(seq_len_sanitized)
     return (
         torch.empty_like(seq_len_sanitized),

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_backend_mamba.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/torch_backend_mamba.py
@@ -113,7 +113,6 @@ def _update_ssm_state_cache(ssm_cache: torch.Tensor, ssm_state: torch.Tensor) ->
 
 @torch.library.custom_op("auto_deploy::torch_ssm_prepare_metadata", mutates_args=())
 def _torch_ssm_prepare_metadata(
-    input_ids: torch.Tensor,
     position_ids: torch.Tensor,
     seq_len: torch.Tensor,
     input_pos: torch.Tensor,
@@ -127,7 +126,7 @@ def _torch_ssm_prepare_metadata(
     Returns a tuple of (seq_len_sanitized, seq_start, slot_idx_sanitized).
     """
     # Determine number of active sequences and compute seq_start boundaries
-    seq_len_sanitized = SequenceInfo._get_sanitized_seq_len(input_ids, seq_len)
+    seq_len_sanitized = SequenceInfo._get_sanitized_seq_len(position_ids, seq_len)
     num_seq = len(seq_len_sanitized)
 
     seq_start = torch.zeros_like(seq_len_sanitized)
@@ -142,10 +141,10 @@ def _torch_ssm_prepare_metadata(
 
 @_torch_ssm_prepare_metadata.register_fake
 def _torch_ssm_prepare_metadata_fake(
-    input_ids, position_ids, seq_len, input_pos, cache_loc, pages_per_seq, slot_idx, page_size
+    position_ids, seq_len, input_pos, cache_loc, pages_per_seq, slot_idx, page_size
 ):
     # Use the same sanitization logic to determine sizes in fake mode
-    seq_len_sanitized = SequenceInfo._get_sanitized_seq_len(input_ids, seq_len)
+    seq_len_sanitized = SequenceInfo._get_sanitized_seq_len(position_ids, seq_len)
     num_seq = len(seq_len_sanitized)
     return (
         torch.empty_like(seq_len_sanitized),

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_attention.py
@@ -284,7 +284,6 @@ def flattened_mha_fake(
     "auto_deploy::triton_attention_prepare_fused_mha_metadata", mutates_args=()
 )
 def prepare_fused_mha_metadata(
-    input_ids: torch.Tensor,
     position_ids: torch.Tensor,
     seq_len: torch.Tensor,
     input_pos: torch.Tensor,
@@ -294,7 +293,7 @@ def prepare_fused_mha_metadata(
     page_size: int,
 ) -> List[torch.Tensor]:
     # TODO: maybe use slot_idx instead of pages_per_seq??
-    num_seq = SequenceInfo._get_sanitized_num_sequences(input_ids, seq_len)
+    num_seq = SequenceInfo._get_sanitized_num_sequences(position_ids, seq_len)
     seq_start = torch.zeros_like(seq_len[:num_seq])
     seq_start[1:] = torch.cumsum(seq_len[: num_seq - 1], 0)
     return (
@@ -309,9 +308,9 @@ def prepare_fused_mha_metadata(
 # SequenceInfo._get_sanitized_num_sequences could break in fake mode
 @prepare_fused_mha_metadata.register_fake
 def prepare_fused_mha_metadata_fake(
-    input_ids, position_ids, seq_len, input_pos, cache_loc, pages_per_seq, slot_idx, page_size
+    position_ids, seq_len, input_pos, cache_loc, pages_per_seq, slot_idx, page_size
 ):
-    num_seq = SequenceInfo._get_sanitized_num_sequences(input_ids, seq_len)
+    num_seq = SequenceInfo._get_sanitized_num_sequences(position_ids, seq_len)
     return (
         torch.empty_like(seq_len[:num_seq]),
         torch.empty_like(input_pos[:num_seq]),

--- a/tensorrt_llm/_torch/auto_deploy/transform/interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/interface.py
@@ -4,7 +4,7 @@ This module defines the base classes and interfaces for all transforms.
 """
 
 import time
-from abc import ABC, abstractmethod
+from abc import ABC
 from contextlib import nullcontext
 from enum import Enum
 from functools import total_ordering, wraps
@@ -82,7 +82,7 @@ class TransformConfig(BaseModel):
     ### OPTIONAL CONFIG ###########################################################################
     run_per_gm: bool = Field(
         description="Whether to run the transform per graph (sub)module or on whole module.",
-        default=False,
+        default=True,
     )
     enabled: bool = Field(
         default=True,
@@ -126,9 +126,11 @@ class TransformInfo(BaseModel):
     }
 
     skipped: bool = Field(
+        default=True,
         description="Whether the transform was skipped.",
     )
     num_matches: int = Field(
+        default=0,
         description="Number of matches found.",
     )
     is_clean: bool = Field(
@@ -144,6 +146,32 @@ class TransformInfo(BaseModel):
         "information of the graph. In other words, the transform does not change the shapes of the "
         "tensors in the graph and it preserves the has_valid_shapes flag of the last transform.",
     )
+
+    @classmethod
+    def from_last_info(cls, info: "TransformInfo") -> "TransformInfo":
+        """Create a new TransformInfo from the last transform info."""
+        return cls(
+            is_clean=info.is_clean,
+            has_valid_shapes=info.has_valid_shapes,
+        )
+
+    def __or__(self, other: "TransformInfo") -> "TransformInfo":
+        """Merge two TransformInfo objects."""
+        return TransformInfo(
+            skipped=self.skipped and other.skipped,  # we only count skipped if both were skipped
+            num_matches=self.num_matches + other.num_matches,
+            is_clean=self.is_clean or other.is_clean,
+            has_valid_shapes=self.has_valid_shapes or other.has_valid_shapes,
+        )
+
+    def __and__(self, other: "TransformInfo") -> "TransformInfo":
+        """Merge two TransformInfo objects."""
+        return TransformInfo(
+            skipped=self.skipped and other.skipped,  # we only count skipped if both were skipped
+            num_matches=self.num_matches + other.num_matches,
+            is_clean=self.is_clean and other.is_clean,
+            has_valid_shapes=self.has_valid_shapes and other.has_valid_shapes,
+        )
 
 
 TransformHistory = Dict[str, TransformInfo]
@@ -248,7 +276,7 @@ class BaseTransform(ABC):
     @final
     def __call__(
         self,
-        gm: nn.Module,
+        mod: nn.Module,
         cm: CachedSequenceInterface,
         factory: ModelFactory,
         shared_config: SharedConfig,
@@ -256,13 +284,13 @@ class BaseTransform(ABC):
         """Apply the transform to the graph.
 
         Args:
-            gm: The graph module to apply the transform to.
+            mod: The model to apply the transform to.
             cm: The cached sequence interface defining the sequence interface.
             factory: The model factory used to build the model.
             shared_config: Global info shared between multiple transforms.
 
         Returns:
-            GraphModule: The transformed graph module.
+            nn.Module: The transformed model.
 
         NOTE: The transform can/should modify the graph module in place if possible. Returning the
         graph is mostly to standardize the interface for transforms that cannot modify the graph
@@ -276,12 +304,15 @@ class BaseTransform(ABC):
         t_name = self.get_transform_key()
 
         # retrieve autodeploy metadata from the graphmodule
-        autodeploy_meta = self._get_autodeploy_meta(gm)
+        autodeploy_meta = self._get_autodeploy_meta(mod)
 
         # retrieve transform history and last transform info
         history: TransformHistory = autodeploy_meta.get(self._history_key, {})
         h_keys = list(history.keys())  # preserves order of insertion/transform execution
         info_last = history[h_keys[-1]] if h_keys else TransformInfo(skipped=False, num_matches=0)
+
+        # initialize new info object
+        info = TransformInfo.from_last_info(info_last)
 
         # show debug info for debug config
         ad_logger.debug(f"{t_name} config: {self.config}")
@@ -294,42 +325,47 @@ class BaseTransform(ABC):
 
         # run or skip the transform
         if self.config.enabled:
-            # run graph pre-cleanup
+            # run graph pre-cleanup and update info object
             elapsed_time_pre_cleanup = -time.time()
-            is_clean_pre, has_valid_shapes_pre = self._run_pre_cleanup(gm, info_last)
+            info = info | self._run_cleanup(
+                mod,
+                self.config.requires_clean_graph,
+                self.config.requires_shape_prop,
+                info.is_clean,
+                info.has_valid_shapes,
+            )
             elapsed_time_pre_cleanup += time.time()
 
             # run the transform in a error-handling wrapper if desired
             elapsed_time_apply = -time.time()
             if self.config.skip_on_error:
                 try:
-                    gm, info = self._apply_per_gm(gm, cm, factory, shared_config)
+                    mod, info_apply = self._apply_per_gm_or_whole_model(
+                        mod, cm, factory, shared_config
+                    )
                 except Exception as e:
                     error_msg = f"Transform {t_name} failed"
                     ad_logger.warning(f"{error_msg}: {e}")
-                    info = TransformInfo(skipped=True, num_matches=0)
+                    info_apply = TransformInfo(skipped=True, num_matches=0)
             else:
                 # handle this here normally to improve debugging and error message
-                gm, info = self._apply_per_gm(gm, cm, factory, shared_config)
+                mod, info_apply = self._apply_per_gm_or_whole_model(mod, cm, factory, shared_config)
             elapsed_time_apply += time.time()
 
             # we cannot say it's clean if the previous wasn't clean even if this one is
             # create new info object with updated cleanup status
-            info_dict = info.model_dump()
-            info_dict["is_clean"] &= is_clean_pre
-            info_dict["has_valid_shapes"] &= has_valid_shapes_pre
-            info = TransformInfo(**info_dict)
+            info = info & info_apply
 
             # run graph post-cleanup
             elapsed_time_post_cleanup = -time.time()
-            info = self._run_post_cleanup(gm, info)
+            info = info | self._run_cleanup(
+                mod,
+                self.config.run_graph_cleanup,
+                self.config.run_shape_prop,
+                info.is_clean,
+                info.has_valid_shapes,
+            )
             elapsed_time_post_cleanup += time.time()
-        else:
-            # skip the transform and set info object using the last transform info
-            info_dict = info_last.model_dump()
-            info_dict["skipped"] = True
-            info_dict["num_matches"] = 0
-            info = TransformInfo(**info_dict)
 
         elapsed_time_total += time.time()
 
@@ -348,36 +384,37 @@ class BaseTransform(ABC):
             f"post_cleanup={elapsed_time_post_cleanup:.3f}s",
         ]
         self._log_info(", ".join(log_msgs_timing))
-        ad_logger.debug(f"Graph after {t_name}: {gm}")
+        ad_logger.debug(f"Model after {t_name}: {mod}")
 
         # update + store new meta data
         history[t_name] = info
         autodeploy_meta[self._history_key] = history
-        self._set_autodeploy_meta(gm, autodeploy_meta)
+        self._set_autodeploy_meta(mod, autodeploy_meta)
 
         # return the graph module
-        return gm
+        return mod
 
     @final
-    def _apply_per_gm(
+    def _apply_per_gm_or_whole_model(
         self,
-        gm: nn.Module,
+        mod: nn.Module,
         cm: CachedSequenceInterface,
         factory: ModelFactory,
         shared_config: SharedConfig,
-    ) -> Tuple[GraphModule, TransformInfo]:
+    ) -> Tuple[nn.Module, TransformInfo]:
         if not self.config.run_per_gm:
-            return self._apply(gm, cm, factory, shared_config)
+            return self._apply_to_full_model(mod, cm, factory, shared_config)
 
         # just run it on first graph module we are encountering for now...
-        for k, graph_sub in named_graphmodules(gm):
-            graph_sub, info = self._apply(graph_sub, cm, factory, shared_config)
+        info = TransformInfo()
+        for k, graph_sub in named_graphmodules(mod):
+            graph_sub, info_apply = self._apply(graph_sub, cm, factory, shared_config)
             if k == "":
-                gm = graph_sub
+                mod = graph_sub
             else:
-                gm.set_submodule(k, graph_sub)
-            break
-        return gm, info
+                mod.set_submodule(k, graph_sub)
+            info = info & info_apply
+        return mod, info
 
     @final
     def _log_info(self, *args: any):
@@ -385,88 +422,56 @@ class BaseTransform(ABC):
         ad_logger.info(*args)
 
     @final
-    def _get_autodeploy_meta(self, gm: GraphModule) -> AutodeployMeta:
+    def _get_autodeploy_meta(self, mod: nn.Module) -> AutodeployMeta:
         """Get the autodeploy metadata from the graphmodule."""
-        if not hasattr(gm, "meta"):
-            gm.meta = {}
-        return gm.meta.get(self._autodeploy_meta_key, {})
+        if not hasattr(mod, "meta"):
+            mod.meta = {}
+        return mod.meta.get(self._autodeploy_meta_key, {})
 
     @final
-    def _set_autodeploy_meta(self, gm: GraphModule, autodeploy_meta: AutodeployMeta) -> None:
+    def _set_autodeploy_meta(self, mod: nn.Module, autodeploy_meta: AutodeployMeta) -> None:
         """Set the autodeploy metadata in the graphmodule."""
-        if not hasattr(gm, "meta"):
-            gm.meta = {}
-        gm.meta[self._autodeploy_meta_key] = autodeploy_meta
+        if not hasattr(mod, "meta"):
+            mod.meta = {}
+        mod.meta[self._autodeploy_meta_key] = autodeploy_meta
 
     @final
-    def _run_pre_cleanup(self, gm: GraphModule, info: TransformInfo) -> Tuple[bool, bool]:
+    def _run_cleanup(
+        self,
+        mod: nn.Module,
+        clean_graph: bool,
+        clean_shape: bool,
+        is_clean: bool,
+        has_valid_shapes: bool,
+    ) -> TransformInfo:
         """Run graph cleanup before the transform.
 
         Args:
-            gm: The graph module to run cleanup on.
-            info: The last transform info.
+            mod: The model to run cleanup on.
+            clean_graph: Whether we want a clean graph after the transform.
+            clean_shape: Whether we want clean shapes after the transform.
+            is_clean: The current cleanup status.
+            has_valid_shapes: The current shape propagation status.
 
         Returns:
-            A tuple of (is_clean, has_valid_shapes) indicating the cleanup status after the
-            pre-cleanup.
-
-        This is used to ensure the transform is applied to a clean graph as needed by the transform.
+            An info object indicating the cleanup status after this function is called.
         """
-        if not self.config.requires_clean_graph:
-            return info.is_clean, info.has_valid_shapes
-
-        is_clean = info.is_clean
-        has_valid_shapes = is_clean and info.has_valid_shapes
-
-        use_meta = isinstance(gm, GraphModule) and placeholders_on_meta(gm)
-
         # check if run cleanup depending on the config and info
-        if self.config.requires_shape_prop and not has_valid_shapes:
-            self._log_info("running pre-cleanup with shape_prop")
-            canonicalize_graph(gm)
-            with lift_to_meta(gm) if use_meta else nullcontext():
-                run_shape_prop(gm)
+        if clean_shape and not (is_clean and has_valid_shapes):
+            self._log_info("running graph cleanup (with shape_prop)")
+            canonicalize_graph(mod)
+            with lift_to_meta(mod) if placeholders_on_meta(mod) else nullcontext():
+                run_shape_prop(mod)
             is_clean = True
             has_valid_shapes = True
-        elif self.config.requires_clean_graph and not is_clean:
-            self._log_info("running pre-cleanup (no shape_prop)")
-            canonicalize_graph(gm)
+        elif clean_graph and not is_clean:
+            self._log_info("running graph cleanup (no shape_prop)")
+            canonicalize_graph(mod)
             is_clean = True
+            has_valid_shapes = False
 
-        return is_clean, has_valid_shapes
+        return TransformInfo(is_clean=is_clean, has_valid_shapes=has_valid_shapes)
 
-    @final
-    def _run_post_cleanup(self, gm: GraphModule, info: TransformInfo) -> TransformInfo:
-        """Run graph cleanup after the transform.
-
-        Cleanup is done as requested in the config and we will update the graph module and info
-        accordingly.
-
-        Returns:
-            Updated TransformInfo with cleanup status.
-        """
-        if not self.config.run_graph_cleanup:
-            return info
-
-        use_meta = isinstance(gm, GraphModule) and placeholders_on_meta(gm)
-
-        # check if run cleanup depending on the config and info
-        if self.config.run_shape_prop and not (info.is_clean and info.has_valid_shapes):
-            self._log_info("running post-cleanup with shape_prop")
-            canonicalize_graph(gm)
-            with lift_to_meta(gm) if use_meta else nullcontext():
-                run_shape_prop(gm)
-        elif self.config.run_graph_cleanup and not info.is_clean:
-            self._log_info("running post-cleanup (no shape_prop)")
-            canonicalize_graph(gm)
-
-        # create new info object with updated cleanup status
-        info_dict = info.model_dump()
-        info_dict["is_clean"] |= self.config.run_graph_cleanup
-        info_dict["has_valid_shapes"] |= self.config.run_shape_prop
-        return TransformInfo(**info_dict)
-
-    @abstractmethod
     def _apply(
         self,
         gm: GraphModule,
@@ -478,6 +483,21 @@ class BaseTransform(ABC):
 
         This is the core method that should be implemented by subclasses.
         """
+        raise NotImplementedError(
+            f"Transform {self.get_transform_key()} only supports `run_per_gm=False`."
+        )
+
+    def _apply_to_full_model(
+        self,
+        model: nn.Module,
+        cm: CachedSequenceInterface,
+        factory: ModelFactory,
+        shared_config: SharedConfig,
+    ) -> Tuple[nn.Module, TransformInfo]:
+        """Apply the transform to the full model."""
+        raise NotImplementedError(
+            f"Transform {self.get_transform_key()} only supports `run_per_gm=True`."
+        )
 
 
 class TransformRegistry:

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/build_model.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/build_model.py
@@ -2,8 +2,8 @@
 
 from typing import Tuple, Type
 
+import torch.nn as nn
 from pydantic import Field
-from torch.fx import GraphModule
 
 from ...models import ModelFactory, hf
 from ...shim.interface import CachedSequenceInterface
@@ -36,23 +36,20 @@ class BuildModel(BaseTransform):
     def get_config_class(cls) -> Type[TransformConfig]:
         return BuildModelConfig
 
-    def _apply(
+    def _apply_to_full_model(
         self,
-        gm: GraphModule,
+        mod: nn.Module,
         cm: CachedSequenceInterface,
         factory: ModelFactory,
         shared_config: SharedConfig,
-    ) -> Tuple[GraphModule, TransformInfo]:
+    ) -> Tuple[nn.Module, TransformInfo]:
         # build the model
         model = factory.build_model(self.config.device)
 
-        # as wrapper to satisfy the interface we will register the model as a submodule
-        gm.add_module("factory_model", model)
-
-        # by convention, we say this fake graph module is always clean
+        # by convention, we say the model is always clean
         info = TransformInfo(skipped=False, num_matches=1, is_clean=True, has_valid_shapes=True)
 
-        return gm, info
+        return model, info
 
 
 @TransformRegistry.register("build_and_load_factory_model")
@@ -68,21 +65,18 @@ class BuildAndLoadFactoryModel(BuildModel):
 
     config: BuildModelConfig
 
-    def _apply(
+    def _apply_to_full_model(
         self,
-        gm: GraphModule,
+        mod: nn.Module,
         cm: CachedSequenceInterface,
         factory: ModelFactory,
         shared_config: SharedConfig,
-    ) -> Tuple[GraphModule, TransformInfo]:
+    ) -> Tuple[nn.Module, TransformInfo]:
         # load model with auto sharding
         assert isinstance(factory, hf.AutoModelFactory), "Only HF models are supported."
 
         # build and load the model
         model = factory.build_and_load_model(self.config.device)
-
-        # as wrapper to satisfy the interface we will register the model as a submodule
-        gm.add_module("factory_model", model)
 
         # this ensures that extra_args are passed in as they are received instead of enforcing the
         # registered extra_args
@@ -95,4 +89,4 @@ class BuildAndLoadFactoryModel(BuildModel):
         # by convention, we say this fake graph module is always clean
         info = TransformInfo(skipped=False, num_matches=1, is_clean=True, has_valid_shapes=True)
 
-        return gm, info
+        return model, info

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/compile_model.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/compile_model.py
@@ -1,7 +1,7 @@
 from typing import List, Literal, Optional, Tuple, Type
 
+import torch.nn as nn
 from pydantic import Field
-from torch.fx import GraphModule
 
 from ...compile import CompileBackendRegistry
 from ...models.factory import ModelFactory
@@ -39,18 +39,18 @@ class CompileModel(BaseTransform):
     def get_config_class(cls) -> Type[TransformConfig]:
         return CompileModelConfig
 
-    def _apply(
+    def _apply_to_full_model(
         self,
-        gm: GraphModule,
+        mod: nn.Module,
         cm: CachedSequenceInterface,
         factory: ModelFactory,
         shared_config: SharedConfig,
-    ) -> Tuple[GraphModule, TransformInfo]:
+    ) -> Tuple[nn.Module, TransformInfo]:
         cm.info.set_generate_only_batch()
 
         compiler_cls = CompileBackendRegistry.get(self.config.compile_backend)
-        egm_compiled = compiler_cls(
-            gm,
+        mod_compiled = compiler_cls(
+            mod,
             args=(),
             kwargs=cm.named_args,
             max_batch_size=cm.info.max_batch_size,
@@ -62,4 +62,4 @@ class CompileModel(BaseTransform):
         # store info object about the transform
         info = TransformInfo(skipped=False, num_matches=1, is_clean=True, has_valid_shapes=True)
 
-        return egm_compiled, info
+        return mod_compiled, info

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache_transformers.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache_transformers.py
@@ -6,7 +6,8 @@ from typing import Any, Dict, List, Optional, Tuple, Type
 
 import torch
 import torch.fx as fx
-from torch.fx import GraphModule, Node
+import torch.nn as nn
+from torch.fx import Graph, GraphModule, Node
 from transformers.configuration_utils import PretrainedConfig
 from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
 
@@ -106,23 +107,24 @@ class DetectHFAttnLayers(BaseTransform):
     This is achieved by running a single forward pass to profile the model.
     """
 
-    def _apply(
+    def _apply_to_full_model(
         self,
-        gm: GraphModule,
+        mod: nn.Module,
         cm: CachedSequenceInterface,
         factory: ModelFactory,
         shared_config: SharedConfig,
     ) -> Tuple[GraphModule, TransformInfo]:
-        model = gm.factory_model
-
         # Register profiler attn operator
         ALL_ATTENTION_FUNCTIONS.register("ad_profile_mha", fake_profiler_mha)
 
+        # let's start a fake graph module for making tracing/profiling easier
+        mod._gm = GraphModule(nn.Module(), Graph())
+
         # run the forward pass with the profiling function
-        with switch_attn_implementation(model.config, "ad_profile_mha"):
+        with switch_attn_implementation(mod.config, "ad_profile_mha"):
             # update the graph module with the fake attn nodes during the profiling run
-            profiling_metadata = {"gm": gm, "num_matches": 0}
-            model.forward(**cm.named_args, profiling_metadata=profiling_metadata)
+            profiling_metadata = {"gm": mod._gm, "num_matches": 0}
+            mod.forward(**cm.named_args, profiling_metadata=profiling_metadata)
 
         info = TransformInfo(
             skipped=False,
@@ -131,7 +133,7 @@ class DetectHFAttnLayers(BaseTransform):
             has_valid_shapes=True,
         )
 
-        return gm, info
+        return mod, info
 
 
 def get_cached_attn(
@@ -188,9 +190,9 @@ def get_cached_attn(
     return cached_attn
 
 
-def forward_with_prepare_metadata(gm: GraphModule, **cm_kwargs):
+def forward_with_prepare_metadata(mod: nn.Module, **cm_kwargs):
     """Run prepare_metadata as pre-processing step, add to kwargs, and then run regular forward."""
-
+    gm = mod._gm
     if hasattr(gm, "_prepare_metadata_info"):
         # collect args+constant args
         args = [cm_kwargs[k] for k in gm._prepare_metadata_info["arg_names"]]
@@ -201,7 +203,7 @@ def forward_with_prepare_metadata(gm: GraphModule, **cm_kwargs):
         return_names = gm._prepare_metadata_info["return_names"]
         cm_kwargs.update({k: v for k, v in zip(return_names, metadata)})
 
-    return gm.factory_model.forward(**cm_kwargs)
+    return mod._original_forward(**cm_kwargs)
 
 
 # TODO: how running different kv cache transforms look like? This one below wouldn't work if we
@@ -242,28 +244,29 @@ class HFReplaceCachedAttn(InsertCachedAttention):
         attn_node.meta["metadata_cache_buffer_keys"] = (*meta_nodes, *cache_nodes, *buffer_nodes)
         attn_node.meta["constants"] = constants
 
-    def _apply(
+    def _apply_to_full_model(
         self,
-        gm: GraphModule,
+        mod: nn.Module,
         cm: CachedSequenceInterface,
         factory: ModelFactory,
         shared_config: SharedConfig,
-    ) -> Tuple[GraphModule, TransformInfo]:
+    ) -> Tuple[nn.Module, TransformInfo]:
         # switch to cached attn inputs from now
         cm.info.switch_to_cached_attn_inputs()
 
-        # run actual insert cached attn transform
-        gm, info = super()._apply(gm, cm, factory, shared_config)
+        # run actual insert cached attn transform with fake graph module
+        mod._gm, info = super()._apply(mod._gm, cm, factory, shared_config)
 
         # register cached attn operator and switch to cached forward function
         ALL_ATTENTION_FUNCTIONS.register("ad_cached_mha", get_cached_attn(self.attn_descriptor))
-        gm.forward = types.MethodType(forward_with_prepare_metadata, gm)
+        mod._original_forward = mod.forward
+        mod.forward = types.MethodType(forward_with_prepare_metadata, mod)
 
-        # switch to cached attn implementation but _only_ for modules/configs that have a cached
+        # switch to cached attn implementation but _only_ for submodules/configs that have a cached
         # attn node (we don't want to switch to cached attn implementation for all modules)
-        for mod in gm.factory_model.modules():
-            if hasattr(mod, "_node_ref"):
-                mod.config._attn_implementation = "ad_cached_mha"
+        for submod in mod.modules():
+            if hasattr(submod, "_node_ref"):
+                submod.config._attn_implementation = "ad_cached_mha"
 
         # we assume graph is clean again by definition
         info_dict = info.model_dump()
@@ -271,4 +274,4 @@ class HFReplaceCachedAttn(InsertCachedAttention):
         info_dict["has_valid_shapes"] = True
         info = TransformInfo(**info_dict)
 
-        return gm, info
+        return mod, info

--- a/tensorrt_llm/_torch/auto_deploy/transform/optimizer.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/optimizer.py
@@ -4,7 +4,6 @@ from typing import Optional
 
 import torch.distributed as dist
 import torch.nn as nn
-from torch.fx import Graph, GraphModule
 
 from ..distributed import common as dist_ad
 from ..models.factory import ModelFactory
@@ -44,41 +43,32 @@ class InferenceOptimizer:
         # return strict config
         return strict_config
 
-    @staticmethod
-    def _init_gm() -> GraphModule:
-        """Initialize a fake graph module.
-
-        This is a dummy graph module that will be used to kick off the transforms.
-        """
-        return GraphModule(nn.Module(), Graph())
-
-    def __call__(
-        self, cm: CachedSequenceInterface, gm: Optional[GraphModule] = None
-    ) -> GraphModule:
+    def __call__(self, cm: CachedSequenceInterface, mod: Optional[nn.Module] = None) -> nn.Module:
         """Transform a model into an optimized inference model.
 
         Args:
             cm: The cached sequence interface defining the sequence interface.
+            mod: The model to transform.
 
         Returns:
-            A GraphModule representing the optimized inference model.
+            A nn.Module representing the optimized inference model.
         """
         ############################################################################################
         # RUN THROUGH CONFIGURED TRANSFORMATIONS
         ############################################################################################
 
-        # start with an empty fake graph module if not provided
-        if gm is None:
-            gm = self._init_gm()
+        # start with an empty model if not provided
+        if mod is None:
+            mod = nn.Module()
 
         # iterate over all transforms sorted by stage in the config
         for t_name, t_config in self.config.items():
             # instantiate transform
             transform = TransformRegistry.get(t_name)(t_config)
             # run transform
-            gm = transform(gm, cm, self.factory, self.shared_config)
+            mod = transform(mod, cm, self.factory, self.shared_config)
 
         ############################################################################################
-        # RETURN OPTIMIZED GRAPH
+        # RETURN OPTIMIZED MODEL
         ############################################################################################
-        return gm
+        return mod

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_cuda_causal_conv_cached_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_cuda_causal_conv_cached_op.py
@@ -176,7 +176,7 @@ def test_prepare_metadata_cuda(conv_env):
     device = conv_env["device"]
 
     b, s = 4, 6
-    input_ids = torch.randint(0, 1000, (b, s), device=device)
+    # input_ids = torch.randint(0, 1000, (b, s), device=device)
     position_ids = torch.arange(s, device=device).expand(b, -1)
     seq_len = torch.tensor([2, 1, 0, 0], device=device, dtype=torch.int32)
     input_pos = torch.tensor([0, 3, 0, 0], device=device, dtype=torch.int32)
@@ -186,7 +186,6 @@ def test_prepare_metadata_cuda(conv_env):
     page_size = 128
 
     out = torch.ops.auto_deploy.cuda_causal_conv_prepare_metadata(
-        input_ids,
         position_ids,
         seq_len,
         input_pos,

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_torch_attention_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_torch_attention_op.py
@@ -469,7 +469,7 @@ class TestTorchBackendAttention:
         batch_size, seq_len_val = 4, 8
         device = self.device
 
-        input_ids = torch.randint(0, 1000, (batch_size, seq_len_val), device=device)
+        # input_ids = torch.randint(0, 1000, (batch_size, seq_len_val), device=device)
         position_ids = torch.arange(seq_len_val, device=device).expand(batch_size, -1)
         seq_len = torch.full((batch_size,), seq_len_val, device=device, dtype=torch.int32)
         input_pos = torch.zeros(batch_size, device=device, dtype=torch.int32)
@@ -479,7 +479,7 @@ class TestTorchBackendAttention:
 
         # Test metadata preparation
         result = torch.ops.auto_deploy.torch_cached_attention_prepare_metadata(
-            input_ids, position_ids, seq_len, input_pos, cache_loc, pages_per_seq, slot_idx, 128
+            position_ids, seq_len, input_pos, cache_loc, pages_per_seq, slot_idx, 128
         )
 
         # Verify result structure

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_torch_causal_conv_cached_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_torch_causal_conv_cached_op.py
@@ -168,7 +168,7 @@ def test_prepare_metadata(conv_env):
     device = conv_env["device"]
 
     b, s = 4, 6
-    input_ids = torch.randint(0, 1000, (b, s), device=device)
+    # input_ids = torch.randint(0, 1000, (b, s), device=device)
     position_ids = torch.arange(s, device=device).expand(b, -1)
     seq_len = torch.tensor([2, 1, 0, 0], device=device, dtype=torch.int32)
     input_pos = torch.tensor([0, 3, 0, 0], device=device, dtype=torch.int32)
@@ -178,7 +178,6 @@ def test_prepare_metadata(conv_env):
     page_size = 128
 
     out = torch.ops.auto_deploy.torch_causal_conv_prepare_metadata(
-        input_ids,
         position_ids,
         seq_len,
         input_pos,

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_torch_mamba_cached_op.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/custom_ops/test_torch_mamba_cached_op.py
@@ -183,7 +183,7 @@ def test_prepare_metadata(mamba_env):
     device = mamba_env["device"]
 
     b, s = 4, 6
-    input_ids = torch.randint(0, 1000, (b, s), device=device)
+    # input_ids = torch.randint(0, 1000, (b, s), device=device)
     position_ids = torch.arange(s, device=device).expand(b, -1)
     seq_len = torch.tensor([2, 1, 0, 0], device=device, dtype=torch.int32)
     input_pos = torch.tensor([0, 3, 0, 0], device=device, dtype=torch.int32)
@@ -193,7 +193,6 @@ def test_prepare_metadata(mamba_env):
     page_size = 128
 
     out = torch.ops.auto_deploy.torch_ssm_prepare_metadata(
-        input_ids,
         position_ids,
         seq_len,
         input_pos,

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_build_small_single.py
@@ -92,6 +92,9 @@ def _check_ad_config(experiment_config: ExperimentConfig, llm_args: LlmArgs):
         ),
         get_small_model_config_pytest_param(
             "mistralai/Mistral-Small-3.1-24B-Instruct-2503",
+            pytest_param_kwargs={
+                "marks": pytest.mark.skip(reason="https://nvbugspro.nvidia.com/bug/5505835")
+            },
             attn_backend="flashinfer",
             compile_backend="torch-simple",
         ),

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_kv_cache.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_kv_cache.py
@@ -163,6 +163,7 @@ def test_sdpa_with_kv_cache(dtype, attn_backend, gqa_config):
         {
             "build_model": {
                 "stage": "factory",
+                "run_per_gm": False,
                 "device": "cuda",
                 "run_graph_cleanup": False,
                 "requires_clean_graph": False,
@@ -170,6 +171,7 @@ def test_sdpa_with_kv_cache(dtype, attn_backend, gqa_config):
             "export_to_gm": {
                 "stage": "export",
                 "strict": False,
+                "run_per_gm": False,
                 "clone_state_dict": True,
                 "run_graph_cleanup": False,
                 "requires_clean_graph": False,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Breaking Changes
  - Metadata preparation ops no longer accept input_ids; use position_ids instead. Update any custom calls accordingly.

- New Features
  - Transforms support full-model execution with configurable per-graph behavior.
  - Improved cleanup and shape propagation during export and attention matching.

- Refactor
  - Pipeline migrated from graph-centric to module-centric across build, export, cache init, load, and compile stages.

- Tests
  - Unit tests updated to reflect new op signatures and configuration defaults (including per-graph execution toggles).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
