### PR TITLE
[None][feat] AutoDeploy: chunked prefill support

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/llm_args.py
+++ b/tensorrt_llm/_torch/auto_deploy/llm_args.py
@@ -136,9 +136,7 @@ class AutoDeployConfig(DynamicYamlMixInForSettings, BaseSettings):
         frozen=True,
     )
 
-    enable_chunked_prefill: bool = Field(
-        default=False, description="Enable chunked prefill.", frozen=True
-    )
+    enable_chunked_prefill: bool = Field(default=False, description="Enable chunked prefill.")
 
     ### INFERENCE OPTIMIZER CONFIG #################################################################
     attn_backend: Literal["flashinfer", "triton", "torch"] = Field(

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -9,7 +9,8 @@ from tensorrt_llm._torch.pyexecutor.seq_slot_manager import SeqSlotManager
 from tensorrt_llm._utils import nvtx_range
 
 from ...._utils import mpi_rank, mpi_world_size
-from ....bindings.internal.batch_manager import CacheType
+from ....bindings.executor import ContextChunkingPolicy
+from ....bindings.internal.batch_manager import CacheType, ContextChunkingConfig
 from ....mapping import Mapping
 from ...distributed import MPIDist
 from ...pyexecutor.model_engine import ModelEngine
@@ -204,9 +205,10 @@ class ADEngine(ModelEngine):
             request.py_batch_idx = request.seq_slot
             last_logit_only.append(True)
 
-            # get cache indices
+            # get cache indices and truncate the number of blocks according to end_compute
             cache_indices = kv_cache_manager.get_cache_indices(request)
-            page_assignments.append(cache_indices)
+            num_active_block = kv_cache_manager.get_num_kv_blocks(end_compute)
+            page_assignments.append(cache_indices[:num_active_block])
 
             # store seq slot idx
             slot_idx.append(request.seq_slot)
@@ -372,12 +374,28 @@ def create_autodeploy_executor(ad_config: LlmArgs):
     )
     resource_manager.resource_managers.move_to_end(ResourceManagerType.KV_CACHE_MANAGER, last=True)
 
+    # TODO: consider passing through scheduler_config arguments here. Not doing this for now since
+    # it requires correctly setting up the C++ pybind scheduler config from the LLMArgs and then
+    # processing the arguments here...
+
+    # Chunked prefill
+    if ad_config.enable_chunked_prefill:
+        chunk_unit_size = ad_config.attn_page_size
+        chunking_policy = ContextChunkingPolicy.FIRST_COME_FIRST_SERVED
+        ctx_chunk_config = ContextChunkingConfig(chunking_policy, chunk_unit_size)
+    else:
+        ctx_chunk_config = None
+
     # scheduling
     capacitor_scheduler = BindCapacityScheduler(
-        ad_config.max_batch_size, kv_cache_manager.impl, peft_cache_manager=None
+        max_num_requests=ad_config.max_batch_size,
+        kv_cache_manager=kv_cache_manager.impl,
+        peft_cache_manager=None,
     )
     mb_scheduler = BindMicroBatchScheduler(
-        ad_config.max_batch_size, engine.cache_seq_interface.info.max_num_tokens
+        max_batch_size=ad_config.max_batch_size,
+        max_num_tokens=engine.cache_seq_interface.info.max_num_tokens,
+        ctx_chunk_config=ctx_chunk_config,
     )
     scheduler = SimpleScheduler(capacitor_scheduler, mb_scheduler)
 

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -207,8 +207,8 @@ class ADEngine(ModelEngine):
 
             # get cache indices and truncate the number of blocks according to end_compute
             cache_indices = kv_cache_manager.get_cache_indices(request)
-            num_active_block = kv_cache_manager.get_num_kv_blocks(end_compute)
-            page_assignments.append(cache_indices[:num_active_block])
+            num_active_blocks = kv_cache_manager.get_num_kv_blocks(end_compute)
+            page_assignments.append(cache_indices[:num_active_blocks])
 
             # store seq slot idx
             slot_idx.append(request.seq_slot)

--- a/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
+++ b/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
@@ -41,8 +41,8 @@ class TestLlama3_1_8B(LlmapiAccuracyTestHarness):
     MODEL_PATH = _hf_model_dir_or_hub_id("llama-3.1-model/Meta-Llama-3.1-8B",
                                          MODEL_NAME)
 
-    def get_default_kwargs(self):
-        return {
+    def get_default_kwargs(self, enable_chunked_prefill=False):
+        config = {
             "skip_tokenizer_init": False,
             "trust_remote_code": True,
             "max_batch_size": 512,
@@ -56,6 +56,11 @@ class TestLlama3_1_8B(LlmapiAccuracyTestHarness):
             "free_mem_ratio": 0.7,
             "cuda_graph_batch_sizes": [1, 2, 4, 8, 16, 32, 64, 128, 256, 512],
         }
+        if enable_chunked_prefill:
+            config["enable_chunked_prefill"] = True
+            config[
+                "max_num_tokens"] = 512  # NOTE: must be > max(attn_page_size, max_batch_size)
+        return config
 
     def get_default_sampling_params(self):
         eos_id = -1
@@ -67,8 +72,9 @@ class TestLlama3_1_8B(LlmapiAccuracyTestHarness):
 
     @pytest.mark.skip_less_device_memory(32000)
     @pytest.mark.parametrize("world_size", [1, 2, 4])
-    def test_auto_dtype(self, world_size):
-        kwargs = self.get_default_kwargs()
+    @pytest.mark.parametrize("enable_chunked_prefill", [False, True])
+    def test_auto_dtype(self, world_size, enable_chunked_prefill):
+        kwargs = self.get_default_kwargs(enable_chunked_prefill)
         sampling_params = self.get_default_sampling_params()
         with AutoDeployLLM(model=self.MODEL_PATH,
                            tokenizer=self.MODEL_PATH,
@@ -84,8 +90,8 @@ class TestNemotronH(LlmapiAccuracyTestHarness):
     MODEL_NAME = "nvidia/Nemotron-H-8B-Base-8K"
     MODEL_PATH = f"{llm_models_root()}/Nemotron-H-8B-Base-8K"
 
-    def get_default_kwargs(self):
-        return {
+    def get_default_kwargs(self, enable_chunked_prefill=False):
+        config = {
             "skip_tokenizer_init": False,
             "trust_remote_code": True,
             # SSMs do not support cache reuse.
@@ -103,6 +109,11 @@ class TestNemotronH(LlmapiAccuracyTestHarness):
             "free_mem_ratio": 0.7,
             "cuda_graph_batch_sizes": [1, 2, 4, 8, 16, 32, 64, 128],
         }
+        if enable_chunked_prefill:
+            config["enable_chunked_prefill"] = True
+            config[
+                "max_num_tokens"] = 512  # NOTE: must be > max(attn_page_size, max_batch_size)
+        return config
 
     def get_default_sampling_params(self):
         eos_id = -1
@@ -113,8 +124,12 @@ class TestNemotronH(LlmapiAccuracyTestHarness):
                               use_beam_search=beam_width > 1)
 
     @pytest.mark.skip_less_device_memory(32000)
-    def test_auto_dtype(self):
-        kwargs = self.get_default_kwargs()
+    @pytest.mark.parametrize("enable_chunked_prefill", [False, True])
+    def test_auto_dtype(self, enable_chunked_prefill):
+        if enable_chunked_prefill:
+            pytest.skip(
+                "see https://github.com/NVIDIA/TensorRT-LLM/issues/8272")
+        kwargs = self.get_default_kwargs(enable_chunked_prefill)
         sampling_params = self.get_default_sampling_params()
         with AutoDeployLLM(model=self.MODEL_PATH,
                            tokenizer=self.MODEL_PATH,

--- a/tests/integration/test_lists/test-db/l0_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_b200.yml
@@ -75,7 +75,7 @@ l0_b200:
   - unittest/_torch/modeling -k "modeling_mixtral"
   - unittest/_torch/modeling -k "modeling_gpt_oss"
     # ------------- AutoDeploy tests ---------------
-  - accuracy/test_llm_api_autodeploy.py::TestLlama3_1_8B::test_auto_dtype[1]
+  - accuracy/test_llm_api_autodeploy.py::TestLlama3_1_8B::test_auto_dtype[False-1]
   - unittest/_torch/auto_deploy/unit/singlegpu
 - condition:
     ranges:

--- a/tests/integration/test_lists/test-db/l0_dgx_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_h100.yml
@@ -42,7 +42,7 @@ l0_dgx_h100:
   - accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_auto_dtype[True-True-False]
   - accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_auto_dtype[True-True-True]
   # ------------- AutoDeploy tests ---------------
-  - accuracy/test_llm_api_autodeploy.py::TestLlama3_1_8B::test_auto_dtype[2]
+  - accuracy/test_llm_api_autodeploy.py::TestLlama3_1_8B::test_auto_dtype[False-2]
 - condition:
     ranges:
       system_gpu_count:

--- a/tests/integration/test_lists/test-db/l0_dgx_h200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_h200.yml
@@ -118,7 +118,7 @@ l0_dgx_h200:
   - test_e2e.py::test_trtllm_bench_mgmn
   - unittest/_torch/multi_gpu -m "post_merge" TIMEOUT (90)
   # ------------- AutoDeploy tests ---------------
-  - accuracy/test_llm_api_autodeploy.py::TestLlama3_1_8B::test_auto_dtype[4]
+  - accuracy/test_llm_api_autodeploy.py::TestLlama3_1_8B::test_auto_dtype[False-4]
 - condition:
     ranges:
       system_gpu_count:

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -116,8 +116,10 @@ l0_h100:
   - test_e2e.py::test_ptp_quickstart_multimodal[gemma-3-27b-it-gemma/gemma-3-27b-it-image-True] TIMEOUT (90)
   - test_e2e.py::test_trtllm_benchmark_serving[llama-3.1-model/Meta-Llama-3.1-8B]
   # ------------- AutoDeploy tests ---------------
-  - accuracy/test_llm_api_autodeploy.py::TestLlama3_1_8B::test_auto_dtype[1]
-  - accuracy/test_llm_api_autodeploy.py::TestNemotronH::test_auto_dtype
+  - accuracy/test_llm_api_autodeploy.py::TestLlama3_1_8B::test_auto_dtype[False-1]
+  - accuracy/test_llm_api_autodeploy.py::TestLlama3_1_8B::test_auto_dtype[True-1]
+  - accuracy/test_llm_api_autodeploy.py::TestNemotronH::test_auto_dtype[False]
+  - accuracy/test_llm_api_autodeploy.py::TestNemotronH::test_auto_dtype[True]
 - condition:
     ranges:
       system_gpu_count:

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/shim/test_engine.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/shim/test_engine.py
@@ -1,4 +1,5 @@
-from typing import Optional, Type
+from types import SimpleNamespace
+from typing import List, Optional, Type
 
 import pytest
 import torch
@@ -129,3 +130,90 @@ def test_demo_engine_sampling(attn_page_size: int):
         token_ids_2, _ = engine._sample(logits, sampling_params_none)
 
         torch.testing.assert_close(token_ids_1, token_ids_2)
+
+
+class _DummyKVCacheManager:
+    def __init__(self, tokens_per_block: int):
+        self.tokens_per_block = tokens_per_block
+
+    def get_cache_indices(self, request):
+        # Return many dummy page IDs; ADEngine will truncate as needed
+        return list(range(1024))
+
+    def get_num_kv_blocks(self, num_tokens: int) -> int:
+        if self.tokens_per_block and self.tokens_per_block > 0:
+            return (num_tokens + self.tokens_per_block - 1) // self.tokens_per_block
+        return num_tokens
+
+
+class _DummyResourceManager:
+    def __init__(self, kv_cache_manager: _DummyKVCacheManager):
+        self._kv = kv_cache_manager
+
+    def get_resource_manager(self, _):
+        return self._kv
+
+
+class _DummyRequest:
+    def __init__(self, tokens: List[int], begin: int, size: int, seq_slot: int = 0):
+        self._tokens = tokens
+        self.context_current_position = begin
+        self.context_chunk_size = size
+        self.seq_slot = seq_slot
+        self.py_batch_idx = None
+        self.py_multimodal_data = None
+
+    def get_tokens(self, _beam: int) -> List[int]:
+        return self._tokens
+
+
+@pytest.mark.parametrize("attn_page_size", [256, 2])
+def test_ad_engine_chunked_prefill_equivalence(attn_page_size: int):
+    """Verify ADEngine logits match between chunked and non-chunked prefill.
+
+    We simulate chunking by splitting a single context request into two chunks and
+    compare the final-step logits to processing the full prompt at once.
+    """
+    seed = 123
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+    device = torch.device("cuda")
+    max_seq_len = 64
+    max_batch_size = 8
+
+    sequence_info = SequenceInfo(
+        max_seq_len=max_seq_len,
+        max_batch_size=max_batch_size,
+        page_size=attn_page_size,
+    )
+    sequence_info.to(device)
+
+    engine = ADEngine(get_inference_model, sequence_info, device)
+
+    # A simple prompt; model is position-wise so last token dominates the last logit
+    tokens = [1, 2, 3, 4, 5, 6]
+
+    kv_manager = _DummyKVCacheManager(tokens_per_block=attn_page_size)
+    resource_manager = _DummyResourceManager(kv_manager)
+
+    # No-chunk: whole prompt in one request
+    req_full = _DummyRequest(tokens=tokens, begin=0, size=len(tokens), seq_slot=0)
+    scheduled_full = SimpleNamespace(context_requests=[req_full], generation_requests=[])
+    logits_full = engine.forward(scheduled_full, resource_manager)["logits"]
+
+    # Chunked: split into two context chunks
+    split = len(tokens) // 2
+    req_part1 = _DummyRequest(tokens=tokens, begin=0, size=split, seq_slot=0)
+    req_part2 = _DummyRequest(tokens=tokens, begin=split, size=len(tokens) - split, seq_slot=0)
+
+    scheduled_part1 = SimpleNamespace(context_requests=[req_part1], generation_requests=[])
+    scheduled_part2 = SimpleNamespace(context_requests=[req_part2], generation_requests=[])
+
+    # Run first chunk (ignored output), then compare second chunk logits to full
+    _ = engine.forward(scheduled_part1, resource_manager)
+    logits_chunked_last = engine.forward(scheduled_part2, resource_manager)["logits"]
+
+    assert logits_full.shape == logits_chunked_last.shape
+    assert torch.allclose(logits_full, logits_chunked_last, atol=1e-5)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added optional chunked prefill support, configurable via a new flag. When enabled, request chunking is applied using the attention page size, and scheduling is updated accordingly for improved handling of long contexts.

* Tests
  * Expanded integration tests to parameterize runs with and without chunked prefill across multiple models and environments.
  * Added a unit test validating logits equivalence between chunked and non-chunked prefill paths.
  * Updated test lists to include new parameterized variants and default to non-chunked runs where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
