### PR TITLE
[https://nvbugs/5521949][fix] Replace test_codellama_fp8_with_bf16_lora with test_llama_3_1_8b_fp8_with_bf16_lora

### DIFF
--- a/tests/unittest/llmapi/test_llm_pytorch.py
+++ b/tests/unittest/llmapi/test_llm_pytorch.py
@@ -509,17 +509,6 @@ def test_nemotron_nas_lora() -> None:
 def test_llama_3_1_8b_fp8_with_bf16_lora() -> None:
     model_dir = f"{llm_models_root()}/llama-3.1-model/Llama-3.1-8B-Instruct-FP8"
     lora_dir = f"{llm_models_root()}/lora/llama-3-chinese-8b-instruct-v2-lora"
-
-    lora_config = LoraConfig(lora_dir=[lora_dir],
-                             max_lora_rank=64,
-                             max_loras=2,
-                             max_cpu_loras=2)
-    llm = LLM(
-        model_dir,
-        lora_config=lora_config,
-        # Disable CUDA graph
-        # TODO: remove this once we have a proper fix for CUDA graph in LoRA
-        cuda_graph_config=None)
     prompts = [
         "美国的首都是哪里？",
         "美国的首都是哪里？",
@@ -529,9 +518,20 @@ def test_llama_3_1_8b_fp8_with_bf16_lora() -> None:
         "华盛顿特区。华盛顿特区是美国的首都和一个行政区。它是由哥伦比亚特区和华盛顿特区的两个行政区",
     ]
 
+    lora_config = LoraConfig(lora_dir=[lora_dir],
+                             max_lora_rank=64,
+                             max_loras=2,
+                             max_cpu_loras=2)
     lora_req = LoRARequest("lora-chinese", 0, lora_dir)
     lora_requests = [None, lora_req]
     assert len(lora_requests) == len(prompts)
+
+    llm = LLM(
+        model_dir,
+        lora_config=lora_config,
+        # Disable CUDA graph
+        # TODO: remove this once we have a proper fix for CUDA graph in LoRA
+        cuda_graph_config=None)
 
     try:
         outputs = llm.generate(prompts,

--- a/tests/unittest/llmapi/test_llm_pytorch.py
+++ b/tests/unittest/llmapi/test_llm_pytorch.py
@@ -26,7 +26,8 @@ from .test_llm import (_test_llm_capture_request_error, get_model_path,
                        prompts, run_llm_abort_request,
                        run_llm_with_postprocess_parallel_and_result_handler,
                        tinyllama_logits_processor_test_harness)
-from utils.util import (force_ampere, similar, skip_gpu_memory_less_than_40gb,
+from utils.util import (force_ampere, similar, skip_fp8_pre_ada,
+                        skip_gpu_memory_less_than_40gb,
                         skip_gpu_memory_less_than_80gb,
                         skip_gpu_memory_less_than_138gb, skip_ray)
 from utils.llm_data import llm_models_root
@@ -507,6 +508,7 @@ def test_nemotron_nas_lora() -> None:
 
 @skip_gpu_memory_less_than_80gb
 def test_llama_3_1_8b_fp8_with_bf16_lora() -> None:
+    skip_fp8_pre_ada(use_fp8=True)
     model_dir = f"{llm_models_root()}/llama-3.1-model/Llama-3.1-8B-Instruct-FP8"
     lora_dir = f"{llm_models_root()}/lora/llama-3-chinese-8b-instruct-v2-lora"
     prompt = "美国的首都是哪里？"

--- a/tests/unittest/llmapi/test_llm_pytorch.py
+++ b/tests/unittest/llmapi/test_llm_pytorch.py
@@ -514,8 +514,8 @@ def test_llama_3_1_8b_fp8_with_bf16_lora() -> None:
         "美国的首都是哪里？",
     ]
     references = [
-        "华盛顿特区（Washington D.C.）是美国的首都，也是世界上唯一一座不属于任何一州的联邦特区。\n华盛顿特区（",
-        "华盛顿特区。华盛顿特区是美国的首都和一个行政区。它是由哥伦比亚特区和华盛顿特区的两个行政区",
+        "华盛顿特区。\n华盛顿特区（英文名：Washington, D.C.",
+        "华盛顿特区。华盛顿特区是美国的首都和一个行政区",
     ]
 
     lora_config = LoraConfig(lora_dir=[lora_dir],
@@ -535,7 +535,7 @@ def test_llama_3_1_8b_fp8_with_bf16_lora() -> None:
 
     try:
         outputs = llm.generate(prompts,
-                               SamplingParams(max_tokens=40),
+                               SamplingParams(max_tokens=20),
                                lora_request=lora_requests)
         assert len(outputs) == len(prompts)
     finally:

--- a/tests/unittest/llmapi/test_llm_pytorch.py
+++ b/tests/unittest/llmapi/test_llm_pytorch.py
@@ -509,22 +509,14 @@ def test_nemotron_nas_lora() -> None:
 def test_llama_3_1_8b_fp8_with_bf16_lora() -> None:
     model_dir = f"{llm_models_root()}/llama-3.1-model/Llama-3.1-8B-Instruct-FP8"
     lora_dir = f"{llm_models_root()}/lora/llama-3-chinese-8b-instruct-v2-lora"
-    prompts = [
-        "美国的首都是哪里？",
-        "美国的首都是哪里？",
-    ]
-    references = [
-        "华盛顿特区。\n华盛顿特区（英文名：Washington, D.C.",
-        "华盛顿特区。华盛顿特区是美国的首都和一个行政区",
-    ]
+    prompt = "美国的首都是哪里？"
+    reference = "华盛顿特区。华盛顿特区是美国的首都和一个行政区"
 
     lora_config = LoraConfig(lora_dir=[lora_dir],
                              max_lora_rank=64,
                              max_loras=2,
                              max_cpu_loras=2)
     lora_req = LoRARequest("lora-chinese", 0, lora_dir)
-    lora_requests = [None, lora_req]
-    assert len(lora_requests) == len(prompts)
 
     llm = LLM(
         model_dir,
@@ -534,14 +526,12 @@ def test_llama_3_1_8b_fp8_with_bf16_lora() -> None:
         cuda_graph_config=None)
 
     try:
-        outputs = llm.generate(prompts,
-                               SamplingParams(max_tokens=20),
-                               lora_request=lora_requests)
-        assert len(outputs) == len(prompts)
+        output = llm.generate(prompt,
+                              SamplingParams(max_tokens=20),
+                              lora_request=[lora_req])
     finally:
         llm.shutdown()
-    for output, ref in zip(outputs, references):
-        assert similar(output.outputs[0].text, ref)
+    assert similar(output.outputs[0].text, reference)
 
 
 @skip_gpu_memory_less_than_80gb


### PR DESCRIPTION
## Description

The issue: The test was failing because it tried to quantize the codellama model through LLM api, by passing `QuantConfig`, whose support for pytorch flow is removed.

The solution: Use a quantized model in the test. So I found `Llama-3.1-8B-Instruct-FP8` with `llama-3-chinese-8b-instruct-v2-lora` that's with dtype of BF16.

## Test Coverage

- `tests/unittest/llmapi/test_llm_pytorch.py::test_llama_3_1_8b_fp8_with_bf16_lora`

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Updated mixed-precision LoRA test to target the latest model configuration (FP8/BF16 with Llama 3.1 8B), with refreshed prompts and references.
  - Streamlined setup to improve reproducibility and reduce flakiness, including explicit resource cleanup.
  - Enhances coverage of adapter-based workflows and generation quality checks, increasing overall test reliability and confidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->