### PR TITLE
[TRTLLM-7846][feat] implement etcd storage for disagg cluster

### DIFF
--- a/tensorrt_llm/serve/cluster_storage.py
+++ b/tensorrt_llm/serve/cluster_storage.py
@@ -91,7 +91,7 @@ class ClusterStorage(abc.ABC):
     async def watch(self, key_prefix: str) -> WatchEventQueue:
         ...
 
-    # unwatch the key prefix, if the key prefix is not in the watch list, raise an error
+    # unwatch the key prefix, if the key prefix is not in the watch list, raise a KeyError
     async def unwatch(self, key_prefix: str) -> None:
         ...
 
@@ -451,6 +451,14 @@ class Etcd3ClusterStorage(ClusterStorage):
     @property
     def client(self):
         return self._client
+
+    async def start(self):
+        # nothing to do
+        ...
+
+    async def stop(self):
+        # nothing to do
+        ...
 
     async def set(self,
                   key: str,

--- a/tests/unittest/disaggregated/test_cluster_storage.py
+++ b/tests/unittest/disaggregated/test_cluster_storage.py
@@ -132,7 +132,7 @@ class TestClusterStorage:
     async def test_unwatch(self, storage_server_client, storage_client):
         assert await storage_server_client.watch("test_key")
         await storage_server_client.unwatch("test_key")
-        with pytest.raises(ValueError):
+        with pytest.raises(KeyError):
             await storage_server_client.unwatch("test_key")
 
     @pytest.mark.threadleak(enabled=False)
@@ -210,8 +210,7 @@ class TestHttpClusterStorage(TestClusterStorage):
 
 
 class TestEtcdClusterStorage(TestClusterStorage):
-    # Disable this test until Etcd functionality is ready.
-    __test__ = False
+    __test__ = True
 
     @pytest.fixture(scope="class")
     def storage_server(self):

--- a/tests/unittest/disaggregated/test_disagg_cluster_manager_worker.py
+++ b/tests/unittest/disaggregated/test_disagg_cluster_manager_worker.py
@@ -18,7 +18,7 @@ from tensorrt_llm.serve.disagg_auto_scaling import (DisaggClusterManager,
 INACTIVE_TIMEOUT = 4
 HEARTBEAT_INTERVAL = 2
 
-storage_types = ["http"]
+storage_types = ["http", "etcd"]
 
 
 def get_uri(storage_type):
@@ -77,7 +77,9 @@ async def cluster_manager(config, storage_server):
 
 
 @pytest.mark.parametrize("config", storage_types, indirect=True)
-@pytest.mark.threadleak(enabled=False)
+@pytest.mark.threadleak(
+    enabled=False
+)  # ignore thread leak for python-etcd3 watch thread, there is no way to stop it
 @pytest.mark.asyncio(scope="module")
 async def test_init_workers_first(config, storage_server):
     try:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added etcd-backed cluster storage option with key-prefix get/watch, TTL/lease support, and event-driven watch queues.
  * Factory methods now accept etcd URIs to create etcd-based storage.

* **Bug Fixes**
  * Improved shutdown flow in auto-scaling to ensure clean unwatch and stop.
  * Safeguarded watch unsubscription to avoid redundant calls and standardized unwatch error behavior.

* **Tests**
  * Enabled and expanded tests to cover etcd-based storage.
  * Updated expectations for unwatch behavior and accounted for the etcd watch thread in leak checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
