### PR TITLE
[TRTLLM-7225][chore] Refactor model loading code for gptoss

### DIFF
--- a/tensorrt_llm/_torch/models/checkpoints/hf/gpt_oss_weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/gpt_oss_weight_mapper.py
@@ -1,0 +1,108 @@
+from typing import Dict, List, Tuple
+
+import torch
+from torch import nn
+
+from tensorrt_llm._torch.models.checkpoints.hf.weight_mapper import \
+    HfWeightMapper
+from tensorrt_llm._torch.models.modeling_utils import register_mapper
+from tensorrt_llm._torch.modules.fused_moe import MoE  # matches GPT-OSS MoE
+
+
+@register_mapper("HF", "GptOssForCausalLM")
+class GptOssHfWeightMapper(HfWeightMapper):
+
+    def __init__(self):
+        super().__init__()
+        self._trt_to_hf_map: List[Tuple[str, str]] = [
+            ("embedding", "embed_tokens"),
+            ("attn.norm", "input_layernorm"),
+            ("attn", "self_attn"),
+            ("mlp.norm", "post_attention_layernorm"),
+            ("block", "layers"),
+            ("gate", "router"),
+        ]
+
+    def _trt_prefix_to_hf_prefix(self, prefix: str) -> str:
+        mapped = prefix
+        for k, v in self._trt_to_hf_map:
+            mapped = mapped.replace(k, v)
+        return mapped
+
+    def filter_weights(self, prefix: str, weights: Dict) -> Dict:
+        hf_prefix = self._trt_prefix_to_hf_prefix(prefix)
+        return super().filter_weights(hf_prefix, weights)
+
+    def is_special_instance_module(self, module: nn.Module) -> bool:
+        return isinstance(module, MoE)
+
+    def handle_special_instance_module(self, module: nn.Module,
+                                       module_name: str,
+                                       module_weights: dict) -> None:
+        # MoE needs to be handled specially
+        try:
+            # BF16 layout
+            gate_up_weight = module_weights['gate_up_proj']
+            gate, up = gate_up_weight[:, :, ::2], gate_up_weight[:, :, 1::2]
+            fused_gate_up = torch.cat([gate, up], dim=-1)
+
+            gate_up_bias = module_weights['gate_up_proj_bias']
+            gate_b, up_b = gate_up_bias[:, ::2], gate_up_bias[:, 1::2]
+            fused_b = torch.cat([gate_b, up_b], dim=-1)
+
+            down = module_weights['down_proj']
+            down_b = module_weights['down_proj_bias']
+
+            moe_weights = {
+                'gate_up_proj':
+                [fused_gate_up[i, :, :] for i in range(fused_gate_up.shape[0])],
+                'down_proj': [down[i, :, :] for i in range(down.shape[0])],
+                'gate_up_proj.bias':
+                [fused_b[i, :] for i in range(fused_b.shape[0])],
+                'down_proj.bias':
+                [down_b[i, :] for i in range(down_b.shape[0])],
+            }
+        except Exception:
+            # MXFP4 blocks + scales
+            gate_up_weight = module_weights['gate_up_proj_blocks'].flatten(
+                -2, -1)
+            gate_w, up_w = gate_up_weight[:, ::2, :], gate_up_weight[:, 1::2, :]
+            fused_gate_up = torch.cat([gate_w, up_w], dim=-2)
+
+            gate_up_bias = module_weights['gate_up_proj_bias']
+            gate_b, up_b = gate_up_bias[:, ::2], gate_up_bias[:, 1::2]
+            fused_b = torch.cat([gate_b, up_b], dim=-1)
+
+            down_blocks = module_weights['down_proj_blocks'].flatten(-2, -1)
+
+            moe_weights = {
+                'gate_up_proj': [
+                    fused_gate_up[i, :, :].transpose(0, 1)
+                    for i in range(fused_gate_up.shape[0])
+                ],
+                'down_proj': [
+                    down_blocks[i, :, :].transpose(0, 1)
+                    for i in range(down_blocks.shape[0])
+                ],
+                'gate_up_proj.bias':
+                [fused_b[i, :] for i in range(fused_b.shape[0])],
+                'down_proj.bias': [
+                    module_weights['down_proj_bias'][i, :]
+                    for i in range(module_weights['down_proj_bias'].shape[0])
+                ],
+            }
+            if 'gate_up_proj_scales' in module_weights and 'down_proj_scales' in module_weights:
+                gate_up_sc = module_weights['gate_up_proj_scales']
+                gate_w_sc, up_w_sc = gate_up_sc[:, ::2, :], gate_up_sc[:,
+                                                                       1::2, :]
+                moe_weights['gate_up_proj_weight_scale'] = [
+                    torch.cat([gate_w_sc[i, :, :], up_w_sc[i, :, :]],
+                              dim=-2).transpose(0, 1)
+                    for i in range(gate_w_sc.shape[0])
+                ]
+                moe_weights['down_proj_weight_scale'] = [
+                    module_weights['down_proj_scales'][i, :, :].transpose(0, 1)
+                    for i in range(module_weights['down_proj_scales'].shape[0])
+                ]
+
+        module.load_weights(weights=[moe_weights])


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
