### PR TITLE
[TRTLLM-8685][chore] Unify CLI options for LLM API across bench, serve, and eval commands

### DIFF
--- a/tensorrt_llm/bench/benchmark/low_latency.py
+++ b/tensorrt_llm/bench/benchmark/low_latency.py
@@ -29,6 +29,7 @@ from tensorrt_llm.bench.benchmark.utils.general import (
 from tensorrt_llm.bench.utils.data import (create_dataset_from_stream,
                                            initialize_tokenizer,
                                            update_metadata_for_multimodal)
+from tensorrt_llm.commands.common_llm_options import common_llm_options
 from tensorrt_llm.logger import logger
 from tensorrt_llm.sampling_params import SamplingParams
 
@@ -44,30 +45,6 @@ from tensorrt_llm.sampling_params import SamplingParams
                     resolve_path=True),
     default=None,
     help="Path to a serialized TRT-LLM engine.",
-)
-@optgroup.option(
-    "--extra_llm_api_options",
-    type=str,
-    default=None,
-    help=
-    "Path to a YAML file that overwrites the parameters specified by trtllm-bench."
-)
-@optgroup.option(
-    "--backend",
-    type=click.Choice(ALL_SUPPORTED_BACKENDS),
-    default="pytorch",
-    help="The backend to use for benchmark. Default is pytorch backend.")
-@optgroup.option(
-    "--kv_cache_free_gpu_mem_fraction",
-    type=float,
-    default=.90,
-    help="The percentage of memory to use for KV Cache after model load.",
-)
-@optgroup.option(
-    "--max_seq_len",
-    type=int,
-    default=None,
-    help="Maximum sequence length.",
 )
 @optgroup.group(
     "Engine Input Configuration",
@@ -108,24 +85,6 @@ from tensorrt_llm.sampling_params import SamplingParams
     type=int,
     default=2,
     help="Number of requests warm up benchmark.",
-)
-@optgroup.option(
-    "--tp",
-    type=int,
-    default=1,
-    help="tensor parallelism size",
-)
-@optgroup.option(
-    "--pp",
-    type=int,
-    default=1,
-    help="pipeline parallelism size",
-)
-@optgroup.option(
-    "--ep",
-    type=int,
-    default=None,
-    help="expert parallelism size",
 )
 @optgroup.group("Request Load Control Options",
                 cls=MutuallyExclusiveOptionGroup,
@@ -185,6 +144,7 @@ from tensorrt_llm.sampling_params import SamplingParams
     required=False,
     help="Path where iteration logging is written to.",
 )
+@common_llm_options
 @click.pass_obj
 def latency_command(
     bench_env: BenchmarkEnvironment,
@@ -285,6 +245,7 @@ def latency_command(
     # Construct the runtime configuration dataclass.
     runtime_config = RuntimeConfig(**exec_settings)
 
+    # TODO: unify LlmArgs parsing via Pydantic
     llm = None
     kwargs = kwargs | runtime_config.get_llm_args()
     kwargs['backend'] = options.backend

--- a/tensorrt_llm/commands/common_llm_options.py
+++ b/tensorrt_llm/commands/common_llm_options.py
@@ -1,0 +1,186 @@
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence
+
+import click
+from click_option_group import OptionGroup, optgroup
+
+from tensorrt_llm.llmapi.llm_args import BaseLlmArgs
+from tensorrt_llm.llmapi.reasoning_parser import ReasoningParserFactory
+
+
+class ChoiceWithAlias(click.Choice):
+
+    def __init__(self,
+                 choices: Sequence[str],
+                 aliases: Mapping[str, str],
+                 case_sensitive: bool = True) -> None:
+        super().__init__(choices, case_sensitive)
+        self.aliases = aliases
+
+    def to_info_dict(self) -> Dict[str, Any]:
+        info_dict = super().to_info_dict()
+        info_dict["aliases"] = self.aliases
+        return info_dict
+
+    def convert(self, value: Any, param: Optional["click.Parameter"],
+                ctx: Optional["click.Context"]) -> Any:
+        if value in self.aliases:
+            value = self.aliases[value]
+        return super().convert(value, param, ctx)
+
+
+def common_llm_options(f: Callable) -> Callable:
+    """Apply all common LLM API options to a command.
+
+    This decorator adds all LLM API-related configuration options and organizes them into
+    logical groups.
+    """
+    # Model and backend configuration
+    f = optgroup.group("Model Configuration",
+                       help="Model, tokenizer, and backend settings.")(f)
+    f = optgroup.option(
+        "--tokenizer",
+        type=str,
+        default=None,
+        help="Path | Name of the tokenizer. "
+        "Specify this value only if using TensorRT engine as model.")(f)
+    f = optgroup.option(
+        "--backend",
+        type=ChoiceWithAlias(["pytorch", "tensorrt", "_autodeploy"],
+                             {"trt": "tensorrt"}),
+        default="pytorch",
+        help="The backend to use. Default is pytorch backend.")(f)
+    f = optgroup.option(
+        "--trust_remote_code",
+        is_flag=True,
+        default=False,
+        help="Flag for HF transformers to trust remote code.")(f)
+    f = optgroup.option(
+        "--extra_llm_api_options",
+        type=str,
+        default=None,
+        help=
+        "Path to a YAML file that overwrites the LLM API configuration for serving the model."
+    )(f)
+
+    # Parallelism configuration
+    f = optgroup.group("Parallelism Configuration",
+                       help="Multi-GPU and distributed execution settings.",
+                       cls=OptionGroup)(f)
+    f = optgroup.option("--tp_size",
+                        "--tp",
+                        "tensor_parallel_size",
+                        type=int,
+                        default=1,
+                        help="Tensor parallelism size.")(f)
+    f = optgroup.option("--pp_size",
+                        "--pp",
+                        "pipeline_parallel_size",
+                        type=int,
+                        default=1,
+                        help="Pipeline parallelism size.")(f)
+    f = optgroup.option("--ep_size",
+                        "--ep",
+                        "moe_expert_parallel_size",
+                        type=int,
+                        default=None,
+                        help="Expert parallelism size for MoE models.")(f)
+    f = optgroup.option(
+        "--cluster_size",
+        "moe_cluster_parallel_size",
+        type=int,
+        default=None,
+        help="Expert cluster parallelism size for MoE models.")(f)
+    f = optgroup.option(
+        "--gpus_per_node",
+        type=int,
+        default=None,
+        help=
+        "Number of GPUs per node. Default to None, and it will be detected automatically."
+    )(f)
+
+    # Build and runtime limits
+    f = optgroup.group(
+        "Build and Runtime Limits",
+        help="Maximum batch size, sequence length, and token limits.",
+        cls=OptionGroup)(f)
+    f = optgroup.option(
+        "--max_batch_size",
+        type=int,
+        default=BaseLlmArgs.model_fields["max_batch_size"].default,
+        help="Maximum number of requests that the engine can schedule.")(f)
+    f = optgroup.option(
+        "--max_num_tokens",
+        type=int,
+        default=BaseLlmArgs.model_fields["max_num_tokens"].default,
+        help=
+        "Maximum number of batched input tokens after padding is removed in each batch."
+    )(f)
+    f = optgroup.option(
+        "--max_seq_len",
+        type=int,
+        default=BaseLlmArgs.model_fields["max_seq_len"].default,
+        help="Maximum total length of one request, including prompt and outputs. "
+        "If unspecified, the value is deduced from the model config.")(f)
+    f = optgroup.option(
+        "--max_beam_width",
+        type=int,
+        default=BaseLlmArgs.model_fields["max_beam_width"].default,
+        help="Maximum number of beams for beam search decoding.")(f)
+    f = optgroup.option(
+        "--max_input_len",
+        type=int,
+        default=BaseLlmArgs.model_fields["max_input_len"].default,
+        help="Maximum input sequence length.")(f)
+
+    # KV cache configuration
+    f = optgroup.group("KV Cache Configuration",
+                       help="KV cache memory and reuse settings.",
+                       cls=OptionGroup)(f)
+    f = optgroup.option(
+        "--kv_cache_free_gpu_memory_fraction",
+        "--kv_cache_free_gpu_mem_fraction",
+        "kv_cache_free_gpu_memory_fraction",
+        type=float,
+        default=0.9,
+        help=
+        "Free GPU memory fraction reserved for KV Cache, after allocating model weights and buffers."
+    )(f)
+    f = optgroup.option("--disable_kv_cache_reuse",
+                        is_flag=True,
+                        default=False,
+                        help="Flag for disabling KV cache reuse.")(f)
+
+    # Postprocessing options
+    f = optgroup.group("Postprocessing Options",
+                       help="Output processing and formatting settings.",
+                       cls=OptionGroup)(f)
+    f = optgroup.option(
+        "--num_postprocess_workers",
+        type=int,
+        default=0,
+        help="[Experimental] Number of workers to postprocess raw responses.")(
+            f)
+    f = optgroup.option(
+        "--reasoning_parser",
+        type=click.Choice(ReasoningParserFactory.parsers.keys()),
+        default=None,
+        help="[Experimental] Specify the parser for reasoning models.")(f)
+
+    # Advanced options
+    f = optgroup.group("Advanced Options",
+                       help="Advanced configuration and debugging settings.",
+                       cls=OptionGroup)(f)
+    f = optgroup.option(
+        "--fail_fast_on_attention_window_too_large",
+        is_flag=True,
+        default=False,
+        help=
+        "Exit with runtime error when attention window is too large to fit even a single sequence in the KV cache."
+    )(f)
+    f = optgroup.option(
+        "--skip_tokenizer_init",
+        is_flag=True,
+        default=False,
+        help="Skip tokenizer initialization when loading the model.")(f)
+
+    return f

--- a/tensorrt_llm/commands/eval.py
+++ b/tensorrt_llm/commands/eval.py
@@ -12,14 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional
-
 import click
 
 import tensorrt_llm.profiler as profiler
 
 from .. import LLM as PyTorchLLM
 from .._tensorrt_engine import LLM
+from ..commands.common_llm_options import common_llm_options
 from ..evaluate import (GSM8K, MMLU, MMMU, CnnDailymail, GPQADiamond,
                         GPQAExtended, GPQAMain, JsonModeEval)
 from ..llmapi import BuildConfig, KvCacheConfig
@@ -34,106 +33,44 @@ from ..logger import logger, severity_map
     type=str,
     help="model name | HF checkpoint path | TensorRT engine path",
 )
-@click.option("--tokenizer",
-              type=str,
-              default=None,
-              help="Path | Name of the tokenizer."
-              "Specify this value only if using TensorRT engine as model.")
-@click.option(
-    "--backend",
-    type=click.Choice(["pytorch", "tensorrt"]),
-    default="pytorch",
-    help="The backend to use for evaluation. Default is pytorch backend.")
 @click.option('--log_level',
               type=click.Choice(severity_map.keys()),
               default='info',
               help="The logging level.")
-@click.option("--max_beam_width",
-              type=int,
-              default=BuildConfig.max_beam_width,
-              help="Maximum number of beams for beam search decoding.")
-@click.option("--max_batch_size",
-              type=int,
-              default=BuildConfig.max_batch_size,
-              help="Maximum number of requests that the engine can schedule.")
-@click.option(
-    "--max_num_tokens",
-    type=int,
-    default=BuildConfig.max_num_tokens,
-    help=
-    "Maximum number of batched input tokens after padding is removed in each batch."
-)
-@click.option(
-    "--max_seq_len",
-    type=int,
-    default=BuildConfig.max_seq_len,
-    help="Maximum total length of one request, including prompt and outputs. "
-    "If unspecified, the value is deduced from the model config.")
-@click.option("--tp_size", type=int, default=1, help='Tensor parallelism size.')
-@click.option("--pp_size",
-              type=int,
-              default=1,
-              help='Pipeline parallelism size.')
-@click.option("--ep_size",
-              type=int,
-              default=None,
-              help="expert parallelism size")
-@click.option("--gpus_per_node",
-              type=int,
-              default=None,
-              help="Number of GPUs per node. Default to None, and it will be "
-              "detected automatically.")
-@click.option("--kv_cache_free_gpu_memory_fraction",
-              type=float,
-              default=0.9,
-              help="Free GPU memory fraction reserved for KV Cache, "
-              "after allocating model weights and buffers.")
-@click.option("--trust_remote_code",
-              is_flag=True,
-              default=False,
-              help="Flag for HF transformers.")
-@click.option("--extra_llm_api_options",
-              type=str,
-              default=None,
-              help="Path to a YAML file that overwrites the parameters")
-@click.option("--disable_kv_cache_reuse",
-              is_flag=True,
-              default=False,
-              help="Flag for disabling KV cache reuse.")
+@common_llm_options
 @click.pass_context
-def main(ctx, model: str, tokenizer: Optional[str], log_level: str,
-         backend: str, max_beam_width: int, max_batch_size: int,
-         max_num_tokens: int, max_seq_len: int, tp_size: int, pp_size: int,
-         ep_size: Optional[int], gpus_per_node: Optional[int],
-         kv_cache_free_gpu_memory_fraction: float, trust_remote_code: bool,
-         extra_llm_api_options: Optional[str], disable_kv_cache_reuse: bool):
+def main(ctx, model: str, log_level: str, **params):
     logger.set_level(log_level)
-    build_config = BuildConfig(max_batch_size=max_batch_size,
-                               max_num_tokens=max_num_tokens,
-                               max_beam_width=max_beam_width,
-                               max_seq_len=max_seq_len)
+    # TODO: unify LlmArgs parsing via Pydantic
+    build_config = BuildConfig(max_batch_size=params.get("max_batch_size"),
+                               max_num_tokens=params.get("max_num_tokens"),
+                               max_beam_width=params.get("max_beam_width"),
+                               max_seq_len=params.get("max_seq_len"))
 
     kv_cache_config = KvCacheConfig(
-        free_gpu_memory_fraction=kv_cache_free_gpu_memory_fraction,
-        enable_block_reuse=not disable_kv_cache_reuse)
+        free_gpu_memory_fraction=params.get("kv_cache_free_gpu_memory_fraction",
+                                            0.9),
+        enable_block_reuse=not params.get("disable_kv_cache_reuse", False))
 
     llm_args = {
         "model": model,
-        "tokenizer": tokenizer,
-        "tensor_parallel_size": tp_size,
-        "pipeline_parallel_size": pp_size,
-        "moe_expert_parallel_size": ep_size,
-        "gpus_per_node": gpus_per_node,
-        "trust_remote_code": trust_remote_code,
+        "tokenizer": params.get("tokenizer"),
+        "tensor_parallel_size": params.get("tensor_parallel_size", 1),
+        "pipeline_parallel_size": params.get("pipeline_parallel_size", 1),
+        "moe_expert_parallel_size": params.get("moe_expert_parallel_size"),
+        "gpus_per_node": params.get("gpus_per_node"),
+        "trust_remote_code": params.get("trust_remote_code", False),
         "build_config": build_config,
         "kv_cache_config": kv_cache_config,
     }
 
+    extra_llm_api_options = params.get("extra_llm_api_options")
     if extra_llm_api_options is not None:
         llm_args = update_llm_args_with_extra_options(llm_args,
                                                       extra_llm_api_options)
 
     profiler.start("trtllm init")
+    backend = params.get("backend", "pytorch")
     if backend == 'pytorch':
         llm = PyTorchLLM(**llm_args)
     elif backend == 'tensorrt':

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1130,8 +1130,9 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
     free_gpu_memory_fraction: Optional[float] = Field(
         default=None,
         description=
-        "The fraction of GPU memory fraction that should be allocated for the KV cache. Default is 90%. If both `max_tokens` and `free_gpu_memory_fraction` are specified, memory corresponding to the minimum will be used."
-    )
+        "The fraction of GPU memory fraction that should be allocated for the KV cache, after allocating model weights "
+        "and buffers. Default is 90%. If both `max_tokens` and `free_gpu_memory_fraction` are specified, memory "
+        "corresponding to the minimum will be used.")
     host_cache_size: Optional[int] = Field(
         default=None,
         description=
@@ -1352,7 +1353,8 @@ class BaseLlmArgs(StrictBaseModel):
     tokenizer: Optional[Union[
         str, Path, TokenizerBase, PreTrainedTokenizerBase]] = Field(
             description=
-            "The path to the tokenizer checkpoint or the tokenizer name from the Hugging Face Hub.",
+            "The path to the tokenizer checkpoint or the tokenizer name from the Hugging Face Hub. "
+            "Specify this value only if using a TensorRT engine as the model.",
             default=None)
 
     tokenizer_mode: Literal['auto', 'slow'] = Field(
@@ -1389,7 +1391,8 @@ class BaseLlmArgs(StrictBaseModel):
 
     gpus_per_node: Optional[int] = Field(
         default=None,
-        description="The number of GPUs per node.",
+        description=
+        "The number of GPUs per node. If not provided, it will be detected automatically.",
         status="beta",
         validate_default=True)
 
@@ -1484,21 +1487,27 @@ class BaseLlmArgs(StrictBaseModel):
     speculative_config: SpeculativeConfig = Field(
         default=None, description="Speculative decoding config.")
 
-    max_batch_size: Optional[int] = Field(default=None,
-                                          description="The maximum batch size.")
+    max_batch_size: Optional[int] = Field(
+        default=None,
+        description=
+        "The maximum number of requests that can be scheduled in one batch.")
 
     # generation constraints
     max_input_len: Optional[int] = Field(
         default=None, description="The maximum input length.")
 
     max_seq_len: Optional[int] = Field(
-        default=None, description="The maximum sequence length.")
+        default=None,
+        description=
+        "The maximum total length of one request, including prompt and outputs. "
+        "If unspecified, the value is deduced from the model config.")
 
-    max_beam_width: Optional[int] = Field(default=None,
-                                          description="The maximum beam width.")
+    max_beam_width: Optional[int] = Field(
+        default=None,
+        description="The maximum number of beams for beam search decoding.")
 
     max_num_tokens: Optional[int] = Field(
-        default=None, description="The maximum number of tokens.")
+        default=None, description="The maximum number of tokens in each batch.")
 
     gather_generation_logits: bool = Field(
         default=False,

--- a/tests/unittest/llmapi/apps/_test_openai_mmencoder.py
+++ b/tests/unittest/llmapi/apps/_test_openai_mmencoder.py
@@ -52,22 +52,22 @@ def model_name():
 @pytest.fixture(scope="module",
                 params=[True, False],
                 ids=["extra_options", "no_extra_options"])
-def extra_encoder_options(request):
+def extra_llm_api_options(request):
     return request.param
 
 
 @pytest.fixture(scope="module")
-def temp_extra_encoder_options_file(request):
+def temp_extra_llm_api_options_file(request):
     temp_dir = tempfile.gettempdir()
-    temp_file_path = os.path.join(temp_dir, "extra_encoder_options.yaml")
+    temp_file_path = os.path.join(temp_dir, "extra_llm_api_options.yaml")
     try:
-        extra_encoder_options_dict = {
+        extra_llm_api_options_dict = {
             "max_batch_size": 8,
             "max_num_tokens": 16384
         }
 
         with open(temp_file_path, 'w') as f:
-            yaml.dump(extra_encoder_options_dict, f)
+            yaml.dump(extra_llm_api_options_dict, f)
 
         yield temp_file_path
     finally:
@@ -76,13 +76,13 @@ def temp_extra_encoder_options_file(request):
 
 
 @pytest.fixture(scope="module")
-def server(model_name: str, extra_encoder_options: bool,
-           temp_extra_encoder_options_file: str):
+def server(model_name: str, extra_llm_api_options: bool,
+           temp_extra_llm_api_options_file: str):
     model_path = get_model_path(model_name)
     args = ["--max_batch_size", "8"]
-    if extra_encoder_options:
+    if extra_llm_api_options:
         args.extend(
-            ["--extra_encoder_options", temp_extra_encoder_options_file])
+            ["--extra_llm_api_options", temp_extra_llm_api_options_file])
 
     with RemoteMMEncoderServer(model_path, args) as remote_server:
         yield remote_server


### PR DESCRIPTION
## Description

Currently, multiple commands including `trtllm-serve`, `trtllm-bench`, and `trtllm-eval` expose CLI args that map to LLM API configuration options. However, there are a few issues with this:
1. The arg definitions are duplicated between each command, which makes it easy for them to diverge.
2. Certain arguments are named differently between each command (e.g. `--tp` vs. `--tp_size`)
3. The code to convert these CLI options into an `LlmArgs` instance is different for each command, which can lead to bugs.
    - This PR does **not** aim to address this part in particular. This will be handled in #8331 instead.

The CLI options have been unified under a `common_llm_options` decorator which is used across multiple commands. The goal here was to ensure full backwards compatibility by creating aliases for each option as needed (e.g. both `--tp` and `--tp_size` will be accepted).

---

@coderabbitai summary

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
