### PR TITLE
[None][feat] Add FP8 rowwise GEMMs for B200

### DIFF
--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/CMakeLists.txt
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/CMakeLists.txt
@@ -200,7 +200,7 @@ add_cuda_architectures(fpA_intB_gemm_src 89)
 add_instantiations(fpA_intB_gemm_src ${INSTANTIATION_GENERATION_DIR}/gemm)
 
 add_library(fb_gemm_src STATIC ${FBGEMM_SRC_CU} ${FBGEMM_CU_INSTANTIATIONS})
-set_cuda_architectures(fb_gemm_src 89 90 120f)
+set_cuda_architectures(fb_gemm_src 89 90 100f 120f)
 # add_instantiations(fb_gemm_src
 # ${INSTANTIATION_GENERATION_DIR}/fp8_rowwise_gemm)
 

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_rowwise_gemm/fp8_rowwise_gemm_kernel_template_sm100.h
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_rowwise_gemm/fp8_rowwise_gemm_kernel_template_sm100.h
@@ -132,11 +132,11 @@ struct DeviceGemmFp8RowwiseSm100
     using EVTComputeBias = cutlass::epilogue::fusion::Sm90EVT<ComputeBias, Bias, EVTCompute1>;
 
     using EpilogueEVT = EVTCompute1;
-    using EpilogueScheduleTypeOverride = cutlass::epilogue::collective::EpilogueScheduleAuto;
+
     using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<ArchTag, OperatorClass,
         TileShape, ClusterShape, cutlass::epilogue::collective::EpilogueTileAuto, ElementAccumulator,
         ElementComputeEpilogue, ElementC, LayoutC, AlignmentC, ElementOutput, LayoutOutput, AlignmentOutput,
-        EpilogueScheduleTypeOverride, EpilogueEVT>::CollectiveOp;
+        EpilogueScheduleType, EpilogueEVT>::CollectiveOp;
 
     using MainLoopSchedule = cutlass::gemm::collective::KernelScheduleAuto;
 

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_rowwise_gemm/fp8_rowwise_gemm_kernel_template_sm100.h
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_rowwise_gemm/fp8_rowwise_gemm_kernel_template_sm100.h
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifdef __GNUC__ // Check if the compiler is GCC or Clang
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#endif // __GNUC__
+
+#include "tensorrt_llm/kernels/archCondition.h"
+
+#ifdef __GNUC__ // Check if the compiler is GCC or Clang
+#pragma GCC diagnostic pop
+#endif          // __GNUC__
+
+namespace tensorrt_llm::kernels::cutlass_kernels
+{
+using namespace cute;
+
+template <typename ElementType, typename OutElementType, typename AccumElementType, typename CTAShape,
+    typename ClusterShape, typename MainloopScheduleType, typename EpilogueScheduleType,
+    typename TileSchedulerType = void>
+struct DeviceGemmFp8RowwiseSm100
+{
+    static_assert(std::is_same_v<ElementType, cutlass::float_e4m3_t>, "ElementType must be FP8(e4m3)");
+
+    // A matrix configuration
+    using ElementA = ElementType;                      // Element type for A matrix operand
+    using LayoutA = cutlass::layout::RowMajor;         // Layout type for A matrix operand
+    static constexpr int AlignmentA
+        = 128 / cutlass::sizeof_bits<ElementA>::value; // Memory access granularity/alignment of A
+                                                       // matrix in units of elements (up to 16 bytes)
+
+    // B matrix configuration
+    using ElementB = ElementType;                      // Element type for B matrix operand
+    using LayoutB = cutlass::layout::ColumnMajor;      // Layout type for B matrix operand
+    static constexpr int AlignmentB
+        = 128 / cutlass::sizeof_bits<ElementB>::value; // Memory access granularity/alignment of B
+                                                       // matrix in units of elements (up to 16 bytes)
+
+    // C/D matrix configuration
+    using ElementC = void;                                   // Element type for C matrix operands
+    using LayoutC = cutlass::layout::RowMajor;               // Layout type for C matrix operands
+    static constexpr int AlignmentC
+        = 128 / cutlass::sizeof_bits<OutElementType>::value; // Memory access granularity/alignment of C matrices in
+                                                             // units of elements (up to 16 bytes)
+
+    // Output matrix configuration
+    using ElementOutput = OutElementType;           // Element type for output matrix operands
+    using LayoutOutput = cutlass::layout::RowMajor; // Layout type for output matrix operands
+    static constexpr int AlignmentOutput = 128 / cutlass::sizeof_bits<ElementOutput>::value;
+
+    // Auxiliary matrix configuration and other fusion types
+    using ElementBias = float;
+
+    // Multiply-accumulate blocking/pipelining details
+    using ElementAccumulator = AccumElementType; // Element type for internal accumulation
+    using ElementCompute = float;                // Element type for compute
+    using ElementComputeEpilogue = float;
+    using ArchTag = cutlass::arch::Sm100;        // Tag indicating the minimum SM that supports the intended feature
+    using OperatorClass = cutlass::arch::OpClassTensorOp; // Operator class tag
+    using TileShape = CTAShape;                           // Threadblock-level tile size
+    using TileScheduler = TileSchedulerType;
+
+    using Multiply = cutlass::epilogue::fusion::Sm90Compute<cutlass::multiplies, ElementComputeEpilogue,
+        ElementComputeEpilogue, cutlass::FloatRoundStyle::round_to_nearest>;
+    using Add = cutlass::epilogue::fusion::Sm90Compute<cutlass::plus, ElementComputeEpilogue, ElementComputeEpilogue,
+        cutlass::FloatRoundStyle::round_to_nearest>;
+    using Cast = cutlass::epilogue::fusion::Sm90Compute<cutlass::epilogue::thread::Identity, OutElementType,
+        ElementComputeEpilogue, cutlass::FloatRoundStyle::round_to_nearest>;
+
+    // static constexpr bool PONG = false;
+    // static constexpr bool FAST_ACCUM = true;
+    // static constexpr bool USE_BIAS = false;
+
+    // using StageCountType = cutlass::gemm::collective::StageCountAuto;     // Stage count maximized
+    //  based on the tile size
+    // using KernelSchedule = cutlass::gemm::collective::KernelScheduleAuto; // Kernel to launch based on the default
+    //  setting in the Collective Builder
+
+    // Implement rowwise scaling epilogue.
+    using XScale = cutlass::epilogue::fusion::Sm90ColBroadcast<0, TileShape, ElementComputeEpilogue>;
+
+    using WScale = cutlass::epilogue::fusion::Sm90RowBroadcast<0, TileShape, ElementComputeEpilogue>;
+
+    using Bias = cutlass::epilogue::fusion::Sm90RowBroadcast<0, TileShape, ElementBias>;
+
+    using Accum = cutlass::epilogue::fusion::Sm90AccFetch;
+    using AccumScale = cutlass::epilogue::fusion::Sm90EVT<Multiply, WScale,
+        cutlass::epilogue::fusion::Sm90EVT<Multiply, XScale, Accum>>;
+
+    using EpilogueEVT
+        = cutlass::epilogue::fusion::Sm90EVT<Cast, cutlass::epilogue::fusion::Sm90EVT<Add, Bias, AccumScale>>;
+
+    using EpilogueScheduleTypeOverride = cutlass::epilogue::collective::EpilogueScheduleAuto;
+    using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<ArchTag, OperatorClass,
+        TileShape, ClusterShape, cutlass::epilogue::collective::EpilogueTileAuto, ElementAccumulator,
+        ElementComputeEpilogue, ElementC, LayoutC, AlignmentC, ElementOutput, LayoutOutput, AlignmentOutput,
+        EpilogueScheduleTypeOverride, EpilogueEVT>::CollectiveOp;
+
+    // using DefaultSchedule = cutlass::gemm::KernelTmaWarpSpecialized;
+    // using PongSchedule = cutlass::gemm::KernelTmaWarpSpecializedPingpong;
+    // using FastDefaultSchedule = cutlass::gemm::KernelTmaWarpSpecializedFP8FastAccum;
+    // using FastPongSchedule = cutlass::gemm::KernelTmaWarpSpecializedPingpongFP8FastAccum;
+
+    // using SlowAccum = DefaultSchedule;
+    // using FastAccum = FastDefaultSchedule;
+    // using MainLoopSchedule = cute::conditional_t<FAST_ACCUM, FastAccum, SlowAccum>;
+    using MainLoopSchedule = cutlass::gemm::collective::KernelScheduleAuto;
+
+    using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<ArchTag, OperatorClass, ElementA,
+        LayoutA, AlignmentA, ElementB, LayoutB, AlignmentB, ElementAccumulator, TileShape, ClusterShape,
+        cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+            sizeof(typename CollectiveEpilogue::SharedStorage))>,
+        MainLoopSchedule>::CollectiveOp;
+
+    template <typename Base>
+    struct Sm100Only : Base
+    {
+        using typename Base::Params;
+
+        CUTLASS_DEVICE
+        void operator()(Params const& params, char* smem_buf)
+        {
+            if constexpr (tensorrt_llm::kernels::arch::is_match_v<100>)
+            {
+                this->Base::operator()(params, smem_buf);
+            }
+            else
+            {
+                if (cute::thread0())
+                {
+                    printf("%s : This kernel shall only run on SM100 devices.\n", __PRETTY_FUNCTION__);
+                    __trap();
+                }
+            }
+        }
+    };
+
+    using GemmKernel
+        = Sm100Only<typename cutlass::gemm::kernel::GemmUniversal<cute::Shape<int, int, int, int>, // Indicates
+                                                                                                   // ProblemShape
+            CollectiveMainloop, CollectiveEpilogue, TileScheduler>>;
+
+    using Gemm = typename cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+};
+
+} // namespace tensorrt_llm::kernels::cutlass_kernels

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_rowwise_gemm/fp8_rowwise_gemm_kernel_template_sm100.h
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_rowwise_gemm/fp8_rowwise_gemm_kernel_template_sm100.h
@@ -99,15 +99,6 @@ struct DeviceGemmFp8RowwiseSm100
     using Cast = cutlass::epilogue::fusion::Sm90Compute<cutlass::epilogue::thread::Identity, OutElementType,
         ElementComputeEpilogue, cutlass::FloatRoundStyle::round_to_nearest>;
 
-    // static constexpr bool PONG = false;
-    // static constexpr bool FAST_ACCUM = true;
-    // static constexpr bool USE_BIAS = false;
-
-    // using StageCountType = cutlass::gemm::collective::StageCountAuto;     // Stage count maximized
-    //  based on the tile size
-    // using KernelSchedule = cutlass::gemm::collective::KernelScheduleAuto; // Kernel to launch based on the default
-    //  setting in the Collective Builder
-
     // Implement rowwise scaling epilogue.
     using XScale = cutlass::epilogue::fusion::Sm90ColBroadcast<0, TileShape, ElementComputeEpilogue,
         ElementComputeEpilogue, cute::Stride<cute::Int<1>, cute::Int<0>, cute::Int<0>>>;
@@ -147,14 +138,6 @@ struct DeviceGemmFp8RowwiseSm100
         ElementComputeEpilogue, ElementC, LayoutC, AlignmentC, ElementOutput, LayoutOutput, AlignmentOutput,
         EpilogueScheduleTypeOverride, EpilogueEVT>::CollectiveOp;
 
-    // using DefaultSchedule = cutlass::gemm::KernelTmaWarpSpecialized;
-    // using PongSchedule = cutlass::gemm::KernelTmaWarpSpecializedPingpong;
-    // using FastDefaultSchedule = cutlass::gemm::KernelTmaWarpSpecializedFP8FastAccum;
-    // using FastPongSchedule = cutlass::gemm::KernelTmaWarpSpecializedPingpongFP8FastAccum;
-
-    // using SlowAccum = DefaultSchedule;
-    // using FastAccum = FastDefaultSchedule;
-    // using MainLoopSchedule = cute::conditional_t<FAST_ACCUM, FastAccum, SlowAccum>;
     using MainLoopSchedule = cutlass::gemm::collective::KernelScheduleAuto;
 
     using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<ArchTag, OperatorClass, ElementA,

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_rowwise_gemm/fp8_rowwise_gemm_template.h
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_rowwise_gemm/fp8_rowwise_gemm_template.h
@@ -47,7 +47,6 @@
 #include "tensorrt_llm/kernels/cutlass_kernels/cutlass_type_conversion.h"
 
 #include <algorithm>
-#include <unistd.h>
 #include <vector>
 
 namespace tensorrt_llm
@@ -725,7 +724,6 @@ std::vector<tkc::CutlassGemmConfig> CutlassFp8RowwiseGemmRunner<T>::getConfigs()
     using tkc::SplitKStyle;
 
     std::vector<CutlassGemmConfig> candidateConfigs;
-
     if (mSm == 90)
     {
         tkc::CutlassGemmConfig::CandidateConfigTypeParam config_type_param

--- a/tests/unittest/_torch/thop/parallel/test_fp8_rowwise_linear.py
+++ b/tests/unittest/_torch/thop/parallel/test_fp8_rowwise_linear.py
@@ -1,12 +1,11 @@
 import pytest
 import torch
-from utils.util import skip_blackwell, skip_pre_hopper
+from utils.util import skip_pre_hopper
 
 from tensorrt_llm._torch.modules.linear import Linear
 from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
 
 
-@skip_blackwell
 @skip_pre_hopper
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 def test_fp8_rowwise_linear(dtype):


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for SM100 GPU architecture with optimized FP8 rowwise GEMM operations.

* **Tests**
  * Enabled FP8 rowwise linear tests to run on Blackwell-based GPUs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Add FP8 rowwise GEMMs for B200

## Test Coverage

test_fp8_rowwise_linear

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
