### PR TITLE
[None][feat] Move StreamGeneration to scaffolding main directory

### DIFF
--- a/examples/scaffolding/contrib/AsyncGeneration/stream_generation_controller.py
+++ b/examples/scaffolding/contrib/AsyncGeneration/stream_generation_controller.py
@@ -42,9 +42,8 @@ class NativeStreamGenerationController(Controller):
                     "custom_sampling_params")
             elif self.custom_sampling_params:
                 task.custom_sampling_params = self.custom_sampling_params
-            stream_task = StreamGenerationTask()
-            stream_task.__dict__ = copy.deepcopy(task.__dict__)
-            stream_task.streaming_step = self.stream_step
+            stream_task = StreamGenerationTask.create_from_generation_task(
+                task, self.stream_step)
             stream_tasks.append(stream_task)
         lst = list(range(len(stream_tasks)))
 

--- a/tensorrt_llm/scaffolding/__init__.py
+++ b/tensorrt_llm/scaffolding/__init__.py
@@ -6,7 +6,8 @@ from .controller import (BestOfNController, Controller, MajorityVoteController,
 from .math_utils import (extract_answer_from_boxed, extract_answer_with_regex,
                          get_digit_majority_vote_result)
 from .scaffolding_llm import ScaffoldingLlm
-from .task import GenerationTask, RewardTask, Task, TaskStatus
+from .task import (GenerationTask, RewardTask, StreamGenerationTask, Task,
+                   TaskStatus)
 from .task_collection import (GenerationTokenCounter, TaskCollection,
                               with_task_collection)
 from .worker import OpenaiWorker, TRTLLMWorker, TRTOpenaiWorker, Worker
@@ -22,6 +23,7 @@ __all__ = [
     "BestOfNController",
     "Task",
     "GenerationTask",
+    "StreamGenerationTask",
     "RewardTask",
     "Worker",
     "OpenaiWorker",

--- a/tensorrt_llm/scaffolding/contrib/AsyncGeneration/stream_generation.py
+++ b/tensorrt_llm/scaffolding/contrib/AsyncGeneration/stream_generation.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
@@ -21,6 +22,15 @@ class StreamGenerationTask(GenerationTask):
     request_handle: Any = field(default=None)
     # worker set this field to True when the generation is finished
     end_flag: bool = field(default=False)
+
+    @staticmethod
+    def create_from_generation_task(
+            task: GenerationTask,
+            streaming_step: int) -> "StreamGenerationTask":
+        stream_task = StreamGenerationTask()
+        stream_task.__dict__ = copy.deepcopy(task.__dict__)
+        stream_task.streaming_step = streaming_step
+        return stream_task
 
 
 async def stream_generation_handler(worker,

--- a/tensorrt_llm/scaffolding/controller.py
+++ b/tensorrt_llm/scaffolding/controller.py
@@ -230,15 +230,16 @@ class MajorityVoteController(Controller):
         yield ParallelProcess(generation_controllers, tasks_list,
                               generation_kwargs_list)
 
-        candidates = [tasks[0].output_str for tasks in tasks_list]
         majority_index, majority_answer = self.majority_vote(
-            candidates, **majority_vote_kwargs)
+            tasks_list, **majority_vote_kwargs)
 
         assert isinstance(majority_answer, str), "majority_vote failed"
         # The task returned by majority vote does not have output_tokens and logits.
         tasks[0].result = tasks_list[majority_index][0].result
 
-    def majority_vote(self, candidates: List[str], **kwargs) -> Tuple[int, str]:
+    def majority_vote(self, candidates_tasks: List[List[Task]],
+                      **kwargs) -> Tuple[int, str]:
+        candidates = [tasks[0].output_str for tasks in candidates_tasks]
         return get_digit_majority_vote_result(candidates)
 
 

--- a/tensorrt_llm/scaffolding/scaffolding_llm.py
+++ b/tensorrt_llm/scaffolding/scaffolding_llm.py
@@ -175,13 +175,19 @@ class ScaffoldingLlm:
         result = ScaffoldingResult(self.streaming_event)
 
         async def put_request():
-            request = ScaffoldingRequest(
-                prompt=prompt,
-                kwargs={},
-                result=result,
-                controller=self.prototype_controller.clone())
-
-            await self.task_queue.put(request)
+            try:
+                request = ScaffoldingRequest(
+                    prompt=prompt,
+                    kwargs={},
+                    result=result,
+                    controller=self.prototype_controller.clone())
+            except Exception as e:
+                self.task_queue.put(None)
+                print(
+                    f"Error: build ScaffoldingRequest failed: {e} \n {traceback.format_exc()}"
+                )
+            else:
+                await self.task_queue.put(request)
 
         asyncio.run_coroutine_threadsafe(put_request(), self.loop)
 
@@ -208,7 +214,7 @@ class ScaffoldingLlm:
 
     def shutdown(self, shutdown_workers=False):
 
-        def shutdown_workers():
+        def shutdown_workers_func():
             for worker in self.workers.values():
                 worker.shutdown()
 
@@ -228,4 +234,4 @@ class ScaffoldingLlm:
             self.shutdown_event.set()
 
         if shutdown_workers:
-            shutdown_workers()
+            shutdown_workers_func()

--- a/tensorrt_llm/scaffolding/task.py
+++ b/tensorrt_llm/scaffolding/task.py
@@ -1,10 +1,11 @@
+import copy
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import torch
 
-from tensorrt_llm.executor.result import GenerationResult
+from tensorrt_llm.executor.result import GenerationResult, TokenLogprobs
 
 
 @dataclass
@@ -64,6 +65,7 @@ class GenerationTask(Task):
     # result field
     # link to TRTLLM's GenerationResult, for async update in streaming mode
     _result: Optional[GenerationResult] = None
+    customized_result_fields: Dict[str, Any] = field(default_factory=dict)
 
     @property
     def result(self) -> GenerationResult:
@@ -96,7 +98,7 @@ class GenerationTask(Task):
             0].cumulative_logprob if self._result else None
 
     @property
-    def logprobs(self) -> Optional[List[float]]:
+    def logprobs(self) -> Optional[TokenLogprobs]:
         return self._result.outputs[0].logprobs if self._result else None
 
     @property
@@ -113,6 +115,32 @@ class GenerationTask(Task):
 
     def create_scaffolding_output(self) -> GenerationResult:
         return self._result
+
+
+@dataclass
+class StreamGenerationTask(GenerationTask):
+    # input field
+    # if the flag is set to True, the worker will cancel the generation work
+    cancel_flag: Optional[bool] = field(default=False)
+    # the task will be returned to the controller with at least new streaming_step tokens
+    # if the streaming_step is set to 0,
+    # the task will be returned to the controller immediately with
+    # new tokens that have already been generated.
+    streaming_step: Optional[int] = field(default=1)
+
+    #result field
+    # worker set this field and identify the same task by this field
+    request_handle: Any = field(default=None)
+    # worker set this field to True when the generation is finished
+    end_flag: bool = field(default=False)
+
+    @staticmethod
+    def create_from_generation_task(task: GenerationTask,
+                                    streaming_step) -> "StreamGenerationTask":
+        stream_task = StreamGenerationTask()
+        stream_task.__dict__ = copy.deepcopy(task.__dict__)
+        stream_task.streaming_step = streaming_step
+        return stream_task
 
 
 @dataclass

--- a/tensorrt_llm/scaffolding/worker.py
+++ b/tensorrt_llm/scaffolding/worker.py
@@ -217,19 +217,14 @@ class TRTLLMWorker(Worker):
                 await task.request_handle._aresult_step()
                 if task.request_handle._done:
                     break
+
             while not task.request_handle._done:
                 async_task = asyncio.create_task(
                     task.request_handle._aresult_step())
                 if not async_task.done():
                     async_task.cancel()
                     break
-            '''
-            task.output_str = task.request_handle.outputs[0].text
-            task.output_tokens = task.request_handle.outputs[0].token_ids
-            task.cumulative_logprob = task.request_handle.outputs[
-                0].cumulative_logprob
-            task.logprobs = task.request_handle.outputs[0].logprobs
-            '''
+
             if task.request_handle._done:
                 task.end_flag = True
 

--- a/tensorrt_llm/scaffolding/worker.py
+++ b/tensorrt_llm/scaffolding/worker.py
@@ -1,15 +1,16 @@
+import asyncio
 from abc import ABC
-from typing import Callable
+from typing import Callable, Optional
 
 import openai
 from transformers import AutoTokenizer
 
 from tensorrt_llm import LLM
 from tensorrt_llm.executor import GenerationExecutor
-from tensorrt_llm.llmapi.llm_args import KvCacheConfig
+from tensorrt_llm.llmapi.llm_args import KvCacheConfig, SchedulerConfig
 from tensorrt_llm.sampling_params import SamplingParams
 
-from .task import GenerationTask, Task, TaskStatus
+from .task import GenerationTask, StreamGenerationTask, Task, TaskStatus
 
 ExecutorCls = GenerationExecutor
 
@@ -150,6 +151,7 @@ class TRTLLMWorker(Worker):
         max_num_tokens: int = 4096,
         kv_cache_free_gpu_memory_fraction: float = 0.9,
         disable_overlap_scheduler: bool = False,
+        scheduler_config: Optional[SchedulerConfig] = None,
     ):
         kv_cache_config = KvCacheConfig(
             free_gpu_memory_fraction=kv_cache_free_gpu_memory_fraction, )
@@ -168,7 +170,8 @@ class TRTLLMWorker(Worker):
                   disable_overlap_scheduler=disable_overlap_scheduler,
                   kv_cache_config=kv_cache_config,
                   max_batch_size=max_batch_size,
-                  max_num_tokens=max_num_tokens)
+                  max_num_tokens=max_num_tokens,
+                  scheduler_config=scheduler_config)
 
         worker = cls(llm, tokenizer)
         worker.own_llm = True
@@ -201,8 +204,49 @@ class TRTLLMWorker(Worker):
         # TODO: error handle
         return TaskStatus.SUCCESS
 
+    async def stream_generation_handler(
+            self, task: StreamGenerationTask) -> TaskStatus:
+
+        async def get_step_or_more_tokens(task: StreamGenerationTask):
+            if task.cancel_flag:
+                task.end_flag = True
+                task.request_handle.abort()
+                return TaskStatus.SUCCESS
+
+            for _ in range(task.streaming_step):
+                await task.request_handle._aresult_step()
+                if task.request_handle._done:
+                    break
+            while not task.request_handle._done:
+                async_task = asyncio.create_task(
+                    task.request_handle._aresult_step())
+                if not async_task.done():
+                    async_task.cancel()
+                    break
+            '''
+            task.output_str = task.request_handle.outputs[0].text
+            task.output_tokens = task.request_handle.outputs[0].token_ids
+            task.cumulative_logprob = task.request_handle.outputs[
+                0].cumulative_logprob
+            task.logprobs = task.request_handle.outputs[0].logprobs
+            '''
+            if task.request_handle._done:
+                task.end_flag = True
+
+        if getattr(task, 'end_flag', False):
+            return TaskStatus.SUCCESS
+        if task.request_handle is None:
+            sampling_params = self.convert_task_params(task)
+            task.request_handle = self.llm.generate_async(
+                task.input_str, sampling_params=sampling_params, streaming=True)
+            task._result = task.request_handle
+        await get_step_or_more_tokens(task)
+
     def shutdown(self):
         if self.own_llm:
             self.llm.shutdown()
 
-    task_handlers = {GenerationTask: generation_handler}
+    task_handlers = {
+        GenerationTask: generation_handler,
+        StreamGenerationTask: stream_generation_handler
+    }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added streaming generation with incremental outputs.
  * Public API now includes streaming task support.
  * Optional scheduler configuration available during worker initialization.
* **Refactor**
  * Majority voting now operates on task-based candidates.
  * Adjusted generation result metadata and log-probabilities representation.
* **Bug Fixes**
  * More robust async request creation with graceful fallback and clearer error messages.
  * Improved worker shutdown handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
