### PR TITLE
[none][feat] Support nano-v2-vlm with multiple PRs

### DIFF
--- a/cpp/kernels/fmha_v2/setup.py
+++ b/cpp/kernels/fmha_v2/setup.py
@@ -6379,6 +6379,16 @@ def enumerate_kernels():
                   and kspec.version       == 2
                   and kspec.cross_mha     == False
                   and kspec.flash_attention == False)
+                  # Clip/SigLip support.
+                  or  (kspec.sm           == 100
+                  and kspec.dtype         in ['fp16', 'bf16', 'fp16_fp32', 'e4m3', 'e4m3_fp32']
+                  and kspec.head_size     == 80
+                  and kspec.head_size_v   == 0
+                  and kspec.sage_block_sizes is None
+                  and kspec.version       == 2
+                  and kspec.cross_mha     == False
+                  and kspec.flash_attention == True
+                  and kspec.input_layout != InputLayout.SEPARATE_Q_K_V)
                   # Deepseek MLA (generation 576/512 paged)
                   or (kspec.sm            in [90, 100, 120]
                   and kspec.dtype         in ['bf16', 'e4m3_fp32']

--- a/cpp/tensorrt_llm/kernels/fmhaDispatcher.cpp
+++ b/cpp/tensorrt_llm/kernels/fmhaDispatcher.cpp
@@ -46,7 +46,10 @@ QkvLayout AttentionInputLayoutToQkvLayout(AttentionInputLayout layout)
 
 FmhaDispatcher::FmhaDispatcher(MHARunnerFixedParams fixedParams)
     : mFixedParams(fixedParams)
-    , mUseTllmGen(tensorrt_llm::common::isSM100Family())
+    // TRTLLM-GEN only supports power of 2 head sizes.
+    // The exception will fall back to fmha v2.
+    // Please update fmha_v2/setup.py if you want to add more supported head sizes.
+    , mUseTllmGen(tensorrt_llm::common::isSM100Family() && (fixedParams.headSize & (fixedParams.headSize - 1)) == 0)
 {
     if (mUseTllmGen)
     {

--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -161,13 +161,15 @@ class ModelConfig(Generic[TConfig]):
         """
         Prevent modification of frozen instance attributes.
         However, we allow modification of 'extra_attrs' attributes for torch.compile
-        and 'pretrained_config' attributes for mutimodal models. All the other
-        attributes are frozen.
+        and 'pretrained_config' attributes for mutimodal models.
+        'quant_config' is allowed to be modified to set different quantization for VLM.
+        All the other attributes are frozen.
         This can be bypassed by manually setting '_frozen' to False. The design is
         to discourage modifying the attributes unintentionally.
         """
         if self._frozen:
-            if key not in ('_frozen', 'extra_attrs', 'pretrained_config'):
+            if key not in ('_frozen', 'extra_attrs', 'pretrained_config',
+                           'quant_config'):
                 raise AttributeError(
                     f"Cannot modify ModelConfig.'{key}' - instance is frozen")
         super().__setattr__(key, value)

--- a/tensorrt_llm/_torch/models/modeling_nanov2vlm.py
+++ b/tensorrt_llm/_torch/models/modeling_nanov2vlm.py
@@ -70,7 +70,8 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
         # Construct the vision encoder.
         vision_model_config = copy.deepcopy(model_config)
         vision_model_config.pretrained_config = vision_model_config.pretrained_config.vision_config
-        self.vision_model = RADIOVisionModel(vision_model_config)
+        self.vision_model = RADIOVisionModel(vision_model_config,
+                                             disable_quantization=True)
 
     def load_weights(self, weights):
         # Load mlp1 weights.
@@ -270,12 +271,6 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
             return input_ids[0].to(torch.int32).tolist(), {}
 
         if images is not None:
-            if isinstance(images[0], torch.Tensor):
-                # NanoV2VL can only support PIL images. Convert normalized tensors (0-1) to PIL images (0-255).
-                images = [
-                    Image.fromarray((image.permute(1, 2, 0) * 255).to(
-                        torch.uint8).cpu().numpy()) for image in images
-                ]
             # Processing for multimodal data.
             processed_images = self.processor(images=images,
                                               return_tensors='pt').to(
@@ -304,16 +299,8 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
             # Process videos one by one to get correct processed_query.
             processed_query = ""
             for video_index, video in enumerate(videos):
-                if isinstance(video[0], torch.Tensor):
-                    # NanoV2VL can only support PIL images. Convert normalized tensors (0-1) to PIL images (0-255).
-                    images = [
-                        Image.fromarray((image.permute(1, 2, 0) * 255).to(
-                            torch.uint8).cpu().numpy()) for image in video
-                    ]
-                else:
-                    images = video
                 # Processing for multimodal data.
-                processed_images = self.processor(images=images,
+                processed_images = self.processor(images=video,
                                                   return_tensors='pt').to(
                                                       self.device)
                 num_patches_list.append(processed_images['num_patches'])

--- a/tensorrt_llm/_torch/models/modeling_nanov2vlm.py
+++ b/tensorrt_llm/_torch/models/modeling_nanov2vlm.py
@@ -14,7 +14,7 @@ from tensorrt_llm.inputs.multimodal import MultimodalParams
 from ...inputs import (BaseMultimodalInputProcessor, ExtraProcessedInputs,
                        InputProcessor, MultimodalPlaceholderMetadata,
                        MultimodalPlaceholderPlacement, TextPrompt,
-                       register_input_processor)
+                       compute_retention_mask, register_input_processor)
 from ...logger import logger
 from ...sampling_params import SamplingParams
 from ..attention_backend import AttentionMetadata
@@ -23,6 +23,8 @@ from .modeling_auto import AutoModelForCausalLM
 from .modeling_multimodal_utils import find_input_mm_embeds, fuse_input_embeds
 from .modeling_radio import RADIOVisionModel
 from .modeling_utils import register_auto_model
+
+VIDEO_PRUNING_RATIO = float(os.getenv("TLLM_VIDEO_PRUNING_RATIO", "0"))
 
 
 # Make this a runtime lookup rather than a module-wide constant for easier unit testing.
@@ -48,6 +50,7 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
         self.num_image_token = int((self.image_size // self.patch_size)**2 *
                                    (config.downsample_ratio**2))
         self.downsample_ratio = config.downsample_ratio
+        self.spatial_merge_size = int(self.patch_size / self.downsample_ratio)
         self.ps_version = config.ps_version  # Pixel shuffle version.
 
         # Construct the vision projection.
@@ -118,6 +121,47 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
         vit_embeds = self.mlp1(vit_embeds)
         return vit_embeds
 
+    def apply_evs(
+            self, mm_embedding: List[torch.Tensor],
+            multimodal_params: List[MultimodalParams]) -> List[torch.Tensor]:
+        """Apply EVS to the multimodal embedding."""
+        if VIDEO_PRUNING_RATIO <= 0:
+            return mm_embedding
+
+        modality_types = [
+            multimodal_param.multimodal_data['modality_type']
+            for multimodal_param in multimodal_params
+        ]
+        video_size_list = [
+            multimodal_param.multimodal_data['video_size']
+            for multimodal_param in multimodal_params
+        ]
+        mm_embedding_evs = []
+        # Iterate over batch.
+        for modality_type, mm_embed, video_sizes in zip(modality_types,
+                                                        mm_embedding,
+                                                        video_size_list):
+            if modality_type == "video":
+                # Iterate over each video in the batch.
+                start_idx, mm_embed_list = 0, []
+                for video_size in video_sizes:
+                    partial_mm_embed = mm_embed[start_idx:start_idx +
+                                                video_size[0]]
+                    retention_mask = compute_retention_mask(
+                        video_embeds=partial_mm_embed,
+                        video_size=video_size,
+                        spatial_merge_size=self.spatial_merge_size,
+                        q=VIDEO_PRUNING_RATIO,
+                        flatten_output=False,
+                    ).flatten(start_dim=1)
+                    start_idx += video_size[0]
+                    partial_mm_embed = partial_mm_embed[retention_mask]
+                    mm_embed_list.append(partial_mm_embed)
+                mm_embedding_evs.append(torch.cat(mm_embed_list, dim=0))
+            else:
+                mm_embedding_evs.append(mm_embed)
+        return mm_embedding_evs
+
     def forward(self, multimodal_params: List[MultimodalParams]):
         mm_embedding = []
         # Batch data.
@@ -138,6 +182,9 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
         mm_embedding = torch.split(batched_image_embeds,
                                    batched_num_patches,
                                    dim=0)
+
+        mm_embedding = self.apply_evs(mm_embedding, multimodal_params)
+
         mm_embedding = [
             m.reshape(-1, self.llm_hidden_size) for m in mm_embedding
         ]
@@ -270,7 +317,9 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
                                               return_tensors="pt")
             return input_ids[0].to(torch.int32).tolist(), {}
 
+        modality_type = None
         if images is not None:
+            modality_type = "image"
             # Processing for multimodal data.
             processed_images = self.processor(images=images,
                                               return_tensors='pt').to(
@@ -288,9 +337,11 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
                 image_repl = self.img_start_token + self.img_context_token * feature_size + self.img_end_token
                 processed_query += image_repl + part
         elif videos is not None:
+            modality_type = "video"
             num_videos = len(videos)
             num_patches_list = []
             pixel_values_list = []
+            video_size_list = []
             parts = text_prompt.split(self.video_context_token)
             if len(parts) - 1 != num_videos:
                 raise ValueError(
@@ -303,20 +354,36 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
                 processed_images = self.processor(images=video,
                                                   return_tensors='pt').to(
                                                       self.device)
+                t, _, h, w = processed_images['pixel_values'].shape
                 num_patches_list.append(processed_images['num_patches'])
                 pixel_values_list.append(processed_images['pixel_values'])
+                video_size_list.append([t, h, w])
 
                 # Processing the text prompt.
                 processed_query += parts[video_index]
-                for num_patches in processed_images['num_patches']:
+                total_num_patches = sum(processed_images['num_patches'])
+                desired_num_tokens = int(self.num_image_token *
+                                         total_num_patches *
+                                         (1.0 - VIDEO_PRUNING_RATIO))
+                existing_num_tokens = 0
+                for num_patches in processed_images['num_patches'][:-1]:
                     feature_size = num_patches * self.num_image_token
+                    feature_size = int(feature_size *
+                                       (1.0 - VIDEO_PRUNING_RATIO))
+                    existing_num_tokens += feature_size
                     image_repl = self.img_start_token + self.img_context_token * feature_size + self.img_end_token
                     processed_query += image_repl
+                # Special handling for the last patch of image tokens.
+                image_repl = self.img_start_token + self.img_context_token * (
+                    desired_num_tokens -
+                    existing_num_tokens) + self.img_end_token
+                processed_query += image_repl
             processed_query += parts[num_videos]
             processed_images['num_patches'] = torch.tensor(
                 [sum(num_patches) for num_patches in num_patches_list])
             processed_images['pixel_values'] = torch.cat(pixel_values_list,
                                                          dim=0)
+            processed_images['video_size'] = video_size_list
 
         input_ids = self.tokenizer.encode(processed_query,
                                           add_special_tokens=False,
@@ -328,6 +395,9 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
             self.dtype)
         multimodal_data['num_patches'] = processed_images['num_patches'].sum(
             dim=0, keepdim=True)
+        multimodal_data['modality_type'] = modality_type
+        multimodal_data['video_size'] = processed_images[
+            'video_size'] if modality_type == "video" else None
         return input_ids[0].to(torch.int32).tolist(), {
             "multimodal_data": multimodal_data,
         }

--- a/tensorrt_llm/_torch/models/modeling_nanov2vlm.py
+++ b/tensorrt_llm/_torch/models/modeling_nanov2vlm.py
@@ -284,18 +284,18 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
 
         def _find_closest_aspect_ratio(aspect_ratio, target_ratios, width,
                                        height, image_size):
-            best_factor = float('-inf')
+            best_ratio_diff = float("inf")
             best_ratio = (1, 1)
             area = width * height
             for ratio in target_ratios:
                 target_aspect_ratio = ratio[0] / ratio[1]
-                factor_based_on_area_n_ratio = min(
-                    (ratio[0] * ratio[1] * image_size * image_size) / area,
-                    0.6) * min(target_aspect_ratio / aspect_ratio,
-                               aspect_ratio / target_aspect_ratio)
-                if factor_based_on_area_n_ratio > best_factor:
-                    best_factor = factor_based_on_area_n_ratio
+                ratio_diff = abs(aspect_ratio - target_aspect_ratio)
+                if ratio_diff < best_ratio_diff:
+                    best_ratio_diff = ratio_diff
                     best_ratio = ratio
+                elif ratio_diff == best_ratio_diff:
+                    if area > 0.5 * image_size * image_size * ratio[0] * ratio[1]:
+                        best_ratio = ratio
             return best_ratio
 
         def _calculate_targets(

--- a/tensorrt_llm/_torch/models/modeling_nanov2vlm.py
+++ b/tensorrt_llm/_torch/models/modeling_nanov2vlm.py
@@ -14,7 +14,8 @@ from tensorrt_llm.inputs.multimodal import MultimodalParams
 from ...inputs import (BaseMultimodalInputProcessor, ExtraProcessedInputs,
                        InputProcessor, MultimodalPlaceholderMetadata,
                        MultimodalPlaceholderPlacement, TextPrompt,
-                       compute_retention_mask, register_input_processor)
+                       compute_retained_tokens_count, compute_retention_mask,
+                       register_input_processor)
 from ...logger import logger
 from ...sampling_params import SamplingParams
 from ..attention_backend import AttentionMetadata
@@ -26,6 +27,8 @@ from .modeling_radio import RADIOVisionModel
 from .modeling_utils import register_auto_model
 
 VIDEO_PRUNING_RATIO = float(os.getenv("TLLM_VIDEO_PRUNING_RATIO", "0"))
+IMAGE_START_TOKEN_ID = 131073
+IMAGE_END_TOKEN_ID = 131074
 
 
 # Make this a runtime lookup rather than a module-wide constant for easier unit testing.
@@ -53,6 +56,7 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
         self.downsample_ratio = config.downsample_ratio
         self.spatial_merge_size = int(self.patch_size / self.downsample_ratio)
         self.ps_version = config.ps_version  # Pixel shuffle version.
+        self.video_pruning_ratio = VIDEO_PRUNING_RATIO
 
         # Construct the vision projection.
         self.vit_hidden_size = config.vit_hidden_size
@@ -123,11 +127,12 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
         return vit_embeds
 
     def apply_evs(
-            self, mm_embedding: List[torch.Tensor],
-            multimodal_params: List[MultimodalParams]) -> List[torch.Tensor]:
+        self, mm_embedding: List[torch.Tensor],
+        multimodal_params: List[MultimodalParams]
+    ) -> Tuple[List[torch.Tensor], Optional[List[List[int]]]]:
         """Apply EVS to the multimodal embedding."""
-        if VIDEO_PRUNING_RATIO <= 0:
-            return mm_embedding
+        if self.video_pruning_ratio <= 0:
+            return mm_embedding, None
 
         modality_types = [
             multimodal_param.multimodal_data['modality_type']
@@ -138,30 +143,48 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
             for multimodal_param in multimodal_params
         ]
         mm_embedding_evs = []
+        num_tokens_in_videos = []
         # Iterate over batch.
         for modality_type, mm_embed, video_sizes in zip(modality_types,
                                                         mm_embedding,
                                                         video_size_list):
             if modality_type == "video":
                 # Iterate over each video in the batch.
-                start_idx, mm_embed_list = 0, []
+                start_idx, mm_embed_list, num_tokens_per_video = 0, [], []
                 for video_size in video_sizes:
-                    partial_mm_embed = mm_embed[start_idx:start_idx +
-                                                video_size[0]]
-                    retention_mask = compute_retention_mask(
-                        video_embeds=partial_mm_embed,
-                        video_size=video_size,
+                    t, p, ih, iw = video_size
+                    partial_mm_embed = mm_embed[start_idx:start_idx + t * p]
+                    # -> [num_frames * num_patches_per_frame, h*w, hidden_size]
+
+                    # Need to expose temporal dimension for EVS.
+                    _, wh, hidden_size = partial_mm_embed.shape
+                    reshaped_partial_mm_embed = partial_mm_embed.reshape(
+                        t, p, wh, hidden_size).reshape(t, p * wh, hidden_size)
+
+                    # -> [num_frames, num_patches_per_frame*h*w, hidden_size]
+                    original_retention_mask = compute_retention_mask(
+                        video_embeds=reshaped_partial_mm_embed,
+                        video_size=(t, p * ih, iw),
                         spatial_merge_size=self.spatial_merge_size,
-                        q=VIDEO_PRUNING_RATIO,
+                        pruning_ratio=self.video_pruning_ratio,
                         flatten_output=False,
                     ).flatten(start_dim=1)
-                    start_idx += video_size[0]
+                    # -> [num_frames, num_patches_per_frame*h*w]
+                    num_tokens_per_frame = original_retention_mask.sum(dim=1)
+                    retention_mask = original_retention_mask.reshape(
+                        t, p, wh).reshape(t * p, wh)
+                    # -> [num_frames * num_patches_per_frame, h*w]
+                    start_idx += t * p
                     partial_mm_embed = partial_mm_embed[retention_mask]
                     mm_embed_list.append(partial_mm_embed)
+                    num_tokens_per_video.append(num_tokens_per_frame)
                 mm_embedding_evs.append(torch.cat(mm_embed_list, dim=0))
+                num_tokens_in_videos.append(
+                    torch.cat(num_tokens_per_video, dim=0))
             else:
                 mm_embedding_evs.append(mm_embed)
-        return mm_embedding_evs
+        return mm_embedding_evs, num_tokens_in_videos if len(
+            num_tokens_in_videos) > 0 else None
 
     def forward(self, multimodal_params: List[MultimodalParams]):
         mm_embedding = []
@@ -184,13 +207,14 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
                                    batched_num_patches,
                                    dim=0)
 
-        mm_embedding = self.apply_evs(mm_embedding, multimodal_params)
+        mm_embedding, num_tokens_in_videos = self.apply_evs(
+            mm_embedding, multimodal_params)
 
         mm_embedding = [
             m.reshape(-1, self.llm_hidden_size) for m in mm_embedding
         ]
         # -> list of [num_patches*num_image_token, hidden_size]
-        return mm_embedding
+        return mm_embedding, num_tokens_in_videos
 
 
 class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
@@ -207,9 +231,11 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
         self.image_size = model_config.force_image_size
         self.patch_size = model_config.patch_size
         self.downsample_ratio = model_config.downsample_ratio
+        self.spatial_merge_size = int(self.patch_size / self.downsample_ratio)
         self.img_context_token_id = model_config.img_context_token_id
         self.num_image_token = int((self.image_size // self.patch_size)**2 *
                                    (self.downsample_ratio**2))
+        self.video_pruning_ratio = VIDEO_PRUNING_RATIO
 
         self.device = 'cpu'
 
@@ -233,8 +259,7 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
 
     def get_mm_special_token_ids(self) -> torch.Tensor:
         " Return multimodal special token ids for NanoV2VL. "
-        # TODO: Hardcoded for now, need extract from model config later.
-        return torch.tensor([131073, 131074])
+        return torch.tensor([IMAGE_START_TOKEN_ID, IMAGE_END_TOKEN_ID])
 
     def get_mm_token_ids(self):
         return torch.tensor([self.img_context_token_id], dtype=torch.int32)
@@ -302,6 +327,8 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
         if self.processor.use_thumbnail and blocks != 1:
             blocks += 1
         num_image_tokens = self.num_image_token * blocks
+        # Add special tokens.
+        num_image_tokens += len(self.get_mm_special_token_ids())
         return num_image_tokens
 
     def get_num_tokens_per_video(
@@ -313,44 +340,30 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
     ):
         # Use VIDEO_PRUNING_RATIO if not explicitly provided
         if video_pruning_ratio is None:
-            video_pruning_ratio = VIDEO_PRUNING_RATIO
+            video_pruning_ratio = self.video_pruning_ratio
 
         num_frames = len(video)
-
         if video_pruning_ratio > 0:
             num_tokens_per_frame = self.get_num_tokens_per_image(image=video[0],
                                                                  **kwargs)
-            num_tokens_per_frame_list = [num_tokens_per_frame] * num_frames
-
-            # Total patches across all frames
-            total_num_tokens_base = sum(num_tokens_per_frame_list)
-
-            # Calculate total desired tokens after pruning
-            desired_num_tokens = int(total_num_tokens_base *
-                                     (1.0 - video_pruning_ratio))
-
-            # Calculate tokens for each frame except the last
-            existing_num_tokens = 0
-            for i in range(num_frames - 1):
-                feature_size = num_tokens_per_frame_list[i]
-                feature_size = int(feature_size * (1.0 - video_pruning_ratio))
-                existing_num_tokens += feature_size
-
-            # Last frame gets the remaining tokens
-            last_frame_tokens = desired_num_tokens - existing_num_tokens
-            num_total_tokens = existing_num_tokens + last_frame_tokens
-
-            # Add start and end tokens for each frame
-            num_total_tokens += num_frames * 2
+            num_image_tokens_per_frame = num_tokens_per_frame - len(
+                self.get_mm_special_token_ids())
+            blocks = num_image_tokens_per_frame // self.num_image_token
+            video_size = (num_frames, blocks * self.image_size, self.image_size)
+            num_total_tokens = compute_retained_tokens_count(
+                video_size=video_size,
+                spatial_merge_size=self.spatial_merge_size,
+                pruning_ratio=video_pruning_ratio,
+            )
+            # Add special tokens for each frame.
+            num_total_tokens += num_frames * len(
+                self.get_mm_special_token_ids())
         else:
             # No pruning - sum tokens for all frames
             num_total_tokens = sum(
                 self.get_num_tokens_per_image(
                     image=frame, video_pruning_ratio=None, **kwargs)
                 for frame in video)
-            # Add start and end tokens for each frame
-            num_total_tokens += num_frames * 2
-
         return num_total_tokens
 
     @torch.inference_mode()
@@ -406,32 +419,40 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, InputProcessor):
             processed_query = ""
             for video_index, video in enumerate(videos):
                 # Processing for multimodal data.
+                num_frames = len(video)
                 processed_images = self.processor(images=video,
                                                   return_tensors='pt').to(
                                                       self.device)
                 t, _, h, w = processed_images['pixel_values'].shape
                 num_patches_list.append(processed_images['num_patches'])
                 pixel_values_list.append(processed_images['pixel_values'])
-                video_size_list.append([t, h, w])
+                video_size_list.append([num_frames, t // num_frames, h, w])
 
                 # Processing the text prompt.
                 processed_query += parts[video_index]
-                total_num_patches = sum(processed_images['num_patches'])
-                desired_num_tokens = int(self.num_image_token *
-                                         total_num_patches *
-                                         (1.0 - VIDEO_PRUNING_RATIO))
-                existing_num_tokens = 0
-                for num_patches in processed_images['num_patches'][:-1]:
-                    feature_size = num_patches * self.num_image_token
-                    feature_size = int(feature_size *
-                                       (1.0 - VIDEO_PRUNING_RATIO))
-                    existing_num_tokens += feature_size
-                    image_repl = self.img_start_token + self.img_context_token * feature_size + self.img_end_token
-                    processed_query += image_repl
-                # Special handling for the last patch of image tokens.
-                image_repl = self.img_start_token + self.img_context_token * (
-                    desired_num_tokens -
-                    existing_num_tokens) + self.img_end_token
+                if self.video_pruning_ratio > 0:
+                    desired_num_tokens = compute_retained_tokens_count(
+                        video_size=(num_frames, t // num_frames * h, w),
+                        spatial_merge_size=self.spatial_merge_size,
+                        pruning_ratio=self.video_pruning_ratio,
+                    )
+                    # It is dummy tokens and will be adjusted in VisionEncoder after applied EVS.
+                    # We need to know the length of the full input ids ahead, to make Mamba-mixer work.
+                    num_tokens_per_frame = [desired_num_tokens
+                                            ] + [0] * (num_frames - 1)
+                else:
+                    num_tokens_per_frame = [
+                        num_patches * self.num_image_token
+                        for num_patches in processed_images['num_patches']
+                    ]
+
+                # Prepare video prompts.
+                # TODO: add metadata like FPS and frame_index when such metadata is available.
+                image_repl = "This is a video:\n"
+                for idx, num_tokens in enumerate(num_tokens_per_frame):
+                    image_repl += f"Frame {idx + 1}: "
+                    image_repl += self.img_start_token + self.img_context_token * num_tokens + self.img_end_token
+                    image_repl += "\n"
                 processed_query += image_repl
             processed_query += parts[num_videos]
             processed_images['num_patches'] = torch.tensor(
@@ -496,6 +517,7 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         self.vocab_size = llm_model_config.pretrained_config.vocab_size
         self.model_dtype = getattr(config, "torch_dtype", torch.bfloat16)
         self.img_context_token_id = config.img_context_token_id
+        self.video_context_token_id = config.video_context_token_id
         self.post_config()
         self.is_loaded = True
 
@@ -520,6 +542,49 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         self.config = self.llm.config
         self.model_config.pretrained_config = self.llm.config
 
+    def update_input_ids(self, input_ids, num_tokens_in_videos):
+        """Update input_ids in videos if EVS is applied.
+
+        Note: it is not compatible with chunked_prefill for now.
+        """
+        image_start_token_id = IMAGE_START_TOKEN_ID
+        image_end_token_id = IMAGE_END_TOKEN_ID
+
+        # Find the positions of start and end image tokens in input_ids
+        image_start_token_mask = (input_ids == image_start_token_id)
+        image_start_token_indices = torch.nonzero(image_start_token_mask,
+                                                  as_tuple=False).flatten()
+        image_end_token_mask = (input_ids == image_end_token_id)
+        image_end_token_indices = torch.nonzero(image_end_token_mask,
+                                                as_tuple=False).flatten()
+
+        num_tokens_in_videos = torch.cat(num_tokens_in_videos, dim=0)
+        results_ids = input_ids.clone()
+        src_idx = 0
+        target_idx1, target_idx2 = 0, 0
+        for start_idx, end_idx, num_tokens in zip(
+                image_start_token_indices.tolist(),
+                image_end_token_indices.tolist(),
+                num_tokens_in_videos.tolist()):
+            if num_tokens == 0:
+                continue
+            target_idx1 = target_idx2
+            target_idx2 = target_idx1 + start_idx - src_idx
+            results_ids[target_idx1:target_idx2] = input_ids[src_idx:start_idx]
+
+            mm_tokens = torch.tensor([image_start_token_id] +
+                                     [self.img_context_token_id] * num_tokens +
+                                     [image_end_token_id],
+                                     dtype=input_ids.dtype,
+                                     device=input_ids.device)
+            target_idx1 = target_idx2
+            target_idx2 = target_idx2 + num_tokens + 2
+            results_ids[target_idx1:target_idx2] = mm_tokens
+
+            src_idx = end_idx + 1
+        results_ids[src_idx:] = input_ids[src_idx:]
+        return results_ids
+
     @torch.inference_mode()
     def forward(
         self,
@@ -542,7 +607,7 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         mm_embedding = []
         if len(multimodal_params) > 0:
             if not _is_disagg():
-                mm_embedding = get_multimodal_embeddings(
+                mm_embedding, num_tokens_in_videos = get_multimodal_embeddings(
                     encoder_forward_fn=self.vision_encoder.forward,
                     multimodal_params=multimodal_params[:num_context_requests])
             else:
@@ -550,6 +615,11 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
                     "Nano-V2-VLM does not support disaggregated inference yet. Please unset "
                     f"the TLLM_MULTIMODAL_DISAGGREGATED environment variable, or set it to '0'."
                 )
+            # Adjust input_ids in videos if EVS is applied.
+            if num_tokens_in_videos is not None:
+                input_ids = self.update_input_ids(input_ids,
+                                                  num_tokens_in_videos)
+
             mm_embedding = find_input_mm_embeds(
                 mm_embedding, multimodal_params[:num_context_requests])
         input_ids, input_embeds = fuse_input_embeds(

--- a/tensorrt_llm/inputs/__init__.py
+++ b/tensorrt_llm/inputs/__init__.py
@@ -1,4 +1,5 @@
 from .data import PromptInputs, TextPrompt, TokensPrompt, prompt_inputs
+from .evs import compute_retained_tokens_count, compute_retention_mask
 from .multimodal import MultimodalInput
 from .registry import (BaseMultimodalInputProcessor, ExtraProcessedInputs,
                        InputProcessor, MultimodalPlaceholderMetadata,
@@ -48,4 +49,6 @@ __all__ = [
     "load_image",
     "load_video",
     "get_cache_salt_id",
+    "compute_retained_tokens_count",
+    "compute_retention_mask",
 ]

--- a/tensorrt_llm/inputs/evs.py
+++ b/tensorrt_llm/inputs/evs.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+
+import torch
+
+
+def compute_retained_tokens_count(video_size: torch.LongTensor,
+                                  spatial_merge_size: int, q: float) -> int:
+    """
+    Compute the number of retained tokens for a given video.
+    Method ensures that we retain all the tokens from the first frame
+    regardless of the pruning rate.
+
+    Args:
+        video_size: The size of the video in the format of (T, H, W).
+        spatial_merge_size: The size of the spatial merge.
+        q: The pruning rate.
+
+    Returns:
+        The number of retained tokens.
+    """
+    T, H, W = map(int, video_size)
+    min_num_tokens = (H // spatial_merge_size) * (W // spatial_merge_size)
+    evs_num_tokens = int(T * min_num_tokens * (1 - q))
+    return max(min_num_tokens, evs_num_tokens)
+
+
+def compute_retention_mask(
+    video_embeds: torch.Tensor,
+    video_size: torch.LongTensor,
+    spatial_merge_size: int,
+    q: float,
+    flatten_output: bool = True,
+) -> torch.Tensor:
+    """
+    Computes the retention mask for input video embeddings.
+
+    Args:
+        video_embeds (`torch.Tensor`): The input video embeddings
+            of shape `(T * H * W // spatial_merge_size ^ 2, hidden_size)`
+            or shape `(T, H * W // spatial_merge_size ^ 2, hidden_size)`.
+        video_size (`torch.LongTensor` of shape `(3)`):
+            The temporal, height and width of video.
+        spatial_merge_size: Size reduction for rows & cols dimensions.
+        q: (`float`): Pruning rate factor [0,1)
+        flatten_output: (`bool`): Whether to flatten the output mask.
+
+    Returns:
+        `torch.Tensor`: The retention mask for the video embeddings of
+            `(T * H * W // spatial_merge_size ^ 2)` shape.
+    """
+    T, H, W = video_size
+
+    # Use reshape instead of einops to avoid graph breaks
+    video_embeds = video_embeds.reshape(
+        T,
+        H // spatial_merge_size,
+        W // spatial_merge_size,
+        video_embeds.size(-1),
+    )
+
+    # Core EVS
+    similarity = torch.nn.functional.cosine_similarity(video_embeds[1:, ...],
+                                                       video_embeds[:-1, ...],
+                                                       dim=-1)
+    dissimilarity = 1 - similarity
+
+    # Always ensure we include all tokens from the first frame
+    dissimilarity = torch.cat(
+        [255 * torch.ones_like(video_embeds[:1, :, :, 0]), dissimilarity],
+        dim=0)
+
+    dissimilarity_flat = dissimilarity.view(-1)
+    order = torch.argsort(dissimilarity_flat,
+                          dim=-1,
+                          descending=True,
+                          stable=True)
+    retain_num_tokens = compute_retained_tokens_count(video_size,
+                                                      spatial_merge_size, q)
+    topk_indices = order[:retain_num_tokens]
+
+    retention_mask = torch.zeros_like(dissimilarity_flat, dtype=torch.bool)
+    retention_mask[topk_indices] = True
+    retention_mask = retention_mask.reshape(dissimilarity.size())
+
+    mask = retention_mask.view(-1) if flatten_output else retention_mask
+    return mask

--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -642,7 +642,8 @@ def find_mm_token_positions(
     num_mm_tokens: List[int],
     vocab_size: Optional[int] = None,
     mm_token_ids: Optional[torch.Tensor] = None,
-    mm_special_token_ids: Optional[torch.Tensor] = None
+    mm_special_token_ids: Optional[torch.Tensor] = None,
+    kwargs: Optional[Dict[str, Any]] = None,
 ) -> Tuple[List[int], List[int]]:
     """Get starting positions of contiguous multimodal token chunks using known lengths.
 
@@ -707,9 +708,15 @@ def find_mm_token_positions(
 
     # Get positions of all multimodal tokens
     mm_positions = torch.where(mm_mask)[0].tolist()
+    try:
+        images = kwargs["mm_data"]['image']
+        image_sizes = [image.shape for image in images]
+    except Exception as e:
+        image_sizes = None
+
     assert len(mm_positions) == sum(
         num_mm_tokens
-    ), f"Number of multimodal tokens does not match sum of all lengths"
+    ), f"Number of multimodal tokens does not match sum of all lengths: {len(mm_positions)=}, {sum(num_mm_tokens)=}, {kwargs=} PIL {image_sizes=}"
 
     # Use num_mm_tokens to find the starting position of each chunk
     start_positions = []

--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -658,6 +658,7 @@ def find_mm_token_positions(
         num_mm_tokens: List of contiguous chunk lengths for each multimodal item
         vocab_size: Size of the model's vocabulary (used to identify tokens > vocab_size)
         mm_token_ids: Specific token IDs that represent multimodal tokens
+        mm_special_token_ids: Specific token IDs that represent special multimodal tokens
 
     Returns:
         List of starting positions for each contiguous multimodal token
@@ -679,13 +680,25 @@ def find_mm_token_positions(
         elif isinstance(input_ids, np.ndarray):
             input_ids = torch.from_numpy(input_ids)
 
-    # Create mask for multimodal tokens
+    # Create mask for multimodal tokens including special tokens if provided
     if mm_token_ids is None:
         mm_mask = input_ids >= vocab_size
+        if mm_special_token_ids is not None:
+            mm_special_token_ids = mm_special_token_ids.to(
+                device=input_ids.device, dtype=input_ids.dtype)
+            mm_mask = mm_mask | torch.isin(input_ids, mm_special_token_ids)
     else:
+        mm_token_ids = mm_token_ids.to(device=input_ids.device,
+                                       dtype=input_ids.dtype)
         if mm_token_ids.ndim != 1:
             raise ValueError("mm_token_ids must be a 1D tensor")
-        mm_token_ids = torch.unique(mm_token_ids)
+        if mm_special_token_ids is not None:
+            mm_special_token_ids = mm_special_token_ids.to(
+                device=input_ids.device, dtype=input_ids.dtype)
+            mm_token_ids = torch.unique(
+                torch.cat([mm_token_ids, mm_special_token_ids]))
+        else:
+            mm_token_ids = torch.unique(mm_token_ids)
         mm_mask = torch.isin(input_ids, mm_token_ids)
 
     # If no multimodal tokens found, return empty list

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -514,6 +514,10 @@ def create_input_processor_with_hash(
                 vocab_size=vocab_size,
                 mm_token_ids=mm_ids,
                 mm_special_token_ids=mm_special_token_ids,
+                kwargs={
+                    "mm_data": mm_data,
+                    "text_prompt": inputs["prompt"],
+                }
             )
             # Store special token offsets if available
             if len(start_special_token_positions


### PR DESCRIPTION
### PRs
- https://github.com/NVIDIA/TensorRT-LLM/pull/8304 (support fp8/nvfp4 model)
- https://github.com/NVIDIA/TensorRT-LLM/pull/8392 (support B200 runtime)
- https://github.com/NVIDIA/TensorRT-LLM/pull/8024 (support EVS)
- https://github.com/NVIDIA/TensorRT-LLM/pull/8425 (fix get_num_tokens_per_image bug)
- https://github.com/NVIDIA/TensorRT-LLM/pull/8458 (support base64 video input)

### Known issues
- chunked_prefill for video will raise error.
- chunked_prefill + EVS for video will raise error.
- num_frames are fixed as 8 for video input.
- No metadata for video input, so the nano-v2-vlm video prompt is bit different from model training.