### PR TITLE
[TRTLLM-8436][feat] batched sampling and top-k logprobs improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ extend_skip_glob = [
     "tests/unittest/_torch/modeling/test_modeling_pixtral.py",
     "tests/unittest/_torch/models/checkpoints/hf/test_weight_loader.py",
     "tests/unittest/_torch/sampler/test_torch_sampler.py",
+    "tensorrt_llm/_torch/pyexecutor/sampler.py",
+    "tensorrt_llm/_torch/pyexecutor/sampling_utils.py",
 ]
 
 [tool.yapf]
@@ -67,6 +69,8 @@ ignore_patterns = [
     "tests/unittest/_torch/modeling/test_modeling_pixtral.py",
     "tests/unittest/_torch/models/checkpoints/hf/test_weight_loader.py",
     "tests/unittest/_torch/sampler/test_torch_sampler.py",
+    "tensorrt_llm/_torch/pyexecutor/sampler.py",
+    "tensorrt_llm/_torch/pyexecutor/sampling_utils.py",
 ]
 
 [tool.codespell]
@@ -102,6 +106,8 @@ exclude = [
     "tests/unittest/_torch/modeling/test_modeling_mistral.py",
     "tests/unittest/_torch/modeling/test_modeling_pixtral.py",
     "tests/unittest/_torch/models/checkpoints/hf/test_weight_loader.py",
+    "tensorrt_llm/_torch/pyexecutor/sampler.py",
+    "tensorrt_llm/_torch/pyexecutor/sampling_utils.py",
 ]
 
 
@@ -147,6 +153,8 @@ include = [
     "tests/unittest/_torch/modeling/test_modeling_pixtral.py",
     "tests/unittest/_torch/models/checkpoints/hf/test_weight_loader.py",
     "tests/unittest/_torch/sampler/test_torch_sampler.py",
+    "tensorrt_llm/_torch/pyexecutor/sampler.py",
+    "tensorrt_llm/_torch/pyexecutor/sampling_utils.py",
 ]
 exclude = [
     "**3rdparty/**",

--- a/tensorrt_llm/_torch/auto_deploy/shim/demollm.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/demollm.py
@@ -13,7 +13,7 @@ from ....executor.request import GenerationRequest
 from ....executor.result import CompletionOutput, GenerationResult
 from ....inputs.multimodal import MultimodalParams
 from ....sampling_params import SamplingParams
-from ...pyexecutor.sampler import greedy_search_sampling_batch, top_k_sampling_batch
+from ...pyexecutor.sampling_utils import greedy_search_sampling_batch, top_k_sampling_batch
 from ..distributed import common as dist_ad
 from ..utils.logger import ad_logger
 from .ad_executor import ADEngine

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1204,13 +1204,12 @@ class PyExecutor:
 
                 self._kv_connector_terminate_requests()
 
-                if self.enable_iter_perf_stats:
+                if self.enable_iter_perf_stats and sample_state is not None:
                     iter_stats.inflight_batching_stats.num_ctx_tokens = self.model_engine.iter_states[
                         'num_ctx_tokens']
                     self._process_iter_stats(
                         finished_requests, self.active_requests,
-                        BatchState(sample_state=SampleState(
-                            scheduled_requests=scheduled_batch),
+                        BatchState(sample_state=sample_state,
                                    iter_stats=iter_stats,
                                    iter_start_time=iter_start_time))
 

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -1,4 +1,3 @@
-import dataclasses
 import enum
 import sys
 from abc import ABC, abstractmethod
@@ -6,24 +5,35 @@ from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass
 from itertools import repeat
-from typing import Any, List, Literal, Optional, TypeVar, cast
+from typing import Any, Callable, List, Optional, TypeVar, cast
 
 import torch
 import torch.nn.functional as F
 
-from tensorrt_llm._torch.pyexecutor.make_decoding_batch_input_output import \
-    MakeDecodingBatchInputOutput
+from tensorrt_llm._torch.pyexecutor.make_decoding_batch_input_output import (
+    MakeDecodingBatchInputOutput,
+)
 from tensorrt_llm._utils import mpi_disabled, nvtx_range, torch_dtype_to_binding
-from tensorrt_llm.bindings import (CudaStream, DataType, ModelConfig,
-                                   WorldConfig, make_sampling_config)
-from tensorrt_llm.bindings.executor import (DecodingConfig, DecodingMode,
-                                            FinishReason)
+from tensorrt_llm.bindings import (
+    CudaStream,
+    DataType,
+    ModelConfig,
+    WorldConfig,
+    make_sampling_config,
+)
+from tensorrt_llm.bindings.executor import DecodingConfig, DecodingMode, FinishReason
 from tensorrt_llm.bindings.internal.algorithms import CreateNewDecoderRequests
 from tensorrt_llm.bindings.internal.batch_manager import (
-    DecoderInputBuffers, add_new_tokens_to_requests, make_decoding_batch_input)
-from tensorrt_llm.bindings.internal.runtime import (BufferManager, CudaEvent,
-                                                    DecoderState,
-                                                    GptDecoderBatched)
+    DecoderInputBuffers,
+    add_new_tokens_to_requests,
+    make_decoding_batch_input,
+)
+from tensorrt_llm.bindings.internal.runtime import (
+    BufferManager,
+    CudaEvent,
+    DecoderState,
+    GptDecoderBatched,
+)
 from tensorrt_llm.executor.result import Logprob
 from tensorrt_llm.llmapi.llm_args import KvCacheConfig
 from tensorrt_llm.mapping import Mapping
@@ -33,12 +43,26 @@ from ..speculative.spec_tree_manager import SpecTreeManager
 from .finish_reason import FinishedState
 from .llm_request import LlmRequest, LlmRequestState, get_draft_token_length
 from .resource_manager import ResourceManager, ResourceManagerType
+from .sampling_utils import (
+    GREEDY,
+    GenericStrategyKeyType,
+    SimpleGroupedStrategySampler,
+    Strategy,
+    UtilsSamplingParams,
+    get_rejected_indices,
+    resolve_sampling_strategy,
+    sample,
+    sample_rejected,
+    torch_multi_arange,
+)
 from .scheduler import ScheduledRequests
 
 if sys.version_info[:2] >= (3, 12):
     from typing import override
 else:
     from typing_extensions import override
+
+T = TypeVar("T")
 
 
 @dataclass(kw_only=True)
@@ -54,14 +78,13 @@ class SampleStateTensors:
 class SampleState:
     scheduled_requests: ScheduledRequests
 
-    device: SampleStateTensors = None
-    host: SampleStateTensors = None
+    device: Optional[SampleStateTensors] = None
+    host: Optional[SampleStateTensors] = None
 
-    sampler_event: torch.cuda.Event = None
+    sampler_event: Optional[torch.cuda.Event] = None
 
 
 class Sampler(ABC):
-
     SampleState = SampleState
 
     def setup_sampler_step(self, scheduled_requests: ScheduledRequests):
@@ -72,18 +95,20 @@ class Sampler(ABC):
 
     @abstractmethod
     def sample_async(
-            self,
-            scheduled_requests: ScheduledRequests,
-            model_outputs,
-            num_context_logits_prefix_sum: list[int],
-            resource_manager: Optional[ResourceManager] = None) -> SampleState:
+        self,
+        scheduled_requests: ScheduledRequests,
+        model_outputs,
+        num_context_logits_prefix_sum: list[int],
+        resource_manager: Optional[ResourceManager] = None,
+    ) -> SampleState:
         raise NotImplementedError
 
     @abstractmethod
     def update_requests(
-            self,
-            state: SampleState,
-            resource_manager: Optional[ResourceManager] = None) -> None:
+        self,
+        state: SampleState,
+        resource_manager: Optional[ResourceManager] = None,
+    ) -> None:
         raise NotImplementedError
 
     @staticmethod
@@ -109,22 +134,24 @@ class EarlyStopSampler(Sampler):
 
     @override
     def sample_async(
-            self,
-            scheduled_requests: ScheduledRequests,
-            model_outputs,
-            num_context_logits_prefix_sum: list[int],
-            resource_manager: Optional[ResourceManager] = None) -> SampleState:
+        self,
+        scheduled_requests: ScheduledRequests,
+        model_outputs,
+        num_context_logits_prefix_sum: list[int],
+        resource_manager: Optional[ResourceManager] = None,
+    ) -> SampleState:
         host = SampleStateTensors(new_tokens=torch.empty(0))
         return SampleState(scheduled_requests=scheduled_requests, host=host)
 
     @override
     def update_requests(
-            self,
-            state: SampleState,
-            resource_manager: Optional[ResourceManager] = None) -> None:
+        self,
+        state: SampleState,
+        resource_manager: Optional[ResourceManager] = None,
+    ) -> None:
         assert isinstance(state, SampleState)
         scheduled_requests = state.scheduled_requests
-        assert (not scheduled_requests.generation_requests)
+        assert not scheduled_requests.generation_requests
         for idx, request in enumerate(scheduled_requests.context_requests):
             request.state = LlmRequestState.GENERATION_COMPLETE
             # NOTE: This is a hack: set finish reason manually and set the beam 0
@@ -137,7 +164,7 @@ class EarlyStopSampler(Sampler):
 
 @dataclass(kw_only=True)
 class MultimodalResult:
-    mm_embeddings: List[torch.Tensor] = None
+    mm_embeddings: List[torch.Tensor]
 
     def values(self):
         return vars(self).values()
@@ -147,7 +174,7 @@ class MultimodalResult:
 class SampleStateWithMMResult:
     scheduled_requests: ScheduledRequests
 
-    data: MultimodalResult = None
+    data: MultimodalResult
 
 
 class EarlyStopWithMMResult(Sampler):
@@ -161,25 +188,24 @@ class EarlyStopWithMMResult(Sampler):
         scheduled_requests: ScheduledRequests,
         model_outputs,
         num_context_logits_prefix_sum: list[int],
-        resource_manager: Optional[ResourceManager] = None
+        resource_manager: Optional[ResourceManager] = None,
     ) -> SampleStateWithMMResult:
         # from model_outputs to MultimodalResult
-        data = MultimodalResult(mm_embeddings=model_outputs['mm_embeddings'])
-        return SampleStateWithMMResult(scheduled_requests=scheduled_requests,
-                                       data=data)
+        data = MultimodalResult(mm_embeddings=model_outputs["mm_embeddings"])
+        return SampleStateWithMMResult(scheduled_requests=scheduled_requests, data=data)
 
     @override
     def update_requests(
-            self,
-            state: SampleStateWithMMResult,
-            resource_manager: Optional[ResourceManager] = None) -> None:
+        self,
+        state: SampleStateWithMMResult,
+        resource_manager: Optional[ResourceManager] = None,
+    ) -> None:
         # resource_manager will not be used in this function, just for interface consistency.
         assert isinstance(state, SampleStateWithMMResult)
         scheduled_requests = state.scheduled_requests
-        assert (not scheduled_requests.generation_requests)
+        assert not scheduled_requests.generation_requests
         mm_embeddings = state.data.mm_embeddings
-        for request, mm_embedding in zip(scheduled_requests.context_requests,
-                                         mm_embeddings):
+        for request, mm_embedding in zip(scheduled_requests.context_requests, mm_embeddings):
             request.state = LlmRequestState.GENERATION_COMPLETE
             # NOTE: This is a hack: set finish reason manually and set the beam 0
             request.set_finished_reason(FinishReason.LENGTH, 0)
@@ -195,214 +221,23 @@ class EarlyStopWithMMResult(Sampler):
         return False
 
 
-def top_k_sampling_batch(
-    logits,
-    *,
-    top_k: int,
-    temperature: float,
-    generator: Optional[torch.Generator] = None,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    # NB: To be replaced by a more efficient implementation.
-    return top_k_top_p_sampling_batch(
-        logits,
-        top_k=top_k,
-        temperature=temperature,
-        generator=generator,
-        top_p=1,
-    )
-
-
-def top_p_sampling_batch(
-    logits: torch.Tensor,
-    *,
-    top_p: float,
-    temperature: float,
-    generator: Optional[torch.Generator] = None,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    # NB: To be replaced by a more efficient implementation.
-    return top_k_top_p_sampling_batch(
-        logits,
-        top_p=top_p,
-        top_k=logits.size(1),
-        temperature=temperature,
-        generator=generator,
-    )
-
-
-def temperature_sampling_batch(
-    logits: torch.Tensor,
-    *,
-    temperature: float,
-    generator: Optional[torch.Generator] = None,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    # NB: To be replaced by a more efficient implementation.
-    return top_k_top_p_sampling_batch(
-        logits,
-        top_p=1,
-        top_k=logits.size(1),
-        temperature=temperature,
-        generator=generator,
-    )
-
-
-def top_k_top_p_sampling_batch(
-    logits: torch.Tensor,
-    *,
-    top_k: int,
-    top_p: float,
-    temperature: float,
-    generator: Optional[torch.Generator] = None
-) -> tuple[torch.Tensor, torch.Tensor]:
-    logits_dim = logits.dim()
-    assert logits_dim == 2, "logits should be 2D: [batch_size, vocab_size]"
-    assert temperature > 0, "non-greedy sampling requires valid temperature"
-    logits = logits / max(temperature, 1e-5)
-    batch_size, vocab_size = logits.size()
-
-    assert top_k > 1, "non-greedy sampling requires valid top_k"
-    need_top_k = top_k < vocab_size
-    assert top_p > 0, "non-greedy sampling requires valid top_p"
-    need_top_p = top_p < 1
-
-    # top-K: mask out logits not belonging to the top-K for each sample
-    if need_top_k:
-        values, _ = torch.topk(logits, top_k, dim=-1)
-        min_values = values[:, -1].unsqueeze(-1).expand(batch_size, vocab_size)
-
-        # set the logits who is less than first top_k logits to -inf
-        logits = torch.where(logits < min_values,
-                             torch.full_like(logits, float('-inf')), logits)
-
-    # top-p: mask out logits outside the nucleus
-    if need_top_p:
-        sorted_logits, sorted_indices = torch.sort(logits,
-                                                   descending=True,
-                                                   dim=-1)
-
-        # compute cumulative probability distribution of each sample
-        cumulative_probs = torch.cumsum(torch.softmax(sorted_logits, dim=-1),
-                                        dim=-1)
-
-        # get the location of top_p
-        # NB: Currently selecting the smallest index with cumulative_probs > top_p.
-        #     Thus, top_p -> 0 resembles greedy; agreement requires torch.sort(..., stable=True).
-        sorted_indices_to_remove = cumulative_probs > top_p
-        sorted_indices_to_remove[:,
-                                 1:] = sorted_indices_to_remove[:, :-1].clone()
-        sorted_indices_to_remove[:, 0] = 0
-
-        # set the logits to -inf for token indices outside top_p
-        indices_to_remove = sorted_indices_to_remove.scatter(
-            1, sorted_indices, sorted_indices_to_remove)
-        logits = logits.masked_fill(indices_to_remove, float('-inf'))
-
-    # compute probability distribution
-    softmax = torch.softmax(logits, dim=-1)
-
-    # sample from the distribution and generate result of [batch_size, 1]
-    next_tokens = torch.multinomial(softmax, num_samples=1,
-                                    generator=generator).squeeze(-1)
-    return next_tokens, softmax
-
-
-def greedy_search_sampling_batch(
-    logits,
-    *,
-    softmax_indices: Optional[torch.IntTensor] = None
-) -> tuple[torch.Tensor, torch.Tensor]:
-    next_tokens = torch.argmax(logits, dim=-1)
-    index_to_scatter = next_tokens
-    if softmax_indices is not None:
-        logits = logits[softmax_indices]
-        index_to_scatter = next_tokens[softmax_indices]
-    probs = torch.zeros_like(logits)
-    probs.scatter_(dim=-1,
-                   index=index_to_scatter.unsqueeze(-1),
-                   src=torch.ones_like(logits))
-    return next_tokens, probs
-
-
-def get_rejected_indices(draft_probs: torch.Tensor, target_probs: torch.Tensor,
-                         generator: torch.Generator,
-                         draft_tokens: list[int]) -> torch.Tensor:
-    # NB: ModelDrafter._pad_to_max_draft_tokens pads draft_tokens, but
-    #     not draft_probs. Relying on shape of draft_probs here.
-    num_draft_tokens = draft_probs.size(0)
-    draft_tokens = draft_tokens[:num_draft_tokens]
-    # NB: torch.arange is needed to enable "advanced indexing",
-    #   cf. https://numpy.org/devdocs/user/basics.indexing.html#integer-array-indexing
-    token_idx = torch.arange(num_draft_tokens,
-                             dtype=torch.int32,
-                             device=generator.device)
-    draft_tokens_cuda = torch.tensor(draft_tokens,
-                                     dtype=torch.int32,
-                                     pin_memory=True).to(
-                                         device=generator.device,
-                                         non_blocking=True)
-    p = draft_probs[token_idx, draft_tokens_cuda]
-    q = target_probs.squeeze(0)[token_idx, draft_tokens_cuda]
-    accept_probs = torch.minimum(
-        torch.ones((), device=generator.device, dtype=q.dtype), q / p)
-    # Use deterministic random generation for multi-GPU consistency
-    rejected_indices = (torch.rand(accept_probs.shape,
-                                   generator=generator,
-                                   device=accept_probs.device)
-                        > accept_probs).nonzero()
-    return rejected_indices
-
-
-def sample_rejected(draft_probs: torch.Tensor, target_probs: torch.Tensor,
-                    generator: torch.Generator, num_accepted: int):
-
-    last_draft = draft_probs[num_accepted]
-    last_target = target_probs[num_accepted]
-    new = last_target - last_draft
-    new = torch.where(new > 0, new, 0.0)
-
-    new_token = torch.multinomial(new, num_samples=1,
-                                  generator=generator).squeeze(-1)
-    return new_token
-
-
-TemperatureOnly = tuple[Literal["temperature"], float]
-TopK = tuple[Literal["top_k"], int, float]
-TopP = tuple[Literal["top_p"], float, float]
-TopKTopP = tuple[Literal["top_k_top_p"], int, float, float]
-Greedy = tuple[Literal["greedy"], None]
-GREEDY: Greedy = ("greedy", None)
-Strategy = TopK | TopP | Greedy | TopKTopP | TemperatureOnly
-
-T = TypeVar('T')
-
-
 # Due to tensorrt_llm::runtime::SamplingConfig using vectors, params
 # in LlmRequest.sampling_params are either None or single-element lists.
 # This helper method simplifies code using such params.
-def _unwrap_singleton(p: Optional[List[T]]) -> Optional[T]:
+def _unwrap_singleton(p: Optional[list[T]]) -> Optional[T]:
     if p is None:
         return None
-    t, = p
+    (t,) = p
     return t
 
 
-@dataclass(frozen=True, kw_only=True)
-class TorchSamplerSamplingParams:
-    """Subset of tensorrt_llm::runtime::SamplingConfig handled by TorchSampler."""
-    temperature: Optional[float]
-    top_p: Optional[float]
-    top_k: Optional[int]
-
-
-def _request_get_sampling_params(
-        request: LlmRequest) -> TorchSamplerSamplingParams:
+def _request_get_sampling_params(request: LlmRequest) -> UtilsSamplingParams:
     sampling_config = request.sampling_config
-    temperature = _unwrap_singleton(
-        cast(Optional[List[float]], sampling_config.temperature))
-    top_p = _unwrap_singleton(cast(Optional[List[float]],
-                                   sampling_config.top_p))
-    top_k = _unwrap_singleton(cast(Optional[List[int]], sampling_config.top_k))
+    temperature = _unwrap_singleton(cast(Optional[list[float]], sampling_config.temperature))
+    top_p = _unwrap_singleton(cast(Optional[list[float]], sampling_config.top_p))
+    top_k = _unwrap_singleton(cast(Optional[list[int]], sampling_config.top_k))
 
-    return TorchSamplerSamplingParams(
+    return UtilsSamplingParams(
         temperature=temperature,
         top_p=top_p,
         top_k=top_k,
@@ -410,119 +245,46 @@ def _request_get_sampling_params(
 
 
 def _request_strategy(request: LlmRequest, *, vocab_size: int) -> Strategy:
-    # The semantics are specified in the doc-string of SamplingParams
-
     params = _request_get_sampling_params(request)
-    temperature = params.temperature
-    top_p = params.top_p
-    top_k = params.top_k
-
-    if SamplingParams.params_imply_greedy_decoding(
-            temperature=temperature,
-            top_p=top_p,
-            top_k=top_k,
-    ):
-        return GREEDY
-
-    # --- resolving default values
-    # NB: not greedy, hence temperature != 0 if specified
-    temperature = temperature or 1.0
-
-    # NB: not greedy, hence top_p != 0 if specified
-    top_p = top_p or 1.0
-    # NB: not greedy, hence top_k != 1 if specified
-    #     (0 and vocab_size are equivalent)
-    top_k = top_k or vocab_size
-
-    assert top_k > 1, "non-greedy sampling requires valid top_k"
-    need_top_k = top_k < vocab_size
-    assert top_p > 0, "non-greedy sampling requires valid top_p"
-    need_top_p = top_p < 1
-
-    if need_top_p:
-        if need_top_k:
-            return ("top_k_top_p", top_k, top_p, temperature)
-        return ("top_p", top_p, temperature)
-    if need_top_k:
-        return ("top_k", top_k, temperature)
-    return ("temperature", temperature)
+    return resolve_sampling_strategy(params, vocab_size=vocab_size)
 
 
-def _group_requests_by_sampling_strategy(
-        requests: Iterable[LlmRequest],
-        *,
-        pin_memory: bool = False,
-        vocab_size: int) -> dict[Strategy, torch.Tensor]:
+def _group_requests_by_strategy_key(
+    requests: Iterable[LlmRequest],
+    *,
+    strategy_to_key: Callable[[Strategy], GenericStrategyKeyType],
+    pin_memory: bool = False,
+    vocab_size: int,
+) -> dict[tuple[GenericStrategyKeyType, bool], tuple[torch.Tensor, List[Strategy]]]:
     # NB: Client code relies on request indices in returned torch.Tensor being sorted.
-    strategy_dict: dict[Strategy, list[int]] = defaultdict(list)
+    group_dict: dict[tuple[GenericStrategyKeyType, bool], tuple[list[int], list[Strategy]]] = (
+        defaultdict(lambda: ([], []))
+    )
     for req_index, req in enumerate(requests):
-        strategy_dict[_request_strategy(
-            req, vocab_size=vocab_size)].append(req_index)
+        strategy = _request_strategy(req, vocab_size=vocab_size)
+        strategy_key = strategy_to_key(strategy)
+        speculation_needs_probs = req.py_draft_logits is not None and strategy is not GREEDY
+        group_dict_entry = group_dict[(strategy_key, speculation_needs_probs)]
+        group_dict_entry[0].append(req_index)
+        group_dict_entry[1].append(strategy)
     return {
-        strategy: torch.tensor(indices,
-                               pin_memory=pin_memory,
-                               dtype=torch.int32)
-        for strategy, indices in strategy_dict.items()
+        group_key: (
+            torch.tensor(indices, pin_memory=pin_memory, dtype=torch.int32),
+            strategies,
+        )
+        for group_key, (indices, strategies) in group_dict.items()
     }
 
 
-def sample(
-    strategy: Strategy,
-    logits: torch.Tensor,
-    generator: Optional[torch.Generator] = None,
-    *,
-    softmax_indices: Optional[torch.IntTensor] = None,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    filter_softmax = True
-    match strategy:
-        case ("top_k", top_k, temperature):
-            tokens, softmax = top_k_sampling_batch(logits,
-                                                   top_k=top_k,
-                                                   temperature=temperature,
-                                                   generator=generator)
-        case ("top_p", top_p, temperature):
-            tokens, softmax = top_p_sampling_batch(
-                logits,
-                top_p=top_p,
-                generator=generator,
-                temperature=temperature,
-            )
-        case ("top_k_top_p", top_k, top_p, temperature):
-            tokens, softmax = top_k_top_p_sampling_batch(
-                logits,
-                top_k=top_k,
-                top_p=top_p,
-                temperature=temperature,
-                generator=generator,
-            )
-        case ("temperature", temperature):
-            tokens, softmax = temperature_sampling_batch(
-                logits,
-                temperature=temperature,
-                generator=generator,
-            )
-        case ("greedy", None):
-            tokens, softmax = greedy_search_sampling_batch(
-                logits, softmax_indices=softmax_indices)
-            filter_softmax = False
-    if filter_softmax and softmax_indices is not None:
-        softmax = softmax[softmax_indices.to(softmax.device, non_blocking=True)]
-    return tokens, softmax
-
-
-def add_token(request: LlmRequest,
-              new_tokens: list[list[list[int]]],
-              *,
-              beam: int,
-              step: int = 0) -> int:
+def add_token(request: LlmRequest, new_tokens: torch.Tensor, *, beam: int, step: int = 0) -> int:
     seq_slot = request.py_seq_slot
     assert seq_slot is not None
-    new_token = new_tokens[step][seq_slot][beam]
+    new_token = cast(int, new_tokens[step][seq_slot][beam].item())
     request.add_new_token(new_token, beam)
     return new_token
 
 
-def int_tensor(shape: tuple[int, ...], device: str = 'cuda') -> torch.Tensor:
+def int_tensor(shape: tuple[int, ...], device: str = "cuda") -> torch.Tensor:
     return torch.empty(shape, dtype=torch.int, device=device)
 
 
@@ -532,78 +294,11 @@ class _BatchedSamplingResult:
     batch_req_indices: torch.Tensor
     # Next tokens for all requests:
     batch_next_tokens_cuda_int: torch.Tensor
-    # Probs for all requests which need them:
-    batch_softmax_cuda: torch.Tensor
-    # (request, batch_softmax indices), for requests having py_draft_logits / requesting py_target_probs:
-    py_draft_logits_indices: list[tuple[LlmRequest,
-                                        torch.Tensor]] = dataclasses.field(
-                                            default_factory=list)
-
-
-# Inspired by https://github.com/pytorch/pytorch/issues/80577; note also the
-# suggestion to consider torch.nested.
-def torch_multi_arange(ends: torch.Tensor,
-                       *,
-                       starts: Optional[torch.Tensor] = None,
-                       steps: Optional[torch.Tensor] = None) -> torch.Tensor:
-    """Efficiently compute torch.cat([torch.arange(b, e, d) for b, e, d in zip(starts, ends, steps)]).
-
-    Starts, ends, steps need to share dtype and shape. Invalid ranges like range(1, 2, -1) are
-    silently discarded. 'steps' defaults to 1 and 'starts' defaults to 0.
-    """
-    if steps is not None:
-        assert ends.dtype == steps.dtype
-        assert ends.shape == steps.shape
-    if starts is not None:
-        assert ends.dtype == starts.dtype
-        assert ends.shape == starts.shape
-
-    # This algorithm combines torch.repeat_interleaved() and torch.cumsum() to
-    # construct the result.
-    #
-    # 1. Given N ranges (characterized by starts, ends, steps), construct a sequence
-    #    of 2N numbers, in which the non-overlapping pairs of consecutive numbers
-    #    correspond to the ranges. For a given range, the pair (a, b) is chosen such
-    #    that upon torch.cumsum() application 'a' turns the last element of the
-    #    preceding range into the start element for the current range and 'b' is
-    #    simply the step size for the current range.
-    #
-    repeats = ends  # number of elements in each range
-    if starts is not None:
-        repeats = repeats.clone()
-        repeats -= starts
-    if steps is not None:
-        repeats = repeats.div(steps, rounding_mode="trunc")
-    repeats = repeats.clip(0)  # ignore invalid ranges
-    range_ends = repeats - 1  # last element in each range
-    if steps is not None:
-        range_ends *= steps
-    if starts is not None:
-        range_ends += starts
-    prev_range_ends = range_ends.roll(
-        1)  # last element in preceding range (or 0)
-    prev_range_ends[0] = 0
-    ones = torch.tensor(1, dtype=ends.dtype, pin_memory=True).to(
-        device=ends.device, non_blocking=True).broadcast_to(ends.shape)
-    if steps is None:
-        steps = ones
-    jumps = -prev_range_ends  # delta from one range to the next
-    if starts is not None:
-        jumps += starts
-    seq = torch.cat((jumps.unsqueeze(-1), steps.unsqueeze(-1)), dim=1).view(-1)
-    #
-    # 2. Construct output via torch.repeat_interleave() and torch.cumsum()
-    seq_repeats = torch.cat((ones.unsqueeze(-1), (repeats - 1).unsqueeze(-1)),
-                            dim=1).view(-1)
-    seq = seq.repeat_interleave(seq_repeats)
-    seq = seq.cumsum(0)
-    return seq
 
 
 # Helper class for _PackedStepIndexer and _UnpackedStepIndexer, facilitating the
 # selection of memory locations of tokens associated with given sets of requests.
 class _StepIndexTranslator(ABC):
-
     def __init__(
         self,
         *,
@@ -636,13 +331,13 @@ class _StepIndexTranslator(ABC):
 
     @staticmethod
     def calculate_request_offsets(
-            req_num_steps: torch.Tensor,
-            pin_memory: bool = False) -> tuple[torch.Tensor, int]:
+        req_num_steps: torch.Tensor,
+        pin_memory: bool = False,
+    ) -> tuple[torch.Tensor, int]:
         if req_num_steps.numel():
             req_offsets = torch.cumsum(req_num_steps, 0)
             sum_steps = int(req_offsets[-1].item())
-            req_offsets_rolled = torch.empty_like(req_offsets,
-                                                  pin_memory=pin_memory)
+            req_offsets_rolled = torch.empty_like(req_offsets, pin_memory=pin_memory)
             req_offsets_rolled[1:] = req_offsets[:-1]
             req_offsets_rolled[0] = 0
             req_offsets = req_offsets_rolled
@@ -652,23 +347,29 @@ class _StepIndexTranslator(ABC):
         return req_offsets, sum_steps
 
     def _build_index(
-            self, req_offsets: torch.Tensor, num_steps: torch.Tensor,
-            max_steps: int,
-            index_dtype: torch.dtype) -> tuple[torch.Tensor, torch.Tensor]:
-        steps_dim = torch.arange(max_steps,
-                                 device=num_steps.device,
-                                 dtype=index_dtype)
+        self,
+        req_offsets: torch.Tensor,
+        num_steps: torch.Tensor,
+        max_steps: int,
+        index_dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        steps_dim = torch.arange(max_steps, device=num_steps.device, dtype=index_dtype)
         valid_mask = steps_dim.unsqueeze(0) < num_steps.unsqueeze(-1)
-        indices = self._compute_index_map(index_dtype=index_dtype,
-                                          steps_dim=steps_dim,
-                                          req_offsets=req_offsets)
+        indices = self._compute_index_map(
+            index_dtype=index_dtype,
+            steps_dim=steps_dim,
+            req_offsets=req_offsets,
+        )
         # NB: steps_dim and req_offsets may have been overwritten by this point.
         return indices, valid_mask
 
     @abstractmethod
-    def _compute_index_map(self, index_dtype: torch.dtype,
-                           steps_dim: torch.Tensor,
-                           req_offsets: torch.Tensor) -> torch.Tensor:
+    def _compute_index_map(
+        self,
+        index_dtype: torch.dtype,
+        steps_dim: torch.Tensor,
+        req_offsets: torch.Tensor,
+    ) -> torch.Tensor:
         """Compute full tensor index map.
 
         Should return a tensor of shape (len(num_steps), max_steps) containing the linear
@@ -709,7 +410,6 @@ class _StepIndexTranslator(ABC):
 # selection of memory locations of tokens associated with given sets of requests,
 # for memory layouts that can be parametrized via request offsets and step stride.
 class _StridedStepIndexTranslator(_StepIndexTranslator):
-
     def __init__(
         self,
         *,
@@ -737,15 +437,20 @@ class _StridedStepIndexTranslator(_StepIndexTranslator):
                          e.g., "step major" indexing into rectangular tensors.
         """
         self._step_stride = step_stride
-        super().__init__(num_steps=num_steps,
-                         req_offsets=req_offsets,
-                         max_steps=max_steps,
-                         index_dtype=index_dtype)
+        super().__init__(
+            num_steps=num_steps,
+            req_offsets=req_offsets,
+            max_steps=max_steps,
+            index_dtype=index_dtype,
+        )
 
     @override
-    def _compute_index_map(self, index_dtype: torch.dtype,
-                           steps_dim: torch.Tensor,
-                           req_offsets: torch.Tensor) -> torch.Tensor:
+    def _compute_index_map(
+        self,
+        index_dtype: torch.dtype,
+        steps_dim: torch.Tensor,
+        req_offsets: torch.Tensor,
+    ) -> torch.Tensor:
         if self._step_stride is not None:
             steps_dim *= self._step_stride  # in-place OK
         return req_offsets.unsqueeze(-1) + steps_dim.unsqueeze(0)
@@ -761,7 +466,6 @@ class _StridedStepIndexTranslator(_StepIndexTranslator):
 #
 # NB: Consider switching to torch.nested (cf. https://github.com/pytorch/pytorch/issues/80577)
 class _PackedStepIndexer(_StridedStepIndexTranslator):
-
     def __init__(
         self,
         *,
@@ -780,10 +484,12 @@ class _PackedStepIndexer(_StridedStepIndexTranslator):
             max_steps (int): The largest value allowed to occur in num_steps.
                              If not provided, it is computed from 'num_steps'.
         """
-        super().__init__(num_steps=num_steps,
-                         req_offsets=req_offsets,
-                         max_steps=max_steps,
-                         index_dtype=index_dtype)
+        super().__init__(
+            num_steps=num_steps,
+            req_offsets=req_offsets,
+            max_steps=max_steps,
+            index_dtype=index_dtype,
+        )
 
 
 # After gathering results with _PackedStepIndexer in TorchSampler._sample_batched_by_strategy,
@@ -793,7 +499,6 @@ class _PackedStepIndexer(_StridedStepIndexTranslator):
 #
 # NB: Consider switching to torch.nested (cf. https://github.com/pytorch/pytorch/issues/80577)
 class _UnpackedStepIndexer(_StridedStepIndexTranslator):
-
     class DimOrder(enum.Enum):
         SLOT_MAJOR = enum.auto()
         STEP_MAJOR = enum.auto()
@@ -868,11 +573,12 @@ class TorchSampler(Sampler):
     def __init__(self, args: Args):
         self.max_seq_len = args.max_seq_len
         self.max_tokens = args.max_draft_len + 1
-        assert args.max_beam_width == self.MAX_BEAM_WIDTH, "TorchSampler only supports beam_width = 1"
+        assert args.max_beam_width == self.MAX_BEAM_WIDTH, (
+            "TorchSampler only supports beam_width = 1"
+        )
         self.max_num_sequences = args.max_num_sequences
 
-        self.NEW_TOKENS_SHAPE = (self.max_tokens, self.max_num_sequences,
-                                 self.MAX_BEAM_WIDTH)
+        self.NEW_TOKENS_SHAPE = (self.max_tokens, self.max_num_sequences, self.MAX_BEAM_WIDTH)
         # AutoDeploy build creates the sampler in inference mode,
         # which would disallow in-place mutating of new_tokens.
         # So, we temporarily exit inference mode.
@@ -899,30 +605,28 @@ class TorchSampler(Sampler):
         assert self._generator.device == device
         return self._generator
 
-    def get_spec_tree_manager(
-            self,
-            resource_manager: ResourceManager) -> Optional[SpecTreeManager]:
+    def get_spec_tree_manager(self, resource_manager: ResourceManager) -> Optional[SpecTreeManager]:
         if resource_manager is None:
             return None
         spec_resource_manager = resource_manager.get_resource_manager(
-            ResourceManagerType.SPEC_RESOURCE_MANAGER)
-        if spec_resource_manager is None or not hasattr(spec_resource_manager,
-                                                        "spec_tree_manager"):
+            ResourceManagerType.SPEC_RESOURCE_MANAGER
+        )
+        if spec_resource_manager is None or not hasattr(spec_resource_manager, "spec_tree_manager"):
             return None
         return spec_resource_manager.spec_tree_manager
 
     def _meet_max_token_stop_criteria(self, request: LlmRequest):
         num_tokens = request.get_num_tokens(self.BEAM)
-        return (num_tokens - request.py_orig_prompt_len
-                >= request.py_max_new_tokens) or (num_tokens
-                                                  >= self.max_seq_len)
+        return (num_tokens - request.py_orig_prompt_len >= request.py_max_new_tokens) or (
+            num_tokens >= self.max_seq_len
+        )
 
     @staticmethod
     def _meet_stop_token_criteria(request: LlmRequest):
         if request.py_stop_words_list:
-            assert isinstance(
-                request.py_stop_words_list,
-                list), "request.py_stop_words_list should be a list"
+            assert isinstance(request.py_stop_words_list, list), (
+                "request.py_stop_words_list should be a list"
+            )
             stop_words_list, prefix_sum = request.py_stop_words_list
             tokens = request.get_tokens(0)
             offset = 0
@@ -932,12 +636,11 @@ class TorchSampler(Sampler):
                 stop_word = stop_words_list[offset:offset_end]
                 if len(stop_word) > len(tokens):
                     continue
-                if tokens[-len(stop_word):] == stop_word:
+                if tokens[-len(stop_word) :] == stop_word:
                     return True
         return False
 
-    def _handle_stop_criteria(self, request: LlmRequest,
-                              new_token: int) -> bool:
+    def _handle_stop_criteria(self, request: LlmRequest, new_token: int) -> bool:
         """Handle stop criteria and set appropriate finish reasons and state.
         Returns True if generation should stop."""
         if new_token == request.py_end_id:
@@ -954,25 +657,37 @@ class TorchSampler(Sampler):
 
         return False
 
-    def handle_logprobs(self, request: LlmRequest, state: SampleState, *,
-                        beam: int, count: int):
-        current_slice = slice(0, count), request.py_seq_slot, beam
+    def handle_logprobs(
+        self,
+        request: LlmRequest,
+        state: SampleState,
+        *,
+        beam: int,
+        count: int,
+    ):
         if request.py_return_log_probs:
             topk_log_probs_vals = request.py_topk_logprobs_vals[:count]
             topk_log_probs_indices = request.py_topk_logprobs_indices[:count]
 
-            token_log_probs = [{
-                token: Logprob(logprob=logprob, rank=rank + 1)
-                for rank, (token, logprob) in enumerate(
-                    zip(topk_token.tolist(), topk_logprob.tolist()))
-            }
-                               for topk_token, topk_logprob in zip(
-                                   topk_log_probs_indices, topk_log_probs_vals)]
-            assert beam == 0, "The following call relies on beam_width to be 1 - hence the list with a single element"
+            token_log_probs = [
+                {
+                    token: Logprob(logprob=logprob, rank=rank + 1)
+                    for rank, (token, logprob) in enumerate(
+                        zip(topk_token.tolist(), topk_logprob.tolist())
+                    )
+                }
+                for topk_token, topk_logprob in zip(topk_log_probs_indices, topk_log_probs_vals)
+            ]
+            assert beam == 0, (
+                "The following call relies on beam_width to be 1 - hence the list with a single element"
+            )
             request.py_result.append_log_probs([token_log_probs])
 
-    def _process_draft_tokens_greedy(self, request: LlmRequest,
-                                     new_tokens: torch.Tensor) -> int:
+    def _process_draft_tokens_greedy(
+        self,
+        request: LlmRequest,
+        new_tokens: torch.Tensor,
+    ) -> int:
         new_token = add_token(request, new_tokens, beam=self.BEAM)
         stop = self._handle_stop_criteria(request, new_token)
         if stop or get_draft_token_length(request) == 0:
@@ -985,31 +700,39 @@ class TorchSampler(Sampler):
                 break
 
             num_accepted += 1
-            new_token = add_token(request,
-                                  new_tokens,
-                                  beam=self.BEAM,
-                                  step=num_accepted)
+            new_token = add_token(request, new_tokens, beam=self.BEAM, step=num_accepted)
             if self._handle_stop_criteria(request, new_token):
                 break
         return num_accepted
 
-    def _process_draft_tokens_tree(self, request: LlmRequest,
-                                   new_tokens: torch.Tensor,
-                                   spec_tree_manager: SpecTreeManager) -> int:
-        """Tree verification for draft token tree based speculative decoding. This function will only be called for the target model.
+    def _process_draft_tokens_tree(
+        self,
+        request: LlmRequest,
+        new_tokens: torch.Tensor,
+        spec_tree_manager: SpecTreeManager,
+    ) -> int:
+        """Tree verification for draft token tree based speculative decoding.
+
+        This function will only be called for the target model.
+
         Verification logic:
             Find the longest prefix match. Since each node in the tree has a related path,
             we can find the longest match by comparing all the paths.
         Args:
             request: LlmRequest. The request with draft tokens.
-            new_tokens: torch.Tensor. [max_draft_len + 1, max_num_sequences, MAX_BEAM_WIDTH], host buffer. The tokens generated by the target model
+            new_tokens: torch.Tensor. [max_draft_len + 1, max_num_sequences, MAX_BEAM_WIDTH], host buffer.
+                        The tokens generated by the target model
                         The relationship between [max_draft_len + 1] and the draft token tree:
                         If the current node is accepted, what is the NEXT token_id that the target model will generate?
-                        For example, new_tokens[0, req_idx, 1] indicates the NEXT token_id sampled from the root node in the draft token tree if it is accepted.
-                        We know that the root node in the draft token tree is always accepted. Therefore, new_tokens[0, req_idx, 1] indicates the token_id following the root node,
+                        For example, new_tokens[0, req_idx, 1] indicates the NEXT token_id sampled from the root
+                        node in the draft token tree if it is accepted.
+                        We know that the root node in the draft token tree is always accepted. Therefore,
+                        new_tokens[0, req_idx, 1] indicates the token_id following the root node,
                         corresponding to the first layer in the draft token tree (the root node is the 0th layer).
-                        Similarly, new_tokens[1, req_idx, 1] represents the NEXT token_id if the first token in the first layer of the draft tokens tree is accepted.
-            spec_tree_manager: SpecTreeManager. which contains the tree structure and other meta information of the tree.
+                        Similarly, new_tokens[1, req_idx, 1] represents the NEXT token_id if the first token in the
+                        first layer of the draft tokens tree is accepted.
+            spec_tree_manager: SpecTreeManager. which contains the tree structure and other meta information
+                               of the tree.
         """
         # handle the drafter model request
         # For the drafter model, we do not execute the tree verification logic,
@@ -1018,8 +741,7 @@ class TorchSampler(Sampler):
             cur_draft_layer_idx = spec_tree_manager.cur_draft_layer_idx
 
             # TODO: For the last layer of the dynamic tree, we need to resampling all the draft tokens.
-            cur_layer_num_nodes = sum(
-                spec_tree_manager.get_top_k_list(cur_draft_layer_idx))
+            cur_layer_num_nodes = sum(spec_tree_manager.get_top_k_list(cur_draft_layer_idx))
             for i in range(cur_layer_num_nodes):
                 new_token = add_token(request, new_tokens, beam=0, step=i)
             return 0
@@ -1031,31 +753,28 @@ class TorchSampler(Sampler):
             eagle_paths = spec_tree_manager.get_eagle_paths(seq_slot)
 
             all_draft_tokens = request.py_draft_tokens  # [max_total_draft_tokens]
-            all_target_tokens = new_tokens[:, seq_slot, :].squeeze(
-                -1)  # [max_total_draft_tokens]
-            assert all_target_tokens.shape[
-                0] == spec_tree_manager.max_total_draft_tokens + 1
+            all_target_tokens = new_tokens[:, seq_slot, :].squeeze(-1)  # [max_total_draft_tokens]
+            assert all_target_tokens.shape[0] == spec_tree_manager.max_total_draft_tokens + 1
 
             longest_accepted_len = 0
             longest_match_path_idx = -1
 
             for path_idx, path in enumerate(eagle_paths):
-                path_exclude_root = path[
-                    1:] - 1  # [max_draft_len], '[1:]' since the new_tokens does not contain the root node.
+                path_exclude_root = (
+                    path[1:] - 1
+                )  # [max_draft_len], '[1:]' since the new_tokens does not contain the root node.
                 # '-1' is the index shift after exclude the root node.
-                draft_tokens_indices = path_exclude_root[path_exclude_root >=
-                                                         0]  # [max_draft_len]
+                draft_tokens_indices = path_exclude_root[path_exclude_root >= 0]  # [max_draft_len]
                 target_tokens_indices = path[path >= 0]  # [max_draft_len + 1]
 
-                assert len(
-                    draft_tokens_indices) == len(target_tokens_indices) - 1
+                assert len(draft_tokens_indices) == len(target_tokens_indices) - 1
 
                 cur_draft_tokens = all_draft_tokens[draft_tokens_indices]
                 cur_target_tokens = all_target_tokens[target_tokens_indices]
 
                 cur_accepted_len = torch.cumprod(
-                    (cur_draft_tokens == cur_target_tokens[:-1]).int(),
-                    dim=-1).sum()
+                    (cur_draft_tokens == cur_target_tokens[:-1]).int(), dim=-1
+                ).sum()
 
                 # Accepted one more token from the target model.
                 cur_accepted_len += 1
@@ -1072,24 +791,29 @@ class TorchSampler(Sampler):
             else:
                 # Take the longest accepted path as the next new token.
                 num_accepted_draft_tokens = 0
-                for idx in eagle_paths[
-                        longest_match_path_idx][:longest_accepted_len]:
-                    new_token = add_token(request, new_tokens, beam=0, step=idx)
+                for idx in eagle_paths[longest_match_path_idx][:longest_accepted_len]:
+                    new_token = add_token(request, new_tokens, beam=0, step=cast(int, idx.item()))
                     num_accepted_draft_tokens += 1
                     if self._handle_stop_criteria(request, new_token):
                         break
 
                 return num_accepted_draft_tokens - 1
 
-    def _tree_sampling_batch(self, requests: list[LlmRequest],
-                             max_num_sequences: int, seq_slots: torch.Tensor,
-                             model_outputs: dict[str, torch.Tensor],
-                             spec_tree_manager: SpecTreeManager):
-
-        if spec_tree_manager.use_dynamic_tree and draft_layer_id == spec_tree_manager.max_draft_len - 1:
+    def _tree_sampling_batch(
+        self,
+        requests: list[LlmRequest],
+        max_num_sequences: int,
+        seq_slots: torch.Tensor,
+        model_outputs: dict[str, torch.Tensor],
+        spec_tree_manager: SpecTreeManager,
+    ):
+        if (
+            spec_tree_manager.use_dynamic_tree
+            # FIXME: 'draft_layer_id' is undefined
+            and draft_layer_id == spec_tree_manager.max_draft_len - 1  # noqa: F821
+        ):
             # TODO: Re-sample the draft tokens for the last layer.
-            raise NotImplementedError(
-                "Dynamic tree is not fully supported yet.")
+            raise NotImplementedError("Dynamic tree is not fully supported yet.")
 
         raw_logits = model_outputs["logits"]
         num_requests = len(requests)
@@ -1106,7 +830,8 @@ class TorchSampler(Sampler):
         new_draft_tokens_cuda = torch.empty(
             (max_num_sequences, spec_tree_manager.max_total_draft_tokens + 1),
             dtype=torch.int64,
-            device=raw_logits.device)
+            device=raw_logits.device,
+        )
 
         top_k_list_cumsum = torch.cumsum(top_k_list, dim=0)
         # Different nodes have different topK value.
@@ -1118,122 +843,132 @@ class TorchSampler(Sampler):
             indices = torch.topk(logits, k=top_k_list_i, dim=-1).indices
             # 4) Write to the temporary output tensor.
             new_draft_tokens_cuda[
-                seq_slots, top_k_list_cumsum[i] -
-                top_k_list_i:top_k_list_cumsum[i]] = indices[request_index]
+                seq_slots, top_k_list_cumsum[i] - top_k_list_i : top_k_list_cumsum[i]
+            ] = indices[request_index]
 
         # 5) Append eagle3 d2t.
         self._apply_d2t(new_draft_tokens_cuda, model_outputs)
 
         # 6) Copy back to the output tensor.
-        int_new_draft_tokens = new_draft_tokens_cuda.transpose(0, 1).to(
-            torch.int, non_blocking=True).unsqueeze(dim=-1)
+        int_new_draft_tokens = (
+            new_draft_tokens_cuda.transpose(0, 1).to(torch.int, non_blocking=True).unsqueeze(dim=-1)
+        )
 
-        new_draft_tokens_host = int_new_draft_tokens.to("cpu",
-                                                        non_blocking=True)
+        new_draft_tokens_host = int_new_draft_tokens.to("cpu", non_blocking=True)
 
         return new_draft_tokens_host
 
     @torch.inference_mode()
     def _process_draft_tokens_rejection_sampling(
-            self, request: LlmRequest, new_tokens: list[list[list[int]]],
-            new_tokens_tensor: torch.Tensor) -> int:
+        self,
+        request: LlmRequest,
+        new_tokens: torch.Tensor,
+    ) -> int:
         # FIXME: Passing a dummy vocab_size could result in unnecessary
         #        filtering of vocab_size logits, out of vocab_size in
         #        total. The 'sample' below should generally be avoided
         #        by retaining the draft_probs during drafting (TRTLLM-7772).
         draft_sampling_strategy = (
-            "greedy", None
-        ) if request.py_draft_use_greedy_sampling else _request_strategy(
-            request, vocab_size=2**31)
+            ("greedy", None)
+            if request.py_draft_use_greedy_sampling
+            else _request_strategy(request, vocab_size=2**31)
+        )
         generator = self.get_generator(request.py_draft_logits.device)
-        _, draft_probs = sample(draft_sampling_strategy,
-                                request.py_draft_logits,
-                                generator=generator)
+        _, draft_probs = sample(
+            draft_sampling_strategy,
+            request.py_draft_logits,
+            generator=generator,
+        )
         target_probs = request.py_target_probs
         d2t = getattr(request, "d2t", None)
         if d2t is not None:
             vocab_d = draft_probs.shape[-1]
             vocab_t = target_probs.shape[-1]
-            assert d2t.numel(
-            ) == vocab_d, f"d2t size mismatch: {d2t.numel()} != {vocab_d}"
-            assert d2t.device == draft_probs.device, f"d2t device mismatch: {d2t.device} != {draft_probs.device}"
+            assert d2t.numel() == vocab_d, f"d2t size mismatch: {d2t.numel()} != {vocab_d}"
+            assert d2t.device == draft_probs.device, (
+                f"d2t device mismatch: {d2t.device} != {draft_probs.device}"
+            )
             aligned_draft_probs = torch.zeros(
                 (*draft_probs.shape[:-1], vocab_t),
                 device=draft_probs.device,
-                dtype=draft_probs.dtype)
+                dtype=draft_probs.dtype,
+            )
             source_indices = torch.arange(vocab_d, device=draft_probs.device)
             target_indices = (source_indices + d2t) % vocab_t
             aligned_draft_probs[..., target_indices] = draft_probs
             draft_probs = aligned_draft_probs
-        rejected_indices = get_rejected_indices(draft_probs, target_probs,
-                                                generator,
-                                                request.py_draft_tokens)
+        rejected_indices = get_rejected_indices(
+            draft_probs,
+            target_probs,
+            generator,
+            request.py_draft_tokens,
+        )
         sample_last = True
         stop = False
         if rejected_indices.numel() == 0:
             num_initially_accepted = get_draft_token_length(request)
             sample_last = False
         else:
-            num_initially_accepted = rejected_indices[0].item()
+            num_initially_accepted = cast(int, rejected_indices[0].item())
         num_accepted = num_initially_accepted
         for i in range(num_accepted):
             new_token = request.py_draft_tokens[i]
-            new_tokens_tensor[i, request.seq_slot, self.BEAM] = new_token
+            new_tokens[i, request.seq_slot, self.BEAM] = new_token
             request.add_new_token(new_token, self.BEAM)
             stop = self._handle_stop_criteria(request, new_token)
             if stop:
                 num_accepted = i + 1
                 return num_accepted
         if sample_last:
-            new_token = sample_rejected(draft_probs, target_probs, generator,
-                                        num_accepted)
-            new_tokens_tensor[num_accepted, request.seq_slot,
-                              self.BEAM] = new_token
+            new_token = sample_rejected(draft_probs, target_probs, generator, num_accepted)
+            new_tokens[num_accepted, request.seq_slot, self.BEAM] = new_token
             request.add_new_token(new_token, self.BEAM)
         else:
-            new_token = add_token(request,
-                                  new_tokens,
-                                  beam=self.BEAM,
-                                  step=num_accepted)
+            new_token = add_token(request, new_tokens, beam=self.BEAM, step=num_accepted)
         stop = self._handle_stop_criteria(request, new_token)
 
         return num_accepted
 
     def process_draft_tokens(
-            self,
-            request: LlmRequest,
-            new_tokens: list[list[list[int]]],
-            new_tokens_tensor: torch.Tensor,
-            resource_manager: Optional[ResourceManager] = None) -> int:
-        if _request_strategy(request, vocab_size=2**
-                             31) == GREEDY or request.py_draft_logits is None:
+        self,
+        request: LlmRequest,
+        new_tokens: torch.Tensor,
+        resource_manager: Optional[ResourceManager] = None,
+    ) -> int:
+        if (
+            _request_strategy(request, vocab_size=2**31) == GREEDY
+            or request.py_draft_logits is None
+        ):
             spec_tree_manager = self.get_spec_tree_manager(resource_manager)
             if spec_tree_manager is not None:
                 num_accepted = self._process_draft_tokens_tree(
                     request,
                     new_tokens=new_tokens,
-                    spec_tree_manager=spec_tree_manager)
+                    spec_tree_manager=spec_tree_manager,
+                )
             else:
-                num_accepted = self._process_draft_tokens_greedy(
-                    request, new_tokens=new_tokens)
+                num_accepted = self._process_draft_tokens_greedy(request, new_tokens=new_tokens)
             return num_accepted
         else:
-            return self._process_draft_tokens_rejection_sampling(
-                request, new_tokens, new_tokens_tensor)
+            return self._process_draft_tokens_rejection_sampling(request, new_tokens)
 
     @override
     def update_requests(
-            self,
-            state: SampleState,
-            resource_manager: Optional[ResourceManager] = None) -> None:
+        self,
+        state: SampleState,
+        resource_manager: Optional[ResourceManager] = None,
+    ) -> None:
         assert isinstance(state, SampleState)
         if state.sampler_event:
             state.sampler_event.synchronize()
 
-        new_tokens = state.host.new_tokens.tolist()
+        new_tokens = state.host.new_tokens
 
         for req in state.scheduled_requests.context_requests:
-            if req.state == LlmRequestState.GENERATION_COMPLETE or req.context_remaining_length != 0:
+            if (
+                req.state == LlmRequestState.GENERATION_COMPLETE
+                or req.context_remaining_length != 0
+            ):
                 continue
             new_token = add_token(req, new_tokens, beam=self.BEAM)
             self._handle_stop_criteria(req, new_token)
@@ -1244,9 +979,7 @@ class TorchSampler(Sampler):
             if req.state == LlmRequestState.GENERATION_COMPLETE:
                 continue
             processed = 1
-            num_accepted = self.process_draft_tokens(req, new_tokens,
-                                                     state.host.new_tokens,
-                                                     resource_manager)
+            num_accepted = self.process_draft_tokens(req, new_tokens, resource_manager)
             if get_draft_token_length(req) > 0:
                 req.py_num_accepted_draft_tokens = num_accepted
                 req.py_rewind_len = req.py_draft_pages_allocated - num_accepted
@@ -1257,21 +990,18 @@ class TorchSampler(Sampler):
             self.handle_logprobs(req, state, beam=self.BEAM, count=processed)
             req.py_decoding_iter += 1
 
-    def log_probs_host(
-            self,
-            scheduled_requests: ScheduledRequests) -> Optional[torch.Tensor]:
-        """Shape: In lockstep with TRTLLMSampler: https://github.com/NVIDIA/TensorRT-LLM/blob/cea5dd1e3883b18bf50901a7f196f50a9544c28c/cpp/include/tensorrt_llm/runtime/decoderState.h#L103"""
-        return any(req.py_return_log_probs
-                   for req in scheduled_requests.all_requests())
+    def return_log_probs(self, scheduled_requests: ScheduledRequests) -> bool:
+        return any(req.py_return_log_probs for req in scheduled_requests.all_requests())
 
     @override
     @torch.inference_mode()
     def sample_async(
-            self,
-            scheduled_requests: ScheduledRequests,
-            model_outputs: dict[str, torch.Tensor],
-            num_context_logits_prefix_sum: list[int],
-            resource_manager: Optional[ResourceManager] = None) -> SampleState:
+        self,
+        scheduled_requests: ScheduledRequests,
+        model_outputs: dict[str, torch.Tensor],
+        num_context_logits_prefix_sum: list[int],
+        resource_manager: Optional[ResourceManager] = None,
+    ) -> SampleState:
         # NB: The sampler is either called directly by PyExecutor, for the target model,
         #     or by ModelDrafter.prepare_draft_tokens(), for the draft model. In the former
         #     case there are 1 + get_draft_token_length(request) tokens per request. In the
@@ -1280,26 +1010,30 @@ class TorchSampler(Sampler):
 
         requests = scheduled_requests.all_requests()
         new_tokens = self.store.new_tokens
-        log_probs_host = self.log_probs_host(scheduled_requests)
+        return_log_probs = self.return_log_probs(scheduled_requests)
         seq_slots_host = torch.tensor(
             [r.py_seq_slot for r in requests],
             dtype=torch.int64,  # for index_fill_
-            pin_memory=True)
+            pin_memory=True,
+        )
         new_tokens_host = self._process_requests(
             scheduled_requests,
             model_outputs,
             new_tokens,
             num_context_logits_prefix_sum,
             seq_slots=seq_slots_host,
-            log_probs_host=log_probs_host,
-            resource_manager=resource_manager)
+            return_log_probs=return_log_probs,
+            resource_manager=resource_manager,
+        )
 
         sampler_event = torch.cuda.Event()
         sampler_event.record()
-        return SampleState(scheduled_requests=scheduled_requests,
-                           device=SampleStateTensors(new_tokens=new_tokens),
-                           host=SampleStateTensors(new_tokens=new_tokens_host),
-                           sampler_event=sampler_event)
+        return SampleState(
+            scheduled_requests=scheduled_requests,
+            device=SampleStateTensors(new_tokens=new_tokens),
+            host=SampleStateTensors(new_tokens=new_tokens_host),
+            sampler_event=sampler_event,
+        )
 
     @staticmethod
     def _apply_d2t(tokens: torch.Tensor, model_outputs) -> None:
@@ -1340,9 +1074,7 @@ class TorchSampler(Sampler):
         #     Since read-caching is expected to help in typical cases, option (ii) is implemented here.
 
         # Track which logits require logit bias application
-        logits_bias_mask = torch.zeros((logits.size(0), ),
-                                       dtype=torch.bool,
-                                       pin_memory=True)
+        logits_bias_mask = torch.zeros((logits.size(0),), dtype=torch.bool, pin_memory=True)
 
         _next_bias_index = 0
 
@@ -1356,8 +1088,7 @@ class TorchSampler(Sampler):
         #
         # NB: hash(torch.Tensor) is equivalent to id(torch.Tensor), and does not
         #     depend on tensor contents, cf. https://github.com/pytorch/pytorch/issues/2569
-        bias_to_index: dict[torch.Tensor,
-                            int] = defaultdict(provision_bias_index)
+        bias_to_index: dict[torch.Tensor, int] = defaultdict(provision_bias_index)
 
         # Source indices for bias application
         bias_gather_indices: list[int] = []
@@ -1368,7 +1099,7 @@ class TorchSampler(Sampler):
             steps = int(steps.item())
             req_bias = req._py_embedding_bias_1d
             if req_bias is not None:
-                logits_bias_mask[i:(i + steps)] = True
+                logits_bias_mask[i : (i + steps)] = True
                 req_bias_index = bias_to_index[req_bias]
                 bias_gather_indices.extend(repeat(req_bias_index, steps))
 
@@ -1376,23 +1107,18 @@ class TorchSampler(Sampler):
             return
         assert req_bias is not None  # otherwise bias_to_index is empty
 
-        bias_gather_indices_cuda = torch.tensor(bias_gather_indices,
-                                                pin_memory=True,
-                                                dtype=torch.int32).to(
-                                                    logits.device,
-                                                    non_blocking=True)
-        logits_bias_mask_cuda = logits_bias_mask.to(logits.device,
-                                                    non_blocking=True)
-        biases_tensor = torch.empty((len(bias_to_index), *req_bias.shape),
-                                    pin_memory=True)
+        bias_gather_indices_cuda = torch.tensor(
+            bias_gather_indices, pin_memory=True, dtype=torch.int32
+        ).to(logits.device, non_blocking=True)
+        logits_bias_mask_cuda = logits_bias_mask.to(logits.device, non_blocking=True)
+        biases_tensor = torch.empty((len(bias_to_index), *req_bias.shape), pin_memory=True)
         biases_tensor = torch.stack(
             tuple(bias_to_index.keys()),
             out=biases_tensor,
         )
         biases_tensor_cuda = biases_tensor.to(logits.device, non_blocking=True)
 
-        biases_tensor_cuda = torch.index_select(biases_tensor_cuda, 0,
-                                                bias_gather_indices_cuda)
+        biases_tensor_cuda = torch.index_select(biases_tensor_cuda, 0, bias_gather_indices_cuda)
         # NB: Avoiding logits[bias_scatter_indices] += biases_tensor (and torch.Tensor.scatter_add_), because it
         #     is unclear if this allows for repeated indices, cf.
         #         https://docs.pytorch.org/docs/2.8/generated/torch.Tensor.index_put_.html#torch-tensor-index-put
@@ -1407,150 +1133,104 @@ class TorchSampler(Sampler):
         model_outputs: dict[str, torch.Tensor],
         *,
         cuda_device: torch.device,
-        log_probs_host: bool = False,
+        logits_cuda_indexer: _PackedStepIndexer,
         req_num_steps: torch.Tensor,
         req_offsets: torch.Tensor,
-        steps_dim_size: int,
         token_dtype: torch.dtype,
     ) -> _BatchedSamplingResult:
-        if log_probs_host:
-            assert logits_cuda.dim() == 2, "logits should be 2D"
-            logprobs = F.log_softmax(logits_cuda.to("cuda",
-                                                    dtype=torch.float32),
-                                     dim=-1)
-            topk_vals, topk_indices = torch.topk(logprobs,
-                                                 k=max(req.py_num_logprobs
-                                                       for req in requests),
-                                                 dim=-1)
-
-        requests_by_strategy = _group_requests_by_sampling_strategy(
-            requests, pin_memory=True, vocab_size=logits_cuda.size(1))
+        grouped_requests = _group_requests_by_strategy_key(
+            requests,
+            pin_memory=True,
+            vocab_size=logits_cuda.size(1),
+            strategy_to_key=SimpleGroupedStrategySampler.strategy_grouping_key,
+        )
         generator_cuda = self.get_generator(cuda_device)
 
         # NB: Currently, "d2t" is applied to draft tokens, but not to draft logits,
         #     breaking _process_draft_tokens_rejection_sampling.
         needs_d2t = "d2t" in model_outputs
-        if needs_d2t and (len(requests_by_strategy) > 1 or
-                          (requests_by_strategy
-                           and next(iter(requests_by_strategy)) != GREEDY)):
+        if needs_d2t and (
+            len(grouped_requests) > 1
+            or (grouped_requests and next(iter(grouped_requests.values()))[1][0] != GREEDY)
+        ):
             raise ValueError("d2t does not yet support non-greedy sampling")
 
-        # Indexer for accessing tokens in 'logits_cuda', corresponding to the
-        # requests in 'requests'.
-        logits_cuda_indexer = _PackedStepIndexer(
-            num_steps=req_num_steps,
-            max_steps=steps_dim_size,
-            req_offsets=req_offsets,
+        # Tensors for collecting sampling results (in batch ordering)
+        batch_req_indices = torch.empty((len(requests),), dtype=torch.int32)
+        batch_next_tokens_cuda_int = torch.empty(
+            (logits_cuda.size(0),), device=cuda_device, dtype=token_dtype
         )
-
-        batched_results: list[tuple[torch.Tensor, torch.Tensor,
-                                    torch.Tensor]] = []
-        py_draft_logits_indices: list[tuple[LlmRequest, torch.Tensor]] = [
-        ]  # see _BatchedSamplingResult for details
-        softmax_index_offset = 0
-        for strategy, group_req_indices in requests_by_strategy.items():
+        batch_req_idx_offset_start = 0
+        batch_next_tokens_offset_start = 0
+        for (strategy_key, speculation_needs_probs), (
+            group_req_indices,
+            group_strategies,
+        ) in grouped_requests.items():
             # group_req_indices: Indices of 'requests' entries having the same sampling
             # strategy, ordered ascending.
-
-            # Indices of 'group_req_indices' entries corresponding to requests
-            # with draft logits.
-            speculation_group_indices = [
-                grp_idx
-                for grp_idx, glob_req_idx in enumerate(group_req_indices)
-                if requests[glob_req_idx].py_draft_logits is not None
-            ]
-            # To skip softmax computation where it is not needed, track
-            #   softmax_req_indices: Indices of 'requests' entries requesting probs
-            #   softmax_grp_indices: Indices of 'speculation_group_indices' entries requesting probs
-            #   speculation_softmax_indices: Indices of 'softmax_grp_indices' entries corresponding
-            #                                to requests with draft logits.
-            if log_probs_host:
-                softmax_req_indices = group_req_indices
-                softmax_grp_indices = torch.arange(len(group_req_indices),
-                                                   dtype=torch.int32)
-                speculation_softmax_indices = torch.tensor(
-                    speculation_group_indices, dtype=torch.int32)
-                for req_id in group_req_indices:
-                    req = requests[req_id]
-                    req.py_topk_logprobs_vals = topk_vals[
-                        logits_cuda_indexer[req_id], :req.py_num_logprobs].to(
-                            device="cpu", non_blocking=True)
-                    req.py_topk_logprobs_indices = topk_indices[
-                        logits_cuda_indexer[req_id], :req.py_num_logprobs].to(
-                            device="cpu", non_blocking=True)
-            else:
-                speculation_group_indices_tensor = torch.tensor(
-                    speculation_group_indices, dtype=torch.int32)
-                softmax_req_indices = group_req_indices[
-                    speculation_group_indices_tensor]
-                softmax_grp_indices = speculation_group_indices_tensor
-                speculation_softmax_indices = torch.arange(
-                    len(speculation_group_indices), dtype=torch.int32)
+            batch_req_idx_offset_end = batch_req_idx_offset_start + group_req_indices.size(0)
+            batch_req_indices[batch_req_idx_offset_start:batch_req_idx_offset_end] = (
+                group_req_indices
+            )
 
             group_logits_cuda_indices = logits_cuda_indexer[group_req_indices]
             # NB: Assuming that group_req_indices are sorted
-            group_req_1st_index, group_req_last_index = group_req_indices[
-                0], group_req_indices[-1]
-            if group_req_last_index - group_req_1st_index + 1 == len(
-                    group_req_indices):
+            group_req_1st_index, group_req_last_index = group_req_indices[0], group_req_indices[-1]
+            group_logits_cuda_indices_cuda: torch.Tensor | slice
+            logit_indices_for_sampler: Optional[torch.Tensor]
+            if group_req_last_index - group_req_1st_index + 1 == len(group_req_indices):
                 # Avoid data movement if indices are contiguous
-                group_logits_cuda = logits_cuda[
-                    req_offsets[group_req_1st_index]:(
-                        req_offsets[group_req_last_index] +
-                        req_num_steps[group_req_last_index])]
+                group_logits_cuda_indices_cuda = slice(
+                    req_offsets[group_req_1st_index],
+                    req_offsets[group_req_last_index] + req_num_steps[group_req_last_index],
+                )
+                group_logits_cuda = logits_cuda[group_logits_cuda_indices_cuda]
+                logit_indices_for_sampler = None
             else:
                 group_logits_cuda_indices_cuda = group_logits_cuda_indices.to(
-                    device=logits_cuda.device, non_blocking=True)
-                group_logits_cuda = logits_cuda[group_logits_cuda_indices_cuda]
+                    device=logits_cuda.device, non_blocking=True
+                )
+                group_logits_cuda = logits_cuda
+                logit_indices_for_sampler = group_logits_cuda_indices_cuda
 
-            # Indexer for accessing tokens in 'group_logits_cuda' (and 'group_next_tokens_cuda')
-            # corresponding to the requests in 'group_req_indices'.
-            group_logits_cuda_indexer = _PackedStepIndexer(
-                num_steps=req_num_steps[group_req_indices],
-                max_steps=steps_dim_size)
-            softmax_group_indices_cuda = group_logits_cuda_indexer[
-                softmax_grp_indices].to(device=logits_cuda.device,
-                                        non_blocking=True)
-
-            # Indexer for accessing tokens in 'group_softmax_cuda' corresponding to the
-            # requests in 'softmax_req_indices'.
-            if softmax_req_indices is not group_req_indices:
-                group_softmax_cuda_indexer = _PackedStepIndexer(
-                    num_steps=req_num_steps[softmax_req_indices],
-                    max_steps=steps_dim_size)
-            else:
-                group_softmax_cuda_indexer = group_logits_cuda_indexer
-
-            py_draft_logits_indices += [(
-                requests[request_idx],
-                softmax_index_offset + group_softmax_cuda_indexer[softmax_idx],
-            ) for softmax_idx, request_idx in zip(
-                speculation_softmax_indices,
-                softmax_req_indices[speculation_softmax_indices],
-            )]
-
-            group_next_tokens_cuda, group_softmax_cuda = sample(
-                strategy,
-                group_logits_cuda,
-                generator_cuda,
-                softmax_indices=cast(torch.IntTensor,
-                                     softmax_group_indices_cuda),
+            group_strategies_per_step = [  # convert from per-request to per-step
+                strat
+                for strat, steps in zip(group_strategies, req_num_steps[group_req_indices])
+                for _ in range(steps)
+            ]
+            group_next_tokens_cuda, group_softmax_cuda = (
+                SimpleGroupedStrategySampler.sample_grouped_strategies(
+                    strategy_key,
+                    group_strategies_per_step,
+                    group_logits_cuda,
+                    generator=generator_cuda,
+                    return_probs=speculation_needs_probs,
+                    group_logit_indices=logit_indices_for_sampler,
+                )
             )
-            group_next_tokens_cuda_int = group_next_tokens_cuda.to(
-                dtype=token_dtype, non_blocking=True)
-            batched_results.append(
-                (group_req_indices, group_next_tokens_cuda_int,
-                 group_softmax_cuda))
-            softmax_index_offset += group_softmax_cuda.size(0)
-        # Batched sampling results, see _BatchedSamplingResult for details.
-        if len(batched_results) > 1:
-            batch_req_indices = torch.cat([res[0] for res in batched_results])
-            batch_next_tokens_cuda_int = torch.cat(
-                [res[1] for res in batched_results])
-            batch_softmax_cuda = torch.cat([res[2] for res in batched_results])
-        else:
-            (batch_req_indices, batch_next_tokens_cuda_int,
-             batch_softmax_cuda), = batched_results
+            batch_next_tokens_offset_end = (
+                batch_next_tokens_offset_start + group_next_tokens_cuda.size(0)
+            )
+            batch_next_tokens_cuda_int[
+                batch_next_tokens_offset_start:batch_next_tokens_offset_end
+            ].copy_(group_next_tokens_cuda, non_blocking=True)
+
+            # Set LlmRequest.py_target_probs
+            if speculation_needs_probs:
+                assert group_softmax_cuda is not None
+                current_offset = 0
+                for req_idx, steps in zip(
+                    group_req_indices, req_num_steps[group_req_indices].tolist()
+                ):
+                    next_offset = current_offset + steps
+                    # using view avoids copy
+                    requests[req_idx].py_target_probs = group_softmax_cuda[
+                        current_offset:next_offset
+                    ]
+                    current_offset = next_offset
+
+            batch_next_tokens_offset_start = batch_next_tokens_offset_end
+            batch_req_idx_offset_start = batch_req_idx_offset_end
 
         # NB: 'd2t' contains offsets for transforming draft vocab token IDs into
         #     the target vocab. This is used by Eagle3ForCausalLM, whose input domain
@@ -1563,8 +1243,6 @@ class TorchSampler(Sampler):
         return _BatchedSamplingResult(
             batch_req_indices=batch_req_indices,
             batch_next_tokens_cuda_int=batch_next_tokens_cuda_int,
-            batch_softmax_cuda=batch_softmax_cuda,
-            py_draft_logits_indices=py_draft_logits_indices,
         )
 
     def _unbatch_sampling_results(
@@ -1574,19 +1252,15 @@ class TorchSampler(Sampler):
         new_tokens_cuda: torch.Tensor,
         req_num_steps: torch.Tensor,
         seq_slots: torch.Tensor,
-        log_probs_host: bool = False,
     ) -> torch.Tensor:
         beam = self.BEAM
         assert beam == 0, "beam_width != 1 not supported"
 
         batch_req_indices = batched_sampling_result.batch_req_indices
         batch_next_tokens_cuda_int = batched_sampling_result.batch_next_tokens_cuda_int
-        batch_softmax_cuda = batched_sampling_result.batch_softmax_cuda
-        py_draft_logits_indices = batched_sampling_result.py_draft_logits_indices
 
         def _dims_canonically_ordered(t: torch.Tensor) -> bool:
-            return len(t.dim_order(
-                ambiguity_check=[torch.contiguous_format])) == t.ndim
+            return len(t.dim_order(ambiguity_check=[torch.contiguous_format])) == t.ndim
 
         # Assert destination tensor dimensions are canonically ordered ("row"-major); this
         # matters for element ordering in the .view(...).scatter_(...) calls below.
@@ -1606,45 +1280,41 @@ class TorchSampler(Sampler):
 
         # Batch update output tensors
         batch_dest_indices_1d_cuda = batch_destination_cuda_indexer[:].to(
-            new_tokens_cuda.device, non_blocking=True)
-        new_tokens_cuda.view(-1,
-                             *new_tokens_cuda.shape[2:])[:, beam, ...].scatter_(
-                                 0, batch_dest_indices_1d_cuda,
-                                 batch_next_tokens_cuda_int)
+            new_tokens_cuda.device, non_blocking=True
+        )
+        new_tokens_cuda.view(-1, *new_tokens_cuda.shape[2:])[:, beam, ...].scatter_(
+            0, batch_dest_indices_1d_cuda, batch_next_tokens_cuda_int
+        )
         new_tokens_host = new_tokens_cuda.to("cpu", non_blocking=True)
-        # For requests with LlmRequest.py_draft_logits, return py_target_probs
-        for request, batch_softmax_index_cuda in py_draft_logits_indices:
-            request.py_target_probs = batch_softmax_cuda[
-                batch_softmax_index_cuda].clone()
 
         return new_tokens_host
 
     @staticmethod
     @torch.inference_mode()
-    def _apply_min_length_penalty(logits: torch.Tensor,
-                                  requests: list[LlmRequest],
-                                  num_steps: list[int]) -> torch.Tensor:
+    def _apply_min_length_penalty(
+        logits: torch.Tensor,
+        requests: list[LlmRequest],
+        num_steps: list[int],
+    ) -> torch.Tensor:
         """Inplace apply min_length_penalty to logits.
 
-            Args:
-                logits: The logits to apply min length penalty to
-                requests: The requests to apply min length penalty to
-                num_steps: The number of steps per request
+        Args:
+            logits: The logits to apply min length penalty to
+            requests: The requests to apply min length penalty to
+            num_steps: The number of steps per request
 
-            Returns:
-                The logits with min length penalty applied
+        Returns:
+            The logits with min length penalty applied
         """
-        if any(r.py_min_length and r.max_beam_num_tokens < r.py_min_length[0]
-               for r in requests):
+        if any(r.py_min_length and r.max_beam_num_tokens < r.py_min_length[0] for r in requests):
             current_offset = 0
             for index, r in enumerate(requests):
                 if r.py_min_length:
                     for step in range(num_steps[index]):
                         if r.max_beam_num_tokens + step < r.py_min_length[0]:
-                            logits[current_offset + step,
-                                   r.py_end_id] = float('-inf')
+                            logits[current_offset + step, r.py_end_id] = float("-inf")
                         else:
-                            #early exit
+                            # early exit
                             break
                 current_offset += num_steps[index]
         return logits
@@ -1663,45 +1333,45 @@ class TorchSampler(Sampler):
         #
         # NB: Context request logits always precede generation request logits, also
         #     requests == scheduled_requests.context_requests + scheduled_requests.generation_requests
-        if any(r.py_return_context_logits
-               for r in scheduled_requests.context_requests):
-            assert len(num_context_logits_prefix_sum) == len(
-                scheduled_requests.context_requests) + 1
+        if any(r.py_return_context_logits for r in scheduled_requests.context_requests):
+            assert (
+                len(num_context_logits_prefix_sum) == len(scheduled_requests.context_requests) + 1
+            )
             req_num_generation_steps_cuda = req_num_generation_steps.to(
-                raw_logits_cuda.device, non_blocking=True)
+                raw_logits_cuda.device, non_blocking=True
+            )
             context_req_offsets_cuda = torch.tensor(
-                num_context_logits_prefix_sum,
-                dtype=torch.int32,
-                pin_memory=True).to(device=raw_logits_cuda.device,
-                                    non_blocking=True)
+                num_context_logits_prefix_sum, dtype=torch.int32, pin_memory=True
+            ).to(device=raw_logits_cuda.device, non_blocking=True)
 
             # Since the goal is to keep the req_num_steps[i] last tokens for each requests[i],
             # only end-offsets of the token storage locations matter.
             next_context_req_offsets_cuda = context_req_offsets_cuda.roll(
-                -1)  # trailing '0' is overwritten below
+                -1
+            )  # trailing '0' is overwritten below
             # Since logits for generation requests are densely packed, cover them all by a single
             # fictituous entry in 'context_req_offsets_cuda'.
             if scheduled_requests.generation_requests:
-                req_num_steps_fictitious_cuda = req_num_generation_steps_cuda[:(
-                    len(scheduled_requests.context_requests) + 1)].clone()
-                req_num_steps_fictitious_cuda[
-                    -1] = generation_requests_total_steps
+                req_num_steps_fictitious_cuda = req_num_generation_steps_cuda[
+                    : (len(scheduled_requests.context_requests) + 1)
+                ].clone()
+                req_num_steps_fictitious_cuda[-1] = generation_requests_total_steps
                 next_context_req_offsets_cuda[-1] = (
-                    next_context_req_offsets_cuda[-2] +
-                    req_num_steps_fictitious_cuda[-1])
+                    next_context_req_offsets_cuda[-2] + req_num_steps_fictitious_cuda[-1]
+                )
             else:
-                req_num_steps_fictitious_cuda = req_num_generation_steps_cuda[:len(
-                    scheduled_requests.context_requests)]
-                next_context_req_offsets_cuda = next_context_req_offsets_cuda[:
-                                                                              -1]
+                req_num_steps_fictitious_cuda = req_num_generation_steps_cuda[
+                    : len(scheduled_requests.context_requests)
+                ]
+                next_context_req_offsets_cuda = next_context_req_offsets_cuda[:-1]
 
             # Now, the generated tokens for context request i are at indices
-            #    range(next_context_req_offsets_cuda[i] - req_num_steps_fictitious_cuda[i], next_context_req_offsets_cuda[i])
+            #    range(next_context_req_offsets_cuda[i] - req_num_steps_fictitious_cuda[i],
+            #          next_context_req_offsets_cuda[i])
             # And if generation requests are present, those tensors each include a trailing entry selecting
             # all tokens/logits generated by all generation requests.
             indices_to_keep_cuda = torch_multi_arange(
-                starts=(next_context_req_offsets_cuda -
-                        req_num_steps_fictitious_cuda),
+                starts=(next_context_req_offsets_cuda - req_num_steps_fictitious_cuda),
                 ends=next_context_req_offsets_cuda,
             )
 
@@ -1710,15 +1380,16 @@ class TorchSampler(Sampler):
 
     @nvtx_range("_process_requests")
     def _process_requests(
-            self,
-            scheduled_requests: ScheduledRequests,
-            model_outputs: dict[str, torch.Tensor],
-            new_tokens_cuda: torch.Tensor,
-            num_context_logits_prefix_sum: list[int],
-            *,
-            seq_slots: torch.Tensor,
-            log_probs_host: torch.Tensor | None = None,
-            resource_manager: Optional[ResourceManager] = None) -> torch.Tensor:
+        self,
+        scheduled_requests: ScheduledRequests,
+        model_outputs: dict[str, torch.Tensor],
+        new_tokens_cuda: torch.Tensor,
+        num_context_logits_prefix_sum: list[int],
+        *,
+        seq_slots: torch.Tensor,
+        return_log_probs: bool,
+        resource_manager: Optional[ResourceManager] = None,
+    ) -> torch.Tensor:
         seq_slots = seq_slots.to(dtype=torch.int32)  # int32 suffices here
         spec_tree_manager = self.get_spec_tree_manager(resource_manager)
 
@@ -1726,16 +1397,13 @@ class TorchSampler(Sampler):
 
         requests = scheduled_requests.all_requests()
         cuda_device = raw_logits_cuda.device
-        req_num_steps_list = [
-            1 + get_draft_token_length(req) for req in requests
-        ]
-        req_num_steps = torch.tensor(req_num_steps_list,
-                                     dtype=torch.int32,
-                                     pin_memory=True)
+        req_num_steps_list = [1 + get_draft_token_length(req) for req in requests]
+        req_num_steps = torch.tensor(req_num_steps_list, dtype=torch.int32, pin_memory=True)
         # NB: These offsets consider generated tokens _only_ (draft and target, but not context)
         #     and are thus only correct after _select_generated_logits() below.
         req_offsets, sum_steps = _PackedStepIndexer.calculate_request_offsets(
-            req_num_steps, pin_memory=True)
+            req_num_steps, pin_memory=True
+        )
 
         raw_logits_cuda = self._select_generated_logits(
             scheduled_requests,
@@ -1744,22 +1412,22 @@ class TorchSampler(Sampler):
             num_context_logits_prefix_sum=num_context_logits_prefix_sum,
             generation_requests_total_steps=(
                 # NB: requests == scheduled_requests.context_requests + scheduled_requests.generation_requests
-                sum_steps - cast(
-                    int, req_offsets[len(
-                        scheduled_requests.context_requests)].item())
-                if scheduled_requests.generation_requests else 0),
+                sum_steps - cast(int, req_offsets[len(scheduled_requests.context_requests)].item())
+                if scheduled_requests.generation_requests
+                else 0
+            ),
         )
 
         # Handle embedding bias
         logits_cuda = raw_logits_cuda[:sum_steps]
         self._apply_embedding_bias(logits_cuda, requests, req_num_steps)
 
-        logits_cuda = self._apply_min_length_penalty(logits_cuda, requests,
-                                                     req_num_steps_list)
+        logits_cuda = self._apply_min_length_penalty(logits_cuda, requests, req_num_steps_list)
 
         # Fast path for drafter model's tree sampling.
         if spec_tree_manager is not None and logits_cuda.size(0) == len(
-                scheduled_requests.all_requests()):
+            scheduled_requests.all_requests()
+        ):
             new_tokens_host = self._tree_sampling_batch(
                 requests,
                 self.max_num_sequences,
@@ -1769,15 +1437,62 @@ class TorchSampler(Sampler):
             )
             return new_tokens_host
 
+        # Indexer for accessing tokens in 'logits_cuda', corresponding to the
+        # requests in 'requests'.
+        steps_dim_size = new_tokens_cuda.size(0)
+        logits_cuda_indexer = _PackedStepIndexer(
+            num_steps=req_num_steps,
+            max_steps=steps_dim_size,
+            req_offsets=req_offsets,
+        )
+
+        # Handle top-k logprobs. This is done outside the sampling loop,
+        # because the returned logprobs are specified to not reflect temperature scaling,
+        # top-k/top-p masking, etc.
+        if return_log_probs:
+            assert logits_cuda.dim() == 2, "logits should be 2D"
+            logprobs_req_indices = [
+                req_id for req_id, req in enumerate(requests) if req.py_num_logprobs
+            ]
+            logprobs_logit_indices = logits_cuda_indexer[logprobs_req_indices]
+            logprobs_logit_indices_cuda = logprobs_logit_indices.to(
+                device=logits_cuda.device, non_blocking=True
+            )
+            logprobs_cuda = F.log_softmax(
+                logits_cuda[logprobs_logit_indices_cuda].to(dtype=torch.float32, non_blocking=True),
+                dim=-1,
+            )
+            topk_vals_cuda, topk_indices_cuda = torch.topk(
+                logprobs_cuda, k=max(req.py_num_logprobs for req in requests), dim=-1
+            )
+            # Use a single D2H copy to reduce overheads
+            topk_vals = torch.empty_like(topk_vals_cuda, device="cpu", pin_memory=True)
+            topk_indices = torch.empty_like(topk_indices_cuda, device="cpu", pin_memory=True)
+            topk_vals.copy_(topk_vals_cuda, non_blocking=True)
+            topk_indices.copy_(topk_indices_cuda, non_blocking=True)
+            current_offset = 0
+            for req_id, steps in zip(
+                logprobs_req_indices, req_num_steps[logprobs_req_indices].tolist()
+            ):
+                req = requests[req_id]
+                next_offset = current_offset + steps
+                # NB: Assigning views on memory which is being filled asynchronously
+                req.py_topk_logprobs_vals = topk_vals[
+                    current_offset:next_offset, : req.py_num_logprobs
+                ]
+                req.py_topk_logprobs_indices = topk_indices[
+                    current_offset:next_offset, : req.py_num_logprobs
+                ]
+                current_offset = next_offset
+
         # Perform sampling in batches
         batched_sampling_result = self._sample_batched_by_strategy(
             logits_cuda,
             requests,
             model_outputs,
             cuda_device=cuda_device,
-            log_probs_host=log_probs_host,
+            logits_cuda_indexer=logits_cuda_indexer,
             req_offsets=req_offsets,
-            steps_dim_size=new_tokens_cuda.size(0),
             req_num_steps=req_num_steps,
             token_dtype=new_tokens_cuda.dtype,
         )
@@ -1786,7 +1501,6 @@ class TorchSampler(Sampler):
         new_tokens_host = self._unbatch_sampling_results(
             batched_sampling_result,
             new_tokens_cuda=new_tokens_cuda,
-            log_probs_host=log_probs_host,
             req_num_steps=req_num_steps,
             seq_slots=seq_slots,
         )
@@ -1810,7 +1524,6 @@ class TorchSampler(Sampler):
 
 
 class Algorithms:
-
     def defined_algorithms(self):
         return [attr for attr in dir(self) if not attr.startswith("__")]
 
@@ -1832,7 +1545,7 @@ class SampleStateTensorsHostTRTLLM(SampleStateTensors):
 class SampleStateTRTLLM(SampleState):
     finalize_events: dict[str, CudaEvent] | None = None
     """`Optional` to accommodate `_forward_step_inter_pp` which creates a `SampleState` without `finalize_events`"""
-    host: SampleStateTensorsHostTRTLLM
+    host: Optional[SampleStateTensorsHostTRTLLM] = None
 
 
 class TRTLLMSampler(Sampler):
@@ -1856,7 +1569,6 @@ class TRTLLMSampler(Sampler):
         decoding_config: Optional[DecodingConfig] = None,
         kv_cache_config: Optional[KvCacheConfig] = None,
     ):
-
         vocab_size = model.config.vocab_size
         num_hidden_layers = model.config.num_hidden_layers
         hidden_size = model.config.hidden_size
@@ -1865,34 +1577,43 @@ class TRTLLMSampler(Sampler):
         self.model_datatype = torch_dtype_to_binding(model_dtype)
         self.logits_datatype = DataType.FLOAT
         self.decoding_mode = decoding_mode
-        self.decoding_config = decoding_config if decoding_config else DecodingConfig(
-            decoding_mode)
+        self.decoding_config = decoding_config if decoding_config else DecodingConfig(decoding_mode)
         max_attn_window = kv_cache_config.max_attention_window
         self.max_seq_len = max_seq_len
-        self.max_attention_window = max(
-            max_attn_window) if max_attn_window is not None else max_seq_len
+        self.max_attention_window = (
+            max(max_attn_window) if max_attn_window is not None else max_seq_len
+        )
         self.max_batch_size = max_batch_size
         self.max_beam_width = max_beam_width
         self.max_num_sequences = mapping.pp_size * max_batch_size
         self.max_seq_idle_microseconds = 180 * 1000 * 1000
         self.is_trt_overlap = not disable_overlap_scheduler
-        self.num_micro_batches = mapping.pp_size if mapping.pp_size > 1 else (
-            2 if self.is_trt_overlap else 1)
+        self.num_micro_batches = (
+            mapping.pp_size if mapping.pp_size > 1 else (2 if self.is_trt_overlap else 1)
+        )
         self.micro_batch_idx = 0
 
         if mpi_disabled():
-            self.world_config = WorldConfig(mapping.tp_size,
-                                            mapping.pp_size,
-                                            mapping.cp_size,
-                                            rank=mapping.rank,
-                                            gpus_per_node=mapping.gpus_per_node)
+            self.world_config = WorldConfig(
+                mapping.tp_size,
+                mapping.pp_size,
+                mapping.cp_size,
+                rank=mapping.rank,
+                gpus_per_node=mapping.gpus_per_node,
+            )
         else:
-            self.world_config = WorldConfig.mpi(mapping.gpus_per_node,
-                                                mapping.tp_size,
-                                                mapping.pp_size)
-        self.model_config = ModelConfig(vocab_size, num_hidden_layers,
-                                        num_hidden_layers, 0, num_heads,
-                                        hidden_size, self.model_datatype)
+            self.world_config = WorldConfig.mpi(
+                mapping.gpus_per_node, mapping.tp_size, mapping.pp_size
+            )
+        self.model_config = ModelConfig(
+            vocab_size,
+            num_hidden_layers,
+            num_hidden_layers,
+            0,
+            num_heads,
+            hidden_size,
+            self.model_datatype,
+        )
 
         self._initialize_store()
         self._instantiate_algorithms()
@@ -1903,25 +1624,21 @@ class TRTLLMSampler(Sampler):
         buffer_manager = BufferManager(stream=torch_stream)
 
         self.store = {
-            "torch_stream":
-            torch_stream,
-            "cuda_stream":
-            cuda_stream,
-            "buffer_manager":
-            buffer_manager,
+            "torch_stream": torch_stream,
+            "cuda_stream": cuda_stream,
+            "buffer_manager": buffer_manager,
             "decoder_input_buffers": [
-                DecoderInputBuffers(self.max_batch_size,
-                                    self.MAX_DECODING_TOKENS, buffer_manager)
+                DecoderInputBuffers(self.max_batch_size, self.MAX_DECODING_TOKENS, buffer_manager)
                 for _ in range(self.num_micro_batches)
             ],
-            "sequence_lengths_host":
-            torch.empty((
-                self.max_num_sequences,
-                self.max_beam_width,
+            "sequence_lengths_host": torch.empty(
+                (
+                    self.max_num_sequences,
+                    self.max_beam_width,
+                ),
+                dtype=torch.int,
             ),
-                        dtype=torch.int),
-            "decoder_state":
-            DecoderState(),
+            "decoder_state": DecoderState(),
             "decoding_input": [None] * self.num_micro_batches,
         }
 
@@ -1951,33 +1668,43 @@ class TRTLLMSampler(Sampler):
         self.algs.create_new_decoder_requests = CreateNewDecoderRequests(
             speculative_decoding_fast_logits=False,
             is_leader_in_orch_mode=False,
-            is_normalize_log_probs=False)
-        self.algs.make_decoding_batch_input_output = MakeDecodingBatchInputOutput(
+            is_normalize_log_probs=False,
         )
+        self.algs.make_decoding_batch_input_output = MakeDecodingBatchInputOutput()
 
     @torch.inference_mode()
     @nvtx_range("setup_sampler_step")
     def setup_sampler_step(self, requests):
-        batch_slots, sampling_configs, lookahead_prompt, lookahead_algo_configs = self.algs.create_new_decoder_requests(
-            self.model_config, self.world_config, self.decoding_config,
-            requests.context_requests, self.logits_datatype,
-            self.store["decoder_input_buffers"][self.micro_batch_idx],
-            self.store["decoder_state"], self.store["cuda_stream"],
-            self.algs.decoder.decoder_stream, self.max_seq_len,
-            self.beam_width(requests.context_requests))
+        batch_slots, sampling_configs, lookahead_prompt, lookahead_algo_configs = (
+            self.algs.create_new_decoder_requests(
+                self.model_config,
+                self.world_config,
+                self.decoding_config,
+                requests.context_requests,
+                self.logits_datatype,
+                self.store["decoder_input_buffers"][self.micro_batch_idx],
+                self.store["decoder_state"],
+                self.store["cuda_stream"],
+                self.algs.decoder.decoder_stream,
+                self.max_seq_len,
+                self.beam_width(requests.context_requests),
+            )
+        )
 
         local_batch_size = len(batch_slots)
         if local_batch_size > 0:
             sampling_config = make_sampling_config(sampling_configs)
             self.algs.decoder.underlying_decoder().setup(
-                sampling_config, local_batch_size, batch_slots,
+                sampling_config,
+                local_batch_size,
+                batch_slots,
                 self.store["decoder_state"].joint_decoding_output,
-                self.model_config.data_type, lookahead_prompt,
-                lookahead_algo_configs)
+                self.model_config.data_type,
+                lookahead_prompt,
+                lookahead_algo_configs,
+            )
 
-        adp = [
-            r for r in requests.generation_requests if r.is_attention_dp_dummy
-        ]
+        adp = [r for r in requests.generation_requests if r.is_attention_dp_dummy]
         batch_size = len(adp)
         if batch_size == 0:
             return
@@ -1988,15 +1715,13 @@ class TRTLLMSampler(Sampler):
     def get_cache_indirection(self) -> torch.Tensor | None:
         return self.store["decoder_state"].cache_indirection_output
 
-    def _update_cache_indirection_buffer(self,
-                                         scheduled_requests: ScheduledRequests):
+    def _update_cache_indirection_buffer(self, scheduled_requests: ScheduledRequests):
         # Copy cache indirection output to input
         for request in scheduled_requests.generation_requests:
-            self.store["decoder_state"].cache_indirection_input[
-                request.py_seq_slot].copy_(
-                    self.store["decoder_state"].cache_indirection_output[
-                        request.py_seq_slot],
-                    non_blocking=True)
+            self.store["decoder_state"].cache_indirection_input[request.py_seq_slot].copy_(
+                self.store["decoder_state"].cache_indirection_output[request.py_seq_slot],
+                non_blocking=True,
+            )
 
     @torch.inference_mode()
     @nvtx_range("sample_async")
@@ -2006,16 +1731,16 @@ class TRTLLMSampler(Sampler):
         scheduled_requests: ScheduledRequests,
         model_outputs,
         num_context_logits_prefix_sum: list[int],
-        resource_manager: Optional[ResourceManager] = None
+        resource_manager: Optional[ResourceManager] = None,
     ) -> SampleStateTRTLLM:
         batch_size = scheduled_requests.batch_size
         beam_width = self.beam_width(scheduled_requests.all_requests())
-        if (batch_size > 1 and beam_width > 1
-                and any(request.py_return_log_probs
-                        for request in scheduled_requests.all_requests())):
-            raise ValueError(
-                "Beam search is not supported for multiple prompts and logprobs"
-            )
+        if (
+            batch_size > 1
+            and beam_width > 1
+            and any(request.py_return_log_probs for request in scheduled_requests.all_requests())
+        ):
+            raise ValueError("Beam search is not supported for multiple prompts and logprobs")
 
         self.setup_sampler_step(scheduled_requests)
 
@@ -2023,17 +1748,20 @@ class TRTLLMSampler(Sampler):
         if beam_width > 1:
             self._update_cache_indirection_buffer(scheduled_requests)
 
-        self.store["decoding_input"][
-            self.micro_batch_idx] = make_decoding_batch_input(
-                scheduled_requests.context_requests,
-                scheduled_requests.generation_requests, model_outputs["logits"],
-                beam_width, num_context_logits_prefix_sum,
-                self.store["decoder_input_buffers"][self.micro_batch_idx],
-                self.store["decoder_state"], self.store["buffer_manager"])
+        self.store["decoding_input"][self.micro_batch_idx] = make_decoding_batch_input(
+            scheduled_requests.context_requests,
+            scheduled_requests.generation_requests,
+            model_outputs["logits"],
+            beam_width,
+            num_context_logits_prefix_sum,
+            self.store["decoder_input_buffers"][self.micro_batch_idx],
+            self.store["decoder_state"],
+            self.store["buffer_manager"],
+        )
 
         self.algs.decoder.forward_async(
-            self.store["decoder_state"],
-            self.store["decoding_input"][self.micro_batch_idx])
+            self.store["decoder_state"], self.store["decoding_input"][self.micro_batch_idx]
+        )
 
         finalize_events = {}
         gathered_ids = None
@@ -2044,61 +1772,53 @@ class TRTLLMSampler(Sampler):
                 if request.is_context_init_state:
                     continue
                 if finished_sum_device[request.seq_slot] == beam_width:
-                    finalize_events[
-                        request.request_id] = self._finalize_request(
-                            request, False)
+                    finalize_events[request.request_id] = self._finalize_request(request, False)
                 elif request.streaming:
-                    finalize_events[
-                        request.request_id] = self._finalize_request(
-                            request, True)
-            gathered_ids = self.store["decoder_state"].gathered_ids.to(
-                'cpu', non_blocking=True)
-        new_output_tokens = self.store["decoder_state"].all_new_tokens.to(
-            'cpu', non_blocking=True)
-        finished_sum = self.store["decoder_state"].finished_sum.to(
-            'cpu', non_blocking=True)
-        finish_reasons = self.store["decoder_state"].finish_reasons.to(
-            'cpu', non_blocking=True)
-        sequence_lengths = self.store["decoder_state"].sequence_lengths.to(
-            'cpu', non_blocking=True)
+                    finalize_events[request.request_id] = self._finalize_request(request, True)
+            gathered_ids = self.store["decoder_state"].gathered_ids.to("cpu", non_blocking=True)
+        new_output_tokens = self.store["decoder_state"].all_new_tokens.to("cpu", non_blocking=True)
+        finished_sum = self.store["decoder_state"].finished_sum.to("cpu", non_blocking=True)
+        finish_reasons = self.store["decoder_state"].finish_reasons.to("cpu", non_blocking=True)
+        sequence_lengths = self.store["decoder_state"].sequence_lengths.to("cpu", non_blocking=True)
 
         log_probs = None
         cum_log_probs = None
-        if any(request.py_return_log_probs
-               for request in scheduled_requests.all_requests()):
-            log_probs = self.store["decoder_state"].log_probs.to(
-                'cpu', non_blocking=True)
-            cum_log_probs = self.store["decoder_state"].cum_log_probs.to(
-                'cpu', non_blocking=True)
+        if any(request.py_return_log_probs for request in scheduled_requests.all_requests()):
+            log_probs = self.store["decoder_state"].log_probs.to("cpu", non_blocking=True)
+            cum_log_probs = self.store["decoder_state"].cum_log_probs.to("cpu", non_blocking=True)
 
-        device = SampleStateTensors(
-            new_tokens=self.store["decoder_state"].all_new_tokens)
+        device = SampleStateTensors(new_tokens=self.store["decoder_state"].all_new_tokens)
 
-        host = SampleStateTensorsHostTRTLLM(new_tokens=new_output_tokens,
-                                            finished_sum=finished_sum,
-                                            finish_reasons=finish_reasons,
-                                            sequence_lengths=sequence_lengths,
-                                            log_probs=log_probs,
-                                            cum_log_probs=cum_log_probs,
-                                            gathered_ids=gathered_ids)
+        host = SampleStateTensorsHostTRTLLM(
+            new_tokens=new_output_tokens,
+            finished_sum=finished_sum,
+            finish_reasons=finish_reasons,
+            sequence_lengths=sequence_lengths,
+            log_probs=log_probs,
+            cum_log_probs=cum_log_probs,
+            gathered_ids=gathered_ids,
+        )
 
         sampler_event = torch.cuda.Event()
         sampler_event.record()
 
-        self.micro_batch_idx = (self.micro_batch_idx +
-                                1) % self.num_micro_batches
+        self.micro_batch_idx = (self.micro_batch_idx + 1) % self.num_micro_batches
 
-        return SampleStateTRTLLM(scheduled_requests=scheduled_requests,
-                                 device=device,
-                                 host=host,
-                                 sampler_event=sampler_event,
-                                 finalize_events=finalize_events)
+        return SampleStateTRTLLM(
+            scheduled_requests=scheduled_requests,
+            device=device,
+            host=host,
+            sampler_event=sampler_event,
+            finalize_events=finalize_events,
+        )
 
     @torch.inference_mode()
     @override
-    def update_requests(self,
-                        state: SampleStateTRTLLM,
-                        resource_manager: Optional[ResourceManager] = None):
+    def update_requests(
+        self,
+        state: SampleStateTRTLLM,
+        resource_manager: Optional[ResourceManager] = None,
+    ):
         # resource_manager will not be used in this function, just for interface consistency.
         assert isinstance(state, SampleStateTRTLLM)
         if state.scheduled_requests.batch_size == 0:
@@ -2119,31 +1839,27 @@ class TRTLLMSampler(Sampler):
     def update_requests_single_beam_single_step(self, state: SampleStateTRTLLM):
         """Specialization of update_requests for single beam and single step"""
         new_tokens_host = state.host.new_tokens.flatten().tolist()
-        sequence_lengths_host_data = state.host.sequence_lengths.flatten(
-        ).tolist()
+        sequence_lengths_host_data = state.host.sequence_lengths.flatten().tolist()
         finish_reasons = state.host.finish_reasons.flatten().tolist()
-        log_probs_host = state.host.log_probs.tolist(
-        ) if state.host.log_probs is not None else None
-        cum_log_probs_host = state.host.cum_log_probs.tolist(
-        ) if state.host.cum_log_probs is not None else None
+        log_probs_host = state.host.log_probs.tolist() if state.host.log_probs is not None else None
+        cum_log_probs_host = (
+            state.host.cum_log_probs.tolist() if state.host.cum_log_probs is not None else None
+        )
 
         reqs = [
-            r for r in state.scheduled_requests.context_requests
-            if not r.is_context_init_state
+            r for r in state.scheduled_requests.context_requests if not r.is_context_init_state
         ] + [
-            r for r in state.scheduled_requests.generation_requests
+            r
+            for r in state.scheduled_requests.generation_requests
             if not r.is_generation_complete_state
         ]
 
         reqs_with_new_tokens = [
-            r for r in reqs
-            if (sequence_lengths_host_data[r.py_seq_slot] > r.get_num_tokens(0))
+            r for r in reqs if (sequence_lengths_host_data[r.py_seq_slot] > r.get_num_tokens(0))
         ]
 
         # Add new tokens
-        new_tokens = [
-            new_tokens_host[r.py_seq_slot] for r in reqs_with_new_tokens
-        ]
+        new_tokens = [new_tokens_host[r.py_seq_slot] for r in reqs_with_new_tokens]
         add_new_tokens_to_requests(reqs_with_new_tokens, new_tokens, 0)
 
         # Log probs
@@ -2153,12 +1869,16 @@ class TRTLLMSampler(Sampler):
                 seq_len = sequence_lengths_host_data[seq_slot]
                 begin_log_probs_offset = request.prompt_len
                 current_token = seq_len - request.prompt_len - 1
-                log_probs = [{
-                    new_tokens_host[seq_slot]:
-                    Logprob(logprob=log_probs_host[seq_slot][0][
-                        begin_log_probs_offset + current_token],
-                            rank=1)
-                }]
+                log_probs = [
+                    {
+                        new_tokens_host[seq_slot]: Logprob(
+                            logprob=log_probs_host[seq_slot][0][
+                                begin_log_probs_offset + current_token
+                            ],
+                            rank=1,
+                        )
+                    }
+                ]
                 cum_log_probs = [cum_log_probs_host[seq_slot]]
                 request.py_result.append_log_probs([log_probs], cum_log_probs)
 
@@ -2172,25 +1892,26 @@ class TRTLLMSampler(Sampler):
 
     @torch.inference_mode()
     @nvtx_range("update_requests_multiple_beams_or_drafting")
-    def update_requests_multiple_beams_or_drafting(self,
-                                                   state: SampleStateTRTLLM,
-                                                   beam_width: int):
+    def update_requests_multiple_beams_or_drafting(
+        self,
+        state: SampleStateTRTLLM,
+        beam_width: int,
+    ):
         new_tokens_host = state.host.new_tokens
         finished_sum_host = state.host.finished_sum.tolist()
         finish_reasons = state.host.finish_reasons.flatten().tolist()
-        sequence_lengths_host_data = state.host.sequence_lengths.flatten(
-        ).tolist()
-        cum_log_probs_host = state.host.cum_log_probs.tolist(
-        ) if state.host.cum_log_probs is not None else None
-        log_probs_host = state.host.log_probs.tolist(
-        ) if state.host.log_probs is not None else None
+        sequence_lengths_host_data = state.host.sequence_lengths.flatten().tolist()
+        cum_log_probs_host = (
+            state.host.cum_log_probs.tolist() if state.host.cum_log_probs is not None else None
+        )
+        log_probs_host = state.host.log_probs.tolist() if state.host.log_probs is not None else None
         finalize_events = state.finalize_events
 
         reqs = [
-            r for r in state.scheduled_requests.context_requests
-            if not r.is_context_init_state
+            r for r in state.scheduled_requests.context_requests if not r.is_context_init_state
         ] + [
-            r for r in state.scheduled_requests.generation_requests
+            r
+            for r in state.scheduled_requests.generation_requests
             if not r.is_generation_complete_state
         ]
 
@@ -2204,36 +1925,36 @@ class TRTLLMSampler(Sampler):
             cum_log_probs = []
 
             for beam in range(beam_width):
-                seq_len = sequence_lengths_host_data[seq_slot * beam_width +
-                                                     beam]
+                seq_len = sequence_lengths_host_data[seq_slot * beam_width + beam]
                 num_new_tokens[beam] = min(
-                    num_generated_tokens,
-                    seq_len - request.get_num_tokens(beam))
+                    num_generated_tokens, seq_len - request.get_num_tokens(beam)
+                )
 
                 for step in range(num_new_tokens[beam]):
-                    new_token = add_token(request,
-                                          new_tokens_host,
-                                          beam=beam,
-                                          step=step)
+                    new_token = add_token(request, new_tokens_host, beam=beam, step=step)
 
                     if request.py_return_log_probs:
                         assert state.host.log_probs is not None
                         # NOTE: Log probs with drafting has not been tested yet.
-                        begin_log_probs_offset = request.prompt_len if request.sampling_config.beam_width == 1 else 0
-                        current_token = seq_len - request.prompt_len - num_new_tokens[
-                            beam] + step
-                        log_probs[beam].append({
-                            new_token:
-                            Logprob(logprob=log_probs_host[seq_slot][beam][
-                                begin_log_probs_offset + current_token],
-                                    rank=1)
-                        })
+                        begin_log_probs_offset = (
+                            request.prompt_len if request.sampling_config.beam_width == 1 else 0
+                        )
+                        current_token = seq_len - request.prompt_len - num_new_tokens[beam] + step
+                        log_probs[beam].append(
+                            {
+                                new_token: Logprob(
+                                    logprob=log_probs_host[seq_slot][beam][
+                                        begin_log_probs_offset + current_token
+                                    ],
+                                    rank=1,
+                                )
+                            }
+                        )
 
                 if request.py_return_log_probs:
                     cum_log_probs.append(cum_log_probs_host[seq_slot][beam])
 
-                finished_state = FinishedState(
-                    finish_reasons[seq_slot * beam_width + beam])
+                finished_state = FinishedState(finish_reasons[seq_slot * beam_width + beam])
                 if finished_state.is_finished:
                     finish_reason = finished_state.to_finish_reason()
                     request.set_finished_reason(finish_reason, beam)
@@ -2243,8 +1964,8 @@ class TRTLLMSampler(Sampler):
 
             # Set number of tokens predicted per runtime iteration. Will be > 1 for speculative decoding.
             request.update_num_tokens_per_iteration(
-                request.max_beam_num_tokens - current_num_of_tokens,
-                self.model_config)
+                request.max_beam_num_tokens - current_num_of_tokens, self.model_config
+            )
 
             # Increment the decoding iteration counter
             if request.state != LlmRequestState.GENERATION_COMPLETE:
@@ -2256,17 +1977,20 @@ class TRTLLMSampler(Sampler):
             if finalize_events is not None and request.request_id in finalize_events:
                 self._post_process_request(request, state)
 
-    def _finalize_request(self, request: LlmRequest, streaming: bool):
-        """ Finalizes the request. This is necessary for beam search. """
+    def _finalize_request(
+        self,
+        request: LlmRequest,
+        streaming: bool,
+    ):
+        """Finalizes the request. This is necessary for beam search."""
         seq_slot = request.py_seq_slot
-        event = self.algs.decoder.finalize(self.store["decoder_state"],
-                                           seq_slot, request.sampling_config,
-                                           streaming)
+        event = self.algs.decoder.finalize(
+            self.store["decoder_state"], seq_slot, request.sampling_config, streaming
+        )
         return event
 
-    def _post_process_request(self, request: LlmRequest,
-                              state: SampleStateTRTLLM):
-        """ Post Process the request. Updates the sequence according to the beam search results.
+    def _post_process_request(self, request: LlmRequest, state: SampleStateTRTLLM):
+        """Post Process the request. Updates the sequence according to the beam search results.
         request: LlmRequest which shall be post processed
         finalize_event: CudaEvent to wait for the finalize step to finish
         """
@@ -2291,27 +2015,28 @@ class TRTLLMSampler(Sampler):
         for beam in range(beam_width):
             # get the correct generated tokens for beam search
             begin = request.py_prompt_len
-            generated_length = sequence_lengths_host[
-                seq_slot, beam].item() - request.py_prompt_len
+            generated_length = sequence_lengths_host[seq_slot, beam].item() - request.py_prompt_len
             end = begin + generated_length
-            generated_tokens[beam] = output_ids_host[seq_slot, beam,
-                                                     begin:end].tolist()
+            generated_tokens[beam] = output_ids_host[seq_slot, beam, begin:end].tolist()
 
             # get the correct log probs for beam search
             if request.py_return_log_probs:
                 cum_log_probs.append(cum_log_probs_host[seq_slot, beam].item())
 
-                begin_log_probs_offset = request.prompt_len if request.sampling_config.beam_width == 1 else 0
+                begin_log_probs_offset = (
+                    request.prompt_len if request.sampling_config.beam_width == 1 else 0
+                )
                 for current_token, token in enumerate(generated_tokens[beam]):
-                    log_probs[beam].append({
-                        token:
-                        Logprob(
-                            logprob=log_probs_host[seq_slot,
-                                                   beam][begin_log_probs_offset
-                                                         +
-                                                         current_token].item(),
-                            rank=1)
-                    })
+                    log_probs[beam].append(
+                        {
+                            token: Logprob(
+                                logprob=log_probs_host[seq_slot, beam][
+                                    begin_log_probs_offset + current_token
+                                ].item(),
+                                rank=1,
+                            )
+                        }
+                    )
         if request.py_return_log_probs:
             request.py_result.set_log_probs(log_probs, cum_log_probs)
 

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import enum
 import sys
 from abc import ABC, abstractmethod

--- a/tensorrt_llm/_torch/pyexecutor/sampling_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampling_utils.py
@@ -1,0 +1,392 @@
+"""Helper functions for sampling.
+
+Code in this module should operate on logits and probs, without
+referring to types like LlmRequest.
+"""
+
+import abc
+import sys
+from dataclasses import dataclass
+from typing import Generic, Literal, Optional, TypeAlias, TypeVar, cast
+
+import torch
+
+from tensorrt_llm.sampling_params import SamplingParams
+
+if sys.version_info[:2] >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+
+
+TemperatureOnly = tuple[Literal["temperature"], float]
+TopK = tuple[Literal["top_k"], int, float]
+TopP = tuple[Literal["top_p"], float, float]
+TopKTopP = tuple[Literal["top_k_top_p"], int, float, float]
+Greedy = tuple[Literal["greedy"], None]
+GREEDY: Greedy = ("greedy", None)
+Strategy = TopK | TopP | Greedy | TopKTopP | TemperatureOnly
+
+
+@dataclass(frozen=True, kw_only=True)
+class UtilsSamplingParams:
+    """Subset of tensorrt_llm::runtime::SamplingConfig supported by sampling_utils."""
+
+    temperature: Optional[float]
+    top_p: Optional[float]
+    top_k: Optional[int]
+
+
+def resolve_sampling_strategy(params: UtilsSamplingParams, *, vocab_size: int) -> Strategy:
+    # The semantics are specified in the doc-string of SamplingParams
+
+    temperature = params.temperature
+    top_p = params.top_p
+    top_k = params.top_k
+
+    if SamplingParams.params_imply_greedy_decoding(
+        temperature=temperature,
+        top_p=top_p,
+        top_k=top_k,
+    ):
+        return GREEDY
+
+    # --- resolving default values
+    # NB: not greedy, hence temperature != 0 if specified
+    temperature = temperature or 1.0
+
+    # NB: not greedy, hence top_p != 0 if specified
+    top_p = top_p or 1.0
+    # NB: not greedy, hence top_k != 1 if specified
+    #     (0 and vocab_size are equivalent)
+    top_k = top_k or vocab_size
+
+    assert top_k > 1, "non-greedy sampling requires valid top_k"
+    need_top_k = top_k < vocab_size
+    assert top_p > 0, "non-greedy sampling requires valid top_p"
+    need_top_p = top_p < 1
+
+    if need_top_p:
+        if need_top_k:
+            return ("top_k_top_p", top_k, top_p, temperature)
+        return ("top_p", top_p, temperature)
+    if need_top_k:
+        return ("top_k", top_k, temperature)
+    return ("temperature", temperature)
+
+
+def top_k_sampling_batch(
+    logits,
+    *,
+    top_k: int,
+    temperature: float,
+    generator: Optional[torch.Generator] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    # NB: To be replaced by a more efficient implementation.
+    return top_k_top_p_sampling_batch(
+        logits,
+        top_k=top_k,
+        temperature=temperature,
+        generator=generator,
+        top_p=1,
+    )
+
+
+def top_p_sampling_batch(
+    logits: torch.Tensor,
+    *,
+    top_p: float,
+    temperature: float,
+    generator: Optional[torch.Generator] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    # NB: To be replaced by a more efficient implementation.
+    return top_k_top_p_sampling_batch(
+        logits,
+        top_p=top_p,
+        top_k=logits.size(1),
+        temperature=temperature,
+        generator=generator,
+    )
+
+
+def temperature_sampling_batch(
+    logits: torch.Tensor,
+    *,
+    temperature: float,
+    generator: Optional[torch.Generator] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    # NB: To be replaced by a more efficient implementation.
+    return top_k_top_p_sampling_batch(
+        logits,
+        top_p=1,
+        top_k=logits.size(1),
+        temperature=temperature,
+        generator=generator,
+    )
+
+
+def top_k_top_p_sampling_batch(
+    logits: torch.Tensor,
+    *,
+    top_k: int,
+    top_p: float,
+    temperature: float,
+    generator: Optional[torch.Generator] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    logits_dim = logits.dim()
+    assert logits_dim == 2, "logits should be 2D: [batch_size, vocab_size]"
+    assert temperature > 0, "non-greedy sampling requires valid temperature"
+    logits = logits / max(temperature, 1e-5)
+    batch_size, vocab_size = logits.size()
+
+    assert top_k > 1, "non-greedy sampling requires valid top_k"
+    need_top_k = top_k < vocab_size
+    assert top_p > 0, "non-greedy sampling requires valid top_p"
+    need_top_p = top_p < 1
+
+    # top-K: mask out logits not belonging to the top-K for each sample
+    if need_top_k:
+        values, _ = torch.topk(logits, top_k, dim=-1)
+        min_values = values[:, -1].unsqueeze(-1).expand(batch_size, vocab_size)
+
+        # set the logits who is less than first top_k logits to -inf
+        logits = torch.where(logits < min_values, torch.full_like(logits, float("-inf")), logits)
+
+    # top-p: mask out logits outside the nucleus
+    if need_top_p:
+        sorted_logits, sorted_indices = torch.sort(logits, descending=True, dim=-1)
+
+        # compute cumulative probability distribution of each sample
+        cumulative_probs = torch.cumsum(torch.softmax(sorted_logits, dim=-1), dim=-1)
+
+        # get the location of top_p
+        # NB: Currently selecting the smallest index with cumulative_probs > top_p.
+        #     Thus, top_p -> 0 resembles greedy; agreement requires torch.sort(..., stable=True).
+        sorted_indices_to_remove = cumulative_probs > top_p
+        sorted_indices_to_remove[:, 1:] = sorted_indices_to_remove[:, :-1].clone()
+        sorted_indices_to_remove[:, 0] = 0
+
+        # set the logits to -inf for token indices outside top_p
+        indices_to_remove = sorted_indices_to_remove.scatter(
+            1, sorted_indices, sorted_indices_to_remove
+        )
+        logits = logits.masked_fill(indices_to_remove, float("-inf"))
+
+    # compute probability distribution
+    softmax = torch.softmax(logits, dim=-1)
+
+    # sample from the distribution and generate result of [batch_size, 1]
+    next_tokens = torch.multinomial(softmax, num_samples=1, generator=generator).squeeze(-1)
+    return next_tokens, softmax
+
+
+def greedy_search_sampling_batch(
+    logits,
+    *,
+    return_probs: bool = True,
+) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+    next_tokens = torch.argmax(logits, dim=-1)
+    softmax: Optional[torch.Tensor] = None
+    if return_probs:
+        softmax = torch.softmax(logits, dim=-1)
+    return next_tokens, softmax
+
+
+def get_rejected_indices(
+    draft_probs: torch.Tensor,
+    target_probs: torch.Tensor,
+    generator: torch.Generator,
+    draft_tokens: list[int],
+) -> torch.Tensor:
+    # NB: ModelDrafter._pad_to_max_draft_tokens pads draft_tokens, but
+    #     not draft_probs. Relying on shape of draft_probs here.
+    num_draft_tokens = draft_probs.size(0)
+    draft_tokens = draft_tokens[:num_draft_tokens]
+    # NB: torch.arange is needed to enable "advanced indexing",
+    #   cf. https://numpy.org/devdocs/user/basics.indexing.html#integer-array-indexing
+    token_idx = torch.arange(num_draft_tokens, dtype=torch.int32, device=generator.device)
+    draft_tokens_cuda = torch.tensor(draft_tokens, dtype=torch.int32, pin_memory=True).to(
+        device=generator.device, non_blocking=True
+    )
+    p = draft_probs[token_idx, draft_tokens_cuda]
+    q = target_probs.squeeze(0)[token_idx, draft_tokens_cuda]
+    accept_probs = torch.minimum(torch.ones((), device=generator.device, dtype=q.dtype), q / p)
+    # Use deterministic random generation for multi-GPU consistency
+    rejected_indices = (
+        torch.rand(accept_probs.shape, generator=generator, device=accept_probs.device)
+        > accept_probs
+    ).nonzero()
+    return rejected_indices
+
+
+def sample_rejected(
+    draft_probs: torch.Tensor,
+    target_probs: torch.Tensor,
+    generator: torch.Generator,
+    num_accepted: int,
+) -> int:
+    last_draft = draft_probs[num_accepted]
+    last_target = target_probs[num_accepted]
+    new = last_target - last_draft
+    new = torch.where(new > 0, new, 0.0)
+
+    new_token = torch.multinomial(new, num_samples=1, generator=generator).squeeze(-1)
+    return cast(int, new_token.item())
+
+
+def sample(
+    strategy: Strategy,
+    logits: torch.Tensor,
+    *,
+    generator: Optional[torch.Generator] = None,
+    return_probs: bool = True,
+) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+    match strategy:
+        case ("top_k", top_k, temperature):
+            tokens, softmax = top_k_sampling_batch(
+                logits, top_k=top_k, temperature=temperature, generator=generator
+            )
+        case ("top_p", top_p, temperature):
+            tokens, softmax = top_p_sampling_batch(
+                logits,
+                top_p=top_p,
+                generator=generator,
+                temperature=temperature,
+            )
+        case ("top_k_top_p", top_k, top_p, temperature):
+            tokens, softmax = top_k_top_p_sampling_batch(
+                logits,
+                top_k=top_k,
+                top_p=top_p,
+                temperature=temperature,
+                generator=generator,
+            )
+        case ("temperature", temperature):
+            tokens, softmax = temperature_sampling_batch(
+                logits,
+                temperature=temperature,
+                generator=generator,
+            )
+        case ("greedy", None):
+            tokens, softmax = greedy_search_sampling_batch(logits, return_probs=return_probs)
+    return tokens, softmax
+
+
+GenericStrategyKeyType = TypeVar("GenericStrategyKeyType")
+
+
+class GroupedStrategySampler(Generic[GenericStrategyKeyType], abc.ABC):
+    @staticmethod
+    @abc.abstractmethod
+    def strategy_grouping_key(strategy: Strategy) -> GenericStrategyKeyType:
+        raise NotImplementedError
+
+    @staticmethod
+    @abc.abstractmethod
+    def sample_grouped_strategies(
+        group_key: GenericStrategyKeyType,
+        strategies: list[Strategy],
+        logits: torch.Tensor,
+        *,
+        group_logit_indices: Optional[torch.Tensor] = None,
+        generator: Optional[torch.Generator] = None,
+        return_probs: bool,
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+        raise NotImplementedError
+
+
+class SimpleGroupedStrategySampler(GroupedStrategySampler[Strategy]):
+    STRATEGY_KEY_TYPE: TypeAlias = Strategy
+
+    @override
+    @staticmethod
+    def strategy_grouping_key(strategy: Strategy) -> STRATEGY_KEY_TYPE:
+        return strategy
+
+    @override
+    @staticmethod
+    def sample_grouped_strategies(
+        group_key: STRATEGY_KEY_TYPE,
+        strategies: list[Strategy],
+        logits: torch.Tensor,
+        *,
+        group_logit_indices: Optional[torch.Tensor] = None,
+        generator: Optional[torch.Generator] = None,
+        return_probs: bool,
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+        if group_logit_indices is None:
+            assert logits.size(0) == len(strategies)
+        else:
+            logits = logits[group_logit_indices]
+
+        assert all(strategy == group_key for strategy in strategies), "group must be consistent"
+
+        return sample(
+            group_key,
+            logits,
+            generator=generator,
+            return_probs=return_probs,
+        )
+
+
+# Inspired by https://github.com/pytorch/pytorch/issues/80577; note also the
+# suggestion to consider torch.nested.
+def torch_multi_arange(
+    ends: torch.Tensor,
+    *,
+    starts: Optional[torch.Tensor] = None,
+    steps: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Efficiently compute torch.cat([torch.arange(b, e, d) for b, e, d in zip(starts, ends, steps)]).
+
+    Starts, ends, steps need to share dtype and shape. Invalid ranges like range(1, 2, -1) are
+    silently discarded. 'steps' defaults to 1 and 'starts' defaults to 0.
+    """
+    if steps is not None:
+        assert ends.dtype == steps.dtype
+        assert ends.shape == steps.shape
+    if starts is not None:
+        assert ends.dtype == starts.dtype
+        assert ends.shape == starts.shape
+
+    # This algorithm combines torch.repeat_interleaved() and torch.cumsum() to
+    # construct the result.
+    #
+    # 1. Given N ranges (characterized by starts, ends, steps), construct a sequence
+    #    of 2N numbers, in which the non-overlapping pairs of consecutive numbers
+    #    correspond to the ranges. For a given range, the pair (a, b) is chosen such
+    #    that upon torch.cumsum() application 'a' turns the last element of the
+    #    preceding range into the start element for the current range and 'b' is
+    #    simply the step size for the current range.
+    #
+    repeats = ends  # number of elements in each range
+    if starts is not None:
+        repeats = repeats.clone()
+        repeats -= starts
+    if steps is not None:
+        repeats = (repeats + steps - 1).div(steps, rounding_mode="floor")
+    repeats = repeats.clip(0)  # ignore invalid ranges
+    range_ends = repeats - 1  # last element in each range
+    if steps is not None:
+        range_ends *= steps
+    if starts is not None:
+        range_ends += starts
+    prev_range_ends = range_ends.roll(1)  # last element in preceding range (or 0)
+    prev_range_ends[0] = 0
+    ones = (
+        torch.tensor(1, dtype=ends.dtype, pin_memory=True)
+        .to(device=ends.device, non_blocking=True)
+        .broadcast_to(ends.shape)
+    )
+    if steps is None:
+        steps = ones
+    jumps = -prev_range_ends  # delta from one range to the next
+    if starts is not None:
+        jumps += starts
+    seq = torch.cat((jumps.unsqueeze(-1), steps.unsqueeze(-1)), dim=1).view(-1)
+    #
+    # 2. Construct output via torch.repeat_interleave() and torch.cumsum()
+    seq_repeats = torch.cat((ones.unsqueeze(-1), (repeats - 1).unsqueeze(-1)), dim=1).view(-1)
+    seq = seq.repeat_interleave(seq_repeats)
+    seq = seq.cumsum(0)
+    return seq

--- a/tensorrt_llm/_torch/pyexecutor/sampling_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampling_utils.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Helper functions for sampling.
 
 Code in this module should operate on logits and probs, without

--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -256,7 +256,7 @@ class MTPSampler(TorchSampler):
         assert isinstance(state, SampleStateMTP)
 
         state.sampler_event.synchronize()
-        new_tokens = state.host.new_tokens.tolist()
+        new_tokens = state.host.new_tokens
         new_tokens_lens_list = state.host.new_tokens_lens.tolist()
         next_draft_tokens_list = state.host.next_draft_tokens.tolist()
         beam_idx = self.BEAM

--- a/tests/unittest/_torch/sampler/test_torch_sampler.py
+++ b/tests/unittest/_torch/sampler/test_torch_sampler.py
@@ -37,10 +37,10 @@ class TestStrategySelection:
         if params.top_p == 0:
             pytest.skip("top_p = 0 disallowed by tensorrt_llm::executor::SamplingConfig")
 
+    # If this xpasses, update _check_params and doc-string of SamplingParams.
+    @pytest.mark.xfail(reason="top_p = 0 disallowed by tensorrt_llm::executor::SamplingConfig")
     def test_top_p_0_disallowed(self):
-        # If this xpasses, update _check_params and doc-string of SamplingParams.
         params = SamplingParams(top_p=0)
-        pytest.xfail("top_p = 0 disallowed by tensorrt_llm::executor::SamplingConfig")
         params._get_sampling_config()
 
     def _build_mock_llm_request(self, params: SamplingParams) -> LlmRequest:

--- a/tests/unittest/_torch/sampler/test_torch_sampler.py
+++ b/tests/unittest/_torch/sampler/test_torch_sampler.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from itertools import product
 from typing import Optional, cast
 

--- a/tests/unittest/_torch/speculative/test_torch_rejection_sampling.py
+++ b/tests/unittest/_torch/speculative/test_torch_rejection_sampling.py
@@ -33,7 +33,7 @@ def test_get_rejected_indices():
             sampled_tokens.append(draft_tokens[0])
         else:
             sampled_tokens.append(
-                sample_rejected(draft_probs, target_probs, generator, 0).item())
+                sample_rejected(draft_probs, target_probs, generator, 0))
         sampled_regular.append(
             torch.multinomial(target_probs[0],
                               num_samples=1,


### PR DESCRIPTION
## Description

Changes:

* Mild refactor of topk-logprobs and batched sampling
* Reduce number of D2H copies for topk-logprobs
* Reduce number of D2D copies (removing `torch.cat` in batched sampling)
* Remove obsolete code paths in batched sampling
* Simplify SoftMax logic by batching together requests which do/do not need probs
* Introduce `GroupedStrategySampler` ABC to support alternative batching schemes and sampling routines
* Fix up some type annotations
* Reformat `sampler.py` using `ruff`
* Move supporting code from `sampler.py` to new `sampling_utils.py`

*Note:* Since GitHub diffs [do not annotate moved code](https://github.com/orgs/community/discussions/9632), alternative tools might simplify the review process.

## Test Coverage

Non-functional change.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive sampling utilities module with multiple decoding strategies including top-k, top-p, temperature-based, and combined sampling approaches.
  * Introduced batch sampling functions that return tokens with optional probability distributions.
  * Added grouped sampling abstractions and rejected-token utilities for advanced decoding control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->