### PR TITLE
[None][feat] Sharded checkpoint loading POC

### DIFF
--- a/docs/source/features/checkpoint-loading.md
+++ b/docs/source/features/checkpoint-loading.md
@@ -31,7 +31,7 @@ The `BaseCheckpointLoader` is the central base interface for all checkpoint load
 
 **Key Methods:**
 - `load_config(checkpoint_dir, **kwargs)`: Loads and returns a `ModelConfig` object
-- `load_weights(checkpoint_dir, **kwargs)`: Loads and returns a dictionary of weights
+- `load_weights(checkpoint_dir, mapping, **kwargs)`: Loads and returns a dictionary of weights
 - `get_initialized_weight_mapper(model, config)`: Returns a runtime initialized weight mapper for the model
 - `cleanup()`: Releases resources and cleans up internal state
 
@@ -63,7 +63,7 @@ Handles the loading of model weights from storage:
 from tensorrt_llm._torch.models.checkpoints.base_weight_loader import BaseWeightLoader
 
 class CustomWeightLoader(BaseWeightLoader):
-    def load_weights(self, checkpoint_dir: str) -> dict[str, Any]:
+    def load_weights(self, checkpoint_dir: str, mapping: Mapping) -> dict[str, Any]:
         # Load weights from your custom format
         # Return a dictionary mapping parameter names to tensors
         return weights_dict
@@ -186,11 +186,12 @@ from tensorrt_llm._torch.models.modeling_utils import register_checkpoint_weight
 
 @register_checkpoint_weight_loader("CUSTOM_FORMAT")
 class CustomWeightLoader(BaseWeightLoader):
-    def load_weights(self, checkpoint_dir: str, **kwargs) -> dict[str, Any]:
+    def load_weights(self, checkpoint_dir: str, mapping: Mapping, **kwargs) -> dict[str, Any]:
         """
         Load weights from your custom format.
         Args:
             checkpoint_dir: Directory containing checkpoint files
+            mapping: A mapping object containing the distributed configuration.
             **kwargs: Additional loading parameters
         Returns:
             Dictionary mapping parameter names to tensors

--- a/tensorrt_llm/_torch/models/checkpoints/base_checkpoint_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/base_checkpoint_loader.py
@@ -14,6 +14,8 @@ from tensorrt_llm._torch.models.checkpoints.base_weight_mapper import \
     BaseWeightMapper
 from tensorrt_llm._torch.models.modeling_utils import \
     CHECKPOINT_LOADER_FORMAT_DEFAULT_MAPPING
+from tensorrt_llm.logger import logger
+from tensorrt_llm.mapping import Mapping
 
 
 class BaseCheckpointLoader(ABC):
@@ -51,10 +53,17 @@ class BaseCheckpointLoader(ABC):
         ...
 
     def load_config(self, checkpoint_dir: str, **kwargs) -> ModelConfig:
+        logger.debug(f"Loading config from {checkpoint_dir}")
         return self.config_loader.load(checkpoint_dir, **kwargs)
 
-    def load_weights(self, checkpoint_dir: str, **kwargs) -> dict[str, Any]:
-        return self.weight_loader.load_weights(checkpoint_dir, **kwargs)
+    def load_weights(self, checkpoint_dir: str, mapping: Mapping,
+                     **kwargs) -> dict[str, Any]:
+        logger.debug(
+            f"Loading weights from {checkpoint_dir} with mapping {mapping.to_dict()}"
+        )
+        return self.weight_loader.load_weights(checkpoint_dir,
+                                               mapping=mapping,
+                                               **kwargs)
 
     @classmethod
     def get(cls, checkpoint_format: str, **kwargs) -> "BaseCheckpointLoader":

--- a/tensorrt_llm/_torch/models/checkpoints/base_weight_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/base_weight_loader.py
@@ -1,16 +1,20 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
+from tensorrt_llm.mapping import Mapping
+
 
 class BaseWeightLoader(ABC):
 
     @abstractmethod
-    def load_weights(self, checkpoint_dir: str) -> dict[str, Any]:
+    def load_weights(self, checkpoint_dir: str,
+                     mapping: Mapping) -> dict[str, Any]:
         """
         Loads weights from a checkpoint directory.
 
         Args:
             checkpoint_dir: A path to the checkpoint directory.
+            mapping: A mapping object containing the distributed configuration.
 
         Returns:
             A dictionary where keys are tensor names and values are the tensors.

--- a/tensorrt_llm/_torch/models/checkpoints/base_weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/base_weight_mapper.py
@@ -8,6 +8,7 @@ from tensorrt_llm._torch.models.modeling_utils import DecoderModelForCausalLM
 
 
 class BaseWeightMapper(ABC):
+    already_sharded: bool = False
 
     def __init__(self):
         self._callbacks: list[Callable] = []

--- a/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
@@ -16,6 +16,7 @@ from tensorrt_llm._torch.models.modeling_utils import (
 from tensorrt_llm._utils import (local_mpi_barrier, local_mpi_rank,
                                  local_mpi_size)
 from tensorrt_llm.logger import logger
+from tensorrt_llm.mapping import Mapping
 
 
 @register_checkpoint_weight_loader("HF")
@@ -24,7 +25,8 @@ class HfWeightLoader(BaseWeightLoader):
     Loads weights from SafeTensors/bin/pth files.
     """
 
-    def load_weights(self, checkpoint_dir: str) -> dict[str, Any]:
+    def load_weights(self, checkpoint_dir: str,
+                     mapping: Mapping) -> dict[str, Any]:
         weight_files = glob.glob(f"{checkpoint_dir}/*.safetensors")
         # Some model checkpoint directories contain not only the sharded safetensors, but one
         # consolidated tensor. In the presence of both, we favor the former, as there really is no need

--- a/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
@@ -58,7 +58,7 @@ class Qwen3Gate(nn.Module):
             hidden_states, self.weight.t(), bias=None, out_dtype=self.out_dtype)
         return logits
 
-    def load_weights(self, weights: List[Dict]):
+    def load_weights(self, weights: List[Dict], **kwargs):
         assert len(weights) == 1
 
         self.weight.copy_(weights[0]["weight"][:])

--- a/tensorrt_llm/_torch/modules/embedding.py
+++ b/tensorrt_llm/_torch/modules/embedding.py
@@ -120,7 +120,7 @@ class LMHead(Linear):
         output = input.new_empty(output_shape)
         return output
 
-    def load_weights(self, weights: List[Dict], already_sharded: bool):
+    def load_weights(self, weights: List[Dict], already_sharded: bool = False):
         original_weight = None
         if self.tp_mode == TensorParallelMode.COLUMN:
             if self.tp_rank == self.tp_size - 1 and self.padding_size > 0:

--- a/tensorrt_llm/_torch/modules/embedding.py
+++ b/tensorrt_llm/_torch/modules/embedding.py
@@ -120,14 +120,14 @@ class LMHead(Linear):
         output = input.new_empty(output_shape)
         return output
 
-    def load_weights(self, weights: List[Dict]):
+    def load_weights(self, weights: List[Dict], already_sharded: bool):
         original_weight = None
         if self.tp_mode == TensorParallelMode.COLUMN:
             if self.tp_rank == self.tp_size - 1 and self.padding_size > 0:
                 original_weight = self.weight.data.zero_()
                 self.weight.data = self.weight[:-self.padding_size, :]
 
-        super().load_weights(weights)
+        super().load_weights(weights, already_sharded=already_sharded)
 
         if original_weight is not None:
             self.weight.data = original_weight

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
@@ -729,12 +729,13 @@ class CutlassFusedMoE(MoE):
             return x.new_empty((num_tokens, top_k, hidden_size),
                                dtype=data_type)
 
-    def load_weights(self, weights: List[Dict]):
+    def load_weights(self, weights: List[Dict], already_sharded: bool = False):
         assert self._weights_created
         assert len(weights) == 1
         weights = weights[0]
 
-        self.quant_method.load_weights(self, weights, self.weight_loading_mode)
+        self.quant_method.load_weights(self, weights, self.weight_loading_mode,
+                                       already_sharded)
 
     def post_load_weights(self):
         self.quant_method.post_load_weights(self)

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_triton.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_triton.py
@@ -1389,12 +1389,13 @@ class TritonFusedMoE(MoE):
 
         return final_hidden_states
 
-    def load_weights(self, weights: List[Dict]):
+    def load_weights(self, weights: List[Dict], already_sharded: bool = False):
         assert self._weights_created
         assert len(weights) == 1
         weights = weights[0]
 
-        self.quant_method.load_weights(self, weights, self.weight_loading_mode)
+        self.quant_method.load_weights(self, weights, self.weight_loading_mode,
+                                       already_sharded)
 
     def post_load_weights(self):
         self.quant_method.post_load_weights(self)

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py
@@ -249,13 +249,14 @@ class TRTLLMGenFusedMoE(MoE):
                                         requires_grad=False)
             self.register_parameter("w2_bias", self.w2_bias)
 
-    def load_weights(self, weights: List[Dict]):
+    def load_weights(self, weights: List[Dict], already_sharded: bool = False):
         assert self._weights_created
 
         assert len(weights) == 1
         weights = weights[0]
 
-        self.quant_method.load_weights(self, weights, self.weight_loading_mode)
+        self.quant_method.load_weights(self, weights, self.weight_loading_mode,
+                                       already_sharded)
 
     def post_load_weights(self):
         self.quant_method.post_load_weights(self)

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_wide_ep.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_wide_ep.py
@@ -1060,12 +1060,13 @@ class WideEPMoE(MoE):
                         expert_id, weight_name, weight_tensor.dtype,
                         weight_tensor[0].shape)
 
-    def load_weights(self, weights: List[Dict]):
+    def load_weights(self, weights: List[Dict], already_sharded: bool = False):
         assert self._weights_created
         assert len(weights) == 1
         weights = weights[0]
 
-        self.quant_method.load_weights(self, weights, self.weight_loading_mode)
+        self.quant_method.load_weights(self, weights, self.weight_loading_mode,
+                                       already_sharded)
 
     def post_load_weights(self):
         self.quant_method.post_load_weights(self)

--- a/tensorrt_llm/_torch/modules/fused_moe/interface.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/interface.py
@@ -204,7 +204,7 @@ class MoE(nn.Module):
         raise NotImplementedError
 
     @abstractmethod
-    def load_weights(self, weights: List[Dict]):
+    def load_weights(self, weights: List[Dict], already_sharded: bool = False):
         raise NotImplementedError
 
     def post_load_weights(self):

--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -208,12 +208,18 @@ class FusedMoEMethodBase(ABC):
             module.w2_bias = None
 
     def load_expert_weights_to_dst(
-            self, module: torch.nn.Module, weights: List[Dict],
-            weight_loading_mode: MoEWeightLoadingMode,
-            load_expert_ids: List[int], dst_w3_w1_weights_tensor: torch.Tensor,
-            dst_w2_weights_tensor: torch.Tensor,
-            dst_w3_w1_bias_tensor: Optional[torch.Tensor],
-            dst_w2_bias_tensor: Optional[torch.Tensor]):
+        self,
+        *,
+        module: torch.nn.Module,
+        weights: List[Dict],
+        weight_loading_mode: MoEWeightLoadingMode,
+        load_expert_ids: List[int],
+        dst_w3_w1_weights_tensor: torch.Tensor,
+        dst_w2_weights_tensor: torch.Tensor,
+        dst_w3_w1_bias_tensor: Optional[torch.Tensor],
+        dst_w2_bias_tensor: Optional[torch.Tensor],
+        already_sharded: bool,
+    ):
         # Multithread weight load is superseded by prefetch_files() in model_engine.py
         # Also, threading adds overhead in order to protect shuffle index cache with critical section.
         for local_slot_id, expert_id in enumerate(load_expert_ids):
@@ -246,31 +252,53 @@ class FusedMoEMethodBase(ABC):
                     f"Unknown weight loading mode in MoE: {weight_loading_mode}"
                 )
 
-            self.load_expert_w3_w1_weight(module, w1_weight, w3_weight,
-                                          dst_w3_w1_weights_tensor[expert_idx])
+            self.load_expert_w3_w1_weight(
+                module=module,
+                w1_weight=w1_weight,
+                w3_weight=w3_weight,
+                dst_w3_w1_weight=dst_w3_w1_weights_tensor[expert_idx],
+                already_sharded=already_sharded)
 
-            self.load_expert_w2_weight(module, w2_weight,
-                                       dst_w2_weights_tensor[expert_idx])
+            self.load_expert_w2_weight(
+                module=module,
+                w2_weight=w2_weight,
+                dst_w2_weight=dst_w2_weights_tensor[expert_idx],
+                already_sharded=already_sharded)
 
             if module.bias:
                 self.load_expert_w3_w1_weight(
-                    module, w1_bias, w3_bias,
-                    dst_w3_w1_bias_tensor.data[expert_idx])
+                    module=module,
+                    w1_weight=w1_bias,
+                    w3_weight=w3_bias,
+                    dst_w3_w1_weight=dst_w3_w1_bias_tensor.data[expert_idx],
+                    already_sharded=already_sharded)
 
-                self.load_expert_w2_weight(module, w2_bias,
-                                           dst_w2_bias_tensor.data[expert_idx])
+                self.load_expert_w2_weight(
+                    module=module,
+                    w2_weight=w2_bias,
+                    dst_w2_weight=dst_w2_bias_tensor.data[expert_idx],
+                    already_sharded=already_sharded)
 
     def load_weights(self, module: torch.nn.Module, weights: List[Dict],
-                     weight_loading_mode: MoEWeightLoadingMode):
+                     weight_loading_mode: MoEWeightLoadingMode,
+                     already_sharded: bool):
+        logger.info(
+            f"Loading weights for {module.__class__.__name__} with weight mode: {weight_loading_mode} and already sharded: {already_sharded}"
+        )
 
         self.load_expert_weights_to_dst(
-            module, weights, weight_loading_mode,
-            module.initial_local_expert_ids, module.w3_w1_weight.data,
-            module.w2_weight.data,
-            module.w3_w1_bias.data if module.bias else None,
-            module.w2_bias.data if module.bias else None)
+            module=module,
+            weights=weights,
+            weight_loading_mode=weight_loading_mode,
+            load_expert_ids=module.initial_local_expert_ids,
+            dst_w3_w1_weights_tensor=module.w3_w1_weight.data,
+            dst_w2_weights_tensor=module.w2_weight.data,
+            dst_w3_w1_bias_tensor=module.w3_w1_bias.data
+            if module.bias else None,
+            dst_w2_bias_tensor=module.w2_bias.data if module.bias else None,
+            already_sharded=already_sharded)
 
-        self.load_quant_scales(module, weights)
+        self.load_quant_scales(module, weights, already_sharded)
 
         if self.need_load_shared_weights(module):
             local_shared_load_expert_ids = module.layer_load_balancer.get_load_expert_ids(
@@ -324,7 +352,8 @@ class FusedMoEMethodBase(ABC):
         # Re-setup quant scales after loading weights as the tensors may have been modified.
         self.setup_quant_scales(module)
 
-    def load_quant_scales(self, module: torch.nn.Module, weights: List[Dict]):
+    def load_quant_scales(self, module: torch.nn.Module, weights: List[Dict],
+                          already_sharded: bool):
         pass
 
     @abstractmethod
@@ -341,25 +370,40 @@ class FusedMoEMethodBase(ABC):
         raise NotImplementedError
 
     # Helper function
-    def load_expert_w3_w1_weight(self, module: torch.nn.Module,
-                                 w1_weight: torch.Tensor,
-                                 w3_weight: torch.Tensor,
-                                 dst_w3_w1_weight: torch.Tensor):
+    def load_expert_w3_w1_weight(
+        self,
+        *,
+        module: torch.nn.Module,
+        w1_weight: torch.Tensor,
+        w3_weight: torch.Tensor,
+        dst_w3_w1_weight: torch.Tensor,
+        already_sharded: bool,
+    ):
         """
         Load w1 and w3 weights for each expert.
         Override this method if you need to preprocess the weights differently.
         """
+
+        if not already_sharded:
+            tp_size = module.tp_size
+            tp_rank = module.tp_rank
+            tp_mode_column = TensorParallelMode.COLUMN
+        else:
+            tp_size = 1
+            tp_rank = 0
+            tp_mode_column = None
+
         # device don't have to be 'cuda', e.g. 'cpu' for online EPLB
         device = dst_w3_w1_weight.device
         w1_weight_shard = load_weight_shard(w1_weight,
-                                            module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.COLUMN,
+                                            tp_size,
+                                            tp_rank,
+                                            tp_mode_column,
                                             device=device)
         w3_weight_shard = load_weight_shard(w3_weight,
-                                            module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.COLUMN,
+                                            tp_size,
+                                            tp_rank,
+                                            tp_mode_column,
                                             device=device)
 
         w31_weight_shard = torch.cat([w3_weight_shard, w1_weight_shard], dim=0)
@@ -367,19 +411,34 @@ class FusedMoEMethodBase(ABC):
                                non_blocking=True)
 
     # Helper function
-    def load_expert_w2_weight(self, module: torch.nn.Module,
-                              w2_weight: torch.Tensor,
-                              dst_w2_weight: torch.Tensor):
+    def load_expert_w2_weight(
+        self,
+        *,
+        module: torch.nn.Module,
+        w2_weight: torch.Tensor,
+        dst_w2_weight: torch.Tensor,
+        already_sharded: bool,
+    ):
         """
         Load w2 weight for each expert.
         Override this method if you need to preprocess the weights differently.
         """
+
+        if not already_sharded:
+            tp_size = module.tp_size
+            tp_rank = module.tp_rank
+            tp_mode_row = TensorParallelMode.ROW
+        else:
+            tp_size = 1
+            tp_rank = 0
+            tp_mode_row = None
+
         # device don't have to be 'cuda', e.g. 'cpu' for online EPLB
         device = dst_w2_weight.device
         w2_weight_shard = load_weight_shard(w2_weight,
-                                            module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.ROW,
+                                            tp_size,
+                                            tp_rank,
+                                            tp_mode_row,
                                             device=device)
         dst_w2_weight.copy_(w2_weight_shard.view(dst_w2_weight.dtype),
                             non_blocking=True)
@@ -617,8 +676,10 @@ class DeepSeekFP8BlockScalesFusedMoEMethod(FusedMoEMethodBase):
         self.setup_quant_scales(module)
 
     def load_weights(self, module: torch.nn.Module, weights: List[Dict],
-                     weight_loading_mode: MoEWeightLoadingMode):
-        super().load_weights(module, weights, weight_loading_mode)
+                     weight_loading_mode: MoEWeightLoadingMode,
+                     already_sharded: bool):
+        super().load_weights(module, weights, weight_loading_mode,
+                             already_sharded)
 
     def setup_quant_scales(self, module: torch.nn.Module):
         module.quant_scales = FusedMoEQuantScalesDeepSeekFP8BlockScales(
@@ -627,9 +688,27 @@ class DeepSeekFP8BlockScalesFusedMoEMethod(FusedMoEMethodBase):
         )
 
     def load_expert_all_weight_scale_fp8_block_scale(
-            self, module: torch.nn.Module, weights: Dict,
-            load_expert_ids: List[int], dst_w3_w1_weight_scale: torch.Tensor,
-            dst_w2_weight_scale: torch.Tensor, device):
+        self,
+        *,
+        module: torch.nn.Module,
+        weights: Dict,
+        load_expert_ids: List[int],
+        dst_w3_w1_weight_scale: torch.Tensor,
+        dst_w2_weight_scale: torch.Tensor,
+        device,
+        already_sharded: bool,
+    ):
+        if not already_sharded:
+            tp_size = module.tp_size
+            tp_rank = module.tp_rank
+            tp_mode_column = TensorParallelMode.COLUMN
+            tp_mode_row = TensorParallelMode.ROW
+        else:
+            tp_size = 1
+            tp_rank = 0
+            tp_mode_column = None
+            tp_mode_row = None
+
         for local_slot_id, expert_id in enumerate(load_expert_ids):
             if module.weight_loading_mode == MoEWeightLoadingMode.FUSED_GATE_UP_PROJ:
                 w3_scale = weights['gate_up_proj_weight_scale'][
@@ -647,16 +726,16 @@ class DeepSeekFP8BlockScalesFusedMoEMethod(FusedMoEMethodBase):
                 )
 
             w3_w1_scale_shard = load_weight_shard(w3_scale,
-                                                  module.tp_size,
-                                                  module.tp_rank,
-                                                  TensorParallelMode.COLUMN,
+                                                  tp_size,
+                                                  tp_rank,
+                                                  tp_mode_column,
                                                   device=device)
 
             if w1_scale is not None:
                 w1_scale_shard = load_weight_shard(w1_scale,
-                                                   module.tp_size,
-                                                   module.tp_rank,
-                                                   TensorParallelMode.COLUMN,
+                                                   tp_size,
+                                                   tp_rank,
+                                                   tp_mode_column,
                                                    device=device)
                 w3_w1_scale_shard = torch.cat(
                     [w3_w1_scale_shard, w1_scale_shard], dim=-2)
@@ -664,20 +743,22 @@ class DeepSeekFP8BlockScalesFusedMoEMethod(FusedMoEMethodBase):
             dst_w3_w1_weight_scale[local_slot_id].copy_(w3_w1_scale_shard)
 
             w2_scale_shard = load_weight_shard(w2_scale,
-                                               module.tp_size,
-                                               module.tp_rank,
-                                               TensorParallelMode.ROW,
+                                               tp_size,
+                                               tp_rank,
+                                               tp_mode_row,
                                                device=device)
             dst_w2_weight_scale[local_slot_id].copy_(w2_scale_shard)
 
-    def load_quant_scales(self, module: torch.nn.Module, weights: Dict):
+    def load_quant_scales(self, module: torch.nn.Module, weights: Dict,
+                          already_sharded: bool):
         self.load_expert_all_weight_scale_fp8_block_scale(
             module,
             weights,
             module.initial_local_expert_ids,
             module.w3_w1_weight_scaling_factor.data,
             module.w2_weight_scaling_factor.data,
-            device=torch.device("cuda"))
+            device=torch.device("cuda"),
+            already_sharded=already_sharded)
         if self.need_load_shared_weights(module):
             local_shared_load_expert_ids = module.layer_load_balancer.get_load_expert_ids(
             )
@@ -697,7 +778,8 @@ class DeepSeekFP8BlockScalesFusedMoEMethod(FusedMoEMethodBase):
                 local_shared_load_expert_ids,
                 local_shared_w3_w1_scale_tensors,
                 local_shared_w2_scale_tensors,
-                device=torch.device("cpu"))
+                device=torch.device("cpu"),
+                already_sharded=already_sharded)
             module.register_all_parameter_slot_and_to_fix_weight_fns({
                 'w3_w1_weight_scaling_factor':
                 local_shared_w3_w1_scale_tensors,
@@ -710,7 +792,8 @@ class DeepSeekFP8BlockScalesFusedMoEMethodDeepGemm(
         DeepSeekFP8BlockScalesFusedMoEMethod):
 
     def load_weights(self, module: torch.nn.Module, weights: List[Dict],
-                     weight_loading_mode: MoEWeightLoadingMode):
+                     weight_loading_mode: MoEWeightLoadingMode,
+                     already_sharded: bool):
         if is_sm_100f():
             expert_ids = set(module.initial_local_expert_ids)
             if self.need_load_shared_weights(module):
@@ -726,7 +809,8 @@ class DeepSeekFP8BlockScalesFusedMoEMethodDeepGemm(
                     scale = weights[name][:]
                     weights[weight_name], weights[name] = resmooth_to_fp8_e8m0(
                         weight, scale)
-        super().load_weights(module, weights, weight_loading_mode)
+        super().load_weights(module, weights, weight_loading_mode,
+                             already_sharded)
 
     def post_load_weights(self, module: torch.nn.Module):
         super().post_load_weights(module)
@@ -798,19 +882,32 @@ class INT8WoqPerChannelFusedMoEMethod(FusedMoEMethodBase):
             fc2_weight_scale=module.fc2_weight_scale,
         )
 
-    def load_expert_w3_w1_weight(self, module: torch.nn.Module,
-                                 w1_weight: torch.Tensor,
-                                 w3_weight: torch.Tensor,
-                                 dst_w3_w1_weight: torch.Tensor):
+    def load_expert_w3_w1_weight(
+        self,
+        *,
+        module: torch.nn.Module,
+        w1_weight: torch.Tensor,
+        w3_weight: torch.Tensor,
+        dst_w3_w1_weight: torch.Tensor,
+        already_sharded: bool,
+    ):
         """
         Load w1 and w3 weights for each expert.
         """
-        w1_weight_shard = load_weight_shard(w1_weight, module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.COLUMN)
-        w3_weight_shard = load_weight_shard(w3_weight, module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.COLUMN)
+
+        if not already_sharded:
+            tp_size = module.tp_size
+            tp_rank = module.tp_rank
+            tp_mode_column = TensorParallelMode.COLUMN
+        else:
+            tp_size = 1
+            tp_rank = 0
+            tp_mode_column = None
+
+        w1_weight_shard = load_weight_shard(w1_weight, tp_size, tp_rank,
+                                            tp_mode_column)
+        w3_weight_shard = load_weight_shard(w3_weight, tp_size, tp_rank,
+                                            tp_mode_column)
         w31_weight_shard = torch.cat([w3_weight_shard, w1_weight_shard], dim=0)
 
         weight_dtype = torch.int8
@@ -828,15 +925,29 @@ class INT8WoqPerChannelFusedMoEMethod(FusedMoEMethodBase):
         dst_w3_w1_weight.copy_(w31_weight_shard.view(dst_w3_w1_weight.dtype),
                                non_blocking=True)
 
-    def load_expert_w2_weight(self, module: torch.nn.Module,
-                              w2_weight: torch.Tensor,
-                              dst_w2_weight: torch.Tensor):
+    def load_expert_w2_weight(
+        self,
+        *,
+        module: torch.nn.Module,
+        w2_weight: torch.Tensor,
+        dst_w2_weight: torch.Tensor,
+        already_sharded: bool,
+    ):
         """
         Load w2 weight for each expert.
         """
-        w2_weight_shard = load_weight_shard(w2_weight, module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.ROW)
+
+        if not already_sharded:
+            tp_size = module.tp_size
+            tp_rank = module.tp_rank
+            tp_mode_row = TensorParallelMode.ROW
+        else:
+            tp_size = 1
+            tp_rank = 0
+            tp_mode_row = None
+
+        w2_weight_shard = load_weight_shard(w2_weight, tp_size, tp_rank,
+                                            tp_mode_row)
 
         weight_dtype = torch.int8
         if not module.quant_config.layer_quant_mode.is_int8_weight_only():
@@ -851,18 +962,32 @@ class INT8WoqPerChannelFusedMoEMethod(FusedMoEMethodBase):
         dst_w2_weight.copy_(w2_weight_shard.view(dst_w2_weight.dtype),
                             non_blocking=True)
 
-    def load_quant_scales(self, module: torch.nn.Module, weights: Dict):
+    def load_quant_scales(
+        self,
+        module: torch.nn.Module,
+        weights: Dict,
+        already_sharded: bool,
+    ):
+        if not already_sharded:
+            tp_size = module.tp_size
+            tp_rank = module.tp_rank
+            tp_mode_column = TensorParallelMode.COLUMN
+            tp_mode_row = TensorParallelMode.ROW
+        else:
+            tp_size = 1
+            tp_rank = 0
+            tp_mode_column = None
+            tp_mode_row = None
+
         # fc31 scales
         all_w3_scales = [
-            load_weight_shard(weights[f"{expert_id}.w3.weight_scale"],
-                              module.tp_size, module.tp_rank,
-                              TensorParallelMode.COLUMN)
+            load_weight_shard(weights[f"{expert_id}.w3.weight_scale"], tp_size,
+                              tp_rank, tp_mode_column)
             for expert_id in module.initial_local_expert_ids
         ]
         all_w1_scales = [
-            load_weight_shard(weights[f"{expert_id}.w1.weight_scale"],
-                              module.tp_size, module.tp_rank,
-                              TensorParallelMode.COLUMN)
+            load_weight_shard(weights[f"{expert_id}.w1.weight_scale"], tp_size,
+                              tp_rank, tp_mode_column)
             for expert_id in module.initial_local_expert_ids
         ]
         w3_w1_scales = torch.cat(
@@ -873,9 +998,8 @@ class INT8WoqPerChannelFusedMoEMethod(FusedMoEMethodBase):
 
         # fc2 scales
         all_w2_scales = [
-            load_weight_shard(weights[f"{expert_id}.w2.weight_scale"],
-                              module.tp_size, module.tp_rank,
-                              TensorParallelMode.ROW)
+            load_weight_shard(weights[f"{expert_id}.w2.weight_scale"], tp_size,
+                              tp_rank, tp_mode_row)
             for expert_id in module.initial_local_expert_ids
         ]
         w2_scales = torch.stack(all_w2_scales).to(module.dtype)
@@ -977,10 +1101,15 @@ class WInt4AFP8FusedMoEMethod(FusedMoEMethodBase):
             alpha_2=module.fc2_alpha,
         )
 
-    def load_expert_w3_w1_weight(self, module: torch.nn.Module,
-                                 w1_weight: torch.Tensor,
-                                 w3_weight: torch.Tensor,
-                                 dst_w3_w1_weight: torch.Tensor):
+    def load_expert_w3_w1_weight(
+        self,
+        *,
+        module: torch.nn.Module,
+        w1_weight: torch.Tensor,
+        w3_weight: torch.Tensor,
+        dst_w3_w1_weight: torch.Tensor,
+        already_sharded: bool,
+    ):
         """
         Load w1 and w3 weights for each expert.
         Override this method if you need to preprocess the weights differently.
@@ -988,15 +1117,25 @@ class WInt4AFP8FusedMoEMethod(FusedMoEMethodBase):
         device = dst_w3_w1_weight.device
         self.device = device
 
+        if not already_sharded:
+            tp_size = module.tp_size
+            tp_rank = module.tp_rank
+            tp_mode_column = TensorParallelMode.COLUMN
+            TensorParallelMode.ROW
+        else:
+            tp_size = 1
+            tp_rank = 0
+            tp_mode_column = None
+
         w1_weight_shard = load_weight_shard(w1_weight,
-                                            module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.COLUMN,
+                                            tp_size,
+                                            tp_rank,
+                                            tp_mode_column,
                                             device=device)
         w3_weight_shard = load_weight_shard(w3_weight,
-                                            module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.COLUMN,
+                                            tp_size,
+                                            tp_rank,
+                                            tp_mode_column,
                                             device=device)
         w31_weight_shard = torch.cat([w3_weight_shard, w1_weight_shard], dim=0)
 
@@ -1033,18 +1172,33 @@ class WInt4AFP8FusedMoEMethod(FusedMoEMethodBase):
         dst_w3_w1_weight.copy_(w31_weight_shard.view(dst_w3_w1_weight.dtype),
                                non_blocking=True)
 
-    def load_expert_w2_weight(self, module: torch.nn.Module,
-                              w2_weight: torch.Tensor,
-                              dst_w2_weight: torch.Tensor):
+    def load_expert_w2_weight(
+        self,
+        *,
+        module: torch.nn.Module,
+        w2_weight: torch.Tensor,
+        dst_w2_weight: torch.Tensor,
+        already_sharded: bool,
+    ):
         """
         Load w2 weight for each expert.
         Override this method if you need to preprocess the weights differently.
         """
         device = dst_w2_weight.device
+
+        if not already_sharded:
+            tp_size = module.tp_size
+            tp_rank = module.tp_rank
+            tp_mode_row = TensorParallelMode.ROW
+        else:
+            tp_size = 1
+            tp_rank = 0
+            tp_mode_row = None
+
         w2_weight_shard = load_weight_shard(w2_weight,
-                                            module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.ROW,
+                                            tp_size,
+                                            tp_rank,
+                                            tp_mode_row,
                                             device=device)
 
         packer = torch.ops.trtllm.pack_int8_tensor_to_packed_int4
@@ -1078,8 +1232,24 @@ class WInt4AFP8FusedMoEMethod(FusedMoEMethodBase):
         dst_w2_weight.copy_(w2_weight_shard.view(dst_w2_weight.dtype),
                             non_blocking=True)
 
-    def load_quant_scales(self, module: torch.nn.Module, weights: Dict):
+    def load_quant_scales(
+        self,
+        module: torch.nn.Module,
+        weights: Dict,
+        already_sharded: bool,
+    ):
         assert self.device.type == "cuda"
+
+        if not already_sharded:
+            tp_size = module.tp_size
+            tp_rank = module.tp_rank
+            tp_mode_column = TensorParallelMode.COLUMN
+            tp_mode_row = TensorParallelMode.ROW
+        else:
+            tp_size = 1
+            tp_rank = 0
+            tp_mode_column = None
+            tp_mode_row = None
 
         # fc31 scales
         w4a8_custom = module.weight_loading_mode == MoEWeightLoadingMode.W4A8_CUSTOM
@@ -1119,17 +1289,17 @@ class WInt4AFP8FusedMoEMethod(FusedMoEMethodBase):
             # In vanilla ckpt (at least from ModelOpt), per-tensor input_scale and per-channel pre_quant_scale are separately stored
             all_w3_pre_quant_scales = [
                 load_weight_shard(weights[f"{expert_id}.w3.pre_quant_scale"],
-                                  module.tp_size,
-                                  module.tp_rank,
-                                  TensorParallelMode.ROW,
+                                  tp_size,
+                                  tp_rank,
+                                  tp_mode_row,
                                   device=self.device)
                 for expert_id in module.initial_local_expert_ids
             ]
             all_w1_pre_quant_scales = [
                 load_weight_shard(weights[f"{expert_id}.w1.pre_quant_scale"],
-                                  module.tp_size,
-                                  module.tp_rank,
-                                  TensorParallelMode.ROW,
+                                  tp_size,
+                                  tp_rank,
+                                  tp_mode_row,
                                   device=self.device)
                 for expert_id in module.initial_local_expert_ids
             ]
@@ -1186,17 +1356,17 @@ class WInt4AFP8FusedMoEMethod(FusedMoEMethodBase):
         # Per-group weight_scale
         all_w3_scales = [
             load_weight_shard(weights[f"{expert_id}.w3.{weight_scale_name}"],
-                              module.tp_size,
-                              module.tp_rank,
-                              TensorParallelMode.COLUMN,
+                              tp_size,
+                              tp_rank,
+                              tp_mode_column,
                               device=self.device)
             for expert_id in module.initial_local_expert_ids
         ]
         all_w1_scales = [
             load_weight_shard(weights[f"{expert_id}.w1.{weight_scale_name}"],
-                              module.tp_size,
-                              module.tp_rank,
-                              TensorParallelMode.COLUMN,
+                              tp_size,
+                              tp_rank,
+                              tp_mode_column,
                               device=self.device)
             for expert_id in module.initial_local_expert_ids
         ]
@@ -1247,9 +1417,9 @@ class WInt4AFP8FusedMoEMethod(FusedMoEMethodBase):
             # In vanilla ckpt (at least from ModelOpt), per-tensor input_scale and per-channel pre_quant_scale are separately stored
             all_w2_pre_quant_scales = [
                 load_weight_shard(weights[f"{expert_id}.w2.pre_quant_scale"],
-                                  module.tp_size,
-                                  module.tp_rank,
-                                  TensorParallelMode.COLUMN,
+                                  tp_size,
+                                  tp_rank,
+                                  tp_mode_column,
                                   device=self.device)
                 for expert_id in module.initial_local_expert_ids
             ]
@@ -1282,9 +1452,9 @@ class WInt4AFP8FusedMoEMethod(FusedMoEMethodBase):
         # Per-group weight_scale
         all_w2_scales = [
             load_weight_shard(weights[f"{expert_id}.w2.{weight_scale_name}"],
-                              module.tp_size,
-                              module.tp_rank,
-                              TensorParallelMode.ROW,
+                              tp_size,
+                              tp_rank,
+                              tp_mode_row,
                               device=self.device)
             for expert_id in module.initial_local_expert_ids
         ]
@@ -1367,24 +1537,39 @@ class WFP4A16FusedMoEMethod(FusedMoEMethodBase):
             scale_1_interleaved=module.fc31_weight_scale,
             scale_2_interleaved=module.fc2_weight_scale)
 
-    def load_expert_w3_w1_weight(self, module: torch.nn.Module,
-                                 w1_weight: torch.Tensor,
-                                 w3_weight: torch.Tensor,
-                                 dst_w3_w1_weight: torch.Tensor):
+    def load_expert_w3_w1_weight(
+        self,
+        *,
+        module: torch.nn.Module,
+        w1_weight: torch.Tensor,
+        w3_weight: torch.Tensor,
+        dst_w3_w1_weight: torch.Tensor,
+        already_sharded: bool,
+    ):
         """
         Load w1 and w3 weights for each expert.
         Override this method if you need to preprocess the weights differently.
         """
         device = dst_w3_w1_weight.device
+
+        if not already_sharded:
+            tp_size = module.tp_size
+            tp_rank = module.tp_rank
+            tp_mode_column = TensorParallelMode.COLUMN
+        else:
+            tp_size = 1
+            tp_rank = 0
+            tp_mode_column = None
+
         w1_weight_shard = load_weight_shard(w1_weight,
-                                            module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.COLUMN,
+                                            tp_size,
+                                            tp_rank,
+                                            tp_mode_column,
                                             device=device)
         w3_weight_shard = load_weight_shard(w3_weight,
-                                            module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.COLUMN,
+                                            tp_size,
+                                            tp_rank,
+                                            tp_mode_column,
                                             device=device)
 
         pad_size_inter = module.intermediate_size_per_partition - w3_weight_shard.shape[
@@ -1407,18 +1592,33 @@ class WFP4A16FusedMoEMethod(FusedMoEMethodBase):
         dst_w3_w1_weight.copy_(w31_weight_shard.view(dst_w3_w1_weight.dtype),
                                non_blocking=True)
 
-    def load_expert_w2_weight(self, module: torch.nn.Module,
-                              w2_weight: torch.Tensor,
-                              dst_w2_weight: torch.Tensor):
+    def load_expert_w2_weight(
+        self,
+        *,
+        module: torch.nn.Module,
+        w2_weight: torch.Tensor,
+        dst_w2_weight: torch.Tensor,
+        already_sharded: bool,
+    ):
         """
         Load w2 weight for each expert.
         Override this method if you need to preprocess the weights differently.
         """
         device = dst_w2_weight.device
+
+        if not already_sharded:
+            tp_size = module.tp_size
+            tp_rank = module.tp_rank
+            tp_mode_row = TensorParallelMode.ROW
+        else:
+            tp_size = 1
+            tp_rank = 0
+            tp_mode_row = None
+
         w2_weight_shard = load_weight_shard(w2_weight,
-                                            module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.ROW,
+                                            tp_size,
+                                            tp_rank,
+                                            tp_mode_row,
                                             device=device)
 
         pad_size_hidden = module.hidden_size - w2_weight_shard.shape[0]
@@ -1436,8 +1636,24 @@ class WFP4A16FusedMoEMethod(FusedMoEMethodBase):
         dst_w2_weight.copy_(w2_weight_shard.view(dst_w2_weight.dtype),
                             non_blocking=True)
 
-    def load_quant_scales(self, module: torch.nn.Module, weights: Dict):
+    def load_quant_scales(
+        self,
+        module: torch.nn.Module,
+        weights: Dict,
+        already_sharded: bool,
+    ):
         device = module.fc31_weight_scale.data.device
+
+        if not already_sharded:
+            tp_size = module.tp_size
+            tp_rank = module.tp_rank
+            tp_mode_column = TensorParallelMode.COLUMN
+            tp_mode_row = TensorParallelMode.ROW
+        else:
+            tp_size = 1
+            tp_rank = 0
+            tp_mode_column = None
+            tp_mode_row = None
 
         # fc31 scales
         assert (len(module.interleave) == 2)
@@ -1447,15 +1663,15 @@ class WFP4A16FusedMoEMethod(FusedMoEMethodBase):
         for expert_id in module.initial_local_expert_ids:
             w3_scale_shard = load_weight_shard(
                 weights[f"{expert_id}.w3.weight_scale_inv"],
-                module.tp_size,
-                module.tp_rank,
-                TensorParallelMode.COLUMN,
+                tp_size,
+                tp_rank,
+                tp_mode_column,
                 device=device)
             w1_scale_shard = load_weight_shard(
                 weights[f"{expert_id}.w1.weight_scale_inv"],
-                module.tp_size,
-                module.tp_rank,
-                TensorParallelMode.COLUMN,
+                tp_size,
+                tp_rank,
+                tp_mode_column,
                 device=device)
 
             pad_size_hidden = module.hidden_size // self.group_size - w3_scale_shard.shape[
@@ -1491,9 +1707,9 @@ class WFP4A16FusedMoEMethod(FusedMoEMethodBase):
         for expert_id in module.initial_local_expert_ids:
             w2_scales_shard = load_weight_shard(
                 weights[f"{expert_id}.w2.weight_scale_inv"],
-                module.tp_size,
-                module.tp_rank,
-                TensorParallelMode.ROW,
+                tp_size,
+                tp_rank,
+                tp_mode_row,
                 device=device)
             pad_size_hidden = module.hidden_size - w2_scales_shard.shape[0]
             pad_size_inter = module.intermediate_size_per_partition // self.group_size - w2_scales_shard.shape[
@@ -1677,7 +1893,8 @@ class NVFP4FusedMoEMethod(FusedMoEMethodBase):
                                              module.fc2_input_scale.data,
                                              dst_fc2_alpha[expert_idx])
 
-    def load_quant_scales(self, module: torch.nn.Module, weights: Dict):
+    def load_quant_scales(self, module: torch.nn.Module, weights: Dict,
+                          already_sharded: bool):
         # Step1: Load input scales.
         tmp_fc31_input_scale = torch.empty(module.num_experts,
                                            dtype=torch.float32)
@@ -1779,20 +1996,35 @@ class NVFP4CutlassFusedMoEMethod(NVFP4FusedMoEMethod):
                                self.block_scales_dtype, block_scales_vec_size)
 
     def load_expert_w3_w1_weight_scale_nvfp4(
-            self, module: torch.nn.Module, w1_weight_scale: torch.Tensor,
-            w3_weight_scale: torch.Tensor,
-            dst_w3_w1_weight_scale: torch.Tensor):
+        self,
+        *,
+        module: torch.nn.Module,
+        w1_weight_scale: torch.Tensor,
+        w3_weight_scale: torch.Tensor,
+        dst_w3_w1_weight_scale: torch.Tensor,
+        already_sharded: bool,
+    ):
         # device don't have to be 'cuda', e.g. 'cpu' for online EPLB
         device = dst_w3_w1_weight_scale.device
+
+        if not already_sharded:
+            tp_size = module.tp_size
+            tp_rank = module.tp_rank
+            tp_mode_column = TensorParallelMode.COLUMN
+        else:
+            tp_size = 1
+            tp_rank = 0
+            tp_mode_column = None
+
         w1_weight_scale = load_weight_shard(w1_weight_scale,
-                                            module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.COLUMN,
+                                            tp_size,
+                                            tp_rank,
+                                            tp_mode_column,
                                             device=device)
         w3_weight_scale = load_weight_shard(w3_weight_scale,
-                                            module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.COLUMN,
+                                            tp_size,
+                                            tp_rank,
+                                            tp_mode_column,
                                             device=device)
         # Keep weights in device buffer
         # w3
@@ -1819,15 +2051,30 @@ class NVFP4CutlassFusedMoEMethod(NVFP4FusedMoEMethod):
 
         dst_w3_w1_weight_scale.copy_(dst_w3_w1_weight_scale_interleaved)
 
-    def load_expert_w2_weight_scale_nvfp4(self, module: torch.nn.Module,
-                                          w2_weight_scale: torch.Tensor,
-                                          dst_w2_weight_scale: torch.Tensor):
+    def load_expert_w2_weight_scale_nvfp4(
+        self,
+        *,
+        module: torch.nn.Module,
+        w2_weight_scale: torch.Tensor,
+        dst_w2_weight_scale: torch.Tensor,
+        already_sharded: bool,
+    ):
         # device don't have to be 'cuda', e.g. 'cpu' for online EPLB
         device = dst_w2_weight_scale.device
+
+        if not already_sharded:
+            tp_size = module.tp_size
+            tp_rank = module.tp_rank
+            tp_mode_row = TensorParallelMode.ROW
+        else:
+            tp_size = 1
+            tp_rank = 0
+            tp_mode_row = None
+
         w2_weight_scale = load_weight_shard(w2_weight_scale,
-                                            module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.ROW,
+                                            tp_size,
+                                            tp_rank,
+                                            tp_mode_row,
                                             device=device)
         # Keep weights in device buffer
         dst_w2_weight_scale.copy_(
@@ -1869,21 +2116,36 @@ class NVFP4TRTLLMGenFusedMoEMethod(NVFP4FusedMoEMethod):
     def setup_quant_scales(self, module: torch.nn.Module):
         module.quant_scales = tuple()
 
-    def load_expert_w3_w1_weight(self, module: torch.nn.Module,
-                                 w1_weight: torch.Tensor,
-                                 w3_weight: torch.Tensor,
-                                 dst_w3_w1_weight: torch.Tensor):
+    def load_expert_w3_w1_weight(
+        self,
+        *,
+        module: torch.nn.Module,
+        w1_weight: torch.Tensor,
+        w3_weight: torch.Tensor,
+        dst_w3_w1_weight: torch.Tensor,
+        already_sharded: bool,
+    ):
         device = dst_w3_w1_weight.device
         assert device.type == "cuda"
+
+        if not already_sharded:
+            tp_size = module.tp_size
+            tp_rank = module.tp_rank
+            tp_mode_column = TensorParallelMode.COLUMN
+        else:
+            tp_size = 1
+            tp_rank = 0
+            tp_mode_column = None
+
         w1_weight_shard = load_weight_shard(w1_weight,
-                                            module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.COLUMN,
+                                            tp_size,
+                                            tp_rank,
+                                            tp_mode_column,
                                             device=device)
         w3_weight_shard = load_weight_shard(w3_weight,
-                                            module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.COLUMN,
+                                            tp_size,
+                                            tp_rank,
+                                            tp_mode_column,
                                             device=device)
 
         # FIXME: this depends on the kernel internals
@@ -1909,15 +2171,30 @@ class NVFP4TRTLLMGenFusedMoEMethod(NVFP4FusedMoEMethod):
             dst_w3_w1_weight.dtype),
                                non_blocking=True)
 
-    def load_expert_w2_weight(self, module: torch.nn.Module,
-                              w2_weight: torch.Tensor,
-                              dst_w2_weight: torch.Tensor):
+    def load_expert_w2_weight(
+        self,
+        *,
+        module: torch.nn.Module,
+        w2_weight: torch.Tensor,
+        dst_w2_weight: torch.Tensor,
+        already_sharded: bool,
+    ):
         device = dst_w2_weight.device
         assert device.type == "cuda"
+
+        if not already_sharded:
+            tp_size = module.tp_size
+            tp_rank = module.tp_rank
+            tp_mode_row = TensorParallelMode.ROW
+        else:
+            tp_size = 1
+            tp_rank = 0
+            tp_mode_row = None
+
         w2_weight_shard = load_weight_shard(w2_weight,
-                                            module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.ROW,
+                                            tp_size,
+                                            tp_rank,
+                                            tp_mode_row,
                                             device=device)
 
         # FIXME: this depends on the kernel internals
@@ -1940,22 +2217,34 @@ class NVFP4TRTLLMGenFusedMoEMethod(NVFP4FusedMoEMethod):
 
     def load_expert_w3_w1_weight_scale_nvfp4(
             self,
+            *,
             module: torch.nn.Module,
             w1_weight_scale: torch.Tensor,
             w3_weight_scale: torch.Tensor,
             dst_w3_w1_weight_scale: torch.Tensor,
+            already_sharded: bool,
             num_elts_per_sf: int = 16):
         device = dst_w3_w1_weight_scale.device
         assert device.type == "cuda"
+
+        if not already_sharded:
+            tp_size = module.tp_size
+            tp_rank = module.tp_rank
+            tp_mode_column = TensorParallelMode.COLUMN
+        else:
+            tp_size = 1
+            tp_rank = 0
+            tp_mode_column = None
+
         w1_weight_scale = load_weight_shard(w1_weight_scale,
-                                            module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.COLUMN,
+                                            tp_size,
+                                            tp_rank,
+                                            tp_mode_column,
                                             device=device)
         w3_weight_scale = load_weight_shard(w3_weight_scale,
-                                            module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.COLUMN,
+                                            tp_size,
+                                            tp_rank,
+                                            tp_mode_column,
                                             device=device)
         # Keep weights in device buffer
         # w3
@@ -1999,16 +2288,28 @@ class NVFP4TRTLLMGenFusedMoEMethod(NVFP4FusedMoEMethod):
                 self.block_scales_dtype).reshape(orig_shape))
 
     def load_expert_w2_weight_scale_nvfp4(self,
+                                          *,
                                           module: torch.nn.Module,
                                           w2_weight_scale: torch.Tensor,
                                           dst_w2_weight_scale: torch.Tensor,
+                                          already_sharded: bool,
                                           num_elts_per_sf: int = 16):
         device = dst_w2_weight_scale.device
         assert device.type == "cuda"
+
+        if not already_sharded:
+            tp_size = module.tp_size
+            tp_rank = module.tp_rank
+            tp_mode_row = TensorParallelMode.ROW
+        else:
+            tp_size = 1
+            tp_rank = 0
+            tp_mode_row = None
+
         w2_weight_scale = load_weight_shard(w2_weight_scale,
-                                            module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.ROW,
+                                            tp_size,
+                                            tp_rank,
+                                            tp_mode_row,
                                             device=device)
         # Keep weights in device buffer
         dst_w2_weight_scale.copy_(
@@ -2040,8 +2341,13 @@ class NVFP4TRTLLMGenFusedMoEMethod(NVFP4FusedMoEMethod):
             processed_w2_weight_scale.view(
                 self.block_scales_dtype).reshape(orig_shape))
 
-    def load_quant_scales(self, module: torch.nn.Module, weights: Dict):
-        super().load_quant_scales(module, weights)
+    def load_quant_scales(
+        self,
+        module: torch.nn.Module,
+        weights: Dict,
+        already_sharded: bool,
+    ):
+        super().load_quant_scales(module, weights, already_sharded)
 
         # last step: load fc31_scale_c
         module.fc31_scale_c.data.copy_(module.fc2_input_scale.data *
@@ -2068,18 +2374,30 @@ class W4A8NVFP4FP8TRTLLMGenFusedMoEMethod(NVFP4TRTLLMGenFusedMoEMethod):
         self.setup_quant_scales(module)
 
     def load_expert_w3_w1_weight_scale_nvfp4(
-            self, module: torch.nn.Module, w1_weight_scale: torch.Tensor,
-            w3_weight_scale: torch.Tensor,
-            dst_w3_w1_weight_scale: torch.Tensor):
-        return super().load_expert_w3_w1_weight_scale_nvfp4(
-            module, w1_weight_scale, w3_weight_scale, dst_w3_w1_weight_scale,
-            32)
+        self,
+        *,
+        module: torch.nn.Module,
+        w1_weight_scale: torch.Tensor,
+        w3_weight_scale: torch.Tensor,
+        dst_w3_w1_weight_scale: torch.Tensor,
+        already_sharded: bool,
+    ):
+        super().load_expert_w3_w1_weight_scale_nvfp4(module, w1_weight_scale,
+                                                     w3_weight_scale,
+                                                     dst_w3_w1_weight_scale,
+                                                     already_sharded, 32)
 
-    def load_expert_w2_weight_scale_nvfp4(self, module: torch.nn.Module,
-                                          w2_weight_scale: torch.Tensor,
-                                          dst_w2_weight_scale: torch.Tensor):
-        return super().load_expert_w2_weight_scale_nvfp4(
-            module, w2_weight_scale, dst_w2_weight_scale, 32)
+    def load_expert_w2_weight_scale_nvfp4(
+        self,
+        *,
+        module: torch.nn.Module,
+        w2_weight_scale: torch.Tensor,
+        dst_w2_weight_scale: torch.Tensor,
+        already_sharded: bool,
+    ):
+        super().load_expert_w2_weight_scale_nvfp4(module, w2_weight_scale,
+                                                  dst_w2_weight_scale,
+                                                  already_sharded, 32)
 
 
 def _get_weight_alignment(weight_alignment, scaling_vector_size, tp_size,
@@ -2207,12 +2525,14 @@ class MXFP4WeightFusedMoEMethod(FusedMoEMethodBase):
             self.load_expert_w2_weight_scale_mxfp4(
                 module, w2_weight_scale, dst_w2_weight_scale[expert_idx])
 
-    def load_quant_scales(self, module: torch.nn.Module, weights: Dict):
+    def load_quant_scales(self, module: torch.nn.Module, weights: Dict,
+                          already_sharded: bool):
         # Step1: Load weight block scales.
         self.load_all_mxfp4_weight_scales(module, weights,
                                           module.initial_local_expert_ids,
                                           module.w3_w1_weight_scale.data,
-                                          module.w2_weight_scale.data)
+                                          module.w2_weight_scale.data,
+                                          already_sharded)
 
         # Step 2: if needed, load into shared
         if self.need_load_shared_weights(module):
@@ -2260,10 +2580,24 @@ class MXFP4WeightCutlassFusedMoEMethod(MXFP4WeightFusedMoEMethod):
                                self.block_scales_dtype, block_scales_vec_size,
                                self.weight_alignment)
 
-    def load_expert_w3_w1_weight(self, module: torch.nn.Module,
-                                 w1_weight: torch.Tensor,
-                                 w3_weight: torch.Tensor,
-                                 dst_w3_w1_weight: torch.Tensor):
+    def load_expert_w3_w1_weight(
+        self,
+        *,
+        module: torch.nn.Module,
+        w1_weight: torch.Tensor,
+        w3_weight: torch.Tensor,
+        dst_w3_w1_weight: torch.Tensor,
+        already_sharded: bool,
+    ):
+        if not already_sharded:
+            tp_size = module.tp_size
+            tp_rank = module.tp_rank
+            tp_mode_column = TensorParallelMode.COLUMN
+        else:
+            tp_size = 1
+            tp_rank = 0
+            tp_mode_column = None
+
         # We pad before the sharding. This is done to avoid fractional scaling factors
         # per shard.
         #
@@ -2275,8 +2609,8 @@ class MXFP4WeightCutlassFusedMoEMethod(MXFP4WeightFusedMoEMethod):
         # while it should've loaded 22nd for the first 16 elements only.
         # We pad the weights before the sharding to avoid this issue.
         alignment = _get_weight_alignment(self.weight_alignment,
-                                          module.scaling_vector_size,
-                                          module.tp_size, w1_weight.shape[0])
+                                          module.scaling_vector_size, tp_size,
+                                          w1_weight.shape[0])
         if len(w1_weight.shape) == 2:
             # Pad weights
             # We already satisfy alignment factor of 2 for we pack two MXFP4 into Uint8.
@@ -2295,30 +2629,42 @@ class MXFP4WeightCutlassFusedMoEMethod(MXFP4WeightFusedMoEMethod):
             w1_weight = maybe_pad_for_mxfp4(w1_weight, alignment)
             w3_weight = maybe_pad_for_mxfp4(w3_weight, alignment)
 
-        w1_weight_shard = load_weight_shard(w1_weight, module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.COLUMN)
-        w3_weight_shard = load_weight_shard(w3_weight, module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.COLUMN)
+        w1_weight_shard = load_weight_shard(w1_weight, tp_size, tp_rank,
+                                            tp_mode_column)
+        w3_weight_shard = load_weight_shard(w3_weight, tp_size, tp_rank,
+                                            tp_mode_column)
 
         w31_weight_shard = torch.cat([w3_weight_shard, w1_weight_shard], dim=0)
         dst_w3_w1_weight.copy_(w31_weight_shard.view(dst_w3_w1_weight.dtype),
                                non_blocking=True)
 
     # Helper function
-    def load_expert_w2_weight(self, module: torch.nn.Module,
-                              w2_weight: torch.Tensor,
-                              dst_w2_weight: torch.Tensor):
+    def load_expert_w2_weight(
+        self,
+        *,
+        module: torch.nn.Module,
+        w2_weight: torch.Tensor,
+        dst_w2_weight: torch.Tensor,
+        already_sharded: bool,
+    ):
         """
         Load w2 weight for each expert.
         Override this method if you need to preprocess the weights differently.
         """
+        if not already_sharded:
+            tp_size = module.tp_size
+            tp_rank = module.tp_rank
+            tp_mode_row = TensorParallelMode.ROW
+        else:
+            tp_size = 1
+            tp_rank = 0
+            tp_mode_row = None
+
         shard_w2_weight_dim = 2 * w2_weight.shape[1] if len(
             w2_weight.shape) == 2 else w2_weight.shape[0]
         alignment = _get_weight_alignment(self.weight_alignment,
-                                          module.scaling_vector_size,
-                                          module.tp_size, shard_w2_weight_dim)
+                                          module.scaling_vector_size, tp_size,
+                                          shard_w2_weight_dim)
 
         if len(w2_weight.shape) == 2:
             assert w2_weight.dtype == torch.uint8
@@ -2329,22 +2675,34 @@ class MXFP4WeightCutlassFusedMoEMethod(MXFP4WeightFusedMoEMethod):
             assert len(w2_weight.shape) == 1
             w2_weight = maybe_pad_for_mxfp4(w2_weight, self.weight_alignment)
 
-        w2_weight_shard = load_weight_shard(w2_weight, module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.ROW)
+        w2_weight_shard = load_weight_shard(w2_weight, tp_size, tp_rank,
+                                            tp_mode_row)
 
         dst_w2_weight.copy_(w2_weight_shard.view(dst_w2_weight.dtype),
                             non_blocking=True)
 
     def load_expert_w3_w1_weight_scale_mxfp4(
-            self, module: torch.nn.Module, w1_weight_scale: torch.Tensor,
-            w3_weight_scale: torch.Tensor,
-            dst_w3_w1_weight_scale: torch.Tensor):
+        self,
+        *,
+        module: torch.nn.Module,
+        w1_weight_scale: torch.Tensor,
+        w3_weight_scale: torch.Tensor,
+        dst_w3_w1_weight_scale: torch.Tensor,
+        already_sharded: bool,
+    ):
         device = dst_w3_w1_weight_scale.device
 
+        if not already_sharded:
+            tp_size = module.tp_size
+            tp_rank = module.tp_rank
+            tp_mode_column = TensorParallelMode.COLUMN
+        else:
+            tp_size = 1
+            tp_rank = 0
+            tp_mode_column = None
+
         alignment = _get_weight_alignment(self.weight_alignment,
-                                          module.scaling_vector_size,
-                                          module.tp_size,
+                                          module.scaling_vector_size, tp_size,
                                           w3_weight_scale.shape[0])
 
         w1_weight_scale = maybe_pad_for_mxfp4(
@@ -2355,14 +2713,14 @@ class MXFP4WeightCutlassFusedMoEMethod(MXFP4WeightFusedMoEMethod):
             self.weight_alignment // module.scaling_vector_size, alignment)
 
         w1_weight_scale = load_weight_shard(w1_weight_scale,
-                                            module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.COLUMN,
+                                            tp_size,
+                                            tp_rank,
+                                            tp_mode_column,
                                             device=device)
         w3_weight_scale = load_weight_shard(w3_weight_scale,
-                                            module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.COLUMN,
+                                            tp_size,
+                                            tp_rank,
+                                            tp_mode_column,
                                             device=device)
 
         # Keep weights in device buffer
@@ -2380,14 +2738,27 @@ class MXFP4WeightCutlassFusedMoEMethod(MXFP4WeightFusedMoEMethod):
                 dst_w3_w1_weight_scale.view(float4_sf_dtype)).view(
                     self.block_scales_dtype).reshape(orig_shape))
 
-    def load_expert_w2_weight_scale_mxfp4(self, module: torch.nn.Module,
-                                          w2_weight_scale: torch.Tensor,
-                                          dst_w2_weight_scale: torch.Tensor):
+    def load_expert_w2_weight_scale_mxfp4(
+        self,
+        *,
+        module: torch.nn.Module,
+        w2_weight_scale: torch.Tensor,
+        dst_w2_weight_scale: torch.Tensor,
+        already_sharded: bool,
+    ):
         device = dst_w2_weight_scale.device
 
+        if not already_sharded:
+            tp_size = module.tp_size
+            tp_rank = module.tp_rank
+            tp_mode_row = TensorParallelMode.ROW
+        else:
+            tp_size = 1
+            tp_rank = 0
+            tp_mode_row = None
+
         alignment = _get_weight_alignment(self.weight_alignment,
-                                          module.scaling_vector_size,
-                                          module.tp_size,
+                                          module.scaling_vector_size, tp_size,
                                           w2_weight_scale.shape[-1])
 
         w2_weight_scale = maybe_pad_for_mxfp4(
@@ -2395,9 +2766,9 @@ class MXFP4WeightCutlassFusedMoEMethod(MXFP4WeightFusedMoEMethod):
             self.weight_alignment)
 
         w2_weight_scale = load_weight_shard(w2_weight_scale,
-                                            module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.ROW,
+                                            tp_size,
+                                            tp_rank,
+                                            tp_mode_row,
                                             device=device)
 
         # Keep weights in device buffer
@@ -2428,12 +2799,13 @@ class W4A8MXFP4MXFP8CutlassFusedMoEMethod(MXFP4WeightCutlassFusedMoEMethod):
 
         self.setup_quant_scales(module)
 
-    def load_quant_scales(self, module: torch.nn.Module, weights: Dict):
+    def load_quant_scales(self, module: torch.nn.Module, weights: Dict,
+                          already_sharded: bool):
         # Step1: Load input scales.
         module.fake_input_scale.fill_(1.)
 
         # Step2: Load weight block scales.
-        super().load_quant_scales(module, weights)
+        super().load_quant_scales(module, weights, already_sharded)
 
     def setup_quant_scales(self, module: torch.nn.Module):
         module.quant_scales = FusedMoEQuantScalesW4A8MXFP4MXFP8(
@@ -2481,7 +2853,8 @@ class W4A8MXFP4FP8CutlassFusedMoEMethod(MXFP4WeightCutlassFusedMoEMethod):
             self, w2_input_scale, dst_fc2_input_scale: torch.Tensor):
         dst_fc2_input_scale.copy_(w2_input_scale[...].reshape([]))
 
-    def load_quant_scales(self, module: torch.nn.Module, weights: Dict):
+    def load_quant_scales(self, module: torch.nn.Module, weights: Dict,
+                          already_sharded: bool):
         # Step1: Load input scales.
         tmp_fc31_input_scale = torch.empty(module.num_experts,
                                            dtype=torch.float32)
@@ -2517,7 +2890,7 @@ class W4A8MXFP4FP8CutlassFusedMoEMethod(MXFP4WeightCutlassFusedMoEMethod):
         module.fc2_input_dequant.data.copy_(tmp_fc2_input_scale.max())
 
         # Step2: Load weight block scales.
-        super().load_quant_scales(module, weights)
+        super().load_quant_scales(module, weights, already_sharded)
 
     def setup_quant_scales(self, module: torch.nn.Module):
         module.quant_scales = FusedMoEQuantScalesW4A8MXFP4FP8(
@@ -2554,12 +2927,26 @@ class MXFP4WeightTRTLLMGenFusedMoEMethod(MXFP4WeightFusedMoEMethod):
     def setup_quant_scales(self, module: torch.nn.Module):
         module.quant_scales = tuple()
 
-    def load_expert_w3_w1_weight(self, module: torch.nn.Module,
-                                 w1_weight: torch.Tensor,
-                                 w3_weight: torch.Tensor,
-                                 dst_w3_w1_weight: torch.Tensor):
+    def load_expert_w3_w1_weight(
+        self,
+        *,
+        module: torch.nn.Module,
+        w1_weight: torch.Tensor,
+        w3_weight: torch.Tensor,
+        dst_w3_w1_weight: torch.Tensor,
+        already_sharded: bool,
+    ):
         device = dst_w3_w1_weight.device
         assert device.type == "cuda"
+
+        if not already_sharded:
+            tp_size = module.tp_size
+            tp_rank = module.tp_rank
+            tp_mode_column = TensorParallelMode.COLUMN
+        else:
+            tp_size = 1
+            tp_rank = 0
+            tp_mode_column = None
 
         # We pad before the sharding. This is done to avoid fractional scaling factors
         # per shard.
@@ -2572,8 +2959,8 @@ class MXFP4WeightTRTLLMGenFusedMoEMethod(MXFP4WeightFusedMoEMethod):
         # while it should've loaded 22nd for the first 16 elements only.
         # We pad the weights before the sharding to avoid this issue.
         alignment = _get_weight_alignment(self.weight_alignment,
-                                          module.scaling_vector_size,
-                                          module.tp_size, w1_weight.shape[0])
+                                          module.scaling_vector_size, tp_size,
+                                          w1_weight.shape[0])
         if len(w1_weight.shape) == 2:
             # Pad weights
             # We already satisfy alignment factor of 2 for we pack two MXFP4 into Uint8.
@@ -2593,14 +2980,14 @@ class MXFP4WeightTRTLLMGenFusedMoEMethod(MXFP4WeightFusedMoEMethod):
             w3_weight = maybe_pad_for_mxfp4(w3_weight, alignment).float()
 
         w1_weight_shard = load_weight_shard(w1_weight,
-                                            module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.COLUMN,
+                                            tp_size,
+                                            tp_rank,
+                                            tp_mode_column,
                                             device=device)
         w3_weight_shard = load_weight_shard(w3_weight,
-                                            module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.COLUMN,
+                                            tp_size,
+                                            tp_rank,
+                                            tp_mode_column,
                                             device=device)
         # FIXME: this depends on the kernel internals
         epilogue_tile_m = 128
@@ -2623,17 +3010,31 @@ class MXFP4WeightTRTLLMGenFusedMoEMethod(MXFP4WeightFusedMoEMethod):
             dst_w3_w1_weight.dtype),
                                non_blocking=True)
 
-    def load_expert_w2_weight(self, module: torch.nn.Module,
-                              w2_weight: torch.Tensor,
-                              dst_w2_weight: torch.Tensor):
+    def load_expert_w2_weight(
+        self,
+        *,
+        module: torch.nn.Module,
+        w2_weight: torch.Tensor,
+        dst_w2_weight: torch.Tensor,
+        already_sharded: bool,
+    ):
         device = dst_w2_weight.device
         assert device.type == "cuda"
+
+        if not already_sharded:
+            tp_size = module.tp_size
+            tp_rank = module.tp_rank
+            tp_mode_row = TensorParallelMode.ROW
+        else:
+            tp_size = 1
+            tp_rank = 0
+            tp_mode_row = None
 
         shard_w2_weight_dim = 2 * w2_weight.shape[1] if len(
             w2_weight.shape) == 2 else w2_weight.shape[0]
         alignment = _get_weight_alignment(self.weight_alignment,
-                                          module.scaling_vector_size,
-                                          module.tp_size, shard_w2_weight_dim)
+                                          module.scaling_vector_size, tp_size,
+                                          shard_w2_weight_dim)
 
         if len(w2_weight.shape) == 2:
             assert w2_weight.dtype == torch.uint8
@@ -2645,12 +3046,12 @@ class MXFP4WeightTRTLLMGenFusedMoEMethod(MXFP4WeightFusedMoEMethod):
             # The bias is applied at each TP rank before the final accumulation.
             assert len(w2_weight.shape) == 1
             w2_weight = maybe_pad_for_mxfp4(
-                w2_weight, self.weight_alignment).float() / module.tp_size
+                w2_weight, self.weight_alignment).float() / tp_size
 
         w2_weight_shard = load_weight_shard(w2_weight,
-                                            module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.ROW,
+                                            tp_size,
+                                            tp_rank,
+                                            tp_mode_row,
                                             device=device)
 
         # FIXME: this depends on the kernel internals
@@ -2672,15 +3073,28 @@ class MXFP4WeightTRTLLMGenFusedMoEMethod(MXFP4WeightFusedMoEMethod):
                             non_blocking=True)
 
     def load_expert_w3_w1_weight_scale_mxfp4(
-            self, module: torch.nn.Module, w1_weight_scale: torch.Tensor,
-            w3_weight_scale: torch.Tensor,
-            dst_w3_w1_weight_scale: torch.Tensor):
+        self,
+        *,
+        module: torch.nn.Module,
+        w1_weight_scale: torch.Tensor,
+        w3_weight_scale: torch.Tensor,
+        dst_w3_w1_weight_scale: torch.Tensor,
+        already_sharded: bool,
+    ):
         device = dst_w3_w1_weight_scale.device
         assert device.type == "cuda"
 
+        if not already_sharded:
+            tp_size = module.tp_size
+            tp_rank = module.tp_rank
+            tp_mode_column = TensorParallelMode.COLUMN
+        else:
+            tp_size = 1
+            tp_rank = 0
+            tp_mode_column = None
+
         alignment = _get_weight_alignment(self.weight_alignment,
-                                          module.scaling_vector_size,
-                                          module.tp_size,
+                                          module.scaling_vector_size, tp_size,
                                           w3_weight_scale.shape[0])
 
         w1_weight_scale = maybe_pad_for_mxfp4(
@@ -2691,14 +3105,14 @@ class MXFP4WeightTRTLLMGenFusedMoEMethod(MXFP4WeightFusedMoEMethod):
             self.weight_alignment // module.scaling_vector_size, alignment)
 
         w1_weight_scale = load_weight_shard(w1_weight_scale,
-                                            module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.COLUMN,
+                                            tp_size,
+                                            tp_rank,
+                                            tp_mode_column,
                                             device=device)
         w3_weight_scale = load_weight_shard(w3_weight_scale,
-                                            module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.COLUMN,
+                                            tp_size,
+                                            tp_rank,
+                                            tp_mode_column,
                                             device=device)
 
         # Keep weights in device buffer
@@ -2735,15 +3149,28 @@ class MXFP4WeightTRTLLMGenFusedMoEMethod(MXFP4WeightFusedMoEMethod):
             processed_w3_w1_weight_scale.view(
                 self.block_scales_dtype).reshape(orig_shape))
 
-    def load_expert_w2_weight_scale_mxfp4(self, module: torch.nn.Module,
-                                          w2_weight_scale: torch.Tensor,
-                                          dst_w2_weight_scale: torch.Tensor):
+    def load_expert_w2_weight_scale_mxfp4(
+        self,
+        *,
+        module: torch.nn.Module,
+        w2_weight_scale: torch.Tensor,
+        dst_w2_weight_scale: torch.Tensor,
+        already_sharded: bool,
+    ):
         device = dst_w2_weight_scale.device
         assert device.type == "cuda"
 
+        if not already_sharded:
+            tp_size = module.tp_size
+            tp_rank = module.tp_rank
+            tp_mode_row = TensorParallelMode.ROW
+        else:
+            tp_size = 1
+            tp_rank = 0
+            tp_mode_row = None
+
         alignment = _get_weight_alignment(self.weight_alignment,
-                                          module.scaling_vector_size,
-                                          module.tp_size,
+                                          module.scaling_vector_size, tp_size,
                                           w2_weight_scale.shape[-1])
 
         w2_weight_scale = maybe_pad_for_mxfp4(
@@ -2751,9 +3178,9 @@ class MXFP4WeightTRTLLMGenFusedMoEMethod(MXFP4WeightFusedMoEMethod):
             self.weight_alignment)
 
         w2_weight_scale = load_weight_shard(w2_weight_scale,
-                                            module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.ROW,
+                                            tp_size,
+                                            tp_rank,
+                                            tp_mode_row,
                                             device=device)
 
         # Keep weights in device buffer
@@ -2822,7 +3249,8 @@ class W4A8MXFP4FP8TRTLLMGenFusedMoEMethod(MXFP4WeightTRTLLMGenFusedMoEMethod):
         dst_fc31_input_scale.copy_(w1_input_scale)
         dst_fc2_input_scale.copy_(w2_input_scale)
 
-    def load_quant_scales(self, module: torch.nn.Module, weights: Dict):
+    def load_quant_scales(self, module: torch.nn.Module, weights: Dict,
+                          already_sharded: bool):
         # Step1: Load input scales.
         tmp_fc31_input_scale = torch.empty(module.num_experts,
                                            dtype=torch.float32)
@@ -2854,7 +3282,7 @@ class W4A8MXFP4FP8TRTLLMGenFusedMoEMethod(MXFP4WeightTRTLLMGenFusedMoEMethod):
         module.fc2_input_dequant.data.copy_(tmp_fc2_input_scale.max())
 
         # Step2: Load weight block scales.
-        super().load_quant_scales(module, weights)
+        super().load_quant_scales(module, weights, already_sharded)
 
 
 class W4A8MXFP4MXFP8TRTLLMGenFusedMoEMethod(MXFP4WeightTRTLLMGenFusedMoEMethod):
@@ -2862,6 +3290,7 @@ class W4A8MXFP4MXFP8TRTLLMGenFusedMoEMethod(MXFP4WeightTRTLLMGenFusedMoEMethod):
     def create_weights(self, module: torch.nn.Module):
         super().create_weights(module)
 
-    def load_quant_scales(self, module: torch.nn.Module, weights: Dict):
+    def load_quant_scales(self, module: torch.nn.Module, weights: Dict,
+                          already_sharded: bool):
         # Load weight block scales.
-        super().load_quant_scales(module, weights)
+        super().load_quant_scales(module, weights, already_sharded)

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -2325,7 +2325,7 @@ class Linear(nn.Module):
 
         return output
 
-    def load_weights(self, weights: List[Dict], already_sharded: bool):
+    def load_weights(self, weights: List[Dict], already_sharded: bool = False):
         assert self._weights_created
 
         weight_mode = self.weights_loading_config.weight_mode

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -237,9 +237,10 @@ class ModelLoader:
             if load_format == LoadFormat.AUTO:
                 if hasattr(model, 'llm_checkpoint_dir'):
                     weights = checkpoint_loader.load_weights(
-                        model.llm_checkpoint_dir)
+                        model.llm_checkpoint_dir, mapping=self.mapping)
                 else:
-                    weights = checkpoint_loader.load_weights(checkpoint_dir)
+                    weights = checkpoint_loader.load_weights(
+                        checkpoint_dir, mapping=self.mapping)
 
                 weight_mapper = checkpoint_loader.get_initialized_weight_mapper(
                     model, config)
@@ -249,7 +250,8 @@ class ModelLoader:
                 if self.spec_config is not None and self.spec_config.spec_dec_mode.need_load_draft_weights(
                 ):
                     weights = checkpoint_loader.load_weights(
-                        self.spec_config.speculative_model_dir)
+                        self.spec_config.speculative_model_dir,
+                        mapping=self.mapping)
                     self._call_load_weights(model.load_draft_weights, weights,
                                             weight_mapper)
 

--- a/tests/integration/test_lists/test-db/l0_dgx_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_h100.yml
@@ -19,6 +19,7 @@ l0_dgx_h100:
   - unittest/_torch/multi_gpu -m "not post_merge" TIMEOUT (90)
   - unittest/_torch/auto_deploy/unit/multigpu
   - unittest/_torch/modeling/test_modeling_pixtral.py::test_tensor_parallelism
+  - unittest/_torch/models/checkpoints/custom/test_sharded_weight_loader.py
   # ------------- Disaggregated serving tests ---------------
   - accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_eagle3[eagle3_one_model=False-overlap_scheduler=False]
   - accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_eagle3[eagle3_one_model=True-overlap_scheduler=True]

--- a/tests/unittest/_torch/models/checkpoints/custom/test_sharded_weight_loader.py
+++ b/tests/unittest/_torch/models/checkpoints/custom/test_sharded_weight_loader.py
@@ -1,0 +1,164 @@
+import glob
+import os
+from pathlib import Path
+from typing import Any, List
+
+import psutil
+import pytest
+import tqdm
+from utils.llm_data import llm_models_root
+
+from tensorrt_llm._torch.models.checkpoints import HfWeightLoader
+from tensorrt_llm._torch.models.checkpoints.hf.checkpoint_loader import HfCheckpointLoader
+from tensorrt_llm._torch.models.checkpoints.hf.config_loader import HfConfigLoader
+from tensorrt_llm._torch.models.checkpoints.hf.weight_mapper import HfWeightMapper
+from tensorrt_llm._torch.models.modeling_utils import (
+    register_checkpoint_weight_loader,
+    register_mapper,
+    run_concurrently,
+)
+from tensorrt_llm._torch.modules.linear import TensorParallelMode, load_weight_shard
+from tensorrt_llm._utils import local_mpi_barrier
+from tensorrt_llm.llmapi.llm import LLM
+from tensorrt_llm.logger import logger
+from tensorrt_llm.mapping import Mapping
+
+
+@register_checkpoint_weight_loader("DUMMY_FORMAT")
+class ShardedWeightLoader(HfWeightLoader):
+    def load_weights(self, checkpoint_dir: str, mapping: Mapping) -> dict[str, Any]:
+        weight_files = glob.glob(f"{checkpoint_dir}/*.safetensors")
+        # Some model checkpoint directories contain not only the sharded safetensors, but one
+        # consolidated tensor. In the presence of both, we favor the former, as there really is no need
+        # to prefetch the (usually) ridiculously large consolidated tensor into memory in such a case.
+        filtered_weight_files = [
+            x for x in weight_files if "consolidated" not in os.path.split(x)[1]
+        ]
+        if len(filtered_weight_files) > 0:
+            weight_files = filtered_weight_files
+        if weight_files:
+            # Prefetch the weight files to CPU memory if the size is less than 90% of the available memory.
+            # This is a heuristic to avoid prefetching files that are too large and causing file cache thrashing.
+            prefetch_size = sum(os.path.getsize(file) for file in weight_files)
+            # If the layer number is overridden, it indicates that only a subset of layers are loaded.
+            # Prefetching all layers is unnecessary.
+            num_layers = int(os.environ.get("TLLM_OVERRIDE_LAYER_NUM", "0"))
+            enable_prefetch = (
+                prefetch_size < psutil.virtual_memory().available * 0.9 and num_layers == 0
+            )
+            if enable_prefetch:
+                logger.info(f"Prefetching {prefetch_size / (1024**3):.2f}GB checkpoint files.")
+                self.prefetch_files(weight_files)
+                # Ensure that all local ranks have finished prefetching before loading weights
+                local_mpi_barrier()
+
+            return self._load_weights_in_parallel(
+                weight_files,
+                self._load_safetensors_file,
+                mapping,
+                "Loading safetensors weights in parallel",
+            )
+
+        weight_files = glob.glob(f"{checkpoint_dir}/*.bin")
+        if not weight_files:
+            weight_files = glob.glob(f"{checkpoint_dir}/*.pth")
+
+        if weight_files:
+            return self._load_weights_in_parallel(
+                weight_files,
+                self._load_bin_or_path_file,
+                mapping,
+                "Loading bin weights in parallel",
+            )
+
+        raise RuntimeError(f"No weight files found in {checkpoint_dir}.")
+
+    def _shard_weights(self, weights: dict[str, Any], mapping: Mapping) -> dict[str, Any]:
+        tp_size = mapping.tp_size
+        tp_rank = mapping.tp_rank
+
+        logger.info(f"Sharding weights for TP size: {tp_size}, TP rank: {tp_rank}")
+
+        for k, v in weights.items():
+            tp_mode = None
+            if "embed_tokens" in k:
+                tp_mode = TensorParallelMode.COLUMN
+            elif "lm_head" in k:
+                tp_mode = TensorParallelMode.COLUMN
+            # elif "norm" in k:
+            #     tp_mode = None
+            elif "self_attn.k_proj" in k:
+                tp_mode = TensorParallelMode.COLUMN
+            elif "self_attn.v_proj" in k:
+                tp_mode = TensorParallelMode.COLUMN
+            elif "self_attn.q_proj" in k:
+                tp_mode = TensorParallelMode.COLUMN
+            elif "self_attn.o_proj" in k:
+                tp_mode = TensorParallelMode.ROW
+            elif "mlp.gate_proj" in k:
+                tp_mode = TensorParallelMode.COLUMN
+            elif "mlp.up_proj" in k:
+                tp_mode = TensorParallelMode.COLUMN
+            elif "mlp.down_proj" in k:
+                tp_mode = TensorParallelMode.ROW
+
+            original_shape = v.shape
+            weights[k] = load_weight_shard(v, tp_size, tp_rank, tp_mode)
+            logger.info(f"Weight {k} has shape {original_shape} -> {weights[k].shape}")
+        return weights
+
+    def _load_weights_in_parallel(
+        self, weight_files: List[str], load_func, mapping: Mapping, description: str
+    ) -> dict[str, Any]:
+        """
+        Load weight files in parallel using the specified loading function.
+
+        Args:
+            weight_files: List of weight file paths
+            load_func: Function to load individual weight files
+            description: Description for the progress bar
+
+        Returns:
+            Dictionary containing all loaded weights
+        """
+        weights = {}
+        pbar = tqdm.tqdm(total=len(weight_files), desc=description)
+
+        # Note that the function is called with a tuple of arguments,
+        # hence we need to wrap the arguments in a tuple via [(w,) for w in weight_files]
+        # specifically the comma right after the w is important to make it a tuple.
+        run_concurrently(
+            load_func, [(w,) for w in weight_files], reduce_func=weights.update, pbar=pbar
+        )
+
+        logger.info(f"Loaded {len(weights)} weights")
+
+        return self._shard_weights(weights, mapping)
+
+
+@register_mapper("DUMMY_FORMAT")
+class ShardedWeightMapper(HfWeightMapper):
+    already_sharded: bool = True
+
+
+def test_sharded_safetensors_checkpoint_loader():
+    """Test that the checkpoint loader can load a sharded safetensors checkpoint."""
+
+    model_dir = Path(llm_models_root()) / "llama-3.2-models/Llama-3.2-1B"
+
+    # Create LLM with the provided model
+    llm = LLM(
+        model=model_dir,
+        backend="pytorch",
+        tensor_parallel_size=2,
+        checkpoint_loader=HfCheckpointLoader(
+            weight_loader=ShardedWeightLoader(),
+            weight_mapper=ShardedWeightMapper(),
+            config_loader=HfConfigLoader(),
+        ),
+    )
+    llm.shutdown()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/unittest/_torch/models/checkpoints/custom/test_sharded_weight_loader.py
+++ b/tests/unittest/_torch/models/checkpoints/custom/test_sharded_weight_loader.py
@@ -138,7 +138,9 @@ class ShardedWeightLoader(HfWeightLoader):
 
 @register_mapper("DUMMY_FORMAT")
 class ShardedWeightMapper(HfWeightMapper):
-    already_sharded: bool = True
+    def __init__(self):
+        super().__init__()
+        self.already_sharded = True
 
 
 def test_sharded_safetensors_checkpoint_loader():

--- a/tests/unittest/_torch/models/checkpoints/hf/test_weight_loader.py
+++ b/tests/unittest/_torch/models/checkpoints/hf/test_weight_loader.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 
 from tensorrt_llm._torch.models.checkpoints import HfWeightLoader
+from tensorrt_llm.mapping import Mapping
 
 
 class MyError(Exception):
@@ -69,7 +70,7 @@ def test_load_weights_ignores_consolidated_ckpt_when_sharded_ckpt_exists(
         mock.patch.object(loader, "prefetch_files") as prefetch_files,
         pytest.raises(MyError),
     ):
-        loader.load_weights(checkpoint_dir=str(checkpoint_dir))
+        loader.load_weights(checkpoint_dir=str(checkpoint_dir), mapping=Mapping())
 
     prefetch_files.assert_called_once()
     prefetched_files = prefetch_files.call_args[0][0]


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

- Modified the `load_weights` method in `BaseCheckpointLoader`, `BaseWeightLoader`, and derived classes to accept a `mapping` parameter.
- Updated documentation to reflect changes in method signatures and added logging for weight loading operations.
- Ensured compatibility across various weight loaders by incorporating the mapping functionality.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
