### PR TITLE
[https://nvbugs/5496705][fix] Fix high IPC overhead with logprobs enabled by removing duplicate sends

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -695,7 +695,7 @@ class TorchSampler(Sampler):
             assert beam == 0, (
                 "The following call relies on beam_width to be 1 - hence the list with a single element"
             )
-            request.py_result.append_log_probs([token_log_probs])
+            request.py_log_probs.append_log_probs([token_log_probs])
 
     def _process_draft_tokens_greedy(
         self,
@@ -1894,7 +1894,7 @@ class TRTLLMSampler(Sampler):
                     }
                 ]
                 cum_log_probs = [cum_log_probs_host[seq_slot]]
-                request.py_result.append_log_probs([log_probs], cum_log_probs)
+                request.py_log_probs.append_log_probs([log_probs], cum_log_probs)
 
         for request in reqs:
             request.py_decoding_iter += 1
@@ -1974,7 +1974,7 @@ class TRTLLMSampler(Sampler):
                     request.set_finished_reason(finish_reason, beam)
 
             if request.py_return_log_probs:
-                request.py_result.append_log_probs(log_probs, cum_log_probs)
+                request.py_log_probs.append_log_probs(log_probs, cum_log_probs)
 
             # Set number of tokens predicted per runtime iteration. Will be > 1 for speculative decoding.
             request.update_num_tokens_per_iteration(
@@ -2052,6 +2052,6 @@ class TRTLLMSampler(Sampler):
                         }
                     )
         if request.py_return_log_probs:
-            request.py_result.set_log_probs(log_probs, cum_log_probs)
+            request.py_log_probs.set_log_probs(log_probs, cum_log_probs)
 
         request.set_generated_tokens(generated_tokens)

--- a/tests/unittest/_torch/executor/test_chunked_logits.py
+++ b/tests/unittest/_torch/executor/test_chunked_logits.py
@@ -95,7 +95,6 @@ class TestPyResult:
                           max_new_tokens=10,
                           use_device_memory=True,
                           streaming=False,
-                          return_log_probs=True,
                           return_context_logits=True,
                           return_generation_logits=True,
                           exclude_last_generation_logits=False,
@@ -105,7 +104,6 @@ class TestPyResult:
         assert result._streaming is False
         assert result._context_logits is not None
         assert result._generation_logits is not None
-        assert result._log_probs is not None
         assert result._mm_embeddings is None
 
     def test_append_logits_no_storage(self, sample_logits):

--- a/tests/unittest/_torch/sampler/test_return_logits.py
+++ b/tests/unittest/_torch/sampler/test_return_logits.py
@@ -107,7 +107,7 @@ def llm(
             yield llm
 
 
-@force_ampere  # Save H100 resource
+# @force_ampere  # Save H100 resource
 @pytest.mark.parametrize("reuse_cache", [False, True])
 @pytest.mark.parametrize("return_log_probs", [False, True])
 # FIXME: sometimes LLM shutdown hangs, might be related to https://nvbugs/5577178


### PR DESCRIPTION
<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Current torch path logic sent the entire logprobs history with every response (in streaming mode), causing severe IPC overhead and performance degradation. This PR fixes the issue by sending only newly generated tokens’ logprobs when required.

In our benchmarking on the Llama-3.1-8B model, enabling logprobs previously caused substantial slowdowns in generation-heavy workloads. For example, with BS=64, ISL=512, OSL=1024, concurrency=64, throughput dropped by **77.5%** compared to runs without logprobs. With this fix, throughput now shows only a 2–3% difference, achieving a **~4.4× throughput improvement** over the previous logprob implementation under the aforementioned setting.

This change targets logprobs in torch path; similar optimizations should later extend to other incremental result types in the current PyResult implementation.

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

Existing logprobs tests are sufficient; no new tests added.

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Streamed log probabilities now support per-beam incremental updates.
  - Results expose log_probs, cum_log_probs, and log_probs_diff_start for easier consumption.
- Refactor
  - Unified log-prob handling through a dedicated result object for clearer, more consistent APIs.
  - Switched to a diff-based accumulation strategy, improving robustness and correctness for streaming and beam search scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->