### PR TITLE
[None][chore] replace print_colored_debug with logger_debug

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_bert.py
+++ b/tensorrt_llm/_torch/models/modeling_bert.py
@@ -4,7 +4,7 @@ import torch
 from torch import nn
 from transformers import BertConfig
 
-from tensorrt_llm.llmapi.utils import print_colored_debug
+from tensorrt_llm.llmapi.utils import logger_debug
 from tensorrt_llm.logger import logger
 
 from ..attention_backend import AttentionMetadata
@@ -309,13 +309,13 @@ class BertForSequenceClassification(nn.Module):
 
         for name, module in self.named_modules():
             if len(module._parameters) > 0:
-                print_colored_debug(f"loading for: {name}")
+                logger_debug(f"loading for: {name}")
                 try:
                     # the provided modules in TRTLLM
                     if hasattr(module, 'load_weights'):
                         module.load_weights(weights=tllm_weights[name])
                     else:
-                        print_colored_debug(f" use copy_ to load {name}")
+                        logger_debug(f" use copy_ to load {name}")
                         module_weights = tllm_weights[name][0]
                         for n, p in module._parameters.items():
                             if p is not None:

--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -19,7 +19,7 @@ from ..builder import ConfigEncoder, Engine, EngineConfig
 from ..llmapi.llm_args import BaseLlmArgs, PybindMirror
 from ..llmapi.tokenizer import TokenizerBase
 from ..llmapi.tracer import global_tracer
-from ..llmapi.utils import _SyncQueue, print_colored_debug
+from ..llmapi.utils import _SyncQueue, logger_debug
 from ..lora_manager import LoraManager
 from ..metrics import RequestEventTiming
 from ..prompt_adapter_manager import PromptAdapterManager
@@ -626,16 +626,15 @@ class AwaitResponseHelper:
         if self.handler_kind is HandlerKind.unknown:
             if not (self.worker.result_queue is not None
                     or self.worker.postproc_queues is not None):
-                print_colored_debug(
-                    f"creating await_response helper for Worker\n",
-                    color="yellow")
+                logger_debug(f"creating await_response helper for Worker\n",
+                             color="yellow")
                 # When ExecutorBindingWorker is used in the main process
                 # aka the single process mode
                 self.handler_kind = HandlerKind.single_process_worker
             elif self.worker.result_queue is not None or self.worker.postproc_queues is not None:
                 # The ExecutorBindingProxy is used
-                print_colored_debug(f"creating await_response helper for IPC\n",
-                                    color="yellow")
+                logger_debug(f"creating await_response helper for IPC\n",
+                             color="yellow")
                 self.handler_kind = HandlerKind.ipc_batched
             else:
                 raise NotImplementedError

--- a/tensorrt_llm/executor/executor.py
+++ b/tensorrt_llm/executor/executor.py
@@ -26,8 +26,8 @@ from ..llmapi.mpi_session import (MpiSession, external_mpi_comm_available,
                                   need_spawn_mpi_workers)
 from ..llmapi.tokenizer import TokenizerBase
 from ..llmapi.utils import (AsyncQueue, enable_llm_debug,
-                            enable_worker_single_process_for_tp1, print_colored,
-                            print_colored_debug)
+                            enable_worker_single_process_for_tp1, logger_debug,
+                            print_colored)
 from ..sampling_params import (BatchedLogitsProcessor, LogprobParams,
                                SamplingParams)
 from ..scheduling_params import SchedulingParams
@@ -448,7 +448,7 @@ class GenerationExecutor(ABC):
         )
 
         if postproc_worker_config.enabled:
-            print_colored_debug(
+            logger_debug(
                 f"Using {postproc_worker_config.num_postprocess_workers} postprocess parallel processes.\n",
                 "green")
 

--- a/tensorrt_llm/executor/ipc.py
+++ b/tensorrt_llm/executor/ipc.py
@@ -14,8 +14,8 @@ import zmq.asyncio
 from tensorrt_llm.logger import logger
 
 from .._utils import nvtx_mark, nvtx_range_debug
-from ..llmapi.utils import (ManagedThread, enable_llm_debug, print_colored,
-                            print_colored_debug)
+from ..llmapi.utils import (ManagedThread, enable_llm_debug, logger_debug,
+                            print_colored)
 
 
 class ZeroMqQueue:
@@ -81,7 +81,7 @@ class ZeroMqQueue:
             )  # Binds to the address and occupy a port immediately
             self.address_endpoint = self.socket.getsockopt(
                 zmq.LAST_ENDPOINT).decode()
-            print_colored_debug(
+            logger_debug(
                 f"Server [{name}] bound to {self.address_endpoint} in {self.socket_type_str[socket_type]}\n",
                 "green")
 
@@ -98,7 +98,7 @@ class ZeroMqQueue:
         self._setup_done = True
 
         if not self.is_server:
-            print_colored_debug(
+            logger_debug(
                 f"Client [{self.name}] connecting to {self.address_endpoint} in {self.socket_type_str[self.socket_type]}\n",
                 "green")
             self.socket.connect(self.address_endpoint)

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -16,8 +16,7 @@ from ..llmapi.mpi_session import (MpiCommSession, MpiPoolSession, MpiSession,
                                   RemoteMpiCommSessionClient)
 from ..llmapi.tracer import enable_llm_tracer, get_tracer, global_tracer
 from ..llmapi.utils import (AsyncQueue, ManagedThread, _SyncQueue,
-                            enable_llm_debug, print_colored,
-                            print_colored_debug)
+                            enable_llm_debug, logger_debug, print_colored)
 from .executor import GenerationExecutor
 from .ipc import FusedIpcQueue, IpcQueue
 from .postproc_worker import PostprocWorker, PostprocWorkerConfig
@@ -63,13 +62,13 @@ class GenerationExecutorProxy(GenerationExecutor):
 
         if mpi_session is None:
             if mpi_process_pre_spawned:
-                print_colored_debug('create comm session ...\n', "yellow")
+                logger_debug('create comm session ...\n', "yellow")
                 self.mpi_session = create_mpi_comm_session(model_world_size)
             else:
-                print_colored_debug('create pool session ...\n', "yellow")
+                logger_debug('create pool session ...\n', "yellow")
                 self.mpi_session = MpiPoolSession(n_workers=model_world_size)
         else:
-            print_colored_debug('using external mpi session ...\n', "yellow")
+            logger_debug('using external mpi session ...\n', "yellow")
             self.mpi_session = mpi_session
 
         if isinstance(self.mpi_session,
@@ -353,7 +352,7 @@ class GenerationExecutorProxy(GenerationExecutor):
     def pre_shutdown(self):
         if not self.workers_started:
             return
-        print_colored_debug('Proxy.pre_shutdown...\n', "yellow")
+        logger_debug('Proxy.pre_shutdown...\n', "yellow")
 
         if self.doing_shutdown:
             return
@@ -373,7 +372,7 @@ class GenerationExecutorProxy(GenerationExecutor):
         if not self.doing_shutdown:
             self.pre_shutdown()
 
-        print_colored_debug('Proxy.shutdown...\n', "yellow")
+        logger_debug('Proxy.shutdown...\n', "yellow")
 
         for f in self.mpi_futures:
             try:

--- a/tensorrt_llm/executor/rpc_proxy.py
+++ b/tensorrt_llm/executor/rpc_proxy.py
@@ -7,8 +7,7 @@ from typing import Optional
 
 from ..llmapi.mpi_session import MpiPoolSession, MpiSession
 from ..llmapi.tracer import global_tracer
-from ..llmapi.utils import (AsyncQueue, _SyncQueue, logger_debug,
-                            print_colored_debug)
+from ..llmapi.utils import AsyncQueue, _SyncQueue, logger_debug
 from ..logger import logger
 from .executor import GenerationExecutor
 from .postproc_worker import PostprocWorkerConfig
@@ -357,13 +356,13 @@ class GenerationExecutorRpcProxy(GenerationExecutor):
         mpi_process_pre_spawned: bool = get_spawn_proxy_process_env()
         if mpi_session is None:
             if mpi_process_pre_spawned:
-                print_colored_debug('create comm session ...\n', "yellow")
+                logger_debug('create comm session ...\n', "yellow")
                 self.mpi_session = create_mpi_comm_session(model_world_size)
             else:
-                print_colored_debug('create pool session ...\n', "yellow")
+                logger_debug('create pool session ...\n', "yellow")
                 self.mpi_session = MpiPoolSession(n_workers=model_world_size)
         else:
-            print_colored_debug('using external mpi session ...\n', "yellow")
+            logger_debug('using external mpi session ...\n', "yellow")
             self.mpi_session = mpi_session
 
     @staticmethod

--- a/tensorrt_llm/executor/utils.py
+++ b/tensorrt_llm/executor/utils.py
@@ -11,11 +11,11 @@ from typing import Any, Callable, List, NamedTuple, Optional
 from strenum import StrEnum
 
 from tensorrt_llm._utils import mpi_rank
-from tensorrt_llm.llmapi.utils import enable_llm_debug, print_colored_debug
+from tensorrt_llm.llmapi.utils import enable_llm_debug, logger_debug
 
 from ..llmapi.mpi_session import (MpiCommSession, MpiPoolSession, MpiSession,
                                   RemoteMpiCommSessionClient)
-from ..llmapi.utils import print_colored_debug
+from ..llmapi.utils import logger_debug
 from ..logger import logger
 
 
@@ -52,14 +52,14 @@ def create_mpi_comm_session(
     if get_spawn_proxy_process_env():
         assert get_spawn_proxy_process_ipc_addr_env(
         ), f"{LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_ADDR} is not set."
-        print_colored_debug(
+        logger_debug(
             f"Using RemoteMpiPoolSessionClient to bind to external MPI processes at {get_spawn_proxy_process_ipc_addr_env()}\n",
             "yellow")
         get_spawn_proxy_process_ipc_hmac_key_env()
         return RemoteMpiCommSessionClient(
             addr=get_spawn_proxy_process_ipc_addr_env())
     else:
-        print_colored_debug(
+        logger_debug(
             f"Using MpiCommSession to bind to external MPI processes\n",
             "yellow")
         return MpiCommSession(n_workers=n_workers)

--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -19,7 +19,7 @@ from ..llmapi.mpi_session import set_mpi_session_cpp
 from ..llmapi.tokenizer import TokenizerBase
 from ..llmapi.tracer import VizTracer, set_global_tracer
 from ..llmapi.utils import (AsyncQueue, ManagedThread, _SyncQueue,
-                            clear_sched_affinity, print_colored_debug,
+                            clear_sched_affinity, logger_debug,
                             print_traceback_on_error)
 from ..sampling_params import BatchedLogitsProcessor
 from .base_worker import BaseWorker
@@ -175,7 +175,7 @@ class GenerationExecutorWorker(BaseWorker):
         else:
             self.doing_shutdown = True
 
-        print_colored_debug(f'Worker {mpi_rank()} shutdown...\n', "yellow")
+        logger_debug(f'Worker {mpi_rank()} shutdown...\n', "yellow")
 
         if self.engine is not None:
             if self.engine.can_enqueue_requests():
@@ -210,7 +210,7 @@ class GenerationExecutorWorker(BaseWorker):
         # Check if there are any errors from the threads before shutdown.
         self._handle_background_error()
 
-        print_colored_debug(f"Worker {mpi_rank()} shutdown done.\n", "yellow")
+        logger_debug(f"Worker {mpi_rank()} shutdown done.\n", "yellow")
 
     def block_subordinates(self):
         if self.rank != 0:
@@ -243,8 +243,7 @@ def worker_main(
     llm_args: Optional[BaseLlmArgs] = None,
 ) -> None:
     mpi_comm().barrier()
-    print_colored_debug(f"Worker {mpi_rank()} entering worker_main...\n",
-                        "green")
+    logger_debug(f"Worker {mpi_rank()} entering worker_main...\n", "green")
 
     pid = os.getpid()
     cpus = os.sched_getaffinity(pid)
@@ -326,7 +325,7 @@ def worker_main(
 
     postprocess_worker_futures = []
     if is_leader and postproc_worker_config.enabled:
-        print_colored_debug(f"initiate postprocess workers...", "yellow")
+        logger_debug(f"initiate postprocess workers...", "yellow")
 
         proxy_result_queue: tuple[
             str, Optional[bytes]] = worker_queues.result_queue_addr
@@ -357,8 +356,7 @@ def worker_main(
     #         error to the error_queue in the main thread.
 
     mpi_comm().barrier()
-    print_colored_debug(f"Worker {mpi_rank()} ready to setup backend...\n",
-                        "green")
+    logger_debug(f"Worker {mpi_rank()} ready to setup backend...\n", "green")
 
     try:
         worker: GenerationExecutorWorker = worker_cls(
@@ -373,7 +371,7 @@ def worker_main(
     except Exception as e:
         logger.error(f"Failed to initialize executor on rank {mpi_rank()}: {e}")
         logger.error(traceback.format_exc())
-        print_colored_debug(f"error: {traceback.format_exc()}", "red")
+        logger_debug(f"error: {traceback.format_exc()}", "red")
         if is_leader:
             # Send error message with confirmation
             error_msg = (e, traceback.format_exc())

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -44,7 +44,7 @@ from .mpi_session import MpiPoolSession, external_mpi_comm_available
 from .tokenizer import TokenizerBase, _xgrammar_tokenizer_info
 # TODO[chunweiy]: move the following symbols back to utils scope, and remove the following import
 from .utils import (append_docstring, exception_handler, get_device_count,
-                    print_colored_debug, set_api_status)
+                    logger_debug, set_api_status)
 
 
 class RequestOutput(DetokenizedGenerationResultBase, GenerationResult):
@@ -181,8 +181,8 @@ class BaseLLM:
         finally:
             logger.set_level(log_level)  # restore the log level
 
-        print_colored_debug(f"LLM.args.mpi_session: {self.args.mpi_session}\n",
-                            "yellow")
+        logger_debug(f"LLM.args.mpi_session: {self.args.mpi_session}\n",
+                     "yellow")
         self.mpi_session = self.args.mpi_session
 
         if self.args.parallel_config.is_multi_gpu:
@@ -198,13 +198,11 @@ class BaseLLM:
             if not self.mpi_session:
                 mpi_process_pre_spawned: bool = get_spawn_proxy_process_env()
                 if not mpi_process_pre_spawned:
-                    print_colored_debug(f"LLM create MpiPoolSession\n",
-                                        "yellow")
+                    logger_debug(f"LLM create MpiPoolSession\n", "yellow")
                     self.mpi_session = MpiPoolSession(
                         n_workers=self.args.parallel_config.world_size)
                 else:
-                    print_colored_debug(f"LLM create MpiCommSession\n",
-                                        "yellow")
+                    logger_debug(f"LLM create MpiCommSession\n", "yellow")
                     self.mpi_session = create_mpi_comm_session(
                         self.args.parallel_config.world_size)
 
@@ -823,7 +821,7 @@ class _TrtLLM(BaseLLM):
             target_engine_dir.mkdir(parents=True, exist_ok=True)
             # copy files one by one
             for file in self._engine_dir.iterdir():
-                print_colored_debug(
+                logger_debug(
                     f"Copying {file} to {target_engine_dir / file.name}\n")
                 shutil.copy(file, target_engine_dir / file.name)
 

--- a/tensorrt_llm/llmapi/llm_utils.py
+++ b/tensorrt_llm/llmapi/llm_utils.py
@@ -42,8 +42,8 @@ from .mpi_session import MPINodeState, MpiSession
 from .tokenizer import TransformersTokenizer, load_hf_tokenizer
 # TODO[chunweiy]: move the following symbols back to utils scope, and remove the following import
 from .utils import (download_hf_model, download_hf_pretrained_config,
-                    enable_llm_debug, get_directory_size_in_gb, print_colored,
-                    print_colored_debug, print_traceback_on_error)
+                    enable_llm_debug, get_directory_size_in_gb, logger_debug,
+                    print_colored, print_traceback_on_error)
 
 
 @dataclass
@@ -540,8 +540,7 @@ class ModelLoader:
             self.build_config,
             BuildConfig), f"build_config is not set yet: {self.build_config}"
 
-        print_colored_debug(f"rank{mpi_rank()} begin to build engine...\n",
-                            "green")
+        logger_debug(f"rank{mpi_rank()} begin to build engine...\n", "green")
 
         # avoid the original build_config is modified, avoid the side effect
         copied_build_config = copy.deepcopy(self.build_config)
@@ -558,7 +557,7 @@ class ModelLoader:
 
         # delete the model explicitly to free all the build-time resources
         self.model = None
-        print_colored_debug(f"rank{mpi_rank()} build engine done\n", "green")
+        logger_debug(f"rank{mpi_rank()} build engine done\n", "green")
 
     def _save_engine_for_runtime(self):
         '''

--- a/tensorrt_llm/llmapi/mgmn_leader_node.py
+++ b/tensorrt_llm/llmapi/mgmn_leader_node.py
@@ -11,24 +11,24 @@ from tensorrt_llm._utils import global_mpi_rank, mpi_world_size
 from tensorrt_llm.executor.ipc import ZeroMqQueue
 from tensorrt_llm.executor.utils import get_spawn_proxy_process_ipc_addr_env
 from tensorrt_llm.llmapi.mpi_session import RemoteMpiCommSessionServer
-from tensorrt_llm.llmapi.utils import print_colored_debug
+from tensorrt_llm.llmapi.utils import logger_debug
 
 
 def launch_server_main(sub_comm=None):
     num_ranks = sub_comm.Get_size() if sub_comm is not None else mpi_world_size(
     )
-    print_colored_debug(f"Starting MPI Comm Server with {num_ranks} workers\n",
-                        "yellow")
+    logger_debug(f"Starting MPI Comm Server with {num_ranks} workers\n",
+                 "yellow")
     server = RemoteMpiCommSessionServer(
         comm=sub_comm,
         n_workers=num_ranks,
         addr=get_spawn_proxy_process_ipc_addr_env(),
         is_comm=True)
-    print_colored_debug(
+    logger_debug(
         f"MPI Comm Server started at {get_spawn_proxy_process_ipc_addr_env()}")
     server.serve()
 
-    print_colored_debug("RemoteMpiCommSessionServer stopped\n", "yellow")
+    logger_debug("RemoteMpiCommSessionServer stopped\n", "yellow")
 
 
 def stop_server_main():
@@ -38,13 +38,13 @@ def stop_server_main():
                         socket_type=zmq.PAIR)
 
     try:
-        print_colored_debug(
+        logger_debug(
             f"RemoteMpiCommSessionClient [rank{global_mpi_rank()}] send shutdown signal to server\n",
             "green")
         queue.put(None)  # ask RemoteMpiCommSessionServer to shutdown
     except zmq.error.ZMQError as e:
-        print_colored_debug(
-            f"Error during RemoteMpiCommSessionClient shutdown: {e}\n", "red")
+        logger_debug(f"Error during RemoteMpiCommSessionClient shutdown: {e}\n",
+                     "red")
 
 
 @click.command()

--- a/tensorrt_llm/llmapi/mpi_session.py
+++ b/tensorrt_llm/llmapi/mpi_session.py
@@ -16,7 +16,7 @@ from tensorrt_llm.bindings.BuildInfo import ENABLE_MULTI_DEVICE
 from tensorrt_llm.logger import logger
 
 from .._utils import global_mpi_rank, mpi_barrier, mpi_rank
-from .utils import print_colored, print_colored_debug
+from .utils import logger_debug, print_colored
 
 if ENABLE_MULTI_DEVICE:
     import mpi4py
@@ -270,8 +270,8 @@ class RemoteMpiCommSessionClient(MpiSession):
         # FIXME: this is a hack to avoid circular import, resolve later
         from tensorrt_llm.executor.ipc import ZeroMqQueue
         self.addr = addr
-        print_colored_debug(
-            f"RemoteMpiCommSessionClient connecting to {addr}\n", "yellow")
+        logger_debug(f"RemoteMpiCommSessionClient connecting to {addr}\n",
+                     "yellow")
         self.queue = ZeroMqQueue((addr, hmac_key),
                                  is_server=False,
                                  socket_type=zmq.PAIR,
@@ -285,10 +285,10 @@ class RemoteMpiCommSessionClient(MpiSession):
                **kwargs) -> list:
         ''' Submit a task to the remote MPI pool. '''
         if self._is_shutdown:
-            print_colored_debug(
-                "RemoteMpiCommSessionClient is already shut down\n", "yellow")
+            logger_debug("RemoteMpiCommSessionClient is already shut down\n",
+                         "yellow")
             return []
-        print_colored_debug(
+        logger_debug(
             f"RemoteMpiCommSessionClient [rank{global_mpi_rank()}] sending task {task} to {self.addr}\n",
             "yellow")
         self.queue.put(RemoteTask(task, args, kwargs, sync=sync))
@@ -301,11 +301,10 @@ class RemoteMpiCommSessionClient(MpiSession):
         self.submit(task, *args, sync=True, **kwargs)
 
         while not ((res := self.poll()) or self._is_shutdown):
-            print_colored_debug(f"Waiting for task completion... {res}\n",
-                                "grey")
+            logger_debug(f"Waiting for task completion... {res}\n", "grey")
             time.sleep(self.SYNC_IDLE_INTERVAL)
 
-        print_colored_debug(
+        logger_debug(
             f"rank{global_mpi_rank()} RemoteMpiCommSessionClient.send_sync received results: {res}\n",
             "green")
 
@@ -367,10 +366,10 @@ class RemoteMpiCommSessionServer():
 
     @staticmethod
     def task_wrapper(task: Callable[..., T], *args, **kwargs) -> T:
-        print_colored_debug(
+        logger_debug(
             f"MpiCommSession rank{mpi_rank()} with world_size {mpi_world_size()}\n",
             "green")
-        print_colored_debug(
+        logger_debug(
             f"MpiCommSession rank{mpi_rank()} start task [{task}] with args: {args} and kwargs: {kwargs}\n",
             "green")
 
@@ -386,24 +385,24 @@ class RemoteMpiCommSessionServer():
             traceback.print_exc()
             raise e
         finally:
-            print_colored_debug(
+            logger_debug(
                 f"MpiCommSession rank{mpi_rank()} task [{task}] finished\n",
                 "green")
             mpi_barrier()
 
     def serve(self):
-        print_colored_debug(
-            f"RemoteMpiCommSessionServer listening on {self.addr}\n", "yellow")
+        logger_debug(f"RemoteMpiCommSessionServer listening on {self.addr}\n",
+                     "yellow")
         while True:
             message: Optional[RemoteTask] = self.queue.get()
             if message is None:
-                print_colored_debug(
+                logger_debug(
                     f"RemoteMpiCommSessionServer [rank{global_mpi_rank()}] received shutdown signal\n",
                     "green")
                 self.session.shutdown_abort()
                 break
             else:
-                print_colored_debug(
+                logger_debug(
                     f"RemoteMpiCommSessionServer [rank{global_mpi_rank()}] received task [{message.task}] from {self.addr}\n",
                     "green")
                 futures = self.session.submit(
@@ -416,10 +415,9 @@ class RemoteMpiCommSessionServer():
                         future.add_done_callback(self.mpi_future_callback)
 
     def mpi_future_callback(self, future):
-        print_colored_debug(f"rank{global_mpi_rank()} got future: {future}\n",
-                            "red")
+        logger_debug(f"rank{global_mpi_rank()} got future: {future}\n", "red")
         if future.exception() is not None:
-            print_colored_debug(
+            logger_debug(
                 f"mpi_future got exception: {future.exception()}, quitting\n",
                 "red")
             self.queue.put(future.exception())
@@ -427,11 +425,11 @@ class RemoteMpiCommSessionServer():
 
         result = future.result()
         self.results.append(result)
-        print_colored_debug(
+        logger_debug(
             f"RemoteMpiCommSessionServer working status: {len(self.results)}/{self.num_results}\n",
             "grey")
         if len(self.results) == self.num_results:
-            print_colored_debug(
+            logger_debug(
                 f"RemoteMpiCommSessionServer received all results, sending to client\n",
                 "green")
             try:
@@ -443,8 +441,8 @@ class RemoteMpiCommSessionServer():
                 else:
                     raise e
 
-            print_colored_debug(
-                f"RemoteMpiCommSessionServer sent results to client\n", "green")
+            logger_debug(f"RemoteMpiCommSessionServer sent results to client\n",
+                         "green")
             self.results.clear()
 
 

--- a/tensorrt_llm/llmapi/utils.py
+++ b/tensorrt_llm/llmapi/utils.py
@@ -37,7 +37,7 @@ def print_traceback_on_error(func):
         try:
             return func(*args, **kwargs)
         except Exception as e:
-            print_colored_debug(f"Exception in {func.__name__}: {e}\n", "red")
+            logger_debug(f"Exception in {func.__name__}: {e}\n", "red")
             traceback.print_exc()
             raise e
 
@@ -61,13 +61,6 @@ def print_colored(message,
         writer.write(colors[color] + message + reset)
     else:
         writer.write(message)
-
-
-def print_colored_debug(message,
-                        color: Optional[str] = None,
-                        writer: io.TextIOWrapper = sys.stderr):
-    if enable_llmapi_debug():
-        print_colored(message, color, writer)
 
 
 def get_current_location(skip_frames: int = 2) -> str:


### PR DESCRIPTION
## Summary
Unify the debugging printing to `logger_debug`, which is used in the RPC code, and enhance logging in the following aspects:

1. Print the calling stack, which is similar to glog
2. Implementation is based on `logger.debug` rather than `sys.stderr`; the former one is unified with the existing logging in the system.
3. Controlled with `TLLM_LLMAPI_ENABLE_DEBUG`(new).  The original `TLLM_LLM_ENABLE_DEBUG` will enable all the `logger.debug`, which dumps too many debug logs, especially in the PyExecutor decoder step. 
4. Once `TLLM_LLMAPI_ENABLE_DEBUG` is off, it will fall back to a traditional `logger.debug`

```
2025-10-22 03:27:29 [...cutor.rpc.rpc_client.RPCClient._response_reader] RPC Client received response: request_id=658988c2c4594704b15fff00c576369c, is_streaming=False, pending_futures=1
2025-10-22 03:27:29 [...c.rpc_client.RPCClient._handle_regular_response] Setting result for request_id: 658988c2c4594704b15fff00c576369c
2025-10-22 03:27:29 [...r.rpc_proxy.GenerationExecutorRpcProxy.shutdown] Cancelling main loop task.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated debug logging across executor and model components through a unified logging mechanism for improved consistency and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
