### PR TITLE
[TRTLLM-7954][feat] Target model KV cache rellocation

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/interface.py
@@ -3,11 +3,14 @@ import weakref
 from collections import namedtuple
 from dataclasses import dataclass, field
 from enum import Enum, IntEnum
-from typing import (Dict, Generic, List, Optional, Protocol, Tuple, Type,
-                    TypeVar, Union)
+from typing import (TYPE_CHECKING, Dict, Generic, List, Optional, Protocol,
+                    Tuple, Type, TypeVar, Union)
 
 import torch
 from typing_extensions import Self
+
+if TYPE_CHECKING:
+    from ..speculative.utils import SpecDecodingTensor
 
 from tensorrt_llm.functional import (PositionEmbeddingType, RopeEmbeddingUtils,
                                      RotaryScalingType)
@@ -330,8 +333,13 @@ class AttentionMetadata:
             setattr(self, f, v)
         self._saved_tensors.clear()
 
-    def update_spec_dec_param(self, is_spec_decoding_enabled, is_spec_dec_tree,
-                              is_spec_dec_dynamic_tree, max_draft_tokens):
+    def update_spec_dec_param(
+            self,
+            is_spec_decoding_enabled,
+            is_spec_dec_tree,
+            is_spec_dec_dynamic_tree,
+            max_draft_tokens,
+            spec_decoding_tensor: Optional['SpecDecodingTensor'] = None):
         """
         Hook to be called when using TRTLLM attention backend in spec-dec mode.
         """

--- a/tensorrt_llm/_torch/attention_backend/sparse/rocket.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/rocket.py
@@ -8,6 +8,7 @@ from triton import next_power_of_2
 
 import tensorrt_llm
 import tensorrt_llm.bindings
+from tensorrt_llm._torch.attention_backend.interface import AttentionMetadata
 from tensorrt_llm._torch.attention_backend.trtllm import (
     TrtllmAttention, TrtllmAttentionMetadata)
 from tensorrt_llm._torch.attention_backend.vanilla import (
@@ -949,7 +950,10 @@ class RocketKVCacheManager(KVCacheManager):
             kt_token_num = math.ceil(req.max_beam_num_tokens / self.page_size)
             self.add_kt_tokens(request_id, kt_token_num)
 
-    def update_resources(self, scheduled_batch):
+    def update_resources(self,
+                         scheduled_batch,
+                         attn_metadata: AttentionMetadata = None,
+                         kv_cache_dtype_byte_size: float = None):
         for request in scheduled_batch.context_requests:
             if request.state != LlmRequestState.GENERATION_COMPLETE:
                 seq_len = request.get_num_tokens(0)

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -2,9 +2,12 @@ import math
 import os
 import weakref
 from dataclasses import dataclass, field
-from typing import Optional, Tuple, Union
+from typing import TYPE_CHECKING, Optional, Tuple, Union
 
 import torch
+
+if TYPE_CHECKING:
+    from ..speculative.utils import SpecDecodingTensor
 
 from tensorrt_llm._utils import get_sm_version
 from tensorrt_llm.bindings.internal import thop
@@ -1045,11 +1048,31 @@ class TrtllmAttentionMetadata(AttentionMetadata):
         self.ctx_kv_indptr[:self.num_contexts + 1].copy_(
             self.host_ctx_kv_indptr[:self.num_contexts + 1], non_blocking=True)
 
-    def update_spec_dec_param(self, is_spec_decoding_enabled, is_spec_dec_tree,
-                              is_spec_dec_dynamic_tree, max_draft_tokens):
+    def update_spec_dec_param(
+        self,
+        is_spec_decoding_enabled,
+        is_spec_dec_tree,
+        is_spec_dec_dynamic_tree,
+        max_draft_tokens,
+        spec_decoding_tensor: Optional['SpecDecodingTensor'] = None,
+    ):
+
+        if spec_decoding_tensor is not None:
+            spec_decoding_position_offsets = spec_decoding_tensor.position_offsets
+            spec_decoding_packed_mask = spec_decoding_tensor.packed_mask
+            spec_decoding_generation_lengths = spec_decoding_tensor.generation_lengths
+        else:
+            spec_decoding_position_offsets = None
+            spec_decoding_packed_mask = None
+            spec_decoding_generation_lengths = None
         # spec_dec mode should only be enabled for pre-Blackwell machines and when there's a spec-dec tree.
         self.is_spec_decoding_enabled = is_spec_decoding_enabled and get_sm_version(
         ) < 100
+
+        if get_sm_version() >= 100:
+            if is_spec_dec_tree or is_spec_dec_dynamic_tree:
+                assert not is_spec_dec_tree, "Spec-dec tree is not supported on this machine. Please use a pre-Blackwell machine for a spec-dec tree."
+                assert not is_spec_dec_dynamic_tree, "Spec-dec dynamic tree is not supported on this machine. Please use a pre-Blackwell machine for a spec-dec dynamic tree."
 
         # use_spec_decoding is default to true by default, change in runtime by layers / requests
         self.use_spec_decoding = self.is_spec_decoding_enabled
@@ -1068,7 +1091,7 @@ class TrtllmAttentionMetadata(AttentionMetadata):
             self.spec_decoding_packed_mask = torch.empty(
                 [
                     self.max_num_requests, max_draft_tokens + 1,
-                    math.ceil(max_draft_tokens / 32)
+                    math.ceil((max_draft_tokens + 1) / 32)
                 ],
                 dtype=torch.int,
                 device='cuda',
@@ -1081,7 +1104,18 @@ class TrtllmAttentionMetadata(AttentionMetadata):
             )
 
             if self.is_spec_dec_dynamic_tree:
-                assert False, "currently dynamic tree is not supported"
+                assert spec_decoding_position_offsets is not None, "spec_decoding_position_offsets is required for dynamic tree"
+                assert spec_decoding_packed_mask is not None, "spec_decoding_packed_mask is required for dynamic tree"
+                self.spec_decoding_position_offsets.copy_(
+                    spec_decoding_position_offsets, non_blocking=True)
+                self.spec_decoding_packed_mask.copy_(spec_decoding_packed_mask,
+                                                     non_blocking=True)
+                if spec_decoding_generation_lengths is not None:
+                    self.spec_decoding_generation_lengths.copy_(
+                        spec_decoding_generation_lengths, non_blocking=True)
+                else:
+                    self.generate_spec_decoding_generation_length(
+                        max_draft_tokens=max_draft_tokens)
             else:
                 # Populate the mask that won't change during inference phase.
                 self.generate_spec_decoding_position_offsets(
@@ -1092,7 +1126,6 @@ class TrtllmAttentionMetadata(AttentionMetadata):
                     max_draft_tokens=max_draft_tokens)
 
     def generate_spec_decoding_position_offsets(self, max_draft_tokens):
-        assert not self.is_spec_dec_tree, "only chained/linear tree is supported now"
         position_offset = torch.arange(max_draft_tokens + 1,
                                        dtype=torch.int,
                                        device='cpu',
@@ -1103,7 +1136,6 @@ class TrtllmAttentionMetadata(AttentionMetadata):
                                                   non_blocking=True)
 
     def generate_spec_decoding_packed_mask(self, max_draft_tokens):
-        assert not self.is_spec_dec_tree, "only chained/linear tree is supported now"
         dummy_idx = torch.arange(max_draft_tokens + 1)
         spec_decoding_packed_mask = torch.pow(2, dummy_idx + 1) - 1
         self.spec_decoding_packed_mask[:, :, 0].copy_(spec_decoding_packed_mask,

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -482,6 +482,8 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
         self.py_target_probs = None
         self.py_last_draft_tokens = None
         self.py_num_accepted_draft_tokens = 0
+        self.py_num_accepted_draft_tokens_indices = []
+        self.py_rewind_draft_token_separate_adjustment = 0
         self.py_decoding_iter = 0
         self.is_attention_dp_dummy = False
         self.is_cuda_graph_dummy = False

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -987,7 +987,9 @@ class PyExecutor:
                         finished_requests = self._handle_responses()
                         previous_scheduled_batch = previous_batch.sample_state.scheduled_requests
                         self.resource_manager.update_resources(
-                            previous_scheduled_batch)
+                            previous_scheduled_batch,
+                            self.model_engine.attn_metadata,
+                            self.model_engine.kv_cache_dtype_byte_size)
                         self._remove_inflight_ids(previous_scheduled_batch)
 
                     self.wait_on_pp_send_handles(prev_microbatch_id)
@@ -1195,7 +1197,9 @@ class PyExecutor:
 
                     self._handle_canceled_requests()
                     finished_requests = self._handle_responses()
-                    self.resource_manager.update_resources(scheduled_batch)
+                    self.resource_manager.update_resources(
+                        scheduled_batch, self.model_engine.attn_metadata,
+                        self.model_engine.kv_cache_dtype_byte_size)
                     if self.enable_kv_cache_events:
                         self._add_kv_cache_events()
 
@@ -1397,7 +1401,9 @@ class PyExecutor:
         self._handle_canceled_requests()
         finished_requests = self._handle_responses()
         scheduled_requests = self.previous_batch.sample_state.scheduled_requests
-        self.resource_manager.update_resources(scheduled_requests)
+        self.resource_manager.update_resources(
+            scheduled_requests, self.model_engine.attn_metadata,
+            self.model_engine.kv_cache_dtype_byte_size)
         if self.enable_kv_cache_events:
             self._add_kv_cache_events()
 

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -986,10 +986,13 @@ class PyExecutor:
 
                         finished_requests = self._handle_responses()
                         previous_scheduled_batch = previous_batch.sample_state.scheduled_requests
+                        attn_metadata = getattr(self.model_engine,
+                                                'attn_metadata', None)
+                        kv_cache_dtype_byte_size = getattr(
+                            self.model_engine, 'kv_cache_dtype_byte_size', None)
                         self.resource_manager.update_resources(
-                            previous_scheduled_batch,
-                            self.model_engine.attn_metadata,
-                            self.model_engine.kv_cache_dtype_byte_size)
+                            previous_scheduled_batch, attn_metadata,
+                            kv_cache_dtype_byte_size)
                         self._remove_inflight_ids(previous_scheduled_batch)
 
                     self.wait_on_pp_send_handles(prev_microbatch_id)
@@ -1197,9 +1200,13 @@ class PyExecutor:
 
                     self._handle_canceled_requests()
                     finished_requests = self._handle_responses()
+                    attn_metadata = getattr(self.model_engine, 'attn_metadata',
+                                            None)
+                    kv_cache_dtype_byte_size = getattr(
+                        self.model_engine, 'kv_cache_dtype_byte_size', None)
                     self.resource_manager.update_resources(
-                        scheduled_batch, self.model_engine.attn_metadata,
-                        self.model_engine.kv_cache_dtype_byte_size)
+                        scheduled_batch, attn_metadata,
+                        kv_cache_dtype_byte_size)
                     if self.enable_kv_cache_events:
                         self._add_kv_cache_events()
 
@@ -1401,9 +1408,12 @@ class PyExecutor:
         self._handle_canceled_requests()
         finished_requests = self._handle_responses()
         scheduled_requests = self.previous_batch.sample_state.scheduled_requests
-        self.resource_manager.update_resources(
-            scheduled_requests, self.model_engine.attn_metadata,
-            self.model_engine.kv_cache_dtype_byte_size)
+        attn_metadata = getattr(self.model_engine, 'attn_metadata', None)
+        kv_cache_dtype_byte_size = getattr(self.model_engine,
+                                           'kv_cache_dtype_byte_size', None)
+        self.resource_manager.update_resources(scheduled_requests,
+                                               attn_metadata,
+                                               kv_cache_dtype_byte_size)
         if self.enable_kv_cache_events:
             self._add_kv_cache_events()
 

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -3,7 +3,8 @@ import enum
 import math
 from abc import ABC, abstractmethod
 from collections import OrderedDict, defaultdict
-from typing import Dict, Iterable, List, Optional, Set, Tuple, Union
+from typing import (TYPE_CHECKING, Dict, Iterable, List, Optional, Set, Tuple,
+                    Union)
 
 import torch
 
@@ -41,6 +42,11 @@ RequestList = list[LlmRequest]
 PeftCacheManagerCpp = tensorrt_llm.bindings.internal.batch_manager.PeftCacheManager
 PeftCacheConfig = tensorrt_llm.bindings.executor.PeftCacheConfig
 WorldConfig = tensorrt_llm.bindings.WorldConfig
+
+if TYPE_CHECKING:
+    from tensorrt_llm._torch.attention_backend.interface import \
+        AttentionMetadata
+
 TempAttentionWindowInputs = tensorrt_llm.bindings.internal.batch_manager.TempAttentionWindowInputs
 BlocksPerWindow = Dict[int, Tuple[
     int,
@@ -237,6 +243,7 @@ class KVCacheManager(BaseResourceManager):
         self.event_buffer_max_size = kv_cache_config.event_buffer_max_size
         self.attention_dp_events_gather_period_ms = kv_cache_config.attention_dp_events_gather_period_ms
         self.max_num_tokens = max_num_tokens
+        self.max_draft_len = spec_config.max_draft_len if spec_config is not None else 0
 
         # Determine max_attention_window_vec
         if kv_cache_config.max_attention_window is None:
@@ -245,7 +252,6 @@ class KVCacheManager(BaseResourceManager):
         else:
             self.max_attention_window_vec = kv_cache_config.max_attention_window.copy(
             )  # Make a copy to avoid modifying original
-
             # Clamp all window sizes to max_seq_len before calculating the
             # number of KV cache blocks. This prevents the KV cache pool from
             # being skewed by the largest window values.
@@ -517,7 +523,13 @@ class KVCacheManager(BaseResourceManager):
             requests.append(req)
         return requests
 
-    def update_resources(self, scheduled_batch: ScheduledRequests):
+    def update_resources(self,
+                         scheduled_batch: ScheduledRequests,
+                         attn_metadata: "AttentionMetadata" = None,
+                         kv_cache_dtype_byte_size: float = None):
+        self.update_kv_cache_draft_token_location(scheduled_batch,
+                                                  attn_metadata,
+                                                  kv_cache_dtype_byte_size)
         # rewind kv cache
         for request in scheduled_batch.generation_requests:
             if request.state != LlmRequestState.GENERATION_COMPLETE:
@@ -527,6 +539,76 @@ class KVCacheManager(BaseResourceManager):
         # For context requests, we store the blocks for reuse.
         for request in scheduled_batch.context_requests:
             self.impl.store_context_blocks(request)
+
+    def locate_accepted_draft_tokens(self, requests: List[LlmRequest]):
+        num_accepted_draft_tokens = []
+        accepted_draft_tokens_indices = []
+        rewind_draft_token_separate_adjustments = []
+        # for context requests, the py_num_accepted_draft_tokens = 0, and py_num_accepted_draft_tokens_indices = []
+        for seq in requests:
+            num_accepted_draft_tokens.append(seq.py_num_accepted_draft_tokens)
+            rewind_draft_token_separate_adjustments.append(
+                seq.py_rewind_draft_token_separate_adjustment)
+            accepted_draft_tokens_indices.extend(
+                seq.py_num_accepted_draft_tokens_indices)
+        batch_size = len(requests)
+        num_accepted_draft_tokens_offset = torch.zeros(batch_size + 1,
+                                                       dtype=torch.int32,
+                                                       device='cuda')
+        num_accepted_draft_tokens_offset[1:] = torch.cumsum(torch.tensor(
+            num_accepted_draft_tokens, dtype=torch.int32),
+                                                            dim=0)
+        accepted_draft_tokens_indices = torch.tensor(
+            accepted_draft_tokens_indices, dtype=torch.int32, device='cuda')
+        rewind_draft_token_separate_adjustments = torch.tensor(
+            rewind_draft_token_separate_adjustments,
+            dtype=torch.int32,
+            device='cuda')
+        return num_accepted_draft_tokens_offset, accepted_draft_tokens_indices, rewind_draft_token_separate_adjustments
+
+    def update_kv_cache_draft_token_location(self,
+                                             scheduled_batch: ScheduledRequests,
+                                             attn_metadata: "AttentionMetadata",
+                                             kv_cache_dtype_byte_size: float):
+        run_kv_cache_rellocation = False
+        for request in scheduled_batch.generation_requests:
+            if request.state != LlmRequestState.GENERATION_COMPLETE:
+                if request.py_num_accepted_draft_tokens > 0:
+                    run_kv_cache_rellocation = True
+        if not run_kv_cache_rellocation:
+            return
+        requests = scheduled_batch.context_requests + scheduled_batch.generation_requests
+        accepted_draft_token_offsets, packed_accepted_draft_tokens_indices, rewind_draft_token_separate_adjustments = self.locate_accepted_draft_tokens(
+            requests)
+        past_key_value_lengths = attn_metadata.kv_lens_cuda
+        if attn_metadata.kv_cache_block_offsets is not None and attn_metadata.host_kv_cache_block_offsets is not None and attn_metadata.host_kv_cache_pool_pointers is not None and attn_metadata.host_kv_cache_pool_mapping is not None:
+            use_paged_kv_cache = True
+        else:
+            use_paged_kv_cache = False
+        assert use_paged_kv_cache, "Only paged kv cache is supported"
+        assert len(
+            self.max_attention_window_vec
+        ) == 1, "Currently, only one max attention window size is supported."
+
+        if use_paged_kv_cache:
+            torch.ops.tensorrt_llm.update_kv_cache_draft_token_location(
+                accepted_draft_token_offsets,
+                packed_accepted_draft_tokens_indices,
+                past_key_value_lengths,
+                True,
+                self.num_layers,
+                self.num_kv_heads,
+                int(self.head_dim * kv_cache_dtype_byte_size),
+                self.max_draft_len,
+                self.max_attention_window_vec[0],
+                rewind_draft_token_separate_adjustments,
+                None,
+                self.kv_cache_pool_pointers,
+                attn_metadata.kv_cache_block_offsets,
+                self.max_blocks_per_seq,
+                self.tokens_per_block,
+                None,
+            )
 
     def free_resources(self, request: LlmRequest, pin_on_release: bool = False):
         return self.impl.remove_sequence(request.py_request_id, request,
@@ -1139,10 +1221,18 @@ class ResourceManager:
                 resource_manager.prepare_resources(scheduled_batch)
 
     @nvtx_range("update_resources")
-    def update_resources(self, scheduled_batch: ScheduledRequests):
+    def update_resources(self,
+                         scheduled_batch: ScheduledRequests,
+                         attn_metadata: "AttentionMetadata" = None,
+                         kv_cache_dtype_byte_size: float = None):
         for _, resource_manager in self.resource_managers.items():
             if hasattr(resource_manager, "update_resources"):
-                resource_manager.update_resources(scheduled_batch)
+                if isinstance(resource_manager, KVCacheManager):
+                    resource_manager.update_resources(scheduled_batch,
+                                                      attn_metadata,
+                                                      kv_cache_dtype_byte_size)
+                else:
+                    resource_manager.update_resources(scheduled_batch)
 
     def free_resources(self, request: LlmRequest):
         for _, resource_manager in reversed(self.resource_managers.items()):

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -573,11 +573,12 @@ class KVCacheManager(BaseResourceManager):
         run_kv_cache_rellocation = False
         for request in scheduled_batch.generation_requests:
             if request.state != LlmRequestState.GENERATION_COMPLETE:
-                if request.py_num_accepted_draft_tokens > 0:
+                if request.py_num_accepted_draft_tokens > 0 and len(
+                        request.py_num_accepted_draft_tokens_indices) > 0:
                     run_kv_cache_rellocation = True
         if not run_kv_cache_rellocation:
             return
-        requests = scheduled_batch.context_requests + scheduled_batch.generation_requests
+        requests = scheduled_batch.all_requests()
         accepted_draft_token_offsets, packed_accepted_draft_tokens_indices, rewind_draft_token_separate_adjustments = self.locate_accepted_draft_tokens(
             requests)
         past_key_value_lengths = attn_metadata.kv_lens_cuda

--- a/tensorrt_llm/_torch/speculative/utils.py
+++ b/tensorrt_llm/_torch/speculative/utils.py
@@ -1,4 +1,7 @@
+from dataclasses import dataclass
 from typing import Optional
+
+import torch
 
 from ..pyexecutor.guided_decoder import GuidedDecoder
 from ..pyexecutor.sampler import TorchSampler
@@ -238,3 +241,18 @@ def update_spec_config_from_model_config(spec_config, model_config):
         spec_config.max_draft_len = spec_config.num_nextn_predict_layers
         # Use `num_nextn_predict_layers_from_model_config` to decide decoding mode MTP / MTP_EAGLE.
         spec_config.num_nextn_predict_layers_from_model_config = model_config.num_nextn_predict_layers
+
+
+@dataclass
+class SpecDecodingTensor:
+    """
+    Container for speculative decoding tensor parameters.
+
+    Attributes:
+        position_offsets: Position offsets for speculative decoding
+        packed_mask: Packed attention mask for speculative decoding
+        generation_lengths: Optional generation lengths for speculative decoding
+    """
+    position_offsets: torch.Tensor
+    packed_mask: torch.Tensor
+    generation_lengths: Optional[torch.Tensor] = None

--- a/tests/unittest/_torch/modeling/test_modeling_llama.py
+++ b/tests/unittest/_torch/modeling/test_modeling_llama.py
@@ -8,7 +8,8 @@ from _torch.helpers import create_mock_engine
 from parameterized import parameterized
 from transformers import LlamaConfig
 from transformers import LlamaForCausalLM as HFLlamaForCausalLM
-from utils.util import default_dtype, getSMVersion
+from utils.llm_data import llm_models_root
+from utils.util import default_dtype, getSMVersion, skip_blackwell
 
 import tensorrt_llm
 from tensorrt_llm._torch.attention_backend.utils import get_attention_backend
@@ -16,7 +17,10 @@ from tensorrt_llm._torch.metadata import KVCacheParams
 from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.models.modeling_llama import LlamaForCausalLM
 from tensorrt_llm._torch.pyexecutor.cuda_graph_runner import CUDAGraphRunner
+from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequestState
 from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
+from tensorrt_llm._torch.pyexecutor.scheduler import ScheduledRequests
+from tensorrt_llm._torch.speculative.utils import SpecDecodingTensor
 from tensorrt_llm.bindings.executor import KvCacheConfig
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.models.modeling_utils import QuantConfig
@@ -373,4 +377,285 @@ class TestLlama(unittest.TestCase):
                                    rtol=0.4)
         if graph_runner is not None:
             graph_runner.clear()
+        kv_cache_manager.shutdown()
+
+    @skip_blackwell
+    @torch.no_grad()
+    def test_llama_verification_with_kv_cache_relocation(self) -> None:
+        """
+        Verify the output of the model with kv cache relocation
+        """
+        backend = "TRTLLM"
+        metadata_cls = get_attention_backend(backend).Metadata
+
+        config_dict = deepcopy(LLAMA_3_1_8B_CONFIG)
+
+        llama_config = LlamaConfig.from_dict(config_dict)
+        dtype = llama_config.torch_dtype
+        device = torch.device('cuda')
+
+        with torch.device(device), default_dtype(dtype):
+            models_path = llm_models_root()
+            model_dir = f"{models_path}/llama-3.1-model/Llama-3.1-8B-Instruct"
+
+            hf_llama = HFLlamaForCausalLM.from_pretrained(
+                model_dir,
+                torch_dtype=torch.bfloat16,
+                device_map="cuda",
+            ).eval()
+
+            model_config = ModelConfig(pretrained_config=llama_config,
+                                       attn_backend=backend)
+
+            llama = LlamaForCausalLM(model_config).to(dtype).to(device)
+            llama.load_weights(hf_llama.state_dict())
+        num_blocks = 1
+        tokens_per_block = 128
+        head_dim = llama.config.hidden_size // llama.config.num_attention_heads
+        num_layers = llama.config.num_hidden_layers
+        num_kv_heads = llama.config.num_key_value_heads
+        max_seq_len = num_blocks * tokens_per_block
+        batch_size = 1
+
+        if dtype == torch.half:
+            kv_cache_dtype = tensorrt_llm.bindings.DataType.HALF
+        elif dtype == torch.bfloat16:
+            kv_cache_dtype = tensorrt_llm.bindings.DataType.BF16
+        else:
+            raise ValueError("Invalid dtype")
+        kv_cache_dtype_byte_size = 2
+
+        mapping = Mapping(world_size=1, tp_size=1, rank=0)
+        kv_cache_config = KvCacheConfig(max_tokens=num_blocks *
+                                        tokens_per_block)
+        kv_cache_manager = KVCacheManager(
+            kv_cache_config,
+            tensorrt_llm.bindings.internal.batch_manager.CacheType.SELF,
+            num_layers=num_layers,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            tokens_per_block=tokens_per_block,
+            max_seq_len=max_seq_len,
+            max_batch_size=batch_size,
+            mapping=mapping,
+            dtype=kv_cache_dtype,
+        )
+
+        # context
+        input_ids = torch.tensor([
+            128000, 32, 6369, 1990, 264, 22999, 1217, 323, 459, 21075, 11478,
+            18328, 13, 578, 18328, 6835, 11190, 11, 11944, 11, 323, 48887,
+            11503, 311, 279, 1217, 596, 4860, 13, 14194, 25, 22691, 36660, 3931,
+            2891, 25
+        ],
+                                 dtype=torch.int,
+                                 device=device)
+
+        num_cached_tokens_per_seq = [0]
+        request_ids = [900]
+        token_nums = [input_ids.size(-1)]
+        prompt_lens = [input_ids.size(-1)]
+        requests = kv_cache_manager.add_dummy_requests(request_ids, token_nums)
+        request = requests[0]
+
+        attn_metadata = metadata_cls(
+            seq_lens=torch.tensor([input_ids.size(-1)], dtype=torch.int),
+            num_contexts=1,
+            kv_cache_params=KVCacheParams(
+                use_cache=True,
+                num_cached_tokens_per_seq=num_cached_tokens_per_seq,
+            ),
+            max_num_requests=1,
+            max_num_tokens=8192,
+            kv_cache_manager=kv_cache_manager,
+            request_ids=request_ids,
+            prompt_lens=prompt_lens,
+        )
+
+        position_ids = [torch.arange(0, input_ids.size(-1))]
+        position_ids = torch.cat(position_ids).unsqueeze(0).cuda()
+        with torch.inference_mode():
+            attn_metadata.prepare()
+            logits = llama.forward(input_ids=input_ids,
+                                   position_ids=position_ids,
+                                   attn_metadata=attn_metadata)
+
+        def run_forward(input_ids, position_ids, attn_metadata):
+            attn_metadata.prepare()
+            return llama.forward(input_ids=input_ids,
+                                 position_ids=position_ids,
+                                 attn_metadata=attn_metadata,
+                                 return_context_logits=True)
+
+        # prepare for the first generation
+        gen_input_ids_0 = torch.tensor([
+            22691, 11, 0, 13, 15592, 323, 315, 12, 311, 362, 220, 32, 362, 426,
+            330, 358, 362, 358, 358, 362, 32, 0, 13, 32, 6369, 7528, 649, 32,
+            32, 649, 6369
+        ],
+                                       dtype=torch.int,
+                                       device=device)
+        spec_decoding_position_offsets = torch.tensor([
+            0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+            2, 3, 3, 3, 3, 3, 3, 3
+        ],
+                                                      dtype=torch.int,
+                                                      device=device)
+        spec_decoding_packed_mask = torch.tensor(
+            [
+                1, 3, 5, 9, 17, 33, 65, 129, 257, 513, 1025, 2051, 4099, 8195,
+                16387, 32771, 65541, 131077, 262153, 524297, 1048593, 2097169,
+                4194321, 8388641, 16842757, 33619973, 67371017, 134479881,
+                268566533, 537001989, 1074266121
+            ],
+            dtype=torch.int,
+            device=device).unsqueeze(0).unsqueeze(2)
+
+        num_cached_tokens_per_seq = [input_ids.size(-1)]
+        is_spec_decoding_enabled = True
+        use_spec_decoding = True
+        is_spec_dec_tree = True
+        is_spec_dec_dynamic_tree = True
+        max_draft_tokens = gen_input_ids_0.size(-1) - 1
+
+        attn_metadata_gen_phase_0 = metadata_cls(
+            seq_lens=torch.tensor([gen_input_ids_0.size(-1)], dtype=torch.int),
+            num_contexts=0,
+            kv_cache_params=KVCacheParams(
+                use_cache=True,
+                num_cached_tokens_per_seq=num_cached_tokens_per_seq,
+            ),
+            max_num_requests=1,
+            max_num_tokens=8192,
+            kv_cache_manager=kv_cache_manager,
+            request_ids=request_ids,
+            prompt_lens=prompt_lens,
+            is_spec_decoding_enabled=is_spec_decoding_enabled,
+            use_spec_decoding=use_spec_decoding,
+            is_spec_dec_tree=is_spec_dec_tree,
+            is_spec_dec_dynamic_tree=is_spec_dec_dynamic_tree,
+        )
+        spec_decoding_tensor = SpecDecodingTensor(
+            position_offsets=spec_decoding_position_offsets,
+            packed_mask=spec_decoding_packed_mask)
+
+        attn_metadata_gen_phase_0.update_spec_dec_param(
+            is_spec_decoding_enabled=is_spec_decoding_enabled,
+            is_spec_dec_dynamic_tree=is_spec_dec_dynamic_tree,
+            is_spec_dec_tree=is_spec_dec_tree,
+            max_draft_tokens=max_draft_tokens,
+            spec_decoding_tensor=spec_decoding_tensor,
+        )
+
+        gen_position_ids_0 = [
+            torch.full((gen_input_ids_0.size(-1), ),
+                       input_ids.size(-1),
+                       dtype=torch.int64)
+        ]
+        gen_position_ids_0 = torch.cat(gen_position_ids_0).unsqueeze(0).cuda()
+
+        with torch.inference_mode():
+            gen_logits_0 = run_forward(input_ids=gen_input_ids_0,
+                                       position_ids=gen_position_ids_0,
+                                       attn_metadata=attn_metadata_gen_phase_0)
+
+            request.py_num_accepted_draft_tokens = 1
+            request.py_num_accepted_draft_tokens_indices = [1]
+            request.py_rewind_len = gen_input_ids_0.size(
+                -1) - request.py_num_accepted_draft_tokens - 1
+            request.state = LlmRequestState.GENERATION_IN_PROGRESS
+            scheduled_requests = ScheduledRequests()
+            scheduled_requests.generation_requests = [request]
+            kv_cache_manager.max_draft_len = gen_input_ids_0.size(-1) - 1
+            kv_cache_manager.update_kv_cache_draft_token_location(
+                scheduled_requests, attn_metadata_gen_phase_0,
+                kv_cache_dtype_byte_size)
+            if request.py_rewind_len > 0:
+                kv_cache_manager.rewind_kv_cache(request, request.py_rewind_len)
+        torch.cuda.synchronize()
+
+        # prepare for the second generation
+        gen_input_ids_1 = torch.tensor([2650, 649],
+                                       dtype=torch.int,
+                                       device=device)
+
+        num_cached_tokens_per_seq_1 = [
+            input_ids.size(-1) + request.py_num_accepted_draft_tokens + 1
+        ]
+        attn_metadata_gen_phase_0.seq_lens = torch.tensor(
+            [gen_input_ids_1.size(-1)], dtype=torch.int)
+        attn_metadata_gen_phase_0.kv_cache_params.num_cached_tokens_per_seq = num_cached_tokens_per_seq_1
+        attn_metadata_gen_phase_0.update_spec_dec_param(
+            is_spec_decoding_enabled=is_spec_decoding_enabled,
+            is_spec_dec_tree=is_spec_dec_tree,
+            is_spec_dec_dynamic_tree=False,
+            max_draft_tokens=gen_input_ids_1.size(-1) - 1)
+
+        gen_position_ids_1 = [
+            torch.full(
+                (gen_input_ids_1.size(-1), ),
+                input_ids.size(-1) + request.py_num_accepted_draft_tokens + 1,
+                dtype=torch.int64)
+        ]
+        gen_position_ids_1 = torch.cat(gen_position_ids_1).unsqueeze(0).cuda()
+
+        with torch.inference_mode():
+            gen_logits_1 = run_forward(input_ids=gen_input_ids_1,
+                                       position_ids=gen_position_ids_1,
+                                       attn_metadata=attn_metadata_gen_phase_0)
+
+        torch.cuda.synchronize()
+
+        # prepare for the reference generation
+        gen_input_ids_ref = torch.tensor([22691, 0, 2650, 649],
+                                         dtype=torch.int,
+                                         device=device)
+        num_cached_tokens_per_seq_ref = [input_ids.size(-1)]
+
+        attn_metadata_ref = metadata_cls(
+            seq_lens=torch.tensor([gen_input_ids_ref.size(-1)],
+                                  dtype=torch.int),
+            num_contexts=0,
+            kv_cache_params=KVCacheParams(
+                use_cache=True,
+                num_cached_tokens_per_seq=num_cached_tokens_per_seq_ref,
+            ),
+            max_num_requests=1,
+            max_num_tokens=8192,
+            kv_cache_manager=kv_cache_manager,
+            request_ids=request_ids,
+            prompt_lens=prompt_lens,
+            is_spec_decoding_enabled=is_spec_decoding_enabled,
+            use_spec_decoding=use_spec_decoding,
+            is_spec_dec_tree=is_spec_dec_tree,
+            is_spec_dec_dynamic_tree=False)
+        attn_metadata_ref.update_spec_dec_param(
+            is_spec_decoding_enabled=is_spec_decoding_enabled,
+            is_spec_dec_tree=is_spec_dec_tree,
+            is_spec_dec_dynamic_tree=False,
+            max_draft_tokens=gen_input_ids_ref.size(-1) - 1,
+        )
+
+        gen_position_ids_ref = [
+            torch.full((gen_input_ids_ref.size(-1), ),
+                       input_ids.size(-1),
+                       dtype=torch.int64)
+        ]
+        gen_position_ids_ref = torch.cat(gen_position_ids_ref).unsqueeze(
+            0).cuda()
+        with torch.inference_mode():
+            gen_logits_ref = run_forward(input_ids=gen_input_ids_ref,
+                                         position_ids=gen_position_ids_ref,
+                                         attn_metadata=attn_metadata_ref)
+
+        torch.cuda.synchronize()
+        torch.testing.assert_close(gen_logits_1[0, :],
+                                   gen_logits_ref[2, :],
+                                   atol=0.02,
+                                   rtol=0.02)
+        torch.testing.assert_close(gen_logits_1[1, :],
+                                   gen_logits_ref[3, :],
+                                   atol=0.02,
+                                   rtol=0.02)
+
         kv_cache_manager.shutdown()


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added dynamic tree speculative decoding support for newer hardware configurations.

* **Improvements**
  * Enhanced KV cache dtype memory sizing calculations.
  * Refined draft token location tracking and relocation handling.
  * Updated resource management to better account for speculative decoding scenarios.

* **Tests**
  * Added KV cache relocation verification test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
