### PR TITLE
[https://nvbugs/5534574][fix] disable spec decoding forever once the request spec decoding is disabled

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
+++ b/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
@@ -109,6 +109,8 @@ class CUDAGraphRunner:
             key = (batch.batch_size, draft_len,
                    spec_resource_manager.is_first_draft)
         else:
+            # With dynamic spec decode, the draft length maybe zero even when enable_spec_decode is True,
+            # so we need to get the draft length from the batch instead of using enable_spec_decode.
             draft_len_list = []
             for request in batch.generation_requests:
                 draft_len_list.append(len(request.py_draft_tokens))

--- a/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
+++ b/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
@@ -98,7 +98,7 @@ class CUDAGraphRunner:
 
     def get_graph_key(
             self,
-            batch_size,
+            batch: ScheduledRequests,
             spec_resource_manager: Optional[BaseResourceManager] = None):
         engine = self._get_engine()
         if engine.is_draft_model and spec_resource_manager is not None and isinstance(
@@ -106,10 +106,16 @@ class CUDAGraphRunner:
             # If 'is_first_draft' is True, even with tree decoding, the length of draft_len will only be 'max_draft_len', not 'max_total_draft_token'.
             # Because we will pad the input to 'max_draft_len' length for the first draft layer.
             draft_len = engine.original_max_draft_len if spec_resource_manager.is_first_draft else 0
-            key = (batch_size, draft_len, spec_resource_manager.is_first_draft)
+            key = (batch.batch_size, draft_len,
+                   spec_resource_manager.is_first_draft)
         else:
-            draft_len = self.spec_config.max_total_draft_tokens if self.enable_spec_decode else 0
-            key = (batch_size, draft_len, False)
+            draft_len_list = []
+            for request in batch.generation_requests:
+                draft_len_list.append(len(request.py_draft_tokens))
+            draft_len = max(draft_len_list)
+            assert len(
+                set(draft_len_list)) == 1, "All draft lengths must be the same"
+            key = (batch.batch_size, draft_len, False)
         return key
 
     @property
@@ -171,7 +177,7 @@ class CUDAGraphRunner:
 
         if not self.enabled or not can_run_cuda_graph:
             return False, None, None, None
-        key = self.get_graph_key(batch_size, spec_resource_manager)
+        key = self.get_graph_key(batch, spec_resource_manager)
 
         if key in self.graphs:
             return True, self.graph_metadata[key][

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -512,6 +512,7 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
         self.py_is_first_draft = is_first_draft
         self.d2t = None
         self.py_draft_use_greedy_sampling = False
+        self.py_disable_speculative_decoding = False
 
         # Chunked logits parameters
         self.py_use_chunked_generation_logits = use_chunked_generation_logits

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -2,7 +2,6 @@ import dataclasses
 import datetime
 import functools
 import gc
-import itertools
 import os
 import pickle  # nosec B403
 import threading
@@ -1084,8 +1083,7 @@ class PyExecutor:
         )
 
         if self.drafter is not None and not self.use_spec_decode:
-            for request in itertools.chain(scheduled_batch.context_requests,
-                                           scheduled_batch.generation_requests):
+            for request in scheduled_batch.all_requests():
                 request.py_disable_speculative_decoding = True
 
         if self.kv_cache_transceiver:
@@ -2350,10 +2348,6 @@ class PyExecutor:
                 self.has_previous_draft_tokens = target_inputs is not None and target_inputs.next_draft_tokens is not None
             else:
                 self.has_previous_draft_tokens = False
-                # We are not running the draft model. Remove the draft tokens and turn off spec
-                # decode so that the requests get handled correctly.
-                for request in scheduled_batch.generation_requests:
-                    request.py_draft_tokens = []
                 target_inputs, draft_outputs, draft_batch = None, None, None
 
         return target_inputs, draft_outputs, draft_batch

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1263,7 +1263,6 @@ class PyExecutor:
                 req.py_last_draft_tokens = req.py_draft_tokens
                 max_total_draft_tokens = self.model_engine.spec_config.max_total_draft_tokens
 
-
                 if max_total_draft_tokens > 0 and self.use_spec_decode and not req.py_disable_speculative_decoding:
                     req.py_draft_tokens = [0] * max_total_draft_tokens
                     req.py_draft_pages_allocated = max_total_draft_tokens
@@ -2351,6 +2350,10 @@ class PyExecutor:
                 self.has_previous_draft_tokens = target_inputs is not None and target_inputs.next_draft_tokens is not None
             else:
                 self.has_previous_draft_tokens = False
+                # We are not running the draft model. Remove the draft tokens and turn off spec
+                # decode so that the requests get handled correctly.
+                for request in scheduled_batch.generation_requests:
+                    request.py_draft_tokens = []
                 target_inputs, draft_outputs, draft_batch = None, None, None
 
         return target_inputs, draft_outputs, draft_batch

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -2,6 +2,7 @@ import dataclasses
 import datetime
 import functools
 import gc
+import itertools
 import os
 import pickle  # nosec B403
 import threading
@@ -1082,6 +1083,11 @@ class PyExecutor:
         scheduled_batch, fitting_disagg_gen_init_requests, num_fitting_reqs = self._schedule(
         )
 
+        if self.drafter is not None and not self.use_spec_decode:
+            for request in itertools.chain(scheduled_batch.context_requests,
+                                           scheduled_batch.generation_requests):
+                request.py_disable_speculative_decoding = True
+
         if self.kv_cache_transceiver:
             # For requests that are fitting disagg gen init, also prepare resources for KV cache manager
             self._prepare_disagg_gen_init(fitting_disagg_gen_init_requests)
@@ -1257,7 +1263,8 @@ class PyExecutor:
                 req.py_last_draft_tokens = req.py_draft_tokens
                 max_total_draft_tokens = self.model_engine.spec_config.max_total_draft_tokens
 
-                if max_total_draft_tokens > 0 and self.use_spec_decode:
+
+                if max_total_draft_tokens > 0 and self.use_spec_decode and not req.py_disable_speculative_decoding:
                     req.py_draft_tokens = [0] * max_total_draft_tokens
                     req.py_draft_pages_allocated = max_total_draft_tokens
                 else:

--- a/tensorrt_llm/_torch/speculative/model_drafter.py
+++ b/tensorrt_llm/_torch/speculative/model_drafter.py
@@ -548,6 +548,12 @@ class ModelDrafter(Drafter):
             for req in scheduled_batch.all_requests()
         }
 
+        for request in draft_batch.all_requests():
+            target_model_req = req_id_to_old_request[request.py_request_id]
+            if target_model_req.is_context_init_state:
+                continue
+            target_model_req.py_draft_tokens = [0] * self.max_draft_len
+
         self.draft_seq_slot_manager.prepare_resources(draft_batch)
         return draft_batch, req_id_to_old_request
 

--- a/tensorrt_llm/_torch/speculative/model_drafter.py
+++ b/tensorrt_llm/_torch/speculative/model_drafter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import itertools
 import traceback
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
@@ -422,6 +423,14 @@ class ModelDrafter(Drafter):
         Returns:
             bool: True if draft model should be forwarded, False otherwise
         """
+        all_disable_speculative_decoding = True
+        for request in itertools.chain(scheduled_batch.context_requests,
+                                       scheduled_batch.generation_requests):
+            if not request.py_disable_speculative_decoding:
+                all_disable_speculative_decoding = False
+                break
+        if all_disable_speculative_decoding:
+            return False
         for request in scheduled_batch.context_requests:
             if request.is_first_context_chunk:
                 continue

--- a/tensorrt_llm/_torch/speculative/model_drafter.py
+++ b/tensorrt_llm/_torch/speculative/model_drafter.py
@@ -112,7 +112,6 @@ class ModelDrafter(Drafter):
         num_draft_tokens = len(
             request.py_last_draft_tokens
         ) if request.py_last_draft_tokens is not None else 0
-        request.py_draft_tokens = []
 
         num_accepted_tokens = request.py_num_accepted_draft_tokens
         num_rejected_tokens = num_draft_tokens - num_accepted_tokens
@@ -387,9 +386,9 @@ class ModelDrafter(Drafter):
         """Update requests with sample state."""
         self.sampler.update_requests(sample_state, resource_manager)
 
-    def process_decoded_tokens(
-            self, draft_batch: ScheduledRequests,
-            req_id_to_old_request: Dict[int, LlmRequest]) -> List[LlmRequest]:
+    def process_decoded_tokens(self, draft_batch: ScheduledRequests,
+                               req_id_to_old_request: Dict[int, LlmRequest],
+                               draft_position: int) -> List[LlmRequest]:
         """Process decoded tokens and determine which requests to continue processing."""
         new_requests = []
         for req in draft_batch.all_requests():
@@ -400,11 +399,10 @@ class ModelDrafter(Drafter):
                 self.draft_seq_slot_manager.free_resources(req)
                 continue
 
-            target_model_req.py_draft_tokens.append(req.get_last_tokens(0))
+            target_model_req.py_draft_tokens[draft_position -
+                                             1] = req.get_last_tokens(0)
             target_model_req.py_draft_logits = req.py_result.generation_logits  # forwards Nones
-            if req.state != LlmRequestState.GENERATION_COMPLETE and len(
-                    target_model_req.py_draft_tokens
-            ) < target_model_req.py_draft_pages_allocated:
+            if req.state != LlmRequestState.GENERATION_COMPLETE and draft_position < self.max_draft_len:
                 new_requests.append(req)
             else:
                 self.draft_seq_slot_manager.free_resources(req)
@@ -580,6 +578,7 @@ class ModelDrafter(Drafter):
             if target_model_req.state != LlmRequestState.GENERATION_IN_PROGRESS:
                 # Chunked prefill request in progress; no need to append draft tokens
                 continue
+            target_model_req.py_draft_tokens = []
             py_draft_logits = []
             for token_idx in range(self.max_draft_len):
                 target_model_req.py_draft_tokens.append(
@@ -601,7 +600,7 @@ class ModelDrafter(Drafter):
         """
         self.update_requests(outputs, resource_manager)
         self.process_decoded_tokens(outputs.scheduled_requests,
-                                    req_id_to_old_request)
+                                    req_id_to_old_request, self.max_draft_len)
 
     def _execute_draft_iteration(
             self, draft_batch: ScheduledRequests,
@@ -685,7 +684,8 @@ class ModelDrafter(Drafter):
             if sample_state is not None and previous_draft_state is not None:
                 new_requests = self.process_decoded_tokens(
                     previous_draft_state.scheduled_requests,
-                    req_id_to_old_request)
+                    req_id_to_old_request,
+                    draft_position=i + 1)
             else:
                 new_requests = []
 

--- a/tensorrt_llm/_torch/speculative/model_drafter.py
+++ b/tensorrt_llm/_torch/speculative/model_drafter.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import itertools
 import traceback
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
@@ -424,8 +423,7 @@ class ModelDrafter(Drafter):
             bool: True if draft model should be forwarded, False otherwise
         """
         all_disable_speculative_decoding = True
-        for request in itertools.chain(scheduled_batch.context_requests,
-                                       scheduled_batch.generation_requests):
+        for request in scheduled_batch.all_requests():
             if not request.py_disable_speculative_decoding:
                 all_disable_speculative_decoding = False
                 break

--- a/tensorrt_llm/_torch/speculative/model_drafter.py
+++ b/tensorrt_llm/_torch/speculative/model_drafter.py
@@ -247,6 +247,8 @@ class ModelDrafter(Drafter):
             draft_batch = ScheduledRequests()
 
             for request in scheduled_requests.context_requests:
+                if request.py_disable_speculative_decoding:
+                    continue
                 if request.is_first_context_chunk:
                     # Ignore requests which still need to be processed by the target model.
                     continue
@@ -262,6 +264,8 @@ class ModelDrafter(Drafter):
                 self._add_to_draft_batch(draft_batch, new_request, request)
 
             for request in scheduled_requests.generation_requests:
+                if request.py_disable_speculative_decoding:
+                    continue
                 if request.state == LlmRequestState.GENERATION_COMPLETE:
                     # Skip generation complete requests. This could happen when enabling overlap scheduler.
                     continue

--- a/tests/unittest/_torch/speculative/test_dynamic_spec_decode.py
+++ b/tests/unittest/_torch/speculative/test_dynamic_spec_decode.py
@@ -79,10 +79,17 @@ def test_dynamic_spec_decode(enforce_single_worker,
                 continue
 
             mock_should_use_spec_decode.call_count += 1
-            # Turn off spec decode when we've called it 5 times.
-            # In the current case, at the 5th call, there are 2 accepted draft tokens,
-            # so we can have better coverage for the switching between spec decode on and off.
-            if mock_should_use_spec_decode.call_count > 5:
+            # Turn spec decoding on/off alternately.
+            # When call_count % 4 is 0 or 1, spec decoding is on.
+            # When call_count % 4 is 2 or 3, spec decoding is off.
+            # By doing this, we can cover all the cases of dynamic spec decoding.
+            # 1. Using spec decoding in iteration i, then using spec decoding in iteration i+1.
+            # 2. Using spec decoding in iteration i, then not using spec decoding in iteration i+1.
+            # 3. Not using spec decoding in iteration i, then using spec decoding in iteration i+1.
+            # 4. Not using spec decoding in iteration i, then not using spec decoding in iteration i+1.
+            if mock_should_use_spec_decode.call_count % 4 < 2:
+                return True
+            else:
                 return False
         return True
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
