### PR TITLE
[#8461][feat] AutoDeploy: trtllm-serve bug fix + unit test

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/llm_args.py
+++ b/tensorrt_llm/_torch/auto_deploy/llm_args.py
@@ -12,6 +12,7 @@ from ...llmapi.llm_args import BaseLlmArgs, BuildConfig, KvCacheConfig, _Paralle
 from ...llmapi.utils import get_type_repr
 from .models import ModelFactory, ModelFactoryRegistry
 from .utils._config import DynamicYamlMixInForSettings
+from .utils.logger import ad_logger
 
 PathLike = Union[str, Path]
 
@@ -249,6 +250,16 @@ class AutoDeployConfig(DynamicYamlMixInForSettings, BaseSettings):
                 setattr(self, shortcut_key, self.transforms[t_key][config_key])
 
         return self
+
+    @field_validator("kv_cache_config", mode="after")
+    @classmethod
+    def validate_kv_cache_config(cls, kv_cache_config: KvCacheConfig) -> KvCacheConfig:
+        if kv_cache_config.copy_on_partial_reuse:
+            kv_cache_config.copy_on_partial_reuse = False
+            ad_logger.warning(
+                "copy_on_partial_reuse is not supported by AutoDeploy. Setting it to False."
+            )
+        return kv_cache_config
 
     ### UTILITY METHODS ############################################################################
     def create_factory(self) -> ModelFactory:

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_trtllm_serve.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/test_ad_trtllm_serve.py
@@ -1,0 +1,101 @@
+import multiprocessing as mp
+import time
+
+import pytest
+import yaml
+from _model_test_utils import get_small_model_config  # type: ignore
+from click.testing import CliRunner
+from openai import OpenAI
+
+from tensorrt_llm._utils import get_free_port
+from tensorrt_llm.commands.serve import main as serve_main
+
+
+def _run_serve_with_click(args):
+    runner = CliRunner()
+    # Blocks while server runs
+    result = runner.invoke(serve_main, args, catch_exceptions=False)
+    if result.exit_code != 0:
+        raise SystemExit(result.exit_code)
+
+
+@pytest.mark.timeout(360)
+def test_trtllm_serve_openai_chat_completion(tmp_path):
+    # Prepare small model config and extra options yaml
+    config = get_small_model_config("meta-llama/Meta-Llama-3.1-8B-Instruct")
+    extra_args = config["args"]
+
+    extra_options_path = tmp_path / "extra_llm_api_options.yaml"
+    with open(extra_options_path, "w") as f:
+        yaml.safe_dump(extra_args, f)
+
+    host = "127.0.0.1"
+    port = get_free_port()
+
+    # Use the same `model` string for server and client requests
+    model_id = extra_args["model"]
+
+    args = [
+        "serve",
+        f"{model_id}",
+        "--backend",
+        "_autodeploy",
+        "--host",
+        host,
+        "--port",
+        str(port),
+        "--extra_llm_api_options",
+        str(extra_options_path),
+    ]
+
+    ctx = mp.get_context("spawn")
+    server = ctx.Process(target=_run_serve_with_click, args=(args,))
+    server.start()
+
+    try:
+        # Wait for server to be ready by polling /v1/models via OpenAI client
+        client = OpenAI(base_url=f"http://{host}:{port}/v1", api_key="tensorrt_llm")
+
+        start_time = time.time()
+        last_err = None
+        while time.time() - start_time < 90:
+            if not server.is_alive():
+                raise RuntimeError("Server process exited prematurely")
+            try:
+                # Lightweight readiness probe
+                _ = client.models.list()
+                break
+            except Exception as e:  # noqa: BLE001
+                last_err = e
+                time.sleep(1)
+        else:
+            raise TimeoutError(f"Server did not become ready in time: {last_err}")
+
+        # Send a small chat completion request
+        resp = client.chat.completions.create(
+            model=model_id,
+            messages=[
+                {"role": "system", "content": "you are a helpful assistant"},
+                {"role": "user", "content": "Say 'ok'"},
+            ],
+            max_tokens=8,
+        )
+
+        # print response
+        print(f"{resp=}")
+
+        assert hasattr(resp, "choices") and len(resp.choices) > 0
+        first = resp.choices[0]
+        # new OpenAI client returns .message for chat completions
+        assert getattr(first, "message", None) is not None
+        # Content may be a string or a structured list depending on client version
+        _ = getattr(first.message, "content", None)
+
+    finally:
+        # Terminate server and clean up
+        if server.is_alive():
+            server.terminate()
+            server.join(timeout=20)
+        if server.is_alive():
+            server.kill()
+            server.join(timeout=20)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * KV cache configuration now includes improved runtime validation that automatically disables unsupported options and provides user warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
