### PR TITLE
[None][feat] Enable time breakdown tool in disagg slurm scripts

### DIFF
--- a/examples/disaggregated/slurm/benchmark/disaggr_torch.slurm
+++ b/examples/disaggregated/slurm/benchmark/disaggr_torch.slurm
@@ -38,6 +38,9 @@ nsys_on=${33}
 seq_offset=${34}  # Offset added to sequence lengths
 numa_bind=${35}    # Whether to enable NUMA binding
 benchmark_mode=${36}  # Benchmark mode: e2e or gen_only
+log_dir=${37}
+enable_time_breakdown=${38}  # Whether to enable request time breakdown
+perf_metrics_max_requests=${39}  # Maximum number of requests to store perf metrics for
 
 # Print all parsed arguments
 echo "Parsed arguments:"
@@ -85,12 +88,15 @@ echo "  model_path: ${model_path}"
 echo "  trtllm_repo: ${trtllm_repo}"
 echo "  build_wheel: ${build_wheel}"
 echo "  work_dir: ${work_dir}"
+echo "  log_dir: ${log_dir}"
 echo "  nsys_on: ${nsys_on}"
+echo "  enable_time_breakdown: ${enable_time_breakdown}"
+echo "  perf_metrics_max_requests: ${perf_metrics_max_requests}"
 
 container_name="disaggr-test"
 
 # Setup logging directory
-log_base="${work_dir}/${isl}-${osl}/" # path to the log directory
+log_base="${log_dir}/${isl}-${osl}/" # path to the log directory
 full_logdir=${log_base}/ctx${num_ctx_servers}_gen${num_gen_servers}_dep${gen_tp_size}_batch${gen_batch_size}_eplb${eplb_num_slots}_mtp${mtp_size}
 enable_pdl=false
 if [ "${gen_enable_attention_dp}" = "false" ]; then
@@ -175,6 +181,8 @@ if ! srun -l -N 1 -n 1 \
                 --cache_transceiver_max_num_tokens ${cache_max_tokens} \
                 $(if [ "${ctx_enable_attention_dp}" = "true" ]; then echo "--ctx_enable_attention_dp"; fi) \
                 $(if [ "${gen_enable_attention_dp}" = "true" ]; then echo "--gen_enable_attention_dp"; fi) \
+                $(if [ "${enable_time_breakdown}" = "true" ]; then echo "--enable_time_breakdown"; fi) \
+                --perf_metrics_max_requests ${perf_metrics_max_requests} \
                 &> ${full_logdir}/gen_worker_config.log; then
     cleanup_on_failure "Failed to generate worker config. Check ${full_logdir}/gen_worker_config.log for details"
 fi
@@ -237,7 +245,7 @@ srun -l --container-name=${container_name} \
     --container-image=${container_image} \
     --container-mounts=${container_mount} \
     --mpi=pmix --overlap -N 1 -n 1 \
-    bash ${work_dir}/start_server.sh ${num_ctx_servers} ${num_gen_servers} ${full_logdir} ${work_dir} \
+    bash ${work_dir}/start_server.sh ${num_ctx_servers} ${num_gen_servers} ${full_logdir} ${work_dir} ${enable_time_breakdown} ${perf_metrics_max_requests} \
         &> ${full_logdir}/output_server.log &
 
 # Start benchmarking
@@ -258,7 +266,7 @@ else
             --container-mounts=${container_mount} \
             --mpi=pmix --overlap -N 1 -n 1 \
             bash ${work_dir}/run_benchmark.sh \
-            "${model_path}" "${dataset_file}" "${multi_round}" "${num_gen_servers}" "${concurrency_list}" "${streaming}" "${full_logdir}/" \
+            "${model_path}" "${isl}" "${osl}" "${dataset_file}" "${multi_round}" "${num_gen_servers}" "${concurrency_list}" "${streaming}" "${full_logdir}/" "${enable_time_breakdown}" \
             &> ${full_logdir}/bench.log; then
         cleanup_on_failure "Benchmark failed. Check ${full_logdir}/bench.log for details"
     fi

--- a/examples/disaggregated/slurm/benchmark/disaggr_torch.slurm
+++ b/examples/disaggregated/slurm/benchmark/disaggr_torch.slurm
@@ -32,15 +32,16 @@ container_mount=${27}
 container_image=${28}
 model_path=${29}
 trtllm_repo=${30}
-build_wheel=${31}
-work_dir=${32}
-nsys_on=${33}
-seq_offset=${34}  # Offset added to sequence lengths
-numa_bind=${35}    # Whether to enable NUMA binding
-benchmark_mode=${36}  # Benchmark mode: e2e or gen_only
-log_dir=${37}
-enable_time_breakdown=${38}  # Whether to enable request time breakdown
-perf_metrics_max_requests=${39}  # Maximum number of requests to store perf metrics for
+install_trtllm=${31}
+build_wheel=${32}
+work_dir=${33}
+scripts_dir=${34}
+nsys_on=${35}
+seq_offset=${36}  # Offset added to sequence lengths
+numa_bind=${37}    # Whether to enable NUMA binding
+benchmark_mode=${38}  # Benchmark mode: e2e or gen_only
+enable_time_breakdown=${39}  # Whether to enable request time breakdown
+perf_metrics_max_requests=${40}  # Maximum number of requests to store perf metrics for
 
 # Print all parsed arguments
 echo "Parsed arguments:"
@@ -86,9 +87,10 @@ echo "  container_mount: ${container_mount}"
 echo "  container_image: ${container_image}"
 echo "  model_path: ${model_path}"
 echo "  trtllm_repo: ${trtllm_repo}"
+echo "  install_trtllm: ${install_trtllm}"
 echo "  build_wheel: ${build_wheel}"
 echo "  work_dir: ${work_dir}"
-echo "  log_dir: ${log_dir}"
+echo "  scripts_dir: ${scripts_dir}"
 echo "  nsys_on: ${nsys_on}"
 echo "  enable_time_breakdown: ${enable_time_breakdown}"
 echo "  perf_metrics_max_requests: ${perf_metrics_max_requests}"
@@ -96,7 +98,7 @@ echo "  perf_metrics_max_requests: ${perf_metrics_max_requests}"
 container_name="disaggr-test"
 
 # Setup logging directory
-log_base="${log_dir}/${isl}-${osl}/" # path to the log directory
+log_base="${work_dir}/${isl}-${osl}/" # path to the log directory
 full_logdir=${log_base}/ctx${num_ctx_servers}_gen${num_gen_servers}_dep${gen_tp_size}_batch${gen_batch_size}_eplb${eplb_num_slots}_mtp${mtp_size}
 enable_pdl=false
 if [ "${gen_enable_attention_dp}" = "false" ]; then
@@ -124,7 +126,11 @@ if ! srun -l --container-image=${container_image} \
 fi
 
 # Build TensorRT-LLM if needed
-if [ -d "${trtllm_repo}" ]; then
+if [ "${install_trtllm}" = "true" ]; then
+    if [ ! -d "${trtllm_repo}" ]; then
+        cleanup_on_failure "install_trtllm is true but trtllm_repo directory not found: ${trtllm_repo}"
+    fi
+
     echo "Installing TensorRT-LLM from ${trtllm_repo}..."
     TRT_LLM_GIT_COMMIT=$(git -C ${trtllm_repo} rev-parse --short HEAD 2>/dev/null || echo "unknown")
     echo "TRT_LLM_GIT_COMMIT: ${TRT_LLM_GIT_COMMIT}"
@@ -151,6 +157,8 @@ if [ -d "${trtllm_repo}" ]; then
         cleanup_on_failure "TensorRT-LLM installation failed. Check ${full_logdir}/install.log for details"
     fi
     echo "TensorRT-LLM installation completed successfully"
+else
+    echo "Skipping TensorRT-LLM installation (install_trtllm is false)"
 fi
 
 # Generate worker config
@@ -162,7 +170,7 @@ if ! srun -l -N 1 -n 1 \
         --container-name=${container_name} \
         --container-mounts=${container_mount} \
         --mpi=pmix --overlap \
-        python3 ${work_dir}/gen_worker_config.py \
+        python3 ${scripts_dir}/gen_worker_config.py \
                 --work_dir ${full_logdir} \
                 --ctx_tp_size ${ctx_tp_size} \
                 --ctx_pp_size ${ctx_pp_size} \
@@ -219,7 +227,7 @@ for i in $(seq 0 $((num_gen_servers - 1))); do
         --container-name=${container_name} \
         --container-mounts=${container_mount} \
         --mpi=pmix \
-        bash ${work_dir}/start_worker.sh \
+        bash ${scripts_dir}/start_worker.sh \
         "GEN" ${i} ${model_path} "8336" "${benchmark_mode}" "${concurrency_list}" "${enable_pdl}" "${numa_bind}" "${full_logdir}" "${nsys_on}" \
         &> ${full_logdir}/output_gen_${i}.log &
 done
@@ -234,7 +242,7 @@ for i in $(seq 0 $((num_ctx_servers - 1))); do
         --container-name=${container_name} \
         --container-mounts=${container_mount} \
         --mpi=pmix \
-        bash ${work_dir}/start_worker.sh \
+        bash ${scripts_dir}/start_worker.sh \
         "CTX" ${i} ${model_path} "8336" "${benchmark_mode}" "${concurrency_list}" "${enable_pdl}" "${numa_bind}" "${full_logdir}" "${nsys_on}" \
         &> ${full_logdir}/output_ctx_${i}.log &
 done
@@ -245,7 +253,7 @@ srun -l --container-name=${container_name} \
     --container-image=${container_image} \
     --container-mounts=${container_mount} \
     --mpi=pmix --overlap -N 1 -n 1 \
-    bash ${work_dir}/start_server.sh ${num_ctx_servers} ${num_gen_servers} ${full_logdir} ${work_dir} ${enable_time_breakdown} ${perf_metrics_max_requests} \
+    bash ${scripts_dir}/start_server.sh ${num_ctx_servers} ${num_gen_servers} ${full_logdir} ${scripts_dir} ${enable_time_breakdown} ${perf_metrics_max_requests} \
         &> ${full_logdir}/output_server.log &
 
 # Start benchmarking
@@ -255,7 +263,7 @@ if [ "${use_nv_sa_benchmark}" = "true" ]; then
     if ! srun -l --container-name=${container_name} \
             --container-mounts=${container_mount} \
             --mpi=pmix --overlap -N 1 -n 1 \
-            bash ${work_dir}/run_benchmark_nv_sa.sh \
+            bash ${scripts_dir}/run_benchmark_nv_sa.sh \
             "${model_path}" "${isl}" "${osl}" "${benchmark_ratio}" "${multi_round}" "${num_gen_servers}" "${concurrency_list}" "${streaming}" "${full_logdir}/" \
             &> ${full_logdir}/bench.log; then
         cleanup_on_failure "NVIDIA SA benchmark failed. Check ${full_logdir}/bench.log for details"
@@ -265,7 +273,7 @@ else
     if ! srun -l --container-name=${container_name} \
             --container-mounts=${container_mount} \
             --mpi=pmix --overlap -N 1 -n 1 \
-            bash ${work_dir}/run_benchmark.sh \
+            bash ${scripts_dir}/run_benchmark.sh \
             "${model_path}" "${isl}" "${osl}" "${dataset_file}" "${multi_round}" "${num_gen_servers}" "${concurrency_list}" "${streaming}" "${full_logdir}/" "${enable_time_breakdown}" \
             &> ${full_logdir}/bench.log; then
         cleanup_on_failure "Benchmark failed. Check ${full_logdir}/bench.log for details"

--- a/examples/disaggregated/slurm/benchmark/gen_server_config.py
+++ b/examples/disaggregated/slurm/benchmark/gen_server_config.py
@@ -27,6 +27,14 @@ if __name__ == "__main__":
                         type=int,
                         default=8333,
                         help="Server port")
+    parser.add_argument("--enable_time_breakdown",
+                        action='store_true',
+                        help="Enable request time breakdown")
+    parser.add_argument(
+        "--perf_metrics_max_requests",
+        type=int,
+        default=1000,
+        help="Maximum number of requests to store perf metrics for")
     args = parser.parse_args()
 
     # check if the work_dir exists
@@ -82,6 +90,11 @@ if __name__ == "__main__":
             'urls': [f'{host}:{args.worker_port}' for host in gen_hostnames]
         }
     }
+
+    if args.enable_time_breakdown:
+        server_config['return_perf_metrics'] = True
+        server_config[
+            'perf_metrics_max_requests'] = args.perf_metrics_max_requests
 
     with open(os.path.join(args.work_dir, "server_config.yaml"), "w") as f:
         yaml.dump(server_config, f)

--- a/examples/disaggregated/slurm/benchmark/gen_worker_config.py
+++ b/examples/disaggregated/slurm/benchmark/gen_worker_config.py
@@ -21,7 +21,9 @@ def gen_config_file(work_dir: str,
                     gen_gpu_memory_fraction: float,
                     eplb_num_slots: int,
                     mtp_size: int = 0,
-                    cache_transceiver_max_num_tokens: int = 4608) -> None:
+                    cache_transceiver_max_num_tokens: int = 4608,
+                    enable_time_breakdown: bool = False,
+                    perf_metrics_max_requests: int = 1000) -> None:
     """
     Generate configuration YAML file for disaggregated inference.
 
@@ -74,6 +76,10 @@ def gen_config_file(work_dir: str,
         },
     }
 
+    if enable_time_breakdown:
+        ctx_config['return_perf_metrics'] = True
+        ctx_config['perf_metrics_max_requests'] = perf_metrics_max_requests
+
     gen_cuda_graph_batch_sizes = [
         1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 768, 1024, 2048, gen_batch_size
     ]
@@ -119,6 +125,10 @@ def gen_config_file(work_dir: str,
         'stream_interval': 20,
         'num_postprocess_workers': 4,
     }
+
+    if enable_time_breakdown:
+        gen_config['return_perf_metrics'] = True
+        gen_config['perf_metrics_max_requests'] = perf_metrics_max_requests
 
     if gen_tp_size == 8 and not gen_enable_attention_dp:
         gen_config['allreduce_strategy'] = "MNNVL"
@@ -234,6 +244,14 @@ if __name__ == "__main__":
                         type=int,
                         default=8448,
                         help="Max number of tokens for cache transceiver")
+    parser.add_argument("--enable_time_breakdown",
+                        action='store_true',
+                        help="Enable request time breakdown")
+    parser.add_argument(
+        "--perf_metrics_max_requests",
+        type=int,
+        default=1000,
+        help="Maximum number of requests to store perf metrics for")
 
     args = parser.parse_args()
 
@@ -245,4 +263,5 @@ if __name__ == "__main__":
                     args.gen_max_num_tokens, args.gen_max_seq_len,
                     args.gen_enable_attention_dp, args.gen_gpu_memory_fraction,
                     args.eplb_num_slots, args.mtp_size,
-                    args.cache_transceiver_max_num_tokens)
+                    args.cache_transceiver_max_num_tokens,
+                    args.enable_time_breakdown, args.perf_metrics_max_requests)

--- a/examples/disaggregated/slurm/benchmark/run_benchmark.sh
+++ b/examples/disaggregated/slurm/benchmark/run_benchmark.sh
@@ -8,17 +8,20 @@ trap 'echo "Error occurred at line $LINENO"; exit 1' ERR
 # Add parameter validation
 if [ "$#" -lt 7 ]; then
     echo "Error: Missing required arguments"
-    echo "Usage: $0 model_name dataset_file multi_round concurrency_list streaming log_path"
+    echo "Usage: $0 model_name input_seq_len output_seq_len dataset_file multi_round num_gen_servers concurrency_list streaming log_path enable_time_breakdown"
     exit 1
 fi
 
 model_name=$1
-dataset_file=$2
-multi_round=$3
-num_gen_servers=$4
-concurrency_list=$5
-streaming=$6
-log_path=$7
+input_seq_len=$2
+output_seq_len=$3
+dataset_file=$4
+multi_round=$5
+num_gen_servers=$6
+concurrency_list=$7
+streaming=$8
+log_path=$9
+enable_time_breakdown=${10:-false}
 
 # check process id is not 0
 if [[ ${SLURM_PROCID} != "0" ]]; then
@@ -104,22 +107,32 @@ for concurrency in ${concurrency_list}; do
     num_prompts=$((concurrency * multi_round))
     echo "Benchmarking with concurrency ${concurrency} ... ${num_prompts} prompts"
     mkdir -p ${log_path}/concurrency_${concurrency}
+
+    # Set dataset arguments based on whether dataset_file is provided
+    if [ -z "${dataset_file}" ]; then
+        dataset_args="--dataset-name random --random-ids"
+    else
+        dataset_args="--dataset-name trtllm_custom --dataset-path ${dataset_file}"
+    fi
+
     python -m tensorrt_llm.serve.scripts.benchmark_serving \
         --model ${model_name} \
         --backend openai \
         --host ${hostname} \
         --port ${port} \
-        --dataset-name "trtllm_custom" \
-        --dataset-path ${dataset_file} \
+        ${dataset_args} \
         --num-prompts ${num_prompts} \
         --max-concurrency ${concurrency} \
         --ignore-eos \
+        --random-input-len "${input_seq_len}" \
+        --random-output-len "${output_seq_len}" \
         --no-test-input \
         --save-result \
         --result-dir "${log_path}/concurrency_${concurrency}" \
         --result-filename "result.json" \
         --percentile-metrics "ttft,tpot,itl,e2el" \
-        $(if [ "${streaming}" = "false" ]; then echo "--non-streaming"; fi)
+        $(if [ "${streaming}" = "false" ]; then echo "--non-streaming"; fi) \
+        $(if [ "${enable_time_breakdown}" = "true" ]; then echo "--save-request-time-breakdown"; fi)
     echo "Benchmark with concurrency ${concurrency} done"
 done
 

--- a/examples/disaggregated/slurm/benchmark/start_server.sh
+++ b/examples/disaggregated/slurm/benchmark/start_server.sh
@@ -7,11 +7,15 @@ num_ctx_servers=$1
 num_gen_servers=$2
 work_dir=$3
 script_dir=$4
+enable_time_breakdown=$5
+perf_metrics_max_requests=$6
 
 python3 ${script_dir}/gen_server_config.py \
     --num_ctx_servers ${num_ctx_servers} \
     --num_gen_servers ${num_gen_servers} \
-    --work_dir ${work_dir}
+    --work_dir ${work_dir} \
+    $(if [ "${enable_time_breakdown}" = "true" ]; then echo "--enable_time_breakdown"; fi) \
+    --perf_metrics_max_requests ${perf_metrics_max_requests}
 echo "server config generated to ${work_dir}/server_config.yaml"
 
 trtllm-serve disaggregated -c ${work_dir}/server_config.yaml -t 7200 -r 7200

--- a/examples/disaggregated/slurm/benchmark/submit.sh
+++ b/examples/disaggregated/slurm/benchmark/submit.sh
@@ -38,17 +38,18 @@ container_image="<container_image>"
 model_path="<model_path>"
 # Path to the TensorRT-LLM repository
 trtllm_repo="<trtllm_repo>"
-# Set to true to do a clean build of TensorRT-LLM from source
+# Set to true to install TensorRT-LLM
+install_trtllm=false
+# Set to true to do a clean build of TensorRT-LLM from source (only if install_trtllm is true)
 build_wheel=false
 
 # Workspace Configuration
 work_dir=$(pwd) # path to the work directory containing the scripts
 
-# Path to
-log_dir=$work_dir
-
-# Configuration
-slurm_file=$work_dir/"disaggr_torch.slurm"
+# Path to scripts directory containing the SLURM file
+scripts_dir="${trtllm_repo}/examples/disaggregated/slurm/benchmark"
+# Path to the SLURM file
+slurm_file="${scripts_dir}/disaggr_torch.slurm"
 
 # Profiling Configuration
 nsys_on=false  # Set to true to enable profiling
@@ -67,6 +68,7 @@ fi
 
 # Validate required paths
 [[ ! -d "${model_path}" ]] && { echo "Error: model_path not found: ${model_path}" >&2; exit 1; }
+[[ ! -d "${trtllm_repo}" ]] && { echo "Error: trtllm_repo not found: ${trtllm_repo}" >&2; exit 1; }
 [[ ! -d "${work_dir}" ]] && { echo "Error: work_dir '${work_dir}' not found" >&2; exit 1; }
 [[ ! -f "${dataset_file}" ]] && { echo "Error: dataset_file '${dataset_file}' not found" >&2; exit 1; }
 
@@ -128,7 +130,7 @@ run_single() {
         "${gen_eplb_num_slots}" "${mtp_size}" "${gen_concurrency_list}" \
         "${gpus_per_node}" "${use_nv_sa_benchmark}" "${isl}" "${osl}" "${multi_round}" "${benchmark_ratio}" \
         "${streaming}" "${cache_max_tokens}" "${dataset_file}" "${container_mount}" "${container_image}" \
-        "${model_path}" "${trtllm_repo}" "${build_wheel}" "${work_dir}" "${nsys_on}" "${seq_offset}" "${numa_bind}" "${benchmark_mode}" "${log_dir}" \
+        "${model_path}" "${trtllm_repo}" "${install_trtllm}" "${build_wheel}" "${work_dir}" "${scripts_dir}" "${nsys_on}" "${seq_offset}" "${numa_bind}" "${benchmark_mode}" \
         "${enable_time_breakdown}" "${perf_metrics_max_requests}"
     set +x
 }

--- a/examples/disaggregated/slurm/benchmark/submit.sh
+++ b/examples/disaggregated/slurm/benchmark/submit.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-# Configuration
-slurm_file="disaggr_torch.slurm"
-
 # SLURM Configuration
 partition="<partition>"
 account="<account>"
@@ -29,6 +26,7 @@ streaming=true             # Enable streaming mode
 cache_max_tokens=4608     # Cache transceiver max tokens
 seq_offset=203  # Offset added to sequence lengths
 # Dataset file for benchmarking
+# Set it to empty to use random dataset
 dataset_file="<dataset_file>"
 
 # Environment Configuration
@@ -46,8 +44,18 @@ build_wheel=false
 # Workspace Configuration
 work_dir=$(pwd) # path to the work directory containing the scripts
 
+# Path to
+log_dir=$work_dir
+
+# Configuration
+slurm_file=$work_dir/"disaggr_torch.slurm"
+
 # Profiling Configuration
 nsys_on=false  # Set to true to enable profiling
+
+# Time Breakdown Configuration
+enable_time_breakdown=true  # Set to true to enable request time breakdown
+perf_metrics_max_requests=20000  # Maximum number of requests to store perf metrics for
 
 ##############################################################
 
@@ -120,7 +128,8 @@ run_single() {
         "${gen_eplb_num_slots}" "${mtp_size}" "${gen_concurrency_list}" \
         "${gpus_per_node}" "${use_nv_sa_benchmark}" "${isl}" "${osl}" "${multi_round}" "${benchmark_ratio}" \
         "${streaming}" "${cache_max_tokens}" "${dataset_file}" "${container_mount}" "${container_image}" \
-        "${model_path}" "${trtllm_repo}" "${build_wheel}" "${work_dir}" "${nsys_on}" "${seq_offset}" "${numa_bind}" "${benchmark_mode}"
+        "${model_path}" "${trtllm_repo}" "${build_wheel}" "${work_dir}" "${nsys_on}" "${seq_offset}" "${numa_bind}" "${benchmark_mode}" "${log_dir}" \
+        "${enable_time_breakdown}" "${perf_metrics_max_requests}"
     set +x
 }
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable time-breakdown tracking for benchmark requests
  * Customizable performance-metrics collection with a max-requests limit
  * Option to control automatic TensorRT-LLM installation
  * Ability to point benchmarks to a separate scripts directory

* **Documentation**
  * README updated to document new flags, script directory usage, and logging/work directory clarifications
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
