### PR TITLE
[None][infra] Change to use pytest-forked to run isolation

### DIFF
--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -270,250 +270,6 @@ def cleanUpNodeResources(def pipeline, SlurmCluster cluster, String nodeName, St
     }
 }
 
-def runIsolatedTests(preprocessedLists, testCmdLine, llmSrc, stageName) {
-    // Run the isolated tests one by one to avoid any potential conflicts
-    def isolateTestList = preprocessedLists.isolate
-    def isolateTestLines = readFile(file: isolateTestList).readLines()
-    def rerunFailed = false
-
-    for (int i = 0; i < isolateTestLines.size(); i++) {
-        def isolateTestName = isolateTestLines[i].trim()
-        // Create a temporary file for this single isolated test
-        def singleTestFile = "${isolateTestList}_isolated_${i}.txt"
-        sh "echo '${isolateTestName}' > ${singleTestFile}"
-        sh "cat ${singleTestFile}"
-
-        def isolateTestCmdLine = testCmdLine.findAll { cmd ->
-            !cmd.contains("--test-list=") &&
-            !cmd.contains("--test-prefix=") &&
-            !cmd.contains("--csv=") &&
-            !cmd.contains("--junit-xml")
-        }
-        isolateTestCmdLine += ["--test-list=${singleTestFile}"]
-        isolateTestCmdLine += ["--test-prefix=${stageName}"]
-        isolateTestCmdLine += ["--csv=${WORKSPACE}/${stageName}/report_isolated_${i}.csv"]
-        isolateTestCmdLine += ["--junit-xml ${WORKSPACE}/${stageName}/results_isolated_${i}.xml"]
-        isolateTestCmdLine += ["--cov-append"]  // Append coverage data to avoid overwriting previous data
-
-        try {
-            sh """
-                cd ${llmSrc}/tests/integration/defs && \
-                ${isolateTestCmdLine.join(" ")}
-            """
-        } catch (InterruptedException e) {
-            throw e
-        } catch (Exception e) {
-            def isRerunFailed = rerunFailedTests(stageName, llmSrc, isolateTestCmdLine, "results_isolated_${i}.xml", "isolated_${i}")
-            if (isRerunFailed) {
-                // Mark that at least one isolated test failed, but continue processing other tests
-                rerunFailed = true
-                echo "Isolated test ${i} (${isolateTestName}) failed after rerun attempt, continuing with remaining tests"
-            }
-        } finally {
-            // Clean up the temporary test file
-            sh "rm -f ${singleTestFile}"
-        }
-    }
-
-    // After processing all isolated tests, set stage failure if any test failed
-    if (rerunFailed) {
-        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-            error "One or more isolated tests failed after rerun attempts"
-        }
-    }
-
-    return rerunFailed  // Return the updated value
-}
-
-def processShardTestList(llmSrc, testDBList, splitId, splits, perfMode=false) {
-    // Preprocess testDBList to extract ISOLATION markers
-    echo "Preprocessing testDBList to extract ISOLATION markers..."
-
-    def originalTestLines = readFile(file: testDBList).readLines()
-    def cleanedTestLines = []
-    def isolationTestLines = []
-
-    originalTestLines.each { originalLine ->
-        def trimmedLine = originalLine.trim()
-        if (trimmedLine && trimmedLine.contains('ISOLATION')) {
-            // Remove ISOLATION marker and nearby comma from the line
-            def cleanedLine = trimmedLine
-
-            // Handle different comma patterns around ISOLATION
-            if (trimmedLine.contains('ISOLATION,')) {
-                // Case: "ISOLATION,OTHER_MARKER" -> remove "ISOLATION,"
-                cleanedLine = cleanedLine.replace('ISOLATION,', '').trim()
-            } else if (trimmedLine.contains(',ISOLATION')) {
-                // Case: "OTHER_MARKER,ISOLATION" -> remove ",ISOLATION"
-                cleanedLine = cleanedLine.replace(',ISOLATION', '').trim()
-            } else {
-                // Case: standalone "ISOLATION" -> remove " ISOLATION"
-                cleanedLine = cleanedLine.replace(' ISOLATION', '').trim()
-            }
-
-            // Add the cleaned line to isolationTestLines if original line had ISOLATION
-            isolationTestLines.add(cleanedLine)
-            cleanedTestLines.add(cleanedLine)
-
-        } else if (trimmedLine) {
-            // Line doesn't contain ISOLATION, add as-is
-            cleanedTestLines.add(originalLine.trim())
-        }
-    }
-
-    // Create cleaned testDBList file (without ISOLATION markers)
-    def cleanedTestDBList = testDBList.replaceAll('\\.txt$', '_cleaned.txt')
-    if (cleanedTestLines.size() > 0) {
-        def cleanedContent = cleanedTestLines.join('\n')
-        sh "echo '${cleanedContent.replace("'", "'\\''")}' > ${cleanedTestDBList}"
-        echo "Created cleaned testDBList: ${cleanedTestDBList} with ${cleanedTestLines.size()} lines (ISOLATION markers removed)"
-    } else {
-        sh "touch ${cleanedTestDBList}"
-        echo "No tests found, created empty cleaned testDBList: ${cleanedTestDBList}"
-    }
-
-    sh "cat ${cleanedTestDBList}"
-    echo "Original testDBList contains ${isolationTestLines.size()} tests that had ISOLATION markers"
-
-    def shardTestList = []
-
-    if (perfMode) {
-        // In perfMode, skip pytest collection as it may cause errors with automatically generated testcases
-        // Instead, use all tests from the original testDBList
-        echo "Performance mode enabled - skipping pytest collection, using all tests from testDBList"
-    } else {
-        def testListCmd = [
-            "LLM_ROOT=${llmSrc}",
-            "LLM_BACKEND_ROOT=${llmSrc}/triton_backend",
-            "pytest",
-            "--collect-only",
-            "--splitting-algorithm least_duration",
-            "--test-list=${cleanedTestDBList}",
-            "--quiet",
-            "--splits ${splits}",
-            "--group ${splitId}"
-        ]
-
-        try {
-            // First execute the pytest command and check if it succeeds
-            def pytestOutput = sh(
-                script: "cd ${llmSrc}/tests/integration/defs && ${testListCmd.join(' ')}",
-                returnStdout: true
-            ).trim()
-
-            // Debug: Show the raw pytest output
-            echo "<<<START_PYTEST_OUTPUT>>>"
-            echo "${pytestOutput}"
-            echo "<<<END_PYTEST_OUTPUT>>>"
-
-            // Filter the output to get only test lines with '::' that occur after "Running X items in this shard"
-            def lines = pytestOutput.split('\n')
-            def foundRunningLine = false
-            def lineIndex = 0
-            shardTestList = lines.findAll { line ->
-                lineIndex++
-
-                if (line.matches(/.*Running \d+ items in this shard.*/) || line.matches(/.*\[pytest-split\] Running group.*/)) {
-                    foundRunningLine = true
-                    return false  // Don't include the "Running" line itself
-                }
-
-                def hasDoubleColon = line.contains('::')
-                def shouldInclude = foundRunningLine && hasDoubleColon
-                return shouldInclude
-            }
-            echo "Filtering complete. shardTestList size: ${shardTestList.size()}"
-        } catch (Exception e) {
-            echo "Error: Failed to execute pytest command for test collection: ${e.getMessage()}"
-            error "Test collection failed for shard ${splitId}/${splits}. Cannot proceed without valid test list."
-        }
-    }
-
-    if (shardTestList || perfMode) {
-        // Split the shard test list into regular and isolate tests
-        def shardRegularTests = []
-        def shardIsolateTests = []
-
-        if (perfMode) {
-            // In perfMode, put all tests in regular and skip isolation
-            echo "Performance mode enabled - all tests will run as regular tests (no isolation)"
-            shardRegularTests = cleanedTestLines.findAll { it.trim() }
-        } else {
-            // Process each test from shardTestList
-            shardTestList.each { test ->
-                def trimmedTest = test.trim()
-                if (trimmedTest) {
-                    // Process test_unittests.py::test_unittests_v2[xxxx] pattern
-                    if (trimmedTest.startsWith('test_unittests.py::test_unittests_v2[') && trimmedTest.endsWith(']')) {
-                        // Extract content between [ and ]
-                        def startIndex = trimmedTest.indexOf('[') + 1
-                        def endIndex = trimmedTest.lastIndexOf(']')
-                        trimmedTest = trimmedTest.substring(startIndex, endIndex)
-                    }
-
-                    // Check if this test is in the isolation list
-                    def isolationTestLine = isolationTestLines.find { it.contains(trimmedTest) }
-                    if (isolationTestLine) {
-                        // This test needs isolation
-                        shardIsolateTests.add(isolationTestLine)
-                    } else {
-                        // This test is a regular test - find the actual line from cleanedTestLines
-                        def cleanedTestLine = cleanedTestLines.find { it.contains(trimmedTest) }
-                        shardRegularTests.add(cleanedTestLine)
-                    }
-                }
-            }
-        }
-
-        // Define file paths for regular and isolate tests
-        def regularTestList = testDBList.replaceAll('\\.txt$', '_regular.txt')
-        def isolateTestList = testDBList.replaceAll('\\.txt$', '_isolate.txt')
-
-        // Create shard-specific test files
-        if (shardRegularTests.size() > 0) {
-            def shardRegularContent = shardRegularTests.join('\n')
-            sh "echo '${shardRegularContent.replace("'", "'\\''")}' > ${regularTestList}"
-            echo "Created ${regularTestList} with ${shardRegularTests.size()} regular tests for this shard"
-        } else {
-            sh "touch ${regularTestList}"
-            echo "No regular tests in this shard, created empty file: ${regularTestList}"
-        }
-        sh "cat ${regularTestList}"
-
-        if (shardIsolateTests.size() > 0) {
-            def shardIsolateContent = shardIsolateTests.join('\n')
-            sh "echo '${shardIsolateContent.replace("'", "'\\''")}' > ${isolateTestList}"
-            echo "Created ${isolateTestList} with ${shardIsolateTests.size()} isolate tests for this shard"
-        } else {
-            sh "touch ${isolateTestList}"
-            echo "No isolate tests in this shard, created empty file: ${isolateTestList}"
-        }
-        sh "cat ${isolateTestList}"
-
-        // Return preprocessed lists object for compatibility
-        return [
-            regular: regularTestList,
-            isolate: isolateTestList,
-            regularCount: shardRegularTests.size(),
-            isolateCount: shardIsolateTests.size()
-        ]
-    } else {
-        echo "No tests found in current shard or failed to list tests"
-        // Create empty files and preprocessed lists object
-        def regularTestList = testDBList.replaceAll('\\.txt$', '_regular.txt')
-        def isolateTestList = testDBList.replaceAll('\\.txt$', '_isolate.txt')
-        sh "touch ${regularTestList}"
-        sh "touch ${isolateTestList}"
-
-        return [
-            regular: regularTestList,
-            isolate: isolateTestList,
-            regularCount: 0,
-            isolateCount: 0
-        ]
-    }
-}
-
 def executeLLMTestOnSlurm(pipeline, platform, testList, config=VANILLA_CONFIG, perfMode=false, stageName="Undefined", splitId=1, splits=1, skipInstallWheel=false, cpver="cp312", runner)
 {
     runner {
@@ -1628,13 +1384,13 @@ def getSSHConnectionPorts(portConfigFile, stageName)
     return [userPort, monitorPort]
 }
 
-def rerunFailedTests(stageName, llmSrc, testCmdLine, resultFileName="results.xml", testType="regular") {
-    if (!fileExists("${WORKSPACE}/${stageName}/${resultFileName}")) {
-        error "There is not ${resultFileName} file, skip the rerun step"
+def rerunFailedTests(stageName, llmSrc, testCmdLine) {
+    if (!fileExists("${WORKSPACE}/${stageName}/results.xml")) {
+        error "There is not results.xml file, skip the rerun step"
     }
 
     // Create rerun directory structure to avoid conflicts
-    def rerunDir = "${WORKSPACE}/${stageName}/rerun/${testType}"
+    def rerunDir = "${WORKSPACE}/${stageName}/rerun/"
     sh "mkdir -p ${rerunDir}"
 
     // Generate rerun test lists
@@ -1643,7 +1399,7 @@ def rerunFailedTests(stageName, llmSrc, testCmdLine, resultFileName="results.xml
         python3 ${llmSrc}/jenkins/scripts/test_rerun.py \
         generate_rerun_tests_list \
         --output-dir=${rerunDir}/ \
-        --input-file=${WORKSPACE}/${stageName}/${resultFileName} \
+        --input-file=${WORKSPACE}/${stageName}/results.xml \
         --fail-signatures='${failSignaturesList}'
     """
 
@@ -1664,14 +1420,14 @@ def rerunFailedTests(stageName, llmSrc, testCmdLine, resultFileName="results.xml
                 script: "grep -v '^[[:space:]]*\$' ${currentRerunTestList} | wc -l",
                 returnStdout: true
             ).trim().toInteger()
-            echo "Found ${count} ${testType} tests to rerun ${times} time(s)"
+            echo "Found ${count} tests to rerun ${times} time(s)"
             validLineCount += count
         }
     }
     if (validLineCount > 5) {
-        error "There are more than 5 failed ${testType} tests, skip the rerun step."
+        error "There are more than 5 failed tests, skip the rerun step."
     } else if (validLineCount == 0) {
-        error "No failed ${testType} tests need to be rerun, skip the rerun step."
+        error "No failed tests need to be rerun, skip the rerun step."
     }
 
     // Rerun tests
@@ -1679,7 +1435,7 @@ def rerunFailedTests(stageName, llmSrc, testCmdLine, resultFileName="results.xml
     for (times in [1, 2]) {
         def currentRerunTestList = "${rerunDir}/rerun_${times}.txt"
         if (!fileExists(currentRerunTestList)) {
-            echo "No failed ${testType} tests need to be rerun ${times} time(s)"
+            echo "No failed tests need to be rerun ${times} time(s)"
             continue
         }
         sh "cat ${currentRerunTestList}"
@@ -1705,15 +1461,16 @@ def rerunFailedTests(stageName, llmSrc, testCmdLine, resultFileName="results.xml
             throw e
         } catch (Exception e) {
             if (!fileExists(xmlFile)) {
-                echo "The ${testType} tests crashed when rerun attempt."
+                echo "The tests crashed when rerun attempt."
                 throw e
             }
-            echo "The ${testType} tests still failed after rerun attempt."
+            echo "The tests still failed after rerun attempt."
             isRerunFailed = true
         }
     }
 
-    echo "isRerunFailed for ${testType}: ${isRerunFailed}"
+    generateRerunReport(stageName, llmSrc)
+
     return isRerunFailed
 }
 
@@ -1721,84 +1478,22 @@ def generateRerunReport(stageName, llmSrc) {
     echo "Generating comprehensive rerun report for stage: ${stageName}"
 
     def rerunBaseDir = "${WORKSPACE}/${stageName}/rerun"
-    def regularRerunDir = "${rerunBaseDir}/regular"
-
-    // Check if regular rerun directory exists
-    def hasRegularReruns = sh(script: "[ -d '${regularRerunDir}' ] && echo 'true' || echo 'false'", returnStdout: true).trim() == 'true'
-
-    // Find all isolated rerun directories (isolated_0, isolated_1, etc.)
-    def isolatedRerunDirs = []
-    def isolatedDirsOutput = sh(script: "find ${rerunBaseDir} -type d -name 'isolated_*' 2>/dev/null || true", returnStdout: true).trim()
-    if (isolatedDirsOutput) {
-        isolatedRerunDirs = isolatedDirsOutput.split('\n').findAll { it.trim() }
-    }
-    def hasIsolatedReruns = isolatedRerunDirs.size() > 0
-
-    echo "Found regular reruns: ${hasRegularReruns}"
-    echo "Found isolated rerun directories: ${isolatedRerunDirs}"
-
-    if (!hasRegularReruns && !hasIsolatedReruns) {
-        echo "No rerun results found, skipping rerun report generation"
-        return
-    }
 
     // Specify the stage name correctly for all result xml files.
     sh "cd ${WORKSPACE}/${stageName} && find . -name '*.xml' -exec sed -i 's/testsuite name=\"pytest\"/testsuite name=\"${stageName}\"/g' {} + || true"
 
-    // Collect all original and rerun result files
-    def allInputFiles = []
+    // Generate rerun report
+    def inputFiles = ["${WORKSPACE}/${stageName}/results.xml",
+                      "${rerunBaseDir}/rerun_results_1.xml",
+                      "${rerunBaseDir}/rerun_results_2.xml"]
 
-    // Add original results
-    if (fileExists("${WORKSPACE}/${stageName}/results.xml")) {
-        allInputFiles.add("${WORKSPACE}/${stageName}/results.xml")
-    }
-
-    // Add isolated test results
-    def isolatedResults = sh(script: "find ${WORKSPACE}/${stageName} -name 'results_isolated_*.xml' 2>/dev/null || true", returnStdout: true).trim()
-    if (isolatedResults) {
-        isolatedResults.split('\n').each { file ->
-            if (file.trim()) {
-                allInputFiles.add(file.trim())
-            }
-        }
-    }
-
-    // Add regular rerun results
-    if (hasRegularReruns) {
-        for (times in [1, 2]) {
-            def rerunFile = "${regularRerunDir}/rerun_results_${times}.xml"
-            if (fileExists(rerunFile)) {
-                allInputFiles.add(rerunFile)
-            }
-        }
-    }
-
-    // Add isolated rerun results from all isolated directories
-    if (hasIsolatedReruns) {
-        isolatedRerunDirs.each { isolatedDir ->
-            for (times in [1, 2]) {
-                def rerunFile = "${isolatedDir}/rerun_results_${times}.xml"
-                if (fileExists(rerunFile)) {
-                    allInputFiles.add(rerunFile)
-                    echo "Added isolated rerun result: ${rerunFile}"
-                }
-            }
-        }
-    }
-
-    if (allInputFiles.isEmpty()) {
-        echo "No valid input files found for rerun report generation"
-        return
-    }
-
-    echo "Generating rerun report with input files: ${allInputFiles.join(',')}"
 
     // Generate comprehensive rerun report
     sh """
         python3 ${llmSrc}/jenkins/scripts/test_rerun.py \
         generate_rerun_report \
         --output-file=${WORKSPACE}/${stageName}/rerun_results.xml \
-        --input-files=${allInputFiles.join(",")}
+        --input-files=${inputFiles.join(",")}
     """
 
     // Update original results xml file with all rerun results for junit
@@ -1806,23 +1501,16 @@ def generateRerunReport(stageName, llmSrc) {
         python3 ${llmSrc}/jenkins/scripts/test_rerun.py \
         merge_junit_xmls \
         --output-file=${WORKSPACE}/${stageName}/results.xml \
-        --input-files=${allInputFiles.join(",")} \
+        --input-files=${inputFiles.join(",")} \
         --deduplicate
     """
 
-    // Upload rerun report
-    if (fileExists("${WORKSPACE}/${stageName}/rerun_results.html")) {
-        trtllm_utils.uploadArtifacts(
-            "${WORKSPACE}/${stageName}/rerun_results.html",
-            "${UPLOAD_PATH}/rerun_reports/${stageName}_rerun_results.html"
-        )
-        echo "Test rerun report: https://urm.nvidia.com/artifactory/${UPLOAD_PATH}/rerun_reports/${stageName}_rerun_results.html"
-    }
+    trtllm_utils.uploadArtifacts(
+        "${WORKSPACE}/${stageName}/rerun_results.html",
+        "${UPLOAD_PATH}/rerun_reports/${stageName}_rerun_results.html"
+    )
 
-    // Remove isolation results since they are merged into results.xml
-    sh "rm -rf ${WORKSPACE}/${stageName}/results_isolated_*.xml || true"
-
-    echo "Rerun report generation completed for stage: ${stageName}"
+    echo "Test rerun report: https://urm.nvidia.com/artifactory/${UPLOAD_PATH}/rerun_reports/${stageName}_rerun_results.html"
 }
 
 def runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config=VANILLA_CONFIG, perfMode=false, stageName="Undefined", splitId=1, splits=1, skipInstallWheel=false, cpver="cp312")
@@ -1995,9 +1683,6 @@ def runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config=VANILLA_CO
 
         def extraInternalEnv = ""
         def pytestTestTimeout = "3600"
-        def noRegularTests = false
-        def noIsolateTests = false
-        def rerunFailed = false
 
         // TRT uses half of the host logic cores for engine building which is bad for multi-GPU machines.
         extraInternalEnv = "__LUNOWUD=\"-thread_pool_size=${TESTER_CORES}\""
@@ -2005,9 +1690,6 @@ def runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config=VANILLA_CO
         extraInternalEnv += " CPP_TEST_TIMEOUT_OVERRIDDEN=${pytestTestTimeout}"
 
         def testDBList = renderTestDB(testList, llmSrc, stageName)
-
-        // Process shard test list and create separate files for regular and isolate tests
-        def preprocessedLists = processShardTestList(llmSrc, testDBList, splitId, splits, perfMode)
 
         def testCmdLine = [
             "LLM_ROOT=${llmSrc}",
@@ -2020,22 +1702,20 @@ def runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config=VANILLA_CO
             testFilter[(DETAILED_LOG)] ? "-s" : "",
             "--timeout-method=thread",
             "--apply-test-list-correction",
+            "--splitting-algorithm least_duration",
             "--timeout=${pytestTestTimeout}",
             "--rootdir ${llmSrc}/tests/integration/defs",
             "--test-prefix=${stageName}",
+            "--splits ${splits}",
+            "--group ${splitId}",
             "--waives-file=${llmSrc}/tests/integration/test_lists/waives.txt",
+            "--test-list=${testDBList}",
             "--output-dir=${WORKSPACE}/${stageName}/",
             "--csv=${WORKSPACE}/${stageName}/report.csv",
             "--junit-xml ${WORKSPACE}/${stageName}/results.xml",
             "-o junit_logging=out-err"
         ]
 
-        // Only add --test-list if there are regular tests to run
-        if (preprocessedLists.regularCount > 0) {
-            // Remove any existing --test-list options and add the new one
-            testCmdLine = testCmdLine.findAll { cmd -> !cmd.contains("--test-list=") }
-            testCmdLine += ["--test-list=${preprocessedLists.regular}"]
-        }
         if (perfMode) {
             testCmdLine += [
                 "--perf",
@@ -2087,61 +1767,20 @@ def runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config=VANILLA_CO
             ]) {
                 sh "env | sort"
                 try {
-                    if (preprocessedLists.regularCount > 0) {
                         sh """
-                            rm -rf ${stageName}/ && \
-                            cd ${llmSrc}/tests/integration/defs && \
-                            ${testCmdLine.join(" ")}
-                        """
-                    } else {
-                        echo "No regular tests to run for stage ${stageName}"
-                        noRegularTests = true
-                        sh "mkdir -p ${stageName}"
-                        // Create an empty results.xml file for consistency
-                        sh """
-                            echo '<?xml version="1.0" encoding="UTF-8"?>' > ${stageName}/results.xml
-                            echo '<testsuites>' >> ${stageName}/results.xml
-                            echo '<testsuite name="${stageName}" errors="0" failures="0" skipped="0" tests="0" time="0.0">' >> ${stageName}/results.xml
-                            echo '</testsuite>' >> ${stageName}/results.xml
-                            echo '</testsuites>' >> ${stageName}/results.xml
-                        """
-                    }
+                        rm -rf ${stageName}/ && \
+                        cd ${llmSrc}/tests/integration/defs && \
+                        ${testCmdLine.join(" ")}
+                    """
                 } catch (InterruptedException e) {
                     throw e
                 } catch (Exception e) {
-                    def isRerunFailed = rerunFailedTests(stageName, llmSrc, testCmdLine, "results.xml", "regular")
+                    def isRerunFailed = rerunFailedTests(stageName, llmSrc, testCmdLine)
                     if (isRerunFailed) {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                            error "Regular tests failed after rerun attempt"
-                        }
-                        rerunFailed = true
+                        error "The tests still failed after rerun attempt."
                     }
                 }
             }
-        }
-
-        // Run the isolated tests if exists
-        if (preprocessedLists.isolateCount > 0) {
-            stage ("[${stageName}] Run Pytest (Isolated)") {
-                echo "There are ${preprocessedLists.isolateCount} isolated tests to run"
-                rerunFailed = runIsolatedTests(preprocessedLists, testCmdLine, llmSrc, stageName) || rerunFailed
-            }
-        } else {
-            echo "No isolated tests to run for stage ${stageName}"
-            noIsolateTests = true
-        }
-
-        if (noRegularTests && noIsolateTests) {
-            error "No tests were executed for stage ${stageName}, please check the test list and test-db rendering result."
-        }
-
-        // Generate comprehensive rerun report if any reruns occurred
-        stage ("[${stageName}] Generate Report") {
-            generateRerunReport(stageName, llmSrc)
-        }
-
-        if (rerunFailed) {
-            error "Some tests still failed after rerun attempts, please check the test report."
         }
 
         if (perfMode) {

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,6 +19,7 @@ pytest-timeout
 pytest-split
 pytest-mock
 pytest-threadleak
+pytest-forked
 rouge_score
 cloudpickle
 typing-extensions==4.12.2

--- a/scripts/check_test_list.py
+++ b/scripts/check_test_list.py
@@ -18,7 +18,7 @@ import os
 import subprocess
 
 # The markers in our test lists, need to be preprocess before checking
-MARKER_LIST_IN_TEST = [" TIMEOUT"]
+MARKER_LIST_IN_TEST = [" TIMEOUT", " ISOLATION"]
 
 
 def install_python_dependencies(llm_src):

--- a/tests/integration/defs/conftest.py
+++ b/tests/integration/defs/conftest.py
@@ -2158,6 +2158,13 @@ def pytest_generate_tests(metafunc: pytest.Metafunc):
                 uts.append(pytest.param(case, marks=mark))
                 # Change back id to include timeout information
                 ids.append(f"{case} TIMEOUT {timeout_str}")
+            elif " ISOLATION" in line:
+                # Process for marker ISOLATION
+                case_part = line.split(" ISOLATION", 1)[0]
+                case = case_part.strip()
+                mark = pytest.mark.forked
+                uts.append(pytest.param(case, marks=mark))
+                ids.append(f"{case} ISOLATION")
             else:
                 uts.append(line.strip())
     metafunc.parametrize("case", uts, ids=lambda x: x)

--- a/tests/integration/defs/test_list_parser.py
+++ b/tests/integration/defs/test_list_parser.py
@@ -18,7 +18,7 @@ from .trt_test_alternative import print_info, print_warning
 
 # from misc.reorder_venv_tests import reorder_tests
 
-kVALID_TEST_LIST_MARKERS = ["XFAIL", "SKIP", "UNSTABLE", "TIMEOUT"]
+kVALID_TEST_LIST_MARKERS = ["XFAIL", "SKIP", "UNSTABLE", "TIMEOUT", "ISOLATION"]
 record_invalid_tests = True
 
 kSTRIP_PARENS_PAT = re.compile(r'\((.*?)\)')
@@ -137,6 +137,10 @@ def parse_test_list_lines(test_list, lines, test_prefix):
                             f'{test_list}:{lineno}: Invalid syntax for TIMEOUT value: "{reason_raw}". '
                             "Expected a numeric value in parentheses.")
                     timeout = int(timeout) * 60
+                elif marker == "ISOLATION":
+                    # Additional processing needed for ISOLATION marker
+                    print_info(f"Isolation setting for {test_name}")
+                    marker = "forked"
                 elif len(reason_raw) > 0:
                     reason = strip_parens(reason_raw.strip())
                     if not reason:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tests can now be marked with ISOLATION to run in forked processes, improving test independence and reliability.

* **Refactor**
  * Streamlined test rerun logic in CI pipeline with simplified unified flow, removing complex preprocessing.

* **Chores**
  * Added pytest-forked development dependency to support test isolation features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
