### PR TITLE
[TRTLLM-8803][feat] Add rope and uk-bgemm overlap for mla generation

### DIFF
--- a/cpp/tensorrt_llm/nanobind/thop/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/thop/bindings.cpp
@@ -65,6 +65,9 @@ void initBindings(nb::module_& m)
         nb::arg("spec_decoding_tensor_params"), nb::arg("sparse_kv_indices") = std::nullopt,
         nb::arg("sparse_kv_offsets") = std::nullopt, nb::arg("sparse_attn_indices") = std::nullopt,
         nb::arg("sparse_attn_offsets") = std::nullopt, nb::arg("sparse_mla_topk") = std::nullopt,
+        nb::arg("cu_q_seqlens") = std::nullopt, nb::arg("cu_kv_seqlens") = std::nullopt,
+        nb::arg("fmha_scheduler_counter") = std::nullopt, nb::arg("mla_bmm1_scale") = std::nullopt,
+        nb::arg("mla_bmm2_scale") = std::nullopt, nb::arg("quant_q_buffer") = std::nullopt,
         "Multi-head attention operation", nb::call_guard<nb::gil_scoped_release>());
 }
 } // namespace tensorrt_llm::nanobind::thop

--- a/cpp/tensorrt_llm/pybind/thop/bindings.cpp
+++ b/cpp/tensorrt_llm/pybind/thop/bindings.cpp
@@ -65,6 +65,9 @@ void initBindings(pybind11::module_& m)
         py::arg("spec_decoding_tensor_params"), py::arg("sparse_kv_indices") = std::nullopt,
         py::arg("sparse_kv_offsets") = std::nullopt, py::arg("sparse_attn_indices") = std::nullopt,
         py::arg("sparse_attn_offsets") = std::nullopt, py::arg("sparse_mla_topk") = std::nullopt,
+        py::arg("cu_q_seqlens") = std::nullopt, py::arg("cu_kv_seqlens") = std::nullopt,
+        py::arg("fmha_scheduler_counter") = std::nullopt, py::arg("mla_bmm1_scale") = std::nullopt,
+        py::arg("mla_bmm2_scale") = std::nullopt, py::arg("quant_q_buffer") = std::nullopt,
         "Multi-head attention operation", py::call_guard<py::gil_scoped_release>());
 }
 } // namespace tensorrt_llm::pybind::thop

--- a/cpp/tensorrt_llm/thop/CMakeLists.txt
+++ b/cpp/tensorrt_llm/thop/CMakeLists.txt
@@ -99,7 +99,8 @@ add_library(
   mtpOp.cpp
   loraOp.cpp
   finegrained_mixed_dtype_gemm_thop.cpp
-  tinygemm2.cpp)
+  tinygemm2.cpp
+  dsv3RopeOp.cpp)
 set_property(TARGET th_common PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(
   th_common PRIVATE ${TORCH_LIBRARIES} th_utils ${Python3_LIBRARIES}

--- a/cpp/tensorrt_llm/thop/attentionOp.h
+++ b/cpp/tensorrt_llm/thop/attentionOp.h
@@ -63,6 +63,9 @@ void attention(torch::Tensor q, std::optional<torch::Tensor> k, std::optional<to
     std::vector<std::optional<torch::Tensor>> spec_decoding_tensor_params,
     std::optional<torch::Tensor> sparse_kv_indices, std::optional<torch::Tensor> sparse_kv_offsets,
     std::optional<torch::Tensor> sparse_attn_indices, std::optional<torch::Tensor> sparse_attn_offsets,
-    std::optional<int64_t> sparse_mla_topk);
+    std::optional<int64_t> sparse_mla_topk, std::optional<torch::Tensor> cu_q_seqlens,
+    std::optional<torch::Tensor> cu_kv_seqlens, std::optional<torch::Tensor> fmha_scheduler_counter,
+    std::optional<torch::Tensor> mla_bmm1_scale, std::optional<torch::Tensor> mla_bmm2_scale,
+    std::optional<torch::Tensor> quant_q_buffer);
 
 } // namespace torch_ext

--- a/cpp/tensorrt_llm/thop/dsv3RopeOp.cpp
+++ b/cpp/tensorrt_llm/thop/dsv3RopeOp.cpp
@@ -1,0 +1,355 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tensorrt_llm/common/attentionOp.h"
+#include "tensorrt_llm/common/dataType.h"
+#include "tensorrt_llm/common/memoryUtils.h"
+#include "tensorrt_llm/kernels/gptKernels.h"
+#include "tensorrt_llm/kernels/mlaKernels.h"
+#include "tensorrt_llm/runtime/torchUtils.h"
+#include "tensorrt_llm/runtime/utils/debugUtils.h"
+#include "tensorrt_llm/thop/thUtils.h"
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+#include <torch/extension.h>
+
+#include <cmath>
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace tk = tensorrt_llm::kernels;
+namespace tc = tensorrt_llm::common;
+namespace tr = tensorrt_llm::runtime;
+
+namespace torch_ext
+{
+
+// Wrapper for MLA rope generation arguments
+struct MlaRopeGenArgs
+{
+    int32_t q_pe_ld;
+    int32_t q_pe_stride;
+    float2 const* rotary_cos_sin_ptr;
+    int32_t num_generations;
+    int32_t num_gen_tokens;
+    int32_t num_heads;
+    tk::MlaMetaParams mla_meta_params;
+    int32_t const* sequence_lengths_ptr;
+    int32_t max_context_q_len;
+    int const* block_ids_per_seq_ptr;
+    tk::KvCacheDataType cache_type;
+    int* cu_q_seqlens_ptr;
+    int* cu_kv_seqlens_ptr;
+    uint32_t* fmha_tile_counter_ptr;
+    float* mla_bmm1_scale_ptr;
+    float* mla_bmm2_scale_ptr;
+    void* quant_q_buffer_ptr;
+    float const* quant_scale_o_ptr;
+    float const* kv_scale_orig_quant_ptr;
+    float const* kv_scale_quant_orig_ptr;
+    float host_bmm1_scale;
+    int32_t const* helix_position_offsets_ptr;
+};
+
+template <typename T, typename KVCacheBuffer>
+void invokeMLARopeGenerationHelper(T const* latent_cache_ptr, T* q_pe_ptr, T* fused_q_ptr,
+    KVCacheBuffer& kv_cache_buffer, MlaRopeGenArgs const& args, cudaStream_t stream)
+{
+    tk::MlaParams<T> mla_params{};
+    mla_params.latent_cache = latent_cache_ptr;
+    mla_params.q_pe = q_pe_ptr;
+    mla_params.q_pe_ld = args.q_pe_ld;
+    mla_params.q_pe_stride = args.q_pe_stride;
+    mla_params.q_buf = fused_q_ptr;
+    mla_params.cos_sin_cache = args.rotary_cos_sin_ptr;
+    mla_params.batch_size = args.num_generations;
+    mla_params.acc_q_len = args.num_gen_tokens;
+    mla_params.head_num = args.num_heads;
+    mla_params.meta = args.mla_meta_params;
+
+    mla_params.cache_seq_lens = args.sequence_lengths_ptr;
+    mla_params.max_input_seq_len = args.max_context_q_len;
+
+    mla_params.block_ids_per_seq = args.block_ids_per_seq_ptr;
+
+    mla_params.cache_type = args.cache_type;
+
+    mla_params.seqQOffset = args.cu_q_seqlens_ptr;
+    mla_params.cu_kv_seqlens = args.cu_kv_seqlens_ptr;
+    mla_params.fmha_tile_counter = args.fmha_tile_counter_ptr;
+    mla_params.bmm1_scale = args.mla_bmm1_scale_ptr;
+    mla_params.bmm2_scale = args.mla_bmm2_scale_ptr;
+    mla_params.quant_q_buf = args.quant_q_buffer_ptr;
+
+    mla_params.quant_scale_o = args.quant_scale_o_ptr;
+    mla_params.quant_scale_q = args.kv_scale_orig_quant_ptr;
+    mla_params.quant_scale_kv = args.kv_scale_orig_quant_ptr;
+    mla_params.dequant_scale_q = args.kv_scale_quant_orig_ptr;
+    mla_params.dequant_scale_kv = args.kv_scale_quant_orig_ptr;
+    mla_params.host_bmm1_scale = args.host_bmm1_scale;
+    mla_params.helix_position_offsets = args.helix_position_offsets_ptr;
+
+    tk::invokeMLARopeGeneration<T>(mla_params, kv_cache_buffer, stream);
+}
+
+void MLARopeGeneration(torch::Tensor fused_q, // [tokens, num_heads, (nope_dim + rope+dim)]
+    torch::Tensor q_pe,                       // [tokens, num_heads, rope_dim]
+    torch::Tensor latent_cache,               // [tokens, kv_lora_rank + rope_dim]
+    std::optional<torch::Tensor> rotary_cos_sin, torch::Tensor cu_q_seqlens, torch::Tensor cu_kv_seqlens,
+    torch::Tensor fmha_scheduler_counter, std::optional<torch::Tensor> mla_bmm1_scale,
+    std::optional<torch::Tensor> mla_bmm2_scale, std::optional<torch::Tensor> quant_q_buffer,
+    torch::Tensor sequence_length, torch::Tensor host_past_key_value_lengths, torch::Tensor host_context_lengths,
+    int64_t const num_contexts, std::optional<torch::Tensor> kv_cache_block_offsets,
+    std::optional<torch::Tensor> host_kv_cache_block_offsets, std::optional<torch::Tensor> host_kv_cache_pool_pointers,
+    std::optional<torch::Tensor> host_kv_cache_pool_mapping,
+    torch::optional<torch::Tensor> kv_scale_orig_quant, // [1] q,k quant scale
+    torch::optional<torch::Tensor> kv_scale_quant_orig, // [1] bmm quant scale
+    torch::optional<torch::Tensor> out_scale,           // [1] output quant scale
+    std::optional<torch::Tensor> block_ids_per_seq, std::vector<std::optional<torch::Tensor>> mla_tensor_params,
+    int64_t const predicted_tokens_per_seq, int64_t const layer_idx, int64_t const num_heads,
+    int64_t const num_kv_heads, int64_t const head_size,
+
+    int64_t const tokens_per_block, int64_t const attention_window_size, int64_t const sink_token_length,
+    int64_t const beam_width, int64_t const quant_mode, double const q_scaling, int64_t q_lora_rank,
+    int64_t kv_lora_rank, int64_t qk_nope_head_dim, int64_t qk_rope_head_dim, int64_t v_head_dim)
+{
+    TLLM_CHECK_WITH_INFO(
+        head_size == kv_lora_rank + qk_rope_head_dim, "head_size must = kv_lora_rank + qk_rope_head_dim");
+    TLLM_CHECK_WITH_INFO(num_kv_heads == 1, "num_kv_heads must = 1");
+    TORCH_CHECK(
+        mla_tensor_params.size() == 1, "Expecting 1 tensor for custom MLA tensor params: helix_position_offsets.");
+
+    auto stream = at::cuda::getCurrentCUDAStream(fused_q.get_device());
+    auto const kv_cache_quant_mode = tc::QuantMode(uint32_t(quant_mode));
+    bool const use_gen_flash_mla = tc::getSMVersion() == 90 && tokens_per_block == 64;
+    TLLM_CHECK_WITH_INFO(!kv_cache_quant_mode.hasFp4KvCache(), "FP4 KV cache is not supported for MLA generation.");
+    TLLM_CHECK_WITH_INFO(
+        host_kv_cache_pool_mapping.has_value(), "KV cache pool mapping is required for MLA generation.");
+
+    bool const use_kv_cache = kv_cache_block_offsets.has_value() && host_kv_cache_block_offsets.has_value()
+        && host_kv_cache_pool_pointers.has_value() && host_kv_cache_pool_mapping.has_value();
+
+    int32_t const num_seqs = host_context_lengths.size(0);
+
+    int32_t const num_tokens = fused_q.size(0);
+    int32_t const num_generations = num_seqs - num_contexts;
+    int32_t const num_gen_tokens = num_tokens;
+    int32_t const seq_offset = num_contexts;
+    auto& mla_helix_position_offsets = mla_tensor_params[0];
+    int32_t const layer_num = host_kv_cache_pool_mapping.value().size(0);
+
+    tk::MlaMetaParams mla_meta_params = {static_cast<int>(q_lora_rank), static_cast<int>(kv_lora_rank),
+        static_cast<int>(qk_nope_head_dim), static_cast<int>(qk_rope_head_dim), static_cast<int>(v_head_dim),
+        static_cast<int>(predicted_tokens_per_seq), static_cast<int>(layer_num)};
+
+    int32_t const* helix_position_offsets_ptr
+        = mla_helix_position_offsets.has_value() ? mla_helix_position_offsets->data_ptr<int32_t>() : nullptr;
+
+    int* cu_q_seqlens_ptr = reinterpret_cast<int*>(cu_q_seqlens.data_ptr());
+    int* cu_kv_seqlens_ptr = reinterpret_cast<int*>(cu_kv_seqlens.data_ptr());
+    uint32_t* fmha_tile_counter_ptr = reinterpret_cast<uint32_t*>(fmha_scheduler_counter.data_ptr());
+    float* mla_bmm1_scale_ptr
+        = mla_bmm1_scale.has_value() ? reinterpret_cast<float*>(mla_bmm1_scale.value().data_ptr()) : nullptr;
+    float* mla_bmm2_scale_ptr
+        = mla_bmm2_scale.has_value() ? reinterpret_cast<float*>(mla_bmm2_scale.value().data_ptr()) : nullptr;
+    void* quant_q_buffer_ptr
+        = quant_q_buffer.has_value() ? reinterpret_cast<void*>(quant_q_buffer.value().data_ptr()) : nullptr;
+
+    float2 const* rotary_cos_sin_ptr = nullptr;
+    if (rotary_cos_sin.has_value())
+    {
+        rotary_cos_sin_ptr = reinterpret_cast<float2 const*>(rotary_cos_sin.value().data_ptr());
+    }
+
+    int const* sequence_lengths_ptr = sequence_length.slice(0, seq_offset).data_ptr<int>();
+    // Note we still need context length during generation for MMHA optimization.
+    int32_t const max_context_q_len
+        = host_context_lengths.slice(0, seq_offset, seq_offset + num_generations).max().item<int32_t>();
+
+    TORCH_CHECK(q_pe.defined());
+    TORCH_CHECK(q_pe.dim() == 3);
+    TORCH_CHECK(q_pe.strides()[2] == 1);
+    int32_t const q_pe_ld = q_pe.strides()[1];
+    int32_t const q_pe_stride = q_pe.strides()[0];
+
+    // kv cache related
+    auto const block_size = tokens_per_block * num_kv_heads * head_size;
+    int32_t const elem_bytes
+        = kv_cache_quant_mode.hasFp8KvCache() ? sizeof(__nv_fp8_e4m3) : static_cast<int32_t>(fused_q.element_size());
+
+    int32_t const bytes_per_token = num_kv_heads * head_size * elem_bytes;
+
+    auto const bytes_per_block = block_size * elem_bytes;
+    int32_t const kv_factor = 1; // 1 for mla, 2 for mha/gqa
+    bool const fp8_context_fmha = kv_cache_quant_mode.hasFp8KvCache();
+    // Commonly, cyclic_attention_window_size, and max_attention_window_size will be the same
+    // unless each layer has different attention window sizes.
+    // the kv_cache capacity.
+    // The cyclic_attention_window_size will determine the cyclic kv cache position of new tokens.
+    // Note that this cyclic_attention_window_size might be smaller than the actual kv cache capactity.
+    int const cyclic_attention_window_size = attention_window_size;
+    int const max_cyclic_attention_window_size = cyclic_attention_window_size;
+    bool const can_use_one_more_block = beam_width > 1;
+
+    // kv cache pool related
+    int32_t const max_blocks_per_sequence
+        = use_kv_cache && kv_cache_block_offsets.has_value() ? kv_cache_block_offsets.value().size(-1) : 0;
+    int32_t const pool_index = use_kv_cache && host_kv_cache_pool_mapping.has_value()
+        ? host_kv_cache_pool_mapping.value().index({layer_idx, 0}).item<int32_t>()
+        : 0;
+    int32_t const layer_idx_in_cache_pool = use_kv_cache && host_kv_cache_pool_mapping.has_value()
+        ? host_kv_cache_pool_mapping.value().index({layer_idx, 1}).item<int32_t>()
+        : 0;
+    auto const intra_pool_offset = layer_idx_in_cache_pool * kv_factor * bytes_per_block;
+
+    tk::KVBlockArray::DataType* block_offsets
+        = static_cast<tk::KVBlockArray::DataType*>(use_kv_cache && kv_cache_block_offsets.has_value()
+                ? kv_cache_block_offsets.value().index({pool_index, seq_offset}).data_ptr()
+                : nullptr);
+
+    void* host_primary_pool_pointer{nullptr};
+    void* host_secondary_pool_pointer{nullptr};
+
+    if (use_kv_cache)
+    {
+        TORCH_CHECK(host_kv_cache_pool_pointers.value().dim() == 2);
+        host_primary_pool_pointer = reinterpret_cast<void*>(
+            reinterpret_cast<char*>(host_kv_cache_pool_pointers.value().index({pool_index, 0}).item<int64_t>())
+            + intra_pool_offset);
+        host_secondary_pool_pointer = reinterpret_cast<void*>(
+            reinterpret_cast<char*>(host_kv_cache_pool_pointers.value().index({pool_index, 1}).item<int64_t>())
+            + intra_pool_offset);
+    }
+
+    float const* kv_scale_orig_quant_ptr = nullptr; // qk quant scale
+    float const* kv_scale_quant_orig_ptr = nullptr; // bmm quant scale
+    if (kv_cache_quant_mode.hasKvCacheQuant() && kv_scale_orig_quant.has_value() && kv_scale_quant_orig.has_value())
+    {
+        kv_scale_orig_quant_ptr = kv_scale_orig_quant.value().data_ptr<float>();
+        kv_scale_quant_orig_ptr = kv_scale_quant_orig.value().data_ptr<float>();
+    }
+
+    // Prepare scalars for MLA params and wrapper
+    // For FP8 output, out_scale represents the output scale.
+    float const* quant_scale_o_ptr
+        = (fp8_context_fmha && out_scale.has_value()) ? out_scale.value().data_ptr<float>() : nullptr;
+    float const host_bmm1_scale = 1.f / (q_scaling * sqrt(static_cast<float>(qk_nope_head_dim + qk_rope_head_dim)));
+
+    if (use_gen_flash_mla)
+    {
+        TLLM_CHECK_WITH_INFO(block_ids_per_seq.has_value(), "block_ids_per_seq is required for gen flash mla");
+    }
+    int const* block_ids_per_seq_ptr = use_gen_flash_mla && block_ids_per_seq.has_value()
+        ? static_cast<int*>(block_ids_per_seq->data_ptr())
+        : nullptr; // only used for flash mla
+
+    int32_t const batch_beam = beam_width * num_generations;
+
+    tk::KvCacheDataType cache_type
+        = (kv_cache_quant_mode.hasFp8KvCache() ? tk::KvCacheDataType::FP8 : tk::KvCacheDataType::BASE);
+
+    auto kv_cache_buffer = tk::KVBlockArray(batch_beam, max_blocks_per_sequence, tokens_per_block, bytes_per_token,
+        cyclic_attention_window_size, max_cyclic_attention_window_size, sink_token_length, can_use_one_more_block,
+        host_primary_pool_pointer, host_secondary_pool_pointer, block_offsets);
+
+    // Currently NVFP4 KV cache is not supported for MLA
+    MlaRopeGenArgs args{q_pe_ld, q_pe_stride, rotary_cos_sin_ptr, num_generations, num_gen_tokens,
+        static_cast<int32_t>(num_heads), mla_meta_params, sequence_lengths_ptr, max_context_q_len,
+        block_ids_per_seq_ptr, cache_type, cu_q_seqlens_ptr, cu_kv_seqlens_ptr, fmha_tile_counter_ptr,
+        mla_bmm1_scale_ptr, mla_bmm2_scale_ptr, quant_q_buffer_ptr, quant_scale_o_ptr, kv_scale_orig_quant_ptr,
+        kv_scale_quant_orig_ptr, host_bmm1_scale, helix_position_offsets_ptr};
+
+    auto const input_dtype = fused_q.scalar_type();
+    if (input_dtype == torch::kFloat16)
+    {
+        invokeMLARopeGenerationHelper(static_cast<half const*>(latent_cache.data_ptr()),
+            static_cast<half*>(q_pe.data_ptr()), static_cast<half*>(fused_q.data_ptr()), kv_cache_buffer, args, stream);
+    }
+    else if (input_dtype == torch::kBFloat16)
+    {
+
+        invokeMLARopeGenerationHelper(static_cast<__nv_bfloat16 const*>(latent_cache.data_ptr()),
+            static_cast<__nv_bfloat16*>(q_pe.data_ptr()), static_cast<__nv_bfloat16*>(fused_q.data_ptr()),
+            kv_cache_buffer, args, stream);
+    }
+    else if (input_dtype == torch::kFloat32)
+    {
+        invokeMLARopeGenerationHelper(static_cast<float const*>(latent_cache.data_ptr()),
+            static_cast<float*>(q_pe.data_ptr()), static_cast<float*>(fused_q.data_ptr()), kv_cache_buffer, args,
+            stream);
+    }
+    else
+    {
+        TLLM_CHECK_WITH_INFO(false, "Unsupported input dtype: %s", c10::toString(input_dtype));
+    }
+}
+
+} // namespace torch_ext
+
+TORCH_LIBRARY_FRAGMENT(trtllm, m)
+{
+    m.def(
+        "mla_rope_generation("
+        "Tensor(a!) fused_q"
+        ", Tensor(a!) q_pe"
+        ", Tensor latent_cache"
+        ", Tensor? rotary_cos_sin"
+        ", Tensor cu_q_seqlens"
+        ", Tensor cu_kv_seqlens"
+        ", Tensor fmha_scheduler_counter"
+        ", Tensor? mla_bmm1_scale"
+        ", Tensor? mla_bmm2_scale"
+        ", Tensor? quant_q_buffer"
+        ", Tensor sequence_length"
+        ", Tensor host_past_key_value_lengths"
+        ", Tensor host_context_lengths"
+        ", int num_contexts"
+        ", Tensor? kv_cache_block_offsets"
+        ", Tensor? host_kv_cache_block_offsets"
+        ", Tensor? host_kv_cache_pool_pointers"
+        ", Tensor? host_kv_cache_pool_mapping"
+        ", Tensor? kv_scale_orig_quant"
+        ", Tensor? kv_scale_quant_orig"
+        ", Tensor? out_scale"
+        ", Tensor? block_ids_per_seq"
+        ", Tensor?[] mla_tensor_params"
+        ", int predicted_tokens_per_seq"
+        ", int layer_idx"
+        ", int num_heads"
+        ", int num_kv_heads"
+        ", int head_size"
+        ", int tokens_per_block"
+        ", int attention_window_size"
+        ", int sink_token_length"
+        ", int beam_width"
+        ", int quant_mode"
+        ", float q_scaling"
+        ", int q_lora_rank"
+        ", int kv_lora_rank"
+        ", int qk_nope_head_dim"
+        ", int qk_rope_head_dim"
+        ", int v_head_dim"
+        ") -> ()");
+}
+
+TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
+{
+    m.impl("mla_rope_generation", &torch_ext::MLARopeGeneration);
+}

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -337,6 +337,12 @@ class TrtllmAttentionWrapper:
         is_fused_qkv: bool = True,
         update_kv_cache: bool = True,
         attention_mask: AttentionMask = PredefinedAttentionMask.CAUSAL,
+        cu_q_seqlens: Optional[torch.Tensor] = None,
+        cu_kv_seqlens: Optional[torch.Tensor] = None,
+        fmha_scheduler_counter: Optional[torch.Tensor] = None,
+        mla_bmm1_scale: Optional[torch.Tensor] = None,
+        mla_bmm2_scale: Optional[torch.Tensor] = None,
+        quant_q_buffer: Optional[torch.Tensor] = None,
     ):
         """
         Run the attention operation.
@@ -520,6 +526,12 @@ class TrtllmAttentionWrapper:
             self.sparse_attn_indices,
             self.sparse_attn_offsets,
             self.sparse_mla_topk,
+            cu_q_seqlens,
+            cu_kv_seqlens,
+            fmha_scheduler_counter,
+            mla_bmm1_scale,
+            mla_bmm2_scale,
+            quant_q_buffer,
         )
         # reset the planned states (especially tensors) to avoid memory leak
         self.plan()
@@ -1260,6 +1272,12 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
         output_sf: Optional[torch.Tensor] = None,
         attention_sinks: Optional[torch.Tensor] = None,
         chunked_prefill_buffer_batch_size: int = 1,
+        cu_q_seqlens: Optional[torch.Tensor] = None,
+        cu_kv_seqlens: Optional[torch.Tensor] = None,
+        fmha_scheduler_counter: Optional[torch.Tensor] = None,
+        mla_bmm1_scale: Optional[torch.Tensor] = None,
+        mla_bmm2_scale: Optional[torch.Tensor] = None,
+        quant_q_buffer: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, Optional[torch.Tensor]]]:
         assert isinstance(
@@ -1371,7 +1389,13 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
             out_dtype=out_dtype,
             is_fused_qkv=not metadata.is_cross and k is None,
             update_kv_cache=not metadata.is_cross or k is not None,
-            attention_mask=attention_mask)
+            attention_mask=attention_mask,
+            cu_q_seqlens=cu_q_seqlens,
+            cu_kv_seqlens=cu_kv_seqlens,
+            fmha_scheduler_counter=fmha_scheduler_counter,
+            mla_bmm1_scale=mla_bmm1_scale,
+            mla_bmm2_scale=mla_bmm2_scale,
+            quant_q_buffer=quant_q_buffer)
 
         if use_nvfp4_output:
             return output, output_sf
@@ -1588,3 +1612,79 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
             Predict sparse kv indices. It's implemented in the derived class.
         """
         raise NotImplementedError
+
+    def mla_rope_generation(
+        self,
+        fused_q: torch.Tensor,
+        q_pe: torch.Tensor,
+        latent_cache: torch.Tensor,
+        metadata: TrtllmAttentionMetadata,
+        cu_q_seqlens: torch.Tensor,
+        cu_kv_seqlens: torch.Tensor,
+        fmha_scheduler_counter: torch.Tensor,
+        mla_bmm1_scale: torch.Tensor,
+        mla_bmm2_scale: torch.Tensor,
+        quant_q_buffer: torch.Tensor,
+        helix_position_offsets: Optional[torch.Tensor] = None,
+        out_scale: Optional[torch.Tensor] = None,
+    ) -> None:
+        """
+            fused_q (torch.Tensor): The tensor to store the fused q, with shape (num_tokens, num_heads, kv_lora_rank + qk_rope_head_dim) on GPU.
+            q_pe (torch.Tensor): The tensor to store the q_pe, with shape (num_tokens, num_heads, qk_rope_head_dim) on GPU.
+            latent_cache (torch.Tensor): The tensor to store the latent cache, with shape (num_tokens, kv_lora_rank + qk_rope_head_dim) on GPU.
+            cu_q_seqlens (torch.Tensor): The tensor to store the cu_q_seqlens, with shape (num_seqs + 1) on GPU.
+            cu_kv_seqlens (torch.Tensor): The tensor to store the cu_kv_seqlens, with shape (num_seqs + 1) on GPU.
+            fmha_scheduler_counter (torch.Tensor): The tensor to store the fmha_scheduler_counter, with shape (1) on GPU.
+            mla_bmm1_scale (torch.Tensor): The tensor to store the mla_bmm1_scale, with shape (2) on GPU.
+            mla_bmm2_scale (torch.Tensor): The tensor to store the mla_bmm2_scale, with shape (1) on GPU.
+            quant_q_buffer (torch.Tensor): The tensor to store the quant_q_buffer, with shape (tokens, num_heads, kv_lora_rank + qk_rope_head_dim) on GPU.
+            helix_position_offsets (torch.Tensor): The tensor to store the helix position offsets, with shape (num_tokens) on GPU.
+            out_scale (torch.Tensor): The tensor to store the out_scale, with shape (1) on GPU.
+        """
+
+        assert self.is_mla_enable and self.mla_params is not None
+        assert metadata.kv_cache_manager is not None
+        sink_token_length = 0
+        mla_tensor_params = [helix_position_offsets]
+
+        torch.ops.trtllm.mla_rope_generation(
+            fused_q,
+            q_pe,
+            latent_cache,
+            self.wrapper.rotary_cos_sin,
+            cu_q_seqlens,
+            cu_kv_seqlens,
+            fmha_scheduler_counter,
+            mla_bmm1_scale,
+            mla_bmm2_scale,
+            quant_q_buffer,
+            metadata.kv_lens_cuda_runtime,  # sequence_length
+            metadata.kv_lens_runtime,  # host_past_key_value_lengths
+            metadata.prompt_lens_cpu_runtime,  # host_context_lengths,
+            metadata.num_contexts,
+            metadata.kv_cache_block_offsets,
+            metadata.host_kv_cache_block_offsets,
+            metadata.kv_cache_manager.kv_cache_pool_pointers,
+            metadata.kv_cache_manager.kv_cache_pool_mapping,
+            self.kv_scale_orig_quant,
+            self.kv_scale_quant_orig,
+            out_scale,
+            metadata.block_ids_per_seq,
+            mla_tensor_params,
+            self.wrapper.predicted_tokens_per_seq,
+            self.get_local_layer_idx(metadata),
+            self.wrapper.num_heads,
+            self.wrapper.num_kv_heads,
+            self.wrapper.head_size,
+            metadata.kv_cache_manager.tokens_per_block,
+            metadata.max_seq_len,  # attention_window_size
+            sink_token_length,
+            metadata.beam_width,
+            self.wrapper.quant_mode,
+            self.wrapper.q_scaling,
+            self.wrapper.q_lora_rank,
+            self.wrapper.kv_lora_rank,
+            self.wrapper.qk_nope_head_dim,
+            self.wrapper.qk_rope_head_dim,
+            self.wrapper.v_head_dim,
+        )

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -585,3 +585,49 @@ def _register_fake():
         m = mat_a.shape[0]
         n = mat_b.shape[0]
         return mat_a.new_empty((m, n), dtype=out_dtype)
+
+    @torch.library.register_fake("trtllm::mla_rope_generation")
+    def _(
+        fused_q: torch.Tensor,
+        q_pe: torch.Tensor,
+        latent_cache: torch.Tensor,
+        rotary_cos_sin: Optional[torch.Tensor],
+        cu_q_seqlens: torch.Tensor,
+        cu_kv_seqlens: torch.Tensor,
+        fmha_scheduler_counter: torch.Tensor,
+        mla_bmm1_scale: Optional[torch.Tensor],
+        mla_bmm2_scale: Optional[torch.Tensor],
+        quant_q_buffer: Optional[torch.Tensor],
+        sequence_length: torch.Tensor,
+        host_past_key_value_lengths: torch.Tensor,
+        host_context_lengths: torch.Tensor,
+        num_contexts: int,
+        kv_cache_block_offsets: Optional[torch.Tensor],
+        host_kv_cache_block_offsets: Optional[torch.Tensor],
+        host_kv_cache_pool_pointers: Optional[torch.Tensor],
+        host_kv_cache_pool_mapping: Optional[torch.Tensor],
+        kv_scale_orig_quant: Optional[torch.Tensor],
+        kv_scale_quant_orig: Optional[torch.Tensor],
+        out_scale: Optional[torch.Tensor],
+        block_ids_per_seq: Optional[torch.Tensor],
+        mla_tensor_params: List[Optional[torch.Tensor]],
+        predicted_tokens_per_seq: int,
+        layer_idx: int,
+        num_heads: int,
+        num_kv_heads: int,
+        head_size: int,
+        tokens_per_block: int,
+        attention_window_size: int,
+        sink_token_length: int,
+        beam_width: int,
+        quant_mode: int,
+        q_scaling: float,
+        q_lora_rank: int,
+        kv_lora_rank: int,
+        qk_nope_head_dim: int,
+        qk_rope_head_dim: int,
+        v_head_dim: int,
+    ) -> None:
+        # This is a fake implementation for shape inference
+        # The actual operation modifies fused_q and q_pe in-place
+        return None

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1198,7 +1198,7 @@ class MLA(nn.Module):
                 assert position_ids is not None
                 k_pe_gen = self.apply_rope(q_gen, k_pe_gen, position_ids)
 
-            self.forward_absorption(
+            self.forward_absorption_generation(
                 q_gen,
                 compressed_kv_gen,
                 k_pe_gen,
@@ -1355,14 +1355,13 @@ class MLA(nn.Module):
         topk_indices: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         if get_sm_version() >= 100:
-            return self.forward_absorption(q,
-                                           compressed_kv,
-                                           k_pe,
-                                           attn_metadata,
-                                           output,
-                                           latent_cache=latent_cache,
-                                           topk_indices=topk_indices,
-                                           is_generation=False)
+            return self.forward_absorption_context(q,
+                                                   compressed_kv,
+                                                   k_pe,
+                                                   attn_metadata,
+                                                   output,
+                                                   latent_cache=latent_cache,
+                                                   topk_indices=topk_indices)
         else:
             return self.forward_sparse_mla_kvcache_bf16(q,
                                                         latent_cache,
@@ -1382,13 +1381,13 @@ class MLA(nn.Module):
         topk_indices: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         if get_sm_version() >= 100:
-            return self.forward_absorption(q,
-                                           compressed_kv,
-                                           k_pe,
-                                           attn_metadata,
-                                           output,
-                                           latent_cache=latent_cache,
-                                           topk_indices=topk_indices)
+            return self.forward_absorption_generation(q,
+                                                      compressed_kv,
+                                                      k_pe,
+                                                      attn_metadata,
+                                                      output,
+                                                      latent_cache=latent_cache,
+                                                      topk_indices=topk_indices)
         else:
             return self.forward_sparse_mla_kvcache_bf16(q,
                                                         latent_cache,
@@ -1653,7 +1652,7 @@ class MLA(nn.Module):
                                             position_ids, attn_metadata, output,
                                             latent_cache)
 
-    def forward_absorption(
+    def forward_absorption_generation(
         self,
         q: torch.Tensor,
         compressed_kv: torch.Tensor,
@@ -1663,7 +1662,171 @@ class MLA(nn.Module):
         position_ids: Optional[torch.Tensor] = None,
         latent_cache: Optional[torch.Tensor] = None,
         topk_indices: Optional[torch.Tensor] = None,
-        is_generation: bool = True,
+    ) -> torch.Tensor:
+        num_tokens = q.shape[0]
+        q_nope, q_pe = q.view([-1, self.num_heads_tp, self.qk_head_dim]).split(
+            [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
+
+        # fused_q contains 1) the result of the following bmm with shape [num_tokens, num_heads, kv_lora_rank]
+        # 2) rope(q_pe) with shape [num_tokens, num_heads, qk_rope_head_dim]. rope is applied inside AttentionOp
+        num_seqs = attn_metadata.kv_lens_cuda_runtime.size(0)
+
+        cu_q_seqlens = torch.empty(num_seqs + 1,
+                                   dtype=torch.int32,
+                                   device=q.device)
+        cu_kv_seqlens = torch.empty(num_seqs + 1,
+                                    dtype=torch.int32,
+                                    device=q.device)
+        fmha_scheduler_counter = torch.empty(1,
+                                             dtype=torch.uint32,
+                                             device=q.device)
+        has_fp8_kv_cache = self.mqa.has_fp8_kv_cache if hasattr(
+            self.mqa, 'has_fp8_kv_cache') else False
+
+        mla_bmm1_scale = None
+        mla_bmm2_scale = None
+        quant_q_buffer = None
+        if has_fp8_kv_cache:
+            mla_bmm1_scale = torch.empty(2,
+                                         dtype=torch.float32,
+                                         device=q.device)
+            mla_bmm2_scale = torch.empty(1,
+                                         dtype=torch.float32,
+                                         device=q.device)
+            quant_q_buffer = torch.empty(
+                num_tokens,
+                self.num_heads_tp, (self.kv_lora_rank + self.qk_rope_head_dim),
+                dtype=torch.uint8,
+                device=q.device)
+
+        fused_q = torch.empty(
+            [
+                num_tokens, self.num_heads_tp,
+                (self.kv_lora_rank + self.qk_rope_head_dim)
+            ],
+            dtype=q.dtype,
+            device=q.device,
+        )
+
+        rope_stream = self.aux_stream if not has_fp8_kv_cache else None
+        if self.k_b_proj_trans.dtype == torch.bfloat16:
+            # [num_heads, num_tokens, self.qk_nope_head_dim]
+            q_nope_t = q_nope.transpose(0, 1)
+            # [num_heads, num_tokens, self.kv_lora_rank]
+            q_nope_out = fused_q[..., :self.kv_lora_rank].transpose(0, 1)
+
+            # [num_heads, num_tokens, self.qk_nope_head_dim] x [num_heads, kv_lora_rank, qk_nope_head_dim]
+            # -> [num_heads, num_tokens, kv_lora_rank] -> [num_tokens, num_heads, kv_lora_rank]
+            # The output of bmm is written directly into fused_q
+            maybe_execute_in_parallel(
+                lambda: torch.ops.trtllm.bmm_out(
+                    q_nope_t, self.k_b_proj_trans.transpose(1, 2), q_nope_out),
+                lambda: self.mqa.mla_rope_generation(
+                    fused_q, q_pe, latent_cache, attn_metadata, cu_q_seqlens,
+                    cu_kv_seqlens, fmha_scheduler_counter, mla_bmm1_scale,
+                    mla_bmm2_scale, quant_q_buffer),
+                self.ln_events[0],
+                self.ln_events[1],
+                rope_stream,
+            )
+
+        elif self.k_b_proj_trans.dtype == torch.float8_e4m3fn:
+            # [num_heads, num_tokens, self.kv_lora_rank]
+            q_nope_out = fused_q[..., :self.kv_lora_rank].transpose(0, 1)
+
+            maybe_execute_in_parallel(
+                lambda: fp8_block_scaling_bmm_out(
+                    q_nope,
+                    self.k_b_proj_trans,
+                    self.k_b_proj_trans_scale,
+                    q_nope_out,
+                    self.k_b_proj_trans_dequant,
+                ),
+                lambda: self.mqa.mla_rope_generation(
+                    fused_q, q_pe, latent_cache, attn_metadata, cu_q_seqlens,
+                    cu_kv_seqlens, fmha_scheduler_counter, mla_bmm1_scale,
+                    mla_bmm2_scale, quant_q_buffer),
+                self.ln_events[0],
+                self.ln_events[1],
+                rope_stream,
+            )
+        else:
+            raise NotImplementedError(
+                f"Missing bmm impl for dtype: {self.k_b_proj_trans.dtype}.")
+
+        fused_q = fused_q.view([
+            num_tokens,
+            self.num_heads_tp * (self.kv_lora_rank + self.qk_rope_head_dim)
+        ])
+
+        # Use generation_only for generation phase and context_only for context phase in DSA attention
+        attention_input_type = AttentionInputType.generation_only
+
+        attn_out_latent = self._attn_forward_gen(
+            self.mqa,
+            fused_q,
+            None,
+            None,
+            position_ids,
+            attn_metadata,
+            attention_input_type=attention_input_type,
+            out_scale=self.out_scale,
+            latent_cache=latent_cache,  # kvcache and k_pe
+            q_pe=q_pe,  # used by `invokeMLARopeGeneration`
+            topk_indices=topk_indices,  # used by DSA attention
+            is_generation=True,  # used by DSA attention
+            cu_q_seqlens=cu_q_seqlens,  # used by `mlaGeneration`
+            cu_kv_seqlens=cu_kv_seqlens,  # used by `mlaGeneration`
+            fmha_scheduler_counter=
+            fmha_scheduler_counter,  # used by `mlaGeneration`
+            mla_bmm1_scale=mla_bmm1_scale,  # used by `mlaGeneration`
+            mla_bmm2_scale=mla_bmm2_scale,  # used by `mlaGeneration`
+            quant_q_buffer=quant_q_buffer,  # used by `mlaGeneration`
+        )
+        fused_q = None
+
+        # note: if we do not have CP, then num_heads_tp_cp == num_heads_tp
+        assert (attn_out_latent.shape[0] == q.shape[0]
+                and attn_out_latent.shape[1]
+                == self.num_heads_tp_cp * self.kv_lora_rank)
+
+        # [seq, num_heads, kv_lora_rank]
+        attn_out_latent = attn_out_latent.view(
+            [-1, self.num_heads_tp_cp, self.kv_lora_rank])
+
+        attn_output = output.view(
+            [num_tokens, self.num_heads_tp_cp, self.v_head_dim])
+
+        if self.v_b_proj.dtype == torch.bfloat16:
+            # [num_heads, seq, kv_lora_rank] x [num_heads, kv_lora_rank, v_head_dim]
+            # -> [num_heads, seq, v_head_dim]
+            torch.ops.trtllm.bmm_out(attn_out_latent.transpose(0, 1),
+                                     self.v_b_proj.transpose(1, 2),
+                                     attn_output.transpose(0, 1))
+        elif self.v_b_proj.dtype == torch.float8_e4m3fn:
+            fp8_block_scaling_bmm_out(
+                attn_out_latent,
+                self.v_b_proj,
+                self.v_b_proj_scale,
+                attn_output.transpose(0, 1),
+                self.v_b_proj_dequant,
+            )
+        else:
+            raise NotImplementedError(
+                f"Missing bmm impl for dtype: {self.v_b_proj.dtype}.")
+
+        return output
+
+    def forward_absorption_context(
+        self,
+        q: torch.Tensor,
+        compressed_kv: torch.Tensor,
+        k_pe: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        output: torch.Tensor,
+        position_ids: Optional[torch.Tensor] = None,
+        latent_cache: Optional[torch.Tensor] = None,
+        topk_indices: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         num_tokens = q.shape[0]
         q_nope, q_pe = q.view([-1, self.num_heads_tp, self.qk_head_dim]).split(
@@ -1715,7 +1878,7 @@ class MLA(nn.Module):
         ])
 
         # Use generation_only for generation phase and context_only for context phase in DSA attention
-        attention_input_type = AttentionInputType.generation_only if is_generation else AttentionInputType.context_only
+        attention_input_type = AttentionInputType.context_only
         attn_out_latent = self._attn_forward_gen(
             self.mqa,
             fused_q,
@@ -1728,7 +1891,7 @@ class MLA(nn.Module):
             latent_cache=latent_cache,  # kvcache and k_pe
             q_pe=q_pe,  # used by `invokeMLARopeGeneration`
             topk_indices=topk_indices,  # used by DSA attention
-            is_generation=is_generation,  # used by DSA attention
+            is_generation=False,  # used by DSA attention
         )
         fused_q = None
 

--- a/tests/unittest/_torch/attention/test_attention_mla.py
+++ b/tests/unittest/_torch/attention/test_attention_mla.py
@@ -713,6 +713,44 @@ def _run_test_for_backend(backend_name, num_heads, num_kv_heads, num_layers,
                     "gen_compressed_kv_list"][step - 1]
                 k_pe = inputs_per_layer[layer_idx]["gen_k_pe_list"][step - 1]
                 latent_cache = torch.cat([compressed_kv, k_pe], dim=-1)
+
+                num_tokens = fused_q.size(0)
+                num_seqs = attn_metadata.kv_lens_cuda_runtime.size(0)
+                cu_q_seqlens = torch.empty(num_seqs + 1,
+                                           dtype=torch.int32,
+                                           device=q.device)
+                cu_kv_seqlens = torch.empty(num_seqs + 1,
+                                            dtype=torch.int32,
+                                            device=q.device)
+                fmha_scheduler_counter = torch.empty(1,
+                                                     dtype=torch.uint32,
+                                                     device=q.device)
+                has_fp8_kv_cache = gen_layers[
+                    layer_idx].has_fp8_kv_cache if hasattr(
+                        gen_layers[layer_idx], 'has_fp8_kv_cache') else False
+
+                if has_fp8_kv_cache:
+                    mla_bmm1_scale = torch.empty(2,
+                                                 dtype=torch.float32,
+                                                 device=q.device)
+                    mla_bmm2_scale = torch.empty(1,
+                                                 dtype=torch.float32,
+                                                 device=q.device)
+                    quant_q_buffer = torch.empty(
+                        num_tokens,
+                        num_heads * (kv_lora_rank + qk_rope_head_dim),
+                        dtype=torch.uint8,
+                        device=q.device)
+                else:
+                    mla_bmm1_scale = None
+                    mla_bmm2_scale = None
+                    quant_q_buffer = None
+
+                gen_layers[layer_idx].mla_rope_generation(
+                    fused_q, q_pe, latent_cache, attn_metadata, cu_q_seqlens,
+                    cu_kv_seqlens, fmha_scheduler_counter, mla_bmm1_scale,
+                    mla_bmm2_scale, quant_q_buffer)
+
                 result = gen_layers[layer_idx].forward(
                     fused_q,
                     None,
@@ -721,6 +759,12 @@ def _run_test_for_backend(backend_name, num_heads, num_kv_heads, num_layers,
                     attention_input_type=AttentionInputType.generation_only,
                     latent_cache=latent_cache,
                     q_pe=q_pe,
+                    cu_q_seqlens=cu_q_seqlens,
+                    cu_kv_seqlens=cu_kv_seqlens,
+                    fmha_scheduler_counter=fmha_scheduler_counter,
+                    mla_bmm1_scale=mla_bmm1_scale,
+                    mla_bmm2_scale=mla_bmm2_scale,
+                    quant_q_buffer=quant_q_buffer,
                 )
                 ref_result, latent_cache_ref = calculate_ref_result_gen(
                     fused_q,


### PR DESCRIPTION
Introduce `dsv3RopeOp `as a standalone operation and decouple it from `attentionOp` during the MLA generation stage. This improves modularity and enables **overlap with bgemm for perf optimization**. Detailly, 
- overlap for kv cache bf16 flow, 
- fp8 kv cache flow has data dependency, currently do not overlap

Workload: ISL8K/OSL1K, local_batch=32, mtp=3(seqlen=4), no quant
Machine: B200

<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-54b2a3ee-7fff-948e-e61c-52b110309489"><div dir="ltr" style="margin-left:0pt;" align="left">
  | bgemm(us) | rope(us) | total(us) | speed up
-- | -- | -- | -- | --
no_overlap | 8.00 | 3.58 | 12.29 | 1
bgemm-rope-overlap | 8.16 | 5.98 | 11.34 | 1.07x

</div></b>

<img width="883" height="243" alt="image" src="https://github.com/user-attachments/assets/f3b4aa63-0875-49a9-9a67-f5900e4cc7d6" />

<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-fcc99ae9-7fff-c3eb-916b-662f5e1beb00"><div dir="ltr" style="margin-left:0pt;" align="left">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposes MLA rope-generation as a callable operation and enables it during generation.
  * Attention APIs now accept optional per-step sequence and quantization tensors for sequence-aware attention.

* **Improvements**
  * Generation wiring now sources sequence/scale/quant parameters from public call arguments, reducing ephemeral workspace use.
  * Python bindings updated to pass new optional tensors through attention and generation paths.

* **Tests**
  * Unit tests updated to exercise the new per-step tensors and FP8/quant handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
